### PR TITLE
feat(core,store,vendo): surgical per-path workspace history and undo (S3)

### DIFF
--- a/.changeset/transcripts-and-harness-state-over-storeops.md
+++ b/.changeset/transcripts-and-harness-state-over-storeops.md
@@ -1,0 +1,46 @@
+---
+"@vendoai/store": minor
+"@vendoai/vendo": minor
+---
+
+Transcripts and harness state ride StoreOps, so a hosted store can serve a
+harness turn.
+
+`threadMessageStore` and `harnessStateStore` opened with `dbFor(store)` and threw
+"Unknown VendoStore handle" for anything `@vendoai/store` did not mint — which is
+every key-only deployment. So `storeServesHarnessTurns` answered false for them
+and the host silently fell back to the legacy chat path: hosted deployments could
+not use `harness:` at all.
+
+- `VendoStore` gains an optional `ops?: StoreOps`. The Cloud `hostedStore` already
+  exposed one, so it satisfies the member with no change.
+- One internal selector, `backendOf`, decides for every store-shaped helper: the
+  SQL handle when there is one (same database, one hop shorter), the store's own
+  32-op surface when there is not, and a named `not-implemented` refusal only when
+  the store offers neither. Nothing above the store package can tell the two
+  apart — no caller changed.
+- Transcripts ride the wire as-is: `transcripts.putMessage` for the write,
+  `transcripts.getThread` for the read, ownership enforced against the thread
+  record's subject exactly as the SQL join enforces it against `vendo_threads`.
+  A foreign or absent thread reads as empty and refuses writes, as it does
+  locally. A guarded (`expectedRevision`) edit has no wire expression and is
+  refused loudly rather than downgraded to last-write-wins; no runtime caller
+  asks for one.
+- Harness state rides the wire's `harness` family under the SAME slot the SQL
+  half uses (`harness_state:<threadId>`, keyed by the thread's owner), so §1.3's
+  rules — one slot per thread, a foreign harness destroying rather than shadowing
+  it, the slot dying with its thread — hold on both backends.
+
+The harness-turn refusal now names both options instead of only SQL, and the
+route probe accepts an ops-capable store.
+
+Proven where it counts: one behavioral suite for each helper runs against three
+backends (real Postgres/PGlite, core's `memoryStoreOps`, and the local 32-op
+backend), and a live seam test writes through the real helper over a real
+`hostedStore` against the real console and reads it back on a second,
+freshly-constructed client — no stub on either side.
+
+Known gap, recorded as a live `it.fails` rather than a comment: the console's
+`transcripts.putMessage` appends instead of editing by id, so re-writing an
+already persisted message (the approval flip) is refused there. The fix is
+console-side; the local backends already do the right thing.

--- a/packages/core/src/conformance/memory-store-ops.ts
+++ b/packages/core/src/conformance/memory-store-ops.ts
@@ -68,10 +68,19 @@ export function memoryStoreOps(): StoreOps {
   // harness: Map<"appId:subject", state>
   const harnessState = new Map<string, unknown>();
 
-  // workspace
-  type WsEntry = { path: string; data: unknown };
-  type WsCommit = { id: string; entries: WsEntry[]; before: Map<string, unknown> };
-  const wsFiles = new Map<string, unknown>();
+  // workspace — one drawer per owner (the end user or org the files belong to);
+  // a call with no owner rides the bound single-player default, exactly as the
+  // local backend does.
+  type WsEntry = { path: string; data?: unknown; delete?: true; expectedRevision?: number };
+  type WsFile = { data: unknown; revision: number; updatedAt: IsoDateTime };
+  type WsCommit = { id: string; owner: string; entries: WsEntry[]; before: Map<string, unknown> };
+  const BOUND_OWNER = "user_local";
+  const drawers = new Map<string, Map<string, WsFile>>();
+  const drawer = (owner: string): Map<string, WsFile> => {
+    let files = drawers.get(owner);
+    if (!files) { files = new Map(); drawers.set(owner, files); }
+    return files;
+  };
   const wsCommits: WsCommit[] = [];
   let wsCommitSeq = 0;
   // idempotency key -> the body it first carried, so a replay can be told from
@@ -244,10 +253,19 @@ export function memoryStoreOps(): StoreOps {
         if (k.startsWith(`${harnessSlot(id)}:`)) harnessState.delete(k);
       }
     },
+    /** Insert, or EDIT BY ID: a message whose id is already in the thread
+        replaces it in place — that is how an approval flips from pending to
+        answered. Appending it would leave two messages under one id, which
+        every real backend refuses. */
     async putMessage(threadId, message) {
       const entry = threads.get(threadId);
       if (!entry) throw new VendoError("not-found", `thread ${threadId} not found`);
-      entry.thread.messages.push(jsonCopy(message));
+      const id = (message as { id?: unknown } | null)?.id;
+      const at = typeof id === "string" && id !== ""
+        ? entry.thread.messages.findIndex((m) => (m as { id?: unknown } | null)?.id === id)
+        : -1;
+      if (at !== -1) entry.thread.messages[at] = jsonCopy(message);
+      else entry.thread.messages.push(jsonCopy(message));
       const rec = threadRecord(threadId, entry.thread, entry.record);
       threads.set(threadId, { record: rec, thread: entry.thread });
       return copyRecord(rec);
@@ -292,9 +310,18 @@ export function memoryStoreOps(): StoreOps {
   // workspace family
   // ---------------------------------------------------------------------------
 
+  const byteLength = (data: unknown): number =>
+    new TextEncoder().encode(JSON.stringify(data ?? null)).length;
+
   const workspace: StoreOps["workspace"] = {
     async index(query) {
-      const entries = [...wsFiles.entries()].map(([path, data]) => ({ path, data }));
+      const files = drawer(query?.owner ?? BOUND_OWNER);
+      const entries = [...files.entries()].map(([path, file]) => ({
+        path,
+        bytes: byteLength(file.data),
+        revision: file.revision,
+        updatedAt: file.updatedAt,
+      }));
       const offset = query?.cursor ? Math.max(0, Number.parseInt(query.cursor, 10)) : 0;
       const end = Math.min(offset + pageLimit(query?.limit), entries.length);
       return {
@@ -302,15 +329,17 @@ export function memoryStoreOps(): StoreOps {
         ...(end < entries.length ? { cursor: String(end) } : {}),
       };
     },
-    async read(paths) {
+    async read(paths, opts) {
+      const files = drawer(opts?.owner ?? BOUND_OWNER);
       const result: Record<string, unknown> = {};
       for (const p of paths) {
-        const v = wsFiles.get(p);
-        if (v !== undefined) result[p] = jsonCopy(v);
+        const file = files.get(p);
+        if (file !== undefined) result[p] = jsonCopy(file.data);
       }
       return result;
     },
     async commit(entries, opts) {
+      const owner = opts?.owner ?? BOUND_OWNER;
       const key = opts?.idempotencyKey;
       if (key !== undefined) {
         const body = JSON.stringify(entries);
@@ -321,16 +350,40 @@ export function memoryStoreOps(): StoreOps {
         }
         wsIdempotencyKeys.set(key, body);
       }
+      const files = drawer(owner);
+      // Strict compare-and-swap is checked for the WHOLE set first: a commit
+      // that conflicts on one path applies none of itself.
+      const conflicts = (entries as WsEntry[])
+        .filter((e) => e.expectedRevision !== undefined
+          && files.get(e.path)?.revision !== e.expectedRevision)
+        .map((e) => e.path);
+      if (conflicts.length > 0) {
+        throw new VendoError(
+          "conflict",
+          `the workspace moved on under ${conflicts.sort().join(", ")}; nothing was committed`,
+        );
+      }
       wsCommitSeq += 1;
       const before = new Map<string, unknown>();
       for (const e of entries as WsEntry[]) {
-        before.set(e.path, wsFiles.get(e.path));
-        wsFiles.set(e.path, jsonCopy(e.data));
+        before.set(e.path, files.get(e.path)?.data);
+        if (e.delete === true) {
+          files.delete(e.path);
+          continue;
+        }
+        files.set(e.path, {
+          data: jsonCopy(e.data),
+          revision: (files.get(e.path)?.revision ?? 0) + 1,
+          updatedAt: isoNow(),
+        });
       }
-      wsCommits.push({ id: String(wsCommitSeq), entries: entries as WsEntry[], before });
+      wsCommits.push({ id: String(wsCommitSeq), owner, entries: entries as WsEntry[], before });
     },
     async history(query) {
-      const all = wsCommits.map((c) => ({ commitId: c.id, entries: c.entries }));
+      const owner = query?.owner ?? BOUND_OWNER;
+      const all = wsCommits
+        .filter((c) => c.owner === owner)
+        .map((c) => ({ commitId: c.id, entries: c.entries }));
       all.reverse(); // newest first
       const offset = query?.cursor ? Math.max(0, Number.parseInt(query.cursor, 10)) : 0;
       const end = Math.min(offset + pageLimit(query?.limit), all.length);
@@ -339,13 +392,17 @@ export function memoryStoreOps(): StoreOps {
         ...(end < all.length ? { cursor: String(end) } : {}),
       };
     },
-    async undo(commitId) {
-      const idx = wsCommits.findIndex((c) => c.id === commitId);
+    async undo(commitId, opts) {
+      const owner = opts?.owner ?? BOUND_OWNER;
+      // Another owner's commit is not this owner's to undo — and saying so
+      // would make the door an existence oracle.
+      const idx = wsCommits.findIndex((c) => c.id === commitId && c.owner === owner);
       if (idx === -1) throw new VendoError("not-found", `commit ${commitId} not found`);
       const commit = wsCommits[idx]!;
+      const files = drawer(owner);
       for (const [path, prev] of commit.before) {
-        if (prev === undefined) wsFiles.delete(path);
-        else wsFiles.set(path, prev);
+        if (prev === undefined) files.delete(path);
+        else files.set(path, { data: prev, revision: (files.get(path)?.revision ?? 0) + 1, updatedAt: isoNow() });
       }
       wsCommits.splice(idx, 1);
     },

--- a/packages/core/src/conformance/memory-store-ops.ts
+++ b/packages/core/src/conformance/memory-store-ops.ts
@@ -351,6 +351,16 @@ export function memoryStoreOps(): StoreOps {
     },
     async commit(entries, opts) {
       const owner = opts?.owner ?? BOUND_OWNER;
+      // One commit, one mutation per path: two entries for the same path leave
+      // the commit with no single before-image, so undoing it would walk back to
+      // the intermediate state the commit itself wrote.
+      const paths = new Set<string>();
+      for (const entry of entries as WsEntry[]) {
+        if (paths.has(entry.path)) {
+          throw new VendoError("validation", `workspace entry ${entry.path} appears twice in one commit`);
+        }
+        paths.add(entry.path);
+      }
       const key = opts?.idempotencyKey;
       if (key !== undefined) {
         const body = JSON.stringify(entries);

--- a/packages/core/src/conformance/memory-store-ops.ts
+++ b/packages/core/src/conformance/memory-store-ops.ts
@@ -73,7 +73,18 @@ export function memoryStoreOps(): StoreOps {
   // local backend does.
   type WsEntry = { path: string; data?: unknown; delete?: true; expectedRevision?: number };
   type WsFile = { data: unknown; revision: number; updatedAt: IsoDateTime };
-  type WsCommit = { id: string; owner: string; entries: WsEntry[]; before: Map<string, unknown> };
+  /** `before` is what each path held before the commit (absent = the commit
+      created it), and `beforeRevision` which revision that was — the pair a
+      per-path undo restores, and the pair it consumes so a later whole-commit
+      undo does not restore the same path twice. */
+  type WsCommit = {
+    id: string;
+    owner: string;
+    at: IsoDateTime;
+    entries: WsEntry[];
+    before: Map<string, unknown>;
+    beforeRevision: Map<string, number>;
+  };
   const BOUND_OWNER = "user_local";
   const drawers = new Map<string, Map<string, WsFile>>();
   const drawer = (owner: string): Map<string, WsFile> => {
@@ -365,25 +376,44 @@ export function memoryStoreOps(): StoreOps {
       }
       wsCommitSeq += 1;
       const before = new Map<string, unknown>();
+      const beforeRevision = new Map<string, number>();
       for (const e of entries as WsEntry[]) {
-        before.set(e.path, files.get(e.path)?.data);
+        const current = files.get(e.path);
+        before.set(e.path, current?.data);
+        if (current !== undefined) beforeRevision.set(e.path, current.revision);
         if (e.delete === true) {
           files.delete(e.path);
           continue;
         }
         files.set(e.path, {
           data: jsonCopy(e.data),
-          revision: (files.get(e.path)?.revision ?? 0) + 1,
+          revision: (current?.revision ?? 0) + 1,
           updatedAt: isoNow(),
         });
       }
-      wsCommits.push({ id: String(wsCommitSeq), owner, entries: entries as WsEntry[], before });
+      wsCommits.push({
+        id: String(wsCommitSeq),
+        owner,
+        at: isoNow(),
+        entries: entries as WsEntry[],
+        before,
+        beforeRevision,
+      });
     },
     async history(query) {
       const owner = query?.owner ?? BOUND_OWNER;
+      const path = query?.path;
       const all = wsCommits
-        .filter((c) => c.owner === owner)
-        .map((c) => ({ commitId: c.id, entries: c.entries }));
+        .filter((c) => c.owner === owner
+          && (path === undefined || c.entries.some((e) => e.path === path)))
+        .map((c) => ({
+          commitId: c.id,
+          entries: c.entries,
+          at: c.at,
+          ...(path !== undefined && c.beforeRevision.has(path)
+            ? { revision: c.beforeRevision.get(path)! }
+            : {}),
+        }));
       all.reverse(); // newest first
       const offset = query?.cursor ? Math.max(0, Number.parseInt(query.cursor, 10)) : 0;
       const end = Math.min(offset + pageLimit(query?.limit), all.length);
@@ -392,19 +422,45 @@ export function memoryStoreOps(): StoreOps {
         ...(end < all.length ? { cursor: String(end) } : {}),
       };
     },
-    async undo(commitId, opts) {
+    async undo(target, opts) {
       const owner = opts?.owner ?? BOUND_OWNER;
-      // Another owner's commit is not this owner's to undo — and saying so
-      // would make the door an existence oracle.
-      const idx = wsCommits.findIndex((c) => c.id === commitId && c.owner === owner);
-      if (idx === -1) throw new VendoError("not-found", `commit ${commitId} not found`);
-      const commit = wsCommits[idx]!;
       const files = drawer(owner);
-      for (const [path, prev] of commit.before) {
-        if (prev === undefined) files.delete(path);
-        else files.set(path, { data: prev, revision: (files.get(path)?.revision ?? 0) + 1, updatedAt: isoNow() });
+      /** Put one path back the way the commit found it: absent means the commit
+          created it, so undoing removes it again. */
+      const restore = (path: string, prev: unknown): number | undefined => {
+        if (prev === undefined) {
+          files.delete(path);
+          return undefined;
+        }
+        const revision = (files.get(path)?.revision ?? 0) + 1;
+        files.set(path, { data: prev, revision, updatedAt: isoNow() });
+        return revision;
+      };
+      if (typeof target === "string") {
+        // Another owner's commit is not this owner's to undo — and saying so
+        // would make the door an existence oracle.
+        const idx = wsCommits.findIndex((c) => c.id === target && c.owner === owner);
+        if (idx === -1) throw new VendoError("not-found", `commit ${target} not found`);
+        for (const [path, prev] of wsCommits[idx]!.before) restore(path, prev);
+        wsCommits.splice(idx, 1);
+        return {};
       }
-      wsCommits.splice(idx, 1);
+      const { path } = target;
+      let idx = wsCommits.length - 1;
+      while (idx >= 0) {
+        const c = wsCommits[idx]!;
+        if (c.owner === owner && c.entries.some((e) => e.path === path)) break;
+        idx -= 1;
+      }
+      if (idx === -1) throw new VendoError("not-found", `no commit has touched ${path}`);
+      const commit = wsCommits[idx]!;
+      const revision = restore(path, commit.before.get(path));
+      // Consume ONLY this path — the rest of the commit stays undoable.
+      commit.entries = commit.entries.filter((e) => e.path !== path);
+      commit.before.delete(path);
+      commit.beforeRevision.delete(path);
+      if (commit.entries.length === 0) wsCommits.splice(idx, 1);
+      return revision === undefined ? {} : { revision };
     },
   };
 

--- a/packages/core/src/conformance/store-ops.ts
+++ b/packages/core/src/conformance/store-ops.ts
@@ -86,6 +86,15 @@ const stringField = (entry: unknown, field: string, message: string): string => 
   return value;
 };
 
+/** The numeric twin of {@link stringField} — `workspace.index` entries carry
+    the revision a strict commit compare-and-swaps against, so the field is
+    contract the same way `commitId` is. */
+const numberField = (entry: unknown, field: string, message: string): number => {
+  const value = (entry as Record<string, unknown> | null)?.[field];
+  assert(typeof value === "number", `${message}: entry ${JSON.stringify(entry)} has no number "${field}"`);
+  return value;
+};
+
 /** A thread's harness state rides the harness slot under this synthetic appId
     (the store's `harnessStateKey`), which is what makes deleteThread's cascade
     onto harness state observable through the 32 ops. */
@@ -344,6 +353,27 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         assert(msgs.length === 2, `putMessage did not append: got ${msgs.length} messages`);
       }),
 
+      /** putMessage is an UPSERT, not an append-only log: a message re-sent
+          under an id the thread already holds REPLACES it, in place. That is
+          how an edit lands and how an approval flips from pending to answered;
+          appending instead leaves two messages under one id, which the thread
+          engines refuse outright, so the flip could never persist. */
+      opsCase(opts, "transcripts.putMessage edits by id, in place", async (ops) => {
+        await ops.transcripts.putThread({ id: "thr_pm2", subject: "u", messages: [] });
+        await ops.transcripts.putMessage("thr_pm2", { id: "msg_a", role: "user", text: "ask" });
+        await ops.transcripts.putMessage("thr_pm2", { id: "msg_b", role: "assistant", text: "answer" });
+        await ops.transcripts.putMessage("thr_pm2", { id: "msg_a", role: "user", text: "ask (edited)" });
+
+        const got = await ops.transcripts.getThread("thr_pm2");
+        const msgs = (got!.data as Record<string, unknown>)["messages"] as Array<Record<string, unknown>>;
+        assert(msgs.length === 2, `the edit should not have added a message: got ${msgs.length}`);
+        assertDeepEqual(
+          msgs.map((message) => [message["id"], message["text"]]),
+          [["msg_a", "ask (edited)"], ["msg_b", "answer"]],
+          "the edit did not replace its message in place",
+        );
+      }),
+
       opsCase(opts, "transcripts.recordAnswer records answer; duplicate same-id refused as conflict", async (ops) => {
         await ops.transcripts.putThread({ id: "thr_ra1", subject: "u", messages: [] });
         await ops.transcripts.recordAnswer("thr_ra1", { id: "ans_1", value: 42 });
@@ -461,6 +491,134 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
           "undo did not restore the value its commit replaced",
         );
         await assertThrowsCode(() => ops.workspace.undo("commit_absent"), "not-found", "undoing an unknown commit");
+      }),
+
+      /** The workspace is the last op family to name its owner, and until it
+          did, every end user of one deployment shared ONE drawer. Two owners,
+          one path: no read, index, history or undo may cross. */
+      opsCase(opts, "workspace ops keep two owners' drawers apart", async (ops) => {
+        const path = "shared.json";
+        await ops.workspace.commit([{ path, data: { who: "a" } }], { owner: "own_a" });
+        await ops.workspace.commit([{ path, data: { who: "b" } }], { owner: "own_b" });
+
+        assertDeepEqual(
+          (await ops.workspace.read([path], { owner: "own_a" }))[path],
+          { who: "a" },
+          "one owner's read returned another owner's file",
+        );
+        assertDeepEqual(
+          (await ops.workspace.read([path], { owner: "own_b" }))[path],
+          { who: "b" },
+          "one owner's read returned another owner's file",
+        );
+        assertDeepEqual(
+          await ops.workspace.read([path], { owner: "own_c" }),
+          {},
+          "an owner with no files read someone else's drawer",
+        );
+        assertDeepEqual(
+          (await ops.workspace.index({ owner: "own_a" })).entries
+            .map((entry) => stringField(entry, "path", "workspace.index")),
+          [path],
+          "one owner's index listed another owner's files",
+        );
+        assertDeepEqual(
+          (await ops.workspace.index({ owner: "own_c" })).entries,
+          [],
+          "an owner with no files indexed someone else's drawer",
+        );
+
+        const commitsOf = async (owner: string): Promise<string[]> =>
+          (await ops.workspace.history({ owner })).entries
+            .map((entry) => stringField(entry, "commitId", "workspace.history"));
+        const [ofA, ofB] = [await commitsOf("own_a"), await commitsOf("own_b")];
+        assert(ofA.length === 1 && ofB.length === 1, "history did not filter by owner");
+        assert(ofA[0] !== ofB[0], "two owners' histories returned the same commit");
+        await assertThrowsCode(
+          () => ops.workspace.undo(ofB[0]!, { owner: "own_a" }),
+          "not-found",
+          "undoing another owner's commit",
+        );
+        assertDeepEqual(
+          (await ops.workspace.read([path], { owner: "own_b" }))[path],
+          { who: "b" },
+          "a cross-owner undo changed the other owner's file",
+        );
+      }),
+
+      /** Deletion was inexpressible over the wire: a hosted workspace could
+          add and overwrite files forever but never drop one. */
+      opsCase(opts, "workspace.commit removes a path with a delete tombstone, and undo restores it", async (ops) => {
+        await ops.workspace.commit([{ path: "tomb.json", data: { v: 1 } }]);
+        await ops.workspace.commit([{ path: "tomb.json", delete: true }]);
+        assertDeepEqual(
+          await ops.workspace.read(["tomb.json"]),
+          {},
+          "the tombstone left the file behind",
+        );
+        assertDeepEqual(
+          (await ops.workspace.index()).entries
+            .map((entry) => stringField(entry, "path", "workspace.index")),
+          [],
+          "the tombstoned path is still in the index",
+        );
+        const newest = stringField(
+          (await ops.workspace.history()).entries[0],
+          "commitId",
+          "workspace.history",
+        );
+        await ops.workspace.undo(newest);
+        assertDeepEqual(
+          (await ops.workspace.read(["tomb.json"]))["tomb.json"],
+          { v: 1 },
+          "undoing a tombstone did not bring the file back",
+        );
+      }),
+
+      /** The `/orgs` mounts commit under strict compare-and-swap: a write built
+          on a revision that has moved must be refused, not silently applied
+          over a colleague's edit. */
+      opsCase(opts, "workspace.commit refuses a stale expectedRevision and applies nothing", async (ops) => {
+        await ops.workspace.commit([{ path: "cas.json", data: { v: 1 } }]);
+        const revision = numberField(
+          (await ops.workspace.index()).entries[0],
+          "revision",
+          "workspace.index",
+        );
+        // The head moves under the caller.
+        await ops.workspace.commit([{ path: "cas.json", data: { v: 2 } }]);
+
+        await assertThrowsCode(
+          () => ops.workspace.commit([
+            { path: "cas.json", data: { v: 3 }, expectedRevision: revision },
+            { path: "cas-other.json", data: { v: 3 } },
+          ]),
+          "conflict",
+          "committing against a revision that has moved",
+        );
+        assertDeepEqual(
+          (await ops.workspace.read(["cas.json"]))["cas.json"],
+          { v: 2 },
+          "the refused commit overwrote the newer content",
+        );
+        assert(
+          !("cas-other.json" in await ops.workspace.read(["cas-other.json"])),
+          "the refused commit applied its non-conflicting entry anyway",
+        );
+
+        // Re-aimed at the live head, the same commit lands.
+        const head = numberField(
+          (await ops.workspace.index()).entries
+            .find((entry) => (entry as { path?: unknown }).path === "cas.json"),
+          "revision",
+          "workspace.index",
+        );
+        await ops.workspace.commit([{ path: "cas.json", data: { v: 3 }, expectedRevision: head }]);
+        assertDeepEqual(
+          (await ops.workspace.read(["cas.json"]))["cas.json"],
+          { v: 3 },
+          "a commit aimed at the live revision did not land",
+        );
       }),
 
       // =====================================================================

--- a/packages/core/src/conformance/store-ops.ts
+++ b/packages/core/src/conformance/store-ops.ts
@@ -575,6 +575,123 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         );
       }),
 
+      // ---------------------------------------------------------------------
+      // the path legs of history/undo — surgical per-file undo. Without them a
+      // user who wanted one file back had to undo whole commits, taking every
+      // other file in them along.
+      // ---------------------------------------------------------------------
+
+      opsCase(opts, "workspace.history narrows to the commits that touched one path", async (ops) => {
+        await ops.workspace.commit([{ path: "p-mine.json", data: { v: 1 } }]);
+        await ops.workspace.commit([{ path: "p-other.json", data: { v: 1 } }]);
+        await ops.workspace.commit([{ path: "p-mine.json", data: { v: 2 } }]);
+
+        const commitsOf = async (path: string): Promise<unknown[]> =>
+          (await ops.workspace.history({ path })).entries;
+        const mine = await commitsOf("p-mine.json");
+        assert(mine.length === 2, `path history should hold this path's two commits, got ${mine.length}`);
+        assert(
+          (await commitsOf("p-other.json")).length === 1,
+          "path history returned commits that did not touch the path",
+        );
+        assertDeepEqual(await commitsOf("p-never.json"), [], "path history invented commits for an untouched path");
+
+        // Newest first, and the newest one names the revision it superseded —
+        // the version a per-path undo walks back to. The commit that CREATED
+        // the path superseded nothing, so it names no revision.
+        const newest = mine[0];
+        assert(
+          numberField(newest, "revision", "workspace.history") > 0,
+          "the overwriting commit did not name the revision it superseded",
+        );
+        assert(
+          (mine[1] as Record<string, unknown>)["revision"] === undefined,
+          "the commit that created the path claimed to have superseded a revision",
+        );
+      }),
+
+      opsCase(opts, "workspace.undo by path restores that path and leaves the rest of its commit", async (ops) => {
+        await ops.workspace.commit([{ path: "u-one.json", data: { v: 1 } }, { path: "u-two.json", data: { v: 1 } }]);
+        await ops.workspace.commit([{ path: "u-one.json", data: { v: 2 } }, { path: "u-two.json", data: { v: 2 } }]);
+
+        await ops.workspace.undo({ path: "u-one.json" });
+        const after = await ops.workspace.read(["u-one.json", "u-two.json"]);
+        assertDeepEqual(after["u-one.json"], { v: 1 }, "the path undo did not restore the previous version");
+        assertDeepEqual(after["u-two.json"], { v: 2 }, "the path undo touched a path it was not asked about");
+
+        await assertThrowsCode(
+          () => ops.workspace.undo({ path: "u-never.json" }),
+          "not-found",
+          "undoing a path nothing has touched",
+        );
+      }),
+
+      opsCase(opts, "workspace.undo by path deletes a file its commit created", async (ops) => {
+        await ops.workspace.commit([{ path: "u-new.json", data: { v: 1 } }]);
+        await ops.workspace.undo({ path: "u-new.json" });
+        assertDeepEqual(
+          await ops.workspace.read(["u-new.json"]),
+          {},
+          "undoing the commit that created a file left the file behind",
+        );
+      }),
+
+      /** The bookkeeping that makes the two legs coexist: a path already undone
+          is CONSUMED from its commit, so undoing that whole commit afterwards
+          steps over it instead of restoring it a second time. */
+      opsCase(opts, "a whole-commit undo skips a path an earlier path undo consumed", async (ops) => {
+        await ops.workspace.commit([{ path: "c-one.json", data: { v: 1 } }, { path: "c-two.json", data: { v: 1 } }]);
+        await ops.workspace.commit([{ path: "c-one.json", data: { v: 2 } }, { path: "c-two.json", data: { v: 2 } }]);
+        const newest = stringField(
+          (await ops.workspace.history()).entries[0],
+          "commitId",
+          "workspace.history",
+        );
+
+        await ops.workspace.undo({ path: "c-one.json" });
+        // Someone puts the file back where the path undo left it from.
+        await ops.workspace.commit([{ path: "c-one.json", data: { v: 3 } }]);
+        await ops.workspace.undo(newest);
+
+        const after = await ops.workspace.read(["c-one.json", "c-two.json"]);
+        assertDeepEqual(after["c-one.json"], { v: 3 }, "the whole-commit undo restored a path already undone by path");
+        assertDeepEqual(after["c-two.json"], { v: 1 }, "the whole-commit undo did not restore its remaining path");
+      }),
+
+      opsCase(opts, "the path legs keep two owners' drawers apart", async (ops) => {
+        const path = "p-shared.json";
+        for (const owner of ["pown_a", "pown_b"]) {
+          await ops.workspace.commit([{ path, data: { who: owner, v: 1 } }], { owner });
+          await ops.workspace.commit([{ path, data: { who: owner, v: 2 } }], { owner });
+        }
+        assert(
+          (await ops.workspace.history({ path, owner: "pown_a" })).entries.length === 2,
+          "one owner's path history did not hold that owner's two commits",
+        );
+        assertDeepEqual(
+          (await ops.workspace.history({ path, owner: "pown_c" })).entries,
+          [],
+          "an owner with no files read another owner's path history",
+        );
+        await assertThrowsCode(
+          () => ops.workspace.undo({ path }, { owner: "pown_c" }),
+          "not-found",
+          "undoing a path in a drawer that has none",
+        );
+
+        await ops.workspace.undo({ path }, { owner: "pown_a" });
+        assertDeepEqual(
+          (await ops.workspace.read([path], { owner: "pown_a" }))[path],
+          { who: "pown_a", v: 1 },
+          "one owner's path undo did not restore their own file",
+        );
+        assertDeepEqual(
+          (await ops.workspace.read([path], { owner: "pown_b" }))[path],
+          { who: "pown_b", v: 2 },
+          "one owner's path undo reached into another owner's drawer",
+        );
+      }),
+
       /** The `/orgs` mounts commit under strict compare-and-swap: a write built
           on a revision that has moved must be refused, not silently applied
           over a colleague's edit. */

--- a/packages/core/src/conformance/store-ops.ts
+++ b/packages/core/src/conformance/store-ops.ts
@@ -738,6 +738,72 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         );
       }),
 
+      /** A DELETE is a commit against a revision too. Without this, a turn that
+          checked out an org file, lost the head to a colleague, and then removed
+          the path erased content it had never seen — the one mutation strict
+          mounts cannot take back. */
+      opsCase(opts, "workspace.commit refuses a stale expectedRevision on a tombstone", async (ops) => {
+        await ops.workspace.commit([{ path: "cas-del.json", data: { v: 1 } }]);
+        const revision = numberField(
+          (await ops.workspace.index()).entries
+            .find((entry) => (entry as { path?: unknown }).path === "cas-del.json"),
+          "revision",
+          "workspace.index",
+        );
+        // The head moves under the caller holding `revision`.
+        await ops.workspace.commit([{ path: "cas-del.json", data: { v: 2 } }]);
+
+        await assertThrowsCode(
+          () => ops.workspace.commit([{ path: "cas-del.json", delete: true, expectedRevision: revision }]),
+          "conflict",
+          "deleting a path whose revision has moved",
+        );
+        assertDeepEqual(
+          (await ops.workspace.read(["cas-del.json"]))["cas-del.json"],
+          { v: 2 },
+          "a stale tombstone deleted the newer content",
+        );
+      }),
+
+      /** Bytes that happen to match the head do not make a stale commit fresh:
+          the caller still read a revision that has moved, and the contract's
+          answer to that is `conflict`, whatever the entry would have written. */
+      opsCase(opts, "workspace.commit refuses a stale expectedRevision whose bytes already match", async (ops) => {
+        await ops.workspace.commit([{ path: "cas-same.json", data: { v: 1 } }]);
+        const revision = numberField(
+          (await ops.workspace.index()).entries
+            .find((entry) => (entry as { path?: unknown }).path === "cas-same.json"),
+          "revision",
+          "workspace.index",
+        );
+        await ops.workspace.commit([{ path: "cas-same.json", data: { v: 2 } }]);
+
+        await assertThrowsCode(
+          () => ops.workspace.commit([{ path: "cas-same.json", data: { v: 2 }, expectedRevision: revision }]),
+          "conflict",
+          "committing the head's own bytes against a revision that has moved",
+        );
+      }),
+
+      /** Two entries for one path leave the commit with no single before-image,
+          so undoing it walks back to the intermediate state the commit itself
+          wrote. Refused at the door instead. */
+      opsCase(opts, "workspace.commit refuses the same path twice in one commit", async (ops) => {
+        await assertThrowsCode(
+          () => ops.workspace.commit([
+            { path: "dup.json", data: { v: 1 } },
+            { path: "dup.json", delete: true },
+          ]),
+          "validation",
+          "committing one path twice",
+        );
+        assertDeepEqual(
+          await ops.workspace.read(["dup.json"]),
+          {},
+          "the refused commit wrote its first entry anyway",
+        );
+      }),
+
       // =====================================================================
       // lifecycle
       // =====================================================================

--- a/packages/core/src/store-wire.ts
+++ b/packages/core/src/store-wire.ts
@@ -205,19 +205,42 @@ export const storeWireHarnessClearRequestSchema = z.object({
 // workspace
 // ---------------------------------------------------------------------------
 
-export const storeWireWorkspaceIndexRequestSchema = cursorQuerySchema;
+/** The owner whose drawer a workspace op addresses: the end user (or org) the
+    files belong to, the way every other op family already names its subject.
+    Optional here because a single-player mount binds its one owner at
+    construction; a mount serving more than one user always sends it, or its
+    whole user base shares one drawer. */
+const ownerField = { owner: z.string().min(1).optional() };
+
+/** One committed change to one path: new content, or a tombstone that removes
+    it (deletion was otherwise inexpressible over the wire). `expectedRevision`
+    makes the write a strict compare-and-swap against the revision the caller
+    read — the `/orgs` mounts' policy — and a stale one refuses the commit.
+    `data` stays unknown: content is the caller's JSON, with binary riding the
+    `{"$vendoWorkspaceBytes": base64}` envelope. */
+export const storeWireWorkspaceEntrySchema = z.object({
+  path: z.string().min(1),
+  data: z.unknown(),
+  delete: z.literal(true).optional(),
+  expectedRevision: z.number().int().min(0).optional(),
+}).passthrough();
+
+export const storeWireWorkspaceIndexRequestSchema = cursorQuerySchema.extend(ownerField);
 
 export const storeWireWorkspaceReadRequestSchema = z.object({
+  ...ownerField,
   paths: z.array(z.string().min(1)).min(1),
 }).passthrough();
 
 export const storeWireWorkspaceCommitRequestSchema = z.object({
-  entries: z.array(z.unknown()).min(1),
+  ...ownerField,
+  entries: z.array(storeWireWorkspaceEntrySchema).min(1),
 }).passthrough();
 
-export const storeWireWorkspaceHistoryRequestSchema = cursorQuerySchema;
+export const storeWireWorkspaceHistoryRequestSchema = cursorQuerySchema.extend(ownerField);
 
 export const storeWireWorkspaceUndoRequestSchema = z.object({
+  ...ownerField,
   commitId: z.string().min(1),
 }).passthrough();
 

--- a/packages/core/src/store-wire.ts
+++ b/packages/core/src/store-wire.ts
@@ -237,12 +237,24 @@ export const storeWireWorkspaceCommitRequestSchema = z.object({
   entries: z.array(storeWireWorkspaceEntrySchema).min(1),
 }).passthrough();
 
-export const storeWireWorkspaceHistoryRequestSchema = cursorQuerySchema.extend(ownerField);
+/** `path` narrows the page to the commits that touched it (newest first, same
+    keyset cursor); without it the page is the whole commit ledger. */
+export const storeWireWorkspaceHistoryRequestSchema = cursorQuerySchema.extend({
+  ...ownerField,
+  path: z.string().min(1).optional(),
+});
 
+/** Exactly ONE of commitId/path: undo the whole commit, or undo one path's
+    newest change. Both set is two different mutations in one call, and neither
+    is an undo with no target. */
 export const storeWireWorkspaceUndoRequestSchema = z.object({
   ...ownerField,
-  commitId: z.string().min(1),
-}).passthrough();
+  commitId: z.string().min(1).optional(),
+  path: z.string().min(1).optional(),
+}).passthrough().refine(
+  (body) => (body.commitId === undefined) !== (body.path === undefined),
+  { message: "undo takes exactly one of commitId or path" },
+);
 
 // ---------------------------------------------------------------------------
 // lifecycle

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -133,12 +133,23 @@ export interface StoreOps {
     set(appId: string, subject: string, state: unknown): Promise<void>;
     clear(appId: string, subject: string): Promise<void>;
   };
+  /** Every workspace verb names its OWNER — the end user (or org) whose drawer
+      the files live in, exactly as conversations, records and blobs already do.
+      Omitted, the backend falls back to the owner it was constructed with, which
+      is the single-player local default; a multi-user hosted mount always passes
+      one, or its whole user base shares one drawer.
+
+      Entries are `{ path, data?, delete?, expectedRevision? }`: `delete: true` is
+      a tombstone (deletion is otherwise inexpressible), and `expectedRevision` is
+      the strict compare-and-swap the `/orgs` mounts commit under — a stale one
+      refuses the WHOLE commit with `conflict`, so the caller re-reads once.
+      Binary content rides `{"$vendoWorkspaceBytes": base64, contentType?}`. */
   workspace: {
-    index(query?: { cursor?: string; limit?: number }): Promise<{ entries: unknown[]; cursor?: string }>;
-    read(paths: string[]): Promise<Record<string, unknown>>;
-    commit(entries: unknown[], opts?: { idempotencyKey?: string }): Promise<void>;
-    history(query?: { cursor?: string; limit?: number }): Promise<{ entries: unknown[]; cursor?: string }>;
-    undo(commitId: string): Promise<void>;
+    index(query?: { cursor?: string; limit?: number; owner?: string }): Promise<{ entries: unknown[]; cursor?: string }>;
+    read(paths: string[], opts?: { owner?: string }): Promise<Record<string, unknown>>;
+    commit(entries: unknown[], opts?: { idempotencyKey?: string; owner?: string }): Promise<void>;
+    history(query?: { cursor?: string; limit?: number; owner?: string }): Promise<{ entries: unknown[]; cursor?: string }>;
+    undo(commitId: string, opts?: { owner?: string }): Promise<void>;
   };
   lifecycle: {
     erase(target: EraseTarget): Promise<unknown>;

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -148,8 +148,20 @@ export interface StoreOps {
     index(query?: { cursor?: string; limit?: number; owner?: string }): Promise<{ entries: unknown[]; cursor?: string }>;
     read(paths: string[], opts?: { owner?: string }): Promise<Record<string, unknown>>;
     commit(entries: unknown[], opts?: { idempotencyKey?: string; owner?: string }): Promise<void>;
-    history(query?: { cursor?: string; limit?: number; owner?: string }): Promise<{ entries: unknown[]; cursor?: string }>;
-    undo(commitId: string, opts?: { owner?: string }): Promise<void>;
+    /** Naming a `path` narrows history to the commits that touched it, newest
+        first, and each entry then also carries the `revision` that path held
+        BEFORE the commit — absent when the commit created it, which is exactly
+        the difference between "there is an older version to go back to" and
+        "there is nothing behind this file". */
+    history(query?: { cursor?: string; limit?: number; owner?: string; path?: string }): Promise<{ entries: unknown[]; cursor?: string }>;
+    /** Undo a whole commit by id, or — with `{ path }` — only that path's
+        newest change: the path's stored before-image comes back (a path the
+        commit CREATED is removed), and only that path is consumed, so undoing
+        the whole commit afterwards does not restore it twice. A path nothing
+        has touched is `not-found`, the same answer an unknown commit gets.
+        `revision` is the restored file's new revision, absent when the undo
+        removed the file. */
+    undo(target: string | { path: string }, opts?: { owner?: string }): Promise<{ revision?: number }>;
   };
   lifecycle: {
     erase(target: EraseTarget): Promise<unknown>;

--- a/packages/store/src/harness-state.ops.test.ts
+++ b/packages/store/src/harness-state.ops.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Durable harness state (build contract §1.3), proven against every backend it
+ * can sit on — the transcript suite's sibling, same shape and same reason.
+ *
+ * `harnessStateStore` demanded a SQL handle, which is why a key-only deployment
+ * re-seeded a session-owning harness on every turn. It picks a backend now
+ * (`backendOf`); this file is the proof that §1.3's rules — one slot per thread,
+ * keyed by its OWNER, a foreign harness DESTROYING rather than shadowing it, and
+ * the slot dying with its thread — read identically whichever backend answers.
+ */
+import { VendoError, type Principal, type StoreOps } from "@vendoai/core";
+import { memoryStoreOps } from "@vendoai/core/conformance";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { backends, type MadeBackend } from "./backends.test-util.js";
+import { createStoreOps, harnessStateStore, threadStore, type VendoStore } from "./index.js";
+
+const alice: Principal = { kind: "user", subject: "user_alice" };
+
+/** Not a handle `@vendoai/store` minted — the shape a hosted store presents. */
+function opsOnlyStore(ops: StoreOps): VendoStore {
+  const unused = (what: string): never => {
+    throw new Error(`the harness-state helper must not reach ${what}`);
+  };
+  return {
+    ops,
+    records: () => unused("records()"),
+    blobs: () => unused("blobs()"),
+    async ensureSchema() {},
+    async close() {},
+    raw: () => unused("raw()"),
+  };
+}
+
+interface Mode {
+  name: string;
+  store: VendoStore;
+  own(id: string, subject: string): Promise<void>;
+  removeThread(id: string, subject: string): Promise<void>;
+}
+
+/** Ids are namespaced per mode because `local-ops` and `sql` share one database. */
+const modesFor = (made: MadeBackend): Mode[] => {
+  const viaOps = (name: string, ops: StoreOps): Mode => ({
+    name,
+    store: opsOnlyStore(ops),
+    own: async (id, subject) => { await ops.transcripts.putThread({ id, subject, messages: [] }); },
+    removeThread: async (id) => { await ops.transcripts.deleteThread(id); },
+  });
+  return [
+    {
+      name: "sql",
+      store: made.store,
+      own: async (id, subject) => { await threadStore(made.store).put({ kind: "user", subject }, { id, messages: [] }); },
+      removeThread: async (id, subject) => { await threadStore(made.store).delete({ kind: "user", subject }, id); },
+    },
+    viaOps("memory-ops", memoryStoreOps()),
+    viaOps("local-ops", createStoreOps(made.store)),
+  ];
+};
+
+for (const backend of backends()) {
+  describe(`${backend.name} durable harness state across backends (§1.3, design D1)`, () => {
+    let made: MadeBackend;
+    let modes: Mode[];
+    beforeAll(async () => {
+      made = await backend.make();
+      await made.store.ensureSchema();
+      modes = modesFor(made);
+    });
+    afterAll(async () => { if (made) await made.cleanup(); });
+
+    describe.each([{ mode: "sql" }, { mode: "memory-ops" }, { mode: "local-ops" }])("$mode", ({ mode }) => {
+      const pick = (): Mode => modes.find((candidate) => candidate.name === mode)!;
+      const id = (suffix: string): string => `thr_hs_${mode.replace("-", "_")}_${suffix}`;
+
+      it("survives the handle: a value set on one reads back on another", async () => {
+        const { store, own } = pick();
+        const thread = id("durable");
+        await own(thread, alice.subject);
+        await harnessStateStore(store).set(thread, "claude-code", "sess_1");
+
+        expect(await harnessStateStore(store).get(thread, "claude-code")).toBe("sess_1");
+      });
+
+      it("a foreign harness CLEARS the slot rather than shadowing it", async () => {
+        const { store, own } = pick();
+        const thread = id("swap");
+        await own(thread, alice.subject);
+        const states = harnessStateStore(store);
+        await states.set(thread, "claude-code", "sess_swap");
+
+        expect(await states.get(thread, "vendo")).toBeUndefined();
+        // Destroyed, not hidden: swapping back must not resurrect a session the
+        // conversation has outgrown.
+        expect(await states.get(thread, "claude-code")).toBeUndefined();
+      });
+
+      it("set(undefined) deletes", async () => {
+        const { store, own } = pick();
+        const thread = id("delete");
+        await own(thread, alice.subject);
+        const states = harnessStateStore(store);
+        await states.set(thread, "claude-code", "sess_delete");
+        await states.set(thread, "claude-code", undefined);
+
+        expect(await states.get(thread, "claude-code")).toBeUndefined();
+      });
+
+      it("clear drops the thread's state whoever owns it", async () => {
+        const { store, own } = pick();
+        const thread = id("clear");
+        await own(thread, alice.subject);
+        const states = harnessStateStore(store);
+        await states.set(thread, "claude-code", "sess_clear");
+        await states.clear(thread);
+
+        expect(await states.get(thread, "claude-code")).toBeUndefined();
+      });
+
+      it("one thread's state is never another's", async () => {
+        const { store, own } = pick();
+        await own(id("a"), alice.subject);
+        await own(id("b"), alice.subject);
+        const states = harnessStateStore(store);
+        await states.set(id("a"), "claude-code", "sess_a");
+        await states.set(id("b"), "claude-code", "sess_b");
+
+        expect(await states.get(id("a"), "claude-code")).toBe("sess_a");
+        expect(await states.get(id("b"), "claude-code")).toBe("sess_b");
+      });
+
+      it("a thread nobody owns cannot hold state — the row would outlive the erase cascade", async () => {
+        await expect(harnessStateStore(pick().store).set(id("orphan"), "claude-code", "x"))
+          .rejects.toBeInstanceOf(VendoError);
+      });
+
+      it("reads a thread that never existed as no state, not an error", async () => {
+        await expect(harnessStateStore(pick().store).get(id("absent"), "claude-code"))
+          .resolves.toBeUndefined();
+      });
+
+      it("deleting the thread deletes its harness state — no ref outlives its thread", async () => {
+        const { store, own, removeThread } = pick();
+        const thread = id("gone");
+        await own(thread, alice.subject);
+        const states = harnessStateStore(store);
+        await states.set(thread, "claude-code", "sess_gone");
+        await removeThread(thread, alice.subject);
+
+        expect(await states.get(thread, "claude-code")).toBeUndefined();
+      });
+    });
+  });
+}
+
+describe("a store with neither a SQL handle nor a StoreOps surface", () => {
+  it("is refused by name, at construction", () => {
+    const bare = { ...opsOnlyStore(memoryStoreOps()), ops: undefined };
+    expect(() => harnessStateStore(bare)).toThrow(/SQL handle or a StoreOps-capable store/);
+  });
+});

--- a/packages/store/src/harness-state.ts
+++ b/packages/store/src/harness-state.ts
@@ -1,5 +1,7 @@
-import { VendoError } from "@vendoai/core";
-import { dbFor, type VendoStore } from "./store.js";
+import { VendoError, type StoreOps } from "@vendoai/core";
+import type { Db } from "./db-postgres.js";
+import { backendOf } from "./helpers/backend.js";
+import type { VendoStore } from "./store.js";
 
 /**
  * Build contract §1.3 — `turn.state`, made durable.
@@ -28,15 +30,89 @@ import { dbFor, type VendoStore } from "./store.js";
  */
 /** The synthetic `app_id` a thread's harness state rides under. Shared with the
  *  thread delete path (`helpers/threads.ts`), which sweeps the row so no
- *  native-session ref outlives its thread. */
+ *  native-session ref outlives its thread — and with the wire's own harness
+ *  family, whose slot is keyed identically so `deleteThread` cascades there too. */
 export const harnessStateKey = (threadId: string): string => `harness_state:${threadId}`;
 
-export function harnessStateStore(store: VendoStore): {
+export interface HarnessStateStore {
   get(threadId: string, harnessName: string): Promise<string | undefined>;
   set(threadId: string, harnessName: string, value: string | undefined): Promise<void>;
   clear(threadId: string): Promise<void>;
-} {
-  const db = dbFor(store);
+}
+
+/** The one row's payload, whichever backend holds it. */
+interface StoredState {
+  harness?: unknown;
+  value?: unknown;
+}
+
+/** Rows come back as jsonb (an object) or as text, depending on the driver. */
+function decode(row: unknown): StoredState | undefined {
+  const stored = typeof row === "string" ? (JSON.parse(row) as unknown) : row;
+  if (typeof stored !== "object" || stored === null) return undefined;
+  return stored as StoredState;
+}
+
+export function harnessStateStore(store: VendoStore): HarnessStateStore {
+  const backend = backendOf(store, "durable harness state (build contract §1.3)");
+  return backend.kind === "ops" ? overOps(backend.ops) : overSql(backend.db);
+}
+
+/**
+ * The hosted half: the SAME slot — `harness_state:<threadId>` as the appId, the
+ * thread's owner as the subject — served by the wire's `harness` family, so a
+ * deployment can move between backends without its sessions changing shape.
+ *
+ * The owner comes from `transcripts.getThread` where SQL reads `vendo_threads`
+ * directly. That read is not decoration: the wire's harness verbs are keyed by
+ * (appId, subject), and a row stored under the wrong subject is a row no erase
+ * and no adoption can reach — the same reason the SQL half refuses to store one.
+ */
+function overOps(ops: StoreOps): HarnessStateStore {
+  const ownerOf = async (threadId: string): Promise<string | undefined> => {
+    const record = await ops.transcripts.getThread(threadId);
+    const subject = (record?.data as { subject?: unknown } | undefined)?.subject;
+    return typeof subject === "string" ? subject : undefined;
+  };
+
+  return {
+    async get(threadId, harnessName) {
+      const subject = await ownerOf(threadId);
+      // No thread, no slot — the SQL half's missing row, reached differently.
+      if (subject === undefined) return undefined;
+      const stored = decode(await ops.harness.get(harnessStateKey(threadId), subject));
+      if (stored === undefined) return undefined;
+      if (stored.harness === harnessName) return typeof stored.value === "string" ? stored.value : undefined;
+      // §1.3's clearing rule: a different thinker holds this conversation now.
+      await ops.harness.clear(harnessStateKey(threadId), subject);
+      return undefined;
+    },
+
+    async set(threadId, harnessName, value) {
+      const subject = await ownerOf(threadId);
+      if (value === undefined) {
+        if (subject !== undefined) await ops.harness.clear(harnessStateKey(threadId), subject);
+        return;
+      }
+      if (subject === undefined) {
+        throw new VendoError("not-found", `No thread ${threadId} to hold harness state for.`);
+      }
+      // One row per (appId, subject), so a harness swap overwrites in place —
+      // the SQL half's delete-then-insert, expressed as the wire's own upsert.
+      await ops.harness.set(harnessStateKey(threadId), subject, { harness: harnessName, value });
+    },
+
+    async clear(threadId) {
+      const subject = await ownerOf(threadId);
+      // A thread that is already gone took its slot with it (deleteThread
+      // cascades the `harness_state:<id>` appId), so there is nothing to drop.
+      if (subject === undefined) return;
+      await ops.harness.clear(harnessStateKey(threadId), subject);
+    },
+  };
+}
+
+function overSql(db: Db): HarnessStateStore {
   const key = harnessStateKey;
 
   const ownerOf = async (threadId: string): Promise<string> => {
@@ -57,11 +133,9 @@ export function harnessStateStore(store: VendoStore): {
   return {
     async get(threadId, harnessName) {
       const result = await db.query("SELECT data FROM vendo_state WHERE app_id = $1", [key(threadId)]);
-      const row = result.rows[0]?.["data"];
-      const stored = typeof row === "string" ? (JSON.parse(row) as unknown) : row;
-      if (typeof stored !== "object" || stored === null) return undefined;
-      const { harness, value } = stored as { harness?: unknown; value?: unknown };
-      if (harness === harnessName) return typeof value === "string" ? value : undefined;
+      const stored = decode(result.rows[0]?.["data"]);
+      if (stored === undefined) return undefined;
+      if (stored.harness === harnessName) return typeof stored.value === "string" ? stored.value : undefined;
       // §1.3's clearing rule: a different thinker holds this conversation now.
       await drop(threadId);
       return undefined;

--- a/packages/store/src/helpers/backend.ts
+++ b/packages/store/src/helpers/backend.ts
@@ -1,0 +1,35 @@
+import { VendoError, type StoreOps } from "@vendoai/core";
+// Type-only — erased at compile time, so the engine stays out of this module's
+// bundle graph (the same rule store.ts states).
+import type { Db } from "../db-postgres.js";
+import { maybeDbFor, type VendoStore } from "../store.js";
+
+/** Where a helper's rows actually live for THIS store handle. */
+export type StoreBackend =
+  | { kind: "sql"; db: Db }
+  | { kind: "ops"; ops: StoreOps };
+
+/**
+ * The one selector every store-shaped helper resolves itself through.
+ *
+ * A helper like `threadMessageStore` used to open with `dbFor(store)` and throw
+ * "Unknown VendoStore handle" for anything this package did not mint — which is
+ * every hosted deployment, and is why a key-only host could not serve a harness
+ * turn. The rows exist either way; only the road to them differs. So: the SQL
+ * handle when there is one, the store's own 32-op surface when there is not, and
+ * a named refusal only when the store offers neither.
+ *
+ * SQL wins when both are present. It is the same database, one hop shorter.
+ *
+ * `what` names the thing being served, so the refusal reads as a fact about the
+ * deployment rather than an internals leak.
+ */
+export function backendOf(store: VendoStore, what: string): StoreBackend {
+  const db = maybeDbFor(store);
+  if (db !== undefined) return { kind: "sql", db };
+  if (store.ops !== undefined) return { kind: "ops", ops: store.ops };
+  throw new VendoError(
+    "not-implemented",
+    `${what} needs a SQL handle or a StoreOps-capable store; the configured store has neither.`,
+  );
+}

--- a/packages/store/src/helpers/thread-messages.ts
+++ b/packages/store/src/helpers/thread-messages.ts
@@ -1,5 +1,7 @@
-import { VendoError, type Principal, type ThreadId } from "@vendoai/core";
-import { dbFor, type VendoStore } from "../store.js";
+import { VendoError, type Principal, type StoreOps, type ThreadId } from "@vendoai/core";
+import type { Db } from "../db-postgres.js";
+import type { VendoStore } from "../store.js";
+import { backendOf } from "./backend.js";
 
 /** The least a transcript row must have for this store to key it: an id.
  *
@@ -15,23 +17,8 @@ export interface ThreadMessageLike {
   id: string;
 }
 
-/** Build contract §6 — one row per transcript message.
- *
- *  Why this exists: rewriting a whole `messages` array on every turn is
- *  O(messages²) over a conversation. One row per message makes a turn's write
- *  O(new messages), which is the property E6 measures.
- *
- *  Two invariants the SQL below enforces rather than trusts:
- *  - **`seq` is the only ordering authority.** Approval flips rewrite older
- *    messages, so `updated_at` does not order a transcript and is never read
- *    for ordering.
- *  - **Threads never cross subjects** (03 §5). The thread row is the ownership
- *    record; every read and write here joins it under `principal.subject`, so a
- *    foreign thread id reads as empty and writes to it are refused.
- */
-export function threadMessageStore<M extends ThreadMessageLike = ThreadMessageLike>(
-  store: VendoStore,
-): {
+/** Build contract §6 — the surface, whichever backend serves it. */
+export interface ThreadMessageStore<M extends ThreadMessageLike = ThreadMessageLike> {
   /** One row per message. Pass `expectedRevision` for a per-row CAS edit
    *  (contract §6): the write lands only if the row is still at that revision,
    *  so an edit built on a stale read is refused instead of clobbering a
@@ -45,8 +32,95 @@ export function threadMessageStore<M extends ThreadMessageLike = ThreadMessageLi
   ): Promise<void>;
   /** Reassembled by seq, oldest → newest. */
   list(principal: Principal, threadId: ThreadId): Promise<M[]>;
-} {
-  const db = dbFor(store);
+}
+
+function requireMessageId(message: ThreadMessageLike): string {
+  const messageId = message.id;
+  if (typeof messageId !== "string" || messageId === "") {
+    throw new VendoError("validation", "a thread message needs a non-empty id");
+  }
+  return messageId;
+}
+
+/** Build contract §6 — one row per transcript message.
+ *
+ *  Why this exists: rewriting a whole `messages` array on every turn is
+ *  O(messages²) over a conversation. One row per message makes a turn's write
+ *  O(new messages), which is the property E6 measures.
+ *
+ *  Two invariants both backends enforce rather than trust:
+ *  - **`seq` is the only ordering authority.** Approval flips rewrite older
+ *    messages, so `updated_at` does not order a transcript and is never read
+ *    for ordering.
+ *  - **Threads never cross subjects** (03 §5). The thread row is the ownership
+ *    record; every read and write here joins it under `principal.subject`, so a
+ *    foreign thread id reads as empty and writes to it are refused.
+ */
+export function threadMessageStore<M extends ThreadMessageLike = ThreadMessageLike>(
+  store: VendoStore,
+): ThreadMessageStore<M> {
+  const backend = backendOf(store, "the per-message transcript (build contract §6)");
+  return backend.kind === "ops" ? overOps<M>(backend.ops) : overSql<M>(backend.db);
+}
+
+/**
+ * The hosted half (design D2): transcripts ride `vendo/store-wire@1` as-is —
+ * `putMessage` for both the insert and the edit (an approval flip re-sends the
+ * message under its own id, which is the wire's edit), `getThread` for the read.
+ *
+ * Two honest differences from the SQL half, neither of which the runtime's
+ * caller can see:
+ * - **`seq` is not sent.** The wire's `putMessage` carries no seq; the service
+ *   appends at `max(seq) + 1`. `persistTurn` walks the canonical array in index
+ *   order and writes only what changed, so appended order IS seq order.
+ * - **Ownership is read-then-write**, not one statement. The TOCTOU window that
+ *   opens is between two writes by the same subject to a thread whose owner
+ *   would have to change mid-call, which the store has no verb for.
+ */
+function overOps<M extends ThreadMessageLike>(ops: StoreOps): ThreadMessageStore<M> {
+  /** The thread record is the ownership record on the wire exactly as the
+   *  `vendo_threads` row is in SQL: `data.subject` is the same field the join
+   *  reads. A foreign or absent thread yields nothing, so reads answer empty
+   *  and writes refuse — mirroring the local empty-read. */
+  const ownedThread = async (
+    principal: Principal,
+    threadId: ThreadId,
+  ): Promise<{ messages?: unknown } | undefined> => {
+    const record = await ops.transcripts.getThread(threadId);
+    if (record === null) return undefined;
+    const data = record.data as { subject?: unknown; messages?: unknown };
+    return data.subject === principal.subject ? data : undefined;
+  };
+
+  return {
+    async upsert(principal, threadId, message, _seq, opts) {
+      requireMessageId(message);
+      if (opts?.expectedRevision !== undefined) {
+        // Deliberately loud rather than silently downgraded to last-write-wins:
+        // a caller asking for CAS is asking not to clobber a concurrent edit.
+        // `transcripts.putMessage` carries no revision, so the guarantee cannot
+        // be honored over the wire — and no runtime caller asks for it.
+        throw new VendoError(
+          "not-implemented",
+          "a per-row CAS transcript edit (expectedRevision) is not expressible over the store wire: "
+          + "transcripts.putMessage carries no revision. Use a SQL-backed store for guarded edits.",
+        );
+      }
+      if (await ownedThread(principal, threadId) === undefined) {
+        throw new VendoError("conflict", `thread ${threadId} does not belong to this subject`);
+      }
+      await ops.transcripts.putMessage(threadId, message);
+    },
+    async list(principal, threadId) {
+      const data = await ownedThread(principal, threadId);
+      if (data === undefined) return [];
+      return Array.isArray(data.messages) ? data.messages as M[] : [];
+    },
+  };
+}
+
+/** The SQL half: the statements are the enforcement. */
+function overSql<M extends ThreadMessageLike>(db: Db): ThreadMessageStore<M> {
   return {
     async upsert(principal, threadId, message, seq, opts) {
       // The ownership gate is the INSERT's own source of rows: the SELECT
@@ -55,10 +129,7 @@ export function threadMessageStore<M extends ThreadMessageLike = ThreadMessageLi
       // Doing it in ONE statement closes the TOCTOU window a read-then-write
       // pre-check leaves open (the same reasoning as putThreadRow's guarded
       // upsert), and it is why the answer cannot be "insert anyway".
-      const messageId = message.id;
-      if (typeof messageId !== "string" || messageId === "") {
-        throw new VendoError("validation", "a thread message needs a non-empty id");
-      }
+      const messageId = requireMessageId(message);
       const expected = opts?.expectedRevision;
       const at = new Date().toISOString();
       // A CAS write is an EDIT, so it is a plain UPDATE rather than an upsert: it

--- a/packages/store/src/ops.ts
+++ b/packages/store/src/ops.ts
@@ -43,6 +43,7 @@ interface WorkspaceEntry {
 }
 
 function parseWorkspaceEntries(entries: unknown[]): WorkspaceEntry[] {
+  const seen = new Set<string>();
   return entries.map((entry) => {
     const path = (entry as { path?: unknown } | null)?.path;
     if (typeof path !== "string" || path === "") invalid("workspace entry needs a non-empty path");
@@ -54,12 +55,30 @@ function parseWorkspaceEntries(entries: unknown[]): WorkspaceEntry[] {
     if (expectedRevision !== undefined && typeof expectedRevision !== "number") {
       invalid(`workspace entry ${path} has a non-numeric expectedRevision`);
     }
+    // One commit, one mutation per path. Two entries for the same path leave a
+    // commit with no single before-image, so undoing it walks back to the
+    // INTERMEDIATE state the commit itself wrote rather than to the state the
+    // commit found. There is nothing a duplicate expresses that a second commit
+    // does not, so it is caller nonsense and says so.
+    if (seen.has(path)) invalid(`workspace entry ${path} appears twice in one commit`);
+    seen.add(path);
     return {
       path,
       ...(tombstone ? { delete: true as const } : { data: (entry as { data: unknown }).data }),
       ...(expectedRevision === undefined ? {} : { expectedRevision }),
     };
   });
+}
+
+/** The revisions a set of paths currently hold, absent for a path with no row —
+ *  the compare half of a strict commit for the entries `land` never sees. */
+async function headRevisions(db: Db, owner: string, paths: string[]): Promise<Map<string, number>> {
+  if (paths.length === 0) return new Map();
+  const result = await db.query(
+    `SELECT path, revision FROM vendo_workspace_files WHERE owner = $1 AND path = ANY($2::text[])`,
+    [owner, paths],
+  );
+  return new Map(result.rows.map((row) => [text(row["path"]), Number(row["revision"])]));
 }
 
 const commitEntries = (commit: VendoRecord): WorkspaceEntry[] =>
@@ -474,9 +493,23 @@ export function createStoreOps(
             // read. A lost swap throws, so the transaction takes the whole
             // commit back with it: a conflicting set applies none of itself and
             // the caller re-reads once.
+            //
+            // `land` performs its own compare, so these heads serve the two
+            // strict entries that never reach it: a TOMBSTONE, and a write whose
+            // bytes already match the head. Both are still commits against a
+            // revision the caller read, and skipping their compare let a stale
+            // delete erase a colleague's newer content outright.
+            const heads = await headRevisions(tdb, owner, [...expected.keys()]);
+            const moved = (path: string): boolean => {
+              const at = expected.get(path);
+              return at !== undefined && heads.get(path) !== at;
+            };
             const conflicts: string[] = [];
             for (const staged of prepared) {
-              if (staged.write === "unchanged") continue;
+              if (staged.write === "unchanged") {
+                if (moved(staged.path)) conflicts.push(staged.path);
+                continue;
+              }
               const at = expected.get(staged.path);
               const written = await txRows.land(
                 owner,
@@ -488,6 +521,10 @@ export function createStoreOps(
             }
             for (const entry of parsed) {
               if (entry.delete !== true) continue;
+              if (moved(entry.path)) {
+                conflicts.push(entry.path);
+                continue;
+              }
               await txRows.remove(owner, entry.path, commitId);
             }
             if (conflicts.length > 0) {

--- a/packages/store/src/ops.ts
+++ b/packages/store/src/ops.ts
@@ -62,6 +62,37 @@ function parseWorkspaceEntries(entries: unknown[]): WorkspaceEntry[] {
   });
 }
 
+const commitEntries = (commit: VendoRecord): WorkspaceEntry[] =>
+  (commit.data as { entries?: WorkspaceEntry[] }).entries ?? [];
+
+const commitCreated = (commit: VendoRecord): string[] =>
+  (commit.data as { created?: string[] }).created ?? [];
+
+const commitTouches = (commit: VendoRecord, path: string): boolean =>
+  commitEntries(commit).some((entry) => entry.path === path);
+
+/** The newest commit in one owner's ledger that touched `path` — the unit a
+ *  per-path undo walks back. The ledger pages newest-first, so the first hit
+ *  is the answer; a path nobody has touched walks the whole ledger and says
+ *  so, rather than undoing something else. */
+async function newestCommitTouching(
+  ledger: RecordStore,
+  owner: string,
+  path: string,
+): Promise<VendoRecord | undefined> {
+  let cursor: string | undefined;
+  do {
+    const page = await ledger.list({
+      refs: { subject: owner },
+      ...(cursor === undefined ? {} : { cursor }),
+    });
+    const hit = page.records.find((record) => commitTouches(record, path));
+    if (hit !== undefined) return hit;
+    cursor = page.cursor;
+  } while (cursor !== undefined);
+  return undefined;
+}
+
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
@@ -99,6 +130,19 @@ export function createStoreOps(
 
   const recordsDoor = (d: Db, collection: string): RecordStore =>
     createReservedRecordStore(d, collection) ?? createRecordStore(d, collection);
+
+  /** commit id → the revision that commit superseded at `path`. Every write a
+   *  commit lands stamps the commit id as its intent, so the workspace history
+   *  rows ARE this index; a commit with no row here created the path (or wrote
+   *  the bytes it already held), and has no older version behind it. */
+  const supersededRevisions = async (owner: string, path: string): Promise<Map<string, number>> => {
+    const result = await db.query(
+      `SELECT revision, intent FROM vendo_workspace_history
+       WHERE path = $1 AND owner = $2 AND intent IS NOT NULL ORDER BY revision ASC`,
+      [path, owner],
+    );
+    return new Map(result.rows.map((row) => [text(row["intent"]), Number(row["revision"])]));
+  };
 
   /** Reassemble one thread as its door record (shared read shape). */
   const readThread = async (d: Db, id: string): Promise<VendoRecord | null> => {
@@ -472,44 +516,96 @@ export function createStoreOps(
       },
       async history(query) {
         const owner = ownerFor(query);
+        const path = query?.path;
         const page = await createRecordStore(db, WORKSPACE_COMMITS).list({
           refs: { subject: owner },
           ...(query?.limit === undefined ? {} : { limit: query.limit }),
           ...(query?.cursor === undefined ? {} : { cursor: query.cursor }),
         });
+        // A path narrows the page in place, so the ledger's keyset cursor keeps
+        // meaning exactly what it meant: follow it for the next page, which may
+        // hold more of this path's commits (or none).
+        const records = path === undefined
+          ? page.records
+          : page.records.filter((record) => commitTouches(record, path));
+        // The before-revision the entry restores to. It is not in the ledger —
+        // it is the revision the write superseded, which every commit stamped
+        // with its own id as the intent when it landed.
+        const superseded = path === undefined
+          ? new Map<string, number>()
+          : await supersededRevisions(owner, path);
         return {
-          entries: page.records.map((record) => ({
+          entries: records.map((record) => ({
             commitId: record.id,
-            entries: (record.data as { entries?: unknown }).entries ?? [],
+            entries: commitEntries(record),
+            at: record.createdAt,
+            ...(superseded.has(record.id) ? { revision: superseded.get(record.id) } : {}),
           })),
           ...(page.cursor === undefined ? {} : { cursor: page.cursor }),
         };
       },
       /** Land the restore and consume the history it walked in ONE transaction. */
-      async undo(commitId, opts) {
+      async undo(target, opts) {
         const owner = ownerFor(opts);
-        await db.transaction(async (q) => {
+        return await db.transaction(async (q) => {
           const tdb = txDb(q);
           const ledger = createRecordStore(tdb, WORKSPACE_COMMITS);
-          const commit = await ledger.get(commitId);
-          // Another owner's commit is not this owner's to undo, and saying so
-          // would make the door an existence oracle: it is simply not found.
-          if (commit === null || commit.refs?.["subject"] !== owner) {
-            throw new VendoError("not-found", `commit ${commitId} not found`);
-          }
-          const data = commit.data as { entries?: WorkspaceEntry[]; created?: string[] };
-          const created = new Set(data.created ?? []);
           const txRows = workspaceRows(tdb, filesFor(tdb));
-          for (const entry of data.entries ?? []) {
-            if (created.has(entry.path)) {
-              // The commit created this path — undoing removes it (recorded to
-              // history, §3.3's append-only law, so it stays recoverable).
-              await txRows.remove(owner, entry.path, `undo ${commitId}`);
-            } else {
-              await txRows.undo(owner, entry.path);
+          /** The commit created this path, so undoing it removes the file
+              (recorded to history, §3.3's append-only law, so it stays
+              recoverable); otherwise the superseded revision comes back. */
+          const undoOne = async (
+            commitId: string,
+            path: string,
+            created: Set<string>,
+          ): Promise<number | undefined> => {
+            if (created.has(path)) {
+              await txRows.remove(owner, path, `undo ${commitId}`);
+              return undefined;
             }
+            const outcome = await txRows.undo(owner, path);
+            return outcome.status === "ok" ? outcome.revision : undefined;
+          };
+
+          if (typeof target === "string") {
+            const commit = await ledger.get(target);
+            // Another owner's commit is not this owner's to undo, and saying so
+            // would make the door an existence oracle: it is simply not found.
+            if (commit === null || commit.refs?.["subject"] !== owner) {
+              throw new VendoError("not-found", `commit ${target} not found`);
+            }
+            const created = new Set(commitCreated(commit));
+            for (const entry of commitEntries(commit)) {
+              await undoOne(target, entry.path, created);
+            }
+            await ledger.delete(target);
+            return {};
           }
-          await ledger.delete(commitId);
+
+          const { path } = target;
+          const commit = await newestCommitTouching(ledger, owner, path);
+          if (commit === undefined) {
+            throw new VendoError("not-found", `no commit has touched ${path}`);
+          }
+          const created = new Set(commitCreated(commit));
+          const revision = await undoOne(commit.id, path, created);
+          // Consume ONLY this path: the rest of the commit is still undoable,
+          // and a later whole-commit undo must not restore this path twice.
+          const rest = commitEntries(commit).filter((entry) => entry.path !== path);
+          if (rest.length === 0) {
+            await ledger.delete(commit.id);
+          } else {
+            await ledger.put({
+              id: commit.id,
+              data: {
+                ...(commit.data as Record<string, Json>),
+                entries: rest as unknown as Json,
+                created: [...created].filter((each) => each !== path),
+              },
+              ...(commit.refs === undefined ? {} : { refs: commit.refs }),
+            });
+          }
+          return revision === undefined ? {} : { revision };
         });
       },
     },

--- a/packages/store/src/ops.ts
+++ b/packages/store/src/ops.ts
@@ -33,17 +33,32 @@ const WORKSPACE_COMMITS = "vendo_workspace_commits";
 
 interface WorkspaceEntry {
   path: string;
-  data: unknown;
+  data?: unknown;
+  /** A tombstone: the commit removes this path (history keeps the content, so
+   *  undo brings it back). */
+  delete?: true;
+  /** Strict compare-and-swap against the revision the caller read — the
+   *  `/orgs` mounts' commit policy. A stale one refuses the WHOLE commit. */
+  expectedRevision?: number;
 }
 
 function parseWorkspaceEntries(entries: unknown[]): WorkspaceEntry[] {
   return entries.map((entry) => {
     const path = (entry as { path?: unknown } | null)?.path;
     if (typeof path !== "string" || path === "") invalid("workspace entry needs a non-empty path");
-    if ((entry as { data?: unknown }).data === undefined) {
+    const tombstone = (entry as { delete?: unknown }).delete === true;
+    if (!tombstone && (entry as { data?: unknown }).data === undefined) {
       invalid(`workspace entry ${path} needs data`);
     }
-    return { path, data: (entry as { data: unknown }).data };
+    const expectedRevision = (entry as { expectedRevision?: unknown }).expectedRevision;
+    if (expectedRevision !== undefined && typeof expectedRevision !== "number") {
+      invalid(`workspace entry ${path} has a non-numeric expectedRevision`);
+    }
+    return {
+      path,
+      ...(tombstone ? { delete: true as const } : { data: (entry as { data: unknown }).data }),
+      ...(expectedRevision === undefined ? {} : { expectedRevision }),
+    };
   });
 }
 
@@ -64,9 +79,12 @@ export function createStoreOps(
   options: { files?: FilesAdapter; workspaceOwner?: string } = {},
 ): StoreOps {
   const db = dbFor(store);
-  /** Workspace verbs carry no subject on the contract — the backend is bound
-   *  to its caller's mount at construction (the cloud door binds per tenant). */
-  const owner = options.workspaceOwner ?? "user_local";
+  /** Whose drawer a workspace verb addresses. The call names it when the mount
+   *  serves more than one user (`/user/**` is the subject's, `/orgs/<org>/**`
+   *  the org's); with no owner on the call the backend falls back to the one it
+   *  was bound to at construction — today's single-player default. */
+  const boundOwner = options.workspaceOwner ?? "user_local";
+  const ownerFor = (opts?: { owner?: string }): string => opts?.owner ?? boundOwner;
 
   /** The helpers all speak Db but only ever call `query`, so a verb's
    *  transaction hands them the same handle with the tx-scoped query in it. */
@@ -316,6 +334,7 @@ export function createStoreOps(
     // -----------------------------------------------------------------------
     workspace: {
       async index(query) {
+        const owner = ownerFor(query);
         const limit = pageLimit(query?.limit);
         const params: unknown[] = [owner];
         let where = "owner = $1";
@@ -342,7 +361,8 @@ export function createStoreOps(
             : {}),
         };
       },
-      async read(paths) {
+      async read(paths, opts) {
+        const owner = ownerFor(opts);
         const rows = workspaceRows(db, files);
         const result: Record<string, unknown> = {};
         for (const path of paths) {
@@ -353,6 +373,7 @@ export function createStoreOps(
         return result;
       },
       async commit(entries, opts) {
+        const owner = ownerFor(opts);
         const parsed = parseWorkspaceEntries(entries);
         const body = JSON.stringify(parsed);
         const key = opts?.idempotencyKey;
@@ -372,6 +393,9 @@ export function createStoreOps(
         let replayed: boolean | undefined;
         try {
           for (const entry of parsed) {
+            // A tombstone stages nothing: the removal is a row delete, and the
+            // content it removes is already stored (history keeps it).
+            if (entry.delete === true) continue;
             prepared.push({
               path: entry.path,
               write: await rows.prepare(owner, entry.path, encoder.encode(JSON.stringify(entry.data))),
@@ -397,9 +421,37 @@ export function createStoreOps(
               return (existing?.data as { body?: unknown } | undefined)?.body === body;
             }
             const txRows = workspaceRows(tdb, filesFor(tdb));
+            const expected = new Map(
+              parsed
+                .filter((entry) => entry.expectedRevision !== undefined)
+                .map((entry) => [entry.path, entry.expectedRevision!]),
+            );
+            // Strict entries compare-and-swap against the revision the caller
+            // read. A lost swap throws, so the transaction takes the whole
+            // commit back with it: a conflicting set applies none of itself and
+            // the caller re-reads once.
+            const conflicts: string[] = [];
             for (const staged of prepared) {
               if (staged.write === "unchanged") continue;
-              await txRows.land(owner, staged.write, commitId);
+              const at = expected.get(staged.path);
+              const written = await txRows.land(
+                owner,
+                staged.write,
+                commitId,
+                at === undefined ? undefined : { strict: true, expectedRevision: at },
+              );
+              if (written.conflict === true) conflicts.push(staged.path);
+            }
+            for (const entry of parsed) {
+              if (entry.delete !== true) continue;
+              await txRows.remove(owner, entry.path, commitId);
+            }
+            if (conflicts.length > 0) {
+              throw new VendoError(
+                "conflict",
+                `the workspace moved on under ${conflicts.sort().join(", ")}; nothing was committed`,
+                { conflicts },
+              );
             }
             return undefined;
           });
@@ -419,6 +471,7 @@ export function createStoreOps(
         }
       },
       async history(query) {
+        const owner = ownerFor(query);
         const page = await createRecordStore(db, WORKSPACE_COMMITS).list({
           refs: { subject: owner },
           ...(query?.limit === undefined ? {} : { limit: query.limit }),
@@ -433,12 +486,15 @@ export function createStoreOps(
         };
       },
       /** Land the restore and consume the history it walked in ONE transaction. */
-      async undo(commitId) {
+      async undo(commitId, opts) {
+        const owner = ownerFor(opts);
         await db.transaction(async (q) => {
           const tdb = txDb(q);
           const ledger = createRecordStore(tdb, WORKSPACE_COMMITS);
           const commit = await ledger.get(commitId);
-          if (commit === null) {
+          // Another owner's commit is not this owner's to undo, and saying so
+          // would make the door an existence oracle: it is simply not found.
+          if (commit === null || commit.refs?.["subject"] !== owner) {
             throw new VendoError("not-found", `commit ${commitId} not found`);
           }
           const data = commit.data as { entries?: WorkspaceEntry[]; created?: string[] };

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -1,4 +1,4 @@
-import type { BlobStore, RecordStore, StoreAdapter } from "@vendoai/core";
+import type { BlobStore, RecordStore, StoreAdapter, StoreOps } from "@vendoai/core";
 import { createBlobStore } from "./blobs.js";
 import { validateEncryptionKey } from "#store/crypto";
 // Type-only — erased at compile time. This module is the engine-agnostic
@@ -15,6 +15,11 @@ export interface VendoStore extends StoreAdapter {
   ensureSchema(): Promise<void>;
   close(): Promise<void>;
   raw(): unknown;
+  /** The 32-op named-operation surface, when this store carries one (the Cloud
+   *  hosted store does; a local store's lives behind `createStoreOps`). It is
+   *  what lets the helpers that need a transcript, a workspace or harness state
+   *  serve a store with no SQL handle — see `backendOf`. */
+  ops?: StoreOps;
 }
 
 /** Per-handle internals kept OFF the public store object (02-store §4 keeps
@@ -31,6 +36,14 @@ export function dbFor(store: VendoStore): Db {
   const found = internals.get(store);
   if (!found) throw new Error("Unknown VendoStore handle");
   return found.db;
+}
+
+/** The SQL handle behind a store, or `undefined` when this handle is not one
+ *  this package minted — a hosted store, or a host's own adapter. The asking
+ *  form of `dbFor`, for the callers that have a second way to serve the read
+ *  (`backendOf`) instead of nothing to say but "unknown handle". */
+export function maybeDbFor(store: VendoStore): Db | undefined {
+  return internals.get(store)?.db;
 }
 
 /** Package-internal (secrets.ts): the secrets configuration bound to a store

--- a/packages/store/src/thread-messages.ops.test.ts
+++ b/packages/store/src/thread-messages.ops.test.ts
@@ -1,0 +1,201 @@
+/**
+ * The transcript helper, proven against EVERY backend it can sit on.
+ *
+ * `threadMessageStore` used to open with `dbFor(store)`, so a store with no SQL
+ * handle — every hosted deployment — got "Unknown VendoStore handle" and the
+ * host silently fell back to the legacy chat path. It picks a backend now
+ * (`backendOf`), and the point of this file is that the CHOICE is invisible: one
+ * suite, three backends, same answers.
+ *
+ * The three:
+ *  - `sql`         — the store's own Postgres, the shipped path;
+ *  - `memory-ops`  — `memoryStoreOps()`, core's reference StoreOps;
+ *  - `local-ops`   — `createStoreOps(store)`, the 32-op contract served off the
+ *                    same real database, which is the closest offline stand-in
+ *                    for the console's own implementation.
+ *
+ * The console itself is proven with no stand-in at all, against Yousef's Vendo
+ * Cloud account, in `packages/vendo/src/hosted-transcript.live.test.ts`.
+ */
+import { VendoError, type Principal, type StoreOps } from "@vendoai/core";
+import { memoryStoreOps } from "@vendoai/core/conformance";
+import type { UIMessage } from "ai";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { backends, type MadeBackend } from "./backends.test-util.js";
+import { createStoreOps, threadMessageStore, threadStore, type VendoStore } from "./index.js";
+
+const alice: Principal = { kind: "user", subject: "user_alice" };
+const bob: Principal = { kind: "user", subject: "user_bob" };
+
+function message(id: string, text: string, role: "user" | "assistant" = "user"): UIMessage {
+  return { id, role, parts: [{ type: "text", text }] } as UIMessage;
+}
+
+/**
+ * A store the way a HOST supplies one: the public `VendoStore` surface plus a
+ * StoreOps, but NOT a handle `@vendoai/store` minted — so it is absent from the
+ * package's internals WeakMap and `dbFor` misses it. That is exactly the shape
+ * the Cloud hosted store presents.
+ */
+function opsOnlyStore(ops: StoreOps): VendoStore {
+  const unused = (what: string): never => {
+    throw new Error(`the transcript helper must not reach ${what}`);
+  };
+  return {
+    ops,
+    records: () => unused("records()"),
+    blobs: () => unused("blobs()"),
+    async ensureSchema() {},
+    async close() {},
+    raw: () => unused("raw()"),
+  };
+}
+
+interface Mode {
+  name: string;
+  store: VendoStore;
+  own(id: string, subject: string): Promise<void>;
+}
+
+/** Ids are namespaced per mode because `local-ops` and `sql` share one database. */
+const modesFor = (made: MadeBackend): Mode[] => {
+  const viaOps = (name: string, ops: StoreOps): Mode => ({
+    name,
+    store: opsOnlyStore(ops),
+    own: async (id, subject) => { await ops.transcripts.putThread({ id, subject, messages: [] }); },
+  });
+  return [
+    {
+      name: "sql",
+      store: made.store,
+      own: async (id, subject) => { await threadStore(made.store).put({ kind: "user", subject }, { id, messages: [] }); },
+    },
+    viaOps("memory-ops", memoryStoreOps()),
+    viaOps("local-ops", createStoreOps(made.store)),
+  ];
+};
+
+for (const backend of backends()) {
+  describe(`${backend.name} transcript helper across backends (build contract §6, design D1/D2)`, () => {
+    let made: MadeBackend;
+    let modes: Mode[];
+    beforeAll(async () => {
+      made = await backend.make();
+      await made.store.ensureSchema();
+      modes = modesFor(made);
+    });
+    afterAll(async () => { if (made) await made.cleanup(); });
+
+    describe.each([{ mode: "sql" }, { mode: "memory-ops" }, { mode: "local-ops" }])("$mode", ({ mode }) => {
+      const pick = (): Mode => modes.find((candidate) => candidate.name === mode)!;
+      const id = (suffix: string): string => `thr_${mode.replace("-", "_")}_${suffix}`;
+
+      it("reads back every message it wrote, oldest → newest", async () => {
+        const { store, own } = pick();
+        const thread = id("order");
+        await own(thread, alice.subject);
+        const messages = threadMessageStore<UIMessage>(store);
+        await messages.upsert(alice, thread, message("m_a", "first"), 0);
+        await messages.upsert(alice, thread, message("m_b", "second"), 1);
+        await messages.upsert(alice, thread, message("m_c", "third"), 2);
+
+        // A FRESH helper: nothing is cached in the handle, the rows are the truth.
+        const listed = await threadMessageStore<UIMessage>(store).list(alice, thread);
+        expect(listed.map((m) => m.id)).toEqual(["m_a", "m_b", "m_c"]);
+      });
+
+      it("scopes to the principal: one subject never reads another's thread messages", async () => {
+        const { store, own } = pick();
+        const thread = id("scoped");
+        await own(thread, alice.subject);
+        const messages = threadMessageStore<UIMessage>(store);
+        await messages.upsert(alice, thread, message("m_secret", "alice only"), 0);
+
+        await expect(messages.list(bob, thread)).resolves.toEqual([]);
+      });
+
+      it("a thread nobody created reads as empty rather than throwing", async () => {
+        const messages = threadMessageStore<UIMessage>(pick().store);
+        await expect(messages.list(alice, id("absent"))).resolves.toEqual([]);
+      });
+
+      it("refuses a cross-subject write to an existing thread", async () => {
+        const { store, own } = pick();
+        const thread = id("takeover");
+        await own(thread, alice.subject);
+        const messages = threadMessageStore<UIMessage>(store);
+        await messages.upsert(alice, thread, message("m_1", "mine"), 0);
+
+        await expect(messages.upsert(bob, thread, message("m_2", "yours"), 1)).rejects.toBeInstanceOf(VendoError);
+        await expect(messages.list(alice, thread)).resolves.toHaveLength(1);
+      });
+
+      it("refuses a write to a thread that does not exist", async () => {
+        const messages = threadMessageStore<UIMessage>(pick().store);
+        await expect(messages.upsert(alice, id("orphan"), message("m_1", "nowhere"), 0))
+          .rejects.toBeInstanceOf(VendoError);
+      });
+
+      it("refuses a message with no id — it is the row's key", async () => {
+        const { store, own } = pick();
+        const thread = id("noid");
+        await own(thread, alice.subject);
+        const messages = threadMessageStore<UIMessage>(store);
+        await expect(messages.upsert(alice, thread, { id: "" } as UIMessage, 0))
+          .rejects.toBeInstanceOf(VendoError);
+      });
+    });
+
+    /**
+     * The approval flip: the runtime re-writes an ALREADY PERSISTED message
+     * under its own id, and the transcript must hold one copy of it, not two.
+     * Over the wire that is `transcripts.putMessage` doing an edit-by-id.
+     *
+     * `memory-ops` is excluded because core's reference `putMessage` appends
+     * unconditionally — the wire's conformance suite only asserts append, so the
+     * reference has no id semantics to edit by. The LIVE console shares that gap
+     * (measured: `packages/vendo/src/hosted-transcript.live.test.ts` records it
+     * with an `it.fails`), which is why the two backends that DO carry id
+     * semantics are the ones checked here: they are what the wire contract has
+     * to grow into, not a lower bar this helper settled for.
+     */
+    describe.each([{ mode: "sql" }, { mode: "local-ops" }])("$mode approval flip", ({ mode }) => {
+      it("edits a message in place instead of appending a second copy", async () => {
+        const target = modes.find((candidate) => candidate.name === mode)!;
+        const thread = `thr_${mode.replace("-", "_")}_flip`;
+        await target.own(thread, alice.subject);
+        const messages = threadMessageStore<UIMessage>(target.store);
+        await messages.upsert(alice, thread, message("m_1", "before", "assistant"), 0);
+        await messages.upsert(alice, thread, message("m_2", "after it", "user"), 1);
+        await messages.upsert(alice, thread, message("m_1", "approved", "assistant"), 0);
+
+        const listed = await messages.list(alice, thread);
+        expect(listed.map((m) => m.id)).toEqual(["m_1", "m_2"]);
+        expect(JSON.stringify(listed[0])).toContain("approved");
+      });
+    });
+
+    /** SQL's per-row CAS has no wire expression: `transcripts.putMessage`
+     *  carries no revision. Loud beats a silent downgrade to last-write-wins. */
+    describe.each([{ mode: "memory-ops" }, { mode: "local-ops" }])("$mode", ({ mode }) => {
+      it("refuses a guarded (expectedRevision) edit rather than quietly clobbering", async () => {
+        const target = modes.find((candidate) => candidate.name === mode)!;
+        const thread = `thr_${mode.replace("-", "_")}_cas`;
+        await target.own(thread, alice.subject);
+        const messages = threadMessageStore<UIMessage>(target.store);
+        await messages.upsert(alice, thread, message("m_1", "one"), 0);
+
+        await expect(
+          messages.upsert(alice, thread, message("m_1", "two"), 0, { expectedRevision: 1 }),
+        ).rejects.toMatchObject({ code: "not-implemented" });
+      });
+    });
+  });
+}
+
+describe("a store with neither a SQL handle nor a StoreOps surface", () => {
+  it("is refused by name, at construction", () => {
+    const bare = { ...opsOnlyStore(memoryStoreOps()), ops: undefined };
+    expect(() => threadMessageStore(bare)).toThrow(/SQL handle or a StoreOps-capable store/);
+  });
+});

--- a/packages/store/src/workspace-ops-rows.ts
+++ b/packages/store/src/workspace-ops-rows.ts
@@ -68,20 +68,66 @@ export function workspaceJsonToBytes(data: unknown): Uint8Array {
   return encoder.encode(JSON.stringify(data));
 }
 
-/** S3 wires per-path history and undo over the wire's `path` legs. Until it
-    lands, a hosted workspace says so instead of pretending there is nothing to
-    restore — a silent `{status:"empty"}` would read as "no history" forever. */
+/** Promote's workspace half is one transaction with the app-row flip, so a
+    hosted store runs the whole move server-side (`lifecycle.promote`) and never
+    reaches this backend — but a silent no-op would strand an app's documents. */
 const notWiredYet = (verb: string): never => {
   throw new VendoError(
     "not-implemented",
-    `a hosted workspace cannot ${verb} yet: per-path history rides the store wire's path legs`,
+    `a hosted workspace cannot ${verb}: that move runs server-side, through lifecycle.promote`,
   );
+};
+
+/** One commit from the wire's path-scoped history. `revision` is the revision
+    the path held BEFORE that commit — absent when the commit created it, which
+    is a version boundary with nothing behind it (the SQL backend has no history
+    row for a create either, which is why both answer `empty` there). */
+interface PathCommit {
+  commitId: string;
+  revision?: number;
+  at: string;
+}
+
+const pathCommitOf = (entry: unknown): PathCommit | undefined => {
+  const row = entry as Record<string, unknown> | null;
+  if (typeof row?.["commitId"] !== "string") return undefined;
+  const revision = row["revision"];
+  return {
+    commitId: row["commitId"],
+    ...(typeof revision === "number" ? { revision } : {}),
+    at: iso(row["at"] ?? new Date(0).toISOString()),
+  };
 };
 
 export function workspaceOpsRows(ops: StoreOps): WorkspaceRows {
   const readOne = async (owner: string, path: string): Promise<unknown | undefined> => {
     const files = await ops.workspace.read([path], { owner });
     return path in files ? files[path] : undefined;
+  };
+
+  /** The commits that touched one path, newest first. `stopAfter` short-circuits
+      the walk for undo, which only ever needs the newest one. */
+  const pathCommits = async (
+    owner: string,
+    path: string,
+    stopAfter?: number,
+  ): Promise<PathCommit[]> => {
+    const commits: PathCommit[] = [];
+    let cursor: string | undefined;
+    do {
+      const page = await ops.workspace.history({
+        owner,
+        path,
+        ...(cursor === undefined ? {} : { cursor }),
+      });
+      for (const entry of page.entries) {
+        const commit = pathCommitOf(entry);
+        if (commit !== undefined) commits.push(commit);
+      }
+      if (stopAfter !== undefined && commits.length >= stopAfter) return commits;
+      cursor = page.cursor;
+    } while (cursor !== undefined);
+    return commits;
   };
 
   return {
@@ -176,17 +222,33 @@ export function workspaceOpsRows(ops: StoreOps): WorkspaceRows {
     },
 
     async moveApp() {
-      // Promote's workspace half is one transaction with the app-row flip, so a
-      // hosted store runs the whole move server-side (`lifecycle.promote`).
       return notWiredYet("move an app between mounts");
     },
 
-    async history(): Promise<WorkspaceHistoryEntry[]> {
-      return notWiredYet("list a path's history");
+    async history(owner, path): Promise<WorkspaceHistoryEntry[]> {
+      const entries: WorkspaceHistoryEntry[] = [];
+      for (const commit of await pathCommits(owner, path)) {
+        // A commit that created the path is not a version you can go back TO,
+        // so it is not one of the path's superseded revisions.
+        if (commit.revision === undefined) continue;
+        // The wire carries no commit message, so the label is the commit id —
+        // which is exactly what the ops backend stamps its writes with.
+        entries.push({ revision: commit.revision, intent: commit.commitId, at: commit.at });
+      }
+      return entries;
     },
 
-    async undo(): Promise<UndoOutcome> {
-      return notWiredYet("undo a path");
+    async undo(owner, path): Promise<UndoOutcome> {
+      const newest = (await pathCommits(owner, path, 1))[0];
+      // Nothing has touched the path, or the only thing that did created it:
+      // either way there is no older version to walk back to.
+      if (newest?.revision === undefined) return { status: "empty" };
+      const { revision } = await ops.workspace.undo({ path }, { owner });
+      // The restore landed but the wire did not name the revision it wrote,
+      // which is the ops backend's answer when the content behind that
+      // revision could not be read back. Naming it beats claiming an `ok`.
+      if (revision === undefined) return { status: "content-missing", revisions: [newest.revision] };
+      return { status: "ok", revision };
     },
   };
 }

--- a/packages/store/src/workspace-ops-rows.ts
+++ b/packages/store/src/workspace-ops-rows.ts
@@ -1,0 +1,192 @@
+import { VendoError, type StoreOps } from "@vendoai/core";
+import { iso } from "./helpers/utils.js";
+import type {
+  UndoOutcome,
+  WorkspaceFileMeta,
+  WorkspaceHistoryEntry,
+  WorkspaceRows,
+} from "./workspace-rows.js";
+
+/**
+ * The workspace pair over the 32-op contract instead of this store's own
+ * Postgres — what makes a hosted store (a key, no database) serve the same
+ * `WorkspaceStoreFs` a local one does, byte for byte. The façade above
+ * (workspace.ts) is unchanged, and so are its permission checks: `can()` reads
+ * through the records door, which the hosted store already serves.
+ *
+ * Two shapes differ from the SQL backend and both are deliberate:
+ *   - **Content is JSON on the wire**, so text files ride as a JSON string and
+ *     anything that is not valid UTF-8 rides the {@link WORKSPACE_BYTES_KEY}
+ *     base64 envelope. Encoding a PNG as a lossy string was the alternative.
+ *   - **Revisions come from the caller.** The wire's commit answers `ok`, not a
+ *     new revision, so `land` reports the checked-out revision plus one — which
+ *     is exactly what the server assigns, and where it is not (a racing writer
+ *     on a `/user` mount) the next turn's index reads the truth. Strict mounts
+ *     never guess: their commit carries `expectedRevision`, and a lost swap
+ *     comes back `conflict`.
+ */
+
+/** The binary envelope: a workspace file whose bytes are not text travels as
+    `{"$vendoWorkspaceBytes": "<base64>"}`. A plain JSON string is text. */
+export const WORKSPACE_BYTES_KEY = "$vendoWorkspaceBytes";
+
+const utf8 = new TextDecoder("utf-8", { fatal: true });
+const encoder = new TextEncoder();
+
+const bytesToBase64 = (bytes: Uint8Array): string => {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+};
+
+const base64ToBytes = (value: string): Uint8Array =>
+  Uint8Array.from(atob(value), (char) => char.charCodeAt(0));
+
+const sameBytes = (left: Uint8Array, right: Uint8Array): boolean =>
+  left.byteLength === right.byteLength && left.every((byte, index) => byte === right[index]);
+
+/** Bytes → the JSON the wire carries: the string itself when the content is
+    text, the base64 envelope when it is not. */
+export function workspaceBytesToJson(bytes: Uint8Array): unknown {
+  try {
+    const text = utf8.decode(bytes);
+    if (!text.includes("\u0000")) return text;
+  } catch {
+    // not UTF-8 — fall through to the envelope
+  }
+  return { [WORKSPACE_BYTES_KEY]: bytesToBase64(bytes) };
+}
+
+/** The wire's JSON → bytes. A value that is neither a string nor an envelope
+    was written by something other than a workspace filesystem (a direct
+    `ops.workspace.commit` of a JSON document), and reads as its JSON text —
+    exactly the bytes the SQL backend stores for the same commit. */
+export function workspaceJsonToBytes(data: unknown): Uint8Array {
+  if (typeof data === "string") return encoder.encode(data);
+  const envelope = (data as Record<string, unknown> | null)?.[WORKSPACE_BYTES_KEY];
+  if (typeof envelope === "string") return base64ToBytes(envelope);
+  return encoder.encode(JSON.stringify(data));
+}
+
+/** S3 wires per-path history and undo over the wire's `path` legs. Until it
+    lands, a hosted workspace says so instead of pretending there is nothing to
+    restore — a silent `{status:"empty"}` would read as "no history" forever. */
+const notWiredYet = (verb: string): never => {
+  throw new VendoError(
+    "not-implemented",
+    `a hosted workspace cannot ${verb} yet: per-path history rides the store wire's path legs`,
+  );
+};
+
+export function workspaceOpsRows(ops: StoreOps): WorkspaceRows {
+  const readOne = async (owner: string, path: string): Promise<unknown | undefined> => {
+    const files = await ops.workspace.read([path], { owner });
+    return path in files ? files[path] : undefined;
+  };
+
+  return {
+    async index(owners) {
+      const metas: WorkspaceFileMeta[] = [];
+      for (const owner of owners) {
+        let cursor: string | undefined;
+        do {
+          const page = await ops.workspace.index({
+            owner,
+            ...(cursor === undefined ? {} : { cursor }),
+          });
+          for (const entry of page.entries) {
+            const row = entry as Record<string, unknown>;
+            if (typeof row["path"] !== "string") continue;
+            metas.push({
+              path: row["path"],
+              owner,
+              bytes: Number(row["bytes"] ?? 0),
+              revision: Number(row["revision"] ?? 0),
+              updatedAt: iso(row["updatedAt"] ?? new Date(0).toISOString()),
+            });
+          }
+          cursor = page.cursor;
+        } while (cursor !== undefined);
+      }
+      return metas.sort((left, right) => (left.path < right.path ? -1 : 1));
+    },
+
+    async read(owner, path) {
+      const data = await readOne(owner, path);
+      return data === undefined ? undefined : workspaceJsonToBytes(data);
+    },
+
+    async prepare(owner, path, bytes) {
+      const current = await readOne(owner, path);
+      if (current !== undefined && sameBytes(workspaceJsonToBytes(current), bytes)) {
+        return "unchanged";
+      }
+      // Nothing is placed remotely until `land` commits: the wire has no
+      // staging area, so there is no blob to orphan and `discard` is free.
+      return {
+        path,
+        content: bytes,
+        bytes: bytes.byteLength,
+        // The server assigns the real revision; `land` reports it from the
+        // revision the caller checked out.
+        revision: 0,
+        stored: { content: undefined, blobRef: undefined },
+        prior: undefined,
+      };
+    },
+
+    async land(owner, prepared, _intent, options) {
+      // The commit message has no field on the wire; it is a history label, and
+      // history is S3's leg.
+      const strict = options?.strict === true && typeof options.expectedRevision === "number";
+      const checkedOut = typeof options?.expectedRevision === "number" ? options.expectedRevision : 0;
+      try {
+        await ops.workspace.commit(
+          [{
+            path: prepared.path,
+            data: workspaceBytesToJson(prepared.content),
+            ...(strict ? { expectedRevision: options!.expectedRevision } : {}),
+          }],
+          { owner },
+        );
+      } catch (error) {
+        // §9.7 — a strict mount's lost swap is the frozen conflict branch, not
+        // a failure: the façade re-reads the new head and re-applies.
+        if (strict && error instanceof VendoError && error.code === "conflict") {
+          return {
+            landed: false,
+            revision: checkedOut,
+            updatedAt: new Date().toISOString(),
+            conflict: true,
+          };
+        }
+        throw error;
+      }
+      return { landed: true, revision: checkedOut + 1, updatedAt: new Date().toISOString() };
+    },
+
+    async discard() {
+      // Nothing was staged remotely, so there is nothing to release.
+    },
+
+    async remove(owner, path, _intent) {
+      if ((await readOne(owner, path)) === undefined) return false;
+      await ops.workspace.commit([{ path, delete: true }], { owner });
+      return true;
+    },
+
+    async moveApp() {
+      // Promote's workspace half is one transaction with the app-row flip, so a
+      // hosted store runs the whole move server-side (`lifecycle.promote`).
+      return notWiredYet("move an app between mounts");
+    },
+
+    async history(): Promise<WorkspaceHistoryEntry[]> {
+      return notWiredYet("list a path's history");
+    },
+
+    async undo(): Promise<UndoOutcome> {
+      return notWiredYet("undo a path");
+    },
+  };
+}

--- a/packages/store/src/workspace-ops.test.ts
+++ b/packages/store/src/workspace-ops.test.ts
@@ -1,0 +1,142 @@
+import type { Membership, Principal } from "@vendoai/core";
+import { VendoError } from "@vendoai/core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { backends, type MadeBackend } from "./backends.test-util.js";
+import { createStoreOps } from "./ops.js";
+import type { VendoStore as StoreHandle } from "./store.js";
+import { workspaceStore } from "./workspace.js";
+
+/**
+ * T1/D3 — the workspace façade over the 32-op contract instead of a SQL handle.
+ *
+ * The seam is real on both sides: the PRODUCER is `WorkspaceStoreFs` driving
+ * `workspaceOpsRows`, and the CONSUMER is `createStoreOps` writing this store's
+ * own Postgres. Neither half is stubbed, so a disagreement between them shows
+ * up here — and the SQL-backed façade reads the same rows back, which is the
+ * parity claim ("hosted is indistinguishable from local") stated as a test.
+ */
+
+const dana: Principal = { kind: "user", subject: "dana" };
+const kim: Principal = { kind: "user", subject: "kim" };
+const acme: Membership[] = [{ org: "acme" }];
+
+/** A store handle with NO local database and the 32 ops instead — exactly the
+    shape a hosted store presents. The record/blob doors still delegate to the
+    real store, because that is what the hosted store's own doors do. */
+const opsBacked = (store: StoreHandle): StoreHandle => ({
+  records: (collection) => store.records(collection),
+  blobs: (namespace) => store.blobs(namespace),
+  ensureSchema: () => store.ensureSchema(),
+  async close() { /* the ops handle owns no local resource */ },
+  raw() { throw new Error("a hosted store has no local database handle"); },
+  ops: createStoreOps(store),
+});
+
+for (const backend of backends()) {
+  describe(`${backend.name} the workspace over StoreOps`, () => {
+    let made: MadeBackend;
+
+    beforeAll(async () => {
+      made = await backend.make();
+      await made.store.ensureSchema();
+    });
+    afterAll(async () => { if (made) await made.cleanup(); });
+
+    /** The façade a hosted deployment gets. */
+    const hosted = () => workspaceStore(opsBacked(made.store));
+
+    it("commits through the ops backend into the ordinary workspace rows", async () => {
+      const path = "/user/notes/plan.md";
+      const first = await hosted().open(dana);
+      await first.writeFile(path, "the plan");
+      expect(await first.commit({ message: "planned" })).toEqual({ status: "ok", changed: [path] });
+
+      // Next turn — a different façade instance — reads it back byte for byte.
+      expect(await (await hosted().open(dana)).readFile(path)).toBe("the plan");
+      // The row is the ordinary workspace row, under the writer as its owner.
+      // Its content is the file's JSON, because the contract carries JSON
+      // documents (a text file is a JSON string, binary is the base64
+      // envelope) — the round trip that matters is façade → ops → row →
+      // façade, and it is exact.
+      expect(await made.sql(
+        "SELECT owner, content FROM vendo_workspace_files WHERE path = $1",
+        [path],
+      )).toEqual([{ owner: "dana", content: '"the plan"' }]);
+    });
+
+    it("keeps two owners' drawers apart at the same path", async () => {
+      const path = "/user/shared.md";
+      const mine = await hosted().open(dana);
+      await mine.writeFile(path, "dana's");
+      await mine.commit();
+      const theirs = await hosted().open(kim);
+      await theirs.writeFile(path, "kim's");
+      await theirs.commit();
+
+      expect(await (await hosted().open(dana)).readFile(path)).toBe("dana's");
+      expect(await (await hosted().open(kim)).readFile(path)).toBe("kim's");
+      const sam = await hosted().open({ kind: "user", subject: "sam" });
+      expect(await sam.exists(path)).toBe(false);
+    });
+
+    it("carries bytes that are not text through the base64 envelope", async () => {
+      const path = "/user/uploads/pixel.png";
+      // A PNG header: valid bytes, invalid UTF-8, with a NUL in it.
+      const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0xff]);
+      const fs = await hosted().open(dana);
+      await fs.writeFile(path, bytes);
+      await fs.commit();
+
+      const next = await hosted().open(dana);
+      expect([...(await next.readFileBuffer(path))]).toEqual([...bytes]);
+      expect((await next.stat(path)).size).toBeGreaterThan(0);
+    });
+
+    it("removes a file with a tombstone, and the next turn does not see it", async () => {
+      const path = "/user/temp.md";
+      const seed = await hosted().open(dana);
+      await seed.writeFile(path, "temporary");
+      await seed.commit();
+
+      const cleaner = await hosted().open(dana);
+      await cleaner.rm(path);
+      expect(await cleaner.commit()).toEqual({ status: "ok", changed: [path] });
+
+      const next = await hosted().open(dana);
+      expect(await next.exists(path)).toBe(false);
+      expect(await made.sql("SELECT path FROM vendo_workspace_files WHERE path = $1", [path])).toEqual([]);
+    });
+
+    it("answers an /orgs commit that lost its base with the conflict branch", async () => {
+      const path = "/orgs/acme/files/roadmap.md";
+      const seed = await hosted().open(dana, { memberships: acme });
+      await seed.writeFile(path, "v1");
+      await seed.commit();
+
+      // Two turns open on the same revision; the second commits against a base
+      // that has moved.
+      const stale = await hosted().open(dana, { memberships: acme });
+      const fresh = await hosted().open(kim, { memberships: acme });
+      await fresh.writeFile(path, "v2 from kim");
+      expect(await fresh.commit()).toEqual({ status: "ok", changed: [path] });
+
+      await stale.writeFile(path, "v2 from dana");
+      expect(await stale.commit()).toEqual({ status: "conflict", paths: [path] });
+      // The colleague's edit stands.
+      expect(await (await hosted().open(dana, { memberships: acme })).readFile(path)).toBe("v2 from kim");
+    });
+
+    it("says per-path history and undo are not wired yet instead of answering empty", async () => {
+      const path = "/user/history.md";
+      const fs = await hosted().open(dana);
+      await fs.writeFile(path, "v1");
+      await fs.commit();
+
+      const workspace = hosted();
+      const caller = { principal: dana };
+      await expect(workspace.history(caller, path)).rejects.toThrow(VendoError);
+      await expect(workspace.history(caller, path)).rejects.toThrow(/not wired|per-path history/);
+      await expect(workspace.undo(caller, path)).rejects.toThrow(/per-path history/);
+    });
+  });
+}

--- a/packages/store/src/workspace-ops.test.ts
+++ b/packages/store/src/workspace-ops.test.ts
@@ -44,6 +44,9 @@ for (const backend of backends()) {
 
     /** The façade a hosted deployment gets. */
     const hosted = () => workspaceStore(opsBacked(made.store));
+    /** The SAME façade over the SAME rows with a database handle instead of
+        the 32 ops — the local answer every hosted answer is compared against. */
+    const local = () => workspaceStore(made.store);
 
     it("commits through the ops backend into the ordinary workspace rows", async () => {
       const path = "/user/notes/plan.md";
@@ -126,17 +129,109 @@ for (const backend of backends()) {
       expect(await (await hosted().open(dana, { memberships: acme })).readFile(path)).toBe("v2 from kim");
     });
 
-    it("says per-path history and undo are not wired yet instead of answering empty", async () => {
-      const path = "/user/history.md";
-      const fs = await hosted().open(dana);
-      await fs.writeFile(path, "v1");
-      await fs.commit();
-
-      const workspace = hosted();
+    /** S3 — the path legs. The claim is not "undo works over the wire" but
+        "the hosted façade answers what the SQL façade answers", so every
+        assertion here is checked against `local()`, the same façade over the
+        same rows with a database handle instead of the 32 ops. */
+    it("walks one path back through its versions, exactly as the SQL façade does", async () => {
+      const path = "/user/notes/history.md";
+      for (const content of ["v1", "v2", "v3"]) {
+        const fs = await hosted().open(dana);
+        await fs.writeFile(path, content);
+        await fs.commit({ message: `wrote ${content}` });
+      }
       const caller = { principal: dana };
-      await expect(workspace.history(caller, path)).rejects.toThrow(VendoError);
-      await expect(workspace.history(caller, path)).rejects.toThrow(/not wired|per-path history/);
-      await expect(workspace.undo(caller, path)).rejects.toThrow(/per-path history/);
+
+      // Two superseded versions behind the head, newest first — the same count
+      // and order the SQL façade reports for the same three commits.
+      const versions = await hosted().history(caller, path);
+      expect(versions).toHaveLength(2);
+      expect(versions.map((entry) => entry.revision)).toEqual([2, 1]);
+      expect(await local().history(caller, path)).toHaveLength(2);
+
+      expect(await hosted().undo(caller, path)).toMatchObject({ status: "ok" });
+      expect(await (await hosted().open(dana)).readFile(path)).toBe("v2");
+      expect(await hosted().undo(caller, path)).toMatchObject({ status: "ok" });
+      expect(await (await hosted().open(dana)).readFile(path)).toBe("v1");
+
+      // One step past the oldest version there is nothing left to restore, and
+      // the file keeps what the last undo put there.
+      expect(await hosted().undo(caller, path)).toEqual({ status: "empty" });
+      expect(await (await hosted().open(dana)).readFile(path)).toBe("v1");
+      expect(await hosted().history(caller, path)).toEqual([]);
+    });
+
+    it("undoes one path without disturbing the others in the same commit", async () => {
+      const [kept, undone] = ["/user/pair/kept.md", "/user/pair/undone.md"];
+      for (const version of ["v1", "v2"]) {
+        const fs = await hosted().open(dana);
+        await fs.writeFile(kept, `${kept} ${version}`);
+        await fs.writeFile(undone, `${undone} ${version}`);
+        await fs.commit();
+      }
+
+      expect(await hosted().undo({ principal: dana }, undone)).toMatchObject({ status: "ok" });
+      const next = await hosted().open(dana);
+      expect(await next.readFile(undone)).toBe(`${undone} v1`);
+      expect(await next.readFile(kept)).toBe(`${kept} v2`);
+    });
+
+    /** A file with one version has nothing behind it — the SQL backend records
+        no history row for a create, so both façades say `empty` and the file
+        stays. (The commit-ledger level below the façade DOES remove it: that is
+        `ops.workspace.undo({ path })`, and the conformance suite pins it.) */
+    it("answers empty for a file that has only ever been created", async () => {
+      const path = "/user/fresh.md";
+      const fs = await hosted().open(dana);
+      await fs.writeFile(path, "only version");
+      await fs.commit();
+      const caller = { principal: dana };
+
+      expect(await hosted().history(caller, path)).toEqual(await local().history(caller, path));
+      expect(await hosted().undo(caller, path)).toEqual({ status: "empty" });
+      expect(await local().undo(caller, path)).toEqual({ status: "empty" });
+      expect(await (await hosted().open(dana)).readFile(path)).toBe("only version");
+    });
+
+    it("brings back a file the agent deleted", async () => {
+      const path = "/user/deleted.md";
+      const seed = await hosted().open(dana);
+      await seed.writeFile(path, "still needed");
+      await seed.commit();
+      const cleaner = await hosted().open(dana);
+      await cleaner.rm(path);
+      await cleaner.commit();
+
+      expect(await hosted().undo({ principal: dana }, path)).toMatchObject({ status: "ok" });
+      expect(await (await hosted().open(dana)).readFile(path)).toBe("still needed");
+    });
+
+    it("keeps one owner's path history and undo out of another's", async () => {
+      const path = "/user/private.md";
+      for (const [who, text] of [[dana, "dana"], [kim, "kim"]] as const) {
+        for (const version of ["v1", "v2"]) {
+          const fs = await hosted().open(who);
+          await fs.writeFile(path, `${text} ${version}`);
+          await fs.commit();
+        }
+      }
+
+      expect(await hosted().history({ principal: dana }, path)).toHaveLength(1);
+      expect(await hosted().undo({ principal: dana }, path)).toMatchObject({ status: "ok" });
+      expect(await (await hosted().open(dana)).readFile(path)).toBe("dana v1");
+      // The other drawer did not move.
+      expect(await (await hosted().open(kim)).readFile(path)).toBe("kim v2");
+
+      // And a stranger's undo of the same path finds nothing of theirs to undo.
+      const sam = { kind: "user", subject: "sam" } as const;
+      expect(await hosted().undo({ principal: sam }, path)).toEqual({ status: "empty" });
+      expect(await (await hosted().open(dana)).readFile(path)).toBe("dana v1");
+    });
+
+    it("still refuses to move an app between mounts — that runs server-side", async () => {
+      await expect(
+        hosted().moveApp("app_1", { kind: "user", subject: "dana" }, { kind: "org", org: "acme" }),
+      ).rejects.toThrow(VendoError);
     });
   });
 }

--- a/packages/store/src/workspace.ts
+++ b/packages/store/src/workspace.ts
@@ -1,7 +1,9 @@
 import { VendoError, type FilesAdapter, type Membership, type Principal, type RunContext, type WorkspaceFs } from "@vendoai/core";
 import { storeFiles } from "./files-store.js";
 import { appAccess, orgOfPath } from "./helpers/app-access.js";
-import { dbFor, type VendoStore } from "./store.js";
+import { backendOf } from "./helpers/backend.js";
+import type { VendoStore } from "./store.js";
+import { workspaceOpsRows } from "./workspace-ops-rows.js";
 import { HOST_MOUNT, normalizePath, pathForbidden, pathNotFound, WorkspaceStoreFs } from "./workspace-fs.js";
 import { workspaceRows, type AppMount, type UndoOutcome, type WorkspaceHistoryEntry } from "./workspace-rows.js";
 
@@ -75,7 +77,17 @@ export function workspaceStore(store: VendoStore, options: { files?: FilesAdapte
       here even though the reads it already served stand. */
   canCommit(caller: WorkspaceCaller, path: string): Promise<boolean>;
 } {
-  const rows = workspaceRows(dbFor(store), options.files ?? storeFiles(store));
+  // T1/D1 — the branch is INSIDE the helper: a store with its own Postgres
+  // keeps today's row helpers, a store with only the 32-op contract (the hosted
+  // one: a key, no database) rides the same façade over the wire. Nothing above
+  // this line can tell the two apart, which is what lets a hosted deployment
+  // serve harness turns with zero caller changes. The permission checks below
+  // are untouched — `can()` reads through the records door, which the hosted
+  // store already serves.
+  const backend = backendOf(store, "the workspace");
+  const rows = backend.kind === "sql"
+    ? workspaceRows(backend.db, options.files ?? storeFiles(store))
+    : workspaceOpsRows(backend.ops);
   const access = appAccess(store);
 
   /** The ctx `can()` reads: it only ever looks at the subject and the asserted

--- a/packages/vendo/src/harness-turn.ts
+++ b/packages/vendo/src/harness-turn.ts
@@ -169,13 +169,12 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
   const threads = new ThreadRepository(config.store);
   // LAZY, and the laziness is load-bearing twice over.
   //
-  // `threadMessageStore` and `workspaceStore` both resolve a SQL handle
-  // (`dbFor`) as their first act. Building them at compose would (a) do work
-  // inside `createVendo`, which the common edge wiring calls at module init where
-  // Workers forbids it, and (b) throw "Unknown VendoStore handle" outright for a
-  // hosted store — which has no local SQL and, in wave 1, no workspace or
-  // transcript door of its own. Deferred, a hosted deployment composes exactly as
-  // before and only a host that actually drives a harness turn meets the gap.
+  // These three helpers pick their backend (`backendOf`) as their first act.
+  // Building them at compose would (a) do work inside `createVendo`, which the
+  // common edge wiring calls at module init where Workers forbids it, and (b)
+  // throw outright for a store that offers neither a SQL handle nor a StoreOps
+  // surface. Deferred, such a deployment composes exactly as before and only a
+  // host that actually drives a harness turn meets the gap.
   let sql: {
     transcript: ReturnType<typeof threadMessageStore<UIMessage>>;
     workspaces: ReturnType<typeof workspaceStore>;
@@ -195,10 +194,10 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
       } catch (cause) {
         throw new VendoError(
           "not-implemented",
-          "Serving a turn through a harness needs a SQL-backed store: the transcript and the workspace "
-          + "(build contract §3.3 / §6) are tables. The configured store has no SQL handle — the Cloud "
-          + "hosted store does not serve the workspace or per-message transcript doors yet. Pass "
-          + "`store: postgres(url)` (or the local default) to use `harness:`.",
+          "Serving a turn through a harness needs somewhere to keep the transcript and the workspace "
+          + "(build contract §3.3 / §6): it needs a SQL-backed store (`store: postgres(url)`, or the "
+          + "local default) or a StoreOps-capable store (the Cloud hosted store). The configured store "
+          + "is neither.",
           { cause },
         );
       }

--- a/packages/vendo/src/hosted-store.test.ts
+++ b/packages/vendo/src/hosted-store.test.ts
@@ -907,6 +907,21 @@ describe("hostedStoreOps — the 32-op wire client", () => {
     expect(calls[4]!.body).toEqual({ commitId: "wsc_1" });
   });
 
+  it("workspace: the path legs of history and undo ride the same two doors", async () => {
+    const { calls, ops } = wireFake({
+      ...ALL_BODIES,
+      [door("workspace.undo")]: { ok: true, revision: 7 },
+    });
+
+    await ops.workspace.history({ path: "/a.md", owner: "own_1" });
+    expect(calls[0]!.body).toEqual({ path: "/a.md", owner: "own_1" });
+
+    // A path target is a path on the wire, never a commit id — the door takes
+    // exactly one of the two, and reports the revision it restored.
+    expect(await ops.workspace.undo({ path: "/a.md" }, { owner: "own_1" })).toEqual({ revision: 7 });
+    expect(calls[1]!.body).toEqual({ path: "/a.md", owner: "own_1" });
+  });
+
   it("lifecycle: erase/adopt/promote plus the three session doors", async () => {
     const { calls, ops } = wireFake(ALL_BODIES);
 

--- a/packages/vendo/src/hosted-store.ts
+++ b/packages/vendo/src/hosted-store.ts
@@ -694,8 +694,13 @@ export function hostedStoreOps(options: HostedStoreOptions): StoreOps {
       async history(query) {
         return entriesOf(await post("workspace.history", P["workspace.history"], { ...query }));
       },
-      async undo(commitId, opts) {
-        await mutate("workspace.undo", P["workspace.undo"], { commitId, ...owned(opts) });
+      async undo(target, opts) {
+        const answer = await mutate("workspace.undo", P["workspace.undo"], {
+          ...(typeof target === "string" ? { commitId: target } : { path: target.path }),
+          ...owned(opts),
+        });
+        const revision = (answer as { revision?: unknown } | null)?.revision;
+        return typeof revision === "number" ? { revision } : {};
       },
     },
     lifecycle: {

--- a/packages/vendo/src/hosted-store.ts
+++ b/packages/vendo/src/hosted-store.ts
@@ -537,6 +537,11 @@ export function hostedStoreOps(options: HostedStoreOptions): StoreOps {
 
   const cursorQuery = (query?: { cursor?: string; limit?: number }): Record<string, unknown> => ({ ...query });
 
+  /** The workspace family's owner, passed through only when the caller named
+      one — a mount that binds its own owner must not be handed `undefined`. */
+  const owned = (opts?: { owner?: string }): Record<string, unknown> =>
+    opts?.owner === undefined ? {} : { owner: opts.owner };
+
   const P = STORE_WIRE_PATHS;
 
   return {
@@ -659,13 +664,18 @@ export function hostedStoreOps(options: HostedStoreOptions): StoreOps {
         await mutate("harness.clear", P["harness.clear"], { appId, subject });
       },
     },
+    // Every workspace call names its OWNER: the mount serves a whole project,
+    // so without one its users would share a single drawer. Entries carry the
+    // wire's tombstones (`delete: true`) and strict-CAS `expectedRevision`
+    // through verbatim — the service reports a lost swap as an enveloped
+    // `conflict`, which the façade reads as the frozen conflict branch.
     workspace: {
       async index(query) {
-        return entriesOf(await post("workspace.index", P["workspace.index"], cursorQuery(query)));
+        return entriesOf(await post("workspace.index", P["workspace.index"], { ...query }));
       },
-      async read(paths) {
+      async read(paths, opts) {
         return field<Record<string, unknown>>(
-          await post("workspace.read", P["workspace.read"], { paths }),
+          await post("workspace.read", P["workspace.read"], { paths, ...owned(opts) }),
           "files",
           "invalid workspace read",
           (value) => typeof value === "object" && value !== null && !Array.isArray(value),
@@ -674,13 +684,18 @@ export function hostedStoreOps(options: HostedStoreOptions): StoreOps {
       async commit(entries, opts) {
         // The caller may own the key (a resumed job replaying its own commit);
         // otherwise `mutate` mints the one key for this operation.
-        await mutate("workspace.commit", P["workspace.commit"], { entries }, opts?.idempotencyKey);
+        await mutate(
+          "workspace.commit",
+          P["workspace.commit"],
+          { entries, ...owned(opts) },
+          opts?.idempotencyKey,
+        );
       },
       async history(query) {
-        return entriesOf(await post("workspace.history", P["workspace.history"], cursorQuery(query)));
+        return entriesOf(await post("workspace.history", P["workspace.history"], { ...query }));
       },
-      async undo(commitId) {
-        await mutate("workspace.undo", P["workspace.undo"], { commitId });
+      async undo(commitId, opts) {
+        await mutate("workspace.undo", P["workspace.undo"], { commitId, ...owned(opts) });
       },
     },
     lifecycle: {

--- a/packages/vendo/src/hosted-transcript.live.test.ts
+++ b/packages/vendo/src/hosted-transcript.live.test.ts
@@ -1,0 +1,123 @@
+/**
+ * The T1 seam, with no stand-in on either side: the REAL transcript and
+ * harness-state helpers, over a REAL `hostedStore`, against the REAL Vendo Cloud
+ * console — written through one client and read back through a second, freshly
+ * constructed one.
+ *
+ * Why a second client: a harness that mocks the counterparty proves nothing, and
+ * so does one that reads its own process's memory back. The read here goes over
+ * the wire a second time, from a client that has never seen the write, so the
+ * only thing that can make it pass is the console genuinely holding the rows.
+ *
+ * Gated on `VENDO_API_KEY` having content, like every other `.live.test.ts`:
+ * skipped without it, so CI and a keyless clone stay green. `VENDO_CLOUD_URL`
+ * overrides the mount for a staging console. Everything written is deleted at
+ * the end, and every id is per-run unique so two runs never collide.
+ */
+import { VendoError, type Principal } from "@vendoai/core";
+import { harnessStateStore, threadMessageStore } from "@vendoai/store";
+import type { UIMessage } from "ai";
+import { afterAll, describe, expect, it } from "vitest";
+import { hostedStore, type HostedStore } from "./hosted-store.js";
+
+// A named secret can EXIST and be empty (`infisical secrets get` exits 0 either
+// way), so the gate checks for content rather than for presence.
+const apiKey = process.env["VENDO_API_KEY"] ?? "";
+const live = apiKey === "" ? describe.skip : describe;
+
+const LIVE_TIMEOUT_MS = 60_000;
+
+/** Every run gets its own thread and its own subjects — the console account is
+ *  Yousef's real one, shared with every other live test. */
+const run = globalThis.crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+const threadId = `thr_live_${run}`;
+const owner: Principal = { kind: "user", subject: `user_live_${run}` };
+const stranger: Principal = { kind: "user", subject: `user_other_${run}` };
+
+const client = (): HostedStore => hostedStore({
+  apiKey,
+  ...(process.env["VENDO_CLOUD_URL"] === undefined ? {} : { baseUrl: process.env["VENDO_CLOUD_URL"] }),
+});
+
+const message = (id: string, text: string, role: "user" | "assistant" = "user"): UIMessage =>
+  ({ id, role, parts: [{ type: "text", text }] }) as UIMessage;
+
+const textOf = (m: UIMessage | undefined): string =>
+  (m?.parts ?? []).map((part) => (part.type === "text" ? part.text : "")).join("");
+
+live("hosted transcript + harness state over the real console", () => {
+  // ONE writer for the whole file; every read builds its own reader.
+  const writer = client();
+
+  afterAll(async () => {
+    await writer.ops.transcripts.deleteThread(threadId).catch(() => undefined);
+  }, LIVE_TIMEOUT_MS);
+
+  it("writes a transcript through the helper and reads it back on a fresh client", async () => {
+    await writer.ops.transcripts.putThread({ id: threadId, subject: owner.subject, messages: [] });
+
+    // The producer: the SHIPPED helper, picking the ops backend off the hosted
+    // store because there is no SQL handle to pick.
+    const producer = threadMessageStore<UIMessage>(writer);
+    await producer.upsert(owner, threadId, message("m_1", "what do I owe?"), 0);
+    await producer.upsert(owner, threadId, message("m_2", "checking now", "assistant"), 1);
+
+    // The consumer: the same shipped helper, over a client constructed after the
+    // write and sharing nothing with the writer but the account.
+    const consumer = threadMessageStore<UIMessage>(client());
+    const listed = await consumer.list(owner, threadId);
+
+    expect(listed.map((m) => m.id)).toEqual(["m_1", "m_2"]);
+    expect(textOf(listed[0])).toBe("what do I owe?");
+    expect(textOf(listed[1])).toBe("checking now");
+  }, LIVE_TIMEOUT_MS);
+
+  /**
+   * KNOWN CONSOLE GAP, recorded as an executable fact rather than a comment:
+   * `it.fails` passes while the console is wrong and turns RED the moment it is
+   * fixed, so nobody has to remember to come back.
+   *
+   * Design D2 reads `transcripts.putMessage` as "insert OR edit-by-id", which is
+   * what the local backend does (`packages/store/src/ops.ts`: append, and on an
+   * id collision UPDATE that row). The live console instead appends into the
+   * thread's message array and re-puts the whole thread, so re-writing a message
+   * under its own id is refused with
+   *   `thread … carries two messages with the id "m_2"; message ids must be
+   *    unique within a thread`.
+   *
+   * That is the approval flip: when an approval resolves, the runtime re-writes
+   * the already persisted assistant message under its own id. Until the console
+   * makes `putMessage` replace-by-id, a hosted deployment fails that write —
+   * loudly, at least, not silently duplicating history. The fix is console-side;
+   * there is no wire op that expresses an edit any other way.
+   */
+  it.fails("an approval flip edits the message in place — one copy, not two", async () => {
+    await threadMessageStore<UIMessage>(writer)
+      .upsert(owner, threadId, message("m_2", "approved: you owe $40", "assistant"), 1);
+
+    const listed = await threadMessageStore<UIMessage>(client()).list(owner, threadId);
+
+    expect(listed.map((m) => m.id)).toEqual(["m_1", "m_2"]);
+    expect(textOf(listed[1])).toBe("approved: you owe $40");
+  }, LIVE_TIMEOUT_MS);
+
+  it("another subject reads the thread as empty and cannot write to it", async () => {
+    const foreign = threadMessageStore<UIMessage>(client());
+
+    await expect(foreign.list(stranger, threadId)).resolves.toEqual([]);
+    await expect(foreign.upsert(stranger, threadId, message("m_x", "mine now"), 2))
+      .rejects.toBeInstanceOf(VendoError);
+    // And the owner's transcript is untouched by the attempt.
+    await expect(threadMessageStore<UIMessage>(client()).list(owner, threadId)).resolves.toHaveLength(2);
+  }, LIVE_TIMEOUT_MS);
+
+  it("keeps a harness's native session across clients, and destroys it on a swap", async () => {
+    await harnessStateStore(writer).set(threadId, "claude-code", `sess_${run}`);
+
+    expect(await harnessStateStore(client()).get(threadId, "claude-code")).toBe(`sess_${run}`);
+    // §1.3: a different thinker holds this conversation now, so the slot is
+    // destroyed rather than shadowed — swapping back must not resurrect it.
+    expect(await harnessStateStore(client()).get(threadId, "vendo")).toBeUndefined();
+    expect(await harnessStateStore(client()).get(threadId, "claude-code")).toBeUndefined();
+  }, LIVE_TIMEOUT_MS);
+});

--- a/packages/vendo/src/hosted-workspace.live.test.ts
+++ b/packages/vendo/src/hosted-workspace.live.test.ts
@@ -1,0 +1,98 @@
+/**
+ * The T1/D3 workspace seam, with no stand-in on either side: the REAL
+ * `workspaceStore` façade over a REAL `hostedStore`, against the REAL Vendo
+ * Cloud console — written through one client and read back through a second,
+ * freshly constructed one, so the only thing that can make it pass is the
+ * console genuinely holding the files.
+ *
+ * What it proves, in order: the façade works at all over the wire; two owners
+ * of the SAME deployment do not see each other's files (the hole the console's
+ * per-request `owner` closes); a delete actually deletes; and erasing one
+ * subject takes their whole drawer with it and leaves the other's.
+ *
+ * Gated on `VENDO_API_KEY` having content, like every other `.live.test.ts`:
+ * skipped without it, so CI and a keyless clone stay green. `VENDO_CLOUD_URL`
+ * overrides the mount for a staging console. Every id is per-run unique so two
+ * runs never collide, and everything written is erased at the end.
+ */
+import type { Principal } from "@vendoai/core";
+import { workspaceStore } from "@vendoai/store";
+import { afterAll, describe, expect, it } from "vitest";
+import { hostedStore, type HostedStore } from "./hosted-store.js";
+
+// A named secret can EXIST and be empty (`infisical secrets get` exits 0 either
+// way), so the gate checks for content rather than for presence.
+const apiKey = process.env["VENDO_API_KEY"] ?? "";
+const live = apiKey === "" ? describe.skip : describe;
+
+const LIVE_TIMEOUT_MS = 60_000;
+
+const run = globalThis.crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+const mine: Principal = { kind: "user", subject: `user_ws_${run}` };
+const theirs: Principal = { kind: "user", subject: `user_ws_other_${run}` };
+const PATH = "/user/notes/plan.md";
+
+const client = (): HostedStore => hostedStore({
+  apiKey,
+  ...(process.env["VENDO_CLOUD_URL"] === undefined ? {} : { baseUrl: process.env["VENDO_CLOUD_URL"] }),
+});
+
+/** The shipped façade, picking the ops backend off the hosted store because
+    there is no SQL handle to pick. */
+const workspace = (store: HostedStore = client()) => workspaceStore(store);
+
+live("hosted workspace over the real console", () => {
+  const writer = client();
+
+  afterAll(async () => {
+    for (const subject of [mine.subject, theirs.subject]) {
+      await writer.ops.lifecycle.erase({ subject }).catch(() => undefined);
+    }
+  }, LIVE_TIMEOUT_MS);
+
+  it("commits a file through the façade and reads it back on a fresh client", async () => {
+    const turn = await workspace(writer).open(mine);
+    await turn.writeFile(PATH, "the plan");
+    expect(await turn.commit({ message: "planned" })).toEqual({ status: "ok", changed: [PATH] });
+
+    // A client constructed after the write, sharing nothing with the writer but
+    // the account.
+    const next = await workspace().open(mine);
+    expect(await next.readFile(PATH)).toBe("the plan");
+    expect(next.getAllPaths()).toContain(PATH);
+  }, LIVE_TIMEOUT_MS);
+
+  it("keeps another user of the same deployment out of that file", async () => {
+    const stranger = await workspace().open(theirs);
+    // Not "forbidden" — absent. The path is not in their drawer at all.
+    expect(await stranger.exists(PATH)).toBe(false);
+
+    // And their own file at the SAME path is their own.
+    await stranger.writeFile(PATH, "someone else's plan");
+    expect(await stranger.commit()).toEqual({ status: "ok", changed: [PATH] });
+    expect(await (await workspace().open(theirs)).readFile(PATH)).toBe("someone else's plan");
+    expect(await (await workspace().open(mine)).readFile(PATH)).toBe("the plan");
+  }, LIVE_TIMEOUT_MS);
+
+  it("removes a file, and a fresh client agrees it is gone", async () => {
+    const doomed = "/user/notes/scratchpad.md";
+    const first = await workspace().open(mine);
+    await first.writeFile(doomed, "temporary");
+    await first.commit();
+    expect(await (await workspace().open(mine)).readFile(doomed)).toBe("temporary");
+
+    const cleaner = await workspace().open(mine);
+    await cleaner.rm(doomed);
+    expect(await cleaner.commit()).toEqual({ status: "ok", changed: [doomed] });
+    expect(await (await workspace().open(mine)).exists(doomed)).toBe(false);
+    // The file that was not deleted is still there.
+    expect(await (await workspace().open(mine)).readFile(PATH)).toBe("the plan");
+  }, LIVE_TIMEOUT_MS);
+
+  it("erases one subject's whole drawer and leaves the other's", async () => {
+    await writer.ops.lifecycle.erase({ subject: mine.subject });
+
+    expect((await workspace().open(mine)).getAllPaths()).toEqual([]);
+    expect(await (await workspace().open(theirs)).readFile(PATH)).toBe("someone else's plan");
+  }, LIVE_TIMEOUT_MS);
+});

--- a/packages/vendo/src/hosted-workspace.live.test.ts
+++ b/packages/vendo/src/hosted-workspace.live.test.ts
@@ -96,3 +96,56 @@ live("hosted workspace over the real console", () => {
     expect(await (await workspace().open(theirs)).readFile(PATH)).toBe("someone else's plan");
   }, LIVE_TIMEOUT_MS);
 });
+
+/**
+ * S3 — the path legs against the same real console. Two levels, because they
+ * answer two different questions:
+ *   - the FAÇADE walks a path back through its versions, and must answer what
+ *     a SQL-backed façade answers (a file with only one version has nothing
+ *     behind it: `empty`, and the file stays);
+ *   - the COMMIT LEDGER underneath is where "undo the newest change to this
+ *     path" removes a file the commit created, which is the wire semantic the
+ *     conformance suite pins and this proves on the real console.
+ */
+const undoer: Principal = { kind: "user", subject: `user_ws_undo_${run}` };
+
+live("hosted per-path undo over the real console", () => {
+  const writer = client();
+
+  afterAll(async () => {
+    await writer.ops.lifecycle.erase({ subject: undoer.subject }).catch(() => undefined);
+  }, LIVE_TIMEOUT_MS);
+
+  it("walks one file back to the version before the last commit", async () => {
+    const path = "/user/notes/versioned.md";
+    for (const content of ["first", "second"]) {
+      const turn = await workspace().open(undoer);
+      await turn.writeFile(path, content);
+      expect(await turn.commit({ message: `wrote ${content}` })).toEqual({ status: "ok", changed: [path] });
+    }
+    expect(await (await workspace().open(undoer)).readFile(path)).toBe("second");
+
+    const caller = { principal: undoer };
+    expect(await workspace().history(caller, path)).toHaveLength(1);
+    expect(await workspace().undo(caller, path)).toMatchObject({ status: "ok" });
+    // A client constructed after the undo, sharing nothing with the writer.
+    expect(await (await workspace().open(undoer)).readFile(path)).toBe("first");
+
+    // Nothing behind the first version — and the file it left stands.
+    expect(await workspace().undo(caller, path)).toEqual({ status: "empty" });
+    expect(await (await workspace().open(undoer)).readFile(path)).toBe("first");
+  }, LIVE_TIMEOUT_MS);
+
+  it("removes a file when the path undo walks back into the commit that created it", async () => {
+    const path = "/user/notes/created-then-undone.md";
+    await writer.ops.workspace.commit(
+      [{ path, data: "only version" }],
+      { owner: undoer.subject },
+    );
+    expect(await writer.ops.workspace.read([path], { owner: undoer.subject }))
+      .toEqual({ [path]: "only version" });
+
+    await client().ops.workspace.undo({ path }, { owner: undoer.subject });
+    expect(await client().ops.workspace.read([path], { owner: undoer.subject })).toEqual({});
+  }, LIVE_TIMEOUT_MS);
+});

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -1133,15 +1133,17 @@ function selectFiles(configured: FilesAdapter | undefined, store: VendoStore): F
 }
 
 /**
- * Can this store serve a harness turn? The transcript (build contract §6) and the
- * workspace (§3.3) are SQL tables; `threadMessageStore` resolves the handle as its
- * first act and throws for a store that has none — the Cloud hosted store, or a
- * host's own non-SQL adapter. Probing is a WeakMap lookup, never I/O, so it is
- * safe where `createVendo` runs at module init (Workers).
+ * Can this store serve a harness turn? The transcript (build contract §6) and
+ * the workspace (§3.3) need a home: a SQL handle, or the store's own 32-op
+ * StoreOps surface, which is what the Cloud hosted store carries.
+ * `threadMessageStore` picks between them (`backendOf`) as its first act and
+ * throws only for a store with neither. Probing stays a WeakMap lookup plus a
+ * property read, never I/O, so it is safe where `createVendo` runs at module
+ * init (Workers).
  *
  * This is the ONE thing that keeps the wave-2 default-route flip honest: a
  * deployment that cannot serve harness turns keeps the shipped `agent.stream`
- * path, which needs neither table, instead of failing every chat turn.
+ * path, which needs neither, instead of failing every chat turn.
  */
 function storeServesHarnessTurns(store: VendoStore): boolean {
   try {
@@ -3311,12 +3313,13 @@ export function createVendo(config: CreateVendoConfig): Vendo {
     // harness improvement shipped to nobody.
     //
     // ONE exception, and it is a capability fact rather than a preference: serving
-    // a turn through a harness needs the transcript and workspace TABLES (build
-    // contract §3.3/§6). A store with no SQL handle — the Cloud hosted store in
-    // wave 1, or a host's own non-SQL adapter — cannot serve them, and flipping
-    // such a deployment would turn every chat turn into a boot-shaped error. Those
-    // stay on `agent.stream`, which needs neither table. The probe is a WeakMap
-    // lookup inside @vendoai/store, not I/O, so it is safe at module init.
+    // a turn through a harness needs somewhere to keep the transcript and the
+    // workspace (build contract §3.3/§6) — a SQL handle, or the store's own
+    // StoreOps surface, which the Cloud hosted store carries. A store with
+    // NEITHER (a host's own bare adapter) cannot serve them, and flipping such a
+    // deployment would turn every chat turn into a boot-shaped error. Those stay
+    // on `agent.stream`, which needs neither. The probe is a WeakMap lookup
+    // inside @vendoai/store, not I/O, so it is safe at module init.
     ...(storeServesHarnessTurns(store) ? { harness: harnessDoor } : {}),
     guard,
     apps,


### PR DESCRIPTION
## Why

Undo over the store wire was all-or-nothing: to get one file back a user had to undo a whole commit and take every other file in it along. S2 shipped the hosted workspace with `history` / `undo` throwing a named not-implemented; this replaces them.

**Stacked on `one-path/s2-workspace-ops`.** Retarget to `main` after S2 lands.

Tandem console half: **runvendo/vendo-web#278** (based on `one-path/workspace-owner` / #276, which has not merged yet).

## The contract (additive, no new op)

- `StoreOps.workspace.history({ path })` — narrows to the commits that touched it, newest first, same keyset cursor. Entries gain `at`; under a path an entry also carries the `revision` the path held **before** the commit. That field is absent when the commit CREATED the path, which is exactly the difference between "there is an older version to go back to" and "there is nothing behind this file".
- `StoreOps.workspace.undo(target)` — `undo("wsc_…")` as before, or `undo({ path })`. Returns `{ revision? }` (the restored file's new revision; absent when the undo removed the file). Existing callers pass a string and ignore the return, so nothing breaks.
- Wire: `workspace.history` gains optional `path`; `workspace.undo` takes exactly one of `commitId` / `path` (both, or neither, is a validation refusal).

## Semantics, at two levels

**Commit ledger (`StoreOps`, both backends, conformance-pinned):** the path leg restores that path's before-image; a path the commit CREATED is removed; only that path is consumed, so a later whole-commit undo steps over it instead of restoring it a second time over whatever has been written since.

**Workspace façade (`WorkspaceFs.undo` / `.history`, hosted):** answers what the SQL façade answers. A file with only one version has nothing behind it — the SQL backend records no history row for a create, so both say `empty` and the file stays. `workspaceOpsRows` reads that off the missing `revision` and does not call the wire.

## Files

- `packages/core/src/store.ts`, `store-wire.ts` — the contract above
- `packages/store/src/ops.ts` — local backend, mirroring the console exactly. The before-revision is not in the ledger; it is the revision each write superseded, which every commit already stamps with its own id as the intent, so the workspace history rows are that index.
- `packages/store/src/workspace-ops-rows.ts` — S2's `notWiredYet` for history/undo replaced with real implementations mapping to `WorkspaceHistoryEntry[]` / `UndoOutcome`
- `packages/core/src/conformance/{store-ops,memory-store-ops}.ts` — 5 new cases + the memory reference
- `packages/vendo/src/hosted-store.ts` — client sends `path`, reads back `revision`

`moveApp` stays not-implemented on the ops backend **by design** (per the structure doc): promote's workspace half is one transaction with the app-row flip, so a hosted store runs the whole move through `lifecycle.promote` — `server.ts` leaves `promoteRows` undefined for hosted stores, so this backend is never reached. A test now pins that refusal.

## Tests

**Conformance (5 new, run against BOTH the memory reference and the local PGlite backend):** path history filter (incl. the created-commit naming no revision) · path undo restores the prior version and leaves the rest of its commit · created-file path undo deletes · consumed-path bookkeeping · two-owner isolation on both legs.

**Parity (`workspace-ops.test.ts`, 6 new):** the hosted façade over the ops backend, cross-checked against the SQL façade over the same rows — version walk (`[2,1]`, both backends agree), one path undone without disturbing its commit-mates, created-file ⇒ `empty` on both, an agent's delete brought back, two-owner isolation, moveApp still refused.

**Client (`hosted-store.test.ts`, 1 new):** the path bodies on the wire.

**Live seam (`hosted-workspace.live.test.ts`, additive describe):** façade version walk + the ledger-level created-file removal.

### The one test I replaced

`workspace-ops.test.ts`'s "says per-path history and undo are not wired yet" was S2's placeholder for exactly this slice — it asserts the behavior this PR removes. It is replaced by the six above, not weakened.

### Proved red first
- Reverting `memory-store-ops.ts` (keeping the cases): 6 fail.
- Reverting `workspace-ops-rows.ts`: all 5 new parity tests fail on the S2 not-implemented; moveApp's still passes.
- Console side, `store-doors.ts` reverted: all 6 new console tests fail.

## Gate

`turbo run test` over core + store + vendo — **zero new failures**. The 7 reds are all pre-existing and environmental: `packaging.e2e` ×3 and the durability/split-brain drills ×2 both die on `Cool%20Code` (the space in this checkout's path breaks child-process module resolution — verified identical with every change stashed), and `dev-creds/model.test.ts` ×2 is the known pair.

typecheck core/store/vendo ✓ · `dependency-guard` ✓ · `portability-gate` ✓

## Live status — honest

**Not proven live yet, and cannot be until the console half deploys.** `console.vendo.run` still runs `main`, which has neither S2's owner field nor S3's path legs, so the whole live describe (S2's four tests included) fails there. The Cloudflare branch preview for vendo-web#278 does not serve the store API at all (405/404 on `/api/v1/store/*`), so it is not a substitute. The test is written and env-gated; run it once #276 + #278 are merged and deployed.

## Known divergence, not chased

A path that is deleted and then re-created: the SQL façade's undo restores the pre-delete content over the new file, while the hosted façade reports `empty` (the newest commit touching the path created it). Both are defensible; making them agree needs the wire to express "undo to the newest superseded version", which is beyond this slice.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds surgical per-path workspace history and undo so users can roll back a single file without undoing an entire commit. Tightens strict commit rules to prevent stale deletes and duplicate path mutations, keeping local and hosted behavior aligned.

- **New Features**
  - `StoreOps.workspace.history({ path })` filters to commits that touched the path, newest first. Entries include `at` and the previous `revision` (absent if the commit created the file).
  - `StoreOps.workspace.undo(target)` accepts a commit id or `{ path }`. Restores the file’s prior content (or removes it if the commit created it) and returns `{ revision? }`. Only that path is consumed from the commit, so later whole-commit undo skips it.
  - Wire: `workspace.history` supports optional `path`; `workspace.undo` requires exactly one of `commitId` or `path` and returns the restored `revision` when available.
  - Local and hosted backends mirror these semantics; owner isolation and keyset cursor behavior are preserved.

- **Bug Fixes**
  - Strict CAS: tombstones now honor `expectedRevision`; a stale delete conflicts instead of erasing unseen content.
  - Strict CAS: same-bytes writes still compare and conflict when stale; no silent fulfill on identical content.
  - Commit validation: a commit that mutates the same path twice is refused to avoid ambiguous undo state.

<sup>Written for commit 69d8db23d0a0cdc198d1855da916a2e457565242. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

