### PR TITLE
feat(core,apps,harnesses): apps remember what they were asked for

### DIFF
--- a/.changeset/apps-remember-what-they-were-asked-for.md
+++ b/.changeset/apps-remember-what-they-were-asked-for.md
@@ -1,0 +1,32 @@
+---
+"@vendoai/core": patch
+"@vendoai/apps": patch
+"@vendoai/harnesses": patch
+"@vendoai/vendo": patch
+---
+
+**Apps remember what they were asked for.** A screen or build run is stateless,
+so the ARTIFACT now carries its own context: `AppDocument` gains an additive
+`memory` of two parts.
+
+- **`asks`** — every `vendo_make` request that touched this app, VERBATIM and in
+  order, the create ask first. Never a paraphrase (a paraphrase drifts the intent
+  it exists to preserve) and never the `<context>`-fenced composite an engine is
+  briefed with: the memory holds what the PERSON said, so one calling agent's
+  background for one call cannot become a standing requirement.
+- **`decisions`** — a short block the agent writes through `save_app`'s new
+  optional `decisions` field: choices made, constraints found, things ruled out.
+  REPLACED on every run that writes one, never appended, because a superseded
+  decision presented as a current one is worse than no memory at all.
+
+Both are read back where the next editor actually reads: the edit brain's brief
+OPENS with the memory, ahead of the document, and the in-box builder's task
+context does the same. Without it an editor meets a deliberately filtered list
+and "fixes" it.
+
+Server-written throughout. `AppsRuntime.remember` is the one door that writes
+memory (`editor`-gated); a model-authored `memory` is stripped from a generated
+document, and an edit pins the stored one. Caps live at that write site rather
+than in the schema — the last 20 asks, 1KB of decisions — so a stored row
+survives a cap that changes. Reasoning traces, transcripts and tool outputs are
+deliberately not stored.

--- a/packages/apps/src/agent-tools.ts
+++ b/packages/apps/src/agent-tools.ts
@@ -342,7 +342,29 @@ export const createAgentTools = (
         const args = input(call.args, ["request"], ["app", "context"]);
         const app = optionalString(args.app, "app");
         const stream = (call as VendoViewStreamingToolCall)[VENDO_VIEW_STREAM];
-        const ask = withContext(args.request as string, optionalString(args.context, "context"));
+        const request = args.request as string;
+        const ask = withContext(request, optionalString(args.context, "context"));
+        /**
+         * The ask, onto the app's memory — the FRONT DOOR's job, because this is
+         * the one place that sees every request that touched an app whichever
+         * engine served it (assembly, the builder, the conductor fall-through,
+         * an edit).
+         *
+         * `request` and not `ask`: the memory holds what the PERSON said. The
+         * `<context>` fence is one calling agent's background for one call, and
+         * replaying it to every future editor as though the person had typed it
+         * is how a stale aside becomes a standing requirement.
+         *
+         * Best-effort, always. There is no arrangement of a lost memory write
+         * that is worse than failing a make the person can already see.
+         */
+        const remember = async (appId: string): Promise<void> => {
+          await runtime.remember({ appId, ask: request }, ctx).catch((error: unknown) => {
+            console.warn(`[vendo] the ask was not recorded on ${appId}: ${
+              error instanceof Error ? error.message : String(error)
+            }`);
+          });
+        };
         if (app === undefined) {
           // ── THE SEAM (blueprint §1 point 2) ─────────────────────────────────
           // "No agent chooses 'quick screen' vs 'real build'. Every request
@@ -379,6 +401,7 @@ export const createAgentTools = (
           if (routed?.kind === "assembled") {
             const stored = await runtime.get(appId, ctx).catch(() => null);
             if (stored !== null) {
+              await remember(appId);
               return receipt({
                 id: stored.id,
                 title: stored.name,
@@ -428,6 +451,9 @@ export const createAgentTools = (
               onView: (part) => stream({ id: vendoViewStreamId(part.appId), part }),
             }),
           }, ctx);
+          // An unsaved create has no row to remember onto; `remember` says so
+          // and moves on, which is the same non-event every other failure is.
+          await remember(created.id);
           // View-only (the store refused the write): the screen IS on the user's
           // page, so this is a success with a caveat, not a failure. Reporting it
           // as an error made the agent apologize for a rendered view and rebuild
@@ -443,7 +469,12 @@ export const createAgentTools = (
               : `${created.name} is on your screen, though I couldn't save it to your apps.`,
           });
         }
-        const result = await runtime.edit(await resolveAppRef(runtime, app, ctx), ask, ctx);
+        const appId = await resolveAppRef(runtime, app, ctx);
+        const result = await runtime.edit(appId, ask, ctx);
+        // Recorded whether or not the change landed: the person DID ask this of
+        // this app, and the next editor reading "asked for X, then asked for X
+        // again, narrower" is reading the truth.
+        await remember(appId);
         // Wave 9 — a ladder-authored automation raises its own card. Published
         // HERE, by the side that knows, rather than duck-typed out of this tool's
         // return value at the bridge: the receipt carries words only.

--- a/packages/apps/src/app-memory.test.ts
+++ b/packages/apps/src/app-memory.test.ts
@@ -1,0 +1,102 @@
+/**
+ * The memory door's caps, through the REAL door and the REAL store.
+ *
+ * The caps live at the write site rather than in the schema so a stored row
+ * survives a cap that changes — which means the only place they can be proved is
+ * a write followed by a read. Nothing here is stubbed: `createApps` over a real
+ * store, `runtime.remember` as the one writer, `runtime.get` as the reader.
+ */
+import type { AppId, RunContext } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { APP_MEMORY_DECISIONS_MAX_BYTES, APP_MEMORY_MAX_ASKS } from "./app-memory.js";
+import { createApps } from "./index.js";
+import { basicLanguageModel, guardFixture, memoryStore } from "./testing/index.js";
+
+const ctx: RunContext = {
+  principal: { kind: "user", subject: "user_memory" },
+  venue: "chat",
+  presence: "present",
+  sessionId: "session_memory",
+};
+
+const runtimeWithApp = async (): Promise<{
+  runtime: ReturnType<typeof createApps>;
+  appId: AppId;
+}> => {
+  const runtime = createApps({
+    store: memoryStore(),
+    guard: guardFixture(),
+    tools: {
+      async descriptors() { return []; },
+      async execute() { return { status: "error", error: { code: "not-found", message: "no tools" } }; },
+    },
+    catalog: [],
+    model: basicLanguageModel(),
+  });
+  const app = await runtime.create({ prompt: "Show my spending" }, ctx);
+  return { runtime, appId: app.id };
+};
+
+describe("the app's memory is capped at the write site", () => {
+  it("keeps the last 20 asks — the 21st drops the first", async () => {
+    const { runtime, appId } = await runtimeWithApp();
+
+    for (let index = 1; index <= APP_MEMORY_MAX_ASKS; index += 1) {
+      await runtime.remember({ appId, ask: `ask ${index}` }, ctx);
+    }
+    const full = await runtime.get(appId, ctx);
+    expect(full?.memory?.asks).toHaveLength(APP_MEMORY_MAX_ASKS);
+    expect(full?.memory?.asks[0]).toBe("ask 1");
+
+    await runtime.remember({ appId, ask: "ask 21" }, ctx);
+
+    const capped = await runtime.get(appId, ctx);
+    expect(capped?.memory?.asks).toHaveLength(APP_MEMORY_MAX_ASKS);
+    // The OLDEST goes, and the order of what is left is untouched.
+    expect(capped?.memory?.asks[0]).toBe("ask 2");
+    expect(capped?.memory?.asks.at(-1)).toBe("ask 21");
+  });
+
+  it("truncates an oversized decisions block, and marks that it truncated", async () => {
+    const { runtime, appId } = await runtimeWithApp();
+    const oversized = "d".repeat(APP_MEMORY_DECISIONS_MAX_BYTES * 3);
+
+    await runtime.remember({ appId, decisions: oversized }, ctx);
+
+    const stored = (await runtime.get(appId, ctx))?.memory?.decisions;
+    expect(stored).toBeDefined();
+    expect(new TextEncoder().encode(stored!).length).toBeLessThanOrEqual(APP_MEMORY_DECISIONS_MAX_BYTES);
+    // A truncation the reader can SEE: a block that just stops is indistinguishable
+    // from one the agent wrote that way.
+    expect(stored!.endsWith("…")).toBe(true);
+  });
+
+  it("a later run's decisions REPLACE the earlier ones; a blank one leaves them alone", async () => {
+    const { runtime, appId } = await runtimeWithApp();
+
+    await runtime.remember({ appId, decisions: "no red — the user said so" }, ctx);
+    await runtime.remember({ appId, ask: "add last month too" }, ctx);
+    expect((await runtime.get(appId, ctx))?.memory?.decisions).toBe("no red — the user said so");
+
+    await runtime.remember({ appId, decisions: "   " }, ctx);
+    expect((await runtime.get(appId, ctx))?.memory?.decisions).toBe("no red — the user said so");
+
+    await runtime.remember({ appId, decisions: "filtered to 2 accounts — the ask was trip-only" }, ctx);
+
+    const stored = (await runtime.get(appId, ctx))?.memory;
+    // REPLACED, not appended: the superseded line is gone, so it cannot be read
+    // as a current constraint.
+    expect(stored?.decisions).toBe("filtered to 2 accounts — the ask was trip-only");
+    expect(stored?.decisions).not.toContain("no red");
+    // …and the asks are untouched by a decisions-only write.
+    expect(stored?.asks).toEqual(["add last month too"]);
+  });
+
+  it("a memory write needs editor access, like every other write to the row", async () => {
+    const { runtime, appId } = await runtimeWithApp();
+    const stranger: RunContext = { ...ctx, principal: { kind: "user", subject: "user_stranger" } };
+
+    await expect(runtime.remember({ appId, ask: "let me in" }, stranger)).rejects.toThrow();
+    expect((await runtime.get(appId, ctx))?.memory).toBeUndefined();
+  });
+});

--- a/packages/apps/src/app-memory.ts
+++ b/packages/apps/src/app-memory.ts
@@ -1,0 +1,83 @@
+/**
+ * The app's memory: the caps that keep it small, and the block every editor
+ * reads before the document itself.
+ *
+ * The type is core's ({@link AppMemory}); the POLICY is here, because a cap is a
+ * write-site decision and a stored document must still parse when the cap
+ * changes. One module so the runtime's write door and the two briefs that read
+ * it cannot disagree about what "the memory" is.
+ */
+import type { AppMemory } from "@vendoai/core";
+
+/**
+ * How many asks a row keeps. Twenty is the point past which an ask is history
+ * rather than context — the oldest is dropped, so the memory stays a working
+ * set instead of growing without bound on a long-lived app.
+ */
+export const APP_MEMORY_MAX_ASKS = 20;
+
+/**
+ * The decisions budget. ~5 lines fits well inside this; the cap exists so a
+ * model that ignores "keep it short" cannot put a transcript in every future
+ * prompt.
+ */
+export const APP_MEMORY_DECISIONS_MAX_BYTES = 1024;
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+/** The ellipsis is part of the budget, so a truncated block is still within it. */
+const ELLIPSIS = "…";
+
+const truncate = (value: string): string => {
+  const bytes = encoder.encode(value);
+  if (bytes.length <= APP_MEMORY_DECISIONS_MAX_BYTES) return value;
+  const room = APP_MEMORY_DECISIONS_MAX_BYTES - encoder.encode(ELLIPSIS).length;
+  // The cut can land mid-codepoint; the decoder emits U+FFFD for the partial
+  // tail, and dropping it is what keeps the truncation valid text.
+  return `${decoder.decode(bytes.slice(0, room)).replace(/\uFFFD$/, "")}${ELLIPSIS}`;
+};
+
+/**
+ * The memory after one run: the ask APPENDED, the decisions REPLACED.
+ *
+ * The asymmetry is the whole design. An ask is what the person actually said and
+ * is true forever; a decisions block describes the app as it stands, so keeping
+ * the previous one beside it would present a superseded constraint as a current
+ * one. An empty or whitespace-only `decisions` is "nothing to say", not "forget
+ * what you knew".
+ */
+export const rememberedMemory = (
+  memory: AppMemory | undefined,
+  input: { ask?: string; decisions?: string },
+): AppMemory => {
+  const asks = [...(memory?.asks ?? []), ...(input.ask === undefined ? [] : [input.ask])];
+  const decisions = input.decisions === undefined || input.decisions.trim() === ""
+    ? memory?.decisions
+    : truncate(input.decisions);
+  return {
+    asks: asks.slice(-APP_MEMORY_MAX_ASKS),
+    ...(decisions === undefined ? {} : { decisions }),
+  };
+};
+
+/**
+ * The memory as a brief opens with it, or `undefined` when there is nothing to
+ * say.
+ *
+ * It leads the prompt rather than trailing the document, because it is what the
+ * document CANNOT say: the reader is about to see a filtered list and needs to
+ * know the filter was the ask before deciding it is a bug.
+ */
+export const appMemoryBrief = (memory: AppMemory | undefined): string | undefined => {
+  const asks = memory?.asks ?? [];
+  const decisions = memory?.decisions?.trim();
+  if (asks.length === 0 && (decisions === undefined || decisions === "")) return undefined;
+  return [
+    "THIS APP'S MEMORY — read it before the app itself. It is what the document cannot tell you.",
+    ...(asks.length === 0 ? [] : [`EVERY ASK THAT SHAPED IT, oldest first:\n${asks.map((ask) => `- ${ask}`).join("\n")}`]),
+    ...(decisions === undefined || decisions === ""
+      ? []
+      : [`DECISIONS ON RECORD (choices made, constraints found, things ruled out):\n${decisions}`]),
+  ].join("\n\n");
+};

--- a/packages/apps/src/generation/brain.ts
+++ b/packages/apps/src/generation/brain.ts
@@ -27,6 +27,7 @@ import {
   type PlanFacts,
   type TextEdit,
 } from "@vendoai/core";
+import { appMemoryBrief } from "../app-memory.js";
 import { appendSessionTurns } from "../persistence.js";
 import { askModel, asTree, type GeneratedAppDocument, type GenerationDependencies } from "./engine.js";
 import { brainPrompt } from "./prompts/brain.js";
@@ -56,7 +57,7 @@ export type BrainOutcome =
   | { kind: "cannot"; reasons: string[] };
 
 /** The app the brain is editing, as much of it as printing needs. */
-export type BrainApp = Pick<GeneratedAppDocument, "name" | "tree" | "components">;
+export type BrainApp = Pick<GeneratedAppDocument, "name" | "tree" | "components" | "memory">;
 
 export interface BrainInput {
   /** What to answer: the person's own words, or a machine instruction (a
@@ -225,12 +226,17 @@ const brainMessage = (
 ): string => {
   const session = input.session ?? [];
   const printed = appText(input.app);
+  const memory = appMemoryBrief(input.app?.memory);
   // ORDER IS DELIBERATE. The app's CURRENT text is the last thing before the
   // instruction, because the last thing read is the thing attended to — and the
   // one mistake that matters here is quoting an <Old> from something stale.
   // Retry feedback goes ABOVE the print for the same reason: the fresh text
   // must stay the nearest thing to the ask.
   return [
+    // The memory OPENS the brief, ahead of everything: it is the only section
+    // that says why the app looks the way it does, and a reader who meets the
+    // filtered list first reads the filter as a bug and "fixes" it.
+    ...(memory === undefined ? [] : [memory]),
     ...(session.length === 0 ? [] : [`THE CONVERSATION SO FAR (what was said, not what the app says):\n${transcript(session)}`]),
     ...(previous === undefined ? [] : [
       `YOUR LAST ANSWER DID NOT WORK:\n${previous.answer}`,

--- a/packages/apps/src/generation/conductor.ts
+++ b/packages/apps/src/generation/conductor.ts
@@ -466,7 +466,12 @@ export const conductEdit = async (
   const previous = input.app;
   const turn = await runBrainTurn({
     instruction: input.instruction,
-    app: { name: previous.name, tree: previous.tree, ...(previous.components === undefined ? {} : { components: previous.components }) },
+    app: {
+      name: previous.name,
+      tree: previous.tree,
+      ...(previous.components === undefined ? {} : { components: previous.components }),
+      ...(previous.memory === undefined ? {} : { memory: previous.memory }),
+    },
     ...(input.session === undefined ? {} : { session: input.session }),
   }, deps);
   if (turn.outcome === undefined) return { kind: "failure", issues: turn.issues, session: turn.session };

--- a/packages/apps/src/runtime.ts
+++ b/packages/apps/src/runtime.ts
@@ -107,6 +107,7 @@ import {
   runBoxEdit,
   type BoxEditResult,
 } from "./box-agent.js";
+import { appMemoryBrief, rememberedMemory } from "./app-memory.js";
 import { parseVendoManifest } from "./manifest.js";
 import { createAppOpener, createProgressiveQueryResolver, stripServerAuthoritativeFields } from "./open.js";
 import { appRecordInput, documentFromRecord, enabledAfterDocumentEdit, listAllRecords, nextEnvStaleAt, rowFromRecord, sessionOf, updateAppRow, withoutSession, type AppRecordWrite } from "./persistence.js";
@@ -806,6 +807,24 @@ export interface AppsRuntime {
     holder(appId: AppId, ctx: RunContext): Promise<string | null>;
   };
   edit(appId: AppId, instruction: string, ctx: RunContext): Promise<EditResult>;
+  /**
+   * The app's memory, and the ONE door that writes it.
+   *
+   * A screen or build run is stateless; the ARTIFACT is what carries its context
+   * forward, and this is where that context lands. `ask` is appended verbatim —
+   * the front door passes the person's own `request`, never the `<context>`-fenced
+   * composite it briefs an engine with. `decisions` REPLACES whatever was there:
+   * it describes the app as it stands, so a superseded one kept beside the new
+   * one reads as a current constraint. Both are capped here (`app-memory.ts`)
+   * rather than in the schema, so a stored row survives a cap that changes.
+   *
+   * There is deliberately no second row-write door for this. Every caller —
+   * `vendo_make`'s create arms, its edit arm, the screen assembler's decisions —
+   * comes through here, which is also the one place the `editor` level is
+   * checked. A caller treats a rejection as a non-event: memory is never worth
+   * failing a make over.
+   */
+  remember(input: { appId: AppId; ask?: string; decisions?: string }, ctx: RunContext): Promise<void>;
   /**
    * The capped version log, and the one-step rollback over it.
    *
@@ -1894,6 +1913,14 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
     } else {
       app.egressApproved = [...previous.egressApproved];
     }
+    // Same rule, same reason: the memory is written by the memory door alone, so
+    // an edit carries the STORED one across rather than whatever the generated
+    // document happens to hold (which, on a rebuild, is nothing).
+    if (previous.memory === undefined) {
+      delete app.memory;
+    } else {
+      app.memory = structuredClone(previous.memory);
+    }
     const versionId = await history.append(
       app.id,
       previous,
@@ -2121,11 +2148,16 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
   ): Promise<{ ok: true; result: BoxEditResult; doc: AppDocument; servedOk: boolean } | { ok: false; result: BoxEditResult }> => {
     const machine = await lifecycle.wake(app);
     await pushBoxEnv(machine, await lifecycle.buildAppEnv(app)).catch(() => undefined);
+    // The builder in the box reads the app's memory before its own contract, for
+    // the same reason the brain does: the code on that disk cannot say which of
+    // its shapes were asked for and which are incidental.
+    const contract = options.served === true
+      ? `${skinContractPrompt(app)}\n${servedAppContractPrompt()}`
+      : skinContractPrompt(app);
+    const memory = appMemoryBrief(app.memory);
     const result = await runBoxEdit(machine, {
       prompt: instruction,
-      context: options.served === true
-        ? `${skinContractPrompt(app)}\n${servedAppContractPrompt()}`
-        : skinContractPrompt(app),
+      context: memory === undefined ? contract : `${memory}\n\n${contract}`,
       ...(boxEditPollMs === undefined ? {} : { pollIntervalMs: boxEditPollMs }),
       ...(boxEditTimeoutMs === undefined ? {} : { timeoutMs: boxEditTimeoutMs }),
     });
@@ -2578,6 +2610,9 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
       if (app.tree !== undefined) stripServerAuthoritativeFields(app.tree);
       delete app.egressApproved;
       delete app.buildFailed;
+      // The memory door is the only writer (`remember`), so a model that echoed
+      // a `memory` block back out of its brief must not have it persisted.
+      delete app.memory;
 
       let finalTree: Tree | undefined;
       if (input.onView !== undefined && app.tree?.formatVersion === VENDO_TREE_FORMAT) {
@@ -3260,6 +3295,15 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
       });
     },
 
+    async remember(input, ctx) {
+      // The same `editor` gate every other write to this row passes: appending
+      // to an app's memory is changing the app.
+      await requireOwned(input.appId, ctx);
+      await updateAppDocument(input.appId, (doc) => ({
+        ...doc,
+        memory: rememberedMemory(doc.memory, input),
+      }));
+    },
 
     /**
      * Build contract §9.3 — the level lives HERE, not only at the wire route

--- a/packages/core/src/app-document.ts
+++ b/packages/core/src/app-document.ts
@@ -73,6 +73,47 @@ export const appSourceFileSchema = z.object({
   blobRef: z.string().min(1).optional(),
 }).passthrough() satisfies z.ZodType<AppSourceFile>;
 
+/**
+ * The app's own memory — what it was asked for, and what was decided.
+ *
+ * A screen or build run is STATELESS; the artifact is what carries the context
+ * forward. Without this, every editor after the first reads a document with no
+ * idea why it looks the way it does, and quietly undoes a deliberate choice
+ * ("filtered to 2 accounts — the ask was trip-only") because nothing recorded
+ * that it was one.
+ *
+ * SERVER-WRITTEN, like {@link AppBuildFailure}: `asks` is recorded by the front
+ * door and `decisions` by the agent's own save hand, both through the runtime's
+ * one memory door. A model-authored `memory` on a generated document is stripped
+ * before persist, exactly as a forged `egressApproved` is.
+ *
+ * Deliberately NOT a log. Reasoning traces, transcripts and tool outputs are not
+ * here and must not be added: this is the smallest thing the next editor needs,
+ * and an append-only history of everything is how dead context gets read as
+ * current fact.
+ */
+export interface AppMemory {
+  /**
+   * Every `vendo_make` request that touched this app, VERBATIM and in order,
+   * the create ask first. Never a paraphrase — a paraphrase drifts the intent
+   * it was written to preserve. Capped at the write site (oldest dropped).
+   */
+  asks: string[];
+  /**
+   * A few lines the agent chose to record: choices made, constraints found,
+   * things ruled out. REPLACED on every run that writes one, never appended —
+   * a stale decision presented as current is worse than no memory at all.
+   * Byte-capped at the write site.
+   */
+  decisions?: string;
+}
+
+/** 01-core §9 */
+export const appMemorySchema = z.object({
+  asks: z.array(z.string()),
+  decisions: z.string().optional(),
+}).passthrough() satisfies z.ZodType<AppMemory>;
+
 /** 01-core §9 */
 export interface Pin {
   slot: string;
@@ -185,6 +226,12 @@ export interface AppDocument {
    * server-authoritative fields.
    */
   buildFailed?: AppBuildFailure;
+  /**
+   * What this app remembers about itself. Server-written — stripped from a
+   * generated document before persist and pinned from the stored row on every
+   * edit, so only the memory door ever changes it.
+   */
+  memory?: AppMemory;
 }
 
 /**
@@ -216,6 +263,7 @@ const appDocumentShapeSchema = z.object({
   placements: z.array(z.string()).optional(),
   forkedFrom: appIdSchema.optional(),
   buildFailed: appBuildFailureSchema.optional(),
+  memory: appMemorySchema.optional(),
 }).passthrough() satisfies z.ZodType<AppDocument>;
 
 /**

--- a/packages/harnesses/src/screen-agent.ts
+++ b/packages/harnesses/src/screen-agent.ts
@@ -129,7 +129,13 @@ export interface ScreenInput {
 
 /** What one assembly run answers. `ScreenOutcome` plus the title an assembled
  *  screen named itself, which the front door turns into a receipt. */
-export type ScreenResult = ScreenOutcome & { title?: string };
+export type ScreenResult = ScreenOutcome & {
+  title?: string;
+  /** What the run chose to record for the next editor (`save_app`'s
+   *  `decisions`). Never a summary this file wrote — only the agent's own words,
+   *  or nothing. */
+  decisions?: string;
+};
 
 const APP_FILE = "app.vendo";
 const PLAN_FILE = "plan.vendo";
@@ -202,6 +208,11 @@ through two tools.
   \`${appId}\`; you never name a path. Every save that parses repaints the person's
   screen, so save as you go — a save is cheap and silence is not. There is no
   edit-in-place tool: save the full document each time.
+  Its \`decisions\` is this app's MEMORY, and the only thing the next editor will
+  have besides the document. Record what reading the document could not tell
+  them — why you narrowed something, a constraint the tools imposed, a shape you
+  ruled out. Never record what you did or in what order; that is narration, and
+  it crowds out the one line that mattered.
 - **\`validate\`** is the floor. Call it on what you saved, fix what it names, save
   again. You are not done until it comes back clean.
 - **\`${ESCALATE_TOOL}\`** is the one door out. Assembling a document out of this
@@ -239,6 +250,9 @@ interface RunRecord {
   assembled: boolean;
   title?: string;
   escalated?: string;
+  /** The last non-empty `decisions` a save carried — this run's whole memory
+   *  contribution, and what replaces the app's stored block. */
+  decisions?: string;
 }
 
 /** Nothing to hire and nothing to load: the job description is already the whole
@@ -314,18 +328,32 @@ export async function assembleScreen(
       + "as you go rather than once at the end. Returns whether the save landed.",
     inputSchema: {
       type: "object",
-      properties: { content: { type: "string", description: "The complete app document, in the .vendo format." } },
+      properties: {
+        content: { type: "string", description: "The complete app document, in the .vendo format." },
+        decisions: {
+          type: "string",
+          description:
+            "What the next person to edit this app must know: choices you made, constraints you found, things "
+            + "you ruled out. Only what is invisible from the document itself — never a narration of your work. "
+            + "It REPLACES this app's decisions, so write the whole block each time, under 5 lines.",
+        },
+      },
       required: ["content"],
       additionalProperties: false,
     },
     execute: async (args, turn) => {
-      const content = (args as { content: string }).content;
+      const { content, decisions } = args as { content: string; decisions?: string };
       const landed = await save(turn, APP_FILE, content);
       if (!landed) {
         return { saved: false, note: "The save did not land — someone else changed this app. Save again." };
       }
       record.assembled = true;
       record.title = nameOf(content) ?? record.title;
+      // The last save that had something to say wins the run. An omitted or blank
+      // `decisions` on a later save is "nothing to add", not "forget the earlier
+      // one" — a save-as-you-go loop would otherwise erase its own memory on the
+      // final validate-fix save.
+      if (decisions !== undefined && decisions.trim() !== "") record.decisions = decisions;
       return { saved: true, note: "Run validate on it now." };
     },
   };
@@ -412,7 +440,13 @@ export async function assembleScreen(
   // stamps it.
   if (record.escalated !== undefined) return { kind: "escalate", why: record.escalated };
   // A model failure AFTER a screen already painted is not a failed screen.
-  if (record.assembled) return { kind: "assembled", ...(record.title === undefined ? {} : { title: record.title }) };
+  if (record.assembled) {
+    return {
+      kind: "assembled",
+      ...(record.title === undefined ? {} : { title: record.title }),
+      ...(record.decisions === undefined ? {} : { decisions: record.decisions }),
+    };
+  }
   return { kind: "unavailable", why: failure ?? "assembly produced nothing that renders" };
 }
 
@@ -489,6 +523,18 @@ export interface ScreenAssemblerDeps {
   render?: (ctx: RunContext) => Omit<RenderSeamOptions, "emit">;
   /** The deployment's assembled prompt for this ctx, when composition has one. */
   system?: (ctx: RunContext) => Promise<string | undefined>;
+  /**
+   * Where a run's `decisions` land: the runtime's one memory door
+   * (`AppsRuntime.remember`), which is on the other side of the layering — this
+   * package holds no store — so composition fills the slot exactly as it does
+   * `render` above.
+   *
+   * Called only for an `assembled` run, because that is the only answer whose
+   * row exists by the time this returns. Unfilled, or throwing, and the run's
+   * decisions are simply not recorded: a lost memory write is never worth
+   * failing a screen the person can already see.
+   */
+  remember?: (appId: AppId, decisions: string, ctx: RunContext) => Promise<void>;
 }
 
 /**
@@ -537,7 +583,15 @@ export function screenAssembler(deps: ScreenAssemblerDeps): ScreenAssembler {
           ...(system === undefined ? {} : { system }),
         },
       );
-      return result.kind === "assembled" ? { kind: "assembled" } : result;
+      if (result.kind !== "assembled") return result;
+      if (result.decisions !== undefined) {
+        await deps.remember?.(request.appId, result.decisions, ctx).catch((error: unknown) => {
+          console.warn(`[vendo] the screen agent's decisions were not recorded on ${request.appId} — ${
+            error instanceof Error ? error.message : String(error)
+          }`);
+        });
+      }
+      return { kind: "assembled" };
     },
   };
 }

--- a/packages/vendo/src/app-memory.e2e.test.ts
+++ b/packages/vendo/src/app-memory.e2e.test.ts
@@ -1,0 +1,295 @@
+/**
+ * THE MEMORY SEAM — the producer and the consumer, with a stub on neither side.
+ *
+ * An app's memory has two writers and two readers, in different packages, and the
+ * only thing that can prove they agree is one run that goes all the way through:
+ *
+ *   producer  the screen agent's `save_app` hand (`@vendoai/harnesses`) and the
+ *             front door's ask recording (`@vendoai/apps`)
+ *   store     the real row, through the real `AppsRuntime.remember` door
+ *   consumer  the edit brain's brief (`@vendoai/apps` generation), which is what
+ *             the NEXT editor actually reads
+ *
+ * So this is a REAL composed deployment: real store, real guard, real apps pack,
+ * real render seam, real checks floor, real front door. Only the MODEL is
+ * scripted — this measures what the memory carries, not a provider's mood.
+ *
+ * The one that must be able to fail: delete the `remember` calls in
+ * `agent-tools.ts` and "the three asks, verbatim and in order" goes red; delete
+ * the memory block from `brainMessage` and "the edit brief opens with it" goes
+ * red. Both re-checked by hand before every push (see the PR).
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { VENDO_MAKE_TOOL, makeReceiptSchema, type Principal } from "@vendoai/core";
+import { defineHarness } from "@vendoai/harnesses";
+import { createStore, type VendoStore } from "@vendoai/store";
+import type { LanguageModel } from "ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createVendo } from "./server.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+const principal: Principal = { kind: "user", subject: "user_memory" };
+const ctx = { principal, venue: "chat" as const, presence: "present" as const };
+
+/** The smallest document the compiler renders and the seam paints. */
+const SPENDING = `<App name="Spending">
+  <Stack>
+    <Text text="This month" />
+  </Stack>
+</App>`;
+
+/** The second save of the same run — same app, refined. */
+const SPENDING_REFINED = `<App name="Spending">
+  <Stack>
+    <Text text="This month" />
+    <Text text="Trip only" />
+  </Stack>
+</App>`;
+
+const DECISIONS_FIRST = "Started from the full account list.";
+const DECISIONS_LAST = "Filtered to 2 accounts — the ask was trip-only. Ruled out a chart: one number.";
+
+const ASK_CREATE = "show me what I spent this month";
+const ASK_EDIT_1 = "say last month instead";
+const ASK_EDIT_2 = "and drop the trip-only line";
+
+// ── the scripted model ───────────────────────────────────────────────────────
+
+const ZERO_USAGE = {
+  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 0, text: 0, reasoning: 0 },
+} as const;
+
+type Chunk = Record<string, unknown>;
+
+const call = (toolName: string, input: unknown, toolCallId: string): Chunk[] => [
+  { type: "tool-call", toolCallId, toolName, input: JSON.stringify(input) },
+  { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "tool-calls", raw: undefined } },
+];
+
+const speak = (text: string): Chunk[] => [
+  { type: "text-start", id: "t1" },
+  { type: "text-delta", id: "t1", delta: text },
+  { type: "text-end", id: "t1" },
+  { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "stop", raw: undefined } },
+];
+
+/** The screen agent's own brief, verbatim from `environmentNote`. */
+const SCREEN_BRIEF_MARKER = "# In this loop";
+/** The brain's edit prompt prints the app it is amending; a create's never can. */
+const EDIT_MARKER = "THE APP AS IT STANDS";
+/** The memory block's own first words (`appMemoryBrief`). */
+const MEMORY_MARKER = "THIS APP'S MEMORY";
+
+/** The two edits, in order, so the second amends what the first landed. */
+const EDITS = [
+  "<Edit><Old>This month</Old><New>Last month</New></Edit>",
+  "<Edit><Old>Trip only</Old><New>Everything</New></Edit>",
+];
+
+interface Scripted {
+  model: LanguageModel;
+  /** Every prompt the model was handed, in order. */
+  prompts: string[];
+}
+
+function scripted(screenTurns: Chunk[][]): Scripted {
+  const prompts: string[] = [];
+  const screen = screenTurns.map((turn) => [...turn]);
+  const edits = [...EDITS];
+  const answer = (prompt: string): Chunk[] => {
+    if (prompt.includes(SCREEN_BRIEF_MARKER)) return screen.shift() ?? speak("nothing more to do");
+    if (prompt.includes(EDIT_MARKER)) return speak(edits.shift() ?? "<Cannot><Reason>no more edits</Reason></Cannot>");
+    return speak(SPENDING);
+  };
+  const textOf = (request: { prompt?: unknown }): string => JSON.stringify(request.prompt ?? "");
+  const model = {
+    specificationVersion: "v2",
+    provider: "vendo-memory",
+    modelId: "vendo-memory-v1",
+    supportedUrls: {},
+    async doGenerate(request: { prompt?: unknown }) {
+      const prompt = textOf(request);
+      prompts.push(prompt);
+      const chunks = answer(prompt);
+      const toolCall = chunks.find((chunk) => chunk["type"] === "tool-call");
+      if (toolCall !== undefined) {
+        return {
+          content: [{
+            type: "tool-call" as const,
+            toolCallId: toolCall["toolCallId"] as string,
+            toolName: toolCall["toolName"] as string,
+            input: toolCall["input"] as string,
+          }],
+          finishReason: "tool-calls" as const,
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        };
+      }
+      return {
+        content: [{
+          type: "text" as const,
+          text: chunks.filter((chunk) => chunk["type"] === "text-delta").map((chunk) => chunk["delta"] as string).join(""),
+        }],
+        finishReason: "stop" as const,
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      };
+    },
+    async doStream(request: { prompt?: unknown }) {
+      const prompt = textOf(request);
+      prompts.push(prompt);
+      return {
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: "stream-start", warnings: [] });
+            for (const chunk of answer(prompt)) controller.enqueue(chunk);
+            controller.close();
+          },
+        }),
+      };
+    },
+  };
+  return { model: model as unknown as LanguageModel, prompts };
+}
+
+async function tempStore(): Promise<VendoStore> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-memory-"));
+  const store = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.ensureSchema().catch(() => undefined);
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  return store;
+}
+
+/** One real turn whose harness does exactly what a calling agent does: ask
+ *  `vendo_make` in words, in order, and keep the receipts. */
+async function walk(options: {
+  screenTurns: Chunk[][];
+  asks: Array<{ request: string; context?: string; app?: (previous: string[]) => string }>;
+}) {
+  vi.stubEnv("VENDO_BASE_URL", "http://memory.test");
+  const store = await tempStore();
+  const { model, prompts } = scripted(options.screenTurns);
+  const ids: string[] = [];
+  const harness = defineHarness({
+    name: "memory-probe",
+    async *run(turn) {
+      for (const ask of options.asks) {
+        const result = await turn.tools.call(VENDO_MAKE_TOOL, {
+          request: ask.request,
+          ...(ask.context === undefined ? {} : { context: ask.context }),
+          ...(ask.app === undefined ? {} : { app: ask.app(ids) }),
+        });
+        if (result.status === "ok") ids.push(makeReceiptSchema.parse(result.output).id);
+      }
+      yield { type: "text", delta: "ok" };
+    },
+  });
+  const vendo = createVendo({
+    model,
+    principal: async () => principal,
+    store,
+    harness: harness as never,
+  } as Parameters<typeof createVendo>[0]);
+  const response = await vendo.handler(new Request("https://memory.test/api/vendo/threads", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      threadId: "thr_memory",
+      message: { id: "m1", role: "user", parts: [{ type: "text", text: "make me something" }] },
+    }),
+  }));
+  expect(response.status).toBe(200);
+  await response.text();
+  return { ids, prompts, vendo };
+}
+
+describe("an app remembers what it was asked for, and what was decided", () => {
+  it("create → edit → edit lands the three asks verbatim and in order, with the last save's decisions", async () => {
+    const walked = await walk({
+      // TWO saves in the one assembly run: the second's `decisions` is what the
+      // app must end up with — a run that refines its own answer must not leave
+      // the superseded note behind.
+      screenTurns: [
+        call("save_app", { content: SPENDING, decisions: DECISIONS_FIRST }, "c1"),
+        call("save_app", { content: SPENDING_REFINED, decisions: DECISIONS_LAST }, "c2"),
+        speak("done"),
+      ],
+      asks: [
+        { request: ASK_CREATE },
+        { request: ASK_EDIT_1, app: (ids) => ids[0]! },
+        { request: ASK_EDIT_2, app: (ids) => ids[0]! },
+      ],
+    });
+
+    const appId = walked.ids[0]!;
+    expect(walked.ids).toEqual([appId, appId, appId]);
+
+    const stored = await walked.vendo.apps.get(appId, ctx);
+    // THE ASKS: verbatim, in order, the create ask first. Not a paraphrase, not a
+    // summary, not the receipt's title.
+    expect(stored?.memory?.asks).toEqual([ASK_CREATE, ASK_EDIT_1, ASK_EDIT_2]);
+    // THE DECISIONS: replaced, not appended. Two saves, one block.
+    expect(stored?.memory?.decisions).toBe(DECISIONS_LAST);
+    expect(stored?.memory?.decisions).not.toContain(DECISIONS_FIRST);
+    // The edits really landed — this is a live app whose memory survived two
+    // rewrites of its document, not a row nobody touched.
+    expect(JSON.stringify(stored)).toContain("Last month");
+  }, 60_000);
+
+  it("the edit brief OPENS with the memory — every earlier ask, and the decisions verbatim", async () => {
+    const walked = await walk({
+      screenTurns: [
+        call("save_app", { content: SPENDING, decisions: DECISIONS_LAST }, "c1"),
+        speak("done"),
+      ],
+      asks: [
+        { request: ASK_CREATE },
+        { request: ASK_EDIT_1, app: (ids) => ids[0]! },
+        { request: ASK_EDIT_2, app: (ids) => ids[0]! },
+      ],
+    });
+
+    // The REAL brief the edit loop was handed, not a rendering of it.
+    const editBriefs = walked.prompts.filter((prompt) => prompt.includes(EDIT_MARKER));
+    expect(editBriefs.length).toBeGreaterThan(1);
+    const last = editBriefs.at(-1)!;
+
+    expect(last).toContain(MEMORY_MARKER);
+    // Both EARLIER asks travelled — the second edit's editor knows the app was
+    // asked for "this month" and then "last month", which nothing in the
+    // document says.
+    expect(last).toContain(ASK_CREATE);
+    expect(last).toContain(ASK_EDIT_1);
+    // …and the decisions the assembly run recorded, verbatim.
+    expect(last).toContain("the ask was trip-only");
+    // BEFORE the document: the reader meets the filter as a choice, not as a bug
+    // to fix. (Both markers are in this one prompt, so the order is the claim.)
+    expect(last.indexOf(MEMORY_MARKER)).toBeLessThan(last.indexOf(EDIT_MARKER));
+  }, 60_000);
+
+  it("the memory holds what the PERSON said — never the calling agent's `<context>`", async () => {
+    const walked = await walk({
+      screenTurns: [call("save_app", { content: SPENDING }, "c1"), speak("done")],
+      asks: [{
+        request: ASK_CREATE,
+        // One calling agent's background for one call. Replaying it to every
+        // future editor turns a stale aside into a standing requirement.
+        context: "the user is on the premium plan and was looking at Q3 earlier",
+      }],
+    });
+
+    const stored = await walked.vendo.apps.get(walked.ids[0]!, ctx);
+    expect(stored?.memory?.asks).toEqual([ASK_CREATE]);
+    expect(JSON.stringify(stored?.memory)).not.toContain("premium plan");
+    expect(JSON.stringify(stored?.memory)).not.toContain("<context>");
+  }, 60_000);
+});

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -2344,6 +2344,12 @@ export function createVendo(input: CreateVendoConfig): Vendo {
         commitSource: (input) => apps.commitSource(input, screenCtx),
         floor: apps.floor(screenCtx),
       }),
+      // The app's memory, through the runtime's one write door — the same door
+      // the front door records asks with. Nothing in this package decides what
+      // goes in it; the assembler hands over the agent's own words.
+      remember: async (appId, decisions, memoryCtx) => {
+        await apps.remember({ appId, decisions }, memoryCtx);
+      },
       // `system` is deliberately unset. The screen agent's brief is the shipped
       // `building-apps` skill plus the host's own tool shapes, and the
       // deployment prompt's job — voice, venue gate, guard directions, the


### PR DESCRIPTION
A screen or build run is stateless, so the **artifact** carries its context.
`AppDocument` gains an additive `memory`, and every editor after the first reads
it before the document.

## The two halves

**`asks`** — every `vendo_make` request that touched this app, verbatim and in
order, the create ask first. Recorded at the front door, the one place that sees
every request whichever engine served it: assembly, the builder, the conductor
fall-through, an edit.

It records `request`, never the `<context>`-fenced composite it briefs an engine
with. The memory holds what the *person* said, so one calling agent's background
for one call cannot become a standing requirement for every future editor.

**`decisions`** — a short block the agent writes itself, through `save_app`'s new
optional `decisions` field: choices made, constraints found, things ruled out
("filtered to 2 accounts — the ask was trip-only"). **Replaced** on every run
that writes one, never appended: a superseded decision presented as a current one
is worse than no memory at all, and an append-only log is how dead context gets
read as fact. The last save with something to say wins the run, so a
save-as-you-go loop does not erase its own memory on the final validate-fix save.

Reasoning traces, transcripts and tool outputs are deliberately not stored.

## Where it is read

The edit brain's brief **opens** with the memory, ahead of the app's own text,
and the in-box builder's task context does the same. That order is the point: a
reader who meets a deliberately filtered list first reads the filter as a bug and
"fixes" it.

## Server-written, one door

`AppsRuntime.remember` is the only writer and the only place `editor` is checked.
A model-authored `memory` is stripped from a generated document and an edit pins
the stored one across the rewrite — the same rule `egressApproved` already has.
Callers treat a rejection as a non-event: there is no arrangement of a lost
memory write worse than failing a make the person can already see.

Caps live at that write site rather than in the schema, so a stored row survives
a cap that changes — the last 20 asks (oldest dropped), 1KB of decisions
(truncated with a visible marker).

## Proof

`packages/vendo/src/app-memory.e2e.test.ts` is the seam, with a stub on neither
side: a real composed deployment (real store, guard, apps pack, render seam,
checks floor, front door) walking create → edit → edit through `vendo_make`.
The producer is the real `save_app` hand in `@vendoai/harnesses`; the consumer is
the real edit brain's prompt in `@vendoai/apps`.

- the three asks land verbatim and in order, and the second save's decisions
  replace the first's
- the actual brief the edit loop receives contains both, memory before document
- the `<context>` fence never reaches the row

`packages/apps/src/app-memory.test.ts` covers the caps through the real door and
the real store: the 21st ask drops the first, an oversized decisions block
truncates, a blank one leaves the stored block alone, and a stranger cannot
write.

**Each proved able to fail** (broken, watched go red, restored):

| break | red |
|---|---|
| drop the `remember` calls in `agent-tools.ts` | all 3 seam tests |
| drop the memory block from `brainMessage` | the edit-brief test only |
| make `save_app` ignore `decisions` | both decisions assertions |
| record `ask` (the composite) instead of `request` | the `<context>` test only |
| remove `slice(-MAX_ASKS)` / the byte cap | both cap tests |

## Gate

`pnpm build` · `pnpm typecheck` · `pnpm lint` green.
`@vendoai/apps` 1039 passed, `@vendoai/harnesses` 387 passed, `@vendoai/core`
1050 passed, `@vendoai/vendo` 2033 passed.

Two pre-existing failures unrelated to this change and reproduced on the clean
base: `packages/vendo/src/dev-creds/model.test.ts` (2 tests, module resolution
from a temp dir — green in CI) and `packages/core/src/packaging.e2e.test.ts`
(3 tests, the packed artifact's path is URL-encoded because this worktree lives
under a directory with a space in its name).

## Not touched

`ScreenOutcome` / `ScreenAssembler`, the #844 loadout semantics, #854's routing
arms, the wire formats, the UI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apps now remember what they were asked for and the latest decisions, so future edits keep context and avoid undoing deliberate choices. Memory is server-written, capped, and read before the app text in editors and the box builder.

- **New Features**
  - `@vendoai/core`: Added `AppDocument.memory { asks: string[]; decisions?: string }` and schema.
  - `@vendoai/apps`:
    - Added `AppsRuntime.remember({ appId, ask?, decisions? })` (`editor`-gated).
    - Front door records each `request` verbatim for `asks` (never the `<context>` composite).
    - Edit brain and box builder prepend memory to their prompts.
    - Generated docs cannot persist `memory`; edits carry the stored memory across rewrites.
  - `@vendoai/harnesses` + `@vendoai/vendo`:
    - `save_app` accepts optional `decisions`; the last non-empty in a run is used.
    - Screen assembler forwards `decisions` to `apps.remember` (best-effort; failures don’t fail the run).
  - Limits and rules:
    - Keep the last 20 asks; decisions capped at 1KB with a visible ellipsis.
    - Blank `decisions` do not overwrite the stored block.

<sup>Written for commit 30e6b54f5c39ee1c643769e97ac32d43f656a2c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

