### PR TITLE
refactor(vendo,guard)!: guard() is an object; one prose story; connectors consolidated; the agent grab-bag dies

### DIFF
--- a/.changeset/config-coherence-guard-instructions-connectors.md
+++ b/.changeset/config-coherence-guard-instructions-connectors.md
@@ -1,0 +1,71 @@
+---
+"@vendoai/vendo": major
+"@vendoai/guard": major
+"@vendoai/agents": minor
+---
+
+**BREAKING:** `createVendo`'s config says one thing once. `guard()` is a value,
+prose has one name, connectors are one list, and the `agent:` grab-bag is gone.
+
+Four incoherences, one shape each. The guard was constructed invisibly from
+three flat keys while `agent()` next door took a guard INSTANCE. `brief` and
+`agent.instructions` were the same prose under two names. `connectorApps` was a
+modifier of `connectors` that was silently ignored whenever `connectors` was
+set. And `agent:` was a bag holding a whole agent OR seven unrelated knobs, half
+of which configured a thinker that never saw them.
+
+| Removed | Replacement |
+| --- | --- |
+| `policy` | `guard: guard({ policy })` |
+| `judge` | `guard: guard({ judge })` |
+| `approvals` | `guard: guard({ approvals })` |
+| `brief` | `instructions` |
+| `agent.instructions` | `instructions` |
+| `connectorApps: ["gmail"]` | `connectors: ["gmail"]` |
+| `agent.toolOutputCap` | `toolOutputCap` |
+| `agent.maxInitialTools` | `maxInitialTools` |
+| `agent.loadout` | `loadout` |
+| `agent.maxSteps` | `harness: vendo({ maxSteps })` |
+| `agent.historyWindow` | `harness: vendo({ historyWindow })` |
+| `agent.maxOutputTokens` | `harness: vendo({ maxOutputTokens })` |
+
+- **`guard` is one slot with two arms.** `guard({ policy, judge, approvals })`
+  from `@vendoai/guard` (re-exported by `@vendoai/vendo/server`) declares the
+  host's RULES and lets composition finish them with the plumbing only a venue
+  has — the store, the app/service risk resolver, the org-policy layer, the
+  cloud policy fallback. A built `VendoGuard` is taken verbatim instead
+  (adapter rule). `agent({ guard })` in `@vendoai/agents` accepts the same
+  union. `createGuard` is still the one constructor both arms end at; the
+  guard's runtime behaviour is untouched, and its own suites pass unmodified.
+  `CreateGuardConfig` now also takes `approvals.parkedCallTtlMs` and the guard
+  exposes the resolved value at `guard.approvals.parkedCallTtlMs`, so a host
+  that brings its own instance keeps the knob instead of losing it.
+- **One prose story.** `instructions` is what this product is, who uses it, and
+  the house voice, placed in the assembled prompt's Product section every turn
+  — the programmatic override for `.vendo/brief.md`, which `vendo init` still
+  writes and still feeds this key. THE ONE BEHAVIOUR DIFFERENCE: prose that
+  used to arrive through `agent.instructions` was appended as the LAST section
+  of the system prompt, after the guard's directions and the component catalog;
+  it now rides the Product section near the top, where `brief` always did.
+  Every deployment whose prose came from `brief`/`.vendo/brief.md` — which is
+  every deployment `vendo init` scaffolded — gets a byte-identical prompt.
+- **Connectors are one list.** `connectors?: readonly (string | Connector)[]`.
+  A string names a Vendo Cloud toolkit and scopes the composed
+  cloudTools/cloudConnections pair to exactly that set; an object is an
+  explicit provider, used verbatim; mix freely. Strings with no `VENDO_API_KEY`
+  mount nothing and the connect surface refuses by naming both fixes — the old
+  key's silent-ignore trap cannot survive, because there is no longer a second
+  list to ignore.
+- **The knobs split by owner.** What the deployment curates is composition's
+  and sits at the top level (`toolOutputCap`, `maxInitialTools`, `loadout` —
+  the bridge and the discovery rail are built here and handed to BOTH
+  thinkers). What the thinker decides rides the thinker (`maxSteps`,
+  `historyWindow`, `maxOutputTokens` — already `vendo()` deps).
+  `agent?: ComposedAgent` now means exactly one thing: the agent `agent()`
+  built, adopted whole. `instructions` joins `harness`/`store`/`files`/`sandbox`
+  as a slot the adopted agent owns, so filling it twice is a boot error.
+
+`createVendo` REFUSES to compose against a removed key, naming its replacement.
+TypeScript already rejects every one of them; the boot error is for the
+JavaScript host, where a dropped `policy` would mean an unconfigured guard
+running wide open.

--- a/corpus/hosts/express-host/src/server/vendo.ts
+++ b/corpus/hosts/express-host/src/server/vendo.ts
@@ -1,5 +1,5 @@
 import { createAnthropic } from "@ai-sdk/anthropic";
-import { createVendo, type Vendo } from "@vendoai/vendo/server";
+import { createVendo, guard, type Vendo } from "@vendoai/vendo/server";
 import type { Principal, VendoStore } from "@vendoai/vendo";
 import type { LanguageModel } from "ai";
 
@@ -25,7 +25,7 @@ export function createRelayVendo(options: RelayVendoOptions = {}): Vendo {
     // Loopback-only single-user fixture: one fixed demo principal is intentional.
     principal: async () => RELAY_PRINCIPAL,
     ...(options.store === undefined ? {} : { store: options.store }),
-    policy: { file: ".vendo/policy.json" },
+    guard: guard({ policy: { file: ".vendo/policy.json" } }),
     telemetry: false,
   });
 }

--- a/docs-site/changelog/overview.mdx
+++ b/docs-site/changelog/overview.mdx
@@ -249,7 +249,7 @@ what the chat loop sends to the model. `toolOutputCap` defaults to 32,000
 characters (pass `0` to disable) and truncates a single runaway tool result
 before it reaches the model; the stored thread is untouched. `historyWindow`
 caps the last N whole messages re-sent per turn without splitting
-tool-call/result pairs. See [Handler options](/reference/handler-options#agent-context).
+tool-call/result pairs. See [Handler options](/reference/handler-options#turn-context).
 
 ## Updates
 

--- a/docs-site/concepts/tools-and-safety.mdx
+++ b/docs-site/concepts/tools-and-safety.mdx
@@ -91,11 +91,11 @@ Breakers can turn a run decision into an ask at any point.
 
 Loadout selection is deterministic:
 
-- An explicit `agent.loadout` list wins: exactly those tool names, uncapped
+- An explicit `loadout` list wins: exactly those tool names, uncapped
   (missing names are dropped).
 - Otherwise the default is a connection-scoped seed — your host tools plus
   the toolkits this principal has actually connected — capped at
-  `agent.maxInitialTools` (default `128`), never an alphabetical slice.
+  `maxInitialTools` (default `128`), never an alphabetical slice.
 - If the seed cannot be resolved, the agent degrades to the whole enabled
   host surface when it fits the cap, else to a read-first bounded default:
   safest risk first, then name. The remainder stay searchable.
@@ -110,7 +110,7 @@ the model calls a searched-in tool, it becomes available on the very next
 step; loaded tools persist for the life of the thread and are cleared when
 the thread is deleted.
 
-See [`agent.maxInitialTools` and `agent.loadout`](/reference/handler-options#agent-context)
+See [`maxInitialTools` and `loadout`](/reference/handler-options#turn-context)
 for the configuration surface.
 
 ### Grant invalidation

--- a/docs-site/connect/instructions.mdx
+++ b/docs-site/connect/instructions.mdx
@@ -11,9 +11,9 @@ each to that place and to its position in the assembled prompt.
 
 | File or config | Purpose |
 | --- | --- |
-| `.vendo/brief.md` | product brief placed near the start of the agent prompt |
+| `.vendo/brief.md` | the deployment's prose, placed near the start of the agent prompt |
+| `createVendo({ instructions })` | the same prose in config; a non-blank value wins over the file |
 | `.vendo/policy.json` `directions` | company steering returned by guard |
-| `createVendo({ agent: { instructions } })` | final host additions to the agent prompt |
 | `.vendo/design-rules.md` | optional rules for app generation, re-read per generation (edits apply without a restart) |
 | `createVendo({ apps: { designRules } })` | the same rules in config; a non-blank value wins over the file |
 
@@ -29,13 +29,16 @@ sections drop out entirely; the rest keep this order:
 2. Presentation guidance, when the venue can render trees (chat and app).
 3. Capability-miss reporting guidance, when enabled.
 4. Discovery-budget guidance, when tool search is on.
-5. The host product brief from `.vendo/brief.md`.
+5. The deployment's prose — `createVendo({ instructions })`, else
+   `.vendo/brief.md`.
 6. Company directions returned by `guard.directions(ctx)`.
 7. Catalog and theme summary, when the venue can render trees.
 8. The knowledge index, when knowledge is configured and the venue can
    render trees.
-9. Host instructions — last, so they are the final word on tone and emphasis.
-   Policy belongs in guard directions, not here.
+There is no separate trailing host-instructions section: `brief` and
+`agent.instructions` were the same prose under two names, and they merged into
+the one `instructions` key at position 5. Policy belongs in guard directions,
+not here.
 
 The apps generation engine has its own specialized prompts for tree emission
 and code edits. It receives the component catalog, theme, optional design

--- a/docs-site/existing-agents/configuration.mdx
+++ b/docs-site/existing-agents/configuration.mdx
@@ -18,7 +18,8 @@ your repo:
 - an auth preset or a `principal` line,
 - `catalog` (the component registry init generated),
 - a `serverActions` map, only when init detected `"use server"` actions,
-- `policy: {}` reads `.vendo/policy.json`: destructive asks, reads run.
+- `guard: guard({ policy: {} })` reads `.vendo/policy.json`: destructive asks,
+  reads run.
 
 ## One principal, two places
 

--- a/docs-site/existing-agents/index.mdx
+++ b/docs-site/existing-agents/index.mdx
@@ -46,13 +46,13 @@ the embeds: Vendo minus the conversation.
 
 ```ts
 // lib/vendo.ts: the same composition as any Vendo host
-import { createVendo } from "@vendoai/vendo/server";
+import { createVendo, guard } from "@vendoai/vendo/server";
 
 export async function getWeather(city: string) { /* … */ }
 export async function sendTripReport(to: string, body: string) { /* … */ }
 
 export const vendo = createVendo({
-  policy: "cautious",
+  guard: guard({ policy: "cautious" }),
   // in-process dispatch for the actions declared in .vendo/tools.json
   serverActions: {
     "lib/vendo.ts#getWeather": getWeather,
@@ -111,7 +111,8 @@ executes the parked call and the embed resolves in place to the executed
 result. Deny resolves it to "declined" and discards the parked call.
 
 Parked calls expire on a TTL sweep, 60 minutes by default. Tune it with
-`createVendo({ approvals: { parkedCallTtlMs } })`; `0` disables expiry. An
+`createVendo({ guard: guard({ approvals: { parkedCallTtlMs } }) })`; `0`
+disables expiry. An
 expired call resolves the embed to "expired" and never runs.
 
 Your agent learns the outcome on a later turn if it matters. This is the

--- a/docs-site/quickstart.mdx
+++ b/docs-site/quickstart.mdx
@@ -84,7 +84,7 @@ write. The scaffold looks like this:
 // app/api/vendo/[...vendo]/route.ts — equivalent to what `vendo init` writes
 // (init emits a relative registry import; the `@/*` alias reads better here)
 import { authJs } from "@vendoai/vendo/auth/auth-js";
-import { createVendo, nextVendoHandler } from "@vendoai/vendo/server";
+import { createVendo, guard, nextVendoHandler } from "@vendoai/vendo/server";
 import { serverActions } from "./vendo-actions";
 import { registry } from "@/vendo/registry";
 
@@ -92,7 +92,7 @@ const vendo = createVendo({
   auth: authJs(),    // detected from package.json
   catalog: registry, // the components the agent may render
   serverActions,     // generated when "use server" actions are detected
-  policy: {},        // .vendo/policy.json: destructive asks, reads run
+  guard: guard({ policy: {} }), // .vendo/policy.json: destructive asks, reads run
 });
 
 export const { GET, POST, PUT, PATCH, DELETE } = nextVendoHandler(vendo);

--- a/docs-site/reference/handler-options.mdx
+++ b/docs-site/reference/handler-options.mdx
@@ -21,19 +21,17 @@ model, anonymous ephemeral sessions, and default persistence;
 | `tools` | the host's own tool declarations in memory — the same `ExtractedTool[]` `vendo init` / `vendo sync` write to `.vendo/tools.json`. The explicit override, not the quickstart: reach for it when the declarations cannot live on a filesystem (a Worker, a per-tenant venue, a test). Wins over the deprecated `profile.tools`, which wins over the `profileDir` / cwd file |
 | `catalog` | `ComponentCatalog` or the name-keyed `ComponentRegistry` of host components exposed to the generation prompt; merged with any `.vendo/catalog.json` written by `vendo sync`, with explicit entries winning by name — see [Host components](/connect/host-components) |
 | `theme` | programmatic override for the theme surface; an explicit theme wins over `.vendo/theme.json`. Resolved once at compose (it feeds app generation and the system-prompt summary), so unlike design rules it is not re-read live |
-| `brief` | programmatic override for the product brief — the same prose `.vendo/brief.md` carries. A non-blank string wins over the file; blank falls through |
+| `instructions` | THE prose the deployment puts in front of the agent every turn: what this product is, who uses it, the house voice, what to emphasize. Programmatic override for the same `.vendo/brief.md` surface `vendo init` writes — a non-blank string wins over the file; blank falls through. It rides the assembled prompt's Product section. (`brief` and `agent.instructions` were two names for this knob and are gone) |
 | `store` | defaults to PGlite at `.vendo/data`; with `VENDO_API_KEY` set and no `store` passed, the Cloud hosted store fills the slot instead — see [Persistence](/deploy/persistence) |
 | `files` | where workspace file CONTENT lives once it outgrows a database row. Unset is a documented default, not a gap: the store's own blobs back it up to 5 MiB and the first over-cap write fails naming this key. `s3({ bucket, … })` covers S3/R2/Supabase/MinIO |
 | `sandbox` | unlocks machine-backed apps (layers 2 and 3); with no adapter passed, `E2B_API_KEY` (with the `e2b` package installed) or `VENDO_API_KEY` fills the slot, and with none of the three, apps stay tree-only |
 | `harness` | who thinks: the built-in `vendo()` (the default), `claudeCode()` (the builder, on a sandbox machine), or your own via `defineHarness`. Every chat turn runs through the harness runtime; a harness declaring `requires: { sandbox: true }` with no `sandbox` adapter is a boot error, never a turn that dies in front of a user |
 | `knowledge` | the product knowledge-base adapter. Configured, it composes the `vendo_knowledge_search` tool; unset, that tool does not exist |
-| `connectors` | adds external connector tool registries |
-| `connectorApps` | toolkit scoping for the auto-composed Cloud connector: with `VENDO_API_KEY` and no explicit `connectors`, discovery, the executable tools and the connect catalog are all bound to exactly these toolkits. Ignored when `connectors` or `connections` is passed explicitly — scope those adapters directly |
+| `connectors` | where outside-service tools come from, as ONE mixed list. A **string** names a Vendo Cloud toolkit (`["gmail", "slack"]`): discovery, the executable tools and the connect catalog all bind to exactly those toolkits, and it needs `VENDO_API_KEY` — without one the toolkits mount nothing and the connect surface refuses by naming the key. A **`Connector` object** is an explicit provider, used verbatim. Unset lets `VENDO_API_KEY` default the unscoped Cloud connector; `[]` means no connectors |
 | `connections` | explicit connections adapter for the connected-accounts surface; always wins over the composed defaults |
 | `actAs` | escape hatch: supplies scoped auth material for away host API execution. Mutually exclusive with `auth` — see [actAs presets](/connect/act-as-presets) |
 | `serverActions` | the server-action registration map emitted by the generated wiring file, keyed `"<module>#<exportName>"`; server-action tools dispatch in-process through it, and a missing key fails closed at execution |
-| `policy` | named preset (`"cautious"`, `"readonly"`, `"autopilot"`), inline rules and directions, a policy file, or a code escape hatch; `policy: {}` reads the default `.vendo/policy.json` (what `vendo init` scaffolds; read fail-soft — a missing default file also auto-runs, with no notice). Omit the key entirely and every call auto-runs |
-| `judge` | contextual guard judge |
+| `guard` | the deployment's choke point, as one value. `guard({ policy, judge, approvals })` declares the rules and this composition completes them with the store, the app/service risk grading and the org-policy layer; a built `VendoGuard` from `createGuard({ store, … })` is taken verbatim instead. `policy` is a named preset (`"cautious"`, `"readonly"`, `"autopilot"`), inline rules and directions, a policy file, or a code escape hatch — `guard({ policy: {} })` reads the default `.vendo/policy.json` (what `vendo init` scaffolds; read fail-soft, so a missing default file also auto-runs with no notice). `judge` is the contextual guard judge. `approvals.parkedCallTtlMs` is the idle timeout for a guarded call parked from a [BYO agent loop](/existing-agents) (default 60 min; `0` disables expiry) — past it the sweep denies the approval and `<VendoApprovalEmbed>` reads "expired"; Vendo-thread approvals are untouched. Omit the key entirely and every call auto-runs |
 | `secrets` | defaults to environment-backed secret lookup |
 | `telemetry` | wires build and development telemetry |
 | `development` | development-only injection seams (e.g. `/dev/inclient-approval`, the remix review-queue routes); `NODE_ENV=development` enables them, `false` disables the environment default |
@@ -42,9 +40,11 @@ model, anonymous ephemeral sessions, and default persistence;
 | `profile` | the `.vendo/` pieces as in-memory compose-time inputs, for venues with no filesystem: `{ overrides?, theme?, brief?, catalog?, policy?, designRules? }`, each independent and each winning over its file. `profile.tools` is **deprecated** — use the `tools:` slot |
 | `mcp` | opens the [MCP door](/capabilities/mcp) so outside agents reach host tools through the guarded path; `true` for defaults, or an object carrying `{ baseUrl?, remoteAs?, federation? }` when door-specific settings need to flow through the umbrella (see [Configure the door through the umbrella](/capabilities/mcp#configure-the-door-through-the-umbrella)); off by default |
 | `oauth` | escape hatch: `HostOAuthAdapter` used by the door for session lookup and principal resolution; required when `mcp` is enabled and `auth` supplies no oauth half. Mutually exclusive with `auth`. The door renders consent when the adapter uses `session`, or hands off the whole page when it supplies `authorize` instead — see [MCP door](/capabilities/mcp) |
-| `agent` | chat context controls: `instructions`, `toolOutputCap`, `maxOutputTokens`, `historyWindow`, `maxInitialTools`, `loadout`, `maxSteps` (see [Agent context](#agent-context)) |
+| `agent` | a whole agent built by `agent()` from `@vendoai/agents`; this deployment adopts its harness, store, blob adapter, sandbox and instructions — see [Use with your existing agent](/existing-agents). The chat-knobs object is gone: see [Turn context](#turn-context) |
 | `sessions` | ephemeral (anonymous) session lifecycle: `ttlMs` idle timeout before a session is swept (default 30 minutes; `0` disables eviction) and `sweepIntervalMs` sweep cadence (default 60 seconds) |
-| `approvals` | approval lifecycle knobs: `parkedCallTtlMs` is the idle timeout for a guarded call parked from a [BYO agent loop](/existing-agents) (default 60 min; `0` disables expiry). Past it, the sweep denies the approval and `<VendoApprovalEmbed>` reads "expired". Vendo-thread approvals are untouched |
+| `toolOutputCap` | how much of one tool result reaches the model, in characters (default `32000`; `0` disables) — see [Turn context](#turn-context) |
+| `maxInitialTools` | cap on the uncurated initial tool loadout; the rest stay discoverable via `find_tools` (default `128`) — see [Turn context](#turn-context) |
+| `loadout` | explicit curated initial loadout, by tool name — see [Turn context](#turn-context) |
 | `skills` | SKILL.md values mounted at `/host/skills` for the harness to list cheaply and load on demand, beside the ones the deployment's own subsystems bring. Names are global as authored and a collision with another contributor fails at boot naming both |
 | `automations` | `false` unmounts automations: the `/automations`, `/runs` and `/webhooks` surfaces answer not-found, `vendo.emit` refuses, and the unattended-irreversibility rule leaves the reviewer's rubric. Mounted by default |
 | `apps` | `false` unmounts app generation entirely — `vendo_make` and the `vendo_apps_*` tools are absent from the registry, the `building-apps` skill is absent from the mount, and the `/apps` surface answers not-found. Otherwise, apps-block options: `designRules` sets host design rules programmatically, and `pipeline` enables the opt-in generation-pipeline flags (`exemplarContract`, `structuredRepair`, `regionParallel`, `endPass`, and `rebind` — the data-sighted verify's strict rebind arm, requires `endPass`) — see [Generated UI](/concepts/generated-ui). Machine-backed (layer-2) apps have no flag: they are gated by a configured `sandbox` adapter alone, and layer-3 served apps additionally need the mounted wire plus `VENDO_BASE_URL` |
@@ -52,10 +52,10 @@ model, anonymous ephemeral sessions, and default persistence;
 
 Named presets: `"cautious"` lets reads run and asks before writes or
 destructive calls, `"readonly"` lets reads run and blocks everything else,
-`"autopilot"` runs everything. Omitting the `policy` key entirely surfaces an
+`"autopilot"` runs everything. Omitting the `guard` key entirely surfaces an
 unconfigured-policy notice in the shipped chrome; a missing
-`.vendo/policy.json` file with `policy: {}` still set does not; keep the
-file in version control.
+`.vendo/policy.json` file with `guard({ policy: {} })` still set does not; keep
+the file in version control.
 
 The umbrella also ships two subpath exports for hosts that keep their own
 agent loop: `@vendoai/vendo/ai-sdk` (`vendoTools`) and `@vendoai/vendo/mastra`
@@ -63,39 +63,40 @@ agent loop: `@vendoai/vendo/ai-sdk` (`vendoTools`) and `@vendoai/vendo/mastra`
 agents. See [Use with your existing agent](/existing-agents) and the
 [server API reference](/reference/server-api#byo-agent-subpaths).
 
-## Agent context
+## Turn context
 
-Pass an `agent` block to tune what the chat loop sends to the model. All
-fields are optional.
+Two owners, and the split is the point. What the deployment CURATES — the
+prose, the tool surface, the size of a tool result — is composition's, and sits
+at the top level. What the THINKER decides — how many steps it may take, how
+much history it re-reads, how many tokens it may emit — belongs to whoever
+thinks, and is set where the thinker is named. There is no `agent: { … }`
+options object: it was one bag holding both, so a host configured the thinker
+through a key the thinker never saw.
 
 ```ts
 createVendo({
   principal,
-  agent: {
-    instructions: "Answer in the product's voice; never invent account numbers.",
-    toolOutputCap: 32_000, // char cap per tool result before it reaches the model; 0 disables
+  instructions: "Answer in the product's voice; never invent account numbers.",
+  toolOutputCap: 32_000,  // char cap per tool result before it reaches the model; 0 disables
+  maxInitialTools: 128,   // cap on host tools shown to the model at turn start; the rest stay discoverable via search
+  loadout: ["issues_list", "issues_create"], // explicit initial host tools; overrides the default policy
+  harness: vendo({
+    maxSteps: 20,         // max agent steps per turn before Vendo stops the loop
+    historyWindow: 20,    // last N whole messages re-sent per turn; omit to send the full thread
     maxOutputTokens: 4_000, // upper bound on tokens the model may emit per turn
-    historyWindow: 20,      // last N whole messages re-sent per turn; omit to send the full thread
-    maxInitialTools: 128,   // cap on host tools shown to the model at turn start; the rest stay discoverable via search
-    loadout: ["issues_list", "issues_create"], // explicit initial host tools; overrides the default policy
-    maxSteps: 20,           // max agent steps per turn before Vendo stops the loop
-  },
+  }),
 });
 ```
 
-- `instructions` is the host's voice and standing guidance, appended to the
-  agent's system prompt every turn: tone, formatting, what to emphasize.
+- `instructions` is the deployment's prose — what this product is, who uses it,
+  the house voice, what to emphasize — placed in the assembled prompt's Product
+  section every turn. It is the programmatic override for `.vendo/brief.md`,
+  which is what `vendo init` writes and most deployments use instead.
   Policy belongs in guard directions, not here.
 - `toolOutputCap` caps a single tool result before it reaches the model, so a
   runaway host response can't blow the context window. Defaults to `32000`
   characters. Pass `0` to disable the cap. Persistence and the streamed
   thread are unaffected; only the copy sent to the model is truncated.
-- `maxOutputTokens` bounds tokens the model may emit per turn. Omit to defer
-  to the model default.
-- `historyWindow` bounds how many past messages are re-sent to the model
-  each turn. Vendo keeps whole messages so tool-call/result pairs stay
-  paired. Omit to send the full thread (current behavior). The stored
-  thread is untouched; only the per-turn model context shrinks.
 - `maxInitialTools` bounds how many host tools the model sees at the start
   of a turn. Hosts that expose hundreds of tools would otherwise flood the
   model's context. When the enabled host surface exceeds the cap, Vendo
@@ -111,11 +112,24 @@ createVendo({
   Anything omitted from the list is still discoverable via
   `find_tools`. Every tool, initial or searched-in, still
   executes through the same guard binding.
+The thinker's own knobs ride `vendo({ … })` (import it from
+`@vendoai/vendo/server`):
+
 - `maxSteps` caps how many agent steps (model call + tool round-trip) run in
   a single turn. Defaults to `20`. When the cap is hit, Vendo stops the loop
   and emits a step-limit notice on the stream so the client can render a
   visible signal; the thread stays consistent and the user can send another
   message to continue. Raise it for long tool chains; lower it to fail fast.
+- `historyWindow` bounds how many past messages are re-sent to the model
+  each turn. Vendo keeps whole messages so tool-call/result pairs stay
+  paired. Omit to send the full thread. The stored thread is untouched; only
+  the per-turn model context shrinks.
+- `maxOutputTokens` bounds tokens the model may emit per turn. Omit to defer
+  to the model default.
+- `contextTokenBudget` bounds the assembled context the loop sends.
+
+A harness you named yourself carries its own equivalents; these three are
+`vendo()`'s.
 
 ## Turn cancellation
 

--- a/docs/archive/config-migration-table.md
+++ b/docs/archive/config-migration-table.md
@@ -69,19 +69,17 @@ truth about the code as it stands.
 | `skills` | **slot** `skills` | added by the pack removal: SKILL.md values mounted at `/host/skills`, where a pack's `skills` slot used to land |
 | `catalog` | **pack option** (`apps()`'s `components`, build contract §5) | unchanged. Host components are the apps pack's input, but they also feed `<VendoRoot>` on the client, so the top-level key is what a host writes once and passes both ways |
 | `theme` | **adapter family** (deployment identity) | unchanged. Not generation-only — the chrome, the client and the prompt summary all read it |
-| `brief` | **adapter family** (deployment identity) | unchanged; the prose `.vendo/brief.md` carries, programmatically |
+| `instructions` | **adapter family** (deployment identity) | RENAMED from `brief`, and merged with `agent.instructions` — one prose key. Still the programmatic override for `.vendo/brief.md`, still the prompt's Product section |
 | `store` | **slot** `store` | unchanged |
 | `files` | **slot** `files` | unchanged. Unset is a documented default, not a gap: blobs live in the store to `FILES_STORE_MAX_BYTES` and the first over-cap write names this key |
 | `sandbox` | **slot** `sandbox` | unchanged |
 | `harness` | **slot** `harness` | unchanged. Unset now means a composed `vendo()` that actually SERVES the chat route (wave-2 flip), not a door nobody reaches |
 | `knowledge` | **adapter family** (`KnowledgeAdapter`) | unchanged. A candidate for a `knowledge()` pack once packs carry adapters; today a pack cannot contribute one |
-| `connectors` | **adapter family** (tool sources) | unchanged |
-| `connectorApps` | **adapter family** (scopes the auto-composed Cloud connector) | unchanged. A modifier of `connectors`, ignored when `connectors`/`connections` is explicit |
+| `connectors` | **adapter family** (tool sources) | widened to `readonly (string \| Connector)[]`: a string names a Cloud toolkit, an object is a provider, mixed freely. `connectorApps` folded into it and is gone |
 | `connections` | **adapter family** (`ConnectionsService`) | unchanged |
 | `actAs` | **adapter family** (`auth`'s per-seam escape hatch) | unchanged; see `principal` |
 | `serverActions` | **venue plumbing** (the generated wiring file's registration map) | unchanged. Emitted by codegen, not hand-written |
-| `policy` | **adapter family** (the guard) | unchanged. The guard is ours, not a pack's, and §14 keeps policy a platform concern |
-| `judge` | **adapter family** (the guard's judgment channel) | unchanged. Note: the JUDGE MODEL is `models.judge`; this key is the judge implementation |
+| `guard` | **slot** `guard` | NEW spelling of the guard seam: `guard({ policy, judge, approvals })` or a built `VendoGuard`. `policy`, `judge` and `approvals` folded into it and are gone. The JUDGE MODEL is still `models.judge`; `guard({ judge })` is the judge implementation |
 | `secrets` | **adapter family** (`SecretsProvider`) | unchanged |
 | `telemetry` | **venue plumbing** | unchanged; a boolean switch on build/dev telemetry |
 | `development` | **venue plumbing** (dev-only source capture) | unchanged |
@@ -90,21 +88,39 @@ truth about the code as it stands.
 | `profile` | **venue plumbing** (the `.vendo/` pieces as in-memory compose inputs) | `profile.tools` **deprecated** → the `tools:` slot; the other pieces (`overrides`, `theme`, `brief`, `catalog`, `policy`, `designRules`) unchanged |
 | `mcp` | **adapter family** (the MCP door) | unchanged |
 | `oauth` | **adapter family** (`auth`'s per-seam escape hatch) | unchanged; see `principal` |
-| `agent` | **harness option** → `vendo({ … })` | unchanged, and NOT movable in wave 2: `instructions`, `toolOutputCap`, `maxOutputTokens`, `historyWindow`, `maxInitialTools`, `loadout`, `maxSearchExpansions`, `maxSteps` are chat-loop knobs, and `vendo()` today declares only `model` and `maxSteps`. Widening its options is a `packages/harnesses/src/vendo.ts` change this lane does not own — see the lane report |
+| `agent` | **slot** `agent` (the composed-agent seam) | narrowed to `ComposedAgent` — the whole agent `agent()` builds. The knobs bag is gone: `instructions` became the top-level key, `toolOutputCap`/`maxInitialTools`/`loadout` became top-level composition keys, and `maxSteps`/`historyWindow`/`maxOutputTokens` became `vendo()` deps (they configure the thinker, and `vendo()` already declares all three) |
 | `sessions` | **venue plumbing** (ephemeral session lifecycle) | unchanged |
-| `approvals` | **adapter family** (the guard's approval lifecycle) | unchanged |
+| `toolOutputCap` | **venue plumbing** (how much of a tool result reaches the model) | moved up from `agent.toolOutputCap`. Composition's, not the thinker's: the same number bounds the agent loop, the harness bridge, and the connector-discovery registry's own search results |
+| `maxInitialTools` | **venue plumbing** (the discovery rail's initial-loadout cap) | moved up from `agent.maxInitialTools`. The rail is built here and handed to BOTH thinkers, so the knob stays on the composition |
+| `loadout` | **venue plumbing** (the discovery rail's curated loadout) | moved up from `agent.loadout`; same rail, same reason |
 | `apps` | **pack option** → `apps({ … })` | unchanged. `designRules`, `fillConcurrency`, `checks`, `pipeline` are generation options; `experimentalMachines` / `experimentalServedApps` are project-level opt-ins. Deliberately NOT given a second spelling in wave 2: `apps: {…}` works, no host asked for `apps({…})`, and two spellings for one thing is the cost, not the feature |
 | `automations` | **subsystem switch** | added by the pack removal: `false` unmounts automations (routes, `emit`, and its judgment rule). `packs` is gone with the same change — capability arrives on `tools`, `skills`, `apps.checks` and `catalog` |
 | `tours` | **venue plumbing** (tour mode's scripted-turn seam) | unchanged. Plain OSS config, arrived on main after this table was written (#713): an ordered list of `{ prompt, respond }` entries replayed in front of the live agent. It composes the agent's `scripted` hook and nothing else, so it has no slot to move into |
 
 ## Deleted keys
 
-**None.** Every one of the 33 has a live consumer, and the contract permits
-deletion only with zero consumers stated. Nothing qualified.
+Wave 2 deleted none. The config-coherence change (2026-08-05) deletes five
+top-level keys and one options object, each folded into a key that already had
+to exist — no capability is lost, and every one has a stated replacement:
+
+- **brief** → `instructions` (one prose key; `.vendo/brief.md` still backs it)
+- **policy** → `guard({ policy })`
+- **judge** → `guard({ judge })`
+- **approvals** → `guard({ approvals })`
+- **connectorApps** → a toolkit string inside `connectors`
+- **agent.instructions** → `instructions`
+- **agent.toolOutputCap** → `toolOutputCap`
+- **agent.maxInitialTools** → `maxInitialTools`
+- **agent.loadout** → `loadout`
+- **agent.maxSteps / historyWindow / maxOutputTokens** → `harness: vendo({ … })`
+
+`createVendo` refuses to compose against any of them, naming the replacement
+(`rejectRemovedConfigKeys`), so a JavaScript host cannot lose its policy
+silently.
 
 ## What a host has to change
 
-Nothing, this minor. Three warnings appear for hosts on the old spellings:
+Three warnings appear for hosts on the deprecated spellings:
 
 ```
 [vendo] `model` is deprecated: use `models: { default }`. …
@@ -113,4 +129,5 @@ Nothing, this minor. Three warnings appear for hosts on the old spellings:
 ```
 
 Each names its destination, because a warning that does not say where to go is a
-warning a host cannot act on.
+warning a host cannot act on. The deleted keys above throw instead of warning:
+they no longer work at all, and a silent drop would change a security posture.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -126,7 +126,7 @@ hand-write one.
 // app/api/vendo/[...vendo]/route.ts — equivalent to what `vendo init` scaffolds
 // (init writes a relative registry import; the `@/*` alias reads better here)
 import { authJs } from "@vendoai/vendo/auth/auth-js";
-import { createVendo, nextVendoHandler } from "@vendoai/vendo/server";
+import { createVendo, guard, nextVendoHandler } from "@vendoai/vendo/server";
 import { registry } from "@/vendo/registry";
 
 const vendo = createVendo({
@@ -135,7 +135,7 @@ const vendo = createVendo({
   // hatch: docs/act-as-presets.md.
   auth: authJs(),
   catalog: registry,
-  policy: {}, // .vendo/policy.json: destructive asks, reads run
+  guard: guard({ policy: {} }), // .vendo/policy.json: destructive asks, reads run
 });
 
 export const { GET, POST, PUT, PATCH, DELETE } = nextVendoHandler(vendo);
@@ -152,7 +152,7 @@ const vendo = createVendo({
   models: { agent: "claude-sonnet-4-6" },
   auth: authJs(),
   catalog: registry,
-  policy: {},
+  guard: guard({ policy: {} }),
 });
 ```
 
@@ -175,17 +175,19 @@ Every key is optional — `createVendo({})` legitimately boots, with an
 env-resolved model, anonymous ephemeral sessions, and PGlite persistence. (The
 config object itself is required: `createVendo()` with no argument does not
 typecheck and throws at runtime.)
-The `policy: {}` line activates the `.vendo/policy.json` file init wrote, so
-the scaffolded default posture is: destructive tools ask, reads run. Remove
-the `policy` key entirely and every call auto-runs (audited, with the
-unconfigured-policy notice in shipped chrome). The default file is read
-fail-soft: deleting `.vendo/policy.json` while keeping `policy: {}` also
-auto-runs, silently and without the notice — keep the file in version
-control; it is part of your security posture. Named presets replace the
-file: `"cautious"` asks before write/destructive calls and runs reads,
-`"readonly"` runs reads and blocks everything else, and `"autopilot"` runs
-everything. Inline `{ rules }` and the explicit `{ file }` form cover
-anything a preset doesn't.
+The `guard: guard({ policy: {} })` line activates the `.vendo/policy.json`
+file init wrote, so the scaffolded default posture is: destructive tools ask,
+reads run. `guard()` is the one place a deployment's rules live — policy, an
+optional judge, and the approval lifecycle — and this composition completes it
+with the store and the risk grading. Remove the `guard` key entirely and every
+call auto-runs (audited, with the unconfigured-policy notice in shipped
+chrome). The default file is read fail-soft: deleting `.vendo/policy.json`
+while keeping `guard({ policy: {} })` also auto-runs, silently and without the
+notice — keep the file in version control; it is part of your security posture.
+Named presets replace the file: `"cautious"` asks before write/destructive
+calls and runs reads, `"readonly"` runs reads and blocks everything else, and
+`"autopilot"` runs everything. Inline `{ rules }` and the explicit `{ file }`
+form cover anything a preset doesn't.
 
 Prefer a separate `vendo/server.ts` (exporting the same `createVendo`
 result) when code outside the route needs the `vendo` object — `vendo.emit`
@@ -376,9 +378,9 @@ VENDO_BASE_URL=https://app.example.com
 ```
 
 Every call passes through the guard. The scaffolded composition passes
-`policy: {}`, which reads `.vendo/policy.json`: destructive tools ask, reads
-run. A composition with no `policy` key at all auto-runs every call (audited),
-and shipped chrome displays the unconfigured-policy notice.
+`guard: guard({ policy: {} })`, which reads `.vendo/policy.json`: destructive
+tools ask, reads run. A composition with no `guard` key at all auto-runs every
+call (audited), and shipped chrome displays the unconfigured-policy notice.
 
 ## What works without more configuration
 
@@ -440,13 +442,13 @@ compiled against the real `CreateVendoConfig` in
 import type {
   ActAs, ActionsRegistry, AppsRuntime, AutomationsEngine, CatalogFile,
   ComponentCatalog, ComponentRegistry, Connector, ExtractedTool, FilesAdapter,
-  Harness, HostOAuthAdapter, Json, Judge, KnowledgeAdapter, OverridesFile,
-  PolicyConfig, PolicyFile, Principal, RunContext, RunId,
+  Harness, HostOAuthAdapter, Json, KnowledgeAdapter, OverridesFile,
+  PolicyFile, Principal, RunContext, RunId,
   SandboxAdapter, SecretsProvider, Skill, ToolDefinition, ToolRegistry,
   VendoAgent, VendoGuard, VendoStore, VendoTheme,
 } from "@vendoai/vendo";
 import type {
-  AgentOptions, AppsConfig, ComposedAgent, ConnectionsService, HarnessTurns,
+  AppsConfig, ComposedAgent, ConnectionsService, GuardRules, HarnessTurns,
   HostAuthPreset, ModelsConfig, ServerActionHandler, TourEntry,
 } from "@vendoai/vendo/server";
 import type { LanguageModel } from "ai";
@@ -463,19 +465,17 @@ export interface CreateVendoConfig {
   skills?: readonly Skill[];  // SKILL.md values mounted at /host/skills
   catalog?: ComponentCatalog | ComponentRegistry;          // registry.tsx, or the array form
   theme?: VendoTheme;         // programmatic override for .vendo/theme.json
-  brief?: string;             // programmatic override for .vendo/brief.md
+  instructions?: string;      // THE prose knob; programmatic override for .vendo/brief.md
   store?: VendoStore;
   files?: FilesAdapter;       // workspace file content; unset → blobs in the store, 5 MiB cap
   sandbox?: SandboxAdapter;
   harness?: Harness<never>;   // WHO THINKS. unset → vendo(). also: claudeCode()
   knowledge?: KnowledgeAdapter; // unset → no vendo_knowledge_search tool
-  connectors?: Connector[];
-  connectorApps?: string[];   // toolkit scope for the auto-composed Cloud connector
+  connectors?: readonly (string | Connector)[]; // a string names a Cloud toolkit; an object is a provider
   connections?: ConnectionsService; // explicit connections adapter; always wins over defaults
   actAs?: ActAs;              // escape hatch
   serverActions?: Record<string, ServerActionHandler>; // the generated vendo-actions.ts map
-  policy?: PolicyConfig;      // "cautious" | "readonly" | "autopilot" | { file } | { rules }
-  judge?: Judge;
+  guard?: VendoGuard | GuardRules; // guard({ policy, judge, approvals }), or a built guard
   secrets?: SecretsProvider;
   telemetry?: boolean;
   development?: boolean;    // dev-only injection seams
@@ -496,9 +496,11 @@ export interface CreateVendoConfig {
     federation?: { secret: string };
   };
   oauth?: HostOAuthAdapter;   // escape hatch; required when `mcp` is true and `auth` is absent
-  agent?: AgentOptions | ComposedAgent; // the chat knobs, OR a whole agent() from @vendoai/agents
+  agent?: ComposedAgent;      // a whole agent() from @vendoai/agents, adopted by this deployment
   sessions?: { ttlMs?: number; sweepIntervalMs?: number; now?: () => number };
-  approvals?: { parkedCallTtlMs?: number };
+  toolOutputCap?: number;     // how much of one tool result reaches the model; 0 disables
+  maxInitialTools?: number;   // cap on the uncurated initial loadout; the rest via find_tools
+  loadout?: readonly string[]; // the curated initial loadout, by tool name
   apps?: false | {            // false unmounts app generation: no tools, skill or /apps routes
     review?: {                // review-kind remixes: who may review (queue/reject/approve)
       reviewer?(ctx: RunContext): boolean | Promise<boolean>;

--- a/examples/ai-sdk-agent/e2e/byo-agent.e2e.test.ts
+++ b/examples/ai-sdk-agent/e2e/byo-agent.e2e.test.ts
@@ -8,7 +8,7 @@ import {
 } from "@vendoai/core";
 import { createStore } from "@vendoai/store";
 import { vendoTools } from "@vendoai/vendo/ai-sdk";
-import { createVendo, type Vendo } from "@vendoai/vendo/server";
+import { createVendo, guard, type Vendo } from "@vendoai/vendo/server";
 import {
   convertToModelMessages,
   stepCountIs,
@@ -112,7 +112,7 @@ async function compose(): Promise<Vendo> {
   return createVendo({
     model: generationModel(),
     principal: async () => demoUser,
-    policy: "cautious",
+    guard: guard({ policy: "cautious" }),
     store,
     serverActions: {
       "lib/vendo.ts#getWeather": getWeather,

--- a/examples/ai-sdk-agent/e2e/cloud-posture.e2e.test.ts
+++ b/examples/ai-sdk-agent/e2e/cloud-posture.e2e.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createStore } from "@vendoai/store";
 import { vendoTools } from "@vendoai/vendo/ai-sdk";
-import { createVendo, type Vendo } from "@vendoai/vendo/server";
+import { createVendo, guard, type Vendo } from "@vendoai/vendo/server";
 import {
   convertToModelMessages,
   stepCountIs,
@@ -175,7 +175,7 @@ describe.skipIf(!LIVE)("examples/ai-sdk-agent — full Vendo Cloud posture (VEND
     // VENDO_API_KEY defaults the lot.
     const vendo = createVendo({
       principal: async () => demoUser,
-      policy: "cautious",
+      guard: guard({ policy: "cautious" }),
       serverActions,
     });
     await vendo.store.ensureSchema();
@@ -214,7 +214,7 @@ describe.skipIf(!LIVE)("examples/ai-sdk-agent — full Vendo Cloud posture (VEND
         model: explicitGenerationModel(),
         store,
         principal: async () => demoUser,
-        policy: "cautious",
+        guard: guard({ policy: "cautious" }),
         serverActions,
       });
       const report = await status(vendo);

--- a/examples/ai-sdk-agent/lib/vendo.ts
+++ b/examples/ai-sdk-agent/lib/vendo.ts
@@ -3,7 +3,7 @@
 // descriptors (name, schema, risk) live in `.vendo/tools.json`, exactly where
 // `vendo init` extracts them in a real app.
 import { anthropic } from "@ai-sdk/anthropic";
-import { createVendo } from "@vendoai/vendo/server";
+import { createVendo, guard } from "@vendoai/vendo/server";
 
 /** The quickstart's weather lookup, registered as a Vendo action
  *  (`host_get_weather`, risk `read` — the cautious policy runs it and audits
@@ -44,7 +44,7 @@ export const vendo = createVendo({
   principal: async () => demoUser,
   // Ask before write/destructive actions, run reads: the gate that turns
   // `host_send_trip_report` into an approval card in your own chat.
-  policy: "cautious",
+  guard: guard({ policy: "cautious" }),
   // In-process dispatch for the two actions declared in .vendo/tools.json.
   serverActions: {
     "lib/vendo.ts#getWeather": getWeather,

--- a/examples/demo-bank/src/vendo/server.ts
+++ b/examples/demo-bank/src/vendo/server.ts
@@ -3,7 +3,7 @@ import { memoryKnowledgeAdapter } from "@vendoai/core/conformance";
 import { vendoAutoJudge } from "@vendoai/guard";
 import { createStore } from "@vendoai/store";
 import { authJs } from "@vendoai/vendo/auth/auth-js";
-import { createVendo, vendoModel } from "@vendoai/vendo/server";
+import { createVendo, guard, vendoModel } from "@vendoai/vendo/server";
 import { authSecret, primaryMapleUser, resolveMaplePerson, resolveMapleSubject } from "@/server/users";
 import { mapleKnowledgeDocs } from "./knowledge";
 import { mapleMcpConfig } from "./mcp-config";
@@ -80,20 +80,14 @@ export const vendo = createVendo({
   // The shared registry (01 §14): the server reads only the data fields;
   // <VendoRoot> takes the same object and reads only component references.
   catalog: mapleRegistry,
-  // Guard auto-judge on unconditionally (demo-refresh Part 2): run/ask/block
-  // rulings on tool calls ride the vendo model family's judge lane —
-  // vendo-judge on the Cloud gateway, the provider's fast pick on BYO rungs.
-  judge: vendoAutoJudge({ model: vendoModel("vendo-judge") }),
-  // The Maple voice (03 §3 agent.instructions) — rides the agent prompt every turn.
-  agent: {
-    instructions: [
-      "You are Maple's money assistant. Speak calmly and plainly; no hype.",
-      "No emojis, ever — not in prose, not in generated UI text.",
-      "Format money as currency (e.g. $1,234.56), never raw cents.",
-      "When you render a view, let it carry the data — don't restate it in prose.",
-      "For a recurring or scheduled payment/task, use vendo_make — describe the schedule in the request; the automation is armed automatically. There is no separate automations tool.",
-    ].join("\n"),
-  },
+  // The Maple voice (03 §3) — rides the agent prompt every turn.
+  instructions: [
+    "You are Maple's money assistant. Speak calmly and plainly; no hype.",
+    "No emojis, ever — not in prose, not in generated UI text.",
+    "Format money as currency (e.g. $1,234.56), never raw cents.",
+    "When you render a view, let it carry the data — don't restate it in prose.",
+    "For a recurring or scheduled payment/task, use vendo_make — describe the schedule in the request; the automation is armed automatically. There is no separate automations tool.",
+  ].join("\n"),
   // Machine-backed execution (layers 2 and 3) is gated by the `sandbox` slot
   // above and nothing else: configure one and Maple can build boxes, leave it
   // out and it cannot. There is no flag here to flip.
@@ -117,7 +111,14 @@ export const vendo = createVendo({
   // Maple's own help-center corpus so citation chips and refusal still demo
   // with no account. The host never constructs a Cloud client itself.
   ...(process.env.VENDO_API_KEY ? {} : { knowledge: memoryKnowledgeAdapter({ docs: mapleKnowledgeDocs }) }),
-  policy: { file: ".vendo/policy.json" },
+  // The deployment's rules, in one value. Guard auto-judge on unconditionally
+  // (demo-refresh Part 2): run/ask/block rulings on tool calls ride the vendo
+  // model family's judge lane — vendo-judge on the Cloud gateway, the
+  // provider's fast pick on BYO rungs.
+  guard: guard({
+    policy: { file: ".vendo/policy.json" },
+    judge: vendoAutoJudge({ model: vendoModel("vendo-judge") }),
+  }),
   mcp: mapleMcpConfig(),
   // BYO Composio when Maple brings its own key; otherwise the slot stays
   // UNSET so a VENDO_API_KEY deployment composes the Cloud tools connector

--- a/examples/mastra-agent/src/lib/vendo.ts
+++ b/examples/mastra-agent/src/lib/vendo.ts
@@ -4,7 +4,7 @@
 // Action descriptors (name, schema, risk) live in `.vendo/tools.json`, exactly
 // where `vendo init` extracts them in a real app.
 import type { Principal } from "@vendoai/core";
-import { createVendo, type Vendo } from "@vendoai/vendo/server";
+import { createVendo, guard, type Vendo } from "@vendoai/vendo/server";
 import { getWeather, sendTripReport } from "./vendo-actions";
 
 /** The demo runs as one fixed user. A real host resolves the principal from
@@ -16,7 +16,7 @@ export function composeVendo(overrides?: Parameters<typeof createVendo>[0]): Ven
     principal: async () => DEMO_PRINCIPAL,
     // "cautious" runs reads and asks before write/destructive calls — that is
     // what parks vendo_send_trip_report on the approval embed in the demo.
-    policy: "cautious",
+    guard: guard({ policy: "cautious" }),
     // The registration map for .vendo/tools.json's server-action bindings.
     serverActions: {
       "src/lib/vendo-actions.ts#getWeather": getWeather,

--- a/fixtures/integration-browser/e2e/harness/backends.ts
+++ b/fixtures/integration-browser/e2e/harness/backends.ts
@@ -173,7 +173,7 @@ export async function startBackends(): Promise<Backends> {
     },
     store,
     actAs: async (principal: Principal) => ({ headers: { cookie: await loginCookie(principal.subject) } }),
-    policy: { file: ".vendo/policy.json" },
+    guard: { policy: { file: ".vendo/policy.json" } },
     connectors: [composioConnector({ apiKey: "stub-key", apps: ["gmail"], baseUrl: composioStub.url })],
     mcp: { baseUrl: wireUrl },
     oauth: {

--- a/fixtures/integration/src/harness.ts
+++ b/fixtures/integration/src/harness.ts
@@ -303,7 +303,7 @@ export async function createStack(options: StackOptions = {}): Promise<Stack> {
     },
     store,
     actAs: fixtureActAs,
-    policy: { file: ".vendo/policy.json" },
+    guard: { policy: { file: ".vendo/policy.json" } },
     ...(options.telemetry === true ? { telemetry: true } : {}),
     ...(options.connectors === undefined ? {} : { connectors: options.connectors }),
     // A configured sandbox IS the opt-in to machine-backed execution; a stack

--- a/fixtures/mcp-e2e/src/knowledge-governance.e2e.test.ts
+++ b/fixtures/mcp-e2e/src/knowledge-governance.e2e.test.ts
@@ -54,11 +54,13 @@ async function createKnowledgeUmbrella(): Promise<Umbrella> {
     // The shipped read posture: the call RUNS at the door, so the leg proves
     // zero leakage on execution (init's vendo_knowledge_* → ask hardening is
     // its own test in packages/vendo/src/cli/init.test.ts).
-    policy: {
-      rules: [
-        { match: { risk: "destructive" }, action: "ask" },
-        { match: { risk: "read" }, action: "run" },
-      ],
+    guard: {
+      policy: {
+        rules: [
+          { match: { risk: "destructive" }, action: "ask" },
+          { match: { risk: "read" }, action: "run" },
+        ],
+      },
     },
     oauth,
     knowledge: memoryKnowledgeAdapter({

--- a/fixtures/mcp-e2e/src/umbrella-hookup.e2e.test.ts
+++ b/fixtures/mcp-e2e/src/umbrella-hookup.e2e.test.ts
@@ -109,12 +109,14 @@ async function createUmbrella(
     store,
     // The shipped posture (05 §3): reads run, destructive asks. venue="mcp" gets
     // the identical treatment chat does (10-mcp §2) — no weaker door perimeter.
-    policy: {
-      rules: [
-        { match: { risk: "destructive" }, action: "ask" },
-        { match: { risk: "read" }, action: "run" },
-        { match: { risk: "write" }, action: "run" },
-      ],
+    guard: {
+      policy: {
+        rules: [
+          { match: { risk: "destructive" }, action: "ask" },
+          { match: { risk: "read" }, action: "run" },
+          { match: { risk: "write" }, action: "run" },
+        ],
+      },
     },
     oauth,
     ...(options.withActAs === false ? {} : { actAs }),

--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -13,7 +13,7 @@ import {
   type Skill,
   type ToolRegistry,
 } from "@vendoai/core";
-import { createGuard, type VendoGuard } from "@vendoai/guard";
+import { createGuard, isGuardInstance, type GuardRules, type VendoGuard } from "@vendoai/guard";
 import { provideHarnessAdapters } from "@vendoai/harnesses";
 import { createStore, storeFiles, type VendoStore } from "@vendoai/store";
 import { randomUUID } from "node:crypto";
@@ -31,8 +31,10 @@ export interface AgentConfig {
   harness: Harness<unknown>;
   tools?: readonly ToolSource[];
   mcp?: readonly McpServerConfig[];
-  /** Always an instance; unset → default `createGuard({ store })`. */
-  guard?: VendoGuard;
+  /** A built guard, or the rules for one — `guard({ policy, judge, approvals })`,
+   *  which this composition completes with its own store. An instance always
+   *  wins verbatim; unset → default `createGuard({ store })`. */
+  guard?: VendoGuard | GuardRules;
   /** Skill folders, boot-loaded; deploy = update the folder. */
   skills?: readonly string[];
   /** Agent-level outbound allowlist; unset = the harness's minimum. */
@@ -204,7 +206,11 @@ export function agent(config: AgentConfig): VendoAgent {
 
   const store = config.store ?? defaultStore();
   const files = storeBlobs.get(store) ?? storeFiles(store);
-  const guard = config.guard ?? createGuard({ store });
+  // One constructor either way: an instance is taken verbatim, rules are
+  // completed with this composition's store.
+  const guard = isGuardInstance(config.guard)
+    ? config.guard
+    : createGuard({ store, ...config.guard });
   const tools = mergeSources(config.tools ?? [], config.mcp ?? []);
   const bound = guard.bind(tools);
   const skills: Skill[] = loadSkillFolders(config.skills);

--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -46,6 +46,26 @@ import type {
   VendoGuard,
 } from "./types.js";
 
+/** A BYO loop has no turn-driven abandonment sweep, so an orphaned approval
+ *  card in a foreign chat expires on time instead: generous enough to walk away
+ *  and come back, bounded enough that stale writes can't be approved days
+ *  later. */
+const DEFAULT_PARKED_CALL_TTL_MS = 60 * 60_000;
+
+/** `0` (the documented off switch) and any other non-negative integer only —
+ *  validated HERE so both entry points, `guard({ approvals })` and a direct
+ *  `createGuard`, refuse the same typo the same way. */
+function resolveParkedCallTtlMs(configured: number | undefined): number {
+  const ttlMs = configured ?? DEFAULT_PARKED_CALL_TTL_MS;
+  if (!Number.isInteger(ttlMs) || ttlMs < 0) {
+    throw new VendoError(
+      "validation",
+      "guard approvals.parkedCallTtlMs must be a non-negative integer (0 disables parked-call expiry)",
+    );
+  }
+  return ttlMs;
+}
+
 const GRANTS_COLLECTION = "vendo_grants";
 const APPROVALS_COLLECTION = "vendo_approvals";
 /** One-time transition receipts for approvals (kill-list B5): `decided:<id>` /
@@ -394,6 +414,7 @@ class GuardImplementation implements VendoGuard {
   readonly #approvalRequestedCallbacks = new Set<(request: ApprovalRequest) => void>();
 
   readonly approvals = {
+    parkedCallTtlMs: DEFAULT_PARKED_CALL_TTL_MS,
     pending: (principal: Principal): Promise<ApprovalRequest[]> =>
       this.#pendingApprovals(principal),
     decide: (
@@ -427,6 +448,7 @@ class GuardImplementation implements VendoGuard {
     this.#policy = new PolicyResolver(this.#policyConfig, config.policyCloudFallback);
     this.#maxCallsPerMinute = config.breakers?.maxCallsPerMinute ?? 60;
     this.#maxWritesPerRun = config.breakers?.maxWritesPerRun ?? 20;
+    this.approvals.parkedCallTtlMs = resolveParkedCallTtlMs(config.approvals?.parkedCallTtlMs);
   }
 
   async check(

--- a/packages/guard/src/index.ts
+++ b/packages/guard/src/index.ts
@@ -1,5 +1,9 @@
 /** @vendoai/guard — policy, approvals, audit, safety (docs/contracts/05-guard.md). */
 export { createGuard } from "./guard.js";
+// The late-bound rules value (`guard({ policy, judge, approvals })`) and the
+// discriminator every consumer of a `VendoGuard | GuardRules` slot needs.
+// `createGuard` stays the one constructor both arms end at.
+export { guard, isGuardInstance } from "./spec.js";
 export { vendoAutoJudge } from "./judge.js";
 // Preset expansion (00-overview decision 8): exported so a caller that needs
 // a preset's ACTUAL rules outside a live guard instance (the try venue's
@@ -20,6 +24,7 @@ export { parseOrgPolicyFile } from "./org-policy.js";
 // package.
 export type { GuardLike } from "@vendoai/core";
 export type {
+  GuardRules,
   Judge,
   PolicyConfig,
   PolicyConfigObject,

--- a/packages/guard/src/spec.ts
+++ b/packages/guard/src/spec.ts
@@ -1,0 +1,30 @@
+/**
+ * `guard(rules)` — the host's rules, declared standalone and completed by
+ * whoever composes them.
+ *
+ * The same shape `vendo()` and `agent()` already use: a value a host writes at
+ * boot, carrying only what a HOST can decide (policy, judge, approval
+ * lifecycle) and none of the plumbing only a composition can supply (the store,
+ * the risk resolver, the org-policy reader, the cloud policy fallback). The
+ * venue finishes it through {@link createGuard} — the one and only constructor,
+ * for both this path and a host that calls it directly.
+ *
+ * Like `defineHarness`, the function is identity: it exists for the authoring
+ * vocabulary and the type inference, not for behaviour. `guard: { policy: … }`
+ * is the same value.
+ */
+import type { GuardRules, VendoGuard } from "./types.js";
+
+export function guard(rules: GuardRules = {}): GuardRules {
+  return rules;
+}
+
+/**
+ * Which arm of a `VendoGuard | GuardRules` slot this is. `bind` is the method
+ * every guard implementation must have (it is how the one choke point is wired)
+ * and no rules object can plausibly carry, so it is the honest discriminator —
+ * the same test `isComposedAgent` makes on `session`.
+ */
+export const isGuardInstance = (
+  value: VendoGuard | GuardRules | undefined,
+): value is VendoGuard => typeof (value as VendoGuard | undefined)?.bind === "function";

--- a/packages/guard/src/types.ts
+++ b/packages/guard/src/types.ts
@@ -113,6 +113,13 @@ export interface VendoGuard extends Guard {
   onApprovalRequested(cb: (request: ApprovalRequest) => void): () => void;
 
   approvals: {
+    /** The resolved parked-approval TTL, in ms (`0` disables expiry). The
+     *  guard holds it because it is the guard's own lifecycle number — both
+     *  sweeps that read it (`sweepExpiredApprovals` here, and the umbrella's
+     *  BYO parked-call sweep) are sweeping approvals this guard minted — so a
+     *  host that passes a built instance keeps the knob instead of losing it
+     *  with the rules that came in beside it. */
+    parkedCallTtlMs: number;
     pending(principal: Principal): Promise<ApprovalRequest[]>;
     decide(
       ids: ApprovalId | ApprovalId[],
@@ -165,10 +172,34 @@ export interface VendoGuard extends Guard {
   };
 }
 
-export interface CreateGuardConfig {
+/**
+ * The host's RULES for a guard — everything a deployment decides, with none of
+ * the plumbing (the store, the risk resolver, the org-policy reader) that only
+ * a composition can supply. This is what {@link guard} carries and what
+ * `createVendo({ guard })` / `agent({ guard })` accept beside a built
+ * {@link VendoGuard}: the spec form is completed by whoever composes it,
+ * through `createGuard` — the one constructor — and an instance always wins
+ * verbatim.
+ */
+export interface GuardRules {
+  policy?: PolicyConfig;
+  judge?: Judge;
+  /** Approval lifecycle. `parkedCallTtlMs` is the idle timeout for a pending
+   *  approval — a guarded call parked from a BYO agent loop (a
+   *  `vendo/approval-ref@1` envelope with no thread to resume through), and the
+   *  general TTL backstop over stranded away/automation approvals. Past it the
+   *  sweep denies through the existing abandonment semantics and
+   *  `<VendoApprovalEmbed>` reads "expired". Default 60 min; `0` disables
+   *  expiry. Vendo-thread approvals are untouched — their abandonment stays
+   *  turn-driven (AGENT-6). */
+  approvals?: {
+    parkedCallTtlMs?: number;
+  };
+}
+
+export interface CreateGuardConfig extends GuardRules {
   store: StoreAdapter;
   resolveRisk?: RiskResolver;
-  policy?: PolicyConfig;
   /** cse lane 3 — a source for a cloud-published policy.json body, consulted
    *  by the PolicyResolver STRICTLY AFTER the local file and only when policy
    *  is already configured (opt-in). The umbrella backs it with the hosted
@@ -181,7 +212,6 @@ export interface CreateGuardConfig {
    *  A resolver that throws applies no org rules and is audited — the guard
    *  never guesses at an unreadable policy, and never loosens on one. */
   orgPolicy?: (ctx: RunContext) => Promise<PolicyRule[]>;
-  judge?: Judge;
   breakers?: {
     maxCallsPerMinute?: number;
     maxWritesPerRun?: number;

--- a/packages/vendo/src/ai-sdk.test.ts
+++ b/packages/vendo/src/ai-sdk.test.ts
@@ -75,7 +75,7 @@ async function compose(): Promise<{ vendo: Vendo; fetchSpy: ReturnType<typeof vi
     model: {} as LanguageModel,
     principal: async () => principal,
     store,
-    policy: { rules: [{ match: { tool: "host_send" }, action: "ask" }] },
+    guard: { policy: { rules: [{ match: { tool: "host_send" }, action: "ask" }] } },
   });
   return { vendo, fetchSpy };
 }

--- a/packages/vendo/src/audit-superset.e2e.test.ts
+++ b/packages/vendo/src/audit-superset.e2e.test.ts
@@ -220,7 +220,7 @@ async function runTheTurn(): Promise<TurnResult> {
     store,
     // `cautious` is what makes the approval leg real: a `write` tool asks, a
     // `read` tool runs. Without a policy every call would be `decidedBy: default`.
-    policy: "cautious",
+    guard: { policy: "cautious" },
     harness: harness as never,
   } as Parameters<typeof createVendo>[0]);
   vendo.actions.add(hostTools());
@@ -480,7 +480,7 @@ describe("the unattended failure card (design §3)", () => {
       model: {} as LanguageModel,
       principal: async () => principal,
       store,
-      policy: "cautious",
+      guard: { policy: "cautious" },
       harness: harness as never,
     } as Parameters<typeof createVendo>[0]);
     vendo.actions.add(awayTools(executed));

--- a/packages/vendo/src/byo-approvals-wire.test.ts
+++ b/packages/vendo/src/byo-approvals-wire.test.ts
@@ -86,10 +86,12 @@ async function setup(options: { parkedCallTtlMs?: number; clock?: () => number }
     model: {} as LanguageModel,
     principal: async () => principal,
     store,
-    policy: { rules: [{ match: { risk: "write" }, action: "ask" }] },
-    ...(options.parkedCallTtlMs === undefined
-      ? {}
-      : { approvals: { parkedCallTtlMs: options.parkedCallTtlMs } }),
+    guard: {
+      policy: { rules: [{ match: { risk: "write" }, action: "ask" }] },
+      ...(options.parkedCallTtlMs === undefined
+        ? {}
+        : { approvals: { parkedCallTtlMs: options.parkedCallTtlMs } }),
+    },
     ...(options.clock === undefined
       ? {}
       : { sessions: { ttlMs: 0, sweepIntervalMs: 1, now: options.clock } }),

--- a/packages/vendo/src/cli/init-scaffolds.ts
+++ b/packages/vendo/src/cli/init-scaffolds.ts
@@ -127,7 +127,7 @@ function authImportLine(auth: AuthMatch | null): string {
 
 export function routeSource(options: { serverActions: boolean; auth: AuthMatch | null; registrySpecifier: string }): string {
   return authImportLine(options.auth) +
-    `import { createVendo, nextVendoHandler } from "@vendoai/vendo/server";\n` +
+    `import { createVendo, guard, nextVendoHandler } from "@vendoai/vendo/server";\n` +
     (options.serverActions ? `import { serverActions } from "./vendo-actions";\n` : "") +
     `import { registry } from ${JSON.stringify(options.registrySpecifier)};\n` +
     `\nconst vendo = createVendo({\n` +
@@ -135,7 +135,7 @@ export function routeSource(options: { serverActions: boolean; auth: AuthMatch |
     (options.auth === null ? anonymousPrincipalLines(true) : authConfigLines(options.auth)) +
     `  catalog: registry,\n` +
     (options.serverActions ? `  serverActions,\n` : "") +
-    `  policy: {}, // .vendo/policy.json: destructive asks, reads run\n` +
+    `  guard: guard({ policy: {} }), // .vendo/policy.json: destructive asks, reads run\n` +
     `});\n\n` +
     `export const { GET, POST, PUT, PATCH, DELETE } = nextVendoHandler(vendo);\n`;
 }
@@ -336,7 +336,7 @@ export function customServerSource(typescript: boolean, auth: AuthMatch | null =
     ` */\n` +
     `import { createAnthropic } from "@ai-sdk/anthropic";\n` +
     authImportLine(auth) +
-    `import { cloudConnections, cloudSandbox, cloudTools, createVendo, hostedStore } from "@vendoai/vendo/server";\n` +
+    `import { cloudConnections, cloudSandbox, cloudTools, createVendo, guard, hostedStore } from "@vendoai/vendo/server";\n` +
     `import { registry } from ${JSON.stringify(registrySpecifier)};\n` +
     envType +
     `\n${signatures.vendoVar}\n` +
@@ -353,7 +353,7 @@ export function customServerSource(typescript: boolean, auth: AuthMatch | null =
     (auth === null ? anonymousPrincipalLines(typescript) : authConfigLines(auth))
       .split("\n").map((line) => (line === "" ? line : `    ${line}`)).join("\n") +
     `      catalog: registry,\n` +
-    `      policy: {}, // .vendo/policy.json: destructive asks, reads run\n` +
+    `      guard: guard({ policy: {} }), // .vendo/policy.json: destructive asks, reads run\n` +
     `      // With a Vendo Cloud key the infrastructure seams wire the Cloud\n` +
     `      // adapters EXPLICITLY (composition decides; blocks never read the\n` +
     `      // environment). Without one, pass your own adapters here — model,\n` +
@@ -434,13 +434,13 @@ export function expressServerSource(typescript: boolean, auth: AuthMatch | null 
     ` */\n` +
     imports +
     authImportLine(auth) +
-    `import { createVendo } from "@vendoai/vendo/server";\n` +
+    `import { createVendo, guard } from "@vendoai/vendo/server";\n` +
     `import { registry } from ${JSON.stringify(registrySpecifier)};\n` +
     types +
     `\nconst vendo = createVendo({\n` +
     (auth === null ? anonymousPrincipalLines(typescript) : authConfigLines(auth)) +
     `  catalog: registry,\n` +
-    `  policy: {}, // .vendo/policy.json: destructive asks, reads run\n` +
+    `  guard: guard({ policy: {} }), // .vendo/policy.json: destructive asks, reads run\n` +
     `});\n\n` +
     `function requestHeaders${signatures.requestHeaders} {\n` +
     `  const result = new Headers();\n` +

--- a/packages/vendo/src/cli/init.test.ts
+++ b/packages/vendo/src/cli/init.test.ts
@@ -142,7 +142,7 @@ describe("vendo init (zero-question)", () => {
     // The generated code files: model-less createVendo (model is optional)
     // wired to the empty shared registry.
     const route = await readFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts"), "utf8");
-    expect(route).toContain('import { createVendo, nextVendoHandler } from "@vendoai/vendo/server";');
+    expect(route).toContain('import { createVendo, guard, nextVendoHandler } from "@vendoai/vendo/server";');
     expect(route).toContain('import { registry } from ' + '"../../../../vendo/registry";');
     expect(route).toContain("catalog: registry,");
     // The anonymous principal matches the docs' chat-route demo principal —
@@ -299,7 +299,7 @@ describe("vendo init (zero-question)", () => {
     // so importing it never resolves the other presets' optional peer deps
     // (corpus-triage Task 9).
     expect(route).toContain(`import { ${preset} } from "${specifier}";`);
-    expect(route).toContain('import { createVendo, nextVendoHandler } from "@vendoai/vendo/server";');
+    expect(route).toContain('import { createVendo, guard, nextVendoHandler } from "@vendoai/vendo/server";');
     expect(route).toContain(`auth: ${preset}(),`);
     // The detected line carries its escape hatch, and the preset owns the
     // principal seam — no hand-wired anonymous resolver remains.
@@ -849,7 +849,7 @@ describe("vendo init (zero-question)", () => {
     const root = await fixture();
     await mkdir(join(root, "app", "api", "vendo", "[...vendo]"), { recursive: true });
     await writeFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts"),
-      'import { createVendo, nextVendoHandler } from "@vendoai/vendo/server";\n' +
+      'import { createVendo, guard, nextVendoHandler } from "@vendoai/vendo/server";\n' +
       "const vendo = createVendo({ principal: async () => null });\n" +
       "export const { GET, POST, PUT, PATCH, DELETE } = nextVendoHandler(vendo);\n");
     const sink = output();
@@ -1151,12 +1151,12 @@ describe("vendo init (zero-question)", () => {
     const root = await fixture();
     expect(await run(root, output())).toBe(0);
     const route = await readFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts"), "utf8");
-    expect(route).toContain("policy: {},");
+    expect(route).toContain("guard: guard({ policy: {} }),");
 
     const express = await expressFixture(false);
     expect(await run(express, output())).toBe(0);
     const server = await readFile(join(express, "vendo", "server.ts"), "utf8");
-    expect(server).toContain("policy: {},");
+    expect(server).toContain("guard: guard({ policy: {} }),");
 
     // End to end: the config the scaffold passes plus the file init wrote
     // really produce the documented posture (destructive asks, reads run).

--- a/packages/vendo/src/cli/quickstart-config-surface.docs-check.ts
+++ b/packages/vendo/src/cli/quickstart-config-surface.docs-check.ts
@@ -32,13 +32,13 @@ type Assert<T extends true> = T;
 import type {
   ActAs, ActionsRegistry, AppsRuntime, AutomationsEngine, CatalogFile,
   ComponentCatalog, ComponentRegistry, Connector, ExtractedTool, FilesAdapter,
-  Harness, HostOAuthAdapter, Json, Judge, KnowledgeAdapter, OverridesFile,
-  PolicyConfig, PolicyFile, Principal, RunContext, RunId,
+  Harness, HostOAuthAdapter, Json, KnowledgeAdapter, OverridesFile,
+  PolicyFile, Principal, RunContext, RunId,
   SandboxAdapter, SecretsProvider, Skill, ToolDefinition, ToolRegistry,
   VendoAgent, VendoGuard, VendoStore, VendoTheme,
 } from "../index.js";
 import type {
-  AgentOptions, AppsConfig, ComposedAgent, ConnectionsService, HarnessTurns,
+  AppsConfig, ComposedAgent, ConnectionsService, GuardRules, HarnessTurns,
   HostAuthPreset, ModelsConfig, ServerActionHandler, TourEntry,
 } from "../server.js";
 import type { LanguageModel } from "ai";
@@ -55,19 +55,17 @@ export interface CreateVendoConfig {
   skills?: readonly Skill[];  // SKILL.md values mounted at /host/skills
   catalog?: ComponentCatalog | ComponentRegistry;          // registry.tsx, or the array form
   theme?: VendoTheme;         // programmatic override for .vendo/theme.json
-  brief?: string;             // programmatic override for .vendo/brief.md
+  instructions?: string;      // THE prose knob; programmatic override for .vendo/brief.md
   store?: VendoStore;
   files?: FilesAdapter;       // workspace file content; unset → blobs in the store, 5 MiB cap
   sandbox?: SandboxAdapter;
   harness?: Harness<never>;   // WHO THINKS. unset → vendo(). also: claudeCode()
   knowledge?: KnowledgeAdapter; // unset → no vendo_knowledge_search tool
-  connectors?: Connector[];
-  connectorApps?: string[];   // toolkit scope for the auto-composed Cloud connector
+  connectors?: readonly (string | Connector)[]; // a string names a Cloud toolkit; an object is a provider
   connections?: ConnectionsService; // explicit connections adapter; always wins over defaults
   actAs?: ActAs;              // escape hatch
   serverActions?: Record<string, ServerActionHandler>; // the generated vendo-actions.ts map
-  policy?: PolicyConfig;      // "cautious" | "readonly" | "autopilot" | { file } | { rules }
-  judge?: Judge;
+  guard?: VendoGuard | GuardRules; // guard({ policy, judge, approvals }), or a built guard
   secrets?: SecretsProvider;
   telemetry?: boolean;
   development?: boolean;    // dev-only injection seams
@@ -88,9 +86,11 @@ export interface CreateVendoConfig {
     federation?: { secret: string };
   };
   oauth?: HostOAuthAdapter;   // escape hatch; required when `mcp` is true and `auth` is absent
-  agent?: AgentOptions | ComposedAgent; // the chat knobs, OR a whole agent() from @vendoai/agents
+  agent?: ComposedAgent;      // a whole agent() from @vendoai/agents, adopted by this deployment
   sessions?: { ttlMs?: number; sweepIntervalMs?: number; now?: () => number };
-  approvals?: { parkedCallTtlMs?: number };
+  toolOutputCap?: number;     // how much of one tool result reaches the model; 0 disables
+  maxInitialTools?: number;   // cap on the uncurated initial loadout; the rest via find_tools
+  loadout?: readonly string[]; // the curated initial loadout, by tool name
   apps?: false | {            // false unmounts app generation: no tools, skill or /apps routes
     review?: {                // review-kind remixes: who may review (queue/reject/approve)
       reviewer?(ctx: RunContext): boolean | Promise<boolean>;

--- a/packages/vendo/src/compound.e2e.test.ts
+++ b/packages/vendo/src/compound.e2e.test.ts
@@ -448,7 +448,7 @@ describe("the real createVendo composition wires the seam", () => {
       model: {} as LanguageModel,
       principal: async () => principal,
       store,
-      policy: { rules: [{ match: { tool: "host_send" }, action: "ask" }] },
+      guard: { policy: { rules: [{ match: { tool: "host_send" }, action: "ask" }] } },
     });
 
     expect((await vendo.actions.descriptors()).map((descriptor) => descriptor.name)).toContain("host_flow");

--- a/packages/vendo/src/config-coherence.test.ts
+++ b/packages/vendo/src/config-coherence.test.ts
@@ -1,0 +1,400 @@
+/**
+ * The config-coherence change, proven on real compositions.
+ *
+ * Four keys reshaped, twelve spellings deleted, and the claim is that NOTHING
+ * behaves differently — this is surface, not semantics. A rename that quietly
+ * changes a guard decision, a system prompt, or a connector catalog is the
+ * failure mode, so each of the three is pinned against the literal main
+ * produced, not against "the new code agrees with itself".
+ *
+ * The old shapes are gone, so they cannot be composed side by side. What is
+ * asserted instead is the literal: the guard decisions main's
+ * `policy: { rules }` produced, the prompt section main's `brief` landed in,
+ * and the scoped catalog main's `connectorApps` produced (the same literals
+ * `server.test.ts` has pinned since the connectorApps criterion landed).
+ *
+ * Each assertion here has been driven red by reverting the line it covers —
+ * see the comment on each block for which line, and what it says when broken.
+ */
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { VENDO_TOOLS_FORMAT, type ExtractedTool } from "@vendoai/actions";
+import { VendoError, type Principal, type RunContext } from "@vendoai/core";
+import { createGuard, guard as guardRules } from "@vendoai/guard";
+import { createStore, type VendoStore } from "@vendoai/store";
+import type { LanguageModel, UIMessage } from "ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createVendo, type Vendo } from "./server.js";
+
+const principal: Principal = { kind: "user", subject: "user_coherence" };
+const ctx: RunContext = { principal, venue: "chat", presence: "present", runId: "run_coherence" };
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+async function tempStore(prefix: string): Promise<VendoStore> {
+  const dataDir = await mkdtemp(join(tmpdir(), prefix));
+  const store = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  await store.ensureSchema();
+  return store;
+}
+
+const routeTool = (name: string, extras: Partial<ExtractedTool> = {}): ExtractedTool => ({
+  name,
+  description: `${name} description`,
+  inputSchema: { type: "object" },
+  risk: "read",
+  binding: { kind: "route", method: "GET", path: `/${name}`, argsIn: "query" },
+  ...extras,
+});
+
+/** The three-risk host surface every decision case below is graded against. */
+const HOST_TOOLS: ExtractedTool[] = [
+  routeTool("host_read"),
+  routeTool("host_write", {
+    risk: "write",
+    binding: { kind: "route", method: "POST", path: "/host_write", argsIn: "body" },
+  }),
+  routeTool("host_wipe", {
+    risk: "destructive",
+    binding: { kind: "route", method: "DELETE", path: "/host_wipe", argsIn: "body" },
+  }),
+];
+
+/** A cwd holding `.vendo/`, so a composition reads real surface files. */
+async function dotVendo(files: Record<string, string> = {}): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "vendo-coherence-root-"));
+  const previousCwd = process.cwd();
+  cleanups.push(async () => {
+    process.chdir(previousCwd);
+    await rm(root, { recursive: true, force: true });
+  });
+  await mkdir(join(root, ".vendo"));
+  await writeFile(join(root, ".vendo", "tools.json"), JSON.stringify({
+    format: VENDO_TOOLS_FORMAT,
+    tools: HOST_TOOLS,
+  }));
+  for (const [name, body] of Object.entries(files)) {
+    await writeFile(join(root, ".vendo", name), body);
+  }
+  process.chdir(root);
+  return root;
+}
+
+/** Every host call answers 200, so an outcome's status is the GUARD's answer. */
+function stubHostFetch(): void {
+  vi.stubEnv("VENDO_BASE_URL", "https://host.test");
+  vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  })));
+}
+
+const call = (tool: string) => ({ id: `call_${tool}`, tool, args: {} });
+
+/** run / ask / block, as the wire sees them. */
+async function decisions(vendo: Vendo): Promise<Record<string, string>> {
+  const out: Record<string, string> = {};
+  for (const tool of ["host_read", "host_write", "host_wipe"]) {
+    out[tool] = (await vendo.guardedTools.execute(call(tool), ctx)).status;
+  }
+  return out;
+}
+
+/**
+ * The decision table main produced for
+ * `createVendo({ policy: { rules: [write→ask, destructive→block] } })`.
+ * Reads run (no rule matches and the unmatched default runs), the write parks,
+ * the destructive is refused.
+ */
+const MAIN_DECISIONS = {
+  host_read: "ok",
+  host_write: "pending-approval",
+  host_wipe: "blocked",
+} as const;
+
+const RULES = {
+  rules: [
+    { match: { risk: "write" as const }, action: "ask" as const },
+    { match: { risk: "destructive" as const }, action: "block" as const },
+  ],
+};
+
+describe("guard: one slot, two arms, the same decisions main made", () => {
+  it("the SPEC arm reproduces main's decision table verbatim", async () => {
+    // RED: drop `...(guardRules.judge …)`/`policy: configPolicy` from the
+    // createGuard call in server.ts and every row becomes "ok" — an
+    // unconfigured guard runs everything.
+    await dotVendo();
+    stubHostFetch();
+    const vendo = createVendo({
+      model: {} as LanguageModel,
+      principal: async () => principal,
+      store: await tempStore("vendo-coherence-spec-"),
+      guard: guardRules({ policy: RULES }),
+    });
+    expect(await decisions(vendo)).toEqual(MAIN_DECISIONS);
+    expect(vendo.guard.status().posture).toBe("rules");
+  });
+
+  it("a bare rules OBJECT is the same value — `guard()` is naming, not behaviour", async () => {
+    await dotVendo();
+    stubHostFetch();
+    const vendo = createVendo({
+      model: {} as LanguageModel,
+      principal: async () => principal,
+      store: await tempStore("vendo-coherence-bare-"),
+      guard: { policy: RULES },
+    });
+    expect(await decisions(vendo)).toEqual(MAIN_DECISIONS);
+  });
+
+  it("an INSTANCE is taken verbatim — the composition adds nothing to it", async () => {
+    // The adapter rule: a host that built its own guard gets exactly that
+    // guard, so the rules it was built with are the rules in force.
+    await dotVendo();
+    stubHostFetch();
+    const store = await tempStore("vendo-coherence-instance-");
+    const built = createGuard({ store, policy: RULES });
+    const vendo = createVendo({
+      model: {} as LanguageModel,
+      principal: async () => principal,
+      store,
+      guard: built,
+    });
+    expect(vendo.guard).toBe(built);
+    expect(await decisions(vendo)).toEqual(MAIN_DECISIONS);
+  });
+
+  it("the approval TTL rides the guard, so an instance keeps the knob", async () => {
+    // RED: read `parkedCallTtlMs` off config again and a host that passes a
+    // built guard silently gets the 60-minute default instead of its own.
+    const store = await tempStore("vendo-coherence-ttl-");
+    expect(createGuard({ store, approvals: { parkedCallTtlMs: 90_000 } }).approvals.parkedCallTtlMs)
+      .toBe(90_000);
+    expect(createGuard({ store }).approvals.parkedCallTtlMs).toBe(60 * 60_000);
+    expect(() => createGuard({ store, approvals: { parkedCallTtlMs: -1 } }))
+      .toThrow(VendoError);
+  });
+});
+
+/** Records every system prompt it is asked to think with, then says one line. */
+function recordingModel(seen: string[]): LanguageModel {
+  return {
+    specificationVersion: "v2",
+    provider: "probe",
+    modelId: "probe-v1",
+    supportedUrls: {},
+    async doStream(request: { prompt: Array<{ role: string; content: unknown }> }) {
+      seen.push(
+        request.prompt.filter((m) => m.role === "system").map((m) => String(m.content)).join("\n"),
+      );
+      return {
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: "stream-start", warnings: [] });
+            controller.enqueue({ type: "text-start", id: "t1" });
+            controller.enqueue({ type: "text-delta", id: "t1", delta: "ok" });
+            controller.enqueue({ type: "text-end", id: "t1" });
+            controller.enqueue({
+              type: "finish",
+              finishReason: "stop",
+              usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            });
+            controller.close();
+          },
+        }),
+      };
+    },
+  } as unknown as LanguageModel;
+}
+
+const PROSE = "COHERENCE-PROBE: Maple is a neobank for freelancers.";
+
+async function promptFor(overrides: Partial<Parameters<typeof createVendo>[0]>): Promise<string> {
+  const seen: string[] = [];
+  const vendo = createVendo({
+    model: recordingModel(seen),
+    principal: async () => principal,
+    store: await tempStore("vendo-coherence-prompt-"),
+    ...overrides,
+  } as Parameters<typeof createVendo>[0]);
+  const message = { id: "m1", role: "user", parts: [{ type: "text", text: "hi" }] } as UIMessage;
+  const response = await vendo.handler(new Request("https://host.test/api/vendo/threads", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ threadId: `thr_${Math.random().toString(36).slice(2)}`, message }),
+  }));
+  await response.text();
+  expect(seen.length, "the model was never asked to think").toBeGreaterThan(0);
+  return seen[0]!;
+}
+
+describe("instructions: one prose story, in the section brief always had", () => {
+  it("the key and the .vendo/brief.md surface produce byte-identical prompts", async () => {
+    // RED: point `resolveInstructions` at the trailing `system.instructions`
+    // slot instead of `product` and the two prompts stop matching, because the
+    // file leg still resolves through `product`.
+    await dotVendo();
+    const fromKey = await promptFor({ instructions: PROSE });
+    await dotVendo({ "brief.md": PROSE });
+    const fromFile = await promptFor({});
+    expect(fromKey).toBe(fromFile);
+  });
+
+  it("lands in the Product section, above the guard's Directions — main's placement", async () => {
+    await dotVendo();
+    const prompt = await promptFor({ instructions: PROSE });
+    // The literal `assembleSystemPrompt` writes for `product` (prompt.ts:98).
+    expect(prompt).toContain(`\n\nProduct\n${PROSE}`);
+  });
+
+  it("an adopted agent's instructions and the top-level key are one slot", async () => {
+    // Filling a slot twice is a boot error, never one side silently losing.
+    const { agent } = await import("@vendoai/agents");
+    const { vendo: vendoHarness } = await import("@vendoai/harnesses");
+    const store = await tempStore("vendo-coherence-adopt-");
+    const composed = agent({ name: "support", harness: vendoHarness(), store, instructions: PROSE });
+    expect(() => createVendo({
+      model: {} as LanguageModel,
+      principal: async () => principal,
+      agent: composed,
+      instructions: "a second voice",
+    })).toThrow(/instructions/);
+  });
+});
+
+describe("connectors: one list, strings and objects", () => {
+  /** A stub console serving a three-toolkit catalog and per-toolkit tools —
+   *  the same shape `server.test.ts` has driven the scoping criterion with. */
+  async function stubConsole(): Promise<string> {
+    const { createServer } = await import("node:http");
+    const stub = createServer((req, res) => {
+      const url = new URL(req.url ?? "/", "http://stub");
+      res.setHeader("content-type", "application/json");
+      if (url.pathname === "/api/v1/connections/catalog") {
+        res.end(JSON.stringify({ available: [
+          { toolkit: "gmail", connector: "composio", description: "Send and read email with Gmail" },
+          { toolkit: "slack", connector: "composio", description: "Post messages to Slack channels" },
+          { toolkit: "notion", connector: "composio", description: "Notion pages and databases" },
+        ] }));
+        return;
+      }
+      if (url.pathname === "/api/v1/tools") {
+        const toolkits = (url.searchParams.get("toolkits") ?? "").split(",").filter(Boolean);
+        res.end(JSON.stringify({ tools: toolkits.map((toolkit) => ({
+          slug: `${toolkit.toUpperCase()}_SEND_THING`,
+          toolkit,
+          description: `use ${toolkit}`,
+          inputParameters: { type: "object" },
+          tags: [],
+        })) }));
+        return;
+      }
+      res.statusCode = 404;
+      res.end("{}");
+    });
+    await new Promise<void>((resolve) => stub.listen(0, "127.0.0.1", resolve));
+    const port = (stub.address() as { port: number }).port;
+    cleanups.push(async () => {
+      stub.close();
+      stub.closeAllConnections();
+    });
+    return `http://127.0.0.1:${port}`;
+  }
+
+  it("a toolkit STRING scopes tools AND the connect catalog to main's literal set", async () => {
+    // RED: drop `apps: toolkits` from selectConnectors and the executable
+    // surface loses gmail_GMAIL_SEND_THING; drop it from selectConnections and
+    // the catalog advertises slack and notion the agent cannot invoke.
+    vi.stubEnv("VENDO_API_KEY", "vnd_test_key");
+    vi.stubEnv("VENDO_CLOUD_URL", await stubConsole());
+    const vendo = createVendo({
+      model: {} as LanguageModel,
+      principal: async () => principal,
+      store: await tempStore("vendo-coherence-strings-"),
+      connectors: ["gmail"],
+    });
+    const names = (await vendo.actions.descriptors()).map((descriptor) => descriptor.name);
+    expect(names).toContain("gmail_GMAIL_SEND_THING");
+    expect(names.some((name) => name.startsWith("slack_") || name.startsWith("notion_"))).toBe(false);
+    expect((await vendo.connections.catalog()).map((entry) => entry.toolkit)).toEqual(["gmail"]);
+  });
+
+  it("strings and connector OBJECTS mix — neither erases the other", async () => {
+    // The trap `connectorApps` had: an explicit connector silently voided the
+    // scope. One list, so there is nothing left to ignore.
+    vi.stubEnv("VENDO_API_KEY", "vnd_test_key");
+    vi.stubEnv("VENDO_CLOUD_URL", await stubConsole());
+    const vendo = createVendo({
+      model: {} as LanguageModel,
+      principal: async () => principal,
+      store: await tempStore("vendo-coherence-mixed-"),
+      connectors: [
+        "gmail",
+        {
+          name: "acme",
+          descriptors: async () => [{
+            name: "acme_ping",
+            description: "ping acme",
+            inputSchema: { type: "object" },
+            risk: "read" as const,
+          }],
+          execute: async () => ({ status: "ok" as const, output: {} }),
+        },
+      ],
+    });
+    const names = (await vendo.actions.descriptors()).map((descriptor) => descriptor.name);
+    expect(names).toContain("gmail_GMAIL_SEND_THING");
+    expect(names).toContain("acme_ping");
+  });
+
+  it("strings with no Cloud key refuse by NAMING the fix, never silently", async () => {
+    // RED: return plain `unconfiguredConnections()` and the message stops
+    // naming the toolkits the host asked for.
+    vi.stubEnv("VENDO_API_KEY", "");
+    const vendo = createVendo({
+      model: {} as LanguageModel,
+      principal: async () => principal,
+      store: await tempStore("vendo-coherence-nokey-"),
+      connectors: ["gmail", "slack"],
+    });
+    expect(vendo.connections.posture).toBe(false);
+    await expect(vendo.connections.initiate(principal, { toolkit: "gmail" }))
+      .rejects.toThrow(/VENDO_API_KEY[\s\S]*composioConnector/);
+    await expect(vendo.connections.initiate(principal, { toolkit: "gmail" }))
+      .rejects.toThrow(/"gmail", "slack"/);
+  });
+});
+
+describe("removed keys refuse to compose, naming their replacement", () => {
+  const cases: Array<[string, Record<string, unknown>, RegExp]> = [
+    ["policy", { policy: "cautious" }, /guard\(\{ policy \}\)/],
+    ["judge", { judge: {} }, /guard\(\{ judge \}\)/],
+    ["approvals", { approvals: { parkedCallTtlMs: 1 } }, /guard\(\{ approvals \}\)/],
+    ["brief", { brief: "prose" }, /`instructions`/],
+    ["connectorApps", { connectorApps: ["gmail"] }, /connectors: \["gmail", "slack"\]/],
+    ["the agent knobs bag", { agent: { maxSteps: 5 } }, /harness: vendo\(\{ maxSteps \}\)/],
+  ];
+  for (const [name, extra, message] of cases) {
+    it(`${name} throws instead of being dropped`, () => {
+      // A JavaScript host gets no type error, and a dropped `policy` would mean
+      // an unconfigured guard running wide open. Loud, or not at all.
+      expect(() => createVendo({
+        model: {} as LanguageModel,
+        principal: async () => principal,
+        ...extra,
+      } as unknown as Parameters<typeof createVendo>[0])).toThrow(message);
+    });
+  }
+});

--- a/packages/vendo/src/config-keys.ts
+++ b/packages/vendo/src/config-keys.ts
@@ -19,6 +19,7 @@
  * It also does real work at runtime: {@link warnDeprecatedConfigKeys} is what
  * tells a host on the old shape where the key went.
  */
+import { VendoError } from "@vendoai/core";
 import type { CreateVendoConfig } from "./server.js";
 
 /**
@@ -38,19 +39,17 @@ export const CREATE_VENDO_CONFIG_KEYS = [
   "skills",
   "catalog",
   "theme",
-  "brief",
+  "instructions",
   "store",
   "files",
   "sandbox",
   "harness",
   "knowledge",
   "connectors",
-  "connectorApps",
   "connections",
   "actAs",
   "serverActions",
-  "policy",
-  "judge",
+  "guard",
   "secrets",
   "telemetry",
   "development",
@@ -61,7 +60,9 @@ export const CREATE_VENDO_CONFIG_KEYS = [
   "oauth",
   "agent",
   "sessions",
-  "approvals",
+  "toolOutputCap",
+  "maxInitialTools",
+  "loadout",
   "apps",
   "automations",
   "tours",
@@ -90,6 +91,64 @@ export const DEPRECATED_CONFIG_KEYS: Readonly<Record<string, string>> = {
     "`profile.tools` is deprecated: use the `tools:` slot, which is the same in-memory host-tool "
     + "declarations under their §10 name. It still works for one more minor.",
 };
+
+/**
+ * Keys that are GONE, mapped to the sentence naming their replacement.
+ *
+ * Unlike {@link DEPRECATED_CONFIG_KEYS} these do not work at all, so the
+ * response is a boot error rather than a warning. TypeScript already rejects
+ * every one of them; this is for the JavaScript host, where a dropped `policy`
+ * would mean an unconfigured guard running wide open and a dropped `brief`
+ * would mean an agent that forgot what the product is. A config change must
+ * never fail that way quietly.
+ */
+export const REMOVED_CONFIG_KEYS: Readonly<Record<string, string>> = {
+  brief: "`brief` is gone: use `instructions` — one prose key, the same `.vendo/brief.md` surface behind it.",
+  policy: "`policy` is gone: use `guard: guard({ policy })` from @vendoai/vendo/server.",
+  judge: "`judge` is gone: use `guard: guard({ judge })` from @vendoai/vendo/server.",
+  approvals: "`approvals` is gone: use `guard: guard({ approvals })` from @vendoai/vendo/server.",
+  connectorApps:
+    "`connectorApps` is gone: name the toolkits in `connectors` itself — `connectors: [\"gmail\", \"slack\"]` "
+    + "(strings and connector objects are one list now).",
+};
+
+/** The `agent:` grab-bag members, and where each one went. Reported together
+ *  when a host still passes the options object, because a config on the old
+ *  shape usually carries several of them. */
+export const REMOVED_AGENT_OPTION_KEYS: Readonly<Record<string, string>> = {
+  instructions: "the top-level `instructions` key",
+  toolOutputCap: "the top-level `toolOutputCap` key",
+  maxInitialTools: "the top-level `maxInitialTools` key",
+  loadout: "the top-level `loadout` key",
+  maxSteps: "`harness: vendo({ maxSteps })`",
+  historyWindow: "`harness: vendo({ historyWindow })`",
+  maxOutputTokens: "`harness: vendo({ maxOutputTokens })`",
+};
+
+/**
+ * Refuse a config still written against a removed key, naming the replacement.
+ * Called from `createVendo` before anything is constructed.
+ */
+export function rejectRemovedConfigKeys(config: Partial<Record<string, unknown>>): void {
+  for (const [key, message] of Object.entries(REMOVED_CONFIG_KEYS)) {
+    if (config[key] !== undefined) throw new VendoError("validation", message);
+  }
+  // `agent:` survives as the composed-agent slot, so it is the VALUE that says
+  // whether this is the old knobs object: an agent from `agent()` has a
+  // `session`, and the knobs object never did.
+  const agent = config["agent"] as Record<string, unknown> | undefined;
+  if (agent === undefined || typeof agent["session"] === "function") return;
+  const moved = Object.keys(REMOVED_AGENT_OPTION_KEYS)
+    .filter((key) => agent[key] !== undefined)
+    .map((key) => `\`agent.${key}\` → ${REMOVED_AGENT_OPTION_KEYS[key]}`);
+  throw new VendoError(
+    "validation",
+    "`agent:` now takes only a whole agent built by `agent()` from @vendoai/agents. "
+    + (moved.length === 0
+      ? "The chat-knobs object is gone."
+      : `Move ${moved.join(", ")}.`),
+  );
+}
 
 /** Keys already warned about in THIS process. A deployment composes once, but a
  *  test file or a multi-tenant venue composes many times, and repeating the same

--- a/packages/vendo/src/connect-invalidation.test.ts
+++ b/packages/vendo/src/connect-invalidation.test.ts
@@ -72,7 +72,7 @@ async function composeVendo(connector: Connector) {
     store,
     connectors: [connector],
     principal: vi.fn(async () => principal),
-    policy: { rules: [{ match: { risk: "write" }, action: "ask" }] },
+    guard: { policy: { rules: [{ match: { risk: "write" }, action: "ask" }] } },
   });
   await vendo.handler(new Request("http://invalidation.test/api/vendo/status"));
   return vendo;

--- a/packages/vendo/src/connections.ts
+++ b/packages/vendo/src/connections.ts
@@ -255,12 +255,14 @@ export function cloudConnections(options: CloudConnectionsOptions): ConnectionsS
 }
 
 /** The no-broker fallback adapter: listing is honestly empty (the panel
- * renders an empty state), any mutation explains what to configure. */
-export function unconfiguredConnections(): ConnectionsService {
+ * renders an empty state), any mutation explains what to configure. The
+ * composition seam may pass a sharper sentence when it knows exactly what this
+ * config was missing (toolkit strings with no Cloud key). */
+export function unconfiguredConnections(reason?: string): ConnectionsService {
   const refuse = (): never => {
     throw new VendoError(
       "not-implemented",
-      "connected accounts are not configured: pass a Composio connector (composioConnector) to createVendo({ connectors }) or set VENDO_API_KEY for the Vendo Cloud broker",
+      reason ?? "connected accounts are not configured: pass a Composio connector (composioConnector) to createVendo({ connectors }) or set VENDO_API_KEY for the Vendo Cloud broker",
     );
   };
   return {

--- a/packages/vendo/src/connector-discovery-wire.test.ts
+++ b/packages/vendo/src/connector-discovery-wire.test.ts
@@ -128,15 +128,15 @@ beforeAll(async () => {
 async function compose(
   connectors: Connector[],
   rules?: PolicyRule[],
-  agent?: { toolOutputCap?: number },
+  overrides: { toolOutputCap?: number } = {},
 ): Promise<Vendo> {
   return createVendo({
     model: {} as LanguageModel,
     principal: async () => principal,
     store: shared!,
     connectors,
-    ...(rules === undefined ? {} : { policy: { rules } }),
-    ...(agent === undefined ? {} : { agent }),
+    ...(rules === undefined ? {} : { guard: { policy: { rules } } }),
+    ...overrides,
   });
 }
 

--- a/packages/vendo/src/discovery-budget.live.test.ts
+++ b/packages/vendo/src/discovery-budget.live.test.ts
@@ -161,7 +161,7 @@ async function composeVendo(entityId: string, baseUrl: string) {
     // The demo posture: BYO Composio scoped to the demo's toolkits, guard
     // asking on every write (Maple's .vendo/policy.json intent).
     connectors: [composioConnector({ apiKey: apiKey!, apps: ["gmail", "slack"], entityId: () => entityId })],
-    policy: { rules: [{ match: { risk: "write" }, action: "ask" }, { match: { risk: "destructive" }, action: "ask" }] },
+    guard: { policy: { rules: [{ match: { risk: "write" }, action: "ask" }, { match: { risk: "destructive" }, action: "ask" }] } },
     principal: async () => ({ kind: "user", subject: entityId }),
   });
   // Settle composition (boot-time schema load) before the counter is read.

--- a/packages/vendo/src/harness-system-prompt.test.ts
+++ b/packages/vendo/src/harness-system-prompt.test.ts
@@ -100,7 +100,7 @@ async function compose(
     model: recordingModel(seen),
     principal: async () => principal,
     store,
-    agent: { instructions: HOST_VOICE },
+    instructions: HOST_VOICE,
     ...overrides,
   } as Parameters<typeof createVendo>[0]);
   vendo.actions.add(hostTools());

--- a/packages/vendo/src/harness-wire.test.ts
+++ b/packages/vendo/src/harness-wire.test.ts
@@ -586,7 +586,7 @@ describe("rail parity: find_tools, the loadout, the menu, capability miss", () =
       // A curated menu of exactly ONE tool: the long tail is off the initial
       // loadout, so `list()` must not offer `maple_invoices_list` until it is
       // searched in. This is the host's `surfaces.agent` menu in effect.
-      agent: { loadout: ["maple_reports_read"] },
+      loadout: ["maple_reports_read"],
       harness: scriptedHarness(async function* (turn) {
         before.push((await turn.tools.list()).map((entry) => entry.name));
         const search = await turn.tools.call("find_tools", { query: "invoices" });

--- a/packages/vendo/src/mastra.test.ts
+++ b/packages/vendo/src/mastra.test.ts
@@ -89,7 +89,7 @@ async function compose(): Promise<{ vendo: Vendo; fetchSpy: ReturnType<typeof vi
     model: {} as LanguageModel,
     principal: async () => principal,
     store,
-    policy: { rules: [{ match: { tool: "host_send" }, action: "ask" }] },
+    guard: { policy: { rules: [{ match: { tool: "host_send" }, action: "ask" }] } },
   });
   return { vendo, fetchSpy };
 }

--- a/packages/vendo/src/mcp-door-internal.e2e.test.ts
+++ b/packages/vendo/src/mcp-door-internal.e2e.test.ts
@@ -94,7 +94,7 @@ async function internalHost(
     model: {} as LanguageModel,
     principal: async () => principal,
     store,
-    policy: "cautious",
+    guard: { policy: "cautious" },
     harness: harness as never,
   } as Parameters<typeof createVendo>[0]);
   composed.actions.add(hostTools());

--- a/packages/vendo/src/mcp-door.test-util.ts
+++ b/packages/vendo/src/mcp-door.test-util.ts
@@ -210,7 +210,7 @@ export async function composedHost(
     model: model ?? ({} as LanguageModel),
     principal: async () => principal,
     store,
-    policy: "cautious",
+    guard: { policy: "cautious" },
     harness: harness as never,
     mcp: true,
     oauth: {
@@ -267,7 +267,7 @@ export async function composedHostOverDoor(
     model: model ?? ({} as LanguageModel),
     principal: async () => principal,
     store,
-    policy: "cautious",
+    guard: { policy: "cautious" },
     harness: harness as never,
     mcp: true,
     ...(extracted === undefined ? {} : { tools: extracted }),

--- a/packages/vendo/src/server-agent-seam.test.ts
+++ b/packages/vendo/src/server-agent-seam.test.ts
@@ -152,8 +152,10 @@ describe("createVendo({ agent }) adopts what the agent already composed", () => 
       /already brings `store`, `sandbox`/,
     );
     expect(() => createVendo({ ...base, harness: boxy() })).toThrow(/already brings `harness`/);
-    // The chat-knob arm and the agent arm are one key, so instructions cannot
-    // conflict at all — the union is what makes that structural.
+    // Prose is a slot the adopted agent owns too, now that there is exactly one
+    // key for it: filling both is the same conflict, not a silent loser.
+    expect(() => createVendo({ ...base, instructions: "a second voice" }))
+      .toThrow(/already brings `instructions`/);
     expect(() => createVendo(base)).not.toThrow();
   });
 

--- a/packages/vendo/src/server.test.ts
+++ b/packages/vendo/src/server.test.ts
@@ -72,7 +72,7 @@ const app = (id = "app_wire"): AppDocument => ({
 
 async function setup(
   resolver = vi.fn(async () => principal),
-  options: Pick<Partial<CreateVendoConfig>, "policy" | "development"> = {},
+  options: Pick<Partial<CreateVendoConfig>, "guard" | "development"> = {},
 ): Promise<{ vendo: Vendo; resolver: typeof resolver }> {
   const store = await tempStore("vendo-wire-");
   const vendo = createVendo({
@@ -841,7 +841,7 @@ describe("09 §3 public wire", () => {
     expect(explicitNames).not.toContain("gmail_GMAIL_SEND_EMAIL");
   });
 
-  it("connectorApps scopes the auto-composed cloud connector AND the connect catalog (criterion 9)", async () => {
+  it("a toolkit STRING in connectors scopes the auto-composed cloud connector AND the connect catalog (criterion 9)", async () => {
     // Same stub-console pattern as the connectors-seam test above: the wire
     // serves a 3-toolkit catalog; the host scopes to gmail only.
     const { createServer } = await import("node:http");
@@ -886,7 +886,7 @@ describe("09 §3 public wire", () => {
       model: {} as LanguageModel,
       principal: vi.fn(async () => principal),
       store,
-      connectorApps: ["gmail"],
+      connectors: ["gmail"],
     });
     await vendo.handler(request("GET", "/status"));
 
@@ -1413,11 +1413,13 @@ describe("09 §2 composition", () => {
 
   it("projects app-edit risk consistently across chat and MCP venues", async () => {
     const { vendo } = await setup(vi.fn(async () => principal), {
-      policy: {
-        rules: [
-          { match: { risk: "write" }, action: "ask" },
-          { match: { risk: "read" }, action: "run" },
-        ],
+      guard: {
+        policy: {
+          rules: [
+            { match: { risk: "write" }, action: "ask" },
+            { match: { risk: "read" }, action: "run" },
+          ],
+        },
       },
     });
     expect((await vendo.handler(request("GET", "/status"))).status).toBe(200);
@@ -2485,7 +2487,7 @@ describe("09 §3 conversational turn against the real composed store", () => {
       model: model as unknown as LanguageModel,
       principal: async () => principal,
       store,
-      policy: { rules: [{ match: { tool: "vendo_apps_*", presence: "present" }, action: "run" }] },
+      guard: { policy: { rules: [{ match: { tool: "vendo_apps_*", presence: "present" }, action: "run" }] } },
     });
 
     const response = await vendo.handler(request("POST", "/threads", {
@@ -2563,7 +2565,7 @@ describe("ENG-252 agent.loadout through createVendo", () => {
       principal: async () => principal,
       store,
       connectors: [connector],
-      agent: { loadout: ["host_beta"] },
+      loadout: ["host_beta"],
     });
 
     const turn = await vendo.handler(request("POST", "/threads", {
@@ -2710,7 +2712,7 @@ describe("surfaces.agent through createVendo", () => {
       principal: async () => principal,
       store,
       // The host names BOTH tools in its explicit loadout; the menu still wins.
-      agent: { loadout: ["host_listAccounts", "host_exportLedger"] },
+      loadout: ["host_listAccounts", "host_exportLedger"],
     });
     const turn = await vendo.handler(request("POST", "/threads", {
       threadId: "thr_surface_loadout",
@@ -3813,7 +3815,7 @@ describe("unified try surface (Task 15a) — in-memory profile", () => {
       model: {} as LanguageModel,
       principal: async () => principal,
       store: await tempStore("vendo-profile-policy-prec-"),
-      policy: { rules: [{ match: {}, action: "block", note: "explicit config wins" }] },
+      guard: { policy: { rules: [{ match: {}, action: "block", note: "explicit config wins" }] } },
       profile: {
         tools: [profileTool("host_invoices_list")],
         policy: { format: VENDO_POLICY_FORMAT, rules: [{ match: {}, action: "run" }] },

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -32,7 +32,7 @@ import { createHarnessTurns, type HarnessTurns } from "./harness-turn.js";
 export type { HarnessTurns } from "./harness-turn.js";
 export type { AppsConfig } from "@vendoai/apps";
 import { registerTurnSteer } from "./turn-liveness.js";
-import { warnDeprecatedConfigKeys } from "./config-keys.js";
+import { rejectRemovedConfigKeys, warnDeprecatedConfigKeys } from "./config-keys.js";
 import { orgPolicyPath, orgPolicyResolver, workspacePolicySource } from "./org-policy.js";
 import { createPromoteApp } from "./promote-app.js";
 import { memoizedSurfaceMenu } from "./surface-menu.js";
@@ -92,7 +92,7 @@ import {
   type VendoTheme,
   type WorkspaceFs,
 } from "@vendoai/core";
-import { createGuard, type Judge, type PolicyConfig, type PolicyFile, type RiskResolver, type VendoGuard } from "@vendoai/guard";
+import { createGuard, isGuardInstance, type GuardRules, type PolicyConfig, type PolicyFile, type RiskResolver, type VendoGuard } from "@vendoai/guard";
 import {
   bindKnowledgeStore,
   cloudKnowledge,
@@ -339,52 +339,27 @@ export type { CatalogFile, ExtractedTool, OverridesFile, ServerActionHandler } f
 export type { VendoAgent as ComposedAgent } from "@vendoai/agents";
 export type { VendoTheme } from "@vendoai/core";
 export type { PolicyFile } from "@vendoai/guard";
-
-/** 03-agent — chat context controls, the non-agent arm of `createVendo({ agent })`.
-    All optional. `toolOutputCap` defaults to DEFAULT_TOOL_OUTPUT_CAP so one huge
-    host-tool response can't blow the context; pass 0 to disable. `historyWindow`
-    bounds messages re-sent per turn (default: full). */
-export interface AgentOptions {
-  /** Host voice and standing guidance, appended to the agent's system
-      prompt every turn (03 §3 `instructions`) — tone, formatting, what to
-      emphasize. Policy belongs in guard directions, not here. */
-  instructions?: string;
-  toolOutputCap?: number;
-  maxOutputTokens?: number;
-  historyWindow?: number;
-  /** ENG-252 — cap on the uncurated initial tool loadout; the rest stay
-      discoverable via `find_tools`. Defaults to the agent block's
-      DEFAULT_MAX_INITIAL_TOOLS. */
-  maxInitialTools?: number;
-  /** ENG-252 — explicit curated initial loadout by tool name. When set,
-      exactly these host tools (that exist and are enabled) start active —
-      the cap is not applied; the rest stay discoverable via
-      `find_tools`. Vendo's own `vendo_*` tools are always active. */
-  loadout?: string[];
-  /** AGENT-7: agent-loop step cap per turn (default 20). Exhaustion streams a
-      renderable `data-vendo-step-limit` part instead of ending silently. */
-  maxSteps?: number;
-}
+// The `guard:` slot's two arms, named from here for the same reason as
+// `ServerActionHandler` and `ComposedAgent`: a host must be able to name what
+// it passes without adding a direct dependency on the block the value came
+// from. `guard()` itself is re-exported below, beside `vendo()`.
+export { guard, createGuard, type GuardRules, type VendoGuard } from "@vendoai/guard";
 
 /** The slots a composed agent brings, and therefore the keys that may not also
     be passed at the top level. Kept beside the adoption in `adoptAgent` so the
     error can never drift from what is actually taken. */
-const AGENT_OWNED_KEYS = ["harness", "store", "files", "sandbox"] as const;
-
-/** `agent()` returns `{ name, session }`; the chat-knobs arm has no `session`. */
-const isComposedAgent = (agent: AgentOptions | ComposedAgent | undefined): agent is ComposedAgent =>
-  typeof (agent as ComposedAgent | undefined)?.session === "function";
+const AGENT_OWNED_KEYS = ["harness", "store", "files", "sandbox", "instructions"] as const;
 
 /** The seam: read what `agent()` composed, and refuse a config that fills any
     of the same slots twice. Runs before anything is constructed, so a miswired
     config leaks no resources. */
 function adoptAgent(config: CreateVendoConfig): AgentComposition | undefined {
-  if (!isComposedAgent(config.agent)) return undefined;
+  if (config.agent === undefined) return undefined;
   const composed = agentComposition(config.agent);
   if (composed === undefined) {
     throw new VendoError(
       "validation",
-      "createVendo({ agent }) was handed an object with a session() method that `agent()` from @vendoai/agents did not build — pass the value that `agent({ … })` returned, or the chat-context knobs object.",
+      "createVendo({ agent }) was handed something `agent()` from @vendoai/agents did not build — pass the value that `agent({ … })` returned.",
     );
   }
   const conflicts = AGENT_OWNED_KEYS.filter((key) => config[key] !== undefined);
@@ -464,10 +439,18 @@ export interface CreateVendoConfig {
       generation and the system-prompt summary), so unlike design-rules/brief
       it is not re-read live. */
   theme?: VendoTheme;
-  /** cse lane 3 — programmatic override for the product brief surface (03-agent
-      §3; the same prose `.vendo/brief.md` carries). A non-blank string wins
-      over the file; blank falls through. */
-  brief?: string;
+  /** THE prose the deployment puts in front of the agent, every turn: what this
+      product is, who uses it, the house voice, what to emphasize (03-agent §3).
+      One knob — `brief` and `agent.instructions` were the same thing under two
+      names, and a host had to guess which one it wanted.
+
+      Programmatic override for the `.vendo/brief.md` surface, which is what
+      `vendo init` writes and the CLI keeps maintaining: a non-blank string wins
+      over the file (and over `profile.brief`); blank falls through. It rides
+      the assembled system prompt's Product section, where the brief has always
+      ridden — so a deployment that only has `.vendo/brief.md` sees no change at
+      all. Policy belongs in guard directions, not here. */
+  instructions?: string;
   store?: VendoStore;
   /** Build contract §3.4 / architecture §10 — where workspace file CONTENT
       lives once it outgrows a database row. Unset, the store's own `vendo_blobs`
@@ -492,16 +475,24 @@ export interface CreateVendoConfig {
       Configured, it composes the `vendo_knowledge_search` agent tool; unset,
       the tool does not exist (precedence: selectKnowledge). */
   knowledge?: KnowledgeAdapter;
-  connectors?: Connector[];
-  /** Toolkit scoping for the AUTO-COMPOSED Cloud connector (discovery
-      discipline, 2026-07-25 spec): with VENDO_API_KEY and no explicit
-      `connectors`, the composed cloudTools/cloudConnections pair is scoped to
-      exactly these toolkits — the discovery index, the executable tools, and
-      the connect catalog all bound to the set (instead of lazily advertising
-      the console's whole catalog). Ignored when `connectors` or `connections`
-      is passed explicitly — scope those adapters directly (e.g.
-      `composioConnector({ apps })`). */
-  connectorApps?: string[];
+  /** Where outside-service tools come from — ONE list, two spellings, mixed
+      freely.
+
+      A STRING names a Vendo Cloud connector toolkit (`"gmail"`, `"slack"`):
+      the composed cloudTools/cloudConnections pair is scoped to exactly the
+      strings in this list, so the discovery index, the executable tools and the
+      connect dock's catalog all bind to the same set instead of lazily
+      advertising the console's whole catalog. Strings need VENDO_API_KEY —
+      without one there is no broker, so the toolkits mount nothing and the
+      connect surface refuses by naming the key (the honest unconfigured path,
+      never a silent drop).
+
+      A {@link Connector} OBJECT is an explicit provider (`composioConnector({…})`,
+      `cloudTools({…})`, a host's own) and is used verbatim.
+
+      Unset lets VENDO_API_KEY default the unscoped Cloud connector, exactly as
+      before; an empty array is still a choice ("no connectors"). */
+  connectors?: readonly (string | Connector)[];
   /** 04-actions §3 — an explicit connections adapter; always wins over the
       defaults (precedence: selectConnections). */
   connections?: ConnectionsService;
@@ -510,8 +501,19 @@ export interface CreateVendoConfig {
       generated wiring file, keyed `"<module>#<exportName>"`. Server-action tools
       dispatch in-process through it; a missing key fails closed at execution. */
   serverActions?: Record<string, ServerActionHandler>;
-  policy?: PolicyConfig;
-  judge?: Judge;
+  /** 05-guard — the deployment's choke point, as ONE value.
+
+      `guard({ policy, judge, approvals })` from `@vendoai/guard` declares the
+      host's RULES and lets this composition finish them: the store, the app/
+      service risk resolver, the org-policy layer and the cloud policy fallback
+      are plumbing only a venue can supply, so they are never on the spec (the
+      same standalone-value-completed-by-the-venue shape `vendo()` and `agent()`
+      already use). A built `VendoGuard` — `createGuard({ store, … })` — is
+      taken VERBATIM instead, adapter-rule style: this composition adds nothing
+      to it, so a host that wants the resolver and the org layer passes rules,
+      not an instance. Unset composes the same unconfigured-posture guard it
+      always did. */
+  guard?: VendoGuard | GuardRules;
   secrets?: SecretsProvider;
   telemetry?: boolean;
   /** Development-only injection seams (e.g. /dev/inclient-approval).
@@ -591,11 +593,10 @@ export interface CreateVendoConfig {
       `actAs`/`principal` (the door is agnostic; the umbrella owns the shape).
       REQUIRED when `mcp` is true: the door cannot mint principals without it. */
   oauth?: HostOAuthAdapter;
-  /** EITHER the chat-context knobs ({@link AgentOptions}) OR a whole agent
-      built by `agent()` from `@vendoai/agents` — the seam the agents-v0 spec
-      names ("Vendo's embed consumes it across a real seam").
+  /** A whole agent built by `agent()` from `@vendoai/agents` — the seam the
+      agents-v0 spec names ("Vendo's embed consumes it across a real seam").
 
-      Handed an agent, this deployment ADOPTS what that agent already composed:
+      This deployment ADOPTS what that agent already composed:
       its harness (who thinks), its store and blob adapter (where the
       transcript and the workspace live), its sandbox (with the agent-level
       egress skin and its boot audit row), and its `instructions`. Passing any
@@ -606,7 +607,7 @@ export interface CreateVendoConfig {
       org policy and app-tool risk grading a standalone agent has no notion of)
       and the host tool surface (`.vendo/tools.json`). The agent's own guard and
       tools keep serving its own `session()` calls. */
-  agent?: AgentOptions | ComposedAgent;
+  agent?: ComposedAgent;
   /** 02-store §4 (kill-list B3) — ephemeral (anonymous) session lifecycle.
       Anonymous visitors get a TTL-based session on disk: every request touches
       it; an idle session is swept — its rows erased from the store and its
@@ -621,16 +622,23 @@ export interface CreateVendoConfig {
     sweepIntervalMs?: number;
     now?: () => number;
   };
-  /** Existing-agents — approval lifecycle knobs.
-      - `parkedCallTtlMs` idle timeout for a guarded call parked from a BYO
-        agent loop (a `vendo/approval-ref@1` envelope with no Vendo thread to
-        resume through). Past it, the sweep denies the approval through the
-        existing abandonment semantics and `<VendoApprovalEmbed>` reads
-        "expired". Default 60 min; `0` disables expiry. Vendo-thread approvals
-        are untouched — their abandonment stays turn-driven (AGENT-6). */
-  approvals?: {
-    parkedCallTtlMs?: number;
-  };
+  /** How much of one tool's response may reach the model, in characters
+      (default DEFAULT_TOOL_OUTPUT_CAP; `0` disables). Composition's, not the
+      thinker's: the same number bounds the agent loop's context, the harness
+      bridge, and the connector-discovery registry's own search results, and a
+      harness cannot reach two of those three. */
+  toolOutputCap?: number;
+  /** ENG-252 — cap on the uncurated initial tool loadout; the rest stay
+      discoverable via `find_tools`. Defaults to the agent block's
+      DEFAULT_MAX_INITIAL_TOOLS. A discovery-rail knob, and the rail is built
+      here and handed to BOTH thinkers, so it stays on the composition. */
+  maxInitialTools?: number;
+  /** ENG-252 — explicit curated initial loadout by tool name. When set,
+      exactly these host tools (that exist and are enabled) start active — the
+      cap is not applied; the rest stay discoverable via `find_tools`. Vendo's
+      own `vendo_*` tools are always active. Same rail, same reason, as
+      `maxInitialTools`. */
+  loadout?: readonly string[];
   /** Apps-block options.
 
       Machine-backed execution (layer 2) has no flag: it is gated by exactly one
@@ -702,12 +710,6 @@ export interface CreateVendoConfig {
     09-vendo contract text). */
 const DEFAULT_SESSION_TTL_MS = 30 * 60_000;
 const DEFAULT_SESSION_SWEEP_INTERVAL_MS = 60_000;
-/** Existing-agents — a BYO loop has no turn-driven abandonment sweep, so an
-    orphaned approval card in a foreign chat expires on time instead: generous
-    enough to walk away and come back, bounded enough that stale writes can't
-    be approved days later. */
-const DEFAULT_PARKED_CALL_TTL_MS = 60 * 60_000;
-
 interface ResolvedSessions {
   ttlMs: number;
   sweepIntervalMs: number;
@@ -726,17 +728,6 @@ function validateSessionsConfig(sessions: CreateVendoConfig["sessions"]): Resolv
     throw new VendoError("validation", "sessions.sweepIntervalMs must be a positive integer");
   }
   return { ttlMs, sweepIntervalMs, ...(sessions?.now === undefined ? {} : { now: sessions.now }) };
-}
-
-function validateParkedCallTtl(approvals: CreateVendoConfig["approvals"]): number {
-  const parkedCallTtlMs = approvals?.parkedCallTtlMs ?? DEFAULT_PARKED_CALL_TTL_MS;
-  if (!Number.isInteger(parkedCallTtlMs) || parkedCallTtlMs < 0) {
-    throw new VendoError(
-      "validation",
-      "approvals.parkedCallTtlMs must be a non-negative integer (0 disables parked-call expiry)",
-    );
-  }
-  return parkedCallTtlMs;
 }
 
 /** Operator-tuned env knobs must be positive integer milliseconds. A typo
@@ -768,24 +759,32 @@ function cloudKeyOptions(): { apiKey: string; baseUrl?: string } | undefined {
   return { apiKey, ...(baseUrl === undefined ? {} : { baseUrl }) };
 }
 
-/** ADAPTER RULE, connectors seam: which Connector[] feeds the actions
-    registry. An explicitly passed array always wins — including an empty one
-    ("no connectors" is a choice). Only a wholly unset slot lets
-    VENDO_API_KEY default the Cloud tools connector (Composio tools brokered
-    through the console; the connections seam below independently resolves to
-    the cloud broker for the SAME posture, so connect and use stay paired). */
-function selectConnectors(configured: Connector[] | undefined, connectorApps?: string[]): Connector[] {
-  if (configured !== undefined) return configured;
+/** ADAPTER RULE, connectors seam: which Connector[] feeds the actions registry,
+    and which Cloud toolkits the composed pair is scoped to.
+
+    ONE list carries both spellings. A Connector object is used verbatim; a
+    string names a Cloud toolkit, and the strings together compose the scoped
+    cloudTools connector — which is also what the connections seam below scopes
+    its catalog to, so connect and use can never advertise different sets.
+
+    An explicitly passed list always wins — including an empty one ("no
+    connectors" is a choice). Only a wholly unset slot lets VENDO_API_KEY
+    default the UNSCOPED Cloud tools connector. Strings with no key mount
+    nothing: there is no broker to reach them through, and the connections seam
+    says so by name rather than dropping them quietly. */
+function selectConnectors(
+  configured: readonly (string | Connector)[] | undefined,
+  toolkits: string[],
+): Connector[] {
   const apiKey = environment("VENDO_API_KEY");
-  if (apiKey !== undefined) {
-    const baseUrl = environment("VENDO_CLOUD_URL");
-    return [cloudTools({
-      apiKey,
-      ...(baseUrl === undefined ? {} : { baseUrl }),
-      ...(connectorApps === undefined ? {} : { apps: connectorApps }),
-    })];
+  const baseUrl = environment("VENDO_CLOUD_URL");
+  const cloudArgs = { ...(baseUrl === undefined ? {} : { baseUrl }) };
+  if (configured === undefined) {
+    return apiKey === undefined ? [] : [cloudTools({ apiKey, ...cloudArgs })];
   }
-  return [];
+  const explicit = configured.filter((entry): entry is Connector => typeof entry !== "string");
+  if (toolkits.length === 0 || apiKey === undefined) return explicit;
+  return [...explicit, cloudTools({ apiKey, ...cloudArgs, apps: toolkits })];
 }
 
 /** ADAPTER RULE, knowledge seam (ENG-368): which KnowledgeAdapter (if any)
@@ -854,17 +853,28 @@ function withDisconnectInvalidation(
 function selectConnections(
   configured: ConnectionsService | undefined,
   connectors: Connector[],
-  connectorApps?: string[],
+  toolkits: string[],
 ): ConnectionsService {
   if (configured !== undefined) return configured;
   if (connectors.some(hasConnections)) return byoConnections(connectors);
   const cloud = cloudKeyOptions();
-  if (cloud === undefined) return unconfiguredConnections();
-  // The same host scoping the composed cloudTools carries — the connect
-  // dock's catalog must never advertise a toolkit the agent cannot invoke.
+  // Named toolkits with no key: the honest unconfigured surface, but saying
+  // which fix THIS config needs. Silently mounting nothing was the old
+  // `connectorApps` trap and it does not survive in any form.
+  if (cloud === undefined) {
+    return unconfiguredConnections(
+      toolkits.length === 0
+        ? undefined
+        : `createVendo({ connectors: [${toolkits.map((toolkit) => `"${toolkit}"`).join(", ")}] }) names Vendo Cloud `
+          + "toolkits, which are brokered by the console: set VENDO_API_KEY, or pass a connector object "
+          + `instead (composioConnector({ apps: [${toolkits.map((toolkit) => `"${toolkit}"`).join(", ")}] }))`,
+    );
+  }
+  // The same scoping the composed cloudTools carries — the connect dock's
+  // catalog must never advertise a toolkit the agent cannot invoke.
   return cloudConnections({
     ...cloud,
-    ...(connectorApps === undefined ? {} : { apps: connectorApps }),
+    ...(toolkits.length === 0 ? {} : { apps: toolkits }),
   });
 }
 
@@ -1530,6 +1540,11 @@ export function createVendo(input: CreateVendoConfig): Vendo {
   // Once per key per process: a deployment composes once, but a multi-tenant
   // venue composes per session and repeated advice is noise nobody reads.
   warnDeprecatedConfigKeys(config as Record<string, unknown>);
+  // …and a key that is GONE refuses to compose, naming its replacement. Types
+  // catch this for a TypeScript host; a JavaScript one would otherwise lose its
+  // `policy` silently and run wide open, which is the one failure mode a config
+  // change must never have.
+  rejectRemovedConfigKeys(config as Record<string, unknown>);
   // 09-vendo §2.1 — one preset or the per-seam trio, never mixed. Checked
   // before anything is constructed so a miswired config leaks no resources.
   if (config.auth !== undefined) {
@@ -1546,12 +1561,6 @@ export function createVendo(input: CreateVendoConfig): Vendo {
   // beside the auth mixing check and for the same reason: a slot filled twice
   // is a wiring mistake the host hears about before anything is constructed.
   const composed = adoptAgent(config);
-  // Whichever arm of `agent:` this is, the chat knobs read from ONE place. A
-  // composed agent carries only `instructions`; the rest are the embed's own
-  // context controls, which a standalone agent has no equivalent of.
-  const agentOptions: AgentOptions = composed === undefined
-    ? (config.agent as AgentOptions | undefined) ?? {}
-    : composed.instructions === undefined ? {} : { instructions: composed.instructions };
   // The three seams the identity story fills: from the preset, from the
   // per-seam trio, or — with neither `auth` nor `principal` — the anonymous
   // default resolver (every session ephemeral, 00 conventions "identity
@@ -1622,7 +1631,10 @@ export function createVendo(input: CreateVendoConfig): Vendo {
   // onto exactly that model (bindVendoModelSlots — per createVendo instance,
   // no process-level registry). A custom judge without a model, or a judge
   // built on a BYO model object, is untouched — and there is NO judge default.
-  bindVendoModelSlots(config.judge?.model, config.models);
+  bindVendoModelSlots(
+    isGuardInstance(config.guard) ? undefined : config.guard?.judge?.model,
+    config.models,
+  );
   // cse lane 3 — the Cloud hosted-config adapter, selected at THIS composition
   // seam from VENDO_API_KEY (adapter rule: the surfaces themselves never read
   // the key; cloudKeyOptions lives only here). Constructing it is PURE (closures
@@ -1697,7 +1709,12 @@ export function createVendo(input: CreateVendoConfig): Vendo {
   // file/cloud legs entirely (inline wins with no merge — 00-overview
   // decision 19); an unset piece leaves the guard's own file/cloud reads
   // unchanged.
-  const configPolicy: PolicyConfig | undefined = config.policy ?? (
+  //
+  // The `guard:` slot's spec arm is where the host's rules live now; an
+  // INSTANCE arm brings its own and is taken verbatim below, so there are no
+  // rules to complete.
+  const guardRules: GuardRules = isGuardInstance(config.guard) ? {} : config.guard ?? {};
+  const configPolicy: PolicyConfig | undefined = guardRules.policy ?? (
     config.profile?.policy === undefined ? undefined : {
       rules: config.profile.policy.rules ?? [],
       directions: config.profile.policy.directions ?? [],
@@ -1717,9 +1734,14 @@ export function createVendo(input: CreateVendoConfig): Vendo {
   // label the guard never sees and is invalidated on first use.
   const resolveRisk: RiskResolver = async (call, _descriptor, ctx) =>
     (await resolveAppToolRisk?.(call, ctx)) ?? await serviceToolRisk(call);
-  const guard = createGuard({
+  // ADAPTER RULE, guard seam: a built VendoGuard is this deployment's choke
+  // point verbatim; rules are completed here with the plumbing only a
+  // composition can supply — the store, the app/service risk resolver, the
+  // cloud policy fallback, the org layer. ONE constructor either way.
+  const guard = isGuardInstance(config.guard) ? config.guard : createGuard({
     store,
     resolveRisk,
+    ...(guardRules.approvals === undefined ? {} : { approvals: guardRules.approvals }),
     ...(configPolicy === undefined ? {} : { policy: configPolicy }),
     // cse lane 3 — a cloud policy.json body, consulted by the resolver STRICTLY
     // AFTER the local file and only within its existing opt-in path (decision
@@ -1732,7 +1754,7 @@ export function createVendo(input: CreateVendoConfig): Vendo {
         return resolved.owner === "cloud" ? resolved.value : undefined;
       },
     }),
-    ...(config.judge === undefined ? {} : { judge: config.judge }),
+    ...(guardRules.judge === undefined ? {} : { judge: guardRules.judge }),
     // Build contract §9.10 — the org-admin layer, composed at the seam like
     // every other adapter choice: the guard evaluates rules, this reads them.
     // Callers with no asserted memberships (every unkeyed deployment, and any
@@ -1828,7 +1850,9 @@ export function createVendo(input: CreateVendoConfig): Vendo {
   }
   // Connectors seam (adapter rule): explicit array wins, VENDO_API_KEY
   // defaults the Cloud tools connector for a wholly unset slot.
-  const resolvedConnectors = selectConnectors(config.connectors, config.connectorApps);
+  // One list, two spellings: strings are Cloud toolkits, objects are providers.
+  const connectorToolkits = (config.connectors ?? []).filter((entry): entry is string => typeof entry === "string");
+  const resolvedConnectors = selectConnectors(config.connectors, connectorToolkits);
   // #557 — cloud overrides.json feeds the actions registry's tool ENABLEMENT
   // (disabled/audience), not only app-generation semantics. The registry
   // resolves `config.overrides` ONCE through its memoized `loadHost`, and every
@@ -1986,7 +2010,10 @@ export function createVendo(input: CreateVendoConfig): Vendo {
   // the resume-on-decide subscriber (same onApprovalDecision seam apps and
   // automations ride), the wire's per-approval read, and the TTL sweep leg.
   const byoApprovals = createByoApprovals({ guard, tools: boundTools, store });
-  const parkedCallTtlMs = validateParkedCallTtl(config.approvals);
+  // The guard owns its approval lifecycle: whether the rules arrived as a spec
+  // this composition completed or as a built instance, the number is read off
+  // the guard, so a host that brings its own never loses the knob.
+  const parkedCallTtlMs = guard.approvals.parkedCallTtlMs;
   // Theme surface (cse lane 3, boot-once/next-load STRUCTURAL): explicit config
   // wins; else the in-memory profile piece (Task 15a); else file → cloud. The
   // compose-time `theme` value (config/profile/file only, no cloud) still feeds
@@ -2450,7 +2477,7 @@ export function createVendo(input: CreateVendoConfig): Vendo {
   // discovery registry — which bounds its own search under it rather than being
   // cut by it (the cap slices serialized JSON, so a search that reaches it loses
   // a schema mid-object).
-  const toolOutputCap = agentOptions.toolOutputCap ?? DEFAULT_TOOL_OUTPUT_CAP;
+  const toolOutputCap = config.toolOutputCap ?? DEFAULT_TOOL_OUTPUT_CAP;
   // The connector-discovery tools (design 2026-08-03), on the SAME registry, each
   // only as far as an adapter backs it — the "no adapter, no tool" rule knowledge
   // follows below, applied per tool rather than per registry.
@@ -2551,19 +2578,24 @@ export function createVendo(input: CreateVendoConfig): Vendo {
     surface: missSurface,
     ...(missCloud === undefined ? {} : { cloud: missCloud }),
   });
-  // AGENT-1/2 — 03 §3: the host product brief (init writes .vendo/brief.md)
-  // and the catalog+theme summary feed the system prompt; prompt.ts places
-  // them (brief = Product section; summary only where trees render).
-  // cse lane 3 — brief is a prompt-family surface, so it resolves LIVE: with a
-  // key present, product is a RESOLVER (file → cloud) re-read per turn by
+  // AGENT-1/2 — 03 §3: ONE prose story. `instructions` and the
+  // `.vendo/brief.md` surface behind it are the deployment's own words about
+  // what this product is and how to speak about it; prompt.ts places them (the
+  // Product section) beside the catalog+theme summary (only where trees
+  // render). `brief:` and `agent.instructions` were two names for this and are
+  // gone.
+  // cse lane 3 — a prompt-family surface, so it resolves LIVE: with a key
+  // present, product is a RESOLVER (file → cloud) re-read per turn by
   // assembleSystemPrompt, so a console publish applies to the next turn with no
   // restart. Without a key, product is the compose-time file/explicit value (no
-  // snapshot read → no I/O at compose). A programmatic `brief` wins over the
-  // file either way. Task 15a: the in-memory profile.brief sits between them —
-  // below the explicit `brief` knob, above the file/cloud surface — and an
-  // explicitly empty one means "no brief" (it never falls through to disk).
-  const resolveBrief = (cloud?: CloudConfig): string | undefined => {
-    const explicit = config.brief?.trim();
+  // snapshot read → no I/O at compose). Programmatic `instructions` wins over
+  // the file either way; an adopted agent's own `instructions` is the same slot
+  // (AGENT_OWNED_KEYS refuses both at once). Task 15a: the in-memory
+  // profile.brief sits between them — below the explicit knob, above the
+  // file/cloud surface — and an explicitly empty one means "no brief" (it never
+  // falls through to disk).
+  const resolveInstructions = (cloud?: CloudConfig): string | undefined => {
+    const explicit = (config.instructions ?? composed?.instructions)?.trim();
     if (explicit) return explicit;
     if (config.profile?.brief !== undefined) return config.profile.brief.trim() || undefined;
     return selectConfigSurface("brief.md", {
@@ -2572,16 +2604,14 @@ export function createVendo(input: CreateVendoConfig): Vendo {
     }).value?.trim() || undefined;
   };
   const product: string | (() => string | undefined) | undefined = configCloud === undefined
-    ? resolveBrief()
-    : () => resolveBrief(configCloud);
+    ? resolveInstructions()
+    : () => resolveInstructions(configCloud);
   const promptCatalog = catalogThemeSummary(catalog, theme);
-  const hostInstructions = agentOptions.instructions?.trim();
-  const system = product !== undefined || hostInstructions || promptCatalog !== undefined || knowledgeIndex !== undefined
+  const system = product !== undefined || promptCatalog !== undefined || knowledgeIndex !== undefined
     ? {
         ...(product === undefined ? {} : { product }),
         ...(promptCatalog === undefined ? {} : { catalog: promptCatalog }),
         ...(knowledgeIndex === undefined ? {} : { knowledge: knowledgeIndex }),
-        ...(hostInstructions ? { instructions: hostInstructions } : {}),
       }
     : undefined;
   // ONE definition of each discovery rail, driven by BOTH thinkers: `createAgent`
@@ -2615,14 +2645,14 @@ export function createVendo(input: CreateVendoConfig): Vendo {
     // this composition; turns only run after createVendo returns, so the
     // closure reference is safe.
     seed: () => loadoutSeedFor(),
-    // The curated agent menu also binds an explicit `agent.loadout`: host
-    // config chooses WITHIN the menu, it does not escape it.
+    // The curated agent menu also binds an explicit `loadout`: host config
+    // chooses WITHIN the menu, it does not escape it.
     menu: async () => {
       const menu = await agentMenu();
       return menu === undefined ? undefined : [...menu];
     },
-    ...(agentOptions.maxInitialTools === undefined ? {} : { maxInitialTools: agentOptions.maxInitialTools }),
-    ...(agentOptions.loadout === undefined ? {} : { loadout: agentOptions.loadout }),
+    ...(config.maxInitialTools === undefined ? {} : { maxInitialTools: config.maxInitialTools }),
+    ...(config.loadout === undefined ? {} : { loadout: [...config.loadout] }),
   };
   const agent = createAgent({
     model: inference.agent.model,
@@ -2630,12 +2660,9 @@ export function createVendo(input: CreateVendoConfig): Vendo {
     guard,
     store,
     ...(system === undefined ? {} : { system }),
-    context: {
-      toolOutputCap,
-      ...(agentOptions.maxOutputTokens === undefined ? {} : { maxOutputTokens: agentOptions.maxOutputTokens }),
-      ...(agentOptions.historyWindow === undefined ? {} : { historyWindow: agentOptions.historyWindow }),
-      ...(agentOptions.maxSteps === undefined ? {} : { maxSteps: agentOptions.maxSteps }),
-    },
+    // The loop's own step/history/token knobs are the THINKER's and live on
+    // `vendo({ … })` now; this legacy route keeps the loop defaults.
+    context: { toolOutputCap },
     capabilityMiss,
     toolSearch,
     // Discovery-discipline: the same connect check the gate-wrapped registry
@@ -2664,20 +2691,12 @@ export function createVendo(input: CreateVendoConfig): Vendo {
   // A composed agent IS a harness choice (its brain, with its knobs already
   // bound and its sandbox already injected), so it takes the same slot.
   //
-  // The host's `agent:` context knobs reach BOTH thinkers. They used to reach
-  // `createAgent` only, so on the default (harness) route a configured history
-  // window or step cap was silently ignored — the same deployment, two answers,
-  // depending on which door happened to serve. A composed harness already
-  // carries its own bound knobs, so only the default construction takes them.
-  const harness = (composed?.harness ?? config.harness ?? vendo({
-    onHire: reportHire,
-    // `agentOptions` is the ONE place the chat knobs are read from (see its
-    // definition): it already normalizes both arms of `agent:`, so a composed
-    // agent contributes nothing here and cannot double-bind its own knobs.
-    ...(agentOptions.maxSteps === undefined ? {} : { maxSteps: agentOptions.maxSteps }),
-    ...(agentOptions.historyWindow === undefined ? {} : { historyWindow: agentOptions.historyWindow }),
-    ...(agentOptions.maxOutputTokens === undefined ? {} : { maxOutputTokens: agentOptions.maxOutputTokens }),
-  })) as Harness;
+  // The loop's context knobs (`maxSteps`, `historyWindow`, `maxOutputTokens`,
+  // `contextTokenBudget`) belong to whoever thinks, so they are set where the
+  // thinker is named — `harness: vendo({ maxSteps: 40 })`. They used to be
+  // createVendo's own `agent:` knobs, which meant a host configured the thinker
+  // through a key the thinker never saw.
+  const harness = (composed?.harness ?? config.harness ?? vendo({ onHire: reportHire })) as Harness;
   assertHarnessComposable(harness, sandbox.adapter === undefined ? {} : { sandbox: sandbox.adapter });
   // The harness runtime, wired to everything a turn needs: the store handle (its
   // transcript and its workspace), the ONE guard-bound registry, the merged pack
@@ -3119,7 +3138,7 @@ export function createVendo(input: CreateVendoConfig): Vendo {
   // Out-of-band revocation — a host calling the adapter directly, or a user
   // revoking in the provider's own dashboard — stays bounded by the 60s TTL,
   // which no cache can improve on.
-  const selectedConnections = selectConnections(config.connections, resolvedConnectors, config.connectorApps);
+  const selectedConnections = selectConnections(config.connections, resolvedConnectors, connectorToolkits);
   const connections = withDisconnectInvalidation(
     selectedConnections,
     (subject) => connectedToolkitsCache.delete(subject),


### PR DESCRIPTION
**BREAKING (config surface only — zero semantic change).** `createVendo`'s
config now says one thing once: `guard()` is a value, prose has one name,
connectors are one list, and the `agent:` grab-bag is gone.

Four incoherences, one shape each:

- the guard was constructed **invisibly** from three flat keys while `agent()`
  next door took a guard **instance**;
- `brief` and `agent.instructions` were the same prose under two names;
- `connectorApps` was a modifier of `connectors` that was **silently ignored**
  whenever `connectors` or `connections` was set;
- `agent:` was one bag holding a whole agent **or** seven unrelated knobs, three
  of which configured a thinker that never saw them.

## Deleted key → new home

| Removed | Replacement |
| --- | --- |
| `policy` | `guard: guard({ policy })` |
| `judge` | `guard: guard({ judge })` |
| `approvals` | `guard: guard({ approvals })` |
| `brief` | `instructions` |
| `agent.instructions` | `instructions` |
| `connectorApps: ["gmail"]` | `connectors: ["gmail"]` |
| `agent.toolOutputCap` | `toolOutputCap` |
| `agent.maxInitialTools` | `maxInitialTools` |
| `agent.loadout` | `loadout` |
| `agent.maxSteps` | `harness: vendo({ maxSteps })` |
| `agent.historyWindow` | `harness: vendo({ historyWindow })` |
| `agent.maxOutputTokens` | `harness: vendo({ maxOutputTokens })` |

`createVendo` **refuses to compose** against any of them, naming the replacement
(`rejectRemovedConfigKeys`). TypeScript already rejects every one; the boot error
is for the JavaScript host, where a dropped `policy` would mean an unconfigured
guard running wide open.

## 1. `guard` is one slot with two arms

`guard({ policy, judge, approvals })` — a new public factory in
`@vendoai/guard`, re-exported from `@vendoai/vendo/server` — declares the host's
RULES and lets composition finish them with the plumbing only a venue has: the
store, the app/service risk resolver, the org-policy layer, the cloud policy
fallback. A built `VendoGuard` is taken **verbatim** instead (adapter rule).
`agent({ guard })` in `@vendoai/agents` accepts the same union.

Like `defineHarness`, `guard()` is identity — it exists for the authoring
vocabulary, so `guard: { policy }` is the same value. **There is one
constructor:** `createGuard` is still where both arms end, and the guard's
runtime behaviour is untouched (its own 268 tests pass unmodified).

`CreateGuardConfig` now also takes `approvals.parkedCallTtlMs`, and the guard
exposes the resolved number at `guard.approvals.parkedCallTtlMs`. That is what
lets an instance-passing host keep the knob instead of losing it with the rules
that used to arrive beside it — the umbrella's two sweeps read it off the guard.

## 2. One prose story

`instructions` is what this product is, who uses it, and the house voice, placed
in the assembled prompt's Product section every turn. It is the programmatic
override for `.vendo/brief.md`, which `vendo init` still writes and still feeds
this key.

**The one behaviour difference, documented:** prose that arrived through
`agent.instructions` used to be appended as the LAST section of the system
prompt, after the guard's directions and the component catalog. It now rides the
Product section near the top, where `brief` always did. Every deployment whose
prose came from `brief` or `.vendo/brief.md` — which is every deployment `vendo
init` scaffolded — gets a byte-identical prompt. `apps.designRules` is untouched
(different audience, different lifecycle).

`instructions` joins `harness`/`store`/`files`/`sandbox` as a slot an adopted
`agent()` owns, so filling it twice is a boot error rather than one side
silently losing.

## 3. Connectors consolidated

`connectors?: readonly (string | Connector)[]`. A string names a Vendo Cloud
toolkit and scopes the composed cloudTools/cloudConnections pair to exactly that
set; an object is an explicit provider, used verbatim; mix freely. Strings with
no `VENDO_API_KEY` mount nothing and the connect surface refuses through the
existing unconfigured path, with a message naming both fixes.

The old key's silent-ignore trap cannot survive in any form, because there is no
longer a second list to ignore.

## 4. The knobs split by owner

What the deployment **curates** is composition's and sits at the top level:
`toolOutputCap` (one number bounding the agent loop's context, the harness
bridge, and the connector-discovery registry's own search results — a harness
can reach only one of those three), `maxInitialTools` and `loadout` (the
discovery rail is built in composition and handed to BOTH thinkers, so the rail's
knobs cannot ride a harness value).

What the **thinker** decides rides the thinker: `maxSteps`, `historyWindow`,
`maxOutputTokens` were already `VendoHarnessDeps` members that the default-harness
composition passed through, so they became `harness: vendo({ … })` deps.
Consequence, stated: the legacy `createAgent` route (only reachable on a store
with no SQL handle) keeps the loop defaults for those three — a harness a host
names is already ignored entirely on that route.

`agent?: ComposedAgent` now means exactly one thing.

## Proof

`packages/vendo/src/config-coherence.test.ts` (16 tests, new) pins each claim
against the literal main produced, since the old shapes cannot be composed
side by side:

- **guard decisions** — read/write/destructive through the real guarded registry
  produce `ok` / `pending-approval` / `blocked` for the spec arm, a bare rules
  object, and a built instance alike;
- **the prompt** — `instructions: X` and `.vendo/brief.md` containing X produce
  **byte-identical** system prompts, and X lands in `\n\nProduct\n…`;
- **the connector catalog** — `connectors: ["gmail"]` yields the same scoped tool
  set and the same one-row connect catalog `connectorApps: ["gmail"]` yielded
  (the literals `server.test.ts` has pinned since that criterion landed);
- **the no-key path** — a real `selectConnections` walk: `posture: false`, and
  `initiate` throws naming `VENDO_API_KEY`, `composioConnector`, and the exact
  toolkits asked for;
- **the removed keys** — six boot errors, each naming its replacement.

**Proven they can fail.** Two reverts, each restored after:

1. point the prose chain at the trailing `system.instructions` slot →
   `2 failed | 14 passed` (`expected 'You are Vendo's agent…' to contain
   '\n\nProduct\nCOHERENCE-PROBE…'`);
2. drop `apps: toolkits` from `selectConnectors` and the sharpened
   `unconfiguredConnections` message → `3 failed | 13 passed`
   (`expected [ 'vendo_make', …(11) ] to include 'gmail_GMAIL_SEND_THING'`).

Restored: `16 passed`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the `createVendo` config for clarity and safety: `guard()` is a first-class value, prose is unified under `instructions`, connectors are one list, and the `agent:` grab-bag is removed. This is a breaking config change with no runtime behavior changes.

- **Refactors**
  - `guard` is one slot that accepts `guard({ policy, judge, approvals })` or a `VendoGuard` instance; exported from `@vendoai/guard` and re-exported by `@vendoai/vendo/server`. `createGuard` remains the single constructor; `isGuardInstance` added for discrimination.
  - Guard approvals add `parkedCallTtlMs` (0 disables) with validation and a default; exposed at `guard.approvals.parkedCallTtlMs`.
  - Prose is now `instructions` (replaces `brief` and `agent.instructions`) and sits in the Product section; `.vendo/brief.md` still feeds it. Only change: former `agent.instructions` now appears earlier in the system prompt.
  - `connectors` is a single list: strings (Vendo Cloud toolkits) or objects (custom providers). Strings require `VENDO_API_KEY`; `connectorApps` is removed. The unconfigured path now returns a sharper message when toolkit strings are used without a broker.
  - `agent:` is only for adopting a `ComposedAgent`. Knobs move:
    - Top level: `toolOutputCap`, `maxInitialTools`, `loadout`.
    - Harness deps: `maxSteps`, `historyWindow`, `maxOutputTokens` (via `harness: vendo({ … })`).
  - Composition rejects removed keys with a clear replacement message (TypeScript and JS).

- **Migration**
  - `policy`/`judge`/`approvals` → `guard: guard({ policy, judge, approvals })`.
  - `brief` and `agent.instructions` → `instructions`.
  - `connectorApps: ["gmail"]` → `connectors: ["gmail"]`.
  - `agent.toolOutputCap` → `toolOutputCap`.
  - `agent.maxInitialTools` → `maxInitialTools`.
  - `agent.loadout` → `loadout`.
  - `agent.maxSteps`/`agent.historyWindow`/`agent.maxOutputTokens` → `harness: vendo({ maxSteps, historyWindow, maxOutputTokens })`.
  - If using toolkit strings, set `VENDO_API_KEY` or supply a `composioConnector`.
  - Expect boot errors if old keys are present; fix using the mappings above.

<sup>Written for commit 5efb177bbf03af767f0f75399af4b2da795fed1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

