### PR TITLE
refactor(apps,core)!: vendo_make has one engine — assembly that produces no screen fails honestly

### DIFF
--- a/.changeset/unavailable-fails-honestly.md
+++ b/.changeset/unavailable-fails-honestly.md
@@ -1,0 +1,34 @@
+---
+"@vendoai/apps": major
+"@vendoai/core": major
+---
+
+`vendo_make` has ONE engine. Assembly that produces no screen is the answer.
+
+`ScreenOutcome.unavailable` used to fall through to the conductor, and so did an
+unwired assembler, an assembler that threw, and an `assembled` that left no app
+row behind. All four now end the ask with a FAILED `MakeReceipt` whose `say`
+names what happened — the assembler's own `why` verbatim where there is one.
+
+A quiet fall-through is how a composition bug ships: a deployment that forgot to
+fill `apps.screen`, or whose assembler is broken, read all-green while every ask
+was served by an engine nobody chose. It reads as broken now.
+
+`escalate` is unchanged — it is a request for the builder, not the seam failing,
+and a deployment with a sandbox still runs the build at the same app id.
+
+**Migration**
+
+- **`apps.screen` is required for `vendo_make`.** `createVendo()` fills it; a host
+  composing `@vendoai/apps` directly must pass a `ScreenAssembler` or `vendo_make`
+  will answer `status: "failed"` on every new-app request. `AppsRuntime.create`
+  and `AppsRuntime.edit` are unaffected and still generate.
+- **`conductCreate`, `conductEdit`, `ConductedApp`, `ConductedResult` and
+  `ConductorOptions` are no longer exported from `@vendoai/apps`.** They were
+  public for "external bench harnesses"; a reverse-dependency walk found no
+  caller in this repo, the examples, the corpus harness or the docs. The pipeline
+  still runs inside `createApps()` — it just has no public surface to be extended
+  through.
+- `generationPromptSections` (internal, `generation/contracts/sections.ts`) is
+  deleted: no caller, and a second unmaintained description of the v2 tree
+  contract is worse than none.

--- a/examples/ai-sdk-agent/e2e/byo-agent.e2e.test.ts
+++ b/examples/ai-sdk-agent/e2e/byo-agent.e2e.test.ts
@@ -63,25 +63,29 @@ function hostAgentModel(toolName: string, input: unknown): LanguageModel {
   }) as unknown as LanguageModel;
 }
 
-/** Vendo's own model seam: answers `vendo_create_app` generation requests with
- *  a minimal valid tree so the build streams for real. The ask is tiny, so the
- *  brain writes the whole app on the spot (`THEY ARE ASKING NOW:` is the brain's marker). */
+const WEATHER_APP = '<App name="Weather dashboard"><Stack><Text text="Paris, London, and Tokyo at a glance"/><Disclaimer reason="Fixture app."/></Stack></App>';
+
+/** Vendo's own model seam: answers the screen agent's turns so the build
+ *  streams for real. `# In this loop` is the assembly loop's own brief — the
+ *  one marker that says "this prompt is the screen agent's" without counting
+ *  calls — and `save_app` is how that loop lands an app. */
 function generationModel(): LanguageModel {
+  let assembled = false;
   return new MockLanguageModelV3({
     doStream: async ({ prompt }) => {
       const serialized = JSON.stringify(prompt);
-      if (serialized.includes("THEY ARE ASKING NOW:")) {
+      if (serialized.includes("# In this loop") && !assembled) {
+        assembled = true;
         return {
           stream: simulateReadableStream({
             chunks: [
-              { type: "text-start", id: "g1" } as const,
               {
-                type: "text-delta",
-                id: "g1",
-                delta: '<App name="Weather dashboard"><Stack><Text text="Paris, London, and Tokyo at a glance"/><Disclaimer reason="Fixture app."/></Stack></App>',
+                type: "tool-call",
+                toolCallId: "call_save_app",
+                toolName: "save_app",
+                input: JSON.stringify({ content: WEATHER_APP }),
               } as const,
-              { type: "text-end", id: "g1" } as const,
-              finish("stop"),
+              finish("tool-calls"),
             ],
           }),
         };

--- a/examples/mastra-agent/e2e/vendo-seam.e2e.test.ts
+++ b/examples/mastra-agent/e2e/vendo-seam.e2e.test.ts
@@ -117,14 +117,18 @@ async function setup() {
   const dataDir = await mkdtemp(join(tmpdir(), "mastra-example-store-"));
   // Vendo's own model (app generation, the delegate loop) — distinct from the
   // Mastra agent's model, exactly like the example (two models, deliberately).
-  const vendoModel = scripted((prompt) =>
-    prompt.includes(DELEGATE_MARKER) ? textTurn("Weather brief compiled.") : [
-      { type: "text-start", id: "g1" },
-      { type: "text-delta", id: "g1", delta: APP_MARKUP },
-      { type: "text-end", id: "g1" },
-      { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "stop", raw: undefined } },
-    ],
-  );
+  // `# In this loop` is the screen agent's own brief — the marker that says a
+  // prompt belongs to the assembly loop — and `save_app` is how that loop lands
+  // an app. One save is the whole generation for an ask this small.
+  let assembled = false;
+  const vendoModel = scripted((prompt) => {
+    if (prompt.includes(DELEGATE_MARKER)) return textTurn("Weather brief compiled.");
+    if (prompt.includes("# In this loop") && !assembled) {
+      assembled = true;
+      return toolCallTurn("save_app", { content: APP_MARKUP });
+    }
+    return textTurn("ok");
+  });
   const store = createStore({ dataDir });
   cleanups.push(async () => {
     await store.close();

--- a/packages/apps/src/agent-tools.test.ts
+++ b/packages/apps/src/agent-tools.test.ts
@@ -8,8 +8,9 @@ import {
 } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
 import { agentToolDescriptors } from "./agent-tools.js";
-import { createApps } from "./index.js";
+import { createApps, type AppsRuntime } from "./index.js";
 import {
+  authoringAssembler,
   bindTools,
   guardFixture,
   memoryStore,
@@ -294,12 +295,13 @@ describe("apps agent tools", () => {
   it("creates and opens an app through the guard-bound fixture", async () => {
     const store = memoryStore();
     const guard = guardFixture();
-    const runtime = createApps({
+    const runtime: AppsRuntime = createApps({
       store,
       guard,
       tools: hostTools,
       catalog: [],
       model: scriptedLanguageModel(generated),
+      screen: authoringAssembler(() => runtime, generated),
     });
     const bound = bindTools(guard, runtime.agentTools());
 
@@ -339,12 +341,13 @@ describe("apps agent tools", () => {
   it("keeps the raw registry unbound while the umbrella wrapper blocks and audits", async () => {
     const store = memoryStore();
     const guard = guardFixture({ rules: { vendo_make: "block" } });
-    const runtime = createApps({
+    const runtime: AppsRuntime = createApps({
       store,
       guard,
       tools: hostTools,
       catalog: [],
       model: scriptedLanguageModel(generated),
+      screen: authoringAssembler(() => runtime, generated),
     });
     const call = {
       id: "call_unbound_create",

--- a/packages/apps/src/agent-tools.ts
+++ b/packages/apps/src/agent-tools.ts
@@ -231,9 +231,10 @@ const optionalLimit = (value: Json | undefined): number | undefined => {
 export interface AgentToolsDataDependencies {
   data: AppDataAccess;
   requireOwned(appId: AppId, ctx: RunContext): Promise<AppDocument>;
-  /** UI-generation blueprint §1 point 2 — the screen agent, in front of the
-   *  conductor. Threaded from `AppsConfig.screen`, which composition fills; see
-   *  the routing block in the `vendo_make` handler below. */
+  /** UI-generation blueprint §1 point 2 — the screen agent. Threaded from
+   *  `AppsConfig.screen`, which composition fills; see the routing block in the
+   *  `vendo_make` handler below. Unfilled, `vendo_make` has nothing to assemble
+   *  with and says so. */
   screen?: ScreenAssembler;
   /** §4.5's other half — the escalated `plan.vendo`, read back out of the app's
    *  workspace so the build anchors on it. Threaded from
@@ -312,6 +313,26 @@ const nameForUnbuilt = (plan: string | undefined, ask: string): string => {
   return collapsed === "" ? "Vendo app" : collapsed.slice(0, 60);
 };
 
+/**
+ * What an ask that produced no screen says to the person.
+ *
+ * The seam used to answer this with a second engine, so the four ways assembly
+ * can come back empty — unwired, threw, `unavailable`, or `assembled` with no
+ * row — were all silently absorbed. They are now the answer: an unwired
+ * assembler is a composition bug and a composition bug that quietly swaps
+ * engines is a bug nobody fixes. The reason travels verbatim because every one
+ * of these is authored (a `why`, a thrown message, or the two constants below)
+ * and a person reading "I couldn't put that screen together" alone has nothing
+ * to act on.
+ */
+const unbuiltSay = (why: string): string =>
+  why.trim() === ""
+    ? "I couldn't put that screen together."
+    : `I couldn't put that screen together — ${why.trim()}`;
+
+const NO_ASSEMBLER = "nothing in this deployment builds screens.";
+const NOTHING_RENDERABLE = "what came back wasn't something I could show.";
+
 const errorOutcome = (error: unknown): ToolOutcome => {
   if (error instanceof VendoError) {
     return {
@@ -347,20 +368,22 @@ export const createAgentTools = (
           // ── THE SEAM (blueprint §1 point 2) ─────────────────────────────────
           // "No agent chooses 'quick screen' vs 'real build'. Every request
           // starts in the cheap screen agent." The id is minted HERE, before the
-          // route, because both engines have to use the same one: an escalation
-          // leaves `plan.vendo` and its painted skeleton at this id, and a
-          // conductor that minted its own would strand that skeleton on a second
-          // stream as a card that builds forever.
+          // route, because both ends have to use the same one: an escalation
+          // leaves `plan.vendo` and its painted skeleton at this id, and a build
+          // that minted its own would strand that skeleton on a second stream as
+          // a card that builds forever.
           //
-          // Only `assembled` WITH A ROW ends the call. The row is the check that
-          // makes default-safety true instead of merely intended: `authored`
+          // Only `assembled` WITH A ROW ends the call happily. The row is the
+          // check that makes that true instead of merely intended: `authored`
           // upserts it iff the seam actually compiled and painted the document,
-          // so a screen agent that saved bytes nobody can render leaves no row
-          // and this falls through to the conductor exactly as if it had never
-          // been composed.
+          // so a screen agent that saved bytes nobody can render leaves no row.
           //
-          // `escalate` is the one answer that is NOT a fall-through — see below.
+          // TWO answers now, and no third. `escalate` is a request for the
+          // builder (§4.5's receiving end, below); everything else is assembly
+          // coming back empty, and assembly coming back empty is the ANSWER —
+          // there is no second engine behind this seam to rescue it with.
           const appId = `app_${globalThis.crypto.randomUUID()}` as AppId;
+          let threw: string | undefined;
           const routed = dependencies.screen === undefined
             ? undefined
             : await dependencies.screen.assemble({
@@ -370,10 +393,8 @@ export const createAgentTools = (
                 onView: (part) => stream({ id: vendoViewStreamId(part.appId), part }),
               }),
             }, ctx).catch((error: unknown) => {
-              // A broken assembler is a slower answer, never a failed one.
-              console.warn(`[vendo] the screen agent could not serve ${appId}; the conductor takes it — ${
-                error instanceof Error ? error.message : String(error)
-              }`);
+              threw = error instanceof Error ? error.message : String(error);
+              console.warn(`[vendo] the screen agent could not serve ${appId} — ${threw}`);
               return undefined;
             });
           if (routed?.kind === "assembled") {
@@ -389,26 +410,38 @@ export const createAgentTools = (
           }
           // ── §4.5's RECEIVING END ────────────────────────────────────────────
           // An escalation is the screen agent asking for the builder by name; it
-          // is not the seam failing, so it is not a fall-through. Two answers,
-          // and the deployment's own shape picks which:
+          // is not the seam failing. Two answers, and the deployment's own shape
+          // picks which:
           //
           //  - A sandbox is configured → the build runs. Same `create` a
           //    server-needing ask has always taken, at the SAME app id, so the
           //    plan's skeleton and the finished app share one stream and the
           //    outline becomes the app. The escalated plan rides in as the
           //    brief; the ask still travels verbatim.
-          //  - No sandbox → say so. Falling to the conductor here would be
-          //    dishonest twice over: the conductor is assembly too, so it cannot
-          //    serve what assembly just escalated, and it would spend a full
-          //    build's latency to arrive at a worse version of the screen the
-          //    person was already shown. The skeleton is left as it is — the UI
-          //    unmounts a still-forming card once the turn is over
+          //  - No sandbox → say so, rather than spending a full build's latency
+          //    to arrive at a worse version of the screen the person was already
+          //    shown. The skeleton is left as it is — the UI unmounts a
+          //    still-forming card once the turn is over
           //    (`chrome/thread/parts.tsx`), so the last word is this receipt.
           const escalated = routed?.kind === "escalate";
           const plan = !escalated
             ? undefined
             : await dependencies.escalatedPlan?.(appId, ctx).catch(() => undefined);
-          if (escalated && !runtime.machine.available()) {
+          if (!escalated) {
+            // Assembly produced no screen. Said plainly, at the id whose stream
+            // the person is looking at, instead of quietly restarting the ask in
+            // a different engine.
+            return receipt({
+              id: appId,
+              title: nameForUnbuilt(undefined, ask),
+              status: "failed",
+              say: unbuiltSay(
+                dependencies.screen === undefined ? NO_ASSEMBLER
+                  : threw ?? (routed?.kind === "unavailable" ? routed.why : NOTHING_RENDERABLE),
+              ),
+            });
+          }
+          if (!runtime.machine.available()) {
             return receipt({
               id: appId,
               // The name on the skeleton they are looking at, so the sentence and

--- a/packages/apps/src/create-unsaved.test.ts
+++ b/packages/apps/src/create-unsaved.test.ts
@@ -1,7 +1,8 @@
-import type { RunContext, ToolRegistry, VendoViewPart } from "@vendoai/core";
+import type { RunContext, ScreenAssembler, ToolRegistry, VendoViewPart } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
 import { createAgentTools } from "./agent-tools.js";
 import { createApps } from "./index.js";
+import { fakeBoxSandbox } from "./testing/fake-box.js";
 import { basicLanguageModel, guardFixture, memoryStore } from "./testing/index.js";
 
 /**
@@ -83,16 +84,26 @@ describe("a create the store refuses to persist", () => {
   });
 
   it("reads to the agent as success with an honest note — never a failure it would retry", async () => {
+    // Through the front door, which reaches `create` by ESCALATION: the screen
+    // agent asks for the builder and this deployment has a sandbox to build in.
+    // (It used to reach it by falling through from an unwired assembler; that
+    // fall-through is gone, and an unwired assembler now fails loudly.)
+    const escalating: ScreenAssembler = {
+      assemble: async () => ({ kind: "escalate", why: "this needs a real build" }),
+    };
     const runtime = createApps({
       store: storeRefusingAppWrites(),
       guard: guardFixture(),
       tools,
       catalog: [],
       model: basicLanguageModel(),
+      machine: { sandbox: fakeBoxSandbox(), buildEnv: () => ({ PORT: "8080" }), boxEditPollMs: 5 },
+      screen: escalating,
     });
     const agentTools = createAgentTools(runtime, {
       data: {} as never,
       requireOwned: async () => { throw new Error("unused"); },
+      screen: escalating,
     });
 
     const outcome = await agentTools.execute(

--- a/packages/apps/src/generation/conductor.ts
+++ b/packages/apps/src/generation/conductor.ts
@@ -4,9 +4,15 @@
  * The delete blocker named in §7.3 — "the floor's types must be freed first" — is
  * GONE: `checking/` now owns `FloorDependencies` and imports nothing from this
  * directory, and the checks it runs are reachable from the paint seam through
- * `AppFloor`, for every author rather than only for apps this pipeline built. What
- * keeps the file alive is its five `runtime.ts` call sites and the public re-export
- * in `index.ts` — all of which still work, unchanged.
+ * `AppFloor`, for every author rather than only for apps this pipeline built.
+ *
+ * Two of the three things keeping it alive are gone as of 2026-08-05. The public
+ * re-export in `index.ts` had no caller anywhere and was deleted, and `vendo_make`
+ * no longer falls through here when assembly comes back empty — an `unavailable`,
+ * an unwired assembler, a throw and an `assembled` with no row all answer with a
+ * failed receipt now. What remains is the five `runtime.ts` call sites: this is
+ * still the engine behind `AppsRuntime.create` and `AppsRuntime.edit`, which have
+ * no replacement builder yet, so it cannot be deleted without one.
  *
  * The replacement is the LEAN loop plus the floor at the seam (§4.1, §7.1): a
  * builder writes `plan.vendo` / `app.vendo` with its own hands, the seam compiles

--- a/packages/apps/src/generation/contracts/sections.ts
+++ b/packages/apps/src/generation/contracts/sections.ts
@@ -1,49 +1,25 @@
 /**
- * Shared prompt sections — the pieces every generation contract (create,
- * exemplar-led create, edit, instant paint) composes from: role lines, the
- * clock, component styling, the catalog/theme/design-rules trio, the host
- * tool/shape sections, the generated COMPONENTS section, and the
- * island contract.
+ * Shared prompt sections — the pieces every generation contract composes from:
+ * the theme/design-rules pair, the host tool/shape sections, the generated
+ * COMPONENTS section, and the island contract.
+ *
+ * `generationPromptSections` — one monolithic JSON-era contract covering the
+ * role line, the v2 tree contract, the clock, component styling and the catalog
+ * — lived here with no caller left; the dialect contracts each compose their own
+ * sections now. Deleted 2026-08-05 rather than left to rot into a second,
+ * silently diverging source of truth about the tree.
  */
 import {
   KIT_WIRE_COMPONENT_NAMES,
-  RESERVED_COMPONENT_NAMES,
-  TREE_MAX_COMPONENT_SOURCE_BYTES,
-  TREE_MAX_GENERATED_COMPONENTS,
-  TREE_MAX_NODES,
-  TREE_MAX_QUERIES,
-  TREE_MAX_TOTAL_COMPONENT_BYTES,
   describeShapeWithSemantics,
   kitPrompt,
   ISLAND_AMBIENT_KIT_NAMES,
-  type NormalizedCatalog,
 } from "@vendoai/core";
-import { pinComponentName, type PinBaseline } from "../../pins.js";
 import { prewiredSchemaPrompt } from "../../prewired-schema.js";
 import type { GenerationDependencies } from "../engine.js";
 
-const catalogPrompt = (catalog: NormalizedCatalog): string => JSON.stringify(
-  catalog.map(({ name, description, propsJsonSchema, examples }) => ({
-    name,
-    whenToUse: description,
-    propsJsonSchema: propsJsonSchema ?? null,
-    examples: examples ?? [],
-  })),
-  null,
-  2,
-);
-
-const pinBaselinesPrompt = (baselines: readonly PinBaseline[] = []): string => JSON.stringify(
-  baselines.map((baseline) => ({
-    slot: baseline.slot,
-    componentName: pinComponentName(baseline.slot),
-  })),
-  null,
-  2,
-);
-
 export interface GenerationPromptSection {
-  id: "role" | "tree-contract" | "clock" | "component-styling" | "catalog" | "theme" | "design-rules" | "remixable-slots" | "prewired-props" | "limits";
+  id: "role" | "tree-contract" | "clock" | "catalog" | "theme" | "design-rules" | "limits";
   content: string;
 }
 
@@ -76,60 +52,6 @@ export const hostThemeSection = (deps: GenerationDependencies): GenerationPrompt
     id: "theme" as const,
     content: `THEME TOKENS:\n${JSON.stringify(deps.theme, null, 2)}`,
   }];
-
-export const generationPromptSections = (deps: GenerationDependencies): GenerationPromptSection[] => [{
-  id: "role",
-  content: "You are the Vendo app generation engine. Return JSON only, with no markdown.",
-}, {
-  id: "tree-contract",
-  content: `TREE CONTRACT (vendo-genui/v2):
-- At rest the app is {name, description?, tree, components?}; never emit id, server, secrets, egress, storage, or authority.
-- tree.formatVersion is "vendo-genui/v2" and tree contains root, nodes, optional data and queries. Generated component sources live at the DOCUMENT level in components — the tree itself never carries them.
-- Maximums: ${TREE_MAX_NODES} nodes, ${TREE_MAX_QUERIES} queries, ${TREE_MAX_GENERATED_COMPONENTS} generated components, ${TREE_MAX_COMPONENT_SOURCE_BYTES} bytes per generated component source, ${TREE_MAX_TOTAL_COMPONENT_BYTES} bytes of generated-component source in total.
-- Reserved prewired primitive names: ${RESERVED_COMPONENT_NAMES.join(", ")}.
-- Every node is exactly {id, component, source?, props?, children?}. "component" is a REQUIRED non-empty string on EVERY node, including layout containers — use a prewired primitive (e.g. Stack, Row, Grid) as the component for containers; children is an array of node ids. Never emit a node without a component.
-- "nodes" is a FLAT array of every node; nesting is expressed only through "children" id references, never by inlining child objects. "root" is the id of the top node.
-- A node source is "prewired", "host", or "generated". Generated names are PascalCase, non-reserved, and require a document components[name] ESM React source.
-- Prefer a host component whenever it covers the need. Matching the host brand is a hard goal.
-- Prop bindings are exactly {"$path":"/json/pointer"} and {"$state":"clientStateKey"}. A query's result lives at "/" + its name.
-- Queries are {name, tool, input?}; name is a bare identifier. Actions embedded in props are {action,payload?}.
-- Query tools and action names are host tool names, or fn:<name> where name matches [A-Za-z_][A-Za-z0-9_-]*. A rung-1 tree cannot use fn: because it has no server.
-`,
-}, {
-  // Without a clock the model guesses the year and hardcodes it into
-  // filters/headers ("Top 10 in 2025" over 2026 data = a false empty state).
-  // Computed per call, never cached.
-  id: "clock",
-  content: `CURRENT DATE: ${new Date().toISOString().slice(0, 10)} — this is "now" for the host's data. Resolve every relative period the user asks for ("this year", "this month", "next 90 days") from this date; never assume or hardcode a different year or period.`,
-}, {
-  id: "component-styling",
-  content: `GENERATED COMPONENT STYLING:
-- The component renders in a sandbox that sits directly on the host page's background (THEME TOKENS colors.background when provided; otherwise assume a light background). Never design for an imaginary dark backdrop; give the component's own containers explicit backgrounds.
-- The host's brand tokens are available as CSS custom properties: --vendo-color-background, --vendo-color-surface, --vendo-color-text, --vendo-color-muted, --vendo-color-accent, --vendo-color-accent-text, --vendo-color-danger, --vendo-color-border, --vendo-font-family, --vendo-heading-family, --vendo-font-size, --vendo-radius-small/medium/large. Prefer them (e.g. color: "var(--vendo-color-text)") so the view matches the host brand.
-`,
-}, {
-  id: "catalog",
-  content: `HOST CATALOG (names, when-to-use guidance, props JSON schemas, and usage examples):\n${catalogPrompt(deps.catalog)}\nWhen a host catalog entry fits any part of the request, you MUST use a source:"host" node with its exact name and props schema; do not generate an equivalent component. Compose host, prewired, and generated nodes when needed.`,
-}, {
-  id: "theme",
-  content: `THEME TOKENS:\n${JSON.stringify(deps.theme ?? null, null, 2)}`,
-}, {
-  id: "design-rules",
-  content: `HOST DESIGN RULES:\n${(typeof deps.designRules === "function" ? deps.designRules() : deps.designRules)?.trim() || "(none provided)"}`,
-}, {
-  // Gesture-owned forking (2026-07-21): the fork is executed DETERMINISTICALLY
-  // by the engine when the user acts on a remixable slot — the model never
-  // decides to fork, so the edit dialect no longer teaches <ForkPin> (the op
-  // keeps compiling for stored apps). This section teaches only what edits on
-  // EXISTING forks need.
-  id: "remixable-slots",
-  content: (deps.pinBaselines ?? []).length === 0 ? "" : `REMIXABLE HOST SLOTS (slot -> the generated component a user fork ships under):
-${pinBaselinesPrompt(deps.pinBaselines)}
-- Forking a slot is a USER GESTURE the engine executes deterministically — never fork a slot yourself, and never copy or imitate captured host source in a new island.
-- A slot the user has forked appears as the generated component named above (its pin is listed in APP_META.pins) with its full source in CURRENT_APP. When the instruction asks to change THAT forked component itself, declare the target and re-declare its island in the same patch: <EditPin name="componentName"/> plus <Island name="componentName">...complete updated source...</Island> with the SMALLEST change the instruction needs — keep the original structure, styling, behavior, and every comment intact (the fork is reviewed as a diff against the host's source; wholesale rewrites and stripped comments are review noise). An <Island> that changes a pinned component without its <EditPin> declaration is rejected.
-- Content the instruction wants NEAR a fork (next to, below, beside, above it) is NOT a change to the fork: leave the pinned component's source untouched and compose the new content as a SIBLING node — <Insert> next to the pinned node, with a NEW <Island> under a different name when it needs custom source.
-- Never remove or rename a pinned component, and never invent or alter baseline hashes.`,
-}];
 
 /** The COMPONENTS section is GENERATED from the component schemas (kitPrompt
  *  over the Kit specs + the legacy primitive signatures); no hand-written

--- a/packages/apps/src/index.ts
+++ b/packages/apps/src/index.ts
@@ -133,21 +133,12 @@ export {
 // through.
 export { agentToolDescriptors } from "./agent-tools.js";
 export { buildingAppsSkill } from "./skills/building-apps.js";
-// The generation seam for external bench harnesses: the SAME conductor
-// createApps() rides, driven directly against a host fixture with no store
-// behind it. Additive export — generation behavior is identical.
-//
-// QUARANTINED (blueprint §14.2) — see the header of `generation/conductor.ts`. The
-// export stays so bench harnesses and the five `runtime.ts` call sites keep working;
-// it is frozen, not extended. New work uses the lean loop and the checks floor at
-// the paint seam.
-export {
-  conductCreate,
-  conductEdit,
-  type ConductedApp,
-  type ConductedResult,
-  type ConductorOptions,
-} from "./generation/conductor.js";
+// `conductCreate` / `conductEdit` and their result types were public here for
+// "external bench harnesses". A reverse-dependency walk (2026-08-05) found no
+// caller anywhere — in this repo, the examples, the corpus harness or the docs —
+// so the quarantined pipeline no longer has a public surface to be extended
+// through. `createApps()` still drives it internally; new work uses the lean
+// loop and the checks floor at the paint seam.
 // Contract §3.2 — the checkout/commit seam. Public because the workspace half of
 // it lives outside this package: a sandboxed harness holds a `WorkspaceFs` and
 // never a store, so composition binds the store side once and hands these to

--- a/packages/apps/src/runtime.ts
+++ b/packages/apps/src/runtime.ts
@@ -283,23 +283,23 @@ export interface AppsConfig {
    *  generation (execution still answers `connect-required` on its own). */
   connectedToolkits?: (ctx: RunContext) => Promise<string[]>;
   /**
-   * UI-generation blueprint §1 point 2 — the screen agent, in front of the
-   * conductor. "The seam routes, not the caller": every `vendo_make` request
-   * starts in the cheap assembly loop, and this block never decides which engine
-   * a request deserves.
+   * UI-generation blueprint §1 point 2 — the screen agent. "The seam routes, not
+   * the caller": every `vendo_make` request starts in the cheap assembly loop,
+   * and this block never decides which engine a request deserves.
    *
    * An ADAPTER SLOT, for the reason every other one here is: the screen agent is a
    * lean loop in `@vendoai/harnesses` and this block depends on `core` alone, so
    * the two sides meet on core's `ScreenAssembler` and composition is the only
-   * place that fills it. Explicitly passed always wins; unfilled changes nothing.
+   * place that fills it. Explicitly passed always wins.
    *
-   * DEFAULT-SAFE by construction. `vendo_make` routes here first and falls
-   * through to `conductCreate` on every answer but `assembled` — an `unavailable`,
-   * an assembler that could not run, a throw, and (the check that makes the
-   * promise true rather than merely intended) an `assembled` that left no app ROW
-   * behind. An `escalate` is the one answer that is NOT a fall-through: it is a
-   * request for the build, and the build is what it gets (see `vendo_make` in
-   * agent-tools.ts).
+   * REQUIRED for `vendo_make`, as of the conductor's retirement. There is no
+   * second engine behind this seam: an `unavailable`, an assembler that could not
+   * run, a throw, an `assembled` that left no app ROW behind, and an unfilled slot
+   * all answer with a FAILED receipt that says what happened. A quiet fall-through
+   * is how a composition bug ships — the deployment reads all-green while every
+   * ask is served by an engine nobody chose. An `escalate` is the one answer that
+   * is neither: it is a request for the build, and the build is what it gets (see
+   * `vendo_make` in agent-tools.ts).
    */
   screen?: ScreenAssembler;
   /**

--- a/packages/apps/src/screen-route.test.ts
+++ b/packages/apps/src/screen-route.test.ts
@@ -1,12 +1,12 @@
 /**
  * The front door's routing seam — blueprint §1 point 2 and §4.5.
  *
- * `vendo_make` starts every request in the screen agent. `unavailable`, a throw
- * and an `assembled` that left no row fall through to the conductor; `escalate`
- * does NOT — it is a request for the builder, and what it gets depends on one
- * thing, whether this deployment has a sandbox to build in. Three properties make
- * that safe rather than merely intended, and all three are asserted here against
- * the REAL conductor:
+ * `vendo_make` starts every request in the screen agent, and the answer it gets
+ * back is the answer the person gets. `escalate` is a request for the builder,
+ * and what it gets depends on one thing — whether this deployment has a sandbox
+ * to build in. Everything else is assembly coming back empty, which is now the
+ * end of the ask rather than a quiet hand-off to a second engine. Three
+ * properties make that safe rather than merely intended:
  *
  * 1. **One app id, whichever way an escalation lands.** An escalation has already
  *    written `plan.vendo` at the id it was handed and its skeleton is already
@@ -14,12 +14,13 @@
  *    paint the finished app onto a SECOND stream and leave that skeleton beside it
  *    as a card that builds forever; a failure reported against a different id
  *    would leave the same orphan.
- * 2. **A deployment that cannot build says so.** No sandbox means no machine, and
- *    the conductor cannot serve what assembly just escalated — it is assembly too.
- *    So the receipt fails honestly instead of spending a build's latency on a
- *    worse version of the screen the person was already shown.
- * 3. **An unwired or unserving assembler changes nothing.** The conductor path is
- *    not amputated by this seam; it is what the seam falls through to.
+ * 2. **A deployment that cannot build says so.** No sandbox means no machine, so
+ *    the receipt fails honestly instead of spending a build's latency on a worse
+ *    version of the screen the person was already shown.
+ * 3. **An unwired or unserving assembler surfaces LOUDLY.** Composition forgetting
+ *    the slot, an assembler that threw, an `unavailable`, and an `assembled` that
+ *    left no row are four different bugs and four failed receipts — never a
+ *    "ready" served by an engine nobody chose.
  */
 import type { AppId, RunContext, ScreenAssembler, ScreenRequest, ToolRegistry, VendoViewPart } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
@@ -40,8 +41,8 @@ const tools: ToolRegistry = {
   async execute() { return { status: "error", error: { code: "not-found", message: "no tools" } }; },
 };
 
-/** Every prompt the conductor's brain was handed, so the escalated plan reaching
- *  the build brief is proved by what the model READ rather than by a comment. */
+/** Every prompt the build was handed, so the escalated plan reaching the build
+ *  brief is proved by what the model READ rather than by a comment. */
 const briefs: string[] = [];
 
 const runtimeWith = (screen?: ScreenAssembler, options: {
@@ -131,10 +132,10 @@ describe("an escalation and the build that finishes it share ONE app id", () => 
     expect(briefs.join("\n")).toContain("Show my spending by category");
   });
 
-  it("with no sandbox the escalation FAILS honestly at the same id, and the conductor never runs", async () => {
-    // The conductor is assembly too, so it cannot serve an ask that assembly just
-    // escalated. Falling through would spend a full build's latency to arrive at a
-    // worse version of the screen the person already saw.
+  it("with no sandbox the escalation FAILS honestly at the same id, and nothing is generated", async () => {
+    // An escalation asks for a machine. Answering it with a second pass at
+    // assembly would spend a full build's latency to arrive at a worse version of
+    // the screen the person already saw.
     const { seen, assembler } = recordingAssembler({ kind: "escalate", why: "this needs real code" });
     const { agentTools, briefs } = runtimeWith(assembler);
 
@@ -164,41 +165,61 @@ describe("an escalation and the build that finishes it share ONE app id", () => 
   });
 });
 
-describe("the conductor is what the seam falls through to", () => {
-  it("an unwired assembler leaves vendo_make exactly as it was", async () => {
-    const { agentTools } = runtimeWith();
-    const outcome = await make(agentTools);
+/** The four ways assembly comes back with no screen. Each one used to be
+ *  absorbed by a second engine; each one is now the answer. */
+describe("assembly that produces no screen fails honestly", () => {
+  const unbuilt = (outcome: Awaited<ReturnType<typeof make>>) => {
     expect(outcome.status).toBe("ok");
-    expect((outcome as { output: { status: string } }).output.status).toBe("ready");
+    return (outcome as { output: { id: string; status: string; title: string; say: string } }).output;
+  };
+
+  it("an unwired assembler is a composition bug, and it says so", async () => {
+    const { agentTools, briefs } = runtimeWith();
+
+    const receipt = unbuilt(await make(agentTools));
+
+    expect(receipt.status).toBe("failed");
+    expect(receipt.say).toContain("nothing in this deployment builds screens");
+    // The ask, so the sentence and the card are about the same thing.
+    expect(receipt.title).toBe("Show my spending by category");
+    // Nothing was generated behind the person's back: not one model call.
+    expect(briefs).toHaveLength(0);
   });
 
-  it("an assembler that cannot serve is not a failed request", async () => {
+  it("an `unavailable` hands the assembler's own `why` to the person", async () => {
     const { assembler } = recordingAssembler({ kind: "unavailable", why: "no workspace here" });
-    const { agentTools } = runtimeWith(assembler);
-    const outcome = await make(agentTools);
-    expect(outcome.status).toBe("ok");
-    expect((outcome as { output: { status: string } }).output.status).toBe("ready");
+    const { agentTools, briefs } = runtimeWith(assembler);
+
+    const receipt = unbuilt(await make(agentTools));
+
+    expect(receipt.status).toBe("failed");
+    // Verbatim — a generic apology is nothing the person can act on.
+    expect(receipt.say).toContain("no workspace here");
+    expect(briefs).toHaveLength(0);
   });
 
-  it("an assembler that THROWS is not a failed request either", async () => {
+  it("an assembler that THROWS reports the throw, not a rescue", async () => {
     const throwing: ScreenAssembler = { assemble: async () => { throw new Error("assembler exploded"); } };
-    const { agentTools } = runtimeWith(throwing);
-    const outcome = await make(agentTools);
-    expect(outcome.status).toBe("ok");
-    expect((outcome as { output: { status: string } }).output.status).toBe("ready");
+    const { agentTools, briefs } = runtimeWith(throwing);
+
+    const receipt = unbuilt(await make(agentTools));
+
+    expect(receipt.status).toBe("failed");
+    expect(receipt.say).toContain("assembler exploded");
+    expect(briefs).toHaveLength(0);
   });
 
-  it("an `assembled` that left no ROW behind falls through — a picture of an app is not an app", async () => {
+  it("an `assembled` that left no ROW behind is not an app — a picture of one is not one", async () => {
     // The screen agent said it assembled, but nothing renderable ever reached the
     // store, so `authored` upserted no row. The front door checks the row rather
-    // than trusting the answer, and the conductor takes the ask.
+    // than trusting the answer.
     const { assembler } = recordingAssembler({ kind: "assembled" });
-    const { agentTools } = runtimeWith(assembler);
-    const outcome = await make(agentTools);
-    expect(outcome.status).toBe("ok");
-    const receipt = (outcome as { output: { status: string; title: string } }).output;
-    expect(receipt.status).toBe("ready");
-    // The conductor's own document, not an invented title over an absent app.
-    expect(receipt.title.length).toBeGreaterThan(0);
+    const { agentTools, briefs } = runtimeWith(assembler);
+
+    const receipt = unbuilt(await make(agentTools));
+
+    expect(receipt.status).toBe("failed");
+    expect(receipt.say).toContain("wasn't something I could show");
+    expect(briefs).toHaveLength(0);
   });
 });

--- a/packages/apps/src/testing/authoring-assembler.ts
+++ b/packages/apps/src/testing/authoring-assembler.ts
@@ -1,0 +1,30 @@
+import { compileWire, type ScreenAssembler } from "@vendoai/core";
+import type { AppsRuntime } from "../runtime.js";
+
+/**
+ * A screen assembler that really assembles.
+ *
+ * `vendo_make` has one engine, so a test that exercises the front door needs
+ * something in the `screen` slot. This is not a stub of the apps side: it
+ * compiles with core's own compiler and lands the row through
+ * `AppsRuntime.authored` — the exact write path the shipped render seam uses, so
+ * the row, the guard decision and the query resolution are all the real ones.
+ * The only thing standing in for a live agent is the document itself, which is
+ * fixed rather than generated.
+ */
+export const authoringAssembler = (
+  /** A getter, because the slot is filled at compose time and the runtime it
+   *  writes through is what composing RETURNS — the same knot `packages/vendo`
+   *  ties. */
+  runtime: () => AppsRuntime,
+  wire: string,
+): ScreenAssembler => ({
+  async assemble({ appId }, ctx) {
+    const compiled = compileWire(wire);
+    if (compiled.issues.length > 0) {
+      return { kind: "unavailable", why: compiled.issues.map(({ message }) => message).join(" ") };
+    }
+    await runtime().authored({ appId, compiled }, ctx);
+    return { kind: "assembled" };
+  },
+});

--- a/packages/apps/src/testing/index.ts
+++ b/packages/apps/src/testing/index.ts
@@ -1,3 +1,4 @@
+export * from "./authoring-assembler.js";
 export * from "./box-files.js";
 export * from "./fake-sandbox.js";
 export * from "./fake-sandbox-stateful.js";

--- a/packages/core/src/screen.ts
+++ b/packages/core/src/screen.ts
@@ -2,18 +2,17 @@
  * The screen-assembly seam — UI-generation blueprint §1 point 2 and §4.2.
  *
  * "The seam routes, not the caller." No agent chooses "quick screen" vs "real
- * build": every `vendo_make` request starts in the cheap screen agent, and the
- * conductor is what an escalation or an unserved ask falls through to.
+ * build": every `vendo_make` request starts in the screen agent, and an
+ * escalation is how it asks for the builder.
  *
  * The screen agent itself is a lean loop in `@vendoai/harnesses` — it needs a
  * model, the guard-bound registry, and a workspace whose commits reach the render
  * seam, none of which `@vendoai/apps` holds. `apps` depends on `core` alone, so
  * the two sides meet on this interface and composition (`packages/vendo`) is the
  * only place that fills the slot. That is the shipped adapter rule: an explicitly
- * passed adapter always wins, an unfilled slot changes nothing, and there is no
- * hidden key-conditional branch. Unset — or set and answering anything but
- * `assembled` — and the conductor path runs exactly as it did before this seam
- * existed.
+ * passed adapter always wins and there is no hidden key-conditional branch. What
+ * an unfilled slot no longer does is quietly hand the ask to a second engine —
+ * `vendo_make` says it could not build the screen instead.
  */
 import type { AppId } from "./ids.js";
 import type { RunContext } from "./run-context.js";
@@ -28,7 +27,7 @@ export interface ScreenRequest {
    * The screen agent's files live at `/user/apps/<appId>/`, the painted view
    * rides `vendoViewStreamId(appId)`, and an escalated plan has to become the
    * build's first skeleton — all three only line up if the id is the same one the
-   * conductor would go on to use, so the caller owns it.
+   * build goes on to use, so the caller owns it.
    */
   appId: AppId;
   /** The person's ask, verbatim — never a paraphrase. */
@@ -45,8 +44,10 @@ export interface ScreenRequest {
  * Only `assembled` means the caller is done: the view is on screen and the app's
  * row is stored. `escalate` is the mid-flight §4.5 hand-off — the plan is already
  * written and its skeleton is already painted, so the build inherits it — and
- * `unavailable` is "nothing ran", which is what an unwired or broken assembler
- * answers. Both fall through to the conductor.
+ * `unavailable` is "nothing ran", which is what a broken assembler answers. An
+ * `unavailable` is the END of the ask: `vendo_make` reports it as a failed
+ * receipt carrying `why`, so a deployment whose assembly is broken reads as
+ * broken instead of being served by an engine nobody chose.
  */
 export type ScreenOutcome =
   | { kind: "assembled" }

--- a/packages/vendo/src/mcp-door.test-util.ts
+++ b/packages/vendo/src/mcp-door.test-util.ts
@@ -138,8 +138,13 @@ export interface ComposedHost {
 }
 
 /**
- * A model that answers every generation prompt with one valid screen, so a
- * `vendo_make` call reaches a REAL receipt instead of the no-model failure path.
+ * A model that assembles one valid screen, so a `vendo_make` call reaches a REAL
+ * receipt instead of the no-screen failure path.
+ *
+ * `# In this loop` is the screen agent's own brief — the one marker that says a
+ * prompt belongs to the assembly loop without counting calls — and `save_app` is
+ * how that loop lands an app. Every other prompt gets prose, which is also what
+ * ends the loop once the app is saved.
  *
  * Local rather than `@vendoai/apps`' `scriptedLanguageModel` because `testing/`
  * is not on that package's exports map; same shape as the other fixture doubles
@@ -147,34 +152,55 @@ export interface ComposedHost {
  */
 export const SCREEN_TITLE = "Spending this month";
 const SCREEN = `<App name="${SCREEN_TITLE}"><Text text="Ready"/><Disclaimer reason="Fixture app."/></App>`;
+const SCREEN_BRIEF_MARKER = "# In this loop";
 
 export const screenModel = (): LanguageModel => {
-  const answer = {
-    content: [{ type: "text" as const, text: SCREEN }],
-    finishReason: "stop" as const,
-    usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+  let saved = false;
+  const assembling = (prompt: unknown): boolean => {
+    if (saved || !JSON.stringify(prompt ?? "").includes(SCREEN_BRIEF_MARKER)) return false;
+    saved = true;
+    return true;
   };
+  const usage = { inputTokens: 1, outputTokens: 1, totalTokens: 2 };
   return {
     specificationVersion: "v2",
     provider: "vendo-parity-screen",
     modelId: "vendo-parity-screen-v1",
     supportedUrls: {},
-    async doGenerate() {
-      return answer;
+    async doGenerate({ prompt }: { prompt?: unknown }) {
+      return assembling(prompt)
+        ? {
+          content: [{
+            type: "tool-call" as const,
+            toolCallId: "call_save_app",
+            toolName: "save_app",
+            input: JSON.stringify({ content: SCREEN }),
+          }],
+          finishReason: "tool-calls" as const,
+          usage,
+        }
+        : { content: [{ type: "text" as const, text: "done" }], finishReason: "stop" as const, usage };
     },
-    async doStream() {
+    async doStream({ prompt }: { prompt?: unknown }) {
+      const save = assembling(prompt);
       return {
         stream: new ReadableStream({
           start(controller) {
             controller.enqueue({ type: "stream-start", warnings: [] });
-            controller.enqueue({ type: "text-start", id: "text_1" });
-            controller.enqueue({ type: "text-delta", id: "text_1", delta: SCREEN });
-            controller.enqueue({ type: "text-end", id: "text_1" });
-            controller.enqueue({
-              type: "finish",
-              finishReason: "stop",
-              usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-            });
+            if (save) {
+              controller.enqueue({
+                type: "tool-call",
+                toolCallId: "call_save_app",
+                toolName: "save_app",
+                input: JSON.stringify({ content: SCREEN }),
+              });
+              controller.enqueue({ type: "finish", finishReason: "tool-calls", usage });
+            } else {
+              controller.enqueue({ type: "text-start", id: "text_1" });
+              controller.enqueue({ type: "text-delta", id: "text_1", delta: "done" });
+              controller.enqueue({ type: "text-end", id: "text_1" });
+              controller.enqueue({ type: "finish", finishReason: "stop", usage });
+            }
             controller.close();
           },
         }),

--- a/packages/vendo/src/screen-route.e2e.test.ts
+++ b/packages/vendo/src/screen-route.e2e.test.ts
@@ -1,11 +1,11 @@
 /**
  * PROOF BAR 1 — "agent → checks → slot proven end to end" (blueprint §15).
  *
- * `vendo_make` is routed through the screen agent instead of straight to the
- * conductor, walked through a REAL composed deployment: real store, real guard,
- * real apps pack, the real render seam, the real `AppsRuntime.authored` app half.
- * Nothing on either side of the seam is stubbed except the MODEL, which is
- * scripted so the routing — not a provider's mood — is what this measures.
+ * `vendo_make` is routed through the screen agent, walked through a REAL composed
+ * deployment: real store, real guard, real apps pack, the real render seam, the
+ * real `AppsRuntime.authored` app half. Nothing on either side of the seam is
+ * stubbed except the MODEL, which is scripted so the routing — not a provider's
+ * mood — is what this measures.
  *
  * The two things a stub could hide, and why they are asserted here rather than in
  * `packages/harnesses`:
@@ -13,9 +13,9 @@
  * 1. **The row.** `authored` is what makes a written file an APP: without it a
  *    screen is a picture of one — absent from the person's list, masked as
  *    `not-found` by `vendo_apps_open`. Only a real store can prove it landed.
- * 2. **The fall-through.** The conductor must still answer when the screen agent
- *    does not, and "still works" is not something a harness-level test can claim:
- *    it needs the real front door with the real `create` behind it.
+ * 2. **The empty answer.** Assembly that produces nothing renderable ends the ask
+ *    with a failed receipt, and "nothing else ran" is not something a
+ *    harness-level test can claim: it needs the real front door.
  *
  * DIALECT NOTE: the `.vendo` literal below is a name, a Stack and a Text with no
  * expressions and no aggregates, so the in-flight dialect change (pipes → nested
@@ -222,10 +222,9 @@ describe("vendo_make routed through the screen agent (blueprint §1 point 2)", (
     const listed = await walked.vendo.apps.list({ principal, venue: "chat", presence: "present" });
     expect(listed.map((app) => app.id)).toContain(receipt.id);
 
-    // ── and the conductor never ran ───────────────────────────────────────────
-    // Two model calls: the save step and the validate step, plus the closing one.
-    // A conductor create is a plan call plus a fill call per group on top of that,
-    // so a routed request is measurably the cheap path and not both paths.
+    // ── and nothing ran behind it ─────────────────────────────────────────────
+    // Exactly three model calls: the save step, the validate step, and the closing
+    // one. A second engine picking the ask up would show here as a fourth.
     expect(walked.model.calls).toBe(3);
   }, 60_000);
 
@@ -276,8 +275,7 @@ describe("vendo_make routed through the screen agent (blueprint §1 point 2)", (
     // Proved by EXHAUSTION rather than by a flag: exactly two turns are scripted,
     // and the model throws on a third. `save_app` exists only inside the screen
     // agent's closed loadout, so a run that lands a ready receipt in two calls can
-    // only have been the assembly loop — a conductor handed a `save_app` call on
-    // its first turn has no plan and fails.
+    // only have been the assembly loop.
     const walked = await walk({
       turns: [call("save_app", { content: SPENDING }, "c1"), speak("done")],
     });
@@ -288,28 +286,31 @@ describe("vendo_make routed through the screen agent (blueprint §1 point 2)", (
     expect(receipt.title).toBe("Spending");
   }, 60_000);
 
-  it("falls through to the conductor when assembly produces nothing that renders", async () => {
+  it("fails honestly when assembly produces nothing that renders — no second engine behind it", async () => {
     // The screen agent saves bytes the compiler cannot render. The seam paints
-    // nothing and `authored` stores no row, so the front door finds no app and the
-    // conductor takes the ask — the fall-through that makes this seam default-safe.
+    // nothing and `authored` stores no row, so there is no app — and that is the
+    // ANSWER. This used to fall through to the conductor, which meant a broken
+    // assembler read as a working deployment.
     const walked = await walk({
       turns: [
         call("save_app", { content: "not a document at all" }, "c1"),
         speak("saved"),
-        // …and then the conductor's own calls, answered with prose it cannot use.
-        speak("I am not a plan either"),
-        speak("nor is this"),
+        // Two spare turns the model must never be asked for: if anything runs
+        // after assembly gives up, `calls` says so.
+        speak("nobody should read this"),
+        speak("nor this"),
       ],
     });
-    // The conductor ran and failed on its own terms — which is exactly what would
-    // have happened with no screen agent composed at all.
-    expect(walked.result?.status).toBe("error");
+
+    // An in-band receipt, not a thrown tool error: the ask was understood and
+    // answered, it just could not be served.
+    expect(walked.result?.status).toBe("ok");
+    const receipt = makeReceiptSchema.parse((walked.result as { output: unknown }).output);
+    expect(receipt.status).toBe("failed");
+    expect(receipt.say).toContain("couldn't put that screen together");
+    // Nothing painted, and nothing generated after the assembly loop's own two
+    // turns — the whole point of cutting the fall-through.
     expect(walked.chunks.filter((chunk) => chunk["type"] === "data-vendo-view")).toHaveLength(0);
-    // More calls than the screen agent's own two: the conductor genuinely ran
-    // after it, so the fall-through is real rather than a swallowed failure. Not
-    // an exact count — how many calls the conductor spends before it gives up is
-    // its business, and pinning it here would make this test a tripwire on the
-    // conductor's internals instead of on the seam.
-    expect(walked.model.calls).toBeGreaterThan(2);
+    expect(walked.model.calls).toBe(2);
   }, 60_000);
 });

--- a/packages/vendo/src/server.test.ts
+++ b/packages/vendo/src/server.test.ts
@@ -2424,10 +2424,10 @@ describe("09 §3 conversational turn against the real composed store", () => {
       outputTokens: { total: 0, text: 0, reasoning: 0 },
     } as const;
     let agentCalls = 0;
-    // A plan — the ask is normal, so the brain plans it and fast workers write
-    // the groups. That is what makes the create arrive in pieces: the plan IS
-    // the layout, on screen before a single group has been written, and each
-    // group lands as its own view.
+    // The screen agent assembles in PASSES: it saves the app as it grows, and
+    // every save paints through the render seam. That is what makes the create
+    // arrive in pieces — a first section on screen before the second is written
+    // — and each save lands as its own view on the app's own stream.
     const generation = (delta: string) => ({
       stream: simulateReadableStream({ chunks: [
         { type: "text-start" as const, id: "generation" },
@@ -2436,22 +2436,29 @@ describe("09 §3 conversational turn against the real composed store", () => {
         { type: "finish" as const, usage, finishReason: { unified: "stop" as const, raw: undefined } },
       ] }),
     });
+    const saveApp = (content: string, id: string) => ({
+      stream: simulateReadableStream({ chunks: [
+        { type: "tool-call" as const, toolCallId: id, toolName: "save_app", input: JSON.stringify({ content }) },
+        { type: "finish" as const, usage, finishReason: { unified: "tool-calls" as const, raw: undefined } },
+      ] }),
+    });
+    const section = (count: number) => `<App name="SSE app">\n  <Stack>\n${
+      Array.from({ length: count }, (_, index) => `    <Text text="Section ${index + 1} ready" />`).join("\n")
+    }\n  </Stack>\n</App>`;
+    const screenTurns = [
+      saveApp(section(1), "c1"),
+      saveApp(section(2), "c2"),
+      saveApp(section(3), "c3"),
+      generation("done"),
+    ];
     const model = new MockLanguageModelV3({
       doStream: async ({ prompt }) => {
         const serialized = JSON.stringify(prompt);
-        if (serialized.includes("THEY ARE ASKING NOW:")) {
-          return generation(`<Plan name="SSE app">
-  <Group>
-    <Leaf component="Text" purpose="A one-line status for the first section"/>
-  </Group>
-  <Group>
-    <Leaf component="Text" purpose="A one-line status for the second section"/>
-  </Group>
-</Plan>`);
+        // The screen agent's own brief. The one marker that says "this prompt is
+        // the assembly loop's" without counting calls.
+        if (serialized.includes("# In this loop")) {
+          return screenTurns.shift() ?? generation("nothing more to do");
         }
-        // One fill worker per group, and the AI reviewer, all ride this model.
-        if (serialized.includes("YOUR SECTION")) return generation('<Text text="Ready"/>');
-        if (serialized.includes("You are the last reader")) return generation("");
 
         agentCalls += 1;
         if (agentCalls === 1) {
@@ -2505,23 +2512,17 @@ describe("09 §3 conversational turn against the real composed store", () => {
 
     expect(response.status).toBe(200);
     expect(views.length).toBeGreaterThanOrEqual(3);
-    // The first view IS the plan's geometry, every leaf still pending.
-    expect(views[0]?.data.payload).toMatchObject({
-      streaming: true,
-      nodes: [
-        { id: "app" },
-        { id: "group-0" },
-        { id: "group-0-body" },
-        { id: "group-0-leaf-0" },
-        { id: "group-1" },
-        { id: "group-1-body" },
-        { id: "group-1-leaf-0" },
-      ],
-    });
+    // The app ARRIVES IN PIECES: each save is its own view, and each one carries
+    // more of the app than the last. This is the property the SSE handler exists
+    // for — the person watches it fill in rather than waiting for one blob.
+    const nodeCounts = views.map((view) => view.data.payload.nodes.length);
+    expect(nodeCounts.at(-1)).toBeGreaterThan(nodeCounts[0] as number);
+    // ONE reconciliation id across every piece, so the card updates in place
+    // instead of a second card appearing beside it.
     expect(new Set(views.map((view) => view.id))).toEqual(new Set([`vendo-view:${views[0]?.data.appId}`]));
-    // Both placeholders are gone, replaced by what their workers wrote.
-    expect(views.at(-1)?.data.payload.nodes).toHaveLength(7);
-    expect(views.at(-1)?.data.payload.streaming).toBeUndefined();
+    // …and the last word SETTLES. While `streaming` is on, the card never
+    // reaches a verdict and stays on "Building your view…".
+    expect(views.at(-1)?.data.payload.streaming).not.toBe(true);
   });
 });
 

--- a/packages/vendo/src/vendo-make-matrix.e2e.test.ts
+++ b/packages/vendo/src/vendo-make-matrix.e2e.test.ts
@@ -16,7 +16,7 @@
  *  2. edit of an existing one  → lands in place, repaints on the SAME stream id
  *  3. escalate WITH a sandbox  → the build runs, and the outline becomes the app
  *  4. escalate with NO sandbox → a failed receipt that says why, no orphan card
- *  5. assembler unavailable    → the conductor still answers (the control case)
+ *  5. assembler unavailable    → a failed receipt that says so, and nothing else runs
  *  6. the MCP door             → an outside agent gets words, and a screen lands
  *
  * Case 3 is the one this PR adds a receiving end for, and it is the one proven
@@ -539,25 +539,28 @@ describe("the six-type matrix — every `vendo_make` ask type, one deployment", 
     // fully drained, which is what makes the card dead rather than pending.
   }, 60_000);
 
-  it("TYPE 5 · an assembler that produces nothing renderable falls through — the conductor answers", async () => {
-    // The control case. The screen agent saved bytes the compiler cannot render,
-    // so the seam painted nothing and `authored` stored no row: the front door
-    // finds no app and the conductor takes the ask, exactly as it did before this
-    // seam existed. An `unavailable` is not an `escalate` and never was.
+  it("TYPE 5 · an assembler that produces nothing renderable fails honestly — nothing rescues it", async () => {
+    // The control case, inverted. The screen agent saved bytes the compiler cannot
+    // render, so the seam painted nothing and `authored` stored no row. That used
+    // to fall through to the conductor; the conductor is gone from this route, and
+    // an unwired or unserving assembler is a composition bug that has to surface
+    // rather than be quietly served by an engine nobody chose.
     const walked = await walk({
       asks: [{ request: "show me what I spent this month" }],
       screenTurns: [call("save_app", { content: "not a document at all" }, "c1"), speak("saved")],
+      // What a fall-through WOULD have built. It must not appear anywhere.
       brain: SPENDING,
     });
 
     const receipt = walked.receipts[0]!;
-    expect(receipt.status).toBe("ready");
-    expect(receipt.title).toBe("Spending");
-    // The conductor genuinely ran: its brain prompt is on the record.
-    expect(walked.prompts.filter((prompt) => prompt.includes(BRAIN_MARKER)).length).toBeGreaterThan(0);
-    // And its app is real and on the same stream the front door minted.
-    expect((await walked.vendo.apps.get(receipt.id, ctx))?.name).toBe("Spending");
-    expect(new Set(walked.views.map((view) => view.appId))).toEqual(new Set([receipt.id]));
+    expect(receipt.status).toBe("failed");
+    // The say is plain, and it is about this ask.
+    expect(receipt.say).toContain("couldn't put that screen together");
+    expect(receipt.title).toBe("show me what I spent this month");
+    // NOTHING generated behind it: not one brain prompt, no row, no paint.
+    expect(walked.prompts.filter((prompt) => prompt.includes(BRAIN_MARKER))).toHaveLength(0);
+    expect(await walked.vendo.apps.get(receipt.id, ctx)).toBeNull();
+    expect(JSON.stringify(walked.views)).not.toContain("This month");
   }, 60_000);
 
   it("TYPE 6 · the MCP door: an outside agent asks for a screen, gets words, and a screen lands", async () => {


### PR DESCRIPTION
Rebased onto `main` after #854 merged (and carries #860/#861 cleanly).

## What changed

`vendo_make` has **one** engine. Assembly that produces no screen is the answer,
not a cue to quietly start over somewhere else.

Four things used to fall through to the conductor. All four now end the ask with
a **failed** `MakeReceipt` whose `say` names what happened:

| assembly came back… | before | now |
| --- | --- | --- |
| `unavailable` | conductor rebuilt it | `failed`, carrying the assembler's own `why` verbatim |
| assembler threw | conductor rebuilt it | `failed`, carrying the thrown message |
| `apps.screen` unfilled | conductor rebuilt it | `failed` — "nothing in this deployment builds screens" |
| `assembled`, no app row | conductor rebuilt it | `failed` — "what came back wasn't something I could show" |

A quiet fall-through is how a composition bug ships: a deployment that forgot to
fill `apps.screen`, or whose assembler is broken, read all-green while every ask
was served by an engine nobody chose.

`escalate` is untouched — it is a request for the builder, not the seam failing,
and a deployment with a sandbox still runs the build at the same app id.

## Deleted

| what | lines | why it was safe |
| --- | --- | --- |
| the public `conductCreate` / `conductEdit` / `ConductedApp` / `ConductedResult` / `ConductorOptions` re-export from `@vendoai/apps` | 15 | kept for "external bench harnesses" — grep found no caller in this repo, `examples/`, `corpus/`, `fixtures/` or the docs |
| `generationPromptSections` (`generation/contracts/sections.ts`) + the imports and two helpers only it used | 88 | zero callers; a second, unmaintained copy of the v2 tree contract |
| the `unavailable` / unwired / throw / no-row fall-through in `agent-tools.ts` | — | replaced by the honest receipt above |

Net: **+400 / −308** across 18 files, including the changeset, the new test
fixture and four test-double repairs — the production diff is negative.

## Test doubles that had to learn the new engine

Five suites reached `create` by falling through an unwired or text-only model.
With the fall-through gone they each needed a screen agent that actually
assembles, so they now script `save_app` on the assembly loop's own brief
(`# In this loop`) — the shipped path — instead of leaning on a second engine:

- `packages/apps/src/agent-tools.test.ts` + a new `testing/authoring-assembler.ts`
  that compiles with core's compiler and lands the row through the real
  `AppsRuntime.authored`, so only the model is standing in.
- `packages/apps/src/create-unsaved.test.ts` — reaches `create` by escalation
  with a sandbox, which is the one route that still gets there.
- `packages/vendo/src/server.test.ts` — the SSE partials test now proves the
  property it exists for (pieces arrive, one reconciliation id, last one
  settles) through the engine that ships.
- `packages/vendo/src/mcp-door.test-util.ts`, `examples/ai-sdk-agent`,
  `examples/mastra-agent` — one `save_app` turn each.

## Kept alive, and why (the reverse-dependency walk)

The contract's chase-list is a hypothesis; the walk is the law, and it overruled
the list in three places.

- **`skeleton.ts` — ALIVE, and not by the conductor.** `skeletonFromPlan` is the
  escalated plan's paint path in the screen agent:
  `packages/harnesses/src/render-seam.ts:53,300`. Deleting it would have broken
  the thing #854 just built.
- **`apps.pipeline` (`{ smokeRender }`) — KEPT.** The gate guards a non-conductor
  path: `generation/validation/validate.ts:88` sits inside `validateCompiledCreate`,
  which `runtime.ts:3062` calls from `AppsRuntime.validate` — the screen agent's
  own review floor. The knob is the only wiring feeding that gate
  (`generationDependencies` copies `config.pipeline` onto the deps), so per the
  contract's own escape clause both stay.
- **`apps.fillConcurrency` — already gone.** It exists nowhere in the tree; the
  only hit is `docs/archive/config-migration-table.md`. The live fill knob is
  `apps.fill` (`{ model }`), read by `fill.ts`, which is conductor-only and is
  parked with it.
- `laneGates`, `runServerLane`, the machine/box lane, the checking layer, the
  floor and the plan compiler are all reached from `runtime.ts` directly — never
  touched.

## Parked: the pipeline deletion itself

The conductor is **not** dead code. It is the live engine of `AppsRuntime.create`
and `AppsRuntime.edit` — public API behind the HTTP wire, the React client,
Maple's chip seeding, and ~30 test files across three packages.

There is no replacement builder to route them to. #854's own commit message says
"a deployment with a sandbox runs the real build", and the real build *is*
`runtime.create`. The only other engine in the tree is the screen agent, whose
closed loadout has no machine tools and whose `escalate` is what hands work *to*
`runtime.create` — routing `runtime.create` back into it is a loop.

Landing the deletion here would also have broken two acceptance criteria the
contract explicitly protects:

- **TYPE 2** (`vendo-make-matrix.e2e.test.ts`) drives `runtime.edit` → `conductEdit`
  and scripts the brain's edit dialect (`EDIT_MARKER`, line 231).
- **TYPE 3** asserts the brain ran and read the escalated plan
  (`brainPrompts.length > 0`, `toContain("Invoice matcher")`). The
  `<Server kind="box">` that provisions the machine comes from the **brain**
  (`BOX_PLAN`); the escalated plan has no `<Server>` at all.

And it contradicts the size guardrail: `packages/apps` cannot import
`@vendoai/harnesses` (dependency-guard), so ~30 test files would each get a
hand-rolled fake assembler — the exact "harness that mocks the counterparty"
failure CLAUDE.md's testing section names.

So this PR cut the conductor's public surface and its last fall-through. What
remains is exactly the five `runtime.ts` call sites, and the quarantine header
now says so. The deletion needs the replacement builder designed first — a
feature PR, not a deletion PR.

## Grep proof

`conductor` still appears in `src` — the file is still the engine of `create`/`edit`
(see above). What is gone is every OTHER reachability:

```
$ grep -rn "conductCreate\|conductEdit\|fillAfterServer\|ConductedResult\|ConductorOptions" \
    --include="*.ts" packages examples corpus fixtures | grep -v node_modules | grep -v /dist/
packages/apps/src/runtime.ts   (5 call sites + 2 type uses)
packages/apps/src/generation/conductor.ts  (definitions)
packages/apps/src/generation/conductor.test.ts
```

Nothing in `index.ts`, nothing in `@vendoai/vendo`, nothing in `@vendoai/harnesses`,
nothing outside the package.

## Proof

- The **six-type matrix is green**, with TYPE 5's new expectation
  ("fails honestly — nothing rescues it"): failed receipt, no brain prompt, no
  row, no paint. TYPE 1–4 and 6 untouched and passing.
- `packages/vendo/src/screen-route.e2e.test.ts` — the fall-through case becomes
  "no second engine behind it": in-band failed receipt, zero paints, and exactly
  the assembly loop's own two model calls.
- `packages/apps/src/screen-route.test.ts` — all four empty-assembly shapes
  asserted separately, each with `briefs` empty (nothing generated behind the
  person's back). **Red-green verified**: reverting `agent-tools.ts` turns all
  four red, restoring turns them green.
- A create and an edit through the real front door still produce painted,
  validated screens (matrix TYPE 1 and TYPE 2).

### Local gate

`build ✅ · typecheck ✅ · lint ✅ (dependency-guard green) · test:affected ❌ (7)`

All seven reds are pre-existing or environmental, none in a package this PR
changes the behaviour of:

| suite | failures | cause |
| --- | --- | --- |
| `packages/vendo/src/dev-creds/model.test.ts` | 2 | the known local red (temp-dir module resolution) |
| `packages/core/src/packaging.e2e.test.ts` | 3 | this worktree's path contains a space; vite cannot load `…/Cool%20Code/…/dist/index.js` |
| `packages/store/src/{durability,split-brain}.drill.test.ts` | 2 | same — the spawned drill writer gets `Cannot find module '…/Cool%20Code/…/drill-writer.mjs'` |

`@vendoai/apps` (1035), `@vendoai/vendo` (2035 of 2037), `@vendoai/harnesses`,
`@vendoai/ui`, `@vendoai/agent`, `@vendoai/guard`, `@vendoai/actions`,
`fixtures/integration`, `fixtures/chat-e2e` and both framework examples are all
green. CI is the gate of record.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `vendo_make` single-engine: every request runs through the screen agent, and if assembly produces no screen it returns a failed `MakeReceipt` that says why. Removed the quiet fall-through to the conductor; `escalate` still runs the real build at the same app id.

- **Refactors**
  - Unwired assembler, thrown errors, `unavailable`, and `assembled` with no row now fail with a clear `say` (assembler `why` when present).
  - Removed `conductCreate`, `conductEdit`, `ConductedApp`, `ConductedResult`, and `ConductorOptions` from `@vendoai/apps`; the conductor remains internal to `AppsRuntime.create`/`edit`.
  - Deleted `generationPromptSections`; dialects compose their own sections.
  - Tests and examples updated to assemble via `save_app` using a real authoring assembler.

- **Migration**
  - `apps.screen` is required for `vendo_make`. Hosts composing `@vendoai/apps` must supply a `ScreenAssembler`, or new-app requests return `status: "failed"`.
  - The public conductor API is no longer exported from `@vendoai/apps`; internal behavior for `AppsRuntime.create`/`edit` is unchanged.

<sup>Written for commit f4d7b8413bfb82329e2cb15f61ee19305a52a5cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

