### PR TITLE
fix(guard,harnesses): pre-parity engine defects — destructive default, false turn failure, ledger double-count, model id

### DIFF
--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -1339,13 +1339,18 @@ class GuardImplementation implements VendoGuard {
       }
     }
 
-    // Nothing spoke. An `ungraded` tool is one nobody has graded — no human,
-    // no judge, no protocol fact — so not-knowing is felt here rather than
-    // hidden behind a run: it asks, exactly as `destructive` does under the
-    // default policy. Guard-level on purpose, so a hand-wired server with no
-    // policy config at all gets it too. A host that consciously wants these to
-    // run says so in writing, with a `risk: "ungraded"` rule.
-    if (descriptor.risk === "ungraded") {
+    // Nothing spoke. `ungraded` is a tool nobody has graded — no human, no
+    // judge, no protocol fact — and `destructive` is one whose effect cannot be
+    // taken back; both need a PERSON, so neither is hidden behind a run here.
+    // Guard-level on purpose, so a hand-wired server with no policy config at
+    // all gets it too. A host that consciously wants these to run says so in
+    // writing, with a matching `risk` rule.
+    //
+    // `withheldFromUnattended` is the same two grades, and reading them off ONE
+    // list is the point: §12 refuses them where there is nobody to ask, and this
+    // asks where there is — the halves cannot drift apart into a default that
+    // silently ran what the unattended law refuses.
+    if (withheldFromUnattended(descriptor)) {
       return withInvalidated({ decision: { action: "ask", decidedBy: "default" } });
     }
     return withInvalidated({ decision: { action: "run", decidedBy: "default" } });

--- a/packages/guard/test/destructive-default.test.ts
+++ b/packages/guard/test/destructive-default.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { createGuard } from "../src/index.js";
+import { createMemoryStore } from "./fixtures/memory-store.js";
+import { FixtureTools, call, context, descriptor } from "./fixtures/tools.js";
+
+/**
+ * The blank state, for the grade that cannot be taken back.
+ *
+ * `ungraded` already asked here (D3) and every preset asks or blocks on
+ * `destructive` — `cautious` is the intended posture in writing. The guard's own
+ * no-match default did not: with no policy configured at all it RAN a declared
+ * `destructive` tool without asking, so the one install where nothing else
+ * speaks — a hand-wired server — was the one install that deleted things
+ * silently. Same posture as `ungraded` for the same reason: not-knowing and
+ * not-undoable both need a person.
+ */
+describe("destructive asks by default", () => {
+  it("asks for a destructive tool on a guard with NO policy config at all", async () => {
+    const guard = createGuard({ store: createMemoryStore() });
+    const d = descriptor("destructive", { name: "host_delete_account" });
+
+    await expect(guard.check(call(d.name, { id: "acc_1" }), d, context())).resolves.toMatchObject({
+      action: "ask",
+      decidedBy: "default",
+    });
+  });
+
+  it("parks the call end to end rather than executing it", async () => {
+    const d = descriptor("destructive", { name: "host_delete_account" });
+    const guard = createGuard({ store: createMemoryStore() });
+    const tools = new FixtureTools([d]);
+    const bound = guard.bind(tools);
+
+    const outcome = await bound.execute(call(d.name, { id: "acc_1" }, "call_delete"), context());
+    expect(outcome).toMatchObject({ status: "pending-approval" });
+    expect(tools.executions).toHaveLength(0);
+  });
+
+  it("leaves reads and graded writes alone — only the irreversible grade moved", async () => {
+    const guard = createGuard({ store: createMemoryStore() });
+    const read = descriptor("read");
+    const write = descriptor("write");
+
+    await expect(guard.check(call(read.name), read, context())).resolves.toMatchObject({
+      action: "run",
+      decidedBy: "default",
+    });
+    await expect(guard.check(call(write.name), write, context())).resolves.toMatchObject({
+      action: "run",
+      decidedBy: "default",
+    });
+  });
+
+  it("never runs it unattended either — nobody to ask is not permission", async () => {
+    const d = descriptor("destructive", { name: "host_delete_account" });
+    const guard = createGuard({ store: createMemoryStore() });
+    const tools = new FixtureTools([d]);
+    const bound = guard.bind(tools);
+
+    const outcome = await bound.execute(
+      call(d.name, { id: "acc_1" }, "call_delete_away"),
+      context({ presence: "away", trigger: { runId: "run_1", kind: "schedule" } }),
+    );
+    expect(outcome.status).not.toBe("ok");
+    expect(tools.executions).toHaveLength(0);
+  });
+
+  it("lets a host loosen it consciously, in writing, with a risk:destructive rule", async () => {
+    const guard = createGuard({
+      store: createMemoryStore(),
+      policy: { rules: [{ match: { risk: "destructive" }, action: "run", note: "we accept this" }] },
+    });
+    const d = descriptor("destructive", { name: "host_delete_account" });
+
+    await expect(guard.check(call(d.name), d, context())).resolves.toMatchObject({
+      action: "run",
+      decidedBy: "rule",
+    });
+  });
+});

--- a/packages/guard/test/pipeline-conformance.test.ts
+++ b/packages/guard/test/pipeline-conformance.test.ts
@@ -76,9 +76,11 @@ describe("decision pipeline conformance", () => {
             judge: { action: "block", decidedBy: "judge" },
             // 05 §6: away holds only app-bound grants — the default posture
             // auto-runs present calls but parks away ones (reads included: away
-            // execution needs captured authority to act as the user).
+            // execution needs captured authority to act as the user). And the
+            // blank state parks `destructive` at any presence: an effect nobody
+            // can take back needs a person, the same reason `ungraded` parks.
             default:
-              presence === "away"
+              presence === "away" || risk === "destructive"
                 ? { action: "ask", decidedBy: "default" }
                 : { action: "run", decidedBy: "default" },
             // The clamp outranks every draft the pipeline can reach here.
@@ -322,6 +324,10 @@ describe("decision pipeline conformance", () => {
   it("write breaker counts write and destructive runs per trigger run key", async () => {
     const guard = createGuard({
       store: createMemoryStore(),
+      // The blank state parks `destructive`, so the question this pins — does a
+      // destructive RUN spend the budget? — needs a host that opted into the run
+      // in writing before there is a run to charge.
+      policy: { rules: [{ match: { risk: "destructive" }, action: "run" }] },
       breakers: { maxWritesPerRun: 1, maxCallsPerMinute: 100 },
     });
     const read = descriptor("read");

--- a/packages/harnesses/src/runtime.ts
+++ b/packages/harnesses/src/runtime.ts
@@ -87,7 +87,9 @@ export interface HireRecord {
   skill?: string;
   /** The specialist's own report back, as the resident received it. */
   summary: string;
-  usage?: { inputTokens: number; outputTokens: number };
+  /** This hire's spend and nobody else's — the full shape, so its row prices on
+   *  its own. The turn's `usage` event never carries it: see `reportRun`. */
+  usage?: UsageTotals;
 }
 
 /**
@@ -196,7 +198,9 @@ export interface HarnessRuntime {
 
 const mintAuditId = (): string => `aud_${globalThis.crypto.randomUUID()}`;
 
-interface UsageTotals {
+/** The metering figures an audit row carries — the `usage` HarnessEvent's own
+ *  shape, which is why a harness can hand one straight over. */
+export interface UsageTotals {
   inputTokens: number;
   outputTokens: number;
   cacheReadTokens?: number;
@@ -734,8 +738,18 @@ async function saveHarnessState(
   }
 }
 
-/** One audit row per turn carrying the metering figures and any failure —
- *  `audit ⊇ transcript`, so billing never depends on the story layer. */
+/**
+ * The turn's metering rows — `audit ⊇ transcript`, so billing never depends on
+ * the story layer.
+ *
+ * HOW TO READ THEM, which is the whole rule a host needs: every row counts its
+ * OWN spend and nobody else's. The `run` row's `usage` is the resident loop
+ * alone; each `subagent` row's `usage` is that one hire. No row contains
+ * another, so a turn's total is the SUM over its rows — and a row on its own is
+ * never the total. The harness held the other half of this: it used to fold the
+ * hires into the turn's `usage` event AND report each hire, so the rows
+ * overlapped and every turn that hired over-billed by its hires.
+ */
 async function reportRun(
   guard: Guard,
   input: TurnRunInput<unknown>,

--- a/packages/harnesses/src/turn-error.test.ts
+++ b/packages/harnesses/src/turn-error.test.ts
@@ -9,19 +9,25 @@
  * the TRANSCRIPT holds — the real read path — not against the live stream, since
  * the live stream was never the part that was broken.
  */
-import type { ThreadId } from "@vendoai/core";
-import type { UIMessage } from "ai";
+import type { SeatModels, ThreadId } from "@vendoai/core";
+import type { LanguageModel, UIMessage } from "ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { defineHarness } from "./define.js";
 import { createHarnessRuntime } from "./runtime.js";
+import { vendo } from "./vendo/vendo.js";
 import {
   boundRegistry,
   ctx,
   readSse,
+  readTool,
+  scriptedModel,
+  seats,
   testGuard,
   testSkills,
   testTranscript,
   testWorkspace,
+  textTurn,
+  toolCallTurn,
   unusedModels,
   userMessage,
 } from "./test-doubles.test-util.js";
@@ -45,16 +51,17 @@ function runtimeFor(overrides: Partial<Parameters<typeof createHarnessRuntime>[0
   const run = async (
     harness: Parameters<typeof runtime.run>[0]["harness"],
     messages: UIMessage[] = [userMessage("m1", "go")],
+    models: SeatModels<LanguageModel> = unusedModels(),
   ) => readSse(await runtime.run({
     harness,
     threadId: THREAD,
     messages,
     ctx: ctx(),
     workspace: testWorkspace(),
-    models: unusedModels(),
+    models,
     interactive: true,
   }));
-  return { run, transcript };
+  return { run, guard, transcript };
 }
 
 const failing = defineHarness({
@@ -127,6 +134,68 @@ describe("a failed turn keeps its reason in the transcript", () => {
     }));
 
     expect(turnErrors(await transcript.list(ctx().principal, THREAD))).toHaveLength(0);
+  });
+});
+
+/**
+ * Ported from the deleted `createAgent` door (`agent/src/stream-error.test.ts`,
+ * "recoverable tool errors are NOT turn failures"): the same loop, now reached
+ * through `vendo()`. Driven end to end — real harness, real runtime, real
+ * guard — because the defect was exactly a disagreement between the two halves:
+ * `vendo()` reported the SDK's recoverable `tool-error` as a harness `error`,
+ * and the runtime, which is right to treat a reported error as the turn's
+ * death, then stamped a finished turn failed.
+ */
+describe("a recoverable tool error is not a failed turn", () => {
+  const echo = readTool("echo");
+  const runRows = (guard: ReturnType<typeof testGuard>) =>
+    guard.events.filter((event) => event.kind === "run");
+
+  it("a hallucinated tool name the model recovers from leaves the turn clean", async () => {
+    // The SDK rejects the unknown name before any tool runs, feeds the rejection
+    // back, and the model answers on the next step. A notice here would render a
+    // permanent failed-turn banner above a successful reply.
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const model = scriptedModel([
+      toolCallTurn("no_such_tool", { value: "x" }, "call_bogus"),
+      textTurn("Here is your dashboard."),
+    ]);
+    const guard = testGuard();
+    const { run, transcript } = runtimeFor({
+      guard,
+      tools: boundRegistry({ echo: { descriptor: echo, execute: async (args) => args } }, guard),
+    });
+
+    const parts = await run(vendo(), [userMessage("m1", "Show me a dashboard")], seats(model));
+
+    expect(parts.find((part) => part.type === "error")).toBeUndefined();
+    const stored = await transcript.list(ctx().principal, THREAD);
+    expect(turnErrors(stored)).toHaveLength(0);
+    expect(JSON.stringify(stored)).toContain("Here is your dashboard.");
+    // The ledger says the same thing the transcript does.
+    expect(runRows(guard).some((row) => (row.detail as { error?: unknown }).error !== undefined))
+      .toBe(false);
+  });
+
+  it("a tool that throws mid-turn leaves the turn clean too", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const model = scriptedModel([
+      toolCallTurn("echo", { value: "x" }, "call_throws"),
+      textTurn("Recovered without it."),
+    ]);
+    const guard = testGuard();
+    const { run, transcript } = runtimeFor({
+      guard,
+      tools: boundRegistry({
+        echo: { descriptor: echo, execute: () => { throw new Error("upstream 500"); } },
+      }, guard),
+    });
+
+    await run(vendo(), [userMessage("m1", "Echo something")], seats(model));
+
+    const stored = await transcript.list(ctx().principal, THREAD);
+    expect(turnErrors(stored)).toHaveLength(0);
+    expect(JSON.stringify(stored)).toContain("Recovered without it.");
   });
 });
 

--- a/packages/harnesses/src/vendo/ledger.test.ts
+++ b/packages/harnesses/src/vendo/ledger.test.ts
@@ -1,0 +1,132 @@
+/**
+ * What a biller reads after a turn that hired — asserted over the ACTUAL audit
+ * rows the guard received, from a real `vendo()` turn through the real runtime.
+ *
+ * The seam is the point: the harness decides what the `usage` event carries and
+ * the runtime decides which rows exist, so a suite that stubbed either half
+ * could never catch them disagreeing — and they did. The harness folded the
+ * hires into the turn's usage AND reported each hire, so the runtime wrote both
+ * a run row containing the hires and a row per hire, and a host summing rows
+ * paid for every hire twice.
+ */
+import type { AuditEvent, ThreadId } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { vendo } from "./vendo.js";
+import { createHarnessRuntime } from "../runtime.js";
+import {
+  boundRegistry,
+  ctx,
+  readSse,
+  scriptedModel,
+  seats,
+  testGuard,
+  testSkills,
+  testTranscript,
+  testWorkspace,
+  textTurn,
+  toolCallTurn,
+  userMessage,
+} from "../test-doubles.test-util.js";
+
+const THREAD = "thr_ledger" as ThreadId;
+
+/** The resident's own step. Split across the cache so the row's cache figures
+ *  can be checked against the loop that actually spent them. */
+const RESIDENT = {
+  inputTokens: { total: 1_000, noCache: 600, cacheRead: 300, cacheWrite: 100 },
+  outputTokens: { total: 100, text: 100, reasoning: 0 },
+} as const;
+
+/** The hire — the bulk of a build turn's inference, and its own cache split. */
+const HIRE = {
+  inputTokens: { total: 90_000, noCache: 60_000, cacheRead: 25_000, cacheWrite: 5_000 },
+  outputTokens: { total: 4_000, text: 4_000, reasoning: 0 },
+} as const;
+
+interface RowUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+  model?: string;
+}
+
+/** Every usage figure this turn wrote anywhere, one entry per row — which is
+ *  exactly how a host bills: sum the rows. */
+const usagesOf = (events: AuditEvent[]): RowUsage[] =>
+  events
+    .filter((event) => event.kind === "run")
+    .flatMap((event) => {
+      const detail = event.detail as { usage?: RowUsage; subagent?: { usage?: RowUsage } };
+      return [detail.usage, detail.subagent?.usage].filter((usage): usage is RowUsage => usage !== undefined);
+    });
+
+/** A turn whose resident hires one specialist and then answers. */
+async function turnThatHires() {
+  const model = scriptedModel([
+    toolCallTurn("hire_subagent", { instructions: "build the invoices app" }),
+    textTurn("did the big job", HIRE),
+    textTurn("All done.", RESIDENT),
+  ]);
+  const guard = testGuard();
+  const runtime = createHarnessRuntime({
+    tools: boundRegistry({}, guard),
+    guard,
+    skills: testSkills(),
+    transcript: testTranscript(),
+  });
+  await readSse(await runtime.run({
+    harness: vendo(),
+    threadId: THREAD,
+    messages: [userMessage("m1", "build me an invoices app")],
+    ctx: ctx(),
+    workspace: testWorkspace(),
+    models: seats(model),
+    interactive: true,
+  }));
+  return { guard };
+}
+
+describe("subagent spend lands in the ledger exactly once", () => {
+  it("counts the whole turn's tokens once across the rows, not once per row that mentions them", async () => {
+    const { guard } = await turnThatHires();
+    const usages = usagesOf(guard.events);
+    const total = (field: keyof RowUsage) =>
+      usages.reduce((sum, usage) => sum + ((usage[field] as number | undefined) ?? 0), 0);
+
+    // What the provider actually charged for: the resident's steps plus the
+    // hire's. Summing the rows has to land on exactly that.
+    expect(total("inputTokens")).toBe(RESIDENT.inputTokens.total + HIRE.inputTokens.total);
+    expect(total("outputTokens")).toBe(RESIDENT.outputTokens.total + HIRE.outputTokens.total);
+    expect(total("cacheReadTokens")).toBe(RESIDENT.inputTokens.cacheRead + HIRE.inputTokens.cacheRead);
+    expect(total("cacheWriteTokens")).toBe(RESIDENT.inputTokens.cacheWrite + HIRE.inputTokens.cacheWrite);
+  });
+
+  it("gives the run row the resident loop alone, cache split included", async () => {
+    const { guard } = await turnThatHires();
+    const run = guard.events.find(
+      (event) => event.kind === "run" && (event.detail as { usage?: unknown }).usage !== undefined,
+    );
+
+    expect((run!.detail as { usage: RowUsage }).usage).toMatchObject({
+      inputTokens: RESIDENT.inputTokens.total,
+      outputTokens: RESIDENT.outputTokens.total,
+      cacheReadTokens: RESIDENT.inputTokens.cacheRead,
+      cacheWriteTokens: RESIDENT.inputTokens.cacheWrite,
+    });
+  });
+
+  it("gives the hire's row the hire's full usage, so its figures are priceable on their own", async () => {
+    const { guard } = await turnThatHires();
+    const hire = guard.events.find(
+      (event) => event.kind === "run" && (event.detail as { subagent?: unknown }).subagent !== undefined,
+    );
+
+    expect((hire!.detail as { subagent: { usage: RowUsage } }).subagent.usage).toMatchObject({
+      inputTokens: HIRE.inputTokens.total,
+      outputTokens: HIRE.outputTokens.total,
+      cacheReadTokens: HIRE.inputTokens.cacheRead,
+      cacheWriteTokens: HIRE.inputTokens.cacheWrite,
+    });
+  });
+});

--- a/packages/harnesses/src/vendo/ledger.test.ts
+++ b/packages/harnesses/src/vendo/ledger.test.ts
@@ -84,7 +84,7 @@ async function turnThatHires() {
     models: seats(model),
     interactive: true,
   }));
-  return { guard };
+  return { guard, modelId: (model as unknown as { modelId: string }).modelId };
 }
 
 describe("subagent spend lands in the ledger exactly once", () => {
@@ -128,5 +128,15 @@ describe("subagent spend lands in the ledger exactly once", () => {
       cacheReadTokens: HIRE.inputTokens.cacheRead,
       cacheWriteTokens: HIRE.inputTokens.cacheWrite,
     });
+  });
+});
+
+describe("a usage row names the model that spent it", () => {
+  it("carries the resolved model id, so a row prices without guessing the seat", async () => {
+    const { guard, modelId } = await turnThatHires();
+    const usages = usagesOf(guard.events);
+
+    expect(usages).not.toHaveLength(0);
+    expect(usages.every((usage) => usage.model === modelId)).toBe(true);
   });
 });

--- a/packages/harnesses/src/vendo/vendo.test.ts
+++ b/packages/harnesses/src/vendo/vendo.test.ts
@@ -11,6 +11,7 @@ import type { HarnessEvent, Json, ToolDescriptor, Turn } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
 import { vendo, type HarnessHand } from "./vendo.js";
 import { createTurnTools } from "../turn-tools.js";
+import type { HireRecord } from "../runtime.js";
 import {
   boundRegistry,
   ctx,
@@ -335,7 +336,7 @@ describe("vendo() — subagent hiring (build-list item 4)", () => {
     expect(texts(events)).toContain("couldn't find");
   });
 
-  it("counts the specialist's tokens into the turn's usage (billing, not the story layer)", async () => {
+  it("reports the specialist's tokens as the SPECIALIST's, never folded into the turn's", async () => {
     const model = scriptedModel([
       toolCallTurn("hire_subagent", { instructions: "big job" }),
       // The specialist's own turn spends the bulk of the tokens.
@@ -348,7 +349,7 @@ describe("vendo() — subagent hiring (build-list item 4)", () => {
         outputTokens: { total: 100, text: 100, reasoning: 0 },
       }),
     ]);
-    const hires: Array<{ usage: { inputTokens: number; outputTokens: number } }> = [];
+    const hires: HireRecord[] = [];
     const { events } = await drive({
       harness: vendo({ onHire: (record) => hires.push(record) }),
       models: seats(model),
@@ -357,12 +358,15 @@ describe("vendo() — subagent hiring (build-list item 4)", () => {
     const usage = events.find((event) => event.type === "usage") as
       | Extract<HarnessEvent, { type: "usage" }>
       | undefined;
-    // The resident alone would report 1,000/100 — 91% of the spend unmetered.
-    expect(usage?.inputTokens).toBe(91_000);
-    expect(usage?.outputTokens).toBe(4_100);
-    // And the hire itself is reported, so composition can audit that it happened.
+    // The resident loop's own spend. Adding the hire's 90,000 here as well is
+    // what over-billed: the hire is ALSO reported below, and the runtime writes
+    // each report as its own audit row, so a host summing rows paid twice.
+    expect(usage?.inputTokens).toBe(1_000);
+    expect(usage?.outputTokens).toBe(100);
+    // The hire's spend, once, in full — cache split included, because its row is
+    // the only row that carries it. (The rows themselves: ./ledger.test.ts.)
     expect(hires).toHaveLength(1);
-    expect(hires[0]!.usage).toEqual({ inputTokens: 90_000, outputTokens: 4_000 });
+    expect(hires[0]!.usage).toMatchObject({ inputTokens: 90_000, outputTokens: 4_000 });
   });
 
   it("a subagent cannot hire a subagent — depth is bounded", async () => {

--- a/packages/harnesses/src/vendo/vendo.ts
+++ b/packages/harnesses/src/vendo/vendo.ts
@@ -19,8 +19,16 @@ import { z } from "zod";
 import { modelToolDescription, type Harness, type HarnessEvent, type Json, type ToolDescriptor, type Turn } from "@vendoai/core";
 import { startTurn, type TurnContext } from "./loop.js";
 import { wireErrorMessage } from "../wire-error.js";
-import { reportHire } from "../runtime.js";
-import { jsonSchema, stepCountIs, streamText, tool, type LanguageModel, type ToolSet } from "ai";
+import { reportHire, type HireRecord, type UsageTotals } from "../runtime.js";
+import {
+  jsonSchema,
+  stepCountIs,
+  streamText,
+  tool,
+  type LanguageModel,
+  type LanguageModelUsage,
+  type ToolSet,
+} from "ai";
 import { defineHarness } from "../define.js";
 
 /** How many messages a hired subagent may exchange before it must report back.
@@ -84,12 +92,7 @@ export interface VendoHarnessDeps {
    * reach it), so without this it would be invisible. Override only to observe it
    * somewhere else too.
    */
-  onHire?: (record: {
-    purpose: string;
-    skill?: string;
-    summary: string;
-    usage: { inputTokens: number; outputTokens: number };
-  }) => void;
+  onHire?: (record: HireRecord) => void;
   /**
    * The CLOSED toolbox. Set, the equipped set is EXACTLY this list: a string
    * equips that registry tool (guarded, via `turn.tools.call`, same as today); a
@@ -216,8 +219,21 @@ async function equipClosedLoadout(
 interface SubagentReport {
   summary: string;
   /** Every token a hired specialist spent. Unmetered subagents are the bulk of a
-   *  build turn's inference, so this is not optional bookkeeping. */
-  usage: { inputTokens: number; outputTokens: number };
+   *  build turn's inference, so this is not optional bookkeeping — and the FULL
+   *  shape, cache split included, because the hire's own audit row is the only
+   *  row that carries it. */
+  usage: UsageTotals;
+}
+
+/** One usage figure set from an `ai` totals block, in `UsageTotals` shape. */
+function usageOf(usage: LanguageModelUsage): UsageTotals {
+  const { cacheReadTokens, cacheWriteTokens } = usage.inputTokenDetails;
+  return {
+    inputTokens: usage.inputTokens ?? 0,
+    outputTokens: usage.outputTokens ?? 0,
+    ...(cacheReadTokens === undefined ? {} : { cacheReadTokens }),
+    ...(cacheWriteTokens === undefined ? {} : { cacheWriteTokens }),
+  };
 }
 
 /**
@@ -253,7 +269,7 @@ async function runSubagent(
   const [text, usage] = await Promise.all([result.text, result.totalUsage]);
   return {
     summary: text.trim() || "The specialist finished without a summary.",
-    usage: { inputTokens: usage.inputTokens ?? 0, outputTokens: usage.outputTokens ?? 0 },
+    usage: usageOf(usage),
   };
 }
 
@@ -293,8 +309,6 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
       // nothing to discover, so it fills the same object once and stops.)
       const residentTools: ToolSet = {};
       let equipped: string[] = [];
-      /** Subagent tokens, drained onto the turn's usage after the stream ends. */
-      const hiredUsage: Array<{ inputTokens: number; outputTokens: number }> = [];
       const hireSubagent = tool({
         description:
           "Hire a specialist for one big job (building or editing an app, a long research pass). "
@@ -310,7 +324,9 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
             // bounded at one and a helper cannot spawn a tree.
             const { [HIRE_SUBAGENT]: _hiring, ...hands } = residentTools;
             const report = await runSubagent(turn, model, input, hands);
-            hiredUsage.push(report.usage);
+            // The ONLY place a hire's spend is reported. The turn's `usage` event
+            // stays the resident's own, so the run row and the hire rows partition
+            // the turn instead of overlapping — see `reportRun`.
             (deps.onHire ?? reportHire)({
               purpose: input.instructions,
               ...(input.skill === undefined ? {} : { skill: input.skill }),
@@ -393,34 +409,14 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
             case "abort":
               // The caller hung up: stop cleanly, say nothing.
               return;
-            case "finish": {
-              // `model` is left unset: the contract's field is optional, and the
-              // resolved model id is not on this part — composition, which chose
-              // the seat, is the honest place to attribute it.
-              const { inputTokens, outputTokens, inputTokenDetails } = part.totalUsage;
-              const hired = hiredUsage.reduce(
-                (total, one) => ({
-                  inputTokens: total.inputTokens + one.inputTokens,
-                  outputTokens: total.outputTokens + one.outputTokens,
-                }),
-                { inputTokens: 0, outputTokens: 0 },
-              );
-              yield {
-                type: "usage",
-                // Subagent tokens are the bulk of a build turn's inference;
-                // billing that counted only the resident would under-report by
-                // most of the spend.
-                inputTokens: (inputTokens ?? 0) + hired.inputTokens,
-                outputTokens: (outputTokens ?? 0) + hired.outputTokens,
-                ...(inputTokenDetails.cacheReadTokens === undefined
-                  ? {}
-                  : { cacheReadTokens: inputTokenDetails.cacheReadTokens }),
-                ...(inputTokenDetails.cacheWriteTokens === undefined
-                  ? {}
-                  : { cacheWriteTokens: inputTokenDetails.cacheWriteTokens }),
-              };
+            case "finish":
+              // The RESIDENT loop's own spend, and only it. Folding the hires in
+              // here too double-counted them: each hire is already its own audit
+              // row (`reportHire`), so a host summing the turn's rows paid for
+              // every specialist twice — and the cache split, which is the
+              // resident's, then described a total that was not.
+              yield { type: "usage", ...usageOf(part.totalUsage) };
               break;
-            }
             default:
               // Tool call/result chunks are consumed here and dropped: the RUNTIME
               // mirrors them (§1.5), so echoing them would double every call.

--- a/packages/harnesses/src/vendo/vendo.ts
+++ b/packages/harnesses/src/vendo/vendo.ts
@@ -220,19 +220,27 @@ interface SubagentReport {
   summary: string;
   /** Every token a hired specialist spent. Unmetered subagents are the bulk of a
    *  build turn's inference, so this is not optional bookkeeping — and the FULL
-   *  shape, cache split included, because the hire's own audit row is the only
-   *  row that carries it. */
+   *  shape, cache split and model included, because the hire's own audit row is
+   *  the only row that carries them. */
   usage: UsageTotals;
 }
 
+/** The resolved id of the seat that spent the tokens: the union's string form IS
+ *  the id, the object form names it. */
+const modelIdOf = (model: LanguageModel): string =>
+  typeof model === "string" ? model : model.modelId;
+
 /** One usage figure set from an `ai` totals block, in `UsageTotals` shape. */
-function usageOf(usage: LanguageModelUsage): UsageTotals {
+function usageOf(usage: LanguageModelUsage, model: LanguageModel): UsageTotals {
   const { cacheReadTokens, cacheWriteTokens } = usage.inputTokenDetails;
   return {
     inputTokens: usage.inputTokens ?? 0,
     outputTokens: usage.outputTokens ?? 0,
     ...(cacheReadTokens === undefined ? {} : { cacheReadTokens }),
     ...(cacheWriteTokens === undefined ? {} : { cacheWriteTokens }),
+    // The seat this loop actually thought with, so the row prices without
+    // anyone asking composition which seat it chose.
+    model: modelIdOf(model),
   };
 }
 
@@ -269,7 +277,7 @@ async function runSubagent(
   const [text, usage] = await Promise.all([result.text, result.totalUsage]);
   return {
     summary: text.trim() || "The specialist finished without a summary.",
-    usage: usageOf(usage),
+    usage: usageOf(usage, model),
   };
 }
 
@@ -415,7 +423,7 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
               // row (`reportHire`), so a host summing the turn's rows paid for
               // every specialist twice — and the cache split, which is the
               // resident's, then described a total that was not.
-              yield { type: "usage", ...usageOf(part.totalUsage) };
+              yield { type: "usage", ...usageOf(part.totalUsage, model) };
               break;
             default:
               // Tool call/result chunks are consumed here and dropped: the RUNTIME

--- a/packages/harnesses/src/vendo/vendo.ts
+++ b/packages/harnesses/src/vendo/vendo.ts
@@ -390,13 +390,6 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
               // travel; the operator's terminal gets the real error.
               yield { type: "error", message: wireErrorMessage(part.error), code: "model" };
               break;
-            case "tool-error":
-              // A thrown or malformed tool call is a real failure the user must be
-              // told about — swallowing it left the turn looking finished.
-              // (`tool-input-error` is a UI-stream chunk, not a fullStream part;
-              // the SDK surfaces that class here as `tool-error` too.)
-              yield { type: "error", message: wireErrorMessage(part.error), code: "tool" };
-              break;
             case "abort":
               // The caller hung up: stop cleanly, say nothing.
               return;
@@ -431,6 +424,18 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
             default:
               // Tool call/result chunks are consumed here and dropped: the RUNTIME
               // mirrors them (§1.5), so echoing them would double every call.
+              //
+              // `tool-error` is dropped with them, and that is the rule: a turn
+              // FAILS by how it ends — an `error` part, a throw out of this drain,
+              // an abort — never by a step it recovered from. The SDK raises this
+              // part for its own malformed-input/unknown-tool class, feeds it back,
+              // and the model answers on the next step; a guarded call cannot raise
+              // it at all, because `turn.tools.call()` never throws (§1.1) and its
+              // failures are already a tool RESULT the model reads. Reporting it as
+              // an `error` event made the runtime — right to treat a reported error
+              // as the turn's death — stamp a finished turn failed: a permanent
+              // "The response didn't finish" notice and a failed audit row above a
+              // perfectly good answer.
               break;
           }
         }

--- a/packages/vendo/src/cli/init.test.ts
+++ b/packages/vendo/src/cli/init.test.ts
@@ -1204,12 +1204,17 @@ describe("vendo init (zero-question)", () => {
         .resolves.toMatchObject({ action: "run", decidedBy: "rule" });
 
       // The documented edge (quickstart/install): deleting the init-written
-      // file while keeping `policy: {}` degrades to auto-run WITHOUT the
-      // unconfigured notice — the default file is read fail-soft, and
-      // status() reads any policy object as configured.
+      // file while keeping `policy: {}` degrades to the guard's own blank
+      // state WITHOUT the unconfigured notice — the default file is read
+      // fail-soft, and status() reads any policy object as configured. What
+      // the blank state means is the guard's to say, and for a destructive
+      // tool it says ask (`default`, not the file's `rule`) — so losing the
+      // file costs the audit trail's attribution, never the consent.
       await rm(join(root, ".vendo", "policy.json"));
       const fileless = createGuard({ store, policy: {} });
       await expect(fileless.check({ id: "call_3", tool: destructive.name, args: {} }, destructive, ctx))
+        .resolves.toMatchObject({ action: "ask", decidedBy: "default" });
+      await expect(fileless.check({ id: "call_4", tool: read.name, args: {} }, read, ctx))
         .resolves.toMatchObject({ action: "run", decidedBy: "default" });
       expect(fileless.status()).toEqual({ posture: "rules" });
     } finally {

--- a/packages/vendo/src/duplicate-titles-projection.test.ts
+++ b/packages/vendo/src/duplicate-titles-projection.test.ts
@@ -102,7 +102,15 @@ describe("the title collision is a deployment property, not a per-run one", () =
       descriptors: async () => clean,
       execute: async (call) => { executed.push(call.tool); return { status: "ok", output: {} }; },
     };
-    const guard = createGuard({ store: memoryStoreAdapter() });
+    // Consent is not this suite's subject: what is pinned is that a clean
+    // deployment reaches the tool at all. The blank state parks a destructive
+    // call, so the host says in writing that this one may run — otherwise the
+    // "clean" case would be indistinguishable from the collision case, which
+    // also never executes.
+    const guard = createGuard({
+      store: memoryStoreAdapter(),
+      policy: { rules: [{ match: { risk: "destructive" }, action: "run" }] },
+    });
     const connectGate = createConnectGate({ toolkitOf: async () => undefined, isConnected: async () => true });
     const registry = withUniqueToolTitles(connectGate.bind(guard.bind(inner)));
 


### PR DESCRIPTION
> **Rebased onto `main`** (`f7c6da2ab`) now that one-path has landed. One real
> conflict — one-path S7/S8 restructured `vendo()`'s hiring tool into a
> standalone value for the new closed-loadout (`deps.tools`) path; resolved for
> intent, keeping that structure and applying only the ledger change inside it.
>
> **Nothing dropped.** Before landing, each of the four red-proofs was re-run
> against `main`'s behaviour: the guard default (`guard.ts:1348` on main) still
> runs destructive unasked; `vendo.ts:393` still reports `tool-error` as a turn
> failure; `vendo.ts:297/313/403` still fold hires into the turn's usage while
> `runtime.ts:766` writes them again; and `vendo.ts:404` still leaves `model`
> unset. S7/S8's persisted-turn-error and check-round work touched neither.

## What

Four verified defects in the engine, one commit each, each with a test that was
red before its fix.

---

### 1. `fix(guard)` — the unconfigured default ran destructive tools unasked

**Defect.** With **no policy configured at all**, the guard's own no-match
default RAN a declared `destructive` host tool without asking. Only `ungraded`
fell through to an ask.

**Root cause.** `packages/guard/src/guard.ts:1326` (base) — `#pipeline`'s
last stage: `if (descriptor.risk === "ungraded") … ask` then `… run`. The
comment above it already claimed `ungraded` asks "exactly as `destructive` does
under the default policy" — but only the *presets* said that, in writing. The
guard-level default did not, so the one install where nothing else speaks for
the user (a hand-wired server, no policy config) was the install that deleted
things silently.

**Fix.** The blank state asks for both grades, read off
`withheldFromUnattended` — the same two §12 refuses where there is nobody to
ask. One list, so the halves cannot drift into a default that silently runs what
the unattended law refuses. `read` and `write` are untouched; a host that wants
these to run says so with a `risk: "destructive"` rule.

**Test.** `packages/guard/test/destructive-default.test.ts` — asks on a
policy-less guard, parks end to end without executing, leaves read/write alone,
never runs unattended, and stays loosenable in writing. Red before: `run` /
`decidedBy: "default"`, and `bound.execute` returned `{ status: "ok" }` with the
tool actually invoked.

---

### 2. `fix(harnesses)` — a recoverable tool error stamped the turn failed

**Defect.** A model that hallucinated a tool name (or sent malformed input),
read the SDK's rejection and answered correctly on the next step still got a
permanent "The response didn't finish" notice in the transcript and a failed
audit row — above a perfectly good reply.

**Root cause.** `packages/harnesses/src/vendo/vendo.ts:307` (base) mapped every
`tool-error` fullStream part to a harness `error` event; its own comment admits
the SDK surfaces its malformed-input class there. `runtime.ts` is right to treat
a reported `error` as the turn's death, so it wrote the `data-vendo-turn-error`
part and the failed row, first-write-wins.

**Fix.** A turn fails by how it **ends** — an `error` part, a throw out of the
drain, an abort — never by a step it recovered from. `tool-error` joins the tool
call/result chunks the drain drops. Nothing is lost: a *guarded* call cannot
raise it, because `turn.tools.call()` never throws (§1.1) and its failures are
already a tool RESULT the model reads.

**Test.** `packages/harnesses/src/turn-error.test.ts` → "a recoverable tool
error is not a failed turn". Driven end to end — real `vendo()`, real runtime,
real guard — because the defect *was* the two halves disagreeing, which no
single-side suite can see. Red before: an `error` chunk on the wire and the
notice in the transcript.

> Credit: this is the deleted `createAgent` door's own regression test
> (`packages/agent/src/stream-error.test.ts`, "recoverable tool errors are NOT
> turn failures", deleted in 659b453a7), ported to the `vendo()` door. The
> semantics were proven on this same loop and were lost with the door.

---

### 3. `fix(harnesses)` — subagent spend was billed twice

**Defect.** Every turn that hired a subagent over-billed by the hire.

**Root cause.** `packages/harnesses/src/vendo/vendo.ts:222/239/317-343` (base)
folded each hire's tokens into the turn's `usage` event — written by the runtime
as the run row's `detail.usage` — **and** reported each hire, which
`runtime.ts:754` writes as its own row with the same figures. A host summing
rows paid twice. The hire report also dropped cache read/write, so the run row's
cache split described the resident while its `inputTokens` already included the
hires: a split that did not add up to its own total.

**Fix.** The rows now **partition** the turn. The run row is the resident loop
alone; each hire row is that one hire, in the full `UsageTotals` shape (cache
split included). Total spend is the sum over rows; no row contains another. The
read rule is stated where the rows are written (`reportRun`), because reading it
is the host's job.

**Why the `usage` event carries the resident only, and gains no field.**
`HarnessEvent` is the closed §1.5 vocabulary, so the shape was never on the
table — but it did not need to be. A hire is not the resident's spend, and the
runtime already had a per-hire channel (`reportHire`) that was already writing a
row. The event's only bug was claiming spend that channel had already claimed;
the cure is subtraction, not a new field. The alternative — an `attribution`
field, or a repeated-figures convention a host has to know about — would put a
protocol where an existing channel already was.

**Test.** `packages/harnesses/src/vendo/ledger.test.ts` — a real `vendo()` turn
that hires, through the real runtime, asserted over the **actual audit rows the
guard received**: summing the rows equals (resident + hire) provider totals, and
each row carries its own figures. Red before: 181,000 input tokens counted where
91,000 were spent. A suite that stubbed either half could never have caught two
halves double-claiming.

---

### 4. `fix(harnesses)` — usage rows carry the model id

**Defect.** Audit rows carried token counts with no model, so they could not be
priced.

**Root cause.** `packages/harnesses/src/vendo/vendo.ts:318` (base) left `model`
unset deliberately, reasoning that composition — which chose the seat — was the
honest place to attribute it. It is not: the row is written by the runtime,
composition never touches it, and the seat is in hand where the event is
yielded.

**Fix.** The resolved id rides both the turn's usage event and each hire's
usage. `UsageTotals` already supported it; `HarnessEvent`'s `usage.model` has
been optional since it was written, so nothing about the contract changes.

> Reference: `packages/apps/src/claude-turn.ts:249-262` already does exactly
> this for the Claude harness — this brings the default harness onto the same
> pattern.

---

## Spec-visible behaviour changes (each in its own commit)

Five existing cases asserted the old behaviour. None had their meaning
weakened; each was re-pinned with the reason in the commit message.

| Case | Was | Now |
| --- | --- | --- |
| `guard/test/pipeline-conformance.test.ts` — "default decides present destructive calls" | present `destructive` auto-runs from the blank state | asks at every presence |
| `guard/test/pipeline-conformance.test.ts` — "write breaker counts write and destructive runs" | relied on the blank state running a destructive call | states the host's opt-in in writing, so there is a run to charge |
| `harnesses/src/vendo/vendo.test.ts` — "counts the specialist's tokens into the turn's usage" | turn usage = 91,000 (the double count) | resident 1,000; the hire reported separately |
| `vendo/src/cli/init.test.ts` — the documented "delete the policy file" edge | degrades to auto-run | degrades to the blank state's ask; losing the file costs the audit attribution, never the consent |
| `vendo/src/duplicate-titles-projection.test.ts` — clean-deployment pass-through | policy-less guard ran a destructive tool | says the run in writing, so "clean" stays distinguishable from the collision case |

## Why

All four are pre-parity defects on the one path `vendo()` is about to be: a
guard default that contradicts every preset it ships beside, a false failure on
a successful turn, a ledger a host cannot sum, and rows nobody can price.

## Verification

Post-rebase, on `main` (`f7c6da2ab`):

```
BUILD=0   TYPECHECK=0   LINT=0
guard 270 · harnesses 427 · actions 634 · apps 1039 · automations 106
agents 77 · vendoai 3 · vendo 2168        -> SCOPED_TEST=0
redteam-e2e (run alone) 24 passed         -> REDTEAM_ALONE=0
```

- [x] `pnpm build` · `pnpm typecheck` · `pnpm lint` green; scoped
      `turbo run test test:ui` over the changed packages and every package
      downstream of them green (**4524 passed, 0 failed**). `test:affected` does
      not exist in this repo, hence the explicit scope. The full suite is CI's
      job; the `ci` check is the gate of record.
- [x] Each fix proven red-before-green twice: once when written, and again
      against `main`'s behaviour after the rebase.
- [x] `fixtures/redteam`'s `away-authority.e2e.test.ts` flakes when
      co-scheduled with the 2168-test `@vendoai/vendo` suite (its automation run
      reports `ok` and the fixture invoice read comes back stale). It passes
      alone with and without these commits, and both of its cases deliberately
      use `host_invoices_update` — a non-destructive **write**, untouched by fix
      1. Machine starvation, not a regression.
- [ ] Screenshots — not UI-affecting.
