### PR TITLE
docs(changeset): user facts, live screen context, and the useVendoContext rename

### DIFF
--- a/.changeset/user-facts-and-screen-context.md
+++ b/.changeset/user-facts-and-screen-context.md
@@ -1,0 +1,38 @@
+---
+"@vendoai/ui": major
+"@vendoai/vendo": major
+"@vendoai/agent": minor
+"@vendoai/agents": minor
+"@vendoai/harnesses": minor
+"@vendoai/apps": minor
+---
+
+The agent can now be told who the user is and what they are looking at.
+
+Two seams, both optional, both merged into one `[Situation]` block on every
+message the user sends:
+
+- **User facts.** The `user` resolver on the `authJs()` and `jwt()` auth presets
+  may now return a `facts` object alongside the principal, and those facts reach
+  the prompt. The session is decoded once per request for both the principal and
+  the facts. An anonymous request resolves no facts.
+- **Live screen context.** `useVendoContext(data)` publishes structured host data
+  for as long as the component is mounted, and retires it on unmount. Several
+  mounted callers coexist and merge. `VendoProvider` also takes `captureScreen`
+  (default `true`) to control the screen snapshot that rides the same channel.
+
+**BREAKING (`@vendoai/ui`, `@vendoai/vendo/react`): `useVendoContext` is now
+`useVendoProvider`.** The name `useVendoContext` previously belonged to the
+zero-argument hook that read everything `VendoProvider` supplies; it now belongs
+to the host-facing hook above, which takes data and returns nothing. Both names
+still exist, so the compiler is the thing that catches this:
+
+```diff
+- const { client } = useVendoContext();
++ const { client } = useVendoProvider();
+```
+
+Because both names still exist, the compiler catches this rather than the
+runtime: an existing zero-argument call now fails with `TS2554: Expected 1
+arguments, but got 0`. Rename the call and you are done — nothing else about the
+provider value changed.


### PR DESCRIPTION
PR #852 landed the user-`facts` + live-screen-context feature **and** a breaking rename of `useVendoContext` with no changeset. Without this, the 1.0.0 release publishes both with no release notes — a newcomer hits `TS2554` and finds nothing in the changelog explaining it.

This adds the missing changeset only. No source changes.

Covers:
- the new capability (`facts` on the auth preset's `user` resolver; `useVendoContext(data)`; `captureScreen` on `VendoProvider`)
- **BREAKING:** `useVendoContext` → `useVendoProvider`, with the one-line migration

The `@auth/core` peer fix is already covered by `.changeset/auth-core-security-floor.md`.

Gate green locally: build 24/24, typecheck 45/45, lint 3/3; `pnpm test` red only on the 7 known pre-existing failures caused by the space in this checkout's path (core packaging.e2e x3, store drills x2, vendo dev-creds/model x2).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing changeset to document user facts, live screen context, and the `useVendoContext` → `useVendoProvider` rename so 1.0.0 ships with clear release notes. No source changes.

- **New Features**
  - Auth presets `authJs()` and `jwt()` can return `facts` on the `user` resolver.
  - `useVendoContext(data)` publishes live screen context; `VendoProvider` adds `captureScreen` (default `true`).

- **Migration**
  - Breaking in `@vendoai/ui` and `@vendoai/vendo/react`: rename zero-arg reads from useVendoContext to useVendoProvider to avoid TS2554.

<sup>Written for commit 9f2478e12818e643c194958613afd4165b4a777a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

