### PR TITLE
refactor(harnesses)!: a hire rides the one loop — no second streamText

### DIFF
--- a/packages/harnesses/src/vendo/subagent-loop.test.ts
+++ b/packages/harnesses/src/vendo/subagent-loop.test.ts
@@ -1,0 +1,276 @@
+/**
+ * A hire rides the ONE loop.
+ *
+ * `runSubagent` used to open a second, bare `streamText` of its own, so every
+ * rail `startTurn` owns — the stop conditions, the history assembly, the cache
+ * breakpoints, the stated retry budget — stopped at the resident, and a hired
+ * specialist ran without them. `vendo()`'s own docstring already claims the
+ * opposite ("NOT a second loop"), and the hire was the one caller that made it
+ * untrue.
+ *
+ * What this suite pins: a hire goes through `startTurn` (asserted by rails only
+ * that loop has), it still cannot hire — both depth-1 locks — two hires still
+ * run at the same time (full parallelism, writes included), and the ledger still
+ * partitions the turn into a resident run row plus one audit row per hire.
+ */
+import {
+  ASK_USER_TOOL,
+  type HarnessEvent,
+  type Json,
+  type ToolOutcome,
+  type ToolRegistry,
+  type Turn,
+} from "@vendoai/core";
+import type { LanguageModel } from "ai";
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+import { describe, expect, it } from "vitest";
+import { vendo } from "./vendo.js";
+import { createTurnTools } from "../turn-tools.js";
+import type { HireRecord } from "../runtime.js";
+import {
+  ctx,
+  readTool,
+  scriptedModel,
+  seats,
+  testGuard,
+  testSkills,
+  testWorkspace,
+  textTurn,
+  toolCallTurn,
+  userMessage,
+  ZERO_USAGE,
+} from "../test-doubles.test-util.js";
+
+const HIRE_SUBAGENT = "hire_subagent";
+
+/** The first words of the specialist system prompt. Matching on them is how a
+ *  double tells a hire's model call from the resident's, and it pins the prose
+ *  as a fixed point at the same time. */
+const SPECIALIST_OPENING = "You are a specialist hired for one job.";
+
+/** No host tools at all — the shape most of the hiring cases need. */
+const NO_TOOLS: ToolRegistry = {
+  descriptors: async () => [],
+  execute: async () => ({ status: "error", error: { code: "not-found", message: "no tools" } }),
+};
+
+/** Drive the harness directly: the runtime is proven separately, so the Turn is
+ *  assembled by hand and the events are collected raw. */
+async function driveTurn(options: {
+  harness: ReturnType<typeof vendo>;
+  registry: ToolRegistry;
+  model: LanguageModel;
+}): Promise<HarnessEvent[]> {
+  const turnTools = createTurnTools({
+    registry: options.registry,
+    guard: testGuard(),
+    ctx: ctx(),
+    interactive: true,
+    mirror: () => {},
+  });
+  const turn: Turn = {
+    messages: [userMessage("m1", "get the big job done")],
+    tools: turnTools,
+    skills: testSkills(),
+    workspace: testWorkspace(),
+    models: seats(options.model),
+    state: { get: () => undefined, set: () => undefined, clear: () => undefined },
+    options: {},
+    signal: new AbortController().signal,
+    interactive: true,
+  };
+  const events: HarnessEvent[] = [];
+  for await (const event of options.harness.run(turn)) events.push(event);
+  turnTools.dispose();
+  return events;
+}
+
+const texts = (events: HarnessEvent[]): string =>
+  events
+    .filter((event): event is Extract<HarnessEvent, { type: "text" }> => event.type === "text")
+    .map((event) => event.delta)
+    .join("");
+
+describe("a hire rides `startTurn`, not a second `streamText`", () => {
+  it("ends the specialist's turn on an answered ask_user — a stop condition only the loop has", async () => {
+    const registry: ToolRegistry = {
+      descriptors: async () => [readTool(ASK_USER_TOOL)],
+      // Hand-rolled rather than `boundRegistry`: the double wraps whatever it
+      // returns in `{status:"ok"}`, which is exactly the field the stop reads.
+      execute: async (): Promise<ToolOutcome> => ({
+        status: "ok",
+        output: { question: "Which account?" } as Json,
+      }),
+    };
+    const model = scriptedModel([
+      // 1. the resident hires
+      toolCallTurn(HIRE_SUBAGENT, { instructions: "move the money" }),
+      // 2. the specialist asks the user a question, and is answered
+      toolCallTurn(ASK_USER_TOOL, { question: "Which account?" }),
+      // 3. the resident's own reply — reached only if the specialist STOPPED
+      textTurn("Done."),
+    ]);
+
+    const events = await driveTurn({ harness: vendo(), registry, model });
+
+    // Three model calls, not four. `askedUserStop` ends the specialist's turn the
+    // same way it ends the resident's; a bare `streamText` carried only the step
+    // cap, so the specialist took another step and ate the resident's script.
+    expect(model.calls).toBe(3);
+    expect(texts(events)).toBe("Done.");
+  });
+
+  it("assembles the specialist's prompt through the loop's own history builder", async () => {
+    const model = scriptedModel([
+      toolCallTurn(HIRE_SUBAGENT, { instructions: "summarise the ledger" }),
+      textTurn("summarised"),
+      textTurn("All done."),
+    ]);
+
+    await driveTurn({ harness: vendo(), registry: NO_TOOLS, model });
+
+    const hirePrompt = model.prompts[1] as Array<{ role: string; providerOptions?: unknown }>;
+    const system = hirePrompt[0];
+    expect(system?.role).toBe("system");
+    // `turnModelMessages` marks the system block for Anthropic prompt caching
+    // (`loop.ts`'s `CACHE_BREAKPOINT`). A raw `streamText({ system })` cannot —
+    // the string has nowhere to carry provider options.
+    expect(system?.providerOptions).toEqual({ anthropic: { cacheControl: { type: "ephemeral" } } });
+    // The brief still arrives, now as the one user message of a one-message thread.
+    expect(JSON.stringify(hirePrompt)).toContain("summarise the ledger");
+  });
+
+  it("keeps the specialist's own words off the screen and its prose unchanged", async () => {
+    const model = scriptedModel([
+      toolCallTurn(HIRE_SUBAGENT, { instructions: "do the thing" }),
+      textTurn("SPECIALIST CHATTER: here is my inner monologue"),
+      textTurn("It's finished."),
+    ]);
+
+    const events = await driveTurn({ harness: vendo(), registry: NO_TOOLS, model });
+
+    expect(texts(events)).toBe("It's finished.");
+    expect(texts(events)).not.toContain("SPECIALIST CHATTER");
+    expect(model.systemPrompts[1]).toBe(
+      "You are a specialist hired for one job. Do it with the tools you have, then report back in "
+      + "at most three sentences. Your reply is read by another agent, not by a person.",
+    );
+  });
+});
+
+describe("depth stays bounded at one, by both locks", () => {
+  it("hands the specialist every tool but the hiring one — tools object and loadout", async () => {
+    const registry: ToolRegistry = {
+      descriptors: async () => [readTool("maple_invoices_list")],
+      execute: async (): Promise<ToolOutcome> => ({ status: "ok", output: { count: 2 } as Json }),
+    };
+    const model = scriptedModel([
+      toolCallTurn(HIRE_SUBAGENT, { instructions: "count the invoices" }),
+      textTurn("there are two"),
+      textTurn("You have 2."),
+    ]);
+
+    await driveTurn({ harness: vendo(), registry, model });
+
+    // The resident's loadout carries the hiring tool.
+    expect(model.toolNamesPerCall[0]).toContain(HIRE_SUBAGENT);
+    // The specialist's carries neither the tool nor the name. What reached the
+    // provider is the tools object AFTER `activeTools` filtered it, so this one
+    // reading pins both locks: lock #1 strips `hire_subagent` from the object,
+    // lock #2 keeps it out of the loadout the model may pick from.
+    expect(model.toolNamesPerCall[1]).toEqual(["maple_invoices_list"]);
+  });
+});
+
+const HIRE_USAGE = {
+  inputTokens: { total: 45_000, noCache: 45_000, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 2_000, text: 2_000, reasoning: 0 },
+};
+const RESIDENT_USAGE = {
+  inputTokens: { total: 900, noCache: 900, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 80, text: 80, reasoning: 0 },
+};
+
+/**
+ * A model whose SPECIALIST calls block until BOTH of them are running. If the
+ * two hires were serialized the first would wait here forever and the test's own
+ * timeout — the hang detector — would report it; there is no inner clock.
+ */
+function overlappingHires(): { model: LanguageModel; order: string[] } {
+  const order: string[] = [];
+  let started = 0;
+  let bothIn: () => void = () => {};
+  const bothStarted = new Promise<void>((resolve) => {
+    bothIn = resolve;
+  });
+  const resident = [
+    // ONE step, TWO hires. D5: full parallelism, writes included.
+    [
+      {
+        type: "tool-call",
+        toolCallId: "h1",
+        toolName: HIRE_SUBAGENT,
+        input: JSON.stringify({ instructions: "job one" }),
+      },
+      {
+        type: "tool-call",
+        toolCallId: "h2",
+        toolName: HIRE_SUBAGENT,
+        input: JSON.stringify({ instructions: "job two" }),
+      },
+      { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "tool-calls", raw: undefined } },
+    ],
+    textTurn("Both specialists are done.", RESIDENT_USAGE),
+  ];
+  const model = new MockLanguageModelV3({
+    doStream: async (request) => {
+      const system = request.prompt.find((message) => message.role === "system");
+      const brief = typeof system?.content === "string" ? system.content : "";
+      if (brief.startsWith(SPECIALIST_OPENING)) {
+        const job = JSON.stringify(request.prompt).includes("job one") ? "one" : "two";
+        order.push(`start:${job}`);
+        started += 1;
+        if (started === 2) bothIn();
+        await bothStarted;
+        order.push(`end:${job}`);
+        return { stream: simulateReadableStream({ chunks: textTurn(`${job} done`, HIRE_USAGE) }) };
+      }
+      const chunks = resident.shift();
+      if (chunks === undefined) throw new Error("resident script exhausted");
+      return { stream: simulateReadableStream({ chunks }) };
+    },
+  }) as unknown as LanguageModel;
+  return { model, order };
+}
+
+describe("two hires in one step, and one ledger between them", () => {
+  it("runs both specialists at the same time and partitions the turn's tokens", async () => {
+    const { model, order } = overlappingHires();
+    const hires: HireRecord[] = [];
+
+    const events = await driveTurn({
+      harness: vendo({ onHire: (record) => hires.push(record) }),
+      registry: NO_TOOLS,
+      model,
+    });
+
+    // Both started before either finished — overlap in time, not two turns in a
+    // row. Write-lane serialization was explicitly rejected.
+    expect(order).toHaveLength(4);
+    expect(order.slice(0, 2).map((entry) => entry.split(":")[0])).toEqual(["start", "start"]);
+    expect(texts(events)).toBe("Both specialists are done.");
+
+    // The run row is the RESIDENT's spend and only it: 900/80, not 90,900/4,080.
+    const usage = events.find((event) => event.type === "usage") as
+      | Extract<HarnessEvent, { type: "usage" }>
+      | undefined;
+    expect(usage).toMatchObject({ inputTokens: 900, outputTokens: 80 });
+
+    // ...and each hire is its own audit row, in full. Summing the rows prices the
+    // turn exactly once.
+    expect(hires).toHaveLength(2);
+    expect(hires.map((record) => record.usage.inputTokens)).toEqual([45_000, 45_000]);
+    expect(hires.map((record) => record.usage.outputTokens)).toEqual([2_000, 2_000]);
+    expect(hires.map((record) => record.purpose).sort()).toEqual(["job one", "job two"]);
+  });
+});

--- a/packages/harnesses/src/vendo/subagent-loop.test.ts
+++ b/packages/harnesses/src/vendo/subagent-loop.test.ts
@@ -273,4 +273,32 @@ describe("two hires in one step, and one ledger between them", () => {
     expect(hires.map((record) => record.usage.outputTokens)).toEqual([2_000, 2_000]);
     expect(hires.map((record) => record.purpose).sort()).toEqual(["job one", "job two"]);
   });
+
+  it("hands back the finished work even when the receipt cannot be booked", async () => {
+    const model = scriptedModel([
+      toolCallTurn(HIRE_SUBAGENT, { instructions: "the big job" }),
+      textTurn("the big job is done"),
+      textTurn("All set."),
+    ]);
+
+    const events = await driveTurn({
+      // `onHire` is a public knob a host overrides to observe hires somewhere of
+      // its own, so its failures are the host's, not the specialist's.
+      harness: vendo({
+        onHire: () => {
+          throw new Error("receipt sink is down");
+        },
+      }),
+      registry: NO_TOOLS,
+      model,
+    });
+
+    // The specialist ran and its tokens are already spent. Reporting a bookkeeping
+    // failure as "could not be reached" invites the one reaction that costs real
+    // money — hiring again for a job that is already done and already paid for.
+    const afterTheHire = JSON.stringify(model.prompts[2]);
+    expect(afterTheHire).toContain("the big job is done");
+    expect(afterTheHire).not.toContain("could not be reached");
+    expect(texts(events)).toBe("All set.");
+  });
 });

--- a/packages/harnesses/src/vendo/vendo.ts
+++ b/packages/harnesses/src/vendo/vendo.ts
@@ -22,8 +22,6 @@ import { wireErrorMessage } from "../wire-error.js";
 import { reportHire, type HireRecord, type UsageTotals } from "../runtime.js";
 import {
   jsonSchema,
-  stepCountIs,
-  streamText,
   tool,
   type LanguageModel,
   type LanguageModelUsage,
@@ -34,6 +32,12 @@ import { defineHarness } from "../define.js";
 /** How many messages a hired subagent may exchange before it must report back.
  *  Bounded so a runaway helper costs a receipt, not a turn. */
 const SUBAGENT_MAX_STEPS = 12;
+
+/** The job description a hire runs under. Its reply is the resident's private
+ *  context, not a wire artifact, which is why the prose says so out loud. */
+const SPECIALIST_SYSTEM =
+  "You are a specialist hired for one job. Do it with the tools you have, then report back in "
+  + "at most three sentences. Your reply is read by another agent, not by a person.";
 
 const HIRE_SUBAGENT = "hire_subagent";
 
@@ -254,7 +258,10 @@ async function runSubagent(
   turn: Turn<unknown>,
   model: LanguageModel,
   input: { instructions: string; skill?: string },
+  /** Already the resident's toolset minus the hiring tool — depth-1 lock #1. */
   tools: ToolSet,
+  /** The loadout the specialist may PICK from, hiring filtered out — lock #2. */
+  equipped: readonly string[],
 ): Promise<SubagentReport> {
   let brief = input.instructions;
   if (input.skill !== undefined) {
@@ -263,18 +270,26 @@ async function runSubagent(
     const body = await turn.skills.load(input.skill);
     brief = `${body}\n\n---\n\n${input.instructions}`;
   }
-  const result = streamText({
+  // THE shipped loop, for the hire as well. This used to be a second, bare
+  // `streamText`, so every rail `startTurn` owns — the stop conditions, the
+  // history assembly, the cache breakpoints, the stated retry budget — stopped
+  // at the resident, and a specialist ran without them. A hire is a turn; the
+  // only thing that makes it different is whose words it speaks.
+  const loop = await startTurn({
     model,
-    system:
-      "You are a specialist hired for one job. Do it with the tools you have, then report back in "
-      + "at most three sentences. Your reply is read by another agent, not by a person.",
-    prompt: brief,
-    // No hiring tool: depth is bounded at one, so a helper cannot spawn a tree.
+    system: SPECIALIST_SYSTEM,
+    // `startTurn` drives a thread, and a hire's thread is one message long: the
+    // brief, as the ask the specialist answers.
+    messages: [{ id: "hire-brief", role: "user", parts: [{ type: "text", text: brief }] }],
     tools,
-    stopWhen: [stepCountIs(SUBAGENT_MAX_STEPS)],
-    abortSignal: turn.signal,
+    // `attach` is a no-op for the same reason it is on the resident: the runtime
+    // owns `find_tools`, not the harness.
+    toolSearch: { activeToolNames: () => [...equipped], attach: () => {} },
+    context: { maxSteps: SUBAGENT_MAX_STEPS },
+    signal: turn.signal,
+    turnId: turn.turnId,
   });
-  const [text, usage] = await Promise.all([result.text, result.totalUsage]);
+  const [text, usage] = await Promise.all([loop.result.text, loop.result.totalUsage]);
   return {
     summary: text.trim() || "The specialist finished without a summary.",
     usage: usageOf(usage, model),
@@ -331,7 +346,16 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
             // searched-in tools included — minus the hiring tool, so depth is
             // bounded at one and a helper cannot spawn a tree.
             const { [HIRE_SUBAGENT]: _hiring, ...hands } = residentTools;
-            const report = await runSubagent(turn, model, input, hands);
+            const report = await runSubagent(
+              turn,
+              model,
+              input,
+              hands,
+              // A snapshot, not the live variable: the specialist's hands are
+              // frozen at hire time, so its loadout has to be too or it could
+              // name a tool it was never handed.
+              equipped.filter((name) => name !== HIRE_SUBAGENT),
+            );
             // The ONLY place a hire's spend is reported. The turn's `usage` event
             // stays the resident's own, so the run row and the hire rows partition
             // the turn instead of overlapping — see `reportRun`.

--- a/packages/harnesses/src/vendo/vendo.ts
+++ b/packages/harnesses/src/vendo/vendo.ts
@@ -33,8 +33,6 @@ import { defineHarness } from "../define.js";
  *  Bounded so a runaway helper costs a receipt, not a turn. */
 const SUBAGENT_MAX_STEPS = 12;
 
-/** The job description a hire runs under. Its reply is the resident's private
- *  context, not a wire artifact, which is why the prose says so out loud. */
 const SPECIALIST_SYSTEM =
   "You are a specialist hired for one job. Do it with the tools you have, then report back in "
   + "at most three sentences. Your reply is read by another agent, not by a person.";
@@ -270,20 +268,14 @@ async function runSubagent(
     const body = await turn.skills.load(input.skill);
     brief = `${body}\n\n---\n\n${input.instructions}`;
   }
-  // THE shipped loop, for the hire as well. This used to be a second, bare
-  // `streamText`, so every rail `startTurn` owns — the stop conditions, the
-  // history assembly, the cache breakpoints, the stated retry budget — stopped
-  // at the resident, and a specialist ran without them. A hire is a turn; the
-  // only thing that makes it different is whose words it speaks.
+  // THE shipped loop, for the hire as well: every rail `startTurn` owns reaches
+  // the specialist too, so it cannot drift from the resident on any of them.
   const loop = await startTurn({
     model,
     system: SPECIALIST_SYSTEM,
-    // `startTurn` drives a thread, and a hire's thread is one message long: the
-    // brief, as the ask the specialist answers.
     messages: [{ id: "hire-brief", role: "user", parts: [{ type: "text", text: brief }] }],
     tools,
-    // `attach` is a no-op for the same reason it is on the resident: the runtime
-    // owns `find_tools`, not the harness.
+    // `attach` is a no-op for the resident's reason: the runtime owns `find_tools`.
     toolSearch: { activeToolNames: () => [...equipped], attach: () => {} },
     context: { maxSteps: SUBAGENT_MAX_STEPS },
     signal: turn.signal,
@@ -346,16 +338,11 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
             // searched-in tools included — minus the hiring tool, so depth is
             // bounded at one and a helper cannot spawn a tree.
             const { [HIRE_SUBAGENT]: _hiring, ...hands } = residentTools;
-            const report = await runSubagent(
-              turn,
-              model,
-              input,
-              hands,
-              // A snapshot, not the live variable: the specialist's hands are
-              // frozen at hire time, so its loadout has to be too or it could
-              // name a tool it was never handed.
-              equipped.filter((name) => name !== HIRE_SUBAGENT),
-            );
+            // A snapshot, not the live variable: the hands are frozen at hire
+            // time, so the loadout has to be too or it could name a tool the
+            // specialist was never handed.
+            const loadout = equipped.filter((name) => name !== HIRE_SUBAGENT);
+            const report = await runSubagent(turn, model, input, hands, loadout);
             // The ONLY place a hire's spend is reported. The turn's `usage` event
             // stays the resident's own, so the run row and the hire rows partition
             // the turn instead of overlapping — see `reportRun`.

--- a/packages/harnesses/src/vendo/vendo.ts
+++ b/packages/harnesses/src/vendo/vendo.ts
@@ -333,6 +333,7 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
           skill: z.string().optional().describe("A skill name from your skill list."),
         }),
         execute: async (input) => {
+          let report: SubagentReport;
           try {
             // The specialist gets the same hands as the resident has RIGHT NOW —
             // searched-in tools included — minus the hiring tool, so depth is
@@ -342,7 +343,16 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
             // time, so the loadout has to be too or it could name a tool the
             // specialist was never handed.
             const loadout = equipped.filter((name) => name !== HIRE_SUBAGENT);
-            const report = await runSubagent(turn, model, input, hands, loadout);
+            report = await runSubagent(turn, model, input, hands, loadout);
+          } catch (error) {
+            // A failed hire is one tool result the resident can react to — never
+            // the turn's death.
+            console.error("[vendo] harness: subagent failed", {
+              error: error instanceof Error ? error.message : String(error),
+            });
+            return { error: "The specialist could not be reached for that job." };
+          }
+          try {
             // The ONLY place a hire's spend is reported. The turn's `usage` event
             // stays the resident's own, so the run row and the hire rows partition
             // the turn instead of overlapping — see `reportRun`.
@@ -352,15 +362,17 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
               summary: report.summary,
               usage: report.usage,
             });
-            return { summary: report.summary };
           } catch (error) {
-            // A failed hire is one tool result the resident can react to — never
-            // the turn's death.
-            console.error("[vendo] harness: subagent failed", {
+            // The work is DONE and its tokens are already spent, so a receipt
+            // that cannot be booked must never read as a hire that failed: the
+            // resident's sane reply to a failed hire is to hire again, and the
+            // same job would then be paid for twice. `onHire` is a host's knob;
+            // its bugs cost the host a receipt, not a second specialist.
+            console.error("[vendo] harness: hire receipt failed to book", {
               error: error instanceof Error ? error.message : String(error),
             });
-            return { error: "The specialist could not be reached for that job." };
           }
+          return { summary: report.summary };
         },
       });
 


### PR DESCRIPTION
Base: `yousefh409/engine-defects` @ 5fa64365b (stacked — see below). The plan's
`Base: main @ <sha> (PROGRAM_BASE)` line cannot be written yet: PROGRAM_BASE does
not exist, because one-path (#863 → #864) has not landed on `main`.

**Stack.** #868 `yousefh409/engine-defects` → **this PR**. It stays a **draft**
until one-path lands and the base can be retargeted to `main`.

## What changed

`packages/harnesses/src/vendo/vendo.ts` — `runSubagent` opened a bare
`streamText` of its own, so every rail `startTurn` owns (the stop conditions, the
history assembly, the cache breakpoints, the stated retry budget) stopped at the
resident and a hired specialist ran without them. `vendo()`'s own docstring
already claimed the opposite ("NOT a second loop"); the hire was the one caller
that made it untrue. It now drives `startTurn` like every other caller.

Fixed points, unchanged: the specialist prose (now the named `SPECIALIST_SYSTEM`,
byte-identical and pinned by a test), `SUBAGENT_MAX_STEPS = 12`, the hire's words
never leaving `runSubagent`, and both depth-1 locks — `tools` is the resident set
minus `hire_subagent` (#1) and `equipped` is the loadout with it filtered out (#2).
D4 (specialists inherit the full toolset minus hire, no allowlist) and D5 (full
parallelism including writes) are untouched.

## S6.2 — the #868 precondition, confirmed

The `hiredUsage` fold is **absent** at the branch point. `vendo.ts`'s `finish`
case yields `{ type: "usage", ...usageOf(part.totalUsage, model) }` — the
resident's own spend and only it — and there is no `hiredUsage` declaration in
the file. Nothing in this PR resurrects or re-deletes it.

## Red-first (S6.3) — `subagent-loop.test.ts` on the unchanged tree

```
 ❯ src/vendo/subagent-loop.test.ts (5 tests | 2 failed) 311ms
   × ends the specialist's turn on an answered ask_user — a stop condition only the loop has
     → expected 4 to be 3 // Object.is equality
   × assembles the specialist's prompt through the loop's own history builder
     → expected undefined to deeply equal { anthropic: { …(1) } }

 Test Files  1 failed (1)
      Tests  2 failed | 3 passed (5)
exit=1
```

The two failures are the two rails only the loop has: `askedUserStop` (a bare
`streamText` carries only the step cap, so the specialist took a fourth step and
ate the resident's script) and the system-block cache breakpoint from
`turnModelMessages` (a raw `streamText({ system })` has nowhere to put provider
options). The three that already passed are preservation assertions — the prose,
the two locks, and the ledger partition — and they must stay green, not turn.

## Revert-proof (S6.11)

Fold reverted (`git stash push -- vendo.ts`):
```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯
      Tests  2 failed | 3 passed (5)
exit=1
```
Fold restored (`git stash pop`):
```
      Tests  5 passed (5)
exit=0
```

## Gate (S6.10) — all green, foreground, read from `/tmp/gate-s6.log`

| step | exit |
|---|---|
| `vitest run src/vendo/subagent-loop.test.ts src/vendo/vendo.test.ts --minWorkers=1 --maxWorkers=2` — 29 passed | 0 |
| `pnpm build --filter @vendoai/harnesses --filter @vendoai/vendo` | 0 |
| `pnpm --filter @vendoai/harnesses typecheck` | 0 |
| `pnpm --filter @vendoai/vendo typecheck` | 0 |
| `pnpm lint --filter @vendoai/harnesses --filter @vendoai/vendo` | 0 |

All 24 existing `vendo.test.ts` cases pass **unmodified** — no assertion changed,
no signature-forced test edit was needed, so there is no second commit to declare.

## Diff scope (S6.4)

```
packages/harnesses/src/vendo/subagent-loop.test.ts
packages/harnesses/src/vendo/vendo.ts
```
`loop.ts` is NOT in the diff (S1 owns it in parallel). `vendo.test.ts` is not in
the diff either — it needed nothing.

## Divergences — reported, not improvised

1. **The `compaction` parameter is NOT implemented.** The brief's signature has
   six parameters, the sixth being `compaction: TurnCompaction`, "passed straight
   through" to `startTurn`. It cannot be: `TurnLoopOptions` has no `compaction`
   slot until S2 adds one, and `loop.ts` is S1's file this week. The only ways to
   ship it here are a parameter that goes nowhere (dead code S2 rewrites anyway)
   or a conditional spread that compiles while silently dropping the field — which
   a reviewer would read as wired. `runSubagent` is module-private with one
   caller, so **S2 can add the parameter in the same change that adds the slot.**
   Flagged for the conductor.
2. **The loop-only rail is not the step-limit notice.** Structure §5 says "a rail
   only the loop has, e.g. the step-limit notice". Surfacing the notice from a
   hire would change the hire's summary text — behaviour this brief does not
   specify. The two rails asserted instead need no added behaviour: `askedUserStop`
   and the system-block cache breakpoint.
3. **Both depth-1 locks are read through one observation.** `activeTools` is
   applied upstream of the provider call, so what reaches the model is the tools
   object *after* the loadout filtered it. `model.toolNamesPerCall[1]` is therefore
   the loadout, and asserting `hire_subagent` is absent from it pins both locks;
   the resident's own call is asserted to still carry it.
4. **Every `vendo.ts` anchor in §3 is line-shifted** (the base is the defects
   branch, not PROGRAM_BASE): `SUBAGENT_MAX_STEPS` `:28`→`:36`, `optionsSchema`
   `:37-44`→`:45-52`, `CONTEXT_KNOBS` `:61`→`:69`, `runSubagent` `:151-180`→
   `:175-204`, the bare `streamText` `:164-174`→`:188-198`, the specialist prose
   `:166-168`→`:190-192` (an inline literal, not a named constant, until this PR),
   `residentTools` minus hire `:237`→`:259`. Same constructs, all verified.

## Not done here (S6.13) — needs Yousef's eyes

One real Maple build turn in the browser: hires still report their receipts and
the reply keeps the deployment's voice. **Pending the conductor's proof pass** —
not self-gradable, and not this builder's item.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored subagent hires to run through the main loop (`startTurn`) instead of a second `streamText`, so hires share stop rails, prompt assembly, and correct usage partitioning. Separated receipt booking from execution so a finished hire never reads as failed, and added tests for rails, locks, parallel hires, and the usage ledger.

- **Refactors**
  - `runSubagent` now uses `startTurn` with a one-message brief, `SUBAGENT_MAX_STEPS = 12`, and `SPECIALIST_SYSTEM`.
  - Depth stays at 1: resident tools minus `hire_subagent`, and a hire-time snapshot of `equipped` via `toolSearch.activeToolNames`.
  - Passed through `context.maxSteps`, `turnId`, and `signal`; parallel hires still supported and ledger partition preserved.
  - Named `SPECIALIST_SYSTEM` constant and tightened comments to state constraints (shared loop, snapshot loadout).

- **Bug Fixes**
  - Hires stop on answered `ask_user`.
  - System block now carries Anthropic cache control via the loop’s history builder.
  - `onHire` receipt failures no longer mark a finished hire as failed; summary is returned and the receipt error is logged.

<sup>Written for commit 282fd51d1cdb887ac7a5351db953047988790698. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

