### PR TITLE
fix(harnesses)!: every projection is well-formed — assistant-first and orphaned tool pairs

### DIFF
--- a/packages/harnesses/src/stale-approvals.test.ts
+++ b/packages/harnesses/src/stale-approvals.test.ts
@@ -224,8 +224,8 @@ describe("1 — a stale approval-requested part is flipped at the start of a har
   });
 
   it("does not need turnModelMessages to be re-derived — the loop's own converter agrees", async () => {
-    const paired = await turnModelMessages(
-      [
+    const { messages: paired } = await turnModelMessages({
+      messages: [
         userMessage("m1", "hi"),
         {
           id: "m2",
@@ -242,9 +242,8 @@ describe("1 — a stale approval-requested part is flipped at the start of a har
           ],
         } as unknown as UIMessage,
       ],
-      "system",
-      undefined,
-    );
+      system: "system",
+    });
     const calls = paired.flatMap((m) => (Array.isArray(m.content) ? m.content : [])).filter((p) => p.type === "tool-call");
     const results = paired.flatMap((m) => (Array.isArray(m.content) ? m.content : [])).filter((p) => p.type === "tool-result");
     expect([calls.length, results.length]).toEqual([1, 1]);

--- a/packages/harnesses/src/vendo/compaction.test.ts
+++ b/packages/harnesses/src/vendo/compaction.test.ts
@@ -112,13 +112,17 @@ function expectSendable(messages: ModelMessage[]): void {
 
 describe("token-budgeted compaction", () => {
   it("sheds nothing at all when the thread already fits", async () => {
-    const generous = await turnModelMessages(thread(), "system", undefined, 100_000);
-    const unbudgeted = await turnModelMessages(thread(), "system", undefined);
+    const { messages: generous } = await turnModelMessages({
+      messages: thread(), system: "system", tokenBudget: 100_000,
+    });
+    const { messages: unbudgeted } = await turnModelMessages({ messages: thread(), system: "system" });
     expect(wire(generous)).toBe(wire(unbudgeted));
   });
 
   it("sheds REASONING first, and nothing else", async () => {
-    const shed = await turnModelMessages(thread(), "system", undefined, 1_500);
+    const { messages: shed } = await turnModelMessages({
+      messages: thread(), system: "system", tokenBudget: 1_500,
+    });
     const raw = wire(shed);
     expect(raw).not.toContain(REASONING);
     // Everything cheaper to keep is still here — this is the whole point of an
@@ -130,7 +134,9 @@ describe("token-budgeted compaction", () => {
   });
 
   it("sheds OLD TOOL PAYLOADS second, keeping the words around them", async () => {
-    const shed = await turnModelMessages(thread(), "system", undefined, 400);
+    const { messages: shed } = await turnModelMessages({
+      messages: thread(), system: "system", tokenBudget: 400,
+    });
     const raw = wire(shed);
     expect(raw).not.toContain(REASONING);
     expect(raw).not.toContain(TOOL_OUTPUT);
@@ -141,7 +147,9 @@ describe("token-budgeted compaction", () => {
   });
 
   it("drops the OLDEST messages only as a last resort", async () => {
-    const shed = await turnModelMessages(thread(), "system", undefined, 10);
+    const { messages: shed } = await turnModelMessages({
+      messages: thread(), system: "system", tokenBudget: 10,
+    });
     const raw = wire(shed);
     expect(raw).not.toContain(OLDEST);
     // Under any budget the ask survives: a turn with no user message is not a
@@ -153,7 +161,9 @@ describe("token-budgeted compaction", () => {
     // An assistant tool-call whose result was pruned is a malformed prompt every
     // provider rejects, so the pair is shed together or not at all.
     for (const budget of [100_000, 1_500, 400, 10]) {
-      const shed = await turnModelMessages(thread(), "system", undefined, budget);
+      const { messages: shed } = await turnModelMessages({
+        messages: thread(), system: "system", tokenBudget: budget,
+      });
       const calls = shed.flatMap((message) =>
         typeof message.content === "string"
           ? []
@@ -169,20 +179,26 @@ describe("token-budgeted compaction", () => {
     // above) cannot see either defect: the dangling call is orphaned before any
     // budget applies, and the assistant-first prompt is perfectly paired.
     for (const budget of [100_000, 2_500, 2_000, 1_000, 600, 500, 200, 10]) {
-      const shed = await turnModelMessages(threadWithDanglingCall(), "system", undefined, budget);
+      const { messages: shed } = await turnModelMessages({
+        messages: threadWithDanglingCall(), system: "system", tokenBudget: budget,
+      });
       expectWellFormed(shed, `budget ${budget}`);
       expect(wire(shed), `budget ${budget}`).toContain(NEWEST);
     }
     // …and the walk really did cross the cliff, so this can never pass on a
     // thread that never sheds a message at all.
-    const floor = await turnModelMessages(threadWithDanglingCall(), "system", undefined, 10);
+    const { messages: floor } = await turnModelMessages({
+      messages: threadWithDanglingCall(), system: "system", tokenBudget: 10,
+    });
     expect(wire(floor)).not.toContain(OLDEST);
   });
 
   it("keeps the message-count window working untouched", async () => {
     // Back-compat: `historyWindow` is a shipped host knob and its meaning does
     // not change because a budget joined it.
-    const windowed = await turnModelMessages(thread(), "system", 1);
+    const { messages: windowed } = await turnModelMessages({
+      messages: thread(), system: "system", historyWindow: 1,
+    });
     expect(wire(windowed)).toContain(NEWEST);
     expect(wire(windowed)).not.toContain(OLDEST);
   });

--- a/packages/harnesses/src/vendo/compaction.test.ts
+++ b/packages/harnesses/src/vendo/compaction.test.ts
@@ -20,6 +20,8 @@ const REASONING = `R${"e".repeat(4000)}`;
 const TOOL_OUTPUT = `T${"o".repeat(4000)}`;
 const OLDEST = "the oldest question";
 const NEWEST = "the newest question";
+/** Enough bulk that a budget can land between the shed's bands. */
+const FILLER = "x".repeat(2000);
 
 /** A thread with all three sheddable kinds in it, newest last. */
 const thread = (): UIMessage[] => [
@@ -48,7 +50,58 @@ const thread = (): UIMessage[] => [
   { id: "m5", role: "user", parts: [{ type: "text", text: NEWEST }] },
 ];
 
+/**
+ * The same thread carrying an UNANSWERED tool call — an approval the previous
+ * turn abandoned, a step a crash cut short. `runtime.ts:294-300` flips those
+ * parts upstream today for exactly this reason: the projection would otherwise
+ * hand the provider a tool-call with no tool-result, which is a 400.
+ */
+const threadWithDanglingCall = (): UIMessage[] => [
+  { id: "d1", role: "user", parts: [{ type: "text", text: `${OLDEST} ${FILLER}` }] },
+  {
+    id: "d2",
+    role: "assistant",
+    parts: [{
+      type: "dynamic-tool",
+      toolName: "dump",
+      toolCallId: "c1",
+      state: "input-available",
+      input: { q: FILLER },
+    }],
+  } as unknown as UIMessage,
+  {
+    id: "d3",
+    role: "assistant",
+    parts: [{
+      type: "dynamic-tool",
+      toolName: "dump",
+      toolCallId: "c2",
+      state: "output-available",
+      input: {},
+      output: { rows: TOOL_OUTPUT },
+    }],
+  } as unknown as UIMessage,
+  { id: "d4", role: "assistant", parts: [{ type: "text", text: "Found some." }] },
+  { id: "d5", role: "user", parts: [{ type: "text", text: NEWEST }] },
+];
+
 const wire = (messages: ModelMessage[]): string => JSON.stringify(messages);
+
+/**
+ * The two prompts every provider rejects outright: a tool-call whose result is
+ * missing (or a result whose call is), and a prompt whose first non-system
+ * message is the assistant's. Both are reachable from the shed above, because
+ * its last band drops from the FRONT.
+ */
+function expectWellFormed(messages: ModelMessage[], where: string): void {
+  const parts = messages.flatMap((message) =>
+    typeof message.content === "string" ? [] : message.content);
+  const called = parts.filter((part) => part.type === "tool-call").map((part) => part.toolCallId);
+  const answered = parts.filter((part) => part.type === "tool-result").map((part) => part.toolCallId);
+  expect([...called].sort(), `tool pairs, ${where}`).toEqual([...answered].sort());
+  expect(messages.find((message) => message.role !== "system")?.role, `first non-system, ${where}`)
+    .toBe("user");
+}
 
 /** Every prompt must still be sendable: a system prompt, then at least the ask. */
 function expectSendable(messages: ModelMessage[]): void {
@@ -107,6 +160,23 @@ describe("token-budgeted compaction", () => {
           : message.content.filter((part) => part.type === "tool-call" || part.type === "tool-result"));
       expect(calls.length % 2, `budget ${budget}`).toBe(0);
     }
+  });
+
+  it("projects a well-formed prompt across the band-2 cliff", async () => {
+    // The cliff this walks, measured on the fixture: 2_500 still fits whole,
+    // 2_000 has shed the tool payloads, and somewhere between 600 and 500 the
+    // shed starts dropping the oldest messages. Pair parity alone (the test
+    // above) cannot see either defect: the dangling call is orphaned before any
+    // budget applies, and the assistant-first prompt is perfectly paired.
+    for (const budget of [100_000, 2_500, 2_000, 1_000, 600, 500, 200, 10]) {
+      const shed = await turnModelMessages(threadWithDanglingCall(), "system", undefined, budget);
+      expectWellFormed(shed, `budget ${budget}`);
+      expect(wire(shed), `budget ${budget}`).toContain(NEWEST);
+    }
+    // …and the walk really did cross the cliff, so this can never pass on a
+    // thread that never sheds a message at all.
+    const floor = await turnModelMessages(threadWithDanglingCall(), "system", undefined, 10);
+    expect(wire(floor)).not.toContain(OLDEST);
   });
 
   it("keeps the message-count window working untouched", async () => {

--- a/packages/harnesses/src/vendo/index.ts
+++ b/packages/harnesses/src/vendo/index.ts
@@ -19,5 +19,7 @@ export {
   type TurnContext,
   type TurnLoop,
   type TurnLoopOptions,
+  type TurnPrompt,
+  type TurnPromptInput,
 } from "./loop.js";
 export { failoverModel, type ResolvedModel } from "./failover.js";

--- a/packages/harnesses/src/vendo/loop.ts
+++ b/packages/harnesses/src/vendo/loop.ts
@@ -181,16 +181,91 @@ function shedToBudget(
 }
 
 /**
+ * Well-formedness, applied to EVERY projection whatever produced it.
+ *
+ * Two prompts a provider rejects outright, and this file can build both. A
+ * tool-call whose result is missing (or a result whose call is): the window
+ * slice above cannot cause it, but a part left at `input-available` by an
+ * abandoned approval arrives that way from the conversion — which is why
+ * `runtime.ts` has to flip those parts upstream before the projection ever runs.
+ * And a prompt whose first non-system message is the assistant's: {@link
+ * shedToBudget}'s last band drops from the FRONT, so it walks into one the
+ * moment a budget lands mid-history.
+ *
+ * Fixing it here rather than at each caller is the point: a projection is the
+ * only thing the provider sees, so well-formedness is a property of the
+ * projection, not a courtesy each producer has to remember.
+ */
+function wellFormed(messages: readonly ModelMessage[]): ModelMessage[] {
+  const called = new Set<string>();
+  const answered = new Set<string>();
+  for (const message of messages) {
+    if (typeof message.content === "string") continue;
+    for (const part of message.content) {
+      if (part.type === "tool-call") called.add(part.toolCallId);
+      if (part.type === "tool-result") answered.add(part.toolCallId);
+    }
+  }
+  const paired = messages.flatMap<ModelMessage>((message) => {
+    if (typeof message.content === "string") return [message];
+    const content = message.content.filter((part) => {
+      if (part.type === "tool-call") return answered.has(part.toolCallId);
+      if (part.type === "tool-result") return called.has(part.toolCallId);
+      return true;
+    });
+    // A message that was nothing but an orphan is no longer a message.
+    if (content.length === 0) return [];
+    return [{ ...message, content } as ModelMessage];
+  });
+  // The ask always survives (see {@link shedToBudget}), so there is normally a
+  // user message to anchor on; a history with none at all cannot be repaired by
+  // dropping more of it, so it is left alone for the caller's error to be the
+  // one that surfaces.
+  const firstUser = paired.findIndex((message) => message.role === "user");
+  if (firstUser === -1) return paired;
+  const firstNonSystem = paired.findIndex((message) => message.role !== "system");
+  return [...paired.slice(0, firstNonSystem), ...paired.slice(firstUser)];
+}
+
+/**
+ * One turn's prompt inputs. This was four positionals; the shipment's window
+ * table, compaction and overflow retry add three more, and a seventh positional
+ * is unreadable at the call site — so the shape is declared once, whole, before
+ * three slices fill it.
+ *
+ * BREAKING: `turnModelMessages` is public (`vendo/index.ts`).
+ */
+export interface TurnPromptInput {
+  messages: UIMessage[];
+  system: string;
+  /** The live toolset, so the trigger can count the tools block. */
+  tools?: ToolSet;
+  historyWindow?: number;
+  tokenBudget?: number;
+  /** `TurnCompaction`, once it exists. */
+  compaction?: unknown;
+  /** Model messages this turn ALREADY produced: appended after the projection
+   *  and never summarized, so a retry CONTINUES the turn instead of re-running
+   *  its tool calls — each one a real guarded effect. */
+  resume?: readonly ModelMessage[];
+}
+
+export interface TurnPrompt {
+  messages: ModelMessage[];
+  /** `CompactionState`, once it exists — carried out as DATA, because the loop
+   *  does not know where the caller's state slot is. */
+  compacted?: unknown;
+}
+
+/**
  * The provider messages for one turn: the system prompt, the optionally windowed
  * and budgeted history, and the cache breakpoints that keep a growing thread from
  * re-billing.
+ *
+ * `tools`, `compaction` and `resume` are accepted and not yet read.
  */
-export async function turnModelMessages(
-  messages: UIMessage[],
-  system: string,
-  historyWindow: number | undefined,
-  tokenBudget?: number,
-): Promise<ModelMessage[]> {
+export async function turnModelMessages(input: TurnPromptInput): Promise<TurnPrompt> {
+  const { messages, system, historyWindow, tokenBudget } = input;
   // History windowing: bound what is re-sent per turn to the last N whole messages.
   // Slicing whole UIMessages keeps each turn's tool-call/result pairing intact.
   const history = historyWindow !== undefined && messages.length > historyWindow
@@ -202,6 +277,9 @@ export async function turnModelMessages(
   // bills, and it runs before the breakpoints below because shedding changes
   // which message is the stable prefix's last one.
   if (tokenBudget !== undefined) converted = shedToBudget(converted, system, tokenBudget);
+  // Whatever the window and the shed left behind, the prompt still has to be one
+  // a provider will accept — and this is the last place that is knowable.
+  converted = wellFormed(converted);
   // Cache the stable history prefix (everything but the final message) alongside the
   // static system prompt below, so Anthropic re-reads the cached prefix instead of
   // re-billing the whole growing thread each turn.
@@ -209,10 +287,12 @@ export async function turnModelMessages(
     const prefixEnd = converted[converted.length - 2] as ModelMessage;
     prefixEnd.providerOptions = { ...prefixEnd.providerOptions, ...CACHE_BREAKPOINT };
   }
-  return [
-    { role: "system", content: system, providerOptions: CACHE_BREAKPOINT },
-    ...converted,
-  ];
+  return {
+    messages: [
+      { role: "system", content: system, providerOptions: CACHE_BREAKPOINT },
+      ...converted,
+    ],
+  };
 }
 
 export interface TurnLoopOptions {
@@ -284,12 +364,12 @@ function turnModel(options: TurnLoopOptions): LanguageModel {
 
 export async function startTurn(options: TurnLoopOptions): Promise<TurnLoop> {
   const maxSteps = options.context?.maxSteps ?? DEFAULT_MAX_STEPS;
-  const modelMessages = await turnModelMessages(
-    options.messages,
-    options.system,
-    options.context?.historyWindow,
-    options.context?.contextTokenBudget,
-  );
+  const { messages: modelMessages } = await turnModelMessages({
+    messages: options.messages,
+    system: options.system,
+    historyWindow: options.context?.historyWindow,
+    tokenBudget: options.context?.contextTokenBudget,
+  });
   const { toolSearch } = options;
   const result = streamText({
     model: turnModel(options),


### PR DESCRIPTION
Base: `yousefh409/engine-defects` @ 5fa64365b — **stacked** on the defects PR #868, which is itself stacked on one-path. Stays a DRAFT until one-path lands on `main`; it then rebases onto `PROGRAM_BASE` (`main` at the #868 merge SHA) and retargets `main`.

Shipment 1, slice **S1 — shed correctness**.

## What changed

**`turnModelMessages` is one options object** (`packages/harnesses/src/vendo/loop.ts:224-292`). Four positionals returning `ModelMessage[]` become `TurnPromptInput` → `TurnPrompt`. `tools`, `compaction` and `resume` are declared now and **unused** — S2/S3/S4 fill them. **TypeScript forced the placeholder**: `TurnCompaction` and `CompactionState` do not exist yet, so `compaction` and `compacted` are typed `unknown` and no `compaction.ts` was created.

```ts
export interface TurnPromptInput {
  messages: UIMessage[]; system: string; tools?: ToolSet;
  historyWindow?: number; tokenBudget?: number;
  compaction?: unknown;            // TurnCompaction, once it exists
  resume?: readonly ModelMessage[];
}
export interface TurnPrompt { messages: ModelMessage[]; compacted?: unknown }
```

**BREAKING** — `turnModelMessages` is public via `packages/harnesses/src/vendo/index.ts:16`.

**The sweep** (`loop.ts:183-217`, called at `:282`), applied to EVERY projection, after the window slice and the shed and before the cache markers: drop orphaned tool-calls and tool-results, then drop leading messages until the first non-system message is `user`. Order is otherwise unchanged.

Why here and not at each caller: a projection is the only thing the provider sees, so well-formedness is a property of the projection. `shedToBudget`'s last band drops from the FRONT (`loop.ts:179`), so it walks into an assistant-first prompt whenever a budget lands mid-history; and a tool part left at `input-available` by an abandoned approval arrives orphaned straight out of the conversion — which is exactly why `runtime.ts:294-300` has to flip those parts upstream today.

## Red-first proof (unchanged tree)

New case `compaction.test.ts` — "projects a well-formed prompt across the band-2 cliff". Both halves fail on the unchanged tree.

**(i) orphaned tool part**
```
 ❯ src/vendo/compaction.test.ts (7 tests | 1 failed) 15ms
   × token-budgeted compaction > projects a well-formed prompt across the band-2 cliff 8ms
     → tool pairs, budget 100000: expected [ 'c1', 'c2' ] to deeply equal [ 'c2' ]
 Test Files  1 failed (1)
      Tests  1 failed | 6 passed (7)
```

**(ii) assistant-first prompt** — the pair assertion muted so the second half is reachable:
```
 ❯ src/vendo/compaction.test.ts (7 tests | 1 failed) 28ms
   × token-budgeted compaction > projects a well-formed prompt across the band-2 cliff 10ms
     → first non-system, budget 500: expected 'assistant' to be 'user'
 Test Files  1 failed (1)
      Tests  1 failed | 6 passed (7)
```

The cliff was measured, not guessed: on the fixture, 2 500 still fits whole, 2 000 has shed the tool payloads, and between 600 and 500 the shed starts dropping the oldest messages. The test walks that band and asserts the walk really crossed it, so it can never go vacuous.

## Revert-proof

Sweep call removed from `loop.ts` → **red**:
```
   × token-budgeted compaction > projects a well-formed prompt across the band-2 cliff 39ms
     → tool pairs, budget 100000: expected [ 'c1', 'c2' ] to deeply equal [ 'c2' ]
```
Restored → **green**:
```
 ✓ src/vendo/compaction.test.ts (7 tests) 13ms
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

## Signature-forced test edits — stated out loud

Commit `5e66d61` — `test(harnesses): turnModelMessages call sites follow the options-object signature` — is mechanical and **call FORM only**. No assertion, no expected value, no budget number was touched. `compaction.test.ts:50-58` (role-first/role-last) and `:99-110` (pair parity) are unchanged in substance; diff them.

## STOP-AND-REPORT — divergences from the brief

1. **An EIGHTH call site the brief does not list.** The brief names seven positional call sites, all in `compaction.test.ts`. There is one more: `packages/harnesses/src/stale-approvals.test.ts:227`, which imports `turnModelMessages` directly. That file is **not** in S1's owned-file list, so the S1.3 check ("only the four owned files") now lists **five**. There was no alternative: the reshape is breaking and the only way to leave that file alone is a back-compat overload, which the brief forecloses. It was converted in the same signature-forced commit, form only, and its `[1 call, 1 result]` assertion is untouched.
2. **`screen-agent.ts` — no change required**, confirming §3 divergence 2. It calls `startTurn` with an options object (`screen-agent.ts:325-336`) and S1 leaves `TurnLoopOptions` untouched, so nothing there sees the reshape. Repo-wide typecheck confirms.
3. **`compaction.test.ts` is 119 lines, not the 120 the anchor ledger records.** Every named line anchor in it is correct; the count is off by one.
4. All other §3 anchors for `loop.ts` verified true as written.

## Gate

Foreground, redirected to `/tmp/gate-s1.log`, read back. `pnpm build` **exit=0** · `pnpm typecheck` **exit=0** · `pnpm lint` **exit=0** · `vitest run src/vendo/compaction.test.ts` **exit=0** (7 passed) · `vitest run src/vendo` **exit=0** (48 passed, 3 skipped) · whole `@vendoai/harnesses` package **exit=0** (417 passed, 13 skipped) — the package run is there because the forced eighth call site lives outside `src/vendo`.

## Not in this PR

No compaction, no window table, no cache-marker work — S2/S3/S5 own those and touch this same file after S1.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures every prompt projection is well‑formed (no orphaned tool parts, user-first) and switches `turnModelMessages` to an options object that returns `{ messages }`. Also exports `TurnPrompt`/`TurnPromptInput` and adds a shared host design brief so both writers follow the same rules.

- **Bug Fixes**
  - Sweep every projection after windowing/shedding: drop orphaned tool calls/results and fix assistant‑first prompts to prevent provider 400s.
  - Add a “band‑2 cliff” test that walks multiple budgets to assert prompts stay well‑formed and the ask survives; window semantics remain intact.

- **Migration**
  - Replace positional calls with `turnModelMessages({ messages, system, historyWindow?, tokenBudget?, tools?, compaction?, resume? })`; destructure `const { messages } = …`.
  - `turnModelMessages` now returns `TurnPrompt`; exported from `@vendoai/harnesses/vendo` along with `TurnPromptInput`.
  - The screen agent accepts `design?: string`; assembler deps accept `design?: () => string | undefined`; compose with `hostDesignBrief` from `@vendoai/apps`.
  - Optional `tools`, `compaction`, and `resume` are accepted but currently ignored.

<sup>Written for commit c6596e9cf861de46ba6045d3c7e1b660b88f0f95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

