### PR TITLE
perf(harnesses): the cache breakpoint advances every step

### DIFF
--- a/packages/harnesses/src/vendo/cache-breakpoints.test.ts
+++ b/packages/harnesses/src/vendo/cache-breakpoints.test.ts
@@ -1,0 +1,162 @@
+/**
+ * The trailing cache breakpoint moves with the turn.
+ *
+ * `turnModelMessages` marks the history prefix ONCE, before the first step. That
+ * mark is right for a turn that takes one step and wrong for every turn that
+ * takes more: a step's own tool calls and tool results are appended to the prompt
+ * after it, so from step two onward the growing tail sits OUTSIDE the cached
+ * prefix and is re-billed in full on every remaining step. A ten-step build turn
+ * is where the whole context lives, and it is exactly the turn that paid the most.
+ *
+ * The fix is one hook, so the proof is one question asked of every step: which
+ * messages carry a breakpoint? The answer must always be two — the static system
+ * prompt, and the last message of THIS step's prompt — and the second one must
+ * have moved since the step before. Anything else is either a prefix that stopped
+ * growing or markers piling up (Anthropic allows four, and a run that accumulates
+ * them silently loses the oldest).
+ */
+import type { UIMessage } from "ai";
+import { tool } from "ai";
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { startTurn } from "./loop.js";
+
+const ZERO_USAGE = {
+  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 0, text: 0, reasoning: 0 },
+} as const;
+
+const echo = tool({
+  description: "Echo a value back.",
+  inputSchema: z.object({ value: z.string() }),
+  execute: async (input: { value: string }) => input,
+});
+
+const untouched = tool({
+  description: "Never active.",
+  inputSchema: z.object({}),
+  execute: async () => ({}),
+});
+
+/**
+ * Long enough that `turnModelMessages` marks a message in the MIDDLE of the
+ * prompt: that mark is the stale one every later step has to strip, and without
+ * it "no stale markers" could pass on a thread that never had a second mark.
+ */
+const thread = (): UIMessage[] => [
+  { id: "m1", role: "user", parts: [{ type: "text", text: "how much did I spend?" }] },
+  { id: "m2", role: "assistant", parts: [{ type: "text", text: "Let me look." }] },
+  { id: "m3", role: "user", parts: [{ type: "text", text: "keep going" }] },
+];
+
+/** Two tool-calling steps then a reply, so the prompt grows twice. */
+function threeStepModel(): MockLanguageModelV3 {
+  let step = 0;
+  return new MockLanguageModelV3({
+    doStream: async () => {
+      step += 1;
+      const chunks = step < 3
+        ? [
+            {
+              type: "tool-call" as const,
+              toolCallId: `call_${step}`,
+              toolName: "echo",
+              input: JSON.stringify({ value: `v${step}` }),
+            },
+            { type: "finish" as const, usage: ZERO_USAGE, finishReason: { unified: "tool-calls" as const, raw: undefined } },
+          ]
+        : [
+            { type: "text-start" as const, id: "t1" },
+            { type: "text-delta" as const, id: "t1", delta: "done" },
+            { type: "text-end" as const, id: "t1" },
+            { type: "finish" as const, usage: ZERO_USAGE, finishReason: { unified: "stop" as const, raw: undefined } },
+          ];
+      return { stream: simulateReadableStream({ chunks }) };
+    },
+  });
+}
+
+type StepPrompt = MockLanguageModelV3["doStreamCalls"][number]["prompt"];
+
+/** Which messages of one step's prompt carry an Anthropic cache breakpoint. */
+function markedIndexes(prompt: StepPrompt): number[] {
+  return prompt.flatMap((message, index) => {
+    const cacheControl = message.providerOptions?.anthropic?.cacheControl as
+      | { type?: unknown }
+      | undefined;
+    return cacheControl?.type === "ephemeral" ? [index] : [];
+  });
+}
+
+/** One turn, drained; the recorded per-step calls are the whole assertion surface. */
+async function runTurn(session?: { activeToolNames(): string[]; attach(): void }) {
+  const model = threeStepModel();
+  const loop = await startTurn({
+    model,
+    system: "system",
+    messages: thread(),
+    tools: { echo, untouched },
+    context: { maxSteps: 5 },
+    ...(session === undefined ? {} : { toolSearch: session as never }),
+  });
+  for await (const _part of loop.result.fullStream) void _part;
+  return model.doStreamCalls;
+}
+
+const stepPrompts = async (): Promise<StepPrompt[]> =>
+  (await runTurn()).map((call) => call.prompt);
+
+describe("the cache breakpoint advances every step", () => {
+  it("marks the LAST message of every step's prompt", async () => {
+    const prompts = await stepPrompts();
+    expect(prompts.length).toBe(3);
+    prompts.forEach((prompt, step) => {
+      const moving = markedIndexes(prompt).filter((index) => prompt[index]?.role !== "system");
+      expect(moving, `step ${step}`).toEqual([prompt.length - 1]);
+    });
+  });
+
+  it("accumulates no stale markers — exactly the system one plus the moving one", async () => {
+    // `turnModelMessages` marked a middle message before the first step, and each
+    // step's own tail is appended to that same prompt. Without a strip, step 3
+    // would carry the system mark, that stale middle one, and the new tail one.
+    const prompts = await stepPrompts();
+    prompts.forEach((prompt, step) => {
+      expect(markedIndexes(prompt).length, `step ${step}`).toBe(2);
+    });
+  });
+
+  it("keeps the system marker exactly where it was", async () => {
+    const prompts = await stepPrompts();
+    prompts.forEach((prompt, step) => {
+      expect(prompt[0]?.role, `step ${step}`).toBe("system");
+      expect(markedIndexes(prompt)[0], `step ${step}`).toBe(0);
+    });
+  });
+
+  it("ADVANCES: the moving marker sits further along on every later step", async () => {
+    // The point of the whole slice. A marker that stays put is a prefix that
+    // stopped growing, which is the bug this replaces.
+    const prompts = await stepPrompts();
+    const moving = prompts.map((prompt) =>
+      markedIndexes(prompt).filter((index) => prompt[index]?.role !== "system")[0]);
+    expect(moving.length).toBe(3);
+    for (let step = 1; step < moving.length; step += 1) {
+      expect(moving[step], `step ${step} vs ${step - 1}`).toBeGreaterThan(moving[step - 1] as number);
+    }
+  });
+
+  it("still carries the tool-search loadout on the same hook", async () => {
+    // `prepareStep` used to exist ONLY under a tool-search session. It is returned
+    // on every turn now, and the loadout rides the same result — so a run that
+    // gates the model's choice must still gate it.
+    const calls = await runTurn({ activeToolNames: () => ["echo"], attach: () => {} });
+    expect(calls.length).toBe(3);
+    for (const [step, call] of calls.entries()) {
+      expect((call.tools ?? []).map((entry) => entry.name), `step ${step}`).toEqual(["echo"]);
+      // …and the marker rail did not stop working because the loadout rail joined it.
+      expect(markedIndexes(call.prompt).length, `step ${step}`).toBe(2);
+    }
+  });
+});

--- a/packages/harnesses/src/vendo/loop.ts
+++ b/packages/harnesses/src/vendo/loop.ts
@@ -295,6 +295,42 @@ export async function turnModelMessages(input: TurnPromptInput): Promise<TurnPro
   };
 }
 
+/**
+ * Move the trailing cache breakpoint to the END of the prompt a step is about to
+ * send.
+ *
+ * {@link turnModelMessages} marks the history prefix once, before the first step.
+ * That is the right prefix for a one-step turn and the wrong one for every turn
+ * after it: each step appends its own assistant message and tool results to the
+ * same prompt, so from step two onward the growing tail sits outside the cached
+ * prefix and is re-billed in full on every remaining step. A ten-step build turn
+ * is where the context actually lives, and it was the turn paying the most.
+ *
+ * Stripping first is not tidiness. Anthropic honours four breakpoints, so a run
+ * that only ever ADDED would quietly lose its oldest — the system prompt — around
+ * step three. Leading system messages are the one thing this never touches: their
+ * marker (see {@link CACHE_BREAKPOINT}) covers the static prefix that every step
+ * shares, including whatever a later slice projects between it and the tail.
+ */
+function advanceCacheBreakpoint(messages: readonly ModelMessage[]): ModelMessage[] {
+  const stripped = messages.map((message) => {
+    if (message.role === "system") return message;
+    const anthropic = message.providerOptions?.anthropic;
+    if (anthropic?.cacheControl === undefined) return message;
+    const { cacheControl: _moved, ...kept } = anthropic;
+    return { ...message, providerOptions: { ...message.providerOptions, anthropic: kept } } as ModelMessage;
+  });
+  const last = stripped.at(-1);
+  // A prompt that is nothing but the system message has no tail to mark, and its
+  // marker is already where it belongs.
+  if (last === undefined || last.role === "system") return stripped;
+  stripped[stripped.length - 1] = {
+    ...last,
+    providerOptions: { ...last.providerOptions, ...CACHE_BREAKPOINT },
+  } as ModelMessage;
+  return stripped;
+}
+
 export interface TurnLoopOptions {
   model: LanguageModel;
   /** §4.1 item 3 — the rungs BELOW `model`, tried in order when a provider fails
@@ -384,12 +420,16 @@ export async function startTurn(options: TurnLoopOptions): Promise<TurnLoop> {
     // `vendo_tools_search` becomes callable on the very next step. This gates the
     // model's CHOICE only — every tool still executes through the guard-bound
     // registry, so there is no unguarded path.
-    ...(toolSearch === undefined
-      ? {}
-      : {
-          activeTools: toolSearch.activeToolNames(),
-          prepareStep: () => ({ activeTools: toolSearch.activeToolNames() }),
-        }),
+    ...(toolSearch === undefined ? {} : { activeTools: toolSearch.activeToolNames() }),
+    // One hook, two rails. `prepareStep` used to be built only when a tool-search
+    // session existed, which is why a step's growing tool results were never
+    // cached — the turn with the most to cache had no hook at all. It is returned
+    // on every turn now, and the loadout rides the same result rather than
+    // growing a second per-step hook beside it.
+    prepareStep: ({ messages }) => ({
+      messages: advanceCacheBreakpoint(messages),
+      ...(toolSearch === undefined ? {} : { activeTools: toolSearch.activeToolNames() }),
+    }),
     // AGENT-3: cancellation reaches the provider call itself; the loop never
     // starts another step once the signal fires.
     abortSignal: options.signal,


### PR DESCRIPTION
Base: `yousefh409/ctx-s1-shed` (S1 #893). Stack: #868 → S1 #893 → **this**.

## What changed

`turnModelMessages` marks the history prefix **once**, before the first step. That is the right prefix for a one-step turn and the wrong one for every turn after it: each step appends its own assistant message and tool results to the same prompt, so from step two onward the growing tail sits *outside* the cached prefix and is re-billed in full on every remaining step. A ten-step build turn — where the context actually lives — was the turn paying the most.

- `loop.ts:298-331` — new module-private `advanceCacheBreakpoint(messages)`: strips prior message-level markers, then marks `at(-1)`. Pure (no mutation of the caller's messages), and it reads only `role` + `providerOptions`, so a later slice's projection shape does not break it.
- `loop.ts:423-433` — `prepareStep` is returned on **every** turn, not only when a tool-search session exists (`:307-312` before). `activeTools` rides the same result, so the two rails share one hook instead of growing a second one.
- `loop.ts:52` `CACHE_BREAKPOINT` and its application to the system block (`turnModelMessages`) are **untouched**. Leading system messages are the one thing `advanceCacheBreakpoint` never rewrites.
- `PrepareStepResult.messages` is supported on the pinned `ai@6.0.28` (`dist/index.d.ts:900-921`); the runtime uses it at `dist/index.js:6431`. No new runtime deps, no tokenizer, still ai@6.

Diff is exactly the two owned files: `loop.ts` + `cache-breakpoints.test.ts`.

## Red-first proof

Test landed first (`ae47f916e`), mechanism second (`220561901`).

**Red — against the unchanged tree** (`/tmp/s5-red.log`):

```
 ❯ src/vendo/cache-breakpoints.test.ts (5 tests | 2 failed) 111ms
   × marks the LAST message of every step's prompt
     → step 0: expected [ 2 ] to deeply equal [ 3 ]
   × ADVANCES: the moving marker sits further along on every later step
     → step 1 vs 0: expected 2 to be greater than 2
 Test Files  1 failed (1)
      Tests  2 failed | 3 passed (5)
exit=1
```

**Green — after the mechanism** (`/tmp/s5-green.log`):

```
 ✓ src/vendo/cache-breakpoints.test.ts (5 tests) 124ms
 Test Files  1 passed (1)
      Tests  5 passed (5)
exit=0
```

**Revert-proof, the strip half** — the marker-advance half is proven by the red above (that IS the mechanism absent); the *strip* is proven separately, because a mechanism that only ever ADDED a marker would still pass the advance assertions while quietly accumulating breakpoints. With the strip disabled inside `advanceCacheBreakpoint` (`/tmp/s5-red-strip.log`):

```
 ❯ src/vendo/cache-breakpoints.test.ts (5 tests | 4 failed) 153ms
   × marks the LAST message of every step's prompt
     → step 0: expected [ 2, 3 ] to deeply equal [ 3 ]
   × accumulates no stale markers — exactly the system one plus the moving one
     → step 0: expected 3 to be 2
   × ADVANCES: the moving marker sits further along on every later step
     → step 1 vs 0: expected 2 to be greater than 2
   × still carries the tool-search loadout on the same hook
     → step 0: expected 3 to be 2
exit=1
```

Restored → green (the run above). This matters beyond tidiness: Anthropic honours four breakpoints, so an add-only implementation would silently drop its oldest — the system prompt — around step three.

## Gates (foreground, redirected to a file, read back)

| Command | Log | Result |
|---|---|---|
| `vitest run src/vendo/cache-breakpoints.test.ts --minWorkers=1 --maxWorkers=2` | `/tmp/s5-vitest.log` | `exit=0` (5 passed) |
| `vitest run src/vendo --minWorkers=1 --maxWorkers=2` | `/tmp/s5-vendo-dir.log` | `exit=0` |
| `pnpm --filter @vendoai/harnesses typecheck` | `/tmp/s5-typecheck.log` | `exit=0` |
| `pnpm build --filter @vendoai/harnesses` | `/tmp/s5-build.log` | `exit=0` |
| `pnpm lint --filter @vendoai/harnesses` | `/tmp/s5-lint.log` | `exit=0` |

(First lint run failed on `portability-gate: packages/vendo/dist/server.js missing` — an unbuilt worktree, not this change. `pnpm build` then lint: green.)

## Still open — needs eyes, not a self-grade

**S5.9, the measured before/after `cacheReadTokens`/`cacheWriteTokens` on one real 10-step Maple turn (`vendo.ts:336-341`) is NOT in this PR.** The mechanism and its unit proof are here; the live measurement is pending the conductor's proof pass. This PR is a **draft** until those two numbers land in this body.

## Notes for the slices behind this one

`advanceCacheBreakpoint` is module-private, not exported, and no new file — S5.5. It is deliberately message-shape-agnostic: it keys off `role === "system"` and `providerOptions` only, so S3's summary-first projection (a `user` message carrying the summary, sitting between the system block and the tail) passes through it untouched and still gets exactly one moving marker.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the Anthropic cache breakpoint to the last message of each step to keep growing tails cached and avoid re-billing. Also returns `prepareStep` on every turn to update markers and keep tool gating on one hook.

- **Bug Fixes**
  - Added module-private `advanceCacheBreakpoint(messages)` to strip prior message-level markers and mark the last non-system message; the system `CACHE_BREAKPOINT` stays untouched.
  - `prepareStep` now returns `{ messages }` for all turns and includes `activeTools` when tool-search is active.
  - Added `cache-breakpoints.test.ts` covering per-step last-message marking, no stale markers, stable system marker, advancing index each step, and preserved tool-search gating; compatible with `ai@6.0.28`.

<sup>Written for commit e68160f5cbf9093563b8abf9f922ac8601a536d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

