### PR TITLE
feat(apps,harnesses): writers get a design brief — design law + host design rules

### DIFF
--- a/.changeset/writers-get-a-design-brief.md
+++ b/.changeset/writers-get-a-design-brief.md
@@ -1,0 +1,35 @@
+---
+"@vendoai/apps": minor
+"@vendoai/harnesses": minor
+"@vendoai/vendo": patch
+---
+
+**Both writers get a design brief.** The screen agent and the `claudeCode()`
+builder could name every component in the catalog and had nothing to say about
+WHICH one, HOW MANY, or WHERE — so a screen was whatever the model reached for
+first.
+
+**The design law ships inside the skill.** `buildingAppsSkill` gains a
+`## What a good screen looks like` section, written in `.vendo` terms rather than
+CSS, because every one of these is a choice made in the plan: lead with the
+answer, fewer parts and better ones, never say the same thing twice, bind the
+rows as they come, group by what the person came to do, `col` is width and never
+slicing, pick the chart by the shape of the data, a hole is a `<Cannot>`, the
+words are the host's own, and an `<Island>` styles with the theme's CSS variables
+and nothing else. One text, in the skill BOTH writers read, so `claudeCode()` and
+the screen agent cannot be taught different design.
+
+**The host's theme and design rules now reach both writers.** `apps.designRules`
+and the theme tokens are documented seams a host sets and expects to be obeyed.
+They reached the fill worker of the retired conductor and nothing else — so on
+both live write paths those two config keys silently did nothing. The new
+`hostDesignBrief` (exported from `@vendoai/apps`) renders that pair ONCE, and
+composition hands the same string to both seams: the screen agent's brief,
+through a `design` slot beside `system` on `ScreenInput` and
+`ScreenAssemblerDeps`, and the composed prompt `claudeCode()` thinks with. The
+slot is a thunk, not a value, so a rules change applies to the next screen rather
+than the next boot.
+
+Deliberately NOT inside `claudeCode()`: that harness thinks with `turn.system`
+whole and alone and appends nothing after the host's prompt seam, so the prompt
+seam is the only honest place for them.

--- a/packages/apps/src/generation/contracts/sections.ts
+++ b/packages/apps/src/generation/contracts/sections.ts
@@ -36,7 +36,9 @@ export const composePromptSections = (sections: readonly GenerationPromptSection
  * the theme tokens are documented seams a host sets and expects to be obeyed.
  * A prompt that omits them makes those config keys silently do nothing.
  */
-export const hostDesignRulesSection = (deps: GenerationDependencies): GenerationPromptSection[] => {
+export const hostDesignRulesSection = (
+  deps: Pick<GenerationDependencies, "designRules">,
+): GenerationPromptSection[] => {
   const rules = (typeof deps.designRules === "function" ? deps.designRules() : deps.designRules)?.trim();
   // The section is emitted even when the host set no rules: "(none provided)" is
   // the difference between a model that knows there are no house rules and one
@@ -47,11 +49,25 @@ export const hostDesignRulesSection = (deps: GenerationDependencies): Generation
   }];
 };
 
-export const hostThemeSection = (deps: GenerationDependencies): GenerationPromptSection[] =>
+export const hostThemeSection = (
+  deps: Pick<GenerationDependencies, "theme">,
+): GenerationPromptSection[] =>
   deps.theme === undefined ? [] : [{
     id: "theme" as const,
     content: `THEME TOKENS:\n${JSON.stringify(deps.theme, null, 2)}`,
   }];
+
+/**
+ * The pair as ONE block, for a brief that has no section list to compose into:
+ * the screen agent's, and the deployment prompt the `claudeCode()` builder
+ * thinks with.
+ *
+ * The same two sections the fill worker reads, so the writers cannot be told
+ * different things about the same host configuration.
+ */
+export const hostDesignBrief = (
+  deps: Pick<GenerationDependencies, "theme" | "designRules">,
+): string => composePromptSections([...hostThemeSection(deps), ...hostDesignRulesSection(deps)]);
 
 /** The COMPONENTS section is GENERATED from the component schemas (kitPrompt
  *  over the Kit specs + the legacy primitive signatures); no hand-written

--- a/packages/apps/src/generation/contracts/sections.ts
+++ b/packages/apps/src/generation/contracts/sections.ts
@@ -36,9 +36,7 @@ export const composePromptSections = (sections: readonly GenerationPromptSection
  * the theme tokens are documented seams a host sets and expects to be obeyed.
  * A prompt that omits them makes those config keys silently do nothing.
  */
-export const hostDesignRulesSection = (
-  deps: Pick<GenerationDependencies, "designRules">,
-): GenerationPromptSection[] => {
+export const hostDesignRulesSection = (deps: Pick<GenerationDependencies, "designRules">): GenerationPromptSection[] => {
   const rules = (typeof deps.designRules === "function" ? deps.designRules() : deps.designRules)?.trim();
   // The section is emitted even when the host set no rules: "(none provided)" is
   // the difference between a model that knows there are no house rules and one
@@ -49,9 +47,7 @@ export const hostDesignRulesSection = (
   }];
 };
 
-export const hostThemeSection = (
-  deps: Pick<GenerationDependencies, "theme">,
-): GenerationPromptSection[] =>
+export const hostThemeSection = (deps: Pick<GenerationDependencies, "theme">): GenerationPromptSection[] =>
   deps.theme === undefined ? [] : [{
     id: "theme" as const,
     content: `THEME TOKENS:\n${JSON.stringify(deps.theme, null, 2)}`,
@@ -65,9 +61,8 @@ export const hostThemeSection = (
  * The same two sections the fill worker reads, so the writers cannot be told
  * different things about the same host configuration.
  */
-export const hostDesignBrief = (
-  deps: Pick<GenerationDependencies, "theme" | "designRules">,
-): string => composePromptSections([...hostThemeSection(deps), ...hostDesignRulesSection(deps)]);
+export const hostDesignBrief = (deps: Pick<GenerationDependencies, "theme" | "designRules">): string =>
+  composePromptSections([...hostThemeSection(deps), ...hostDesignRulesSection(deps)]);
 
 /** The COMPONENTS section is GENERATED from the component schemas (kitPrompt
  *  over the Kit specs + the legacy primitive signatures); no hand-written

--- a/packages/apps/src/generation/prompts/worker.ts
+++ b/packages/apps/src/generation/prompts/worker.ts
@@ -17,11 +17,7 @@ import {
   type PlanGroup,
   type PlanQuery,
 } from "@vendoai/core";
-import {
-  composePromptSections,
-  hostDesignRulesSection,
-  hostThemeSection,
-} from "../contracts/sections.js";
+import { hostDesignBrief } from "../contracts/sections.js";
 import { PREWIRED_SCHEMAS } from "../../prewired-schema.js";
 import type { GenerationDependencies } from "../engine.js";
 
@@ -77,7 +73,7 @@ export const workerSystemPrompt = (deps: GenerationDependencies, group: PlanGrou
     // The worker writes the markup, so the host's stated design rules and brand
     // tokens have to reach IT — they are host configuration, not prompt polish,
     // and a section written without them ignores what the host asked for.
-    composePromptSections([...hostThemeSection(deps), ...hostDesignRulesSection(deps)]),
+    hostDesignBrief(deps),
   ].filter((section) => section !== "").join("\n\n");
 
 export interface WorkerFillInput {

--- a/packages/apps/src/index.ts
+++ b/packages/apps/src/index.ts
@@ -133,6 +133,11 @@ export {
 // through.
 export { agentToolDescriptors } from "./agent-tools.js";
 export { buildingAppsSkill } from "./skills/building-apps.js";
+// The host's own theme and design rules, as the writers read them. Public
+// because both briefs that carry them are assembled outside this package — the
+// screen agent's in `@vendoai/harnesses`, the builder's in composition — and a
+// second rendering of the same two config keys is how they start to disagree.
+export { hostDesignBrief } from "./generation/contracts/sections.js";
 // `conductCreate` / `conductEdit` and their result types were public here for
 // "external bench harnesses". A reverse-dependency walk (2026-08-05) found no
 // caller anywhere — in this repo, the examples, the corpus harness or the docs —

--- a/packages/apps/src/skills/building-apps.ts
+++ b/packages/apps/src/skills/building-apps.ts
@@ -132,6 +132,65 @@ group.
 Write each \`purpose\` so a stranger could build that part from it and nothing
 else — because that is exactly what happens next.
 
+## What a good screen looks like
+
+Not decoration, and not CSS: every one of these is a choice you make in the plan
+and in the parts you name.
+
+**Lead with the answer.** The first thing on screen is what they asked for — the
+number, the summary, the one chart that settles it. Detail goes underneath. One
+focal point per screen: if two parts are competing to be the headline, one of
+them is not the headline.
+
+**Fewer parts, better parts.** A group is five leaves at most and usually three.
+One table that answers the question beats three that circle it. Whitespace is
+what a screen looks like when nothing unnecessary is on it — never something you
+add, and never something you fill.
+
+**Never say the same thing twice.** Two charts of the same series, or a number
+repeated from the table under it, is one part pretending to be two. A chart
+beside the table it summarises is not that — the chart shows the share, the table
+shows the figures.
+
+**Bind the rows as they come.** Never reshape, trim or re-bucket data to fit a
+part you have already picked — pick the part that fits the data. Props are
+checked against the query's real shape, so an array you assembled yourself is a
+failed app.
+
+**Group by what the person came to do**, not by which query the data came from.
+Related values sit together in one group. \`tab\` splits a screen only when the
+tabs are genuinely different jobs ("Overview", "Overdue") — never to break up one
+long list. Two or three tabs, never five.
+
+**\`col\` is width, not slicing.** A single number is narrow; a table or a chart
+wants the row. Never fragment one story into a grid of small cards — a card per
+field is a form, not a screen.
+
+**Pick the chart by the shape of the data:**
+
+- a value over time → \`LineChart\`, or \`Sparkline\` where it rides inline
+- comparing categories → \`BarChart\`
+- share of one whole → \`DonutChart\`
+- one number → \`Stat\`, and no chart at all
+- many rows of the same thing → a table, not one small part per row
+
+Never chart two data points, and never chart something a sentence with a number
+in it already says. When in doubt it is a \`Stat\`.
+
+**A hole is a \`<Cannot>\`.** Where this product cannot serve part of the ask, say
+that in one sentence and build nothing around it. Never a placeholder part, never
+an empty card standing in for a feature, never a chart of zeros.
+
+**The words are theirs.** Label things the way this product labels them — its own
+field names, the words already on its screens. Sentence case. No exclamation
+marks, and no paragraph explaining a heading that explains itself.
+
+**An \`<Island>\` is code, not a style sheet.** If a catalog or Kit component can
+express it, do not write one. Inside one, style only with the theme's own CSS
+variables and the ambient Kit: no hex colours, no gradients, no named or imported
+fonts, no emoji standing in for an icon. An island that invents a palette is the
+one thing on the screen that looks like it came from somewhere else.
+
 ## 3. When part of it has to happen while they are away
 
 Some asks are not only a view. "Check every morning", "whenever an invoice comes

--- a/packages/harnesses/src/screen-agent.ts
+++ b/packages/harnesses/src/screen-agent.ts
@@ -125,6 +125,10 @@ export interface ScreenInput {
   /** The deployment's assembled prompt, when there is one — prepended, so the
    *  host's voice and the guard's directions are not lost to the job description. */
   system?: string;
+  /** The host's own theme tokens and design rules (`hostDesignBrief`), when
+   *  composition has them. House rules for the WRITER, so they sit with the job
+   *  description rather than with the deployment's voice. */
+  design?: string;
 }
 
 /** What one assembly run answers. `ScreenOutcome` plus the title an assembled
@@ -230,12 +234,15 @@ deliberate.
 ${toolBrief(listings)}`;
 
 /** The full brief: the deployment's own prompt, the shipped job description, the
- *  shipped syntax manual, then what is different here. */
+ *  shipped syntax manual, the host's own house rules, then what is different
+ *  here. The design brief sits with the job rather than with the deployment's
+ *  voice — it is configuration the writer obeys, not a thing to say. */
 function screenBrief(input: ScreenInput, listings: readonly ToolListing[]): string {
   return [
     input.system,
     buildingAppsSkill.body,
     buildingAppsSkill.files?.[`references/${"format.md"}`],
+    input.design,
     environmentNote(input.appId, listings),
   ]
     .filter((section): section is string => section !== undefined && section.trim().length > 0)
@@ -523,6 +530,10 @@ export interface ScreenAssemblerDeps {
   render?: (ctx: RunContext) => Omit<RenderSeamOptions, "emit">;
   /** The deployment's assembled prompt for this ctx, when composition has one. */
   system?: (ctx: RunContext) => Promise<string | undefined>;
+  /** The host's theme tokens and design rules (`hostDesignBrief` in
+   *  `@vendoai/apps`). A thunk, not a value: `designRules` resolves per
+   *  generation so a console publish applies to the next screen. */
+  design?: () => string | undefined;
   /**
    * Where a run's `decisions` land: the runtime's one memory door
    * (`AppsRuntime.remember`), which is on the other side of the layering — this
@@ -567,6 +578,7 @@ export function screenAssembler(deps: ScreenAssemblerDeps): ScreenAssembler {
         emit: (_streamId, part) => request.onView?.(part),
       });
       const system = await deps.system?.(ctx);
+      const design = deps.design?.();
       const result = await assembleScreen(
         {
           models: deps.models,
@@ -581,6 +593,7 @@ export function screenAssembler(deps: ScreenAssemblerDeps): ScreenAssembler {
           appId: request.appId,
           request: request.request,
           ...(system === undefined ? {} : { system }),
+          ...(design === undefined ? {} : { design }),
         },
       );
       if (result.kind !== "assembled") return result;

--- a/packages/harnesses/src/screen-design-brief.test.ts
+++ b/packages/harnesses/src/screen-design-brief.test.ts
@@ -1,0 +1,94 @@
+/**
+ * What the screen agent is told about DESIGN.
+ *
+ * A seam test, like `screen-agent.test.ts` beside it: the brief is read off the
+ * scripted model's own system prompt after a real `screenAssembler` run, so what
+ * is measured is the text an assembly actually thinks with — never a helper
+ * called by hand.
+ *
+ * Two halves, and they arrive by different routes on purpose. The design LAW is
+ * shipped inside `buildingAppsSkill`, so both writers read the same words; the
+ * host's THEME and design rules are configuration composition holds, so they
+ * arrive through the `design` slot the way `system` does.
+ */
+import { type AppId, type Json, type ToolDescriptor } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { screenAssembler } from "./screen-agent.js";
+import {
+  boundRegistry,
+  ctx,
+  readTool,
+  scriptedModel,
+  seats,
+  testGuard,
+  testWorkspace,
+  textTurn,
+} from "./test-doubles.test-util.js";
+
+const APP = "app_design" as AppId;
+
+/** The host's own rules, as `apps.designRules` carries them, and a token value
+ *  that appears nowhere else in the brief — so a passing assertion cannot be
+ *  the shipped skill text agreeing with itself. */
+const HOST_DESIGN = `THEME TOKENS:
+{
+  "colors": { "accent": "#0f7b4a" },
+  "density": "compact"
+}
+
+HOST DESIGN RULES:
+Maple never shows a balance without its account name beside it.`;
+
+const listTool: ToolDescriptor = { ...readTool("maple_spend_summary"), title: "Spending summary" };
+
+/** One assembler over the real workspace and the real render seam, with the
+ *  host's design brief in the slot composition fills. */
+function harness(design?: string) {
+  const model = scriptedModel([textTurn("nothing to build")]);
+  const assembler = screenAssembler({
+    models: seats(model),
+    tools: boundRegistry(
+      { [listTool.name]: { descriptor: listTool, execute: (): Json => ({ ok: true }) } },
+      testGuard(),
+    ),
+    workspace: async () => testWorkspace(),
+    ...(design === undefined ? {} : { design: () => design }),
+  });
+  return {
+    model,
+    assemble: async () => await assembler.assemble({ appId: APP, request: "show me my spending" }, ctx()),
+  };
+}
+
+describe("the writers' design brief", () => {
+  it("carries the shipped design law — the same words both writers read", async () => {
+    const screen = harness();
+    await screen.assemble();
+    const brief = screen.model.systemPrompts[0] ?? "";
+
+    // The law, in `.vendo` terms rather than CSS: hierarchy, density, chart
+    // choice by data shape, the honest hole, and the island's one styling rule.
+    expect(brief).toContain("What a good screen looks like");
+    expect(brief).toContain("Lead with the answer.");
+    expect(brief).toContain("Never chart two data points");
+    expect(brief).toContain("A hole is a `<Cannot>`.");
+    expect(brief).toContain("no hex colours, no gradients");
+  });
+
+  it("carries the HOST's theme and design rules when composition has them", async () => {
+    const screen = harness(HOST_DESIGN);
+    await screen.assemble();
+    const brief = screen.model.systemPrompts[0] ?? "";
+
+    expect(brief).toContain("THEME TOKENS:");
+    expect(brief).toContain("#0f7b4a");
+    expect(brief).toContain("HOST DESIGN RULES:");
+    expect(brief).toContain("Maple never shows a balance without its account name beside it.");
+  });
+
+  it("says nothing about the host's rules when composition has none", async () => {
+    const screen = harness();
+    await screen.assemble();
+    expect(screen.model.systemPrompts[0] ?? "").not.toContain("HOST DESIGN RULES:");
+  });
+});

--- a/packages/vendo/src/design-brief-wire.test.ts
+++ b/packages/vendo/src/design-brief-wire.test.ts
@@ -1,0 +1,113 @@
+/**
+ * The host's theme and design rules reach the BUILDER's brief.
+ *
+ * `claudeCode()` writes `app.vendo` with its own hands and thinks with
+ * `turn.system` WHOLE and ALONE — it appends nothing after the host's prompt
+ * seam, and `claude-code.test.ts` ("Turn.system reaches the box WHOLE and
+ * ALONE") measures that against a real box door. So the only place the host's
+ * `theme` and `apps.designRules` can reach it is composition's own prompt
+ * closure, which is what this file drives: real `createVendo`, real HTTP
+ * `Request` into `vendo.handler`, and the harness reading the `Turn` the runtime
+ * built. Nothing is stubbed on either side of that seam.
+ *
+ * Without this, the two config keys reach the fill worker and the screen agent
+ * and silently do nothing on the builder path.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Principal, VendoTheme } from "@vendoai/core";
+import { createStore, type VendoStore } from "@vendoai/store";
+import { defineHarness } from "@vendoai/harnesses";
+import type { LanguageModel, UIMessage } from "ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createVendo } from "./server.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+const principal: Principal = { kind: "user", subject: "user_design" };
+
+const theme: VendoTheme = {
+  colors: {
+    background: "#ffffff",
+    surface: "#f7f7f5",
+    text: "#101010",
+    muted: "#6b6b6b",
+    accent: "#0f7b4a",
+    accentText: "#ffffff",
+    danger: "#b3261e",
+    border: "#e4e4e0",
+  },
+  typography: { fontFamily: "Onest", baseSize: "15px" },
+  radius: { small: "6px", medium: "10px", large: "16px" },
+  density: "compact",
+  motion: "reduced",
+};
+
+const DESIGN_RULES = "Maple never shows a balance without its account name beside it.";
+
+const request = (path: string, body: unknown): Request =>
+  new Request(`https://host.test/api/vendo${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+const userMessage = (id: string, text: string): UIMessage =>
+  ({ id, role: "user", parts: [{ type: "text", text }] }) as UIMessage;
+
+/** One composed turn, answering with the brief the runtime handed the thinker.
+ *  A scripted harness stands where `claudeCode()` stands and reads the same
+ *  field it reads — `turn.system`, and nothing else. */
+async function briefFor(overrides: Record<string, unknown>): Promise<string> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-design-brief-"));
+  const store = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.ensureSchema().catch(() => undefined);
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  let brief: string | undefined;
+  const vendo = createVendo({
+    model: {} as LanguageModel,
+    principal: async () => principal,
+    store,
+    harness: defineHarness({
+      name: "scripted",
+      async *run(turn) {
+        brief = turn.system;
+        yield { type: "text", delta: "read the brief" };
+      },
+    }),
+    ...overrides,
+  } as Parameters<typeof createVendo>[0]);
+  const response = await vendo.handler(request("/threads", {
+    threadId: "thr_design",
+    message: userMessage("m1", "build me a spending screen"),
+  }));
+  // Drained, and proven served: an unread brief and an unserved turn look the
+  // same from here otherwise.
+  expect(await response.text()).toContain("read the brief");
+  return brief ?? "";
+}
+
+describe("the host's design configuration in the composed brief", () => {
+  it("carries the theme tokens and the host's design rules", async () => {
+    const brief = await briefFor({ theme, apps: { designRules: DESIGN_RULES } });
+    expect(brief).toContain("THEME TOKENS:");
+    // The token a builder writing an island actually needs, not a one-line
+    // summary of the theme's density and font.
+    expect(brief).toContain("#0f7b4a");
+    expect(brief).toContain("HOST DESIGN RULES:");
+    expect(brief).toContain(DESIGN_RULES);
+  });
+
+  it("says so plainly when the host set no rules, rather than leaving it unsaid", async () => {
+    const brief = await briefFor({});
+    expect(brief).toContain("HOST DESIGN RULES:\n(none provided)");
+    expect(brief).not.toContain("THEME TOKENS:");
+  });
+});

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -42,6 +42,7 @@ import {
   buildingAppsSkill,
   createApps,
   createAppTokens,
+  hostDesignBrief,
   pinBaselineSchema,
   type AppsConfig,
   type AppsRuntime,
@@ -2043,6 +2044,16 @@ export function createVendo(input: CreateVendoConfig): Vendo {
   const designRules = configDesignRules
     ? configDesignRules
     : () => selectConfigSurface("design-rules.md", { readFile: readSurfaceFile, cloud: configCloud }).value;
+  /**
+   * The same two config keys, for whoever WRITES the app.
+   *
+   * The apps thunk seam below hands them to the fill worker; this hands them to
+   * the two briefs assembled outside that seam — the screen agent's, and the
+   * deployment prompt a `claudeCode()` builder thinks with. Rendered by the apps
+   * block's own sections either way, so the writers cannot be told different
+   * things. Resolved per call for the same reason `designRules` is a provider.
+   */
+  const writerDesignBrief = (): string => hostDesignBrief({ theme: themeProvider(), designRules });
   const pinBaselines = dotVendoPinBaselines(config.profileDir);
   // W3 + cse lane 3 — field semantics from the merged .vendo
   // pair (generated tools.json overlaid by overrides.json). The OVERRIDES
@@ -2388,6 +2399,13 @@ export function createVendo(input: CreateVendoConfig): Vendo {
       // deployment prompt's job — voice, venue gate, guard directions, the
       // discovery rail — belongs to the thinker talking to the PERSON. This loop
       // talks to nobody: the front door speaks its one-line receipt.
+      //
+      // `design` is NOT part of that. `apps.designRules` and the theme tokens are
+      // documented seams a host sets and expects a generated screen to obey, and
+      // this loop is the thing that generates it — a brief without them makes
+      // those two config keys silently do nothing on the route that serves every
+      // ask.
+      design: writerDesignBrief,
     }),
     // Round-2 hardening — the host's reviewer assertion for the review-kind
     // remix lifecycle, threaded verbatim (see the CreateVendoConfig comment).
@@ -2788,18 +2806,27 @@ export function createVendo(input: CreateVendoConfig): Vendo {
     // can never name different sets.
     catalog,
     models: inference.seats,
-    system: async (ctx, opts) => assembleSystemPrompt(
-      guard,
-      ctx,
-      system,
-      // Both rails now reach the harness path (`createDiscoveryRails`), so the
-      // prompt may promise them — and must, or the model is handed the miss
-      // reporter and a discovery rail with no instructions about either. WHICH
-      // discovery section rides is the turn's to say: an uncurated surface has no
-      // `find_tools`, so teaching it would name a tool that is not there.
-      true,
-      opts?.discovery ?? "find-tools",
-    ),
+    system: async (ctx, opts) => [
+      await assembleSystemPrompt(
+        guard,
+        ctx,
+        system,
+        // Both rails now reach the harness path (`createDiscoveryRails`), so the
+        // prompt may promise them — and must, or the model is handed the miss
+        // reporter and a discovery rail with no instructions about either. WHICH
+        // discovery section rides is the turn's to say: an uncurated surface has no
+        // `find_tools`, so teaching it would name a tool that is not there.
+        true,
+        opts?.discovery ?? "find-tools",
+      ),
+      // The host's house rules, HERE rather than inside `claudeCode()`: that
+      // harness thinks with `turn.system` whole and alone, and lines it appends
+      // after the host's prompt seam are exactly what it refuses to invent
+      // (`claude-code/index.ts`). It writes `app.vendo` with its own hands, so
+      // without this the theme and `apps.designRules` reach the fill worker and
+      // the screen agent and never reach the builder.
+      writerDesignBrief(),
+    ].filter((section) => section.trim() !== "").join("\n\n"),
     // Projected for THIS ctx, so THE LAW's unattended filter (design §12) decides
     // what the model is even shown — not just what it is allowed to run.
     descriptors: (ctx) => boundTools.descriptors(ctx),

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -2806,27 +2806,24 @@ export function createVendo(input: CreateVendoConfig): Vendo {
     // can never name different sets.
     catalog,
     models: inference.seats,
-    system: async (ctx, opts) => [
-      await assembleSystemPrompt(
-        guard,
-        ctx,
-        system,
-        // Both rails now reach the harness path (`createDiscoveryRails`), so the
-        // prompt may promise them — and must, or the model is handed the miss
-        // reporter and a discovery rail with no instructions about either. WHICH
-        // discovery section rides is the turn's to say: an uncurated surface has no
-        // `find_tools`, so teaching it would name a tool that is not there.
-        true,
-        opts?.discovery ?? "find-tools",
-      ),
-      // The host's house rules, HERE rather than inside `claudeCode()`: that
-      // harness thinks with `turn.system` whole and alone, and lines it appends
-      // after the host's prompt seam are exactly what it refuses to invent
-      // (`claude-code/index.ts`). It writes `app.vendo` with its own hands, so
-      // without this the theme and `apps.designRules` reach the fill worker and
-      // the screen agent and never reach the builder.
-      writerDesignBrief(),
-    ].filter((section) => section.trim() !== "").join("\n\n"),
+    // The host's house rules ride HERE rather than inside `claudeCode()`: that
+    // harness thinks with `turn.system` whole and alone, and lines it appends
+    // after the host's prompt seam are exactly what it refuses to invent
+    // (`claude-code/index.ts`). It writes `app.vendo` with its own hands, so
+    // without this the theme and `apps.designRules` reach the fill worker and
+    // the screen agent and never reach the builder.
+    system: async (ctx, opts) => `${await assembleSystemPrompt(
+      guard,
+      ctx,
+      system,
+      // Both rails now reach the harness path (`createDiscoveryRails`), so the
+      // prompt may promise them — and must, or the model is handed the miss
+      // reporter and a discovery rail with no instructions about either. WHICH
+      // discovery section rides is the turn's to say: an uncurated surface has no
+      // `find_tools`, so teaching it would name a tool that is not there.
+      true,
+      opts?.discovery ?? "find-tools",
+    )}\n\n${writerDesignBrief()}`,
     // Projected for THIS ctx, so THE LAW's unattended filter (design §12) decides
     // what the model is even shown — not just what it is allowed to run.
     descriptors: (ctx) => boundTools.descriptors(ctx),


### PR DESCRIPTION
Both writers — the screen agent and the `claudeCode()` builder — could name every
component in the catalog and had nothing to say about **which** one, **how many**,
or **where**. So a screen was whatever the model reached for first.

## 1. The design law, in the shipped skill

A ~55-line `## What a good screen looks like` section inside `buildingAppsSkill`,
written in `.vendo` terms rather than CSS, because every one of these is a choice
made in the plan:

- **Lead with the answer** — the number first, detail underneath, one focal point.
- **Fewer parts, better parts** — five leaves at most, usually three; whitespace is
  what is left when nothing unnecessary is on the screen.
- **Never say the same thing twice** — a chart beside the table it summarises is
  fine; two charts of the same series is one part pretending to be two.
- **Bind the rows as they come** — never reshape data to fit a part already picked;
  props are checked against the query's real shape.
- **Grouping** — group by what the person came to do, not by which query it came
  from; `tab` only for genuinely different jobs; `col` is width, never slicing.
- **Chart by data shape** — trend → `LineChart`, comparison → `BarChart`, share →
  `DonutChart`, one number → `Stat` and no chart, many rows → a table. Never chart
  two data points.
- **A hole is a `<Cannot>`** — never a placeholder part, never a chart of zeros.
- **The words are theirs** — the host's own field names, sentence case, no
  exclamation marks, no paragraph explaining a heading.
- **An `<Island>` is code, not a style sheet** — theme CSS variables and the ambient
  Kit only; no hex colours, no gradients, no imported fonts, no emoji-as-icon.

One text, in the skill both writers read, so `claudeCode()` and the screen agent
cannot be taught different design.

## 2. The host's theme and design rules reach both writers

`apps.designRules` and the theme tokens are documented seams a host **sets and
expects to be obeyed**. They reached the fill worker of the deprecated conductor
and nothing else — so on both live write paths those two config keys silently did
nothing.

`hostDesignBrief` (`packages/apps/src/generation/contracts/sections.ts:60`) renders
the two sections composition already had, and composition hands the same string to
both seams:

- the **screen agent's** brief, through a `design` slot beside `system`
  (`packages/harnesses/src/screen-agent.ts:129`, `:246`, `:539`; filled at
  `packages/vendo/src/server.ts:2401`)
- the **composed prompt** `claudeCode()` thinks with
  (`packages/vendo/src/server.ts:2818`)

Deliberately **not** inside `claudeCode()`: that harness thinks with `turn.system`
whole and alone and appends nothing after the host's prompt seam, so the prompt
seam is the only honest place for them.

`worker.ts` now composes through the same helper, so there is one rendering of the
pair rather than three.

## Tests

Seam tests, no stub on either side, both new files:

- `packages/harnesses/src/screen-design-brief.test.ts` — the brief read off a
  scripted model's own system prompt after a **real `screenAssembler` run**: the
  shipped design law, and the host's theme/rules when composition has them.
- `packages/vendo/src/design-brief-wire.test.ts` — `turn.system` off a **real
  `createVendo` turn** through a real HTTP `Request`. The other leg (`turn.system`
  → the box, whole and alone) is already measured against a real box door by
  `claude-code.test.ts` "Turn.system reaches the box WHOLE and ALONE".

Both proven to fail: with the three source changes reverted and rebuilt, 4 of the
5 new assertions go red; restored, all green.

## Browser proof

Real Chromium against `pnpm --filter demo-bank dev` (Maple, Vendo Cloud key, local
PGlite store), same three asks before and after, one fresh conversation each.
Screenshots are local artifacts (`/tmp/uigen-shots/`, this repo does not commit
them — same posture as `packages/ui/e2e/screenshots/`).

| ask | before | after |
|---|---|---|
| "make me a dashboard for my upcoming bills and subscriptions" | two stat tiles, then two tables; amounts read `-$5,790.59` for what are costs; no way to find a subscription | three stats reading positively (`Scheduled payments $5,790.59`), then scheduled payments, then recurring charges with a **search box and a category filter** and a category column |
| "build a screen to track my savings goals" | five cards, then a table repeating **exactly the same five rows** — the duplication the law forbids | one row per goal with a progress bar, percent, saved / target, **sorted closest-to-target first**, and no second copy of the data |
| "show me my spending by category this month" | donut + breakdown table | build refused by the checks floor — see below |

`before-{1,2,3}-*.png` / `after-{1,2,3}-*.png`.

## One pre-existing defect found, not fixed here

The spending ask now fails the checks floor:

```
[screen-types] <MapleSpendingDonut> prop "slices" takes a list of rows, but this
value is { category: string; amount: number; }[] — bind a value whose type matches
```

Maple's `host_getSpendingInsights` declares `category` as a JSON-Schema **enum**, and
`MapleSpendingDonut.slices` requires that enum — but on the screen-agent path
`queryTypeText` falls through to the **sampled** shape (`screen-typings.ts:274`),
which erases enums to `string`. The prop can then never be satisfied, whatever the
model writes.

Proven pre-existing, not a regression: reverted only the skill text, rebuilt,
restarted, and the identical failure reproduces (control run, same ask, same
error). Worth its own fix — thread `toolOutputSchemas` into the screen path, or
widen the enum check.

While chasing that I did remove one line of my own that made things worse:
`progress toward a target → Progress` steered the model into per-row `Progress`
bindings, which trip a **second** checker gap (`{ $path: string }` in a row context
is not typed as a number). The chart list now says "many rows of the same thing → a
table", which is both better design and inside what the checker can see.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared design brief to both writers so generated screens follow a clear design law and the host’s theme and `apps.designRules`. This makes the previously no-op config effective on both the screen agent and `claudeCode()` paths.

- New Features
  - Added “What a good screen looks like” to `buildingAppsSkill` (lead with the answer, no duplicates, pick charts by data shape, holes are `<Cannot>`, islands use theme variables only).
  - Introduced `hostDesignBrief` to render theme tokens and host design rules; exported from `@vendoai/apps`.
  - Screen agent now accepts a `design` slot; harness passes `hostDesignBrief` alongside `system`.
  - Builder path (`createVendo`) now includes the same brief in `turn.system` so `claudeCode()` reads it.
  - Added seam tests to verify the brief reaches both writers.

- Refactors
  - Simplified composed brief assembly to a single template literal and dropped unreachable empty-section filtering on builder/worker prompts.
  - Shortened section helper signatures using `Pick<GenerationDependencies,...>` to match adjacent helpers and avoid divergent renders.

<sup>Written for commit 16e79d8f154d4b3c8b9ddea14deb865d37b98b25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

