### PR TITLE
feat: agent addressing — vendo_make{slot}, pin/unpin, door withholdTools

### DIFF
--- a/.changeset/agent-addressing-slots.md
+++ b/.changeset/agent-addressing-slots.md
@@ -1,0 +1,34 @@
+---
+"@vendoai/core": minor
+"@vendoai/apps": minor
+"@vendoai/mcp": minor
+---
+
+Agents can address a place on the page.
+
+`vendo_make` takes one optional `slot`, honoured on both engines the one front
+door routes to: an assembled screen claims the slot the moment its row lands,
+and an ask that escalates to a real build claims it at mint — so a build that is
+still running occupies the place the caller aimed at instead of appearing later
+out of nowhere. On a CHANGE, `slot` is refused by name: silently moving an
+existing app would evict whatever holds that slot off the back of an edit nobody
+aimed there.
+
+Two new tools do the moving. `vendo_apps_pin { app, slot }` puts an app the user
+already has into a slot and reports what it replaced as `evicted`;
+`vendo_apps_unpin { app, slot }` takes it out and leaves the app itself alone.
+Both aim by the app's id OR the name the user said, like every other door in
+this registry, and both are graded `write` — a placement row is small and
+reversible.
+
+Neither is offered to an unattended run. `PRESENCE_ONLY_TOOLS` (core) joins THE
+LAW's projection: a tool whose whole effect is on a person's screen has nothing
+to act on when nobody is looking, and rearranging a dashboard someone comes back
+to is a change they never saw being made. Keyed on the name, not the grade, so
+policy rules and consent cards still read an honest `write`.
+
+`McpDoorConfig.withholdTools` — names one door never offers, checked BEFORE the
+`vendo_` prefix bypass. The bypass protects the product's plumbing from a HOST's
+curated menu; this is the deployment's own decision about its own door. Curation,
+not security: a withheld name answers with the same in-band not-found an unknown
+name gets.

--- a/packages/apps/src/agent-tools.test.ts
+++ b/packages/apps/src/agent-tools.test.ts
@@ -11,7 +11,9 @@ import { agentToolDescriptors } from "./agent-tools.js";
 import { createApps, type AppsRuntime } from "./index.js";
 import {
   authoringAssembler,
+  basicLanguageModel,
   bindTools,
+  fakeBoxSandbox,
   guardFixture,
   memoryStore,
   seedAppRow,
@@ -534,5 +536,135 @@ describe("§3 consumer voice — every apps tool carries a title", () => {
       // The title is what a person reads; it must not be the identifier again.
       expect(descriptor.title, descriptor.name).not.toMatch(/vendo|_/i);
     }
+  });
+});
+
+describe("vendo_make — the slot a new app lands in", () => {
+  /** The ASSEMBLY engine — the one that serves most asks. `authoringAssembler`
+   *  compiles with core's own compiler and lands the row through
+   *  `runtime.authored`, which is the shipped write path, not a stub. */
+  const assembling = (): AppsRuntime => {
+    const runtime: AppsRuntime = createApps({
+      store: memoryStore(),
+      guard: guardFixture(),
+      tools: hostTools,
+      catalog: [],
+      model: scriptedLanguageModel(generated),
+      screen: authoringAssembler(() => runtime, generated),
+    });
+    return runtime;
+  };
+
+  /** The BUILDER engine — assembly escalates and this deployment has somewhere
+   *  to build. Same front door, same minted id, a different engine behind it,
+   *  which is exactly why the placement is asserted on both. */
+  const escalating = (): AppsRuntime => createApps({
+    store: memoryStore(),
+    guard: guardFixture(),
+    tools: hostTools,
+    catalog: [],
+    model: basicLanguageModel(),
+    machine: { sandbox: fakeBoxSandbox(), buildEnv: () => ({ PORT: "8080" }), boxEditPollMs: 5 },
+    screen: { async assemble() { return { kind: "escalate", why: "this needs real code" }; } },
+  });
+
+  it("takes request, app, context and slot — request required, nothing else allowed", async () => {
+    const descriptors = await assembling().agentTools().descriptors();
+    const schema = descriptors.find(({ name }) => name === "vendo_make")!.inputSchema as {
+      properties: Record<string, unknown>;
+      required: string[];
+      additionalProperties: boolean;
+    };
+
+    expect(Object.keys(schema.properties).sort()).toEqual(["app", "context", "request", "slot"]);
+    expect(schema.required).toEqual(["request"]);
+    expect(schema.additionalProperties).toBe(false);
+  });
+
+  it("lands an ASSEMBLED screen in the slot the caller aimed at", async () => {
+    // The SEAM, not a stub on either side: the tool writes through the real
+    // assembly path, and the assertion reads back through the runtime's real
+    // placements path. Nothing here knows how a placement row is stored.
+    const runtime = assembling();
+
+    const outcome = await runtime.agentTools().execute({
+      id: "call_make_slot",
+      tool: "vendo_make",
+      args: { request: "my spending this month", slot: "dashboard.hero" },
+    }, ctx);
+
+    expect(outcome.status).toBe("ok");
+    const receipt = (outcome as { output: { id: string; status: string } }).output;
+    expect(receipt.status).toBe("ready");
+    expect(await runtime.placements({}, ctx)).toEqual([
+      expect.objectContaining({ slot: "dashboard.hero", app: receipt.id, status: "ready" }),
+    ]);
+  });
+
+  it("lands an ESCALATED build in it too — one front door, two engines, one row", async () => {
+    // The engine the ask is routed to is Vendo's decision, never the caller's.
+    // If only one of the two left a row, `slot` would be a coin toss the caller
+    // cannot see — and it would have shipped green, because each engine has its
+    // own tests.
+    const runtime = escalating();
+
+    const outcome = await runtime.agentTools().execute({
+      id: "call_make_slot_built",
+      tool: "vendo_make",
+      args: { request: "match my invoices to payments", slot: "dashboard.hero" },
+    }, ctx);
+
+    expect(outcome.status).toBe("ok");
+    const receipt = (outcome as { output: { id: string; status: string } }).output;
+    expect(receipt.status).toBe("ready");
+    expect(await runtime.placements({}, ctx)).toEqual([
+      expect.objectContaining({ slot: "dashboard.hero", app: receipt.id }),
+    ]);
+  });
+
+  it("leaves no placement at all when no slot was named", async () => {
+    const runtime = assembling();
+
+    await runtime.agentTools().execute({
+      id: "call_make_no_slot",
+      tool: "vendo_make",
+      args: { request: "my spending this month" },
+    }, ctx);
+
+    expect(await runtime.placements({}, ctx)).toEqual([]);
+  });
+
+  it("refuses a slot on a CHANGE, and names the tool that does move an app", async () => {
+    // Silently ignoring it would be worse, and silently PLACING it would evict
+    // whatever holds that slot off the back of an edit nobody aimed there.
+    const runtime = assembling();
+    const created = await runtime.create({ prompt: "Build a dashboard" }, ctx);
+
+    const outcome = await runtime.agentTools().execute({
+      id: "call_edit_slot",
+      tool: "vendo_make",
+      args: { app: created.id, request: "Make the heading blue", slot: "dashboard.hero" },
+    }, ctx);
+
+    expect(outcome).toEqual({
+      status: "error",
+      error: {
+        code: "validation",
+        message: expect.stringContaining("vendo_apps_pin") as unknown as string,
+      },
+    });
+  });
+
+  it("refuses an empty slot string", async () => {
+    const outcome = await assembling().agentTools().execute({
+      id: "call_make_blank_slot",
+      tool: "vendo_make",
+      args: { request: "my spending", slot: "  " },
+    }, ctx);
+
+    expect(outcome).toEqual({
+      status: "error",
+      error: { code: "validation", message: "slot must be a non-empty string" },
+    });
   });
 });

--- a/packages/apps/src/agent-tools.test.ts
+++ b/packages/apps/src/agent-tools.test.ts
@@ -51,6 +51,8 @@ describe("apps agent tools", () => {
       "vendo_make",
       "vendo_apps_rebase_pin",
       "vendo_apps_open",
+      "vendo_apps_pin",
+      "vendo_apps_unpin",
       "vendo_apps_data_list",
       "vendo_apps_data_put",
       "vendo_apps_data_delete",
@@ -71,7 +73,7 @@ describe("apps agent tools", () => {
     // rearranging your own view is not an act on the world, and history/undo are
     // the safety net.
     expect(descriptors.map((descriptor) => descriptor.risk)).toEqual([
-      "read", "write", "read", "read", "write", "write",
+      "read", "write", "read", "write", "write", "read", "write", "write",
     ]);
     // The one-narrower-retry instruction survived the merge onto `vendo_make`:
     // without it the model's answer to a rejected change was to rebuild the app
@@ -663,6 +665,122 @@ describe("vendo_make — the slot a new app lands in", () => {
     }, ctx);
 
     expect(outcome).toEqual({
+      status: "error",
+      error: { code: "validation", message: "slot must be a non-empty string" },
+    });
+  });
+});
+
+describe("vendo_apps_pin / vendo_apps_unpin — putting an app on the page", () => {
+  // No screen assembler: every app here is made through the runtime's own
+  // `create`, and these two tools only ever move an app that already exists.
+  const makeRuntime = (): AppsRuntime => createApps({
+    store: memoryStore(),
+    guard: guardFixture(),
+    tools: hostTools,
+    catalog: [],
+    model: scriptedLanguageModel(generated),
+  });
+
+  it("takes exactly app and slot, both required", async () => {
+    const descriptors = await makeRuntime().agentTools().descriptors();
+
+    for (const name of ["vendo_apps_pin", "vendo_apps_unpin"]) {
+      const schema = descriptors.find((descriptor) => descriptor.name === name)!.inputSchema as {
+        properties: Record<string, unknown>;
+        required: string[];
+        additionalProperties: boolean;
+      };
+      expect(Object.keys(schema.properties).sort(), name).toEqual(["app", "slot"]);
+      expect(schema.required.slice().sort(), name).toEqual(["app", "slot"]);
+      expect(schema.additionalProperties, name).toBe(false);
+    }
+  });
+
+  it("pins an existing app into a slot, and the placement reads back", async () => {
+    const runtime = makeRuntime();
+    const created = await runtime.create({ prompt: "Build a dashboard" }, ctx);
+
+    const outcome = await runtime.agentTools().execute({
+      id: "call_pin",
+      tool: "vendo_apps_pin",
+      args: { app: created.id, slot: "dashboard.hero" },
+    }, ctx);
+
+    expect(outcome).toEqual({ status: "ok", output: { app: created.id, slot: "dashboard.hero" } });
+    expect(await runtime.placements({}, ctx)).toEqual([
+      expect.objectContaining({ slot: "dashboard.hero", app: created.id }),
+    ]);
+  });
+
+  it("names what it replaced, so the model can say so", async () => {
+    const runtime = makeRuntime();
+    const first = await runtime.create({ prompt: "Build a dashboard" }, ctx);
+    const second = await runtime.create({ prompt: "Build a second dashboard" }, ctx);
+    await runtime.agentTools().execute({
+      id: "call_pin_first",
+      tool: "vendo_apps_pin",
+      args: { app: first.id, slot: "dashboard.hero" },
+    }, ctx);
+
+    const outcome = await runtime.agentTools().execute({
+      id: "call_pin_second",
+      tool: "vendo_apps_pin",
+      args: { app: second.id, slot: "dashboard.hero" },
+    }, ctx);
+
+    expect(outcome).toEqual({
+      status: "ok",
+      output: { app: second.id, slot: "dashboard.hero", evicted: first.id },
+    });
+    expect(await runtime.placements({}, ctx)).toEqual([
+      expect.objectContaining({ slot: "dashboard.hero", app: second.id }),
+    ]);
+  });
+
+  it("aims by the NAME the user said, not only by id", async () => {
+    const runtime = makeRuntime();
+    const created = await runtime.create({ prompt: "Build a dashboard" }, ctx);
+
+    const outcome = await runtime.agentTools().execute({
+      id: "call_pin_by_name",
+      tool: "vendo_apps_pin",
+      args: { app: created.name, slot: "dashboard.hero" },
+    }, ctx);
+
+    expect(outcome).toEqual({ status: "ok", output: { app: created.id, slot: "dashboard.hero" } });
+  });
+
+  it("unpins, leaving the app itself alone", async () => {
+    const runtime = makeRuntime();
+    const created = await runtime.create({ prompt: "Build a dashboard" }, ctx);
+    await runtime.agentTools().execute({
+      id: "call_pin_before_unpin",
+      tool: "vendo_apps_pin",
+      args: { app: created.id, slot: "dashboard.hero" },
+    }, ctx);
+
+    const outcome = await runtime.agentTools().execute({
+      id: "call_unpin",
+      tool: "vendo_apps_unpin",
+      args: { app: created.id, slot: "dashboard.hero" },
+    }, ctx);
+
+    expect(outcome).toEqual({ status: "ok", output: { app: created.id, slot: "dashboard.hero" } });
+    expect(await runtime.placements({}, ctx)).toEqual([]);
+    // The app is still the user's; only its place on the page is gone.
+    expect((await runtime.list(ctx)).map((app) => app.id)).toContain(created.id);
+  });
+
+  it("refuses a missing slot", async () => {
+    const runtime = makeRuntime();
+    const created = await runtime.create({ prompt: "Build a dashboard" }, ctx);
+
+    expect(await runtime.agentTools().execute({
+      id: "call_pin_no_slot",
+      tool: "vendo_apps_pin",
+      args: { app: created.id },
+    }, ctx)).toEqual({
       status: "error",
       error: { code: "validation", message: "slot must be a non-empty string" },
     });

--- a/packages/apps/src/agent-tools.ts
+++ b/packages/apps/src/agent-tools.ts
@@ -1,4 +1,6 @@
 import {
+  VENDO_APPS_PIN_TOOL,
+  VENDO_APPS_UNPIN_TOOL,
   VENDO_MAKE_TOOL,
   VENDO_TOOL_TITLES,
   appIdSchema,
@@ -94,6 +96,56 @@ const descriptors = [
       additionalProperties: false,
     },
     risk: "read",
+  },
+  {
+    name: VENDO_APPS_PIN_TOOL,
+    description: "Put one of the user's own apps into a named slot on the page they are looking at, where it stays until they move it. `app` is the app's id, or its name exactly as the user said it, resolved against their own apps (if two share that name you are told both, so ask which one they mean). `slot` is a slot id the host published for that place on the page — pass one you were told rather than one you invented. Whatever held that slot is replaced, and the reply names it as `evicted` so you can say what moved.",
+    inputSchema: {
+      $schema: DRAFT_2020_12,
+      type: "object",
+      properties: {
+        app: {
+          type: "string",
+          minLength: 1,
+          description: "The app's id, or its name as the user says it.",
+        },
+        slot: {
+          type: "string",
+          minLength: 1,
+          description: "The slot id the host published for that place on the page.",
+        },
+      },
+      required: ["app", "slot"],
+      additionalProperties: false,
+    },
+    // A `write`, and only a write: one small row saying where an app the user
+    // already owns sits on their own page. It is reversible by the tool below,
+    // and history is the safety net. What keeps it away from an unattended run
+    // is `PRESENCE_ONLY_TOOLS`, not an inflated grade.
+    risk: "write",
+  },
+  {
+    name: VENDO_APPS_UNPIN_TOOL,
+    description: "Take an app back out of a slot on the user's page. The app itself is untouched — it stays in their apps and can be put back any time. `app` is the app's id or its name as the user said it; `slot` is the slot it is in.",
+    inputSchema: {
+      $schema: DRAFT_2020_12,
+      type: "object",
+      properties: {
+        app: {
+          type: "string",
+          minLength: 1,
+          description: "The app's id, or its name as the user says it.",
+        },
+        slot: {
+          type: "string",
+          minLength: 1,
+          description: "The slot the app is in.",
+        },
+      },
+      required: ["app", "slot"],
+      additionalProperties: false,
+    },
+    risk: "write",
   },
   {
     name: "vendo_apps_data_list",
@@ -576,6 +628,23 @@ export const createAgentTools = (
         // "no such app" while that app sat in the caller's own list.
         const appId = await resolveAppRef(runtime, args.appId as string, ctx);
         return { status: "ok", output: await runtime.open(appId, ctx) as unknown as Json };
+      }
+      if (call.tool === VENDO_APPS_PIN_TOOL) {
+        const args = input(call.args, ["app", "slot"]);
+        const appId = await resolveAppRef(runtime, args.app as string, ctx);
+        const slot = args.slot as string;
+        const { evicted } = await runtime.place({ app: appId, slot }, ctx);
+        return {
+          status: "ok",
+          output: { app: appId, slot, ...(evicted === undefined ? {} : { evicted }) },
+        };
+      }
+      if (call.tool === VENDO_APPS_UNPIN_TOOL) {
+        const args = input(call.args, ["app", "slot"]);
+        const appId = await resolveAppRef(runtime, args.app as string, ctx);
+        const slot = args.slot as string;
+        await runtime.unplace({ app: appId, slot }, ctx);
+        return { status: "ok", output: { app: appId, slot } };
       }
       if (call.tool === "vendo_apps_data_list") {
         const args = input(call.args, ["appId", "collection"], ["refs", "limit", "cursor"]);

--- a/packages/apps/src/agent-tools.ts
+++ b/packages/apps/src/agent-tools.ts
@@ -40,7 +40,7 @@ const descriptors = [
     // live host data itself. The retry one: a rejected change is worth one
     // narrower attempt on the same app, and was worth saying because the
     // alternative the model reached for was rebuilding it from scratch.
-    description: "Make the user something to look at — a screen, or a full app — from a plain-language request. Say what they want in your own words; Vendo decides whether to assemble a screen or build an app, and it arrives on the user's own page. Pass `app` only to change one specific existing app — its id, or its name exactly as the user said it, which is resolved against their own apps (if two share that name you are told both, so ask which one); leave it out and Vendo decides whether to continue the last one or start something new. A recurring or scheduled task belongs here too: describe the schedule and the action in the request and it is armed as part of the same call; there is no separate automations tool. One app can hold SEVERAL automations, so to add another one to an app it already has, name that app in `app` and describe the new schedule — never refuse a second schedule. Never bake data values you computed or fetched (counts, totals, amounts) into the request — it binds live host data itself and hardcoded figures fail its checks. Never specify fonts, colors, or branding — it inherits the host theme. You get back a one-line receipt to say out loud, never the screen itself; if the receipt says \"failed\", try once more on the same `app` with a narrower request rather than rebuilding it.",
+    description: "Make the user something to look at — a screen, or a full app — from a plain-language request. Say what they want in your own words; Vendo decides whether to assemble a screen or build an app, and it arrives on the user's own page. Pass `app` only to change one specific existing app — its id, or its name exactly as the user said it, which is resolved against their own apps (if two share that name you are told both, so ask which one); leave it out and Vendo decides whether to continue the last one or start something new. A recurring or scheduled task belongs here too: describe the schedule and the action in the request and it is armed as part of the same call; there is no separate automations tool. One app can hold SEVERAL automations, so to add another one to an app it already has, name that app in `app` and describe the new schedule — never refuse a second schedule. Never bake data values you computed or fetched (counts, totals, amounts) into the request — it binds live host data itself and hardcoded figures fail its checks. Never specify fonts, colors, or branding — it inherits the host theme. You get back a one-line receipt to say out loud, never the screen itself; if the receipt says \"failed\", try once more on the same `app` with a narrower request rather than rebuilding it. Pass `slot` only when the request names a particular place on the user's page for it to land — the host publishes those slot ids, so pass one you were told rather than one you invented, and whatever held that place is replaced. `slot` is for something NEW: to move an app that already exists, use the pin tool instead.",
     inputSchema: {
       $schema: DRAFT_2020_12,
       type: "object",
@@ -48,6 +48,7 @@ const descriptors = [
         request: { type: "string", minLength: 1 },
         app: { type: "string", minLength: 1 },
         context: { type: "string", minLength: 1 },
+        slot: { type: "string", minLength: 1 },
       },
       required: ["request"],
       additionalProperties: false,
@@ -360,8 +361,9 @@ export const createAgentTools = (
   async execute(call, ctx: RunContext): Promise<ToolOutcome> {
     try {
       if (call.tool === VENDO_MAKE_TOOL) {
-        const args = input(call.args, ["request"], ["app", "context"]);
+        const args = input(call.args, ["request"], ["app", "context", "slot"]);
         const app = optionalString(args.app, "app");
+        const slot = optionalString(args.slot, "slot");
         const stream = (call as VendoViewStreamingToolCall)[VENDO_VIEW_STREAM];
         const request = args.request as string;
         const ask = withContext(request, optionalString(args.context, "context"));
@@ -423,6 +425,11 @@ export const createAgentTools = (
             const stored = await runtime.get(appId, ctx).catch(() => null);
             if (stored !== null) {
               await remember(appId);
+              // B1, on the engine that serves most asks. `place()` gates on the
+              // app record (§9.4) and assembly is what writes that record, so
+              // this is the FIRST instant the claim can legally be made — and
+              // the last instant it is still part of the call the person made.
+              if (slot !== undefined) await runtime.place({ app: stored.id, slot }, ctx);
               return receipt({
                 id: stored.id,
                 title: stored.name,
@@ -479,6 +486,11 @@ export const createAgentTools = (
             appId,
             prompt: ask,
             ...(plan === undefined ? {} : { plan }),
+            // B1 — `create` claims the slot at MINT, so a build that is still
+            // running (or that never lands) occupies the place the caller aimed
+            // at instead of appearing out of nowhere minutes later. This tool
+            // only aims; the runtime owns the row.
+            ...(slot === undefined ? {} : { slot }),
             onUnsaved: (reason) => { unsaved = reason; },
             ...(stream === undefined ? {} : {
               onView: (part) => stream({ id: vendoViewStreamId(part.appId), part }),
@@ -501,6 +513,17 @@ export const createAgentTools = (
               ? `${created.name} is on your screen.`
               : `${created.name} is on your screen, though I couldn't save it to your apps.`,
           });
+        }
+        // `slot` says where a NEW app lands. On a change it would have to mean
+        // "and also move it", which evicts whatever holds that slot off the back
+        // of an edit nobody aimed there — so it is refused, by name, at the one
+        // tool that does the moving. Refused before the ref is resolved: the
+        // answer does not depend on which app was meant.
+        if (slot !== undefined) {
+          throw new VendoError(
+            "validation",
+            "`slot` says where a new app lands. To move an app that already exists, call vendo_apps_pin with that app and slot.",
+          );
         }
         const appId = await resolveAppRef(runtime, app, ctx);
         const result = await runtime.edit(appId, ask, ctx);

--- a/packages/core/src/grant-sets.test.ts
+++ b/packages/core/src/grant-sets.test.ts
@@ -173,3 +173,33 @@ describe("bundles are proposed, never blank (§12)", () => {
     expect(isBundleEligible(["a", "b"], registry, [tool("a", "read"), tool("b", "destructive")])).toBe(false);
   });
 });
+
+describe("presence-only tools: nothing rearranges a page nobody is looking at", () => {
+  const surface = [
+    tool("vendo_make", "read"),
+    tool("vendo_apps_pin", "write"),
+    tool("vendo_apps_unpin", "write"),
+    tool("maple_invoice_update", "write"),
+  ];
+
+  it("withholds the placement pair from an unattended run", () => {
+    const projected = projectableForRun(surface, { venue: "automation", presence: "away" });
+
+    expect(projected.map((t) => t.name)).toEqual(["vendo_make", "maple_invoice_update"]);
+  });
+
+  it("keys the rule on the NAME, not the grade — another write is untouched", () => {
+    // Their risk is honestly `write`: a placement row is small and reversible,
+    // and needs no ceremony with a person right there. So the withholding cannot
+    // ride the risk label, and this is the assertion that says so.
+    const projected = projectableForRun(surface, { venue: "automation", presence: "away" });
+
+    expect(projected.map((t) => t.risk)).toEqual(["read", "write"]);
+  });
+
+  it("offers them to a person who is present", () => {
+    const projected = projectableForRun(surface, { venue: "chat", presence: "present" });
+
+    expect(projected).toHaveLength(4);
+  });
+});

--- a/packages/core/src/grant-sets.ts
+++ b/packages/core/src/grant-sets.ts
@@ -1,7 +1,7 @@
 import { canonicalJson } from "./jcs.js";
 import { sha256Hex } from "./sha256.js";
 import type { Json } from "./ids.js";
-import { USE_SERVICE_TOOL, type ToolDescriptor } from "./tools.js";
+import { PRESENCE_ONLY_TOOLS, USE_SERVICE_TOOL, type ToolDescriptor } from "./tools.js";
 import type { RunContext } from "./run-context.js";
 
 /** Build contract §7 — a grant set is per person, bound to an app's INTENT
@@ -117,7 +117,12 @@ export function projectableForRun(
 ): ToolDescriptor[] {
   if (!isUnattended(ctx)) return [...descriptors];
   return descriptors.filter(
-    (descriptor) => !withheldFromUnattended(descriptor) || isGrantedDispatcher(descriptor, ctx),
+    (descriptor) =>
+      // A tool whose whole effect is on a person's screen has nothing to act on
+      // when nobody is there — see {@link PRESENCE_ONLY_TOOLS}. Named, not
+      // graded: these are honest `write`s.
+      !PRESENCE_ONLY_TOOLS.has(descriptor.name)
+      && (!withheldFromUnattended(descriptor) || isGrantedDispatcher(descriptor, ctx)),
   );
 }
 

--- a/packages/core/src/tools.test.ts
+++ b/packages/core/src/tools.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
   isVendoAppsTool,
   modelToolDescription,
+  PRESENCE_ONLY_TOOLS,
   TOOL_NAME_PATTERN,
+  VENDO_APPS_PIN_TOOL,
   VENDO_APPS_TOOL_PREFIX,
+  VENDO_APPS_UNPIN_TOOL,
   VENDO_MAKE_TOOL,
   VENDO_TOOL_TITLES,
 } from "./index.js";
@@ -73,5 +76,30 @@ describe("modelToolDescription — the model can only speak a title it was told"
     // `ToolListing.title` falls back to the NAME; repeating the identifier as a
     // label would teach the model exactly the wrong vocabulary.
     expect(modelToolDescription({ name: "host_x", title: "host_x", description: "Does a thing." })).toBe("Does a thing.");
+  });
+});
+
+describe("the placement pair — one name, read by three packages", () => {
+  it("pins both names inside the apps family, so the family's laws apply to them", () => {
+    expect(VENDO_APPS_PIN_TOOL).toBe("vendo_apps_pin");
+    expect(VENDO_APPS_UNPIN_TOOL).toBe("vendo_apps_unpin");
+    expect(isVendoAppsTool(VENDO_APPS_PIN_TOOL)).toBe(true);
+    expect(isVendoAppsTool(VENDO_APPS_UNPIN_TOOL)).toBe(true);
+    expect(TOOL_NAME_PATTERN.test(VENDO_APPS_PIN_TOOL)).toBe(true);
+    expect(TOOL_NAME_PATTERN.test(VENDO_APPS_UNPIN_TOOL)).toBe(true);
+  });
+
+  it("titles both in the consumer voice — a model may only say a label it was told", () => {
+    // The apps package asserts `descriptor.title === VENDO_TOOL_TITLES[name]`
+    // for EVERY descriptor, so a missing entry here is a titleless tool there.
+    expect(VENDO_TOOL_TITLES[VENDO_APPS_PIN_TOOL]).toBe("Pin the app to your page");
+    expect(VENDO_TOOL_TITLES[VENDO_APPS_UNPIN_TOOL]).toBe("Take the app off your page");
+    for (const title of [VENDO_TOOL_TITLES[VENDO_APPS_PIN_TOOL], VENDO_TOOL_TITLES[VENDO_APPS_UNPIN_TOOL]]) {
+      expect(title).not.toMatch(/vendo|_/i);
+    }
+  });
+
+  it("names them as the presence-only set the projection reads", () => {
+    expect([...PRESENCE_ONLY_TOOLS].sort()).toEqual(["vendo_apps_pin", "vendo_apps_unpin"]);
   });
 });

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -33,6 +33,39 @@ export const VENDO_APPS_TOOL_PREFIX = "vendo_apps_";
 export const VENDO_MAKE_TOOL = "vendo_make";
 
 /**
+ * The two tools that put one of a person's own apps into a named place on the
+ * HOST'S page, and take it back out.
+ *
+ * Named here for the same reason `VENDO_MAKE_TOOL` is: three sides read them and
+ * a security-relevant name with three spellings drifts silently — the apps
+ * registry that implements them, the projection below that withholds them from
+ * an unattended run, and any door that names them in `withholdTools`.
+ */
+export const VENDO_APPS_PIN_TOOL = "vendo_apps_pin";
+export const VENDO_APPS_UNPIN_TOOL = "vendo_apps_unpin";
+
+/**
+ * Tools whose whole effect is on a PERSON'S SCREEN.
+ *
+ * §12's projection withholds these from an unattended run exactly as it
+ * withholds a destructive one, for a reason of the same shape: there is no page
+ * and nobody looking at it. A firing that rearranged someone's dashboard while
+ * they were away would be a change they never asked for and never saw being
+ * made — and, because a placement EVICTS whatever held that slot, one they would
+ * come back to without knowing what happened.
+ *
+ * Keyed on the NAME rather than on the grade, because the grade is honestly
+ * `write`: with a person right there, putting your own app on your own page is a
+ * small reversible write that needs no ceremony. Grading them `destructive` to
+ * buy the withholding would lie to every other reader of the label (policy
+ * rules, the consent card, the automations planner).
+ */
+export const PRESENCE_ONLY_TOOLS: ReadonlySet<string> = new Set<string>([
+  VENDO_APPS_PIN_TOOL,
+  VENDO_APPS_UNPIN_TOOL,
+]);
+
+/**
  * 01-core §16 — is this one of the app runtime's own tools?
  *
  * The prefix was the test in four places (two through the constant, two by
@@ -67,6 +100,8 @@ export const VENDO_TOOL_TITLES: Readonly<Record<string, string>> = {
   vendo_make: "Make you a screen",
   vendo_apps_open: "Open the app",
   vendo_apps_rebase_pin: "Refresh a remixed piece",
+  vendo_apps_pin: "Pin the app to your page",
+  vendo_apps_unpin: "Take the app off your page",
   vendo_apps_data_list: "Read the app's saved items",
   vendo_apps_data_put: "Save an item in the app",
   vendo_apps_data_delete: "Remove an item from the app",

--- a/packages/mcp/src/door.test.ts
+++ b/packages/mcp/src/door.test.ts
@@ -2158,6 +2158,66 @@ describe("createMcpDoor tool menu, titles, and annotations", () => {
     expect(listed.tools.map((tool) => tool.name)).toEqual(["host_lookup", "host_pay", "host_wipe", "host_admin"]);
     await connected.client.close();
   });
+
+  it("never offers a withheld tool — not even a vendo_ one the menu can never curate away", async () => {
+    // The prefix bypass exists so a host's curated menu cannot delete Vendo's
+    // own plumbing. `withholdTools` is the deployment's own decision about ITS
+    // door, so it is checked FIRST — otherwise it could hold back everything
+    // except the tools it most needs to.
+    const { connected } = await open({
+      extraDescriptors: [
+        ...surfaceDescriptors,
+        { name: "vendo_make", description: "Make a screen", inputSchema: { type: "object" }, risk: "read" as const },
+        { name: "vendo_apps_pin", description: "Pin an app", inputSchema: { type: "object" }, risk: "write" as const },
+      ],
+      withholdTools: ["vendo_apps_pin", "host_admin"],
+    });
+
+    const listed = (await connected.client.listTools()).tools.map((tool) => tool.name);
+    expect(listed).not.toContain("vendo_apps_pin");
+    expect(listed).not.toContain("host_admin");
+    expect(listed).toContain("vendo_make");
+    expect(listed).toContain("host_lookup");
+    await connected.client.close();
+  });
+
+  it("answers a call to a withheld tool with the same in-band not-found an unknown name gets", async () => {
+    const { harness, connected } = await open({
+      extraDescriptors: [
+        { name: "vendo_apps_pin", description: "Pin an app", inputSchema: { type: "object" }, risk: "write" as const },
+      ],
+      withholdTools: ["vendo_apps_pin"],
+    });
+
+    const before = harness.executions.length;
+    const refused = await connected.client.callTool({ name: "vendo_apps_pin", arguments: {} });
+    expect(refused).toMatchObject({
+      isError: true,
+      content: [{ type: "text", text: expect.stringContaining("not-found") }],
+    });
+    // Not offered means not callable: the tool never ran.
+    expect(harness.executions.length).toBe(before);
+    await connected.client.close();
+  });
+
+  it("withholds an apps ride-along by name, so the apps path is not a way around it", async () => {
+    const { connected } = await open({
+      withholdTools: ["vendo_apps_call"],
+      apps: {
+        async list() { return []; },
+        async open() { return { kind: "tree" as const, payload: { formatVersion: "vendo-genui/v2", root: "root", nodes: [] } }; },
+        async call() { return {}; },
+      },
+    });
+
+    const listed = (await connected.client.listTools()).tools.map((tool) => tool.name);
+    expect(listed).toContain("vendo_apps_list");
+    expect(listed).toContain("vendo_apps_open");
+    expect(listed).not.toContain("vendo_apps_call");
+    const refused = await connected.client.callTool({ name: "vendo_apps_call", arguments: {} });
+    expect(refused).toMatchObject({ isError: true });
+    await connected.client.close();
+  });
 });
 
 /**
@@ -2691,6 +2751,8 @@ function hugeProperties(): Record<string, unknown> {
 interface HarnessOptions {
   store?: MemoryStore;
   menuTools?: string[] | (() => string[] | undefined | Promise<string[] | undefined>);
+  /** 10-mcp — names this door never offers, whatever the menu says. */
+  withholdTools?: string[];
   productName?: string;
   state?: McpDoorState;
   /** The call is passed so one harness can answer several tools differently. */
@@ -2755,6 +2817,7 @@ function makeHarness(options: HarnessOptions = {}) {
     store,
     apps: options.apps,
     ...(options.menuTools === undefined ? {} : { menuTools: options.menuTools }),
+    ...(options.withholdTools === undefined ? {} : { withholdTools: options.withholdTools }),
     ...(options.productName === undefined ? {} : { productName: options.productName }),
     ...(options.mount === undefined ? {} : { mount: options.mount }),
     ...(options.baseUrl === undefined ? {} : { baseUrl: options.baseUrl }),

--- a/packages/mcp/src/door.ts
+++ b/packages/mcp/src/door.ts
@@ -175,6 +175,25 @@ export interface McpDoorConfig {
    */
   menuTools?: string[] | (() => string[] | undefined | Promise<string[] | undefined>);
   /**
+   * Names this door NEVER offers, whatever else says otherwise.
+   *
+   * The MENU curates the host's API and deliberately cannot touch Vendo's own
+   * `vendo_*` plumbing. This is the other decision: what THIS door, as deployed,
+   * does not do. It is checked BEFORE the prefix bypass, so a deployment can
+   * hold back a runtime tool (the placement pair, for a door whose client has no
+   * page to place anything on) without inventing a second menu.
+   *
+   * Same posture as the menu: curation, not security. A withheld name is neither
+   * listed nor callable, and the refusal is the SAME in-band not-found an
+   * unknown name gets — it leaks nothing and grants nothing. The guard, not this
+   * list, is what stops a call that IS offered.
+   *
+   * A plain list rather than a provider: unlike the menu (which is read from a
+   * file that changes under a running process), this is authored in composition
+   * and cannot change without one.
+   */
+  withholdTools?: string[];
+  /**
    * The product name shown to PEOPLE (the connect page) and advertised on the
    * server card. Wins over the `package.json` name the door otherwise reads,
    * which is a package id and is often not what the product is called. Set it
@@ -242,6 +261,9 @@ export function createMcpDoorWithState(config: McpDoorConfig, state: McpDoorStat
 
 class Door {
   readonly #config: McpDoorConfig;
+  /** {@link McpDoorConfig.withholdTools}, resolved once — config is fixed at
+   *  construction, so unlike the menu there is nothing to re-read. */
+  readonly #withheld: ReadonlySet<string>;
   /** The OUTSIDE credential space, as this door holds it: the protocol server
    *  and the host's own adapter, present or absent TOGETHER. Both are undefined
    *  on an `internal` door — which is the whole of what "internal" means, and
@@ -269,6 +291,7 @@ class Door {
   constructor(config: McpDoorConfig, state: McpDoorState) {
     this.#config = config;
     this.#state = state;
+    this.#withheld = new Set(config.withholdTools ?? []);
     // `internal` WINS, and it wins here rather than at each route, so there is
     // exactly one place that can decide whether an outside space exists. An
     // adapter passed alongside it is dropped rather than rejected: the flag is
@@ -764,7 +787,7 @@ class Door {
     // `mcpContext` hardcodes `presence: "present"` and is a hole the moment any
     // context here can say otherwise. Not projected has to mean not projected.
     const descriptors = (await this.#config.tools.descriptors(state.context))
-      .filter((descriptor) => offeredAtDoor(menu, descriptor.name));
+      .filter((descriptor) => offeredAtDoor(menu, descriptor.name, this.#withheld));
     const appsConfigured = this.#config.apps !== undefined;
     const compiles = wireSchemaCompiler();
     // The bound registry's descriptors are served VERBATIM — name, description,
@@ -797,7 +820,7 @@ class Door {
     // verbatim descriptor (with door `_meta` attached above) and is not duplicated.
     if (appsConfigured) {
       const taken = new Set(tools.map((tool) => tool.name));
-      tools.push(...appTools().filter((tool) => !taken.has(tool.name)));
+      tools.push(...appTools().filter((tool) => !taken.has(tool.name) && !this.#withheld.has(tool.name)));
     }
     return tools;
   }
@@ -822,8 +845,12 @@ class Door {
     // An off-menu name answers exactly like a name that does not exist: the
     // menu decides what this door OFFERS, and offering nothing is the whole
     // refusal (the guard, not the menu, is what stops a call that IS offered).
-    if (!offeredAtDoor(await this.#menu(), name) || !descriptors.some((descriptor) => descriptor.name === name)) {
-      if (this.#config.apps !== undefined && APP_TOOL_NAMES.has(name)) {
+    if (!offeredAtDoor(await this.#menu(), name, this.#withheld)
+      || !descriptors.some((descriptor) => descriptor.name === name)) {
+      // The apps ride-along path answers names the registry does not own, so it
+      // has to honour the same withholding — otherwise a withheld viewer name
+      // would be invisible on the listing and callable anyway.
+      if (this.#config.apps !== undefined && APP_TOOL_NAMES.has(name) && !this.#withheld.has(name)) {
         return this.#callAppsTool(name, args, state, identity);
       }
       return inBandError(`not-found: Tool ${name} was not found`);
@@ -1251,8 +1278,13 @@ const VENDO_RESULT_PREFIX = "vendo_";
 const VENDO_RESULT_VALUE = `${VENDO_RESULT_PREFIX}value`;
 
 /** Whether a curated door offers `name`. Asked by BOTH the listing and the call
- *  path, so a curated door cannot advertise one surface and answer to another. */
-function offeredAtDoor(menu: Set<string> | undefined, name: string): boolean {
+ *  path, so a curated door cannot advertise one surface and answer to another.
+ *
+ *  `withheld` is checked FIRST, ahead of the `vendo_` bypass: the bypass exists
+ *  so a HOST's menu cannot delete Vendo's plumbing, while the withhold list is
+ *  the deployment's own decision about its own door. */
+function offeredAtDoor(menu: Set<string> | undefined, name: string, withheld: ReadonlySet<string>): boolean {
+  if (withheld.has(name)) return false;
   return menu === undefined || name.startsWith(VENDO_TOOL_PREFIX) || menu.has(name);
 }
 

--- a/packages/vendo/src/default-composition.test.ts
+++ b/packages/vendo/src/default-composition.test.ts
@@ -32,7 +32,9 @@ const DEFAULT_TOOL_NAMES = [
   "vendo_apps_data_list",
   "vendo_apps_data_put",
   "vendo_apps_open",
+  "vendo_apps_pin",
   "vendo_apps_rebase_pin",
+  "vendo_apps_unpin",
   "vendo_make",
 ] as const;
 

--- a/packages/vendo/src/mcp-door-outside-agent.e2e.test.ts
+++ b/packages/vendo/src/mcp-door-outside-agent.e2e.test.ts
@@ -81,7 +81,9 @@ describe("the MCP door, as an OUTSIDE agent sees it — pinned before door-ctx",
       "vendo_apps_data_put",
       "vendo_apps_list",
       "vendo_apps_open",
+      "vendo_apps_pin",
       "vendo_apps_rebase_pin",
+      "vendo_apps_unpin",
       // The one-tool contract's whole point for MCP: an outside agent asks for a
       // screen through `vendo_make` and never has to decide "new or change?"
       // first. Losing it from this list is losing the front door.

--- a/packages/vendo/src/placement-tools.e2e.test.ts
+++ b/packages/vendo/src/placement-tools.e2e.test.ts
@@ -1,0 +1,173 @@
+/**
+ * PLACEMENT, through the doors a real caller actually uses.
+ *
+ * Every assertion here crosses a seam that a stub could hide:
+ *  - the WRITE goes in over the real MCP door (register → authorize → token →
+ *    JSON-RPC), through the real guard-bound registry and the real apps
+ *    contribution;
+ *  - the READ comes back out of the real store's `vendo_placements` rows.
+ *    Nothing in this file knows how a placement is stored, and nothing in the
+ *    apps runtime knows this file exists.
+ *  - the PROJECTION is measured on real turns — one attended, one unattended —
+ *    because the composed surface is declared STATICALLY
+ *    (`toolsFromRegistry(appsAgentTools, agentToolDescriptors)` in server.ts),
+ *    so the guard's projection is the only thing between an automation and a
+ *    tool.
+ *
+ * This host has no sandbox, so `vendo_make` here is always served by the
+ * ASSEMBLY engine. The escalated-builder half of `slot` is proved one layer
+ * down, in `packages/apps/src/agent-tools.test.ts`, where a fake box makes that
+ * route reachable.
+ */
+import {
+  VENDO_APPS_PIN_TOOL,
+  VENDO_APPS_UNPIN_TOOL,
+  VENDO_MAKE_TOOL,
+  makeReceiptSchema,
+  type ToolListing,
+} from "@vendoai/core";
+import { defineHarness } from "@vendoai/harnesses";
+import type { VendoStore } from "@vendoai/store";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  SUBJECT,
+  bearer,
+  openDoor,
+  principal,
+  runCleanups,
+  runHarnessTurn,
+  runUnattendedTurn,
+  screenModel,
+  tempStore,
+} from "./mcp-door.test-util.js";
+import { createVendo, type Vendo } from "./server.js";
+
+afterEach(runCleanups);
+
+/** A1 — placements are rows in the GENERIC records collection, keyed by refs. */
+const PLACEMENTS = "vendo_placements";
+
+interface PlacementRow {
+  slot: string;
+  appId: string;
+  placedBy: string;
+  placedAt: string;
+}
+
+const placementRows = async (store: VendoStore): Promise<PlacementRow[]> => {
+  const { records } = await store.records(PLACEMENTS).list({ refs: { subject: SUBJECT } });
+  return records.map((record) => record.data as unknown as PlacementRow);
+};
+
+interface Host {
+  vendo: Vendo;
+  store: VendoStore;
+  /** One entry per turn, in order: what `turn.tools.list()` offered it. */
+  listings: ToolListing[][];
+}
+
+/**
+ * The composed host. No `policy`, deliberately: the guard's default runs a
+ * write, so these tests measure PLACEMENT rather than the approval queue (the
+ * cautious preset's parking of writes is already proven in the door parity
+ * gate). `screenModel()` is what makes a `vendo_make` reach a real receipt
+ * instead of the no-screen failure path.
+ */
+async function host(): Promise<Host> {
+  const store = await tempStore();
+  const listings: ToolListing[][] = [];
+  const harness = defineHarness({
+    name: "placement-probe",
+    async *run(turn) {
+      listings.push(await turn.tools.list());
+      yield { type: "text", delta: "done" };
+    },
+  });
+  const vendo = createVendo({
+    model: screenModel(),
+    principal: async () => principal,
+    store,
+    harness: harness as never,
+    mcp: true,
+    oauth: {
+      async authorize() {
+        return { subject: SUBJECT };
+      },
+      async principal(subject) {
+        return { kind: "user", subject };
+      },
+    },
+  } as Parameters<typeof createVendo>[0]);
+  await store.ensureSchema();
+  return { vendo, store, listings };
+}
+
+describe("a slot-targeted make, over the MCP door", () => {
+  it("lands the app in the slot the caller aimed at, and the app it named is ready", async () => {
+    const { vendo, store } = await host();
+    const door = await openDoor(vendo, await bearer(vendo));
+
+    const answered = await door.callTool(VENDO_MAKE_TOOL, {
+      request: "my spending this month",
+      slot: "dashboard.hero",
+    });
+
+    expect(answered.isError).toBeFalsy();
+    const receipt = makeReceiptSchema.parse(JSON.parse(answered.text));
+    expect(receipt.status).toBe("ready");
+    const rows = await placementRows(store);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ slot: "dashboard.hero", appId: receipt.id });
+    // The row is written by the runtime as part of the make, so it carries its
+    // own provenance rather than being reconstructed by a reader.
+    expect(typeof rows[0]!.placedBy).toBe("string");
+    expect(Number.isFinite(Date.parse(rows[0]!.placedAt))).toBe(true);
+  });
+
+  it("leaves no placement when no slot was named", async () => {
+    const { vendo, store } = await host();
+    const door = await openDoor(vendo, await bearer(vendo));
+
+    const answered = await door.callTool(VENDO_MAKE_TOOL, { request: "my spending this month" });
+
+    expect(answered.isError).toBeFalsy();
+    expect(await placementRows(store)).toEqual([]);
+  });
+});
+
+describe("pin and unpin, over the MCP door", () => {
+  it("writes the row on pin and removes it on unpin", async () => {
+    const { vendo, store } = await host();
+    const door = await openDoor(vendo, await bearer(vendo));
+    const made = await door.callTool(VENDO_MAKE_TOOL, { request: "my spending this month" });
+    const { id } = makeReceiptSchema.parse(JSON.parse(made.text));
+
+    const pinned = await door.callTool(VENDO_APPS_PIN_TOOL, { app: id, slot: "sidebar.one" });
+    expect(pinned.isError).toBeFalsy();
+    expect(JSON.parse(pinned.text)).toEqual({ app: id, slot: "sidebar.one" });
+    expect(await placementRows(store)).toEqual([
+      expect.objectContaining({ slot: "sidebar.one", appId: id }),
+    ]);
+
+    const unpinned = await door.callTool(VENDO_APPS_UNPIN_TOOL, { app: id, slot: "sidebar.one" });
+    expect(unpinned.isError).toBeFalsy();
+    expect(await placementRows(store)).toEqual([]);
+  });
+});
+
+describe("THE LAW, for a tool whose whole effect is on a person's screen", () => {
+  it("offers the placement pair to a present person and withholds it from an unattended run", async () => {
+    const { vendo, listings } = await host();
+
+    await runHarnessTurn(vendo, "thr_present", "what can you do");
+    await runUnattendedTurn(vendo, "thr_away", "run the nightly job");
+
+    const [present, away] = listings.map((listed) => listed.map((tool) => tool.name));
+    expect(present).toContain(VENDO_APPS_PIN_TOOL);
+    expect(present).toContain(VENDO_APPS_UNPIN_TOOL);
+    expect(away).not.toContain(VENDO_APPS_PIN_TOOL);
+    expect(away).not.toContain(VENDO_APPS_UNPIN_TOOL);
+    // And the front door is untouched: an automation may still MAKE something.
+    expect(away).toContain(VENDO_MAKE_TOOL);
+  });
+});

--- a/packages/vendo/src/vendo-make.e2e.test.ts
+++ b/packages/vendo/src/vendo-make.e2e.test.ts
@@ -92,11 +92,11 @@ describe("vendo_make (contract §3.1)", () => {
     expect(make!.title).toBe(VENDO_TOOL_TITLES[VENDO_MAKE_TOOL]);
   });
 
-  it("takes exactly request, app and context — request required", async () => {
+  it("takes exactly request, app, context and slot — request required", async () => {
     let listed: ToolListing[] = [];
     await turn(async (tools) => { listed = await tools.list(); });
     const schema = listed.find((listing) => listing.name === VENDO_MAKE_TOOL)!.inputSchema!;
-    expect(Object.keys(schema["properties"] as object).sort()).toEqual(["app", "context", "request"]);
+    expect(Object.keys(schema["properties"] as object).sort()).toEqual(["app", "context", "request", "slot"]);
     expect(schema["required"]).toEqual(["request"]);
     // `additionalProperties: false` is what makes the three-param surface a
     // promise rather than a suggestion.


### PR DESCRIPTION
Second PR in the slots stack. **Base is `yousefh409/slots-placement-core` (PR1), not `main`.**

PR1 shipped the placement rows and the runtime verbs. This PR teaches every AGENT door to address a slot on the user's page.

## What's in it

**1. `vendo_make` grows one optional `slot`.** Honoured on BOTH engines the one front door routes to (#862 made `vendo_make` one engine with a routing seam behind it):

- **assembly** — `runtime.place({ app, slot })` the moment the stored row is confirmed. `place()` gates on the app record, and assembly is what writes that record, so this is the first instant the claim can legally be made.
- **escalated build** — `create({ slot })`, which claims at mint, so a build still running occupies the place the caller aimed at instead of appearing out of nowhere minutes later.

Threading `slot` into `create()` alone would have shipped a **dead feature** for the default path — assembly serves most asks and never calls `runtime.create`. Both engines are asserted, in `packages/apps/src/agent-tools.test.ts` and again over the real MCP door.

On a CHANGE (`app` present), `slot` is refused by name: silently moving an existing app would evict whatever holds that slot off the back of an edit nobody aimed there. The error names `vendo_apps_pin`.

**2. `vendo_apps_pin` / `vendo_apps_unpin`.** Put an app the user already has into a slot and take it back out. Aimed by the app's id OR the name the user said, like every other door in this registry. Pin reports what it replaced as `evicted`. Risk `write` — a placement row is small and reversible.

Neither is offered to an unattended run. `PRESENCE_ONLY_TOOLS` (core) joins THE LAW's projection in `projectableForRun`: a tool whose whole effect is on a person's screen has nothing to act on when nobody is looking, and rearranging a dashboard someone comes back to is a change they never saw being made. **Keyed on the NAME, not the grade** — grading them `destructive` to buy the withholding would lie to every other reader of the label (policy rules, consent card, automations planner).

**3. `McpDoorConfig.withholdTools`.** Names one door never offers, checked **before** the `vendo_` prefix bypass. The bypass exists so a HOST's curated menu cannot delete Vendo's own plumbing; this is the deployment's own decision about its own door. Listing, call path, and the apps ride-along path all read the one set, so a withheld name cannot be invisible and callable. Curation, not security: a withheld name answers with the same in-band not-found an unknown name gets.

## Pinned surfaces that moved

Three existing test files pin surfaces this PR adds to, and moved for that reason only:

- `packages/vendo/src/mcp-door-outside-agent.e2e.test.ts` — the sorted set an outside agent sees gains `vendo_apps_pin` / `vendo_apps_unpin`
- `packages/vendo/src/default-composition.test.ts` — `DEFAULT_TOOL_NAMES` gains the same two
- `packages/vendo/src/vendo-make.e2e.test.ts` — the `vendo_make` schema pin gains `slot`

## Proof

`packages/vendo/src/placement-tools.e2e.test.ts` is new and crosses the seam in both directions with no stub on either side: the write goes in over the real MCP door (register to authorize to token to JSON-RPC) through the real guard-bound registry; the read comes back out of the real store's `vendo_placements` rows. The projection is measured on two real turns, present and away.

Three revert-and-watch runs, each confirming the test fails for the right reason and only that reason:

| Reverted | Went red | Message |
| --- | --- | --- |
| `...(slot === undefined ? {} : { slot })` on the escalated `create` | only the ESCALATED unit test | `expected [] to deeply equal [ ObjectContaining{...} ]` |
| `runtime.place(...)` on the assembled branch | only the slot-targeted e2e | `expected [] to have a length of 1` |
| `!PRESENCE_ONLY_TOOLS.has(name)` in the projection | only THE LAW e2e | `expected [ ..., 'vendo_apps_pin', ... ] not to contain 'vendo_apps_pin'` |

## Two contradictions found during recon

1. **"withheld via the existing projection" + "risk `write`" cannot both be true without a name-keyed rule.** `projectableForRun` withholds on `risk === "destructive" | "ungraded"` only, so a `write` is projected into every unattended run. A ctx-aware `descriptors(ctx)` would be dead on the composed path — packs are gone (#848) and the apps surface is a static capability contribution (`toolsFromRegistry(...)` in `server.ts`), while the actions registry's `descriptors()` takes no ctx at all. Hence `PRESENCE_ONLY_TOOLS` inside `projectableForRun`: same mechanism, second predicate, keyed on name.

2. **B1's "claim at mint" no longer covers the engine that serves most asks, so the row is written per engine.** PR1's mint-time claim lives inside `create({ slot })`, and `place()` gates on the app record, which does not exist at mint — so nothing PR1 ships can claim a slot at the mint line. **The cost:** a slot-targeted make whose ASSEMBLY fails leaves the slot untouched instead of showing the failure there (the builder path is unaffected — it still shows `building`, then `failed`). Honouring B1's letter on both engines would need PR1 to expose its mint-time claim as a runtime verb, which is a PR1 contract change, not this PR's to invent. Flagging rather than improvising.

## Gate

`pnpm build`, `pnpm typecheck`, `pnpm lint` — all green.

`pnpm test:affected` — green except three **pre-existing** failure groups, none of them touched by this PR:

- `packages/vendo/src/dev-creds/model.test.ts` (2 cases) — the known red on clean `main`, same as PR1 (#889).
- `packages/core/src/packaging.e2e.test.ts` (3 cases) — verified pre-existing by stashing this branch's changes and re-running on the untouched base.
- `packages/store/src/durability.drill.test.ts` + `split-brain.drill.test.ts` (2 cases) — `packages/store` is untouched by this PR (`git diff --stat base..HEAD -- packages/store` is empty). Root cause is `new URL(...).pathname` keeping percent-encoding, so a checkout path containing a space spawns `.../Cool%20Code/.../drill-writer.mjs` and Node cannot resolve it. An artifact of the worktree this ran in, not of the change; left alone under the scope fence.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Agents can now place apps in specific page slots. `vendo_make` accepts a slot, new pin/unpin tools move existing apps, and `withholdTools` lets deployments hide tools; presence rules keep page-only actions out of unattended runs.

- New Features
  - `@vendoai/apps`: `vendo_make` adds optional `slot`. Assembly places on row confirm; escalated builds claim at mint. Refused on edits that pass `app`.
  - `@vendoai/apps`: `vendo_apps_pin` and `vendo_apps_unpin` to place/remove existing apps by id or exact name; pin returns `evicted`. Risk `write`.
  - `@vendoai/core`: `PRESENCE_ONLY_TOOLS` keeps `vendo_apps_pin`/`vendo_apps_unpin` off unattended runs (keyed by name, not grade).
  - `@vendoai/mcp`: `McpDoorConfig.withholdTools` to never offer named tools, checked before the `vendo_` prefix bypass; listing, calls, and apps ride-along all honor it.

- Migration
  - No breaking changes; `slot` is optional.
  - For doors without a page UI, set `withholdTools` to include `vendo_apps_pin` and `vendo_apps_unpin`.

<sup>Written for commit c0277018cb7d91c03dfb5a1d42818ded668f94f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

