### PR TITLE
feat(harnesses): the loop knows the model's window, and counts the tools block

### DIFF
--- a/packages/harnesses/src/vendo/ask-user-stop.test.ts
+++ b/packages/harnesses/src/vendo/ask-user-stop.test.ts
@@ -18,6 +18,7 @@
 import { ASK_USER_TOOL, type Json, type ToolOutcome, type ToolRegistry, type Turn } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
 import { vendo } from "./vendo.js";
+import { createTurnState } from "../harness-state.js";
 import { createTurnTools } from "../turn-tools.js";
 import {
   ctx,
@@ -52,7 +53,7 @@ async function askAndCount(outcome: ToolOutcome): Promise<number> {
     skills: testSkills(),
     workspace: testWorkspace(),
     models: seats(model),
-    state: { get: () => undefined, set: () => undefined, clear: () => undefined },
+    state: createTurnState(undefined),
     options: {},
     signal: new AbortController().signal,
     interactive: true,

--- a/packages/harnesses/src/vendo/compaction-state.test.ts
+++ b/packages/harnesses/src/vendo/compaction-state.test.ts
@@ -1,0 +1,60 @@
+/**
+ * The compaction state codec — what a thread remembers between turns.
+ *
+ * The slot is `turn.state` (build contract §1.3): ONE opaque string per thread,
+ * written at turn end and handed back on the next turn. Opaque means the codec is
+ * the only thing standing between a stored string and the loop's assumptions, and
+ * the string can be older than this build: a slot written by a future version, or
+ * by a different harness, or truncated by a store that lost half a row. Every one
+ * of those reads as "no state" rather than as a shape the loop then trusts —
+ * losing the state costs one un-compacted turn, and trusting a bad one costs a
+ * prompt nobody can predict.
+ */
+import { describe, expect, it } from "vitest";
+import { readCompactionState, writeCompactionState, type CompactionState } from "./compaction.js";
+
+describe("the compaction state codec", () => {
+  it("round-trips everything the slot carries", () => {
+    const state: CompactionState = {
+      version: 1,
+      summary: "The user is reconciling January.",
+      coveredThroughMessageId: "m_42",
+      lastPromptTokens: 91_284,
+    };
+    expect(readCompactionState(writeCompactionState(state))).toEqual(state);
+  });
+
+  it("round-trips a slot carrying only what S2 writes", () => {
+    // The summary arrives with the summarizer; until then the slot is the
+    // provider's last prompt count and nothing else, and that must survive on
+    // its own rather than needing the fields around it.
+    const state: CompactionState = { version: 1, lastPromptTokens: 91_284 };
+    expect(readCompactionState(writeCompactionState(state))).toEqual(state);
+  });
+
+  it("discards an UNKNOWN version rather than guessing at its shape", () => {
+    expect(readCompactionState(JSON.stringify({ version: 2, summary: "from the future" }))).toBeUndefined();
+    expect(readCompactionState(JSON.stringify({ summary: "from before versions" }))).toBeUndefined();
+  });
+
+  it("discards an UNREADABLE string", () => {
+    // A foreign harness's session id, a truncated row, a store that handed back
+    // half a value: none of them is a compaction state, and none may throw.
+    expect(readCompactionState("sess_01HZY3")).toBeUndefined();
+    expect(readCompactionState("{\"version\":1")).toBeUndefined();
+    expect(readCompactionState("[1,2,3]")).toBeUndefined();
+    expect(readCompactionState("null")).toBeUndefined();
+  });
+
+  it("reads an EMPTY slot as no state", () => {
+    expect(readCompactionState(undefined)).toBeUndefined();
+    expect(readCompactionState("")).toBeUndefined();
+  });
+
+  it("drops fields of the wrong type instead of handing them on", () => {
+    // A number where a string belongs is the same class of problem as an
+    // unreadable slot, but only for that one field — the rest still works.
+    const slot = JSON.stringify({ version: 1, summary: 7, coveredThroughMessageId: [], lastPromptTokens: "big" });
+    expect(readCompactionState(slot)).toEqual({ version: 1 });
+  });
+});

--- a/packages/harnesses/src/vendo/compaction-trigger.test.ts
+++ b/packages/harnesses/src/vendo/compaction-trigger.test.ts
@@ -1,0 +1,203 @@
+/**
+ * How big the loop thinks its own prompt is, and when that is too big.
+ *
+ * Three claims, each of which the loop got wrong before this slice:
+ *
+ * 1. **The tools block counts.** A deployment's toolset is sent in FULL on every
+ *    step — names, descriptions and JSON schemas — and on a curated surface it is
+ *    routinely tens of thousands of tokens. An estimate over the messages alone
+ *    is not an estimate of the prompt; it is an estimate of part of it, and the
+ *    part it omits does not shrink.
+ * 2. **The provider's own number beats a guess about the same tokens.** Every
+ *    turn ends with a `finish-step` carrying `usage.inputTokens` for the whole
+ *    prompt. Re-guessing that prefix at four characters per token throws away a
+ *    measurement we already paid for; the guess is for the DELTA only.
+ * 3. **The trip is at 81%, not at 100%.** A trigger that fires when the window is
+ *    full has already lost — the turn that discovers it is the turn that 400s.
+ *
+ * The interim floor is asserted here too, and it is deliberately shallow: with no
+ * summarizer yet, a trip sheds to `contextWindowTokens × triggerRatio`. That
+ * budget bounds the MESSAGES, so a trip caused by the tools block alone sheds
+ * nothing — the tools are not sheddable and the floor does not pretend otherwise.
+ * S3 replaces the trip with a summarizer and demotes this to an emergency floor.
+ */
+import { jsonSchema, tool, type ModelMessage, type ToolSet, type UIMessage } from "ai";
+import { describe, expect, it } from "vitest";
+import {
+  estimatePromptTokens,
+  shouldCompact,
+  PRESERVE_RECENT_TOKENS,
+  TRIGGER_RATIO,
+} from "./compaction.js";
+import { turnModelMessages } from "./loop.js";
+
+const message = (role: "user" | "assistant", text: string): ModelMessage =>
+  ({ role, content: [{ type: "text", text }] }) as ModelMessage;
+
+/** A toolset whose SCHEMAS are the bulk, as a real curated surface's are. */
+const fatTools = (): ToolSet => ({
+  maple_listTransactions: tool({
+    description: `List transactions. ${"d".repeat(20_000)}`,
+    inputSchema: jsonSchema({
+      type: "object",
+      properties: { account: { type: "string", description: "x".repeat(20_000) } },
+      additionalProperties: false,
+    } as never),
+    execute: async () => ({}),
+  }),
+});
+
+describe("the prompt estimate", () => {
+  it("COUNTS THE TOOLS BLOCK — the same messages cost more with tools attached", () => {
+    const messages = [message("user", "how much did I spend?")];
+    const bare = estimatePromptTokens({ system: "system", messages, tools: {} });
+    const equipped = estimatePromptTokens({ system: "system", messages, tools: fatTools() });
+    // Not "a bit more": the block is ~40k characters, so it is worth ~10k tokens
+    // and it is sent on every step of every turn.
+    expect(equipped - bare).toBeGreaterThan(9_000);
+  });
+
+  it("counts the SYSTEM prompt, which is also part of the same window", () => {
+    const messages = [message("user", "hi")];
+    const short = estimatePromptTokens({ system: "system", messages, tools: {} });
+    const long = estimatePromptTokens({ system: "s".repeat(40_000), messages, tools: {} });
+    expect(long - short).toBeGreaterThan(9_000);
+  });
+
+  it("uses the PROVIDER's number for the prefix it covers, not a guess", () => {
+    // A prefix nobody needs to guess at: 400k characters the provider already
+    // priced at 50k tokens. Re-estimating it would report ~100k.
+    const covered = [message("user", "a".repeat(200_000)), message("assistant", "b".repeat(200_000))];
+    const messages = [...covered, message("user", "and now the newest ask")];
+    const guessed = estimatePromptTokens({ system: "system", messages, tools: {} });
+    const measured = estimatePromptTokens({
+      system: "system",
+      messages,
+      tools: {},
+      lastPromptTokens: 50_000,
+      reportedThrough: covered.length,
+    });
+    expect(guessed).toBeGreaterThan(90_000);
+    expect(measured).toBeLessThan(51_000);
+    expect(measured).toBeGreaterThan(50_000);
+  });
+
+  it("guesses the DELTA the provider has not seen, rather than ignoring it", () => {
+    const covered = [message("user", "old")];
+    const tail = message("user", "n".repeat(8_000));
+    const measured = estimatePromptTokens({
+      system: "system",
+      messages: [...covered, tail],
+      tools: {},
+      lastPromptTokens: 50_000,
+      reportedThrough: covered.length,
+    });
+    // ~8k characters of new text is ~2k tokens at four characters each.
+    expect(measured - 50_000).toBeGreaterThan(1_800);
+    expect(measured - 50_000).toBeLessThan(2_400);
+  });
+
+  it("is exactly the provider's number when nothing has been added since", () => {
+    const messages = [message("user", "old"), message("assistant", "older")];
+    expect(estimatePromptTokens({
+      system: "system",
+      messages,
+      tools: {},
+      lastPromptTokens: 50_000,
+      reportedThrough: messages.length,
+    })).toBe(50_000);
+  });
+
+  it("falls back to the whole-prompt guess when no turn has reported yet", () => {
+    // The first turn of a thread has no provider number at all.
+    const messages = [message("user", "a".repeat(40_000))];
+    const first = estimatePromptTokens({ system: "system", messages, tools: {} });
+    expect(first).toBeGreaterThan(9_000);
+  });
+});
+
+describe("the trigger", () => {
+  it("carries the ported cline ratios", () => {
+    expect(TRIGGER_RATIO).toBe(0.81);
+    expect(PRESERVE_RECENT_TOKENS).toBe(20_000);
+  });
+
+  it("trips at 81% of the window — NOT at 80%", () => {
+    const config = { contextWindowTokens: 100_000 };
+    expect(shouldCompact(81_000, config)).toBe(true);
+    expect(shouldCompact(80_999, config)).toBe(false);
+    expect(shouldCompact(80_000, config)).toBe(false);
+  });
+
+  it("lets a host move the ratio without moving the window", () => {
+    expect(shouldCompact(50_000, { contextWindowTokens: 100_000, triggerRatio: 0.5 })).toBe(true);
+    expect(shouldCompact(50_000, { contextWindowTokens: 100_000 })).toBe(false);
+  });
+});
+
+/** A thread whose messages alone are worth roughly 10k tokens. */
+const thread = (): UIMessage[] => [
+  { id: "m1", role: "user", parts: [{ type: "text", text: `OLDEST ${"o".repeat(20_000)}` }] },
+  { id: "m2", role: "assistant", parts: [{ type: "text", text: "a".repeat(20_000) }] },
+  { id: "m3", role: "user", parts: [{ type: "text", text: "NEWEST" }] },
+];
+
+const wire = (messages: ModelMessage[]): string => JSON.stringify(messages);
+
+describe("the loop's interim floor", () => {
+  it("sheds to the window when the estimate trips", async () => {
+    const { messages } = await turnModelMessages({
+      messages: thread(),
+      system: "system",
+      tools: {},
+      compaction: { model: "probe-model", contextWindowTokens: 2_000 },
+    });
+    // 0.81 × 2_000 = 1_620 tokens: the oldest goes, the ask never does.
+    expect(wire(messages)).not.toContain("OLDEST");
+    expect(wire(messages)).toContain("NEWEST");
+  });
+
+  it("leaves a turn UNDER the trigger byte-for-byte alone", async () => {
+    const roomy = await turnModelMessages({
+      messages: thread(),
+      system: "system",
+      tools: {},
+      compaction: { model: "probe-model", contextWindowTokens: 1_000_000 },
+    });
+    const untriggered = await turnModelMessages({ messages: thread(), system: "system" });
+    expect(wire(roomy.messages)).toBe(wire(untriggered.messages));
+  });
+
+  it("still slices `historyWindow` FIRST, then estimates what is left", async () => {
+    // Q2b: the host's explicit slice is not advice. A window of 1 leaves one
+    // short message, which is nowhere near the trigger — so a trigger that ran
+    // on the unsliced thread would shed a prompt that never needed it.
+    const { messages } = await turnModelMessages({
+      messages: thread(),
+      system: "system",
+      tools: {},
+      historyWindow: 1,
+      compaction: { model: "probe-model", contextWindowTokens: 2_000 },
+    });
+    expect(wire(messages)).toContain("NEWEST");
+    expect(wire(messages)).not.toContain("OLDEST");
+    expect(messages.filter((entry) => entry.role !== "system").length).toBe(1);
+  });
+
+  it("uses the state's provider number instead of re-guessing the prefix", async () => {
+    // Same thread, same window, one difference: the previous turn reported that
+    // this prompt cost 100 tokens. The guess says ~10k and would shed; the
+    // measurement says it fits, and the measurement is what the provider billed.
+    const { messages } = await turnModelMessages({
+      messages: thread(),
+      system: "system",
+      tools: {},
+      compaction: {
+        model: "probe-model",
+        contextWindowTokens: 2_000,
+        state: { version: 1, lastPromptTokens: 100 },
+      },
+    });
+    expect(wire(messages)).toContain("OLDEST");
+  });
+});

--- a/packages/harnesses/src/vendo/compaction.ts
+++ b/packages/harnesses/src/vendo/compaction.ts
@@ -1,0 +1,158 @@
+/**
+ * What a thread remembers about its own size, and when that size is a problem.
+ *
+ * Three small pieces, one job: keep a long conversation inside the model's window
+ * without anybody having to notice. The state codec is what survives between
+ * turns; the estimate is how big the loop believes this turn's prompt is; the
+ * trigger is the line it must not cross.
+ *
+ * The estimate is a HYBRID, and that is the whole idea. Every turn ends with the
+ * provider telling us exactly what the prompt cost (`finish-step`'s
+ * `usage.inputTokens`, cache reads included), so re-guessing that same prefix at
+ * four characters per token throws away a measurement already paid for. The guess
+ * is for the DELTA only — the messages the provider has not seen yet. Ported from
+ * pi-mono (`packages/agent/src/harness/compaction/compaction.ts`, MIT, Mario
+ * Zechner), whose estimator carries the reported count forward for exactly this
+ * reason.
+ *
+ * No tokenizer: a per-provider vocabulary is megabytes, is wrong for every model
+ * it was not built for, and would have to load before the first turn. Four
+ * characters per token is within a few percent of every BPE tokenizer on English
+ * prose and JSON, and the trigger sits at 81% precisely so an estimate can be a
+ * few percent wrong without costing anyone a turn.
+ */
+import { asSchema, type ModelMessage, type ToolSet } from "ai";
+
+export interface CompactionState {
+  version: 1;
+  summary?: string;
+  /** `id` of the newest transcript message the summary covers. */
+  coveredThroughMessageId?: string;
+  /** Provider-reported prompt tokens on the LAST step of the turn that wrote this. */
+  lastPromptTokens?: number;
+}
+
+/**
+ * Decode the thread's slot.
+ *
+ * The slot is opaque by contract (`turn.state`, build contract §1.3) and can hold
+ * anything: a string written by a future version of this file, a foreign
+ * harness's native session id, half a row a store lost. Every one of those reads
+ * as "no state" rather than as a shape the loop then trusts — losing the state
+ * costs one un-compacted turn, and trusting a bad one costs a prompt nobody can
+ * predict.
+ */
+export function readCompactionState(slot: string | undefined): CompactionState | undefined {
+  if (slot === undefined || slot === "") return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(slot);
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return undefined;
+  const raw = parsed as Record<string, unknown>;
+  // An unknown version is a shape this build has never seen. There is nothing to
+  // migrate from and nothing to guess at.
+  if (raw["version"] !== 1) return undefined;
+  const summary = raw["summary"];
+  const covered = raw["coveredThroughMessageId"];
+  const lastPromptTokens = raw["lastPromptTokens"];
+  return {
+    version: 1,
+    ...(typeof summary === "string" ? { summary } : {}),
+    ...(typeof covered === "string" ? { coveredThroughMessageId: covered } : {}),
+    ...(typeof lastPromptTokens === "number" ? { lastPromptTokens } : {}),
+  };
+}
+
+export function writeCompactionState(state: CompactionState): string {
+  return JSON.stringify(state);
+}
+
+/**
+ * Ported from cline `sdk/packages/core/src/extensions/context/compaction-shared.ts:15,17`
+ * (Apache-2.0): `CONTEXT_WINDOW_INPUT_RATIO = 0.9` × `COMPACTION_TRIGGER_RATIO = 0.9`.
+ *
+ * Two multiplied margins, and both are load-bearing. The first keeps the ANSWER's
+ * room: a prompt that fills the window leaves nowhere for the model to reply. The
+ * second is the compaction headroom: the summarizer pass itself is a call against
+ * the same window, so a trigger that waits for the window to be full has already
+ * lost — the turn that discovers the problem is the turn that 400s.
+ */
+export const TRIGGER_RATIO = 0.81;
+
+/**
+ * Ported from cline `sdk/packages/core/src/extensions/context/compaction-shared.ts:19`
+ * (Apache-2.0): the verbatim tail a compaction always preserves.
+ *
+ * Declared here with the ratio it belongs beside; the cut point that reads it
+ * arrives with the summarizer.
+ */
+export const PRESERVE_RECENT_TOKENS = 20_000;
+
+/** The ceiling on one summarizer pass. Declared here, read by the summarizer. */
+export const SUMMARY_MAX_OUTPUT_TOKENS = 2_000;
+
+export interface CompactionConfig {
+  contextWindowTokens: number;
+  triggerRatio?: number;
+  preserveRecentTokens?: number;
+}
+
+/** Prompt tokens per character — see the file header for why this is an estimate
+ *  and not a tokenizer. The shed keeps its own copy (`loop.ts`'s
+ *  `CHARS_PER_TOKEN`) because it measures a different thing: the messages it may
+ *  drop, never the system prompt or the tools block it cannot. */
+const CHARS_PER_TOKEN = 4;
+
+const tokensFor = (chars: number): number => Math.ceil(chars / CHARS_PER_TOKEN);
+
+const messageChars = (messages: readonly ModelMessage[]): number =>
+  messages.reduce((chars, message) => chars + JSON.stringify(message).length, 0);
+
+/**
+ * The tools block, counted.
+ *
+ * Ported from cline `compaction.ts:300-304` (Apache-2.0), which counts the tool
+ * definitions into the same estimate as the messages. It is not a rounding error:
+ * a curated deployment sends every equipped tool's name, description and JSON
+ * schema on EVERY step, routinely tens of thousands of tokens, and unlike the
+ * messages it never shrinks. An estimate that omits it is an estimate of part of
+ * the prompt.
+ */
+function toolsBlockChars(tools: ToolSet): number {
+  return Object.entries(tools).reduce((chars, [name, entry]) => {
+    // A schema built lazily resolves to a promise, which stringifies to `{}` —
+    // an undercount for a shape the provider has not been handed either.
+    const inputSchema = asSchema(entry.inputSchema as never).jsonSchema;
+    return chars + JSON.stringify({ name, description: entry.description, inputSchema }).length;
+  }, 0);
+}
+
+export function estimatePromptTokens(input: {
+  system: string;
+  messages: readonly ModelMessage[];
+  tools: ToolSet;
+  lastPromptTokens?: number;
+  /** How many of `messages` that number already covers. */
+  reportedThrough?: number;
+}): number {
+  const { system, messages, tools, lastPromptTokens, reportedThrough } = input;
+  if (lastPromptTokens === undefined) {
+    return tokensFor(system.length + messageChars(messages) + toolsBlockChars(tools));
+  }
+  // The provider's number already covers the system prompt and the tools block
+  // it was sent with, so only the messages it has not seen are added to it.
+  const covered = Math.min(Math.max(reportedThrough ?? 0, 0), messages.length);
+  return lastPromptTokens + tokensFor(messageChars(messages.slice(covered)));
+}
+
+/** The estimate at which a turn must act. */
+export function triggerTokens(config: CompactionConfig): number {
+  return Math.floor(config.contextWindowTokens * (config.triggerRatio ?? TRIGGER_RATIO));
+}
+
+export function shouldCompact(promptTokens: number, config: CompactionConfig): boolean {
+  return promptTokens >= triggerTokens(config);
+}

--- a/packages/harnesses/src/vendo/index.ts
+++ b/packages/harnesses/src/vendo/index.ts
@@ -19,7 +19,24 @@ export {
   type TurnContext,
   type TurnLoop,
   type TurnLoopOptions,
+  type TurnCompaction,
   type TurnPrompt,
   type TurnPromptInput,
 } from "./loop.js";
+// The window table and its BYO override — the one new public knob of the
+// context shipment, and the only part of it a host is ever meant to touch.
+export {
+  contextWindowTokens,
+  DEFAULT_CONTEXT_WINDOW_TOKENS,
+  MODEL_CONTEXT_WINDOWS,
+} from "./model-windows.js";
+// The state codec, because the slot it decodes is the HOST's row: anyone reading
+// `harnessStateStore` directly needs the same reader the loop uses, or the two
+// disagree about a shape only one of them ships.
+export {
+  readCompactionState,
+  writeCompactionState,
+  type CompactionConfig,
+  type CompactionState,
+} from "./compaction.js";
 export { failoverModel, type ResolvedModel } from "./failover.js";

--- a/packages/harnesses/src/vendo/loop.ts
+++ b/packages/harnesses/src/vendo/loop.ts
@@ -33,6 +33,13 @@ import {
   type ToolSet,
   type UIMessage,
 } from "ai";
+import {
+  estimatePromptTokens,
+  shouldCompact,
+  triggerTokens,
+  type CompactionConfig,
+  type CompactionState,
+} from "./compaction.js";
 import { failoverModel, type ResolvedModel } from "./failover.js";
 import type { ToolSearchSession } from "../tool-search.js";
 
@@ -228,6 +235,20 @@ function wellFormed(messages: readonly ModelMessage[]): ModelMessage[] {
 }
 
 /**
+ * What the loop is asked to do about a window it now knows the size of.
+ *
+ * `contextWindowTokens` and the two ratios come from {@link CompactionConfig};
+ * the rest is the turn's own: which seat summarizes, what the thread already
+ * remembers, and whether the caller is past asking.
+ */
+export interface TurnCompaction extends CompactionConfig {
+  model: LanguageModel;
+  state?: CompactionState;
+  /** Compact whatever the estimate says — the overflow retry's re-entry. */
+  force?: boolean;
+}
+
+/**
  * One turn's prompt inputs. This was four positionals; the shipment's window
  * table, compaction and overflow retry add three more, and a seventh positional
  * is unreadable at the call site — so the shape is declared once, whole, before
@@ -242,8 +263,7 @@ export interface TurnPromptInput {
   tools?: ToolSet;
   historyWindow?: number;
   tokenBudget?: number;
-  /** `TurnCompaction`, once it exists. */
-  compaction?: unknown;
+  compaction?: TurnCompaction;
   /** Model messages this turn ALREADY produced: appended after the projection
    *  and never summarized, so a retry CONTINUES the turn instead of re-running
    *  its tool calls — each one a real guarded effect. */
@@ -252,9 +272,26 @@ export interface TurnPromptInput {
 
 export interface TurnPrompt {
   messages: ModelMessage[];
-  /** `CompactionState`, once it exists — carried out as DATA, because the loop
-   *  does not know where the caller's state slot is. */
-  compacted?: unknown;
+  /** Carried out as DATA, because the loop does not know where the caller's
+   *  state slot is. Written by the summarizer. */
+  compacted?: CompactionState;
+}
+
+/**
+ * How much of a projection the provider's own count already covers.
+ *
+ * `lastPromptTokens` was measured on the LAST step of the previous turn, whose
+ * prompt ended with that turn's own assistant output and tool results. Everything
+ * up to the trailing run of user messages is therefore inside that number, and
+ * only this turn's fresh ask is not. Both directions of error are cheap and
+ * self-correcting: a previous turn that was itself windowed or shed reports a
+ * smaller number than its history really costs, which buys one late compaction —
+ * and the next turn's own report replaces the figure either way.
+ */
+function reportedThrough(messages: readonly ModelMessage[]): number {
+  let index = messages.length;
+  while (index > 0 && messages[index - 1]?.role === "user") index -= 1;
+  return index;
 }
 
 /**
@@ -262,10 +299,10 @@ export interface TurnPrompt {
  * and budgeted history, and the cache breakpoints that keep a growing thread from
  * re-billing.
  *
- * `tools`, `compaction` and `resume` are accepted and not yet read.
+ * `resume` is accepted and not yet read.
  */
 export async function turnModelMessages(input: TurnPromptInput): Promise<TurnPrompt> {
-  const { messages, system, historyWindow, tokenBudget } = input;
+  const { messages, system, historyWindow, tokenBudget, compaction } = input;
   // History windowing: bound what is re-sent per turn to the last N whole messages.
   // Slicing whole UIMessages keeps each turn's tool-call/result pairing intact.
   const history = historyWindow !== undefined && messages.length > historyWindow
@@ -277,6 +314,30 @@ export async function turnModelMessages(input: TurnPromptInput): Promise<TurnPro
   // bills, and it runs before the breakpoints below because shedding changes
   // which message is the stable prefix's last one.
   if (tokenBudget !== undefined) converted = shedToBudget(converted, system, tokenBudget);
+  // The window the model actually has, measured against the prompt this turn is
+  // actually sending — system, messages AND the tools block, which is the part
+  // no rail here has ever counted and the part that never shrinks. The host's
+  // own `historyWindow` slice is already applied above and is not negotiable
+  // (Q2b): what the host cut is gone, and this decides about what is left.
+  if (compaction !== undefined) {
+    const lastPromptTokens = compaction.state?.lastPromptTokens;
+    const promptTokens = estimatePromptTokens({
+      system,
+      messages: converted,
+      tools: input.tools ?? {},
+      ...(lastPromptTokens === undefined
+        ? {}
+        : { lastPromptTokens, reportedThrough: reportedThrough(converted) }),
+    });
+    // INTERIM, until the summarizer lands: a trip falls straight to the shed,
+    // which drops reasoning, then tool payloads, then the oldest messages, with
+    // no summary and no notice to the model. The budget bounds the MESSAGES, so
+    // a trip caused by the tools block alone sheds nothing — the tools are not
+    // sheddable, and the floor does not pretend otherwise.
+    if (shouldCompact(promptTokens, compaction)) {
+      converted = shedToBudget(converted, system, triggerTokens(compaction));
+    }
+  }
   // Whatever the window and the shed left behind, the prompt still has to be one
   // a provider will accept — and this is the last place that is knowable.
   converted = wellFormed(converted);
@@ -355,6 +416,12 @@ export interface TurnLoopOptions {
    *  stop mechanism beside this one. */
   stopWhen?: readonly StopCondition<ToolSet>[];
   toolSearch?: ToolSearchSession;
+  /** The window this turn has, and what the thread already remembers about
+   *  filling it. Unset means no window awareness at all — the loop's behaviour
+   *  before this shipment. */
+  compaction?: TurnCompaction;
+  /** Model messages this turn already produced, for a retry that continues it. */
+  resume?: readonly ModelMessage[];
 }
 
 /** The per-turn knobs, one shape both callers pass so neither can carry half of
@@ -383,6 +450,9 @@ export interface TurnLoop {
    * because of the cap, not because the model finished.
    */
   stepLimitPart(): Promise<VendoStepLimitPart | undefined>;
+  /** What this turn compacted, as DATA for whoever owns the state slot — the
+   *  loop does not know where that is. Written by the summarizer. */
+  compacted?: CompactionState;
 }
 
 /** The model `streamText` is handed: the one the caller named, or the ordered
@@ -403,8 +473,13 @@ export async function startTurn(options: TurnLoopOptions): Promise<TurnLoop> {
   const { messages: modelMessages } = await turnModelMessages({
     messages: options.messages,
     system: options.system,
+    // The live toolset, because the trigger has to count what the prompt
+    // actually carries and the tools block is most of it on a curated surface.
+    tools: options.tools,
     historyWindow: options.context?.historyWindow,
     tokenBudget: options.context?.contextTokenBudget,
+    ...(options.compaction === undefined ? {} : { compaction: options.compaction }),
+    ...(options.resume === undefined ? {} : { resume: options.resume }),
   });
   const { toolSearch } = options;
   const result = streamText({

--- a/packages/harnesses/src/vendo/model-windows.test.ts
+++ b/packages/harnesses/src/vendo/model-windows.test.ts
@@ -1,0 +1,63 @@
+/**
+ * How big the model's window is — the number every other part of this shipment
+ * measures against.
+ *
+ * The table is matched by SUBSTRING, longest first, because a model id does not
+ * arrive as a bare name. It arrives prefixed by a gateway and suffixed by a
+ * snapshot date (`us.anthropic.claude-sonnet-4-6-20260101`), so exact keys would
+ * miss every real id and the whole shipment would run on the default. The two
+ * failure directions are deliberately asymmetric: a model the table cannot name
+ * falls to a CONSERVATIVE default, because under-guessing costs one early
+ * compaction and over-guessing costs a 400 mid-turn.
+ */
+import type { LanguageModel } from "ai";
+import { describe, expect, it } from "vitest";
+import {
+  contextWindowTokens,
+  DEFAULT_CONTEXT_WINDOW_TOKENS,
+  MODEL_CONTEXT_WINDOWS,
+} from "./model-windows.js";
+
+/** The object form of a seat: the id is the only field this reads. */
+const seat = (modelId: string): LanguageModel =>
+  ({ specificationVersion: "v3", provider: "probe", modelId, supportedUrls: {} }) as unknown as LanguageModel;
+
+describe("the model's context window", () => {
+  it("names the seats the table knows", () => {
+    expect(contextWindowTokens("claude-sonnet-4-5")).toBe(200_000);
+    expect(contextWindowTokens("gpt-4o")).toBe(128_000);
+    expect(contextWindowTokens("gemini-2.5-flash")).toBe(1_048_576);
+  });
+
+  it("reads a PREFIXED, DATE-SUFFIXED id — the form ids actually arrive in", () => {
+    // A gateway prefix and a snapshot date are the normal case, not the edge
+    // case; exact keys would miss every one of these.
+    expect(contextWindowTokens("us.anthropic.claude-sonnet-4-6-20260101")).toBe(200_000);
+    expect(contextWindowTokens(seat("anthropic/claude-opus-4-1-20250805"))).toBe(200_000);
+    expect(contextWindowTokens(seat("gpt-4o-2024-11-20"))).toBe(128_000);
+  });
+
+  it("takes the LONGEST match, so a family default cannot shadow a member", () => {
+    // `gemini-` carries the family's 1M window; 1.5 Pro is the 2M exception, and
+    // it only wins if length breaks the tie rather than table order.
+    expect(contextWindowTokens("gemini-1.5-pro-002")).toBe(2_097_152);
+    expect(contextWindowTokens("gemini-1.5-flash-002")).toBe(1_048_576);
+  });
+
+  it("falls to the conservative default for a model it cannot name", () => {
+    expect(contextWindowTokens("some-new-model-nobody-has-heard-of")).toBe(DEFAULT_CONTEXT_WINDOW_TOKENS);
+    expect(DEFAULT_CONTEXT_WINDOW_TOKENS).toBe(128_000);
+  });
+
+  it("lets the host's override WIN, table hit or not — the BYO escape", () => {
+    // The one knob a host has when the table is wrong about their seat. It has
+    // to beat a table hit too, or a stale entry would be unfixable from outside.
+    expect(contextWindowTokens("claude-sonnet-4-5", 42_000)).toBe(42_000);
+    expect(contextWindowTokens("some-new-model-nobody-has-heard-of", 900_000)).toBe(900_000);
+  });
+
+  it("carries no duplicate keys, so a match is never ambiguous", () => {
+    const keys = MODEL_CONTEXT_WINDOWS.map(([match]) => match);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});

--- a/packages/harnesses/src/vendo/model-windows.ts
+++ b/packages/harnesses/src/vendo/model-windows.ts
@@ -1,0 +1,62 @@
+/**
+ * How many tokens the model's context window holds.
+ *
+ * The loop has never known this, which is why every context rail it had was a
+ * number a host guessed at: `contextTokenBudget` is an absolute figure with no
+ * default and no way to reach it from `createVendo`, so in practice nothing
+ * bounded the prompt but the provider's own 400. A window table is the smallest
+ * thing that turns that into a decision the loop can make for itself.
+ *
+ * Matched by SUBSTRING, longest first, because a model id does not arrive as a
+ * bare name. It arrives prefixed by whichever gateway routed it and suffixed by a
+ * snapshot date — `us.anthropic.claude-sonnet-4-6-20260101` — so a table of exact
+ * keys would miss every real id and silently run the whole shipment on the
+ * default.
+ *
+ * No tokenizer, no network lookup, no per-provider metadata fetch: a table in the
+ * repo is wrong slowly and visibly, which is the failure mode a host can fix with
+ * the override below.
+ */
+import type { LanguageModel } from "ai";
+
+/** The window assumed for a model this table does not name. Deliberately the
+ *  smallest window still in wide use: under-guessing costs one early compaction,
+ *  over-guessing costs a 400 in the middle of somebody's turn. */
+export const DEFAULT_CONTEXT_WINDOW_TOKENS = 128_000;
+
+/**
+ * Substring → window, longest match wins.
+ *
+ * Family entries carry the family's standard window and member entries carry the
+ * exceptions, so a new dated snapshot of a known family is right on the day it
+ * ships rather than on the day someone remembers this file. Every figure is the
+ * window available on a PLAIN request: Anthropic's 1M window is behind a beta
+ * header we do not send, so claiming it here would trade one early compaction for
+ * a request the provider rejects.
+ */
+export const MODEL_CONTEXT_WINDOWS: readonly (readonly [match: string, tokens: number])[] = [
+  ["claude-", 200_000],
+  ["gpt-4o", 128_000],
+  ["gpt-4.1", 1_047_576],
+  ["gpt-5", 400_000],
+  ["gemini-", 1_048_576],
+  ["gemini-1.5-pro", 2_097_152],
+];
+
+/**
+ * THE one new public knob of this shipment.
+ *
+ * `override` is the BYO escape and it wins outright, table hit or not: a host on
+ * a model this repo has never heard of, or on a seat whose entry has gone stale,
+ * needs a way to be right that does not involve waiting for a release.
+ */
+export function contextWindowTokens(model: LanguageModel, override?: number): number {
+  if (override !== undefined) return override;
+  const id = (typeof model === "string" ? model : model.modelId).toLowerCase();
+  let matched: readonly [string, number] | undefined;
+  for (const entry of MODEL_CONTEXT_WINDOWS) {
+    if (!id.includes(entry[0])) continue;
+    if (matched === undefined || entry[0].length > matched[0].length) matched = entry;
+  }
+  return matched?.[1] ?? DEFAULT_CONTEXT_WINDOW_TOKENS;
+}

--- a/packages/harnesses/src/vendo/vendo.test.ts
+++ b/packages/harnesses/src/vendo/vendo.test.ts
@@ -10,6 +10,7 @@
 import type { HarnessEvent, Json, ToolDescriptor, Turn } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
 import { vendo, type HarnessHand } from "./vendo.js";
+import { createTurnState } from "../harness-state.js";
 import { createTurnTools } from "../turn-tools.js";
 import type { HireRecord } from "../runtime.js";
 import {
@@ -71,7 +72,7 @@ async function drive(options: {
     skills: options.skills ?? testSkills(),
     workspace,
     models: options.models,
-    state: { get: () => undefined, set: () => undefined, clear: () => undefined },
+    state: createTurnState(undefined),
     options: options.options ?? {},
     signal: options.signal ?? new AbortController().signal,
     interactive: options.interactive ?? true,
@@ -143,7 +144,7 @@ describe("vendo() — the loop", () => {
       skills: testSkills(),
       workspace: testWorkspace(),
       models,
-      state: { get: () => undefined, set: () => undefined, clear: () => undefined },
+      state: createTurnState(undefined),
       options: { model: override },
       signal: new AbortController().signal,
       interactive: true,

--- a/packages/harnesses/src/vendo/vendo.ts
+++ b/packages/harnesses/src/vendo/vendo.ts
@@ -17,7 +17,9 @@
  */
 import { z } from "zod";
 import { modelToolDescription, type Harness, type HarnessEvent, type Json, type ToolDescriptor, type Turn } from "@vendoai/core";
-import { startTurn, type TurnContext } from "./loop.js";
+import { readCompactionState, writeCompactionState } from "./compaction.js";
+import { startTurn, type TurnCompaction, type TurnContext } from "./loop.js";
+import { contextWindowTokens } from "./model-windows.js";
 import { wireErrorMessage } from "../wire-error.js";
 import { reportHire, type HireRecord, type UsageTotals } from "../runtime.js";
 import {
@@ -51,6 +53,7 @@ const optionsSchema = z.object({
   historyWindow: z.number().int().positive().optional(),
   contextTokenBudget: z.number().int().positive().optional(),
   maxOutputTokens: z.number().int().positive().optional(),
+  contextWindowTokens: z.number().int().positive().optional(),
 });
 
 export interface VendoHarnessOptions {
@@ -64,11 +67,20 @@ export interface VendoHarnessOptions {
   historyWindow?: number;
   contextTokenBudget?: number;
   maxOutputTokens?: number;
+  /** Override the window this seat is assumed to have. The BYO escape for a
+   *  model {@link contextWindowTokens}'s table cannot name. */
+  contextWindowTokens?: number;
 }
 
 /** The knobs a per-turn option may override, and the deployment defaults they
  *  override. One list, so a new knob cannot reach one half and not the other. */
-const CONTEXT_KNOBS = ["maxSteps", "historyWindow", "contextTokenBudget", "maxOutputTokens"] as const;
+const CONTEXT_KNOBS = [
+  "maxSteps",
+  "historyWindow",
+  "contextTokenBudget",
+  "maxOutputTokens",
+  "contextWindowTokens",
+] as const;
 
 export interface VendoHarnessDeps {
   /**
@@ -87,6 +99,10 @@ export interface VendoHarnessDeps {
   historyWindow?: number;
   contextTokenBudget?: number;
   maxOutputTokens?: number;
+  /** The window this deployment's seat is assumed to have, when the shipped
+   *  table is wrong about it. Q1a: this lives on the harness and nowhere else —
+   *  it is a fact about a model, not a product decision a host composes. */
+  contextWindowTokens?: number;
   /**
    * Called once per hired specialist. Defaults to the runtime's own
    * {@link reportHire}, which writes the audit row and the transcript receipt — a
@@ -260,6 +276,9 @@ async function runSubagent(
   tools: ToolSet,
   /** The loadout the specialist may PICK from, hiring filtered out — lock #2. */
   equipped: readonly string[],
+  /** The resident's window, minus its state: a hire has no next turn, so there
+   *  is nothing for it to remember and nothing of the thread's for it to spend. */
+  compaction: TurnCompaction,
 ): Promise<SubagentReport> {
   let brief = input.instructions;
   if (input.skill !== undefined) {
@@ -278,6 +297,7 @@ async function runSubagent(
     // `attach` is a no-op for the resident's reason: the runtime owns `find_tools`.
     toolSearch: { activeToolNames: () => [...equipped], attach: () => {} },
     context: { maxSteps: SUBAGENT_MAX_STEPS },
+    compaction,
     signal: turn.signal,
     turnId: turn.turnId,
   });
@@ -305,11 +325,24 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
       if (model === undefined) {
         throw new Error("vendo() thinks with `turn.models.default`, and this turn carries no default seat");
       }
-      const context: TurnContext = {};
+      const resolved: Partial<Record<(typeof CONTEXT_KNOBS)[number], number>> = {};
       for (const knob of CONTEXT_KNOBS) {
         const value = turn.options?.[knob] ?? deps[knob];
-        if (value !== undefined) context[knob] = value;
+        if (value !== undefined) resolved[knob] = value;
       }
+      // The window is not one of the loop's `TurnContext` knobs — it configures
+      // COMPACTION, which is its own shape. It rides the same resolution list
+      // anyway, so a per-turn option and a deployment default cannot disagree
+      // about which one wins for this knob and not for its neighbours.
+      const { contextWindowTokens: windowOverride, ...context } = resolved;
+      // What the thread already knows about its own size. An unreadable or
+      // foreign slot reads as no state, which costs one un-compacted turn.
+      const carried = readCompactionState(turn.state.get());
+      const compaction: TurnCompaction = {
+        model,
+        contextWindowTokens: contextWindowTokens(model, windowOverride),
+        ...(carried === undefined ? {} : { state: carried }),
+      };
       const system =
         (typeof deps.system === "function" ? await deps.system() : deps.system)
         ?? turn.system
@@ -343,7 +376,10 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
             // time, so the loadout has to be too or it could name a tool the
             // specialist was never handed.
             const loadout = equipped.filter((name) => name !== HIRE_SUBAGENT);
-            report = await runSubagent(turn, model, input, hands, loadout);
+            report = await runSubagent(turn, model, input, hands, loadout, {
+              ...compaction,
+              state: undefined,
+            });
           } catch (error) {
             // A failed hire is one tool result the resident can react to — never
             // the turn's death.
@@ -412,6 +448,10 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
           // not the harness — owns `find_tools`: that is the dividing line, and it
           // is what gives a third-party harness the same rail for free.
           toolSearch: { activeToolNames, attach: () => {} },
+          // How big this seat's window is, and what the thread remembers about
+          // filling it. Always passed: a deployment that never set a knob is
+          // exactly the deployment that has never had a context rail at all.
+          compaction,
           // The WHOLE context, not just `maxSteps`. Passing one knob is what made
           // every other knob unreachable from `vendo()` — the loop declared them,
           // `createAgent` passed them, and this caller silently dropped them, so
@@ -423,11 +463,20 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
         return;
       }
 
+      // The provider's own count for the whole prompt of a step — cache reads
+      // included, which is what makes it usable as the next turn's ground truth
+      // instead of a second guess at the same tokens.
+      let lastPromptTokens: number | undefined;
       try {
         for await (const part of loop.result.fullStream) {
           switch (part.type) {
             case "text-delta":
               yield { type: "text", delta: part.text };
+              break;
+            case "finish-step":
+              // Last step wins: it sent the biggest prompt of the turn, and it
+              // is the one the next turn grows from.
+              lastPromptTokens = part.usage.inputTokens ?? lastPromptTokens;
               break;
             case "error":
               // `wireErrorMessage` is the SHIPPED formatter: a Vendo-shaped error
@@ -469,6 +518,15 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
       } catch (error) {
         yield { type: "error", message: wireErrorMessage(error), code: "model" };
         return;
+      }
+
+      // §1.3's slot, which the runtime persists at turn end (`runtime.ts`
+      // `onFinish` → `saveHarnessState`). Written only after a turn that
+      // finished: a measurement from a turn that died describes a prompt the
+      // thread never actually sent. Whatever else the slot carries is spread
+      // through, so a later slice's summary is not erased by a token count.
+      if (lastPromptTokens !== undefined) {
+        turn.state.set(writeCompactionState({ ...carried, version: 1, lastPromptTokens }));
       }
 
       const stepLimit = await loop.stepLimitPart();

--- a/packages/vendo/src/compaction-state.e2e.test.ts
+++ b/packages/vendo/src/compaction-state.e2e.test.ts
@@ -1,0 +1,189 @@
+/**
+ * The compaction state SEAM — one write path, one read path, no stub on either.
+ *
+ * The loop's estimate is only as good as the number it carries between turns, and
+ * that number crosses four owners to get there: `vendo()` writes it into
+ * `turn.state`, the harness runtime buffers it and saves it at turn end
+ * (`runtime.ts` `onFinish` → `saveHarnessState`), the REAL
+ * `harnessStateStore(store)` puts it in `vendo_state`, and the next turn's
+ * projection reads it back. A suite that mocked the store would let the writer and
+ * the reader agree about a shape neither ships, which is exactly the failure this
+ * repo has already paid for once.
+ *
+ * So both halves run for real, through `createVendo`'s own door, over a real
+ * PGlite store. The read half is proven by DIFFERENCE rather than by inspection:
+ * two identical second turns, one with the slot intact and one with the slot
+ * cleared through the same real store, must project differently — because the
+ * measured number says the thread fits and the guess says it does not. A read that
+ * never reached the projection would make both turns identical.
+ *
+ * In S2 the slot carries `lastPromptTokens`. The summary field arrives with the
+ * summarizer in S3; this asserts what S2 actually writes.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Principal, ToolDescriptor, ToolRegistry } from "@vendoai/core";
+import { vendo as vendoHarness } from "@vendoai/harnesses";
+import { readCompactionState } from "@vendoai/harnesses/vendo";
+import { createStore, harnessStateStore, type VendoStore } from "@vendoai/store";
+import type { UIMessage } from "ai";
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+import { afterEach, describe, expect, it } from "vitest";
+import { createVendo, type CreateVendoConfig, type Vendo } from "./server.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+const principal: Principal = { kind: "user", subject: "user_compaction_state" };
+
+/** Two markers, so a projection can be read off the wire without counting. */
+const OLDEST = "OLDEST-JAN-TRANSFER";
+const NEWEST = "NEWEST-ASK";
+/** Big enough that the four-characters-per-token guess is worth ~5k tokens. */
+const BULK = "b".repeat(20_000);
+
+/** The window this deployment claims — small enough that 5k tokens trips it. */
+const TINY_WINDOW = 2_000;
+/** What the provider "reports" for the first turn: the truth the guess misses. */
+const MEASURED_PROMPT_TOKENS = 120;
+
+/** A model that answers in one word and reports a prompt count the guess cannot
+ *  reach on its own — the whole point of preferring the provider's number. */
+function reportingModel(): MockLanguageModelV3 {
+  return new MockLanguageModelV3({
+    doStream: async () => ({
+      stream: simulateReadableStream({
+        chunks: [
+          { type: "text-start", id: "t1" },
+          { type: "text-delta", id: "t1", delta: "ok" },
+          { type: "text-end", id: "t1" },
+          {
+            type: "finish",
+            usage: {
+              inputTokens: {
+                total: MEASURED_PROMPT_TOKENS,
+                noCache: MEASURED_PROMPT_TOKENS,
+                cacheRead: 0,
+                cacheWrite: 0,
+              },
+              outputTokens: { total: 1, text: 1, reasoning: 0 },
+            },
+            finishReason: { unified: "stop" as const, raw: undefined },
+          },
+        ],
+      }),
+    }),
+  });
+}
+
+const hostTools = (): ToolRegistry => {
+  const descriptor: ToolDescriptor = {
+    name: "maple_listAccounts",
+    title: "List accounts",
+    description: "List the signed-in customer's accounts",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+    risk: "read",
+  };
+  return {
+    async descriptors() {
+      return [descriptor];
+    },
+    async execute() {
+      return { status: "ok", output: { accounts: [] } };
+    },
+  };
+};
+
+interface Composed {
+  vendo: Vendo;
+  store: VendoStore;
+  model: MockLanguageModelV3;
+  chat: (threadId: string, id: string, text: string) => Promise<void>;
+}
+
+async function compose(): Promise<Composed> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-compaction-state-"));
+  const store = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  await store.ensureSchema();
+  const model = reportingModel();
+  const vendo = createVendo({
+    model: model as never,
+    principal: async () => principal,
+    store,
+    // Q1a: the window override lives on the HARNESS, never on `createVendo`.
+    harness: vendoHarness({ contextWindowTokens: TINY_WINDOW }) as never,
+  } as CreateVendoConfig);
+  vendo.actions.add(hostTools());
+  const chat = async (threadId: string, id: string, text: string): Promise<void> => {
+    const message: UIMessage = { id, role: "user", parts: [{ type: "text", text }] };
+    const response = await vendo.handler(new Request("https://host.test/api/vendo/threads", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ threadId, message }),
+    }));
+    await response.text();
+  };
+  return { vendo, store, model, chat };
+}
+
+/** The prompt of the call that carried `marker`, as sent to the provider. */
+function promptCarrying(model: MockLanguageModelV3, marker: string): string {
+  const call = model.doStreamCalls.findLast((entry) => JSON.stringify(entry.prompt).includes(marker));
+  expect(call, `no provider call carried ${marker}`).toBeDefined();
+  return JSON.stringify(call?.prompt);
+}
+
+describe("the compaction slot, written and read through the real store", () => {
+  it("writes the provider's prompt count into the thread's own slot", async () => {
+    const { store, chat } = await compose();
+    await chat("thr_state_write", "m1", `${OLDEST} ${BULK}`);
+
+    // A FRESH handle over the same store — the runtime's own instance is not
+    // reused, so nothing but the row can be carrying the value.
+    const slot = await harnessStateStore(store).get("thr_state_write", "vendo");
+    expect(slot, "the turn wrote no harness state at all").toBeDefined();
+    expect(readCompactionState(slot)).toEqual({
+      version: 1,
+      lastPromptTokens: MEASURED_PROMPT_TOKENS,
+    });
+  });
+
+  it("keeps the slot out of another harness's reach", async () => {
+    // §1.3's clearing rule, on the real row: the state belongs to `vendo`, and a
+    // different thinker asking for it gets nothing.
+    const { store, chat } = await compose();
+    await chat("thr_state_owner", "m1", `${OLDEST} ${BULK}`);
+    expect(await harnessStateStore(store).get("thr_state_owner", "claude-code")).toBeUndefined();
+  });
+
+  it("feeds the NEXT turn's projection: the measured number keeps history the guess would shed", async () => {
+    const { model, chat } = await compose();
+    const threadId = "thr_state_read";
+    await chat(threadId, "m1", `${OLDEST} ${BULK}`);
+    await chat(threadId, "m2", NEWEST);
+
+    // 20k characters guess at ~5k tokens, well over 0.81 × 2_000 — so without the
+    // slot the second turn sheds the oldest message. With it, the provider's own
+    // 120 says the thread fits, and the history survives.
+    expect(promptCarrying(model, NEWEST)).toContain(OLDEST);
+  });
+
+  it("…and sheds it once the slot is gone — the read really is what changed", async () => {
+    const { store, model, chat } = await compose();
+    const threadId = "thr_state_cleared";
+    await chat(threadId, "m1", `${OLDEST} ${BULK}`);
+    // Cleared through the SAME real store the runtime writes to. Nothing else
+    // about the second turn differs.
+    await harnessStateStore(store).clear(threadId);
+    await chat(threadId, "m2", NEWEST);
+
+    expect(promptCarrying(model, NEWEST)).not.toContain(OLDEST);
+  });
+});


### PR DESCRIPTION
Base: `yousefh409/ctx-s6-subagent-loop` @ `ea0ca9b56` — stacked #868 → #893 (S1) → #894 (S5) → #891 (S6) → **this (S2)**.

Shipment 1, slice S2 — window awareness + trigger. The loop learns how big its own
prompt is: an in-repo window table with a BYO override, the compaction state codec,
a hybrid estimate that finally counts the tools block, and a trigger at 81%.
**No summarizer** — that is S3.

> **Interim behaviour, S2 → S3: shed now runs by default.**
> Before this PR, `shedToBudget` only ran when a host set `contextTokenBudget`, which has no default
> and is unreachable from `createVendo` — so in practice it never ran. From this PR until S3 lands,
> a turn that crosses `contextWindowTokens × 0.81` sheds to the window instead of 400ing. Shed drops
> reasoning, then tool payloads, then the oldest messages, with no summary and no notice to the
> model. This is the interim floor, not the end state: S3 replaces the trip with one summarizer pass
> and demotes shed to an emergency floor. **Flagged because it changes behaviour for every
> deployment during the S2 → S3 window.**

## What landed

| File | What |
|---|---|
| `model-windows.ts` (new) | `DEFAULT_CONTEXT_WINDOW_TOKENS = 128_000`, `MODEL_CONTEXT_WINDOWS` (substring, longest match wins), `contextWindowTokens(model, override?)` |
| `compaction.ts` (new) | state codec, `TRIGGER_RATIO`, `PRESERVE_RECENT_TOKENS`, `SUMMARY_MAX_OUTPUT_TOKENS`, `CompactionConfig`, `estimatePromptTokens`, `triggerTokens`, `shouldCompact`. **No summarizer.** |
| `loop.ts` | `TurnCompaction`; `TurnPromptInput.compaction` / `TurnPrompt.compacted` firmed off their `unknown` placeholders; `TurnLoopOptions.compaction` + `.resume`; `TurnLoop.compacted`; the trigger inside `turnModelMessages`; `startTurn` now passes the live `tools` into the projection |
| `vendo.ts` | `contextWindowTokens` on `optionsSchema`, `VendoHarnessOptions`, `VendoHarnessDeps` and `CONTEXT_KNOBS`; slot read via `readCompactionState`; new `finish-step` case recording `lastPromptTokens`; slot written via `turn.state.set(writeCompactionState(...))`; `runSubagent` takes its sixth parameter |
| `vendo/index.ts` | exports the window table + the state codec |

`runSubagent`'s sixth parameter is the **S6 addendum** (PR #891 body) landing here: S6 deliberately
shipped five params, and the `compaction` slot on `TurnLoopOptions` did not exist until this PR. It
is added in the same change that creates the slot — one construct, no dead code. A hire gets the
resident's window with `state: undefined`: a hire has no next turn, so it has nothing to remember.

## Ported, with credit

- `TRIGGER_RATIO` (0.9 × 0.9) and `PRESERVE_RECENT_TOKENS` ← cline
  `sdk/packages/core/src/extensions/context/compaction-shared.ts:15,17,19` (Apache-2.0)
- tools-block counting ← cline `compaction.ts:300-304` (Apache-2.0)
- the hybrid estimate (provider number for the covered prefix, chars/4 for the delta) ← pi-mono
  `packages/agent/src/harness/compaction/compaction.ts` (MIT, Mario Zechner)

No new runtime deps, no tokenizer, still on `ai@6.0.28`.

## The live measurement — `finish-step` `usage.inputTokens` IS the whole prompt

One real Anthropic call through `startTurn` on Yousef's key, `claude-haiku-4-5-20251001`, with a
~9.6k-token system prefix so the cache engages. Two identical turns:

| turn | `inputTokens` | `noCacheTokens` | `cacheReadTokens` | `cacheWriteTokens` | sum of the three |
|---|---|---|---|---|---|
| 1 (cache write) | **9624** | 3 | 0 | 9621 | 9624 |
| 2 (cache **read**) | **9624** | 3 | 9621 | 0 | 9624 |

`inputTokens` is unchanged across a full cache hit and equals `noCache + cacheRead + cacheWrite` on
both turns. The number covers the WHOLE prompt, cache reads included — so the hybrid estimate's
ground truth holds and S3 can proceed. (Probe was a throwaway file, run and deleted; not committed.)

## Red-first proofs

**Unit suites, against the unchanged tree** — all three modules did not exist:

```
FAIL src/vendo/compaction-state.test.ts   Failed to load url ./compaction.js
FAIL src/vendo/compaction-trigger.test.ts Failed to load url ./compaction.js
FAIL src/vendo/model-windows.test.ts      Failed to load url ./model-windows.js
Test Files  3 failed (3)
```

**The seam suite, against the unchanged tree** — 2 of 4 red for exactly the two things the
mechanism adds:

```
× writes the provider's prompt count into the thread's own slot
  → the turn wrote no harness state at all: expected undefined to be defined
× …and sheds it once the slot is gone — the read really is what changed
  → expected '[{"role":"system"…' not to contain 'OLDEST-JAN-TRANSFER'
Test Files  1 failed (1)   Tests  2 failed | 2 passed (4)
```

Stated plainly: the other two passed vacuously on the unchanged tree (with nothing written and
nothing shed, "history survives" is trivially true). They are the guard half of a PAIR — the
cleared-slot control is the one that can fail, and it does.

**After the mechanism:**

```
✓ src/vendo/model-windows.test.ts (6)  ✓ compaction-trigger.test.ts (13)  ✓ compaction-state.test.ts (6)
✓ src/compaction-state.e2e.test.ts (4)   Tests  25 passed / 4 passed
```

## Revert-proofs

**The trigger** — removed the `if (compaction !== undefined)` block from `turnModelMessages`:

```
× the loop's interim floor > sheds to the window when the estimate trips
  → expected '[{"role":"system","content":"system",…' not to contain 'OLDEST'
Tests  1 failed | 12 passed (13)
```
restored → `13 passed`.

**The tools-block count** — made `toolsBlockChars` return 0:

```
× the prompt estimate > COUNTS THE TOOLS BLOCK — the same messages cost more with tools attached
  → expected 0 to be greater than 9000
Tests  1 failed | 12 passed (13)
```
restored → `13 passed`.

## Signature-forced test edit (own commit, stated)

`8c3fec783 test(harnesses): the state slot stubs become a real in-memory TurnState`

`vendo()` now reads and writes `turn.state`, and the three no-op stubs
(`vendo.test.ts:63,135`, `ask-user-stop.test.ts:55`) could not observe either. They become the
shipped `createTurnState(undefined)`. **No assertion, expected value or budget in either file is
touched.** `subagent-loop.test.ts`'s stub is S6's file and is left alone.

## Laws honoured

- **Q1a** — `contextWindowTokens` lives on `vendo({ … })` + the per-turn option only.
  `git grep contextWindowTokens packages/vendo/src/server.ts` → nothing.
- **Q2b** — `historyWindow` still slices FIRST; the estimate runs on what remains. Asserted by
  `compaction-trigger.test.ts` ("still slices `historyWindow` FIRST, then estimates what is left").
- **D2** — no new store surface, no new table; nothing under `packages/store/src/` in the diff.
- **D1 / D3** — untouched here; no summarizer, no `prepareStep` change (S5's hook is byte-identical).
- The seam test runs through the REAL `harnessStateStore(store)` over a real PGlite store, no stub on
  either side.

## Known, deliberate, and named

The interim floor's shed bounds the MESSAGES only, so a trip caused by the **tools block alone**
sheds nothing — the tools are not sheddable and the floor does not pretend otherwise. That is why
the tools-block proof is a unit assertion on `estimatePromptTokens` rather than a loop-level one:
in S2 no observable projection difference can isolate it. S3's summarizer removes the gap.

## Gate

`/tmp/gate-s2.log`, foreground, read back:

```
build exit=0
typecheck exit=0
lint exit=0
harness-unit exit=0   Test Files 3 passed   Tests 25 passed
seam exit=0           Test Files 1 passed   Tests 4 passed
vendo-dir exit=0      Test Files 11 passed | 1 skipped   Tests 84 passed | 3 skipped
```

Diff is the owned files and nothing else (11 files).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds model window awareness and a full prompt size estimate (including the tools block) so the loop compacts before hitting provider limits. Exports the window table and state codec, persists provider-reported `inputTokens`, and adds end-to-end state tests; until S3, trips shed to the window instead of 400s.

- **New Features**
  - Window table with longest-substring match and BYO override `contextWindowTokens`, exported via `@vendoai/harnesses/vendo`.
  - Hybrid prompt estimator `estimatePromptTokens` counts system + messages + tools; uses `finish-step.usage.inputTokens` for covered prefix and chars/4 for the delta.
  - Trigger at `0.81` (`TRIGGER_RATIO`) with recent-tail constant (`PRESERVE_RECENT_TOKENS`); on trip, sheds to `contextWindowTokens × triggerRatio`.
  - State codec (`readCompactionState`/`writeCompactionState`) persisting `lastPromptTokens`; `vendo()` reads/writes `turn.state`. Loop passes live `tools`; subagents inherit the window but not state. Tests switch to `createTurnState` and add an e2e seam test through `@vendoai/store`.

- **Migration**
  - From S2→S3, shedding runs by default at 81% of the window.
  - Hosts may override the window via `contextWindowTokens`; otherwise the in-repo table is used.
  - Known gap: tools-only overflow isn’t sheddable in S2; S3’s summarizer addresses this.

<sup>Written for commit 4d6a06dae4603d2da723fee98ff0b59dba310a63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

