### PR TITLE
feat(ui): slot build states + Add to… picker

### DIFF
--- a/.changeset/slot-display-states-and-add-to.md
+++ b/.changeset/slot-display-states-and-add-to.md
@@ -1,0 +1,32 @@
+---
+"@vendoai/ui": minor
+"@vendoai/vendo": minor
+---
+
+A slot tells the truth about the app placed in it, and any surface can put one there.
+
+`VendoSlot` reads the placement's build status, not just its app id:
+
+- **building** — an EMPTY slot shows the skeleton it already uses, minus the
+  invitation, because there is nothing left to ask for. A slot carrying the
+  host's own markup keeps it until the build is ready: a working host component
+  never blanks into a skeleton for the length of a build.
+- **failed** — the consumer sentence (never the wire's `reason`, which names
+  components, expressions and env vars and is written for whoever can fix the
+  build), a "Try again" that re-issues the ORIGINAL request and is offered only
+  when the failed record kept one, and "Clear this slot" — the unplace the
+  host's own markup comes back from.
+- **ready** — unchanged, and now proven in a browser for both surface kinds: a
+  tree payload and a served machine url.
+
+`AddToPicker` puts "Add to…" on the app embed's bar, so a BYO chat page can send
+a generated app to the dashboard without a host-built pin control. It awaits
+`client.apps.place` before saying "Added to Hero", then announces the placement
+so a mounted slot fills without waiting out its poll.
+
+- `noteSlot` / `knownSlots` (new, re-exported from `vendoai/react`): the picker's
+  destinations. A slot id is the host's markup and no Vendo record carries it, so
+  a mounted `VendoSlot` recording itself in origin-scoped `localStorage` is the
+  only way a surface on another page can offer that slot at all. A slot the host
+  filled with an explicit `appId`/`pin` stays out of the list — a placement
+  written into it would never be read.

--- a/packages/ui/e2e/harness/main.tsx
+++ b/packages/ui/e2e/harness/main.tsx
@@ -2199,6 +2199,47 @@ function ByoEmbedScenario({ appId, title }: { appId: string; title: string }) {
   );
 }
 
+/** A placement written at mint time, narrating itself: the skeleton while the
+ *  build streams, then the app in place. ALONE on its page — every mounted slot
+ *  shares one poller, so a page of five would burn the fixture's build window
+ *  in the mount burst. No host markup either: a slot that has its own content
+ *  keeps it while a build forms, so the beat belongs to the empty one. */
+function SlotBuildingScenario() {
+  return <VendoSlot id="slot-building" />;
+}
+
+/** The rest of the slot's build vocabulary over the real wire: both ready
+ *  surface kinds (tree and http) and a terminally failed build.
+ *  `slot-failed-clear` is seeded by the spec itself, so the destructive case is
+ *  idempotent under retries. */
+function SlotStatesScenario() {
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      <section aria-label="Slot ready tree"><VendoSlot id="slot-ready"><p>Host hero (tree)</p></VendoSlot></section>
+      <section aria-label="Slot ready http"><VendoSlot id="slot-http"><p>Host hero (served)</p></VendoSlot></section>
+      <section aria-label="Slot failed"><VendoSlot id="slot-failed"><p>Host hero (failed)</p></VendoSlot></section>
+      <section aria-label="Slot failed clear"><VendoSlot id="slot-failed-clear"><p>Host hero (clear me)</p></VendoSlot></section>
+    </div>
+  );
+}
+
+/** "Add to…": a chat page's embed writing a placement into a slot mounted on the
+ *  SAME page. The slot renders first so its note lands before the picker reads
+ *  the list. */
+function SlotPickerScenario() {
+  return (
+    <VendoProvider client={baseClient} components={components}>
+      <div style={{ display: "grid", gap: 16 }}>
+        <VendoSlot id="picker-target"><p>Host hero (empty)</p></VendoSlot>
+        <p style={{ margin: 0 }}>AI: here is the view you asked for.</p>
+        {/* The envelope always says "building"; app_1 is servable, so the wire
+            answers with the surface and the bar flips to the app's name. */}
+        <VendoToolResult output={{ kind: "vendo/app-ref@1", appId: "app_1", title: "Invoices", status: "building" }} />
+      </div>
+    </VendoProvider>
+  );
+}
+
 function scenario(pathname: string): { title: string; theme?: Partial<VendoTheme>; content: ReactNode; ownProvider?: boolean } {
   switch (pathname) {
     case "/thread": return { title: "Thread — dark theme", theme: darkTheme, content: <VendoThread threadId="thr_1" /> };
@@ -2264,6 +2305,9 @@ function scenario(pathname: string): { title: string; theme?: Partial<VendoTheme
     case "/slot-empty-dark": return { title: "Inline slot — empty CTA (dark)", theme: darkTheme, content: <><VendoSlot id="hero" /><VendoPalette /><VendoOverlay launcher="none" /></> };
     case "/slot-pinned": return { title: "Inline slot — pinned component", theme: mapleTheme, content: <VendoSlot id="hero" pin={{ payload: pinnedViewTree }}><section aria-label="Original host component"><h2>Original host hero</h2></section></VendoSlot> };
     case "/slot-fallback": return { title: "Slot pin fallback", content: <SlotFallbackScenario />, ownProvider: true };
+    case "/slot-building": return { title: "Inline slot — a build landing in place", content: <SlotBuildingScenario /> };
+    case "/slot-states": return { title: "Inline slot — ready / failed", content: <SlotStatesScenario /> };
+    case "/slot-picker": return { title: "Add to… — embed writes a placement", content: <SlotPickerScenario />, ownProvider: true };
     case "/pin-shelf": return { title: "Pin — nudge, ceremony, Apps shelf", content: <PinShelfScenario />, ownProvider: true };
     case "/appframe": return { title: "App execution planes", content: <AppFrameScenario /> };
     case "/appframe-resize": return { title: "App frame resize — the host's bounds win", content: <AppFrameResizeScenario /> };

--- a/packages/ui/e2e/harness/vite.config.ts
+++ b/packages/ui/e2e/harness/vite.config.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from "node:url";
 import { defineConfig, type ViteDevServer } from "vite";
-import { createWireServer } from "../../test/wire-server.ts";
+import { createWireServer, fixtureApp } from "../../test/wire-server.ts";
 
 const harnessRoot = fileURLToPath(new URL(".", import.meta.url));
 
@@ -31,6 +31,25 @@ export default defineConfig(async ({ command }) => {
       retryable: true,
       prompt: "a board showing where my money goes each month",
     });
+    // (/slot-states, /slot-building) — the slot's own build vocabulary over the
+    // real wire. `app_slot_building` lands on the second placements read; the
+    // spec places it itself so each attempt rewinds that window. `slot-ready`
+    // and `slot-http` are the two surface kinds a ready slot must mount; and
+    // `slot-failed` carries the same developer sentence the embed must not
+    // print, so the audit is over the real thing.
+    wire.state.landingApps.set("app_slot_building", { after: 2, seen: 0, name: "Trip planner" });
+    wire.state.placements.push({ slot: "slot-ready", appId: "app_1" });
+    wire.state.apps.push(fixtureApp("app_slot_http", "Served dashboard"));
+    wire.state.httpApps.set("app_slot_http", "/frame-target.html");
+    wire.state.placements.push({ slot: "slot-http", appId: "app_slot_http" });
+    wire.state.failedApps.set("app_slot_failed", {
+      reason: "This app wasn't created, because it didn't pass the checks that keep an app honest:"
+        + " the `value` expression is a declarative string that the DataTable does not evaluate,"
+        + " not JavaScript: amount / sum(spending.data.amount)",
+      retryable: true,
+      prompt: "a board showing where my money goes each month",
+    });
+    wire.state.placements.push({ slot: "slot-failed", appId: "app_slot_failed" });
   }
 
   // Ephemeral by default so parallel lanes never collide; playwright.config

--- a/packages/ui/e2e/slot-states.spec.ts
+++ b/packages/ui/e2e/slot-states.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test } from "@playwright/test";
+import { openScenario, screenshotPath } from "./helpers.js";
+
+/**
+ * The slot's own build vocabulary, in a real browser over the real wire.
+ *
+ * A placement row is written the moment the app id is minted, so an EMPTY slot
+ * knows it is about to be filled while the build is still streaming: the
+ * skeleton, then the live app, without a reload. (A slot carrying the host's own
+ * markup keeps it until the build is ready — a working host component never
+ * blanks into a skeleton.) Both READY surface kinds are proven here — a tree
+ * payload and a served (http) machine url — because a slot that only ever
+ * mounted trees would ship broken for every rung-4 app.
+ */
+
+const BUILD_FAILURE_COPY = "I couldn't finish building that view — nothing was changed."
+  + " Ask again and I'll try a different approach.";
+
+test("a placed build narrates itself: skeleton, then the live app in place", async ({ page }) => {
+  // Seeded by the test: placing a landing app rewinds its build window, so a CI
+  // retry gets the same story instead of a slot that already filled.
+  await page.request.post("/api/vendo/apps/app_slot_building/place", { data: { slot: "slot-building" } });
+  await openScenario(page, "slot-building");
+
+  const slot = page.locator('[data-vendo-slot="slot-building"]');
+  await expect(slot.getByRole("status")).toContainText("Building your view");
+  await page.screenshot({ path: screenshotPath("slot-building"), animations: "disabled" });
+  await expect(slot.getByText("Trip planner app surface")).toBeVisible({ timeout: 20_000 });
+});
+
+test("a ready slot mounts BOTH surface kinds — a tree payload and a served machine url", async ({ page }) => {
+  await openScenario(page, "slot-states");
+
+  const tree = page.locator('[data-vendo-slot="slot-ready"]');
+  await expect(tree.getByText("Invoices app surface")).toBeVisible();
+
+  const served = page.locator('[data-vendo-slot="slot-http"] iframe[title="Vendo app"]');
+  await expect(served).toBeVisible();
+  await expect(served).toHaveAttribute("src", "/frame-target.html");
+  await expect(
+    page.frameLocator('[data-vendo-slot="slot-http"] iframe[title="Vendo app"]').getByText("Local HTTP app"),
+  ).toBeVisible();
+  // `animations: "disabled"` runs the reveal to its end state first — a
+  // screenshot caught mid cross-fade shows the host's markup and the app on top
+  // of each other, which is evidence of nothing.
+  await page.screenshot({ path: screenshotPath("slot-states"), fullPage: true, animations: "disabled" });
+});
+
+test("a failed build says the consumer sentence — nothing code-shaped reaches the host page", async ({ page }) => {
+  await openScenario(page, "slot-states");
+  const slot = page.locator('[data-vendo-slot="slot-failed"]');
+  await expect(slot.getByRole("alert")).toBeVisible();
+  await expect(slot.getByText(BUILD_FAILURE_COPY)).toBeVisible();
+  await expect(slot.getByRole("button", { name: "Try again" })).toBeVisible();
+  await expect(slot.getByRole("button", { name: "Clear this slot" })).toBeVisible();
+  await slot.screenshot({ path: screenshotPath("slot-failed"), animations: "disabled" });
+
+  const rendered = (await slot.innerText()).replace(/\s+/g, " ");
+  const codeShaped: readonly [string, RegExp][] = [
+    ["a backtick quote", /`/],
+    ["call syntax", /\w+\(/],
+    ["a dotted path", /\w\.\w+\.\w/],
+    ["a snake_case identifier", /[A-Za-z]_[A-Za-z]/],
+    ["a package specifier", /@[\w-]+\//],
+    ["an npm command", /\bnpm\b/],
+    ["a shouted env var", /\b[A-Z][A-Z0-9_]{4,}\b/],
+  ];
+  for (const [what, pattern] of codeShaped) {
+    expect(pattern.test(rendered), `${what} reached the slot: ${rendered}`).toBe(false);
+  }
+  const wholePage = await page.locator("body").innerText();
+  for (const word of ["declarative", "JavaScript", "sum(spending.data.amount)", "DataTable", "expression"]) {
+    expect(wholePage, `"${word}" leaked to the page`).not.toContain(word);
+  }
+});
+
+test("clearing a failed slot gives the host its own markup back", async ({ page }) => {
+  // Seeded by the test, not the harness: this case UNPLACES, and CI retries
+  // would otherwise re-run it against a slot it already emptied.
+  await page.request.post("/api/vendo/apps/app_slot_failed/place", { data: { slot: "slot-failed-clear" } });
+  await openScenario(page, "slot-states");
+
+  const section = page.getByRole("region", { name: "Slot failed clear" });
+  await section.getByRole("button", { name: "Clear this slot" }).click();
+  await expect(section.getByText("Host hero (clear me)")).toBeVisible();
+  await expect(page.locator('[data-vendo-slot="slot-failed-clear"]')).toHaveCount(0);
+});
+
+test("Add to… puts the embed's app into a slot on the same page", async ({ page }) => {
+  // Idempotent under retries: clear whatever a previous attempt placed.
+  await page.request.post("/api/vendo/apps/app_1/unplace", { data: { slot: "picker-target" } });
+  await openScenario(page, "slot-picker");
+
+  await expect(page.getByText("Host hero (empty)")).toBeVisible();
+  await page.getByRole("button", { name: "Add to…" }).click();
+  // The open menu, photographed: it hangs off the app-card bar, which is the one
+  // place it could be clipped.
+  await expect(page.getByRole("menu")).toBeVisible();
+  await page.screenshot({ path: screenshotPath("slot-picker-menu"), fullPage: true, animations: "disabled" });
+  await page.getByRole("menuitem", { name: "Picker target" }).click();
+
+  await expect(page.getByRole("button", { name: "Added to Picker target" })).toBeVisible();
+  await expect(page.locator('[data-vendo-slot="picker-target"]').getByText("Invoices app surface")).toBeVisible();
+  await page.screenshot({ path: screenshotPath("slot-picker"), fullPage: true, animations: "disabled" });
+});

--- a/packages/ui/src/chrome/add-to-picker.tsx
+++ b/packages/ui/src/chrome/add-to-picker.tsx
@@ -1,0 +1,84 @@
+/**
+ * "Add to…" — the placement write from a surface that is not the host's page.
+ *
+ * A BYO chat page renders a generated app inline; the app belongs on the
+ * dashboard. The destinations come from slot-notes (a mounted `VendoSlot` is the
+ * only thing that knows a slot exists — a slot id is host markup, not a Vendo
+ * document), and the write is `apps.place`, AWAITED here: "Added to Hero" is a
+ * fact, not a hope. With nothing noted there is nowhere to add to, and the
+ * affordance renders nothing at all rather than an empty menu.
+ *
+ * The same `.fl-barpin` affordance the thread card's pin uses — no new button
+ * language on the app-card bar.
+ */
+import { useEffect, useState } from "react";
+import { useVendoProvider } from "../context.js";
+import { announcePin } from "../pin-events.js";
+import { knownSlots, type SlotNote } from "../slot-notes.js";
+
+export function AddToPicker({ appId }: { appId: string }) {
+  const { client } = useVendoProvider();
+  const [slots, setSlots] = useState<SlotNote[]>([]);
+  const [open, setOpen] = useState(false);
+  const [placedIn, setPlacedIn] = useState<string>();
+  const [failed, setFailed] = useState(false);
+
+  // Storage is unreadable during render (SSR) and a slot may mount after this
+  // embed did, so the list is read on mount and again on every open.
+  useEffect(() => {
+    setSlots(knownSlots());
+  }, []);
+
+  const toggle = () => {
+    setSlots(knownSlots());
+    setFailed(false);
+    setOpen(current => !current);
+  };
+
+  const choose = async (slot: SlotNote) => {
+    try {
+      await client.apps.place(appId, slot.id);
+      // Every mounted slot re-reads on the announcement instead of waiting out
+      // its poll floor (pin-events.ts).
+      announcePin(appId);
+      setPlacedIn(slot.label);
+      setOpen(false);
+    } catch {
+      // The wire's sentence is a developer's and this is a host's own page. One
+      // honest line, and the menu stays open so they can try again.
+      setFailed(true);
+    }
+  };
+
+  if (slots.length === 0) return null;
+  return (
+    <span className="fl-slotpick">
+      <button
+        type="button"
+        className="fl-barpin"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={toggle}
+      >
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+          <path d="M12 17v5M9 3h6l-1 7 3 3H7l3-3-1-7Z" />
+        </svg>
+        {placedIn === undefined ? "Add to…" : `Added to ${placedIn}`}
+      </button>
+      {open ? (
+        <div
+          className="fl-slotpick-menu"
+          role="menu"
+          onKeyDown={event => { if (event.key === "Escape") setOpen(false); }}
+        >
+          {slots.map(slot => (
+            <button key={slot.id} type="button" role="menuitem" onClick={() => void choose(slot)}>
+              {slot.label}
+            </button>
+          ))}
+          {failed ? <span className="fl-slotpick-note" role="alert">That didn’t go through — try again.</span> : null}
+        </div>
+      ) : null}
+    </span>
+  );
+}

--- a/packages/ui/src/chrome/chrome-css.ts
+++ b/packages/ui/src/chrome/chrome-css.ts
@@ -1873,6 +1873,21 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the S1 des
   0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--vendo-accent) 26%, transparent); }
   45% { box-shadow: 0 0 0 5px color-mix(in srgb, var(--vendo-accent) 10%, transparent); } }
 
+/* "Add to…" on the embed's app-card bar: the picker that writes a placement
+   from a chat page. The trigger is the existing .fl-barpin; the menu borrows
+   the ✦ popover's glass look (.fl-remix-menu). */
+.fl-slotpick { position: relative; margin-left: auto; display: inline-flex; flex-shrink: 0; }
+.fl-slotpick .fl-barpin { margin-left: 0; }
+.fl-slotpick-menu { position: absolute; top: 28px; right: 0; z-index: 8; min-width: 172px; padding: 6px;
+  display: flex; flex-direction: column; gap: 2px; text-align: left;
+  border: 1px solid var(--vendo-border-strong); border-radius: 12px;
+  background: var(--vendo-surface); box-shadow: var(--vendo-shadow-float); }
+.fl-slotpick-menu button { text-align: left; font: 500 12.5px/1.2 var(--vendo-font); padding: 7px 9px;
+  border: 0; border-radius: 8px; background: transparent; color: var(--vendo-fg); cursor: pointer; }
+.fl-slotpick-menu button:hover { background: var(--vendo-accent-soft); }
+.fl-slotpick-menu button:focus-visible { outline: 2px solid var(--vendo-accent); outline-offset: 1px; }
+.fl-slotpick-note { padding: 6px 9px; font: 500 11px/1.4 var(--vendo-font); color: var(--vendo-fg-muted); }
+
 /* 2B — Send now on the queued pill. */
 .fl-queued-now { flex-shrink: 0; border: 0; background: none; cursor: pointer; padding: 3px 6px;
   border-radius: 6px; font: 600 11px/1.2 var(--vendo-font); color: var(--vendo-accent); }

--- a/packages/ui/src/chrome/embeds.tsx
+++ b/packages/ui/src/chrome/embeds.tsx
@@ -16,6 +16,7 @@ import type {
 import { useResource } from "../hooks/use-resource.js";
 import { AppFrame } from "../tree/frames.js";
 import type { ApprovalResolution, OpenSurface } from "../wire-types.js";
+import { AddToPicker } from "./add-to-picker.js";
 import { ApprovalCard } from "./approval-card.js";
 import {
   CardActions,
@@ -370,6 +371,11 @@ export function VendoAppEmbed({ refValue }: VendoAppEmbedProps) {
             <span className="fl-boot-building" aria-hidden={!building}>Building {title}…</span>
             <span className="fl-boot-ready" aria-hidden={building}>{title}</span>
           </span>
+          {/* The destination affordance, only once the view is READY — the same
+              law the thread card's pin follows (§8: a build gets one moving
+              thing). It targets the app actually on screen, so after a retry
+              that is the replacement build's id. */}
+          {surface !== undefined ? <AddToPicker appId={activeAppId} /> : null}
           <span className="fl-boot-hairline" aria-hidden="true" />
         </div>
         <div className="fl-appcard-body">

--- a/packages/ui/src/chrome/vendo-slot.tsx
+++ b/packages/ui/src/chrome/vendo-slot.tsx
@@ -300,24 +300,23 @@ export function VendoSlot({ id, appId: appIdProp, pin, onAuthor, discover = true
     );
   }
 
-  // A placement row is written the moment the app id is minted, so the slot
-  // knows it is about to be filled while the build is still streaming. It says
-  // so with the skeleton the empty state already uses — minus the invitation,
-  // because there is nothing to ask for any more. Ahead of the empty/children
-  // arms below: a slot with a build coming is not empty, and the host's markup
-  // gives way to the view that is about to take its place.
-  if (status === "building") {
-    return (
-      <ChromeRoot>
-        <div className="fl-slot" data-vendo-slot={id}>
-          <SlotGhost label="Building your view…" loading />
-        </div>
-      </ChromeRoot>
-    );
-  }
-
   if (!appId && !pin) {
     if (children !== undefined) return <>{children}</>;
+    // A placement row is written the moment the app id is minted, so a slot
+    // with no markup of its own says what is coming instead of inviting a
+    // second ask — the skeleton the empty state already uses, minus the
+    // invitation. BEHIND the children arm above, deliberately: a working host
+    // component must never blank into a skeleton for the length of a build.
+    // The conversation surface carries that beat for the person who asked.
+    if (status === "building") {
+      return (
+        <ChromeRoot>
+          <div className="fl-slot" data-vendo-slot={id}>
+            <SlotGhost label="Building your view…" loading />
+          </div>
+        </ChromeRoot>
+      );
+    }
     // The invitation (pick S-A×S-D): accent-washed surface, real copy, up to
     // three concrete suggestion chips, and (layout "button") a primary CTA.
     // The skeleton stays behind at low opacity so it still reads as "a view

--- a/packages/ui/src/chrome/vendo-slot.tsx
+++ b/packages/ui/src/chrome/vendo-slot.tsx
@@ -1,6 +1,7 @@
 import type { Json, ToolOutcome, UIPayload } from "@vendoai/core";
-import { useEffect, useMemo, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { useVendoProvider } from "../context.js";
+import { announcePin } from "../pin-events.js";
 import { noteSlot } from "../slot-notes.js";
 import { useApp } from "../hooks/use-app.js";
 import { useSlotApp } from "../hooks/use-slot-app.js";
@@ -11,6 +12,7 @@ import { defaultSlotSuggestions } from "./discoverability.js";
 import { developmentMode } from "./dev-mode.js";
 import { openVendoConversation } from "./overlay-registry.js";
 import { openVendoPalette } from "./palette-hotkey.js";
+import { BUILD_FAILURE_COPY } from "./thread/message-data.js";
 
 /** A slot id is a code identifier ("net-worth-card"); the person choosing a
  *  destination in the picker reads words. */
@@ -78,6 +80,85 @@ function SlotLoadFailed({ reason, onRetry }: { reason: Error; onRetry(): void })
         <span className="fl-slot-cta-label">This view didn’t load</span>
         <small>{loadFailureCopy(reason)}</small>
         <button type="button" className="fl-invite-btn" onClick={onRetry}>Try again</button>
+      </span>
+    </div>
+  );
+}
+
+/**
+ * The terminal BUILD failure of the app placed here.
+ *
+ * Two remedies, both honest: ask again — offered ONLY when the failed record
+ * kept the original request, because re-issuing anything else is a different
+ * build wearing this one's name — and clear the slot, which is the unplace the
+ * host's own markup comes back from.
+ *
+ * The wire's `reason` never reaches this page (§16 law 3, same law as the
+ * embed's): every one of those sentences names a component, an expression or an
+ * env var, and this is a host's own page. The developer sentence keeps the home
+ * it has — the server's `[vendo] app build failed (app_…)` log line.
+ */
+function SlotBuildFailed({ appId, slotId, onChanged }: {
+  appId: string;
+  slotId: string;
+  onChanged(): void;
+}) {
+  const { client } = useVendoProvider();
+  const [failure, setFailure] = useState<{ retryable?: boolean; prompt?: string }>();
+  const [busy, setBusy] = useState(false);
+
+  // ONE read, not a poll: the record is terminal. The status already came from
+  // the placements read; this is only the retry affordance's evidence.
+  useEffect(() => {
+    let cancelled = false;
+    setFailure(undefined);
+    void client.apps.open(appId, { pending: true }).then(
+      surface => { if (!cancelled && surface.kind === "failed") setFailure(surface); },
+      () => { /* the record is failed either way; without detail there is no retry */ },
+    );
+    return () => { cancelled = true; };
+  }, [appId, client]);
+
+  const retry = async () => {
+    const prompt = failure?.prompt;
+    if (prompt === undefined) return;
+    setBusy(true);
+    try {
+      const created = await client.apps.create({ prompt });
+      // The affordance AWAITS the placement itself, so the slot showing the new
+      // build is a fact rather than a hope.
+      await client.apps.place(created.id, slotId);
+      announcePin(created.id);
+    } finally {
+      setBusy(false);
+      onChanged();
+    }
+  };
+
+  const clear = async () => {
+    setBusy(true);
+    try {
+      await client.apps.unplace(appId, slotId);
+    } finally {
+      setBusy(false);
+      onChanged();
+    }
+  };
+
+  return (
+    <div className="fl-slot-ghost">
+      <GhostSkeleton />
+      <span className="fl-slot-cta" role="alert">
+        <span className="fl-slot-cta-label">This view didn’t build</span>
+        <small>{BUILD_FAILURE_COPY}</small>
+        {failure?.retryable === true && failure.prompt !== undefined ? (
+          <button type="button" className="fl-invite-btn" disabled={busy} onClick={() => void retry()}>
+            Try again
+          </button>
+        ) : null}
+        <button type="button" className="fl-invite-own" disabled={busy} onClick={() => void clear()}>
+          Clear this slot
+        </button>
       </span>
     </div>
   );
@@ -168,17 +249,22 @@ export function VendoSlot({ id, appId: appIdProp, pin, onAuthor, discover = true
   // guaranteed "this view didn't load". The host's own children stay up until
   // there is something real to swap in.
   const appId = appIdProp ?? (pin === undefined && discovery.status === "ready" ? discovery.appId : undefined);
-  // The placed app's own build status. Only discovery carries one: an explicit
-  // `appId`/`pin` prop is the host asserting the slot's contents, and that path
-  // is unchanged.
-  const status = appIdProp === undefined && pin === undefined ? discovery.status : undefined;
+  // An explicit `appId`/`pin` prop is the host asserting the slot's contents:
+  // it carries no build status of its own, and a placement written into it
+  // would never be read.
+  const resolvesItself = appIdProp === undefined && pin === undefined;
+  // The placed app's own build status — discovery's, and only discovery's.
+  const status = resolvesItself ? discovery.status : undefined;
 
   // A slot id lives in the host's markup and nowhere else, so a surface that is
   // not on this page (the embed's "Add to…" picker) can only learn this slot
-  // exists from here. Every state notes it, including the untouched-children one.
+  // exists from here. Every state of a self-resolving slot notes it, including
+  // the untouched-children one; a host-asserted one stays out of the picker
+  // rather than promising a landing the person would never see.
   useEffect(() => {
+    if (!resolvesItself) return;
     noteSlot({ id, label: slotLabel(id) });
-  }, [id]);
+  }, [id, resolvesItself]);
 
   const author = () => {
     if (onAuthor) {
@@ -201,6 +287,18 @@ export function VendoSlot({ id, appId: appIdProp, pin, onAuthor, discover = true
       console.warn(`[vendo] VendoSlot "${id}": suggestions open the conversation surface — mount a VendoOverlay for them to land in.`);
     }
   };
+
+  // A build that will never land. `discovery.appId`, not `appId`: only a READY
+  // placement resolves into a mountable app id, and this one never will.
+  if (status === "failed" && discovery.appId !== undefined) {
+    return (
+      <ChromeRoot>
+        <div className="fl-slot" data-vendo-slot={id}>
+          <SlotBuildFailed appId={discovery.appId} slotId={id} onChanged={() => void discovery.refresh()} />
+        </div>
+      </ChromeRoot>
+    );
+  }
 
   // A placement row is written the moment the app id is minted, so the slot
   // knows it is about to be filled while the build is still streaming. It says

--- a/packages/ui/src/chrome/vendo-slot.tsx
+++ b/packages/ui/src/chrome/vendo-slot.tsx
@@ -168,6 +168,10 @@ export function VendoSlot({ id, appId: appIdProp, pin, onAuthor, discover = true
   // guaranteed "this view didn't load". The host's own children stay up until
   // there is something real to swap in.
   const appId = appIdProp ?? (pin === undefined && discovery.status === "ready" ? discovery.appId : undefined);
+  // The placed app's own build status. Only discovery carries one: an explicit
+  // `appId`/`pin` prop is the host asserting the slot's contents, and that path
+  // is unchanged.
+  const status = appIdProp === undefined && pin === undefined ? discovery.status : undefined;
 
   // A slot id lives in the host's markup and nowhere else, so a surface that is
   // not on this page (the embed's "Add to…" picker) can only learn this slot
@@ -197,6 +201,22 @@ export function VendoSlot({ id, appId: appIdProp, pin, onAuthor, discover = true
       console.warn(`[vendo] VendoSlot "${id}": suggestions open the conversation surface — mount a VendoOverlay for them to land in.`);
     }
   };
+
+  // A placement row is written the moment the app id is minted, so the slot
+  // knows it is about to be filled while the build is still streaming. It says
+  // so with the skeleton the empty state already uses — minus the invitation,
+  // because there is nothing to ask for any more. Ahead of the empty/children
+  // arms below: a slot with a build coming is not empty, and the host's markup
+  // gives way to the view that is about to take its place.
+  if (status === "building") {
+    return (
+      <ChromeRoot>
+        <div className="fl-slot" data-vendo-slot={id}>
+          <SlotGhost label="Building your view…" loading />
+        </div>
+      </ChromeRoot>
+    );
+  }
 
   if (!appId && !pin) {
     if (children !== undefined) return <>{children}</>;

--- a/packages/ui/src/chrome/vendo-slot.tsx
+++ b/packages/ui/src/chrome/vendo-slot.tsx
@@ -1,6 +1,7 @@
 import type { Json, ToolOutcome, UIPayload } from "@vendoai/core";
-import { useMemo, type ReactNode } from "react";
+import { useEffect, useMemo, type ReactNode } from "react";
 import { useVendoProvider } from "../context.js";
+import { noteSlot } from "../slot-notes.js";
 import { useApp } from "../hooks/use-app.js";
 import { useSlotApp } from "../hooks/use-slot-app.js";
 import { FluidReveal } from "../tree/fluid-reveal.js";
@@ -10,6 +11,13 @@ import { defaultSlotSuggestions } from "./discoverability.js";
 import { developmentMode } from "./dev-mode.js";
 import { openVendoConversation } from "./overlay-registry.js";
 import { openVendoPalette } from "./palette-hotkey.js";
+
+/** A slot id is a code identifier ("net-worth-card"); the person choosing a
+ *  destination in the picker reads words. */
+function slotLabel(id: string): string {
+  const words = id.replace(/[-_]+/g, " ").replace(/([a-z\d])([A-Z])/g, "$1 $2").trim();
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
 
 /** The faint skeleton behind the ghost/empty states — decorative only. */
 function GhostSkeleton() {
@@ -160,6 +168,13 @@ export function VendoSlot({ id, appId: appIdProp, pin, onAuthor, discover = true
   // guaranteed "this view didn't load". The host's own children stay up until
   // there is something real to swap in.
   const appId = appIdProp ?? (pin === undefined && discovery.status === "ready" ? discovery.appId : undefined);
+
+  // A slot id lives in the host's markup and nowhere else, so a surface that is
+  // not on this page (the embed's "Add to…" picker) can only learn this slot
+  // exists from here. Every state notes it, including the untouched-children one.
+  useEffect(() => {
+    noteSlot({ id, label: slotLabel(id) });
+  }, [id]);
 
   const author = () => {
     if (onAuthor) {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -15,6 +15,7 @@ export type { VendoAppEmbedProps, VendoApprovalEmbedProps, VendoApprovalEmbedSta
 export { VendoAppEmbed, VendoApprovalEmbed, VendoToolResult } from "./chrome/embeds.js";
 export * from "./hooks/index.js";
 export { announcePin, onPinAnnounced } from "./pin-events.js";
+export { knownSlots, noteSlot, type SlotNote } from "./slot-notes.js";
 export { defaultVendoTheme, resolveTheme, themeCssVariables } from "./theme.js";
 export { useVoice, type UseVoiceResult } from "./voice/use-voice.js";
 export * from "./wire-types.js";

--- a/packages/ui/src/slot-notes.ts
+++ b/packages/ui/src/slot-notes.ts
@@ -1,0 +1,68 @@
+/**
+ * The slots this origin has seen mounted — the "Add to…" picker's only source
+ * of destinations.
+ *
+ * A slot id is the HOST's markup, not a Vendo document: nothing on the server
+ * knows a slot exists until something is placed in it. So the picker (which
+ * lives in an app embed, on whatever page the host renders a chat) can only
+ * learn about a slot from a mounted `VendoSlot` saying so. localStorage —
+ * origin-scoped, exactly like discoverability's seen-marks — is what carries
+ * that across the navigation from the dashboard to the chat page.
+ *
+ * Module-level like pin-events.ts, and for the same reason: the announcer (a
+ * slot in the host's page) and the listener (a picker in a chat surface) share
+ * no React tree.
+ */
+
+const KEY = "vendo.slots";
+
+export interface SlotNote {
+  /** The slot's `id` — the value that goes over the wire as a placement. */
+  id: string;
+  /** What a person choosing a destination reads. */
+  label: string;
+}
+
+function storage(): Storage | null {
+  return typeof window === "undefined" ? null : window.localStorage;
+}
+
+function read(): SlotNote[] {
+  try {
+    const raw = storage()?.getItem(KEY);
+    if (raw === null || raw === undefined || raw === "") return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((note): note is SlotNote =>
+      typeof note === "object" && note !== null
+      && typeof (note as SlotNote).id === "string"
+      && typeof (note as SlotNote).label === "string");
+  } catch {
+    // Denied storage, or a value another tool wrote under our key. Neither is
+    // recoverable and neither is worth a broken picker: no slots is a state the
+    // picker already renders (it hides).
+    return [];
+  }
+}
+
+/** Record that a slot exists on this origin. Idempotent; a remount with a new
+ *  label updates it in place. Best-effort — a refused write leaves the picker
+ *  with whatever it already knew. */
+export function noteSlot(note: SlotNote): void {
+  const known = read();
+  const existing = known.find(item => item.id === note.id);
+  if (existing !== undefined && existing.label === note.label) return;
+  const next = existing === undefined
+    ? [...known, note]
+    : known.map(item => (item.id === note.id ? note : item));
+  try {
+    storage()?.setItem(KEY, JSON.stringify(next));
+  } catch {
+    /* quota / denied — the picker keeps the slots it already knows */
+  }
+}
+
+/** Every slot this origin has mounted, in the order they were first seen. */
+export function knownSlots(): SlotNote[] {
+  return read();
+}

--- a/packages/ui/test/chrome/add-to-picker.test.tsx
+++ b/packages/ui/test/chrome/add-to-picker.test.tsx
@@ -11,7 +11,10 @@ import { VendoAppEmbed, VendoProvider, createVendoClient, noteSlot, type VendoCl
 import { VendoSlot } from "../../src/chrome/index.js";
 import { createWireServer } from "../wire-server.js";
 
-const ready: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_1", title: "Invoices", status: "ready" };
+// The envelope's status is ALWAYS "building" — it never means done (core's
+// vendoAppRefSchema). Readiness is the wire's answer: app_1 is servable, so the
+// embed resolves its surface and the bar flips to the app's name.
+const ready: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_1", title: "Invoices", status: "building" };
 
 describe("the Add to… picker", () => {
   let wire: Awaited<ReturnType<typeof createWireServer>>;

--- a/packages/ui/test/chrome/add-to-picker.test.tsx
+++ b/packages/ui/test/chrome/add-to-picker.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+// "Add to…" — the placement write from a surface that is NOT the host's page.
+// A BYO chat page renders a generated app inline; the app belongs on the
+// dashboard, and until now the only path there was a host-built pin control.
+// Destinations come from slot-notes (a mounted VendoSlot is the only thing that
+// knows a slot exists) and the write is awaited, so "Added" is a fact.
+import type { VendoAppRef } from "@vendoai/core";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { VendoAppEmbed, VendoProvider, createVendoClient, noteSlot, type VendoClient } from "../../src/index.js";
+import { VendoSlot } from "../../src/chrome/index.js";
+import { createWireServer } from "../wire-server.js";
+
+const ready: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_1", title: "Invoices", status: "ready" };
+
+describe("the Add to… picker", () => {
+  let wire: Awaited<ReturnType<typeof createWireServer>>;
+  let client: VendoClient;
+
+  beforeEach(async () => {
+    window.localStorage.clear();
+    wire = await createWireServer();
+    client = createVendoClient({ baseUrl: wire.url });
+  });
+
+  afterEach(async () => {
+    cleanup();
+    vi.restoreAllMocks();
+    await wire.close();
+  });
+
+  const embed = () => render(
+    <VendoProvider client={client}><VendoAppEmbed refValue={ready} /></VendoProvider>,
+  );
+
+  it("offers nothing when this origin has never mounted a slot", async () => {
+    embed();
+    await screen.findByText("Invoices app surface");
+    expect(screen.queryByRole("button", { name: /Add to/ })).toBeNull();
+  });
+
+  it("lists the slots this origin has seen", async () => {
+    noteSlot({ id: "hero", label: "Hero" });
+    noteSlot({ id: "sidebar", label: "Sidebar" });
+    embed();
+    fireEvent.click(await screen.findByRole("button", { name: /Add to/ }));
+    expect(screen.getByRole("menuitem", { name: "Hero" })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: "Sidebar" })).toBeTruthy();
+  });
+
+  it("writes the placement over the wire and says where it landed", async () => {
+    noteSlot({ id: "hero", label: "Hero" });
+    embed();
+    fireEvent.click(await screen.findByRole("button", { name: /Add to/ }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Hero" }));
+    await waitFor(() => expect(
+      wire.state.placements.find(row => row.slot === "hero")?.appId,
+    ).toBe("app_1"));
+    expect(await screen.findByRole("button", { name: /Added to Hero/ })).toBeTruthy();
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("announces the placement so a slot on the page fills without waiting for its poll", async () => {
+    render(
+      <VendoProvider client={client}>
+        <VendoSlot id="hero"><span>Original hero</span></VendoSlot>
+        <VendoAppEmbed refValue={ready} />
+      </VendoProvider>,
+    );
+    fireEvent.click(await screen.findByRole("button", { name: /Add to/ }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Hero" }));
+    // The slot re-reads on the announcement, not on its 5s poll floor.
+    expect(await screen.findByText("Invoices app surface")).toBeTruthy();
+  });
+
+  it("keeps the menu open with one honest line when the write does not go through", async () => {
+    noteSlot({ id: "hero", label: "Hero" });
+    vi.spyOn(client.apps, "place").mockRejectedValue(new Error("wire down"));
+    embed();
+    fireEvent.click(await screen.findByRole("button", { name: /Add to/ }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Hero" }));
+    expect(await screen.findByRole("alert")).toBeTruthy();
+    expect(screen.getByRole("menu")).toBeTruthy();
+    // Nothing code-shaped from the wire's sentence reaches the page.
+    expect(document.body.textContent).not.toContain("wire down");
+  });
+
+  it("closes on Escape", async () => {
+    noteSlot({ id: "hero", label: "Hero" });
+    embed();
+    fireEvent.click(await screen.findByRole("button", { name: /Add to/ }));
+    fireEvent.keyDown(screen.getByRole("menu"), { key: "Escape" });
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("stays out of the bar while the build is still streaming", async () => {
+    noteSlot({ id: "hero", label: "Hero" });
+    const building: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_never", title: "Weather board", status: "building" };
+    render(<VendoProvider client={client}><VendoAppEmbed refValue={building} /></VendoProvider>);
+    await screen.findByText(/Building/);
+    expect(screen.queryByRole("button", { name: /Add to/ })).toBeNull();
+  });
+});

--- a/packages/ui/test/chrome/slot-notes-mount.test.tsx
+++ b/packages/ui/test/chrome/slot-notes-mount.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+// A mounted slot is the ONLY thing that knows a slot exists (slot-notes.ts), so
+// every VendoSlot says so — in every state, including the one where it renders
+// the host's own markup untouched.
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { VendoProvider, createVendoClient, knownSlots, type VendoClient } from "../../src/index.js";
+import { VendoSlot } from "../../src/chrome/index.js";
+import { createWireServer } from "../wire-server.js";
+
+describe("a mounted VendoSlot notes itself", () => {
+  let wire: Awaited<ReturnType<typeof createWireServer>>;
+  let client: VendoClient;
+
+  beforeEach(async () => {
+    window.localStorage.clear();
+    wire = await createWireServer();
+    client = createVendoClient({ baseUrl: wire.url });
+  });
+
+  afterEach(async () => {
+    cleanup();
+    vi.restoreAllMocks();
+    await wire.close();
+  });
+
+  it("notes the slot with a human label derived from its id", () => {
+    render(<VendoProvider client={client}><VendoSlot id="net-worth-card" /></VendoProvider>);
+    expect(knownSlots()).toEqual([{ id: "net-worth-card", label: "Net worth card" }]);
+  });
+
+  it("notes it even when the slot renders the host's children untouched", () => {
+    render(
+      <VendoProvider client={client}>
+        <VendoSlot id="hero"><span>Original hero</span></VendoSlot>
+      </VendoProvider>,
+    );
+    expect(knownSlots()).toEqual([{ id: "hero", label: "Hero" }]);
+  });
+
+  it("notes every slot on the page, once each", () => {
+    render(
+      <VendoProvider client={client}>
+        <VendoSlot id="hero" />
+        <VendoSlot id="sidebar_feed" />
+      </VendoProvider>,
+    );
+    expect(knownSlots().map(note => note.label)).toEqual(["Hero", "Sidebar feed"]);
+  });
+});

--- a/packages/ui/test/chrome/slot-states.test.tsx
+++ b/packages/ui/test/chrome/slot-states.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+// The slot's own build vocabulary. A placement row is written the moment the app
+// id is minted, so the slot knows it is about to be filled while the build is
+// still streaming — and says so, in the skeleton the empty state already uses.
+// Everything here goes over the fixture wire: the states are read from real
+// /apps/placements answers, never from a stubbed hook.
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { VendoProvider, createVendoClient, type VendoClient } from "../../src/index.js";
+import { VendoSlot } from "../../src/chrome/index.js";
+import { BUILD_FAILURE_COPY } from "../../src/chrome/thread/message-data.js";
+import { createWireServer } from "../wire-server.js";
+
+describe("VendoSlot build states", () => {
+  let wire: Awaited<ReturnType<typeof createWireServer>>;
+  let client: VendoClient;
+
+  beforeEach(async () => {
+    window.localStorage.clear();
+    wire = await createWireServer();
+    client = createVendoClient({ baseUrl: wire.url });
+  });
+
+  afterEach(async () => {
+    // Unmount BEFORE closing the wire: a still-mounted slot keeps polling into
+    // the closing server and server.close() livelocks to the hook timeout.
+    cleanup();
+    vi.restoreAllMocks();
+    await wire.close();
+  });
+
+  const slot = (id: string) => render(
+    <VendoProvider client={client}>
+      <VendoSlot id={id}><span>Original hero</span></VendoSlot>
+    </VendoProvider>,
+  );
+
+  describe("building", () => {
+    it("shows a skeleton in the slot while the placed build is still streaming", async () => {
+      wire.state.placements.push({ slot: "hero", appId: "app_minting" });
+      slot("hero");
+      const beat = await screen.findByRole("status");
+      expect(beat.textContent).toContain("Building your view");
+      // The host's markup gives way — the slot is committed to this app.
+      expect(screen.queryByText("Original hero")).toBeNull();
+    });
+
+    it("mounts the app in place the moment the build lands — no remount, no reload", async () => {
+      wire.state.placements.push({ slot: "hero", appId: "app_lands" });
+      wire.state.landingApps.set("app_lands", { remaining: 2, name: "Trip planner" });
+      slot("hero");
+      expect((await screen.findByRole("status")).textContent).toContain("Building your view");
+      expect(await screen.findByText("Trip planner app surface")).toBeTruthy();
+    });
+  });
+});

--- a/packages/ui/test/chrome/slot-states.test.tsx
+++ b/packages/ui/test/chrome/slot-states.test.tsx
@@ -36,21 +36,122 @@ describe("VendoSlot build states", () => {
   );
 
   describe("building", () => {
-    it("shows a skeleton in the slot while the placed build is still streaming", async () => {
+    // A slot with host markup of its own KEEPS it while a build forms — a
+    // working host component never blanks into a skeleton for the length of a
+    // build (pinned by slot-discovery.test.tsx). The beat below is the empty
+    // slot's: it had only an invitation to give up.
+    const emptySlot = (id: string) => render(
+      <VendoProvider client={client}><VendoSlot id={id} /></VendoProvider>,
+    );
+
+    it("shows a skeleton in an empty slot while the placed build is still streaming", async () => {
       wire.state.placements.push({ slot: "hero", appId: "app_minting" });
-      slot("hero");
+      emptySlot("hero");
       const beat = await screen.findByRole("status");
       expect(beat.textContent).toContain("Building your view");
-      // The host's markup gives way — the slot is committed to this app.
-      expect(screen.queryByText("Original hero")).toBeNull();
+      // The invitation gives way — there is nothing to ask for any more.
+      expect(screen.queryByText("This space builds itself")).toBeNull();
     });
 
     it("mounts the app in place the moment the build lands — no remount, no reload", async () => {
       wire.state.placements.push({ slot: "hero", appId: "app_lands" });
       wire.state.landingApps.set("app_lands", { remaining: 2, name: "Trip planner" });
-      slot("hero");
+      emptySlot("hero");
       expect((await screen.findByRole("status")).textContent).toContain("Building your view");
       expect(await screen.findByText("Trip planner app surface")).toBeTruthy();
+    });
+  });
+
+  describe("failed", () => {
+    // The real sentences the wire carries — every one is written for whoever can
+    // FIX the build, and a slot is a host's own page, the most public surface we
+    // have. Same audit as the embed's (test/embeds.test.tsx).
+    const developerReason = "This app wasn't created, because it didn't pass the checks that keep an app honest:"
+      + " the `value` expression is a declarative string that the DataTable does not evaluate,"
+      + " not JavaScript: amount / sum(spending.data.amount)";
+
+    const codeShaped: readonly [string, RegExp][] = [
+      ["a backtick quote", /`/],
+      ["call syntax", /\w+\(/],
+      ["a dotted path", /\w\.\w+\.\w/],
+      ["a snake_case identifier", /[A-Za-z]_[A-Za-z]/],
+      ["a package specifier", /@[\w-]+\//],
+      ["an npm command", /\bnpm\b/],
+      ["a shouted env var", /\b[A-Z][A-Z0-9_]{4,}\b/],
+    ];
+
+    function doomed(retryable: boolean, prompt?: string) {
+      wire.state.failedApps.set("app_doomed", {
+        reason: developerReason,
+        retryable,
+        ...(prompt === undefined ? {} : { prompt }),
+      });
+      wire.state.placements.push({ slot: "hero", appId: "app_doomed" });
+    }
+
+    it("says the CONSUMER sentence — not one fragment of the wire's reaches the page", async () => {
+      doomed(true, "a spending board");
+      slot("hero");
+      await screen.findByText(BUILD_FAILURE_COPY);
+      const rendered = document.querySelector<HTMLElement>("[data-vendo-slot]")?.textContent ?? "";
+      expect(rendered).not.toContain(developerReason);
+      for (const word of developerReason.split(/\s+/).filter(token => token.length > 12)) {
+        expect(rendered).not.toContain(word);
+      }
+      for (const [what, pattern] of codeShaped) {
+        expect(pattern.test(rendered), `${what} reached the slot: ${rendered}`).toBe(false);
+      }
+    });
+
+    it("offers a retry that re-issues the ORIGINAL request and takes the slot", async () => {
+      doomed(true, "a spending board");
+      slot("hero");
+      fireEvent.click(await screen.findByRole("button", { name: "Try again" }));
+      await waitFor(() => expect(
+        wire.state.placements.find(row => row.slot === "hero")?.appId,
+      ).not.toBe("app_doomed"));
+      // The fixture names a created app after its prompt, so the mounted app is
+      // provably the re-issued request and not the failed record.
+      expect(await screen.findByText("a spending board app surface")).toBeTruthy();
+    });
+
+    it("offers no retry when the failure is not retryable — never a button that lies", async () => {
+      doomed(false, "a spending board");
+      slot("hero");
+      await screen.findByText(BUILD_FAILURE_COPY);
+      expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
+      expect(screen.getByRole("button", { name: "Clear this slot" })).toBeTruthy();
+    });
+
+    it("offers no retry when the record kept no request — there is nothing honest to re-issue", async () => {
+      doomed(true);
+      slot("hero");
+      await screen.findByText(BUILD_FAILURE_COPY);
+      expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
+    });
+
+    it("clearing the slot unplaces the app and gives the host its own markup back", async () => {
+      doomed(false, "a spending board");
+      slot("hero");
+      fireEvent.click(await screen.findByRole("button", { name: "Clear this slot" }));
+      await waitFor(() => expect(wire.state.placements.some(row => row.slot === "hero")).toBe(false));
+      expect(await screen.findByText("Original hero")).toBeTruthy();
+    });
+  });
+
+  describe("ready", () => {
+    it("mounts the placed app — the tree surface", async () => {
+      wire.state.placements.push({ slot: "hero", appId: "app_1" });
+      slot("hero");
+      expect(await screen.findByText("Invoices app surface")).toBeTruthy();
+    });
+
+    it("mounts the placed app — the http surface", async () => {
+      wire.state.httpApps.set("app_1", "/frame-target.html");
+      wire.state.placements.push({ slot: "hero", appId: "app_1" });
+      slot("hero");
+      const frame = await screen.findByTitle("Vendo app");
+      expect(frame.getAttribute("src")).toBe("/frame-target.html");
     });
   });
 });

--- a/packages/ui/test/chrome/slot-states.test.tsx
+++ b/packages/ui/test/chrome/slot-states.test.tsx
@@ -55,7 +55,7 @@ describe("VendoSlot build states", () => {
 
     it("mounts the app in place the moment the build lands — no remount, no reload", async () => {
       wire.state.placements.push({ slot: "hero", appId: "app_lands" });
-      wire.state.landingApps.set("app_lands", { remaining: 2, name: "Trip planner" });
+      wire.state.landingApps.set("app_lands", { after: 2, seen: 0, name: "Trip planner" });
       emptySlot("hero");
       expect((await screen.findByRole("status")).textContent).toContain("Building your view");
       expect(await screen.findByText("Trip planner app surface")).toBeTruthy();

--- a/packages/ui/test/slot-notes-ssr.test.ts
+++ b/packages/ui/test/slot-notes-ssr.test.ts
@@ -1,0 +1,13 @@
+// @vitest-environment node
+// A slot renders on the server too; touching storage during that render is a
+// crash, so both entry points answer honestly with no window at all.
+import { describe, expect, it } from "vitest";
+import { knownSlots, noteSlot } from "../src/slot-notes.js";
+
+describe("slot notes on the server", () => {
+  it("knows no slots and writes none", () => {
+    expect(typeof window).toBe("undefined");
+    expect(() => noteSlot({ id: "hero", label: "Hero" })).not.toThrow();
+    expect(knownSlots()).toEqual([]);
+  });
+});

--- a/packages/ui/test/slot-notes.test.ts
+++ b/packages/ui/test/slot-notes.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+// The picker's destinations. A slot id is the HOST's markup — no Vendo record
+// carries it — so a mounted VendoSlot noting itself is the only way a surface
+// on another page can offer that slot at all. Origin-scoped localStorage, the
+// same storage law as chrome/discoverability.ts.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { knownSlots, noteSlot } from "../src/slot-notes.js";
+
+describe("slot notes", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("knows nothing before a slot mounts", () => {
+    expect(knownSlots()).toEqual([]);
+  });
+
+  it("records a slot and reads it back", () => {
+    noteSlot({ id: "hero", label: "Hero" });
+    expect(knownSlots()).toEqual([{ id: "hero", label: "Hero" }]);
+  });
+
+  it("keeps first-seen order and never duplicates an id", () => {
+    noteSlot({ id: "hero", label: "Hero" });
+    noteSlot({ id: "net-worth", label: "Net worth" });
+    noteSlot({ id: "hero", label: "Hero" });
+    expect(knownSlots().map(note => note.id)).toEqual(["hero", "net-worth"]);
+  });
+
+  it("updates a label in place when the same slot mounts with a new one", () => {
+    noteSlot({ id: "hero", label: "Hero" });
+    noteSlot({ id: "hero", label: "Home hero" });
+    expect(knownSlots()).toEqual([{ id: "hero", label: "Home hero" }]);
+  });
+
+  it("survives a value another tool wrote under the key", () => {
+    window.localStorage.setItem("vendo.slots", "{not json");
+    expect(knownSlots()).toEqual([]);
+    noteSlot({ id: "hero", label: "Hero" });
+    expect(knownSlots()).toEqual([{ id: "hero", label: "Hero" }]);
+  });
+
+  it("drops entries that are not slot notes rather than handing them to the picker", () => {
+    window.localStorage.setItem("vendo.slots", JSON.stringify([{ id: "hero" }, 7, { id: "ok", label: "Ok" }]));
+    expect(knownSlots()).toEqual([{ id: "ok", label: "Ok" }]);
+  });
+
+  it("does not throw when storage refuses the write (quota, private mode)", () => {
+    // Storage.prototype, not the instance: jsdom's localStorage is a Proxy and
+    // spying the instance property does not stick.
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+    expect(() => noteSlot({ id: "hero", label: "Hero" })).not.toThrow();
+  });
+});

--- a/packages/ui/test/wire-placements.test.ts
+++ b/packages/ui/test/wire-placements.test.ts
@@ -39,7 +39,7 @@ describe("fixture wire — placements", () => {
   });
 
   it("lands a building app after its poll window, in place", async () => {
-    wire.state.landingApps.set("app_lands", { remaining: 2, name: "Trip planner" });
+    wire.state.landingApps.set("app_lands", { after: 2, seen: 0, name: "Trip planner" });
     await client.apps.place("app_lands", "hero");
     expect((await client.apps.placements(["hero"]))[0]?.status).toBe("building");
     expect((await client.apps.placements(["hero"]))[0]).toEqual({

--- a/packages/ui/test/wire-placements.test.ts
+++ b/packages/ui/test/wire-placements.test.ts
@@ -1,0 +1,73 @@
+// The fixture wire's placement half — asserted directly, because every slot and
+// picker test in this PR reads and writes through it. A fixture that lies makes
+// every test above it meaningless.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createVendoClient, type VendoClient } from "../src/index.js";
+import { createWireServer } from "./wire-server.js";
+
+describe("fixture wire — placements", () => {
+  let wire: Awaited<ReturnType<typeof createWireServer>>;
+  let client: VendoClient;
+
+  beforeEach(async () => {
+    wire = await createWireServer();
+    client = createVendoClient({ baseUrl: wire.url });
+  });
+
+  afterEach(async () => {
+    await wire.close();
+  });
+
+  it("reports a placed, servable app as ready with its title", async () => {
+    await client.apps.place("app_1", "hero");
+    expect(await client.apps.placements()).toEqual([
+      { slot: "hero", app: "app_1", title: "Invoices", status: "ready" },
+    ]);
+  });
+
+  it("reports an id with no servable record yet as building", async () => {
+    await client.apps.place("app_minting", "hero");
+    const [entry] = await client.apps.placements(["hero"]);
+    expect(entry?.status).toBe("building");
+  });
+
+  it("reports a terminally failed build as failed", async () => {
+    wire.state.failedApps.set("app_doomed", { reason: "quota exhausted" });
+    await client.apps.place("app_doomed", "hero");
+    const [entry] = await client.apps.placements(["hero"]);
+    expect(entry?.status).toBe("failed");
+  });
+
+  it("lands a building app after its poll window, in place", async () => {
+    wire.state.landingApps.set("app_lands", { remaining: 2, name: "Trip planner" });
+    await client.apps.place("app_lands", "hero");
+    expect((await client.apps.placements(["hero"]))[0]?.status).toBe("building");
+    expect((await client.apps.placements(["hero"]))[0]).toEqual({
+      slot: "hero", app: "app_lands", title: "Trip planner", status: "ready",
+    });
+  });
+
+  it("filters to the slots asked for", async () => {
+    await client.apps.place("app_1", "hero");
+    await client.apps.place("app_1", "sidebar");
+    expect((await client.apps.placements(["sidebar"])).map(entry => entry.slot)).toEqual(["sidebar"]);
+  });
+
+  it("evicts the app already in the slot and reports which one", async () => {
+    await client.apps.place("app_1", "hero");
+    expect(await client.apps.place("app_auto", "hero")).toEqual({ evicted: "app_1" });
+    const [entry] = await client.apps.placements(["hero"]);
+    expect(entry?.app).toBe("app_auto");
+  });
+
+  it("unplace clears the row", async () => {
+    await client.apps.place("app_1", "hero");
+    await client.apps.unplace("app_1", "hero");
+    expect(await client.apps.placements()).toEqual([]);
+  });
+
+  it("serves a rung-4 app as the http surface kind", async () => {
+    wire.state.httpApps.set("app_1", "/frame-target.html");
+    expect(await client.apps.open("app_1")).toEqual({ kind: "http", url: "/frame-target.html" });
+  });
+});

--- a/packages/ui/test/wire-server.ts
+++ b/packages/ui/test/wire-server.ts
@@ -90,6 +90,12 @@ function app(id: string, name: string, automation = false): AppDocument {
   };
 }
 
+/** The fixture's app shape, for callers outside this module (the browser
+ *  harness seeds served/landing apps before the first request). */
+export function fixtureApp(id: string, name: string): AppDocument {
+  return app(id, name);
+}
+
 /** Existing-agents polish — a model-realistic generated dashboard island: the
  *  page sizes itself with viewport-height CSS in a `<style>` TAG (not inline
  *  styles), the shape the live examples' builds produce. Inside an auto-sized
@@ -311,6 +317,13 @@ export async function createWireServer(options: WireServerOptions = {}) {
      *  per subject — one row per slot, and the entry's status is derived from
      *  the app list on read, never stored. */
     placements: [] as Array<{ slot: string; appId: string }>,
+    /** PR3 — apps whose build "lands" after N placements polls (app id →
+     *  {remaining, name}), so a test can watch a slot go building → ready over
+     *  the real wire instead of asserting two static pages. */
+    landingApps: new Map<string, { remaining: number; name: string }>(),
+    /** PR3 — apps served as an `{kind:"http"}` surface (app id → url): the
+     *  second surface kind a slot must mount. */
+    httpApps: new Map<string, string>(),
     approvals: [approval()],
     // Existing-agents — decided approvals move here so GET /approvals/:id can
     // answer the embed's poll; tests may also seed terminal states directly.
@@ -1102,6 +1115,14 @@ export async function createWireServer(options: WireServerOptions = {}) {
       // real route table (the catch-all would otherwise read "placements" as an
       // app id).
       if (url.pathname === "/apps/placements" && method === "GET") {
+        // PR3 — the harness's build window: a landing app joins the app list
+        // after a couple of polls, exactly like a build completing mid-poll.
+        for (const [landingId, landing] of state.landingApps) {
+          landing.remaining -= 1;
+          if (landing.remaining <= 0 && !state.apps.some(item => item.id === landingId)) {
+            state.apps.push(app(landingId, landing.name));
+          }
+        }
         const asked = (url.searchParams.get("slots") ?? "")
           .split(",").map(slot => slot.trim()).filter(slot => slot.length > 0);
         const rows = state.placements.filter(row => asked.length === 0 || asked.includes(row.slot));
@@ -1111,9 +1132,14 @@ export async function createWireServer(options: WireServerOptions = {}) {
             slot: row.slot,
             app: row.appId,
             title: placed?.name ?? "",
-            status: placed === undefined
-              ? "building"
-              : placed.buildFailed === undefined ? "ready" : "failed",
+            // PR3 — a failure record is a terminal build, whether the fixture
+            // carries it on the app document (the runtime's persisted
+            // `buildFailed`) or in the failedApps shim open() answers from.
+            status: state.failedApps.has(row.appId)
+              ? "failed"
+              : placed === undefined
+                ? "building"
+                : placed.buildFailed === undefined ? "ready" : "failed",
           };
         }));
       }
@@ -1207,6 +1233,10 @@ export async function createWireServer(options: WireServerOptions = {}) {
           return wireError(response, "not-found", "App not found", 404);
         }
         if (action === "open" && method === "GET") {
+          // A served (rung-4) app answers with its machine url; everything else
+          // is a tree. Both must mount in a slot.
+          const served = state.httpApps.get(id);
+          if (served !== undefined) return json(response, { kind: "http", url: served });
           return json(response, { kind: "tree", payload: state.apps[index]?.tree });
         }
         if (action === "call" && method === "POST") return json(response, { status: "ok", output: parsedBody });

--- a/packages/ui/test/wire-server.ts
+++ b/packages/ui/test/wire-server.ts
@@ -317,10 +317,12 @@ export async function createWireServer(options: WireServerOptions = {}) {
      *  per subject — one row per slot, and the entry's status is derived from
      *  the app list on read, never stored. */
     placements: [] as Array<{ slot: string; appId: string }>,
-    /** PR3 — apps whose build "lands" after N placements polls (app id →
-     *  {remaining, name}), so a test can watch a slot go building → ready over
-     *  the real wire instead of asserting two static pages. */
-    landingApps: new Map<string, { remaining: number; name: string }>(),
+    /** PR3 — apps whose build "lands" on the `after`-th placements read, so a
+     *  test can watch a slot go building → ready over the real wire instead of
+     *  asserting two static pages. Placing one again rewinds it (see the place
+     *  route): the browser harness shares one wire across a whole spec file, so
+     *  a one-shot window would be spent by the first attempt. */
+    landingApps: new Map<string, { after: number; seen: number; name: string }>(),
     /** PR3 — apps served as an `{kind:"http"}` surface (app id → url): the
      *  second surface kind a slot must mount. */
     httpApps: new Map<string, string>(),
@@ -1116,10 +1118,10 @@ export async function createWireServer(options: WireServerOptions = {}) {
       // app id).
       if (url.pathname === "/apps/placements" && method === "GET") {
         // PR3 — the harness's build window: a landing app joins the app list
-        // after a couple of polls, exactly like a build completing mid-poll.
+        // after a couple of reads, exactly like a build completing mid-poll.
         for (const [landingId, landing] of state.landingApps) {
-          landing.remaining -= 1;
-          if (landing.remaining <= 0 && !state.apps.some(item => item.id === landingId)) {
+          landing.seen += 1;
+          if (landing.seen >= landing.after && !state.apps.some(item => item.id === landingId)) {
             state.apps.push(app(landingId, landing.name));
           }
         }
@@ -1151,6 +1153,15 @@ export async function createWireServer(options: WireServerOptions = {}) {
         if (placeMatch[2] === "unplace") {
           if (held?.appId === id) state.placements = state.placements.filter(row => row.slot !== slot);
           return json(response, {});
+        }
+        // PR3 — placing a landing app rewinds its build window and takes back
+        // its servable record, so a browser spec can seed the building → ready
+        // story per attempt (the harness's wire outlives every test in a file).
+        const landing = state.landingApps.get(id);
+        if (landing !== undefined) {
+          landing.seen = 0;
+          const landed = state.apps.findIndex(item => item.id === id);
+          if (landed >= 0) state.apps.splice(landed, 1);
         }
         state.placements = [...state.placements.filter(row => row.slot !== slot), { slot, appId: id }];
         return json(response, held === undefined || held.appId === id ? {} : { evicted: held.appId });

--- a/packages/vendo/src/react.tsx
+++ b/packages/vendo/src/react.tsx
@@ -71,6 +71,11 @@ export {
   // own control instead of a Vendo surface.
   announcePin,
   onPinAnnounced,
+  // slot-notes.ts — the destinations the embed's "Add to…" picker offers; a
+  // mounted VendoSlot is the only thing that knows a slot exists.
+  knownSlots,
+  noteSlot,
+  type SlotNote,
   // theme.ts
   defaultVendoTheme,
   resolveTheme,


### PR DESCRIPTION
Stacked on PR2 (placement rows + `useSlotApp`/`usePlacements`). Merge at the tip of the stack; base is `yousefh409/slots-agent-addressing`.

## What changed

- **`VendoSlot` renders the placed app's real state.**
  - *building* — an **empty** slot shows the empty state's own skeleton, minus the invitation. A slot carrying the host's own markup **keeps it** until the build is ready: a working host component must never blank into a skeleton for the length of a build ("never a dead rectangle" applies to the host's content too), and the conversation surface already carries the building beat for the person who asked.
  - *failed* — the consumer sentence, a **"Try again"** that re-issues the ORIGINAL request (offered only when the failed record kept one — re-issuing anything else is a different build wearing this one's name), and **"Clear this slot"** = unplace, which is how the host's own markup comes back.
  - *ready* — unchanged mount path, now proven in a browser for **both** surface kinds (a tree payload and a served machine url).
- **`slot-notes.ts` (new)** — a mounted `VendoSlot` records itself in origin-scoped `localStorage`, because a slot id is host markup and nothing on the server knows a slot exists until something is placed in it. A slot the host filled with an explicit `appId`/`pin` stays out of the list: a placement written into it would never be read.
- **"Add to…" in the app embed's bar** — destinations are the noted slots, and the write is `await client.apps.place(...)` then `announcePin(...)`. The affordance owns the placement rather than firing a host callback and hoping, so "Added to Hero" is a fact.
- **Fixture wire** — serves the http surface kind and a re-armable build window (`landingApps`), so every test above reads and writes through a real HTTP server on both sides.

## Consumer voice

The wire's build-failure `reason` never reaches the slot. Enforced by a mechanical code-shaped audit in **both** the unit suite and the browser suite, over the exact developer sentence captured from a real user's thread on 2026-08-03. The audit was proven to fail: rendering `failure.reason` instead of `BUILD_FAILURE_COPY` turns it red.

## Verified

- `pnpm build` — green
- `pnpm test:affected` — green except the 7 known pre-existing reds on this stack (`core/packaging.e2e.test.ts` x3, `vendo/dev-creds/model.test.ts` x2, `store` durability + split-brain drills x2). **`@vendoai/ui`: 122 files / 1087 tests, all passing.**
- `pnpm typecheck` — green (45/45) · `pnpm lint` — green
- `playwright test e2e/slot-states.spec.ts` — 5 passed · `e2e/smoke.spec.ts e2e/accessibility.spec.ts` — 25 passed

Screenshots in the first comment.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show real build states in slots and add an “Add to…” picker on app embeds so users can place generated apps into noted slots directly. Improves UX for building/failed states and mounts both tree and http surfaces.

- New Features
  - `VendoSlot` now reflects placement status:
    - building: empty slots show a skeleton; slots with host markup keep it until ready
    - failed: shows consumer copy with “Try again” (when retryable and prompt is known) and “Clear this slot”
    - ready: mounts both surface kinds (tree and served http)
  - Added `AddToPicker` to the embed’s bar (shown when ready). Lists noted slots, awaits `client.apps.place`, announces with `announcePin`, and confirms “Added to …”.
  - New slot-notes store: `noteSlot` and `knownSlots` (origin-scoped `localStorage`). A self-resolving `VendoSlot` notes itself with a human label. Exported from `@vendoai/ui` and re-exported by `@vendoai/vendo`.
  - CSS for the picker menu and integration into `VendoAppEmbed`.

- Bug Fixes
  - Build failure details from the wire never reach the host page; only consumer-friendly copy is shown.
  - The building state never blanks host-provided markup; the skeleton appears only in empty slots.

<sup>Written for commit 64e6f7860f6c4963b71e88eb1cf37ed5d6616cc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

