### PR TITLE
fix(harnesses): a yielded turn error persists its specific message — the yield path was only proven through a throwing double

### DIFF
--- a/packages/harnesses/src/provider-401.test.ts
+++ b/packages/harnesses/src/provider-401.test.ts
@@ -16,13 +16,16 @@
 import { VendoError, type ThreadId } from "@vendoai/core";
 import { APICallError } from "ai";
 import type { UIMessage } from "ai";
+import { MockLanguageModelV3 } from "ai/test";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { defineHarness } from "./define.js";
 import { createHarnessRuntime } from "./runtime.js";
+import { vendo } from "./vendo/vendo.js";
 import {
   boundRegistry,
   ctx,
   readSse,
+  seats,
   testGuard,
   testSkills,
   testTranscript,
@@ -147,5 +150,65 @@ describe("the credential ladder's fix survives the fold", () => {
       expect(turn.streamed, where).toBe(`Vendo: ${KEYLESS.message} (validation)`);
       expect(turn.persisted, where).toBe(`Vendo: ${KEYLESS.message} (validation)`);
     }
+  });
+});
+
+/**
+ * …and the path the cases above cannot reach.
+ *
+ * Both `failedTurn` shapes THROW, which lands in the runtime's catch, where
+ * `specificWireErrorMessage` still holds the real `VendoError`. The SHIPPED
+ * harness never throws: `vendo()` catches a model failure and YIELDS
+ * `{ type: "error", message: wireErrorMessage(error) }` (vendo.ts). By then the
+ * sentence is a formatted STRING, and the runtime's error case wrote it to the
+ * wire before recording it — which re-entered the stream's own `onError` with a
+ * plain Error, so the generic constant claimed the once-per-turn slot and the
+ * specific record became a no-op.
+ *
+ * Live banner right, persisted line generic: a keyless host reloaded the page
+ * and lost the one sentence that says what to do. Found by a cold walk of the
+ * real browser, not by this suite, because this suite mocked the harness — the
+ * seam the whole feature turns on.
+ */
+async function keylessOnTheShippedHarness(): Promise<{ streamed?: string; persisted?: string }> {
+  vi.spyOn(console, "error").mockImplementation(() => undefined);
+  const guard = testGuard();
+  const transcript = testTranscript();
+  const runtime = createHarnessRuntime({
+    tools: boundRegistry({}, guard),
+    guard,
+    skills: testSkills(),
+    transcript,
+  });
+  const parts = await readSse(await runtime.run({
+    // The real one. A double that throws proves the other branch.
+    harness: vendo(),
+    threadId: THREAD,
+    messages: [userMessage("m1", "go")] as UIMessage[],
+    ctx: ctx(),
+    workspace: testWorkspace(),
+    // What a keyless deployment hits: the credential ladder's VendoError, raised
+    // where the loop reaches for the model — inside `vendo()`'s own try.
+    models: seats(new MockLanguageModelV3({ doStream: async () => { throw KEYLESS; } })),
+    interactive: true,
+  }));
+  const stored = await transcript.list(ctx().principal, THREAD);
+  const notice = stored
+    .flatMap((message) => message.parts)
+    .find((part) => part.type === "data-vendo-turn-error");
+  return {
+    streamed: parts.find((part) => part.type === "error")?.errorText as string | undefined,
+    persisted: (notice as { data?: { message?: string } } | undefined)?.data?.message,
+  };
+}
+
+describe("a yielded turn error keeps its sentence", () => {
+  it("persists what the banner said on the SHIPPED harness, not the generic constant", async () => {
+    const turn = await keylessOnTheShippedHarness();
+    const guidance = `Vendo: ${KEYLESS.message} (validation)`;
+    // The banner was always right — this is the half that regressed.
+    expect(turn.streamed).toBe(guidance);
+    expect(turn.persisted).toBe(guidance);
+    expect(turn.persisted).not.toBe(UNNAMEABLE);
   });
 });

--- a/packages/harnesses/src/runtime.ts
+++ b/packages/harnesses/src/runtime.ts
@@ -509,18 +509,26 @@ export function createHarnessRuntime(deps: HarnessRuntimeDeps): HarnessRuntime {
                   break;
                 case "error":
                   failure = { message: event.message, ...(event.code === undefined ? {} : { code: event.code }) };
-                  // The SCREEN's failure affordance — the same ai-SDK error chunk
-                  // `createAgent` raises, so the host renders its banner, its
-                  // Retry and its detail line. Splicing the sentence into the
-                  // assistant's prose instead would read as the agent talking and
-                  // would offer the user nothing to act on.
                   text.break();
                   surfaced = event.message;
-                  writeError(writer, event.message);
-                  // …and the TRANSCRIPT's. The chunk above belongs to no
-                  // message, so without this the reload of a failed turn shows
-                  // the question answered by a blank reply.
+                  // The TRANSCRIPT's failure affordance, and it goes FIRST. The
+                  // chunk below belongs to no message, so without this the reload
+                  // of a failed turn shows the question answered by a blank reply
+                  // — but writing that chunk re-enters the stream's own `onError`
+                  // (which knows it: see the note there), and by then this
+                  // sentence is a formatted STRING, not the `VendoError` it came
+                  // from. `onError` therefore records the generic constant and
+                  // takes the one-per-turn slot with it, leaving the record below
+                  // a no-op. The banner said "run `vendo login`" and the reload
+                  // said "something went wrong". Claiming the slot first is what
+                  // keeps the two the same sentence.
                   recordTurnError(event.message, (part) => writer.write(part as never));
+                  // …and the SCREEN's — the same ai-SDK error chunk `createAgent`
+                  // raised, so the host renders its banner, its Retry and its
+                  // detail line. Splicing the sentence into the assistant's prose
+                  // instead would read as the agent talking and would offer the
+                  // user nothing to act on.
+                  writeError(writer, event.message);
                   break;
                 case "usage":
                   // Audit/metering only — never the screen, never the transcript.


### PR DESCRIPTION
Finding 1 from the fresh-eyes cold walk (#864 comment). Reproduced, fixed, and
proven red first through the **shipped** harness.

## The bug

A keyless host got the right sentence live and the wrong one on reload:

```
data: {"type":"error","errorText":"Vendo: Vendo found no model key. … run `vendo login` … (validation)"}
data: {"type":"data-vendo-turn-error","data":{"message":"Something went wrong on my side, so I stopped."}}
```

The transient banner is specific; the thing that survives the refresh — the
whole point of the persisted turn error — is the generic constant.

## Why

`vendo()` never throws. On a model failure it **yields**
`{ type: "error", message: wireErrorMessage(error) }` (`vendo/vendo.ts`), and by
then the sentence is a formatted **string**, not the `VendoError` it came from.

The runtime's `case "error"` wrote that to the wire before recording it:

1. `writeError(writer, event.message)` — writing an error chunk re-enters the
   stream's own `onError`; the note at `runtime.ts` already documented that it does
2. `onError` sees a plain `Error`, so `specificWireErrorMessage` returns
   `undefined` → it records `HARNESS_FAILED` and flips `turnErrorRecorded`
3. the specific `recordTurnError(event.message, …)` below is then a no-op

## The fix

Two lines swapped: the transcript record claims the one-per-turn slot **before**
the chunk that re-enters `onError`. The screen gets the identical chunk it always
did. I took the reorder over a pending-specific slot in `onError` because it is
smaller and keeps the ordering rule in one place.

## Why the green suite missed it

Both `failedTurn` shapes in `provider-401.test.ts` **throw** — the harness
double, or `liveTurn`. A throw lands in the runtime's catch, where the real
`VendoError` is still intact and `specificWireErrorMessage` wins. The branch the
product runs was never exercised: **the mocked seam was the harness itself**,
which is exactly the class `CLAUDE.md` calls out.

The new case composes the real `vendo()` against a model that fails keyless and
asserts the PERSISTED part. On the pre-fix tree it fails precisely where the walk
said it would — `streamed` passes, `persisted` does not:

```
✓ expect(turn.streamed).toBe(guidance)
× expect(turn.persisted).toBe(guidance)
  Expected: "Vendo: Vendo found no model key. … (validation)"
  Received: "Something went wrong on my side, so I stopped."
```

Green after. The three throwing cases stay — they cover the other half.

## Gates

- `packages/harnesses` full suite: **431 passed**, 13 skipped, 34 files (the
  reorder changes wire ordering, so I ran all of it, not just the touched file)
- `provider-401.test.ts`: 4 passed
- `audit-superset.e2e.test.ts` + `harness-wire.test.ts` in `@vendoai/vendo`: 22 passed
- `typecheck` on `@vendoai/harnesses` + `@vendoai/vendo`: clean

## Not in this PR

The walk's other findings are separate: thread delete has no UI affordance
(Finding 2), the cached `build:jail` leaves `dist` restored but `src/` missing
(Finding 3, pre-existing), and the 144px failure chip is `nowrap` + ellipsis, so
the restored sentence will be clipped there — worth its own UI fix now that there
is something worth reading.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes persisted turn error messages for yielded errors so the specific guidance (e.g., “run `vendo login`”) survives reloads. Records the turn error before writing the error chunk, keeping the banner and persisted line in sync.

- **Bug Fixes**
  - In `packages/harnesses/src/runtime.ts`, record `data-vendo-turn-error` before `writeError(...)` to avoid `onError` overwriting the one-per-turn slot with a generic message.
  - Adds a test in `packages/harnesses/src/provider-401.test.ts` that uses the shipped `vendo()` with a keyless `MockLanguageModelV3` to exercise the yield path and assert the persisted message; existing throwing-path tests remain.

<sup>Written for commit 73941e9e7f0403593a7c058b2d8258e7cbe2d58b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

