### PR TITLE
feat(harnesses): a mid-turn overflow compacts and retries once, silently

### DIFF
--- a/packages/harnesses/src/vendo/index.ts
+++ b/packages/harnesses/src/vendo/index.ts
@@ -39,4 +39,8 @@ export {
   type CompactionConfig,
   type CompactionState,
 } from "./compaction.js";
+// Told apart from a 429 by the same pattern set the retry uses, because a host
+// driving `startTurn` itself faces the identical fork: compact and continue, or
+// surface the failure.
+export { isContextOverflow } from "./overflow.js";
 export { failoverModel, type ResolvedModel } from "./failover.js";

--- a/packages/harnesses/src/vendo/overflow.test.ts
+++ b/packages/harnesses/src/vendo/overflow.test.ts
@@ -1,0 +1,312 @@
+/**
+ * A prompt that did not fit is recoverable — exactly once.
+ *
+ * Two things are pinned here and they are different in kind. The classifier is a
+ * pattern set, and what matters about it is the line it draws: a provider saying
+ * "your prompt is too big" must be told apart from a provider saying "you are
+ * asking too often", because the answers are opposite — compact and continue
+ * versus back off and stop. Bedrock formats a throttle as "Too many tokens,
+ * please wait", which reads as an overflow to anyone matching on words alone, and
+ * a turn that "recovers" from a rate limit by summarizing and calling again has
+ * turned one 429 into two.
+ *
+ * The retry is the other half, and its whole design is in one sentence: the
+ * second attempt CONTINUES the first. Every tool call the failed attempt made
+ * went through `turn.tools.call()` and committed a real effect — a transfer, a
+ * file, a build — so a retry that replays them performs each one twice. What the
+ * first attempt produced therefore rides the next prompt verbatim, below the
+ * compaction, and the only thing that changes between the two attempts is how
+ * much history the projection carries.
+ */
+import type { HarnessEvent, ToolRegistry, Turn } from "@vendoai/core";
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+import type { LanguageModel } from "ai";
+import { describe, expect, it } from "vitest";
+import { isContextOverflow } from "./overflow.js";
+import { vendo } from "./vendo.js";
+import { createTurnState } from "../harness-state.js";
+import { createTurnTools } from "../turn-tools.js";
+import {
+  boundRegistry,
+  ctx,
+  readTool,
+  seats,
+  testGuard,
+  testSkills,
+  testWorkspace,
+  textTurn,
+  toolCallTurn,
+  userMessage,
+  ZERO_USAGE,
+} from "../test-doubles.test-util.js";
+
+// ── the classifier ───────────────────────────────────────────────────────────
+
+/**
+ * One real sentence per ported pattern, in pi-mono's own order
+ * (`packages/ai/src/utils/overflow.ts:37-63`). The examples are the ones pi
+ * documents above the set, so this table is also the audit trail: 25 entries,
+ * 25 patterns.
+ */
+const OVERFLOW_MESSAGES: Record<string, string> = {
+  anthropic: "prompt is too long: 213462 tokens > 200000 maximum",
+  "anthropic-413": '413 {"error":{"type":"request_too_large","message":"Request exceeds the maximum size"}}',
+  bedrock: "Input is too long for requested model.",
+  openai: "Your input exceeds the context window of this model",
+  litellm: "Requested token count exceeds the model's maximum context length of 131072 tokens",
+  gemini: "The input token count (1196265) exceeds the maximum number of tokens allowed (1048575)",
+  xai: "This model's maximum prompt length is 131072 but the request contains 537812 tokens",
+  groq: "Please reduce the length of the messages or completion",
+  openrouter: "This endpoint's maximum context length is 131072 tokens. However, you requested about 537812 tokens",
+  poolside: "Input length 265330 exceeds the maximum allowed input length of 262144 tokens.",
+  together: "The input (265330 tokens) is longer than the model's context length (262144 tokens).",
+  copilot: "prompt token count of 145000 exceeds the limit of 128000",
+  "llama-cpp": "the request exceeds the available context size, try increasing it",
+  "lm-studio": "tokens to keep from the initial prompt is greater than the context length",
+  minimax: "invalid params, context window exceeds limit",
+  kimi: "Your request exceeded model token limit: 262144 (requested: 300000)",
+  mistral: "Prompt contains 300000 tokens, too large for model with 131072 maximum context length",
+  ds4: "Prompt has 300,000 tokens, but the configured context size is 131,072 tokens",
+  "z-ai": "model_context_window_exceeded",
+  ollama: "prompt too long; exceeded max context length by 4096 tokens",
+  dashscope: "Range of input length should be [1, 129024]",
+  "generic-context-length": "context_length_exceeded",
+  "generic-too-many-tokens": "too many tokens in the request",
+  "generic-token-limit": "token limit exceeded",
+  cerebras: "400 status code (no body)",
+};
+
+/**
+ * The exclusion set, and it is not decoration: the first three sentences below
+ * each match an OVERFLOW pattern as well. Without the guard, a throttled Bedrock
+ * call and a rate-limited proxy would both be answered by summarizing the thread
+ * and calling the provider straight back.
+ */
+const NON_OVERFLOW_MESSAGES: Record<string, string> = {
+  "bedrock-throttle": "Throttling error: Too many tokens, please wait before trying again.",
+  "bedrock-unavailable": "Service unavailable: too many tokens",
+  "rate-limited-proxy": "Rate limit reached: token limit exceeded for this minute",
+  "http-429": "429 Too Many Requests",
+  quota: "You exceeded your current quota, please check your plan and billing details.",
+};
+
+describe("isContextOverflow — the prompt did not fit", () => {
+  it("covers every ported provider sentence", () => {
+    expect(Object.keys(OVERFLOW_MESSAGES)).toHaveLength(25);
+  });
+
+  it.each(Object.entries(OVERFLOW_MESSAGES))("reads %s's overflow as an overflow", (_provider, message) => {
+    expect(isContextOverflow(new Error(message))).toBe(true);
+  });
+
+  it.each(Object.entries(NON_OVERFLOW_MESSAGES))("never reads %s as an overflow", (_case, message) => {
+    expect(isContextOverflow(new Error(message))).toBe(false);
+  });
+
+  it("reads a bare string as well as an Error, because `error` parts carry both", () => {
+    expect(isContextOverflow("prompt is too long: 213462 tokens > 200000 maximum")).toBe(true);
+    expect(isContextOverflow("the model refused")).toBe(false);
+  });
+
+  it("says no to anything with no words in it", () => {
+    expect(isContextOverflow(undefined)).toBe(false);
+    expect(isContextOverflow(null)).toBe(false);
+    expect(isContextOverflow({ status: 400 })).toBe(false);
+  });
+});
+
+// ── the retry ────────────────────────────────────────────────────────────────
+
+type StreamChunks = ReturnType<typeof textTurn>;
+
+/** One step of a scripted attempt: the chunks the provider streams, or the error
+ *  it throws instead of streaming anything. */
+type ScriptedStep = StreamChunks | Error;
+
+const OVERFLOW = (): Error => new Error("prompt is too long: 213462 tokens > 200000 maximum");
+
+/**
+ * A seat that can FAIL mid-turn.
+ *
+ * `doStream` walks the script one provider call at a time — the loop's steps and
+ * the retry's steps share the same counter, which is exactly what makes "how many
+ * calls did this turn cost" answerable. `doGenerate` answers the summarizer, so a
+ * forced compaction has something to run on.
+ */
+function overflowSeat(script: readonly ScriptedStep[], summary = "## Goal\nEverything that came before.") {
+  const prompts: unknown[] = [];
+  let streamCalls = 0;
+  let generateCalls = 0;
+  const model = new MockLanguageModelV3({
+    doGenerate: async () => {
+      generateCalls += 1;
+      return {
+        content: [{ type: "text" as const, text: summary }],
+        finishReason: { unified: "stop" as const, raw: undefined },
+        usage: ZERO_USAGE,
+        warnings: [],
+      };
+    },
+    doStream: async (request) => {
+      prompts.push(structuredClone(request.prompt));
+      const next = script[streamCalls];
+      streamCalls += 1;
+      if (next === undefined) throw new Error("seat exhausted");
+      if (next instanceof Error) throw next;
+      return { stream: simulateReadableStream({ chunks: next }) };
+    },
+  });
+  return {
+    model: model as unknown as LanguageModel,
+    /** What each provider call actually sent. */
+    prompts,
+    streamCalls: () => streamCalls,
+    generateCalls: () => generateCalls,
+  };
+}
+
+const NO_TOOLS: ToolRegistry = {
+  descriptors: async () => [],
+  execute: async () => ({ status: "error", error: { code: "not-found", message: "no tools" } }),
+};
+
+/** Drive the harness directly: the runtime is proven separately, so the Turn is
+ *  assembled by hand and the events are collected raw. */
+async function driveTurn(options: {
+  model: LanguageModel;
+  registry?: ToolRegistry;
+  messages?: Turn["messages"];
+  signal?: AbortSignal;
+  harness?: ReturnType<typeof vendo>;
+}): Promise<HarnessEvent[]> {
+  const turnTools = createTurnTools({
+    registry: options.registry ?? NO_TOOLS,
+    guard: testGuard(),
+    ctx: ctx(),
+    interactive: true,
+    mirror: () => {},
+  });
+  const turn: Turn = {
+    messages: options.messages ?? [userMessage("m1", "move the money")],
+    tools: turnTools,
+    skills: testSkills(),
+    workspace: testWorkspace(),
+    models: seats(options.model),
+    state: createTurnState(undefined),
+    options: {},
+    signal: options.signal ?? new AbortController().signal,
+    interactive: true,
+  };
+  const events: HarnessEvent[] = [];
+  for await (const event of (options.harness ?? vendo()).run(turn)) events.push(event);
+  turnTools.dispose();
+  return events;
+}
+
+const texts = (events: HarnessEvent[]): string =>
+  events
+    .filter((event): event is Extract<HarnessEvent, { type: "text" }> => event.type === "text")
+    .map((event) => event.delta)
+    .join("");
+
+const errors = (events: HarnessEvent[]): HarnessEvent[] =>
+  events.filter((event) => event.type === "error");
+
+/** A thread big enough that the compaction has something above the preserved
+ *  tail to summarize (`PRESERVE_RECENT_TOKENS` is 20k), and still small enough
+ *  that the trigger never fires on its own against the default 128k window. */
+const ANCHOR = "the January transfer came from Checking 4021";
+const bigThread = (): Turn["messages"] => [
+  userMessage("m1", ANCHOR),
+  userMessage("m2", `and now: ${"x".repeat(90_000)}`),
+];
+
+describe("a mid-turn overflow compacts and retries once", () => {
+  it("recovers silently: the user sees the answer, never the failure", async () => {
+    const seat = overflowSeat([OVERFLOW(), textTurn("All set.")]);
+
+    const events = await driveTurn({ model: seat.model });
+
+    expect(seat.streamCalls()).toBe(2);
+    expect(texts(events)).toBe("All set.");
+    expect(errors(events)).toEqual([]);
+  });
+
+  it("carries what the first attempt already did, and never re-runs it", async () => {
+    const registry = boundRegistry(
+      { maple_transfer_create: { descriptor: readTool("maple_transfer_create", "write"), execute: () => ({ ok: true }) } },
+      testGuard(),
+    );
+    const seat = overflowSeat([
+      // Attempt 0, step 1: a real guarded write commits.
+      toolCallTurn("maple_transfer_create", { amount: 40 }, "call_1"),
+      // Attempt 0, step 2: the prompt the tool result grew no longer fits.
+      OVERFLOW(),
+      // Attempt 1: the turn continues from there.
+      textTurn("Transfer done."),
+    ]);
+
+    const events = await driveTurn({ model: seat.model, registry });
+
+    expect(seat.streamCalls()).toBe(3);
+    expect(texts(events)).toBe("Transfer done.");
+    // ONCE. The retry re-sends the call and its result as history; replaying it
+    // would move the money twice.
+    expect(registry.invocations.maple_transfer_create).toBe(1);
+    const retryPrompt = JSON.stringify(seat.prompts[2]);
+    expect(retryPrompt).toContain("call_1");
+    expect(retryPrompt).toContain("maple_transfer_create");
+  });
+
+  it("forces the compaction the estimate never asked for", async () => {
+    const seat = overflowSeat([OVERFLOW(), textTurn("Done.")]);
+
+    await driveTurn({ model: seat.model, messages: bigThread() });
+
+    // Attempt 0 was under the trigger, so it summarized nothing and sent the
+    // thread whole; attempt 1 summarized because the provider had already said no.
+    expect(JSON.stringify(seat.prompts[0])).toContain(ANCHOR);
+    expect(seat.generateCalls()).toBe(1);
+    const retryPrompt = JSON.stringify(seat.prompts[1]);
+    expect(retryPrompt).toContain("Everything that came before.");
+    expect(retryPrompt).not.toContain(ANCHOR);
+  });
+
+  it("gives up after the second failure: one compaction, no third call", async () => {
+    const seat = overflowSeat([OVERFLOW(), OVERFLOW()]);
+
+    const events = await driveTurn({ model: seat.model, messages: bigThread() });
+
+    expect(seat.streamCalls()).toBe(2);
+    expect(seat.generateCalls()).toBe(1);
+    expect(errors(events)).toHaveLength(1);
+  });
+
+  it("never retries a throttle, however much it sounds like one", async () => {
+    const seat = overflowSeat([new Error("Throttling error: Too many tokens, please wait before trying again.")]);
+
+    const events = await driveTurn({ model: seat.model });
+
+    expect(seat.streamCalls()).toBe(1);
+    expect(errors(events)).toHaveLength(1);
+  });
+
+  it("never retries a turn whose caller has hung up", async () => {
+    const controller = new AbortController();
+    let streamCalls = 0;
+    const model = new MockLanguageModelV3({
+      doStream: async () => {
+        streamCalls += 1;
+        controller.abort();
+        throw OVERFLOW();
+      },
+    }) as unknown as LanguageModel;
+
+    const events = await driveTurn({ model, signal: controller.signal });
+
+    expect(streamCalls).toBe(1);
+    // An abandoned turn stops cleanly and says nothing — it does not pay for a
+    // summarizer and a second attempt nobody is listening to.
+    expect(events).toEqual([]);
+  });
+});

--- a/packages/harnesses/src/vendo/overflow.ts
+++ b/packages/harnesses/src/vendo/overflow.ts
@@ -1,0 +1,74 @@
+/**
+ * Did the provider refuse because the PROMPT did not fit?
+ *
+ * There is no status code for it. Every provider answers an oversized prompt
+ * with its own sentence, on a 400 that looks exactly like the 400 for a malformed
+ * request, and the only thing that tells them apart is the prose. So this file is
+ * a pattern set — an unglamorous shape, and the honest one, which is why it is
+ * ported from somebody who already collected the sentences from real traffic
+ * rather than guessed at them.
+ *
+ * The exclusion half is the part worth reading twice. "Too many tokens, please
+ * wait before trying again" is Bedrock THROTTLING, and a caller that treats it as
+ * an overflow answers a rate limit by summarizing the thread and calling straight
+ * back — turning one 429 into two, at the exact moment the provider asked for
+ * fewer. The overflow patterns are matched only after the non-overflow patterns
+ * have had their say.
+ */
+
+/**
+ * Ported from pi-mono `packages/ai/src/utils/overflow.ts` (MIT, Mario Zechner):
+ * the 25 OVERFLOW_PATTERNS (L37-63) minus the 3 NON_OVERFLOW_PATTERNS (L74-78),
+ * so a 429 is never read as an overflow. pi's silent-overflow and length-stop
+ * cases need a usage/window pair we do not have at the error site — not ported.
+ */
+const OVERFLOW_PATTERNS = [
+  /prompt is too long/i, // Anthropic token overflow
+  /request_too_large/i, // Anthropic request byte-size overflow (HTTP 413)
+  /input is too long for requested model/i, // Amazon Bedrock
+  /exceeds the context window/i, // OpenAI (Completions & Responses API)
+  /exceeds (?:the )?(?:model'?s )?maximum context length(?: of [\d,]+ tokens?|\s*\([\d,]+\))/i, // OpenAI-compatible proxies (LiteLLM)
+  /input token count.*exceeds the maximum/i, // Google (Gemini)
+  /maximum prompt length is \d+/i, // xAI (Grok)
+  /reduce the length of the messages/i, // Groq
+  /maximum context length is \d+ tokens/i, // OpenRouter (most backends)
+  /exceeds (?:the )?maximum allowed input length of [\d,]+ tokens?/i, // OpenRouter/Poolside
+  /input \(\d+ tokens\) is longer than the model'?s context length \(\d+ tokens\)/i, // Together AI
+  /exceeds the limit of \d+/i, // GitHub Copilot
+  /exceeds the available context size/i, // llama.cpp server
+  /greater than the context length/i, // LM Studio
+  /context window exceeds limit/i, // MiniMax
+  /exceeded model token limit/i, // Kimi For Coding
+  /too large for model with \d+ maximum context length/i, // Mistral
+  /prompt has [\d,]+ tokens?, but the configured context size is [\d,]+ tokens?/i, // DS4 server
+  /model_context_window_exceeded/i, // z.ai non-standard finish_reason surfaced as error text
+  /prompt too long; exceeded (?:max )?context length/i, // Ollama explicit overflow error
+  /range of input length should be/i, // DashScope / Qwen Token Plan
+  /context[_ ]length[_ ]exceeded/i, // Generic fallback
+  /too many tokens/i, // Generic fallback
+  /token limit exceeded/i, // Generic fallback
+  /^4(?:00|13)\s*(?:status code)?\s*\(no body\)/i, // Cerebras: 400/413 with no body
+] as const;
+
+/** Rate limiting and unavailability, which several providers word in tokens.
+ *  Matching one of these settles the question before the set above is consulted. */
+const NON_OVERFLOW_PATTERNS = [
+  /^(Throttling error|Service unavailable):/i, // AWS Bedrock, via its own error formatter
+  /rate limit/i, // Generic rate limiting
+  /too many requests/i, // Generic HTTP 429 style
+] as const;
+
+/** The provider's own words, wherever the SDK put them. A `fullStream` error part
+ *  carries `unknown`: an `APICallError` in the normal case, a bare string from
+ *  some proxies. Anything with no sentence in it cannot be classified and is not. */
+function errorText(error: unknown): string {
+  if (typeof error === "string") return error;
+  const message = (error as { message?: unknown } | null | undefined)?.message;
+  return typeof message === "string" ? message : "";
+}
+
+export function isContextOverflow(error: unknown): boolean {
+  const text = errorText(error);
+  if (text === "" || NON_OVERFLOW_PATTERNS.some((pattern) => pattern.test(text))) return false;
+  return OVERFLOW_PATTERNS.some((pattern) => pattern.test(text));
+}

--- a/packages/harnesses/src/vendo/vendo.ts
+++ b/packages/harnesses/src/vendo/vendo.ts
@@ -20,6 +20,7 @@ import { modelToolDescription, type Harness, type HarnessEvent, type Json, type 
 import { readCompactionState, writeCompactionState } from "./compaction.js";
 import { startTurn, type TurnCompaction, type TurnContext } from "./loop.js";
 import { contextWindowTokens } from "./model-windows.js";
+import { isContextOverflow } from "./overflow.js";
 import { wireErrorMessage } from "../wire-error.js";
 import { reportHire, type HireRecord, type UsageTotals } from "../runtime.js";
 import {
@@ -27,6 +28,7 @@ import {
   tool,
   type LanguageModel,
   type LanguageModelUsage,
+  type ModelMessage,
   type ToolSet,
 } from "ai";
 import { defineHarness } from "../define.js";
@@ -428,11 +430,18 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
         activeToolNames = () => equipped;
       }
 
-      let loop: Awaited<ReturnType<typeof startTurn>>;
-      try {
+      // ONE attempt at the turn. The overflow retry re-enters through the same
+      // function so the two attempts cannot drift on any input but the two the
+      // retry means to change.
+      const attempt = (
+        attemptCompaction: TurnCompaction,
+        /** What the failed attempt already produced, for a retry that CONTINUES
+         *  the turn rather than restarting it. */
+        resume?: readonly ModelMessage[],
+      ): Promise<Awaited<ReturnType<typeof startTurn>>> =>
         // THE shipped loop. Every rail lives in it, so this harness cannot drift
         // from `createAgent` on any of them.
-        loop = await startTurn({
+        startTurn({
           model,
           system,
           messages: [...turn.messages],
@@ -451,13 +460,18 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
           // How big this seat's window is, and what the thread remembers about
           // filling it. Always passed: a deployment that never set a knob is
           // exactly the deployment that has never had a context rail at all.
-          compaction,
+          compaction: attemptCompaction,
+          ...(resume === undefined ? {} : { resume }),
           // The WHOLE context, not just `maxSteps`. Passing one knob is what made
           // every other knob unreachable from `vendo()` — the loop declared them,
           // `createAgent` passed them, and this caller silently dropped them, so
           // the two thinkers disagreed about a host's own configuration.
           ...(Object.keys(context).length === 0 ? {} : { context }),
         });
+
+      let loop: Awaited<ReturnType<typeof startTurn>>;
+      try {
+        loop = await attempt(compaction);
       } catch (error) {
         yield { type: "error", message: wireErrorMessage(error), code: "model" };
         return;
@@ -467,57 +481,90 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
       // included, which is what makes it usable as the next turn's ground truth
       // instead of a second guess at the same tokens.
       let lastPromptTokens: number | undefined;
-      try {
-        for await (const part of loop.result.fullStream) {
-          switch (part.type) {
-            case "text-delta":
-              yield { type: "text", delta: part.text };
-              break;
-            case "finish-step":
-              // Last step wins: it sent the biggest prompt of the turn, and it
-              // is the one the next turn grows from.
-              lastPromptTokens = part.usage.inputTokens ?? lastPromptTokens;
-              break;
-            case "error":
-              // `wireErrorMessage` is the SHIPPED formatter: a Vendo-shaped error
-              // keeps its message and code, the Cloud meter's 402 becomes the
-              // sentence with figures, reset date and both exits, and anything
-              // else stays the fixed generic string. Provider internals never
-              // travel; the operator's terminal gets the real error.
-              yield { type: "error", message: wireErrorMessage(part.error), code: "model" };
-              break;
-            case "abort":
-              // The caller hung up: stop cleanly, say nothing.
-              return;
-            case "finish":
-              // The RESIDENT loop's own spend, and only it. Folding the hires in
-              // here too double-counted them: each hire is already its own audit
-              // row (`reportHire`), so a host summing the turn's rows paid for
-              // every specialist twice — and the cache split, which is the
-              // resident's, then described a total that was not.
-              yield { type: "usage", ...usageOf(part.totalUsage, model) };
-              break;
-            default:
-              // Tool call/result chunks are consumed here and dropped: the RUNTIME
-              // mirrors them (§1.5), so echoing them would double every call.
-              //
-              // `tool-error` is dropped with them, and that is the rule: a turn
-              // FAILS by how it ends — an `error` part, a throw out of this drain,
-              // an abort — never by a step it recovered from. The SDK raises this
-              // part for its own malformed-input/unknown-tool class, feeds it back,
-              // and the model answers on the next step; a guarded call cannot raise
-              // it at all, because `turn.tools.call()` never throws (§1.1) and its
-              // failures are already a tool RESULT the model reads. Reporting it as
-              // an `error` event made the runtime — right to treat a reported error
-              // as the turn's death — stamp a finished turn failed: a permanent
-              // "The response didn't finish" notice and a failed audit row above a
-              // perfectly good answer.
-              break;
+      /** The turn's single retry, spent. */
+      let retried = false;
+      for (;;) {
+        /** Set when THIS attempt died on a prompt that did not fit. */
+        let overflowed = false;
+        try {
+          for await (const part of loop.result.fullStream) {
+            switch (part.type) {
+              case "text-delta":
+                yield { type: "text", delta: part.text };
+                break;
+              case "finish-step":
+                // Last step wins: it sent the biggest prompt of the turn, and it
+                // is the one the next turn grows from.
+                lastPromptTokens = part.usage.inputTokens ?? lastPromptTokens;
+                break;
+              case "error":
+                // A prompt that did not fit is the ONE provider failure this loop
+                // can answer by itself: compact what the thread is carrying and
+                // continue, silently, once. Everything else — and a second
+                // overflow, and a caller who has already hung up — takes the
+                // normal path below.
+                if (!retried && !turn.signal.aborted && isContextOverflow(part.error)) {
+                  overflowed = true;
+                  break;
+                }
+                // `wireErrorMessage` is the SHIPPED formatter: a Vendo-shaped error
+                // keeps its message and code, the Cloud meter's 402 becomes the
+                // sentence with figures, reset date and both exits, and anything
+                // else stays the fixed generic string. Provider internals never
+                // travel; the operator's terminal gets the real error.
+                yield { type: "error", message: wireErrorMessage(part.error), code: "model" };
+                break;
+              case "abort":
+                // The caller hung up: stop cleanly, say nothing.
+                return;
+              case "finish":
+                // The RESIDENT loop's own spend, and only it. Folding the hires in
+                // here too double-counted them: each hire is already its own audit
+                // row (`reportHire`), so a host summing the turn's rows paid for
+                // every specialist twice — and the cache split, which is the
+                // resident's, then described a total that was not.
+                yield { type: "usage", ...usageOf(part.totalUsage, model) };
+                break;
+              default:
+                // Tool call/result chunks are consumed here and dropped: the RUNTIME
+                // mirrors them (§1.5), so echoing them would double every call.
+                //
+                // `tool-error` is dropped with them, and that is the rule: a turn
+                // FAILS by how it ends — an `error` part, a throw out of this drain,
+                // an abort — never by a step it recovered from. The SDK raises this
+                // part for its own malformed-input/unknown-tool class, feeds it back,
+                // and the model answers on the next step; a guarded call cannot raise
+                // it at all, because `turn.tools.call()` never throws (§1.1) and its
+                // failures are already a tool RESULT the model reads. Reporting it as
+                // an `error` event made the runtime — right to treat a reported error
+                // as the turn's death — stamp a finished turn failed: a permanent
+                // "The response didn't finish" notice and a failed audit row above a
+                // perfectly good answer.
+                break;
+            }
           }
+        } catch (error) {
+          yield { type: "error", message: wireErrorMessage(error), code: "model" };
+          return;
         }
-      } catch (error) {
-        yield { type: "error", message: wireErrorMessage(error), code: "model" };
-        return;
+        if (!overflowed) break;
+        retried = true;
+        // Everything the failed attempt said and did, tool RESULTS included. It
+        // rides the next prompt verbatim, below the compaction: each of those
+        // calls has already run through `turn.tools.call()` and committed a real
+        // effect, so an attempt that replayed them would transfer the money
+        // twice. An overflow on the FIRST step produced no step at all, and `ai`
+        // rejects `response` rather than resolving it empty — nothing to carry.
+        const resume: readonly ModelMessage[] = await loop.result.response.then(
+          (response) => response.messages,
+          () => [],
+        );
+        try {
+          loop = await attempt({ ...compaction, force: true }, resume);
+        } catch (error) {
+          yield { type: "error", message: wireErrorMessage(error), code: "model" };
+          return;
+        }
       }
 
       // §1.3's slot, which the runtime persists at turn end (`runtime.ts`


### PR DESCRIPTION
Base: `yousefh409/ctx-s3-compaction` (after S3) — stack: #868 → #893 → #894 → #891 → #901 → #903 → this.

Last engine slice of Shipment 1. A provider that refuses because the prompt did not fit is now
answered by the loop itself: compact, continue, once, silently.

## What changed

- **`packages/harnesses/src/vendo/overflow.ts` (new)** — `isContextOverflow(error: unknown)`. Ported
  from pi-mono `packages/ai/src/utils/overflow.ts` (MIT, Mario Zechner): the 25 `OVERFLOW_PATTERNS`
  (L37-63) minus the `NON_OVERFLOW_PATTERNS` (L74-78), so a 429 is never read as an overflow. pi's
  silent-overflow and length-stop cases need a usage/window pair we do not have at the error site —
  not ported (Structure §2 says so explicitly).
- **`packages/harnesses/src/vendo/vendo.ts:395-503`** — the `startTurn` call becomes an `attempt()`
  helper, and the `fullStream` drain runs inside one retry loop. A `fullStream` `error` part that
  classifies as an overflow, when the turn has not already retried and its caller has not hung up,
  re-enters `attempt({ ...compaction, force: true }, resume)` where `resume` is
  `await result.response.messages` — everything the failed attempt already produced, tool results
  included. `turnModelMessages` appends `resume` after the projection and never summarizes it
  (S3, `loop.ts:362-365`), so no committed tool effect is ever re-executed. Exactly one retry; a
  second failure takes the normal error path.
- **`packages/harnesses/src/vendo/index.ts`** — exports `isContextOverflow`.

`loop.ts` is NOT in the diff. S3 (#903) already landed both halves it owns — `compaction.force` and
`resume` are read in `turnModelMessages`/`startTurn`. `TurnLoop.result` is unchanged for its four
consumers; the retry lives in `vendo.ts` because that is where the state slot and the drain already
are (Structure §3).

## Red-first

Test committed first (`ca48852`), mechanism second (`5437a51`).

Against the unchanged tree, with `overflow.ts` present and no wiring in `vendo.ts` — 35 classifier
assertions green, all four retry assertions red for behavioural reasons:

```
 ❯ src/vendo/overflow.test.ts (39 tests | 4 failed) 42ms
   × recovers silently: the user sees the answer, never the failure   → expected 1 to be 2
   × carries what the first attempt already did, and never re-runs it → expected 2 to be 3
   × forces the compaction the estimate never asked for               → expected +0 to be 1
   × gives up after the second failure: one compaction, no third call → expected 1 to be 2
 Test Files  1 failed (1)
      Tests  4 failed | 35 passed (39)
```

## Revert-proof

Delete the four-line retry decision in `vendo.ts` (`if (!retried && !turn.signal.aborted &&
isContextOverflow(part.error))`), everything else intact:

```
 Test Files  1 failed (1)
      Tests  4 failed | 35 passed (39)
```

Restore it:

```
 Test Files  1 passed (1)
      Tests  39 passed (39)
```

## Gate (`/tmp/gate-s4.log`, foreground, read back — every leg `exit=0`)

| leg | result | exit |
|---|---|---|
| `vitest run src/vendo/overflow.test.ts --minWorkers=1 --maxWorkers=2` | 39 passed | 0 |
| `vitest run src/vendo --minWorkers=1 --maxWorkers=2` | 13 files passed, 2 skipped · 141 passed, 4 skipped | 0 |
| `pnpm build` | 24/24 | 0 |
| `pnpm typecheck` | 42/42 | 0 |
| `pnpm lint` | dependency-guard OK, portability-gate all legs green, 4/4 | 0 |

## What the suite pins

`overflow.test.ts` — 25 real provider sentences, one per ported pattern, each classified as an
overflow; five non-overflow sentences (Bedrock throttle, Bedrock unavailable, rate-limited proxy,
HTTP 429, quota) each classified as not one. Three of those five also match an OVERFLOW pattern —
"Throttling error: Too many tokens, please wait" is the exclusion set earning its keep, because a
turn that "recovers" from a rate limit by summarizing and calling straight back turns one 429 into
two.

The retry: one overflow → two provider calls and a clean answer, no error event; an overflow after a
committed `maple_transfer_create` → the registry records **one** invocation and the retry's prompt
carries `call_1` and its result as history; a forced compaction on the second attempt that the
estimate never asked for on the first (one `doGenerate`, the summary in the retry prompt, the
pre-cut anchor gone); a second overflow → two calls, one compaction, one error event, no third call;
a throttle → one call, no retry; an aborted caller → one call, zero events, no summarizer.

## Stop-and-report

1. **pi's `NON_OVERFLOW_PATTERNS` is 3 patterns, not 4.** The brief's verbatim credit comment says
   "minus the 4 NON_OVERFLOW_PATTERNS (L74-78)". `overflow.ts:74-78` in pi-mono holds three regexes
   (`/^(Throttling error|Service unavailable):/i`, `/rate limit/i`, `/too many requests/i`); L74-78
   is the array literal's span, which is where the 4 came from. Shipped with the accurate count
   rather than a credit comment that misstates its source — flagged here rather than adjusted
   silently. The 25 OVERFLOW_PATTERNS count is correct.
2. **The abort guard is explicit, not incidental.** `!turn.signal.aborted` sits in the retry
   decision. `ai` normally replaces a queued `error` part with an `abort` part once the signal
   fires, so the abort path usually wins on its own — but "usually" is not a rail, and the cost of
   losing that race is a summarizer call plus a whole second turn nobody is listening to.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a silent, one-time retry when a provider rejects mid-turn due to context overflow by compacting the thread and continuing without user-visible errors. Also introduces a robust overflow classifier and exports `isContextOverflow`.

- **New Features**
  - Retries once in `packages/harnesses/src/vendo/vendo.ts` using an `attempt()` helper; triggers on `fullStream` errors classified by `isContextOverflow`, skips if already retried or the caller aborted.
  - Continues the failed attempt by passing `response.messages` as `resume`, so prior text and tool results are preserved and never re-executed.
  - Forces compaction on retry with `{ ...compaction, force: true }`.
  - Adds `packages/harnesses/src/vendo/overflow.ts` with `isContextOverflow` (25 overflow patterns with 3 non-overflow guards) and exports it from `packages/harnesses/src/vendo/index.ts`.
  - Adds `packages/harnesses/src/vendo/overflow.test.ts` to pin classifier coverage and retry behavior (silent recovery, preserved tool effects, forced compaction, single retry, no retry on throttle or when aborted).

<sup>Written for commit 71f013da3d824251e0b8a6bf902bdaaa3887e439. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

