### PR TITLE
feat(apps): one validation floor at every door; declared tool schemas reach the screen type check

### DIFF
--- a/.changeset/one-validation-floor-declared-tool-schemas.md
+++ b/.changeset/one-validation-floor-declared-tool-schemas.md
@@ -1,0 +1,27 @@
+---
+"@vendoai/apps": minor
+---
+
+One validation floor at every door, and a host's declared tool schemas finally
+reach the screen type check.
+
+Four doors let an app reach a screen — the paint seam, `validate({ document })`,
+`validate({ appId })` and the edit path — and each ran a different subset of the
+checks, so an app refused at one shipped through another. An island that crashes
+the moment it renders was caught at exactly one of them. All four now compose
+the same `floorChecks`: the fact checks, the compiler static half, and the island
+gates (admission plus the smoke render). The AI reviewer has not moved — it still
+runs only where it ran before, at `validate`, because it spends a model call.
+
+The island gates move from `generation/validation/` into `checking/`, where the
+floor that runs them lives; the generation pipeline imports them from there. On
+the paint hot path a repeated save costs ~3ms more, because the smoke render is
+keyed on island source and an unchanged island never renders twice.
+
+`screenTypings` has always preferred a tool's DECLARED `outputSchema` over the
+shape sampled from one live call, and nothing ever populated it. It does now, so
+a screen is type-checked against the host's own contract. Sampling erases what a
+declaration keeps: an enum field samples as a bare `string`, so a host component
+whose prop takes that enum could never be satisfied by any tool — demo-bank's
+`MapleSpendingDonut` against `host_getSpendingInsights` was blocked at the checks
+floor on a screen that was correct.

--- a/packages/apps/src/checking/declared-tool-schemas.test.ts
+++ b/packages/apps/src/checking/declared-tool-schemas.test.ts
@@ -1,0 +1,153 @@
+/**
+ * A tool's DECLARED output schema is what the screen type check reads.
+ *
+ * `screenTypings` has always preferred `toolOutputSchemas` over the sampled
+ * `toolShapes` — and nothing ever populated it, so every screen was type-checked
+ * against one observation instead of the host's own contract. Sampling erases
+ * what a declaration keeps: an enum field samples as a bare `string`, so a host
+ * component whose prop takes that enum could never be satisfied from any tool,
+ * and "show me my spending by category" was refused at the checks floor on a
+ * screen that was correct (demo-bank's `MapleSpendingDonut.slices` against
+ * `host_getSpendingInsights`, live 2026-08).
+ *
+ * Both halves of the seam are real here: the declaration travels the SHIPPED
+ * write path (a `ToolRegistry` descriptor → `generationToolContext` → the floor's
+ * dependencies) and is read back through the SHIPPED read path (the `validate`
+ * door → `screenTypesCheck` → `tsc`). Neither side is stubbed, so they cannot
+ * agree by construction.
+ */
+import {
+  type JsonSchema,
+  type NormalizedCatalog,
+  type RunContext,
+  type StandardSchema,
+  type ToolDescriptor,
+  type ToolRegistry,
+} from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { createApps } from "../index.js";
+import { guardFixture, memoryStore, scriptedLanguageModel } from "../testing/index.js";
+
+const TOOL = "host_getSpendingInsights";
+const CATEGORIES = ["dining", "groceries", "other"] as const;
+
+/** The host's own contract: category is an ENUM, and the slices live one hop in
+ *  under `data`. */
+const outputSchema: JsonSchema = {
+  type: "object",
+  properties: {
+    data: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          category: { type: "string", enum: [...CATEGORIES] },
+          amount: { type: "integer" },
+        },
+        required: ["category", "amount"],
+      },
+    },
+  },
+  required: ["data"],
+};
+
+/** The donut in miniature: `slices` takes rows whose category is the SAME enum,
+ *  which a sampled `string` can never satisfy. */
+const donutJsonSchema: JsonSchema = {
+  type: "object",
+  properties: {
+    slices: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          category: { type: "string", enum: [...CATEGORIES] },
+          amount: { type: "number" },
+        },
+        required: ["category", "amount"],
+      },
+    },
+  },
+  required: ["slices"],
+  additionalProperties: false,
+};
+
+const catalog: NormalizedCatalog = [{
+  name: "MapleSpendingDonut",
+  description: "Spending by category",
+  propsSchema: z.object({
+    slices: z.array(z.object({ category: z.enum(CATEGORIES), amount: z.number() })),
+  }) as unknown as StandardSchema,
+  propsJsonSchema: donutJsonSchema,
+}];
+
+const descriptor = (declared: boolean): ToolDescriptor => ({
+  name: TOOL,
+  description: "Spending by category, this month",
+  inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  risk: "read",
+  ...(declared ? { outputSchema } : {}),
+});
+
+/** A registry that really answers, so the runtime really samples: the sample
+ *  carries `category: "dining"`, which derives to the bare `string` that erases
+ *  the enum. `sampled: false` is the tool that cannot be sampled at all, where
+ *  only a declaration can say anything. */
+const registry = (options: { declared: boolean; sampled: boolean }): ToolRegistry => ({
+  async descriptors() { return [descriptor(options.declared)]; },
+  async execute() {
+    return options.sampled
+      ? { status: "ok" as const, output: { data: [{ category: "dining", amount: 34_218 }] } }
+      : { status: "error" as const, error: { code: "unavailable" as const, message: "the account is not connected" } };
+  },
+});
+
+const ctx: RunContext = {
+  principal: { kind: "user", subject: "user_ada" },
+  venue: "app",
+  presence: "present",
+  sessionId: "session_ada",
+};
+
+const runtime = (options: { declared: boolean; sampled: boolean }) => createApps({
+  store: memoryStore(),
+  guard: guardFixture(),
+  tools: registry(options),
+  catalog,
+  model: scriptedLanguageModel(() => "no"),
+});
+
+const DONUT = `<App name="Spending"><Query id="spending" tool="${TOOL}"/><MapleSpendingDonut slices={spending.data}/></App>`;
+const WRONG_FIELD = `<App name="Spending"><Query id="spending" tool="${TOOL}"/><Text text={spending.total}/></App>`;
+
+const blocked = (findings: readonly { severity: string; message: string }[]): string =>
+  findings.filter(({ severity }) => severity === "block").map(({ message }) => message).join("\n");
+
+describe("the declaration is the contract the screen is checked against", () => {
+  it("refuses a field the declaration does not carry, with no sample in play", async () => {
+    const result = await runtime({ declared: true, sampled: false }).validate({ document: WRONG_FIELD }, ctx);
+
+    expect(result.ok).toBe(false);
+    // The declaration is the only thing that could know this — and it teaches
+    // the field that IS there.
+    expect(blocked(result.findings)).toContain('reads field "total"');
+    expect(blocked(result.findings)).toContain("data");
+  }, 60_000);
+
+  it("satisfies an enum-typed prop — the donut case", async () => {
+    const result = await runtime({ declared: true, sampled: true }).validate({ document: DONUT }, ctx);
+
+    expect(blocked(result.findings)).toBe("");
+    expect(result.ok).toBe(true);
+  }, 60_000);
+
+  it("without it, the sample erases the enum and the same screen is refused", async () => {
+    // The pre-existing bug, kept as the contrast: this is the ONLY difference
+    // between the two runs, so the declaration is demonstrably what unblocks it.
+    const result = await runtime({ declared: false, sampled: true }).validate({ document: DONUT }, ctx);
+
+    expect(result.ok).toBe(false);
+    expect(blocked(result.findings)).toContain("slices");
+  }, 60_000);
+});

--- a/packages/apps/src/checking/deps.ts
+++ b/packages/apps/src/checking/deps.ts
@@ -9,7 +9,7 @@
  * keeps working unchanged — and the floor now runs anywhere a catalog and a model
  * exist, which is what lets it move to the paint seam.
  */
-import type { NormalizedCatalog, ShapeType } from "@vendoai/core";
+import type { JsonSchema, NormalizedCatalog, ShapeType } from "@vendoai/core";
 import type { LanguageModel } from "ai";
 
 /** The slice of a tool descriptor the floor (and the generation prompts) need:
@@ -24,6 +24,12 @@ export interface HostToolInfo {
   description: string;
   risk: string;
   inputSchema?: Record<string, unknown>;
+  /** The tool's DECLARED result shape (`ToolDescriptor.outputSchema`). The
+   *  screen type check prefers it over a sampled shape: a declaration is the
+   *  host's contract where a sample is one observation, and sampling erases
+   *  what a declaration keeps — an enum field samples as a bare `string`, so a
+   *  prop that takes the enum could never be satisfied from a sample. */
+  outputSchema?: JsonSchema;
 }
 
 /**

--- a/packages/apps/src/checking/facts.ts
+++ b/packages/apps/src/checking/facts.ts
@@ -519,6 +519,11 @@ const screenTypeFindings = (tree: Tree, document: AppDocument, deps: FloorDepend
   const typings = screenTypings({
     catalog: [...deps.catalog, ...generated],
     queries,
+    // The host's own declared response shapes, which outrank the samples: a
+    // sample erases what a declaration keeps (an enum field samples as a bare
+    // `string`, so a prop declared over that enum could never be satisfied).
+    toolOutputSchemas: Object.fromEntries((deps.tools ?? [])
+      .flatMap((tool) => (tool.outputSchema === undefined ? [] : [[tool.name, tool.outputSchema] as const]))),
     toolShapes: deps.toolShapes,
   });
   const screen = printWire({ tree, components: {}, name: document.name }, { includeIds: false });

--- a/packages/apps/src/checking/floor.ts
+++ b/packages/apps/src/checking/floor.ts
@@ -27,10 +27,13 @@ import {
   type Finding,
   type WireCompileResult,
 } from "@vendoai/core";
+import { isPinComponentName } from "../pins.js";
 import { wireCompileOptionsFor } from "../wire-options.js";
 import type { FloorDependencies } from "./deps.js";
 import { screenTypesCheck } from "./facts.js";
+import { prepareIslands } from "./islands.js";
 import { createCheckingLayer } from "./layer.js";
+import { smokeRenderIslands } from "./smoke-render.js";
 
 /** A compiled wire result as the document the checks read. The checks take a whole
  *  `AppDocument` (build contract §5) and the seam knows the id, so this is the
@@ -45,6 +48,54 @@ const documentOf = (appId: AppId, compiled: WireCompileResult): AppDocument => (
   tree: compiled.tree as unknown as AppDocument["tree"],
   ...(Object.keys(compiled.components).length === 0 ? {} : { components: compiled.components }),
 } as AppDocument);
+
+/**
+ * The island gate as a check: admission through the ambient contract
+ * (`prepareIslands`) and, on an otherwise-clean set, the crash gate
+ * (`smokeRenderIslands`) — the same two the create validator runs, ordered the
+ * same way, so a cheap failure never pays for a render.
+ *
+ * PINNED components are skipped: their source is host source captured on the
+ * furnishing trust path, so it keeps its imports and was never a model island.
+ */
+const islandsCheck = (deps: FloorDependencies): Check => ({
+  name: "islands-render",
+  kind: "fact",
+  run: async ({ document, request }) => {
+    const components = Object.fromEntries(Object.entries(document.components ?? {})
+      .filter(([name]) => !isPinComponentName(name)));
+    if (Object.keys(components).length === 0) return [];
+    const prepared = await prepareIslands(
+      components,
+      deps.tools,
+      deps.catalog.map(({ name }) => name),
+      // Absence is "no carve-out" — the conservative direction, and what a
+      // verb call or a file save honestly has.
+      request === "" ? undefined : request,
+    );
+    const issues = prepared.issues.length > 0 ? prepared.issues : await smokeRenderIslands({
+      components: prepared.components,
+      componentTools: prepared.componentTools,
+      tools: deps.tools,
+      toolShapes: deps.toolShapes,
+    });
+    // An island issue already names its island, so it has no separate locus.
+    return issues.map((message) => ({ severity: "block" as const, message }));
+  },
+});
+
+/**
+ * THE floor: the mechanical checks every door runs on top of the layer's own
+ * fact checks — the compiler static half and the island gates. One definition,
+ * imported by all four doors (the paint seam below, `validate` on a document,
+ * `validate` on a stored app, and the edit path), because the four used to run
+ * four different subsets and an app blocked at one shipped through another.
+ *
+ * The AI reviewer is NOT here. It spends a model call, so it stays exactly where
+ * it is today: `AppsRuntime.validate` alone.
+ */
+export const floorChecks = (deps: FloorDependencies): Check[] =>
+  [screenTypesCheck(deps), islandsCheck(deps)];
 
 export interface AppFloorOptions {
   /**
@@ -70,13 +121,13 @@ export const createAppFloor = ({ deps, checks }: AppFloorOptions): AppFloor => {
     },
     async check({ appId, compiled }) {
       const resolved = await once();
-      // The compiler static half runs HERE — the paint gate blocks a bad screen
-      // from a user, and this ms is off the synchronous create latency budget
-      // (§7.1). The generate path uses the cheap node-anchored `bindingKindCheck`
-      // instead; neither path runs both.
+      // The compiler static half and the island gates run HERE — the paint gate
+      // blocks a bad screen from a user, and this ms is off the synchronous
+      // create latency budget (§7.1). The generate path uses the cheap
+      // node-anchored `bindingKindCheck` instead; neither path runs both.
       const layer = createCheckingLayer({
         deps: resolved,
-        checks: [screenTypesCheck(resolved), ...(checks ?? [])],
+        checks: [...floorChecks(resolved), ...(checks ?? [])],
       });
       // `request: ""` for the same reason `validate` passes it: a file write
       // carries no user text, and the checks that read it treat absence as "no

--- a/packages/apps/src/checking/islands.ts
+++ b/packages/apps/src/checking/islands.ts
@@ -17,8 +17,8 @@ import {
   scanIslandTools,
   stripIslandImports,
 } from "@vendoai/core";
-import { hasDefaultExport } from "../../pins.js";
-import type { HostToolInfo } from "../engine.js";
+import { hasDefaultExport } from "../pins.js";
+import type { HostToolInfo } from "./deps.js";
 
 /** Models wrap island TSX in a JSX template-literal expression (`{`…`}`)
  *  despite instructions; strip it deterministically, the way the engine's

--- a/packages/apps/src/checking/screen-tsc.ts
+++ b/packages/apps/src/checking/screen-tsc.ts
@@ -14,7 +14,7 @@
  * or loads but predates the API this module calls, the check returns NO
  * findings and never fails a build — the same posture as the smoke-render gate
  * ("Environment failures … skip the gate silently — the esbuild lazy-load
- * precedent", generation/validation/smoke-render.ts:26-30) and as extraction's
+ * precedent", checking/smoke-render.ts:26-30) and as extraction's
  * "extraction never fails your build" floor (actions/sync/compiler-gate.ts).
  *
  * The lazy `createRequire` resolution is not a style choice: `typescript@` is

--- a/packages/apps/src/checking/smoke-render.ts
+++ b/packages/apps/src/checking/smoke-render.ts
@@ -34,7 +34,7 @@ import {
   ISLAND_AMBIENT_REACT_NAMES,
   type ShapeType,
 } from "@vendoai/core";
-import type { HostToolInfo } from "../engine.js";
+import type { HostToolInfo } from "./deps.js";
 
 export interface SmokeRenderOptions {
   /** name → island TSX source (post-prepare, canonical). */

--- a/packages/apps/src/engine.bundler-safety.e2e.test.ts
+++ b/packages/apps/src/engine.bundler-safety.e2e.test.ts
@@ -1,5 +1,5 @@
 /**
- * The island syntax check (generation/validation/islands.ts) lazy-loads
+ * The island syntax check (checking/islands.ts) lazy-loads
  * esbuild (a native-binary package). A bundler (webpack, or Next's Turbopack) that
  * sees a literal `import("esbuild")` in a module it's bundling walks INTO
  * esbuild's own package to build its module graph — regardless of whether
@@ -57,7 +57,7 @@ const GUARDED_ESBUILD_IMPORT =
 
 function buildDistIslandsSource(): string {
   execFileSync("npx", ["tsc", "-p", "tsconfig.json"], { cwd: PACKAGE_DIR, stdio: "pipe" });
-  return readFileSync(join(PACKAGE_DIR, "dist", "generation", "validation", "islands.js"), "utf8");
+  return readFileSync(join(PACKAGE_DIR, "dist", "checking", "islands.js"), "utf8");
 }
 
 describe("islands.ts esbuild import — bundler-style reachability (built dist)", () => {
@@ -72,7 +72,7 @@ describe("islands.ts esbuild import — bundler-style reachability (built dist)"
   });
 
   it("sanity: the source itself carries the same guarded form (what a reviewer edits matches what ships)", () => {
-    const source = readFileSync(join(PACKAGE_DIR, "src", "generation", "validation", "islands.ts"), "utf8");
+    const source = readFileSync(join(PACKAGE_DIR, "src", "checking", "islands.ts"), "utf8");
     expect(NAKED_ESBUILD_IMPORT.test(source)).toBe(false);
     expect(GUARDED_ESBUILD_IMPORT.test(source)).toBe(true);
   });

--- a/packages/apps/src/generation/lanes.ts
+++ b/packages/apps/src/generation/lanes.ts
@@ -31,6 +31,8 @@ import {
   type Trigger,
 } from "@vendoai/core";
 import { planAutomation, type AutomationPlan } from "../automation-plan.js";
+import { prepareIslands } from "../checking/islands.js";
+import { smokeRenderIslands } from "../checking/smoke-render.js";
 import type { Finding } from "../checking/types.js";
 import type { GeneratedAppDocument, GenerationDependencies } from "./engine.js";
 

--- a/packages/apps/src/generation/validation/validate.ts
+++ b/packages/apps/src/generation/validation/validate.ts
@@ -16,6 +16,7 @@ import {
   validateAppDocument,
   validateTree,
   type AppDocument,
+  type Finding,
   type WireCompileResult,
 } from "@vendoai/core";
 import {
@@ -30,6 +31,10 @@ import {
   queryInputIssues,
   unknownToolIssues,
 } from "../../checking/facts.js";
+import { floorChecks } from "../../checking/floor.js";
+import { createCheckingLayer } from "../../checking/layer.js";
+import { prepareIslands } from "../../checking/islands.js";
+import { smokeRenderIslands } from "../../checking/smoke-render.js";
 import { pinComponentName } from "../../pins.js";
 import {
   asPayload,
@@ -37,8 +42,12 @@ import {
   type GenerationDependencies,
 } from "../engine.js";
 import { withoutPlanVocabulary } from "../skeleton.js";
-import { prepareIslands } from "./islands.js";
-import { smokeRenderIslands } from "./smoke-render.js";
+
+/** The id a document that is not stored is checked under. A freshly compiled
+ *  document has no id of its own, and both doors that hold one — create
+ *  validation below and `validate({ document })` — need the checks to read a
+ *  whole `AppDocument`. */
+export const UNSTORED_APP_ID = "app_generation_validation";
 
 /** Create validation: the compile must be complete and clean, the tree
  *  catalog-consistent and renderable, islands syntactically sound, queries
@@ -106,16 +115,21 @@ export const validateCompiledCreate = async (
       componentTools: structuredClone(prepared.componentTools),
     }),
   };
-  const appValidation = validateAppDocument({ ...document, id: "app_generation_validation" });
+  const appValidation = validateAppDocument({ ...document, id: UNSTORED_APP_ID });
   if (!appValidation.ok) return { issues: [appValidation.error.message] };
   return { document, issues: [] };
 };
 
-/** Edit validation. Every per-node check is filtered against the pre-existing
- *  app the same way, so an edit that doesn't touch a stale node (a legacy
- *  Table.data prop, an already-dead button) is never blocked by that node's
- *  issue — only issues the edit newly introduces surface. Ids are stable
- *  across an edit, so a carried-over issue is a byte-identical string. */
+/** One finding as the issue line this validator speaks. */
+const issueLine = ({ where, message }: Finding): string =>
+  where === undefined ? message : `${where} ${message}`;
+
+/** Edit validation: the SAME floor every other door runs (checking/floor.ts),
+ *  filtered against the pre-existing app, so an edit that doesn't touch a stale
+ *  node (a legacy Table.data prop, an already-dead button, an island that
+ *  already crashed) is never blocked by that node's issue — only issues the edit
+ *  newly introduces surface. Ids are stable across an edit and both runs read
+ *  the same request text, so a carried-over issue is a byte-identical string. */
 export const validateEditedApp = async (
   app: AppDocument,
   deps: GenerationDependencies,
@@ -130,13 +144,11 @@ export const validateEditedApp = async (
   if (app.tree?.formatVersion !== VENDO_TREE_FORMAT) return ["tree edit produced an unsupported format"];
   const treeValidation = validateTree(app.tree);
   if (!treeValidation.ok) return [treeValidation.error.message];
-  const sourceTreeValidation = validateTree(source.tree);
-  const carried = sourceTreeValidation.ok
-    ? new Set((await catalogIssues(sourceTreeValidation.tree, source.components, deps.catalog)).map(factIssueLine))
-    : new Set<string>();
-  void requestText;
-  return (await catalogIssues(treeValidation.tree, app.components, deps.catalog))
-    .map(factIssueLine)
+  const layer = createCheckingLayer({ deps, checks: floorChecks(deps) });
+  const request = requestText ?? "";
+  const carried = new Set((await layer.run({ document: source, request })).map(issueLine));
+  return (await layer.run({ document: app, request }))
+    .map(issueLine)
     .filter((issue) => !carried.has(issue));
 };
 
@@ -173,12 +185,10 @@ export const documentFromEdit = async (
   });
   const hostComponents = deps.catalog.map(({ name }) => name);
   const parts = split(compiled.components);
+  // Admission runs here for the STAMP (`componentTools`); its issues are the
+  // floor's to report, from `validateEditedApp` below, where the carried-issue
+  // filter lives.
   const prepared = await prepareIslands(parts.model, deps.tools, hostComponents, instruction);
-  // A pre-existing island issue never blocks an unrelated edit: both prepares
-  // see the SAME instruction text, so a carried-over issue stays byte-identical.
-  const before = await prepareIslands(split(previous.components ?? {}).model, deps.tools, hostComponents, instruction);
-  const carried = new Set(before.issues);
-  const islandIssues = prepared.issues.filter((issue) => !carried.has(issue));
   const components = { ...parts.pinned, ...prepared.components };
   if (Object.keys(components).length === 0) {
     delete app.components;
@@ -190,6 +200,6 @@ export const documentFromEdit = async (
     // source-scan fallback.
     app.componentTools = structuredClone(prepared.componentTools);
   }
-  const issues = [...islandIssues, ...await validateEditedApp(app, deps, previous, instruction)];
+  const issues = await validateEditedApp(app, deps, previous, instruction);
   return issues.length > 0 ? { issues } : { document: app, issues: [] };
 };

--- a/packages/apps/src/island-host-components.test.ts
+++ b/packages/apps/src/island-host-components.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { ambientKitEquivalent, prepareIslands } from "./generation/validation/islands.js";
+import { ambientKitEquivalent, prepareIslands } from "./checking/islands.js";
 
 /**
  * Rematch gate 2026-07-25 (docs/eval/runs/2026-07-25-rematch): 17+ Cadence

--- a/packages/apps/src/one-floor.test.ts
+++ b/packages/apps/src/one-floor.test.ts
@@ -1,0 +1,153 @@
+/**
+ * ONE floor at every door.
+ *
+ * Four doors let an app reach a screen — the paint seam (`createAppFloor`),
+ * `validate({ document })`, `validate({ appId })`, and the edit path — and each
+ * ran a different subset of the checks. An island that crashes the moment it
+ * renders was caught at exactly one of them: `validate({ document })` ran the
+ * smoke render, and the paint seam, the stored-app door and the edit path each
+ * shipped the same broken island without ever executing it.
+ *
+ * These drive one deliberately-broken island through all four doors, each
+ * through its own real entry point, and assert the SAME refusal at every one.
+ * Nothing here stubs a check: the floor is the shipped floor, the store is a
+ * real store, and the island really renders (and really crashes) in a worker.
+ */
+import {
+  compileWire,
+  VENDO_APP_FORMAT,
+  type AppDocument,
+  type NormalizedCatalog,
+  type RunContext,
+  type ToolRegistry,
+} from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { documentFromEdit } from "./generation/validation/validate.js";
+import type { GenerationDependencies } from "./generation/engine.js";
+import { createApps } from "./index.js";
+import { guardFixture, memoryStore, scriptedLanguageModel, seedAppRow } from "./testing/index.js";
+import type { FloorDependencies } from "./checking/deps.js";
+import { blocks, createAppFloor } from "./checking/floor.js";
+import { wireCompileOptionsFor } from "./wire-options.js";
+
+/** Renders once, reaches for a name nothing in the ambient scope carries, and
+ *  takes the whole app down with it. It passes ADMISSION — valid TSX, no
+ *  imports, no host tags, no network — so only the smoke render can see it. */
+const CRASHING_ISLAND = `export default function BrokenCard() {
+  return <div>{missingTotal.value}</div>;
+}`;
+
+const HEALTHY_ISLAND = `export default function BrokenCard() {
+  return <div>steady</div>;
+}`;
+
+const wireWith = (island: string): string =>
+  `<App name="Broken"><Island name="BrokenCard">${island}</Island><BrokenCard/></App>`;
+
+const CRASH = /crashed in the smoke render/;
+
+const catalog: NormalizedCatalog = [];
+const floorDeps = (): FloorDependencies => ({ catalog, tools: [] });
+
+const ctx: RunContext = {
+  principal: { kind: "user", subject: "user_ada" },
+  venue: "app",
+  presence: "present",
+  sessionId: "session_ada",
+};
+
+const tools: ToolRegistry = {
+  async descriptors() { return []; },
+  async execute() { return { status: "error", error: { code: "not-found", message: "no tools" } }; },
+};
+
+/** A model that answers nothing useful: every door under test here is
+ *  deterministic, and the reviewer is fail-open by design. */
+const model = () => scriptedLanguageModel(() => "no");
+
+const documentWith = (island: string, id: string): AppDocument => {
+  const compiled = compileWire(wireWith(island), wireCompileOptionsFor(floorDeps()));
+  return {
+    format: VENDO_APP_FORMAT,
+    id,
+    name: "Broken",
+    ui: "tree",
+    tree: compiled.tree as unknown as AppDocument["tree"],
+    components: compiled.components,
+  } as AppDocument;
+};
+
+describe("a crashing island is refused at every door", () => {
+  it("the paint seam", async () => {
+    const floor = createAppFloor({ deps: async () => floorDeps() });
+    const compiled = await floor.compile(wireWith(CRASHING_ISLAND));
+
+    const findings = blocks(await floor.check({ appId: "app_one_floor", compiled }));
+
+    expect(findings.map(({ message }) => message).join("\n")).toMatch(CRASH);
+  }, 60_000);
+
+  it("validate({ document })", async () => {
+    const runtime = createApps({ store: memoryStore(), guard: guardFixture(), tools, catalog, model: model() });
+
+    const result = await runtime.validate({ document: wireWith(CRASHING_ISLAND) }, ctx);
+
+    expect(result.ok).toBe(false);
+    expect(result.findings.map(({ message }) => message).join("\n")).toMatch(CRASH);
+  }, 60_000);
+
+  it("validate({ appId })", async () => {
+    const store = memoryStore();
+    const runtime = createApps({ store, guard: guardFixture(), tools, catalog, model: model() });
+    await seedAppRow(store, documentWith(CRASHING_ISLAND, "app_stored_broken"), ctx.principal.subject);
+
+    const result = await runtime.validate({ appId: "app_stored_broken" }, ctx);
+
+    expect(result.ok).toBe(false);
+    expect(result.findings.map(({ message }) => message).join("\n")).toMatch(CRASH);
+  }, 60_000);
+
+  it("the edit path", async () => {
+    const deps = { ...floorDeps(), model: model() } as unknown as GenerationDependencies;
+    const previous = documentWith(HEALTHY_ISLAND, "app_edited");
+
+    const built = await documentFromEdit(
+      previous,
+      compileWire(wireWith(CRASHING_ISLAND), wireCompileOptionsFor(deps)),
+      deps,
+      "make the card show the total",
+    );
+
+    expect(built.document).toBeUndefined();
+    expect(built.issues.join("\n")).toMatch(CRASH);
+  }, 60_000);
+});
+
+describe("the floor still lets a sound app through every door", () => {
+  it("the paint seam and validate({ document }) both say nothing", async () => {
+    const floor = createAppFloor({ deps: async () => floorDeps() });
+    const compiled = await floor.compile(wireWith(HEALTHY_ISLAND));
+    const runtime = createApps({ store: memoryStore(), guard: guardFixture(), tools, catalog, model: model() });
+
+    expect(blocks(await floor.check({ appId: "app_one_floor_ok", compiled }))).toEqual([]);
+    expect((await runtime.validate({ document: wireWith(HEALTHY_ISLAND) }, ctx)).ok).toBe(true);
+  }, 60_000);
+
+  it("an edit does not inherit the blame for an island that was already broken", async () => {
+    // The carried-issue rule: the previous app's island crashes, the edit does
+    // not touch it, so the edit lands rather than being blocked by history.
+    const deps = { ...floorDeps(), model: model() } as unknown as GenerationDependencies;
+    const previous = documentWith(CRASHING_ISLAND, "app_already_broken");
+    const edited = wireWith(CRASHING_ISLAND).replace("<BrokenCard/>", '<BrokenCard/><Text text="added"/>');
+
+    const built = await documentFromEdit(
+      previous,
+      compileWire(edited, wireCompileOptionsFor(deps)),
+      deps,
+      "add a caption",
+    );
+
+    expect(built.issues).toEqual([]);
+    expect(built.document).toBeDefined();
+  }, 60_000);
+});

--- a/packages/apps/src/pins.ts
+++ b/packages/apps/src/pins.ts
@@ -75,6 +75,15 @@ export const pinComponentName = (slot: string): string => {
   return `Pinned${stem}${sha256Hex(slot).slice(0, 8)}`;
 };
 
+/** Is this component name a captured host slot's? The counterpart of
+ *  {@link pinComponentName}, for the seams that hold a document's components
+ *  but not its `pins` — the paint floor checks a compiled `app.vendo`, and a
+ *  checkout prints pinned sources into that file alongside the model's islands.
+ *  Captured host source is not a model island: it keeps its imports and is
+ *  never put through the ambient contract. */
+export const isPinComponentName = (name: string): boolean =>
+  /^Pinned[A-Za-z0-9]*[0-9a-f]{8}$/.test(name);
+
 /**
  * Blank comment and string/template contents (length-preserving) so export
  * detection never matches commented-out or quoted code. (Adapted from the

--- a/packages/apps/src/runtime.ts
+++ b/packages/apps/src/runtime.ts
@@ -56,7 +56,7 @@ import { appLifecycleEvent } from "./audit.js";
 import { createAppCaller } from "./call.js";
 import { createParkedActions } from "./parked-action.js";
 import type { Check } from "./checking/types.js";
-import { createAppFloor } from "./checking/floor.js";
+import { createAppFloor, floorChecks } from "./checking/floor.js";
 import type {
   CloudAppsClient,
   PublishRecord,
@@ -81,10 +81,9 @@ import type { Finding } from "./checking/types.js";
 // The `validate` verb IS the shipped floor plus the shipped create validation,
 // called rather than re-derived — so the verb and generation can never disagree
 // about whether a document is sound.
-import { screenTypesCheck } from "./checking/facts.js";
 import { createCheckingLayer, judgmentRules } from "./checking/layer.js";
 import { reviewerCheck } from "./checking/reviewer.js";
-import { validateCompiledCreate } from "./generation/validation/validate.js";
+import { UNSTORED_APP_ID, validateCompiledCreate } from "./generation/validation/validate.js";
 import { wireCompileOptionsFor } from "./wire-options.js";
 import { createAppHistory, type PinIntentKind } from "./history.js";
 import { createInClientApprovals, type InClientVerdict } from "./inclient.js";
@@ -2094,7 +2093,7 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
         }
       }));
     return {
-      tools: descriptors.map(({ name, description, risk, inputSchema }) => ({
+      tools: descriptors.map(({ name, description, risk, inputSchema, outputSchema }) => ({
         name,
         description,
         risk,
@@ -2103,6 +2102,9 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
         ...(typeof inputSchema === "object" && inputSchema !== null && !Array.isArray(inputSchema)
           ? { inputSchema: inputSchema as Record<string, unknown> }
           : {}),
+        // The host's own declared response shape — what the screen type check
+        // reads before it falls back to a sample (checking/deps.ts).
+        ...(outputSchema === undefined ? {} : { outputSchema }),
       })),
       ...(sampledShapes.size === 0 ? {} : { toolShapes: Object.fromEntries(sampledShapes) }),
     };
@@ -3088,11 +3090,18 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
           input.document,
           wireCompileOptionsFor(deps),
         );
-        const { issues } = await validateCompiledCreate(compiled, deps);
-        return {
-          ok: issues.length === 0,
-          findings: issues.map((message) => ({ severity: "block" as const, message })),
-        };
+        const { document, issues } = await validateCompiledCreate(compiled, deps);
+        if (document === undefined) {
+          // Wire that did not compile, or islands that did not pass admission:
+          // the screen text the floor would read does not exist yet, so those
+          // sentences are the whole answer.
+          return { ok: false, findings: issues.map((message) => ({ severity: "block" as const, message })) };
+        }
+        // …and then the SAME floor every other door runs, on the document the
+        // wire assembled to.
+        const findings = await createCheckingLayer({ deps, checks: floorChecks(deps) })
+          .run({ document: { ...document, id: UNSTORED_APP_ID } as AppDocument, request: "" });
+        return { ok: !findings.some(({ severity }) => severity === "block"), findings };
       }
 
       if (input.appId === undefined) {
@@ -3124,9 +3133,9 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
       const plugged = config.checks ?? [];
       const findings = await createCheckingLayer({
         deps,
-        // The thorough door: the compiler static half AND the reviewer. Off the
+        // The thorough door: the shared floor AND the reviewer. Off the
         // scripted-create hot path, so the tsc pass is affordable here (§7.1).
-        checks: [screenTypesCheck(deps), reviewerCheck(deps, undefined, judgmentRules(plugged)), ...plugged],
+        checks: [...floorChecks(deps), reviewerCheck(deps, undefined, judgmentRules(plugged)), ...plugged],
       }).run({ document, request: "" });
       return { ok: !findings.some(({ severity }) => severity === "block"), findings };
     },

--- a/packages/apps/src/smoke-render-workerd-unavailable.test.ts
+++ b/packages/apps/src/smoke-render-workerd-unavailable.test.ts
@@ -22,7 +22,7 @@ vi.mock("node:worker_threads", () => ({
 
 describe("smokeRenderIslands on a Worker-thread-less environment (workerd)", () => {
   it("skips the gate silently instead of throwing when new Worker() is unimplemented", async () => {
-    const { smokeRenderIslands } = await import("./generation/validation/smoke-render.js");
+    const { smokeRenderIslands } = await import("./checking/smoke-render.js");
     const source = `
 export default function ClientList() {
   return <Text text="hello" />;

--- a/packages/apps/src/smoke-render.test.ts
+++ b/packages/apps/src/smoke-render.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isWorkerLoadablePath, resolveWorkerModulePaths, sampleFromShape, smokeRenderIslands } from "./generation/validation/smoke-render.js";
+import { isWorkerLoadablePath, resolveWorkerModulePaths, sampleFromShape, smokeRenderIslands } from "./checking/smoke-render.js";
 
 /**
  * v4 wave — the smoke-render gate. Final gate 2026-07-21: two crash forms


### PR DESCRIPTION
Four doors let an app reach a screen, and each ran a different subset of the
checks. So "does this app pass?" had four answers, and an app refused at one door
shipped through another. Separately, `screenTypings` has always preferred a
tool's DECLARED output schema over the shape sampled from one live call — and
nothing anywhere ever populated it, so every screen was type-checked against one
observation instead of the host's own contract.

## 1. One floor at every door

`floorChecks(deps)` (`packages/apps/src/checking/floor.ts:87`) is the whole
definition, imported by all four doors. On top of the layer's own `factChecks`
it is the compiler static half (`screenTypesCheck`) and the island gates
(`prepareIslands`, then `smokeRenderIslands` on an otherwise-clean set).

| door | before | after |
|---|---|---|
| paint seam (`createAppFloor`, every `app.vendo` commit) | facts + tsc | facts + tsc + **islands** |
| `validate({ document })` | facts (hand-rolled) + islands | + **tsc** |
| `validate({ appId })` | facts + tsc + reviewer | + **islands** |
| edit path (`validateEditedApp`) | catalog existence, and nothing else | facts + tsc + islands, carried-issue filtered |

The AI reviewer has **not** moved. It spends a model call, so it stays exactly
where it was: `AppsRuntime.validate`, and nowhere else.

The edit door is the biggest change and the one worth reading
(`packages/apps/src/generation/validation/validate.ts:118`). It used to be a
single `catalogIssues` call. It now runs the same layer twice — once over the
edited app, once over the app the edit started from — and drops findings the two
runs share. That is the rule it already had for catalog issues, generalized to
every check, so a stale node or an island that was already broken never blocks an
unrelated edit. `documentFromEdit` loses its own copy of the island scan and its
own carried-issue filter; it keeps `prepareIslands` only for the
`componentTools` stamp.

Pinned components are skipped by the island check
(`isPinComponentName`, `packages/apps/src/pins.ts:78`). Their source is host
source captured on the furnishing trust path — it keeps its imports and was never
a model island. The name is the only marker available at the paint seam, whose
document is built from compiled wire and carries no `pins`, and `checkoutApp`
prints pinned sources into `app.vendo` alongside the model's islands.

### The move

`generation/validation/islands.ts` and `smoke-render.ts` move to `checking/`.
Not cosmetic: `packages/apps/src/checking/deps.test.ts` is an architecture guard
that fails if anything under `checking/` imports `../generation/`, and the floor
that runs these gates lives there. The two modules only ever depended on core,
`pins.ts`, and `HostToolInfo` — which is already `checking/deps.ts`'s own type,
re-exported by `generation/engine.ts`. Four existing tests change **only** their
import path (and the bundler-safety e2e its `dist` path); not one assertion moves.

### Paint-seam cost

The paint floor is the save hot path, so it was measured
(`createAppFloor.check`, apps `dist`, 0/1/3 islands):

```
0 islands: cold 130ms, warm 4ms
1 island:  cold 499ms, warm 7ms
3 islands: cold 295ms, warm 7ms
```

Cold is dominated by the tsc program the door already paid for, plus one-time
worker/module resolution. A repeated save — the real shape of a build turn —
costs **~3ms** more, because the smoke render is keyed on island source and an
unchanged island never renders twice.

## 2. Declared tool schemas reach the screen type check

`ToolDescriptor.outputSchema` now travels: `HostToolInfo` carries it
(`checking/deps.ts:22`), `generationToolContext` fills it from the registry
(`runtime.ts:2088`), and `screenTypeFindings` hands it to `screenTypings` as
`toolOutputSchemas` (`checking/facts.ts:519`). Sampled shapes remain the
fallback, exactly as `screenTypings` always documented.

This matters because **sampling erases what a declaration keeps**. An enum field
samples as a bare `string`, so a host component whose prop takes that enum could
never be satisfied by any tool. demo-bank's `MapleSpendingDonut.slices` takes the
category enum, `host_getSpendingInsights` DECLARES it (`.vendo/tools.json`), and
the check was reading the sample instead.

## Tests (new only)

- `packages/apps/src/one-floor.test.ts` — one island that passes admission and
  crashes on render, through all four doors, each by its own real entry point
  (the real floor, the real runtime, a real store row, the real edit path).
  Plus the sound-app case and the carried-issue case.
- `packages/apps/src/checking/declared-tool-schemas.test.ts` — the seam, both
  sides live: a real `ToolRegistry` descriptor → `generationToolContext` →
  `validate` → `screenTypesCheck` → `tsc`. A field the declaration does not carry
  is refused with no sample in play; the enum-typed prop is satisfiable; and with
  the declaration removed the sample erases the enum and the same screen is
  refused.

Each was proven to fail. Dropping `islandsCheck` from `floorChecks` turns 3 of
the 4 doors red (`validate({ document })` stays green — it was the one door that
already ran the smoke render). Reverting the `validate({ document })` door to its
old shape turns both must-block schema cases red. Removing the
`toolOutputSchemas` wiring turns the two declaration cases red.

## Browser proof

demo-bank on Vendo Cloud, real browser, `pnpm dev`.

"show me my spending by category this month" — renders, real category data:

![spending by category](https://raw.githubusercontent.com/runvendo/vendo/7386e3180cfe98f27dcfefbdefa39b8d90afd41c/one-floor-spending-by-category.png)

The donut case itself — the app the agent stored is
`MapleSpendingDonut` with `slices` bound to `/spending/data`, the exact
enum-typed host prop that the erased sample could not satisfy:

![maple spending donut](https://raw.githubusercontent.com/runvendo/vendo/7386e3180cfe98f27dcfefbdefa39b8d90afd41c/one-floor-maple-spending-donut.png)

One honest caveat: the *live* before/after is suggestive, not proof. On a build
with the `toolOutputSchemas` wiring reverted, the same prompt produced the Kit
`DonutChart` instead of the host donut — consistent with the agent being refused
on `MapleSpendingDonut` and falling back, but the model is free to choose either.
The deterministic proof of that class is the schema test above, which goes red
without the wiring.

## Gate

`pnpm build`, `pnpm typecheck`, `pnpm lint` green on the rebased branch.
`packages/apps` in full: 1048 passed, 19 skipped, 0 failed.
`packages/harnesses` in full: 421 passed, 13 skipped, 0 failed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies validation across all app entry points with a single `floorChecks` that runs compiler type checks and island gates everywhere. Also pipes declared `ToolDescriptor.outputSchema` into screen type checks so screens are validated against the host contract, fixing enum erasure cases like the spending donut.

- **New Features**
  - One shared floor across the paint seam, `validate({ document })`, `validate({ appId })`, and the edit path; it runs `screenTypesCheck` plus island admission (`prepareIslands`) and the smoke render (`smokeRenderIslands`). The reviewer stays only on `validate`.
  - Edit validation runs the floor on both the source and edited app and filters carried issues; pinned components skip the island gate via `isPinComponentName`.
  - Declared tool schemas (`outputSchema`) now travel via `HostToolInfo` and are passed to `screenTypings` as `toolOutputSchemas`. Samples remain the fallback; enums no longer erase to `string`.
  - Moved island modules to `checking/` and updated imports/tests; warm saves add ~3ms due to keyed smoke renders.

<sup>Written for commit 89050047257d4d9e78f73aac19a772c54164ffd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

