### PR TITLE
fix(apps,guard,mcp,ui): risk-round findings — placement masking, atomic eviction, presence-only law, withheld tools

### DIFF
--- a/.changeset/slots-risk-round.md
+++ b/.changeset/slots-risk-round.md
@@ -3,6 +3,8 @@
 "@vendoai/core": patch
 "@vendoai/guard": patch
 "@vendoai/mcp": patch
+"@vendoai/ui": patch
+"@vendoai/vendo": patch
 ---
 
 Risk-round fixes on the placement stack.
@@ -25,12 +27,40 @@ Risk-round fixes on the placement stack.
   reused, so a stale client's delete can only ever hit its own placement.
   Pointers live in their own generic collection (`vendo_placement_slots`), so
   `vendo_placements` still holds exactly one row per live placement.
-- A `vendo_make` that names a `slot` is presence-only, like the pin tool: the
-  slot claims a place on somebody's page and evicts whatever held it, so an
-  unattended run still builds but takes no slot. Plain makes are not regraded.
+- A `vendo_make` that names a `slot` still builds when nobody is there, and
+  simply takes no slot. Placement is what needs a person present; creation is
+  not, and refusing the whole call would silently break the automations that
+  legitimately create screens. `presenceOnlyCall` now names the pin tools and
+  only those.
 - The presence-only law now has the second layer the destructive half has
   always had. `projectableForRun` only decides what a run is OFFERED; the
   guard's choke point refuses a presence-only call outright, so a standing
   automation grant can no longer rearrange a page with nobody watching.
 - `withholdTools` holds on both legs of an MCP mount. A turn-bearing session
   listed and could call a name the deployment said it never offers.
+
+Second round, on the pointer/live-row split the first round introduced.
+
+- A `place()` that dies between writing its live row and swinging the pointer
+  no longer strands that row. Until the pointer lands nothing names the row, so
+  a failed swing takes it back out; every retry used to leave one more row that
+  nothing read and nothing collected, against the "exactly one live row per
+  slot" count the seam readers take. `place()`'s comment claimed a cleanup no
+  code performed; it now describes what the code does.
+- Deleting an app leaves no placement behind. The clear removed only the live
+  row, so the pointer kept the dead app's id, its `placedBy` and its timestamp
+  forever — nothing in the tree ever removed a pointer, and one accumulated per
+  slot a person ever used. The pointer now goes too, and only while it still
+  names the token being cleared, so a place that took the slot in between keeps
+  it.
+- Deleting a SHARED app clears it out of everyone's slots, not just the
+  deleter's. Placement rows carry `refs.app_id` (the ref `egress-approval.ts`
+  clears an app by) and the sweep is by app, so a co-owner's delete can no
+  longer leave a permanent "didn't build" card standing over another person's
+  host markup.
+- `placements({ slots })` normalizes the slot id the same way every write does,
+  so `place(" hero ")` is findable as `" hero "`. Only the write trimmed before.
+- A slot id containing a "," survives the wire. The client joined slot ids on
+  "," and the route split on ",", so such an id was writable and permanently
+  unreadable. Each id is now percent-encoded on its own inside the list and
+  decoded per item after the split.

--- a/.changeset/slots-risk-round.md
+++ b/.changeset/slots-risk-round.md
@@ -17,9 +17,14 @@ Risk-round fixes on the placement stack.
   "nothing was replaced" while one of them was silently displaced. The write
   now compare-and-swaps on the row's revision and the loser retries against the
   winner's row.
-- `unplace()`'s delete is scoped to the app the caller named, at the store, so a
-  stale client cannot clear the app that replaced it. Adapters that expose
-  `RecordStore.claim` compare and delete in one statement.
+- `unplace()` can no longer clear the app that replaced it. A placement is now
+  two rows: a pointer at `plc:<subject>:<slot>` that says who holds the slot
+  under which token (the single CAS arbitration point), and a live row at
+  `plcv:<subject>:<slot>:<token>` that exists only while that placement holds
+  it. A clear deletes the token'd row and nothing else, and tokens are never
+  reused, so a stale client's delete can only ever hit its own placement.
+  Pointers live in their own generic collection (`vendo_placement_slots`), so
+  `vendo_placements` still holds exactly one row per live placement.
 - A `vendo_make` that names a `slot` is presence-only, like the pin tool: the
   slot claims a place on somebody's page and evicts whatever held it, so an
   unattended run still builds but takes no slot. Plain makes are not regraded.

--- a/.changeset/slots-risk-round.md
+++ b/.changeset/slots-risk-round.md
@@ -1,0 +1,31 @@
+---
+"@vendoai/apps": patch
+"@vendoai/core": patch
+"@vendoai/guard": patch
+"@vendoai/mcp": patch
+---
+
+Risk-round fixes on the placement stack.
+
+- `GET /apps/placements` is an app read. `entryFor` raw-read the app row, so a
+  viewer whose grant was taken back kept reading a placed app's title and its
+  live build status after `open`/`get`/`list` had all gone back to not-found.
+  Every entry now passes the same `can()` check those paths use, and a slot the
+  caller may no longer view reads as empty.
+- `place()` is one decision, not read-then-write. The eviction receipt used to
+  be a separate read, so two places into the same slot could both answer
+  "nothing was replaced" while one of them was silently displaced. The write
+  now compare-and-swaps on the row's revision and the loser retries against the
+  winner's row.
+- `unplace()`'s delete is scoped to the app the caller named, at the store, so a
+  stale client cannot clear the app that replaced it. Adapters that expose
+  `RecordStore.claim` compare and delete in one statement.
+- A `vendo_make` that names a `slot` is presence-only, like the pin tool: the
+  slot claims a place on somebody's page and evicts whatever held it, so an
+  unattended run still builds but takes no slot. Plain makes are not regraded.
+- The presence-only law now has the second layer the destructive half has
+  always had. `projectableForRun` only decides what a run is OFFERED; the
+  guard's choke point refuses a presence-only call outright, so a standing
+  automation grant can no longer rearrange a page with nobody watching.
+- `withholdTools` holds on both legs of an MCP mount. A turn-bearing session
+  listed and could call a name the deployment said it never offers.

--- a/packages/apps/src/agent-tools.ts
+++ b/packages/apps/src/agent-tools.ts
@@ -4,6 +4,7 @@ import {
   VENDO_MAKE_TOOL,
   VENDO_TOOL_TITLES,
   appIdSchema,
+  isUnattended,
   VENDO_VIEW_STREAM,
   VendoError,
   makeReceiptSchema,
@@ -416,6 +417,12 @@ export const createAgentTools = (
         const args = input(call.args, ["request"], ["app", "context", "slot"]);
         const app = optionalString(args.app, "app");
         const slot = optionalString(args.slot, "slot");
+        // Presence-only, at the source (core `presenceOnlyCall`): a slot claims
+        // a place on somebody's page and evicts whatever held it, so with
+        // nobody there the build still runs and the slot is simply not taken.
+        // The refusal below still reads `slot`, because "you aimed a new app at
+        // a slot on an EDIT" is wrong however present the person is.
+        const claimed = isUnattended(ctx) ? undefined : slot;
         const stream = (call as VendoViewStreamingToolCall)[VENDO_VIEW_STREAM];
         const request = args.request as string;
         const ask = withContext(request, optionalString(args.context, "context"));
@@ -481,7 +488,7 @@ export const createAgentTools = (
               // app record (§9.4) and assembly is what writes that record, so
               // this is the FIRST instant the claim can legally be made — and
               // the last instant it is still part of the call the person made.
-              if (slot !== undefined) await runtime.place({ app: stored.id, slot }, ctx);
+              if (claimed !== undefined) await runtime.place({ app: stored.id, slot: claimed }, ctx);
               return receipt({
                 id: stored.id,
                 title: stored.name,
@@ -542,7 +549,7 @@ export const createAgentTools = (
             // running (or that never lands) occupies the place the caller aimed
             // at instead of appearing out of nowhere minutes later. This tool
             // only aims; the runtime owns the row.
-            ...(slot === undefined ? {} : { slot }),
+            ...(claimed === undefined ? {} : { slot: claimed }),
             onUnsaved: (reason) => { unsaved = reason; },
             ...(stream === undefined ? {} : {
               onView: (part) => stream({ id: vendoViewStreamId(part.appId), part }),

--- a/packages/apps/src/agent-tools.ts
+++ b/packages/apps/src/agent-tools.ts
@@ -417,9 +417,11 @@ export const createAgentTools = (
         const args = input(call.args, ["request"], ["app", "context", "slot"]);
         const app = optionalString(args.app, "app");
         const slot = optionalString(args.slot, "slot");
-        // Presence-only, at the source (core `presenceOnlyCall`): a slot claims
-        // a place on somebody's page and evicts whatever held it, so with
-        // nobody there the build still runs and the slot is simply not taken.
+        // The slot, and ONLY the slot, needs a person there: it claims a place
+        // on somebody's page and evicts whatever held it. Creation does not, so
+        // an unattended run still builds what it was asked for and simply takes
+        // no slot — this is the whole of that rule (ruled 2026-08-06; the
+        // guard's presence-only refusal covers the pin tools, never make).
         // The refusal below still reads `slot`, because "you aimed a new app at
         // a slot on an EDIT" is wrong however present the person is.
         const claimed = isUnattended(ctx) ? undefined : slot;

--- a/packages/apps/src/placement-risk-2.test.ts
+++ b/packages/apps/src/placement-risk-2.test.ts
@@ -1,0 +1,168 @@
+/**
+ * ADVERSARIAL round 2 on the placement rows (re-check, 2026-08-06), against the
+ * pointer + token-keyed live row the first round's fixes introduced.
+ *
+ * Round 1's six findings are closed and their cases are green; nothing here
+ * re-litigates them. These are the cases the NEW shape opens, plus the two
+ * round-1 "plausible" items confirmed now that there is a tree to run them in.
+ *
+ * Same fixtures as `placement-runtime.test.ts` and `placement-risk.test.ts`:
+ * the real runtime over a real store, and the rows read back out of the store.
+ */
+import type { AppDocument, RunContext, StoreAdapter, ToolRegistry } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { createApps } from "./index.js";
+import {
+  PLACEMENTS_COLLECTION,
+  PLACEMENT_SLOTS_COLLECTION,
+  placementStore,
+} from "./placements.js";
+import { guardFixture, memoryStore, seedAppRow } from "./testing/index.js";
+
+const ada: RunContext = {
+  principal: { kind: "user", subject: "user_ada" },
+  venue: "app",
+  presence: "present",
+  sessionId: "session_ada",
+};
+const mia: RunContext = {
+  ...ada,
+  principal: { kind: "user", subject: "user_mia" },
+  sessionId: "session_mia",
+};
+
+const tools: ToolRegistry = {
+  async descriptors() { return []; },
+  async execute() { return { status: "error", error: { code: "not-found", message: "no tools" } }; },
+};
+
+const doc = (id: string, name: string): AppDocument => ({
+  format: "vendo/app@1",
+  id,
+  name,
+  ui: "tree",
+  tree: {
+    formatVersion: "vendo-genui/v2",
+    root: "root",
+    nodes: [{ id: "root", component: "Stack", source: "prewired" }],
+  },
+});
+
+/** The count `placements.ts` calls "exactly one row per live placement, which
+ *  is what the seam readers count" — and which `placement-rows.test.ts` pins. */
+const liveRows = async (store: StoreAdapter, subject: string) =>
+  (await store.records(PLACEMENTS_COLLECTION).list({ refs: { subject } })).records;
+
+const pointerApps = async (store: StoreAdapter, subject: string): Promise<string[]> =>
+  (await store.records(PLACEMENT_SLOTS_COLLECTION).list({ refs: { subject } })).records
+    .map((record) => (record.data as { appId?: string }).appId ?? "");
+
+describe("a placement that dies between its live row and its pointer", () => {
+  it("leaves no live row behind for the retry to pile on top of", async () => {
+    // `place()` writes the live row FIRST and swings the pointer second, which
+    // is what keeps a reader from ever seeing the slot empty mid-replace. The
+    // cost is that anything which stops the pointer write strands the live row:
+    // nothing names it, nothing reads it, and nothing ever collects it.
+    //
+    // The blip is injected at the store's own `atomic` seam — the real adapter
+    // interface, and the reason `place()` has a retry loop at all. A client
+    // that retries (the picker, the pin ceremony, the poller's next tick) adds
+    // one more stranded row every time, unbounded, each holding the subject,
+    // the app id and the timestamp.
+    const base = memoryStore();
+    let blip = true;
+    const store: StoreAdapter = {
+      ...base,
+      records(collection) {
+        const rows = base.records(collection);
+        const atomic = rows.atomic;
+        if (collection !== PLACEMENT_SLOTS_COLLECTION || atomic === undefined) return rows;
+        return {
+          ...rows,
+          atomic: {
+            ...atomic,
+            async insertIfAbsent(input) {
+              if (blip) {
+                blip = false;
+                throw new Error("transient store blip");
+              }
+              return await atomic.insertIfAbsent(input);
+            },
+          },
+        };
+      },
+    } as StoreAdapter;
+    await seedAppRow(base, doc("app_1", "Spending"), ada.principal.subject);
+    const runtime = createApps({ store, guard: guardFixture(), tools, catalog: [] });
+
+    await expect(runtime.place({ app: "app_1", slot: "home-hero" }, ada)).rejects.toThrow();
+    await runtime.place({ app: "app_1", slot: "home-hero" }, ada);
+
+    // The slot itself is right — the pointer is the only arbiter, and it names
+    // the second attempt. It is the collection underneath that is not.
+    expect(await runtime.placements({}, ada)).toHaveLength(1);
+    expect(await liveRows(base, ada.principal.subject)).toHaveLength(1);
+  });
+});
+
+describe("what a deleted app leaves in the slot rows", () => {
+  it("takes its pointer with it, not just its live row", async () => {
+    // Before the pointer split, `delete` removed the placement outright. Now it
+    // clears the live row and leaves the pointer holding the dead app's id, its
+    // placedBy subject and its timestamp — and nothing else in the codebase
+    // ever deletes a pointer, so one accumulates per slot the person ever used
+    // and only a full subject erase reaches it.
+    const store = memoryStore();
+    await seedAppRow(store, doc("app_1", "Spending"), ada.principal.subject);
+    const runtime = createApps({ store, guard: guardFixture(), tools, catalog: [] });
+    await runtime.place({ app: "app_1", slot: "home-hero" }, ada);
+
+    await runtime.delete("app_1", ada);
+
+    expect(await runtime.placements({}, ada)).toEqual([]);
+    expect(await liveRows(store, ada.principal.subject)).toHaveLength(0);
+    expect(await pointerApps(store, ada.principal.subject)).toEqual([]);
+  });
+
+  it("clears the rows OTHER people hold on it, not only the deleter's", async () => {
+    // `delete` sweeps `placementRows.list(ctx.principal.subject)` — the
+    // DELETER's rows. Mia owns a shared app, Ada placed it on her own page, Mia
+    // deletes it: Ada's row survives with no record behind it, which `entryFor`
+    // reads as a build in flight and then, past the build window, as `failed`.
+    //
+    // A failed slot REPLACES the host's own markup (ruled by design, and the
+    // only way out is a person tapping "Clear this slot"), so one person
+    // deleting their own app leaves an error card standing on another person's
+    // page. The §9.4 mask added this round does not catch it: the masking arm
+    // runs only where an app record exists, and here there is none.
+    const store = memoryStore();
+    await seedAppRow(store, doc("app_mia", "Mia's view"), mia.principal.subject);
+    await placementStore(store).put(ada.principal.subject, {
+      slot: "home-hero",
+      appId: "app_mia",
+      placedBy: ada.principal.subject,
+      placedAt: new Date().toISOString(),
+    });
+    const runtime = createApps({ store, guard: guardFixture(), tools, catalog: [] });
+
+    await runtime.delete("app_mia", mia);
+
+    expect(await runtime.placements({}, ada)).toEqual([]);
+  });
+});
+
+describe("the slot string a caller places with is the slot string it can read", () => {
+  it("answers a `slots` filter that is spelled exactly as the write was", async () => {
+    // `requireSlot` trims on every WRITE (place/unplace/create); the read path
+    // (`placements({slots})` → `placementStore.list`) does not trim at all, so
+    // the same string round-trips to nothing. The wire hides it — its query
+    // parser trims each name — which is exactly why it is invisible until a
+    // host calls the runtime or the client's `placements([...])` directly.
+    const store = memoryStore();
+    await seedAppRow(store, doc("app_1", "Spending"), ada.principal.subject);
+    const runtime = createApps({ store, guard: guardFixture(), tools, catalog: [] });
+    await runtime.place({ app: "app_1", slot: " home-hero " }, ada);
+
+    expect(await runtime.placements({ slots: [" home-hero "] }, ada)).toHaveLength(1);
+  });
+});

--- a/packages/apps/src/placement-risk.test.ts
+++ b/packages/apps/src/placement-risk.test.ts
@@ -1,0 +1,192 @@
+/**
+ * ADVERSARIAL probes on the placement verbs (risk round, 2026-08-06).
+ *
+ * Same fixtures and same shape as `placement-runtime.test.ts` — these are the
+ * cases that file does not ask, aimed at the three claims the code makes in
+ * prose: that a placement is masked exactly as an app is, that the eviction
+ * receipt is true, and that "a stale client can never evict the app that
+ * replaced it".
+ */
+import type { AppDocument, RunContext, StoreAdapter, ToolRegistry } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { createApps, type AppsRuntime } from "./index.js";
+import { seedGrantRows, storeAccessFixture } from "./testing/app-access-fixture.js";
+import {
+  authoringAssembler,
+  guardFixture,
+  memoryStore,
+  scriptedLanguageModel,
+  seedAppRow,
+} from "./testing/index.js";
+
+const ada: RunContext = {
+  principal: { kind: "user", subject: "user_ada" },
+  venue: "app",
+  presence: "present",
+  sessionId: "session_ada",
+};
+
+const tools: ToolRegistry = {
+  async descriptors() { return []; },
+  async execute() { return { status: "error", error: { code: "not-found", message: "no tools" } }; },
+};
+
+const doc = (id: string, name: string, overrides: Partial<AppDocument> = {}): AppDocument => ({
+  format: "vendo/app@1",
+  id,
+  name,
+  ui: "tree",
+  tree: {
+    formatVersion: "vendo-genui/v2",
+    root: "root",
+    nodes: [{ id: "root", component: "Stack", source: "prewired" }],
+  },
+  ...overrides,
+});
+
+describe("a placement read is not an access check (risk round)", () => {
+  it("keeps naming an app the caller lost access to, after open() has gone back to not-found", async () => {
+    // Mia's app, shared with Ada as a viewer. Ada places it in her own slot —
+    // which `place()` allows, correctly: seeing an app is enough to put it on
+    // your own page.
+    const store = memoryStore();
+    await seedAppRow(store, doc("app_mia", "Mia's Q3 severance model"), "user_mia");
+    await seedGrantRows(store, "app_mia", { "user:user_ada": "viewer" });
+    const runtime = createApps({
+      store,
+      guard: guardFixture(),
+      tools,
+      catalog: [],
+      appAccess: storeAccessFixture(store),
+      multiParty: true,
+    });
+    await runtime.place({ app: "app_mia", slot: "home-hero" }, ada);
+
+    // Mia takes the share back.
+    await store.records("vendo_app_grants").delete("ag_app_mia_user:user_ada");
+
+    // §9.4's posture, proved on the read path Ada still has: the app is masked.
+    await expect(runtime.open("app_mia", ada)).rejects.toMatchObject({ code: "not-found" });
+    expect(await runtime.get("app_mia", ada)).toBeNull();
+    expect(await runtime.list(ada)).toEqual([]);
+    // …and this is the same subject asking the placements read, which never
+    // consults `can()` at all: `entryFor` does a raw `apps.get(row.appId)`.
+    // The title of a document Ada may no longer open comes straight back.
+    expect(await runtime.placements({}, ada)).toEqual([]);
+  });
+});
+
+describe("the eviction receipt is read-then-write, with no CAS (risk round)", () => {
+  it("loses one of two concurrent places into the same slot and reports no eviction", async () => {
+    const store = memoryStore();
+    await seedAppRow(store, doc("app_1", "Spending"), ada.principal.subject);
+    await seedAppRow(store, doc("app_2", "Savings"), ada.principal.subject);
+    const runtime = createApps({ store, guard: guardFixture(), tools, catalog: [] });
+
+    const [first, second] = await Promise.all([
+      runtime.place({ app: "app_1", slot: "home-hero" }, ada),
+      runtime.place({ app: "app_2", slot: "home-hero" }, ada),
+    ]);
+
+    // One of the two DID displace the other — the slot holds one app. Whoever
+    // lost was evicted without anybody being told, so the agent's sentence
+    // ("nothing was replaced") is false for one of these two callers.
+    const held = (await runtime.placements({}, ada))[0]?.app;
+    const loser = held === "app_1" ? "app_2" : "app_1";
+    expect([first.evicted, second.evicted]).toContain(loser);
+  });
+});
+
+describe("unplace's 'a stale client can never evict the app that replaced it' (risk round)", () => {
+  it("clears the slot the winner just took when a place lands inside unplace's read-then-delete", async () => {
+    // The interleaving is forced through the STORE, not through a stub of
+    // either verb: the runtime, the placement rows and the store beneath are
+    // all the real ones. `delete` on the placements collection is held open
+    // until the competing `place` has committed — the exact window
+    // `unplace()`'s own comment says cannot be exploited.
+    const base = memoryStore();
+    let openTheWindow = (): void => {};
+    const window = new Promise<void>((resolve) => { openTheWindow = resolve; });
+    let held = false;
+    const store: StoreAdapter = {
+      ...base,
+      records(collection) {
+        const rows = base.records(collection);
+        if (collection !== "vendo_placements") return rows;
+        return {
+          ...rows,
+          async delete(id: string) {
+            if (!held) {
+              held = true;
+              await window;
+            }
+            return await rows.delete(id);
+          },
+        };
+      },
+    } as StoreAdapter;
+
+    await seedAppRow(base, doc("app_1", "Spending"), ada.principal.subject);
+    await seedAppRow(base, doc("app_2", "Savings"), ada.principal.subject);
+    const runtime = createApps({ store, guard: guardFixture(), tools, catalog: [] });
+    await runtime.place({ app: "app_1", slot: "home-hero" }, ada);
+
+    // The stale client's unplace reads the row (app_1), then stalls in delete.
+    const stale = runtime.unplace({ app: "app_1", slot: "home-hero" }, ada);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    // Meanwhile the person places app_2 there.
+    expect(await runtime.place({ app: "app_2", slot: "home-hero" }, ada)).toEqual({ evicted: "app_1" });
+    openTheWindow();
+    await stale;
+
+    expect(await runtime.placements({}, ada)).toEqual([
+      { slot: "home-hero", app: "app_2", title: "Savings", status: "ready" },
+    ]);
+  });
+});
+
+describe("vendo_make's `slot`, on a run with nobody there (risk round)", () => {
+  const generated = '<App name="Nightly digest"><Text text="Ready"/><Disclaimer reason="Fixture app."/></App>';
+
+  const away: RunContext = {
+    principal: ada.principal,
+    venue: "automation",
+    presence: "away",
+    sessionId: "session_nightly",
+  };
+
+  /** The assembly engine, exactly as `agent-tools.test.ts` composes it. */
+  const assembling = (): AppsRuntime => {
+    const runtime: AppsRuntime = createApps({
+      store: memoryStore(),
+      guard: guardFixture(),
+      tools,
+      catalog: [],
+      model: scriptedLanguageModel(generated),
+      screen: authoringAssembler(() => runtime, generated),
+    });
+    return runtime;
+  };
+
+  it("rearranges the page anyway — the presence rule catches the pin tool and not this", async () => {
+    // `PRESENCE_ONLY_TOOLS` (core/tools.ts) withholds vendo_apps_pin from an
+    // unattended run because "a firing that rearranged someone's dashboard
+    // while they were away would be a change they never asked for and never
+    // saw being made — and, because a placement EVICTS whatever held that
+    // slot, one they would come back to without knowing what happened."
+    //
+    // `vendo_make` is graded `read`, so no projection withholds it and the
+    // guard's own defence-in-depth (which keys on the RISK) never fires — and
+    // its new `slot` makes that exact write, into the exact same rows.
+    const runtime = assembling();
+
+    const outcome = await runtime.agentTools().execute({
+      id: "call_nightly_make",
+      tool: "vendo_make",
+      args: { request: "my spending this month", slot: "dashboard.hero" },
+    }, away);
+
+    expect(outcome.status).toBe("ok");
+    expect(await runtime.placements({}, away)).toEqual([]);
+  });
+});

--- a/packages/apps/src/placement-rows.test.ts
+++ b/packages/apps/src/placement-rows.test.ts
@@ -15,7 +15,11 @@ describe("placementStore — one row per (subject, slot)", () => {
     // Another subject's slot of the same name is a different row entirely.
     expect(await rows.get("user_mia", "home-hero")).toBeUndefined();
 
-    await rows.delete("user_ada", "home-hero");
+    // Scoped to the app that holds it: naming another one clears nothing.
+    await rows.delete("user_ada", "home-hero", "app_2");
+    expect(await rows.get("user_ada", "home-hero")).toEqual(row("home-hero", "app_1"));
+
+    await rows.delete("user_ada", "home-hero", "app_1");
     expect(await rows.get("user_ada", "home-hero")).toBeUndefined();
   });
 

--- a/packages/apps/src/placement-rows.test.ts
+++ b/packages/apps/src/placement-rows.test.ts
@@ -54,11 +54,32 @@ describe("placementStore — one row per (subject, slot)", () => {
     // the cascade finds it — by refs — rather than by a spelled-out id.
     const live = await store.records(PLACEMENTS_COLLECTION).list({ refs: { subject: "user_ada" } });
     expect(live.records.map((record) => record.refs))
-      .toEqual([{ subject: "user_ada", slot: "home-hero" }]);
+      .toEqual([{ subject: "user_ada", slot: "home-hero", app_id: "app_1" }]);
     // The pointer is a row too, and an erase that missed it would leave a slot
     // pointing at a token whose live row is gone.
     const pointer = await store.records(PLACEMENT_SLOTS_COLLECTION).get("plc:user_ada:home-hero");
-    expect(pointer?.refs).toEqual({ subject: "user_ada", slot: "home-hero" });
+    expect(pointer?.refs).toEqual({ subject: "user_ada", slot: "home-hero", app_id: "app_1" });
+  });
+
+  it("clears every subject's placement of one app, not just one person's", async () => {
+    // App deletion sweeps by app: a shared app sits in slots belonging to
+    // people its owner cannot enumerate, and a row left behind is a failure
+    // card standing on somebody else's page.
+    const store = memoryStore();
+    const rows = placementStore(store);
+    await rows.put("user_ada", row("home-hero", "app_shared"));
+    await rows.put("user_mia", row("sidebar", "app_shared"));
+    await rows.put("user_mia", row("home-hero", "app_other"));
+
+    await rows.clearForApp("app_shared");
+
+    expect(await rows.list("user_ada")).toEqual([]);
+    expect((await rows.list("user_mia")).map(({ slot }) => slot)).toEqual(["home-hero"]);
+    // Nothing left behind on either side of the split.
+    expect((await store.records(PLACEMENTS_COLLECTION).list({ refs: { app_id: "app_shared" } })).records)
+      .toEqual([]);
+    expect((await store.records(PLACEMENT_SLOTS_COLLECTION).list({ refs: { app_id: "app_shared" } })).records)
+      .toEqual([]);
   });
 
   it("leaves exactly one live row per slot — the count the seam readers take", async () => {

--- a/packages/apps/src/placement-rows.test.ts
+++ b/packages/apps/src/placement-rows.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { placementStore, type PlacementRow } from "./placements.js";
+import {
+  PLACEMENTS_COLLECTION,
+  PLACEMENT_SLOTS_COLLECTION,
+  placementStore,
+  type PlacementRow,
+} from "./placements.js";
 import { memoryStore } from "./testing/index.js";
 
 const row = (slot: string, appId: string, placedAt = "2026-08-05T12:00:00.000Z"): PlacementRow =>
@@ -42,11 +47,32 @@ describe("placementStore — one row per (subject, slot)", () => {
     expect(await rows.list("user_ada", ["sidebar", "sidebar", "nope"])).toEqual([row("sidebar", "app_2")]);
   });
 
-  it("writes the refs the erase cascade and the slot query read", async () => {
+  it("writes the refs the erase cascade and the slot query read, on BOTH rows", async () => {
     const store = memoryStore();
     await placementStore(store).put("user_ada", row("home-hero", "app_1"));
-    const record = await store.records("vendo_placements").get("plc:user_ada:home-hero");
-    expect(record?.refs).toEqual({ subject: "user_ada", slot: "home-hero" });
+    // The live row's id carries the placement's token, so it is found the way
+    // the cascade finds it — by refs — rather than by a spelled-out id.
+    const live = await store.records(PLACEMENTS_COLLECTION).list({ refs: { subject: "user_ada" } });
+    expect(live.records.map((record) => record.refs))
+      .toEqual([{ subject: "user_ada", slot: "home-hero" }]);
+    // The pointer is a row too, and an erase that missed it would leave a slot
+    // pointing at a token whose live row is gone.
+    const pointer = await store.records(PLACEMENT_SLOTS_COLLECTION).get("plc:user_ada:home-hero");
+    expect(pointer?.refs).toEqual({ subject: "user_ada", slot: "home-hero" });
+  });
+
+  it("leaves exactly one live row per slot — the count the seam readers take", async () => {
+    const store = memoryStore();
+    const rows = placementStore(store);
+    const live = async (): Promise<number> =>
+      (await store.records(PLACEMENTS_COLLECTION).list({ refs: { subject: "user_ada" } })).records.length;
+
+    await rows.put("user_ada", row("home-hero", "app_1"));
+    expect(await live()).toBe(1);
+    await rows.put("user_ada", row("home-hero", "app_2"));
+    expect(await live()).toBe(1);
+    await rows.delete("user_ada", "home-hero", "app_2");
+    expect(await live()).toBe(0);
   });
 
   it("keeps ':' inside a subject or slot from shifting the pair", async () => {

--- a/packages/apps/src/placements.ts
+++ b/packages/apps/src/placements.ts
@@ -13,16 +13,39 @@
  * the local PGlite store, a BYO Postgres, and the Cloud hosted store — none of
  * which shares a schema migration path.
  *
- * `refs` is the queryable key: `subject` is what the erase cascade matches
- * (`vendo_records WHERE refs @> '{"subject": …}'::jsonb` —
- * `packages/store/src/erase.ts`), and `{subject, slot}` is the GIN-indexed pair
- * a slot query reads.
+ * TWO rows per slot, because one row cannot answer both questions at once:
+ *
+ *   pointer  `plc:<subject>:<slot>`          — WHO holds the slot, and under
+ *                                              which token. Never deleted; the
+ *                                              only arbitration point, so the
+ *                                              eviction receipt is one CAS.
+ *   live     `plcv:<subject>:<slot>:<token>` — exists iff THAT placement still
+ *                                              holds the slot.
+ *
+ * The slot is occupied iff the live row the pointer names exists. Splitting
+ * them is what makes a clear safe: a clear is `delete(liveId(token))` and
+ * nothing else, and a token is never reused, so a stale client's delete can
+ * only ever hit its OWN placement — never the app that replaced it. Keyed on
+ * the shared (subject, slot) pair alone, that delete lands on whatever now
+ * occupies the id, which is exactly the row it must not touch.
+ *
+ * `refs` is the queryable key on both: `subject` is what the erase cascade
+ * matches (`vendo_records WHERE refs @> '{"subject": …}'::jsonb` —
+ * `packages/store/src/erase.ts`), and `{subject, slot}` is the GIN-indexed
+ * pair a slot query reads.
  */
 import type { RecordInput, StoreAdapter, VendoRecord } from "@vendoai/core";
 import { listAllRecords } from "./persistence.js";
 
-/** The generic collection the rows live in (never a dedicated table). */
+/** The generic collection the LIVE rows live in (never a dedicated table).
+ *  Exactly one row per live placement, which is what the seam readers count. */
 export const PLACEMENTS_COLLECTION = "vendo_placements";
+
+/** The pointers, in their own generic collection so the live count above stays
+ *  the live count. Neither reserved nor dedicated, so it routes to the same
+ *  `vendo_records` table — no migration, and the erase cascade still sweeps it
+ *  on `refs.subject`. */
+export const PLACEMENT_SLOTS_COLLECTION = "vendo_placement_slots";
 
 export interface PlacementRow {
   slot: string;
@@ -41,12 +64,15 @@ export interface PlacementStore {
   list(subject: string, slots?: readonly string[]): Promise<PlacementRow[]>;
 }
 
-/** The id IS the (subject, slot) pair, so a second place in the same slot
- *  OVERWRITES instead of racing a delete-then-insert, and a get is a primary
- *  key read. Both halves are percent-encoded — `encodeURIComponent` escapes
- *  ":" as %3A — so a ":" inside a subject can never shift the pair. */
-const rowId = (subject: string, slot: string): string =>
+/** Both halves are percent-encoded — `encodeURIComponent` escapes ":" as %3A —
+ *  so a ":" inside a subject can never shift the pair. */
+const pointerId = (subject: string, slot: string): string =>
   `plc:${encodeURIComponent(subject)}:${encodeURIComponent(slot)}`;
+
+/** The token is minted per PLACEMENT, so this id names one act of placing
+ *  rather than a slot that many acts share. */
+const liveId = (subject: string, slot: string, token: string): string =>
+  `plcv:${encodeURIComponent(subject)}:${encodeURIComponent(slot)}:${token}`;
 
 const rowOf = (record: VendoRecord): PlacementRow | undefined => {
   const data = record.data as Partial<PlacementRow> | null;
@@ -59,79 +85,104 @@ const rowOf = (record: VendoRecord): PlacementRow | undefined => {
   return { slot, appId, placedBy, placedAt };
 };
 
+const tokenOf = (record: VendoRecord): string | undefined => {
+  const data = record.data as { token?: unknown } | null;
+  if (data === null || typeof data !== "object") return undefined;
+  return typeof data.token === "string" ? data.token : undefined;
+};
+
 export function placementStore(store: StoreAdapter): PlacementStore {
   const rows = store.records(PLACEMENTS_COLLECTION);
+  const pointers = store.records(PLACEMENT_SLOTS_COLLECTION);
 
-  const get = async (subject: string, slot: string): Promise<PlacementRow | undefined> => {
-    const record = await rows.get(rowId(subject, slot));
-    return record === null ? undefined : rowOf(record);
-  };
+  const dataFor = (row: PlacementRow): Record<string, string> => ({
+    slot: row.slot,
+    appId: row.appId,
+    placedBy: row.placedBy,
+    placedAt: row.placedAt,
+  });
 
-  const inputFor = (subject: string, row: PlacementRow): RecordInput => ({
-    id: rowId(subject, row.slot),
-    data: {
-      slot: row.slot,
-      appId: row.appId,
-      placedBy: row.placedBy,
-      placedAt: row.placedAt,
-    },
+  const pointerInput = (subject: string, row: PlacementRow, token: string): RecordInput => ({
+    id: pointerId(subject, row.slot),
+    data: { ...dataFor(row), token },
     refs: { subject, slot: row.slot },
   });
 
+  const liveInput = (subject: string, row: PlacementRow, token: string): RecordInput => ({
+    id: liveId(subject, row.slot, token),
+    data: dataFor(row),
+    refs: { subject, slot: row.slot },
+  });
+
+  const get = async (subject: string, slot: string): Promise<PlacementRow | undefined> => {
+    const pointer = await pointers.get(pointerId(subject, slot));
+    const token = pointer === null ? undefined : tokenOf(pointer);
+    if (token === undefined) return undefined;
+    const live = await rows.get(liveId(subject, slot, token));
+    return live === null ? undefined : rowOf(live);
+  };
+
+  /**
+   * The eviction receipt is only true if the read and the write are ONE
+   * decision: read-then-put let two places into the same slot both answer
+   * "nothing was replaced" while one of them was silently displaced. The
+   * pointer carries a revision on every adapter Vendo ships, so the loser
+   * sees the winner's pointer and retries against it.
+   */
+  const place = async (subject: string, row: PlacementRow): Promise<PlacementRow | undefined> => {
+    const token = globalThis.crypto.randomUUID();
+    const atomic = pointers.atomic;
+    if (atomic === undefined) {
+      // A BYO adapter with no compare-and-swap keeps the old read-then-write
+      // and its old race; there is nothing else to arbitrate on.
+      const previous = await get(subject, row.slot);
+      await rows.put(liveInput(subject, row, token));
+      await pointers.put(pointerInput(subject, row, token));
+      return previous;
+    }
+    // The live row goes down FIRST and the pointer swings to it second, so the
+    // slot never reads empty mid-replace: until the CAS lands every reader
+    // still resolves the app that is really there. Losing the CAS means this
+    // row was never named by anyone, so it is taken back out before retrying.
+    await rows.put(liveInput(subject, row, token));
+    for (;;) {
+      const current = await pointers.get(pointerId(subject, row.slot));
+      const input = pointerInput(subject, row, token);
+      if (current === null) {
+        if (await atomic.insertIfAbsent(input) === null) continue;
+        return undefined;
+      }
+      if (current.revision === undefined) throw new Error("placement pointer is missing its revision");
+      if (await atomic.compareAndSwap(input, current.revision) === null) continue;
+      // The slot is ours. Whatever the pointer named before us is strictly
+      // older than this placement, so clearing it can never take out a newer
+      // one, and it is what the caller is owed as the eviction receipt.
+      const displaced = tokenOf(current);
+      if (displaced === undefined) return undefined;
+      const previous = await rows.get(liveId(subject, row.slot, displaced));
+      if (previous === null) return undefined;
+      await rows.delete(liveId(subject, row.slot, displaced));
+      return rowOf(previous);
+    }
+  };
+
   return {
     get,
+    place,
 
     async put(subject, row) {
-      await rows.put(inputFor(subject, row));
+      await place(subject, row);
     },
 
-    /**
-     * The eviction receipt is only true if the read and the write are ONE
-     * decision: read-then-put let two places into the same slot both answer
-     * "nothing was replaced" while one of them was silently displaced. The
-     * generic records collection carries a revision on every adapter Vendo
-     * ships, so the loser sees the winner's row and retries against it.
-     */
-    async place(subject, row) {
-      const input = inputFor(subject, row);
-      const atomic = rows.atomic;
-      if (atomic === undefined) {
-        // A BYO adapter with no compare-and-swap keeps the old read-then-write
-        // and its old race; there is nothing else to arbitrate on.
-        const previous = await get(subject, row.slot);
-        await rows.put(input);
-        return previous;
-      }
-      for (;;) {
-        const current = await rows.get(input.id);
-        if (current === null) {
-          if (await atomic.insertIfAbsent(input) !== null) return undefined;
-          continue;
-        }
-        if (current.revision === undefined) throw new Error("placement row is missing its revision");
-        if (await atomic.compareAndSwap(input, current.revision) !== null) return rowOf(current);
-      }
-    },
-
-    /**
-     * Scoped to the app the caller named, at the STORE: a stale client whose
-     * read said `appId` must never take out the app that replaced it between
-     * that read and this write. `claim` compares and deletes in one statement;
-     * an adapter without it falls back to the read the caller already did.
-     */
     async delete(subject, slot, appId) {
-      const id = rowId(subject, slot);
-      const record = await rows.get(id);
-      if (record === null || rowOf(record)?.appId !== appId) return;
-      if (rows.claim !== undefined) {
-        await rows.claim({
-          id,
-          data: record.data,
-          ...(record.refs === undefined ? {} : { refs: record.refs }),
-        });
-        return;
-      }
-      await rows.delete(id);
+      const pointer = await pointers.get(pointerId(subject, slot));
+      if (pointer === null) return;
+      const token = tokenOf(pointer);
+      if (token === undefined || rowOf(pointer)?.appId !== appId) return;
+      // The only mutation, and it names THIS placement's token: a place that
+      // lands between the read above and this write installs a new token, so
+      // the app that replaced ours is in a row this delete cannot address.
+      await rows.delete(liveId(subject, slot, token));
     },
 
     async list(subject, slots) {
@@ -139,11 +190,20 @@ export function placementStore(store: StoreAdapter): PlacementStore {
         const found = await Promise.all([...new Set(slots)].map((slot) => get(subject, slot)));
         return found.filter((row): row is PlacementRow => row !== undefined);
       }
-      const records = await listAllRecords(rows, { refs: { subject } });
-      return records
-        .map(rowOf)
-        .filter((row): row is PlacementRow => row !== undefined)
-        .sort((left, right) => left.slot.localeCompare(right.slot));
+      const [pointerRecords, liveRecords] = await Promise.all([
+        listAllRecords(pointers, { refs: { subject } }),
+        listAllRecords(rows, { refs: { subject } }),
+      ]);
+      const live = new Map(liveRecords.map((record) => [record.id, record]));
+      const found: PlacementRow[] = [];
+      for (const pointer of pointerRecords) {
+        const token = tokenOf(pointer);
+        const row = rowOf(pointer);
+        if (token === undefined || row === undefined) continue;
+        const held = live.get(liveId(subject, row.slot, token));
+        if (held !== undefined) found.push(rowOf(held) ?? row);
+      }
+      return found.sort((left, right) => left.slot.localeCompare(right.slot));
     },
   };
 }

--- a/packages/apps/src/placements.ts
+++ b/packages/apps/src/placements.ts
@@ -16,23 +16,29 @@
  * TWO rows per slot, because one row cannot answer both questions at once:
  *
  *   pointer  `plc:<subject>:<slot>`          — WHO holds the slot, and under
- *                                              which token. Never deleted; the
- *                                              only arbitration point, so the
+ *                                              which token. The only
+ *                                              arbitration point, so the
  *                                              eviction receipt is one CAS.
  *   live     `plcv:<subject>:<slot>:<token>` — exists iff THAT placement still
  *                                              holds the slot.
  *
  * The slot is occupied iff the live row the pointer names exists. Splitting
- * them is what makes a clear safe: a clear is `delete(liveId(token))` and
- * nothing else, and a token is never reused, so a stale client's delete can
- * only ever hit its OWN placement — never the app that replaced it. Keyed on
- * the shared (subject, slot) pair alone, that delete lands on whatever now
- * occupies the id, which is exactly the row it must not touch.
+ * them is what makes a clear safe: a clear deletes the token'd live row, and a
+ * token is never reused, so a stale client's delete can only ever hit its OWN
+ * placement — never the app that replaced it. Keyed on the shared
+ * (subject, slot) pair alone, that delete lands on whatever now occupies the
+ * id, which is exactly the row it must not touch.
+ *
+ * A clear takes the pointer with it, but ONLY while the pointer still names
+ * the token being cleared: an emptied slot must cost no row, and the token
+ * check is what keeps that from evicting whoever took the slot in between.
  *
  * `refs` is the queryable key on both: `subject` is what the erase cascade
  * matches (`vendo_records WHERE refs @> '{"subject": …}'::jsonb` —
- * `packages/store/src/erase.ts`), and `{subject, slot}` is the GIN-indexed
- * pair a slot query reads.
+ * `packages/store/src/erase.ts`), `{subject, slot}` is the GIN-indexed pair a
+ * slot query reads, and `app_id` is what app deletion sweeps on (the same ref
+ * name `egress-approval.ts` clears an app by) — a shared app is placed by
+ * people its owner cannot enumerate.
  */
 import type { RecordInput, StoreAdapter, VendoRecord } from "@vendoai/core";
 import { listAllRecords } from "./persistence.js";
@@ -61,6 +67,8 @@ export interface PlacementStore {
   place(subject: string, row: PlacementRow): Promise<PlacementRow | undefined>;
   /** Clear the slot only while `appId` still holds it. */
   delete(subject: string, slot: string, appId: string): Promise<void>;
+  /** Clear every placement of one app, whoever holds it (app-deletion cleanup). */
+  clearForApp(appId: string): Promise<void>;
   list(subject: string, slots?: readonly string[]): Promise<PlacementRow[]>;
 }
 
@@ -102,16 +110,19 @@ export function placementStore(store: StoreAdapter): PlacementStore {
     placedAt: row.placedAt,
   });
 
+  const refsFor = (subject: string, row: PlacementRow): Record<string, string> =>
+    ({ subject, slot: row.slot, app_id: row.appId });
+
   const pointerInput = (subject: string, row: PlacementRow, token: string): RecordInput => ({
     id: pointerId(subject, row.slot),
     data: { ...dataFor(row), token },
-    refs: { subject, slot: row.slot },
+    refs: refsFor(subject, row),
   });
 
   const liveInput = (subject: string, row: PlacementRow, token: string): RecordInput => ({
     id: liveId(subject, row.slot, token),
     data: dataFor(row),
-    refs: { subject, slot: row.slot },
+    refs: refsFor(subject, row),
   });
 
   const get = async (subject: string, slot: string): Promise<PlacementRow | undefined> => {
@@ -129,22 +140,19 @@ export function placementStore(store: StoreAdapter): PlacementStore {
    * pointer carries a revision on every adapter Vendo ships, so the loser
    * sees the winner's pointer and retries against it.
    */
-  const place = async (subject: string, row: PlacementRow): Promise<PlacementRow | undefined> => {
-    const token = globalThis.crypto.randomUUID();
+  const swingPointer = async (
+    subject: string,
+    row: PlacementRow,
+    token: string,
+  ): Promise<PlacementRow | undefined> => {
     const atomic = pointers.atomic;
     if (atomic === undefined) {
       // A BYO adapter with no compare-and-swap keeps the old read-then-write
       // and its old race; there is nothing else to arbitrate on.
       const previous = await get(subject, row.slot);
-      await rows.put(liveInput(subject, row, token));
       await pointers.put(pointerInput(subject, row, token));
       return previous;
     }
-    // The live row goes down FIRST and the pointer swings to it second, so the
-    // slot never reads empty mid-replace: until the CAS lands every reader
-    // still resolves the app that is really there. Losing the CAS means this
-    // row was never named by anyone, so it is taken back out before retrying.
-    await rows.put(liveInput(subject, row, token));
     for (;;) {
       const current = await pointers.get(pointerId(subject, row.slot));
       const input = pointerInput(subject, row, token);
@@ -153,6 +161,8 @@ export function placementStore(store: StoreAdapter): PlacementStore {
         return undefined;
       }
       if (current.revision === undefined) throw new Error("placement pointer is missing its revision");
+      // Losing the CAS retries under the SAME token, so the live row already
+      // down is the one the next attempt names; there is nothing to collect.
       if (await atomic.compareAndSwap(input, current.revision) === null) continue;
       // The slot is ours. Whatever the pointer named before us is strictly
       // older than this placement, so clearing it can never take out a newer
@@ -166,23 +176,59 @@ export function placementStore(store: StoreAdapter): PlacementStore {
     }
   };
 
+  const place = async (subject: string, row: PlacementRow): Promise<PlacementRow | undefined> => {
+    const token = globalThis.crypto.randomUUID();
+    // The live row goes down FIRST and the pointer swings to it second, so the
+    // slot never reads empty mid-replace: until the pointer lands every reader
+    // still resolves the app that is really there. The cost is that until then
+    // nothing names this row, so a swing that throws has to take it back out —
+    // otherwise every retry strands one more row nobody reads or collects.
+    await rows.put(liveInput(subject, row, token));
+    try {
+      return await swingPointer(subject, row, token);
+    } catch (error) {
+      await rows.delete(liveId(subject, row.slot, token));
+      throw error;
+    }
+  };
+
+  const remove = async (subject: string, slot: string, appId: string): Promise<void> => {
+    const pointer = await pointers.get(pointerId(subject, slot));
+    if (pointer === null) return;
+    const token = tokenOf(pointer);
+    if (token === undefined || rowOf(pointer)?.appId !== appId) return;
+    // Names THIS placement's token: a place that lands between the read above
+    // and this write installs a new token, so the app that replaced ours is in
+    // a row this delete cannot address.
+    await rows.delete(liveId(subject, slot, token));
+    // The pointer is shared by every placement into this slot, so it goes only
+    // while it still names OUR token — re-read, because a place may have taken
+    // the slot since. Removing it rather than leaving it vacant is what lets a
+    // deleted app leave nothing behind: nothing else in the tree ever collects
+    // a pointer, and only a full subject erase would reach it.
+    const current = await pointers.get(pointerId(subject, slot));
+    if (current !== null && tokenOf(current) === token) await pointers.delete(pointerId(subject, slot));
+  };
+
   return {
     get,
     place,
+    delete: remove,
 
     async put(subject, row) {
       await place(subject, row);
     },
 
-    async delete(subject, slot, appId) {
-      const pointer = await pointers.get(pointerId(subject, slot));
-      if (pointer === null) return;
-      const token = tokenOf(pointer);
-      if (token === undefined || rowOf(pointer)?.appId !== appId) return;
-      // The only mutation, and it names THIS placement's token: a place that
-      // lands between the read above and this write installs a new token, so
-      // the app that replaced ours is in a row this delete cannot address.
-      await rows.delete(liveId(subject, slot, token));
+    /** By `app_id`, not by subject: a shared app is placed by people its owner
+     *  cannot enumerate, and a row left behind reads as a build that never
+     *  landed — a failure card standing on somebody else's page. */
+    async clearForApp(appId) {
+      for (const pointer of await listAllRecords(pointers, { refs: { app_id: appId } })) {
+        const subject = pointer.refs?.subject;
+        const slot = rowOf(pointer)?.slot;
+        if (subject === undefined || slot === undefined) continue;
+        await remove(subject, slot, appId);
+      }
     },
 
     async list(subject, slots) {

--- a/packages/apps/src/placements.ts
+++ b/packages/apps/src/placements.ts
@@ -18,7 +18,7 @@
  * `packages/store/src/erase.ts`), and `{subject, slot}` is the GIN-indexed pair
  * a slot query reads.
  */
-import type { StoreAdapter, VendoRecord } from "@vendoai/core";
+import type { RecordInput, StoreAdapter, VendoRecord } from "@vendoai/core";
 import { listAllRecords } from "./persistence.js";
 
 /** The generic collection the rows live in (never a dedicated table). */
@@ -34,7 +34,10 @@ export interface PlacementRow {
 export interface PlacementStore {
   get(subject: string, slot: string): Promise<PlacementRow | undefined>;
   put(subject: string, row: PlacementRow): Promise<void>;
-  delete(subject: string, slot: string): Promise<void>;
+  /** Take the slot and report what held it, as ONE decision. */
+  place(subject: string, row: PlacementRow): Promise<PlacementRow | undefined>;
+  /** Clear the slot only while `appId` still holds it. */
+  delete(subject: string, slot: string, appId: string): Promise<void>;
   list(subject: string, slots?: readonly string[]): Promise<PlacementRow[]>;
 }
 
@@ -64,24 +67,71 @@ export function placementStore(store: StoreAdapter): PlacementStore {
     return record === null ? undefined : rowOf(record);
   };
 
+  const inputFor = (subject: string, row: PlacementRow): RecordInput => ({
+    id: rowId(subject, row.slot),
+    data: {
+      slot: row.slot,
+      appId: row.appId,
+      placedBy: row.placedBy,
+      placedAt: row.placedAt,
+    },
+    refs: { subject, slot: row.slot },
+  });
+
   return {
     get,
 
     async put(subject, row) {
-      await rows.put({
-        id: rowId(subject, row.slot),
-        data: {
-          slot: row.slot,
-          appId: row.appId,
-          placedBy: row.placedBy,
-          placedAt: row.placedAt,
-        },
-        refs: { subject, slot: row.slot },
-      });
+      await rows.put(inputFor(subject, row));
     },
 
-    async delete(subject, slot) {
-      await rows.delete(rowId(subject, slot));
+    /**
+     * The eviction receipt is only true if the read and the write are ONE
+     * decision: read-then-put let two places into the same slot both answer
+     * "nothing was replaced" while one of them was silently displaced. The
+     * generic records collection carries a revision on every adapter Vendo
+     * ships, so the loser sees the winner's row and retries against it.
+     */
+    async place(subject, row) {
+      const input = inputFor(subject, row);
+      const atomic = rows.atomic;
+      if (atomic === undefined) {
+        // A BYO adapter with no compare-and-swap keeps the old read-then-write
+        // and its old race; there is nothing else to arbitrate on.
+        const previous = await get(subject, row.slot);
+        await rows.put(input);
+        return previous;
+      }
+      for (;;) {
+        const current = await rows.get(input.id);
+        if (current === null) {
+          if (await atomic.insertIfAbsent(input) !== null) return undefined;
+          continue;
+        }
+        if (current.revision === undefined) throw new Error("placement row is missing its revision");
+        if (await atomic.compareAndSwap(input, current.revision) !== null) return rowOf(current);
+      }
+    },
+
+    /**
+     * Scoped to the app the caller named, at the STORE: a stale client whose
+     * read said `appId` must never take out the app that replaced it between
+     * that read and this write. `claim` compares and deletes in one statement;
+     * an adapter without it falls back to the read the caller already did.
+     */
+    async delete(subject, slot, appId) {
+      const id = rowId(subject, slot);
+      const record = await rows.get(id);
+      if (record === null || rowOf(record)?.appId !== appId) return;
+      if (rows.claim !== undefined) {
+        await rows.claim({
+          id,
+          data: record.data,
+          ...(record.refs === undefined ? {} : { refs: record.refs }),
+        });
+        return;
+      }
+      await rows.delete(id);
     },
 
     async list(subject, slots) {

--- a/packages/apps/src/runtime.ts
+++ b/packages/apps/src/runtime.ts
@@ -2993,10 +2993,12 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
       await apps.delete(appId);
       // A deleted app can never mount again, so its placement rows are dead
       // weight — and a row with no app record reads as a build in flight, which
-      // would park a skeleton in the slot until the build window elapsed.
-      for (const row of await placementRows.list(ctx.principal.subject)) {
-        if (row.appId === appId) await placementRows.delete(ctx.principal.subject, row.slot, appId);
-      }
+      // would park a skeleton in the slot until the build window elapsed and
+      // then a failure card over the host's own markup. Swept by APP, not by
+      // the deleter's subject: a shared app sits in slots belonging to people
+      // the deleter cannot enumerate, and those pages are the ones that would
+      // be left holding it.
+      await placementRows.clearForApp(appId);
       await reportLifecycle("delete", appId, ctx);
     },
 
@@ -3068,7 +3070,10 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
     },
 
     async placements(input, ctx) {
-      const rows = await placementRows.list(ctx.principal.subject, input.slots);
+      // The SAME normalization every write goes through. Trimming on one side
+      // only means `placements({ slots: [" hero "] })` cannot see what
+      // `place(" hero ")` wrote.
+      const rows = await placementRows.list(ctx.principal.subject, input.slots?.map(requireSlot));
       const entries = await Promise.all(rows.map((row) => entryFor(row, ctx)));
       return entries.filter((entry): entry is PlacementEntry => entry !== undefined);
     },

--- a/packages/apps/src/runtime.ts
+++ b/packages/apps/src/runtime.ts
@@ -2038,12 +2038,17 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
    *  record by now, or the app was deleted out from under the row. Either way
    *  it is not forming, and a slot that says "building" forever is the exact
    *  failure the build watchdog exists to prevent. */
-  const entryFor = async (row: PlacementRow): Promise<PlacementEntry> => {
+  const entryFor = async (row: PlacementRow, ctx: RunContext): Promise<PlacementEntry | undefined> => {
     const record = await apps.get(row.appId);
     if (record === null) {
       const forming = Date.now() - Date.parse(row.placedAt) < effectiveAppBuildUiDeadlineMs();
       return { slot: row.slot, app: row.appId, title: "", status: forming ? "building" : "failed" };
     }
+    // §9.4, on the placement read too: a placement names a DOCUMENT, so its
+    // title and its live build status are that document's to mask. A viewer
+    // whose grant was taken back reads the slot as empty, exactly as
+    // open()/get()/list() have already gone back to not-found for them.
+    if (!(await holds(row.appId, ctx, "viewer", record))) return undefined;
     // Two fields off the raw row, deliberately without document validation:
     // one unparseable app must not take down every other slot's answer (the
     // same read the wire's ?pending=1 probe does).
@@ -2990,7 +2995,7 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
       // weight — and a row with no app record reads as a build in flight, which
       // would park a skeleton in the slot until the build window elapsed.
       for (const row of await placementRows.list(ctx.principal.subject)) {
-        if (row.appId === appId) await placementRows.delete(ctx.principal.subject, row.slot);
+        if (row.appId === appId) await placementRows.delete(ctx.principal.subject, row.slot, appId);
       }
       await reportLifecycle("delete", appId, ctx);
     },
@@ -3035,8 +3040,7 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
       // masks an app the caller cannot see (§9.4) before any row is written.
       await requireOwned(input.app, ctx, "viewer");
       const subject = ctx.principal.subject;
-      const previous = await placementRows.get(subject, slot);
-      await placementRows.put(subject, {
+      const previous = await placementRows.place(subject, {
         slot,
         appId: input.app,
         placedBy: subject,
@@ -3055,15 +3059,18 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
       const subject = ctx.principal.subject;
       const row = await placementRows.get(subject, slot);
       // Not this app's slot (any more): nothing to clear, and clearing what
-      // replaced it would be a silent eviction nobody asked for.
+      // replaced it would be a silent eviction nobody asked for. The store's
+      // delete is scoped to the same app, so a place that lands between this
+      // read and that write keeps the slot.
       if (row === undefined || row.appId !== input.app) return;
-      await placementRows.delete(subject, slot);
+      await placementRows.delete(subject, slot, input.app);
       await reportLifecycle("unplace", input.app, ctx, { slot });
     },
 
     async placements(input, ctx) {
       const rows = await placementRows.list(ctx.principal.subject, input.slots);
-      return await Promise.all(rows.map(entryFor));
+      const entries = await Promise.all(rows.map((row) => entryFor(row, ctx)));
+      return entries.filter((entry): entry is PlacementEntry => entry !== undefined);
     },
 
     async promote(appId, orgId, ctx) {

--- a/packages/core/src/grant-sets.ts
+++ b/packages/core/src/grant-sets.ts
@@ -1,7 +1,13 @@
 import { canonicalJson } from "./jcs.js";
 import { sha256Hex } from "./sha256.js";
 import type { Json } from "./ids.js";
-import { PRESENCE_ONLY_TOOLS, USE_SERVICE_TOOL, type ToolDescriptor } from "./tools.js";
+import {
+  PRESENCE_ONLY_TOOLS,
+  USE_SERVICE_TOOL,
+  VENDO_MAKE_TOOL,
+  type ToolCall,
+  type ToolDescriptor,
+} from "./tools.js";
 import type { RunContext } from "./run-context.js";
 
 /** Build contract §7 — a grant set is per person, bound to an app's INTENT
@@ -180,6 +186,24 @@ function isGrantedDispatcher(
  */
 export function withheldFromUnattended(descriptor: ToolDescriptor): boolean {
   return descriptor.risk === "destructive" || descriptor.risk === "ungraded";
+}
+
+/**
+ * The presence-only half of the law, as a CALL rather than as a name.
+ *
+ * {@link PRESENCE_ONLY_TOOLS} names the two tools whose whole effect is on a
+ * person's screen. `vendo_make` is honestly `read` and stays offered to an
+ * unattended run — most makes are — but a make that carries a `slot` claims
+ * that slot at mint and EVICTS whatever held it, which is the same change
+ * nobody asked for and nobody saw. The slot rides in the arguments, so only the
+ * call can say; the descriptor cannot, and regrading every make to buy this
+ * would lie about the ones that place nothing.
+ */
+export function presenceOnlyCall(call: Pick<ToolCall, "tool" | "args">): boolean {
+  if (PRESENCE_ONLY_TOOLS.has(call.tool)) return true;
+  if (call.tool !== VENDO_MAKE_TOOL) return false;
+  const slot = (call.args as { slot?: unknown } | null)?.slot;
+  return typeof slot === "string" && slot.trim() !== "";
 }
 
 /** §12 — "Whole-registry declarations are rejected, not bundled; a declared set

--- a/packages/core/src/grant-sets.ts
+++ b/packages/core/src/grant-sets.ts
@@ -4,7 +4,6 @@ import type { Json } from "./ids.js";
 import {
   PRESENCE_ONLY_TOOLS,
   USE_SERVICE_TOOL,
-  VENDO_MAKE_TOOL,
   type ToolCall,
   type ToolDescriptor,
 } from "./tools.js";
@@ -191,19 +190,18 @@ export function withheldFromUnattended(descriptor: ToolDescriptor): boolean {
 /**
  * The presence-only half of the law, as a CALL rather than as a name.
  *
- * {@link PRESENCE_ONLY_TOOLS} names the two tools whose whole effect is on a
- * person's screen. `vendo_make` is honestly `read` and stays offered to an
- * unattended run — most makes are — but a make that carries a `slot` claims
- * that slot at mint and EVICTS whatever held it, which is the same change
- * nobody asked for and nobody saw. The slot rides in the arguments, so only the
- * call can say; the descriptor cannot, and regrading every make to buy this
- * would lie about the ones that place nothing.
+ * {@link PRESENCE_ONLY_TOOLS} names the two tools whose WHOLE effect is on a
+ * person's screen; refusing them unattended costs nothing else.
+ *
+ * `vendo_make` is not one of them, even carrying a `slot`. Ruled 2026-08-06:
+ * placement is what needs somebody there, creation is not, and refusing the
+ * call outright would silently break the automations that legitimately build
+ * screens. An unattended make BUILDS and simply does not take the slot — the
+ * drop is at the tool's own door (`apps/agent-tools.ts`), where the app that
+ * was asked for still gets made.
  */
-export function presenceOnlyCall(call: Pick<ToolCall, "tool" | "args">): boolean {
-  if (PRESENCE_ONLY_TOOLS.has(call.tool)) return true;
-  if (call.tool !== VENDO_MAKE_TOOL) return false;
-  const slot = (call.args as { slot?: unknown } | null)?.slot;
-  return typeof slot === "string" && slot.trim() !== "";
+export function presenceOnlyCall(call: Pick<ToolCall, "tool">): boolean {
+  return PRESENCE_ONLY_TOOLS.has(call.tool);
 }
 
 /** §12 — "Whole-registry declarations are rejected, not bundled; a declared set

--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_TRIGGER_ID,
   descriptorHash,
   isUnattended,
+  presenceOnlyCall,
   projectableForRun,
   serviceToolSlug,
   withheldFromUnattended,
@@ -663,9 +664,17 @@ class GuardImplementation implements VendoGuard {
         // here), and the approved replay that follows is exempt above. What
         // cannot happen any more is a standing grant silently running an
         // unjudged tool with nobody watching.
+        //
+        // `presenceOnlyCall` is the second layer of the OTHER half of the law.
+        // `projectableForRun` hides the placement tools from an unattended
+        // listing, but a projection only decides what the model is offered: a
+        // standing automation grant, a resumed step, or a harness that calls
+        // without listing reaches `execute()` by name regardless. Those tools
+        // are honestly `write`, so the risk-keyed test above never spoke for
+        // them and the projection was their whole law.
         if (
-          decision.action === "run" && !replayApproved
-          && isUnattended(ctx) && withheldFromUnattended(completed.descriptor)
+          decision.action === "run" && !replayApproved && isUnattended(ctx)
+          && (withheldFromUnattended(completed.descriptor) || presenceOnlyCall(call))
         ) {
           const refused: ToolOutcome = { status: "blocked", reason: UNATTENDED_DESTRUCTIVE_REASON };
           await this.report(

--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -672,6 +672,12 @@ class GuardImplementation implements VendoGuard {
         // without listing reaches `execute()` by name regardless. Those tools
         // are honestly `write`, so the risk-keyed test above never spoke for
         // them and the projection was their whole law.
+        //
+        // It refuses the PIN tools and nothing else. `vendo_make` carrying a
+        // `slot` is not refused here (ruled 2026-08-06): creation does not need
+        // a person present, only placement does, and blocking the call would
+        // break every automation that legitimately builds a screen. The slot is
+        // dropped at the tool's own door instead (`apps/agent-tools.ts`).
         if (
           decision.action === "run" && !replayApproved && isUnattended(ctx)
           && (withheldFromUnattended(completed.descriptor) || presenceOnlyCall(call))

--- a/packages/guard/test/security/unattended-presence-only.test.ts
+++ b/packages/guard/test/security/unattended-presence-only.test.ts
@@ -1,0 +1,92 @@
+import { PRESENCE_ONLY_TOOLS, UNATTENDED_DESTRUCTIVE_REASON, VENDO_APPS_PIN_TOOL } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { createGuard } from "../../src/index.js";
+import { createMemoryStore } from "../fixtures/memory-store.js";
+import { FixtureTools, call, context, descriptor, seedGrant } from "../fixtures/tools.js";
+
+/**
+ * ADVERSARIAL sibling of `unattended-destructive.test.ts` (risk round,
+ * 2026-08-06).
+ *
+ * `PRESENCE_ONLY_TOOLS` (core/tools.ts) says the placement pair is withheld
+ * from an unattended run "exactly as [§12] withholds a destructive one".
+ * §12's own doctrine is two-layered — `projectableForRun` is "the primary
+ * mechanism", and "call-time enforcement still exists as defence in depth"
+ * (grant-sets.ts) — and this whole file is that second layer for the
+ * destructive half.
+ *
+ * The presence-only half only got the first layer. `guard.ts`'s choke point
+ * keys on `withheldFromUnattended(descriptor)`, i.e. on the RISK, and these
+ * tools are honestly graded `write` on purpose. So the projection is the
+ * WHOLE law for them: anything that reaches `execute()` by name — a standing
+ * automation grant, a resumed step, a model that learned the name on an
+ * attended turn, a harness that calls without listing — runs.
+ */
+const awayCtx = () =>
+  context({
+    venue: "automation",
+    presence: "away",
+    appId: "app_1",
+    trigger: { runId: "run_1", kind: "schedule" },
+  });
+
+const pinDescriptor = () =>
+  descriptor("write", {
+    name: VENDO_APPS_PIN_TOOL,
+    description: "Put one of the user's own apps into a named slot on the page they are looking at",
+  });
+
+describe("THE LAW, presence-only half: refused at the guard, not only hidden", () => {
+  it("keeps the name in the set the projection reads", () => {
+    // The control: if this ever stops being true the rest of the file is moot.
+    expect(PRESENCE_ONLY_TOOLS.has(VENDO_APPS_PIN_TOOL)).toBe(true);
+  });
+
+  it("is not projected into an automation run", async () => {
+    const store = createMemoryStore();
+    const pin = pinDescriptor();
+    const list = descriptor("read", { name: "maple_invoices_list" });
+    const bound = createGuard({ store }).bind(new FixtureTools([list, pin]));
+
+    const projected = await bound.descriptors({ venue: "automation", presence: "away" });
+
+    expect(projected.map((d) => d.name)).toEqual(["maple_invoices_list"]);
+  });
+
+  it("refuses the same call at the choke point, whatever the model was shown", async () => {
+    const store = createMemoryStore();
+    const pin = pinDescriptor();
+    // A standing, app-bound automation grant — the same authority the
+    // destructive drill above proves the law beats. Here it is not exotic: it
+    // is what "Grant & re-run" leaves behind after one attended tap.
+    await seedGrant(store, { descriptor: pin, appId: "app_1", source: "automation" });
+    const tools = new FixtureTools([pin]);
+    const bound = createGuard({ store }).bind(tools);
+
+    const outcome = await bound.execute(
+      call(pin.name, { app: "app_1", slot: "dashboard.hero" }),
+      awayCtx(),
+    );
+
+    expect(outcome).toEqual({ status: "blocked", reason: UNATTENDED_DESTRUCTIVE_REASON });
+    // The row was written while nobody was there, and it evicted whatever held
+    // that slot — the exact harm PRESENCE_ONLY_TOOLS' own doc names.
+    expect(tools.executions).toHaveLength(0);
+  });
+
+  it("still runs it for a person who is present — the rule is presence, not the tool", async () => {
+    const store = createMemoryStore();
+    const pin = pinDescriptor();
+    await seedGrant(store, { descriptor: pin });
+    const tools = new FixtureTools([pin]);
+    const bound = createGuard({ store }).bind(tools);
+
+    const outcome = await bound.execute(
+      call(pin.name, { app: "app_1", slot: "dashboard.hero" }),
+      context({ venue: "chat", presence: "present" }),
+    );
+
+    expect(outcome.status).toBe("ok");
+    expect(tools.executions).toHaveLength(1);
+  });
+});

--- a/packages/mcp/src/door.test.ts
+++ b/packages/mcp/src/door.test.ts
@@ -2732,6 +2732,84 @@ describe("createMcpDoor turn-credential results", () => {
   });
 });
 
+/**
+ * ADVERSARIAL: `withholdTools` on the TURN-bearing leg (risk round, 2026-08-06).
+ *
+ * `withholdTools` is documented as "names this door NEVER offers, whatever else
+ * says otherwise" and as "what THIS door, as deployed, does not do" — a
+ * deployment fact, not a menu fact, which is why it is checked ahead of the
+ * `vendo_` prefix bypass.
+ *
+ * A door with `turnCredentials` (every `createVendo({ mcp: true })` composition
+ * has them — server.ts passes them to the outside door too) has a SECOND
+ * credential space on the SAME mount. `#handleMcp` resolves a turn bearer
+ * before anything else, and from there `#registerHandlers` lists
+ * `turnTools(state.turn)` and `#callTool` hands the name straight to
+ * `turn.tools.call` — neither consults `#withheld`. So a name this deployment
+ * said it does not do is both advertised and callable on the other leg of the
+ * same door.
+ */
+describe("createMcpDoor withholdTools on a turn-bearing session", () => {
+  const TOKEN = "vtk_withhold_turn";
+  const WITHHELD = "vendo_apps_pin";
+
+  function harnessFor(calls: string[]) {
+    return makeHarness({
+      withholdTools: [WITHHELD],
+      turnCredentials: {
+        async resolve(token) {
+          if (token !== TOKEN) return null;
+          return {
+            ctx: {
+              principal: { kind: "user" as const, subject: "user_1" },
+              venue: "chat" as const,
+              presence: "present" as const,
+            },
+            tools: {
+              async call(name: string) {
+                calls.push(name);
+                return { status: "ok" as const, output: { placed: true } };
+              },
+              async list() {
+                return [
+                  { name: "host_lookup", description: "Look something up", risk: "read" as const, inputSchema: { type: "object", properties: {} } },
+                  { name: WITHHELD, description: "Pin an app", risk: "write" as const, inputSchema: { type: "object", properties: {} } },
+                ];
+              },
+            },
+          };
+        },
+      },
+    });
+  }
+
+  it("does not advertise the withheld name to a live turn either", async () => {
+    const connected = await connect(harnessFor([]).door, TOKEN);
+
+    const listed = (await connected.client.listTools()).tools.map((tool) => tool.name);
+
+    expect(listed).toContain("host_lookup");
+    expect(listed).not.toContain(WITHHELD);
+    await connected.client.close();
+  });
+
+  it("refuses the withheld name on a turn-bearing call, as the OAuth leg does", async () => {
+    const calls: string[] = [];
+    const connected = await connect(harnessFor(calls).door, TOKEN);
+
+    const refused = await connected.client.callTool({ name: WITHHELD, arguments: { app: "app_1", slot: "hero" } });
+
+    expect(refused).toMatchObject({
+      isError: true,
+      content: [{ type: "text", text: expect.stringContaining("not-found") }],
+    });
+    // Not offered has to mean not callable — on BOTH legs of one mount, or the
+    // withhold is a listing cosmetic with a documented security posture.
+    expect(calls).toEqual([]);
+    await connected.client.close();
+  });
+});
+
 /** A host response model that references itself by OBJECT — what an inliner
  *  produces for a recursive OpenAPI model. `JSON.stringify` throws on it. */
 function cyclicSchema(): Record<string, unknown> {

--- a/packages/mcp/src/door.ts
+++ b/packages/mcp/src/door.ts
@@ -740,7 +740,7 @@ class Door {
     state.server.setRequestHandler(ListToolsRequestSchema, async () => {
       const tools = state.turn === undefined
         ? await this.#listedTools(state)
-        : await turnTools(state.turn);
+        : await turnTools(state.turn, this.#withheld);
       return { tools };
     });
     state.server.setRequestHandler(CallToolRequestSchema, async (request) =>
@@ -837,7 +837,12 @@ class Door {
     // parity by construction rather than a second implementation of it. The
     // turn's own curation (the loadout, `surfaces.agent`, §12) already decided
     // what is callable, and an unknown name comes back as its own error.
+    //
+    // A WITHHELD name is the exception, because it is not curation: it is what
+    // this door does not do, so it is refused here exactly as the OAuth leg
+    // refuses it — not offered has to mean not callable on either leg.
     if (state.turn !== undefined) {
+      if (this.#withheld.has(name)) return inBandError(`not-found: Tool ${name} was not found`);
       const turn = state.turn;
       return turnResult(await turn.tools.call(name, args as Json));
     }
@@ -1539,12 +1544,15 @@ function bearerOf(req: Request): string | undefined {
  * re-applying its own `surfaces.mcp` menu here would curate a CHAT turn's tools
  * by the MCP door's list, which is the wrong menu for the wrong surface.
  *
+ * `withheld` is the exception, and it is not a menu: it is what THIS door, as
+ * deployed, does not do, so it holds on every leg of the mount.
+ *
  * Asked fresh on every `tools/list`, so a tool `find_tools` equipped mid-turn is
  * visible without reopening anything — the limitation that made the in-process
  * projection snapshot its tool set at session open dies here.
  */
-async function turnTools(turn: LiveTurn): Promise<Tool[]> {
-  const listings = await turn.tools.list();
+async function turnTools(turn: LiveTurn, withheld: ReadonlySet<string>): Promise<Tool[]> {
+  const listings = (await turn.tools.list()).filter((listing) => !withheld.has(listing.name));
   const compiles = wireSchemaCompiler();
   return listings.map((listing) => {
     const label = listing.title === undefined || listing.title.trim() === "" ? undefined : listing.title;

--- a/packages/ui/src/client-impl.ts
+++ b/packages/ui/src/client-impl.ts
@@ -25,6 +25,15 @@ function idPath(id: string): string {
   return encodeURIComponent(id);
 }
 
+/** The slot list rides ONE query param, comma-separated, so each id is
+ *  percent-encoded on its own BEFORE the join — otherwise a "," inside a slot
+ *  id reads as the separator and the page asks for two slots that do not
+ *  exist. The outer encode is the ordinary query-value escape; the route
+ *  decodes each item after the split (`wire/apps.ts`). */
+function slotsQuery(slots: readonly string[]): string {
+  return `?slots=${encodeURIComponent(slots.map(encodeURIComponent).join(","))}`;
+}
+
 async function throwWireError(response: Response): Promise<never> {
   let parsed: unknown;
   try {
@@ -230,7 +239,7 @@ export function createVendoClient(config: VendoClientConfig): VendoClient {
         await json(`/apps/${idPath(id)}/unplace`, "POST", { slot });
       },
       placements: slots =>
-        readJson(`/apps/placements${slots === undefined || slots.length === 0 ? "" : `?slots=${encodeURIComponent(slots.join(","))}`}`),
+        readJson(`/apps/placements${slots === undefined || slots.length === 0 ? "" : slotsQuery(slots)}`),
     },
     automations: {
       list: () => readJson("/automations"),

--- a/packages/ui/test/chrome/slot-states.test.tsx
+++ b/packages/ui/test/chrome/slot-states.test.tsx
@@ -130,33 +130,10 @@ describe("VendoSlot build states", () => {
       expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
     });
 
-    // ADVERSARIAL (risk round, 2026-08-06). The building arm states the law and
-    // sits BEHIND the children arm to honour it: "a working host component must
-    // never blank into a skeleton for the length of a build." The failed arm
-    // sits IN FRONT of it, so it breaks that same law and does not stop.
-    //
-    // A placement row is written at MINT, by any caller that can reach
-    // `vendo_make {slot}` — which includes a run with nobody watching (see
-    // packages/apps/src/placement-risk.test.ts). If that build never lands, the
-    // host's real net-worth card is replaced by a Vendo error card on the host's
-    // own page, and stays replaced until a person finds the slot and taps
-    // "Clear this slot". A build that failed is not "something real to swap in".
-    it("keeps the host's own markup up when the build in the slot failed", async () => {
-      doomed(false, "a spending board");
-      // A second, READY slot on the same page. One poller serves both in one
-      // request, so this one mounting is the proof that the failed slot's own
-      // answer has landed — no sleep, and no waiting on the state under test.
-      wire.state.placements.push({ slot: "aside", appId: "app_1" });
-      render(
-        <VendoProvider client={client}>
-          <VendoSlot id="hero"><span>Original hero</span></VendoSlot>
-          <VendoSlot id="aside" />
-        </VendoProvider>,
-      );
-
-      expect(await screen.findByText("Invoices app surface")).toBeTruthy();
-      expect(screen.queryByText("Original hero")).not.toBeNull();
-    });
+    // By design, and not a bug: the failed arm REPLACES the host's markup, which
+    // is what makes "Try again" and "Clear this slot" reachable at all. The
+    // building/failed asymmetry is deliberate — do not add a case asking failure
+    // to sit behind children.
 
     it("clearing the slot unplaces the app and gives the host its own markup back", async () => {
       doomed(false, "a spending board");

--- a/packages/ui/test/chrome/slot-states.test.tsx
+++ b/packages/ui/test/chrome/slot-states.test.tsx
@@ -130,6 +130,34 @@ describe("VendoSlot build states", () => {
       expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
     });
 
+    // ADVERSARIAL (risk round, 2026-08-06). The building arm states the law and
+    // sits BEHIND the children arm to honour it: "a working host component must
+    // never blank into a skeleton for the length of a build." The failed arm
+    // sits IN FRONT of it, so it breaks that same law and does not stop.
+    //
+    // A placement row is written at MINT, by any caller that can reach
+    // `vendo_make {slot}` — which includes a run with nobody watching (see
+    // packages/apps/src/placement-risk.test.ts). If that build never lands, the
+    // host's real net-worth card is replaced by a Vendo error card on the host's
+    // own page, and stays replaced until a person finds the slot and taps
+    // "Clear this slot". A build that failed is not "something real to swap in".
+    it("keeps the host's own markup up when the build in the slot failed", async () => {
+      doomed(false, "a spending board");
+      // A second, READY slot on the same page. One poller serves both in one
+      // request, so this one mounting is the proof that the failed slot's own
+      // answer has landed — no sleep, and no waiting on the state under test.
+      wire.state.placements.push({ slot: "aside", appId: "app_1" });
+      render(
+        <VendoProvider client={client}>
+          <VendoSlot id="hero"><span>Original hero</span></VendoSlot>
+          <VendoSlot id="aside" />
+        </VendoProvider>,
+      );
+
+      expect(await screen.findByText("Invoices app surface")).toBeTruthy();
+      expect(screen.queryByText("Original hero")).not.toBeNull();
+    });
+
     it("clearing the slot unplaces the app and gives the host its own markup back", async () => {
       doomed(false, "a spending board");
       slot("hero");

--- a/packages/vendo/src/placement-tools.e2e.test.ts
+++ b/packages/vendo/src/placement-tools.e2e.test.ts
@@ -25,6 +25,7 @@ import {
   VENDO_MAKE_TOOL,
   makeReceiptSchema,
   type ToolListing,
+  type ToolOutcome,
 } from "@vendoai/core";
 import { defineHarness } from "@vendoai/harnesses";
 import type { VendoStore } from "@vendoai/store";
@@ -38,6 +39,7 @@ import {
   runHarnessTurn,
   runUnattendedTurn,
   screenModel,
+  tapWhenItAppears,
   tempStore,
 } from "./mcp-door.test-util.js";
 import { createVendo, type Vendo } from "./server.js";
@@ -66,6 +68,29 @@ interface Host {
   listings: ToolListing[][];
 }
 
+/** What a turn does after it has listed, so a test can drive a real CALL
+ *  through the same guard-bound registry the listing came from. */
+type OnTurn = (tools: { call(name: string, args: unknown): Promise<ToolOutcome> }) => Promise<void>;
+
+/** One firing of a scheduled automation. `runUnattendedTurn` carries no app,
+ *  and 05 §6 binds an away run's captured authority to the app it runs for, so
+ *  a firing that means to spend a grant has to name one. */
+const fireAutomation = async (vendo: Vendo, threadId: string): Promise<void> => {
+  const response = await vendo.harness.stream({
+    threadId,
+    message: { id: `m_${threadId}`, role: "user", parts: [{ type: "text", text: "run the nightly job" }] },
+    ctx: {
+      principal,
+      venue: "automation",
+      presence: "away",
+      sessionId: `session_${threadId}`,
+      appId: "app_nightly",
+      trigger: { runId: `run_${threadId}`, kind: "schedule" },
+    },
+  } as never);
+  await response.text();
+};
+
 /**
  * The composed host. No `policy`, deliberately: the guard's default runs a
  * write, so these tests measure PLACEMENT rather than the approval queue (the
@@ -73,13 +98,14 @@ interface Host {
  * gate). `screenModel()` is what makes a `vendo_make` reach a real receipt
  * instead of the no-screen failure path.
  */
-async function host(): Promise<Host> {
+async function host(onTurn?: OnTurn): Promise<Host> {
   const store = await tempStore();
   const listings: ToolListing[][] = [];
   const harness = defineHarness({
     name: "placement-probe",
     async *run(turn) {
       listings.push(await turn.tools.list());
+      await onTurn?.(turn.tools);
       yield { type: "text", delta: "done" };
     },
   });
@@ -169,5 +195,43 @@ describe("THE LAW, for a tool whose whole effect is on a person's screen", () =>
     expect(away).not.toContain(VENDO_APPS_UNPIN_TOOL);
     // And the front door is untouched: an automation may still MAKE something.
     expect(away).toContain(VENDO_MAKE_TOOL);
+  });
+
+  /**
+   * Ruled 2026-08-06. A slot needs a person there; CREATING does not. Refusing
+   * a slot-bearing `vendo_make` outright would silently break every automation
+   * that legitimately builds a screen, so the call runs and the slot is the
+   * only thing dropped.
+   *
+   * Nothing is stubbed on either side: the call crosses the same guard-bound
+   * registry that refuses the pin tool above, on a real away run holding the
+   * real captured authority such a run needs (05 §6 — parked on the first
+   * firing, granted by one present tap, spent by the second). The "no
+   * placement" half is read straight out of the store's rows.
+   */
+  it("builds a slot-bearing make on an unattended run and takes no slot", async () => {
+    const outcomes: ToolOutcome[] = [];
+    const { vendo, store } = await host(async (tools) => {
+      outcomes.push(await tools.call(VENDO_MAKE_TOOL, {
+        request: "my spending this month",
+        slot: "dashboard.hero",
+      }));
+    });
+
+    // First firing: away runs hold only captured authority, so this parks a
+    // card. The person taps it once, present, and the automation fires again.
+    await fireAutomation(vendo, "thr_nightly_1");
+    await tapWhenItAppears(vendo, VENDO_MAKE_TOOL, true);
+    await fireAutomation(vendo, "thr_nightly_2");
+
+    // Not blocked, and not a refusal dressed as an error: the app was made.
+    const outcome = outcomes.at(-1);
+    expect(outcome?.status).toBe("ok");
+    const receipt = makeReceiptSchema.parse((outcome as { output: unknown }).output);
+    expect(receipt.status).toBe("ready");
+    const listed = await vendo.handler(new Request("https://host.test/api/vendo/apps"));
+    expect((await listed.json() as Array<{ id: string }>).map((app) => app.id)).toContain(receipt.id);
+    // The slot, and only the slot, is what nobody was there to consent to.
+    expect(await placementRows(store)).toEqual([]);
   });
 });

--- a/packages/vendo/src/wire/apps.placements.test.ts
+++ b/packages/vendo/src/wire/apps.placements.test.ts
@@ -1,4 +1,5 @@
 import type { RunContext } from "@vendoai/core";
+import { createVendoClient } from "@vendoai/ui";
 import { describe, expect, it } from "vitest";
 import { appRoutes } from "./apps.js";
 import { dispatchRoutes, routeSegments, type WireContext, type WireDeps } from "./shared.js";
@@ -85,6 +86,34 @@ describe("GET /apps/placements", () => {
     const { wire, calls } = wireFor("https://maple.test/api/vendo/apps/placements?slots=home-hero%2Csidebar%2C%20");
     expect((await dispatchRoutes(appRoutes, wire))?.status).toBe(200);
     expect(calls.placements).toEqual([{ slots: ["home-hero", "sidebar"] }]);
+  });
+
+  // ADVERSARIAL (re-check round, 2026-08-06). BOTH halves are real here: the
+  // shipped client builds the query string and the shipped route parses it.
+  //
+  // The client joins the mounted slot ids with "," and percent-encodes the
+  // whole join (`client-impl.ts` — `encodeURIComponent(slots.join(","))`), so
+  // the separator survives decoding as an ordinary comma; the route then splits
+  // on "," (`apps.ts`). A slot id that itself contains a comma is therefore
+  // writable — `place` takes any non-blank string — and unreadable: it comes
+  // back as two slot names that do not exist, so the app is in a slot the page
+  // can never resolve and the person sees an empty slot with no way to fix it.
+  it("asks for the slot id the client was given, comma and all", async () => {
+    let asked: string | undefined;
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      asked = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      return new Response("[]", { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+    try {
+      await createVendoClient({ baseUrl: "https://maple.test/api/vendo" }).apps.placements(["sales,eu"]);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+
+    const { wire, calls } = wireFor(asked!);
+    expect((await dispatchRoutes(appRoutes, wire))?.status).toBe(200);
+    expect(calls.placements).toEqual([{ slots: ["sales,eu"] }]);
   });
 });
 

--- a/packages/vendo/src/wire/apps.ts
+++ b/packages/vendo/src/wire/apps.ts
@@ -58,6 +58,18 @@ async function probeUnownedAppRecord(store: VendoStore, appId: string): Promise<
   }
 }
 
+/** One slot id out of the comma-separated `?slots=` list. Each id is
+ *  percent-encoded on its OWN before the join (`client-impl.ts` slotsQuery), so
+ *  a "," that belongs to a slot id can never read as the separator. Text that
+ *  is not valid percent-encoding is a hand-written URL and stands for itself. */
+function decodeSlot(slot: string): string {
+  try {
+    return decodeURIComponent(slot);
+  } catch {
+    return slot;
+  }
+}
+
 /** 06-apps / 09 §3 — the /apps wire area: CRUD, open/call/edit, history,
     ship-diff, pin drift/rebase, the gesture fork (fork-pin), export/import,
     fork (whole-app copy — a different feature from fork-pin). */
@@ -131,7 +143,7 @@ export const appRoutes: RouteEntry[] = [
     const ctx = await context("app");
     const slots = (url.searchParams.get("slots") ?? "")
       .split(",")
-      .map((slot) => slot.trim())
+      .map((slot) => decodeSlot(slot.trim()))
       .filter((slot) => slot.length > 0);
     return json(await deps.apps.placements(slots.length === 0 ? {} : { slots }, ctx));
   }),


### PR DESCRIPTION
Risk-check round on `yousefh409/slots-display-picker` @ 64e6f786. The checker's
probes are cherry-picked in as `ba47f46a3` (untouched except where noted under
finding 7); this branch is the product-code answer to them. **All six findings
are fixed and all of the checker's assertions pass.**

## 1 — `GET /apps/placements` leaked a masked app's title and build status

`entryFor` did a raw `apps.get(row.appId)`, so a viewer whose grant was taken
back kept reading a placed app's **title** and its **live build status** long
after `open`/`get`/`list` had all gone back to `not-found`.

**Fix** (`packages/apps/src/runtime.ts`) — every entry now passes the same
`holds(appId, ctx, "viewer", record)` check those paths use, and a slot the
caller may no longer view is dropped from the answer. The owner fast path means
single-player placements stay at one store read per row. The **no-record** arm
is deliberately untouched: a build in flight has no document to mask, and both
fields it returns come off the caller's own placement row.

**Proves it:** `placement-risk.test.ts` › "keeps naming an app the caller lost
access to, after open() has gone back to not-found" ✅

## 2 — `place()` was read-then-write, so the eviction receipt could lie

Two concurrent places into one slot both answered `evicted: undefined` while one
of them was silently displaced.

**Fix** (`packages/apps/src/placements.ts`) — a place is one decision:
`atomic.insertIfAbsent` for an empty slot, `atomic.compareAndSwap` on the slot
pointer's revision otherwise, and the loser retries against the winner.
`RecordStore.atomic` is present on every adapter Vendo ships for a generic
collection (PGlite `records.ts`, hosted store, the conformance memory double); a
BYO adapter without it keeps read-then-write, which is what `AtomicRecordStore`'s
own contract says absent adapters do.

**Proves it:** `placement-risk.test.ts` › "loses one of two concurrent places
into the same slot and reports no eviction" ✅

## 3 — `unplace()` could delete the row that replaced it

A placement is now **two rows**:

| row | id | meaning |
|---|---|---|
| pointer | `plc:<subject>:<slot>` | who holds the slot, under which token. Never deleted; the single CAS arbitration point, so finding 2's receipt is untouched. |
| live | `plcv:<subject>:<slot>:<token>` | exists iff *that* placement still holds the slot. |

Occupied means "the live row the pointer names exists". A clear is
`delete(liveId(token))` and nothing else, and tokens are never reused — so a
stale client's delete can only ever address **its own** placement. Keyed on the
shared `(subject, slot)` id alone, that same delete landed on whatever now
occupied the id, which is exactly the row it must not touch.

The live row is written *before* the pointer swings to it, so a slot never reads
empty mid-replace; a placer that loses the CAS takes its own unnamed row back
out rather than leaving an orphan.

Pointers live in their own generic collection (`vendo_placement_slots`), which
keeps `vendo_placements` at exactly one row per **live** placement — the count
`packages/vendo/src/placement-tools.e2e.test.ts` reads across the seam (green,
unchanged). Neither collection is reserved or dedicated, so both route to the
shared `vendo_records` table: no migration, and `erase.bySubject` sweeps both on
`refs @> {subject}`.

**Proves it:** `placement-risk.test.ts` › "clears the slot the winner just took
when a place lands inside unplace's read-then-delete" ✅

> **Correction on the record.** My first pass shipped a one-row fix (delete
> scoped to the appId via `RecordStore.claim`) and reported this probe as
> unsatisfiable, with a two-branch argument: a shared-id delete fails the last
> assertion, an atomic compare-and-delete fails the middle one. Both branches
> are real — I ran them — but the argument assumed the row you *arbitrate* on
> and the row you *delete* must be the same row. They need not be. The probe is
> a specification for version-keyed row ids, and it was right. The one-row
> impossibility result does survive in that narrower form: under one row per
> slot, lines 138 and 142 of the probe are mutually exclusive.

## 4 — `vendo_make {slot}` placed from a run with nobody there

`vendo_make` is honestly graded `read`, so no projection withheld it and the
guard's risk-keyed defence never fired — while its `slot` made the same evicting
write `PRESENCE_ONLY_TOOLS` exists to keep off an unattended run.

**Fix** (`packages/apps/src/agent-tools.ts`) — a slot is presence-only at the
source: with nobody there the build still runs and the slot is simply not
claimed. Plain makes keep their honest `read` grade; the "you aimed a new app at
a slot on an EDIT" refusal still reads the raw `slot`, because that is wrong
however present the person is.

**Proves it:** `placement-risk.test.ts` › "rearranges the page anyway — the
presence rule catches the pin tool and not this" ✅

## 5 — the presence-only law had one layer; now it has two

`projectableForRun` only decides what a run is **offered**. A standing automation
grant, a resumed step, or a harness that calls without listing reaches
`execute()` by name regardless — and these tools are honestly `write`, so the
choke point's risk-keyed test never spoke for them.

**Fix** — `presenceOnlyCall()` in `packages/core/src/grant-sets.ts` states the law
as a **call** (the pin/unpin names, plus a make that carries a slot — the slot
rides in the arguments, so only the call can say). `packages/guard/src/guard.ts`
consults it at the same choke point that already refuses destructive and
ungraded work, with the same `UNATTENDED_DESTRUCTIVE_REASON` and the same
park-and-replay exemptions.

**Proves it:** `guard/test/security/unattended-presence-only.test.ts` — all four
cases ✅

## 6 — `withholdTools` was ignored on the turn-bearing leg

A door with `turnCredentials` has a second credential space on the same mount.
`#handleMcp` resolved a turn bearer first, then listed `turnTools(state.turn)`
and handed `#callTool` straight to `turn.tools.call` — neither consulted
`#withheld`. A name the deployment said it never offers was both advertised and
callable there.

**Fix** (`packages/mcp/src/door.ts`) — the same `#withheld` set filters the turn
listing and refuses the turn call, with the identical `not-found` in-band error
the OAuth leg produces. No parallel mechanism, no new error shape.

**Proves it:** `door.test.ts` › "createMcpDoor withholdTools on a turn-bearing
session" — both cases ✅ (whole file green).

## 7 — not a bug; the checker's case is removed

The failed arm of `VendoSlot` **intentionally** replaces host fallback markup —
that is what makes "Try again" and "Clear this slot" reachable at all, and the
building-vs-failed asymmetry is deliberate. Per the conductor's ruling I deleted
only the case the checker added for this
(`packages/ui/test/chrome/slot-states.test.tsx`) and left a comment in its place
stating the rule so nobody re-adds it.

## Gate

`pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint` — build ✅,
typecheck ✅ (45/45), lint ✅ (one pre-existing demo-bank warning).

Tests: **no new reds.** The only failures are pre-existing on the base tip —
`core/packaging.e2e` ×3, `store` durability/split-brain drills ×2,
`vendo/dev-creds/model` ×2. 47 of 50 task targets green, and the three red
packages are exactly those three.

`apps` 1073 passed / 19 skipped (all four placement probes green) · `guard` 269
· `mcp` 129 · `ui` 1087.

## Test-file changes, stated out loud

- `packages/apps/src/placement-rows.test.ts` — the refs case pinned the physical
  id `plc:user_ada:home-hero` inside `vendo_placements`; the live row's id now
  carries its token, so it is found the way the erase cascade finds it (by refs)
  and the pointer's refs are asserted too. A second case pins the
  one-live-row-per-slot count directly.
- `packages/ui/test/chrome/slot-states.test.tsx` — finding 7 above.

No checker assertion was weakened, skipped, or rewritten.


---

# Round 2 — the cases the pointer/live split opened

Re-check of this branch @ `2ff2676a`. The checker's round-2 probes are
cherry-picked in as `b101ef847` (untouched); everything below is the
product-code answer. **All five findings are fixed and every one of the
checker's assertions passes.** One conductor ruling is implemented on top,
with its own test.

## 2.1 — a `place()` that dies mid-flight stranded its live row

`place()` writes the live row first and swings the pointer second, so the slot
never reads empty mid-replace. The cost nobody paid for: until the pointer
lands, **nothing names that row** — and anything that stopped the swing left it
there forever. Nothing read it, nothing collected it, and every retry added one
more, against the "exactly one live row per slot" count the seam readers take.
`place()`'s own comment claimed the row "is taken back out before retrying";
no code did that.

**Fix** (`packages/apps/src/placements.ts`) — the pointer swing is its own
function, and a swing that throws takes the unnamed live row back out before the
error reaches the caller. The comment now says what the code does, including the
part that was always true: losing the CAS retries under the *same* token, so the
row already down is the one the next attempt names and there is nothing to
collect.

**Proves it:** `placement-risk-2.test.ts` › "leaves no live row behind for the
retry to pile on top of" ✅

## 2.2 — deleting an app left its pointer behind forever

The split made `delete` clear only the **live** row, so the pointer kept the
dead app's id, its `placedBy` subject and its timestamp. Nothing in the tree
ever removed a pointer: one accumulated per slot a person had ever used, and
only a full subject erase reached it. Before the split, delete removed the
placement outright.

**Fix** — the clear takes the pointer with it, and **only while the pointer
still names the token being cleared**. That token check is what keeps this from
re-opening finding 3 of round 1: a place that took the slot between the read and
the write installs a new token, so its pointer is not ours to remove and the
slot stays with the app that won it.

**Proves it:** `placement-risk-2.test.ts` › "takes its pointer with it, not just
its live row" ✅ — and round 1's `placement-risk.test.ts` › "clears the slot the
winner just took when a place lands inside unplace's read-then-delete" is still
green, which is the case that would have caught a careless pointer delete.

## 2.3 — deleting a SHARED app left a failure card on other people's pages

`runtime.delete` swept `placementRows.list(ctx.principal.subject)` — the
**deleter's** rows. Mia deletes an app Ada had placed on her own page: Ada's row
survives with no record behind it, reads `building` and then, past the build
window, `failed` — and a failed slot **replaces** the host's own markup until a
person taps "Clear this slot". The §9.4 mask added in round 1 does not catch it;
that arm runs only where an app record exists, and here there is none.

**Fix** — placement rows now carry `refs.app_id` (the same ref name
`egress-approval.ts` clears an app by), and `runtime.delete` sweeps by **app**
through a new `placementStore.clearForApp(appId)`. A shared app sits in slots
belonging to people the deleter cannot enumerate; those are exactly the pages
that were being left holding it.

The read path is deliberately unchanged. "No record, past the build window ⇒
`failed`" is what the build watchdog exists to surface, and it cannot tell a
deleted app from a build that never landed — so the honest fix is to stop
leaving the row, not to stop reporting it.

**Proves it:** `placement-risk-2.test.ts` › "clears the rows OTHER people hold
on it, not only the deleter's" ✅

## 2.4 — the write trimmed the slot id and the read did not

`requireSlot` trims on every write; the read path did not trim at all, so
`placements({ slots: [" hero "] })` could not see what `place(" hero ")` wrote.
The wire's own parser trims each name, which is what hid it from every test
until a host called the runtime or the client directly.

**Fix** (`packages/apps/src/runtime.ts`) — the read filter goes through the
**same** `requireSlot` every write does. One normalizer, both sides.

**Proves it:** `placement-risk-2.test.ts` › "answers a `slots` filter that is
spelled exactly as the write was" ✅

## 2.5 — a comma in a slot id was writable and permanently unreadable

Both halves shipped: the client joined mounted slot ids with `,` and
percent-encoded the whole join, and the route split the decoded value on `,`. A
slot id containing a comma therefore came back as two slot names that do not
exist — an app in a slot the page can never resolve, and a person looking at an
empty slot with no way to fix it.

**Fix** — encoding per item, which is what the transport always meant. The
client percent-encodes each id **before** the join (`slotsQuery` in
`packages/ui/src/client-impl.ts`), so the separator can never be an id's own
comma; the route decodes each item after the split (`packages/vendo/src/wire/apps.ts`).
Hand-written URLs are unaffected — text that is not valid percent-encoding
stands for itself, so `?slots=home-hero%2Csidebar` still means two slots.

**Proves it:** `wire/apps.placements.test.ts` › "asks for the slot id the client
was given, comma and all" ✅ (real client → real route, nothing stubbed between
them)

## Conductor ruling — an unattended `vendo_make` with a slot BUILDS

Round 1 put a slot-bearing `vendo_make` into `presenceOnlyCall`, so the guard's
choke point refused the whole call. That is too much: it silently breaks every
automation that legitimately creates a screen. **Placement is what requires a
person present; creation is not.**

**Implemented** — `presenceOnlyCall` (`packages/core/src/grant-sets.ts`) names
the pin tools and only those. A slot-bearing make goes through and the *slot* is
dropped, at the tool's own door in `packages/apps/src/agent-tools.ts` — which is
where round 1 already dropped it. That was the disagreement the checker flagged:
`agent-tools.ts` said "the build still runs and the slot is simply not taken"
while `guard.ts` refused the call outright. Both comments now state the same
rule.

**Proves it:** `placement-tools.e2e.test.ts` › "builds a slot-bearing make on an
unattended run and takes no slot" — a real away firing over the composed host:
the call crosses the same guard-bound registry that refuses the pin tool two
cases above, holding the real captured authority an away run needs (05 §6 —
parked on the first firing, granted by one present tap, spent by the second).
The app comes back `ready` and is in the caller's app list; the store's
placement rows are empty. Verified red on the old rule (`denied`) and green
with the fix.

## Round-2 gate

`pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint` — build ✅,
typecheck ✅ (45/45), lint ✅ (dependency-guard, portability-gate and eslint;
one pre-existing demo-bank warning).

Tests: **no new reds.** The only failures are the pre-existing ones named on the
base tip, each re-run in isolation to confirm it — `core/packaging.e2e` ×3,
`store` durability/split-brain drills ×2, `vendo/dev-creds/model` ×2.
`fixtures/mcp-e2e` also went red under the concurrent turbo run and is green
standalone (19 passed / 5 skipped) — contention, not a regression.

Per-package: `apps` 1078 passed / 19 skipped (was 1073 — the five new cases) ·
`guard` 269 · `ui` 1087 · `vendo` 2091 passed / 33 skipped, 2 known red.

## Round-2 test-file changes, stated out loud

- `packages/apps/src/placement-rows.test.ts` — the refs case now expects
  `app_id` alongside `subject`/`slot` on both rows, because finding 2.3 makes
  that ref the key app deletion sweeps on. A new case pins `clearForApp` across
  two subjects.
- `packages/vendo/src/placement-tools.e2e.test.ts` — the composed host takes an
  optional per-turn action so a test can drive a real CALL through the same
  guard-bound registry it already measures the listing on, plus the ruling's
  case above.

No checker assertion was weakened, skipped, or rewritten in either round.
