### PR TITLE
fix(ui): the "Add to…" picker reaches the surface a person is actually on

### DIFF
--- a/.changeset/slot-display-states-and-add-to.md
+++ b/.changeset/slot-display-states-and-add-to.md
@@ -19,10 +19,17 @@ A slot tells the truth about the app placed in it, and any surface can put one t
 - **ready** — unchanged, and now proven in a browser for both surface kinds: a
   tree payload and a served machine url.
 
-`AddToPicker` puts "Add to…" on the app embed's bar, so a BYO chat page can send
-a generated app to the dashboard without a host-built pin control. It awaits
+`AddToPicker` puts "Add to…" on a generated view's bar, so a person can send it
+to any slot the host has mounted instead of the one place a host wired. It awaits
 `client.apps.place` before saying "Added to Hero", then announces the placement
 so a mounted slot fills without waiting out its poll.
+
+It appears in the two places a generated view has a bar: the app embed (for a BYO
+chat page) and the IN-THREAD card, which is the surface a person reaches a view
+from in every host that renders its conversation through `VendoOverlay`. The
+thread card's affordance stays the one-click "Pin to dashboard" while the origin
+knows a single destination — a menu of one is not a choice — and becomes the
+picker the moment it knows more.
 
 - `noteSlot` / `knownSlots` (new, re-exported from `vendoai/react`): the picker's
   destinations. A slot id is the host's markup and no Vendo record carries it, so

--- a/packages/ui/src/chrome/add-to-picker.tsx
+++ b/packages/ui/src/chrome/add-to-picker.tsx
@@ -9,28 +9,35 @@
  * affordance renders nothing at all rather than an empty menu.
  *
  * The same `.fl-barpin` affordance the thread card's pin uses — no new button
- * language on the app-card bar.
+ * language on the app-card bar. The thread card swaps ITS pin for this picker
+ * once the origin knows more than one destination (thread/parts.tsx), which is
+ * what makes the choice reachable from a conversation in a real host and not
+ * only from a BYO page that mounts `VendoAppEmbed` itself.
  */
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useVendoProvider } from "../context.js";
 import { announcePin } from "../pin-events.js";
 import { knownSlots, type SlotNote } from "../slot-notes.js";
 
+/** The slots this origin has seen, plus a re-read. Storage is unreadable during
+ *  render (SSR) and a slot may mount after the reader did, so the list is read
+ *  on mount and again whenever the caller asks. */
+export function useKnownSlots(): [SlotNote[], () => void] {
+  const [slots, setSlots] = useState<SlotNote[]>([]);
+  const reread = useCallback(() => { setSlots(knownSlots()); }, []);
+  useEffect(() => { reread(); }, [reread]);
+  return [slots, reread];
+}
+
 export function AddToPicker({ appId }: { appId: string }) {
   const { client } = useVendoProvider();
-  const [slots, setSlots] = useState<SlotNote[]>([]);
+  const [slots, rereadSlots] = useKnownSlots();
   const [open, setOpen] = useState(false);
   const [placedIn, setPlacedIn] = useState<string>();
   const [failed, setFailed] = useState(false);
 
-  // Storage is unreadable during render (SSR) and a slot may mount after this
-  // embed did, so the list is read on mount and again on every open.
-  useEffect(() => {
-    setSlots(knownSlots());
-  }, []);
-
   const toggle = () => {
-    setSlots(knownSlots());
+    rereadSlots();
     setFailed(false);
     setOpen(current => !current);
   };

--- a/packages/ui/src/chrome/index.ts
+++ b/packages/ui/src/chrome/index.ts
@@ -25,6 +25,9 @@ export { defaultVendoGreeting, hasSeen, markSeen, type VendoDiscoverability, typ
 export { openVendoConversation, type OpenConversationOptions } from "./overlay-registry.js";
 export { Remixable, type RemixableProps } from "./remixable.js";
 export { playPinCeremony, usePinAction, usePinNudge, type PinCeremonyOptions } from "./pin-ceremony.js";
+// The "Add to…" destination picker and the destinations it reads — public
+// because the in-thread card (an eject template) is built out of them.
+export { AddToPicker, useKnownSlots } from "./add-to-picker.js";
 export { VendoTrigger, type VendoTriggerProps } from "./vendo-trigger.js";
 export { VendoPage, type VendoPageProps } from "./vendo-page.js";
 export { VendoPalette, type VendoCommand } from "./vendo-palette.js";

--- a/packages/ui/src/chrome/thread/parts.tsx
+++ b/packages/ui/src/chrome/thread/parts.tsx
@@ -5,6 +5,7 @@ import { useVendoProvider } from "../../context.js";
 import { useSplitView } from "../split-view.js";
 import { useApprovalSheetPresentation } from "../../hooks/use-mobile-takeover.js";
 import { PayloadView } from "../../tree/renderer.js";
+import { AddToPicker, useKnownSlots } from "../add-to-picker.js";
 import { ApprovalCard } from "../approval-card.js";
 import { ApprovalSheet } from "../approval-sheet.js";
 import { AutomationCard } from "../automation-card.js";
@@ -419,6 +420,10 @@ const PREVIEW_MAX_HEIGHT = 300;
 function ThreadAppCard({ appId, payload, restored, buildKey }: { appId: string; payload: UIPayload; restored: boolean; buildKey: string }) {
   const { client, components } = useVendoProvider();
   const pin = usePinAction();
+  // The destinations this origin knows — a mounted VendoSlot is the only thing
+  // that can say a slot exists (slot-notes.ts). More than one, and the bar's
+  // placement affordance is a picker rather than a single fixed pin.
+  const [slots] = useKnownSlots();
   const split = useSplitView();
   const streaming = (payload as { streaming?: boolean }).streaming === true;
   // The nudge belongs to the build that just LANDED (§10.1: the user pins, the
@@ -580,22 +585,31 @@ function ThreadAppCard({ appId, payload, restored, buildKey }: { appId: string; 
             Feature
           </button>
         ) : null}
-        {/* Lane pick C5 (5A+5D) — the pin lives ON the bar (visible only once
-            the view is ready), replacing the old full-width footer row. The
-            renderer lane's data-state/label/hairline markup above is the
-            shared contract and stays untouched. */}
+        {/* Lane pick C5 (5A+5D) — the placement affordance lives ON the bar
+            (visible only once the view is ready), replacing the old full-width
+            footer row. The renderer lane's data-state/label/hairline markup
+            above is the shared contract and stays untouched.
+
+            ONE destination is a verb ("Pin to dashboard") — naming the only
+            place it could go would be a menu of one. Several, and the same
+            affordance becomes the picker: this card is the surface a real user
+            actually reaches a generated view from, so it is where the choice
+            has to live (the embed-only picker was unreachable in every host
+            that renders its conversation through the overlay). */}
         {!streaming && pin ? (
-          <button
-            type="button"
-            className="fl-barpin"
-            {...(nudge === undefined ? {} : { "data-vendo-pin": nudge })}
-            onClick={() => pin({ appId, payload })}
-          >
-            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-              <path d="M12 17v5M9 3h6l-1 7 3 3H7l3-3-1-7Z" />
-            </svg>
-            Pin to dashboard
-          </button>
+          slots.length > 1 ? <AddToPicker appId={appId} /> : (
+            <button
+              type="button"
+              className="fl-barpin"
+              {...(nudge === undefined ? {} : { "data-vendo-pin": nudge })}
+              onClick={() => pin({ appId, payload })}
+            >
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                <path d="M12 17v5M9 3h6l-1 7 3 3H7l3-3-1-7Z" />
+              </svg>
+              Pin to dashboard
+            </button>
+          )
         ) : null}
         <span className="fl-boot-hairline" aria-hidden="true" />
       </div>

--- a/packages/ui/test/chrome/add-to-picker.test.tsx
+++ b/packages/ui/test/chrome/add-to-picker.test.tsx
@@ -9,6 +9,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { VendoAppEmbed, VendoProvider, createVendoClient, noteSlot, type VendoClient } from "../../src/index.js";
 import { VendoSlot } from "../../src/chrome/index.js";
+import { ThreadPart } from "../../src/chrome/thread/parts.js";
 import { createWireServer } from "../wire-server.js";
 
 // The envelope's status is ALWAYS "building" — it never means done (core's
@@ -101,6 +102,92 @@ describe("the Add to… picker", () => {
     const building: VendoAppRef = { kind: "vendo/app-ref@1", appId: "app_never", title: "Weather board", status: "building" };
     render(<VendoProvider client={client}><VendoAppEmbed refValue={building} /></VendoProvider>);
     await screen.findByText(/Building/);
+    expect(screen.queryByRole("button", { name: /Add to/ })).toBeNull();
+  });
+});
+
+/**
+ * THE SEAM, end to end, with nothing stubbed on either side.
+ *
+ * The picker shipped reachable only from `VendoAppEmbed` — a component no host
+ * in this repo mounts — so it passed its own suite while being dead in the
+ * product: every real host renders its conversation through the overlay's
+ * thread, and the thread's card offered one fixed pin. These cases walk the
+ * whole chain the way a person does: REAL `VendoSlot`s note themselves into
+ * slot-notes (the producer), the REAL in-thread card reads them (the consumer),
+ * and the pick goes client → wire → placement row, which the slot on the page
+ * then reads back.
+ *
+ * The host wiring mirrors demo-bank exactly: `pinSlot` is the Home hero, and the
+ * destination proven here is the OTHER one — the pick has to be able to beat the
+ * default, or the picker is decoration.
+ */
+describe("placing a generated view from the conversation the user is actually in", () => {
+  let wire: Awaited<ReturnType<typeof createWireServer>>;
+  let client: VendoClient;
+
+  beforeEach(async () => {
+    window.localStorage.clear();
+    wire = await createWireServer();
+    client = createVendoClient({ baseUrl: wire.url });
+  });
+
+  afterEach(async () => {
+    cleanup();
+    vi.restoreAllMocks();
+    await wire.close();
+  });
+
+  /** The shape the stream emits for a finished build (`data-vendo-view`). */
+  function view(appId: string) {
+    return {
+      type: "data-vendo-view",
+      data: {
+        appId,
+        payload: {
+          formatVersion: "vendo-genui/v2",
+          name: "Spending board",
+          root: "root",
+          nodes: [{ id: "root", component: "Text", props: { text: "Spending board body" } }],
+        },
+      },
+    } as unknown as Parameters<typeof ThreadPart>[0]["part"];
+  }
+
+  /** A host page carrying its own slots, with the conversation open over it —
+   *  demo-bank's shape. Nothing here calls `noteSlot`: the slots do. */
+  function host(appId: string, slots: string[]) {
+    return render(
+      <VendoProvider client={client} pinSlot="home-hero">
+        {slots.map(id => <VendoSlot key={id} id={id} />)}
+        <ThreadPart part={view(appId)} partKey="p0" role="assistant" restored={false} />
+      </VendoProvider>,
+    );
+  }
+
+  it("offers every slot the host has mounted, named the way the page names them", async () => {
+    host("app_1", ["home-hero", "insights-custom-view"]);
+    fireEvent.click(await screen.findByRole("button", { name: /Add to/ }));
+    expect(screen.getByRole("menuitem", { name: "Home hero" })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: "Insights custom view" })).toBeTruthy();
+  });
+
+  it("puts the view in the slot the person picked — not the host's default — and the slot reads it back", async () => {
+    host("app_1", ["home-hero", "insights-custom-view"]);
+    fireEvent.click(await screen.findByRole("button", { name: /Add to/ }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Insights custom view" }));
+
+    // The row on the real wire, under the picked slot and no other.
+    await waitFor(() => expect(wire.state.placements).toEqual([{ slot: "insights-custom-view", appId: "app_1" }]));
+    expect(await screen.findByRole("button", { name: /Added to Insights custom view/ })).toBeTruthy();
+    // And the real slot on the page, reading that row back over the same wire.
+    const landed = await screen.findByText("Invoices app surface");
+    expect(landed.closest("[data-vendo-slot]")?.getAttribute("data-vendo-slot")).toBe("insights-custom-view");
+  });
+
+  it("keeps the one-click pin when the origin knows a single destination — a menu of one is not a choice", async () => {
+    host("app_2", ["home-hero"]);
+    expect(await screen.findByRole("button", { name: "Pin to dashboard" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: /Add to/ })).toBeNull();
   });
 });

--- a/packages/ui/test/chrome/export-surface.test.ts
+++ b/packages/ui/test/chrome/export-surface.test.ts
@@ -60,6 +60,13 @@ const VALUE_EXPORTS = [
   // and the invitation are two halves of one affordance: a host that ejects the
   // template and keeps the pin needs both or its pin goes quiet.
   "usePinNudge",
+  // ⚠️ TEST EDIT — the "Add to…" picker and its destination read, public for the
+  // SAME reason `usePinNudge` is: the thread card now renders the picker in place
+  // of the fixed pin once the origin knows more than one slot, and every import in
+  // `thread/parts.tsx` is public API by construction. An ejected thread that keeps
+  // the placement affordance needs both or it silently loses the multi-slot half.
+  "AddToPicker",
+  "useKnownSlots",
   // Shelf Lane B — the two placeable pieces (ui-usage-dx §2).
   "VendoActivities",
   "VendoTrigger",


### PR DESCRIPTION
## The dead-feature gap

PR3 shipped the "Add to…" destination picker rendering in exactly one place:
inside `VendoAppEmbed`. **No host in this repo mounts that component.** Every
real host renders its conversation through `VendoOverlay`, and the overlay's
in-thread card offered a single fixed destination — the host's `pinSlot`. So in
the actual product there was no way for a person to choose where a generated
view lands. The feature was unreachable.

Its unit tests and its Playwright spec both passed, because both drive the `ui`
package's own harness — and the harness mounts the embed the product never does.
This is the fourth time this repo has shipped a green suite over a dead feature
(see the testing section of `CLAUDE.md`): the producer and the consumer each
tested against a surface the other never uses, so they could never disagree.

## The fix

The thread card's placement affordance becomes the picker once the origin knows
more than one destination, and keeps today's one-click **Pin to dashboard** when
it knows one — naming the only place a view could go would be a menu of one.

Same `.fl-barpin` language, no new component, no new host wiring, no new option.
The whole behavioural change is one render swap in `ThreadAppCard`:

```tsx
{!streaming && pin ? (
  slots.length > 1 ? <AddToPicker appId={appId} /> : (
    <button className="fl-barpin" …>Pin to dashboard</button>
  )
) : null}
```

`useKnownSlots` is extracted from the picker so both readers share one source —
slot-notes is unreadable during SSR render, so it is read after mount and re-read
on every open.

`AddToPicker` and `useKnownSlots` join the pinned chrome export surface for the
same reason `usePinNudge` did: the thread is an eject template, so every import in
`thread/parts.tsx` is public API by construction.

## The seam test that closes it

`packages/ui/test/chrome/add-to-picker.test.tsx` gains a suite that walks the
whole chain with **nothing stubbed on either side**:

- **producer** — real mounted `VendoSlot`s note themselves into slot-notes (no
  `noteSlot()` calls in the test),
- **consumer** — the real in-thread card reads them and renders the picker,
- **write** — the pick goes real client → real wire server → real placement row,
- **read-back** — the real slot on the page mounts the placed app.

It places into the slot that is **not** the provider's `pinSlot`, because a pick
that cannot beat the default proves nothing. The host wiring mirrors demo-bank
exactly (`pinSlot="home-hero"`, plus an `insights-custom-view` slot).

Proven to have teeth: reverting the render swap turns both new cases red
(the third, the single-slot fallback, correctly stays green).

## Real-host proof — Maple (`examples/demo-bank`), real browser

Not the harness. `pnpm build` → `pnpm --filter @vendoai/ui build:jail` →
`pnpm --filter demo-bank dev`, Vendo Cloud model gateway, real Auth.js session.

1. Visited **Insights** — its `insights-custom-view` slot notes itself; Home's
   `home-hero` was already noted. `localStorage["vendo.slots"]` holds both.
2. On Home, opened **Ask Maple** and asked it to build a spending-by-category
   view. Real build, real host tools (`host_getSpendingInsights`).
3. The card's bar offered **Add to…** instead of the fixed pin:

![picker open in Maple's thread](https://raw.githubusercontent.com/runvendo/vendo/d20e97b00f356e1968cba11a07308ebac1b60f18/verification/picker-reachable/picker-open-in-maple-thread.png)

4. Picked **Insights custom view** — the non-default destination. The bar
   confirms only after the write lands:

![added to Insights custom view](https://raw.githubusercontent.com/runvendo/vendo/d20e97b00f356e1968cba11a07308ebac1b60f18/verification/picker-reachable/picker-confirmed-added.png)

5. The wire agrees, one row, on the picked slot and not the default:

```json
[{"slot":"insights-custom-view","app":"app_8ebf8832-…","title":"Spending by Category","status":"ready"}]
```

6. Navigated to `/maple/insights` — the view is live under "Your custom view":

![landed in the Insights slot](https://raw.githubusercontent.com/runvendo/vendo/d20e97b00f356e1968cba11a07308ebac1b60f18/verification/picker-reachable/landed-in-insights-slot-closeup.png)

<details><summary>Full Insights page</summary>

![full page](https://raw.githubusercontent.com/runvendo/vendo/d20e97b00f356e1968cba11a07308ebac1b60f18/verification/picker-reachable/landed-in-insights-slot.png)

</details>

7. **Fallback, same real host:** cleared slot-notes, stayed on Home (one slot
   known), built another view — the bar is back to one-click **Pin to dashboard**,
   no picker:

![single-slot fallback](https://raw.githubusercontent.com/runvendo/vendo/d20e97b00f356e1968cba11a07308ebac1b60f18/verification/picker-reachable/fallback-single-slot-pin.png)

Screenshots live on the `verification/picker-reachable` branch, deliberately out
of this PR's diff.

## Deliberate boundary

The split-view **stage** bar keeps its fixed `Pin to dashboard` in the multi-slot
case. It is a secondary surface reached from the card this PR fixes, and it still
works; widening it is beyond the reported gap.

## Gate

`pnpm build` ✅ · `pnpm test:affected` — `@vendoai/ui` **122/122 green**, only the
seven known pre-existing reds elsewhere (core `packaging.e2e` ×3, store durability
/split-brain drills ×2, vendo `dev-creds/model` ×2) · `pnpm typecheck` ✅ 45/45 ·
`pnpm lint` ✅


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the "Add to…" picker available in the in-thread card so people can choose where a generated view lands from the surface they actually use. Keeps one-click "Pin to dashboard" when only one slot exists, and switches to the picker when multiple slots are known.

- **Bug Fixes**
  - In `ThreadAppCard`, render `AddToPicker` when `useKnownSlots()` reports more than one slot; otherwise show "Pin to dashboard". Same `.fl-barpin` control, no host wiring changes.
  - Extracted and exported `useKnownSlots` with `AddToPicker`; reads `slot-notes` after mount and on open to stay in sync with mounted `VendoSlot`s.
  - Added seam tests that mount real `VendoSlot`s, pick a non-default slot, write via the real wire, and verify the slot reads the placement back; single-slot fallback remains a direct pin.

<sup>Written for commit 7e295ca6b6237c98b495c0001a0107af59e04ec6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

