### PR TITLE
fix(apps): a slot-targeted make claims its slot at mint on the assembly path too

### DIFF
--- a/.changeset/slot-claim-at-mint.md
+++ b/.changeset/slot-claim-at-mint.md
@@ -1,0 +1,19 @@
+---
+"@vendoai/apps": patch
+---
+
+A slot-targeted `vendo_make` claims its slot at MINT on the assembly engine too,
+not only on the escalated builder.
+
+The row used to go down only after assembly RETURNED, so on the engine that
+serves most asks a slot the person was already looking at stayed empty for the
+whole of the make — the skeleton the slot exists to show never appeared — and an
+assembly that failed wrote no row at all, so the slot showed nothing and the
+failure existed only in the conversation.
+
+Both engines are now claimed for from the one place that mints the id: the
+`vendo_make` front door, before it routes. And an ask no engine landed leaves the
+same terminal record a failed build leaves, so the claimed slot turns into the
+honest failure card (dismiss = unplace) the instant assembly gives up, rather
+than holding a skeleton until the build window ages out. That record is a
+tombstone like any other failed build's — it never joins the user's apps.

--- a/packages/apps/src/agent-tools.test.ts
+++ b/packages/apps/src/agent-tools.test.ts
@@ -4,11 +4,12 @@ import {
   VENDO_TOOL_TITLES,
   toolDescriptorSchema,
   type RunContext,
+  type ScreenAssembler,
   type ToolRegistry,
 } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
 import { agentToolDescriptors } from "./agent-tools.js";
-import { createApps, type AppsRuntime } from "./index.js";
+import { createApps, type AppsRuntime, type PlacementEntry } from "./index.js";
 import {
   authoringAssembler,
   basicLanguageModel,
@@ -542,20 +543,26 @@ describe("§3 consumer voice — every apps tool carries a title", () => {
 });
 
 describe("vendo_make — the slot a new app lands in", () => {
-  /** The ASSEMBLY engine — the one that serves most asks. `authoringAssembler`
-   *  compiles with core's own compiler and lands the row through
-   *  `runtime.authored`, which is the shipped write path, not a stub. */
-  const assembling = (): AppsRuntime => {
+  /** The front door with one answer or another behind the seam. `self` is the
+   *  same compose-time knot `packages/vendo` ties: the assembler writes through
+   *  the runtime that composing returns. */
+  const assemblingWith = (screen: (self: () => AppsRuntime) => ScreenAssembler): AppsRuntime => {
     const runtime: AppsRuntime = createApps({
       store: memoryStore(),
       guard: guardFixture(),
       tools: hostTools,
       catalog: [],
       model: scriptedLanguageModel(generated),
-      screen: authoringAssembler(() => runtime, generated),
+      screen: screen(() => runtime),
     });
     return runtime;
   };
+
+  /** The ASSEMBLY engine — the one that serves most asks. `authoringAssembler`
+   *  compiles with core's own compiler and lands the row through
+   *  `runtime.authored`, which is the shipped write path, not a stub. */
+  const assembling = (): AppsRuntime =>
+    assemblingWith((self) => authoringAssembler(self, generated));
 
   /** The BUILDER engine — assembly escalates and this deployment has somewhere
    *  to build. Same front door, same minted id, a different engine behind it,
@@ -601,6 +608,64 @@ describe("vendo_make — the slot a new app lands in", () => {
     expect(await runtime.placements({}, ctx)).toEqual([
       expect.objectContaining({ slot: "dashboard.hero", app: receipt.id, status: "ready" }),
     ]);
+  });
+
+  it("claims the slot at MINT, so the slot shows the build while assembly is still running", async () => {
+    // B1 on the FAST engine. The row used to go down only after assembly
+    // RETURNED, so a slot the person was already looking at stayed empty for the
+    // whole of the make and the skeleton it exists to show never appeared. The
+    // reading is taken from inside the assembler, mid-flight, through the
+    // runtime's own placements path.
+    let inFlight: PlacementEntry[] = [];
+    const runtime = assemblingWith((self) => ({
+      async assemble(request, runCtx) {
+        inFlight = await self().placements({}, runCtx);
+        return authoringAssembler(self, generated).assemble(request, runCtx);
+      },
+    }));
+
+    const outcome = await runtime.agentTools().execute({
+      id: "call_make_slot_inflight",
+      tool: "vendo_make",
+      args: { request: "my spending this month", slot: "dashboard.hero" },
+    }, ctx);
+
+    const receipt = (outcome as { output: { id: string } }).output;
+    expect(inFlight).toEqual([
+      { slot: "dashboard.hero", app: receipt.id, title: "", status: "building" },
+    ]);
+    // The same row, unmoved, is what goes READY when assembly lands.
+    expect(await runtime.placements({}, ctx)).toEqual([
+      expect.objectContaining({ slot: "dashboard.hero", app: receipt.id, status: "ready" }),
+    ]);
+  });
+
+  it("leaves the honest failure IN the slot when assembly fails terminally", async () => {
+    // B1's other half. A make that died in assembly wrote no row at all, so the
+    // slot showed nothing and the failure lived only in the conversation.
+    const runtime = assemblingWith(() => ({
+      async assemble() { return { kind: "unavailable", why: "the screen agent is down" }; },
+    }));
+
+    const outcome = await runtime.agentTools().execute({
+      id: "call_make_slot_failed",
+      tool: "vendo_make",
+      args: { request: "my spending this month", slot: "dashboard.hero" },
+    }, ctx);
+
+    const receipt = (outcome as { output: { id: string; status: string; title: string } }).output;
+    expect(receipt.status).toBe("failed");
+    // FAILED now, read back through the real placements path — not a skeleton
+    // that only ages into a failure once the build window elapses.
+    expect(await runtime.placements({}, ctx)).toEqual([
+      { slot: "dashboard.hero", app: receipt.id, title: receipt.title, status: "failed" },
+    ]);
+    // The terminal record is a tombstone, exactly as a failed build's is: it
+    // answers the slot and never joins the user's apps.
+    expect(await runtime.list(ctx)).toEqual([]);
+    // Dismiss = unplace, and it leaves nothing behind.
+    await runtime.unplace({ app: receipt.id, slot: "dashboard.hero" }, ctx);
+    expect(await runtime.placements({}, ctx)).toEqual([]);
   });
 
   it("lands an ESCALATED build in it too — one front door, two engines, one row", async () => {

--- a/packages/apps/src/agent-tools.ts
+++ b/packages/apps/src/agent-tools.ts
@@ -285,6 +285,14 @@ const optionalLimit = (value: Json | undefined): number | undefined => {
 export interface AgentToolsDataDependencies {
   data: AppDataAccess;
   requireOwned(appId: AppId, ctx: RunContext): Promise<AppDocument>;
+  /** B1 — claim the slot for an id this door just minted, before either engine
+   *  runs. `AppsRuntime.place` cannot: it gates on an app record, and there is
+   *  none yet. Filled by the runtime that constructs this registry. */
+  claimSlot(appId: AppId, slot: string, ctx: RunContext): Promise<void>;
+  /** B1's other end — the terminal record for an id assembly never landed, so a
+   *  claimed slot reads as the honest failure card instead of a skeleton that
+   *  ages out. The same tombstone a failed build leaves. */
+  markUnbuilt(appId: AppId, name: string, reason: string, ctx: RunContext): Promise<void>;
   /** UI-generation blueprint §1 point 2 — the screen agent. Threaded from
    *  `AppsConfig.screen`, which composition fills; see the routing block in the
    *  `vendo_make` handler below. Unfilled, `vendo_make` has nothing to assemble
@@ -468,6 +476,21 @@ export const createAgentTools = (
           // coming back empty, and assembly coming back empty is the ANSWER —
           // there is no second engine behind this seam to rescue it with.
           const appId = `app_${globalThis.crypto.randomUUID()}` as AppId;
+          // B1 — the claim rides the MINT, not the landing, for BOTH engines.
+          // Claiming after assembly returned left the slot empty for the whole
+          // of a fast make, and left nothing at all behind a failed one, so the
+          // slot stayed empty and the person heard about the failure only in the
+          // conversation. The builder route has always claimed here (`create`'s
+          // own `slot`, which this door no longer needs to pass).
+          if (claimed !== undefined) await dependencies.claimSlot(appId, claimed, ctx);
+          /** The one exit for an ask no engine landed: the tombstone that turns
+           *  the claimed slot into the honest failure card, then the receipt
+           *  that says so — the record's reason is the sentence the person is
+           *  told, verbatim, because there is nothing else true to record. */
+          const failUnbuilt = async (title: string, say: string): Promise<ToolOutcome> => {
+            if (claimed !== undefined) await dependencies.markUnbuilt(appId, title, say, ctx);
+            return receipt({ id: appId, title, status: "failed", say });
+          };
           let threw: string | undefined;
           const routed = dependencies.screen === undefined
             ? undefined
@@ -486,11 +509,8 @@ export const createAgentTools = (
             const stored = await runtime.get(appId, ctx).catch(() => null);
             if (stored !== null) {
               await remember(appId);
-              // B1, on the engine that serves most asks. `place()` gates on the
-              // app record (§9.4) and assembly is what writes that record, so
-              // this is the FIRST instant the claim can legally be made — and
-              // the last instant it is still part of the call the person made.
-              if (claimed !== undefined) await runtime.place({ app: stored.id, slot: claimed }, ctx);
+              // No claim here: the slot has held this id since the mint above,
+              // and the row already names it.
               return receipt({
                 id: stored.id,
                 title: stored.name,
@@ -522,36 +542,29 @@ export const createAgentTools = (
             // Assembly produced no screen. Said plainly, at the id whose stream
             // the person is looking at, instead of quietly restarting the ask in
             // a different engine.
-            return receipt({
-              id: appId,
-              title: nameForUnbuilt(undefined, ask),
-              status: "failed",
-              say: unbuiltSay(
+            return await failUnbuilt(
+              nameForUnbuilt(undefined, ask),
+              unbuiltSay(
                 dependencies.screen === undefined ? NO_ASSEMBLER
                   : threw ?? (routed?.kind === "unavailable" ? routed.why : NOTHING_RENDERABLE),
               ),
-            });
+            );
           }
           if (!runtime.machine.available()) {
-            return receipt({
-              id: appId,
+            return await failUnbuilt(
               // The name on the skeleton they are looking at, so the sentence and
               // the card are about the same thing.
-              title: nameForUnbuilt(plan, ask),
-              status: "failed",
-              say: "That one needs a real build — code running on a server — and I can't do that here.",
-            });
+              nameForUnbuilt(plan, ask),
+              "That one needs a real build — code running on a server — and I can't do that here.",
+            );
           }
           let unsaved: string | undefined;
           const created = await runtime.create({
             appId,
             prompt: ask,
             ...(plan === undefined ? {} : { plan }),
-            // B1 — `create` claims the slot at MINT, so a build that is still
-            // running (or that never lands) occupies the place the caller aimed
-            // at instead of appearing out of nowhere minutes later. This tool
-            // only aims; the runtime owns the row.
-            ...(claimed === undefined ? {} : { slot: claimed }),
+            // No `slot`: the claim went down at the mint above, which is the
+            // same instant `create` would have made it for an id of its own.
             onUnsaved: (reason) => { unsaved = reason; },
             ...(stream === undefined ? {} : {
               onView: (part) => stream({ id: vendoViewStreamId(part.appId), part }),

--- a/packages/apps/src/create-unsaved.test.ts
+++ b/packages/apps/src/create-unsaved.test.ts
@@ -103,6 +103,8 @@ describe("a create the store refuses to persist", () => {
     const agentTools = createAgentTools(runtime, {
       data: {} as never,
       requireOwned: async () => { throw new Error("unused"); },
+      claimSlot: async () => { throw new Error("unused"); },
+      markUnbuilt: async () => { throw new Error("unused"); },
       screen: escalating,
     });
 

--- a/packages/apps/src/runtime.ts
+++ b/packages/apps/src/runtime.ts
@@ -2030,10 +2030,54 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
     return trimmed;
   };
 
+  /**
+   * B1 — the slot is claimed the moment the id EXISTS, so it shows the build
+   * forming (and, if it never lands, its failure) instead of sitting empty
+   * until the app record does. `place()` cannot be used: it gates on an app
+   * record, and by construction there is none yet.
+   *
+   * Two callers, one write: `create` for a build that mints its own id, and the
+   * `vendo_make` front door for the id it minted before it routed. Whichever
+   * engine the ask reaches, the row is already down.
+   */
+  const claimSlot = async (appId: AppId, slot: string, ctx: RunContext): Promise<void> => {
+    const named = requireSlot(slot);
+    await placementRows.put(ctx.principal.subject, {
+      slot: named,
+      appId,
+      placedBy: ctx.principal.subject,
+      placedAt: new Date().toISOString(),
+    });
+    await reportLifecycle("place", appId, ctx, { slot: named });
+  };
+
+  /**
+   * The terminal record for an id no engine will ever land — the front door's
+   * own, for an ask that died in assembly.
+   *
+   * The SAME tombstone a failed build leaves (`failBuild`, inside `create`), and
+   * that is the whole point: `entryFor` below reads one thing, so a claimed slot
+   * turns into the honest failure card the instant either engine gives up rather
+   * than holding a skeleton until the build window ages out.
+   */
+  const markUnbuilt = async (
+    appId: AppId,
+    name: string,
+    reason: string,
+    ctx: RunContext,
+  ): Promise<void> => {
+    await apps.put(appRecordInput({
+      format: "vendo/app@1",
+      id: appId,
+      name,
+      buildFailed: { reason, at: new Date().toISOString() },
+    }, ctx.principal.subject));
+  };
+
   /** Where a placed app's build stands, read off its record every time.
    *
-   *  NO RECORD is the build still running — `create` writes the placement row
-   *  at mint and the app record only at completion. Past the UI build window
+   *  NO RECORD is the build still running — the slot is claimed at mint and the
+   *  app record only lands at completion. Past the UI build window
    *  that stops being true: either the watchdog would have landed a terminal
    *  record by now, or the app was deleted out from under the row. Either way
    *  it is not forming, and a slot that says "building" forever is the exact
@@ -2552,20 +2596,9 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
       // skeleton and this build's paints share one stream.
       const appId = input.appId ?? `app_${globalThis.crypto.randomUUID()}`;
       const createStartedAt = Date.now();
-      // B1 — the slot is claimed the moment the id exists, so the slot shows
-      // this build forming (and, if it never lands, its failure) instead of
-      // sitting empty until the record does. `place()` cannot be used: there
-      // is no app record to gate on yet, by construction.
-      if (input.slot !== undefined) {
-        const slot = requireSlot(input.slot);
-        await placementRows.put(ctx.principal.subject, {
-          slot,
-          appId,
-          placedBy: ctx.principal.subject,
-          placedAt: new Date().toISOString(),
-        });
-        await reportLifecycle("place", appId, ctx, { slot });
-      }
+      // B1, for a caller that minted its id HERE. The front door claims before
+      // it routes (it minted earlier), so it passes no slot down.
+      if (input.slot !== undefined) await claimSlot(appId, input.slot, ctx);
       // The build's dead-man switch. The catch below persists a terminal failure
       // when the build turn THROWS, but a build task that hangs (a provider
       // stream that never settles) or dies with its promise chain severed
@@ -3540,6 +3573,8 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
       return createAgentTools(runtime, {
         data,
         requireOwned,
+        claimSlot,
+        markUnbuilt,
         ...(config.screen === undefined ? {} : { screen: config.screen }),
         ...(config.escalatedPlan === undefined ? {} : { escalatedPlan: config.escalatedPlan }),
       });

--- a/packages/apps/src/screen-route.test.ts
+++ b/packages/apps/src/screen-route.test.ts
@@ -86,6 +86,8 @@ const runtimeWith = (screen?: ScreenAssembler, options: {
     agentTools: createAgentTools(runtime, {
       data: {} as never,
       requireOwned: async () => { throw new Error("unused"); },
+      claimSlot: async () => { throw new Error("unused"); },
+      markUnbuilt: async () => { throw new Error("unused"); },
       ...(screen === undefined ? {} : { screen }),
       ...(escalatedPlan === undefined ? {} : { escalatedPlan }),
     }),

--- a/packages/vendo/src/placement-tools.e2e.test.ts
+++ b/packages/vendo/src/placement-tools.e2e.test.ts
@@ -5,9 +5,12 @@
  *  - the WRITE goes in over the real MCP door (register → authorize → token →
  *    JSON-RPC), through the real guard-bound registry and the real apps
  *    contribution;
- *  - the READ comes back out of the real store's `vendo_placements` rows.
- *    Nothing in this file knows how a placement is stored, and nothing in the
- *    apps runtime knows this file exists.
+ *  - the READ comes back out of the real store's `vendo_placements` rows, and
+ *    what the slot SHOWS out of the real `GET /apps/placements` route a browser
+ *    polls — the status is derived server-side, so a build that lands (or that
+ *    never does) is measured where the person would see it. Nothing in this file
+ *    knows how a placement is stored, and nothing in the apps runtime knows this
+ *    file exists.
  *  - the PROJECTION is measured on real turns — one attended, one unattended —
  *    because the composed surface is declared STATICALLY
  *    (`toolsFromRegistry(appsAgentTools, agentToolDescriptors)` in server.ts),
@@ -59,6 +62,15 @@ interface PlacementRow {
 const placementRows = async (store: VendoStore): Promise<PlacementRow[]> => {
   const { records } = await store.records(PLACEMENTS).list({ refs: { subject: SUBJECT } });
   return records.map((record) => record.data as unknown as PlacementRow);
+};
+
+/** What a slot on the page actually SHOWS, over the same route a browser polls
+ *  — the real read path, with the build status derived server-side. */
+interface PlacementEntry { slot: string; app: string; title: string; status: string }
+
+const placementEntries = async (vendo: Vendo): Promise<PlacementEntry[]> => {
+  const response = await vendo.handler(new Request("https://host.test/api/vendo/apps/placements"));
+  return await response.json() as PlacementEntry[];
 };
 
 interface Host {
@@ -148,6 +160,42 @@ describe("a slot-targeted make, over the MCP door", () => {
     // own provenance rather than being reconstructed by a reader.
     expect(typeof rows[0]!.placedBy).toBe("string");
     expect(Number.isFinite(Date.parse(rows[0]!.placedAt))).toBe(true);
+    // And through the read path a slot on the page actually polls: READY, the
+    // other end of the same transition the failure case below measures.
+    expect(await placementEntries(vendo)).toEqual([
+      { slot: "dashboard.hero", app: receipt.id, title: receipt.title, status: "ready" },
+    ]);
+  });
+
+  it("holds the slot with the honest failure when assembly cannot serve the ask", async () => {
+    // B1's failure half, end to end. A make that dies in assembly used to write
+    // no row at all: the slot the caller aimed at showed NOTHING and the failure
+    // existed only in the conversation.
+    //
+    // The failure is real, not injected — this host's screen agent can serve one
+    // ask, so the second reaches the same door and comes back with nothing that
+    // renders. Nothing is stubbed on either side: the write goes over the real
+    // MCP door and the status comes back out of GET /apps/placements.
+    const { vendo, store } = await host();
+    const door = await openDoor(vendo, await bearer(vendo));
+    await door.callTool(VENDO_MAKE_TOOL, { request: "my spending this month" });
+
+    const answered = await door.callTool(VENDO_MAKE_TOOL, {
+      request: "match my invoices to payments",
+      slot: "dashboard.hero",
+    });
+
+    const receipt = makeReceiptSchema.parse(JSON.parse(answered.text));
+    expect(receipt.status).toBe("failed");
+    // The row exists at all — the gap this closes left none.
+    expect(await placementRows(store)).toEqual([
+      expect.objectContaining({ slot: "dashboard.hero", appId: receipt.id }),
+    ]);
+    // …and the read path calls it FAILED now, not a skeleton that only becomes a
+    // failure once the build window ages out.
+    expect(await placementEntries(vendo)).toEqual([
+      { slot: "dashboard.hero", app: receipt.id, title: receipt.title, status: "failed" },
+    ]);
   });
 
   it("leaves no placement when no slot was named", async () => {


### PR DESCRIPTION
## The B1 gap

Decision **B1** of the approved design: a slot-targeted `vendo_make` claims its
slot the moment the appId is minted, so the slot shows the build immediately, and
a terminal failure shows the honest failure card **in the slot** (dismiss =
unplace).

The cold walk found this held on the **escalated builder** path only. On the
**fast screen-assembly** path — the engine that serves most asks — the placement
row was written *after* assembly succeeded. Two consequences, both observed in
the real product:

- **(a)** an empty slot showed nothing for the whole of a fast make, instead of
  the skeleton the slot exists to show;
- **(b)** a **failed** assembly wrote **no row at all**, so the slot showed
  nothing and the person learned of the failure only in the conversation.

## The fix

The claim now rides the **mint**, at the one place that mints the id — the
`vendo_make` front door, before it routes — so both engines are claimed for from
the same instant.

- `runtime.ts`: the mint-time claim is extracted into one internal `claimSlot`
  write. `create` keeps its own `slot` (for callers that mint inside it) and now
  goes through that same write; the front door no longer passes `slot` down,
  because it already claimed.
- `agent-tools.ts`: `claimSlot` fires right after the mint, before the assembler
  runs. The two terminal-failure exits (assembly came back empty; escalation with
  no sandbox) now land the **same terminal record a failed build leaves**, via
  `markUnbuilt`. `entryFor` therefore reads one thing and the claimed slot turns
  into the honest failure card the instant either engine gives up, rather than
  holding a skeleton until the 5-minute build window ages out.

Both new capabilities are internal wiring on `AgentToolsDataDependencies` (the
channel the runtime already uses to construct its own tool registry) — **no
public `AppsRuntime` surface added**.

Round-2 properties preserved, deliberately:

- the read path still cannot distinguish "app deleted" from "never landed" — the
  tombstone is a **write-side** answer, and app deletion still sweeps rows by
  `refs.app_id` through `clearForApp`, so a placement whose app no longer exists
  still renders as nothing placed;
- a placement whose app exists and FAILED renders the failure card — that is the
  path this PR extends to the assembly engine;
- the tombstone is a tombstone: `list()` already skips `buildFailed` documents,
  so it answers the slot and never joins the user's apps (asserted).

No assertion was weakened or removed.

## Proof 1 — unit/integration (`packages/apps/src/agent-tools.test.ts`)

Two new tests, both reading back through the runtime's real `placements()` path:

- **claims at MINT** — the reading is taken *from inside the assembler*,
  mid-flight: `{ slot, app, title: "", status: "building" }`, then the same row
  goes `ready` when assembly lands.
- **terminal failure** — an assembler that answers `unavailable` leaves
  `status: "failed"` in the slot with the receipt's own title, the app is absent
  from `list()`, and `unplace` (dismiss) clears it.

**Revert-and-watch, both directions:**

| reverted | result |
| --- | --- |
| drop the mint-time `claimSlot` | 4 red, incl. `expected [] to deeply equal [{ slot: 'dashboard.hero', … }]` — the slot is empty through the make |
| drop `markUnbuilt` | 1 red: `- "status": "failed"` / `+ "status": "building"` — the stuck skeleton this fixes |

Restored, 29/29 green.

## Proof 2 — seam (`packages/vendo/src/placement-tools.e2e.test.ts`)

Extended, nothing stubbed on either side. The failure is **real, not injected**:
this host's screen agent can serve one ask, so the second `vendo_make` reaches the
same real MCP door (register → authorize → token → JSON-RPC) and comes back with
nothing that renders.

- the write goes over the real MCP door;
- the row is read out of the real store's `vendo_placements`;
- the **status** is read back over the real `GET /apps/placements` route a browser
  polls — `status: "failed"`, title matching the receipt.

The ready direction now also reads through that same route in the existing
first test (added assertion, nothing changed).

**Revert-and-watch:** with `markUnbuilt` dropped, the seam test goes red with
`- "status": "failed" / + "status": "building"` and `- title: "match my invoices
to payments" / + title: ""`. Restored, 6/6 green.

## Gate

`pnpm build` ✅ · `pnpm test:affected` ✅ (only the known pre-existing reds) ·
`pnpm typecheck` ✅ · `pnpm lint` ✅

Known pre-existing reds, unchanged by this PR: `core/packaging.e2e` ×3,
`vendo/dev-creds/model` ×2, `store` drills ×2. `fixtures/mcp-e2e` ran clean.

Changeset: `.changeset/slot-claim-at-mint.md` (`@vendoai/apps` patch).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes slot-targeted `vendo_make` so it claims the slot at mint on both assembly and builder paths. Slots now show the build immediately, and terminal assembly failures render as failed in the slot.

- **Bug Fixes**
  - Claim happens at the `vendo_make` front door right after id mint; `create` uses the same internal `claimSlot`.
  - Added `markUnbuilt` so unlanded asks leave the same tombstone as a failed build; the slot shows failed and `list()` excludes it.
  - Wired via `AgentToolsDataDependencies`; no public `AppsRuntime` changes in `@vendoai/apps`.
  - Tests updated, including e2e verifying status via real `GET /apps/placements`.

<sup>Written for commit c81126c24e3ef831b35ddd3cbe3fd4c3a9f418ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

