### PR TITLE
fix(apps): advisory compile issues are advisory at every validation door

### DIFF
--- a/.changeset/advisory-is-advisory-at-every-door.md
+++ b/.changeset/advisory-is-advisory-at-every-door.md
@@ -1,0 +1,25 @@
+---
+"@vendoai/core": patch
+"@vendoai/apps": patch
+---
+
+Advisory compile issues are advisory at every validation door.
+
+#906 put ONE floor behind the four doors an app reaches a screen through, but the
+compile issues in FRONT of that floor were still classified twice. The paint seam
+refuses only what did not parse — `compile-failed`, `missing-app` — while
+`validateCompiledCreate` turned EVERY wire issue into a block.
+
+They disagreed on `wire-id-ignored`, which is not a code a model has to invent:
+`checkoutApp` writes an app's own `app.vendo` with
+`printWire(…, { includeIds: true })`, so every element of a checked-out app carries
+an id the compiler then ignores. The seam painted those bytes and
+`validate({ document })` refused them — the door the assembly loop is told to call
+"the floor" answering "does not pass" over our own printer's output. PR #913
+measured it and deliberately left it.
+
+Core now names the one classification the doors share
+(`isAdvisoryWireIssue` / `WIRE_ADVISORY_ISSUE_CODES`), and the create and edit
+validators read it instead of blocking on every issue. Nothing else moves: an
+issue that drops something the author actually wrote still blocks everywhere, and
+the paint seam's own parse gate is untouched.

--- a/packages/apps/src/generation/validation/validate.ts
+++ b/packages/apps/src/generation/validation/validate.ts
@@ -11,6 +11,7 @@
  * at it are gone.
  */
 import {
+  isAdvisoryWireIssue,
   VENDO_APP_FORMAT,
   VENDO_TREE_FORMAT,
   validateAppDocument,
@@ -49,6 +50,19 @@ import { withoutPlanVocabulary } from "../skeleton.js";
  *  whole `AppDocument`. */
 export const UNSTORED_APP_ID = "app_generation_validation";
 
+/** The compile issues a door must REFUSE, as the sentences it speaks.
+ *
+ *  Advisory codes drop out here, from the one classification every door shares
+ *  (`isAdvisoryWireIssue`) rather than a list per door. Mapping EVERY wire issue
+ *  to a block is what made these two doors disagree with the paint seam, which
+ *  refuses only what did not parse: `wire-id-ignored` is what our own
+ *  `printWire({ includeIds: true })` stamps on an app's `app.vendo`, so the seam
+ *  painted that source and `validate({ document })` refused the same bytes. */
+const blockingWireIssues = ({ issues }: WireCompileResult): string[] =>
+  issues
+    .filter((issue) => !isAdvisoryWireIssue(issue))
+    .map(({ code, message }) => `wire ${code}: ${message}`);
+
 /** Create validation: the compile must be complete and clean, the tree
  *  catalog-consistent and renderable, islands syntactically sound, queries
  *  aimed at real host tools, bindings shape-checked, and the assembled
@@ -63,7 +77,7 @@ export const validateCompiledCreate = async (
 ): Promise<{ document?: GeneratedAppDocument; issues: string[] }> => {
   const issues: string[] = [];
   if (!compiled.complete) issues.push("wire did not parse to a complete <App> document");
-  issues.push(...compiled.issues.map(({ code, message }) => `wire ${code}: ${message}`));
+  issues.push(...blockingWireIssues(compiled));
   const name = compiled.name?.trim() ?? "";
   if (name === "") {
     issues.push('App must carry a non-empty name="..." attribute');
@@ -168,7 +182,7 @@ export const documentFromEdit = async (
 ): Promise<{ document?: AppDocument; issues: string[] }> => {
   const structural = [
     ...(compiled.complete ? [] : ["the edited app did not parse to a complete <App> document; the change was dropped."]),
-    ...compiled.issues.map(({ code, message }) => `wire ${code}: ${message}`),
+    ...blockingWireIssues(compiled),
     ...compiled.bindingErrors.map((error) =>
       `binding ${error.path} on node "${error.nodeId}" prop "${error.prop}": ${error.message}${error.available === undefined ? "" : ` (available: ${error.available.join(", ")})`}`),
   ];

--- a/packages/core/src/genui/wire/expression.ts
+++ b/packages/core/src/genui/wire/expression.ts
@@ -148,6 +148,26 @@ export interface WireIssue {
   index?: number;
 }
 
+/**
+ * The ADVISORY codes: the compiler normalized something and the tree it produced
+ * is already what the author meant, so there is nothing to repair and no
+ * validation door may refuse a document over one.
+ *
+ * `wire-id-ignored` is the reason this exists. It is what our OWN printer
+ * produces — an app's `app.vendo` is written with
+ * `printWire(…, { includeIds: true })` (`@vendoai/apps` app-source.ts), so every
+ * element of a checked-out app carries an id the compiler then ignores. The paint
+ * seam waved that through and painted it; the create/edit validators turned every
+ * wire issue into a block and refused the same bytes. Every OTHER code drops
+ * something the author actually wrote, so it stays blocking.
+ */
+export const WIRE_ADVISORY_ISSUE_CODES: readonly WireIssueCode[] = ["wire-id-ignored"];
+
+/** True for an issue no door may block on — the one classification all four
+ *  share (see {@link WIRE_ADVISORY_ISSUE_CODES}). */
+export const isAdvisoryWireIssue = ({ code }: WireIssue): boolean =>
+  WIRE_ADVISORY_ISSUE_CODES.includes(code);
+
 /** v2 spec §2 — the declared `<Query>` names in scope for binding resolution. */
 export interface ExpressionContext {
   queryNames: ReadonlySet<string>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -59,7 +59,13 @@ export * from "./workspace.js";
 // compiled tree once the fn: shapes are sampled.
 export { compileWire, type WireCompileOptions, type WireCompileResult } from "./genui/wire/compile.js";
 export { expandInlineRefs, type InlineRefsResult } from "./genui/wire/inline-refs.js";
-export { WIRE_ISSUE_CODES, type WireIssue, type WireIssueCode } from "./genui/wire/expression.js";
+export {
+  isAdvisoryWireIssue,
+  WIRE_ADVISORY_ISSUE_CODES,
+  WIRE_ISSUE_CODES,
+  type WireIssue,
+  type WireIssueCode,
+} from "./genui/wire/expression.js";
 // v2 spec §5 — the one-dialect edit surface: print the app as id-anchored
 // wire (the model's edit context).
 export { printWire, type WirePrintInput, type WirePrintOptions } from "./genui/wire/print.js";

--- a/packages/harnesses/src/advisory-door-agreement.test.ts
+++ b/packages/harnesses/src/advisory-door-agreement.test.ts
@@ -1,0 +1,125 @@
+/**
+ * ADVISORY COMPILE ISSUES ARE ADVISORY AT EVERY DOOR.
+ *
+ * #906 put ONE floor behind the four doors an app reaches a screen through, but
+ * the COMPILE issues in FRONT of that floor were still classified twice. The
+ * paint seam refuses only what did not parse — `compile-failed`, `missing-app`
+ * (`render-seam.ts`) — while `validateCompiledCreate` turned EVERY wire issue
+ * into a block.
+ *
+ * `wire-id-ignored` is where the two disagreed, and it is not a code a model has
+ * to invent: `checkoutApp` writes an app's own `app.vendo` with
+ * `printWire(…, { includeIds: true })` (`@vendoai/apps` app-source.ts), so every
+ * element of a checked-out app carries an id, and recompiling those bytes raises
+ * exactly that issue and nothing else. The seam painted them; `validate({
+ * document })` refused them — the door the assembly loop is told to call "the
+ * floor" answering "does not pass" over our own printer's output. PR #913
+ * measured the disagreement and deliberately left it; this closes it.
+ *
+ * So ONE document — the printer's own output — walks the doors, each through its
+ * real entry point, and every door must reach the SAME verdict. Nothing is
+ * stubbed: the seam is the real `commit()` proxy, the floor is the real floor off
+ * `AppsRuntime.floor`, the row `validate({ appId })` judges is the one the real
+ * paint created through `AppsRuntime.authored`, and `validate` is the shipped
+ * verb. The fourth door — the edit path — is not reachable from this package; it
+ * reads the same shared classification and is driven in
+ * `packages/apps/src/one-floor.test.ts`.
+ *
+ * The one that must be able to fail: put `compiled.issues.map(…)` back in
+ * `apps/generation/validation/validate.ts` and `validate({ document })` goes red
+ * on `wire wire-id-ignored: …` while the seam beside it still paints.
+ */
+import { createApps } from "@vendoai/apps";
+import {
+  compileWire,
+  printWire,
+  type AppId,
+  type NormalizedCatalog,
+  type ToolRegistry,
+  type VendoViewPart,
+} from "@vendoai/core";
+import { memoryStoreAdapter } from "@vendoai/core/conformance";
+import { describe, expect, it } from "vitest";
+import { wrapWorkspaceForRender } from "./render-seam.js";
+import { ctx, scriptedModel, testGuard, testWorkspace } from "./test-doubles.test-util.js";
+
+const APP_ID = "app_advisory_door" as AppId;
+const APP_VENDO = `/user/apps/${APP_ID}/app.vendo`;
+
+const catalog: NormalizedCatalog = [];
+
+const tools: ToolRegistry = {
+  async descriptors() {
+    return [];
+  },
+  async execute() {
+    return { status: "error", error: { code: "not-found", message: "no tools" } };
+  },
+};
+
+/** A sound app — nothing here is wrong with it at any door. */
+const SOUND = '<App name="Spending"><Stack><Text text="This month" /></Stack></App>';
+
+/** …and the bytes a CHECKOUT writes for that same app: the id-anchored print,
+ *  which is the one wire this codebase produces that raises `wire-id-ignored`. */
+const CHECKED_OUT = printWire(compileWire(SOUND, {}), { includeIds: true });
+
+const context = ctx({ venue: "app" });
+
+/** A real apps runtime. The model is scripted-empty on purpose: every door under
+ *  test here is deterministic, and the AI reviewer `validate({ appId })` runs is
+ *  fail-open, so a model that answers nothing costs no findings. */
+const appsRuntime = () => createApps({
+  store: memoryStoreAdapter(),
+  guard: testGuard(),
+  tools,
+  catalog,
+  model: scriptedModel([]),
+});
+
+describe("an advisory compile issue is advisory at every door", () => {
+  it("the document under test carries wire-id-ignored and nothing else", () => {
+    // Without this the rest could pass on a document that raises no issue at all.
+    const codes = new Set(compileWire(CHECKED_OUT, {}).issues.map(({ code }) => code));
+    expect([...codes]).toEqual(["wire-id-ignored"]);
+  });
+
+  it("the paint seam paints it, and both validate doors pass the very same bytes", async () => {
+    const runtime = appsRuntime();
+    const emitted: VendoViewPart[] = [];
+    const workspace = wrapWorkspaceForRender(testWorkspace(), {
+      emit: (_streamId, part) => emitted.push(part),
+      floor: runtime.floor(context),
+      authoredApp: (input) => runtime.authored(input, context),
+    });
+
+    // DOOR 1 — the paint seam, through the real write-then-commit path.
+    await workspace.writeFile(APP_VENDO, CHECKED_OUT);
+    await workspace.commit();
+    expect(emitted.map((part) => part.appId)).toContain(APP_ID);
+
+    // DOOR 2 — `validate({ document })` on the SAME bytes the seam just painted.
+    const onDocument = await runtime.validate({ document: CHECKED_OUT }, context);
+    // Named, not merely counted: the point is WHICH issue must not block.
+    expect(onDocument.findings.map(({ message }) => message).join("\n")).not.toContain("wire-id-ignored");
+    expect(onDocument.ok).toBe(true);
+
+    // DOOR 3 — `validate({ appId })` on the row that paint created, which is the
+    // door the assembly loop's brief actually names.
+    const onRow = await runtime.validate({ appId: APP_ID }, context);
+    expect(onRow.ok).toBe(true);
+  }, 60_000);
+
+  it("a wire issue that is NOT advisory still blocks — the floor did not get softer", async () => {
+    // `unknown-reference`: the binding names no declared query, so the attribute
+    // is DROPPED and the app promises a value it cannot show. Advisory is one
+    // named class, never "compile issues stopped mattering".
+    const broken = '<App name="Spending"><Stack><Text text={nope.total} /></Stack></App>';
+    expect(compileWire(broken, {}).issues.map(({ code }) => code)).toContain("unknown-reference");
+
+    const result = await appsRuntime().validate({ document: broken }, context);
+
+    expect(result.ok).toBe(false);
+    expect(result.findings.map(({ message }) => message).join("\n")).toContain("unknown-reference");
+  }, 60_000);
+});


### PR DESCRIPTION
`validate({ document })` refused our own printer's output.

`checkoutApp` writes an app's own `app.vendo` with
`printWire(…, { includeIds: true })` (`packages/apps/src/app-source.ts:220`), so
every element of a checked-out app carries an id. Recompiling those bytes raises
exactly one issue — `wire-id-ignored` — and core already pins that
(`packages/core/src/genui/wire/print.test.ts:94`).

The paint seam paints them. `validate({ document })` blocked them.

## The disagreement

#906 put ONE floor behind the four doors an app reaches a screen through. The
compile issues in FRONT of that floor were still classified twice:

| | classifies compile issues |
|---|---|
| paint seam (`packages/harnesses/src/render-seam.ts:275`) | refuses only `compile-failed` / `missing-app` — "did it parse at all" |
| `validateCompiledCreate` (`packages/apps/src/generation/validation/validate.ts:66`) | every wire issue → a block |
| `documentFromEdit` (same file, `:171`) | every wire issue → a block |

So the door the assembly loop's brief calls "the floor" answered "does not pass"
over source the seam had just painted. PR #913 measured this and deliberately
left it out of scope; this closes it.

**Not intentional, and not documented as such** — `floor.ts:88-92` states the
opposite as the contract: "One definition, imported by all four doors … because
the four used to run four different subsets and an app blocked at one shipped
through another."

## The fix

One shared classification in core, next to the closed issue registry that owns
these codes — not a list per door:

```ts
export const WIRE_ADVISORY_ISSUE_CODES: readonly WireIssueCode[] = ["wire-id-ignored"];
export const isAdvisoryWireIssue = ({ code }: WireIssue): boolean =>
  WIRE_ADVISORY_ISSUE_CODES.includes(code);
```

Advisory means the compiler normalized something and the tree it produced is
already what the author meant. Every other code drops something the author
actually wrote, so it stays blocking — and the seam's own parse gate is
untouched. The two validators read the predicate through one local helper
(`blockingWireIssues`), so they cannot drift apart again.

+43 / -3 across three source files.

## Proof

`packages/harnesses/src/advisory-door-agreement.test.ts` — one document, the
printer's own output, through each door's real entry point. Nothing stubbed: the
real `commit()` proxy, the real floor off `AppsRuntime.floor`, the row created by
the real paint through `AppsRuntime.authored`, and the shipped `validate` verb.

- pins that the document really carries `wire-id-ignored` **and nothing else**
- seam paints it → `validate({ document })` passes → `validate({ appId })` passes
- a counter-case: `unknown-reference` still blocks, so this is one named class and
  not "compile issues stopped mattering"

**Revert-proven.** Put `compiled.issues.map(…)` back, rebuild:

```
× the paint seam paints it, and both validate doors pass the very same bytes
  → expected 'wire wire-id-ignored: wire-supplied i…' not to contain 'wire-id-ignored'
```

The seam assertion in that same run still passes — which is the disagreement,
reproduced.

```
pnpm build 23/23 · pnpm typecheck 42/42 · pnpm lint clean (0 errors)
core   183 tests (print · compile · text-edit)
apps    86 tests (one-floor · validate · validate-door · floor · app-floor · app-source)
harnesses 87 tests (advisory-door-agreement · render-seam-floor · render-seam · screen-agent)
vendo   21 tests (screen-floor-door.e2e · screen-route.e2e · vendo-verbs-wire · review/drift-rebase/inclient fixtures)
```

## Note for a follow-up, not done here

`documentFromEdit` — the "edit path" door — has **no production caller**. Its only
callers are `packages/apps/src/one-floor.test.ts`; `authored` is the one write
path since #895 (`runtime.ts:1921`). It is fixed here for consistency rather than
deleted, because deleting it means touching an existing test, which is its own
change.

No user-visible UI change: this only widens what the existing validate door
accepts, so there is nothing to screenshot.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat advisory wire compile issues as non-blocking at all validation doors, fixing the case where `validate({ document })` rejected our own `printWire({ includeIds: true })` output (`wire-id-ignored`). Centralizes advisory classification in `@vendoai/core` so create/edit validators in `@vendoai/apps` match the paint seam.

- **Bug Fixes**
  - Centralized advisory detection with `isAdvisoryWireIssue` and `WIRE_ADVISORY_ISSUE_CODES` in `@vendoai/core` and exported them for use.
  - Updated `validateCompiledCreate` and `documentFromEdit` to ignore advisory issues while still blocking parse failures and real drops.
  - Added `advisory-door-agreement.test` to prove `validate({ document })` and `validate({ appId })` agree with the paint seam; `unknown-reference` still blocks.

<sup>Written for commit f47dfb5380454575a3b4add09a23973ce7eb219b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

