### PR TITLE
fix(ui): a persisted turn failure reads whole after a reload

### DIFF
--- a/.changeset/persisted-failure-headline-readable.md
+++ b/.changeset/persisted-failure-headline-readable.md
@@ -1,0 +1,15 @@
+---
+"@vendoai/ui": patch
+---
+
+A persisted turn failure reads whole after a reload.
+
+The failure's headline rendered through the build beat's label — `white-space:
+nowrap` + `text-overflow: ellipsis` — inside a block capped at `max-width: 92%`
+of a turn that is itself shrink-to-fit. The percentage therefore resolved
+against a width the block's own text had just set, so the box came out narrower
+than the headline it contained and the ellipsis ate the end: a reloaded failure
+with no detail line under it read "The response didn't f…" (144px of a 159px
+sentence). The turn already caps at 92% of the list, so the inner cap is gone
+and a failure headline now wraps instead of clipping — it is content, not a
+progress line. No copy, color or component changed.

--- a/packages/ui/src/chrome/chrome-css.ts
+++ b/packages/ui/src/chrome/chrome-css.ts
@@ -491,7 +491,16 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the S1 des
 /* A terminally failed app build: the ✕ beat plus the classified reason,
    indented under it. Prose, not a failure component (spec §15) — no card, no
    retry chrome; the agent's next sentence carries the recovery. */
-.fl-buildfail { align-self: flex-start; max-width: 92%; }
+.fl-buildfail { align-self: flex-start; }
+/* A failure headline is CONTENT: it wraps rather than ellipsizing. The beat's
+   nowrap clip is right for a progress line and wrong here, and TWO rules hid
+   the sentence together — a turn is shrink-to-fit (.fl-turn-assistant is
+   align-self: flex-start), so this block's former 92% max-width resolved
+   against a width its own text had just set, making the box 8% narrower than
+   the headline inside it, and the ellipsis ate the end. A persisted failure
+   with no detail line under it read "The response didn't f…" after a reload
+   (PR #864 proof). The turn already caps at 92% of the list. */
+.fl-buildfail .fl-beat-label { overflow: visible; white-space: normal; text-overflow: clip; }
 .fl-buildfail .fl-approval-more { margin-left: 21px; line-height: 1.5; }
 
 /* The tool chip was replaced by the build beats above; only its error line

--- a/packages/ui/test/chrome/error-surface.test.tsx
+++ b/packages/ui/test/chrome/error-surface.test.tsx
@@ -7,6 +7,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { VendoProvider, createVendoClient, type VendoClient } from "../../src/index.js";
 import { VendoThread } from "../../src/chrome/index.js";
+import { CHROME_CSS } from "../../src/chrome/chrome-css.js";
 import { turnErrorSentence } from "../../src/chrome/thread/message-data.js";
 import { createWireServer } from "../wire-server.js";
 
@@ -194,6 +195,22 @@ describe("visible error surface + retry (ENG-214)", () => {
     // The wire's "Vendo: " marker is plumbing, never shown to the reader.
     expect(notice.textContent).not.toContain("Vendo: ");
     expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+  });
+
+  it("keeps the persisted failure's headline WHOLE, never ellipsized (jsdom can't measure layout, so pin the stylesheet contract)", () => {
+    // The failure rendered its headline through `.fl-beat-label` — nowrap +
+    // ellipsis, right for a progress line, wrong for content — inside a block
+    // whose `max-width: 92%` resolved against the shrink-to-fit turn its OWN
+    // text had just sized. The box came out narrower than the headline every
+    // time, so a reloaded failure with no detail line under it read "The
+    // response didn't f…" (PR #864 proof, measured at 144px).
+    const block = /\.fl-buildfail \{[^}]*\}/.exec(CHROME_CSS)?.[0];
+    expect(block, "expected a .fl-buildfail rule in CHROME_CSS").toBeTruthy();
+    expect(block).not.toContain("max-width");
+    const label = /\.fl-buildfail \.fl-beat-label \{[^}]*\}/.exec(CHROME_CSS)?.[0];
+    expect(label, "expected the failure block to override the beat label's clip").toBeTruthy();
+    expect(label).toContain("white-space: normal");
+    expect(label).toContain("overflow: visible");
   });
 
   it("retries a mid-stream failure through Regenerate, without duplicating messages", async () => {


### PR DESCRIPTION
## What

A persisted turn failure reads whole after a reload. Two CSS declarations in
`@vendoai/ui`, no component or copy change:

- `.fl-buildfail` loses its `max-width: 92%`
- `.fl-buildfail .fl-beat-label` overrides the beat's `nowrap` + ellipsis clip

## Why

Follow-up to the fresh-eyes walk on #864: the reloaded failure row read
**"The response didn't f…"**. The data was right; the UI hid it.

Two rules did it together. The failure headline renders through the build
beat's label (`white-space: nowrap; text-overflow: ellipsis` — correct for a
progress line, wrong for content), inside a block capped at `max-width: 92%`.
A turn is shrink-to-fit (`.fl-turn-assistant` is `align-self: flex-start`), so
that percentage resolved against a width the block's **own text** had just
set — the box came out 8% narrower than the headline inside it, every time, and
the ellipsis ate the end. Measured live in demo-bank: 144.4px of available
width for a 159px sentence.

It bites whenever the failure has no detail line under it — i.e. any failure
the wire gate can't name (raw provider/transport errors, an uncoded
`Vendo:`-prefixed message). With a detail sentence present, the long line
widens the block and the headline happens to survive, which is why this hid so
long.

The turn already caps at 92% of the list, so the inner cap is redundant as well
as self-defeating; and a failure headline now wraps rather than clipping, which
matches the live error banner's language (`.fl-error` wraps, `.fl-error-detail`
is `overflow-wrap: anywhere` — no ellipsis anywhere on that surface).
Accessibility: text stays selectable (verified by selecting the full sentence
in the page), colour/contrast untouched (`--vendo-danger` on the same surface),
identical in light and dark since no colour token is involved.

## Verification

Real browser, demo-bank (Maple), signed in as a user, one dev server at a time.
Screenshots in `/tmp/f1-proof/`:

| file | what it shows |
| --- | --- |
| `03-nodetail-after-reload-BEFORE-mainCSS.png` | the defect, reproduced in the live app with `main`'s two declarations restored on the page: "The response didn't f…" (label 144.4px, needs 159px) |
| `04-nodetail-after-reload-FIXED.png` | same page, same persisted turn, this branch's CSS: "The response didn't finish", whole, one line, no clip |
| `02-nokey-after-reload-FIXED.png` | no model key → failure → **reload** → headline + the full coded sentence ("I couldn't make that request work — nothing was changed. Ask again and I'll try a different approach.") |
| `06-narrow-414-FIXED.png` | 414px mobile takeover — headline still whole |
| `08-stylesheet-light-dark-FIXED.png` | light and dark host tokens side by side, both failure shapes |
| `07-key-restored-regenerate-clean.png` | model restored → Regenerate on the failed turn → clean answer ("You've spent $265.81 on groceries…"), failure row gone |

How the no-detail failure was produced as a user: a real model key with a bogus
`VENDO_MODEL` pin, so the provider 404s and `wireErrorMessage` has nothing safe
to name — the exact shape #864 photographed (headline only, no detail line).

Tests: `packages/ui/test/chrome/error-surface.test.tsx` gains a stylesheet
contract test beside the existing persisted-turn-error test (jsdom can't measure
layout — same pattern as `user-bubble.test.tsx`). Proven red first: with the CSS
change stashed it fails on `expected '.fl-buildfail { align-self: flex-start;
max-width: 92%; }' not to contain 'max-width'`; green with it.

- [ ] `pnpm build && pnpm test && pnpm typecheck && pnpm lint` green — **not run
      here.** This worker ran: `vitest run` on the touched file plus
      `build-failed-banner`, `s1-recipe`, `transcript-beats`, `status-beats`
      (58 passed, worker-capped), `pnpm --filter @vendoai/ui typecheck`, and
      `pnpm build`. The full suite belongs at the merge boundary, once.
- [x] Screenshots attached (paths above)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persisted turn failure headlines now read in full after reloads. We removed the inner width cap and turned off ellipsis so the sentence wraps instead of clipping.

- **Bug Fixes**
  - Remove `max-width: 92%` from `.fl-buildfail` in `@vendoai/ui` (the turn already caps at 92%).
  - Override `.fl-buildfail .fl-beat-label` to wrap: `white-space: normal`, `overflow: visible`, `text-overflow: clip`.
  - Add a stylesheet contract test to pin these rules.

<sup>Written for commit 12f9bcc41d8725e2a7625a9c56c2c072190fe956. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

