### PR TITLE
fix: next-auth v4 hosts fail loud and correct (authJs secret order, lazy sessions, init advisory, honest doctor)

### DIFF
--- a/.changeset/authjs-v4-fail-loud.md
+++ b/.changeset/authjs-v4-fail-loud.md
@@ -1,0 +1,16 @@
+---
+"@vendoai/actions": patch
+"@vendoai/vendo": patch
+---
+
+next-auth v4 hosts fail loud and correct instead of silently breaking: the
+authJs preset resolves `AUTH_SECRET` then v4's `NEXTAUTH_SECRET` (Auth.js's
+own legacy order), defers module/secret work until an Auth.js session cookie
+is actually present (a misconfigured preset no longer 501s anonymous
+traffic), and names next-auth v4 once when it sees a v4 session cookie.
+`vendo init` prints a v4 advisory when wiring authJs onto a major-4 host.
+The wire surfaces a failed principal resolver's own message instead of a
+generic Internal Vendo error. Doctor distinguishes a declined actAs mint
+(new E-AUTH-008 warning) from an unconfigured seam (E-AUTH-007), passes the
+wire's failure reason through E-AUTH-004, and its act-as pass message stops
+claiming host verification the probe never performs.

--- a/docs-site/agents/host-auth.mdx
+++ b/docs-site/agents/host-auth.mdx
@@ -17,7 +17,7 @@ Init detects from `package.json` (dependencies and devDependencies):
 
 | Dependency matches | Preset | Runtime SDK the preset lazy-loads |
 | --- | --- | --- |
-| `next-auth` or `@auth/*` | `authJs` | `@auth/core` |
+| `next-auth` or `@auth/*` | `authJs` (v5 — a next-auth major-4 host is wired with a printed advisory: v4 sessions resolve as anonymous) | `@auth/core` |
 | `@clerk/*` | `clerk` | `@clerk/backend` |
 | `@supabase/*` | `supabase` | `jose` |
 | `@auth0/*` | `auth0` | `jose` |

--- a/docs-site/agents/verify.mdx
+++ b/docs-site/agents/verify.mdx
@@ -434,15 +434,20 @@ runs once `/status` answers.
 
 ### E-AUTH-004 {#E-AUTH-004}
 
-**Symptom:** actAs mint + host verification failed.
+**Symptom:** actAs mint + host verification failed. The doctor line carries
+the wire's own failure reason (a missing module, the mint's error) when the
+probe surfaced one.
 
-**Cause:** The composition minted an away credential but the host did not
-verify it. The verifier middleware is missing, or the secret the preset signs
-with differs from the one the host verifies with.
+**Cause:** The composition minted an away credential but the composition's own
+principal resolver did not accept it over the wire — or the mint itself
+errored. Note the probe's scope: it verifies against the composition's
+resolver, not the host app's session middleware, so a pass still depends on
+the host verifying real away calls.
 
-**Fix:** Check `createVendo({ auth })` (or the hand-wired `actAs`), its
-verifier middleware on the host API, and the host principal resolver. For
-Clerk/Auth0, `VENDO_AWAY_TOKEN_SECRET` must be the same value on both sides.
+**Fix:** Start from the reason in the doctor line. Then check
+`createVendo({ auth })` (or the hand-wired `actAs`), its verifier middleware
+on the host API, and the host principal resolver. For Clerk/Auth0,
+`VENDO_AWAY_TOKEN_SECRET` must be the same value on both sides.
 See [Host auth](/agents/host-auth).
 
 ### E-AUTH-005 {#E-AUTH-005}
@@ -469,11 +474,27 @@ preset), and re-run doctor.
 
 **Cause:** The composition has neither an `auth` preset nor an `actAs` seam,
 so the agent cannot act through the host API while the user is away. Present
-(user-in-the-room) calls still work.
+(user-in-the-room) calls still work. (A configured seam that *declines* the
+probe is a different state — see [E-AUTH-008](#E-AUTH-008).)
 
 **Fix:** Wire an auth preset (`auth: authJs()` and friends fill `actAs`) or
 pass `createVendo({ actAs })` before enabling away host actions. Acceptable to
 leave for a present-only install; this never blocks doctor.
+
+### E-AUTH-008 {#E-AUTH-008}
+
+**Symptom (warning):** actAs is configured but declined the doctor probe's
+synthetic principal.
+
+**Cause:** The actAs seam is wired and answered — with a no. Expected when a
+`subject→user` resolver only mints for subjects in the host's real user table
+(the doctor's synthetic subject is not one), or when the preset's secret is
+unset so the mint declines. The doctor line carries the wire's reason.
+
+**Fix:** Nothing, if the decline is your resolver refusing unknown subjects —
+that is the fail-closed behavior working; real away runs depend on the
+resolver accepting real subjects. If the reason names a missing secret,
+set it (`AUTH_SECRET` / the preset's documented variable) and re-run.
 
 ## MCP door
 

--- a/docs-site/connect/act-as-presets.mdx
+++ b/docs-site/connect/act-as-presets.mdx
@@ -29,7 +29,7 @@ name/email session-token claims:
 
 | Preset | Session secret (env) | Session source |
 | --- | --- | --- |
-| `authJs()` | `AUTH_SECRET` | Auth.js session JWE |
+| `authJs()` | `AUTH_SECRET`, then next-auth v4's `NEXTAUTH_SECRET` | Auth.js session JWE (v5 only — v4 sessions resolve as anonymous) |
 | `clerk()` | `CLERK_SECRET_KEY` (+ optional `CLERK_JWT_KEY`) | `__session` cookie or `Authorization: Bearer` |
 | `supabase()` | `SUPABASE_JWT_SECRET` (HS256, offline) and/or `SUPABASE_URL` (ES256 logins via GoTrue's JWKS) | `sb-*-auth-token` cookie or `Authorization: Bearer` |
 | `auth0()` | `AUTH0_DOMAIN` / `AUTH0_ISSUER_BASE_URL` (tenant JWKS) | `Authorization: Bearer` |

--- a/docs/act-as-presets.md
+++ b/docs/act-as-presets.md
@@ -24,7 +24,7 @@ name/email session-token claims:
 
 | Preset | Session secret (env) | Session source |
 | --- | --- | --- |
-| `authJs()` | `AUTH_SECRET` | Auth.js session JWE (`@auth/core`) |
+| `authJs()` | `AUTH_SECRET`, then next-auth v4's `NEXTAUTH_SECRET` | Auth.js session JWE (`@auth/core`) |
 | `clerk()` | `CLERK_SECRET_KEY` (+ optional `CLERK_JWT_KEY`) | `__session` cookie or `Authorization: Bearer` |
 | `supabase()` | `SUPABASE_JWT_SECRET` | `sb-*-auth-token` cookie or `Authorization: Bearer` |
 | `auth0()` | `AUTH0_DOMAIN` / `AUTH0_ISSUER_BASE_URL` (tenant JWKS) | `Authorization: Bearer` |
@@ -122,6 +122,17 @@ the host API verifier uses, never a public or publishable key.
 
 Install Auth.js alongside the preset. It is an optional peer so hosts that do
 not use Auth.js do not install it.
+
+**next-auth v4 is not supported.** v4 uses its own cookie names
+(`next-auth.session-token`) and its own JWE derivation, so v4 sessions are
+structurally unreadable here: signed-in users resolve as anonymous (the
+preset logs one console hint when it sees a v4-named cookie), and away calls
+into the host fail its session verification even though the doctor probe's
+vendo-side round-trip passes. `vendo init` prints an advisory when it wires
+authJs() onto a next-auth major-4 host. The secret fallback to
+`NEXTAUTH_SECRET` exists for v5 hosts still using the legacy variable name —
+it does not make v4 sessions readable. Upgrade to v5, or stay anonymous with
+`--auth none` until then.
 
 ```sh
 pnpm add @auth/core

--- a/packages/actions/src/presets/auth-js.test.ts
+++ b/packages/actions/src/presets/auth-js.test.ts
@@ -21,7 +21,10 @@ const cookieName = "authjs.session-token";
 
 describe("authJsPreset", () => {
   beforeEach(() => vi.useFakeTimers().setSystemTime(new Date("2026-07-14T12:00:00.000Z")));
-  afterEach(() => vi.useRealTimers());
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+  });
 
   it("mints an Auth.js v5 JWE accepted by the real getToken implementation", async () => {
     const actAs = authJsPreset({
@@ -103,5 +106,41 @@ describe("authJsPreset", () => {
 
     await expect(denied(principal, grant)).resolves.toBeNull();
     await expect(missingSecret(principal, grant)).resolves.toBeNull();
+  });
+
+  it("falls back to NEXTAUTH_SECRET (next-auth v4's name) when AUTH_SECRET is absent", async () => {
+    vi.stubEnv("NEXTAUTH_SECRET", secret);
+    const actAs = authJsPreset({ cookieName });
+
+    const material = await actAs(principal, grant);
+
+    expect(material?.headers.cookie).toMatch(/^authjs\.session-token=/);
+    await expect(getToken({
+      req: { headers: material?.headers ?? {} },
+      secret,
+      cookieName,
+    })).resolves.toMatchObject({ sub: principal.subject });
+  });
+
+  it("prefers AUTH_SECRET over NEXTAUTH_SECRET when both are set (Auth.js's own order)", async () => {
+    vi.stubEnv("AUTH_SECRET", secret);
+    vi.stubEnv("NEXTAUTH_SECRET", "legacy-secret-that-must-lose");
+    const actAs = authJsPreset({ cookieName });
+
+    const material = await actAs(principal, grant);
+
+    await expect(getToken({
+      req: { headers: material?.headers ?? {} },
+      secret,
+      cookieName,
+    })).resolves.toMatchObject({ sub: principal.subject });
+  });
+
+  it("an explicit secret source that declines never falls back to the env names", async () => {
+    vi.stubEnv("AUTH_SECRET", secret);
+    vi.stubEnv("NEXTAUTH_SECRET", secret);
+    const declined = authJsPreset({ secret: async () => undefined });
+
+    await expect(declined(principal, grant)).resolves.toBeNull();
   });
 });

--- a/packages/actions/src/presets/auth-js.ts
+++ b/packages/actions/src/presets/auth-js.ts
@@ -19,7 +19,8 @@ type AuthJsEncode = (options: {
 }) => Promise<string>;
 
 export interface AuthJsPresetOptions {
-  /** The host's Auth.js secret. Defaults to AUTH_SECRET. */
+  /** The host's Auth.js secret. Defaults to AUTH_SECRET, then next-auth v4's
+      NEXTAUTH_SECRET — the same legacy-name order Auth.js itself resolves. */
   secret?: SecretSource;
   /** Must match the host's session cookie name because Auth.js uses it as the JWE salt. */
   cookieName?: string;
@@ -58,7 +59,12 @@ export function authJsPreset(options: AuthJsPresetOptions = {}): ActAs {
   };
 
   return async (principal, grant): Promise<AuthMaterial | null> => {
-    const secret = await resolveSecret(options.secret, "AUTH_SECRET");
+    // Zero-config resolves AUTH_SECRET then next-auth v4's NEXTAUTH_SECRET
+    // (Auth.js's own legacy-name order); an explicit source that declines
+    // never falls through to the env names — explicit wins, including its no.
+    const secret = options.secret !== undefined
+      ? await resolveSecret(options.secret)
+      : await resolveSecret(undefined, "AUTH_SECRET") ?? await resolveSecret(undefined, "NEXTAUTH_SECRET");
     if (!secret) return null;
     const additionalClaims = await resolveClaims(options.claims, principal, grant);
     if (additionalClaims === null) return null;

--- a/packages/vendo/src/auth-presets/auth-js.test.ts
+++ b/packages/vendo/src/auth-presets/auth-js.test.ts
@@ -110,6 +110,50 @@ describe("authJs() zero-argument standard case", () => {
     await expect(preset.principal(withCookie(await sessionCookie("user_env"))))
       .rejects.toThrow(/AUTH_SECRET/);
   });
+
+  it("resolves cookie-less requests to null without touching the secret or @auth/core (#872)", async () => {
+    // A misconfigured preset must not take down anonymous traffic: with no
+    // Auth.js session cookie there is no session to decode, so nothing that
+    // can throw may run.
+    vi.stubEnv("AUTH_SECRET", "");
+    const preset = authJs();
+    await expect(preset.principal(new Request("https://host.test/api/vendo/threads")))
+      .resolves.toBeNull();
+    await expect(preset.principal(withCookie("unrelated=1; theme=dark")))
+      .resolves.toBeNull();
+  });
+
+  it("reads NEXTAUTH_SECRET (next-auth v4's name) when AUTH_SECRET is absent", async () => {
+    vi.stubEnv("NEXTAUTH_SECRET", secret);
+    const preset = authJs();
+    const resolved = await preset.principal(withCookie(await sessionCookie("user_v4_name")));
+    expect(resolved).toEqual({ kind: "user", subject: "user_v4_name" });
+  });
+
+  it("prefers AUTH_SECRET over NEXTAUTH_SECRET when both are set", async () => {
+    vi.stubEnv("AUTH_SECRET", secret);
+    vi.stubEnv("NEXTAUTH_SECRET", "legacy-secret-that-must-lose");
+    const preset = authJs();
+    const resolved = await preset.principal(withCookie(await sessionCookie("user_both_names")));
+    expect(resolved).toEqual({ kind: "user", subject: "user_both_names" });
+  });
+
+  it("names next-auth v4 ONCE when it sees a v4 session cookie, and resolves it as anonymous", async () => {
+    vi.stubEnv("AUTH_SECRET", secret);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      const preset = authJs();
+      const v4Cookie = "next-auth.session-token=some-v4-jwe-vendo-cannot-read";
+      await expect(preset.principal(withCookie(v4Cookie))).resolves.toBeNull();
+      await expect(preset.principal(withCookie(v4Cookie))).resolves.toBeNull();
+      const v4Warnings = warn.mock.calls.filter(([message]) =>
+        typeof message === "string" && message.includes("next-auth v4"));
+      expect(v4Warnings).toHaveLength(1);
+      expect(v4Warnings[0]![0]).toContain("Auth.js v5");
+    } finally {
+      warn.mockRestore();
+    }
+  });
 });
 
 describe("authJs() subject→user resolver overrides", () => {

--- a/packages/vendo/src/auth-presets/auth-js.ts
+++ b/packages/vendo/src/auth-presets/auth-js.ts
@@ -9,6 +9,7 @@ import { environment } from "../wire/shared.js";
 import {
   actAsClaimsFromUser,
   composeHostAuthPreset,
+  cookieValue,
   lazyActAs,
   lazyModule,
   loginRedirect,
@@ -34,7 +35,18 @@ const MISSING_AUTH_CORE_MESSAGE =
   "authJs() reads the Auth.js session through @auth/core, which is not installed. Install it alongside your Auth.js setup: npm install @auth/core";
 
 const MISSING_SECRET_MESSAGE =
-  "authJs() has no session secret: set AUTH_SECRET (mirroring Auth.js itself) or pass authJs({ secret }).";
+  "authJs() has no session secret: set AUTH_SECRET (mirroring Auth.js itself; next-auth v4's NEXTAUTH_SECRET also works) or pass authJs({ secret }).";
+
+/** Auth.js v5's two session cookie spellings — the only names getToken reads. */
+const AUTH_JS_SESSION_COOKIES = ["authjs.session-token", "__Secure-authjs.session-token"] as const;
+
+/** next-auth v4's spellings: vendo cannot read these (v4 uses its own cookie
+    names AND its own JWE derivation), but seeing one means the host is a v4
+    install whose signed-in users will resolve as anonymous — worth naming
+    exactly once instead of failing silently forever. */
+const NEXT_AUTH_V4_SESSION_COOKIES = ["next-auth.session-token", "__Secure-next-auth.session-token"] as const;
+
+let warnedV4Cookie = false;
 
 /** Node's dynamic-import failure for a package that simply isn't installed. */
 function isAuthCoreNotFound(error: unknown): boolean {
@@ -80,10 +92,30 @@ export function authJs(options: HostAuthPresetOptions = {}): HostAuthPreset {
   const { secret, user, memberships, resolvePerson } = options;
 
   const sessionClaims = async (request: Request): Promise<JwtClaims | null> => {
+    // No Auth.js session cookie → no session, before any module/secret work: a
+    // misconfigured preset must not take down anonymous traffic (#872). A
+    // v4-named cookie gets one loud hint — v4 sessions are structurally
+    // unreadable here (different cookie names AND JWE derivation).
+    if (!AUTH_JS_SESSION_COOKIES.some((name) => cookieValue(request, name) !== undefined)) {
+      if (!warnedV4Cookie && NEXT_AUTH_V4_SESSION_COOKIES.some((name) => cookieValue(request, name) !== undefined)) {
+        warnedV4Cookie = true;
+        console.warn(
+          "[vendo] a next-auth v4 session cookie (next-auth.session-token) was seen, but authJs() speaks Auth.js v5 — "
+          + "v4 sessions resolve as anonymous. Upgrade next-auth to v5, or see docs/act-as-presets.md for the v4 posture.",
+        );
+      }
+      return null;
+    }
     const getToken = await loadGetToken();
     return getToken({
       req: request,
-      secret: await resolvePresetSecret(secret, "AUTH_SECRET", MISSING_SECRET_MESSAGE),
+      // AUTH_SECRET then next-auth v4's NEXTAUTH_SECRET — Auth.js's own
+      // legacy-name order; an explicit source stays authoritative.
+      secret: await resolvePresetSecret(
+        secret ?? (() => environment("AUTH_SECRET") ?? environment("NEXTAUTH_SECRET")),
+        undefined,
+        MISSING_SECRET_MESSAGE,
+      ),
       secureCookie: isSecureDeployment(),
     });
   };

--- a/packages/vendo/src/cli/doctor-codes.test.ts
+++ b/packages/vendo/src/cli/doctor-codes.test.ts
@@ -25,6 +25,7 @@ describe("doctor error-code registry", () => {
         "E-AUTH-005": "the actAs probe is unreachable",
         "E-AUTH-006": "the actAs probe cannot run while the dev server is down",
         "E-AUTH-007": "actAs is not configured",
+        "E-AUTH-008": "actAs is configured but declined the doctor probe's synthetic principal",
         "E-CFG-001": "a required .vendo/ config file is missing",
         "E-CFG-002": ".vendo/data/.gitignore is missing",
         "E-CLOUD-001": "VENDO_API_KEY is set but not usable",

--- a/packages/vendo/src/cli/doctor-codes.ts
+++ b/packages/vendo/src/cli/doctor-codes.ts
@@ -44,6 +44,7 @@ export const DOCTOR_ERROR_CODES = {
   "E-AUTH-005": "the actAs probe is unreachable",
   "E-AUTH-006": "the actAs probe cannot run while the dev server is down",
   "E-AUTH-007": "actAs is not configured",
+  "E-AUTH-008": "actAs is configured but declined the doctor probe's synthetic principal",
   "E-MCP-001": "MCP protected-resource metadata did not resolve",
   "E-MCP-002": "MCP authorization-server metadata did not resolve",
   "E-MCP-003": "the MCP server card did not parse",

--- a/packages/vendo/src/cli/doctor.test.ts
+++ b/packages/vendo/src/cli/doctor.test.ts
@@ -451,6 +451,64 @@ describe("vendo doctor", () => {
     expect(fetchImpl.mock.calls[4]?.[0]).toBe("http://localhost:3000/api/vendo/doctor/machines");
   });
 
+  it("a declined actAs mint warns E-AUTH-008 instead of claiming actAs is unconfigured (#873)", async () => {
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.endsWith("/status")) {
+        return Response.json({ posture: "unconfigured", version: CLI_VERSION, blocks: { store: true, sandbox: "cloud" } });
+      }
+      if (url.endsWith("/doctor/present")) return Response.json({ ok: true });
+      if (url.endsWith("/doctor/act-as")) {
+        return Response.json(
+          { ok: false, error: { code: "act-as-declined", message: "the host declined away execution for this action" } },
+          { status: 409 },
+        );
+      }
+      if (url.endsWith("/doctor/machines")) return Response.json({ scheduleCallerConfigured: false, machines: [] });
+      return Response.json({ error: { message: "unexpected probe" } }, { status: 404 });
+    });
+    const messages = output();
+    // A declined synthetic principal is a correctly wired host, not a failure:
+    // warn, keep exit 0.
+    expect(await doctor({
+      targetDir: await healthy(),
+      fetchImpl,
+      output: messages.sink,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    })).toBe(0);
+    const everything = [...messages.logs, ...messages.errors].join("\n");
+    expect(everything).toContain("declined the doctor's synthetic principal");
+    expect(everything).not.toContain("actAs is not configured");
+  });
+
+  it("E-AUTH-004 carries the wire's own failure message instead of a generic line (#873)", async () => {
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.endsWith("/status")) {
+        return Response.json({ posture: "unconfigured", version: CLI_VERSION, blocks: { store: true, sandbox: "cloud" } });
+      }
+      if (url.endsWith("/doctor/present")) return Response.json({ ok: true });
+      if (url.endsWith("/doctor/act-as")) {
+        return Response.json(
+          { ok: false, error: { code: "act-as-verification-failed", message: "actAs round-trip failed: the mint exploded with boom-detail" } },
+          { status: 409 },
+        );
+      }
+      if (url.endsWith("/doctor/machines")) return Response.json({ scheduleCallerConfigured: false, machines: [] });
+      return Response.json({ error: { message: "unexpected probe" } }, { status: 404 });
+    });
+    const messages = output();
+    expect(await doctor({
+      targetDir: await healthy(),
+      fetchImpl,
+      output: messages.sink,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    })).toBe(1);
+    const everything = [...messages.logs, ...messages.errors].join("\n");
+    expect(everything).toContain("actAs mint + host verification failed");
+    expect(everything).toContain("boom-detail");
+  });
+
   // execution-v2 Lane D — machine/schedule reporting (dev-only wire surface).
   it("reports machine-bearing apps and warns when schedules have no caller", async () => {
     const fetchImpl = successfulProbeFetch();
@@ -630,7 +688,7 @@ describe("vendo doctor", () => {
     })).toBe(0);
     expect(messages.logs).toEqual(expect.arrayContaining([
       "ok: present credentials reach the host API",
-      "ok: actAs mint + host verification live round-trip",
+      "ok: actAs mint round-trip verified by the composition's own principal resolver — host middleware is not exercised, real away calls still depend on it",
     ]));
     expect(host.actAs).toHaveBeenCalledOnce();
     const [syntheticPrincipal, syntheticGrant] = host.actAs.mock.calls[0] as [Principal, PermissionGrant];

--- a/packages/vendo/src/cli/doctor.ts
+++ b/packages/vendo/src/cli/doctor.ts
@@ -625,11 +625,20 @@ export async function runDoctor(options: DoctorOptions): Promise<number> {
       });
       const body = await probeBody(response);
       if (response.ok && body.ok === true) {
-        pass("auth/act-as", "actAs mint + host verification live round-trip");
+        // Honest scope: the probe verifies the mint against the composition's
+        // OWN resolver over the wire — it never exercises the host app's real
+        // session middleware (#874).
+        pass("auth/act-as", "actAs mint round-trip verified by the composition's own principal resolver — host middleware is not exercised, real away calls still depend on it");
       } else if (body.error?.code === "act-as-not-configured") {
         warn("auth/act-as", "E-AUTH-007", "actAs is not configured; pass createVendo({ actAs }) before enabling away host actions");
+      } else if (body.error?.code === "act-as-declined") {
+        // A configured seam that says no to the synthetic doctor principal is
+        // expected on hosts whose subject→user resolver only mints for real
+        // users — a warn with the wire's own reason, never "not configured".
+        warn("auth/act-as", "E-AUTH-008", `actAs is configured and declined the doctor's synthetic principal (${typeof body.error?.message === "string" ? body.error.message : "no detail"}) — expected when a subject→user resolver only mints for real users; real away runs depend on it accepting real subjects`);
       } else {
-        fail("auth/act-as", "E-AUTH-004", "actAs mint + host verification failed; check createVendo({ actAs }), its verifier middleware, and the host principal resolver");
+        const detail = typeof body.error?.message === "string" ? `: ${body.error.message}` : "; check createVendo({ actAs }), its verifier middleware, and the host principal resolver";
+        fail("auth/act-as", "E-AUTH-004", `actAs mint + host verification failed${detail}`);
       }
     } catch {
       fail("auth/act-as", "E-AUTH-005", `actAs probe is unreachable at ${statusUrl}/doctor/act-as; restart the dev server and check createVendo({ actAs })`);

--- a/packages/vendo/src/cli/init-auth.test.ts
+++ b/packages/vendo/src/cli/init-auth.test.ts
@@ -1,0 +1,83 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { detectAuthPreset, resolveScaffoldAuth } from "./init-auth.js";
+
+const roots: string[] = [];
+
+async function hostRoot(manifest: Record<string, unknown>): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "vendo-init-auth-"));
+  roots.push(root);
+  await writeFile(join(root, "package.json"), JSON.stringify(manifest), "utf8");
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+const COMPOSITION = "vendo/server.ts";
+
+describe("next-auth v4 advisory (#871)", () => {
+  it("detection carries a v4 advisory when next-auth resolves to major 4", async () => {
+    const root = await hostRoot({ dependencies: { "next-auth": "^4.24.11" } });
+    const detection = await detectAuthPreset(root);
+    expect(detection.wired?.preset).toBe("authJs");
+    expect(detection.wired?.advisory).toContain("next-auth v4");
+    expect(detection.wired?.advisory).toContain("^4.24.11");
+  });
+
+  it("v5 ranges carry no advisory", async () => {
+    const root = await hostRoot({ dependencies: { "next-auth": ">=5.0.0-beta.32" } });
+    const detection = await detectAuthPreset(root);
+    expect(detection.wired?.preset).toBe("authJs");
+    expect(detection.wired?.advisory).toBeUndefined();
+  });
+
+  it("an @auth/* match without next-auth carries no advisory", async () => {
+    const root = await hostRoot({ dependencies: { "@auth/prisma-adapter": "^2.7.4" } });
+    const detection = await detectAuthPreset(root);
+    expect(detection.wired?.preset).toBe("authJs");
+    expect(detection.wired?.advisory).toBeUndefined();
+  });
+
+  it("unparseable ranges (workspace:, latest) carry no advisory", async () => {
+    const root = await hostRoot({ dependencies: { "next-auth": "workspace:*" } });
+    const detection = await detectAuthPreset(root);
+    expect(detection.wired?.advisory).toBeUndefined();
+  });
+
+  it("the silent (non-interactive) path surfaces the advisory as advice", async () => {
+    const root = await hostRoot({ dependencies: { "next-auth": "~4.2.0" } });
+    const auth = await resolveScaffoldAuth(root, COMPOSITION, undefined, undefined, undefined);
+    expect(auth.wired?.preset).toBe("authJs");
+    expect(auth.advice).toContain("next-auth v4");
+  });
+
+  it("the --auth flag path surfaces the advisory as advice", async () => {
+    const root = await hostRoot({ dependencies: { "next-auth": "4.24.11" } });
+    const auth = await resolveScaffoldAuth(root, COMPOSITION, "authJs", undefined, undefined);
+    expect(auth.wired?.preset).toBe("authJs");
+    expect(auth.advice).toContain("next-auth v4");
+  });
+
+  it("the confirm-accept path surfaces the advisory and names v4 in the question", async () => {
+    const root = await hostRoot({ dependencies: { "next-auth": "^4.24.11" } });
+    let question = "";
+    const auth = await resolveScaffoldAuth(root, COMPOSITION, undefined, async (asked) => {
+      question = asked;
+      return true;
+    }, undefined);
+    expect(auth.wired?.preset).toBe("authJs");
+    expect(question).toContain("next-auth v4");
+    expect(auth.advice).toContain("next-auth v4");
+  });
+
+  it("a v5 host's silent path keeps advice null when wired", async () => {
+    const root = await hostRoot({ dependencies: { "next-auth": "5.0.0" } });
+    const auth = await resolveScaffoldAuth(root, COMPOSITION, undefined, undefined, undefined);
+    expect(auth.wired?.preset).toBe("authJs");
+    expect(auth.advice).toBeNull();
+  });
+});

--- a/packages/vendo/src/cli/init-auth.ts
+++ b/packages/vendo/src/cli/init-auth.ts
@@ -25,6 +25,9 @@ export interface AuthMatch {
   /** How the family was chosen: detection (default) cites the dependency it
       found; a picker pick says so honestly — nothing was detected. */
   source?: "picked";
+  /** A version-shaped caveat the wiring paths must surface (today: next-auth
+      v4, whose sessions the v5-speaking authJs() preset cannot read). */
+  advisory?: string;
 }
 
 export interface AuthDetection {
@@ -41,23 +44,48 @@ export const AUTH_FAMILIES: ReadonlyArray<{ preset: AuthPresetName; test: (depen
   { preset: "auth0", test: (dependency) => dependency.startsWith("@auth0/") },
 ];
 
+/** The leading major of a semver-ish range ("^4.24.11" → 4, ">=5.0.0-beta" →
+    5); undefined for ranges that name no version (workspace:, catalog:,
+    latest, tags) — no advisory beats a wrong one. */
+function rangeMajor(range: string | undefined): number | undefined {
+  if (range === undefined) return undefined;
+  const match = /^\s*[~^]?[><=\s]*v?(\d+)/.exec(range);
+  return match === null ? undefined : Number(match[1]);
+}
+
+/** The one caveat detection can attach today: next-auth v4 wired to the
+    v5-speaking authJs() preset. Wiring proceeds (the composition is correct
+    for a future v5 upgrade) but the consequences are named, not discovered. */
+function nextAuthV4Advisory(range: string): string {
+  return `Auth: next-auth v4 detected (${range}) — authJs() speaks Auth.js v5. On v4, signed-in users ` +
+    "resolve as anonymous (v4 session cookies are not readable) and away runs cannot be verified by the " +
+    "host. Wiring authJs() anyway for a future v5 upgrade; to stay anonymous instead, pass --auth none. " +
+    "Details: docs/act-as-presets.md.";
+}
+
 /** Silent auth-preset detection from the host's package.json (zero-question
     contract): one unambiguous family gets wired; none or several stay
     anonymous and become one advisory line (detection-as-advice). */
 export async function detectAuthPreset(root: string): Promise<AuthDetection> {
   let dependencies: string[] = [];
+  let versions: Record<string, string> = {};
   try {
     const manifest = JSON.parse((await readOptional(join(root, "package.json"))) ?? "{}") as {
       dependencies?: Record<string, string>;
       devDependencies?: Record<string, string>;
     };
-    dependencies = Object.keys({ ...manifest.dependencies, ...manifest.devDependencies });
+    versions = { ...manifest.devDependencies, ...manifest.dependencies };
+    dependencies = Object.keys(versions);
   } catch {
     // No readable manifest — nothing to detect; anonymous is the safe default.
   }
   const matches = AUTH_FAMILIES.flatMap(({ preset, test }) => {
     const dependency = dependencies.find(test);
-    return dependency === undefined ? [] : [{ preset, dependency }];
+    if (dependency === undefined) return [];
+    const advisory = preset === "authJs" && dependency === "next-auth" && rangeMajor(versions[dependency]) === 4
+      ? nextAuthV4Advisory(versions[dependency]!)
+      : undefined;
+    return [{ preset, dependency, ...(advisory === undefined ? {} : { advisory }) }];
   });
   return { wired: matches.length === 1 ? matches[0]! : null, matches };
 }
@@ -124,7 +152,7 @@ export async function pickScaffoldAuth(
     };
   }
   const detectedMatch = detected.find((match) => match.preset === picked);
-  if (detectedMatch !== undefined) return { wired: detectedMatch, advice: null };
+  if (detectedMatch !== undefined) return { wired: detectedMatch, advice: detectedMatch.advisory ?? null };
   if (picked in AUTH_FAMILY_INFO) {
     // Picked without its SDK in package.json: wire it exactly like a
     // detection-accept, plus one install hint.
@@ -165,14 +193,17 @@ export async function resolveScaffoldAuth(
     return pickScaffoldAuth(detection, compositionPath, async () => authAnswer);
   }
   if (confirmAuth === undefined) {
-    return { wired: detection.wired, advice: authAdvisory(detection, compositionPath) };
+    return {
+      wired: detection.wired,
+      advice: detection.wired?.advisory ?? authAdvisory(detection, compositionPath),
+    };
   }
   if (detection.wired !== null) {
     const accepted = await confirmAuth(
-      `Detected ${detection.wired.dependency} — wire auth: ${detection.wired.preset}()?`,
+      `Detected ${detection.wired.dependency}${detection.wired.advisory === undefined ? "" : " (next-auth v4 — see the advisory below)"} — wire auth: ${detection.wired.preset}()?`,
       true,
     );
-    if (accepted) return { wired: detection.wired, advice: null };
+    if (accepted) return { wired: detection.wired, advice: detection.wired.advisory ?? null };
     if (selectAuth !== undefined) return pickScaffoldAuth(detection, compositionPath, selectAuth);
     return { wired: null, advice: declinedAuthAdvisory(detection.wired, compositionPath) };
   }

--- a/packages/vendo/src/server.test.ts
+++ b/packages/vendo/src/server.test.ts
@@ -1930,6 +1930,37 @@ describe("09 §2.1 — host-identity presets (auth)", () => {
     const probe = await vendo.handler(request("POST", "/doctor/act-as", {}));
     expect(await probe.json()).toEqual({ ok: true });
   });
+
+  it("a DECLINED actAs mint answers act-as-declined, not act-as-not-configured (#873)", async () => {
+    vi.stubEnv("AUTH_SECRET", authJsSecret);
+    const store = await tempStore("vendo-auth-actas-declined-");
+    // A subject→user resolver backed by a real user table declines the doctor's
+    // synthetic subject — a correctly wired host, not a missing seam.
+    const vendo = createVendo({
+      model: {} as LanguageModel,
+      store,
+      auth: authJs({ user: async () => null }),
+    });
+    const probe = await vendo.handler(request("POST", "/doctor/act-as", {}));
+    expect(probe.status).toBe(409);
+    const body = await probe.json() as { ok: boolean; error?: { code?: string; message?: string } };
+    expect(body.ok).toBe(false);
+    expect(body.error?.code).toBe("act-as-declined");
+    expect(body.error?.message).toContain("declined");
+  });
+
+  it("an ABSENT actAs seam still answers act-as-not-configured (#873)", async () => {
+    const store = await tempStore("vendo-auth-actas-absent-");
+    const vendo = createVendo({
+      model: {} as LanguageModel,
+      store,
+      auth: { principal: async () => null },
+    });
+    const probe = await vendo.handler(request("POST", "/doctor/act-as", {}));
+    expect(probe.status).toBe(501);
+    const body = await probe.json() as { ok: boolean; error?: { code?: string } };
+    expect(body.error?.code).toBe("act-as-not-configured");
+  });
 });
 
 describe("XCUT-3 — umbrella runtime store surface", () => {

--- a/packages/vendo/src/wire/context.principal-errors.test.ts
+++ b/packages/vendo/src/wire/context.principal-errors.test.ts
@@ -1,0 +1,60 @@
+import { VendoError, type Principal } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { createContextResolver } from "./context.js";
+import type { WireDeps } from "./shared.js";
+
+/** #872 — a throwing principal resolver must surface its own actionable
+    message (the presets write those to be shown), not vanish into the
+    catch-all's "Internal Vendo error". */
+
+const request = (): Request => new Request("https://host.test/api/vendo/connections");
+
+const depsFor = (principal: () => Promise<Principal | null>): WireDeps => ({
+  principal,
+  trustedBaseIsHttps: false,
+  sessionId: "sess_wire",
+  sessions: { ttlMs: 1000, sweepIntervalMs: 1000, now: () => 0 },
+  sessionStore: {
+    async register() { /* no registry needed for these cases */ },
+    async adopt() { return null; },
+  },
+} as unknown as WireDeps);
+
+describe("#872 — principal-resolver failures are named", () => {
+  it("wraps a thrown Error into a VendoError carrying the resolver's message", async () => {
+    const resolve = createContextResolver(
+      depsFor(async () => {
+        throw new Error("authJs() has no session secret: set AUTH_SECRET or pass authJs({ secret }).");
+      }),
+      {},
+    );
+    const failure = await resolve(request(), "chat").then(
+      () => null,
+      (error: unknown) => error,
+    );
+    expect(failure).toBeInstanceOf(VendoError);
+    expect((failure as VendoError).message).toContain("principal resolution failed");
+    expect((failure as VendoError).message).toContain("authJs() has no session secret");
+  });
+
+  it("passes a resolver-thrown VendoError through unchanged", async () => {
+    const original = new VendoError("blocked", "the host says no");
+    const resolve = createContextResolver(
+      depsFor(async () => {
+        throw original;
+      }),
+      {},
+    );
+    await expect(resolve(request(), "chat")).rejects.toBe(original);
+  });
+
+  it("non-Error throws still produce a named VendoError", async () => {
+    const resolve = createContextResolver(
+      depsFor(async () => {
+        throw "string failure"; // eslint-disable-line no-throw-literal -- the point of the case
+      }),
+      {},
+    );
+    await expect(resolve(request(), "chat")).rejects.toThrow(/principal resolution failed: string failure/);
+  });
+});

--- a/packages/vendo/src/wire/context.ts
+++ b/packages/vendo/src/wire/context.ts
@@ -138,7 +138,19 @@ export function createContextResolver(
   anon: AnonSession,
 ): (req: Request, venue: RunContext["venue"]) => Promise<RunContext> {
   return async (req, venue) => {
-    const resolved = await deps.principal(req);
+    let resolved: Principal | null;
+    try {
+      resolved = await deps.principal(req);
+    } catch (error) {
+      if (error instanceof VendoError) throw error;
+      // #872 — the resolver's own message is actionable host-facing copy (the
+      // presets write it to be shown); the catch-all's generic "Internal Vendo
+      // error" cost a debugging session per config mistake.
+      throw new VendoError(
+        "not-implemented",
+        `principal resolution failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
     let principal: Principal;
     // Host-resolved principals keep the process-wide fallback sessionId; only
     // anonymous requests fall back to their per-client cookie id (below).

--- a/packages/vendo/src/wire/doctor.ts
+++ b/packages/vendo/src/wire/doctor.ts
@@ -110,7 +110,19 @@ export const doctorRoutes: RouteEntry[] = [
   route("POST", "/doctor/act-as", async ({ deps }) => {
     const outcome = await deps.doctor.actAs();
     if (doctorProbeOk(outcome)) return json({ ok: true });
+    // The probe executor calls the actions registry directly (no guard
+    // binding), so the actAs disposition passthrough survives on the outcome —
+    // the one discriminator between "no seam" and "a seam that said no": a
+    // configured host whose subject→user resolver declines the synthetic
+    // doctor principal must not be told actAs is unconfigured (#873).
+    const disposition = (outcome as { actAs?: string }).actAs;
     if (outcome.status === "error" && outcome.error.code === "not-implemented") {
+      if (disposition === "declined") {
+        return json({
+          ok: false,
+          error: { code: "act-as-declined", message: outcome.error.message },
+        }, 409);
+      }
       return json({
         ok: false,
         error: {
@@ -123,7 +135,12 @@ export const doctorRoutes: RouteEntry[] = [
       ok: false,
       error: {
         code: "act-as-verification-failed",
-        message: "actAs returned no usable AuthMaterial, or the host API did not accept it. Check the matching verifier middleware and principal resolver.",
+        // The registry's own error text is the actionable half (it can name a
+        // missing module or the mint failure); never replace it with a
+        // generic line (#873).
+        message: outcome.status === "error"
+          ? `actAs round-trip failed: ${outcome.error.message}`
+          : "actAs returned no usable AuthMaterial, or the composition's principal resolver did not accept it. Check the actAs seam and principal resolver.",
       },
     }, 409);
   }),


### PR DESCRIPTION
﻿## What

next-auth v4 hosts currently break silently: authJs() only reads AUTH_SECRET, init wires the v5-only preset onto v4 hosts without a word, a misconfigured preset 501s every request including anonymous ones, and doctor reports a green "host verification" that never touched the host. Found on a real-host install eval (Linkwarden: yarn-4 monorepo, next-auth v4). Fixes #870, #871, #872, #873, #874.

This PR makes v4 fail loud and correct (it does NOT add v4 session support — that design decision is tracked separately):

- **authJs secret**: zero-config resolves `AUTH_SECRET` then `NEXTAUTH_SECRET` (Auth.js's own legacy order), both halves; an explicit secret source that declines never falls through.
- **Lazy-until-cookie sessions**: no Auth.js session cookie → null before any module/secret work, so a misconfigured preset can no longer take down anonymous traffic; a v4-named cookie logs one hint naming the posture.
- **init advisory**: a next-auth major-4 host still wires authJs() but every path (silent, `--auth`, confirm) prints what v4 cannot do and the `--auth none` alternative.
- **Wire**: principal-resolver throws surface their own actionable message instead of a generic `Internal Vendo error` 501.
- **Doctor**: new `act-as-declined` wire answer + `E-AUTH-008` warning distinguish a configured-but-declining seam from an absent one; `E-AUTH-004` carries the wire's failure reason; the act-as pass message states its honest scope (composition-side verification only).

## How

Six commits, one concern each, tests alongside (TDD). Key files: `packages/actions/src/presets/auth-js.ts`, `packages/vendo/src/auth-presets/auth-js.ts`, `packages/vendo/src/cli/init-auth.ts`, `packages/vendo/src/wire/context.ts`, `packages/vendo/src/wire/doctor.ts`, `packages/vendo/src/cli/doctor{,-codes}.ts`. The declined/absent discriminator rides the existing actAs disposition passthrough (the probe executor bypasses guard.bind, so no core contract changes). Docs updated in-change: `docs/act-as-presets.md`, `docs-site/connect/act-as-presets.mdx`, `docs-site/agents/{verify,host-auth}.mdx`. Patch changeset included.

## Tests & review

New/updated suites green: `auth-presets/auth-js` (28), `presets/auth-js` (8), `cli/init-auth` (8, new), `wire/context.principal-errors` (3, new), `cli/doctor` + `doctor-codes` (81), server act-as branches (2 new). Typecheck, dependency-guard, and the workerd portability gate green locally. Field-verified on the originating v4 host: the 973-request 501 storm becomes clean 200s, the one-time v4 hint fires, doctor honest end-to-end. Local Windows caveat: a set of pre-existing environment test failures (POSIX file modes, symlinks, CRLF-sensitive byte comparisons) reproduce identically on unmodified main — CI is authoritative.

## Pending

None blocking. Follow-up design question tracked on the issues: a real v4 mint mode vs a documented hard v5-only gate (#870 discussion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
