### PR TITLE
docs(docs-site): one on-ramp page for a company's own in-product agent

### DIFF
--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -57,6 +57,7 @@
         "group": "Bring your own agent",
         "tag": "Recommended",
         "pages": [
+          "existing-agents/your-agent",
           "existing-agents/index",
           "existing-agents/ai-sdk",
           "existing-agents/mastra",

--- a/docs-site/existing-agents/your-agent.mdx
+++ b/docs-site/existing-agents/your-agent.mdx
@@ -1,0 +1,344 @@
+---
+title: "Add Vendo to your product's agent"
+sidebarTitle: "Your product's agent"
+description: "The on-ramp for a product that already ships an agent: vendo init, one fork (in-process tools or the MCP door), the system-prompt guidance that teaches your agent when to build UI, and the slot that decides where the screen lands."
+---
+
+Your user asks your agent for something. A real, live view appears in your
+product, on your brand, reading your own data. Your agent keeps its loop, its
+model, its tools, its MCP connectors, and its chat UI.
+
+<Frame caption="A generated spending breakdown filling a host's own page slot. The figures come from the host's endpoint at render time — nothing in the request was a number the agent computed.">
+  <img src="/images/existing-agents/mcp-walk-slot-filled.png" alt="A product dashboard slot showing a generated spending breakdown with a donut chart and a category table of live amounts" />
+</Frame>
+
+## 1. Install
+
+```bash
+npm install @vendoai/vendo
+npx vendo init
+```
+
+Init detects your framework and auth from `package.json` and writes:
+
+| | |
+| --- | --- |
+| the composition | `app/api/vendo/[...vendo]/route.ts` on Next.js (`vendo/server.ts` on Express or `--framework custom`), holding `createVendo()` |
+| `.vendo/tools.json` | your API surface read into tool definitions from your routes and OpenAPI spec, each with a schema, a risk grade, and its dispatch binding. `overrides.json` beside it is yours, for renaming and curating |
+| `.vendo/theme.json` | your brand, scanned out of your app |
+| `vendo/vendo-root.tsx` | a `"use client"` wrapper establishing the provider every Vendo surface reads through |
+| `.env.example`, `predev`/`prebuild` | `VENDO_BASE_URL`, and `vendo sync` so `tools.json` tracks your API |
+
+Init never edits a file you authored, so one paste is yours:
+
+```tsx
+// app/layout.tsx
+import { VendoRoot } from "../vendo/vendo-root";
+
+<VendoRoot>{children}</VendoRoot>
+```
+
+The generated wrapper also mounts `<VendoOverlay />`, Vendo's own launcher pill.
+Delete that line if your agent is the only conversation in your product — but
+keep the provider, or the slots and embeds below have no wire to read.
+
+Full inventory: [vendo init](/connect/vendo-init). Caller identity comes from
+your auth, through `principal` or an [auth preset](/connect/act-as-presets).
+
+## 2. Pick how your agent reaches Vendo
+
+One question: **can your agent `import` the package?** Node or TypeScript in the
+same app as `createVendo` → Path A. Separate service, another language, or you
+already standardize on MCP connectors → Path B.
+
+### Path A — tools in your agent
+
+```ts
+// app/api/chat/route.ts — your existing route, one spread
+import { vendoTools } from "@vendoai/vendo/ai-sdk";
+import { vendo } from "@/lib/vendo";
+
+const result = streamText({
+  model,
+  messages,
+  tools: { ...yourTools, ...(await vendoTools(vendo, { principal })) },
+});
+```
+
+Built per request: tool execution needs a principal-scoped context, so pass the
+caller your auth already resolved. On Mastra, `vendoMastraTools(vendo)` from
+`@vendoai/vendo/mastra` is the same pack in `createTool` shape, with the
+principal on Mastra's `RequestContext`. Detail:
+[AI SDK](/existing-agents/ai-sdk) · [Mastra](/existing-agents/mastra).
+
+### Path B — Vendo as an MCP connector
+
+Three things, none of them scaffolded by init:
+
+```ts
+// lib/vendo.ts
+export const vendo = createVendo({
+  model,
+  principal: resolvePrincipal,
+  mcp: true,
+  oauth, // a HostOAuthAdapter: session() + principal()
+});
+```
+
+```ts
+// app/.well-known/[...vendo]/route.ts — origin-root discovery
+import { wellKnownVendoHandler } from "@vendoai/vendo/server";
+import { vendo } from "@/lib/vendo";
+
+export const { GET, POST } = wellKnownVendoHandler(vendo);
+```
+
+Your existing catch-all already serves the transport. Your agent then adds one
+URL: `https://your-app.example.com/api/vendo/mcp`. The OAuth is nobody's code.
+Adapter contract, consent page, and tool-menu curation:
+[Bring your own agent over MCP](/existing-agents/mcp) ·
+[door internals](/capabilities/mcp).
+
+### The fork, side by side
+
+Identical either way: the same tools, the same guard-bound registry (policy,
+approvals, audit), the same receipt of words rather than pixels, the same slots,
+the same `.vendo/theme.json`.
+
+| Differs | Path A (in process) | Path B (MCP door) |
+| --- | --- | --- |
+| Setup | one spread | `mcp: true`, OAuth adapter, discovery route |
+| Identity | the `principal` you pass per request | the OAuth'd subject, from `oauth.principal()` |
+| Runtime | Node/TS, same process as `createVendo` | any language, any host |
+| Clients | your agent | your agent, plus any MCP client you point at it |
+| Extra tools | `vendo_delegate` | `vendo_apps_pin` · `vendo_apps_unpin` · `vendo_apps_open` · the saved-apps viewer |
+| `vendo_make` takes | `request` · `context` · `app` | `request` · `context` · `app` · `slot` |
+
+<Warning>
+  Read the last two rows twice. The in-process pack **does not carry** `slot` or
+  any `vendo_apps_*` tool — in-app interaction rides the wire, not your loop.
+  Placing a view is still fully available on Path A; you do it from your own code
+  with the app id, in [step 5](#5-put-it-where-you-want-it).
+</Warning>
+
+## 3. Teach your agent when to use it
+
+A tool your agent never reaches for is not a feature. Paste this into your
+system prompt, beside whatever you already say about your other tools.
+
+```text
+## Making the person a screen
+
+You have `vendo_make`. It puts a real, live view in front of the person, and it
+is the only way you can do that. You never build UI yourself.
+
+USE IT when the honest answer is a shape, not a sentence: more than a handful of
+rows, a comparison or trend or breakdown, something they will come back to
+("track", "every week"), something they need to act on — a screen carries
+buttons; your message cannot.
+
+ANSWER IN WORDS when the answer IS words: one number, one status, one fact, a
+yes or no, an explanation. A screen for "what's my balance" is worse than saying
+the balance.
+
+`request` is prose — what you would say to a designer sitting next to you.
+- Describe the want: "the last three months of spending, broken down by
+  category, with a way to jump into any month"
+- No component names, no layout grids, no JSON, no field names you guessed at
+- No fonts, colors, or branding: it inherits the product's own
+- Never paste numbers you looked up or computed ("Total: $4,210"). The screen
+  binds live data itself, and hardcoded figures are rejected as invented
+
+`context`: background the product cannot see — what they told you earlier, a
+constraint they mentioned, which of several things they meant. A sentence or two.
+
+`app`: ONLY to change one view that already exists, by id or by its name exactly
+as they said it. Leave it out and the product decides whether to continue the
+last one or start something new, which is usually right.
+
+WHAT COMES BACK is a receipt: id, title, status, and `say` — one line in the
+person's voice. Say `say`, close to verbatim. That is the whole report. You never
+get the screen; it goes from the server straight to their page, on a channel you
+are not on. So:
+- NEVER wait for it. Nothing to poll, nothing to check.
+- NEVER describe it. You have not seen it. No sections, charts, colors, or
+  buttons, and never tell them what to click.
+- Never paste a link or an id unless they asked.
+- status "failed": try once more on the same `app`, narrower, then stop and say
+  so plainly.
+- status "building": honest, not an error. Say the line and move on.
+```
+
+Add this second block **only on Path B**. Teaching an agent about a tool it does
+not have is how you get an invented tool call:
+
+```text
+WHERE IT LANDS
+By default, the person's own list of views.
+
+`slot`: ONLY when they name a place in the product AND you have that place's
+exact id — they said it, or an earlier answer carried it. Slot ids belong to the
+product, not to you: NEVER invent one. A made-up id puts the screen where nobody
+is looking, and that does not look like an error. No id, no `slot`.
+
+MOVING ONE THEY ALREADY HAVE
+`vendo_apps_pin` puts an existing view into a slot; `vendo_apps_unpin` clears
+one. Both are writes and can stop for the person's approval.
+- Only on an explicit instruction ("put the renewals radar on my dashboard"),
+  never on something you inferred.
+- Pinning replaces: a slot holds one view. If they did not name the slot, ask.
+- `slot` on `vendo_make` is for something NEW; to move an existing view, pin it.
+```
+
+Source, shipped to Claude Code as a skill:
+[`examples/claude-code-plugin/skills/make-a-screen`](https://github.com/runvendo/vendo/tree/main/examples/claude-code-plugin/skills/make-a-screen).
+
+## 4. Your first screen
+
+```json
+{ "request": "A breakdown of this month's spending by category, largest first" }
+```
+
+The view builds on your live data, lands in the person's own list of views, and
+your agent gets exactly this:
+
+```json
+{
+  "id": "app_790892b0…",
+  "title": "August Spending",
+  "status": "ready",
+  "say": "August Spending is on your screen."
+}
+```
+
+**Four fields of words, never pixels — the whole contract, not a summary of a
+richer one.** The earlier version handed the agent the whole document, and a
+model handed a tree eventually talks about the tree: narrating a screen it has
+not seen, to someone looking at a different one. So the receipt is deliberately
+unusable for narration. `status` is `"ready"`, `"building"`, or `"failed"`, and
+`"building"` is honest — an escalated build outlives the call and there is
+nothing to poll. `"failed"` means the checks floor rejected a view whose
+bindings claim data your host does not return, or whose props do not type-check;
+nothing is painted.
+
+In process the call returns fast: the first streamed view part carries the app's
+permanent id, so your loop gets a `vendo/app-ref@1`
+([envelope contract](/existing-agents/embeds)) while the build streams over the
+wire.
+
+## 5. Put it where you want it
+
+A slot is your markup:
+
+```tsx
+import { VendoSlot } from "@vendoai/ui/chrome";
+
+<VendoSlot id="home-hero">
+  <YourOriginalCard />
+</VendoSlot>
+```
+
+Add `@vendoai/ui` as a direct dependency. Empty, the slot renders your children
+untouched — no wrapper, so inline one anywhere. Filled: build skeleton, then the
+live view, then a failure with a retry. Never a blank hole. One view per slot per
+person; a second one evicts the first.
+
+**Path B** — your agent aims at a slot by id:
+
+```json
+{ "request": "This month's spending by category, largest first", "slot": "home-hero" }
+```
+
+**Path A** — you place it, using the `appId` from the `vendo/app-ref@1` envelope
+your loop already received:
+
+```tsx
+<VendoSlot id={block.id} appId={block.vendoAppId} />
+```
+
+<Note>
+  **Building a document or block editor? That is this shape.** One `<VendoSlot>`
+  per block, with the block's own id as the slot id. A generated view then lives
+  in a block like any other: it moves when the block moves, it is scoped to the
+  person with that document open, and your editor keeps owning layout.
+</Note>
+
+Slot ids are yours, and nothing enumerates them for an agent at the door — tell
+the agent the id, or let the person say it. That is why step 3 forbids inventing
+one.
+
+## 6. Move a screen after the fact
+
+"Put that on my dashboard" about a view they already have is `vendo_apps_pin`,
+which answers with what it displaced so your agent can say what moved:
+
+```json
+// in:  { "app": "app_5a3948bc…", "slot": "home-hero" }
+{ "app": "app_5a3948bc…", "slot": "home-hero", "evicted": "app_c0d6b562…" }
+```
+
+`vendo_apps_unpin` clears the slot; the view itself is untouched. Both are
+writes — under a `cautious` policy the first one parks in your approvals queue,
+where the person sees the tool, the view, the slot, and the exact arguments
+before anything moves. Routes: [HTTP routes](/reference/http-routes).
+
+<Warning>
+  Both pin tools reach an agent over the MCP door only. Do not put
+  `vendo_apps_pin` in a Path A system prompt — move a view there by writing the
+  app id into your own record and re-rendering the slot.
+</Warning>
+
+Inside your own chat, your agent's Vendo tool outputs render inline:
+
+```tsx
+import { VendoProvider, VendoToolResult } from "@vendoai/vendo/react";
+
+<VendoProvider>
+  {/* for each finished tool part: */}
+  <VendoToolResult output={part.output} />
+</VendoProvider>
+```
+
+`<VendoToolResult>` dispatches any `vendo_*` output — a live view for an app ref,
+an approve/deny card for an approval ref, nothing for plain data. You never
+branch on envelope type ([Embeds and envelopes](/existing-agents/embeds)).
+
+## 7. The perimeter
+
+- **Every call runs as the signed-in person**, through the same guard-bound
+  registry Vendo's own surfaces use — policy, approvals, audit. No second
+  authority path.
+- **No duplicate of your API credentials.** Host actions reach your own routes
+  through the `actAs` seam, never by forwarding an agent's bearer token; without
+  a grant the call fails closed.
+- **Writes can require the person.** `.vendo/policy.json` decides where that line
+  sits; a parked call waits in **your** queue while the agent moves on.
+- **Generated views render jailed** — in an iframe with `connect-src 'none'` by
+  default, so a tree-only view reaches no host tools and performs no egress.
+  Interactions ride the wire back through the guard, never your loop.
+
+[Tools and safety](/concepts/tools-and-safety) ·
+[How generated UI works](/concepts/generated-ui).
+
+## Next
+
+<CardGroup cols={2}>
+  <Card title="The MCP door" href="/existing-agents/mcp">
+    Path B end to end: the OAuth dance, the consent page, the connect page for
+    your users, and a screenshot walkthrough.
+  </Card>
+  <Card title="Door internals" href="/capabilities/mcp">
+    The `HostOAuthAdapter` contract, `surfaces.mcp` curation, federation,
+    revocation.
+  </Card>
+  <Card title="Quickstart: AI SDK / Mastra" href="/existing-agents/ai-sdk">
+    Path A wired end to end with the real diff — and
+    [the same in Mastra](/existing-agents/mastra).
+  </Card>
+  <Card title="Embeds and envelopes" href="/existing-agents/embeds">
+    The envelope contract and the three components that render it.
+  </Card>
+  <Card title="Register your components" href="/connect/host-components">
+    So generated views render your branded UI, not generic primitives.
+  </Card>
+</CardGroup>

--- a/packages/vendo/src/your-agent-docs.docs.test.ts
+++ b/packages/vendo/src/your-agent-docs.docs.test.ts
@@ -1,0 +1,240 @@
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Docs-rot gate for the BYO on-ramp page ("Add Vendo to your product's agent").
+ * Same shape as mcp-byo-docs.docs.test.ts: the docs live in this repo, so this
+ * is a plain test against the sources. It reads files and nothing else — no
+ * package import, so it runs without a build.
+ *
+ * What it holds, and why each claim is load-bearing:
+ *  1. the page is published and every nav entry still resolves, with this page
+ *     FIRST in its group (it is the on-ramp);
+ *  2. every tool name the page puts in a reader's system prompt really exists
+ *     in the registry the page is describing;
+ *  3. `vendo_make`'s four documented arguments are its real schema properties,
+ *     and the page's asymmetry claim — that the IN-PROCESS pack carries no
+ *     `slot` and no `vendo_apps_*` — matches pack.ts. That asymmetry is the one
+ *     thing a reader can silently get wrong (an invented tool call), so it is
+ *     pinned from both sides;
+ *  4. the receipt really has exactly the four fields the page calls a law;
+ *  5. every component the page tells a reader to import is really exported from
+ *     the entry point the page names;
+ *  6. the page never mentions `vendo doctor` (deliberately out of this on-ramp);
+ *  7. its links resolve.
+ */
+
+const REPO_ROOT = new URL("../../../", import.meta.url);
+const read = (path: string): Promise<string> => readFile(new URL(path, REPO_ROOT), "utf8");
+const readJson = async <T>(path: string): Promise<T> => JSON.parse(await read(path)) as T;
+
+const PAGE = "docs-site/existing-agents/your-agent.mdx";
+const NAV_ENTRY = "existing-agents/your-agent";
+const AGENT_TOOLS = "packages/apps/src/agent-tools.ts";
+const PACK = "packages/vendo/src/pack.ts";
+
+interface DocsJson {
+  navigation: { groups: { group: string; pages: string[] }[] };
+}
+
+/** A docs.json page id resolves as `<id>.mdx` or `<id>/index.mdx`. */
+const pageExists = (id: string): boolean =>
+  existsSync(new URL(`docs-site/${id}.mdx`, REPO_ROOT)) ||
+  existsSync(new URL(`docs-site/${id}/index.mdx`, REPO_ROOT));
+
+describe("the BYO on-ramp page is published", () => {
+  it("exists with Mintlify frontmatter and a short sidebar title", async () => {
+    expect(existsSync(new URL(PAGE, REPO_ROOT)), `${PAGE} must exist`).toBe(true);
+    const text = await read(PAGE);
+    expect(text.startsWith("---\n")).toBe(true);
+    expect(text).toMatch(/^title: "Add Vendo to your product's agent"$/m);
+    expect(text).toMatch(/^sidebarTitle: "/m);
+    expect(text).toMatch(/^description: "/m);
+  });
+
+  it("is the FIRST entry in the Bring-your-own-agent group", async () => {
+    const docs = await readJson<DocsJson>("docs-site/docs.json");
+    const group = docs.navigation.groups.find((entry) => entry.group === "Bring your own agent");
+    expect(group, "the 'Bring your own agent' group must exist").toBeDefined();
+    expect(group?.pages[0]).toBe(NAV_ENTRY);
+  });
+
+  it("leaves no nav entry pointing at a file that does not exist", async () => {
+    const docs = await readJson<DocsJson>("docs-site/docs.json");
+    const missing = docs.navigation.groups
+      .flatMap((group) => group.pages)
+      .filter((id) => !pageExists(id));
+    expect(missing).toEqual([]);
+  });
+
+  it("links only to pages that exist", async () => {
+    const text = await read(PAGE);
+    const targets = [...text.matchAll(/\]\((\/[^)\s#]*)(#[^)\s]*)?\)/g)].map((match) => match[1]!);
+    const broken = [...new Set(targets)].filter((target) => !pageExists(target.replace(/^\//, "")));
+    expect(broken).toEqual([]);
+  });
+});
+
+describe("every tool the page names really exists", () => {
+  /** The page puts these in a reader's SYSTEM PROMPT. A name that drifted here
+   *  teaches their agent to call a tool that does not answer. */
+  it.each(["vendo_make", "vendo_apps_pin", "vendo_apps_unpin", "vendo_apps_open"])(
+    "%s is declared in the apps agent-tool registry",
+    async (tool) => {
+      const page = await read(PAGE);
+      expect(page, `${PAGE} must name ${tool}`).toContain(tool);
+      const source = await read(AGENT_TOOLS);
+      // Either the literal name or core's constant for it.
+      const constant = `VENDO_${tool.slice("vendo_".length).toUpperCase()}_TOOL`;
+      expect(
+        source.includes(`name: "${tool}"`) || source.includes(`name: ${constant}`),
+        `${AGENT_TOOLS} must declare ${tool}`,
+      ).toBe(true);
+    },
+  );
+
+  it("vendo_make is core's own constant, not a docs-only alias", async () => {
+    expect(await read("packages/core/src/tools.ts")).toContain('export const VENDO_MAKE_TOOL = "vendo_make"');
+  });
+
+  it("vendo_delegate, which the page offers only on the in-process path, is the pack's", async () => {
+    const page = await read(PAGE);
+    expect(page).toContain("vendo_delegate");
+    expect(await read("packages/vendo/src/tool-pack.ts")).toContain('VENDO_DELEGATE_TOOL = "vendo_delegate"');
+  });
+});
+
+describe("the page's argument tables match the real schemas", () => {
+  /** The door serves the bound registry's descriptors verbatim, so THIS schema
+   *  is what an outside agent sees — all four arguments the page documents. */
+  it("the registry's vendo_make takes request, context, app, and slot", async () => {
+    const source = await read(AGENT_TOOLS);
+    const start = source.indexOf("name: VENDO_MAKE_TOOL");
+    expect(start, "the make descriptor must still exist").toBeGreaterThan(-1);
+    const schema = source.slice(start, source.indexOf('name: "vendo_apps_rebase_pin"', start));
+    for (const argument of ["request", "context", "app", "slot"]) {
+      expect(schema, `vendo_make must accept \`${argument}\``).toMatch(
+        new RegExp(`\\b${argument}: \\{ type: "string"`),
+      );
+    }
+    expect(schema).toContain('required: ["request"]');
+    const page = await read(PAGE);
+    for (const argument of ["request", "context", "app", "slot"]) {
+      expect(page).toContain(`\`${argument}\``);
+    }
+  });
+
+  /** The one asymmetry the page warns about twice. If the in-process pack ever
+   *  gains `slot` or the pin tools, the page's warnings become the lie. */
+  it("the IN-PROCESS pack's vendo_make still has no slot", async () => {
+    const source = await read(PACK);
+    const start = source.indexOf("function makeAppTool");
+    expect(start, "makeAppTool must still exist").toBeGreaterThan(-1);
+    const schema = source.slice(start, source.indexOf("function delegateTool", start));
+    expect(schema).toContain('request: { type: "string"');
+    expect(schema).toContain('context: { type: "string"');
+    expect(schema).toContain('app: { type: "string"');
+    expect(schema, "pack.ts gained `slot` — the page's Path A warnings are now wrong").not.toContain(
+      'slot: { type: "string"',
+    );
+  });
+
+  it("the IN-PROCESS pack still strips every vendo_apps_* tool", async () => {
+    const source = await read(PACK);
+    expect(source).toContain("if (descriptor.name.startsWith(VENDO_TOOL_PACK_PREFIX)) continue;");
+    expect(source, "pack.ts now re-adds a pin tool — the page's Path A warning is wrong").not.toContain(
+      "VENDO_APPS_PIN_TOOL",
+    );
+  });
+
+  it("the page says so, in both places it must", async () => {
+    const page = await read(PAGE);
+    expect(page).toMatch(/in-process pack \*\*does not carry\*\* `slot`/i);
+    expect(page).toMatch(/Do not put\s+`vendo_apps_pin` in a Path A system prompt/);
+  });
+});
+
+describe("the receipt law the page teaches is the real receipt", () => {
+  it("has exactly id, title, status, say — and status's three values", async () => {
+    const source = await read("packages/core/src/make-receipt.ts");
+    expect(source).toContain("id: appIdSchema");
+    expect(source).toContain("title: z.string().min(1)");
+    expect(source).toContain('status: z.enum(["ready", "building", "failed"])');
+    expect(source).toContain("say: z.string().min(1)");
+    const page = await read(PAGE);
+    for (const field of ["`say`", "`status`", '"ready"', '"building"', '"failed"']) {
+      expect(page, `${PAGE} must teach ${field}`).toContain(field);
+    }
+  });
+});
+
+describe("every component the page tells a reader to import is exported", () => {
+  it.each([
+    ["VendoSlot", "@vendoai/ui/chrome", "packages/ui/src/chrome/index.ts"],
+    ["VendoToolResult", "@vendoai/vendo/react", "packages/vendo/src/react.tsx"],
+    ["VendoProvider", "@vendoai/vendo/react", "packages/vendo/src/react.tsx"],
+    ["VendoRoot", "@vendoai/vendo/react", "packages/vendo/src/react.tsx"],
+  ])("%s is exported from %s", async (component, specifier, entry) => {
+    const page = await read(PAGE);
+    expect(page, `${PAGE} must name ${component}`).toContain(component);
+    expect(page, `${PAGE} must name ${specifier}`).toContain(specifier);
+    expect(await read(entry)).toMatch(new RegExp(`\\b${component}\\b`));
+  });
+
+  it("wellKnownVendoHandler, the Path B discovery route, is a server export", async () => {
+    expect(await read(PAGE)).toContain("wellKnownVendoHandler");
+    expect(await read("packages/vendo/src/server.ts")).toContain("export function wellKnownVendoHandler");
+  });
+
+  it("vendoTools and vendoMastraTools are the shims the page spreads", async () => {
+    const page = await read(PAGE);
+    expect(page).toContain("vendoTools");
+    expect(page).toContain("vendoMastraTools");
+    expect(await read("packages/vendo/src/ai-sdk.ts")).toContain("export async function vendoTools");
+    expect(await read("packages/vendo/src/mastra.ts")).toContain("export async function vendoMastraTools");
+  });
+
+  it("mcp and oauth are real createVendo keys", async () => {
+    const page = await read(PAGE);
+    expect(page).toContain("mcp: true");
+    const source = await read("packages/vendo/src/server.ts");
+    expect(source).toMatch(/^ {2}mcp\?:/m);
+    expect(source).toMatch(/^ {2}oauth\?: HostOAuthAdapter;$/m);
+  });
+});
+
+describe("the page keeps its two deliberate omissions and its one screenshot", () => {
+  it("never mentions vendo doctor", async () => {
+    expect(await read(PAGE)).not.toMatch(/vendo doctor/);
+  });
+
+  it("reuses the committed slot-filled screenshot", async () => {
+    const image = "docs-site/images/existing-agents/mcp-walk-slot-filled.png";
+    expect(await read(PAGE)).toContain("/images/existing-agents/mcp-walk-slot-filled.png");
+    expect(existsSync(new URL(image, REPO_ROOT)), `${image} must exist`).toBe(true);
+  });
+});
+
+describe("the pasteable guidance stays in step with the skill it was lifted from", () => {
+  const SKILL = "examples/claude-code-plugin/skills/make-a-screen/SKILL.md";
+
+  it("the skill still teaches the laws the page's block repeats", async () => {
+    const skill = await read(SKILL);
+    for (const needle of [/never invent/i, /close to verbatim/i, /`context`/, /`slot`/]) {
+      expect(skill).toMatch(needle);
+    }
+  });
+
+  it("the page's block carries the same four laws", async () => {
+    const page = await read(PAGE);
+    expect(page).toMatch(/NEVER invent one/);
+    expect(page).toMatch(/close to verbatim/i);
+    expect(page).toMatch(/NEVER describe it/);
+    expect(page).toMatch(/hardcoded figures/i);
+  });
+
+  it("credits the skill as the source", async () => {
+    expect(await read(PAGE)).toContain("examples/claude-code-plugin/skills/make-a-screen");
+  });
+});


### PR DESCRIPTION
## Why

The **Bring your own agent** group had a framework quickstart, an MCP
walkthrough, and a concepts overview — and no page that answers the first
question a senior engineer with an existing agent actually asks: *what do I do,
in what order, and how do I get my agent to reach for this at the right moment?*

Written for a real prospect shape: an OKR / collaborative-document product whose
agent already has its own tools and MCP connectors, self-hosts, and wants
generated views to land **inside their document blocks**.

## The page

`docs-site/existing-agents/your-agent.mdx` — "Add Vendo to your product's agent",
positioned FIRST in the group as the on-ramp. 344 lines, 2,236 words, seven
numbered steps:

1. **Install** — `vendo init`, what it actually writes (`.vendo/tools.json` from
   their routes/OpenAPI, `.vendo/theme.json`, the composition, the mount
   wrapper), and the one paste that is theirs. No `vendo doctor` anywhere.
2. **Pick how your agent reaches Vendo** — the fork as one question: *can your
   agent `import` the package?*
3. **Teach your agent when to use it** — the pasteable system-prompt block.
4. **Your first screen** — `vendo_make` and the receipt law as a *why*.
5. **Put it where you want it** — `<VendoSlot>`, and the block-editor case.
6. **Move a screen after the fact** — `vendo_apps_pin`, plus `<VendoToolResult>`.
7. **The perimeter** — short.

## The fork

| | Path A (in process) | Path B (MCP door) |
| --- | --- | --- |
| Setup | one `vendoTools` spread | `mcp: true` + OAuth adapter + discovery route |
| Identity | the `principal` you pass | the OAuth'd subject |
| Runtime | Node/TS, same process | any language, any host |
| `vendo_make` takes | `request` · `context` · `app` | + `slot` |
| Extra tools | `vendo_delegate` | `vendo_apps_pin` · `_unpin` · `_open` |

Identical either way: same tools, same guard-bound registry, same words-not-pixels
receipt, same slots, same theme. Door internals are **linked**, not restated.

**The asymmetry is named out loud, twice**, because it is the one thing a reader
can silently get wrong. `buildVendoToolPack` skips every `vendo_*` descriptor and
re-adds only `vendo_make` + `vendo_delegate`, and the in-process `vendo_make`
schema has no `slot`. So `vendo_apps_pin` in a Path A system prompt is an
invented tool call. Path A places a view from host code instead:
`<VendoSlot id={block.id} appId={block.vendoAppId} />`, using the `appId` off the
`vendo/app-ref@1` envelope the loop already received.

## The new section

The reason the page exists. Today the "when should I build a screen" guidance
lives **only** in `examples/claude-code-plugin/skills/make-a-screen/SKILL.md`,
where nobody but a Claude Code user benefits from it. This lifts that guidance
into a copyable system-prompt block for **any** agent: when a reply wants to be
looked at rather than read, how to phrase `request` (prose, no component names,
no computed figures), when to pass `context`, the receipt is words so never
describe or wait for the screen, and what to do on `building` and `failed`.

A **second, separately-pasteable block** carries `slot` and pin etiquette, marked
Path B only — teaching an agent about a tool it does not have is how you get an
invented tool call.

## The docs test

`packages/vendo/src/your-agent-docs.docs.test.ts`, 27 tests, in the style of
`mcp-byo-docs.docs.test.ts` (file reads only, no build needed). It pins:

- every tool name the page puts in a reader's system prompt exists in the apps
  registry, and `vendo_make` is core's constant not a docs-only alias;
- `vendo_make`'s real schema has `request`/`context`/`app`/`slot`;
- the in-process pack still has **no** `slot` and still strips `vendo_apps_*` —
  asserted from both the code side and the page's warnings, so the page and
  `pack.ts` cannot drift apart silently;
- the receipt's four fields and three statuses against `make-receipt.ts`;
- every component the page imports is exported from the entry point it names;
- nav position (first in group), all nav entries resolve, all page links resolve;
- no `vendo doctor` string on the page.

**Red-then-green proof:** added `slot` to `pack.ts`'s `makeAppTool` schema and
appended a `vendo doctor` line to the page → 2 failed / 25 passed, with the
authored message *"pack.ts gained `slot` — the page's Path A warnings are now
wrong"*. Restored → 27/27.

## Gate

`pnpm build` 23/23 · `pnpm typecheck` 42/42 · `pnpm lint` 0 errors (1
pre-existing demo-bank warning) · the new test + the sibling
`mcp-byo-docs.docs.test.ts` 56/56 green together. Docs-only change plus one test
file; CI's `ci` check is the gate of record.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a single on-ramp page that shows how to plug Vendo into an existing in‑product agent, for both in‑process tools and the MCP door, with a copy‑paste system prompt that teaches when to use `vendo_make`. Adds a docs test to pin the page to real tool schemas, exports, and nav so it can’t drift.

- **New Features**
  - New page `existing-agents/your-agent` (first in “Bring your own agent”): 7 steps covering `vendo init`, Path A (in‑process spread) vs Path B (MCP with `mcp: true`, OAuth adapter, discovery route), receipt behavior, placing views with `VendoSlot`, moving views via `vendo_apps_pin` (MCP only), and safety.
  - Path asymmetry is explicit: Path A’s pack exposes `vendo_make` without `slot` and strips all `vendo_apps_*`; Path B adds `slot` and pin tools—prevents invented tool calls.
  - Snippets use `VendoSlot` from `@vendoai/ui/chrome`, and `VendoProvider`, `VendoRoot`, `VendoToolResult`, plus server `wellKnownVendoHandler` from `@vendoai/vendo`.
  - New test `packages/vendo/src/your-agent-docs.docs.test.ts` verifies tool names and schemas (`request`, `context`, `app`, `slot`), Path A exclusions, receipt fields/statuses, component exports, nav position, link targets, and omits `vendo doctor`.
  - `docs-site/docs.json` updated to add `existing-agents/your-agent` as the first page in the group.

<sup>Written for commit 0095988fee87d83f7f3540a9d5b4913626284af7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

