### PR TITLE
feat(vendo): the in-process pack's vendo_make takes `slot`

### DIFF
--- a/.changeset/pack-make-takes-slot.md
+++ b/.changeset/pack-make-takes-slot.md
@@ -1,0 +1,12 @@
+---
+"@vendoai/vendo": minor
+---
+
+The in-process tool pack's `vendo_make` takes `slot`, like the MCP door's.
+
+A host whose own agent runs in process could not say where a screen should land:
+`slot` was on the door's `vendo_make` and missing from the pack's. It is now on
+both, with the door's own wording, and reaches the same handler — the placement
+claim rides `vendo_make`'s mint whichever door called it, so there is no second
+path to keep honest. The pin tools stay door-only; on Path A you still move an
+existing view from your own code with the app id.

--- a/docs-site/existing-agents/your-agent.mdx
+++ b/docs-site/existing-agents/your-agent.mdx
@@ -112,13 +112,14 @@ the same `.vendo/theme.json`.
 | Runtime | Node/TS, same process as `createVendo` | any language, any host |
 | Clients | your agent | your agent, plus any MCP client you point at it |
 | Extra tools | `vendo_delegate` | `vendo_apps_pin` · `vendo_apps_unpin` · `vendo_apps_open` · the saved-apps viewer |
-| `vendo_make` takes | `request` · `context` · `app` | `request` · `context` · `app` · `slot` |
+| `vendo_make` takes | `request` · `context` · `app` · `slot` | `request` · `context` · `app` · `slot` |
 
 <Warning>
-  Read the last two rows twice. The in-process pack **does not carry** `slot` or
-  any `vendo_apps_*` tool — in-app interaction rides the wire, not your loop.
-  Placing a view is still fully available on Path A; you do it from your own code
-  with the app id, in [step 5](#5-put-it-where-you-want-it).
+  Read the `Extra tools` row twice. The in-process pack **does not carry** any
+  `vendo_apps_*` tool — in-app interaction rides the wire, not your loop. Moving
+  a view your agent already made is still fully available on Path A; you do it
+  from your own code with the app id, in
+  [step 5](#5-put-it-where-you-want-it).
 </Warning>
 
 ## 3. Teach your agent when to use it
@@ -169,7 +170,8 @@ are not on. So:
 - status "building": honest, not an error. Say the line and move on.
 ```
 
-Add this second block **only on Path B**. Teaching an agent about a tool it does
+Add this second block too. `WHERE IT LANDS` is both paths; add `MOVING ONE THEY
+ALREADY HAVE` **only on Path B**, because teaching an agent about a tool it does
 not have is how you get an invented tool call:
 
 ```text
@@ -243,14 +245,14 @@ untouched — no wrapper, so inline one anywhere. Filled: build skeleton, then t
 live view, then a failure with a retry. Never a blank hole. One view per slot per
 person; a second one evicts the first.
 
-**Path B** — your agent aims at a slot by id:
+**Either path** — your agent aims at a slot by id:
 
 ```json
 { "request": "This month's spending by category, largest first", "slot": "home-hero" }
 ```
 
-**Path A** — you place it, using the `appId` from the `vendo/app-ref@1` envelope
-your loop already received:
+**Path A, without `slot`** — you place it, using the `appId` from the
+`vendo/app-ref@1` envelope your loop already received:
 
 ```tsx
 <VendoSlot id={block.id} appId={block.vendoAppId} />
@@ -263,7 +265,7 @@ your loop already received:
   person with that document open, and your editor keeps owning layout.
 </Note>
 
-Slot ids are yours, and nothing enumerates them for an agent at the door — tell
+Slot ids are yours, and nothing enumerates them for an agent on either path — tell
 the agent the id, or let the person say it. That is why step 3 forbids inventing
 one.
 

--- a/packages/vendo/src/pack.test.ts
+++ b/packages/vendo/src/pack.test.ts
@@ -364,7 +364,7 @@ describe("vendo_make (the pack's app door)", () => {
     expect(description).toMatch(/never describe|never say it is created/i);
   });
 
-  it("takes vendo_make's own arguments: request required, context/app optional", async () => {
+  it("takes vendo_make's own arguments: request required, context/app/slot optional", async () => {
     const { byName } = await pack({
       implementations: { ...hostTools(), [VENDO_MAKE_TOOL]: makeTool({ appId: "app_schema", name: "x" }) },
     });
@@ -375,10 +375,35 @@ describe("vendo_make (the pack's app door)", () => {
         request: { type: "string", minLength: 1 },
         context: { type: "string", minLength: 1 },
         app: { type: "string", minLength: 1 },
+        slot: { type: "string", minLength: 1 },
       },
       required: ["request"],
       additionalProperties: false,
     });
+  });
+
+  /** Parity with the MCP door: an in-process agent can say where the screen
+   *  lands, and the slot reaches the same `vendo_make` handler that claims it. */
+  it("takes `slot` and forwards it to vendo_make", async () => {
+    const seen: Json[] = [];
+    const implementations = {
+      ...hostTools(),
+      [VENDO_MAKE_TOOL]: {
+        descriptor: makeTool({ appId: "app_slot", name: "Spending" }).descriptor,
+        execute: (args: Json): Json => {
+          seen.push(args);
+          return { id: "app_slot", title: "Spending", status: "ready", say: "Spending is on your screen." };
+        },
+      },
+    };
+    const { byName } = await pack({ implementations });
+    const tool = byName.get(VENDO_MAKE_TOOL)!;
+    expect((tool.inputSchema as { properties: Record<string, unknown> }).properties.slot).toEqual({
+      type: "string",
+      minLength: 1,
+    });
+    await tool.execute({ request: "this month's spending", slot: "home-hero" }, { ctx: ctx() });
+    expect(seen).toEqual([{ request: "this month's spending", slot: "home-hero" }]);
   });
 
   it("forwards the caller's arguments to vendo_make verbatim — nothing is translated", async () => {

--- a/packages/vendo/src/pack.ts
+++ b/packages/vendo/src/pack.ts
@@ -172,7 +172,7 @@ function wrapHostTool(registry: ToolRegistry, descriptor: ToolDescriptor): Vendo
 function makeAppTool(registry: ToolRegistry, descriptor: ToolDescriptor): VendoPackTool {
   return {
     name: VENDO_MAKE_TOOL,
-    description: "Create a Vendo app (generated UI) from a plain-language request. Returns fast with a vendo/app-ref@1 envelope carrying status \"building\" — the build was only ACCEPTED and is still streaming; you have not seen its contents and do not know yet whether it will succeed. Say only that you're building it (present tense, no specifics) and stop there. Never say it is created/ready/done, and never describe, list, or invent anything it will contain (no tables, no numbers, no chart data) — the embed shows real build progress and the true final result, including a build failure, and it will contradict anything you claim. If the build later fails, you will not be told in this reply; do not assume or claim success in a later turn either — check with the user or a read tool before describing this app again.",
+    description: "Create a Vendo app (generated UI) from a plain-language request. Returns fast with a vendo/app-ref@1 envelope carrying status \"building\" — the build was only ACCEPTED and is still streaming; you have not seen its contents and do not know yet whether it will succeed. Say only that you're building it (present tense, no specifics) and stop there. Never say it is created/ready/done, and never describe, list, or invent anything it will contain (no tables, no numbers, no chart data) — the embed shows real build progress and the true final result, including a build failure, and it will contradict anything you claim. If the build later fails, you will not be told in this reply; do not assume or claim success in a later turn either — check with the user or a read tool before describing this app again. Pass `slot` only when the request names a particular place on the user's page for it to land — the host publishes those slot ids, so pass one you were told rather than one you invented, and whatever held that place is replaced. `slot` is for something NEW.",
     inputSchema: {
       $schema: DRAFT_2020_12,
       type: "object",
@@ -180,6 +180,11 @@ function makeAppTool(registry: ToolRegistry, descriptor: ToolDescriptor): VendoP
         request: { type: "string", minLength: 1 },
         context: { type: "string", minLength: 1 },
         app: { type: "string", minLength: 1 },
+        // Same argument the door offers, reaching the same handler: the claim
+        // rides `vendo_make`'s mint in agent-tools.ts, whichever door called it.
+        // The door's own wording, minus its pin-tool pointer — the pack has no
+        // `vendo_apps_*` tool to point at.
+        slot: { type: "string", minLength: 1 },
       },
       required: ["request"],
       additionalProperties: false,

--- a/packages/vendo/src/your-agent-docs.docs.test.ts
+++ b/packages/vendo/src/your-agent-docs.docs.test.ts
@@ -13,9 +13,9 @@ import { describe, expect, it } from "vitest";
  *     FIRST in its group (it is the on-ramp);
  *  2. every tool name the page puts in a reader's system prompt really exists
  *     in the registry the page is describing;
- *  3. `vendo_make`'s four documented arguments are its real schema properties,
- *     and the page's asymmetry claim — that the IN-PROCESS pack carries no
- *     `slot` and no `vendo_apps_*` — matches pack.ts. That asymmetry is the one
+ *  3. `vendo_make`'s four documented arguments are its real schema properties on
+ *     BOTH doors, and the page's remaining asymmetry claim — that the IN-PROCESS
+ *     pack carries no `vendo_apps_*` — matches pack.ts. That asymmetry is the one
  *     thing a reader can silently get wrong (an invented tool call), so it is
  *     pinned from both sides;
  *  4. the receipt really has exactly the four fields the page calls a law;
@@ -125,19 +125,18 @@ describe("the page's argument tables match the real schemas", () => {
     }
   });
 
-  /** The one asymmetry the page warns about twice. If the in-process pack ever
-   *  gains `slot` or the pin tools, the page's warnings become the lie. */
-  it("the IN-PROCESS pack's vendo_make still has no slot", async () => {
+  /** `slot` is the one argument both doors carry, and the page now says so on
+   *  both paths. If the pack ever loses it, the page's parity claim is the lie. */
+  it("the IN-PROCESS pack's vendo_make takes the same four arguments", async () => {
     const source = await read(PACK);
     const start = source.indexOf("function makeAppTool");
     expect(start, "makeAppTool must still exist").toBeGreaterThan(-1);
     const schema = source.slice(start, source.indexOf("function delegateTool", start));
-    expect(schema).toContain('request: { type: "string"');
-    expect(schema).toContain('context: { type: "string"');
-    expect(schema).toContain('app: { type: "string"');
-    expect(schema, "pack.ts gained `slot` — the page's Path A warnings are now wrong").not.toContain(
-      'slot: { type: "string"',
-    );
+    for (const argument of ["request", "context", "app", "slot"]) {
+      expect(schema, `the pack's vendo_make must accept \`${argument}\``).toContain(
+        `${argument}: { type: "string"`,
+      );
+    }
   });
 
   it("the IN-PROCESS pack still strips every vendo_apps_* tool", async () => {
@@ -150,7 +149,7 @@ describe("the page's argument tables match the real schemas", () => {
 
   it("the page says so, in both places it must", async () => {
     const page = await read(PAGE);
-    expect(page).toMatch(/in-process pack \*\*does not carry\*\* `slot`/i);
+    expect(page).toMatch(/in-process pack \*\*does not carry\*\* any\s+`vendo_apps_\*` tool/i);
     expect(page).toMatch(/Do not put\s+`vendo_apps_pin` in a Path A system prompt/);
   });
 });


### PR DESCRIPTION
## The gap

`slot` — "put this screen in that place on the user's page" — was on the MCP door's `vendo_make` and missing from the in-process tool pack's. A host whose own agent runs in process (Path A: AI SDK, Mastra, any BYO loop) therefore could not tell Vendo where the screen should land; it had to take the app id off the receipt and re-render a `<VendoSlot>` from its own code.

## The change

One line of schema in `packages/vendo/src/pack.ts`:

```ts
slot: { type: "string", minLength: 1 },
```

The pack forwards the caller's arguments to `vendo_make` **verbatim** (`args: input as Json`), so the schema was the only gate. The value lands in the same handler the door uses — `packages/apps/src/agent-tools.ts`, where `input(call.args, ["request"], ["app", "context", "slot"])` reads it and `claimSlot` rides the mint. Same code, not a parallel one: nothing was duplicated.

The tool's description gains the door descriptor's own two `slot` sentences, minus its closing pointer at the pin tool — the pack has no `vendo_apps_*` tool to point at, and naming one is exactly how you get an invented tool call.

## Docs and the guard test that pinned the old behaviour

`packages/vendo/src/your-agent-docs.docs.test.ts` asserted the pack has **no** `slot` ("pack.ts gained `slot` — the page's Path A warnings are now wrong"). That guard is inverted: it now requires all four arguments on both doors. The page-side assertion moves to the asymmetry that survives — the pin tools are still door-only.

`docs-site/existing-agents/your-agent.mdx`, minimal edits:
- fork table: the `vendo_make` takes row is now identical on both paths;
- the Warning under it is about `vendo_apps_*` alone, not `slot`;
- the second system-prompt block: `WHERE IT LANDS` goes in on both paths, `MOVING ONE THEY ALREADY HAVE` still only on Path B;
- step 5: "**Either path** — your agent aims at a slot by id", with the manual placement kept as "Path A, without `slot`";
- "nothing enumerates them for an agent at the door" → "on either path".

Checked the rest of the docs: `existing-agents/mcp.mdx`, `existing-agents/ai-sdk.mdx`, `capabilities/mcp.mdx` and the claude-code-plugin skill describe the door path only and state no asymmetry — nothing else went false.

## Red-then-green

Removed the `slot` line from the schema and re-ran, with the fix's tests in place:

```
× the IN-PROCESS pack's vendo_make takes the same four arguments
  → the pack's vendo_make must accept `slot`
× takes vendo_make's own arguments: request required, context/app/slot optional
× takes `slot` and forwards it to vendo_make
Tests  3 failed | 49 passed (52)
```

Restored → `52 passed`. The new test is one focused case in `pack.test.ts`: the pack tool declares `slot` and forwards `{ request, slot }` to the underlying `vendo_make` untouched.

## Gate

`pnpm build` 23/23 · `pnpm typecheck` 43/43 · `pnpm lint` 3/3 (one pre-existing demo-bank warning) · `packages/vendo` — `pack.test.ts`, `your-agent-docs.docs.test.ts`, `ai-sdk.test.ts`, `tool-pack.test.ts`, `mcp-byo-docs.docs.test.ts`, `handler-options.docs.test.ts`: 96 passed. Full suite is CI's.

Changeset: `@vendoai/vendo` minor.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `slot` to the in-process pack’s `vendo_make` so hosts can target where a screen lands, matching the MCP door. Arguments are forwarded verbatim to the same handler; no duplicated logic.

- **New Features**
  - Schema adds `slot: { type: "string", minLength: 1 }` in `packages/vendo/src/pack.ts`.
  - Tool description explains when to pass `slot` (door wording, without pin-tool pointer).
  - Parity with the door: `request` required; `context`/`app`/`slot` optional.

- **Docs and Tests**
  - Updated `docs-site/existing-agents/your-agent.mdx` to show `slot` on both paths; warning now only about `vendo_apps_*` being door-only.
  - Tests assert schema parity and verbatim forwarding; pack still strips `vendo_apps_*`.

<sup>Written for commit 0e527bba6fa09b8de3ef6dfd85793f5c5ddf9cc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

