### PR TITLE
fix(build): turbo cache restores runtime-bundle.gen.ts on a warm hit

### DIFF
--- a/packages/ui/test/jail-runtime-outputs.test.ts
+++ b/packages/ui/test/jail-runtime-outputs.test.ts
@@ -1,0 +1,40 @@
+/**
+ * The jail runtime bundle is generated INTO the source tree (`prebuild` ->
+ * scripts/build-jail-runtime.mjs) and gitignored, and dev-mode hosts resolve
+ * @vendoai/ui from src/, not dist/ (examples/demo-bank/next.config.ts's
+ * turbopack resolveAlias). So the generated file has to be a declared turbo
+ * output: with `dist/**` alone, a cache hit replays the build's logs —
+ * including "[ui] generated jail runtime" — without restoring the file, and a
+ * fresh clone with a warm cache 500s on every page with
+ * "Can't resolve './runtime-bundle.gen.js'" (#915).
+ *
+ * Asked of turbo itself rather than of turbo.json's text, so the pin holds
+ * wherever the declaration lives (global `build`, `@vendoai/ui#build`, an
+ * extended config).
+ */
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const PACKAGE_DIR = join(dirname(fileURLToPath(import.meta.url)), "..");
+const GENERATED = "src/tree/jail/runtime-bundle.gen.ts";
+
+describe("jail runtime bundle is a cacheable build output", () => {
+  it("is the path the generator writes", () => {
+    const generator = readFileSync(join(PACKAGE_DIR, "scripts/build-jail-runtime.mjs"), "utf8");
+    expect(generator).toContain(`"${GENERATED}"`);
+  });
+
+  it("is in the resolved turbo outputs for @vendoai/ui#build", () => {
+    const dryRun = JSON.parse(
+      execFileSync("pnpm", ["exec", "turbo", "run", "build", "--dry=json", "--filter=@vendoai/ui"], {
+        cwd: PACKAGE_DIR,
+        encoding: "utf8",
+      }),
+    ) as { tasks: { taskId: string; resolvedTaskDefinition: { outputs: string[] } }[] };
+    const build = dryRun.tasks.find((task) => task.taskId === "@vendoai/ui#build");
+    expect(build?.resolvedTaskDefinition.outputs).toEqual(expect.arrayContaining([GENERATED, "dist/**"]));
+  });
+});

--- a/turbo.json
+++ b/turbo.json
@@ -11,6 +11,15 @@
     // before @vendoai/kit:build and the template build dies on an unresolvable @vendoai/kit.
     "@vendoai/apps#test": { "dependsOn": ["^build", "build", "@vendoai/box-template#build"], "env": ["CI", "POSTGRES_URL", "VITEST_MIN_FORKS", "VITEST_MAX_FORKS", "VITEST_MIN_THREADS", "VITEST_MAX_THREADS"] },
     "@vendoai/apps#test:coverage": { "dependsOn": ["^build", "build", "@vendoai/box-template#build"], "outputs": ["coverage/**"], "env": ["CI", "POSTGRES_URL", "VITEST_MIN_FORKS", "VITEST_MAX_FORKS", "VITEST_MIN_THREADS", "VITEST_MAX_THREADS"] },
+    // packages/ui's prebuild generates src/tree/jail/runtime-bundle.gen.ts INTO
+    // the source tree, and dev-mode hosts resolve @vendoai/ui from src/ rather
+    // than dist/ (examples/demo-bank/next.config.ts's turbopack resolveAlias).
+    // With the global `dist/**` alone, a cache hit replayed the generator's log
+    // line without restoring the file, so a fresh clone with a warm cache 500'd
+    // on every page: "Can't resolve './runtime-bundle.gen.js'" (#915).
+    // Package-scoped definitions replace the global one, so `dist/**` is
+    // repeated here. `.next/**` is not — this package has no Next build.
+    "@vendoai/ui#build": { "dependsOn": ["^build"], "outputs": ["dist/**", "src/tree/jail/runtime-bundle.gen.ts"] },
     "conformance": { "dependsOn": ["^build", "build"], "env": ["CI", "POSTGRES_URL"] },
     "typecheck": { "dependsOn": ["^build"] },
     "lint": {}


### PR DESCRIPTION
**Problem** — `turbo.json` declared `dist/**` as the only `build` output, so a warm cache hit replayed packages/ui's `prebuild` logs without restoring `packages/ui/src/tree/jail/runtime-bundle.gen.ts`, which dev-mode hosts resolve from *source* (`examples/demo-bank/next.config.ts` aliases `@vendoai/ui` → `packages/ui/src/**`). A fresh clone with a warm cache 500s on every page: `Can't resolve './runtime-bundle.gen.js'`.

**Fix** — one package-scoped entry declaring the generated source path:

```jsonc
"@vendoai/ui#build": { "dependsOn": ["^build"], "outputs": ["dist/**", "src/tree/jail/runtime-bundle.gen.ts"] },
```

Package-scoped definitions *replace* the global one, so `dist/**` is repeated. `.next/**` is not — this package has no Next build. The file being gitignored is irrelevant to turbo outputs (`dist/` is too).

## Red → green test proof

`packages/ui/test/jail-runtime-outputs.test.ts` asks **turbo itself** for the resolved outputs (`turbo run build --dry=json --filter=@vendoai/ui`) rather than parsing turbo.json's text, so the pin holds wherever the declaration lives. A second assertion pins that the declared path is the one the generator actually writes.

RED, with the fix reverted (`npx vitest run test/jail-runtime-outputs.test.ts` in `packages/ui`):

```
 FAIL  test/jail-runtime-outputs.test.ts > jail runtime bundle is a cacheable build output > is in the resolved turbo outputs for @vendoai/ui#build
- ArrayContaining [
-   "src/tree/jail/runtime-bundle.gen.ts",
+ Array [
+   "!.next/cache/**",
+   ".next/**",
    "dist/**",
  ]
```

GREEN with the fix: `Test Files  1 passed (1) · Tests  2 passed (2)`.

## End-to-end cache-restore proof

Same four steps both times: real build → `rm` the generated file (the fresh-clone state) → rebuild into a cache hit → check. Run on `origin/main` first, because the turbo.json edit itself changes the task hash.

**BEFORE — on `origin/main`:**

```
$ npx turbo run build --filter=@vendoai/ui --force
@vendoai/ui:build: [ui] generated jail runtime (946086 bytes)
Cached:    0 cached, 2 total
-rw-r--r--  965170  packages/ui/src/tree/jail/runtime-bundle.gen.ts

$ rm -f packages/ui/src/tree/jail/runtime-bundle.gen.ts
$ npx turbo run build --filter=@vendoai/ui
@vendoai/ui:build: [ui] generated jail runtime (946086 bytes)   <- log replayed
Cached:    2 cached, 2 total
  Time:    61ms >>> FULL TURBO

$ ls -l packages/ui/src/tree/jail/runtime-bundle.gen.ts
ls: No such file or directory
STILL MISSING -> next dev: Can't resolve './runtime-bundle.gen.js' -> 500 on every page
```

The cache hit reports the generator's byte count for a file that is not on disk — exactly the failure mode.

**AFTER — on this branch (cache warmed at the new hash):**

```
$ npx turbo run build --filter=@vendoai/ui
@vendoai/ui:build: [ui] generated jail runtime (946086 bytes)
-rw-r--r--  965170  packages/ui/src/tree/jail/runtime-bundle.gen.ts

$ rm -f packages/ui/src/tree/jail/runtime-bundle.gen.ts   # gone
$ npx turbo run build --filter=@vendoai/ui
Cached:    2 cached, 2 total
  Time:    61ms >>> FULL TURBO

$ ls -l packages/ui/src/tree/jail/runtime-bundle.gen.ts
-rw-r--r--  965170  packages/ui/src/tree/jail/runtime-bundle.gen.ts
$ head -c 90 packages/ui/src/tree/jail/runtime-bundle.gen.ts
/** Generated by scripts/build-jail-runtime.mjs. Do not edit. */
export const JAIL_RUNTIME
```

Restored byte-identical from the cache on a warm hit.

## Gate

`pnpm build`, `pnpm typecheck`, `pnpm lint` all green from the worktree root. Tests: `@vendoai/ui` in full, capped (`VITEST_MIN/MAX_FORKS=1/2`, `VITEST_MIN/MAX_THREADS=1/2`) — `Test Files 123 passed (123) · Tests 1098 passed (1098)`.

Not `pnpm test:affected`: a root `turbo.json` change marks **every** package affected (96 tasks — the whole suite), which CLAUDE.md forbids running on a laptop. `@vendoai/ui` is the only package with a source change; CI's green `ci` check is the gate of record for the rest.

## Same class, deliberately untouched

`packages/vendo`'s `prebuild` writes `src/cli/playground/bundle.gen.ts` and `embed-bundle.gen.ts` into its source tree, also gitignored and also undeclared in turbo outputs. It does not break the demo (nothing resolves `@vendoai/vendo` from source in dev), but it bites the same way when you run `npx vitest run` or `tsc` directly in that package dir on a warm cache — the workflow CLAUDE.md recommends for scoping a single test file. Left for its own change. (`packages/ui/src/chrome/onest-font.gen.ts` is *committed* and not a build hook, so it's fine.)

The issue's trailing smaller notes — the `/` 404, the ~2s `/api/vendo/connections` polling, and the `CenterChats` React key warning — are intentionally untouched here.

Fixes #915

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #915 by ensuring Turbo restores the generated `runtime-bundle.gen.ts` on cache hits, preventing demo 500s when `@vendoai/ui` is resolved from source. Adds a package-scoped outputs entry and a test to pin it.

- **Bug Fixes**
  - Declare `src/tree/jail/runtime-bundle.gen.ts` in `@vendoai/ui#build` outputs in `turbo.json` (repeats `dist/**` since package-scoped entries replace the global one).
  - Add `packages/ui/test/jail-runtime-outputs.test.ts` that verifies Turbo’s resolved outputs via `--dry=json` and that the generator writes to the same path.

<sup>Written for commit 2e8181673c0ff24803b5fd75598fc61a78475e2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

