### PR TITLE
fix(apps): the history row and the returned version share one clock read

### DIFF
--- a/packages/apps/src/lifecycle.test.ts
+++ b/packages/apps/src/lifecycle.test.ts
@@ -408,4 +408,73 @@ describe("apps lifecycle", () => {
       vi.useRealTimers();
     }
   });
+
+  it("never reports an overlapping edit's version as its own", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-07-12T12:00:00.000Z"));
+    /** A save that has landed, and a hold released by the test. */
+    const gate = () => {
+      let open = (): void => {};
+      const held = new Promise<void>((resolve) => {
+        open = resolve;
+      });
+      let landed = (): void => {};
+      const saved = new Promise<void>((resolve) => {
+        landed = resolve;
+      });
+      return { held, open, saved, landed };
+    };
+    const gates = new Map([["First", gate()], ["Second", gate()]]);
+    const gateFor = (request: string) =>
+      [...gates].find(([instruction]) => request.trimEnd().endsWith(instruction))?.[1];
+    try {
+      const store = memoryStore();
+      let runtime: AppsRuntime;
+      const assembler = screenFor(() => runtime);
+      runtime = createApps({
+        store,
+        guard: guardFixture(),
+        tools,
+        catalog: [],
+        model: basicLanguageModel(),
+        // Held between the save and the answer, so the test can interleave two
+        // edits of the SAME app around each other's history row.
+        screen: {
+          async assemble(request, assembleCtx) {
+            const outcome = await assembler.assemble(request, assembleCtx);
+            vi.setSystemTime(new Date(Date.now() + 1));
+            const held = gateFor(request.request);
+            if (held !== undefined) {
+              held.landed();
+              await held.held;
+            }
+            return outcome;
+          },
+        },
+      });
+      const ctx = context("user_ada");
+      const app = await runtime.create({ prompt: "Valid" }, ctx);
+
+      // "First" saves its row, then waits. "Second" starts on top of it, saves
+      // its own row, and waits too — so when "First" answers, the newest row on
+      // this app is SOMEONE ELSE'S edit.
+      const first = runtime.edit(app.id, "First", ctx);
+      await gates.get("First")?.saved;
+      const second = runtime.edit(app.id, "Second", ctx);
+      await gates.get("Second")?.saved;
+      gates.get("First")?.open();
+      const firstResult = await first;
+      gates.get("Second")?.open();
+      const secondResult = await second;
+
+      // Never the sibling's row — the words in the version an edit reports are
+      // the words that edit was given.
+      expect(firstResult.version.intent).toBe("First");
+      expect(secondResult.version.intent).toBe("Second");
+      // …and the edit whose row is still the newest one reports it verbatim.
+      await expect(runtime.history(app.id, ctx).list()).resolves.toContainEqual(secondResult.version);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/apps/src/lifecycle.test.ts
+++ b/packages/apps/src/lifecycle.test.ts
@@ -372,4 +372,40 @@ describe("apps lifecycle", () => {
     await expect(runtime.list(ctx)).resolves.toEqual([edited.app]);
     await expect(runtime.history(valid.id, ctx).list()).resolves.toEqual([edited.version]);
   });
+
+  it("reports the version history stored, not a later clock read", async () => {
+    // Only `Date` is faked: the store, the guard and every await in the write
+    // path still run on real timers.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-07-12T12:00:00.000Z"));
+    try {
+      const store = memoryStore();
+      let runtime: AppsRuntime;
+      const assembler = screenFor(() => runtime);
+      runtime = createApps({
+        store,
+        guard: guardFixture(),
+        tools,
+        catalog: [],
+        model: basicLanguageModel(),
+        // The assembler's save is where the history row is appended, so moving
+        // the clock the moment it returns puts every later read in the NEXT
+        // millisecond — the straddle that used to need a busy machine.
+        screen: {
+          async assemble(request, assembleCtx) {
+            const outcome = await assembler.assemble(request, assembleCtx);
+            vi.setSystemTime(new Date(Date.now() + 1));
+            return outcome;
+          },
+        },
+      });
+      const ctx = context("user_ada");
+      const app = await runtime.create({ prompt: "Valid" }, ctx);
+      const edited = await runtime.edit(app.id, "Edited", ctx);
+
+      await expect(runtime.history(app.id, ctx).list()).resolves.toEqual([edited.version]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/apps/src/runtime.ts
+++ b/packages/apps/src/runtime.ts
@@ -1975,11 +1975,32 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
    * and `edit` reports it verbatim rather than stamping a second `new Date()`:
    * two clock reads agree only inside one millisecond, so the version handed to
    * the caller otherwise differs from the one history holds whenever the two
-   * straddle a tick. Cleared at the top of every `assembleEdit` so a previous
-   * edit's row can never be reported as this one's, and taken (not read) by
-   * `edit`.
+   * straddle a tick.
+   *
+   * Keyed by app, like `editIntents` — so two OVERLAPPING edits of one app share
+   * a slot, and the WORDS decide whose row it is (`takeEditVersion`): an edit
+   * takes the entry only when its intent is the instruction that edit was given,
+   * and otherwise leaves the sibling's row where it is and stamps its own
+   * version exactly as this door did before any row was captured. Both misses
+   * degrade to that stamp — the millisecond skew this fix removes in the
+   * ordinary case — and neither can hand a caller someone else's version.
    */
   const editVersions = new Map<AppId, VersionEntry>();
+
+  /**
+   * THIS edit's captured row, or nothing.
+   *
+   * The intent match is the correlation: `edit` reports a version, and the only
+   * version it may report is one recorded under the words it was asked to carry
+   * out. A row belonging to an overlapping edit of the same app is left in the
+   * map for that edit to take.
+   */
+  const takeEditVersion = (appId: AppId, instruction: string): VersionEntry | undefined => {
+    const recorded = editVersions.get(appId);
+    if (recorded?.intent !== instruction) return undefined;
+    editVersions.delete(appId);
+    return recorded;
+  };
 
   /**
    * ONE instruction through the ONE builder.
@@ -2015,6 +2036,12 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
     const before = await apps.get(appId).catch(() => null);
     const memory = appMemoryBrief(before === null ? undefined : rowFromRecord(before).doc.memory);
     editIntents.set(appId, instruction);
+    // Kept even though `takeEditVersion` matches on the words: an entry no edit
+    // ever took (an assembler that saved and then reported unavailable, a
+    // `rebind` inside the ladder) would otherwise sit here until some later edit
+    // of this app said exactly the same thing and reported that OLD row as its
+    // own. Clearing can only cost a concurrent edit its captured row, and losing
+    // a row means stamping the version the way this door always did.
     editVersions.delete(appId);
     let outcome: Awaited<ReturnType<ScreenAssembler["assemble"]>>;
     try {
@@ -3477,12 +3504,11 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
       // (see `editIntents`), so the version reported here IS that row — read
       // back rather than re-stamped, because a second clock read tells the
       // caller a millisecond history does not hold. Nothing else is written.
-      const version: VersionEntry = editVersions.get(appId) ?? {
+      const version: VersionEntry = takeEditVersion(appId, instruction) ?? {
         at: new Date().toISOString(),
         intent: instruction,
         rung: rungFor(app),
       };
-      editVersions.delete(appId);
       return withPinDrift({
         app,
         version,

--- a/packages/apps/src/runtime.ts
+++ b/packages/apps/src/runtime.ts
@@ -1968,6 +1968,20 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
   const editIntents = new Map<AppId, string>();
 
   /**
+   * The version row an edit's own save APPENDED, keyed by app — the return leg
+   * of `editIntents`.
+   *
+   * The row is written where the save happens (`authored`, the one write path),
+   * and `edit` reports it verbatim rather than stamping a second `new Date()`:
+   * two clock reads agree only inside one millisecond, so the version handed to
+   * the caller otherwise differs from the one history holds whenever the two
+   * straddle a tick. Cleared at the top of every `assembleEdit` so a previous
+   * edit's row can never be reported as this one's, and taken (not read) by
+   * `edit`.
+   */
+  const editVersions = new Map<AppId, VersionEntry>();
+
+  /**
    * ONE instruction through the ONE builder.
    *
    * There is no second engine: the assembler opens the app's own `app.vendo`,
@@ -2001,6 +2015,7 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
     const before = await apps.get(appId).catch(() => null);
     const memory = appMemoryBrief(before === null ? undefined : rowFromRecord(before).doc.memory);
     editIntents.set(appId, instruction);
+    editVersions.delete(appId);
     let outcome: Awaited<ReturnType<ScreenAssembler["assemble"]>>;
     try {
       outcome = await config.screen.assemble({
@@ -2887,11 +2902,15 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
               // (`edit`, and the trail `pins.rebase` replays); "Saved app.vendo"
               // for every other author, which is all a bare file save can say.
               const intent = editIntents.get(input.appId);
-              appended = await history.append(input.appId, previous, {
+              const entry: VersionEntry = {
                 at: new Date().toISOString(),
                 intent: intent ?? "Saved app.vendo",
                 rung: rungFor(document),
-              }, touchedPinSlots(previous, document),
+              };
+              // ONE clock read for this save: when the save is an `edit`'s, that
+              // door reports this very row (see `editVersions`).
+              if (intent !== undefined) editVersions.set(input.appId, entry);
+              appended = await history.append(input.appId, previous, entry, touchedPinSlots(previous, document),
               // A "touch" for an authored save, never an "edit": that receipt
               // records THAT the save changed a pinned component and nothing
               // about what it changed. Handing "Saved app.vendo" to a rebase as a
@@ -2944,6 +2963,9 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
           // snapshot predates the concurrent edit the refusal just preserved, and
           // `undo()` would write it straight over that edit (see discardVersion).
           if (appended !== undefined) await discardVersion(input.appId, appended);
+          // …and a discarded version is not history, so it is not this edit's
+          // answer either.
+          editVersions.delete(input.appId);
         }
       }
       // The queries, through the SAME guard-bound caller `open()` resolves with:
@@ -3452,13 +3474,15 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
         }
       }
       // `authored` appended this edit's own undo point under the person's words
-      // (see `editIntents`), so the version reported here names the surface the
-      // edit LANDED on and nothing else is written.
-      const version: VersionEntry = {
+      // (see `editIntents`), so the version reported here IS that row — read
+      // back rather than re-stamped, because a second clock read tells the
+      // caller a millisecond history does not hold. Nothing else is written.
+      const version: VersionEntry = editVersions.get(appId) ?? {
         at: new Date().toISOString(),
         intent: instruction,
         rung: rungFor(app),
       };
+      editVersions.delete(appId);
       return withPinDrift({
         app,
         version,


### PR DESCRIPTION
**Problem.** `runtime.edit` stamped the `version` it returned with a fresh `new Date().toISOString()` *after* `authored` had already appended the history row off its own clock read. The two only agree inside one millisecond, so on a busy machine the stored undo point and the value handed to the caller differ by a tick — the flake in `packages/apps/src/lifecycle.test.ts > skips corrupt app and history rows in list surfaces`, and a small real disagreement between history and the door that wrote it. Fixes #930.

**Fix.** One clock read per save. `authored` builds the `VersionEntry` once, appends it, and records it in `editVersions` — the return leg of the existing `editIntents` channel. `edit` reports that row verbatim. A save that is refused already discards its version, so it now withdraws the entry too, and `edit` never reports a row history does not hold.

**Overlapping edits** (Greptile P1, second commit). The map is keyed by app, like `editIntents`, so two edits of one app share a slot. The WORDS decide whose row it is: `takeEditVersion` takes the entry only when its intent is the instruction that edit was given, and otherwise leaves the sibling's row where it is and stamps its own version the way this door always did. Every miss degrades to that stamp — the millisecond skew this PR removes in the ordinary case — and none can report another edit's row. Covered by `never reports an overlapping edit's version as its own`, which drives two interleaved edits of one app on a faked clock and fails deterministically without the guard (`expected 'Second' to be 'First'`). Full per-invocation correlation would thread an edit id through the assembler and `authored` — the same public-seam change flagged below for the ladder — and is deliberately out of scope.

**Red → green (deterministic, not a reroll).** New test `reports the version history stored, not a later clock read` fakes `Date` only (`vi.useFakeTimers({ toFake: ["Date"] })`, the repo's existing time-control pattern) and advances the clock 1ms the moment the assembler's save returns — the straddle that used to need a busy machine. Before the fix:

```
FAIL  src/lifecycle.test.ts > apps lifecycle > reports the version history stored, not a later clock read
AssertionError: expected [ { …(3) } ] to deeply equal [ { …(3) } ]

  Array [
    Object {
-     "at": "2026-07-12T12:00:00.002Z",
+     "at": "2026-07-12T12:00:00.001Z",
      "intent": "Edited",
      "rung": 1,
    },
  ]
```

After: `Test Files 1 passed · Tests 13 passed`. The pre-existing flaky assertion was not touched.

**Other paths in the same file.** Checked all of them. The box edit (`editServerViaBox`), `pins.fork` and `pins.rebase` already mint one `VersionEntry`, pass it to the write and return that same object — nothing to fix. `edit`'s **escalation ladder** (`runServerWork`) still re-reads the clock for the version it reports: that path writes through `land`/the surface flip inside `runServerLane`, can land more than one row per edit, and shares `landVersion` with `create`, so "which row is the answer" is a design question rather than a shared timestamp. Left alone deliberately, per the scope of this fix; it degrades to today's behaviour (a version whose `at` may be a tick off), never to a wrong app's row.

**Gate** (scoped, from the worktree root): `pnpm build` ✅ · `pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm test:affected` — `@vendoai/apps` 1053 passed / 19 skipped, 36 of 37 tasks green.

The one red task is `@vendoai-fixtures/integration` (8 failures), which is **red on untouched `origin/main`**: I stashed this change, rebuilt, and reproduced the same 6 fast failures (`app-edit`, `chat-generates-app`, `external-capability` ×4) plus the two 120s anon-session timeouts on the unmodified tree. Not touched here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure `runtime.edit` returns the exact version row that history stores, using a single clock read to avoid 1ms timestamp mismatches. Fixes #930.

- **Bug Fixes**
  - Write the `VersionEntry` once in the save path and record it in `editVersions`; `edit` now returns that row verbatim.
  - Clear `editVersions` at the start of assemble, delete it after returning, and withdraw it on refused saves to avoid stale or mismatched versions.
  - Add a deterministic test to confirm the returned version matches history even across clock ticks.

<sup>Written for commit 277997706ee9e42fe7aceb5e6207ec9427394337. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


