### PR TITLE
fix(harnesses): an invented skill name degrades the hire, not kills it

### DIFF
--- a/packages/harnesses/src/vendo/vendo.test.ts
+++ b/packages/harnesses/src/vendo/vendo.test.ts
@@ -7,6 +7,7 @@
  * These suites assert the LOOP, not a model: the thinker is scripted so what is
  * measured is the lift.
  */
+import { createTurnSkills, renderSkillMd, skillPath } from "@vendoai/core";
 import type { HarnessEvent, Json, ToolDescriptor, Turn } from "@vendoai/core";
 import { APICallError } from "ai";
 import { MockLanguageModelV3 } from "ai/test";
@@ -265,6 +266,15 @@ describe("vendo() — bounded by construction", () => {
 });
 
 describe("vendo() — subagent hiring (build-list item 4)", () => {
+  /** The brief one scripted call actually carried: the user half of the hire's
+   *  one-message thread. Read out rather than matched inside a JSON dump, so an
+   *  assertion can quote a notice that contains quotes of its own. */
+  const briefOf = (prompt: unknown): string =>
+    (prompt as Array<{ role: string; content: Array<{ text?: string }> }>)
+      .filter((message) => message.role === "user")
+      .flatMap((message) => message.content.map((part) => part.text ?? ""))
+      .join("");
+
   const skills = testSkills([
     {
       name: "building-apps",
@@ -327,13 +337,112 @@ describe("vendo() — subagent hiring (build-list item 4)", () => {
     expect(mirrored).toContain("result");
   });
 
-  it("hiring a subagent for an unknown skill fails the tool, not the turn", async () => {
+  it("hiring for a skill that does not exist degrades the hire — the specialist still runs", async () => {
     const model = scriptedModel([
-      toolCallTurn("hire_subagent", { instructions: "go", skill: "no-such-skill" }),
-      textTurn("I couldn't find the instructions for that."),
+      // The name a model GUESSES when it has no listing to read: the incident
+      // behind this case passed `research` where only `building-apps` existed.
+      toolCallTurn("hire_subagent", { instructions: "research the market", skill: "research" }),
+      textTurn("researched what I could"),
+      textTurn("Here's what I found."),
     ]);
     const { events } = await drive({ harness: vendo(), models: seats(model), skills });
-    expect(texts(events)).toContain("couldn't find");
+    // Three model calls: the specialist was hired, not lost to a wrong string.
+    expect(model.calls).toBe(3);
+    expect(texts(events)).toBe("Here's what I found.");
+    // ...and it was told what it is missing, so it can say what it could not cover.
+    const brief = briefOf(model.prompts[1]);
+    expect(brief).toContain('The "research" skill could not be loaded');
+    expect(brief).toContain("research the market");
+  });
+
+  it("loads a real skill in full even when a sibling hire names one that does not exist", async () => {
+    /** ONE step, TWO hires — the incident's shape. `toolCallTurn` carries a finish
+     *  part of its own, so the first hire's is dropped to splice them into a
+     *  single step. Both specialists reply the same words, so which of the two
+     *  takes which scripted turn cannot matter. */
+    const twoHires = [
+      ...toolCallTurn("hire_subagent", { instructions: "research the market", skill: "research" }, "h1")
+        .slice(0, -1),
+      ...toolCallTurn("hire_subagent", { instructions: "build the app", skill: "building-apps" }, "h2"),
+    ];
+    const model = scriptedModel([
+      twoHires,
+      textTurn("specialist done"),
+      textTurn("specialist done"),
+      textTurn("Both are done."),
+    ]);
+
+    const { events } = await drive({ harness: vendo(), models: seats(model), skills });
+
+    expect(texts(events)).toBe("Both are done.");
+    // A guessed name degrades ITS OWN hire and nothing else: the mounted skill's
+    // body still reached the specialist that asked for it.
+    const briefs = [briefOf(model.prompts[1]), briefOf(model.prompts[2])];
+    expect(briefs.filter((brief) => brief.includes("Run me in a fresh subagent"))).toHaveLength(1);
+    expect(briefs.filter((brief) => brief.includes('The "research" skill could not be loaded')))
+      .toHaveLength(1);
+  });
+
+  it("hires on a readable skill even when an UNRELATED one on the mount will not read", async () => {
+    const model = scriptedModel([
+      toolCallTurn("hire_subagent", { instructions: "build it", skill: "building-apps" }),
+      textTurn("subagent done"),
+      textTurn("Done."),
+    ]);
+    // The REAL store, over a mount carrying one broken neighbour. The hire opens
+    // its OWN skill and nothing else — `list()` would have read every file on the
+    // mount, including this one, and taken a perfectly good hire down with it.
+    const files: Record<string, string> = {
+      [skillPath("building-apps")]: renderSkillMd({
+        name: "building-apps",
+        description: "how to build an app",
+        body: "# Building apps\nRun me in a fresh subagent.",
+      }),
+      [skillPath("half-written")]: "",
+    };
+    const brokenMount = createTurnSkills({
+      getAllPaths: () => Object.keys(files),
+      readFile: async (path) => {
+        if (path === skillPath("half-written")) throw new Error("EIO: unreadable SKILL.md");
+        return files[path] as string;
+      },
+    });
+
+    const { events } = await drive({ harness: vendo(), models: seats(model), skills: brokenMount });
+
+    expect(model.calls).toBe(3);
+    expect(texts(events)).toBe("Done.");
+    // The full body, not the notice: this hire's own skill read fine.
+    const brief = briefOf(model.prompts[1]);
+    expect(brief).toContain("Run me in a fresh subagent");
+    expect(brief).not.toContain("could not be loaded");
+  });
+
+  it("hires with the same honest notice when the requested skill itself will not read", async () => {
+    const model = scriptedModel([
+      toolCallTurn("hire_subagent", { instructions: "build it", skill: "building-apps" }),
+      textTurn("did what I could without it"),
+      textTurn("Done."),
+    ]);
+    // The REQUESTED skill is mounted and its own file will not read. Nothing here
+    // can tell that from a name nobody mounted — `load()` throws the same plain
+    // `Error` for both — so the hire does not pretend to know which, and the one
+    // notice covers both truthfully.
+    const files: Record<string, string> = { [skillPath("building-apps")]: "" };
+    const unreadable = createTurnSkills({
+      getAllPaths: () => Object.keys(files),
+      readFile: async () => {
+        throw new Error("EIO: unreadable SKILL.md");
+      },
+    });
+
+    const { events } = await drive({ harness: vendo(), models: seats(model), skills: unreadable });
+
+    // Soft, like every other load failure: a running specialist beats a hire
+    // nobody made (#899), and the brief says plainly what did not arrive.
+    expect(model.calls).toBe(3);
+    expect(texts(events)).toBe("Done.");
+    expect(briefOf(model.prompts[1])).toContain('The "building-apps" skill could not be loaded');
   });
 
   it("reports the specialist's tokens as the SPECIALIST's, never folded into the turn's", async () => {

--- a/packages/harnesses/src/vendo/vendo.ts
+++ b/packages/harnesses/src/vendo/vendo.ts
@@ -44,6 +44,22 @@ const SPECIALIST_SYSTEM =
 const HIRE_SUBAGENT = "hire_subagent";
 
 /**
+ * What a specialist is handed instead of the skill it was hired with, when that
+ * skill could not be loaded. Written for the SPECIALIST, not the user: like
+ * `SPECIALIST_SYSTEM`, this text is read by another agent.
+ *
+ * A degraded hire beats no hire (#899), but only if what it is told is TRUE — the
+ * specialist acts on this and the transcript keeps it. Nothing here can tell an
+ * invented name from a file that will not read (`load()` throws the same plain
+ * `Error` for both), so the notice does not pretend to: it names both
+ * possibilities, which is the whole of what is actually known.
+ */
+const unloadableSkillNotice = (name: string): string =>
+  `The "${name}" skill could not be loaded — it may not exist, or this deployment's `
+  + `skills may themselves be unreadable — so the instructions it was to give you are not `
+  + `in this brief. Do the job below with the tools you have, and say what you could not cover.`;
+
+/**
  * The per-turn knobs — the TYPE is the whole declaration.
  *
  * There was a `Harness.optionsSchema` here too, restating these knobs as zod. It
@@ -283,6 +299,26 @@ function usageOf(usage: LanguageModelUsage, model: LanguageModel): UsageTotals {
 }
 
 /**
+ * The head of a brief for a hire that named a skill: the full SKILL.md body — the
+ * job description, and the point of hiring rather than inlining — or the notice
+ * that says it is not coming.
+ *
+ * ONE call and one fallback, because a hire has one job. Whatever went wrong, the
+ * answer is the same: load nothing, say so in the brief, run the specialist. So
+ * there is nothing to classify, and nothing else on the mount is ever opened —
+ * `createTurnSkills.list()` reads every mounted SKILL.md to describe it, so
+ * consulting it would let one unreadable file anywhere take down a hire whose own
+ * skill is perfectly fine.
+ */
+async function skillHead(turn: Turn<unknown>, skill: string): Promise<string> {
+  try {
+    return `${await turn.skills.load(skill)}\n\n---\n\n`;
+  } catch {
+    return `${unloadableSkillNotice(skill)}\n\n`;
+  }
+}
+
+/**
  * A hired subagent: a fresh, blinkered loop with the same hands and the same
  * guard, whose OWN words never leave this function. The resident keeps only the
  * receipt — its private context, not a wire artifact, so the one-assistant law
@@ -300,13 +336,10 @@ async function runSubagent(
    *  is nothing for it to remember and nothing of the thread's for it to spend. */
   compaction: TurnCompaction,
 ): Promise<SubagentReport> {
-  let brief = input.instructions;
-  if (input.skill !== undefined) {
-    // The full SKILL.md body is the job description; loading it is the point of
-    // hiring rather than inlining.
-    const body = await turn.skills.load(input.skill);
-    brief = `${body}\n\n---\n\n${input.instructions}`;
-  }
+  const { skill } = input;
+  const brief = skill === undefined
+    ? input.instructions
+    : `${await skillHead(turn, skill)}${input.instructions}`;
   // THE shipped loop, for the hire as well: every rail `startTurn` owns reaches
   // the specialist too, so it cannot drift from the resident on any of them.
   const loop = await startTurn({


### PR DESCRIPTION
## Problem

`hire_subagent` loaded its named skill straight through `turn.skills.load`, which throws for a name nothing mounted — so one guessed string cost the entire hire. In the S6 real-user proof (#891) the model passed `skill: "research"` where only `building-apps` and `format-reference` existed, and **both** parallel hires came back "The specialist could not be reached for that job."

## The fix

A skill that will not load is a per-hire soft failure. Load nothing, prepend one notice to the brief, run the specialist.

```ts
async function skillHead(turn: Turn<unknown>, skill: string): Promise<string> {
  try {
    return `${await turn.skills.load(skill)}\n\n---\n\n`;
  } catch {
    return `${unloadableSkillNotice(skill)}\n\n`;
  }
}
```

The notice:

```
The "research" skill could not be loaded — it may not exist, or this deployment's
skills may themselves be unreadable — so the instructions it was to give you are
not in this brief. Do the job below with the tools you have, and say what you
could not cover.
```

One call, one fallback, one notice — 40 lines of product, most of it comment.

**Why the notice names both possibilities.** `load()` throws a plain `Error` for a name nobody mounted and for a file that will not read alike. Nothing at this seam can tell them apart, so the notice does not pretend to. It says exactly what is known, which keeps it true in both cases and means one notice can serve every failure.

**Why nothing consults `turn.skills.list()`.** Whatever went wrong, the answer is the same, so there is nothing to classify — and not asking is also what makes the hire independent of the rest of the mount. `createTurnSkills.list()` reads *every* mounted SKILL.md to describe it, so consulting it would let one unreadable file anywhere take down a hire whose own skill is perfectly fine. There is now no path on which a hire opens a file other than its own skill's.

**A broken mount is not hidden.** The notice states in the brief — and therefore in the transcript — that the skill could not be loaded and that the deployment's skills may themselves be unreadable. The specialist reads it and reports against it; nothing fails silently.

### On "several skills, one unknown"

`hire_subagent`'s input takes a single optional `skill` string, so a hire cannot name a list — there is no mixed list to partially load. The equivalent case is a *sibling* hire, which is what one test pins: two hires in one step, one naming `research` and one naming `building-apps`, and the real skill's body still reaches the specialist that asked for it.

## Tests

Four, all against the real `createTurnSkills` where a mount is involved:

1. unknown skill → the hire runs and the brief carries the notice
2. a real skill still loads in full (and a sibling hire's bad name does not touch it)
3. the requested skill's own file will not read → the hire runs with the same notice
4. an unrelated unreadable skill on the mount never blocks a readable hire — the #899 incident's other half

## Red → green

Each behaviour got its own red first.

**1. The original defect** (test commit `d1637da`, against the unchanged loader):

```
[vendo] harness: subagent failed { error: 'no such skill: research' }
 × hiring for a skill that does not exist degrades the hire — the specialist still runs
   → expected 2 to be 3
```

Two model calls, not three: the specialist never ran.

**2. Sibling coupling** (against `d46bc04`, real store, broken *neighbour*):

```
[vendo] harness: subagent failed { error: 'EIO: unreadable SKILL.md' }
 × hires on a readable skill even when an UNRELATED one on the mount will not read
   → expected 2 to be 3
```

The hire died on a file that had nothing to do with it.

**3. The notice's honesty** (against `15d1f2b`, requested skill mounted and unreadable):

```
 × never tells the specialist a broken skill is missing
   → expected 'There is no "building-apps" skill, so…' not to contain 'There is no'
```

The old wording denied the existence of a skill that exists.

**Final shape** — the branch reached this behaviour through an intermediate version that classified failures three ways using `list()`. That machinery was **removed before merge at the repo owner's instruction** as scope beyond what #899 asked (`d87e330`); the always-soft path above is what ships. See the comment below.

```
@vendoai/harnesses  Test Files  44 passed | 4 skipped (48)
                         Tests  567 passed | 14 skipped (581)
```

### Existing tests changed, each in its own commit with the reason

- `"hiring a subagent for an unknown skill fails the tool, not the turn"` pinned exactly the behaviour the issue reports as the defect — replaced in `d1637da`.
- `"still fails the hire when a skill that IS mounted cannot be read"` pinned the hard-fail branch — deleted in `d87e330` when that branch was removed on the owner's ruling.

No other existing test was touched.

## Gate

| | |
|---|---|
| `pnpm build` | pass |
| `pnpm typecheck` | pass |
| `pnpm lint` | pass |
| `@vendoai/harnesses` suite | 567 passed, 14 skipped |

Earlier full `test:affected` runs on this branch were green except `@vendoai-fixtures/integration`, which fails 8 app-generation-through-the-wire tests. Verified pre-existing by checking out untouched `origin/main` (5f643c7), rebuilding, and running the same suite: the identical 8 failures. Not touched here.

**Diff:** 40 added / 7 removed in product (`vendo.ts`), 113 / 4 in tests. No UI surface.

Fixes #899