### PR TITLE
chore(deps): clear five of six audit advisories (js-yaml high via mastra example)

### DIFF
--- a/fixtures/integration/src/external-capability.e2e.test.ts
+++ b/fixtures/integration/src/external-capability.e2e.test.ts
@@ -20,6 +20,7 @@ import {
   createStack,
   generationTurn,
   resetFixture,
+  reviewerTurn,
   screenAgentCreateTurns,
   textTurn,
   toolCallTurn,
@@ -252,6 +253,10 @@ describe("E5: the contributed judgment rule reaches the live reviewer", () => {
    * the appId the front door minted for this ask is read back off the brief the
    * loop was just handed. The reviewer's own model call sits between the validate
    * step and the closing one, which is why REVIEW_SILENT is scripted there.
+   *
+   * And the mandatory pass asks it AGAIN after the loop stops — a painted screen
+   * faces the reviewer whether or not the loop volunteered — so the script ends
+   * with that verdict too.
    */
   const saveThenValidateTurns = [
     toolCallTurn("save_app", { content: CLEAN_APP }, "screen_save"),
@@ -259,6 +264,7 @@ describe("E5: the contributed judgment rule reaches the live reviewer", () => {
       toolCallTurn("validate", { appId: appIdInPrompt(prompt) }, "screen_validate"),
     generationTurn(REVIEW_SILENT, "review_1"),
     textTurn("saved", "screen_done"),
+    reviewerTurn(),
   ];
 
   it("puts the rule on the reviewer's rubric in the composed server, not just in a list", async () => {

--- a/fixtures/integration/src/harness.ts
+++ b/fixtures/integration/src/harness.ts
@@ -113,22 +113,46 @@ export function generationTurn(dialect: unknown, id = "gen_1"): LanguageModelV3S
 }
 
 /**
- * The screen agent's two turns for one `vendo_make` ask: save the whole
- * document with its own hands, then stop. A CREATE and an EDIT are the same
- * loop — an edit is the assembler opening this app's own document and saving it
- * back — so one helper scripts either.
+ * The AI reviewer's verdict on one finished screen — a `report_findings` strict
+ * tool call over `doGenerate` (`packages/apps/src/checking/strict-tool-call.ts`),
+ * empty by default because "nothing wrong" is what a fixture app deserves.
+ *
+ * Scripted as the call it really is rather than left to run the script dry:
+ * `strictToolCall` swallows every failure into "no findings", so an unscripted
+ * reviewer passes for the wrong reason AND eats the turn the caller after it was
+ * waiting for.
+ */
+export function reviewerTurn(
+  findings: ReadonlyArray<{ severity: "block" | "warn"; where: string; message: string }> = [],
+  toolCallId = "screen_review",
+): LanguageModelV3StreamPart[] {
+  return toolCallTurn("report_findings", { findings }, toolCallId);
+}
+
+/**
+ * The screen agent's turns for one `vendo_make` ask: save the whole document
+ * with its own hands, stop, and then face the reviewer. A CREATE and an EDIT are
+ * the same loop — an edit is the assembler opening this app's own document and
+ * saving it back — so one helper scripts either.
  *
  * Every `vendo_make` ask starts in the assembly loop now — that used to be
  * behind `apps.experimentalScreenAgent` and the flag is gone — so a script that
  * only feeds the conductor's generation turns runs the assembly loop out of
  * answers and then feeds ITS turns to the conductor, one call out of step.
- * Written as one helper rather than two lines per fixture because the pair is
- * one thing: "the screen agent answered this ask".
+ * Written as one helper rather than three lines per fixture because the three
+ * are one thing: "the screen agent answered this ask".
+ *
+ * The reviewer turn is part of that one thing because the pass is MANDATORY: a
+ * screen that PAINTED faces it once at the finish line whether or not the loop
+ * called `validate` itself (`screen-agent.ts`'s mandatory reviewer pass). A save
+ * the floor blocks never paints, so that ask leaves this turn unspent — an
+ * unused turn costs a script nothing, and a missing one costs it the next call.
  */
 export function screenAgentCreateTurns(dialect: string): LanguageModelV3StreamPart[][] {
   return [
     toolCallTurn("save_app", { content: dialect }, "screen_save"),
     textTurn("saved", "screen_done"),
+    reviewerTurn(),
   ];
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,12 @@ overrides:
   next-auth: '>=5.0.0-beta.32'
   next: '>=16.2.11'
   '@types/react-dom': ^19.2.0
-  postcss@<8.5.18: '>=8.5.18'
+  postcss@<8.5.23: '>=8.5.23'
+  js-yaml@>=3 <3.15.1: '>=3.15.1 <4'
+  js-yaml@>=4 <4.3.1: '>=4.3.1 <5'
+  tar@>=7 <7.5.21: '>=7.5.21 <8'
+  hono@>=4 <4.12.34: '>=4.12.34 <5'
+  '@hono/node-server@<2.0.5': '>=2.0.5 <3'
   brace-expansion@<1.1.18: '>=1.1.18 <2'
   brace-expansion@>=2 <2.1.4: '>=2.1.4 <3'
   brace-expansion@>=4 <5.0.9: '>=5.0.9 <6'
@@ -431,7 +436,7 @@ importers:
         version: 6.0.230(zod@3.25.76)
       mastra:
         specifier: ^1.18.2
-        version: 1.19.0(@hono/node-server@1.19.14(hono@4.12.29))(@mastra/core@1.51.0(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.230(zod@3.25.76))(express@5.2.1)(rxjs@7.8.1)(zod@3.25.76))(rxjs@7.8.1)(typescript@5.9.3)(zod@3.25.76)
+        version: 1.19.0(@hono/node-server@2.1.0(hono@4.13.0))(@mastra/core@1.51.0(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.230(zod@3.25.76))(express@5.2.1)(rxjs@7.8.1)(zod@3.25.76))(rxjs@7.8.1)(typescript@5.9.3)(zod@3.25.76)
       next:
         specifier: '>=16.2.11'
         version: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@22.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2592,18 +2597,18 @@ packages:
   '@floating-ui/utils@0.2.12':
     resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
 
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
+  '@hono/node-server@2.1.0':
+    resolution: {integrity: sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==}
+    engines: {node: '>=20'}
     peerDependencies:
-      hono: ^4
+      hono: '>=4.12.34 <5'
 
   '@hono/node-ws@1.3.1':
     resolution: {integrity: sha512-vo/MwCnpJAVHBkGzWjCJ28wF45fYHAfbPZcH2rodZODHtch2GHA94KtMfusmVycTUtsLAsaNsHhtY6P8X3RQsA==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      '@hono/node-server': ^1.19.11
-      hono: ^4.6.0
+      '@hono/node-server': '>=2.0.5 <3'
+      hono: '>=4.12.34 <5'
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -5762,8 +5767,8 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
-  hono@4.12.29:
-    resolution: {integrity: sha512-1hNiRjawYrLq/4m3DQQjPGFg0VZkk4RjQJDff/excI6Dm9BiL75qxGrd7/c6YOxPdq6AscP3LiXhQ6fKFC1Waw==}
+  hono@4.13.0:
+    resolution: {integrity: sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@4.0.0:
@@ -6118,12 +6123,12 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@25.0.1:
@@ -7038,8 +7043,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.22:
-    resolution: {integrity: sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==}
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -7751,8 +7756,8 @@ packages:
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
 
-  tar@7.5.20:
-    resolution: {integrity: sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==}
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
     engines: {node: '>=18'}
 
   teex@1.0.1:
@@ -9005,7 +9010,7 @@ snapshots:
   '@changesets/parse@0.4.3':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -9465,7 +9470,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -9510,14 +9515,14 @@ snapshots:
 
   '@floating-ui/utils@0.2.12': {}
 
-  '@hono/node-server@1.19.14(hono@4.12.29)':
+  '@hono/node-server@2.1.0(hono@4.13.0)':
     dependencies:
-      hono: 4.12.29
+      hono: 4.13.0
 
-  '@hono/node-ws@1.3.1(@hono/node-server@1.19.14(hono@4.12.29))(hono@4.12.29)':
+  '@hono/node-ws@1.3.1(@hono/node-server@2.1.0(hono@4.13.0))(hono@4.13.0)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.29)
-      hono: 4.12.29
+      '@hono/node-server': 2.1.0(hono@4.13.0)
+      hono: 4.13.0
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -9896,12 +9901,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@mastra/deployer@1.51.0(@hono/node-server@1.19.14(hono@4.12.29))(@mastra/core@1.51.0(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.230(zod@3.25.76))(express@5.2.1)(rxjs@7.8.1)(zod@3.25.76))(typescript@5.9.3)(zod@3.25.76)':
+  '@mastra/deployer@1.51.0(@hono/node-server@2.1.0(hono@4.13.0))(@mastra/core@1.51.0(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.230(zod@3.25.76))(express@5.2.1)(rxjs@7.8.1)(zod@3.25.76))(typescript@5.9.3)(zod@3.25.76)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
       '@babel/traverse': 7.29.7
-      '@hono/node-ws': 1.3.1(@hono/node-server@1.19.14(hono@4.12.29))(hono@4.12.29)
+      '@hono/node-ws': 1.3.1(@hono/node-server@2.1.0(hono@4.13.0))(hono@4.13.0)
       '@mastra/core': 1.51.0(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.230(zod@3.25.76))(express@5.2.1)(rxjs@7.8.1)(zod@3.25.76)
       '@mastra/server': 1.51.0(@mastra/core@1.51.0(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.230(zod@3.25.76))(express@5.2.1)(rxjs@7.8.1)(zod@3.25.76))(zod@3.25.76)
       '@optimize-lodash/rollup-plugin': 5.1.0(rollup@4.62.2)
@@ -9918,7 +9923,7 @@ snapshots:
       find-workspaces: 0.3.1
       fs-extra: 11.3.6
       gray-matter: 4.0.3
-      hono: 4.12.29
+      hono: 4.13.0
       local-pkg: 1.2.1
       resolve.exports: 2.0.3
       rollup: 4.62.2
@@ -9994,7 +9999,7 @@ snapshots:
   '@mastra/server@1.51.0(@mastra/core@1.51.0(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.230(zod@3.25.76))(express@5.2.1)(rxjs@7.8.1)(zod@3.25.76))(zod@3.25.76)':
     dependencies:
       '@mastra/core': 1.51.0(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.230(zod@3.25.76))(express@5.2.1)(rxjs@7.8.1)(zod@3.25.76)
-      hono: 4.12.29
+      hono: 4.13.0
       zod: 3.25.76
 
   '@mixmark-io/domino@2.2.0': {}
@@ -10010,7 +10015,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.29)
+      '@hono/node-server': 2.1.0(hono@4.13.0)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -10020,7 +10025,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.29
+      hono: 4.13.0
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -10034,7 +10039,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.29)
+      '@hono/node-server': 2.1.0(hono@4.13.0)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -10044,7 +10049,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.29
+      hono: 4.13.0
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -10774,7 +10779,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.2
       '@tailwindcss/oxide': 4.3.2
-      postcss: 8.5.22
+      postcss: 8.5.25
       tailwindcss: 4.3.2
 
   '@tanstack/query-core@5.101.2': {}
@@ -12040,7 +12045,7 @@ snapshots:
       glob: 11.1.0
       openapi-fetch: 0.14.1
       platform: 1.3.6
-      tar: 7.5.20
+      tar: 7.5.22
       undici: 7.29.0
 
   eastasianwidth@0.2.0: {}
@@ -12980,7 +12985,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -13039,7 +13044,7 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
-  hono@4.12.29: {}
+  hono@4.13.0: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:
@@ -13363,12 +13368,12 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -13641,14 +13646,14 @@ snapshots:
 
   markdown-table@3.0.4: {}
 
-  mastra@1.19.0(@hono/node-server@1.19.14(hono@4.12.29))(@mastra/core@1.51.0(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.230(zod@3.25.76))(express@5.2.1)(rxjs@7.8.1)(zod@3.25.76))(rxjs@7.8.1)(typescript@5.9.3)(zod@3.25.76):
+  mastra@1.19.0(@hono/node-server@2.1.0(hono@4.13.0))(@mastra/core@1.51.0(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.230(zod@3.25.76))(express@5.2.1)(rxjs@7.8.1)(zod@3.25.76))(rxjs@7.8.1)(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
       '@clack/prompts': 1.7.0
       '@expo/devcert': 1.2.1
       '@mastra/core': 1.51.0(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.230(zod@3.25.76))(express@5.2.1)(rxjs@7.8.1)(zod@3.25.76)
-      '@mastra/deployer': 1.51.0(@hono/node-server@1.19.14(hono@4.12.29))(@mastra/core@1.51.0(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.230(zod@3.25.76))(express@5.2.1)(rxjs@7.8.1)(zod@3.25.76))(typescript@5.9.3)(zod@3.25.76)
+      '@mastra/deployer': 1.51.0(@hono/node-server@2.1.0(hono@4.13.0))(@mastra/core@1.51.0(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.230(zod@3.25.76))(express@5.2.1)(rxjs@7.8.1)(zod@3.25.76))(typescript@5.9.3)(zod@3.25.76)
       '@mastra/loggers': 1.2.0(@mastra/core@1.51.0(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.230(zod@3.25.76))(express@5.2.1)(rxjs@7.8.1)(zod@3.25.76))
       archiver: 8.0.0
       commander: 14.0.3
@@ -14173,7 +14178,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.43
       caniuse-lite: 1.0.30001805
-      postcss: 8.5.22
+      postcss: 8.5.25
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.4)
@@ -14200,7 +14205,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.43
       caniuse-lite: 1.0.30001805
-      postcss: 8.5.22
+      postcss: 8.5.25
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.4)
@@ -14227,7 +14232,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.43
       caniuse-lite: 1.0.30001805
-      postcss: 8.5.22
+      postcss: 8.5.25
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(react@19.2.4)
@@ -14254,7 +14259,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.43
       caniuse-lite: 1.0.30001805
-      postcss: 8.5.22
+      postcss: 8.5.25
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(react@19.2.4)
@@ -14281,7 +14286,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.43
       caniuse-lite: 1.0.30001805
-      postcss: 8.5.22
+      postcss: 8.5.25
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       styled-jsx: 5.1.6(react@19.2.7)
@@ -14637,7 +14642,7 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.22:
+  postcss@8.5.25:
     dependencies:
       nanoid: 3.3.16
       picocolors: 1.1.1
@@ -14866,7 +14871,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       pify: 4.0.1
       strip-bom: 3.0.0
 
@@ -15625,7 +15630,7 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  tar@7.5.20:
+  tar@7.5.22:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
@@ -16047,7 +16052,7 @@ snapshots:
   vite@5.4.21(@types/node@22.20.0)(lightningcss@1.32.0)(terser@5.48.0):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.5.22
+      postcss: 8.5.25
       rollup: 4.62.2
     optionalDependencies:
       '@types/node': 22.20.0
@@ -16060,7 +16065,7 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
-      postcss: 8.5.22
+      postcss: 8.5.25
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -16077,7 +16082,7 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
-      postcss: 8.5.22
+      postcss: 8.5.25
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -77,7 +77,64 @@ overrides:
   "@types/react-dom": "^19.2.0"
   # 2026-07-24 advisory: PostCSS path traversal in previous source map,
   # GHSA-r28c-9q8g-f849 (<=8.5.17) — floor raised from the earlier 8.5.10 line.
-  "postcss@<8.5.18": ">=8.5.18"
+  # Raised again 2026-08-06 to 8.5.23 for GHSA-fxqj-rqcc-2cmp (<=8.5.22), the
+  # incomplete-fix follow-up to GHSA-6g55-p6wh-862q. The override exists at all
+  # because next pins postcss exactly (16.2.11 -> 8.4.31), so the consumers
+  # (examples/{ai-sdk-agent,demo-bank} > next, demo-bank > next-auth > next)
+  # cannot reach the patch on their own. Drop it once every next in the tree
+  # pins >=8.5.23 (next 16.3.0 does).
+  "postcss@<8.5.23": ">=8.5.23"
+  # 2026-08-06 advisory: js-yaml quadratic CPU consumption resolving !!omap,
+  # GHSA-5p4m-2wfm-xmqj / CVE-2026-59870 (>=3.0.0 <3.15.1 and >=4.0.0 <4.3.1).
+  # This is the HIGH that reddened the required `audit` check repo-wide.
+  #
+  # The 3.x line is the prod path: examples/mastra-agent > @mastra/core >
+  # gray-matter, which declares `js-yaml: ^3.13.1` and is itself unmaintained at
+  # 4.0.3, so the 3.15.1 backport is already inside its declared range — the
+  # lockfile was simply pinned to 3.15.0. Floored per major line, and bounded,
+  # because gray-matter calls the removed 3.x `safeLoad` API: letting this floor
+  # walk to 4.x or 5.x would break that CJS consumer at runtime.
+  #
+  # The 4.x floor is dev-tooling hygiene, not a prod fix — 4.3.0's only
+  # consumers are @changesets/parse and @eslint/eslintrc, which is why
+  # `pnpm audit --prod` never flagged it. Same advisory, so it is closed here
+  # rather than left to rot until the day a prod path picks up js-yaml 4.
+  "js-yaml@>=3 <3.15.1": ">=3.15.1 <4"
+  "js-yaml@>=4 <4.3.1": ">=4.3.1 <5"
+  # 2026-08-06 advisory: node-tar uncontrolled recursion in mapHas/filesFilter,
+  # an uncatchable stack-overflow DoS from a crafted long-path archive,
+  # GHSA-r292-9mhp-454m (<=7.5.20). Reaches the prod graph only via
+  # examples/demo-bank > e2b, which declares `tar: ^7.5.19` — the patch is
+  # inside its range and the lockfile was pinned to 7.5.20. Bounded to the 7.x
+  # line that is actually installed.
+  "tar@>=7 <7.5.21": ">=7.5.21 <8"
+  # 2026-08-06 advisories, both arriving through @modelcontextprotocol/sdk:
+  #   - hono ReDoS in the CORS middleware via Access-Control-Request-Headers,
+  #     GHSA-8j4g-w8fx-2239 (<4.12.34). The sdk declares `hono: ^4.11.4`, so
+  #     the patch is in range; the lockfile was pinned to 4.12.29.
+  #   - @hono/node-server path traversal in serve-static on Windows via an
+  #     encoded backslash, GHSA-frvp-7c67-39w9 (<2.0.5).
+  #
+  # Not examples-only: `pnpm why --prod` puts both in the published
+  # @vendoai/{mcp,engine,apps,harnesses} trees (apps/harnesses via
+  # @anthropic-ai/claude-agent-sdk>@modelcontextprotocol/sdk), alongside
+  # examples/mastra-agent>@mastra/core.
+  #
+  # The node-server floor is the one deliberate exception to this file's
+  # don't-cross-a-major rule: there is NO 1.x backport — upstream's only
+  # patched version is 2.0.5 — so the choice is 2.x or carry the advisory
+  # forever. Checked rather than assumed, because the installed sdk (1.29.0)
+  # still declares `^1.19.9`, i.e. this floor is outside its range:
+  #   - sdk 1.30.0 declares `^1.19.9 || ^2.0.5`, so upstream has blessed 2.x;
+  #   - sdk 1.29.0 imports exactly `serve` and `getRequestListener`, and 2.1.0
+  #     exports both (its breaking changes are elsewhere);
+  #   - @hono/node-ws@1.3.1 lists node-server as a peer but imports nothing
+  #     from it at runtime (only `hono/ws`, `node:http`, `ws`), so the unmet
+  #     peer range is types-only.
+  # Drop this floor once the tree carries @modelcontextprotocol/sdk >=1.30.0,
+  # which asks for the patched line itself. Both bounded below the next major.
+  "hono@>=4 <4.12.34": ">=4.12.34 <5"
+  "@hono/node-server@<2.0.5": ">=2.0.5 <3"
   # 2026-08-03 advisory: brace-expansion DoS via unbounded intermediate arrays
   # bypassing the CVE-2026-14257 mitigation, GHSA-rgw5-rvv9-x895 (<1.1.18 and
   # >=4.0.0 <5.0.9). Reaches the prod graph only transitively:


### PR DESCRIPTION
## Why

The required `audit` check is red **repo-wide, including on `main`**, so it
blocks every merge. It runs `pnpm audit --prod --audit-level high`, and the
js-yaml high (GHSA-5p4m-2wfm-xmqj) failed it.

This is that fix as its own chore PR — no product change, only dependency
resolution.

## Red → green

**Before** (on `origin/main`, `pnpm audit --prod --audit-level high` → exit 1):

```
│ high                │ JS-YAML: Quadratic CPU consumption in !!omap           │
│                     │ resolution (3.x and 4.x) — CVE-2026-59870 fix not      │
│                     │ backported                                             │
│ Package             │ js-yaml                                                │
│ Vulnerable versions │ >=3.0.0 <3.15.1                                        │
│ Patched versions    │ >=3.15.1                                               │
│ Paths               │ examples__mastra-agent>@mastra/ai-sdk>@mastra/         │
│                     │ core>gray-matter>js-yaml                               │
│                     │ ... Found 12 paths                                     │
6 vulnerabilities found
Severity: 1 low | 4 moderate | 1 high
```

**After** (same command → exit 0):

```
1 vulnerabilities found
Severity: 1 low
```

The gate passes. The full-severity run (`pnpm audit --prod`, no threshold) went
from `1 low | 4 moderate | 1 high` to `1 low`.

## What changed, per advisory

Every fixable one was a **stale lockfile resolution** — the patched version
already sat inside the consumer's own declared range, and the lockfile was
simply pinned below it. Each is closed with a bounded, per-major-line security
floor in `pnpm-workspace.yaml`, matching the convention already in that file,
and commented with its advisory ID, the dependent that needs it, and the
condition for dropping it.

| Sev | Package | Advisory | Was → now | Reached via | Note |
|---|---|---|---|---|---|
| **high** | `js-yaml` (3.x) | GHSA-5p4m-2wfm-xmqj | 3.15.0 → **3.15.1** | mastra-agent > @mastra/core > gray-matter | gray-matter declares `^3.13.1`; bounded `<4` because it calls the removed 3.x `safeLoad` |
| high | `js-yaml` (4.x) | GHSA-5p4m-2wfm-xmqj | 4.3.0 → **4.3.1** | @changesets/parse, @eslint/eslintrc | dev-only, which is why `--prod` never flagged it; same advisory, closed here |
| moderate | `hono` | GHSA-8j4g-w8fx-2239 | 4.12.29 → **4.13.0** | @modelcontextprotocol/sdk (declares `^4.11.4`) | |
| moderate | `@hono/node-server` | GHSA-frvp-7c67-39w9 | 1.19.14 → **2.1.0** | @modelcontextprotocol/sdk | **crosses a major** — see below |
| moderate | `tar` | GHSA-r292-9mhp-454m | 7.5.20 → **7.5.22** | demo-bank > e2b (declares `^7.5.19`) | |
| moderate | `postcss` | GHSA-fxqj-rqcc-2cmp | 8.5.22 → **8.5.25** | next (pins 8.4.31 exactly) | existing floor raised 8.5.18 → 8.5.23 |
| low | `@ai-sdk/provider-utils` | GHSA-866g-f22w-33x8 | **not fixed** | @mastra/core | no patched release exists — see below |

`hono` and `@hono/node-server` are **not examples-only**: `pnpm why --prod`
puts both in the published `@vendoai/{mcp,engine,apps,harnesses}` trees, via
`@anthropic-ai/claude-agent-sdk > @modelcontextprotocol/sdk`.

### The one major bump, checked rather than assumed

`@hono/node-server` has no 1.x backport — upstream's only patched version is
2.0.5 — so the choice was 2.x or carry the advisory forever. The installed
`@modelcontextprotocol/sdk@1.29.0` still declares `^1.19.9`, i.e. this floor is
outside its range, so I verified the swap three ways:

- sdk **1.30.0 declares `^1.19.9 || ^2.0.5`** — upstream has blessed 2.x;
- sdk 1.29.0 imports exactly `serve` and `getRequestListener`, and 2.1.0
  exports both (`export { RequestError, createAdaptorServer, getRequestListener, serve, upgradeWebSocket }`);
- `@hono/node-ws@1.3.1` lists node-server as a peer but imports **nothing** from
  it at runtime (only `hono/ws`, `node:http`, `ws`), so the peer range is
  types-only. `pnpm peers check` reports no new violation.

The floor's comment says to drop it once the tree carries sdk >=1.30.0, which
asks for the patched line itself.

### The one advisory not fixed

`@ai-sdk/provider-utils` GHSA-866g-f22w-33x8 (**low**) has **no patched release
at all** — GitHub's advisory API reports `first_patched_version: null`, and the
highest published 3.0.x is 3.0.31 against a "patched >=3.0.98" claim. `@mastra/core`
pins it exactly (`@ai-sdk/provider-utils-v5: npm:@ai-sdk/provider-utils@3.0.28`)
for its AI-SDK-v5 compat slot, so forcing 4.x/5.x would break that shim.

It is left **honest and unmasked** — no `auditConfig` ignore, no threshold
change. It is low, below the gate's `high` threshold, and does not block. It
clears when mastra picks up an upstream fix.

## Gate

Run at the worktree root, all green:

| Step | Result |
|---|---|
| `pnpm install --frozen-lockfile` | ✅ (lockfile in sync, so CI's install passes) |
| `pnpm build` | ✅ 23/23 — includes `mastra-agent` (`next build`, compiled in 8.7s) |
| `pnpm typecheck` | ✅ 43/43 |
| `pnpm lint` | ✅ 3/3 (1 pre-existing demo-bank warning) |
| `pnpm audit --prod --audit-level high` | ✅ exit 0 |

**On test scope:** a lockfile change makes turbo mark **all 33 packages
affected**, i.e. `test:affected` becomes the full suite — which is CI's job, not
a laptop's. So I ran the packages whose resolved versions actually changed and
whose runtime could be affected by the hono/node-server major swap, capped at
`VITEST_MIN_FORKS=1 MAX_FORKS=2 MIN_THREADS=1 MAX_THREADS=2`:

- `@vendoai/mcp` 3 ✅ · `@vendoai/engine` 5 ✅ · `@vendoai/apps` 93 ✅ · `@vendoai/harnesses` 44 ✅ · `@vendoai-fixtures/mcp-e2e` 7 ✅
- `@vendoai/vendo` 203 ✅ · `@vendoai/ui` 122 ✅
- `demo-bank` 24 ✅ · `mastra-agent` 1 ✅ · `ai-sdk-agent` 2 ✅ · `mcp-agent`, `integration-browser` ✅

That's every consumer of the changed hono/node-server, tar and js-yaml prod
paths. `postcss` is a build-tool transitive that reaches nearly every package
but cannot change test behavior, and `pnpm build` covers it. CI's sharded run
is the full gate of record.

## Merge order

This PR's own `integration` check will stay red until the sibling
integration-fix PR — which targets **this** branch, not `main` — merges into it.
`@vendoai-fixtures/integration` is already red on `main` (deterministic,
"scripted model exhausted") and is untouched here. That's the planned unblock
order: sibling → this branch → `main`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks the repo-wide audit gate by flooring patched dependency versions and refreshing the lockfile, clearing 5 of 6 advisories (including the `js-yaml` high). Also updates integration fixtures to script the mandatory reviewer turn so runs stay in step.

- **Dependencies**
  - Added bounded security floors in `pnpm-workspace.yaml`:
    - `js-yaml`: `>=3.15.1 <4` and `>=4.3.1 <5`
    - `hono`: `>=4.12.34 <5`
    - `@hono/node-server`: `>=2.0.5 <3` (major; verified compatible)
    - `tar`: `>=7.5.21 <8`
    - `postcss`: `>=8.5.23`
  - Refreshed `pnpm-lock.yaml` to patched versions: `hono@4.13.0`, `@hono/node-server@2.1.0`, `js-yaml@3.15.1/4.3.1`, `tar@7.5.22`, `postcss@8.5.25`. One low in `@ai-sdk/provider-utils` remains unpatched and below the gate.

- **Bug Fixes**
  - Fixtures: added `reviewerTurn()` and included it in `screenAgentCreateTurns` and E5’s script to match the mandatory reviewer pass; prevents out‑of‑step scripts and timeouts with no assertion changes.

<sup>Written for commit 3d5323942fd90771bb308ca928a264492eeee0c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

