### PR TITLE
test(fixtures): the integration scripts feed the mandatory reviewer its turn

### DIFF
--- a/fixtures/integration/src/external-capability.e2e.test.ts
+++ b/fixtures/integration/src/external-capability.e2e.test.ts
@@ -20,6 +20,7 @@ import {
   createStack,
   generationTurn,
   resetFixture,
+  reviewerTurn,
   screenAgentCreateTurns,
   textTurn,
   toolCallTurn,
@@ -252,6 +253,10 @@ describe("E5: the contributed judgment rule reaches the live reviewer", () => {
    * the appId the front door minted for this ask is read back off the brief the
    * loop was just handed. The reviewer's own model call sits between the validate
    * step and the closing one, which is why REVIEW_SILENT is scripted there.
+   *
+   * And the mandatory pass asks it AGAIN after the loop stops — a painted screen
+   * faces the reviewer whether or not the loop volunteered — so the script ends
+   * with that verdict too.
    */
   const saveThenValidateTurns = [
     toolCallTurn("save_app", { content: CLEAN_APP }, "screen_save"),
@@ -259,6 +264,7 @@ describe("E5: the contributed judgment rule reaches the live reviewer", () => {
       toolCallTurn("validate", { appId: appIdInPrompt(prompt) }, "screen_validate"),
     generationTurn(REVIEW_SILENT, "review_1"),
     textTurn("saved", "screen_done"),
+    reviewerTurn(),
   ];
 
   it("puts the rule on the reviewer's rubric in the composed server, not just in a list", async () => {

--- a/fixtures/integration/src/harness.ts
+++ b/fixtures/integration/src/harness.ts
@@ -113,22 +113,46 @@ export function generationTurn(dialect: unknown, id = "gen_1"): LanguageModelV3S
 }
 
 /**
- * The screen agent's two turns for one `vendo_make` ask: save the whole
- * document with its own hands, then stop. A CREATE and an EDIT are the same
- * loop — an edit is the assembler opening this app's own document and saving it
- * back — so one helper scripts either.
+ * The AI reviewer's verdict on one finished screen — a `report_findings` strict
+ * tool call over `doGenerate` (`packages/apps/src/checking/strict-tool-call.ts`),
+ * empty by default because "nothing wrong" is what a fixture app deserves.
+ *
+ * Scripted as the call it really is rather than left to run the script dry:
+ * `strictToolCall` swallows every failure into "no findings", so an unscripted
+ * reviewer passes for the wrong reason AND eats the turn the caller after it was
+ * waiting for.
+ */
+export function reviewerTurn(
+  findings: ReadonlyArray<{ severity: "block" | "warn"; where: string; message: string }> = [],
+  toolCallId = "screen_review",
+): LanguageModelV3StreamPart[] {
+  return toolCallTurn("report_findings", { findings }, toolCallId);
+}
+
+/**
+ * The screen agent's turns for one `vendo_make` ask: save the whole document
+ * with its own hands, stop, and then face the reviewer. A CREATE and an EDIT are
+ * the same loop — an edit is the assembler opening this app's own document and
+ * saving it back — so one helper scripts either.
  *
  * Every `vendo_make` ask starts in the assembly loop now — that used to be
  * behind `apps.experimentalScreenAgent` and the flag is gone — so a script that
  * only feeds the conductor's generation turns runs the assembly loop out of
  * answers and then feeds ITS turns to the conductor, one call out of step.
- * Written as one helper rather than two lines per fixture because the pair is
- * one thing: "the screen agent answered this ask".
+ * Written as one helper rather than three lines per fixture because the three
+ * are one thing: "the screen agent answered this ask".
+ *
+ * The reviewer turn is part of that one thing because the pass is MANDATORY: a
+ * screen that PAINTED faces it once at the finish line whether or not the loop
+ * called `validate` itself (`screen-agent.ts`'s mandatory reviewer pass). A save
+ * the floor blocks never paints, so that ask leaves this turn unspent — an
+ * unused turn costs a script nothing, and a missing one costs it the next call.
  */
 export function screenAgentCreateTurns(dialect: string): LanguageModelV3StreamPart[][] {
   return [
     toolCallTurn("save_app", { content: dialect }, "screen_save"),
     textTurn("saved", "screen_done"),
+    reviewerTurn(),
   ];
 }
 


### PR DESCRIPTION
## What was wrong

`@vendoai-fixtures/integration` was deterministically red on untouched
`origin/main` (5f643c7c7) — 8 failures locally, 9 with Postgres — which took the
required `integration` check down and blocked every merge in the repo.

Every failure was the same error, `scripted model exhausted`, thrown from this
suite's own FIFO scripted model.

## Root cause

**#928 (`7163a2501`, feat(apps,harnesses): every finished screen faces the
reviewer).** It made the AI reviewer pass MANDATORY: a screen that PAINTS now
faces the reviewer once at the finish line, whether or not the assembly loop
volunteered to call `validate` itself.

```
screen-agent.ts, after the loop stops:
  if (record.assembled) {
    const instruction = record.painted
      ? repairInstruction(await validateWrittenApps({ …, review: true }))
      : undefined;
```

`validateWrittenApps({ review: true })` asks `validate` twice — the mechanical
door with `{ document }` (pure code), then the second door with `{ appId }`,
which composes the floor **and the reviewer**. The reviewer is
`strictToolCall` → one `generateText`. So every `vendo_make` ask now costs one
extra MODEL call.

This suite drives ONE FIFO script that both the agent loop (`doStream`) and the
engine (`doGenerate`) draw from, in consumption order. Every app-generation
journey was therefore one call out of step and then ran dry:

- **J1** — script: `vendo_make` → `save_app` → `"saved"` → `"Created your app."`.
  The reviewer ate turn 4, and the resident's closing step found the queue
  empty. `"Created your app."` never reached the stream.
- **E5** — create consumed `save_app` + `"saved"`, the reviewer ate the edit's
  `save_app`, and the edit's loop then answered with the leftover `"saved"` text
  turn. Nothing was ever saved, so the contributed check had nothing to object
  to — "a contributed check reports nothing".
- **ENG-263 / J7** — the same drift, ending in a hang: 120s and 92s timeouts.
- **J3 / J9** — the edit never applied / the row never landed.

The reviewer's own failure is swallowed (`strictToolCall` catches everything
into "no findings"), which is why the exhaustion never surfaced as a reviewer
error — it surfaced one caller later.

#928 updated the scripts it could see (`vendo-make-matrix.e2e.test.ts`,
`claude-code-composed.test.ts`) and missed this fixture package. It merged
during today's GitHub Actions outage, so no red run ever said so. (#931,
the prime suspect going in, is innocent: it only widens the in-process pack's
`vendo_make` schema and its description string, and this suite composes
`createVendo`, not the pack.)

## Which side of the seam

**Fixture side, entirely.** The mandatory pass is #928's deliberate feature —
verified live on Maple against a bills dashboard that double-counted an $11,216
headline over ~$6,276 of real bills, and covered product-side by
`packages/vendo/src/mandatory-reviewer.e2e.test.ts`. Nothing in the product
rejects a call a host legitimately makes; the fixture scripts simply predate the
extra turn. No product file is touched.

`screenAgentCreateTurns` now scripts the reviewer's verdict alongside the save
and the stop, because the three are one thing — "the screen agent answered this
ask" — so all six journeys are fixed at one point. The verdict is a real
`report_findings` tool call with an empty findings array rather than an
unscripted turn, matching how `mandatory-reviewer.e2e.test.ts` answers it: an
unscripted reviewer passes for the wrong reason (the swallow) AND eats the next
caller's turn. E5's explicit-`validate` script gets the same turn at its end for
the same reason.

A save the floor BLOCKS never paints, so those asks leave the turn unspent — an
unused turn costs a script nothing, a missing one costs it the next call.

**Not one assertion is weakened or removed.**

## Red → green

Before, on untouched `origin/main` (5f643c7c7):

```
× E5 … fires the contributed fact check on a generated app and reports what it found
× E5 … says nothing about an app the contributed check is happy with
× E5 … registers the contributed component in the catalog the engine builds against
× E5 … and the SAME edit is rejected when the component was not registered
× ENG-263 … adopts threads/apps into the signed-in subject …          120172ms → timed out
× J7 … gives each client its own subject, hides threads/apps/approvals …  91593ms → timed out
× J3 … creates, edits by saving the app's own document back …
× J1 … streams a turn that creates a vendo_apps row owned by ADA …

 Test Files  5 failed | 14 passed | 1 skipped (20)
      Tests  8 failed | 42 passed | 1 skipped (51)
  Duration  282.48s

Error: scripted model exhausted
    at shift (fixtures/integration/src/harness.ts:163:35)
    at doStream (fixtures/integration/src/harness.ts:168:78)
```

After, on this branch:

```
 Test Files  19 passed | 1 skipped (20)
      Tests  50 passed | 1 skipped (51)
  Duration  56.66s
```

J9 is the skipped one locally (it gates on `POSTGRES_URL`) — it is CI's 9th
failure, so it was proven separately against a real Postgres:

```
# origin/main fixture, POSTGRES_URL set
× J9: core journeys on Postgres survive a serving-process restart …
 Test Files  1 failed (1)

# this branch, same Postgres
✓ J9: core journeys on Postgres survive a serving-process restart …  470ms
 Test Files  1 passed (1)
```

## Gate

`pnpm build` ✅ · `pnpm typecheck` ✅ (43 tasks) · `pnpm lint` ✅ · the
integration suite ✅ (above). No product package is touched, so there is no
product suite to run.

Every other suite in the same `integration` job — the steps CI never reached on
`main`, because it fails fast at the one above — was run locally too, and all
are green: `mcp-e2e` 19 passed, `redteam-e2e` 24 passed, `automations-e2e` 70
passed, `demo-bank` 101 passed. Only the Playwright leg (`integration-browser`)
is left to CI.

## Base

Based on `yousefh409/chore-audit-advisories`, **not `main`**: that branch is the
audit-advisory fix, and it cannot show a green `integration` check on its own
while `main` is red. This PR merges into it first so the pair lands on `main`
with every required check green.
