### PR TITLE
fix(harnesses): Stop reaches a box session immediately, not up to 10s later

### DIFF
--- a/.changeset/stop-lands-on-a-quiet-box.md
+++ b/.changeset/stop-lands-on-a-quiet-box.md
@@ -1,0 +1,12 @@
+---
+"@vendoai/harnesses": patch
+---
+
+Stop reaches a sandboxed session immediately, not up to ten seconds later.
+
+The box driver only noticed `turn.signal` between polls, and the box door holds a
+poll open for ten seconds when the session has nothing to say. So Stop pressed
+during a long tool call — the moment a user actually reaches for it — sat behind
+that parked poll before the interrupt was sent. The driver now interrupts from an
+`abort` listener the instant the signal fires, matching the local (non-sandboxed)
+path, which has always done it this way.

--- a/packages/harnesses/src/claude-code/box.ts
+++ b/packages/harnesses/src/claude-code/box.ts
@@ -320,13 +320,26 @@ export async function boxMachine(options: BoxMachineOptions): Promise<SessionMac
       const deadline = Date.now() + MESSAGE_BUDGET_MS;
       let cursor = 0;
 
+      // Interrupt the TURN, not the conversation — and do it the moment Stop is
+      // pressed. The door parks a poll for POLL_WAIT_MS when the box has nothing
+      // to say (a long tool call), so noticing the signal only between polls left
+      // Stop up to ten seconds late. Same shape as the local sibling.
+      let stopped = false;
+      const stop = () => {
+        stopped = true;
+        void request(`/session/${messageId}/interrupt`, {}).catch(() => undefined);
+      };
+
       try {
+        // A signal that is already aborted never fires the event.
+        if (message.signal?.aborted === true) {
+          await request(`/session/${messageId}/interrupt`, {}).catch(() => undefined);
+          return;
+        }
+        message.signal?.addEventListener("abort", stop, { once: true });
         for (;;) {
-          if (message.signal?.aborted === true) {
-            // Interrupt the TURN, not the conversation.
-            await request(`/session/${messageId}/interrupt`, {}).catch(() => undefined);
-            return;
-          }
+          // The listener has already interrupted; this only ends the loop.
+          if (stopped) return;
           if (Date.now() > deadline) {
             await request(`/session/${messageId}/interrupt`, {}).catch(() => undefined);
             throw new VendoError("sandbox-unavailable", "the box message outran its budget");
@@ -348,6 +361,7 @@ export async function boxMachine(options: BoxMachineOptions): Promise<SessionMac
           if (polled["done"] === true) return;
         }
       } finally {
+        message.signal?.removeEventListener("abort", stop);
         inFlight = undefined;
       }
     },

--- a/packages/harnesses/src/claude-code/claude-code.test.ts
+++ b/packages/harnesses/src/claude-code/claude-code.test.ts
@@ -1414,17 +1414,11 @@ describe("stop is still the only thing that cancels — steering never does", ()
     let release: (() => void) | undefined;
     const sandbox = fakeSandbox(async (box) => {
       box.emit({ type: "text", delta: "building it" });
-      // A real build is not silent, and that matters here: the poll loop checks
-      // the abort at the TOP of each pass, and the door holds a poll open for up
-      // to POLL_WAIT_MS when it has nothing to say. A talking box returns each
-      // poll promptly, which is what lets Stop land promptly. (A SILENT box waits
-      // out the poll window — real, pre-existing, and not this lane's to change.)
-      const beat = setInterval(() => box.emit({ type: "text", delta: "." }), 20);
-      try {
-        await new Promise<void>((resolve) => { release = resolve; });
-      } finally {
-        clearInterval(beat);
-      }
+      // The box then goes QUIET — a long tool call, which is exactly when a user
+      // reaches for Stop. The door parks the poll for POLL_WAIT_MS with nothing
+      // to say, so an interrupt that rides the poll loop cannot arrive until the
+      // park expires. Nothing may wake this box before the assertion below.
+      await new Promise<void>((resolve) => { release = resolve; });
     });
     const { turn } = makeTurn({ threadId: "thr_stop" });
     (turn as unknown as { signal: AbortSignal }).signal = abort.signal;
@@ -1436,7 +1430,10 @@ describe("stop is still the only thing that cancels — steering never does", ()
     await vi.waitFor(() => expect(events).toContainEqual({ type: "text", delta: "building it" }));
 
     abort.abort();
-    await vi.waitFor(() => expect(sandbox.boxes[0]!.interrupted).toBe(true));
+    // PROMPTLY is the whole assertion: the box is silent, so a poll is parked for
+    // POLL_WAIT_MS (10s) right now. 3s is far above any scheduling noise and far
+    // below that park, so crossing it means the interrupt waited for the poll.
+    await vi.waitFor(() => expect(sandbox.boxes[0]!.interrupted).toBe(true), { timeout: 3_000 });
     release?.();
     await running;
   });


### PR DESCRIPTION
## What was wrong

`boxMachine.send()` only looked at `turn.signal` **between** polls, then blocked on
`POST /session/<id>/poll` with `waitMs: 10_000` — a wait the box door genuinely holds
open when the session has nothing to say. Press Stop while the box is inside a long
tool call and the interrupt sat behind that parked poll for up to ten seconds before
it was ever sent.

The local (non-sandboxed) sibling `local.ts:327-334` has always done it right: it
registers an `abort` listener and interrupts on the spot. This brings the box path to
the same shape.

Scope, honestly: streaming text deltas wake a parked poll, so the ten-second window is
mostly tool time, not token time. It is still exactly the window in which a user
reaches for Stop.

## What changed

- `packages/harnesses/src/claude-code/box.ts` — an `abort` listener that POSTs
  `/session/<id>/interrupt`, removed in `finally`. The already-aborted case is handled
  once before the loop (a signal aborted before registration never fires the event),
  and the loop-top check now only ends the loop.
- `packages/harnesses/src/claude-code/claude-code.test.ts` — **deleting the heartbeat
  from the stop test is part of the fix, not tidying.** The test kept a 20ms
  `setInterval` emitting text so every poll returned instantly, with a comment
  conceding that "a SILENT box waits out the poll window — real, pre-existing, and not
  this lane's to change." That heartbeat is precisely why a green suite could not see
  this bug: it removed the only condition under which the bug occurs. The box now goes
  quiet after its first line, which is the case Stop matters in, and the assertion has
  a 3s budget — far above scheduling noise, far below the 10s poll park, so crossing it
  means the interrupt waited for the poll.

## Evidence

Test commit first, watched fail on the unfixed driver:

```
× an aborted turn reaches ClaudeSession.interrupt() through the door, unchanged 3085ms
  → expected false to be true // Object.is equality
 Test Files  1 failed (1)
```

After the fix (whole file, 599ms total — the interrupt lands immediately):

```
 ✓ src/claude-code/claude-code.test.ts (73 tests) 599ms
 Test Files  1 passed (1)
      Tests  73 passed (73)
```

Gates: `pnpm build` ✅ · `src/claude-code` suite 88 passed / 10 skipped ✅ ·
`pnpm typecheck` ✅ · `pnpm lint` ✅. No counterparty is mocked — the test drives the
REAL box door (`@vendoai/apps/box-door`) over a fake transport, so the parked poll and
the concurrent interrupt POST are the real ones.

Changeset: `patch` for `@vendoai/harnesses`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop now interrupts sandboxed box sessions immediately, even during a parked poll, eliminating the up-to-10s delay during long tool calls. This matches the local (non-sandboxed) path and improves responsiveness.

- Bug Fixes
  - Added an abort listener in `packages/harnesses/src/claude-code/box.ts` to POST `/session/<id>/interrupt` as soon as `turn.signal` aborts. Handles already-aborted signals and removes the listener in `finally`; the loop now only exits when stopped.
  - Updated `packages/harnesses/src/claude-code/claude-code.test.ts` to remove the heartbeat (box stays quiet) and assert the interrupt within 3s to verify prompt behavior.

Changeset: patch release for `@vendoai/harnesses`.

<sup>Written for commit f2dd4d2e6a064ca7bef7c8248a4b128c657a43bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

