### PR TITLE
fix(actions): sync stops inventing a DELETE and stops discarding props schemas

### DIFF
--- a/.changeset/scan-reads-what-the-code-says.md
+++ b/.changeset/scan-reads-what-the-code-says.md
@@ -1,0 +1,22 @@
+---
+"@vendoai/actions": patch
+---
+
+Sync's scanners stop inventing a delete and stop discarding a props schema.
+
+A `pages/api` handler that switches on a body discriminant —
+`switch (req.body.action) { case "delete": ... }` — had every string case clause
+counted as an HTTP method, and the verb is upper-cased before it is checked. The
+scan handed the agent an ENABLED, `destructive`-graded DELETE tool bound to the
+route's real URL for a delete the handler never implements, and because any verb
+evidence short-circuits the `req.body` inference below it, that phantom verb
+*replaced* the POST the route actually serves. Only an uppercase verb literal
+counts now.
+
+Separately, the component catalog scanner failed a whole props object as soon as
+one property could not be converted, so a component with a single callback,
+`ReactNode`, or npm-typed prop published `propsSchema: {}` for every prop — and
+the console then told the host it had declared no props schema at all. One
+unrepresentable property now degrades to a permissive `{}` and drops out of
+`required`, the same rule the route input converter already applies, so every
+prop that converted fine reaches the catalog and previews can draw from them.

--- a/packages/actions/src/sync/catalog-scan.test.ts
+++ b/packages/actions/src/sync/catalog-scan.test.ts
@@ -85,9 +85,42 @@ describe("deterministic component catalog scan", () => {
     `);
 
     const [entry] = (await scanComponentCatalog(root)).entries;
-    expect(entry).toMatchObject({ name: "ExoticCard", propsSchema: {} });
+    expect(entry).toMatchObject({
+      name: "ExoticCard",
+      propsSchema: { type: "object", properties: { render: {} }, additionalProperties: false },
+    });
     expect(entry?.note).toContain("could not be represented deterministically");
-    expect(entry?.note).toContain("property render");
+    expect(entry?.note).toContain("render");
+  });
+
+  it("keeps the representable props when one prop is exotic", async () => {
+    const root = await host(`
+      export function MixedCard(
+        { title, count, onSelect, footer }:
+        { title: string; count?: number; onSelect: (id: string) => void; footer?: (value: string) => string },
+      ) {
+        return <div onClick={() => onSelect(title)}>{count}{footer?.("x")}</div>;
+      }
+      type ComponentType = (props: unknown) => unknown;
+      export const hostComponents: Record<string, ComponentType> = { MixedCard: MixedCard as ComponentType };
+      export function CatalogRoot() { return <VendoRoot components={hostComponents} />; }
+    `);
+
+    const [entry] = (await scanComponentCatalog(root)).entries;
+    // One unrepresentable prop degrades to permissive `{}` and drops out of
+    // `required`; every prop that converted fine still reaches the catalog,
+    // so the console does not read "declares no props schema".
+    expect(entry).toMatchObject({
+      name: "MixedCard",
+      propsSchema: {
+        type: "object",
+        properties: { count: { type: "number" }, footer: {}, onSelect: {}, title: { type: "string" } },
+        required: ["title"],
+        additionalProperties: false,
+      },
+    });
+    expect(entry?.note).toContain("onSelect");
+    expect(entry?.note).toContain("footer");
   });
 
   it("lets a createVendo catalog registration win, deriving its disk schema from the single zod props schema", async () => {

--- a/packages/actions/src/sync/catalog-scan.ts
+++ b/packages/actions/src/sync/catalog-scan.ts
@@ -550,7 +550,8 @@ function schemaForType(
     const item = checker.getIndexTypeOfType(type, ts.IndexKind.Number);
     if (item === undefined) return { unsupported: `array item type could not be resolved (${checker.typeToString(type)})` };
     const converted = schemaForType(checker, item, location, new Set(seen), depth + 1);
-    return converted.schema === undefined ? converted : { schema: { type: "array", items: converted.schema } };
+    if (converted.schema === undefined) return converted;
+    return { schema: { type: "array", items: converted.schema }, ...(converted.unsupported === undefined ? {} : { unsupported: converted.unsupported }) };
   }
 
   if (type.getCallSignatures().length > 0 || type.getConstructSignatures().length > 0) {
@@ -568,14 +569,23 @@ function schemaForType(
 
   const properties: Record<string, JsonSchema> = {};
   const required: string[] = [];
+  const reasons: string[] = [];
   for (const property of checker.getPropertiesOfType(type).sort((left, right) => compareText(left.name, right.name))) {
     const declaration = property.valueDeclaration ?? property.declarations?.[0] ?? location;
     const propertyType = checker.getTypeOfSymbolAtLocation(property, declaration);
     const converted = schemaForType(checker, propertyType, declaration, new Set(seen), depth + 1);
-    if (converted.schema === undefined) {
-      return { unsupported: `property ${property.name} uses ${converted.unsupported ?? checker.typeToString(propertyType)}` };
+    // Degrade the one unrepresentable property to permissive `{}` and drop it
+    // from `required` — the same rule the sibling converter in
+    // route-schema.ts applies. Failing the whole object instead would throw
+    // away every property that converted fine, and a component with a single
+    // callback prop would reach the console as "declares no props schema".
+    properties[property.name] = converted.schema ?? {};
+    if (converted.unsupported !== undefined) {
+      reasons.push(`property ${property.name} uses ${converted.unsupported}`);
+    } else if (converted.schema === undefined) {
+      reasons.push(`property ${property.name} uses ${checker.typeToString(propertyType)}`);
     }
-    properties[property.name] = converted.schema;
+    if (converted.schema === undefined) continue;
     if ((property.flags & ts.SymbolFlags.Optional) === 0
       && withoutUndefined(propertyType).length === (propertyType.isUnion() ? propertyType.types.length : 1)) {
       required.push(property.name);
@@ -587,11 +597,11 @@ function schemaForType(
   if (stringIndex === undefined) schema.additionalProperties = false;
   else {
     const converted = schemaForType(checker, stringIndex, location, new Set(seen), depth + 1);
-    if (converted.schema === undefined) return converted;
-    schema.additionalProperties = converted.schema;
+    schema.additionalProperties = converted.schema ?? {};
+    if (converted.unsupported !== undefined) reasons.push(`index signature uses ${converted.unsupported}`);
   }
   if (required.length > 0) schema.required = required;
-  return { schema };
+  return reasons.length > 0 ? { schema, unsupported: reasons.join("; ") } : { schema };
 }
 
 function schemaForComponent(checker: tsTypes.TypeChecker, declaration: tsTypes.FunctionLikeDeclaration): SchemaResult {

--- a/packages/actions/src/sync/route-scan.test.ts
+++ b/packages/actions/src/sync/route-scan.test.ts
@@ -390,6 +390,52 @@ describe("pages route verb evidence", () => {
     expect(await methodsFor(root, "/api/put-only")).toEqual(["PUT"]);
   });
 
+  it("does not read a lowercase case clause as verb evidence (a switch on a body discriminant)", async () => {
+    const root = await temporaryRoot();
+    // A POST-only handler that dispatches on `req.body.action`, not on
+    // `req.method`. Reading `case "delete"` as a verb hands the agent an
+    // ENABLED, destructive-graded DELETE at the route's real URL that the
+    // handler never implements — and, because any verb evidence wins over
+    // none, it replaces the POST the route actually serves.
+    await write(
+      root,
+      "pages/api/bulk.ts",
+      [
+        "export default async function handle(req: any, res: any) {",
+        "  if (req.method !== \"POST\") return res.status(405).end();",
+        "  switch (req.body.action) {",
+        "    case \"delete\":",
+        "      return res.status(200).json({ ok: true });",
+        "    case \"archive\":",
+        "      return res.status(200).json({ ok: true });",
+        "    default:",
+        "      return res.status(400).end();",
+        "  }",
+        "}",
+      ].join("\n"),
+    );
+    // The same switch with no `req.method` guard anywhere: the false verb is
+    // the route's ONLY evidence, so it does not merely add a phantom tool —
+    // any verb evidence short-circuits the `req.body` inference below it, so
+    // the phantom DELETE *replaces* the POST this handler actually serves.
+    await write(
+      root,
+      "pages/api/dispatch.ts",
+      [
+        "export default async function handle(req: any, res: any) {",
+        "  switch (req.body.action) {",
+        "    case \"delete\":",
+        "      return res.status(200).json({ ok: true });",
+        "    default:",
+        "      return res.status(400).end();",
+        "  }",
+        "}",
+      ].join("\n"),
+    );
+    expect(await methodsFor(root, "/api/bulk")).toEqual(["POST"]);
+    expect(await methodsFor(root, "/api/dispatch")).toEqual(["POST"]);
+  });
+
   it("treats a NextAuth handler as GET+POST", async () => {
     const root = await temporaryRoot();
     await write(

--- a/packages/actions/src/sync/route-scan.ts
+++ b/packages/actions/src/sync/route-scan.ts
@@ -225,7 +225,16 @@ function exportedVerbs(module: ParsedModule, kind: RouteSource["kind"]): Set<Htt
         && isStringLike(ts, node.right)) {
         addMethod(methods, node.right.text);
       }
-      if (ts.isCaseClause(node) && isStringLike(ts, node.expression)) addMethod(methods, node.expression.text);
+      // Only an UPPERCASE verb literal counts. The switch's own discriminant
+      // is not checked (that reads too many working shapes as unclassified),
+      // so the casing is the whole signal: without it a handler dispatching
+      // on `req.body.action` with `case "delete"` mints an enabled,
+      // destructive DELETE at the route's real URL — and, being the route's
+      // only evidence, it replaces the verb the handler actually serves.
+      if (ts.isCaseClause(node) && isStringLike(ts, node.expression)
+        && HTTP_METHOD_SET.has(node.expression.text)) {
+        addMethod(methods, node.expression.text);
+      }
       if (ts.isCallExpression(node)) {
         allowHeaderVerbs(ts, methods, node);
         if (calleeSimpleName(ts, node) === "NextAuth") {


### PR DESCRIPTION
Two verified bugs in `@vendoai/actions`' sync scanners. Both are cases where the
scanner reported something the host's code does not say.

## 1 — Any lowercase `case` clause minted a destructive DELETE

`exportedVerbs` counted **every** string-literal case clause in a `pages/api`
file as HTTP-method evidence, and `addMethod` upper-cases before it checks the
verb set. So a handler that dispatches on a body discriminant was read as a verb
switch.

**Repro** (`pages/api/dispatch.ts`, a POST-only bulk endpoint):

```ts
export default async function handle(req: any, res: any) {
  switch (req.body.action) {
    case "delete": return res.status(200).json({ ok: true });
    default: return res.status(400).end();
  }
}
```

Before: one tool, `DELETE /api/dispatch`, `risk: "destructive"`, **enabled**,
bound to the route's real URL. Worse than a phantom addition — `verbsFromSource`
returns early on `methods.size > 0`, so the false DELETE short-circuited the
`req.body` inference that would have said POST. The invented verb *replaced* the
real one. After: `POST`.

This is a refactor regression; the previous regex required an uppercase verb, so
the fix restores that requirement (2 lines). **Rejected alternative:** requiring
the switch's discriminant to be `req.method`. Checked against the suite's real
Next.js shapes, it drops three handlers this scan reads correctly today and mints
a bogus GET for a POST-only route. Casing is the whole signal.

## 2 — One unsupported prop discarded the entire component props schema

`schemaForType` returned `{unsupported}` for the whole object the moment a single
property failed, so one callback / `ReactNode` / npm-typed prop emitted
`propsSchema: {}` for **every** prop — and `components.ts` then labelled the
component `no-examples`: "declares neither examples nor a props schema", which is
false. Preview sample generation had nothing to draw with.

```ts
function MixedCard(props: {
  title: string; count?: number;
  onSelect: (id: string) => void; footer?: (v: string) => string;
}) { ... }
```

Before:

```json
{ "propsSchema": {} }
```

After:

```json
{ "propsSchema": { "type": "object",
    "properties": { "count": {"type":"number"}, "footer": {}, "onSelect": {}, "title": {"type":"string"} },
    "required": ["title"], "additionalProperties": false } }
```

The note carries the per-property reasons. The unrepresentable props degrade to a
permissive `{}` and drop out of `required` — which is exactly what
`generateSampleProps` already expects: it skips an optional property it cannot
synthesize, so a preview now draws from `title` and `count` instead of falling to
the honest-but-wrong "no props" label.

This is the rule the sibling converter in `route-schema.ts` (route inputs)
already applies, comment and all; only this path aborted wholesale.
`route-schema.ts` is untouched.

**Out of scope:** when the *whole* props type is an unresolvable imported alias
the failure happens above the property loop, so the schema is still empty there.
Only partial failures are recovered.

## Evidence

- `packages/actions/src/sync/route-scan.test.ts` and `catalog-scan.test.ts` —
  three assertions written first, watched fail against `main`, then fixed
  (separate test/fix commits). The existing exotic-props expectation encoded the
  wholesale abort and now pins the per-property degrade.
- All 22 suites under `packages/actions/src/sync` pass: 323/323.
- `pnpm build` (23/23), `pnpm typecheck`, `pnpm lint` (dependency-guard OK,
  portability gate OK) green. Full suite is CI's job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two sync scanner bugs in `@vendoai/actions`: stops inventing a `DELETE` from lowercase switch cases in `pages/api` handlers, and preserves component props schemas when one prop is unrepresentable. This removes phantom destructive tools and restores accurate, usable props for previews.

- **Bug Fixes**
  - Route scan: only counts UPPERCASE HTTP verb literals in `case` clauses; avoids treating body-discriminant cases like `"delete"` as method evidence, so real `POST` detection is kept.
  - Catalog scan: converts props per property; unsupported props degrade to `{}` and are dropped from `required`; reasons are aggregated in the entry note. Matches the route input converter so previews can use the props that do convert.

<sup>Written for commit 8a0ae4b52dc0de1690fe1e508f08c8e23aeb90bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

