### PR TITLE
fix(apps): an edit that did not save says so, and the format reference stops denying `<Plan display>`

### DIFF
--- a/.changeset/an-edit-that-did-not-save-says-so.md
+++ b/.changeset/an-edit-that-did-not-save-says-so.md
@@ -1,0 +1,22 @@
+---
+"@vendoai/apps": patch
+---
+
+An edit that did not save says so, and the format reference stops denying `<Plan display>`.
+
+A refused save degrades rather than throws — the app is on screen, it just is not in the
+store — and the assembler sits between that save and `edit()`, so the refusal had nowhere
+to go: `assembleEdit` re-read the row, found the PRE-edit document, and handed it back with
+no `failure`. An agent read that as done and the person's ask was silently lost. The save
+now records why it did not land, keyed by app and matched on the person's own words (the
+return leg `editIntents` already had), and the edit fails with that reason instead. The
+live trigger is a write-only refusal — chiefly the `assertCurrent` conflict when a skill's
+timer-save races an edit; a whole-store outage already self-reported through the read.
+
+The `.vendo` format reference promised it was taken from the parsers and then stated flatly
+that no `<Plan>` attribute but `name` is read, while `compilePlan` reads `display` and the
+`building-apps` skill on the same mount teaches `display="stage"` as load-bearing. A model
+that trusted the reference stripped it, and the app arrived as an inline card instead of a
+full-width stage. `display` is documented now, and the reference's own suite scans the
+compiler for the attributes it reads, so the next one fails the build until it is written
+down.

--- a/packages/apps/src/runtime.ts
+++ b/packages/apps/src/runtime.ts
@@ -1988,6 +1988,30 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
   const editVersions = new Map<AppId, VersionEntry>();
 
   /**
+   * Why an edit's own save did NOT land, keyed by app — the other return leg of
+   * `editIntents`, and the only one that can say the edit failed.
+   *
+   * A refused save degrades rather than throws (the file is on screen, it just
+   * is not in the store), and the assembler sits between that save and this
+   * runtime, so `authored`'s return value cannot carry the refusal back to
+   * `edit`. Without this, `assembleEdit` re-reads the row, finds the PRE-edit
+   * document, and reports it as the edit — a success receipt for a change that
+   * never happened.
+   *
+   * Keyed by app and matched on the WORDS, exactly like `editVersions`, so two
+   * overlapping edits of one app cannot take each other's refusal.
+   */
+  const editRefusals = new Map<AppId, { intent: string; reason: string }>();
+
+  /** THIS edit's refusal, or nothing. See {@link editRefusals}. */
+  const takeEditRefusal = (appId: AppId, instruction: string): string | undefined => {
+    const recorded = editRefusals.get(appId);
+    if (recorded?.intent !== instruction) return undefined;
+    editRefusals.delete(appId);
+    return recorded.reason;
+  };
+
+  /**
    * THIS edit's captured row, or nothing.
    *
    * The intent match is the correlation: `edit` reports a version, and the only
@@ -2043,6 +2067,7 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
     // own. Clearing can only cost a concurrent edit its captured row, and losing
     // a row means stamping the version the way this door always did.
     editVersions.delete(appId);
+    editRefusals.delete(appId);
     let outcome: Awaited<ReturnType<ScreenAssembler["assemble"]>>;
     try {
       outcome = await config.screen.assemble({
@@ -2056,6 +2081,11 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
     }
     if (outcome.kind === "escalate") return { kind: "escalate" };
     if (outcome.kind === "unavailable") return { kind: "failed", issues: [outcome.why] };
+    // The assembler says it saved, and the STORE may have refused that save (see
+    // `editRefusals`). The row below would then read back the pre-edit document
+    // and this door would report it as the edit.
+    const refused = takeEditRefusal(appId, instruction);
+    if (refused !== undefined) return { kind: "failed", issues: [refused] };
     // Through `requireOwned`, so what comes back is the same classified,
     // access-checked document every other door hands out — the row is the answer
     // and it must read identically wherever it is read.
@@ -2985,7 +3015,13 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
           // The same degradation create takes on a refused write: the app is on
           // screen, it just is not in the list. Never silent — and never a reason
           // to withhold the data the person can already see.
-          console.error(`[vendo] app not saved (${input.appId}): the harness wrote it as a file but it did not land — ${safeErrorMessage(error)}`);
+          const reason = safeErrorMessage(error);
+          console.error(`[vendo] app not saved (${input.appId}): the harness wrote it as a file but it did not land — ${reason}`);
+          // …and when the save was an EDIT's, the refusal is that edit's answer:
+          // the row still holds the pre-edit document, so `assembleEdit` reading
+          // it back would report an unchanged app as the change (`editRefusals`).
+          const refusedIntent = editIntents.get(input.appId);
+          if (refusedIntent !== undefined) editRefusals.set(input.appId, { intent: refusedIntent, reason });
           // …and a refused save spends no undo point: the appended version's
           // snapshot predates the concurrent edit the refusal just preserved, and
           // `undo()` would write it straight over that edit (see discardVersion).

--- a/packages/apps/src/screen-route.test.ts
+++ b/packages/apps/src/screen-route.test.ts
@@ -113,6 +113,25 @@ const runtimeWith = (screen?: ScreenAssembler, options: {
   };
 };
 
+/** A store whose `vendo_apps` writes are refused while `refusing()` says so, with
+ *  reads left healthy — the write-only refusal an edit actually meets. */
+const storeRefusingAppWritesWhile = (refusing: () => boolean): ReturnType<typeof memoryStore> => {
+  const store = memoryStore();
+  const records = store.records.bind(store);
+  return Object.assign(store, {
+    records(collection: string) {
+      const inner = records(collection);
+      if (collection !== "vendo_apps") return inner;
+      return Object.assign(Object.create(Object.getPrototypeOf(inner) ?? {}), inner, {
+        async put(...args: Parameters<typeof inner.put>) {
+          if (refusing()) throw Object.assign(new Error("Store request failed."), { code: "unavailable" });
+          return await inner.put(...args);
+        },
+      });
+    },
+  }) as ReturnType<typeof memoryStore>;
+};
+
 /** An assembler that records what it was handed and answers however the test says. */
 function recordingAssembler(answer: Awaited<ReturnType<ScreenAssembler["assemble"]>>) {
   const seen: ScreenRequest[] = [];
@@ -329,6 +348,37 @@ describe("the public create/edit API runs the one engine", () => {
     // which is what keeps a remix's replayable trail replayable.
     expect((await runtime.history(app.id, ctx).list()).map(({ intent }) => intent))
       .toContain("say last month instead");
+  });
+
+  it("`edit` whose save was REFUSED fails — it never reports the pre-edit app as the edit", async () => {
+    // A whole-store outage self-reports (the read fails and the door throws), so
+    // what an edit really meets is a refused WRITE: the `assertCurrent` conflict
+    // when a skill's timer-save lands inside the save's window, or a write the
+    // store rejects on its own. Both arrive in the same place — `authored`
+    // catches them, logs, and returns as if it had saved. Assembly then says
+    // "assembled", the row still holds the PRE-edit document, and reading it back
+    // as this edit's result is a success receipt for a change that never
+    // happened: the agent moves on and the person's ask is silently lost.
+    let runtime: AppsRuntime;
+    let refusing = false;
+    runtime = createApps({
+      store: storeRefusingAppWritesWhile(() => refusing),
+      guard: guardFixture(),
+      tools,
+      catalog: [],
+      model: basicLanguageModel(),
+      screen: scriptedAssembler(() => runtime, (_request, current) => current === null ? WIRE : EDITED),
+    });
+    const app = await runtime.create({ prompt: "Show my spending" }, ctx);
+
+    refusing = true;
+    const edited = await runtime.edit(app.id, "say last month instead", ctx);
+
+    expect(edited.failure?.code).toBe("edit-rejected");
+    expect(edited.issues?.join(" ")).toContain("Store request failed.");
+    // And the app the caller is handed is the one that is really stored.
+    expect(JSON.stringify(edited.app)).toContain("This month");
+    expect(JSON.stringify(await runtime.get(app.id, ctx))).toContain("This month");
   });
 
   it("`edit` with no assembler composed refuses, and the stored app is untouched", async () => {

--- a/packages/apps/src/skills/format-reference.test.ts
+++ b/packages/apps/src/skills/format-reference.test.ts
@@ -7,11 +7,33 @@
  * the model follows it, the app fails validation, and the model has no way to
  * learn which of the two was wrong.
  */
+import { readFile } from "node:fs/promises";
 import { compilePlan, compileWire, EXPR_CALLS, RESHAPE_OPS, WIRE_COMPONENT_NAMES } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
 import { VENDO_FORMAT_REFERENCE } from "./format-reference.js";
 
 const FENCED = /```\n([\s\S]*?)```/g;
+
+const REPO_ROOT = new URL("../../../../", import.meta.url);
+const PLAN_COMPILER = "packages/core/src/genui/plan/compile.ts";
+
+/** The reference's own `<Plan>` section, up to the next heading. */
+const planSection = (): string => {
+  const start = VENDO_FORMAT_REFERENCE.indexOf("### `<Plan");
+  const end = VENDO_FORMAT_REFERENCE.indexOf("\n### ", start + 1);
+  return VENDO_FORMAT_REFERENCE.slice(start, end);
+};
+
+/** Every attribute the plan compiler reads off the `<Plan>` ROOT, scanned from
+ *  the compiler itself — `head` is the root tag there, and every other element
+ *  reads its own `attrs.props`. */
+const planRootAttributes = async (): Promise<string[]> => {
+  const source = await readFile(new URL(PLAN_COMPILER, REPO_ROOT), "utf8");
+  return [...new Set([
+    ...source.matchAll(/stringAttr\(head\.props, "(\w+)"\)/g),
+    ...source.matchAll(/head\.props\??\.(\w+)/g),
+  ].map(([, name]) => name as string))];
+};
 
 /** Every fenced block whose first non-space character opens the named element. */
 const blocks = (tag: string): string[] =>
@@ -82,6 +104,26 @@ describe("the reference only names things that exist", () => {
     expect(documented).not.toContain("avg");
     expect(VENDO_FORMAT_REFERENCE).not.toContain("| avg");
     expect(VENDO_FORMAT_REFERENCE).toContain('sum(rows, "field")');
+  });
+
+  /** The reference's header promises it is taken from the parsers, and a model
+   *  that believes it strips whatever it does not find here — `display="stage"`
+   *  went undocumented while the compiler read it, so a full-width app arrived
+   *  as an inline card. This is the half that stops it drifting again: the
+   *  attribute list comes from the compiler, not from a reader. */
+  it("documents every attribute the plan compiler reads off `<Plan>`", async () => {
+    const attributes = await planRootAttributes();
+    // The scan itself is load-bearing: if the compiler stopped calling its root
+    // tag `head`, this would empty out and the loop below would hold nothing.
+    expect(attributes, `${PLAN_COMPILER} no longer reads <Plan> through \`head.props\``)
+      .toEqual(expect.arrayContaining(["name", "display"]));
+    const section = planSection();
+    for (const attribute of attributes) {
+      expect(section, `compilePlan reads <Plan ${attribute}> and the reference never says so`)
+        .toContain(`\`${attribute}\``);
+    }
+    // And it must not deny the ones it does not list.
+    expect(section).not.toMatch(/No other attribute on `<Plan>` is read/);
   });
 
   it("teaches the plan's real element set and no invented one", () => {

--- a/packages/apps/src/skills/format-reference.ts
+++ b/packages/apps/src/skills/format-reference.ts
@@ -51,9 +51,12 @@ read from the first \`<Plan\` to the last \`</Plan>\`.
 A plan holds \`<Query>\`, \`<Group>\` (of \`<Leaf>\`), \`<Server>\`, \`<Island>\` and
 \`<Cannot>\`, and nothing else. It needs at least one group or one \`<Cannot>\`.
 
-### \`<Plan name="…">\`
+### \`<Plan name display>\`
 
-\`name\` becomes the app's title. No other attribute on \`<Plan>\` is read.
+| attribute | | |
+|---|---|---|
+| \`name\` | required | becomes the app's title. |
+| \`display\` | optional | \`"inline"\` (default) or \`"stage"\`. \`"stage"\` opens the app full-width and assembles it there; it is for what the person asked you to BUILD when it takes several groups. Anything else is reported and the app arrives inline. |
 
 ### \`<Query id tool input/>\` — self-closing
 


### PR DESCRIPTION
Two verified bugs in `@vendoai/apps`. Failing test first in each existing behavior-named suite, then the fix — separate commits, in that order.

## 1 · `edit()` reported success when the save was refused

**What was wrong.** `authored()` degrades on a refused write rather than throwing — the app is on screen, it just is not in the store — and it returned `{ data }` exactly as a landed save does. The assembler sits between that save and `assembleEdit`, so the refusal had nowhere to go: `assembleEdit` re-read the row, found the **pre-edit** document, and `edit()` handed it back as `{ kind: "assembled" }` with no `failure`. An agent reads that as done and the person's ask is silently lost. Create is protected by an existence check; an edit's row always exists, so that guard cannot work there.

**The fix.** The refusal now travels the return leg `editIntents` already had: `authored` records why the save did not land, keyed by app and matched on the person's own words (the same correlation `editVersions`/`takeEditVersion` use), and `assembleEdit` turns it into a failed edit. `runtime.ts` is scheduled for decomposition, so the change is additive only — one map, one take-helper, two call sites, no restructuring.

**Deviation from the card, stated.** The card proposed returning `{ data, saved: false, reason }` from `authored`. That return value goes to the render seam / host assembler, never back to `edit()` — the assembler is always in between — so on its own it cannot fix the bug, and no caller consumes it. The internal channel achieves the card's stated outcome (a not-saved edit becomes `failedEdit`) without adding an unconsumed field to the public `AuthoredAppResult`.

**Scope, honestly.** Narrower than the bug first looked. A whole-store outage self-reports through the read, so what an edit actually meets is a **write-only** refusal — chiefly the `assertCurrent` conflict when a skill's timer-save lands inside the save's window. The test is written against that shape: reads healthy, `vendo_apps` writes refused.

**Evidence.** `screen-route.test.ts`, in the existing "the public create/edit API runs the one engine" block, before the fix:

```
× `edit` whose save was REFUSED fails — it never reports the pre-edit app as the edit
  AssertionError: expected undefined to be 'edit-rejected'
```

## 2 · The format reference denied a `<Plan>` attribute the compiler reads

**What was wrong.** The reference's header promises it is taken from the parsers, and its `<Plan>` section then stated flatly "No other attribute on `<Plan>` is read" — while `compilePlan` reads `display` and sets inline/stage, and the `building-apps` skill on the same mount teaches `display="stage"` as load-bearing. A model that trusts the reference strips `display` and the app arrives as an inline card instead of a full-width stage.

**The fix.** `<Plan>` gets a real attribute table (`name`, `display`) in the same shape every other element has, and the false sentence is gone. The durable half is the assertion: the reference's own suite now scans `compilePlan` for the attributes it reads off the `<Plan>` root and requires each one to appear in that section, with a guard so a compiler rename fails loudly instead of emptying the list. A new root attribute now fails the build until it is documented.

**Severity, corrected.** Medium, not high: `building-apps.ts` is always in context and teaches `display` correctly, so the contradiction causes intermittent stripping, not guaranteed degradation. Nothing in `building-apps.ts` needed changing — it was the correct side of the contradiction. Stale doc, not intent.

**Evidence.** `format-reference.test.ts`, before the fix:

```
× documents every attribute the plan compiler reads off `<Plan>`
  compilePlan reads <Plan display> and the reference never says so
```

## Gates

Green on the touched scope: `pnpm build` (23/23), the owned + edit-path suites in `packages/apps` (17 files, 250 tests), root `pnpm typecheck` (43/43) and `pnpm lint`. `packages/core/src/genui/plan/compile.ts` was read-only here — the new assertion reads it, it does not change it. Nothing rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes silent data loss in `@vendoai/apps` by correctly failing edits when a save is refused, and updates the `.vendo` format reference to document `<Plan display>` so docs match the compiler.

- **Bug Fixes**
  - Edits whose save is refused now return a failed edit with a reason; `edit()` no longer reports the pre-edit app as the result.
  - The format reference now documents `<Plan display>`; tests scan the compiler to keep the docs in sync.

<sup>Written for commit e4da5b1516d1ce9f04db48f75b2a735a80f4e037. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

