### PR TITLE
fix(demo-bank): the MCP door speaks from where Maple actually is

### DIFF
--- a/examples/demo-bank/README.md
+++ b/examples/demo-bank/README.md
@@ -109,7 +109,10 @@ gateway — see "Store posture"), `VENDO_BASE_URL`, `AUTH_SECRET`,
 `MAPLE_DEMO_EMAIL`, and `MAPLE_DEMO_PASSWORD`.
 `VENDO_BASE_URL` is the one public-origin switch: set it to the
 default Railway origin first, then change it to `https://maple.vendo.run` after
-DNS is live and redeploy.
+DNS is live and redeploy. It is the ORIGIN only, never the mount point — host
+tool bindings already carry `/maple`, and `src/vendo/mcp-config.ts` adds it to
+the MCP door's public base. Without it the door has no way to learn where it
+is, and every URL it advertises 404s.
 
 For a fast local HTTPS iteration loop, this machine has Tailscale Funnel:
 
@@ -125,12 +128,17 @@ through the funnel. Stop the tunnel with `tailscale funnel reset`. The tunnel is
 only for iteration and is not part of the Railway deployment.
 
 The real-SDK proof runs discovery, DCR, PKCE, Maple login, the door-owned
-consent page, a seeded account tool, and a destructive transfer that parks for
-in-product approval before succeeding on retry:
+consent page, a seeded account tool (walking its in-product approval if the
+guard asks for one), and a money transfer that the guard must refuse:
 
 ```bash
-pnpm --filter demo-bank mcp:e2e -- http://localhost:3000
+pnpm --filter demo-bank mcp:e2e
 ```
+
+The argument is Maple's ORIGIN and defaults to `http://localhost:3000`; where
+Maple sits on it comes from the app's own mount point, so
+`http://localhost:3000/maple` is the same run. `VENDO_BASE_URL` must be set to
+that origin for the door's discovery documents to name URLs a client can reach.
 
 ## Broker-fronted MCP (remote authorization server)
 

--- a/examples/demo-bank/scripts/assert-curated-mcp-menu.mjs
+++ b/examples/demo-bank/scripts/assert-curated-mcp-menu.mjs
@@ -11,7 +11,8 @@
  * HTTP MCP (initialize + tools/list) with the bearer it earned.
  *
  * Usage: node scripts/assert-curated-mcp-menu.mjs [base-url]
- *   base-url defaults to http://127.0.0.1:3457
+ *   base-url is where Maple is MOUNTED, prefix included
+ *   (e.g. http://localhost:3000/maple); defaults to http://127.0.0.1:3457.
  * Exit 0 = the door's menu matches the authored file exactly.
  */
 import { createHash, randomBytes } from "node:crypto";
@@ -20,7 +21,8 @@ import { fileURLToPath } from "node:url";
 import { encode } from "next-auth/jwt";
 
 const base = (process.argv[2] ?? "http://127.0.0.1:3457").replace(/\/+$/, "");
-const endpoint = `${base}/api/vendo/mcp`;
+const MOUNT = "/api/vendo/mcp";
+const endpoint = `${base}${MOUNT}`;
 const appDir = fileURLToPath(new URL("..", import.meta.url));
 const COOKIE_NAME = "authjs.session-token";
 const SEEDED_SUBJECT = "vendo-demo";
@@ -63,9 +65,10 @@ const verifier = b64url(randomBytes(32));
 const challenge = b64url(createHash("sha256").update(verifier).digest());
 const redirectUri = "http://127.0.0.1:43117/callback";
 
-const metadataUrl = new URL(endpoint);
-metadataUrl.pathname = `/.well-known/oauth-authorization-server${metadataUrl.pathname}`;
-const metadataResponse = await fetch(metadataUrl);
+// Prefix-LOCAL, not RFC 8414 root-insertion: a deployment mounted under a path
+// prefix owns no path outside it, so that is the spelling the door advertises
+// and answers (packages/mcp/src/door.ts).
+const metadataResponse = await fetch(`${base}/.well-known/oauth-authorization-server${MOUNT}`);
 if (!metadataResponse.ok) await fail("metadata", metadataResponse);
 const metadata = await metadataResponse.json();
 

--- a/examples/demo-bank/scripts/mcp-e2e.ts
+++ b/examples/demo-bank/scripts/mcp-e2e.ts
@@ -27,32 +27,42 @@ async function main() {
   try {
     const listed = await client.listTools();
     assert(listed.tools.some((tool) => tool.name === "host_listAccounts"), "Maple account tool was not listed.");
-    const accounts = await client.callTool({ name: "host_listAccounts", arguments: {} });
+
+    // MAPLE'S OWN DATA, THROUGH THE DOOR — and if the guard ASKS for it first,
+    // a person decides in Maple's own product and the retry is the real
+    // answer. Whether it asks is not this script's to predict: every host tool
+    // is `ungraded` in .vendo/tools.json, the grade is merged from
+    // .vendo/overrides.json, an auto-judge rules on top, and the ORG policy
+    // above that is seeded locally but console-managed on the hosted store
+    // (src/demo-script/console-seed.ts). Pinning one ruling would report a
+    // deployment posture as a regression.
+    let accounts = await client.callTool({ name: "host_listAccounts", arguments: {} });
+    const approvalId = textOf(accounts).match(/apr_[0-9a-f-]+/)?.[0];
+    if (accounts.isError && approvalId !== undefined) {
+      const decided = await fetch(`${base}/api/vendo/approvals/decide`, {
+        method: "POST",
+        headers: { cookie, "content-type": "application/json" },
+        body: JSON.stringify({
+          ids: [approvalId],
+          decision: { approve: true, remember: { scope: { kind: "tool" }, duration: "standing" } },
+        }),
+      });
+      assert(decided.ok, `Maple's in-product approval decision failed (${decided.status}).`);
+      accounts = await client.callTool({ name: "host_listAccounts", arguments: {} });
+    }
     assert(!accounts.isError, `Maple account tool failed: ${textOf(accounts)}`);
     assert(textOf(accounts).includes("Maple Checking"), "Maple account tool did not return seeded account data.");
 
-    const transferArgs = { amount: 1234, recipient_name: "MCP Proof Recipient", memo: "ENG-267 e2e" };
-    const parked = await client.callTool({ name: "host_transferMoney", arguments: transferArgs });
-    assert(parked.isError, "Destructive Maple transfer did not park for approval.");
-    const approvalId = textOf(parked).match(/apr_[0-9a-f-]+/)?.[0];
-    assert(approvalId, "Parked transfer did not name its approval.");
-
-    const decided = await fetch(`${base}/api/vendo/approvals/decide`, {
-      method: "POST",
-      headers: { cookie, "content-type": "application/json" },
-      body: JSON.stringify({
-        ids: [approvalId],
-        decision: {
-          approve: true,
-          remember: { scope: { kind: "tool" }, duration: "standing" },
-        },
-      }),
+    // AND MONEY DOES NOT MOVE WITHOUT A PERSON. Ask or block is the
+    // deployment's policy to choose — Maple's seeded org policy blocks this
+    // one tool at the MCP venue outright ("Money never moves on behalf of an
+    // external MCP client"), a console-managed org may only ask. The thing
+    // that must never happen either way is a transfer nobody was asked about.
+    const transfer = await client.callTool({
+      name: "host_transferMoney",
+      arguments: { amount: 1234, recipient_name: "MCP Proof Recipient", memo: "ENG-267 e2e" },
     });
-    assert(decided.ok, `Maple's in-product approval decision failed (${decided.status}).`);
-
-    const retried = await client.callTool({ name: "host_transferMoney", arguments: transferArgs });
-    assert(!retried.isError, `Approved transfer retry failed: ${textOf(retried)}`);
-    assert(textOf(retried).includes("MCP Proof Recipient"), "Approved transfer did not return Maple's side effect.");
+    assert(transfer.isError, "A money transfer ran over MCP without asking anyone.");
 
     console.log(JSON.stringify({
       base,
@@ -71,10 +81,11 @@ async function main() {
         sdkClient: true,
         toolsListed: listed.tools.length,
         mapleDataTool: "host_listAccounts",
-        destructiveTool: "host_transferMoney",
-        parkedApproval: approvalId,
-        resolvedInProduct: true,
-        retrySucceeded: true,
+        // undefined when the guard ran the read outright; an id when it asked
+        // and the decision was walked in Maple's own product.
+        parkedApproval: approvalId ?? null,
+        moneyRefusedWithoutAPerson: "host_transferMoney",
+        refusal: textOf(transfer),
       },
     }, null, 2));
   } finally {

--- a/examples/demo-bank/scripts/mcp-e2e.ts
+++ b/examples/demo-bank/scripts/mcp-e2e.ts
@@ -9,7 +9,7 @@ const CLIENT_NAME = "Maple MCP proof client";
 async function main() {
   const target = process.argv.slice(2).find((argument) => argument !== "--");
   const session = await signIn(target, CLIENT_NAME);
-  const { cookie, origin, resource } = session;
+  const { cookie, base, resource } = session;
 
   // The door's own consent page wears the HOST's brand, not Vendo's. Read the
   // accent from Maple's authored theme rather than pinning a literal here —
@@ -37,7 +37,7 @@ async function main() {
     const approvalId = textOf(parked).match(/apr_[0-9a-f-]+/)?.[0];
     assert(approvalId, "Parked transfer did not name its approval.");
 
-    const decided = await fetch(new URL("/api/vendo/approvals/decide", origin), {
+    const decided = await fetch(`${base}/api/vendo/approvals/decide`, {
       method: "POST",
       headers: { cookie, "content-type": "application/json" },
       body: JSON.stringify({
@@ -55,7 +55,7 @@ async function main() {
     assert(textOf(retried).includes("MCP Proof Recipient"), "Approved transfer did not return Maple's side effect.");
 
     console.log(JSON.stringify({
-      origin: origin.toString(),
+      base,
       discovery: session.discovery,
       oauth: {
         dcr: true,

--- a/examples/demo-bank/scripts/mcp-oauth.ts
+++ b/examples/demo-bank/scripts/mcp-oauth.ts
@@ -11,10 +11,39 @@
  */
 import crypto from "node:crypto";
 
-export type DoorSession = {
-  origin: URL;
+/** The door's fixed mount inside the app (10-mcp §5). */
+const MOUNT = "/api/vendo/mcp";
+
+export type DoorWalk = {
+  /** Where Maple is served — every URL below hangs off this. */
+  base: string;
   /** The door's resource URL — also the OAuth `resource` every request carries. */
   resource: string;
+  protectedResourceMetadata: string;
+  authorizationServerMetadata: string;
+  login: string;
+};
+
+/**
+ * EVERY URL THE WALK TOUCHES, decided in one place from the target.
+ *
+ * The door's own OAuth surface is the only one this script can walk (a
+ * broker-fronted deployment owns the sign-in itself), so the authorization
+ * server is the door — its metadata sits beside the protected-resource
+ * document rather than being re-derived from what discovery returns.
+ */
+export function doorUrls(target: string | undefined): DoorWalk {
+  const base = new URL(target ?? "http://localhost:3000").origin;
+  return {
+    base,
+    resource: `${base}${MOUNT}`,
+    protectedResourceMetadata: `${base}/.well-known/oauth-protected-resource${MOUNT}`,
+    authorizationServerMetadata: `${base}/.well-known/oauth-authorization-server${MOUNT}`,
+    login: `${base}/login`,
+  };
+}
+
+export type DoorSession = DoorWalk & {
   accessToken: string;
   refreshToken: string | undefined;
   /** Maple's own Auth.js session, for calling the product's routes as the person. */
@@ -65,28 +94,18 @@ export function textOf(result: unknown): string {
 }
 
 export async function signIn(target: string | undefined, clientName: string): Promise<DoorSession> {
-  const origin = new URL(target ?? "http://localhost:3000");
-  origin.pathname = "/";
-  origin.search = "";
-  origin.hash = "";
-  const resource = new URL("/api/vendo/mcp", origin).toString();
-  const protectedMetadataUrl = new URL(
-    "/.well-known/oauth-protected-resource/api/vendo/mcp",
-    origin,
-  );
+  const walk = doorUrls(target);
+  const { base, resource } = walk;
 
   const protectedMetadata = await json<{
     resource: string;
     authorization_servers: string[];
-  }>(await fetch(protectedMetadataUrl), "protected-resource discovery");
+  }>(await fetch(walk.protectedResourceMetadata), "protected-resource discovery");
   assert(protectedMetadata.resource === resource, "Protected-resource metadata advertised the wrong resource.");
 
   const authorizationServer = protectedMetadata.authorization_servers?.[0];
   assert(authorizationServer, "Protected-resource metadata omitted its authorization server.");
-  const authorizationMetadataUrl = new URL(
-    `/.well-known/oauth-authorization-server${new URL(resource).pathname}`,
-    authorizationServer,
-  );
+  const authorizationMetadataUrl = walk.authorizationServerMetadata;
   const authorizationMetadata = await json<{
     authorization_endpoint: string;
     token_endpoint: string;
@@ -127,15 +146,16 @@ export async function signIn(target: string | undefined, clientName: string): Pr
   const bounce = await fetch(authorizeUrl, { redirect: "manual" });
   assert(bounce.status === 302, `Authorization did not bounce to Maple login (${bounce.status}).`);
   const loginUrl = new URL(bounce.headers.get("location") ?? "");
-  assert(loginUrl.pathname === "/login", "Authorization bounced somewhere other than Maple login.");
+  assert(`${loginUrl.origin}${loginUrl.pathname}` === walk.login, "Authorization bounced somewhere other than Maple login.");
   assert(loginUrl.searchParams.get("returnTo") === authorizeUrl.toString(), "Login bounce did not preserve the exact returnTo.");
   const loginPage = await fetch(loginUrl);
   assert(loginPage.ok && (await loginPage.text()).includes("Sign in to Maple"), "Maple login page did not render.");
 
   const email = process.env.MAPLE_DEMO_EMAIL ?? "yousef@maple.com";
-  const password = process.env.MAPLE_DEMO_PASSWORD ?? (origin.hostname === "localhost" ? "maple-demo" : undefined);
+  const password = process.env.MAPLE_DEMO_PASSWORD
+    ?? (new URL(base).hostname === "localhost" ? "maple-demo" : undefined);
   assert(password, "Set MAPLE_DEMO_PASSWORD for non-local runs.");
-  const login = await fetch(new URL("/login", origin), {
+  const login = await fetch(walk.login, {
     method: "POST",
     redirect: "manual",
     headers: { "content-type": "application/x-www-form-urlencoded" },
@@ -197,15 +217,14 @@ export async function signIn(target: string | undefined, clientName: string): Pr
   );
 
   return {
-    origin,
-    resource,
+    ...walk,
     accessToken: token.access_token,
     refreshToken: token.refresh_token,
     cookie,
     consentHtml,
     discovery: {
-      protectedResource: protectedMetadataUrl.toString(),
-      authorizationServer: authorizationMetadataUrl.toString(),
+      protectedResource: walk.protectedResourceMetadata,
+      authorizationServer: authorizationMetadataUrl,
       advertisedResource: protectedMetadata.resource,
     },
   };

--- a/examples/demo-bank/scripts/mcp-oauth.ts
+++ b/examples/demo-bank/scripts/mcp-oauth.ts
@@ -10,6 +10,7 @@
  * with no Vendo imports reaching the door), so the dance exists once.
  */
 import crypto from "node:crypto";
+import { BASE_PATH } from "../src/lib/base-path.js";
 
 /** The door's fixed mount inside the app (10-mcp §5). */
 const MOUNT = "/api/vendo/mcp";
@@ -27,13 +28,25 @@ export type DoorWalk = {
 /**
  * EVERY URL THE WALK TOUCHES, decided in one place from the target.
  *
+ * The target names Maple's ORIGIN; WHERE Maple sits on it is the app's own
+ * fact (src/lib/base-path.ts), not an argument — so a target that already
+ * carries the mount point and one that doesn't are the same walk. Nothing
+ * here is origin-rooted: the door, its two discovery documents and the login
+ * it bounces to all live under the prefix, and an origin-rooted URL reaches
+ * Maple's 404 page instead.
+ *
+ * The well-known URLs are the door's own PREFIX-LOCAL spelling, not RFC 8414
+ * / 9728 root-insertion: a mounted deployment owns no path outside its
+ * prefix, so that is the spelling it advertises and answers
+ * (packages/mcp/src/door.ts).
+ *
  * The door's own OAuth surface is the only one this script can walk (a
  * broker-fronted deployment owns the sign-in itself), so the authorization
  * server is the door — its metadata sits beside the protected-resource
  * document rather than being re-derived from what discovery returns.
  */
 export function doorUrls(target: string | undefined): DoorWalk {
-  const base = new URL(target ?? "http://localhost:3000").origin;
+  const base = new URL(target ?? "http://localhost:3000").origin + BASE_PATH;
   return {
     base,
     resource: `${base}${MOUNT}`,
@@ -146,7 +159,10 @@ export async function signIn(target: string | undefined, clientName: string): Pr
   const bounce = await fetch(authorizeUrl, { redirect: "manual" });
   assert(bounce.status === 302, `Authorization did not bounce to Maple login (${bounce.status}).`);
   const loginUrl = new URL(bounce.headers.get("location") ?? "");
-  assert(`${loginUrl.origin}${loginUrl.pathname}` === walk.login, "Authorization bounced somewhere other than Maple login.");
+  assert(
+    `${loginUrl.origin}${loginUrl.pathname}` === walk.login,
+    `Authorization bounced to ${loginUrl.origin}${loginUrl.pathname}, not Maple login at ${walk.login}.`,
+  );
   assert(loginUrl.searchParams.get("returnTo") === authorizeUrl.toString(), "Login bounce did not preserve the exact returnTo.");
   const loginPage = await fetch(loginUrl);
   assert(loginPage.ok && (await loginPage.text()).includes("Sign in to Maple"), "Maple login page did not render.");

--- a/examples/demo-bank/scripts/mcp-oauth.ts
+++ b/examples/demo-bank/scripts/mcp-oauth.ts
@@ -40,10 +40,9 @@ export type DoorWalk = {
  * prefix, so that is the spelling it advertises and answers
  * (packages/mcp/src/door.ts).
  *
- * The door's own OAuth surface is the only one this script can walk (a
- * broker-fronted deployment owns the sign-in itself), so the authorization
- * server is the door — its metadata sits beside the protected-resource
- * document rather than being re-derived from what discovery returns.
+ * `authorizationServerMetadata` is only where the door's OWN metadata sits —
+ * which server to read is discovery's answer, not this table's (see
+ * `authorizationServerMetadataUrl`).
  */
 export function doorUrls(target: string | undefined): DoorWalk {
   const base = new URL(target ?? "http://localhost:3000").origin + BASE_PATH;
@@ -54,6 +53,27 @@ export function doorUrls(target: string | undefined): DoorWalk {
     authorizationServerMetadata: `${base}/.well-known/oauth-authorization-server${MOUNT}`,
     login: `${base}/login`,
   };
+}
+
+const withoutTrailingSlash = (url: string): string => url.replace(/\/+$/, "");
+
+/**
+ * WHOSE authorization-server metadata to read: the server the protected-
+ * resource document advertises (RFC 9728 §3.3), never one derived from where
+ * the door sits.
+ *
+ * Maple's own door names ITSELF, and the document it answers on is the
+ * prefix-local one beside the protected-resource document. A broker-fronted
+ * deployment names `https://{tenant}.mcp.vendo.run` and 404s its own metadata
+ * route on purpose, so the advertised issuer is the only reachable document
+ * — and it is a plain RFC 8414 root-insertion on that issuer.
+ */
+export function authorizationServerMetadataUrl(walk: DoorWalk, issuer: string): string {
+  if (withoutTrailingSlash(issuer) === withoutTrailingSlash(walk.resource)) {
+    return walk.authorizationServerMetadata;
+  }
+  const advertised = new URL(issuer);
+  return `${advertised.origin}/.well-known/oauth-authorization-server${withoutTrailingSlash(advertised.pathname)}`;
 }
 
 export type DoorSession = DoorWalk & {
@@ -118,7 +138,7 @@ export async function signIn(target: string | undefined, clientName: string): Pr
 
   const authorizationServer = protectedMetadata.authorization_servers?.[0];
   assert(authorizationServer, "Protected-resource metadata omitted its authorization server.");
-  const authorizationMetadataUrl = walk.authorizationServerMetadata;
+  const authorizationMetadataUrl = authorizationServerMetadataUrl(walk, authorizationServer);
   const authorizationMetadata = await json<{
     authorization_endpoint: string;
     token_endpoint: string;

--- a/examples/demo-bank/scripts/mcp-stock-agent.ts
+++ b/examples/demo-bank/scripts/mcp-stock-agent.ts
@@ -88,7 +88,7 @@ async function main() {
     process.exit(1);
   }
   console.log("\nPASS — words to the agent, pixels to the product.");
-  console.log(`       the screen is at ${new URL("/vendo/apps", session.origin)}  (app ${String(receipt.id)})`);
+  console.log(`       the screen is at ${session.base}/vendo/apps  (app ${String(receipt.id)})`);
 }
 
 main().catch((error) => {

--- a/examples/demo-bank/src/lib/base-path.ts
+++ b/examples/demo-bank/src/lib/base-path.ts
@@ -18,3 +18,12 @@ export const BASE_PATH = "/maple";
 export function withBasePath(path: string): string {
   return `${BASE_PATH}${path}`;
 }
+
+/** The inverse: a pathname back in the app's own vocabulary, whichever way it
+ *  arrived. Next strips the prefix off its own request URLs, but a URL built
+ *  from the deployment's PUBLIC base still carries it — the MCP door's
+ *  `returnTo` is one — and putting it on twice is a 404. */
+export function stripBasePath(pathname: string): string {
+  if (pathname === BASE_PATH) return "/";
+  return pathname.startsWith(`${BASE_PATH}/`) ? pathname.slice(BASE_PATH.length) : pathname;
+}

--- a/examples/demo-bank/src/server/__tests__/mount-point.test.ts
+++ b/examples/demo-bank/src/server/__tests__/mount-point.test.ts
@@ -13,6 +13,7 @@ import { describe, expect, it } from "vitest";
 import { config } from "../../proxy";
 import spec from "../../../openapi.json";
 import tools from "../../../.vendo/tools.json";
+import { doorUrls } from "../../../scripts/mcp-oauth";
 import { BASE_PATH } from "@/lib/base-path";
 
 describe("Maple's mount point", () => {
@@ -37,6 +38,27 @@ describe("Maple's mount point", () => {
       .map(tool => `${tool.binding.method} ${tool.binding.path}`)
       .sort();
     expect(synced).toEqual(documented);
+  });
+
+  /** THE MCP DOOR IS UNDER THE MOUNT POINT TOO, and the same nothing-visible
+   *  rule applies: an origin-rooted discovery URL reaches Maple's 404 PAGE, and
+   *  a 404 page is an HTML body a walk can read right past. The door, its two
+   *  discovery documents and the login it bounces to all live under the prefix
+   *  — the door advertises the prefix-LOCAL well-known spelling, because a
+   *  mounted deployment owns no path outside its prefix. */
+  it("roots the MCP door walk — resource, discovery, login — at the mount point", () => {
+    const walk = {
+      base: `http://localhost:3000${BASE_PATH}`,
+      resource: `http://localhost:3000${BASE_PATH}/api/vendo/mcp`,
+      protectedResourceMetadata: `http://localhost:3000${BASE_PATH}/.well-known/oauth-protected-resource/api/vendo/mcp`,
+      authorizationServerMetadata: `http://localhost:3000${BASE_PATH}/.well-known/oauth-authorization-server/api/vendo/mcp`,
+      login: `http://localhost:3000${BASE_PATH}/login`,
+    };
+    // No argument at all is the same walk: the default target is the dev
+    // server's origin, not a bare origin the door does not answer on.
+    expect(doorUrls(undefined)).toEqual(walk);
+    expect(doorUrls("http://localhost:3000")).toEqual(walk);
+    expect(doorUrls("http://localhost:3000/maple")).toEqual(walk);
   });
 
   /** Next prefixes every proxy matcher with the mount point, so the catch-all

--- a/examples/demo-bank/src/server/__tests__/mount-point.test.ts
+++ b/examples/demo-bank/src/server/__tests__/mount-point.test.ts
@@ -9,12 +9,14 @@
  * number the agent quotes is a 404. That is why this is asserted rather than
  * eyeballed.
  */
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { config } from "../../proxy";
 import spec from "../../../openapi.json";
 import tools from "../../../.vendo/tools.json";
-import { doorUrls } from "../../../scripts/mcp-oauth";
+import { doorUrls, signIn } from "../../../scripts/mcp-oauth";
 import { BASE_PATH } from "@/lib/base-path";
+
+afterEach(() => vi.unstubAllGlobals());
 
 describe("Maple's mount point", () => {
   it("is what the spec declares as its server", () => {
@@ -59,6 +61,42 @@ describe("Maple's mount point", () => {
     expect(doorUrls(undefined)).toEqual(walk);
     expect(doorUrls("http://localhost:3000")).toEqual(walk);
     expect(doorUrls("http://localhost:3000/maple")).toEqual(walk);
+  });
+
+  /** …AND THE AUTHORIZATION SERVER MAY NOT BE UNDER THE MOUNT POINT AT ALL.
+   *  Maple's own door names itself as its authorization server, so its
+   *  metadata is the prefix-local document beside the protected-resource one.
+   *  A broker-fronted deployment (`VENDO_MCP_REMOTE_AS_ISSUER`) names
+   *  `{tenant}.mcp.vendo.run` instead and 404s its own metadata route — so the
+   *  walk must read the server the protected-resource document ADVERTISES
+   *  (RFC 9728 §3.3), never one derived from where the door sits. */
+  it("follows the advertised authorization server off Maple's origin when a broker fronts the door", async () => {
+    const walk = doorUrls("http://localhost:3000");
+    const broker = "https://maple.mcp.vendo.run";
+    const brokerMetadata = `${broker}/.well-known/oauth-authorization-server`;
+    const requested: string[] = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      requested.push(url);
+      if (url === walk.protectedResourceMetadata) {
+        return Response.json({ resource: walk.resource, authorization_servers: [broker] });
+      }
+      if (url === brokerMetadata) {
+        return Response.json({
+          issuer: broker,
+          authorization_endpoint: `${broker}/authorize`,
+          token_endpoint: `${broker}/token`,
+          registration_endpoint: `${broker}/register`,
+          code_challenge_methods_supported: ["S256"],
+        });
+      }
+      return new Response("Maple's 404 page", { status: 404 });
+    });
+
+    // The walk cannot COMPLETE against a broker — the broker owns the sign-in
+    // pages this script types into. Discovery still has to get there.
+    await expect(signIn("http://localhost:3000", "mount-point test")).rejects.toThrow();
+    expect(requested.slice(0, 2)).toEqual([walk.protectedResourceMetadata, brokerMetadata]);
   });
 
   /** Next prefixes every proxy matcher with the mount point, so the catch-all

--- a/examples/demo-bank/src/vendo/auth.test.ts
+++ b/examples/demo-bank/src/vendo/auth.test.ts
@@ -3,7 +3,8 @@ import { authJs } from "@vendoai/vendo/auth/auth-js";
 import { encode } from "next-auth/jwt";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { authSecret, resolveMapleSubject } from "@/server/users";
-import { resolveMapleSession, safeReturnTo } from "./auth";
+import { BASE_PATH } from "@/lib/base-path";
+import { resolveMapleSession, safeReturnTo, withMountedLogin } from "./auth";
 
 afterEach(() => vi.unstubAllEnvs());
 
@@ -94,6 +95,24 @@ describe("authJs's actAs half (away/MCP minting) — the session resolveMapleSes
   });
 });
 
+describe("the MCP door's sign-in bounce", () => {
+  /** The one page a real MCP client's human ever sees. The preset builds it as
+   *  `<public origin>/login`, which on the mounted demo is a 404 — measured on
+   *  maple.vendo.run, where the door bounces to /login and Maple's login page
+   *  is at /maple/login. */
+  it("lands under Maple's mount point, not the bare origin", async () => {
+    const returnTo = "http://localhost:3000/maple/api/vendo/mcp/authorize?state=ok";
+    const answer = await withMountedLogin(auth).oauth!.session!(
+      new Request("http://localhost:3000/api/vendo/mcp/authorize"),
+      { returnTo },
+    );
+    expect(answer).toBeInstanceOf(Response);
+    const location = new URL((answer as Response).headers.get("location")!);
+    expect(location.pathname).toBe(`${BASE_PATH}/login`);
+    expect(location.searchParams.get("returnTo")).toBe(returnTo);
+  });
+});
+
 describe("safeReturnTo", () => {
   it("only accepts same-origin return targets", () => {
     vi.stubEnv("VENDO_BASE_URL", "https://maple.example.com");
@@ -102,5 +121,18 @@ describe("safeReturnTo", () => {
     expect(safeReturnTo("/settings")).toBe("/settings");
     expect(safeReturnTo("https://attacker.example/callback")).toBe("/");
     expect(safeReturnTo(null)).toBe("/");
+  });
+
+  /** Every caller puts the mount point back on with `withBasePath`, so this
+   *  must hand back the app's own vocabulary whichever way the prefix arrived
+   *  — Next strips it off its own request URLs, but an absolute URL built from
+   *  the deployment's public base (the MCP door's `returnTo`) still carries
+   *  it, and prefixing that a second time is a 404 the human sees right after
+   *  typing their password. */
+  it("answers in the app's own vocabulary, mount point or no mount point", () => {
+    vi.stubEnv("VENDO_BASE_URL", "https://maple.example.com");
+    expect(safeReturnTo(`https://maple.example.com${BASE_PATH}/api/vendo/mcp/authorize?state=ok`))
+      .toBe("/api/vendo/mcp/authorize?state=ok");
+    expect(safeReturnTo(BASE_PATH)).toBe("/");
   });
 });

--- a/examples/demo-bank/src/vendo/auth.ts
+++ b/examples/demo-bank/src/vendo/auth.ts
@@ -1,4 +1,6 @@
+import type { authJs } from "@vendoai/vendo/auth/auth-js";
 import { getToken } from "next-auth/jwt";
+import { stripBasePath, withBasePath } from "@/lib/base-path";
 import {
   authSecret,
   isSecureDeployment,
@@ -25,13 +27,15 @@ export function publicOrigin(request?: Request): URL {
   return new URL(process.env.VENDO_BASE_URL ?? request?.url ?? "http://localhost:3000");
 }
 
-/** Same-origin-only returnTo: anything else collapses to "/". */
+/** Same-origin-only returnTo, in the APP's own vocabulary — the mount point
+ * comes off here and every caller puts it back with `withBasePath`. Anything
+ * not same-origin collapses to "/". */
 export function safeReturnTo(candidate: string | null | undefined, base: URL = publicOrigin()): string {
   if (!candidate) return "/";
   try {
     const target = new URL(candidate, base);
     return target.origin === base.origin
-      ? `${target.pathname}${target.search}${target.hash}`
+      ? `${stripBasePath(target.pathname)}${target.search}${target.hash}`
       : "/";
   } catch {
     return "/";
@@ -40,4 +44,34 @@ export function safeReturnTo(candidate: string | null | undefined, base: URL = p
 
 export function maplePublicUrl(request: Request, path: string): URL {
   return new URL(path, publicOrigin(request));
+}
+
+/**
+ * THE DOOR'S SIGN-IN BOUNCE, UNDER THE MOUNT POINT.
+ *
+ * A sessionless MCP client is redirected to the host's login page, and that is
+ * the ONE page a real client's human ever sees. The auth preset builds it as
+ * `<public origin>/login` — it has no way to know Maple is served in place
+ * under BASE_PATH — so the Location it emits 404s. Same job as
+ * `mountedRedirect` in src/proxy.ts: Next puts the prefix back on nothing the
+ * app builds itself, and a redirect's Location is the app's own URL.
+ */
+export function withMountedLogin(preset: ReturnType<typeof authJs>): ReturnType<typeof authJs> {
+  const oauth = preset.oauth;
+  if (oauth?.session === undefined) return preset;
+  const bounce = oauth.session;
+  return {
+    ...preset,
+    oauth: {
+      ...oauth,
+      session: async (request, context) => {
+        const answer = await bounce(request, context);
+        // The only Response this seam returns is that login redirect.
+        if (!(answer instanceof Response)) return answer;
+        const login = new URL(answer.headers.get("location")!);
+        login.pathname = withBasePath(login.pathname);
+        return Response.redirect(login, answer.status);
+      },
+    },
+  };
 }

--- a/examples/demo-bank/src/vendo/mcp-config.test.ts
+++ b/examples/demo-bank/src/vendo/mcp-config.test.ts
@@ -1,11 +1,40 @@
 import { describe, expect, it } from "vitest";
+import { BASE_PATH } from "@/lib/base-path";
 import { mapleMcpConfig } from "./mcp-config";
 
 describe("mapleMcpConfig", () => {
   it("keeps the local-AS door when no broker envs are set", () => {
     // Next's ProcessEnv augmentation makes NODE_ENV required; it carries no
-    // signal for mapleMcpConfig, which reads only VENDO_MCP_* keys.
+    // signal for mapleMcpConfig beyond the public base.
     expect(mapleMcpConfig({ NODE_ENV: "test" })).toBe(true);
+  });
+
+  /** Every URL the door advertises derives from the public base it was handed,
+   *  and Next strips the mount point off a request before the route handler
+   *  sees it — so a door handed the bare origin advertises
+   *  `<origin>/api/vendo/mcp`, which 404s. Discovery is ALL a real MCP client
+   *  has, so that is a dead door with a live-looking product. VENDO_BASE_URL
+   *  stays the bare ORIGIN (host tool bindings concatenate it with paths that
+   *  already carry the prefix); the mount goes on here and only here. */
+  it("advertises the door at the mount point, not the bare origin", () => {
+    expect(mapleMcpConfig({ NODE_ENV: "test", VENDO_BASE_URL: "https://maple.vendo.run" }))
+      .toEqual({ baseUrl: `https://maple.vendo.run${BASE_PATH}` });
+    expect(mapleMcpConfig({ NODE_ENV: "test", VENDO_BASE_URL: "https://maple.vendo.run/" }))
+      .toEqual({ baseUrl: `https://maple.vendo.run${BASE_PATH}` });
+  });
+
+  it("carries the same public base into the broker-fronted door", () => {
+    expect(mapleMcpConfig({
+      NODE_ENV: "test",
+      VENDO_BASE_URL: "https://maple.vendo.run",
+      VENDO_MCP_REMOTE_AS_ISSUER: "https://maple.mcp.vendo.run",
+    })).toEqual({
+      baseUrl: `https://maple.vendo.run${BASE_PATH}`,
+      remoteAs: {
+        issuer: "https://maple.mcp.vendo.run",
+        audience: "https://maple.mcp.vendo.run/mcp",
+      },
+    });
   });
 
   it("trusts the broker issuer with the tenant-resource audience default", () => {

--- a/examples/demo-bank/src/vendo/mcp-config.ts
+++ b/examples/demo-bank/src/vendo/mcp-config.ts
@@ -1,4 +1,25 @@
 import type { CreateVendoConfig } from "@vendoai/vendo/server";
+import { BASE_PATH } from "@/lib/base-path";
+
+/**
+ * WHERE THE DOOR IS ON THE PUBLIC INTERNET.
+ *
+ * Every URL the door advertises — issuer, endpoints, the protected-resource
+ * `resource`, the RFC 8707 audience it binds tokens to — derives from the
+ * public base it is handed. Next strips Maple's mount point off a request
+ * before any route handler sees it, so a door handed the bare origin
+ * advertises `<origin>/api/vendo/mcp` and every one of those URLs 404s.
+ * Discovery is ALL a real MCP client has, so that is a dead door behind a
+ * live-looking product.
+ *
+ * `VENDO_BASE_URL` stays the bare ORIGIN — host tool bindings concatenate it
+ * with paths that already carry the mount (see src/lib/base-path.ts) — so the
+ * mount goes on HERE, and only here.
+ */
+function doorBaseUrl(env: NodeJS.ProcessEnv): string | undefined {
+  const origin = env.VENDO_BASE_URL;
+  return origin === undefined ? undefined : `${origin.replace(/\/+$/, "")}${BASE_PATH}`;
+}
 
 /** ENG-286: Maple's door normally serves its own OAuth surface (`mcp: true`).
  * When the operator provides the broker trust envs, the door instead trusts
@@ -14,11 +35,13 @@ import type { CreateVendoConfig } from "@vendoai/vendo/server";
  *                                    at broker provisioning time
  */
 export function mapleMcpConfig(env: NodeJS.ProcessEnv = process.env): CreateVendoConfig["mcp"] {
+  const baseUrl = doorBaseUrl(env);
   const issuer = env.VENDO_MCP_REMOTE_AS_ISSUER;
-  if (!issuer) return true;
+  if (!issuer) return baseUrl === undefined ? true : { baseUrl };
   const jwksUri = env.VENDO_MCP_REMOTE_AS_JWKS_URI;
   const secret = env.VENDO_MCP_FEDERATION_SECRET;
   return {
+    ...(baseUrl === undefined ? {} : { baseUrl }),
     remoteAs: {
       issuer,
       audience: env.VENDO_MCP_REMOTE_AS_AUDIENCE ?? `${issuer.replace(/\/+$/, "")}/mcp`,

--- a/examples/demo-bank/src/vendo/server.ts
+++ b/examples/demo-bank/src/vendo/server.ts
@@ -5,6 +5,7 @@ import { createStore } from "@vendoai/store";
 import { authJs } from "@vendoai/vendo/auth/auth-js";
 import { createVendo, guard, vendoModel } from "@vendoai/vendo/server";
 import { authSecret, primaryMapleUser, resolveMaplePerson, resolveMapleSubject } from "@/server/users";
+import { withMountedLogin } from "./auth";
 import { mapleKnowledgeDocs } from "./knowledge";
 import { mapleMcpConfig } from "./mcp-config";
 import { namedHarness } from "./proof-harness";
@@ -17,7 +18,9 @@ const composioApiKey = process.env.COMPOSIO_API_KEY;
 // OAuth adapter. `user` maps an Auth.js subject to the seeded Maple
 // identity; returning null means "not a Maple user" — the principal
 // resolves to anonymous and away/MCP minting for that subject declines.
-export const mapleAuth = authJs({
+// `withMountedLogin`: the door's sessionless bounce is the one page a real MCP
+// client's human sees, and the preset builds it origin-rooted — see ./auth.ts.
+export const mapleAuth = withMountedLogin(authJs({
   secret: authSecret,
   user: (subject) => {
     const user = resolveMapleSubject(subject);
@@ -63,7 +66,7 @@ export const mapleAuth = authJs({
     const user = resolveMaplePerson(query);
     return user ? { subject: user.subject, display: user.display } : null;
   },
-});
+}));
 
 export const vendo = createVendo({
   // Model + store slots stay UNSET (demo-refresh Part 2): the env ladder


### PR DESCRIPTION
## What broke

Maple is served in place under `basePath: "/maple"` (#725). The MCP door never
learned. Four independent breaks, each measured against a real server —
`localhost:3000` and the live `maple.vendo.run` — and each one alone is enough
to make the door dead for a real MCP client:

| # | Where | Measured |
|---|-------|----------|
| 1 | `scripts/mcp-oauth.ts` — `origin.pathname = "/"` discarded the prefix, so `resource`, both discovery URLs and `/login` were origin-rooted | `GET /.well-known/oauth-protected-resource/api/vendo/mcp` → **404** (Maple's `/_not-found` page). A bare `pnpm mcp:e2e` 404s too. |
| 2 | `src/vendo/mcp-config.ts` — the door was handed the bare origin | The live door advertises `resource: https://demo-maple-production.up.railway.app/api/vendo/mcp` → **404**. Discovery is all a real client has, so the live door stays dead even with the script fixed. |
| 3 | The door's sessionless login bounce | `https://maple.vendo.run/login` → **404**; the page is at `/maple/login`. That is the one page a real client's human ever sees. |
| 4 | `/login` POST double-prefixed the door's `returnTo` | `/maple/maple/api/vendo/mcp/authorize` → **404**, right after the password. |

Next strips the mount point off a request before any route handler sees it, so
nothing downstream can learn it from the request. It has to be told.

## What changed

1. **`doorUrls(target)`** — one place decides where the door is. The target
   names Maple's **origin**; where Maple sits on it is the app's own fact
   (`src/lib/base-path.ts`), so a bare run and `-- http://localhost:3000/maple`
   are the same run. Well-known URLs use the door's **prefix-local** spelling,
   not RFC 8414/9728 root-insertion — a mounted deployment owns no path outside
   its prefix, and that is the spelling `packages/mcp/src/door.ts` advertises
   and answers.
2. **`mapleMcpConfig`** hands the door `VENDO_BASE_URL` **+ the mount**.
   `VENDO_BASE_URL` stays the bare origin because host tool bindings concatenate
   it with paths that already carry `/maple` — the mount goes on here and only
   here.
3. **`withMountedLogin`** puts the mount back on the door's login bounce.
4. **`safeReturnTo`** answers in the app's own vocabulary (new `stripBasePath`),
   so callers keep putting the prefix back exactly once.

`scripts/assert-curated-mcp-menu.mjs` carried break #1 too and is fixed the same
way. It still fails two assertions of its **own**, both pre-existing and outside
this piece: annotation drift (`readOnlyHint != undefined (risk ungraded)`) and
the org-policy block below. Nothing references it from CI.

## The approval-parking defect: the rules are right, the script was wrong

The e2e asserted `host_listAccounts` succeeds outright and `host_transferMoney`
parks, is approved in-product, and succeeds on retry. Measured on this branch:

- `host_listAccounts` **ran** — with the Cloud judge *and* with no model key at
  all. The reported parking did not reproduce here.
- `host_transferMoney` was **blocked**, not parked:
  `"Money never moves on behalf of an external MCP client."` That is Maple's own
  seeded org policy (`src/demo-script/console-seed.ts`), a deliberate rule with a
  written note. The curated MCP menu (`.vendo/overrides.json` `surfaces.mcp`)
  offers exactly one money-moving tool, and the policy blocks that one at the
  MCP venue.

So the script was asserting a ruling it does not own. Every host tool is
`ungraded` in `.vendo/tools.json`, the grade is merged from
`.vendo/overrides.json`, an auto-judge rules on top, and the org policy above
*that* is seeded locally but **console-managed on the hosted store** — the same
call legitimately runs, asks, or is blocked depending on which Maple is behind
the door. Pinning one of those reports a deployment posture as a regression.

Nothing about the policy is weakened. The script now:

- calls `host_listAccounts`, and **if the guard asks, walks the approval** —
  park → decide through `/api/vendo/approvals/decide` as the signed-in person →
  retry — then asserts the seeded data;
- asserts the one thing true in every posture: **a money transfer never runs
  over MCP without a person** (`transfer.isError`), whether the guard asks or
  blocks.

## Proof — real server, no mocks

`pnpm --filter demo-bank dev` (Cloud key, local PGlite store,
`VENDO_BASE_URL=http://localhost:3000`), then both invocations:

```
### BARE (no argument)
$ tsx scripts/mcp-e2e.ts
{
  "base": "http://localhost:3000/maple",
  "discovery": {
    "protectedResource": "http://localhost:3000/maple/.well-known/oauth-protected-resource/api/vendo/mcp",
    "authorizationServer": "http://localhost:3000/maple/.well-known/oauth-authorization-server/api/vendo/mcp",
    "advertisedResource": "http://localhost:3000/maple/api/vendo/mcp"
  },
  "oauth": {
    "dcr": true, "pkceS256": true, "loginBounce": true, "mapleSession": true,
    "defaultConsent": true, "mapleThemeTokens": true, "accessToken": true, "refreshToken": true
  },
  "mcp": {
    "sdkClient": true,
    "toolsListed": 23,
    "mapleDataTool": "host_listAccounts",
    "parkedApproval": null,
    "moneyRefusedWithoutAPerson": "host_transferMoney",
    "refusal": "Money never moves on behalf of an external MCP client."
  }
}
bare exit=0

### PREFIXED (http://localhost:3000/maple)
$ tsx scripts/mcp-e2e.ts -- http://localhost:3000/maple
{ ...byte-identical body... }
prefixed exit=0
```

That walk is discovery → DCR → PKCE S256 → login bounce → real Auth.js session →
the door's own consent page (carrying Maple's authored accent) → code exchange →
a real `@modelcontextprotocol/sdk` client → `tools/list` (23) → a real
`host_listAccounts` returning seeded Maple data. Nothing is stubbed.

The same run **keyless** (no `VENDO_API_KEY`, no judge to answer) also exits 0,
so both guard branches are live.

Before the fix, against the same server:
`Error: protected-resource discovery failed (404): <!DOCTYPE html>…`

## CI

`demo-bank`'s `mcp:e2e` is **not** wired into the PR gate. It needs a booted
Next server, and `pnpm --filter demo-bank test` in the same job already boots one
for the away drill — a second server means a second dist dir and the exact
sibling/child collision `CLAUDE.md` warns about, for ~60-90s of a 4-5 minute
budget. Not worth it.

What *is* wired in, at zero added cost, is the regression class itself. All four
breaks are now asserted by unit tests that already run in CI via
`pnpm --filter demo-bank test` (ci.yml:367), none of which needs a key or the
network:

- `src/server/__tests__/mount-point.test.ts` — the walk's `resource`, both
  discovery URLs and `/login` are rooted at the mount point, argument or no
  argument (break #1);
- `src/vendo/mcp-config.test.ts` — the door's advertised public base carries the
  mount (#2);
- `src/vendo/auth.test.ts` — the login bounce lands under the mount (#3) and
  `safeReturnTo` answers in the app's own vocabulary (#4).

Each was committed red first and watched fail on values.

## Not fixed here

- **Deployment env, for the W5 redeploy.** `VENDO_BASE_URL` on the Railway
  service is `https://demo-maple-production.up.railway.app`, not
  `https://maple.vendo.run`. With this change the door advertises
  `<VENDO_BASE_URL>/maple`, so the redeploy must point it at the public
  hostname or discovery still names a host prospects do not use. **Keep it the
  bare origin — do not add `/maple`**, or host tool calls get the prefix twice.
- **`packages/vendo` (not this file set).**
  `auth-presets/identity.ts:loginRedirect` builds
  `new URL("/login", publicOrigin(request))`, origin-rooted no matter what the
  deployment configures — a mounted host has no option and must wrap the
  preset's `oauth.session`, which is what `withMountedLogin` does. `authJs()`
  exposes no login-path option even though the preset's own docstring says a
  host with a different login path should pass one. Worth closing upstream.
- **Dev-server gotcha, cost 20 minutes here.** `next dev` on a `.next` that a
  `next build` has written silently drops every catch-all route
  (`/api/vendo/*`, `/api/auth/*`, `.well-known`) to the 404 page. `rm -rf .next`
  between the two.

## Gate

| Command | Result |
|---|---|
| `pnpm build` | exit 0 — 22/22 tasks, 1m5s |
| `demo-bank` vitest (`VITEST_M{IN,AX}_{FORKS,THREADS}` capped) | exit 0 — 24 files, 106 tests |
| `pnpm typecheck` | exit 0 — 41/41 tasks |
| `pnpm lint --force` | exit 0 — 3/3 tasks, 16s (forced; turbo caches across worktrees) |
| `npx eslint .` in `examples/demo-bank` | exit 0 — 1 pre-existing warning in `src/app/logout/route.ts`, untouched |

No changeset: `examples/` is not published.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the MCP door to respect Maple’s `/maple` mount and to follow the authorization server advertised by discovery, so real MCP clients can authenticate and use tools in local, hosted, and broker-fronted deployments.

- **Bug Fixes**
  - Rooted all door URLs under the mount via `doorUrls()` using `BASE_PATH`; well-known paths are prefix-local; resource is `${BASE_PATH}/api/vendo/mcp`.
  - `mapleMcpConfig` now advertises `baseUrl = <VENDO_BASE_URL>${BASE_PATH}` and carries it into remote-AS mode.
  - Fixed sessionless login bounce with `withMountedLogin()` and prevented double-prefixes via `safeReturnTo()` + `stripBasePath()`.
  - OAuth walk now resolves authorization-server metadata from the issuer discovery advertises (RFC 9728) and follows it off-origin when broker-fronted.
  - Updated scripts to use mounted URLs; e2e walks approvals when asked and asserts money transfers never run without a person.
  - Added tests for mount-rooted resource/discovery/login and for following a broker-advertised authorization server; README clarifies origin-only config.

- **Migration**
  - Set `VENDO_BASE_URL` to the public origin only (no `/maple`) and redeploy so discovery advertises the host clients reach.

<sup>Written for commit 305c39ae063280b30ae095af117cca239099fb76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

