### PR TITLE
refactor(apps): the query writer is one define, not a pointer engine

### DIFF
--- a/.changeset/tidy-pointers-open.md
+++ b/.changeset/tidy-pointers-open.md
@@ -1,0 +1,10 @@
+---
+"@vendoai/apps": patch
+---
+
+Replace the RFC-6901 JSON Pointer writer in `open.ts` with a direct assignment
+under the query's name. The pointer was always `"/" + query.name`, and both
+producers of a query name (`validateTree` and the wire compiler) hold it to
+`/^[A-Za-z_][A-Za-z0-9_]*$/`, so no separator, escape or index could ever
+reach it. The prototype defence stays, as an own-property define — the same
+8-line shape `ui/src/tree/mcp-shim/shim-core.ts` already ships.

--- a/packages/apps/src/data-unavailable.test.ts
+++ b/packages/apps/src/data-unavailable.test.ts
@@ -184,6 +184,37 @@ describe("open() on an app whose query did not resolve", () => {
   });
 });
 
+describe("where a resolved query's result lands", () => {
+  it("writes it at the query's name (v2 spec §2 — always one top-level key)", async () => {
+    const { runtime, store } = stand();
+    await seedAppRow(store, treeApp(), "u1");
+
+    const surface = await runtime.open(APP_ID, ctx());
+    if (surface.kind !== "tree") throw new Error("expected a tree surface");
+    expect((surface.payload as { data?: unknown }).data)
+      .toEqual({ spend: { total: 4210, currency: "USD" } });
+  });
+
+  it("makes a __proto__-named query own data, never the prototype", async () => {
+    // The name grammar (`/^[A-Za-z_][A-Za-z0-9_]*$/`) admits `__proto__`, so it
+    // reaches the writer and validateTree will not stop it. A plain assignment
+    // here would hand a model-written or imported `.vendoapp` document the
+    // Object prototype of every object in the process.
+    const { runtime, store } = stand({ outcome: { status: "ok", output: { polluted: true } } });
+    const app = treeApp();
+    (app.tree as unknown as { queries: { name: string; tool: string }[] })
+      .queries = [{ name: "__proto__", tool: "maple_spend_summary" }];
+    await seedAppRow(store, app, "u1");
+
+    const surface = await runtime.open(APP_ID, ctx());
+    if (surface.kind !== "tree") throw new Error("expected a tree surface");
+    const data = (surface.payload as { data: Record<string, unknown> }).data;
+    expect(Object.getPrototypeOf(data)).toBe(Object.prototype);
+    expect(Object.getOwnPropertyDescriptor(data, "__proto__")?.value).toEqual({ polluted: true });
+    expect(({} as Record<string, unknown>)["polluted"]).toBeUndefined();
+  });
+});
+
 describe("authored() — the same answer for a files-first save", () => {
   it("tells the render seam its queries failed, so the painted view says so", async () => {
     const { runtime } = stand({

--- a/packages/apps/src/open.ts
+++ b/packages/apps/src/open.ts
@@ -15,76 +15,22 @@ import type { InClientVenueState } from "./inclient.js";
 import { detectPinDrift, pinComponentName, type PinBaseline, type PinDrift } from "./pins.js";
 import type { OpenSurface } from "./runtime.js";
 
-const isObject = (value: unknown): value is Record<string, Json> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
-// Query paths come from the app document — model-written or imported from an untrusted
-// .vendoapp artifact — so a pointer segment that names a prototype key must never resolve.
-const UNSAFE_KEYS = new Set(["__proto__", "constructor", "prototype"]);
-
-const decodePointer = (pointer: string): string[] | null => {
-  if (pointer === "") return [];
-  if (!pointer.startsWith("/")) return null;
-  const encoded = pointer.slice(1).split("/");
-  if (encoded.some((part) => /~(?![01])/u.test(part))) return null;
-  const parts = encoded.map((part) => part.replaceAll("~1", "/").replaceAll("~0", "~"));
-  if (parts.some((part) => UNSAFE_KEYS.has(part))) return null;
-  return parts;
+/**
+ * v2 spec §2 — a query's result lives at `"/" + name`: always a single
+ * top-level key, because both producers of a query name (validateTree and the
+ * wire compiler) hold it to `/^[A-Za-z_][A-Za-z0-9_]*$/`, so no separator,
+ * escape or index can occur. Own-property define so the one hostile name that
+ * grammar DOES admit — `__proto__` — becomes data, never the prototype.
+ * Mirrors ui/src/tree/mcp-shim/shim-core.ts.
+ */
+const setQueryData = (data: Record<string, Json>, query: TreeQuery, output: Json): void => {
+  Object.defineProperty(data, query.name, {
+    value: structuredClone(output),
+    enumerable: true,
+    writable: true,
+    configurable: true,
+  });
 };
-
-type JsonContainer = Record<string, Json> | Json[];
-const arrayIndex = (part: string): number | null => /^(0|[1-9][0-9]*)$/.test(part) ? Number(part) : null;
-
-const child = (target: JsonContainer, part: string): Json | undefined => {
-  if (Array.isArray(target)) {
-    const index = arrayIndex(part);
-    return index === null ? undefined : target[index];
-  }
-  return target[part];
-};
-
-const assignChild = (target: JsonContainer, part: string, value: Json): boolean => {
-  if (Array.isArray(target)) {
-    const index = arrayIndex(part);
-    if (index === null || !Number.isSafeInteger(index) || index > target.length) return false;
-    target[index] = value;
-    return true;
-  }
-  target[part] = value;
-  return true;
-};
-
-const setQueryData = (data: Record<string, Json>, pointer: string, value: Json): boolean => {
-  const parts = decodePointer(pointer);
-  if (parts === null) return false;
-  if (parts.length === 0) {
-    if (!isObject(value)) return false;
-    const replacement = structuredClone(value);
-    for (const key of Object.keys(data)) delete data[key];
-    for (const [key, item] of Object.entries(replacement)) {
-      if (!UNSAFE_KEYS.has(key)) data[key] = item;
-    }
-    return true;
-  }
-  let target: JsonContainer = data;
-  for (let index = 0; index < parts.length - 1; index += 1) {
-    const part = parts[index];
-    const next = parts[index + 1];
-    if (part === undefined || next === undefined) return false;
-    let current = child(target, part);
-    if (!isObject(current) && !Array.isArray(current)) {
-      current = arrayIndex(next) === null ? {} : [];
-      if (!assignChild(target, part, current)) return false;
-    }
-    target = current as JsonContainer;
-  }
-  const final = parts.at(-1);
-  if (final === undefined) return false;
-  return assignChild(target, final, structuredClone(value));
-};
-
-/** A v2 query's result lives at `"/" + name` by definition (v2 spec §2). */
-const queryPointer = (query: TreeQuery): string => `/${query.name}`;
 
 interface QueryState {
   key: string;
@@ -158,7 +104,7 @@ export const createProgressiveQueryResolver = (
         failed = true;
         continue;
       }
-      setQueryData(data, queryPointer(state.query), state.result.output);
+      setQueryData(data, state.query, state.result.output);
     }
     resolvedData = data;
     unavailable = failed;


### PR DESCRIPTION
## What

`packages/apps/src/open.ts` carried a full RFC-6901 JSON Pointer **writer** — `~0`/`~1` unescaping, an unsafe-key blocklist, array indices, auto-vivification, whole-document root replacement — to set one top-level key. It is now one `Object.defineProperty`.

**70 lines deleted, 16 added in `open.ts` (net −54).** The deleted symbols: `isObject`, `UNSAFE_KEYS`, `decodePointer`, `JsonContainer`, `arrayIndex`, `child`, `assignChild`, the 28-line `setQueryData`, `queryPointer`. None were exported; nothing public changed, so the changeset is `patch`.

## Why it was safe to cut

**The pointer had exactly one caller and it was hard-coded.** Verified by grep over `*.ts/tsx/mts/js/mjs/md/mdx/json` across the whole repo including `examples/`, `fixtures/`, `docs-site/` and every test directory: `setQueryData`, `queryPointer`, `decodePointer`, `assignChild`, `arrayIndex`, `UNSAFE_KEYS` appeared **only inside `open.ts` itself**, with the single call site `open.ts:161` passing `queryPointer(state.query)` = `` `/${query.name}` ``. (The `setQueryData` in `packages/ui/.../shim-core.ts` is a separate, already-8-line function; the read-side pointer resolver is a different thing and is untouched.)

**Validation really does run first — on all three paths, not just the one the audit named.** The writer is reached only through `createProgressiveQueryResolver`, which has three callers, and every one of them is downstream of the grammar `QUERY_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/` (`core/src/genui/tree.ts:15`, enforced at `tree.ts:109`):

| Caller | Where the grammar runs first |
|---|---|
| `open.ts:389` | `validateTree(app.tree)` at `open.ts:356`, and the resolver is fed `validation.tree` |
| `runtime.ts:2856` (create) | the generated document passed `validateAppDocument` at `generation/validation/validate.ts:132`, which calls `validateTree` (`core/src/app-document.ts:345`) |
| `runtime.ts:3038` (`authored`) | the tree comes from `compileWire`, and `core/src/genui/wire/compile.ts:169` tests `QUERY_NAME_PATTERN` and **drops** any query whose name fails |

That grammar admits no `/`, no `~`, and no leading digit — so a separator, an escape sequence, an array index and a nested segment were all unreachable. It is v1 leftovers: v1 queries had a `path` field; v2 deleted it (`core/src/genui/tree.ts:11-12` says so in a comment).

## The prototype defence still rejects — proven, not asserted

The grammar **does** admit `__proto__` (it starts with `_`), so this is the one guard that had to survive. It survives as an own-property define, matching `packages/ui/src/tree/mcp-shim/shim-core.ts:129`.

New test, named: **`where a resolved query's result lands > makes a __proto__-named query own data, never the prototype`** in `packages/apps/src/data-unavailable.test.ts`. It opens a stored app whose query is literally named `__proto__` and asserts the resolved `data` still has `Object.prototype` as its prototype, that the output landed as an **own** property, and that `({}).polluted` is `undefined`.

**Mutation-checked so it cannot be vacuous:** swapping the define for a plain `data[query.name] = …` and rebuilding makes that test fail (`AssertionError: expected undefined to deeply equal { polluted: true }`), then it passes again on the real code.

One deliberate behaviour change, and it is a strict improvement: the old blocklist made a `__proto__`-named query contribute **nothing**. It now contributes its data under that key. Neither pollutes; the new one does not silently drop the person's result.

## Tests deleted

**None.** No test in `packages/apps` covered the pointer machinery — the only test importing `open.js` is `jail-packages.test.ts`, which covers `stripFurnishingPackages` and is unaffected. Two tests were **added** (the `__proto__` one above plus a companion pinning that a resolved result lands at the query's name).

## Gates

- `pnpm build` — 29 packages, exit 0
- `packages/apps` (capped forks/threads): `data-unavailable`, `jail-packages`, `app-data`, `conformance`, `runtime.e2e`, `inclient` — **61 passed (6 files)**, exit 0
- `pnpm typecheck` — **40 successful, 40 total**, exit 0
- `pnpm lint --force` (re-run forced, `0 cached`) — **3 successful, 3 total**, exit 0
- Post-commit grep for every deleted symbol across the repo **including test dirs**: zero hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the JSON Pointer writer in `packages/apps/src/open.ts` with a single safe own-property define under the query’s name. This simplifies the code, keeps prototype safety, and preserves public behavior.

- **Refactors**
  - Removed the unused pointer engine and helpers; now write results directly to `data[query.name]` via `Object.defineProperty`.
  - Aligns with v2: names match `/^[A-Za-z_][A-Za-z0-9_]*$/`, so no separators/escapes/indexing are needed.
  - Mirrors the setter used in `ui/src/tree/mcp-shim/shim-core.ts`. No public API changes (`@vendoai/apps` patch).

- **Bug Fixes**
  - Prevents prototype pollution by defining an own property for `__proto__`-named queries; data is kept instead of dropped.
  - Added tests to pin placement at the query name and verify the prototype remains `Object.prototype`.

<sup>Written for commit 4bd91cdd8040b3c21b6bc1c55cbf1f9d386df347. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

