### PR TITLE
refactor(apps): delete the orphaned edit validator, and one-floor.test.ts stops proving things about it

### DIFF
--- a/.changeset/delete-the-orphaned-edit-validator.md
+++ b/.changeset/delete-the-orphaned-edit-validator.md
@@ -1,0 +1,22 @@
+---
+"@vendoai/apps": patch
+---
+
+Delete the orphaned edit validator, and make `one-floor.test.ts` true again.
+
+`documentFromEdit`, `validateEditedApp` and their `issueLine` helper lost their
+only caller when "the brain dies" deleted `generation/conductor.ts`: an edit is
+the screen assembler rewriting the app's own `app.vendo` and saving it, so it is
+checked by the paint seam's floor and by nothing else. Nothing public changes —
+none of the three was exported from the package.
+
+`one-floor.test.ts` opened by claiming four doors "each through its own REAL
+entry point" and then drove its edit case through that orphan, so its edit-door
+proofs were proofs about a function nothing calls. It now drives three doors
+through `AppsRuntime.floor(ctx)`, `validate({ document })` and
+`validate({ appId })`, and says plainly that the edit path is the first of them.
+
+With the orphan goes its **carried-issue filter** — an edit was excused for an
+issue the previous version already carried. That rule was never re-implemented
+on this architecture and is not a behaviour production has: the floor runs on
+every commit for every author, and a block is a block.

--- a/packages/apps/src/generation/validation/validate.ts
+++ b/packages/apps/src/generation/validation/validate.ts
@@ -1,9 +1,14 @@
 /**
- * Create/edit validation — the FACTS enforced on a compiled document before it
- * can become an app: the compile is complete and clean, the tree is
+ * Create validation — the FACTS enforced on a compiled document before it can
+ * become an app: the compile is complete and clean, the tree is
  * catalog-consistent, its islands are syntactically sound and render without
  * crashing, its queries name real host tools, and its bindings fit the shapes
  * those tools actually return.
+ *
+ * EDIT validation is not here and no longer exists as a thing of its own. Since
+ * "the brain dies" (9a3e81342) an edit is the screen assembler rewriting the
+ * app's own `app.vendo` and saving it, so the save is checked by the paint
+ * seam's floor (../../checking/floor.ts) like every other author's commit.
  *
  * Judgment is not here and never was checkable here. Whether a number is
  * invented, a button dead, or a section beside the point is the AI reviewer's
@@ -13,11 +18,7 @@
 import {
   isAdvisoryWireIssue,
   VENDO_APP_FORMAT,
-  VENDO_TREE_FORMAT,
   validateAppDocument,
-  validateTree,
-  type AppDocument,
-  type Finding,
   type WireCompileResult,
 } from "@vendoai/core";
 import {
@@ -32,11 +33,8 @@ import {
   queryInputIssues,
   unknownToolIssues,
 } from "../../checking/facts.js";
-import { floorChecks } from "../../checking/floor.js";
-import { createCheckingLayer } from "../../checking/layer.js";
 import { prepareIslands } from "../../checking/islands.js";
 import { smokeRenderIslands } from "../../checking/smoke-render.js";
-import { pinComponentName } from "../../pins.js";
 import {
   asPayload,
   type GeneratedAppDocument,
@@ -54,7 +52,7 @@ export const UNSTORED_APP_ID = "app_generation_validation";
  *
  *  Advisory codes drop out here, from the one classification every door shares
  *  (`isAdvisoryWireIssue`) rather than a list per door. Mapping EVERY wire issue
- *  to a block is what made these two doors disagree with the paint seam, which
+ *  to a block is what made this door disagree with the paint seam, which
  *  refuses only what did not parse: `wire-id-ignored` is what our own
  *  `printWire({ includeIds: true })` stamps on an app's `app.vendo`, so the seam
  *  painted that source and `validate({ document })` refused the same bytes. */
@@ -132,88 +130,4 @@ export const validateCompiledCreate = async (
   const appValidation = validateAppDocument({ ...document, id: UNSTORED_APP_ID });
   if (!appValidation.ok) return { issues: [appValidation.error.message] };
   return { document, issues: [] };
-};
-
-/** One finding as the issue line this validator speaks. */
-const issueLine = ({ where, message }: Finding): string =>
-  where === undefined ? message : `${where} ${message}`;
-
-/** Edit validation: the SAME floor every other door runs (checking/floor.ts),
- *  filtered against the pre-existing app, so an edit that doesn't touch a stale
- *  node (a legacy Table.data prop, an already-dead button, an island that
- *  already crashed) is never blocked by that node's issue — only issues the edit
- *  newly introduces surface. Ids are stable across an edit and both runs read
- *  the same request text, so a carried-over issue is a byte-identical string. */
-export const validateEditedApp = async (
-  app: AppDocument,
-  deps: GenerationDependencies,
-  source: AppDocument,
-  /** The edit instruction — the user text in scope, threaded into the island
-   *  law-1 scan the same way create threads its request, so a value the user
-   *  themselves named is never read as a fabrication. */
-  requestText?: string,
-): Promise<string[]> => {
-  const validation = validateAppDocument(app);
-  if (!validation.ok) return [validation.error.message];
-  if (app.tree?.formatVersion !== VENDO_TREE_FORMAT) return ["tree edit produced an unsupported format"];
-  const treeValidation = validateTree(app.tree);
-  if (!treeValidation.ok) return [treeValidation.error.message];
-  const layer = createCheckingLayer({ deps, checks: floorChecks(deps) });
-  const request = requestText ?? "";
-  const carried = new Set((await layer.run({ document: source, request })).map(issueLine));
-  return (await layer.run({ document: app, request }))
-    .map(issueLine)
-    .filter((issue) => !carried.has(issue));
-};
-
-/**
- * A compiled edit as the NEXT version of a stored app. The tree and its islands
- * are the model's; everything else on the document — trigger, storage, machine,
- * pins, description — is the app's own history and survives untouched. Model
- * islands go through the same ambient contract create screens them with;
- * PINNED components are captured host source on the furnishing trust path, so
- * they are neither stripped nor scanned.
- */
-export const documentFromEdit = async (
-  previous: AppDocument,
-  compiled: WireCompileResult,
-  deps: GenerationDependencies,
-  instruction: string,
-): Promise<{ document?: AppDocument; issues: string[] }> => {
-  const structural = [
-    ...(compiled.complete ? [] : ["the edited app did not parse to a complete <App> document; the change was dropped."]),
-    ...blockingWireIssues(compiled),
-    ...compiled.bindingErrors.map((error) =>
-      `binding ${error.path} on node "${error.nodeId}" prop "${error.prop}": ${error.message}${error.available === undefined ? "" : ` (available: ${error.available.join(", ")})`}`),
-  ];
-  if (structural.length > 0) return { issues: structural };
-  const app: AppDocument = {
-    ...structuredClone(previous),
-    ...(compiled.name === undefined ? {} : { name: compiled.name }),
-    tree: asPayload(structuredClone(compiled.tree)),
-  };
-  const pinned = new Set((previous.pins ?? []).map((pin) => pinComponentName(pin.slot)));
-  const split = (all: Record<string, string>): { pinned: Record<string, string>; model: Record<string, string> } => ({
-    pinned: Object.fromEntries(Object.entries(all).filter(([name]) => pinned.has(name))),
-    model: Object.fromEntries(Object.entries(all).filter(([name]) => !pinned.has(name))),
-  });
-  const hostComponents = deps.catalog.map(({ name }) => name);
-  const parts = split(compiled.components);
-  // Admission runs here for the STAMP (`componentTools`); its issues are the
-  // floor's to report, from `validateEditedApp` below, where the carried-issue
-  // filter lives.
-  const prepared = await prepareIslands(parts.model, deps.tools, hostComponents, instruction);
-  const components = { ...parts.pinned, ...prepared.components };
-  if (Object.keys(components).length === 0) {
-    delete app.components;
-    delete app.componentTools;
-  } else {
-    app.components = structuredClone(components);
-    // componentTools stays DEFINED whenever components exist, so the renderer's
-    // stamped-era rule (missing key = zero tools) applies instead of its
-    // source-scan fallback.
-    app.componentTools = structuredClone(prepared.componentTools);
-  }
-  const issues = await validateEditedApp(app, deps, previous, instruction);
-  return issues.length > 0 ? { issues } : { document: app, issues: [] };
 };

--- a/packages/apps/src/one-floor.test.ts
+++ b/packages/apps/src/one-floor.test.ts
@@ -1,14 +1,24 @@
 /**
  * ONE floor at every door.
  *
- * Four doors let an app reach a screen — the paint seam (`createAppFloor`),
- * `validate({ document })`, `validate({ appId })`, and the edit path — and each
- * ran a different subset of the checks. An island that crashes the moment it
- * renders was caught at exactly one of them: `validate({ document })` ran the
- * smoke render, and the paint seam, the stored-app door and the edit path each
- * shipped the same broken island without ever executing it.
+ * Three doors let an app reach a screen — the paint seam's floor
+ * (`AppsRuntime.floor`, which composition hands the render seam),
+ * `validate({ document })` and `validate({ appId })` — and each ran a different
+ * subset of the checks. An island that crashes the moment it renders was caught
+ * at exactly one of them: `validate({ document })` ran the smoke render, and the
+ * paint seam and the stored-app door each shipped the same broken island without
+ * ever executing it.
  *
- * These drive one deliberately-broken island through all four doors, each
+ * There WAS a fourth door. Until "the brain dies" (9a3e81342) an edit ran a
+ * validator of its own (`documentFromEdit`); since then an edit is the screen
+ * assembler opening the app's own `app.vendo`, rewriting it and saving it, so
+ * the save is checked by the paint seam's floor below and by nothing else. That
+ * validator sat callerless and is deleted, and with it its carried-issue filter
+ * — an edit excused for a stale node the previous version already carried —
+ * which production has never had on this architecture: a block is a block, from
+ * every author, on every commit (`harnesses/render-seam.ts`).
+ *
+ * These drive one deliberately-broken island through all three doors, each
  * through its own real entry point, and assert the SAME refusal at every one.
  * Nothing here stubs a check: the floor is the shipped floor, the store is a
  * real store, and the island really renders (and really crashes) in a worker.
@@ -22,12 +32,10 @@ import {
   type ToolRegistry,
 } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
-import { documentFromEdit } from "./generation/validation/validate.js";
-import type { GenerationDependencies } from "./generation/engine.js";
 import { createApps } from "./index.js";
 import { guardFixture, memoryStore, scriptedLanguageModel, seedAppRow } from "./testing/index.js";
 import type { FloorDependencies } from "./checking/deps.js";
-import { blocks, createAppFloor } from "./checking/floor.js";
+import { blocks } from "./checking/floor.js";
 import { wireCompileOptionsFor } from "./wire-options.js";
 
 /** Renders once, reaches for a name nothing in the ambient scope carries, and
@@ -65,6 +73,9 @@ const tools: ToolRegistry = {
  *  deterministic, and the reviewer is fail-open by design. */
 const model = () => scriptedLanguageModel(() => "no");
 
+const runtime = () =>
+  createApps({ store: memoryStore(), guard: guardFixture(), tools, catalog, model: model() });
+
 const documentWith = (island: string, id: string): AppDocument => {
   const compiled = compileWire(wireWith(island), wireCompileOptionsFor(floorDeps()));
   return {
@@ -78,8 +89,11 @@ const documentWith = (island: string, id: string): AppDocument => {
 };
 
 describe("a crashing island is refused at every door", () => {
-  it("the paint seam", async () => {
-    const floor = createAppFloor({ deps: async () => floorDeps() });
+  it("the paint seam, which is where an edit's save lands too", async () => {
+    // `AppsRuntime.floor(ctx)` verbatim — the object `packages/vendo` passes to
+    // the render seam that wraps the screen assembler's workspace, so this is
+    // the door for a files-first save, a `vendo_make` create AND an edit.
+    const floor = runtime().floor(ctx);
     const compiled = await floor.compile(wireWith(CRASHING_ISLAND));
 
     const findings = blocks(await floor.check({ appId: "app_one_floor", compiled }));
@@ -88,9 +102,9 @@ describe("a crashing island is refused at every door", () => {
   }, 60_000);
 
   it("validate({ document })", async () => {
-    const runtime = createApps({ store: memoryStore(), guard: guardFixture(), tools, catalog, model: model() });
+    const apps = runtime();
 
-    const result = await runtime.validate({ document: wireWith(CRASHING_ISLAND) }, ctx);
+    const result = await apps.validate({ document: wireWith(CRASHING_ISLAND) }, ctx);
 
     expect(result.ok).toBe(false);
     expect(result.findings.map(({ message }) => message).join("\n")).toMatch(CRASH);
@@ -98,56 +112,23 @@ describe("a crashing island is refused at every door", () => {
 
   it("validate({ appId })", async () => {
     const store = memoryStore();
-    const runtime = createApps({ store, guard: guardFixture(), tools, catalog, model: model() });
+    const apps = createApps({ store, guard: guardFixture(), tools, catalog, model: model() });
     await seedAppRow(store, documentWith(CRASHING_ISLAND, "app_stored_broken"), ctx.principal.subject);
 
-    const result = await runtime.validate({ appId: "app_stored_broken" }, ctx);
+    const result = await apps.validate({ appId: "app_stored_broken" }, ctx);
 
     expect(result.ok).toBe(false);
     expect(result.findings.map(({ message }) => message).join("\n")).toMatch(CRASH);
-  }, 60_000);
-
-  it("the edit path", async () => {
-    const deps = { ...floorDeps(), model: model() } as unknown as GenerationDependencies;
-    const previous = documentWith(HEALTHY_ISLAND, "app_edited");
-
-    const built = await documentFromEdit(
-      previous,
-      compileWire(wireWith(CRASHING_ISLAND), wireCompileOptionsFor(deps)),
-      deps,
-      "make the card show the total",
-    );
-
-    expect(built.document).toBeUndefined();
-    expect(built.issues.join("\n")).toMatch(CRASH);
   }, 60_000);
 });
 
 describe("the floor still lets a sound app through every door", () => {
   it("the paint seam and validate({ document }) both say nothing", async () => {
-    const floor = createAppFloor({ deps: async () => floorDeps() });
+    const apps = runtime();
+    const floor = apps.floor(ctx);
     const compiled = await floor.compile(wireWith(HEALTHY_ISLAND));
-    const runtime = createApps({ store: memoryStore(), guard: guardFixture(), tools, catalog, model: model() });
 
     expect(blocks(await floor.check({ appId: "app_one_floor_ok", compiled }))).toEqual([]);
-    expect((await runtime.validate({ document: wireWith(HEALTHY_ISLAND) }, ctx)).ok).toBe(true);
-  }, 60_000);
-
-  it("an edit does not inherit the blame for an island that was already broken", async () => {
-    // The carried-issue rule: the previous app's island crashes, the edit does
-    // not touch it, so the edit lands rather than being blocked by history.
-    const deps = { ...floorDeps(), model: model() } as unknown as GenerationDependencies;
-    const previous = documentWith(CRASHING_ISLAND, "app_already_broken");
-    const edited = wireWith(CRASHING_ISLAND).replace("<BrokenCard/>", '<BrokenCard/><Text text="added"/>');
-
-    const built = await documentFromEdit(
-      previous,
-      compileWire(edited, wireCompileOptionsFor(deps)),
-      deps,
-      "add a caption",
-    );
-
-    expect(built.issues).toEqual([]);
-    expect(built.document).toBeDefined();
+    expect((await apps.validate({ document: wireWith(HEALTHY_ISLAND) }, ctx)).ok).toBe(true);
   }, 60_000);
 });


### PR DESCRIPTION
## What

Deletes three dead functions in `packages/apps/src/generation/validation/validate.ts`
(`issueLine`, `validateEditedApp`, `documentFromEdit` — 85 lines, plus 7 imports
that went with them), and rewrites `packages/apps/src/one-floor.test.ts` so its
own opening claim is true.

## Why

`one-floor.test.ts` opened with *"Four doors … each through its own REAL entry
point"* and then tested "the edit path" by calling `documentFromEdit` directly.
That function has had no production caller since `9a3e81342` ("the brain dies"),
which deleted `generation/conductor.ts` — its only caller. So the file's proof
that a crashing island is refused on the edit path, and its proof of the
carried-issue filter, were both proofs about a function nothing calls.

## The judgement call: intended or abandoned?

**Verdict: abandoned.** The carried-issue rule (an edit is not blamed for an
issue the previous version already carried) exists only in the dead code.
Evidence, in order of weight:

1. **The architecture that hosted the rule is gone, deliberately.** `9a3e81342`'s
   own changeset: *"`edit` is the assembler opening the app's own `app.vendo`,
   rewriting it and saving it; the save lands through `AppsRuntime.authored`, so
   the store write, **the checks floor** and the paint are the shipped ones."*
   The shipped floor, singular — not a per-door variant.
2. **The live seam cannot express the rule.** An edit's save is checked by
   `AppFloor.check({ appId, compiled })` inside `packages/harnesses/src/render-seam.ts`,
   whose own comment is *"The floor, on EVERY commit, for every author — our loop,
   Claude Code, a human with an editor (§7.1). A `block` means this must not reach
   a screen."* The seam has no previous document and cannot tell an edit from any
   other author's file save; `AppFloor` is a public `@vendoai/core` type with no
   slot for one.
3. **The rules that WERE meant to survive were ported by name, and this one was
   not.** `runtime.ts`'s `authoredDocument` explicitly re-implements
   `documentFromEdit`'s history-survives rule and its pinned/model split, citing
   it in comments both times. The carried-issue filter is absent.
4. **The one-floor design law contradicts it.** `checking/floor.ts`: the four
   doors "used to run four different subsets and an app blocked at one shipped
   through another." A carried-issue filter on one door is exactly a door running
   a different subset — an app blocked at `validate({ appId })` would ship through
   the edit door.
5. **The hazard it existed for is gone.** The old edit path replaced the stored
   document wholesale, so a refusal was destructive and the filter kept a
   half-stale app editable. Today a blocking finding is non-destructive: nothing
   paints, `authoredApp` is never called, and the previous good document keeps
   serving.
6. **No contract asks for it.** Nothing in `docs/archive/contracts/` names a
   carried-issue or pre-existing-issue rule. `06-apps.md §76` says the opposite:
   *"a completed tree cannot ship broken."*

The one piece of counter-evidence, handled: **#906** (`ce98c5460`, 07:06 on
2026-08-06) *broadened* the filter from `catalogIssues` to the whole floor. But
that landed **four hours after** `9a3e81342` (02:55 the same day) orphaned the
function, and #906's changeset lists "the edit path" as one of the four doors it
was unifying — it was written believing the code was live. That is an authoring
error against the new architecture, not a re-endorsement of the rule.

**Not re-implemented here, on purpose.** Putting the rule back at the live seam
would mean widening a public `@vendoai/core` type (`AppFloor.check`) and threading
a previous document through `packages/apps/src/runtime.ts` and
`packages/harnesses/src/render-seam.ts` — three packages, a public contract, and
a product-behaviour decision. That is a plan, not a de-slop. Flagged, not guessed.

## What `one-floor.test.ts` proves now, door by door

There are **three** doors, not four — the fourth collapsed into the first when the
brain died, and the header now says so instead of claiming otherwise.

| Door | Entry point | Proves |
| --- | --- | --- |
| the paint seam (**and where an edit's save lands**) | `createApps(…).floor(ctx)` — the object `packages/vendo/src/server.ts:2430` passes to the render seam wrapping the assembler's workspace | a crashing island is a `block` finding |
| `validate({ document })` | `createApps(…).validate({ document })` | `ok: false`, crash in the findings |
| `validate({ appId })` | `createApps(…).validate({ appId })` over a really-seeded row | `ok: false`, crash in the findings |
| sound app | the floor **and** `validate({ document })` | no blocks, `ok: true` |

Door 1 was upgraded from the internal `createAppFloor` constructor to
`AppsRuntime.floor(ctx)`, the supported composed path (`internal.ts` says so),
which is also what makes it visibly the edit path's door.

## Tests deleted

- `one-floor.test.ts` › "the edit path" — drove the deleted `documentFromEdit`.
  Its crash-refusal claim is already covered on the live path by door 1.
- `one-floor.test.ts` › "an edit does not inherit the blame for an island that was
  already broken" — the carried-issue assertion. **Deleted, not ported: it asserted
  a behaviour production does not have.**

`validate.test.ts` (`validateCompiledCreate`) is untouched — that function is live,
called from `runtime.ts:3352`.

## Caller sweep

Grepped `documentFromEdit`, `validateEditedApp`, `issueLine` across every package,
`examples/`, `corpus/`, `docs/`, `docs-site/`, `fixtures/`, all test directories,
`*.md`, `*.json`, and the `vendo-web` sibling repo.

Rejected leads (things the sweep hit that are **not** callers, and why):
- `UNSTORED_APP_ID` and `validateCompiledCreate` — **live**, imported by
  `packages/apps/src/runtime.ts:89`. Same file, not deleted.
- `packages/{apps,core,vendo,harnesses}/CHANGELOG.md` — historical release notes.
- `packages/harnesses/src/advisory-door-agreement.test.ts:7` — a comment about
  `validateCompiledCreate`, not the deleted functions.
- `packages/apps/src/runtime.ts:1168,1194` — comments citing `documentFromEdit` as
  the ancestor of `authoredDocument`'s rules. **Left in place:** `runtime.ts` is
  mid-decomposition under a sibling slice and a collision there is expensive. The
  comments still describe the code beside them; they now cite a departed ancestor.
  Worth a one-line follow-up once the split lands.

## vendo-web disposition

**No hits, no adaptation needed.** `documentFromEdit`, `validateEditedApp` and
"carried issue" return zero matches across `~/repos/vendo-web` (`*.ts`, `*.tsx`,
`*.md`, excluding `node_modules`/`.next`). None of the three was exported from
`@vendoai/apps`, so no console-side mirror could have referenced them, and no
emitted artifact (`.vendo/components/`, `vendo_*` collections, blob namespaces)
changes shape.

## Gates

`pnpm build` ✅ · `pnpm typecheck` ✅ (40/40) · `pnpm lint --force` ✅ (0 errors) ·
`packages/apps` › `one-floor.test.ts` + `validate.test.ts` ✅ (5 passed).
Full suite is CI's.

## LOC

−146 / +41 across two files (85 lines of dead function, 7 dead imports, the two
dead test cases; the additions are the corrected header and the composed floor
entry point).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the orphaned edit validator and aligned tests with the single-floor architecture. Edits now validate via the paint seam floor, and the carried-issue test was removed because production doesn’t support that rule.

- **Refactors**
  - Deleted dead functions `documentFromEdit`, `validateEditedApp`, and `issueLine` from `packages/apps/src/generation/validation/validate.ts`.
  - Rewrote `packages/apps/src/one-floor.test.ts` to drive the three live doors via real entry points: `AppsRuntime.floor(ctx)`, `validate({ document })`, and `validate({ appId })`.
  - Dropped the edit-path and carried-issue assertions; the floor blocks consistently across all commits.
  - No public API changes; `@vendoai/apps` remains compatible.

<sup>Written for commit 4334d72a1f667b49ff3ae2ea7b587c7193cae15b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

