### PR TITLE
refactor(harnesses): one screen door, and a tool bridge that stops currying for nobody

### DIFF
--- a/.changeset/one-screen-door-one-tool-bridge.md
+++ b/.changeset/one-screen-door-one-tool-bridge.md
@@ -1,0 +1,28 @@
+---
+"@vendoai/harnesses": minor
+---
+
+The screen agent ships one door, and the tool bridge stops currying for a caller
+that no longer exists.
+
+`screenAgent()` is removed from `@vendoai/harnesses`. The file shipped two doors
+into one assembly loop, and only `screenAssembler()` — the `vendo_make` route
+composition fills — was ever wired. The unused door had already drifted from the
+live one: it never passed `design`, so a screen assembled through it lost the
+host's theme brief, and it passed `turn.system` straight through, the
+conversational prompt the live door deliberately withholds from a writer loop. A
+door that nothing calls cannot be found wrong by anything, so it silently became
+the wrong door. `assembleScreen`, `screenAssembler`, `escalatedPlanPath`,
+`ScreenSurface`, `ScreenInput`, `ScreenResult` and the three tool-name constants
+are unchanged and still exported.
+
+Inside the package, `buildAgentTools` and `addAgentTool` are gone with it. They
+built an ai-SDK `ToolSet` for a path this repo stopped taking — the harness
+runtime calls the bridge directly, and `find_tools` builds its own tool — and
+their existence was the entire reason `guardedCall` and `previewApproval` were
+curried factories rather than plain functions. Both now take the call arguments
+directly (`guardedCall(descriptor, options, input, { toolCallId })`,
+`previewApproval(descriptor, options, input, { toolCallId }, onAsk?)`); both live
+callers invoked the returned closure on the very next expression, so this is
+behaviour-neutral. `onAsk` is unchanged, and neither function was ever on the
+barrel.

--- a/packages/harnesses/src/index.ts
+++ b/packages/harnesses/src/index.ts
@@ -40,7 +40,6 @@ export { tokenBudgetStop } from "./vendo/loop.js";
 export {
   assembleScreen,
   escalatedPlanPath,
-  screenAgent,
   screenAssembler,
   ESCALATE_TOOL,
   SAVE_APP_TOOL,

--- a/packages/harnesses/src/screen-agent.ts
+++ b/packages/harnesses/src/screen-agent.ts
@@ -20,9 +20,8 @@
  *   view and never compiles anything — that is exactly why a screen it assembles
  *   passes the same floor a `claudeCode()` app does.
  * - **`vendo_make` is withheld, not merely unused.** The screen agent IS what
- *   `vendo_make` calls, so leaving it callable is a loop. A closed loadout excludes
- *   it by omission; the `Harness` door withholds it at `toolSurface` as well, so
- *   the runtime answers the name with the same `not-found` a typo gets.
+ *   `vendo_make` calls, so leaving it callable is a loop. The closed loadout
+ *   excludes it by omission.
  * - **The job description is the shipped skill.** `buildingAppsSkill` plus its
  *   `references/format.md` are the same text `claudeCode()` reads. This file adds
  *   one short block that corrects the ENVIRONMENT (no disk, no delegation, two
@@ -49,13 +48,11 @@ import {
   type TurnState,
   type TurnTools,
   type WorkspaceFs,
-  type Harness,
   type Turn,
   modelToolDescription,
 } from "@vendoai/core";
 import { buildingAppsSkill } from "@vendoai/apps";
 import type { LanguageModel } from "ai";
-import { defineHarness } from "./define.js";
 import { vendo, type HarnessHand, type VendoHarnessOptions } from "./vendo/vendo.js";
 import { paintedIn, wrapWorkspaceForRender, type RenderSeamOptions } from "./render-seam.js";
 import { repairInstruction, validateWrittenApps } from "./validate-gate.js";
@@ -102,11 +99,10 @@ const ASSEMBLY_TOOLS: readonly string[] = [
 /**
  * What the lean loop needs, and nothing else.
  *
- * A `Turn` satisfies this by construction — structurally, with no adapter and no
- * wrapper — which is what lets the `Harness` door and the `vendo_make` door share
- * ONE loop instead of growing a second copy of it. Composition's door builds the
- * same fields out of the pieces it already holds; the two identities are optional
- * because only the harness door is inside a turn that already has them.
+ * A structural subset of `Turn`, so a caller already inside a turn passes its own
+ * turn verbatim — no adapter, no wrapper — and the `vendo_make` door builds the
+ * same fields out of the pieces composition already holds. The two identities are
+ * optional because only a caller inside a turn already has them.
  */
 export interface ScreenSurface {
   readonly models: SeatModels<LanguageModel>;
@@ -556,62 +552,7 @@ export async function assembleScreen(
   return { kind: "unavailable", why: failure ?? "assembly produced nothing that renders" };
 }
 
-// ─── Door 1: the harness ─────────────────────────────────────────────────────
-
-/**
- * The screen agent as a `Harness`.
- *
- * Its `Turn` is the surface, verbatim: the runtime already wrapped
- * `turn.workspace` with the render seam, already bound `turn.tools` to the guard,
- * and already assembled `turn.system`. So this door is the lean loop with nothing
- * around it — which is the point of `ScreenSurface` being a structural subset of
- * `Turn`.
- */
-export function screenAgent(): Harness<never> {
-  return defineHarness<never>({
-    name: "screen",
-    // Uncurated for `claudeCode()`'s reason: this loadout is chosen here, by
-    // name and by risk, so the discovery loadout has nothing to add — and
-    // `vendo_make` is withheld because the screen agent is what it calls.
-    toolSurface: { curated: false, withhold: [VENDO_MAKE_TOOL] },
-    async *run(turn: Turn<never>) {
-      if (turn.signal.aborted) return;
-      const appId = `app_${globalThis.crypto.randomUUID()}` as AppId;
-      yield { type: "status", label: "Putting it together…", phase: "assembling", appId };
-      const result = await assembleScreen(turn, {
-        appId,
-        request: latestAsk(turn),
-        ...(turn.system === undefined ? {} : { system: turn.system }),
-      });
-      // One line, consumer voice — the screen IS the answer, so this is never a
-      // narration of it (§10.1).
-      yield { type: "text", delta: sayFor(result) };
-    },
-  });
-}
-
-/** The person's latest words — what a screen is assembled from. */
-const latestAsk = (turn: Turn<unknown>): string => {
-  for (let index = turn.messages.length - 1; index >= 0; index -= 1) {
-    const message = turn.messages[index];
-    if (message?.role !== "user") continue;
-    const text = message.parts
-      .filter((part): part is { type: "text"; text: string } => part.type === "text")
-      .map((part) => part.text)
-      .join("\n")
-      .trim();
-    if (text.length > 0) return text;
-  }
-  return "";
-};
-
-const sayFor = (result: ScreenResult): string => {
-  if (result.kind === "assembled") return `${result.title ?? "It"} is on your screen.`;
-  if (result.kind === "escalate") return "That one needs building — I've started it, and the outline is on your screen.";
-  return "I couldn't put that together. Try describing it a different way.";
-};
-
-// ─── Door 2: the `vendo_make` route ──────────────────────────────────────────
+// ─── The `vendo_make` route ──────────────────────────────────────────────────
 
 export interface ScreenAssemblerDeps {
   /** The seats, as `Turn.models` carries them. */
@@ -623,9 +564,9 @@ export interface ScreenAssemblerDeps {
    *  render seam itself, so composition never has to know that it must. */
   workspace: (ctx: RunContext) => Promise<WorkspaceFs>;
   /** The seam's optional halves — the checks floor, plan facts, the app half
-   *  (`AppsRuntime.authored`) and source persistence. The SAME options the
-   *  harness-turn route passes: a screen assembled here compiles in the production
-   *  dialect and passes the same floor, or it does not paint. */
+   *  (`AppsRuntime.authored`) and source persistence. A screen assembled here
+   *  compiles in the production dialect and passes the same floor, or it does not
+   *  paint. */
   render?: (ctx: RunContext) => Omit<RenderSeamOptions, "emit">;
   /** The deployment's assembled prompt for this ctx, when composition has one. */
   system?: (ctx: RunContext) => Promise<string | undefined>;

--- a/packages/harnesses/src/tool-bridge.ts
+++ b/packages/harnesses/src/tool-bridge.ts
@@ -3,7 +3,6 @@ import {
   VENDO_KNOWLEDGE_RESULT_KIND,
   VENDO_MAKE_TOOL,
   VENDO_VIEW_STREAM,
-  modelToolDescription,
   toVendoWirePart,
   vendoAutomationPartSchema,
   vendoCitationsPartSchema,
@@ -28,13 +27,7 @@ import {
   type VendoViewStreamingToolCall,
   type VendoViewStreamUpdate,
 } from "@vendoai/core";
-import {
-  dynamicTool,
-  jsonSchema,
-  type ToolSet,
-  type UIMessage,
-  type UIMessageStreamWriter,
-} from "ai";
+import type { UIMessage, UIMessageStreamWriter } from "ai";
 
 type VendoPart = VendoApprovalPart | VendoAutomationPart | VendoBuildFailedPart | VendoCitationsPart | VendoConnectPart | VendoViewPart;
 
@@ -157,17 +150,6 @@ function capOutcome(outcome: ToolOutcome, cap: number | undefined): ToolOutcome 
   };
 }
 
-/** 03-agent §2 */
-export async function buildAgentTools(options: ToolBridgeOptions): Promise<ToolSet> {
-  // Pass the turn's context so THE LAW's projection actually applies (design
-  // §12): an unattended turn is never handed a destructive or external tool.
-  // Without this the guard's withholding is computed and then discarded.
-  const descriptors = await options.registry.descriptors(options.ctx);
-  const tools: ToolSet = {};
-  for (const descriptor of descriptors) addAgentTool(tools, descriptor, options);
-  return tools;
-}
-
 /**
  * Execute ONE guarded call with every shipped rail attached: the view channel
  * (a `vendo_apps_*` tree OpenSurface, plus the VENDO_VIEW_STREAM bridge that
@@ -180,18 +162,12 @@ export async function buildAgentTools(options: ToolBridgeOptions): Promise<ToolS
  * commit-gated workspace render seam is additive for file-truth harnesses — not a
  * replacement for this channel. Both coexist.
  */
-export function guardedCall(
+export async function guardedCall(
   descriptor: ToolDescriptor,
   options: ToolBridgeOptions,
-): (input: unknown, context: { toolCallId: string }) => Promise<ToolOutcome> {
-  // Returns the closure rather than taking the call as arguments, so the ai-SDK
-  // still invokes THIS function body directly with no delegating hop in between.
-  // That is load-bearing, not style: an extra microtask between the tool
-  // returning and the SDK recording its output changes who wins the race against
-  // an abort raised inside a tool, and `abort.test.ts` pins the shipped outcome
-  // (an aborted call leaves NO tool part in the persisted message, rather than an
-  // unpaired `input-available` one that a provider would later reject).
-  return async (input, { toolCallId }) => {
+  input: unknown,
+  { toolCallId }: { toolCallId: string },
+): Promise<ToolOutcome> {
   const call: VendoViewStreamingToolCall = { id: toolCallId, tool: descriptor.name, args: input };
   if (descriptor.name === VENDO_MAKE_TOOL && options.writer !== undefined) {
     Object.defineProperty(call, VENDO_VIEW_STREAM, {
@@ -295,7 +271,6 @@ export function guardedCall(
   const modelOutcome = capOutcome(outcome, options.toolOutputCap);
   finishCall?.(modelOutcome);
   return modelOutcome;
-  };
 }
 
 /**
@@ -303,22 +278,22 @@ export function guardedCall(
  * today's `data-vendo-approval` part — `invalidatedGrant` and all — when the guard
  * wants a human.
  *
- * Exported for the same reason as {@link executeGuardedCall}, and it is exactly
- * why `previewCheck` exists: a caller that will make the REAL dispatching call
+ * Exported for the same reason as {@link guardedCall}, and it is exactly why
+ * `previewCheck` exists: a caller that will make the REAL dispatching call
  * moments later must not charge the write-budget/call-rate breakers twice, nor
  * run the judge twice. The harness runtime previews here, awaits the tap, then
  * executes ONCE.
  */
-export function previewApproval(
+export async function previewApproval(
   descriptor: ToolDescriptor,
   options: ToolBridgeOptions,
+  input: unknown,
+  { toolCallId }: { toolCallId: string },
   /** Receives the guard's approval id when the verdict is "ask" (undefined when
-   *  the guard itself threw and we fail closed). Reported by callback rather than
-   *  by return value so this closure IS the ai-SDK's `needsApproval` hook — see
-   *  the timing note on {@link guardedCall}. */
+   *  the guard itself threw and we fail closed) — a second output beside the
+   *  boolean verdict, which is the only thing a caller can wait on. */
   onAsk?: (approvalId: ApprovalId | undefined) => void,
-): (input: unknown, context: { toolCallId: string }) => Promise<boolean> {
-  return async (input, { toolCallId }) => {
+): Promise<boolean> {
   if (options.guard === undefined) return false;
   // Pre-guard short-circuit: a call preflight already rules out (an
   // unconnected service) must not reach the guard — asking would mint
@@ -364,21 +339,4 @@ export function previewApproval(
     onAsk?.(undefined);
     return true;
   }
-  };
-}
-
-/** Build ONE guard-bound agent tool and insert it into `tools`. Exported so a
- * tool lazily expanded mid-turn (find_tools, spec 2026-07-20)
- * materializes with the exact wrapper the boot-time toolset uses. */
-export function addAgentTool(tools: ToolSet, descriptor: ToolDescriptor, options: ToolBridgeOptions): void {
-  const needsApproval = options.guard ? previewApproval(descriptor, options) : undefined;
-
-  tools[descriptor.name] = dynamicTool({
-    // Title-first, so the model has a human label to speak (§3): its own
-    // refusals and explanations are user-visible surfaces.
-    description: modelToolDescription(descriptor),
-    inputSchema: jsonSchema(descriptor.inputSchema as Parameters<typeof jsonSchema>[0]),
-    execute: guardedCall(descriptor, options),
-    ...(needsApproval ? { needsApproval } : {}),
-  });
 }

--- a/packages/harnesses/src/tools-preview-check.test.ts
+++ b/packages/harnesses/src/tools-preview-check.test.ts
@@ -1,16 +1,16 @@
 import type { Guard, GuardDecision, RunContext, ToolCall, ToolDescriptor, ToolOutcome, ToolRegistry } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
-import { addAgentTool } from "./tool-bridge.js";
+import { guardedCall, previewApproval } from "./tool-bridge.js";
 import { ctx } from "./test-doubles.test-util.js";
 
-// genqa defect 1 (double-count): the AI SDK calls `needsApproval` (a preview)
-// and then, when it answers false, `execute` (the real, dispatching call)
-// moments later for the SAME toolCallId. Before this fix both hooks called
-// `guard.check()` — a "run" verdict billed the write-budget/call-rate
-// breakers TWICE for one logical call. `addAgentTool`'s `needsApproval` must
-// prefer `guard.previewCheck` when the guard implements it, and never call
-// `guard.check` itself in that case — the dispatching path (`execute`, via
-// the guard-bound registry) remains the ONLY caller of `check`.
+// genqa defect 1 (double-count): a caller previews with `previewApproval` and
+// then, when it answers false, dispatches with `guardedCall` moments later for
+// the SAME toolCallId. Before this fix both called `guard.check()` — a "run"
+// verdict billed the write-budget/call-rate breakers TWICE for one logical
+// call. `previewApproval` must prefer `guard.previewCheck` when the guard
+// implements it, and never call `guard.check` itself in that case — the
+// dispatching path (`guardedCall`, via the guard-bound registry) remains the
+// ONLY caller of `check`.
 function countingGuard(action: GuardDecision["action"]): Guard & { checkCalls: number; previewCalls: number } {
   const decision: GuardDecision = action === "run"
     ? { action: "run", decidedBy: "default" }
@@ -72,24 +72,16 @@ function boundRegistryOver(guard: Guard, outcome: ToolOutcome): ToolRegistry {
   };
 }
 
-describe("addAgentTool needsApproval prefers previewCheck (genqa defect 1)", () => {
-  it("a run verdict: previewCheck is called once (needsApproval) and check is called once (execute) — never check twice", async () => {
+describe("previewApproval prefers previewCheck (genqa defect 1)", () => {
+  it("a run verdict: previewCheck is called once (preview) and check is called once (dispatch) — never check twice", async () => {
     const guard = countingGuard("run");
     const registry = boundRegistryOver(guard, { status: "ok", output: { done: true } });
-    const tools: Record<string, unknown> = {};
-    addAgentTool(tools as never, await registry.descriptors().then((d) => d[0]!), {
-      registry,
-      guard,
-      ctx: ctx(),
-    });
-    const tool = tools["host_write"] as {
-      needsApproval(input: unknown, opts: { toolCallId: string }): Promise<boolean>;
-      execute(input: unknown, opts: { toolCallId: string }): Promise<ToolOutcome>;
-    };
+    const descriptor = await registry.descriptors().then((d) => d[0]!);
+    const options = { registry, guard, ctx: ctx() };
 
-    const needsApproval = await tool.needsApproval({}, { toolCallId: "call_1" });
+    const needsApproval = await previewApproval(descriptor, options, {}, { toolCallId: "call_1" });
     expect(needsApproval).toBe(false);
-    const outcome = await tool.execute({}, { toolCallId: "call_1" });
+    const outcome = await guardedCall(descriptor, options, {}, { toolCallId: "call_1" });
 
     expect(outcome).toMatchObject({ status: "ok" });
     expect(guard.previewCalls).toBe(1);
@@ -100,19 +92,11 @@ describe("addAgentTool needsApproval prefers previewCheck (genqa defect 1)", () 
     const guard = countingGuard("run");
     delete (guard as { previewCheck?: unknown }).previewCheck;
     const registry = boundRegistryOver(guard, { status: "ok", output: { done: true } });
-    const tools: Record<string, unknown> = {};
-    addAgentTool(tools as never, await registry.descriptors().then((d) => d[0]!), {
-      registry,
-      guard,
-      ctx: ctx(),
-    });
-    const tool = tools["host_write"] as {
-      needsApproval(input: unknown, opts: { toolCallId: string }): Promise<boolean>;
-      execute(input: unknown, opts: { toolCallId: string }): Promise<ToolOutcome>;
-    };
+    const descriptor = await registry.descriptors().then((d) => d[0]!);
+    const options = { registry, guard, ctx: ctx() };
 
-    await tool.needsApproval({}, { toolCallId: "call_1" });
-    await tool.execute({}, { toolCallId: "call_1" });
+    await previewApproval(descriptor, options, {}, { toolCallId: "call_1" });
+    await guardedCall(descriptor, options, {}, { toolCallId: "call_1" });
 
     expect(guard.checkCalls).toBe(2);
   });

--- a/packages/harnesses/src/turn-tools.ts
+++ b/packages/harnesses/src/turn-tools.ts
@@ -302,9 +302,9 @@ export function createTurnTools(options: TurnToolsOptions): RuntimeTurnTools {
         // never runs the judge a second time, so an approved call is executed
         // ONCE below rather than executed-then-re-executed.
         let approvalId: ApprovalId | undefined;
-        const ask = await previewApproval(descriptor, bridge, (id) => {
+        const ask = await previewApproval(descriptor, bridge, args, { toolCallId }, (id) => {
           approvalId = id;
-        })(args, { toolCallId });
+        });
 
         if (ask) {
           if (approvalId !== undefined) {
@@ -346,7 +346,7 @@ export function createTurnTools(options: TurnToolsOptions): RuntimeTurnTools {
         // channel (a `vendo_apps_*` tree plus the VENDO_VIEW_STREAM partials),
         // the connect card, the build-failed banner, the citations part and
         // `toolOutputCap` all come from here — never a second implementation.
-        const outcome = await guardedCall(descriptor, bridge)(args, { toolCallId });
+        const outcome = await guardedCall(descriptor, bridge, args, { toolCallId });
         if (outcome.status === "pending-approval") {
           // The preview said run and the REAL check asked — a breaker or presence
           // boundary. Nobody is waiting on this one, so it must still be swept.

--- a/packages/harnesses/src/vendo/loop.ts
+++ b/packages/harnesses/src/vendo/loop.ts
@@ -479,8 +479,8 @@ export interface TurnLoopOptions {
   fallbacks?: readonly ResolvedModel[];
   system: string;
   messages: UIMessage[];
-  /** Already built and guard-bound by the caller (buildAgentTools, or the
-   *  harness runtime's delegating set). */
+  /** Already built and guard-bound by the caller (the harness runtime's
+   *  delegating set). */
   tools: ToolSet;
   signal?: AbortSignal;
   /** §3.5 — the turn this loop is running, for anything downstream that has to


### PR DESCRIPTION
Two confirmed-dead paths in `@vendoai/harnesses`, plus the function shape one of
them was distorting. Behaviour outside the removals is identical.

## Card 19 — the screen agent's `Harness` door has zero callers

`screenAgent()` is gone, along with its two private helpers (`latestAsk`,
`sayFor`) and the `defineHarness` / `Harness` imports that existed only for it.

The file shipped two doors into one assembly loop. Door 2 (`screenAssembler()`,
the `vendo_make` route composition fills) is wired everywhere. Door 1 was
referenced by nothing — and it had already drifted from the live door in two
ways that nothing could catch, because nothing called it:

- it never passed `design`, so a screen assembled through it silently lost the
  host's theme brief;
- it passed `turn.system` straight through — the conversational prompt door 2's
  own comment says is deliberately unset for a writer loop.

The file's own barrel header states the rule this breaks: *"A barrel export with
no reader is surface nobody asked for."*

**`ScreenSurface` survives** — door 2 constructs one, and `assembleScreen` still
takes it (`screen-agent.ts:107`, `:305`). So do `assembleScreen`,
`screenAssembler`, `escalatedPlanPath`, `ScreenInput`, `ScreenResult` and the
three tool-name constants. Only `screenAgent` leaves the barrel.

Three comments that described the two-door arrangement were corrected rather
than left lying (the file header's `vendo_make` withholding note, the
`ScreenSurface` doc, and the `render` slot's "SAME options the harness-turn route
passes"). The `Door 2` section heading is now just `The vendo_make route`.

**Real LOC:** `screen-agent.ts` −69/+10, `index.ts` −1/+0.

**This is a public export of a published package**, so it carries a `minor`
changeset (`.changeset/one-screen-door-one-tool-bridge.md`).

## Card 22 — dead ai-SDK toolset path, and the curry it forced on two live functions

`buildAgentTools` and `addAgentTool` are removed. They built an ai-SDK `ToolSet`
for a path this repo no longer takes: the harness runtime calls the bridge
directly through `turn-tools.ts`, and `find_tools` builds its own `dynamicTool`
in `tool-search.ts:229` rather than going through `addAgentTool` — so the
"lazily expanded mid-turn (find_tools)" justification in `addAgentTool`'s own
doc comment was dead too.

Their existence was the entire reason the two **live** functions were curried
factories. The ~9-line comment defending that shape cites `abort.test.ts` as the
thing pinning the microtask timing — **that file does not exist anywhere**, not
in this repo and not in `vendo-web`. Both live callers invoke the returned
closure on the very next expression (`turn-tools.ts:305`, `:349`), so there is no
ai-SDK hook to be, and un-currying is behaviour-neutral.

New signatures:

```ts
guardedCall(descriptor, options, input, { toolCallId }): Promise<ToolOutcome>
previewApproval(descriptor, options, input, { toolCallId }, onAsk?): Promise<boolean>
```

**`onAsk` is kept.** The catalog's proposed signature dropped it;
`turn-tools.ts:305` depends on it to capture the approval id it later waits on
(`waiter.raise` / `waiter.wait`), so dropping it would have broken the approval
path. It stays as the trailing optional parameter.

Imports orphaned by the removal are gone: `dynamicTool`, `jsonSchema`, `ToolSet`
from `ai` (the whole import collapses to a type-only import), and
`modelToolDescription` from core. A stale `{@link executeGuardedCall}` reference
— a function that has never existed — now points at `guardedCall`. A stale
`buildAgentTools` mention in `vendo/loop.ts:482` is corrected.

**Real LOC:** `tool-bridge.ts` −55/+13, `turn-tools.ts` −3/+3, `loop.ts` −2/+2.

### The repointed test

`tools-preview-check.test.ts` was the only caller of `addAgentTool`. It is
**repointed, not deleted** — it pins the genqa defect-1 invariant (a "run"
verdict must charge the guard's breakers once, not twice), which is a property of
`previewApproval` + `guardedCall`, not of the dead wrapper.

Per the card, it now drives **both** functions to preserve the once-each
invariant: `previewApproval(...)` where it called `tool.needsApproval`, and
`guardedCall(...)` where it called `tool.execute`. **Every assertion is
byte-identical** (`previewCalls` 1 / `checkCalls` 1, and `checkCalls` 2 on the
no-`previewCheck` fallback) — that is the proof the un-currying changed nothing.
−35/+19. No test was deleted in this PR.

## Caller sweep

Grepped `screenAgent`, `buildAgentTools`, `addAgentTool`, `guardedCall`,
`previewApproval`, `ScreenSurface`, `ScreenInput`, `ScreenResult`,
`assembleScreen`, `escalatedPlanPath` across every tracked file (any extension,
not just `.ts`) in all of `packages/`, `examples/`, `fixtures/`, `corpus/`,
`docs/`, `docs-site/` and every test directory — plus the same sweep over the
`vendo-web` clone on this machine.

**Rejected leads, with reasons:**

- `fixtures/integration/src/harness.ts:151` + 9 e2e test files export/use
  **`screenAgentCreateTurns`** — a *different symbol*. It is a mock
  `LanguageModelV3StreamPart[][]` builder for the model stream, not the harness
  door. Word-boundary grep confirms no `screenAgent` token among them.
- `CHANGELOG.md` hits in `core`, `apps`, `store`, `vendo` and `harnesses` for all
  three removed names — release history, not callers. Left untouched.
- `vendo/loop.ts:482` mentioned `buildAgentTools` in a **doc comment only**, no
  call. Corrected in this PR.
- `@vendoai/vendo` umbrella does **not** re-export `screenAgent`: it has no
  `export *` (a dedicated test, `react-export-parity.test.ts`, bans that
  pattern) and no named import of it.
- `@vendoai/harnesses` subpath exports are `.`, `./vendo`, `./claude-code`;
  `tool-bridge.ts` is on none of them, so `buildAgentTools` / `addAgentTool` /
  `guardedCall` / `previewApproval` were never public. Only card 19 touches
  published surface.

**Post-commit re-sweep** (all tracked files including `test/` dirs, which some
packages' typecheck configs do not cover): `git grep -E
'\b(screenAgent|buildAgentTools|addAgentTool)\b'` → **zero hits** outside
CHANGELOGs and the changeset.

## vendo-web disposition

**No companion PR needed, and no adaptation required.** All ten symbols above
return **zero hits** across the entire `vendo-web` clone (excluding
`node_modules` and `.next`). `vendo-web` does not import `screenAgent`, does not
construct a screen `Harness`, and does not touch the tool bridge — the only
removed *public* symbol is `screenAgent`, and vendo-web never referenced it. This
is a written no-op justification, not a "mechanical" hand-wave: the grep names
the files it would have hit, and there are none.

## Gates

Run in this worktree on `origin/main` @ 6fb568a07, in the foreground, output to
files:

| Gate | Result |
| --- | --- |
| `pnpm build` | `Tasks: 21 successful, 21 total` |
| `npx vitest run` (packages/harnesses, capped forks/threads) | `Test Files 44 passed \| 4 skipped (48)` · `Tests 567 passed \| 14 skipped (581)` — incl. `screen-agent.test.ts` 13/13 and `tools-preview-check.test.ts` 2/2 |
| `pnpm typecheck` | `Tasks: 40 successful, 40 total` |
| `pnpm lint --force` | `Tasks: 3 successful, 3 total`, `Cached: 0` — 0 errors (1 pre-existing `demo-bank` warning, untouched here). Re-run forced because the first run returned FULL TURBO instantly. `dependency-guard.mjs` and `portability-gate.mjs` both pass. |

The full suite is CI's job; the green `ci` check is the gate of record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the dead `screenAgent()` export and uncurried the tool bridge (`guardedCall`, `previewApproval`) to simplify calls. Behavior is unchanged; public surface is smaller and internals are clearer.

- **Refactors**
  - Removed `screenAgent()` and its helpers; `screenAssembler()` remains the single path.
  - Deleted unused `buildAgentTools` and `addAgentTool`.
  - Updated signatures:
    - `guardedCall(descriptor, options, input, { toolCallId })`
    - `previewApproval(descriptor, options, input, { toolCallId }, onAsk?)`
  - Kept `onAsk`; fixed stale references; trimmed imports; repointed `tools-preview-check.test.ts`.

- **Migration**
  - `@vendoai/harnesses`: `screenAgent` removed. Use `screenAssembler` via the `vendo_make` route.
  - No changes needed for `vendo-web` or other callers; tool-bridge functions were not on the barrel.

<sup>Written for commit bd65da15aa54fdd446c0abd68ab035149888c318. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

