### PR TITLE
fix(core): days_until reads one date, a duplicate that lost says so, and the plan's issue list stops being a prompt bomb

### DIFF
--- a/.changeset/days-until-reads-one-date.md
+++ b/.changeset/days-until-reads-one-date.md
@@ -1,0 +1,27 @@
+---
+"@vendoai/core": patch
+---
+
+The `$expr` fact check and the evaluator agree about `days_until`.
+
+`days_until(invoices.due_date)` reads the `due_date` COLUMN off every row, and the
+evaluator has always refused it — "days_until() reads one date, but
+invoices.due_date is a list of 3". The static check looked past the column at its
+items, saw strings, and passed. So a generated app shipped through the fact check
+clean and then rendered the contained data-shape notice instead of the number the
+model was asked for. `days_until` is now checked as the scalar slot it is, with
+the evaluator's own repair sentence. The check/evaluator agreement table that
+landed with the two-level column paths grows the three rows that cover it.
+
+Two smaller compiler corrections ride along. A duplicate attribute whose LAST value
+was dropped (single-quoted, ill-formed UTF-16, an invalid action) was still reported
+as "the last one wins", which sent a retry back to re-write the value that never
+landed; the message now names the outcome, and two compiler-owned `id` attributes
+no longer claim a winner where both are ignored. And `compilePlan`'s issue list —
+which is verbatim the model's retry prompt — is capped at 64 with a final count,
+the way the wire compiler already caps its own; a broken document previously minted
+one sentence per stray token with no bound.
+
+Internal only, no public surface change: the wire attribute layer's dead `patch`
+element mode, its action-attribute regex duplicated into the printer, and
+`state.ts`'s pass-through re-export of `isWellFormedUtf16` are gone.

--- a/.changeset/days-until-reads-one-date.md
+++ b/.changeset/days-until-reads-one-date.md
@@ -16,11 +16,13 @@ landed with the two-level column paths grows the three rows that cover it.
 Two smaller compiler corrections ride along. A duplicate attribute whose LAST value
 was dropped (single-quoted, ill-formed UTF-16, an invalid action) was still reported
 as "the last one wins", which sent a retry back to re-write the value that never
-landed; the message now names the outcome, and two compiler-owned `id` attributes
-no longer claim a winner where both are ignored. And `compilePlan`'s issue list —
-which is verbatim the model's retry prompt — is capped at 64 with a final count,
-the way the wire compiler already caps its own; a broken document previously minted
-one sentence per stray token with no bound.
+landed; the message now names the outcome — including the case where EVERY value
+was dropped and no attribute survives at all — and two compiler-owned `id`
+attributes no longer claim a winner where both are ignored. And `compilePlan`'s
+issue list — which is verbatim the model's retry prompt — is capped at 64 with a
+final count, the way the wire compiler already caps its own; a broken document
+previously minted one sentence per stray token with no bound. That count reads
+"1 further problem was not listed" when exactly one is omitted.
 
 Internal only, no public surface change: the wire attribute layer's dead `patch`
 element mode, its action-attribute regex duplicated into the printer, and

--- a/packages/core/src/genui/expr.test.ts
+++ b/packages/core/src/genui/expr.test.ts
@@ -371,6 +371,12 @@ describe("checkExpr", () => {
       ['sum(grids, "cells")', null],
       ["difference(matrix, 5)", null],
       ["difference(orders.lines.cents, 5)", null],
+      // days_until reads ONE date, so a column of dates is the same split in a
+      // non-numeric slot: the evaluator refuses the list, and the check may not
+      // wave it through just because the column's items are strings.
+      ["days_until(orders.0.placed)", -11],
+      ["days_until(orders.placed)", null],
+      ["days_until(orders.lines.at)", null],
     ];
     for (const [source, value] of table) {
       const issues = checkExpr(source, context);

--- a/packages/core/src/genui/expr.ts
+++ b/packages/core/src/genui/expr.ts
@@ -1020,7 +1020,16 @@ const callShape = (state: CheckState, node: ExprNode & { kind: "call" }): ShapeT
     return { kind: "number" };
   }
   if (node.name === "days_until") {
-    const shape = columnItems(pathShape(state, rows).shape);
+    const shape = pathShape(state, rows).shape;
+    // days_until is a SCALAR slot: it reads one date, so a column of dates is
+    // as wrong as a column of numbers is under `-`. The evaluator says so; the
+    // check said nothing while columnItems looked past the list at its items.
+    if (shape.kind === "array") {
+      state.issues.push(
+        `days_until() reads one date, but ${rows.text} is a list — point it at a single row's date field`,
+      );
+      return { kind: "number" };
+    }
     if (shape.kind !== "json" && shape.kind !== "string") {
       state.issues.push(`days_until() reads an ISO date string, but ${rows.text} is a ${shape.kind} field`);
     }

--- a/packages/core/src/genui/plan/compile.test.ts
+++ b/packages/core/src/genui/plan/compile.test.ts
@@ -223,24 +223,6 @@ describe("compilePlan", () => {
     expect(result.issues.at(-1)).toContain("were not listed");
   });
 
-  it("issues read as sentences a person could say, never error codes", () => {
-    const result = compilePlan(
-      `<Plan>
-         <Group tab="Overview" layout="masonry">
-           <Leaf purpose="Something"/>
-           <Leaf component="StatTile"/>
-         </Group>
-         <Server kind="magic" why="Because."/>
-         <Cannot></Cannot>
-       </Plan>`,
-      FACTS,
-    );
-    expect(result.issues.length).toBeGreaterThan(4);
-    for (const message of result.issues) {
-      expect(message.split(" ").length).toBeGreaterThan(4);
-    }
-  });
-
   it("reads a valid five-field cron schedule without complaint", () => {
     const result = compilePlan(
       `<Plan name="Valid cron"><Group><Leaf component="StatTile" purpose="Total outstanding"/></Group>

--- a/packages/core/src/genui/plan/compile.test.ts
+++ b/packages/core/src/genui/plan/compile.test.ts
@@ -215,6 +215,14 @@ describe("compilePlan", () => {
     expect(truncated.issues.join(" ")).toContain("ended before </Plan>");
   });
 
+  it("caps the issue list, because the issues become the retry prompt", () => {
+    // One stray close tag mints one sentence, so a hostile (or merely broken)
+    // document otherwise hands the model an issue per byte.
+    const result = compilePlan(`<Plan name="Noise">${"</X>".repeat(2000)}</Plan>`, FACTS);
+    expect(result.issues.length).toBeLessThan(200);
+    expect(result.issues.at(-1)).toContain("were not listed");
+  });
+
   it("issues read as sentences a person could say, never error codes", () => {
     const result = compilePlan(
       `<Plan>

--- a/packages/core/src/genui/plan/compile.test.ts
+++ b/packages/core/src/genui/plan/compile.test.ts
@@ -223,6 +223,14 @@ describe("compilePlan", () => {
     expect(result.issues.at(-1)).toContain("were not listed");
   });
 
+  it("counts a single omitted issue in the singular", () => {
+    // The issue list is the retry prompt verbatim, so "1 further problems" is
+    // a grammatical error handed straight to the model.
+    const result = compilePlan(`<Plan name="Noise">${"</X>".repeat(64)}</Plan>`, FACTS);
+    expect(result.issues).toHaveLength(65);
+    expect(result.issues.at(-1)).toBe("1 further problem was not listed — fix these first and write the plan again.");
+  });
+
   it("reads a valid five-field cron schedule without complaint", () => {
     const result = compilePlan(
       `<Plan name="Valid cron"><Group><Leaf component="StatTile" purpose="Total outstanding"/></Group>

--- a/packages/core/src/genui/plan/compile.ts
+++ b/packages/core/src/genui/plan/compile.ts
@@ -566,13 +566,15 @@ const compilePlanUnsafe = (text: string, facts: PlanFacts): PlanCompileResult =>
   return { plan: appPlan, issues: plan.issues };
 };
 
-const capIssues = (issues: string[]): string[] =>
-  issues.length <= PLAN_MAX_ISSUES
-    ? issues
-    : [
-      ...issues.slice(0, PLAN_MAX_ISSUES),
-      `${issues.length - PLAN_MAX_ISSUES} further problems were not listed — fix these first and write the plan again.`,
-    ];
+const capIssues = (issues: string[]): string[] => {
+  if (issues.length <= PLAN_MAX_ISSUES) return issues;
+  const omitted = issues.length - PLAN_MAX_ISSUES;
+  const problems = omitted === 1 ? "1 further problem was" : `${omitted} further problems were`;
+  return [
+    ...issues.slice(0, PLAN_MAX_ISSUES),
+    `${problems} not listed — fix these first and write the plan again.`,
+  ];
+};
 
 /**
  * Read one `<Plan>` document into an {@link AppPlan}, checking it against what

--- a/packages/core/src/genui/plan/compile.ts
+++ b/packages/core/src/genui/plan/compile.ts
@@ -36,7 +36,15 @@ import { parseAttributes, type ParsedAttributes } from "../wire/attributes.js";
 import { makeState, opensRoot, prescanDeclarations } from "../wire/compile.js";
 import { collectText, readName, scanCloseTag, skipCommentOrBraces, skipElement, skipWhitespace } from "../wire/scan.js";
 import { FAILED, type CompileState, type Failed } from "../wire/state.js";
-import type { AppPlan, PlanGroup, PlanLeaf, PlanQuery, PlanServer } from "./types.js";
+import {
+  PLAN_DISPLAYS,
+  type AppPlan,
+  type PlanDisplay,
+  type PlanGroup,
+  type PlanLeaf,
+  type PlanQuery,
+  type PlanServer,
+} from "./types.js";
 
 /** What the host actually has, for the fact checks. */
 export interface PlanFacts {
@@ -541,11 +549,11 @@ const compilePlanUnsafe = (text: string, facts: PlanFacts): PlanCompileResult =>
   }
   const appPlan: AppPlan = { name: name ?? "", queries: [], groups: [], cannot: [] };
   const display = head.props?.display;
-  if (display === "inline" || display === "stage") {
-    appPlan.display = display;
+  if (typeof display === "string" && (PLAN_DISPLAYS as readonly string[]).includes(display)) {
+    appPlan.display = display as PlanDisplay;
   } else if (display !== undefined) {
     plan.issues.push(
-      `a plan's display is "inline" or "stage", and ${describe(display)} is neither — this one arrives inline.`,
+      `a plan's display is ${PLAN_DISPLAYS.map((one) => `"${one}"`).join(" or ")}, and ${describe(display)} is neither — this one arrives inline.`,
     );
   }
   if (!head.selfClosing) compilePlanChildren(plan, appPlan);

--- a/packages/core/src/genui/plan/compile.ts
+++ b/packages/core/src/genui/plan/compile.ts
@@ -68,6 +68,13 @@ const NO_NAMES: ReadonlySet<string> = new Set();
  *  stops teaching once it becomes a catalog dump. */
 const MAX_LISTED_NAMES = 12;
 
+/** At most this many issues are handed back. The issue list IS the retry
+ *  prompt, and a broken document mints a sentence per stray token, so an
+ *  uncapped list is an unbounded prompt (the wire compiler caps its own for
+ *  the same reason, wire/state.ts). A plan is a short document: nothing a
+ *  rewrite can act on lives past the first few dozen sentences. */
+const PLAN_MAX_ISSUES = 64;
+
 const nameList = (names: readonly string[]): string => {
   if (names.length === 0) return "none at all";
   const shown = names.slice(0, MAX_LISTED_NAMES).join(", ");
@@ -551,6 +558,14 @@ const compilePlanUnsafe = (text: string, facts: PlanFacts): PlanCompileResult =>
   return { plan: appPlan, issues: plan.issues };
 };
 
+const capIssues = (issues: string[]): string[] =>
+  issues.length <= PLAN_MAX_ISSUES
+    ? issues
+    : [
+      ...issues.slice(0, PLAN_MAX_ISSUES),
+      `${issues.length - PLAN_MAX_ISSUES} further problems were not listed — fix these first and write the plan again.`,
+    ];
+
 /**
  * Read one `<Plan>` document into an {@link AppPlan}, checking it against what
  * the host actually has. Pure, deterministic and total: never throws — an
@@ -558,7 +573,8 @@ const compilePlanUnsafe = (text: string, facts: PlanFacts): PlanCompileResult =>
  */
 export function compilePlan(text: string, facts: PlanFacts): PlanCompileResult {
   try {
-    return compilePlanUnsafe(text, facts);
+    const result = compilePlanUnsafe(text, facts);
+    return { ...result, issues: capIssues(result.issues) };
   } catch (error) {
     return {
       issues: [`the plan could not be read (${safeErrorMessage(error)}); write it again as one <Plan> document.`],

--- a/packages/core/src/genui/wire/attributes.ts
+++ b/packages/core/src/genui/wire/attributes.ts
@@ -190,16 +190,20 @@ export const parseAttributes = (state: CompileState, element: AttributeElement):
       seen.add(name);
       continue;
     }
-    // Reported AFTER the drop, because the outcome is what a retry acts on: a
-    // dropped last value leaves the earlier one standing, and saying the last
-    // one won sends the model back to re-write the value that never landed.
+    // Reported AFTER the drop, because the outcome is what a retry acts on:
+    // saying the last one won when it was dropped sends the model back to
+    // re-write a value that never landed, and saying an earlier one stands
+    // when every value was dropped points it at a prop that is not there.
+    // props is the record of what actually landed; seen is only occurrence.
     if (seen.has(name)) {
       issue(
         state,
         "duplicate-attribute",
-        value === DROPPED
-          ? `duplicate attribute "${name}" (the last one was dropped, so the earlier one stands)`
-          : `duplicate attribute "${name}" (the last one wins)`,
+        value !== DROPPED
+          ? `duplicate attribute "${name}" (the last one wins)`
+          : Object.prototype.hasOwnProperty.call(props, name)
+            ? `duplicate attribute "${name}" (the last one was dropped, so the earlier one stands)`
+            : `duplicate attribute "${name}" (every value was dropped, so the attribute is missing)`,
       );
     }
     seen.add(name);

--- a/packages/core/src/genui/wire/attributes.ts
+++ b/packages/core/src/genui/wire/attributes.ts
@@ -195,14 +195,24 @@ export const parseAttributes = (state: CompileState, element: AttributeElement):
     } else {
       state.index = beforeValue;
     }
-    if (seen.has(name)) {
-      issue(state, "duplicate-attribute", `duplicate attribute "${name}" (the last one wins)`);
-    }
-    seen.add(name);
-    if (name === "id" && element !== "declaration" && element !== "patch") {
+    if (name === "id" && element !== "declaration") {
       issue(state, "wire-id-ignored", "wire-supplied id attributes are ignored (ids are compiler-owned)");
+      seen.add(name);
       continue;
     }
+    // Reported AFTER the drop, because the outcome is what a retry acts on: a
+    // dropped last value leaves the earlier one standing, and saying the last
+    // one won sends the model back to re-write the value that never landed.
+    if (seen.has(name)) {
+      issue(
+        state,
+        "duplicate-attribute",
+        value === DROPPED
+          ? `duplicate attribute "${name}" (the last one was dropped, so the earlier one stands)`
+          : `duplicate attribute "${name}" (the last one wins)`,
+      );
+    }
+    seen.add(name);
     if (value === DROPPED) continue;
     // defineOwn: a wire attribute named __proto__ must become data, never
     // the props object's prototype.

--- a/packages/core/src/genui/wire/attributes.ts
+++ b/packages/core/src/genui/wire/attributes.ts
@@ -9,38 +9,27 @@
 
 import { FN_REFERENCE_PATTERN, findInvalidActionReference } from "../../fn-references.js";
 import type { Json } from "../../ids.js";
+import { isWellFormedUtf16 } from "../../jcs.js";
 import { TOOL_NAME_PATTERN } from "../../tools.js";
 import { defineOwn } from "../tree-node.js";
 import { parseExpression } from "./expression.js";
 import { NAME_START, readName, skipBraceBlock, skipQuotedRun, skipWhitespace } from "./scan.js";
-import {
-  DROPPED,
-  FAILED,
-  issue,
-  isWellFormedUtf16,
-  mergeIssues,
-  type CompileState,
-  type Dropped,
-  type Failed,
-} from "./state.js";
+import { DROPPED, FAILED, issue, mergeIssues, type CompileState, type Dropped, type Failed } from "./state.js";
 
-/** D5 — an attribute name in action position: `on` + uppercase letter. */
-const ACTION_ATTR_PATTERN = /^on[A-Z][A-Za-z0-9_]*$/;
+/** D5 — an attribute name in action position: `on` + uppercase letter. Shared
+ *  with the printer (print.ts), which reads it as D5's inverse. */
+export const ACTION_ATTR_PATTERN = /^on[A-Z][A-Za-z0-9_]*$/;
 
 /**
- * Which element kind the attribute region belongs to (D3/D5; patch is v2
- * spec §5):
+ * Which element kind the attribute region belongs to (D3/D5):
  * - `component` — `id` is compiler-owned (ignored with an issue) and
  *   string-form `on*` attributes compile to canonical actions.
  * - `app` — `id` is ignored like a component's, but non-name attributes are
  *   silently discarded by the caller, so no action compilation runs.
  * - `declaration` — Query/Island: `id`/`name` are the declaration's own
  *   fields, kept verbatim; no action compilation.
- * - `patch` — edit-dialect ops: `id` is the op's ANCHOR (kept verbatim), and
- *   values compile exactly like a component's (actions included), since Set
- *   merges them into node props.
  */
-export type AttributeElement = "component" | "app" | "declaration" | "patch";
+export type AttributeElement = "component" | "app" | "declaration";
 
 /** D3 — markup-layer strings are double-quoted only; `\"` and `\\` are the
  *  only escapes (other backslash sequences pass through verbatim — rich
@@ -116,7 +105,8 @@ export interface ParsedAttributes {
 
 /** Parses the attribute region of an open tag through its `>` or `/>`.
  *  Three value forms (D3): `attr="string"`, `attr={expr}`, bare `attr` →
- *  true. Duplicates: last wins + issue. Outside declarations, `id` is
+ *  true. Duplicates: the last one wins unless it was dropped, either way with
+ *  an issue naming the outcome. Outside declarations, `id` is
  *  ignored with an issue (ids are compiler-owned) and string-form `on*`
  *  attributes compile to actions on components (D5, see
  *  {@link AttributeElement}). Returns FAILED only on EOF truncation. */
@@ -157,7 +147,7 @@ export const parseAttributes = (state: CompileState, element: AttributeElement):
         const parsed = parseMarkupString(state, name);
         if (parsed === FAILED) return FAILED;
         value = parsed;
-        if (typeof value === "string" && (element === "component" || element === "patch") && ACTION_ATTR_PATTERN.test(name)) {
+        if (typeof value === "string" && element === "component" && ACTION_ATTR_PATTERN.test(name)) {
           value = compileActionValue(state, name, value);
         }
       } else if (opener === "{") {
@@ -169,7 +159,7 @@ export const parseAttributes = (state: CompileState, element: AttributeElement):
         // value smuggling { action: "fn:9bad" } anywhere would un-validate
         // the tree. Drop the attribute here instead — only component props
         // land in tree nodes, so only "component" needs the walk.
-        if ((element === "component" || element === "patch") && value !== DROPPED) {
+        if (element === "component" && value !== DROPPED) {
           const invalidAction = findInvalidActionReference(value);
           if (invalidAction !== null) {
             issue(

--- a/packages/core/src/genui/wire/compile.test.ts
+++ b/packages/core/src/genui/wire/compile.test.ts
@@ -169,6 +169,20 @@ describe("compileWire attributes", () => {
     expect(codes(result)).toEqual(["duplicate-attribute"]);
   });
 
+  it("says the earlier attribute stands when the last one was dropped", () => {
+    // "the last one wins" is the model's repair instruction: told the last one
+    // won when it was dropped, a retry re-sends the value that never landed.
+    const result = compile(`<App><Card a="1" a='2'/></App>`);
+    expect(result.tree.nodes[1]?.props).toStrictEqual({ a: "1" });
+    expect(result.issues.map(({ message }) => message).join("\n")).not.toContain("the last one wins");
+  });
+
+  it("does not claim a winner when both duplicates are compiler-owned ids", () => {
+    const result = compile('<App><Card id="one" id="two"/></App>');
+    expect(result.tree.nodes[1]).toStrictEqual({ id: "card-1", component: "Card", source: "prewired" });
+    expect(result.issues.map(({ message }) => message).join("\n")).not.toContain("the last one wins");
+  });
+
   it("drops an ill-formed UTF-16 string attribute (lone surrogate)", () => {
     const result = compile('<App><Card title="a\uD800b"/></App>');
     expect(result.tree.nodes[1]).toStrictEqual({ id: "card-1", component: "Card", source: "prewired" });

--- a/packages/core/src/genui/wire/compile.test.ts
+++ b/packages/core/src/genui/wire/compile.test.ts
@@ -177,6 +177,16 @@ describe("compileWire attributes", () => {
     expect(result.issues.map(({ message }) => message).join("\n")).not.toContain("the last one wins");
   });
 
+  it("does not claim a survivor when every duplicate value was dropped", () => {
+    // Both values are dropped, so no onClick prop exists. Telling a retry that
+    // "the earlier one stands" points it at a value that is not there.
+    const result = compile('<App><Card onClick="not a tool" onClick="also not a tool"/></App>');
+    expect(result.tree.nodes[1]?.props).toBeUndefined();
+    expect(result.issues.map(({ message }) => message)).toContain(
+      'duplicate attribute "onClick" (every value was dropped, so the attribute is missing)',
+    );
+  });
+
   it("does not claim a winner when both duplicates are compiler-owned ids", () => {
     const result = compile('<App><Card id="one" id="two"/></App>');
     expect(result.tree.nodes[1]).toStrictEqual({ id: "card-1", component: "Card", source: "prewired" });

--- a/packages/core/src/genui/wire/compile.ts
+++ b/packages/core/src/genui/wire/compile.ts
@@ -31,6 +31,7 @@ import { safeErrorMessage } from "../../errors.js";
 import { FN_REFERENCE_PATTERN } from "../../fn-references.js";
 import { VENDO_TREE_FORMAT } from "../../formats.js";
 import type { Json } from "../../ids.js";
+import { isWellFormedUtf16 } from "../../jcs.js";
 import { isPlainObject, type TreeNode } from "../tree-node.js";
 import { KIT_COMPONENT_NAMES, WIRE_COMPONENT_NAMES } from "../../kit/specs.js";
 import { QUERY_NAME_PATTERN, type TreeQuery, type Tree } from "../tree.js";
@@ -41,7 +42,7 @@ import { checkBindingShapes, mirrorBindingIssues, type BindingShapeError } from 
 import { expandInlineRefs } from "./inline-refs.js";
 import { admitIslandSource, claimNodeSlot, claimQuerySlot } from "./limits.js";
 import { collectText, NAME_CHAR, readName, scanCloseTag, scanTagEnd, skipCommentOrBraces, skipElement, skipWhitespace } from "./scan.js";
-import { FAILED, issue, isWellFormedUtf16, type CompileState, type Frame } from "./state.js";
+import { FAILED, issue, type CompileState, type Frame } from "./state.js";
 
 /** v2 spec §2 / plan D3 — compiler options. `hostComponents` (the host
  *  catalog names) feeds source resolution: host brand wins over the prewired

--- a/packages/core/src/genui/wire/expression.test.ts
+++ b/packages/core/src/genui/wire/expression.test.ts
@@ -212,6 +212,9 @@ describe("parseExpression bindings", () => {
     const numeric = parseExpression("revenue.0", { queryNames: new Set(["revenue"]) });
     expect(numeric.issues).toEqual([]);
     expect(numeric.value).toEqual({ $path: "/revenue/0" });
+    const midPath = parseExpression("accounts.data.0.sparkline", { queryNames: new Set(["accounts"]) });
+    expect(midPath.issues).toEqual([]);
+    expect(midPath.value).toEqual({ $path: "/accounts/data/0/sparkline" });
     expectDropped("revenue.", "malformed-expression");
   });
 });
@@ -365,14 +368,6 @@ describe("parseExpression reshape calls", () => {
     expect(result.dropped).toBe(true);
     expect(result.issues[0]?.code).toBe("malformed-expression");
     expect(result.issues[0]?.message).toContain("reshape pipes are gone");
-  });
-});
-
-describe("numeric path segments", () => {
-  it("accepts dot-numeric segments for array elements in query bindings", () => {
-    const result = parseExpression("accounts.data.0.sparkline", { queryNames: new Set(["accounts"]) });
-    expect(result.issues).toEqual([]);
-    expect(result.value).toEqual({ $path: "/accounts/data/0/sparkline" });
   });
 });
 

--- a/packages/core/src/genui/wire/expression.ts
+++ b/packages/core/src/genui/wire/expression.ts
@@ -44,7 +44,8 @@ export const WIRE_ISSUE_CODES = [
   // — attribute layer (attributes.ts)
   /** Attribute syntax error (bad char, single-quoted string, missing value, ill-formed UTF-16); attribute dropped or char skipped. */
   "malformed-attribute",
-  /** Same attribute name twice in one tag; the last one wins. */
+  /** Same attribute name twice in one tag; the last one wins, unless it was
+   *  dropped — then the earlier one stands and the message says so. */
   "duplicate-attribute",
   /** Wire-supplied `id` on a non-declaration element ignored (ids are compiler-owned). */
   "wire-id-ignored",

--- a/packages/core/src/genui/wire/expression.ts
+++ b/packages/core/src/genui/wire/expression.ts
@@ -45,7 +45,8 @@ export const WIRE_ISSUE_CODES = [
   /** Attribute syntax error (bad char, single-quoted string, missing value, ill-formed UTF-16); attribute dropped or char skipped. */
   "malformed-attribute",
   /** Same attribute name twice in one tag; the last one wins, unless it was
-   *  dropped — then the earlier one stands and the message says so. */
+   *  dropped — then whichever value actually landed stands, and the message
+   *  says which, up to none of them. */
   "duplicate-attribute",
   /** Wire-supplied `id` on a non-declaration element ignored (ids are compiler-owned). */
   "wire-id-ignored",

--- a/packages/core/src/genui/wire/expression.ts
+++ b/packages/core/src/genui/wire/expression.ts
@@ -19,10 +19,10 @@
 
 import { safeErrorMessage } from "../../errors.js";
 import type { Json } from "../../ids.js";
+import { isWellFormedUtf16 } from "../../jcs.js";
 import { findInvalidReshapeSteps, type ReshapeStep } from "../../reshape.js";
 import { exprPathHeads, parseExprPrefix, type ExprBinding, type ExprNode } from "../expr.js";
 import { defineOwn, isPathBinding, isStateBinding, type PathBinding, type StateBinding } from "../tree-node.js";
-import { isWellFormedUtf16 } from "./state.js";
 
 /**
  * v2 spec §2 — the closed registry of stable issue codes across all six

--- a/packages/core/src/genui/wire/limits.ts
+++ b/packages/core/src/genui/wire/limits.ts
@@ -13,6 +13,7 @@
 // CORE-6: the contract pins the byte caps in kilobytes, so island sources
 // are measured with component-map.ts's shared UTF-8 byte counter.
 import { utf8ByteLength } from "../../component-map.js";
+import { isWellFormedUtf16 } from "../../jcs.js";
 import {
   TREE_MAX_COMPONENT_SOURCE_BYTES,
   TREE_MAX_GENERATED_COMPONENTS,
@@ -20,7 +21,7 @@ import {
   TREE_MAX_QUERIES,
   TREE_MAX_TOTAL_COMPONENT_BYTES,
 } from "../tree-limits.js";
-import { issue, isWellFormedUtf16, type CompileState } from "./state.js";
+import { issue, type CompileState } from "./state.js";
 
 /** §8 TREE_MAX_NODES — true when another node may be appended. Beyond the
  *  cap, elements are still parsed for document structure/recovery, but no

--- a/packages/core/src/genui/wire/print.ts
+++ b/packages/core/src/genui/wire/print.ts
@@ -1,10 +1,10 @@
 /**
- * Internal: the vendo-genui/v2 wire printer — the inverse of the wave-1
- * compiler and the edit dialect's model context (v2 spec §5,
- * docs/superpowers/specs/2026-07-18-vendo-v2-format-spec.md). A compile (or
- * patch) result prints back to the JSX-wire markup; with `includeIds` each
- * element is stamped with its compiler-minted id so the model can anchor a
- * patch. Only `printWire` is public (root export).
+ * Internal: the vendo-genui/v2 wire printer — the inverse of the compiler
+ * (v2 spec §5, docs/superpowers/specs/2026-07-18-vendo-v2-format-spec.md). A
+ * compile result prints back to the JSX-wire markup; with `includeIds` each
+ * element is stamped with its compiler-minted id, which is how a checked-out
+ * app's `app.vendo` carries stable ids. Only `printWire` is public (root
+ * export).
  *
  * The round-trip law (pinned in print.test.ts): for any COMPILER-PRODUCED
  * result, `compileWire(printWire(result))` reproduces tree, components,
@@ -20,6 +20,7 @@ import { FN_REFERENCE_PATTERN } from "../../fn-references.js";
 import { isExprBinding, parseExpr } from "../expr.js";
 import { isPathBinding, isPlainObject, isStateBinding, type TreeNode } from "../tree-node.js";
 import type { TreeQuery } from "../tree.js";
+import { ACTION_ATTR_PATTERN } from "./attributes.js";
 import type { WireCompileResult } from "./compile.js";
 
 /** v2 spec §5 — printer options. `includeIds` stamps node ids (the model's
@@ -28,11 +29,10 @@ export interface WirePrintOptions {
   includeIds: boolean;
 }
 
-/** The printable slice of a compile/patch result. */
+/** The printable slice of a compile result. */
 export type WirePrintInput = Pick<WireCompileResult, "tree" | "components" | "name">;
 
 const IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
-const ACTION_ATTR_PATTERN = /^on[A-Z][A-Za-z0-9_]*$/;
 
 /** Markup strings escape exactly the quote and the backslash (attributes.ts
  *  decodes only those two); expression strings use the same minimal pair —
@@ -188,7 +188,7 @@ const printQuery = (query: TreeQuery, queryNames: ReadonlySet<string>): string =
 };
 
 /**
- * v2 spec §5 — print a compile/patch result back to wire markup. Pure,
+ * v2 spec §5 — print a compile result back to wire markup. Pure,
  * deterministic, total. Document order matches the spec example (queries →
  * body → islands), which also keeps re-minted ids identical on recompile.
  */

--- a/packages/core/src/genui/wire/state.ts
+++ b/packages/core/src/genui/wire/state.ts
@@ -2,8 +2,7 @@
  * Internal: shared compiler state for the vendo-genui/v2 wire markup compiler
  * (v2 spec §2, docs/superpowers/specs/2026-07-18-vendo-v2-format-spec.md;
  * plan decisions D3/D6). Bottom of the wire module stack: compile →
- * attributes → scan → state; expression.ts also imports the shared UTF-16
- * well-formedness guard from here.
+ * attributes → scan → state.
  */
 
 import type { TreeNode } from "../tree-node.js";
@@ -98,9 +97,3 @@ export const issue = (state: CompileState, code: WireIssueCode, message: string)
 export const mergeIssues = (state: CompileState, issues: readonly WireIssue[]): void => {
   for (const entry of issues) pushCapped(state, entry);
 };
-
-/** The shared UTF-16 well-formedness guard, canonically in jcs.ts (whose
- *  canonicalJson throws on lone surrogates, so ill-formed UTF-16 must never
- *  enter props). Re-exported for the markup layer (attributes.ts, compile.ts,
- *  limits.ts) and the expression layer (expression.ts). */
-export { isWellFormedUtf16 } from "../../jcs.js";


### PR DESCRIPTION
## What

Every **remaining** catalog finding under `packages/core/src/genui`, worst-first, plus the `days_until` bug flagged for its own change.

**Real LOC: +138 / −77 across 13 files** (source: +82/−63; tests: +29/−14; changeset +27).

## The work list

I read `## @vendoai/core` in the slop map and selected every finding whose files live under `packages/core/src/genui`. Cards 1/7/8 (#946) and 12/18/25 (#961) were already landed and are not redone.

| # | Finding | Disposition |
|---|---|---|
| — | `days_until(invoices.due_date)` — the card-8 check/evaluator split in a non-numeric slot | **FIXED** (failing test first) |
| L-1088 | `"last one wins"` message lies when the last value is dropped | **FIXED** (failing test first) |
| L-1090 | Plan issue list has no cap, unlike the wire compiler's | **FIXED** (failing test first) |
| M-1024 | Debris from a deleted `patch.ts`: dead `"patch"` mode | **DELETED** — the four issue codes and the `scripted-model.ts` half already went in #961; the `AttributeElement` mode and the printer's "(or patch)" wording are what was left |
| L-1066 | Action-attribute regex copied into compiler and printer | **FIXED** — one exported `ACTION_ATTR_PATTERN` |
| L-1092 | Pass-through re-export of `isWellFormedUtf16` | **DELETED** — four readers import `jcs.js` directly |
| L-1086 | Validators hand-spell unions the types file declares | **PARTLY FIXED** — only `display` had a declared const (`PLAN_DISPLAYS`); it now checks membership. `layout` and `Server kind` have no const array to check against, and minting two new ones to satisfy a symmetry nobody asked for is the wrong trade |
| L-1060 | A test that asserts sentences have more than four words | **DELETED** |
| L-1064 | Numeric path segments tested twice, 150 lines apart | **DELETED** — the orphan describe's one extra case (a numeric segment MID-path) is folded into the surviving test, not lost |
| L-1084 | Twin `excerpt` helpers in `text-edit.ts` | **REJECTED — moot**, the file was deleted in #961 |
| L-1080 | "Re-asserting eight expectations already made earlier" | **REJECTED — cannot locate.** Neither the "eight expectations" pair nor the "slash-inside-string case" the finding names exists in the current `expression.test.ts`. Needs the cataloguer's line numbers |
| M-1026 | Two copies of the same child-scanning loop | **DEFERRED** — see below |
| M-1032 | 1439-line catch-all test file; `shape-check.ts` has no test file | **DEFERRED** |
| L-1072 | Four near-identical fixtures across three wire test files | **DEFERRED** |
| L-1076 | Four copy-pasted tests for one self-closing branch | **REJECTED.** The four tests each assert a *different* downstream effect on the plan (query dropped vs leaf kept vs server kept vs island kept). An `it.each` row would need a per-row assertion callback, which is not simpler than four short tests |
| L-1094 | Header comments cite a docs directory that does not exist | **DEFERRED** — `docs/superpowers/` is cited 36 times across `packages/`, and the archived contracts themselves cite it (`00-overview.md:4`, `01-core.md:3`). Fixing 11 genui files leaves the repo inconsistent; this is a repo-wide citation sweep, not a genui slice |

## Why the three fixes matter

**`days_until` on a date column.** `days_until(invoices.due_date)` reads the `due_date` COLUMN off every row. The evaluator has always refused it — *"days_until() reads one date, but invoices.due\_date is a list of 3"*. `checkExpr` called `columnItems`, looked past the list at its items, saw strings, and passed. So the app shipped through the fact check clean and rendered the contained data-shape notice instead of the number. `days_until` is now checked as the scalar slot it is, with the evaluator's own repair sentence. The check/evaluator agreement table from #946 grows from 14 to 17 rows.

**A duplicate that lost.** `duplicate-attribute` was reported *before* the value was dropped, so `<Card a="1" a='2'/>` told the model "the last one wins" when `a="1"` stood — sending a retry back to re-write the value that never landed. Two compiler-owned `id`s claimed a winner where both were ignored. The message now names the outcome.

**An uncapped plan issue list.** `compilePlan`'s issues ARE the model's retry prompt, and a broken document mints one sentence per stray token. `<Plan>` + 2000 stray close tags produced 2000 sentences. Capped at 64 with a final count, the way `wire/state.ts` already caps its own.

## Tests deleted (part of this change)

- `plan/compile.test.ts` — "issues read as sentences a person could say, never error codes" (a word count; the neighbouring tests pin every sentence exactly).
- `wire/expression.test.ts` — `describe("numeric path segments")`, a duplicate of the bindings test 150 lines above it. Its one distinct case was folded in.

## Caller sweep

- `AttributeElement`, `ACTION_ATTR_PATTERN`, `isWellFormedUtf16`'s re-export: none are public exports of `@vendoai/core` (`src/index.ts` re-exports only `compileWire`, `printWire`, `expandInlineRefs`, `checkBindingShapes`, `compilePlan` and the issue contract from `genui/wire`). Grepped `packages/`, `examples/`, `corpus/`, `docs/`, `docs-site/` and every test dir for each symbol and each changed message string after committing — `parseAttributes` has nine call sites, none of which ever passed `"patch"`; `isWellFormedUtf16` has exactly the four readers, all repointed.
- `wire-id-ignored` is a live seam (`packages/harnesses/src/advisory-door-agreement.test.ts`), so that suite was run explicitly.

## vendo-web disposition

Swept `~/repos/vendo-web` for `AttributeElement`, `isWellFormedUtf16`, `PLAN_DISPLAYS`, `days_until`, `checkExpr`, `compilePlan`, `duplicate-attribute`, `"the last one wins"`. The **only** hits are in `apps/console/lib/automations/exec-bundle.generated.ts` — a checked-in esbuild bundle emitted by `apps/console/hosted-exec/build.mjs` from the published `@vendoai/*` packages, header `// Generated by hosted-exec/build.mjs. Do not edit.` No hand-written vendo-web source references any symbol here.

**No companion PR needed, and here is why it is a no-op:** this slice removes nothing from `@vendoai/core`'s public surface, so the bundle keeps building against the same exports. The two behaviour deltas it will pick up on its next regeneration are strictly good ones (a wrong repair sentence corrected, an unbounded issue list capped). Nothing in vendo-web matches on either string.

## Evidence

- `pnpm build` — 21/21 tasks, exit 0.
- `pnpm typecheck` — 40/40 tasks, exit 0.
- `pnpm lint --force` — 3/3 tasks, exit 0 (1 pre-existing warning in `demo-bank`).
- `packages/core` full suite — **58 files, 1073 tests passed**.
- Downstream canaries (core is layer 0): `packages/apps` `src/checking` + `src/generation` + `src/skills` — **17 passed / 1 skipped, 203 tests**; `packages/harnesses/src/advisory-door-agreement.test.ts` — **3 passed**.
- Never ran the full repo suite. CI's green `ci` check is the gate of record.

## Deferred — dispatch a follow-up

One slice, all in the genui **test estate** plus one plan-compiler refactor, none of it correctness:

1. **M-1026** extract one `scanChildren` from `compileGroupChildren` / `compilePlanChildren`. Deferred on purpose: #946 rewrote this exact loop's close-tag handling three days ago, and the two copies differ in the loose-text sentence, the ancestor rewind, the dropped-leaf counter and the trailing "ended before `</Plan>`" issue — an extraction wants its own review, not a ride-along.
2. **M-1032** move the four shape-related describes out of the 1439-line `wire/compile.test.ts` into a new `shape-check.test.ts`.
3. **L-1072** one shared "Cash Overview" fixture across `compile.test.ts` / `print.test.ts` / `roundtrip.e2e.test.ts`.
4. **L-1094** the repo-wide `docs/superpowers/` citation sweep (36 hits, and the archive cites it too) — needs an owner-level call on what to point at.

## Changeset

`patch` for `@vendoai/core`: no public export was added or removed, so the surface neither grows nor shrinks — this is three behaviour corrections plus internal cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three genui compiler issues: `days_until` now enforces scalar input, duplicate attributes report the real outcome, and plan issues are capped at 64 with a correct omitted count. No public API changes in `@vendoai/core`.

- **Bug Fixes**
  - `days_until(...)` now rejects column inputs and uses the evaluator’s wording.
  - Duplicate attributes: message names the outcome — earlier value stands if the last was dropped; if all were dropped, it says the attribute is missing; no “last one wins” for compiler-owned `id`s.
  - `compilePlan` caps issues at 64 and appends a count, using the singular when exactly one is omitted.

- **Refactors**
  - Removed dead `"patch"` mode from the wire attribute layer.
  - Exported one `ACTION_ATTR_PATTERN`; the printer imports it.
  - Dropped the pass-through re-export of `isWellFormedUtf16`; readers import from `jcs` directly.
  - `Plan.display` validated against `PLAN_DISPLAYS` with a clearer error.
  - Trimmed redundant tests; added targeted coverage for the fixes.

<sup>Written for commit 26a48566804f590c6a29e7295344ae9808fcebe2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

