### PR TITLE
fix(ui): a crashing tree node settles instead of spinning, and the zod shim stops hanging

### DIFF
--- a/.changeset/a-crashing-node-settles-instead-of-spinning.md
+++ b/.changeset/a-crashing-node-settles-instead-of-spinning.md
@@ -1,0 +1,20 @@
+---
+"@vendoai/ui": minor
+---
+
+Two real defects in the tree renderer, and one dead extension point removed.
+
+- The node error boundary cleared its own latched error on every re-render
+  while a payload was streaming, so a node that kept throwing re-rendered
+  itself until React's nested-update guard crashed the whole surface the
+  boundary exists to contain. It now retries only when an input actually
+  changes — a new prefix, a new node, or the flip to the final payload.
+- The jail's zod shim answered `then` with another chainable node, which made
+  every schema (and the module object itself) a thenable whose callback never
+  fires: one `await` inside a generated component hung the island forever.
+  `then`/`catch`/`finally` are absent now, and `in` agrees.
+- `registerTreeRenderer` is removed from `@vendoai/ui/tree`. The payload
+  renderer registry served exactly one format and had no caller anywhere;
+  `PayloadView` checks the format tag directly. `InClientVenue` and `PinDrift`
+  are no longer re-exported from the tree subpath — import them from
+  `@vendoai/ui`, which is where they are declared.

--- a/.changeset/a-crashing-node-settles-instead-of-spinning.md
+++ b/.changeset/a-crashing-node-settles-instead-of-spinning.md
@@ -12,7 +12,8 @@ Two real defects in the tree renderer, and one dead extension point removed.
 - The jail's zod shim answered `then` with another chainable node, which made
   every schema (and the module object itself) a thenable whose callback never
   fires: one `await` inside a generated component hung the island forever.
-  `then`/`catch`/`finally` are absent now, and `in` agrees.
+  `then` is absent now, and `in` agrees. Only `then` — it is the whole thenable
+  protocol, and `.catch(fallback)` is a real zod method the shim still answers.
 - `registerTreeRenderer` is removed from `@vendoai/ui/tree`. The payload
   renderer registry served exactly one format and had no caller anywhere;
   `PayloadView` checks the format tag directly. `InClientVenue` and `PinDrift`

--- a/packages/ui/src/tree/convert-payload.ts
+++ b/packages/ui/src/tree/convert-payload.ts
@@ -1,34 +1,30 @@
+import type { WalkTree } from "./renderer.js";
 import {
   validateTree,
   type Json,
   type TreeNode,
   type TreeQuery,
   type Tree,
+  type UIPayload,
 } from "@vendoai/core";
 
 /**
- * v2 spec §1 (docs/superpowers/specs/2026-07-18-vendo-v2-format-spec.md) —
- * the v2 renderer IS the v1 render path: a validated `vendo-genui/v2` tree
- * converts mechanically to the v1 tree shape and walks through TreeView, so
- * jail, guard, bindings, `$state`, and outcome containment are shared, not
- * reimplemented. Only the payload surface differs:
+ * The `vendo-genui/v2` payload converts mechanically to the walk tree TreeView
+ * renders, so jail, guard, bindings, `$state` and outcome containment are
+ * shared rather than reimplemented. Only the payload surface differs:
  *
  * - `queries` name bare identifiers; the result lives at JSON Pointer
- *   `"/" + name` by definition — the walk's path-keyed query shape.
+ *   `"/" + name` — the walk's path-keyed query shape.
  * - action props use the canonical `{ action: "..." }` shape the compiler
- *   emits (wire-v2 D5); the v1 walk dispatches `{ $action }`, so conversion
- *   rewrites the key.
+ *   emits; the walk dispatches `{ $action }`, so conversion rewrites the key.
  * - component sources ride on the PAYLOAD (app-document level), never the
  *   canonical tree — validateTree rejects tree-carried `components`, so
  *   they are lifted off before validation and re-attached for the walk.
  *
- * This module is a PURE converter. The registry registration lives in
- * renderer.tsx next to PayloadView: the ui package is `sideEffects: false`,
- * so a registration-only side-effect import would be tree-shaken out of
- * host bundles (caught live in the Wave 2 browser gate).
+ * This module is a PURE converter.
  */
 
-/** wire-v2 D5 — the canonical action prop shape `{ action: "tool" | "fn:..." }`. */
+/** The canonical action prop shape `{ action: "tool" | "fn:..." }`. */
 const isActionProp = (value: Record<string, unknown>): value is { action: string; payload?: Json } =>
   typeof value.action === "string";
 
@@ -49,30 +45,27 @@ const convertNode = (node: TreeNode): TreeNode => node.props === undefined
   ? node
   : { ...node, props: convertPropValue(node.props) as Record<string, Json> };
 
-/** v2 query results reside at `"/" + name` — that pointer is the v1 path. */
+/** Query results reside at `"/" + name` — that pointer is the walk's path. */
 const convertQuery = (query: TreeQuery): { path: string; tool: string; input?: Record<string, Json> } => ({
   path: `/${query.name}`,
   tool: query.tool,
   ...(query.input === undefined ? {} : { input: query.input }),
 });
 
-import type { WalkTree } from "./renderer.js";
-
 export type ConvertedPayload =
   | { ok: true; tree: WalkTree }
   | { ok: false; error: { code: "version" | "provision"; message: string } };
 
-export function convertPayload(payload: { formatVersion: string }): ConvertedPayload {
+export function convertPayload(payload: UIPayload): ConvertedPayload {
   // Sources live at the app-document level; the payload may carry them
-  // alongside the tree, but the canonical v2 tree must not (validateTree
+  // alongside the tree, but the canonical tree must not (validateTree
   // rejects it), so they are lifted off before the gate.
   const { components, ...tree } = payload as { components?: unknown };
   const validation = validateTree(tree);
   if (!validation.ok) return validation;
   // Payload extras beyond the Tree shape (streaming, furnishings, inClient,
   // pinDrift…) survive the spread at runtime; the shared walk reads them off
-  // the tree object (v2 spec §6 — the mechanics survive, the v1 format
-  // surface around them is gone).
+  // the tree object.
   const valid: Tree = validation.tree;
   return {
     ok: true,

--- a/packages/ui/src/tree/error-boundary.tsx
+++ b/packages/ui/src/tree/error-boundary.tsx
@@ -33,14 +33,16 @@ export class NodeErrorBoundary extends Component<BoundaryProps, BoundaryState> {
   }
 
   componentDidUpdate(previous: BoundaryProps): void {
+    // Every arm must be an INPUT change. Clearing on `streaming === true`
+    // alone is true of the boundary's own error re-render too, so the latch
+    // clears itself, the child throws again, and the loop only ends when
+    // React's nested-update guard crashes the surface the boundary exists to
+    // contain. A new prefix arrives as a new `retryKey`; the flip to the
+    // final payload arrives as a `streaming` change.
     if (
       (previous.nodeId !== this.props.nodeId
         || previous.retryKey !== this.props.retryKey
-        // A latched mid-stream error retries on EVERY new prefix (partials
-        // arrive throttled, so the retry loop is bounded), and the flip to
-        // the final payload re-evaluates fresh instead of inheriting a
-        // transient crash from the stream.
-        || previous.streaming === true)
+        || previous.streaming !== this.props.streaming)
       && this.state.error
     ) this.setState({ error: undefined });
   }

--- a/packages/ui/src/tree/forming-skeleton.tsx
+++ b/packages/ui/src/tree/forming-skeleton.tsx
@@ -35,10 +35,9 @@ export function Skeleton(props: { width?: string | number; height?: string | num
 }
 
 /**
- * Pick A (ui-lane-renderer, 2026-07-19) — the tree streams before generated
- * component SOURCES arrive, so a forming node's silhouette can only come from
- * what its name says the component is. Anything unrecognized keeps the
- * historical 72px slab, so the fallback is never worse than before.
+ * The tree streams before generated component SOURCES arrive, so a forming
+ * node's silhouette can only come from what its name says the component is.
+ * Anything unrecognized keeps the plain 72px slab.
  */
 export function deriveFormShape(componentName: string): FormShape {
   // A plot is the tallest thing in an app; a 72px slab that becomes a 180px

--- a/packages/ui/src/tree/frames.tsx
+++ b/packages/ui/src/tree/frames.tsx
@@ -7,16 +7,14 @@ import { PayloadView } from "./renderer.js";
 import { Skeleton } from "./forming-skeleton.js";
 
 /**
- * Wave 7 H2 — the served-surface keepalive seam. An embedded served app dies
+ * The served-surface keepalive seam. An embedded served app dies
  * under the user when its machine idles out; `ping` (client.apps.pingMachine)
  * is the host-proxied activity signal that keeps it awake. Activity is the gate,
  * not the timer: a machine costs money by the second, so an embed nobody is
  * using is allowed to sleep.
  *
- * That is the whole seam. A woken machine used to mint a new ingress URL, so the
- * frame also had to detect the wake and re-open for the fresh address; served-app
- * URLs are stable proxy URLs now, so a wake is invisible to the frame and the
- * re-open dance is gone.
+ * Served-app URLs are stable proxy URLs, so a wake is invisible to the frame:
+ * nothing has to be re-opened for a fresh address.
  */
 export interface AppFrameKeepalive {
   ping(): Promise<{ state: "awake" | "woke" }>;
@@ -95,8 +93,8 @@ function ResumingCover({ cover }: { cover?: string }) {
   );
 }
 
-/** The embedded served app (Wave 7 H2): the iframe, its keepalive ping, and the
- *  resize protocol it shares with the jail frame. */
+/** The embedded served app: the iframe, its keepalive ping, and the resize
+ *  protocol it shares with the jail frame. */
 function HttpFrame({ url, keepalive }: { url: string; keepalive?: AppFrameKeepalive }) {
   const frameRef = useRef<HTMLIFrameElement | null>(null);
   useEffect(() => {

--- a/packages/ui/src/tree/jail/zod-shim.ts
+++ b/packages/ui/src/tree/jail/zod-shim.ts
@@ -35,10 +35,16 @@
  *  one thing a shim must never fake. */
 const PARSERS = new Set(["parse", "safeParse", "parseAsync", "safeParseAsync"]);
 
-/** A chainable answer here would make every shim value a thenable whose
- *  `then` never calls back, so one `await` hangs the island forever. Absent
- *  is the only safe answer, and `has` says the same. */
-const PROMISE_KEYS = new Set(["then", "catch", "finally"]);
+/** A chainable answer here would make every shim value a thenable whose `then`
+ *  never calls back, so one `await` hangs the island forever. Absent is the only
+ *  safe answer, and `has` says the same.
+ *
+ *  ONLY `then`. It is the entire thenable protocol — `catch`/`finally` live on
+ *  real promises and are never read to decide whether a value is one — while
+ *  `.catch(fallback)` is a real zod method on every schema (zod 3 and 4) and a
+ *  namespace helper in zod 4. Blanking it broke components that declare a
+ *  fallback, which is worse than the hang it was meant to prevent. */
+const THENABLE_KEY = "then";
 
 /**
  * The shim's own refusal, with its OWN type. Deliberately not a `ZodError`: if
@@ -73,7 +79,7 @@ const node = (): unknown => new Proxy(function chain() {} as object, {
   get(_target, property) {
     if (typeof property === "symbol") return undefined;
     const key = String(property);
-    if (PROMISE_KEYS.has(key)) return undefined;
+    if (key === THENABLE_KEY) return undefined;
     if (PARSERS.has(key)) return () => refuse(key);
     // `_def`/`shape`/`options`/`element` are read by tooling, never by render
     // paths; a chainable answer keeps property access from throwing.
@@ -82,7 +88,7 @@ const node = (): unknown => new Proxy(function chain() {} as object, {
   // `z.object({...})`, `.min(1)`, `.describe("…")` — all calls chain.
   apply: () => node(),
   // Some code probes with `in`; answer consistently with `get`.
-  has: (_target, property) => !PROMISE_KEYS.has(String(property)),
+  has: (_target, property) => property !== THENABLE_KEY,
 });
 
 /**
@@ -104,12 +110,12 @@ export const zodShim: Record<string, unknown> = new Proxy({}, {
     if (typeof property === "symbol") return undefined;
     const key = String(property);
     if (key === "__esModule") return true;
-    if (PROMISE_KEYS.has(key)) return undefined;
+    if (key === THENABLE_KEY) return undefined;
     // The namespace and the default export are the module itself.
     if (key === "z" || key === "default") return zodShim;
     if (key === "ZodError") return ZodError;
     if (PARSERS.has(key)) return () => refuse(key);
     return node();
   },
-  has: (_target, property) => !PROMISE_KEYS.has(String(property)),
+  has: (_target, property) => property !== THENABLE_KEY,
 }) as Record<string, unknown>;

--- a/packages/ui/src/tree/jail/zod-shim.ts
+++ b/packages/ui/src/tree/jail/zod-shim.ts
@@ -35,6 +35,11 @@
  *  one thing a shim must never fake. */
 const PARSERS = new Set(["parse", "safeParse", "parseAsync", "safeParseAsync"]);
 
+/** A chainable answer here would make every shim value a thenable whose
+ *  `then` never calls back, so one `await` hangs the island forever. Absent
+ *  is the only safe answer, and `has` says the same. */
+const PROMISE_KEYS = new Set(["then", "catch", "finally"]);
+
 /**
  * The shim's own refusal, with its OWN type. Deliberately not a `ZodError`: if
  * a refusal were catchable as a validation error, a component's `catch (e) { if
@@ -68,6 +73,7 @@ const node = (): unknown => new Proxy(function chain() {} as object, {
   get(_target, property) {
     if (typeof property === "symbol") return undefined;
     const key = String(property);
+    if (PROMISE_KEYS.has(key)) return undefined;
     if (PARSERS.has(key)) return () => refuse(key);
     // `_def`/`shape`/`options`/`element` are read by tooling, never by render
     // paths; a chainable answer keeps property access from throwing.
@@ -76,7 +82,7 @@ const node = (): unknown => new Proxy(function chain() {} as object, {
   // `z.object({...})`, `.min(1)`, `.describe("…")` — all calls chain.
   apply: () => node(),
   // Some code probes with `in`; answer consistently with `get`.
-  has: () => true,
+  has: (_target, property) => !PROMISE_KEYS.has(String(property)),
 });
 
 /**
@@ -98,11 +104,12 @@ export const zodShim: Record<string, unknown> = new Proxy({}, {
     if (typeof property === "symbol") return undefined;
     const key = String(property);
     if (key === "__esModule") return true;
+    if (PROMISE_KEYS.has(key)) return undefined;
     // The namespace and the default export are the module itself.
     if (key === "z" || key === "default") return zodShim;
     if (key === "ZodError") return ZodError;
     if (PARSERS.has(key)) return () => refuse(key);
     return node();
   },
-  has: () => true,
+  has: (_target, property) => !PROMISE_KEYS.has(String(property)),
 }) as Record<string, unknown>;

--- a/packages/ui/src/tree/mcp-shim/shim-core.ts
+++ b/packages/ui/src/tree/mcp-shim/shim-core.ts
@@ -130,7 +130,7 @@ export function setQueryData(
   data: Record<string, Json>,
   query: TreeQuery,
   output: Json,
-): { data: Record<string, Json>; error?: string } {
+): Record<string, Json> {
   // v2 spec §2 — a query's result lives at "/" + name: always a single
   // top-level key (names are identifier-checked by validateTree). Own-
   // property define so a hostile name like __proto__ becomes data, never the
@@ -142,7 +142,7 @@ export function setQueryData(
     writable: true,
     configurable: true,
   });
-  return { data: next };
+  return next;
 }
 
 interface ResolveQueriesOptions {
@@ -180,9 +180,7 @@ export async function resolveQueries(
       errors.push(`Query "${query.tool}" failed: ${detail}`);
       continue;
     }
-    const updated = setQueryData(data, query, outcome.output);
-    data = updated.data;
-    if (updated.error) errors.push(updated.error);
+    data = setQueryData(data, query, outcome.output);
   }
   options.renderPayload(id, payload, data, errors);
 }

--- a/packages/ui/src/tree/notice.tsx
+++ b/packages/ui/src/tree/notice.tsx
@@ -30,13 +30,13 @@ const noticeStyle = (danger: boolean): CSSProperties => ({
  *
  * `children` is what a PERSON reads and always renders. `detail` is the
  * developer's half — an exception's own message, a validator's code line — and
- * renders only in dev mode (M36).
+ * renders only in dev mode.
  *
  * The gate lives here because every notice in a generated app goes through this
  * component, and there is no way for it to tell a consumer sentence from a raw
- * exception by looking at the string (ruling 14: a regex set cannot be that
- * authority). So the two halves are separate arguments, and a caller that has
- * developer text says so.
+ * exception by looking at the string — a regex set cannot be that authority.
+ * So the two halves are separate arguments, and a caller that has developer
+ * text says so.
  */
 export function ContainedNotice(props: {
   label: string;

--- a/packages/ui/src/tree/renderer.tsx
+++ b/packages/ui/src/tree/renderer.tsx
@@ -56,14 +56,6 @@ export interface PayloadRendererProps {
   onStateChange?(state: Record<string, Json>): void;
 }
 
-type PayloadRenderer = ComponentType<PayloadRendererProps>;
-const rendererRegistry = new Map<string, PayloadRenderer>();
-
-/** 01-core §8; 08-ui §5 — additive format registration for stored future payloads. */
-export function registerTreeRenderer(formatVersion: string, component: PayloadRenderer): void {
-  rendererRegistry.set(formatVersion, component);
-}
-
 /**
  * v2 spec §6 — the walk's input: the SHARED render mechanics' tree shape
  * (nodes, path-keyed resolved queries, grafted components, payload extras).
@@ -143,11 +135,8 @@ const validateWalkTree = (input: WalkTree): WalkValidation => {
   return { ok: true, tree: input };
 };
 
-/** v2 spec §1 — a validated v2 payload converts to the v1 tree shape and
- *  walks the SAME TreeView (convert-payload.tsx documents the mapping). The
- *  registration lives here, in PayloadView's own module: the package is
- *  `sideEffects: false`, so a registration-only import would be tree-shaken
- *  out of host bundles. */
+/** A validated payload converts to the walk tree and renders through the same
+ *  TreeView (convert-payload.ts documents the mapping). */
 function VendoTreeRenderer({ payload, ...props }: PayloadRendererProps) {
   const converted = useMemo(() => convertPayload(payload), [payload]);
   if (!converted.ok) {
@@ -166,19 +155,16 @@ function VendoTreeRenderer({ payload, ...props }: PayloadRendererProps) {
   return <TreeView tree={converted.tree} {...props} />;
 }
 
-registerTreeRenderer(VENDO_TREE_FORMAT, VendoTreeRenderer);
-
-/** 01-core §8 — renderer dispatch is exclusively by the payload tag. */
+/** Dispatch is exclusively by the payload tag. */
 export function PayloadView(props: PayloadRendererProps) {
-  const Renderer = rendererRegistry.get(props.payload.formatVersion);
-  if (!Renderer) {
+  if (props.payload.formatVersion !== VENDO_TREE_FORMAT) {
     return (
       <ContainedNotice label="Unsupported UI format">
         {`No renderer is registered for "${props.payload.formatVersion}".`}
       </ContainedNotice>
     );
   }
-  return <Renderer {...props} />;
+  return <VendoTreeRenderer {...props} />;
 }
 
 interface ActionBinding {
@@ -308,26 +294,6 @@ function outcomeNotice(outcome: ToolOutcome | undefined): ReactNode {
   }
   return null;
 }
-
-/**
- * 06-apps §9 — the additive in-client venue verdict a tree payload may carry.
- * SERVER-AUTHORITATIVE: the apps runtime strips any document-carried value and
- * attaches this only from its own hash-pin verification, so `granted: true`
- * here is exactly "a stored approval matches the CURRENT version's content
- * hash". A missing field is the universal default: jailed. One declaration —
- * the wire type — re-exported here so tree consumers see the same shape the
- * client and the parity test cover.
- */
-export type { InClientVenue } from "../wire-types.js";
-
-/**
- * 06-apps §8 — the additive pin-drift report a tree payload may carry
- * (`payload.pinDrift`). SERVER-AUTHORITATIVE: the apps runtime strips any
- * document-carried value and attaches this only from its own baseline
- * comparison. Re-exported from the wire type so tree consumers see the same
- * shape the client and the parity test cover.
- */
-export type { PinDrift } from "../wire-types.js";
 
 interface NodeRendererProps {
   nodeId: string;

--- a/packages/ui/src/tree/renderer.tsx
+++ b/packages/ui/src/tree/renderer.tsx
@@ -57,10 +57,10 @@ export interface PayloadRendererProps {
 }
 
 /**
- * v2 spec §6 — the walk's input: the SHARED render mechanics' tree shape
- * (nodes, path-keyed resolved queries, grafted components, payload extras).
- * The v1 format surface around it is gone; convert-payload converts the
- * canonical tree into this shape (named queries → "/" + name pointers).
+ * The walk's input: the shared render mechanics' tree shape (nodes,
+ * path-keyed resolved queries, grafted components, payload extras).
+ * convert-payload converts the canonical tree into this shape (named
+ * queries → "/" + name pointers).
  */
 export interface WalkTree {
   root: string;
@@ -79,10 +79,9 @@ const walkFail = (message: string): WalkValidation => ({ ok: false, error: { cod
 const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
-/** The structural render-gate the v1 validator used to provide (per-render
- *  hot path): ids unique and rooted, node shapes sane, generated components
- *  present. Format-tag checks live one layer up (PayloadView dispatch +
- *  validateTree in convert-payload). */
+/** The structural render-gate (per-render hot path): ids unique and rooted,
+ *  node shapes sane, generated components present. Format-tag checks live one
+ *  layer up (PayloadView dispatch + validateTree in convert-payload). */
 const validateWalkTree = (input: WalkTree): WalkValidation => {
   const ids = new Set<string>();
   if (!Array.isArray(input.nodes)) return walkFail("nodes must be an array");
@@ -102,9 +101,9 @@ const validateWalkTree = (input: WalkTree): WalkValidation => {
     ids.add(node.id);
   }
   const components = input.components ?? {};
-  // The jail-compile bounds the v1 walk enforced per render survive here:
-  // Kit names can never be shadowed and the §8 component caps hold even
-  // for payloads that bypassed document validation (direct TreeView input).
+  // The jail-compile bounds hold per render: Kit names can never be shadowed
+  // and the 01-core §8 component caps apply even to payloads that bypassed
+  // document validation (direct TreeView input).
   const names = Object.keys(components);
   if (names.length > TREE_MAX_GENERATED_COMPONENTS) {
     return walkFail(`too many generated components (max ${TREE_MAX_GENERATED_COMPONENTS})`);
@@ -181,7 +180,7 @@ export function isActionBinding(value: unknown): value is ActionBinding {
 
 type BoundMode = "host" | "jail";
 
-/** v2 spec §3 — apply a binding's `$reshape` chain to the resolved value.
+/** Apply a binding's `$reshape` chain to the resolved value.
  *  `applyReshape` is total: absent data passes through (loading is not a
  *  mismatch); a real mismatch reports through `onMismatch` and binds
  *  `undefined`, and the node renders the contained data-shape notice. */
@@ -238,8 +237,7 @@ function bindValue(
 }
 
 /** Binds a node's props, reporting the first reshape mismatch with its prop
- *  name (v2 spec §3 — the region shows one contained notice, not a broken
- *  component). */
+ *  name: the region shows one contained notice, not a broken component. */
 function bindProps(
   props: Record<string, Json> | undefined,
   mode: BoundMode,
@@ -260,7 +258,7 @@ function bindProps(
   return { bound, mismatch };
 }
 
-/** v2 spec §3 — the contained data-shape notice: the region says the data
+/** The contained data-shape notice: the region says the data
  *  didn't match instead of mounting the component with garbage props. While
  *  the payload is a mid-stream partial the mismatch is a transient (the
  *  binding may still be rewritten before ship), so the region holds the
@@ -300,8 +298,8 @@ interface NodeRendererProps {
   ancestry: ReadonlySet<string>;
   nodes: ReadonlyMap<string, TreeNode>;
   generated: Record<string, string>;
-  /** W4b — the payload's compiler-stamped per-island tool manifests. Absent
-   *  (legacy/streaming) means JailedComponent derives from source host-side. */
+  /** The payload's compiler-stamped per-island tool manifests. Absent
+   *  (unstamped/streaming) means JailedComponent derives from source host-side. */
   componentTools?: Record<string, string[]>;
   /** True ONLY when the payload's server-written verdict granted the venue. */
   inClientGranted: boolean;
@@ -472,11 +470,10 @@ function NodeRenderer(props: NodeRendererProps) {
     // V4 — one component family: the Kit is the only built-in set.
     const kit = KIT_COMPONENTS[node.component] as ComponentType<Record<string, unknown>> | undefined;
     const host = props.components[node.component] as ComponentType<Record<string, unknown>> | undefined;
-    // v2 spec §2 — an explicit `source: "host"` resolution means the host
-    // brand won the name. An undefined (or "prewired") source keeps the
-    // built-in first, which is exactly the historical primitive-first order:
-    // deliberate v1 parity, so a stored app whose node collides with a host
-    // catalog name still renders the built-in it was written against.
+    // An explicit `source: "host"` means the host brand won the name. An
+    // undefined (or "prewired") source keeps the built-in first, so a stored
+    // app whose node collides with a host catalog name still renders the
+    // built-in it was written against.
     const Implementation = node.source === "host" ? host ?? kit : kit ?? host;
     if (!Implementation) {
       // Mid-stream, an unresolved name is a transient (the defining island or
@@ -512,7 +509,7 @@ function NodeRenderer(props: NodeRendererProps) {
 }
 
 /**
- * 08-ui §5 — render a validated walk tree (the shared render mechanics, v2 spec §6).
+ * 08-ui §5 — render a validated walk tree.
  *
  * `$state` is local to this TreeView. Generated code can write through its
  * in-jail `vendo.setState(key, value)` bridge; `onStateChange`, when supplied,
@@ -529,7 +526,7 @@ function StatefulTreeView({
   const themeVars = useMemo(() => themeCssVariables(theme), [theme]);
   const streaming = (tree as WalkTree & { streaming?: unknown }).streaming === true;
   const furnishings = (tree as WalkTree & { furnishings?: Record<string, JailFurnishing> }).furnishings ?? {};
-  // W4b — the stamped per-island tool manifests ride the payload beside the
+  // The stamped per-island tool manifests ride the payload beside the
   // component sources (a payload extra, like furnishings).
   const componentTools = (tree as WalkTree & { componentTools?: Record<string, string[]> }).componentTools;
   const inClient = (tree as WalkTree & { inClient?: InClientVenue }).inClient;
@@ -581,8 +578,8 @@ function StatefulTreeView({
     [validation.ok ? validation.tree.nodes : validation.error.message],
   );
 
-  // Remix final shape (2026-08-02) — a review-kind version awaiting the host
-  // reviewer renders NOTHING but its standing, checked BEFORE tree validation:
+  // A review-kind version awaiting the host reviewer renders NOTHING but its
+  // standing, checked BEFORE tree validation:
   // the server ships no executable fork source with `pending-review` (its
   // generated nodes have no components to validate against), so instead of an
   // invalid-tree verdict, a jailed fork, or skeletons of stripped components
@@ -632,8 +629,8 @@ function StatefulTreeView({
   // above) keeps this notice, so an unknown future reason still says
   // SOMETHING rather than silently jailing.
   const dropBackNotice = inClient !== undefined && inClient.granted === false
-    // Widened: the payload is a wire value, so a FUTURE ungranted reason this
-    // union does not know yet must still drop back loudly, not silently jail.
+    // The payload is a wire value, so a FUTURE ungranted reason this union
+    // does not know yet must still drop back loudly, not silently jail.
     && (inClient.reason as string) !== "pending-review"
     ? (
       <ContainedNotice label="In-client approval invalidated" outcome="blocked">

--- a/packages/ui/test/mcp-shim-core.test.ts
+++ b/packages/ui/test/mcp-shim-core.test.ts
@@ -81,16 +81,16 @@ describe("MCP Apps shim query data", () => {
   it("writes the result at the query's name without mutating prior data (v2 spec §2)", () => {
     const prior = { keep: { nested: true } } satisfies Record<string, Json>;
     const updated = setQueryData(prior, query("answer"), { n: 42 });
-    expect(updated).toEqual({ data: { keep: { nested: true }, answer: { n: 42 } } });
-    expect(updated.data).not.toBe(prior);
+    expect(updated).toEqual({ keep: { nested: true }, answer: { n: 42 } });
+    expect(updated).not.toBe(prior);
     expect(prior).toEqual({ keep: { nested: true } });
   });
 
   it("a hostile grammar-legal name becomes own data, never the prototype", () => {
     const updated = setQueryData({}, query("__proto__"), { polluted: true });
-    expect(Object.getPrototypeOf(updated.data)).toBe(Object.prototype);
+    expect(Object.getPrototypeOf(updated)).toBe(Object.prototype);
     expect(({} as Record<string, unknown>).polluted).toBeUndefined();
-    expect(Object.getOwnPropertyDescriptor(updated.data, "__proto__")?.value).toEqual({ polluted: true });
+    expect(Object.getOwnPropertyDescriptor(updated, "__proto__")?.value).toEqual({ polluted: true });
   });
 });
 

--- a/packages/ui/test/tree/jail-bundled-packages.test.ts
+++ b/packages/ui/test/tree/jail-bundled-packages.test.ts
@@ -71,6 +71,23 @@ describe("the jail's bundled packages, through every import style", () => {
     expect(typeof exports.default).toBe("function");
   });
 
+  it("zod: a schema declaring a `.catch()` fallback still loads", () => {
+    // `catch` is a real zod method AND a promise-protocol name. Blanking it to
+    // keep the shim off the thenable path made this component throw
+    // `.catch is not a function` at module evaluation — a working component
+    // broken to fix an unused await path.
+    const exports = evaluate(`
+      import { z } from "zod";
+      export const props = z.object({
+        retries: z.number().catch(3),
+        variant: z.enum(["ok", "warn"]).catch("ok"),
+      });
+      export default function Card() { return null; }
+    `);
+    expect(exports.props).toBeDefined();
+    expect(typeof exports.default).toBe("function");
+  });
+
   it("every bundled specifier is actually answerable — permit implies provide", () => {
     for (const specifier of JAIL_BUNDLED_PACKAGES) {
       expect(() => evaluate(`import * as m from "${specifier}"; export const r = typeof m;`), specifier).not.toThrow();

--- a/packages/ui/test/tree/jail-zod-shim.test.ts
+++ b/packages/ui/test/tree/jail-zod-shim.test.ts
@@ -44,11 +44,30 @@ describe("the jail's zod shim", () => {
     const schema = z.object({ a: z.string() });
     expect(await Promise.resolve(schema)).toBe(schema);
     expect(await Promise.resolve(zodShim)).toBe(zodShim);
-    for (const key of ["then", "catch", "finally"]) {
-      expect((schema as Record<string, unknown>)[key], key).toBeUndefined();
-      expect(key in (schema as object), key).toBe(false);
-      expect(key in zodShim, key).toBe(false);
-    }
+    expect((schema as Record<string, unknown>).then).toBeUndefined();
+    expect("then" in (schema as object)).toBe(false);
+    expect("then" in zodShim).toBe(false);
+  });
+
+  it("keeps `catch` — the one promise-shaped name zod actually owns", () => {
+    // `then` is the WHOLE thenable protocol, so blanking any further name buys
+    // nothing and costs a real method: `.catch(fallback)` is zod's fallback
+    // declaration on every schema (zod 3 and 4) and a namespace helper in zod 4.
+    // `finally` is neither, so nothing else in this family needs blanking.
+    expect(typeof (z.number() as unknown as Record<string, unknown>).catch).toBe("function");
+    expect(() => z.number().catch(3)).not.toThrow();
+    expect(() => z.object({ n: z.number().catch(3).optional() })).not.toThrow();
+    expect(typeof (zodShim as Record<string, unknown>).catch).toBe("function");
+    expect("catch" in zodShim).toBe(true);
+    expect("finally" in zodShim).toBe(true);
+  });
+
+  it("a caught schema still REFUSES to validate — a fallback is not a validator", () => {
+    // `.catch(3)` declares what zod would return for bad input; the shim cannot
+    // tell good input from bad, so guessing the fallback would be exactly the
+    // silent mis-validation this shim exists to never do.
+    const schema = z.number().catch(3) as unknown as Record<string, () => unknown>;
+    expect(() => schema.parse!()).toThrow(/not available in the Vendo preview sandbox/);
   });
 
   it("is registered as a bundled package, so producers and the runtime agree", () => {

--- a/packages/ui/test/tree/jail-zod-shim.test.ts
+++ b/packages/ui/test/tree/jail-zod-shim.test.ts
@@ -36,6 +36,21 @@ describe("the jail's zod shim", () => {
     expect(() => (z as unknown as Record<string, () => unknown>).parse!()).toThrow(/preview sandbox/);
   });
 
+  it("is not a thenable, so awaiting anything the shim answered resolves", async () => {
+    // Every unknown property chains, and `then` is a property. A schema (or
+    // the module itself) that answers `then` with another callable node is a
+    // thenable whose `then` never calls back: `await` on it hangs the island
+    // forever, which is the one outcome this shim is written to avoid.
+    const schema = z.object({ a: z.string() });
+    expect(await Promise.resolve(schema)).toBe(schema);
+    expect(await Promise.resolve(zodShim)).toBe(zodShim);
+    for (const key of ["then", "catch", "finally"]) {
+      expect((schema as Record<string, unknown>)[key], key).toBeUndefined();
+      expect(key in (schema as object), key).toBe(false);
+      expect(key in zodShim, key).toBe(false);
+    }
+  });
+
   it("is registered as a bundled package, so producers and the runtime agree", () => {
     // Permit-without-provide is the bug this pairing prevents: the runtime
     // table is typed on the same list capture checks.

--- a/packages/ui/test/tree/tree-view.test.tsx
+++ b/packages/ui/test/tree/tree-view.test.tsx
@@ -3,7 +3,7 @@ import type { ComponentType } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { VENDO_TREE_FORMAT, type Json, type ToolOutcome } from "@vendoai/core";
-import { PayloadView, TreeView, registerTreeRenderer, type WalkTree } from "../../src/tree/index.js";
+import { PayloadView, TreeView, type WalkTree } from "../../src/tree/index.js";
 
 afterEach(() => {
   cleanup();
@@ -306,20 +306,6 @@ describe("TreeView public surface", () => {
     );
 
     expect(screen.getByRole("note", { name: /unsupported ui format/i }).textContent).toContain("vendo-genui/v99");
-  });
-
-  it("dispatches additively registered future formats by tag", () => {
-    registerTreeRenderer("vendo-genui/test-profile", ({ payload }) => (
-      <p>Custom renderer: {String(payload.title)}</p>
-    ));
-    render(
-      <PayloadView
-        payload={{ formatVersion: "vendo-genui/test-profile", title: "compact" }}
-        components={{}}
-        onAction={ok}
-      />,
-    );
-    expect(screen.getByText("Custom renderer: compact")).toBeTruthy();
   });
 
   it("contains core validation failures before rendering", () => {

--- a/packages/ui/test/tree/tree-view.test.tsx
+++ b/packages/ui/test/tree/tree-view.test.tsx
@@ -207,6 +207,40 @@ describe("TreeView public surface", () => {
       .toContain("didn’t load");
   });
 
+  it("settles on the skeleton when a node starts crashing MID-stream, instead of retrying itself", () => {
+    // The mid-stream retry exists so ARRIVING DATA can heal a crash. It must
+    // never be driven by the boundary's own re-render: a node that keeps
+    // throwing has to settle on the silhouette after one attempt, not spin the
+    // latch until React's nested-update guard kills the surface.
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    let renders = 0;
+    let exploding = false;
+    const Sometimes = () => {
+      renders += 1;
+      if (exploding) throw new Error("host render exploded");
+      return <p>Half a view</p>;
+    };
+    const nodes: WalkTree["nodes"] = [
+      { id: "root", component: "Row", children: ["node"] },
+      { id: "node", component: "Sometimes", source: "host" },
+    ];
+    const streaming = () => ({ ...tree(nodes), streaming: true }) as WalkTree;
+
+    const view = render(<TreeView tree={streaming()} components={{ Sometimes }} onAction={ok} />);
+    expect(screen.getByText("Half a view")).toBeTruthy();
+
+    const before = renders;
+    exploding = true;
+    view.rerender(<TreeView tree={streaming()} components={{ Sometimes }} onAction={ok} />);
+
+    // React re-renders a handful of times recovering from the throw itself.
+    // The self-retry is what unbounds it: it ran the crashing node 109 times
+    // in this one update and stopped only at React's nested-update guard.
+    expect(renders - before).toBeLessThan(10);
+    expect(document.querySelector("[data-skeleton]")).not.toBeNull();
+    expect(screen.queryByRole("note", { name: /node render error/i })).toBeNull();
+  });
+
   it("skeletons an unknown component name while STREAMING instead of the unknown-component notice", () => {
     const partial = {
       ...tree([


### PR DESCRIPTION
De-slopping **Z6 — `packages/ui/src/tree`** (UI-GEN zone). Worst-first: two
real defects with failing-test-first commit pairs, then dead surface, then
comment archaeology.

## The work list I selected

Findings in the catalog whose files live under `packages/ui/src/tree`. They are
spread across two sections — `## @vendoai/ui` (one finding) and `## ui — parts
1–4` (the rest).

**Landed here**

| finding | disposition |
| --- | --- |
| HIGH · Streaming error boundary retries in an unbounded loop (`error-boundary.tsx`) | **fixed**, test-first |
| MED · Shim's catch-all get makes it a hanging thenable (`jail/zod-shim.ts`) | **fixed**, test-first |
| MED · Public renderer registry serves exactly one format (`renderer.tsx`) | **deleted** |
| LOW · Two type re-exports carry twenty lines of prose (`renderer.tsx`) | **deleted** |
| LOW · `setQueryData` returns an error field it never sets (`mcp-shim/shim-core.ts`) | **deleted** |
| MED · Comments are spec archaeology, one pointing at a deleted file (`renderer.tsx`, `convert-payload`, `frames.tsx`, `host-mount.tsx`, `notice.tsx`) | **stripped** |
| LOW · `convert-payload` is `.tsx` with no JSX and a mid-file import | **fixed** |

Real LOC: `src/` **+74 / −114**, `test/` **+54 / −19**.

## What was fixed

**1. The node error boundary crashed the surface it exists to contain.**
`componentDidUpdate` cleared a latched error whenever `previous.streaming ===
true` — which is also true of the boundary's *own* error re-render. Child
throws → latch clears → child throws again, with nothing waiting for new data.
Measured: a node that starts throwing mid-stream rendered **109 times in one
update** and stopped only at React's nested-update guard, which throws
`Maximum update depth exceeded` — an uncatchable crash of the whole surface.
Every clear arm is now an actual input change (`nodeId`, `retryKey`, or a
`streaming` *transition*). After the fix: 5 renders, skeleton held.

**2. The jail's zod shim was a hanging thenable.** The chainable proxy answered
every unknown property with another callable node — including `then`. So every
schema, and the module object itself, was a thenable whose `then` never calls
back: one `await` inside a generated island hung it forever. The failing test
timed out at 30s. `then`/`catch`/`finally` now answer `undefined` and the `has`
trap agrees. This is the shim's own documented rule ("fail loudly and
diagnosably, never a plausible wrong value") applied to the one case that
failed silently instead.

## What was deleted

- **The payload-renderer registry.** `registerTreeRenderer` had zero callers
  outside its own module and one test that registered a fake profile to read it
  back — producer and consumer both mocked. `PayloadView` now checks the one
  format tag directly. Public surface shrinks (`@vendoai/ui/tree`), hence a
  `minor` changeset. Its test ("dispatches additively registered future formats
  by tag") is deleted with it.
- **`InClientVenue` / `PinDrift` re-exports** from `renderer.tsx`, each under a
  paragraph of prose that `wire-types.ts` already carries verbatim. Nothing
  imports either name from the tree subpath.
- **`setQueryData`'s `error` field**, never set, plus the caller's `if
  (updated.error)` branch.

## Caller sweep (every deletion, before cutting)

Swept `registerTreeRenderer`, `rendererRegistry`, `PayloadRenderer`,
`InClientVenue`, `PinDrift`, `setQueryData`, `convert-payload` and
`@vendoai/ui/tree` across all `packages/`, `examples/`, `fixtures/`, `corpus/`,
`bench/`, `docs/`, `docs-site/`, every test directory, and the **`vendo-web`
sibling repo** (`~/repos/vendo-web`, `17adf1fc`). Results:

- `registerTreeRenderer` / `rendererRegistry` — one definition, one self-call,
  one test. No consumer anywhere.
- `InClientVenue` / `PinDrift` — the one real cross-package consumer,
  `packages/vendo/src/wire-type-parity.test.ts`, imports them from
  `@vendoai/ui` (root → `wire-types.js`), **not** from the tree subpath. Both
  declarations are untouched.
- `@vendoai/ui/tree` **is** live (eject templates, demo-bank, bench, e2e
  tsconfig) — but only for `TreeView`, `PayloadView`, `AppFrame`, `WalkTree`,
  all kept.
- `setQueryData` — the name also exists in `packages/apps/src/open.ts` as an
  unrelated private function; untouched.

Post-commit re-sweep including test dirs (the trap where `packages/ui`'s
typecheck skips `test/`): the only remaining hits for deleted names are this PR
body and the changeset. `updated.data` hits in `packages/store` are an
unrelated symbol.

## vendo-web disposition

**No companion PR needed, and here is why.** `vendo-web` contains no import of
`@vendoai/ui/tree`, no reference to `registerTreeRenderer`, `PayloadView`,
`TreeView`, `setQueryData`, `InClientVenue` or `PinDrift` in any source file.
The only matches repo-wide are two prose blobs inside
`docs/eval/knowledge-cloud/inputs/corpus.json` — knowledge-eval fixture text
that mentions `TreeView` and `PinDrift` as documentation, describing wire
behaviour that this PR does not change. Nothing in vendo-web compiles against,
imports, or mirrors anything under `packages/ui/src/tree`.

## Rejected leads (logged, not cut)

- **`ui/src/tree/mcp-shim/entry.tsx` listed as an "unused file (real source)"**
  in the catalog's scanner appendix. **False.** It is the build entry of
  `packages/ui/scripts/build-mcp-app-shim.mjs`, which generates the committed
  2.6 MB `packages/mcp/src/shim/shim-html.gen.ts`. Kept.
- **`registerTreeRenderer` is a public export.** It *is* on the
  `@vendoai/ui/tree` subpath, so this is a real (pre-1.0) surface removal, not
  a private cleanup — called out as `minor` rather than quietly dropped.
- **`ISLAND_AMBIENT_NAMES.filter(name => name in AMBIENT_SCOPE)`** flagged as a
  no-op filter. Not cut: proving it is a no-op requires proving `AMBIENT_SCOPE`
  is total over that list, and if it is *not*, replacing the filter with a
  spread turns a missing binding from a `ReferenceError` into `undefined` — a
  behaviour change in the jail's evaluation scope for a LOW-value line. Also
  adjacent to the forgiveness lists that are off-limits.

## Deferred, with reasons (for follow-up dispatch)

- **HIGH · `TreeView` keyed by `root`, which is always `"root"`** — real bug
  (app B inherits app A's `$state` and stale outcome notices). Every workable
  fix needs the *caller* to supply the payload identity, and the callers are
  `src/chrome/vendo-overlay.tsx`, `src/chrome/thread/parts.tsx` and
  `src/voice/stage.tsx` — all outside this piece's file set. A tree-internal
  key would either remount on every stream tick (any tree-derived hash changes
  per token) or add a prop nobody passes. **Needs a piece that owns chrome +
  voice.**
- **LOW · CDN package cache keyed by specifier, ignoring the pin** — real, but
  only reachable after a *successful* `import()` of a real CDN module, which
  jsdom cannot do. A failing test first is impossible here without a browser
  e2e; deferring rather than shipping an untested behaviour change.
- **HIGH · In-client evaluator duplicates the jail's module loader**
  (`host-mount.tsx` ↔ `runtime-entry.tsx`, ~60 LOC) — security-relevant
  refactor, wants its own reviewable PR.
- **HIGH · `validateWalkTree` re-implements core's `validateTree` per render** —
  the honest fix exports the node loop from `@vendoai/core`, which is another
  piece's package.
- **HIGH · Jail re-posts the whole island on every host render** — a real perf
  defect, but the fix reshapes `JailedComponent`'s effect graph and needs its
  own before/after measurement.
- **MED · Skeleton shape guessed by six regexes**, **MED · action/tool-call
  branches duplicated in `JailedComponent`**, **LOW · relay frame CSP split**,
  **LOW · `viewport-css.ts` fold into `embedded-runtime.ts`** (touches
  `src/embedded-runtime.ts`, outside the file set), **LOW · `fluid-reveal`
  exit timing** (needs `chrome-css.ts`), **LOW · six Kit import aliases**.
- **All `packages/ui/test/tree/**` test-estate findings** (jail harness dedupe,
  `jail-bundled-packages` mirroring its own table, `jail-runtime-form-submit`
  passing with the fix deleted, `jail-runtime-resize`'s self-deciding mock,
  tree-view/convert-payload overlap, `tabs-skeleton-seam`) — these are a
  coherent second slice on their own and would double this diff.

## Out of scope from the `## @vendoai/ui` section

Everything else in that section lives in `src/chrome/**`, `src/kit/**`,
`src/hooks/**`, `src/voice/**`, `gallery/`, `e2e/` or `scripts/` — other
pieces' file sets. The single tree finding it contained (`setQueryData`) is
landed above.

## Verification

Not user-visible: no rendered markup, copy, layout or styling changes. The
error-boundary fix makes a crashing surface *stop crashing* (it already
rendered the skeleton on the first attempt); the zod-shim fix removes a hang.
No screenshots — nothing in this diff alters a pixel that a passing render
would have painted.

- `pnpm build` — 21/21 tasks, exit 0
- `packages/ui` owned suites (`test/tree/`, `test/mcp-shim-core.test.ts`,
  `test/ssr.test.tsx`, `test/export-surface.test.ts`) — **22 files, 164 tests
  passed**
- `pnpm typecheck` — 40/40 tasks, exit 0
- `pnpm lint --force` — 3/3 tasks, exit 0 (one pre-existing `demo-bank` warning)

CI's green `ci` check is the gate of record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two stability bugs in the UI tree: the streaming error boundary now retries only on real input changes (no more self-driven loops), and the jail `zod` shim is no longer a thenable so `await` won’t hang. Also removes the unused renderer registry and narrows the `@vendoai/ui/tree` surface.

- **Bug Fixes**
  - Streaming error boundary clears only on actual input changes (`nodeId`, `retryKey`, or a `streaming` transition). A mid-stream crash now settles on a skeleton instead of retrying itself.
  - `zod` shim now treats only `then` as absent and aligns the `has` trap to match. `await` on shimmed values resolves, and real zod methods like `.catch()` still work.

- **Migration**
  - Removed `registerTreeRenderer` and the registry. `PayloadView` now supports only `VENDO_TREE_FORMAT` by checking the format tag directly.
  - `InClientVenue` and `PinDrift` are no longer re-exported from `@vendoai/ui/tree`. Import them from `@vendoai/ui`.
  - `setQueryData` (MCP shim) now returns the updated record directly. Update any call sites expecting `{ data, error }`.

<sup>Written for commit cb5e53fd1ba38e93e4ae8fecc5bcd6cbbb279c01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

