### PR TITLE
fix(guard): a preview no longer spends the human's yes, and the TTL sweep stops reading the whole table

### DIFF
--- a/.changeset/a-preview-no-longer-spends-the-yes.md
+++ b/.changeset/a-preview-no-longer-spends-the-yes.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/guard": patch
+---
+
+Two guard fixes. `previewCheck` no longer spends the single-use approval it was only inspecting: the pipeline now knows whether the caller is committing, so a preview reports that an approved replay exists without claiming its `consumed:<id>` receipt, and the real dispatching check that follows claims it — once, atomically, exactly as before. Previously a previewed call with a stable id answered "run", burned the human's tap, and then parked a fresh approval when the real call arrived, so the call never executed. And `sweepExpiredApprovals` now queries the pending set instead of paging every approval ever decided and filtering in JS — that read ran every 60 seconds per process and grew without bound.

--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -596,11 +596,14 @@ class GuardImplementation implements VendoGuard {
    *  swept. A `ttlMs <= 0` disables the sweep. */
   async sweepExpiredApprovals(ttlMs: number, at: number = Date.parse(now())): Promise<number> {
     if (ttlMs <= 0) return 0;
-    const records = await listAll(this.#store.records(APPROVALS_COLLECTION));
+    // Filtered by the store, not in JS: this runs every 60s for the life of the
+    // process, and the unfiltered read grows with every approval ever decided.
+    const records = await listAll(this.#store.records(APPROVALS_COLLECTION), {
+      refs: { status: "pending" },
+    });
     let swept = 0;
     for (const record of records) {
       const data = approvalData(record);
-      if (data.status !== "pending") continue;
       const parkedAt = Date.parse(data.request.createdAt);
       if (!Number.isFinite(parkedAt) || parkedAt + ttlMs > at) continue;
       try {

--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -994,8 +994,9 @@ class GuardImplementation implements VendoGuard {
    * contract, and `bind().execute()`'s internal use) from "decide, without
    * charging a run" (the PREVIEW-ONLY seam `previewCheck()` below exposes).
    * A previewed "run" is deliberately un-committed: the caller who asked to
-   * preview is never the one who gets to spend the budget — the very next
-   * real check (moments later, same call) does that once, for real. A
+   * preview is never the one who gets to spend the budget, the window slot, or
+   * a single-use approval — the very next real check (moments later, same
+   * call) does that once, for real. A
    * previewed "ask"/"block" is unaffected either way — parking and audit
    * already happen exactly once, because the SDK never calls `execute()` at
    * all for a call its own preview paused.
@@ -1026,7 +1027,7 @@ class GuardImplementation implements VendoGuard {
     const callsTripped = commitRun
       ? this.#recordCall(ctx.principal.subject)
       : this.#peekCallsTripped(ctx.principal.subject);
-    const metadata = await this.#pipeline(call, effectiveDescriptor, ctx);
+    const metadata = await this.#pipeline(call, effectiveDescriptor, ctx, commitRun);
     let draft = metadata.decision;
 
     // 05 §6: away runs hold only grants captured while present and bound to the
@@ -1294,18 +1295,19 @@ class GuardImplementation implements VendoGuard {
     call: ToolCall,
     descriptor: ToolDescriptor,
     ctx: RunContext,
+    commitRun: boolean,
   ): Promise<DecisionMetadata> {
     // An exact approved replay answers a confirmEach ask (05 §2 stays otherwise:
     // grants/rules/judge never suppress confirmEach).
-    let consumedReplay = false;
+    let replayable = false;
     if (descriptor.confirmEach === true) {
-      consumedReplay = await this.#consumeApprovedCall(call, descriptor, ctx);
-      if (!consumedReplay) {
+      replayable = await this.#approvedReplay(call, descriptor, ctx, commitRun);
+      if (!replayable) {
         return { decision: { action: "ask", decidedBy: "confirmEach" } };
       }
     }
 
-    if (consumedReplay || await this.#consumeApprovedCall(call, descriptor, ctx)) {
+    if (replayable || await this.#approvedReplay(call, descriptor, ctx, commitRun)) {
       return { decision: { action: "run", decidedBy: "grant" } };
     }
 
@@ -1678,10 +1680,16 @@ class GuardImplementation implements VendoGuard {
     });
   }
 
-  async #consumeApprovedCall(
+  /** Is there an approved, unspent replay for exactly this call — and, when
+   *  `claim` is true, spend it? `claim` is false for a preview (commitRun
+   *  false): a preview dispatches nothing, so spending the human's one yes
+   *  there would strand the real call moments later in park → approve → park,
+   *  with the tap burned. The real check that follows claims it, once. */
+  async #approvedReplay(
     call: ToolCall,
     descriptor: ToolDescriptor,
     ctx: RunContext,
+    claim: boolean,
   ): Promise<boolean> {
     const fingerprint = descriptorHash(descriptor);
     const store = this.#store.records(APPROVALS_COLLECTION);
@@ -1717,6 +1725,7 @@ class GuardImplementation implements VendoGuard {
       // next candidate — the same approved call parked twice yields two
       // approvals, each replayable once, exactly as before, and a lost claim can
       // also mean the person took the yes back between the list and here.
+      if (!claim) return true;
       if (await this.#spendConsumedTransition(record.id, ctx.principal.subject) !== "spent") continue;
       return true;
     }

--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -93,7 +93,7 @@ function resolveBreakerLimit(configured: number | undefined, name: string, fallb
 
 const GRANTS_COLLECTION = "vendo_grants";
 const APPROVALS_COLLECTION = "vendo_approvals";
-/** One-time transition receipts for approvals (kill-list B5): `decided:<id>` /
+/** One-time transition receipts for approvals: `decided:<id>` /
  *  `consumed:<id>` rows in a guard-owned generic collection, written only via
  *  the store's atomic `insertIfAbsent` (02-store §4) so exactly one caller —
  *  across processes — wins each transition. Rows carry `refs.subject`, so the
@@ -339,7 +339,7 @@ function presenceMatches(grant: PermissionGrant, ctx: RunContext): boolean {
   return grant.appId === undefined || grant.appId === ctx.appId;
 }
 
-/** Re-gate 2026-07-26 finding 2: a read invoked from the APP venue renders a
+/** A read invoked from the APP venue renders a
  *  surface — the query resolver and island tool bridge consume the outcome at
  *  render time, and a parked read query is never resumed (apps resume only
  *  mutating actions). An "ask" on a present app-venue read is therefore a
@@ -425,7 +425,7 @@ class GuardImplementation implements VendoGuard {
    *  while a second, separately-intended identical call gets the next one. */
   readonly #effectOrdinals = new Map<string, Map<string, number>>();
   /** In-flight execution per effect key, so concurrent identical calls share one
-   *  execution instead of both racing past an empty ledger (finding 14). */
+   *  execution instead of both racing past an empty ledger. */
   readonly #effectsInFlight = new Map<string, Promise<ToolOutcome>>();
   readonly #config: CreateGuardConfig;
   readonly #policyConfig: PolicyConfigObject | undefined;
@@ -488,7 +488,7 @@ class GuardImplementation implements VendoGuard {
     return (await this.#checkWithMetadata(call, descriptor, ctx)).decision;
   }
 
-  /** genqa defect 1 — a preview of `check()`'s verdict for a caller that is
+  /** A preview of `check()`'s verdict for a caller that is
    *  about to make (or ask the SDK to make) the REAL, dispatching call
    *  itself: a "run" verdict here never spends the write-budget/call-rate
    *  breakers, because the caller's own follow-up (calling `check()` again,
@@ -544,7 +544,7 @@ class GuardImplementation implements VendoGuard {
     };
   }
 
-  /** AGENT-6: deny approvals the conversation abandoned. Rides the same
+  /** Deny approvals the conversation abandoned. Rides the same
    *  decide path as an explicit denial (audit + callbacks), but is
    *  idempotent: an already-decided (conflict) or unknown/foreign (not-found)
    *  approval already holds the state abandonment wants — only a real store
@@ -585,7 +585,7 @@ class GuardImplementation implements VendoGuard {
     return await this.#spendConsumedTransition(id, principal.subject);
   }
 
-  /** Spec 2026-07-20 (#5): the TTL backstop over the general approvals
+  /** The TTL backstop over the general approvals
    *  collection. Chat approvals are abandoned on the next thread turn and BYO
    *  parked calls have their own sweep, but away/automation/app approvals — and
    *  approvals from turns that errored mid-stream before their thread part
@@ -682,9 +682,9 @@ class GuardImplementation implements VendoGuard {
         // `withheldFromUnattended`, not `=== "destructive"`: an `ungraded` tool
         // is refused here too. The two laws land on the same answer — §12 keeps
         // irreversible actions off an unattended run, and the risk-grading
-        // redesign (D3) says a tool nobody has graded needs a PERSON — and an
+        // redesign says a tool nobody has graded needs a PERSON — and an
         // unattended venue has none to ask. Without this the merge left a real
-        // hole: extraction stopped guessing from names (D1), so Maple's
+        // hole: extraction stopped guessing from names, so Maple's
         // `host_transferMoney` reads `ungraded`, the vote that used to call it
         // destructive no longer speaks for it, and an enable-time standing grant
         // authorized an unattended transfer. Proved by the away drill: the run
@@ -705,7 +705,7 @@ class GuardImplementation implements VendoGuard {
         // them and the projection was their whole law.
         //
         // It refuses the PIN tools and nothing else. `vendo_make` carrying a
-        // `slot` is not refused here (ruled 2026-08-06): creation does not need
+        // `slot` is not refused here: creation does not need
         // a person present, only placement does, and blocking the call would
         // break every automation that legitimately builds a screen. The slot is
         // dropped at the tool's own door instead (`apps/agent-tools.ts`).
@@ -976,7 +976,7 @@ class GuardImplementation implements VendoGuard {
   }
 
   /**
-   * genqa defect 1 (double-count): a "run" verdict here mutates the call-rate
+   * Double-count: a "run" verdict here mutates the call-rate
    * window (#recordCall) and the write budget (below) as a side effect —
    * `check()`'s documented/tested contract is a fresh, un-memoized
    * evaluation every time (repeat calls with the identical id legitimately

--- a/packages/guard/src/policy.ts
+++ b/packages/guard/src/policy.ts
@@ -24,7 +24,7 @@ const POLICY_PRESET_RULES: Record<PolicyPresetName, PolicyRule[]> = {
     { match: { risk: "read" }, action: "run" },
     { match: { risk: "write" }, action: "block" },
     { match: { risk: "destructive" }, action: "block" },
-    // D3 — `ungraded` behaves like `destructive`. Leaving it to the guard's
+    // `ungraded` behaves like `destructive`. Leaving it to the guard's
     // ask-default would have INVERTED this preset: the one posture that blocks
     // a known write would have offered the user an approve button for a tool
     // nobody has graded, which could be a write.
@@ -67,7 +67,7 @@ function errorCode(error: unknown): string | undefined {
   return typeof code === "string" ? code : undefined;
 }
 
-/** Parse and validate a policy document body (from disk or, in the cse lane 3
+/** Parse and validate a policy document body (from disk or, in the cloud
  *  fallback, a cloud-published policy.json). Malformed JSON or an invalid shape
  *  fails loud as a "validation" VendoError — the same posture for both sources,
  *  so a bad cloud policy is as noisy as a bad file. */
@@ -123,7 +123,7 @@ export class PolicyResolver {
    *  `resolvePolicyConfig` at `createGuard` compose time, before this class
    *  ever sees the config.
    *
-   *  `cloudFallback` (cse lane 3) is a source for a cloud-published
+   *  `cloudFallback` is a source for a cloud-published
    *  policy.json body, consulted STRICTLY AFTER the file and only within the
    *  existing opt-in path: it fires only when policy is configured (`#config`
    *  set) and no local file resolves. A host that never configures policy
@@ -157,7 +157,7 @@ export class PolicyResolver {
     this.#filePromise ??= readPolicyFile(this.#config);
     const fromFile = await this.#filePromise;
     if (fromFile !== undefined) return fromFile;
-    // File absent (non-explicit) — cse lane 3: fall to a cloud-published
+    // File absent (non-explicit): fall to a cloud-published
     // policy.json body when the umbrella supplies one. Consulted LIVE on every
     // call and never memoized: a cold cloud snapshot yields undefined now and
     // the real policy once it warms (the snapshot is TTL-cached upstream, so

--- a/packages/guard/src/types.ts
+++ b/packages/guard/src/types.ts
@@ -133,7 +133,7 @@ export interface VendoGuard extends Guard {
     revoke(id: ApprovalId, principal: Principal): Promise<void>;
   };
 
-  /** Spec 2026-07-20 (#5): TTL backstop over the general approvals collection —
+  /** TTL backstop over the general approvals collection —
    *  denies every pending approval older than `ttlMs` (across subjects, via the
    *  idempotent abandon path) so away/automation/stranded approvals self-heal.
    *  Optional: the umbrella feature-detects it. Returns the count swept. */
@@ -191,7 +191,7 @@ export interface GuardRules {
    *  sweep denies through the existing abandonment semantics and
    *  `<VendoApprovalEmbed>` reads "expired". Default 60 min; `0` disables
    *  expiry. Vendo-thread approvals are untouched — their abandonment stays
-   *  turn-driven (AGENT-6). */
+   *  turn-driven. */
   approvals?: {
     parkedCallTtlMs?: number;
   };
@@ -212,7 +212,7 @@ export interface GuardRules {
 export interface CreateGuardConfig extends GuardRules {
   store: StoreAdapter;
   resolveRisk?: RiskResolver;
-  /** cse lane 3 — a source for a cloud-published policy.json body, consulted
+  /** A source for a cloud-published policy.json body, consulted
    *  by the PolicyResolver STRICTLY AFTER the local file and only when policy
    *  is already configured (opt-in). The umbrella backs it with the hosted
    *  config snapshot; this block never reads the key. Unset = no change. */

--- a/packages/guard/test/abandon.test.ts
+++ b/packages/guard/test/abandon.test.ts
@@ -22,7 +22,7 @@ function askGuard(sqlStore: PGliteStore) {
   });
 }
 
-/** AGENT-6: approvals the conversation walked away from are resolved
+/** Approvals the conversation walked away from are resolved
  *  guard-side — denied, no grant — instead of sitting pending forever. */
 describe("abandoned approvals resolve guard-side", () => {
   it("denies a pending approval and audits the denial", async () => {

--- a/packages/guard/test/app-venue-reads.test.ts
+++ b/packages/guard/test/app-venue-reads.test.ts
@@ -5,7 +5,7 @@ import { asLanguageModel, scriptedJudgeModel, throwingJudgeModel } from "./fixtu
 import { call, context, descriptor, FixtureTools } from "./fixtures/tools.js";
 
 /**
- * Re-gate 2026-07-26 finding 2: reads invoked from the APP venue render UI —
+ * Reads invoked from the APP venue render UI —
  * query resolution and island tools consume the outcome at render time, and a
  * parked read query is never resumed (apps call.ts resumes only mutating
  * actions). An "ask" ruling on a present app-venue read is therefore a

--- a/packages/guard/test/destructive-default.test.ts
+++ b/packages/guard/test/destructive-default.test.ts
@@ -61,7 +61,9 @@ describe("destructive asks by default", () => {
       call(d.name, { id: "acc_1" }, "call_delete_away"),
       context({ presence: "away", trigger: { runId: "run_1", kind: "schedule" } }),
     );
-    expect(outcome.status).not.toBe("ok");
+    // Named, not `not.toBe("ok")` — that passes for a crash as readily as for
+    // the park this test is about.
+    expect(outcome).toMatchObject({ status: "pending-approval" });
     expect(tools.executions).toHaveLength(0);
   });
 

--- a/packages/guard/test/effect-ledger.test.ts
+++ b/packages/guard/test/effect-ledger.test.ts
@@ -117,7 +117,7 @@ describe("effect ledger (build contract §7)", () => {
     expect(ledgered.records).toHaveLength(0);
   });
 
-  it("lets a legitimately repeated mutation happen twice in one run (finding 7, contract ordinal)", async () => {
+  it("lets a legitimately repeated mutation happen twice in one run (contract ordinal)", async () => {
     // "Pay $10 twice" is a real intent. Keying on (run, tool, input) alone
     // collapsed it to one payment and reported success for both. The key now
     // carries an ordinal counting prior identical calls in the same run.
@@ -203,7 +203,7 @@ describe("effect ledger (build contract §7)", () => {
     expect(events.some((event) => event.tool === write.name && event.outcome === "ok")).toBe(true);
   });
 
-  it("does not let two concurrent identical calls BOTH execute (finding 14, TOCTOU)", async () => {
+  it("does not let two concurrent identical calls BOTH execute (TOCTOU)", async () => {
     const store = createMemoryStore();
     const write = descriptor("write");
     await seedGrant(store, { descriptor: write });

--- a/packages/guard/test/grant-set-decide.test.ts
+++ b/packages/guard/test/grant-set-decide.test.ts
@@ -1,4 +1,4 @@
-// Grant-set atomicity (demo-live-readiness, criterion 19): a multi-id
+// Grant-set atomicity: a multi-id
 // approvals.decide is ONE set decision and must land all-or-none over the
 // REAL store transaction (atomic transition receipts), never a partially
 // granted set. Semantics under contention:

--- a/packages/guard/test/policy.test.ts
+++ b/packages/guard/test/policy.test.ts
@@ -410,7 +410,7 @@ describe("policy files, rules, directions, and code", () => {
   });
 });
 
-describe("cloud policy fallback (cse lane 3)", () => {
+describe("cloud policy fallback", () => {
   const cloudBody = JSON.stringify({
     format: VENDO_POLICY_FORMAT,
     directions: ["Cloud: escalate wires."],

--- a/packages/guard/test/security/approval-replay.test.ts
+++ b/packages/guard/test/security/approval-replay.test.ts
@@ -2,7 +2,7 @@ import type { ApprovalId } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
 import { createGuard } from "../../src/index.js";
 import { createMemoryStore } from "../fixtures/memory-store.js";
-import { FixtureTools, alice, bob, call, context } from "../fixtures/tools.js";
+import { FixtureTools, alice, bob, call, context, descriptor } from "../fixtures/tools.js";
 
 // Approvals are single-use and pinned to the exact call AND the exact context
 // the user saw. They never replay across uses, across present→away, or across
@@ -22,6 +22,30 @@ describe("approval replay is single-use and context-pinned", () => {
     await expect(bound.execute(c, context())).resolves.toMatchObject({ status: "ok" });
     expect(tools.executions).toHaveLength(1);
     // Replay of the exact same ToolCall is refused — the approval was consumed.
+    await expect(bound.execute(c, context())).resolves.toMatchObject({ status: "pending-approval" });
+    expect(tools.executions).toHaveLength(1);
+  });
+
+  it("a preview does not spend the yes — the real call it cleared still runs", async () => {
+    const store = createMemoryStore();
+    const guard = createGuard({ store, policy: { rules: [{ match: {}, action: "ask" }] } });
+    const tools = new FixtureTools();
+    const bound = guard.bind(tools);
+    const c = call("host_write", { amount: 5 }, "call_preview");
+
+    const parked = await bound.execute(c, context());
+    if (parked.status !== "pending-approval") throw new Error("expected the call to park");
+    await guard.approvals.decide(parked.approvalId, { approve: true }, alice);
+
+    // The harness previews before it dispatches (harnesses tool-bridge's
+    // `needsApproval` hook), then makes the real call. A preview never
+    // dispatches anything, so it must not spend the one use it is inspecting.
+    await expect(guard.previewCheck!(c, descriptor("write"), context()))
+      .resolves.toMatchObject({ action: "run" });
+    await expect(bound.execute(c, context())).resolves.toMatchObject({ status: "ok" });
+    expect(tools.executions).toHaveLength(1);
+
+    // Still single-use: the preview did not mint a second one.
     await expect(bound.execute(c, context())).resolves.toMatchObject({ status: "pending-approval" });
     expect(tools.executions).toHaveLength(1);
   });

--- a/packages/guard/test/security/approval-single-use-cas.test.ts
+++ b/packages/guard/test/security/approval-single-use-cas.test.ts
@@ -1,4 +1,3 @@
-import { descriptorHash } from "@vendoai/core";
 import type { ApprovalRequest, StoreAdapter } from "@vendoai/core";
 import { afterEach, describe, expect, it } from "vitest";
 import { createGuard } from "../../src/index.js";
@@ -120,7 +119,6 @@ describe("approvals fail closed without the store's atomic claims", () => {
       ctx: { principal: alice, venue: "chat", presence: "present" },
       createdAt: new Date().toISOString(),
     };
-    expect(descriptorHash(request.descriptor)).toBe(descriptorHash(descriptor("write")));
     await base.records("vendo_approvals").put({
       id: request.id,
       data: {

--- a/packages/guard/test/security/breakers.test.ts
+++ b/packages/guard/test/security/breakers.test.ts
@@ -31,7 +31,7 @@ describe("deterministic breakers (05 §2)", () => {
     ).resolves.toMatchObject({ action: "ask", decidedBy: "breaker" });
   });
 
-  it("criterion 15 (discovery-discipline): a tripped write breaker never flips READS to ask", async () => {
+  it("a tripped write breaker never flips READS to ask", async () => {
     const store = createMemoryStore();
     const guard = createGuard({
       store,
@@ -105,13 +105,13 @@ describe("deterministic breakers (05 §2)", () => {
   });
 });
 
-// genqa defect 1 — the agent bridge's needsApproval→execute pairing calls the
+// The agent bridge's needsApproval→execute pairing calls the
 // guard twice for one logical call (packages/agent/src/tools.ts): a preview
 // through `previewCheck`, then the real, dispatching check through
 // `check()`/`bind().execute()` moments later. A `previewCheck` "run" must
 // never itself spend the write budget or call-rate window — only the REAL
 // check that follows it does — or a run's budget silently halves.
-describe("previewCheck does not double-spend the breakers (genqa defect 1)", () => {
+describe("previewCheck does not double-spend the breakers", () => {
   it("previewing every write before the real check still allows the full maxWritesPerRun budget", async () => {
     const store = createMemoryStore();
     const guard = createGuard({

--- a/packages/guard/test/security/unattended-presence-only.test.ts
+++ b/packages/guard/test/security/unattended-presence-only.test.ts
@@ -5,22 +5,13 @@ import { createMemoryStore } from "../fixtures/memory-store.js";
 import { FixtureTools, call, context, descriptor, seedGrant } from "../fixtures/tools.js";
 
 /**
- * ADVERSARIAL sibling of `unattended-destructive.test.ts` (risk round,
- * 2026-08-06).
+ * THE LAW's presence-only half has both layers §12 asks for: `projectableForRun`
+ * hides `PRESENCE_ONLY_TOOLS` from an unattended run, and the choke point
+ * refuses whatever reached `execute()` anyway. This file proves the second one.
  *
- * `PRESENCE_ONLY_TOOLS` (core/tools.ts) says the placement pair is withheld
- * from an unattended run "exactly as [§12] withholds a destructive one".
- * §12's own doctrine is two-layered — `projectableForRun` is "the primary
- * mechanism", and "call-time enforcement still exists as defence in depth"
- * (grant-sets.ts) — and this whole file is that second layer for the
- * destructive half.
- *
- * The presence-only half only got the first layer. `guard.ts`'s choke point
- * keys on `withheldFromUnattended(descriptor)`, i.e. on the RISK, and these
- * tools are honestly graded `write` on purpose. So the projection is the
- * WHOLE law for them: anything that reaches `execute()` by name — a standing
- * automation grant, a resumed step, a model that learned the name on an
- * attended turn, a harness that calls without listing — runs.
+ * The choke point keys these tools on the CALL NAME (`presenceOnlyCall`,
+ * guard.ts:683) rather than on the risk, because they are honestly graded
+ * `write` — `withheldFromUnattended` alone would let them through.
  */
 const awayCtx = () =>
   context({
@@ -69,8 +60,6 @@ describe("THE LAW, presence-only half: refused at the guard, not only hidden", (
     );
 
     expect(outcome).toEqual({ status: "blocked", reason: UNATTENDED_DESTRUCTIVE_REASON });
-    // The row was written while nobody was there, and it evicted whatever held
-    // that slot — the exact harm PRESENCE_ONLY_TOOLS' own doc names.
     expect(tools.executions).toHaveLength(0);
   });
 

--- a/packages/guard/test/sweep-expired-approvals.test.ts
+++ b/packages/guard/test/sweep-expired-approvals.test.ts
@@ -1,5 +1,7 @@
+import type { RecordQuery, StoreAdapter } from "@vendoai/core";
 import { afterEach, describe, expect, it } from "vitest";
 import { createGuard } from "../src/index.js";
+import { createMemoryStore } from "./fixtures/memory-store.js";
 import { createPGliteStore, type PGliteStore } from "./fixtures/pglite-store.js";
 import { alice, bob, call, context, FixtureTools } from "./fixtures/tools.js";
 
@@ -60,5 +62,41 @@ describe("sweepExpiredApprovals", () => {
     await parkWrite(guard, alice, "call_off");
     expect(await guard.sweepExpiredApprovals!(0, Date.now() + 10_000_000)).toBe(0);
     expect(await guard.approvals.pending(alice)).toHaveLength(1);
+  });
+
+  // The sweep runs every 60s per process, forever. It must ask the store for
+  // the pending set rather than paging every approval ever decided and
+  // discarding the rest in JS — that read grows without bound on a live
+  // deployment.
+  it("asks the store for pending approvals only, never the whole collection", async () => {
+    const base = createMemoryStore();
+    const queries: (RecordQuery | undefined)[] = [];
+    const spy: StoreAdapter = {
+      ...base,
+      records(collection) {
+        const inner = base.records(collection);
+        if (collection !== "vendo_approvals") return inner;
+        return {
+          ...inner,
+          list: (query) => {
+            queries.push(query);
+            return inner.list(query);
+          },
+        };
+      },
+    };
+    const guard = createGuard({
+      store: spy,
+      policy: { rules: [{ match: { risk: "write" }, action: "ask" }] },
+    });
+    const bound = guard.bind(new FixtureTools());
+    const parked = await bound.execute(call("host_write", { value: 1 }, "call_spy"), context());
+    if (parked.status !== "pending-approval") throw new Error("expected a parked write");
+    await guard.approvals.decide(parked.approvalId, { approve: false }, alice);
+
+    queries.length = 0;
+    expect(await guard.sweepExpiredApprovals!(60_000, Date.now() + 61_000)).toBe(0);
+    expect(queries).not.toHaveLength(0);
+    for (const query of queries) expect(query?.refs).toMatchObject({ status: "pending" });
   });
 });

--- a/packages/guard/test/ungraded-default.test.ts
+++ b/packages/guard/test/ungraded-default.test.ts
@@ -113,7 +113,7 @@ describe("ungraded asks by default (D3)", () => {
 });
 
 /**
- * Checker round 2, finding A — a no has to STAY no. A caller that re-issues a
+ * A no has to STAY no. A caller that re-issues a
  * stable call id (the apps runtime derives a query's id from app+tool+args, so
  * its refetch is byte-identical) would otherwise mint a fresh approval on every
  * retry: deny, reopen, new card, forever.
@@ -225,7 +225,7 @@ describe("a denial answers the identical re-issue instead of re-parking", () => 
 });
 
 /**
- * Checker round 3, finding 2 — parking never dedupes, so ONE stable call id can
+ * Parking never dedupes, so ONE stable call id can
  * hold an approved row and a denied row at once. The person's latest word has
  * to win, whichever order they arrive in.
  */
@@ -278,7 +278,7 @@ describe("the newest human decision on a call wins", () => {
 });
 
 /**
- * Checker round 2, finding C — a DELIBERATE choice, pinned so it never becomes
+ * A DELIBERATE choice, pinned so it never becomes
  * an accident: an approved replay is scoped to the SUBJECT, not the session.
  * One person approving on their phone and seeing the result render on their
  * laptop is the same person answering the same question.
@@ -377,7 +377,7 @@ describe("payInvoice, before and after the judge (AC3)", () => {
 });
 
 /**
- * Checker round 4, finding 1 — voiding and replaying a yes are the SAME
+ * Voiding and replaying a yes are the SAME
  * one-time transition. Both claim `consumed:<id>`, so exactly one of them can
  * happen: a take-back can never be erased by a replay that read the row before
  * it, and a replay can never spend a yes the person has taken back. Both
@@ -568,7 +568,7 @@ describe("a void and a replay can never both win", () => {
   });
 
   /**
-   * Checker round 5, finding 1 — the row can also be GONE. Subject erasure
+   * The row can also be GONE. Subject erasure
    * (02-store §5) and anonymous-subject adoption DELETE approval rows, so a
    * replay that treated a missing row as "unchanged" would re-create an erased
    * subject's approval and run the tool as them.
@@ -599,7 +599,7 @@ describe("a void and a replay can never both win", () => {
   });
 
   /**
-   * Checker round 5, finding 3 — the receipt is durable BEFORE the row write, so
+   * The receipt is durable BEFORE the row write, so
    * a take-back whose put failed leaves the receipt claimed and the row still
    * standing. The retry has to finish the job, not report it as already done.
    */
@@ -627,7 +627,7 @@ describe("a void and a replay can never both win", () => {
   });
 
   /**
-   * Checker round 5, finding 4 — a batch's compensation restores each applied
+   * A batch's compensation restores each applied
    * member to its pre-decision state, which is right unless a concurrent actor
    * has since SPENT or voided that member: those transitions are single-use, so
    * re-opening the ask would advertise a decision nobody can make again.
@@ -670,7 +670,7 @@ describe("a void and a replay can never both win", () => {
   });
 
   /**
-   * Checker round 5, finding 2 (the guard half) — the automations engine spends a
+   * The automations engine spends a
    * yes by arming the standing grant it asked for instead of replaying a call, so
    * that spend contends on the same transition as `approvals.revoke`.
    */


### PR DESCRIPTION
The `@vendoai/guard` slice of the de-slop sweep, worst-first: two correctness
bugs in the authorization path first, then the test assertions that could not
fail, then the comment exhaust.

**No change here widens what is permitted.** Every surviving denial is named
below with the test that proves it.

## Work list, in the order it was worked

| # | Finding | Disposition |
|---|---|---|
| 1 | `previewCheck` silently spends a single-use approval (HIGH) | **Fixed** — red test first (`d578b46`), fix (`de43976`) |
| 2 | `sweepExpiredApprovals` scans every approval row every 60s (HIGH→MED) | **Fixed** — red test first (`ec908c0`), fix (`bfe866a`) |
| 3 | Assertion compares a value to itself (LOW) | **Fixed** (`cb7658f`) |
| 4 | `destructive-default.test.ts` asserts `not.toBe("ok")` (from the downgrade note on the destructive/ungraded card) | **Fixed** (`cb7658f`) |
| 5 | Test header declares a security hole its own tests disprove (HIGH→LOW) | **Fixed** (`cb7658f`), including the leftover at :72-73 the card missed |
| 6 | Comments narrate the project's history in private jargon (MED) | **Fixed** — src (`4e307a8`) and tests (`ff7b0aa`) |
| 7 | Comments cite an internal audit process no reader can follow (LOW) | **Fixed** — same two commits |
| 8 | Org-policy clamp is a console-only layer with known holes (MED) | **Rejected — moot.** The owner cancelled this cut on 2026-08-07: the clamp is live authorization, wired for every deployment, and the only enforcement point. `git diff` over `packages/guard/src/` touches no `orgRule` / `orgPolicy` / `strictness` / `org-policy` line. |
| 9 | Barrel exports with no consumers (MED) | **Rejected — the claim is false for 2 of 3.** `resolvePolicyConfig` is imported by `vendo-web` at `apps/console/lib/try/chat.ts:31,442`; `policyFileSchema` by `apps/console/lib/preview/draft-config.ts:2` and `apps/console/lib/guard/service.ts:2`. Only `policyRuleSchema` has no external consumer, and dropping half of a file+rule schema pair for three lines is a breaking change with no benefit. (`parseOrgPolicyFile`, checked separately as instructed, has a real importer at `packages/vendo/src/org-policy.ts:2`.) |
| 10 | Guard stores a TTL it never reads (LOW) | **Rejected — false.** `approvals.parkedCallTtlMs` is read cross-package at `packages/vendo/src/server.ts:2063` and drives both sweeps at `:3127-3137`; pinned by `packages/vendo/src/config-coherence.test.ts:180-186`. |
| 11 | `policy.code` escape hatch has no user outside tests (MED) | **Rejected.** `PolicyFn` is re-exported from the umbrella (`packages/vendo/src/index.ts:23`), pinned by `packages/vendo/src/type-surface.test.ts:67`, and documented in `docs/archive/contracts/05-guard.md:84-86`. Deleting the stage also removes a host's ability to *deny* — a widening. |
| 12 | Store queries re-filter in JS on the refs they just queried (LOW) | **Rejected.** In the authorization package the second filter is the security boundary, not redundancy; deleting it makes the store's ref derivation the only thing standing between a subject and another subject's rows. |

## The two fixes

**1. A preview no longer spends the yes.** `previewCheck` is documented as the
un-committing seam, but `commitRun=false` only skipped the call-rate window and
the write budget. The full `#pipeline` still ran, and its first act claimed the
one-time atomic `consumed:<id>` receipt. So: a call with a stable id (the apps
runtime derives query/secret/egress ids from app+tool+args) parks, the user taps
approve, the harness previews (`packages/harnesses/src/tool-bridge.ts:349`) —
the preview eats the approval and answers "run", so no card is shown — and then
the real call finds the yes already spent, falls through to the default, and
parks a *new* approval. The tap is burned and the call never executes.

`#pipeline` now takes `commitRun`, and `#consumeApprovedCall` becomes
`#approvedReplay(…, claim)`: with `claim` false it answers "there is an approved,
unspent, context-matching replay" without claiming the receipt.

- **Restricted before:** an approval authorizes exactly one execution, enforced
  by the atomic `consumed:<id>` receipt.
- **Governs after:** unchanged. `claim` is `true` on every path that can
  dispatch — `check()` (default `commitRun=true`) and `bind().execute()`.
  `previewCheck` is the only `false`, and it dispatches nothing.
- **Surviving-denial proof:**
  `packages/guard/test/security/approval-replay.test.ts` →
  *"a preview does not spend the yes — the real call it cleared still runs"*
  asserts the **second** real replay comes back `pending-approval` and
  `tools.executions` stays at 1, i.e. the preview did not mint a second use.
  Also still green:
  `packages/guard/test/security/approval-single-use-cas.test.ts` →
  *"two guard instances consume one approved replay exactly once"*.

**2. The TTL sweep stops reading the whole table.** `sweepExpiredApprovals`
listed `vendo_approvals` with no query and dropped non-pending rows in JS. It
runs every 60s per process (`packages/vendo/src/server.ts:3137`), so a
deployment with a year of approvals re-read every decided row 1,440 times a day.
It now passes `refs: { status: "pending" }` — a declared ref on that collection
in both the routed store and the memory adapter, derived from the real column on
write, and already used verbatim at `guard.ts:1780`.

- **Restricted before / governs after:** the same set — every *pending* approval
  older than the TTL is denied. The JS `status !== "pending"` filter was doing
  nothing the ref query does not.
- **Surviving-denial proof:**
  `packages/guard/test/sweep-expired-approvals.test.ts` →
  *"denies pending approvals older than the TTL, across subjects"* (unchanged,
  green), plus the new *"asks the store for pending approvals only, never the
  whole collection"*.

## vendo-web disposition

**No companion PR needed.** No exported symbol, type, or signature changed —
this PR touches `guard.ts` internals (one private method renamed), one query
argument, and comments. `vendo-web` imports exactly `resolvePolicyConfig` and
`policyFileSchema` from `@vendoai/guard`, both untouched, and never calls
`previewCheck`, `sweepExpiredApprovals`, `spendApproval`, or
`abandonApprovals` (grepped clean across `apps/`, excluding generated bundles).
The console *intends* to manage org policy and does not yet, which is why the
org clamp stays exactly as it is.

## One dangling reference, not mine to fix

`packages/apps/src/parked-action.ts:17` names the old private method in a
comment: `(guard \`#consumeApprovedCall\`)`. `packages/apps/**` belongs to
another in-flight piece, so I left it. It is a comment only — no build,
typecheck, or test impact — and the new name (`#approvedReplay`) actually reads
truer to the sentence it sits in.

## Deferred

The large test-estate restructurings, all `worth-exploring` and none of them
correctness: the 42-case `pipeline-conformance` matrix, the `park-resume` ↔
`security/` overlap, the 526-line PGlite fixture and its raw-SQL assertions, the
shared `withPGliteStore()`/`askGuard()`/`wrapRecords()` fixtures, splitting
`ungraded-default.test.ts`'s lifecycle tests out, merging
`abandon`/`sweep-expired-approvals`, `breakers-lifecycle.e2e.test.ts` (rename,
not delete — two of its three describes are the only place asserting
`decided_by='breaker'` persisted), the `conformance.test.ts` double run, the
`judge.live.test.ts` placeholder, `surface.test.ts`'s type gymnastics, and the
`freeze.test.ts` collapse. Also deferred on the source side: splitting the
1840-line class, the receipt→row-CAS redesign, the batch-decide rollback saga,
the zero-limit audit cursor branch, the `confirmEach` replay flag, and policy
parse caching.

## Gates

```
pnpm build                                    21 successful, 21 total
packages/guard suite (forks/threads capped)   26 files, 278 tests passed
pnpm typecheck                                40 successful, 40 total
pnpm lint --force                             3 successful (1 pre-existing
                                              demo-bank warning, untouched)
```

Real LOC: +128 / -65 across `packages/guard`.

Changeset: `patch` (`@vendoai/guard`) — two behavior fixes, no public surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two guard issues in `@vendoai/guard`: previews no longer spend a single-use approval, and the TTL sweep now queries only pending approvals to avoid full-table scans. Improves reliability and reduces store load with no public API changes.

- **Bug Fixes**
  - `previewCheck` inspects approved replays without claiming them; the real check claims once at dispatch. Prevents the preview from burning the user’s approval and stranding the follow-up call.
  - `sweepExpiredApprovals` now queries `refs: { status: "pending" }` instead of reading the entire `vendo_approvals` table, cutting repeated full-table reads.

<sup>Written for commit fe2af67b49cf96921b68ac42888ad9c4bc56ffcf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

