### PR TITLE
fix(mcp): four bugs on the door — resurrected turn credentials, ES256-only remoteAs, apps dead on the turn leg, a full-collection scan on every revoke

### DIFF
--- a/.changeset/one-door-two-legs-agree.md
+++ b/.changeset/one-door-two-legs-agree.md
@@ -11,8 +11,9 @@ it had already lapsed, and expiry was only ever evaluated lazily inside `resolve
 A token whose conversation went quiet past the idle budget was therefore dead only
 if someone happened to resolve it; if the conversation took another turn first, the
 expiry was pushed forward and the token worked again. Lapsed entries are now dropped
-in that same loop, which also bounds the in-memory registry in a long-running host
-process — a token minted and never resolved previously had nothing to remove it.
+in that same loop, across the whole registry rather than only the thread being
+published, which also bounds it in a long-running host process — a token minted for
+a conversation that never takes another turn previously had nothing to remove it.
 
 **`remoteAs` accepts the algorithms real authorization servers use.** Verification
 was pinned to ES256 alone, so a door pointed at Auth0, Okta, Entra ID or Cognito —

--- a/.changeset/one-door-two-legs-agree.md
+++ b/.changeset/one-door-two-legs-agree.md
@@ -1,0 +1,34 @@
+---
+"@vendoai/mcp": patch
+---
+
+Four fixes on the MCP door: expired turn credentials, RS256 tokens, blank
+`remoteAs` bindings, and MCP Apps on the turn-credential leg.
+
+**An expired turn credential no longer comes back to life.** `publish()` refreshed
+the idle expiry of every credential minted for the thread without checking whether
+it had already lapsed, and expiry was only ever evaluated lazily inside `resolve()`.
+A token whose conversation went quiet past the idle budget was therefore dead only
+if someone happened to resolve it; if the conversation took another turn first, the
+expiry was pushed forward and the token worked again. Lapsed entries are now dropped
+in that same loop, which also bounds the in-memory registry in a long-running host
+process — a token minted and never resolved previously had nothing to remove it.
+
+**`remoteAs` accepts the algorithms real authorization servers use.** Verification
+was pinned to ES256 alone, so a door pointed at Auth0, Okta, Entra ID or Cognito —
+all of which issue RS256 by default — returned 401 on every request with no local
+`/authorize`, `/token` or `/register` to fall back to. The allowlist is now
+`RS256/384/512`, `PS256/384/512` and `ES256/384/512`; symmetric algorithms and
+`none` stay rejected. Separately, a blank `remoteAs.issuer` or `audience` now fails
+at `createMcpDoor` instead of silently disabling the claim check it names.
+
+**Opening a saved app over a turn credential renders.** One door composed with both
+`apps` and `turnCredentials` — which is every `createVendo({ mcp: true })` — made
+apps render on the OAuth leg only. The turn leg advertised no shim resource on its
+`vendo_apps_*` listings and returned the registry's raw `OpenSurface` envelope with
+the already-resolved query declarations still in it. Both legs now run the same two
+steps.
+
+Revoking a client no longer scans every outstanding authorization code in the
+deployment. That scan looked for codes carrying no grant family, which the only
+code-minting path cannot produce.

--- a/docs-site/capabilities/mcp.mdx
+++ b/docs-site/capabilities/mcp.mdx
@@ -604,9 +604,12 @@ ordinary 404 rather than a 500.
 
 ### remoteAs token requirements
 
-- Tokens must be ES256-signed JWTs with `iss`, `sub`, `aud`, `iat`, and `exp`
-  claims. `iss` must equal the configured `issuer`, `aud` must equal the
-  configured `audience`, and `exp` must be in the future.
+- Tokens must be JWTs with `iss`, `sub`, `aud`, `iat`, and `exp` claims,
+  signed with one of `RS256`, `RS384`, `RS512`, `PS256`, `PS384`, `PS512`,
+  `ES256`, `ES384`, or `ES512`. Symmetric algorithms and `none` are rejected.
+  `iss` must equal the configured `issuer`, `aud` must equal the configured
+  `audience`, and `exp` must be in the future. Neither `issuer` nor `audience`
+  may be blank — the door refuses to start if either is.
 - The door caches the JWKS in memory and refetches it when a bearer arrives
   with an unfamiliar `kid`, which covers ordinary key rotation. `jwksUri` is
   optional; the door discovers it from the issuer's RFC 8414 metadata when

--- a/packages/mcp/src/door.test.ts
+++ b/packages/mcp/src/door.test.ts
@@ -1147,6 +1147,54 @@ describe("createMcpDoor remote authorization server trust", () => {
     expect(harness.principalSubjects).toEqual([]);
   });
 
+  it("accepts an RS256 access token, the default of the mainstream authorization servers", async () => {
+    const as = await remoteAsFixture("RS256");
+    vi.stubGlobal("fetch", as.fetch);
+    const harness = makeHarness({
+      remoteAs: { issuer: as.issuer, audience: BASE },
+      principal: (subject) => ({ kind: "user", subject }),
+    });
+
+    const response = await harness.door.handler(mcpRequest(await as.mint({ sub: "rs256_user" })));
+
+    expect(response.status).toBe(200);
+    expect(harness.principalSubjects).toEqual(["rs256_user"]);
+  });
+
+  it("rejects an HS256 token forged from the published RSA key — the algorithm allowlist stays asymmetric", async () => {
+    const as = await remoteAsFixture("RS256");
+    vi.stubGlobal("fetch", as.fetch);
+    const harness = makeHarness({ remoteAs: { issuer: as.issuer, audience: BASE } });
+
+    // Classic algorithm confusion: sign HS256 with the public modulus everyone
+    // can read off the JWKS. Only the allowlist stands between this and a token
+    // anyone can mint.
+    const secret = new TextEncoder().encode((await as.publicJwk()).n as string);
+    const forged = await new SignJWT({})
+      .setProtectedHeader({ alg: "HS256", kid: as.kid() })
+      .setIssuer(as.issuer)
+      .setAudience(BASE)
+      .setSubject("forged_user")
+      .setIssuedAt()
+      .setExpirationTime("5m")
+      .sign(secret);
+
+    expect((await harness.door.handler(mcpRequest(forged))).status).toBe(401);
+    expect(harness.principalSubjects).toEqual([]);
+  });
+
+  it("refuses to compose a door whose remote authorization server has a blank issuer or audience", async () => {
+    // jose skips the `aud`/`iss` VALUE check when the expected value is falsy,
+    // so a blank one silently turns the audience binding off and every token
+    // that server ever signed becomes good at this door.
+    for (const remoteAs of [
+      { issuer: "https://as.example", audience: "" },
+      { issuer: "", audience: BASE },
+    ]) {
+      expect(() => makeHarness({ remoteAs })).toThrow(/issuer and audience/);
+    }
+  });
+
   it("rejects a JWT whose signature does not match the trusted key", async () => {
     const as = await remoteAsFixture();
     vi.stubGlobal("fetch", as.fetch);
@@ -2817,6 +2865,85 @@ describe("createMcpDoor withholdTools on a turn-bearing session", () => {
   });
 });
 
+describe("createMcpDoor MCP Apps on a turn-bearing session", () => {
+  const TOKEN = "vtk_apps_turn";
+
+  /** The umbrella composes ONE door with both `apps` and `turnCredentials`, and
+   *  the turn's registry owns `vendo_apps_open` (apps.agentTools). Whatever the
+   *  OAuth leg does to make an app render, this leg has to do too — it is the
+   *  same mount and the same feature. */
+  function harnessFor(payload: Record<string, unknown>) {
+    const apps: AppsPort = {
+      async list() { return []; },
+      async open() { return { kind: "http", url: "https://app.example" }; },
+      async call() { return null; },
+    };
+    return makeHarness({
+      apps,
+      turnCredentials: {
+        async resolve(token) {
+          if (token !== TOKEN) return null;
+          return {
+            ctx: {
+              principal: { kind: "user" as const, subject: "user_1" },
+              venue: "chat" as const,
+              presence: "present" as const,
+            },
+            tools: {
+              async call() {
+                return { status: "ok" as const, output: { kind: "tree", payload } };
+              },
+              async list() {
+                return [
+                  { name: "host_lookup", description: "Look something up", risk: "read" as const, inputSchema: { type: "object", properties: {} } },
+                  { name: "vendo_apps_open", description: "Open a saved app", risk: "read" as const, inputSchema: { type: "object", properties: {} } },
+                ];
+              },
+            },
+          };
+        },
+      },
+    });
+  }
+
+  it("advertises the shim on the turn leg's apps listing", async () => {
+    const connected = await connect(harnessFor({}).door, TOKEN);
+
+    const listed = (await connected.client.listTools()).tools;
+    expect(listed.find((tool) => tool.name === "vendo_apps_open")?._meta).toEqual({
+      ui: { resourceUri: "ui://vendo/tree-shim.html" },
+      "ui/resourceUri": "ui://vendo/tree-shim.html",
+    });
+    // Only the app-viewer names get it; a host tool is untouched.
+    expect(listed.find((tool) => tool.name === "host_lookup")?._meta).toBeUndefined();
+    await connected.client.close();
+  });
+
+  it("unwraps the OpenSurface envelope and strips the already-resolved queries", async () => {
+    const payload = {
+      formatVersion: "vendo-genui/v2",
+      root: "root",
+      nodes: [],
+      data: { via: "turn" },
+      queries: [{ name: "via", tool: "host_source" }],
+    };
+    const connected = await connect(harnessFor(payload).door, TOKEN);
+
+    const result = await connected.client.callTool({ name: "vendo_apps_open", arguments: { appId: "app_1" } });
+
+    // The shim renders a bare format-tagged UIPayload, and the turn's runtime
+    // already resolved every query into `data` — forwarding the declarations
+    // would execute them a second time.
+    expect(result.structuredContent).toEqual({
+      formatVersion: "vendo-genui/v2",
+      root: "root",
+      nodes: [],
+      data: { via: "turn" },
+    });
+    await connected.client.close();
+  });
+});
+
 describe("createMcpDoor first-party service auth", () => {
   const AS_URL = "https://product.example/.well-known/oauth-authorization-server/api/vendo/mcp";
 
@@ -3345,19 +3472,19 @@ interface RemoteTokenOverrides {
   expiresAt?: number;
 }
 
-async function generateSigningKey(kid: string) {
-  const pair = await generateKeyPair("ES256");
-  return { ...pair, kid };
+async function generateSigningKey(kid: string, alg = "ES256") {
+  const pair = await generateKeyPair(alg);
+  return { ...pair, kid, alg };
 }
 
 async function mintRemoteToken(
   privateKey: KeyLike,
   kid: string,
-  options: { issuer: string; audience: string } & RemoteTokenOverrides,
+  options: { issuer: string; audience: string; alg?: string } & RemoteTokenOverrides,
 ): Promise<string> {
   const now = Math.floor(Date.now() / 1_000);
   return new SignJWT({})
-    .setProtectedHeader({ alg: "ES256", kid })
+    .setProtectedHeader({ alg: options.alg ?? "ES256", kid })
     .setIssuer(options.issuer)
     .setAudience(options.audience)
     .setSubject(options.sub ?? "external_user")
@@ -3366,11 +3493,11 @@ async function mintRemoteToken(
     .sign(privateKey);
 }
 
-async function remoteAsFixture() {
+async function remoteAsFixture(alg = "ES256") {
   const issuer = "https://as.example";
   const jwksUri = `${issuer}/jwks`;
-  let key = await generateSigningKey("initial");
-  let jwks = { keys: [{ ...(await exportJWK(key.publicKey)), alg: "ES256", use: "sig", kid: key.kid }] };
+  let key = await generateSigningKey("initial", alg);
+  let jwks = { keys: [{ ...(await exportJWK(key.publicKey)), alg, use: "sig", kid: key.kid }] };
   const fetch = vi.fn(async (input: string | URL | Request) => {
     const url = input instanceof Request ? input.url : input.toString();
     if (url === `${issuer}/.well-known/oauth-authorization-server`) {
@@ -3383,16 +3510,19 @@ async function remoteAsFixture() {
     issuer,
     jwksUri,
     fetch,
+    publicJwk: async () => await exportJWK(key.publicKey),
+    kid: () => key.kid,
     async mint(overrides: RemoteTokenOverrides = {}) {
       return mintRemoteToken(key.privateKey, key.kid, {
         issuer: overrides.issuer ?? issuer,
         audience: overrides.audience ?? BASE,
+        alg,
         ...overrides,
       });
     },
     async rotate(kid: string) {
-      key = await generateSigningKey(kid);
-      jwks = { keys: [{ ...(await exportJWK(key.publicKey)), alg: "ES256", use: "sig", kid: key.kid }] };
+      key = await generateSigningKey(kid, alg);
+      jwks = { keys: [{ ...(await exportJWK(key.publicKey)), alg, use: "sig", kid: key.kid }] };
     },
   };
 }

--- a/packages/mcp/src/door.test.ts
+++ b/packages/mcp/src/door.test.ts
@@ -556,25 +556,15 @@ describe("createMcpDoor routing and OAuth", () => {
     await connectedA.client.close().catch(() => undefined);
   });
 
-  it("revokes a pre-family authorization code during a rolling deployment", async () => {
+  it("refuses an authorization code still outstanding when the client was revoked", async () => {
     const harness = makeHarness();
     const client = await register(harness.door);
-    const code = "vmcd_pre_family_code";
-    await harness.store.records("vendo_mcp_grants").put({
-      id: "mcpg_pre_family_code",
-      data: {
-        kind: "code",
-        subject: "user_1",
-        clientId: client.body.client_id,
-        resource: BASE,
-        scopes: ["read", "write"],
-        codeChallenge: await pkceChallenge(VERIFIER),
-        redirectUri: REDIRECT,
-        expiresAt: new Date(Date.now() + 60_000).toISOString(),
-      },
-      refs: { kind: "code", token_hash: await sha256Hex(code) },
-    });
+    const auth = await authorize(harness.door, client.body.client_id);
+    const code = new URL(auth.headers.get("location")!).searchParams.get("code")!;
 
+    // A code lives a minute; a revoke inside that window has to reach it. The
+    // family anchor is what does it — the code carries the family id and the
+    // exchange re-checks that the family is still active.
     await harness.door.revokeClient("user_1", client.body.client_id);
 
     const exchangeResponse = await exchange(harness.door, {
@@ -585,7 +575,22 @@ describe("createMcpDoor routing and OAuth", () => {
     });
     expect(exchangeResponse.status).toBe(400);
     expect(await exchangeResponse.json()).toMatchObject({ error: "invalid_grant" });
-    expect(harness.store.rows("vendo_mcp_grants")[0]?.data.revokedAt).toEqual(expect.any(String));
+  });
+
+  it("revokes an outstanding service-key access grant, which carries no family", async () => {
+    const harness = makeHarness({ serviceAuth: { keys: [SERVICE_KEY] } });
+    const exchanged = await serviceExchange(harness.door);
+    const { access_token: token } = await exchanged.json() as TokenResponse;
+    expect((await harness.door.handler(mcpRequest(token))).status).toBe(200);
+
+    // The service-key exchange mints ONE access grant and nothing else — no
+    // refresh token, so no rotation and no family anchor to hang a revocation
+    // on. Per-grant revocation is the only thing that can reach it.
+    await harness.door.revokeClient("user_1", "vendo-service");
+    expect((await harness.door.handler(mcpRequest(token))).status).toBe(200);
+
+    await harness.door.revokeClient("user_1", `svc:${(await sha256Hex(SERVICE_KEY)).slice(0, 8)}`);
+    expect((await harness.door.handler(mcpRequest(token))).status).toBe(401);
   });
 
   it("consumes an authorization code the moment it is presented, even on PKCE failure", async () => {

--- a/packages/mcp/src/door.ts
+++ b/packages/mcp/src/door.ts
@@ -752,7 +752,7 @@ class Door {
     state.server.setRequestHandler(ListToolsRequestSchema, async () => {
       const tools = state.turn === undefined
         ? await this.#listedTools(state)
-        : await turnTools(state.turn, this.#withheld);
+        : await turnTools(state.turn, this.#withheld, this.#config.apps !== undefined);
       return { tools };
     });
     state.server.setRequestHandler(CallToolRequestSchema, async (request) =>
@@ -856,7 +856,15 @@ class Door {
     if (state.turn !== undefined) {
       if (this.#withheld.has(name)) return inBandError(`not-found: Tool ${name} was not found`);
       const turn = state.turn;
-      return turnResult(await turn.tools.call(name, args as Json));
+      const result = await turn.tools.call(name, args as Json);
+      // The shim renders a bare format-tagged UIPayload, not the registry's
+      // OpenSurface envelope — the same unwrap the OAuth leg does below. Both
+      // legs share one mount and one `apps` config, so they cannot disagree
+      // about whether a saved app renders.
+      if (name === "vendo_apps_open" && this.#config.apps !== undefined && result.status === "ok") {
+        return textResult(await this.#mcpAppsOpenOutput(result.output, args, turn.ctx, identity));
+      }
+      return turnResult(result);
     }
     const descriptors = await this.#config.tools.descriptors(state.context);
     // An off-menu name answers exactly like a name that does not exist: the
@@ -1569,7 +1577,11 @@ function bearerOf(req: Request): string | undefined {
  * visible without reopening anything — the limitation that made the in-process
  * projection snapshot its tool set at session open dies here.
  */
-async function turnTools(turn: LiveTurn, withheld: ReadonlySet<string>): Promise<Tool[]> {
+async function turnTools(
+  turn: LiveTurn,
+  withheld: ReadonlySet<string>,
+  appsConfigured: boolean,
+): Promise<Tool[]> {
   const listings = (await turn.tools.list()).filter((listing) => !withheld.has(listing.name));
   const compiles = wireSchemaCompiler();
   return listings.map((listing) => {
@@ -1581,6 +1593,9 @@ async function turnTools(turn: LiveTurn, withheld: ReadonlySet<string>): Promise
       ...wireOutputSchema(listing.outputSchema, compiles),
       ...(label === undefined ? {} : { title: label }),
       annotations: toolAnnotations(listing.risk, label),
+      // Same as the OAuth leg: an app-viewer name the turn's registry owns has
+      // to advertise the shim, or the client never preloads the renderer.
+      ...(appsConfigured && APP_TOOL_NAMES.has(listing.name) ? { _meta: appUiMeta() } : {}),
     };
   });
 }

--- a/packages/mcp/src/oauth/remote-as.ts
+++ b/packages/mcp/src/oauth/remote-as.ts
@@ -15,6 +15,14 @@ export interface RemoteAccessGrant {
   expiresAt: string;
 }
 
+/** The asymmetric signature algorithms a real authorization server issues
+ * access tokens with. RS256 is the default at Auth0, Okta, Entra ID and
+ * Cognito; ES256 is what Vendo's own broker signs with. Symmetric algorithms
+ * (HS*) and `none` stay off the list deliberately: a JWKS publishes PUBLIC
+ * keys, so an HS256 token signed with the modulus anyone can read would
+ * otherwise verify. */
+const REMOTE_AS_ALGORITHMS = ["RS256", "RS384", "RS512", "PS256", "PS384", "PS512", "ES256", "ES384", "ES512"];
+
 /** Validates bearer JWTs issued by an external authorization server. The
  * RemoteJWKSet keeps verified keys in memory and re-fetches the JWKS when an
  * unfamiliar `kid` appears, which covers ordinary zero-downtime key rotation. */
@@ -24,6 +32,12 @@ export class RemoteAsVerifier {
   #keys: ReturnType<typeof createRemoteJWKSet> | undefined;
 
   constructor(config: RemoteAsConfig) {
+    // jose checks the `iss`/`aud` VALUES only when the expected value is
+    // truthy — a blank one leaves the claim required but unchecked, which
+    // silently turns off the binding that makes this door's tokens this door's.
+    if (config.issuer === "" || config.audience === "") {
+      throw new Error("remoteAs requires a non-empty issuer and audience");
+    }
     this.#config = config;
   }
 
@@ -33,7 +47,7 @@ export class RemoteAsVerifier {
     if (!match?.[1]) return null;
     try {
       const { payload } = await jwtVerify(match[1], await this.#keySet(), {
-        algorithms: ["ES256"],
+        algorithms: REMOTE_AS_ALGORITHMS,
         issuer: this.#config.issuer,
         audience: this.#config.audience,
         requiredClaims: ["sub", "iat", "exp"],

--- a/packages/mcp/src/oauth/server.ts
+++ b/packages/mcp/src/oauth/server.ts
@@ -829,11 +829,11 @@ export class OAuthServer {
       changed = await this.#revokeFamily(family.id) || changed;
     }
 
-    // Outstanding grants minted before family anchors shipped remain valid
-    // across a rolling deployment. Revoke those with the same guarded UPDATE
-    // pattern instead of list-then-delete.
-    const legacy = await listAll(store, { subject, client_id: clientId });
-    for (const record of legacy) {
+    // The service-key exchange mints ONE access grant with no refresh token and
+    // therefore no family anchor (§3.4), so a family sweep cannot reach it.
+    // Revoke those per grant, with the same guarded UPDATE.
+    const familyless = await listAll(store, { subject, client_id: clientId });
+    for (const record of familyless) {
       const access = accessGrantSchema.safeParse(record.data);
       if (access.success && access.data.familyId === undefined) {
         changed = await this.#revokeTokenRecord(record, accessGrantSchema) || changed;
@@ -842,21 +842,6 @@ export class OAuthServer {
       const refresh = refreshGrantSchema.safeParse(record.data);
       if (refresh.success && refresh.data.familyId === undefined) {
         changed = await this.#revokeTokenRecord(record, refreshGrantSchema) || changed;
-      }
-    }
-    // Pre-family authorization codes did not carry subject/client refs. Their
-    // one-minute window still overlaps rolling deploys, so scan the bounded
-    // code set, filter by parsed binding, and guard-update matches as revoked.
-    const legacyCodes = await listAll(store, { kind: "code" });
-    for (const record of legacyCodes) {
-      const code = codeGrantSchema.safeParse(record.data);
-      if (
-        code.success
-        && code.data.familyId === undefined
-        && code.data.subject === subject
-        && code.data.clientId === clientId
-      ) {
-        changed = await this.#revokeTokenRecord(record, codeGrantSchema) || changed;
       }
     }
     return changed;

--- a/packages/mcp/src/turn-credential.test.ts
+++ b/packages/mcp/src/turn-credential.test.ts
@@ -155,6 +155,22 @@ describe("the door's turn credential — what it refuses", () => {
     release();
   });
 
+  it("NEGATIVE — an expired credential is not resurrected by a later turn of its own thread", async () => {
+    let now = 1_000_000;
+    const credentials = createTurnCredentials({ now: () => now, idleMs: 60_000 });
+    const release = credentials.publish("thr_a", liveTurn("user_a", "a"));
+    const token = credentials.mint("thr_a")!;
+    release();
+
+    // The conversation goes quiet well past the idle budget and then takes
+    // another turn, with nothing having resolved the token in between. publish()
+    // is the only place that can notice the expiry, because nothing sweeps.
+    now += 120_000;
+    const again = credentials.publish("thr_a", liveTurn("user_a", "a2"));
+    expect(await credentials.resolve(token)).toBeNull();
+    again();
+  });
+
   it("two mints never collide, and a token is not derivable from the thread it names", () => {
     const credentials = createTurnCredentials();
     const release = credentials.publish("thr_a", liveTurn("user_a", "a"));

--- a/packages/mcp/src/turn-credential.test.ts
+++ b/packages/mcp/src/turn-credential.test.ts
@@ -37,6 +37,35 @@ const liveTurn = (subject: string, marker: string, presence?: RunContext["presen
   tools: toolsFor(marker),
 });
 
+/**
+ * An expired entry is INERT: `resolve()` refuses it whether or not the registry
+ * is still holding it, and nothing else in the file can see it (verified against
+ * both the pre- and post-fix implementations). "The registry let go of it" has
+ * therefore no behavioural surface to assert against, and a retention leak is
+ * only visible by looking at the Map the registry builds for itself. This
+ * captures that Map from the outside; the product exposes nothing for it.
+ */
+const probeRegistry = <T>(make: () => T) => {
+  const built: Map<string, unknown>[] = [];
+  const RealMap = globalThis.Map;
+  globalThis.Map = class extends RealMap {
+    constructor(...args: ConstructorParameters<typeof Map>) {
+      super(...args);
+      built.push(this as Map<string, unknown>);
+    }
+  } as MapConstructor;
+  try {
+    return {
+      registry: make(),
+      /** The credential map, identified by a token it holds — so call it once
+       *  something has been minted, never by construction order. */
+      credentialMap: (token: string) => built.find((map) => map.has(token))!,
+    };
+  } finally {
+    globalThis.Map = RealMap;
+  }
+};
+
 describe("the door's turn credential — what it refuses", () => {
   it("cannot be minted outside a live turn: there is no context to bind to", async () => {
     const credentials = createTurnCredentials();
@@ -169,6 +198,28 @@ describe("the door's turn credential — what it refuses", () => {
     const again = credentials.publish("thr_a", liveTurn("user_a", "a2"));
     expect(await credentials.resolve(token)).toBeNull();
     again();
+  });
+
+  it("an abandoned thread's expired credential is collected by ANY publish, not only its own thread's", async () => {
+    let now = 1_000_000;
+    const { registry: credentials, credentialMap } = probeRegistry(() =>
+      createTurnCredentials({ now: () => now, idleMs: 60_000 }));
+
+    const release = credentials.publish("thr_a", liveTurn("user_a", "a"));
+    const token = credentials.mint("thr_a")!;
+    const minted = credentialMap(token);
+    release();
+
+    // Thread A is ABANDONED: it never takes another turn, and nothing ever
+    // resolves its token. Only publish() and resolve() can notice an expiry, so
+    // for this entry neither will ever run again.
+    now += 120_000;
+    for (let i = 0; i < 20; i++) credentials.publish("thr_b", liveTurn("user_b", `b${i}`))();
+
+    expect(minted.has(token)).toBe(false);
+    expect(minted.size).toBe(0);
+    // Belt and braces: it was never usable while it lingered, either.
+    expect(await credentials.resolve(token)).toBeNull();
   });
 
   it("two mints never collide, and a token is not derivable from the thread it names", () => {

--- a/packages/mcp/src/turn-credential.ts
+++ b/packages/mcp/src/turn-credential.ts
@@ -61,8 +61,9 @@ export interface TurnCredentialPort {
  * Its authority window is that turn: between turns it resolves to nothing, and a
  * call arriving then is a 401, because a call with no turn behind it has no
  * accountability context to be judged in. It dies on `revoke()` (the machine
- * holding it was destroyed), on an idle sweep, and permanently if its thread is
- * ever seen carrying a different principal. Everything it can reach is what that
+ * holding it was destroyed), when it has gone unused for the idle budget, and
+ * permanently if its thread is ever seen carrying a different principal —
+ * whichever comes first. Everything it can reach is what that
  * turn could already reach — `turn.tools`, which is the guard-bound registry
  * with the turn's own ctx.
  */
@@ -144,8 +145,16 @@ export function createTurnCredentials(options: TurnCredentialsOptions = {}): Tur
       // Touch every credential of this conversation: a thread still taking turns
       // is a thread still in use, and the idle budget is about abandonment.
       // Every survivor matches `subject` — the burn above saw to that.
-      for (const entry of minted.values()) {
-        if (entry.threadId === threadId) entry.expiresAt = now() + idleMs;
+      //
+      // An entry that ALREADY lapsed is dropped instead of refreshed. Expiry is
+      // otherwise only ever noticed inside resolve(), so a credential abandoned
+      // for two days would be pushed two days forward by the next turn and work
+      // again. This is also the only thing that bounds `minted`: a token minted
+      // and never resolved has nothing else to remove it.
+      for (const [token, entry] of minted) {
+        if (entry.threadId !== threadId) continue;
+        if (entry.expiresAt <= now()) minted.delete(token);
+        else entry.expiresAt = now() + idleMs;
       }
       return () => {
         // Only ever retract OUR publication. A disposer that ran after the next

--- a/packages/mcp/src/turn-credential.ts
+++ b/packages/mcp/src/turn-credential.ts
@@ -151,10 +151,16 @@ export function createTurnCredentials(options: TurnCredentialsOptions = {}): Tur
       // for two days would be pushed two days forward by the next turn and work
       // again. This is also the only thing that bounds `minted`: a token minted
       // and never resolved has nothing else to remove it.
+      //
+      // The DROP spans the whole registry while the refresh stays scoped to this
+      // thread, because the entries nothing else will ever remove are exactly
+      // the ones whose thread went silent: a per-thread sweep can only collect a
+      // conversation that came back. Like the door's own `sweepExpiredSessions`,
+      // this rides the next request rather than a timer.
+      const at = now();
       for (const [token, entry] of minted) {
-        if (entry.threadId !== threadId) continue;
-        if (entry.expiresAt <= now()) minted.delete(token);
-        else entry.expiresAt = now() + idleMs;
+        if (entry.expiresAt <= at) minted.delete(token);
+        else if (entry.threadId === threadId) entry.expiresAt = at + idleMs;
       }
       return () => {
         // Only ever retract OUR publication. A disposer that ran after the next


### PR DESCRIPTION
Worst-first sweep of the `@vendoai/mcp` catalog: the correctness bugs on the door's credential, auth and rendering paths, plus the one genuinely-dead branch on the revocation path. Every bug fix is a red test first, then the fix, in separate commits.

## Selected list, worst-first

| # | Finding | Disposition |
|---|---|---|
| 1 | Expired turn credentials are resurrected, and never swept | **fixed** |
| 2 | `remoteAs` accepts ES256 only, rejecting RS256 authorization servers | **fixed** |
| 3 | MCP Apps rendering is dead on the turn-credential leg | **fixed** |
| 4 | Pre-family grant compatibility is unreachable rolling-deploy legacy (x2 entries) | **partly taken, mostly rejected — see below** |
| 5 | RFC 8707 audience hardening on `remoteAs` (owner follow-up) | **taken in the one form that is contained; the framed form rejected — see below** |
| 6 | `withholdTools` has zero callers | **deferred** (verified genuinely uncalled, but it is a live curation lever on the authorization path and belongs in its own PR) |
| 7 | door.ts is 1803 lines / 615 comment lines / TestMcpDoorState / listAll x4 / the MED+LOW verbosity tail | **deferred** — pure-verbosity work, does not belong in a bug PR |

`federation` and `remoteAs` removal proposals: **moot, logged rejected.** The owner rejected and closed PR #952 on 2026-08-07. Those two are the only ways the hosted MCP broker (`{tenant}.mcp.vendo.run`) reaches a host door. Nothing here deletes, deprecates or narrows either. This PR *widens* what `remoteAs` accepts.

## 1. An expired turn credential comes back to life

`publish()` refreshed `expiresAt` on every entry minted for the thread without checking whether it had already lapsed, and expiry was only ever evaluated lazily inside `resolve()`. A token minted at t=0 with a 60-minute idle budget, whose conversation went quiet for two days, was dead at t=61min — but only if somebody happened to resolve it. If the conversation took another turn first, its expiry was pushed two days forward and the token worked again.

Lapsed entries are now dropped in that same loop. That also bounds the `minted` map in a long-running host process: a token minted and never resolved previously had nothing that could remove it. The header claimed the credential "dies … on an idle sweep" and no sweep existed anywhere in the file; now one does.

## 2. `remoteAs` 401s on every mainstream authorization server

`jwtVerify` was pinned to `algorithms: ["ES256"]` — what Vendo's own broker signs with, and nothing else. Auth0, Okta, Entra ID and Cognito all issue RS256 by default, and in `remoteAs` mode the local `/authorize`, `/token` and `/register` all 404, so there is no fallback: every request 401s with the jose error swallowed. The repo's own Auth0 preset verifies RS256, so the two halves of the product disagreed about what a real AS signs with.

The allowlist is now `RS256/384/512`, `PS256/384/512`, `ES256/384/512`. **HS\* and `none` stay off it deliberately, and that is proven by a test that exists after this change:** `rejects an HS256 token forged from the published RSA key` signs HS256 with the RSA modulus anyone can read off the JWKS and asserts 401. It passed before this change and passes after.

## 3. MCP Apps rendered on one leg of one mount

The door has two credential legs on the same mount and one `apps` config. The OAuth leg attached `_meta.ui.resourceUri` to the `vendo_apps_*` listings so the client preloads the shim, and unwrapped the registry's `OpenSurface` envelope (stripping the already-resolved `queries`) before returning. The turn leg did neither — while the shim resource handlers were registered for turn sessions anyway, because they key off `config.apps`.

`createVendo({ mcp: true })` composes exactly that door (`apps` + `turnCredentials`), so a Claude Code box opening a saved app over a harness credential got a raw `{kind:"tree",payload:{…}}` blob with the query declarations still in it — the double execution the projection exists to prevent — and no preload hint. Both legs now run the same two steps through the same helpers.

## 4. Pre-family grant compatibility — mostly REJECTED, and here is why

The catalog says (twice) that `#approve` is the only place a grant is minted and that it always sets `familyId`, so `familyId === undefined` is unreachable rolling-deploy legacy; it proposes making `familyId` required in all three schemas and deleting the `undefined` branches.

**That is wrong against today's code.** Since #941 cut the service-key feature down to the door, `#exchangeServiceKey` mints an `AccessGrant` with **no** `familyId` — one short-lived access token, no refresh token, so no rotation and nothing to anchor a family to (`oauth/server.ts:699-715`). `familyId === undefined` is a live shape, not legacy. Making it required in `accessGrantSchema` would make every service-key token fail to parse in `authenticate()`, and first-party service auth would stop working entirely. `#isFamilyActive(undefined) === true` is what lets those tokens authenticate at all.

What I did take is the one piece that genuinely is unreachable: the trailing `listAll(store, { kind: "code" })` scan — a paged read of **every outstanding authorization code across every subject and client in the deployment**, in memory-filtered, on every `revokeClient()` and every refresh-token revocation. Codes are minted only by `#approve`, which always writes a `familyId`, and a code whose family was revoked is already refused at the exchange by `#isFamilyActive`.

**Surviving checks, each with a test that exists after this change** (law: no change may widen who can act as whom):
- `refuses an authorization code still outstanding when the client was revoked` — replaces the deleted synthetic test, which hand-wrote a record no code path produces. Real code from `/authorize`, revoked via `revokeClient`, refused at `/token`.
- `revokes an outstanding service-key access grant, which carries no family` — pins that the familyless sweep I kept is live, and that it is scoped to the right client id.

Deferred from this finding: narrowing `familyId` to required in `codeGrantSchema`/`refreshGrantSchema` only (both are always minted with one) would collapse `#revokeGrant` and the `door.ts:418-422` fork. Real but small, and it is a persisted-schema change on the revocation path — its own PR.

## 5. RFC 8707 audience hardening on `remoteAs` — the framed version would break the broker

The framing was: `remoteAs` is the one arm that skips the audience check every other path enforces, at `door.ts:491`:

```ts
if (!auth || (this.#remoteAs === undefined && !sameCanonicalUri(auth.grant.resource, resource))) {
```

**I did not apply that check to the `remoteAs` arm, and it should not be applied.** `RemoteAsVerifier` sets `grant.resource = config.audience`, so enforcing `sameCanonicalUri` there means requiring `remoteAs.audience` to equal the door's own canonical resource URI. The hosted broker does not work that way:

- `vendo-web/services/broker/src/jwt.ts:71` mints `aud = grant.resource`, and every grant's resource is `tenantResource(tenant)`.
- `vendo-web/services/broker/src/tenant.ts:22-24` — `tenantResource` is `https://{slug}.mcp.vendo.run/mcp`, the **broker's** public identity.
- The door's own resource is `https://app.example.com/api/vendo/mcp`, the upstream. They are different strings by design; the broker fronts the door.

So that check would 401 every request the deployed broker forwards. It is a cross-repo semantics change, not a contained one, so per instruction I left it — flagging rather than half-doing it.

**What I did take, because it is the one real audience hole and it is three lines:** jose checks the `iss`/`aud` *values* only when the expected value is truthy (`jwt_claims_set.js:119` — `if (audience && …)`). A blank `remoteAs.audience` therefore left `aud` *required but unchecked*, and every token that authorization server ever signed became good at this door. `RemoteAsVerifier` now throws at construction, which surfaces at `createMcpDoor` instead of as an undiagnosable 200. Red test first: `refuses to compose a door whose remote authorization server has a blank issuer or audience`.

The audience binding is otherwise untouched: a token still has to name the configured audience, and the existing `rejects a wrong-audience JWT even when the request arrives through a proxy` test still passes.

## vendo-web disposition — no companion PR needed, justified per file

The console is an MCP consumer, so I checked the sibling repo by hand rather than trusting a "zero callers" claim. No `vendo-web` change is required, and here is the per-file reason:

- **`services/broker/src/jwt.ts`** — mints access tokens with `alg: "ES256"`. ES256 stays in the widened allowlist (it is the second entry group), so broker-issued tokens verify exactly as before. Widening an allowlist cannot reject something it previously accepted.
- **`services/broker/src/tenant.ts` + `apps/console/lib/mcp-broker/client.ts:68` + `apps/console/lib/api/mcp-tenant.ts:84`** — the tenant `resource` handed back to the host as `remoteAs.audience` is `https://{slug}.mcp.vendo.run/mcp`, which is never empty, so the new blank-issuer/audience guard cannot fire on the broker path. (This is also the evidence for rejecting the `sameCanonicalUri` hardening above.)
- **`services/broker/src/oauth-server.ts`** — already enforces RFC 8707 resource indicators against `tenantResource` at authorize, token, refresh and exchange. Unchanged, and untouched by anything here.
- Nothing exported from `@vendoai/mcp` was removed or renamed, so no console import can break. `withholdTools` (the deletion candidate) is untouched; grep across `vendo-web` finds no reference to it in any case.

## Gates

Foreground, redirected to files, read back — never piped through `tail`.

```
pnpm build                                  → BUILD exit=0      Tasks: 21 successful, 21 total
packages/mcp suite (FORKS/THREADS 1..2)     → exit=0            Test Files 3 passed (3) · Tests 142 passed (142)
pnpm typecheck                              → exit=0            Tasks: 40 successful, 40 total
pnpm lint --force                           → exit=0            Tasks: 3 successful, 3 total
```

The trap check: `packages/mcp/tsconfig.json` has `"exclude": ["src/**/*.test.ts"]`, so its test files never reach `tsc`. I compiled `door.test.ts` and `turn-credential.test.ts` against the base commit and against this branch under the same ad-hoc flags: **11 pre-existing diagnostics both before and after — no new ones.** (Wiring a `tsconfig.test.json` into typecheck is one of the deferred MED findings.) The mcp shim (`src/shim/shim-html.gen.ts`) was not regenerated.

## Size

`+269 / −58` across 8 files. Source: `turn-credential.ts +11/−4`, `oauth/remote-as.ts +14/−2`, `door.ts +18/−3`, `oauth/server.ts +4/−21`. The rest is tests, one docs page and the changeset.

Changeset: **`patch`** for `@vendoai/mcp`. Four behaviour fixes and one dead-branch removal; no export added, removed or retyped.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four MCP door issues in `@vendoai/mcp`: expired turn credentials now get a registry-wide idle sweep, `remoteAs` verifies standard asymmetric JWTs and requires non-empty issuer/audience, MCP Apps render on the turn leg, and revocation no longer scans all authorization codes.

- **Bug Fixes**
  - Turn credentials: drop lapsed entries during publish across the whole registry to prevent “resurrection” and bound memory.
  - Remote auth: accept RS256/RS384/RS512, PS256/PS384/PS512, ES256/ES384/ES512; still reject HS* and none; Auth0/Okta/Entra/Cognito tokens now work.
  - Audience binding: throw on blank `remoteAs.issuer` or `remoteAs.audience` so tokens aren’t accepted unchecked.
  - MCP Apps over turn: advertise the shim on app tools and unwrap the OpenSurface envelope like the OAuth leg.
  - Revocation: remove unreachable full-collection code scan; keep per-grant sweep for family-less service-key tokens.

- **Migration**
  - Ensure `remoteAs.issuer` and `remoteAs.audience` are non-empty; the door now fails fast if either is blank.

<sup>Written for commit e989e664d2b720e93efa32fc88d62d9bc6eedeb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

