### PR TITLE
fix(automations): engine-owned rows carry their app ref; the package root and its essays shrink to what has readers

### DIFF
--- a/.changeset/automations-generic-rows-carry-app-ref.md
+++ b/.changeset/automations-generic-rows-carry-app-ref.md
@@ -1,0 +1,21 @@
+---
+"@vendoai/automations": minor
+---
+
+Engine-owned generic rows carry their app ref, so app erase collects them.
+
+The schedule cursor, the webhook signing secret and the delivery ledger were
+written with no refs at all. The 02-store §5 app-erase cascade collects generic
+rows by `refs @> {app_id}`, so all three outlived the app they belong to — a
+live HMAC secret kept authenticating for an app that no longer existed, and
+`automations:deliveries`, which has no sweep or TTL anywhere, grew one permanent
+row per webhook delivery. Five write sites now carry the ref, including the
+tick's compare-and-swap replacement and the pre-rekey cursor migration.
+
+Rows already on disk are unaffected in behavior: every read is by row id, so
+nothing that works today stops working. The ref is stamped forward — a live
+schedule cursor gains it on its next tick; a webhook secret gains it on its next
+mint or rotation.
+
+The package root drops `appIntentOf`, `SPONSORSHIPS` and the `Sponsorship` type.
+Nothing outside this package imported them. `triggerKey` stays exported.

--- a/packages/automations/src/byo-refs.test.ts
+++ b/packages/automations/src/byo-refs.test.ts
@@ -28,6 +28,7 @@ import {
   type RecordStore,
   type StoreAdapter,
   type ToolRegistry,
+  type Trigger,
   type VendoRecord,
 } from "@vendoai/core";
 import type { AppsRuntime } from "@vendoai/apps";
@@ -116,7 +117,7 @@ const tools: ToolRegistry = {
 
 const appsDouble = (): AppsRuntime => ({ call: async () => ({ status: "ok", output: {} }) }) as AppsRuntime;
 
-const preTrainApp = (id: string, on: AppDocument["triggers"] extends undefined ? never : NonNullable<AppDocument["triggers"]>[number]["on"]): AppDocument => ({
+const preTrainApp = (id: string, on: Trigger["on"]): AppDocument => ({
   format: VENDO_APP_FORMAT,
   id,
   name: id,

--- a/packages/automations/src/engine.test.ts
+++ b/packages/automations/src/engine.test.ts
@@ -157,9 +157,6 @@ const memoryStoreWithoutAtomic = (): StoreAdapter => {
   };
 };
 
-const storedRun = async (store: StoreAdapter, id: string): Promise<Record<string, unknown>> =>
-  (await store.records("vendo_runs").get(id))?.data as Record<string, unknown>;
-
 const sign = async (secret: string, deliveryId: string, timestamp: string, body: string): Promise<string> => {
   let normalized = secret.replace(/-/g, "+").replace(/_/g, "/");
   normalized += "=".repeat((4 - normalized.length % 4) % 4);
@@ -271,13 +268,15 @@ describe("automations enable and grant capture", () => {
     expect(await store.records("automations:schedule").get(`${schedule.id}:main`)).toEqual(cursor);
   });
 
-  it("mints next-firing authority for an approved agentic call with no parked continuation", async () => {
+  it("mints next-firing authority when an agentic run's approval is granted", async () => {
     const doc = app("app_agent_next", {
       on: { kind: "host-event", event: "go" },
       run: { kind: "agentic", prompt: "write later" },
     });
     await seedApp(store, doc, "user_a", true);
-    const engine = createAutomations({
+    // Constructing the engine is the whole subject here: that is what registers
+    // the guard's onApprovalDecision callback the decision below travels through.
+    createAutomations({
       apps: appsDouble(), tools: registry([writeTool]), guard, store, now: () => NOW,
     });
     const request = {
@@ -311,7 +310,6 @@ describe("automations enable and grant capture", () => {
     expect((await store.records("vendo_approvals").get(request.id))?.data).toMatchObject({
       consumedAt: NOW.toISOString(),
     });
-    void engine;
   });
 });
 

--- a/packages/automations/src/engine.test.ts
+++ b/packages/automations/src/engine.test.ts
@@ -86,7 +86,7 @@ class GuardDouble implements Guard {
   store?: StoreAdapter;
   private readonly callbacks = new Set<(id: ApprovalId, approved: boolean) => void>();
 
-  /** AGENT-6, the real guard's contract in miniature: deny as `system` (never a
+  /** The real guard's contract in miniature: deny as `system` (never a
    *  standing no), idempotent, mint nothing, then fire the decision callbacks
    *  the same way an explicit denial does. */
   async abandonApprovals(ids: ApprovalId[]): Promise<void> {
@@ -1296,7 +1296,7 @@ describe("schedule, webhook, and host triggers", () => {
   });
 });
 
-// wave 2 (Cloud auto): under the hosted store, Vendo Cloud's own scheduler and Composio
+// Under the hosted store, Vendo Cloud's own scheduler and Composio
 // delivery already fire schedule/external automations for the deployment — the local engine
 // composed alongside it must not ALSO fire them (double-run). `localTriggerKinds` scopes which
 // trigger kinds this engine instance fires; host-event (vendo.emit) is never gated by it.

--- a/packages/automations/src/engine.test.ts
+++ b/packages/automations/src/engine.test.ts
@@ -1231,6 +1231,71 @@ describe("schedule, webhook, and host triggers", () => {
       receivedAt: NOW.toISOString(),
     });
   });
+
+  it("refs the schedule cursor, webhook secret, and delivery to their app so app erase collects them", async () => {
+    const store = memoryStoreAdapter();
+    const external = app("app_refs_webhook", {
+      on: { kind: "external", connector: "github", event: "push" },
+      run: { kind: "steps", steps: [] },
+    });
+    const scheduled = app("app_refs_schedule", {
+      on: { kind: "schedule", every: "15m" },
+      run: { kind: "steps", steps: [] },
+    });
+    await seedApp(store, external);
+    await seedApp(store, scheduled);
+    const engine = createAutomations({
+      apps: appsDouble(), tools: registry(), guard: new GuardDouble(), store, now: () => NOW,
+    });
+    await engine.enable(external.id, "main", ctx());
+    await engine.enable(scheduled.id, "main", ctx());
+    const secret = ((await store.records("automations:webhook").get(`${external.id}:main`))?.data as { secret: string }).secret;
+    const body = JSON.stringify({ answer: 42 });
+    const timestamp = String(NOW.getTime() / 1_000);
+    const signature = await sign(secret, "delivery_refs", timestamp, body);
+    await engine.webhook(new Request("https://example.test/api/webhooks/github", {
+      method: "POST",
+      headers: {
+        "webhook-id": "delivery_refs",
+        "webhook-timestamp": timestamp,
+        "webhook-signature": `v1,${signature}`,
+      },
+      body,
+    }));
+
+    expect((await store.records("automations:webhook").get(`${external.id}:main`))?.refs)
+      .toEqual({ app_id: external.id });
+    expect((await store.records("automations:deliveries").get(`${external.id}:main:delivery_refs`))?.refs)
+      .toEqual({ app_id: external.id });
+    expect((await store.records("automations:schedule").get(`${scheduled.id}:main`))?.refs)
+      .toEqual({ app_id: scheduled.id });
+  });
+
+  it("refs a schedule cursor the tick itself writes, on both the claiming and the not-yet-due path", async () => {
+    const store = memoryStoreAdapter();
+    const due = app("app_refs_tick_due", {
+      on: { kind: "schedule", every: "15m" },
+      run: { kind: "steps", steps: [] },
+    });
+    const future = app("app_refs_tick_future", {
+      on: { kind: "schedule", at: "2026-07-12T13:00:00.000Z" },
+      run: { kind: "steps", steps: [] },
+    });
+    await seedApp(store, due, "user_a", true);
+    await seedApp(store, future, "user_a", true);
+    // No cursor rows yet: the tick is what writes both, and the app row alone
+    // is what an erase would otherwise leave them behind from.
+    const engine = createAutomations({
+      apps: appsDouble(), tools: registry(), guard: new GuardDouble(), store, now: () => NOW,
+    });
+
+    await engine.tick();
+
+    expect((await store.records("automations:schedule").get(`${due.id}:main`))?.refs)
+      .toEqual({ app_id: due.id });
+    expect((await store.records("automations:schedule").get(`${future.id}:main`))?.refs)
+      .toEqual({ app_id: future.id });
+  });
 });
 
 // wave 2 (Cloud auto): under the hosted store, Vendo Cloud's own scheduler and Composio

--- a/packages/automations/src/engine.ts
+++ b/packages/automations/src/engine.ts
@@ -581,27 +581,17 @@ export const createAutomationsEngine = (config: AutomationsConfig): AutomationsE
    * Move any pre-rekey schedule cursor onto its (app, trigger) key, and return the
    * rows the tick should read for the keys that were missing.
    *
-   * The cursor moved from the bare `appId` to `<appId>:<triggerId>` when an app
-   * became a LIST of triggers. `automations:schedule` is a GENERIC collection keyed
-   * by row id, and nothing rewrites generic row ids — the reserved store migrates
-   * itself through generated columns over reserved TABLES, which this is not — so
-   * the old row is invisible on every store, not just a host-supplied one.
+   * The cursor moved from the bare `appId` when an app became a LIST of triggers,
+   * and no store rewrites GENERIC row ids, so the old row is invisible everywhere.
+   * A cursor the tick cannot find reads as "start the clock now" (so a new
+   * schedule does not backfill every window since the epoch) — applied to one that
+   * merely moved, that silently restarts a running automation's clock.
    *
-   * Invisible does not read as "overdue", which would be far worse: a cursor the
-   * tick cannot find is read as "start the clock now", deliberately, so a schedule
-   * discovered for the first time does not fire for every window since the epoch.
-   * Applied to a cursor that merely MOVED, that silently restarts a running
-   * automation's clock — it skips the firing it was due for and comes back up to
-   * one interval late, with nothing anywhere saying so.
-   *
-   * The state is carried VERBATIM (`lastFiredAt`, and `firedAt` for a one-shot
-   * `at:` schedule), because it is the automation's own history and rewriting it
-   * would either skip a window or replay one. Only trigger `main` is looked for:
-   * that is the id a pre-list document's one trigger normalizes to, so no other
-   * trigger can have a bare-id cursor. The old row is deleted once carried, so it
-   * can never be read again and dragged over a cursor that has since moved on; a
-   * row that will not parse is left exactly where it is, unreadable but not
-   * destroyed, and the tick treats it as the missing cursor it already was.
+   * State is carried VERBATIM: it is the automation's own history, and rewriting
+   * it would skip a window or replay one. Only `main` can have a bare-id cursor.
+   * The old row is deleted once carried so it can never drag a newer cursor
+   * backwards; an unparseable one is left alone and stays the missing cursor it
+   * already was. Proven by schedule-cursor.test.ts.
    */
   const migratePreRekeyCursors = async (
     records: RecordStore,
@@ -618,6 +608,7 @@ export const createAutomationsEngine = (config: AutomationsConfig): AutomationsE
       carried.push(await records.put({
         id: triggerKey(record.id, DEFAULT_TRIGGER_ID),
         data: { ...parsed.data },
+        refs: appRef(record.id),
       }));
       await records.delete(record.id);
     }
@@ -627,20 +618,17 @@ export const createAutomationsEngine = (config: AutomationsConfig): AutomationsE
   /**
    * The app rows that fire on this trigger kind, under EITHER ref spelling.
    *
-   * An app has a LIST of triggers, so "which kind does this app fire on" is a SET
-   * and a ref is matched by equality — which is why one `trigger_kind: "<kind>"`
-   * ref became one key per kind. The RESERVED store re-derives its refs from
-   * generated columns over the document, so it migrated every existing row the
-   * moment the column existed. A host-supplied adapter does not: 01-core §12 says
-   * a generic adapter stores the refs it is GIVEN, so its pre-list rows still
-   * carry the old key and nothing rewrites them. Asking only the new key took
-   * every automation armed before the rename dark on BYO storage — no error, no
-   * run row, no audit event, which is the one failure mode an automation may
-   * never have.
+   * One `trigger_kind: "<kind>"` ref became one key per kind when an app got a
+   * LIST of triggers (a ref matches by equality; "which kinds" is a set). The
+   * RESERVED store re-derives refs from generated columns, so it migrated itself;
+   * a host-supplied adapter stores the refs it is GIVEN (01-core §12) and its
+   * pre-list rows still carry the old key. Asking only the new key took every
+   * automation armed before the rename dark on BYO storage — no error, no run
+   * row, no audit event, the one failure mode an automation may never have.
    *
-   * So both are asked and the rows are deduped by id. The old-key query ages out
-   * on its own rather than needing a sweep: `writeApp` re-derives refs from the
-   * document, so the first arm, disarm or edit moves that row onto the new keys.
+   * So both are asked and deduped by id. The old-key query ages out without a
+   * sweep: `writeApp` re-derives refs, so the first arm, disarm or edit moves the
+   * row across. Proven by byo-refs.test.ts.
    */
   const appsFiringOn = async (
     kind: TriggerSource["kind"],
@@ -682,11 +670,10 @@ export const createAutomationsEngine = (config: AutomationsConfig): AutomationsE
    * armed only when BOTH say so: the app-level `enabled` the apps runtime owns,
    * and the trigger's OWN armed row.
    *
-   * There is deliberately no "enabled but no rows ⇒ all of them" fallback. That
-   * read was authority-widening for any writer that sets `enabled` without armed
-   * rows — a trigger added to the list later would fire without anyone having
-   * armed it. The pre-list state it existed for is MIGRATED in {@link armedFor}
-   * instead, which names the one trigger it always meant.
+   * There is deliberately no "enabled but no rows ⇒ all of them" fallback: it was
+   * authority-widening, since a trigger added to the list later would fire
+   * without anyone having armed it. The pre-list state it existed for is MIGRATED
+   * in {@link armedFor} instead, which names the one trigger it always meant.
    */
   const armedTriggers = (row: AppRow, armed: ReadonlySet<string>): Trigger[] =>
     row.enabled
@@ -698,11 +685,10 @@ export const createAutomationsEngine = (config: AutomationsConfig): AutomationsE
    *
    * "Enabled with no per-trigger armed row at all" is the on-disk state of every
    * automation armed before triggers were a list, and it must not go quietly
-   * dark — that is the one failure mode an automation may never have. So the
-   * state is resolved ONCE, here, by seeding the armed row it always meant:
-   * `main`, the id read normalization gives a single-`trigger` document's one
-   * trigger. Deterministic (it names one id, never "whatever the list holds now")
-   * and idempotent (the row it writes is what makes the next read skip this).
+   * dark. Resolved ONCE, here, by seeding the row it always meant: `main`, the id
+   * a single-`trigger` document normalizes to. Deterministic (one id, never
+   * "whatever the list holds now") and idempotent (the row it writes is what
+   * makes the next read skip this).
    */
   const armedFor = async (rows: readonly AppRow[]): Promise<Set<string>> => {
     // ONE query for every (app, trigger) key, so per-trigger arming is not an
@@ -1868,10 +1854,10 @@ export const createAutomationsEngine = (config: AutomationsConfig): AutomationsE
   /**
    * Every sponsorship row for these apps' triggers, in ONE query — and the
    * pre-list rekey, because the LIST is where a person reads who an automation
-   * runs as (§13) and whether it stopped. A row that is invisible here
-   * does not merely go missing: both sentences then answer with the app's OWNER,
-   * so an automation someone else took on reads as the reader's own, and a
-   * STOPPED one shows no stopped line and no way back to it.
+   * runs as (§13) and whether it stopped. A row that is invisible here does not
+   * merely go missing: both sentences then answer with the app's OWNER, so an
+   * automation someone else took on reads as the reader's own, and a STOPPED one
+   * shows no stopped line and no way back to it.
    *
    * The batch is kept. Only a `main` key that MISSED can be pre-list, and those
    * app ids are probed in one further batched read; a deployment with no pre-list
@@ -1909,13 +1895,12 @@ export const createAutomationsEngine = (config: AutomationsConfig): AutomationsE
     const records = await allRecords(config.store.records(APPS), { refs: { subject } });
     const rows = records.map(parseAppRow).filter((row) => row.subject === subject);
     const seen = new Set(rows.map((row) => row.doc.id));
-    // An ORG-held app's row subject is the org id (§9.5), so matching
-    // the caller's own subject listed a promoted automation for NOBODY: not the
-    // members, not the org admin, not even the person who promoted it. Promote
-    // deliberately disarms the automation and tells the promoter it "stays off
-    // until someone turns it back on" — a promise nothing could keep while the
-    // only surface that mentions it hid it. The orgs come from the ctx (§9.1:
-    // asserted, never stored) and `can(editor)` still decides each row.
+    // An ORG-held app's row subject is the org id (§9.5), so matching only the
+    // caller's own subject listed a promoted automation for NOBODY — not the
+    // members, not the org admin, not the person who promoted it — while promote
+    // tells that person it "stays off until someone turns it back on". The orgs
+    // come from the ctx (§9.1: asserted, never stored) and `can(editor)` still
+    // decides each row.
     for (const org of new Set((ctx.memberships ?? []).map(({ org: id }) => id))) {
       for (const record of await allRecords(config.store.records(APPS), { refs: { subject: org } })) {
         const row = parseAppRow(record);

--- a/packages/automations/src/engine.ts
+++ b/packages/automations/src/engine.ts
@@ -93,6 +93,13 @@ const ARMED = "automations:armed";
 const WEBHOOK_MAX_BYTES = 1024 * 1024;
 const FOREACH_MAX_ITEMS = 1000;
 
+/** Every engine-owned generic row belongs to ONE app, and the 02-store §5 erase
+ *  cascade collects generic rows by `refs @> {app_id}` — so a row written
+ *  without this ref outlives the app forever. That is not only clutter: a
+ *  webhook secret is a live signing key, and the delivery ledger has no other
+ *  lifecycle at all. */
+const appRef = (appId: string): Record<string, string> => ({ app_id: appId });
+
 const appRowSchema = z.object({
   subject: z.string(),
   enabled: z.boolean(),
@@ -1844,14 +1851,14 @@ export const createAutomationsEngine = (config: AutomationsConfig): AutomationsE
     if (trigger.on.kind === "schedule") {
       const cursor = await config.store.records(SCHEDULE).get(key);
       if (cursor === null) {
-        await config.store.records(SCHEDULE).put({ id: key, data: { lastFiredAt: iso() } });
+        await config.store.records(SCHEDULE).put({ id: key, data: { lastFiredAt: iso() }, refs: appRef(appId) });
       }
     }
     if (trigger.on.kind === "external") {
       const secret = await config.store.records(WEBHOOK).get(key);
       if (secret === null) {
         const bytes = globalThis.crypto.getRandomValues(new Uint8Array(32));
-        await config.store.records(WEBHOOK).put({ id: key, data: { secret: base64url(bytes) } });
+        await config.store.records(WEBHOOK).put({ id: key, data: { secret: base64url(bytes) }, refs: appRef(appId) });
       }
     }
     return { enabled: true, missing, ...(missing.length === 0 ? {} : { grantSetId }) };
@@ -2088,6 +2095,10 @@ export const createAutomationsEngine = (config: AutomationsConfig): AutomationsE
       const trigger = validateTrigger(declared);
       if (trigger.on.kind !== "schedule") continue;
       const cursorKey = triggerKey(row.doc.id, trigger.id);
+      // Every write of this row restates the ref, including the compare-and-swap
+      // replacement: a put that omitted it would strip the app ref the enable
+      // wrote and re-orphan the cursor on the very next tick.
+      const cursorRow = (data: Json) => ({ id: cursorKey, data, refs: appRef(row.doc.id) });
       const cursorRecord = cursorById.get(cursorKey) ?? null;
       const cursor = cursorRecord === null
         ? { lastFiredAt: at.toISOString() }
@@ -2105,8 +2116,8 @@ export const createAutomationsEngine = (config: AutomationsConfig): AutomationsE
       }
       if (scheduledFor === undefined) {
         if (cursorRecord === null) {
-          if (scheduleRecords.atomic === undefined) await scheduleRecords.put({ id: cursorKey, data: cursor });
-          else await scheduleRecords.atomic.insertIfAbsent({ id: cursorKey, data: cursor });
+          if (scheduleRecords.atomic === undefined) await scheduleRecords.put(cursorRow(cursor));
+          else await scheduleRecords.atomic.insertIfAbsent(cursorRow(cursor));
         }
         continue;
       }
@@ -2117,15 +2128,12 @@ export const createAutomationsEngine = (config: AutomationsConfig): AutomationsE
       };
       let claimed = true;
       if (cursorRecord === null) {
-        if (scheduleRecords.atomic === undefined) await scheduleRecords.put({ id: cursorKey, data: nextCursor });
-        else claimed = await scheduleRecords.atomic.insertIfAbsent({ id: cursorKey, data: nextCursor }) !== null;
+        if (scheduleRecords.atomic === undefined) await scheduleRecords.put(cursorRow(nextCursor));
+        else claimed = await scheduleRecords.atomic.insertIfAbsent(cursorRow(nextCursor)) !== null;
       } else if (scheduleRecords.atomic !== undefined && cursorRecord.revision !== undefined) {
-        claimed = await scheduleRecords.atomic.compareAndSwap(
-          { id: cursorKey, data: nextCursor },
-          cursorRecord.revision,
-        ) !== null;
+        claimed = await scheduleRecords.atomic.compareAndSwap(cursorRow(nextCursor), cursorRecord.revision) !== null;
       } else {
-        await scheduleRecords.put({ id: cursorKey, data: nextCursor });
+        await scheduleRecords.put(cursorRow(nextCursor));
       }
       if (!claimed) continue;
       fired.push({ row, trigger, scheduledFor, firedAt: atIso });
@@ -2306,6 +2314,7 @@ export const createAutomationsEngine = (config: AutomationsConfig): AutomationsE
             deliveryId: headerResult.data.id,
             receivedAt: iso(),
           },
+          refs: appRef(row.doc.id),
         };
         if (deliveries.atomic === undefined) {
           if (await deliveries.get(deliveryKey) !== null) {

--- a/packages/automations/src/engine.ts
+++ b/packages/automations/src/engine.ts
@@ -265,7 +265,7 @@ const stopFor = (
 ): { reason: NonNullable<Sponsorship["reason"]>; summary: string } =>
   ({ reason, summary: SPONSORSHIP_STOP[reason](automationName) });
 
-/** §9.9 + F10 — what a run says when the identity checks could not ANSWER (the
+/** §9.9 — what a run says when the identity checks could not ANSWER (the
  *  host's memberships callback or access seam threw). The raw failure is a host
  *  system's error text — a DSN, a stack, a driver message — and the run row is
  *  rendered verbatim to consumers (`automations-panel.tsx` prints `summary` and
@@ -906,8 +906,8 @@ export const createAutomationsEngine = (config: AutomationsConfig): AutomationsE
 
   /** The run's context before any seam is consulted — a pure function of the run
    *  and a subject, so it cannot fail. It is what a failed identity resolution
-   *  still audits under (F10: a fire that cannot even resolve who it runs as
-   *  must leave a record, not vanish). */
+   *  still audits under: a fire that cannot even resolve who it runs as must
+   *  leave a record, not vanish. */
   const baseRunContext = (run: InternalRunRecord, subject: string): RunContext => ({
     principal: { kind: "user", subject },
     venue: "automation",
@@ -1387,8 +1387,8 @@ export const createAutomationsEngine = (config: AutomationsConfig): AutomationsE
           ctx = await runContext(app.doc, record, app.subject);
           stop = await sponsorshipRefusal(app, trigger, ctx);
         } catch (error) {
-          // F10 — the consumer sentence and the operator's detail part ways
-          // here: `summary` is rendered verbatim in the automations panel, so
+          // The consumer sentence and the operator's detail part ways here:
+          // `summary` is rendered verbatim in the automations panel, so
           // the host's raw throw rides the audit row below instead.
           stop = { summary: IDENTITY_UNAVAILABLE(app.doc.name), detail: message(error) };
         }
@@ -1868,7 +1868,7 @@ export const createAutomationsEngine = (config: AutomationsConfig): AutomationsE
   /**
    * Every sponsorship row for these apps' triggers, in ONE query — and the
    * pre-list rekey, because the LIST is where a person reads who an automation
-   * runs as (§13) and whether it stopped (E8-F2). A row that is invisible here
+   * runs as (§13) and whether it stopped. A row that is invisible here
    * does not merely go missing: both sentences then answer with the app's OWNER,
    * so an automation someone else took on reads as the reader's own, and a
    * STOPPED one shows no stopped line and no way back to it.
@@ -1909,7 +1909,7 @@ export const createAutomationsEngine = (config: AutomationsConfig): AutomationsE
     const records = await allRecords(config.store.records(APPS), { refs: { subject } });
     const rows = records.map(parseAppRow).filter((row) => row.subject === subject);
     const seen = new Set(rows.map((row) => row.doc.id));
-    // E8-F1 — an ORG-held app's row subject is the org id (§9.5), so matching
+    // An ORG-held app's row subject is the org id (§9.5), so matching
     // the caller's own subject listed a promoted automation for NOBODY: not the
     // members, not the org admin, not even the person who promoted it. Promote
     // deliberately disarms the automation and tells the promoter it "stays off
@@ -1931,7 +1931,7 @@ export const createAutomationsEngine = (config: AutomationsConfig): AutomationsE
     // sponsorship rows are ref'd by subject, so this is one indexed query, never
     // a scan of everybody's apps.
     //
-    // E8-F2 — INVALIDATED rows are included on purpose: a stopped automation
+    // INVALIDATED rows are included on purpose: a stopped automation
     // must not vanish from here, or there is no way back to it at all.
     // Deduped: sponsorship is per (app, trigger), so sponsoring two triggers of
     // one app must still fetch that app once.
@@ -1990,7 +1990,7 @@ export const createAutomationsEngine = (config: AutomationsConfig): AutomationsE
           const sponsorship = sponsorRows.get(key);
           const sponsor = sponsorship?.sponsor ?? row.subject;
           const display = sponsorship?.display ?? (sponsor === subject ? ctx.principal.display : undefined);
-          // E8-F2 — a stopped automation says so HERE, in the same sentence the
+          // A stopped automation says so HERE, in the same sentence the
           // stopped run row uses, so the list is a way back to it rather than a
           // place it silently disappeared from.
           const stopped = sponsorship?.status === "invalidated"

--- a/packages/automations/src/engine.ts
+++ b/packages/automations/src/engine.ts
@@ -22,7 +22,6 @@ import {
   type Json,
   type PermissionGrant,
   type GrantScope,
-  type Principal,
   type RecordStore,
   type RunContext,
   type RunId,
@@ -72,23 +71,20 @@ const CAPTURES = "automations:captures";
 const SCHEDULE = "automations:schedule";
 const WEBHOOK = "automations:webhook";
 const DELIVERIES = "automations:deliveries";
-/**
- * Which TRIGGERS of an app are armed — one row per armed (app, trigger),
- * engine-owned like `automations:captures`, so the generic records door is right
- * here.
- *
- * It is a second fact beside the app row's `enabled` boolean deliberately, and
- * the two mean different things: `enabled` is the APP-level arm the apps runtime
- * already owns (a trigger edit disarms the whole app there, §9.9), this is the
- * per-trigger arm a person turns on and off. A firing needs BOTH, so the
- * existing app-level disarm keeps working untouched and turning one trigger off
- * never reaches another.
- */
 /** The app row's trigger-kind ref BEFORE the trigger list: one key holding one
  *  kind. Kept only so the queries below can still find a row nobody has
  *  rewritten yet — nothing writes it any more. */
 const PRE_LIST_TRIGGER_KIND_REF = "trigger_kind";
-
+/**
+ * Which TRIGGERS of an app are armed — one row per armed (app, trigger).
+ *
+ * A second fact beside the app row's `enabled` boolean deliberately, and the two
+ * mean different things: `enabled` is the APP-level arm the apps runtime already
+ * owns (a trigger edit disarms the whole app there, §9.9), this is the
+ * per-trigger arm a person turns on and off. A firing needs BOTH, so the
+ * existing app-level disarm keeps working untouched and turning one trigger off
+ * never reaches another.
+ */
 const ARMED = "automations:armed";
 const WEBHOOK_MAX_BYTES = 1024 * 1024;
 const FOREACH_MAX_ITEMS = 1000;

--- a/packages/automations/src/index.ts
+++ b/packages/automations/src/index.ts
@@ -31,7 +31,7 @@ export { triggerKey } from "./sponsorship.js";
 export { UNATTENDED_IRREVERSIBILITY_RULE, unattendedIrreversibilityCheck } from "./law.js";
 
 /** Build contract §9.3's `can()`, as much of it as the engine needs — taken as
- *  config so this package never reaches sideways into the store. Lane G's
+ *  config so this package never reaches sideways into the store. The umbrella's
  *  `appAccess(store)` satisfies it as-is; absent, `can(editor)` degenerates to
  *  ownership, which is exactly the rule before app-access grants existed. */
 export interface AppAccessSeam {
@@ -41,7 +41,7 @@ export interface AppAccessSeam {
     thing: { app: AppId },
   ): Promise<boolean>;
   /** The app's grant rows. Only their COUNT is read here (the window label's
-   *  wider editor set), so the row shape stays lane G's to define. */
+   *  wider editor set), so the row shape stays the access seam's to define. */
   list?(ctx: RunContext, appId: AppId): Promise<readonly unknown[]>;
 }
 
@@ -129,9 +129,9 @@ export interface RunPlan {
 /** 07 §1 */
 export interface AutomationsEngine {
   /** Arm/disarm ONE trigger of an app. Enabling runs the grant-capture flow
-   *  (07 §3) for that trigger alone. `grantSetId` (additive — 07 §1 amendment
-   *  parked) names the ONE grant set the `missing` asks belong to, so a single
-   *  decision can settle them all; present exactly when `missing` is non-empty. */
+   *  (07 §3) for that trigger alone. `grantSetId` names the ONE grant set the
+   *  `missing` asks belong to, so a single decision can settle them all; present
+   *  exactly when `missing` is non-empty. */
   enable(
     appId: AppId,
     triggerId: string,
@@ -147,10 +147,9 @@ export interface AutomationsEngine {
     triggers: Array<{
       trigger: Trigger;
       enabled: boolean;
-      /** `pendingGrants`/`grantSetId` (additive — 07 §1 amendment parked) project
-       *  this trigger's still-undecided standing-grant asks, so surfaces can show
-       *  "waiting on N permissions" after a reload instead of trusting an
-       *  enable() result held in memory. */
+      /** `pendingGrants`/`grantSetId` project this trigger's still-undecided
+       *  standing-grant asks, so surfaces can show "waiting on N permissions"
+       *  after a reload instead of trusting an enable() result held in memory. */
       pendingGrants?: number;
       grantSetId?: string;
       /** §13 — who this trigger runs as, for its window label ("runs with
@@ -160,9 +159,9 @@ export interface AutomationsEngine {
       sponsor?: { subject: string; display?: string };
       /** Set exactly while this trigger is STOPPED. `summary` is the same
        *  consumer sentence the stopped run row carries, so the list is a route
-       *  back to a paused automation instead of the one place it vanished from
-       *  (E8-F2). It never names the sponsor: this string is read by anyone who
-       *  can edit the app. */
+       *  back to a paused automation instead of the one place it vanished from.
+       *  It never names the sponsor: this string is read by anyone who can edit
+       *  the app. */
       stopped?: { reason: "edit" | "departure" | "grants"; summary: string };
     }>;
     /** How many principals hold a grant on the app, when an access seam is

--- a/packages/automations/src/index.ts
+++ b/packages/automations/src/index.ts
@@ -27,7 +27,7 @@ import type {
 import type { AppsRuntime } from "@vendoai/apps";
 import { createAutomationsEngine } from "./engine.js";
 
-export { appIntentOf, SPONSORSHIPS, triggerKey, type Sponsorship } from "./sponsorship.js";
+export { triggerKey } from "./sponsorship.js";
 export { UNATTENDED_IRREVERSIBILITY_RULE, unattendedIrreversibilityCheck } from "./law.js";
 
 /** Build contract §9.3's `can()`, as much of it as the engine needs — taken as

--- a/packages/automations/src/schedule-cursor.test.ts
+++ b/packages/automations/src/schedule-cursor.test.ts
@@ -75,9 +75,9 @@ describe("pre-rekey schedule cursors", () => {
     apps: appsDouble(), tools, guard: new GuardDouble(), store, now: () => NOW,
   });
 
-  /** An armed hourly automation whose cursor sits where the code used to put it,
-   *  last fired three hours ago — so it is two windows overdue right now. */
-  async function seedPreRekey(id: string): Promise<AppDocument> {
+  /** An armed hourly automation whose cursor sits where the code used to put it.
+   *  Three hours ago by default, so it is two windows overdue right now. */
+  async function seedPreRekey(id: string, lastFiredHoursAgo = 3): Promise<AppDocument> {
     const doc = hourly(id);
     await store.records("vendo_apps").put({
       id: doc.id,
@@ -86,7 +86,7 @@ describe("pre-rekey schedule cursors", () => {
     });
     await store.records(SCHEDULE).put({
       id: doc.id,
-      data: { lastFiredAt: new Date(NOW.getTime() - 3 * HOUR).toISOString() },
+      data: { lastFiredAt: new Date(NOW.getTime() - lastFiredHoursAgo * HOUR).toISOString() },
     });
     return doc;
   }
@@ -110,6 +110,16 @@ describe("pre-rekey schedule cursors", () => {
     // …and the row it came from is gone, so it can never be read again and
     // re-migrated over a cursor that has since moved on.
     expect(await store.records(SCHEDULE).get(doc.id)).toBeNull();
+  });
+
+  it("gives the carried cursor the app ref its pre-rekey row never had", async () => {
+    // Not due, so the tick writes nothing after the move: the ref has to come
+    // from the move itself, or the app-erase cascade can never collect this row.
+    const doc = await seedPreRekey("app_cursor_refs", 0.5);
+
+    expect(await engine().tick(NOW)).toEqual([]);
+
+    expect((await store.records(SCHEDULE).get(`${doc.id}:main`))?.refs).toEqual({ app_id: doc.id });
   });
 
   it("does not resurrect a pre-rekey cursor once the pair key already has one", async () => {

--- a/packages/automations/src/schedule-cursor.test.ts
+++ b/packages/automations/src/schedule-cursor.test.ts
@@ -92,7 +92,7 @@ describe("pre-rekey schedule cursors", () => {
   }
 
   it("fires an overdue automation whose cursor predates the (app, trigger) rekey", async () => {
-    const doc = await seedPreRekey("app_cursor_due");
+    await seedPreRekey("app_cursor_due");
 
     const fired = await engine().tick(NOW);
 

--- a/packages/automations/src/sponsorship.test.ts
+++ b/packages/automations/src/sponsorship.test.ts
@@ -141,7 +141,7 @@ const setSponsorship = async (store: StoreAdapter, row: Sponsorship): Promise<vo
   await store.records(SPONSORSHIPS).put({ id: triggerKey(row.appId, row.triggerId), data: row, refs: { subject: row.sponsor } });
 };
 
-/** `can(editor)` as lane G freezes it (§9.3), stubbed: editor for the listed
+/** `can(editor)` (§9.3), stubbed: editor for the listed
  *  subjects, nobody else. Automations takes it as config and never imports
  *  the store, so this stub is the same shape production wires. The set is
  *  mutable so a test can REVOKE access the way a real revoke does. */
@@ -297,7 +297,7 @@ describe("sponsorship — the fire-time gate", () => {
   });
 });
 
-/** F1 (verifier repro), re-run half — a run that met a missing permission fails
+/** A run that met a missing permission fails
  *  loudly, and the remedy is a FRESH run through `runs.rerun`. That is a second
  *  firing through a different door, so the fire-time gate has to run again there
  *  too: a third party editing the document between the failure and the re-run
@@ -478,7 +478,7 @@ describe("sponsorship — invalidation on a third party's edit", () => {
   });
 });
 
-/** F3 — the sponsorship row carries the sponsor's subject, so a subject erase
+/** The sponsorship row carries the sponsor's subject, so a subject erase
  *  DELETES it. Without a trace that the app was ever sponsored, the fire-time
  *  gate would read "no sponsorship" and quietly hand the automation back to the
  *  app's owner. The era marker is that trace: keyed to the app only, so a
@@ -532,14 +532,14 @@ describe("sponsorship — an erased sponsor", () => {
   });
 });
 
-/** F9 — nothing a person reads should say `user_dana`. The sponsor's own
+/** Nothing a person reads should say `user_dana`. The sponsor's own
  *  display name is captured at enable (their Principal carries it) and used
  *  everywhere the automation talks about them. */
 describe("sponsorship — consumer-voice names", () => {
   it("captures the sponsor's display name, and keeps it off the run summary", async () => {
-    // F8 (wave-3 check) moved the NAME off the persisted run summary: the run
-    // row outlives a subject erase, the sponsorship row does not. The
-    // consumer-voice law is unchanged — nothing a person reads says `user_dana`.
+    // The NAME stays off the persisted run summary: the run row outlives a
+    // subject erase, the sponsorship row does not. The consumer-voice law is
+    // unchanged — nothing a person reads says `user_dana`.
     const app = doc("app_named");
     const { store, engine } = harness();
     await seedApp(store, app);
@@ -555,7 +555,7 @@ describe("sponsorship — consumer-voice names", () => {
   });
 });
 
-/** F10 — the identity checks call HOST code (a memberships callback, an access
+/** The identity checks call HOST code (a memberships callback, an access
  *  seam). They run before the run row is written, and the schedule path swallows
  *  a rejected run, so a throw there used to make the whole firing vanish: no
  *  row, no audit, nothing to look at. */
@@ -585,7 +585,7 @@ describe("sponsorship — a broken identity seam", () => {
     expect(runId).toBeDefined();
     const run = await engine.runs.get(runId!, ctx());
     expect(run).toMatchObject({ status: "error" });
-    // F10 (wave-3 check): the host's raw throw is the AUDIT row's, never the
+    // The host's raw throw is the AUDIT row's, never the
     // consumer's — the panel renders `summary` and `error.message` verbatim.
     expect(run?.error?.message).not.toContain("host directory is down");
     expect(guard.audit.some((event) =>
@@ -633,7 +633,7 @@ describe("sponsorship — a broken identity seam", () => {
 
     // The host's directory dies between the failure and the re-run: the fresh
     // run cannot check who it runs as, so it must land a loud terminal row of
-    // its own rather than sit in "running" forever (F10, the re-run half).
+    // its own rather than sit in "running" forever.
     breakSeam = true;
     guard.decide("apr_seam", true);
     await flush();
@@ -658,7 +658,7 @@ describe("sponsorship — a broken identity seam", () => {
   });
 });
 
-/** F12 — the consent rows are generic records, and the 02-store §5 erase cascade
+/** The consent rows are generic records, and the 02-store §5 erase cascade
  *  finds generic rows by their REFS. Without them a subject erase (or an app
  *  delete) leaves the automation's pending asks behind. */
 describe("sponsorship — consent rows join the erase cascade", () => {
@@ -696,7 +696,7 @@ describe("sponsorship — consent rows join the erase cascade", () => {
   });
 });
 
-/** F6 — an automation runs as its SPONSOR, who may not own the app. §8's
+/** An automation runs as its SPONSOR, who may not own the app. §8's
  *  editor = edit, so every door the owner has is the editor's too — otherwise
  *  the person it runs as cannot see it, pause it, or stop it. */
 describe("sponsorship — an editor's doors", () => {
@@ -789,8 +789,8 @@ describe("sponsorship — the window label", () => {
   });
 });
 
-/** F8/F10/F18 (wave-3 independent check) — what a STOPPED run is allowed to
- *  leave behind. Two constraints meet on the same row:
+/** What a STOPPED run is allowed to leave behind. Two constraints meet on the
+ *  same row:
  *
  *  1. It is read by people: `automations-panel.tsx` renders `summary` and
  *     `error.message` verbatim.
@@ -875,8 +875,7 @@ describe("sponsorship — what the stopped run row is allowed to say", () => {
   });
 });
 
-/** E8-F1/E8-F2 (live browser proof, 2026-08-01) — the two ways an automation
- *  became BUILT BUT UNREACHABLE. `list` is the only surface that mentions an
+/** The two ways an automation became BUILT BUT UNREACHABLE. `list` is the only surface that mentions an
  *  automation outside the app itself, so anything it hides is, in practice, gone:
  *  promote deliberately disarms the automation and the Share dialog promises it
  *  "stays off until someone turns it back on", and an invalidated sponsorship
@@ -930,8 +929,7 @@ describe("sponsorship — an automation the caller can edit is an automation the
   });
 });
 
-/** ORCHESTRATOR RULING 2026-08-01 (handoff #5, derived from the locked model) —
- *  an event emitted by a MEMBER of the org fires that org's automations.
+/** An event emitted by a MEMBER of the org fires that org's automations.
  *
  *  `emit` matched apps by the emitter's own subject, so an ORG-owned host-event
  *  automation could never be fired by anybody: the row subject is the org id

--- a/packages/automations/src/sponsorship.ts
+++ b/packages/automations/src/sponsorship.ts
@@ -113,9 +113,13 @@ export const currentIntentHash = (doc: AppDocument, trigger: Trigger | undefined
   intentHash(appIntentOf(doc, trigger));
 
 /** The stored sponsorship, or undefined when there is none (an automation
- *  enabled before sponsorship shipped) or the row is unreadable. A corrupt row
- *  is not a sponsorship — it degenerates to the pre-sponsorship behavior of
- *  running as the app's owner rather than stranding the automation. */
+ *  enabled before sponsorship shipped) or the row is unreadable.
+ *
+ *  A corrupt row therefore reads as NO row, which the caller resolves against
+ *  the {@link SPONSORED} era marker — and since every sponsorship write stamps
+ *  that marker, the automation fails CLOSED (it stops) rather than falling back
+ *  to running as the app's owner. That is the intended answer: an unreadable
+ *  sponsorship is not evidence that nobody took the automation on. */
 export const readSponsorship = async (
   records: RecordStore,
   appId: string,


### PR DESCRIPTION
Sweep of the `@vendoai/automations` catalog section, worst-first: correctness
bugs, then dead code, then verbosity. Every finding in the section is
dispositioned below.

## Worked

### 1. HIGH — engine-owned generic rows survive app erase (`fix`, test first)

The 02-store §5 app-erase cascade collects generic rows by `refs @> {app_id}`
(`packages/store/src/erase.ts:229`). Three engine-owned collections were written
with **no refs at all**, so deleting an app left them behind forever:

- `automations:webhook` — a live HMAC **signing secret**, still authenticating
  for an app that no longer exists.
- `automations:deliveries` — which has no sweep, TTL or delete anywhere in the
  repo, so it grew one permanent row per delivery.
- `automations:schedule` — the cursor.

Every other engine collection gets this right and says why (`setArmed` refs
`app_id`; `writeCapture` derives refs precisely because "an unref'd capture
outlives both the person who was asked and the app that asked").

Fixed at **five** write sites behind one `appRef()` helper — including two the
catalog did not name:

- the tick's **compare-and-swap replacement**. `put` replaces refs, so a
  replacement that omitted it would strip what `enable()` wrote on the very
  next tick;
- `migratePreRekeyCursors`, which moved a bare-appId cursor onto the pair key
  with no refs, so a cursor that migrated but was *not due* kept none.

Two failing tests first (5 new cases total), in the existing behavior-named
suites — `engine.test.ts` under "schedule, webhook, and host triggers" and
`schedule-cursor.test.ts`. Both watched fail, then fixed, separate commits.

### 2. Persisted-shape answer (this is a scheduled engine touching stored state)

**Nothing breaks and nothing needs a migration.** Every read of these three
collections is `get(rowId)` — refs are never queried on the read path, only by
the erase cascade. Rows already on disk keep working byte for byte.

The ref is stamped **forward**:

| row | when it gains the ref |
| --- | --- |
| schedule cursor | next tick that writes it (i.e. its next firing) — self-heals |
| pre-rekey cursor | the moment it migrates |
| webhook secret | next mint or rotation |
| delivery | it is a one-shot row; existing ones stay unref'd |

So a never-rotated secret on a live deployment stays orphaned until it is
rotated. That is stated rather than fixed on purpose: a backfill would be a
store migration, and this repo spent today deleting migration code, not adding
it.

### 3. MED — a comment that lied about a security behavior

`readSponsorship`'s docstring said a corrupt row "degenerates to the
pre-sponsorship behavior of running as the app's owner". It does not. A corrupt
row parses to `undefined`, the `SPONSORED` era marker is present (every
sponsorship write stamps it), so `sponsorshipState` returns `erased` and the run
**stops**. Fail-closed is the right answer — an unreadable sponsorship is not
evidence that nobody took the automation on — so the comment was corrected, not
the code. The catalog's suggested fix ("check the marker before the parse so a
corrupt row genuinely falls back to owner-run") would have been a privilege
escalation.

### 4. LOW — dead code

- Package root drops `appIntentOf`, `SPONSORSHIPS`, `Sponsorship`. Nothing
  outside this package imports them; its own tests already read
  `./sponsorship.js` directly. **`triggerKey` stays** — the catalog said nobody
  imports it, but `packages/vendo/src/wave3-integration.test.ts` and
  `automations-defer.test.ts` both import it from `@vendoai/automations`.
- `Principal` was an unused type import in `engine.ts`.
- The `ARMED` doc block had been separated from `const ARMED` by a later
  insertion and read as documentation for `PRE_LIST_TRIGGER_KIND_REF`.
- Tests: dead `storedRun` helper, a lint-silencing `void engine;`, an unused
  `doc` binding, and `AppDocument["triggers"] extends undefined ? never : ...`
  which resolves to exactly `Trigger["on"]`. A test title promised "no parked
  continuation"; parking does not exist any more (07 §5).

### 5. MED — verbosity

- The pre-list/pre-rekey essays. The **migrations stay** (see rejections), but
  each was three to five paragraphs re-deriving the same rename from first
  principles, and the same explanation appeared **seven** times in `engine.ts`.
  Each now states the constraint, the consequence, and the suite that proves it.
- Build-process exhaust stripped: F-numbers (F1/F3/F6/F8/F9/F10/F12/F18),
  E8-F1/E8-F2, `AGENT-6`, "wave 2", "wave-3 check", "lane G", "amendment
  parked", and `ORCHESTRATOR RULING 2026-08-01 (handoff #5)`. The behavioral
  sentence that followed each one is what stays.

## Moot — bugs in code deleted by #953

Both confirmed: `packages/automations/src/adoption.ts` no longer exists
(deleted in `022f78975`, "cut the automations adoption handoff").

- **§747, adoption card labels connector actions "Not reviewed"** — rejected,
  the file the bug lives in is gone.
- **§797, consent card shows raw JSONata expressions as arguments** — rejected,
  same file, same reason.

## Rejected, with reasons

- **Delete the pre-list / pre-rekey back-compat layer** (3 catalog entries, one
  already marked `refuted`). `@vendoai/automations` 0.7.0 is published and the
  0.8.0 trigger-list rename is the BREAKING change these paths bridge. Deleting
  `migratePreListSponsorship` makes a pre-0.8 **stopped** sponsorship read as
  never-sponsored, which falls to the "run as the app OWNER" branch — privilege
  escalation on upgrade. This is a support-cutoff decision for the owner ("when
  do we drop 0.7 upgrade support?"), not an agent cleanup. The essays were cut
  instead.
- **Webhook scans every app in the deployment.** Already written down in-repo as
  intentional: `packages/store/src/schema.ts:261-263` says verbatim that webhook
  "gets a column for symmetry (so the ref key exists the day it stops scanning)
  and no index it never uses". There is deliberately no index, so the "fix" buys
  a filtered seq scan, not an indexed query — and the throw is caught at
  `server.ts:1518` and returned as a 400, not unhandled.
- **`law.ts` has a spare export.** `UNATTENDED_IRREVERSIBILITY_RULE` is
  re-exported as public API by `packages/vendo/src/server.ts:263`. Not spare.
- **Delete the `fn:` steps `console.warn`.** It fires at the only point that
  sees both the trigger kind and the steps, and the alternative is a person
  finding out when a 3 a.m. run fails. Kept.
- **`AppAccessSeam` should be a `Pick` of core's `AppAccess`.** The narrow seam
  is deliberate — it is a public config surface a host implements, and core's
  `can()` takes the wider `CanThing`, so the "cleanup" makes it strictly harder
  to satisfy for no behavioral gain.
- **`createAutomationsEngine` monster split** (2 entries) — out of scope, owner
  dropped it in priority.

## vendo-web (live consumer — the console hosts automations)

Grepped the sibling clone. Two hits:

- **`apps/console/lib/automations/webhooks.ts`** — mints and rotates the same
  `automations:webhook` rows. **Not a no-op**: `put` replaces refs, so a console
  rotation would have stripped what the engine writes here. Companion PR
  **runvendo/vendo-web#294**, landing with this one, adds the same ref to its
  three write sites (test first there too — 19/19 green).
- **`apps/console/scripts/customer-harness.ts:1780`** — reads
  `automations:schedule` by row id. **No-op**: refs are not on any read path.

Also in-repo but not mine: `packages/apps/src/manifest-triggers.ts` writes
schedule cursors during the manifest cutover, also without refs. It is
`insert-if-absent`, so it never clobbers this fix — but cursors it creates stay
unref'd until their first tick. Left to the `packages/apps` owner rather than
reaching across file-set boundaries. **No behavior conflict either way.**

## Deferred

- Extract one `test-support.ts` for `GuardDouble`/`appsDouble`/`registry`/
  `seedApp`/`ctx`/`flush`/`sign`, copy-pasted across six suites (2 catalog
  entries).
- Consolidate `src/security/` into `engine.test.ts`; split the 80-line webhook
  mega-test; dedupe the three org-app revoke scenarios; fold the spend outcomes
  into `it.each`.
- `sponsorship.ts` as an 18-export utility bag, and moving the app-document
  helpers out — both entangled with the engine split that is out of scope.

## Real LOC

+218 / −132 across 8 files, all inside `packages/automations/**` and
`.changeset/`. Source shrinks (−10 `engine.ts`, −1 `index.ts`, +4
`sponsorship.ts`); the growth is the 5 new test cases that prove the erase bug.
This slice is a bug fix, not a deletion sweep, and the numbers say so.

## Gates

| gate | result |
| --- | --- |
| `pnpm build --filter='...@vendoai/automations...'` | `21 successful, 21 total` |
| `packages/automations` vitest | `Test Files 6 passed · Tests 104 passed` |
| `fixtures/automations-e2e` vitest | `Test Files 17 passed, 1 skipped (18) · Tests 69 passed, 1 skipped (70)` |
| `pnpm typecheck` | `40 successful, 40 total` |
| `pnpm lint --force` | `3 successful, 3 total` |

Changeset: **minor** — the package root drops three exports.

Note for reviewers on the CLAUDE.md trap: `packages/automations/tsconfig.json`
excludes `src/**/*.test.ts`, so a broken test survives build + typecheck here.
Every symbol removed was grepped repo-wide including test dirs, `examples/`,
`fixtures/`, `corpus/`, `docs-site/` and the vendo-web clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes data retention in `@vendoai/automations` by adding `app_id` refs to engine-owned generic records so app deletions also remove schedule cursors, webhook secrets, and delivery rows. Also trims unused exports and noisy comments; adds targeted tests.

- **Bug Fixes**
  - Added `refs: { app_id }` at all write sites: schedule cursor (enable, tick insert/compare-and-swap), webhook secret mint/rotate, delivery ledger, and pre-rekey cursor migration.
  - Keeps reads unchanged (all by row id); refs are forward-stamped on next write. No data migration needed.
  - New tests cover erase cascade collection and cursor migration with refs.

- **Refactors**
  - Package root drops `appIntentOf`, `SPONSORSHIPS`, and `Sponsorship`; `triggerKey` stays.
  - Removed dead test helpers/imports and tightened comments for clarity.

<sup>Written for commit cf4c3a859af0ab3f738045f2a83a107c82aa91a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

