### PR TITLE
fix(knowledge,telemetry,corpus,bench): citations keep provenance, two toasts stop failing a run, the privacy notice stops lying

### DIFF
--- a/.changeset/knowledge-citations-keep-provenance.md
+++ b/.changeset/knowledge-citations-keep-provenance.md
@@ -14,6 +14,12 @@ only glossary lookups and the cloud engine carried it. `source` is now
 denormalized alongside `title` at upsert time and rides the hit ref, so all
 three intents return the same ref shape.
 
+Existing stores get this without a re-sync. Chunk rows written by earlier
+versions have no `source` field, and `vendo knowledge sync` skips documents
+whose content hash is unchanged, so those rows would never be rewritten —
+search reads through to the document row for them instead. Nothing to run, no
+migration, and the doc row has always carried `source`.
+
 `cloudKnowledge` and `httpKnowledge` were the same `vendo/knowledge-wire@1`
 client written out twice: identical transport, identical response parsing,
 identical `includeInternal` handling, identical route bodies. Only the base

--- a/.changeset/knowledge-citations-keep-provenance.md
+++ b/.changeset/knowledge-citations-keep-provenance.md
@@ -1,0 +1,28 @@
+---
+"@vendoai/knowledge": minor
+---
+
+Knowledge citations keep their provenance on the main search path, and both
+shipped wire engines are one client.
+
+The built-in local engine denormalized `kind`, `visibility` and `title` from
+the doc into each chunk row but not `source`, so the chat/deep ref shape had no
+`source` while the schema-intent and `fetch` shapes did. Since `toCitation`
+forwards `source` only when it is present, every citation an agent produced on
+the default retrieval path silently lost the file or URL the text came from —
+only glossary lookups and the cloud engine carried it. `source` is now
+denormalized alongside `title` at upsert time and rides the hit ref, so all
+three intents return the same ref shape.
+
+`cloudKnowledge` and `httpKnowledge` were the same `vendo/knowledge-wire@1`
+client written out twice: identical transport, identical response parsing,
+identical `includeInternal` handling, identical route bodies. Only the base
+path, whether the bearer is mandatory, the posture, and the wording of the
+client's own errors ever differed. They now share one internal client that
+takes those four as arguments, so a retry, header, timeout or status mapping is
+added in one place instead of two that can drift. No behaviour changes for
+either engine.
+
+`toCitation` is no longer exported from the package barrel. It is the tool's
+own hit-to-citation mapper, it had no importer anywhere, and the citation shape
+it produces is already public as `KnowledgeCitation`.

--- a/.changeset/telemetry-notice-opt-out-works.md
+++ b/.changeset/telemetry-notice-opt-out-works.md
@@ -1,0 +1,18 @@
+---
+"@vendoai/telemetry": patch
+---
+
+The first-run telemetry notice advertises an opt-out that exists.
+
+The one-time consent notice told every new user "disable now: `vendo telemetry
+disable`". No such command has ever existed — the CLI has no `telemetry`
+branch, and the only occurrence of that string anywhere in the repo was the
+notice itself — so the single actionable instruction in the privacy notice
+failed with an unknown-command error. It now names `VENDO_TELEMETRY_DISABLED=1`,
+which the very next line already listed and which TELEMETRY.md has documented
+all along.
+
+The test that covers the notice now checks every environment variable the
+notice names is one `envOptOut` actually honors, and that the notice names no
+`vendo …` command at all: this package deliberately depends on no `@vendoai`
+package, so it can never verify that a CLI command exists.

--- a/bench/package.json
+++ b/bench/package.json
@@ -7,8 +7,6 @@
   "engines": {
     "node": ">=20"
   },
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "scripts": {
     "bench": "node dist/run.js",
     "build": "tsc -p tsconfig.json",

--- a/bench/src/benches/automations-tick.ts
+++ b/bench/src/benches/automations-tick.ts
@@ -24,7 +24,7 @@ const WARMUP = 10;
 
 // A minimal registry + apps port: the seeded apps never fire (schedules are not due, the
 // emitted event matches nothing), so neither is actually invoked by these cases.
-const benchTools = (): ToolRegistry => ({
+const idleTools = (): ToolRegistry => ({
   async descriptors() { return []; },
   async execute() { return { status: "ok", output: {} }; },
 });
@@ -72,7 +72,7 @@ export const automationsTickSuite: Suite = {
   async run(): Promise<SuiteResult> {
     const store = memoryStore();
     const guard = createGuard({ store });
-    const automations = createAutomations({ apps: benchApps(), tools: benchTools(), guard, store });
+    const automations = createAutomations({ apps: benchApps(), tools: idleTools(), guard, store });
     await seed(store);
 
     const principal: Principal = { kind: "user", subject: OWNER };

--- a/bench/src/budgets.test.ts
+++ b/bench/src/budgets.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  budgetKey,
-  findBreaches,
-  findUnmatchedCeilings,
-  loadBudgets,
-  type BudgetsFile,
-} from "./budgets.js";
+import { findBreaches, findUnmatchedCeilings, loadBudgets, type BudgetsFile } from "./budgets.js";
 import { DETERMINISTIC_SUITES } from "./benches/index.js";
 import type { SuiteResult } from "./types.js";
 
@@ -97,16 +91,3 @@ describe("committed budgets.json integrity", () => {
   });
 });
 
-describe("budgetKey", () => {
-  it("joins suite and case with a colon", () => {
-    expect(budgetKey("store", "put-pglite")).toBe("store:put-pglite");
-  });
-});
-
-describe("loadBudgets", () => {
-  it("loads the committed budgets.json with ceilings", async () => {
-    const file = await loadBudgets();
-    expect(Object.keys(file.ceilings).length).toBeGreaterThan(0);
-    for (const value of Object.values(file.ceilings)) expect(typeof value).toBe("number");
-  });
-});

--- a/bench/src/index.ts
+++ b/bench/src/index.ts
@@ -1,7 +1,0 @@
-/** @vendoai/bench — perf-budget gate and honest latency measurements (bench/README.md). */
-export * from "./types.js";
-export * from "./stats.js";
-export * from "./budgets.js";
-export * from "./report.js";
-export * from "./trees.js";
-export { SUITES, DETERMINISTIC_SUITES, LIVE_SUITES, suiteByName } from "./benches/index.js";

--- a/bench/tsconfig.json
+++ b/bench/tsconfig.json
@@ -6,8 +6,6 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "rootDir": "src",
     "outDir": "dist",
-    "declaration": true,
-    "declarationMap": true,
     "sourceMap": true
   },
   "include": ["src"],

--- a/corpus/harness/src/boot.test.ts
+++ b/corpus/harness/src/boot.test.ts
@@ -153,44 +153,6 @@ describe("bootRepo", () => {
     ]);
   });
 
-  it("provisions Redis after Postgres and tears both down in reverse order", async () => {
-    const corpusRoot = await makeTempRoot();
-    const context = createRunContext({ corpusRoot });
-    const repo = repoEntry("twentyish");
-    repo.bootstrap.redis = {
-      kind: "docker-redis",
-      containerName: "vendo-corpus-twentyish-redis",
-      image: "redis:7-alpine",
-      hostPort: 56379,
-    };
-    await mkdir(context.repoDir(repo.name), { recursive: true });
-    const events: string[] = [];
-    const server = fakeProcess(7788);
-
-    const boot = await bootRepo(repo, {
-      context,
-      provisionDatabase: async (database) => {
-        events.push(`service:start:${database.kind}:${database.containerName}`);
-        return { teardown: async () => { events.push(`service:stop:${database.kind}`); } };
-      },
-      runCommand: async () => ({ code: 0, signal: null, stdout: "", stderr: "" }),
-      spawnProcess: () => server,
-      checkReadiness: async () => true,
-      killProcessTree: async () => {},
-      sleep: async () => {},
-    });
-
-    expect(boot.logPaths.redis).toBe(path.join(context.logsDir(repo.name), "boot.redis.log"));
-    await boot.teardown();
-
-    expect(events).toEqual([
-      "service:start:docker-postgres:vendo-corpus-twentyish-postgres",
-      "service:start:docker-redis:vendo-corpus-twentyish-redis",
-      "service:stop:docker-redis",
-      "service:stop:docker-postgres",
-    ]);
-  });
-
   it("rejects a foreign readiness response until the configured body marker is present", async () => {
     const corpusRoot = await makeTempRoot();
     const context = createRunContext({ corpusRoot });

--- a/corpus/harness/src/boot.ts
+++ b/corpus/harness/src/boot.ts
@@ -26,7 +26,6 @@ export interface BootLogPaths {
   server: string;
   seed?: string;
   database?: string;
-  redis?: string;
 }
 
 export interface BootHandle {
@@ -158,7 +157,7 @@ async function defaultProvisionDatabase(
   context: DatabaseProvisionContext,
 ): Promise<DatabaseProvisionHandle> {
   await writeFile(context.logPath, "");
-  if (database.kind !== "docker-postgres" && database.kind !== "docker-redis") {
+  if (database.kind !== "docker-postgres") {
     throw new Error(`Unsupported database provisioning kind: ${(database as { kind: string }).kind}`);
   }
 
@@ -167,37 +166,22 @@ async function defaultProvisionDatabase(
   const removeBefore = await runBinary("docker", ["rm", "-f", database.containerName], dockerOptions);
   await appendDatabaseLog(context.logPath, `docker rm -f ${database.containerName}`, removeBefore);
 
-  const runArgs = database.kind === "docker-postgres"
-    ? [
-        "run",
-        "-d",
-        "--name",
-        database.containerName,
-        "-e",
-        `POSTGRES_USER=${database.username}`,
-        "-e",
-        `POSTGRES_PASSWORD=${database.password}`,
-        "-e",
-        `POSTGRES_DB=${database.database}`,
-        "-p",
-        `127.0.0.1:${database.hostPort}:5432`,
-        database.image,
-      ]
-    : [
-        "run",
-        "-d",
-        "--name",
-        database.containerName,
-        "-p",
-        `127.0.0.1:${database.hostPort}:6379`,
-        database.image,
-      ];
-  const readinessArgs = database.kind === "docker-postgres"
-    ? ["exec", database.containerName, "pg_isready", "-U", database.username, "-d", database.database]
-    : ["exec", database.containerName, "redis-cli", "ping"];
-  const readinessLabel = database.kind === "docker-postgres" ? "pg_isready" : "redis-cli ping";
-  const isReady = (result: BinaryResult): boolean =>
-    result.code === 0 && (database.kind !== "docker-redis" || result.stdout.includes("PONG"));
+  const runArgs = [
+    "run",
+    "-d",
+    "--name",
+    database.containerName,
+    "-e",
+    `POSTGRES_USER=${database.username}`,
+    "-e",
+    `POSTGRES_PASSWORD=${database.password}`,
+    "-e",
+    `POSTGRES_DB=${database.database}`,
+    "-p",
+    `127.0.0.1:${database.hostPort}:5432`,
+    database.image,
+  ];
+  const readinessArgs = ["exec", database.containerName, "pg_isready", "-U", database.username, "-d", database.database];
 
   let startedContainer = false;
   try {
@@ -211,8 +195,8 @@ async function defaultProvisionDatabase(
     let lastResult: BinaryResult | undefined;
     for (let attempt = 0; attempt < attempts; attempt += 1) {
       lastResult = await runBinary("docker", readinessArgs, dockerOptions);
-      await appendDatabaseLog(context.logPath, `docker exec ... ${readinessLabel}`, lastResult);
-      if (isReady(lastResult)) {
+      await appendDatabaseLog(context.logPath, "docker exec ... pg_isready", lastResult);
+      if (lastResult.code === 0) {
         return {
           teardown: async () => {
             const stopped = await runBinary("docker", ["rm", "-f", database.containerName], dockerOptions);
@@ -402,12 +386,10 @@ export async function bootRepo(repo: BootRepo, options: BootRepoOptions = {}): P
   };
   if (repo.bootstrap.seedCommand) logPaths.seed = path.join(logsDir, "boot.seed.log");
   if (repo.bootstrap.database) logPaths.database = path.join(logsDir, "boot.database.log");
-  if (repo.bootstrap.redis) logPaths.redis = path.join(logsDir, "boot.redis.log");
 
   await mkdir(logsDir, { recursive: true });
 
   let databaseHandle: DatabaseProvisionHandle | undefined;
-  let redisHandle: DatabaseProvisionHandle | undefined;
   let serverProcess: BootProcess | undefined;
   let closeServerLog: (() => Promise<void>) | undefined;
   let serverExit: string | undefined;
@@ -439,11 +421,6 @@ export async function bootRepo(repo: BootRepo, options: BootRepoOptions = {}): P
       }
     }
     try {
-      await redisHandle?.teardown?.();
-    } catch (error) {
-      errors.push(error);
-    }
-    try {
       await databaseHandle?.teardown?.();
     } catch (error) {
       errors.push(error);
@@ -460,17 +437,6 @@ export async function bootRepo(repo: BootRepo, options: BootRepoOptions = {}): P
         context,
         logsDir,
         logPath: logPaths.database ?? path.join(logsDir, "boot.database.log"),
-        env,
-        sleep: sleepFn,
-      });
-    }
-
-    if (repo.bootstrap.redis) {
-      redisHandle = await provisionDatabase(repo.bootstrap.redis, {
-        repo,
-        context,
-        logsDir,
-        logPath: logPaths.redis ?? path.join(logsDir, "boot.redis.log"),
         env,
         sleep: sleepFn,
       });

--- a/corpus/harness/src/layers/e2e.test.ts
+++ b/corpus/harness/src/layers/e2e.test.ts
@@ -43,8 +43,16 @@ class FakeLocator implements E2eLocator {
     this.handlers.press?.(key);
   }
 
+  /** Playwright's strict mode: a single-element read on a locator that resolves
+      to more than one element throws instead of picking one. */
   async textContent(): Promise<string> {
+    const count = await this.count();
+    if (count > 1) throw new Error(`strict mode violation: locator resolved to ${count} elements`);
     return this.text;
+  }
+
+  async allTextContents(): Promise<string[]> {
+    return Array.from({ length: await this.count() }, () => this.text);
   }
 
   first(): E2eLocator {
@@ -210,6 +218,16 @@ describe("evaluateAssertion", () => {
     await expect(evaluateAssertion({ kind: "no-error-toast" }, signals({}), stageErrorPage))
       .resolves.toMatchObject({ pass: false });
     await expect(evaluateAssertion({ kind: "no-error-toast" }, signals({ errorToasts: [{ text: "failed" }] })))
+      .resolves.toMatchObject({ pass: false });
+  });
+
+  it("reads several visible toasts at once instead of tripping Playwright's strict mode", async () => {
+    const twoBenignToasts = new FakePage({ ".fl-toast": 2 }, "Saved successfully");
+    const twoErrorToasts = new FakePage({ ".fl-toast": 2 }, "Upload failed");
+
+    await expect(evaluateAssertion({ kind: "no-error-toast" }, signals({}), twoBenignToasts))
+      .resolves.toMatchObject({ pass: true });
+    await expect(evaluateAssertion({ kind: "no-error-toast" }, signals({}), twoErrorToasts))
       .resolves.toMatchObject({ pass: false });
   });
 });

--- a/corpus/harness/src/layers/e2e.ts
+++ b/corpus/harness/src/layers/e2e.ts
@@ -873,11 +873,11 @@ async function countErrorDomSignals(page: E2ePage): Promise<number> {
   const stageErrors = page.frameLocator
     ? await safeCount(page.frameLocator('iframe#vendo-stage, iframe[title="Vendo stage"]').locator(stageErrorSelector))
     : 0;
-  const toasts = page.locator(".fl-toast:visible");
-  const toastCount = await safeCount(toasts);
-  if (toastCount === 0) return hardErrors + stageErrors;
-  const text = await toasts.textContent?.();
-  return hardErrors + stageErrors + (text && errorToastText.test(text) ? toastCount : 0);
+  // Several toasts can be visible at once, so read them all: a single-element
+  // textContent() would trip Playwright's strict mode, and a concatenated read
+  // would score two benign toasts as errors the moment one of them matched.
+  const toasts = await page.locator(".fl-toast:visible").allTextContents?.().catch(() => [] as string[]) ?? [];
+  return hardErrors + stageErrors + toasts.filter((text) => errorToastText.test(text)).length;
 }
 
 function viewMatches(assertion: Extract<ConversationAssertion, { kind: "view-rendered" }>, view: E2eViewSignal): boolean {

--- a/corpus/harness/src/manifest.test.ts
+++ b/corpus/harness/src/manifest.test.ts
@@ -104,35 +104,6 @@ describe("parseManifest", () => {
     expect(() => parseManifest([invalid])).toThrow(/requiresBuild/i);
   });
 
-  it("accepts docker-redis service provisioning and rejects malformed redis recipes", () => {
-    const redis = {
-      kind: "docker-redis",
-      containerName: "vendo-corpus-twenty-redis",
-      image: "redis:7-alpine",
-      hostPort: 56379,
-      readinessTimeoutMs: 30_000,
-    };
-    const withRedis = {
-      ...entry,
-      bootstrap: { ...entry.bootstrap, redis },
-    };
-    expect(parseManifest([withRedis])[0]?.bootstrap.redis).toEqual(redis);
-
-    // The redis slot only takes the redis kind, and postgres-only fields never sneak in.
-    expect(() => parseManifest([{
-      ...entry,
-      bootstrap: { ...entry.bootstrap, redis: { ...redis, kind: "docker-postgres" } },
-    }])).toThrow(/kind/i);
-    expect(() => parseManifest([{
-      ...entry,
-      bootstrap: { ...entry.bootstrap, redis: { ...redis, username: "corpus" } },
-    }])).toThrow(/username/i);
-    expect(() => parseManifest([{
-      ...entry,
-      bootstrap: { ...entry.bootstrap, redis: { ...redis, hostPort: 70000 } },
-    }])).toThrow(/hostPort/i);
-  });
-
   it("rejects invalid deep-tier docker database provisioning", () => {
     const invalid = {
       ...entry,

--- a/corpus/harness/src/manifest.ts
+++ b/corpus/harness/src/manifest.ts
@@ -48,31 +48,12 @@ const dockerPostgresProvisioningSchema = z
   })
   .strict();
 
-/** Redis mirrors the Postgres provisioning shape (docker container + readiness
- * probe). No fixture currently boots Redis. */
-const dockerRedisProvisioningSchema = z
-  .object({
-    kind: z.literal("docker-redis"),
-    containerName: z.string().min(1),
-    image: z.string().min(1),
-    hostPort: z.number().int().min(1024).max(65535),
-    readinessTimeoutMs: z.number().int().positive().optional(),
-    readinessIntervalMs: z.number().int().positive().optional(),
-  })
-  .strict();
-
-const databaseProvisioningSchema = z.discriminatedUnion("kind", [
-  dockerPostgresProvisioningSchema,
-  dockerRedisProvisioningSchema,
-]);
-
 const bootstrapRecipeSchema = z
   .object({
     installCommand: z.string().min(1),
     envTemplate: z.record(z.string(), z.string()),
     seedCommand: z.string().min(1).optional(),
     database: dockerPostgresProvisioningSchema.optional(),
-    redis: dockerRedisProvisioningSchema.optional(),
     typecheckCommand: z.string().min(1).optional(),
     buildCommand: z.string().min(1),
     devServer: devServerSchema.optional(),
@@ -156,7 +137,7 @@ export const corpusManifestSchema = z
 
 export type ManifestEntry = z.input<typeof manifestEntrySchema>;
 export type CorpusManifest = ManifestEntry[];
-export type DatabaseProvisioning = z.infer<typeof databaseProvisioningSchema>;
+export type DatabaseProvisioning = z.infer<typeof dockerPostgresProvisioningSchema>;
 
 export const defaultManifestPath = fileURLToPath(new URL("../../manifest.json", import.meta.url));
 

--- a/packages/knowledge/package.json
+++ b/packages/knowledge/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "vitest run",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit",
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {

--- a/packages/knowledge/src/agent-tools.test.ts
+++ b/packages/knowledge/src/agent-tools.test.ts
@@ -52,6 +52,11 @@ describe("createKnowledgeTools descriptor (K1 pin)", () => {
     expect(descriptor.name).toBe(VENDO_KNOWLEDGE_SEARCH_TOOL);
     expect(descriptor.name).toBe("vendo_knowledge_search");
     expect(descriptor.risk).toBe("read");
+    // Without a title, ToolListing.title falls back to the identifier and the
+    // model speaks `vendo_knowledge_search` at a person.
+    expect(descriptor.title).toBe(VENDO_TOOL_TITLES[VENDO_KNOWLEDGE_SEARCH_TOOL]);
+    expect(descriptor.title).toBeTruthy();
+    expect(descriptor.title).not.toMatch(/vendo|_/i);
     const schema = descriptor.inputSchema as {
       properties: Record<string, unknown>;
       required: string[];
@@ -440,14 +445,3 @@ describe("rate breaker (ENG-370)", () => {
   });
 });
 
-describe("§3 consumer voice — the knowledge tool carries a title", () => {
-  // Wave-1 live proof E1-5: without a title, `ToolListing.title` falls back to
-  // the identifier and the model speaks `vendo_knowledge_search` to a person.
-  it("titles the descriptor from the shared table", async () => {
-    const tools = createKnowledgeTools({ adapter: memoryKnowledgeAdapter([]) });
-    const [descriptor] = await tools.descriptors();
-    expect(descriptor?.title).toBe(VENDO_TOOL_TITLES[VENDO_KNOWLEDGE_SEARCH_TOOL]);
-    expect(descriptor?.title).toBeTruthy();
-    expect(descriptor?.title).not.toMatch(/vendo|_/i);
-  });
-});

--- a/packages/knowledge/src/agent-tools.ts
+++ b/packages/knowledge/src/agent-tools.ts
@@ -13,9 +13,9 @@ import {
 
 const DRAFT_2020_12 = "https://json-schema.org/draft/2020-12/schema";
 
-/** Knowledge K1 pin — `vendo_`-prefixed so the loadout policy keeps it always
-    active (tool-search isAlwaysActive); a bare name could be gated out on
-    hosts with a large tool surface. */
+/** `vendo_`-prefixed so the loadout policy keeps it always active
+    (tool-search isAlwaysActive); a bare name could be gated out on hosts with
+    a large tool surface. */
 export const VENDO_KNOWLEDGE_SEARCH_TOOL = "vendo_knowledge_search";
 
 /** The envelope tag core names once (stream-parts.ts) — re-exported so tool
@@ -34,8 +34,8 @@ export interface KnowledgeCitation {
   title?: string;
   source?: string;
   kind: KnowledgeHit["kind"];
-  /** Checker round 1 (pin amended): rides from KnowledgeHit.visibility so
-      the UI's origin line states it instead of guessing. */
+  /** Rides from KnowledgeHit.visibility so the UI's origin line states it
+      instead of guessing. */
   visibility: KnowledgeHit["visibility"];
   snippet: string;
 }
@@ -59,8 +59,8 @@ export interface KnowledgeResultEnvelope {
 
 const descriptor: ToolDescriptor = {
   name: VENDO_KNOWLEDGE_SEARCH_TOOL,
-  // §3 — what a person reads. Without it `ToolListing.title` falls back to the
-  // identifier and the model speaks the slug (wave-1 proof E1-5).
+  // What a person reads. Without it `ToolListing.title` falls back to the
+  // identifier and the model speaks the slug.
   title: VENDO_TOOL_TITLES[VENDO_KNOWLEDGE_SEARCH_TOOL],
   description: "Search the host's product knowledge base (documentation, glossary, API reference) and cite what you find. Use it whenever the user asks how the product works or what a term means. Set lookup:true for an exact glossary/API term lookup. Pass readMore:{docId} to read the full document behind an earlier hit when its snippet is not enough. An insufficient-evidence outcome means the knowledge base does not cover the question — say you don't know instead of guessing.",
   inputSchema: {
@@ -86,17 +86,17 @@ const descriptor: ToolDescriptor = {
 };
 
 export interface KnowledgeToolsOptions {
-  /** Refusal calibration (per-engine, K2 evals): hits scoring below this are
-      "weak". Default 0 — never triggers, so score-less/constant-score engines
-      (the memory adapter) never falsely refuse. */
+  /** Refusal calibration, per engine: hits scoring below this are "weak".
+      Default 0 — never triggers, so score-less/constant-score engines (the
+      memory adapter) never falsely refuse. */
   weakScoreThreshold?: number;
-  /** ENG-370 rate breaker: per-principal calls per rolling minute before the
-      tool answers a loud "rate-limited" error. Explicit option wins over the
+  /** Per-principal calls per rolling minute before the tool answers a loud
+      "rate-limited" error. Explicit option wins over the
       VENDO_KNOWLEDGE_MAX_CALLS_PER_MINUTE env knob; default 60. */
   maxCallsPerMinute?: number;
 }
 
-/** ENG-370 default; the env knob is the operator escape hatch. */
+/** The env knob is the operator escape hatch. */
 const MAX_CALLS_PER_MINUTE = 60;
 
 const maxCallsPerMinuteFromEnv = (): number | undefined => {
@@ -105,11 +105,11 @@ const maxCallsPerMinuteFromEnv = (): number | undefined => {
   return Number.isFinite(configured) && configured > 0 ? configured : undefined;
 };
 
-/** ENG-370 — a small in-memory rolling-minute breaker keyed by principal
-    subject (guard.ts #recordCall is the house pattern, including the
-    once-per-minute sweep that bounds the map for process lifetime). Scoped
-    per registry instance; the tool composes once per createVendo, so the
-    window is per-process like the guard's. */
+/** A small in-memory rolling-minute breaker keyed by principal subject
+    (guard.ts #recordCall is the house pattern, including the once-per-minute
+    sweep that bounds the map for process lifetime). Scoped per registry
+    instance; the tool composes once per createVendo, so the window is
+    per-process like the guard's. */
 class CallRateBreaker {
   #windows = new Map<string, number[]>();
   #lastSweepAt = 0;
@@ -228,13 +228,12 @@ const envelope = (
   output: { kind: VENDO_KNOWLEDGE_RESULT_KIND, ...fields } as unknown as Json,
 });
 
-/** Knowledge K1 — the one knowledge agent tool behind core's adapter contract.
-    The registry composes into createVendo exactly when a `knowledge` adapter
-    is configured (selectKnowledge). Tool-layer policy (spec §Agent experience
-    and trust): chat default → auto-escalate deep once on weak results →
-    structured insufficient-evidence; lookup → schema over glossary/api with
-    honest not-found; readMore → posture-gated fetch; adapter failure → loud
-    unavailable, never a silent empty result. */
+/** The one knowledge agent tool behind core's adapter contract. The registry
+    composes into createVendo exactly when a `knowledge` adapter is configured
+    (selectKnowledge). Tool-layer policy: chat default → auto-escalate deep
+    once on weak results → structured insufficient-evidence; lookup → schema
+    over glossary/api with honest not-found; readMore → posture-gated fetch;
+    adapter failure → loud unavailable, never a silent empty result. */
 export function createKnowledgeTools(
   adapter: KnowledgeAdapter,
   options: KnowledgeToolsOptions = {},
@@ -243,7 +242,7 @@ export function createKnowledgeTools(
   const breaker = new CallRateBreaker(options.maxCallsPerMinute ?? maxCallsPerMinuteFromEnv() ?? MAX_CALLS_PER_MINUTE);
 
   // An engine failure has two audiences and they need different halves of the
-  // same error (conductor amendment, 2026-07-27).
+  // same error.
   //
   // The MODEL gets the statement — what failed — because an outcome with no
   // reason is the silence this whole seam exists to kill: the agent could not
@@ -268,8 +267,8 @@ export function createKnowledgeTools(
     return raw.split(" — ")[0]!;
   };
 
-  // The status()-verified refusal (checker round 1): an empty/weak search
-  // from a SICK engine must not pass as an honest refusal or not-found — the
+  // The status()-verified refusal: an empty/weak search from a SICK engine
+  // must not pass as an honest refusal or not-found — the
   // emptiness is unverifiable. Consulted only on the zero/weak paths (a
   // strong answer never pays the status call); a throw propagates to the
   // caller's catch, which maps it to the loud "unavailable".
@@ -305,8 +304,8 @@ export function createKnowledgeTools(
       if (call.tool !== VENDO_KNOWLEDGE_SEARCH_TOOL) {
         return { status: "error", error: { code: "not-found", message: `Unknown tool: ${call.tool}` } };
       }
-      // ENG-370 breaker — LOUD, never a silent empty result. "rate-limited"
-      // is the house wire code for this condition (Cloud device-login speaks
+      // LOUD, never a silent empty result. "rate-limited" is the house wire
+      // code for this condition (Cloud device-login speaks
       // it); deliberately NOT a VendoErrorCode, so it never rides VendoError.
       if (breaker.record(ctx.principal.subject)) {
         return {
@@ -324,15 +323,15 @@ export function createKnowledgeTools(
         return errorOutcome(error);
       }
 
-      // R5 (knowledge.ts KnowledgeContext): the agent path is
-      // principal-carrying, so includeInternal is NEVER set here.
+      // The agent path is principal-carrying, so includeInternal is NEVER
+      // set here.
       const knowledgeCtx = { principal: ctx.principal };
       try {
         if (input.readMore !== undefined) return await readMore(input.readMore, ctx);
 
         if (input.lookup === true) {
-          // Contract invariant (knowledge.ts R3): intent never implies kinds —
-          // the schema lookup restricts to the structured-fact kinds
+          // Contract invariant: intent never implies kinds — the schema
+          // lookup restricts to the structured-fact kinds
           // explicitly. An empty result is an honest not-found, never a fuzzy
           // fallback into prose docs.
           const result = await adapter.search(

--- a/packages/knowledge/src/cloud.test-util.ts
+++ b/packages/knowledge/src/cloud.test-util.ts
@@ -45,7 +45,7 @@ export interface FakeKnowledgeServer {
 
 /**
  * In-process fake of a `vendo/knowledge-wire@1` server — the test double for
- * the cloud client (ENG-364) and the REFERENCE implementation the BYO docs
+ * the cloud client and the REFERENCE implementation the BYO docs
  * point at: everything a conformant wire server must do fits in this one
  * handler. Speaks core's wire schemas verbatim over any KnowledgeAdapter:
  *

--- a/packages/knowledge/src/cloud.ts
+++ b/packages/knowledge/src/cloud.ts
@@ -1,16 +1,7 @@
-import {
-  KNOWLEDGE_WIRE_PATHS,
-  VendoError,
-  knowledgeFetchResultSchema,
-  knowledgeSearchResultSchema,
-  knowledgeWireStatusSchema,
-  parseKnowledgeWireError,
-  type KnowledgeAdapter,
-  type KnowledgeContext,
-} from "@vendoai/core";
+import { VendoError, type KnowledgeAdapter } from "@vendoai/core";
+import { knowledgeWireAdapter } from "./wire.js";
 
 const DEFAULT_BASE_URL = "https://console.vendo.run";
-const DEFAULT_TIMEOUT_MS = 30_000;
 
 export interface CloudKnowledgeOptions {
   /** The Vendo Cloud key (`vendo login`); sent as a Bearer token. */
@@ -21,92 +12,36 @@ export interface CloudKnowledgeOptions {
   fetch?: typeof fetch;
 }
 
-/** The Vendo Cloud knowledge engine client (knowledge design v2 R2,
- * ENG-364): speaks exactly `vendo/knowledge-wire@1` against the console
- * mount — the same five routes any BYO endpoint implements. Tenancy never
- * crosses the wire: the corpus is the key's org, resolved server-side.
+/** The Vendo Cloud knowledge engine client: speaks exactly
+ * `vendo/knowledge-wire@1` against the console mount — the same five routes
+ * any BYO endpoint implements. Tenancy never crosses the wire: the corpus is
+ * the key's org, resolved server-side.
  *
  * Full posture: the cloud engine chunks/searches vendor-side and its upsert
- * resolves only once documents are searchable (the mount owns awaiting
- * that; this client just doesn't resolve early). Layering keeps this
- * sender self-contained (core-only imports — no cloud-console reuse). */
+ * resolves only once documents are searchable (the mount owns awaiting that;
+ * this client just doesn't resolve early). Layering keeps this sender
+ * self-contained (core-only imports — no cloud-console reuse). */
 export function cloudKnowledge(options: CloudKnowledgeOptions): KnowledgeAdapter {
   const base = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
-  const transport = options.fetch ?? fetch;
-
-  async function call(path: string, init: { method: "GET" | "POST"; body?: unknown }): Promise<unknown> {
-    let response: Response;
-    try {
-      response = await transport(`${base}/api/v1/knowledge${path}`, {
-        method: init.method,
-        headers: {
-          authorization: `Bearer ${options.apiKey}`,
-          ...(init.body === undefined ? {} : { "content-type": "application/json" }),
-        },
-        ...(init.body === undefined ? {} : { body: JSON.stringify(init.body) }),
-        signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
-      });
-    } catch (error) {
-      throw new VendoError(
+  return knowledgeWireAdapter({
+    base: `${base}/api/v1/knowledge`,
+    bearer: options.apiKey,
+    posture: { fetch: true, write: true, visibility: "enforced" },
+    ...(options.fetch === undefined ? {} : { fetch: options.fetch }),
+    errors: {
+      unreachable: (cause) => new VendoError(
         "cloud-required",
-        `Vendo Cloud knowledge is unreachable at ${base}: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    }
-    const body: unknown = await response.json().catch(() => undefined);
-    if (response.status === 401) {
+        `Vendo Cloud knowledge is unreachable at ${base}: ${cause instanceof Error ? cause.message : String(cause)}`,
+      ),
       // Client-specific tail sanctioned by the wire module: any 401 is a key
       // problem, whatever the body looks like.
-      throw new VendoError("cloud-required", "Vendo Cloud rejected the API key — run `vendo login` or check VENDO_API_KEY");
-    }
-    if (!response.ok) throw parseKnowledgeWireError(response.status, body);
-    return body;
-  }
-
-  const parse = <T>(schema: { safeParse(value: unknown): { success: boolean; data?: unknown } }, value: unknown, route: string): T => {
-    const parsed = schema.safeParse(value);
-    if (!parsed.success) {
-      // A server-shaped failure, never the caller's: the mount answered 2xx
-      // with a body that is not the knowledge wire.
-      throw new VendoError("not-implemented", `Vendo Cloud ${route} answered with a body that is not vendo/knowledge-wire@1`);
-    }
-    return parsed.data as T;
-  };
-
-  const includeInternal = (ctx: KnowledgeContext): { includeInternal?: boolean } =>
-    ctx.includeInternal === true ? { includeInternal: true } : {};
-
-  return {
-    posture: { fetch: true, write: true, visibility: "enforced" },
-
-    async search(query, ctx) {
-      const body = await call(KNOWLEDGE_WIRE_PATHS.search, { method: "POST", body: { query, ...includeInternal(ctx) } });
-      return parse(knowledgeSearchResultSchema, body, "/search");
+      rejected: (status) => status === 401
+        ? new VendoError("cloud-required", "Vendo Cloud rejected the API key — run `vendo login` or check VENDO_API_KEY")
+        : undefined,
+      badBody: (route) => new VendoError(
+        "not-implemented",
+        `Vendo Cloud ${route} answered with a body that is not vendo/knowledge-wire@1`,
+      ),
     },
-
-    async fetch(ref, ctx) {
-      try {
-        const body = await call(KNOWLEDGE_WIRE_PATHS.fetch, { method: "POST", body: { ref, ...includeInternal(ctx) } });
-        return parse(knowledgeFetchResultSchema, body, "/fetch");
-      } catch (error) {
-        // Only an ENVELOPED not-found translates to the contract's null (a
-        // bare 404 already degraded to "not-implemented" in the parser — the
-        // hosted-store lesson: a missing mount must not read as absence).
-        if (error instanceof VendoError && error.code === "not-found") return null;
-        throw error;
-      }
-    },
-
-    async upsert(docs) {
-      await call(KNOWLEDGE_WIRE_PATHS.upsert, { method: "POST", body: { docs } });
-    },
-
-    async remove(docIds) {
-      await call(KNOWLEDGE_WIRE_PATHS.remove, { method: "POST", body: { docIds } });
-    },
-
-    async status() {
-      const body = await call(KNOWLEDGE_WIRE_PATHS.status, { method: "GET" });
-      return parse<{ status: Awaited<ReturnType<KnowledgeAdapter["status"]>> }>(knowledgeWireStatusSchema, body, "/status").status;
-    },
-  };
+  });
 }

--- a/packages/knowledge/src/collections.ts
+++ b/packages/knowledge/src/collections.ts
@@ -1,6 +1,6 @@
 /**
  * The store record collections backing the built-in local engine, created by
- * the store DDL (ENG-356). The local engine reads/writes documents and their
+ * the store DDL. The local engine reads/writes documents and their
  * chunks through these; the cloud engine keeps its corpus server-side and never
  * touches them.
  */

--- a/packages/knowledge/src/http.ts
+++ b/packages/knowledge/src/http.ts
@@ -1,17 +1,5 @@
-import {
-  KNOWLEDGE_WIRE_PATHS,
-  VendoError,
-  knowledgeFetchResultSchema,
-  knowledgeSearchResultSchema,
-  knowledgeWireStatusSchema,
-  parseKnowledgeWireError,
-  type KnowledgeAdapter,
-  type KnowledgeContext,
-  type KnowledgePosture,
-  type KnowledgeStatus,
-} from "@vendoai/core";
-
-const DEFAULT_TIMEOUT_MS = 30_000;
+import { VendoError, type KnowledgeAdapter, type KnowledgePosture } from "@vendoai/core";
+import { knowledgeWireAdapter } from "./wire.js";
 
 /** BYO defaults: the least a wire endpoint can promise — search + status,
     read-only, attested public-only. Declare more via `posture`. */
@@ -29,90 +17,29 @@ export interface HttpKnowledgeOptions {
   posture?: Partial<KnowledgePosture>;
 }
 
-/** The BYO template (knowledge design v2 R2, ENG-365): any host endpoint —
- * any language — implementing the `vendo/knowledge-wire@1` routes is a
- * first-class knowledge engine. Partial implementations are first-class too:
- * a search-only endpoint declares the default posture and the optional
- * adapter members are simply absent (`fetch` missing ⇒ read-more gracefully
- * absent; `write: false` ⇒ `vendo knowledge sync` refuses loudly to push).
- * The reference server implementation lives in this package's
- * `cloud.test-util.ts` fake — one handler, wire-schema-validated. */
+/** The BYO template: any host endpoint — any language — implementing the
+ * `vendo/knowledge-wire@1` routes is a first-class knowledge engine. Partial
+ * implementations are first-class too: a search-only endpoint declares the
+ * default posture and the optional adapter members are simply absent (`fetch`
+ * missing ⇒ read-more gracefully absent; `write: false` ⇒ `vendo knowledge
+ * sync` refuses loudly to push). The reference server implementation lives in
+ * this package's `cloud.test-util.ts` fake — one handler, wire-schema-validated. */
 export function httpKnowledge(options: HttpKnowledgeOptions): KnowledgeAdapter {
-  const posture: KnowledgePosture = { ...DEFAULT_POSTURE, ...options.posture };
   const base = options.url.replace(/\/+$/, "");
-  const transport = options.fetch ?? fetch;
-  const bearer = options.auth?.bearer;
-
-  async function call(path: string, init: { method: "GET" | "POST"; body?: unknown }): Promise<unknown> {
-    let response: Response;
-    try {
-      response = await transport(`${base}${path}`, {
-        method: init.method,
-        headers: {
-          ...(bearer === undefined ? {} : { authorization: `Bearer ${bearer}` }),
-          ...(init.body === undefined ? {} : { "content-type": "application/json" }),
-        },
-        ...(init.body === undefined ? {} : { body: JSON.stringify(init.body) }),
-        signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
-      });
-    } catch (error) {
-      throw new Error(
-        `knowledge endpoint ${base} is unreachable: ${error instanceof Error ? error.message : String(error)}`,
-        { cause: error },
-      );
-    }
-    const body: unknown = await response.json().catch(() => undefined);
-    if (!response.ok) throw parseKnowledgeWireError(response.status, body);
-    return body;
-  }
-
-  const parse = <T>(schema: { safeParse(value: unknown): { success: boolean; data?: unknown } }, value: unknown, route: string): T => {
-    const parsed = schema.safeParse(value);
-    if (!parsed.success) {
-      throw new VendoError("not-implemented", `knowledge endpoint ${base}${route} answered with a body that is not vendo/knowledge-wire@1`);
-    }
-    return parsed.data as T;
-  };
-
-  const includeInternal = (ctx: KnowledgeContext): { includeInternal?: boolean } =>
-    ctx.includeInternal === true ? { includeInternal: true } : {};
-
-  const adapter: KnowledgeAdapter = {
-    posture,
-
-    async search(query, ctx) {
-      const body = await call(KNOWLEDGE_WIRE_PATHS.search, { method: "POST", body: { query, ...includeInternal(ctx) } });
-      return parse(knowledgeSearchResultSchema, body, "/search");
+  return knowledgeWireAdapter({
+    base,
+    ...(options.auth?.bearer === undefined ? {} : { bearer: options.auth.bearer }),
+    posture: { ...DEFAULT_POSTURE, ...options.posture },
+    ...(options.fetch === undefined ? {} : { fetch: options.fetch }),
+    errors: {
+      unreachable: (cause) => new Error(
+        `knowledge endpoint ${base} is unreachable: ${cause instanceof Error ? cause.message : String(cause)}`,
+        { cause },
+      ),
+      badBody: (route) => new VendoError(
+        "not-implemented",
+        `knowledge endpoint ${base}${route} answered with a body that is not vendo/knowledge-wire@1`,
+      ),
     },
-
-    async status(): Promise<KnowledgeStatus> {
-      const body = await call(KNOWLEDGE_WIRE_PATHS.status, { method: "GET" });
-      return parse<{ status: KnowledgeStatus }>(knowledgeWireStatusSchema, body, "/status").status;
-    },
-  };
-
-  // Optional members exist exactly when the declared posture covers them
-  // (R2: presence is conformance-tested, not promised).
-  if (posture.fetch) {
-    adapter.fetch = async (ref, ctx) => {
-      try {
-        const body = await call(KNOWLEDGE_WIRE_PATHS.fetch, { method: "POST", body: { ref, ...includeInternal(ctx) } });
-        return parse(knowledgeFetchResultSchema, body, "/fetch");
-      } catch (error) {
-        // Only the ENVELOPED not-found means document absence; a bare 404
-        // already degraded to "not-implemented" in the parser.
-        if (error instanceof VendoError && error.code === "not-found") return null;
-        throw error;
-      }
-    };
-  }
-  if (posture.write) {
-    adapter.upsert = async (docs) => {
-      await call(KNOWLEDGE_WIRE_PATHS.upsert, { method: "POST", body: { docs } });
-    };
-    adapter.remove = async (docIds) => {
-      await call(KNOWLEDGE_WIRE_PATHS.remove, { method: "POST", body: { docIds } });
-    };
-  }
-  return adapter;
+  });
 }

--- a/packages/knowledge/src/index.test.ts
+++ b/packages/knowledge/src/index.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from "vitest";
 import { KNOWLEDGE_CHUNKS_COLLECTION, KNOWLEDGE_DOCS_COLLECTION } from "./index.js";
 
-describe("@vendoai/knowledge scaffold", () => {
-  it("names the store collections the local engine binds to (ENG-356 DDL)", () => {
+describe("@vendoai/knowledge released collection names", () => {
+  // Not a self-mirror: these two literals are a cross-repo constant. The
+  // console imports them (vendo-web apps/console/tests/
+  // knowledge-table-collision.test.ts) to prove its own knowledge tables never
+  // collide, after an incident where both sides ran CREATE TABLE IF NOT EXISTS
+  // for the same name against one hosted data-plane database. Changing either
+  // string breaks the console, so it is pinned here and not only in the type.
+  it("keeps the literals the console's collision guard is written against", () => {
     expect(KNOWLEDGE_DOCS_COLLECTION).toBe("vendo_knowledge_docs");
     expect(KNOWLEDGE_CHUNKS_COLLECTION).toBe("vendo_knowledge_chunks");
   });

--- a/packages/knowledge/src/index.ts
+++ b/packages/knowledge/src/index.ts
@@ -1,23 +1,21 @@
 /**
- * @vendoai/knowledge — the product knowledge base (knowledge design v2,
- * 2026-07-22).
+ * @vendoai/knowledge — the product knowledge base.
  *
  * This package holds the concrete `KnowledgeAdapter` engines — the built-in
  * local lexical engine, the cloud client, and the BYO HTTP template — plus the
  * ingestion pipeline (parse → normalize → structural chunk → sync) and the
  * `vendo_knowledge_search` agent tool, all behind core's frozen contract
- * (`@vendoai/core`, ENG-358).
+ * (`@vendoai/core`).
  *
  * Pure re-export barrel, alphabetical by module.
  */
 
 export type { KnowledgeAdapter } from "@vendoai/core";
 
-/** Knowledge K1 — the `vendo_knowledge_search` agent tool (tool-layer intent
-    policy, structured refusal, read-more) over any adapter. */
+/** The `vendo_knowledge_search` agent tool (tool-layer intent policy,
+    structured refusal, read-more) over any adapter. */
 export {
   createKnowledgeTools,
-  toCitation,
   VENDO_KNOWLEDGE_RESULT_KIND,
   VENDO_KNOWLEDGE_SEARCH_TOOL,
   type KnowledgeCitation,
@@ -38,7 +36,7 @@ export {
   type KnowledgeSourceConfig,
 } from "./ingest/index.js";
 export { bindKnowledgeStore, vendoKnowledge } from "./local/lexical.js";
-/** Knowledge k8 — the static prompt index (boot + sync-state refresh). */
+/** The static prompt index (boot + sync-state refresh). */
 export {
   knowledgeIndexResolver,
   knowledgeIndexSummary,

--- a/packages/knowledge/src/ingest/chunker.ts
+++ b/packages/knowledge/src/ingest/chunker.ts
@@ -4,7 +4,7 @@ import { splitBlocks, splitHeadingSections, startsWithFence } from "./markdown.j
 /** Soft per-chunk character budget. Chunks split at structural boundaries
     (headings, then blank-line blocks); an oversized block subdivides further
     — prose by sentence, then by line, then by hard slice — so no chunk is
-    unbounded (checker round 1 fix 3). */
+    unbounded. */
 const CHUNK_BUDGET = 1200;
 
 /** Fenced code stays atomic up to this hard cap (splitting mid-fence breaks
@@ -68,7 +68,7 @@ function packSection(lines: string[], budget: number): string[] {
   return pack(splitBlocks(lines).flatMap(subdivideBlock), budget, "\n\n");
 }
 
-/** Knowledge design v2 R1 — the v1 structural chunker. Prose (`docs`) splits
+/** The structural chunker. Prose (`docs`) splits
     at h1-h6 boundaries (fence-aware — a heading inside a code block never
     splits, including fences opened in list items) with the accumulated
     heading path on every chunk and a soft size budget applied at blank-line

--- a/packages/knowledge/src/ingest/config.ts
+++ b/packages/knowledge/src/ingest/config.ts
@@ -6,7 +6,7 @@ import {
   type KnowledgeVisibility,
 } from "@vendoai/core";
 
-/** The `.vendo/knowledge.json` format tag (knowledge design v2, developer
+/** The `.vendo/knowledge.json` format tag (developer
     door). An ingestion INPUT like tools.json — deliberately NOT a config
     surface (push/pull semantics don't apply). */
 export const VENDO_KNOWLEDGE_CONFIG_FORMAT = "vendo/knowledge@1" as const;
@@ -29,7 +29,7 @@ export interface KnowledgeConfig {
   sources: KnowledgeSourceConfig[];
 }
 
-/** Checker round 1 fix 1 (SECURITY): a source glob must stay inside the
+/** SECURITY: a source glob must stay inside the
     project root — ingestion runs with the developer's filesystem rights, so
     an absolute or `..`-escaping pattern would sync arbitrary readable files
     into the corpus. Rejected loudly here (the CLI's `add` and every

--- a/packages/knowledge/src/ingest/index.ts
+++ b/packages/knowledge/src/ingest/index.ts
@@ -12,7 +12,7 @@ export {
   type KnowledgeSourceConfig,
 } from "./config.js";
 export { structuralChunker } from "./chunker.js";
-export { parseSourceFile, docId, termSlug } from "./parse.js";
+export { parseSourceFile } from "./parse.js";
 
 /** Hand-rolled glob (zero new deps): `**` spans whole path segments, `*` and
     `?` stay within one. No brace/extglob syntax — the config format keeps to
@@ -50,7 +50,7 @@ const staticPrefix = (glob: string): string[] => {
 
 /** Sorted recursive file walk. Dotfiles and node_modules never match — a
     knowledge glob is for authored content, not vendored trees. The walk is
-    clamped to `root` (checker round 1 fix 1's second layer: even a pattern
+    clamped to `root` (the second layer of the traversal guard: even a pattern
     that slipped past schema validation can never read outside the root). */
 async function walkFiles(root: string, prefix: string[]): Promise<string[]> {
   const rootPath = resolve(root);

--- a/packages/knowledge/src/ingest/markdown.ts
+++ b/packages/knowledge/src/ingest/markdown.ts
@@ -3,7 +3,7 @@
  * design — zero markdown deps). The fence-aware splitter is the algorithm
  * from packages/ui/src/chrome/markdown.tsx (React-local, so copied rather
  * than imported), extended from h2/h3 to h1-h6 with heading-path
- * accumulation and CommonMark-ish list-item fence handling (checker round 1
+ * accumulation and CommonMark-ish list-item fence handling
  * fix 2).
  */
 

--- a/packages/knowledge/src/local/lexical.test.ts
+++ b/packages/knowledge/src/local/lexical.test.ts
@@ -101,6 +101,14 @@ describe("vendoKnowledge — retrieval quality", () => {
     expect((await adapter.search({ text: "Refund policy", intent: "schema" }, ctx)).hits).toEqual([]);
   });
 
+  it("carries the doc source on every intent so citations keep provenance", async () => {
+    const { adapter } = await seeded();
+    const chat = await adapter.search({ text: "How long do refunds take?" }, ctx);
+    expect(chat.hits[0]!.ref.source).toBe(CORPUS[0]!.source);
+    const schema = await adapter.search({ text: "APR", intent: "schema" }, ctx);
+    expect(schema.hits[0]!.ref.source).toBe(CORPUS[3]!.source);
+  });
+
   it("an empty kinds array matches nothing; kinds filter applies in-query", async () => {
     const { adapter } = await seeded();
     expect((await adapter.search({ text: "refunds", kinds: [] }, ctx)).hits).toEqual([]);

--- a/packages/knowledge/src/local/lexical.test.ts
+++ b/packages/knowledge/src/local/lexical.test.ts
@@ -109,6 +109,20 @@ describe("vendoKnowledge — retrieval quality", () => {
     expect(schema.hits[0]!.ref.source).toBe(CORPUS[3]!.source);
   });
 
+  it("falls back to the doc row for chunks written before chunk rows carried a source", async () => {
+    const { store, adapter } = await seeded();
+    // Every store synced by a shipped version holds chunk rows in this shape,
+    // and hash-based sync never rewrites an unchanged doc.
+    const chunks = store.records(KNOWLEDGE_CHUNKS_COLLECTION);
+    for (const row of (await chunks.list({ refs: { doc_id: "docs#refunds.md" }, limit: 1000 })).records) {
+      const { source: _dropped, ...legacy } = row.data as Record<string, unknown>;
+      await chunks.put({ id: row.id, data: legacy, refs: row.refs! });
+    }
+    const hit = (await adapter.search({ text: "How long do refunds take?" }, ctx)).hits[0]!;
+    expect(hit.ref.docId).toBe("docs#refunds.md");
+    expect(hit.ref.source).toBe(CORPUS[0]!.source);
+  });
+
   it("an empty kinds array matches nothing; kinds filter applies in-query", async () => {
     const { adapter } = await seeded();
     expect((await adapter.search({ text: "refunds", kinds: [] }, ctx)).hits).toEqual([]);

--- a/packages/knowledge/src/local/lexical.ts
+++ b/packages/knowledge/src/local/lexical.ts
@@ -22,6 +22,7 @@ interface ChunkRow extends KnowledgeChunk {
   kind: KnowledgeDoc["kind"];
   visibility: KnowledgeDoc["visibility"];
   title: string;
+  source: string;
 }
 
 /** LIST PAGINATION ruling: every corpus scan pages with the keyset cursor
@@ -151,7 +152,7 @@ export function vendoKnowledge(options: { store?: StoreAdapter } = {}): Knowledg
       // limit truncates the ranking, never changes it (R3).
       return {
         hits: scored.slice(0, limit).map(({ chunk, score }) => ({
-          ref: { docId: chunk.docId, chunkId: chunk.chunkId, title: chunk.title },
+          ref: { docId: chunk.docId, chunkId: chunk.chunkId, title: chunk.title, source: chunk.source },
           snippet: snippetAround(chunk.text, tokens),
           kind: chunk.kind,
           visibility: chunk.visibility,
@@ -196,10 +197,16 @@ export function vendoKnowledge(options: { store?: StoreAdapter } = {}): Knowledg
           if (!keep.has(stale.id)) await chunkRows().delete(stale.id);
         }
         for (const chunk of chunks) {
-          const data: ChunkRow = { ...chunk, kind: doc.kind, visibility: doc.visibility, title: doc.title };
-          // REFS ruling: chunks ref their doc; knowledge is host-level, so
-          // rows deliberately carry no subject_id (subject-erase skips them).
-          await chunkRows().put({ id: chunk.chunkId, data: { ...data }, refs: { doc_id: doc.id } });
+          const data: ChunkRow = {
+            ...chunk,
+            kind: doc.kind,
+            visibility: doc.visibility,
+            title: doc.title,
+            source: doc.source,
+          };
+          // Chunks ref their doc; knowledge is host-level, so rows deliberately
+          // carry no subject_id (subject-erase skips them).
+          await chunkRows().put({ id: chunk.chunkId, data, refs: { doc_id: doc.id } });
         }
         await docRows().put({ id: doc.id, data: { ...doc }, refs: { source: doc.source } });
       }

--- a/packages/knowledge/src/local/lexical.ts
+++ b/packages/knowledge/src/local/lexical.ts
@@ -14,6 +14,10 @@ import {
 } from "@vendoai/core";
 import { KNOWLEDGE_CHUNKS_COLLECTION, KNOWLEDGE_DOCS_COLLECTION } from "../collections.js";
 import { structuralChunker } from "../ingest/chunker.js";
+// Schema intent matches a term on its title case- and whitespace-insensitively,
+// which is the same normalization ingest uses to mint the term's id fragment.
+// They must agree, so they are one function.
+import { termSlug } from "../ingest/parse.js";
 
 /** A stored chunk row: the chunk plus doc fields denormalized at upsert time
     (upsert replaces every chunk of a doc, so they can never go stale) —
@@ -25,9 +29,8 @@ interface ChunkRow extends KnowledgeChunk {
   source: string;
 }
 
-/** LIST PAGINATION ruling: every corpus scan pages with the keyset cursor
-    (page cap 1000); status()-style counts via paginated scan are the
-    accepted R1 answer. */
+/** Every corpus scan pages with the keyset cursor (page cap 1000), including
+    the status() counts. */
 async function listAll(store: RecordStore, refs?: Record<string, string>): Promise<VendoRecord[]> {
   const records: VendoRecord[] = [];
   let cursor: string | undefined;
@@ -52,26 +55,21 @@ function snippetAround(text: string, tokens: string[]): string {
   return text.slice(start, at + SNIPPET_RADIUS * 2).trim();
 }
 
-/** Exact-lookup normalization for schema intent: a term matches on its title
-    case-insensitively, whitespace-insensitively, or via its slug form. */
-const exactKey = (text: string): string =>
-  text.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
-
-/** The built-in local lexical engine (free tier — knowledge design v2 R1/R3):
- * keyword retrieval over the host's own store, in the knowledge-owned
- * collections. Honestly keyword-grade — deterministic term-frequency ranking
- * with title/heading boosts, no embeddings, no fuzziness.
+/** The built-in local lexical engine (free tier): keyword retrieval over the
+ * host's own store, in the knowledge-owned collections. Honestly
+ * keyword-grade — deterministic term-frequency ranking with title/heading
+ * boosts, no embeddings, no fuzziness.
  *
- * Intents (LEXICAL INTENTS ruling): `chat` ranks token matches over chunks;
- * `deep` is an honest no-op escalation for a lexical engine (same retrieval —
- * engines behind the wire do real agentic deep search); `schema` is exact
- * term/title lookup over glossary/api docs where empty means not-found.
- * Scores are engine-relative and zero-match queries return zero hits.
+ * Intents: `chat` ranks token matches over chunks; `deep` is an honest no-op
+ * escalation for a lexical engine (same retrieval — engines behind the wire do
+ * real agentic deep search); `schema` is exact term/title lookup over
+ * glossary/api docs where empty means not-found. Scores are engine-relative
+ * and zero-match queries return zero hits.
  *
  * Zero-config: `knowledge: vendoKnowledge()` — createVendo injects the
- * composed store (server wiring, ENG-360). Pass `{ store }` to keep the
- * knowledge tables in a different database (BYO rule); until a store is
- * bound, operations fail loudly rather than pretending to be an empty corpus.
+ * composed store. Pass `{ store }` to keep the knowledge tables in a different
+ * database (BYO rule); until a store is bound, operations fail loudly rather
+ * than pretending to be an empty corpus.
  */
 export function vendoKnowledge(options: { store?: StoreAdapter } = {}): KnowledgeAdapter {
   const store = (): StoreAdapter => {
@@ -94,14 +92,14 @@ export function vendoKnowledge(options: { store?: StoreAdapter } = {}): Knowledg
 
   /** schema intent: exact term/title match over glossary+api docs. */
   async function schemaSearch(query: KnowledgeQuery, ctx: KnowledgeContext, limit: number): Promise<KnowledgeHit[]> {
-    const key = exactKey(query.text);
+    const key = termSlug(query.text);
     if (key.length === 0) return [];
     const hits: KnowledgeHit[] = [];
     for (const row of await listAll(docRows())) {
       const doc = row.data as KnowledgeDoc;
       if (doc.kind !== "glossary" && doc.kind !== "api") continue;
       if (!kindMatches(doc.kind, query.kinds) || !visible(doc.visibility, ctx)) continue;
-      if (exactKey(doc.title) !== key) continue;
+      if (termSlug(doc.title) !== key) continue;
       hits.push({
         ref: { docId: doc.id, title: doc.title, source: doc.source },
         snippet: doc.text.slice(0, SNIPPET_RADIUS * 2).trim(),
@@ -127,8 +125,8 @@ export function vendoKnowledge(options: { store?: StoreAdapter } = {}): Knowledg
       const tokens = tokenize(query.text);
       if (tokens.length === 0) return { hits: [] };
       const scored: { chunk: ChunkRow; score: number }[] = [];
-      // Visibility and kind filter BEFORE ranking (R5): invisible rows never
-      // enter the candidate set, so they cannot influence scores or limits.
+      // Visibility and kind filter BEFORE ranking: invisible rows never enter
+      // the candidate set, so they cannot influence scores or limits.
       for (const row of await listAll(chunkRows())) {
         const chunk = row.data as ChunkRow;
         if (!visible(chunk.visibility, ctx) || !kindMatches(chunk.kind, query.kinds)) continue;
@@ -149,7 +147,7 @@ export function vendoKnowledge(options: { store?: StoreAdapter } = {}): Knowledg
         b.score - a.score
         || (a.chunk.docId < b.chunk.docId ? -1 : a.chunk.docId > b.chunk.docId ? 1 : 0)
         || a.chunk.index - b.chunk.index);
-      // limit truncates the ranking, never changes it (R3).
+      // limit truncates the ranking, never changes it.
       return {
         hits: scored.slice(0, limit).map(({ chunk, score }) => ({
           ref: { docId: chunk.docId, chunkId: chunk.chunkId, title: chunk.title, source: chunk.source },
@@ -165,7 +163,7 @@ export function vendoKnowledge(options: { store?: StoreAdapter } = {}): Knowledg
       const row = await docRows().get(ref.docId);
       if (row === null) return null;
       const doc = row.data as KnowledgeDoc;
-      // A ref is not a capability: internal docs read as unknown (R5).
+      // A ref is not a capability: internal docs read as unknown.
       if (!visible(doc.visibility, ctx)) return null;
       if (ref.chunkId !== undefined) {
         const chunkRow = await chunkRows().get(ref.chunkId);
@@ -192,7 +190,7 @@ export function vendoKnowledge(options: { store?: StoreAdapter } = {}): Knowledg
         const keep = new Set(chunks.map((chunk) => chunk.chunkId));
         // Replace chunk rows: stale rows go first so a re-chunked doc never
         // leaves orphans, then the new rows land, then the doc row — by the
-        // time upsert resolves the doc is searchable (frozen invariant).
+        // time upsert resolves the doc is searchable.
         for (const stale of await listAll(chunkRows(), { doc_id: doc.id })) {
           if (!keep.has(stale.id)) await chunkRows().delete(stale.id);
         }

--- a/packages/knowledge/src/local/lexical.ts
+++ b/packages/knowledge/src/local/lexical.ts
@@ -21,12 +21,15 @@ import { termSlug } from "../ingest/parse.js";
 
 /** A stored chunk row: the chunk plus doc fields denormalized at upsert time
     (upsert replaces every chunk of a doc, so they can never go stale) —
-    search filters visibility and boosts titles without a per-row doc join. */
+    search filters visibility and boosts titles without a per-row doc join.
+    `source` is optional on READ only: rows written before it was denormalized
+    lack it and hash-based sync never rewrites an unchanged doc, so search
+    falls back to the doc row. Upsert always writes it. */
 interface ChunkRow extends KnowledgeChunk {
   kind: KnowledgeDoc["kind"];
   visibility: KnowledgeDoc["visibility"];
   title: string;
-  source: string;
+  source?: string;
 }
 
 /** Every corpus scan pages with the keyset cursor (page cap 1000), including
@@ -90,6 +93,11 @@ export function vendoKnowledge(options: { store?: StoreAdapter } = {}): Knowledg
   const kindMatches = (kind: KnowledgeKind, kinds: KnowledgeKind[] | undefined): boolean =>
     kinds === undefined || kinds.includes(kind);
 
+  /** The cited chunk's source, reading through to the doc row for chunks
+      written before `source` was denormalized onto the row. */
+  const chunkSource = async (chunk: ChunkRow): Promise<string | undefined> =>
+    chunk.source ?? ((await docRows().get(chunk.docId))?.data as KnowledgeDoc | undefined)?.source;
+
   /** schema intent: exact term/title match over glossary+api docs. */
   async function schemaSearch(query: KnowledgeQuery, ctx: KnowledgeContext, limit: number): Promise<KnowledgeHit[]> {
     const key = termSlug(query.text);
@@ -147,15 +155,16 @@ export function vendoKnowledge(options: { store?: StoreAdapter } = {}): Knowledg
         b.score - a.score
         || (a.chunk.docId < b.chunk.docId ? -1 : a.chunk.docId > b.chunk.docId ? 1 : 0)
         || a.chunk.index - b.chunk.index);
-      // limit truncates the ranking, never changes it.
+      // limit truncates the ranking, never changes it — so the doc-row
+      // fallback for source-less legacy chunks costs at most `limit` gets.
       return {
-        hits: scored.slice(0, limit).map(({ chunk, score }) => ({
-          ref: { docId: chunk.docId, chunkId: chunk.chunkId, title: chunk.title, source: chunk.source },
+        hits: await Promise.all(scored.slice(0, limit).map(async ({ chunk, score }) => ({
+          ref: { docId: chunk.docId, chunkId: chunk.chunkId, title: chunk.title, source: await chunkSource(chunk) },
           snippet: snippetAround(chunk.text, tokens),
           kind: chunk.kind,
           visibility: chunk.visibility,
           score,
-        })),
+        }))),
       };
     },
 

--- a/packages/knowledge/src/prompt-note.ts
+++ b/packages/knowledge/src/prompt-note.ts
@@ -2,13 +2,13 @@ import type { KnowledgeAdapter, KnowledgeStatus } from "@vendoai/core";
 import { VENDO_KNOWLEDGE_SEARCH_TOOL } from "./agent-tools.js";
 import { knowledgeConfigSchema, type KnowledgeConfig } from "./ingest/index.js";
 
-/** Knowledge k8 (ENG-368) — the static prompt index + usage guidance. Pure
+/** The static prompt index + usage guidance. Pure
     assembly: sources come from `.vendo/knowledge.json` (when the developer
     door wrote one), counts from the adapter's `status()`. The caller owns
     WHEN this runs (boot + sync-state change, never per-turn) — the output
     for a given input is byte-stable by construction.
 
-    Checker round 1 P0 (ENG-370 law): the index rides END-USER prompts, so it
+    The index rides END-USER prompts, so it
     names PUBLIC sources only — an internal source's existence is corpus
     metadata and must never surface on a principal-facing path, exactly like
     internal hits. Counts stay aggregate (no per-source identity). */
@@ -60,7 +60,7 @@ export interface KnowledgeIndexReaders {
 /** The index resolver assembleSystemPrompt consumes. Construction is PURE
     (createVendo may run at Workers module init, where I/O is forbidden).
 
-    Refresh contract (checker round 1 P1 — real invalidation, not a
+    Refresh contract (real invalidation, not a
     boot-forever lock):
     - At a FIXED sync state (same manifest bytes) every turn returns the SAME
       cached string — byte-stable, zero adapter I/O (prompt-cache stability).

--- a/packages/knowledge/src/wire.ts
+++ b/packages/knowledge/src/wire.ts
@@ -1,0 +1,122 @@
+import {
+  KNOWLEDGE_WIRE_PATHS,
+  VendoError,
+  knowledgeFetchResultSchema,
+  knowledgeSearchResultSchema,
+  knowledgeWireStatusSchema,
+  parseKnowledgeWireError,
+  type KnowledgeAdapter,
+  type KnowledgeContext,
+  type KnowledgePosture,
+  type KnowledgeStatus,
+} from "@vendoai/core";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/** How one client names its own failures. Everything else about speaking
+    `vendo/knowledge-wire@1` is identical for Cloud and BYO, so this is the
+    whole difference between them. */
+export interface WireErrors {
+  /** The transport never answered. */
+  unreachable: (cause: unknown) => Error;
+  /** Consulted before the wire's status mapping, for statuses this client
+      reads as its own (Cloud folds any 401 into a key problem, whatever the
+      response body claims). Return undefined to fall through. */
+  rejected?: (status: number) => Error | undefined;
+  /** 2xx with a body that is not the wire. */
+  badBody: (route: string) => Error;
+}
+
+export interface WireClientOptions {
+  /** The five wire paths are appended directly to this base. */
+  base: string;
+  bearer?: string;
+  posture: KnowledgePosture;
+  fetch?: typeof fetch;
+  errors: WireErrors;
+}
+
+/** The one `vendo/knowledge-wire@1` client. Both shipped engines are this
+    function plus a base url, a bearer, a posture and an error flavour, so a
+    retry, a header or a status mapping is added in exactly one place.
+
+    Optional members exist exactly when the declared posture covers them
+    (presence is conformance-tested, not promised) — a full-posture caller gets
+    fetch/upsert/remove, a search-only endpoint's adapter simply lacks them. */
+export function knowledgeWireAdapter(options: WireClientOptions): KnowledgeAdapter {
+  const { base, bearer, posture, errors } = options;
+  const transport = options.fetch ?? fetch;
+
+  async function call(path: string, init: { method: "GET" | "POST"; body?: unknown }): Promise<unknown> {
+    let response: Response;
+    try {
+      response = await transport(`${base}${path}`, {
+        method: init.method,
+        headers: {
+          ...(bearer === undefined ? {} : { authorization: `Bearer ${bearer}` }),
+          ...(init.body === undefined ? {} : { "content-type": "application/json" }),
+        },
+        ...(init.body === undefined ? {} : { body: JSON.stringify(init.body) }),
+        signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+      });
+    } catch (error) {
+      throw errors.unreachable(error);
+    }
+    const body: unknown = await response.json().catch(() => undefined);
+    const rejected = errors.rejected?.(response.status);
+    if (rejected !== undefined) throw rejected;
+    if (!response.ok) throw parseKnowledgeWireError(response.status, body);
+    return body;
+  }
+
+  const parse = <T>(
+    schema: { safeParse(value: unknown): { success: boolean; data?: unknown } },
+    value: unknown,
+    route: string,
+  ): T => {
+    const parsed = schema.safeParse(value);
+    if (!parsed.success) throw errors.badBody(route);
+    return parsed.data as T;
+  };
+
+  const includeInternal = (ctx: KnowledgeContext): { includeInternal?: boolean } =>
+    ctx.includeInternal === true ? { includeInternal: true } : {};
+
+  const adapter: KnowledgeAdapter = {
+    posture,
+
+    async search(query, ctx) {
+      const body = await call(KNOWLEDGE_WIRE_PATHS.search, { method: "POST", body: { query, ...includeInternal(ctx) } });
+      return parse(knowledgeSearchResultSchema, body, KNOWLEDGE_WIRE_PATHS.search);
+    },
+
+    async status(): Promise<KnowledgeStatus> {
+      const body = await call(KNOWLEDGE_WIRE_PATHS.status, { method: "GET" });
+      return parse<{ status: KnowledgeStatus }>(knowledgeWireStatusSchema, body, KNOWLEDGE_WIRE_PATHS.status).status;
+    },
+  };
+
+  if (posture.fetch) {
+    adapter.fetch = async (ref, ctx) => {
+      try {
+        const body = await call(KNOWLEDGE_WIRE_PATHS.fetch, { method: "POST", body: { ref, ...includeInternal(ctx) } });
+        return parse(knowledgeFetchResultSchema, body, KNOWLEDGE_WIRE_PATHS.fetch);
+      } catch (error) {
+        // Only an ENVELOPED not-found means document absence; a bare 404
+        // already degraded to "not-implemented" in the parser — the
+        // hosted-store lesson: a missing mount must not read as absence.
+        if (error instanceof VendoError && error.code === "not-found") return null;
+        throw error;
+      }
+    };
+  }
+  if (posture.write) {
+    adapter.upsert = async (docs) => {
+      await call(KNOWLEDGE_WIRE_PATHS.upsert, { method: "POST", body: { docs } });
+    };
+    adapter.remove = async (docIds) => {
+      await call(KNOWLEDGE_WIRE_PATHS.remove, { method: "POST", body: { docIds } });
+    };
+  }
+  return adapter;
+}

--- a/packages/knowledge/tsconfig.test.json
+++ b/packages/knowledge/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/packages/vendo-telemetry/package.json
+++ b/packages/vendo-telemetry/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "vitest run",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit",
     "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {

--- a/packages/vendo-telemetry/src/client.test.ts
+++ b/packages/vendo-telemetry/src/client.test.ts
@@ -26,7 +26,7 @@ describe("createTelemetry.track", () => {
     const t = createTelemetry(deps);
     await t.track("init_started", { framework: "next" });
     expect(deps.fetchImpl).toHaveBeenCalledOnce();
-    const [url, init] = deps.fetchImpl.mock.calls[0];
+    const [url, init] = deps.fetchImpl.mock.calls[0]!;
     expect(String(url)).toContain("us.i.posthog.com");
     const body = JSON.parse((init as { body: string }).body);
     expect(body.api_key).toBe("phc_test");
@@ -54,7 +54,7 @@ describe("createTelemetry.track", () => {
     const deps = makeDeps();
     const t = createTelemetry(deps);
     await t.track("init_started", { framework: "next", sourceCode: "secret" } as never);
-    const body = JSON.parse((deps.fetchImpl.mock.calls[0][1] as { body: string }).body);
+    const body = JSON.parse((deps.fetchImpl.mock.calls[0]![1] as { body: string }).body);
     expect(body.properties.sourceCode).toBeUndefined();
     expect(body.properties.framework).toBe("next");
   });
@@ -63,7 +63,7 @@ describe("createTelemetry.track", () => {
     const deps = makeDeps();
     const t = createTelemetry(deps);
     await t.track("init_started", { framework: "a".repeat(5000) });
-    const body = JSON.parse((deps.fetchImpl.mock.calls[0][1] as { body: string }).body);
+    const body = JSON.parse((deps.fetchImpl.mock.calls[0]![1] as { body: string }).body);
     expect(body.properties.framework.length).toBeLessThanOrEqual(512);
   });
 
@@ -71,7 +71,7 @@ describe("createTelemetry.track", () => {
     const deps = makeDeps();
     const t = createTelemetry(deps);
     await t.track("init_started", { framework: { nested: "secret" } } as never);
-    const body = JSON.parse((deps.fetchImpl.mock.calls[0][1] as { body: string }).body);
+    const body = JSON.parse((deps.fetchImpl.mock.calls[0]![1] as { body: string }).body);
     expect(body.properties.framework).toBeUndefined();
   });
 
@@ -86,7 +86,7 @@ describe("createTelemetry.track", () => {
       });
       const t = createTelemetry(deps);
       await t.track("agent_run", {});
-      const body = JSON.parse((deps.fetchImpl.mock.calls[0][1] as { body: string }).body);
+      const body = JSON.parse((deps.fetchImpl.mock.calls[0]![1] as { body: string }).body);
       expect(body.properties.packageManager).toBe("pnpm");
       expect(body.properties.projectIdHash).toMatch(/^[0-9a-f]{64}$/);
     } finally {
@@ -100,7 +100,7 @@ describe("createTelemetry.track", () => {
       const deps = makeDeps({ cwd });
       const t = createTelemetry(deps);
       await t.track("agent_run", {});
-      const body = JSON.parse((deps.fetchImpl.mock.calls[0][1] as { body: string }).body);
+      const body = JSON.parse((deps.fetchImpl.mock.calls[0]![1] as { body: string }).body);
       expect("projectIdHash" in body.properties).toBe(false);
       expect("packageManager" in body.properties).toBe(false);
     } finally {
@@ -118,14 +118,14 @@ describe("createTelemetry.track", () => {
     const deps = makeDeps({ env: { VENDO_POSTHOG_HOST: "https://posthog.internal:8000" } });
     const t = createTelemetry(deps);
     await t.track("init_started", { framework: "next" });
-    expect(String(deps.fetchImpl.mock.calls[0][0])).toBe("https://posthog.internal:8000/capture/");
+    expect(String(deps.fetchImpl.mock.calls[0]![0])).toBe("https://posthog.internal:8000/capture/");
   });
 
   it("falls back to the shipped cloud when the override is unusable", async () => {
     const deps = makeDeps({ env: { VENDO_POSTHOG_HOST: "not a url" } });
     const t = createTelemetry(deps);
     await t.track("init_started", { framework: "next" });
-    expect(String(deps.fetchImpl.mock.calls[0][0])).toContain("us.i.posthog.com");
+    expect(String(deps.fetchImpl.mock.calls[0]![0])).toContain("us.i.posthog.com");
   });
 
   it("returns after the telemetry timeout when fetch never settles", async () => {
@@ -243,7 +243,7 @@ describe("default transport (no fetchImpl)", () => {
 const CLOUD_KEY = `vnd_${"0123456789abcdef".repeat(2)}01234567`; // 40 hex chars
 
 function sentProps(deps: ReturnType<typeof makeDeps>): Record<string, unknown> {
-  const body = JSON.parse((deps.fetchImpl.mock.calls[0][1] as { body: string }).body);
+  const body = JSON.parse((deps.fetchImpl.mock.calls[0]![1] as { body: string }).body);
   return body.properties as Record<string, unknown>;
 }
 
@@ -348,7 +348,7 @@ describe("cloud lane (VENDO_API_KEY)", () => {
     // errorDetail even carries the key itself — the scrubbed hash-only
     // markers are all that may reach the wire.
     await t.track("init_failed", { errorDetail: `401: key ${CLOUD_KEY} rejected` });
-    const rawBody = (deps.fetchImpl.mock.calls[0][1] as { body: string }).body;
+    const rawBody = (deps.fetchImpl.mock.calls[0]![1] as { body: string }).body;
     expect(rawBody).not.toContain(CLOUD_KEY);
   });
 

--- a/packages/vendo-telemetry/src/client.ts
+++ b/packages/vendo-telemetry/src/client.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { request as httpRequest, type ClientRequest } from "node:http";
 import { request as httpsRequest } from "node:https";
-import { resolveConsent } from "./consent.js";
+import { resolveConsent, truthy } from "./consent.js";
 import { baseProps, projectProps, type ProjectProps } from "./base-props.js";
 import { CLOUD_PROP_KEYS, EVENT_ALLOWLIST, type EventName } from "./events.js";
 import { scrubErrorDetail } from "./scrub.js";
@@ -194,14 +194,11 @@ export function createTelemetry(deps: TelemetryDeps): Telemetry {
   // Internal lane: VENDO_INTERNAL=1 tags events instead of dropping them, so
   // internal harnesses (cert campaigns, eval sandboxes) that intentionally
   // exercise the real telemetry path stay verifiable end-to-end while
-  // analytics filters them out on `internal = true`. Same truthy values as
-  // consent.ts. Deliberately NOT a consent input — CI / DO_NOT_TRACK /
-  // VENDO_TELEMETRY_DISABLED semantics are unchanged, and this marker is
-  // producer-set like the cloud markers so callers can never spoof it.
-  const internalMarker =
-    deps.env.VENDO_INTERNAL === "1" || deps.env.VENDO_INTERNAL === "true"
-      ? { internal: true }
-      : {};
+  // analytics filters them out on `internal = true`. Deliberately NOT a
+  // consent input — CI / DO_NOT_TRACK / VENDO_TELEMETRY_DISABLED semantics are
+  // unchanged, and this marker is producer-set like the cloud markers so
+  // callers can never spoof it.
+  const internalMarker = truthy(deps.env.VENDO_INTERNAL) ? { internal: true } : {};
   // Filesystem-backed props are computed once per client, never per event.
   // Guarded so the never-throw contract holds at the API surface even if
   // cwd resolution or the filesystem probes fail in an unexpected way.

--- a/packages/vendo-telemetry/src/config.test.ts
+++ b/packages/vendo-telemetry/src/config.test.ts
@@ -38,26 +38,26 @@ describe("config store", () => {
     expect(reread.noticeShown).toBe(true);
   });
 
-  it("honors a hand-written opt-out even without an anonymous id (review)", () => {
+  it("honors a hand-written opt-out even without an anonymous id", () => {
     mkdirSync(configDir(home), { recursive: true });
     writeFileSync(configPath(home), JSON.stringify({ optedOut: true }), "utf8");
-    const c = loadConfig(home);
+    const c = loadConfig(home, {});
     expect(c.optedOut).toBe(true);
   });
 
-  it("does not mint or persist a tracking id when an env opt-out is set (review)", () => {
+  it("does not mint or persist a tracking id when an env opt-out is set", () => {
     const c = loadConfig(home, { DO_NOT_TRACK: "1" });
     expect(c.optedOut).toBe(true);
     expect(existsSync(configPath(home))).toBe(false);
   });
 
-  it("still writes a normal opted-in config on first run without env opt-out (review)", () => {
+  it("still writes a normal opted-in config on first run without env opt-out", () => {
     const c = loadConfig(home, {});
     expect(c.optedOut).toBe(false);
     expect(existsSync(configPath(home))).toBe(true);
   });
 
-  it("degrades to an in-memory config when the config dir can't be written (review)", () => {
+  it("degrades to an in-memory config when the config dir can't be written", () => {
     // Make configDir un-creatable: a file where the .vendo parent must be a dir.
     const badHome = join(home, "as-file");
     writeFileSync(badHome, "x", "utf8"); // badHome/.vendo/... → ENOTDIR on mkdir

--- a/packages/vendo-telemetry/src/consent.ts
+++ b/packages/vendo-telemetry/src/consent.ts
@@ -11,7 +11,8 @@ export interface ConsentResult {
   reason: string;
 }
 
-function truthy(v: string | undefined): boolean {
+/** The one spelling of an env flag being on, shared by every reader. */
+export function truthy(v: string | undefined): boolean {
   return v === "1" || v === "true";
 }
 

--- a/packages/vendo-telemetry/src/notice.test.ts
+++ b/packages/vendo-telemetry/src/notice.test.ts
@@ -1,7 +1,23 @@
 import { describe, it, expect, vi } from "vitest";
+import { envOptOut } from "./consent.js";
 import { maybeShowNotice } from "./notice.js";
 
 describe("maybeShowNotice", () => {
+  it("advertises only opt-outs this package actually honors", () => {
+    const log = vi.fn();
+    maybeShowNotice({ anonymousId: "x", optedOut: false, noticeShown: false }, { log, save: vi.fn() });
+    const notice = log.mock.calls[0][0] as string;
+
+    const named = [...notice.matchAll(/\b([A-Z][A-Z_]+)=1\b/g)].map(([, name]) => name!);
+    expect(named.length).toBeGreaterThan(0);
+    for (const name of named) expect(envOptOut({ [name]: "1" })).toBe(true);
+
+    // This package deliberately depends on no @vendoai package, so it can never
+    // check that a `vendo …` command exists. Naming one is how the notice came
+    // to advertise `vendo telemetry disable`, which the CLI has never had.
+    expect(notice).not.toMatch(/`vendo /);
+  });
+
   it("prints once and marks the config", () => {
     const log = vi.fn();
     const save = vi.fn();

--- a/packages/vendo-telemetry/src/notice.test.ts
+++ b/packages/vendo-telemetry/src/notice.test.ts
@@ -6,7 +6,7 @@ describe("maybeShowNotice", () => {
   it("advertises only opt-outs this package actually honors", () => {
     const log = vi.fn();
     maybeShowNotice({ anonymousId: "x", optedOut: false, noticeShown: false }, { log, save: vi.fn() });
-    const notice = log.mock.calls[0][0] as string;
+    const notice = log.mock.calls[0]![0] as string;
 
     const named = [...notice.matchAll(/\b([A-Z][A-Z_]+)=1\b/g)].map(([, name]) => name!);
     expect(named.length).toBeGreaterThan(0);
@@ -26,7 +26,7 @@ describe("maybeShowNotice", () => {
       { log, save },
     );
     expect(log).toHaveBeenCalledOnce();
-    expect(log.mock.calls[0][0]).toContain("TELEMETRY.md");
+    expect(log.mock.calls[0]![0]).toContain("TELEMETRY.md");
     expect(save).toHaveBeenCalledOnce();
     expect(shown.noticeShown).toBe(true);
   });

--- a/packages/vendo-telemetry/src/notice.ts
+++ b/packages/vendo-telemetry/src/notice.ts
@@ -3,8 +3,8 @@ import type { TelemetryConfig } from "./config.js";
 const NOTICE = [
   "Vendo collects anonymous, opt-out usage telemetry to guide development.",
   "No code, prompts, file contents, or keys are ever collected.",
-  "Details and opt-out: TELEMETRY.md; disable now: `vendo telemetry disable`",
-  "(also honored: VENDO_TELEMETRY_DISABLED=1, DO_NOT_TRACK=1, CI)",
+  "Details and opt-out: TELEMETRY.md; disable now: VENDO_TELEMETRY_DISABLED=1",
+  "(also honored: DO_NOT_TRACK=1, CI)",
 ].join("\n");
 
 export interface NoticeIO {

--- a/packages/vendo-telemetry/tsconfig.test.json
+++ b/packages/vendo-telemetry/tsconfig.test.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "noEmit": true },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
De-slop sweep across four small packages — `@vendoai/knowledge`, `@vendoai/bench`,
`@vendoai/telemetry`, `@vendoai/corpus-harness` — worked worst-first: correctness
bugs, then dead code, then verbosity.

**+431 / −494 across 39 files, net −63.** Per package:
`knowledge` +291/−287 · `telemetry` +48/−29 · `bench` +3/−33 · `corpus` +43/−145.

## Correctness (failing test first, in the existing behavior-named suite)

**1. `knowledge` — chat citations lost their provenance.** The local lexical engine
denormalized `kind`/`visibility`/`title` from the doc into each chunk row but not
`source`, so the chat/deep ref shape had no `source` while the schema-intent and
`fetch` shapes did. `toCitation` forwards `source` only when present, so every
citation an agent produced on the *default* retrieval path silently dropped the
file or URL the text came from — only glossary lookups and the cloud engine
carried it, and the conformance suite never checked. `source` now rides the chunk
row and the hit ref; all three intents return the same shape.
`c97326b5c` (test) → `c188b87e5` (fix)

**2. `corpus` — two visible toasts crashed the no-error-toast assertion.**
`countErrorDomSignals` read the multi-match `.fl-toast:visible` locator with
`textContent()`, which Playwright's strict mode rejects. The throw escaped the
unguarded first `evaluateAssertions()` in `waitForAssertions` and landed in
`runAttempt`'s catch, so a conversation showing two benign toasts ("Saved",
"Copied") was recorded as a Layer 3 *error* rather than an assertion result. It
also miscounted: on a concatenated match it scored **every** toast as an error.
Now reads `allTextContents()` and counts only the entries that look like errors.

The fake could never have caught this — `FakeLocator.textContent()` answered
happily at any element count. The fake now throws the way strict mode does; the
new case fails on the old implementation. `18b60f8e2` (test) → `b5cddce7f` (fix)

**3. `telemetry` — the privacy notice told every new user to run a command that
does not exist.** The one-time consent notice said "disable now:
`vendo telemetry disable`". The CLI has no `telemetry` branch and the only
occurrence of that string anywhere in the repo was the notice itself, so the
single actionable instruction in the privacy notice failed with an
unknown-command error. It now names `VENDO_TELEMETRY_DISABLED=1`, which the very
next line already listed and TELEMETRY.md has documented all along (no doc change
needed — the docs were right, the code lied).

The old test asserted only that the string contained "TELEMETRY.md". It now
checks every env var the notice names is one `envOptOut` actually honors, and
that the notice names no `vendo …` command at all — this package depends on no
`@vendoai` package by design, so it can never verify a CLI command exists.
`81dcaf56b` (test) → `01bd49062` (fix)

**4. `telemetry` — an opt-out test passed for CI's reason, not its own.**
`loadConfig` defaults its env to `process.env`; under a CI runner `CI=true` is an
env opt-out, so the hand-written-`{optedOut:true}` case asserted `true` without
the config file mattering. Passes the explicit empty env its neighbours pass.
`cd71c05ad`

**5. `knowledge` + `telemetry` — the tests were never typechecked, and a call that
cannot compile proved it.** Both tsconfigs exclude `src/**/*.test.ts` and both
`typecheck` scripts run that same tsconfig, so ~1,600 lines of tests were checked
by no gate. The bill was already in the tree: `agent-tools.test.ts:447` called
`createKnowledgeTools({ adapter: memoryKnowledgeAdapter([]) })` — the first
parameter is a `KnowledgeAdapter`, not `{ adapter }`, and `memoryKnowledgeAdapter`
takes `{ docs }`, not an array. It passed because `descriptors()` never touches
the adapter, so its one real assertion proved nothing about an adapter at all.
That assertion now lives in the descriptor pin test above it, which builds a real
adapter. Both packages ship a `tsconfig.test.json` and run it, matching `guard`.
`40450615e`

## Dead code

**`corpus` — `docker-redis` provisioning, zero users.** Twenty was its only boot
and #950 deleted it. What was left: a schema branch, a redis arm in every
conditional inside `defaultProvisionDatabase`, a second handle + teardown in
`bootRepo`, and two tests that exercised only each other — the source comment
already said "No fixture currently boots Redis." **Verified:** no manifest entry
carries a `bootstrap.redis` block; the `REDIS_URL`/`UPSTASH_*` strings in
`corpus/manifest.json` are `envTemplate` values pointing at services the harness
never provisioned. `DatabaseProvisioning` is now the postgres shape directly, so
the union, the kind ternaries and the `isReady` indirection all collapse. −102 LOC.
`1064578da`

**`bench` — the library entry point nothing imports.** `bench/src/index.ts`
re-exported the harness for consumers that do not exist: no package declares
`@vendoai/bench` as a dependency, nothing imports it (`run.ts` and
`budgets.test.ts` reach for `./benches/index.js` directly), and the package is
private. `main`/`types` pointed at that dead entry, so declaration emit was
building `.d.ts` for nobody. Also drops the `budgetKey` and `loadBudgets`
describes (one asserts a template literal, the other that a committed JSON file
parses — both implied by the integrity suite above them) and renames
automations-tick's local zero-descriptor registry to `idleTools` so it stops
shadowing the three-tool `benchTools` fixture it is not a copy of. `3c252462d`

## Verbosity

**`knowledge` — one wire client behind both shipped engines.** `cloudKnowledge`
and `httpKnowledge` were the same `vendo/knowledge-wire@1` client written twice:
identical `call()` transport, identical local `parse()` helper with the same
hand-rolled structural type, identical `includeInternal()`, identical route
bodies. Only four things ever differed — base path, mandatory-vs-optional bearer,
posture, and how the client words its own errors. `wire.ts` holds the client and
takes those four as arguments; both engines *are* the argument list. No behaviour
change for either. Also: `exactKey` was byte-identical to ingest's `termSlug` and
has to stay that way (schema lookup matches a title against the same
normalization ingest used to mint the term's id), so it imports the one function;
comment archaeology (ticket ids, R-numbers, round numbers, dates) stripped
package-wide, keeping the sentence that states the constraint. `786746c87`

**`telemetry` — one spelling of an env flag being on.** `client.ts` open-coded
`=== "1" || === "true"` for `VENDO_INTERNAL` with a comment pointing at
`consent.ts`'s private `truthy()` as the thing it was copying. Exports that
instead. Stays inside the package. `ba1e5a9ec`

---

## Rejected leads — every one dispositioned

**`knowledge`: delete `index.test.ts`, "asserts two constants equal their own
literals"** — **REJECTED, and this is law #1 firing a fifth time.**
`KNOWLEDGE_DOCS_COLLECTION` / `KNOWLEDGE_CHUNKS_COLLECTION` are imported by
`vendo-web/apps/console/tests/knowledge-table-collision.test.ts`, which guards
the K16 incident: the console once created its canonical knowledge table under
the OSS store's published record-collection name, and in hosted mode both run
`CREATE TABLE IF NOT EXISTS` against the *same* data-plane database. These are
released cross-repo constants, not a self-mirror. The test is **kept** and
renamed to say what it guards. The companion finding "fold the constants into
`local/lexical.ts` and remove `collections.ts`" is rejected for the same reason.

**`knowledge`: delete `CallRateBreaker`, "nobody can configure or asked for"** —
**REJECTED.** The option is never passed in production, but the *default* 60
calls/minute breaker is live on every knowledge tool call in every deployment.
Deleting it removes real rate limiting, not dead code. (The many other
`maxCallsPerMinute` hits in the repo belong to guard's separate, well-used
breaker.)

**`knowledge`: make the unreachable case throw `VendoError` in both clients** —
**REJECTED** (did the merge without it). No `VendoErrorCode` honestly names "the
host's own endpoint is down"; `agent-tools`' `errorOutcome` already maps a bare
`Error` to `code: "internal"`, which is exactly what a `VendoError("internal")`
would produce — so the change buys nothing and loses the `{ cause }` chain.

**`telemetry`: cut the barrel to the ten names actually consumed** — **REJECTED.**
Of the eight exports with no external importer, five are either the nameable
types of public functions (`InitTelemetryOptions`, `RepoHost`, `Telemetry`) or
the host-facing consent/config surface a published privacy package should keep
(`resolveConsent`, `saveConfig`, `configPath`). Only three are true internals —
not worth a breaking change to a published package, especially since `edge.ts`
is a portability-gated mirror of the barrel and would have to move in lockstep.

**`telemetry`: delete the unreachable try/catch in `scrub.ts`** — **REJECTED.**
It is the last line of defence on `errorDetail`, the only free-text property
Vendo ever sends. Four lines, and "unreachable" is precisely the claim you do not
want to be wrong about in a redaction path.

**`bench`: delete `gen-live.ts`, `e2b.ts` and the live/deterministic duality** —
**REJECTED for now.** Confirmed they never run in CI (no reference in
`.github/`, `turbo.json`, or root `package.json`) and both self-skip without
`ANTHROPIC_API_KEY` / `E2B_API_KEY` — but they are hand-runnable and are the only
latency measurement of the live gen and sandbox paths. Deleting a measurement
capability is a product call, not a de-slop call.

**`corpus`: `withoutShadowedRoutes` now has one mount source where it had two** —
**OUT OF SCOPE, not acted on.** Verified it lives in
`packages/actions/src/sync/extractors.ts:86` (private, one caller, same file,
covered by name-free tests in `extractors.test.ts:62` and `trpc.test.ts`).
`packages/actions/**` belongs to a piece in flight. Flagging, not touching.

## vendo-web disposition

**No companion PR needed. No file in `vendo-web` breaks.** Verified by grepping
the sibling clone for every symbol I touched or removed:

- `toCitation`, `termSlug`, `exactKey`, `docId` (fn), `CallRateBreaker`,
  `saveConfig`, `configPath`, `resolveConsent`, `createTelemetry`,
  `maybeShowNotice`, `docker-redis`, `SuiteKind`, `budgetKey` — **zero hits**
  anywhere in `vendo-web`.
- `@vendoai/knowledge` has exactly **one** importer in `vendo-web`:
  `apps/console/tests/knowledge-table-collision.test.ts`, which imports the two
  collection constants. **Both are unchanged and still exported** — that is why
  I kept `collections.ts` and `index.test.ts` (above).
- `@vendoai/telemetry` is declared and vendored in `vendo-web` but has **zero
  import statements**; the console runs its own PostHog provider with an
  independently-defined `DEFAULT_POSTHOG_KEY` (a name collision, not a use).
- `@vendoai/bench` — **zero references**.
- The console's copies of the corpus data (`docs/eval/knowledge-cloud/inputs/
  corpus.json`, `golden.json`, `refusals.json`) are **frozen snapshots pinned to
  an older vendo commit**, not mirrors — a shipped tuning constant is derived
  from them, so editing them to "match" would decouple a live threshold from its
  measurements. **Left alone deliberately.** I touched no corpus fixture data.

## Deferred — with reasons

**`telemetry`: `loadConfig` secretly mints and persists a tracking id on read.**
**STOP — expected vs found.** The finding is real: booting a production Vendo
server creates a persistent anonymous id in the deploying machine's `~/.vendo/`
even though product telemetry is fail-closed in production. *Expected* the fix to
be containable inside `packages/vendo-telemetry`. *Found* that it is not:
`capability-misses.ts:239` uses `telemetryConfig.anonymousId` as the capability-
miss uploader's `hostId`. Making `loadConfig` a pure read hands that uploader an
empty (or per-process ephemeral) `hostId` — a silent regression in a cloud
feature. The correct fix splits `loadConfig` / `ensureAnonymousId` **and** changes
one line in `packages/vendo/src/capability-misses.ts` to mint inside the
cloud-uploader branch. `packages/vendo/**` belongs to a piece in flight, so I
stopped rather than reach into it. Ready to land as a one-file follow-up.

**`bench`: the memory store re-implements core's, diverged, invalidates
measurements.** **NEEDS-DECISION.** Confirmed the diagnosis — the 122-line copy
omits `atomic`/`claim`, and `automations/engine.ts`, `apps/persistence.ts`,
`apps/placements.ts` and `guard/guard.ts` all take a degraded `put()` fallback
when `atomic === undefined`, so three of six gated suites time a path production
never executes. The fix requires re-measuring and recalibrating three ceilings in
`budgets.json` in the same PR. **I will not calibrate perf ceilings on a shared
8-core box with ~7 other agents active** — the numbers would be noise baked into
a permanent gate. Needs a quiet machine.

**`corpus`: the four remaining HIGH refactors** — the `cli.test.ts` `makeDeps`
builder (~700 LOC), the fourteen spawn-and-collect copies (~200 LOC), the
hand-written Playwright/ChildProcess shims (~120 LOC), and the `prepareRepo`
extraction (~90 LOC). Each is a substantial standalone change in a 24k-line
package; bundling them here would have made the diff unreviewable. Deferred as
their own slice.

## Changesets

- `@vendoai/knowledge` — **minor**: public surface changed (`toCitation` dropped
  from the barrel; it had no importer anywhere including `vendo-web`), plus the
  citation-provenance fix and the wire-client merge.
- `@vendoai/telemetry` — **patch**: the notice string fix and internal dedup; no
  public surface change.
- `@vendoai/bench` and `@vendoai/corpus-harness` — **no changeset**: both are
  `"private": true` and unpublished.

## Constraint honoured

`@vendoai/telemetry` gained **no** `@vendoai/*` dependency, was not merged into
another package, and had nothing shared into it from elsewhere. The `truthy`
dedup is entirely intra-package. The one finding that proposed folding telemetry
into `packages/vendo/` is logged rejected on that basis. `scripts/dependency-guard.mjs`
and `scripts/portability-gate.mjs` both pass.

## Gate — foreground, redirected to files, read back

```
BUILD      Tasks: 21 successful, 21 total          4m04s
TYPECHECK  Tasks: 40 successful, 40 total (--force) 3m36s
LINT       Tasks:  3 successful,  3 total (--force)   39s

@vendoai/knowledge       Test Files 8 passed (8)    Tests  87 passed (87)
@vendoai/telemetry       Test Files 9 passed (9)    Tests 124 passed (124)
@vendoai/bench           Test Files 4 passed (4)    Tests  30 passed (30)
@vendoai/corpus-harness  Test Files 38 passed | 1 skipped (39)
                         Tests 347 passed | 2 skipped (349)
```

All suites run with `VITEST_MIN_FORKS=1 VITEST_MAX_FORKS=2 VITEST_MIN_THREADS=1
VITEST_MAX_THREADS=2`. Never ran the full repo suite. Every deleted symbol was
re-grepped repo-wide including test dirs after committing — the trap where a
package's typecheck excludes its tests is exactly what commit `40450615e` closes
for two of these four packages.

## Review round 1 — Greptile P1 "Legacy chunks lose citation provenance"

**Real, and fixed here without any host action.** Confirmed by running it, not
by reading it. Chunk-level `source` did not exist before this PR, so *every*
store any shipped version synced holds chunk rows without it — and
`vendo knowledge sync` upserts only documents whose content hash changed
(`packages/vendo/src/cli/knowledge/index.ts`), so those rows would never be
rewritten. On a store seeded and then stripped back to that shape, the fixed
retrieval path returned `ref.source === undefined`; on a freshly synced store it
returned the doc's source.

The provenance is on disk, though: the doc row has always carried `source`
(`docRows().put({ ..., refs: { source: doc.source } })`). Search now reads
through to it when the chunk row has none — only for hits that survive the
`limit`, and only when the field is missing, so a fresh store does zero extra
reads. **No migration, no backfill, no re-sync, nothing for a host to run.**
No real store was touched.

`4eea9f1e1` (test — `falls back to the doc row for chunks written before chunk
rows carried a source`, in `local/lexical.test.ts`) → `d77b92463` (fix).

**vendo-web:** no companion PR. The change is read-side only — the persisted
chunk-row shape written by `upsert` in
`packages/knowledge/src/local/lexical.ts` is byte-identical to what this PR
already had. The console's one importer
(`apps/console/tests/knowledge-table-collision.test.ts`) reads the two
collection-name constants, both untouched.

**Round-1 gate** (rebased onto `origin/main` @ `15f475901`, 29 PRs of drift):

```
BUILD --filter=@vendoai/knowledge...   Tasks: 2 successful, 2 total       4.6s
@vendoai/knowledge                     Test Files 8 passed (8)  Tests 88 passed (88)
TYPECHECK (root)                       Tasks: 40 successful, 40 total  1m23s
LINT (root, --force)                   Tasks: 3 successful, 3 total    15.3s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing citation provenance and adds a no‑migration fallback for legacy chunks; stabilizes e2e toast checks; and corrects the telemetry opt‑out notice. Also unifies the knowledge wire client, removes unused Redis/bench code, and typechecks tests.

- **Bug Fixes**
  - `@vendoai/knowledge`: Chat/deep hits now include `source`; legacy chunks without `source` fall back to the doc row so citations keep provenance without a re‑sync; all intents return the same ref shape.
  - `@vendoai/corpus-harness`: Toast assertions read all visible toasts, avoid Playwright strict‑mode errors, and only count error‑looking toasts.
  - `@vendoai/telemetry`: Privacy notice points to `VENDO_TELEMETRY_DISABLED=1`. Tests verify only honored env vars are advertised and pass an explicit empty env to avoid `CI=true` leakage.

- **Refactors**
  - `@vendoai/knowledge`: Added a shared `knowledgeWireAdapter` used by both `cloud` and `http`; exact term matching uses ingest’s `termSlug` internally; stopped exporting `toCitation` and `termSlug` from barrels.
  - `@vendoai/corpus-harness`: Removed unused Docker Redis provisioning and simplified database provisioning types.
  - `@vendoai/bench`: Removed unused library entry and declaration emit; minor fixture/test cleanup.
  - `@vendoai/telemetry`: Exported shared `truthy` for env flags and reused for `VENDO_INTERNAL`.
  - Tests: Added `tsconfig.test.json` in `@vendoai/knowledge` and `@vendoai/telemetry` and typecheck tests.

<sup>Written for commit 5de13c82304f21d6a3a7e907663ce808bf6976b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

