### PR TITLE
fix(demo-bank): scenario cards name their own beat, so a reorder cannot swap the demo's script

### DIFF
--- a/examples/demo-bank/src/demo-script/engine.test.ts
+++ b/examples/demo-bank/src/demo-script/engine.test.ts
@@ -82,16 +82,26 @@ const threadState = vi.hoisted(() => ({
 
 /** The scenario ladder is host copy: cards get added, dropped and reordered.
  *  `reversed` serves the SAME cards in a different order (which must not
- *  change which script a card plays); `dropped` removes one card entirely. */
-const scenarioLadder = vi.hoisted(() => ({ reversed: false, dropped: "" }));
+ *  change which script a card plays); `dropped` removes one card entirely;
+ *  `collided` prepends a transfer card carrying the spending card's prompt
+ *  (padded with whitespace, so it trims to the same routing key) — the
+ *  duplicate that would hand the choice of script back to ladder order. */
+const scenarioLadder = vi.hoisted(() => ({ reversed: false, dropped: "", collided: false }));
 
 vi.mock("@/vendo/scenarios", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/vendo/scenarios")>();
+  const card = (beat: string): (typeof actual.mapleScenarios)[number] => {
+    const found = actual.mapleScenarios.find((candidate) => candidate.beat === beat);
+    if (found === undefined) throw new Error(`no Maple scenario card declares beat "${beat}"`);
+    return found;
+  };
   return {
     ...actual,
     get mapleScenarios() {
-      const cards = actual.mapleScenarios.filter((card) => card.beat !== scenarioLadder.dropped);
-      return scenarioLadder.reversed ? [...cards].reverse() : cards;
+      const cards = actual.mapleScenarios.filter((candidate) => candidate.beat !== scenarioLadder.dropped);
+      const ladder = scenarioLadder.reversed ? [...cards].reverse() : cards;
+      if (!scenarioLadder.collided) return ladder;
+      return [{ ...card("transfer"), prompt: `  ${card("spending").prompt}  ` }, ...ladder];
     },
   };
 });
@@ -141,6 +151,7 @@ describe("scripted beats stream wire-safe tool parts", () => {
     threadState.persisted = [];
     scenarioLadder.reversed = false;
     scenarioLadder.dropped = "";
+    scenarioLadder.collided = false;
   });
 
   it("the low-balance beat streams every tool input as an object (Anthropic replay contract)", async () => {
@@ -231,6 +242,20 @@ describe("scripted beats stream wire-safe tool parts", () => {
     scenarioLadder.dropped = "moneyhq";
     vi.resetModules();
     await expect(import("./engine.js")).rejects.toThrow(/moneyhq/);
+  });
+
+  it("two cards sharing a prompt fail at import, naming both beats", async () => {
+    scenarioLadder.collided = true;
+    vi.resetModules();
+    const error = await import("./engine.js").then(
+      () => undefined,
+      (thrown: unknown) => thrown as Error,
+    );
+    expect(error, "a duplicate prompt must not boot — first match would decide the script").toBeDefined();
+    expect(error?.message).toContain("transfer");
+    expect(error?.message).toContain("spending");
+    expect(error?.message).toContain(cardPrompt("Where did my money go?"));
+    expect(error?.message).toContain("src/vendo/scenarios.tsx");
   });
 
   it("a parked set abandoned by the next prompt resolves non-orphan — real-agent replay never 400s (criterion 23)", async () => {

--- a/examples/demo-bank/src/demo-script/engine.test.ts
+++ b/examples/demo-bank/src/demo-script/engine.test.ts
@@ -80,6 +80,21 @@ const threadState = vi.hoisted(() => ({
   persisted: [] as unknown[],
 }));
 
+/** The scenario ladder is host copy: cards get added, dropped and reordered.
+ *  Flipping this serves the SAME cards in a different order, which must not
+ *  change which script a card plays. */
+const scenarioOrder = vi.hoisted(() => ({ reversed: false }));
+
+vi.mock("@/vendo/scenarios", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/vendo/scenarios")>();
+  return {
+    ...actual,
+    get mapleScenarios() {
+      return scenarioOrder.reversed ? [...actual.mapleScenarios].reverse() : actual.mapleScenarios;
+    },
+  };
+});
+
 vi.mock("./threads", () => ({
   loadScriptedThread: vi.fn(async () => ({ id: "thr_test", messages: threadState.messages as UIMessage[] })),
   persistScriptedThread: vi.fn(async (_principal: unknown, _id: unknown, messages: unknown[]) => {
@@ -90,7 +105,15 @@ vi.mock("./threads", () => ({
   },
 }));
 
+import { mapleScenarios } from "@/vendo/scenarios";
 import { scriptedThreadsResponse } from "./engine";
+
+/** The prompt a card sends on tap, found by its headline — never by position. */
+function cardPrompt(title: string): string {
+  const card = mapleScenarios.find((candidate) => candidate.title === title);
+  if (card === undefined) throw new Error(`no Maple scenario card titled "${title}"`);
+  return (card.prompt ?? card.title).trim();
+}
 
 function threadsRequest(text: string): Request {
   return new Request("http://localhost:3000/api/vendo/threads", {
@@ -115,9 +138,10 @@ describe("scripted beats stream wire-safe tool parts", () => {
     vi.clearAllMocks();
     threadState.messages = [];
     threadState.persisted = [];
+    scenarioOrder.reversed = false;
   });
 
-  it("card (e) low-balance beat: every tool input is an object (Anthropic replay contract)", async () => {
+  it("the low-balance beat streams every tool input as an object (Anthropic replay contract)", async () => {
     const response = await scriptedThreadsResponse(
       threadsRequest("When my checking balance drops below $2,000, email me an alert."),
     );
@@ -145,7 +169,7 @@ describe("scripted beats stream wire-safe tool parts", () => {
     expect(JSON.stringify(grantInput)).toContain("standing, this app only");
   }, 60_000);
 
-  it("card (c) weekly beat surfaces the WHOLE grant set as one data-vendo-grant-set part (criterion 22, demo half)", async () => {
+  it("the weekly beat surfaces the WHOLE grant set as one data-vendo-grant-set part (criterion 22, demo half)", async () => {
     const response = await scriptedThreadsResponse(
       threadsRequest("Every Friday, email me a summary of that week's spending."),
     );
@@ -173,6 +197,33 @@ describe("scripted beats stream wire-safe tool parts", () => {
     // No legacy single-ask approval part for grant asks.
     expect(chunks.filter((chunk) => chunk.type === "data-vendo-approval")).toHaveLength(0);
   }, 60_000);
+
+  it("every card still plays its OWN script when the scenario ladder is reordered", async () => {
+    scenarioOrder.reversed = true;
+    const turn = async (title: string): Promise<{ tools: string[]; text: string }> => {
+      const response = await scriptedThreadsResponse(threadsRequest(cardPrompt(title)));
+      expect(response, `"${title}" matched no scripted beat`).not.toBeNull();
+      const chunks = await streamedChunks(response as Response);
+      return {
+        tools: chunks.filter((chunk) => chunk.type === "tool-input-start").map((chunk) => String(chunk.toolName)),
+        text: chunks.filter((chunk) => chunk.type === "text-delta").map((chunk) => String(chunk.delta)).join(""),
+      };
+    };
+
+    const [spending, transfer, weekly, moneyHq, lowBalance] = await Promise.all([
+      turn("Where did my money go?"),
+      turn("Move money to savings"),
+      turn("Email me a weekly summary"),
+      turn("Build my money HQ"),
+      turn("Alert me before I overdraft"),
+    ]);
+
+    expect(spending.text).toContain("Here's where this month went.");
+    expect(transfer.tools).toContain("host_transferMoney");
+    expect(weekly.text).toContain("Setting up your Friday digest");
+    expect(moneyHq.text).toContain("Here's your money HQ");
+    expect(lowBalance.text).toContain("You want a heads-up before checking runs low.");
+  }, 120_000);
 
   it("a parked set abandoned by the next prompt resolves non-orphan — real-agent replay never 400s (criterion 23)", async () => {
     // History: a weekly turn parked on its grant set, never decided.

--- a/examples/demo-bank/src/demo-script/engine.test.ts
+++ b/examples/demo-bank/src/demo-script/engine.test.ts
@@ -81,16 +81,17 @@ const threadState = vi.hoisted(() => ({
 }));
 
 /** The scenario ladder is host copy: cards get added, dropped and reordered.
- *  Flipping this serves the SAME cards in a different order, which must not
- *  change which script a card plays. */
-const scenarioOrder = vi.hoisted(() => ({ reversed: false }));
+ *  `reversed` serves the SAME cards in a different order (which must not
+ *  change which script a card plays); `dropped` removes one card entirely. */
+const scenarioLadder = vi.hoisted(() => ({ reversed: false, dropped: "" }));
 
 vi.mock("@/vendo/scenarios", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/vendo/scenarios")>();
   return {
     ...actual,
     get mapleScenarios() {
-      return scenarioOrder.reversed ? [...actual.mapleScenarios].reverse() : actual.mapleScenarios;
+      const cards = actual.mapleScenarios.filter((card) => card.beat !== scenarioLadder.dropped);
+      return scenarioLadder.reversed ? [...cards].reverse() : cards;
     },
   };
 });
@@ -138,7 +139,8 @@ describe("scripted beats stream wire-safe tool parts", () => {
     vi.clearAllMocks();
     threadState.messages = [];
     threadState.persisted = [];
-    scenarioOrder.reversed = false;
+    scenarioLadder.reversed = false;
+    scenarioLadder.dropped = "";
   });
 
   it("the low-balance beat streams every tool input as an object (Anthropic replay contract)", async () => {
@@ -199,7 +201,7 @@ describe("scripted beats stream wire-safe tool parts", () => {
   }, 60_000);
 
   it("every card still plays its OWN script when the scenario ladder is reordered", async () => {
-    scenarioOrder.reversed = true;
+    scenarioLadder.reversed = true;
     const turn = async (title: string): Promise<{ tools: string[]; text: string }> => {
       const response = await scriptedThreadsResponse(threadsRequest(cardPrompt(title)));
       expect(response, `"${title}" matched no scripted beat`).not.toBeNull();
@@ -224,6 +226,12 @@ describe("scripted beats stream wire-safe tool parts", () => {
     expect(moneyHq.text).toContain("Here's your money HQ");
     expect(lowBalance.text).toContain("You want a heads-up before checking runs low.");
   }, 120_000);
+
+  it("a beat left without a card fails at import, naming the beat", async () => {
+    scenarioLadder.dropped = "moneyhq";
+    vi.resetModules();
+    await expect(import("./engine.js")).rejects.toThrow(/moneyhq/);
+  });
 
   it("a parked set abandoned by the next prompt resolves non-orphan — real-agent replay never 400s (criterion 23)", async () => {
     // History: a weekly turn parked on its grant set, never decided.

--- a/examples/demo-bank/src/demo-script/engine.ts
+++ b/examples/demo-bank/src/demo-script/engine.ts
@@ -36,7 +36,7 @@ import {
   type UIMessageStreamWriter,
 } from "ai";
 import { resolveMapleSession } from "@/vendo/auth";
-import { mapleScenarios } from "@/vendo/scenarios";
+import { mapleScenarioBeats, mapleScenarios, type MapleScenarioBeat } from "@/vendo/scenarios";
 import { vendo } from "@/vendo/server";
 import { demoAppId } from "./seed";
 import {
@@ -52,7 +52,19 @@ const THREAD_ID_HEADER = "x-vendo-thread-id";
 const SCRIPT_CALL_PREFIX = "mds_";
 const PARKED_OUTCOME_COLLECTION = "vendo_parked_call_outcome";
 
-type Beat = "spending" | "transfer" | "weekly" | "moneyhq" | "lowbalance" | "gmailConnected";
+/** The card beats, plus the one beat no card sends (the post-OAuth line). */
+type Beat = MapleScenarioBeat | "gmailConnected";
+
+// A beat whose card was renamed away would otherwise go quietly unreachable
+// and the demo would just stop answering that prompt — fail at boot instead.
+const unbound = mapleScenarioBeats.filter(
+  (candidate) => !mapleScenarios.some((card) => card.beat === candidate),
+);
+if (unbound.length > 0) {
+  throw new Error(
+    `demo-script: no Maple scenario card declares beat ${unbound.join(", ")} — see src/vendo/scenarios.tsx`,
+  );
+}
 
 /** The automations the scripted beats arm; keys match demoAppId's. */
 type AutomationKey = "weekly" | "lowbalance";
@@ -79,12 +91,9 @@ function userText(message: UIMessage): string {
 }
 
 function matchBeat(text: string): Beat | undefined {
-  const prompts = mapleScenarios.map((card) => (card.prompt ?? card.title).trim());
-  if (text === prompts[0]) return "spending";
-  if (text === prompts[1]) return "transfer";
-  if (text === prompts[2]) return "weekly";
-  if (text === prompts[3]) return "moneyhq";
-  if (text === prompts[4]) return "lowbalance";
+  // Each card names its own beat, so reordering the ladder is a no-op here.
+  const card = mapleScenarios.find((candidate) => (candidate.prompt ?? candidate.title).trim() === text);
+  if (card !== undefined) return card.beat;
   // The ConnectCard's deterministic continuation line after a live Gmail
   // OAuth ("Connected Gmail." — parts.tsx onConnected, kept natural on
   // purpose; the parked connect-required call above it carries the context).
@@ -231,7 +240,7 @@ function spendingSlices(outcome: ToolOutcome): Array<{ category: string; amount:
     : [];
 }
 
-/** Card (a) — "Where did my money go?" */
+/** The spending beat — the "Where did my money go?" card. */
 async function spendingBeat({ writer, ctx, signal }: BeatContext): Promise<void> {
   await beat(500, 800); // a breath before the first activity row
   const insights = await toolBeat(writer, ctx, "host_getSpendingInsights", {}, 1200);
@@ -255,7 +264,8 @@ async function spendingBeat({ writer, ctx, signal }: BeatContext): Promise<void>
   );
 }
 
-/** Card (b), turn 1 — "Move money to savings": the REAL parked approval. The
+/** The transfer beat, turn 1 — the "Move money to savings" card: the REAL
+ *  parked approval. The
  *  guarded transfer call parks under the guard's pending approval; Approve in
  *  the thread decides the guard record over the wire, the BYO parked-call
  *  subscriber re-dispatches the EXACT call, and Maple's transfer API debits
@@ -325,7 +335,7 @@ async function confirmTransfer(
 }
 
 /* ------------------------------------------------------------------ */
-/* automation machinery shared by cards (c) and (e)                    */
+/* automation machinery shared by the weekly and low-balance beats     */
 /* ------------------------------------------------------------------ */
 
 /** Grant-ask tool-call ids carry the automation key so the approval-resume
@@ -495,7 +505,7 @@ async function automationArmedConfirmation(context: BeatContext, key: Automation
   );
 }
 
-/** The approval-resume leg for a grant-SET decision (cards c/e). The deciding
+/** The approval-resume leg for a grant-SET decision (weekly/low-balance). The deciding
  *  surface (the in-thread set card or the workspace panel) already settled
  *  the WHOLE set over the wire with ONE decision — the automations engine's
  *  subscriber minted (or discarded) every grant; nothing is bulk-approved
@@ -536,7 +546,7 @@ async function automationGrantResume(
   await automationArmedConfirmation(context, key);
 }
 
-/** Card (c) — "Email me a weekly summary": REAL automation (enabled through
+/** The weekly beat — the "Email me a weekly summary" card: REAL automation (enabled through
  *  the automations engine), the automation card in-thread, its standing-grant
  *  approval (approve resumes the scripted confirmation), then the Gmail
  *  connect moment. */
@@ -564,7 +574,7 @@ async function weeklyBeat(context: BeatContext): Promise<void> {
   await automationArmedConfirmation(context, "weekly");
 }
 
-/** Card (e) — "Alert me before I overdraft": narration → a real balance read
+/** The low-balance beat — the "Alert me before I overdraft" card: narration → a real balance read
  *  → the automation card → the standing-grant approve moment → (on approve,
  *  via the resume) "Armed — …" + the Gmail delivery moment. */
 async function lowBalanceBeat(context: BeatContext): Promise<void> {
@@ -609,7 +619,7 @@ async function gmailConnectedBeat({ writer, signal }: BeatContext): Promise<void
   );
 }
 
-/** Card (d) — "Build my money HQ": building beats, then the saved Money HQ
+/** The money-HQ beat — the "Build my money HQ" card: building beats, then the saved Money HQ
  *  document embeds with the pin affordance on its bar. */
 async function moneyHqBeat({ writer, ctx, signal }: BeatContext): Promise<void> {
   await beat(500, 800); // a breath before the first activity row
@@ -788,7 +798,7 @@ export async function scriptedThreadsResponse(request: Request): Promise<Respons
       write(writer, { type: "start", messageId: message.id });
       write(writer, { type: "start-step" });
       if (grantKey !== undefined) {
-        // An automation's standing-grant decision (cards c/e). The card
+        // An automation's standing-grant decision (weekly/low-balance). The card
         // already decided the REAL guard approval over the wire — the
         // automations engine minted (or skipped) the grant; this leg settles
         // the parked tool part and streams the scripted continuation.

--- a/examples/demo-bank/src/demo-script/engine.ts
+++ b/examples/demo-bank/src/demo-script/engine.ts
@@ -36,7 +36,12 @@ import {
   type UIMessageStreamWriter,
 } from "ai";
 import { resolveMapleSession } from "@/vendo/auth";
-import { mapleScenarioBeats, mapleScenarios, type MapleScenarioBeat } from "@/vendo/scenarios";
+import {
+  mapleScenarioBeats,
+  mapleScenarios,
+  type MapleScenarioBeat,
+  type MapleScenarioCard,
+} from "@/vendo/scenarios";
 import { vendo } from "@/vendo/server";
 import { demoAppId } from "./seed";
 import {
@@ -55,6 +60,9 @@ const PARKED_OUTCOME_COLLECTION = "vendo_parked_call_outcome";
 /** The card beats, plus the one beat no card sends (the post-OAuth line). */
 type Beat = MapleScenarioBeat | "gmailConnected";
 
+/** The text a card sends on tap — the engine's whole routing key. */
+const cardKey = (card: MapleScenarioCard): string => (card.prompt ?? card.title).trim();
+
 // A beat whose card was renamed away would otherwise go quietly unreachable
 // and the demo would just stop answering that prompt — fail at boot instead.
 const unbound = mapleScenarioBeats.filter(
@@ -63,6 +71,22 @@ const unbound = mapleScenarioBeats.filter(
 if (unbound.length > 0) {
   throw new Error(
     `demo-script: no Maple scenario card declares beat ${unbound.join(", ")} — see src/vendo/scenarios.tsx`,
+  );
+}
+
+// Two cards sending the same text would hand the choice of script back to
+// ladder order, since the first match wins — the exact failure the per-card
+// beat removed. Fail at boot instead.
+const beatsByKey = new Map<string, MapleScenarioBeat[]>();
+for (const card of mapleScenarios) {
+  beatsByKey.set(cardKey(card), [...(beatsByKey.get(cardKey(card)) ?? []), card.beat]);
+}
+const shared = [...beatsByKey].filter(([, beats]) => beats.length > 1);
+if (shared.length > 0) {
+  throw new Error(
+    `demo-script: Maple scenario cards share a prompt, so ladder order would decide which script plays — ${shared
+      .map(([key, beats]) => `beats ${beats.join(", ")} all send "${key}"`)
+      .join("; ")}; see src/vendo/scenarios.tsx`,
   );
 }
 
@@ -92,7 +116,7 @@ function userText(message: UIMessage): string {
 
 function matchBeat(text: string): Beat | undefined {
   // Each card names its own beat, so reordering the ladder is a no-op here.
-  const card = mapleScenarios.find((candidate) => (candidate.prompt ?? candidate.title).trim() === text);
+  const card = mapleScenarios.find((candidate) => cardKey(candidate) === text);
   if (card !== undefined) return card.beat;
   // The ConnectCard's deterministic continuation line after a live Gmail
   // OAuth ("Connected Gmail." — parts.tsx onConnected, kept natural on

--- a/examples/demo-bank/src/vendo/scenarios.tsx
+++ b/examples/demo-bank/src/vendo/scenarios.tsx
@@ -4,33 +4,47 @@ import type { VendoThreadProps } from "@vendoai/ui/chrome";
  *  VendoSuggestionCard by name, so derive it from the prop). */
 type SuggestionCard = Exclude<NonNullable<VendoThreadProps["suggestions"]>[number], string>;
 
+/** The scripted beats a card can play (src/demo-script/engine.ts). */
+export const mapleScenarioBeats = ["spending", "transfer", "weekly", "moneyhq", "lowbalance"] as const;
+
+export type MapleScenarioBeat = (typeof mapleScenarioBeats)[number];
+
+/** A starter card plus the beat its prompt plays. The engine binds on `beat`,
+ *  so this ladder can be reordered freely. */
+export type MapleScenarioCard = SuggestionCard & { beat: MapleScenarioBeat };
+
 /** demo-refresh Part 6 — the Maple scenario ladder, rendered as starter cards
  *  on the empty thread (overlay and full page). Tapping a card SENDS the
  *  prompt: generated UI → guarded host tool call → integration + automation →
  *  pin-to-home. */
-export const mapleScenarios: SuggestionCard[] = [
+export const mapleScenarios: MapleScenarioCard[] = [
   {
+    beat: "spending",
     title: "Where did my money go?",
     description: "A live breakdown of this month's spending",
     prompt: "Where did my money go this month? Build me a spending breakdown I can keep.",
   },
   {
+    beat: "transfer",
     title: "Move money to savings",
     description: "Transfer $200 — you approve it first",
     prompt: "Move $200 from my checking account to savings.",
   },
   {
+    beat: "weekly",
     title: "Email me a weekly summary",
     description: "A Friday spending digest via Gmail",
     prompt: "Every Friday, email me a summary of that week's spending.",
   },
   {
+    beat: "moneyhq",
     title: "Build my money HQ",
     description: "Goals, spending, and upcoming bills in one view",
     prompt:
       "Build me a money HQ: goals progress, spending by category, upcoming bills, and account balances — something I can pin to my home screen.",
   },
   {
+    beat: "lowbalance",
     title: "Alert me before I overdraft",
     description: "Emails you when checking dips below $2,000",
     prompt: "When my checking balance drops below $2,000, email me an alert.",


### PR DESCRIPTION
## The hazard

`matchBeat` in `examples/demo-bank/src/demo-script/engine.ts` mapped
`mapleScenarios` to a prompt array and read the beat out of it **by index** —
`[0]`→spending, `[1]`→transfer, `[2]`→weekly, `[3]`→moneyhq, `[4]`→lowbalance.
The cards in `src/vendo/scenarios.tsx` carried no identity at all, only
title/description/prompt. Reorder one card and Maple silently narrates the
wrong script to a prospect on maple.vendo.run: no type error, no test failure,
no runtime complaint. The coupling had already leaked into the test vocabulary
("card (e)", "card (c)").

## The shape

Each card now declares the beat it plays:

```ts
export const mapleScenarioBeats = ["spending", "transfer", "weekly", "moneyhq", "lowbalance"] as const;
export type MapleScenarioCard = SuggestionCard & { beat: MapleScenarioBeat };
```

`matchBeat` finds the card by its own prompt and returns **that card's** beat,
so position carries no meaning. Two ways a mismatch now fails loudly:

- **Type-check** — a beat that is not in `mapleScenarioBeats` is a compile
  error on the card, and `Beat = MapleScenarioBeat | "gmailConnected"` keeps the
  `BEATS` handler record exhaustive.
- **Module load** — `engine.ts` throws at import naming any beat no card
  declares: `demo-script: no Maple scenario card declares beat moneyhq — see
  src/vendo/scenarios.tsx`. There is no fallback to "some card".

## The tests

- **`every card still plays its OWN script when the scenario ladder is
  reordered`** — the point of the PR. It serves the same five cards in reverse
  order through the real route seam and asserts each card still narrates its
  own beat. Committed red first (79394dd): under the old positional binding
  "Where did my money go?" streamed the low-balance script —
  `expected 'You want a heads-up before checking r…' to contain "Here's where this month went."`.
- **`a beat left without a card fails at import, naming the beat`** — drops a
  card from the mocked ladder and asserts the engine import rejects with the
  orphaned beat's name.
- Renamed the two positionally-named cases so card letters stop leaking into
  the vocabulary: `card (e) low-balance beat: …` → **`the low-balance beat
  streams every tool input as an object (Anthropic replay contract)`**, and
  `card (c) weekly beat surfaces …` → **`the weekly beat surfaces the WHOLE
  grant set as one data-vendo-grant-set part (criterion 22, demo half)`**. The
  positional `Card (a)`–`Card (e)` doc comments in `engine.ts` now name their
  beat too.

## Narration is unchanged

The shipped ladder's card→beat mapping is byte-identical to the old positional
one, and no demo copy was touched (the `scenarios.tsx` diff adds only `beat:`
lines). Verified against a real production build of Maple (`next start`, real
store, real guard) by driving all five cards through `POST /api/vendo/threads`
as the signed-in demo user:

| card | tools streamed | narration |
| --- | --- | --- |
| Where did my money go? | `host_getSpendingInsights` | "Here's where this month went. Housing is your largest category at $4,700.00 — 75% of the $6,281.00…" |
| Move money to savings | `host_transferMoney` + `data-vendo-approval` | "You're moving $200.00 from Maple Checking…" |
| Email me a weekly summary | `host_getCashflowInsights`, `host_getSpendingInsights` + `data-vendo-automation`, `data-vendo-grant-set` | "Setting up your Friday digest…" |
| Build my money HQ | `host_listAccounts`, `host_listGoals`, `host_getSpendingInsights` + `data-vendo-view` | "Here's your money HQ…" |
| Alert me before I overdraft | `host_listAccounts` ×2 + `data-vendo-automation`, `data-vendo-grant-set` | "You want a heads-up before checking runs low…" |

No visual change: the extra `beat` field is inert data — the chrome's starter
card reads only `title`, `description`, `icon` and `prompt`
(`packages/ui/src/chrome/thread/index.tsx`), never spreading the object onto a
DOM node.

## `vendo-web` no-op justification

Checked, not assumed. `vendo-web` at `00969751` has **zero** hits for
`mapleScenarios`, `matchBeat`, `demo-script` and `MapleScenario` across the
whole repo (tests included). Its playground does render a scenario surface, but
it boots from `@vendoai/vendo/try-surface`
(`app/playground/venue.tsx`, `app/playground/try-venue.ts`), i.e. **`packages/vendo`'s**
scenarios — which carry explicit ids already and are untouched here. demo-bank
is an example app, published to nobody and imported by nothing; this change
crosses no seam the console mirrors. No tandem PR, and no changeset (examples
are `private: true` and outside the release graph).

## Out of scope, on purpose

`packages/vendo`'s tours module is clean (it binds by frozen prompt string via
`TourEntry.prompt`) and is not touched. Replacing Maple's hand-rolled script
with the real tours feature stays an open owner decision — only 1 of Maple's 6
beats is expressible today. `TourPart` and the tours API are untouched.

## Gates

- `pnpm build --filter=demo-bank...` — 14/14 successful
- `examples/demo-bank` vitest (capped forks/threads) — **24 files, 109 tests passed**
- `pnpm typecheck --force` — 40/40 successful; plus `tsc -p tsconfig.json --noEmit`
  inside `examples/demo-bank` (it has no `typecheck` task, and root typecheck skips
  it — that grep caught a real `TS2835` in the new test that build and root
  typecheck both missed)
- `pnpm lint --force` — 3/3 successful
- `pnpm --filter demo-bank mcp:e2e` — **green**, org policy intact:
  `"moneyRefusedWithoutAPerson": "host_transferMoney"`,
  `"refusal": "Money never moves on behalf of an external MCP client."`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind Maple demo scenario cards to their own beats so reordering can’t swap scripts. Adds boot-time guards for missing beats and duplicate prompts, plus tests to prevent silent routing regressions.

- **Bug Fixes**
  - Added `beat` to each scenario card, typed as `MapleScenarioBeat`.
  - `matchBeat` uses a single `cardKey` (trimmed `prompt`/`title`) to find the card and return that card’s beat (no positional coupling).
  - Import-time guards throw if a beat in `mapleScenarioBeats` has no card, or if two cards share a prompt (names all colliding beats and the shared text).
  - Updated comments to reference beats. No UI or copy changes; mapping is unchanged.

- **Tests**
  - Ensures each card still plays its own script when the ladder is reversed.
  - Fails fast on a missing beat and on duplicate prompts (whitespace-trimmed), naming the offending beats.
  - Renamed positional test names to behavior-focused titles.

<sup>Written for commit 6e92e7cc5801a31f4e876abcdeb1fbf93e717104. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

