### PR TITLE
fix(store,agents): three row-level correctness bugs, and two dead seams in the agent front door

### DIFF
--- a/.changeset/agents-drops-a-knowledge-re-export.md
+++ b/.changeset/agents-drops-a-knowledge-re-export.md
@@ -1,0 +1,16 @@
+---
+"@vendoai/agents": minor
+---
+
+`vendoKnowledge` is no longer re-exported from `@vendoai/agents`.
+
+`AgentConfig` and `AgentComposition` have no knowledge slot, so nothing composed
+through the agents front door could use it — the umbrella's knowledge seam is
+its own `createVendo({ knowledge })` key, never the agent's. Import it from
+`@vendoai/knowledge`, which is where every real consumer already imports it
+from. The `@vendoai/knowledge` dependency goes with it, as does an unused
+`zod` dependency (the `zod` peer stays).
+
+`session()` also stops opening the workspace twice — the first result was
+discarded before the per-turn open, so this removes one database round trip per
+session, including on the `{ threadId }` resume path.

--- a/.changeset/agents-drops-a-knowledge-re-export.md
+++ b/.changeset/agents-drops-a-knowledge-re-export.md
@@ -8,8 +8,7 @@
 through the agents front door could use it — the umbrella's knowledge seam is
 its own `createVendo({ knowledge })` key, never the agent's. Import it from
 `@vendoai/knowledge`, which is where every real consumer already imports it
-from. The `@vendoai/knowledge` dependency goes with it, as does an unused
-`zod` dependency (the `zod` peer stays).
+from. The `@vendoai/knowledge` dependency goes with it.
 
 `session()` also stops opening the workspace twice — the first result was
 discarded before the per-turn open, so this removes one database round trip per

--- a/.changeset/store-thread-rows-and-grant-rows.md
+++ b/.changeset/store-thread-rows-and-grant-rows.md
@@ -2,7 +2,7 @@
 "@vendoai/store": patch
 ---
 
-Three correctness fixes. No public surface changes, no stored shape changes, no migration.
+Five correctness fixes. No public surface changes, no stored shape changes, no migration.
 
 **One rule for a transcript row's id.** `threadMessageRowIds` (TypeScript) and
 `replaceThreadMessages`'s `COALESCE(elem->>'id', …)` (SQL, twice) expressed the
@@ -28,3 +28,21 @@ minted a fresh `ag_<uuid>` per `grant`; uniqueness came only from
 hosted or BYO adapter has. A second row made downgrades silently fold back to
 the stronger level and left `revoke` deleting only the first match. `grant` now
 reuses the existing row's id, and `revoke` deletes every matching row.
+
+**A grant no longer races itself.** Reading the grants and only then minting an
+id is a read-then-write window: two overlapping grants both read "no row for
+this principal", both mint a different random id, and the duplicate pair — with
+its dead downgrade — is back. A principal with no row yet now gets a DERIVED id,
+`ag_<appId>_<principal>`, the same id core's reference adapter derives, so the
+write is one put on one key and the overlap collapses to last-write-wins on a
+single row. An id already on disk still wins, so nothing stored is re-keyed.
+
+**A concurrent transcript write can no longer escape the delete cascade.** The
+cascade is one transaction, but a writer that only READS the thread row takes no
+lock on it, so under READ COMMITTED its snapshot still shows a row the cascade
+has removed and not yet committed — the message lands after the sweep and
+outlives its own thread, unreachable for the same reason the cascade exists.
+`recordAnswer` and `threadMessageStore.upsert` both did this while reporting
+success; their ownership reads now end in `FOR KEY SHARE OF t`, the same lock a
+foreign key takes. `putThreadRow` and `ops.transcripts.putMessage` were already
+safe and are unchanged.

--- a/.changeset/store-thread-rows-and-grant-rows.md
+++ b/.changeset/store-thread-rows-and-grant-rows.md
@@ -1,0 +1,30 @@
+---
+"@vendoai/store": patch
+---
+
+Three correctness fixes. No public surface changes, no stored shape changes, no migration.
+
+**One rule for a transcript row's id.** `threadMessageRowIds` (TypeScript) and
+`replaceThreadMessages`'s `COALESCE(elem->>'id', …)` (SQL, twice) expressed the
+same rule in two dialects that disagree: `elem->>'id'` yields `''` for
+`{"id":""}` rather than NULL, and `'5'` for `{"id":5}`. The duplicate-id guard
+runs on the TypeScript rule, so those inputs cleared it and then collided inside
+the INSERT, failing with the bare Postgres 21000 the guard exists to prevent and
+losing the whole write. The ids are now derived once and passed in as a
+`text[]`; both `COALESCE` expressions are gone.
+
+**`threadStore.delete` takes the transcript with it.** It dropped the thread row
+and the harness-state row but never `vendo_thread_messages`, which has no
+foreign key. A message row carries no subject of its own, so those rows became
+permanently unreachable — `erase.bySubject` reaches them only through
+`thread_id IN (SELECT id FROM vendo_threads WHERE subject = $1)`, which is empty
+once the thread is gone. It is now the same cascade
+`ops.transcripts.deleteThread` already ran, in one transaction, still guarded on
+the RETURNING row so a foreign principal's delete sweeps nothing.
+
+**One grant row per (app, principal), on every records adapter.** `appAccess`
+minted a fresh `ag_<uuid>` per `grant`; uniqueness came only from
+`ON CONFLICT (app_id, principal)` in the local Postgres routing door, which no
+hosted or BYO adapter has. A second row made downgrades silently fold back to
+the stronger level and left `revoke` deleting only the first match. `grant` now
+reuses the existing row's id, and `revoke` deletes every matching row.

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -54,10 +54,8 @@
     "@vendoai/core": "workspace:*",
     "@vendoai/guard": "workspace:*",
     "@vendoai/harnesses": "workspace:*",
-    "@vendoai/knowledge": "workspace:*",
     "@vendoai/mcp": "workspace:*",
-    "@vendoai/store": "workspace:*",
-    "zod": "^3.25.0"
+    "@vendoai/store": "workspace:*"
   },
   "peerDependencies": {
     "ai": ">=6.0.0 <7",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -55,7 +55,8 @@
     "@vendoai/guard": "workspace:*",
     "@vendoai/harnesses": "workspace:*",
     "@vendoai/mcp": "workspace:*",
-    "@vendoai/store": "workspace:*"
+    "@vendoai/store": "workspace:*",
+    "zod": "^3.25.0"
   },
   "peerDependencies": {
     "ai": ">=6.0.0 <7",

--- a/packages/agents/src/index.test.ts
+++ b/packages/agents/src/index.test.ts
@@ -12,7 +12,6 @@ describe("the package surface", () => {
     expect(agents.createGuard).toBeTypeOf("function");
     expect(agents.e2b).toBeTypeOf("function");
     expect(agents.postgres).toBeTypeOf("function");
-    expect(agents.vendoKnowledge).toBeTypeOf("function");
     expect(agents.provideCloudAdapters).toBeTypeOf("function");
   });
 

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -26,4 +26,3 @@ export type { EgressConfig } from "./egress.js";
 export type { RunContext } from "@vendoai/core";
 
 export { createGuard, type GuardLike, type VendoGuard } from "@vendoai/guard";
-export { vendoKnowledge } from "@vendoai/knowledge";

--- a/packages/agents/src/session.ts
+++ b/packages/agents/src/session.ts
@@ -129,6 +129,10 @@ export async function createSession(
 
   const transcript = threadMessageStore<UIMessage>(deps.store);
   const workspaces = workspaceStore(deps.store, { files: deps.files });
+  // Opened once per turn, in `stream()` below, so a turn always sees a fresh
+  // path index. Nothing reads it before then: `runtime()` is only called inside
+  // `stream()`, after the open.
+  let workspace: Awaited<ReturnType<typeof workspaces.open>>;
   const runtime = () =>
     createHarnessRuntime({
       tools: deps.tools,
@@ -138,9 +142,6 @@ export async function createSession(
       harnessState: harnessStateStore(deps.store),
       ...(deps.liveTurn === undefined ? {} : { liveTurn: deps.liveTurn }),
     });
-  // Opened at session start (the spec's "opens thread + workspace") and
-  // reopened per turn below, so a turn always sees a fresh path index.
-  let workspace = await workspaces.open(principal, { host: hostSkillFiles(deps.skills) });
 
   const contextFor = (turnContext: Record<string, unknown> | undefined): RunContext => ({
     principal,

--- a/packages/store/src/app-access.test.ts
+++ b/packages/store/src/app-access.test.ts
@@ -340,6 +340,26 @@ describe("build contract §9.2 — grants over a generic records adapter", () =>
     expect(await access.levelFor(ctxFor("kim", [{ org: "acme" }]), app)).toBe("viewer");
   });
 
+  it("keeps one row when two grants for the same principal overlap, so a later downgrade sticks", async () => {
+    const access = await madeStore();
+    // Two owners share with kim in the same instant. `grant` reads the app's
+    // grants, finds no row for kim, and only THEN writes — so both reads land
+    // before either write and an id minted on that empty read is a DIFFERENT id
+    // per caller. Two rows for one principal is the unrevokable grant this
+    // whole describe exists to prevent: `levelFor` folds them with
+    // `strongerLevel`, so the downgrade below updates one row and the other
+    // keeps editor standing. Nothing here is a stub — the interleave is the
+    // real reference adapter's own await points.
+    await Promise.all([
+      access.grant(owner, app, "user:kim", "editor"),
+      access.grant(owner, app, "user:kim", "editor"),
+    ]);
+    expect(await access.list(owner, app)).toHaveLength(1);
+
+    await access.grant(owner, app, "user:kim", "viewer");
+    expect(await access.levelFor(ctxFor("kim", [{ org: "acme" }]), app)).toBe("viewer");
+  });
+
   it("revokes every row for the principal, so access cannot survive a revoke", async () => {
     const access = await madeStore();
     await access.grant(owner, app, "user:kim", "viewer");

--- a/packages/store/src/app-access.test.ts
+++ b/packages/store/src/app-access.test.ts
@@ -1,10 +1,11 @@
 import { VendoError, type Membership, type RunContext } from "@vendoai/core";
-import { appAccessConformance } from "@vendoai/core/conformance";
+import { appAccessConformance, memoryStoreAdapter } from "@vendoai/core/conformance";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { appAccess } from "./helpers/app-access.js";
 import { appStore } from "./helpers/apps.js";
 import { appFixture } from "./fixtures.test-util.js";
 import { backends, type MadeBackend } from "./backends.test-util.js";
+import type { VendoStore } from "./store.js";
 
 /** Build contract §9.2–§9.4 — grants are the only rows Vendo stores, and
     `can()` is the one function every door reaches. */
@@ -292,3 +293,61 @@ for (const backend of backends()) {
     });
   });
 }
+
+/**
+ * §9.2's one-row-per-(app, principal) rule, proven on a records adapter that is
+ * NOT the local Postgres engine.
+ *
+ * The rule was enforced only by `ON CONFLICT (app_id, principal)` in
+ * `routing.ts` — a constraint this door never sees. Every multi-party
+ * deployment runs on a hosted or BYO records adapter, which is keyed by id
+ * alone, exactly as core's reference adapter is. This is the same failure class
+ * `app-access.ts` already documents one paragraph up: a rule enforced only in
+ * the local engine behaved differently on Cloud.
+ */
+describe("build contract §9.2 — grants over a generic records adapter", () => {
+  const app = "app_shared";
+  const owner = ctxFor("dana", [{ org: "acme", admin: true }]);
+
+  const madeStore = async (): Promise<ReturnType<typeof appAccess>> => {
+    const adapter = memoryStoreAdapter();
+    await adapter.ensureSchema();
+    const store = adapter as unknown as VendoStore;
+    await store.records("vendo_apps").put({
+      id: app,
+      data: { subject: "acme", enabled: true, doc: doc(app) },
+    });
+    return appAccess(store);
+  };
+
+  it("re-granting a principal updates the one row rather than accreting a second", async () => {
+    const access = await madeStore();
+    await access.grant(owner, app, "user:kim", "viewer");
+    await access.grant(owner, app, "user:kim", "editor");
+
+    const rows = await access.list(owner, app);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.level).toBe("editor");
+  });
+
+  it("downgrades a principal, instead of folding the old level back in", async () => {
+    const access = await madeStore();
+    await access.grant(owner, app, "user:kim", "editor");
+    await access.grant(owner, app, "user:kim", "viewer");
+
+    // Two rows make `levelFor` fold them with `strongerLevel`, so the downgrade
+    // silently does nothing and kim keeps editor forever.
+    expect(await access.levelFor(ctxFor("kim", [{ org: "acme" }]), app)).toBe("viewer");
+  });
+
+  it("revokes every row for the principal, so access cannot survive a revoke", async () => {
+    const access = await madeStore();
+    await access.grant(owner, app, "user:kim", "viewer");
+    await access.grant(owner, app, "user:kim", "editor");
+
+    await access.revoke(owner, app, "user:kim");
+
+    expect(await access.list(owner, app)).toHaveLength(0);
+    expect(await access.levelFor(ctxFor("kim", [{ org: "acme" }]), app)).toBeNull();
+  });
+});

--- a/packages/store/src/helpers/app-access.ts
+++ b/packages/store/src/helpers/app-access.ts
@@ -187,12 +187,25 @@ export function appAccess(store: VendoStore): AppAccess {
       // BYO records adapter has, and `records.put` is keyed by id alone. A
       // second row for one principal is an unrevokable grant: `levelFor` folds
       // every match with `strongerLevel`, so a downgrade does nothing, and
-      // `revoke` would have to find them all. Reusing the existing row's id
-      // (rather than deriving one) keeps every grant already written on an
-      // engine that minted a random id revokable and updatable in place.
+      // `revoke` would have to find them all.
+      //
+      // The id for a principal that has no row yet is DERIVED, exactly as core's
+      // reference adapter derives it, and never minted. Reading first and then
+      // minting is a read-then-write window: two overlapping grants both read
+      // "no row", both mint a random id, and the pair is back — an authorization
+      // write racing itself. A derived id makes the whole write ONE put on ONE
+      // key, which is the only shape that is atomic on an adapter interface
+      // offering no transaction; the overlap collapses to last-write-wins on a
+      // single row, which is a state some serial order also produces.
+      //
+      // The FOUND id still wins when there is one, and that is the migration
+      // property: every grant already on disk carries a random id, and a derived
+      // id would sit BESIDE it rather than replacing it. The local engine keeps
+      // its own id through `ON CONFLICT (app_id, principal) DO UPDATE`, which
+      // never writes the id column, so nothing already stored is re-keyed.
       const existing = (await grantsFor(appId)).find((row) => row.principal === principal);
       await grants.put({
-        id: existing?.id ?? `ag_${globalThis.crypto.randomUUID()}`,
+        id: existing?.id ?? `ag_${appId}_${principal}`,
         data: { appId, orgId, principal, level, createdBy: ctx.principal.subject },
         // The door writes the refs it queries by. The local engine derives them
         // from the row's own columns, but an adapter that stores records

--- a/packages/store/src/helpers/app-access.ts
+++ b/packages/store/src/helpers/app-access.ts
@@ -182,8 +182,17 @@ export function appAccess(store: VendoStore): AppAccess {
           + " — move it into a team first (sharing offers to), or fork a copy for them",
         );
       }
+      // ONE row per (app, principal), enforced HERE rather than by the local
+      // engine's `ON CONFLICT (app_id, principal)` — a constraint no hosted or
+      // BYO records adapter has, and `records.put` is keyed by id alone. A
+      // second row for one principal is an unrevokable grant: `levelFor` folds
+      // every match with `strongerLevel`, so a downgrade does nothing, and
+      // `revoke` would have to find them all. Reusing the existing row's id
+      // (rather than deriving one) keeps every grant already written on an
+      // engine that minted a random id revokable and updatable in place.
+      const existing = (await grantsFor(appId)).find((row) => row.principal === principal);
       await grants.put({
-        id: `ag_${globalThis.crypto.randomUUID()}`,
+        id: existing?.id ?? `ag_${globalThis.crypto.randomUUID()}`,
         data: { appId, orgId, principal, level, createdBy: ctx.principal.subject },
         // The door writes the refs it queries by. The local engine derives them
         // from the row's own columns, but an adapter that stores records
@@ -197,8 +206,11 @@ export function appAccess(store: VendoStore): AppAccess {
 
     async revoke(ctx, appId, principal) {
       await require(ctx, appId, "owner");
-      const existing = (await grantsFor(appId)).find((row) => row.principal === principal);
-      if (existing !== undefined) await grants.delete(existing.id);
+      // EVERY matching row, not the first: an adapter that accreted duplicates
+      // before `grant` reused ids would otherwise keep the person granted, and
+      // a revoke that leaves access standing is the worst possible outcome here.
+      const matching = (await grantsFor(appId)).filter((row) => row.principal === principal);
+      for (const row of matching) await grants.delete(row.id);
     },
 
     async list(ctx, appId) {

--- a/packages/store/src/helpers/rows.ts
+++ b/packages/store/src/helpers/rows.ts
@@ -111,26 +111,32 @@ export async function replaceThreadMessages(
   now = new Date().toISOString(),
 ): Promise<void> {
   // A legacy/hand-written row may hold messages with no `id` (the door accepts
-  // any Json). Derive a positional id for those rather than dropping them —
-  // the same rule the v6 backfill uses, so both doors agree.
+  // any Json). Derive a positional id for those rather than dropping them.
+  //
+  // The ids are derived ONCE, in TypeScript, and passed in beside the messages.
+  // SQL used to re-derive them with `COALESCE(elem->>'id', …)`, which disagreed
+  // with the TypeScript rule on an empty-string id ('' is not NULL, so COALESCE
+  // kept it) and on a non-string id (`elem->>'id'` renders 5 as '5'). The
+  // duplicate guard runs on the TypeScript rule, so those inputs cleared it and
+  // then collided inside this statement — the bare 21000 the guard exists to
+  // prevent. One derivation means the guard and the statement cannot disagree.
+  const ids = threadMessageRowIds(messages);
   await db.query(
     `INSERT INTO vendo_thread_messages (thread_id, id, seq, message, created_at, updated_at)
-     SELECT $1, COALESCE(elem->>'id', 'msg_' || (ordinality - 1)::text),
-            (ordinality - 1)::integer, elem, $3, $3
-     FROM jsonb_array_elements($2::jsonb) WITH ORDINALITY AS a(elem, ordinality)
+     SELECT $1, ids.id, (a.ordinality - 1)::integer, a.elem, $4, $4
+     FROM unnest($3::text[]) WITH ORDINALITY AS ids(id, n)
+     JOIN jsonb_array_elements($2::jsonb) WITH ORDINALITY AS a(elem, ordinality)
+       ON a.ordinality = ids.n
      ON CONFLICT (thread_id, id) DO UPDATE
        SET seq = EXCLUDED.seq, message = EXCLUDED.message, updated_at = EXCLUDED.updated_at,
            revision = vendo_thread_messages.revision + 1
        WHERE vendo_thread_messages.message IS DISTINCT FROM EXCLUDED.message
           OR vendo_thread_messages.seq IS DISTINCT FROM EXCLUDED.seq`,
-    [threadId, JSON.stringify(messages), now],
+    [threadId, JSON.stringify(messages), ids, now],
   );
   await db.query(
-    `DELETE FROM vendo_thread_messages
-     WHERE thread_id = $1 AND id <> ALL (
-       SELECT COALESCE(elem->>'id', 'msg_' || (ordinality - 1)::text)
-       FROM jsonb_array_elements($2::jsonb) WITH ORDINALITY AS a(elem, ordinality))`,
-    [threadId, JSON.stringify(messages)],
+    "DELETE FROM vendo_thread_messages WHERE thread_id = $1 AND id <> ALL ($2::text[])",
+    [threadId, ids],
   );
 }
 

--- a/packages/store/src/helpers/thread-messages.ts
+++ b/packages/store/src/helpers/thread-messages.ts
@@ -129,6 +129,18 @@ function overSql<M extends ThreadMessageLike>(db: Db): ThreadMessageStore<M> {
       // Doing it in ONE statement closes the TOCTOU window a read-then-write
       // pre-check leaves open (the same reasoning as putThreadRow's guarded
       // upsert), and it is why the answer cannot be "insert anyway".
+      //
+      // The insert leg LOCKS that row (`FOR KEY SHARE OF t`) rather than merely
+      // reading it. One statement is not enough on its own: under READ COMMITTED
+      // a plain read still sees a row a concurrent `threadStore.delete` has
+      // removed but not yet committed, so the message landed after that
+      // cascade's sweep and outlived its own thread — unreachable forever, since
+      // a message row carries no subject and no foreign key. KEY SHARE is the
+      // weakest strength that conflicts with deleting the row (the lock a
+      // foreign key would take), so thread touches still run alongside writes.
+      // The CAS leg below needs no lock: it is a plain UPDATE of an existing
+      // message row, so a swept row makes it match nothing — it can refuse, but
+      // it can never create a row the cascade has already passed.
       const messageId = requireMessageId(message);
       const expected = opts?.expectedRevision;
       const at = new Date().toISOString();
@@ -142,6 +154,7 @@ function overSql<M extends ThreadMessageLike>(db: Db): ThreadMessageStore<M> {
           `INSERT INTO vendo_thread_messages (thread_id, id, seq, message, created_at, updated_at)
            SELECT t.id, $2, $3, $4::jsonb, $5, $5 FROM vendo_threads t
              WHERE t.id = $1 AND t.subject = $6
+           FOR KEY SHARE OF t
            ON CONFLICT (thread_id, id) DO UPDATE
              SET seq = EXCLUDED.seq, message = EXCLUDED.message,
                  updated_at = EXCLUDED.updated_at,

--- a/packages/store/src/helpers/threads.ts
+++ b/packages/store/src/helpers/threads.ts
@@ -62,17 +62,28 @@ export function threadStore(store: VendoStore): {
       }));
     },
     async delete(principal, id) {
-      const deleted = await db.query(
-        "DELETE FROM vendo_threads WHERE id = $1 AND subject = $2 RETURNING id",
-        [id, principal.subject],
-      );
-      // The thread's harness state (a native-session ref) rides `vendo_state`
-      // under a synthetic app_id, so no table cascade covers it — without this
-      // sweep the ref outlives its thread until a subject-level erase. Guarded
-      // on the RETURNING row: a foreign principal's no-op delete sweeps nothing.
-      if (deleted.rows.length > 0) {
-        await db.query("DELETE FROM vendo_state WHERE app_id = $1", [harnessStateKey(id)]);
-      }
+      // The delete is a CASCADE, in one transaction: the thread row, its v6
+      // message rows, and its harness state die together.
+      //
+      // `vendo_thread_messages` has no foreign key, and a message row carries no
+      // subject of its own — the thread row IS the ownership record. So a
+      // message left behind here is unreachable forever: `erase.bySubject` finds
+      // transcript rows only through `thread_id IN (SELECT id FROM vendo_threads
+      // WHERE subject = $1)`, and that subquery is empty once the thread is
+      // gone. The harness state (a native-session ref) rides `vendo_state` under
+      // a synthetic app_id, which no table cascade covers either.
+      //
+      // Every drop is guarded on the RETURNING row, so a foreign principal's
+      // no-op delete sweeps nothing.
+      await db.transaction(async (q) => {
+        const deleted = await q(
+          "DELETE FROM vendo_threads WHERE id = $1 AND subject = $2 RETURNING id",
+          [id, principal.subject],
+        );
+        if (deleted.rows.length === 0) return;
+        await q("DELETE FROM vendo_thread_messages WHERE thread_id = $1", [id]);
+        await q("DELETE FROM vendo_state WHERE app_id = $1", [harnessStateKey(id)]);
+      });
     },
 
     /**

--- a/packages/store/src/helpers/threads.ts
+++ b/packages/store/src/helpers/threads.ts
@@ -108,6 +108,18 @@ export function threadStore(store: VendoStore): {
      *    caller cannot choose where in someone's history their answer lands,
      *    which would otherwise let an answer be inserted BEFORE the question it
      *    supposedly answers.
+     * 4. `FOR KEY SHARE OF t` — the ownership read LOCKS the thread row rather
+     *    than merely reading it. One statement is not enough on its own: under
+     *    READ COMMITTED a plain read still sees a row a concurrent
+     *    `threadStore.delete` has removed but not yet committed, so the answer
+     *    landed after that delete's message sweep and outlived the thread that
+     *    owns it — unreachable forever, because a message row has no subject and
+     *    no foreign key. With the lock the two orders are the only outcomes: the
+     *    answer commits first and the cascade sweeps it, or the delete commits
+     *    first and this statement finds no row and refuses below. KEY SHARE is
+     *    the weakest strength that conflicts with deleting the row — the same
+     *    lock a foreign key would take — so ordinary thread touches
+     *    (`updated_at`, `revision`) still run alongside answers.
      *
      * The row id is `ans_<questionId>`, NOT the bare `questionId`. The prefix is
      * a namespace, and the in-lane security review is why it exists: the bare id
@@ -137,6 +149,7 @@ export function threadStore(store: VendoStore): {
                 COALESCE((SELECT max(m.seq) + 1 FROM vendo_thread_messages m WHERE m.thread_id = t.id), 0),
                 $3::jsonb, $5, $5
          FROM vendo_threads t WHERE t.id = $1 AND t.subject = $4
+         FOR KEY SHARE OF t
          ON CONFLICT (thread_id, id) DO NOTHING
          RETURNING thread_id`,
         [threadId, rowId, JSON.stringify(message), principal.subject, now],

--- a/packages/store/src/thread-messages.test.ts
+++ b/packages/store/src/thread-messages.test.ts
@@ -1,8 +1,11 @@
 import { VendoError, type Json, type Principal } from "@vendoai/core";
 import type { UIMessage } from "ai";
+import { Client } from "pg";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { backends, type MadeBackend } from "./backends.test-util.js";
-import { eraseStore, storeFiles, threadMessageStore, threadStore } from "./index.js";
+import { harnessStateKey } from "./harness-state.js";
+import { createStore, eraseStore, storeFiles, threadMessageStore, threadStore } from "./index.js";
+import type { VendoStore } from "./store.js";
 
 const alice: Principal = { kind: "user", subject: "user_alice" };
 const bob: Principal = { kind: "user", subject: "user_bob" };
@@ -229,3 +232,130 @@ for (const backend of backends()) {
     });
   });
 }
+
+/**
+ * The cascade under CONCURRENCY.
+ *
+ * `threadStore.delete` is one transaction, but a transcript writer that only
+ * READS the thread row takes no lock on it. Under READ COMMITTED its snapshot
+ * still shows that row while the delete sits uncommitted, so it appends a
+ * message the cascade has already swept past — and the row outlives the thread
+ * that owns it. That row is then unreachable forever, for exactly the reason
+ * the cascade above exists: no foreign key, no subject of its own, and
+ * `erase.bySubject` reaches transcript rows only through `thread_id IN (SELECT
+ * id FROM vendo_threads WHERE subject = $1)`.
+ *
+ * PGlite cannot show this — it is single-connection and serializes
+ * transactions, so the interleave is unreachable there. Real Postgres only,
+ * which the store shards already set POSTGRES_URL for.
+ *
+ * The overlap is FORCED, not raced: a third connection holds the `vendo_state`
+ * row the cascade deletes LAST, so the delete parks with the thread row already
+ * gone and not yet committed — precisely the window that strands a row.
+ */
+describe.runIf(process.env["POSTGRES_URL"])("a concurrent transcript write cannot escape the cascade", () => {
+  const url = process.env["POSTGRES_URL"]!;
+  let store: VendoStore;
+  let admin: Client;
+
+  beforeAll(async () => {
+    admin = new Client({ connectionString: url });
+    await admin.connect();
+    store = createStore({ url });
+    await store.ensureSchema();
+  });
+  afterAll(async () => {
+    if (store) await store.close();
+    if (admin) await admin.end();
+  });
+
+  const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+  /** Poll until `ready`. The attempt bound is a safety net far inside the
+   *  suite's own timeout, so the test timeout stays the only hang detector. */
+  const until = async (ready: () => Promise<boolean>): Promise<void> => {
+    for (let attempt = 0; attempt < 400; attempt++) {
+      if (await ready()) return;
+      await wait(25);
+    }
+    throw new Error("the forced overlap never opened");
+  };
+
+  const blockedOn = async (table: string): Promise<boolean> => (
+    await admin.query(
+      `SELECT 1 FROM pg_stat_activity WHERE wait_event_type = 'Lock' AND query LIKE '%' || $1 || '%'`,
+      [table],
+    )
+  ).rows.length > 0;
+
+  /** An owned thread with one message, plus the harness-state row the cascade
+   *  deletes last — that row is the parking brake. */
+  const seed = async (id: string): Promise<void> => {
+    await threadStore(store).put(alice, { id, messages: [] });
+    await threadMessageStore<UIMessage>(store).upsert(alice, id, message("m_seed", "before"), 0);
+    await admin.query(
+      `INSERT INTO vendo_state (app_id, subject, data, created_at, updated_at)
+       VALUES ($1, $2, '{}'::jsonb, now(), now())`,
+      [harnessStateKey(id), alice.subject],
+    );
+  };
+
+  /** Run `write` while the cascade is parked, then let the cascade finish.
+   *  Resolves to "ok" when the write reported success to its caller. */
+  const duringCascade = async (id: string, write: () => Promise<unknown>): Promise<string> => {
+    const brake = new Client({ connectionString: url });
+    await brake.connect();
+    await brake.query("BEGIN");
+    await brake.query("SELECT 1 FROM vendo_state WHERE app_id = $1 FOR UPDATE", [harnessStateKey(id)]);
+
+    const deleting = threadStore(store).delete(alice, id);
+    await until(() => blockedOn("vendo_state"));
+
+    let settled = false;
+    const writing = write()
+      .then(() => "ok", (error: unknown) => String(error))
+      .finally(() => { settled = true; });
+    // The write has either finished (it escaped) or parked on the thread row's
+    // own lock (it did not). Either way the window is open; release the brake.
+    await until(async () => settled || await blockedOn("vendo_thread_messages"));
+
+    await brake.query("ROLLBACK");
+    await brake.end();
+    const outcome = await writing;
+    await deleting;
+    return outcome;
+  };
+
+  const survivingMessages = async (id: string): Promise<number> => (
+    await admin.query("SELECT id FROM vendo_thread_messages WHERE thread_id = $1", [id])
+  ).rows.length;
+
+  it("refuses an ask_user answer written into a thread the cascade is deleting", async () => {
+    const id = "thr_race_answer";
+    await seed(id);
+
+    const outcome = await duringCascade(id, () => threadStore(store).recordAnswer(alice, {
+      threadId: id,
+      questionId: "q_race",
+      answer: { picked: "yes" },
+    }));
+
+    // Reporting success is the worse half of the bug: `recordAnswer`'s contract
+    // is that a receipt means the row exists, and the model reads that receipt.
+    expect(outcome).not.toBe("ok");
+    expect(await survivingMessages(id)).toBe(0);
+  });
+
+  it("refuses a message upsert written into a thread the cascade is deleting", async () => {
+    const id = "thr_race_upsert";
+    await seed(id);
+
+    const outcome = await duringCascade(
+      id,
+      () => threadMessageStore<UIMessage>(store).upsert(alice, id, message("m_race", "during"), 1),
+    );
+
+    expect(outcome).not.toBe("ok");
+    expect(await survivingMessages(id)).toBe(0);
+  });
+});

--- a/packages/store/src/thread-messages.test.ts
+++ b/packages/store/src/thread-messages.test.ts
@@ -1,4 +1,4 @@
-import { VendoError, type Principal } from "@vendoai/core";
+import { VendoError, type Json, type Principal } from "@vendoai/core";
 import type { UIMessage } from "ai";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { backends, type MadeBackend } from "./backends.test-util.js";
@@ -92,6 +92,76 @@ for (const backend of backends()) {
         [id],
       );
       expect(left[0]!["n"]).toBe(0);
+    });
+
+    it("deletes the thread's message rows with the thread, leaving nothing erase cannot reach", async () => {
+      // A message row carries no subject of its own — the thread row IS the
+      // ownership record — so a message left behind by a thread delete is
+      // unreachable by `erase.bySubject`, which finds it only through
+      // `thread_id IN (SELECT id FROM vendo_threads WHERE subject = $1)`.
+      const id = "thr_deleted";
+      await ownThread(made, alice, id);
+      await threadMessageStore<UIMessage>(made.store).upsert(alice, id, message("m_1", "private"), 0);
+
+      await threadStore(made.store).delete(alice, id);
+
+      const left = await made.sql(
+        "SELECT count(*)::int AS n FROM vendo_thread_messages WHERE thread_id = $1",
+        [id],
+      );
+      expect(left[0]!["n"]).toBe(0);
+    });
+
+    it("keeps a foreign principal's failed delete from touching the thread's message rows", async () => {
+      const id = "thr_delete_guard";
+      await ownThread(made, alice, id);
+      await threadMessageStore<UIMessage>(made.store).upsert(alice, id, message("m_1", "mine"), 0);
+
+      await threadStore(made.store).delete(bob, id);
+
+      const left = await made.sql(
+        "SELECT count(*)::int AS n FROM vendo_thread_messages WHERE thread_id = $1",
+        [id],
+      );
+      expect(left[0]!["n"]).toBe(1);
+    });
+
+    it("derives every row id once, so an empty-string id cannot collide inside the statement", async () => {
+      // The duplicate guard runs on the TypeScript derivation; the INSERT used a
+      // separate SQL COALESCE that disagreed with it. `elem->>'id'` yields '' for
+      // {"id":""} rather than NULL, so two such messages passed the guard as
+      // msg_0/msg_1 and then hit ON CONFLICT twice with the same key '' — a bare
+      // Postgres 21000 cardinality violation that lost the whole write.
+      const id = "thr_blank_ids";
+      await threadStore(made.store).put(alice, {
+        id,
+        messages: [message("", "first"), message("", "second")] as unknown as Json[],
+      });
+
+      const rows = await made.sql(
+        "SELECT id, seq FROM vendo_thread_messages WHERE thread_id = $1 ORDER BY seq",
+        [id],
+      );
+      expect(rows.map((row) => row["id"])).toEqual(["msg_0", "msg_1"]);
+    });
+
+    it("derives every row id once, so a non-string id cannot collide with its own text form", async () => {
+      // `elem->>'id'` renders {"id":5} as '5', which the TypeScript rule never
+      // produces — so [{id:5},{id:"5"}] cleared the guard and collided in SQL.
+      const id = "thr_numeric_ids";
+      await threadStore(made.store).put(alice, {
+        id,
+        messages: [
+          { id: 5, role: "user", parts: [{ type: "text", text: "numeric" }] },
+          { id: "5", role: "user", parts: [{ type: "text", text: "textual" }] },
+        ] as unknown as Json[],
+      });
+
+      const rows = await made.sql(
+        "SELECT id, seq FROM vendo_thread_messages WHERE thread_id = $1 ORDER BY seq",
+        [id],
+      );
+      expect(rows.map((row) => row["id"])).toEqual(["msg_0", "5"]);
     });
 
     it("writes one row per message — O(messages), not O(messages²)", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -826,7 +826,7 @@ importers:
         specifier: workspace:*
         version: link:../store
       zod:
-        specifier: '>=3.25.0 <5'
+        specifier: ^3.25.0
         version: 3.25.76
     devDependencies:
       '@types/node':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -819,9 +819,6 @@ importers:
       '@vendoai/harnesses':
         specifier: workspace:*
         version: link:../harnesses
-      '@vendoai/knowledge':
-        specifier: workspace:*
-        version: link:../knowledge
       '@vendoai/mcp':
         specifier: workspace:*
         version: link:../mcp
@@ -829,7 +826,7 @@ importers:
         specifier: workspace:*
         version: link:../store
       zod:
-        specifier: ^3.25.0
+        specifier: '>=3.25.0 <5'
         version: 3.25.76
     devDependencies:
       '@types/node':


### PR DESCRIPTION
De-slopping sweep for `@vendoai/store` and `@vendoai/agents`, worked worst-first: correctness bugs → dead code → verbosity. Three HIGH correctness bugs in `store`, two dead-code removals in `agents`, one catalog claim rejected, the rest deferred with reasons.

Every bug fix is **failing test first**, in the existing behaviour-named suite, watched failing, then fixed — separate commits.

---

## Work list and per-finding disposition

| # | Finding (catalog) | Severity | Disposition |
|---|---|---|---|
| 1 | Message row-id derived twice with different rules; guard misses collisions | HIGH·strong | **FIXED** — `helpers/rows.ts` |
| 2 | `threadStore.delete` strands transcript rows past the reach of erase | HIGH·strong | **FIXED** — `helpers/threads.ts` |
| 3 | `grant()` mints a fresh row id, so re-granting accretes duplicate rows *(listed twice in the catalog — also as "Re-granting is idempotent only because of one SQL constraint")* | HIGH·strong | **FIXED** — `helpers/app-access.ts` |
| 4 | Session opens the workspace twice; first result is dead | MED·strong | **FIXED** — `agents/src/session.ts` |
| 5 | agents depends on knowledge for one unusable re-export | MED·strong | **FIXED** — re-export + dependency removed |
| 6 | Unused `zod` dep | MED·strong | **BLOCKED** — see "Handoff" below; dep restored |
| 7 | CloudAdapters store rung is a seam nobody fills / wired nowhere | MED·strong ×2 | **REJECTED** — catalog wrong |
| 8 | Stale `s3()` doc mentions in my two packages | follow-up | **NONE EXIST** — all live ones are outside my file set |
| 9 | `harnessStateStore.get` deletes the slot it was asked about | HIGH·strong | **DEFERRED — NEEDS-DECISION** |

### 1. One rule for a transcript row's id — `helpers/rows.ts`

`threadMessageRowIds` (TypeScript) and `replaceThreadMessages`'s `COALESCE(elem->>'id', …)` (SQL, twice) expressed the same rule in two dialects that **disagree**:

- `elem->>'id'` returns `''` for `{"id":""}` — not NULL, so `COALESCE` keeps it.
- `elem->>'id'` returns `'5'` for `{"id":5}`.

The duplicate-id guard runs on the **TypeScript** rule, so both inputs cleared it and then collided inside the INSERT, failing with the bare Postgres 21000 the guard exists to prevent — **losing the entire write**. Reproduced exactly: `ON CONFLICT DO UPDATE command cannot affect row a second time`.

The ids are now derived **once**, in TypeScript, and passed in as a `text[]` joined by ordinality. Both `COALESCE` expressions are gone.

**Load-bearing equivalence claim — a silent id-scheme change in a store is exactly what corrupts data later, so this is explicit, not implied:** the new derivation is `messages.map((message, index) => … : msg_${index})`. `Array.prototype.map`'s `index` is **0-based**. The old SQL was `'msg_' || (ordinality - 1)::text`, and SQL `WITH ORDINALITY` is **1-based**, so `ordinality - 1` is also 0-based. **The two produce byte-identical ids for every input on which they previously agreed.** The test asserting this is `packages/store/src/thread-messages.test.ts` → *"derives every row id once, so an empty-string id cannot collide inside the statement"*, which asserts `["msg_0", "msg_1"]`.

### 2. `threadStore.delete` takes the transcript with it — `helpers/threads.ts`

It dropped the thread row and the harness-state row but never `vendo_thread_messages`, which has **no foreign key** (confirmed against `schema.ts:79-86` — `PRIMARY KEY (thread_id, id)`, no `REFERENCES`, no `ON DELETE CASCADE`).

A message row carries no subject of its own — the thread row *is* the ownership record — so a stranded row is unreachable **forever**: `erase.bySubject` reaches transcript rows only through `thread_id IN (SELECT id FROM vendo_threads WHERE subject = $1)`, which is empty once the thread is gone. `ops.transcripts.deleteThread` already got this right and says so in a comment; the exported helper was never fixed.

Now the same cascade, in one `db.transaction`, still guarded on the RETURNING row so a foreign principal's no-op delete sweeps nothing (pinned by a second test that already passed and now guards the fix).

### 3. One grant row per (app, principal) — `helpers/app-access.ts`

`grant` always wrote `id: ag_${crypto.randomUUID()}`. Uniqueness came **only** from `ON CONFLICT (app_id, principal)` in the local Postgres routing door — a constraint this file never sees. The file's own header says it goes through `store.records` *precisely because* "multi-party deployments are exactly the ones running on a hosted store".

On a hosted or BYO records adapter, `records.put` is keyed by id alone, so a second grant to the same principal wrote a **second row**. Then `levelFor` folds every match with `strongerLevel` — so a downgrade silently does nothing — and `revoke` deleted only the **first** match, so revoking access could leave the person still granted.

Proven with core's **real reference in-memory adapter** (`memoryStoreAdapter` from `@vendoai/core/conformance`), not a hand-rolled stub — `vendo_app_grants` is not a reserved collection there, so it is generic and id-keyed, exactly the hosted/BYO shape. All three cases failed first: 2 rows instead of 1, `expected 'editor' to be 'viewer'`, and 1 row surviving revoke.

`grant` now reuses the existing row's id; `revoke` deletes every matching row.

---

## Persisted-data impact (`packages/store` owns persisted data)

**No stored shape changes. No index changes. No query-path changes. No migration required. No live or Cloud store was touched, reset, or migrated by this PR — and none needs to be for it to be correct.**

- **Row-id derivation.** Existing rows keep their ids. Two pathological legacy cases re-key on their *next* write: a row the v6 backfill wrote as `''` (from `{"id":""}`) or `'5'` (from `{"id":5}`) is DELETEd and re-INSERTed as `msg_<index>`. **Message content and `seq` are preserved; only the row key changes and `revision` restarts at 1. No row becomes unreadable.** The v6 backfill in `schema.ts` still uses the SQL `COALESCE` — it runs once over legacy pre-v6 arrays and cannot call TypeScript. I removed the now-false comment claiming the two rules agree.
- **Thread-delete cascade.** Deletes strictly *more* rows than before; no shape change. The `vendo_state` drop is unchanged in scope — same synthetic `harness_state:<threadId>` app_id, now inside the transaction. **Rows already stranded by past deletes are NOT reachable by this change** (their thread row is gone). Clearing them would need a one-off sweep, `DELETE FROM vendo_thread_messages WHERE thread_id NOT IN (SELECT id FROM vendo_threads)`. **I did not run this against any store, live or otherwise.** It is written up here and stops here — it needs an owner's decision and a backup first.
- **App grants.** Reusing the *found* id, rather than deriving `ag_<appId>_<principal>` the way core's reference adapter does, is deliberate and is the migration-safety property: every grant already on disk carries a random id, and a derived id would sit **beside** the existing row instead of replacing it. `revoke` deleting all matches also cleans up duplicates already accreted on a hosted store.

---

## vendo-web tandem disposition — SAFE NO-OP on all three changes, no companion PR needed

Cloud runs on this store and the console keeps a mirrored copy of the schema, so this was checked exhaustively rather than waved through as "mechanical".

- **Row-id change** — vendo-web's `putThread` delegates entirely to the store (`apps/console/lib/api/store-doors.ts:192`); its own `putMessage` mints `msg_<uuid>` via a different store path (`ops.putMessage`), which never touched the array-splitting derivation. There are **zero** occurrences of `elem->>`, `ordinality`, or `COALESCE(elem` in vendo-web source. Its one id-less-message test (`apps/console/tests/store-conformance.test.ts:186`, bare-string messages) derives `msg_0` under both the old and new rules and passes unchanged.
- **Thread-delete cascade** — vendo-web never calls `threadStore.delete`; it uses the generic records door plus its own three follow-up sweeps (`store-doors.ts:236-239`), with a deliberately **opposite** delete order documented in a 20-line rationale at `store-doors.ts:218-235`. My cascade never fires on that path, and the two paths share no code — so nothing breaks, and the orderings should not be "unified" without reading that comment. Its harness state lives in `vendo_records` (freeform collection `vendo_harness_state`), **not** `vendo_state`, so my `vendo_state` drop is a zero-row no-op on a Cloud tenant; parity is already provided by their `deleteByRefs`.
- **Grant rows** — `vendo_app_grants` appears in **no** vendo-web source file at all. Nothing mints an `ag_` id, parses one, or assumes multiple rows per principal. Their generic records passthrough (`lib/api/store-handlers.ts:493`) forwards ids verbatim to the store's own `parseAppGrantData` (`/^ag_.+$/`), which a reused `ag_<uuid>` still satisfies.
- **One release-time chore, not a code change** — `apps/console/lib/automations/exec-bundle.generated.ts` is a checked-in esbuild artifact that still embeds the pre-change store SQL. It is regenerated by re-vendoring the tarball and re-running `apps/console/hosted-exec/build.mjs`; no hand edit. **Not a correctness hazard** — old and new derivations produce identical strings.

---

## Rejected (catalog wrong)

**"CloudAdapters store rung is a seam nobody fills" / "The Cloud store rung is wired nowhere and only produces errors."** Both say to delete the store half of `CloudAdapters` and its throw. That would delete an **intentional** loud failure. `packages/vendo/src/server.ts:211-216` documents it as a deliberate 2026-08-04 hold: tenant-store access is under redesign, so the rung stays unfilled *on purpose* and a `VENDO_API_KEY`-only `agent()` fails loudly naming `store: postgres(url)` rather than composing something broken. The sibling `sandbox` rung **is** filled in production, so the mechanism is live. Not dead code.

**Stale `s3()` doc mentions.** None exist in my two packages. `packages/store`'s only mention (`ops.ts:151`, "A host-wired adapter (S3) is external either way") is valid prose about the surviving BYO `FilesAdapter`, not the removed export; `packages/agents` has none. The genuinely stale ones are all outside my file set and are **left and listed**: `packages/core/src/workspace.ts:44`, `packages/vendo/src/server.ts:461-462` and `:1071-1072`, `docs/archive/config-migration-table.md:28`.

---

## Handoff — a real latent bug I could not fix inside my file set

Removing the genuinely unused `dependencies.zod` from `@vendoai/agents` **fails `pnpm lint`**:

```
✗ @vendoai/agents: "zod" range ">=3.25.0 <5" has no modelable floor
```

`scripts/dependency-guard.mjs` rule 4 does `pkg.dependencies?.zod ?? pkg.peerDependencies?.zod`. With the dep gone it falls through to the peer range `">=3.25.0 <5"`, and the floor parser is `FLOOR_TOKEN = /^(?:\^|~|>=)?\s*(\d+)\.(\d+)\.(\d+)$/` — **`$`-anchored, so it cannot read a compound range with an upper bound.** Every other package carrying an `ai` peer also carries a simple `dependencies.zod`, so the `??` short-circuits and that branch has never been reached; `@vendoai/agents` is the first package to reach it.

**The manifest is right and the guard is wrong.** The fix is one line in `parseVersionFloor` (take the first whitespace-separated token before matching). That file is outside this slice's file set and is shared with pieces in flight, so I restored the dependency rather than reach for it. Finding 6 is unresolved and is a clean one-line follow-up.

Related, same file, also left alone: the `@vendoai/agents` allow-list at `scripts/dependency-guard.mjs:93` still permits `@vendoai/knowledge`, an edge that no longer exists. The guard only rejects *disallowed* edges, so this is stale rather than broken — but it means an accidental re-introduction would now pass silently.

---

## Deferred, with reasons

- **`harnessStateStore.get` deletes the slot it was asked about — NEEDS-DECISION.** The destructive read is *documented intent*, not an oversight: `harness-state.ts:23-25` states "a foreign harness DESTROYS the row rather than shadowing it", derived from build contract §1.3, and `packages/vendo/src/hosted-transcript.live.test.ts:95-103` pins it in a test literally named *"keeps a harness's native session across clients, and destroys it on a swap"*. Changing it is a contract-semantics decision **and** requires editing a file outside my set. Worth revisiting — the catalog's argument that `set` already handles the swap is sound — but not unilaterally.
- **Concurrent undo deletes the blob the restored file points at** (`workspace-rows.ts`) and **`undo(commitId)` undoes the newest change** (`ops.ts`) — both real HIGH data-loss findings, both substantial slices of their own. Deferred to keep this PR coherent.
- **Knowledge-corpus erase selectors can never match a real row** — NEEDS-DECISION (is an ingested corpus subject-scoped for GDPR, or host-owned?) and spans `packages/knowledge`, outside my set.
- **`recordAnswer` dead ask-answer door**, **four dedicated record tables identical to `vendo_records`**, **the v1–v6 migration train in `schema.ts`** — all span `packages/core`/`packages/vendo` or carry live-data migrations needing an owner's sign-off.
- **`approvals.ts` is dead** — plausible, but needs its own verification pass plus repointing four test files; not bundled here.
- **The ~40-item MED/LOW test-consolidation tier** — deliberately deferred. This is the repo's most memory-hungry suite; the churn is large and the correctness value is near zero.

---

## Gates

All foreground, redirected to a file, read from disk. Scoped builds only.

| Gate | Result |
|---|---|
| `turbo build --filter=@vendoai/store... --filter=@vendoai/agents...` | **exit 0** |
| `packages/store` suite | **exit 0** — `Test Files 51 passed \| 1 skipped (52)`, `Tests 507 passed \| 2 skipped (509)`, 1485.32s |
| `packages/agents` suite | **exit 0** — `Test Files 9 passed (9)`, `Tests 79 passed (79)`, 113.71s |
| root `pnpm typecheck` | **exit 0** — `Tasks: 40 successful, 40 total` |
| root `pnpm lint` | **exit 0** (includes `dependency-guard.mjs` + `portability-gate.mjs`) |
| root `turbo lint --force` | **exit 0** — `Tasks: 3 successful, 3 total`, `Cached: 0 cached`, 24.383s |

Suites ran with `VITEST_MIN_FORKS=1 VITEST_MAX_FORKS=2 VITEST_MIN_THREADS=1 VITEST_MAX_THREADS=2`. The full repo suite was not run locally — that is CI's job.

Post-commit symbol sweep run repo-wide **including test dirs** (typecheck configs exclude test files, so a broken test survives build and typecheck): **zero** consumers of `vendoKnowledge` via `@vendoai/agents` anywhere in `packages/`, `examples/`, `fixtures/`, `corpus/`, `docs/`, `docs-site/`, or vendo-web. Every `@vendoai/agents` importer uses `agent`, `awayRunner`, or `VendoAgent` — none touched. `packages/vendo`'s two `vendoKnowledge` users import it from `@vendoai/knowledge` directly.

## Real LOC

| Package | Source | Tests |
|---|---|---|
| `packages/store` | +54 / −25 | +131 / −2 |
| `packages/agents` | +4 / −4 | +0 / −1 |

## Changesets

- `@vendoai/store` → **patch**: three bug fixes, no public surface change.
- `@vendoai/agents` → **minor**: removes the `vendoKnowledge` re-export, a public surface removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multiple data-correctness bugs in `@vendoai/store` (safer deletes, id handling, and concurrency), and removes unused code in `@vendoai/agents`. No schema changes or migration required.

- **Bug Fixes**
  - Derive thread message IDs once in TypeScript and pass as `text[]`, avoiding collisions on empty-string and non-string ids.
  - Make `threadStore.delete` a guarded cascade that also deletes `vendo_thread_messages` and harness state in one transaction.
  - Prevent writes from escaping the delete cascade by locking the thread row (`FOR KEY SHARE`) in `recordAnswer` and `threadMessageStore.upsert`.
  - Ensure one grant row per (app, principal) on all adapters: reuse existing id; if none, use derived `ag_<appId>_<principal>` to collapse overlaps; `revoke` removes all matches.

- **Refactors**
  - Stop opening the workspace twice in `session()`; removes one DB round trip per session.
  - Drop the `vendoKnowledge` re-export and the `@vendoai/knowledge` dependency from `@vendoai/agents`.

<sup>Written for commit a0e33391c14d8aabf6ee8982242e405f8fb78b97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

