### PR TITLE
fix(scripts): the zod floor parser reads compound ranges, and the agents allow-list loses its dead knowledge edge

### DIFF
--- a/scripts/dependency-guard.mjs
+++ b/scripts/dependency-guard.mjs
@@ -79,9 +79,14 @@ const LAYERS = {
   // the standalone agent runtime (agents-v0 spec, 2026-08-04): the open-source
   // front door Vendo's embed consumes across a real seam. It assembles what the
   // umbrella assembles — harness runtime (harnesses), guard, store, host tools
-  // and MCP connectors (actions), knowledge, and the e2b sandbox adapter (apps)
-  // — but it is NOT the umbrella: no @vendoai/vendo, ever (the spec's
-  // dependency law; the embed consumes agents, never the reverse).
+  // and MCP connectors (actions), and the e2b sandbox adapter (apps) — but it
+  // is NOT the umbrella: no @vendoai/vendo, ever (the spec's dependency law;
+  // the embed consumes agents, never the reverse).
+  //
+  // knowledge LEFT with the dead `vendoKnowledge` re-export (#982): the runtime
+  // reaches knowledge engines through core's KnowledgeAdapter, so the direct
+  // edge had no importer. An allow-list entry with no edge behind it is a hole
+  // in the gate — it permits what nobody intends — so it goes when the edge does.
   //
   // mcp joined for the TOOL DOOR (Amendment 2, 2026-08-05): a harness declaring
   // `requires.toolDoor` thinks outside this process and reaches the host's
@@ -96,7 +101,6 @@ const LAYERS = {
     "@vendoai/apps",
     "@vendoai/guard",
     "@vendoai/harnesses",
-    "@vendoai/knowledge",
     "@vendoai/mcp",
     "@vendoai/store",
   ],
@@ -127,24 +131,47 @@ const LAYERS = {
  */
 const ZOD_V4_EXPORT_FLOOR = [3, 25, 0];
 
-/** A range token whose x.y.z IS its floor: "^3.25.76", "~3.25.0",
- * ">=3.25.76", or a bare "3.25.76". Anything else (upper bounds like
- * "<=3.25.0", wildcards, comparator intersections) is not modeled. */
-const FLOOR_TOKEN = /^(?:\^|~|>=)?\s*(\d+)\.(\d+)\.(\d+)$/;
+/** One comparator: an operator (or none) over a possibly-partial version —
+ * "^3.25.0", "~3.25.0", ">=3.25.0", "3.25.76", "<5". A missing minor or patch
+ * reads as 0, which is what npm means by them in a lower bound ("^3" is
+ * >=3.0.0, "3.25" is >=3.25.0). Wildcards ("3.25.x", "*"), prereleases
+ * ("3.25.0-beta.1") and the hyphen range's bare "-" deliberately do NOT match. */
+const COMPARATOR = /^(\^|~|>=|>|<=|<|=)?\s*(\d+)(?:\.(\d+))?(?:\.(\d+))?$/;
 
-/** Extracts a [major, minor, patch] floor from a semver range: a single
- * floor-shaped token, or a `||` union of them. A union is only as safe as
- * its LOWEST satisfiable alternative, so the floor is the minimum across
- * every `||` branch; any branch that is not floor-shaped (e.g. "<=3.25.0",
- * whose x.y.z is a ceiling, not a floor) returns null so the guard fails
- * closed instead of trusting a range it cannot model. */
+/** Operators whose version is a ceiling. They cannot raise a floor, so the
+ * floor scan skips them — but they are still a shape we understand, which is
+ * the whole point: ">=3.25.0 <5" has a floor, it is just not the last token. */
+const CEILING_OPERATORS = new Set(["<", "<="]);
+
+/** Extracts a [major, minor, patch] floor from a semver range.
+ *
+ * A range is a `||` union of alternatives, and each alternative is a
+ * whitespace-separated INTERSECTION of comparators — the shape every `ai`-peer
+ * package in this repo uses for its zod peer, ">=3.25.0 <5". An alternative's
+ * floor is the highest of its lower bounds (an intersection can only narrow);
+ * the range's floor is the lowest across alternatives, because a union is only
+ * as safe as the oldest zod it admits. `>x.y.z` is read as a floor of x.y.z —
+ * an epsilon low, which can only make the guard stricter, never laxer.
+ *
+ * Returns null for any shape this cannot model — a wildcard, a prerelease, a
+ * hyphen range, or an alternative that is all ceiling ("<5", which admits
+ * zod 1.0.0). The caller turns null into a loud failure: a version gate that
+ * quietly accepts what it cannot read is worse than one that errors. */
 function parseVersionFloor(range) {
   let floor = null;
   for (const alternative of String(range).split("||")) {
-    const match = FLOOR_TOKEN.exec(alternative.trim());
-    if (!match) return null;
-    const version = [Number(match[1]), Number(match[2]), Number(match[3])];
-    if (!floor || compareVersions(version, floor) < 0) floor = version;
+    let alternativeFloor = null;
+    for (const comparator of alternative.trim().split(/\s+/)) {
+      const match = COMPARATOR.exec(comparator);
+      if (!match) return null;
+      if (CEILING_OPERATORS.has(match[1])) continue;
+      const version = [Number(match[2]), Number(match[3] ?? 0), Number(match[4] ?? 0)];
+      if (!alternativeFloor || compareVersions(version, alternativeFloor) > 0) {
+        alternativeFloor = version;
+      }
+    }
+    if (!alternativeFloor) return null;
+    if (!floor || compareVersions(alternativeFloor, floor) < 0) floor = alternativeFloor;
   }
   return floor;
 }
@@ -244,7 +271,7 @@ for (const dir of dirs) {
       const floor = parseVersionFloor(zodRange);
       if (!floor) {
         errors.push(
-          `${pkg.name}: "zod" range "${zodRange}" has no modelable floor (rule 4 accepts ^x.y.z, ~x.y.z, >=x.y.z, or bare x.y.z tokens, or a || union of them) — declare a simple floor at or above ${ZOD_V4_EXPORT_FLOOR.join(".")}.`,
+          `${pkg.name}: "zod" range "${zodRange}" has no modelable floor (rule 4 reads ^ ~ >= > <= = comparators over whole x[.y[.z]] versions, space-intersected and ||-unioned, e.g. ">=3.25.0 <5"; wildcards, prereleases and hyphen ranges are not modeled) — declare a floor at or above ${ZOD_V4_EXPORT_FLOOR.join(".")}.`,
         );
       } else if (compareVersions(floor, ZOD_V4_EXPORT_FLOOR) < 0) {
         errors.push(

--- a/scripts/dependency-guard.mjs
+++ b/scripts/dependency-guard.mjs
@@ -132,11 +132,19 @@ const LAYERS = {
 const ZOD_V4_EXPORT_FLOOR = [3, 25, 0];
 
 /** One comparator: an operator (or none) over a possibly-partial version —
- * "^3.25.0", "~3.25.0", ">=3.25.0", "3.25.76", "<5". A missing minor or patch
- * reads as 0, which is what npm means by them in a lower bound ("^3" is
- * >=3.0.0, "3.25" is >=3.25.0). Wildcards ("3.25.x", "*"), prereleases
- * ("3.25.0-beta.1") and the hyphen range's bare "-" deliberately do NOT match. */
-const COMPARATOR = /^(\^|~|>=|>|<=|<|=)?\s*(\d+)(?:\.(\d+))?(?:\.(\d+))?$/;
+ * "^3.25.0", "~3.25.0", ">=3.25.0", ">= 3.25.0", "3.25.76", "<5". A missing
+ * minor or patch reads as 0, which is what npm means by them in a lower bound
+ * ("^3" is >=3.0.0, "3.25" is >=3.25.0). Wildcards ("3.25.x", "*"), prereleases
+ * ("3.25.0-beta.1") and the hyphen range's bare "-" deliberately do NOT match.
+ *
+ * Sticky, and it absorbs the whitespace on both sides, because npm allows a
+ * space BETWEEN an operator and its version (">= 3.25.0"). The operator and its
+ * version are therefore one token that the scanner walks over; whitespace only
+ * separates COMPLETE comparators. Splitting on bare whitespace instead would
+ * fragment ">= 3.25.0 < 5" into ">=", "3.25.0", "<", "5" and strand both
+ * operators. `\d+` is required, so a match is never empty and the walk always
+ * advances. */
+const COMPARATOR = /\s*(\^|~|>=|>|<=|<|=)?\s*(\d+)(?:\.(\d+))?(?:\.(\d+))?\s*/y;
 
 /** Operators whose version is a ceiling. They cannot raise a floor, so the
  * floor scan skips them — but they are still a shape we understand, which is
@@ -147,7 +155,10 @@ const CEILING_OPERATORS = new Set(["<", "<="]);
  *
  * A range is a `||` union of alternatives, and each alternative is a
  * whitespace-separated INTERSECTION of comparators — the shape every `ai`-peer
- * package in this repo uses for its zod peer, ">=3.25.0 <5". An alternative's
+ * package in this repo uses for its zod peer, ">=3.25.0 <5". Each alternative
+ * is SCANNED comparator by comparator rather than split on whitespace, so the
+ * equally legal ">= 3.25.0 < 5" reads the same; anything left over when the
+ * scan stalls is a shape we do not model. An alternative's
  * floor is the highest of its lower bounds (an intersection can only narrow);
  * the range's floor is the lowest across alternatives, because a union is only
  * as safe as the oldest zod it admits. `>x.y.z` is read as a floor of x.y.z —
@@ -160,9 +171,11 @@ const CEILING_OPERATORS = new Set(["<", "<="]);
 function parseVersionFloor(range) {
   let floor = null;
   for (const alternative of String(range).split("||")) {
+    const text = alternative.trim();
     let alternativeFloor = null;
-    for (const comparator of alternative.trim().split(/\s+/)) {
-      const match = COMPARATOR.exec(comparator);
+    COMPARATOR.lastIndex = 0;
+    while (COMPARATOR.lastIndex < text.length) {
+      const match = COMPARATOR.exec(text);
       if (!match) return null;
       if (CEILING_OPERATORS.has(match[1])) continue;
       const version = [Number(match[2]), Number(match[3] ?? 0), Number(match[4] ?? 0)];


### PR DESCRIPTION
## What

Two fixes in `scripts/dependency-guard.mjs`, the layering gate `pnpm lint` runs.

**1. Rule 4's zod floor parser could not read a compound range.** The token regex was
`$`-anchored on a single `x.y.z`:

```js
const FLOOR_TOKEN = /^(?:\^|~|>=)?\s*(\d+)\.(\d+)\.(\d+)$/;
```

Every `ai`-peer package in this repo declares its zod peer as `">=3.25.0 <5"`. The
branch had never been reached because every one of them *also* declares a simple
`dependencies.zod`, which the rule prefers. Remove a genuinely unused
`dependencies.zod` and the check drops through to the peer range, fails to parse it,
and reports a manifest problem that does not exist. **The manifest was right; the
guard was wrong.**

The parser now models a range the way npm does: a `||` union of alternatives, each a
whitespace-separated *intersection* of comparators. An alternative's floor is the
**highest** of its lower bounds (an intersection only narrows); the range's floor is
the **lowest** across alternatives (a union is only as safe as the oldest zod it
admits). Ceiling operators (`<`, `<=`) are recognised and skipped — they cannot raise
a floor — instead of being fatal. `>x.y.z` reads as a floor of `x.y.z`, an epsilon
low, which can only make the guard stricter.

**Shapes it now reads** (all present in this repo's manifests, or trivially adjacent):
`^3.25.0` · `~3.25.0` · `3.25.76` · `>=3.25.0 <5` · `^3.25.0 || ^4.0.0` · partial
versions (`^3`, `>=3.25`) where a missing minor/patch reads as `0`, which is npm's
meaning in a lower bound.

**Shapes it rejects loudly** (returns `null`, guard exits 1): wildcards (`*`,
`3.25.x`), prereleases (`>=3.25.0-beta.1`), hyphen ranges (`3.25.0 - 4.0.0`), and any
alternative that is all ceiling (`<5`, which admits zod 1.0.0). This was deliberate,
not a widened regex — a version gate that quietly accepts what it cannot read is
worse than one that errors.

**2. `@vendoai/knowledge` leaves the `agents` allow-list.** #982 removes the dead
`vendoKnowledge` re-export and the `@vendoai/knowledge` dependency behind it. An
allow-list entry with no edge behind it is a hole in the gate — it permits an edge
nobody intends.

## Merge order — this PR must land AFTER #982

**This PR is stacked on #982** (base is `yousefh409/deslop-sweep-store-agents`, so
GitHub retargets to `main` automatically when #982 merges). That is not a preference,
it is a correctness requirement:

- On current `main`, `packages/agents` still declares `"@vendoai/knowledge":
  "workspace:*"` and `src/index.ts` still has `export { vendoKnowledge } from
  "@vendoai/knowledge"`. Removing the allow-list entry before #982 merges would fail
  `pnpm lint` on `main`.
- Stacking makes the order mechanical and keeps this PR's own `ci` check green.

**Follow-up unlocked:** #982 had to *restore* `dependencies.zod` in
`packages/agents/package.json` (commit `de0af2249`, "keep the zod dependency — the
guard cannot read the peer range") solely because of the bug fixed here. Once this
lands, that dependency can be dropped — the peer range `">=3.25.0 <5"` now satisfies
rule 4 on its own. Recording it here so it is not lost; I did not touch that manifest,
it belongs to #982.

## Proof

`scripts/` has **no test harness today** (no root vitest project, no test file anywhere
references `scripts/*.mjs`), and one script does not justify inventing one. The guard
is itself a whole-repo gate, so the proof is the real script run against real
manifests — mutated in a scratch working tree and `git checkout --`'d after each case.
The tree was clean at the end of the run.

### The real failing case — before vs after

```
########## BEFORE (guard as on main) ##########
--- [1] drop agents dependencies.zod -> the real failing case ---
dependency-guard: FAILED

  ✗ @vendoai/agents: "zod" range ">=3.25.0 <5" has no modelable floor (rule 4 accepts
    ^x.y.z, ~x.y.z, >=x.y.z, or bare x.y.z tokens, or a || union of them) — declare a
    simple floor at or above 3.25.0.
exit=1

########## AFTER (this PR) ##########
--- [2] same drop of agents dependencies.zod ---
dependency-guard: OK (15 packages checked)
exit=0
```

### It still fails loudly — not disabled

Each row sets `packages/agents` `peerDependencies.zod` to the given range with no
`dependencies.zod`, then runs the guard:

```
--- "<5" ---
  ✗ @vendoai/agents: "zod" range "<5" has no modelable floor (...) — declare a floor at or above 3.25.0.
--- "*" ---
  ✗ ... has no modelable floor ...
--- "3.25.x" ---
  ✗ ... has no modelable floor ...
--- ">=3.25.0-beta.1 <5" ---
  ✗ ... has no modelable floor ...
--- "3.25.0 - 4.0.0" ---
  ✗ ... has no modelable floor ...
--- ">=3.24.0 <5" ---
  ✗ @vendoai/agents: "zod" floor ">=3.24.0 <5" is below 3.25.0, the first zod release
    with the ./v4 export ai needs — raise it (see 174aa430).
--- ">=3.25.0 <4 || >=3.24.9 <5" ---
  ✗ @vendoai/agents: "zod" floor ">=3.25.0 <4 || >=3.24.9 <5" is below 3.25.0, ... 
--- "^3.25.0 || ^4.0.0" ---
dependency-guard: OK (15 packages checked)
--- ">=3.25.0 <5" ---
dependency-guard: OK (15 packages checked)
```

The two `below 3.25.0` rows are the important ones: the floor is *read out of* the
compound range and *compared*, not merely accepted. The union row proves the union
takes its lowest branch.

### Layering not weakened

```
--- bad layering edge: agents -> @vendoai/vendo (the umbrella, forbidden) ---
  ✗ @vendoai/agents: dependency "@vendoai/vendo" violates the layering rule
    (allowed: @vendoai/core, @vendoai/actions, @vendoai/apps, @vendoai/guard,
     @vendoai/harnesses, @vendoai/mcp, @vendoai/store).

--- the removed entry: agents -> @vendoai/knowledge is now rejected ---
  ✗ @vendoai/agents: dependency "@vendoai/knowledge" violates the layering rule
    (allowed: @vendoai/core, @vendoai/actions, @vendoai/apps, @vendoai/guard,
     @vendoai/harnesses, @vendoai/mcp, @vendoai/store).
```

The second is the allow-list change proving itself: the edge that used to be permitted
is now refused.

## Gates

```
$ pnpm lint       -> LINT_EXIT=0   (dependency-guard: OK (15 packages checked); 29 packages lint clean)
$ pnpm typecheck  -> TYPECHECK_EXIT=0   (40 tasks successful)
```

(`pnpm build --filter @vendoai/vendo...` first — `portability-gate.mjs` needs
`packages/vendo/dist/server.js`. 13 tasks successful.)

## Scope notes

- **No changeset.** `scripts/` is repo-internal tooling, not published; no package
  version changes.
- **No `vendo-web` counterpart.** Grepped `vendo-web` for `dependency-guard`, `LAYERS`,
  and the zod peer range — zero hits. It is a repo-internal lint script with no
  cross-repo seam.
- **No `packages/**` files touched.** The `agents` `zod` dependency removal belongs to
  #982; see the follow-up note above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the dependency guard to read compound and spaced `zod` semver ranges and migrates the client surface to `VendoProvider` with a full‑public‑URL join law. Also tightens several correctness and security edges and removes a stale agents allow‑list entry.

- **Bug Fixes**
  - `scripts/dependency-guard.mjs`: scans comparators as single tokens (operator + version), handles whitespace and `||` unions, computes the correct floor, skips ceilings, and still rejects wildcards/prereleases/hyphen ranges; also drops the dead `@vendoai/knowledge` allow-list entry in `@vendoai/agents`.
  - Knowledge: citations keep `source` across the main retrieval path; legacy chunks read through to the doc row for provenance.
  - Wire: `POST /sync/impact` is mounted only in development compositions; URL joins go through core `joinUrl` so a full `VENDO_BASE_URL` path prefix is attached exactly once and stored tool paths are prefix‑free.
  - Telemetry: the first‑run notice names `VENDO_TELEMETRY_DISABLED=1` as the opt‑out.

- **Migration**
  - Replace `VendoRoot` with `VendoProvider` and pass `baseUrl` (include your path prefix, e.g. `/api/vendo`) and `components`.
  - Set `VENDO_BASE_URL` to the app’s full public URL, path prefix included (e.g. `https://site.com/maple`). Tools now store prefix‑free paths; callers using `VendoProvider`/`joinUrl` need no other changes.

<sup>Written for commit d2bcd61a9dbdf5cfa9927f3f21a50e013c2f410f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

