### PR TITLE
fix(vendo): fifteen correctness bugs on the front door — two of them leak, one hangs, four answer wrong

### DIFF
--- a/.changeset/the-front-door-tells-the-truth.md
+++ b/.changeset/the-front-door-tells-the-truth.md
@@ -1,0 +1,36 @@
+---
+"@vendoai/vendo": patch
+---
+
+Fourteen correctness fixes on the umbrella — the package hosts actually install.
+
+Two of them touch what leaves a machine. Pinning `VENDO_DEV_CREDENTIAL=vendo-cloud`
+without a `VENDO_API_KEY` used to return the cloud rung anyway, and the gateway call
+was then made with `apiKey: undefined` — `@ai-sdk/anthropic` falls back to
+`process.env.ANTHROPIC_API_KEY`, so the host's own provider key was sent to
+console.vendo.run. The pin now degrades to `none`, which is what the docs already
+promised. And composing a Vendo minted a persistent, opted-in telemetry id into
+`~/.vendo/telemetry.json` on first boot, whether or not telemetry was ever enabled and
+whether or not anything could ever be uploaded; that identity is now read only when the
+Cloud slot is filled, and local-only capability misses carry no identity at all.
+
+The served-app proxy rebuilt its forwarded path from percent-decoded segments, so an
+encoded `/` or `?` in a URL turned into a real separator inside the box's request. A
+host pointing `profileDir` at its own `.vendo` directory silently lost theme, brief,
+catalog, knowledge and its pin baselines. `vendo sync` answered "no saved references"
+for tools that live generated app code calls, because it never read the compiler's
+`componentTools` manifest. A repeated tool name from the console took down the host's
+entire tool registry. The vendo verbs flattened their own written-for-the-model refusals
+("this app has no schedule to change — ask for the automation first") into "could not
+complete, try again".
+
+On the CLI: `vendo doctor` failed every Pages-Router host forever and told it to edit a
+file that does not exist — it and `vendo init` now share one answer for where the mount
+belongs. Doctor also hung for up to two minutes after printing its verdict when the dev
+server failed to spawn. Theme extraction let an `@import`ed stylesheet override the
+sheet that imported it, reporting the wrong brand colour as an exact read. The judge
+discarded its best-evidenced grades as "no evidence" when the quote ran long, and could
+not repair the commonest truncation of all. `vendo init` ran a package install on
+workspaces that already had the dependency hoisted, and pointed users at a docs path
+that only exists inside this repo. Auth0 tenants configured with a trailing slash could
+not log in at all.

--- a/docs-site/agents/verify.mdx
+++ b/docs-site/agents/verify.mdx
@@ -67,16 +67,18 @@ Do not mount the handler anywhere else; doctor checks these two paths only.
 
 ### E-WIRE-004 {#E-WIRE-004}
 
-**Symptom:** No app layout mounts `<VendoRoot>`.
+**Symptom:** No client entry mounts `<VendoRoot>`.
 
 **Cause:** No `layout.tsx` (or `.jsx`/`.js`) under `app/` or `src/app/` — root
-or nested — contains a `<VendoRoot` (or `<VendoProvider`) element.
+or nested — and no `pages/_app.tsx` (or `.jsx`/`.js`, under `src/` too)
+contains a `<VendoRoot` (or `<VendoProvider`) element.
 
 **Fix:** Run `npx vendo init` to generate the client mount wrapper
 `vendo/vendo-root.tsx` (its export is also named `VendoRoot`), then mount it
 yourself. Init never edits your source, so this paste is always yours — it is
-the last line of init's output. Wrap `{children}` in the layout that covers
-your pages:
+the last line of init's output. Doctor names the same file init named. Wrap
+`{children}` in the layout that covers your pages (or `<Component
+{...pageProps} />` in `pages/_app.tsx` on a Pages-Router host):
 
 ```tsx
 import { VendoRoot } from "../vendo/vendo-root";

--- a/packages/vendo/src/auth-presets/auth0.test.ts
+++ b/packages/vendo/src/auth-presets/auth0.test.ts
@@ -130,6 +130,25 @@ describe("auth0() tenant environment (Auth0's own conventions)", () => {
       .resolves.toEqual({ kind: "user", subject: "user_issuer_base" });
   });
 
+  it("tolerates a trailing slash on AUTH0_DOMAIN — copy-paste is how people set it", async () => {
+    // Auth0 issuers always carry exactly one trailing slash. A pasted
+    // `tenant.auth0.com/` produced `https://tenant.auth0.com//`, which matches
+    // no token's `iss` and points the JWKS fetch at the wrong path, so EVERY
+    // login fails with no hint about the extra character.
+    vi.stubEnv("AUTH0_DOMAIN", `${tenantDomain}/`);
+    const preset = auth0();
+    await expect(preset.principal(withBearer(await sessionToken("user_slash"))))
+      .resolves.toEqual({ kind: "user", subject: "user_slash" });
+    expect(jwksState.url).toBe(`https://${tenantDomain}/.well-known/jwks.json`);
+  });
+
+  it("names AUTH0_DOMAIN rather than throwing a URL parse error on an unusable value", async () => {
+    vi.stubEnv("AUTH0_DOMAIN", "https://");
+    const preset = auth0();
+    await expect(preset.principal(withBearer(await sessionToken("user_bad_domain"))))
+      .rejects.toThrow(/AUTH0_DOMAIN/);
+  });
+
   it("throws an actionable error naming AUTH0_DOMAIN when no tenant is configured", async () => {
     const preset = auth0();
     await expect(preset.principal(withBearer(await sessionToken("user_nodomain"))))

--- a/packages/vendo/src/auth-presets/auth0.ts
+++ b/packages/vendo/src/auth-presets/auth0.ts
@@ -41,18 +41,22 @@ const loadJose = lazyModule<JoseModule>(
 
 /** The tenant issuer per Auth0's env conventions: AUTH0_DOMAIN (the v4 SDK's
     bare domain, scheme tolerated), else AUTH0_ISSUER_BASE_URL (the v3 SDK's
-    full URL). Auth0 issuers always carry the trailing slash. */
+    full URL). Auth0 issuers always carry EXACTLY ONE trailing slash — a pasted
+    value with its own would otherwise produce `https://tenant.auth0.com//`,
+    which matches no token's `iss` and points the JWKS fetch at the wrong path,
+    so every login fails with nothing naming the extra character. */
 function tenantIssuer(): string {
-  const domain = environment("AUTH0_DOMAIN");
-  if (domain !== undefined) {
-    return domain.startsWith("http://") || domain.startsWith("https://")
-      ? `${new URL(domain).origin}/`
-      : `https://${domain}/`;
-  }
-  const base = environment("AUTH0_ISSUER_BASE_URL");
-  if (base !== undefined) {
+  for (const name of ["AUTH0_DOMAIN", "AUTH0_ISSUER_BASE_URL"] as const) {
+    const value = environment(name);
+    if (value === undefined) continue;
+    const withScheme = value.startsWith("http://") || value.startsWith("https://")
+      ? value
+      : `https://${value}`;
     try {
-      return `${new URL(base).origin}/`;
+      const { origin } = new URL(withScheme);
+      // `new URL("https://")` parses but has no host, so origin is "null".
+      if (origin === "null") throw new Error(MISSING_DOMAIN_MESSAGE);
+      return `${origin}/`;
     } catch {
       throw new Error(MISSING_DOMAIN_MESSAGE);
     }

--- a/packages/vendo/src/capability-misses.test.ts
+++ b/packages/vendo/src/capability-misses.test.ts
@@ -81,9 +81,14 @@ describe("capability-miss Cloud upload", () => {
 
     const capture = createCapabilityMissCapture({
       env: {},
+      // The Cloud slot is what makes the identity load-bearing: it is the id
+      // the console correlates uploads by. Without it nothing is uploaded and
+      // nothing is read from the user's home directory at all.
+      cloud: { apiKey: "vnd_test" },
       telemetryHome: home,
       surface: () => Promise.resolve(surface),
       append: async () => {},
+      fetchImpl: vi.fn(async () => Response.json({ accepted: 1, duplicates: 0 }, { status: 202 })),
     });
 
     expect(capture.hostId).toBe("telemetry-installation-id");

--- a/packages/vendo/src/capability-misses.test.ts
+++ b/packages/vendo/src/capability-misses.test.ts
@@ -89,6 +89,26 @@ describe("capability-miss Cloud upload", () => {
     expect(capture.hostId).toBe("telemetry-installation-id");
   });
 
+  it("mints NO installation id on the user's disk when there is no Cloud slot to upload through", async () => {
+    // This capture is composed on every createVendo boot, keyed or not. A
+    // keyless host uploads nothing ever, so it must not leave a persistent,
+    // opted-in tracking id in ~/.vendo/telemetry.json for a deployment that
+    // opted into nothing.
+    const home = await tempDir("vendo-miss-home-keyless-");
+    const capture = createCapabilityMissCapture({
+      env: {},
+      telemetryHome: home,
+      surface: () => Promise.resolve(surface),
+      append: async () => {},
+    });
+
+    capture.record(event("mis_keyless"));
+    await capture.flush();
+
+    await expect(readFile(join(home, ".vendo", "telemetry.json"), "utf8")).rejects.toThrow();
+    expect(capture.hostId.length).toBeGreaterThan(0);
+  });
+
   it("keeps local capture but sends nothing without a Cloud slot", async () => {
     const append = vi.fn(async () => {});
     const fetchImpl = vi.fn<typeof fetch>();

--- a/packages/vendo/src/capability-misses.ts
+++ b/packages/vendo/src/capability-misses.ts
@@ -14,6 +14,10 @@ const DEFAULT_QUEUE_LIMIT = 1_000;
 const DEFAULT_BATCH_DELAY_MS = 250;
 const DEFAULT_REQUEST_TIMEOUT_MS = 1_500;
 const DEFAULT_RETRY_DELAYS_MS = [250, 1_000] as const;
+/** The hostId stamped on misses that stay on this machine. `CapabilityMissEvent`
+ *  requires the field, but a local-only log correlates nothing across hosts, so
+ *  there is no identity to mint. */
+const LOCAL_ONLY_IDENTITY = { anonymousId: "local", optedOut: true } as const;
 
 export interface CapabilitySurfaceSnapshot {
   hash: string;
@@ -209,8 +213,16 @@ function createMissUploader(options: {
 
 export function createCapabilityMissCapture(options: CaptureOptions): CapabilityMissCapture {
   const env = options.env ?? runtimeEnv();
+  // Only the upload stream needs a STABLE installation identity, and it exists
+  // only when the host filled the Cloud slot and no kill switch is tripped.
+  // `loadConfig` MINTS AND PERSISTS an opted-in id into ~/.vendo/telemetry.json,
+  // and this capture is composed on every createVendo boot — so reaching it
+  // unconditionally leaves a tracking id on the disk of every host that never
+  // enabled telemetry and can never upload. Local-only capture writes to the
+  // project's own .vendo/data, where a cross-boot identity means nothing.
+  const uploads = options.cloud !== undefined && !envOptOut(env);
   const telemetryConfig = options.telemetryConfig
-    ?? loadConfig(options.telemetryHome, env);
+    ?? (uploads ? loadConfig(options.telemetryHome, env) : LOCAL_ONLY_IDENTITY);
   let uploader: MissUploader | undefined;
   if (options.cloud !== undefined) {
     // Contract (01-core §17): upload is gated by the key plus envOptOut only.

--- a/packages/vendo/src/cli/cloud/host-components.test.ts
+++ b/packages/vendo/src/cli/cloud/host-components.test.ts
@@ -122,6 +122,35 @@ describe("host component push", () => {
     expect(first.error).toBeUndefined();
   });
 
+  it("counts BYTES uploaded, not UTF-16 code units — sync prints the number as KB", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vendo-push-utf8-"));
+    roots.push(root);
+    const dir = join(root, ".vendo/components");
+    await mkdir(join(dir, "modules"), { recursive: true });
+    const entry = hex("utf8-entry");
+    const body = JSON.stringify({ source: "const label = \"café — €10 ✅\";" });
+    await writeFile(join(dir, "modules", `${entry}.json`), body, "utf8");
+    await writeFile(join(dir, "Widget.json"), JSON.stringify({
+      name: "Widget",
+      hash: `sha256:${hex("Widget")}`,
+      capturedAt: "2026-08-02T00:00:00.000Z",
+      module: "src/vendo/registry.tsx",
+      export: "Widget",
+      entry,
+      modules: {},
+    }), "utf8");
+
+    const result = await pushHostComponents({
+      vendoDir: join(root, ".vendo"),
+      apiKey: "vendo_key",
+      baseUrl: "https://cloud.test",
+      fetchImpl: fakeCloud().fetchImpl,
+    });
+
+    expect(result.uploadedBytes).toBe(new TextEncoder().encode(body).length);
+    expect(result.uploadedBytes).toBeGreaterThan(body.length);
+  });
+
   it("a second sync compares hashes over a keys-only manifest and uploads nothing", async () => {
     const root = await corpus();
     const cloud = fakeCloud({

--- a/packages/vendo/src/cli/cloud/host-components.ts
+++ b/packages/vendo/src/cli/cloud/host-components.ts
@@ -193,9 +193,13 @@ export async function pushHostComponents(options: {
     const remoteModules = new Set(await blobs.list());
     for (const [ref, body] of [...local.modules].sort(([left], [right]) => left.localeCompare(right))) {
       if (remoteModules.has(ref)) continue;
-      await blobs.put(ref, new TextEncoder().encode(body), { contentType: "application/json" });
+      // The encoded array is what actually crosses the wire, and sync reports
+      // this total to the user as KB — `body.length` counts UTF-16 code units,
+      // which undercounts every non-ASCII byte in the source.
+      const encoded = new TextEncoder().encode(body);
+      await blobs.put(ref, encoded, { contentType: "application/json" });
       modules.uploaded += 1;
-      uploadedBytes += body.length;
+      uploadedBytes += encoded.length;
     }
 
     const remote = new Map<string, unknown>();

--- a/packages/vendo/src/cli/dep-versions.ts
+++ b/packages/vendo/src/cli/dep-versions.ts
@@ -76,7 +76,7 @@ export async function installedZodVersion(root: string): Promise<string | null> 
  * read rather than require.resolve, deliberately: exports maps may hide
  * ./package.json, and in-process resolver patches (test runners, loaders)
  * must not change what we report about the host's tree. */
-async function installedVersion(root: string, name: string): Promise<string | null> {
+export async function installedVersion(root: string, name: string): Promise<string | null> {
   for (let dir = resolve(root); ; dir = dirname(dir)) {
     try {
       return versionOf(await readFile(join(dir, "node_modules", ...name.split("/"), "package.json"), "utf8"));

--- a/packages/vendo/src/cli/doctor-live.test.ts
+++ b/packages/vendo/src/cli/doctor-live.test.ts
@@ -137,4 +137,29 @@ describe("startDevServerForProbe", () => {
     expect(started.ok).toBe(false);
     expect(started.log.join("")).toContain("spawn yarn ENOENT");
   });
+
+  it("stops polling as soon as the spawn fails, so doctor exits with its verdict", async () => {
+    // The status poll is the only thing left holding node's event loop after
+    // doctor prints — bin/vendo.mjs sets process.exitCode and never calls
+    // process.exit(). A poll that outlives the spawn failure hangs the CLI for
+    // the whole timeout.
+    const child = new EventEmitter() as unknown as ChildProcess & EventEmitter;
+    (child as unknown as { kill: () => void }).kill = vi.fn();
+    const fetchImpl = vi.fn(async () => { throw new Error("connection refused"); });
+    const started = await startDevServerForProbe({
+      root: "/nonexistent/vendo-doctor-spawn-test",
+      statusUrl: "http://localhost:3000/api/vendo",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      timeoutMs: 60_000,
+      spawnDev: () => {
+        setImmediate(() => child.emit("error", new Error("spawn yarn ENOENT")));
+        return child;
+      },
+    });
+    expect(started.ok).toBe(false);
+
+    const pollsAtReturn = fetchImpl.mock.calls.length;
+    await new Promise((resolve) => setTimeout(resolve, 1_700)); // two poll intervals
+    expect(fetchImpl.mock.calls.length).toBe(pollsAtReturn);
+  });
 });

--- a/packages/vendo/src/cli/doctor-live.ts
+++ b/packages/vendo/src/cli/doctor-live.ts
@@ -219,16 +219,28 @@ function defaultSpawnDev(packageManager: string, root: string): ChildProcess {
   return spawn(packageManager, ["run", "dev"], { cwd: root, stdio: ["ignore", "pipe", "pipe"] });
 }
 
-async function waitForStatus(statusUrl: string, fetchImpl: typeof fetch, timeoutMs: number): Promise<boolean> {
+/** `abandon` settles when the caller no longer wants an answer (the spawn
+    failed). Without it the loop outlives the race it lost and its ref'd poll
+    timer keeps node alive for the whole timeout — the CLI prints its verdict
+    and then sits there, because bin/vendo.mjs only sets `process.exitCode`. */
+async function waitForStatus(
+  statusUrl: string,
+  fetchImpl: typeof fetch,
+  timeoutMs: number,
+  abandon: Promise<unknown>,
+): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
+  let abandoned = false;
+  void abandon.then(() => { abandoned = true; });
+  while (!abandoned && Date.now() < deadline) {
     try {
       const response = await fetchImpl(`${statusUrl}/status`);
       if (response.ok) return true;
     } catch {
       // not up yet
     }
-    await new Promise((resolve) => setTimeout(resolve, 750));
+    if (abandoned) break;
+    await Promise.race([new Promise((resolve) => setTimeout(resolve, 750)), abandon]);
   }
   return false;
 }
@@ -267,7 +279,7 @@ export async function startDevServerForProbe(options: StartDevServerOptions): Pr
     child.unref?.(); // injected test doubles may not implement it
   };
   const up = await Promise.race([
-    waitForStatus(options.statusUrl, fetchImpl, options.timeoutMs ?? 120_000),
+    waitForStatus(options.statusUrl, fetchImpl, options.timeoutMs ?? 120_000, spawnFailed),
     spawnFailed,
   ]);
   if (!up) stop();

--- a/packages/vendo/src/cli/doctor.test.ts
+++ b/packages/vendo/src/cli/doctor.test.ts
@@ -1491,6 +1491,42 @@ describe("vendo doctor error codes + fix_refs", () => {
     })).toBe(0);
   });
 
+  // A pages-only Next host is a shape init explicitly supports: clientRoot()
+  // hands the user `pages/_app.tsx` to paste into, because there is no app
+  // layout to wrap. Doctor scanning app/ layouts only fails such a host
+  // forever, and names a file init never mentioned and that does not exist.
+  it("finds the <VendoRoot> mount in a Pages-Router host's pages/_app.tsx", async () => {
+    const root = await healthy();
+    await rm(join(root, "app", "layout.tsx"));
+    await mkdir(join(root, "pages"), { recursive: true });
+    await writeFile(join(root, "pages", "_app.tsx"),
+      "export default ({Component, pageProps}) => <VendoRoot><Component {...pageProps} /></VendoRoot>;");
+    expect(await doctor({
+      targetDir: root,
+      fetchImpl: successfulProbeFetch(),
+      output: output().sink,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    })).toBe(0);
+  });
+
+  it("names pages/_app.tsx, not app/layout.tsx, when a Pages-Router host has no mount", async () => {
+    const root = await healthy();
+    await rm(join(root, "app", "layout.tsx"));
+    await mkdir(join(root, "pages"), { recursive: true });
+    await writeFile(join(root, "pages", "_app.tsx"),
+      "export default ({Component, pageProps}) => <Component {...pageProps} />;");
+    const messages = output();
+    expect(await doctor({
+      targetDir: root,
+      fetchImpl: successfulProbeFetch(),
+      output: messages.sink,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    })).toBe(1);
+    const wire004 = messages.errors.join("\n");
+    expect(wire004).toContain(join("pages", "_app.tsx"));
+    expect(wire004).not.toContain(join("app", "layout.tsx"));
+  });
+
   // Render gate (0.4.1 E2E cert M3): the certified invoify install had every
   // page 500ing while doctor exited 0 — a live wire proves nothing about the
   // pages users load.

--- a/packages/vendo/src/cli/doctor.test.ts
+++ b/packages/vendo/src/cli/doctor.test.ts
@@ -1500,7 +1500,7 @@ describe("vendo doctor error codes + fix_refs", () => {
     await rm(join(root, "app", "layout.tsx"));
     await mkdir(join(root, "pages"), { recursive: true });
     await writeFile(join(root, "pages", "_app.tsx"),
-      "export default ({Component, pageProps}) => <VendoRoot><Component {...pageProps} /></VendoRoot>;");
+      "export default ({Component, pageProps}) => <VendoRoot><Component {...pageProps} /><VendoOverlay /></VendoRoot>;");
     expect(await doctor({
       targetDir: root,
       fetchImpl: successfulProbeFetch(),

--- a/packages/vendo/src/cli/doctor.ts
+++ b/packages/vendo/src/cli/doctor.ts
@@ -27,7 +27,7 @@ import { importsGeneratedMap, missingRegistrations, registrationKey, requiredSer
 import { CONFIG_SURFACES, OVERRIDES_ENABLEMENT_NOTE } from "../config-surface.js";
 import { walk } from "./theme/walk.js";
 import { remoteUrls, sameUrl, validateRegistryServer } from "./mcp/registry.js";
-import { askYesNo, CLI_VERSION, consoleOutput, exists, normalizeDotEnvValue, readOptional, toolingTelemetry, type Output } from "./shared.js";
+import { askYesNo, clientRoot, CLI_VERSION, consoleOutput, exists, normalizeDotEnvValue, readOptional, toolingTelemetry, type Output } from "./shared.js";
 
 export interface DoctorOptions {
   targetDir: string;
@@ -270,29 +270,33 @@ export async function runDoctor(options: DoctorOptions): Promise<number> {
     // correct scaffold mounts the generated vendo/vendo-root.tsx wrapper —
     // whose export is also named VendoRoot, so the marker holds there too.
     let rootWired = false;
-    for (const appDir of [join(root, "app"), join(root, "src", "app")]) {
-      for (const path of await walk(appDir, (rel) => /(^|[\\/])layout\.(?:tsx|jsx|js)$/.test(rel))) {
-        const source = await readFile(path, "utf8").catch(() => "");
-        if (source.includes("<VendoRoot") || source.includes("<VendoProvider")) rootWired = true;
-      }
+    const mountCandidates = [
+      ...await walk(join(root, "app"), (rel) => /(^|[\\/])layout\.(?:tsx|jsx|js)$/.test(rel)),
+      ...await walk(join(root, "src", "app"), (rel) => /(^|[\\/])layout\.(?:tsx|jsx|js)$/.test(rel)),
+      // A pages-only host has no layout to wrap: init hands it pages/_app, so
+      // that is where the mount lives. Without this the check can never pass on
+      // a router shape init explicitly supports.
+      ...["pages", join("src", "pages")].flatMap((pages) =>
+        ["_app.tsx", "_app.jsx", "_app.js"].map((file) => join(root, pages, file))),
+    ];
+    for (const path of mountCandidates) {
+      const source = await readFile(path, "utf8").catch(() => "");
+      if (source.includes("<VendoRoot") || source.includes("<VendoProvider")) rootWired = true;
     }
     if (rootWired) {
       pass("wiring/next-root", "<VendoRoot> wraps the app");
     } else {
       // The exact paste, not a description of it: init never edits user source,
       // so this is the one step a by-the-book install still owes, and doctor is
-      // where a missed paste surfaces. Name the file that exists.
-      const layoutPath = (await Promise.all(
-        [join(root, "app", "layout.tsx"), join(root, "src", "app", "layout.tsx")].map(
-          async (candidate) => (await exists(candidate)) ? candidate : null,
-        ),
-      )).find((candidate) => candidate !== null) ?? join(root, "app", "layout.tsx");
+      // where a missed paste surfaces. `clientRoot` is init's own answer to
+      // "which file", so the two can never name different files again.
+      const { file: layoutPath, children } = await clientRoot(root);
       const file = relative(root, layoutPath);
       const specifier = relative(dirname(layoutPath), join(dirname(dirname(layoutPath)), "vendo", "vendo-root"))
         .split(sep).join("/");
       fail("wiring/next-root", "E-WIRE-004",
-        `no app layout mounts <VendoRoot> — Vendo is wired but invisible. In ${file}, paste: `
-        + `import { VendoRoot } from "${specifier}";  … then wrap: <VendoRoot>{children}</VendoRoot>. `
+        `no client entry mounts <VendoRoot> — Vendo is wired but invisible. In ${file}, paste: `
+        + `import { VendoRoot } from "${specifier}";  … then wrap: <VendoRoot>${children}</VendoRoot>. `
         + "(The generated vendo/vendo-root.tsx wrapper's export is also named VendoRoot and mounts <VendoOverlay />; "
         + "any layout that covers your pages works. `vendo init` never edits your source, so this paste is always yours.)");
     }

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -41,7 +41,9 @@ import {
 } from "./theme/extract-theme.js";
 import { baseFrom, writeBase } from "./theme/provenance.js";
 import {
+  appDirectory,
   askYesNo,
+  clientRoot,
   cloudProjectProps,
   consoleOutput,
   envLocalValueSync,
@@ -282,21 +284,6 @@ async function defaultThemeReview(summary: ThemeSummary): Promise<Record<string,
   return overrides;
 }
 
-/** Where init scaffolds app/api/vendo/[...vendo] and (for a fresh scaffold)
-    the app-router layout wrap. Next hard-fails ("pages and app directories
-    should be under the same folder") when app/ and pages/ sit at different
-    bases, so a host whose pages router already lives under src/ must get its
-    NEW app/ segment there too, mirroring detectRouter's src/pages signal
-    below — even before any src/app exists to detect directly. This still
-    hands a pure-Pages host an App-Router route segment by design (valid in
-    Next as long as both share one base); whether pages-native hosts deserve
-    a pages/api scaffold instead is a separate, unaddressed question. */
-async function appDirectory(root: string): Promise<string> {
-  if (await exists(join(root, "src", "app"))) return join(root, "src", "app");
-  if (await exists(join(root, "src", "pages"))) return join(root, "src", "app");
-  return join(root, "app");
-}
-
 /** Telemetry `router` enum (init_completed): app | pages | none, from the
     same directory evidence appDirectory rides. Express hosts are "none". */
 async function detectRouter(root: string, framework: Exclude<HostFramework, "unknown"> | "custom"): Promise<"app" | "pages" | "none"> {
@@ -321,22 +308,6 @@ function pastePath(target: string): string {
   return /^[\w./@+-]+$/.test(path) ? path : `'${path.replace(/'/g, "'\\''")}'`;
 }
 
-/** The file whose client root the <VendoRoot> paste belongs in, and the child
-    expression it wraps there. A pages-only host has NO app/layout.tsx to wrap
-    — its client root is pages/_app.tsx, and the generated vendo-root.tsx is a
-    client component that mounts there unchanged. (Where the API route segment
-    gets scaffolded is a separate, deliberate choice — see appDirectory.)
-    Keyed on the layout FILE, not on detectRouter: the scaffold creates app/
-    mid-run, and the answer must be the same before and after it. */
-async function clientRoot(root: string): Promise<{ file: string; children: string }> {
-  const layout = join(await appDirectory(root), "layout.tsx");
-  if (!(await exists(layout))) {
-    for (const pages of [join(root, "src", "pages"), join(root, "pages")]) {
-      if (await exists(pages)) return { file: join(pages, "_app.tsx"), children: "<Component {...pageProps} />" };
-    }
-  }
-  return { file: layout, children: "{children}" };
-}
 
 /** Relative, posix-style import specifier from the layout's directory to the
     project-root `.vendo/theme.json` — printed for the user's paste, never

--- a/packages/vendo/src/cli/judge/parse.test.ts
+++ b/packages/vendo/src/cli/judge/parse.test.ts
@@ -54,6 +54,15 @@ describe("repairJson — the two malformations real judge batches produce", () =
     expect(JSON.parse(repairJson(`{"a": [{"b": 1`)!)).toEqual({ a: [{ b: 1 }] });
   });
 
+  it("drops a trailing comma sitting AT eof before closing — a batch cut after a complete grade", () => {
+    // The commonest truncation of all: the model finished one grade, wrote the
+    // separator, and the output stopped. The trailing-comma rule only fires when
+    // a closer already follows, so the comma survived and the auto-closers were
+    // appended after it — losing every recoverable grade in the batch.
+    expect(JSON.parse(repairJson(`{"tools":[{"name":"a"},`)!)).toEqual({ tools: [{ name: "a" }] });
+    expect(JSON.parse(repairJson(`{"tools":[{"name":"a"},  \n`)!)).toEqual({ tools: [{ name: "a" }] });
+  });
+
   it("NEVER touches commas or braces inside a string literal", () => {
     const raw = `{"evidence": "const x = {a: 1,}; // trailing , here ]"}`;
     expect(JSON.parse(repairJson(raw)!)).toEqual({

--- a/packages/vendo/src/cli/judge/parse.ts
+++ b/packages/vendo/src/cli/judge/parse.ts
@@ -106,7 +106,10 @@ export function repairJson(raw: string): string | null {
       let ahead = index + 1;
       while (ahead < raw.length && /\s/.test(raw[ahead]!)) ahead += 1;
       const next = raw[ahead];
-      if (next === "}" || next === "]") continue;
+      // `undefined` means end of input, where the auto-closers below are about
+      // to supply the closer — so this comma is redundant there too. It is the
+      // commonest truncation of all: a batch cut right after a complete grade.
+      if (next === undefined || next === "}" || next === "]") continue;
       out.push(char);
       continue;
     }

--- a/packages/vendo/src/cli/judge/pass.test.ts
+++ b/packages/vendo/src/cli/judge/pass.test.ts
@@ -767,6 +767,28 @@ describe("runJudgmentPass — advisories can never discard proposals", () => {
     expect(fields.title!.length).toBeLessThanOrEqual(60);
   });
 
+  it("an over-long `evidence` quote clamps too — it is evidence, not the absence of it", async () => {
+    // The most thorough possible answer (a long quoted handler body) failed the
+    // 500-char bound, and every issue on the evidence path is bucketed as
+    // "evidence-less" — so the operator was told the model supplied no evidence
+    // and the whole grade was silently dropped.
+    const fixture = await twoToolHost();
+    const bus = channel();
+    const result = await runJudgmentPass(options(fixture, bus, {
+      harness: scripted([
+        reply({
+          tools: [{ ...twoGoodProposals[0]!, evidence: `await db.update(accounts)${"x".repeat(600)}` }],
+          narrative: "",
+        }),
+        reply({ verdicts: [{ name: twoGoodProposals[0]!.name, field: "risk", verdict: "uphold" }] }),
+      ]),
+    }));
+
+    expect(result).toMatchObject({ status: "judged", evidenceless: 0 });
+    const file = await readJudgments(fixture);
+    expect(file.tools.host_transferMoney!.fields.risk).toBe("destructive");
+  });
+
   it("a capability field with a BOGUS value is still rejected — clamping is prose-only", async () => {
     const fixture = await twoToolHost();
     const bus = channel();

--- a/packages/vendo/src/cli/judge/pass.ts
+++ b/packages/vendo/src/cli/judge/pass.ts
@@ -118,6 +118,11 @@ const PROSE_LIMITS: ReadonlyArray<readonly [string, number]> = [
   ["description", 500],
   ["title", 60],
   ["reason", ADVISORY_LIMIT],
+  // A quote that ran long is still evidence. Unclamped, the schema rejects it
+  // with an issue on the `evidence` path, and every issue on that path is
+  // counted as evidence-LESS — so the most thorough answer the model can give
+  // is reported to the operator as "no evidence" and the grade is discarded.
+  ["evidence", 500],
 ];
 
 /** Cut to `limit`, marking the cut so a reader can tell clamped text from text

--- a/packages/vendo/src/cli/provider-deps.test.ts
+++ b/packages/vendo/src/cli/provider-deps.test.ts
@@ -299,6 +299,35 @@ describe("ensureZodFloor", () => {
   });
 });
 
+describe("ensureProviderDeps in a hoisted workspace", () => {
+  it("sees the hoisted ai + provider and installs nothing", async () => {
+    // The app resolves both through the workspace root's node_modules, exactly
+    // as `ai` does at runtime. A root-only stat calls them missing and makes
+    // `vendo init` shell a real install that rewrites the app's package.json.
+    const workspace = await tempRoot();
+    await writeFile(join(workspace, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n");
+    await writeFile(join(workspace, "pnpm-lock.yaml"), "");
+    await installModule(workspace, "ai");
+    await installModule(workspace, "@ai-sdk/anthropic");
+    const app = join(workspace, "apps", "web");
+    await mkdir(app, { recursive: true });
+    await writeFile(join(app, "package.json"), JSON.stringify({ name: "web" }));
+
+    const calls: unknown[] = [];
+    await ensureProviderDeps({
+      root: app,
+      credential: { rung: "vendo-cloud" },
+      output: output().sink,
+      run: async (...call) => {
+        calls.push(call);
+        return 0;
+      },
+    });
+
+    expect(calls).toEqual([]);
+  });
+});
+
 describe("ensureZodFloor in a hoisted workspace (checker round 1)", () => {
   /** pnpm workspace root hoisting zod@3.23.8, app nested with no
       node_modules or lockfile of its own — where most real hosts live. */

--- a/packages/vendo/src/cli/provider-deps.ts
+++ b/packages/vendo/src/cli/provider-deps.ts
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
 import type { DevCredential, EnvKeyProvider } from "../dev-creds/resolve.js";
-import { installedZodVersion } from "./dep-versions.js";
+import { installedVersion, installedZodVersion } from "./dep-versions.js";
 import type { Output } from "./shared.js";
 
 /**
@@ -32,14 +32,12 @@ export function providerModuleFor(credential: DevCredential): { module: string; 
 
 /** Resolvability is what the runtime ladder checks, so node_modules is the
     evidence — not package.json (a hoisting monorepo satisfies the import
-    without a local entry). */
+    without a local entry). `installedVersion` walks the node_modules chain
+    upward the way node resolves a bare specifier, so a hoisted workspace
+    install is seen where `ai` sees it; a fixed root path called it missing and
+    made init shell a package install the tree already satisfied. */
 async function isInstalled(root: string, moduleName: string): Promise<boolean> {
-  try {
-    await readFile(join(root, "node_modules", ...moduleName.split("/"), "package.json"), "utf8");
-    return true;
-  } catch {
-    return false;
-  }
+  return (await installedVersion(root, moduleName)) !== null;
 }
 
 async function fileExists(root: string, name: string): Promise<boolean> {

--- a/packages/vendo/src/cli/shared.ts
+++ b/packages/vendo/src/cli/shared.ts
@@ -238,3 +238,39 @@ export async function detectPackageManager(root: string): Promise<"pnpm" | "yarn
   if (await exists(join(root, "bun.lockb")) || await exists(join(root, "bun.lock"))) return "bun";
   return "npm";
 }
+
+/** Where init scaffolds app/api/vendo/[...vendo] and (for a fresh scaffold)
+    the app-router layout wrap. Next hard-fails ("pages and app directories
+    should be under the same folder") when app/ and pages/ sit at different
+    bases, so a host whose pages router already lives under src/ must get its
+    NEW app/ segment there too, mirroring detectRouter's src/pages signal —
+    even before any src/app exists to detect directly. This still hands a
+    pure-Pages host an App-Router route segment by design (valid in Next as
+    long as both share one base); whether pages-native hosts deserve a
+    pages/api scaffold instead is a separate, unaddressed question. */
+export async function appDirectory(root: string): Promise<string> {
+  if (await exists(join(root, "src", "app"))) return join(root, "src", "app");
+  if (await exists(join(root, "src", "pages"))) return join(root, "src", "app");
+  return join(root, "app");
+}
+
+/** The file whose client root the <VendoRoot> paste belongs in, and the child
+    expression it wraps there. A pages-only host has NO app/layout.tsx to wrap
+    — its client root is pages/_app.tsx, and the generated vendo-root.tsx is a
+    client component that mounts there unchanged. (Where the API route segment
+    gets scaffolded is a separate, deliberate choice — see appDirectory.)
+    Keyed on the layout FILE, not on a router probe: the scaffold creates app/
+    mid-run, and the answer must be the same before and after it.
+
+    Shared with doctor on purpose: init tells the user which file to paste into
+    and doctor grades whether they did. Two copies of this rule meant doctor
+    failed every pages-only host forever, naming a file init never mentioned. */
+export async function clientRoot(root: string): Promise<{ file: string; children: string }> {
+  const layout = join(await appDirectory(root), "layout.tsx");
+  if (!(await exists(layout))) {
+    for (const pages of [join(root, "src", "pages"), join(root, "pages")]) {
+      if (await exists(pages)) return { file: join(pages, "_app.tsx"), children: "<Component {...pageProps} />" };
+    }
+  }
+  return { file: layout, children: "{children}" };
+}

--- a/packages/vendo/src/cli/theme/extract-theme.test.ts
+++ b/packages/vendo/src/cli/theme/extract-theme.test.ts
@@ -122,6 +122,24 @@ describe("extractTheme allowlist fast-path", () => {
     expect(result.usedModel).toBe(false);
   });
 
+  it("lets the IMPORTING sheet win over the sheet it imports, like the real cascade", async () => {
+    // `@import` must precede other rules, so an imported declaration behaves as
+    // if inserted at the import point — the importer's own later declaration
+    // wins at equal specificity. Reading the imported file last inverts that and
+    // reports the wrong brand colour as an EXACT read, which is the one outcome
+    // the exact-then-staged design exists to prevent.
+    const root = await fixture({
+      "package.json": "{}\n",
+      "app/layout.tsx": 'import "./global.css";\nexport default function Layout({ children }) { return <html><body>{children}</body></html>; }\n',
+      "app/global.css": '@import "./tokens.css";\n:root { --primary: #ff6600; }\n',
+      "app/tokens.css": ":root { --primary: #000000; }\n",
+    });
+
+    const result = await extractTheme(root);
+
+    expect(result.slots.accent).toBe("#ff6600");
+  });
+
   it("derives accentText without any model involvement when every other core token is exact", async () => {
     const root = await fixture({
       "package.json": "{}\n",

--- a/packages/vendo/src/cli/theme/extract-theme.ts
+++ b/packages/vendo/src/cli/theme/extract-theme.ts
@@ -140,7 +140,10 @@ async function collectCss(layout: ContextFile | null, targetDir: string): Promis
     seen.add(absolute);
     const content = await readCapped(absolute);
     if (content === null) return;
-    files.push({ path: path.relative(targetDir, absolute), content });
+    // Imported sheets go in FIRST, this one after them: `@import` must precede
+    // every other rule, so an imported declaration behaves as if inserted at the
+    // import point. At equal specificity the importing sheet's own declaration
+    // wins, and the readers below take the LAST match in this array.
     for (const match of content.matchAll(CSS_AT_IMPORT_RE)) {
       const spec = match[1]!;
       if (spec === "tailwindcss" || spec.startsWith("http")) continue;
@@ -152,6 +155,7 @@ async function collectCss(layout: ContextFile | null, targetDir: string): Promis
         await visit(path.join(targetDir, spec.slice(2)), depth + 1);
       }
     }
+    files.push({ path: path.relative(targetDir, absolute), content });
   };
 
   if (layout !== null) {

--- a/packages/vendo/src/cloud-tools.test.ts
+++ b/packages/vendo/src/cloud-tools.test.ts
@@ -53,6 +53,28 @@ describe("cloudTools", () => {
     expect(stub.requests[0]!.url).toBe("https://cloud.test/api/v1/tools?toolkits=gmail%2Cslack");
   });
 
+  it("skips a duplicate tool name instead of failing the whole registry load", async () => {
+    // A thrown descriptors() takes the ENTIRE registry down, host tools
+    // included, and this connector is auto-composed from a bare VENDO_API_KEY.
+    // One repeated slug from the console must not delete the host's own tools.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const stub = consoleStub(() => ({ body: { tools: [GMAIL_TOOL, GMAIL_TOOL] } }));
+      const connector = cloudTools({ apiKey: "vnd_key", baseUrl: "https://cloud.test", apps: ["gmail"], fetch: stub.fetchImpl });
+      const descriptors = await connector.descriptors();
+      expect(descriptors.map((descriptor) => descriptor.name)).toEqual(["gmail_GMAIL_SEND_EMAIL"]);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("dedupes repeated toolkits so the broker is not asked for the same list twice", async () => {
+    const stub = consoleStub(() => ({ body: { tools: [] } }));
+    const connector = cloudTools({ apiKey: "vnd_key", baseUrl: "https://cloud.test", apps: ["gmail", "gmail"], fetch: stub.fetchImpl });
+    await connector.descriptors();
+    expect(stub.requests[0]!.url).toBe("https://cloud.test/api/v1/tools?toolkits=gmail");
+  });
+
   it("degrades to zero tools (never throws) when the broker is missing or unconfigured", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {

--- a/packages/vendo/src/cloud-tools.ts
+++ b/packages/vendo/src/cloud-tools.ts
@@ -122,13 +122,18 @@ export function cloudTools(options: CloudToolsOptions): Connector {
       // The auto-composed cloud default must never brick the host: a thrown
       // descriptors() fails the ENTIRE registry load, host tools included.
       // The fetch below degrades to "no connector tools" with one warn.
-      const items = await fetchToolkitTools(options.apps.join(","));
+      const items = await fetchToolkitTools([...new Set(options.apps)].join(","));
       const nextNormalizedToRaw = new Map<string, { raw: string; toolkit: string }>();
       const descriptors: ToolDescriptor[] = [];
       for (const item of items) {
         if (typeof item.slug !== "string" || typeof item.toolkit !== "string") continue;
         const name = normalizeToolName(item.toolkit, item.slug);
-        if (nextNormalizedToRaw.has(name)) throw new Error(`Cloud tools name collision: ${name}`);
+        // Degrade, do not throw: the console repeating a slug must not delete
+        // the host's own tools. First one wins so the list stays stable.
+        if (nextNormalizedToRaw.has(name)) {
+          console.warn(`[vendo] Cloud tools: skipping duplicate tool name ${name}`);
+          continue;
+        }
         nextNormalizedToRaw.set(name, { raw: item.slug, toolkit: item.toolkit });
         const tags = Array.isArray(item.tags)
           ? (item.tags as unknown[]).filter((tag): tag is string => typeof tag === "string")

--- a/packages/vendo/src/compound.e2e.test.ts
+++ b/packages/vendo/src/compound.e2e.test.ts
@@ -26,10 +26,9 @@ import type { LanguageModel } from "ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createVendo } from "./server.js";
 
-// 04-actions §6 guard-visibility e2e: compound steps route through the REAL
-// guard binding, so approvals, grants, breakers, and audit demonstrably see
-// every individual step. The stub-seam adversarial suite lives in
-// packages/actions/src/security/compound-no-bypass.test.ts.
+// Guard-visibility e2e: compound steps route through the REAL guard binding,
+// so approvals, grants, breakers, and audit demonstrably see every individual
+// step.
 
 const principal: Principal = { kind: "user", subject: "user_compound" };
 const ctx: RunContext = {

--- a/packages/vendo/src/dev-creds/resolve.test.ts
+++ b/packages/vendo/src/dev-creds/resolve.test.ts
@@ -27,10 +27,18 @@ describe("resolveDevCredential (real keys only)", () => {
       .toEqual({ rung: "none" });
   });
 
-  it("VENDO_DEV_CREDENTIAL pins a rung; a pinned env-key without its key degrades to none", async () => {
+  it("VENDO_DEV_CREDENTIAL pins a rung; a pin whose key is missing degrades to none", async () => {
+    expect(await resolveDevCredential({
+      env: { VENDO_DEV_CREDENTIAL: "vendo-cloud", VENDO_API_KEY: "vnd_x", ANTHROPIC_API_KEY: "sk-1" },
+    })).toEqual({ rung: "vendo-cloud" });
+
+    // Without VENDO_API_KEY the cloud rung cannot resolve. It must degrade like
+    // the env-key pin below, not hand the Cloud gateway an undefined apiKey —
+    // @ai-sdk/anthropic then falls back to process.env.ANTHROPIC_API_KEY and
+    // sends the host's own provider key to a third-party origin.
     expect(await resolveDevCredential({
       env: { VENDO_DEV_CREDENTIAL: "vendo-cloud", ANTHROPIC_API_KEY: "sk-1" },
-    })).toEqual({ rung: "vendo-cloud" });
+    })).toEqual({ rung: "none" });
 
     expect(await resolveDevCredential({
       env: { VENDO_DEV_CREDENTIAL: "env-key:openai", OPENAI_API_KEY: "sk-2", ANTHROPIC_API_KEY: "sk-1" },

--- a/packages/vendo/src/dev-creds/resolve.ts
+++ b/packages/vendo/src/dev-creds/resolve.ts
@@ -44,7 +44,15 @@ export async function resolveDevCredential(
 
   const pinned = env["VENDO_DEV_CREDENTIAL"]?.trim();
   if (pinned !== undefined && pinned.length > 0) {
-    if (pinned === "vendo-cloud" || pinned === "none") return { rung: pinned };
+    if (pinned === "none") return { rung: "none" };
+    // A pin that cannot resolve degrades, exactly like the env-key pin below:
+    // without VENDO_API_KEY the cloud branch would call the Cloud gateway with
+    // `apiKey: undefined`, and @ai-sdk/anthropic then falls back to
+    // process.env.ANTHROPIC_API_KEY — sending the host's own provider key to a
+    // third-party origin.
+    if (pinned === "vendo-cloud") {
+      return present(env, "VENDO_API_KEY") ? { rung: "vendo-cloud" } : { rung: "none" };
+    }
     const match = /^env-key:(anthropic|openai|google)$/.exec(pinned);
     if (match !== null) {
       const provider = match[1] as EnvKeyProvider;

--- a/packages/vendo/src/screen-floor-door.e2e.test.ts
+++ b/packages/vendo/src/screen-floor-door.e2e.test.ts
@@ -224,10 +224,18 @@ describe("the assembly loop always hears the floor's verdict on what it saved", 
     // …and this is why the hand cannot lean on the door the brief used to name.
     // The loop's own `validate({appId})` — step 2, the id straight off its brief —
     // is row-scoped, and a save that never painted leaves no row, so it refused to
-    // judge the one document that needed it. Both live lines, in one run.
+    // judge the one document that needed it.
+    //
+    // The seam's half stays the operator's: no row is our defect to chase, and the
+    // loop can do nothing with it.
     const logged = operatorLog(refusals.mock.calls);
     expect(logged).toContain("has no row to hold its source");
-    expect(logged).toContain("app not found");
+    // The refusal's half is the LOOP's, and it now arrives where the loop can read
+    // it — the prompt after the `validate` call. It used to be flattened to
+    // "could not complete. Try again", which sent the loop back through a call that
+    // can never succeed while the real sentence went only to a log nobody was
+    // reading. Same refusal, same run; the door it comes through is the fix.
+    expect(walked.prompts[2] ?? "").toContain("app not found");
   }, 120_000);
 
   it("a save that DOES reach the screen still lands the row, the paint and a ready receipt", async () => {

--- a/packages/vendo/src/server.test.ts
+++ b/packages/vendo/src/server.test.ts
@@ -3750,6 +3750,31 @@ describe("unified try surface (Task 15a) — in-memory profile", () => {
     expect(content).toContain("Product\nDisk brief for the profile seam.");
   });
 
+  it("a profileDir pointing AT the .vendo directory resolves every surface, not just tools.json", async () => {
+    // `vendoDirOf` exists because a gate that always appends `/.vendo/` reads
+    // nothing at all when profileDir already names it. The actions registry
+    // honours that rule; the surface reader must too, or theme, brief, catalog
+    // and knowledge all silently resolve to `.vendo/.vendo/…` and disappear.
+    const root = await diskProfile();
+    const store = await tempStore("vendo-profile-dotdir-store-");
+    const { model, prompts } = await promptCapture();
+
+    const vendo = createVendo({
+      model,
+      principal: async () => principal,
+      store,
+      profileDir: join(root, ".vendo"),
+    });
+
+    const names = (await vendo.actions.descriptors()).map((descriptor) => descriptor.name);
+    expect(names).toContain("host_from_disk");
+
+    await runTurn(vendo, "thr_profile_dotdir");
+    const content = systemContent(prompts);
+    expect(content).toContain("Disk Grotesk");
+    expect(content).toContain("Product\nDisk brief for the profile seam.");
+  });
+
   it("workerd portability regression: profile.tools skips the tools.json disk read entirely (a malformed file there is never opened)", async () => {
     // Reproduces the real-workerd failure class's PRIMARY fix: a supplied
     // in-memory profile piece must make the disk leg never run at all.

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -1175,13 +1175,19 @@ function isJsonRequest(request: Request): boolean {
 /** 09 §4 — the .vendo/ files feeding the generation seat, read fail-soft (the
     composition works without them; on non-Node runtimes they just stay unset).
     Reads `node:fs` through the runtime built-in accessor so this module carries
-    NO static Node import and still loads/bundles for edge/Worker targets. */
+    NO static Node import and still loads/bundles for edge/Worker targets.
+
+    `root` is a `profileDir`, so it goes through `vendoDirOf` — it may be the
+    host root or the `.vendo` directory itself, exactly like the actions
+    registry's reader. Appending unconditionally reads `.vendo/.vendo/…`, which
+    fail-soft turns into silence: theme, brief, catalog and knowledge all
+    vanish with no error. */
 function dotVendoFile(name: string, root?: string): string | undefined {
   try {
     const proc = (globalThis as { process?: { getBuiltinModule?: (id: string) => unknown } }).process;
     const fs = proc?.getBuiltinModule?.("node:fs") as typeof import("node:fs") | undefined;
     if (fs === undefined) return undefined;
-    return fs.readFileSync(`${root === undefined ? "." : root}/.vendo/${name}`, "utf8");
+    return fs.readFileSync(`${vendoDirOf(root ?? ".")}/${name}`, "utf8");
   } catch {
     return undefined;
   }
@@ -1279,7 +1285,7 @@ function dotVendoPinBaselines(root?: string): PinBaseline[] {
   const proc = (globalThis as { process?: { getBuiltinModule?: (id: string) => unknown } }).process;
   const fs = proc?.getBuiltinModule?.("node:fs") as typeof import("node:fs") | undefined;
   if (fs === undefined) return [];
-  const directory = `${root === undefined ? "." : root}/.vendo/remixable`;
+  const directory = `${vendoDirOf(root ?? ".")}/remixable`;
   let names: string[];
   try {
     names = fs.readdirSync(directory).filter((name) => name.endsWith(".json")).sort();

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -458,8 +458,8 @@ export interface CreateVendoConfig {
   /** Build contract §3.4 / architecture §10 — where workspace file CONTENT
       lives once it outgrows a database row. Unset, the store's own `vendo_blobs`
       backs it up to `FILES_STORE_MAX_BYTES` (5 MiB) and the first over-cap write
-      fails naming this key; `s3({ bucket, … })` is the shipped implementation
-      and covers S3/R2/Supabase/MinIO.
+      fails naming this key. Any S3-compatible bucket (S3/R2/Supabase/MinIO)
+      is reachable through a host-supplied adapter.
 
       Resolved ONCE, inside `selectStore`, and handed to every consumer from
       there — the workspace that writes blobs, and the erase/adoption/sweep
@@ -1068,8 +1068,8 @@ function isHostedStore(store: VendoStore): store is HostedStore {
          writes fail closed with instructions).
     The adapters themselves never read the environment. */
 /** ADAPTER RULE, files seam (build contract §3.4): the one place a
-    `FilesAdapter` is chosen. Explicit `files:` wins (BYO — s3/R2/Supabase/MinIO
-    via `s3()`, or the host's own); unset, the store's `vendo_blobs` backs it up
+    `FilesAdapter` is chosen. Explicit `files:` wins (BYO — any S3-compatible
+    bucket, or the host's own); unset, the store's `vendo_blobs` backs it up
     to `FILES_STORE_MAX_BYTES`, and the over-cap error names `files:` by name.
 
     Deliberately NOT defaulted at each call site. The workspace writes blobs and

--- a/packages/vendo/src/sync-impact.test.ts
+++ b/packages/vendo/src/sync-impact.test.ts
@@ -101,6 +101,36 @@ describe("computeImpact", () => {
     ]);
   });
 
+  it("counts the tools an island's generated SOURCE calls, not just the tree's queries", async () => {
+    const store = await setup();
+    // `componentTools` is the compiler-stamped manifest of what each generated
+    // island's code calls through the ambient `tools` API — calls that by
+    // construction never appear in tree.queries or node props. Missing it makes
+    // `vendo sync` answer "no saved references" for a tool live apps call.
+    await appStore(store).put(principal, {
+      format: VENDO_APP_FORMAT,
+      id: "app_island",
+      name: "Island dashboard",
+      ui: "tree",
+      tree: {
+        formatVersion: VENDO_TREE_FORMAT,
+        root: "root",
+        nodes: [{ id: "root", component: "OrdersPanel", props: {} }],
+        queries: [],
+      },
+      componentTools: { OrdersPanel: ["host_get_orders"] },
+    });
+
+    await expect(computeImpact(store, ["host_get_orders"])).resolves.toEqual([
+      {
+        tool: "host_get_orders",
+        apps: [{ id: "app_island", title: "Island dashboard" }],
+        automations: [],
+        grants: 0,
+      },
+    ]);
+  });
+
   it("counts a pre-list automation, whose document still carries the single `trigger`", async () => {
     const store = await setup();
     // Raw SQL on purpose: the record door normalizes a document on the way IN, so

--- a/packages/vendo/src/sync-impact.ts
+++ b/packages/vendo/src/sync-impact.ts
@@ -66,6 +66,15 @@ function referencedTools(doc: AppDocument): Set<string> {
     }
     for (const node of tree.nodes ?? []) collectActions(node.props, tools);
   }
+  // The compiler-stamped manifest of what each island's SOURCE calls through
+  // the ambient `tools` API. Those calls are in generated code, so they never
+  // appear in tree.queries or node props — without this, an app full of islands
+  // reports zero references for every tool it actually runs.
+  for (const names of Object.values(doc.componentTools ?? {})) {
+    for (const name of names) {
+      if (!name.startsWith("fn:")) tools.add(name);
+    }
+  }
   for (const trigger of doc.triggers ?? []) {
     if (trigger.run.kind !== "steps") continue;
     for (const step of trigger.run.steps) {

--- a/packages/vendo/src/vendo-verbs.test.ts
+++ b/packages/vendo/src/vendo-verbs.test.ts
@@ -1,4 +1,4 @@
-import { VENDO_TOOL_TITLES, type RunContext } from "@vendoai/core";
+import { VENDO_TOOL_TITLES, VendoError, type RunContext } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
 import { VENDO_VERB_TOOLS, vendoVerbsRegistry } from "./vendo-verbs.js";
 
@@ -103,6 +103,24 @@ describe("the vendo verbs are projected as ordinary tools (design §4)", () => {
     expect(outcome.status).toBe("error");
     expect(JSON.stringify(outcome)).not.toContain("Cannot read properties");
     expect(JSON.stringify(outcome)).not.toContain("TypeError");
+  });
+
+  it("forwards a VendoError's own code and message — those are written for the model", async () => {
+    // The ports raise authored, actionable refusals ("app X has no schedule to
+    // change. Ask for the automation itself first…"). Flattening those into
+    // "could not complete. Try again" tells the model to retry a call that can
+    // never succeed. Masking is for the errors nobody wrote for a reader.
+    const registry = vendoVerbsRegistry(ports({
+      schedule: async () => {
+        throw new VendoError("validation", "app app_1 has no schedule to change. Ask for the automation itself first.");
+      },
+    }));
+
+    const outcome = await registry.execute(call("schedule", { appId: "app_1", cron: "0 8 * * *" }), ctx());
+
+    expect(outcome.status).toBe("error");
+    expect(JSON.stringify(outcome)).toContain("Ask for the automation itself first");
+    expect(JSON.stringify(outcome)).toContain("validation");
   });
 
   it("refuses an unknown verb instead of silently succeeding", async () => {

--- a/packages/vendo/src/vendo-verbs.ts
+++ b/packages/vendo/src/vendo-verbs.ts
@@ -1,4 +1,4 @@
-import { VENDO_TOOL_TITLES, type Json, type RunContext, type ToolDescriptor, type ToolRegistry } from "@vendoai/core";
+import { VENDO_TOOL_TITLES, VendoError, type Json, type RunContext, type ToolDescriptor, type ToolRegistry } from "@vendoai/core";
 
 /**
  * Design §4's vendo-verb family, projected as ordinary tools on the one
@@ -151,7 +151,11 @@ export function vendoVerbsRegistry(ports: VendoVerbPorts): ToolRegistry {
             return fail("not-found", `${call.tool} is not a Vendo verb`);
         }
       } catch (error) {
-        // A port failure is OURS, not the model's, and raw JS text ("Cannot read
+        // A VendoError was authored FOR the model ("app X has no schedule to
+        // change. Ask for the automation itself first…"). Masking it tells the
+        // model to retry a call that can never succeed, so forward it verbatim.
+        if (error instanceof VendoError) return fail(error.code, error.message);
+        // Anything else is OURS, not the model's, and raw JS text ("Cannot read
         // properties of undefined") teaches it nothing it can act on while
         // leaking our internals into the transcript. Log the detail for us; hand
         // the model a sentence about what to do.

--- a/packages/vendo/src/wire/box.served.test.ts
+++ b/packages/vendo/src/wire/box.served.test.ts
@@ -68,6 +68,17 @@ describe("§9.8 — the served proxy forwards the whole request line", () => {
     expect(seen[0]?.path).toBe("/");
   });
 
+  it("keeps percent-encoding intact instead of decoding it into separators", async () => {
+    // The forwarded path is concatenated straight into the box's fetch URL, so
+    // a decoded segment rewrites the request: %2F becomes a path separator and
+    // %3F starts a query the caller never sent.
+    const { wire, seen } = wireFor(
+      "https://maple.test/api/vendo/apps/app_1/serve/files/a%2Fb%3Fc",
+    );
+    await dispatchRoutes(servedProxyRoutes, wire);
+    expect(seen[0]?.path).toBe("/files/a%2Fb%3Fc");
+  });
+
   it("still forwards the PAYLOAD only — no cookie, authorization or host header", async () => {
     const { wire, seen } = wireFor("https://maple.test/api/vendo/apps/app_1/serve/save?id=7", "POST");
     await dispatchRoutes(servedProxyRoutes, wire);

--- a/packages/vendo/src/wire/box.ts
+++ b/packages/vendo/src/wire/box.ts
@@ -81,7 +81,7 @@ function relayAnswer(answer: BoxResponse): Response {
     the skin has one shape, not two. */
 export const servedProxyRoutes: RouteEntry[] = [
   route("*", "/apps/:appId/serve/*", async (wire) => {
-    const { request, params, deps, segments } = wire;
+    const { request, params, deps } = wire;
     const appId = string(params["appId"], "app id");
     const ctx = await wire.context("app");
     // Everything after `/apps/<id>/serve` is the path INSIDE the box, QUERY
@@ -89,7 +89,12 @@ export const servedProxyRoutes: RouteEntry[] = [
     // every served app that reads one (?tab=, ?vendoTheme=, pagination) breaks
     // the moment the app is shared. Still payload only — the search string is
     // part of what the caller asked for, not host authority.
-    const inner = `/${segments.slice(3).join("/")}${wire.url.search}`;
+    //
+    // Split `wire.path` (raw), NOT `wire.segments` (percent-DECODED): this path
+    // is concatenated into the box's fetch URL, so a decoded `%2F` would become
+    // a real separator and a decoded `%3F` would start a query nobody sent.
+    const raw = wire.path.split("/").filter(Boolean);
+    const inner = `/${raw.slice(3).join("/")}${wire.url.search}`;
     // `serve` re-checks can(viewer) against live rows BEFORE any machine work,
     // so a revoked viewer's next request is refused even though what their
     // session already rendered stands.


### PR DESCRIPTION
The umbrella is the package hosts actually `npm install`. This slice works the
`@vendoai/vendo` section of the catalog **worst-first** and lands the correctness
tier: **15 real bugs, every one verified against the code first, every one with a
failing test committed before its fix.** Nothing here is a refactor.

**Real diff:** 39 files, +556 / −103 (source only: +303 / −94).

## Selected list and disposition

Ordered worst-first, as worked.

| # | Finding | Disposition |
|---|---|---|
| 1 | `VENDO_DEV_CREDENTIAL=vendo-cloud` with no `VENDO_API_KEY` returned the cloud rung; `model.ts` then called the Cloud gateway with `apiKey: undefined`, and `@ai-sdk/anthropic` falls back to `process.env.ANTHROPIC_API_KEY` — **the host's own provider key was sent to console.vendo.run**, by a config the docs actively recommend | **fixed** (`dev-creds/resolve.ts`) |
| 2 | `createCapabilityMissCapture` runs on **every** `createVendo` boot and called telemetry's `loadConfig`, which **mints and persists an opted-in tracking id into `~/.vendo/telemetry.json`** — for hosts that never enabled telemetry and can never upload | **fixed** (`capability-misses.ts`) — handed over from sweep-small-packages; see the section below |
| 3 | Served-app proxy rebuilt the forwarded path from percent-**decoded** segments, so `%2F` became a real separator and `%3F` started a query the caller never sent, straight into the box's fetch URL — the only door to org apps | **fixed** (`wire/box.ts`) |
| 4 | `dotVendoFile` appended `/.vendo/` unconditionally while the actions registry used the idempotent `vendoDirOf`, so `profileDir: "./.vendo"` (a shape the code claims to support) **silently lost theme, brief, catalog, knowledge and pin baselines** — fail-soft, so no error | **fixed** (`server.ts`, incl. `dotVendoPinBaselines`, which the catalog missed) |
| 5 | `sync-impact` never read `componentTools`, the compiler-stamped manifest of what each island's source calls — so `vendo sync` answered **"no saved references"** for tools live generated apps run | **fixed** (`sync-impact.ts`) |
| 6 | `cloudTools.descriptors()` **threw** on a duplicate slug. A thrown `descriptors()` fails the whole registry load, host tools included — from a connector auto-composed off a bare `VENDO_API_KEY`, contradicting its own docblock | **fixed** (`cloud-tools.ts`; also dedupes the `toolkits=` query) |
| 7 | The vendo-verbs catch-all flattened **authored, model-facing** `VendoError`s ("app X has no schedule to change. Ask for the automation itself first") into "could not complete. Try again" — telling the model to retry a call that can never succeed | **fixed** (`vendo-verbs.ts`; unknown throws still masked) |
| 8 | `vendo doctor` hung for up to **120 s after printing its verdict** when the dev-server spawn failed: `waitForStatus` lost the race but kept polling on a ref'd timer, and `bin/vendo.mjs` only sets `process.exitCode` | **fixed** (`cli/doctor-live.ts`) |
| 9 | Doctor's `<VendoRoot>` check scanned `app/` layouts only, so a **Pages-Router host could never pass E-WIRE-004** — and was told to paste into `app/layout.tsx`, a file `vendo init` never mentioned and that does not exist | **fixed** (`cli/doctor.ts`) — init's `clientRoot()` moved to `cli/shared.ts`; both now read one rule |
| 10 | `collectCss` pushed a sheet **before** recursing into its `@import`s and the readers take the last declaration, so the imported sheet beat the importer — the inverse of the real cascade. A brand colour overridden in `globals.css` was reported as an **exact** read of the imported default | **fixed** (`cli/theme/extract-theme.ts`) |
| 11 | `evidence` was capped at 500 in the schema but absent from `PROSE_LIMITS`, and every issue on that path is bucketed as evidence-**less** — so the most thorough answer a model can give printed as **"no evidence → rejected"** and the grade was silently dropped | **fixed** (`cli/judge/pass.ts`) |
| 12 | `repairJson`'s trailing-comma rule required a closer to already follow, so a batch truncated **right after a complete grade** repaired to `…},]}` and every recoverable grade in it was lost — the exact shape the module exists for | **fixed** (`cli/judge/parse.ts`) |
| 13 | `isInstalled` stat'd `<root>/node_modules` only, so a hoisted npm/pnpm workspace read as MISSING and `vendo init` shelled a real install that rewrote the app's `package.json` — while the sibling `installedVersion` in the same directory already walked up correctly | **fixed** (`cli/provider-deps.ts`) |
| 14 | A trailing slash on `AUTH0_DOMAIN` produced a double-slash issuer that matches no token's `iss` and mislocates the JWKS — **every login failed**, with nothing naming the extra character; an unusable value threw a bare URL parse error | **fixed** (`auth-presets/auth0.ts`) |
| 15 | `uploadedBytes` counted UTF-16 code units and `vendo sync` prints it to the user as KB | **fixed** (`cli/cloud/host-components.ts`) |
| — | Six stale `s3()` doc mentions; `compound.e2e.test.ts` pointing at a directory being deleted elsewhere | **fixed** (prose only; 2 of the 6 `s3()` mentions are in `packages/vendo`, the third is in `packages/core` — not my file set) |

## Rejected leads — the catalog was wrong or the fix is not mine

Logged as required. Every "dead"/"zero callers" claim in my scope was checked by hand.

- **`x-vendo-session-id` "has no repo-wide reference outside `context.ts`" — FALSE.** It is in `examples/demo-bank/src/demo-script/engine.ts:648` and, critically, in **vendo-web**'s console try-chat CORS allow-list (`apps/console/lib/try/chat.ts:498`, asserted at `tests/try-chat.test.ts:473`). Deleting the header would have broken the hosted try surface. The *other* half of that card — host-resolved principals sharing one process-wide `sessionId`, so "allow for this session" outlives the session — is real, but changing it is a consent-semantics decision with guard tandem implications, not a sweep item. **Deferred, needs an owner call.**
- **`packages/vendo/src/cli/playground/bundle.gen.ts` is not gitignored — already fixed.** #960 renamed it to `embed-bundle.gen.ts` and it is on line 1 of `packages/vendo/.gitignore`. Confirmed empirically: a full scoped build leaves a clean `git status`.
- **Unhandled wire errors answer 501 instead of 500** — real, but `internalError()` reuses the `not-implemented` code whose 501 mapping is shared with `@vendoai/core`'s store-wire and knowledge-wire. Fixing it means adding a code in `packages/core`, which is not my file set. **Deferred.**
- **`cloudTools`'s throw is "uniquely wrong"** — partly false. The identical throw is the established pattern in `packages/actions/src/connectors/{composio,mcp}.ts`. What makes it wrong *here* is that this connector is the auto-composed zero-config default and its own docblock states the opposite policy. Fixed here only; the sibling connectors are not my file set.

## Deferred, with reasons — please dispatch

1. **`POST /sync/impact` is gated only by `NODE_ENV === "production"`** (`wire/misc.ts:136`). `environment()` returns `undefined` when `typeof process === "undefined"`, so it **fails open on Cloudflare Workers and on any Node deploy that never sets `NODE_ENV`** — and `computeImpact` enumerates every app and automation across **all** subjects. The sibling route four lines up uses `deps.development` and fails closed. I did not fix it because the fix breaks `fixtures/integration/src/sync-impact.e2e.test.ts` (outside my file set — it composes with no `NODE_ENV` and expects a 200) and it changes the gate from per-request to compose-time. It also newly 404s the impact probe for express/custom hosts that do not set `NODE_ENV`. **That is an owner decision, not a sweep call.** This is the single worst thing left in the section.
2. **Hosted store's `records.atomic` capability mirror** omits `vendo_apps`/`vendo_effects` that the local engine exposes, so **every app-document mutation on Vendo Cloud is last-write-wins**. Needs a console-side companion; genuinely tandem.
3. The rest of the section — the `createVendo` split (explicitly out of scope), the ~60 test-duplication cards (`tempStore` in 40 files, the model doubles in 24), the comment-archaeology sweep, and the deprecated model-seat spellings. All separable from this slice.

## Telemetry hand-over (the one folded in mid-flight)

**Is the id minted when telemetry is disabled? Yes — that is why it is a privacy defect, not hygiene.** Product telemetry is opt-in (`telemetryClient` returns `undefined` unless `telemetry: true`), and `resolveConsent` fails *closed* in production. But the capability-miss capture is composed unconditionally, and it reached `loadConfig`, which writes when the file is absent and no env kill switch is set.

**Written to a user's disk, before:** the first `createVendo()` boot on a machine created `~/.vendo/telemetry.json` = `{ anonymousId: <fresh uuid>, optedOut: false, noticeShown: false }` — a persistent, opted-**in** installation identity, outside the first-run notice both consented paths go through, for a host that enabled nothing and (with no `VENDO_API_KEY`) could never upload anything.

**After:** that file is created only by the consented paths — the `vendo` CLI / `telemetry: true` collector via `initTelemetry`, which shows the notice — or by a `createVendo()` boot that filled the Cloud slot (`VENDO_API_KEY` set, no kill switch), which the docs already name as the host's explicit opt-in to miss upload. A keyless host writes **nothing** to its home directory; its local `.vendo/data/misses.jsonl` records carry `hostId: "local"`.

**Both sides proven.** The new test asserts no file appears for a keyless capture. The pre-existing "uses the persisted telemetry anonymous id as the normative host id" test still passes and still reads `telemetry-installation-id` — it now runs in the Cloud posture, the only one where that identity is load-bearing; that adaptation is called out in the fix commit. `packages/vendo-telemetry` itself is untouched, so its zero-`@vendoai`-dependency boundary is intact — and `loadConfig` can now be made a pure read there without regressing `hostId`.

## vendo-web disposition — eight changes checked, all NO-OP

`packages/vendo` is the umbrella, so this got the full sweep of the sibling repo. Every user-visible change was checked against `/home/ubuntu/repos/vendo-web`:

1. **Served-app path encoding** — no-op. vendo-web has no `/apps/<id>/serve/...` caller. `workers/machine-proxy` is a different proxy on `*-m.vendo.run` and already forwards `URL.pathname` (encoded); the real `vendo-app-proxy` source is not in that repo.
2. **cloud-tools skip-vs-throw + toolkit dedupe** — no-op, mildly positive. vendo-web is the *server* (`apps/console/lib/api/tools.ts`); it never calls `descriptors()`, never dedupes or rejects repeats, and no test sends a repeated toolkit in one query. Dedupe only improves its 5-minute per-scope cache reuse.
3. **`hostId: "local"` on local-only misses** — no-op, and unreachable. `handleMissIngest` requires a `Bearer vnd_` key, so a keyless host cannot post at all. Even if it could: validation is `isNonEmptyString(hostId)`, dedup keys on `(project_id, id)` not `hostId`, the `hostId` index is a plain btree, and the gap dashboard renders it as a raw label.
4. **E-WIRE-004 wording** — no-op. `E-WIRE-004` does not appear anywhere in vendo-web; doctor is referenced only as the string `vendo doctor --json` in agent prompts.
5. **`docs/act-as-presets.md` → `https://docs.vendo.run/connect/act-as-presets`** — no-op, and the target is confirmed published: `docs-site/docs.json:82` lists `connect/act-as-presets`, the `.mdx` exists, five in-repo pages already link `/connect/act-as-presets`, and `wire/apps.ts:214` already emits `docs.vendo.run/...` the same way. vendo-web does not serve `docs.vendo.run` (that is the separate Mintlify docs site) and asserts the old string nowhere — the one literal hit is a synthetic knowledge-eval corpus fixture no test reads.
6. **Dev-credential rung degrade** — no-op. `VENDO_DEV_CREDENTIAL` is never set in vendo-web (two hits, both static documentation text). Its try venue composes a model explicitly rather than through the ladder.
7. **`profileDir` resolution** — no-op. `profileDir` appears nowhere in vendo-web. Its one real `createVendo(` call (`apps/console/lib/try/chat.ts:470`) passes an inline in-memory `profile`, explicitly with no I/O, so nothing new can resolve.
8. **`componentTools` in sync impact** — no-op. vendo-web never calls `/sync/impact`; the inbound `POST /api/v1/sync/report` treats `impact` as an opaque array, stores it verbatim, and no page or component renders it.

**No companion vendo-web PR is required.**

## CLI proof — it still runs

Beyond the suites. Built with the scoped build, then the real binary:

```
$ node packages/vendo/bin/vendo.mjs --help
exit=0 — full command list renders (init, login, doctor, sync, eject, knowledge, mcp, cloud, config)

$ node packages/vendo/bin/vendo.mjs doctor examples/demo-bank --json
exit=1 — a real report, 20+ checks
  wiring/next-route      ok   catch-all handler is wired
  wiring/next-root       ok   <VendoRoot> wraps the app        ← the check I changed
  wiring/surface         ok   a visible agent surface is mounted
  deps/ai-sdk-major      ok   installed ai@6.0.28
  tools/live-surface     ok   18 live host tools
  tools/graded           ok   catalog: all 22 tools graded
  config/data-gitignore  warn E-CFG-002
  live/status            broken E-LIVE-002  ← no dev server running, expected
  auth/present · auth/act-as · turn/model   broken, same cause
```

Exit 1 comes only from the live probes with no dev server up; every static check, including the one I touched, is green — and the command **returns immediately** rather than hanging, which is bug #8's fix observed end to end.

## Gates

Run one at a time, foreground, redirected to a file, `MemAvailable` read before each. Scoped build, only the suites covering what I touched — never the whole package, never the full repo.

```
pnpm build --filter=@vendoai/vendo...    exit=0   Tasks: 13 successful, 13 total
pnpm typecheck                            exit=0   Tasks: 40 successful, 40 total
pnpm lint --force                         exit=0   dependency-guard: OK (15 packages checked)
                                                   portability-gate: all legs green
                                                   Tasks: 3 successful, 3 total
                                                   (1 pre-existing warning in demo-bank, untouched)
```

The portability gate matters here: `server.ts` and `capability-misses.ts` both sit in the Worker graph, and it re-verified the workerd fixture serves `/status` 200.

Suites, all green after the fixes:

```
doctor-live · dev-creds · box.served · sync-impact · cloud-tools · vendo-verbs        35 + 12 passed
server.test.ts                                                                       128 passed
capability-misses                                                                     16 passed
extract-theme · judge/parse · judge/pass · provider-deps · auth0 · host-components   129 passed
doctor · init · onboarding-safety · init-scaffolds · doctor-mcp-broker · skew        213 passed
box-wire · served-apps-wire · vendo-verbs-wire · sync · sync.coherence · dep-versions
  · doctor-codes.docs · cli.test · dev-creds                                         138 passed
auth-presets/* · cli/theme/* · config-surface · catalog · knowledge-resolution
  · config-coherence · connections                                                   283 passed
harness-wire · compound.e2e · cli/judge/* · init-judgment                            125 passed
```

CI's green `ci` check is the gate of record.

## Scope discipline

- Touched only `packages/vendo/**`, `.changeset/`, and the one docs page describing a message I changed (`docs-site/agents/verify.mdx`, E-WIRE-004).
- **Not touched:** `src/react.tsx` (rebase in flight) and `src/cli/playground/app/**` (the live `@vendoai/vendo/try-surface`). Confirmed absent from the diff.
- The `createVendo` split was left alone as instructed.
- Every deleted or moved symbol (`appDirectory`, `clientRoot`, `isInstalled`, `installedVersion`, `dotVendoFile`, `dotVendoPinBaselines`) was grepped repo-wide **including test directories** after committing — the typecheck-excludes-tests trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes fifteen correctness bugs in `@vendoai/vendo` that could leak keys, misroute requests, hang the CLI, or return wrong answers. Improves safety defaults, doctor guidance, and accuracy across proxying, auth, sync, and judging.

- **Bug Fixes**
  - Security & privacy: `VENDO_DEV_CREDENTIAL=vendo-cloud` without `VENDO_API_KEY` now degrades to none (prevents provider key leak via `@ai-sdk/anthropic`); capability-miss capture no longer mints a telemetry id for keyless hosts (local misses use hostId "local").
  - Served-app proxy: preserves percent-encoding and forwards the real path plus query, preventing `%2F`/`%3F` from rewriting requests.
  - Profile I/O: `profileDir` may point at `.vendo/`; readers use `vendoDirOf` so theme, brief, catalog, knowledge, and pin baselines load.
  - CLI doctor: cancels the status poll when the dev-server spawn fails (no post-verdict hang); detects `<VendoRoot>` in `pages/_app.*` and names it in E-WIRE-004.
  - CSS/theme: imported sheets load before the importer so the importer wins at equal specificity.
  - Judge pipeline: clamps `evidence` to 500 chars; JSON repair drops a trailing comma at EOF to recover valid grades.
  - Dependencies: respects hoisted workspace installs for `ai` and provider packages; avoids unnecessary installs.
  - Auth: tolerates a trailing slash in `AUTH0_DOMAIN`, produces clearer errors for unusable values, and fixes the JWKS URL.
  - Sync & tools: includes `componentTools` in impact; cloud-tools skip duplicate slugs and dedupe `toolkits`; uploaded module size counts UTF‑8 bytes; `vendo-verbs` forward `VendoError` code and message.

<sup>Written for commit c6c8aa87a3d398fcf03111112cd5c4d194dca5d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

