### PR TITLE
fix(demo-bank): remove staff data leak from unauthenticated profile response

### DIFF
--- a/examples/demo-bank/src/app/api/profile/route.test.ts
+++ b/examples/demo-bank/src/app/api/profile/route.test.ts
@@ -34,8 +34,9 @@ describe("GET /api/profile — the identity is the signed-in person's, all of it
     expect(yousef.avatarInitials).toBe("YH")
   })
 
-  it("leaves the seed's own initials alone when nobody is signed in", async () => {
+  it("leaves the seed's own initials alone when nobody is signed in, and hides staff", async () => {
     const anonymous = await bodyOf(new Request("http://localhost:3000/api/profile"))
     expect(anonymous.avatarInitials).toBe("YH")
+    expect(anonymous.staff).toBeUndefined()
   })
 })

--- a/examples/demo-bank/src/app/api/profile/route.ts
+++ b/examples/demo-bank/src/app/api/profile/route.ts
@@ -37,6 +37,6 @@ export async function GET(req: Request) {
           demoAutologin,
           staff,
         }
-      : { ...profile, demoAutologin, staff },
+      : { ...profile, demoAutologin },
   )
 }


### PR DESCRIPTION
Resolves #968

### What happened
The `/api/profile` endpoint in the Demo Bank app was unconditionally attaching the `staff` roster (containing the seeded demo users' subjects, names, and emails) to the response, even for anonymous unauthenticated callers. This leaked demo data and undercut the data isolation narrative of the demo.

### What changed
- Modified `examples/demo-bank/src/app/api/profile/route.ts` to omit the `staff` object from the unauthenticated fallback branch. The staff roster is now only returned when there is a valid, authenticated session.
- Added a strict assertion in `examples/demo-bank/src/app/api/profile/route.test.ts` to verify that `anonymous.staff` is `undefined` for anonymous callers, ensuring this leak does not regress.

### Verification
- [x] Tested locally via `pnpm test` and the targeted profile route test passes perfectly.
- [x] Code is clean and focused solely on this bug fix (no unrelated modifications).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `staff` roster from unauthenticated `/api/profile` responses to stop leaking demo user data and preserve isolation. Added a test to ensure `staff` is only returned for authenticated sessions.

<sup>Written for commit 9c3ed4ad6b2389228bf3743dfa448c429b092bb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

