### PR TITLE
fix(ui): an app's $state stays its own — TreeView keys on the app, not on a constant

### DIFF
--- a/.changeset/one-apps-state-stays-its-own.md
+++ b/.changeset/one-apps-state-stays-its-own.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/ui": minor
+---
+
+An app's `$state` no longer leaks into the next app rendered in its place. `TreeView` keyed its stateful body on `tree.root`, but the compiler roots every compiled app at the same synthetic `root` node, so the key never changed between two different apps: React reused the instance and app B rendered app A's `$state` (and outcomes). `TreeView`, `PayloadView` and `AppFrame` now take an optional `appId` — the identity the surrounding code already had — and key on it. Omit it and the key falls back to `tree.root` exactly as before, so no existing caller changes behavior.

--- a/packages/ui/src/tree/frames.tsx
+++ b/packages/ui/src/tree/frames.tsx
@@ -24,6 +24,12 @@ export interface AppFrameKeepalive {
 
 export interface AppFrameProps {
   surface: OpenSurface;
+  /**
+   * Which app this surface belongs to. A frame that can show a DIFFERENT app in
+   * the same position passes it, and the tree surface's `$state` then belongs to
+   * that app alone (renderer.tsx's TreeView documents why the tree cannot say).
+   */
+  appId?: string;
   components?: Record<string, ComponentType>;
   data?: Record<string, Json>;
   onAction?(req: { nodeId: string; action: string; payload?: Json }): Promise<ToolOutcome>;
@@ -157,7 +163,7 @@ function HttpFrame({ url, keepalive }: { url: string; keepalive?: AppFrameKeepal
 }
 
 /** 08-ui §5; 06-apps §1 — render every app execution plane fail-soft. */
-export function AppFrame({ surface, components = {}, data, onAction = unavailableAction, onStateChange, keepalive }: AppFrameProps) {
+export function AppFrame({ surface, appId, components = {}, data, onAction = unavailableAction, onStateChange, keepalive }: AppFrameProps) {
   if (surface.kind === "http") {
     return <HttpFrame url={surface.url} keepalive={keepalive} />;
   }
@@ -173,6 +179,7 @@ export function AppFrame({ surface, components = {}, data, onAction = unavailabl
     return (
       <PayloadView
         payload={payload}
+        {...(appId === undefined ? {} : { appId })}
         components={components}
         data={data}
         onAction={onAction}

--- a/packages/ui/src/tree/renderer.tsx
+++ b/packages/ui/src/tree/renderer.tsx
@@ -38,6 +38,12 @@ import { useKeyedState } from "../kit/state.js";
 
 export interface TreeViewProps {
   tree: WalkTree;
+  /**
+   * Which app this tree belongs to — the `$state` and outcome namespace's
+   * identity. A caller that can render a DIFFERENT app in the same position
+   * passes it; see {@link TreeView} for what it buys.
+   */
+  appId?: string;
   components: Record<string, ComponentType>;
   data?: Record<string, Json>;
   onAction(req: { nodeId: string; action: string; payload?: Json }): Promise<ToolOutcome>;
@@ -50,6 +56,8 @@ export interface TreeViewProps {
 
 export interface PayloadRendererProps {
   payload: UIPayload;
+  /** As {@link TreeViewProps.appId}. */
+  appId?: string;
   components: Record<string, ComponentType>;
   data?: Record<string, Json>;
   onAction(req: { nodeId: string; action: string; payload?: Json }): Promise<ToolOutcome>;
@@ -693,7 +701,19 @@ function StatefulTreeView({
   );
 }
 
-/** A new tree identity owns a fresh `$state` and outcome namespace. */
+/**
+ * A new app owns a fresh `$state` and outcome namespace.
+ *
+ * The identity is `appId`. It cannot be the tree: the compiler roots EVERY
+ * compiled app at the same synthetic `root` node (core/genui/wire/compile.ts),
+ * so keying on `tree.root` reused one instance across two different apps and
+ * app B rendered app A's `$state`. Nor can it be the tree's contents — a
+ * streaming tree changes on every chunk, and wiping `$state` mid-stream would
+ * throw away what the user just typed.
+ *
+ * Without `appId` the key falls back to `tree.root`, which is exactly the
+ * behavior every existing caller already had.
+ */
 export function TreeView(props: TreeViewProps) {
-  return <StatefulTreeView key={props.tree.root} {...props} />;
+  return <StatefulTreeView key={props.appId ?? props.tree.root} {...props} />;
 }

--- a/packages/ui/test/tree/frames-and-jail.test.tsx
+++ b/packages/ui/test/tree/frames-and-jail.test.tsx
@@ -167,6 +167,49 @@ describe("AppFrame", () => {
     expect(screen.getByText("Instant app")).toBeTruthy();
   });
 
+  it("does not carry one app's $state into the next app mounted in its place", async () => {
+    // The same leak as the TreeView case, through the surface a host actually
+    // renders: both apps carry the compiler's synthetic `root`, so only `appId`
+    // separates them.
+    const StateProbe: ComponentType<{ value?: unknown }> = ({ value }) => <output>{String(value)}</output>;
+    const payload = (island: string) => ({
+      formatVersion: VENDO_TREE_FORMAT,
+      root: "root",
+      nodes: [
+        { id: "root", component: "Row", children: ["generated", "probe"] },
+        { id: "generated", component: island, source: "generated" as const },
+        { id: "probe", component: "StateProbe", source: "host" as const, props: { value: { $state: "draft" } } },
+      ],
+      components: { [island]: `export default function ${island}() { return <div>editor</div> }` },
+    });
+
+    const view = render(
+      <AppFrame
+        appId="app_a"
+        surface={{ kind: "tree", payload: payload("EditorA") }}
+        components={{ StateProbe }}
+        onAction={ok}
+      />,
+    );
+    const iframe = screen.getByTitle("Generated component: EditorA") as HTMLIFrameElement;
+    window.dispatchEvent(new MessageEvent("message", {
+      source: iframe.contentWindow,
+      data: { kind: "state-set", key: "draft", value: "belongs to app A" },
+    }));
+    await waitFor(() => expect(screen.getByText("belongs to app A")).toBeTruthy());
+
+    view.rerender(
+      <AppFrame
+        appId="app_b"
+        surface={{ kind: "tree", payload: payload("EditorB") }}
+        components={{ StateProbe }}
+        onAction={ok}
+      />,
+    );
+    expect(screen.queryByText("belongs to app A")).toBeNull();
+    expect(screen.getByText("undefined")).toBeTruthy();
+  });
+
   it("contains unknown surface kinds", () => {
     render(<AppFrame surface={{ kind: "spatial" } as never} />);
     expect(screen.getByRole("note", { name: /unsupported app surface/i }).textContent).toContain("spatial");

--- a/packages/ui/test/tree/tree-view.test.tsx
+++ b/packages/ui/test/tree/tree-view.test.tsx
@@ -430,6 +430,38 @@ describe("TreeView bindings and outcomes", () => {
     expect(screen.getByText("undefined")).toBeTruthy();
   });
 
+  it("does not carry one app's $state into the next app rendered in its place", async () => {
+    // Every compiled app is rooted at the SAME synthetic node id (the compiler
+    // emits `root: "root"` for all of them — core/genui/wire/compile.ts), so the
+    // root is not an app identity: `appId` is. Two real apps, same position.
+    const StateProbe: ComponentType<{ value?: unknown }> = ({ value }) => <output>{String(value)}</output>;
+    const appTree = (island: string) => tree(
+      [
+        { id: "root", component: "Row", children: ["generated", "probe"] },
+        { id: "generated", component: island, source: "generated" },
+        { id: "probe", component: "StateProbe", source: "host", props: { value: { $state: "draft" } } },
+      ],
+      "root",
+      { [island]: `export default function ${island}() { return <div>editor</div> }` },
+    );
+
+    const view = render(
+      <TreeView appId="app_a" tree={appTree("EditorA")} components={{ StateProbe }} onAction={ok} />,
+    );
+    const iframe = screen.getByTitle("Generated component: EditorA") as HTMLIFrameElement;
+    window.dispatchEvent(new MessageEvent("message", {
+      source: iframe.contentWindow,
+      data: { kind: "state-set", key: "draft", value: "belongs to app A" },
+    }));
+    await waitFor(() => expect(screen.getByText("belongs to app A")).toBeTruthy());
+
+    view.rerender(
+      <TreeView appId="app_b" tree={appTree("EditorB")} components={{ StateProbe }} onAction={ok} />,
+    );
+    expect(screen.queryByText("belongs to app A")).toBeNull();
+    expect(screen.getByText("undefined")).toBeTruthy();
+  });
+
   it("turns $action props into callbacks and marks pending approval", async () => {
     const ActionButton: ComponentType<{ run?: () => Promise<ToolOutcome> }> = ({ run }) => (
       <button type="button" onClick={() => void run?.()}>Run action</button>


### PR DESCRIPTION
## The bug

`TreeView` keyed its stateful body on `tree.root`:

```tsx
return <StatefulTreeView key={props.tree.root} {...props} />;
```

and **`tree.root` is a constant.** The compiler emits a *synthetic* root node for
every app it compiles — `root: "root"`, `packages/core/src/genui/wire/compile.ts:519,550`
— so the key never changed between two different apps. React reused the same
instance, and **app B rendered app A's `$state`** (and its outcome namespace).
One user's app showing another app's state.

Found and deferred by #971, which stopped at its file-set edge. Verified from the
code here, not taken on trust.

## The fix

`TreeView`, `PayloadView` and `AppFrame` take an **optional `appId`** and key on
it. The public API already promised this — `TreeView`'s own comment read *"A new
tree identity owns a fresh `$state`"* — and it was false; this is code being made
to match its own documented guarantee, not new surface.

Why `appId` and not something off the tree: the tree carries no app identity, and
its *contents* cannot stand in for one — a streaming tree changes on every chunk,
so keying on content would wipe `$state` mid-stream, throwing away what the user
just typed. `appId` is stable: it is the server-issued app id the callers already
hold, unchanged across every re-render, stream chunk and edit of the same app.
The clincher is that two chrome call sites had **independently hand-rolled
`key={appId}`** around `AppFrame` for exactly this reason
(`chrome/vendo-slot.tsx:180`, `chrome/center/apps-page.tsx:59`) — the codebase had
already arrived at the right answer and never pushed it into the component that
claims to provide it.

**`appId` is optional and omitting it is byte-for-byte today's behavior:** the key
falls back to `tree.root`. No existing caller changes, in this repo or any host's.

## The test — the point of the piece

Committed **red first** (d93f4d2), fix second (be916ec). Both render app A, write
`$state.draft` through the jail's real `state-set` bridge, put app B in the same
position, and assert B does not see A's value. Both trees carry the compiler's
synthetic `root`, which is what makes them realistic:

- **`does not carry one app's $state into the next app rendered in its place`** —
  `packages/ui/test/tree/tree-view.test.tsx` (TreeView seam)
- **`does not carry one app's $state into the next app mounted in its place`** —
  `packages/ui/test/tree/frames-and-jail.test.tsx` (AppFrame seam, what a host
  actually renders)

The existing `resets $state when the tree root identity changes`
(tree-view.test.tsx) is **kept, untouched, and still passes**: with the fallback it
now asserts something true — the `tree.root` leg of the key, which is the
documented behavior when a caller passes no `appId`. It was never wrong, only
mistaken for the whole guarantee; it passes because its two trees have
hand-written distinct roots, which no compiled app ever has.

## Callers

**None changed.** I surveyed every `AppFrame` / `PayloadView` / `TreeView` call
site in `src/chrome/**` before writing anything: `vendo-slot.tsx:180`,
`center/apps-page.tsx:59`, `vendo-overlay.tsx:690` and `thread/parts.tsx:341`
already key on the app id, and `embeds.tsx:383` / `remixable.tsx:247` cannot leak
because `hooks/use-app.ts:71-88` and `embeds.tsx:270` clear the surface to
`undefined` on an app change, which unmounts the frame. So the leak was never
reachable through this repo's own chrome — the exposure was the **public API**,
for any host that renders a different app in the same position, which is precisely
what the false comment invited them to do.

## Residual, on record

`src/tree/mcp-shim/entry.tsx:38-46` renders successive apps into **one** React root
via `renderPayload(id, payload)` and does not key — and it *has* the id in hand, as
the first parameter it already binds `runtime.callApp` to. **Left alone
deliberately:** the shim's fix is inert without regenerating
`packages/mcp/src/shim/shim-html.gen.ts`, which is banned right now. Flagging it
for whoever lifts that ban; I did not lift it myself.

## Verification

Keying only — **nothing renders differently**, so no browser screenshots (a
remount boundary changes *when* state is dropped, never what is painted).

- `pnpm build --filter=@vendoai/ui...` — 2 successful, 2 total
- `packages/ui` `test/tree` + `test/ssr.test.tsx` — **21 files, 154 tests passed**
- `pnpm typecheck` — 40 successful, 40 total
- `pnpm lint --force` — 3 successful, 3 total

`packages/ui`'s typecheck skips `test/`, so every changed symbol was grepped
repo-wide including test dirs: `TreeViewProps`, `PayloadRendererProps` and
`AppFrameProps` have no consumer outside `src/tree/`.

**No `vendo-web` hit** — the change is confined to `packages/ui/src/tree/`, touches
no wire type, no `.vendo/` artifact, no `vendo_*` collection and no blob namespace,
so there is nothing for the console to mirror and no companion PR is owed.

Changeset: `minor` for `@vendoai/ui` (new optional prop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where an app’s `$state` leaked into the next app rendered in the same position. `TreeView`, `PayloadView`, and `AppFrame` now key state on an optional `appId` to keep each app’s state isolated.

- **Bug Fixes**
  - Added optional `appId` to `TreeView`, `PayloadView`, and `AppFrame`; state is keyed by `appId`, falling back to `tree.root` for full backward compatibility.
  - Added tests to ensure no `$state` carryover at both `TreeView` and `AppFrame` seams; published a `minor` changeset for `@vendoai/ui`.

<sup>Written for commit be916ec8d9511b10d32789cb3a8068100c318d11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

