### PR TITLE
fix(demo-bank,vendo,ui): fresh-walk fixes — env example teaches the URL law, E-WIRE-010 precision, one mismatch report per page

### DIFF
--- a/examples/demo-bank/.env.example
+++ b/examples/demo-bank/.env.example
@@ -3,10 +3,16 @@
 ANTHROPIC_API_KEY=
 
 # Vendo credential forwarding + MCP door
-# The operator-set PUBLIC origin. Present execution forwards the signed-in
-# user's session to this trusted base, and the door derives its OAuth
-# discovery/audience URLs from it. Required for host tools to work.
-VENDO_BASE_URL=http://localhost:3000
+# This deployment's FULL public URL — path prefix included. Nothing strips its
+# path: every URL Vendo builds (host tool calls, login redirects, the door's
+# OAuth discovery/audience URLs) hangs off it. Maple is served under /maple
+# (next.config.ts `basePath`), so the prefix belongs here too.
+VENDO_BASE_URL=http://localhost:3000/maple
+# Optional — the host API on another origin (default: the public URL above).
+# VENDO_HOST_API_URL=
+# Optional — the login page (default: {public URL}/login). May be absolute,
+# on another domain.
+# VENDO_LOGIN_URL=
 
 # Auth.js (real Maple login)
 # Required in production; outside production a fixed local development secret

--- a/examples/demo-bank/README.md
+++ b/examples/demo-bank/README.md
@@ -96,18 +96,19 @@ The Vendo store slot is an explicit demo decision, wired in
   scripted seeding, beats, and reset all go through the store-agnostic
   records door and work identically on both.
 
-## Railway and public-origin configuration
+## Railway and public-URL configuration
 
 Railway builds `examples/demo-bank/Dockerfile` from the monorepo root. Configure the
 service with `VENDO_API_KEY` (composes the hosted store and Cloud model
 gateway — see "Store posture"), `VENDO_BASE_URL`, `AUTH_SECRET`,
 `MAPLE_DEMO_EMAIL`, and `MAPLE_DEMO_PASSWORD`.
-`VENDO_BASE_URL` is the one public-origin switch: set it to the
-default Railway origin first, then change it to `https://maple.vendo.run` after
-DNS is live and redeploy. It is the ORIGIN only, never the mount point — host
-tool bindings already carry `/maple`, and `src/vendo/mcp-config.ts` adds it to
-the MCP door's public base. Without it the door has no way to learn where it
-is, and every URL it advertises 404s.
+`VENDO_BASE_URL` is the one public-URL switch: set it to the default Railway
+origin with `/maple` on the end first, then change it to
+`https://maple.vendo.run/maple` after DNS is live and redeploy. It is the app's FULL public URL, **path prefix
+included** — Maple is served under `/maple`, so `/maple` belongs in the value.
+Nothing strips it: stored host tool bindings are prefix-free and every URL
+Vendo builds hangs off this one. Without it the door has no way to learn where
+it is, and every URL it advertises 404s.
 
 For a fast local HTTPS iteration loop, this machine has Tailscale Funnel:
 
@@ -117,8 +118,8 @@ tailscale funnel --bg 3000
 tailscale funnel status
 ```
 
-Copy the HTTPS origin printed by `tailscale funnel status` into the ignored
-local environment as `VENDO_BASE_URL`, restart Maple, and verify discovery
+Copy the HTTPS origin printed by `tailscale funnel status`, append `/maple`, and
+set that as `VENDO_BASE_URL` in the ignored local environment; restart Maple, and verify discovery
 through the funnel. Stop the tunnel with `tailscale funnel reset`. The tunnel is
 only for iteration and is not part of the Railway deployment.
 
@@ -133,7 +134,8 @@ pnpm --filter demo-bank mcp:e2e
 The argument is Maple's ORIGIN and defaults to `http://localhost:3000`; where
 Maple sits on it comes from the app's own mount point, so
 `http://localhost:3000/maple` is the same run. `VENDO_BASE_URL` must be set to
-that origin for the door's discovery documents to name URLs a client can reach.
+that origin **with `/maple` on the end** for the door's discovery documents to
+name URLs a client can reach.
 
 ## Broker-fronted MCP (remote authorization server)
 

--- a/packages/ui/src/client-impl.ts
+++ b/packages/ui/src/client-impl.ts
@@ -97,6 +97,13 @@ function pageMount(): string | undefined {
   return segments.length === 0 ? "" : `/${segments[0]}`;
 }
 
+/** The mount mismatches already reported on this page, keyed by the pair the
+ *  message is about (client baseUrl + the page's prefix). A page routinely
+ *  holds several clients — the overlay's and each embed's — and one wiring
+ *  mistake printing once per client is a wall of the same paragraph. ONE loud
+ *  report, then silence; the throw still reaches every caller. */
+const reportedMounts = new Set<string>();
+
 /** 08-ui §2 */
 export function createVendoClient(config: VendoClientConfig): VendoClient {
   const baseUrl = config.baseUrl ?? "/api/vendo";
@@ -111,10 +118,9 @@ export function createVendoClient(config: VendoClientConfig): VendoClient {
    *
    *  The throw alone is not enough: callers that degrade on a failed fetch
    *  (the connector catalog's retry warning) bury it among the page's other
-   *  404s, so the one message that names the fix is reported once per client,
-   *  at error level, before it is thrown. */
+   *  404s, so the one message that names the fix is reported once per page, at
+   *  error level, before it is thrown. */
   let mountProven = false;
-  let mountReported = false;
 
   async function send(path: string, init?: RequestInit): Promise<Response> {
     const target = joinPath(baseUrl, path);
@@ -133,8 +139,9 @@ export function createVendoClient(config: VendoClientConfig): VendoClient {
           requested: target,
           ...(mount === undefined ? {} : { pageMount: mount }),
         });
-        if (!mountReported) {
-          mountReported = true;
+        const pair = `${baseUrl}|${mount ?? ""}`;
+        if (!reportedMounts.has(pair)) {
+          reportedMounts.add(pair);
           console.error(message);
         }
         throw new Error(message);

--- a/packages/ui/test/client.test.ts
+++ b/packages/ui/test/client.test.ts
@@ -177,7 +177,7 @@ describe("createVendoClient", () => {
 
   /** An unprefixed baseUrl on a prefixed page is the #914 shape from the
    *  browser: one loud error naming both sides and the fix, not a bare 404. */
-  it("throws ONE named mount-mismatch error on first contact, reported once at error level", async () => {
+  it("throws ONE named mount-mismatch error on first contact, reported once per PAGE", async () => {
     const originalFetch = globalThis.fetch;
     const errors = vi.spyOn(console, "error").mockImplementation(() => {});
     window.history.replaceState({}, "", "/maple/dashboard");
@@ -189,9 +189,14 @@ describe("createVendoClient", () => {
       const client = createVendoClient({ baseUrl: "/api/vendo" });
       await expect(client.threads.list()).rejects.toThrow(/wire mount mismatch/);
       await expect(client.status()).rejects.toThrow(/\/maple/);
+      // A page holds several clients — the overlay's and each embed's — and
+      // they all hit the same wall. The guard is keyed by the pair the message
+      // is about, so the second client throws without reprinting it.
+      const second = createVendoClient({ baseUrl: "/api/vendo" });
+      await expect(second.threads.list()).rejects.toThrow(/wire mount mismatch/);
       // Callers that degrade on a failed fetch (the connector catalog) swallow
       // the throw, so the console.error is what the developer actually sees —
-      // once per client, never folded into a retry warning.
+      // once per page, never folded into a retry warning.
       expect(errors.mock.calls).toEqual([[expect.stringMatching(/wire mount mismatch[\s\S]*\/maple/)]]);
     } finally {
       globalThis.fetch = originalFetch;

--- a/packages/vendo/src/cli/doctor.test.ts
+++ b/packages/vendo/src/cli/doctor.test.ts
@@ -1510,6 +1510,24 @@ describe("vendo doctor error codes + fix_refs", () => {
     });
   });
 
+  /** …and a host whose OWN component happens to be named VendoRoot is not
+      carrying anything legacy: Maple's src/components/vendo/VendoRoot.tsx is a
+      local wrapper around <VendoProvider>, and a healthy install was told to
+      swap a component Vendo never shipped it. The name alone proves nothing —
+      the import source and the missing provider do. */
+  it("stays silent on a local component merely NAMED VendoRoot that wraps <VendoProvider>", async () => {
+    const root = await healthy();
+    await mkdir(join(root, "components"), { recursive: true });
+    await writeFile(join(root, "components", "VendoRoot.tsx"),
+      "\"use client\";\nimport { VendoProvider } from \"@vendoai/vendo/react\";\n"
+      + "export function VendoRoot({children}) { return <VendoProvider baseUrl=\"/api/vendo\">{children}</VendoProvider>; }");
+    await writeFile(join(root, "app", "layout.tsx"),
+      "import { VendoRoot } from \"@/components/VendoRoot\";\n"
+      + "export default ({children}) => <VendoRoot>{children}<VendoOverlay /></VendoRoot>;");
+    const { report } = await jsonChecks({ targetDir: root, fetchImpl: successfulProbeFetch() });
+    expect(report.checks.find((check) => check.id === "wiring/vendo-root")).toBeUndefined();
+  });
+
   it("accepts a BYO embed (<VendoToolResult>) as the visible surface", async () => {
     const root = await healthy();
     await writeFile(join(root, "app", "layout.tsx"),

--- a/packages/vendo/src/cli/framework.ts
+++ b/packages/vendo/src/cli/framework.ts
@@ -11,7 +11,10 @@ export interface VendoWiring {
       provider that renders nothing (0.4.1 E2E cert B3: by-the-book installs
       ended doctor-green with nothing on screen). */
   surface: boolean;
-  /** The host still names the removed <VendoRoot> — doctor prints the swap. */
+  /** The host still uses the removed <VendoRoot> — doctor prints the swap. The
+      NAME alone is not evidence: a host's own wrapper component may be called
+      VendoRoot (Maple's is), so this is the import from @vendoai, or the tag
+      with no <VendoProvider> anywhere in the source. */
   legacyRoot: boolean;
 }
 
@@ -33,6 +36,10 @@ export const SURFACE_MARKERS: readonly string[] = [
   "useVendoThread(",
   "useSlotApp(",
 ];
+
+/** `import { …, VendoRoot, … } from "@vendoai/…"` — the removed export taken
+    from the package, which is the only spelling that can no longer resolve. */
+const LEGACY_ROOT_IMPORT = /import\s*\{[^}]*\bVendoRoot\b[^}]*\}\s*from\s*["']@vendoai\//;
 
 const SOURCE_FILE = /\.(?:[cm]?[jt]sx?)$/;
 const SOURCE_SCAN_MAX_FILES = 2_000;
@@ -74,18 +81,25 @@ export async function workspaceHostCandidates(root: string): Promise<string[]> {
     agree. */
 export async function detectVendoWiring(root: string): Promise<VendoWiring> {
   let server = false;
-  let client = false;
+  let provider = false;
+  let legacyTag = false;
+  let legacyImport = false;
   let surface = false;
-  let legacyRoot = false;
   const files = await walk(root, (relativePath) => SOURCE_FILE.test(relativePath), SOURCE_SCAN_MAX_FILES);
   for (const file of files) {
     const source = await readFile(file, "utf8").catch(() => "");
     const code = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
     if (code.includes("@vendoai/vendo/server") && /\bcreateVendo\s*\(/.test(code)) server = true;
-    if (code.includes("<VendoProvider")) client = true;
-    if (code.includes("<VendoRoot")) { client = true; legacyRoot = true; }
+    if (code.includes("<VendoProvider")) provider = true;
+    if (code.includes("<VendoRoot")) legacyTag = true;
+    if (LEGACY_ROOT_IMPORT.test(code)) legacyImport = true;
     if (SURFACE_MARKERS.some((marker) => code.includes(marker))) surface = true;
-    if (server && client && surface) break;
+    if (server && provider && surface) break;
   }
-  return { server, client, surface, legacyRoot };
+  return {
+    server,
+    client: provider || legacyTag,
+    surface,
+    legacyRoot: legacyImport || (legacyTag && !provider),
+  };
 }

--- a/packages/vendo/src/cli/framework.ts
+++ b/packages/vendo/src/cli/framework.ts
@@ -37,8 +37,10 @@ export const SURFACE_MARKERS: readonly string[] = [
   "useSlotApp(",
 ];
 
-/** `import { …, VendoRoot, … } from "@vendoai/…"` — the removed export taken
-    from the package, which is the only spelling that can no longer resolve. */
+/** A `VendoRoot` named in an import from a Vendo package — the removed export
+    taken from the package, the one spelling that can no longer resolve. (The
+    specifier is not spelled out in prose here: the dependency guard reads a
+    literal one as a real cross-package import.) */
 const LEGACY_ROOT_IMPORT = /import\s*\{[^}]*\bVendoRoot\b[^}]*\}\s*from\s*["']@vendoai\//;
 
 const SOURCE_FILE = /\.(?:[cm]?[jt]sx?)$/;


### PR DESCRIPTION
Three defects a fresh-eyes walk found in what #957/#958 shipped.

**1. demo-bank taught the old URL law.** `.env.example` still shipped an
origin-only `VENDO_BASE_URL`, and the README still said "It is the ORIGIN only,
never the mount point" — both contradict the law #957 merged: `VENDO_BASE_URL`
is the app's FULL public URL, path prefix included. Maple is served under
`/maple`, so the demo posture is `http://localhost:3000/maple`, and the Railway,
Tailscale Funnel, and `mcp:e2e` passages say so too. Wording matches
`VENDO_ENV_EXAMPLE` in `init-scaffolds.ts`.

**2. E-WIRE-010 false-fired on a healthy install.** The scan warned on the NAME
`<VendoRoot>`, so Maple — whose own `src/components/vendo/VendoRoot.tsx` is a
local wrapper around `<VendoProvider>` — was told to swap a component Vendo
never shipped it. It now warns on the import from the Vendo package, or on a
`<VendoRoot>` tag with no `<VendoProvider>` anywhere in the source. Failing test
first; the true-positive test (the legacy `vendo/vendo-root.tsx` wrapper) stays
green, as do init's and onboarding's legacy fixtures.

**3. Mount mismatch shouted once per client.** The once-guard lived in the
client closure, so a page holding the overlay's client and each embed's printed
the same paragraph several times. It is module-scoped now, keyed by the pair the
message is about (client `baseUrl` + the page's prefix): one loud report per
page, and the throw still reaches every caller.

## Verification

Scoped gate green on the touched scope: `pnpm build && pnpm test:affected &&
pnpm typecheck && pnpm lint` — 35 test tasks pass (`@vendoai/vendo` 205 files,
`@vendoai/ui` 124, `demo-bank` 24), typecheck and lint clean. Fix 3's test was
proven to fail against the old per-client guard before the fix landed. No UI
surface changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three issues from a fresh walk: `VENDO_BASE_URL` now clearly requires the full public URL (with path), E-WIRE-010 no longer false-fires on local wrappers, and mount mismatch errors print only once per page instead of per client.

- **Bug Fixes**
  - `demo-bank`: `.env.example` and README now show `VENDO_BASE_URL` as the full URL with `/maple`; Railway and Tailscale Funnel steps updated; added optional `VENDO_HOST_API_URL` and `VENDO_LOGIN_URL` notes.
  - `@vendoai/vendo` doctor (E-WIRE-010): flags only when `VendoRoot` is imported from `@vendoai/...` or when a `<VendoRoot>` tag appears with no `<VendoProvider>` in the codebase; no warning for local wrappers named `VendoRoot`. Tests added.
  - `@vendoai/ui`: mount mismatch is logged once per page (keyed by `baseUrl` + page prefix) and still throws for all callers. Test updated.

<sup>Written for commit 9643997e172c4963c1ea699ee6b3adb71645611f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

