### PR TITLE
refactor(corpus): the four deferred HIGHs — a faithful Playwright port, one process runner, one prep recipe

### DIFF
--- a/corpus/harness/src/boot.test.ts
+++ b/corpus/harness/src/boot.test.ts
@@ -61,6 +61,7 @@ function fakeProcess(pid: number): FakeBootProcess {
     kill() {
       return true;
     },
+    once() {},
   };
 }
 

--- a/corpus/harness/src/boot.ts
+++ b/corpus/harness/src/boot.ts
@@ -14,12 +14,16 @@ export interface BootCommandResult {
   stderr: string;
 }
 
+// The slice of ChildProcess the boot recipe drives. `pid` stays optional
+// because a real ChildProcess leaves it unset until the spawn succeeds; the
+// rest are required, so a fake that forgets one fails to compile instead of
+// quietly turning teardown or the exit watcher into a no-op.
 export interface BootProcess {
   pid?: number;
-  stdout?: Readable | NodeJS.ReadableStream | null;
-  stderr?: Readable | NodeJS.ReadableStream | null;
-  kill?: (signal?: NodeJS.Signals | number) => boolean;
-  once?: (event: "exit" | "close" | "error", listener: (...args: unknown[]) => void) => unknown;
+  stdout: Readable | null;
+  stderr: Readable | null;
+  kill(signal?: NodeJS.Signals | number): boolean;
+  once(event: "exit" | "close" | "error", listener: (...args: unknown[]) => void): unknown;
 }
 
 export interface BootLogPaths {
@@ -293,12 +297,8 @@ function attachLogStream(
   bootProcess.stderr?.on("data", write);
 
   return async () => {
-    const stdout = bootProcess.stdout as { off?: (event: string, listener: (chunk: unknown) => void) => void; removeListener?: (event: string, listener: (chunk: unknown) => void) => void } | null | undefined;
-    const stderr = bootProcess.stderr as { off?: (event: string, listener: (chunk: unknown) => void) => void; removeListener?: (event: string, listener: (chunk: unknown) => void) => void } | null | undefined;
-    if (stdout?.off) stdout.off("data", write);
-    else stdout?.removeListener?.("data", write);
-    if (stderr?.off) stderr.off("data", write);
-    else stderr?.removeListener?.("data", write);
+    bootProcess.stdout?.off("data", write);
+    bootProcess.stderr?.off("data", write);
     await new Promise<void>((resolve, reject) => {
       writer.end((error?: Error | null) => {
         if (error) reject(error);
@@ -406,7 +406,7 @@ export async function bootRepo(repo: BootRepo, options: BootRepoOptions = {}): P
       } catch (error) {
         errors.push(error);
       }
-    } else if (serverProcess?.kill) {
+    } else if (serverProcess) {
       try {
         serverProcess.kill("SIGTERM");
       } catch (error) {
@@ -447,10 +447,10 @@ export async function bootRepo(repo: BootRepo, options: BootRepoOptions = {}): P
     }
 
     serverProcess = spawnProcess(devServer.command, { cwd: appRoot, env });
-    serverProcess.once?.("exit", (code, signal) => {
+    serverProcess.once("exit", (code, signal) => {
       serverExit = `Dev server exited before readiness with ${code === null ? `signal ${String(signal)}` : `exit code ${String(code)}`}`;
     });
-    serverProcess.once?.("error", (error) => {
+    serverProcess.once("error", (error) => {
       serverExit = `Dev server failed to start: ${error instanceof Error ? error.message : String(error)}`;
     });
     closeServerLog = attachLogStream(serverProcess, logPaths.server, tail);

--- a/corpus/harness/src/boot.ts
+++ b/corpus/harness/src/boot.ts
@@ -6,6 +6,8 @@ import type { Readable } from "node:stream";
 import { resolveAppRoot } from "./app-root.js";
 import type { DatabaseProvisioning, ManifestEntry } from "./manifest.js";
 import { createRunContext, type CorpusRunContext } from "./run-context.js";
+import { runCommand } from "./process.js";
+import { sleep } from "./util.js";
 
 export interface BootCommandResult {
   code: number | null;
@@ -76,69 +78,23 @@ export interface BootRepoOptions {
   lastLogLines?: number;
 }
 
-interface BinaryResult {
-  code: number | null;
-  signal: NodeJS.Signals | null;
-  stdout: string;
-  stderr: string;
-}
-
 const defaultReadinessTimeoutMs = 60_000;
 const defaultReadinessIntervalMs = 500;
 const defaultLastLogLines = 40;
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
-
-function commandResultOutput(result: BinaryResult | BootCommandResult): string {
+function commandResultOutput(result: BootCommandResult): string {
   return [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
 }
 
-function runCommand(command: string, options: { cwd: string; env: NodeJS.ProcessEnv }): Promise<BootCommandResult> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, {
-      cwd: options.cwd,
-      env: options.env,
-      shell: true,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    child.stdout.on("data", (chunk) => { stdout += chunk; });
-    child.stderr.on("data", (chunk) => { stderr += chunk; });
-    child.on("error", reject);
-    child.on("close", (code, signal) => resolve({ code, signal, stdout, stderr }));
-  });
-}
-
-function runBinary(command: string, args: readonly string[], options: { cwd: string; env: NodeJS.ProcessEnv }): Promise<BinaryResult> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
-      cwd: options.cwd,
-      env: options.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    child.stdout.on("data", (chunk) => { stdout += chunk; });
-    child.stderr.on("data", (chunk) => { stderr += chunk; });
-    child.on("error", reject);
-    child.on("close", (code, signal) => resolve({ code, signal, stdout, stderr }));
-  });
+function runBinary(command: string, args: readonly string[], options: { cwd: string; env: NodeJS.ProcessEnv }): Promise<BootCommandResult> {
+  return runCommand(command, { args, cwd: options.cwd, env: options.env });
 }
 
 async function checkedBinary(
   command: string,
   args: readonly string[],
   options: { cwd: string; env: NodeJS.ProcessEnv },
-): Promise<BinaryResult> {
+): Promise<BootCommandResult> {
   const result = await runBinary(command, args, options);
   if (result.code !== 0) {
     const output = commandResultOutput(result);
@@ -147,7 +103,7 @@ async function checkedBinary(
   return result;
 }
 
-async function appendDatabaseLog(logPath: string, command: string, result: BinaryResult | string): Promise<void> {
+async function appendDatabaseLog(logPath: string, command: string, result: BootCommandResult | string): Promise<void> {
   if (typeof result === "string") {
     await appendFile(logPath, `$ ${command}\n${result}${result.endsWith("\n") ? "" : "\n"}`);
     return;
@@ -196,7 +152,7 @@ async function defaultProvisionDatabase(
     const timeoutMs = database.readinessTimeoutMs ?? 30_000;
     const intervalMs = database.readinessIntervalMs ?? defaultReadinessIntervalMs;
     const attempts = Math.max(1, Math.ceil(timeoutMs / intervalMs));
-    let lastResult: BinaryResult | undefined;
+    let lastResult: BootCommandResult | undefined;
     for (let attempt = 0; attempt < attempts; attempt += 1) {
       lastResult = await runBinary("docker", readinessArgs, dockerOptions);
       await appendDatabaseLog(context.logPath, "docker exec ... pg_isready", lastResult);

--- a/corpus/harness/src/bootstrap.ts
+++ b/corpus/harness/src/bootstrap.ts
@@ -1,5 +1,4 @@
-import { spawn } from "node:child_process";
-import { access, mkdir, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { resolveAppRoot } from "./app-root.js";
@@ -7,6 +6,8 @@ import { normalizeBootstrapInstallCommand } from "./install-command.js";
 import { pnpmDeclaresBuiltDependencies } from "./pnpm-build-policy.js";
 import type { ManifestEntry } from "./manifest.js";
 import { createRunContext, type CorpusRunContext } from "./run-context.js";
+import { runCommand } from "./process.js";
+import { pathExists } from "./util.js";
 
 export type BootstrapRepo = Pick<ManifestEntry, "name" | "appDir" | "localPath" | "bootstrap">;
 
@@ -27,13 +28,6 @@ export interface BootstrapResult {
   repoDir: string;
   envPath: string;
   logs: BootstrapLogPaths;
-}
-
-interface CommandResult {
-  code: number | null;
-  signal: NodeJS.Signals | null;
-  stdout: string;
-  stderr: string;
 }
 
 const placeholderPattern = /\$\{(CORPUS_[A-Z0-9_]+)\}/g;
@@ -76,10 +70,6 @@ function logPaths(logsDir: string): BootstrapLogPaths {
   };
 }
 
-async function pathExists(file: string): Promise<boolean> {
-  return access(file).then(() => true, () => false);
-}
-
 const DEFAULT_RETRY_DELAY_MS = 5_000;
 
 // Small, deliberately narrow transient-failure class (nextcrm flake:
@@ -97,25 +87,6 @@ const TRANSIENT_BOOTSTRAP_FAILURE_PATTERNS: readonly RegExp[] = [
 
 function isTransientBootstrapFailure(output: string): boolean {
   return TRANSIENT_BOOTSTRAP_FAILURE_PATTERNS.some((pattern) => pattern.test(output));
-}
-
-function runInstallCommand(command: string, cwd: string, env: NodeJS.ProcessEnv): Promise<CommandResult> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, {
-      cwd,
-      env,
-      shell: true,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    child.stdout.on("data", (chunk) => { stdout += chunk; });
-    child.stderr.on("data", (chunk) => { stderr += chunk; });
-    child.on("error", reject);
-    child.on("close", (code, signal) => resolve({ code, signal, stdout, stderr }));
-  });
 }
 
 export async function bootstrapRepo(repo: BootstrapRepo, options: BootstrapOptions = {}): Promise<BootstrapResult> {
@@ -154,7 +125,7 @@ export async function bootstrapRepo(repo: BootstrapRepo, options: BootstrapOptio
     dropIgnoreWorkspace: hasPnpmWorkspace,
     pnpmConfig: repoCuratesBuilds ? ["--config.minimumReleaseAge=0"] : undefined,
   });
-  let result = await runInstallCommand(installCommand.command, repoDir, env);
+  let result = await runCommand(installCommand.command, { cwd: repoDir, env });
   const normalizationNote = installCommand.changed
     ? `Corpus harness normalized bootstrap install command from "${repo.bootstrap.installCommand}" to "${installCommand.command}" so lockfile updates are allowed.\n`
     : "";
@@ -168,7 +139,7 @@ export async function bootstrapRepo(repo: BootstrapRepo, options: BootstrapOptio
     const retryDelayMs = options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
     retryNote = `Bootstrap install for ${repo.name} failed with a transient-looking registry/resolver error on attempt 1; retrying once after ${retryDelayMs}ms...\n`;
     if (retryDelayMs > 0) await delay(retryDelayMs);
-    const retryResult = await runInstallCommand(installCommand.command, repoDir, env);
+    const retryResult = await runCommand(installCommand.command, { cwd: repoDir, env });
     retryNote += retryResult.code === 0
       ? `Bootstrap retry succeeded for ${repo.name} — transient registry/resolver failure recovered on attempt 2.\n`
       : `Bootstrap retry did not recover for ${repo.name} — attempt 2 failed too.\n`;

--- a/corpus/harness/src/cli.ts
+++ b/corpus/harness/src/cli.ts
@@ -1,5 +1,4 @@
-import { spawn } from "node:child_process";
-import { access, mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -47,7 +46,6 @@ import {
   type ScoredLayerRunResult,
 } from "./layers/scored.js";
 import {
-  corpusHostCommandEnv,
   runStructuralLayer as defaultRunStructuralLayer,
   type StructuralCheckResult,
   type StructuralCommandResult,
@@ -104,6 +102,8 @@ import {
   type KnowledgeEvalDeps,
   type KnowledgeEvalOptions,
 } from "./knowledge-eval/run.js";
+import { runHostCommand } from "./process.js";
+import { errorMessage, isRecord, pathExists, readOptional } from "./util.js";
 
 const usage = `Usage:
   pnpm corpus --help
@@ -259,7 +259,7 @@ function resolveDeps(deps: CorpusCliDependencies = {}): ResolvedDeps {
     discoverConfiguredGalleryRepoNames: deps.discoverConfiguredGalleryRepoNames ?? defaultDiscoverConfiguredGalleryRepoNames,
     captureGalleryRepo: deps.captureGalleryRepo ?? defaultCaptureGalleryRepo,
     writeGalleryHtml: deps.writeGalleryHtml ?? defaultWriteGalleryHtml,
-    commandRunner: deps.commandRunner ?? runShellCommand,
+    commandRunner: deps.commandRunner ?? runHostCommand,
     discoverAiConfiguredRepoNames: deps.discoverAiConfiguredRepoNames ?? defaultDiscoverAiConfiguredRepoNames,
     ensureAgentSdk: deps.ensureAgentSdk ?? defaultEnsureAgentSdk,
     createExtractionHarness: deps.createExtractionHarness ?? corpusExtractionHarness,
@@ -487,19 +487,6 @@ function selectedRepos(manifest: CorpusManifest, names: readonly string[]): Mani
   });
 }
 
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
-async function readOptional(file: string | undefined): Promise<string | undefined> {
-  if (!file) return undefined;
-  try {
-    return await readFile(file, "utf8");
-  } catch {
-    return undefined;
-  }
-}
-
 function artifactPaths(artifacts: InitStepArtifacts): string[] {
   return [artifacts.log, artifacts.diff, artifacts.tokenCost].filter((value): value is string => Boolean(value));
 }
@@ -550,14 +537,6 @@ function printBaselineUpdate(
   write(update.source.trimEnd());
 }
 
-async function pathExists(file: string): Promise<boolean> {
-  return access(file).then(() => true, () => false);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 async function detectPackageRunner(repoDir: string, packageManager: unknown): Promise<string> {
   if (typeof packageManager === "string") {
     if (packageManager.startsWith("pnpm@")) return "pnpm";
@@ -583,24 +562,7 @@ async function detectTypecheckCommand(repoDir: string): Promise<string | undefin
   return `${runner} typecheck`;
 }
 
-function runShellCommand(command: string, options: { cwd: string; env?: NodeJS.ProcessEnv }): Promise<StructuralCommandResult> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, {
-      cwd: options.cwd,
-      env: corpusHostCommandEnv(options.env),
-      shell: true,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    child.stdout.on("data", (chunk) => { stdout += chunk; });
-    child.stderr.on("data", (chunk) => { stderr += chunk; });
-    child.on("error", reject);
-    child.on("close", (code, signal) => resolve({ code, signal, stdout, stderr }));
-  });
-}
+
 
 function commandLogLabel(command: string, index: number): string {
   const orderedLabels = ["typecheck", "build"];

--- a/corpus/harness/src/cli.ts
+++ b/corpus/harness/src/cli.ts
@@ -636,6 +636,37 @@ async function captureHostBaseline(
   return { typecheck, build };
 }
 
+/** Checkout, resolve the app root, bootstrap, and inject the local Vendo build:
+ *  everything every command needs in place before `vendo init` can run. */
+async function prepareRepo(
+  repo: ManifestEntry,
+  context: CorpusRunContext,
+  injector: LocalVendoInjector,
+  deps: ResolvedDeps,
+): Promise<{ appRoot: string; bootstrap: BootstrapResult }> {
+  const checkoutDir = await deps.ensureRepoCheckout(repo, { context, workspaceRoot: deps.workspaceRoot });
+  const appRoot = resolveAppRoot(repo, checkoutDir);
+  const bootstrap = await deps.bootstrapRepo(repo, { context, env: deps.env });
+  await injector.inject(repo);
+  return { appRoot, bootstrap };
+}
+
+/** Run init once and refuse to continue on a failure. The sweep does NOT use
+ *  this: it runs init twice with AI polish on and feeds a non-zero exit code to
+ *  the structural layer as a finding rather than throwing. */
+async function runCheckedInit(
+  repo: ManifestEntry,
+  context: CorpusRunContext,
+  deps: ResolvedDeps,
+  artifactPrefix: string,
+): Promise<InitStepResult> {
+  const init = await deps.runInit(repo, { context, env: deps.env, artifactPrefix });
+  if (init.exitCode !== 0) {
+    throw new Error(`vendo init failed for ${repo.name}; see ${init.artifacts.log}`);
+  }
+  return init;
+}
+
 async function runRepoThroughLayerOne(
   repo: ManifestEntry,
   options: RunCommandOptions,
@@ -646,12 +677,9 @@ async function runRepoThroughLayerOne(
   const logPaths: string[] = [];
 
   try {
-    const checkoutDir = await deps.ensureRepoCheckout(repo, { context, workspaceRoot: deps.workspaceRoot });
-    const appRoot = resolveAppRoot(repo, checkoutDir);
-    const bootstrap = await deps.bootstrapRepo(repo, { context, env: deps.env });
+    const { appRoot, bootstrap } = await prepareRepo(repo, context, injector, deps);
     logPaths.push(bootstrap.logs.stdout, bootstrap.logs.stderr);
 
-    const injectResult = await injector.inject(repo);
     const typecheckCommand = repo.bootstrap.typecheckCommand ?? await detectTypecheckCommand(appRoot);
     const buildCommand = repo.bootstrap.buildCommand;
     const baselineCommands = createLoggedCommandRunner(context.logsDir(repo.name), "baseline", deps.commandRunner);
@@ -831,20 +859,10 @@ async function runBootCommand(options: BootCommandOptions, deps: ResolvedDeps): 
 
   const context = deps.createContext();
   const injector = deps.createInjector({ context, workspaceRoot: deps.workspaceRoot });
-  await deps.ensureRepoCheckout(repo, { context, workspaceRoot: deps.workspaceRoot });
-  await deps.bootstrapRepo(repo, { context, env: deps.env });
-
-  const injectResult = await injector.inject(repo);
-  const init = await deps.runInit(repo, {
-    context,
-    env: deps.env,
-    artifactPrefix: "boot.init",
-  });
-  if (init.exitCode !== 0) {
-    throw new Error(`vendo init failed for ${repo.name}; see ${init.artifacts.log}`);
-  }
-  await deps.applyVendoRootPaste(injectResult.repoDir, repo.framework, await readOptional(init.artifacts.log) ?? "");
-  await deps.prepareE2eRepo(repo, injectResult.repoDir, context.logsDir(repo.name));
+  const { appRoot } = await prepareRepo(repo, context, injector, deps);
+  const init = await runCheckedInit(repo, context, deps, "boot.init");
+  await deps.applyVendoRootPaste(appRoot, repo.framework, await readOptional(init.artifacts.log) ?? "");
+  await deps.prepareE2eRepo(repo, appRoot, context.logsDir(repo.name));
 
   const handle = await deps.bootRepo(repo, {
     context,
@@ -892,18 +910,8 @@ async function runGalleryCommand(options: GalleryCommandOptions, deps: ResolvedD
     let result: GalleryRepoResult | undefined;
     let failure: string | undefined;
     try {
-      const checkoutDir = await deps.ensureRepoCheckout(repo, { context, workspaceRoot: deps.workspaceRoot });
-      const appRoot = resolveAppRoot(repo, checkoutDir);
-      await deps.bootstrapRepo(repo, { context, env: deps.env });
-      await injector.inject(repo);
-      const init = await deps.runInit(repo, {
-        context,
-        env: deps.env,
-        artifactPrefix: "gallery.init",
-      });
-      if (init.exitCode !== 0) {
-        throw new Error(`vendo init failed for ${repo.name}; see ${init.artifacts.log}`);
-      }
+      const { appRoot } = await prepareRepo(repo, context, injector, deps);
+      const init = await runCheckedInit(repo, context, deps, "gallery.init");
       await deps.applyVendoRootPaste(appRoot, repo.framework, await readOptional(init.artifacts.log) ?? "");
       await deps.prepareE2eRepo(repo, appRoot, context.logsDir(repo.name));
       // Build only when the dev server serves prebuilt output (manifest
@@ -995,14 +1003,8 @@ async function runAiCommand(options: AiCommandOptions, deps: ResolvedDeps): Prom
   const results: AiRepoResult[] = [];
   for (const repo of repos) {
     try {
-      const checkoutDir = await deps.ensureRepoCheckout(repo, { context, workspaceRoot: deps.workspaceRoot });
-      const appRoot = resolveAppRoot(repo, checkoutDir);
-      await deps.bootstrapRepo(repo, { context, env: deps.env });
-      await injector.inject(repo);
-      const init = await deps.runInit(repo, { context, env: deps.env, artifactPrefix: "ai.init" });
-      if (init.exitCode !== 0) {
-        throw new Error(`vendo init failed for ${repo.name}; see ${init.artifacts.log}`);
-      }
+      const { appRoot } = await prepareRepo(repo, context, injector, deps);
+      await runCheckedInit(repo, context, deps, "ai.init");
       results.push(await deps.runAiRepoMatrix({
         repoName: repo.name,
         appRoot,

--- a/corpus/harness/src/clone.ts
+++ b/corpus/harness/src/clone.ts
@@ -1,9 +1,9 @@
-import { spawn } from "node:child_process";
 import { realpathSync } from "node:fs";
 import { cp, mkdir, realpath, rm } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ManifestEntry } from "./manifest.js";
+import { runCommand, type CommandResult } from "./process.js";
 import { createRunContext, type CorpusRunContext } from "./run-context.js";
 
 export type CloneRepo = Pick<ManifestEntry, "name" | "gitUrl" | "pinnedSha" | "localPath">;
@@ -12,12 +12,6 @@ export interface EnsureRepoCheckoutOptions {
   context?: CorpusRunContext;
   gitBin?: string;
   workspaceRoot?: string;
-}
-
-interface CommandResult {
-  code: number | null;
-  stdout: string;
-  stderr: string;
 }
 
 interface FetchAttempt {
@@ -29,27 +23,17 @@ interface FetchAttempt {
 const defaultWorkspaceRoot = path.resolve(fileURLToPath(new URL("../../../", import.meta.url)));
 
 function runGit(gitBin: string, args: readonly string[], cwd: string): Promise<CommandResult> {
-  return new Promise((resolve, reject) => {
-    const targetDir = args[0] === "-C" && args[1] ? args[1] : cwd;
-    const child = spawn(gitBin, args, {
-      cwd,
-      env: {
-        ...process.env,
-        // All corpus clones are direct children of .repos. Even if a caller
-        // forgets the toplevel identity check, Git must not discover beyond
-        // that cache boundary.
-        GIT_CEILING_DIRECTORIES: realpathSync(path.dirname(targetDir)),
-      },
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    child.stdout.on("data", (chunk) => { stdout += chunk; });
-    child.stderr.on("data", (chunk) => { stderr += chunk; });
-    child.on("error", reject);
-    child.on("close", (code) => resolve({ code, stdout, stderr }));
+  const targetDir = args[0] === "-C" && args[1] ? args[1] : cwd;
+  return runCommand(gitBin, {
+    args,
+    cwd,
+    env: {
+      ...process.env,
+      // All corpus clones are direct children of .repos. Even if a caller
+      // forgets the toplevel identity check, Git must not discover beyond
+      // that cache boundary.
+      GIT_CEILING_DIRECTORIES: realpathSync(path.dirname(targetDir)),
+    },
   });
 }
 

--- a/corpus/harness/src/doctor-live.ts
+++ b/corpus/harness/src/doctor-live.ts
@@ -1,7 +1,7 @@
-import { spawn } from "node:child_process";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { ScorecardCheck } from "./scorecard.js";
+import { runCommand } from "./process.js";
 
 export interface LiveDoctorCommandResult {
   code: number | null;
@@ -35,21 +35,7 @@ function defaultSpawnDoctor(
   args: readonly string[],
   options: { cwd: string; env: NodeJS.ProcessEnv },
 ): Promise<LiveDoctorCommandResult> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
-      cwd: options.cwd,
-      env: options.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    child.stdout.on("data", (chunk) => { stdout += chunk; });
-    child.stderr.on("data", (chunk) => { stderr += chunk; });
-    child.on("error", reject);
-    child.on("close", (code, signal) => resolve({ code, signal, stdout, stderr }));
-  });
+  return runCommand(command, { args, cwd: options.cwd, env: options.env });
 }
 
 function commandStatus(result: LiveDoctorCommandResult): string {

--- a/corpus/harness/src/e2e-prep.ts
+++ b/corpus/harness/src/e2e-prep.ts
@@ -1,9 +1,10 @@
-import { access, copyFile, mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { ManifestEntry } from "./manifest.js";
 import { mountCorpusOverlay } from "./e2e-prep/overlay-mount.js";
 import { vendoRouteFilePath } from "./e2e-prep/route-path.js";
 import { prepareSkateshopE2eRepo } from "./e2e-prep/skateshop.js";
+import { escapeRegex, isRecord, pathExists } from "./util.js";
 
 // Umami authenticates its API with a Bearer token the app keeps in
 // localStorage. Chat tool calls now execute SERVER-side (route bindings,
@@ -930,7 +931,7 @@ async function ensureEnvValue(envPath: string, key: string, value: string): Prom
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
   }
-  if (new RegExp(`^${escapeRegExp(key)}=`, "m").test(source)) return;
+  if (new RegExp(`^${escapeRegex(key)}=`, "m").test(source)) return;
   const separator = source === "" || source.endsWith("\n") ? "" : "\n";
   await writeFile(envPath, `${source}${separator}${key}=${value}\n`);
 }
@@ -953,14 +954,3 @@ async function ensureFile(filePath: string, source: string): Promise<void> {
   }
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function pathExists(filePath: string): Promise<boolean> {
-  return access(filePath).then(() => true, () => false);
-}

--- a/corpus/harness/src/gallery.ts
+++ b/corpus/harness/src/gallery.ts
@@ -271,7 +271,7 @@ export async function createPlaywrightGalleryDriver(): Promise<GalleryCaptureDri
         const targetUrl = new URL(input.screen.path, input.readinessUrl).toString();
         await prepareLayer3Page(
           input.repoName,
-          page as unknown as E2ePage,
+          page,
           nativeScreenTimeoutMs,
           targetUrl,
           galleryNavigationOptions(nativeScreenTimeoutMs),
@@ -309,18 +309,18 @@ export async function createPlaywrightGalleryDriver(): Promise<GalleryCaptureDri
         );
         await prepareLayer3Page(
           input.repoName,
-          page as unknown as E2ePage,
+          page,
           Math.min(timeoutMs, 30_000),
           targetUrl,
           galleryNavigationOptions(timeoutMs),
         );
-        await openVendoSurface(page as unknown as E2ePage, Math.min(timeoutMs, 30_000));
+        await openVendoSurface(page, Math.min(timeoutMs, 30_000));
         const initialGeneratedNodes = await page.locator(firstPaintSelector).count();
         const initialGenerationTools = await page.locator(generationToolSelector).count();
         const startedAt = performance.now();
-        await sendPrompt(page as unknown as E2ePage, input.prompt.prompt);
+        await sendPrompt(page, input.prompt.prompt);
         let stopApprovalWatcher = false;
-        const approvalWatcher = approveGenerationIfRequested(page as unknown as E2ePage, {
+        const approvalWatcher = approveGenerationIfRequested(page, {
           timeoutMs,
           shouldStop: () => stopApprovalWatcher,
         });
@@ -344,7 +344,7 @@ export async function createPlaywrightGalleryDriver(): Promise<GalleryCaptureDri
         await page.screenshot({ path: firstPaintPath, fullPage: false });
 
         const remainingMs = Math.max(1_000, timeoutMs - firstPaint);
-        await waitForIdle(page as unknown as E2ePage, remainingMs);
+        await waitForIdle(page, remainingMs);
         const settledStartedAt = performance.now();
         while (
           await page.locator(firstPaintSelector).count() <= initialGeneratedNodes
@@ -403,11 +403,9 @@ export async function approveGenerationIfRequested(
   }));
   const startedAt = performance.now();
   while (!options.shouldStop?.() && performance.now() - startedAt < options.timeoutMs) {
-    const matches = page.locator(generationApprovalSelector);
-    const approve = matches.first ? matches.first() : matches;
+    const approve = page.locator(generationApprovalSelector).first();
     try {
       if (await approve.count() > 0) {
-        if (!approve.click) throw new Error("Gallery approval control is not clickable.");
         await approve.click();
         return true;
       }

--- a/corpus/harness/src/gallery.ts
+++ b/corpus/harness/src/gallery.ts
@@ -11,6 +11,7 @@ import {
   type E2eNavigationOptions,
   type E2ePage,
 } from "./layers/e2e.js";
+import { errorMessage } from "./util.js";
 
 const safeIdPattern = /^[a-z0-9][a-z0-9-]*$/;
 const nativeScreenSchema = z.object({
@@ -648,10 +649,6 @@ function escapeHtml(value: string): string {
     .replaceAll(">", "&gt;")
     .replaceAll('"', "&quot;")
     .replaceAll("'", "&#39;");
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }
 
 const galleryCss = `

--- a/corpus/harness/src/init-step.ts
+++ b/corpus/harness/src/init-step.ts
@@ -1,9 +1,9 @@
-import { spawn } from "node:child_process";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveAppRoot } from "./app-root.js";
 import { createRunContext, type CorpusRunContext } from "./run-context.js";
+import { runCommand, type CommandResult } from "./process.js";
 
 export interface InitStepRepo {
   name: string;
@@ -38,14 +38,6 @@ export interface RunVendoInitStepOptions {
   aiPolish?: boolean;
 }
 
-interface CommandResult {
-  code: number | null;
-  signal: NodeJS.Signals | null;
-  stdout: string;
-  stderr: string;
-  combined: string;
-}
-
 const defaultWorkspaceRoot = path.resolve(fileURLToPath(new URL("../../../", import.meta.url)));
 const defaultCliBin = path.join(defaultWorkspaceRoot, "packages/vendo/bin/vendo.mjs");
 
@@ -72,36 +64,6 @@ function initArgs(repoDir: string, options: RunVendoInitStepOptions): string[] {
   return args;
 }
 
-function runCommand(
-  command: string,
-  args: readonly string[],
-  cwd: string,
-  env: NodeJS.ProcessEnv,
-): Promise<CommandResult> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
-      cwd,
-      env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    let stdout = "";
-    let stderr = "";
-    let combined = "";
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    child.stdout.on("data", (chunk: string) => {
-      stdout += chunk;
-      combined += chunk;
-    });
-    child.stderr.on("data", (chunk: string) => {
-      stderr += chunk;
-      combined += chunk;
-    });
-    child.on("error", reject);
-    child.on("close", (code, signal) => resolve({ code, signal, stdout, stderr, combined }));
-  });
-}
-
 function commandOutput(result: CommandResult): string {
   return (result.stderr || result.stdout).trim();
 }
@@ -112,7 +74,7 @@ async function checkedCommand(
   cwd: string,
   env: NodeJS.ProcessEnv,
 ): Promise<CommandResult> {
-  const result = await runCommand(command, args, cwd, env);
+  const result = await runCommand(command, { args, cwd, env });
   if (result.code !== 0) {
     const output = commandOutput(result);
     throw new Error(`${command} ${args.join(" ")} failed${output ? `:\n${output}` : ""}`);
@@ -197,7 +159,7 @@ export async function runVendoInitStep(
     ? await captureGitTree(repoDir, logsDir, options.gitBin ?? "git", env)
     : undefined;
   const startedAt = Date.now();
-  const result = await runCommand(cliCommand, cliArgs, defaultWorkspaceRoot, env);
+  const result = await runCommand(cliCommand, { args: cliArgs, cwd: defaultWorkspaceRoot, env });
   const durationMs = Date.now() - startedAt;
   await writeFile(artifacts.log, result.combined);
 

--- a/corpus/harness/src/inject.ts
+++ b/corpus/harness/src/inject.ts
@@ -1,4 +1,3 @@
-import { spawn } from "node:child_process";
 import { access, copyFile, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import {
@@ -12,15 +11,11 @@ import { normalizePostInjectionInstallCommand } from "./install-command.js";
 import { pnpmDeclaresBuiltDependencies } from "./pnpm-build-policy.js";
 import type { ManifestEntry } from "./manifest.js";
 import { createRunContext, type CorpusRunContext } from "./run-context.js";
+import { runCommand } from "./process.js";
+import { escapeRegex, isRecord, pathExists, readOptional } from "./util.js";
 
 export type InjectRepo = Pick<ManifestEntry, "name" | "appDir"> & Partial<Pick<ManifestEntry, "bootstrap">>;
 export type PackWorkspacePackage = LocalPackRunner;
-
-export interface InjectCommandResult {
-  code: number | null;
-  stdout: string;
-  stderr: string;
-}
 
 export interface LocalVendoInjectResult extends LocalVendoInstallSummary {
   repoDir: string;
@@ -40,36 +35,8 @@ export interface CreateLocalVendoInjectorOptions {
   log?: (message: string) => void;
 }
 
-function runCommand(command: string, args: readonly string[], cwd: string): Promise<InjectCommandResult> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    child.stdout.on("data", (chunk) => { stdout += chunk; });
-    child.stderr.on("data", (chunk) => { stderr += chunk; });
-    child.on("error", reject);
-    child.on("close", (code) => resolve({ code, stdout, stderr }));
-  });
-}
-
-function runShellCommand(command: string, cwd: string): Promise<InjectCommandResult> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, { cwd, shell: true, stdio: ["ignore", "pipe", "pipe"] });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    child.stdout.on("data", (chunk) => { stdout += chunk; });
-    child.stderr.on("data", (chunk) => { stderr += chunk; });
-    child.on("error", reject);
-    child.on("close", (code) => resolve({ code, stdout, stderr }));
-  });
-}
-
 async function checkedShellCommand(command: string, cwd: string): Promise<void> {
-  const result = await runShellCommand(command, cwd);
+  const result = await runCommand(command, { cwd });
   if (result.code !== 0) {
     const output = [result.stderr, result.stdout].filter(Boolean).join("\n");
     throw new Error(`${command} failed in ${cwd} with exit code ${result.code ?? "unknown"}:\n${output}`);
@@ -77,7 +44,7 @@ async function checkedShellCommand(command: string, cwd: string): Promise<void> 
 }
 
 async function defaultBuildWorkspace(workspaceRoot: string): Promise<void> {
-  const result = await runCommand("pnpm", ["build"], workspaceRoot);
+  const result = await runCommand("pnpm", { args: ["build"], cwd: workspaceRoot });
   if (result.code !== 0) {
     throw new Error(`pnpm build failed in ${workspaceRoot}:\n${result.stderr || result.stdout}`);
   }
@@ -88,7 +55,7 @@ async function defaultPackWorkspacePackage(
   opts: { repoDir: string; vendorDir: string; fileName: string },
 ): Promise<void> {
   await mkdir(opts.vendorDir, { recursive: true });
-  const result = await runCommand("pnpm", ["-C", pkg.dir, "pack", "--pack-destination", opts.vendorDir], opts.repoDir);
+  const result = await runCommand("pnpm", { args: ["-C", pkg.dir, "pack", "--pack-destination", opts.vendorDir], cwd: opts.repoDir });
   if (result.code !== 0) {
     throw new Error(`pnpm pack failed for ${pkg.name}:\n${result.stderr || result.stdout}`);
   }
@@ -105,10 +72,6 @@ function assertPathHasNoSpaces(label: string, value: string): void {
   }
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 function stringRecord(value: unknown): Record<string, string> {
   if (!isRecord(value)) return {};
   return Object.fromEntries(Object.entries(value).filter((entry): entry is [string, string] => typeof entry[1] === "string"));
@@ -122,10 +85,6 @@ function packageTarballPrefix(name: string): string {
   return name.startsWith("@") ? name.slice(1).replace("/", "-") : name;
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 function isVendoPackageName(name: string): boolean {
   return name === "vendoai" || name.startsWith("@vendoai/");
 }
@@ -134,18 +93,6 @@ function lockfileMentionsVendoPackage(lockfile: string): boolean {
   return lockfile.includes("@vendoai/")
     || /(^|\n)\s*['"]?vendoai['"]?:/m.test(lockfile)
     || /\/vendoai\/[^/\s]+/i.test(lockfile);
-}
-
-async function readOptional(file: string): Promise<string | null> {
-  try {
-    return await readFile(file, "utf8");
-  } catch {
-    return null;
-  }
-}
-
-async function pathExists(file: string): Promise<boolean> {
-  return access(file).then(() => true, () => false);
 }
 
 async function findPnpmWorkspaceRoot(checkoutDir: string, targetDir: string): Promise<string | undefined> {
@@ -194,7 +141,7 @@ function installCommandSource(repo: InjectRepo, summary: LocalVendoInstallSummar
 async function tarballFileForPackage(vendorDir: string, name: string): Promise<string> {
   const entries = await readdir(vendorDir);
   const prefix = packageTarballPrefix(name);
-  const tarballPattern = new RegExp(`^${escapeRegExp(prefix)}-\\d.*\\.tgz$`);
+  const tarballPattern = new RegExp(`^${escapeRegex(prefix)}-\\d.*\\.tgz$`);
   const matches = entries.filter((entry) => tarballPattern.test(entry)).sort();
   if (matches.length !== 1) {
     throw new Error(`expected exactly one local tarball for ${name} in ${vendorDir}, found ${matches.length}`);

--- a/corpus/harness/src/install-eval/doctor.ts
+++ b/corpus/harness/src/install-eval/doctor.ts
@@ -1,8 +1,10 @@
 import { spawn } from "node:child_process";
-import { access, mkdir, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { InstallEvalFixture } from "./fixtures.js";
 import type { DoctorOutcome } from "./score.js";
+import { runCommand, type CommandResult } from "../process.js";
+import { pathExists } from "../util.js";
 
 /**
  * The harness runs `vendo doctor --json` ITSELF at the end of every run
@@ -17,10 +19,6 @@ import type { DoctorOutcome } from "./score.js";
 const CLI_MISSING_CODE = "vendo-cli-missing";
 const SERVER_UNREACHABLE_CODE = "dev-server-unreachable";
 const PORT_OCCUPIED_CODE = "port-already-occupied";
-
-async function pathExists(file: string): Promise<boolean> {
-  return access(file).then(() => true, () => false);
-}
 
 interface DevServerHandle {
   stop(): Promise<void>;
@@ -76,26 +74,6 @@ function startDevServer(
       await writeFile(logPath, chunks.join(""));
     },
   };
-}
-
-interface CommandResult {
-  code: number | null;
-  stdout: string;
-  stderr: string;
-}
-
-function runCommand(command: string, args: readonly string[], cwd: string, env: NodeJS.ProcessEnv): Promise<CommandResult> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, args, { cwd, env, stdio: ["ignore", "pipe", "pipe"] });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    child.stdout.on("data", (chunk) => { stdout += chunk; });
-    child.stderr.on("data", (chunk) => { stderr += chunk; });
-    child.on("error", reject);
-    child.on("close", (code) => resolve({ code, stdout, stderr }));
-  });
 }
 
 interface DoctorJsonReport {
@@ -211,12 +189,11 @@ export async function runFixtureDoctor(options: RunFixtureDoctorOptions): Promis
         detail: `dev server never became ready at ${options.fixture.devServer.readinessUrl}`,
       };
     }
-    const result = await runCommand(
-      doctorCommand.command,
-      [...doctorCommand.prefixArgs, "doctor", ".", "--json", "--url", options.fixture.doctorUrl],
-      options.fixtureDir,
+    const result = await runCommand(doctorCommand.command, {
+      args: [...doctorCommand.prefixArgs, "doctor", ".", "--json", "--url", options.fixture.doctorUrl],
+      cwd: options.fixtureDir,
       env,
-    );
+    });
     await writeFile(
       path.join(options.logsDir, "install-eval.doctor.json.log"),
       `$ vendo doctor . --json --url ${options.fixture.doctorUrl}\n${result.stdout}\n${result.stderr}`,

--- a/corpus/harness/src/install-eval/fixtures.ts
+++ b/corpus/harness/src/install-eval/fixtures.ts
@@ -1,9 +1,10 @@
-import { spawn } from "node:child_process";
 import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { ensureRepoCheckout } from "../clone.js";
 import { loadManifest } from "../manifest.js";
 import { createRunContext } from "../run-context.js";
+import { runCommand, type CommandResult } from "../process.js";
+import { isRecord } from "../util.js";
 
 /**
  * Install-eval fixtures: real host apps copied to a clean directory with the
@@ -122,10 +123,6 @@ const EXCLUDED_ROOT_FILES = new Set([
   "bun.lockb",
 ]);
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 function isVendoPackageName(name: string): boolean {
   return name === "vendoai" || name.startsWith("@vendoai/");
 }
@@ -160,24 +157,8 @@ export function stripVendoFromPackageJson(source: string): string {
   return `${JSON.stringify(pkg, null, 2)}\n`;
 }
 
-interface CommandResult {
-  code: number | null;
-  stdout: string;
-  stderr: string;
-}
-
 function runGit(args: readonly string[], cwd: string): Promise<CommandResult> {
-  return new Promise((resolve, reject) => {
-    const child = spawn("git", args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    child.stdout.on("data", (chunk) => { stdout += chunk; });
-    child.stderr.on("data", (chunk) => { stderr += chunk; });
-    child.on("error", reject);
-    child.on("close", (code) => resolve({ code, stdout, stderr }));
-  });
+  return runCommand("git", { args, cwd });
 }
 
 async function checkedGit(args: readonly string[], cwd: string): Promise<void> {

--- a/corpus/harness/src/install-eval/pack.ts
+++ b/corpus/harness/src/install-eval/pack.ts
@@ -1,7 +1,8 @@
-import { spawn } from "node:child_process";
-import { access, mkdir, readFile, readdir } from "node:fs/promises";
+import { mkdir, readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 import { LOCAL_VENDO_PACKAGE_NAMES } from "../local-pack.js";
+import { runCommand, type CommandResult } from "../process.js";
+import { pathExists } from "../util.js";
 
 /**
  * Pack the whole publishable Vendo set (the same closure the corpus injector
@@ -16,30 +17,10 @@ function tarballFileName(name: string, version: string): string {
   return `${base}-${version}.tgz`;
 }
 
-interface CommandResult {
-  code: number | null;
-  stdout: string;
-  stderr: string;
-}
-
 export type PackCommandRunner = (command: string, args: readonly string[], cwd: string) => Promise<CommandResult>;
 
 function defaultRunCommand(command: string, args: readonly string[], cwd: string): Promise<CommandResult> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    child.stdout.on("data", (chunk) => { stdout += chunk; });
-    child.stderr.on("data", (chunk) => { stderr += chunk; });
-    child.on("error", reject);
-    child.on("close", (code) => resolve({ code, stdout, stderr }));
-  });
-}
-
-async function pathExists(file: string): Promise<boolean> {
-  return access(file).then(() => true, () => false);
+  return runCommand(command, { args, cwd });
 }
 
 export interface PackWorkspaceVendoTarballsOptions {

--- a/corpus/harness/src/layers/e2e.test.ts
+++ b/corpus/harness/src/layers/e2e.test.ts
@@ -60,41 +60,50 @@ class FakeLocator implements E2eLocator {
   }
 }
 
-class FakePage implements E2ePage {
-  constructor(
-    private readonly counts: Record<string, number>,
-    private readonly bodyText = "",
-    private readonly frameCounts: Record<string, number> = {},
-  ) {}
+/** A complete page: every member the layer can reach is present, so a test can
+    never accidentally exercise a degraded path a real Playwright page has no
+    way to take. Tests override only the members they drive. */
+function fakePage(overrides: Partial<E2ePage>): E2ePage {
+  return {
+    async goto() {},
+    locator: () => new FakeLocator(0),
+    getByRole: () => new FakeLocator(0),
+    getByTestId: () => new FakeLocator(0),
+    frameLocator: () => fakeFrame({}),
+    keyboard: { press: async () => {} },
+    on: () => {},
+    off: () => {},
+    screenshot: async () => {},
+    close: async () => {},
+    ...overrides,
+  };
+}
 
-  async goto(_url: string, _options?: E2eNavigationOptions): Promise<void> {}
+function fakeFrame(counts: Record<string, number>): E2eFrameLocator {
+  return {
+    locator: (selector: string) => new FakeLocator(counts[selector] ?? 0),
+    getByRole: (role: string) => new FakeLocator(counts[`role:${role}`] ?? 0),
+    getByTestId: (testId: string) => new FakeLocator(counts[`testid:${testId}`] ?? 0),
+  };
+}
 
-  locator(selector: string): E2eLocator {
-    if (selector === "body") return new FakeLocator(1, this.bodyText);
-    if (selector.includes(".fl-toast")) return new FakeLocator(this.counts[".fl-toast"] ?? 0, this.bodyText);
-    const key = Object.keys(this.counts).find((candidate) => selector.includes(candidate));
-    return new FakeLocator(key ? this.counts[key] ?? 0 : 0);
-  }
-
-  getByRole(role: string): E2eLocator {
-    return new FakeLocator(this.counts[`role:${role}`] ?? 0);
-  }
-
-  getByLabel(): E2eLocator {
-    return new FakeLocator(this.counts.label ?? 0);
-  }
-
-  getByTestId(testId: string): E2eLocator {
-    return new FakeLocator(this.counts[`testid:${testId}`] ?? 0);
-  }
-
-  frameLocator(): E2eFrameLocator {
-    return {
-      locator: (selector: string) => new FakeLocator(this.frameCounts[selector] ?? 0),
-      getByRole: (role: string) => new FakeLocator(this.frameCounts[`role:${role}`] ?? 0),
-      getByTestId: (testId: string) => new FakeLocator(this.frameCounts[`testid:${testId}`] ?? 0),
-    };
-  }
+/** A page whose locators answer from a selector-substring count table. */
+function countingPage(
+  counts: Record<string, number>,
+  bodyText = "",
+  frameCounts: Record<string, number> = {},
+): E2ePage {
+  return fakePage({
+    locator(selector: string) {
+      if (selector === "body") return new FakeLocator(1, bodyText);
+      if (selector.includes(".fl-toast")) return new FakeLocator(counts[".fl-toast"] ?? 0, bodyText);
+      const key = Object.keys(counts).find((candidate) => selector.includes(candidate));
+      return new FakeLocator(key ? counts[key] ?? 0 : 0);
+    },
+    getByRole: (role: string) => new FakeLocator(counts[`role:${role}`] ?? 0),
+    getByTestId: (testId: string) => new FakeLocator(counts[`testid:${testId}`] ?? 0),
+    frameLocator: () => fakeFrame(frameCounts),
+  });
 }
 
 function signals(partial: Partial<E2eObservableSignals>): E2eObservableSignals {
@@ -138,7 +147,7 @@ describe("conversation suite parsing", () => {
 describe("prepareLayer3Page", () => {
   it("forwards an explicit DOM-ready navigation policy to the host page", async () => {
     const navigations: Array<{ url: string; options?: { waitUntil?: "load" | "domcontentloaded"; timeout?: number } }> = [];
-    const page = new FakePage({});
+    const page = countingPage({});
     page.goto = async (url, options) => { navigations.push({ url, options }); };
 
     await prepareLayer3Page("express-host", page, 30_000, "http://127.0.0.1:3210/", {
@@ -174,7 +183,7 @@ describe("evaluateAssertion", () => {
     const observed = signals({
       views: [{ component: "DataTable", role: "table", testId: "ui-node", text: "Pricing" }],
     });
-    const page = new FakePage({ "role:list": 1, "testid:ui-node": 1 });
+    const page = countingPage({ "role:list": 1, "testid:ui-node": 1 });
 
     await expect(evaluateAssertion({ kind: "view-rendered", component: "DataTable", role: "table" }, observed))
       .resolves.toMatchObject({ pass: true });
@@ -185,20 +194,20 @@ describe("evaluateAssertion", () => {
   });
 
   it("matches generated view roles inside the Vendo stage iframe", async () => {
-    const page = new FakePage({}, "", { "role:table": 1 });
+    const page = countingPage({}, "", { "role:table": 1 });
 
     await expect(evaluateAssertion({ kind: "view-rendered", role: "table" }, signals({}), page))
       .resolves.toMatchObject({ pass: true });
   });
 
   it("evaluates approval cards and no-error-toast from fake page/signal objects", async () => {
-    const approvalPage = new FakePage({ "Approval request": 1 });
-    const genericAlertPage = new FakePage({ '[role="alert"]': 1 });
-    const shellErrorPage = new FakePage({ ".fl-error": 1 });
-    const explicitDataErrorPage = new FakePage({ '[data-error="true"]': 1 });
-    const benignDataErrorPage = new FakePage({ "[data-error]": 1 });
-    const stageErrorPage = new FakePage({}, "", { "[data-error]:visible, [data-error-boundary]:visible": 1 });
-    const statusToastPage = new FakePage({ ".fl-toast": 1 }, "Saved successfully");
+    const approvalPage = countingPage({ "Approval request": 1 });
+    const genericAlertPage = countingPage({ '[role="alert"]': 1 });
+    const shellErrorPage = countingPage({ ".fl-error": 1 });
+    const explicitDataErrorPage = countingPage({ '[data-error="true"]': 1 });
+    const benignDataErrorPage = countingPage({ "[data-error]": 1 });
+    const stageErrorPage = countingPage({}, "", { "[data-error]:visible, [data-error-boundary]:visible": 1 });
+    const statusToastPage = countingPage({ ".fl-toast": 1 }, "Saved successfully");
     const approvalAssertion: ConversationAssertion = { kind: "approval-card-shown" };
 
     await expect(evaluateAssertion(approvalAssertion, signals({}), approvalPage))
@@ -222,8 +231,8 @@ describe("evaluateAssertion", () => {
   });
 
   it("reads several visible toasts at once instead of tripping Playwright's strict mode", async () => {
-    const twoBenignToasts = new FakePage({ ".fl-toast": 2 }, "Saved successfully");
-    const twoErrorToasts = new FakePage({ ".fl-toast": 2 }, "Upload failed");
+    const twoBenignToasts = countingPage({ ".fl-toast": 2 }, "Saved successfully");
+    const twoErrorToasts = countingPage({ ".fl-toast": 2 }, "Upload failed");
 
     await expect(evaluateAssertion({ kind: "no-error-toast" }, signals({}), twoBenignToasts))
       .resolves.toMatchObject({ pass: true });
@@ -298,7 +307,7 @@ describe("runE2eLayer", () => {
 
     let launcherClicks = 0;
     let promptSent = false;
-    const page: E2ePage = {
+    const page = fakePage({
       async goto() {},
       locator(selector: string) {
         if (selector === "body" || selector.includes("[role='dialog']")) return new FakeLocator(1, "dialog ready");
@@ -323,15 +332,7 @@ describe("runE2eLayer", () => {
         }
         return new FakeLocator(0);
       },
-      getByLabel() {
-        return new FakeLocator(1, "", {
-          fill: () => {},
-          press: () => {
-            promptSent = true;
-          },
-        });
-      },
-    };
+    });
 
     const result = await runE2eLayer({
       repoName: "fixture",
@@ -376,7 +377,7 @@ describe("runE2eLayer", () => {
     const gotoUrls: string[] = [];
     let usernameVisible = true;
     let promptSent = false;
-    const page: E2ePage = {
+    const page = fakePage({
       async goto(url: string) {
         gotoUrls.push(url);
       },
@@ -409,15 +410,7 @@ describe("runE2eLayer", () => {
         }
         return new FakeLocator(0);
       },
-      getByLabel() {
-        return new FakeLocator(1, "", {
-          fill: () => {},
-          press: () => {
-            promptSent = true;
-          },
-        });
-      },
-    };
+    });
 
     const result = await runE2eLayer({
       repoName: "umami",
@@ -464,7 +457,7 @@ describe("runE2eLayer", () => {
 
     const gotoUrls: string[] = [];
     let promptSent = false;
-    const page: E2ePage = {
+    const page = fakePage({
       async goto(url: string) {
         gotoUrls.push(url);
       },
@@ -484,15 +477,7 @@ describe("runE2eLayer", () => {
         }
         return new FakeLocator(0);
       },
-      getByLabel() {
-        return new FakeLocator(1, "", {
-          fill: () => {},
-          press: () => {
-            promptSent = true;
-          },
-        });
-      },
-    };
+    });
 
     const result = await runE2eLayer({
       repoName: "papermark",
@@ -541,7 +526,7 @@ describe("runE2eLayer", () => {
     const gotoUrls: string[] = [];
     let credentialsVisible = true;
     let promptSent = false;
-    const page: E2ePage = {
+    const page = fakePage({
       async goto(url: string) {
         gotoUrls.push(url);
       },
@@ -574,15 +559,7 @@ describe("runE2eLayer", () => {
         }
         return new FakeLocator(0);
       },
-      getByLabel() {
-        return new FakeLocator(1, "", {
-          fill: () => {},
-          press: () => {
-            promptSent = true;
-          },
-        });
-      },
-    };
+    });
 
     const result = await runE2eLayer({
       repoName: "teable",

--- a/corpus/harness/src/layers/e2e.ts
+++ b/corpus/harness/src/layers/e2e.ts
@@ -3,41 +3,46 @@ import path from "node:path";
 import { z } from "zod";
 import type { ScorecardCheck, ScorecardLayerInput, ScorecardScore } from "../scorecard.js";
 
+// A narrow structural port of the slice of Playwright this layer drives. Every
+// member is required: a real Locator/Page always has all of them, so an
+// optional member would only ever be absent on a test fake — and a fake that
+// silently lacks fill() turns a host login into a no-op the run still scores.
+// Return types are widened where Playwright's are richer (goto resolves a
+// Response) so a real Page satisfies this interface without a cast.
 export interface E2eLocator {
   count(): Promise<number>;
-  click?(options?: unknown): Promise<void>;
-  fill?(value: string): Promise<void>;
-  press?(key: string): Promise<void>;
-  textContent?(): Promise<string | null>;
-  allTextContents?(): Promise<string[]>;
-  first?(): E2eLocator;
+  click(options?: unknown): Promise<unknown>;
+  fill(value: string): Promise<unknown>;
+  press(key: string): Promise<unknown>;
+  textContent(): Promise<string | null>;
+  allTextContents(): Promise<string[]>;
+  first(): E2eLocator;
 }
 
 export interface E2eFrameLocator {
   locator(selector: string): E2eLocator;
   getByRole(role: string, options?: { name?: string | RegExp }): E2eLocator;
-  getByTestId?(testId: string): E2eLocator;
+  getByTestId(testId: string): E2eLocator;
 }
 
 export interface E2eRequest {
   url(): string;
   method(): string;
-  postData?(): string | null;
-  postDataJSON?(): unknown;
+  postData(): string | null;
+  postDataJSON(): unknown;
 }
 
 export interface E2ePage {
-  goto(url: string, options?: E2eNavigationOptions): Promise<void>;
+  goto(url: string, options?: E2eNavigationOptions): Promise<unknown>;
   locator(selector: string): E2eLocator;
   getByRole(role: string, options?: { name?: string | RegExp }): E2eLocator;
-  getByLabel(label: string | RegExp): E2eLocator;
-  getByTestId?(testId: string): E2eLocator;
-  frameLocator?(selector: string): E2eFrameLocator;
-  keyboard?: { press(key: string): Promise<void> };
-  on?(event: "request", listener: (request: E2eRequest) => void): void;
-  off?(event: "request", listener: (request: E2eRequest) => void): void;
-  screenshot?(options: { path: string; fullPage?: boolean }): Promise<Buffer | void>;
-  close?(): Promise<void>;
+  getByTestId(testId: string): E2eLocator;
+  frameLocator(selector: string): E2eFrameLocator;
+  keyboard: { press(key: string): Promise<unknown> };
+  on(event: "request", listener: (request: E2eRequest) => void): unknown;
+  off(event: "request", listener: (request: E2eRequest) => void): unknown;
+  screenshot(options: { path: string; fullPage?: boolean }): Promise<unknown>;
+  close(): Promise<unknown>;
 }
 
 export interface E2eNavigationOptions {
@@ -528,7 +533,7 @@ async function runAttempt(
       if (error || assertions.some((assertion) => !assertion.pass)) {
         screenshotPath = path.join(ctx.logsDir, `e2e.${safeFilePart(script.id)}.${attempt}.png`);
         try {
-          await session.page.screenshot?.({ path: screenshotPath, fullPage: true });
+          await session.page.screenshot({ path: screenshotPath, fullPage: true });
           screenshots.push(screenshotPath);
         } catch {
           screenshotPath = undefined;
@@ -572,7 +577,7 @@ async function defaultPageFactory(): Promise<E2ePageSession> {
   const context = await browser.newContext();
   const page = await context.newPage();
   return {
-    page: page as unknown as E2ePage,
+    page,
     close: async () => {
       await context.close();
       await browser.close();
@@ -651,7 +656,6 @@ async function loginToUmami(page: E2ePage, timeoutMs: number): Promise<void> {
   if (await safeCount(username) === 0) return;
 
   const password = page.locator('[data-test="input-password"] input, input[name="password"]');
-  if (!username.fill || !password.fill) return;
   await username.fill("admin");
   await password.fill("umami");
   await clickIfPresent(page.getByRole("button", { name: /^login$/i }));
@@ -676,11 +680,10 @@ async function loginToTeable(
   if (await safeCount(email) === 0) return;
 
   const password = page.locator('input[name="password"], input[type="password"], #password');
-  if (!email.fill || !password.fill) return;
   await email.fill("test@e2e.com");
   await password.fill("12345678");
   if (!await clickIfPresent(page.getByRole("button", { name: /sign\s?in|log\s?in|continue|submit/i }))) {
-    await email.press?.("Enter");
+    await email.press("Enter");
   }
   // The form clears from the DOM once the redirect lands.
   await waitFor(async () => (await safeCount(email)) === 0, timeoutMs).catch(() => undefined);
@@ -724,10 +727,10 @@ async function attachNetworkSignals(
       if (tool) signals.toolCalls.push({ name: tool, method, url, source: "voice-tools" });
     }
   };
-  page.on?.("request", onRequest);
+  page.on("request", onRequest);
   return {
     dispose() {
-      page.off?.("request", onRequest);
+      page.off("request", onRequest);
     },
   };
 }
@@ -768,8 +771,8 @@ export async function openVendoSurface(page: E2ePage, timeoutMs: number): Promis
       lastOpenAttempt = now;
       const launcher = page.getByRole("button", { name: /ask|assistant|vendo/i });
       if (!await clickIfPresent(launcher)) {
-        await page.keyboard?.press("Meta+K");
-        await page.keyboard?.press("Control+K");
+        await page.keyboard.press("Meta+K");
+        await page.keyboard.press("Control+K");
       }
     }
 
@@ -782,14 +785,8 @@ export async function sendPrompt(page: E2ePage, prompt: string): Promise<void> {
   // (aria-label "Message composer" / "Message"), so a bare getByLabel violates
   // Playwright strict mode — target the textbox role.
   const input = page.getByRole("textbox", { name: /message/i });
-  if (!input.fill) throw new Error("Vendo composer message field did not expose fill()");
   await input.fill(prompt);
-  if (input.press) {
-    await input.press("Enter");
-    return;
-  }
-  if (!page.keyboard) throw new Error("Vendo composer message field did not expose press() and page has no keyboard");
-  await page.keyboard.press("Enter");
+  await input.press("Enter");
 }
 
 async function waitForAssertions(
@@ -830,7 +827,7 @@ async function waitFor(predicate: () => Promise<boolean>, timeoutMs: number): Pr
 
 async function countToolCallDomMatches(page: E2ePage, name: TextMatcher): Promise<number> {
   const labels = page.locator(".fl-tool-label");
-  const texts = await labels.allTextContents?.().catch(() => [] as string[]) ?? [];
+  const texts = await labels.allTextContents().catch(() => [] as string[]);
   return texts.filter((text) => textMatches(name, text.replace(/^Tool:\s*/i, ""))).length;
 }
 
@@ -838,7 +835,7 @@ async function countViewDomMatches(page: E2ePage, assertion: Extract<Conversatio
   let count = 0;
   if (assertion.testId) {
     const literal = literalMatcherValue(assertion.testId);
-    if (literal) count += await safeCount(page.getByTestId ? page.getByTestId(literal) : page.locator(attrSelector("data-testid", literal)));
+    if (literal) count += await safeCount(page.getByTestId(literal));
   }
   if (assertion.component) {
     const literal = literalMatcherValue(assertion.component);
@@ -852,31 +849,31 @@ async function countViewDomMatches(page: E2ePage, assertion: Extract<Conversatio
     }
   }
   if (!assertion.testId && !assertion.component && !assertion.role) {
-    count += await safeCount(page.getByTestId ? page.getByTestId("ui-node") : page.locator(attrSelector("data-testid", "ui-node")));
+    count += await safeCount(page.getByTestId("ui-node"));
   }
   if (assertion.text && count === 0) {
     const body = page.locator("body");
-    const text = await body.textContent?.();
+    const text = await body.textContent();
     if (textMatches(assertion.text, text ?? undefined)) count += await safeCount(body);
   }
   return count;
 }
 
+function stageFrame(page: E2ePage): E2eFrameLocator {
+  return page.frameLocator('iframe#vendo-stage, iframe[title="Vendo stage"]');
+}
+
 async function countStageFrameRoleMatches(page: E2ePage, role: string, text: TextMatcher | undefined): Promise<number> {
-  const frame = page.frameLocator?.('iframe#vendo-stage, iframe[title="Vendo stage"]');
-  if (!frame) return 0;
-  return safeCount(frame.getByRole(role, roleOptions(text)));
+  return safeCount(stageFrame(page).getByRole(role, roleOptions(text)));
 }
 
 async function countErrorDomSignals(page: E2ePage): Promise<number> {
   const hardErrors = await safeCount(page.locator(hardErrorSelector));
-  const stageErrors = page.frameLocator
-    ? await safeCount(page.frameLocator('iframe#vendo-stage, iframe[title="Vendo stage"]').locator(stageErrorSelector))
-    : 0;
+  const stageErrors = await safeCount(stageFrame(page).locator(stageErrorSelector));
   // Several toasts can be visible at once, so read them all: a single-element
   // textContent() would trip Playwright's strict mode, and a concatenated read
   // would score two benign toasts as errors the moment one of them matched.
-  const toasts = await page.locator(".fl-toast:visible").allTextContents?.().catch(() => [] as string[]) ?? [];
+  const toasts = await page.locator(".fl-toast:visible").allTextContents().catch(() => [] as string[]);
   return hardErrors + stageErrors + toasts.filter((text) => errorToastText.test(text)).length;
 }
 
@@ -900,8 +897,8 @@ function roleOptions(text: TextMatcher | undefined): { name?: string | RegExp } 
 }
 
 async function clickIfPresent(locator: E2eLocator): Promise<boolean> {
-  if (await safeCount(locator) === 0 || !locator.click) return false;
-  await (locator.first?.() ?? locator).click?.();
+  if (await safeCount(locator) === 0) return false;
+  await locator.first().click();
   return true;
 }
 
@@ -915,7 +912,7 @@ async function safeCount(locator: E2eLocator): Promise<number> {
 
 async function captureObservableText(page: E2ePage): Promise<string | undefined> {
   try {
-    return (await page.locator(".fl-msglist, [role='dialog'], body").textContent?.()) ?? undefined;
+    return (await page.locator(".fl-msglist, [role='dialog'], body").textContent()) ?? undefined;
   } catch {
     return undefined;
   }
@@ -927,16 +924,16 @@ async function closeSession(session: E2ePageSession | undefined): Promise<void> 
     await session.close();
     return;
   }
-  await session.page.close?.();
+  await session.page.close();
 }
 
 function requestJson(request: E2eRequest): unknown {
   try {
-    if (request.postDataJSON) return request.postDataJSON();
+    return request.postDataJSON();
   } catch {
     // Fall back to raw post data.
   }
-  const raw = request.postData?.();
+  const raw = request.postData();
   if (!raw) return undefined;
   try {
     return JSON.parse(raw) as unknown;

--- a/corpus/harness/src/layers/e2e.ts
+++ b/corpus/harness/src/layers/e2e.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { z } from "zod";
 import type { ScorecardCheck, ScorecardLayerInput, ScorecardScore } from "../scorecard.js";
+import { errorMessage, escapeRegex, isRecord, sleep } from "../util.js";
 
 // A narrow structural port of the slice of Playwright this layer drives. Every
 // member is required: a real Locator/Page always has all of them, so an
@@ -1000,20 +1001,3 @@ function round(value: number): number {
   return Number(value.toFixed(6));
 }
 
-function escapeRegex(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}

--- a/corpus/harness/src/layers/scored.ts
+++ b/corpus/harness/src/layers/scored.ts
@@ -19,6 +19,7 @@ import {
   type ThemeRubricDimension,
 } from "../expectations.js";
 import type { ScorecardCheck, ScorecardLayerInput, ScorecardScore } from "../scorecard.js";
+import { errorMessage } from "../util.js";
 
 export interface ScoredLayerContext {
   repoName: string;
@@ -51,10 +52,6 @@ interface WeightedResult {
 
 const WRITE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 const EPSILON = 0.000001;
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
 
 function round(value: number): number {
   return Number(value.toFixed(6));

--- a/corpus/harness/src/layers/structural.ts
+++ b/corpus/harness/src/layers/structural.ts
@@ -1,5 +1,4 @@
-import { spawn } from "node:child_process";
-import { access, readdir, readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import path from "node:path";
 import type TS from "typescript";
@@ -12,6 +11,8 @@ import {
   type ToolsFile,
 } from "@vendoai/actions";
 import type { ZodError } from "zod";
+import { runHostCommand } from "../process.js";
+import { errorMessage, pathExists } from "../util.js";
 
 export type StructuralCheckId =
   | "init.exit"
@@ -169,48 +170,15 @@ function importBindingOf(mod: BoundModule, use: TS.Identifier): { specifier: str
   }
   return null;
 }
-export function corpusHostCommandEnv(env?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
-  return {
-    ...process.env,
-    ...env,
-    PNPM_CONFIG_MINIMUM_RELEASE_AGE: "0",
-    PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS: "true",
-    YARN_ENABLE_IMMUTABLE_INSTALLS: "false",
-  };
-}
-
-async function exists(file: string): Promise<boolean> {
-  return access(file).then(() => true, () => false);
-}
-
-function runShellCommand(command: string, options: StructuralCommandOptions): Promise<StructuralCommandResult> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, {
-      cwd: options.cwd,
-      env: corpusHostCommandEnv(options.env),
-      shell: true,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    child.stdout.on("data", (chunk) => { stdout += chunk; });
-    child.stderr.on("data", (chunk) => { stderr += chunk; });
-    child.on("error", reject);
-    child.on("close", (code, signal) => resolve({ code, signal, stdout, stderr }));
-  });
-}
-
 export async function findAppRouter(repoDir: string): Promise<AppRouterInfo | null> {
   for (const appDirRel of ["app", "src/app"] as const) {
     for (const name of ["layout.tsx", "layout.jsx", "layout.js"] as const) {
       const layoutRel = path.posix.join(appDirRel, name);
-      if (await exists(path.join(repoDir, layoutRel))) {
+      if (await pathExists(path.join(repoDir, layoutRel))) {
         return {
           appDirRel,
           layoutRel,
-          ts: name.endsWith(".tsx") || await exists(path.join(repoDir, "tsconfig.json")),
+          ts: name.endsWith(".tsx") || await pathExists(path.join(repoDir, "tsconfig.json")),
         };
       }
     }
@@ -251,11 +219,11 @@ async function readText(repoDir: string, rel: string): Promise<string | null> {
  * a real Express/Nest API host (vendo/server.ts|mjs; the client lives in a
  * separate frontend, so no VendoProvider requirement). */
 async function expressShape(repoDir: string): Promise<"pre-wired" | "generated"> {
-  return await exists(path.join(repoDir, "src/server/vendo.ts")) ? "pre-wired" : "generated";
+  return await pathExists(path.join(repoDir, "src/server/vendo.ts")) ? "pre-wired" : "generated";
 }
 
 async function generatedExpressServerRel(repoDir: string): Promise<string> {
-  return await exists(path.join(repoDir, "vendo/server.mjs")) && !await exists(path.join(repoDir, "vendo/server.ts"))
+  return await pathExists(path.join(repoDir, "vendo/server.mjs")) && !await pathExists(path.join(repoDir, "vendo/server.ts"))
     ? "vendo/server.mjs"
     : "vendo/server.ts";
 }
@@ -468,7 +436,7 @@ async function checkExpectedFiles(ctx: StructuralLayerContext): Promise<Structur
   const missing: string[] = [];
 
   for (const rel of required) {
-    if (!await exists(path.join(ctx.repoDir, rel))) missing.push(rel);
+    if (!await pathExists(path.join(ctx.repoDir, rel))) missing.push(rel);
   }
 
   const wiringProblems: string[] = [];
@@ -593,7 +561,7 @@ async function checkCommand(
     return { id, pass: false, detail: `no ${label} command was provided` };
   }
   const baseline = id === "host.typecheck" ? ctx.baseline?.typecheck : ctx.baseline?.build;
-  const runner = ctx.commandRunner ?? runShellCommand;
+  const runner = ctx.commandRunner ?? runHostCommand;
   try {
     const result = await runner(command, { cwd: ctx.repoDir, env: ctx.env });
     if (baseline && !commandPassed(baseline)) {
@@ -697,10 +665,6 @@ function trimOutput(output: string, max = 500): string {
   const trimmed = output.trim();
   if (trimmed.length <= max) return trimmed;
   return `${trimmed.slice(0, max)}...`;
-}
-
-function errorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
 }
 
 async function safeCheck(

--- a/corpus/harness/src/layers/ui-parity.ts
+++ b/corpus/harness/src/layers/ui-parity.ts
@@ -2,6 +2,7 @@ import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { z } from "zod";
 import type { ScorecardCheck, ScorecardLayerInput, ScorecardScore } from "../scorecard.js";
+import { isRecord } from "../util.js";
 
 /**
  * UI-parity audit layer (spec §6, ENG-257). An agent enumerates what the host
@@ -198,10 +199,6 @@ async function readOptionalJson(file: string): Promise<unknown> {
   } catch {
     return undefined;
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 /**

--- a/corpus/harness/src/local-pack.ts
+++ b/corpus/harness/src/local-pack.ts
@@ -1,6 +1,7 @@
-import { spawn } from "node:child_process";
 import { promises as fs } from "node:fs";
 import path from "node:path";
+import { runCommand } from "./process.js";
+import { isRecord, pathExists, readOptional } from "./util.js";
 
 // Direct dependencies every injected fixture gets. @vendoai/ui rides along
 // because the corpus e2e prep mounts the shipped chat chrome
@@ -58,10 +59,6 @@ export interface WorkspacePackage {
 
 export interface LocalPackRunner {
   (pkg: WorkspacePackage, opts: { repoDir: string; vendorDir: string; fileName: string }): Promise<void>;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function stringRecord(value: unknown): Record<string, string> {
@@ -143,19 +140,9 @@ async function defaultPackRunner(
   opts: { repoDir: string; vendorDir: string; fileName: string },
 ): Promise<void> {
   await fs.mkdir(opts.vendorDir, { recursive: true });
-  const output = await new Promise<{ code: number | null; stdout: string; stderr: string }>((resolve, reject) => {
-    const child = spawn("pnpm", ["-C", pkg.dir, "pack", "--pack-destination", opts.vendorDir], {
-      cwd: opts.repoDir,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    child.stdout.on("data", (chunk) => { stdout += chunk; });
-    child.stderr.on("data", (chunk) => { stderr += chunk; });
-    child.on("error", reject);
-    child.on("close", (code) => resolve({ code, stdout, stderr }));
+  const output = await runCommand("pnpm", {
+    args: ["-C", pkg.dir, "pack", "--pack-destination", opts.vendorDir],
+    cwd: opts.repoDir,
   });
   if (output.code !== 0) {
     throw new Error(`pnpm pack failed for ${pkg.name}:\n${output.stderr || output.stdout}`);
@@ -181,18 +168,6 @@ export function pnpmMajorFromField(value: unknown): number | null {
   if (typeof value !== "string" || !value.startsWith("pnpm@")) return null;
   const major = Number.parseInt(value.slice("pnpm@".length).split(".")[0] ?? "", 10);
   return Number.isFinite(major) ? major : null;
-}
-
-async function readOptional(file: string): Promise<string | null> {
-  try {
-    return await fs.readFile(file, "utf8");
-  } catch {
-    return null;
-  }
-}
-
-async function pathExists(file: string): Promise<boolean> {
-  return fs.access(file).then(() => true, () => false);
 }
 
 async function readOptionalPackageJson(dir: string): Promise<PackageJson | null> {

--- a/corpus/harness/src/process.ts
+++ b/corpus/harness/src/process.ts
@@ -1,0 +1,65 @@
+import { spawn } from "node:child_process";
+
+export interface CommandResult {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  /** Both streams in arrival order — what a human reading the log wants. */
+  combined: string;
+}
+
+export interface RunCommandOptions {
+  /** Omit to run `command` through a shell; pass args to spawn it directly. */
+  args?: readonly string[];
+  cwd: string;
+  /** Omitted means inherit the harness's own environment. */
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Spawn a command, collect both streams, and resolve however it exits — a
+ * non-zero code is a result, not an error. Rejects only when the process could
+ * not be spawned at all.
+ */
+export function runCommand(command: string, options: RunCommandOptions): Promise<CommandResult> {
+  return new Promise((resolve, reject) => {
+    const child = options.args
+      ? spawn(command, options.args, { cwd: options.cwd, env: options.env, stdio: ["ignore", "pipe", "pipe"] })
+      : spawn(command, { cwd: options.cwd, env: options.env, shell: true, stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    let combined = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+      combined += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+      combined += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (code, signal) => resolve({ code, signal, stdout, stderr, combined }));
+  });
+}
+
+/**
+ * Host repos are third-party checkouts pinned to a sha: relax the guards that
+ * would fail their install for reasons that have nothing to do with Vendo.
+ */
+export function corpusHostCommandEnv(env?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    ...env,
+    PNPM_CONFIG_MINIMUM_RELEASE_AGE: "0",
+    PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS: "true",
+    YARN_ENABLE_IMMUTABLE_INSTALLS: "false",
+  };
+}
+
+/** The shell runner every host-facing command in the harness goes through. */
+export function runHostCommand(command: string, options: { cwd: string; env?: NodeJS.ProcessEnv }): Promise<CommandResult> {
+  return runCommand(command, { cwd: options.cwd, env: corpusHostCommandEnv(options.env) });
+}

--- a/corpus/harness/src/ui-parity-nightly.ts
+++ b/corpus/harness/src/ui-parity-nightly.ts
@@ -1,4 +1,3 @@
-import { access } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveAppRoot } from "./app-root.js";
@@ -10,6 +9,7 @@ import {
   type GenerateTextLike,
   type UiParityLayerRunResult,
 } from "./layers/ui-parity.js";
+import { pathExists } from "./util.js";
 
 /**
  * Nightly driver for the UI-parity audit layer (ENG-257). It runs AFTER the
@@ -59,10 +59,6 @@ export async function resolveModel(env: NodeJS.ProcessEnv): Promise<ResolvedMode
   const generateText = ai.generateText as GenerateTextLike;
   const model = createAnthropic({ apiKey })(env.UI_PARITY_MODEL?.trim() || DEFAULT_MODEL);
   return { model, generateText };
-}
-
-async function exists(file: string): Promise<boolean> {
-  return access(file).then(() => true, () => false);
 }
 
 function line(label: string, value: string): string {
@@ -124,7 +120,7 @@ export async function runUiParityNightly(
   let audited = 0;
   for (const repo of repos) {
     const appRoot = resolveAppRoot(repo, context.repoDir(repo.name));
-    if (!await exists(path.join(appRoot, ".vendo", "tools.json"))) {
+    if (!await pathExists(path.join(appRoot, ".vendo", "tools.json"))) {
       log(`skip ${repo.name}: no generated .vendo/tools.json checkout (run the sweep first)`);
       continue;
     }

--- a/corpus/harness/src/util.ts
+++ b/corpus/harness/src/util.ts
@@ -1,0 +1,33 @@
+import { access, readFile } from "node:fs/promises";
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function pathExists(file: string): Promise<boolean> {
+  return access(file).then(() => true, () => false);
+}
+
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** The file's text, or undefined if it is missing or unreadable. */
+export async function readOptional(file: string | undefined): Promise<string | undefined> {
+  if (!file) return undefined;
+  try {
+    return await readFile(file, "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+export function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}


### PR DESCRIPTION
The four HIGH corpus-harness findings #979 deferred, worked worst-first. Three
refactored, one rejected on evidence. Net **−320 lines** across the harness
(+100 in two new leaf modules, −420 in eighteen existing files).

## The list, ordered by blast radius

**1. Optional-method shims over Playwright and ChildProcess** — *refactored*
(`layers/e2e.ts`, `gallery.ts`, `boot.ts`, `layers/e2e.test.ts`, `boot.test.ts`).
Worst of the four because it is the only one that can make the harness lie about
a result: `if (!username.fill || !password.fill) return;` skipped the umami
login and an identical line skipped teable's, after which the run kept going and
scored whatever an unauthenticated page happened to show. Sixteen optional
members across four interfaces, paid for with 22 defensive branches. The four
inline page fakes in the test file defined exactly the four then-required
members and nothing else — the fake and the interface agreed with each other and
neither agreed with Playwright, which is the #979 lesson again.

Every member is required now. Return types are widened where Playwright's are
richer (`goto` resolves a Response), so a real `Page` satisfies `E2ePage`
directly and all seven `as unknown as E2ePage` casts are gone. One `fakePage()`
factory supplies a complete page; each test overrides only what it drives.
`E2ePage.getByLabel` went with it — required, implemented by five fakes, called
by nothing.

**2. Fourteen copies of the spawn-and-collect promise** — *refactored*
(new `process.ts`, `util.ts`, 16 files). Actually **sixteen** copies, not
fourteen: the catalog missed `bootstrap.ts:104` and the two test helpers, and
wrongly counted `ai/matrix.ts:276` (that one discards stdout and rejects on a
non-zero exit). Eight resolved `{code, signal, stdout, stderr}` and eight
dropped `signal` for the same job. `runCommand(command, { args?, cwd, env })` —
omit `args` and it runs through a shell — is the one implementation now.
`corpusHostCommandEnv` moved to `process.ts` with it, so `cli.ts` no longer
reaches into a layer module to build a process environment.

Micro-helper counts corrected too: `pathExists` was **eight** definitions plus
two named `exists`, not six; `escapeRegExp` was **three**, not two (one spelled
`escapeRegex`). `isRecord` (7), `errorMessage` (5), `sleep` (2) confirmed. The
null-vs-undefined claim is true for exactly one helper — `readOptional`, two
returning `null` and one `undefined`; the shared one returns `undefined`.

Five long-lived spawns are deliberately left alone: they hand back a handle,
stream to a file under a time budget, or reject on non-zero. Named in the commit.

**3. Repo preparation copy-pasted across four CLI commands** — *refactored*
(`cli.ts`). The dead `injectResult` binding is confirmed exactly, and nothing
was ever going to flag it: `corpus/harness` has no lint script, the repo has no
eslint config outside `examples/`, and neither tsconfig sets `noUnusedLocals`.
boot derived its app root from `injectResult.repoDir` while the other three used
`resolveAppRoot` — **provably the same value today** (the injector calls
`resolveAppRoot` on the same checkout dir), so this is a latent fragility, not a
live bug; boot uses `resolveAppRoot` now like everything else.

Two claims corrected: there is **no fifth copy in `ui-parity-nightly.ts`** (it
never calls checkout/bootstrap/inject/init at all), and the sweep is **not** the
same recipe — it runs init twice with `--ai-polish` and feeds a non-zero exit
code to the structural layer as a finding instead of throwing. A single helper
over all four would have silently turned AI polish on for boot/gallery/ai or off
for the sweep. `prepareRepo()` covers the genuinely shared prefix;
`runCheckedInit()` covers the three throwers and says why the sweep is out.

**4. Every CLI test hand-builds the same 80-line fake deps object** —
**REJECTED, evidence falsified.** `cli.test.ts` is 1284 lines / 18 tests, which
matches. Nothing else does:

- The headline evidence — *"the same ten-package `packages: [...]` array
  repeated a dozen-plus times"* — **does not exist**. It appears **once**, at
  lines 139-150. All eleven other `packages:` sites are `packages: []`.
- *"the same 80-line object"*: the 17 literals measure 81, 65, 39, 71, 97, 45,
  42, 42, 45, 64, 47, 6, 61, 16, 12, 7, 10. Median 45. Exactly one is ~80. Six
  are under 20.
- The proposed `makeDeps(context, overrides)` builder **already exists** in the
  file as `aiDeps` (line 1084) and is already applied to the four tests where it
  pays — which are the four smallest literals in the file.
- Measured verbatim duplication: longest 3-copy block **26 lines**, longest
  2-copy block **49 lines**. Realistic recovery ~100 lines before per-test
  overrides, not the claimed 700.
- Three of the 18 tests build no deps at all.

Against that, the assertions are identity- and ordering-sensitive
(`toEqual([{ context, workspaceRoot }])`, `toBe(context)`, exact ordered `events`
arrays, three assertions living *inside* stub bodies), and `noUncheckedIndexedAccess`
means a spread-based builder widens the inferred stub-callback params at every
override site. Churning a 1284-line suite for ~100 lines, to add a second
builder next to the one already there, is a net loss. Not deferred — declined.

## Dispositions on the rest

- `fixtures/existing-agents-e2e/src/local-pack.ts` is a deliberate lean copy of
  the harness's local-pack, documented as such in its own header, and lives
  outside this file-set. Left alone.
- The six MED/LOW corpus findings are out of this slice's scope. Note that
  `ui-parity-nightly.ts` is 163 lines today, not the 900 the catalog claims.
- **No changeset**: `@vendoai/corpus-harness` is `private: true` and unpublished.

## vendo-web

**No companion PR needed — no-op, justified.** Two files in the sibling repo
touch the corpus and neither is affected:

- `tests/corpus-count.test.tsx:23` pins marketing copy to the **repo count** in
  `corpus/manifest.json` (16). Untouched.
- `docs/eval/knowledge-cloud/README.md:65` names
  `corpus/harness/src/knowledge-eval/fixtures/corpus.json` as a **frozen
  snapshot pinned to vendo `5d71cb9ea`**, from which the shipped Agentset bar
  constant is derived. Untouched, and per #950's tandem rule it must not be
  edited to match anything.

## Gate

- `pnpm build --filter=@vendoai/corpus-harness...` — 13/13, FULL TURBO
- `pnpm --filter @vendoai/corpus-harness test` — **38 files passed, 347 tests
  passed**, 1 file / 2 tests skipped. Byte-identical to the pre-change baseline.
- `pnpm typecheck` — 40/40 successful, 56s. `corpus/harness/tsconfig.json`
  includes `src/**/*` with no `exclude`, so the test files **are** typechecked
  by this gate (checked before starting, given the CI trap).
- `pnpm lint --force` — 3/3 successful, 0 cached. (2 pre-existing `demo-bank`
  warnings, 0 errors.)
- Removed/moved symbols grepped repo-wide including every test dir:
  `corpusHostCommandEnv`, `InjectCommandResult`, `escapeRegExp`, `BinaryResult`,
  `getByLabel` — no external consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthened the corpus harness by making the Playwright page/locator contract strict to prevent false passes, and unifying process execution and utilities to reduce duplication and drift. Also centralized repo preparation and init flow across commands and aligned boot’s app root resolution.

- **Refactors**
  - Made all `E2ePage`/`E2eLocator`/`E2eFrameLocator`/`E2eRequest` members required; removed optional shims and casts; added a `fakePage()` test factory.
  - Consolidated process runners into `process.ts` with `runCommand`, `runHostCommand`, and `corpusHostCommandEnv`; all shell/binary calls use it.
  - Moved shared helpers to `util.ts` (`isRecord`, `pathExists`, `escapeRegex`, `sleep`, `readOptional`, `errorMessage`).
  - Added `prepareRepo()` and `runCheckedInit()` and used them in `boot`, `gallery`, `ai`, and layer-one paths; `boot` now uses `resolveAppRoot`.
  - Tightened `BootProcess` shape; simplified stream teardown with `.off`.

- **Bug Fixes**
  - Removed silent login skips in Umami/Teable caused by missing `fill`/`press` on fakes.
  - Avoided strict-mode pitfalls by using `.first().click()` and `.allTextContents()` consistently.
  - Eliminated Playwright type casts in gallery by matching real return types.

<sup>Written for commit 08e918da9c291c4aca5bb2f14aa00e207d64c919. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

