### PR TITLE
fix(store): two workspace-undo data-loss bugs, and the third lead sent back with a correction

### DIFF
--- a/.changeset/undo-keeps-the-content-it-was-not-asked-to-remove.md
+++ b/.changeset/undo-keeps-the-content-it-was-not-asked-to-remove.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/store": patch
+---
+
+Two workspace-undo data-loss fixes. `undo` reuses its history row's blob for the live file row rather than re-uploading the bytes, so the key it holds can already be the live file's only copy — a second undo landing on the same revision reached "the winner stored exactly these bytes, so our blob is surplus" and deleted it, leaving the file row pointing at nothing and no history row naming it. Both of `landRow`'s post-swap blob releases now keep a blob some row still points at. Separately, `ops.workspace.undo(commitId)` delegates to a walk that pops the NEWEST superseded revision at a path, so given an older commit it restored that commit's own content and destroyed the newer commit's — permanently, since an undo writes no history row behind it — then deleted the older commit from the ledger and left the newer one. A commit is now only undoable while it is still the newest at every path it touched; otherwise the undo is refused with `conflict` naming the paths, and the later commits are undone first.

--- a/packages/store/src/ops.ts
+++ b/packages/store/src/ops.ts
@@ -95,6 +95,37 @@ const commitCreated = (commit: VendoRecord): string[] =>
 const commitTouches = (commit: VendoRecord, path: string): boolean =>
   commitEntries(commit).some((entry) => entry.path === path);
 
+/** Which of `commit`'s paths a LATER commit has since touched.
+ *
+ *  `workspaceRows.undo` pops the newest superseded revision at a path, so it
+ *  can only walk back the newest commit there. Undoing an older one instead
+ *  restored the older commit's own content and destroyed the newer commit's —
+ *  permanently, because an undo writes no history row behind it. The ledger
+ *  pages newest-first, so everything ahead of the commit itself is newer. */
+async function pathsMovedOn(
+  ledger: RecordStore,
+  owner: string,
+  commit: VendoRecord,
+): Promise<string[]> {
+  const mine = new Set(commitEntries(commit).map((entry) => entry.path));
+  const moved = new Set<string>();
+  let cursor: string | undefined;
+  do {
+    const page = await ledger.list({
+      refs: { subject: owner },
+      ...(cursor === undefined ? {} : { cursor }),
+    });
+    for (const record of page.records) {
+      if (record.id === commit.id) return [...moved].sort();
+      for (const entry of commitEntries(record)) {
+        if (mine.has(entry.path)) moved.add(entry.path);
+      }
+    }
+    cursor = page.cursor;
+  } while (cursor !== undefined);
+  return [...moved].sort();
+}
+
 /** The newest commit in one owner's ledger that touched `path` — the unit a
  *  per-path undo walks back. The ledger pages newest-first, so the first hit
  *  is the answer; a path nobody has touched walks the whole ledger and says
@@ -618,6 +649,19 @@ export function createStoreOps(
             // would make the door an existence oracle: it is simply not found.
             if (commit === null || commit.refs?.["subject"] !== owner) {
               throw new VendoError("not-found", `commit ${target} not found`);
+            }
+            // Only the newest commit at a path is that path's to walk back.
+            // Refusing is the honest answer: the newer write has no history row
+            // behind it, so undoing through it would destroy content nobody
+            // asked to remove and could never be recovered.
+            const movedOn = await pathsMovedOn(ledger, owner, commit);
+            if (movedOn.length > 0) {
+              throw new VendoError(
+                "conflict",
+                `${movedOn.join(", ")} changed after commit ${target}, so undoing it would walk back`
+                  + ` the later change instead; undo the later commits first`,
+                { conflicts: movedOn },
+              );
             }
             const created = new Set(commitCreated(commit));
             for (const entry of commitEntries(commit)) {

--- a/packages/store/src/ops.ts
+++ b/packages/store/src/ops.ts
@@ -627,6 +627,26 @@ export function createStoreOps(
           const tdb = txDb(q);
           const ledger = createRecordStore(tdb, WORKSPACE_COMMITS);
           const txRows = workspaceRows(tdb, filesFor(tdb));
+          /** Hold these paths' file rows for the rest of the transaction.
+           *
+           *  Every undo below is a CHECK — which commit is newest here — and
+           *  then an ACT: walk that path's history back one step. The two are
+           *  only sound together. With nothing held between them a commit
+           *  lands in the gap and appends a history row, and the act pops
+           *  THAT row instead: the committer is told its write landed and the
+           *  content is destroyed with no history row behind it (undo has no
+           *  redo). A write cannot append a history row without swapping the
+           *  path's file row first — one CTE does both — so holding the row
+           *  is what makes the pair atomic. Ordered by path, so two undos
+           *  queue instead of deadlocking. */
+          const hold = async (paths: string[]): Promise<void> => {
+            if (paths.length === 0) return;
+            await q(
+              `SELECT 1 FROM vendo_workspace_files WHERE owner = $1 AND path = ANY($2::text[])
+               ORDER BY path FOR UPDATE`,
+              [owner, paths],
+            );
+          };
           /** The commit created this path, so undoing it removes the file
               (recorded to history, §3.3's append-only law, so it stays
               recoverable); otherwise the superseded revision comes back. */
@@ -654,6 +674,7 @@ export function createStoreOps(
             // Refusing is the honest answer: the newer write has no history row
             // behind it, so undoing through it would destroy content nobody
             // asked to remove and could never be recovered.
+            await hold(commitEntries(commit).map((entry) => entry.path));
             const movedOn = await pathsMovedOn(ledger, owner, commit);
             if (movedOn.length > 0) {
               throw new VendoError(
@@ -672,6 +693,9 @@ export function createStoreOps(
           }
 
           const { path } = target;
+          // Same check-then-act as above, one path wide: `newestCommitTouching`
+          // decides and `undoOne` walks back, so the row is held across both.
+          await hold([path]);
           const commit = await newestCommitTouching(ledger, owner, path);
           if (commit === undefined) {
             throw new VendoError("not-found", `no commit has touched ${path}`);

--- a/packages/store/src/workspace-ops.test.ts
+++ b/packages/store/src/workspace-ops.test.ts
@@ -2,8 +2,9 @@ import type { Membership, Principal } from "@vendoai/core";
 import { VendoError } from "@vendoai/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { backends, type MadeBackend } from "./backends.test-util.js";
+import type { Query } from "./db.js";
 import { createStoreOps } from "./ops.js";
-import type { VendoStore as StoreHandle } from "./store.js";
+import { dbFor, type VendoStore as StoreHandle } from "./store.js";
 import { workspaceStore } from "./workspace.js";
 
 /**
@@ -249,6 +250,73 @@ for (const backend of backends()) {
       const ledger = await ops.workspace.history({ owner: "dana", path });
       expect((ledger.entries as { commitId: string }[]).map((entry) => entry.commitId))
         .toContain("wsc_key_s1");
+    });
+
+    /** The window under the refusal above. `pathsMovedOn` is the CHECK and
+        `undoOne` is the ACT; with nothing held between them, a commit that
+        lands in the gap appends a history row that `undoOne` then pops —
+        restoring the older value over the commit that just succeeded, with no
+        history row behind it. The committer was told "ok" and its content is
+        gone, which is the very outcome the check exists to prevent.
+
+        Two transactions have to overlap for real, so this only bites on a
+        backend that runs them concurrently: PGlite serialises and cannot
+        express it. The invariant asserted is the one that matters either way —
+        content a commit reported as landed is never silently destroyed. */
+    it("destroys no committed content when a commit lands while an undo is deciding", async () => {
+      const path = "/user/window/notes.md";
+      const ops = createStoreOps(made.store);
+      for (const [key, data] of [["w0", "zero"], ["w1", "one"], ["w2", "two"]] as const) {
+        await ops.workspace.commit([{ path, data }], { owner: "dana", idempotencyKey: key });
+      }
+
+      // Fire a fourth commit in the gap: after the undo's ledger walk has
+      // decided the target is still the newest here, before it reads history.
+      const db = dbFor(made.store);
+      const originalTx = db.transaction.bind(db);
+      let racer: Promise<void> | undefined;
+      db.transaction = (async (run: (q: Query) => Promise<unknown>) => await originalTx(async (q) => {
+        const wrapped: Query = async (text, params) => {
+          if (racer === undefined && text.includes("FROM vendo_workspace_history")) {
+            racer = ops.workspace.commit(
+              [{ path, data: "three" }],
+              { owner: "dana", idempotencyKey: "w3" },
+            );
+            // Long enough for an unblocked racer to land; a racer the undo is
+            // holding off simply stays blocked and this returns on the timer.
+            await Promise.race([
+              racer.catch(() => undefined),
+              new Promise((resolve) => setTimeout(resolve, 2_000)),
+            ]);
+          }
+          return await q(text, params);
+        };
+        return await run(wrapped);
+      })) as typeof db.transaction;
+
+      let undone: string;
+      try {
+        undone = await ops.workspace.undo("wsc_key_w2", { owner: "dana" }).then(() => "ok", (error: unknown) =>
+          error instanceof VendoError ? error.code : String(error));
+      } finally {
+        db.transaction = originalTx;
+      }
+      const landed = await racer!.then(() => true, () => false);
+      expect(racer).toBeDefined();
+
+      // Whatever the two decided between them, a commit that reported success
+      // must still be reachable — live, or behind a history row.
+      if (landed) {
+        const live = await (await hosted().open(dana)).readFile(path);
+        const history = await made.sql(
+          "SELECT content FROM vendo_workspace_history WHERE path = $1 AND owner = $2",
+          [path, "dana"],
+        );
+        const stored = history.map((row) => String(row["content"]));
+        expect([live === "three", stored.includes('"three"')].includes(true))
+          .toBe(true);
+      }
+      expect(["ok", "conflict"]).toContain(undone);
     });
 
     it("still refuses to move an app between mounts — that runs server-side", async () => {

--- a/packages/store/src/workspace-ops.test.ts
+++ b/packages/store/src/workspace-ops.test.ts
@@ -228,6 +228,29 @@ for (const backend of backends()) {
       expect(await (await hosted().open(dana)).readFile(path)).toBe("dana v1");
     });
 
+    /** `workspaceRows.undo` pops the NEWEST superseded revision at a path, and
+        nothing checked that the revision belonged to the commit being undone.
+        So undoing an older commit walked back the NEWER commit's write — and
+        that write has no history row behind it (undo has no redo), so its
+        content was gone for good, while the ledger kept the newer commit and
+        dropped the older one it never actually undid. */
+    it("refuses to undo a commit a later one has already built on", async () => {
+      const path = "/user/stacked/notes.md";
+      const ops = createStoreOps(made.store);
+      for (const [key, data] of [["s0", "zero"], ["s1", "one"], ["s2", "two"]] as const) {
+        await ops.workspace.commit([{ path, data }], { owner: "dana", idempotencyKey: key });
+      }
+
+      await expect(ops.workspace.undo("wsc_key_s1", { owner: "dana" }))
+        .rejects.toBeInstanceOf(VendoError);
+      // The newest commit's content is what it was, and still the live version.
+      expect(await (await hosted().open(dana)).readFile(path)).toBe("two");
+      // And the commit it refused is still on the ledger, undoable in order.
+      const ledger = await ops.workspace.history({ owner: "dana", path });
+      expect((ledger.entries as { commitId: string }[]).map((entry) => entry.commitId))
+        .toContain("wsc_key_s1");
+    });
+
     it("still refuses to move an app between mounts — that runs server-side", async () => {
       await expect(
         hosted().moveApp("app_1", { kind: "user", subject: "dana" }, { kind: "org", org: "acme" }),

--- a/packages/store/src/workspace-rows.ts
+++ b/packages/store/src/workspace-rows.ts
@@ -187,6 +187,16 @@ export function workspaceRows(db: Db, files: FilesAdapter): WorkspaceRows {
     if (stored.blobRef !== undefined) await files.delete(stored.blobRef);
   };
 
+  /** Drop `stored` unless `keep` is the same blob. `undo` hands its history
+   *  row's blob straight to the live file row rather than re-uploading the
+   *  bytes, so two undos that pick the same revision both hold the key the
+   *  winner has just made the live file's only copy — and the loser would
+   *  release it, leaving a row pointing at nothing and no history row naming
+   *  it. Whoever still points at a blob keeps it. */
+  const release = async (stored: StoredContent, keep: StoredContent): Promise<void> => {
+    if (stored.blobRef !== keep.blobRef) await dropBlob(stored);
+  };
+
   const currentOf = async (owner: string, path: string): Promise<Current | undefined> => {
     const result = await db.query(
       `SELECT content, blob_ref, revision, bytes, updated_at FROM vendo_workspace_files
@@ -362,7 +372,7 @@ export function workspaceRows(db: Db, files: FilesAdapter): WorkspaceRows {
         // permanent loss, the mirror of the N1/N2 hazard. A won CAS on
         // `revision = prior.revision` is the proof nobody else superseded it.
         if (prepared.prior !== undefined && !options.recordHistory) {
-          await dropBlob(prepared.prior.stored);
+          await release(prepared.prior.stored, prepared.stored);
         }
         await trim(owner, prepared.path);
         return { landed: true, revision: prepared.revision, updatedAt: now };
@@ -374,8 +384,9 @@ export function workspaceRows(db: Db, files: FilesAdapter): WorkspaceRows {
         const settled = await load(head.stored);
         if (settled !== undefined && sameBytes(settled, prepared.content)) {
           // The winner stored exactly these bytes, so there is nothing left to
-          // write — and our blob is now surplus.
-          await dropBlob(prepared.stored);
+          // write — and our blob is surplus, unless the winner is the one now
+          // pointing at it.
+          await release(prepared.stored, head.stored);
           return { landed: false, revision: head.revision, updatedAt: head.updatedAt };
         }
       }

--- a/packages/store/src/workspace.test.ts
+++ b/packages/store/src/workspace.test.ts
@@ -664,6 +664,60 @@ for (const backend of backends()) {
       expect(await (await workspace.open(user)).readFile(path)).toBe(big("b"));
     });
 
+    // The other half of N7, and the worse one: undo hands its history row's
+    // BLOB straight to the live row rather than re-uploading the bytes. Two
+    // undos of the same revision therefore both hold the key the winner just
+    // made the live file's only copy — and the loser's "the winner stored
+    // exactly these bytes, so our blob is surplus" branch deletes it. The row
+    // survives pointing at nothing, so the file is unreadable forever with no
+    // history row left naming it.
+    it("keeps the restored file readable when a second undo lands on the same revision", async () => {
+      const path = "/user/files/undo-twice.bin";
+      const workspace = workspaceStore(made.store);
+      const big = (marker: string): string => marker.repeat(WORKSPACE_INLINE_MAX_BYTES + 1);
+
+      // Live r2 (blob K_b), history r1 (blob K_a).
+      for (const content of [big("a"), big("b")]) {
+        const fs = await workspace.open(user);
+        await fs.writeFile(path, content);
+        await fs.commit({ message: "wrote" });
+      }
+
+      // Force the interleave: an undo's compare-and-swap is the one carrying
+      // recordHistory=false (its last SQL param). Just before the FIRST one
+      // runs, run a whole second undo to completion — so it wins the swap and
+      // K_a becomes the live row's blob, and the one already in flight then
+      // finds a head holding exactly the bytes it was about to write.
+      const db = dbFor(made.store);
+      const original = db.query.bind(db);
+      let winner = false;
+      db.query = async (text: string, params?: unknown[]) => {
+        if (!winner && text.includes("WITH swapped AS") && params?.[params.length - 1] === false) {
+          winner = true;
+          await workspace.undo(caller, path);
+        }
+        return original(text, params);
+      };
+      try {
+        await workspace.undo(caller, path);
+      } finally {
+        db.query = original;
+      }
+      expect(winner).toBe(true);
+
+      // The live row must not point at a blob that is gone.
+      const dangling = await made.sql(
+        `SELECT f.blob_ref FROM vendo_workspace_files f
+         WHERE f.blob_ref IS NOT NULL AND f.path = $1
+           AND NOT EXISTS (
+             SELECT 1 FROM vendo_blobs b WHERE b.namespace = 'workspace' AND b.key = f.blob_ref
+           )`,
+        [path],
+      );
+      expect(dangling).toEqual([]);
+      expect(await (await workspace.open(user)).readFile(path)).toBe(big("a"));
+    });
+
     it("strands no blob when overlapping commits race on one blob-backed path", async () => {
       const path = "/user/files/raced-big.bin";
       const workspace = workspaceStore(made.store);


### PR DESCRIPTION
Three deferred data-integrity leads from the `@vendoai/store` sweep (#982), read fresh against the code and reproduced before any fix. **Two were real and are fixed here. One is not a store bug and is reported, not changed** — the reasoning is below, and it includes a correction to #982's own record.

Each fix is **failing test first**, in the existing behaviour-named suite, watched failing, then fixed — separate commits.

## Order, and what "worst" meant

Worst-first, where worst = **destroying data a user expected to keep** beats **failing to destroy data they asked to remove**. Both fixes fall in the first category, so they are ordered by how total the loss is:

1. **Bug A** leaves the live file row pointing at a deleted blob. The file is unreadable *forever*, with no history row naming what was lost and no user action implicated — two ordinary concurrent turns are enough.
2. **Bug B** destroys one revision. The file stays readable at an older revision, and it takes an explicit `undo(commitId)` call to trigger.

---

## Bug A — `undo` released the blob the live file row points at (`workspace-rows.ts`)

`undo` hands its history row's blob **straight to the live file row** rather than re-uploading the bytes, so the key it holds can already be the live file's only copy. Two undos that pick the same revision therefore both hold that key, and the loser reaches `landRow`'s "the winner stored exactly these bytes, so our blob is surplus" branch and deletes it.

Result: `vendo_workspace_files.blob_ref` points at nothing, the history row that named the revision is already consumed, and the file is unreadable forever.

This is the sibling of the N7 hazard the suite already pins (*"destroys no content when an undo loses its race to a concurrent writer"*), reached through the *other* branch — N7's racing writer wrote **different** bytes, which is exactly why it never hit this one.

**Fix.** Both of `landRow`'s post-swap blob releases now go through one `release(stored, keep)` that keeps a blob some row still points at: the surplus branch checks against the head it lost to, the no-history branch checks the superseded row against the one replacing it. The invariant is stated once instead of re-derived per call site. Nothing is weakened — the blob is still released in every case where nothing points at it.

**Failing test:** `packages/store/src/workspace.test.ts` → *"keeps the restored file readable when a second undo lands on the same revision"*. Fails with one dangling `vendo_workspace_files.blob_ref` on **both** the pglite and the real-Postgres legs.

## Bug B — `undo(commitId)` walked back the newest change instead (`ops.ts`)

`ops.workspace.undo(commitId)` delegates to `workspaceRows.undo`, which pops the **newest** superseded revision at a path — nothing checked that the revision belonged to the commit being undone. Given three commits on one path and an undo of the middle one, it restored the *middle* commit's own content and destroyed the *newest* commit's. Permanently: an undo writes no history row behind it ("undo has no redo"), so there was nowhere left to recover it from. It then deleted the older commit from the ledger and left the newer one, so the ledger afterwards claims the opposite of what happened.

That contradicts the door's own documented promise in `packages/core/src/store.ts`: *"the path's stored before-image comes back"*.

**Fix.** `pathsMovedOn` walks the ledger newest-first as far as the commit itself and names every path a later commit has since touched; the undo is then **refused** with `conflict` rather than walking back a change nobody asked to remove — undo the later commits first. This tightens a guarantee, it does not weaken one. The per-path leg already selects `newestCommitTouching`, so it satisfies the same rule by construction and is unchanged. The `store-ops` conformance suite only ever undoes the newest commit, so it is unaffected (all four of its undo cases pass).

**Failing test:** `packages/store/src/workspace-ops.test.ts` → *"refuses to undo a commit a later one has already built on"*. Fails on both legs, resolving `{}` instead of refusing; with the refusal assertion removed it reads back `"one"` where `"two"` was committed, and the refused commit is gone from the ledger.

## Bug C — `harnessStateStore.get` destroying on read: NOT a store bug, reported not changed

I read all three implementations and the only production caller before deciding. The read **is** destructive, and it is destructive **on purpose**:

- The rule is stated in the interface itself — `packages/harnesses/src/harness-state.ts`: *"The stored state iff it belongs to `harnessName`; a foreign owner CLEARS"* — and implemented identically by the memory reference implementation there and by both halves (SQL and StoreOps) here.
- The **only** production caller is `packages/harnesses/src/runtime.ts:270`, which calls `get(threadId, input.harness.name)` for the harness that is **about to run the turn**. There is no speculative or probing read anywhere in `packages/`, `examples/`, or vendo-web. So the clear fires exactly when a harness swap has genuinely happened, which is what §1.3 asks for.
- **#982 recorded the catalog's argument as "sound". It is not, and this is the new finding.** The argument was that `set` already handles the swap. It does not: `saveHarnessState` (`packages/harnesses/src/runtime.ts:735`) returns early unless `pending.dirty`, so a harness that never writes `turn.state` writes **nothing** at turn end. Drop the destructive read and the previous harness's session id survives the swap and is handed back on a swap-back — precisely the resurrection §1.3 exists to prevent. Recording this so it is not quietly inherited by the next reader of the catalog.

Changing it is therefore a **contract-semantics decision**, and the change would have to land in `packages/harnesses/src/harness-state.ts` — or the SQL and StoreOps halves would disagree with the memory reference implementation, the exact producer/consumer seam-lie this repo's testing law names — plus the pinning test in `packages/vendo/src/hosted-transcript.live.test.ts`. **Both are outside this slice's file set** (`packages/store/**`, `.changeset/`), and `packages/vendo` has pieces in flight. Expected three fixes; found two. Not changed, not started.

---

## Real Postgres — and a behaviour PGlite structurally hides

Bug A is concurrency-shaped, so per the #982 lesson it was not judged from a PGlite run alone. A throwaway Postgres 16 database and role were created locally, used, and **dropped afterwards** (`DROP DATABASE deslop_store; DROP ROLE deslop;` — confirmed, only `postgres`/`template0`/`template1` remain). **No live or Cloud store was touched at any point.**

- Both new tests **fail pre-fix and pass post-fix on the real-Postgres leg as well as pglite**, so the Postgres coverage is load-bearing rather than decorative.
- **The divergence, worth writing down for the next person.** Probing two concurrent whole-commit `undo`s of the *same* commit:
  - **PGlite: one success and one `not-found`, 12/12 trials.** It serialises, so it physically cannot express the interleave.
  - **Real Postgres: BOTH land, 11/12 trials** (the 12th, at zero stagger, went 1). `ops.undo` runs in a transaction and two of them genuinely overlap on a real pool.
  - **End state is correct either way:** right live content, zero dangling blobs, history intact, across a further 8 three-revision trials. **No additional data loss** — the loser's re-aim finds the head already holding its bytes and, with Bug A's fix, releases nothing.
  - What is left is that the second caller is told its undo succeeded when it did nothing. **Observed behaviour, noted and deliberately NOT fixed here** — that is a fourth bug in a slice scoped to three. The probe was scratch and is not committed.

  The general lesson: a green PGlite run is not evidence that an interleaved-transaction path is safe, and here it actively reports the *opposite* of what the real engine does.

## Persisted data — what happens to rows that already exist

**No schema change. No migration. No sweep. Nothing was run against any live or Cloud store, and nothing needs to be for these fixes to be correct.**

- **Bug A.** Both edits are pure delete-suppression: strictly *fewer* blob deletions, never more, and never a different row. Rows already on disk are untouched and read exactly as before. **A dangling `blob_ref` written before this fix does NOT heal itself** — such a row stays unreadable, and the content is genuinely gone: no history row and no second copy exist, because the history row that named the revision was consumed in the same operation that deleted the blob. There is therefore **no recovery action to propose, because there is nothing left to recover from**. The only host-visible action is *detection*, and the read-only query is the one the new test uses:

  ```sql
  SELECT f.path, f.owner, f.blob_ref
    FROM vendo_workspace_files f
   WHERE f.blob_ref IS NOT NULL
     AND NOT EXISTS (
       SELECT 1 FROM vendo_blobs b
        WHERE b.namespace = 'workspace' AND b.key = f.blob_ref
     );
  ```

  It is read-only and destroys nothing, but **I did not run it against anything except my throwaway database.** Whether to run it on a real deployment — and what to do with any rows it returns, since the content cannot be restored and the choice is between leaving an unreadable row and deleting it — is an owner's call, not mine.

- **Bug B.** Adds a pre-check and a refusal; writes no row that was not written before. Existing ledger and workspace rows are read with the same queries and are unchanged. **Commits already mis-undone left no trace to repair**: the newer content they destroyed is gone, and the older commit they deleted from the ledger cannot be reconstructed from what remains. Detection only; no sweep proposed, nothing run.

- **Behaviour change to be aware of on upgrade:** an `ops.workspace.undo(commitId)` that used to "succeed" against a superseded commit now returns `conflict`. That is the point — it was succeeding by destroying something. Callers undo the later commits first.

## vendo-web tandem disposition — no companion PR needed, per bug

Cloud runs on this store, so this was checked in vendo-web's source rather than waved through. The file is **`apps/console/lib/api/store-doors.ts`** in every case.

- **Bug A — no mirror exists.** The console's hosted workspace stores each file as a `vendo_records` row carrying its `data` **inline** (`fileRow`/`fileId`, `store-doors.ts:410-480`). There is no blob indirection in that path at all, so there is no blob to release and nothing to adapt. Cloud's other consumer of this code — the automations executor, which vendors `@vendoai/store` and opens a real `postgres(url)` — picks the fix up unchanged when the tarball is re-vendored. Safe no-op.
- **Bug B — the console implements this verb itself, on a different model, and does not have this bug.** Its `case "undo"` (`store-doors.ts:658`) restores the **before-image the commit itself recorded** (`commitBefore`), so it can never restore the wrong revision the way the local backend did. No adaptation is required, and none would be correct.
- **Bug C — no mirror.** The console's harness door is a plain `get`/`set`/`clear` on `(appId, subject)` over `vendo_harness_state`; it knows nothing of harness names. The destructive step lives entirely in this repo's `overOps.get`, which issues an explicit extra `harness.clear` call.
- **One Cloud-side finding to flag, in that same file, which I did NOT touch:** undoing an *older* commit there overwrites a newer commit's value via `files.put` **without recording a before-image anywhere**, so the newer content is unrecoverable — the same family as Bug B, a different mechanism. It is in a repo outside this slice, and the right answer (refuse, as here, vs. revert-with-clobber) is a semantics call. **Flagged for an owner, not started.**

## Gates

All foreground, one at a time, each redirected to a file and read back from disk. Scoped builds only; the `store` suite ran alone (it boots an embedded PGlite per worker, and its own config pins `fileParallelism: false`).

| Gate | Result |
|---|---|
| `pnpm build --filter=@vendoai/store...` | **exit 0** — `Tasks: 2 successful, 2 total` |
| `packages/store` suite | **exit 0** — `Test Files 51 passed \| 1 skipped (52)`, `Tests 510 passed \| 4 skipped (514)`, 1138.21s |
| `packages/store` suite with `POSTGRES_URL` set (both legs, touched suites) | **exit 0** — `Test Files 2 passed (2)`, `Tests 86 passed (86)` |
| root `pnpm typecheck` | **exit 0** — `Tasks: 40 successful, 40 total` |
| root `pnpm lint` | **exit 0** (FULL TURBO) |
| root `turbo lint --force` | **exit 0** — `Tasks: 3 successful, 3 total`, `Cached: 0 cached`, 17.118s |

Suites ran with `VITEST_MIN_FORKS=1 VITEST_MAX_FORKS=2 VITEST_MIN_THREADS=1 VITEST_MAX_THREADS=2`. The full repo suite was not run locally — that is CI's job.

**Post-commit symbol sweep, repo-wide including test dirs.** Package typecheck configs exclude test files (`packages/store/tsconfig.json` → `"exclude": ["src/**/*.test.ts", ...]`), so a broken test survives build *and* typecheck and dies only in CI. Checked explicitly rather than assumed:

- `pathsMovedOn` and `release` are both newly introduced and **module-local** — the only repo-wide hits for `pathsMovedOn` are its definition and its one call site in `ops.ts`; every other `release(` in the repo is an unrelated local in another package's tests.
- `git diff origin/main...HEAD` on `packages/store/src/index.ts` and `postgres.ts` is **empty** — no public surface change.
- Ran `tsc` over the package **with the test exclusion removed**, on my branch and on `origin/main`: **67 errors on both, the identical set**, the only difference being one pre-existing error shifting from line 695 to 749 by exactly the 54 lines I inserted above it. **My test additions introduce zero new typecheck errors.**

## Real LOC

| | Source | Tests |
|---|---|---|
| `packages/store` | +58 / −3 | +77 / −0 |

## Changeset

`@vendoai/store` → **patch**: two bug fixes, no public surface change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix two workspace-undo data‑loss bugs in `@vendoai/store` and close a mid‑undo race so files stay readable and newer content isn’t removed. `undo(commitId)` now rejects older commits if newer commits touched the same paths; no schema or public API changes.

- **Bug Fixes**
  - Prevent dangling file pointers on double‑undo: centralize blob release in `workspace-rows.ts` to keep a blob if any row still references it.
  - Make undo order‑safe: add `pathsMovedOn` pre‑check in `ops.ts` so `ops.workspace.undo(commitId)` returns `conflict` when newer commits modified the same paths; only newest commits are undoable.
  - Close the undo race window: hold affected file rows with `SELECT ... FOR UPDATE` during undo’s check‑and‑act in `ops.ts` to avoid destroying content from a commit that lands mid‑undo (both bulk and per‑path).

<sup>Written for commit 1533d372b6cd25e8885751b93e9ed6024d0d170a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

