### PR TITLE
fix(automations,demo-bank): Maple's Automations tab 400s on its own seeded run history

### DIFF
--- a/.changeset/a-run-row-without-a-trigger-still-reads.md
+++ b/.changeset/a-run-row-without-a-trigger-still-reads.md
@@ -1,0 +1,16 @@
+---
+"@vendoai/automations": patch
+---
+
+A run row that names no trigger reads back under the default trigger.
+
+Making an app's triggers a LIST added a required `triggerId` to the persisted
+run record with no read fallback, so every row written before that made
+`runs.list` throw `validation` for the whole app — the surface asking for one
+automation's history got a 400 instead of a gap, and one legacy row took the
+app's entire fire record down with it. The field now defaults to
+`DEFAULT_TRIGGER_ID` on read, exactly as the capture row's `triggerId` beside
+it already did: a row written when an app had one trigger fired that trigger.
+
+Nothing changes for rows written since. Nothing is rewritten on disk; the
+default applies on read.

--- a/examples/demo-bank/src/demo-script/console-seed.test.ts
+++ b/examples/demo-bank/src/demo-script/console-seed.test.ts
@@ -1,0 +1,72 @@
+/**
+ * The console seed's producer/consumer seam.
+ *
+ * `seedConsoleData` writes `vendo_apps` and `vendo_runs` rows that nothing in
+ * this app reads back — the Vendo automations engine does, through the same
+ * `/runs` door the Automations tab calls. So both halves are REAL here: the
+ * shipped seeder writes into a real store, and the shipped composition reads
+ * out of it, with no stub on either side. A seed shaped for an older row
+ * schema is invisible to a test that reads its own writes, and shipped as four
+ * 400s on the live demo's Automations tab.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { AppId, RunContext } from "@vendoai/core";
+import { createStore, type VendoStore } from "@vendoai/store";
+import { createVendo, type Vendo } from "@vendoai/vendo/server";
+import { mapleDemoUsers } from "@/server/users";
+import { seedConsoleData } from "./console-seed";
+
+const ctx = (subject: string): RunContext => ({
+  principal: { kind: "user", subject },
+  venue: "chat",
+  presence: "present",
+  sessionId: `session_${subject}`,
+});
+
+describe("console seed", () => {
+  let dataDir: string;
+  let store: VendoStore;
+  let vendo: Vendo;
+
+  beforeAll(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), "maple-console-seed-"));
+    store = createStore({ dataDir });
+    await store.ensureSchema();
+    await seedConsoleData(store);
+    vendo = createVendo({ store });
+  }, 120_000);
+
+  afterAll(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+
+  it("gives every seeded automation a run history the Automations tab can read", async () => {
+    const subject = mapleDemoUsers()[0]!.subject;
+    const listed = await vendo.automations.list(ctx(subject));
+    expect(listed.length).toBeGreaterThan(0);
+
+    // The panel's health strip fetches runs per (app, trigger) pair, exactly
+    // like this. A pair whose rows the engine cannot parse throws instead of
+    // answering, and the tab's strip goes missing behind a 400.
+    const withHistory: string[] = [];
+    for (const entry of listed) {
+      for (const { trigger } of entry.triggers) {
+        const { runs } = await vendo.automations.runs.list(
+          { appId: entry.app.id as AppId, triggerId: trigger.id },
+          ctx(subject),
+        );
+        if (runs.length > 0) withHistory.push(entry.app.name);
+      }
+    }
+    expect(withHistory.sort()).toEqual([
+      "Balance below $500 alert",
+      "Monthly bill review",
+      "Payday savings sweep",
+      "Weekly spending digest",
+    ]);
+  }, 120_000);
+});

--- a/examples/demo-bank/src/demo-script/console-seed.ts
+++ b/examples/demo-bank/src/demo-script/console-seed.ts
@@ -249,6 +249,10 @@ async function seedRuns(store: VendoStore, subjects: string[], anchor: Date): Pr
       const outcome = run.failure === undefined ? ("ok" as const) : ("error" as const);
       const record = {
         id: run.id, appId: run.appId,
+        // WHICH trigger fired. Every seeded automation declares exactly one,
+        // under the default id (automationDocs above), so that is what a fire
+        // of it recorded.
+        triggerId: DEFAULT_TRIGGER_ID,
         trigger: { kind: "schedule" as const },
         status, startedAt, finishedAt,
         steps: run.steps.map((step, index) => ({

--- a/packages/automations/src/engine.test.ts
+++ b/packages/automations/src/engine.test.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_TRIGGER_ID,
   VENDO_APP_FORMAT,
   descriptorHash,
   triggerKindRefs,
@@ -1009,6 +1010,36 @@ describe("fail-loud consent and re-run", () => {
 
     expect(await engine.runs.get("run_legacy", ctx())).toMatchObject({ status: "error" });
     expect((await engine.runs.list({ appId: doc.id }, ctx())).runs.map((run) => run.status)).toEqual(["error"]);
+  });
+
+  /** A row written before an app had a LIST of triggers names no trigger. It is
+   *  the app's only one, so it reads back as the default — a strict parse made
+   *  one such row throw for every runs.list of its app, which is the whole
+   *  history gone, not one row. */
+  it("reads a run row written before triggers were a list back under the default trigger", async () => {
+    const store = memoryStoreAdapter();
+    const doc = twoStepApp("app_legacy_untriggered");
+    await seedApp(store, doc, "user_a", true);
+    const engine = createAutomations({
+      apps: appsDouble(), tools: registry([readTool, writeTool]), guard: new GuardDouble(), store, now: () => NOW,
+    });
+    const record = {
+      id: "run_untriggered",
+      appId: doc.id,
+      trigger: { kind: "host-event", event: "go" },
+      status: "ok",
+      startedAt: NOW.toISOString(),
+      steps: [{ id: "read", tool: readTool.name, outcome: "ok", at: NOW.toISOString() }],
+    };
+    await store.records("vendo_runs").put({
+      id: record.id,
+      data: { appId: doc.id, trigger: record.trigger, status: "ok", record, startedAt: record.startedAt },
+      refs: { app_id: doc.id, status: "ok" },
+    });
+
+    expect(await engine.runs.get("run_untriggered", ctx())).toMatchObject({ triggerId: DEFAULT_TRIGGER_ID });
+    const listed = await engine.runs.list({ appId: doc.id, triggerId: DEFAULT_TRIGGER_ID }, ctx());
+    expect(listed.runs.map((run) => run.id)).toEqual(["run_untriggered"]);
   });
 });
 

--- a/packages/automations/src/types.ts
+++ b/packages/automations/src/types.ts
@@ -146,7 +146,12 @@ const storedRunStatusSchema = z.union([
 const baseRunRecordSchema = z.object({
   id: z.string(),
   appId: z.string(),
-  triggerId: z.string(),
+  /** Defaulted for the same reason `captureSchema.triggerId` above is: a run
+   *  row written before triggers became a list names none, and it fired the
+   *  app's only trigger, which is the default one. Strict, ONE such row threw
+   *  for every `runs.list` of its app — a single legacy row took the whole
+   *  history down, and the surface reading it got a 400 rather than a gap. */
+  triggerId: z.string().default(DEFAULT_TRIGGER_ID),
   trigger: z.object({
     kind: z.enum(["schedule", "host-event", "external"]),
     event: z.string().optional(),


### PR DESCRIPTION
Maple's **Automations tab** fired four `GET /api/vendo/runs` that all came back **400**, on the demo we show prospects. Found during a browser check of #973, which correctly flagged it rather than widening — that PR touched no automations code.

## The four requests, and what the server actually said

```
GET /api/vendo/runs?appId=app_seed_paydaysweep_vendo-demo&triggerId=main
  400 {"error":{"code":"validation","message":"invalid run row run_seed_sweep_1_vendo-demo: Required"}}
GET /api/vendo/runs?appId=app_seed_lowbalance500_vendo-demo&triggerId=main
  400 {"error":{"code":"validation","message":"invalid run row run_seed_alert_1_vendo-demo: Required"}}
GET /api/vendo/runs?appId=app_seed_billreview_vendo-demo&triggerId=main
  400 {"error":{"code":"validation","message":"invalid run row run_seed_bills_1_vendo-demo: Required"}}
GET /api/vendo/runs?appId=app_seed_weeklydigest_vendo-demo&triggerId=main
  400 {"error":{"code":"validation","message":"invalid run row run_seed_digest_2_vendo-demo: Required"}}
```

One bug, four times: the tab fetches runs per (app, trigger) pair, and exactly the four seeded automations that carry run history fail. The two paused ones have no rows, so they answer fine.

## Root cause

#827 made an app's triggers a **list** and added a required `triggerId` to the **persisted** run record (`baseRunRecordSchema`) with no read fallback. Two consequences, and the fix needs both halves:

1. **Every run row written before #827 now fails to parse.** `runs.list` parses each row in the page, so ONE unparseable row throws `validation` for the whole app — the surface asking for one automation's history gets a 400 instead of a gap. The sibling field in the same file, `captureSchema.triggerId`, was given exactly this fallback in that same change; the run row was missed.
2. **The demo's console seed still writes pre-#827 rows.** It was written before #827 and never updated.

Seeding is insert-if-absent, so half 2 alone would **not** have fixed maple.vendo.run — the broken rows are already in the deployed store and would have survived the redeploy untouched. Half 1 is what repairs them, with no migration and nothing rewritten on disk.

## Fix

- `packages/automations/src/types.ts` — `baseRunRecordSchema.triggerId` defaults to `DEFAULT_TRIGGER_ID` on read. A row written when an app had one trigger fired that trigger. (Diagnosed in `engine.ts`; #993 split the engine mid-flight, so this is rebased onto the schema's new home in `types.ts`.)
- `examples/demo-bank/src/demo-script/console-seed.ts` — the seed writes `triggerId`. The seeder should not lean on a legacy fallback.

No Maple brand, copy, seeded content or product behaviour changed. The org policy ("Money never moves on behalf of an external MCP client") is untouched and still enforced — see the `mcp:e2e` output below.

## Tests — failing first, in separate commits

- `packages/automations/src/engine.test.ts` → **"reads a run row written before triggers were a list back under the default trigger"**, next to the existing legacy-parked-row case.
- `examples/demo-bank/src/demo-script/console-seed.test.ts` (new — the seeder had **no** test at all) → **"gives every seeded automation a run history the Automations tab can read"**. This is the real seam: the shipped `seedConsoleData` writes into a real PGlite store and the shipped `createVendo` composition reads it back through `automations.runs.list`, no stub on either side. Both were red for the production reason (`invalid run row ...: Required`) before the fix.

## Browser verification

Real Chromium, real dev server, same viewport, same cards. The before/after pair was captured against the **already-broken** store with no reseed — the maple.vendo.run situation exactly — which is what proves the fallback repairs rows already on disk.

| | Before | After |
|---|---|---|
| Run-health strips | absent | `Last 10 runs · 9 ok · 1 failed`, `Last 3 runs · 3 ok` |
| Run history panel | opens empty | real seeded summaries |
| Console errors | 12 × `400 (Bad Request)` | **0** |
| Failed `/api/vendo/*` | 4 distinct, 12 total | **0** |

**The run-health strip, same two cards, same viewport** — absent before, present after:

<img width="440" src="https://raw.githubusercontent.com/runvendo/vendo/evidence/fix-maple-automations-400/shots/before-history-strips.png" alt="Automations tab before the fix: Balance below $500 alert and Payday savings sweep cards show no run-health strip" /> <img width="440" src="https://raw.githubusercontent.com/runvendo/vendo/evidence/fix-maple-automations-400/shots/after-history-strips.png" alt="Automations tab after the fix: the same two cards now show Last 10 runs 9 ok 1 failed and Last 3 runs 3 ok" />

**Run history, opened on the same automation** — silently empty before, real seeded summaries after:

<img width="440" src="https://raw.githubusercontent.com/runvendo/vendo/evidence/fix-maple-automations-400/shots/before-run-history.png" alt="Run history panel open but rendering nothing" /> <img width="440" src="https://raw.githubusercontent.com/runvendo/vendo/evidence/fix-maple-automations-400/shots/after-run-history.png" alt="Run history showing two Succeeded runs with their seeded bill-review summaries" />

**Final rebased build, wiped store, freshly seeded** — the Automations tab clean, zero console errors:

<img width="900" src="https://raw.githubusercontent.com/runvendo/vendo/evidence/fix-maple-automations-400/shots/final-run-history.png" alt="Automations tab on the final build: Monthly bill review with run-health strip and expanded run history" />

Also exercised the fresh-seed path two ways: clicking **Reset demo** (wipe + re-seed through the app's own door), and a wiped `.vendo/data` boot on the final rebased build. Both: zero 400s, zero console errors, automations still rendering their real seeded content.

## vendo-web tandem — no-op, justified

`apps/console/lib/automations/runs.ts` already applies this exact fallback in two places: `triggerId?: string` on `InternalRun`, `run.triggerId ?? DEFAULT_TRIGGER_ID` at line 400, and the same default at line 231. The console's mirror got it right; the OSS reader was the outlier. No companion PR needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
