### PR TITLE
feat(apps,fixtures): apps ships its testing fixtures, and the twice-written model and bridge helpers get one private home

### DIFF
--- a/.changeset/apps-ships-its-testing-fixtures.md
+++ b/.changeset/apps-ships-its-testing-fixtures.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/apps": minor
+---
+
+`@vendoai/apps` now ships its testing fixtures at the `./testing` subpath. The directory (`fake-sandbox`, `fake-box`, `scriptedLanguageModel`, `guardFixture`, `memoryStore`, and the rest) was already compiled into `dist/testing/` and already inside the published `dist` files-entry, but no `exports` key pointed at it, so it was dead weight in the tarball and unreachable to anyone — including this repo's own fixture suites, one of which carries the comment "the apps package's own test double is internal to that package" as the reason it hand-rolled a fortieth copy of a scripted model. Same posture as the `./adapter-conformance` subpath this package already publishes: testing material a host can use against the seams it implements. Purely additive — no existing subpath, type, or runtime behaviour changes.

--- a/fixtures/automations-e2e/src/agentic-consent.e2e.test.ts
+++ b/fixtures/automations-e2e/src/agentic-consent.e2e.test.ts
@@ -15,8 +15,8 @@
  *     can never happen is a false choice, not consent.
  */
 import { planAutomation, type HostToolInfo } from "@vendoai/apps";
+import { scriptedLanguageModel } from "@vendoai/apps/testing";
 import { withheldFromUnattended, type ToolDescriptor } from "@vendoai/core";
-import type { LanguageModel } from "ai";
 import { beforeEach, describe, expect, it } from "vitest";
 import { automationDoc, createStack, hostTools, ownerCtx, resetFixture } from "./harness.js";
 import { ADA } from "./support.js";
@@ -39,32 +39,6 @@ const descriptorFor = (name: string): ToolDescriptor => {
     risk: tool.risk as ToolDescriptor["risk"],
   };
 };
-
-/** One scripted turn, streamed the way `askModel` consumes it. */
-const scriptedModel = (answer: string): LanguageModel => ({
-  specificationVersion: "v2",
-  provider: "vendo-fixture",
-  modelId: "vendo-fixture-v1",
-  supportedUrls: {},
-  async doStream() {
-    return {
-      stream: new ReadableStream({
-        start(controller) {
-          controller.enqueue({ type: "stream-start", warnings: [] });
-          controller.enqueue({ type: "text-start", id: "text_1" });
-          controller.enqueue({ type: "text-delta", id: "text_1", delta: answer });
-          controller.enqueue({ type: "text-end", id: "text_1" });
-          controller.enqueue({
-            type: "finish",
-            finishReason: "stop",
-            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-          });
-          controller.close();
-        },
-      }),
-    };
-  },
-} as unknown as LanguageModel);
 
 /** What the planner is asked for, in the words the finding used: a judgment run
  *  that READS and WRITES A NOTE. It reaches two tools; the app is bound to six. */
@@ -97,7 +71,7 @@ describe("agentic consent surface", () => {
       instruction: REVIEW_INSTRUCTION,
       mode: "agentic",
       tools: plannerTools,
-    }, scriptedModel(REVIEW_PLAN));
+    }, scriptedLanguageModel(REVIEW_PLAN));
 
     if (planned.kind !== "plan") throw new Error(`planning failed: ${planned.issues.join(" | ")}`);
     const { run } = planned.plan.trigger;

--- a/fixtures/automations-e2e/src/automation-refusal.e2e.test.ts
+++ b/fixtures/automations-e2e/src/automation-refusal.e2e.test.ts
@@ -22,60 +22,18 @@
  * never offered, and an ask that needs one comes back as a sentence.
  */
 import { planAutomation, type AutomationPlanInput, type HostToolInfo } from "@vendoai/apps";
+import { scriptedLanguageModel, type ScriptedModelCall } from "@vendoai/apps/testing";
 import { UNATTENDED_DESTRUCTIVE_REASON } from "@vendoai/core";
-import type { LanguageModel } from "ai";
 import { describe, expect, it } from "vitest";
 
 const SEND_TOOL = "host_invoices_send";
 
-interface ModelCall {
-  prompt: Array<{ role: string; content: string | Array<{ type?: string; text?: string }> }>;
-}
-
-const promptText = (call: ModelCall): string => call.prompt
+/** The prompt the planner was asked with, flattened. */
+const promptText = (call: ScriptedModelCall): string => call.prompt
   .map((message) => typeof message.content === "string"
     ? message.content
     : message.content.map((part) => part.text ?? "").join(""))
   .join("\n");
-
-/** Minimal deterministic LanguageModelV2 double — one scripted answer, and the
- *  prompt it was asked with. Local copy for the same reason `ladder.e2e.test.ts`
- *  keeps one: the apps package's own test double is internal to that package. */
-const scriptedModel = (respond: (prompt: string) => string): LanguageModel => {
-  const model = {
-    specificationVersion: "v2" as const,
-    provider: "vendo-scripted",
-    modelId: "vendo-scripted-refusal",
-    supportedUrls: {},
-    async doGenerate(call: ModelCall) {
-      return {
-        content: [{ type: "text" as const, text: respond(promptText(call)) }],
-        finishReason: "stop" as const,
-        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-      };
-    },
-    async doStream(call: ModelCall) {
-      const text = respond(promptText(call));
-      return {
-        stream: new ReadableStream({
-          start(controller) {
-            controller.enqueue({ type: "stream-start", warnings: [] });
-            controller.enqueue({ type: "text-start", id: "text_1" });
-            controller.enqueue({ type: "text-delta", id: "text_1", delta: text });
-            controller.enqueue({ type: "text-end", id: "text_1" });
-            controller.enqueue({
-              type: "finish",
-              finishReason: "stop",
-              usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-            });
-            controller.close();
-          },
-        }),
-      };
-    },
-  };
-  return model as unknown as LanguageModel;
-};
 
 const tools: HostToolInfo[] = [
   { name: "host_invoices_list", description: "List invoices", risk: "read" },
@@ -132,7 +90,7 @@ const issuesOf = (result: Awaited<ReturnType<typeof planAutomation>>): string[] 
 
 describe("automation authoring refuses irreversible work", () => {
   it("refuses a steps body that names a destructive send tool, in the person's words", async () => {
-    const result = await planAutomation(stepsInput, scriptedModel(() => readAndSend));
+    const result = await planAutomation(stepsInput, scriptedLanguageModel(readAndSend));
 
     const refusal = issuesOf(result).find((issue) => issue.includes(SEND_TOOL));
     expect(refusal).toBeDefined();
@@ -144,7 +102,8 @@ describe("automation authoring refuses irreversible work", () => {
 
   it("never offers the destructive tool to the model in the first place", async () => {
     const offered: string[] = [];
-    const model = scriptedModel((prompt) => {
+    const model = scriptedLanguageModel((call) => {
+      const prompt = promptText(call);
       offered.push(prompt);
       return readAndPublish;
     });
@@ -172,7 +131,7 @@ describe("automation authoring refuses irreversible work", () => {
 
     const result = await planAutomation(
       { ...stepsInput, mode: "agentic" },
-      scriptedModel(() => agentic),
+      scriptedLanguageModel(agentic),
     );
 
     const refusal = issuesOf(result).find((issue) => issue.includes(SEND_TOOL));
@@ -181,7 +140,7 @@ describe("automation authoring refuses irreversible work", () => {
   });
 
   it("still accepts the away-safe version of the same ask — read, then publish", async () => {
-    const result = await planAutomation(stepsInput, scriptedModel(() => readAndPublish));
+    const result = await planAutomation(stepsInput, scriptedLanguageModel(readAndPublish));
 
     expect(result.kind).toBe("plan");
     if (result.kind !== "plan") return;

--- a/fixtures/integration/package.json
+++ b/fixtures/integration/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@types/node": "^22.0.0",
+    "@vendoai-fixtures/test-kit": "workspace:*",
     "ai": "^6.0.0",
     "fflate": "^0.8.2",
     "typescript": "^5.6.0",

--- a/fixtures/integration/src/harness.ts
+++ b/fixtures/integration/src/harness.ts
@@ -29,7 +29,16 @@ import type { AppDocument, Principal, ToolRegistry } from "@vendoai/core";
 import { createMcpDoor, type AppsPort, type HostOAuthAdapter, type McpDoor } from "@vendoai/mcp";
 import { createStore, type VendoStore } from "@vendoai/store";
 import { createVendo, type CreateVendoConfig, type Vendo } from "@vendoai/vendo/server";
-import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+import {
+  scriptedModel,
+  textTurn,
+  toolCallTurn,
+  ZERO_USAGE,
+  type LanguageModelV3Prompt,
+  type LanguageModelV3StreamPart,
+  type ScriptedModel,
+  type ScriptedTurn,
+} from "@vendoai-fixtures/test-kit/stream-turns";
 import type { LanguageModel } from "ai";
 
 export const fixtureBaseUrl = (): string => inject("fixtureBaseUrl");
@@ -59,45 +68,23 @@ export const BOB: Principal = { kind: "user", subject: "user_bob" };
 export const WIRE_BASE = "/api/vendo";
 
 // ---------------------------------------------------------------------------
-// Scripted LanguageModel — the chat-e2e technique. ONE model instance drives
-// BOTH the agent loop (doStream) AND the apps generation engine (doGenerate via
-// generateText); they share one FIFO queue of turns, so a journey scripts turns
-// in the exact order the composed system will consume them.
+// Scripted LanguageModel — the chat-e2e technique, now shared with every other
+// suite that scripts a model (`@vendoai-fixtures/test-kit/stream-turns`).
+// Re-exported here so
+// this harness stays the single import every journey in this package reaches
+// for.
 // ---------------------------------------------------------------------------
 
-type LanguageModelV3Prompt = Parameters<MockLanguageModelV3["doStream"]>[0]["prompt"];
-type LanguageModelV3StreamPart = Awaited<
-  ReturnType<MockLanguageModelV3["doStream"]>
->["stream"] extends ReadableStream<infer Part> ? Part : never;
-type LanguageModelV3GenerateResult = Awaited<ReturnType<MockLanguageModelV3["doGenerate"]>>;
-type LanguageModelV3Content = LanguageModelV3GenerateResult["content"][number];
-
-export const ZERO_USAGE = {
-  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
-  outputTokens: { total: 0, text: 0, reasoning: 0 },
-} as const;
-
-/** A plain assistant text turn (agent doStream). */
-export function textTurn(text: string, id = "text_1"): LanguageModelV3StreamPart[] {
-  return [
-    { type: "text-start", id },
-    { type: "text-delta", id, delta: text },
-    { type: "text-end", id },
-    { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "stop", raw: undefined } },
-  ];
-}
-
-/** An agent turn that calls one tool (agent doStream). */
-export function toolCallTurn(
-  toolName: string,
-  input: unknown,
-  toolCallId = "call_1",
-): LanguageModelV3StreamPart[] {
-  return [
-    { type: "tool-call", toolCallId, toolName, input: JSON.stringify(input) },
-    { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "tool-calls", raw: undefined } },
-  ];
-}
+export {
+  scriptedModel,
+  textTurn,
+  toolCallTurn,
+  ZERO_USAGE,
+  type LanguageModelV3Prompt,
+  type LanguageModelV3StreamPart,
+  type ScriptedModel,
+  type ScriptedTurn,
+};
 
 /** A generation-engine turn: the apps engine reads this through doGenerate and
  * parses the emitted text as CREATE/EDIT-dialect JSON. Pass the object; it is
@@ -156,60 +143,11 @@ export function screenAgentCreateTurns(dialect: string): LanguageModelV3StreamPa
   ];
 }
 
-/**
- * One scripted turn: the chunks, or a function of the prompt that was handed to
- * the model.
- *
- * The function form exists for the ids a journey cannot know in advance — the
- * front door mints an app's id at request time and writes it into the screen
- * agent's brief, so a turn that has to NAME that app (`validate({ appId })`)
- * reads it off the brief exactly as the model it stands in for would.
- */
-export type ScriptedTurn =
-  | LanguageModelV3StreamPart[]
-  | ((prompt: LanguageModelV3Prompt) => LanguageModelV3StreamPart[]);
-
 /** The app id the composed server put in the prompt it just sent, if any. */
 export function appIdInPrompt(prompt: LanguageModelV3Prompt): string {
   const found = /app_[0-9a-f-]{8,}/.exec(JSON.stringify(prompt));
   if (found === null) throw new Error("no app id in the prompt the model was handed");
   return found[0];
-}
-
-export type ScriptedModel = MockLanguageModelV3 & { prompts: LanguageModelV3Prompt[] };
-
-export function scriptedModel(turns: readonly ScriptedTurn[]): ScriptedModel {
-  const remaining = turns.map((turn) => (typeof turn === "function" ? turn : [...turn]));
-  const prompts: LanguageModelV3Prompt[] = [];
-  const shift = (prompt: LanguageModelV3Prompt): LanguageModelV3StreamPart[] => {
-    prompts.push(structuredClone(prompt));
-    const turn = remaining.shift();
-    if (turn === undefined) throw new Error("scripted model exhausted");
-    const chunks = typeof turn === "function" ? turn(prompt) : turn;
-    return chunks;
-  };
-  const model = new MockLanguageModelV3({
-    doStream: async (request) => ({ stream: simulateReadableStream({ chunks: shift(request.prompt) }) }),
-    doGenerate: async (request): Promise<LanguageModelV3GenerateResult> => {
-      const chunks = shift(request.prompt);
-      const finish = chunks.find((part) => part.type === "finish");
-      const content: LanguageModelV3Content[] = [];
-      const text = chunks
-        .filter((part): part is Extract<LanguageModelV3StreamPart, { type: "text-delta" }> => part.type === "text-delta")
-        .map((part) => part.delta)
-        .join("");
-      if (text.length > 0) content.push({ type: "text", text });
-      for (const part of chunks) if (part.type === "tool-call") content.push(structuredClone(part));
-      return {
-        content,
-        finishReason: finish?.finishReason ?? { unified: "stop", raw: undefined },
-        usage: finish?.usage ?? ZERO_USAGE,
-        warnings: [],
-      };
-    },
-  }) as ScriptedModel;
-  model.prompts = prompts;
-  return model;
 }
 
 // ---------------------------------------------------------------------------

--- a/fixtures/mcp-e2e/package.json
+++ b/fixtures/mcp-e2e/package.json
@@ -24,6 +24,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@types/node": "^22.0.0",
     "@types/pg": "^8.11.10",
+    "@vendoai-fixtures/test-kit": "workspace:*",
     "pg": "^8.22.0",
     "typescript": "^5.6.0",
     "vitest": "^2.1.0"

--- a/fixtures/mcp-e2e/src/knowledge-governance.e2e.test.ts
+++ b/fixtures/mcp-e2e/src/knowledge-governance.e2e.test.ts
@@ -7,9 +7,10 @@
  * packages/vendo/src/knowledge-governance.test.ts.
  */
 import { mkdtemp, rm } from "node:fs/promises";
-import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { nodeBridge } from "@vendoai-fixtures/test-kit/node-bridge";
 import { memoryKnowledgeAdapter } from "@vendoai/core/conformance";
 import type { Principal } from "@vendoai/core";
 import type { HostOAuthAdapter } from "@vendoai/mcp";
@@ -85,7 +86,7 @@ async function createKnowledgeUmbrella(): Promise<Umbrella> {
     }),
   };
   let handler: Vendo["handler"] | undefined;
-  const httpServer = createServer((req, res) => void bridge(req, res, (request) => handler!(request)));
+  const httpServer = createServer((req, res) => void nodeBridge(req, res, (request) => handler!(request)));
   await new Promise<void>((resolve, reject) => {
     httpServer.once("error", reject);
     httpServer.listen(0, "127.0.0.1", () => {
@@ -137,34 +138,3 @@ describe("visibility governance — MCP leg (k8 T5)", () => {
     }
   });
 });
-
-async function bridge(
-  req: IncomingMessage,
-  res: ServerResponse,
-  handler: (request: Request) => Promise<Response>,
-): Promise<void> {
-  try {
-    const chunks: Buffer[] = [];
-    for await (const chunk of req) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-    const host = req.headers.host ?? "127.0.0.1";
-    const headers = new Headers();
-    for (const [name, value] of Object.entries(req.headers)) {
-      if (value === undefined) continue;
-      headers.set(name, Array.isArray(value) ? value.join(", ") : value);
-    }
-    const body = chunks.length === 0 ? undefined : Buffer.concat(chunks);
-    const request = new Request(`http://${host}${req.url ?? "/"}`, {
-      method: req.method,
-      headers,
-      ...(body === undefined ? {} : { body }),
-    });
-    const response = await handler(request);
-    res.statusCode = response.status;
-    response.headers.forEach((value, name) => res.setHeader(name, value));
-    res.end(Buffer.from(await response.arrayBuffer()));
-  } catch (error) {
-    res.statusCode = 500;
-    res.setHeader("content-type", "text/plain");
-    res.end(error instanceof Error ? error.message : "knowledge umbrella bridge failed");
-  }
-}

--- a/fixtures/mcp-e2e/src/umbrella-hookup.e2e.test.ts
+++ b/fixtures/mcp-e2e/src/umbrella-hookup.e2e.test.ts
@@ -13,9 +13,10 @@
  * loopback origin, so the door and the host API are genuinely separate origins.
  */
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
-import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { nodeBridge } from "@vendoai-fixtures/test-kit/node-bridge";
 import { type Principal } from "@vendoai/core";
 import { VENDO_TOOLS_FORMAT } from "@vendoai/actions";
 import type { HostOAuthAdapter } from "@vendoai/mcp";
@@ -128,7 +129,7 @@ async function createUmbrella(
   // loopback origin. Pass that door origin explicitly via mcp.baseUrl so
   // discovery advertises the URL the SDK client can actually reach.
   let handler: Vendo["handler"] | undefined;
-  const httpServer = createServer((req, res) => void bridge(req, res, (request) => handler!(request)));
+  const httpServer = createServer((req, res) => void nodeBridge(req, res, (request) => handler!(request)));
   await new Promise<void>((resolve, reject) => {
     httpServer.once("error", reject);
     httpServer.listen(0, "127.0.0.1", () => {
@@ -431,34 +432,3 @@ describe("umbrella hookup — createVendo({ mcp: true }) mounts the door", () =>
     }
   });
 });
-
-async function bridge(
-  req: IncomingMessage,
-  res: ServerResponse,
-  handler: (request: Request) => Promise<Response>,
-): Promise<void> {
-  try {
-    const chunks: Buffer[] = [];
-    for await (const chunk of req) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-    const host = req.headers.host ?? "127.0.0.1";
-    const headers = new Headers();
-    for (const [name, value] of Object.entries(req.headers)) {
-      if (value === undefined) continue;
-      headers.set(name, Array.isArray(value) ? value.join(", ") : value);
-    }
-    const body = chunks.length === 0 ? undefined : Buffer.concat(chunks);
-    const request = new Request(`http://${host}${req.url ?? "/"}`, {
-      method: req.method,
-      headers,
-      ...(body === undefined ? {} : { body }),
-    });
-    const response = await handler(request);
-    res.statusCode = response.status;
-    response.headers.forEach((value, name) => res.setHeader(name, value));
-    res.end(Buffer.from(await response.arrayBuffer()));
-  } catch (error) {
-    res.statusCode = 500;
-    res.setHeader("content-type", "text/plain");
-    res.end(error instanceof Error ? error.message : "umbrella bridge failed");
-  }
-}

--- a/fixtures/test-kit/README.md
+++ b/fixtures/test-kit/README.md
@@ -1,0 +1,39 @@
+# @vendoai-fixtures/test-kit
+
+Test helpers that MORE THAN ONE suite needs, and that a suite could not write
+differently without being wrong. Private: a devDependency of the suites that use
+it, never published, never a runtime dependency of anything.
+
+## What belongs here
+
+Only helpers for the two counterparties a test genuinely cannot run:
+
+- `./stream-turns` — the scripted `LanguageModel` and the stream parts it
+  replays. The counterparty is Anthropic's API.
+- `./node-bridge` — a `node:http` request/response pair handed to a Web
+  `Request` → `Response` handler. Not a double at all: it is the same adapter a
+  Node host writes for real, so a fixture serving the umbrella's own `handler`
+  over a loopback socket is exercising the real handler over real HTTP.
+
+## What does not
+
+A helper that stands in for something this repo owns. A harness that mocks the
+counterparty proves nothing (CLAUDE.md), and a *shared* one hides the
+disagreement from both sides at once. Anything spanning a producer and a
+consumer in this repo has a real write path and a real read path; drive those.
+
+Concretely, these were considered and left where they are:
+
+- **the guard double** (`packages/harnesses/src/test-doubles.test-util.ts`,
+  `packages/vendo/src/agent-doubles.test-util.ts`) — `@vendoai/guard` ships a
+  real `createGuard`, and `packages/guard/test/abandon.test.ts` already drives
+  it against a real store. A shared `testGuard` would be a fake standing in for
+  a seam that can be run for real, promoted to a package.
+- **`tempStore`** — forty copies, every one of them inside `packages/vendo`.
+  That is one package's own helper written forty times, not a shared one.
+
+## No barrel
+
+There is no `.` export on purpose. `./stream-turns` needs `ai`; `./node-bridge`
+needs nothing. A barrel would make every consumer of either pay for both, and a
+suite that has no model has no reason to install one.

--- a/fixtures/test-kit/package.json
+++ b/fixtures/test-kit/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@vendoai-fixtures/test-kit",
+  "version": "0.0.0",
+  "description": "Test helpers shared by more than one suite. Private: never published, never a runtime dependency.",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./node-bridge": {
+      "types": "./dist/node-bridge.d.ts",
+      "default": "./dist/node-bridge.js"
+    },
+    "./stream-turns": {
+      "types": "./dist/stream-turns.d.ts",
+      "default": "./dist/stream-turns.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "peerDependencies": {
+    "ai": ">=6.0.0 <7"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "ai": "6.0.28",
+    "typescript": "^5.6.0"
+  }
+}

--- a/fixtures/test-kit/src/node-bridge.ts
+++ b/fixtures/test-kit/src/node-bridge.ts
@@ -1,0 +1,41 @@
+/**
+ * A `node:http` request/response pair, handed to a Web `Request` → `Response`
+ * handler and written back verbatim.
+ *
+ * Not a double: this is the same adapter a Node host writes for real, so a
+ * fixture that serves the umbrella's own `handler` over a loopback socket is
+ * exercising the real handler over real HTTP. Suites that need the WIRE rather
+ * than an in-process call use it to get one.
+ */
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+export async function nodeBridge(
+  req: IncomingMessage,
+  res: ServerResponse,
+  handler: (request: Request) => Promise<Response>,
+): Promise<void> {
+  try {
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    const host = req.headers.host ?? "127.0.0.1";
+    const headers = new Headers();
+    for (const [name, value] of Object.entries(req.headers)) {
+      if (value === undefined) continue;
+      headers.set(name, Array.isArray(value) ? value.join(", ") : value);
+    }
+    const body = chunks.length === 0 ? undefined : Buffer.concat(chunks);
+    const request = new Request(`http://${host}${req.url ?? "/"}`, {
+      method: req.method,
+      headers,
+      ...(body === undefined ? {} : { body }),
+    });
+    const response = await handler(request);
+    res.statusCode = response.status;
+    response.headers.forEach((value, name) => res.setHeader(name, value));
+    res.end(Buffer.from(await response.arrayBuffer()));
+  } catch (error) {
+    res.statusCode = 500;
+    res.setHeader("content-type", "text/plain");
+    res.end(error instanceof Error ? error.message : "node bridge failed");
+  }
+}

--- a/fixtures/test-kit/src/stream-turns.ts
+++ b/fixtures/test-kit/src/stream-turns.ts
@@ -1,0 +1,97 @@
+/**
+ * The scripted LanguageModel and the stream parts it replays.
+ *
+ * ONE model instance drives BOTH the agent loop (`doStream`) and the apps
+ * generation engine (`doGenerate`) off a single FIFO queue, so a journey scripts
+ * turns in the exact order the composed system will consume them.
+ *
+ * This is a MODEL double, not a seam double: the counterparty it stands in for
+ * is Anthropic's API, which a test genuinely cannot call. Everything between the
+ * suite and this model — the wire, the loop, the guard, the store — stays real.
+ * Nothing that has a real write path and a real read path inside this repo
+ * belongs in here.
+ */
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+
+export type LanguageModelV3Prompt = Parameters<MockLanguageModelV3["doStream"]>[0]["prompt"];
+export type LanguageModelV3StreamPart = Awaited<
+  ReturnType<MockLanguageModelV3["doStream"]>
+>["stream"] extends ReadableStream<infer Part> ? Part : never;
+export type LanguageModelV3GenerateResult = Awaited<ReturnType<MockLanguageModelV3["doGenerate"]>>;
+export type LanguageModelV3Content = LanguageModelV3GenerateResult["content"][number];
+
+export const ZERO_USAGE = {
+  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 0, text: 0, reasoning: 0 },
+} as const;
+
+/** A plain assistant text turn (agent doStream). */
+export function textTurn(text: string, id = "text_1"): LanguageModelV3StreamPart[] {
+  return [
+    { type: "text-start", id },
+    { type: "text-delta", id, delta: text },
+    { type: "text-end", id },
+    { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "stop", raw: undefined } },
+  ];
+}
+
+/** An agent turn that calls one tool (agent doStream). */
+export function toolCallTurn(
+  toolName: string,
+  input: unknown,
+  toolCallId = "call_1",
+): LanguageModelV3StreamPart[] {
+  return [
+    { type: "tool-call", toolCallId, toolName, input: JSON.stringify(input) },
+    { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "tool-calls", raw: undefined } },
+  ];
+}
+
+/**
+ * One scripted turn: the chunks, or a function of the prompt that was handed to
+ * the model.
+ *
+ * The function form exists for the ids a journey cannot know in advance — the
+ * front door mints an app's id at request time and writes it into the screen
+ * agent's brief, so a turn that has to NAME that app (`validate({ appId })`)
+ * reads it off the brief exactly as the model it stands in for would.
+ */
+export type ScriptedTurn =
+  | LanguageModelV3StreamPart[]
+  | ((prompt: LanguageModelV3Prompt) => LanguageModelV3StreamPart[]);
+
+export type ScriptedModel = MockLanguageModelV3 & { prompts: LanguageModelV3Prompt[] };
+
+export function scriptedModel(turns: readonly ScriptedTurn[]): ScriptedModel {
+  const remaining = turns.map((turn) => (typeof turn === "function" ? turn : [...turn]));
+  const prompts: LanguageModelV3Prompt[] = [];
+  const shift = (prompt: LanguageModelV3Prompt): LanguageModelV3StreamPart[] => {
+    prompts.push(structuredClone(prompt));
+    const turn = remaining.shift();
+    if (turn === undefined) throw new Error("scripted model exhausted");
+    const chunks = typeof turn === "function" ? turn(prompt) : turn;
+    return chunks;
+  };
+  const model = new MockLanguageModelV3({
+    doStream: async (request) => ({ stream: simulateReadableStream({ chunks: shift(request.prompt) }) }),
+    doGenerate: async (request): Promise<LanguageModelV3GenerateResult> => {
+      const chunks = shift(request.prompt);
+      const finish = chunks.find((part) => part.type === "finish");
+      const content: LanguageModelV3Content[] = [];
+      const text = chunks
+        .filter((part): part is Extract<LanguageModelV3StreamPart, { type: "text-delta" }> => part.type === "text-delta")
+        .map((part) => part.delta)
+        .join("");
+      if (text.length > 0) content.push({ type: "text", text });
+      for (const part of chunks) if (part.type === "tool-call") content.push(structuredClone(part));
+      return {
+        content,
+        finishReason: finish?.finishReason ?? { unified: "stop", raw: undefined },
+        usage: finish?.usage ?? ZERO_USAGE,
+        warnings: [],
+      };
+    },
+  }) as ScriptedModel;
+  model.prompts = prompts;
+  return model;
+}

--- a/fixtures/test-kit/tsconfig.json
+++ b/fixtures/test-kit/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src"]
+}

--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -43,6 +43,10 @@
       "types": "./dist/adapter-conformance.d.ts",
       "default": "./dist/adapter-conformance.js"
     },
+    "./testing": {
+      "types": "./dist/testing/index.d.ts",
+      "default": "./dist/testing/index.js"
+    },
     "./internal": {
       "types": "./dist/internal.d.ts",
       "default": "./dist/internal.js"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -606,6 +606,9 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.20.0
+      '@vendoai-fixtures/test-kit':
+        specifier: workspace:*
+        version: link:../test-kit
       ai:
         specifier: ^6.0.0
         version: 6.0.28(zod@3.25.76)
@@ -704,6 +707,9 @@ importers:
       '@types/pg':
         specifier: ^8.11.10
         version: 8.20.0
+      '@vendoai-fixtures/test-kit':
+        specifier: workspace:*
+        version: link:../test-kit
       pg:
         specifier: ^8.22.0
         version: 8.22.0
@@ -764,6 +770,18 @@ importers:
       vitest:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@22.20.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)
+
+  fixtures/test-kit:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.0
+      ai:
+        specifier: 6.0.28
+        version: 6.0.28(zod@4.4.3)
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
 
   packages/actions:
     dependencies:
@@ -8321,6 +8339,13 @@ snapshots:
       '@vercel/oidc': 3.1.0
       zod: 3.25.76
 
+  '@ai-sdk/gateway@3.0.11(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.2
+      '@ai-sdk/provider-utils': 4.0.4(zod@4.4.3)
+      '@vercel/oidc': 3.1.0
+      zod: 4.4.3
+
   '@ai-sdk/gateway@3.0.151(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.14
@@ -8381,6 +8406,13 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.1.0
       zod: 3.25.76
+
+  '@ai-sdk/provider-utils@4.0.4(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.2
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
 
   '@ai-sdk/provider-utils@4.0.40(zod@3.25.76)':
     dependencies:
@@ -11171,6 +11203,14 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.4(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
+
+  ai@6.0.28(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.11(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.2
+      '@ai-sdk/provider-utils': 4.0.4(zod@4.4.3)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.4.3
 
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:


### PR DESCRIPTION
The **additive half** of the test-estate consolidation: two new surfaces, three suites migrated onto them as proof. **No test files are deleted here** — the per-package migrations and deletions land as their own slices, after the two monster splits in flight.

## 1. `@vendoai/apps` gains `./testing`

`packages/apps/src/testing/` was already compiled into `dist/testing/` and already inside the published `dist` files-entry. It was shipping to npm and reachable by nobody, because no `exports` key pointed at it. `packages/apps/src/testing/scripted-model.test.ts:2` has been asserting `@vendoai/apps/testing` is "SHIPPED code" since the day it was written; it did not resolve. This makes that true.

Same posture as `./adapter-conformance`, which this package already publishes: testing material a host can run against the seams it implements. Purely additive — no existing subpath, type, or runtime behaviour changes.

**Subpath-pin check (done before adding it):** nothing pins `@vendoai/apps`' export list. `packages/ui/test/eject-templates.test.ts:201` is the repo's only full-list pin (`toEqual` on `Object.keys(exports)`) and it covers `@vendoai/ui` only, from inside a `pnpm pack` of that package. `packages/core/src/packaging.e2e.test.ts` iterates a hardcoded two-item list for core. `packages/vendoai/src/alias.test.ts` uses `toHaveProperty`, additive-safe. No publint, no attw, no export-surface CI gate.

## 2. `@vendoai-fixtures/test-kit` — private, unpublished

Carries only the helpers I could **verify** are written more than once and could not be written differently without being wrong:

| helper | verified duplication |
|---|---|
| `ZERO_USAGE` / `textTurn` / `toolCallTurn` / `scriptedModel` (`./stream-turns`) | 13 independent `ZERO_USAGE` definitions across `packages/{vendo×7,harnesses×3}`, `fixtures/{integration,integration-browser}`, `corpus/hosts/express-host`, `examples/mastra-agent`; 5 `textTurn`, 5 `toolCallTurn`, 6 `scriptedModel` |
| `nodeBridge` (`./node-bridge`) | **byte-identical** in `fixtures/mcp-e2e/src/umbrella-hookup.e2e.test.ts` and `.../knowledge-governance.e2e.test.ts` (only the non-Error fallback string differed), plus a variant in `packages/vendo/src/cli/doctor.test.ts` |

**No `.` export, on purpose.** `./stream-turns` needs `ai`; `./node-bridge` needs nothing. A barrel makes every consumer of either pay for both — and it bit during this PR: the first cut had one, and `fixtures/mcp-e2e` (which has no `ai` dependency) took `ai/test` in through the back door.

**Why `fixtures/` and not `packages/`.** `scripts/dependency-guard.mjs` rule 3 requires every `@vendoai/*` import in a `packages/*` source — test files included — to be declared in `dependencies` or `peerDependencies`, with devDeps explicitly not counting. A scoped kit under `packages/` would therefore have to enter a *published* package's dependency list to be consumable: a private test package in a shipped tarball's manifest. Under `fixtures/`, using the `@vendoai-fixtures/` scope five sibling fixtures already use, it is a devDependency and nothing more.

**Consequence: `scripts/dependency-guard.mjs` is untouched.** No layering entry was needed, so there is **no overlap with #983** (the version-range parser fix). `dependency-guard: OK (15 packages checked)` — the same 15 as before.

## 3. Three consumers migrated (proof, not paperwork)

| suite | what changed | result |
|---|---|---|
| `fixtures/integration/src/harness.ts` | takes the turn helpers from the kit and **re-exports** them, so all 19 journeys are unchanged at the call site | 19 files, **51 passed**, 1 skipped |
| `fixtures/mcp-e2e` ×2 | two copies of `bridge` → one `nodeBridge` | 7 files, **19 passed**, 5 skipped |
| `fixtures/automations-e2e` ×2 | two hand-rolled scripted models → `scriptedLanguageModel` from `@vendoai/apps/testing` | 17 files, **69 passed**, 1 skipped |

`fixtures/automations-e2e/src/automation-refusal.e2e.test.ts` is the one that matters most. It carried this comment above its local copy:

> *Local copy for the same reason `ladder.e2e.test.ts` keeps one: **the apps package's own test double is internal to that package**.*

That is the `./testing` subpath's justification, written down in the tree before the subpath existed.

## What I refused to promote

- **The guard double** (`testGuard` / `boundRegistry` / `ctx`, duplicated between `packages/harnesses/src/test-doubles.test-util.ts` and `packages/vendo/src/agent-doubles.test-util.ts`). `@vendoai/guard` ships a real `createGuard`, and `packages/guard/test/abandon.test.ts` already drives it against a real PGlite store. A *shared* fake standing in for a seam that can be run for real is exactly the mock farm CLAUDE.md forbids — and both existing copies carry a written decision against sharing them ("a doubles surface on a published package is surface nobody asked for"). It stays duplicated, visibly, where its drift is a diff.
- **`tempStore`** — 40 definitions, **every one inside `packages/vendo`**. That is one package's own helper written forty times, not a shared one; it belongs in a `vendo` test-util, in the vendo slice.

## Map claims I could not substantiate

The map's helper list was a lead, and three items did not survive checking:

- **"the invoice table"** — one occurrence repo-wide (`packages/store/src/host-queryability.test.ts:16`, an inline `CREATE TABLE invoices`). Not duplicated. Everything else matching `invoice` is domain vocabulary in vendo test data.
- **"the OAuth client"** — no duplicated OAuth *double* exists. Every `HostOAuthAdapter` hit is production code (`packages/mcp/src/oauth/*`, `packages/vendo/src/auth-presets/*`).
- **"the wire server"** — `packages/ui/test/wire-server.ts` + `packages/ui/test/kit/wire-fixture.ts`, both inside `@vendoai/ui`. Intra-package, and out of this slice's file-set.
- **"a temp-dir helper"** — `mkdtemp(join(tmpdir(), …))` appears inline in ~100 files with **no named helper anywhere**. A one-line wrapper is not worth a shared export; deleting beats adding.

## Placement convention (`colocated src/`) — reported, not fixed

Violators today, left alone per the brief — counted, not guessed (`find packages/*/ -name '*.test.ts*'` outside `src/`):

- **`packages/ui`** — 124 test files outside `src/` (`test/`, `e2e/`)
- **`packages/guard`** — 27 test files outside `src/` (`test/`)

Those are the only two. Every other package is colocated `src/`. `fixtures/*` and `corpus/*` use `src/` or `e2e/` by their own convention, which is not the packages rule.

## vendo-web tandem: written no-op

`@vendoai/apps` is a **public surface change**, so I checked. vendo-web consumes it as a *vendored tarball* pinned to older versions and imports only the root subpath:

- `~/repos/vendo-web/package.json:47` — `"@vendoai/apps": "file:./vendor/vendoai-apps-0.5.0.tgz"`
- `~/repos/vendo-web/apps/console/package.json:38` — `"@vendoai/apps": "file:../../vendor/vendoai-apps-0.4.8.tgz"`
- imports are `createApps` / `OpenSurface` only (`apps/console/lib/preview/run-preview.ts:2-3`, `apps/console/hosted-exec/src/assembly.ts:4`)

Zero references to `apps/testing`, `fake-sandbox`, `scriptedLanguageModel`, or `@vendoai-fixtures/*` anywhere in that repo. Adding a subpath cannot reach a pinned tarball, and the kit is private and never published. **No companion PR.**

## Gate

Scoped, blocking, one at a time (the box was under memory pressure from sibling workers; one `automations-e2e` run took an OOM SIGKILL and was re-run clean on a quiet box).

```
pnpm build --filter=@vendoai-fixtures/{integration,mcp-e2e,automations-e2e}...
  Tasks: 14 successful, 14 total

fixtures/mcp-e2e            Test Files  7 passed | 2 skipped (9)    Tests  19 passed | 5 skipped (24)
fixtures/automations-e2e    Test Files 17 passed | 1 skipped (18)   Tests  69 passed | 1 skipped (70)
fixtures/integration        Test Files 19 passed | 1 skipped (20)   Tests  51 passed | 1 skipped (52)

pnpm typecheck              Tasks: 42 successful, 42 total
packages/apps tsc -p tsconfig.json --noEmit   exit 0   (the excluded-test-files trap: apps has no source change here, only an exports key; changed symbols grepped repo-wide including test dirs, no strays)
pnpm lint --force           dependency-guard: OK (15 packages checked)
                            portability-gate: all legs green
                            Tasks: 3 successful, 3 total
```

Full suite is CI's job — the green `ci` check is the gate of record.

## Recommended follow-up slices

1. **`packages/vendo` test-utils** (after the split lands) — 40 `tempStore` copies and 7 inline `ZERO_USAGE` into that package's own `*.test-util.ts`. Biggest single win in the estate; entirely intra-package, so no kit needed.
2. **`packages/harnesses` onto `./stream-turns`** — blocked on one real decision, not mechanics: harnesses' `textTurn(text, usage)` and everyone else's `textTurn(text, id)` are different signatures across 74 call sites. Reconciling them is a behaviour call that belongs in its own slice.
3. **The remaining `ZERO_USAGE`/turn-helper copies** — `fixtures/integration-browser/e2e/harness/model.ts`, `corpus/hosts/express-host/e2e/harness.ts`, `examples/mastra-agent/e2e/vendo-seam.e2e.test.ts`. All byte-identical substitutions; each needs its own suite run (Playwright / express host), which is why they are not here.
4. **`readSse`** — 4 copies, but three genuinely different return shapes (`Array<Record>` vs `StreamRead` vs `SseRead`). Needs one agreed shape decided first, then centralising.
5. **`loginCookie`** — 5 copies across the fixture packages, each bound to its own fixture host. Worth a look once the fixture harnesses themselves are consolidated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
