### PR TITLE
docs: make the docs match the repo after the day's cuts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,25 +75,39 @@ generated UI in a sandboxed, brand-native surface.
   test's own timeout. The test timeout is the hang-detector; a tighter inner
   budget is a second, invisible speed limit that reports a product bug when
   the machine is merely busy.
-- The full suite (`pnpm test`) is CI's job now — sharded into 8 vitest shards
-  for the big three (vendo×3, store×3, ui×2), 2 turbo groups for the remaining
-  packages, and a `hermetic-extras` job for the orphan suites. It still runs
-  with `--continue` and `--concurrency=4`, the same bound CI has used since
-  #340: `--continue` so one red package never hides every other package's
-  result; the bound because unbounded parallelism runs ~27 vitest workers at
-  once on a 12-core laptop (load average ~150) and the full-stack suites in
-  `packages/vendo` then miss their 30s budget on work that takes 5s alone. A
-  timeout is a hang-detector; do not raise one to buy headroom the machine
-  never had. Locally, run `pnpm test:affected` instead — same caps, scoped to
+- The full suite is CI's job now (`.github/workflows/ci.yml`), fanned out over
+  a shared turbo remote cache: `typecheck-lint` (build + typecheck + lint),
+  `test-shards` (9 intra-package vitest shards for the big three — vendo×4,
+  store×3, ui×2), `test-rest` (the other packages in 2 turbo groups: guard +
+  actions, then everything else expressed as negations so a new package joins
+  the day it is created), and `coverage-merge`, which replays the shards' blob
+  reports and enforces the per-package coverage floors — a floor is only
+  meaningful against the whole suite, so the per-shard runs pass
+  `--coverage.thresholds.lines=0` and the gate moves to the merge. The
+  aggregate job is named `ci`; the required checks on main are `ci`,
+  `integration`, `conformance`, and `audit`, and renaming any of those job
+  names breaks merges. No browser runs in CI (2026-08-06) — headless
+  mis-resolves `:focus-visible` and `light-dark()`, so the Playwright suites
+  stay a LOCAL pre-PR gate.
+- `--continue` and a turbo concurrency bound are the standing rule wherever the
+  suite runs: `--continue` so one red package never hides every other package's
+  result; the bound (2 in CI's `test-rest`, 4 in the root `test` /
+  `test:affected` / `test:coverage` scripts) because unbounded parallelism runs
+  ~27 vitest workers at once on a 12-core laptop (load average ~150) and the
+  full-stack suites in `packages/vendo` then miss their 30s budget on work that
+  takes 5s alone. A timeout is a hang-detector; do not raise one to buy headroom
+  the machine never had. Locally, run `pnpm test:affected` — same caps, scoped to
   changed packages; never run the full suite on a laptop.
 - Turbo's bound is only the OUTER layer. Each package's vitest sizes its own
   worker pool to the CPU count, so 4 packages at a time meant ~60 processes and
   ~13GB on a 12-core laptop, and an OOM kill on a 15GB runner — the PGlite
   suites (`store`, `guard`, the fixtures) boot an embedded Postgres per worker.
-  `VITEST_MIN_FORKS/MAX_FORKS` and `VITEST_MIN_THREADS/MAX_THREADS` in the root
-  `test` and `test:coverage` scripts cap the inner layer at 4 x 2 workers, which
-  is why CI runs those scripts instead of calling turbo itself. Set them in any
-  new script or workflow that runs the suite. The MIN half is not optional:
+  `VITEST_MIN_FORKS/MAX_FORKS` and `VITEST_MIN_THREADS/MAX_THREADS` cap the
+  inner layer at 2 workers — set in the root `test` / `test:affected` /
+  `test:coverage` scripts locally, and at job level on `test-shards` and
+  `test-rest` in CI (which invoke vitest and turbo directly, so they do not
+  inherit the root scripts). Set them in any new script or workflow that runs
+  the suite. The MIN half is not optional:
   vitest 2.1 defaults `minThreads` to the CPU count independently of the max, so
   a max-only cap makes Tinypool throw `minThreads and maxThreads must not
   conflict` before a single test runs. `fileParallelism: false` still wins where

--- a/README.md
+++ b/README.md
@@ -71,23 +71,17 @@ Every capture below is a real agent run in a demo host app, not a mockup.
 
 <table>
   <tr>
-    <td width="50%" valign="top">
+    <td width="33%" valign="top">
       <img src="assets/hero.gif" alt="A Maple customer asks where their money went and the agent composes a live spending view" width="100%">
       <p align="center"><sub><b>Build views.</b> Ask a question, get a live view composed from the host's own components and API.</sub></p>
     </td>
-    <td width="50%" valign="top">
+    <td width="33%" valign="top">
       <img src="assets/remix.gif" alt="A Cadence user hovers the deadlines card, asks for urgency color-coding, and applies the remix in place" width="100%">
       <p align="center"><sub><b>Remix the UI.</b> Hover a component, describe the change, apply it in place.</sub></p>
     </td>
-  </tr>
-  <tr>
-    <td width="50%" valign="top">
+    <td width="33%" valign="top">
       <img src="assets/automation.gif" alt="A Cadence user asks for a morning document-chase automation and turns it on with per-tool approvals" width="100%">
       <p align="center"><sub><b>Automate across tools.</b> Plain language in, standing automation out, every tool gated by approval.</sub></p>
-    </td>
-    <td width="50%" valign="top">
-      <img src="assets/voice.gif" alt="A Maple voice session: the user asks out loud where their money went and the agent renders the view while talking back" width="100%">
-      <p align="center"><sub><b>Talk to it.</b> A live voice session: ask out loud, the agent talks back and renders the view.</sub></p>
     </td>
   </tr>
 </table>
@@ -143,7 +137,7 @@ Install individual blocks when you want to compose Vendo yourself.
 | `@vendoai/guard` | Policy, approvals, grants, audit, breakers, and safety |
 | `@vendoai/apps` | App generation, editing, execution, interchange, and sandbox adapters |
 | `@vendoai/automations` | Trigger ingestion, schedules, away runs, and run history |
-| `@vendoai/ui` | Headless React hooks, optional chrome, tree rendering, and voice surfaces |
+| `@vendoai/ui` | Headless React hooks, optional chrome, tree rendering, and the in-jail component kit |
 | `@vendoai/mcp` | The door: serves the host's tools to outside MCP clients |
 | `@vendoai/telemetry` | Anonymous, opt-out build and development telemetry |
 | `@vendoai/vendo` | Default composition, public wire, React entry, and `vendo` bin |

--- a/docs-site/connect/api-tools.mdx
+++ b/docs-site/connect/api-tools.mdx
@@ -105,7 +105,7 @@ The extractor loads the TypeScript compiler from your app's own
 `node_modules`. If TypeScript is not available, tRPC extraction is skipped with
 a warning and no tRPC tools are emitted; extraction never fails your build.
 
-### Next.js server actions
+### Next.js server actions {#next-js-server-actions}
 
 If your Next.js app declares server actions, sync extracts each exported
 action as its own tool. The extractor statically scans modules that begin with

--- a/docs-site/deploy/deploying.mdx
+++ b/docs-site/deploy/deploying.mdx
@@ -50,5 +50,4 @@ yours to work through.
 | Sandbox | User apps that need a server escalate into a jail | [How Vendo works](/concepts/architecture) |
 | Connectors | External tools executed as the signed-in user | [Connected accounts](/capabilities/connected-accounts) |
 | MCP door | Claude, ChatGPT, and Cursor use your product's tools; a host decision, never a default, needing a `HostOAuthAdapter` and `createVendo({ mcp: true, oauth })` | [MCP](/capabilities/mcp) |
-| Voice | Real-time voice surfaces over the same tools and policy | [Voice](/ui/components#voice) |
 | Vendo Cloud | Sharing, publishing, org overlays, hosted automations via `VENDO_API_KEY` | [Vendo Cloud](/deploy/vendo-cloud) |

--- a/docs-site/reference/cli.mdx
+++ b/docs-site/reference/cli.mdx
@@ -96,7 +96,10 @@ Options:
   rule and the same flag pair apply to `vendo sync`.
 - `--engine <claude|codex|npx>` pins which engine runs the AI pass instead of
   first-available (`claude` = Claude Agent SDK or the `claude` CLI, `codex` =
-  the `codex` CLI, `npx` = the npx-fetched engine on Vendo Cloud fuel). A
+  the `codex` CLI, `npx` = Anthropic's published `@anthropic-ai/claude-code`,
+  fetched on the fly with `npm exec` at a pinned version and driven headless
+  and read-only — a one-time ~250MB download, paid by `ANTHROPIC_API_KEY` or
+  by `VENDO_API_KEY` through the Vendo Cloud model gateway). A
   pinned engine that is not available skips the AI pass with one loud line —
   it never falls back to a different provider. Interactively, when more than
   one engine is available, the consent question itself becomes a pick (your

--- a/docs-site/reference/cli.mdx
+++ b/docs-site/reference/cli.mdx
@@ -116,6 +116,8 @@ Options:
   your endpoint even with a Vendo Cloud key present, and is never overridden.
   The `claude` rung additionally runs on a plain Claude Code login; `npx` does
   not, because it fetches the package rather than reusing a local install.
+  That is the ladder `vendo init` always walks; `vendo sync --ai` is the one
+  exception — see the `--ai` option under `vendo sync`.
 - `--theme <slot=value>` overrides a theme slot value directly (repeatable).
 - `--force` regenerates Vendo-owned files under `.vendo/`. It does not replace
   existing host source files.
@@ -501,8 +503,19 @@ Options:
   (interactive; cannot combine with `--json`).
 - `--full`: judge the whole catalog instead of only what moved.
 - `--engine <name>`: pin the judgment engine family (`claude`, `codex`,
-  `npx`); an unavailable pin skips loudly, never falls back.
-- `--ai`: run the judgment pass with no prompt, interactive or not.
+  `npx`); an unavailable pin skips loudly, never falls back. Subject to the
+  `--ai` carve-out below.
+- `--ai`: run the judgment pass with no prompt, interactive or not. **On an
+  incremental run `--ai` skips the engine sweep** — `vendo sync` runs in
+  `predev` on every dev-server start, so it must not probe harnesses each time
+  — and the pass resolves its own engine behind a narrower credential gate that
+  reads only `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
+  `GOOGLE_GENERATIVE_AI_API_KEY` and `VENDO_API_KEY`. A machine carrying **only**
+  `ANTHROPIC_AUTH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN` or a standalone
+  `ANTHROPIC_BASE_URL` therefore gets `judgment: structural-only` on
+  `vendo sync --ai`, even though `vendo init` and an interactive `vendo sync`
+  accept all three. Add `--full`, or drop `--ai` on an interactive run, to walk
+  the whole ladder.
 - `--no-ai`: force the judgment pass off (what the installed `predev`/
   `prebuild` hooks pass, so committed files never churn and a build never
   spends). `--no-watermark` remains accepted as an alias.

--- a/docs-site/reference/cli.mdx
+++ b/docs-site/reference/cli.mdx
@@ -98,13 +98,24 @@ Options:
   first-available (`claude` = Claude Agent SDK or the `claude` CLI, `codex` =
   the `codex` CLI, `npx` = Anthropic's published `@anthropic-ai/claude-code`,
   fetched on the fly with `npm exec` at a pinned version and driven headless
-  and read-only — a one-time ~250MB download, paid by `ANTHROPIC_API_KEY` or
-  by `VENDO_API_KEY` through the Vendo Cloud model gateway). A
+  and read-only — a one-time ~250MB download). A
   pinned engine that is not available skips the AI pass with one loud line —
   it never falls back to a different provider. Interactively, when more than
   one engine is available, the consent question itself becomes a pick (your
   source goes to the provider you choose), so the flag is mostly for
   unattended runs.
+
+  Both Claude-shaped rungs — the `claude` CLI and `npx` — read the same four
+  credentials, in this order: `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`,
+  `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_BASE_URL`. The last three are the
+  corporate-gateway, device-flow-OAuth and custom-endpoint paths Claude Code
+  supports, and a base URL counts on its own with no token beside it (mTLS or
+  proxy auth). `VENDO_API_KEY` is the fallback **only** when none of those four
+  is set, and it routes the pass through the Vendo Cloud model gateway. Your own
+  configuration always wins: a custom `ANTHROPIC_BASE_URL` keeps the pass on
+  your endpoint even with a Vendo Cloud key present, and is never overridden.
+  The `claude` rung additionally runs on a plain Claude Code login; `npx` does
+  not, because it fetches the package rather than reusing a local install.
 - `--theme <slot=value>` overrides a theme slot value directly (repeatable).
 - `--force` regenerates Vendo-owned files under `.vendo/`. It does not replace
   existing host source files.

--- a/docs-site/ui/components.mdx
+++ b/docs-site/ui/components.mdx
@@ -31,7 +31,7 @@ phones. It's running on this page: click the Vendo pill in the corner.
   <img src="/images/ui/hero-launcher.png" alt="Vendo overlay launcher pill in the corner of a host page" />
 </Frame>
 
-Wire it in the [quickstart](/quickstart#add-the-overlay); control it
+Wire it in the [quickstart](/quickstart#the-client-mount); control it
 programmatically with
 [useVendoOverlay](/reference/hooks#overlay-control-usevendooverlay).
 

--- a/docs/config-migration-table.md
+++ b/docs/config-migration-table.md
@@ -25,7 +25,7 @@ createVendo({
   packs:   [apps(), automations(), complianceReports], // default: apps()
   models:  { default: anthropic("claude-fable-5"), reviewer: openai("gpt-5.6") },
   store:   postgres(env.DATABASE_URL),
-  files:   s3(bucket),                                 // optional
+  files:   myFilesAdapter,                             // optional; your own FilesAdapter
   sandbox: e2b({ warmPool: 2 }),                       // optional
 });
 ```
@@ -71,7 +71,7 @@ truth about the code as it stands.
 | `theme` | **adapter family** (deployment identity) | unchanged. Not generation-only — the chrome, the client and the prompt summary all read it |
 | `instructions` | **adapter family** (deployment identity) | RENAMED from `brief`, and merged with `agent.instructions` — one prose key. Still the programmatic override for `.vendo/brief.md`, still the prompt's Product section |
 | `store` | **slot** `store` | unchanged |
-| `files` | **slot** `files` | unchanged. Unset is a documented default, not a gap: blobs live in the store to `FILES_STORE_MAX_BYTES` and the first over-cap write names this key |
+| `files` | **slot** `files` | unchanged, and BYO-only since `s3()` was deleted: pass your own `FilesAdapter` (`{ put, get, delete }`, from `@vendoai/core`). Unset is a documented default, not a gap: blobs live in the store to `FILES_STORE_MAX_BYTES` and the first over-cap write names this key |
 | `sandbox` | **slot** `sandbox` | unchanged |
 | `harness` | **slot** `harness` | unchanged. Unset now means a composed `vendo()` that actually SERVES the chat route (wave-2 flip), not a door nobody reaches |
 | `knowledge` | **adapter family** (`KnowledgeAdapter`) | unchanged. A candidate for a `knowledge()` pack once packs carry adapters; today a pack cannot contribute one |
@@ -84,7 +84,7 @@ truth about the code as it stands.
 | `telemetry` | **venue plumbing** | unchanged; a boolean switch on build/dev telemetry |
 | `development` | **venue plumbing** (dev-only source capture) | unchanged |
 | `profileDir` | **venue plumbing** (which project root `.vendo/` is read under) | unchanged. The `tools:` slot is the in-memory alternative for one piece; this stays the answer for the rest |
-| `fetch` | **venue plumbing** (the fetch host tool bindings execute through) | unchanged; `npx vendo try` injects a synthetic-fixture fetch here |
+| `fetch` | **venue plumbing** (the fetch host tool bindings execute through) | unchanged; the console's hosted try venue injects a synthetic-fixture fetch here (`createSyntheticFetch` from `@vendoai/vendo/try`). There is no `vendo try` CLI command |
 | `profile` | **venue plumbing** (the `.vendo/` pieces as in-memory compose inputs) | `profile.tools` **deprecated** → the `tools:` slot; the other pieces (`overrides`, `theme`, `brief`, `catalog`, `policy`, `designRules`) unchanged |
 | `mcp` | **adapter family** (the MCP door) | unchanged |
 | `oauth` | **adapter family** (`auth`'s per-seam escape hatch) | unchanged; see `principal` |

--- a/docs/host-components.md
+++ b/docs/host-components.md
@@ -289,11 +289,18 @@ brand-new generated apps.
 ```ts
 export function TreeView(props: {
   tree: Tree;
+  appId?: string;
   components: Record<string, ComponentType>;
   data?: Record<string, Json>;
   onAction(req: { nodeId: string; action: string; payload?: Json }): Promise<ToolOutcome>;
+  onStateChange?(state: Record<string, Json>): void;
 }): JSX.Element;
 ```
+
+`appId` names which app the tree belongs to — the identity of its `$state` and
+outcome namespace. Pass it whenever the same position can render a *different*
+app, so one app's state never bleeds into the next; omit it and the tree root
+stands in. `PayloadView` and `AppFrame` take it too.
 
 `PayloadView` renders `vendo-genui/v2` (`TreeView` is the underlying walk). `$path` resolves against app data and
 `$state` against the per-user, per-app state singleton. Host components render

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -270,8 +270,12 @@ the next one is tried:
    pinned version and driven headless and read-only like rung 2 — real
    Claude Code, no local install required. This is a one-time ~250MB
    download (npm caches it, so later runs skip it); init prints the
-   download notice before it starts. `ANTHROPIC_API_KEY` pays, or
-   `VENDO_API_KEY` through the Vendo Cloud model gateway.
+   download notice before it starts. It reads the same four credentials as
+   rung 2, in the same order (`ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`,
+   `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_BASE_URL`), and falls back to
+   `VENDO_API_KEY` through the Vendo Cloud model gateway only when none of
+   them is set. Unlike rung 2 it does not run on a bare Claude Code login,
+   having no local install to read one from.
 
 When none of the four resolves, init still completes — extraction defaults
 stand — and prints every rung's remedy. If a chosen rung fails partway

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,7 +1,8 @@
 # @vendoai/ui
 
 Provides Vendo's headless React hooks, optional chrome, tree renderer, generated
-component jail, theming, and voice surfaces.
+component jail, theming, and — at `@vendoai/ui/kit` — the component kit a
+generated app imports inside its box.
 
 Read [Generated UI](https://docs.vendo.run/concepts/generated-ui) and
 [Theming](https://docs.vendo.run/connect/theming).


### PR DESCRIPTION
Sweep of `docs/`, `docs-site/`, `CLAUDE.md` and the package READMEs against the code, after ~40 PRs deleted packages, cut features and changed gates. **Most pages were already corrected by the PRs that made the cuts** — `api-tools.mdx` (four stacks, the GraphQL skip and its documented residual), `http-routes.mdx` / `cli.mdx` / `troubleshooting.mdx` (`/sync/impact` and `/doctor/*` mounting), `docs/quickstart.md` (the npx rung), `agents/README.md` (session resume), `box-template/README.md`, `handler-options.mdx` (the `files` seam). This PR is the residue they missed, plus two broken links.

Rebased onto `898eb8fd5` (#997).

## What was corrected

| Area | Change |
| --- | --- |
| `CLAUDE.md` | The CI section described a CI that no longer exists. Rewritten from `.github/workflows/ci.yml`. |
| `docs/config-migration-table.md` | `files: s3(bucket)` → your own `FilesAdapter`; the `files` row says BYO-only. `npx vendo try` → the console's hosted try venue (no such CLI command exists). |
| `docs-site/deploy/deploying.mdx` | Dropped the **Voice** unlock row — the voice stage is cut and its `/ui/components#voice` anchor was already dead. |
| `README.md` | Dropped the voice demo tile (the `examples/demo-bank` driver went with #973); `@vendoai/ui` no longer advertises "voice surfaces". |
| `packages/ui/README.md` | "voice surfaces" → the `@vendoai/ui/kit` component kit. |
| `docs-site/reference/cli.mdx` | `--engine npx` now names Anthropic's published `@anthropic-ai/claude-code` and the fetch mechanics, instead of "the npx-fetched engine on Vendo Cloud fuel". Both Claude-shaped rungs' **four** credentials are now enumerated in precedence order (see finding 4). The `vendo sync` `--ai` option additionally names the narrower credential gate on that one path (see finding 6). |
| `docs/quickstart.md` | Rung 4 carried the same credential omission as the CLI page; corrected to match rung 2, which was already right. |
| `docs/host-components.md` | `TreeView` gains the optional `appId` (and `onStateChange`, which was also missing) plus a sentence on what `appId` buys. |
| Links | `/quickstart#add-the-overlay` → `#the-client-mount`; `/connect/api-tools#next-js-server-actions` pinned with an explicit Mintlify heading id. Both pre-date today's cuts. |

## CI: what CLAUDE.md claimed vs what CI does

| Claimed | Actual |
| --- | --- |
| 8 shards, vendo×3 | **9** shards, **vendo×4** (the comment in `ci.yml` explains why 3 clustered badly) |
| a `hermetic-extras` job | **does not exist** |
| `--concurrency=4` everywhere | **2** in CI's `test-rest`; 4 only in the root scripts |
| "CI runs those scripts instead of calling turbo itself" | **false** — `test-shards` invokes vitest directly and `test-rest` invokes turbo directly; both set `VITEST_MIN/MAX_*` at job level |
| (unmentioned) | `coverage-merge` holds the per-package floors, because a floor is meaningless against one shard; the required checks are `ci`, `integration`, `conformance`, `audit`; no browser runs in CI |

## Findings

1. **`/sync/impact` and `/doctor/*` are not "declared `development` only".** `packages/vendo/src/server.ts` resolves `development` to `NODE_ENV === "development"` when the key is unset; explicit `false` disables. The shipped docs already say exactly this ("`createVendo({ development })`, which `NODE_ENV=development` enables") — so **no edit was needed**, and the stricter phrasing would have made them wrong.
2. **Kept, and confirmed still documented:** MCP `federation` + `remoteAs` (`capabilities/mcp.mdx`, `existing-agents/mcp.mdx`, `server-api.mdx`, `handler-options.mdx`) and the guard org-admin clamp. Neither was wrongly stripped.
3. **The automations adoption handoff was never documented** — `AdoptionCard`, `adopt()`, `POST /automations/:id/adopt/:triggerId` appear in no doc. Nothing to remove.
4. **The npx rung's credential set is wider than this PR first documented** (Greptile P2, fixed in `7a42c1600`). `npxEngineHarness.availability()` accepts `ANTHROPIC_API_KEY`, then `ANTHROPIC_AUTH_TOKEN` / `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_BASE_URL` (`OWN_CREDENTIAL_ENV_VARS` in `gateway-fuel.ts`), then `VENDO_API_KEY`. A base URL counts on its own with no token beside it (mTLS/proxy auth). `composeGatewayFuel` refuses to overlay onto any of the four independently of the caller's verdict, so an own endpoint is never silently redirected onto Vendo's meter. **No code bug** — the code was right and the page was thin.
5. **Asymmetry documented, not tidied.** The `claude` PATH rung also runs on a bare Claude Code login via its `probe()`; the `npx` rung has no such branch, so with only a login it reports unavailable. That matches its stated design (last resort for a machine with nothing Claude-shaped installed, hence no local login to read), so the pages say what the code does rather than the tidier symmetric version. Not filed as a bug.
6. **CODE GAP — `vendo sync --ai` skips three supported credential paths** (Greptile P1; documented in `833272142`, **not fixed here**). `chooseEngine` (`cli/sync-flow.ts:309`) short-circuits before the engine sweep when `--ai` is passed on an **incremental** run — deliberate, since `sync` runs in `predev` on every dev-server start and must not probe harnesses each time. The pass then resolves its own engine via `resolveJudgmentEngine`, whose first step is `resolveDevCredential`, and that resolver's `ENV_KEY_VARS` (`dev-creds/resolve.ts:21`) knows only `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY` and `VENDO_API_KEY`. A machine carrying **only** `ANTHROPIC_AUTH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN` or a standalone `ANTHROPIC_BASE_URL` therefore gets `judgment: structural-only`, though both Claude-shaped harnesses would have reported available.
   - **Expected:** the fallback resolver accepts the same credentials as the harnesses it stands in for.
   - **Found:** it accepts a strictly narrower set.
   - **Scope:** `vendo sync --ai` **without** `--full` only. `vendo init` is always mode `"full"` and sweeps the ladder; an interactive `vendo sync` with no `--ai` sweeps it too and hands the chosen harness down, bypassing the gate.
   - **Why not fixed here:** `resolveDevCredential` is shared by `vendo doctor`, `doctor-live`, the runtime `dev-creds/model.ts` ladder and init's key resolution, and those want a real API key for product turns — an interactive-only OAuth token is not one. Widening it uniformly could hand a runtime path a credential it cannot serve turns with. Own slice, own tests. The page now names the carve-out instead.

> **Resolved on rebase.** This PR previously reported that `@vendoai/apps` had no `./testing` export subpath while `src/testing/scripted-model.test.ts` called it shipped code. #997 (`898eb8fd5`) adds the subpath; the contradiction is gone. No doc described the old state, so nothing needed correcting — the item is simply withdrawn.

## Stale comments in `src/` — not mine to touch, reporting as findings

- `packages/core/src/workspace.ts:44` — "`s3()` is the one shipped implementation". `s3()` no longer exists.
- `packages/vendo/src/cli/playground/app/try-app.tsx:7,143` — reference a "Refine" affordance whose panel and `/api/refine` endpoints were deleted.
- `.github/workflows/ci.yml:58` — the coverage comment measures "kit's shard 1/2"; `@vendoai/kit` is gone and is not one of the sharded packages.
- `assets/voice.gif` is now unreferenced (asset, outside this PR's file-set).

## vendo-web disposition

**No companion PR needed.** Two docs-site pages name console surfaces, and both are accurate: `connect/knowledge.mdx` (the console's Knowledge **Playground** tab) and `ui/components.mdx` (`vendo.run/playground`, the hosted theme/component playground). Neither is the retired `vendo playground` CLI command, which no doc mentions. The one page whose subject moved — the synthetic-fixture fetch, now owned by the console's hosted try venue — is `docs/config-migration-table.md`, an internal doc; the console's own copy is not touched by this change.

## Changeset

**None.** The only published-package README edited is `packages/ui/README.md`, and both changes it makes (voice out, `./kit` in) are already covered by the pending `cut-the-voice-stage.md` and `kit-folds-into-ui.md` changesets, each `minor` on `@vendoai/ui`. A third entry would double-count one unreleased change.

## Gates

Run on the rebased tree, one blocking step at a time:

```
pnpm build --filter '@vendoai/vendo...'            EXIT=0   13/13 tasks
pnpm lint                                          EXIT=0   dependency-guard: OK (15 packages checked)
                                                            portability-gate: ok — Worker target, zero unresolved imports; no Node-only leg (665 modules)
                                                            turbo lint 3/3
pnpm --filter @vendoai/vendo exec vitest run docs  EXIT=0   7 files, 73 tests passed
```

The docs-site CI gate is the `*.docs.test.ts` suite in `packages/vendo` (handler-options, server-api, your-agent, mcp-byo, quickstart, doctor-codes, remix-graduation); it runs inside the `vendo` shards. The build is scoped only because `portability-gate.mjs` reads `packages/vendo/dist/server.js`.

I also ran an internal-link check across all 49 `docs-site` pages (every `](/…)` target and `#anchor`): all resolve after this PR, and every nav entry in `docs.json` points at a real file with no orphaned pages.

## Follow-up (not in this PR)

The guard org-admin clamp (`orgPolicy` on `CreateGuardConfig`) is a real OSS seam with **no docs page anywhere**. Writing its first page is new documentation, not a truth correction, so it is deliberately out of scope here and logged as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

