### PR TITLE
refactor(fixtures,corpus,examples): three more turn-helper copies fold into the shared kit; harnesses stays put, on the evidence

### DIFF
--- a/corpus/hosts/express-host/e2e/harness.ts
+++ b/corpus/hosts/express-host/e2e/harness.ts
@@ -4,66 +4,20 @@ import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createStore, type VendoStore } from "@vendoai/store";
-import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+import {
+  scriptedModel,
+  textTurn,
+  toolCallTurn,
+  ZERO_USAGE,
+  type LanguageModelV3StreamPart as StreamPart,
+} from "@vendoai-fixtures/test-kit/stream-turns";
 import type { LanguageModel, UIMessage } from "ai";
 import { createRelayServer } from "../src/server/index.js";
 
-type ModelPrompt = Parameters<MockLanguageModelV3["doStream"]>[0]["prompt"];
-export type StreamPart = Awaited<ReturnType<MockLanguageModelV3["doStream"]>>["stream"] extends ReadableStream<infer Part> ? Part : never;
-type GenerateResult = Awaited<ReturnType<MockLanguageModelV3["doGenerate"]>>;
-type GenerateContent = GenerateResult["content"][number];
-
-export const ZERO_USAGE = {
-  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
-  outputTokens: { total: 0, text: 0, reasoning: 0 },
-} as const;
-
-export function textTurn(text: string, id = "text_1"): StreamPart[] {
-  return [
-    { type: "text-start", id },
-    { type: "text-delta", id, delta: text },
-    { type: "text-end", id },
-    { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "stop", raw: undefined } },
-  ];
-}
-
-export function toolCallTurn(toolName: string, input: unknown, toolCallId = "call_1"): StreamPart[] {
-  return [
-    { type: "tool-call", toolCallId, toolName, input: JSON.stringify(input) },
-    { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "tool-calls", raw: undefined } },
-  ];
-}
-
-export function scriptedModel(turns: StreamPart[][]): LanguageModel {
-  const remaining = turns.map((turn) => [...turn]);
-  const shift = (_prompt: ModelPrompt): StreamPart[] => {
-    const chunks = remaining.shift();
-    if (chunks === undefined) throw new Error("scripted model exhausted");
-    return chunks;
-  };
-  return new MockLanguageModelV3({
-    doStream: async (request) => ({ stream: simulateReadableStream({ chunks: shift(request.prompt) }) }),
-    doGenerate: async (request): Promise<GenerateResult> => {
-      const chunks = shift(request.prompt);
-      const finish = chunks.find((part) => part.type === "finish");
-      const content: GenerateContent[] = [];
-      const generatedText = chunks
-        .filter((part): part is Extract<StreamPart, { type: "text-delta" }> => part.type === "text-delta")
-        .map((part) => part.delta)
-        .join("");
-      if (generatedText.length > 0) content.push({ type: "text", text: generatedText });
-      for (const part of chunks) {
-        if (part.type === "tool-call") content.push(structuredClone(part));
-      }
-      return {
-        content,
-        finishReason: finish?.finishReason ?? { unified: "stop", raw: undefined },
-        usage: finish?.usage ?? ZERO_USAGE,
-        warnings: [],
-      };
-    },
-  });
-}
+// The scripted model and its stream parts come from the shared kit
+// (`@vendoai-fixtures/test-kit/stream-turns`); re-exported here so this harness
+// stays the single import every e2e in this host reaches for.
+export { scriptedModel, textTurn, toolCallTurn, ZERO_USAGE, type StreamPart };
 
 export interface TestHost {
   baseUrl: string;

--- a/corpus/hosts/express-host/package.json
+++ b/corpus/hosts/express-host/package.json
@@ -27,6 +27,7 @@
     "@types/node": "^22.0.0",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
+    "@vendoai-fixtures/test-kit": "workspace:*",
     "@vendoai/store": "workspace:*",
     "@vitejs/plugin-react": "^4.3.4",
     "tsx": "^4.19.0",

--- a/examples/mastra-agent/e2e/vendo-seam.e2e.test.ts
+++ b/examples/mastra-agent/e2e/vendo-seam.e2e.test.ts
@@ -21,6 +21,11 @@ import { noopObserve } from "@mastra/core/tools";
 import { parseVendoToolEnvelope, vendoAppRefSchema, vendoApprovalRefSchema } from "@vendoai/core";
 import { createStore } from "@vendoai/store";
 import { VENDO_PRINCIPAL_KEY, VENDO_SESSION_KEY, vendoMastraTools } from "@vendoai/vendo/mastra";
+import {
+  textTurn,
+  ZERO_USAGE,
+  type LanguageModelV3StreamPart as StreamPart,
+} from "@vendoai-fixtures/test-kit/stream-turns";
 import type { LanguageModel } from "ai";
 import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
 import { afterAll, describe, expect, it } from "vitest";
@@ -28,22 +33,10 @@ import { DEMO_PRINCIPAL, composeVendo } from "../src/lib/vendo";
 import { sentTripReports } from "../src/lib/vendo-actions";
 import { weatherTool } from "../src/mastra/tools/weather-tool";
 
-const ZERO_USAGE = {
-  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
-  outputTokens: { total: 0, text: 0, reasoning: 0 },
-};
-
-type StreamPart = Record<string, unknown>;
-
-const textTurn = (text: string): StreamPart[] => [
-  { type: "text-start", id: "t1" },
-  { type: "text-delta", id: "t1", delta: text },
-  { type: "text-end", id: "t1" },
-  { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "stop", raw: undefined } },
-];
-
 // Mastra's loop accumulates tool calls from the input-streaming bracket, so a
-// scripted tool call must stream tool-input-start/delta/end before tool-call.
+// scripted tool call must stream tool-input-start/delta/end before tool-call —
+// which is why this one is NOT the shared `toolCallTurn` from
+// `@vendoai-fixtures/test-kit/stream-turns`. The plain text turn is.
 const toolCallTurn = (toolName: string, input: unknown): StreamPart[] => [
   { type: "tool-input-start", id: "call_1", toolName },
   { type: "tool-input-delta", id: "call_1", delta: JSON.stringify(input) },

--- a/examples/mastra-agent/package.json
+++ b/examples/mastra-agent/package.json
@@ -35,6 +35,7 @@
     "@types/node": "^22.0.0",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
+    "@vendoai-fixtures/test-kit": "workspace:*",
     "@vendoai/store": "workspace:*",
     "eslint": "^9",
     "eslint-config-next": "16.2.9",

--- a/fixtures/integration-browser/e2e/harness/model.ts
+++ b/fixtures/integration-browser/e2e/harness/model.ts
@@ -5,46 +5,24 @@
  * engine (doGenerate) off a single FIFO queue — but the queue is MUTABLE so the
  * test (running in a separate process from the model) can enqueue turns over the
  * wire server's `/__test/script` control endpoint before it drives the page.
+ * That mutability is why the model itself is built here rather than taken from
+ * `@vendoai-fixtures/test-kit/stream-turns`, whose queue is fixed at construction.
  *
  * The control endpoint speaks a small high-level TurnSpec dialect (kind:"text" |
  * "tool" | "generate") rather than raw stream parts, so tests stay legible and
  * the JSON on the wire stays tiny; this module expands each spec into the exact
- * LanguageModelV3 stream parts the composed system consumes.
+ * LanguageModelV3 stream parts the composed system consumes, using the shared
+ * turn builders.
  */
+import {
+  textTurn,
+  toolCallTurn,
+  ZERO_USAGE,
+  type LanguageModelV3Content,
+  type LanguageModelV3GenerateResult,
+  type LanguageModelV3StreamPart,
+} from "@vendoai-fixtures/test-kit/stream-turns";
 import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
-
-type LanguageModelV3StreamPart = Awaited<
-  ReturnType<MockLanguageModelV3["doStream"]>
->["stream"] extends ReadableStream<infer Part> ? Part : never;
-type LanguageModelV3GenerateResult = Awaited<ReturnType<MockLanguageModelV3["doGenerate"]>>;
-type LanguageModelV3Content = LanguageModelV3GenerateResult["content"][number];
-
-const ZERO_USAGE = {
-  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
-  outputTokens: { total: 0, text: 0, reasoning: 0 },
-} as const;
-
-/** A plain assistant text turn (agent doStream). */
-function textTurn(text: string, id = "text_1"): LanguageModelV3StreamPart[] {
-  return [
-    { type: "text-start", id },
-    { type: "text-delta", id, delta: text },
-    { type: "text-end", id },
-    { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "stop", raw: undefined } },
-  ];
-}
-
-/** An agent turn that calls one tool (agent doStream). */
-function toolCallTurn(
-  toolName: string,
-  input: unknown,
-  toolCallId = "call_1",
-): LanguageModelV3StreamPart[] {
-  return [
-    { type: "tool-call", toolCallId, toolName, input: JSON.stringify(input) },
-    { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "tool-calls", raw: undefined } },
-  ];
-}
 
 /**
  * The high-level control dialect the `/__test/script` endpoint accepts.

--- a/fixtures/integration-browser/package.json
+++ b/fixtures/integration-browser/package.json
@@ -27,6 +27,7 @@
     "@types/node": "^22.0.0",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
+    "@vendoai-fixtures/test-kit": "workspace:*",
     "ai": "^6.0.0",
     "typescript": "^5.6.0",
     "vite": "^6.0.0"

--- a/fixtures/test-kit/README.md
+++ b/fixtures/test-kit/README.md
@@ -31,6 +31,20 @@ Concretely, these were considered and left where they are:
   a seam that can be run for real, promoted to a package.
 - **`tempStore`** — forty copies, every one of them inside `packages/vendo`.
   That is one package's own helper written forty times, not a shared one.
+- **`packages/harnesses`' turn helpers** — same NAMES, different meaning. This
+  kit's `textTurn(text, id)` names the stream part; harnesses'
+  `textTurn(text, usage)` sets the token usage on the `finish` part and
+  hardcodes the part id. Seven of its 73 call sites pass the second argument and
+  every one passes a usage object, all of them feeding the metering asserts
+  (`vendo/ledger.test.ts`, `vendo/subagent-loop.test.ts`, `vendo/vendo.test.ts`).
+  Reading that argument as an id would zero every usage figure and leave those
+  suites asserting against `ZERO_USAGE` — green, and measuring nothing. Its
+  `scriptedModel` is a different double too: `doStream` only, recording
+  `toolNamesPerCall`/`systemPrompts`/`calls` rather than driving a generation
+  engine. Only `ZERO_USAGE` and `toolCallTurn` are truly identical, and taking
+  just those two would leave one file where `toolCallTurn` is this kit's and the
+  same-named `textTurn` deliberately is not — the very collision that makes the
+  74 call sites dangerous. Left whole, on purpose.
 
 ## No barrel
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.0
         version: 19.2.3(@types/react@19.2.17)
+      '@vendoai-fixtures/test-kit':
+        specifier: workspace:*
+        version: link:../../../fixtures/test-kit
       '@vendoai/store':
         specifier: workspace:*
         version: link:../../../packages/store
@@ -462,6 +465,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.0
         version: 19.2.3(@types/react@19.2.17)
+      '@vendoai-fixtures/test-kit':
+        specifier: workspace:*
+        version: link:../../fixtures/test-kit
       '@vendoai/store':
         specifier: workspace:*
         version: link:../../packages/store
@@ -664,6 +670,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.0
         version: 19.2.3(@types/react@19.2.17)
+      '@vendoai-fixtures/test-kit':
+        specifier: workspace:*
+        version: link:../test-kit
       ai:
         specifier: ^6.0.0
         version: 6.0.28(zod@3.25.76)


### PR DESCRIPTION
The migration slice after #997. Three of the four remaining copies of the scripted-turn helpers now take them from `@vendoai-fixtures/test-kit/stream-turns`. The fourth is left alone deliberately, and that is the load-bearing part of this PR.

Every duplication claim was verified against the files before anything was deleted — one of the four turned out not to be a duplicate at all.

## Migrated, each with its own suite run

**`fixtures/integration-browser/e2e/harness/model.ts`** — `ZERO_USAGE`, `textTurn`, `toolCallTurn` and the three type aliases were byte-identical to the kit's. `createControllableModel` stays: its queue is MUTABLE so the out-of-process test can enqueue turns over the `/__test/script` control endpoint, which the kit's construction-time FIFO cannot do. The header now says that in place, so the next reader does not try again. → **6/6 Playwright journeys pass.**

**`corpus/hosts/express-host/e2e/harness.ts`** — the same four, plus a `scriptedModel` that differed from the kit's only by not recording prompts (the kit's extra `prompts` field is additive; nothing here reads it). Re-exported from the harness so every e2e in this host keeps its single import, the pattern #997 established in `fixtures/integration`. → **5 pass, 1 fails.** The failure (`doctor.e2e.test.ts`) is pre-existing: it reproduces identically on unmodified `origin/main`, verified by stashing this branch's changes and re-running the same command. It is `broken: present credentials did not reach the host API` + `actAs mint + host verification failed` — VENDO_BASE_URL/actAs wiring, nothing to do with turn helpers. Not fixed here; out of scope.

**`examples/mastra-agent/e2e/vendo-seam.e2e.test.ts`** — takes `ZERO_USAGE` and `textTurn`. Its `toolCallTurn` **does not move** and now records why in place: Mastra's loop accumulates tool calls from the input-streaming bracket, so a scripted tool call must emit `tool-input-start`/`delta`/`end` before `tool-call`. Sharing it would have broken the Mastra loop — this was a false duplication claim. Adopting the kit's part type also let a `type StreamPart = Record<string, unknown>` escape hatch go, so this file's stream parts are now genuinely typed. → **5/5 pass.**

## Not migrated: `packages/harnesses` — the signature question, settled

I was asked to establish whether harnesses' second argument is the same slot as the kit's before touching 74 call sites. **It is not.**

| | kit | `packages/harnesses` |
|---|---|---|
| signature | `textTurn(text, id = "text_1")` | `textTurn(text, usage = ZERO_USAGE)` |
| arg 2 lands in | the `text-start`/`text-delta`/`text-end` part ids | the `finish` part's `usage` |
| part id | caller-chosen | hardcoded `"t1"` |

Seven of the 73 call sites pass the second argument, and **every one passes a token-usage object**, all feeding metering assertions:

- `vendo/ledger.test.ts` — `HIRE`/`RESIDENT` usage summed per audit row, "which is exactly how a host bills"
- `vendo/vendo.test.ts:113` — asserts `{ inputTokens: 1200, outputTokens: 40 }` reaches the usage event
- `vendo/subagent-loop.test.ts` — `HIRE_USAGE` vs `RESIDENT_USAGE` separating subagent spend from the resident's

Reading that argument as a part id would silently drop every usage figure to `ZERO_USAGE`, and those suites would then assert against zeros — green, and measuring nothing. That is precisely the "mechanical rename that quietly changes what a test checks" outcome that is worse than the duplication.

Given they are different, I chose **leave harnesses alone** over **extend the kit**, because the extension buys almost nothing:

1. The biggest piece cannot move regardless. Harnesses' `scriptedModel` implements `doStream` only and records `toolNamesPerCall`, `systemPrompts` and `calls` — three fields the kit's model does not have; the kit's implements `doGenerate` for the apps generation engine, which harnesses has no use for.
2. So the genuinely-identical surface is `ZERO_USAGE` + `toolCallTurn`, about 8 lines. Taking just those leaves one file where `toolCallTurn` is the kit's while the same-named `textTurn` deliberately is not — reintroducing the exact same-name/different-meaning collision that makes the 74 call sites dangerous, inside a single file.
3. Adding a `usage` parameter to the kit's `textTurn` is a knob for exactly one consumer, on a shared signature three suites already depend on, days after it landed.

The reasoning is recorded in `fixtures/test-kit/README.md` beside #997's guard-double and `tempStore` entries, so it is where the next person will look rather than only in this PR.

## Behaviour

Three suite source files changed; one of them (`vendo-seam.e2e.test.ts`) contains assertions, and **no assertion in it was touched** — only the helper definitions above them. The migrated `textTurn`/`toolCallTurn`/`ZERO_USAGE` are identical in signature and body to what they replaced in `integration-browser` and `express-host`. In `mastra-agent` the only observable change is the text part id (`"t1"` → `"text_1"`); nothing in that repo asserts on part ids, and its 5 tests pass unchanged.

## Gates

- `pnpm build --filter=` the four touched packages — 16/16 successful
- `pnpm typecheck --filter=` the same four — 18/18 successful. `express-host` runs three tsconfigs including `tsconfig.test.json` (`include: ["e2e/**/*.ts"]`), so the e2e sources are typechecked, not skipped
- `pnpm lint` — pass, including `scripts/dependency-guard.mjs` (`OK (15 packages checked)`)
- Changed symbols grepped repo-wide including test dirs: no external consumer of the removed locals (`express-host`'s `StreamPart` was exported but only ever used inside its own file)

No changeset: every touched package is private and `privatePackages.version` is `false`, so nothing publishable moved.

**`vendo-web`: no-op.** Grepped the repo for `test-kit`, `stream-turns`, `ZERO_USAGE`, `textTurn`, `toolCallTurn` — the single hit is `PRO_ZERO_USAGE`, an unrelated console quota fixture. The kit is private and fixture-scoped; the console has no stake.

## Still open (deliberately not done here)

- **`readSse`** — 4 copies with 3 genuinely different return shapes (`{parts, raw}` in `fixtures/integration`, `{parts}` in `express-host`, a bare array in `harnesses`). Needs one agreed shape before consolidation, which is a decision, not a migration.
- **`loginCookie`** — 5 copies, each bound to its own fixture host's login route.
- **`examples/ai-sdk-agent`** — has hand-rolled scripted models too, but was outside this piece's file-set; worth a look in a later slice.
- `packages/vendo`'s 40 `tempStore` copies stay untouched — intra-package tidying, and #998 is in flight there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated three test turn-helper copies into the shared kit to reduce duplication; kept one local helper where semantics differ to avoid breaking tests.

- **Refactors**
  - `fixtures/integration-browser/e2e/harness/model.ts`: Use `textTurn`, `toolCallTurn`, `ZERO_USAGE`, and types from `@vendoai-fixtures/test-kit/stream-turns`; keep `createControllableModel` for its mutable queue.
  - `corpus/hosts/express-host/e2e/harness.ts`: Replace local helpers with the kit and re-export `scriptedModel`, `textTurn`, `toolCallTurn`, `ZERO_USAGE`, and `StreamPart` to preserve the single-import pattern.
  - `examples/mastra-agent/e2e/vendo-seam.e2e.test.ts`: Adopt kit `textTurn` and `ZERO_USAGE`; keep a local `toolCallTurn` because Mastra needs `tool-input-start/delta/end` before `tool-call`. Stream parts now use the kit’s `LanguageModelV3StreamPart` type.
  - Not migrated: `packages/harnesses` — its `textTurn(text, usage)` differs from the kit’s `textTurn(text, id)` and drives metering assertions; leaving as-is.

- **Dependencies**
  - Add `@vendoai-fixtures/test-kit` to `fixtures/integration-browser`, `corpus/hosts/express-host`, and `examples/mastra-agent`.

<sup>Written for commit 44fa952c4e5b6b61ea698fbf13e666abe8c4d235. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

