### PR TITLE
fix(automations,core,vendo,apps,actions,guard): automations typechecks its own tests, and stale comments stop pointing at deleted code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,11 +54,11 @@ jobs:
   # The big three, split file-wise inside each package. Coverage is collected
   # per shard as a BLOB report and merged in coverage-merge; the per-shard runs
   # pass --coverage.thresholds.lines=0 because vitest enforces the package's
-  # floor against whatever that shard happened to cover (measured: kit's
-  # shard 1/2 reports 48% of the 94% the whole suite reaches, and a floor of 90
-  # fails the shard). Zeroing it here moves the floor to the merge, where the
-  # number is the real one — the gate is not weakened, it is moved to the only
-  # place it can be correct.
+  # floor against whatever that shard happened to cover (measured back when a
+  # `kit` package still existed: its shard 1/2 reported 48% of the 94% the whole
+  # suite reaches, and a floor of 90 fails the shard). Zeroing it here moves the
+  # floor to the merge, where the number is the real one — the gate is not
+  # weakened, it is moved to the only place it can be correct.
   test-shards:
     runs-on: ubuntu-latest
     timeout-minutes: 25

--- a/packages/actions/src/runtime/steps.ts
+++ b/packages/actions/src/runtime/steps.ts
@@ -4,8 +4,8 @@ import { safeErrorMessage, type ApprovalId, type Json, type Step, type ToolCall,
  * Pure step-walker kernel for compound tools (04-actions §6).
  *
  * Semantics deliberately mirror the automations engine's `continueSteps`
- * (packages/automations/src/engine.ts) — same if/forEach/args ordering, same
- * forEach cap and error texts, same verbatim re-issue of a parked call on
+ * (packages/automations/src/run-execution.ts) — same if/forEach/args ordering,
+ * same forEach cap and error texts, same verbatim re-issue of a parked call on
  * resume — WITHOUT the run-record/stop persistence concerns. Automations is
  * the reference implementation; parity is enforced by a shared fixture table
  * (packages/vendo/src/compound-parity.test.ts). Single-sourcing automations

--- a/packages/apps/src/manifest-triggers.ts
+++ b/packages/apps/src/manifest-triggers.ts
@@ -45,10 +45,11 @@ const LEGACY_SCHEDULE_STATE_COLLECTION = "vendo_app_schedules";
 
 /**
  * The automations engine's per-trigger schedule cursor, as the CUTOVER needs to
- * write it. Two facts have to agree byte for byte with
- * `packages/automations/src/engine.ts` (`SCHEDULE`, `triggerKey`) and are
- * written down here because this package cannot import that one (the dependency
- * guard's layering: apps → core only):
+ * write it. Two facts have to agree byte for byte with automations
+ * (`SCHEDULE` in `packages/automations/src/types.ts`, `triggerKey` in
+ * `packages/automations/src/sponsorship.ts`) and are written down here because
+ * this package cannot import that one (the dependency guard's layering:
+ * apps → core only):
  *
  *   collection  "automations:schedule"
  *   row id      `<appId>:<triggerId>`

--- a/packages/automations/package.json
+++ b/packages/automations/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "vitest run",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit",
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {

--- a/packages/automations/src/byo-refs.test.ts
+++ b/packages/automations/src/byo-refs.test.ts
@@ -115,7 +115,8 @@ const tools: ToolRegistry = {
   async execute() { return { status: "ok", output: {} }; },
 };
 
-const appsDouble = (): AppsRuntime => ({ call: async () => ({ status: "ok", output: {} }) }) as AppsRuntime;
+const appsCall: AppsRuntime["call"] = async () => ({ status: "ok", output: {} });
+const appsDouble = (): AppsRuntime => ({ call: appsCall }) as AppsRuntime;
 
 const preTrainApp = (id: string, on: Trigger["on"]): AppDocument => ({
   format: VENDO_APP_FORMAT,

--- a/packages/automations/src/schedule-cursor.test.ts
+++ b/packages/automations/src/schedule-cursor.test.ts
@@ -51,7 +51,8 @@ const tools: ToolRegistry = {
   async execute() { return { status: "ok", output: {} }; },
 };
 
-const appsDouble = (): AppsRuntime => ({ call: async () => ({ status: "ok", output: {} }) }) as AppsRuntime;
+const appsCall: AppsRuntime["call"] = async () => ({ status: "ok", output: {} });
+const appsDouble = (): AppsRuntime => ({ call: appsCall }) as AppsRuntime;
 
 const hourly = (id: string): AppDocument => ({
   format: VENDO_APP_FORMAT,

--- a/packages/automations/src/security/webhook-verification.test.ts
+++ b/packages/automations/src/security/webhook-verification.test.ts
@@ -62,7 +62,8 @@ const registry = (
   execute: (call: ToolCall, runCtx: RunContext) => Promise<ToolOutcome> = async () => ({ status: "ok", output: {} }),
 ): ToolRegistry => ({ async descriptors() { return descriptors; }, execute });
 
-const appsDouble = (): AppsRuntime => ({ call: async () => ({ status: "ok", output: {} }) } as AppsRuntime);
+const appsCall: AppsRuntime["call"] = async () => ({ status: "ok", output: {} });
+const appsDouble = (): AppsRuntime => ({ call: appsCall } as AppsRuntime);
 
 /** Real HMAC-SHA256 signer over `id.timestamp.body`, key = base64url secret. */
 const sign = async (secret: string, deliveryId: string, timestamp: string, body: string): Promise<string> => {

--- a/packages/automations/src/sponsorship.test.ts
+++ b/packages/automations/src/sponsorship.test.ts
@@ -101,7 +101,8 @@ class GuardDouble implements Guard {
   }
 }
 
-const appsDouble = (): AppsRuntime => ({ call: async () => ({ status: "ok", output: {} }) } as AppsRuntime);
+const appsCall: AppsRuntime["call"] = async () => ({ status: "ok", output: {} });
+const appsDouble = (): AppsRuntime => ({ call: appsCall } as AppsRuntime);
 
 const flush = async (): Promise<void> => { await new Promise<void>((resolve) => setTimeout(resolve, 0)); };
 

--- a/packages/automations/tsconfig.test.json
+++ b/packages/automations/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/packages/core/src/grant-sets.ts
+++ b/packages/core/src/grant-sets.ts
@@ -86,8 +86,9 @@ export const UNATTENDED_DESTRUCTIVE_REASON =
  *   - `{ venue: "automation", presence: "away" }` is a real unattended firing —
  *     the shape every schedule fires with, including a machine app's own
  *     `vendo.json` schedules once they are folded into its document triggers
- *     (`apps/src/manifest-triggers.ts` → `automations/src/engine.ts`), so a
- *     venue-based predicate would let every schedule out from under the law.
+ *     (`apps/src/manifest-triggers.ts` → `baseRunContext` in
+ *     `automations/src/sponsorship-gate.ts`), so a venue-based predicate would
+ *     let every schedule out from under the law.
  *   - `{ venue: "automation", presence: "present" }` is a CEREMONY, not a run:
  *     the enable/capture flow and the "allow this while you're away" approval
  *     card both run with a human right there clicking, and they must SEE the

--- a/packages/core/src/workspace.ts
+++ b/packages/core/src/workspace.ts
@@ -41,7 +41,8 @@ export type CommitResult =
 
 /** Build contract §3.4 — the blob seam under the workspace: files past the
     inline cap live here, keyed by the store's `blob_ref`. Unset, the store's
-    own `blobs()` backs it (capped); `s3()` is the one shipped implementation. */
+    own `blobs()` backs it (capped); past that cap the host brings its own via
+    `files:` on createVendo (any S3-compatible bucket) — nothing ships one. */
 export interface FilesAdapter {
   put(key: string, bytes: Uint8Array, meta?: { contentType?: string }): Promise<void>;
   get(key: string): Promise<{ bytes: Uint8Array; contentType?: string } | undefined>;

--- a/packages/guard/test/security/unattended-destructive.test.ts
+++ b/packages/guard/test/security/unattended-destructive.test.ts
@@ -159,11 +159,12 @@ describe("THE LAW: unattended destructive calls are refused at the guard", () =>
   // an ORed venue would hide from them.
   //
   // The away sweep also covers the real callers the venue label would have let
-  // out: `packages/automations/src/engine.ts` fires genuine unattended work as
-  // `{ venue: "automation", presence: "away" }` — including a machine app's own
-  // `vendo.json` schedules, which `packages/apps/src/manifest-triggers.ts` folds
-  // into document triggers that same engine fires — so a venue-keyed predicate
-  // would put every scheduled firing outside the law.
+  // out: `baseRunContext` in `packages/automations/src/sponsorship-gate.ts`
+  // fires genuine unattended work as `{ venue: "automation", presence: "away" }`
+  // — including a machine app's own `vendo.json` schedules, which
+  // `packages/apps/src/manifest-triggers.ts` folds into document triggers that
+  // same engine fires — so a venue-keyed predicate would put every scheduled
+  // firing outside the law.
   it.each(VENUES)("refuses an away destructive call in venue %s", async (venue) => {
     const store = createMemoryStore();
     const send = descriptor("destructive", { name: "maple_payments_send" });

--- a/packages/vendo/src/audit-superset.e2e.test.ts
+++ b/packages/vendo/src/audit-superset.e2e.test.ts
@@ -419,7 +419,7 @@ describe("audit ⊇ transcript (design §3, evaluation E7)", () => {
  *
  *  - Per-APP dedupe, keyed `(appId, tool)`, EXISTS — but at ENABLE time, in the
  *    automations engine's capture reuse (`pendingCaptures` → `pendingForApp` in
- *    `packages/automations/src/engine.ts`), and it is already covered by
+ *    `packages/automations/src/consent.ts`), and it is already covered by
  *    `engine.test.ts` ("re-running enable() reuses the pending ask — no duplicate
  *    ApprovalRequest per (appId, tool)"). That is the layer it lives at, so this
  *    file does not re-stage it.
@@ -546,7 +546,7 @@ describe("the unattended failure card (design §3)", () => {
   it.skip("dedupes every failed firing onto ONE card per missing grant per app", async () => {
     // MUST BE BUILT: a stable dedupe key for (appId, tool, args-shape) on the
     // FIRE path, the way `enable()` already reuses a pending capture per
-    // (appId, tool) in `packages/automations/src/engine.ts`. `#parkApproval`
+    // (appId, tool) in `packages/automations/src/consent.ts`. `#parkApproval`
     // (`packages/guard/src/guard.ts`) currently mints `apr_<uuid>` with no
     // lookup, so the fire path has no dedupe at all.
     const fixture = await awayFixture();

--- a/packages/vendo/src/cli/playground/app/try-app.tsx
+++ b/packages/vendo/src/cli/playground/app/try-app.tsx
@@ -4,8 +4,8 @@
  * backdrop — one of five archetypes picked from the profile's tool domains
  * (try-stage.tsx / pickStageArchetype) — and the agent overlay floats over it
  * ALREADY OPEN, greeting the visitor by product name with the use-case chips
- * inside the panel's empty state (try-panel.tsx). Depth indicator + Refine
- * stay as a quiet top-right cluster over the stage.
+ * inside the panel's empty state (try-panel.tsx). The depth indicator stays as
+ * a quiet top-right cluster over the stage.
  *
  * The slot's data source is decided per render by selectSurfaceMode: when the
  * profile reports liveChat, the surface talks to the real wire at the boot
@@ -139,10 +139,10 @@ export function TryApp({ boot }: { boot: TryBoot }) {
         logoUrl={logoUrl}
         navLabels={navLabels}
       />
-      {/* The shell's own controls, quiet in the header region per the canvas:
-          the live depth indicator and (server capability permitting) Refine.
-          Fixed above the stage; while the overlay is open they sit under its
-          scrim like the rest of the page, and come back on close. */}
+      {/* The shell's own control, quiet in the header region per the canvas:
+          the live depth indicator. Fixed above the stage; while the overlay is
+          open it sits under its scrim like the rest of the page, and comes
+          back on close. */}
       <div style={{ position: "fixed", top: 12, right: 16, zIndex: 20, display: "flex", alignItems: "center", gap: 10 }}>
         {label ? (
           <span


### PR DESCRIPTION
Four findings handed over by other workers today. Each was re-verified against `origin/main` first.

### 1. `packages/automations` has no `lint` script — **deferred, the finding is wrong**
No package under `packages/` has a `lint` script, and there is no eslint config or eslint dependency anywhere in the library tree. `pnpm lint` is `dependency-guard` + `portability-gate` + `turbo run lint`, and `turbo run lint` matches only the three `examples/*` Next apps, each with its own `eslint.config.mjs`. So eslint has never run over *any* of the ten packages — this is a repo-wide posture, not an automations gap, and there are no "sibling packages" to copy. Standing up eslint for the library tree is a repo-wide decision with its own config, dependency and backlog; it is not this PR. **Nothing was added, so there is no new lint run to report.**

### 2. Four `AppsRuntime` cast errors — **fixed, plus the trap that hid them**
`packages/automations/tsconfig.json` excludes `src/**/*.test.ts`, so its test files have never been typechecked. Four of them were broken:

```
src/byo-refs.test.ts(118,39):                    error TS2352
src/schedule-cursor.test.ts(54,39):              error TS2352
src/security/webhook-verification.test.ts(65,40): error TS2352
src/sponsorship.test.ts(104,40):                 error TS2352
```

Root cause is the same in all four: `async () => ({ status: "ok", output: {} })` infers `status: string`, which does not overlap the `ToolOutcome` union, so `as AppsRuntime` is a mistaken conversion. Fixed by typing the double's `call` against `AppsRuntime["call"]` — the exact shape `engine.test.ts:137` and `security/emit-tick-isolation.test.ts:55` in this same package already use, and which is why *those* two doubles were fine. Not silenced with `as unknown as`.

The package now gets a `tsconfig.test.json` and the second `tsc` in `typecheck`, matching `knowledge`, `vendo-telemetry` and `guard` (#979). Those four were the only errors it surfaces.

### 3. Stale source comments — all three still stale, all three fixed
- `packages/core/src/workspace.ts:44` named the deleted `s3()` as "the one shipped implementation". Nothing ships a `FilesAdapter` now; hosts pass `files:` (see `selectFiles` in `packages/vendo/src/server.ts`).
- `packages/vendo/src/cli/playground/app/try-app.tsx:7,143` described a Refine control in the top-right cluster. The cluster now renders the depth indicator and nothing else.
- `.github/workflows/ci.yml:57` measured "kit's shard 1/2". `kit` is gone; the measurement is kept but marked as the historical one it is, rather than repointed at a package it was never taken on.

### 4. Six `engine.ts` pointers after #993 — all six found and repointed
`createAutomationsEngine` is 13 lines now and the symbols moved to siblings:

| site | was | now |
|---|---|---|
| `apps/src/manifest-triggers.ts:49` | `engine.ts` (`SCHEDULE`, `triggerKey`) | `types.ts` / `sponsorship.ts` |
| `core/src/grant-sets.ts:89` | `engine.ts` | `baseRunContext` in `sponsorship-gate.ts` |
| `actions/src/runtime/steps.ts:7` | `engine.ts` (`continueSteps`) | `run-execution.ts` |
| `vendo/src/audit-superset.e2e.test.ts:422` | `engine.ts` (`pendingCaptures` → `pendingForApp`) | `consent.ts` |
| `vendo/src/audit-superset.e2e.test.ts:549` | `engine.ts` | `consent.ts` |
| `guard/test/security/unattended-destructive.test.ts:162` | `engine.ts` | `sponsorship-gate.ts` |

No `automations/src/engine.ts` pointers remain in tracked source.

### Out of scope, reported not fixed
Two more #993 casualties, left alone because they are outside the assigned list:
- `packages/automations/src/security/webhook-verification.test.ts:21` — "07-automations engine.ts"; the webhook ingress is `ingestion-surface.ts` now.
- `packages/ui/test/chrome/automation-card.test.tsx:38` — cites "engine.ts §325, §2068" for a file that is 31 lines long.

### Gates
- `pnpm build --filter=@vendoai/automations... --filter=@vendoai/guard... --filter=@vendoai/actions...` → 5/5 successful
- `pnpm typecheck --filter=` automations, core, apps, actions, guard → 7/7 successful (automations now runs both configs)
- `pnpm --filter=@vendoai/automations test` → 6 files, 105 passed
- `.github/workflows/ci.yml` parses clean and still declares all 8 jobs
- `pnpm lint`: `dependency-guard: OK (15 packages checked)`; the portability gate needs `packages/vendo/dist`, which needs an unscoped build — not run here, and untouched by a comment-and-tsconfig change. CI covers it.

`packages/vendo` was not gated: the only changes there are four comment lines, and #998/#999 are live in that package.

**Tandem:** no-op. `vendo-web` has one hit for any changed symbol — a July planning doc mentioning `automations/src/engine.ts` — and nothing in this PR crosses a `vendo-web` seam.

**Changeset:** none. No published package's behaviour changes; the diff is comments, a dev-only `typecheck` script, and a new `tsconfig.test.json` that is not in `files`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable test typechecking in `@vendoai/automations` and fix four broken `AppsRuntime` test doubles; also refresh stale comments across the repo that referenced moved or deleted code. No runtime behavior changes.

- **Bug Fixes**
  - `@vendoai/automations`: add `tsconfig.test.json` and run it in `typecheck`; fix four tests by typing `appsCall` as `AppsRuntime["call"]` instead of casting.
  - Stale prose: repoint `engine.ts` references after #993 across `@vendoai/apps`, `@vendoai/core`, `@vendoai/actions`, `@vendoai/vendo`, and `@vendoai/guard`; clarify `FilesAdapter` comment (hosts provide `files:`); update CI shard note about the removed `kit` package; remove the old Refine mention from the playground UI text.

<sup>Written for commit 378b6c2883e90ddf000f7d1b96ff2e76503dbd4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

