### PR TITLE
refactor(vendo): the playground's console scenario becomes the two panels a host still mounts

### DIFF
--- a/.changeset/the-playground-drops-the-console-scenario.md
+++ b/.changeset/the-playground-drops-the-console-scenario.md
@@ -1,0 +1,17 @@
+---
+"@vendoai/vendo": minor
+---
+
+The playground's `page` scenario is replaced by the two panels a host still mounts itself.
+
+`VendoPage` is being cut, so the scenario that mounted it (`#page`, "Workspace
+console") goes with it. What it uniquely showed that no other scenario did was
+the automations list and the connected-accounts settings, so those become
+scenarios of their own against the same fake wire client: `#automations-panel`
+(`AutomationsPanel`) joins the Automations group, and `#accounts`
+(`ConnectedAccountsPanel`) opens a new Accounts group. The `Page` group is gone.
+
+Breaking for `mountScenario`/`VendoDocsEmbed.mount` callers: `scenario: "page"`
+now throws `unknown scenario`. The console shell itself — the conversation-history
+rail, the app shelf, and the Apps door — is no longer demonstrated anywhere,
+because it is no longer shipped.

--- a/packages/vendo/src/cli/playground/app/scenarios.test.ts
+++ b/packages/vendo/src/cli/playground/app/scenarios.test.ts
@@ -10,12 +10,13 @@ const REQUIRED = [
   "thread-view",
   "thread-connect",
   "approval-flow",
+  "automations-panel",
   "activities",
   "activities-empty",
   "slot-empty",
   "slot-filled",
   "slot-broken",
-  "page",
+  "accounts",
   "mobile",
 ];
 
@@ -53,9 +54,9 @@ describe("playground scenario registry", () => {
   });
 
   it("auto-played scenarios carry the prompt their script answers", () => {
-    // These stay interactive: the launcher waits for a click, the page waits
-    // for a typed turn, and mobile embeds another scenario in an iframe.
-    const interactive = new Set(["overlay-launcher", "page", "mobile"]);
+    // These stay interactive: the launcher waits for a click, and mobile
+    // embeds another scenario in an iframe.
+    const interactive = new Set(["overlay-launcher", "mobile"]);
     for (const scenario of scenarios) {
       if (scenario.script && !interactive.has(scenario.id)) {
         expect(scenario.autoSend, `${scenario.id} plays a script and needs an opening user turn`).toBeTruthy();

--- a/packages/vendo/src/cli/playground/app/scenarios.tsx
+++ b/packages/vendo/src/cli/playground/app/scenarios.tsx
@@ -5,7 +5,7 @@
  * scripted transport, and the auto-sent opening turn.
  */
 import type { DirectorScript } from "@vendoai/ui";
-import { VendoActivities, VendoOverlay, VendoPage, VendoSlot, VendoThread } from "@vendoai/ui/chrome";
+import { AutomationsPanel, ConnectedAccountsPanel, VendoActivities, VendoOverlay, VendoSlot, VendoThread } from "@vendoai/ui/chrome";
 import { useMemo, type ReactElement } from "react";
 import {
   approvalScript,
@@ -21,7 +21,7 @@ import {
 
 export interface PlaygroundScenario {
   id: string;
-  group: "Overlay" | "Thread" | "Approvals" | "Automations" | "Activities" | "Slot" | "Page" | "Mobile";
+  group: "Overlay" | "Thread" | "Approvals" | "Automations" | "Activities" | "Slot" | "Accounts" | "Mobile";
   title: string;
   description: string;
   /** Scripted turns this scenario's sends play (ScriptedTransport). */
@@ -158,6 +158,13 @@ export const scenarios: PlaygroundScenario[] = [
     render: () => <ThreadPane />,
   },
   {
+    id: "automations-panel",
+    group: "Automations",
+    title: "Automations panel",
+    description: "Where an armed automation lives afterwards: its trigger, the standing permissions it holds, a dry run, and the last ten runs. Hosts mount this piece on their own settings route.",
+    render: () => <AutomationsPanel pollMs={0} />,
+  },
+  {
     id: "activities",
     group: "Activities",
     title: "Approvals queue + activity feed",
@@ -202,12 +209,11 @@ export const scenarios: PlaygroundScenario[] = [
     ),
   },
   {
-    id: "page",
-    group: "Page",
-    title: "Workspace console",
-    description: "The full VendoPage: conversations with history, the waiting-on-you approval strip, apps, automations, accounts, and activity.",
-    script: viewScript(),
-    render: () => <VendoPage />,
+    id: "accounts",
+    group: "Accounts",
+    title: "Connected accounts",
+    description: "The settings-page counterpart to the in-thread connect card: the accounts this user has connected, and disconnecting one (with an undo window).",
+    render: () => <ConnectedAccountsPanel />,
   },
   {
     id: "mobile",


### PR DESCRIPTION
`VendoPage` is being cut. This is the piece that makes the **playground** stop
depending on it, landing **before** the deletion so nothing is ever broken on
`main`. Neither `vendo-page.tsx` nor `chrome/center/**` is touched here.

## What the `page` scenario actually demonstrated

`#page` ("Workspace console") mounted the whole `VendoPage`: an in-page rail
beside one conversation column, with doors to Apps, Automations, Activity and
Connected Accounts. Read against the rest of the registry, exactly two things it
showed were reachable from nowhere else:

- **`AutomationsPanel`** — the automations *management* surface. The existing
  `#automation-created` scenario shows an automation being armed in a thread; it
  never shows where that automation lives afterwards.
- **`ConnectedAccountsPanel`** — the settings-page counterpart to the in-flow
  connect card in `#thread-connect`.

Both are exported `@vendoai/ui/chrome` components that survive the cut, and with
`VendoPage` gone they are the *only* way a host surfaces that state. So they
become scenarios in their own right rather than disappearing with the shell:

| before | after |
| --- | --- |
| `#page` · group **Page** · `<VendoPage />` | `#automations-panel` · group **Automations** · `<AutomationsPanel pollMs={0} />` |
| | `#accounts` · group **Accounts** · `<ConnectedAccountsPanel />` |

Everything else the console displayed is already covered: the thread column by
the Thread group, the waiting-on-you strip by `#approval-flow`, the activity
ledger by `#activities`.

## What a visitor loses — the product consequence

**The console shell itself is no longer demonstrated anywhere**: the
conversation-history rail with New chat, the day-zero app shelf, and the Apps
door. That is not a gap in the playground — it is `VendoPage` no longer being a
thing Vendo ships, and the playground's job ("every surface") is to say so. But
it is a visible change on `vendo.run/playground`: the **Page** group leaves the
nav, and an **Accounts** group takes its place.

`#page` degrades gracefully rather than erroring — `useHashScenario` already
falls back to the first scenario for an unknown hash, so an old shared link
lands on "Closed, with launcher" (verified in the browser below).

**Breaking for embed callers**: `mountScenario` / `window.VendoDocsEmbed.mount`
with `scenario: "page"` now throws `unknown scenario`. `docs-site/ui/components.mdx`
still has one (`<VendoEmbed surface="page">` plus the `## Page` prose section) —
that file is another piece's file-set, and it is not broken by this PR (see the
bundle section).

## Embed bundle rebuilt

`pnpm --filter @vendoai/vendo run build:embed` (the artifact is `.gitignore`d
here — it is hand-copied into `vendo-web`'s `public/playground/embed.js`):

| | bytes |
| --- | --- |
| built from `origin/main` | 2,806,176 |
| built from this branch | 2,776,526 |
| | **−29,650 (−1.1%)** |

Grepped the two bundles to confirm the removal actually reached the artifact:

| string | main | this branch |
| --- | --- | --- |
| `Workspace console` (scenario title) | 1 | **0** |
| `Vendo workspace` (`VendoPage`'s `aria-label`) | 1 | **0** |
| `vendo-tab-` (`chrome/center/rail.tsx`) | 1 | **0** |
| `Automations panel` (new scenario) | 0 | **1** |

`fl-center-*` still appears once, in the `chrome-css.ts` stylesheet string — the
final deletion piece removes those rules with the component.

## vendo-web disposition — no companion PR, deliberately

Grepped `runvendo/vendo-web`: **no source reference to `VendoPage` or to the
`page` scenario id.** Two separate facts corrected a premise worth writing down:

1. **`vendo.run/playground` does not load `embed.js`.** `app/playground/venue.tsx`
   imports `@vendoai/vendo/try-surface`, which `package.json` pins to the vendored
   tarball `./vendor/vendoai-vendo-0.5.0.tgz`. The live playground page changes
   when vendo-web re-vendors, not when this merges.
2. **`public/playground/embed.js` is a release artifact, not an adaptation.** It
   is built from OSS `932f0640b` (2026-07-26, **878 commits** behind `main`) and
   is only ever refreshed by explicit `chore: re-vendor` commits that bump the
   tarballs at the same time. Dropping today's bundle in alone would (a) ship 878
   unrelated commits of UI onto a live surface unverified, (b) leave `/playground`
   on 0.5.0 while the docs embeds run 0.8.0, and (c) immediately break docs-site's
   still-present `surface="page"` embed (it falls back to the poster image).

Leaving it stale is the safe state: the old bundle still serves `page`, so
docs-site keeps working until its own piece drops the section. **The refresh
belongs to a re-vendor chore after the docs piece lands** — flagged for the
conductor as a decision, not done here.

## Browser verification

Real Chromium against the real `PlaygroundApp` shell, scripted data. Zero console
errors across all four loads.

Scenario nav + the new **Automations panel** scenario — real trigger card, dry
run, run history strip, standing-access grant:

![automations panel scenario](https://gist.githubusercontent.com/yousefh409/e3262889842f5ca5c872d2f2469e5623/raw/f6f40f8ac04bce7a7a07f1658ce96ed71b1bfcda/automations-panel.png)

The new **Connected accounts** scenario — connected + expired account, disconnect
and reconnect affordances:

![connected accounts scenario](https://gist.githubusercontent.com/yousefh409/e3262889842f5ca5c872d2f2469e5623/raw/f6f40f8ac04bce7a7a07f1658ce96ed71b1bfcda/accounts.png)

An existing scenario, unchanged — `#approval-flow` still plays its script and
parks on the approval card:

![approval flow still works](https://gist.githubusercontent.com/yousefh409/e3262889842f5ca5c872d2f2469e5623/raw/f6f40f8ac04bce7a7a07f1658ce96ed71b1bfcda/approval-flow.png)

Rendered nav, in order:

```
OVERLAY: Closed, with launcher · Open, mid-conversation · Streaming turn
THREAD: Streaming text · Generated view arriving · Connect card
APPROVALS: Pending → approved → resumed
AUTOMATIONS: Automation created · Automations panel
ACTIVITIES: Approvals queue + activity feed · Empty state
SLOT: Empty ghost · Filled with a pinned view · Broken view → host fallback
ACCOUNTS: Connected accounts
MOBILE: Phone viewport
```

`#page` → falls back to "Closed, with launcher". No `Page` group.

## Test change, stated out loud

`scenarios.test.ts` is the registry's own contract test, so it moves with the
registry: `page` leaves the required-ids list (the two new ids take its place)
and leaves the `interactive` set (which exempts script-carrying scenarios from
needing an `autoSend`). No other test touched.

## Gate

```
pnpm build --filter=@vendoai/vendo...        13 successful, 13 total
vitest run src/cli/playground                5 files, 80 tests passed
pnpm typecheck                               42 successful, 42 total
pnpm lint                                    dependency-guard OK · portability-gate all legs green · 3/3
```

Plus the tests-included typecheck trap (`packages/vendo`'s tsconfig excludes test
files, so the normal gate would not see a test-only break): ran `tsc --noEmit`
over `src/**` *including* `*.test.ts(x)` on both `origin/main` and this branch —
**265 pre-existing errors on each, byte-identical error sets.** No new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the playground’s `#page` console scenario (which mounted `VendoPage`) with two standalone panel scenarios so the playground no longer depends on `VendoPage`. Automations and connected accounts remain reachable via dedicated scenarios.

- **Refactors**
  - Added `#automations-panel` (Automations) using `<AutomationsPanel pollMs={0} />` from `@vendoai/ui/chrome`.
  - Added `#accounts` (Accounts) using `<ConnectedAccountsPanel />` from `@vendoai/ui/chrome`.
  - Removed `#page` and the Page group; other surfaces are already covered by existing scenarios.
  - Updated registry tests to require the new ids and removed `page` from the interactive set.

- **Migration**
  - `mountScenario`/`window.VendoDocsEmbed.mount` with `scenario: "page"` now throws `unknown scenario`; use `automations-panel` or `accounts`.

<sup>Written for commit 9a0aa0deb87799fc872269e6f7bee42494e7fadc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

