### PR TITLE
fix(vendo): sync --ai reaches an engine on a Claude Code OAuth token, not just an API key

### DIFF
--- a/.changeset/tidy-moons-guess.md
+++ b/.changeset/tidy-moons-guess.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/vendo": patch
+---
+
+`vendo sync --ai` on an incremental run now reaches an engine on Claude Code's own-credential env vars (`ANTHROPIC_AUTH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, a custom `ANTHROPIC_BASE_URL`), which both Claude harnesses already accept. That one flag combination is the only path that falls back to the runtime credential resolver instead of sweeping the harness ladder, so it alone reported "no model credential" while `vendo init` and an interactive `vendo sync` ran fine on the same login. The runtime resolver itself is unchanged — product turns still require a real API key.

--- a/packages/vendo/src/cli/judge/engine.test.ts
+++ b/packages/vendo/src/cli/judge/engine.test.ts
@@ -61,6 +61,21 @@ describe("resolveJudgmentEngine", () => {
     expect(resolved.reason).toContain("VENDO_API_KEY");
   });
 
+  it.each(["ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_BASE_URL"])(
+    "%s is a coding-agent credential the gate must honor, even though it serves no product turn",
+    async (envVar) => {
+      const resolved = await resolveJudgmentEngine({
+        root: "/tmp",
+        env: { [envVar]: "set" },
+        // The real resolver's answer for this env: no runtime model key. The
+        // harnesses run on it all the same.
+        resolveCredential: async () => ({ rung: "none" }),
+        harnesses: [harness("claude-cli", `your ${envVar}`)],
+      });
+      expect(resolved.engine?.credential).toBe(`your ${envVar}`);
+    },
+  );
+
   it("picks the first available rung when no pin is given", async () => {
     const resolved = await resolveJudgmentEngine({
       root: "/tmp",

--- a/packages/vendo/src/cli/judge/engine.ts
+++ b/packages/vendo/src/cli/judge/engine.ts
@@ -2,6 +2,7 @@ import { resolveDevCredential, type DevCredential } from "../../dev-creds/resolv
 import { claudeCliHarness } from "../extract/claude-cli-harness.js";
 import { claudeHarness } from "../extract/claude-harness.js";
 import { codexCliHarness } from "../extract/codex-cli-harness.js";
+import { hasOwnAnthropicEnvOverride } from "../extract/gateway-fuel.js";
 import { npxEngineHarness } from "../extract/npx-engine-harness.js";
 import type { ExtractionHarness } from "../extract/harness.js";
 
@@ -11,7 +12,8 @@ import type { ExtractionHarness } from "../extract/harness.js";
  * both are preserved verbatim:
  *
  * - the CREDENTIAL gate comes first (resolveDevCredential: BYO provider key →
- *   VENDO_API_KEY → none), so a keyless repo never probes a single harness. The
+ *   VENDO_API_KEY → none, WIDENED here by Claude Code's own-credential env vars
+ *   — see the gate itself), so a keyless repo never probes a single harness. The
  *   probes are local and cheap but they are still observable work, and the
  *   keyless answer is "structural-only", not "try anyway";
  * - an `--engine` pin NEVER falls back to another provider. The pin is usually a
@@ -83,7 +85,16 @@ export async function resolveJudgmentEngine(
 ): Promise<{ engine: AvailableEngine | null; reason?: string }> {
   const resolve = options.resolveCredential ?? resolveDevCredential;
   const credential = await resolve({ env: options.env });
-  if (credential.rung === "none") {
+  // resolveDevCredential answers a DIFFERENT question — what can serve a
+  // product turn at runtime — and real API keys are the only answer to that
+  // one (doctor, doctor-live and dev-creds/model.ts all read it, so it must
+  // stay that way). A coding agent is not a product turn: Claude Code also
+  // runs on an interactive OAuth token or a corporate endpoint, none of which
+  // is a key. Without this widening, `vendo sync --ai` on an incremental run —
+  // the ONE path that falls back to this resolver instead of sweeping the
+  // ladder — told those devs they had no engine while `vendo init` and an
+  // interactive `vendo sync` ran fine on the same credentials.
+  if (credential.rung === "none" && !hasOwnAnthropicEnvOverride(options.env)) {
     return {
       engine: null,
       reason: "no model credential — set ANTHROPIC_API_KEY / OPENAI_API_KEY (BYO) or VENDO_API_KEY (`vendo login`)",

--- a/packages/vendo/src/cli/sync-flow.test.ts
+++ b/packages/vendo/src/cli/sync-flow.test.ts
@@ -2,8 +2,10 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { describeDevCredential, resolveDevCredential } from "../dev-creds/resolve.js";
+import type { ExtractionHarness } from "./extract/harness.js";
 import type { Output } from "./shared.js";
-import { runSyncFlow, type SyncFlowOptions, type SyncFlowResult } from "./sync-flow.js";
+import { readEnvFiles, runSyncFlow, type SyncFlowOptions, type SyncFlowResult } from "./sync-flow.js";
 
 /**
  * The ONE flow `vendo init` (mode "full") and `vendo sync` (mode "incremental")
@@ -205,6 +207,66 @@ describe("the AI flag matrix (one rule, both modes)", () => {
       judge: { harnesses: [forbidden], confirm: async () => { throw new Error("prompted"); } },
     });
     expect(messages.logs.join("\n")).not.toContain("judgment");
+  });
+});
+
+describe("a harness-owned credential (Claude Code OAuth / auth token / custom endpoint)", () => {
+  /** The Claude Code rungs run on any of ANTHROPIC_AUTH_TOKEN,
+   *  CLAUDE_CODE_OAUTH_TOKEN or a custom ANTHROPIC_BASE_URL — none of which is
+   *  a product-turn API key. Only `availability()` knows that, so only
+   *  `availability()` may decide whether this run has an engine. */
+  const oauthEngine: ExtractionHarness = {
+    id: "oauth-only",
+    availability: async ({ env }) =>
+      (env["CLAUDE_CODE_OAUTH_TOKEN"] ?? "") === "" ? null : "your CLAUDE_CODE_OAUTH_TOKEN",
+    run: async () => "```json\n" + JSON.stringify({ tools: [], narrative: "" }) + "\n```",
+  };
+
+  /** One never-judged tool, so incremental mode has real work and the run
+   *  reaches the engine rather than the up-to-date shortcut. */
+  const UNJUDGED = `${JSON.stringify({
+    format: "vendo/tools@3",
+    tools: [{
+      name: "host_a",
+      description: "Use this to call host_a.",
+      inputSchema: { type: "object", properties: {} },
+      risk: "read",
+      binding: { kind: "route", method: "GET", path: "/api/a", argsIn: "query" },
+    }],
+  })}\n`;
+
+  /** A host holding ONLY a harness-owned credential: no API key on any rung. */
+  async function oauthHost(): Promise<string> {
+    for (const name of ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY", "VENDO_API_KEY", "VENDO_DEV_CREDENTIAL"]) {
+      vi.stubEnv(name, "");
+    }
+    const root = await host({ ".env": "CLAUDE_CODE_OAUTH_TOKEN=oauth-tok\n" });
+    await writeFile(join(root, ".vendo", "tools.json"), UNJUDGED, "utf8");
+    return root;
+  }
+
+  it("`sync --ai` on an incremental run reaches the engine, same as init and an interactive sync", async () => {
+    const messages = captureOutput();
+    const result = await flow({
+      root: await oauthHost(),
+      output: messages.output,
+      fetchImpl: offline,
+      ai: true,
+      judge: { harnesses: [oauthEngine] },
+    });
+    expect(messages.logs.join("\n")).not.toContain("structural-only");
+    expect(result.judged.ran).toBe(true);
+  });
+
+  it("leaves the runtime model ladder alone: the same env still has NO product-turn credential", async () => {
+    // doctor, doctor-live and dev-creds/model.ts all read this one resolver,
+    // and an interactive-only OAuth token cannot serve a product turn. Widening
+    // it would be a worse bug than the one above.
+    const root = await oauthHost();
+    const env = await readEnvFiles(root);
+    expect(env["CLAUDE_CODE_OAUTH_TOKEN"]).toBe("oauth-tok");
+    expect(await resolveDevCredential({ env })).toEqual({ rung: "none" });
+    expect(describeDevCredential(await resolveDevCredential({ env }))).toBe("no model credential found");
   });
 });
 


### PR DESCRIPTION
## The gap

Two routes reach a judgment engine, and only one crosses the runtime credential resolver.

- `chooseEngine` (`packages/vendo/src/cli/sync-flow.ts:313`) calls `selectJudgmentEngines` directly. It sweeps the harness ladder, so `availability()` sees all three Claude Code credential paths, and the chosen harness goes to `runJudgmentPass`, which then skips `resolveJudgmentEngine` entirely (`judge/pass.ts:442`).
- `resolveJudgmentEngine` (`judge/engine.ts:84`) ran `resolveDevCredential` first and returned early on `rung: "none"`. That resolver knows `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY` and `VENDO_API_KEY` — nothing else.

**The fork is `sync-flow.ts:309`**: `--ai` on an **incremental** run short-circuits the sweep, so the pass falls back to the gated resolver. Verified line-for-line against `origin/main` today.

**Net effect is narrower than it looks.** `vendo init` is always mode `"full"` and sweeps the ladder; an interactive `vendo sync` with no `--ai` sweeps it too; the auto-installed `predev`/`prebuild` hooks carry `--no-ai` and stop above the fork. **Only `vendo sync --ai` without `--full` hit the gate.** A dev authenticated by `ANTHROPIC_AUTH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN` or a custom `ANTHROPIC_BASE_URL` — all genuinely supported by the npx and PATH harnesses — was told there was no engine on that one flag combination, while the same credentials worked everywhere else.

## The shape, and why

The fix widens the gate **at that one call site**, not in the shared resolver. `resolveDevCredential` is read by `vendo doctor`, `doctor-live`, the runtime `dev-creds/model.ts` ladder and init's key resolution, and those want a real API key for **product turns** — an interactive-only OAuth token cannot serve one. Widening it everywhere would hand a runtime path a credential it cannot use: a worse bug than this one.

The gate now also asks `hasOwnAnthropicEnvOverride` from `extract/gateway-fuel.ts` — **the predicate the harnesses themselves already use**, so there is no second list of variable names to drift out of sync. One import, one clause.

**The alternative I tried and backed out of:** deleting the `mode !== "full"` clause so `--ai` always sweeps the ladder. It is the tidier answer on paper (one route instead of two) and it also fixes the bare `claude auth` login case, which this PR does not. I reverted it because the blast radius is wrong for this change: it broke four tests in `sync.test.ts` — a file outside this piece's scope — including the deliberate "keyless sync must never probe an engine" invariant, and one test that has no harness seam and consequently spawned the **real** `claude` CLI and hung for 30s. That is a real signal, not just test churn: sweeping on the incremental path means every `sync --ai` probes the machine before the pass's local up-to-date check can short-circuit. Worth doing, but as its own change with its own consent conversation — not smuggled into a credential fix. The residual (a Claude Code login with no env var still falls to `structural-only` on `sync --ai` incremental) is inherent to a gate that exists specifically to avoid probing.

## Discipline

- **Failing test first**, separate commit (820919034), in the existing behavior-named suite `sync-flow.test.ts` — no round/wave/ticket-named file. Watched it fail on the right line:
  `judgment: structural-only (no model credential — set ANTHROPIC_API_KEY / OPENAI_API_KEY (BYO) or VENDO_API_KEY)` with `CLAUDE_CODE_OAUTH_TOKEN` set and every key rung blanked.
- **Companion regression assertion**, same commit: the same env still resolves to `{ rung: "none" }` and `describeDevCredential` still says "no model credential found" — doctor, doctor-live and `dev-creds/model.ts` all read that one resolver, and it is untouched. Proven live too: `doctor.test.ts` (80), `doctor-live.test.ts` (12), `dev-creds/resolve.test.ts` (5), `model.test.ts` (29), `model-edge.test.ts` (3) all green, unmodified.
- **No existing test was edited.** Two additions only.
- **vendo-web:** grepped for `resolveJudgmentEngine`, `selectJudgmentEngines`, `chooseEngine`, `resolveDevCredential`, `sync --ai`, `CLAUDE_CODE_OAUTH_TOKEN`, `AI polish` — **zero hits**. This is CLI-internal engine selection; nothing crosses the console seam. No companion PR needed.
- **tsconfig-excludes-tests trap:** ran `tsc --noEmit` over `packages/vendo/src` **including** test files, on this branch and on `origin/main`. Both produce the same **106** pre-existing errors in unrelated e2e suites; `diff` of the sorted error sets is **empty**, and none touch `sync-flow` or `judge/`.

## Gate

```
pnpm build --filter=@vendoai/vendo...   13 successful, 13 total
vitest (owned + regression suites)      14 files, 399 passed
pnpm typecheck                          42 successful, 42 total
pnpm lint                               3 successful, 3 total
```

Suites run: `sync-flow`, `sync-flow.unattended`, `judge/**`, `sync`, `init`, `doctor`, `doctor-live`, `dev-creds/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`vendo sync --ai` (incremental) now reaches a judgment engine when the host has Claude Code credentials (OAuth token or custom Anthropic endpoint), not just an API key. This aligns behavior with `vendo init` and interactive `vendo sync` without changing runtime credential rules.

- **Bug Fixes**
  - Honor Claude env vars `ANTHROPIC_AUTH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, and `ANTHROPIC_BASE_URL` in the judgment gate via `hasOwnAnthropicEnvOverride`.
  - Scope: only affects incremental `vendo sync` with `--ai`; other paths already sweep harnesses.
  - `resolveDevCredential` remains keys-only; `doctor`, `doctor-live`, and runtime model ladder are unchanged.
  - Added tests in `judge/engine.test.ts` and `sync-flow.test.ts`; no existing tests edited.
  - Changeset added for `@vendoai/vendo`.

<sup>Written for commit 67124a6e67a0fae280a1ae05143dae81728b4928. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

