### PR TITLE
refactor(core): the six longest validators read as one rule per function

### DIFF
--- a/.changeset/core-splits-its-six-longest-validators.md
+++ b/.changeset/core-splits-its-six-longest-validators.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/core": patch
+---
+
+Internal refactor: core's six highest-cognitive-complexity functions are decomposed into named helpers. `applyStep` and `reshapeShape` (reshape.ts) each split one branch per reshape op; `validateAppDocumentUnsafe` (app-document.ts) splits one function per cross-field rule; `validateTreeUnsafe` (genui/tree.ts) splits the query block and the node walk; `parseAttributes` (genui/wire/attributes.ts) splits the `=`-value forms and the duplicate-attribute message; `prescanDeclarations` (genui/wire/compile.ts) splits the `<Query>` and `<Island>` pre-scan branches. Every extracted helper is module-private and every message, order of checks and return value is unchanged. **No public surface changed** — not one exported symbol, signature or type moved, and no test file was touched.

--- a/packages/core/src/app-document.ts
+++ b/packages/core/src/app-document.ts
@@ -320,24 +320,9 @@ const collectTreeFnReferences = (
   }
 };
 
-const validateAppDocumentUnsafe = (input: unknown): AppDocumentValidation => {
-  if (typeof input !== "object" || input === null || Array.isArray(input)) {
-    return fail("validation", "app document must be a non-null object");
-  }
-  if ((input as Record<string, unknown>).format !== VENDO_APP_FORMAT) {
-    return fail("version", `format must be "${VENDO_APP_FORMAT}"`);
-  }
-
-  const parsed = appDocumentSchema.safeParse(input);
-  if (!parsed.success) {
-    return fail("validation", parsed.error.issues[0]?.message ?? "invalid app document");
-  }
-  const app = parsed.data;
-  if (app.name.length === 0) {
-    return fail("validation", "name must be non-empty");
-  }
-
-  const fnReferences: string[] = [];
+/** The tree/components pair, and the fn: references the tree names. Null when
+ *  the pair checks out. */
+const treeAndComponentsError = (app: AppDocument, fnReferences: string[]): AppDocumentValidation | null => {
   if (app.tree?.formatVersion === VENDO_TREE_FORMAT) {
     // No grafting: trees never carry components (validateTree rejects a
     // tree-level `components` member itself), so the tree validates AS-IS and
@@ -370,10 +355,13 @@ const validateAppDocumentUnsafe = (input: unknown): AppDocumentValidation => {
       return fail("validation", componentError);
     }
   }
+  return null;
+};
 
-  // W4b — a stamped island tool manifest must name a real island and real
-  // (grammar-valid) registry tool names; the runtime trusts this map as the
-  // island's entire tool surface.
+/** W4b — a stamped island tool manifest must name a real island and real
+ *  (grammar-valid) registry tool names; the runtime trusts this map as the
+ *  island's entire tool surface. */
+const componentToolsError = (app: AppDocument): AppDocumentValidation | null => {
   for (const [componentName, manifest] of Object.entries(app.componentTools ?? {})) {
     if (!Object.prototype.hasOwnProperty.call(app.components ?? {}, componentName)) {
       return fail("validation", `componentTools names "${componentName}" which has no components entry`);
@@ -384,10 +372,14 @@ const validateAppDocumentUnsafe = (input: unknown): AppDocumentValidation => {
       }
     }
   }
+  return null;
+};
 
-  // A trigger id is what everything per-trigger is keyed by (grants, sponsorship,
-  // schedule cursors, runs), so two triggers sharing one would silently share all
-  // of it. The grammar is the schema's; uniqueness is cross-field and lives here.
+/** A trigger id is what everything per-trigger is keyed by (grants, sponsorship,
+ *  schedule cursors, runs), so two triggers sharing one would silently share all
+ *  of it. The grammar is the schema's; uniqueness is cross-field and lives here.
+ *  Also collects the fn: references the triggers' steps name. */
+const triggersError = (app: AppDocument, fnReferences: string[]): AppDocumentValidation | null => {
   const triggerIds = new Set<string>();
   for (const trigger of app.triggers ?? []) {
     if (triggerIds.has(trigger.id)) {
@@ -404,6 +396,10 @@ const validateAppDocumentUnsafe = (input: unknown): AppDocumentValidation => {
       }
     }
   }
+  return null;
+};
+
+const fnReferencesError = (app: AppDocument, fnReferences: readonly string[]): AppDocumentValidation | null => {
   for (const reference of fnReferences) {
     if (!FN_REFERENCE_PATTERN.test(reference)) {
       return fail("validation", `invalid fn: reference "${reference}"`);
@@ -415,11 +411,14 @@ const validateAppDocumentUnsafe = (input: unknown): AppDocumentValidation => {
   if (fnReferences.length > 0 && app.server === undefined && app.machine === undefined) {
     return fail("validation", "fn: references require a machine (or legacy app server)");
   }
+  return null;
+};
 
-  // Contract §3.2 — a source key is a POSIX-relative path inside the app
-  // directory. Checked HERE because a checkout writes each key to disk: `../` or
-  // a leading slash would put one app's checkout in another app's files, and the
-  // document validator is the gate every stored document passes.
+/** Contract §3.2 — a source key is a POSIX-relative path inside the app
+ *  directory. Checked HERE because a checkout writes each key to disk: `../` or
+ *  a leading slash would put one app's checkout in another app's files, and the
+ *  document validator is the gate every stored document passes. */
+const sourceError = (app: AppDocument): AppDocumentValidation | null => {
   for (const [path, file] of Object.entries(app.source ?? {})) {
     if (path.length === 0 || path.startsWith("/")) {
       return fail("validation", `source path "${path}" must be relative to the app directory`);
@@ -431,7 +430,10 @@ const validateAppDocumentUnsafe = (input: unknown): AppDocumentValidation => {
       return fail("validation", `source file "${path}" must carry exactly one of text or blobRef`);
     }
   }
+  return null;
+};
 
+const storageError = (app: AppDocument): AppDocumentValidation | null => {
   for (const [name, declaration] of Object.entries(app.storage ?? {})) {
     if (name === "state") {
       return fail("validation", 'storage collection "state" is reserved');
@@ -445,7 +447,12 @@ const validateAppDocumentUnsafe = (input: unknown): AppDocumentValidation => {
       }
     }
   }
+  return null;
+};
 
+/** The reference-shaped fields: the box the app runs on, its fork provenance,
+ *  and its slot placements. */
+const referenceFieldsError = (app: AppDocument): AppDocumentValidation | null => {
   if (app.server !== undefined && !SERVER_REFERENCE_PATTERN.test(app.server)) {
     return fail("validation", `invalid server reference "${app.server}"`);
   }
@@ -465,6 +472,38 @@ const validateAppDocumentUnsafe = (input: unknown): AppDocumentValidation => {
       return fail("validation", "placement slot must be non-empty");
     }
   }
+  return null;
+};
+
+const validateAppDocumentUnsafe = (input: unknown): AppDocumentValidation => {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    return fail("validation", "app document must be a non-null object");
+  }
+  if ((input as Record<string, unknown>).format !== VENDO_APP_FORMAT) {
+    return fail("version", `format must be "${VENDO_APP_FORMAT}"`);
+  }
+
+  const parsed = appDocumentSchema.safeParse(input);
+  if (!parsed.success) {
+    return fail("validation", parsed.error.issues[0]?.message ?? "invalid app document");
+  }
+  const app = parsed.data;
+  if (app.name.length === 0) {
+    return fail("validation", "name must be non-empty");
+  }
+
+  // The cross-field rules, in the order their messages are pinned to: each
+  // returns the failure it found, or null. `fnReferences` accumulates across
+  // the tree and trigger rules and is checked once both have filled it.
+  const fnReferences: string[] = [];
+  const violation = treeAndComponentsError(app, fnReferences)
+    ?? componentToolsError(app)
+    ?? triggersError(app, fnReferences)
+    ?? fnReferencesError(app, fnReferences)
+    ?? sourceError(app)
+    ?? storageError(app)
+    ?? referenceFieldsError(app);
+  if (violation !== null) return violation;
 
   return { ok: true, app };
 };

--- a/packages/core/src/genui/tree.ts
+++ b/packages/core/src/genui/tree.ts
@@ -69,6 +69,100 @@ const fail = (code: "version" | "provision", message: string): TreeValidation =>
   error: { code, message },
 });
 
+/** The `queries` block: an array within the cap, each entry a well-formed
+ *  declaration with a unique, non-reserved identifier name. */
+const queriesError = (queries: unknown): TreeValidation | null => {
+  if (!Array.isArray(queries)) {
+    return fail("provision", "queries must be an array");
+  }
+  if (queries.length > TREE_MAX_QUERIES) {
+    return fail("provision", `too many queries (max ${TREE_MAX_QUERIES})`);
+  }
+  const queryNames = new Set<string>();
+  for (const query of queries) {
+    if (!isPlainObject(query)) {
+      return fail("provision", "each query must be an object");
+    }
+    if (typeof query.name !== "string" || !QUERY_NAME_PATTERN.test(query.name)) {
+      return fail("provision", "query name must match /^[A-Za-z_][A-Za-z0-9_]*$/");
+    }
+    if (query.name === "state") {
+      return fail("provision", 'query name "state" is reserved');
+    }
+    if (queryNames.has(query.name)) {
+      return fail("provision", `duplicate query name "${query.name}"`);
+    }
+    queryNames.add(query.name);
+    if (typeof query.tool !== "string" || query.tool.length === 0) {
+      return fail("provision", "query tool must be a non-empty string");
+    }
+    if (query.tool.startsWith("fn:") && !FN_REFERENCE_PATTERN.test(query.tool)) {
+      return fail("provision", `query tool "${query.tool}" is not a valid fn: reference`);
+    }
+    if (query.input !== undefined && !isPlainObject(query.input)) {
+      return fail("provision", "query input must be a plain object");
+    }
+  }
+  return null;
+};
+
+/** One node's own shape and prop grammar — everything checkable without
+ *  looking at the rest of the tree. */
+const nodeError = (node: unknown): TreeValidation | null => {
+  if (!isPlainObject(node)) {
+    return fail("provision", "each node must be an object");
+  }
+  if (typeof node.id !== "string" || node.id.length === 0) {
+    return fail("provision", "each node must have a non-empty string id");
+  }
+  if (typeof node.component !== "string") {
+    return fail("provision", `node "${node.id}" must have a string component`);
+  }
+  if (node.source !== undefined && !["prewired", "host", "generated"].includes(node.source as string)) {
+    return fail("provision", `node "${node.id}" has an invalid source`);
+  }
+  if (node.children !== undefined
+    && (!Array.isArray(node.children) || !node.children.every((child) => typeof child === "string"))) {
+    return fail("provision", `node "${node.id}" children must be an array of strings`);
+  }
+  if (node.props !== undefined && !isPlainObject(node.props)) {
+    return fail("provision", `node "${node.id}" props must be a plain object`);
+  }
+  if (node.props !== undefined) {
+    // Same rule as v1 CORE-5 (01 §8): fn: grammar holds ANYWHERE a tree
+    // names a callable — action names in props included. Machine-presence
+    // and generated-component presence are enforced one level up by the
+    // app-document validator, which knows `server` and `components`.
+    const invalidAction = findInvalidActionReference(node.props);
+    if (invalidAction !== null) {
+      return fail("provision", `node "${node.id}" action "${invalidAction}" is not a valid fn: reference`);
+    }
+    // v2 spec §3 — the bounded reshape vocabulary is enforced here at the
+    // format gate (same walk discipline as the fn: action rule above), so
+    // an unknown op or malformed chain can never reach the renderer.
+    const invalidReshape = findInvalidReshape(node.props);
+    if (invalidReshape !== null) {
+      return fail("provision", `node "${node.id}" has an invalid $reshape: ${invalidReshape}`);
+    }
+  }
+  return null;
+};
+
+/** Every node, plus the cross-node id uniqueness rule. Fills `ids` so the
+ *  caller can check the root against it. */
+const nodesError = (nodes: readonly unknown[], ids: Set<string>): TreeValidation | null => {
+  for (const node of nodes) {
+    const violation = nodeError(node);
+    if (violation !== null) return violation;
+    const { id } = node as { id: string };
+    if (ids.has(id)) {
+      return fail("provision", `duplicate node id "${id}"`);
+    }
+    ids.add(id);
+  }
+  return null;
+};
+
 const validateTreeUnsafe = (input: unknown): TreeValidation => {
   if (!isPlainObject(input)) {
     return fail("provision", "tree must be a non-null object");
@@ -95,82 +189,13 @@ const validateTreeUnsafe = (input: unknown): TreeValidation => {
   }
 
   if (input.queries !== undefined) {
-    if (!Array.isArray(input.queries)) {
-      return fail("provision", "queries must be an array");
-    }
-    if (input.queries.length > TREE_MAX_QUERIES) {
-      return fail("provision", `too many queries (max ${TREE_MAX_QUERIES})`);
-    }
-    const queryNames = new Set<string>();
-    for (const query of input.queries) {
-      if (!isPlainObject(query)) {
-        return fail("provision", "each query must be an object");
-      }
-      if (typeof query.name !== "string" || !QUERY_NAME_PATTERN.test(query.name)) {
-        return fail("provision", "query name must match /^[A-Za-z_][A-Za-z0-9_]*$/");
-      }
-      if (query.name === "state") {
-        return fail("provision", 'query name "state" is reserved');
-      }
-      if (queryNames.has(query.name)) {
-        return fail("provision", `duplicate query name "${query.name}"`);
-      }
-      queryNames.add(query.name);
-      if (typeof query.tool !== "string" || query.tool.length === 0) {
-        return fail("provision", "query tool must be a non-empty string");
-      }
-      if (query.tool.startsWith("fn:") && !FN_REFERENCE_PATTERN.test(query.tool)) {
-        return fail("provision", `query tool "${query.tool}" is not a valid fn: reference`);
-      }
-      if (query.input !== undefined && !isPlainObject(query.input)) {
-        return fail("provision", "query input must be a plain object");
-      }
-    }
+    const violation = queriesError(input.queries);
+    if (violation !== null) return violation;
   }
 
   const ids = new Set<string>();
-  for (const node of nodes) {
-    if (!isPlainObject(node)) {
-      return fail("provision", "each node must be an object");
-    }
-    if (typeof node.id !== "string" || node.id.length === 0) {
-      return fail("provision", "each node must have a non-empty string id");
-    }
-    if (typeof node.component !== "string") {
-      return fail("provision", `node "${node.id}" must have a string component`);
-    }
-    if (node.source !== undefined && !["prewired", "host", "generated"].includes(node.source as string)) {
-      return fail("provision", `node "${node.id}" has an invalid source`);
-    }
-    if (node.children !== undefined
-      && (!Array.isArray(node.children) || !node.children.every((child) => typeof child === "string"))) {
-      return fail("provision", `node "${node.id}" children must be an array of strings`);
-    }
-    if (node.props !== undefined && !isPlainObject(node.props)) {
-      return fail("provision", `node "${node.id}" props must be a plain object`);
-    }
-    if (node.props !== undefined) {
-      // Same rule as v1 CORE-5 (01 §8): fn: grammar holds ANYWHERE a tree
-      // names a callable — action names in props included. Machine-presence
-      // and generated-component presence are enforced one level up by the
-      // app-document validator, which knows `server` and `components`.
-      const invalidAction = findInvalidActionReference(node.props);
-      if (invalidAction !== null) {
-        return fail("provision", `node "${node.id}" action "${invalidAction}" is not a valid fn: reference`);
-      }
-      // v2 spec §3 — the bounded reshape vocabulary is enforced here at the
-      // format gate (same walk discipline as the fn: action rule above), so
-      // an unknown op or malformed chain can never reach the renderer.
-      const invalidReshape = findInvalidReshape(node.props);
-      if (invalidReshape !== null) {
-        return fail("provision", `node "${node.id}" has an invalid $reshape: ${invalidReshape}`);
-      }
-    }
-    if (ids.has(node.id)) {
-      return fail("provision", `duplicate node id "${node.id}"`);
-    }
-    ids.add(node.id);
-  }
+  const violation = nodesError(nodes, ids);
+  if (violation !== null) return violation;
 
   if (!ids.has(root)) {
     return fail("provision", `root "${root}" does not match any node id`);

--- a/packages/core/src/genui/wire/attributes.ts
+++ b/packages/core/src/genui/wire/attributes.ts
@@ -98,6 +98,70 @@ const compileActionValue = (state: CompileState, name: string, value: string): J
   return DROPPED;
 };
 
+/** The `=`-value forms of D3, with the cursor sitting on the `=`. Bare
+ *  attributes never reach here — the caller keeps that form. */
+const parseAttributeValue = (
+  state: CompileState,
+  element: AttributeElement,
+  name: string,
+): Json | Dropped | Failed => {
+  state.index += 1;
+  skipWhitespace(state);
+  const opener = state.source[state.index];
+  if (opener === '"') {
+    const parsed = parseMarkupString(state, name);
+    if (parsed === FAILED) return FAILED;
+    if (typeof parsed === "string" && element === "component" && ACTION_ATTR_PATTERN.test(name)) {
+      return compileActionValue(state, name, parsed);
+    }
+    return parsed;
+  }
+  if (opener === "{") {
+    const parsed = parseExpressionAttribute(state);
+    if (parsed === FAILED) return FAILED;
+    // D6 always-validates: validateTree walks node props for the fn:
+    // action grammar (same walk, ../fn-references.js), so an expression
+    // value smuggling { action: "fn:9bad" } anywhere would un-validate
+    // the tree. Drop the attribute here instead — only component props
+    // land in tree nodes, so only "component" needs the walk.
+    if (element === "component" && parsed !== DROPPED) {
+      const invalidAction = findInvalidActionReference(parsed);
+      if (invalidAction !== null) {
+        issue(
+          state,
+          "invalid-action",
+          `attribute "${name}" contains action "${invalidAction}", not a valid fn: reference; the attribute was dropped`,
+        );
+        return DROPPED;
+      }
+    }
+    return parsed;
+  }
+  if (opener === "'") {
+    issue(
+      state,
+      "malformed-attribute",
+      `attribute "${name}" uses a single-quoted string (markup strings are double-quoted); the attribute was dropped`,
+    );
+    if (skipQuotedRun(state, "'") === FAILED) return FAILED;
+    return DROPPED;
+  }
+  issue(state, "malformed-attribute", `attribute "${name}" has no value after "="; the attribute was dropped`);
+  return DROPPED;
+};
+
+/** Reported AFTER the drop, because the outcome is what a retry acts on:
+ *  saying the last one won when it was dropped sends the model back to
+ *  re-write a value that never landed, and saying an earlier one stands
+ *  when every value was dropped points it at a prop that is not there.
+ *  props is the record of what actually landed; seen is only occurrence. */
+const duplicateMessage = (name: string, value: Json | Dropped, props: Record<string, Json>): string => {
+  if (value !== DROPPED) return `duplicate attribute "${name}" (the last one wins)`;
+  return Object.prototype.hasOwnProperty.call(props, name)
+    ? `duplicate attribute "${name}" (the last one was dropped, so the earlier one stands)`
+    : `duplicate attribute "${name}" (every value was dropped, so the attribute is missing)`;
+};
+
 export interface ParsedAttributes {
   props?: Record<string, Json>;
   selfClosing: boolean;
@@ -140,48 +204,9 @@ export const parseAttributes = (state: CompileState, element: AttributeElement):
     skipWhitespace(state);
     let value: Json | Dropped = true; // bare attribute form
     if (state.source[state.index] === "=") {
-      state.index += 1;
-      skipWhitespace(state);
-      const opener = state.source[state.index];
-      if (opener === '"') {
-        const parsed = parseMarkupString(state, name);
-        if (parsed === FAILED) return FAILED;
-        value = parsed;
-        if (typeof value === "string" && element === "component" && ACTION_ATTR_PATTERN.test(name)) {
-          value = compileActionValue(state, name, value);
-        }
-      } else if (opener === "{") {
-        const parsed = parseExpressionAttribute(state);
-        if (parsed === FAILED) return FAILED;
-        value = parsed;
-        // D6 always-validates: validateTree walks node props for the fn:
-        // action grammar (same walk, ../fn-references.js), so an expression
-        // value smuggling { action: "fn:9bad" } anywhere would un-validate
-        // the tree. Drop the attribute here instead — only component props
-        // land in tree nodes, so only "component" needs the walk.
-        if (element === "component" && value !== DROPPED) {
-          const invalidAction = findInvalidActionReference(value);
-          if (invalidAction !== null) {
-            issue(
-              state,
-              "invalid-action",
-              `attribute "${name}" contains action "${invalidAction}", not a valid fn: reference; the attribute was dropped`,
-            );
-            value = DROPPED;
-          }
-        }
-      } else if (opener === "'") {
-        issue(
-          state,
-          "malformed-attribute",
-          `attribute "${name}" uses a single-quoted string (markup strings are double-quoted); the attribute was dropped`,
-        );
-        if (skipQuotedRun(state, "'") === FAILED) return FAILED;
-        value = DROPPED;
-      } else {
-        issue(state, "malformed-attribute", `attribute "${name}" has no value after "="; the attribute was dropped`);
-        value = DROPPED;
-      }
+      const parsed = parseAttributeValue(state, element, name);
+      if (parsed === FAILED) return FAILED;
+      value = parsed;
     } else {
       state.index = beforeValue;
     }
@@ -190,21 +215,8 @@ export const parseAttributes = (state: CompileState, element: AttributeElement):
       seen.add(name);
       continue;
     }
-    // Reported AFTER the drop, because the outcome is what a retry acts on:
-    // saying the last one won when it was dropped sends the model back to
-    // re-write a value that never landed, and saying an earlier one stands
-    // when every value was dropped points it at a prop that is not there.
-    // props is the record of what actually landed; seen is only occurrence.
     if (seen.has(name)) {
-      issue(
-        state,
-        "duplicate-attribute",
-        value !== DROPPED
-          ? `duplicate attribute "${name}" (the last one wins)`
-          : Object.prototype.hasOwnProperty.call(props, name)
-            ? `duplicate attribute "${name}" (the last one was dropped, so the earlier one stands)`
-            : `duplicate attribute "${name}" (every value was dropped, so the attribute is missing)`,
-      );
+      issue(state, "duplicate-attribute", duplicateMessage(name, value, props));
     }
     seen.add(name);
     if (value === DROPPED) continue;

--- a/packages/core/src/genui/wire/compile.ts
+++ b/packages/core/src/genui/wire/compile.ts
@@ -426,6 +426,33 @@ const opensApp = (state: CompileState): boolean => opensRoot(state, "App");
  * issue happen in the main pass, in source order (this pass runs on a
  * throwaway state whose issues are discarded).
  */
+/** Pre-scan `<Query>`: records a grammar-valid id and steps the cursor past
+ *  the element. False stops the scan (the tag was truncated). */
+const prescanQuery = (state: CompileState, queryNames: Set<string>): boolean => {
+  const attrs = parseAttributes(state, "declaration");
+  if (attrs === FAILED) return false;
+  const id = attrs.props?.id;
+  if (typeof id === "string" && QUERY_NAME_PATTERN.test(id) && id !== "state") queryNames.add(id);
+  if (!attrs.selfClosing) skipElement(state, "Query");
+  return true;
+};
+
+/** Pre-scan `<Island>`: records a grammar-valid, non-reserved name and steps
+ *  the cursor past the raw content. False stops the scan. */
+const prescanIsland = (state: CompileState, islandNames: Set<string>): boolean => {
+  const attrs = parseAttributes(state, "declaration");
+  if (attrs === FAILED) return false;
+  if (attrs.selfClosing) return true; // no content — the main pass skips it
+  const close = state.source.indexOf(ISLAND_CLOSE, state.index);
+  if (close === -1) return false; // unterminated — the main pass drops it
+  state.index = close + ISLAND_CLOSE.length;
+  const islandName = attrs.props?.name;
+  if (typeof islandName === "string" && PASCAL_TAG_PATTERN.test(islandName) && !KIT_NAMES.has(islandName)) {
+    islandNames.add(islandName);
+  }
+  return true;
+};
+
 export const prescanDeclarations = (wire: string, rootTag = "App"): { queryNames: Set<string>; islandNames: Set<string> } => {
   const queryNames = new Set<string>();
   const islandNames = new Set<string>();
@@ -455,24 +482,11 @@ export const prescanDeclarations = (wire: string, rootTag = "App"): { queryNames
     state.index += 1;
     const name = readName(state);
     if (name === "Query") {
-      const attrs = parseAttributes(state, "declaration");
-      if (attrs === FAILED) break;
-      const id = attrs.props?.id;
-      if (typeof id === "string" && QUERY_NAME_PATTERN.test(id) && id !== "state") queryNames.add(id);
-      if (!attrs.selfClosing) skipElement(state, "Query");
+      if (!prescanQuery(state, queryNames)) break;
       continue;
     }
     if (name === "Island") {
-      const attrs = parseAttributes(state, "declaration");
-      if (attrs === FAILED) break;
-      if (attrs.selfClosing) continue; // no content — the main pass skips it
-      const close = state.source.indexOf(ISLAND_CLOSE, state.index);
-      if (close === -1) break; // unterminated — the main pass drops it
-      state.index = close + ISLAND_CLOSE.length;
-      const islandName = attrs.props?.name;
-      if (typeof islandName === "string" && PASCAL_TAG_PATTERN.test(islandName) && !KIT_NAMES.has(islandName)) {
-        islandNames.add(islandName);
-      }
+      if (!prescanIsland(state, islandNames)) break;
       continue;
     }
     if (name === "App" || !PASCAL_TAG_PATTERN.test(name)) {

--- a/packages/core/src/reshape.ts
+++ b/packages/core/src/reshape.ts
@@ -288,143 +288,141 @@ const applyAggregate = (op: ReshapeOp, rows: readonly Record<string, unknown>[],
   return { ok: true, value: reduceNumeric(op as NumericReduction, values) };
 };
 
-const applyStep = (value: Json, step: ReshapeStep): ReshapeResult => {
-  const { op, args } = step;
-  if (op === "count") {
-    if (!Array.isArray(value)) return mismatch("count needs an array");
-    return { ok: true, value: value.length };
+const applyAsPoints = (value: Json, args: readonly string[]): ReshapeResult => {
+  const [labelField, valueField] = args as [string, string];
+  if (!isRowArray(value)) return mismatch("asPoints needs an array of rows");
+  // Strict per-row: a chart silently missing rows IS the broken-chart
+  // class, so any row lacking either axis field is a mismatch (an absent
+  // key signals mis-binding; sparse data carries explicit nulls, which
+  // still plot). pick/rename stay lenient — they are projections, not axes.
+  const missing = [labelField, valueField]
+    .filter((field) => value.some((row) => !Object.prototype.hasOwnProperty.call(row, field)));
+  if (missing.length > 0) {
+    return mismatch(`asPoints fields ${missing.map((field) => `"${field}"`).join(", ")} are absent from one or more rows`);
   }
-  if (AGGREGATE_OPS.has(op)) {
-    if (!isRowArray(value)) return mismatch(`aggregate "${op}" needs an array of rows`);
-    return applyAggregate(op, value, args[0] as string);
+  return { ok: true, value: value.map((row) => ({ label: row[labelField], value: row[valueField] })) };
+};
+
+const applyAsOptions = (value: Json, args: readonly string[]): ReshapeResult => {
+  const [valueField, labelField] = args as [string, string];
+  if (!isRowArray(value)) return mismatch("asOptions needs an array of rows");
+  // Strict per-row (mirrors asPoints): a Select silently missing an option's
+  // value or label IS the blank-option class, so any row lacking either
+  // field is a mismatch — an absent key signals mis-binding.
+  const missing = [valueField, labelField]
+    .filter((field) => value.some((row) => !Object.prototype.hasOwnProperty.call(row, field)));
+  if (missing.length > 0) {
+    return mismatch(`asOptions fields ${missing.map((field) => `"${field}"`).join(", ")} are absent from one or more rows`);
   }
-  if (op === "asPoints") {
-    const [labelField, valueField] = args as [string, string];
-    if (!isRowArray(value)) return mismatch("asPoints needs an array of rows");
-    // Strict per-row: a chart silently missing rows IS the broken-chart
-    // class, so any row lacking either axis field is a mismatch (an absent
-    // key signals mis-binding; sparse data carries explicit nulls, which
-    // still plot). pick/rename stay lenient — they are projections, not axes.
-    const missing = [labelField, valueField]
-      .filter((field) => value.some((row) => !Object.prototype.hasOwnProperty.call(row, field)));
-    if (missing.length > 0) {
-      return mismatch(`asPoints fields ${missing.map((field) => `"${field}"`).join(", ")} are absent from one or more rows`);
-    }
-    return { ok: true, value: value.map((row) => ({ label: row[labelField], value: row[valueField] })) };
+  return { ok: true, value: value.map((row) => ({ value: row[valueField], label: row[labelField] })) };
+};
+
+const resolveTemplatePath = (row: Record<string, unknown>, path: readonly string[]): unknown => {
+  let current: unknown = row;
+  for (const segment of path) {
+    if (!isPlainObject(current)) return undefined;
+    current = (current as Record<string, unknown>)[segment];
   }
-  if (op === "asOptions") {
-    const [valueField, labelField] = args as [string, string];
-    if (!isRowArray(value)) return mismatch("asOptions needs an array of rows");
-    // Strict per-row (mirrors asPoints): a Select silently missing an option's
-    // value or label IS the blank-option class, so any row lacking either
-    // field is a mismatch — an absent key signals mis-binding.
-    const missing = [valueField, labelField]
-      .filter((field) => value.some((row) => !Object.prototype.hasOwnProperty.call(row, field)));
-    if (missing.length > 0) {
-      return mismatch(`asOptions fields ${missing.map((field) => `"${field}"`).join(", ")} are absent from one or more rows`);
+  return current;
+};
+
+/** Interpolate one row/object; a placeholder resolving to an object or
+ *  array is the raw-braces class the op exists to prevent — a mismatch,
+ *  never a stringified object. */
+const renderTemplate = (pattern: string, row: Record<string, unknown>): { text: string } | { bad: string } => {
+  let bad: string | null = null;
+  const text = pattern.replace(TEMPLATE_PLACEHOLDER, (whole, raw: string) => {
+    const resolved = resolveTemplatePath(row, raw.split("."));
+    if (resolved === null || resolved === undefined) return "";
+    if (typeof resolved === "object") {
+      bad ??= whole;
+      return "";
     }
-    return { ok: true, value: value.map((row) => ({ value: row[valueField], label: row[labelField] })) };
+    return String(resolved);
+  });
+  return bad === null ? { text } : { bad };
+};
+
+const nonScalarTemplate = (bad: string): ReshapeResult =>
+  mismatch(`template placeholder ${bad} does not resolve to a scalar — reference a nested field (e.g. ${bad.slice(0, -1)}.name})`);
+
+const applyTemplate = (value: Json, args: readonly string[]): ReshapeResult => {
+  const pattern = args[args.length - 1] as string;
+  const paths = templatePaths(pattern) ?? [];
+  const roots = [...new Set(paths.map((path) => path[0] as string))];
+  const absentFrom = (record: Record<string, unknown>): string[] =>
+    roots.filter((root) => !Object.prototype.hasOwnProperty.call(record, root));
+  if (args.length === 1) {
+    if (!isPlainObject(value)) {
+      return mismatch("template(pattern) needs a bare object; over rows use template(field, pattern)");
+    }
+    const record = value as Record<string, unknown>;
+    const absent = absentFrom(record);
+    if (absent.length > 0) {
+      return mismatch(`template placeholders reference ${absent.map((root) => `"${root}"`).join(", ")}, absent`);
+    }
+    const rendered = renderTemplate(pattern, record);
+    return "bad" in rendered ? nonScalarTemplate(rendered.bad) : { ok: true, value: rendered.text };
   }
-  if (op === "template") {
-    const pattern = args[args.length - 1] as string;
-    const paths = templatePaths(pattern) ?? [];
-    const resolvePath = (row: Record<string, unknown>, path: readonly string[]): unknown => {
-      let current: unknown = row;
-      for (const segment of path) {
-        if (!isPlainObject(current)) return undefined;
-        current = (current as Record<string, unknown>)[segment];
-      }
-      return current;
-    };
-    /** Interpolate one row/object; a placeholder resolving to an object or
-     *  array is the raw-braces class the op exists to prevent — a mismatch,
-     *  never a stringified object. */
-    const render = (row: Record<string, unknown>): { text: string } | { bad: string } => {
-      let bad: string | null = null;
-      const text = pattern.replace(TEMPLATE_PLACEHOLDER, (whole, raw: string) => {
-        const resolved = resolvePath(row, raw.split("."));
-        if (resolved === null || resolved === undefined) return "";
-        if (typeof resolved === "object") {
-          bad ??= whole;
-          return "";
-        }
-        return String(resolved);
-      });
-      return bad === null ? { text } : { bad };
-    };
-    const nonScalar = (bad: string): ReshapeResult =>
-      mismatch(`template placeholder ${bad} does not resolve to a scalar — reference a nested field (e.g. ${bad.slice(0, -1)}.name})`);
-    const roots = [...new Set(paths.map((path) => path[0] as string))];
-    const absentFrom = (record: Record<string, unknown>): string[] =>
-      roots.filter((root) => !Object.prototype.hasOwnProperty.call(record, root));
-    if (args.length === 1) {
-      if (!isPlainObject(value)) {
-        return mismatch("template(pattern) needs a bare object; over rows use template(field, pattern)");
-      }
-      const record = value as Record<string, unknown>;
-      const absent = absentFrom(record);
-      if (absent.length > 0) {
-        return mismatch(`template placeholders reference ${absent.map((root) => `"${root}"`).join(", ")}, absent`);
-      }
-      const rendered = render(record);
-      return "bad" in rendered ? nonScalar(rendered.bad) : { ok: true, value: rendered.text };
+  const field = args[0] as string;
+  const templateRow = (row: Record<string, unknown>): ReshapeResult => {
+    const rendered = renderTemplate(pattern, row);
+    if ("bad" in rendered) return nonScalarTemplate(rendered.bad);
+    const next = { ...row };
+    defineOwn(next, field, rendered.text);
+    return { ok: true, value: next as Json };
+  };
+  if (isRowArray(value)) {
+    const absent = roots.filter((root) => !fieldPresent(value, root));
+    if (absent.length > 0) {
+      return mismatch(`template placeholders reference ${absent.map((root) => `"${root}"`).join(", ")}, absent from the rows`);
     }
-    const field = args[0] as string;
-    const templateRow = (row: Record<string, unknown>): ReshapeResult => {
-      const rendered = render(row);
-      if ("bad" in rendered) return nonScalar(rendered.bad);
-      const next = { ...row };
-      defineOwn(next, field, rendered.text);
-      return { ok: true, value: next as Json };
-    };
-    if (isRowArray(value)) {
-      const absent = roots.filter((root) => !fieldPresent(value, root));
-      if (absent.length > 0) {
-        return mismatch(`template placeholders reference ${absent.map((root) => `"${root}"`).join(", ")}, absent from the rows`);
-      }
-      const out: Json[] = [];
-      for (const row of value) {
-        const result = templateRow(row);
-        if (!result.ok) return result;
-        out.push(result.value as Json);
-      }
-      return { ok: true, value: out };
-    }
-    if (isPlainObject(value)) {
-      const record = value as Record<string, unknown>;
-      const absent = absentFrom(record);
-      if (absent.length > 0) {
-        return mismatch(`template placeholders reference ${absent.map((root) => `"${root}"`).join(", ")}, absent`);
-      }
-      return templateRow(record);
-    }
-    return mismatch("template needs an object or an array of rows");
-  }
-  if (op === "format") {
-    if (args.length === 1) {
-      const formatted = formatScalar(value, args[0] as FormatKind);
-      return formatted === null
-        ? mismatch(`format "${args[0]}" cannot format this value`)
-        : { ok: true, value: formatted };
-    }
-    const [field, kind] = args as [string, FormatKind];
-    if (!isRowArray(value)) return mismatch("per-field format needs an array of rows");
-    if (!fieldPresent(value, field)) return mismatch(`field "${field}" is absent from the rows`);
-    const rows: Json[] = [];
+    const out: Json[] = [];
     for (const row of value) {
-      if (!Object.prototype.hasOwnProperty.call(row, field)) {
-        rows.push(row);
-        continue;
-      }
-      const formatted = formatScalar(row[field], kind);
-      if (formatted === null) return mismatch(`format "${kind}" cannot format "${field}" values`);
-      const next = { ...row };
-      defineOwn(next, field, formatted);
-      rows.push(next);
+      const result = templateRow(row);
+      if (!result.ok) return result;
+      out.push(result.value as Json);
     }
-    return { ok: true, value: rows };
+    return { ok: true, value: out };
   }
-  // pick / rename — per-row on arrays, direct on objects.
+  if (isPlainObject(value)) {
+    const record = value as Record<string, unknown>;
+    const absent = absentFrom(record);
+    if (absent.length > 0) {
+      return mismatch(`template placeholders reference ${absent.map((root) => `"${root}"`).join(", ")}, absent`);
+    }
+    return templateRow(record);
+  }
+  return mismatch("template needs an object or an array of rows");
+};
+
+const applyFormat = (value: Json, args: readonly string[]): ReshapeResult => {
+  if (args.length === 1) {
+    const formatted = formatScalar(value, args[0] as FormatKind);
+    return formatted === null
+      ? mismatch(`format "${args[0]}" cannot format this value`)
+      : { ok: true, value: formatted };
+  }
+  const [field, kind] = args as [string, FormatKind];
+  if (!isRowArray(value)) return mismatch("per-field format needs an array of rows");
+  if (!fieldPresent(value, field)) return mismatch(`field "${field}" is absent from the rows`);
+  const rows: Json[] = [];
+  for (const row of value) {
+    if (!Object.prototype.hasOwnProperty.call(row, field)) {
+      rows.push(row);
+      continue;
+    }
+    const formatted = formatScalar(row[field], kind);
+    if (formatted === null) return mismatch(`format "${kind}" cannot format "${field}" values`);
+    const next = { ...row };
+    defineOwn(next, field, formatted);
+    rows.push(next);
+  }
+  return { ok: true, value: rows };
+};
+
+// pick / rename — per-row on arrays, direct on objects.
+const applyPickRename = (op: ReshapeOp, value: Json, args: readonly string[]): ReshapeResult => {
   const perRow = op === "pick"
     ? (row: Record<string, unknown>) => pickFields(row, args)
     : (row: Record<string, unknown>) => renameFields(row, args);
@@ -445,6 +443,23 @@ const applyStep = (value: Json, step: ReshapeStep): ReshapeResult => {
     return { ok: true, value: perRow(record) };
   }
   return mismatch(`${op} needs an object or an array of rows`);
+};
+
+const applyStep = (value: Json, step: ReshapeStep): ReshapeResult => {
+  const { op, args } = step;
+  if (op === "count") {
+    if (!Array.isArray(value)) return mismatch("count needs an array");
+    return { ok: true, value: value.length };
+  }
+  if (AGGREGATE_OPS.has(op)) {
+    if (!isRowArray(value)) return mismatch(`aggregate "${op}" needs an array of rows`);
+    return applyAggregate(op, value, args[0] as string);
+  }
+  if (op === "asPoints") return applyAsPoints(value, args);
+  if (op === "asOptions") return applyAsOptions(value, args);
+  if (op === "template") return applyTemplate(value, args);
+  if (op === "format") return applyFormat(value, args);
+  return applyPickRename(op, value, args);
 };
 
 /**
@@ -559,144 +574,121 @@ const checkedFields = (
 const objectShape = (fields: Record<string, ShapeType>, optional: readonly string[]): ShapeType =>
   optional.length > 0 ? { kind: "object", fields, optional: [...optional] } : { kind: "object", fields };
 
-/**
- * v2 spec §3 — flow a response shape through one reshape step (the wire
- * compiler's binding type-check). `json` regions stay defensive (no error);
- * a known-shape violation returns the typed error with missing/available
- * fields for the per-binding repair prompt.
- */
-export function reshapeShape(shape: ShapeType, step: ReshapeStep): ReshapeShapeResult {
-  const structural = invalidStep(step);
-  if (structural !== null) return shapeError(structural);
-  const { op, args } = step;
-
-  if (op === "count") {
-    if (shape.kind !== "json" && shape.kind !== "array") return shapeError("count needs an array");
-    return { ok: true, shape: NUMBER_SHAPE };
-  }
-
-  if (op === "format" && args.length === 1) {
-    const kind = args[0] as FormatKind;
-    const formattable = shape.kind === "json"
-      || (kind === "date" ? shape.kind === "string" || shape.kind === "number" : shape.kind === "number");
-    if (!formattable) return shapeError(`format "${kind}" cannot format a ${shape.kind} value`);
-    return { ok: true, shape: STRING_SHAPE };
-  }
-
-  if (op === "template") {
-    const paths = templatePaths(args[args.length - 1] as string) ?? [];
-    /** Walks each placeholder path through the row/object shape: an absent
-     *  root is the repair-carrying miss; an object/array leaf is the
-     *  raw-braces class caught at compile. `json` regions stay defensive. */
-    const placeholderMiss = (owner: ShapeType): ReshapeShapeResult | null => {
-      for (const path of paths) {
-        const at = shapeAtPointer(owner, `/${path.join("/")}`);
-        if (at === undefined) {
-          return shapeError(
-            `template placeholder "{${path.join(".")}}" is absent from the response shape`,
-            [path[0] as string],
-            owner.kind === "object" ? Object.keys(owner.fields) : undefined,
-          );
-        }
-        if (at.kind === "object" || at.kind === "array") {
-          return shapeError(`template placeholder "{${path.join(".")}}" is an ${at.kind}, not a scalar — reference a nested field (e.g. {${path.join(".")}.name})`);
-        }
-      }
-      return null;
-    };
-    if (args.length === 1) {
-      if (shape.kind === "json") return { ok: true, shape: STRING_SHAPE };
-      if (shape.kind !== "object") {
-        return shapeError(`template(pattern) needs a bare object; over rows use template(field, pattern); the response shape is ${shape.kind}`);
-      }
-      return placeholderMiss(shape) ?? { ok: true, shape: STRING_SHAPE };
-    }
-    const view = viewRows(shape, op);
-    if (view === null) return shapeError(`template needs an object or an array of rows; the response shape is ${shape.kind}`);
-    if (view.fields === null) return { ok: true, shape: view.rebuild(JSON_SHAPE) };
-    const violation = placeholderMiss(objectShape(view.fields, [...view.optional]));
-    if (violation !== null) return violation;
-    const target = args[0] as string;
-    const fields: Record<string, ShapeType> = {};
-    for (const [key, value] of Object.entries(view.fields)) {
-      defineOwn(fields, key, key === target ? STRING_SHAPE : value);
-    }
-    if (!Object.prototype.hasOwnProperty.call(fields, target)) {
-      defineOwn(fields, target, STRING_SHAPE);
-    }
-    // The target field is always written, so it leaves the optional set.
-    return { ok: true, shape: view.rebuild(objectShape(fields, [...view.optional].filter((key) => key !== target))) };
-  }
-
-  const view = viewRows(shape, op);
-  if (view === null) {
-    return shapeError(`${op} needs ${AGGREGATE_OPS.has(op) || op === "asPoints" || op === "asOptions" ? "an array of rows" : "an object or an array of rows"}; the response shape is ${shape.kind}`);
-  }
-
-  if (AGGREGATE_OPS.has(op)) {
-    const field = args[0] as string;
-    const violation = checkedFields(view, [field], op);
-    if (violation !== null) return violation;
-    if (view.fields !== null) {
-      const fieldShape = view.fields[field] as ShapeType;
-      if (fieldShape.kind !== "number" && fieldShape.kind !== "json") {
-        return shapeError(
-          `aggregate "${op}" needs numeric "${field}" values; the response shape has ${fieldShape.kind}`,
-          undefined,
-          Object.keys(view.fields),
-        );
-      }
-    }
-    return { ok: true, shape: NUMBER_SHAPE };
-  }
-
-  if (op === "asPoints") {
-    const [labelField, valueField] = args as [string, string];
-    const violation = checkedFields(view, [labelField, valueField], op);
-    if (violation !== null) return violation;
-    const labelShape = view.fields === null ? JSON_SHAPE : view.fields[labelField] as ShapeType;
-    const valueShape = view.fields === null ? JSON_SHAPE : view.fields[valueField] as ShapeType;
-    return {
-      ok: true,
-      shape: { kind: "array", items: { kind: "object", fields: { label: labelShape, value: valueShape } } },
-    };
-  }
-
-  if (op === "asOptions") {
-    const [valueField, labelField] = args as [string, string];
-    const violation = checkedFields(view, [valueField, labelField], op);
-    if (violation !== null) return violation;
-    const valueShape = view.fields === null ? JSON_SHAPE : view.fields[valueField] as ShapeType;
-    const labelShape = view.fields === null ? JSON_SHAPE : view.fields[labelField] as ShapeType;
-    return {
-      ok: true,
-      shape: { kind: "array", items: { kind: "object", fields: { value: valueShape, label: labelShape } } },
-    };
-  }
-
-  if (op === "format") {
-    const [field, kind] = args as [string, FormatKind];
-    const violation = checkedFields(view, [field], op);
-    if (violation !== null) return violation;
-    if (view.fields === null) return { ok: true, shape: view.rebuild(JSON_SHAPE) };
-    const fieldShape = view.fields[field] as ShapeType;
-    const formattable = fieldShape.kind === "json"
-      || (kind === "date" ? fieldShape.kind === "string" || fieldShape.kind === "number" : fieldShape.kind === "number");
-    if (!formattable) {
+/** Walks each placeholder path through the row/object shape: an absent
+ *  root is the repair-carrying miss; an object/array leaf is the
+ *  raw-braces class caught at compile. `json` regions stay defensive. */
+const placeholderMiss = (owner: ShapeType, paths: readonly string[][]): ReshapeShapeResult | null => {
+  for (const path of paths) {
+    const at = shapeAtPointer(owner, `/${path.join("/")}`);
+    if (at === undefined) {
       return shapeError(
-        `format "${kind}" cannot format "${field}" (${fieldShape.kind}) values`,
+        `template placeholder "{${path.join(".")}}" is absent from the response shape`,
+        [path[0] as string],
+        owner.kind === "object" ? Object.keys(owner.fields) : undefined,
+      );
+    }
+    if (at.kind === "object" || at.kind === "array") {
+      return shapeError(`template placeholder "{${path.join(".")}}" is an ${at.kind}, not a scalar — reference a nested field (e.g. {${path.join(".")}.name})`);
+    }
+  }
+  return null;
+};
+
+const templateShape = (shape: ShapeType, args: readonly string[]): ReshapeShapeResult => {
+  const paths = templatePaths(args[args.length - 1] as string) ?? [];
+  if (args.length === 1) {
+    if (shape.kind === "json") return { ok: true, shape: STRING_SHAPE };
+    if (shape.kind !== "object") {
+      return shapeError(`template(pattern) needs a bare object; over rows use template(field, pattern); the response shape is ${shape.kind}`);
+    }
+    return placeholderMiss(shape, paths) ?? { ok: true, shape: STRING_SHAPE };
+  }
+  const view = viewRows(shape, "template");
+  if (view === null) return shapeError(`template needs an object or an array of rows; the response shape is ${shape.kind}`);
+  if (view.fields === null) return { ok: true, shape: view.rebuild(JSON_SHAPE) };
+  const violation = placeholderMiss(objectShape(view.fields, [...view.optional]), paths);
+  if (violation !== null) return violation;
+  const target = args[0] as string;
+  const fields: Record<string, ShapeType> = {};
+  for (const [key, value] of Object.entries(view.fields)) {
+    defineOwn(fields, key, key === target ? STRING_SHAPE : value);
+  }
+  if (!Object.prototype.hasOwnProperty.call(fields, target)) {
+    defineOwn(fields, target, STRING_SHAPE);
+  }
+  // The target field is always written, so it leaves the optional set.
+  return { ok: true, shape: view.rebuild(objectShape(fields, [...view.optional].filter((key) => key !== target))) };
+};
+
+const aggregateShape = (view: RowsView, op: ReshapeOp, args: readonly string[]): ReshapeShapeResult => {
+  const field = args[0] as string;
+  const violation = checkedFields(view, [field], op);
+  if (violation !== null) return violation;
+  if (view.fields !== null) {
+    const fieldShape = view.fields[field] as ShapeType;
+    if (fieldShape.kind !== "number" && fieldShape.kind !== "json") {
+      return shapeError(
+        `aggregate "${op}" needs numeric "${field}" values; the response shape has ${fieldShape.kind}`,
         undefined,
         Object.keys(view.fields),
       );
     }
-    const fields: Record<string, ShapeType> = {};
-    for (const [key, value] of Object.entries(view.fields)) {
-      defineOwn(fields, key, key === field ? STRING_SHAPE : value);
-    }
-    return { ok: true, shape: view.rebuild(objectShape(fields, [...view.optional])) };
   }
+  return { ok: true, shape: NUMBER_SHAPE };
+};
 
-  // pick / rename
+const asPointsShape = (view: RowsView, args: readonly string[]): ReshapeShapeResult => {
+  const [labelField, valueField] = args as [string, string];
+  const violation = checkedFields(view, [labelField, valueField], "asPoints");
+  if (violation !== null) return violation;
+  const labelShape = view.fields === null ? JSON_SHAPE : view.fields[labelField] as ShapeType;
+  const valueShape = view.fields === null ? JSON_SHAPE : view.fields[valueField] as ShapeType;
+  return {
+    ok: true,
+    shape: { kind: "array", items: { kind: "object", fields: { label: labelShape, value: valueShape } } },
+  };
+};
+
+const asOptionsShape = (view: RowsView, args: readonly string[]): ReshapeShapeResult => {
+  const [valueField, labelField] = args as [string, string];
+  const violation = checkedFields(view, [valueField, labelField], "asOptions");
+  if (violation !== null) return violation;
+  const valueShape = view.fields === null ? JSON_SHAPE : view.fields[valueField] as ShapeType;
+  const labelShape = view.fields === null ? JSON_SHAPE : view.fields[labelField] as ShapeType;
+  return {
+    ok: true,
+    shape: { kind: "array", items: { kind: "object", fields: { value: valueShape, label: labelShape } } },
+  };
+};
+
+const formatFieldShape = (view: RowsView, args: readonly string[]): ReshapeShapeResult => {
+  const [field, kind] = args as [string, FormatKind];
+  const violation = checkedFields(view, [field], "format");
+  if (violation !== null) return violation;
+  if (view.fields === null) return { ok: true, shape: view.rebuild(JSON_SHAPE) };
+  const fieldShape = view.fields[field] as ShapeType;
+  const formattable = fieldShape.kind === "json"
+    || (kind === "date" ? fieldShape.kind === "string" || fieldShape.kind === "number" : fieldShape.kind === "number");
+  if (!formattable) {
+    return shapeError(
+      `format "${kind}" cannot format "${field}" (${fieldShape.kind}) values`,
+      undefined,
+      Object.keys(view.fields),
+    );
+  }
+  const fields: Record<string, ShapeType> = {};
+  for (const [key, value] of Object.entries(view.fields)) {
+    defineOwn(fields, key, key === field ? STRING_SHAPE : value);
+  }
+  return { ok: true, shape: view.rebuild(objectShape(fields, [...view.optional])) };
+};
+
+const pickRenameShape = (
+  view: RowsView,
+  shape: ShapeType,
+  op: ReshapeOp,
+  args: readonly string[],
+): ReshapeShapeResult => {
   const referenced = op === "pick" ? args : args.filter((_, index) => index % 2 === 0);
   const violation = checkedFields(view, referenced, op);
   if (violation !== null) return violation;
@@ -721,4 +713,43 @@ export function reshapeShape(shape: ShapeType, step: ReshapeStep): ReshapeShapeR
     if (view.optional.has(key)) optional.push(nextKey);
   }
   return { ok: true, shape: view.rebuild(objectShape(fields, optional)) };
+};
+
+/**
+ * v2 spec §3 — flow a response shape through one reshape step (the wire
+ * compiler's binding type-check). `json` regions stay defensive (no error);
+ * a known-shape violation returns the typed error with missing/available
+ * fields for the per-binding repair prompt.
+ */
+export function reshapeShape(shape: ShapeType, step: ReshapeStep): ReshapeShapeResult {
+  const structural = invalidStep(step);
+  if (structural !== null) return shapeError(structural);
+  const { op, args } = step;
+
+  if (op === "count") {
+    if (shape.kind !== "json" && shape.kind !== "array") return shapeError("count needs an array");
+    return { ok: true, shape: NUMBER_SHAPE };
+  }
+
+  if (op === "format" && args.length === 1) {
+    const kind = args[0] as FormatKind;
+    const formattable = shape.kind === "json"
+      || (kind === "date" ? shape.kind === "string" || shape.kind === "number" : shape.kind === "number");
+    if (!formattable) return shapeError(`format "${kind}" cannot format a ${shape.kind} value`);
+    return { ok: true, shape: STRING_SHAPE };
+  }
+
+  if (op === "template") return templateShape(shape, args);
+
+  const view = viewRows(shape, op);
+  if (view === null) {
+    return shapeError(`${op} needs ${AGGREGATE_OPS.has(op) || op === "asPoints" || op === "asOptions" ? "an array of rows" : "an object or an array of rows"}; the response shape is ${shape.kind}`);
+  }
+
+  if (AGGREGATE_OPS.has(op)) return aggregateShape(view, op, args);
+  if (op === "asPoints") return asPointsShape(view, args);
+  if (op === "asOptions") return asOptionsShape(view, args);
+  if (op === "format") return formatFieldShape(view, args);
+  // pick / rename
+  return pickRenameShape(view, shape, op, args);
 }


### PR DESCRIPTION
Pure refactor of `packages/core`'s six functions over the sonarjs
cognitive-complexity threshold of 50. Byte-identical behaviour: every message,
every order of checks, every return value unchanged. **No public surface
changed** — not one exported symbol, signature or type moved, and no test file
was touched.

Each of the six was a long if/else chain doing one cohesive thing per branch.
Each branch is now a named module-private helper and the entry point is the
dispatch. Nothing was split below the level of a real rule: no three-line
helpers, no ternary hoisting.

## Scores

| function | before | after |
|---|---|---|
| `reshape.ts` `reshapeShape` | 86 | **19** |
| `reshape.ts` `applyStep` | 81 | **10** |
| `app-document.ts` `validateAppDocumentUnsafe` | 71 | **12** |
| `genui/wire/attributes.ts` `parseAttributes` | 69 | **32** |
| `genui/tree.ts` `validateTreeUnsafe` | 65 | **13** |
| `genui/wire/compile.ts` `prescanDeclarations` | 54 | **37** |

Measured with `sonarjs/cognitive-complexity` over
`packages/core/**/*.{ts,tsx}`, threshold lowered to 0 to read exact scores.
`packages/core` now has **zero** functions at or above 50 (next highest:
`conformance/memory-store.ts` at 49, untouched and pre-existing).

## What moved where

- **`reshape.ts`** — `applyStep` and `reshapeShape` are both op dispatches, so
  the split is one function per reshape op: `applyAsPoints` / `applyAsOptions`
  / `applyTemplate` / `applyFormat` / `applyPickRename`, and `templateShape` /
  `aggregateShape` / `asPointsShape` / `asOptionsShape` / `formatFieldShape` /
  `pickRenameShape`. The template renderer (`resolveTemplatePath`,
  `renderTemplate`, `nonScalarTemplate`) and the placeholder-shape walk
  (`placeholderMiss`) were closures inside a branch and are now module-scope
  functions taking the state they used to close over.
- **`app-document.ts`** — one function per cross-field rule
  (`treeAndComponentsError`, `componentToolsError`, `triggersError`,
  `fnReferencesError`, `sourceError`, `storageError`, `referenceFieldsError`),
  chained with `??` in the exact order their messages are pinned to.
  `fnReferences` still accumulates across the tree and trigger rules and is
  checked once both have filled it — `??` short-circuits identically to the
  original early returns.
- **`genui/tree.ts`** — `queriesError` (the queries block) and `nodesError` /
  `nodeError` (the node walk, plus one node's own shape and prop grammar).
  `nodesError` fills the `ids` set the caller checks the root against.
- **`genui/wire/attributes.ts`** — `parseAttributeValue` (the four `=`-value
  forms of D3) and `duplicateMessage` (the three-way duplicate-attribute
  message) leave the loop body. Cursor movement is unchanged, which matters:
  the pre-scan and the main pass must move identically by construction.
- **`genui/wire/compile.ts`** — `prescanQuery` and `prescanIsland` return
  "keep scanning", which is what the `break`s in the loop meant.

Comments travel with the code they explain. Three inline `//` blocks became
`/** */` doc comments on the function they now describe — text unchanged, plus
one added sentence on `triggersError` noting it also fills `fnReferences`.

## Pure movement

**65.7%** of added lines appear verbatim among removed lines (337 / 513
non-empty added lines, whitespace-normalized). The remaining 176 lines are
*all* function signatures, closing braces, `return null;`, the dispatch call
sites, and the relocated doc comments — reviewed line by line, none is new
logic. The number is lower than the 93–97% the big three scored because these
functions are 60–160 lines, not 2,000: the fixed cost of a signature and a
brace per extracted helper is a far larger fraction of a small diff.

```
git diff origin/main...HEAD -M -C --numstat
5	0	.changeset/core-splits-its-six-longest-validators.md
67	28	packages/core/src/app-document.ts
98	73	packages/core/src/genui/tree.ts
68	56	packages/core/src/genui/wire/attributes.ts
29	15	packages/core/src/genui/wire/compile.ts
279	248	packages/core/src/reshape.ts
```

## Test files changed: 0

Not one, not even an import path. Every extracted helper is module-private;
the three functions with importers outside their file (`reshapeShape`,
`parseAttributes`, `prescanDeclarations`) keep byte-identical signatures.

## Nothing refused

All six are under the threshold. `parseAttributes` (32) and
`prescanDeclarations` (37) are the two highest and were left there
deliberately: both are single scanner loops over a character cursor, and every
remaining branch is a distinct token the cursor can be sitting on. Shredding
the loop body further would hide the cursor's state machine, not reveal it.

## vendo-web tandem: no-op

`packages/core` is the bottom of the layering, so every touched and every new
symbol was grepped across the `vendo-web` clone at `/home/ubuntu/repos/vendo-web`
(`*.ts`, `*.tsx`, `*.js`, `*.mjs`, excluding `node_modules`) — 35 names,
**zero hits**:

```
applyStep, reshapeShape, validateAppDocumentUnsafe, validateTreeUnsafe,
parseAttributes, prescanDeclarations, applyTemplate, templateShape,
placeholderMiss, nodesError, queriesError, parseAttributeValue,
duplicateMessage, prescanQuery, prescanIsland, resolveTemplatePath,
renderTemplate, nonScalarTemplate, applyPickRename, pickRenameShape,
aggregateShape, asPointsShape, asOptionsShape, formatFieldShape,
applyAsPoints, applyAsOptions, applyFormat, treeAndComponentsError,
componentToolsError, triggersError, fnReferencesError, sourceError,
storageError, referenceFieldsError, nodeError
  → 0 hits each
```

The same sweep across `packages/`, `examples/`, `corpus/` and `scripts/`
(including test dirs) found importers only for `reshapeShape`
(`genui/wire/shape-check.ts` + `reshape.test.ts`), `parseAttributes` and
`prescanDeclarations` (`genui/plan/compile.ts`) — all three unchanged in
signature. One name overlap worth noting and deliberately kept:
`packages/ui/src/kit/format.ts` exports its own `applyFormat`; core's is a new
module-private const in a different package, named for consistency with its
sibling `applyAsPoints` / `applyTemplate` / `applyPickRename` family.

## Gate

```
pnpm build --filter=@vendoai/core...
 Tasks:    1 successful, 1 total
  Time:    29.198s

packages/core: VITEST_MIN_FORKS=1 VITEST_MAX_FORKS=2 VITEST_MIN_THREADS=1 VITEST_MAX_THREADS=2 npx vitest run
 Test Files  60 passed (60)
      Tests  1098 passed (1098)
   Duration  61.92s

root pnpm typecheck
 Tasks:    42 successful, 42 total
  Time:    3m37.079s

root pnpm lint
 Tasks:    3 successful, 3 total
  Time:    33.571s
 (2 pre-existing warnings in examples/demo-bank, untouched by this PR)
```

No lint config touched: `package.json`, `eslint.report.config.mjs`,
`knip.json` and `turbo.json` are all unmodified — the throwaway measuring
config was deleted before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored six high-complexity validators in `@vendoai/core` into small, rule-focused helpers with byte-identical behavior and no public API changes. All checks, messages, and return values are preserved; no test files changed.

- **Refactors**
  - `reshape.ts`: split `applyStep`/`reshapeShape` into per-op helpers (`applyAsPoints`, `applyAsOptions`, `applyTemplate`, `applyFormat`, pick/rename); hoisted template path/renderer and placeholder walk.
  - `app-document.ts`: one function per cross-field rule chained with `??`; `fnReferences` accumulation preserved.
  - `genui/tree.ts`: extracted `queriesError`, `nodesError`/`nodeError`; root-id check preserved via filled `ids`.
  - `genui/wire/attributes.ts`: extracted `parseAttributeValue` and `duplicateMessage`; cursor movement unchanged.
  - `genui/wire/compile.ts`: extracted `prescanQuery` and `prescanIsland`; helpers return “keep scanning.”

<sup>Written for commit f14159311476096bca361f2cce64fde7b84b8fb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

