### PR TITLE
refactor(apps,guard): four dense functions become the shapes they describe

### DIFF
--- a/.changeset/the-guard-dispatch-is-its-own-method.md
+++ b/.changeset/the-guard-dispatch-is-its-own-method.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/guard": patch
+---
+
+`bind().execute` keeps the decisions and hands the dispatch to a `#runOnce` private method: the grant the call runs under, the effect key, the in-flight share and the receipt write all sit together now, and the door above them reads as the four things it decides. No public surface changed, no behaviour changed, and no test changed.

--- a/.changeset/the-make-tool-has-its-own-module.md
+++ b/.changeset/the-make-tool-has-its-own-module.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/apps": patch
+---
+
+Three of this block's densest functions are decompositions now. The agent-tool registry's `execute` is a dispatcher: `vendo_make` and its two routes moved to `make-tool.ts`, the three `vendo_apps_data_*` doors to `data-tools.ts`, and the argument checks both share to `tool-args.ts`. `validatePlan` hands its steps rules to a `stepsIssues` collector beside the `scheduleIssues` one it already had, and the Claude session loop reads its `query()` options and its assistant-message scan from two named siblings — siblings, not modules, because `dist/claude-turn.js` is copied verbatim into the box image and has no relative imports to give them. No public surface changed, no behaviour changed, and no test changed.

--- a/packages/apps/src/agent-tools.ts
+++ b/packages/apps/src/agent-tools.ts
@@ -3,26 +3,20 @@ import {
   VENDO_APPS_UNPIN_TOOL,
   VENDO_MAKE_TOOL,
   VENDO_TOOL_TITLES,
-  appIdSchema,
-  isUnattended,
-  VENDO_VIEW_STREAM,
   VendoError,
-  makeReceiptSchema,
-  vendoViewStreamId,
   type AppDocument,
   type AppId,
   type Json,
-  type MakeReceipt,
-  type RecordQuery,
   type RunContext,
   type ScreenAssembler,
   type ToolDescriptor,
   type ToolOutcome,
   type ToolRegistry,
-  type VendoViewStreamingToolCall,
 } from "@vendoai/core";
 import type { AppDataAccess } from "./app-data.js";
-import { NO_ASSEMBLER, NOTHING_RENDERABLE, NO_MACHINE } from "./build-messages.js";
+import { deleteAppData, listAppData, putAppData } from "./data-tools.js";
+import { runMakeTool } from "./make-tool.js";
+import { input, resolveAppRef } from "./tool-args.js";
 import type { AppsRuntime } from "./types.js";
 
 const DRAFT_2020_12 = "https://json-schema.org/draft/2020-12/schema";
@@ -211,78 +205,6 @@ export const agentToolDescriptors: ToolDescriptor[] = descriptors.map((descripto
   return title === undefined ? descriptor : { ...descriptor, title };
 });
 
-const input = (
-  value: Json,
-  required: string[],
-  optional: string[] = [],
-): Record<string, Json> => {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    throw new VendoError("validation", "tool input must be an object");
-  }
-  const record = value as Record<string, Json>;
-  const allowed = new Set([...required, ...optional]);
-  const unexpected = Object.keys(record).find((key) => !allowed.has(key));
-  if (unexpected !== undefined) throw new VendoError("validation", `unexpected input property: ${unexpected}`);
-  for (const key of required) {
-    if (typeof record[key] !== "string" || (record[key] as string).trim() === "") {
-      throw new VendoError("validation", `${key} must be a non-empty string`);
-    }
-  }
-  return record;
-};
-
-const optionalString = (value: Json | undefined, name: string): string | undefined => {
-  if (value === undefined) return undefined;
-  if (typeof value !== "string" || value.trim() === "") {
-    throw new VendoError("validation", `${name} must be a non-empty string`);
-  }
-  return value;
-};
-
-/**
- * Contract §3.1 — the caller's `context` appended to the request, clearly
- * delimited.
- *
- * It exists for outside agents whose conversation we cannot see: over MCP there is
- * no transcript for us to attach, so they pass whatever background helps. On OUR
- * doors the runtime's own transcript stays authoritative and this is supplemental
- * — which is why it is appended rather than merged, and fenced rather than run
- * together with the ask. Free text, never a messages array: every framework's
- * message format differs and a string is universal.
- */
-const withContext = (request: string, context: string | undefined): string =>
-  context === undefined ? request : `${request}\n\n<context>\n${context}\n</context>`;
-
-/** The tool's whole model-facing answer. Parsed, so the four-field law is enforced
- *  here rather than trusted — a document that leaked into `output` would fail. */
-const receipt = (value: MakeReceipt): ToolOutcome => ({
-  status: "ok",
-  output: makeReceiptSchema.parse(value) as unknown as Json,
-});
-
-const optionalRefs = (value: Json | undefined): Record<string, string> | undefined => {
-  if (value === undefined) return undefined;
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    throw new VendoError("validation", "refs must be an object");
-  }
-  const refs: Record<string, string> = {};
-  for (const [key, item] of Object.entries(value)) {
-    if (key === "" || typeof item !== "string" || item.trim() === "") {
-      throw new VendoError("validation", "refs must have non-empty string keys and values");
-    }
-    refs[key] = item;
-  }
-  return refs;
-};
-
-const optionalLimit = (value: Json | undefined): number | undefined => {
-  if (value === undefined) return undefined;
-  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 1) {
-    throw new VendoError("validation", "limit must be a positive integer");
-  }
-  return value;
-};
-
 export interface AgentToolsDataDependencies {
   data: AppDataAccess;
   requireOwned(appId: AppId, ctx: RunContext): Promise<AppDocument>;
@@ -321,79 +243,6 @@ export interface AgentToolsDataDependencies {
 const FORK_OFFER = "I can’t change the team’s copy of this app. Say so plainly, and offer them"
   + " their own copy instead — forking the app from its card gives them one I can change freely.";
 
-/**
- * The `app` slot as a person says it: an app id, or the app's NAME.
- *
- * A fresh thread holds no ids — "add a weekly one to the transactions app" is
- * the whole ask, and until now it died on the way in, because `app` took an id
- * and nothing in this registry lists or searches. The aim already has a slot;
- * this is that slot understanding the name the user actually said.
- *
- * Exact name first, then case-insensitively, over THIS caller's own apps (the
- * same owned ∪ granted list every other door reads). Two apps of one name is a
- * question, never a coin toss: the candidates come back in the refusal so the
- * model can ask which one. And a ref that matches no name is handed on
- * untouched, so "no such app" and "you may not change that one" stay the
- * runtime's own sentences.
- */
-const resolveAppRef = async (
-  runtime: AppsRuntime,
-  ref: string,
-  ctx: RunContext,
-): Promise<string> => {
-  // An id is an id (core's own shape). Nothing is listed for the common path.
-  if (appIdSchema.safeParse(ref).success) return ref;
-  const apps = await runtime.list(ctx);
-  const exact = apps.filter(({ name }) => name === ref);
-  const matches = exact.length > 0
-    ? exact
-    : apps.filter(({ name }) => name.toLowerCase() === ref.toLowerCase());
-  if (matches.length === 1) return (matches[0] as AppDocument).id;
-  if (matches.length > 1) {
-    throw new VendoError(
-      "validation",
-      `More than one app is called "${ref}": ${matches.map(({ name, id }) => `${name} (${id})`).join(", ")}.`
-      + " Ask which one they mean and pass that app's id.",
-    );
-  }
-  return ref;
-};
-
-/**
- * What to call an app that was never built — the one receipt with no document to
- * read a name off (`MakeReceipt.title` is required).
- *
- * The `<Plan>`'s own name first, because the person is already looking at that
- * plan's skeleton titled with this exact string, so the sentence and the card are
- * about the same thing. Otherwise the ask, collapsed and capped — the same answer
- * a failed build record's name field gets.
- */
-const nameForUnbuilt = (plan: string | undefined, ask: string): string => {
-  const named = plan === undefined ? null : /<Plan\b[^>]*\bname="([^"]+)"/.exec(plan);
-  const title = named?.[1]?.trim();
-  if (title !== undefined && title !== "") return title;
-  const collapsed = ask.replace(/\s+/g, " ").trim();
-  return collapsed === "" ? "Vendo app" : collapsed.slice(0, 60);
-};
-
-/**
- * What an ask that produced no screen says to the person.
- *
- * The seam used to answer this with a second engine, so the four ways assembly
- * can come back empty — unwired, threw, `unavailable`, or `assembled` with no
- * row — were all silently absorbed. They are now the answer: an unwired
- * assembler is a composition bug and a composition bug that quietly swaps
- * engines is a bug nobody fixes. The reason travels verbatim because every one
- * of these is authored (a `why`, a thrown message, or the two constants below)
- * and a person reading "I couldn't put that screen together" alone has nothing
- * to act on.
- */
-const unbuiltSay = (why: string): string =>
-  why.trim() === ""
-    ? "I couldn't put that screen together."
-    : `I couldn't put that screen together — ${why.trim()}`;
-
-
 const errorOutcome = (error: unknown): ToolOutcome => {
   if (error instanceof VendoError) {
     return {
@@ -421,218 +270,7 @@ export const createAgentTools = (
   async execute(call, ctx: RunContext): Promise<ToolOutcome> {
     try {
       if (call.tool === VENDO_MAKE_TOOL) {
-        const args = input(call.args, ["request"], ["app", "context", "slot"]);
-        const app = optionalString(args.app, "app");
-        const slot = optionalString(args.slot, "slot");
-        // The slot, and ONLY the slot, needs a person there: it claims a place
-        // on somebody's page and evicts whatever held it. Creation does not, so
-        // an unattended run still builds what it was asked for and simply takes
-        // no slot — this is the whole of that rule (ruled 2026-08-06; the
-        // guard's presence-only refusal covers the pin tools, never make).
-        // The refusal below still reads `slot`, because "you aimed a new app at
-        // a slot on an EDIT" is wrong however present the person is.
-        const claimed = isUnattended(ctx) ? undefined : slot;
-        const stream = (call as VendoViewStreamingToolCall)[VENDO_VIEW_STREAM];
-        const request = args.request as string;
-        const ask = withContext(request, optionalString(args.context, "context"));
-        /**
-         * The ask, onto the app's memory — the FRONT DOOR's job, because this is
-         * the one place that sees every request that touched an app whichever
-         * engine served it (assembly, the builder, the conductor fall-through,
-         * an edit).
-         *
-         * `request` and not `ask`: the memory holds what the PERSON said. The
-         * `<context>` fence is one calling agent's background for one call, and
-         * replaying it to every future editor as though the person had typed it
-         * is how a stale aside becomes a standing requirement.
-         *
-         * Best-effort, always. There is no arrangement of a lost memory write
-         * that is worse than failing a make the person can already see.
-         */
-        const remember = async (appId: string): Promise<void> => {
-          await runtime.remember({ appId, ask: request }, ctx).catch((error: unknown) => {
-            console.warn(`[vendo] the ask was not recorded on ${appId}: ${
-              error instanceof Error ? error.message : String(error)
-            }`);
-          });
-        };
-        if (app === undefined) {
-          // ── THE SEAM (blueprint §1 point 2) ─────────────────────────────────
-          // "No agent chooses 'quick screen' vs 'real build'. Every request
-          // starts in the cheap screen agent." The id is minted HERE, before the
-          // route, because both ends have to use the same one: an escalation
-          // leaves `plan.vendo` and its painted skeleton at this id, and a build
-          // that minted its own would strand that skeleton on a second stream as
-          // a card that builds forever.
-          //
-          // Only `assembled` WITH A ROW ends the call happily. The row is the
-          // check that makes that true instead of merely intended: `authored`
-          // upserts it iff the seam actually compiled and painted the document,
-          // so a screen agent that saved bytes nobody can render leaves no row.
-          //
-          // TWO answers now, and no third. `escalate` is a request for the
-          // builder (§4.5's receiving end, below); everything else is assembly
-          // coming back empty, and assembly coming back empty is the ANSWER —
-          // there is no second engine behind this seam to rescue it with.
-          const appId = `app_${globalThis.crypto.randomUUID()}` as AppId;
-          // B1 — the claim rides the MINT, not the landing, for BOTH engines.
-          // Claiming after assembly returned left the slot empty for the whole
-          // of a fast make, and left nothing at all behind a failed one, so the
-          // slot stayed empty and the person heard about the failure only in the
-          // conversation. The builder route has always claimed here (`create`'s
-          // own `slot`, which this door no longer needs to pass).
-          if (claimed !== undefined) await dependencies.claimSlot(appId, claimed, ctx);
-          /** The one exit for an ask no engine landed: the tombstone that turns
-           *  the claimed slot into the honest failure card, then the receipt
-           *  that says so — the record's reason is the sentence the person is
-           *  told, verbatim, because there is nothing else true to record. */
-          const failUnbuilt = async (title: string, say: string): Promise<ToolOutcome> => {
-            if (claimed !== undefined) await dependencies.markUnbuilt(appId, title, say, ctx);
-            return receipt({ id: appId, title, status: "failed", say });
-          };
-          let threw: string | undefined;
-          const routed = dependencies.screen === undefined
-            ? undefined
-            : await dependencies.screen.assemble({
-              appId,
-              request: ask,
-              ...(stream === undefined ? {} : {
-                onView: (part) => stream({ id: vendoViewStreamId(part.appId), part }),
-              }),
-            }, ctx).catch((error: unknown) => {
-              threw = error instanceof Error ? error.message : String(error);
-              console.warn(`[vendo] the screen agent could not serve ${appId} — ${threw}`);
-              return undefined;
-            });
-          if (routed?.kind === "assembled") {
-            const stored = await runtime.get(appId, ctx).catch(() => null);
-            if (stored !== null) {
-              await remember(appId);
-              // No claim here: the slot has held this id since the mint above,
-              // and the row already names it.
-              return receipt({
-                id: stored.id,
-                title: stored.name,
-                status: "ready",
-                say: `${stored.name} is on your screen.`,
-              });
-            }
-          }
-          // ── §4.5's RECEIVING END ────────────────────────────────────────────
-          // An escalation is the screen agent asking for the builder by name; it
-          // is not the seam failing. Two answers, and the deployment's own shape
-          // picks which:
-          //
-          //  - A sandbox is configured → the build runs. Same `create` a
-          //    server-needing ask has always taken, at the SAME app id, so the
-          //    plan's skeleton and the finished app share one stream and the
-          //    outline becomes the app. The escalated plan rides in as the
-          //    brief; the ask still travels verbatim.
-          //  - No sandbox → say so, rather than spending a full build's latency
-          //    to arrive at a worse version of the screen the person was already
-          //    shown. The skeleton is left as it is — the UI unmounts a
-          //    still-forming card once the turn is over
-          //    (`chrome/thread/parts.tsx`), so the last word is this receipt.
-          const escalated = routed?.kind === "escalate";
-          const plan = !escalated
-            ? undefined
-            : await dependencies.escalatedPlan?.(appId, ctx).catch(() => undefined);
-          if (!escalated) {
-            // Assembly produced no screen. Said plainly, at the id whose stream
-            // the person is looking at, instead of quietly restarting the ask in
-            // a different engine.
-            return await failUnbuilt(
-              nameForUnbuilt(undefined, ask),
-              unbuiltSay(
-                dependencies.screen === undefined ? NO_ASSEMBLER
-                  : threw ?? (routed?.kind === "unavailable" ? routed.why : NOTHING_RENDERABLE),
-              ),
-            );
-          }
-          if (!runtime.machine.available()) {
-            return await failUnbuilt(
-              // The name on the skeleton they are looking at, so the sentence and
-              // the card are about the same thing.
-              nameForUnbuilt(plan, ask),
-              NO_MACHINE,
-            );
-          }
-          let unsaved: string | undefined;
-          const created = await runtime.create({
-            appId,
-            prompt: ask,
-            ...(plan === undefined ? {} : { plan }),
-            // No `slot`: the claim went down at the mint above, which is the
-            // same instant `create` would have made it for an id of its own.
-            onUnsaved: (reason) => { unsaved = reason; },
-            ...(stream === undefined ? {} : {
-              onView: (part) => stream({ id: vendoViewStreamId(part.appId), part }),
-            }),
-          }, ctx);
-          // An unsaved create has no row to remember onto; `remember` says so
-          // and moves on, which is the same non-event every other failure is.
-          await remember(created.id);
-          // View-only (the store refused the write): the screen IS on the user's
-          // page, so this is a success with a caveat, not a failure. Reporting it
-          // as an error made the agent apologize for a rendered view and rebuild
-          // it twice more — three cards, one prompt (live 2026-07-27). The
-          // caveat rides `say`, which is the whole point of `say`: one true
-          // sentence, and nothing to react to.
-          return receipt({
-            id: created.id,
-            title: created.name,
-            status: "ready",
-            say: unsaved === undefined
-              ? `${created.name} is on your screen.`
-              : `${created.name} is on your screen, though I couldn't save it to your apps.`,
-          });
-        }
-        // `slot` says where a NEW app lands. On a change it would have to mean
-        // "and also move it", which evicts whatever holds that slot off the back
-        // of an edit nobody aimed there — so it is refused, by name, at the one
-        // tool that does the moving. Refused before the ref is resolved: the
-        // answer does not depend on which app was meant.
-        if (slot !== undefined) {
-          throw new VendoError(
-            "validation",
-            "`slot` says where a new app lands. To move an app that already exists, call vendo_apps_pin with that app and slot.",
-          );
-        }
-        const appId = await resolveAppRef(runtime, app, ctx);
-        const result = await runtime.edit(appId, ask, ctx);
-        // Recorded whether or not the change landed: the person DID ask this of
-        // this app, and the next editor reading "asked for X, then asked for X
-        // again, narrower" is reading the truth.
-        await remember(appId);
-        // Wave 9 — a ladder-authored automation raises its own card. Published
-        // HERE, by the side that knows, rather than duck-typed out of this tool's
-        // return value at the bridge: the receipt carries words only.
-        if (result.automation !== undefined && stream !== undefined) {
-          stream({
-            id: `vendo-automation-${result.app.id}`,
-            part: {
-              type: "data-vendo-automation",
-              appId: result.app.id,
-              name: result.app.name,
-              enabled: result.automation.enabled,
-              ...(result.automation.trigger === undefined ? {} : { trigger: result.automation.trigger }),
-              ...(result.app.description === undefined || result.app.description.length === 0
-                ? {}
-                : { description: result.app.description }),
-              ...((result.automation.pendingGrants ?? []).length === 0
-                ? {}
-                : { pendingGrants: result.automation.pendingGrants!.length }),
-            },
-          });
-        }
-        return receipt({
-          id: result.app.id,
-          title: result.app.name,
-          status: result.failure === undefined ? "ready" : "failed",
-          say: result.failure === undefined
-            ? `${result.app.name} is updated.`
-            : `I couldn't make that change to ${result.app.name}.`,
-        });
+        return await runMakeTool(runtime, dependencies, call, ctx);
       }
       if (call.tool === "vendo_apps_rebase_pin") {
         const args = input(call.args, ["appId", "slot"]);
@@ -668,42 +306,13 @@ export const createAgentTools = (
         return { status: "ok", output: { app: appId, slot } };
       }
       if (call.tool === "vendo_apps_data_list") {
-        const args = input(call.args, ["appId", "collection"], ["refs", "limit", "cursor"]);
-        const app = await dependencies.requireOwned(args.appId as string, ctx);
-        const refs = optionalRefs(args.refs);
-        const limit = optionalLimit(args.limit);
-        if (args.cursor !== undefined && (typeof args.cursor !== "string" || args.cursor.trim() === "")) {
-          throw new VendoError("validation", "cursor must be a non-empty string");
-        }
-        const query: RecordQuery = {
-          ...(refs === undefined ? {} : { refs }),
-          ...(limit === undefined ? {} : { limit }),
-          ...(args.cursor === undefined ? {} : { cursor: args.cursor as string }),
-        };
-        return {
-          status: "ok",
-          output: await dependencies.data.records(app, args.collection as string).list(query) as unknown as Json,
-        };
+        return await listAppData(dependencies, call, ctx);
       }
       if (call.tool === "vendo_apps_data_put") {
-        const args = input(call.args, ["appId", "collection", "id"], ["data", "refs"]);
-        if (!Object.prototype.hasOwnProperty.call(args, "data") || args.data === undefined) {
-          throw new VendoError("validation", "data is required");
-        }
-        const app = await dependencies.requireOwned(args.appId as string, ctx);
-        const refs = optionalRefs(args.refs);
-        const record = await dependencies.data.records(app, args.collection as string).put({
-          id: args.id as string,
-          data: args.data,
-          ...(refs === undefined ? {} : { refs }),
-        });
-        return { status: "ok", output: record as unknown as Json };
+        return await putAppData(dependencies, call, ctx);
       }
       if (call.tool === "vendo_apps_data_delete") {
-        const args = input(call.args, ["appId", "collection", "id"]);
-        const app = await dependencies.requireOwned(args.appId as string, ctx);
-        await dependencies.data.records(app, args.collection as string).delete(args.id as string);
-        return { status: "ok", output: { status: "ok" } };
+        return await deleteAppData(dependencies, call, ctx);
       }
       return { status: "error", error: { code: "not-found", message: `Unknown tool: ${call.tool}` } };
     } catch (error) {

--- a/packages/apps/src/automation-plan.ts
+++ b/packages/apps/src/automation-plan.ts
@@ -8,6 +8,7 @@ import {
   UNKNOWN_INPUT_SCHEMA_NOTE,
   UNKNOWN_OUTPUT_SHAPE_NOTE,
   type ShapeType,
+  type Step,
   type Trigger,
 } from "@vendoai/core";
 import type { LanguageModel } from "ai";
@@ -262,6 +263,69 @@ const scheduleIssues = (trigger: Omit<Trigger, "id">): string[] => {
   return issues;
 };
 
+/** Everything a `steps` run has to satisfy beyond the schema: referable step
+ *  ids, a tool universe the planner could actually see, §12's defence in depth
+ *  per step, and a published result that derives from live data and lands in the
+ *  collection the plan declared. */
+const stepsIssues = (
+  steps: readonly Step[],
+  input: AutomationPlanInput,
+  refused: ReadonlySet<string>,
+  resultsCollection: unknown,
+): string[] => {
+  const issues: string[] = [];
+  if (steps.length === 0) issues.push("steps must not be empty");
+  // The planning surface is the whole legal tool universe here: fn: refs
+  // are NOT accepted — the ladder only authors automations for machine-less
+  // apps this wave, and a machine-less app has no fn: to call.
+  const known = new Set(plannerTools(input.tools).map(({ name }) => name));
+  const seen = new Set<string>();
+  const priorIds = new Set<string>();
+  let publishesDeclaredCollection = false;
+  for (const step of steps) {
+    // Bare-identifier ids only: a hyphenated id referenced as
+    // steps.invoice-rows parses as SUBTRACTION in jsonata, so the reference
+    // silently evaluates to nothing at run time.
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(step.id) || seen.has(step.id)) {
+      issues.push(`step ids must be unique bare identifiers ([A-Za-z_][A-Za-z0-9_]*) — "${step.id}" is not`);
+    }
+    seen.add(step.id);
+    if (refused.has(step.tool)) {
+      issues.push(refusal(`step "${step.id}"`, step.tool));
+    } else if (!known.has(step.tool)) {
+      issues.push(`step "${step.id}" names unknown tool "${step.tool}"; the available tools are: ${[...known].join(", ") || "(none)"}`);
+    }
+    // Law 1 for automations: a published result must be BUILT from a PRIOR
+    // step's output (or the trigger event) — a hand-typed data payload is
+    // invented data on the board. Quoted jsonata string literals (BOTH legal
+    // quote forms) are stripped first so 'a steps guide' or "steps.rows"
+    // cannot smuggle past the check, and the referenced step id must be one
+    // that ran EARLIER (a bare "steps" token or a forward reference
+    // publishes nothing at run time).
+    if (step.tool === RESULTS_TOOL) {
+      const dataExpression = (step.args?.data ?? "").replace(/'[^']*'|"[^"]*"/g, "");
+      const referencedPrior = [...dataExpression.matchAll(/\bsteps\.([A-Za-z_][A-Za-z0-9_]*)/g)]
+        .some((match) => priorIds.has(match[1] as string));
+      if (!referencedPrior && !/\bevent\b/.test(dataExpression)) {
+        issues.push(`step "${step.id}" publishes hand-typed data — the "${RESULTS_TOOL}" data expression must derive from an EARLIER step's output (steps.<priorStepId>...) or the trigger event; add the read step that fetches the live data first`);
+      }
+      if (typeof resultsCollection === "string"
+        && step.args?.collection?.trim() === `'${resultsCollection}'`
+        && step.args?.appId?.trim() === `'${input.appId}'`) {
+        publishesDeclaredCollection = true;
+      }
+    }
+    priorIds.add(step.id);
+  }
+  // A declared results collection the run never writes leaves the rebound
+  // board permanently empty — require the publish step to target exactly
+  // this app and that collection (literal jsonata strings).
+  if (typeof resultsCollection === "string" && !publishesDeclaredCollection) {
+    issues.push(`resultsCollection "${resultsCollection}" is declared but no step publishes it — add a "${RESULTS_TOOL}" step with args {"appId":"'${input.appId}'","collection":"'${resultsCollection}'","id":"'latest'","data":...}`);
+  }
+  return issues;
+};
+
 const validatePlan = (
   raw: string,
   input: AutomationPlanInput,
@@ -314,56 +378,7 @@ const validatePlan = (
     }
   }
   if (trigger.run.kind === "steps") {
-    const steps = trigger.run.steps;
-    if (steps.length === 0) issues.push("steps must not be empty");
-    // The planning surface is the whole legal tool universe here: fn: refs
-    // are NOT accepted — the ladder only authors automations for machine-less
-    // apps this wave, and a machine-less app has no fn: to call.
-    const known = new Set(plannerTools(input.tools).map(({ name }) => name));
-    const seen = new Set<string>();
-    const priorIds = new Set<string>();
-    let publishesDeclaredCollection = false;
-    for (const step of steps) {
-      // Bare-identifier ids only: a hyphenated id referenced as
-      // steps.invoice-rows parses as SUBTRACTION in jsonata, so the reference
-      // silently evaluates to nothing at run time.
-      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(step.id) || seen.has(step.id)) {
-        issues.push(`step ids must be unique bare identifiers ([A-Za-z_][A-Za-z0-9_]*) — "${step.id}" is not`);
-      }
-      seen.add(step.id);
-      if (refused.has(step.tool)) {
-        issues.push(refusal(`step "${step.id}"`, step.tool));
-      } else if (!known.has(step.tool)) {
-        issues.push(`step "${step.id}" names unknown tool "${step.tool}"; the available tools are: ${[...known].join(", ") || "(none)"}`);
-      }
-      // Law 1 for automations: a published result must be BUILT from a PRIOR
-      // step's output (or the trigger event) — a hand-typed data payload is
-      // invented data on the board. Quoted jsonata string literals (BOTH legal
-      // quote forms) are stripped first so 'a steps guide' or "steps.rows"
-      // cannot smuggle past the check, and the referenced step id must be one
-      // that ran EARLIER (a bare "steps" token or a forward reference
-      // publishes nothing at run time).
-      if (step.tool === RESULTS_TOOL) {
-        const dataExpression = (step.args?.data ?? "").replace(/'[^']*'|"[^"]*"/g, "");
-        const referencedPrior = [...dataExpression.matchAll(/\bsteps\.([A-Za-z_][A-Za-z0-9_]*)/g)]
-          .some((match) => priorIds.has(match[1] as string));
-        if (!referencedPrior && !/\bevent\b/.test(dataExpression)) {
-          issues.push(`step "${step.id}" publishes hand-typed data — the "${RESULTS_TOOL}" data expression must derive from an EARLIER step's output (steps.<priorStepId>...) or the trigger event; add the read step that fetches the live data first`);
-        }
-        if (typeof resultsCollection === "string"
-          && step.args?.collection?.trim() === `'${resultsCollection}'`
-          && step.args?.appId?.trim() === `'${input.appId}'`) {
-          publishesDeclaredCollection = true;
-        }
-      }
-      priorIds.add(step.id);
-    }
-    // A declared results collection the run never writes leaves the rebound
-    // board permanently empty — require the publish step to target exactly
-    // this app and that collection (literal jsonata strings).
-    if (typeof resultsCollection === "string" && !publishesDeclaredCollection) {
-      issues.push(`resultsCollection "${resultsCollection}" is declared but no step publishes it — add a "${RESULTS_TOOL}" step with args {"appId":"'${input.appId}'","collection":"'${resultsCollection}'","id":"'latest'","data":...}`);
-    }
+    issues.push(...stepsIssues(trigger.run.steps, input, refused, resultsCollection));
   }
   const name = candidate.name;
   if (name !== undefined && (typeof name !== "string" || name.trim() === "" || name.length > 80)) {

--- a/packages/apps/src/claude-turn.ts
+++ b/packages/apps/src/claude-turn.ts
@@ -329,6 +329,118 @@ const WRITING_TOOL_NAMES = new Set(WRITING_TOOLS.split("|"));
 const PLANNING_TOOL = "TodoWrite";
 
 /**
+ * Everything `query()` is told, once, for the life of the session.
+ *
+ * A sibling function rather than a sibling MODULE: `dist/claude-turn.js` is
+ * copied verbatim into the machine image (module header), so this file has no
+ * relative imports to give it.
+ */
+function sessionOptions(
+  input: ClaudeSessionInput,
+  onPostToolUse: (raw: unknown) => Promise<Record<string, unknown>>,
+): Record<string, unknown> {
+  return {
+    cwd: input.cwd,
+    ...(input.model === undefined ? {} : { model: input.model }),
+    ...(input.effort === undefined ? {} : { effort: input.effort }),
+    ...(input.maxTurns === undefined ? {} : { maxTurns: input.maxTurns }),
+    ...(input.resume === undefined ? {} : { resume: input.resume }),
+    // Append, never replace: the co-trained Claude Code harness IS the product
+    // decision behind this adapter.
+    systemPrompt: { type: "preset", preset: "claude_code", append: input.systemPrompt ?? "" },
+    // Nothing local left to ask: the box contains the box's own hands, and the
+    // guard decides host tools at the door (module header).
+    permissionMode: "bypassPermissions",
+    // The SDK documents the pair as required ("Must be set to `true` when using
+    // `permissionMode: 'bypassPermissions'`"); today's CLI treats it as advisory
+    // (measured 2026-08-03), so this is hygiene against one that enforces it.
+    allowDangerouslySkipPermissions: true,
+    disallowedTools: DISALLOWED_TOOLS,
+    // The host's own door, over native remote MCP. `alwaysLoad` because this
+    // surface is deliberately UNCURATED (`toolSurface: { curated: false }`):
+    // the door lists everything the ctx projects — THE LAW's §12 withholding
+    // and the host's `surfaces.agent` menu still decide that set — so letting
+    // the engine defer the listing behind its own tool search would put back
+    // exactly the friction the redesign removed. It also makes an unreachable
+    // door fail at startup instead of silently presenting a model with no hands.
+    ...(input.toolDoor === undefined ? {} : {
+      mcpServers: {
+        [VENDO_MCP_SERVER]: {
+          type: "http",
+          url: input.toolDoor.url,
+          headers: { Authorization: `Bearer ${input.toolDoor.token}` },
+          alwaysLoad: true,
+        },
+      },
+    }),
+    // Never read settings or CLAUDE.md off the materialized workspace: those are
+    // the USER's files, and a file cannot be allowed to configure the harness.
+    // This disables FILESYSTEM settings discovery only — `plugins` below is an
+    // explicit programmatic list, so native skills survive tenant isolation.
+    settingSources: [],
+    // The other half of that rule, for MCP: `settingSources` closes SETTINGS
+    // discovery, and the SDK names a project `.mcp.json` as something only this
+    // flag ignores. The box's cwd is a disk the model writes itself, and `reopen`
+    // relaunches a fresh CLI over it — a server mounted that way would arrive as
+    // `mcp__*` tools, outside DISALLOWED_TOOLS, the guard, the audit log and the
+    // egress filter. The door above is the only MCP server this box wants.
+    strictMcpConfig: true,
+    // Without this the SDK hands us whole assistant blocks and the user watches
+    // a still screen for the length of a paragraph.
+    includePartialMessages: true,
+    env: input.env,
+    ...(input.pluginPath === undefined ? {} : {
+      // `skipMcpDiscovery`: we own the MCP wiring (the in-process projection),
+      // so the engine must not read a plugin's own .mcp.json.
+      plugins: [{ type: "local", path: input.pluginPath, skipMcpDiscovery: true }],
+      // The SDK's single switch for turning discovered skills ON. NAMED, never
+      // "all": "all" also enables whatever the machine's own home directory
+      // happens to carry. A plugin whose skills are never enabled is a
+      // directory nobody reads, so an empty name list still passes [].
+      skills: [...(input.skillNames ?? [])],
+    }),
+    ...(input.onFileWritten === undefined ? {} : {
+      hooks: { PostToolUse: [{ matcher: WRITING_TOOLS, hooks: [onPostToolUse] }] },
+    }),
+  };
+}
+
+/**
+ * One `assistant` message, read for what the user should see.
+ *
+ * An `assistant` message is the COMPLETED form of prose that may already
+ * have streamed as deltas. Emitting both showed the user every sentence
+ * twice (measured live 2026-08-02, once `includePartialMessages` went on).
+ * Whichever arrived first wins; the block is still the only source when
+ * an SDK build streams nothing, so the fallback stays real.
+ *
+ * The message is SCANNED either way, never skipped whole: a `tool_use`
+ * block rides in the SAME message as the sentence that introduced it, so
+ * skipping the duplicate prose also threw away every beat in any turn
+ * where the model spoke — which is every real turn.
+ */
+function readAssistantMessage(
+  input: ClaudeSessionInput,
+  message: Record<string, unknown>,
+  streamed: boolean,
+  beat: (phase: BeatPhase, label: string) => void,
+): void {
+  const content = (message["message"] as { content?: Array<Record<string, unknown>> } | undefined)?.content;
+  for (const block of content ?? []) {
+    if (block["type"] === "text") {
+      if (!streamed && typeof block["text"] === "string" && block["text"] !== "") {
+        input.emit({ type: "text", delta: block["text"] });
+      }
+    } else if (block["type"] === "tool_use" && typeof block["name"] === "string") {
+      // The tool's NAME and nothing else. Its inputs are the model's own
+      // text and can name a file (see {@link PLANNING_TOOL}).
+      if (block["name"] === PLANNING_TOOL) beat("planning", "Working out the steps");
+      else if (WRITING_TOOL_NAMES.has(block["name"])) beat("building", "Putting it together");
+    }
+  }
+}
+
+/**
  * Open ONE live session for a whole conversation.
  *
  * `query()` is called exactly once. Its `prompt` is a stream we keep open, so a
@@ -387,72 +499,7 @@ export function createClaudeSession(input: ClaudeSessionInput): ClaudeSession {
   };
 
   const drain = (async () => {
-    const options: Record<string, unknown> = {
-      cwd: input.cwd,
-      ...(input.model === undefined ? {} : { model: input.model }),
-      ...(input.effort === undefined ? {} : { effort: input.effort }),
-      ...(input.maxTurns === undefined ? {} : { maxTurns: input.maxTurns }),
-      ...(input.resume === undefined ? {} : { resume: input.resume }),
-      // Append, never replace: the co-trained Claude Code harness IS the product
-      // decision behind this adapter.
-      systemPrompt: { type: "preset", preset: "claude_code", append: input.systemPrompt ?? "" },
-      // Nothing local left to ask: the box contains the box's own hands, and the
-      // guard decides host tools at the door (module header).
-      permissionMode: "bypassPermissions",
-      // The SDK documents the pair as required ("Must be set to `true` when using
-      // `permissionMode: 'bypassPermissions'`"); today's CLI treats it as advisory
-      // (measured 2026-08-03), so this is hygiene against one that enforces it.
-      allowDangerouslySkipPermissions: true,
-      disallowedTools: DISALLOWED_TOOLS,
-      // The host's own door, over native remote MCP. `alwaysLoad` because this
-      // surface is deliberately UNCURATED (`toolSurface: { curated: false }`):
-      // the door lists everything the ctx projects — THE LAW's §12 withholding
-      // and the host's `surfaces.agent` menu still decide that set — so letting
-      // the engine defer the listing behind its own tool search would put back
-      // exactly the friction the redesign removed. It also makes an unreachable
-      // door fail at startup instead of silently presenting a model with no hands.
-      ...(input.toolDoor === undefined ? {} : {
-        mcpServers: {
-          [VENDO_MCP_SERVER]: {
-            type: "http",
-            url: input.toolDoor.url,
-            headers: { Authorization: `Bearer ${input.toolDoor.token}` },
-            alwaysLoad: true,
-          },
-        },
-      }),
-      // Never read settings or CLAUDE.md off the materialized workspace: those are
-      // the USER's files, and a file cannot be allowed to configure the harness.
-      // This disables FILESYSTEM settings discovery only — `plugins` below is an
-      // explicit programmatic list, so native skills survive tenant isolation.
-      settingSources: [],
-      // The other half of that rule, for MCP: `settingSources` closes SETTINGS
-      // discovery, and the SDK names a project `.mcp.json` as something only this
-      // flag ignores. The box's cwd is a disk the model writes itself, and `reopen`
-      // relaunches a fresh CLI over it — a server mounted that way would arrive as
-      // `mcp__*` tools, outside DISALLOWED_TOOLS, the guard, the audit log and the
-      // egress filter. The door above is the only MCP server this box wants.
-      strictMcpConfig: true,
-      // Without this the SDK hands us whole assistant blocks and the user watches
-      // a still screen for the length of a paragraph.
-      includePartialMessages: true,
-      env: input.env,
-      ...(input.pluginPath === undefined ? {} : {
-        // `skipMcpDiscovery`: we own the MCP wiring (the in-process projection),
-        // so the engine must not read a plugin's own .mcp.json.
-        plugins: [{ type: "local", path: input.pluginPath, skipMcpDiscovery: true }],
-        // The SDK's single switch for turning discovered skills ON. NAMED, never
-        // "all": "all" also enables whatever the machine's own home directory
-        // happens to carry. A plugin whose skills are never enabled is a
-        // directory nobody reads, so an empty name list still passes [].
-        skills: [...(input.skillNames ?? [])],
-      }),
-      ...(input.onFileWritten === undefined ? {} : {
-        hooks: { PostToolUse: [{ matcher: WRITING_TOOLS, hooks: [onPostToolUse] }] },
-      }),
-    };
-
-    const query = sdk.query({ prompt: inbox.stream(), options });
+    const query = sdk.query({ prompt: inbox.stream(), options: sessionOptions(input, onPostToolUse) });
     live = query;
     /** Did the message now being assembled already reach the user as deltas? */
     let streamed = false;
@@ -470,29 +517,7 @@ export function createClaudeSession(input: ClaudeSessionInput): ClaudeSession {
         continue;
       }
       if (type === "assistant") {
-        // An `assistant` message is the COMPLETED form of prose that may already
-        // have streamed as deltas. Emitting both showed the user every sentence
-        // twice (measured live 2026-08-02, once `includePartialMessages` went on).
-        // Whichever arrived first wins; the block is still the only source when
-        // an SDK build streams nothing, so the fallback stays real.
-        //
-        // The message is SCANNED either way, never skipped whole: a `tool_use`
-        // block rides in the SAME message as the sentence that introduced it, so
-        // skipping the duplicate prose also threw away every beat in any turn
-        // where the model spoke — which is every real turn.
-        const content = (message["message"] as { content?: Array<Record<string, unknown>> } | undefined)?.content;
-        for (const block of content ?? []) {
-          if (block["type"] === "text") {
-            if (!streamed && typeof block["text"] === "string" && block["text"] !== "") {
-              input.emit({ type: "text", delta: block["text"] });
-            }
-          } else if (block["type"] === "tool_use" && typeof block["name"] === "string") {
-            // The tool's NAME and nothing else. Its inputs are the model's own
-            // text and can name a file (see {@link PLANNING_TOOL}).
-            if (block["name"] === PLANNING_TOOL) beat("planning", "Working out the steps");
-            else if (WRITING_TOOL_NAMES.has(block["name"])) beat("building", "Putting it together");
-          }
-        }
+        readAssistantMessage(input, message, streamed, beat);
         streamed = false;
         continue;
       }

--- a/packages/apps/src/data-tools.ts
+++ b/packages/apps/src/data-tools.ts
@@ -1,0 +1,70 @@
+/**
+ * `vendo_apps_data_list` · `_put` · `_delete` — the agent's reach into a
+ * declared app data collection, over the same `requireOwned` gate every other
+ * door reads.
+ *
+ * Lifted out of `createAgentTools` unchanged.
+ */
+import {
+  VendoError,
+  type Json,
+  type RecordQuery,
+  type RunContext,
+  type ToolCall,
+  type ToolOutcome,
+} from "@vendoai/core";
+import type { AgentToolsDataDependencies } from "./agent-tools.js";
+import { input, optionalLimit, optionalRefs } from "./tool-args.js";
+
+export const listAppData = async (
+  dependencies: AgentToolsDataDependencies,
+  call: ToolCall,
+  ctx: RunContext,
+): Promise<ToolOutcome> => {
+  const args = input(call.args, ["appId", "collection"], ["refs", "limit", "cursor"]);
+  const app = await dependencies.requireOwned(args.appId as string, ctx);
+  const refs = optionalRefs(args.refs);
+  const limit = optionalLimit(args.limit);
+  if (args.cursor !== undefined && (typeof args.cursor !== "string" || args.cursor.trim() === "")) {
+    throw new VendoError("validation", "cursor must be a non-empty string");
+  }
+  const query: RecordQuery = {
+    ...(refs === undefined ? {} : { refs }),
+    ...(limit === undefined ? {} : { limit }),
+    ...(args.cursor === undefined ? {} : { cursor: args.cursor as string }),
+  };
+  return {
+    status: "ok",
+    output: await dependencies.data.records(app, args.collection as string).list(query) as unknown as Json,
+  };
+};
+
+export const putAppData = async (
+  dependencies: AgentToolsDataDependencies,
+  call: ToolCall,
+  ctx: RunContext,
+): Promise<ToolOutcome> => {
+  const args = input(call.args, ["appId", "collection", "id"], ["data", "refs"]);
+  if (!Object.prototype.hasOwnProperty.call(args, "data") || args.data === undefined) {
+    throw new VendoError("validation", "data is required");
+  }
+  const app = await dependencies.requireOwned(args.appId as string, ctx);
+  const refs = optionalRefs(args.refs);
+  const record = await dependencies.data.records(app, args.collection as string).put({
+    id: args.id as string,
+    data: args.data,
+    ...(refs === undefined ? {} : { refs }),
+  });
+  return { status: "ok", output: record as unknown as Json };
+};
+
+export const deleteAppData = async (
+  dependencies: AgentToolsDataDependencies,
+  call: ToolCall,
+  ctx: RunContext,
+): Promise<ToolOutcome> => {
+  const args = input(call.args, ["appId", "collection", "id"]);
+  const app = await dependencies.requireOwned(args.appId as string, ctx);
+  await dependencies.data.records(app, args.collection as string).delete(args.id as string);
+  return { status: "ok", output: { status: "ok" } };
+};

--- a/packages/apps/src/make-tool.ts
+++ b/packages/apps/src/make-tool.ts
@@ -1,0 +1,328 @@
+/**
+ * `vendo_make` — the one door a calling agent asks for a screen through, and
+ * the two routes behind it: a NEW thing (assembly, escalating to the builder)
+ * and a change to one app the caller named.
+ *
+ * Lifted out of `createAgentTools` unchanged.
+ */
+import {
+  isUnattended,
+  VENDO_VIEW_STREAM,
+  VendoError,
+  makeReceiptSchema,
+  vendoViewStreamId,
+  type AppId,
+  type Json,
+  type MakeReceipt,
+  type RunContext,
+  type ToolCall,
+  type ToolOutcome,
+  type VendoViewStreamUpdate,
+  type VendoViewStreamingToolCall,
+} from "@vendoai/core";
+import type { AgentToolsDataDependencies } from "./agent-tools.js";
+import { NO_ASSEMBLER, NOTHING_RENDERABLE, NO_MACHINE } from "./build-messages.js";
+import { input, optionalString, resolveAppRef } from "./tool-args.js";
+import type { AppsRuntime } from "./types.js";
+
+/**
+ * Contract §3.1 — the caller's `context` appended to the request, clearly
+ * delimited.
+ *
+ * It exists for outside agents whose conversation we cannot see: over MCP there is
+ * no transcript for us to attach, so they pass whatever background helps. On OUR
+ * doors the runtime's own transcript stays authoritative and this is supplemental
+ * — which is why it is appended rather than merged, and fenced rather than run
+ * together with the ask. Free text, never a messages array: every framework's
+ * message format differs and a string is universal.
+ */
+const withContext = (request: string, context: string | undefined): string =>
+  context === undefined ? request : `${request}\n\n<context>\n${context}\n</context>`;
+
+/** The tool's whole model-facing answer. Parsed, so the four-field law is enforced
+ *  here rather than trusted — a document that leaked into `output` would fail. */
+const receipt = (value: MakeReceipt): ToolOutcome => ({
+  status: "ok",
+  output: makeReceiptSchema.parse(value) as unknown as Json,
+});
+
+/**
+ * What to call an app that was never built — the one receipt with no document to
+ * read a name off (`MakeReceipt.title` is required).
+ *
+ * The `<Plan>`'s own name first, because the person is already looking at that
+ * plan's skeleton titled with this exact string, so the sentence and the card are
+ * about the same thing. Otherwise the ask, collapsed and capped — the same answer
+ * a failed build record's name field gets.
+ */
+const nameForUnbuilt = (plan: string | undefined, ask: string): string => {
+  const named = plan === undefined ? null : /<Plan\b[^>]*\bname="([^"]+)"/.exec(plan);
+  const title = named?.[1]?.trim();
+  if (title !== undefined && title !== "") return title;
+  const collapsed = ask.replace(/\s+/g, " ").trim();
+  return collapsed === "" ? "Vendo app" : collapsed.slice(0, 60);
+};
+
+/**
+ * What an ask that produced no screen says to the person.
+ *
+ * The seam used to answer this with a second engine, so the four ways assembly
+ * can come back empty — unwired, threw, `unavailable`, or `assembled` with no
+ * row — were all silently absorbed. They are now the answer: an unwired
+ * assembler is a composition bug and a composition bug that quietly swaps
+ * engines is a bug nobody fixes. The reason travels verbatim because every one
+ * of these is authored (a `why`, a thrown message, or the two constants below)
+ * and a person reading "I couldn't put that screen together" alone has nothing
+ * to act on.
+ */
+const unbuiltSay = (why: string): string =>
+  why.trim() === ""
+    ? "I couldn't put that screen together."
+    : `I couldn't put that screen together — ${why.trim()}`;
+
+/** What both routes read: the doors, the ask as the engines see it, the view
+ *  stream this call arrived on, and the memory write. */
+interface MakeCall {
+  runtime: AppsRuntime;
+  dependencies: AgentToolsDataDependencies;
+  ctx: RunContext;
+  /** The person's words, plus the caller's `<context>` fence when it sent one. */
+  ask: string;
+  /** The client parts this execution may publish, when the caller opened a stream. */
+  stream: ((update: VendoViewStreamUpdate) => void) | undefined;
+  /** The ask, onto the app's memory. Best-effort, always. */
+  remember(appId: string): Promise<void>;
+}
+
+const makeNewApp = async (
+  { runtime, dependencies, ctx, ask, stream, remember }: MakeCall,
+  claimed: string | undefined,
+): Promise<ToolOutcome> => {
+  // ── THE SEAM (blueprint §1 point 2) ─────────────────────────────────
+  // "No agent chooses 'quick screen' vs 'real build'. Every request
+  // starts in the cheap screen agent." The id is minted HERE, before the
+  // route, because both ends have to use the same one: an escalation
+  // leaves `plan.vendo` and its painted skeleton at this id, and a build
+  // that minted its own would strand that skeleton on a second stream as
+  // a card that builds forever.
+  //
+  // Only `assembled` WITH A ROW ends the call happily. The row is the
+  // check that makes that true instead of merely intended: `authored`
+  // upserts it iff the seam actually compiled and painted the document,
+  // so a screen agent that saved bytes nobody can render leaves no row.
+  //
+  // TWO answers now, and no third. `escalate` is a request for the
+  // builder (§4.5's receiving end, below); everything else is assembly
+  // coming back empty, and assembly coming back empty is the ANSWER —
+  // there is no second engine behind this seam to rescue it with.
+  const appId = `app_${globalThis.crypto.randomUUID()}` as AppId;
+  // B1 — the claim rides the MINT, not the landing, for BOTH engines.
+  // Claiming after assembly returned left the slot empty for the whole
+  // of a fast make, and left nothing at all behind a failed one, so the
+  // slot stayed empty and the person heard about the failure only in the
+  // conversation. The builder route has always claimed here (`create`'s
+  // own `slot`, which this door no longer needs to pass).
+  if (claimed !== undefined) await dependencies.claimSlot(appId, claimed, ctx);
+  /** The one exit for an ask no engine landed: the tombstone that turns
+   *  the claimed slot into the honest failure card, then the receipt
+   *  that says so — the record's reason is the sentence the person is
+   *  told, verbatim, because there is nothing else true to record. */
+  const failUnbuilt = async (title: string, say: string): Promise<ToolOutcome> => {
+    if (claimed !== undefined) await dependencies.markUnbuilt(appId, title, say, ctx);
+    return receipt({ id: appId, title, status: "failed", say });
+  };
+  let threw: string | undefined;
+  const routed = dependencies.screen === undefined
+    ? undefined
+    : await dependencies.screen.assemble({
+      appId,
+      request: ask,
+      ...(stream === undefined ? {} : {
+        onView: (part) => stream({ id: vendoViewStreamId(part.appId), part }),
+      }),
+    }, ctx).catch((error: unknown) => {
+      threw = error instanceof Error ? error.message : String(error);
+      console.warn(`[vendo] the screen agent could not serve ${appId} — ${threw}`);
+      return undefined;
+    });
+  if (routed?.kind === "assembled") {
+    const stored = await runtime.get(appId, ctx).catch(() => null);
+    if (stored !== null) {
+      await remember(appId);
+      // No claim here: the slot has held this id since the mint above,
+      // and the row already names it.
+      return receipt({
+        id: stored.id,
+        title: stored.name,
+        status: "ready",
+        say: `${stored.name} is on your screen.`,
+      });
+    }
+  }
+  // ── §4.5's RECEIVING END ────────────────────────────────────────────
+  // An escalation is the screen agent asking for the builder by name; it
+  // is not the seam failing. Two answers, and the deployment's own shape
+  // picks which:
+  //
+  //  - A sandbox is configured → the build runs. Same `create` a
+  //    server-needing ask has always taken, at the SAME app id, so the
+  //    plan's skeleton and the finished app share one stream and the
+  //    outline becomes the app. The escalated plan rides in as the
+  //    brief; the ask still travels verbatim.
+  //  - No sandbox → say so, rather than spending a full build's latency
+  //    to arrive at a worse version of the screen the person was already
+  //    shown. The skeleton is left as it is — the UI unmounts a
+  //    still-forming card once the turn is over
+  //    (`chrome/thread/parts.tsx`), so the last word is this receipt.
+  const escalated = routed?.kind === "escalate";
+  const plan = !escalated
+    ? undefined
+    : await dependencies.escalatedPlan?.(appId, ctx).catch(() => undefined);
+  if (!escalated) {
+    // Assembly produced no screen. Said plainly, at the id whose stream
+    // the person is looking at, instead of quietly restarting the ask in
+    // a different engine.
+    return await failUnbuilt(
+      nameForUnbuilt(undefined, ask),
+      unbuiltSay(
+        dependencies.screen === undefined ? NO_ASSEMBLER
+          : threw ?? (routed?.kind === "unavailable" ? routed.why : NOTHING_RENDERABLE),
+      ),
+    );
+  }
+  if (!runtime.machine.available()) {
+    return await failUnbuilt(
+      // The name on the skeleton they are looking at, so the sentence and
+      // the card are about the same thing.
+      nameForUnbuilt(plan, ask),
+      NO_MACHINE,
+    );
+  }
+  let unsaved: string | undefined;
+  const created = await runtime.create({
+    appId,
+    prompt: ask,
+    ...(plan === undefined ? {} : { plan }),
+    // No `slot`: the claim went down at the mint above, which is the
+    // same instant `create` would have made it for an id of its own.
+    onUnsaved: (reason) => { unsaved = reason; },
+    ...(stream === undefined ? {} : {
+      onView: (part) => stream({ id: vendoViewStreamId(part.appId), part }),
+    }),
+  }, ctx);
+  // An unsaved create has no row to remember onto; `remember` says so
+  // and moves on, which is the same non-event every other failure is.
+  await remember(created.id);
+  // View-only (the store refused the write): the screen IS on the user's
+  // page, so this is a success with a caveat, not a failure. Reporting it
+  // as an error made the agent apologize for a rendered view and rebuild
+  // it twice more — three cards, one prompt (live 2026-07-27). The
+  // caveat rides `say`, which is the whole point of `say`: one true
+  // sentence, and nothing to react to.
+  return receipt({
+    id: created.id,
+    title: created.name,
+    status: "ready",
+    say: unsaved === undefined
+      ? `${created.name} is on your screen.`
+      : `${created.name} is on your screen, though I couldn't save it to your apps.`,
+  });
+};
+
+const changeExistingApp = async (
+  { runtime, ctx, ask, stream, remember }: MakeCall,
+  app: string,
+): Promise<ToolOutcome> => {
+  const appId = await resolveAppRef(runtime, app, ctx);
+  const result = await runtime.edit(appId, ask, ctx);
+  // Recorded whether or not the change landed: the person DID ask this of
+  // this app, and the next editor reading "asked for X, then asked for X
+  // again, narrower" is reading the truth.
+  await remember(appId);
+  // Wave 9 — a ladder-authored automation raises its own card. Published
+  // HERE, by the side that knows, rather than duck-typed out of this tool's
+  // return value at the bridge: the receipt carries words only.
+  if (result.automation !== undefined && stream !== undefined) {
+    stream({
+      id: `vendo-automation-${result.app.id}`,
+      part: {
+        type: "data-vendo-automation",
+        appId: result.app.id,
+        name: result.app.name,
+        enabled: result.automation.enabled,
+        ...(result.automation.trigger === undefined ? {} : { trigger: result.automation.trigger }),
+        ...(result.app.description === undefined || result.app.description.length === 0
+          ? {}
+          : { description: result.app.description }),
+        ...((result.automation.pendingGrants ?? []).length === 0
+          ? {}
+          : { pendingGrants: result.automation.pendingGrants!.length }),
+      },
+    });
+  }
+  return receipt({
+    id: result.app.id,
+    title: result.app.name,
+    status: result.failure === undefined ? "ready" : "failed",
+    say: result.failure === undefined
+      ? `${result.app.name} is updated.`
+      : `I couldn't make that change to ${result.app.name}.`,
+  });
+};
+
+export const runMakeTool = async (
+  runtime: AppsRuntime,
+  dependencies: AgentToolsDataDependencies,
+  call: ToolCall,
+  ctx: RunContext,
+): Promise<ToolOutcome> => {
+  const args = input(call.args, ["request"], ["app", "context", "slot"]);
+  const app = optionalString(args.app, "app");
+  const slot = optionalString(args.slot, "slot");
+  // The slot, and ONLY the slot, needs a person there: it claims a place
+  // on somebody's page and evicts whatever held it. Creation does not, so
+  // an unattended run still builds what it was asked for and simply takes
+  // no slot — this is the whole of that rule (ruled 2026-08-06; the
+  // guard's presence-only refusal covers the pin tools, never make).
+  // The refusal below still reads `slot`, because "you aimed a new app at
+  // a slot on an EDIT" is wrong however present the person is.
+  const claimed = isUnattended(ctx) ? undefined : slot;
+  const stream = (call as VendoViewStreamingToolCall)[VENDO_VIEW_STREAM];
+  const request = args.request as string;
+  const ask = withContext(request, optionalString(args.context, "context"));
+  /**
+   * The ask, onto the app's memory — the FRONT DOOR's job, because this is
+   * the one place that sees every request that touched an app whichever
+   * engine served it (assembly, the builder, the conductor fall-through,
+   * an edit).
+   *
+   * `request` and not `ask`: the memory holds what the PERSON said. The
+   * `<context>` fence is one calling agent's background for one call, and
+   * replaying it to every future editor as though the person had typed it
+   * is how a stale aside becomes a standing requirement.
+   *
+   * Best-effort, always. There is no arrangement of a lost memory write
+   * that is worse than failing a make the person can already see.
+   */
+  const remember = async (appId: string): Promise<void> => {
+    await runtime.remember({ appId, ask: request }, ctx).catch((error: unknown) => {
+      console.warn(`[vendo] the ask was not recorded on ${appId}: ${
+        error instanceof Error ? error.message : String(error)
+      }`);
+    });
+  };
+  const make: MakeCall = { runtime, dependencies, ctx, ask, stream, remember };
+  if (app === undefined) return await makeNewApp(make, claimed);
+  // `slot` says where a NEW app lands. On a change it would have to mean
+  // "and also move it", which evicts whatever holds that slot off the back
+  // of an edit nobody aimed there — so it is refused, by name, at the one
+  // tool that does the moving. Refused before the ref is resolved: the
+  // answer does not depend on which app was meant.
+  if (slot !== undefined) {
+    throw new VendoError(
+      "validation",
+      "`slot` says where a new app lands. To move an app that already exists, call vendo_apps_pin with that app and slot.",
+    );
+  }
+  return await changeExistingApp(make, app);
+};

--- a/packages/apps/src/tool-args.ts
+++ b/packages/apps/src/tool-args.ts
@@ -1,0 +1,103 @@
+/**
+ * The `vendo_*` tool arguments, checked before any door is touched.
+ *
+ * Internal to the agent-tool registry (`agent-tools.ts` and its handler
+ * modules) — the doors themselves take typed input.
+ */
+import {
+  appIdSchema,
+  VendoError,
+  type AppDocument,
+  type Json,
+  type RunContext,
+} from "@vendoai/core";
+import type { AppsRuntime } from "./types.js";
+
+export const input = (
+  value: Json,
+  required: string[],
+  optional: string[] = [],
+): Record<string, Json> => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new VendoError("validation", "tool input must be an object");
+  }
+  const record = value as Record<string, Json>;
+  const allowed = new Set([...required, ...optional]);
+  const unexpected = Object.keys(record).find((key) => !allowed.has(key));
+  if (unexpected !== undefined) throw new VendoError("validation", `unexpected input property: ${unexpected}`);
+  for (const key of required) {
+    if (typeof record[key] !== "string" || (record[key] as string).trim() === "") {
+      throw new VendoError("validation", `${key} must be a non-empty string`);
+    }
+  }
+  return record;
+};
+
+export const optionalString = (value: Json | undefined, name: string): string | undefined => {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new VendoError("validation", `${name} must be a non-empty string`);
+  }
+  return value;
+};
+
+export const optionalRefs = (value: Json | undefined): Record<string, string> | undefined => {
+  if (value === undefined) return undefined;
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new VendoError("validation", "refs must be an object");
+  }
+  const refs: Record<string, string> = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (key === "" || typeof item !== "string" || item.trim() === "") {
+      throw new VendoError("validation", "refs must have non-empty string keys and values");
+    }
+    refs[key] = item;
+  }
+  return refs;
+};
+
+export const optionalLimit = (value: Json | undefined): number | undefined => {
+  if (value === undefined) return undefined;
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 1) {
+    throw new VendoError("validation", "limit must be a positive integer");
+  }
+  return value;
+};
+
+/**
+ * The `app` slot as a person says it: an app id, or the app's NAME.
+ *
+ * A fresh thread holds no ids — "add a weekly one to the transactions app" is
+ * the whole ask, and until now it died on the way in, because `app` took an id
+ * and nothing in this registry lists or searches. The aim already has a slot;
+ * this is that slot understanding the name the user actually said.
+ *
+ * Exact name first, then case-insensitively, over THIS caller's own apps (the
+ * same owned ∪ granted list every other door reads). Two apps of one name is a
+ * question, never a coin toss: the candidates come back in the refusal so the
+ * model can ask which one. And a ref that matches no name is handed on
+ * untouched, so "no such app" and "you may not change that one" stay the
+ * runtime's own sentences.
+ */
+export const resolveAppRef = async (
+  runtime: AppsRuntime,
+  ref: string,
+  ctx: RunContext,
+): Promise<string> => {
+  // An id is an id (core's own shape). Nothing is listed for the common path.
+  if (appIdSchema.safeParse(ref).success) return ref;
+  const apps = await runtime.list(ctx);
+  const exact = apps.filter(({ name }) => name === ref);
+  const matches = exact.length > 0
+    ? exact
+    : apps.filter(({ name }) => name.toLowerCase() === ref.toLowerCase());
+  if (matches.length === 1) return (matches[0] as AppDocument).id;
+  if (matches.length > 1) {
+    throw new VendoError(
+      "validation",
+      `More than one app is called "${ref}": ${matches.map(({ name, id }) => `${name} (${id})`).join(", ")}.`
+      + " Ask which one they mean and pass that app's id.",
+    );
+  }
+  return ref;
+};

--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -758,73 +758,7 @@ class GuardImplementation implements VendoGuard {
             await this.#reportFrozenBlock(ctx, call);
             return { status: "blocked", reason: FROZEN_REASON };
           }
-          const grant = await this.#grantForExecution(decision, call, completed.descriptor, ctx);
-          // CORE-2: `grant` is a first-class RunContext field — no cast needed.
-          const executeCtx = grant === undefined ? ctx : { ...ctx, grant };
-          // Build contract §7: for a MUTATING call, a key that already succeeded
-          // returns its recorded outcome INSTEAD of executing. The check sits
-          // here, after the guard has said run and before the registry is
-          // touched, because that is the only point where skipping is both safe
-          // (authority was still checked) and effective (the effect is avoided).
-          //
-          // The DECLARED label decides — the dev's label is final (two-vote
-          // grading removed), so a declared `read` is silent and takes no
-          // receipt.
-          const risk = completed.descriptor.risk;
-          const mutating = risk === "write" || risk === "destructive";
-          const base = mutating ? effectBaseKey(ctx, call) : undefined;
-          const key = base === undefined ? undefined : effectKeyOf(base, this.#effectOrdinal(base, call.id));
-          const recorded = key === undefined ? undefined : await this.#recordedEffect(key);
-          if (recorded !== undefined) {
-            outcome = recorded;
-          } else {
-            // Finding 14 (TOCTOU): two concurrent identical calls both read "no
-            // receipt" and both executed. Share one in-flight execution per key
-            // so the second awaits the first's outcome instead of repeating it.
-            const inFlight = key === undefined ? undefined : this.#effectsInFlight.get(key);
-            if (inFlight !== undefined) {
-              outcome = await inFlight;
-            } else {
-              const run = (async (): Promise<ToolOutcome> => {
-                try {
-                  return await tools.execute(call, executeCtx);
-                } catch (error) {
-                  return {
-                    status: "error",
-                    error: {
-                      code: error instanceof VendoError ? error.code : "error",
-                      message: errorMessage(error),
-                    },
-                  };
-                }
-              })();
-              if (key !== undefined) this.#effectsInFlight.set(key, run);
-              try {
-                outcome = await run;
-              } finally {
-                if (key !== undefined) this.#effectsInFlight.delete(key);
-              }
-              // Only a SUCCESS is ledgered. A failed mutation may not have landed
-              // at all, so recording it would turn a transient upstream error into
-              // a permanent refusal to retry — the opposite of the goal.
-              if (key !== undefined && outcome.status === "ok") {
-                // The mutation ALREADY HAPPENED. A receipt-store failure must
-                // never discard it: throwing here would lose both the caller's
-                // outcome and the audit row for real, completed work. Surface it
-                // loudly and carry on — an unrecorded receipt risks a duplicate
-                // on a later re-run, which is strictly better than losing the
-                // record of a payment that went out.
-                try {
-                  await this.#recordEffect(key, outcome, ctx.principal.subject);
-                } catch (error) {
-                  console.error(
-                    `[vendo] guard: ${call.tool} completed but its effect receipt could not be written `
-                    + `(${errorMessage(error)}). A re-run of this run may repeat the call.`,
-                  );
-                }
-              }
-            }
-          }
+          outcome = await this.#runOnce(tools, call, decision, completed.descriptor, ctx);
         }
 
         const detail: Record<string, unknown> = {};
@@ -1476,6 +1410,81 @@ class GuardImplementation implements VendoGuard {
     };
     if (records.atomic === undefined) await records.put(input);
     else await records.atomic.insertIfAbsent(input);
+  }
+
+  /** The dispatch itself, once the guard has said run and the freeze has been
+   *  re-read: resolve the grant the call runs under, then hand it to the
+   *  registry exactly once per effect key. */
+  async #runOnce(
+    tools: ToolRegistry,
+    call: ToolCall,
+    decision: GuardDecision,
+    descriptor: ToolDescriptor,
+    ctx: RunContext,
+  ): Promise<ToolOutcome> {
+    const grant = await this.#grantForExecution(decision, call, descriptor, ctx);
+    // CORE-2: `grant` is a first-class RunContext field — no cast needed.
+    const executeCtx = grant === undefined ? ctx : { ...ctx, grant };
+    // Build contract §7: for a MUTATING call, a key that already succeeded
+    // returns its recorded outcome INSTEAD of executing. The check sits
+    // here, after the guard has said run and before the registry is
+    // touched, because that is the only point where skipping is both safe
+    // (authority was still checked) and effective (the effect is avoided).
+    //
+    // The DECLARED label decides — the dev's label is final (two-vote
+    // grading removed), so a declared `read` is silent and takes no
+    // receipt.
+    const risk = descriptor.risk;
+    const mutating = risk === "write" || risk === "destructive";
+    const base = mutating ? effectBaseKey(ctx, call) : undefined;
+    const key = base === undefined ? undefined : effectKeyOf(base, this.#effectOrdinal(base, call.id));
+    const recorded = key === undefined ? undefined : await this.#recordedEffect(key);
+    if (recorded !== undefined) return recorded;
+    // Finding 14 (TOCTOU): two concurrent identical calls both read "no
+    // receipt" and both executed. Share one in-flight execution per key
+    // so the second awaits the first's outcome instead of repeating it.
+    const inFlight = key === undefined ? undefined : this.#effectsInFlight.get(key);
+    if (inFlight !== undefined) return await inFlight;
+    const run = (async (): Promise<ToolOutcome> => {
+      try {
+        return await tools.execute(call, executeCtx);
+      } catch (error) {
+        return {
+          status: "error",
+          error: {
+            code: error instanceof VendoError ? error.code : "error",
+            message: errorMessage(error),
+          },
+        };
+      }
+    })();
+    if (key !== undefined) this.#effectsInFlight.set(key, run);
+    let outcome: ToolOutcome;
+    try {
+      outcome = await run;
+    } finally {
+      if (key !== undefined) this.#effectsInFlight.delete(key);
+    }
+    // Only a SUCCESS is ledgered. A failed mutation may not have landed
+    // at all, so recording it would turn a transient upstream error into
+    // a permanent refusal to retry — the opposite of the goal.
+    if (key !== undefined && outcome.status === "ok") {
+      // The mutation ALREADY HAPPENED. A receipt-store failure must
+      // never discard it: throwing here would lose both the caller's
+      // outcome and the audit row for real, completed work. Surface it
+      // loudly and carry on — an unrecorded receipt risks a duplicate
+      // on a later re-run, which is strictly better than losing the
+      // record of a payment that went out.
+      try {
+        await this.#recordEffect(key, outcome, ctx.principal.subject);
+      } catch (error) {
+        console.error(
+          `[vendo] guard: ${call.tool} completed but its effect receipt could not be written `
+          + `(${errorMessage(error)}). A re-run of this run may repeat the call.`,
+        );
+      }
+    }
+    return outcome;
   }
 
   async #grantForExecution(


### PR DESCRIPTION
Four functions in `@vendoai/apps` and `@vendoai/guard` were doing several jobs
each behind one long body. Every one is decomposed here, and **only** decomposed:
no bug fixed, no rename beyond what a move requires, no tidying, no test touched.

## Scores (sonarjs cognitive-complexity, threshold 50)

| function | before | after |
|---|---|---|
| `packages/apps/src/agent-tools.ts` — `createAgentTools().execute` | 90 | **11** |
| `packages/apps/src/automation-plan.ts` — `validatePlan` | 58 | **31** |
| `packages/apps/src/claude-turn.ts` — `createClaudeSession`'s `drain` | 58 | **30** |
| `packages/guard/src/guard.ts` — `bind().execute` | 55 | **19** |

Nothing extracted lands anywhere near the threshold either — the worst new
function is `makeNewApp` at 18, then `stepsIssues` 19, `#runOnce` 13,
`readAssistantMessage` 13, `changeExistingApp` 10, `sessionOptions` 7.
Measured with `sonarjs/cognitive-complexity` at threshold 0 over both packages;
`packages/apps` and `packages/guard` now report **zero** functions over 50.

Nothing was refused. All four came apart along seams the code already described.

## What moved where

**`apps/agent-tools.ts`** — `execute` is a dispatcher now.
- `make-tool.ts` — `vendo_make` and its two routes: `makeNewApp` (the assembly
  seam, §4.5's escalation to the builder) and `changeExistingApp`. The `MakeCall`
  interface holds what both read — the doors, the ask, the view stream, the
  best-effort memory write — the same "one context type, one module per section"
  shape `createApps` took last week.
- `data-tools.ts` — the three `vendo_apps_data_*` doors.
- `tool-args.ts` — the argument checks all of them share.
- `agent-tools.ts` keeps the descriptor table, `AgentToolsDataDependencies`,
  `FORK_OFFER`/`errorOutcome`, and the four small tools whose whole body is a
  door call. Every symbol that moved was already module-private, so no import
  anywhere changed.

**`apps/automation-plan.ts`** — `validatePlan` hands its `steps` rules to a
`stepsIssues` collector placed beside the `scheduleIssues` one the file already
had. Same file, because that is the pattern the file already uses.

**`apps/claude-turn.ts`** — `sessionOptions` and `readAssistantMessage` are named
siblings **in this file**, deliberately not modules: `dist/claude-turn.js` is
copied verbatim into the box image (`box/build-template.mjs` line 71), so this
file may hold no relative import. The module header says so; the new
`sessionOptions` doc comment repeats it so the next reader does not undo it.

**`guard/guard.ts`** — `bind().execute` keeps the four things it decides
(unknown tool · §12 unattended refusal · block/ask/run · the audit row) and hands
the dispatch to a `#runOnce` private method, where the grant, the effect key, the
in-flight share and the receipt write now sit together. The freeze re-read stays
in `execute` because it returns early past the generic audit — moving it would
have changed that.

## Purity

- **80.3% of added lines appear verbatim among removed lines** (743 added
  non-blank, 597 matched; indentation-insensitive, since un-nesting a block
  necessarily re-indents it). Every one of the 146 unmatched lines is a module
  header, an import, a function signature, a call site, or the `MakeCall`
  interface — audited line by line, no invented logic.
- **0 test files changed.** Not one, not even an import path.
- **No public surface changed.** `packages/apps/src/index.ts` and the guard's
  exports are byte-identical; the three new modules are package-internal and are
  not re-exported.
- Every load-bearing "why" comment travelled with the code it explains.

## Tandem rule — a `vendo-web` no-op

Confirmed by grep over the clone at `/home/ubuntu/repos/vendo-web`:

```
$ grep -rn --include='*.ts' --include='*.tsx' '@vendoai/apps/\|@vendoai/guard/' . | grep -v node_modules | wc -l
0            # no deep imports into either package

$ grep -rn -e 'agent-tools' -e 'make-tool' -e 'data-tools' -e 'tool-args' \
           -e 'runMakeTool' -e 'stepsIssues' -e 'claude-turn' . | grep -v node_modules
(nothing — the only 'validatePlan' hits are the console's own unrelated
 billing-plan validator in apps/console/scripts/commerce-demo.ts, and the only
 'guard.ts' hit is a prose reference in apps/console/lib/guard/view.ts)
```

No wire format, store collection, blob namespace or emitted artifact is touched:
this is internal restructuring inside two server packages.

## Gate

```
pnpm build --filter=@vendoai/apps... --filter=@vendoai/guard...
  Tasks:    3 successful, 3 total          BUILD=0

packages/apps  $ VITEST_MIN_FORKS=1 VITEST_MAX_FORKS=2 VITEST_MIN_THREADS=1 VITEST_MAX_THREADS=2 npx vitest run
  Test Files  90 passed | 3 skipped (93)
       Tests  1046 passed | 18 skipped (1064)     EXIT=0

packages/guard $ VITEST_MIN_FORKS=1 VITEST_MAX_FORKS=2 VITEST_MIN_THREADS=1 VITEST_MAX_THREADS=2 npx vitest run
  Test Files  26 passed | 1 skipped (27)
       Tests  278 passed | 3 skipped (281)        EXIT=0

pnpm typecheck
  Tasks:    42 successful, 42 total        TSC=0

pnpm lint
  Tasks:    3 successful, 3 total          LINT=0
```

Suites ran one package at a time (guard boots an embedded PGlite per worker).
Every moved symbol was additionally grepped repo-wide **including test
directories** — all were module-private before the move, and no test, fixture,
example or corpus file names any of them.

Two changesets, one per published package, both `patch`, both stating that no
public surface changed. The throwaway `eslint.cc.config.mjs` and the devDeps it
needed were reverted before the commit; `package.json` and `pnpm-lock.yaml` are
untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored four dense functions into focused helpers across `@vendoai/apps` and `@vendoai/guard` with no behavior or API changes. Cognitive complexity drops significantly (e.g., `createAgentTools().execute` 90→11).

- **Refactors**
  - `@vendoai/apps`: `agent-tools.ts` `execute` is now a dispatcher; `vendo_make` routes moved to `make-tool.ts`; `vendo_apps_data_*` moved to `data-tools.ts`; shared arg checks in `tool-args.ts`; `automation-plan.ts` adds `stepsIssues` and `validatePlan` delegates; `claude-turn.ts` adds in-file `sessionOptions` and `readAssistantMessage` helpers (no imports).
  - `@vendoai/guard`: `bind().execute` delegates dispatch to private `#runOnce` (grant resolution, effect key, in-flight sharing, receipt write).

<sup>Written for commit edf8cdc9b63e0dfc9c5661b60da0f79c3b11a6d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

