### PR TITLE
fix(vendo): a repo's dotenv may no longer choose the coding-agent endpoint

### DIFF
--- a/.changeset/a-repo-cannot-choose-the-agent-endpoint.md
+++ b/.changeset/a-repo-cannot-choose-the-agent-endpoint.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/vendo": minor
+---
+
+A project file may no longer choose the coding-agent endpoint. `readEnvFiles` — the CLI's one dotenv reader — now drops `ANTHROPIC_BASE_URL` from `.env` and `.env.local`; only the developer's own shell (or an explicit programmatic env) may set it. Before this, `vendo init` on a freshly cloned repo would send its source-bearing extraction prompts (catalog entries plus verbatim quotes from the host's own files) to whatever endpoint the repo's `.env` named, whenever the developer had no Anthropic credential of their own — a repo-supplied bare base URL counted as an own credential on every Claude rung, which also suppressed the Vendo Cloud gateway that would otherwise have carried the run. This is a deliberate security-posture change, not a bug fix: a repo that relied on `.env` to point Vendo's extraction at a corporate gateway must now export `ANTHROPIC_BASE_URL` in the developer's shell instead. Nothing else moves — a shell `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN` or `CLAUDE_CODE_OAUTH_TOKEN` still reaches an engine on every path, including `vendo sync --ai` on an incremental run.

--- a/packages/vendo/src/cli/extract/claude-cli-harness.test.ts
+++ b/packages/vendo/src/cli/extract/claude-cli-harness.test.ts
@@ -210,7 +210,13 @@ describe("claudeCliHarness", () => {
       })).toBe("your CLAUDE_CODE_OAUTH_TOKEN");
     });
 
-    it("labels the rung with ANTHROPIC_BASE_URL when only a custom base URL is set (no token), not the Vendo Cloud key", async () => {
+    it("labels the rung with the DEVELOPER'S OWN ANTHROPIC_BASE_URL (no token), not the Vendo Cloud key", async () => {
+      // A bare base URL is still a credential (mTLS/proxy auth) and still wins
+      // — but only when it is the developer's, which by the time an env
+      // reaches a rung is the only kind there is: readEnvFiles refuses to
+      // carry one out of `.env`/`.env.local`, so an env like this one can only
+      // have come from the shell or an explicit programmatic caller. The seam
+      // proving the project half is closed lives in sync-flow.test.ts.
       const harness = claudeCliHarness({ probeBinary: async () => true, probeLogin: async () => false });
       expect(await harness.availability({
         root: "/x",

--- a/packages/vendo/src/cli/extract/claude-cli-harness.ts
+++ b/packages/vendo/src/cli/extract/claude-cli-harness.ts
@@ -27,6 +27,12 @@ import { extractionModelPin, type ExtractionHarness, type ExtractionRunInput } f
  * runs on Vendo Cloud's model gateway instead of degrading to unavailable
  * (see gateway-fuel.ts). Own credential always wins — this never overrides a
  * working ANTHROPIC_API_KEY, login, or any of those env vars.
+ *
+ * "Own" is provenance, not spelling: the ANTHROPIC_BASE_URL this rung honors
+ * (and labels, and refuses to overlay) is the developer's own — from their
+ * shell, or explicitly passed by a programmatic caller. A project's `.env`
+ * cannot supply one; sync-flow.ts's readEnvFiles drops it before any env
+ * reaches here, so a cloned repo can never pick where its source is sent.
  */
 
 const DISALLOWED_TOOLS = [

--- a/packages/vendo/src/cli/extract/gateway-fuel.ts
+++ b/packages/vendo/src/cli/extract/gateway-fuel.ts
@@ -19,6 +19,15 @@ import { resolveCloudBaseUrl } from "../cloud/client.js";
  * inference through Vendo's gateway and bill their org's meter — this
  * module checks it directly rather than trusting callers to remember.
  *
+ * That invariant is about the DEVELOPER's own endpoint, and for
+ * ANTHROPIC_BASE_URL (see AGENT_ENDPOINT_ENV_VAR) it holds only because a
+ * project file can no longer supply one: `readEnvFiles` in sync-flow.ts
+ * drops the key from `.env`/`.env.local`, at the one point where file-vs-
+ * shell provenance is still known. By the time any env reaches this module
+ * the key can only have come from the developer's shell or a programmatic
+ * caller, so "is it set" and "did the developer choose it" are the same
+ * question again — which is why a flat env map is enough to answer it here.
+ *
  * The gateway must be able to refuse this traffic for free-plan orgs
  * (spec's free-plan policy), so every request gets tagged with the
  * INIT_PURPOSE_HEADER — a plain "name: value" line via Claude Code's
@@ -43,6 +52,17 @@ export const INIT_PURPOSE_HEADER_VALUE = "init";
  */
 export const EXTRACTION_MODEL_ID = "vendo-extract";
 
+/**
+ * The one env var that REDIRECTS a coding agent's source-bearing prompts to a
+ * different endpoint, rather than merely paying for them. A project file may
+ * never choose it: `.env` ships with the repo, so honoring one would let a
+ * freshly cloned repo pick where its own source code gets sent whenever the
+ * developer has no Anthropic credential of their own. Only the developer's
+ * shell (or a programmatic caller passing an explicit env) may set it —
+ * enforced in sync-flow.ts's `readEnvFiles`, the CLI's one dotenv reader.
+ */
+export const AGENT_ENDPOINT_ENV_VAR = "ANTHROPIC_BASE_URL";
+
 /** Env vars that Claude Code itself accepts as an own credential besides
  *  ANTHROPIC_API_KEY and a CLI login: a corporate-gateway auth token, a
  *  device-flow OAuth token, or a custom base URL with no token at all
@@ -50,11 +70,12 @@ export const EXTRACTION_MODEL_ID = "vendo-extract";
  *  probe, so any caller folding "own credential" into its own predicate
  *  (claude-cli-harness.ts's availability()/run()) must check these three
  *  directly rather than relying solely on the login probe. Exported so
- *  every harness checks the identical set. */
+ *  every harness checks the identical set. The base URL counts only when it
+ *  is the developer's own — see AGENT_ENDPOINT_ENV_VAR. */
 export const OWN_CREDENTIAL_ENV_VARS = [
   "ANTHROPIC_AUTH_TOKEN",
   "CLAUDE_CODE_OAUTH_TOKEN",
-  "ANTHROPIC_BASE_URL",
+  AGENT_ENDPOINT_ENV_VAR,
 ] as const;
 
 function nonBlank(value: string | undefined): value is string {

--- a/packages/vendo/src/cli/extract/npx-engine-harness.ts
+++ b/packages/vendo/src/cli/extract/npx-engine-harness.ts
@@ -34,7 +34,10 @@ import { extractionModelPin, type ExtractionHarness, type ExtractionRunInput } f
  * always wins — availability() must label these honestly (not as "Vendo
  * Cloud key") since composeGatewayFuel itself refuses to overlay onto any of
  * them; a wrong label here would make the consent prompt lie about what
- * run() actually does.
+ * run() actually does. As on the PATH rung, the base URL that counts is the
+ * developer's own (shell or an explicit programmatic env) — a project's
+ * `.env` cannot supply one, because sync-flow.ts's readEnvFiles drops it
+ * before any env reaches this rung.
  */
 
 export const ENGINE_PACKAGE_NAME = "@anthropic-ai/claude-code";

--- a/packages/vendo/src/cli/sync-flow.test.ts
+++ b/packages/vendo/src/cli/sync-flow.test.ts
@@ -3,7 +3,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { describeDevCredential, resolveDevCredential } from "../dev-creds/resolve.js";
+import { claudeCliHarness } from "./extract/claude-cli-harness.js";
 import type { ExtractionHarness } from "./extract/harness.js";
+import { npxEngineHarness } from "./extract/npx-engine-harness.js";
 import type { Output } from "./shared.js";
 import { readEnvFiles, runSyncFlow, type SyncFlowOptions, type SyncFlowResult } from "./sync-flow.js";
 
@@ -72,6 +74,19 @@ const JUDGED_CATALOG = {
     },
   })}\n`,
 };
+
+/** One never-judged tool, so incremental mode has real work and the run
+ *  reaches the engine rather than the up-to-date shortcut. */
+const UNJUDGED_TOOLS = `${JSON.stringify({
+  format: "vendo/tools@3",
+  tools: [{
+    name: "host_a",
+    description: "Use this to call host_a.",
+    inputSchema: { type: "object", properties: {} },
+    risk: "read",
+    binding: { kind: "route", method: "GET", path: "/api/a", argsIn: "query" },
+  }],
+})}\n`;
 
 const offline = (async () => { throw new Error("offline"); }) as unknown as typeof fetch;
 
@@ -222,26 +237,13 @@ describe("a harness-owned credential (Claude Code OAuth / auth token / custom en
     run: async () => "```json\n" + JSON.stringify({ tools: [], narrative: "" }) + "\n```",
   };
 
-  /** One never-judged tool, so incremental mode has real work and the run
-   *  reaches the engine rather than the up-to-date shortcut. */
-  const UNJUDGED = `${JSON.stringify({
-    format: "vendo/tools@3",
-    tools: [{
-      name: "host_a",
-      description: "Use this to call host_a.",
-      inputSchema: { type: "object", properties: {} },
-      risk: "read",
-      binding: { kind: "route", method: "GET", path: "/api/a", argsIn: "query" },
-    }],
-  })}\n`;
-
   /** A host holding ONLY a harness-owned credential: no API key on any rung. */
   async function oauthHost(): Promise<string> {
     for (const name of ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY", "VENDO_API_KEY", "VENDO_DEV_CREDENTIAL"]) {
       vi.stubEnv(name, "");
     }
     const root = await host({ ".env": "CLAUDE_CODE_OAUTH_TOKEN=oauth-tok\n" });
-    await writeFile(join(root, ".vendo", "tools.json"), UNJUDGED, "utf8");
+    await writeFile(join(root, ".vendo", "tools.json"), UNJUDGED_TOOLS, "utf8");
     return root;
   }
 
@@ -267,6 +269,107 @@ describe("a harness-owned credential (Claude Code OAuth / auth token / custom en
     expect(env["CLAUDE_CODE_OAUTH_TOKEN"]).toBe("oauth-tok");
     expect(await resolveDevCredential({ env })).toEqual({ rung: "none" });
     expect(describeDevCredential(await resolveDevCredential({ env }))).toBe("no model credential found");
+  });
+});
+
+describe("the coding-agent endpoint is the developer's to choose, never the project's", () => {
+  const REPO_ENDPOINT = "https://repo-chose-this.example.com";
+  const SHELL_ENDPOINT = "https://anthropic.corp.example.com";
+
+  /** stdout the judgment pass accepts, so the run reaches the child spawn
+   *  whose env is what these tests are actually about. */
+  const JUDGED = "```json\n" + JSON.stringify({ tools: [], narrative: "" }) + "\n```";
+
+  /** Both Claude rungs, built for real, with only the child spawn stubbed:
+   *  the env under test is the one the REAL harness hands the REAL spawn,
+   *  produced by the REAL dotenv reader — no stub on either side of the seam. */
+  const rungs: ReadonlyArray<{
+    name: string;
+    harness: (capture: (env: NodeJS.ProcessEnv) => void) => ExtractionHarness;
+  }> = [
+    {
+      name: "the PATH `claude` rung",
+      harness: (capture) => claudeCliHarness({
+        probeBinary: async () => true,
+        probeLogin: async () => false,
+        exec: async (_args, options) => {
+          capture(options.env);
+          return { stdout: JUDGED, stderr: "", code: 0 };
+        },
+      }),
+    },
+    {
+      name: "the npx-fetched engine rung",
+      harness: (capture) => npxEngineHarness({
+        exec: async (_args, options) => {
+          capture(options.env);
+          return { stdout: JUDGED, stderr: "", code: 0 };
+        },
+      }),
+    },
+  ];
+
+  /** A host with a Cloud key and one never-judged tool, so an incremental
+   *  `--ai` run has real work and actually spawns the child. No credential of
+   *  the developer's own — the exposed case. */
+  async function keyedHost(dotenv: string): Promise<string> {
+    for (const name of [
+      "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY",
+      "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_BASE_URL",
+      "VENDO_API_KEY", "VENDO_CLOUD_URL", "VENDO_DEV_CREDENTIAL",
+    ]) {
+      vi.stubEnv(name, "");
+    }
+    const root = await host({ ".env": `VENDO_API_KEY=vnd_x\n${dotenv}` });
+    await writeFile(join(root, ".vendo", "tools.json"), UNJUDGED_TOOLS, "utf8");
+    return root;
+  }
+
+  async function spawnEnvFor(
+    rung: (capture: (env: NodeJS.ProcessEnv) => void) => ExtractionHarness,
+    root: string,
+  ): Promise<NodeJS.ProcessEnv | undefined> {
+    let captured: NodeJS.ProcessEnv | undefined;
+    const messages = captureOutput();
+    await flow({
+      root,
+      output: messages.output,
+      fetchImpl: offline,
+      ai: true,
+      judge: { harnesses: [rung((env) => { captured ??= env; })] },
+    });
+    return captured;
+  }
+
+  for (const { name, harness } of rungs) {
+    it(`${name}: a project dotenv naming a base URL never reaches the child process`, async () => {
+      const root = await keyedHost(`ANTHROPIC_BASE_URL=${REPO_ENDPOINT}\n`);
+      const env = await spawnEnvFor(harness, root);
+      // The child really ran — it just ran on Vendo Cloud's gateway (the Cloud
+      // key IS the developer's own credential here), never on the endpoint the
+      // repo tried to pick.
+      expect(env).toBeDefined();
+      expect(env?.ANTHROPIC_BASE_URL).not.toContain("repo-chose-this");
+      expect(env?.ANTHROPIC_AUTH_TOKEN).toBe("vnd_x");
+    });
+
+    it(`${name}: the developer's own SHELL base URL still reaches the child process`, async () => {
+      const root = await keyedHost("");
+      vi.stubEnv("ANTHROPIC_BASE_URL", SHELL_ENDPOINT);
+      const env = await spawnEnvFor(harness, root);
+      expect(env?.ANTHROPIC_BASE_URL).toBe(SHELL_ENDPOINT);
+      // Own credential wins: no gateway fuel overlaid onto the dev's endpoint.
+      expect(env?.ANTHROPIC_AUTH_TOKEN).toBeFalsy();
+    });
+  }
+
+  it("readEnvFiles drops a dotenv base URL and keeps the shell's — provenance, not variable name", async () => {
+    const root = await host({ ".env": `ANTHROPIC_BASE_URL=${REPO_ENDPOINT}\nVENDO_API_KEY=vnd_x\n` });
+    expect(await readEnvFiles(root, {})).toEqual({ VENDO_API_KEY: "vnd_x" });
+    // A blank shell value must NOT fall back to the file one either.
+    expect((await readEnvFiles(root, { ANTHROPIC_BASE_URL: "" }))["ANTHROPIC_BASE_URL"]).toBe("");
+    expect((await readEnvFiles(root, { ANTHROPIC_BASE_URL: SHELL_ENDPOINT }))["ANTHROPIC_BASE_URL"])
+      .toBe(SHELL_ENDPOINT);
   });
 });
 

--- a/packages/vendo/src/cli/sync-flow.ts
+++ b/packages/vendo/src/cli/sync-flow.ts
@@ -9,6 +9,7 @@ import {
   writePushComponents,
 } from "./cloud/host-components.js";
 import { pushPinBaselines } from "./cloud/pin-baselines.js";
+import { AGENT_ENDPOINT_ENV_VAR } from "./extract/gateway-fuel.js";
 import type { ThemeStageInput } from "./extract/stages.js";
 import { runProseStages } from "./init-judgment.js";
 import { selectJudgmentEngines, type AvailableEngine } from "./judge/engine.js";
@@ -110,6 +111,16 @@ export interface SyncFlowResult {
  * invisible and the run went structural-only with no signal why), sync read
  * both through doctor's copy, and telemetry had a third. Minimal KEY=VALUE
  * parser: `export ` prefix, matching quotes, `#` comment lines.
+ *
+ * ONE exception, and it is a security boundary rather than a parsing rule:
+ * the files may not supply AGENT_ENDPOINT_ENV_VAR. Everything downstream
+ * sees a flat map and so cannot tell a shell value from a file one; this is
+ * the last point where that provenance is still known, so it is where the
+ * distinction gets made. Dropping the key here (rather than filtering it at
+ * each consumer) carries provenance to every rung for free: below this line
+ * the only remaining source is `processEnv`, and every consumer that
+ * re-merges `process.env` over its input — both Claude rungs do — therefore
+ * still honors the developer's own shell endpoint.
  */
 export async function readEnvFiles(
   root: string,
@@ -121,6 +132,7 @@ export async function readEnvFiles(
     if (source === null) continue;
     Object.assign(fromFiles, parseDotEnv(source));
   }
+  delete fromFiles[AGENT_ENDPOINT_ENV_VAR];
   const merged: Record<string, string | undefined> = { ...fromFiles, ...processEnv };
   for (const [key, value] of Object.entries(processEnv)) {
     if ((value ?? "").trim() === "" && fromFiles[key] !== undefined) merged[key] = fromFiles[key];


### PR DESCRIPTION
## What

A project file may **never** choose the coding-agent endpoint. `readEnvFiles` — the CLI's one dotenv reader — now drops `ANTHROPIC_BASE_URL` from `.env` and `.env.local`. Only the developer's own shell (or an explicit programmatic env) may set it.

**This is a deliberate security-posture change, not a bug fix.** A repo that relied on a dotenv to point Vendo's extraction at a corporate gateway must now export `ANTHROPIC_BASE_URL` in the developer's shell instead. `minor` changeset for `@vendoai/vendo`.

## Why — measured, on `origin/main`

`sync-flow.ts` builds the coding agent's env from `readEnvFiles(root)`, which reads the project's dotenv files before merging `process.env`. A bare `ANTHROPIC_BASE_URL` with no token beside it counted as an own credential on every Claude rung — an invariant documented at `extract/gateway-fuel.ts` with a committed test blessing it.

Net effect: **`vendo init` / `vendo sync --ai` on a freshly cloned repo sent source-bearing prompts (catalog entries plus verbatim quotes from the host's own files) to an endpoint the repo chose**, whenever the developer had no Anthropic credential of their own. It also suppressed the Vendo Cloud gateway that would otherwise have carried the run. Reproduced end-to-end at the CLI with a shim `claude` on PATH, a dotenv naming `https://repo-chose-this.example.com` plus a Cloud key, and no shell credential:

```
BEFORE (origin/main): child ANTHROPIC_BASE_URL=https://repo-chose-this.example.com
AFTER  (this branch): child ANTHROPIC_BASE_URL=https://console.vendo.run/api/v1
                      child ANTHROPIC_CUSTOM_HEADERS=x-vendo-purpose: init
```

The only mitigation before this was the merge order (`{...fromFiles, ...processEnv}`), so a *non-blank* shell value always won — a blank one did not, and a developer with **no** credential of their own had nothing to win with.

## How provenance is carried

Everything downstream of `readEnvFiles` sees a **flat env map** and so cannot tell a shell value from a file one. Rather than adding a provenance channel with one consumer, the distinction is made at the last point where it is still known: the key is dropped from the file layer, never flattened in. Below that line the only remaining source for `ANTHROPIC_BASE_URL` is `processEnv`, and every consumer that re-merges `process.env` over its input — **both Claude rungs do**, `{...process.env, ...input.env}` — therefore still honors the developer's own shell endpoint, unchanged and with no new plumbing. Provenance, not variable name: same spelling, different source, different answer.

The constant lives with the invariant it defends (`AGENT_ENDPOINT_ENV_VAR` in `extract/gateway-fuel.ts`) and is what `OWN_CREDENTIAL_ENV_VARS` names.

## The blessing test — an intentional behaviour change, stated out loud

`claude-cli-harness.test.ts`'s *"labels the rung with ANTHROPIC_BASE_URL when only a custom base URL is set (no token)"* encoded the decision that a bare base URL is an own credential. That decision **still stands** — a bare base URL is still mTLS/proxy auth and still wins — but it now means something narrower, so the test says so: it is retitled to *"labels the rung with the **DEVELOPER'S OWN** ANTHROPIC_BASE_URL"*, with a comment recording that an env reaching a rung can no longer contain a project-supplied one and pointing at the seam test that proves it. Editing a test that encodes a deliberate decision needs a public justification; this is it. No assertion was weakened or deleted.

`extract/gateway-fuel.ts`'s module INVARIANT now states the same thing where the rule lives: the invariant is about the *developer's* endpoint, and a flat env map is enough to recognize one precisely because a project file can no longer put one there. Both rung headers say it too.

## Tests — failing first

Red commit `83563b0f1`, in the existing behavior-named suite (`cli/sync-flow.test.ts`), one new describe: **"the coding-agent endpoint is the developer's to choose, never the project's"**.

- `<rung>: a project dotenv naming a base URL never reaches the child process` — for **both** Claude rungs. Both sides of the seam are real: the dotenv is written to disk and read by the real `readEnvFiles`; the env asserted on is the one the real `claudeCliHarness` / `npxEngineHarness` hands the real spawn (only the spawn itself is a seam). Non-vacuous — the child **does** run, on Vendo Cloud's gateway.
- **Companion**, so the fix cannot drift into blocking both: `<rung>: the developer's own SHELL base URL still reaches the child process` — green before and after.
- `readEnvFiles drops a dotenv base URL and keeps the shell's` — including that a *blank* shell value must not fall back to the file one.

Red run: 3 failed, `expected 'https://repo-chose-this.example.com' not to contain 'repo-chose-this'` on both rungs. Green after `bfe973d1e`.

## #1008 is intact

`18d35bda4` fixed `vendo sync --ai` on an incremental run reporting no engine for developers with a Claude Code OAuth token, an auth token, or a custom endpoint. Both of its tests are untouched and green, as are `judge/engine.test.ts`'s three `it.each` cases (`ANTHROPIC_AUTH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_BASE_URL` each still pass the credential gate). Proven at the CLI too: a shell `ANTHROPIC_BASE_URL` gives `judgment (your ANTHROPIC_BASE_URL)`; a shell `CLAUDE_CODE_OAUTH_TOKEN` gives `judgment (your CLAUDE_CODE_OAUTH_TOKEN)`.

## Finding: the same hole exists for the other own-credential vars — NOT changed here

A project dotenv supplying `ANTHROPIC_AUTH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` still reaches the coding agent, verified. #1008's own regression test is literally that shape (a dotenv holding `CLAUDE_CODE_OAUTH_TOKEN`), so it is a supported, documented story, not an oversight. It is also a **materially smaller** problem: those vars pay for the traffic, they do not redirect it — source still goes to `api.anthropic.com`. The scope of this PR is the endpoint specifically. Two notes for whoever picks the wider question up:

- `.env.local` is the developer's own file by convention (git-ignored; `vendo login` writes the Cloud key there) while `.env` commonly ships with the repo. This PR treats both alike, per the decision as written; a later pass may want to split them.
- `docs/quickstart.md` lists `ANTHROPIC_BASE_URL` among the credentials the rungs accept without saying it must come from the shell. Out of this PR's file-set — flagged, not edited.

## vendo-web

No companion PR needed. `vendo-web` never reads `ANTHROPIC_BASE_URL`, `readEnvFiles`, or anything from `gateway-fuel.ts`. Its only tie to this area is the cross-repo `x-vendo-purpose: init` header contract in `apps/console/lib/api/messages-gateway.ts` (mirrored in `apps/console/tests/messages-gateway.test.ts`) — the header, the overlay shape and the gateway's own policy are all unchanged. The only console-visible effect is that gateway fuel now applies in cases where a repo's dotenv used to suppress it, i.e. more legitimate traffic on the same contract.

## Evidence

- `pnpm build --filter=@vendoai/vendo...` — 13/13 tasks successful
- `pnpm typecheck` — 42/42 successful · `pnpm lint` — 3/3 successful, 0 errors
- Owned + all `readEnvFiles`-consumer suites (`sync-flow`, `extract/`, `judge/`, `doctor`, `config`, `init`, `sync`) — **522 passed, 3 skipped, 0 failed**
- The tsconfig-excludes-tests trap: `tsc --noEmit` over `packages/vendo/src` **including tests**, error set diffed against `origin/main` — **98 errors on both, `diff` empty**, no new type errors
- CLI: `vendo doctor` returns a real 17-check report in 2.2s; `vendo init --yes --ai` and `vendo sync --ai` both reach an engine and both spawn on the gateway, never on the repo's endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block repos from choosing the coding‑agent endpoint by ignoring `ANTHROPIC_BASE_URL` from project dotenvs. Only the developer’s shell (or an explicit programmatic env) can set it; runs otherwise use the Vendo Cloud gateway.

- **Migration**
  - If your repo set `ANTHROPIC_BASE_URL` in `.env`/`.env.local`, move it to each developer’s shell.
  - Other own-credential envs remain supported: `ANTHROPIC_AUTH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`.

<sup>Written for commit bfe973d1ebd9c990ab7c4878dfe847acaa6b51da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

