### PR TITLE
refactor(actions): the ten complexity monsters become named helpers

### DIFF
--- a/.changeset/dull-donkeys-repeat.md
+++ b/.changeset/dull-donkeys-repeat.md
@@ -1,0 +1,7 @@
+---
+"@vendoai/actions": patch
+---
+
+Decompose the ten highest cognitive-complexity functions in `@vendoai/actions`
+into named helpers alongside them. Internal restructuring only — no public
+surface changed, no behaviour changed, and no test file was touched.

--- a/packages/actions/src/runtime/registry.ts
+++ b/packages/actions/src/runtime/registry.ts
@@ -511,25 +511,36 @@ async function executeServerAction(
   return projected.ok ? projected.output : error("server-action-error", `Server action ${key} returned a non-JSON value: ${projected.message}`);
 }
 
-async function executeHost(config: RegistryConfig, tool: ExtractedTool, call: ToolCall, ctx: RunContext): Promise<ToolOutcome> {
-  if (!isArgsObject(call.args)) return error("validation", `Arguments for ${call.tool} must be an object`);
-  if (tool.binding.kind === "server-action") return executeServerAction(config, tool.binding, call, ctx);
+/** The HTTP request one host tool call becomes. */
+interface HostRequest {
+  url: URL;
+  method: HttpMethod;
+  body: string | undefined;
+}
 
+/** Bind the call's arguments onto the tool's declared shape: the tRPC envelope,
+ *  or path substitution and then query/body per the binding's `argsIn`. */
+function hostRequest(
+  config: RegistryConfig,
+  binding: RouteBinding | OpenApiBinding | TrpcBinding,
+  call: ToolCall,
+  args: Record<string, unknown>,
+): { request: HostRequest } | { error: ToolOutcome } {
   let url: URL;
   let method: HttpMethod;
   let body: string | undefined;
   try {
-    if (tool.binding.kind === "trpc") {
-      const request = trpcRequest(tool.binding, call.args, config.baseUrl);
+    if (binding.kind === "trpc") {
+      const request = trpcRequest(binding, args, config.baseUrl);
       url = request.url;
       method = request.method;
       body = request.body;
     } else {
-      method = tool.binding.method;
-      const substituted = withPathArgs(tool.binding.path, call.args);
-      url = resolveUrl({ ...tool.binding, path: substituted.path }, config.baseUrl);
-      if (tool.binding.kind === "route") {
-        if (tool.binding.argsIn === "query") {
+      method = binding.method;
+      const substituted = withPathArgs(binding.path, args);
+      url = resolveUrl({ ...binding, path: substituted.path }, config.baseUrl);
+      if (binding.kind === "route") {
+        if (binding.argsIn === "query") {
           for (const [key, value] of Object.entries(substituted.remaining)) appendQuery(url, key, value);
         } else {
           body = JSON.stringify(substituted.remaining);
@@ -544,23 +555,74 @@ async function executeHost(config: RegistryConfig, tool: ExtractedTool, call: To
       }
     }
   } catch (cause) {
-    return error("validation", cause instanceof Error ? cause.message : `Invalid arguments for ${call.tool}`);
+    return { error: error("validation", cause instanceof Error ? cause.message : `Invalid arguments for ${call.tool}`) };
   }
+  return { request: { url, method, body } };
+}
 
-  let headers: Record<string, string>;
-  let actAsMinted = false;
+/** The present user's own credentials, forwarded only where the binding and the
+ *  configured origin allow it — and never silently when they do not. */
+async function presentHeaders(
+  config: RegistryConfig,
+  tool: ExtractedTool,
+  call: ToolCall,
+  ctx: RunContext,
+  url: URL,
+): Promise<{ headers: Record<string, string> } | { error: ToolOutcome }> {
+  const forwardsPresentHeaders = mayForwardPresentHeaders(
+    tool.binding,
+    url,
+    config.baseUrl,
+    config.baseUrlTrusted ?? true,
+  );
+  if (!forwardsPresentHeaders && hasInboundAuthHeaders(ctx)) {
+    const reason = config.baseUrlTrusted === false
+      ? "untrusted-host-origin" as const
+      : "cross-origin-binding" as const;
+    if (config.onPresentCredentialsNotForwarded !== undefined) {
+      try {
+        await config.onPresentCredentialsNotForwarded({ ctx, tool: descriptorOf(tool), reason });
+      } catch {
+        // A warning sink must never turn a host API call into a product failure.
+      }
+    }
+    // "untrusted-host-origin" only (09-vendo §2 install-dx wave 1.1):
+    // "cross-origin-binding" always stays warn-only, in every policy.
+    if (reason === "untrusted-host-origin" && config.untrustedOriginPolicy === "fail") {
+      return {
+        error: error(
+          "blocked",
+          `Present credentials for ${call.tool} cannot be forwarded because VENDO_BASE_URL is not set. `
+            + "Set VENDO_BASE_URL to this deployment's full public URL (path prefix included) — "
+            + "or VENDO_HOST_API_URL when the host API answers on another origin — and restart the server.",
+        ),
+      };
+    }
+  }
+  return { headers: forwardsPresentHeaders ? forwardedHeaders(ctx) : {} };
+}
+
+/** How this call authenticates to the host: the ActAs seam for away and MCP,
+ *  the present user's forwarded credentials otherwise. */
+async function hostHeaders(
+  config: RegistryConfig,
+  tool: ExtractedTool,
+  call: ToolCall,
+  ctx: RunContext,
+  url: URL,
+): Promise<{ headers: Record<string, string>; actAsMinted: boolean } | { error: ToolOutcome }> {
   if (ctx.presence === "away") {
-    if (!config.actAs) return error("not-implemented", "away execution isn't set up for this product");
+    if (!config.actAs) return { error: error("not-implemented", "away execution isn't set up for this product") };
     const grant = (ctx as ActionsRunContext).grant;
-    if (!grant) return error("validation", "away execution requires a captured grant");
+    if (!grant) return { error: error("validation", "away execution requires a captured grant") };
     const authed = await actAsAuth(config.actAs, ctx.principal, grant, {
       declined: "the host declined away execution for this action",
       failed: "away authentication failed",
     });
-    if ("error" in authed) return authed.error;
-    headers = authed.headers;
-    actAsMinted = true;
-  } else if (ctx.venue === "mcp" || (ctx as ActionsRunContext).mcpConsent !== undefined) {
+    if ("error" in authed) return { error: authed.error };
+    return { headers: authed.headers, actAsMinted: true };
+  }
+  if (ctx.venue === "mcp" || (ctx as ActionsRunContext).mcpConsent !== undefined) {
     // 04 §4 / 10-mcp §2.1 / §3: an MCP-OAuth user has no host browser session,
     // so the present path has nothing to forward — and we forward NOTHING even
     // if a forged/mis-plumbed ctx carries requestHeaders (fail-closed). Host
@@ -575,88 +637,84 @@ async function executeHost(config: RegistryConfig, tool: ExtractedTool, call: To
     // (unauthenticated for MCP users) present-forward branch. A venue="app" ctx
     // WITHOUT mcpConsent (ordinary in-product app use) never enters here.
     if (!config.actAs) {
-      return error(
-        "not-implemented",
-        "MCP host execution isn't set up for this product — the host must provide actAs (createVendo({ actAs }))",
-      );
+      return {
+        error: error(
+          "not-implemented",
+          "MCP host execution isn't set up for this product — the host must provide actAs (createVendo({ actAs }))",
+        ),
+      };
     }
     const actionsCtx = ctx as ActionsRunContext;
     // A ctx with neither a real grant nor the door's consent record did not come
     // from the door — fail closed rather than authenticate an unattested call.
     const grant = actionsCtx.grant ?? mcpConsentGrant(actionsCtx, call, tool);
-    if (!grant) return error("validation", "MCP host execution requires the door's consent context");
+    if (!grant) return { error: error("validation", "MCP host execution requires the door's consent context") };
     const authed = await actAsAuth(config.actAs, ctx.principal, grant, {
       declined: "the host declined MCP execution for this action",
       failed: "MCP authentication failed",
     });
-    if ("error" in authed) return authed.error;
-    headers = authed.headers;
-    actAsMinted = true;
-  } else {
-    const forwardsPresentHeaders = mayForwardPresentHeaders(
-      tool.binding,
-      url,
-      config.baseUrl,
-      config.baseUrlTrusted ?? true,
-    );
-    if (!forwardsPresentHeaders && hasInboundAuthHeaders(ctx)) {
-      const reason = config.baseUrlTrusted === false
-        ? "untrusted-host-origin" as const
-        : "cross-origin-binding" as const;
-      if (config.onPresentCredentialsNotForwarded !== undefined) {
-        try {
-          await config.onPresentCredentialsNotForwarded({ ctx, tool: descriptorOf(tool), reason });
-        } catch {
-          // A warning sink must never turn a host API call into a product failure.
-        }
-      }
-      // "untrusted-host-origin" only (09-vendo §2 install-dx wave 1.1):
-      // "cross-origin-binding" always stays warn-only, in every policy.
-      if (reason === "untrusted-host-origin" && config.untrustedOriginPolicy === "fail") {
-        return error(
-          "blocked",
-          `Present credentials for ${call.tool} cannot be forwarded because VENDO_BASE_URL is not set. `
-            + "Set VENDO_BASE_URL to this deployment's full public URL (path prefix included) — "
-            + "or VENDO_HOST_API_URL when the host API answers on another origin — and restart the server.",
-        );
+    if ("error" in authed) return { error: authed.error };
+    return { headers: authed.headers, actAsMinted: true };
+  }
+  const present = await presentHeaders(config, tool, call, ctx, url);
+  return "error" in present ? present : { headers: present.headers, actAsMinted: false };
+}
+
+/** The host request itself. Every failure — transport, status, body — comes back
+ *  as an outcome, so the caller's audit enrichment always runs. */
+async function fetchHostTool(
+  config: RegistryConfig,
+  tool: ExtractedTool,
+  call: ToolCall,
+  { url, method, body }: HostRequest,
+  headers: Record<string, string>,
+): Promise<ToolOutcome> {
+  try {
+    const request = config.fetch ?? defaultFetch;
+    const response = await request(url, {
+      method,
+      headers,
+      ...(body !== undefined ? { body } : {}),
+    });
+    const text = await response.text();
+    if (!response.ok) {
+      return error(
+        "http-error",
+        `${method} ${requestTarget(url)} → ${response.status}: ${text.slice(0, 200)}`,
+      );
+    }
+    if (text) {
+      try {
+        const parsed: unknown = JSON.parse(text);
+        return {
+          status: "ok",
+          output: tool.binding.kind === "trpc" ? trpcOutput(tool.binding, parsed) : parsed,
+        };
+      } catch {
+        // Successful non-JSON responses retain their HTTP status and text.
       }
     }
-    headers = forwardsPresentHeaders ? forwardedHeaders(ctx) : {};
+    return { status: "ok", output: { status: response.status, text } };
+  } catch (cause) {
+    return error("network-error", cause instanceof Error ? cause.message : `Network request failed for ${call.tool}`);
   }
+}
+
+async function executeHost(config: RegistryConfig, tool: ExtractedTool, call: ToolCall, ctx: RunContext): Promise<ToolOutcome> {
+  if (!isArgsObject(call.args)) return error("validation", `Arguments for ${call.tool} must be an object`);
+  if (tool.binding.kind === "server-action") return executeServerAction(config, tool.binding, call, ctx);
+
+  const built = hostRequest(config, tool.binding, call, call.args);
+  if ("error" in built) return built.error;
+  const { url, body } = built.request;
+
+  const authed = await hostHeaders(config, tool, call, ctx, url);
+  if ("error" in authed) return authed.error;
+  const { headers, actAsMinted } = authed;
   setHeader(headers, "accept", "application/json");
   if (body !== undefined) setHeader(headers, "content-type", "application/json");
 
-  const outcome = await (async (): Promise<ToolOutcome> => {
-    try {
-      const request = config.fetch ?? defaultFetch;
-      const response = await request(url, {
-        method,
-        headers,
-        ...(body !== undefined ? { body } : {}),
-      });
-      const text = await response.text();
-      if (!response.ok) {
-        return error(
-          "http-error",
-          `${method} ${requestTarget(url)} → ${response.status}: ${text.slice(0, 200)}`,
-        );
-      }
-      if (text) {
-        try {
-          const parsed: unknown = JSON.parse(text);
-          return {
-            status: "ok",
-            output: tool.binding.kind === "trpc" ? trpcOutput(tool.binding, parsed) : parsed,
-          };
-        } catch {
-          // Successful non-JSON responses retain their HTTP status and text.
-        }
-      }
-      return { status: "ok", output: { status: response.status, text } };
-    } catch (cause) {
-      return error("network-error", cause instanceof Error ? cause.message : `Network request failed for ${call.tool}`);
-    }
-  })();
+  const outcome = await fetchHostTool(config, tool, call, built.request, headers);
   // Audit enrichment: every actAs-authenticated host call reports the seam's
   // disposition, even when the host request itself then fails.
   return actAsMinted ? withActAs(outcome, "minted") : outcome;

--- a/packages/actions/src/runtime/steps.ts
+++ b/packages/actions/src/runtime/steps.ts
@@ -67,6 +67,45 @@ const validateForEachItems = (step: Step, value: Json): Json[] => {
   return value;
 };
 
+/**
+ * Retire the parked call and rebuild the state the walk stopped in — or, if the
+ * re-issued call parks or fails again, the result the whole walk carries out.
+ */
+async function resumedState(
+  steps: Step[],
+  invoke: (call: ToolCall) => Promise<ToolOutcome>,
+  resume: StepResumePoint,
+): Promise<{ state: WalkState } | { result: StepWalkResult }> {
+  const step = steps[resume.stepIndex];
+  if (step === undefined) {
+    return { result: validationHalt({ id: "?", tool: "?" }, "parked step is missing") };
+  }
+  // Re-issue the parked call VERBATIM (original id + args) so guard's
+  // single-use approval replay matches the approved call.
+  const outcome = await invoke(resume.pendingCall);
+  if (outcome.status === "pending-approval") {
+    return { result: { status: "parked", approvalId: outcome.approvalId, resume } };
+  }
+  if (outcome.status !== "ok") return { result: { status: "halted", outcome, step } };
+  if (resume.iterationItems === undefined) {
+    return {
+      state: {
+        stepIndex: resume.stepIndex + 1,
+        stepOutputs: { ...resume.stepOutputs, [step.id]: outcome.output },
+      },
+    };
+  }
+  return {
+    state: {
+      stepIndex: resume.stepIndex,
+      stepOutputs: { ...resume.stepOutputs },
+      iterationItems: resume.iterationItems,
+      iterationOutputs: [...(resume.iterationOutputs ?? []), outcome.output],
+      forEachIndex: (resume.forEachIndex ?? 0) + 1,
+    },
+  };
+}
+
 export async function walkSteps(options: StepWalkOptions): Promise<StepWalkResult> {
   const { steps, root, evaluate, invoke, newCallId } = options;
 
@@ -85,32 +124,9 @@ export async function walkSteps(options: StepWalkOptions): Promise<StepWalkResul
   let state: WalkState;
 
   if (options.resumeFrom !== undefined) {
-    const resume = options.resumeFrom;
-    const step = steps[resume.stepIndex];
-    if (step === undefined) {
-      return validationHalt({ id: "?", tool: "?" }, "parked step is missing");
-    }
-    // Re-issue the parked call VERBATIM (original id + args) so guard's
-    // single-use approval replay matches the approved call.
-    const outcome = await invoke(resume.pendingCall);
-    if (outcome.status === "pending-approval") {
-      return { status: "parked", approvalId: outcome.approvalId, resume };
-    }
-    if (outcome.status !== "ok") return { status: "halted", outcome, step };
-    if (resume.iterationItems === undefined) {
-      state = {
-        stepIndex: resume.stepIndex + 1,
-        stepOutputs: { ...resume.stepOutputs, [step.id]: outcome.output },
-      };
-    } else {
-      state = {
-        stepIndex: resume.stepIndex,
-        stepOutputs: { ...resume.stepOutputs },
-        iterationItems: resume.iterationItems,
-        iterationOutputs: [...(resume.iterationOutputs ?? []), outcome.output],
-        forEachIndex: (resume.forEachIndex ?? 0) + 1,
-      };
-    }
+    const resumed = await resumedState(steps, invoke, options.resumeFrom);
+    if ("result" in resumed) return resumed.result;
+    state = resumed.state;
   } else {
     state = { stepIndex: 0, stepOutputs: {} };
   }

--- a/packages/actions/src/sync/catalog-scan.ts
+++ b/packages/actions/src/sync/catalog-scan.ts
@@ -278,6 +278,160 @@ interface RegistrationCandidate {
   modulePath: string;
 }
 
+/** The module the catalog expression actually lives in — the registration
+ * file itself, or the shared registry module it imports (01 §14: one
+ * registry file serves both `createVendo` and `<VendoRoot>`). */
+interface CatalogContext {
+  constants: Map<string, tsTypes.Expression>;
+  module: FileModule;
+  modulePath: string;
+}
+
+/** State shared by every registration file one scan visits. */
+interface RegistrationRun {
+  extraction: StaticExtraction;
+  root: string;
+  scanned: Map<string, CatalogEntry>;
+  seen: Set<string>;
+  warnings: string[];
+}
+
+function arrayEntryCandidate(context: CatalogContext, element: tsTypes.Expression): RegistrationCandidate | null {
+  const rawEntry = resolvedLocalExpression(context.constants, element);
+  if (!ts.isObjectLiteralExpression(rawEntry)) return null;
+  return {
+    name: localConstantJson(context.constants, objectField(rawEntry, "name") ?? rawEntry) as unknown,
+    description: localConstantJson(context.constants, objectField(rawEntry, "description") ?? rawEntry) as unknown,
+    examples: readExamples(context.constants, rawEntry),
+    schemaExpression: objectField(rawEntry, "propsSchema"),
+    module: context.module,
+    modulePath: context.modulePath,
+  };
+}
+
+function registryEntryCandidate(context: CatalogContext, name: string, value: tsTypes.Expression): RegistrationCandidate {
+  const rawEntry = resolvedLocalExpression(context.constants, value);
+  if (!ts.isObjectLiteralExpression(rawEntry)) {
+    return { name, description: undefined, examples: undefined, schemaExpression: undefined, module: context.module, modulePath: context.modulePath };
+  }
+  // 01 §14: the registry entry's `component` reference is IGNORED by sync
+  // (and the server) — it exists so the same object serves the client.
+  return {
+    name,
+    description: localConstantJson(context.constants, objectField(rawEntry, "description") ?? rawEntry) as unknown,
+    examples: readExamples(context.constants, rawEntry),
+    schemaExpression: objectField(rawEntry, "props"),
+    module: context.module,
+    modulePath: context.modulePath,
+  };
+}
+
+/** Every `catalog:` expression a `createVendo({…})` call in this module names. */
+function catalogExpressionsIn(local: CatalogContext): tsTypes.Expression[] {
+  const found: tsTypes.Expression[] = [];
+  const visit = (node: tsTypes.Node): void => {
+    if (!ts.isCallExpression(node)
+      || !ts.isIdentifier(node.expression)
+      || node.expression.text !== "createVendo"
+      || node.arguments[0] === undefined) {
+      ts.forEachChild(node, visit);
+      return;
+    }
+    const config = resolvedLocalExpression(local.constants, node.arguments[0]);
+    if (!ts.isObjectLiteralExpression(config)) return;
+    const catalogExpression = objectField(config, "catalog");
+    if (catalogExpression !== undefined) found.push(catalogExpression);
+  };
+  visit(local.module.sf);
+  return found;
+}
+
+/** The registrations one `catalog:` expression carries, in either the array form
+ *  or the registry-object form. */
+async function catalogCandidates(
+  run: RegistrationRun,
+  local: CatalogContext,
+  catalogExpression: tsTypes.Expression,
+): Promise<RegistrationCandidate[]> {
+  let context = local;
+  let catalog = resolvedLocalExpression(local.constants, catalogExpression);
+  if (ts.isIdentifier(catalog)) {
+    // The shared-registry main path: `catalog` is imported from the one
+    // registry module both sides consume — follow the import statically.
+    const resolved = await resolveIdentifier(run.extraction, local.module, catalog.text, 0);
+    if (resolved !== null) {
+      context = {
+        constants: localConstants(resolved.module.sf),
+        module: resolved.module,
+        modulePath: relativeModulePath(run.root, resolved.module.file),
+      };
+      catalog = resolvedLocalExpression(context.constants, unwrapExpression(resolved.expr));
+    }
+  }
+  const candidates: RegistrationCandidate[] = [];
+  if (ts.isArrayLiteralExpression(catalog)) {
+    for (const element of catalog.elements) {
+      if (ts.isSpreadElement(element)) continue;
+      const candidate = arrayEntryCandidate(context, element);
+      if (candidate !== null) candidates.push(candidate);
+    }
+  } else if (ts.isObjectLiteralExpression(catalog)) {
+    for (const property of catalog.properties) {
+      if (ts.isPropertyAssignment(property)) {
+        const name = propertyName(property.name);
+        if (name !== undefined) candidates.push(registryEntryCandidate(context, name, property.initializer));
+      }
+    }
+  } else {
+    run.warnings.push(`registered component catalog in ${local.modulePath} is not a statically resolvable array or registry object; scanned entries remain authoritative`);
+  }
+  return candidates;
+}
+
+/** One candidate's catalog entry, or null when it was rejected — always with the
+ *  reason warned. `modulePath` is the REGISTRATION file's, the identity a human
+ *  reading the warning is looking for. */
+async function registeredEntry(
+  run: RegistrationRun,
+  candidate: RegistrationCandidate,
+  modulePath: string,
+): Promise<CatalogEntry | null> {
+  const { name, description, examples } = candidate;
+  if (typeof name !== "string" || !PASCAL_CASE.test(name)
+    || typeof description !== "string"
+    || (examples !== undefined && (!Array.isArray(examples) || examples.some((example) => typeof example !== "string")))) {
+    run.warnings.push(`registered component in ${modulePath} could not be serialized deterministically and was omitted`);
+    return null;
+  }
+  if (run.seen.has(name)) {
+    run.warnings.push(`registered component ${name} appears more than once; kept the first registration`);
+    return null;
+  }
+  run.seen.add(name);
+  let propsSchema: Record<string, unknown> = {};
+  let note: string | undefined;
+  if (candidate.schemaExpression !== undefined) {
+    const interpreted = await zodFromExpression(run.extraction, candidate.module, candidate.schemaExpression, 0);
+    if (interpreted.recognized) {
+      propsSchema = interpreted.schema;
+      if (interpreted.reason !== undefined) {
+        note = `Props schema is partially permissive because parts could not be statically interpreted: ${interpreted.reason}.`;
+      }
+    } else {
+      note = `Props schema is permissive because the registration's schema could not be statically interpreted: ${interpreted.reason ?? "unrecognized schema expression"}. The runtime derives the real schema from the live registration.`;
+    }
+  }
+  return {
+    name,
+    exportPath: run.scanned.get(name)?.exportPath ?? `${modulePath}#catalog.${name}`,
+    propsSchema,
+    description,
+    ...(examples === undefined ? {} : { examples: examples as string[] }),
+    source: "registered",
+    ...(note === undefined ? {} : { note }),
+  };
+}
+
 /** 04 §1: `catalog@1`'s `propsSchema` field carries the DERIVED JSON Schema.
  * Sync derives it statically from the registration's single zod schema; the
  * hand-written `propsJsonSchema` field is gone (01 §14, 2026-07-18). A
@@ -289,8 +443,13 @@ async function registeredCatalogEntries(
   warnings: string[],
 ): Promise<CatalogEntry[]> {
   const entries: CatalogEntry[] = [];
-  const seen = new Set<string>();
-  const extraction: StaticExtraction = { ts, root, modules: new Map() };
+  const run: RegistrationRun = {
+    extraction: { ts, root, modules: new Map() },
+    root,
+    scanned,
+    seen: new Set<string>(),
+    warnings,
+  };
   for (const file of registrationFiles) {
     let source: string;
     try {
@@ -298,128 +457,19 @@ async function registeredCatalogEntries(
     } catch {
       continue;
     }
-    const module = parseModule(extraction, file, source);
-    const constants = localConstants(module.sf);
-    const modulePath = relativeModulePath(root, file);
+    const module = parseModule(run.extraction, file, source);
+    const local: CatalogContext = {
+      constants: localConstants(module.sf),
+      module,
+      modulePath: relativeModulePath(root, file),
+    };
     const candidates: RegistrationCandidate[] = [];
-    /** The module the catalog expression actually lives in — the registration
-     * file itself, or the shared registry module it imports (01 §14: one
-     * registry file serves both `createVendo` and `<VendoRoot>`). */
-    interface CatalogContext {
-      constants: Map<string, tsTypes.Expression>;
-      module: FileModule;
-      modulePath: string;
-    }
-    const collectArrayEntry = (context: CatalogContext, element: tsTypes.Expression): void => {
-      const rawEntry = resolvedLocalExpression(context.constants, element);
-      if (!ts.isObjectLiteralExpression(rawEntry)) return;
-      candidates.push({
-        name: localConstantJson(context.constants, objectField(rawEntry, "name") ?? rawEntry) as unknown,
-        description: localConstantJson(context.constants, objectField(rawEntry, "description") ?? rawEntry) as unknown,
-        examples: readExamples(context.constants, rawEntry),
-        schemaExpression: objectField(rawEntry, "propsSchema"),
-        module: context.module,
-        modulePath: context.modulePath,
-      });
-    };
-    const collectRegistryEntry = (context: CatalogContext, name: string, value: tsTypes.Expression): void => {
-      const rawEntry = resolvedLocalExpression(context.constants, value);
-      if (!ts.isObjectLiteralExpression(rawEntry)) {
-        candidates.push({ name, description: undefined, examples: undefined, schemaExpression: undefined, module: context.module, modulePath: context.modulePath });
-        return;
-      }
-      // 01 §14: the registry entry's `component` reference is IGNORED by sync
-      // (and the server) — it exists so the same object serves the client.
-      candidates.push({
-        name,
-        description: localConstantJson(context.constants, objectField(rawEntry, "description") ?? rawEntry) as unknown,
-        examples: readExamples(context.constants, rawEntry),
-        schemaExpression: objectField(rawEntry, "props"),
-        module: context.module,
-        modulePath: context.modulePath,
-      });
-    };
-    const catalogExpressions: tsTypes.Expression[] = [];
-    const visit = (node: tsTypes.Node): void => {
-      if (!ts.isCallExpression(node)
-        || !ts.isIdentifier(node.expression)
-        || node.expression.text !== "createVendo"
-        || node.arguments[0] === undefined) {
-        ts.forEachChild(node, visit);
-        return;
-      }
-      const config = resolvedLocalExpression(constants, node.arguments[0]);
-      if (!ts.isObjectLiteralExpression(config)) return;
-      const catalogExpression = objectField(config, "catalog");
-      if (catalogExpression !== undefined) catalogExpressions.push(catalogExpression);
-    };
-    visit(module.sf);
-    for (const catalogExpression of catalogExpressions) {
-      let context: CatalogContext = { constants, module, modulePath };
-      let catalog = resolvedLocalExpression(constants, catalogExpression);
-      if (ts.isIdentifier(catalog)) {
-        // The shared-registry main path: `catalog` is imported from the one
-        // registry module both sides consume — follow the import statically.
-        const resolved = await resolveIdentifier(extraction, module, catalog.text, 0);
-        if (resolved !== null) {
-          context = {
-            constants: localConstants(resolved.module.sf),
-            module: resolved.module,
-            modulePath: relativeModulePath(root, resolved.module.file),
-          };
-          catalog = resolvedLocalExpression(context.constants, unwrapExpression(resolved.expr));
-        }
-      }
-      if (ts.isArrayLiteralExpression(catalog)) {
-        for (const element of catalog.elements) {
-          if (!ts.isSpreadElement(element)) collectArrayEntry(context, element);
-        }
-      } else if (ts.isObjectLiteralExpression(catalog)) {
-        for (const property of catalog.properties) {
-          if (ts.isPropertyAssignment(property)) {
-            const name = propertyName(property.name);
-            if (name !== undefined) collectRegistryEntry(context, name, property.initializer);
-          }
-        }
-      } else {
-        warnings.push(`registered component catalog in ${modulePath} is not a statically resolvable array or registry object; scanned entries remain authoritative`);
-      }
+    for (const catalogExpression of catalogExpressionsIn(local)) {
+      candidates.push(...await catalogCandidates(run, local, catalogExpression));
     }
     for (const candidate of candidates) {
-      const { name, description, examples } = candidate;
-      if (typeof name !== "string" || !PASCAL_CASE.test(name)
-        || typeof description !== "string"
-        || (examples !== undefined && (!Array.isArray(examples) || examples.some((example) => typeof example !== "string")))) {
-        warnings.push(`registered component in ${modulePath} could not be serialized deterministically and was omitted`);
-        continue;
-      }
-      if (seen.has(name)) {
-        warnings.push(`registered component ${name} appears more than once; kept the first registration`);
-        continue;
-      }
-      seen.add(name);
-      let propsSchema: Record<string, unknown> = {};
-      let note: string | undefined;
-      if (candidate.schemaExpression !== undefined) {
-        const interpreted = await zodFromExpression(extraction, candidate.module, candidate.schemaExpression, 0);
-        if (interpreted.recognized) {
-          propsSchema = interpreted.schema;
-          if (interpreted.reason !== undefined) {
-            note = `Props schema is partially permissive because parts could not be statically interpreted: ${interpreted.reason}.`;
-          }
-        } else {
-          note = `Props schema is permissive because the registration's schema could not be statically interpreted: ${interpreted.reason ?? "unrecognized schema expression"}. The runtime derives the real schema from the live registration.`;
-        }
-      }
-      entries.push({
-        name,
-        exportPath: scanned.get(name)?.exportPath ?? `${modulePath}#catalog.${name}`,
-        propsSchema,
-        description,
-        ...(examples === undefined ? {} : { examples: examples as string[] }),
-        source: "registered",
-        ...(note === undefined ? {} : { note }),
-      });
+      const entry = await registeredEntry(run, candidate, local.modulePath);
+      if (entry !== null) entries.push(entry);
     }
   }
   return entries.sort((left, right) => compareText(left.name, right.name));
@@ -507,6 +557,76 @@ function withoutUndefined(type: tsTypes.Type): tsTypes.Type[] {
   return members.filter((member) => (member.flags & (ts.TypeFlags.Undefined | ts.TypeFlags.Void)) === 0);
 }
 
+/** The union arms that survived undefined/void stripping. A single arm collapses
+ *  to itself, all-boolean-literals is just `boolean`, and all-literals is an enum. */
+function unionSchema(
+  checker: tsTypes.TypeChecker,
+  members: tsTypes.Type[],
+  location: tsTypes.Node,
+  seen: Set<number>,
+  depth: number,
+): SchemaResult {
+  if (members.length === 1) return schemaForType(checker, members[0]!, location, seen, depth);
+  if (members.every((member) => (member.flags & ts.TypeFlags.BooleanLiteral) !== 0)) {
+    return { schema: { type: "boolean" } };
+  }
+  const values = members.map(literalValue);
+  if (values.every((value) => value !== undefined)) return { schema: { enum: values } };
+  const variants: JsonSchema[] = [];
+  for (const member of members) {
+    const converted = schemaForType(checker, member, location, new Set(seen), depth + 1);
+    if (converted.schema === undefined) return converted;
+    variants.push(converted.schema);
+  }
+  return { schema: { anyOf: variants } };
+}
+
+/** An object type's properties and index signature. Its id is already in `seen`,
+ *  so a property that loops back to it is reported rather than followed. */
+function objectSchema(
+  checker: tsTypes.TypeChecker,
+  type: tsTypes.Type,
+  location: tsTypes.Node,
+  seen: Set<number>,
+  depth: number,
+): SchemaResult {
+  const properties: Record<string, JsonSchema> = {};
+  const required: string[] = [];
+  const reasons: string[] = [];
+  for (const property of checker.getPropertiesOfType(type).sort((left, right) => compareText(left.name, right.name))) {
+    const declaration = property.valueDeclaration ?? property.declarations?.[0] ?? location;
+    const propertyType = checker.getTypeOfSymbolAtLocation(property, declaration);
+    const converted = schemaForType(checker, propertyType, declaration, new Set(seen), depth + 1);
+    // Degrade the one unrepresentable property to permissive `{}` and drop it
+    // from `required` — the same rule the sibling converter in
+    // route-schema.ts applies. Failing the whole object instead would throw
+    // away every property that converted fine, and a component with a single
+    // callback prop would reach the console as "declares no props schema".
+    properties[property.name] = converted.schema ?? {};
+    if (converted.unsupported !== undefined) {
+      reasons.push(`property ${property.name} uses ${converted.unsupported}`);
+    } else if (converted.schema === undefined) {
+      reasons.push(`property ${property.name} uses ${checker.typeToString(propertyType)}`);
+    }
+    if (converted.schema === undefined) continue;
+    if ((property.flags & ts.SymbolFlags.Optional) === 0
+      && withoutUndefined(propertyType).length === (propertyType.isUnion() ? propertyType.types.length : 1)) {
+      required.push(property.name);
+    }
+  }
+
+  const schema: JsonSchema = { type: "object", properties };
+  const stringIndex = checker.getIndexTypeOfType(type, ts.IndexKind.String);
+  if (stringIndex === undefined) schema.additionalProperties = false;
+  else {
+    const converted = schemaForType(checker, stringIndex, location, new Set(seen), depth + 1);
+    schema.additionalProperties = converted.schema ?? {};
+    if (converted.unsupported !== undefined) reasons.push(`index signature uses ${converted.unsupported}`);
+  }
+  if (required.length > 0) schema.required = required;
+  return reasons.length > 0 ? { schema, unsupported: reasons.join("; ") } : { schema };
+}
+
 function schemaForType(
   checker: tsTypes.TypeChecker,
   type: tsTypes.Type,
@@ -523,21 +643,7 @@ function schemaForType(
   // prop's `T | undefined` reduces to T; a pure union keeps every member).
   const members = withoutUndefined(type);
   if (members.length === 0) return { unsupported: `unsupported type ${checker.typeToString(type)}` };
-  if (type.isUnion()) {
-    if (members.length === 1) return schemaForType(checker, members[0]!, location, seen, depth);
-    if (members.every((member) => (member.flags & ts.TypeFlags.BooleanLiteral) !== 0)) {
-      return { schema: { type: "boolean" } };
-    }
-    const values = members.map(literalValue);
-    if (values.every((value) => value !== undefined)) return { schema: { enum: values } };
-    const variants: JsonSchema[] = [];
-    for (const member of members) {
-      const converted = schemaForType(checker, member, location, new Set(seen), depth + 1);
-      if (converted.schema === undefined) return converted;
-      variants.push(converted.schema);
-    }
-    return { schema: { anyOf: variants } };
-  }
+  if (type.isUnion()) return unionSchema(checker, members, location, seen, depth);
 
   const literal = literalValue(type);
   if (literal !== undefined) return { schema: { const: literal } };
@@ -577,41 +683,7 @@ function schemaForType(
     seen.add(id);
   }
 
-  const properties: Record<string, JsonSchema> = {};
-  const required: string[] = [];
-  const reasons: string[] = [];
-  for (const property of checker.getPropertiesOfType(type).sort((left, right) => compareText(left.name, right.name))) {
-    const declaration = property.valueDeclaration ?? property.declarations?.[0] ?? location;
-    const propertyType = checker.getTypeOfSymbolAtLocation(property, declaration);
-    const converted = schemaForType(checker, propertyType, declaration, new Set(seen), depth + 1);
-    // Degrade the one unrepresentable property to permissive `{}` and drop it
-    // from `required` — the same rule the sibling converter in
-    // route-schema.ts applies. Failing the whole object instead would throw
-    // away every property that converted fine, and a component with a single
-    // callback prop would reach the console as "declares no props schema".
-    properties[property.name] = converted.schema ?? {};
-    if (converted.unsupported !== undefined) {
-      reasons.push(`property ${property.name} uses ${converted.unsupported}`);
-    } else if (converted.schema === undefined) {
-      reasons.push(`property ${property.name} uses ${checker.typeToString(propertyType)}`);
-    }
-    if (converted.schema === undefined) continue;
-    if ((property.flags & ts.SymbolFlags.Optional) === 0
-      && withoutUndefined(propertyType).length === (propertyType.isUnion() ? propertyType.types.length : 1)) {
-      required.push(property.name);
-    }
-  }
-
-  const schema: JsonSchema = { type: "object", properties };
-  const stringIndex = checker.getIndexTypeOfType(type, ts.IndexKind.String);
-  if (stringIndex === undefined) schema.additionalProperties = false;
-  else {
-    const converted = schemaForType(checker, stringIndex, location, new Set(seen), depth + 1);
-    schema.additionalProperties = converted.schema ?? {};
-    if (converted.unsupported !== undefined) reasons.push(`index signature uses ${converted.unsupported}`);
-  }
-  if (required.length > 0) schema.required = required;
-  return reasons.length > 0 ? { schema, unsupported: reasons.join("; ") } : { schema };
+  return objectSchema(checker, type, location, seen, depth);
 }
 
 function schemaForComponent(checker: tsTypes.TypeChecker, declaration: tsTypes.FunctionLikeDeclaration): SchemaResult {

--- a/packages/actions/src/sync/components.ts
+++ b/packages/actions/src/sync/components.ts
@@ -16,6 +16,7 @@ import {
   overBudgetWarning,
   portablePath,
   previewBlockingSpecifiers,
+  type CapturedClosure,
 } from "./capture.js";
 import { generateSampleProps } from "./sample-props.js";
 import type { HostComponentSite } from "./catalog-scan.js";
@@ -175,6 +176,139 @@ function captureHash(record: Omit<CapturedHostComponent, "hash" | "capturedAt">)
   return `sha256:${sha256Hex(canonicalJson(record as unknown as Record<string, unknown>))}`;
 }
 
+/** The closure state one capture run shares across every component it visits. */
+interface CaptureContext {
+  root: string;
+  realRoot: string;
+  styles: readonly CapturedPinStyle[];
+  styleRefs: () => Array<{ path: string; ref: string }>;
+  budgetBytes: number | undefined;
+  corpus: Corpus;
+  catalogByName: Map<string, CatalogEntry>;
+  result: HostComponentCaptureResult;
+}
+
+/** One discovered component's source, read off disk. */
+interface FoundComponent {
+  label: string;
+  realFile: string;
+  source: string;
+  /** The component's own module path, portable relative to the project root. */
+  module: string;
+}
+
+/** The record a component whose whole import closure captured cleanly earns. */
+function capturedRecord(
+  ctx: CaptureContext,
+  site: HostComponentSite,
+  found: FoundComponent,
+  entryExportName: string,
+  closure: CapturedClosure,
+): Omit<CapturedHostComponent, "hash" | "capturedAt"> {
+  const { sourceImports, subSources, bytes, requires, packages } = closure;
+  const modules: Record<string, string> = {};
+  for (const [id, sub] of Object.entries(subSources)) {
+    modules[id] = addModule(ctx.corpus, {
+      source: sub.source,
+      ...(Object.keys(sub.imports).length === 0 ? {} : { imports: sub.imports }),
+    });
+  }
+  const sample = sampleFrom(site.name, ctx.catalogByName.get(site.name));
+  if ("gap" in sample) ctx.result.withoutSamples.push(site.name);
+  return {
+    name: site.name,
+    module: found.module,
+    ...(entryExportName === "default" ? {} : { export: entryExportName }),
+    entry: addModule(ctx.corpus, {
+      source: found.source,
+      ...(Object.keys(sourceImports).length === 0 ? {} : { imports: sourceImports }),
+    }),
+    ...(Object.keys(modules).length === 0 ? {} : { modules }),
+    ...(ctx.styles.length === 0 ? {} : { styles: ctx.styleRefs() }),
+    bytes,
+    ...(requires.length === 0 ? {} : { requires }),
+    ...(Object.keys(packages).length === 0 ? {} : { packages }),
+    ...("gap" in sample
+      ? { noSampleProps: sample.gap }
+      : { sampleProps: sample.props, sampleOrigin: sample.origin }),
+  };
+}
+
+/** The record one discovered component earns: its capture, or the reason — always
+ *  a property of the SOURCE, never a transient failure — it has none. */
+async function recordFor(
+  ctx: CaptureContext,
+  site: HostComponentSite,
+  found: FoundComponent,
+): Promise<Omit<CapturedHostComponent, "hash" | "capturedAt">> {
+  /** Record the reason on disk so the console can say WHY, not just show a
+   *  grey block. Only reached when the reason is a property of the SOURCE,
+   *  never for a transient failure. */
+  const skip = (reason: HostComponentSkip): Omit<CapturedHostComponent, "hash" | "capturedAt"> => {
+    ctx.result.warnings.push(`${found.label} was not captured: ${reason.detail}`);
+    ctx.result.skipped.push(site.name);
+    return { name: site.name, module: found.module, skipped: reason };
+  };
+
+  if (site.binding === null) {
+    return skip({
+      reason: "no-named-declaration",
+      detail: "It has no named declaration to re-export. Name the component (or export it) so it can be rendered.",
+    });
+  }
+  if (!isInside(ctx.realRoot, found.realFile) || found.realFile.split(path.sep).includes("node_modules")) {
+    return skip({
+      reason: "in-package",
+      detail: "It is declared inside a package, not in your source, so its code is not yours to capture.",
+    });
+  }
+  const entry = entryExport(found.source, found.realFile, site.binding);
+  if ("skip" in entry) return skip(entry.skip);
+
+  const walked = await captureClosure({
+    root: ctx.root,
+    realRoot: ctx.realRoot,
+    label: found.label,
+    primaryFile: found.realFile,
+    primarySource: found.source,
+    ...(ctx.budgetBytes === undefined ? {} : { budgetBytes: ctx.budgetBytes }),
+    warnings: ctx.result.warnings,
+  });
+  if (!walked.ok) {
+    ctx.result.warnings.push(overBudgetWarning(found.label, walked.overBudget));
+    ctx.result.skipped.push(site.name);
+    return {
+      name: site.name,
+      module: found.module,
+      skipped: {
+        reason: "too-large",
+        detail: `Its import closure is ${Math.round(walked.overBudget.bytes / 1024)} KB, over the ${Math.round(walked.overBudget.budgetBytes / 1024)} KB per-component budget (largest: ${walked.overBudget.largest}).`,
+        bytes: walked.overBudget.bytes,
+        budgetBytes: walked.overBudget.budgetBytes,
+        largest: walked.overBudget.largest,
+      },
+    };
+  }
+  const blocking = previewBlockingSpecifiers(walked.closure);
+  if (blocking.length > 0) {
+    // The closure would LOAD as a crash. A named "cannot preview" tile
+    // beats a red error box mislabeled as a generated-component
+    // failure, which is what shipping this capture would produce. A
+    // package the preview CAN fetch from the pinned CDN is not blocking
+    // — one it cannot says so in its own clause.
+    const named = blocking.map((value) => {
+      const why = walked.closure.unloadablePackages[value];
+      return why === undefined ? `"${value}"` : `"${value}" (${why})`;
+    });
+    return skip({
+      reason: "unsupported-imports",
+      detail: `It imports ${named.join(", ")}, which the sandboxed preview cannot load.`,
+      specifiers: blocking,
+    });
+  }
+  return capturedRecord(ctx, site, found, entry.export, walked.closure);
+}
+
 /**
  * Capture every registered component's source into `.vendo/components/`.
  * `styles` are the app-root stylesheets the pin capture already collected —
@@ -208,6 +342,16 @@ export async function captureHostComponents(options: {
     path: style.path,
     ref: addModule(corpus, { source: style.css }),
   }));
+  const ctx: CaptureContext = {
+    root,
+    realRoot,
+    styles,
+    styleRefs,
+    budgetBytes: options.budgetBytes,
+    corpus,
+    catalogByName,
+    result,
+  };
   /** Every component the scan DISCOVERED, capture succeeded or not. Prune runs
    *  against this, never against "what we managed to write": a transient
    *  unreadable file must not delete a good record here and its row in Cloud
@@ -240,102 +384,7 @@ export async function captureHostComponents(options: {
       continue;
     }
     const module = portablePath(realRoot, realFile);
-    /** Record the reason on disk so the console can say WHY, not just show a
-     *  grey block. Only reached when the reason is a property of the SOURCE,
-     *  never for a transient failure. */
-    const skip = (reason: HostComponentSkip): Omit<CapturedHostComponent, "hash" | "capturedAt"> => {
-      result.warnings.push(`${label} was not captured: ${reason.detail}`);
-      result.skipped.push(site.name);
-      return { name: site.name, module, skipped: reason };
-    };
-
-    let record: Omit<CapturedHostComponent, "hash" | "capturedAt">;
-    if (site.binding === null) {
-      record = skip({
-        reason: "no-named-declaration",
-        detail: "It has no named declaration to re-export. Name the component (or export it) so it can be rendered.",
-      });
-    } else {
-      if (!isInside(realRoot, realFile) || realFile.split(path.sep).includes("node_modules")) {
-        record = skip({
-          reason: "in-package",
-          detail: "It is declared inside a package, not in your source, so its code is not yours to capture.",
-        });
-      } else {
-        const entry = entryExport(source, realFile, site.binding);
-        if ("skip" in entry) record = skip(entry.skip);
-        else {
-          const walked = await captureClosure({
-            root,
-            realRoot,
-            label,
-            primaryFile: realFile,
-            primarySource: source,
-            ...(options.budgetBytes === undefined ? {} : { budgetBytes: options.budgetBytes }),
-            warnings: result.warnings,
-          });
-          const blocking = walked.ok ? previewBlockingSpecifiers(walked.closure) : [];
-          if (!walked.ok) {
-            result.warnings.push(overBudgetWarning(label, walked.overBudget));
-            result.skipped.push(site.name);
-            record = {
-              name: site.name,
-              module,
-              skipped: {
-                reason: "too-large",
-                detail: `Its import closure is ${Math.round(walked.overBudget.bytes / 1024)} KB, over the ${Math.round(walked.overBudget.budgetBytes / 1024)} KB per-component budget (largest: ${walked.overBudget.largest}).`,
-                bytes: walked.overBudget.bytes,
-                budgetBytes: walked.overBudget.budgetBytes,
-                largest: walked.overBudget.largest,
-              },
-            };
-          } else if (blocking.length > 0) {
-            // The closure would LOAD as a crash. A named "cannot preview" tile
-            // beats a red error box mislabeled as a generated-component
-            // failure, which is what shipping this capture would produce. A
-            // package the preview CAN fetch from the pinned CDN is not blocking
-            // — one it cannot says so in its own clause.
-            const named = blocking.map((value) => {
-              const why = walked.closure.unloadablePackages[value];
-              return why === undefined ? `"${value}"` : `"${value}" (${why})`;
-            });
-            record = skip({
-              reason: "unsupported-imports",
-              detail: `It imports ${named.join(", ")}, which the sandboxed preview cannot load.`,
-              specifiers: blocking,
-            });
-          } else {
-            const { sourceImports, subSources, bytes, requires, packages } = walked.closure;
-            const modules: Record<string, string> = {};
-            for (const [id, sub] of Object.entries(subSources)) {
-              modules[id] = addModule(corpus, {
-                source: sub.source,
-                ...(Object.keys(sub.imports).length === 0 ? {} : { imports: sub.imports }),
-              });
-            }
-            const sample = sampleFrom(site.name, catalogByName.get(site.name));
-            if ("gap" in sample) result.withoutSamples.push(site.name);
-            record = {
-              name: site.name,
-              module,
-              ...(entry.export === "default" ? {} : { export: entry.export }),
-              entry: addModule(corpus, {
-                source,
-                ...(Object.keys(sourceImports).length === 0 ? {} : { imports: sourceImports }),
-              }),
-              ...(Object.keys(modules).length === 0 ? {} : { modules }),
-              ...(styles.length === 0 ? {} : { styles: styleRefs() }),
-              bytes,
-              ...(requires.length === 0 ? {} : { requires }),
-              ...(Object.keys(packages).length === 0 ? {} : { packages }),
-              ...("gap" in sample
-                ? { noSampleProps: sample.gap }
-                : { sampleProps: sample.props, sampleOrigin: sample.origin }),
-            };
-          }
-        }
-      }
-    }
+    const record = await recordFor(ctx, site, { label, realFile, source, module });
 
     const hash = captureHash(record);
     const existing = await readRecord(recordFile);

--- a/packages/actions/src/sync/sample-props.ts
+++ b/packages/actions/src/sync/sample-props.ts
@@ -108,6 +108,63 @@ function coherePairs(value: Record<string, unknown>): void {
   value[current] = Math.max(1, Math.round(low % Math.max(2, high)));
 }
 
+/** A tuple's `prefixItems` in order, else a bounded run of the element schema. */
+function generateArray(schema: JsonSchema, key: string, name: string, path: string, depth: number): Generated {
+  if (Array.isArray(schema.prefixItems)) {
+    const tuple: unknown[] = [];
+    for (const [index, item] of schema.prefixItems.entries()) {
+      const generated = generate(item as JsonSchema, key, name, `${path}/${index}`, depth + 1);
+      if (!generated.ok) return FAILED;
+      tuple.push(generated.value);
+    }
+    return { ok: true, value: tuple };
+  }
+  const items = schema.items as JsonSchema | undefined;
+  // An array whose element type is unknown can only be `[]`, and a component
+  // that guards on `.length` would render nothing — the exact failure the
+  // seed exists to prevent. Fail instead, so the caller can drop an optional
+  // prop or fall to an honest label.
+  if (items === undefined || Object.keys(items).length === 0) return FAILED;
+  const minItems = typeof schema.minItems === "number" ? schema.minItems : 0;
+  const maxItems = typeof schema.maxItems === "number" ? schema.maxItems : Number.POSITIVE_INFINITY;
+  const count = Math.max(minItems, Math.min(DEFAULT_ARRAY_ITEMS, maxItems));
+  const values: unknown[] = [];
+  for (let index = 0; index < count; index += 1) {
+    const generated = generate(items, key, name, `${path}/${index}`, depth + 1);
+    if (!generated.ok) return FAILED;
+    values.push(generated.value);
+  }
+  return { ok: true, value: values };
+}
+
+function generateObject(schema: JsonSchema, name: string, path: string, depth: number): Generated {
+  const properties = (schema.properties ?? {}) as Record<string, JsonSchema>;
+  const required = new Set(Array.isArray(schema.required) ? schema.required as string[] : []);
+  const value: Record<string, unknown> = {};
+  for (const propertyKey of Object.keys(properties).sort()) {
+    const generated = generate(properties[propertyKey]!, propertyKey, name, `${path}/${propertyKey}`, depth + 1);
+    // A required property we cannot synthesize makes the whole object
+    // unusable; an optional one is simply left out.
+    if (!generated.ok) {
+      if (required.has(propertyKey)) return FAILED;
+      continue;
+    }
+    value[propertyKey] = generated.value;
+  }
+  // An EMPTY object where the schema expected data is the same blank-render
+  // trap as an empty array: `if (!rows?.length) return null` draws nothing and
+  // the surface spins. That happens two ways — a `z.record()` (no declared
+  // properties, an open value schema) and an all-optional object whose every
+  // property failed to synthesize. Both fall to the honest rung-3 label.
+  // A component that genuinely declares NO props is different: `{}` is the
+  // correct seed and it will draw.
+  coherePairs(value);
+  const expectedData = Object.keys(properties).length > 0
+    || (typeof schema.additionalProperties === "object" && schema.additionalProperties !== null);
+  if (expectedData && Object.keys(value).length === 0) return FAILED;
+  return { ok: true, value };
+}
+
 function generate(schema: JsonSchema, key: string, name: string, path: string, depth: number): Generated {
   if (depth > MAX_DEPTH) return FAILED;
   const seed = seedOf(name, path);
@@ -132,61 +189,9 @@ function generate(schema: JsonSchema, key: string, name: string, path: string, d
   if (type === "boolean") return { ok: true, value: seed % 2 === 0 };
   if (type === "null") return { ok: true, value: null };
 
-  if (type === "array") {
-    if (Array.isArray(schema.prefixItems)) {
-      const tuple: unknown[] = [];
-      for (const [index, item] of schema.prefixItems.entries()) {
-        const generated = generate(item as JsonSchema, key, name, `${path}/${index}`, depth + 1);
-        if (!generated.ok) return FAILED;
-        tuple.push(generated.value);
-      }
-      return { ok: true, value: tuple };
-    }
-    const items = schema.items as JsonSchema | undefined;
-    // An array whose element type is unknown can only be `[]`, and a component
-    // that guards on `.length` would render nothing — the exact failure the
-    // seed exists to prevent. Fail instead, so the caller can drop an optional
-    // prop or fall to an honest label.
-    if (items === undefined || Object.keys(items).length === 0) return FAILED;
-    const minItems = typeof schema.minItems === "number" ? schema.minItems : 0;
-    const maxItems = typeof schema.maxItems === "number" ? schema.maxItems : Number.POSITIVE_INFINITY;
-    const count = Math.max(minItems, Math.min(DEFAULT_ARRAY_ITEMS, maxItems));
-    const values: unknown[] = [];
-    for (let index = 0; index < count; index += 1) {
-      const generated = generate(items, key, name, `${path}/${index}`, depth + 1);
-      if (!generated.ok) return FAILED;
-      values.push(generated.value);
-    }
-    return { ok: true, value: values };
-  }
+  if (type === "array") return generateArray(schema, key, name, path, depth);
 
-  if (type === "object" || schema.properties !== undefined) {
-    const properties = (schema.properties ?? {}) as Record<string, JsonSchema>;
-    const required = new Set(Array.isArray(schema.required) ? schema.required as string[] : []);
-    const value: Record<string, unknown> = {};
-    for (const propertyKey of Object.keys(properties).sort()) {
-      const generated = generate(properties[propertyKey]!, propertyKey, name, `${path}/${propertyKey}`, depth + 1);
-      // A required property we cannot synthesize makes the whole object
-      // unusable; an optional one is simply left out.
-      if (!generated.ok) {
-        if (required.has(propertyKey)) return FAILED;
-        continue;
-      }
-      value[propertyKey] = generated.value;
-    }
-    // An EMPTY object where the schema expected data is the same blank-render
-    // trap as an empty array: `if (!rows?.length) return null` draws nothing and
-    // the surface spins. That happens two ways — a `z.record()` (no declared
-    // properties, an open value schema) and an all-optional object whose every
-    // property failed to synthesize. Both fall to the honest rung-3 label.
-    // A component that genuinely declares NO props is different: `{}` is the
-    // correct seed and it will draw.
-    coherePairs(value);
-    const expectedData = Object.keys(properties).length > 0
-      || (typeof schema.additionalProperties === "object" && schema.additionalProperties !== null);
-    if (expectedData && Object.keys(value).length === 0) return FAILED;
-    return { ok: true, value };
-  }
+  if (type === "object" || schema.properties !== undefined) return generateObject(schema, name, path, depth);
 
   // No type, no enum, no const, no properties: the permissive placeholder sync
   // writes when it could not interpret a schema. Nothing to synthesize.

--- a/packages/actions/src/sync/server-actions.ts
+++ b/packages/actions/src/sync/server-actions.ts
@@ -145,6 +145,105 @@ async function zodInferSchema(
   return zodFromExpression(extraction, resolved.module, resolved.expr, depth + 1);
 }
 
+/** `A | B | undefined | null` — undefined makes the whole type optional, null
+ *  wraps it, and an all-string-literal union collapses to an enum. */
+async function unionTypeSchema(
+  extraction: Extraction,
+  module: FileModule,
+  type: TS.UnionTypeNode,
+  depth: number,
+): Promise<ZodSchemaResult> {
+  const { ts } = extraction;
+  const options: Record<string, unknown>[] = [];
+  let optional = false;
+  let nullable = false;
+  for (const member of type.types) {
+    if (member.kind === ts.SyntaxKind.UndefinedKeyword) {
+      optional = true;
+      continue;
+    }
+    if (ts.isLiteralTypeNode(member) && member.literal.kind === ts.SyntaxKind.NullKeyword) {
+      nullable = true;
+      continue;
+    }
+    const option = await typeNodeSchema(extraction, module, member, depth + 1);
+    if (!option.recognized) return notInterpreted(option.reason ?? "union member is not statically interpreted");
+    options.push(option.schema);
+  }
+  if (options.length === 0) return { schema: {}, optional, recognized: true };
+  const allStringConsts = options.every((option) => typeof option.const === "string" && Object.keys(option).length === 1);
+  let schema: Record<string, unknown> = allStringConsts
+    ? { type: "string", enum: options.map((option) => option.const) }
+    : options.length === 1 ? options[0]! : { anyOf: options };
+  if (nullable) schema = { anyOf: [schema, { type: "null" }] };
+  return { schema, optional, recognized: true };
+}
+
+/** An inline `{ a: string; b?: number }` object type. */
+async function typeLiteralSchema(
+  extraction: Extraction,
+  module: FileModule,
+  type: TS.TypeLiteralNode,
+  depth: number,
+): Promise<ZodSchemaResult> {
+  const { ts } = extraction;
+  const properties: Record<string, unknown> = {};
+  const required: string[] = [];
+  const reasons: string[] = [];
+  for (const member of type.members) {
+    if (ts.isIndexSignatureDeclaration(member)) continue; // stays additive below
+    if (!ts.isPropertySignature(member) || !member.name) return notInterpreted("object type member is not a plain property");
+    const key = ts.isIdentifier(member.name) || ts.isStringLiteral(member.name) ? member.name.text : null;
+    if (key === null) return notInterpreted("object type member has a computed name");
+    const value = member.type
+      ? await typeNodeSchema(extraction, module, member.type, depth + 1)
+      : notInterpreted("object type member has no type annotation");
+    properties[key] = value.recognized ? value.schema : {};
+    if (!value.recognized && value.reason) reasons.push(`${key}: ${value.reason}`);
+    if (member.questionToken === undefined && !value.optional && value.recognized) required.push(key);
+  }
+  const hasIndexSignature = type.members.some((member) => ts.isIndexSignatureDeclaration(member));
+  const schema: Record<string, unknown> = {
+    type: "object",
+    properties,
+    ...(required.length > 0 ? { required } : {}),
+    additionalProperties: hasIndexSignature,
+  };
+  if (reasons.length > 0) return { schema, optional: false, recognized: true, reason: reasons.join("; ") };
+  return recognizedSchema(schema);
+}
+
+/** A named type: a zod `infer`, or one of the handful of built-ins whose shape
+ *  is knowable without a type checker. */
+async function typeReferenceSchema(
+  extraction: Extraction,
+  module: FileModule,
+  type: TS.TypeReferenceNode,
+  depth: number,
+): Promise<ZodSchemaResult> {
+  const { ts } = extraction;
+  const zod = await zodInferSchema(extraction, module, type, depth);
+  if (zod !== null) return zod;
+  const name = entityNameText(ts, type.typeName);
+  if (name === "Date") return recognizedSchema({ type: "string", format: "date-time" });
+  // Every server action is async, so its declared return type is a Promise;
+  // the tool's response is what the promise RESOLVES to.
+  if (name === "Promise" && type.typeArguments?.length === 1) {
+    return typeNodeSchema(extraction, module, type.typeArguments[0]!, depth + 1);
+  }
+  if (name === "Array" && type.typeArguments?.length === 1) {
+    const items = await typeNodeSchema(extraction, module, type.typeArguments[0]!, depth + 1);
+    return items.recognized
+      ? recognizedSchema({ type: "array", items: items.schema })
+      : { schema: { type: "array" }, optional: false, recognized: true, reason: items.reason };
+  }
+  if (name === "Record" && type.typeArguments?.length === 2) {
+    const value = await typeNodeSchema(extraction, module, type.typeArguments[1]!, depth + 1);
+    return recognizedSchema({ type: "object", additionalProperties: value.recognized ? value.schema : true });
+  }
+  return notInterpreted(`type "${name}" is not statically interpreted`);
+}
+
 async function typeNodeSchema(
   extraction: Extraction,
   module: FileModule,
@@ -180,79 +279,9 @@ async function typeNodeSchema(
       ? recognizedSchema({ type: "array", items: items.schema })
       : { schema: { type: "array" }, optional: false, recognized: true, reason: items.reason };
   }
-  if (ts.isUnionTypeNode(type)) {
-    const options: Record<string, unknown>[] = [];
-    let optional = false;
-    let nullable = false;
-    for (const member of type.types) {
-      if (member.kind === ts.SyntaxKind.UndefinedKeyword) {
-        optional = true;
-        continue;
-      }
-      if (ts.isLiteralTypeNode(member) && member.literal.kind === ts.SyntaxKind.NullKeyword) {
-        nullable = true;
-        continue;
-      }
-      const option = await typeNodeSchema(extraction, module, member, depth + 1);
-      if (!option.recognized) return notInterpreted(option.reason ?? "union member is not statically interpreted");
-      options.push(option.schema);
-    }
-    if (options.length === 0) return { schema: {}, optional, recognized: true };
-    const allStringConsts = options.every((option) => typeof option.const === "string" && Object.keys(option).length === 1);
-    let schema: Record<string, unknown> = allStringConsts
-      ? { type: "string", enum: options.map((option) => option.const) }
-      : options.length === 1 ? options[0]! : { anyOf: options };
-    if (nullable) schema = { anyOf: [schema, { type: "null" }] };
-    return { schema, optional, recognized: true };
-  }
-  if (ts.isTypeLiteralNode(type)) {
-    const properties: Record<string, unknown> = {};
-    const required: string[] = [];
-    const reasons: string[] = [];
-    for (const member of type.members) {
-      if (ts.isIndexSignatureDeclaration(member)) continue; // stays additive below
-      if (!ts.isPropertySignature(member) || !member.name) return notInterpreted("object type member is not a plain property");
-      const key = ts.isIdentifier(member.name) || ts.isStringLiteral(member.name) ? member.name.text : null;
-      if (key === null) return notInterpreted("object type member has a computed name");
-      const value = member.type
-        ? await typeNodeSchema(extraction, module, member.type, depth + 1)
-        : notInterpreted("object type member has no type annotation");
-      properties[key] = value.recognized ? value.schema : {};
-      if (!value.recognized && value.reason) reasons.push(`${key}: ${value.reason}`);
-      if (member.questionToken === undefined && !value.optional && value.recognized) required.push(key);
-    }
-    const hasIndexSignature = type.members.some((member) => ts.isIndexSignatureDeclaration(member));
-    const schema: Record<string, unknown> = {
-      type: "object",
-      properties,
-      ...(required.length > 0 ? { required } : {}),
-      additionalProperties: hasIndexSignature,
-    };
-    if (reasons.length > 0) return { schema, optional: false, recognized: true, reason: reasons.join("; ") };
-    return recognizedSchema(schema);
-  }
-  if (ts.isTypeReferenceNode(type)) {
-    const zod = await zodInferSchema(extraction, module, type, depth);
-    if (zod !== null) return zod;
-    const name = entityNameText(ts, type.typeName);
-    if (name === "Date") return recognizedSchema({ type: "string", format: "date-time" });
-    // Every server action is async, so its declared return type is a Promise;
-    // the tool's response is what the promise RESOLVES to.
-    if (name === "Promise" && type.typeArguments?.length === 1) {
-      return typeNodeSchema(extraction, module, type.typeArguments[0]!, depth + 1);
-    }
-    if (name === "Array" && type.typeArguments?.length === 1) {
-      const items = await typeNodeSchema(extraction, module, type.typeArguments[0]!, depth + 1);
-      return items.recognized
-        ? recognizedSchema({ type: "array", items: items.schema })
-        : { schema: { type: "array" }, optional: false, recognized: true, reason: items.reason };
-    }
-    if (name === "Record" && type.typeArguments?.length === 2) {
-      const value = await typeNodeSchema(extraction, module, type.typeArguments[1]!, depth + 1);
-      return recognizedSchema({ type: "object", additionalProperties: value.recognized ? value.schema : true });
-    }
-    return notInterpreted(`type "${name}" is not statically interpreted`);
-  }
+  if (ts.isUnionTypeNode(type)) return unionTypeSchema(extraction, module, type, depth);
+  if (ts.isTypeLiteralNode(type)) return typeLiteralSchema(extraction, module, type, depth);
+  if (ts.isTypeReferenceNode(type)) return typeReferenceSchema(extraction, module, type, depth);
   return notInterpreted("parameter type is not statically interpreted");
 }
 
@@ -330,6 +359,95 @@ function moduleStem(moduleRel: string): string {
   return path.posix.basename(moduleRel).replace(SOURCE_FILE_PATTERN, "");
 }
 
+/** One `"use server"` module's collection in progress: where actions land, and
+ *  the two dispositions a statement can give one. */
+interface ActionCollector {
+  extraction: Extraction;
+  module: FileModule;
+  moduleRel: string;
+  out: CollectedAction[];
+  pushFunction: (exportName: string, sourceName: string, fn: FunctionNode) => Promise<void>;
+  pushUnclassifiable: (exportName: string, reason: string) => void;
+}
+
+/** `export function name(…)` / `export default function name(…)`. */
+async function collectFunctionDeclaration(
+  collector: ActionCollector,
+  statement: TS.FunctionDeclaration,
+  isDefault: boolean,
+): Promise<void> {
+  const declared = statement.name?.text;
+  const exportName = isDefault ? "default" : declared;
+  if (!exportName) return;
+  await collector.pushFunction(exportName, declared ?? moduleStem(collector.moduleRel), statement);
+}
+
+/** `export const name = …` — a function, a recognized wrapper around one, or
+ *  something the extractor cannot confirm is callable. */
+async function collectVariableStatement(collector: ActionCollector, statement: TS.VariableStatement): Promise<void> {
+  const { extraction, module, moduleRel, out, pushFunction, pushUnclassifiable } = collector;
+  const { ts } = extraction;
+  for (const declaration of statement.declarationList.declarations) {
+    if (!ts.isIdentifier(declaration.name)) continue;
+    const exportName = declaration.name.text;
+    if (!declaration.initializer) continue;
+    const fn = functionNode(ts, declaration.initializer);
+    if (fn) {
+      await pushFunction(exportName, exportName, fn);
+      continue;
+    }
+    const wrapped = await wrappedAction(extraction, module, declaration.initializer);
+    if (wrapped !== null) {
+      if ("fn" in wrapped) await pushFunction(exportName, exportName, wrapped.fn);
+      else out.push({ module, moduleRel, exportName, sourceName: exportName, params: wrapped.params });
+      continue;
+    }
+    pushUnclassifiable(exportName, "the export is not a statically confirmable function");
+  }
+}
+
+/** `export default …` — an identifier resolved back to its local declaration,
+ *  or an inline function expression. */
+async function collectExportAssignment(collector: ActionCollector, statement: TS.ExportAssignment): Promise<void> {
+  const { extraction, module, moduleRel, pushFunction, pushUnclassifiable } = collector;
+  const { ts } = extraction;
+  let expr = unwrapExpression(ts, statement.expression);
+  let sourceName = moduleStem(moduleRel);
+  if (ts.isIdentifier(expr)) {
+    sourceName = expr.text;
+    const local = localFunction(extraction, module, expr.text);
+    if (local) {
+      await pushFunction("default", sourceName, local);
+      return;
+    }
+    pushUnclassifiable("default", `default export "${expr.text}" is not a statically confirmable function`);
+    return;
+  }
+  const fn = functionNode(ts, expr);
+  if (fn) await pushFunction("default", ts.isFunctionExpression(fn) && fn.name ? fn.name.text : sourceName, fn);
+  else pushUnclassifiable("default", "the default export is not a statically confirmable function");
+}
+
+/** `export { a, b as c }` — local bindings only; a re-export is not followed. */
+async function collectNamedExports(
+  collector: ActionCollector,
+  statement: TS.ExportDeclaration,
+  exportClause: TS.NamedExports,
+): Promise<void> {
+  const { extraction, module, moduleRel, pushFunction, pushUnclassifiable } = collector;
+  if (statement.moduleSpecifier !== undefined) {
+    extraction.warnings.push(`server-actions: re-exports from ${moduleRel} are not followed; declare actions in the "use server" module itself`);
+    return;
+  }
+  for (const element of exportClause.elements) {
+    const exportName = element.name.text;
+    const localName = (element.propertyName ?? element.name).text;
+    const local = localFunction(extraction, module, localName);
+    if (local) await pushFunction(exportName, localName, local);
+    else pushUnclassifiable(exportName, `exported binding "${localName}" is not a statically confirmable function`);
+  }
+}
+
 async function collectModuleActions(
   extraction: Extraction,
   module: FileModule,
@@ -352,6 +470,7 @@ async function collectModuleActions(
   const pushUnclassifiable = (exportName: string, reason: string): void => {
     out.push({ ...base, exportName, sourceName: exportName, params: [], disabled: "unclassifiable", unclassifiableReason: reason });
   };
+  const collector: ActionCollector = { extraction, module, moduleRel, out, pushFunction, pushUnclassifiable };
 
   for (const statement of module.sf.statements) {
     const modifiers = ts.canHaveModifiers(statement) ? ts.getModifiers(statement) ?? [] : [];
@@ -359,62 +478,19 @@ async function collectModuleActions(
     const isDefault = modifiers.some((modifier) => modifier.kind === ts.SyntaxKind.DefaultKeyword);
 
     if (ts.isFunctionDeclaration(statement) && isExported) {
-      const declared = statement.name?.text;
-      const exportName = isDefault ? "default" : declared;
-      if (!exportName) continue;
-      await pushFunction(exportName, declared ?? moduleStem(moduleRel), statement);
+      await collectFunctionDeclaration(collector, statement, isDefault);
       continue;
     }
     if (ts.isVariableStatement(statement) && isExported) {
-      for (const declaration of statement.declarationList.declarations) {
-        if (!ts.isIdentifier(declaration.name)) continue;
-        const exportName = declaration.name.text;
-        if (!declaration.initializer) continue;
-        const fn = functionNode(ts, declaration.initializer);
-        if (fn) {
-          await pushFunction(exportName, exportName, fn);
-          continue;
-        }
-        const wrapped = await wrappedAction(extraction, module, declaration.initializer);
-        if (wrapped !== null) {
-          if ("fn" in wrapped) await pushFunction(exportName, exportName, wrapped.fn);
-          else out.push({ ...base, exportName, sourceName: exportName, params: wrapped.params });
-          continue;
-        }
-        pushUnclassifiable(exportName, "the export is not a statically confirmable function");
-      }
+      await collectVariableStatement(collector, statement);
       continue;
     }
     if (ts.isExportAssignment(statement) && !statement.isExportEquals) {
-      let expr = unwrapExpression(ts, statement.expression);
-      let sourceName = moduleStem(moduleRel);
-      if (ts.isIdentifier(expr)) {
-        sourceName = expr.text;
-        const local = localFunction(extraction, module, expr.text);
-        if (local) {
-          await pushFunction("default", sourceName, local);
-          continue;
-        }
-        pushUnclassifiable("default", `default export "${expr.text}" is not a statically confirmable function`);
-        continue;
-      }
-      const fn = functionNode(ts, expr);
-      if (fn) await pushFunction("default", ts.isFunctionExpression(fn) && fn.name ? fn.name.text : sourceName, fn);
-      else pushUnclassifiable("default", "the default export is not a statically confirmable function");
+      await collectExportAssignment(collector, statement);
       continue;
     }
     if (ts.isExportDeclaration(statement) && statement.exportClause && ts.isNamedExports(statement.exportClause)) {
-      if (statement.moduleSpecifier !== undefined) {
-        extraction.warnings.push(`server-actions: re-exports from ${moduleRel} are not followed; declare actions in the "use server" module itself`);
-        continue;
-      }
-      for (const element of statement.exportClause.elements) {
-        const exportName = element.name.text;
-        const localName = (element.propertyName ?? element.name).text;
-        const local = localFunction(extraction, module, localName);
-        if (local) await pushFunction(exportName, localName, local);
-        else pushUnclassifiable(exportName, `exported binding "${localName}" is not a statically confirmable function`);
-      }
+      await collectNamedExports(collector, statement, statement.exportClause);
     }
   }
 }

--- a/packages/actions/src/sync/static-ts.ts
+++ b/packages/actions/src/sync/static-ts.ts
@@ -332,7 +332,82 @@ export async function zodFromExpression(
   return unrecognized("schema call shape is not statically interpreted");
 }
 
-async function zodBase(
+const recognized = (schema: Record<string, unknown>): ZodSchemaResult => ({ schema, optional: false, recognized: true });
+
+/** `z.object({ … })` — each property interpreted in turn; an uninterpretable one
+ *  stays permissive rather than failing the whole object closed. */
+async function zodObject(
+  extraction: StaticExtraction,
+  module: FileModule,
+  call: TS.CallExpression,
+  depth: number,
+): Promise<ZodSchemaResult> {
+  const { ts } = extraction;
+  const argument = call.arguments[0];
+  if (!argument || !ts.isObjectLiteralExpression(argument)) return unrecognized("z.object argument is not an object literal");
+  const properties: Record<string, unknown> = {};
+  const required: string[] = [];
+  const reasons: string[] = [];
+  for (const property of argument.properties) {
+    if (!ts.isPropertyAssignment(property)) continue;
+    const key = propertyKeyName(extraction, property.name);
+    if (!key) continue;
+    const value = await zodFromExpression(extraction, module, property.initializer, depth + 1);
+    properties[key] = value.recognized ? value.schema : {};
+    if (!value.recognized && value.reason) reasons.push(`${key}: ${value.reason}`);
+    if (!value.optional && value.recognized) required.push(key);
+  }
+  const schema: Record<string, unknown> = {
+    type: "object",
+    properties,
+    ...(required.length > 0 ? { required } : {}),
+    additionalProperties: false,
+  };
+  if (reasons.length > 0) {
+    // Partially recognized: emit what we know, keep unknown properties permissive.
+    return { schema, optional: false, recognized: true, reason: reasons.join("; ") };
+  }
+  return recognized(schema);
+}
+
+/** `z.enum([…])` — string literals only. */
+function zodEnum(extraction: StaticExtraction, call: TS.CallExpression): ZodSchemaResult {
+  const { ts } = extraction;
+  const argument = call.arguments[0];
+  if (!argument || !ts.isArrayLiteralExpression(argument)) return unrecognized("z.enum argument is not an array literal");
+  const values: string[] = [];
+  for (const element of argument.elements) {
+    const value = literalValue(extraction, element);
+    if (typeof value !== "string") return unrecognized("z.enum contains a non-literal value");
+    values.push(value);
+  }
+  return recognized({ type: "string", enum: values });
+}
+
+async function zodArray(
+  extraction: StaticExtraction,
+  module: FileModule,
+  call: TS.CallExpression,
+  depth: number,
+): Promise<ZodSchemaResult> {
+  const argument = call.arguments[0];
+  if (!argument) return recognized({ type: "array" });
+  const items = await zodFromExpression(extraction, module, argument, depth + 1);
+  // An unrecognized `items` degrades to a bare `{type:"array"}` (kept
+  // recognized:true with `reason` attached) rather than failing the
+  // whole array closed — but one level up, `recognized()` drops that
+  // `reason` on the floor. A nested-array depth-exhaustion case hits
+  // exactly this and never surfaces as fail-closed at the top; see the
+  // "depth exhaustion" row's comment in static-ts.oracle.test.ts for
+  // the traced example and the modifier-chain workaround it uses instead.
+  return items.recognized
+    ? recognized({ type: "array", items: items.schema })
+    : { schema: { type: "array" }, optional: false, recognized: true, reason: items.reason };
+}
+
+/** `z.union([…])` / `z.discriminatedUnion(key, […])` — every option must be
+ *  interpretable, or the whole union fails closed. */
+async function zodUnion(
   extraction: StaticExtraction,
   module: FileModule,
   method: string,
@@ -340,93 +415,50 @@ async function zodBase(
   depth: number,
 ): Promise<ZodSchemaResult> {
   const { ts } = extraction;
-  const ok = (schema: Record<string, unknown>): ZodSchemaResult => ({ schema, optional: false, recognized: true });
+  const argument = call.arguments[method === "union" ? 0 : 1];
+  if (!argument || !ts.isArrayLiteralExpression(argument)) return unrecognized(`z.${method} options are not an array literal`);
+  const options: Record<string, unknown>[] = [];
+  for (const element of argument.elements) {
+    const option = await zodFromExpression(extraction, module, element, depth + 1);
+    if (!option.recognized) return unrecognized(option.reason ?? `z.${method} option not statically interpreted`);
+    options.push(option.schema);
+  }
+  return recognized({ anyOf: options });
+}
+
+async function zodBase(
+  extraction: StaticExtraction,
+  module: FileModule,
+  method: string,
+  call: TS.CallExpression,
+  depth: number,
+): Promise<ZodSchemaResult> {
   switch (method) {
-    case "object": {
-      const argument = call.arguments[0];
-      if (!argument || !ts.isObjectLiteralExpression(argument)) return unrecognized("z.object argument is not an object literal");
-      const properties: Record<string, unknown> = {};
-      const required: string[] = [];
-      const reasons: string[] = [];
-      for (const property of argument.properties) {
-        if (!ts.isPropertyAssignment(property)) continue;
-        const key = propertyKeyName(extraction, property.name);
-        if (!key) continue;
-        const value = await zodFromExpression(extraction, module, property.initializer, depth + 1);
-        properties[key] = value.recognized ? value.schema : {};
-        if (!value.recognized && value.reason) reasons.push(`${key}: ${value.reason}`);
-        if (!value.optional && value.recognized) required.push(key);
-      }
-      const schema: Record<string, unknown> = {
-        type: "object",
-        properties,
-        ...(required.length > 0 ? { required } : {}),
-        additionalProperties: false,
-      };
-      if (reasons.length > 0) {
-        // Partially recognized: emit what we know, keep unknown properties permissive.
-        return { schema, optional: false, recognized: true, reason: reasons.join("; ") };
-      }
-      return ok(schema);
-    }
-    case "string": return ok({ type: "string" });
-    case "number": return ok({ type: "number" });
-    case "bigint": return ok({ type: "integer" });
-    case "boolean": return ok({ type: "boolean" });
-    case "date": return ok({ type: "string", format: "date-time" });
-    case "null": return ok({ type: "null" });
+    case "object": return zodObject(extraction, module, call, depth);
+    case "string": return recognized({ type: "string" });
+    case "number": return recognized({ type: "number" });
+    case "bigint": return recognized({ type: "integer" });
+    case "boolean": return recognized({ type: "boolean" });
+    case "date": return recognized({ type: "string", format: "date-time" });
+    case "null": return recognized({ type: "null" });
     case "any":
-    case "unknown": return ok({});
+    case "unknown": return recognized({});
     case "void":
     case "undefined": return { schema: {}, optional: true, recognized: true };
     case "literal": {
       const value = call.arguments[0] ? literalValue(extraction, call.arguments[0]) : undefined;
       if (value === undefined) return unrecognized("z.literal value is not a static literal");
-      return ok({ const: value });
+      return recognized({ const: value });
     }
-    case "enum": {
-      const argument = call.arguments[0];
-      if (!argument || !ts.isArrayLiteralExpression(argument)) return unrecognized("z.enum argument is not an array literal");
-      const values: string[] = [];
-      for (const element of argument.elements) {
-        const value = literalValue(extraction, element);
-        if (typeof value !== "string") return unrecognized("z.enum contains a non-literal value");
-        values.push(value);
-      }
-      return ok({ type: "string", enum: values });
-    }
-    case "array": {
-      const argument = call.arguments[0];
-      if (!argument) return ok({ type: "array" });
-      const items = await zodFromExpression(extraction, module, argument, depth + 1);
-      // An unrecognized `items` degrades to a bare `{type:"array"}` (kept
-      // recognized:true with `reason` attached) rather than failing the
-      // whole array closed — but one level up, `ok()` drops that `reason`
-      // on the floor. A nested-array depth-exhaustion case hits exactly
-      // this and never surfaces as fail-closed at the top; see the
-      // "depth exhaustion" row's comment in static-ts.oracle.test.ts for
-      // the traced example and the modifier-chain workaround it uses instead.
-      return items.recognized
-        ? ok({ type: "array", items: items.schema })
-        : { schema: { type: "array" }, optional: false, recognized: true, reason: items.reason };
-    }
+    case "enum": return zodEnum(extraction, call);
+    case "array": return zodArray(extraction, module, call, depth);
     case "union":
-    case "discriminatedUnion": {
-      const argument = call.arguments[method === "union" ? 0 : 1];
-      if (!argument || !ts.isArrayLiteralExpression(argument)) return unrecognized(`z.${method} options are not an array literal`);
-      const options: Record<string, unknown>[] = [];
-      for (const element of argument.elements) {
-        const option = await zodFromExpression(extraction, module, element, depth + 1);
-        if (!option.recognized) return unrecognized(option.reason ?? `z.${method} option not statically interpreted`);
-        options.push(option.schema);
-      }
-      return ok({ anyOf: options });
-    }
+    case "discriminatedUnion": return zodUnion(extraction, module, method, call, depth);
     case "record": {
       const valueArgument = call.arguments[call.arguments.length - 1];
-      if (!valueArgument) return ok({ type: "object", additionalProperties: true });
+      if (!valueArgument) return recognized({ type: "object", additionalProperties: true });
       const value = await zodFromExpression(extraction, module, valueArgument, depth + 1);
-      return ok({ type: "object", additionalProperties: value.recognized ? value.schema : true });
+      return recognized({ type: "object", additionalProperties: value.recognized ? value.schema : true });
     }
     default:
       return unrecognized(`z.${method} is not statically interpreted`);

--- a/packages/actions/src/sync/trpc.ts
+++ b/packages/actions/src/sync/trpc.ts
@@ -115,6 +115,63 @@ function procedureFromChain(extraction: Extraction, expr: TS.CallExpression, mod
   };
 }
 
+/** `mergeRouters(a, b, …)` — one flat router carrying every argument's entries. */
+async function mergedRouter(
+  extraction: Extraction,
+  module: FileModule,
+  expr: TS.CallExpression,
+  depth: number,
+  contextPath: string,
+): Promise<RouterDef> {
+  const entries = new Map<string, RouterDef | ProcedureDef>();
+  for (const argument of expr.arguments) {
+    const merged = await evaluateRouterExpression(extraction, module, argument, depth + 1, contextPath);
+    if (merged?.kind === "router") {
+      for (const [key, value] of merged.entries) entries.set(key, value);
+    } else {
+      extraction.warnings.push(`trpc: could not statically resolve a mergeRouters argument at ${contextPath || "<root>"}`);
+    }
+  }
+  return { kind: "router", entries };
+}
+
+/** The object literal a router factory was called with: every property is a
+ *  nested router or a procedure, and a spread contributes another router's. */
+async function routerFromObjectLiteral(
+  extraction: Extraction,
+  module: FileModule,
+  argument: TS.ObjectLiteralExpression,
+  depth: number,
+  contextPath: string,
+): Promise<RouterDef> {
+  const { ts } = extraction;
+  const entries = new Map<string, RouterDef | ProcedureDef>();
+  for (const property of argument.properties) {
+    if (ts.isPropertyAssignment(property)) {
+      const key = propertyKeyName(extraction, property.name);
+      if (!key) continue;
+      const child = await evaluateRouterEntry(extraction, module, property.initializer, depth + 1, `${contextPath}${contextPath ? "." : ""}${key}`);
+      if (child) entries.set(key, child);
+    } else if (ts.isShorthandPropertyAssignment(property)) {
+      const key = property.name.text;
+      const resolved = await resolveIdentifier(extraction, module, key, depth + 1);
+      const child = resolved
+        ? await evaluateRouterEntry(extraction, resolved.module, resolved.expr, depth + 1, `${contextPath}${contextPath ? "." : ""}${key}`)
+        : null;
+      if (child) entries.set(key, child);
+      else extraction.warnings.push(`trpc: could not statically resolve router entry "${key}"`);
+    } else if (ts.isSpreadAssignment(property)) {
+      const spread = await evaluateRouterExpression(extraction, module, property.expression, depth + 1, contextPath);
+      if (spread?.kind === "router") {
+        for (const [key, value] of spread.entries) entries.set(key, value);
+      } else {
+        extraction.warnings.push(`trpc: could not statically resolve a spread router entry at ${contextPath || "<root>"}`);
+      }
+    }
+  }
+  return { kind: "router", entries };
+}
+
 async function evaluateRouterExpression(
   extraction: Extraction,
   module: FileModule,
@@ -138,16 +195,7 @@ async function evaluateRouterExpression(
 
   const name = calleeName(extraction, expr);
   if (name && MERGE_ROUTERS_NAMES.has(name)) {
-    const entries = new Map<string, RouterDef | ProcedureDef>();
-    for (const argument of expr.arguments) {
-      const merged = await evaluateRouterExpression(extraction, module, argument, depth + 1, contextPath);
-      if (merged?.kind === "router") {
-        for (const [key, value] of merged.entries) entries.set(key, value);
-      } else {
-        extraction.warnings.push(`trpc: could not statically resolve a mergeRouters argument at ${contextPath || "<root>"}`);
-      }
-    }
-    return { kind: "router", entries };
+    return mergedRouter(extraction, module, expr, depth, contextPath);
   }
 
   if (name && ROUTER_FACTORY_NAMES.has(name) && expr.arguments.length === 1) {
@@ -160,31 +208,7 @@ async function evaluateRouterExpression(
         ? expr.expression.expression.text
         : ts.isIdentifier(expr.expression) ? expr.expression.text : name;
       recordRouterFactorySource(extraction, module, factoryName);
-      const entries = new Map<string, RouterDef | ProcedureDef>();
-      for (const property of argument.properties) {
-        if (ts.isPropertyAssignment(property)) {
-          const key = propertyKeyName(extraction, property.name);
-          if (!key) continue;
-          const child = await evaluateRouterEntry(extraction, module, property.initializer, depth + 1, `${contextPath}${contextPath ? "." : ""}${key}`);
-          if (child) entries.set(key, child);
-        } else if (ts.isShorthandPropertyAssignment(property)) {
-          const key = property.name.text;
-          const resolved = await resolveIdentifier(extraction, module, key, depth + 1);
-          const child = resolved
-            ? await evaluateRouterEntry(extraction, resolved.module, resolved.expr, depth + 1, `${contextPath}${contextPath ? "." : ""}${key}`)
-            : null;
-          if (child) entries.set(key, child);
-          else extraction.warnings.push(`trpc: could not statically resolve router entry "${key}"`);
-        } else if (ts.isSpreadAssignment(property)) {
-          const spread = await evaluateRouterExpression(extraction, module, property.expression, depth + 1, contextPath);
-          if (spread?.kind === "router") {
-            for (const [key, value] of spread.entries) entries.set(key, value);
-          } else {
-            extraction.warnings.push(`trpc: could not statically resolve a spread router entry at ${contextPath || "<root>"}`);
-          }
-        }
-      }
-      return { kind: "router", entries };
+      return routerFromObjectLiteral(extraction, module, argument, depth, contextPath);
     }
   }
 


### PR DESCRIPTION
Pure refactor. The ten functions in `@vendoai/actions` that scored over the
50-point `sonarjs/cognitive-complexity` cap are now assemblers over helpers
named for what they do, in the same module as the code they came from.

No public surface changed, no behaviour changed, **zero test files touched** —
not even an import path.

## Scores (measured with `sonarjs/cognitive-complexity`, threshold 50)

| function | file | before | after |
|---|---|---:|---:|
| `captureHostComponents` | `sync/components.ts` | 103 | **13** |
| `typeNodeSchema` | `sync/server-actions.ts` | 92 | **20** |
| `evaluateRouterExpression` | `sync/trpc.ts` | 83 | **20** |
| `collectModuleActions` | `sync/server-actions.ts` | 73 | **15** |
| `registeredCatalogEntries` | `sync/catalog-scan.ts` | 69 | **10** |
| `executeHost` | `runtime/registry.ts` | 60 | **6** |
| `generate` | `sync/sample-props.ts` | 57 | **22** |
| `schemaForType` | `sync/catalog-scan.ts` | 55 | **27** |
| `zodBase` | `sync/static-ts.ts` | 54 | **9** |
| `walkSteps` | `runtime/steps.ts` | 52 | **45** |

`packages/actions` now reports **0 violations** at threshold 50 (it reported
exactly these 10 on `origin/main`). Nothing was refused.

## What each split is

- **`captureHostComponents`** — the per-site record decision leaves the loop as
  `recordFor` (why a component was skipped, always a property of the source)
  and `capturedRecord` (the record a clean closure earns), over a
  `CaptureContext` holding the run's shared closure state. The loop body is now
  read-source → decide → write.
- **`typeNodeSchema`** — one function per compound TS type node:
  `unionTypeSchema`, `typeLiteralSchema`, `typeReferenceSchema`. The keyword
  switch and literal handling stay in the dispatcher.
- **`evaluateRouterExpression`** — `mergedRouter` (`mergeRouters(…)`) and
  `routerFromObjectLiteral` (the factory's `{…}`, including the shorthand and
  spread arms).
- **`collectModuleActions`** — one collector per exported statement kind
  (`collectFunctionDeclaration`, `collectVariableStatement`,
  `collectExportAssignment`, `collectNamedExports`) over an `ActionCollector`
  carrying the two push dispositions.
- **`registeredCatalogEntries`** — candidate shaping
  (`arrayEntryCandidate` / `registryEntryCandidate`), discovery
  (`catalogExpressionsIn`), per-expression resolution (`catalogCandidates`,
  which follows the imported shared registry) and validation
  (`registeredEntry`) each become their own function. The function-local
  `CatalogContext` interface moved to module scope unchanged.
- **`executeHost`** — three phases, each returning `{…} | { error }` exactly
  like the neighbouring `actAsAuth` already does: `hostRequest` (argument
  binding), `hostHeaders` (away / MCP / present authentication, with the
  present-forward policy in `presentHeaders`), `fetchHostTool` (the request
  itself, which was already an inline async IIFE). The actAs audit enrichment
  stays in the entry point.
- **`generate`** — `generateArray` and `generateObject`.
- **`schemaForType`** — `unionSchema` and `objectSchema`.
- **`zodBase`** — a function per fat zod constructor (`zodObject`, `zodEnum`,
  `zodArray`, `zodUnion`); the thin cases stay in the switch. Its local
  `ok()` helper became the module-level `recognized()` so the extracted cases
  can use it.
- **`walkSteps`** — `resumedState` rebuilds the parked walk's state (or returns
  the result the whole walk carries out). The step/iteration loop is unchanged;
  the header's parity contract with automations' `continueSteps` — same
  `if`/`forEach`/args ordering, same texts — is untouched.

Every "why" comment travelled verbatim with the code it explains.

## How much of the diff is pure movement

`git diff origin/main...HEAD -U0 -- packages/actions`, added vs. removed lines,
whitespace-normalized:

- **54.6%** (523 / 957 added lines) appear **verbatim** among removed lines.
- **65.2%** counting statements that are identical but for a rebound receiver
  (`tool.binding` → `binding`, `result.` → `ctx.result.`, `call.args` → `args`)
  or an error wrapped into the `{ error }` return shape.
- The remaining 333 lines are 278 lines of signature / parameter / interface /
  closing-brace scaffolding for 25 new helpers, plus 55 lines of new doc
  comments.

That is well below the 93–97% the three monster splits scored, and the reason
is structural, not sloppiness: those cut single 2,000-line functions into
modules where whole bodies moved untouched, so per-helper overhead was
negligible. Here ten mid-sized functions (50–180 lines) became 25 helpers, so
signature and parameter overhead dominates the added side.

## Test files changed

**0.** `git diff --stat` touches 8 source files and 1 changeset:

```
packages/actions/src/runtime/registry.ts    | 230 ++++++++++------
packages/actions/src/runtime/steps.ts       |  68 +++--
packages/actions/src/sync/catalog-scan.ts   | 414 ++++++++++++++++------------
packages/actions/src/sync/components.ts     | 241 +++++++++-------
packages/actions/src/sync/sample-props.ts   | 113 ++++----
packages/actions/src/sync/server-actions.ts | 316 +++++++++++++--------
packages/actions/src/sync/static-ts.ts      | 184 ++++++++-----
packages/actions/src/sync/trpc.ts           |  94 ++++---
```

## Functions refused

None. All ten came under the cap without shredding.

`walkSteps` came down least (52 → 45): after lifting the resume-point
reconstruction out, what remains is one irreducible thing — the step loop and
its `forEach` iteration loop, which share `state`, `items`, `outputs` and the
park/halt returns. Splitting the two loops apart would mean threading four
mutable locals through a parameter list, which reads worse than the loop does.
It is under the cap, so it stays as it is.

## vendo-web tandem: no-op

Nothing here is public surface, so `vendo-web` cannot see it. Evidence, against
the clone at `/home/ubuntu/repos/vendo-web`:

1. Exported symbols are byte-identical in all 8 touched files:

```
$ for f in <the 8 files>; do
    diff <(git show origin/main:$f | grep -oE "^export (async function|function|const|interface|type|class|enum) [A-Za-z0-9_]+" | sort) \
         <(grep -oE "^export (async function|function|const|interface|type|class|enum) [A-Za-z0-9_]+" $f | sort) \
    >/dev/null && echo "SAME  $f" || echo "DIFF  $f"; done
SAME  packages/actions/src/runtime/registry.ts
SAME  packages/actions/src/runtime/steps.ts
SAME  packages/actions/src/sync/catalog-scan.ts
SAME  packages/actions/src/sync/components.ts
SAME  packages/actions/src/sync/sample-props.ts
SAME  packages/actions/src/sync/server-actions.ts
SAME  packages/actions/src/sync/static-ts.ts
SAME  packages/actions/src/sync/trpc.ts
```

2. `vendo-web` references none of the 30 new/renamed identifiers:

```
$ grep -rnE --include='*.ts' --include='*.tsx' --include='*.js' --include='*.mjs' \
    'executeHost|hostRequest|hostHeaders|presentHeaders|fetchHostTool|resumedState|capturedRecord|recordFor|unionTypeSchema|typeLiteralSchema|typeReferenceSchema|collectFunctionDeclaration|collectVariableStatement|collectExportAssignment|collectNamedExports|mergedRouter|routerFromObjectLiteral|arrayEntryCandidate|registryEntryCandidate|catalogExpressionsIn|catalogCandidates|registeredEntry|unionSchema|objectSchema|generateArray|generateObject|zodObject|zodEnum|zodArray|zodUnion|CaptureContext|FoundComponent|ActionCollector|RegistrationRun|HostRequest' . \
  | grep -v node_modules
apps/console/lib/automations/exec-bundle.generated.ts:2:  (5× `generateObject` — the AI SDK's, inside a generated bundle blob)
```

3. `vendo-web`'s only contact with this package is `createActions({})` from
   `@vendoai/actions` (4 call sites), whose signature and behaviour are
   unchanged — only the module-private `executeHost` under it was restructured.

## Gate

All four foreground, scoped, redirected to a file.

`pnpm build --filter=@vendoai/actions...` — exit 0
```
@vendoai/actions:build: cache miss, executing 82a3ddf0ee4ecb41
@vendoai/actions:build: $ tsc -p tsconfig.json
 Tasks:    2 successful, 2 total
```

`VITEST_MIN_FORKS=1 VITEST_MAX_FORKS=2 VITEST_MIN_THREADS=1 VITEST_MAX_THREADS=2 npx vitest run` in `packages/actions` — exit 0
```
 Test Files  51 passed | 1 skipped (52)
      Tests  616 passed | 4 skipped (620)
   Duration  93.27s
```

root `pnpm typecheck` — exit 0
```
 Tasks:    42 successful, 42 total
  Time:    1m27.106s
```

root `pnpm lint` — exit 0
```
dependency-guard: OK (15 packages checked)
portability-gate: all legs green
 Tasks:    3 successful, 3 total
```

No lint config was touched: `package.json`, `pnpm-lock.yaml`,
`eslint.report.config.mjs`, `knip.json` and `turbo.json` are all unmodified,
and the throwaway measuring config was deleted before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor: split the 10 most complex functions in `@vendoai/actions` into small, named helpers to lower cognitive complexity and improve readability. No public API or behavior changes; tests untouched.

- **Refactors**
  - Broke large functions into focused helpers across runtime and sync code (e.g., `recordFor`, `capturedRecord`, `unionTypeSchema`, `mergedRouter`, per-export collectors, `hostRequest`/`hostHeaders`/`fetchHostTool`, `generateArray`/`generateObject`, `unionSchema`/`objectSchema`, `zodObject`/`zodEnum`/`zodArray`/`zodUnion`, `resumedState`).
  - Package now reports 0 `sonarjs/cognitive-complexity` violations at threshold 50.
  - No exports changed. No behavior changes. No test files modified.

<sup>Written for commit 254aef32d748ef1a622c1f6ead4956d62c51953a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

