### PR TITLE
refactor(vendo): the CLI's nine complexity monsters read as their own steps

### DIFF
--- a/.changeset/init-doctor-judge-sync-read-as-their-steps.md
+++ b/.changeset/init-doctor-judge-sync-read-as-their-steps.md
@@ -1,0 +1,11 @@
+---
+"@vendoai/vendo": patch
+---
+
+Internal refactor: the CLI's longest functions are split into the steps their
+own section comments already named. `runDoctor` becomes an itinerary over
+per-section check modules, `runJudgmentPass` a pipeline of named stages,
+`runInit`/`buildPlan` their labelled steps, `runSyncFlow` its five stages, and
+`main` a flat command table. Behaviour, output text and exit codes are
+unchanged, and no public surface changed: every exported name, signature and
+module path is identical.

--- a/packages/vendo/src/cli.ts
+++ b/packages/vendo/src/cli.ts
@@ -129,6 +129,142 @@ function target(args: string[]): string {
   return args.find((value) => !value.startsWith("--") && !optionValues.has(value)) ?? process.cwd();
 }
 
+/** One function per command: each owns its own flag validation and the shape it
+ *  hands its runner, so `main` below stays the flat table of what `vendo <x>`
+ *  means. Every one of them prints `vendo <command>: <problems>` + HELP and
+ *  exits 1 rather than passing a bad flag down. */
+async function loginCommand(args: string[]): Promise<number> {
+  const problems = optionErrors(args, new Set(), LOGIN_VALUE_OPTIONS);
+  const wait = option(args, "--wait");
+  if (wait !== undefined && !/^\d+$/.test(wait)) {
+    problems.push("--wait takes a whole number of seconds (example: vendo login --wait 90)");
+  }
+  if (problems.length > 0) {
+    console.error(`vendo login: ${problems.join("; ")}\n\n${HELP}`);
+    return 1;
+  }
+  return runLoginCommand(args);
+}
+
+async function initCommand(args: string[]): Promise<number> {
+  const problems = optionErrors(args, INIT_FLAGS, INIT_VALUE_OPTIONS);
+  const auth = option(args, "--auth");
+  if (auth !== undefined && !INIT_AUTH_VALUES.includes(auth)) {
+    problems.push(`--auth must be one of ${INIT_AUTH_VALUES.join(", ")} (example: vendo init --auth clerk)`);
+  }
+  const framework = option(args, "--framework");
+  if (framework !== undefined && !INIT_FRAMEWORK_VALUES.includes(framework)) {
+    problems.push("--framework must be next, express, or custom (example: vendo init --framework custom for a Cloudflare Worker / Bun / Deno host)");
+  }
+  const cloudKey = option(args, "--cloud-key");
+  if (cloudKey !== undefined && !isVendoKey(cloudKey)) {
+    problems.push("--cloud-key must be a Vendo Cloud key (vnd_ + 40 hex; `vendo login` issues one)");
+  }
+  const engine = option(args, "--engine");
+  if (engine !== undefined && !ENGINE_VALUES.includes(engine)) {
+    problems.push(`--engine must be one of ${ENGINE_VALUES.join(", ")} (example: vendo init --engine codex)`);
+  }
+  if (cloudKey !== undefined && args.includes("--byo")) {
+    problems.push("--cloud-key and --byo answer the same question — pass one or the other");
+  }
+  const initAi = args.includes("--ai") || args.includes("--ai-polish");
+  if (initAi && args.includes("--no-ai")) {
+    problems.push("--ai and --no-ai answer the same question — pass one or the other");
+  }
+  const themePairs = options(args, "--theme");
+  const badTheme = themePairs.find((pair) => !/^[A-Za-z]+=./.test(pair));
+  if (badTheme !== undefined) {
+    problems.push(`--theme takes slot=value (example: vendo init --theme accent=#7c3bed), got ${JSON.stringify(badTheme)}`);
+  }
+  if (problems.length > 0) {
+    console.error(`vendo init: ${problems.join("; ")}\n\n${HELP}`);
+    return 1;
+  }
+  return runInit({
+    targetDir: target(args),
+    agent: args.includes("--agent"),
+    yes: args.includes("--yes"),
+    force: args.includes("--force"),
+    ...(auth === undefined ? {} : { auth: auth as InitOptions["auth"] }),
+    ...(framework === undefined ? {} : { framework: framework as InitOptions["framework"] }),
+    ...(cloudKey === undefined ? {} : { cloudKey }),
+    ...(args.includes("--byo") ? { byo: true } : {}),
+    ...(initAi ? { ai: true } : args.includes("--no-ai") ? { ai: false } : {}),
+    ...(engine === undefined ? {} : { engine }),
+    ...(themePairs.length === 0 ? {} : {
+      themeAnswers: Object.fromEntries(themePairs.map((pair) => {
+        const at = pair.indexOf("=");
+        return [pair.slice(0, at), pair.slice(at + 1)];
+      })),
+    }),
+  });
+}
+
+async function ejectCommand(args: string[]): Promise<number> {
+  const positional = args.filter((value) => !value.startsWith("--"));
+  const list = args.includes("--list");
+  // `eject --list [dir]` has no surface positional — the first one is the dir.
+  return runEject({
+    surface: list ? undefined : positional[0],
+    targetDir: (list ? positional[0] : positional[1]) ?? process.cwd(),
+    list,
+    force: args.includes("--force"),
+  });
+}
+
+async function doctorCommand(args: string[]): Promise<number> {
+  const problems = optionErrors(args, DOCTOR_FLAGS, DOCTOR_VALUE_OPTIONS);
+  if (problems.length > 0) {
+    console.error(`vendo doctor: ${problems.join("; ")}\n\n${HELP}`);
+    return 1;
+  }
+  return runDoctor({
+    targetDir: target(args),
+    url: option(args, "--url"),
+    json: args.includes("--json"),
+    yes: args.includes("--yes"),
+  });
+}
+
+async function syncCommand(args: string[]): Promise<number> {
+  const problems = optionErrors(args, SYNC_FLAGS, SYNC_VALUE_OPTIONS);
+  const engine = option(args, "--engine");
+  if (engine !== undefined && !ENGINE_VALUES.includes(engine)) {
+    problems.push(`--engine must be one of ${ENGINE_VALUES.join(", ")} (example: vendo sync --engine codex)`);
+  }
+  if (args.includes("--review") && args.includes("--json")) {
+    problems.push("--review is interactive and cannot combine with --json");
+  }
+  const syncNoAi = args.includes("--no-ai") || args.includes("--no-watermark");
+  if (args.includes("--ai") && syncNoAi) {
+    problems.push("--ai and --no-ai answer the same question — pass one or the other");
+  }
+  if (args.includes("--push-components") && args.includes("--no-push-components")) {
+    problems.push("--push-components and --no-push-components answer the same question — pass one or the other");
+  }
+  if (problems.length > 0) {
+    console.error(`vendo sync: ${problems.join("; ")}\n\n${HELP}`);
+    return 1;
+  }
+  return runSync({
+    targetDir: target(args),
+    strict: args.includes("--strict"),
+    url: option(args, "--url"),
+    json: args.includes("--json"),
+    report: args.includes("--report"),
+    apiKey: option(args, "--key"),
+    apiUrl: option(args, "--api-url"),
+    review: args.includes("--review"),
+    full: args.includes("--full"),
+    yes: args.includes("--yes"),
+    themeRefresh: args.includes("--theme-refresh"),
+    ...(args.includes("--ai") ? { ai: true } : syncNoAi ? { ai: false } : {}),
+    ...(args.includes("--push-components") ? { pushComponents: true }
+      : args.includes("--no-push-components") ? { pushComponents: false } : {}),
+    ...(engine === undefined ? {} : { engine }),
+  });
+}
+
 export async function main(argv: string[]): Promise<number> {
   const [command, ...args] = argv;
   if (command === undefined || command === "--help" || command === "-h") {
@@ -139,99 +275,14 @@ export async function main(argv: string[]): Promise<number> {
     console.log(CLI_VERSION);
     return 0;
   }
-  if (command === "login") {
-    const problems = optionErrors(args, new Set(), LOGIN_VALUE_OPTIONS);
-    const wait = option(args, "--wait");
-    if (wait !== undefined && !/^\d+$/.test(wait)) {
-      problems.push("--wait takes a whole number of seconds (example: vendo login --wait 90)");
-    }
-    if (problems.length > 0) {
-      console.error(`vendo login: ${problems.join("; ")}\n\n${HELP}`);
-      return 1;
-    }
-    return runLoginCommand(args);
-  }
+  if (command === "login") return loginCommand(args);
   if (command === "cloud") return runCloud(args);
   if (command === "config") return runConfig(args);
   if (command === "knowledge") return runKnowledge(args);
   if (command === "mcp") return runMcp(args);
-  if (command === "init") {
-    const problems = optionErrors(args, INIT_FLAGS, INIT_VALUE_OPTIONS);
-    const auth = option(args, "--auth");
-    if (auth !== undefined && !INIT_AUTH_VALUES.includes(auth)) {
-      problems.push(`--auth must be one of ${INIT_AUTH_VALUES.join(", ")} (example: vendo init --auth clerk)`);
-    }
-    const framework = option(args, "--framework");
-    if (framework !== undefined && !INIT_FRAMEWORK_VALUES.includes(framework)) {
-      problems.push("--framework must be next, express, or custom (example: vendo init --framework custom for a Cloudflare Worker / Bun / Deno host)");
-    }
-    const cloudKey = option(args, "--cloud-key");
-    if (cloudKey !== undefined && !isVendoKey(cloudKey)) {
-      problems.push("--cloud-key must be a Vendo Cloud key (vnd_ + 40 hex; `vendo login` issues one)");
-    }
-    const engine = option(args, "--engine");
-    if (engine !== undefined && !ENGINE_VALUES.includes(engine)) {
-      problems.push(`--engine must be one of ${ENGINE_VALUES.join(", ")} (example: vendo init --engine codex)`);
-    }
-    if (cloudKey !== undefined && args.includes("--byo")) {
-      problems.push("--cloud-key and --byo answer the same question — pass one or the other");
-    }
-    const initAi = args.includes("--ai") || args.includes("--ai-polish");
-    if (initAi && args.includes("--no-ai")) {
-      problems.push("--ai and --no-ai answer the same question — pass one or the other");
-    }
-    const themePairs = options(args, "--theme");
-    const badTheme = themePairs.find((pair) => !/^[A-Za-z]+=./.test(pair));
-    if (badTheme !== undefined) {
-      problems.push(`--theme takes slot=value (example: vendo init --theme accent=#7c3bed), got ${JSON.stringify(badTheme)}`);
-    }
-    if (problems.length > 0) {
-      console.error(`vendo init: ${problems.join("; ")}\n\n${HELP}`);
-      return 1;
-    }
-    return runInit({
-      targetDir: target(args),
-      agent: args.includes("--agent"),
-      yes: args.includes("--yes"),
-      force: args.includes("--force"),
-      ...(auth === undefined ? {} : { auth: auth as InitOptions["auth"] }),
-      ...(framework === undefined ? {} : { framework: framework as InitOptions["framework"] }),
-      ...(cloudKey === undefined ? {} : { cloudKey }),
-      ...(args.includes("--byo") ? { byo: true } : {}),
-      ...(initAi ? { ai: true } : args.includes("--no-ai") ? { ai: false } : {}),
-      ...(engine === undefined ? {} : { engine }),
-      ...(themePairs.length === 0 ? {} : {
-        themeAnswers: Object.fromEntries(themePairs.map((pair) => {
-          const at = pair.indexOf("=");
-          return [pair.slice(0, at), pair.slice(at + 1)];
-        })),
-      }),
-    });
-  }
-  if (command === "eject") {
-    const positional = args.filter((value) => !value.startsWith("--"));
-    const list = args.includes("--list");
-    // `eject --list [dir]` has no surface positional — the first one is the dir.
-    return runEject({
-      surface: list ? undefined : positional[0],
-      targetDir: (list ? positional[0] : positional[1]) ?? process.cwd(),
-      list,
-      force: args.includes("--force"),
-    });
-  }
-  if (command === "doctor") {
-    const problems = optionErrors(args, DOCTOR_FLAGS, DOCTOR_VALUE_OPTIONS);
-    if (problems.length > 0) {
-      console.error(`vendo doctor: ${problems.join("; ")}\n\n${HELP}`);
-      return 1;
-    }
-    return runDoctor({
-      targetDir: target(args),
-      url: option(args, "--url"),
-      json: args.includes("--json"),
-      yes: args.includes("--yes"),
-    });
-  }
+  if (command === "init") return initCommand(args);
+  if (command === "eject") return ejectCommand(args);
+  if (command === "doctor") return doctorCommand(args);
   if (command === "refine") {
     // Retired in #568 (format v3): `vendo sync` now owns AI enrichment of
     // .vendo (compounds/briefs live in .vendo/overrides.json).
@@ -245,44 +296,7 @@ export async function main(argv: string[]): Promise<number> {
     console.error("vendo playground was retired — set Vendo up in your own repo instead: `vendo init`, then `vendo doctor`. Docs: https://vendo.run/quickstart");
     return 1;
   }
-  if (command === "sync") {
-    const problems = optionErrors(args, SYNC_FLAGS, SYNC_VALUE_OPTIONS);
-    const engine = option(args, "--engine");
-    if (engine !== undefined && !ENGINE_VALUES.includes(engine)) {
-      problems.push(`--engine must be one of ${ENGINE_VALUES.join(", ")} (example: vendo sync --engine codex)`);
-    }
-    if (args.includes("--review") && args.includes("--json")) {
-      problems.push("--review is interactive and cannot combine with --json");
-    }
-    const syncNoAi = args.includes("--no-ai") || args.includes("--no-watermark");
-    if (args.includes("--ai") && syncNoAi) {
-      problems.push("--ai and --no-ai answer the same question — pass one or the other");
-    }
-    if (args.includes("--push-components") && args.includes("--no-push-components")) {
-      problems.push("--push-components and --no-push-components answer the same question — pass one or the other");
-    }
-    if (problems.length > 0) {
-      console.error(`vendo sync: ${problems.join("; ")}\n\n${HELP}`);
-      return 1;
-    }
-    return runSync({
-      targetDir: target(args),
-      strict: args.includes("--strict"),
-      url: option(args, "--url"),
-      json: args.includes("--json"),
-      report: args.includes("--report"),
-      apiKey: option(args, "--key"),
-      apiUrl: option(args, "--api-url"),
-      review: args.includes("--review"),
-      full: args.includes("--full"),
-      yes: args.includes("--yes"),
-      themeRefresh: args.includes("--theme-refresh"),
-      ...(args.includes("--ai") ? { ai: true } : syncNoAi ? { ai: false } : {}),
-      ...(args.includes("--push-components") ? { pushComponents: true }
-        : args.includes("--no-push-components") ? { pushComponents: false } : {}),
-      ...(engine === undefined ? {} : { engine }),
-    });
-  }
+  if (command === "sync") return syncCommand(args);
   console.error(`Unknown command: ${command}\n\n${HELP}`);
   return 1;
 }

--- a/packages/vendo/src/cli/doctor-config-checks.ts
+++ b/packages/vendo/src/cli/doctor-config-checks.ts
@@ -1,0 +1,212 @@
+import { readFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { applyJudgment, judgmentsFileSchema, overridesFileSchema, toolsFileSchema, type ExtractedTool, type ToolJudgment, type ToolsFile } from "@vendoai/actions";
+import { firstOpenApiSpec, openApiMountPath } from "@vendoai/actions/sync";
+import { publicBase, type RiskLabel } from "@vendoai/core";
+import { CONFIG_SURFACES, OVERRIDES_ENABLEMENT_NOTE } from "../config-surface.js";
+import { describeDevCredential, resolveDevCredential } from "../dev-creds/resolve.js";
+// Relative (not the #dev-creds condition): the CLI is Node-only and the edge
+// build deliberately does not export the pin map.
+import { SLOT_PIN_ENV } from "../dev-creds/model.js";
+import type { DoctorRun } from "./doctor-report.js";
+import { EJECT_MANIFEST_FILE, type EjectedManifest } from "./eject.js";
+import { walk } from "./theme/walk.js";
+import { exists, readOptional } from "./shared.js";
+
+export async function checkConfigFiles(run: DoctorRun): Promise<void> {
+  const { root } = run;
+  for (const file of ["tools.json", "overrides.json", "policy.json", "brief.md", "theme.json"]) {
+    if (await exists(join(root, ".vendo", file))) run.pass(`config/${file}`, `.vendo/${file}`);
+    else run.fail(`config/${file}`, "E-CFG-001", `missing .vendo/${file}`);
+  }
+  if (!await exists(join(root, ".vendo", "data", ".gitignore"))) run.warn("config/data-gitignore", "E-CFG-002", ".vendo/data/.gitignore is missing");
+}
+
+/** Spec 2026-08-06 §B1 — the deployment's path prefix has exactly one home:
+ *  VENDO_BASE_URL. A spec that declares a DIFFERENT relative server mount is the
+ *  #914 shape by another route: every page renders and every tool call 404s. */
+export async function checkMountAgreement(run: DoctorRun): Promise<void> {
+  const { root, env } = run;
+  const specPath = await firstOpenApiSpec(root);
+  const declaredMount = specPath === null ? "" : await openApiMountPath(specPath);
+  const configuredBase = env["VENDO_BASE_URL"];
+  if (declaredMount === "" || configuredBase === undefined || configuredBase.trim() === "") return;
+  let basePath = "";
+  try {
+    basePath = publicBase(configuredBase).path;
+  } catch {
+    basePath = "";
+  }
+  if (basePath !== declaredMount) {
+    run.fail("config/mount", "E-CFG-003",
+      `${relative(root, specPath!)} declares servers[0].url ${JSON.stringify(declaredMount)} but VENDO_BASE_URL's path is `
+      + `${JSON.stringify(basePath)} — one of them is wrong, and the disagreement 404s every host tool while every page renders. `
+      + `Set VENDO_BASE_URL to the app's FULL public URL including ${JSON.stringify(declaredMount)}, or drop the relative server from the spec.`);
+  } else {
+    run.pass("config/mount", `the OpenAPI server mount and VENDO_BASE_URL agree on ${JSON.stringify(declaredMount)}`);
+  }
+}
+
+/** cse lane 3 — per-surface OWNERSHIP: for each cloud-resolvable content
+ *  surface, is the local file the source of truth, or is it resolved at
+ *  runtime (from hosted config when VENDO_API_KEY is set, else unset)? Local
+ *  only (no console call) — `vendo config status` does the cloud-aware view.
+ *  A programmatic `explicit` override in createVendo is not observable here. */
+export async function checkSurfaceOwnership(run: DoctorRun): Promise<void> {
+  const surfaceOwners = await Promise.all(
+    CONFIG_SURFACES.map(async (surface) => `${surface}=${(await exists(join(run.root, ".vendo", surface))) ? "file" : "runtime"}`),
+  );
+  run.pass("config/ownership", `surface ownership (file = local source of truth; runtime = resolved from hosted config or unset): ${surfaceOwners.join(", ")}. ${OVERRIDES_ENABLEMENT_NOTE}`);
+}
+
+/** Models spec 2026-07-22 — exactly two honest model facts, resolver-based
+ *  (the same resolver the runtime rides, no network): which credential rung
+ *  wins, and any active VENDO_MODEL_* pins. Deliberately NO role/alias
+ *  table: on the Cloud rung the family names map to concrete models
+ *  SERVER-SIDE, so the client would only be guessing. */
+export async function checkModelResolution(run: DoctorRun): Promise<void> {
+  const { env } = run;
+  const modelCredential = await resolveDevCredential({ env });
+  if (modelCredential.rung !== "none") {
+    run.pass("model/credential", `model credential: ${describeDevCredential(modelCredential)}`);
+  } else {
+    run.note("model credential: none found — the live turn check below carries the honest failure");
+  }
+  const activePins = Object.values(SLOT_PIN_ENV)
+    .map((name) => ({ name, value: env[name]?.trim() }))
+    .filter((pin): pin is { name: string; value: string } => (pin.value ?? "").length > 0);
+  if (activePins.length > 0) {
+    run.pass("model/pins", `model pins: ${activePins.map(({ name, value }) => `${name}=${value}`).join(", ")}`);
+  }
+}
+
+/** The three-layer effective stack the runtime resolves: skeleton ⊕ judgments ⊕
+ *  overrides. `applyJudgment` ignores an entry whose binding moved and applies
+ *  the fail-closed audience exclusion, so a disable a check reports is one the
+ *  agent will actually see. A human override still wins last — including a
+ *  deliberate wake of something a judgment disabled. */
+function effectiveGrades(
+  toolsFile: ToolsFile,
+  judgments: Record<string, ToolJudgment>,
+  overridesTools: Record<string, { disabled?: boolean; risk?: RiskLabel }>,
+): { live: number; ungraded: number } {
+  const live = toolsFile.tools.filter((tool) => {
+    const effective = applyJudgment(tool, judgments[tool.name]);
+    return (overridesTools[tool.name]?.disabled ?? effective.disabled ?? false) !== true;
+  });
+  // Risk-grading redesign D4 — not-knowing must be FELT. Extraction only
+  // asserts protocol facts, so a catalog nobody has judged is mostly
+  // `ungraded`, and every ungraded tool asks on each call. Counted over the
+  // same three-layer effective stack, so a judged or overridden grade is
+  // reflected here exactly as the guard will see it.
+  const ungraded = toolsFile.tools.filter((tool) => {
+    const effective = applyJudgment(tool, judgments[tool.name]);
+    return (overridesTools[tool.name]?.risk ?? effective.risk) === "ungraded";
+  });
+  return { live: live.length, ungraded: ungraded.length };
+}
+
+/** Malformed overrides are their own (pre-existing) failure surface, and
+ *  malformed judgments are the judgment pass's own loud failure; the grade
+ *  reads the skeleton rather than guessing at either file. */
+function parseSidecar<T>(raw: string | null, parse: (value: unknown) => T, fallback: T): T {
+  if (raw === null) return fallback;
+  try {
+    return parse(JSON.parse(raw) as unknown);
+  } catch {
+    return fallback;
+  }
+}
+
+/** Not-knowing must be FELT here too. A blind slot is not a failure — the
+ *  tool still works permissively — but it is why an agent pastes a whole
+ *  response into a card instead of binding two fields, and why it calls a
+ *  tool with no arguments when the handler wanted three. */
+function checkSchemaCoverage(run: DoctorRun, tools: ExtractedTool[]): void {
+  const blindInputs = tools
+    .filter((tool) => (tool.inputSchemaSource ?? "unknown") === "unknown")
+    .map((tool) => tool.name);
+  const blindOutputs = tools
+    .filter((tool) => (tool.outputSchemaSource ?? "unknown") === "unknown")
+    .map((tool) => tool.name);
+  const total = tools.length;
+  const coverage = `inputs ${total - blindInputs.length}/${total} · outputs ${total - blindOutputs.length}/${total}`;
+  if (blindInputs.length > 0 || blindOutputs.length > 0) {
+    const blind = [...new Set([...blindInputs, ...blindOutputs])].sort();
+    run.warn(
+      "tools/schemas",
+      "E-TOOLS-004",
+      `catalog: ${coverage} — blind: ${blind.slice(0, 8).join(", ")}${blind.length > 8 ? ` +${blind.length - 8} more` : ""};`
+      + " declare them in your OpenAPI/tRPC contract, or run `vendo sync` with a model key so the judge reads the handlers",
+    );
+  } else if (total > 0) {
+    run.pass("tools/schemas", `catalog: ${coverage}`);
+  }
+}
+
+/** The core promise, statically checkable: does the agent have any HOST
+ *  tool it may actually call? All-disabled is an explicit misconfiguration
+ *  (fail); an empty extraction is a strong warning — connector-only hosts
+ *  are legitimate, but a fresh install landing here means extraction found
+ *  nothing user-facing (field case: an infra product whose surface was all
+ *  internal endpoints ended with tools: [] and a silently useless agent). */
+export async function checkToolCatalog(run: DoctorRun): Promise<void> {
+  const { root } = run;
+  const toolsRaw = await readOptional(join(root, ".vendo", "tools.json"));
+  const overridesRaw = await readOptional(join(root, ".vendo", "overrides.json"));
+  const judgmentsRaw = await readOptional(join(root, ".vendo", "judgments.json"));
+  if (toolsRaw === null) return;
+  try {
+    const toolsParsed: unknown = JSON.parse(toolsRaw);
+    const toolsFile = toolsFileSchema.parse(toolsParsed);
+    const overridesTools = parseSidecar<Record<string, { disabled?: boolean; risk?: RiskLabel }>>(
+      overridesRaw, (value) => overridesFileSchema.parse(value).tools, {});
+    const judgments = parseSidecar<Record<string, ToolJudgment>>(
+      judgmentsRaw, (value) => judgmentsFileSchema.parse(value).tools, {});
+    const { live, ungraded } = effectiveGrades(toolsFile, judgments, overridesTools);
+    if (toolsFile.tools.length === 0) {
+      run.warn("tools/live-surface", "E-TOOLS-002", "the extracted tool surface is empty — the agent cannot act on this product's API; re-run `vendo init` extraction (or ignore if this deployment is connector-only)");
+    } else if (live === 0) {
+      run.fail("tools/live-surface", "E-TOOLS-001", `zero live host tools — all ${toolsFile.tools.length} extracted tools are disabled or excluded; review the audience exclusions in .vendo/overrides.json and re-enable the end-user surface (disabled: false)`);
+    } else {
+      run.pass("tools/live-surface", `${live} live host tool${live === 1 ? "" : "s"}`);
+    }
+    if (ungraded > 0) {
+      run.warn("tools/graded", "E-TOOLS-003", `catalog: ${ungraded}/${toolsFile.tools.length} tools ungraded — each one asks on every call; run \`vendo sync\` with a model key to grade`);
+    } else {
+      run.pass("tools/graded", `catalog: all ${toolsFile.tools.length} tools graded`);
+    }
+    checkSchemaCoverage(run, toolsFile.tools);
+  } catch {
+    // Not a vendo/tools@3 shape (e.g. a placeholder {}) — the config
+    // checks above already govern presence; nothing to grade here.
+  }
+}
+
+/** §4 customization ladder — ejected chrome drift. The ejected pixels are the
+ *  host's code, so a version gap is awareness (warn), never breakage (fail):
+ *  the hooks/wire dependency keeps working; only new presentation is missed. */
+export async function checkEjectDrift(run: DoctorRun): Promise<void> {
+  const { root } = run;
+  const installedUi = await readOptional(join(root, "node_modules", "@vendoai", "ui", "package.json"));
+  let uiVersion: string | null = null;
+  try {
+    if (installedUi !== null) uiVersion = (JSON.parse(installedUi) as { version?: string }).version ?? null;
+  } catch {
+    // Malformed install metadata — skip the drift check rather than fail doctor.
+  }
+  if (uiVersion === null) return;
+  for (const manifestPath of await walk(root, (rel) => rel.endsWith(EJECT_MANIFEST_FILE))) {
+    let ejected: EjectedManifest;
+    try {
+      ejected = JSON.parse(await readFile(manifestPath, "utf8")) as EjectedManifest;
+    } catch {
+      continue;
+    }
+    if (ejected.version === uiVersion) {
+      run.pass(`eject/${ejected.surface}`, `ejected ${ejected.surface} matches @vendoai/ui v${uiVersion}`);
+    } else {
+      run.warn(`eject/${ejected.surface}`, "E-UI-001", `ejected ${ejected.surface} came from @vendoai/ui v${ejected.version} but v${uiVersion} is installed — review the changelog (https://github.com/runvendo/vendo/releases) and \`vendo eject ${ejected.surface} --force\` if you want the new presentation`);
+    }
+  }
+}

--- a/packages/vendo/src/cli/doctor-deps-checks.ts
+++ b/packages/vendo/src/cli/doctor-deps-checks.ts
@@ -1,0 +1,62 @@
+import { installedAiVersion, installedZodVersion, isOlderVersion, npmLatestVersion } from "./dep-versions.js";
+import { zodBelowAiSdkFloor, zodBumpInvocation } from "./provider-deps.js";
+import type { DoctorRun } from "./doctor-report.js";
+import { CLI_VERSION, type Output } from "./shared.js";
+
+/** #478 short-term — @vendoai/vendo speaks AI SDK v6 to the host's `ai`
+ *  package (peer `ai >=6 <7`), but npm installs the peer conflict anyway:
+ *  the static checks all pass and every internal turn then throws
+ *  AI_InvalidPromptError (v7 removed system-role messages). Fail fast on the
+ *  installed major. An absent install is the wiring/turn checks' story, and
+ *  pre-v6 installs predate the peer contract — both skip silently. */
+async function checkAiSdkMajor(run: DoctorRun): Promise<void> {
+  const aiVersion = await installedAiVersion(run.root);
+  const aiMajor = aiVersion === null ? Number.NaN : Number.parseInt(aiVersion, 10);
+  if (aiMajor >= 7) {
+    run.fail("deps/ai-sdk-major", "E-DEP-001", `installed ai@${aiVersion} is unsupported — Vendo supports ai@6; downgrade (npm install ai@^6 @ai-sdk/anthropic@^3 @ai-sdk/react@^3) or track github.com/runvendo/vendo/issues/478`);
+  } else if (aiMajor === 6) {
+    run.pass("deps/ai-sdk-major", `installed ai@${aiVersion} is the supported AI SDK major (v6)`);
+  }
+}
+
+/** FINDINGS F2 — ai@6 imports the zod/v3 + zod/v4 subpaths that arrive in
+ *  zod 3.25; a host pinning older zod builds red inside ai the moment the
+ *  vendo wiring pulls it into the bundle. An absent zod skips silently: a
+ *  host without its own zod resolves ai's copy, which always satisfies. */
+async function checkZodFloor(run: DoctorRun): Promise<void> {
+  const zodVersion = await installedZodVersion(run.root);
+  if (zodVersion !== null && zodBelowAiSdkFloor(zodVersion)) {
+    run.fail("deps/zod-floor", "E-DEP-003", `installed zod@${zodVersion} predates the zod/v3 + zod/v4 subpaths the AI SDK imports (needs >=3.25) — the app build fails inside ai@6; bump within zod 3: ${await zodBumpInvocation(run.root)}`);
+  } else if (zodVersion !== null) {
+    run.pass("deps/zod-floor", `installed zod@${zodVersion} exposes the AI SDK's zod/v3 + zod/v4 subpaths (>=3.25)`);
+  }
+}
+
+/** Self-serve audit F1 — npm release-cooldown configs (`min-release-age`)
+ *  resolve an old @vendoai/vendo silently, and Vendo ships often enough that
+ *  those users stay permanently behind with nothing ever saying so. A hint,
+ *  not a check: it has no fix_ref registry code and never changes the exit
+ *  code, and an unreachable registry says nothing at all. Skipped outright
+ *  under --json, so an agent run never pays for a lookup it cannot see. */
+async function noteVersionBehindLatest(
+  run: DoctorRun,
+  output: Output,
+  npmLatest: (() => Promise<string | null>) | undefined,
+): Promise<void> {
+  if (run.json) return;
+  const latestPublished = await (npmLatest ?? (() => npmLatestVersion("@vendoai/vendo")))();
+  if (latestPublished !== null && isOlderVersion(CLI_VERSION, latestPublished)) {
+    output.error(`warning: installed @vendoai/vendo ${CLI_VERSION} is behind latest ${latestPublished} — npm install @vendoai/vendo@latest (release-cooldown npm configs like min-release-age resolve old versions silently)`);
+  }
+}
+
+/** What the target project actually has installed beside Vendo. */
+export async function checkInstalledDeps(
+  run: DoctorRun,
+  output: Output,
+  npmLatest: (() => Promise<string | null>) | undefined,
+): Promise<void> {
+  await checkAiSdkMajor(run);
+  await checkZodFloor(run);
+  await noteVersionBehindLatest(run, output, npmLatest);
+}

--- a/packages/vendo/src/cli/doctor-mcp-checks.ts
+++ b/packages/vendo/src/cli/doctor-mcp-checks.ts
@@ -1,0 +1,148 @@
+import { join } from "node:path";
+import type { DoctorErrorCode } from "./doctor-codes.js";
+import type { DoctorRun } from "./doctor-report.js";
+import { remoteUrls, sameUrl, validateRegistryServer } from "./mcp/registry.js";
+import { readOptional } from "./shared.js";
+
+/** Fetch a discovery document, grade it, and hand it back so a follow-up check
+ *  can read what it advertised. A non-JSON error page still names its status;
+ *  only a fetch that never answered is "unreachable". */
+type ResolveDocument = (
+  id: string,
+  code: DoctorErrorCode,
+  url: string,
+  valid: (body: Record<string, unknown>) => boolean,
+  label: string,
+) => Promise<Record<string, unknown> | null>;
+
+function documentResolver(run: DoctorRun): ResolveDocument {
+  return async (id, code, url, valid, label) => {
+    let status: number | undefined;
+    try {
+      const response = await run.fetchImpl(url, { headers: { accept: "application/json" } });
+      status = response.status;
+      const body = await response.json() as Record<string, unknown>;
+      if (response.ok && valid(body)) { run.pass(id, label); return body; }
+      run.fail(id, code, `${label} (${status})`);
+    } catch {
+      // A non-JSON error page still names its status; only a fetch that
+      // never answered is "unreachable".
+      if (status === undefined) run.fail(id, code, `${label} is unreachable`);
+      else run.fail(id, code, `${label} (${status})`);
+    }
+    return null;
+  };
+}
+
+/** Remote-AS posture: the door deliberately 404s its own authorization-
+ *  server metadata — an external AS fronts it, named in the protected-
+ *  resource document (RFC 9728 §2). The contract still requires BOTH
+ *  documents to resolve (10-mcp §5), and the runtime fetches the
+ *  EXTERNAL issuer's metadata before it can verify a single token
+ *  (remote-as.ts) — so doctor must resolve that document, not re-read
+ *  the one it already validated. */
+async function checkBrokerAuthorizationServer(
+  run: DoctorRun,
+  resolves: ResolveDocument,
+  resource: Record<string, unknown> | null,
+): Promise<void> {
+  const servers = resource?.authorization_servers;
+  const advertised = Array.isArray(servers) && typeof servers[0] === "string" ? servers[0] as string : undefined;
+  const parses = (value: string): boolean => { try { new URL(value); return true; } catch { return false; } };
+  if (advertised === undefined) {
+    run.fail("mcp/authorization-server", "E-MCP-002", "MCP protected-resource metadata does not name the external authorization server fronting the door");
+  } else if (!parses(advertised)) {
+    run.fail("mcp/authorization-server", "E-MCP-002", `the advertised authorization server "${advertised}" is not a valid URL — the runtime cannot resolve its metadata`);
+  } else {
+    await resolves(
+      "mcp/authorization-server",
+      "E-MCP-002",
+      `${advertised.replace(/\/+$/, "")}/.well-known/oauth-authorization-server`,
+      (body) => body.issuer === advertised,
+      `MCP authorization-server metadata at ${advertised} resolves`,
+    );
+  }
+}
+
+/** 10-mcp §5 — the official registry artifact is optional until a host is
+ *  published, but once present it must describe this live door exactly. */
+async function checkServerJson(run: DoctorRun, liveDoorUrl: string): Promise<void> {
+  const serverJson = await readOptional(join(run.root, "server.json"));
+  if (serverJson === null) return;
+  try {
+    const server = JSON.parse(serverJson) as unknown;
+    const errors = validateRegistryServer(server);
+    if (errors.length === 0) run.pass("mcp/server-json", "server.json matches MCP registry discovery requirements");
+    else run.fail("mcp/server-json", "E-MCP-004", `server.json is invalid: ${errors.join("; ")}`);
+
+    if (remoteUrls(server).some((remote) => sameUrl(remote, liveDoorUrl))) {
+      run.pass("mcp/server-json-remote", "server.json remote agrees with the live MCP door");
+    } else {
+      run.fail("mcp/server-json-remote", "E-MCP-005", `server.json remote does not match the live MCP door ${liveDoorUrl}`);
+    }
+  } catch {
+    run.fail("mcp/server-json", "E-MCP-006", "server.json is invalid JSON");
+  }
+}
+
+async function checkRegistryAuthChallenge(run: DoctorRun, origin: string): Promise<void> {
+  const localChallenge = await readOptional(join(run.root, "public", ".well-known", "mcp-registry-auth"));
+  if (localChallenge !== null) {
+    if (localChallenge.trim().startsWith("v=MCPv1")) run.pass("mcp/registry-auth-local", "local MCP registry auth challenge parses");
+    else run.fail("mcp/registry-auth-local", "E-MCP-007", "local MCP registry auth challenge must start with v=MCPv1");
+  }
+  try {
+    const response = await run.fetchImpl(`${origin}/.well-known/mcp-registry-auth`, {
+      headers: { accept: "text/plain" },
+    });
+    if (response.ok) {
+      const challenge = await response.text();
+      if (challenge.trim().startsWith("v=MCPv1")) run.pass("mcp/registry-auth-live", "MCP registry auth challenge parses");
+      else run.fail("mcp/registry-auth-live", "E-MCP-008", "MCP registry auth challenge must start with v=MCPv1");
+    }
+  } catch {
+    // The HTTP proof is optional; DNS verification may be in use instead.
+  }
+}
+
+/** 10-mcp §5 — when the door is open, verify both discovery documents resolve
+ *  and the server card parses. The metadata is path-inserted (RFC 9728 §3): a
+ *  door mounted at /api/vendo/mcp serves /.well-known/...-resource/api/vendo/mcp. */
+export async function checkMcpDiscovery(run: DoctorRun, mcpPosture: "local" | "broker"): Promise<void> {
+  // Which mode is this door in? Broker mode is DECLARED, so the answer is a
+  // composition fact worth printing rather than inferring from the checks.
+  run.note(mcpPosture === "broker"
+    ? "MCP door mode: broker — an external authorization server fronts it (VENDO_MCP_BROKER_URL, or mcp.remoteAs)"
+    : "MCP door mode: local — the door serves its own OAuth surface (set VENDO_MCP_BROKER_URL to front it with a broker)");
+  const origin = new URL(run.statusUrl).origin;
+  const mountPath = `${new URL(run.statusUrl).pathname.replace(/\/$/, "")}/mcp`;
+  const resolves = documentResolver(run);
+  const resource = await resolves(
+    "mcp/protected-resource",
+    "E-MCP-001",
+    `${origin}/.well-known/oauth-protected-resource${mountPath}`,
+    (body) => typeof body.resource === "string",
+    "MCP protected-resource metadata resolves",
+  );
+  if (mcpPosture === "broker") {
+    await checkBrokerAuthorizationServer(run, resolves, resource);
+  } else {
+    await resolves(
+      "mcp/authorization-server",
+      "E-MCP-002",
+      `${origin}/.well-known/oauth-authorization-server${mountPath}`,
+      (body) => typeof body.issuer === "string",
+      "MCP authorization-server metadata resolves",
+    );
+  }
+  await resolves(
+    "mcp/server-card",
+    "E-MCP-003",
+    `${origin}/.well-known/mcp/server-card.json`,
+    (body) => typeof body.name === "string" && Array.isArray(body.transports),
+    "MCP server card parses",
+  );
+
+  await checkServerJson(run, `${origin}${mountPath}`);
+  await checkRegistryAuthChallenge(run, origin);
+}

--- a/packages/vendo/src/cli/doctor-probe-checks.ts
+++ b/packages/vendo/src/cli/doctor-probe-checks.ts
@@ -1,0 +1,315 @@
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import { stdin, stdout } from "node:process";
+import { startDevServerForProbe } from "./doctor-live.js";
+import { CLI_VERSION, askYesNo } from "./shared.js";
+import { probeBody, type DoctorRun } from "./doctor-report.js";
+import type { DoctorOptions } from "./doctor.js";
+
+/** Whether the optional `e2b` SDK resolves from the target project — the same
+ *  node_modules walk the running wire's dynamic `import("e2b")` performs, so
+ *  doctor certifies the venue against the resolution that will actually be
+ *  asked to load it (0.4.4 defect C: /status said e2b on a host without the
+ *  SDK, and the first build died in an unusable venue). */
+function e2bResolvableFrom(root: string): boolean {
+  try {
+    createRequire(join(root, "__vendo-doctor-probe__.js")).resolve("e2b");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** NOTHING doctor can observe proves WHY the auth probes 404, so neither
+    message below asserts a cause — they report what was seen, name the
+    candidates, and hand the reader the step that separates them.
+
+    `/doctor/base-url` is the best evidence available: wire/doctor.ts mounts it
+    in EVERY environment (wireRoutesFor keeps it outside the `deps.development`
+    ternary) precisely so a production misconfiguration stays probeable, while
+    the probes beside it are development-only. But it is only evidence. A
+    Vendo-shaped answer is indistinguishable between "your dev server with the
+    gate closed" and "a real Vendo deployment that is not the one you meant" —
+    a stale base URL aimed at staging answers identically, byte for byte — and
+    doctor cannot know which deployment the reader intended. In the other
+    direction, ANY non-404 was read as the wire until an HTML catch-all (200),
+    an auth layer (401) and a proxy error page (500) all sailed through, so the
+    body must carry the route's `{ ok }` shape to count as the wire at all. */
+const PROBES_404_WIRE_ANSWERS =
+  "the doctor probes answered 404 while /doctor/base-url — mounted by every composition in every "
+  + "environment — answered like a Vendo wire. Two things look exactly like this from here. Most "
+  + "likely this composition never declared itself development, so the development-only probes were "
+  + "left out of the route table: pass createVendo({ development: true }) for this host, or run it "
+  + "with NODE_ENV=development (next dev sets that for you; a plain node/tsx server does not), "
+  + "restart, and re-run doctor. If they still 404, this URL is a real Vendo deployment but not the "
+  + "dev server you meant — a stale base URL or a proxy aimed at staging or production, which is "
+  + "meant to answer 404 here.";
+
+/** base-url did not answer like the wire, so the development gate is the less
+    likely story: every composition mounts that route. Something answered
+    /status at this URL — a proxy, an HTML catch-all, an unrelated service. */
+const PROBES_404_NO_WIRE = (statusUrl: string, observed: string): string =>
+  `the doctor probes answered 404, and /doctor/base-url — mounted by every composition in every `
+  + `environment — did not answer like a Vendo wire either (${observed}). So most likely ${statusUrl} `
+  + `is not this app's Vendo wire base, even though something there answered /status: check the origin `
+  + `and the FULL mount path you passed (a host under a basePath needs it, e.g. `
+  + `http://localhost:3000/maple/api/vendo), and any proxy, auth layer or HTML catch-all in front of `
+  + `it. If the URL is right, this host's @vendoai/vendo predates the doctor surface — upgrade it and `
+  + `restart the dev server.`;
+
+/** Consent-gated dev-server start (design §5): when nothing is listening on
+ *  the dev port and doctor is interactive, offer to boot it so the live probes
+ *  have something to reach. --yes is the documented non-interactive consent
+ *  (quickstart: "pass --yes to start it non-interactively"), so it bypasses
+ *  the TTY gate. Skipped in --json runs (stdout carries only the final object).
+ *
+ *  Returns the stopper the caller must invoke once the probes are done. */
+export async function startDevServerIfOffered(run: DoctorRun, options: DoctorOptions): Promise<(() => void) | null> {
+  const { statusUrl, fetchImpl, env, root } = run;
+  const interactive = options.interactive ?? (Boolean(stdout.isTTY) && Boolean(stdin.isTTY));
+  const confirm = options.confirm ?? askYesNo;
+  if (run.json || !(interactive || options.yes === true)) return null;
+  let listening = false;
+  try { listening = (await fetchImpl(`${statusUrl}/status`)).ok; } catch { listening = false; }
+  if (listening) return null;
+  const go = options.yes === true
+    || await confirm("Nothing is listening on the dev port. Start the dev server for the probe?", true);
+  if (!go) return null;
+  run.note(`\nStarting the dev server so the probe has a live composition to reach…`);
+  const start = options.startDevServer ?? startDevServerForProbe;
+  const started = await start({ root, statusUrl, env, fetchImpl });
+  if (started.ok) {
+    run.pass("dev/start", "started the dev server for the probe");
+    return started.stop;
+  }
+  run.warn("dev/start", "E-DEV-001", "could not start the dev server for the probe; start it yourself (e.g. `npm run dev`) and re-run `vendo doctor`");
+  return null;
+}
+
+/** 0.4.4 defect C — "ok: execution venue: e2b" on a host that cannot
+ *  actually run e2b is a false blessing: the venue must be USABLE
+ *  (key set and SDK resolvable from this project), or every server-app
+ *  build dies in it instead of riding the Cloud sandbox. */
+function checkE2bVenue(run: DoctorRun, e2bResolvable: ((root: string) => boolean) | undefined): void {
+  const { env, root } = run;
+  const keyPresent = typeof env.E2B_API_KEY === "string" && env.E2B_API_KEY.trim() !== "";
+  const installed = (e2bResolvable ?? e2bResolvableFrom)(root);
+  if (keyPresent && installed) {
+    run.pass("live/venue", "execution venue: e2b");
+    return;
+  }
+  const missing = [
+    ...(keyPresent ? [] : ["E2B_API_KEY is not set"]),
+    ...(installed ? [] : ["the e2b package does not resolve from this project"]),
+  ].join(" and ");
+  // This reads doctor's OWN env and project root, not the server's, so
+  // a live e2b venue failing here means the two disagree.
+  run.fail("live/venue", "E-LIVE-007", `the running wire selected the e2b execution venue but ${missing}; server-app builds will fail in an unusable sandbox. Fix: install the e2b package and set E2B_API_KEY, or remove E2B_API_KEY from the server env (with VENDO_API_KEY set, the managed Cloud sandbox takes over), then restart the dev server and re-run doctor`);
+}
+
+function checkVenue(run: DoctorRun, sandboxVenue: unknown, e2bResolvable: ((root: string) => boolean) | undefined): void {
+  if (sandboxVenue === "e2b") {
+    checkE2bVenue(run, e2bResolvable);
+  } else if (sandboxVenue === "cloud" || sandboxVenue === "custom") {
+    run.pass("live/venue", `execution venue: ${sandboxVenue}`);
+  } else if (sandboxVenue === false) {
+    run.warn("live/venue", "E-LIVE-004", "install the e2b package and set E2B_API_KEY, or set VENDO_API_KEY for the managed Cloud sandbox, or pass sandbox: to createVendo; without one, server apps (rungs 2-4) return sandbox-unavailable");
+  } else if (sandboxVenue === undefined) {
+    // Older hosts predate blocks.sandbox — version skew, not a broken install.
+    run.warn("live/venue", "E-LIVE-005", "host /status does not report an execution venue; upgrade @vendoai/vendo to enable the venue check");
+  } else {
+    run.fail("live/venue", "E-LIVE-003", "/status returned an invalid execution venue");
+  }
+}
+
+/** Split-brain guard (0.4.2 re-run, invoify defect 13): a direct
+ *  @vendoai/vendo dependency pinned to an older range beats the vendoai
+ *  umbrella's for the APP import, so `npm install vendoai@latest` runs a
+ *  new CLI while /status silently serves the old runtime. Any CLI/wire
+ *  version disagreement — split-brain or just a dev server started
+ *  before the upgrade — means doctor is not certifying what users run. */
+function checkVersionSkew(run: DoctorRun, wireVersion: string): void {
+  if (wireVersion === CLI_VERSION) {
+    run.pass("deps/version-skew", `CLI and running wire agree on @vendoai/vendo ${CLI_VERSION}`);
+  } else {
+    run.fail("deps/version-skew", "E-DEP-002", `the running wire serves @vendoai/vendo ${wireVersion} but this CLI is ${CLI_VERSION} — likely a split-brain install (a direct @vendoai/vendo dependency pinned to an older range wins over the vendoai umbrella's). Fix: npm install @vendoai/vendo@${CLI_VERSION} (or remove the direct @vendoai/vendo dependency and reinstall), then restart the dev server and re-run doctor.`);
+  }
+}
+
+export interface LiveComposition {
+  /** 10-mcp §1 — the door flag lives under blocks.mcp. Since the broker
+   *  seam it is a posture ("local" | "broker" | false); older wires still
+   *  send a boolean (version skew), which predates the broker — "local". */
+  mcpPosture: "local" | "broker" | false;
+  live: boolean;
+}
+
+export async function checkLiveStatus(run: DoctorRun, e2bResolvable: ((root: string) => boolean) | undefined): Promise<LiveComposition> {
+  const { statusUrl, fetchImpl } = run;
+  try {
+    const response = await fetchImpl(`${statusUrl}/status`, {
+      headers: { accept: "application/json" },
+    });
+    const body = await response.json() as {
+      posture?: unknown;
+      version?: unknown;
+      blocks?: { mcp?: unknown; sandbox?: unknown } | null;
+    };
+    if (!response.ok || typeof body.posture !== "string" || typeof body.version !== "string"
+      || typeof body.blocks !== "object" || body.blocks === null) {
+      run.fail("live/status", "E-LIVE-001", `/status returned an invalid composition response (${response.status})`);
+      return { mcpPosture: false, live: false };
+    }
+    run.pass("live/status", `/status live round-trip (${body.version}, ${body.posture})`);
+    checkVersionSkew(run, body.version);
+    const mcpPosture = body.blocks.mcp === "broker" ? "broker"
+      : body.blocks.mcp === true || body.blocks.mcp === "local" ? "local"
+      : false;
+    checkVenue(run, body.blocks.sandbox, e2bResolvable);
+    return { mcpPosture, live: true };
+  } catch {
+    run.fail("live/status", "E-LIVE-002", `/status is unreachable at ${statusUrl}/status — doctor expects the WIRE BASE (your app origin plus the mount path, e.g. http://localhost:3000/api/vendo); a bare site origin passed to --url is missing the /api/vendo part`);
+    return { mcpPosture: false, live: false };
+  }
+}
+
+/** Render gate (0.4.1 E2E cert M3): a live wire proves nothing about the
+ *  PAGES — the certified invoify install had every page 500ing (registry
+ *  passed across the Server Component boundary) while doctor exited 0. One
+ *  cheap GET of the app root catches a site that is down for users. */
+export async function checkRootRender(run: DoctorRun): Promise<void> {
+  const { statusUrl, fetchImpl } = run;
+  try {
+    const response = await fetchImpl(`${new URL(statusUrl).origin}/`, { headers: { accept: "text/html" } });
+    if (response.status >= 500) {
+      run.fail("live/render", "E-LIVE-006", `the app's root page returned ${response.status} — the site is crashing for users even though the wire answers (typical cause: the component registry declared in a Server Component layout; move it into your own "use client" file with the provider). Check the dev server log.`);
+    } else {
+      run.pass("live/render", `the app's root page renders (HTTP ${response.status})`);
+    }
+  } catch {
+    // The wire answered but the origin root didn't resolve at all — hosts
+    // that serve no page at / are not doctor's business; skip silently.
+  }
+}
+
+async function checkPresentCredential(run: DoctorRun, probe404Message: () => Promise<string>): Promise<void> {
+  const { statusUrl, fetchImpl } = run;
+  try {
+    const response = await fetchImpl(`${statusUrl}/doctor/present`, {
+      method: "POST",
+      headers: {
+        accept: "application/json",
+        "content-type": "application/json",
+        authorization: "Bearer vendo-doctor-present",
+        cookie: "vendo_doctor_present=1",
+      },
+      body: "{}",
+    });
+    const body = await probeBody(response);
+    if (response.ok && body.ok === true) {
+      run.pass("auth/present", "present credentials reach the host API");
+    } else if (response.status === 404) {
+      run.fail("auth/present", "E-AUTH-001", await probe404Message());
+    } else {
+      run.fail("auth/present", "E-AUTH-001", "present credentials did not reach the host API; set VENDO_BASE_URL to the running host origin and restart the dev server");
+    }
+  } catch {
+    run.fail("auth/present", "E-AUTH-002", `present credential probe is unreachable at ${statusUrl}/doctor/present; restart the dev server and verify VENDO_BASE_URL`);
+  }
+}
+
+async function checkActAs(run: DoctorRun, probe404Message: () => Promise<string>): Promise<void> {
+  const { statusUrl, fetchImpl } = run;
+  try {
+    const response = await fetchImpl(`${statusUrl}/doctor/act-as`, {
+      method: "POST",
+      headers: { accept: "application/json", "content-type": "application/json" },
+      body: "{}",
+    });
+    const body = await probeBody(response);
+    if (response.ok && body.ok === true) {
+      run.pass("auth/act-as", "actAs mint + host verification live round-trip");
+    } else if (body.error?.code === "act-as-not-configured") {
+      run.warn("auth/act-as", "E-AUTH-007", "actAs is not configured; pass createVendo({ actAs }) before enabling away host actions");
+    } else if (response.status === 404) {
+      run.fail("auth/act-as", "E-AUTH-004", await probe404Message());
+    } else {
+      run.fail("auth/act-as", "E-AUTH-004", "actAs mint + host verification failed; check createVendo({ actAs }), its verifier middleware, and the host principal resolver");
+    }
+  } catch {
+    run.fail("auth/act-as", "E-AUTH-005", `actAs probe is unreachable at ${statusUrl}/doctor/act-as; restart the dev server and check createVendo({ actAs })`);
+  }
+}
+
+export async function checkAuthProbes(run: DoctorRun, liveComposition: boolean): Promise<void> {
+  const { statusUrl, fetchImpl } = run;
+  if (!liveComposition) {
+    run.fail("auth/present", "E-AUTH-003", `present credential probe cannot run; start the dev server at ${statusUrl} and retry`);
+    run.fail("auth/act-as", "E-AUTH-006", `cannot probe actAs; start the dev server at ${statusUrl} and retry`);
+    return;
+  }
+  // Asked at most once, and only when a probe actually 404s, so a healthy
+  // run costs no extra request. The route answers `{ ok: true }`, or
+  // `{ ok: false, error }` in a production deployment with VENDO_BASE_URL
+  // unset — a boolean `ok` is the whole fingerprint, and anything without it
+  // (HTML, a redirect target, an error page, no response at all) did not
+  // come from a Vendo route table.
+  let probe404: Promise<string> | undefined;
+  const probe404Message = (): Promise<string> => (probe404 ??= (async () => {
+    let observed = "no response";
+    try {
+      const response = await fetchImpl(`${statusUrl}/doctor/base-url`, { headers: { accept: "application/json" } });
+      if (typeof (await probeBody(response)).ok === "boolean") return PROBES_404_WIRE_ANSWERS;
+      observed = `HTTP ${response.status}, not a Vendo response body`;
+    } catch { /* keep "no response" */ }
+    return PROBES_404_NO_WIRE(statusUrl, observed);
+  })());
+
+  await checkPresentCredential(run, probe404Message);
+  await checkActAs(run, probe404Message);
+}
+
+/** Machine + schedule REPORTING (no new subcommand): which apps carry a
+ *  machine, what their manifests declare, and whether a schedule caller is
+ *  configured for the authenticated /tick surface. Declarations only — when a
+ *  schedule last ran is the automation's run records now, and printing "never
+ *  fired" from a payload that no longer carries last-fired state would be a
+ *  doctor telling you something untrue. /doctor/machines is a dev-only route,
+ *  so an unreachable or older host simply skips the section (reporting must
+ *  never break doctor). */
+export async function reportMachines(run: DoctorRun): Promise<void> {
+  const { statusUrl, fetchImpl } = run;
+  try {
+    const response = await fetchImpl(`${statusUrl}/doctor/machines`, { headers: { accept: "application/json" } });
+    if (!response.ok) return;
+    const body = await response.json() as {
+      scheduleCallerConfigured?: unknown;
+      machines?: Array<{
+        appId?: string;
+        name?: string;
+        awake?: boolean;
+        schedules?: Array<{ cron?: string; fn?: string }>;
+      }>;
+    };
+    const machines = Array.isArray(body.machines) ? body.machines : [];
+    run.pass("machines/apps", machines.length === 0
+      ? "no machine-bearing apps"
+      : `${machines.length} machine-bearing app${machines.length === 1 ? "" : "s"}`);
+    for (const machine of machines) {
+      run.note(`  ${machine.appId ?? "?"} (${machine.name ?? "unnamed"}): ${machine.awake === true ? "awake" : "asleep"}`);
+      for (const schedule of machine.schedules ?? []) {
+        run.note(`    ${schedule.cron ?? "?"} -> POST /fn/${schedule.fn ?? "?"}`);
+      }
+    }
+    const declaresSchedules = machines.some((machine) => (machine.schedules?.length ?? 0) > 0);
+    if (body.scheduleCallerConfigured === true) {
+      run.pass("machines/schedule-caller", "schedule caller configured (VENDO_TICK_SECRET); point an external cron at POST /api/vendo/tick");
+    } else if (declaresSchedules) {
+      run.warn("machines/schedule-caller", "E-SCHED-001", "apps declare vendo.json schedules but no schedule caller is configured — set VENDO_TICK_SECRET and point an external cron (Vercel cron, GitHub Actions, crontab) at POST /api/vendo/tick");
+    } else if (machines.length > 0) {
+      run.note("  no schedule caller configured (VENDO_TICK_SECRET unset) — needed once an app declares vendo.json schedules");
+    }
+  } catch {
+    // Reporting only — an unreachable machines route never fails doctor.
+  }
+}

--- a/packages/vendo/src/cli/doctor-report.ts
+++ b/packages/vendo/src/cli/doctor-report.ts
@@ -1,0 +1,80 @@
+import { doctorFixRef, type DoctorErrorCode } from "./doctor-codes.js";
+import type { Output } from "./shared.js";
+
+type CheckStatus = "ok" | "broken" | "warning";
+/** Agent-install DX (design 2026-07-19 §CLI-3) — every check carries a stable
+ *  id; failures and warnings additionally carry the registry error_code and a
+ *  full fix_ref URL. Passing checks carry neither: a pass has no failure mode
+ *  to anchor, so agents filter `status !== "ok"` and follow fix_ref. */
+export interface DoctorCheck {
+  id: string;
+  status: CheckStatus;
+  message: string;
+  error_code?: DoctorErrorCode;
+  fix_ref?: string;
+}
+
+/** The ambient facts every check section reads, plus the four reporters they
+ *  write through. Sections take this and nothing else where they can, so the
+ *  order the checks array is built in stays visible in `runDoctor` rather than
+ *  being spread across the file. */
+export interface DoctorRun {
+  /** The TARGET project's root (a resolved absolute path), not the shell cwd. */
+  root: string;
+  env: Record<string, string | undefined>;
+  json: boolean;
+  /** The wire base every live probe hangs off: origin + mount path. */
+  statusUrl: string;
+  fetchImpl: typeof fetch;
+  checks: DoctorCheck[];
+  failures: number;
+  warnings: number;
+  note: (message: string) => void;
+  pass: (id: string, message: string) => void;
+  fail: (id: string, code: DoctorErrorCode, message: string) => void;
+  warn: (id: string, code: DoctorErrorCode, message: string) => void;
+}
+
+export function createDoctorRun(input: {
+  root: string;
+  env: Record<string, string | undefined>;
+  json: boolean;
+  statusUrl: string;
+  fetchImpl: typeof fetch;
+  output: Output;
+}): DoctorRun {
+  const { json, output } = input;
+  const run: DoctorRun = {
+    root: input.root,
+    env: input.env,
+    json,
+    statusUrl: input.statusUrl,
+    fetchImpl: input.fetchImpl,
+    checks: [],
+    failures: 0,
+    warnings: 0,
+    // In --json mode nothing but the final object may reach stdout; human lines
+    // are suppressed and the same information rides the checks array instead.
+    note: (message: string): void => { if (!json) output.log(message); },
+    // Human lines stay exactly as before (the fix_ref URL is a machine
+    // affordance; --json is the agent surface, so no per-line URL noise here).
+    pass: (id: string, message: string): void => { run.checks.push({ id, status: "ok", message }); if (!json) output.log(`ok: ${message}`); },
+    fail: (id: string, code: DoctorErrorCode, message: string): void => { run.failures += 1; run.checks.push({ id, status: "broken", message, error_code: code, fix_ref: doctorFixRef(code) }); if (!json) output.error(`broken: ${message}`); },
+    warn: (id: string, code: DoctorErrorCode, message: string): void => { run.warnings += 1; run.checks.push({ id, status: "warning", message, error_code: code, fix_ref: doctorFixRef(code) }); if (!json) output.error(`warning: ${message}`); },
+  };
+  return run;
+}
+
+interface DoctorProbeBody {
+  ok?: unknown;
+  error?: { code?: unknown; message?: unknown };
+}
+
+export async function probeBody(response: Response): Promise<DoctorProbeBody> {
+  try {
+    const body = await response.json() as unknown;
+    return typeof body === "object" && body !== null ? body as DoctorProbeBody : {};
+  } catch {
+    return {};
+  }
+}

--- a/packages/vendo/src/cli/doctor-wiring-checks.ts
+++ b/packages/vendo/src/cli/doctor-wiring-checks.ts
@@ -1,0 +1,176 @@
+import { readFile } from "node:fs/promises";
+import { dirname, join, relative } from "node:path";
+import { detectFramework, detectVendoWiring, type VendoWiring } from "./framework.js";
+import { importsGeneratedMap, missingRegistrations, registrationKey, requiredServerActions, serverActionsWiring } from "./init-scaffolds.js";
+import type { DoctorRun } from "./doctor-report.js";
+import { walk } from "./theme/walk.js";
+import { clientRoot, exists, readOptional } from "./shared.js";
+
+async function hasDependency(root: string): Promise<boolean> {
+  try {
+    const manifest = JSON.parse(await readFile(join(root, "package.json"), "utf8")) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    return [manifest.dependencies, manifest.devDependencies].some((deps) =>
+      deps?.["@vendoai/vendo"] !== undefined || deps?.vendoai !== undefined);
+  } catch {
+    return false;
+  }
+}
+
+/** No framework to pattern-match (field case: a Cloudflare Worker + Vite host
+ *  failed E-WIRE-003/004 forever) — judge the wiring by the same bounded source
+ *  scan init uses, never by another framework's file layout. The surface check
+ *  in `checkWiring` still runs; it is source-generic. */
+function checkGenericWiring(run: DoctorRun, wiring: VendoWiring): void {
+  if (wiring.server) run.pass("wiring/server", "createVendo server wiring found");
+  else run.fail("wiring/server", "E-WIRE-007", "no createVendo server wiring found — import createVendo from @vendoai/vendo/server and mount vendo.handler on your runtime's request entry");
+  if (wiring.client) run.pass("wiring/client", "<VendoProvider> wraps the client");
+  else run.warn("wiring/client", "E-WIRE-008", "no <VendoProvider> found in the host source — the @vendoai/ui hooks and embeds need it; ignore this if the host renders a fully custom surface");
+}
+
+function checkExpressWiring(run: DoctorRun, wiring: VendoWiring): void {
+  if (wiring.server) run.pass("wiring/express-server", "Express server is wired");
+  else run.fail("wiring/express-server", "E-WIRE-001", "Express server is not wired with createVendo from @vendoai/vendo/server");
+  if (wiring.client) run.pass("wiring/express-client", "<VendoProvider> wraps the client");
+  else run.fail("wiring/express-client", "E-WIRE-002", "Express client is not wrapped in <VendoProvider>");
+}
+
+async function nextRoutePath(root: string): Promise<string | null> {
+  const routeCandidates = [
+    join(root, "app", "api", "vendo", "[...vendo]", "route.ts"),
+    join(root, "src", "app", "api", "vendo", "[...vendo]", "route.ts"),
+  ];
+  return (await Promise.all(
+    routeCandidates.map(async (candidate) => (await exists(candidate)) ? candidate : null),
+  )).find((candidate) => candidate !== null) ?? null;
+}
+
+/** Server actions (ENG-248): init only ever CREATES, so a route or a
+ *  registration map that predates the host's `"use server"` surface stays
+ *  exactly as the developer left it — and every server-action tool then
+ *  fails closed at execution time with nothing else red. Doctor is where
+ *  that shows up. Every judgment below is the SAME one init makes, from the
+ *  same shared helpers: the two must never disagree about whether a host is
+ *  wired, or one of them is lying. Silent when the host has no live server
+ *  actions at all. */
+async function checkServerActionsWiring(run: DoctorRun, routePath: string): Promise<void> {
+  const { root } = run;
+  const registrations = await requiredServerActions(root);
+  if (registrations.length === 0) return;
+  const routeSource = await readFile(routePath, "utf8").catch(() => "");
+  const wiring = serverActionsWiring(routeSource);
+  if (wiring === "unknown") {
+    // No recognizable createVendo({ … }) — the same shape init declines to
+    // name a paste for. Nothing honest to grade.
+    return;
+  }
+  if (wiring === "wired" && !importsGeneratedMap(routeSource)) {
+    // The route passes a map it composes itself (a local object, an aliased
+    // import). Init leaves that alone by design, and there is no generated
+    // map to grade against — so doctor says nothing rather than guessing.
+    return;
+  }
+  const mapPath = join(dirname(routePath), "vendo-actions.ts");
+  const map = await readOptional(mapPath);
+  const missing = map === null ? registrations : missingRegistrations(map, registrations);
+  if (wiring === "wired" && missing.length === 0) {
+    run.pass("wiring/server-actions", `${registrations.length} server action${registrations.length === 1 ? " is" : "s are"} registered and wired`);
+  } else {
+    run.fail("wiring/server-actions", "E-WIRE-009",
+      `server actions fail closed — ${[
+        ...(missing.length === 0 ? [] : [map === null
+          ? `${relative(root, mapPath)} is missing`
+          : `${relative(root, mapPath)} does not register ${missing.map(registrationKey).join(", ")}`]),
+        // Scoped to the call on purpose: an import line alone is not
+        // wiring, and it is exactly where a half-applied paste lands.
+        ...(wiring === "unwired" ? [`${relative(root, routePath)} does not pass serverActions inside createVendo({ … })`] : []),
+      ].join("; ")}. Re-run \`npx vendo init\`: it prints the exact paste for each (it never rewrites a file you already have).`);
+  }
+}
+
+/** The mount may live in ANY layout, not just the root one (i18n/route-group
+ *  hosts mount in e.g. app/[locale]/layout.tsx — the literal root-layout grep
+ *  fought exactly that correct wiring in the 0.4.1 E2E cert). */
+async function checkProviderMount(run: DoctorRun): Promise<void> {
+  const { root } = run;
+  let rootWired = false;
+  const mountCandidates = [
+    ...await walk(join(root, "app"), (rel) => /(^|[\\/])layout\.(?:tsx|jsx|js)$/.test(rel)),
+    ...await walk(join(root, "src", "app"), (rel) => /(^|[\\/])layout\.(?:tsx|jsx|js)$/.test(rel)),
+    // A pages-only host has no layout to wrap: init hands it pages/_app, so
+    // that is where the mount lives. Without this the check can never pass on
+    // a router shape init explicitly supports.
+    ...["pages", join("src", "pages")].flatMap((pages) =>
+      ["_app.tsx", "_app.jsx", "_app.js"].map((file) => join(root, pages, file))),
+  ];
+  for (const path of mountCandidates) {
+    const source = await readFile(path, "utf8").catch(() => "");
+    if (source.includes("<VendoProvider")) rootWired = true;
+  }
+  if (rootWired) {
+    run.pass("wiring/next-root", "<VendoProvider> wraps the app");
+  } else {
+    // The exact paste, not a description of it: init never edits user source,
+    // so this is the one step a by-the-book install still owes, and doctor is
+    // where a missed paste surfaces. `clientRoot` is init's own answer to
+    // "which file", so the two can never name different files again.
+    const { file: layoutPath, children } = await clientRoot(root);
+    const file = relative(root, layoutPath);
+    run.fail("wiring/next-root", "E-WIRE-004",
+      `no client entry mounts <VendoProvider> — Vendo is wired but nothing on the page can reach it. In ${file}, paste: `
+      + `import { VendoProvider } from "@vendoai/vendo/react";  … then wrap: <VendoProvider baseUrl="/api/vendo">${children}</VendoProvider>. `
+      + "(Any layout that covers your pages works. `vendo init` never edits your source, so this paste is always yours.)");
+  }
+}
+
+async function checkNextWiring(run: DoctorRun): Promise<void> {
+  const routePath = await nextRoutePath(run.root);
+  if (routePath !== null) run.pass("wiring/next-route", "catch-all handler is wired");
+  else run.fail("wiring/next-route", "E-WIRE-003", "missing app/api/vendo/[...vendo]/route.ts");
+  if (routePath !== null) await checkServerActionsWiring(run, routePath);
+  await checkProviderMount(run);
+}
+
+/** VendoRoot is gone in this release (spec 2026-08-06 §B2). A host that still
+ *  names it, or still carries the wrapper init used to generate, gets the
+ *  three-line fix by name instead of a build error it has to decode. */
+async function checkLegacyRoot(run: DoctorRun, legacyRoot: boolean): Promise<void> {
+  const { root } = run;
+  const legacyWrapper = (await Promise.all(
+    [join(root, "vendo", "vendo-root.tsx"), join(root, "src", "vendo", "vendo-root.tsx")]
+      .map(async (candidate) => (await exists(candidate)) ? candidate : null),
+  )).find((candidate) => candidate !== null);
+  if (legacyWrapper !== undefined || legacyRoot) {
+    run.warn("wiring/vendo-root", "E-WIRE-010",
+      `<VendoRoot> was removed — swap it for <VendoProvider baseUrl="/api/vendo">. `
+      + (legacyWrapper === undefined ? "" : `${relative(root, legacyWrapper)} is YOUR file now: change its import to \`import { VendoProvider } from "@vendoai/vendo/react"\`, rename the tag, and add baseUrl. `)
+      + "Nothing else moves — the props are identical.");
+  }
+}
+
+/** The static half of doctor: is this host wired at all, does anything visible
+ *  reach the agent, and is the dependency declared. No network. */
+export async function checkWiring(run: DoctorRun): Promise<void> {
+  const { root } = run;
+  const framework = await detectFramework(root);
+  const wiring = await detectVendoWiring(root);
+  if (framework === "unknown") checkGenericWiring(run, wiring);
+  else if (framework === "express") checkExpressWiring(run, wiring);
+  else await checkNextWiring(run);
+
+  // Visible surface (0.4.1 E2E cert B3): <VendoProvider> is a context provider
+  // that renders NOTHING — two certified stacks ended doctor-green with no
+  // way for a user to reach the agent. Green must mean visible.
+  if (wiring.surface) {
+    run.pass("wiring/surface", "a visible agent surface is mounted (<VendoOverlay /> or an equivalent)");
+  } else {
+    run.fail("wiring/surface", "E-WIRE-006", "no visible agent surface is mounted — <VendoProvider> renders nothing by itself; add <VendoOverlay /> (the launcher pill + panel) or render your own surface (<VendoThread />, <VendoToolResult>, the BYO embeds)");
+  }
+
+  await checkLegacyRoot(run, wiring.legacyRoot);
+
+  if (await hasDependency(root)) run.pass("wiring/dependency", "@vendoai/vendo dependency is declared");
+  else run.fail("wiring/dependency", "E-WIRE-005", "@vendoai/vendo (or vendoai alias) is not declared");
+}

--- a/packages/vendo/src/cli/doctor.ts
+++ b/packages/vendo/src/cli/doctor.ts
@@ -1,32 +1,18 @@
-import { readFile } from "node:fs/promises";
-import { createRequire } from "node:module";
-import { dirname, join, relative, resolve } from "node:path";
-import { stdin, stdout } from "node:process";
+import { resolve } from "node:path";
 import type { Telemetry } from "@vendoai/telemetry";
 import {
   cloudDoctor,
   liveModelTurn,
-  startDevServerForProbe,
   type CloudDoctorResult,
   type LiveTurnResult,
 } from "./doctor-live.js";
-import { installedAiVersion, installedZodVersion, isOlderVersion, npmLatestVersion } from "./dep-versions.js";
-import { zodBelowAiSdkFloor, zodBumpInvocation } from "./provider-deps.js";
-import { describeDevCredential, resolveDevCredential } from "../dev-creds/resolve.js";
-// Relative (not the #dev-creds condition): the CLI is Node-only and the edge
-// build deliberately does not export the pin map.
-import { SLOT_PIN_ENV } from "../dev-creds/model.js";
-import { doctorFixRef, type DoctorErrorCode } from "./doctor-codes.js";
-import { EJECT_MANIFEST_FILE, type EjectedManifest } from "./eject.js";
-import { applyJudgment, judgmentsFileSchema, overridesFileSchema, toolsFileSchema, type ToolJudgment } from "@vendoai/actions";
-import { firstOpenApiSpec, openApiMountPath } from "@vendoai/actions/sync";
-import { publicBase, type RiskLabel } from "@vendoai/core";
-import { detectFramework, detectVendoWiring } from "./framework.js";
-import { importsGeneratedMap, missingRegistrations, registrationKey, requiredServerActions, serverActionsWiring } from "./init-scaffolds.js";
-import { CONFIG_SURFACES, OVERRIDES_ENABLEMENT_NOTE } from "../config-surface.js";
-import { walk } from "./theme/walk.js";
-import { remoteUrls, sameUrl, validateRegistryServer } from "./mcp/registry.js";
-import { askYesNo, clientRoot, CLI_VERSION, consoleOutput, exists, readOptional, toolingTelemetry, type Output } from "./shared.js";
+import { checkConfigFiles, checkEjectDrift, checkModelResolution, checkMountAgreement, checkSurfaceOwnership, checkToolCatalog } from "./doctor-config-checks.js";
+import { checkInstalledDeps } from "./doctor-deps-checks.js";
+import { checkMcpDiscovery } from "./doctor-mcp-checks.js";
+import { checkAuthProbes, checkLiveStatus, checkRootRender, reportMachines, startDevServerIfOffered } from "./doctor-probe-checks.js";
+import { createDoctorRun, type DoctorRun } from "./doctor-report.js";
+import { checkWiring } from "./doctor-wiring-checks.js";
+import { CLI_VERSION, consoleOutput, toolingTelemetry, type Output } from "./shared.js";
 import { readEnvFiles } from "./sync-flow.js";
 
 export interface DoctorOptions {
@@ -59,46 +45,6 @@ export interface DoctorOptions {
   npmLatest?: () => Promise<string | null>;
 }
 
-type CheckStatus = "ok" | "broken" | "warning";
-/** Agent-install DX (design 2026-07-19 §CLI-3) — every check carries a stable
- *  id; failures and warnings additionally carry the registry error_code and a
- *  full fix_ref URL. Passing checks carry neither: a pass has no failure mode
- *  to anchor, so agents filter `status !== "ok"` and follow fix_ref. */
-interface DoctorCheck {
-  id: string;
-  status: CheckStatus;
-  message: string;
-  error_code?: DoctorErrorCode;
-  fix_ref?: string;
-}
-
-/** Whether the optional `e2b` SDK resolves from the target project — the same
- *  node_modules walk the running wire's dynamic `import("e2b")` performs, so
- *  doctor certifies the venue against the resolution that will actually be
- *  asked to load it (0.4.4 defect C: /status said e2b on a host without the
- *  SDK, and the first build died in an unusable venue). */
-function e2bResolvableFrom(root: string): boolean {
-  try {
-    createRequire(join(root, "__vendo-doctor-probe__.js")).resolve("e2b");
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function hasDependency(root: string): Promise<boolean> {
-  try {
-    const manifest = JSON.parse(await readFile(join(root, "package.json"), "utf8")) as {
-      dependencies?: Record<string, string>;
-      devDependencies?: Record<string, string>;
-    };
-    return [manifest.dependencies, manifest.devDependencies].some((deps) =>
-      deps?.["@vendoai/vendo"] !== undefined || deps?.vendoai !== undefined);
-  } catch {
-    return false;
-  }
-}
-
 /** root rides in as the client's cwd: projectIdHash/packageManager and the
     .env.local cloud-key read attribute to the TARGET project, not the shell
     cwd. Seams in options.telemetry win. */
@@ -106,59 +52,50 @@ function telemetryFor(options: DoctorOptions, output: Output, root: string): Tel
   return toolingTelemetry({ cwd: root, ...options.telemetry, log: (message) => output.log(message) });
 }
 
-interface DoctorProbeBody {
-  ok?: unknown;
-  error?: { code?: unknown; message?: unknown };
-}
-
-async function probeBody(response: Response): Promise<DoctorProbeBody> {
-  try {
-    const body = await response.json() as unknown;
-    return typeof body === "object" && body !== null ? body as DoctorProbeBody : {};
-  } catch {
-    return {};
+/** One real model turn through the wired route (design §5). Exit 0 == a user
+    would have gotten an answer. Reuses the resolver + vendoModel: the running
+    dev server serves the turn over the same credential doctor reports. */
+async function checkLiveTurn(run: DoctorRun, options: DoctorOptions, liveComposition: boolean): Promise<LiveTurnResult> {
+  const { statusUrl, fetchImpl, env } = run;
+  if (!liveComposition) {
+    run.fail("turn/model", "E-TURN-002", `live model turn cannot run; start the dev server at ${statusUrl} and retry`);
+    return { attempted: false, ok: false, rung: "none", credential: "n/a", elapsedMs: 0, error: "dev server unreachable" };
   }
+  const liveTurn = await (options.liveTurn ?? ((base: string) => liveModelTurn({
+    base,
+    fetchImpl,
+    env,
+  })))(statusUrl);
+  if (liveTurn.ok) {
+    run.pass("turn/model", `live model turn answered over ${liveTurn.credential} (${liveTurn.elapsedMs}ms)`);
+    if (liveTurn.reply !== undefined) run.note(`\n  ${liveTurn.reply.trim()}\n`);
+  } else {
+    run.fail("turn/model", "E-TURN-001", `live model turn did not answer over ${liveTurn.credential}: ${liveTurn.error ?? "no reply"}`);
+  }
+  return liveTurn;
 }
 
-/** NOTHING doctor can observe proves WHY the auth probes 404, so neither
-    message below asserts a cause — they report what was seen, name the
-    candidates, and hand the reader the step that separates them.
-
-    `/doctor/base-url` is the best evidence available: wire/doctor.ts mounts it
-    in EVERY environment (wireRoutesFor keeps it outside the `deps.development`
-    ternary) precisely so a production misconfiguration stays probeable, while
-    the probes beside it are development-only. But it is only evidence. A
-    Vendo-shaped answer is indistinguishable between "your dev server with the
-    gate closed" and "a real Vendo deployment that is not the one you meant" —
-    a stale base URL aimed at staging answers identically, byte for byte — and
-    doctor cannot know which deployment the reader intended. In the other
-    direction, ANY non-404 was read as the wire until an HTML catch-all (200),
-    an auth layer (401) and a proxy error page (500) all sailed through, so the
-    body must carry the route's `{ ok }` shape to count as the wire at all. */
-const PROBES_404_WIRE_ANSWERS =
-  "the doctor probes answered 404 while /doctor/base-url — mounted by every composition in every "
-  + "environment — answered like a Vendo wire. Two things look exactly like this from here. Most "
-  + "likely this composition never declared itself development, so the development-only probes were "
-  + "left out of the route table: pass createVendo({ development: true }) for this host, or run it "
-  + "with NODE_ENV=development (next dev sets that for you; a plain node/tsx server does not), "
-  + "restart, and re-run doctor. If they still 404, this URL is a real Vendo deployment but not the "
-  + "dev server you meant — a stale base URL or a proxy aimed at staging or production, which is "
-  + "meant to answer 404 here.";
-
-/** base-url did not answer like the wire, so the development gate is the less
-    likely story: every composition mounts that route. Something answered
-    /status at this URL — a proxy, an HTML catch-all, an unrelated service. */
-const PROBES_404_NO_WIRE = (statusUrl: string, observed: string): string =>
-  `the doctor probes answered 404, and /doctor/base-url — mounted by every composition in every `
-  + `environment — did not answer like a Vendo wire either (${observed}). So most likely ${statusUrl} `
-  + `is not this app's Vendo wire base, even though something there answered /status: check the origin `
-  + `and the FULL mount path you passed (a host under a basePath needs it, e.g. `
-  + `http://localhost:3000/maple/api/vendo), and any proxy, auth layer or HTML catch-all in front of `
-  + `it. If the URL is right, this host's @vendoai/vendo predates the doctor surface — upgrade it and `
-  + `restart the dev server.`;
+/** VENDO_API_KEY local shape check + what Cloud unlocks (design §5-6). Key
+    problems surface on the first real service call — no validate round-trip. */
+async function checkCloudKey(run: DoctorRun, options: DoctorOptions): Promise<CloudDoctorResult> {
+  const cloud = await (options.cloudProbe ?? cloudDoctor)({ env: run.env });
+  if (cloud.present && cloud.ok) {
+    run.pass("cloud/key", "Vendo Cloud key present and well-formed");
+  } else if (cloud.present) {
+    run.warn("cloud/key", "E-CLOUD-001", `VENDO_API_KEY is set but not usable: ${cloud.error ?? "malformed"}`);
+  } else {
+    run.note(`Vendo Cloud (optional): no VENDO_API_KEY. A key unlocks ${cloud.unlocks.join("; ")}. Run \`vendo login\` to start.`);
+  }
+  return cloud;
+}
 
 /** 09-vendo §5 / block-actions A — wiring checks plus live composition,
-    present-credential, and actAs mint+verify round-trips. */
+    present-credential, and actAs mint+verify round-trips.
+ *
+ *  An itinerary, and nothing else: every section is a module that takes the
+ *  `DoctorRun` (doctor-report.ts) and appends to its checks array, so the ORDER
+ *  doctor reports in — which is the whole user-visible contract of this command
+ *  — reads top to bottom here instead of over 750 lines. */
 export async function runDoctor(options: DoctorOptions): Promise<number> {
   const root = resolve(options.targetDir);
   const output = options.output ?? consoleOutput;
@@ -169,732 +106,41 @@ export async function runDoctor(options: DoctorOptions): Promise<number> {
   // cloud and live-turn checks and users must export it by hand.
   const env = options.env ?? await readEnvFiles(root);
   const telemetry = telemetryFor(options, output, root);
-  let failures = 0;
-  let warnings = 0;
-  const checks: DoctorCheck[] = [];
-  // In --json mode nothing but the final object may reach stdout; human lines
-  // are suppressed and the same information rides the checks array instead.
-  const note = (message: string): void => { if (!json) output.log(message); };
-  // Human lines stay exactly as before (the fix_ref URL is a machine
-  // affordance; --json is the agent surface, so no per-line URL noise here).
-  const pass = (id: string, message: string): void => { checks.push({ id, status: "ok", message }); if (!json) output.log(`ok: ${message}`); };
-  const fail = (id: string, code: DoctorErrorCode, message: string): void => { failures += 1; checks.push({ id, status: "broken", message, error_code: code, fix_ref: doctorFixRef(code) }); if (!json) output.error(`broken: ${message}`); };
-  const warn = (id: string, code: DoctorErrorCode, message: string): void => { warnings += 1; checks.push({ id, status: "warning", message, error_code: code, fix_ref: doctorFixRef(code) }); if (!json) output.error(`warning: ${message}`); };
+  const run = createDoctorRun({
+    root,
+    env,
+    json,
+    statusUrl: options.url
+      ?? env.VENDO_URL?.replace(/\/$/, "")
+      ?? "http://localhost:3000/api/vendo",
+    fetchImpl: options.fetchImpl ?? fetch,
+    output,
+  });
 
-  const framework = await detectFramework(root);
-  const wiring = await detectVendoWiring(root);
-  if (framework === "unknown") {
-    // No framework to pattern-match (field case: a Cloudflare Worker + Vite
-    // host failed E-WIRE-003/004 forever) — judge the wiring by the same
-    // bounded source scan init uses, never by another framework's file
-    // layout. The surface check below still runs; it is source-generic.
-    if (wiring.server) pass("wiring/server", "createVendo server wiring found");
-    else fail("wiring/server", "E-WIRE-007", "no createVendo server wiring found — import createVendo from @vendoai/vendo/server and mount vendo.handler on your runtime's request entry");
-    if (wiring.client) pass("wiring/client", "<VendoProvider> wraps the client");
-    else warn("wiring/client", "E-WIRE-008", "no <VendoProvider> found in the host source — the @vendoai/ui hooks and embeds need it; ignore this if the host renders a fully custom surface");
-  } else if (framework === "express") {
-    if (wiring.server) pass("wiring/express-server", "Express server is wired");
-    else fail("wiring/express-server", "E-WIRE-001", "Express server is not wired with createVendo from @vendoai/vendo/server");
-    if (wiring.client) pass("wiring/express-client", "<VendoProvider> wraps the client");
-    else fail("wiring/express-client", "E-WIRE-002", "Express client is not wrapped in <VendoProvider>");
-  } else {
-    const routeCandidates = [
-      join(root, "app", "api", "vendo", "[...vendo]", "route.ts"),
-      join(root, "src", "app", "api", "vendo", "[...vendo]", "route.ts"),
-    ];
-    const routePath = (await Promise.all(
-      routeCandidates.map(async (candidate) => (await exists(candidate)) ? candidate : null),
-    )).find((candidate) => candidate !== null) ?? null;
-    if (routePath !== null) pass("wiring/next-route", "catch-all handler is wired");
-    else fail("wiring/next-route", "E-WIRE-003", "missing app/api/vendo/[...vendo]/route.ts");
+  await checkWiring(run);
+  await checkInstalledDeps(run, output, options.npmLatest);
+  await checkConfigFiles(run);
+  await checkMountAgreement(run);
+  await checkSurfaceOwnership(run);
+  await checkModelResolution(run);
+  await checkToolCatalog(run);
+  await checkEjectDrift(run);
 
-    // Server actions (ENG-248): init only ever CREATES, so a route or a
-    // registration map that predates the host's `"use server"` surface stays
-    // exactly as the developer left it — and every server-action tool then
-    // fails closed at execution time with nothing else red. Doctor is where
-    // that shows up. Every judgment below is the SAME one init makes, from the
-    // same shared helpers: the two must never disagree about whether a host is
-    // wired, or one of them is lying. Silent when the host has no live server
-    // actions at all.
-    const registrations = routePath === null ? [] : await requiredServerActions(root);
-    if (routePath !== null && registrations.length > 0) {
-      const routeSource = await readFile(routePath, "utf8").catch(() => "");
-      const wiring = serverActionsWiring(routeSource);
-      if (wiring === "unknown") {
-        // No recognizable createVendo({ … }) — the same shape init declines to
-        // name a paste for. Nothing honest to grade.
-      } else if (wiring === "wired" && !importsGeneratedMap(routeSource)) {
-        // The route passes a map it composes itself (a local object, an aliased
-        // import). Init leaves that alone by design, and there is no generated
-        // map to grade against — so doctor says nothing rather than guessing.
-      } else {
-        const mapPath = join(dirname(routePath), "vendo-actions.ts");
-        const map = await readOptional(mapPath);
-        const missing = map === null ? registrations : missingRegistrations(map, registrations);
-        if (wiring === "wired" && missing.length === 0) {
-          pass("wiring/server-actions", `${registrations.length} server action${registrations.length === 1 ? " is" : "s are"} registered and wired`);
-        } else {
-          fail("wiring/server-actions", "E-WIRE-009",
-            `server actions fail closed — ${[
-              ...(missing.length === 0 ? [] : [map === null
-                ? `${relative(root, mapPath)} is missing`
-                : `${relative(root, mapPath)} does not register ${missing.map(registrationKey).join(", ")}`]),
-              // Scoped to the call on purpose: an import line alone is not
-              // wiring, and it is exactly where a half-applied paste lands.
-              ...(wiring === "unwired" ? [`${relative(root, routePath)} does not pass serverActions inside createVendo({ … })`] : []),
-            ].join("; ")}. Re-run \`npx vendo init\`: it prints the exact paste for each (it never rewrites a file you already have).`);
-        }
-      }
-    }
+  const devServerStop = await startDevServerIfOffered(run, options);
+  const { mcpPosture, live } = await checkLiveStatus(run, options.e2bResolvable);
+  if (live) await checkRootRender(run);
+  await checkAuthProbes(run, live);
+  if (mcpPosture !== false) await checkMcpDiscovery(run, mcpPosture);
+  if (live) await reportMachines(run);
 
-    // The mount may live in ANY layout, not just the root one (i18n/route-group
-    // hosts mount in e.g. app/[locale]/layout.tsx — the literal root-layout
-    // grep fought exactly that correct wiring in the 0.4.1 E2E cert).
-    let rootWired = false;
-    const mountCandidates = [
-      ...await walk(join(root, "app"), (rel) => /(^|[\\/])layout\.(?:tsx|jsx|js)$/.test(rel)),
-      ...await walk(join(root, "src", "app"), (rel) => /(^|[\\/])layout\.(?:tsx|jsx|js)$/.test(rel)),
-      // A pages-only host has no layout to wrap: init hands it pages/_app, so
-      // that is where the mount lives. Without this the check can never pass on
-      // a router shape init explicitly supports.
-      ...["pages", join("src", "pages")].flatMap((pages) =>
-        ["_app.tsx", "_app.jsx", "_app.js"].map((file) => join(root, pages, file))),
-    ];
-    for (const path of mountCandidates) {
-      const source = await readFile(path, "utf8").catch(() => "");
-      if (source.includes("<VendoProvider")) rootWired = true;
-    }
-    if (rootWired) {
-      pass("wiring/next-root", "<VendoProvider> wraps the app");
-    } else {
-      // The exact paste, not a description of it: init never edits user source,
-      // so this is the one step a by-the-book install still owes, and doctor is
-      // where a missed paste surfaces. `clientRoot` is init's own answer to
-      // "which file", so the two can never name different files again.
-      const { file: layoutPath, children } = await clientRoot(root);
-      const file = relative(root, layoutPath);
-      fail("wiring/next-root", "E-WIRE-004",
-        `no client entry mounts <VendoProvider> — Vendo is wired but nothing on the page can reach it. In ${file}, paste: `
-        + `import { VendoProvider } from "@vendoai/vendo/react";  … then wrap: <VendoProvider baseUrl="/api/vendo">${children}</VendoProvider>. `
-        + "(Any layout that covers your pages works. `vendo init` never edits your source, so this paste is always yours.)");
-    }
-  }
+  run.note("Ladder: execution venue is checked above; actAs for away host actions; connectors for external tools.");
 
-  // Visible surface (0.4.1 E2E cert B3): <VendoProvider> is a context provider
-  // that renders NOTHING — two certified stacks ended doctor-green with no
-  // way for a user to reach the agent. Green must mean visible.
-  if (wiring.surface) {
-    pass("wiring/surface", "a visible agent surface is mounted (<VendoOverlay /> or an equivalent)");
-  } else {
-    fail("wiring/surface", "E-WIRE-006", "no visible agent surface is mounted — <VendoProvider> renders nothing by itself; add <VendoOverlay /> (the launcher pill + panel) or render your own surface (<VendoThread />, <VendoToolResult>, the BYO embeds)");
-  }
-
-  // VendoRoot is gone in this release (spec 2026-08-06 §B2). A host that still
-  // names it, or still carries the wrapper init used to generate, gets the
-  // three-line fix by name instead of a build error it has to decode.
-  const legacyWrapper = (await Promise.all(
-    [join(root, "vendo", "vendo-root.tsx"), join(root, "src", "vendo", "vendo-root.tsx")]
-      .map(async (candidate) => (await exists(candidate)) ? candidate : null),
-  )).find((candidate) => candidate !== null);
-  if (legacyWrapper !== undefined || wiring.legacyRoot) {
-    warn("wiring/vendo-root", "E-WIRE-010",
-      `<VendoRoot> was removed — swap it for <VendoProvider baseUrl="/api/vendo">. `
-      + (legacyWrapper === undefined ? "" : `${relative(root, legacyWrapper)} is YOUR file now: change its import to \`import { VendoProvider } from "@vendoai/vendo/react"\`, rename the tag, and add baseUrl. `)
-      + "Nothing else moves — the props are identical.");
-  }
-
-  if (await hasDependency(root)) pass("wiring/dependency", "@vendoai/vendo dependency is declared");
-  else fail("wiring/dependency", "E-WIRE-005", "@vendoai/vendo (or vendoai alias) is not declared");
-
-  // #478 short-term — @vendoai/vendo speaks AI SDK v6 to the host's `ai`
-  // package (peer `ai >=6 <7`), but npm installs the peer conflict anyway:
-  // the static checks all pass and every internal turn then throws
-  // AI_InvalidPromptError (v7 removed system-role messages). Fail fast on the
-  // installed major. An absent install is the wiring/turn checks' story, and
-  // pre-v6 installs predate the peer contract — both skip silently.
-  const aiVersion = await installedAiVersion(root);
-  const aiMajor = aiVersion === null ? Number.NaN : Number.parseInt(aiVersion, 10);
-  if (aiMajor >= 7) {
-    fail("deps/ai-sdk-major", "E-DEP-001", `installed ai@${aiVersion} is unsupported — Vendo supports ai@6; downgrade (npm install ai@^6 @ai-sdk/anthropic@^3 @ai-sdk/react@^3) or track github.com/runvendo/vendo/issues/478`);
-  } else if (aiMajor === 6) {
-    pass("deps/ai-sdk-major", `installed ai@${aiVersion} is the supported AI SDK major (v6)`);
-  }
-
-  // FINDINGS F2 — ai@6 imports the zod/v3 + zod/v4 subpaths that arrive in
-  // zod 3.25; a host pinning older zod builds red inside ai the moment the
-  // vendo wiring pulls it into the bundle. An absent zod skips silently: a
-  // host without its own zod resolves ai's copy, which always satisfies.
-  const zodVersion = await installedZodVersion(root);
-  if (zodVersion !== null && zodBelowAiSdkFloor(zodVersion)) {
-    fail("deps/zod-floor", "E-DEP-003", `installed zod@${zodVersion} predates the zod/v3 + zod/v4 subpaths the AI SDK imports (needs >=3.25) — the app build fails inside ai@6; bump within zod 3: ${await zodBumpInvocation(root)}`);
-  } else if (zodVersion !== null) {
-    pass("deps/zod-floor", `installed zod@${zodVersion} exposes the AI SDK's zod/v3 + zod/v4 subpaths (>=3.25)`);
-  }
-
-  // Self-serve audit F1 — npm release-cooldown configs (`min-release-age`)
-  // resolve an old @vendoai/vendo silently, and Vendo ships often enough that
-  // those users stay permanently behind with nothing ever saying so. A hint,
-  // not a check: it has no fix_ref registry code and never changes the exit
-  // code, and an unreachable registry says nothing at all. Skipped outright
-  // under --json, so an agent run never pays for a lookup it cannot see.
-  if (!json) {
-    const latestPublished = await (options.npmLatest ?? (() => npmLatestVersion("@vendoai/vendo")))();
-    if (latestPublished !== null && isOlderVersion(CLI_VERSION, latestPublished)) {
-      output.error(`warning: installed @vendoai/vendo ${CLI_VERSION} is behind latest ${latestPublished} — npm install @vendoai/vendo@latest (release-cooldown npm configs like min-release-age resolve old versions silently)`);
-    }
-  }
-
-  for (const file of ["tools.json", "overrides.json", "policy.json", "brief.md", "theme.json"]) {
-    if (await exists(join(root, ".vendo", file))) pass(`config/${file}`, `.vendo/${file}`);
-    else fail(`config/${file}`, "E-CFG-001", `missing .vendo/${file}`);
-  }
-  if (!await exists(join(root, ".vendo", "data", ".gitignore"))) warn("config/data-gitignore", "E-CFG-002", ".vendo/data/.gitignore is missing");
-
-  // Spec 2026-08-06 §B1 — the deployment's path prefix has exactly one home:
-  // VENDO_BASE_URL. A spec that declares a DIFFERENT relative server mount is the
-  // #914 shape by another route: every page renders and every tool call 404s.
-  const specPath = await firstOpenApiSpec(root);
-  const declaredMount = specPath === null ? "" : await openApiMountPath(specPath);
-  const configuredBase = env["VENDO_BASE_URL"];
-  if (declaredMount !== "" && configuredBase !== undefined && configuredBase.trim() !== "") {
-    let basePath = "";
-    try {
-      basePath = publicBase(configuredBase).path;
-    } catch {
-      basePath = "";
-    }
-    if (basePath !== declaredMount) {
-      fail("config/mount", "E-CFG-003",
-        `${relative(root, specPath!)} declares servers[0].url ${JSON.stringify(declaredMount)} but VENDO_BASE_URL's path is `
-        + `${JSON.stringify(basePath)} — one of them is wrong, and the disagreement 404s every host tool while every page renders. `
-        + `Set VENDO_BASE_URL to the app's FULL public URL including ${JSON.stringify(declaredMount)}, or drop the relative server from the spec.`);
-    } else {
-      pass("config/mount", `the OpenAPI server mount and VENDO_BASE_URL agree on ${JSON.stringify(declaredMount)}`);
-    }
-  }
-
-  // cse lane 3 — per-surface OWNERSHIP: for each cloud-resolvable content
-  // surface, is the local file the source of truth, or is it resolved at
-  // runtime (from hosted config when VENDO_API_KEY is set, else unset)? Local
-  // only (no console call) — `vendo config status` does the cloud-aware view.
-  // A programmatic `explicit` override in createVendo is not observable here.
-  const surfaceOwners = await Promise.all(
-    CONFIG_SURFACES.map(async (surface) => `${surface}=${(await exists(join(root, ".vendo", surface))) ? "file" : "runtime"}`),
-  );
-  pass("config/ownership", `surface ownership (file = local source of truth; runtime = resolved from hosted config or unset): ${surfaceOwners.join(", ")}. ${OVERRIDES_ENABLEMENT_NOTE}`);
-
-  // Models spec 2026-07-22 — exactly two honest model facts, resolver-based
-  // (the same resolver the runtime rides, no network): which credential rung
-  // wins, and any active VENDO_MODEL_* pins. Deliberately NO role/alias
-  // table: on the Cloud rung the family names map to concrete models
-  // SERVER-SIDE, so the client would only be guessing.
-  const modelCredential = await resolveDevCredential({ env });
-  if (modelCredential.rung !== "none") {
-    pass("model/credential", `model credential: ${describeDevCredential(modelCredential)}`);
-  } else {
-    note("model credential: none found — the live turn check below carries the honest failure");
-  }
-  const activePins = Object.values(SLOT_PIN_ENV)
-    .map((name) => ({ name, value: env[name]?.trim() }))
-    .filter((pin): pin is { name: string; value: string } => (pin.value ?? "").length > 0);
-  if (activePins.length > 0) {
-    pass("model/pins", `model pins: ${activePins.map(({ name, value }) => `${name}=${value}`).join(", ")}`);
-  }
-
-  // The core promise, statically checkable: does the agent have any HOST
-  // tool it may actually call? All-disabled is an explicit misconfiguration
-  // (fail); an empty extraction is a strong warning — connector-only hosts
-  // are legitimate, but a fresh install landing here means extraction found
-  // nothing user-facing (field case: an infra product whose surface was all
-  // internal endpoints ended with tools: [] and a silently useless agent).
-  const toolsRaw = await readOptional(join(root, ".vendo", "tools.json"));
-  const overridesRaw = await readOptional(join(root, ".vendo", "overrides.json"));
-  const judgmentsRaw = await readOptional(join(root, ".vendo", "judgments.json"));
-  if (toolsRaw !== null) {
-    try {
-      const toolsParsed: unknown = JSON.parse(toolsRaw);
-      const toolsFile = toolsFileSchema.parse(toolsParsed);
-      let overridesTools: Record<string, { disabled?: boolean; risk?: RiskLabel }> = {};
-      if (overridesRaw !== null) {
-        try {
-          const overridesParsed: unknown = JSON.parse(overridesRaw);
-          overridesTools = overridesFileSchema.parse(overridesParsed).tools;
-        } catch {
-          // Malformed overrides are their own (pre-existing) failure surface.
-        }
-      }
-      let judgments: Record<string, ToolJudgment> = {};
-      if (judgmentsRaw !== null) {
-        try {
-          const judgmentsParsed: unknown = JSON.parse(judgmentsRaw);
-          judgments = judgmentsFileSchema.parse(judgmentsParsed).tools;
-        } catch {
-          // Malformed judgments are the judgment pass's own loud failure; the
-          // grade below reads the skeleton rather than guessing at the file.
-        }
-      }
-      // The SAME three-layer stack the runtime resolves: skeleton ⊕ judgments ⊕
-      // overrides. `applyJudgment` ignores an entry whose binding moved and
-      // applies the fail-closed audience exclusion, so a disable this check
-      // reports is one the agent will actually see. A human override still wins
-      // last — including a deliberate wake of something a judgment disabled.
-      const live = toolsFile.tools.filter((tool) => {
-        const effective = applyJudgment(tool, judgments[tool.name]);
-        return (overridesTools[tool.name]?.disabled ?? effective.disabled ?? false) !== true;
-      });
-      if (toolsFile.tools.length === 0) {
-        warn("tools/live-surface", "E-TOOLS-002", "the extracted tool surface is empty — the agent cannot act on this product's API; re-run `vendo init` extraction (or ignore if this deployment is connector-only)");
-      } else if (live.length === 0) {
-        fail("tools/live-surface", "E-TOOLS-001", `zero live host tools — all ${toolsFile.tools.length} extracted tools are disabled or excluded; review the audience exclusions in .vendo/overrides.json and re-enable the end-user surface (disabled: false)`);
-      } else {
-        pass("tools/live-surface", `${live.length} live host tool${live.length === 1 ? "" : "s"}`);
-      }
-      // Risk-grading redesign D4 — not-knowing must be FELT. Extraction only
-      // asserts protocol facts, so a catalog nobody has judged is mostly
-      // `ungraded`, and every ungraded tool asks on each call. Counted over the
-      // same three-layer effective stack, so a judged or overridden grade is
-      // reflected here exactly as the guard will see it.
-      const ungraded = toolsFile.tools.filter((tool) => {
-        const effective = applyJudgment(tool, judgments[tool.name]);
-        return (overridesTools[tool.name]?.risk ?? effective.risk) === "ungraded";
-      });
-      if (ungraded.length > 0) {
-        warn("tools/graded", "E-TOOLS-003", `catalog: ${ungraded.length}/${toolsFile.tools.length} tools ungraded — each one asks on every call; run \`vendo sync\` with a model key to grade`);
-      } else {
-        pass("tools/graded", `catalog: all ${toolsFile.tools.length} tools graded`);
-      }
-      // Not-knowing must be FELT here too. A blind slot is not a failure — the
-      // tool still works permissively — but it is why an agent pastes a whole
-      // response into a card instead of binding two fields, and why it calls a
-      // tool with no arguments when the handler wanted three.
-      const blindInputs = toolsFile.tools
-        .filter((tool) => (tool.inputSchemaSource ?? "unknown") === "unknown")
-        .map((tool) => tool.name);
-      const blindOutputs = toolsFile.tools
-        .filter((tool) => (tool.outputSchemaSource ?? "unknown") === "unknown")
-        .map((tool) => tool.name);
-      const total = toolsFile.tools.length;
-      const coverage = `inputs ${total - blindInputs.length}/${total} · outputs ${total - blindOutputs.length}/${total}`;
-      if (blindInputs.length > 0 || blindOutputs.length > 0) {
-        const blind = [...new Set([...blindInputs, ...blindOutputs])].sort();
-        warn(
-          "tools/schemas",
-          "E-TOOLS-004",
-          `catalog: ${coverage} — blind: ${blind.slice(0, 8).join(", ")}${blind.length > 8 ? ` +${blind.length - 8} more` : ""};`
-          + " declare them in your OpenAPI/tRPC contract, or run `vendo sync` with a model key so the judge reads the handlers",
-        );
-      } else if (total > 0) {
-        pass("tools/schemas", `catalog: ${coverage}`);
-      }
-    } catch {
-      // Not a vendo/tools@3 shape (e.g. a placeholder {}) — the config
-      // checks above already govern presence; nothing to grade here.
-    }
-  }
-
-  // §4 customization ladder — ejected chrome drift. The ejected pixels are the
-  // host's code, so a version gap is awareness (warn), never breakage (fail):
-  // the hooks/wire dependency keeps working; only new presentation is missed.
-  const installedUi = await readOptional(join(root, "node_modules", "@vendoai", "ui", "package.json"));
-  let uiVersion: string | null = null;
-  try {
-    if (installedUi !== null) uiVersion = (JSON.parse(installedUi) as { version?: string }).version ?? null;
-  } catch {
-    // Malformed install metadata — skip the drift check rather than fail doctor.
-  }
-  if (uiVersion !== null) {
-    for (const manifestPath of await walk(root, (rel) => rel.endsWith(EJECT_MANIFEST_FILE))) {
-      let ejected: EjectedManifest;
-      try {
-        ejected = JSON.parse(await readFile(manifestPath, "utf8")) as EjectedManifest;
-      } catch {
-        continue;
-      }
-      if (ejected.version === uiVersion) {
-        pass(`eject/${ejected.surface}`, `ejected ${ejected.surface} matches @vendoai/ui v${uiVersion}`);
-      } else {
-        warn(`eject/${ejected.surface}`, "E-UI-001", `ejected ${ejected.surface} came from @vendoai/ui v${ejected.version} but v${uiVersion} is installed — review the changelog (https://github.com/runvendo/vendo/releases) and \`vendo eject ${ejected.surface} --force\` if you want the new presentation`);
-      }
-    }
-  }
-
-  const statusUrl = options.url
-    ?? env.VENDO_URL?.replace(/\/$/, "")
-    ?? "http://localhost:3000/api/vendo";
-  const fetchImpl = options.fetchImpl ?? fetch;
-
-  // Consent-gated dev-server start (design §5): when nothing is listening on
-  // the dev port and doctor is interactive, offer to boot it so the live probes
-  // have something to reach. --yes is the documented non-interactive consent
-  // (quickstart: "pass --yes to start it non-interactively"), so it bypasses
-  // the TTY gate. Skipped in --json runs (stdout carries only the final object).
-  const interactive = options.interactive ?? (Boolean(stdout.isTTY) && Boolean(stdin.isTTY));
-  const confirm = options.confirm ?? askYesNo;
-  let devServerStop: (() => void) | null = null;
-  if (!json && (interactive || options.yes === true)) {
-    let listening = false;
-    try { listening = (await fetchImpl(`${statusUrl}/status`)).ok; } catch { listening = false; }
-    if (!listening) {
-      const go = options.yes === true
-        || await confirm("Nothing is listening on the dev port. Start the dev server for the probe?", true);
-      if (go) {
-        note(`\nStarting the dev server so the probe has a live composition to reach…`);
-        const start = options.startDevServer ?? startDevServerForProbe;
-        const started = await start({ root, statusUrl, env, fetchImpl });
-        if (started.ok) { devServerStop = started.stop; pass("dev/start", "started the dev server for the probe"); }
-        else warn("dev/start", "E-DEV-001", "could not start the dev server for the probe; start it yourself (e.g. `npm run dev`) and re-run `vendo doctor`");
-      }
-    }
-  }
-
-  let mcpPosture: "local" | "broker" | false = false;
-  let sandboxVenue: unknown;
-  let liveComposition = false;
-  try {
-    const response = await fetchImpl(`${statusUrl}/status`, {
-      headers: { accept: "application/json" },
-    });
-    const body = await response.json() as {
-      posture?: unknown;
-      version?: unknown;
-      blocks?: { mcp?: unknown; sandbox?: unknown } | null;
-    };
-    if (!response.ok || typeof body.posture !== "string" || typeof body.version !== "string"
-      || typeof body.blocks !== "object" || body.blocks === null) {
-      fail("live/status", "E-LIVE-001", `/status returned an invalid composition response (${response.status})`);
-    } else {
-      pass("live/status", `/status live round-trip (${body.version}, ${body.posture})`);
-      liveComposition = true;
-      // Split-brain guard (0.4.2 re-run, invoify defect 13): a direct
-      // @vendoai/vendo dependency pinned to an older range beats the vendoai
-      // umbrella's for the APP import, so `npm install vendoai@latest` runs a
-      // new CLI while /status silently serves the old runtime. Any CLI/wire
-      // version disagreement — split-brain or just a dev server started
-      // before the upgrade — means doctor is not certifying what users run.
-      if (body.version === CLI_VERSION) {
-        pass("deps/version-skew", `CLI and running wire agree on @vendoai/vendo ${CLI_VERSION}`);
-      } else {
-        fail("deps/version-skew", "E-DEP-002", `the running wire serves @vendoai/vendo ${body.version} but this CLI is ${CLI_VERSION} — likely a split-brain install (a direct @vendoai/vendo dependency pinned to an older range wins over the vendoai umbrella's). Fix: npm install @vendoai/vendo@${CLI_VERSION} (or remove the direct @vendoai/vendo dependency and reinstall), then restart the dev server and re-run doctor.`);
-      }
-      // 10-mcp §1 — the door flag lives under blocks.mcp. Since the broker
-      // seam it is a posture ("local" | "broker" | false); older wires still
-      // send a boolean (version skew), which predates the broker — "local".
-      mcpPosture = body.blocks.mcp === "broker" ? "broker"
-        : body.blocks.mcp === true || body.blocks.mcp === "local" ? "local"
-        : false;
-      sandboxVenue = body.blocks.sandbox;
-      if (sandboxVenue === "e2b") {
-        // 0.4.4 defect C — "ok: execution venue: e2b" on a host that cannot
-        // actually run e2b is a false blessing: the venue must be USABLE
-        // (key set and SDK resolvable from this project), or every server-app
-        // build dies in it instead of riding the Cloud sandbox.
-        const keyPresent = typeof env.E2B_API_KEY === "string" && env.E2B_API_KEY.trim() !== "";
-        const installed = (options.e2bResolvable ?? e2bResolvableFrom)(root);
-        if (keyPresent && installed) {
-          pass("live/venue", "execution venue: e2b");
-        } else {
-          const missing = [
-            ...(keyPresent ? [] : ["E2B_API_KEY is not set"]),
-            ...(installed ? [] : ["the e2b package does not resolve from this project"]),
-          ].join(" and ");
-          // This reads doctor's OWN env and project root, not the server's, so
-          // a live e2b venue failing here means the two disagree.
-          fail("live/venue", "E-LIVE-007", `the running wire selected the e2b execution venue but ${missing}; server-app builds will fail in an unusable sandbox. Fix: install the e2b package and set E2B_API_KEY, or remove E2B_API_KEY from the server env (with VENDO_API_KEY set, the managed Cloud sandbox takes over), then restart the dev server and re-run doctor`);
-        }
-      } else if (sandboxVenue === "cloud" || sandboxVenue === "custom") {
-        pass("live/venue", `execution venue: ${sandboxVenue}`);
-      } else if (sandboxVenue === false) {
-        warn("live/venue", "E-LIVE-004", "install the e2b package and set E2B_API_KEY, or set VENDO_API_KEY for the managed Cloud sandbox, or pass sandbox: to createVendo; without one, server apps (rungs 2-4) return sandbox-unavailable");
-      } else if (sandboxVenue === undefined) {
-        // Older hosts predate blocks.sandbox — version skew, not a broken install.
-        warn("live/venue", "E-LIVE-005", "host /status does not report an execution venue; upgrade @vendoai/vendo to enable the venue check");
-      } else {
-        fail("live/venue", "E-LIVE-003", "/status returned an invalid execution venue");
-      }
-    }
-  } catch {
-    fail("live/status", "E-LIVE-002", `/status is unreachable at ${statusUrl}/status — doctor expects the WIRE BASE (your app origin plus the mount path, e.g. http://localhost:3000/api/vendo); a bare site origin passed to --url is missing the /api/vendo part`);
-  }
-
-  // Render gate (0.4.1 E2E cert M3): a live wire proves nothing about the
-  // PAGES — the certified invoify install had every page 500ing (registry
-  // passed across the Server Component boundary) while doctor exited 0. One
-  // cheap GET of the app root catches a site that is down for users.
-  if (liveComposition) {
-    try {
-      const response = await fetchImpl(`${new URL(statusUrl).origin}/`, { headers: { accept: "text/html" } });
-      if (response.status >= 500) {
-        fail("live/render", "E-LIVE-006", `the app's root page returned ${response.status} — the site is crashing for users even though the wire answers (typical cause: the component registry declared in a Server Component layout; move it into your own "use client" file with the provider). Check the dev server log.`);
-      } else {
-        pass("live/render", `the app's root page renders (HTTP ${response.status})`);
-      }
-    } catch {
-      // The wire answered but the origin root didn't resolve at all — hosts
-      // that serve no page at / are not doctor's business; skip silently.
-    }
-  }
-
-  if (!liveComposition) {
-    fail("auth/present", "E-AUTH-003", `present credential probe cannot run; start the dev server at ${statusUrl} and retry`);
-    fail("auth/act-as", "E-AUTH-006", `cannot probe actAs; start the dev server at ${statusUrl} and retry`);
-  } else {
-    // Asked at most once, and only when a probe actually 404s, so a healthy
-    // run costs no extra request. The route answers `{ ok: true }`, or
-    // `{ ok: false, error }` in a production deployment with VENDO_BASE_URL
-    // unset — a boolean `ok` is the whole fingerprint, and anything without it
-    // (HTML, a redirect target, an error page, no response at all) did not
-    // come from a Vendo route table.
-    let probe404: Promise<string> | undefined;
-    const probe404Message = (): Promise<string> => (probe404 ??= (async () => {
-      let observed = "no response";
-      try {
-        const response = await fetchImpl(`${statusUrl}/doctor/base-url`, { headers: { accept: "application/json" } });
-        if (typeof (await probeBody(response)).ok === "boolean") return PROBES_404_WIRE_ANSWERS;
-        observed = `HTTP ${response.status}, not a Vendo response body`;
-      } catch { /* keep "no response" */ }
-      return PROBES_404_NO_WIRE(statusUrl, observed);
-    })());
-
-    try {
-      const response = await fetchImpl(`${statusUrl}/doctor/present`, {
-        method: "POST",
-        headers: {
-          accept: "application/json",
-          "content-type": "application/json",
-          authorization: "Bearer vendo-doctor-present",
-          cookie: "vendo_doctor_present=1",
-        },
-        body: "{}",
-      });
-      const body = await probeBody(response);
-      if (response.ok && body.ok === true) {
-        pass("auth/present", "present credentials reach the host API");
-      } else if (response.status === 404) {
-        fail("auth/present", "E-AUTH-001", await probe404Message());
-      } else {
-        fail("auth/present", "E-AUTH-001", "present credentials did not reach the host API; set VENDO_BASE_URL to the running host origin and restart the dev server");
-      }
-    } catch {
-      fail("auth/present", "E-AUTH-002", `present credential probe is unreachable at ${statusUrl}/doctor/present; restart the dev server and verify VENDO_BASE_URL`);
-    }
-
-    try {
-      const response = await fetchImpl(`${statusUrl}/doctor/act-as`, {
-        method: "POST",
-        headers: { accept: "application/json", "content-type": "application/json" },
-        body: "{}",
-      });
-      const body = await probeBody(response);
-      if (response.ok && body.ok === true) {
-        pass("auth/act-as", "actAs mint + host verification live round-trip");
-      } else if (body.error?.code === "act-as-not-configured") {
-        warn("auth/act-as", "E-AUTH-007", "actAs is not configured; pass createVendo({ actAs }) before enabling away host actions");
-      } else if (response.status === 404) {
-        fail("auth/act-as", "E-AUTH-004", await probe404Message());
-      } else {
-        fail("auth/act-as", "E-AUTH-004", "actAs mint + host verification failed; check createVendo({ actAs }), its verifier middleware, and the host principal resolver");
-      }
-    } catch {
-      fail("auth/act-as", "E-AUTH-005", `actAs probe is unreachable at ${statusUrl}/doctor/act-as; restart the dev server and check createVendo({ actAs })`);
-    }
-  }
-
-  // 10-mcp §5 — when the door is open, verify both discovery documents resolve
-  // and the server card parses. The metadata is path-inserted (RFC 9728 §3): a
-  // door mounted at /api/vendo/mcp serves /.well-known/...-resource/api/vendo/mcp.
-  if (mcpPosture !== false) {
-    // Which mode is this door in? Broker mode is DECLARED, so the answer is a
-    // composition fact worth printing rather than inferring from the checks.
-    note(mcpPosture === "broker"
-      ? "MCP door mode: broker — an external authorization server fronts it (VENDO_MCP_BROKER_URL, or mcp.remoteAs)"
-      : "MCP door mode: local — the door serves its own OAuth surface (set VENDO_MCP_BROKER_URL to front it with a broker)");
-    const origin = new URL(statusUrl).origin;
-    const mountPath = `${new URL(statusUrl).pathname.replace(/\/$/, "")}/mcp`;
-    const resolves = async (id: string, code: DoctorErrorCode, url: string, valid: (body: Record<string, unknown>) => boolean, label: string): Promise<Record<string, unknown> | null> => {
-      let status: number | undefined;
-      try {
-        const response = await fetchImpl(url, { headers: { accept: "application/json" } });
-        status = response.status;
-        const body = await response.json() as Record<string, unknown>;
-        if (response.ok && valid(body)) { pass(id, label); return body; }
-        fail(id, code, `${label} (${status})`);
-      } catch {
-        // A non-JSON error page still names its status; only a fetch that
-        // never answered is "unreachable".
-        if (status === undefined) fail(id, code, `${label} is unreachable`);
-        else fail(id, code, `${label} (${status})`);
-      }
-      return null;
-    };
-    const resource = await resolves(
-      "mcp/protected-resource",
-      "E-MCP-001",
-      `${origin}/.well-known/oauth-protected-resource${mountPath}`,
-      (body) => typeof body.resource === "string",
-      "MCP protected-resource metadata resolves",
-    );
-    if (mcpPosture === "broker") {
-      // Remote-AS posture: the door deliberately 404s its own authorization-
-      // server metadata — an external AS fronts it, named in the protected-
-      // resource document (RFC 9728 §2). The contract still requires BOTH
-      // documents to resolve (10-mcp §5), and the runtime fetches the
-      // EXTERNAL issuer's metadata before it can verify a single token
-      // (remote-as.ts) — so doctor must resolve that document, not re-read
-      // the one it already validated.
-      const servers = resource?.authorization_servers;
-      const advertised = Array.isArray(servers) && typeof servers[0] === "string" ? servers[0] as string : undefined;
-      const parses = (value: string): boolean => { try { new URL(value); return true; } catch { return false; } };
-      if (advertised === undefined) {
-        fail("mcp/authorization-server", "E-MCP-002", "MCP protected-resource metadata does not name the external authorization server fronting the door");
-      } else if (!parses(advertised)) {
-        fail("mcp/authorization-server", "E-MCP-002", `the advertised authorization server "${advertised}" is not a valid URL — the runtime cannot resolve its metadata`);
-      } else {
-        await resolves(
-          "mcp/authorization-server",
-          "E-MCP-002",
-          `${advertised.replace(/\/+$/, "")}/.well-known/oauth-authorization-server`,
-          (body) => body.issuer === advertised,
-          `MCP authorization-server metadata at ${advertised} resolves`,
-        );
-      }
-    } else {
-      await resolves(
-        "mcp/authorization-server",
-        "E-MCP-002",
-        `${origin}/.well-known/oauth-authorization-server${mountPath}`,
-        (body) => typeof body.issuer === "string",
-        "MCP authorization-server metadata resolves",
-      );
-    }
-    await resolves(
-      "mcp/server-card",
-      "E-MCP-003",
-      `${origin}/.well-known/mcp/server-card.json`,
-      (body) => typeof body.name === "string" && Array.isArray(body.transports),
-      "MCP server card parses",
-    );
-
-    // 10-mcp §5 — the official registry artifact is optional until a host is
-    // published, but once present it must describe this live door exactly.
-    const serverJson = await readOptional(join(root, "server.json"));
-    if (serverJson !== null) {
-      try {
-        const server = JSON.parse(serverJson) as unknown;
-        const errors = validateRegistryServer(server);
-        if (errors.length === 0) pass("mcp/server-json", "server.json matches MCP registry discovery requirements");
-        else fail("mcp/server-json", "E-MCP-004", `server.json is invalid: ${errors.join("; ")}`);
-
-        const liveDoorUrl = `${origin}${mountPath}`;
-        if (remoteUrls(server).some((remote) => sameUrl(remote, liveDoorUrl))) {
-          pass("mcp/server-json-remote", "server.json remote agrees with the live MCP door");
-        } else {
-          fail("mcp/server-json-remote", "E-MCP-005", `server.json remote does not match the live MCP door ${liveDoorUrl}`);
-        }
-      } catch {
-        fail("mcp/server-json", "E-MCP-006", "server.json is invalid JSON");
-      }
-    }
-
-    const localChallenge = await readOptional(join(root, "public", ".well-known", "mcp-registry-auth"));
-    if (localChallenge !== null) {
-      if (localChallenge.trim().startsWith("v=MCPv1")) pass("mcp/registry-auth-local", "local MCP registry auth challenge parses");
-      else fail("mcp/registry-auth-local", "E-MCP-007", "local MCP registry auth challenge must start with v=MCPv1");
-    }
-    try {
-      const response = await fetchImpl(`${origin}/.well-known/mcp-registry-auth`, {
-        headers: { accept: "text/plain" },
-      });
-      if (response.ok) {
-        const challenge = await response.text();
-        if (challenge.trim().startsWith("v=MCPv1")) pass("mcp/registry-auth-live", "MCP registry auth challenge parses");
-        else fail("mcp/registry-auth-live", "E-MCP-008", "MCP registry auth challenge must start with v=MCPv1");
-      }
-    } catch {
-      // The HTTP proof is optional; DNS verification may be in use instead.
-    }
-  }
-
-  // Machine + schedule REPORTING (no new subcommand): which apps carry a
-  // machine, what their manifests declare, and whether a schedule caller is
-  // configured for the authenticated /tick surface. Declarations only — when a
-  // schedule last ran is the automation's run records now, and printing "never
-  // fired" from a payload that no longer carries last-fired state would be a
-  // doctor telling you something untrue. /doctor/machines is a dev-only route,
-  // so an unreachable or older host simply skips the section (reporting must
-  // never break doctor).
-  if (liveComposition) {
-    try {
-      const response = await fetchImpl(`${statusUrl}/doctor/machines`, { headers: { accept: "application/json" } });
-      if (response.ok) {
-        const body = await response.json() as {
-          scheduleCallerConfigured?: unknown;
-          machines?: Array<{
-            appId?: string;
-            name?: string;
-            awake?: boolean;
-            schedules?: Array<{ cron?: string; fn?: string }>;
-          }>;
-        };
-        const machines = Array.isArray(body.machines) ? body.machines : [];
-        pass("machines/apps", machines.length === 0
-          ? "no machine-bearing apps"
-          : `${machines.length} machine-bearing app${machines.length === 1 ? "" : "s"}`);
-        for (const machine of machines) {
-          note(`  ${machine.appId ?? "?"} (${machine.name ?? "unnamed"}): ${machine.awake === true ? "awake" : "asleep"}`);
-          for (const schedule of machine.schedules ?? []) {
-            note(`    ${schedule.cron ?? "?"} -> POST /fn/${schedule.fn ?? "?"}`);
-          }
-        }
-        const declaresSchedules = machines.some((machine) => (machine.schedules?.length ?? 0) > 0);
-        if (body.scheduleCallerConfigured === true) {
-          pass("machines/schedule-caller", "schedule caller configured (VENDO_TICK_SECRET); point an external cron at POST /api/vendo/tick");
-        } else if (declaresSchedules) {
-          warn("machines/schedule-caller", "E-SCHED-001", "apps declare vendo.json schedules but no schedule caller is configured — set VENDO_TICK_SECRET and point an external cron (Vercel cron, GitHub Actions, crontab) at POST /api/vendo/tick");
-        } else if (machines.length > 0) {
-          note("  no schedule caller configured (VENDO_TICK_SECRET unset) — needed once an app declares vendo.json schedules");
-        }
-      }
-    } catch {
-      // Reporting only — an unreachable machines route never fails doctor.
-    }
-  }
-
-  note("Ladder: execution venue is checked above; actAs for away host actions; connectors for external tools.");
-
-  // One real model turn through the wired route (design §5). Exit 0 == a user
-  // would have gotten an answer. Reuses the resolver + vendoModel: the running
-  // dev server serves the turn over the same credential doctor reports.
-  let liveTurn: LiveTurnResult;
-  if (liveComposition) {
-    liveTurn = await (options.liveTurn ?? ((base: string) => liveModelTurn({
-      base,
-      fetchImpl,
-      env,
-    })))(statusUrl);
-    if (liveTurn.ok) {
-      pass("turn/model", `live model turn answered over ${liveTurn.credential} (${liveTurn.elapsedMs}ms)`);
-      if (liveTurn.reply !== undefined) note(`\n  ${liveTurn.reply.trim()}\n`);
-    } else {
-      fail("turn/model", "E-TURN-001", `live model turn did not answer over ${liveTurn.credential}: ${liveTurn.error ?? "no reply"}`);
-    }
-  } else {
-    liveTurn = { attempted: false, ok: false, rung: "none", credential: "n/a", elapsedMs: 0, error: "dev server unreachable" };
-    fail("turn/model", "E-TURN-002", `live model turn cannot run; start the dev server at ${statusUrl} and retry`);
-  }
-
-  // VENDO_API_KEY local shape check + what Cloud unlocks (design §5-6). Key
-  // problems surface on the first real service call — no validate round-trip.
-  const cloud = await (options.cloudProbe ?? cloudDoctor)({ env });
-  if (cloud.present && cloud.ok) {
-    pass("cloud/key", "Vendo Cloud key present and well-formed");
-  } else if (cloud.present) {
-    warn("cloud/key", "E-CLOUD-001", `VENDO_API_KEY is set but not usable: ${cloud.error ?? "malformed"}`);
-  } else {
-    note(`Vendo Cloud (optional): no VENDO_API_KEY. A key unlocks ${cloud.unlocks.join("; ")}. Run \`vendo login\` to start.`);
-  }
+  const liveTurn = await checkLiveTurn(run, options, live);
+  const cloud = await checkCloudKey(run, options);
 
   if (devServerStop !== null) devServerStop();
 
+  const { failures, warnings, checks } = run;
   const wired = failures === 0;
   await telemetry.track("doctor_run", { failures, warnings, wired });
 

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -10,7 +10,7 @@ import { scrubErrorDetail, type Telemetry } from "@vendoai/telemetry";
 import { detectDepVersions, installedAiVersion } from "./dep-versions.js";
 import { AUTH_MD_URL, runCloudStep, upsertEnvLocal, warnEnvLocalNotIgnored, type CloudStepOptions } from "./cloud-init.js";
 import type { InitPolishSeam } from "./init-judgment.js";
-import { runSyncFlow } from "./sync-flow.js";
+import { runSyncFlow, type SyncFlowResult } from "./sync-flow.js";
 import { BRIEF_TEMPLATE } from "./extract/stages.js";
 import { ENV_KEY_VARS, resolveDevCredential, describeDevCredential, type DevCredential } from "../dev-creds/resolve.js";
 import { detectFramework, detectVendoWiring, workspaceHostCandidates, type HostFramework } from "./framework.js";
@@ -605,6 +605,166 @@ type LayoutWiring =
       printed wiring lines — route requests through it, mount the client. */
   | { kind: "custom" };
 
+/** What one framework's composition branch contributes to the plan: the files
+ *  init will create, the pastes it can only describe, and the auth facts the
+ *  agent tail reports. */
+interface ScaffoldPlan {
+  changes: PlannedChange[];
+  edits: ManualEdit[];
+  authAdvice: string | null;
+  authWired: AuthMatch | null;
+  compositionPath: string | null;
+  layout: LayoutWiring;
+}
+
+const emptyScaffold = (layout: LayoutWiring): ScaffoldPlan => ({
+  changes: [],
+  edits: [],
+  authAdvice: null,
+  authWired: null,
+  compositionPath: null,
+  layout,
+});
+
+async function planCustomComposition(
+  root: string,
+  options: InitOptions,
+  confirmAuth?: ConfirmAuth,
+  selectAuth?: SelectAuth,
+): Promise<ScaffoldPlan> {
+  const scaffold = emptyScaffold({ kind: "custom" });
+  const wiring = await detectVendoWiring(root);
+  if (!wiring.server || !wiring.client) {
+    const typescript = await exists(join(root, "tsconfig.json"));
+    const server = join(root, "vendo", typescript ? "server.ts" : "server.mjs");
+    const serverBefore = await readOptional(server);
+    // Same ownership rule as the Express branch: init composes only when it
+    // CREATES the composition.
+    const scaffolding = serverBefore === null && !wiring.server;
+    if (scaffolding) {
+      const path = relative(root, server);
+      const auth = await resolveScaffoldAuth(root, path, options.auth, confirmAuth, selectAuth);
+      const serverAfter = customServerSource(typescript, auth.wired);
+      scaffold.changes.push({ absolute: server, path, before: null, after: serverAfter, diff: diff(path, null, serverAfter) });
+      scaffold.authAdvice = auth.advice;
+      scaffold.authWired = auth.wired;
+      scaffold.compositionPath = path;
+    }
+  }
+  return scaffold;
+}
+
+async function planExpressComposition(
+  root: string,
+  options: InitOptions,
+  confirmAuth?: ConfirmAuth,
+  selectAuth?: SelectAuth,
+): Promise<ScaffoldPlan> {
+  const scaffold = emptyScaffold({ kind: "express" });
+  const wiring = await detectVendoWiring(root);
+  if (!wiring.server || !wiring.client) {
+    const typescript = await exists(join(root, "tsconfig.json"));
+    const server = join(root, "vendo", typescript ? "server.ts" : "server.mjs");
+    const serverBefore = await readOptional(server);
+    // Init owns the composition only when it CREATES it: no generated
+    // server module yet AND no hand-wired createVendo anywhere else. A host
+    // that composed at its own path but hasn't pasted <VendoProvider> yet
+    // gets no duplicate server module — the Express analog of the Next
+    // branch's routeBefore === null guard.
+    const scaffolding = serverBefore === null && !wiring.server;
+    if (scaffolding) {
+      const path = relative(root, server);
+      // Detect + confirm happens only here — fresh composition creation —
+      // so a re-run before the manual <VendoProvider> paste neither asks nor
+      // re-fires the advisory after "Already wired".
+      const auth = await resolveScaffoldAuth(root, path, options.auth, confirmAuth, selectAuth);
+      const serverAfter = expressServerSource(typescript, auth.wired);
+      scaffold.changes.push({ absolute: server, path, before: null, after: serverAfter, diff: diff(path, null, serverAfter) });
+      scaffold.authAdvice = auth.advice;
+      scaffold.authWired = auth.wired;
+      scaffold.compositionPath = path;
+    }
+  }
+  return scaffold;
+}
+
+/** The registration map is generated once, when the host's first "use server"
+ *  action appears. After that it is the developer's file and is never rewritten
+ *  — so an existing one is compared by the KEYS it registers, not byte-for-byte.
+ *  Byte-comparing would demand a paste for their own formatting, their own extra
+ *  entries, and even a reworded comment in a Vendo release, forever, on a
+ *  surface that never moved. */
+function planServerActionsMap(
+  scaffold: ScaffoldPlan,
+  root: string,
+  actionsModule: string,
+  actionsBefore: string | null,
+  registrations: Awaited<ReturnType<typeof requiredServerActions>>,
+): void {
+  const path = relative(root, actionsModule);
+  if (actionsBefore === null) {
+    const actionsAfter = serverActionsModuleSource(root, dirname(actionsModule), registrations);
+    scaffold.changes.push({ absolute: actionsModule, path, before: null, after: actionsAfter, diff: diff(path, null, actionsAfter) });
+    return;
+  }
+  const missing = missingRegistrations(actionsBefore, registrations);
+  if (missing.length > 0) {
+    scaffold.edits.push({
+      file: path,
+      lines: missingRegistrationLines(root, dirname(actionsModule), actionsBefore, missing),
+      why: `${missing.length} action${missing.length === 1 ? "" : "s"} the host exposes ${missing.length === 1 ? "is" : "are"} not registered here — ${missing.length === 1 ? "it fails" : "each one fails"} closed at execution time (no work performed). The rest of the file is yours; nothing else needs to change.`,
+    });
+  }
+}
+
+async function planNextComposition(
+  root: string,
+  options: InitOptions,
+  confirmAuth?: ConfirmAuth,
+  selectAuth?: SelectAuth,
+): Promise<ScaffoldPlan> {
+  const scaffold = emptyScaffold({ kind: "manual" });
+  const app = await appDirectory(root);
+  const route = join(app, "api", "vendo", "[...vendo]", "route.ts");
+  const actionsModule = join(app, "api", "vendo", "[...vendo]", "vendo-actions.ts");
+  const routeBefore = await readOptional(route);
+  const actionsBefore = await readOptional(actionsModule);
+  const registrations = await requiredServerActions(root);
+  // …and the map exists only for a route that will CONSUME it: the one being
+  // created now, one that already imports ./vendo-actions, or one init is
+  // about to hand the import paste to. A route composing its own map never
+  // grows an orphan — the same rule the registry above follows, and the same
+  // shape doctor stays silent about.
+  const mapConsumed = routeBefore === null
+    || importsGeneratedMap(routeBefore)
+    || serverActionsWiring(routeBefore) === "unwired";
+  if (registrations.length > 0 && mapConsumed) {
+    planServerActionsMap(scaffold, root, actionsModule, actionsBefore, registrations);
+  }
+  if (routeBefore === null) {
+    const path = relative(root, route);
+    // Detect + confirm happens only on fresh composition creation.
+    const auth = await resolveScaffoldAuth(root, path, options.auth, confirmAuth, selectAuth);
+    const routeAfter = routeSource({ serverActions: registrations.length > 0, auth: auth.wired });
+    scaffold.changes.push({ absolute: route, path, before: routeBefore, after: routeAfter, diff: diff(path, routeBefore, routeAfter) });
+    scaffold.authAdvice = auth.advice;
+    scaffold.authWired = auth.wired;
+    scaffold.compositionPath = path;
+  } else if (registrations.length > 0) {
+    // The route already exists but server actions appeared since it was
+    // generated: name the wiring the existing createVendo is missing, so
+    // server-action execution stops failing closed (ENG-248).
+    const edit = routeServerActionsEdit(routeBefore, relative(root, route));
+    if (edit !== null) scaffold.edits.push(edit);
+  }
+
+  // Init never writes a client file, so the only question is whether the host
+  // already mounts one. A host source that mounts the provider IS the mount.
+  const mounts = await detectVendoWiring(root);
+  if (mounts.client) scaffold.layout = { kind: "already" };
+  return scaffold;
+}
+
 async function buildPlan(options: InitOptions, confirmAuth?: ConfirmAuth, selectAuth?: SelectAuth): Promise<{
   plan: InitPlan;
   changes: PlannedChange[];
@@ -630,118 +790,13 @@ async function buildPlan(options: InitOptions, confirmAuth?: ConfirmAuth, select
   // explicit --framework so agents never inherit a guess silently).
   const detected = options.framework ?? await detectFramework(root);
   const framework: "next" | "express" | "custom" = detected === "unknown" ? "custom" : detected;
-  const changes: PlannedChange[] = [];
-  const edits: ManualEdit[] = [];
-  let authAdvice: string | null = null;
-  let authWired: AuthMatch | null = null;
-  let compositionPath: string | null = null;
-  let layout: LayoutWiring = { kind: "manual" };
+  const scaffold = framework === "custom"
+    ? await planCustomComposition(root, options, confirmAuth, selectAuth)
+    : framework === "express"
+      ? await planExpressComposition(root, options, confirmAuth, selectAuth)
+      : await planNextComposition(root, options, confirmAuth, selectAuth);
+  const { changes, edits, authAdvice, authWired, compositionPath, layout } = scaffold;
 
-  if (framework === "custom") {
-    layout = { kind: "custom" };
-    const wiring = await detectVendoWiring(root);
-    if (!wiring.server || !wiring.client) {
-      const typescript = await exists(join(root, "tsconfig.json"));
-      const server = join(root, "vendo", typescript ? "server.ts" : "server.mjs");
-      const serverBefore = await readOptional(server);
-      // Same ownership rule as the Express branch: init composes only when it
-      // CREATES the composition.
-      const scaffolding = serverBefore === null && !wiring.server;
-      if (scaffolding) {
-        const path = relative(root, server);
-        const auth = await resolveScaffoldAuth(root, path, options.auth, confirmAuth, selectAuth);
-        const serverAfter = customServerSource(typescript, auth.wired);
-        changes.push({ absolute: server, path, before: null, after: serverAfter, diff: diff(path, null, serverAfter) });
-        authAdvice = auth.advice;
-        authWired = auth.wired;
-        compositionPath = path;
-      }
-    }
-  } else if (framework === "express") {
-    layout = { kind: "express" };
-    const wiring = await detectVendoWiring(root);
-    if (!wiring.server || !wiring.client) {
-      const typescript = await exists(join(root, "tsconfig.json"));
-      const server = join(root, "vendo", typescript ? "server.ts" : "server.mjs");
-      const serverBefore = await readOptional(server);
-      // Init owns the composition only when it CREATES it: no generated
-      // server module yet AND no hand-wired createVendo anywhere else. A host
-      // that composed at its own path but hasn't pasted <VendoProvider> yet
-      // gets no duplicate server module — the Express analog of the Next
-      // branch's routeBefore === null guard.
-      const scaffolding = serverBefore === null && !wiring.server;
-      if (scaffolding) {
-        const path = relative(root, server);
-        // Detect + confirm happens only here — fresh composition creation —
-        // so a re-run before the manual <VendoProvider> paste neither asks nor
-        // re-fires the advisory after "Already wired".
-        const auth = await resolveScaffoldAuth(root, path, options.auth, confirmAuth, selectAuth);
-        const serverAfter = expressServerSource(typescript, auth.wired);
-        changes.push({ absolute: server, path, before: null, after: serverAfter, diff: diff(path, null, serverAfter) });
-        authAdvice = auth.advice;
-        authWired = auth.wired;
-        compositionPath = path;
-      }
-    }
-  } else {
-    const app = await appDirectory(root);
-    const route = join(app, "api", "vendo", "[...vendo]", "route.ts");
-    const actionsModule = join(app, "api", "vendo", "[...vendo]", "vendo-actions.ts");
-    const routeBefore = await readOptional(route);
-    const actionsBefore = await readOptional(actionsModule);
-    const registrations = await requiredServerActions(root);
-    // The registration map is generated once, when the host's first
-    // "use server" action appears. After that it is the developer's file and is
-    // never rewritten — so an existing one is compared by the KEYS it registers,
-    // not byte-for-byte. Byte-comparing would demand a paste for their own
-    // formatting, their own extra entries, and even a reworded comment in a
-    // Vendo release, forever, on a surface that never moved.
-    // …and the map exists only for a route that will CONSUME it: the one being
-    // created now, one that already imports ./vendo-actions, or one init is
-    // about to hand the import paste to. A route composing its own map never
-    // grows an orphan — the same rule the registry above follows, and the same
-    // shape doctor stays silent about.
-    const mapConsumed = routeBefore === null
-      || importsGeneratedMap(routeBefore)
-      || serverActionsWiring(routeBefore) === "unwired";
-    if (registrations.length > 0 && mapConsumed) {
-      const path = relative(root, actionsModule);
-      if (actionsBefore === null) {
-        const actionsAfter = serverActionsModuleSource(root, dirname(actionsModule), registrations);
-        changes.push({ absolute: actionsModule, path, before: null, after: actionsAfter, diff: diff(path, null, actionsAfter) });
-      } else {
-        const missing = missingRegistrations(actionsBefore, registrations);
-        if (missing.length > 0) {
-          edits.push({
-            file: path,
-            lines: missingRegistrationLines(root, dirname(actionsModule), actionsBefore, missing),
-            why: `${missing.length} action${missing.length === 1 ? "" : "s"} the host exposes ${missing.length === 1 ? "is" : "are"} not registered here — ${missing.length === 1 ? "it fails" : "each one fails"} closed at execution time (no work performed). The rest of the file is yours; nothing else needs to change.`,
-          });
-        }
-      }
-    }
-    if (routeBefore === null) {
-      const path = relative(root, route);
-      // Detect + confirm happens only on fresh composition creation.
-      const auth = await resolveScaffoldAuth(root, path, options.auth, confirmAuth, selectAuth);
-      const routeAfter = routeSource({ serverActions: registrations.length > 0, auth: auth.wired });
-      changes.push({ absolute: route, path, before: routeBefore, after: routeAfter, diff: diff(path, routeBefore, routeAfter) });
-      authAdvice = auth.advice;
-      authWired = auth.wired;
-      compositionPath = path;
-    } else if (registrations.length > 0) {
-      // The route already exists but server actions appeared since it was
-      // generated: name the wiring the existing createVendo is missing, so
-      // server-action execution stops failing closed (ENG-248).
-      const edit = routeServerActionsEdit(routeBefore, relative(root, route));
-      if (edit !== null) edits.push(edit);
-    }
-
-    // Init never writes a client file, so the only question is whether the host
-    // already mounts one. A host source that mounts the provider IS the mount.
-    const mounts = await detectVendoWiring(root);
-    if (mounts.client) layout = { kind: "already" };
-  }
   const packageJson = join(root, "package.json");
   const packageBefore = await readOptional(packageJson);
   if (packageBefore !== null) {
@@ -832,6 +887,395 @@ function telemetryFor(options: InitOptions, output: Output, root: string): Telem
 }
 
 /** 09-vendo §5 — idempotent, zero-question setup. */
+/** Apply the answers a human gave (via `--theme` or the review prompt) over the
+ *  extracted/merged summary, in place. Unknown slots and invalid values are
+ *  reported and skipped rather than written. */
+function applyThemeAnswers(
+  summary: ThemeSummary,
+  answers: Record<string, string>,
+  output: Output,
+): void {
+  for (const [slot, raw] of Object.entries(answers)) {
+    if (!Object.hasOwn(summary.slots, slot)) {
+      output.error(`ignored unknown theme slot ${JSON.stringify(slot)}`);
+      continue;
+    }
+    const value = validateSlotValue(slot as keyof ThemeSlotValues, raw);
+    if (value === null) {
+      output.error(`ignored invalid theme ${slot} value ${JSON.stringify(raw)}`);
+    } else {
+      (summary.slots as unknown as Record<string, string>)[slot] = value;
+      summary.matched[slot] = "(you)";
+      // The slot no longer defaulted — the human just set it.
+      summary.defaulted = summary.defaulted.filter((name) => name !== slot);
+    }
+  }
+  // A replaced accent invalidates an accentText nobody chose — one that
+  // was contrast-derived, or still the neutral default because the
+  // model omitted the accent too. Re-derive against the new accent; an
+  // explicit token or a direct human/model answer stays authoritative.
+  const accentTextUnchosen = summary.matched["accentText"] === "(contrast) accent"
+    || summary.defaulted.includes("accentText");
+  if (summary.matched["accent"] === "(you)" && accentTextUnchosen) {
+    summary.slots.accentText = contrastingText(summary.slots.accent);
+    summary.matched["accentText"] = "(contrast) accent";
+    summary.defaulted = summary.defaulted.filter((name) => name !== "accentText");
+  }
+}
+
+/** Theme finalization (Task 4): merge whatever the AI pass filled — if
+ *  consent was declined or unavailable, `themeDraft` is simply null
+ *  and the exact-only summary stands — then --theme answers (a human
+ *  "(you)" wins over a model value), the one-glance palette print, and
+ *  finally the uncertain-slot review. */
+async function finalizeTheme(input: {
+  themeSummary: ThemeSummary;
+  themeDraft: SyncFlowResult["themeDraft"];
+  themePath: string;
+  options: InitOptions;
+  output: Output;
+}): Promise<void> {
+  const { themeSummary, themeDraft, themePath, options, output } = input;
+  const summary = themeDraft === null ? themeSummary : applyThemeDraft(themeSummary, themeDraft);
+  // --theme answers land first; the review prompt then covers only the
+  // uncertain slots the flags left unanswered (non-interactive runs keep
+  // the extracted/merged values for those, exactly as before).
+  const answers: Record<string, string> = { ...(options.themeAnswers ?? {}) };
+  const unanswered = summary.uncertain.filter((entry) => !Object.hasOwn(answers, entry.slot));
+  if (unanswered.length > 0 && options.yes !== true) {
+    const reviewed = await (options.themeReview ?? defaultThemeReview)(
+      unanswered.length === summary.uncertain.length ? summary : { ...summary, uncertain: unanswered },
+    );
+    for (const [slot, raw] of Object.entries(reviewed)) {
+      if (!Object.hasOwn(answers, slot)) answers[slot] = raw;
+    }
+  }
+  if (Object.keys(answers).length > 0) applyThemeAnswers(summary, answers, output);
+  await writeText(themePath, `${JSON.stringify(toVendoTheme(summary.slots), null, 2)}\n`);
+  printThemeSummary(summary, output);
+}
+
+/** Done — the pastes init cannot take (it only ever CREATES files in your
+ *  source tree), then their own dev server. They get their own framed block
+ *  because skipping them is the whole failure mode: a green install nobody
+ *  can see, or server-action tools that silently fail closed. */
+function printClosingSteps(input: {
+  output: Output;
+  handSteps: ManualEdit[];
+  manualSteps: string[];
+  credential: DevCredential;
+  cloud: { keyValid: boolean };
+  compositionPath: string | null;
+}): void {
+  const { output, handSteps, manualSteps, credential, cloud, compositionPath } = input;
+  if (handSteps.length > 0) {
+    const rule = "─".repeat(64);
+    output.log(`\n${rule}`);
+    output.log(handSteps.length === 1
+      ? "ONE STEP LEFT — paste this yourself (init never edits your files)"
+      : `${handSteps.length} STEPS LEFT — paste these yourself (init never edits your files)`);
+    for (const step of handSteps) {
+      output.log(`\n  File: ${step.file}`);
+      for (const line of step.lines) output.log(`    ${line}`);
+      output.log(`\n  ${step.why}`);
+    }
+    output.log("  Then confirm it landed: npx vendo doctor");
+    output.log(rule);
+  }
+  // Express and custom hosts have no single host file to name, so their
+  // wiring keeps the compact list; the block above already said everything
+  // a Next host needs, and nothing is printed twice.
+  if (handSteps.length === 0 && manualSteps.length > 0) {
+    output.log("\nLast steps are yours:");
+    for (const line of manualSteps) output.log(`  ${line}`);
+  }
+  // A run without a USABLE model credential is wired but not answering, so
+  // the closing line must not claim otherwise. The rung alone is not that
+  // answer: resolveDevCredential only checks that VENDO_API_KEY is non-blank
+  // (and VENDO_DEV_CREDENTIAL=vendo-cloud pins the rung with no key at all),
+  // so a malformed key resolves "vendo-cloud" while the cloud step — the one
+  // thing that inspected the key — already said it is not usable. Keyless,
+  // the composition decides: one written THIS run passes no model, so "no
+  // key" is the whole story, while one init did not write may pass its own
+  // `model` to createVendo — nothing here can see that, so state the
+  // condition rather than guess either way.
+  // …and it only gets to speak at all once nothing is outstanding: a paste
+  // still pending means the frame above just said Vendo is invisible until
+  // it lands, so "the agent is live in your app" would contradict it in the
+  // same breath (self-serve audit F5).
+  const modelReady = credential.rung === "env-key"
+    || (credential.rung === "vendo-cloud" && cloud.keyValid);
+  if (handSteps.length === 0) {
+    output.log(`\nThen start your dev server — ${modelReady
+      ? "the agent is live in your app."
+      : compositionPath !== null
+        ? "the agent is live once you add a model key."
+        : "no model key resolved here, so the agent is live only if your composition passes its own model."}`);
+  }
+  output.log(`${handSteps.length === 0 ? "" : "\n"}Verify everything: \`npx vendo doctor\` (it can start the server and run a live turn).`);
+}
+
+/** Star ask (agent-install-dx §CLI-5): the interactive success screen
+ *  ends with ONE consent question — never shown non-interactively (the
+ *  playbook owns the agent-path ask; deterministic runs stay that way),
+ *  and never fatal: nothing in this step can change init's exit code.
+ *  Yes stars via gh; any failure degrades to the repo URL, one line.
+ *  No does nothing — no guilt text. */
+async function askForStar(input: {
+  options: InitOptions;
+  pretty: PrettyOutput | null;
+  output: Output;
+  telemetry: Telemetry;
+}): Promise<void> {
+  const { options, pretty, output, telemetry } = input;
+  try {
+    // Consent guard: an unshown prompt is NEVER a yes. On a non-TTY
+    // stdin (programmatic `interactive: true`, `init < file`) both real
+    // confirms would resolve the default — pretty.confirm returns it,
+    // askYesNo would block — and starring is an account action, so the
+    // answer without a real keyboard is false, regardless of path.
+    const confirmStar = options.confirmStar
+      ?? (async (question: string, defaultYes: boolean) =>
+        stdin.isTTY === true
+          ? (pretty === null ? askYesNo : pretty.confirm)(question, defaultYes)
+          : false);
+    if (await confirmStar(`Star ${STAR_REPO} to support the project?`, true)) {
+      const starred = await starViaGh(
+        options.spawnStar ?? ((command, args) => spawn(command, args, { stdio: "ignore" })),
+      );
+      if (!starred) output.log(`Star it anytime: ${STAR_LINK}`);
+      // Star attribution: `starred` is an exact star-from-the-CLI signal
+      // (closed outcome enum; counts-and-enums promise holds).
+      await telemetry.track("star_prompt", { outcome: starred ? "starred" : "star-failed" });
+    } else {
+      await telemetry.track("star_prompt", { outcome: "declined" });
+    }
+  } catch {
+    // The ask is best-effort by design; init already succeeded.
+  }
+}
+
+/** An undetectable framework has NO safe default: a non-interactive run
+ *  (agents) errors with the exact flag instead of guessing the Next layout
+ *  into an unknown host. An interactive run keeps today's fall-through to the
+ *  custom scaffold — silently wrong when the host is a workspace package one
+ *  level down, so name the candidates instead of guessing for them.
+ *
+ *  Returns false when init must stop with exit 1. */
+async function guardUndetectedFramework(input: {
+  root: string;
+  options: InitOptions;
+  output: Output;
+  interactive: boolean;
+}): Promise<boolean> {
+  const { root, options, output, interactive } = input;
+  if (options.framework !== undefined || await detectFramework(root) !== "unknown") return true;
+  if (options.yes === true || !interactive) {
+    output.error(
+      "Framework not detected (no next or express dependency in package.json) and this run cannot ask. " +
+      "Pass --framework. Examples: vendo init --yes --framework next · --framework custom (any Web-standard runtime: Cloudflare Workers, Bun, Hono, ...)",
+    );
+    return false;
+  }
+  const candidates = await workspaceHostCandidates(root);
+  if (candidates.length > 0) {
+    output.error(
+      `warning: no next or express dependency in this directory, but ${candidates.join(", ")} ` +
+      `${candidates.length === 1 ? "looks" : "look"} like the host — did you mean ${candidates[0]}? ` +
+      `Re-run there (vendo init ${pastePath(join(root, candidates[0]!))}) or pass --framework to scaffold this directory anyway.`,
+    );
+  }
+  return true;
+}
+
+/** Key first (product order fix): the model-credential story — env keys,
+ *  else the Vendo Cloud offer — runs BEFORE the AI-assisted passes, so a
+ *  starter key minted here powers the SAME run's theme model pass and AI
+ *  polish instead of those passes reporting "no model" while the offer
+ *  waits below them. --yes / non-interactive semantics are unchanged. */
+async function resolveModelCredential(input: {
+  root: string;
+  env: Record<string, string | undefined>;
+  options: InitOptions;
+  output: Output;
+  pretty: PrettyOutput | null;
+}): Promise<{ credential: DevCredential; cloud: Awaited<ReturnType<typeof runCloudStep>> }> {
+  const { root, env, options, output, pretty } = input;
+  // Dev keys may live in .env.local rather than this process's env — a
+  // PRIOR run's minted starter key, or hand-added provider keys. Merge
+  // them into the env every credential consumer reads (credential ladder,
+  // cloud step, theme model pass, AI polish); an explicit env value
+  // always wins over .env.local.
+  let effectiveEnv = env;
+  for (const name of [...ENV_KEY_VARS.map((entry) => entry.envVar), "VENDO_API_KEY"]) {
+    if ((env[name] ?? "").trim() !== "") continue;
+    const stored = envFileValueSync(root, name);
+    if (stored !== null) effectiveEnv = { ...effectiveEnv, [name]: stored };
+  }
+  let credential = await (options.resolveCredential ?? resolveDevCredential)({ env: effectiveEnv });
+  if (credential.rung === "env-key") {
+    output.log(`Model: ${describeDevCredential(credential)} — production uses this same key server-side.`);
+  }
+  const cloud = await runCloudStep({
+    root,
+    output,
+    // --byo answers the offer with "no" AND suppresses the agent-path
+    // auth.md pointer (an explicit BYO choice is final); --yes skips the
+    // prompt but still gets the pointer so an agent can mint in-band.
+    yes: options.yes === true,
+    byo: options.byo === true,
+    credential,
+    // The RUN's env, not process.env: a programmatic caller's key must be
+    // what the probe and the mint see (seams in options.cloud still win).
+    env: effectiveEnv,
+    // The step's own command_run row rides init's telemetry seams.
+    ...(options.telemetry === undefined ? {} : { telemetry: options.telemetry }),
+    ...(pretty === null ? {} : { confirm: pretty.confirm }),
+    ...(options.cloud ?? {}),
+  });
+  // Same-run pickup: a starter key minted just now lands in .env.local —
+  // merge it the same way so THIS run's passes already benefit.
+  if (cloud.wroteEnvLocal) {
+    const minted = envFileValueSync(root, "VENDO_API_KEY");
+    if (minted !== null) {
+      effectiveEnv = { ...effectiveEnv, VENDO_API_KEY: minted };
+      credential = await (options.resolveCredential ?? resolveDevCredential)({ env: effectiveEnv });
+    }
+  }
+  return { credential, cloud };
+}
+
+/** Wire — apply the bounded change set. No gates, no prompts. Then scan:
+ *  the .vendo artifacts + static extraction (the hints layer for the AI
+ *  extraction; interim tools.json source until it lands).
+ *
+ *  Returns the elapsed wiringMs the cloud telemetry lane reports. */
+async function wireAndScaffold(input: {
+  root: string;
+  changes: PlannedChange[];
+  force: boolean;
+}): Promise<number> {
+  const { root, changes, force } = input;
+  const wiringStarted = Date.now();
+  for (const change of changes) {
+    await writeText(change.absolute, change.after);
+  }
+
+  await ensureVendoEnvExample(root);
+  await mkdir(join(root, ".vendo"), { recursive: true });
+  await writeIfMissing(
+    join(root, ".vendo", "overrides.json"),
+    `${JSON.stringify({
+      format: "vendo/overrides@3",
+      tools: {},
+      remix: { ignoreSlots: [] },
+    }, null, 2)}\n`,
+    force,
+  );
+  await writeIfMissing(
+    join(root, ".vendo", "policy.json"),
+    `${JSON.stringify({
+      format: "vendo/policy@1",
+      directions: [],
+      rules: [
+        { match: { risk: "destructive" }, action: "ask", note: "Review irreversible actions" },
+        // ENG-370 hardening: knowledge tools are read-class, so this rule
+        // must sit ABOVE the read→run rule (first match wins). MCP clients
+        // sit outside the product surface; hosts may harden ask → block.
+        { match: { tool: "vendo_knowledge_*", venue: "mcp" }, action: "ask", note: "Knowledge access from an MCP client" },
+        { match: { risk: "read" }, action: "run" },
+      ],
+    }, null, 2)}\n`,
+    force,
+  );
+  await writeIfMissing(
+    join(root, ".vendo", "brief.md"),
+    BRIEF_PLACEHOLDER,
+    force,
+  );
+  await writeIfMissing(join(root, ".vendo", "data", ".gitignore"), "*\n!.gitignore\n", force);
+  return Date.now() - wiringStarted;
+}
+
+/** init ENDS in the one shared flow — the same extraction, theme path,
+ *  consent, judgment, prose stages, report and Cloud pushes `vendo sync`
+ *  runs, in "full" mode (a fresh install has judged nothing). */
+async function runInstallSyncFlow(input: {
+  root: string;
+  output: Output;
+  options: InitOptions;
+  pretty: PrettyOutput | null;
+}): Promise<SyncFlowResult> {
+  const { root, output, options, pretty } = input;
+  // `--extract` is the test seam onto the flow's judgment step, in init's own
+  // flat spelling; where it overlaps a real flag, the seam wins.
+  const extract = options.extract ?? {};
+  const ai = extract.ai ?? options.ai;
+  const engine = extract.engine ?? options.engine;
+  return runSyncFlow({
+    root,
+    output,
+    mode: "full",
+    // The AI-polish step keeps its OWN interactivity posture (a real TTY that
+    // no package script drives), distinct from `interactive` above — that one
+    // is the auth confirm's seam, and spending money on a model is not a
+    // question a programmatic caller may be assumed to have answered.
+    interactive: extract.interactive
+      ?? (!invokedByPackageScript() && Boolean(stdin.isTTY) && Boolean(stdout.isTTY)),
+    yes: options.yes === true,
+    // --ai IS the consent (no prompt, non-interactive runs stop skipping);
+    // --no-ai is the refusal. No flag = ask, every interactive run.
+    ...(ai === undefined ? {} : { ai }),
+    ...(options.force === true ? { force: true } : {}),
+    ...(engine === undefined ? {} : { engine }),
+    ...(pretty === null ? {} : { confirm: pretty.confirm, choose: pretty.select }),
+    ...(extract.choose === undefined ? {} : { choose: extract.choose }),
+    judge: {
+      ...(extract.harnesses === undefined ? {} : { harnesses: extract.harnesses }),
+      ...(extract.confirm === undefined ? {} : { confirm: extract.confirm }),
+      ...(extract.resolveCredential === undefined ? {} : { resolveCredential: extract.resolveCredential }),
+    },
+  });
+}
+
+/** The two dependency repairs a fresh install owes the host, both degrading to
+ *  a printed command rather than failing the run. */
+async function ensureHostDeps(input: {
+  root: string;
+  output: Output;
+  options: InitOptions;
+  pretty: PrettyOutput | null;
+  interactive: boolean;
+  credential: DevCredential;
+}): Promise<void> {
+  const { root, output, options, pretty, interactive, credential } = input;
+  // The credential's runtime provider must be resolvable from the host or
+  // the FIRST turn 500s (dev-creds/model.ts loads it host-side; nothing
+  // declares @ai-sdk/* — 0.4.1 E2E cert finding). Install exactly what the
+  // resolved credential needs; a failure degrades to the manual command.
+  await ensureProviderDeps({
+    root,
+    credential,
+    output,
+    ...(options.installProvider === undefined ? {} : { run: options.installProvider }),
+  });
+
+  // FINDINGS F2 (skateshop): a host pinning zod < 3.25 builds red once the
+  // wiring pulls ai@6 into the bundle (ai imports the zod/v3 + zod/v4
+  // subpaths that arrive in 3.25, and the host's own pin wins the installed
+  // tree). Ask-and-bump with the auth confirm's interactivity posture:
+  // --yes performs the announced bump, non-interactive prints the command.
+  await ensureZodFloor({
+    root,
+    output,
+    ...(options.yes === true ? { yes: true } : {}),
+    ...(options.yes === true || !interactive
+      ? {}
+      : { confirm: options.confirmZodBump ?? (pretty === null ? askYesNo : pretty.confirm) }),
+    ...(options.installZod === undefined ? {} : { run: options.installZod }),
+  });
+}
+
 export async function runInit(options: InitOptions): Promise<number> {
   // The clack-style renderer rides the SAME Output seam: it restyles the
   // exact plain messages below, and is selected only for a human terminal
@@ -864,28 +1308,7 @@ export async function runInit(options: InitOptions): Promise<number> {
   // the AI-polish consent.
   const interactive = options.interactive
     ?? (!invokedByPackageScript() && Boolean(stdin.isTTY) && Boolean(stdout.isTTY));
-  // An undetectable framework has NO safe default: a non-interactive run
-  // (agents) errors with the exact flag instead of guessing the Next layout
-  // into an unknown host. An interactive run keeps today's fall-through to the
-  // custom scaffold — silently wrong when the host is a workspace package one
-  // level down, so name the candidates instead of guessing for them.
-  if (options.framework === undefined && await detectFramework(root) === "unknown") {
-    if (options.yes === true || !interactive) {
-      output.error(
-        "Framework not detected (no next or express dependency in package.json) and this run cannot ask. " +
-        "Pass --framework. Examples: vendo init --yes --framework next · --framework custom (any Web-standard runtime: Cloudflare Workers, Bun, Hono, ...)",
-      );
-      return 1;
-    }
-    const candidates = await workspaceHostCandidates(root);
-    if (candidates.length > 0) {
-      output.error(
-        `warning: no next or express dependency in this directory, but ${candidates.join(", ")} ` +
-        `${candidates.length === 1 ? "looks" : "look"} like the host — did you mean ${candidates[0]}? ` +
-        `Re-run there (vendo init ${pastePath(join(root, candidates[0]!))}) or pass --framework to scaffold this directory anyway.`,
-      );
-    }
-  }
+  if (!await guardUndetectedFramework({ root, options, output, interactive })) return 1;
   // (No stdin-TTY guard on these defaults, unlike the star ask's: an unshown
   // auth confirm resolving its default just wires the detected preset — the
   // very accept the non-interactive path performs silently anyway.)
@@ -910,52 +1333,7 @@ export async function runInit(options: InitOptions): Promise<number> {
       output.log("Wrote VENDO_API_KEY to .env.local (--cloud-key).");
       await warnEnvLocalNotIgnored(root, output);
     }
-    // Key first (product order fix): the model-credential story — env keys,
-    // else the Vendo Cloud offer — runs BEFORE the AI-assisted passes, so a
-    // starter key minted here powers the SAME run's theme model pass and AI
-    // polish instead of those passes reporting "no model" while the offer
-    // waits below them. --yes / non-interactive semantics are unchanged.
-    // Dev keys may live in .env.local rather than this process's env — a
-    // PRIOR run's minted starter key, or hand-added provider keys. Merge
-    // them into the env every credential consumer reads (credential ladder,
-    // cloud step, theme model pass, AI polish); an explicit env value
-    // always wins over .env.local.
-    let effectiveEnv = env;
-    for (const name of [...ENV_KEY_VARS.map((entry) => entry.envVar), "VENDO_API_KEY"]) {
-      if ((env[name] ?? "").trim() !== "") continue;
-      const stored = envFileValueSync(root, name);
-      if (stored !== null) effectiveEnv = { ...effectiveEnv, [name]: stored };
-    }
-    let credential = await (options.resolveCredential ?? resolveDevCredential)({ env: effectiveEnv });
-    if (credential.rung === "env-key") {
-      output.log(`Model: ${describeDevCredential(credential)} — production uses this same key server-side.`);
-    }
-    const cloud = await runCloudStep({
-      root,
-      output,
-      // --byo answers the offer with "no" AND suppresses the agent-path
-      // auth.md pointer (an explicit BYO choice is final); --yes skips the
-      // prompt but still gets the pointer so an agent can mint in-band.
-      yes: options.yes === true,
-      byo: options.byo === true,
-      credential,
-      // The RUN's env, not process.env: a programmatic caller's key must be
-      // what the probe and the mint see (seams in options.cloud still win).
-      env: effectiveEnv,
-      // The step's own command_run row rides init's telemetry seams.
-      ...(options.telemetry === undefined ? {} : { telemetry: options.telemetry }),
-      ...(pretty === null ? {} : { confirm: pretty.confirm }),
-      ...(options.cloud ?? {}),
-    });
-    // Same-run pickup: a starter key minted just now lands in .env.local —
-    // merge it the same way so THIS run's passes already benefit.
-    if (cloud.wroteEnvLocal) {
-      const minted = envFileValueSync(root, "VENDO_API_KEY");
-      if (minted !== null) {
-        effectiveEnv = { ...effectiveEnv, VENDO_API_KEY: minted };
-        credential = await (options.resolveCredential ?? resolveDevCredential)({ env: effectiveEnv });
-      }
-    }
+    const { credential, cloud } = await resolveModelCredential({ root, env, options, output, pretty });
     // A key that landed in .env.local THIS run (--cloud-key upsert or the
     // login ceremony) must activate the telemetry cloud lane for the rest of
     // this run's events too — rebuild the client so it re-reads .env.local.
@@ -964,49 +1342,7 @@ export async function runInit(options: InitOptions): Promise<number> {
       telemetry = telemetryFor(options, output, root);
     }
 
-    // Wire — apply the bounded change set and list it. No gates, no prompts.
-    // (Timed for the cloud lane's wiringMs; the static scan below adds on.)
-    const wiringStarted = Date.now();
-    for (const change of changes) {
-      await writeText(change.absolute, change.after);
-    }
-
-    // Scan — .vendo artifacts + static extraction (the hints layer for the AI
-    // extraction; interim tools.json source until it lands).
-    await ensureVendoEnvExample(root);
-    await mkdir(join(root, ".vendo"), { recursive: true });
-    await writeIfMissing(
-      join(root, ".vendo", "overrides.json"),
-      `${JSON.stringify({
-        format: "vendo/overrides@3",
-        tools: {},
-        remix: { ignoreSlots: [] },
-      }, null, 2)}\n`,
-      options.force === true,
-    );
-    await writeIfMissing(
-      join(root, ".vendo", "policy.json"),
-      `${JSON.stringify({
-        format: "vendo/policy@1",
-        directions: [],
-        rules: [
-          { match: { risk: "destructive" }, action: "ask", note: "Review irreversible actions" },
-          // ENG-370 hardening: knowledge tools are read-class, so this rule
-          // must sit ABOVE the read→run rule (first match wins). MCP clients
-          // sit outside the product surface; hosts may harden ask → block.
-          { match: { tool: "vendo_knowledge_*", venue: "mcp" }, action: "ask", note: "Knowledge access from an MCP client" },
-          { match: { risk: "read" }, action: "run" },
-        ],
-      }, null, 2)}\n`,
-      options.force === true,
-    );
-    await writeIfMissing(
-      join(root, ".vendo", "brief.md"),
-      BRIEF_PLACEHOLDER,
-      options.force === true,
-    );
-    await writeIfMissing(join(root, ".vendo", "data", ".gitignore"), "*\n!.gitignore\n", options.force === true);
-    const wiringMs = Date.now() - wiringStarted;
+    const wiringMs = await wireAndScaffold({ root, changes, force: options.force === true });
 
     // Summary — what changed. What was LEARNED is the shared flow's report,
     // printed by the flow itself a few lines down.
@@ -1030,35 +1366,7 @@ export async function runInit(options: InitOptions): Promise<number> {
     // stays fail-LOUD: the catch at the bottom still exits 1.
     const themePath = join(root, ".vendo", "theme.json");
     const engineStarted = Date.now();
-    // `--extract` is the test seam onto the flow's judgment step, in init's own
-    // flat spelling; where it overlaps a real flag, the seam wins.
-    const extract = options.extract ?? {};
-    const ai = extract.ai ?? options.ai;
-    const engine = extract.engine ?? options.engine;
-    const flow = await runSyncFlow({
-      root,
-      output,
-      mode: "full",
-      // The AI-polish step keeps its OWN interactivity posture (a real TTY that
-      // no package script drives), distinct from `interactive` above — that one
-      // is the auth confirm's seam, and spending money on a model is not a
-      // question a programmatic caller may be assumed to have answered.
-      interactive: extract.interactive
-        ?? (!invokedByPackageScript() && Boolean(stdin.isTTY) && Boolean(stdout.isTTY)),
-      yes: options.yes === true,
-      // --ai IS the consent (no prompt, non-interactive runs stop skipping);
-      // --no-ai is the refusal. No flag = ask, every interactive run.
-      ...(ai === undefined ? {} : { ai }),
-      ...(options.force === true ? { force: true } : {}),
-      ...(engine === undefined ? {} : { engine }),
-      ...(pretty === null ? {} : { confirm: pretty.confirm, choose: pretty.select }),
-      ...(extract.choose === undefined ? {} : { choose: extract.choose }),
-      judge: {
-        ...(extract.harnesses === undefined ? {} : { harnesses: extract.harnesses }),
-        ...(extract.confirm === undefined ? {} : { confirm: extract.confirm }),
-        ...(extract.resolveCredential === undefined ? {} : { resolveCredential: extract.resolveCredential }),
-      },
-    });
+    const flow = await runInstallSyncFlow({ root, output, options, pretty });
     const engineMs = Date.now() - engineStarted;
     const { themeSummary, counts: { tools: toolCount, routes: routeCount } } = flow;
 
@@ -1069,50 +1377,7 @@ export async function runInit(options: InitOptions): Promise<number> {
     // finally the uncertain-slot review. Skipped entirely when theme.json
     // pre-existed this run (the flow reconciles that one instead).
     if (themeSummary !== null) {
-      const summary = flow.themeDraft === null ? themeSummary : applyThemeDraft(themeSummary, flow.themeDraft);
-      // --theme answers land first; the review prompt then covers only the
-      // uncertain slots the flags left unanswered (non-interactive runs keep
-      // the extracted/merged values for those, exactly as before).
-      const answers: Record<string, string> = { ...(options.themeAnswers ?? {}) };
-      const unanswered = summary.uncertain.filter((entry) => !Object.hasOwn(answers, entry.slot));
-      if (unanswered.length > 0 && options.yes !== true) {
-        const reviewed = await (options.themeReview ?? defaultThemeReview)(
-          unanswered.length === summary.uncertain.length ? summary : { ...summary, uncertain: unanswered },
-        );
-        for (const [slot, raw] of Object.entries(reviewed)) {
-          if (!Object.hasOwn(answers, slot)) answers[slot] = raw;
-        }
-      }
-      if (Object.keys(answers).length > 0) {
-        for (const [slot, raw] of Object.entries(answers)) {
-          if (!Object.hasOwn(summary.slots, slot)) {
-            output.error(`ignored unknown theme slot ${JSON.stringify(slot)}`);
-            continue;
-          }
-          const value = validateSlotValue(slot as keyof ThemeSlotValues, raw);
-          if (value === null) {
-            output.error(`ignored invalid theme ${slot} value ${JSON.stringify(raw)}`);
-          } else {
-            (summary.slots as unknown as Record<string, string>)[slot] = value;
-            summary.matched[slot] = "(you)";
-            // The slot no longer defaulted — the human just set it.
-            summary.defaulted = summary.defaulted.filter((name) => name !== slot);
-          }
-        }
-        // A replaced accent invalidates an accentText nobody chose — one that
-        // was contrast-derived, or still the neutral default because the
-        // model omitted the accent too. Re-derive against the new accent; an
-        // explicit token or a direct human/model answer stays authoritative.
-        const accentTextUnchosen = summary.matched["accentText"] === "(contrast) accent"
-          || summary.defaulted.includes("accentText");
-        if (summary.matched["accent"] === "(you)" && accentTextUnchosen) {
-          summary.slots.accentText = contrastingText(summary.slots.accent);
-          summary.matched["accentText"] = "(contrast) accent";
-          summary.defaulted = summary.defaulted.filter((name) => name !== "accentText");
-        }
-      }
-      await writeText(themePath, `${JSON.stringify(toVendoTheme(summary.slots), null, 2)}\n`);
-      printThemeSummary(summary, output);
+      await finalizeTheme({ themeSummary, themeDraft: flow.themeDraft, themePath, options, output });
     }
 
     // Judgment state, one line: a pass that ran already narrated itself (it
@@ -1147,31 +1412,7 @@ export async function runInit(options: InitOptions): Promise<number> {
       ...(await cloudProjectProps(root)),
     });
 
-    // The credential's runtime provider must be resolvable from the host or
-    // the FIRST turn 500s (dev-creds/model.ts loads it host-side; nothing
-    // declares @ai-sdk/* — 0.4.1 E2E cert finding). Install exactly what the
-    // resolved credential needs; a failure degrades to the manual command.
-    await ensureProviderDeps({
-      root,
-      credential,
-      output,
-      ...(options.installProvider === undefined ? {} : { run: options.installProvider }),
-    });
-
-    // FINDINGS F2 (skateshop): a host pinning zod < 3.25 builds red once the
-    // wiring pulls ai@6 into the bundle (ai imports the zod/v3 + zod/v4
-    // subpaths that arrive in 3.25, and the host's own pin wins the installed
-    // tree). Ask-and-bump with the auth confirm's interactivity posture:
-    // --yes performs the announced bump, non-interactive prints the command.
-    await ensureZodFloor({
-      root,
-      output,
-      ...(options.yes === true ? { yes: true } : {}),
-      ...(options.yes === true || !interactive
-        ? {}
-        : { confirm: options.confirmZodBump ?? (pretty === null ? askYesNo : pretty.confirm) }),
-      ...(options.installZod === undefined ? {} : { run: options.installZod }),
-    });
+    await ensureHostDeps({ root, output, options, pretty, interactive, credential });
 
     // The one short Cloud reminder in the end-of-run summary — ONLY while no
     // key exists (the full emphasized block already ran up top; no repeat).
@@ -1187,56 +1428,8 @@ export async function runInit(options: InitOptions): Promise<number> {
       output.error(`warning: installed ai@${aiVersion} is unsupported — Vendo supports ai@6; downgrade (npm install ai@^6 @ai-sdk/anthropic@^3 @ai-sdk/react@^3) or track github.com/runvendo/vendo/issues/478`);
     }
 
-    // Done — the pastes init cannot take (it only ever CREATES files in your
-    // source tree), then their own dev server. They get their own framed block
-    // because skipping them is the whole failure mode: a green install nobody
-    // can see, or server-action tools that silently fail closed.
     const handSteps = [...(mount === null ? [] : [mount]), ...edits];
-    if (handSteps.length > 0) {
-      const rule = "─".repeat(64);
-      output.log(`\n${rule}`);
-      output.log(handSteps.length === 1
-        ? "ONE STEP LEFT — paste this yourself (init never edits your files)"
-        : `${handSteps.length} STEPS LEFT — paste these yourself (init never edits your files)`);
-      for (const step of handSteps) {
-        output.log(`\n  File: ${step.file}`);
-        for (const line of step.lines) output.log(`    ${line}`);
-        output.log(`\n  ${step.why}`);
-      }
-      output.log("  Then confirm it landed: npx vendo doctor");
-      output.log(rule);
-    }
-    // Express and custom hosts have no single host file to name, so their
-    // wiring keeps the compact list; the block above already said everything
-    // a Next host needs, and nothing is printed twice.
-    if (handSteps.length === 0 && manualSteps.length > 0) {
-      output.log("\nLast steps are yours:");
-      for (const line of manualSteps) output.log(`  ${line}`);
-    }
-    // A run without a USABLE model credential is wired but not answering, so
-    // the closing line must not claim otherwise. The rung alone is not that
-    // answer: resolveDevCredential only checks that VENDO_API_KEY is non-blank
-    // (and VENDO_DEV_CREDENTIAL=vendo-cloud pins the rung with no key at all),
-    // so a malformed key resolves "vendo-cloud" while the cloud step — the one
-    // thing that inspected the key — already said it is not usable. Keyless,
-    // the composition decides: one written THIS run passes no model, so "no
-    // key" is the whole story, while one init did not write may pass its own
-    // `model` to createVendo — nothing here can see that, so state the
-    // condition rather than guess either way.
-    // …and it only gets to speak at all once nothing is outstanding: a paste
-    // still pending means the frame above just said Vendo is invisible until
-    // it lands, so "the agent is live in your app" would contradict it in the
-    // same breath (self-serve audit F5).
-    const modelReady = credential.rung === "env-key"
-      || (credential.rung === "vendo-cloud" && cloud.keyValid);
-    if (handSteps.length === 0) {
-      output.log(`\nThen start your dev server — ${modelReady
-        ? "the agent is live in your app."
-        : compositionPath !== null
-          ? "the agent is live once you add a model key."
-          : "no model key resolved here, so the agent is live only if your composition passes its own model."}`);
-    }
-    output.log(`${handSteps.length === 0 ? "" : "\n"}Verify everything: \`npx vendo doctor\` (it can start the server and run a live turn).`);
+    printClosingSteps({ output, handSteps, manualSteps, credential, cloud, compositionPath });
 
     // Agent tail (agent-install-dx): the --yes-or-non-TTY path is agent-driven
     // — the run's FINAL block is the repo-specific pointers an agent parses.
@@ -1247,37 +1440,7 @@ export async function runInit(options: InitOptions): Promise<number> {
       const tail = await agentTailLines({ root, framework: plan.framework, compositionPath, authWired, layout, edits, cloudKeyMissing: credential.rung === "none" });
       for (const line of tail) output.log(`  ${line}`);
     } else {
-      // Star ask (agent-install-dx §CLI-5): the interactive success screen
-      // ends with ONE consent question — never shown non-interactively (the
-      // playbook owns the agent-path ask; deterministic runs stay that way),
-      // and never fatal: nothing in this step can change init's exit code.
-      // Yes stars via gh; any failure degrades to the repo URL, one line.
-      // No does nothing — no guilt text.
-      try {
-        // Consent guard: an unshown prompt is NEVER a yes. On a non-TTY
-        // stdin (programmatic `interactive: true`, `init < file`) both real
-        // confirms would resolve the default — pretty.confirm returns it,
-        // askYesNo would block — and starring is an account action, so the
-        // answer without a real keyboard is false, regardless of path.
-        const confirmStar = options.confirmStar
-          ?? (async (question: string, defaultYes: boolean) =>
-            stdin.isTTY === true
-              ? (pretty === null ? askYesNo : pretty.confirm)(question, defaultYes)
-              : false);
-        if (await confirmStar(`Star ${STAR_REPO} to support the project?`, true)) {
-          const starred = await starViaGh(
-            options.spawnStar ?? ((command, args) => spawn(command, args, { stdio: "ignore" })),
-          );
-          if (!starred) output.log(`Star it anytime: ${STAR_LINK}`);
-          // Star attribution: `starred` is an exact star-from-the-CLI signal
-          // (closed outcome enum; counts-and-enums promise holds).
-          await telemetry.track("star_prompt", { outcome: starred ? "starred" : "star-failed" });
-        } else {
-          await telemetry.track("star_prompt", { outcome: "declined" });
-        }
-      } catch {
-        // The ask is best-effort by design; init already succeeded.
-      }
+      await askForStar({ options, pretty, output, telemetry });
     }
     // The run's LAST word is the outstanding paste, on both paths (self-serve
     // audit F5: interactive installs used to end on the star ask with the one

--- a/packages/vendo/src/cli/judge/pass.ts
+++ b/packages/vendo/src/cli/judge/pass.ts
@@ -408,23 +408,7 @@ export async function runJudgmentPass(options: JudgmentPassOptions): Promise<Jud
   const storedFile = await readJudgmentsFile(judgmentsPath);
   const stored: Record<string, ToolJudgment> = storedFile?.tools ?? {};
 
-  // ------------------------------------------------------------------
-  // Candidates. The whole set in full mode; in incremental mode a tool is a
-  // candidate when it has never been judged, when its judgment describes a
-  // handler that MOVED (binding mismatch — the entry is inert), or when its
-  // source hash drifted out from under a standing judgment.
-  // ------------------------------------------------------------------
-  const byName = new Map<string, Candidate>();
-  for (const tool of tools) {
-    const entry = stored[tool.name];
-    const valid = entry !== undefined && entry.binding === bindingIdentity(tool.binding) ? entry : undefined;
-    byName.set(tool.name, { tool, effective: applyJudgment(tool, valid), existing: valid });
-  }
-  const candidates = [...byName.values()]
-    .filter((candidate) => options.mode === "full"
-      || candidate.existing === undefined
-      || candidate.existing.srcHash !== candidate.tool.srcHash)
-    .sort((left, right) => bindingIdentity(left.tool.binding).localeCompare(bindingIdentity(right.tool.binding)));
+  const { byName, candidates } = selectCandidates(tools, stored, options.mode);
 
   // The up-to-date check is purely LOCAL and runs BEFORE engine resolution: a
   // fully judged, unchanged catalog says so whether or not a model key is
@@ -462,6 +446,110 @@ export async function runJudgmentPass(options: JudgmentPassOptions): Promise<Jud
     credential = resolved.engine.credential;
   }
 
+  const { overrideNames, appName } = await readPromptContext(options);
+
+  const artifactDir = join(options.out, "data", "judge");
+  await rm(artifactDir, { recursive: true, force: true });
+  const notes: string[] = [];
+  const stages = createStageRunner({ harness, artifactDir, options });
+
+  const judged = await runJudgeStage({ candidates, byName, appName, overrideNames, notes, stages, options });
+
+  if (judged.chunksParsed === 0) {
+    output.error(
+      `warning: judgment output unparseable — skipped, the structural catalog stands (${sanitize(notes[0] ?? "no usable batch")})`,
+    );
+    return { status: "skipped" };
+  }
+
+  const verdicts = await runSkepticStage({ proposals: judged.proposals, appName, notes, stages, options });
+
+  const routed = routeProposals(judged.proposals, verdicts, stored);
+
+  // Drop entries that no longer describe anything BEFORE the review, so a human
+  // is never asked about a loosening on a tool that vanished.
+  const pruned = pruneJudgments({ format: VENDO_JUDGMENTS_FORMAT, tools: routed.next }, tools);
+
+  // ------------------------------------------------------------------
+  // Loosenings: one aggregated decision, or the queue.
+  // ------------------------------------------------------------------
+  const { approved, queued, declined } = options.loosenings === "review"
+    ? await reviewPendingLoosenings(pruned, byName, options)
+    : { approved: 0, declined: 0, queued: countPending(pruned) };
+
+  // ------------------------------------------------------------------
+  // Write. Stable key order, no-churn bytes, and validated against the strict
+  // schema — a malformed write is a bug here and must never land on disk.
+  // ------------------------------------------------------------------
+  const sortedTools: Record<string, ToolJudgment> = {};
+  for (const name of Object.keys(pruned.tools).sort()) sortedTools[name] = pruned.tools[name]!;
+  const file = judgmentsFileSchema.parse({ format: VENDO_JUDGMENTS_FORMAT, tools: sortedTools });
+  // Don't create an empty file where none existed: a pass that found nothing to
+  // record leaves the directory as it was.
+  if (storedFile !== null || Object.keys(sortedTools).length > 0) {
+    await writeIfChanged(judgmentsPath, `${JSON.stringify(file, null, 2)}\n`);
+  }
+
+  // Schemas land in tools.json, NOT in judgments.json: the descriptor's schema
+  // is the machine layer, and `patchToolSchemas` refuses any slot the
+  // deterministic extractors already filled.
+  const patched = await patchToolSchemas(join(options.out, "tools.json"), routed.schemaPatches);
+
+  reportNarrative({
+    output,
+    credential,
+    judged,
+    routed,
+    patched,
+    loosenings: { approved, declined, queued },
+    repairedStages: stages.repairedStages,
+    notes,
+  });
+
+  return {
+    status: "judged",
+    judged: routed.judgedNames.length,
+    hardened: routed.hardenedFields.length,
+    queued,
+    approved,
+    rejectedBySkeptic: routed.rejectedBySkeptic.length,
+    unexaminedRejected: routed.unexaminedRejected.length,
+    evidenceless: judged.evidenceless.length,
+    advisoriesClamped: judged.advisoriesClamped,
+    inconsistentRisk: judged.inconsistentRisk.length,
+    schemasInferred: patched.written.length,
+    schemasRejected: judged.schemasRefused.length + routed.schemasVetoed + patched.skipped.length,
+  };
+}
+
+/** Candidates. The whole set in full mode; in incremental mode a tool is a
+ *  candidate when it has never been judged, when its judgment describes a
+ *  handler that MOVED (binding mismatch — the entry is inert), or when its
+ *  source hash drifted out from under a standing judgment. */
+function selectCandidates(
+  tools: ExtractedTool[],
+  stored: Record<string, ToolJudgment>,
+  mode: JudgmentPassOptions["mode"],
+): { byName: Map<string, Candidate>; candidates: Candidate[] } {
+  const byName = new Map<string, Candidate>();
+  for (const tool of tools) {
+    const entry = stored[tool.name];
+    const valid = entry !== undefined && entry.binding === bindingIdentity(tool.binding) ? entry : undefined;
+    byName.set(tool.name, { tool, effective: applyJudgment(tool, valid), existing: valid });
+  }
+  const candidates = [...byName.values()]
+    .filter((candidate) => mode === "full"
+      || candidate.existing === undefined
+      || candidate.existing.srcHash !== candidate.tool.srcHash)
+    .sort((left, right) => bindingIdentity(left.tool.binding).localeCompare(bindingIdentity(right.tool.binding)));
+  return { byName, candidates };
+}
+
+/** Read-only context the prompts quote: which tools a human has already
+ *  overridden, and what to call the app. */
+async function readPromptContext(
+  options: JudgmentPassOptions,
+): Promise<{ overrideNames: string[]; appName: string }> {
   const overridesRaw = await readOptional(join(options.out, "overrides.json"));
   let overrideNames: string[] = [];
   if (overridesRaw !== null) {
@@ -481,27 +569,37 @@ export async function runJudgmentPass(options: JudgmentPassOptions): Promise<Jud
       appName = "app";
     }
   }
+  return { overrideNames, appName };
+}
 
-  const artifactDir = join(options.out, "data", "judge");
-  await rm(artifactDir, { recursive: true, force: true });
-  const notes: string[] = [];
+const failure = (error: unknown): string => error instanceof Error ? error.message : "unknown error";
+
+interface StageRunner {
+  /** One harness call plus its artifact. A throw is recorded and rethrown so the
+   *  caller decides whether that stage is fatal. */
+  run: <Schema extends z.ZodTypeAny>(stage: string, instructions: string, schema: Schema) => Promise<z.infer<Schema>>;
   /** Stages whose output needed a syntax repair — warned about, never hidden. */
+  repairedStages: string[];
+}
+
+function createStageRunner(input: {
+  harness: ExtractionHarness;
+  artifactDir: string;
+  options: JudgmentPassOptions;
+}): StageRunner {
+  const { harness, artifactDir, options } = input;
   const repairedStages: string[] = [];
   const writeArtifact = async (stage: string, body: unknown): Promise<void> => {
     await writeIfChanged(join(artifactDir, `${stage}.json`), `${JSON.stringify(body, null, 2)}\n`);
   };
-  const failure = (error: unknown): string => error instanceof Error ? error.message : "unknown error";
-
-  /** One harness call plus its artifact. A throw is recorded and rethrown so the
-   *  caller decides whether that stage is fatal. */
-  async function runStage<Schema extends z.ZodTypeAny>(
+  const run = async <Schema extends z.ZodTypeAny>(
     stage: string,
     instructions: string,
     schema: Schema,
-  ): Promise<z.infer<Schema>> {
+  ): Promise<z.infer<Schema>> => {
     let text: string | null = null;
     try {
-      text = await harness!.run({
+      text = await harness.run({
         root: options.root,
         env: options.env,
         instructions,
@@ -523,22 +621,115 @@ export async function runJudgmentPass(options: JudgmentPassOptions): Promise<Jud
       await writeArtifact(stage, { stage, error: failure(error), ...(text === null ? {} : { raw: text }) });
       throw error;
     }
-  }
+  };
+  return { run, repairedStages };
+}
 
-  // ------------------------------------------------------------------
-  // JUDGE.
-  // ------------------------------------------------------------------
+/** Everything one JUDGE pass produced: the surviving proposals, and every
+ *  tally the narrative and the counts report. */
+interface JudgeStageResult {
+  proposals: Map<string, Proposal>;
+  chunksParsed: number;
+  evidenceless: string[];
+  malformed: string[];
+  unknownTools: string[];
+  inconsistentRisk: string[];
+  schemasRefused: string[];
+  missedSurfaces: string[];
+  narratives: string[];
+  advisoriesClamped: number;
+}
+
+/** One parsed proposal, ingested into `result`. Everything model-authored is
+ *  sanitized at INGEST, not just at the print site, so the value is safe
+ *  everywhere it travels. */
+function ingestProposal(raw: unknown, byName: Map<string, Candidate>, result: JudgeStageResult): void {
+  const prose = clampProse(raw);
+  result.advisoriesClamped += prose.clamped;
+  const parsed = judgeProposalSchema.safeParse(prose.value);
+  if (!parsed.success) {
+    // This name never matched a real tool, so it is pure model text with no
+    // schema behind it.
+    const name = typeof (raw as { name?: unknown } | null)?.name === "string"
+      ? sanitize((raw as { name: string }).name)
+      : "(unnamed)";
+    // Evidence is the one requirement worth counting separately: it is the
+    // difference between a finding and an opinion.
+    if (parsed.error.issues.some((issue) => issue.path[0] === "evidence")) result.evidenceless.push(name);
+    else result.malformed.push(name);
+    return;
+  }
+  const candidate = byName.get(parsed.data.name);
+  if (candidate === undefined) {
+    // Parsed, but names no tool in the catalog — so it is model text that
+    // never met a schema constraint either. Same ingest-time sanitize.
+    result.unknownTools.push(sanitize(parsed.data.name));
+    return;
+  }
+  const fields: JudgmentFields = {};
+  for (const key of JUDGMENT_FIELDS) {
+    const value = parsed.data[key];
+    if (value !== undefined) Object.assign(fields, { [key]: value });
+  }
+  // Self-consistency backstop. The model hedges upward: it emits `write`
+  // while its own reason says the handler changes no stored state (cache
+  // revalidation, a GET dispatching query procedures). Such a grade is
+  // DROPPED, not corrected in either direction — applying it would auto-apply
+  // a hardening the reason itself denies, and rewriting it to `read` would
+  // apply a loosening no human approved. Dropping leaves the tool's standing
+  // grade untouched, which is the only move that loosens nothing.
+  if (
+    (fields.risk === "write" || fields.risk === "destructive")
+    && parsed.data.reason !== undefined
+    && assertsNoMutation(parsed.data.reason)
+  ) {
+    delete fields.risk;
+    result.inconsistentRisk.push(parsed.data.name);
+  }
+  // Only a BLIND slot may be offered. The prompt says so; this is the code
+  // that means it, and `patchToolSchemas` is the third and final wall.
+  const schemas: Partial<Record<ToolSchemaSlot, JsonSchema>> = {};
+  for (const slot of SCHEMA_SLOTS) {
+    const proposed = parsed.data[slot];
+    if (proposed === undefined) continue;
+    const source = slot === "inputSchema"
+      ? candidate.tool.inputSchemaSource ?? "unknown"
+      : candidate.tool.outputSchemaSource ?? "unknown";
+    if (source === "unknown") schemas[slot] = proposed;
+    else result.schemasRefused.push(`${parsed.data.name}.${slot}`);
+  }
+  result.proposals.set(parsed.data.name, {
+    candidate,
+    fields,
+    schemas,
+    evidence: parsed.data.evidence,
+    ...(parsed.data.reason === undefined ? {} : { reason: parsed.data.reason }),
+  });
+}
+
+async function runJudgeStage(input: {
+  candidates: Candidate[];
+  byName: Map<string, Candidate>;
+  appName: string;
+  overrideNames: string[];
+  notes: string[];
+  stages: StageRunner;
+  options: JudgmentPassOptions;
+}): Promise<JudgeStageResult> {
+  const { candidates, byName, appName, overrideNames, notes, stages, options } = input;
   const chunks = chunked(candidates, JUDGE_BATCH_LIMIT);
-  const proposals = new Map<string, Proposal>();
-  const evidenceless: string[] = [];
-  const malformed: string[] = [];
-  const unknownTools: string[] = [];
-  const inconsistentRisk: string[] = [];
-  const schemasRefused: string[] = [];
-  const missedSurfaces: string[] = [];
-  const narratives: string[] = [];
-  let advisoriesClamped = 0;
-  let judgeChunksParsed = 0;
+  const result: JudgeStageResult = {
+    proposals: new Map<string, Proposal>(),
+    chunksParsed: 0,
+    evidenceless: [],
+    malformed: [],
+    unknownTools: [],
+    inconsistentRisk: [],
+    schemasRefused: [],
+    missedSurfaces: [],
+    narratives: [],
+    advisoriesClamped: 0,
+  };
 
   for (const [index, chunk] of chunks.entries()) {
     options.onProgress?.(chunks.length > 1
@@ -546,7 +737,7 @@ export async function runJudgmentPass(options: JudgmentPassOptions): Promise<Jud
       : `judging ${chunk.length} tools`);
     let artifact: z.infer<typeof judgeResultSchema>;
     try {
-      artifact = await runStage(
+      artifact = await stages.run(
         `judge-${index + 1}`,
         composeJudgeInstructions({
           appName,
@@ -561,89 +752,23 @@ export async function runJudgmentPass(options: JudgmentPassOptions): Promise<Jud
       notes.push(`judge batch ${index + 1}/${chunks.length} unusable (${failure(error)}) — its tools stay unjudged`);
       continue;
     }
-    judgeChunksParsed += 1;
+    result.chunksParsed += 1;
     const advisories = normalizeAdvisories(artifact);
-    advisoriesClamped += advisories.clamped;
-    if (advisories.narrative !== "") narratives.push(advisories.narrative);
-    missedSurfaces.push(...advisories.surfaces);
+    result.advisoriesClamped += advisories.clamped;
+    if (advisories.narrative !== "") result.narratives.push(advisories.narrative);
+    result.missedSurfaces.push(...advisories.surfaces);
 
-    for (const raw of artifact.tools) {
-      const prose = clampProse(raw);
-      advisoriesClamped += prose.clamped;
-      const parsed = judgeProposalSchema.safeParse(prose.value);
-      if (!parsed.success) {
-        // Sanitized at INGEST, not just at the print site, so the value is safe
-        // everywhere it travels — this name never matched a real tool, so it is
-        // pure model text with no schema behind it.
-        const name = typeof (raw as { name?: unknown } | null)?.name === "string"
-          ? sanitize((raw as { name: string }).name)
-          : "(unnamed)";
-        // Evidence is the one requirement worth counting separately: it is the
-        // difference between a finding and an opinion.
-        if (parsed.error.issues.some((issue) => issue.path[0] === "evidence")) evidenceless.push(name);
-        else malformed.push(name);
-        continue;
-      }
-      const candidate = byName.get(parsed.data.name);
-      if (candidate === undefined) {
-        // Parsed, but names no tool in the catalog — so it is model text that
-        // never met a schema constraint either. Same ingest-time sanitize.
-        unknownTools.push(sanitize(parsed.data.name));
-        continue;
-      }
-      const fields: JudgmentFields = {};
-      for (const key of JUDGMENT_FIELDS) {
-        const value = parsed.data[key];
-        if (value !== undefined) Object.assign(fields, { [key]: value });
-      }
-      // Self-consistency backstop. The model hedges upward: it emits `write`
-      // while its own reason says the handler changes no stored state (cache
-      // revalidation, a GET dispatching query procedures). Such a grade is
-      // DROPPED, not corrected in either direction — applying it would auto-apply
-      // a hardening the reason itself denies, and rewriting it to `read` would
-      // apply a loosening no human approved. Dropping leaves the tool's standing
-      // grade untouched, which is the only move that loosens nothing.
-      if (
-        (fields.risk === "write" || fields.risk === "destructive")
-        && parsed.data.reason !== undefined
-        && assertsNoMutation(parsed.data.reason)
-      ) {
-        delete fields.risk;
-        inconsistentRisk.push(parsed.data.name);
-      }
-      // Only a BLIND slot may be offered. The prompt says so; this is the code
-      // that means it, and `patchToolSchemas` is the third and final wall.
-      const schemas: Partial<Record<ToolSchemaSlot, JsonSchema>> = {};
-      for (const slot of SCHEMA_SLOTS) {
-        const proposed = parsed.data[slot];
-        if (proposed === undefined) continue;
-        const source = slot === "inputSchema"
-          ? candidate.tool.inputSchemaSource ?? "unknown"
-          : candidate.tool.outputSchemaSource ?? "unknown";
-        if (source === "unknown") schemas[slot] = proposed;
-        else schemasRefused.push(`${parsed.data.name}.${slot}`);
-      }
-      proposals.set(parsed.data.name, {
-        candidate,
-        fields,
-        schemas,
-        evidence: parsed.data.evidence,
-        ...(parsed.data.reason === undefined ? {} : { reason: parsed.data.reason }),
-      });
-    }
+    for (const raw of artifact.tools) ingestProposal(raw, byName, result);
   }
+  return result;
+}
 
-  if (judgeChunksParsed === 0) {
-    output.error(
-      `warning: judgment output unparseable — skipped, the structural catalog stands (${sanitize(notes[0] ?? "no usable batch")})`,
-    );
-    return { status: "skipped" };
-  }
+type Verdicts = Map<string, { verdict: "uphold" | "reject"; reason?: string }>;
 
-  // ------------------------------------------------------------------
-  // SKEPTIC — a second, independent run per chunk. `harness.run` is stateless,
-  // so each call is a fresh conversation on the same engine.
-  // ------------------------------------------------------------------
+/** The moves one proposal asks the skeptic to check. A proposal with no fields
+ *  is a bare CONFIRMATION ("I read this, nothing to change"): there is nothing
+ *  to uphold, so it does not cost a skeptic call and yields no subject. */
+function skepticSubjects(proposals: Map<string, Proposal>): SkepticSubject[] {
   const subjects: SkepticSubject[] = [];
   for (const proposal of proposals.values()) {
     const moves: SkepticSubject["moves"] = Object.entries(proposal.fields).map(([field, to]) => ({
@@ -656,8 +781,6 @@ export async function runJudgmentPass(options: JudgmentPassOptions): Promise<Jud
     for (const [slot, schema] of Object.entries(proposal.schemas)) {
       moves.push({ field: slot, from: "unknown", to: schema });
     }
-    // A proposal with no fields is a bare CONFIRMATION ("I read this, nothing to
-    // change"). There is nothing to uphold, so it does not cost a skeptic call.
     if (moves.length === 0) continue;
     subjects.push({
       tool: proposal.candidate.effective,
@@ -666,8 +789,21 @@ export async function runJudgmentPass(options: JudgmentPassOptions): Promise<Jud
       ...(proposal.reason === undefined ? {} : { reason: proposal.reason }),
     });
   }
+  return subjects;
+}
 
-  const verdicts = new Map<string, { verdict: "uphold" | "reject"; reason?: string }>();
+/** SKEPTIC — a second, independent run per chunk. `harness.run` is stateless,
+ *  so each call is a fresh conversation on the same engine. */
+async function runSkepticStage(input: {
+  proposals: Map<string, Proposal>;
+  appName: string;
+  notes: string[];
+  stages: StageRunner;
+  options: JudgmentPassOptions;
+}): Promise<Verdicts> {
+  const { proposals, appName, notes, stages, options } = input;
+  const subjects = skepticSubjects(proposals);
+  const verdicts: Verdicts = new Map();
   const collectVerdicts = (artifact: z.infer<typeof skepticResultSchema>): void => {
     for (const raw of artifact.verdicts) {
       const parsed = skepticVerdictSchema.safeParse(raw);
@@ -682,7 +818,7 @@ export async function runJudgmentPass(options: JudgmentPassOptions): Promise<Jud
   for (const [index, chunk] of chunked(subjects, JUDGE_BATCH_LIMIT).entries()) {
     options.onProgress?.(`checking ${chunk.length} proposals against the source`);
     try {
-      collectVerdicts(await runStage(
+      collectVerdicts(await stages.run(
         `skeptic-${index + 1}`,
         composeSkepticInstructions({ appName, subjects: chunk }),
         skepticResultSchema,
@@ -704,7 +840,7 @@ export async function runJudgmentPass(options: JudgmentPassOptions): Promise<Jud
   if (unexaminedSubjects.length > 0) {
     options.onProgress?.("re-asking the skeptic about unexamined fields");
     try {
-      collectVerdicts(await runStage(
+      collectVerdicts(await stages.run(
         "skeptic-reask",
         composeSkepticInstructions({ appName, subjects: unexaminedSubjects, reask: true }),
         skepticResultSchema,
@@ -713,182 +849,194 @@ export async function runJudgmentPass(options: JudgmentPassOptions): Promise<Jud
       notes.push(`skeptic re-ask unusable (${failure(error)}) — the unexamined fields are rejected`);
     }
   }
+  return verdicts;
+}
 
-  // ------------------------------------------------------------------
-  // Routing.
-  // ------------------------------------------------------------------
-  const next: Record<string, ToolJudgment> = { ...stored };
-  const rejectedBySkeptic: string[] = [];
-  const unexaminedRejected: string[] = [];
-  const hardenedFields: string[] = [];
-  const discredited: string[] = [];
-  const judgedNames: string[] = [];
-  const schemaPatches: ToolSchemaPatch[] = [];
+/** What routing wrote, and every tally the narrative reports about it. */
+interface RoutingResult {
+  next: Record<string, ToolJudgment>;
+  rejectedBySkeptic: string[];
+  unexaminedRejected: string[];
+  hardenedFields: string[];
+  discredited: string[];
+  judgedNames: string[];
+  schemaPatches: ToolSchemaPatch[];
   /** Slots the skeptic vetoed or never examined — counted with the refusals. */
-  let schemasVetoed = 0;
+  schemasVetoed: number;
+}
 
-  for (const proposal of proposals.values()) {
-    const { candidate } = proposal;
-    const name = candidate.tool.name;
-    // An omitted verdict is a rejection: the skeptic answers every (name, field)
-    // pair it was given, so silence is not assent.
-    const upheldBySkeptic = (field: string): boolean => {
-      const verdict = verdicts.get(verdictKey(name, field));
-      if (verdict === undefined) {
-        unexaminedRejected.push(`${name}.${field}`);
-        return false;
-      }
-      if (verdict.verdict === "reject") {
-        rejectedBySkeptic.push(
-          `${name}.${field}${verdict.reason === undefined ? "" : ` — ${sanitize(verdict.reason)}`}`,
-        );
-        return false;
-      }
-      return true;
-    };
-
-    const upheld: JudgmentFields = {};
-    for (const [field, value] of Object.entries(proposal.fields)) {
-      if (upheldBySkeptic(field)) Object.assign(upheld, { [field]: value });
+/** Route ONE proposal's surviving fields and schemas into `result`. */
+function routeProposal(proposal: Proposal, verdicts: Verdicts, result: RoutingResult): void {
+  const { candidate } = proposal;
+  const name = candidate.tool.name;
+  // An omitted verdict is a rejection: the skeptic answers every (name, field)
+  // pair it was given, so silence is not assent.
+  const upheldBySkeptic = (field: string): boolean => {
+    const verdict = verdicts.get(verdictKey(name, field));
+    if (verdict === undefined) {
+      result.unexaminedRejected.push(`${name}.${field}`);
+      return false;
     }
-
-    let upheldSchemas = 0;
-    for (const [slot, schema] of Object.entries(proposal.schemas) as Array<[ToolSchemaSlot, JsonSchema]>) {
-      if (upheldBySkeptic(slot)) {
-        schemaPatches.push({ tool: name, binding: bindingIdentity(candidate.tool.binding), slot, schema });
-        upheldSchemas += 1;
-      } else {
-        schemasVetoed += 1;
-      }
+    if (verdict.verdict === "reject") {
+      result.rejectedBySkeptic.push(
+        `${name}.${field}${verdict.reason === undefined ? "" : ` — ${sanitize(verdict.reason)}`}`,
+      );
+      return false;
     }
+    return true;
+  };
 
-    // A proposal that survived NOTHING — and the quote it rests on — did not
-    // survive review. Writing an entry from it would record evidence the
-    // skeptic just called fabricated, and its srcHash would stop the tool ever
-    // being re-asked, so nothing is written and it stays a candidate for the
-    // next run. The test is what SURVIVED, never what was offered: a proposal
-    // whose only surviving contribution is a schema patch is kept (the patch is
-    // applied below and the entry records the srcHash), while one whose fields
-    // and schemas were all vetoed is discredited like any other. A proposal
-    // that offered nothing at all is a bare CONFIRMATION and is kept.
-    const proposedCount = Object.keys(proposal.fields).length + Object.keys(proposal.schemas).length;
-    if (proposedCount > 0 && Object.keys(upheld).length === 0 && upheldSchemas === 0) {
-      discredited.push(name);
-      continue;
-    }
-
-    const wire: JudgmentProposal = {
-      ...upheld,
-      evidence: proposal.evidence,
-      ...(proposal.reason === undefined ? {} : { reason: proposal.reason }),
-    };
-    const { hardenings, loosenings } = splitProposal(candidate.effective, wire);
-
-    const base = candidate.existing;
-    const fields: JudgmentFields = { ...(base?.fields ?? {}), ...hardenings };
-    // Semantics merge PER KEY: a judgment corrects individual response fields,
-    // it never wipes what a previous pass established.
-    if (hardenings.semantics !== undefined) {
-      fields.semantics = { ...(base?.fields.semantics ?? {}), ...hardenings.semantics };
-    }
-    for (const field of Object.keys(hardenings)) hardenedFields.push(`${name}.${field}`);
-
-    next[name] = {
-      binding: bindingIdentity(candidate.tool.binding),
-      ...(candidate.tool.srcHash === undefined ? {} : { srcHash: candidate.tool.srcHash }),
-      fields,
-      evidence: proposal.evidence,
-      ...(((base?.pending ?? []).length + loosenings.length) > 0
-        ? { pending: [...(base?.pending ?? []), ...loosenings] }
-        : {}),
-    };
-    judgedNames.push(name);
+  const upheld: JudgmentFields = {};
+  for (const [field, value] of Object.entries(proposal.fields)) {
+    if (upheldBySkeptic(field)) Object.assign(upheld, { [field]: value });
   }
 
-  // Drop entries that no longer describe anything BEFORE the review, so a human
-  // is never asked about a loosening on a tool that vanished.
-  const pruned = pruneJudgments({ format: VENDO_JUDGMENTS_FORMAT, tools: next }, tools);
+  let upheldSchemas = 0;
+  for (const [slot, schema] of Object.entries(proposal.schemas) as Array<[ToolSchemaSlot, JsonSchema]>) {
+    if (upheldBySkeptic(slot)) {
+      result.schemaPatches.push({ tool: name, binding: bindingIdentity(candidate.tool.binding), slot, schema });
+      upheldSchemas += 1;
+    } else {
+      result.schemasVetoed += 1;
+    }
+  }
 
-  // ------------------------------------------------------------------
-  // Loosenings: one aggregated decision, or the queue.
-  // ------------------------------------------------------------------
+  // A proposal that survived NOTHING — and the quote it rests on — did not
+  // survive review. Writing an entry from it would record evidence the
+  // skeptic just called fabricated, and its srcHash would stop the tool ever
+  // being re-asked, so nothing is written and it stays a candidate for the
+  // next run. The test is what SURVIVED, never what was offered: a proposal
+  // whose only surviving contribution is a schema patch is kept (the patch is
+  // applied below and the entry records the srcHash), while one whose fields
+  // and schemas were all vetoed is discredited like any other. A proposal
+  // that offered nothing at all is a bare CONFIRMATION and is kept.
+  const proposedCount = Object.keys(proposal.fields).length + Object.keys(proposal.schemas).length;
+  if (proposedCount > 0 && Object.keys(upheld).length === 0 && upheldSchemas === 0) {
+    result.discredited.push(name);
+    return;
+  }
+
+  const wire: JudgmentProposal = {
+    ...upheld,
+    evidence: proposal.evidence,
+    ...(proposal.reason === undefined ? {} : { reason: proposal.reason }),
+  };
+  const { hardenings, loosenings } = splitProposal(candidate.effective, wire);
+
+  const base = candidate.existing;
+  const fields: JudgmentFields = { ...(base?.fields ?? {}), ...hardenings };
+  // Semantics merge PER KEY: a judgment corrects individual response fields,
+  // it never wipes what a previous pass established.
+  if (hardenings.semantics !== undefined) {
+    fields.semantics = { ...(base?.fields.semantics ?? {}), ...hardenings.semantics };
+  }
+  for (const field of Object.keys(hardenings)) result.hardenedFields.push(`${name}.${field}`);
+
+  result.next[name] = {
+    binding: bindingIdentity(candidate.tool.binding),
+    ...(candidate.tool.srcHash === undefined ? {} : { srcHash: candidate.tool.srcHash }),
+    fields,
+    evidence: proposal.evidence,
+    ...(((base?.pending ?? []).length + loosenings.length) > 0
+      ? { pending: [...(base?.pending ?? []), ...loosenings] }
+      : {}),
+  };
+  result.judgedNames.push(name);
+}
+
+function routeProposals(
+  proposals: Map<string, Proposal>,
+  verdicts: Verdicts,
+  stored: Record<string, ToolJudgment>,
+): RoutingResult {
+  const result: RoutingResult = {
+    next: { ...stored },
+    rejectedBySkeptic: [],
+    unexaminedRejected: [],
+    hardenedFields: [],
+    discredited: [],
+    judgedNames: [],
+    schemaPatches: [],
+    schemasVetoed: 0,
+  };
+  for (const proposal of proposals.values()) routeProposal(proposal, verdicts, result);
+  return result;
+}
+
+const countPending = (pruned: JudgmentsFile): number =>
+  Object.values(pruned.tools).reduce((total, entry) => total + (entry.pending ?? []).length, 0);
+
+/** Loosenings: one aggregated decision. Mutates `pruned` in place — either way
+ *  the queue is emptied, so the same question is not asked forever. */
+async function reviewPendingLoosenings(
+  pruned: JudgmentsFile,
+  byName: Map<string, Candidate>,
+  options: JudgmentPassOptions,
+): Promise<{ approved: number; queued: number; declined: number }> {
   let approved = 0;
-  let queued = 0;
   let declined = 0;
-  if (options.loosenings === "review") {
-    const items: LooseningReviewItem[] = [];
-    for (const [name, entry] of Object.entries(pruned.tools)) {
-      const tool = byName.get(name)?.tool;
-      if (tool === undefined || (entry.pending ?? []).length === 0) continue;
-      // The "from" side is the state AFTER this run's hardenings landed —
-      // otherwise the diff shows a value the loosening no longer moves from.
-      const { pending: _queued, ...applied } = entry;
-      const effective = applyJudgment(tool, applied);
-      for (const pending of entry.pending ?? []) {
-        items.push({
-          name,
-          field: pending.field,
-          from: effectiveValue(effective, pending.field),
-          to: pending.value,
-          evidence: pending.evidence,
-          ...(pending.reason === undefined ? {} : { reason: pending.reason }),
-        });
-      }
+  const items: LooseningReviewItem[] = [];
+  for (const [name, entry] of Object.entries(pruned.tools)) {
+    const tool = byName.get(name)?.tool;
+    if (tool === undefined || (entry.pending ?? []).length === 0) continue;
+    // The "from" side is the state AFTER this run's hardenings landed —
+    // otherwise the diff shows a value the loosening no longer moves from.
+    const { pending: _queued, ...applied } = entry;
+    const effective = applyJudgment(tool, applied);
+    for (const pending of entry.pending ?? []) {
+      items.push({
+        name,
+        field: pending.field,
+        from: effectiveValue(effective, pending.field),
+        to: pending.value,
+        evidence: pending.evidence,
+        ...(pending.reason === undefined ? {} : { reason: pending.reason }),
+      });
     }
-    const verdict = items.length === 0 ? "approved" : await reviewLoosenings(items, {
-      note: (line) => output.log(line),
-      confirm: options.confirm ?? (async () => false),
-    });
-    for (const [name, entry] of Object.entries(pruned.tools)) {
-      const pending = entry.pending ?? [];
-      if (pending.length === 0) continue;
-      const fields: JudgmentFields = { ...entry.fields };
-      if (verdict === "approved") {
-        for (const item of pending) if (promote(fields, item)) approved += 1;
-      } else {
-        declined += pending.length;
-      }
-      // Either way the queue is emptied: an approved loosening moved into
-      // `fields`, and a declined one is DROPPED rather than silently re-queued
-      // so the same question is not asked forever.
-      const { pending: _dropped, ...rest } = entry;
-      pruned.tools[name] = { ...rest, fields };
+  }
+  const verdict = items.length === 0 ? "approved" : await reviewLoosenings(items, {
+    note: (line) => options.output.log(line),
+    confirm: options.confirm ?? (async () => false),
+  });
+  for (const [name, entry] of Object.entries(pruned.tools)) {
+    const pending = entry.pending ?? [];
+    if (pending.length === 0) continue;
+    const fields: JudgmentFields = { ...entry.fields };
+    if (verdict === "approved") {
+      for (const item of pending) if (promote(fields, item)) approved += 1;
+    } else {
+      declined += pending.length;
     }
-  } else {
-    for (const entry of Object.values(pruned.tools)) queued += (entry.pending ?? []).length;
+    // Either way the queue is emptied: an approved loosening moved into
+    // `fields`, and a declined one is DROPPED rather than silently re-queued
+    // so the same question is not asked forever.
+    const { pending: _dropped, ...rest } = entry;
+    pruned.tools[name] = { ...rest, fields };
   }
+  return { approved, queued: 0, declined };
+}
 
-  // ------------------------------------------------------------------
-  // Write. Stable key order, no-churn bytes, and validated against the strict
-  // schema — a malformed write is a bug here and must never land on disk.
-  // ------------------------------------------------------------------
-  const sortedTools: Record<string, ToolJudgment> = {};
-  for (const name of Object.keys(pruned.tools).sort()) sortedTools[name] = pruned.tools[name]!;
-  const file = judgmentsFileSchema.parse({ format: VENDO_JUDGMENTS_FORMAT, tools: sortedTools });
-  // Don't create an empty file where none existed: a pass that found nothing to
-  // record leaves the directory as it was.
-  if (storedFile !== null || Object.keys(sortedTools).length > 0) {
-    await writeIfChanged(judgmentsPath, `${JSON.stringify(file, null, 2)}\n`);
-  }
-
-  // Schemas land in tools.json, NOT in judgments.json: the descriptor's schema
-  // is the machine layer, and `patchToolSchemas` refuses any slot the
-  // deterministic extractors already filled.
-  const patched = await patchToolSchemas(join(options.out, "tools.json"), schemaPatches);
-  const schemasRejectedCount = schemasRefused.length + schemasVetoed + patched.skipped.length;
-
-  // ------------------------------------------------------------------
-  // Narrative.
-  // ------------------------------------------------------------------
-  output.log(`judgment (${sanitize(credential)}): ${judgedNames.length} tools judged`);
-  if (hardenedFields.length > 0) output.log(`  hardened (${hardenedFields.length}): ${listed(hardenedFields)}`);
+function reportNarrative(input: {
+  output: Output;
+  credential: string;
+  judged: JudgeStageResult;
+  routed: RoutingResult;
+  patched: Awaited<ReturnType<typeof patchToolSchemas>>;
+  loosenings: { approved: number; declined: number; queued: number };
+  repairedStages: string[];
+  notes: string[];
+}): void {
+  const { output, credential, judged, routed, patched, repairedStages, notes } = input;
+  const { approved, declined, queued } = input.loosenings;
+  output.log(`judgment (${sanitize(credential)}): ${routed.judgedNames.length} tools judged`);
+  if (routed.hardenedFields.length > 0) output.log(`  hardened (${routed.hardenedFields.length}): ${listed(routed.hardenedFields)}`);
   if (patched.written.length > 0) {
     output.log(`  schemas inferred (${patched.written.length}): ${listed(patched.written.map((entry) => `${entry.tool}.${entry.slot}`))}`);
   }
   // Skeptic vetoes count as rejections but are printed by the skeptic's own
   // line — this one names the slots refused for being occupied or rebound.
   const schemasRefusedList = [
-    ...schemasRefused,
+    ...judged.schemasRefused,
     ...patched.skipped.map((entry) => `${entry.tool}.${entry.slot} (${entry.reason})`),
   ];
   if (schemasRefusedList.length > 0) {
@@ -899,33 +1047,33 @@ export async function runJudgmentPass(options: JudgmentPassOptions): Promise<Jud
   if (queued > 0) {
     output.log(`  ${queued} loosenings queued — review with \`vendo sync --review\``);
   }
-  if (rejectedBySkeptic.length > 0) {
-    output.log(`  rejected by the skeptic (${rejectedBySkeptic.length}): ${listed(rejectedBySkeptic, 6)}`);
+  if (routed.rejectedBySkeptic.length > 0) {
+    output.log(`  rejected by the skeptic (${routed.rejectedBySkeptic.length}): ${listed(routed.rejectedBySkeptic, 6)}`);
   }
-  if (unexaminedRejected.length > 0) {
+  if (routed.unexaminedRejected.length > 0) {
     output.log(
-      `  unexamined after one re-ask, rejected (${unexaminedRejected.length}): ${listed(unexaminedRejected, 6)}`,
+      `  unexamined after one re-ask, rejected (${routed.unexaminedRejected.length}): ${listed(routed.unexaminedRejected, 6)}`,
     );
   }
-  if (evidenceless.length > 0) {
-    output.log(`  no evidence → rejected (${evidenceless.length}): ${listed(evidenceless)}`);
+  if (judged.evidenceless.length > 0) {
+    output.log(`  no evidence → rejected (${judged.evidenceless.length}): ${listed(judged.evidenceless)}`);
   }
-  if (malformed.length > 0) output.log(`  malformed proposals ignored (${malformed.length}): ${listed(malformed)}`);
-  if (inconsistentRisk.length > 0) {
+  if (judged.malformed.length > 0) output.log(`  malformed proposals ignored (${judged.malformed.length}): ${listed(judged.malformed)}`);
+  if (judged.inconsistentRisk.length > 0) {
     output.log(
-      `  risk grade contradicted its own reason, dropped (${inconsistentRisk.length}):`
-      + ` ${listed(inconsistentRisk)}`,
+      `  risk grade contradicted its own reason, dropped (${judged.inconsistentRisk.length}):`
+      + ` ${listed(judged.inconsistentRisk)}`,
     );
   }
-  if (discredited.length > 0) {
-    output.log(`  wholly rejected, left unjudged (${discredited.length}): ${listed(discredited)}`);
+  if (routed.discredited.length > 0) {
+    output.log(`  wholly rejected, left unjudged (${routed.discredited.length}): ${listed(routed.discredited)}`);
   }
-  if (unknownTools.length > 0) {
-    output.log(`  proposals for unknown tools ignored (${unknownTools.length}): ${listed(unknownTools)}`);
+  if (judged.unknownTools.length > 0) {
+    output.log(`  proposals for unknown tools ignored (${judged.unknownTools.length}): ${listed(judged.unknownTools)}`);
   }
-  if (advisoriesClamped > 0) {
+  if (judged.advisoriesClamped > 0) {
     output.error(
-      `warning: ${advisoriesClamped} advisory string${advisoriesClamped === 1 ? "" : "s"} clamped`
+      `warning: ${judged.advisoriesClamped} advisory string${judged.advisoriesClamped === 1 ? "" : "s"} clamped`
       + " (over-long or unusable) — tool judgments were unaffected",
     );
   }
@@ -936,29 +1084,14 @@ export async function runJudgmentPass(options: JudgmentPassOptions): Promise<Jud
     );
   }
   for (const note of notes) output.error(`warning: ${sanitize(note)}`);
-  for (const narrative of narratives) {
+  for (const narrative of judged.narratives) {
     for (const line of narrative.split("\n")) output.log(`  ${sanitize(line)}`);
   }
   // Coverage leads are WARNINGS, never tools: naming a surface is a lead, and
   // adding a tool is the deterministic scanner's job.
-  for (const missed of missedSurfaces) {
+  for (const missed of judged.missedSurfaces) {
     output.error(`warning: missed surface (not extracted yet): ${sanitize(missed)}`);
   }
-
-  return {
-    status: "judged",
-    judged: judgedNames.length,
-    hardened: hardenedFields.length,
-    queued,
-    approved,
-    rejectedBySkeptic: rejectedBySkeptic.length,
-    unexaminedRejected: unexaminedRejected.length,
-    evidenceless: evidenceless.length,
-    advisoriesClamped,
-    inconsistentRisk: inconsistentRisk.length,
-    schemasInferred: patched.written.length,
-    schemasRejected: schemasRejectedCount,
-  };
 }
 
 /** The current value of one proposed field, for the skeptic's before/after. */

--- a/packages/vendo/src/cli/sync-flow.ts
+++ b/packages/vendo/src/cli/sync-flow.ts
@@ -371,6 +371,246 @@ async function chooseEngine(
   return { skip: false, engine: chosen };
 }
 
+/** The two CLI-level event sinks every stage writes through — printed AND
+ *  collected, so `sync --json` carries them in its one object. */
+interface FlowNotes {
+  note: (message: string) => void;
+  noteError: (message: string) => void;
+}
+
+/** Theme, ONE path: init's install creates the file (it is the editable source
+ *  of truth from then on), and every later run reconciles it — a rebrand
+ *  reaches Vendo, a hand edit is never clobbered. */
+async function resolveTheme(input: {
+  root: string;
+  vendoDir: string;
+  mode: SyncFlowOptions["mode"];
+  options: SyncFlowOptions;
+  note: (message: string) => void;
+}): Promise<{ themeSummary: ThemeSummary | null; themeMs: number | undefined; theme: SyncFlowResult["theme"] }> {
+  const { root, vendoDir, mode, options, note } = input;
+  const themePath = join(vendoDir, "theme.json");
+  if (mode === "full" && (options.force === true || !(await exists(themePath)))) {
+    const themeStarted = Date.now();
+    const themeSummary = await extractTheme(root);
+    const themeMs = Date.now() - themeStarted;
+    await writeText(themePath, `${JSON.stringify(toVendoTheme(themeSummary.slots), null, 2)}\n`);
+    // The merge base for every later re-scan: what the DETERMINISTIC pass read,
+    // before any model fill or --theme answer — those are decisions, and the
+    // reconcile must pin them (theme/provenance.ts).
+    await writeBase(vendoDir, baseFrom(themeSummary));
+    return { themeSummary, themeMs, theme: null };
+  }
+  return {
+    themeSummary: null,
+    themeMs: undefined,
+    theme: await reconcileTheme(root, vendoDir, options.themeRefresh === true, note),
+  };
+}
+
+/** The judgment pass: grade the freshly synced catalog, with a verbatim quote
+ *  behind every proposal and an independent skeptic checking each one.
+ *  Hardenings and prose apply themselves; loosenings wait for a human —
+ *  `--review` (or an attended run) asks now, otherwise they queue as
+ *  `pending`. Keyless resolves to one structural-only line. */
+async function runGradingStages(input: {
+  root: string;
+  vendoDir: string;
+  mode: SyncFlowOptions["mode"];
+  env: Record<string, string | undefined>;
+  options: SyncFlowOptions;
+  output: SyncFlowOptions["output"];
+  themeSummary: ThemeSummary | null;
+  notes: FlowNotes;
+}): Promise<{ judged: SyncFlowResult["judged"]; themeDraft: SyncFlowResult["themeDraft"] }> {
+  const { root, vendoDir, mode, env, options, output, themeSummary } = input;
+  const { note, noteError } = input.notes;
+  const judged: SyncFlowResult["judged"] = { ran: false };
+  let themeDraft: SyncFlowResult["themeDraft"] = null;
+  const selection = await chooseEngine(options, env, note);
+  if (selection.skip) return { judged, themeDraft };
+
+  // A one-time install narrates the slowest step it is about to take; an
+  // incremental sync stays as quiet as it is today.
+  if (mode === "full" && selection.engine !== undefined) {
+    output.log(`\nReading your product (${selection.engine.credential})…`);
+  }
+  try {
+    // `--yes` means every question is already answered, so it must not reach
+    // the aggregated loosening review either: an unattended run cannot
+    // answer, and the guard law forbids lowering risk without a human, so
+    // loosenings queue instead — and no `confirm` is handed down at all, so
+    // nothing downstream can acquire a way to block.
+    const attended = options.interactive && !options.yes;
+    const loosenings = attended || options.review === true ? "review" : "queue";
+    const pass = await runJudgmentPass({
+      root,
+      out: vendoDir,
+      mode,
+      loosenings,
+      env,
+      output: { log: note, error: noteError },
+      ...(options.engine === undefined ? {} : { engine: options.engine }),
+      ...(selection.engine === undefined
+        ? (options.judge?.harness === undefined ? {} : { harness: options.judge.harness })
+        : { harness: selection.engine.harness }),
+      ...(loosenings === "review" ? { confirm: options.judge?.confirm ?? options.confirm ?? askYesNo } : {}),
+      ...(options.judge?.harnesses === undefined ? {} : { harnesses: options.judge.harnesses }),
+      ...(options.judge?.resolveCredential === undefined ? {} : { resolveCredential: options.judge.resolveCredential }),
+      ...(options.judge?.onProgress === undefined ? {} : { onProgress: options.judge.onProgress }),
+    });
+    // The pass already printed the count and `vendo sync --review`; say WHY
+    // they were held, so an unattended caller doesn't read it as a refusal.
+    if (loosenings === "queue" && pass.status === "judged" && pass.queued > 0) {
+      note("  (held, not applied: this run had no one to ask — re-run `vendo init` in a terminal to review them inline)");
+    }
+    judged.ran = true;
+    const engine = selection.engine === undefined ? undefined : ENGINE_BY_HARNESS_ID[selection.engine.harness.id];
+    if (engine !== undefined) judged.engine = engine;
+  } catch (error) {
+    note(`judgment failed soft: ${error instanceof Error ? error.message : "unknown error"}`);
+    judged.ran = false;
+  }
+
+  // The prose stages — the product brief and the theme fill — read the GRADED
+  // catalog, so they run after the pass. Full mode only: `vendo sync` in
+  // predev must not redraft a brief on every dev-server start.
+  if (mode === "full" && selection.engine !== undefined) {
+    const stages = await runProseStages({
+      root,
+      output,
+      env,
+      harness: selection.engine.harness,
+      tools: await exists(join(vendoDir, "tools.json")),
+      ...(options.force === true ? { force: true } : {}),
+      ...(themeSummary === null ? {} : { theme: themeStageInput(themeSummary) }),
+    });
+    themeDraft = stages.theme ?? null;
+  }
+  return { judged, themeDraft };
+}
+
+async function probeImpact(input: {
+  report: SyncReportWithWarnings;
+  options: SyncFlowOptions;
+  output: SyncFlowOptions["output"];
+  note: (message: string) => void;
+}): Promise<ToolImpact[] | null> {
+  const { report, options, output, note } = input;
+  const wireUrl = (options.url ?? process.env.VENDO_URL ?? "http://localhost:3000/api/vendo").replace(/\/+$/, "");
+  const tools = [...new Set([
+    ...report.breaking.map((breaking) => breaking.tool),
+    ...report.tools.changed,
+  ])];
+  if (tools.length === 0) return [];
+  try {
+    const response = await (options.fetchImpl ?? fetch)(`${wireUrl}/sync/impact`, {
+      method: "POST",
+      headers: { accept: "application/json", "content-type": "application/json" },
+      body: JSON.stringify({ tools }),
+    });
+    if (!response.ok) throw new Error(`sync impact returned ${response.status}`);
+    const impact = impactResponse(await response.json());
+    printImpact(output, impact);
+    return impact;
+  } catch {
+    note(`impact unknown — dev server not reachable at ${wireUrl}`);
+    return null;
+  }
+}
+
+async function pushBaselinesToCloud(input: {
+  vendoDir: string;
+  cloudKey: string | undefined;
+  keyed: boolean;
+  options: SyncFlowOptions;
+  notes: FlowNotes;
+}): Promise<SyncFlowResult["baselines"]> {
+  const { vendoDir, cloudKey, keyed, options } = input;
+  const { note, noteError } = input.notes;
+  // No `.vendo/remixable/` at all means this host has never had a wrapper —
+  // nothing to push, and nothing Cloud could be holding to prune.
+  if (!(await exists(join(vendoDir, "remixable")))) return null;
+  if (!keyed) {
+    // Captures exist but this environment has no key. Keyless is a supported
+    // path (BYO), so this is a statement of fact rather than a warning — but
+    // it must be SAID: a build env that lacks the key the runtime has pushes
+    // nothing, and the console then shows a fork it cannot diff.
+    note("baselines stay local — no Vendo Cloud key in this environment; Cloud's Remix reviews screen needs a keyed sync to diff forks");
+    return null;
+  }
+  // Never throws: whatever landed before a failure is still accounted for.
+  const result = await pushPinBaselines({
+    vendoDir,
+    apiKey: cloudKey!,
+    ...(options.apiUrl === undefined ? {} : { baseUrl: options.apiUrl }),
+    ...(options.fetchImpl === undefined ? {} : { fetchImpl: options.fetchImpl }),
+    ...(options.baselineBudgetMs === undefined ? {} : { budgetMs: options.baselineBudgetMs }),
+  });
+  if (result.unreadable.length > 0) {
+    // A file that exists but won't parse is a half-written capture, not a
+    // deleted slot — its Cloud row was deliberately left in place.
+    noteError(`warning: unreadable baselines left untouched in Vendo Cloud: ${result.unreadable.join(", ")} — re-run sync to recapture .vendo/remixable/<slot>.json`);
+  }
+  if (result.pushed.length > 0 || result.pruned.length > 0) {
+    note(`baselines → Vendo Cloud: ${result.pushed.length} pushed, ${result.pruned.length} pruned (component source crosses the wire so the console can review forks)`);
+  }
+  if (result.error !== undefined) {
+    noteError(`warning: pin baselines did not fully reach Vendo Cloud: ${result.error} — the rest stay in .vendo/remixable/ and the next sync retries`);
+  }
+  return { pushed: result.pushed, pruned: result.pruned };
+}
+
+/** Registered host components → Vendo Cloud. The project answers once and the
+ *  answer is committed with the rest of `.vendo/`. Keyless/BYO never asks and
+ *  never uploads. */
+async function pushComponentsToCloud(input: {
+  vendoDir: string;
+  cloudKey: string | undefined;
+  keyed: boolean;
+  options: SyncFlowOptions;
+  notes: FlowNotes;
+}): Promise<SyncFlowResult["components"]> {
+  const { vendoDir, cloudKey, keyed, options } = input;
+  const { note, noteError } = input.notes;
+  if (!(keyed && await exists(join(vendoDir, "components")))) {
+    if (await exists(join(vendoDir, "components"))) {
+      // Same statement of fact #765 makes for baselines, for the same reason: a
+      // build env without the key its runtime has pushes nothing, and the console
+      // then draws grey placeholders with no host-side signal why.
+      note("components stay local — no Vendo Cloud key in this environment; the console needs a keyed sync to render your components instead of placeholders");
+    }
+    return null;
+  }
+  let allowed = options.pushComponents ?? await readPushComponents(vendoDir);
+  if (allowed === undefined) {
+    allowed = options.interactive && await (options.confirm ?? askYesNo)(
+      "Send this project's registered host components to Vendo Cloud, so the console renders them instead of grey placeholders? Their source and your app-root CSS cross the wire; package code never does. Saved to .vendo/cloud.json — asked once.",
+      true,
+    );
+    if (options.interactive) await writePushComponents(vendoDir, allowed);
+    else note("components: not pushed — this run cannot ask (pass `--push-components` in CI, or run `vendo sync` once in a terminal to decide)");
+  }
+  if (!allowed) return null;
+  const result = await pushHostComponents({
+    vendoDir,
+    apiKey: cloudKey!,
+    ...(options.apiUrl === undefined ? {} : { baseUrl: options.apiUrl }),
+    ...(options.fetchImpl === undefined ? {} : { fetchImpl: options.fetchImpl }),
+    ...(options.baselineBudgetMs === undefined ? {} : { budgetMs: options.baselineBudgetMs }),
+  });
+  if (result.unreadable.length > 0) {
+    noteError(`warning: unreadable component captures left untouched in Vendo Cloud: ${result.unreadable.join(", ")} — re-run sync to recapture .vendo/components/<Name>.json`);
+  }
+  if (result.pushed.length > 0 || result.pruned.length > 0 || result.modules.uploaded > 0) {
+    note(`components → Vendo Cloud: ${result.pushed.length} pushed, ${result.pruned.length} pruned, ${result.modules.uploaded} new module${result.modules.uploaded === 1 ? "" : "s"} (${Math.round(result.uploadedBytes / 1024)} KB)`);
+  }
+  if (result.error !== undefined) {
+    noteError(`warning: host components did not fully reach Vendo Cloud: ${result.error} — the rest stay in .vendo/components/ and the next sync retries`);
+  }
+  return { pushed: result.pushed, pruned: result.pruned, modules: result.modules };
+}
+
 export async function runSyncFlow(options: SyncFlowOptions): Promise<SyncFlowResult> {
   const { root, output, mode } = options;
   const vendoDir = join(root, ".vendo");
@@ -394,114 +634,10 @@ export async function runSyncFlow(options: SyncFlowOptions): Promise<SyncFlowRes
   });
   printSyncReport(report, output);
 
-  // Theme, ONE path: init's install creates the file (it is the editable source
-  // of truth from then on), and every later run reconciles it — a rebrand
-  // reaches Vendo, a hand edit is never clobbered.
-  const themePath = join(vendoDir, "theme.json");
-  let themeSummary: ThemeSummary | null = null;
-  let themeMs: number | undefined;
-  let theme: SyncFlowResult["theme"] = null;
-  if (mode === "full" && (options.force === true || !(await exists(themePath)))) {
-    const themeStarted = Date.now();
-    themeSummary = await extractTheme(root);
-    themeMs = Date.now() - themeStarted;
-    await writeText(themePath, `${JSON.stringify(toVendoTheme(themeSummary.slots), null, 2)}\n`);
-    // The merge base for every later re-scan: what the DETERMINISTIC pass read,
-    // before any model fill or --theme answer — those are decisions, and the
-    // reconcile must pin them (theme/provenance.ts).
-    await writeBase(vendoDir, baseFrom(themeSummary));
-  } else {
-    theme = await reconcileTheme(root, vendoDir, options.themeRefresh === true, note);
-  }
-
-  // The judgment pass: grade the freshly synced catalog, with a verbatim quote
-  // behind every proposal and an independent skeptic checking each one.
-  // Hardenings and prose apply themselves; loosenings wait for a human —
-  // `--review` (or an attended run) asks now, otherwise they queue as
-  // `pending`. Keyless resolves to one structural-only line.
-  const judged: SyncFlowResult["judged"] = { ran: false };
-  let themeDraft: SyncFlowResult["themeDraft"] = null;
-  const selection = await chooseEngine(options, env, note);
-  if (!selection.skip) {
-    // A one-time install narrates the slowest step it is about to take; an
-    // incremental sync stays as quiet as it is today.
-    if (mode === "full" && selection.engine !== undefined) {
-      output.log(`\nReading your product (${selection.engine.credential})…`);
-    }
-    try {
-      // `--yes` means every question is already answered, so it must not reach
-      // the aggregated loosening review either: an unattended run cannot
-      // answer, and the guard law forbids lowering risk without a human, so
-      // loosenings queue instead — and no `confirm` is handed down at all, so
-      // nothing downstream can acquire a way to block.
-      const attended = options.interactive && !options.yes;
-      const loosenings = attended || options.review === true ? "review" : "queue";
-      const pass = await runJudgmentPass({
-        root,
-        out: vendoDir,
-        mode,
-        loosenings,
-        env,
-        output: { log: note, error: noteError },
-        ...(options.engine === undefined ? {} : { engine: options.engine }),
-        ...(selection.engine === undefined
-          ? (options.judge?.harness === undefined ? {} : { harness: options.judge.harness })
-          : { harness: selection.engine.harness }),
-        ...(loosenings === "review" ? { confirm: options.judge?.confirm ?? options.confirm ?? askYesNo } : {}),
-        ...(options.judge?.harnesses === undefined ? {} : { harnesses: options.judge.harnesses }),
-        ...(options.judge?.resolveCredential === undefined ? {} : { resolveCredential: options.judge.resolveCredential }),
-        ...(options.judge?.onProgress === undefined ? {} : { onProgress: options.judge.onProgress }),
-      });
-      // The pass already printed the count and `vendo sync --review`; say WHY
-      // they were held, so an unattended caller doesn't read it as a refusal.
-      if (loosenings === "queue" && pass.status === "judged" && pass.queued > 0) {
-        note("  (held, not applied: this run had no one to ask — re-run `vendo init` in a terminal to review them inline)");
-      }
-      judged.ran = true;
-      const engine = selection.engine === undefined ? undefined : ENGINE_BY_HARNESS_ID[selection.engine.harness.id];
-      if (engine !== undefined) judged.engine = engine;
-    } catch (error) {
-      note(`judgment failed soft: ${error instanceof Error ? error.message : "unknown error"}`);
-      judged.ran = false;
-    }
-
-    // The prose stages — the product brief and the theme fill — read the GRADED
-    // catalog, so they run after the pass. Full mode only: `vendo sync` in
-    // predev must not redraft a brief on every dev-server start.
-    if (mode === "full" && selection.engine !== undefined) {
-      const stages = await runProseStages({
-        root,
-        output,
-        env,
-        harness: selection.engine.harness,
-        tools: await exists(join(vendoDir, "tools.json")),
-        ...(options.force === true ? { force: true } : {}),
-        ...(themeSummary === null ? {} : { theme: themeStageInput(themeSummary) }),
-      });
-      themeDraft = stages.theme ?? null;
-    }
-  }
-
-  const wireUrl = (options.url ?? process.env.VENDO_URL ?? "http://localhost:3000/api/vendo").replace(/\/+$/, "");
-  const tools = [...new Set([
-    ...report.breaking.map((breaking) => breaking.tool),
-    ...report.tools.changed,
-  ])];
-  let impact: ToolImpact[] | null = tools.length === 0 ? [] : null;
-  if (tools.length > 0) {
-    try {
-      const response = await (options.fetchImpl ?? fetch)(`${wireUrl}/sync/impact`, {
-        method: "POST",
-        headers: { accept: "application/json", "content-type": "application/json" },
-        body: JSON.stringify({ tools }),
-      });
-      if (!response.ok) throw new Error(`sync impact returned ${response.status}`);
-      impact = impactResponse(await response.json());
-      printImpact(output, impact);
-    } catch {
-      note(`impact unknown — dev server not reachable at ${wireUrl}`);
-    }
-  }
+  const notes_ = { note, noteError };
+  const { themeSummary, themeMs, theme } = await resolveTheme({ root, vendoDir, mode, options, note });
+  const { judged, themeDraft } = await runGradingStages({ root, vendoDir, mode, env, options, output, themeSummary, notes: notes_ });
+  const impact = await probeImpact({ report, options, output, note });
 
   // Pin baselines → Vendo Cloud (decision 4). Part of a NORMAL keyed run, not
   // something `--report` gates: the console's Remix reviews screen cannot show
@@ -509,79 +645,8 @@ export async function runSyncFlow(options: SyncFlowOptions): Promise<SyncFlowRes
   // no request at all, and a Cloud hiccup is a note — never a failed build.
   const cloudKey = options.apiKey ?? env.VENDO_API_KEY;
   const keyed = cloudKey !== undefined && cloudKey.trim() !== "";
-  // No `.vendo/remixable/` at all means this host has never had a wrapper —
-  // nothing to push, and nothing Cloud could be holding to prune.
-  let baselines: SyncFlowResult["baselines"] = null;
-  if (await exists(join(vendoDir, "remixable"))) {
-    if (keyed) {
-      // Never throws: whatever landed before a failure is still accounted for.
-      const result = await pushPinBaselines({
-        vendoDir,
-        apiKey: cloudKey!,
-        ...(options.apiUrl === undefined ? {} : { baseUrl: options.apiUrl }),
-        ...(options.fetchImpl === undefined ? {} : { fetchImpl: options.fetchImpl }),
-        ...(options.baselineBudgetMs === undefined ? {} : { budgetMs: options.baselineBudgetMs }),
-      });
-      baselines = { pushed: result.pushed, pruned: result.pruned };
-      if (result.unreadable.length > 0) {
-        // A file that exists but won't parse is a half-written capture, not a
-        // deleted slot — its Cloud row was deliberately left in place.
-        noteError(`warning: unreadable baselines left untouched in Vendo Cloud: ${result.unreadable.join(", ")} — re-run sync to recapture .vendo/remixable/<slot>.json`);
-      }
-      if (result.pushed.length > 0 || result.pruned.length > 0) {
-        note(`baselines → Vendo Cloud: ${result.pushed.length} pushed, ${result.pruned.length} pruned (component source crosses the wire so the console can review forks)`);
-      }
-      if (result.error !== undefined) {
-        noteError(`warning: pin baselines did not fully reach Vendo Cloud: ${result.error} — the rest stay in .vendo/remixable/ and the next sync retries`);
-      }
-    } else {
-      // Captures exist but this environment has no key. Keyless is a supported
-      // path (BYO), so this is a statement of fact rather than a warning — but
-      // it must be SAID: a build env that lacks the key the runtime has pushes
-      // nothing, and the console then shows a fork it cannot diff.
-      note("baselines stay local — no Vendo Cloud key in this environment; Cloud's Remix reviews screen needs a keyed sync to diff forks");
-    }
-  }
-
-  // Registered host components → Vendo Cloud. The project answers once and the
-  // answer is committed with the rest of `.vendo/`. Keyless/BYO never asks and
-  // never uploads.
-  let components: SyncFlowResult["components"] = null;
-  if (keyed && await exists(join(vendoDir, "components"))) {
-    let allowed = options.pushComponents ?? await readPushComponents(vendoDir);
-    if (allowed === undefined) {
-      allowed = options.interactive && await (options.confirm ?? askYesNo)(
-        "Send this project's registered host components to Vendo Cloud, so the console renders them instead of grey placeholders? Their source and your app-root CSS cross the wire; package code never does. Saved to .vendo/cloud.json — asked once.",
-        true,
-      );
-      if (options.interactive) await writePushComponents(vendoDir, allowed);
-      else note("components: not pushed — this run cannot ask (pass `--push-components` in CI, or run `vendo sync` once in a terminal to decide)");
-    }
-    if (allowed) {
-      const result = await pushHostComponents({
-        vendoDir,
-        apiKey: cloudKey!,
-        ...(options.apiUrl === undefined ? {} : { baseUrl: options.apiUrl }),
-        ...(options.fetchImpl === undefined ? {} : { fetchImpl: options.fetchImpl }),
-        ...(options.baselineBudgetMs === undefined ? {} : { budgetMs: options.baselineBudgetMs }),
-      });
-      components = { pushed: result.pushed, pruned: result.pruned, modules: result.modules };
-      if (result.unreadable.length > 0) {
-        noteError(`warning: unreadable component captures left untouched in Vendo Cloud: ${result.unreadable.join(", ")} — re-run sync to recapture .vendo/components/<Name>.json`);
-      }
-      if (result.pushed.length > 0 || result.pruned.length > 0 || result.modules.uploaded > 0) {
-        note(`components → Vendo Cloud: ${result.pushed.length} pushed, ${result.pruned.length} pruned, ${result.modules.uploaded} new module${result.modules.uploaded === 1 ? "" : "s"} (${Math.round(result.uploadedBytes / 1024)} KB)`);
-      }
-      if (result.error !== undefined) {
-        noteError(`warning: host components did not fully reach Vendo Cloud: ${result.error} — the rest stay in .vendo/components/ and the next sync retries`);
-      }
-    }
-  } else if (await exists(join(vendoDir, "components"))) {
-    // Same statement of fact #765 makes for baselines, for the same reason: a
-    // build env without the key its runtime has pushes nothing, and the console
-    // then draws grey placeholders with no host-side signal why.
-    note("components stay local — no Vendo Cloud key in this environment; the console needs a keyed sync to render your components instead of placeholders");
-  }
+  const baselines = await pushBaselinesToCloud({ vendoDir, cloudKey, keyed, options, notes: notes_ });
+  const components = await pushComponentsToCloud({ vendoDir, cloudKey, keyed, options, notes: notes_ });
 
   return {
     report,

--- a/packages/vendo/src/cli/sync.ts
+++ b/packages/vendo/src/cli/sync.ts
@@ -4,7 +4,7 @@ import { vendoSync, type SyncReportWithWarnings } from "@vendoai/actions/sync";
 import type { ToolImpact } from "../sync-impact.js";
 import { pushSyncReport } from "./cloud/services.js";
 import type { JudgmentPassOptions } from "./judge/pass.js";
-import { runSyncFlow } from "./sync-flow.js";
+import { runSyncFlow, type SyncFlowResult } from "./sync-flow.js";
 import { consoleOutput, invokedByPackageScript, withCommandRun, type Output, type TelemetryOptions } from "./shared.js";
 
 export interface SyncReportPayload {
@@ -101,6 +101,46 @@ export async function runSync(options: SyncOptions): Promise<number> {
   );
 }
 
+/** The `--report` push. Returns whether the run asked to report and could not
+ *  — a `--report` that never reported is a failed run (self-serve audit B6:
+ *  this used to complain and exit 0, so a CI reporting lane stayed green for
+ *  as long as it never reported). */
+async function pushReport(
+  flow: SyncFlowResult,
+  options: SyncOptions,
+  noteError: (message: string) => void,
+): Promise<boolean> {
+  // The same resolved key the baseline push uses — a `--report` that saw a
+  // different env from the reconcile beside it was a trap (#567's fix
+  // applies to every keyed leg of a sync, not just the judgment pass).
+  const apiKey = flow.cloudKey;
+  if (!apiKey) {
+    noteError("vendo sync: --report needs a Vendo Cloud key — run `vendo login`, set VENDO_API_KEY, or pass --key.");
+    return true;
+  }
+  // `impact` rides along only when the check actually ran: nothing
+  // changed means nothing could be impacted, and an empty array would
+  // read to the console as a checked, clean blast radius.
+  const report = flow.report;
+  const checked = report.breaking.length > 0 || report.tools.changed.length > 0;
+  const payload: SyncReportPayload = {
+    report,
+    ...(checked && flow.impact !== null ? { impact: flow.impact } : {}),
+    at: new Date().toISOString(),
+  };
+  try {
+    if (options.push !== undefined) await options.push(payload);
+    else await pushSyncReport(payload, {
+      apiKey,
+      ...(options.apiUrl === undefined ? {} : { apiUrl: options.apiUrl }),
+      ...(options.fetchImpl === undefined ? {} : { fetchImpl: options.fetchImpl }),
+    });
+  } catch (error) {
+    noteError(`warning: failed to push sync report: ${error instanceof Error ? error.message : "unknown error"}`);
+  }
+  return false;
+}
+
 /**
  * sync = the shared flow (sync-flow.ts) in "incremental" mode, plus the two
  * things that are the COMMAND's and not the flow's: the `--report` push and
@@ -145,39 +185,9 @@ async function sync(options: SyncOptions): Promise<number> {
     notes.push(...flow.notes);
     const report = flow.report;
 
-    let reportUnkeyed = false;
-    if (options.report === true) {
-      // The same resolved key the baseline push uses — a `--report` that saw a
-      // different env from the reconcile beside it was a trap (#567's fix
-      // applies to every keyed leg of a sync, not just the judgment pass).
-      const apiKey = flow.cloudKey;
-      if (!apiKey) {
-        // Self-serve audit B6: this used to complain and exit 0, so a CI
-        // reporting lane stayed green for as long as it never reported.
-        reportUnkeyed = true;
-        noteError("vendo sync: --report needs a Vendo Cloud key — run `vendo login`, set VENDO_API_KEY, or pass --key.");
-      } else {
-        // `impact` rides along only when the check actually ran: nothing
-        // changed means nothing could be impacted, and an empty array would
-        // read to the console as a checked, clean blast radius.
-        const checked = report.breaking.length > 0 || report.tools.changed.length > 0;
-        const payload: SyncReportPayload = {
-          report,
-          ...(checked && flow.impact !== null ? { impact: flow.impact } : {}),
-          at: new Date().toISOString(),
-        };
-        try {
-          if (options.push !== undefined) await options.push(payload);
-          else await pushSyncReport(payload, {
-            apiKey,
-            ...(options.apiUrl === undefined ? {} : { apiUrl: options.apiUrl }),
-            ...(options.fetchImpl === undefined ? {} : { fetchImpl: options.fetchImpl }),
-          });
-        } catch (error) {
-          noteError(`warning: failed to push sync report: ${error instanceof Error ? error.message : "unknown error"}`);
-        }
-      }
-    }
+    const reportUnkeyed = options.report !== true
+      ? false
+      : await pushReport(flow, options, noteError);
 
     let exitCode: SyncJsonResult["exitCode"] = report.remixableErrors.length > 0 ? 2 : 0;
     if (options.strict === true && report.breaking.length > 0) {

--- a/packages/vendo/src/cli/theme/font-stack.ts
+++ b/packages/vendo/src/cli/theme/font-stack.ts
@@ -281,11 +281,57 @@ export function layoutFontBindings(source: string): FontBinding[] {
     }
   }
 
-  // next/font/google: `import { Some_Font } from "next/font/google"` +
-  // `const someFont = Some_Font({ ..., variable: "--font-x" })` — the export
-  // name is the family (underscores become spaces). The factory callee is
-  // symbol-verified against the import; the font local must be a file-scope
-  // declaration (the universal layout shape) or nothing derives.
+  bindings.push(...googleFontBindings(mod));
+  return bindings;
+}
+
+/** The `variable:` a next/font/google factory call declares, if the options
+ *  object literal spells one. */
+function factoryVariable(mod: BoundModule, call: TS.CallExpression): string | null {
+  const { ts } = mod;
+  const options = call.arguments[0];
+  if (options === undefined || !ts.isObjectLiteralExpression(options)) return null;
+  let variable: string | null = null;
+  for (const property of options.properties) {
+    if (!ts.isPropertyAssignment(property)) continue;
+    const name = ts.isIdentifier(property.name) || ts.isStringLiteral(property.name) ? property.name.text : null;
+    if (name === "variable" && ts.isStringLiteralLike(property.initializer)) {
+      variable = property.initializer.text;
+    }
+  }
+  return variable;
+}
+
+/** The file-scope `const someFont = Some_Font({ … })` for one imported font
+ *  export. The factory callee is symbol-verified against the import, and the
+ *  font local must be a file-scope declaration (the universal layout shape) or
+ *  nothing derives. */
+function fontFactoryCall(
+  mod: BoundModule,
+  element: TS.ImportSpecifier,
+): { variable: string | null; local: string; declaration: TS.Declaration } | null {
+  const { ts, sf } = mod;
+  for (const statement of sf.statements) {
+    if (!ts.isVariableStatement(statement)) continue;
+    for (const node of statement.declarationList.declarations) {
+      if (!ts.isIdentifier(node.name)) continue;
+      const init = node.initializer;
+      if (init === undefined || !ts.isCallExpression(init)) continue;
+      if (!ts.isIdentifier(init.expression)) continue;
+      // Symbol-verified: the callee must BE this import binding.
+      if (declarationOf(mod, init.expression) !== element) continue;
+      return { variable: factoryVariable(mod, init), local: node.name.text, declaration: node };
+    }
+  }
+  return null;
+}
+
+/** next/font/google: `import { Some_Font } from "next/font/google"` +
+ *  `const someFont = Some_Font({ ..., variable: "--font-x" })` — the export
+ *  name is the family (underscores become spaces). */
+function googleFontBindings(mod: BoundModule): FontBinding[] {
+  const { ts, sf } = mod;
+  const bindings: FontBinding[] = [];
   for (const statement of sf.statements) {
     if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier)) continue;
     if (statement.moduleSpecifier.text !== "next/font/google") continue;
@@ -293,38 +339,11 @@ export function layoutFontBindings(source: string): FontBinding[] {
     if (named === undefined || !ts.isNamedImports(named)) continue;
     for (const element of named.elements) {
       const family = (element.propertyName ?? element.name).text.replace(/_/g, " ");
-      let variable: string | null = null;
-      let fontLocal: string | null = null;
-      let fontDeclaration: TS.Declaration | null = null;
-      for (const declStatement of sf.statements) {
-        if (fontLocal !== null) break;
-        if (!ts.isVariableStatement(declStatement)) continue;
-        for (const node of declStatement.declarationList.declarations) {
-          if (!ts.isIdentifier(node.name)) continue;
-          const init = node.initializer;
-          if (init === undefined || !ts.isCallExpression(init)) continue;
-          if (!ts.isIdentifier(init.expression)) continue;
-          // Symbol-verified: the callee must BE this import binding.
-          if (declarationOf(mod, init.expression) !== element) continue;
-          fontLocal = node.name.text;
-          fontDeclaration = node;
-          const options = init.arguments[0];
-          if (options !== undefined && ts.isObjectLiteralExpression(options)) {
-            for (const property of options.properties) {
-              if (!ts.isPropertyAssignment(property)) continue;
-              const name = ts.isIdentifier(property.name) || ts.isStringLiteral(property.name) ? property.name.text : null;
-              if (name === "variable" && ts.isStringLiteralLike(property.initializer)) {
-                variable = property.initializer.text;
-              }
-            }
-          }
-          break;
-        }
-      }
+      const factory = fontFactoryCall(mod, element);
       bindings.push({
-        variable,
+        variable: factory?.variable ?? null,
         family,
-        applied: fontLocal !== null && fontDeclaration !== null && appliedToJsx(mod, fontLocal, fontDeclaration),
+        applied: factory !== null && appliedToJsx(mod, factory.local, factory.declaration),
       });
     }
   }

--- a/packages/vendo/src/wire/apps.ts
+++ b/packages/vendo/src/wire/apps.ts
@@ -1,6 +1,6 @@
-import { VendoError, type AccessLevel, type Json } from "@vendoai/core";
+import { VendoError, type AccessLevel, type Json, type RunContext } from "@vendoai/core";
 import type { VendoStore } from "@vendoai/store";
-import { json, requestJson, route, string, type RouteEntry } from "./shared.js";
+import { json, requestJson, route, string, type RouteEntry, type WireContext } from "./shared.js";
 
 /** Build contract §9.3 — the level vocabulary is CLOSED, so the wire refuses
     anything outside it instead of letting a typo reach the store. */
@@ -69,6 +69,167 @@ function decodeSlot(slot: string): string {
     return slot;
   }
 }
+
+/** Existing-agents polish — the embed's build-window poll. The app record
+    lands only at build completion, so until then open() (and the meta
+    route alike) answers not-found, and every 1.2s poll logged a browser
+    console 404. Under the additive ?pending=1 flag, ONLY that expected
+    pre-servable miss becomes a quiet 200 {kind:"pending"}; unflagged
+    callers keep the contracted 404, and every other failure keeps its
+    envelope and status either way. A record that DOES exist — just not
+    for this caller — is not a build in progress and never will be: that
+    answers the terminal failed vocabulary (with the principal-mismatch
+    diagnosis) so the embed resolves promptly instead of skeleton-polling
+    to its deadline (0.4.1 E2E cert B4). */
+async function openWithPendingWindow(wire: WireContext, appId: string, ctx: RunContext): Promise<Response> {
+  const { deps } = wire;
+  try {
+    return json(await deps.apps.open(appId, ctx));
+  } catch (reason) {
+    if (!(reason instanceof VendoError && reason.code === "not-found")) throw reason;
+    // Build contract §9.4 — the probe is a DIAGNOSTIC for a caller who
+    // can already see the app, never a lookup for one who cannot. It
+    // reads UNSCOPED rows, so running it for a non-viewer made
+    // `?pending=1` an existence oracle: any stranger with an app id
+    // learned whether a team app was real, at HTTP 200, while the same
+    // request without the flag correctly 404'd. A non-viewer now gets
+    // exactly what a non-existent app gets.
+    const probe = await probeUnownedAppRecord(deps.store, appId);
+    if (await deps.apps.access.levelFor(appId, ctx) === null) {
+      // The principal-mismatch diagnosis (0.4.1 E2E cert B4) is a HOST
+      // wiring problem in a developer's voice, so it keeps its signal
+      // where only the host reads it — the server log — instead of
+      // being served to whoever asked.
+      if (probe.exists) {
+        console.warn(
+          `[vendo] GET /apps/${appId}/open answered not-found, but a record with that id `
+          + "exists under another subject: this wire route's principal must resolve the same "
+          + "subject your agent loop uses (see docs.vendo.run/existing-agents)",
+        );
+      }
+      return json({ kind: "pending" });
+    }
+    // A terminal build failure is terminal for EVERY caller: pass the
+    // server-written reason through instead of masking it as a build
+    // still in progress (0.4.6 cert defect D2).
+    if (probe.buildFailed !== undefined) {
+      return json({
+        kind: "failed",
+        reason: probe.buildFailed.reason,
+        ...(probe.buildFailed.retryable === undefined ? {} : { retryable: probe.buildFailed.retryable }),
+      });
+    }
+    // This caller CAN see the app (checked above) and it carries no
+    // terminal marker, so "still building" is the honest answer. The
+    // principal-mismatch diagnosis that used to live here belongs to the
+    // non-viewer branch, where it is now logged for the host instead of
+    // served to the caller.
+    return json({ kind: "pending" });
+  }
+}
+
+async function handleHistory(wire: WireContext, appId: string, ctx: RunContext): Promise<Response | undefined> {
+  const { request, deps } = wire;
+  // The door still masks an app this caller cannot see at all, so a
+  // not-found answer never depends on which verb they asked for.
+  if (await deps.apps.get(appId, ctx) === null) throw new VendoError("not-found", `app not found: ${appId}`);
+  if (request.method === "GET") return json(await deps.apps.history(appId, ctx).list());
+  if (request.method === "POST") {
+    const body = await requestJson(request);
+    if (body["op"] !== "undo") throw new VendoError("validation", "history op must be undo");
+    return json(await deps.apps.history(appId, ctx).undo());
+  }
+  return undefined;
+}
+
+/** Owner-gated on purpose: whoever may ask this may enumerate the host's own
+    directory, so the gate is the same one that writes the grant. A caller who
+    cannot see the app at all stays masked (§9.4). */
+async function resolvePersonForShare(wire: WireContext, appId: string, ctx: RunContext): Promise<Response> {
+  const { request, deps } = wire;
+  const level = await deps.apps.access.levelFor(appId, ctx);
+  if (level === null) throw new VendoError("not-found", `app not found: ${appId}`);
+  if (level !== "owner") throw new VendoError("forbidden", `owner access is required for ${appId}`);
+  // ...and an owner with NO asserted org, on top of that. A person-share
+  // implies an org workspace (§9.5), so a caller in no org can never complete
+  // the share this lookup exists for — answering them is nothing but
+  // directory exposure. A signed-in stranger probing from their own personal
+  // app was handed the host's real subjects and display names at HTTP 200.
+  if ((ctx.memberships ?? []).length === 0) {
+    throw new VendoError(
+      "forbidden",
+      `no org is asserted for this caller, so a person-share on ${appId} could never be completed`,
+    );
+  }
+  if (deps.resolvePerson === undefined) {
+    throw new VendoError(
+      "not-implemented",
+      "sharing with one person needs the auth preset's `resolvePerson` seam:"
+      + " Vendo has no directory, so only your identity system can turn a typed"
+      + " name into one of your subjects",
+    );
+  }
+  const body = await requestJson(request);
+  // The asker rides along: only the host knows which part of its own
+  // directory this person may see.
+  return json({ person: await deps.resolvePerson(string(body["query"], "query"), ctx.principal) });
+}
+
+async function handleGrants(wire: WireContext, appId: string, ctx: RunContext): Promise<Response | undefined> {
+  const { request, deps } = wire;
+  if (request.method === "GET") {
+    return json({
+      level: await deps.apps.access.levelFor(appId, ctx),
+      grants: await deps.apps.access.list(appId, ctx),
+      // §9.5 — "share implies promote" needs to know whether this is still
+      // the caller's own copy. Derived from who HOLDS the row, so the
+      // dialog never has to guess from an empty grant list.
+      personal: await deps.apps.access.holder(appId, ctx) === ctx.principal.subject,
+    });
+  }
+  if (request.method === "POST") {
+    const body = await requestJson(request);
+    await deps.apps.access.grant(
+      appId,
+      string(body["principal"], "principal"),
+      accessLevel(body["level"]),
+      ctx,
+    );
+    return json({ grants: await deps.apps.access.list(appId, ctx) });
+  }
+  if (request.method === "DELETE") {
+    const principal = wire.url.searchParams.get("principal");
+    await deps.apps.access.revoke(appId, string(principal, "principal"), ctx);
+    // The revoke LANDED. Reading the list back is a courtesy for the dialog,
+    // and a caller who just removed their OWN last grant may no longer read
+    // it — that is §9.4's masking answering a different question, not a
+    // failed removal, and reporting it as one told them to retry work that
+    // was already done. Answer with what they can still legitimately see:
+    // nothing.
+    //
+    // Only `can()` may be forgiven here, and `can()` always refuses with a
+    // VendoError — so the TYPE is half the test. A hosted store carries a
+    // misbehaving console's failure on a plain Error with the server's code
+    // attached (hosted-store.ts), and "the console said not-found" is not
+    // "the caller may no longer look": that, and every other failure,
+    // surfaces.
+    const remaining = await deps.apps.access.list(appId, ctx).catch((reason: unknown) => {
+      const masked = reason instanceof VendoError
+        && (reason.code === "not-found" || reason.code === "forbidden");
+      if (masked) return [];
+      throw reason;
+    });
+    return json({ grants: remaining });
+  }
+  return undefined;
+}
+
+/** Every operation arm in the table below asks the same three-part question:
+    this method, this operation segment, exactly this many segments. Naming it
+    once keeps an arm's SHAPE the thing you read, instead of thirteen
+    repetitions of the triple. */
+const op = (wire: WireContext, method: string, operation: string, length = 3): boolean =>
+  wire.request.method === method && wire.segments[2] === operation && wire.segments.length === length;
 
 /** 06-apps / 09 §3 — the /apps wire area: CRUD, open/call/edit, history,
     ship-diff, pin drift/rebase, the gesture fork (fork-pin), export/import,
@@ -177,72 +338,15 @@ export const appRoutes: RouteEntry[] = [
         return json({});
       }
     }
-    if (request.method === "GET" && operation === "open" && segments.length === 3) {
-      // Existing-agents polish — the embed's build-window poll. The app record
-      // lands only at build completion, so until then open() (and the meta
-      // route alike) answers not-found, and every 1.2s poll logged a browser
-      // console 404. Under the additive ?pending=1 flag, ONLY that expected
-      // pre-servable miss becomes a quiet 200 {kind:"pending"}; unflagged
-      // callers keep the contracted 404, and every other failure keeps its
-      // envelope and status either way. A record that DOES exist — just not
-      // for this caller — is not a build in progress and never will be: that
-      // answers the terminal failed vocabulary (with the principal-mismatch
-      // diagnosis) so the embed resolves promptly instead of skeleton-polling
-      // to its deadline (0.4.1 E2E cert B4).
-      if (wire.url.searchParams.get("pending") === "1") {
-        try {
-          return json(await deps.apps.open(appId, ctx));
-        } catch (reason) {
-          if (reason instanceof VendoError && reason.code === "not-found") {
-            // Build contract §9.4 — the probe is a DIAGNOSTIC for a caller who
-            // can already see the app, never a lookup for one who cannot. It
-            // reads UNSCOPED rows, so running it for a non-viewer made
-            // `?pending=1` an existence oracle: any stranger with an app id
-            // learned whether a team app was real, at HTTP 200, while the same
-            // request without the flag correctly 404'd. A non-viewer now gets
-            // exactly what a non-existent app gets.
-            const probe = await probeUnownedAppRecord(deps.store, appId);
-            if (await deps.apps.access.levelFor(appId, ctx) === null) {
-              // The principal-mismatch diagnosis (0.4.1 E2E cert B4) is a HOST
-              // wiring problem in a developer's voice, so it keeps its signal
-              // where only the host reads it — the server log — instead of
-              // being served to whoever asked.
-              if (probe.exists) {
-                console.warn(
-                  `[vendo] GET /apps/${appId}/open answered not-found, but a record with that id `
-                  + "exists under another subject: this wire route's principal must resolve the same "
-                  + "subject your agent loop uses (see docs.vendo.run/existing-agents)",
-                );
-              }
-              return json({ kind: "pending" });
-            }
-            // A terminal build failure is terminal for EVERY caller: pass the
-            // server-written reason through instead of masking it as a build
-            // still in progress (0.4.6 cert defect D2).
-            if (probe.buildFailed !== undefined) {
-              return json({
-                kind: "failed",
-                reason: probe.buildFailed.reason,
-                ...(probe.buildFailed.retryable === undefined ? {} : { retryable: probe.buildFailed.retryable }),
-              });
-            }
-            // This caller CAN see the app (checked above) and it carries no
-            // terminal marker, so "still building" is the honest answer. The
-            // principal-mismatch diagnosis that used to live here belongs to the
-            // non-viewer branch, where it is now logged for the host instead of
-            // served to the caller.
-            return json({ kind: "pending" });
-          }
-          throw reason;
-        }
-      }
+    if (op(wire, "GET", "open")) {
+      if (wire.url.searchParams.get("pending") === "1") return openWithPendingWindow(wire, appId, ctx);
       return json(await deps.apps.open(appId, ctx));
     }
-    if (request.method === "POST" && operation === "call" && segments.length === 3) {
+    if (op(wire, "POST", "call")) {
       const body = await requestJson(request);
       return json(await deps.apps.call(appId, string(body["ref"], "ref"), body["args"] as Json, ctx));
     }
-    if (request.method === "POST" && operation === "edit" && segments.length === 3) {
+    if (op(wire, "POST", "edit")) {
       const body = await requestJson(request);
       return json(await deps.apps.edit(appId, string(body["instruction"], "instruction"), ctx));
     }
@@ -252,21 +356,14 @@ export const appRoutes: RouteEntry[] = [
     // caller; it is no longer the only thing standing between a viewer and the
     // team's history.
     if (operation === "history" && segments.length === 3) {
-      // The door still masks an app this caller cannot see at all, so a
-      // not-found answer never depends on which verb they asked for.
-      if (await deps.apps.get(appId, ctx) === null) throw new VendoError("not-found", `app not found: ${appId}`);
-      if (request.method === "GET") return json(await deps.apps.history(appId, ctx).list());
-      if (request.method === "POST") {
-        const body = await requestJson(request);
-        if (body["op"] !== "undo") throw new VendoError("validation", "history op must be undo");
-        return json(await deps.apps.history(appId, ctx).undo());
-      }
+      const answer = await handleHistory(wire, appId, ctx);
+      if (answer !== undefined) return answer;
     }
     // 06-apps §8–§9 — additive: the reviewable diff of what this app ships
     // relative to the captured host baselines, hash-pinned to the version
     // an in-client approval would cover. Viewer-scoped: reading what a shared
     // app ships is part of seeing it (the runtime owns the level, as ever).
-    if (request.method === "GET" && operation === "ship-diff" && segments.length === 3) {
+    if (op(wire, "GET", "ship-diff")) {
       return json(await deps.apps.inClient.shipDiff(appId, ctx));
     }
     // 06-apps §8 — additive drift→rebase surface. `drift` only reads, so it is
@@ -274,16 +371,16 @@ export const appRoutes: RouteEntry[] = [
     // runtime owns both levels. A rebase is only ever invoked
     // explicitly here or via the vendo_apps_rebase_pin agent tool — drift
     // detection never auto-rebases.
-    if (request.method === "GET" && operation === "pin-drift" && segments.length === 3) {
+    if (op(wire, "GET", "pin-drift")) {
       return json(await deps.apps.pins.drift(appId, ctx));
     }
-    if (request.method === "POST" && operation === "rebase-pin" && segments.length === 3) {
+    if (op(wire, "POST", "rebase-pin")) {
       const body = await requestJson(request);
       return json(await deps.apps.pins.rebase({ appId, slot: string(body["slot"], "slot") }, ctx));
     }
     // 06-apps §8 — the same gesture fork landing in an EXISTING app (the
     // filled-slot / driver surface). Editor-scoped: it lands a change.
-    if (request.method === "POST" && operation === "fork-pin" && segments.length === 3) {
+    if (op(wire, "POST", "fork-pin")) {
       const body = await requestJson(request);
       return json(await deps.apps.pins.fork({
         appId,
@@ -294,11 +391,11 @@ export const appRoutes: RouteEntry[] = [
     // Placement (2026-08-05) — one app per slot. The level lives in the
     // runtime (viewer: putting an app you can see into your own slot), and
     // `evicted` names whatever held the slot before.
-    if (request.method === "POST" && operation === "place" && segments.length === 3) {
+    if (op(wire, "POST", "place")) {
       const body = await requestJson(request);
       return json(await deps.apps.place({ app: appId, slot: string(body["slot"], "slot") }, ctx));
     }
-    if (request.method === "POST" && operation === "unplace" && segments.length === 3) {
+    if (op(wire, "POST", "unplace")) {
       const body = await requestJson(request);
       await deps.apps.unplace({ app: appId, slot: string(body["slot"], "slot") }, ctx);
       return json({});
@@ -312,7 +409,7 @@ export const appRoutes: RouteEntry[] = [
     // enforced by the runtime: without apps.review.reviewer the reject
     // refuses, naming the hook) instead of owner scoping; any other caller
     // gets the same not-found an unowned app answers (masked).
-    if (request.method === "POST" && operation === "reject-review" && segments.length === 3) {
+    if (op(wire, "POST", "reject-review")) {
       if (!deps.development || ctx.principal.ephemeral === true) {
         throw new VendoError("not-found", `app not found: ${appId}`);
       }
@@ -322,10 +419,10 @@ export const appRoutes: RouteEntry[] = [
     // Wave 7 H2 — the embed surface's keepalive: user activity on an embedded
     // served app rides one host-proxied HEAD through the machine (re-arming
     // the idle timer); "woke" tells the embed its URL is stale — re-open.
-    if (request.method === "POST" && operation === "machine" && segments[3] === "ping" && segments.length === 4) {
+    if (op(wire, "POST", "machine", 4) && segments[3] === "ping") {
       return json(await deps.apps.machine.ping(appId, ctx));
     }
-    if (request.method === "GET" && operation === "export" && segments.length === 3) {
+    if (op(wire, "GET", "export")) {
       const bytes = await deps.apps.exportApp(appId, ctx);
       return new Response(bytes as BodyInit, {
         headers: {
@@ -334,7 +431,7 @@ export const appRoutes: RouteEntry[] = [
         },
       });
     }
-    if (request.method === "POST" && operation === "fork" && segments.length === 3) {
+    if (op(wire, "POST", "fork")) {
       return json(await deps.apps.fork(appId, ctx));
     }
     // Build contract §9.1 companion — the host names the person. Vendo holds no
@@ -344,85 +441,18 @@ export const appRoutes: RouteEntry[] = [
     // Owner-gated on purpose: whoever may ask this may enumerate the host's own
     // directory, so the gate is the same one that writes the grant. A caller who
     // cannot see the app at all stays masked (§9.4).
-    if (request.method === "POST" && operation === "grants" && segments[3] === "resolve" && segments.length === 4) {
-      const level = await deps.apps.access.levelFor(appId, ctx);
-      if (level === null) throw new VendoError("not-found", `app not found: ${appId}`);
-      if (level !== "owner") throw new VendoError("forbidden", `owner access is required for ${appId}`);
-      // ...and an owner with NO asserted org, on top of that. A person-share
-      // implies an org workspace (§9.5), so a caller in no org can never complete
-      // the share this lookup exists for — answering them is nothing but
-      // directory exposure. A signed-in stranger probing from their own personal
-      // app was handed the host's real subjects and display names at HTTP 200.
-      if ((ctx.memberships ?? []).length === 0) {
-        throw new VendoError(
-          "forbidden",
-          `no org is asserted for this caller, so a person-share on ${appId} could never be completed`,
-        );
-      }
-      if (deps.resolvePerson === undefined) {
-        throw new VendoError(
-          "not-implemented",
-          "sharing with one person needs the auth preset's `resolvePerson` seam:"
-          + " Vendo has no directory, so only your identity system can turn a typed"
-          + " name into one of your subjects",
-        );
-      }
-      const body = await requestJson(request);
-      // The asker rides along: only the host knows which part of its own
-      // directory this person may see.
-      return json({ person: await deps.resolvePerson(string(body["query"], "query"), ctx.principal) });
+    if (op(wire, "POST", "grants", 4) && segments[3] === "resolve") {
+      return resolvePersonForShare(wire, appId, ctx);
     }
     // Build contract §9.2–§9.6 — the Share dialog's door. Reading the grant
     // list is viewer-gated and OSS; writing one is owner-gated AND
     // Cloud-gated, and the runtime (not this route) is where both are decided,
     // so the MCP door inherits the same rules without a second copy.
     if (operation === "grants" && segments.length === 3) {
-      if (request.method === "GET") {
-        return json({
-          level: await deps.apps.access.levelFor(appId, ctx),
-          grants: await deps.apps.access.list(appId, ctx),
-          // §9.5 — "share implies promote" needs to know whether this is still
-          // the caller's own copy. Derived from who HOLDS the row, so the
-          // dialog never has to guess from an empty grant list.
-          personal: await deps.apps.access.holder(appId, ctx) === ctx.principal.subject,
-        });
-      }
-      if (request.method === "POST") {
-        const body = await requestJson(request);
-        await deps.apps.access.grant(
-          appId,
-          string(body["principal"], "principal"),
-          accessLevel(body["level"]),
-          ctx,
-        );
-        return json({ grants: await deps.apps.access.list(appId, ctx) });
-      }
-      if (request.method === "DELETE") {
-        const principal = wire.url.searchParams.get("principal");
-        await deps.apps.access.revoke(appId, string(principal, "principal"), ctx);
-        // The revoke LANDED. Reading the list back is a courtesy for the dialog,
-        // and a caller who just removed their OWN last grant may no longer read
-        // it — that is §9.4's masking answering a different question, not a
-        // failed removal, and reporting it as one told them to retry work that
-        // was already done. Answer with what they can still legitimately see:
-        // nothing.
-        //
-        // Only `can()` may be forgiven here, and `can()` always refuses with a
-        // VendoError — so the TYPE is half the test. A hosted store carries a
-        // misbehaving console's failure on a plain Error with the server's code
-        // attached (hosted-store.ts), and "the console said not-found" is not
-        // "the caller may no longer look": that, and every other failure,
-        // surfaces.
-        const remaining = await deps.apps.access.list(appId, ctx).catch((reason: unknown) => {
-          const masked = reason instanceof VendoError
-            && (reason.code === "not-found" || reason.code === "forbidden");
-          if (masked) return [];
-          throw reason;
-        });
-        return json({ grants: remaining });
-      }
+      const answer = await handleGrants(wire, appId, ctx);
+      if (answer !== undefined) return answer;
     }
-    if (request.method === "POST" && operation === "promote" && segments.length === 3) {
+    if (op(wire, "POST", "promote")) {
       const body = await requestJson(request);
       return json(await deps.apps.promote(appId, string(body["orgId"], "orgId"), ctx));
     }


### PR DESCRIPTION
## What this is

Step 2 of the lint plan, `packages/vendo` slice: the cognitive-complexity
monsters at the chosen threshold of **50**, decomposed. Nine of this package's
ten findings are fixed; the tenth is deferred with a reason below.

**Pure refactor.** No bug fixes, no renames beyond what a move requires, no
tidying. Behaviour, printed text, check order and exit codes are unchanged.

**No lint config is touched here** — the rules flip to blocking in their own PR.

## The nine

| function | file | before | after |
|---|---|--:|--:|
| `runDoctor` | `cli/doctor.ts` | **301** | <50 |
| `runJudgmentPass` | `cli/judge/pass.ts` | 178 | <50 |
| `runInit` | `cli/init.ts` | 142 | <50 |
| `runSyncFlow` | `cli/sync-flow.ts` | 110 | <50 |
| `/apps/:appId/*` handler | `wire/apps.ts` | 101 | <50 |
| `main` | `cli.ts` | 89 | <50 |
| `layoutFontBindings` | `cli/theme/font-stack.ts` | 83 | <50 |
| `buildPlan` | `cli/init.ts` | 67 | <50 |
| `sync` | `cli/sync.ts` | 64 | <50 |

`packages/vendo` now reports **one** function over 50, and it is the deferral
below. 301 was the worst function in the repository.

Every split follows the seams the code already named. `runDoctor`'s section
comments became the modules; `runJudgmentPass`'s `// ---- JUDGE ----` banners
became the stage functions they were describing; `runInit`'s labelled steps
became the steps. The one thing that is genuinely better rather than merely
smaller: the ORDER doctor reports its checks in is the whole user-visible
contract of that command, and it now reads top-to-bottom in a 40-line
`runDoctor` instead of being spread over 750 lines.

## One deferral

`hosted-store.test-util.ts` `fakeConsole` (**92**) is **not** touched. It is an
in-memory fake of the console's `/api/v1/store` HTTP surface, consumed by six
test suites, and `packages/vendo`'s tsconfig excludes `*.test-util.ts`
outright — only vitest ever compiles it. Refactoring it means changing a test
file, which destroys the very thing that makes a refactor provable: there
would be no untouched suite left to check it against. It belongs with the
test-estate consolidation that is reworking this package's test machinery
anyway.

## Evidence

- **Test files changed: 0.** Not one, not even an import path.
- **Export surface: byte-identical.** Every one of the eight pre-existing files
  has the same `^export` lines as `origin/main`. The seven new `doctor-*.ts`
  modules are package-internal — not in the `exports` map, not re-exported.
- **Pure movement: 80.1%** of removed lines reappear verbatim in the new code
  (1,619 / 2,022; whitespace-insensitive, receiver-normalised).

  Stating this plainly because it is below the 93–97% the three big splits
  scored, and the reason is specific rather than hand-wavy: those splits moved
  method bodies into a context that already had the same names in scope.
  `runDoctor` had four bare closures (`pass`/`fail`/`warn`/`note`), so moving
  them onto a shared `DoctorRun` gave ~200 call sites a `run.` receiver. That,
  plus seven new module headers and the interfaces the stage results needed, is
  the entire difference. No logic was rewritten.
- **Moved symbols grepped repo-wide including test dirs** (`packages/`,
  `examples/`, `fixtures/`, `corpus/`, `docs/`): every symbol that moved was
  module-private before the move, and nothing outside its new home names it.
  This matters because `packages/vendo`'s `typecheck` script excludes
  `*.test.ts`, `*.test.tsx` and `*.test-util.ts` — tsc would never have caught
  a broken test import.

## Tandem: `vendo-web` is a no-op

Confirmed by grep, not assumed. Zero hits in `vendo-web` for `runDoctor`,
`runJudgmentPass`, `runSyncFlow`, `runInit`, `appRoutes`, `layoutFontBindings`,
`createDoctorRun`, `DoctorRun` or `buildPlan`. It consumes `@vendoai/vendo` as a
packed tarball (`file:./vendor/vendoai-vendo-0.5.0.tgz`) whose public surface
is unchanged, and none of this crosses a `.vendo/` seam.

## Follow-up spotted, deliberately not done here

`planCustomComposition` and `planExpressComposition` in `cli/init.ts` are
near-identical apart from the source generator they call and their comments.
Collapsing them is worth its own change; riding it on a pure move would make
this diff unreviewable. Noted in the commit message too.

## Changeset

One `patch` for `@vendoai/vendo`. **No public surface changed** — every
exported name, signature and module path is identical.

## Gate

Foreground, one at a time, output redirected then read.

```
pnpm build --filter=@vendoai/vendo...   → exit 0   Tasks: 13 successful, 13 total

packages/vendo full vitest suite        → Test Files  2 failed | 197 passed | 9 skipped (208)
                                          Tests       2 failed | 2204 passed | 37 skipped (2243)

pnpm typecheck                          → exit 0   Tasks: 42 successful, 42 total
pnpm lint                               → exit 0   Tasks: 3 successful, 3 total
                                          (2 pre-existing demo-bank warnings, unchanged)
```

### The two failures are the machine, and here is the proof

```
× demo-host journey through the store seam …            30042ms
× ONE files adapter (build contract §3.4) …             31038ms

Error: Test timed out in 30000ms.
```

Both are `testTimeout: 30_000` expiring — the hang-detector, not an assertion.
The box was running up to ten vitest processes from three sibling refactor
slices while this suite ran. Re-run alone on the same worktree, same commit:

```
$ npx vitest run src/harness-wire.test.ts src/hosted-store.test.ts
  Test Files  2 passed (2)
  Tests       68 passed (68)                             → exit 0
```

`hosted-store.test.ts` imports nothing this PR touches. `harness-wire.test.ts`
does reach `wire/apps.ts` through `server.ts`, which is why it got the re-run
rather than an assumption. Per CLAUDE.md: a timeout is a hang-detector, and the
answer to a busy machine is not a bigger number.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the CLI’s longest functions in `packages/vendo` into small, named steps to cut cognitive complexity under 50 across the board. Behavior, output text, command order, and public exports stay the same.

- **Refactors**
  - `runDoctor` → per-section check modules; top-to-bottom itinerary; 301→<50.
  - `runJudgmentPass` → explicit stage pipeline; 178→<50.
  - `runInit`/`buildPlan` and `runSyncFlow` → labeled steps/stages; each <50.
  - `wire/apps.ts` router, `cli.ts` command handlers, `layoutFontBindings`, and `sync --report` push extracted to helpers; each <50.
  - No test files changed; new modules are internal; changeset: patch for `@vendoai/vendo`.
  - One deferral: test-only `hosted-store.test-util.ts` `fakeConsole` (92) left as-is, to handle with test consolidation.

<sup>Written for commit 3672140c826ed2d85ff82961a563d4f1c0db0747. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

