### PR TITLE
fix(corpus): the install-eval transcript is on disk before anything reads it

### DIFF
--- a/corpus/harness/src/install-eval/agent.ts
+++ b/corpus/harness/src/install-eval/agent.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { createWriteStream } from "node:fs";
+import { createWriteStream, type WriteStream } from "node:fs";
 import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import { detectsKeyQuestion } from "./score.js";
@@ -105,6 +105,17 @@ function killProcessGroup(child: ReturnType<typeof spawn>, signal: NodeJS.Signal
   }
 }
 
+/** `end()` only QUEUES the flush; the callback fires once the bytes are on
+ * disk (or the write failed). */
+function endStream(stream: WriteStream): Promise<void> {
+  return new Promise((resolve, reject) => {
+    stream.end((error?: Error | null) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
 interface InvokeClaudeOnceOptions {
   claudeBin: string;
   args: string[];
@@ -129,39 +140,40 @@ async function invokeClaudeOnce(options: InvokeClaudeOnceOptions): Promise<Invok
   const transcript = createWriteStream(options.transcriptPath, { flags });
   // stderr goes to its own log so the transcript stays pure JSONL.
   const stderrLog = createWriteStream(`${options.transcriptPath}.stderr.log`, { flags });
+  let timer: NodeJS.Timeout | undefined;
 
-  return new Promise<InvokeClaudeOnceResult>((resolve, reject) => {
-    const child = spawn(options.claudeBin, options.args, {
-      cwd: options.cwd,
-      env: options.env,
-      stdio: ["ignore", "pipe", "pipe"],
-      detached: true,
-    });
-    let timedOut = false;
-    const timer = setTimeout(() => {
-      timedOut = true;
-      killProcessGroup(child, "SIGTERM");
-      setTimeout(() => { killProcessGroup(child, "SIGKILL"); }, 10_000).unref();
-    }, options.timeBudgetMs);
-    const finish = (): void => {
-      clearTimeout(timer);
-      transcript.end();
-      stderrLog.end();
-    };
+  try {
+    return await new Promise<InvokeClaudeOnceResult>((resolve, reject) => {
+      const child = spawn(options.claudeBin, options.args, {
+        cwd: options.cwd,
+        env: options.env,
+        stdio: ["ignore", "pipe", "pipe"],
+        detached: true,
+      });
+      let timedOut = false;
+      timer = setTimeout(() => {
+        timedOut = true;
+        killProcessGroup(child, "SIGTERM");
+        setTimeout(() => { killProcessGroup(child, "SIGKILL"); }, 10_000).unref();
+      }, options.timeBudgetMs);
 
-    child.stdout.pipe(transcript, { end: false });
-    child.stderr.pipe(stderrLog, { end: false });
-    child.on("error", (error) => {
-      finish();
-      reject(error);
+      child.stdout.pipe(transcript, { end: false });
+      child.stderr.pipe(stderrLog, { end: false });
+      child.on("error", reject);
+      child.on("close", (code) => {
+        // The agent is done; sweep any process-group stragglers regardless.
+        killProcessGroup(child, "SIGKILL");
+        resolve({ code, timedOut, command: `${options.claudeBin} ${options.args.map((arg) => (arg.includes(" ") ? JSON.stringify(arg) : arg)).join(" ")}` });
+      });
     });
-    child.on("close", (code) => {
-      finish();
-      // The agent is done; sweep any process-group stragglers regardless.
-      killProcessGroup(child, "SIGKILL");
-      resolve({ code, timedOut, command: `${options.claudeBin} ${options.args.map((arg) => (arg.includes(" ") ? JSON.stringify(arg) : arg)).join(" ")}` });
-    });
-  });
+  } finally {
+    clearTimeout(timer);
+    // Returning on "close" alone let the caller readFile() a transcript whose
+    // last bytes were still queued — or, since a WriteStream opens its fd
+    // lazily, a file that did not exist yet. Both logs hit disk before we
+    // return, on the error path too.
+    await Promise.all([endStream(transcript), endStream(stderrLog)]);
+  }
 }
 
 export async function runInstallAgent(options: RunInstallAgentOptions): Promise<InstallAgentResult> {


### PR DESCRIPTION
## What

`corpus/harness/src/install-eval/agent.ts` — `invokeClaudeOnce` resolved inside
`child.on("close")` immediately after calling `transcript.end()`. It now returns
only once both the transcript and the stderr log have finished writing.

## Why — this is a real flake that has been costing CI reruns

`stream.end()` only *queues* the flush, and `fs.createWriteStream` opens its fd
lazily. `runInstallAgent` `readFile`s the transcript on the very next line after
`invokeClaudeOnce` returns, so that read could land before the bytes — or before
the file existed at all. When it read short, `finalAssistantText()` returned
`null`, the mandated Cloud-vs-BYO key question went undetected, the scripted
continuation never fired, and the run reported `scriptedReplies: 0`.

The visible symptom is `src/install-eval/agent.test.ts` — *"runInstallAgent
scripted-human continuation > caps at ONE scripted reply"* failing with
`expected +0 to be 1`. It is not a timeout; load makes it worse, and it has
almost certainly been eating CI reruns for a while. It is the flake that took
#1016's CI red.

## Evidence: repro counts, not a deterministic test

**I did not add a test, and I want to be plain about why: this race cannot be
made deterministic from userland.** I tried three ways and reported each:

1. **Large payload** (20k lines / ~8 MB through the pipe, so the WriteStream
   would still be draining at `close`) — 0 bad reads in 60 iterations. The
   fs writes always won.
2. **Saturating libuv's threadpool** (16 queued `pbkdf2` jobs so the lazy
   `open` would queue behind them) — 0 bad reads in 20 iterations. It actually
   *hides* the bug: a saturated pool serialises open → write → read in FIFO
   submission order, which is the correct order.
3. Which is the tell: this is a genuine **two-thread** race. With free threads,
   the `readFile` gets its own thread and can beat the still-pending `open`.
   Forcing that loss deterministically would mean mocking `fs` — i.e. mocking
   the thing under test.

So the evidence is a loop over the **real** `runInstallAgent` with the suite's
own fake-claude script, counting how often the test at
`agent.test.ts:135` would fail:

| | iterations | `scriptedReplies: 0` | threw `ENOENT` | total failures |
|---|---|---|---|---|
| **before** | 400 | 1 | 3 | **4** |
| **after** | 400 | 0 | 0 | **0** |

A narrower probe of just the stream shape (no product code) on an otherwise idle
box: **5 bad reads / 1200 before, 0 / 1200 after** — all five `ENOENT`, i.e. the
transcript file did not exist yet when the caller read it.

## Shape of the fix

`boot.ts:258` already does this correctly — it awaits `writer.end(callback)`.
This change reuses that idiom rather than importing anything new, wrapping the
spawn promise in `try`/`finally` so both logs flush on the error path too. Net
effect on `invokeClaudeOnce` is a small simplification: the hand-rolled `finish`
closure and the duplicated `clearTimeout` are gone, and `child.on("error")` is
now just `reject`.

## Evidence

- `corpus/harness` full suite: **38 passed | 1 skipped (39 files), 347 passed**
- `corpus/harness` `tsc -p tsconfig.json --noEmit`: clean. Its `include` is
  `src/**/*`, so test files **are** typechecked — no excluded-tests gap here.
- `pnpm build --filter=@vendoai/corpus-harness...`: 13/13 successful
- root `pnpm lint` (dependency-guard + portability-gate + turbo lint): 0 errors

## Changeset

**None.** `@vendoai/corpus-harness` is `"private": true` — nothing published
changes.

## vendo-web

**No-op, justified.** `corpus/` is a repo-local eval harness with no consumer
outside this repo. Grepping `vendo-web` for `createWriteStream`,
`invokeClaudeOnce`, and `install-eval` returns hits only under `node_modules`
(`@types/node`, `undici`) — zero source references. Nothing to adapt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race where `runInstallAgent` read the install-eval transcript before it was written, causing occasional ENOENT/empty reads and CI flakes. We now wait for both the transcript and stderr log to finish writing before `invokeClaudeOnce` returns.

- **Bug Fixes**
  - Add `endStream` helper and await `end(cb)` for transcript and stderr logs.
  - Wrap spawn in `try/finally` to always flush logs and clear the timeout.
  - Simplify error handling (`child.on("error", reject)`) and remove duplicated cleanup.

<sup>Written for commit 9c8f234782a02f863753ca4c0ef164c51cb92513. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

