### PR TITLE
refactor(ui): six surfaces nothing could reach, and the thread surface stops ejecting an internal changelog

### DIFF
--- a/.changeset/warm-pianos-listen.md
+++ b/.changeset/warm-pianos-listen.md
@@ -1,0 +1,10 @@
+---
+"@vendoai/ui": minor
+---
+
+Remove five options and one recorder that nothing in the repo could reach: the
+director stream recorder in `useVendoThread` (its two globals were never set by
+anything), `subscribeConversationCommands`, `MorphToast`'s `dockTo` and
+`holdMs` props, `VendoSlot`'s `emptyState.mark` and `emptyState.layout` props,
+and `isConsumerSafe`. The thread surface's comments no longer ship internal
+ticket, lane and ruling labels into ejected customer code.

--- a/packages/ui/src/chrome/morph-toast.tsx
+++ b/packages/ui/src/chrome/morph-toast.tsx
@@ -25,10 +25,6 @@ export interface MorphToastProps {
   sub?: string;
   logoUrl?: string;
   theme: VendoTheme;
-  holdMs?: number;
-  /** Override the dock target lookup (default: the `data-vendo-activity-anchor`
-      element). Return undefined to fade in place. */
-  dockTo?(): { top: number; left: number; width: number; height: number } | undefined;
   onDone(): void;
 }
 
@@ -52,14 +48,12 @@ function activityAnchorRect(): { top: number; left: number; width: number; heigh
   return rect.width > 0 ? { top: rect.top, left: rect.left, width: rect.width, height: rect.height } : undefined;
 }
 
-export function MorphToast({ startRect, title, sub, logoUrl, theme, holdMs, dockTo, onDone }: MorphToastProps) {
+export function MorphToast({ startRect, title, sub, logoUrl, theme, onDone }: MorphToastProps) {
   const [settled, setSettled] = useState(false);
   const [leaving, setLeaving] = useState(false);
   const [dock, setDock] = useState<{ x: number; y: number } | null>(null);
   const doneRef = useRef(onDone);
   doneRef.current = onDone;
-  const dockToRef = useRef(dockTo);
-  dockToRef.current = dockTo;
   const reduced = typeof matchMedia === "function" && matchMedia("(prefers-reduced-motion: reduce)").matches;
 
   useEffect(() => {
@@ -71,11 +65,11 @@ export function MorphToast({ startRect, title, sub, logoUrl, theme, holdMs, dock
     // anchor that appears mid-hold docks after the longer fade-length hold.
     const willDock = !reduced
       && typeof document !== "undefined"
-      && (dockToRef.current ? dockToRef.current() !== undefined : activityAnchorRect() !== undefined);
-    const hold = holdMs ?? (willDock ? DOCK_HOLD_MS : FADE_HOLD_MS);
+      && activityAnchorRect() !== undefined;
+    const hold = willDock ? DOCK_HOLD_MS : FADE_HOLD_MS;
     const timers: ReturnType<typeof setTimeout>[] = [];
     timers.push(setTimeout(() => {
-      const rect = reduced ? undefined : (dockToRef.current ? dockToRef.current() : activityAnchorRect());
+      const rect = reduced ? undefined : activityAnchorRect();
       if (rect) {
         setDock({ x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 });
         timers.push(setTimeout(() => {
@@ -91,7 +85,7 @@ export function MorphToast({ startRect, title, sub, logoUrl, theme, holdMs, dock
       cancelAnimationFrame(raf);
       for (const timer of timers) clearTimeout(timer);
     };
-  }, [holdMs, reduced]);
+  }, [reduced]);
 
   if (typeof window === "undefined" || typeof document === "undefined") return null;
 

--- a/packages/ui/src/chrome/overlay-registry.ts
+++ b/packages/ui/src/chrome/overlay-registry.ts
@@ -67,8 +67,7 @@ export function openVendoConversation(options?: OpenConversationOptions): boolea
 }
 
 /** One palette command — the shape hosts route in `VendoPalette.onCommand`.
- *  Lives here (not in vendo-palette) because the overlay renders these as its
- *  composer chip strip; the palette re-exports it for compatibility. */
+ *  The palette re-exports it. */
 export interface VendoCommand {
   id: string;
   label: string;
@@ -76,39 +75,28 @@ export interface VendoCommand {
   appId?: string;
 }
 
-/** The command set a (headless) VendoPalette publishes for the overlay's chip
- *  strip: the commands plus the palette's own routing (which folds in the host
- *  `onCommand` when supplied). LIFO like every registry here — the most
- *  recently mounted palette owns the strip. */
+/** The command set a (headless) VendoPalette publishes: the commands plus the
+ *  palette's own routing (which folds in the host `onCommand` when supplied).
+ *  LIFO like every registry here — the most recently mounted palette wins. */
 export interface ConversationCommandSet {
   commands: VendoCommand[];
   select(command: VendoCommand): void;
 }
 
 const commandSets: ConversationCommandSet[] = [];
-const commandListeners = new Set<() => void>();
 
 /** Publish a command set for the conversation surface; returns an unsubscribe. */
 export function registerConversationCommands(set: ConversationCommandSet): () => void {
   commandSets.push(set);
-  for (const listener of commandListeners) listener();
   return () => {
     const index = commandSets.lastIndexOf(set);
     if (index >= 0) commandSets.splice(index, 1);
-    for (const listener of commandListeners) listener();
   };
 }
 
-/** The active (most recently published) command set, or null. Stable reference
- *  between changes so it works as a useSyncExternalStore snapshot. */
+/** The active (most recently published) command set, or null. */
 export function getConversationCommands(): ConversationCommandSet | null {
   return commandSets[commandSets.length - 1] ?? null;
-}
-
-/** Subscribe to command-set changes (useSyncExternalStore-compatible). */
-export function subscribeConversationCommands(listener: () => void): () => void {
-  commandListeners.add(listener);
-  return () => commandListeners.delete(listener);
 }
 
 interface Prefill {

--- a/packages/ui/src/chrome/thread/approval-wire.ts
+++ b/packages/ui/src/chrome/thread/approval-wire.ts
@@ -1,31 +1,9 @@
-/** spec §16 law 2 — the descriptor travels with the approval.
+/** Build the in-thread `ApprovalRequest` from the `data-vendo-approval` wire part.
  *
- *  THE BUG this file exists for: the in-thread approval built its own
- *  descriptor with `inputSchema: {}` (parts.tsx:506-525), so `declaredMoneyUnit`
- *  had nothing to read and a $47.50 transfer rendered as
- *  "4750 (unit not specified)" IN THE THREAD while the same ask formatted
- *  correctly in the queue. The description fell to `""` for the same reason, so
- *  the card's plain-words line disappeared. Anything the wire part carries —
- *  schema, authored title, description — now rides through to the card.
- *
- *  Drop-in for the synthesis at `parts.tsx:506-525` (Lane C owns that file; the
- *  conductor wires this in at integration):
- *
- *      const approval = buildApprovalRequest({
- *        approvalId: part.approval.id,
- *        toolCallId: part.toolCallId,
- *        tool: name,
- *        args: input,
- *        risk,
- *        ...(guardApproval?.invalidatedGrant === undefined
- *          ? {} : { invalidatedGrant: guardApproval.invalidatedGrant }),
- *        ...(guardApproval?.descriptor === undefined
- *          ? {} : { descriptor: guardApproval.descriptor }),
- *      }, tools);
- *
- *  `descriptor` is the `data-vendo-approval` part's passthrough descriptor
- *  (01-core §16 parts are `.passthrough()`, so a server that has the descriptor
- *  can ride it without a contract change and an older server simply omits it).
+ *  The descriptor must travel with the approval: without the declared
+ *  `inputSchema`, `declaredMoneyUnit` has nothing to read and a $47.50 transfer
+ *  renders as "4750 (unit not specified)" in the thread while the same ask
+ *  formats correctly in the queue.
  */
 import type { ApprovalRequest, Json, JsonSchema, RiskLabel } from "@vendoai/core";
 import { preview, SYNTHESIZED_CREATED_AT } from "./message-data.js";
@@ -44,10 +22,7 @@ export interface ApprovalWirePart {
   tool: string;
   /** The REAL inputs the model passed. */
   args?: unknown;
-  /**
-   * From the `data-vendo-approval` part. ABSENT means `ungraded` — never
-   * read-only: see the default in the builder below.
-   */
+  /** Absent means `ungraded` — never read-only; see the default in the builder. */
   risk?: RiskLabel;
   invalidatedGrant?: ApprovalRequest["invalidatedGrant"];
   /** Descriptor fields the wire part carries when the server has them. */
@@ -69,30 +44,17 @@ export function buildApprovalRequest(part: ApprovalWirePart, tools: ToolDescript
     descriptor: {
       name: part.tool,
       description: authored?.description ?? tools[part.tool]?.description ?? "",
-      // The whole point: the declared schema when the wire has one, so money
-      // formats as money on every surface — `{}` only when there is none.
       inputSchema: authored?.inputSchema ?? {},
-      // An absent risk is UNGRADED, and #747 made that a FIRST-CLASS grade, so
-      // it is carried as itself.
-      //
-      // Two approximations died here. Defaulting to "read" made every ungraded
-      // ask claim "Read-only" on its chip and "This reads your data, as you."
-      // as its line — the safest-sounding thing we could say about a call we
-      // know nothing about. Defaulting to `write` + `critical: true` was the
-      // wave's own patch: honest about scrutiny, but it still displayed a grade
-      // nobody assigned, and it duplicated in the client a state the contract
-      // now has a word for. The chip reads "Not reviewed", the line says so in
-      // plain words, and the ceremony (never fold, keep the edge) is derived
-      // from the grade at each card rather than smuggled in on a second flag.
+      // An absent risk is UNGRADED, a first-class grade — never "read", which
+      // would make an unreviewed call claim "Read-only" on its chip.
       risk: part.risk ?? "ungraded",
       ...(title === undefined || title.length === 0 ? {} : { title }),
     },
     // Client-side humanized, never the server's `tool slug + canonical JSON`.
     inputPreview: preview(part.args),
     ...(part.invalidatedGrant === undefined ? {} : { invalidatedGrant: part.invalidatedGrant }),
-    // ENG-216 — the live conversation IS the context, and the wire carries no
-    // ctx: only structurally-true, stable values ride here (never shown, the
-    // card sets showContext={false} in-thread).
+    // The wire carries no ctx: only structurally-true, stable values ride here.
+    // Never shown — the card sets showContext={false} in-thread.
     ctx: { principal: { kind: "user", subject: "" }, venue: "chat", presence: "present" },
     createdAt: SYNTHESIZED_CREATED_AT,
   };

--- a/packages/ui/src/chrome/thread/attachments.tsx
+++ b/packages/ui/src/chrome/thread/attachments.tsx
@@ -1,7 +1,7 @@
 import type { UIMessage } from "ai";
 
 /** A picked File → an ai-SDK FileUIPart (data URL) so it can ride the turn.
-    Lane pick 2F — the optional `onProgress` (0..1) feeds the chip's read ring:
+    The optional `onProgress` (0..1) feeds the chip's read ring:
     attachments are now read eagerly at attach time (progress visible, failures
     surfaced per-chip with retry) instead of silently at send time. */
 export function fileToPart(
@@ -44,7 +44,7 @@ export function formatBytes(size: number): string {
 
 export type FilePart = Extract<UIMessage["parts"][number], { type: "file" }>;
 
-/** ENG-225 — a sent attachment in the transcript: images render as the designed
+/** A sent attachment in the transcript: images render as the designed
     `.fl-msg-img` thumbnail, anything else as a `.fl-msg-file` download pill. */
 export function SentAttachment({ part }: { part: FilePart }) {
   const name = part.filename ?? "attachment";

--- a/packages/ui/src/chrome/thread/composer.tsx
+++ b/packages/ui/src/chrome/thread/composer.tsx
@@ -13,7 +13,7 @@ type OutgoingMessage =
   | { text: string; files?: Awaited<ReturnType<typeof fileToPart>>[] }
   | { parts: UIMessage["parts"] };
 
-/** Lane pick 2F — one attachment's eager-read lifecycle (drives the chip ring). */
+/** One attachment's eager-read lifecycle (drives the chip ring). */
 type AttachmentRead = {
   status: "reading" | "ready" | "error";
   /** 0..1 read progress; meaningful while `reading`. */
@@ -21,9 +21,9 @@ type AttachmentRead = {
   part?: Awaited<ReturnType<typeof fileToPart>>;
 };
 
-/** ENG-225 — drag-drop attach: only reacts to drags that actually carry files
+/** Drag-drop attach: only reacts to drags that actually carry files
     (text selections dragged across the composer must not flash the drop zone).
-    Exported for the thread-level drop surface (lane pick 2E). */
+    Exported for the thread-level drop surface. */
 export const dragHasFiles = (event: React.DragEvent) =>
   Array.from(event.dataTransfer?.types ?? []).includes("Files");
 
@@ -33,7 +33,7 @@ export const dragHasFiles = (event: React.DragEvent) =>
 export function useComposer({ busy, sendMessage, steer }: {
   busy: boolean;
   sendMessage: (message: OutgoingMessage) => unknown;
-  /** §10.2 — offer words to the turn in flight; answers whether they landed.
+  /** Offer words to the turn in flight; answers whether they landed.
       Absent for surfaces whose transport cannot steer (a scripted replay). */
   steer?: (text: string) => Promise<boolean>;
 }) {
@@ -41,13 +41,13 @@ export function useComposer({ busy, sendMessage, steer }: {
   const fileRef = useRef<HTMLInputElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [files, setFiles] = useState<File[]>([]);
-  // ENG-225 — drag-drop attach. A depth counter, not a boolean: dragging over
+  // Drag-drop attach. A depth counter, not a boolean: dragging over
   // the composer's children fires enter/leave pairs for every element crossed.
   const [dragDepth, setDragDepth] = useState(0);
-  // ENG-225 — object-URL thumbnails for image attachments in the chip strip.
+  // Object-URL thumbnails for image attachments in the chip strip.
   // Keyed by File identity; a URL is minted once per file and revoked only when
   // that file leaves the set — never recreated for files still shown (which
-  // would briefly point a mounted <img> at a revoked URL, Devin review). The
+  // would briefly point a mounted <img> at a revoked URL). The
   // ref mirrors the state so the unmount cleanup revokes the final set.
   const [attachmentPreviews, setAttachmentPreviews] = useState<Map<File, string>>(new Map());
   const previewsRef = useRef(attachmentPreviews);
@@ -71,7 +71,7 @@ export function useComposer({ busy, sendMessage, steer }: {
   useEffect(() => () => {
     for (const url of previewsRef.current.values()) URL.revokeObjectURL(url);
   }, []);
-  // Lane pick 2F — attachments read EAGERLY at attach time. Each file's read
+  // Attachments read EAGERLY at attach time. Each file's read
   // progress (FileReader onprogress) drives the chip ring; a failed read marks
   // that chip (inline retry) instead of surfacing only as a text line at send.
   // The finished part is cached so send doesn't re-read. Keyed by File identity,
@@ -123,14 +123,14 @@ export function useComposer({ busy, sendMessage, steer }: {
     // startRead closes over stable setters only; files is the real trigger.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [files]);
-  // ENG-225 — the connect dock's liquid tray, anchored over the composer.
+  // The connect dock's liquid tray, anchored over the composer.
   const [dockOpen, setDockOpen] = useState(false);
   const dockButtonRef = useRef<HTMLButtonElement>(null);
-  // ENG-215 — a message the user sent DURING a turn: it parks here (visible as a
+  // A message the user sent DURING a turn: it parks here (visible as a
   // pill) and auto-sends the instant the turn finishes. A single slot — a second
   // send while one is parked replaces it — because there is only ever one "next"
   // turn. Stop stays the explicit interrupt; queueing never cancels the stream.
-  // `landed` (§10.2): the running turn TOOK this message, so it is already in the
+  // `landed`: the running turn TOOK this message, so it is already in the
   // transcript as the user's own turn and the busy-edge flush below must not send
   // it a second time. The slot stays visible as a receipt, not a queue.
   const [queued, setQueued] = useState<{ text: string; files: File[]; context?: string; landed?: true } | null>(null);
@@ -141,7 +141,7 @@ export function useComposer({ busy, sendMessage, steer }: {
   // own history carries it, so a follow-up needs no second copy.
   const contextRef = useRef<string | undefined>(undefined);
 
-  // ENG-215 — commit a turn to the transport (attachment parts come from the
+  // Commit a turn to the transport (attachment parts come from the
   // eager-read cache when ready, else a fresh read). Used both by an immediate
   // send and by the deferred flush of a queued message.
   const dispatch = (text: string, pending: File[], context?: string) => {
@@ -155,9 +155,9 @@ export function useComposer({ busy, sendMessage, steer }: {
       } catch {
         // A file read failed. The message is restored so it never vanishes
         // silently — and the person is told what happened in their own terms
-        // (spec §15: what happened · nothing changed · what happens next).
+        // (what happened · nothing changed · what happens next).
         // The browser's own sentence ("NotReadableError: …") is a developer
-        // string and is dropped here rather than rendered (§16 law 3). It gets
+        // string and is dropped here rather than rendered. It gets
         // no dev-mode rail because this file is an EJECT TEMPLATE: it may only
         // import from the public chrome surface, and `developmentMode` is not
         // on it (scripts/eject-templates-lib.mjs enforces that).
@@ -201,7 +201,7 @@ export function useComposer({ busy, sendMessage, steer }: {
     if (fileRef.current) fileRef.current.value = "";
     if (busy) {
       setQueued({ text, files: pending, ...(context === undefined ? {} : { context }) });
-      // §10.2 — then OFFER it to the turn that is running. Words only: an
+      // Then OFFER it to the turn that is running. Words only: an
       // attachment or a grounding marker cannot ride a steer, so those keep the
       // turn-end flush. A `false` (or no steer at all) changes nothing.
       if (steer !== undefined && text !== "" && pending.length === 0 && context === undefined) {
@@ -226,7 +226,7 @@ export function useComposer({ busy, sendMessage, steer }: {
   // Prefill bridge: a host affordance (a trigger button, the legacy
   // `vendo:prefill` event, the ✦ remix popover) opens this surface and hands
   // it the request to type + send, so the whole build happens here — the one
-  // conversational place (08-ui §4). The registry consumer also drains a
+  // conversational place. The registry consumer also drains a
   // prompt parked while this composer was still mounting (overlay first open /
   // fresh conversation).
   useEffect(() => {
@@ -270,7 +270,7 @@ export function useComposer({ busy, sendMessage, steer }: {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [busy, queued]);
 
-  // ENG-215 — autogrow: the textarea tracks its content height (CSS caps it at
+  // Autogrow: the textarea tracks its content height (CSS caps it at
   // max-height and scrolls past that). Runs on every draft change, including the
   // programmatic reset on send and the refill on edit.
   useEffect(() => {
@@ -304,7 +304,7 @@ export interface ComposerProps {
   jumpBar?: import("react").ReactNode;
 }
 
-/** The message composer (08-ui §4): attachments, drag-drop, queueing, dock. */
+/** The message composer: attachments, drag-drop, queueing, dock. */
 export function Composer({ composer, busy, status, errorMessage, onStop, onVoice, jumpBar }: ComposerProps) {
   const {
     draft, setDraft, files, setFiles,
@@ -345,7 +345,7 @@ export function Composer({ composer, busy, status, errorMessage, onStop, onVoice
         DOM order: both are positioned with auto z-index, so its entrance rises
         from BEHIND the composer instead of sliding over its face. */}
     {jumpBar}
-    {/* Lane pick 2E — drag-drop moved UP to the whole thread surface (see
+    {/* Drag-drop lives on the whole thread surface (see
         VendoThread): the bar itself no longer owns enter/leave/drop. */}
     <form
       className="fl-composer"
@@ -354,7 +354,7 @@ export function Composer({ composer, busy, status, errorMessage, onStop, onVoice
     >
       {attachError ? <div className="fl-att-error" role="alert">{attachError}</div> : null}
       {queued ? (
-        // §10.2 — one element, two fates. The copy says what happened to the
+        // One element, two fates. The copy says what happened to the
         // MESSAGE and never anything about the result: a steer is words
         // delivered, and the build's own reply is the only thing entitled to
         // describe the build.
@@ -364,7 +364,7 @@ export function Composer({ composer, busy, status, errorMessage, onStop, onVoice
           <span className="fl-queued-hint">
             {queued.landed ? "added to the reply in progress" : "sends when the reply finishes"}
           </span>
-          {/* Lane pick 2B — Send now: stop the stream; the ENG-215 busy-edge
+          {/* Send now: stop the stream; the busy-edge
               flush then dispatches this queued slot immediately. One code
               path for both the polite wait and the deliberate interrupt.
               A message already delivered has nothing left to send. */}
@@ -388,12 +388,11 @@ export function Composer({ composer, busy, status, errorMessage, onStop, onVoice
               <button type="button" className={`fl-att-rm${asFileChip ? " fl-att-rm-file" : ""}`} aria-label={`Remove ${file.name}`}
                 onClick={() => setFiles(current => current.filter((_, j) => j !== i))}>×</button>
             );
-            // ENG-225 — images preview as the designed thumbnail chip; other
+            // Images preview as the designed thumbnail chip; other
             // files carry an extension badge plus name and size. An image whose
             // READ failed falls through to the error file-chip below (retry in
             // place) instead of silently posing as attachable — the object-URL
             // thumbnail says nothing about whether FileReader could read it
-            // (AI-review catch).
             if (preview !== undefined && read?.status !== "error") {
               return (
                 <span className="fl-att-img" key={`${file.name}-${i}`}>
@@ -402,7 +401,7 @@ export function Composer({ composer, busy, status, errorMessage, onStop, onVoice
                 </span>
               );
             }
-            // Lane pick 2F — the chip narrates its read: progress ring while
+            // The chip narrates its read: progress ring while
             // reading, error + inline retry on failure, quiet size when ready.
             const failed = read?.status === "error";
             const reading = read?.status === "reading";
@@ -453,7 +452,7 @@ export function Composer({ composer, busy, status, errorMessage, onStop, onVoice
             placeholder="Ask anything"
             rows={1}
             value={draft}
-            // ENG-215 — never disabled: typing (and queueing) stays live through
+            // Never disabled: typing (and queueing) stays live through
             // the whole turn, and the composer never dumps focus to <body>.
             onChange={event => setDraft(event.currentTarget.value)}
             onKeyDown={(event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
@@ -468,7 +467,7 @@ export function Composer({ composer, busy, status, errorMessage, onStop, onVoice
             </svg>
           </button>
         ) : null}
-        {/* ENG-215 — Stop is the explicit interrupt (only mid-turn); Send is
+        {/* Stop is the explicit interrupt (only mid-turn); Send is
             always available and, during a turn, queues the message instead. */}
         {busy ? (
           <button className="fl-icon-btn fl-stop" type="button" aria-label="Stop" onClick={onStop}>

--- a/packages/ui/src/chrome/thread/index.tsx
+++ b/packages/ui/src/chrome/thread/index.tsx
@@ -11,7 +11,7 @@ import { MessageList } from "./message-list.js";
 import { useMessageWindow, useStickToBottom } from "./scrolling.js";
 import { approvalByCall, grantSetByCall, riskByCall, toolCallPending, turnErrorSentence, userText } from "./message-data.js";
 
-/** Lane pick 4B — a rich landing suggestion: two-line starter card. */
+/** A rich landing suggestion: two-line starter card. */
 export interface VendoSuggestionCard {
   /** Card headline (verb-first reads best: "Build a view"). */
   title: string;
@@ -30,17 +30,17 @@ export interface VendoThreadProps {
   /** One quiet capability line under the landing headline (muted, centered).
    * Purely additive: absent means today's headline-only landing. */
   intro?: string;
-  /** Starter prompts on the empty landing; clicking sends one. Lane pick 4B —
+  /** Starter prompts on the empty landing; clicking sends one.
    * a plain string keeps today's pill chip; the object form renders a two-line
    * starter card (title + concrete outcome, optional icon) with more scent. */
   suggestions?: (string | VendoSuggestionCard)[];
   /** Show a mic affordance in the composer that launches the host's voice surface. */
   onVoice?: () => void;
-  /** ENG-222 — fires with the effective thread id once it is known, including
+  /** Fires with the effective thread id once it is known, including
    * the fresh `thr_` the server mints for a new conversation. Lets a host
    * surface (e.g. a host's own conversation list) pull the new one in. */
   onThreadId?: (threadId: string) => void;
-  /** The discoverability dial (ui-usage-dx §6), overriding the provider's:
+  /** The discoverability dial, overriding the provider's:
    * `"quiet"` disables the fire-once greeting-as-tutorial below. */
   discoverability?: VendoDiscoverability;
   /** Greeting-as-tutorial content (intro + prompt chips) overriding the
@@ -53,7 +53,7 @@ export interface VendoThreadProps {
   composerAccessory?: import("react").ReactNode;
 }
 
-/** 08-ui §4 — conversation chrome over the headless thread transport. */
+/** Conversation chrome over the headless thread transport. */
 export function VendoThread({
   threadId,
   greeting = "What can I help you build?",
@@ -66,7 +66,7 @@ export function VendoThread({
   composerAccessory,
 }: VendoThreadProps) {
   const thread = useVendoThread(threadId);
-  // ui-usage-dx §6 — greeting-as-tutorial: the user's FIRST-ever conversation
+  // Greeting-as-tutorial: the user's FIRST-ever conversation
   // open (fresh thread only — an adopted thread with history is not a first
   // open and does not burn the flag) renders the agent-voiced intro + starter
   // chips locally. Presentation-only: nothing here touches the transport or
@@ -94,7 +94,7 @@ export function VendoThread({
   useEffect(() => {
     if (tutorialActive && (messageCount > 0 || threadId !== undefined)) setTutorialActive(false);
   }, [tutorialActive, messageCount, threadId]);
-  // ENG-222 — surface the effective (possibly server-minted) thread id upward.
+  // Surface the effective (possibly server-minted) thread id upward.
   const reportedThreadId = thread.threadId;
   useEffect(() => {
     if (reportedThreadId !== undefined) onThreadId?.(reportedThreadId);
@@ -137,7 +137,7 @@ export function VendoThread({
   }, [thread.messages, scroll]);
 
   const messageWindow = useMessageWindow(thread.messages, scroll.listRef, threadId);
-  // ENG-218 — entrance-animation gating on restore. The .fl-item-in rise runs
+  // Entrance-animation gating on restore. The .fl-item-in rise runs
   // when an article first mounts; a reopened long thread mounts them all at once
   // → a stampede on first paint. We record every message id present when the
   // thread is first shown (and after each switch) as "restored" and suppress
@@ -155,7 +155,7 @@ export function VendoThread({
   const composerApi = useComposer({
     busy,
     sendMessage: message => thread.sendMessage(message),
-    // §10.2 — a message typed mid-turn is offered to that turn before it queues.
+    // A message typed mid-turn is offered to that turn before it queues.
     ...(thread.steer === undefined ? {} : { steer: thread.steer }),
   });
   const { setDraft, setQueued, textareaRef, send } = composerApi;
@@ -217,7 +217,7 @@ export function VendoThread({
   const assistantHasVisibleText = activeAssistant?.parts.some(
     part => part.type === "text" && part.text.trim().length > 0,
   ) ?? false;
-  // ENG-217 — the streaming moments each get exactly ONE affordance: a streamed
+  // The streaming moments each get exactly ONE affordance: a streamed
   // turn whose text is still empty shows the lone caret (renderPart); once
   // text flows the trailing caret rides .fl-md--streaming. FluidThinking covers
   // every remaining gap, INCLUDING the wait before the first chunk — that
@@ -232,7 +232,7 @@ export function VendoThread({
   const hasBeats = activeAssistant?.parts.some(part => isToolUIPart(part)) ?? false;
   const working = busy && !assistantHasVisibleText && !caretShowing && !hasBeats;
 
-  // ENG-215 — edit the last user turn: drop it (and anything after) from the
+  // Edit the last user turn: drop it (and anything after) from the
   // transcript and refill the composer, so re-sending amends rather than
   // duplicates. Only meaningful when idle.
   const lastUserIndex = (() => {
@@ -242,7 +242,7 @@ export function VendoThread({
     return -1;
   })();
   // Turn actions attach by id, not list index: the map below renders a windowed
-  // slice (ENG-218), so positional indices no longer line up with thread.messages.
+  // slice, so positional indices no longer line up with thread.messages.
   const lastUserId = lastUserIndex >= 0 ? thread.messages[lastUserIndex]?.id : undefined;
   const editLast = () => {
     if (busy || lastUserIndex < 0) return;
@@ -254,7 +254,7 @@ export function VendoThread({
     requestAnimationFrame(() => textareaRef.current?.focus());
   };
 
-  // ENG-215 — regenerate the last assistant turn (re-issues from the preserved
+  // Regenerate the last assistant turn (re-issues from the preserved
   // user message; no duplication). Only when idle and an assistant turn exists.
   const lastAssistantIndex = (() => {
     for (let index = thread.messages.length - 1; index >= 0; index -= 1) {
@@ -268,21 +268,21 @@ export function VendoThread({
     void thread.regenerate();
   };
 
-  // ENG-214 — a broken turn (failed send, mid-stream drop, any thread.error)
+  // A broken turn (failed send, mid-stream drop, any thread.error)
   // surfaces VISIBLY in the thread, not only through the hidden status span.
   // The copy stays friendly — raw transport errors are announced to assistive
   // tech below but never printed to end users.
   // A "Vendo: " prefixed message is the agent's OWN safe error (VendoError
   // code + operator-crafted text, wireErrorMessage in @vendoai/harnesses) — the
   // ONE error shape end users may see in detail. Raw transport/provider
-  // strings never match the prefix and stay hidden (ENG-214 policy).
+  // Strings never match the prefix and stay hidden.
   // self-serve P — a live turn error now ALSO lands in the turn itself (the
   // data-vendo-turn-error part, which survives reload); when that part is
   // already saying it, the banner keeps only its headline + Retry so the same
   // sentence isn't printed twice.
   const turnErrorInThread = activeAssistant?.parts.some(part => part.type === "data-vendo-turn-error") ?? false;
   const errorDetail = turnErrorInThread ? undefined : turnErrorSentence(thread.error?.message);
-  // Ruling 16 — §15 governs the surfaces where the AGENT CAN SPEAK, and this is
+  // The copy law governs the surfaces where the AGENT CAN SPEAK, and this is
   // one: the banner used to carry its own Retry button, a bespoke failure
   // control beside a conversation that already has one recovery path (the turn's
   // Regenerate action, and the composer). The banner states what happened and
@@ -296,11 +296,10 @@ export function VendoThread({
     </div>
   ) : null;
 
-  // Lane picks 3A + 6B — the jump affordance is a bar with a COUNT and snippet
-  // ("2 new replies · …") docked flush onto the composer's top edge (rendered
-  // inside its .fl-dock-anchor, tray-style, so the two read as one piece); at
-  // mobile widths the same element re-clothes as a bottom-center pill (pure
-  // CSS, see the lane block in chrome-css). Activating it re-sticks as before.
+  // The jump affordance is a bar with a COUNT and a snippet ("2 new replies ·
+  // …") docked flush onto the composer's top edge (rendered inside its
+  // .fl-dock-anchor, tray-style, so the two read as one piece); at mobile
+  // widths the same element re-clothes as a bottom-center pill, in CSS alone.
   const jumpBar = scroll.showJump ? (
     <button
       type="button"
@@ -334,7 +333,7 @@ export function VendoThread({
     .filter((part): part is Extract<typeof part, { state: "approval-requested" }> =>
       part.state === "approval-requested" && !grantSets.has(part.toolCallId));
 
-  // Spec §1 — the ribbon no longer narrates tool calls: the TRANSCRIPT owns the
+  // The ribbon no longer narrates tool calls: the TRANSCRIPT owns the
   // work now (one beat per call, at its position in the conversation), so a
   // second live narration above the composer would say the same thing twice.
   // All that survives above the composer is the between-steps gap below.
@@ -374,13 +373,13 @@ export function VendoThread({
     const timer = setTimeout(() => setQuietBusy(true), 800);
     return () => clearTimeout(timer);
   }, [quietBusyEligible]);
-  // §3.4 — the gap narrates the latest harness beat when there is one;
+  // The gap narrates the latest harness beat when there is one;
   // "Working" is the floor for a harness that says nothing. It renders as a
   // WorkingBeat at the transcript tail (2026-08-06 polish: one beat
   // vocabulary, no separate ribbon pill).
   const quietLabel = quietBusy ? thread.beats.at(-1)?.label ?? "Working" : undefined;
 
-  // Lane pick 2E — the WHOLE thread surface is the drop target (the composer
+  // The WHOLE thread surface is the drop target (the composer
   // bar no longer owns drag): a huge, overshoot-proof zone with a centered
   // card naming what will happen. Depth counter as before (child crossings).
   const { dragDepth, setDragDepth, setFiles } = composerApi;
@@ -454,7 +453,7 @@ export function VendoThread({
               </>
             )}
             {!tutorialActive && suggestions.length > 0 ? (
-              // Lane pick 4B — object suggestions render as two-line starter
+              // Object suggestions render as two-line starter
               // cards (title + concrete outcome, optional host icon); plain
               // strings keep the pill chip. A MIXED array renders both
               // containers (cards grid, then one plain chips row) so string

--- a/packages/ui/src/chrome/thread/message-data.ts
+++ b/packages/ui/src/chrome/thread/message-data.ts
@@ -7,37 +7,24 @@ export function partData(part: UIMessage["parts"][number]): unknown {
   return "data" in part ? part.data : part;
 }
 
-/** ENG-214 — the marker the agent's `wireErrorMessage` puts on its OWN safe
- * error text (VendoError code + operator-crafted message). Only prefixed
- * strings may be shown in detail to an end user; raw transport/provider
- * strings never carry it. Read by both error surfaces (the banner and the
- * in-thread turn-error part). */
+/** The marker the agent's `wireErrorMessage` puts on its OWN safe error text
+ * (VendoError code + operator-crafted message). Only prefixed strings may be
+ * shown in detail to an end user; raw transport/provider strings never carry
+ * it. Read by both error surfaces (the banner and the turn-error part). */
 export const VENDO_ERROR_PREFIX = "Vendo: ";
 
 /**
- * CR-3 — what a PERSON is told about a broken turn, BY CODE.
+ * What a PERSON is told about a broken turn, BY CODE.
  *
- * The `"Vendo: "` marker says a sentence is safe to put on the WIRE (it is
- * ours, not the provider's). It has never said the sentence was written for a
- * reader, and mostly it was not: `packages/vendo/src/sandbox.ts` raises
- * `Vendo Cloud sandbox sbx_… is gone (destroyed by the provider): <raw provider
- * message>` — an id AND a nested exception, inside a conversation — and
- * demo/dev refusals name shell commands ("Run `vendo login` for a free dev
- * key"). Prefix-only was therefore a hole exactly as wide as the set of
- * sentences our own code raises.
+ * The `"Vendo: "` marker only says a sentence is safe to put on the WIRE — not
+ * that it was written for a reader. Our own code raises sandbox ids, nested
+ * provider exceptions and shell commands behind that marker, so the reader gets
+ * copy chosen by the VendoError CODE instead and the operator's sentence is
+ * never printed (it keeps the server log and the console line
+ * `wireErrorMessage` writes).
  *
- * So the reader gets copy chosen by the VendoError CODE, exactly the
- * `refusalCopy` pattern the consent cards use, and the operator's sentence is
- * never printed. Ruling 14 rules out re-using `consumerVoiceViolation` as a
- * runtime gate: a regex set cannot decide what a person may read.
- *
- * One exception, named and narrow: 01-core's `formatMeterExhausted` composes a
- * sentence that IS consumer copy (Pricing v3 §5 — the meter, the figures, the
- * reset date and the two exits, all from structured fields). It survives
- * verbatim, recognized by the head that function always writes.
- *
- * The code and the operator's own sentence keep the home they already have:
- * the server log and the browser console line `wireErrorMessage` writes.
+ * One exception: core's `formatMeterExhausted` composes a sentence that IS
+ * consumer copy, recognized by the head that function always writes.
  */
 const TURN_ERROR_COPY: Record<VendoErrorCode, string> = {
   validation: "I couldn’t make that request work — nothing was changed. Ask again and I’ll try a different approach.",
@@ -76,39 +63,26 @@ export function turnErrorSentence(message: string | undefined): string | undefin
 }
 
 /**
- * Spec §15 + §16 law 3 — what a PERSON is told when an app build fails.
+ * What a PERSON is told when an app build fails.
  *
- * The wire's `reason` is the runtime's classified, provider-safe line, and
- * provider-safe is not the same as the reader's language: it is written for
- * whoever can FIX the build. The wave E2E photographed all of it in a real
- * user's thread — the honesty gate's teaching sentence names components and
- * expressions (`amount / sum(spending.data.amount)`), the no-model-key lines
- * name environment variables and npm packages, the watchdog line says to check
- * the host server log. Same class as the slot's `loadFailureCopy`, so the same
- * answer: the developer sentence keeps the home it already has (the server logs
- * it in full with every blocking finding — `[vendo] app build failed (app_…)`,
- * apps/runtime.ts), and the person gets §15's standing copy law — what happened
- * · nothing was changed · what happens next.
+ * The wire's `reason` is written for whoever can FIX the build — it names
+ * components, expressions, environment variables and npm packages — so it stays
+ * in the server log and the person gets this instead.
  *
- * ONE sentence for every class, deliberately. Splitting the copy by the
- * runtime's classification was tried and reverted on live evidence: the
- * classifier is a substring scan over the concatenated findings
- * (`buildFailureReason`), and `host_listScheduledPayments` in a finding's tool
- * inventory contains "payment", so an ordinary validation failure is persisted
- * as "quota exhausted" (observed 2026-08-03, fix-defects proof). Copy that
- * branches on an unreliable label just tells a different lie — "try again
- * later" for a build that will fail identically. Asking again is true and
- * harmless for every class, so that is what it says.
+ * ONE sentence for every failure class, deliberately: the runtime's
+ * classification is a substring scan over the concatenated findings, so
+ * `host_listScheduledPayments` in a tool inventory makes an ordinary validation
+ * failure read as "quota exhausted". Copy that branches on an unreliable label
+ * just tells a different lie. Asking again is true for every class.
  */
 export const BUILD_FAILURE_COPY =
   "I couldn't finish building that view — nothing was changed."
   + " Ask again and I'll try a different approach.";
 
-// ENG-216 — a stable placeholder for the in-thread synthesized ApprovalRequest's
-// required `createdAt`. The wire approval part carries no timestamp; this value
-// is never displayed (the card hides the context byline in-thread) and a fixed
-// constant replaces the former per-render `new Date()` that churned on every
-// re-render and broke deterministic tests.
+// A stable placeholder for the in-thread synthesized ApprovalRequest's required
+// `createdAt`: the wire approval part carries no timestamp, and the value is
+// never displayed (the card hides the context byline in-thread). Fixed, not
+// `new Date()`, so it does not churn on every re-render.
 export const SYNTHESIZED_CREATED_AT = "1970-01-01T00:00:00.000Z";
 
 export function riskByCall(messages: UIMessage[]): Map<string, RiskLabel> {
@@ -128,10 +102,10 @@ export function riskByCall(messages: UIMessage[]): Map<string, RiskLabel> {
 /** Guard approval metadata by tool call — carried in the data-vendo-approval
     part beside the native ai-SDK approval (whose own id is transport-local).
 
-    spec §16 law 2 — `descriptor` rides here too when the server has one: the
-    §16 parts are `.passthrough()`, so a newer server can send the declared
+    `descriptor` rides here too when the server has one: the wire parts are
+    `.passthrough()`, so a newer server can send the declared
     schema/title/description with the ask and an older one simply omits it
-    (buildApprovalRequest degrades to host ToolMeta). */
+    (buildApprovalRequest then degrades to host ToolMeta). */
 export function approvalByCall(messages: UIMessage[]): Map<string, ApprovalWireMeta> {
   const approvals = new Map<string, ApprovalWireMeta>();
   for (const message of messages) {
@@ -197,19 +171,17 @@ export function grantSetByCall(messages: UIMessage[]): Map<string, {
   return sets;
 }
 
-/** Knowledge K1 — what a turn's `data-vendo-citations` parts add up to.
-    Chips render only ANSWERED citations (a refusal's weak hits stay off the
-    chip row — mockup state 2 shows the searched-line alone); the flags carry
-    the refusal/outage states. */
+/** What a turn's `data-vendo-citations` parts add up to. Chips render only
+    ANSWERED citations (a refusal's weak hits stay off the chip row); the flags
+    carry the refusal/outage states. */
 export interface TurnKnowledgeSources {
   citations: VendoKnowledgeCitation[];
   refused: boolean;
   unavailable: boolean;
 }
 
-/** Knowledge K1 (pattern: approvalByCall) — fold a turn's citations parts
-    into the one summary TurnCitations renders, deduped by doc+chunk across
-    multiple knowledge calls in the same turn. */
+/** Fold a turn's citations parts into the one summary TurnCitations renders,
+    deduped by doc+chunk across multiple knowledge calls in the same turn. */
 export function sourcesFor(message: UIMessage): TurnKnowledgeSources {
   const citations: VendoKnowledgeCitation[] = [];
   const seen = new Set<string>();
@@ -264,7 +236,7 @@ function toolSignature(part: Extract<UIMessage["parts"][number], { toolCallId: s
   return `${toolName(part)}::${serialized}`;
 }
 
-/** ENG-216 — collapse runs of consecutive identical tool chips (e.g. eight
+/** Collapse runs of consecutive identical tool chips (e.g. eight
     `host_listClientDocuments` calls) into one entry carrying a count. The
     latest part in the run is kept so the chip icon reflects the final state. */
 export function collapseToolRuns(
@@ -298,40 +270,35 @@ export function toolCallPending(part: UIMessage["parts"][number]): boolean {
     && part.state !== "output-denied";
 }
 
-/** Spec §15 — a failed or declined call is CONTENT, not progress: its beat
-    stays visible after the turn folds, and it never counts as a thing the agent
-    did. Everything else is progress, and progress folds into the summary. */
+/** A failed or declined call is CONTENT, not progress: its beat stays visible
+    after the turn folds, and it never counts as a thing the agent did.
+    Everything else is progress, and progress folds into the summary. */
 export function toolCallIsContent(part: UIMessage["parts"][number]): boolean {
   return isToolUIPart(part)
     && (part.state === "output-error" || part.state === "output-denied");
 }
 
-/** Spec §8 D1 — the app-building call this turn's app card is narrating. The
-    card bar narrates that step ("Building your view…" → the app's name), so a
-    beat beside it would narrate the same work twice; the settled summary still
-    counts it. Recognized exactly the way the server decides to emit the view
-    part (06-apps §1: the apps tool namespace + a tree surface), never by
-    duck-typing an arbitrary tool's output.
+/** The app-building call this turn's app card is narrating. The card bar
+    narrates that step ("Building your view…" → the app's name), so a beat
+    beside it would narrate the same work twice; the settled summary still
+    counts it. Recognized the way the server decides to emit the view part (the
+    apps tool namespace + a tree surface), never by duck-typing an output.
 
-    Wave E2E defect D1 — the card goes up at build START (`vendo_make` is the one
-    tool that streams partial views through the VENDO_VIEW_STREAM bridge), so
-    checking only the RESULT left the whole build window narrating twice: a
-    "Build an app…" beat above a bar already saying "Building your view…". The
-    running build is therefore recognized by tool IDENTITY, before its output
-    exists. No other apps tool streams a partial view, so for the rest the beat
-    is the only narration until their tree lands — and a build that is parked on
-    an approval or has FAILED is narrated by no card at all, so its beat is the
-    whole record (§15). */
+    A running `vendo_make` is recognized by tool IDENTITY, before its output
+    exists: it is the one tool that streams partial views, so the card is
+    already up during the build window. No other apps tool streams a partial
+    view, so for the rest the beat is the only narration until their tree lands
+    — and a build parked on an approval or FAILED has no card, so its beat is
+    the whole record. */
 export function narratedByAppCard(
   part: UIMessage["parts"][number],
   siblingParts: UIMessage["parts"],
 ): boolean {
   if (!isToolUIPart(part)) return false;
-  // M20 — a build that FAILED terminally narrates through its own block (the
-  // `data-vendo-build-failed` part: a ✕ beat reading "Couldn't build the app"
-  // plus what it means for the reader). The failed call's own ✕ beat sat right
-  // above it, so one failure printed two ✕ lines. The part names the call it
-  // is about, so the suppression is exact rather than a guess by tool identity.
+  // A build that FAILED terminally narrates through its own
+  // `data-vendo-build-failed` block, so the failed call's own ✕ beat would
+  // print a second ✕ line. The part names the call it is about, so the
+  // suppression is exact rather than a guess by tool identity.
   const failed = siblingParts.some(sibling => sibling.type === "data-vendo-build-failed"
     && (partData(sibling) as { toolCallId?: unknown; reason?: unknown }).toolCallId === part.toolCallId
     && typeof (partData(sibling) as { reason?: unknown }).reason === "string");
@@ -342,12 +309,9 @@ export function narratedByAppCard(
   if (name === VENDO_MAKE_TOOL) {
     if (building) return true;
     if (part.state !== "output-available") return false;
-    // A SETTLED build used to be recognized by its output carrying a tree.
-    // `vendo_make` answers with a `MakeReceipt` — four fields of words — so that
-    // test can never match again, and leaving it would have printed a "Make you
-    // a screen" ✓ beat beside the very card it describes. The card's own part on
-    // the wire is the test now, which is exact rather than a guess: if the view
-    // is there, the card is what the reader is looking at.
+    // `vendo_make` answers with a `MakeReceipt` — words, no tree — so a settled
+    // build cannot be recognized by its output. The card's own part on the wire
+    // is the test: if the view is there, that is what the reader is looking at.
     return siblingParts.some(sibling => sibling.type === "data-vendo-view");
   }
   if (part.state !== "output-available") return false;
@@ -357,13 +321,12 @@ export function narratedByAppCard(
 }
 
 /**
- * LEAK 4's grounding carrier (spec §16 law 3): a text part the MODEL reads and
- * the person never sees. An affordance that opens the conversation about a
- * specific thing (the ✦ remix popover) has to tell the agent WHICH thing, and
- * the identifier for it is an app id — our plumbing, not something a person
- * types or reads. So it rides the sent message as its own text part, marked
- * here; the transcript skips it and `userText` (which seeds "edit last
- * message") leaves it out, so it stays out of every surface a person touches.
+ * The grounding carrier: a text part the MODEL reads and the person never sees.
+ * An affordance that opens the conversation about a specific thing (the ✦ remix
+ * popover) has to tell the agent WHICH thing, and the identifier is an app id —
+ * plumbing, not something a person types or reads. So it rides the sent message
+ * as its own marked text part; the transcript skips it and `userText` (which
+ * seeds "edit last message") leaves it out.
  *
  * A text part is the carrier because it is the ONLY channel that reaches the
  * model: `convertToModelMessages` keeps text and drops metadata and data parts.
@@ -371,20 +334,14 @@ export function narratedByAppCard(
 export const AGENT_CONTEXT_METADATA = { vendo: { agentContext: true } } as const;
 
 /**
- * The SAME mark, in the text itself — 01-core's, re-exported so the chrome's
- * consumers keep the name they import today.
+ * The SAME mark, in the text itself — core's, re-exported for the chrome's
+ * consumers.
  *
- * THE HOLE the post-check found: `providerMetadata` is the only thing saying
- * "never show this", and a store that persists a text part as `{ type, text }`
- * — which the wire contract permits and several stores do — drops it. The
- * marked part then comes back as an ORDINARY text part, so a reloaded
- * transcript prints the app id, and "edit last message" seeds the composer
- * with it. That is the exact leak the carrier was invented to avoid, one
- * reload later.
- *
- * It lives in core (not here) because the SERVER needs it too: the thread title
- * is minted in @vendoai/agent, which had no concept of the mark and persisted
- * "[vendo:context] Declined to connect Gmail." into the thread rail.
+ * `providerMetadata` alone is not enough: a store that persists a text part as
+ * `{ type, text }` — which the wire contract permits — drops it, and the marked
+ * part comes back as an ORDINARY text part, so a reloaded transcript prints the
+ * app id. The mark lives in core because the SERVER needs it too: thread titles
+ * are minted in @vendoai/agent.
  */
 export { AGENT_CONTEXT_MARK };
 
@@ -404,7 +361,7 @@ export function isAgentContext(part: UIMessage["parts"][number]): boolean {
 }
 
 /** The plain text a user turn carried, joined across its text parts — the seed
-    for "edit last message" (ENG-215). */
+    for "edit last message". */
 export function userText(message: UIMessage): string {
   return message.parts
     .filter((part): part is Extract<UIMessage["parts"][number], { type: "text" }> =>
@@ -422,12 +379,10 @@ export function assistantText(message: UIMessage): string {
     .join("\n\n");
 }
 
-/** ENG-216 — the in-thread approval preview is built client-side (the wire part
-    carries no descriptor), so format args as readable `Label: value` lines
-    instead of the raw JSON with literal \n escapes end users were reading. */
+/** The in-thread approval preview, built client-side: readable `Label: value`
+    lines instead of raw JSON with literal \n escapes. */
 export function preview(input: unknown): string {
-  // ENG-216 — readable `Label: value` lines instead of raw JSON. ENG-218 — then
-  // bound the result before it reaches the DOM: a huge argument blob (dumped
+  // Bound the result before it reaches the DOM: a huge argument blob (dumped
   // rows, base64) otherwise renders unbounded inside the approval card's <pre>,
   // blowing up layout and the node count.
   const formatted = previewArgs(input);

--- a/packages/ui/src/chrome/thread/message-list.tsx
+++ b/packages/ui/src/chrome/thread/message-list.tsx
@@ -6,9 +6,9 @@ import { ThreadMessage } from "./message.js";
 import { ThreadApprovals } from "./parts.js";
 import type { useMessageWindow, useStickToBottom } from "./scrolling.js";
 
-/** The transcript pane: the windowed message list (ENG-218), parked approval
-    and connect cards, and the ENG-217 streaming indicators. The jump-to-latest
-    affordance (ENG-213) lives with the composer, docked onto the bar.
+/** The transcript pane: the windowed message list, parked approval and connect
+    cards, and the streaming indicators. The jump-to-latest affordance lives
+    with the composer, docked onto the bar.
     Pure presentation over the thread-level state. */
 export function MessageList({
   scroll, messageWindow, busy, risks, isRestored,
@@ -86,9 +86,9 @@ export function MessageList({
         {working ? <FluidThinking label="Working" /> : null}
         {quietLabel !== undefined ? <WorkingBeat label={quietLabel} /> : null}
       </div>
-      {/* Lane picks 3A + 6B — the jump affordance ("N new replies · …") now
-          renders inside the composer's .fl-dock-anchor (see VendoThread), so
-          it docks flush onto the bar and the two read as one piece. */}
+      {/* The jump affordance ("N new replies · …") renders inside the
+          composer's .fl-dock-anchor (see VendoThread), so it docks flush onto
+          the bar and the two read as one piece. */}
     </div>
   );
 }

--- a/packages/ui/src/chrome/thread/message.tsx
+++ b/packages/ui/src/chrome/thread/message.tsx
@@ -11,11 +11,11 @@ import { TurnCitations } from "./turn-citations.js";
 // 2026-07 demo feedback — the settled turn's "sources" chip row (lane pick 8C)
 // is GONE: the little read-call pills under assistant messages read as clutter
 // and duplicated the Activity panel, which remains the mechanical record.
-// Spec §1 (2026-08-03) then gave the turn its work back as BEATS — a checklist
+// The turn's work comes back as BEATS — a checklist
 // line per call while the turn runs, folded into one reopenable summary row
 // ("Did 4 things · 7.1s") the moment it settles.
 
-/** ENG-225 — the copy turn action (.fl-turn-actions design). */
+/** The copy turn action (.fl-turn-actions design). */
 function CopyTurnButton({ text }: { text: string }) {
   const [copied, copy] = useCopyFeedback();
   return (
@@ -34,10 +34,9 @@ function CopyTurnButton({ text }: { text: string }) {
   );
 }
 
-/** One turn in the transcript: the user attachments beside the bubble
-    (ENG-225), the article with its stream parts, and the settled-turn
-    actions (Copy always; Edit on the last user turn, Regenerate on the
-    last assistant turn — ENG-215). */
+/** One turn in the transcript: the user attachments beside the bubble, the
+    article with its stream parts, and the settled-turn actions (Copy always;
+    Edit on the last user turn, Regenerate on the last assistant turn). */
 export function ThreadMessage({ message, restored, risks, busy, activeAssistantId, lastUserId, lastAssistantId, onEditLast, onRegenerateLast, sendMessage, respond }: {
   message: UIMessage;
   restored: boolean;
@@ -53,7 +52,7 @@ export function ThreadMessage({ message, restored, risks, busy, activeAssistantI
   /** The thread's native approval response — grant-set cards resume with it. */
   respond?: (response: { id: string; approved: boolean }) => void;
 }) {
-  // ENG-225 — a user turn's attachments render BESIDE the bubble
+  // A user turn's attachments render BESIDE the bubble
   // (the designed .fl-turn-user-att block), not inside it; a
   // files-only send has no bubble at all.
   const sentFiles = message.role === "user"
@@ -62,15 +61,15 @@ export function ThreadMessage({ message, restored, risks, busy, activeAssistantI
   const bubbleText = message.role === "user" ? userText(message) : assistantText(message);
   const skipBubble = message.role === "user" && bubbleText.length === 0
     && message.parts.every(part => part.type === "file" || isAgentContext(part));
-  // ENG-225 — every settled turn carries a Copy action (hover-
+  // Every settled turn carries a Copy action (hover-
   // revealed, see chrome-css); Edit stays on the last user turn and
-  // Regenerate on the last assistant turn (ENG-215). The actively
+  // Regenerate on the last assistant turn. The actively
   // streaming turn gets no actions — its text is still arriving.
   const streamingTurn = busy && message.role === "assistant" && message.id === activeAssistantId;
   const showEdit = !busy && message.role === "user" && message.id === lastUserId;
   const showRegenerate = !busy && message.role === "assistant" && message.id === lastAssistantId;
   const showActions = !streamingTurn && (bubbleText.length > 0 || showEdit || showRegenerate);
-  // Spec §1 — the turn's beats fold into ONE summary row once the whole turn
+  // The turn's beats fold into ONE summary row once the whole turn
   // has settled: while any call is still working (or parked on an approval)
   // every beat stays open, and the fold waits. Restored history arrives folded,
   // which is also what keeps a long thread from a beat entrance stampede.
@@ -78,7 +77,7 @@ export function ThreadMessage({ message, restored, risks, busy, activeAssistantI
   const calls = items.filter(item => isToolUIPart(item.part));
   const pending = streamingTurn || calls.some(item => toolCallPending(item.part));
   // A failed or declined call is not one of the "things I did", and its ✕ beat
-  // never folds (spec §15) — so the count is the work that actually landed, and
+  // never folds — so the count is the work that actually landed, and
   // the failure keeps its own line right where it happened.
   const steps = calls.filter(item => !toolCallIsContent(item.part));
   const [beatsOpen, setBeatsOpen] = useState(false);

--- a/packages/ui/src/chrome/thread/scrolling.ts
+++ b/packages/ui/src/chrome/thread/scrolling.ts
@@ -2,7 +2,7 @@ import type { UIMessage } from "ai";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { isAgentContext } from "./message-data.js";
 
-/** ENG-218 — windowing for long threads. Rendering a reopened 200-turn thread
+/** Windowing for long threads. Rendering a reopened 200-turn thread
     mounts every turn's DOM (and runs every entrance animation) at once. Instead
     we render only a trailing window of the most recent messages and reveal older
     ones in chunks when the reader scrolls to the top — the DOM stays bounded, so
@@ -56,7 +56,7 @@ export function useMessageWindow(messages: UIMessage[], listRef: React.RefObject
     entrance easing) never breaks the stick. */
 const BOTTOM_SLACK_PX = 32;
 
-/** ENG-213 — scroll management for the message list.
+/** Scroll management for the message list.
 
     Stick-to-bottom: while the reader is at the end, every content change
     (history load, streamed deltas, tool chips, approvals) keeps the latest
@@ -72,10 +72,10 @@ export function useStickToBottom(messages: UIMessage[], threadKey?: string, cont
   const stuckRef = useRef(true);
   const lastScrollHeightRef = useRef(0);
   const [unseen, setUnseen] = useState(false);
-  // Lane pick 3A — the jump affordance grew into a bar with a COUNT of turns
-  // that landed while scrolled away and a snippet of the newest text. Count =
-  // messages appended since the stick released; snippet = the latest turn's
-  // trailing text (best-effort, purely presentational).
+  // The jump affordance is a bar with a COUNT of turns that landed while
+  // scrolled away and a snippet of the newest text. Count = messages appended
+  // since the stick released; snippet = the latest turn's trailing text
+  // (best-effort, purely presentational).
   const [unseenCount, setUnseenCount] = useState(0);
   const seenLengthRef = useRef(messages.length);
 
@@ -87,7 +87,7 @@ export function useStickToBottom(messages: UIMessage[], threadKey?: string, cont
   useEffect(() => {
     const previousKey = previousThreadKeyRef.current;
     previousThreadKeyRef.current = threadKey;
-    // ENG-222 id mint is NOT a thread switch: a conversation started without
+    // A server-minted id is NOT a thread switch: a conversation started without
     // an id gets its server-minted thr_ fed back mid-first-stream (a host's
     // onThreadId loop), flipping this key while the reader is mid-read. The
     // messages are the same conversation — KEEP the growth baseline: zeroing
@@ -170,7 +170,7 @@ export function useStickToBottom(messages: UIMessage[], threadKey?: string, cont
       setUnseen(true);
       setUnseenCount(Math.max(1, messages.length - seenLengthRef.current));
     }
-    // contentRevision — ENG-215: turn-actions (Edit/Regenerate) mount below the
+    // contentRevision — turn-actions (Edit/Regenerate) mount below the
     // last turn the instant a stream settles (busy→false), adding height AFTER
     // the message-driven stick already ran. Re-run so the reader stays pinned.
   }, [messages, contentRevision]);

--- a/packages/ui/src/chrome/vendo-slot.tsx
+++ b/packages/ui/src/chrome/vendo-slot.tsx
@@ -230,13 +230,8 @@ export function VendoSlot({ id, appId: appIdProp, pin, onAuthor, discover = true
     subtitle?: string;
     /** Up to 3 prompt chips. Default: generic view-authoring prompts. */
     suggestions?: string[];
-    /** Primary button label (layout "button"). Default "Design a view". */
+    /** Primary button label. Default "Design a view". */
     ctaLabel?: string;
-    /** "button" (chips + primary CTA, default) or "chips-first" (chips are
-     *  the actions; a quiet "or describe your own…" link opens the composer). */
-    layout?: "button" | "chips-first";
-    /** Optional mark above the title. Default "none" (Yousef's pick). */
-    mark?: "none" | "sparkle" | "tile";
   };
   children?: ReactNode;
 }) {
@@ -317,17 +312,14 @@ export function VendoSlot({ id, appId: appIdProp, pin, onAuthor, discover = true
         </ChromeRoot>
       );
     }
-    // The invitation (pick S-A×S-D): accent-washed surface, real copy, up to
-    // three concrete suggestion chips, and (layout "button") a primary CTA.
-    // The skeleton stays behind at low opacity so it still reads as "a view
-    // goes here". No icon by default.
+    // The invitation: accent-washed surface, real copy, up to three concrete
+    // suggestion chips, and a primary CTA. The skeleton stays behind at low
+    // opacity so it still reads as "a view goes here".
     const invite = {
       title: emptyState?.title ?? "This space builds itself",
       subtitle: emptyState?.subtitle ?? "describe a view — it renders here, live on your data",
       suggestions: (emptyState?.suggestions ?? defaultSlotSuggestions).slice(0, 3),
       ctaLabel: emptyState?.ctaLabel ?? "Design a view",
-      layout: emptyState?.layout ?? "button",
-      mark: emptyState?.mark ?? "none",
     };
     return (
       <ChromeRoot>
@@ -335,14 +327,6 @@ export function VendoSlot({ id, appId: appIdProp, pin, onAuthor, discover = true
           <div className="fl-slot-ghost fl-slot-invite">
             <GhostSkeleton />
             <div className="fl-slot-cta" role="group" aria-label={invite.title}>
-              {invite.mark !== "none" ? (
-                <span className={`fl-invite-mark${invite.mark === "tile" ? " fl-invite-mark-tile" : ""}`} aria-hidden="true">
-                  <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="m12 3 1.4 4.1L17.5 8.5l-4.1 1.4L12 14l-1.4-4.1-4.1-1.4 4.1-1.4L12 3Z" />
-                    <path d="m18 14 .8 2.2L21 17l-2.2.8L18 20l-.8-2.2L15 17l2.2-.8L18 14Z" />
-                  </svg>
-                </span>
-              ) : null}
               <span className="fl-invite-title">{invite.title}</span>
               <small className="fl-invite-sub">{invite.subtitle}</small>
               {invite.suggestions.length > 0 ? (
@@ -357,11 +341,7 @@ export function VendoSlot({ id, appId: appIdProp, pin, onAuthor, discover = true
                   </div>
                 </>
               ) : null}
-              {invite.layout === "button" ? (
-                <button type="button" className="fl-invite-btn" onClick={author}>{invite.ctaLabel}</button>
-              ) : (
-                <button type="button" className="fl-invite-own" onClick={author}>or describe your own…</button>
-              )}
+              <button type="button" className="fl-invite-btn" onClick={author}>{invite.ctaLabel}</button>
             </div>
           </div>
         </div>

--- a/packages/ui/src/consumer-voice.ts
+++ b/packages/ui/src/consumer-voice.ts
@@ -1,21 +1,15 @@
 /**
- * spec §16 law 3 — the ONE definition of what a DEVELOPER string looks like.
+ * The ONE definition of what a DEVELOPER string looks like.
  *
- * A TEST ORACLE, and nothing else (ruling 14). It has exactly one reader: the
- * law's sweep over every chrome surface (test/chrome/consumer-voice-law.test.tsx
- * and its e2e twin). Every pattern here was seen LIVE on a consumer surface
- * during the redesign wave.
+ * A TEST ORACLE, and nothing else: its readers are the law's sweep over every
+ * chrome surface (test/chrome/consumer-voice-law.test.tsx and its e2e twin).
+ * Every pattern here was seen live on a consumer surface.
  *
- * It was briefly a RUNTIME gate too — `admissibleDescription` asked it whether a
- * descriptor's sentence could occupy a consent card's plain-words line. Ruling
- * 14 reversed that, and the reason generalizes: a regex set cannot be the
- * authority for what a person may read. It admitted raw JSON, raw exceptions and
- * model instructions (false negatives) while silently deleting good host copy
- * like "Funds do not leave your account until you approve." (false positives,
- * with no production trace). As an oracle its false negatives are just gaps in a
- * test; as a gate they were lies on a bank customer's screen. The runtime
- * answer is a fixed precedence ladder instead — `consentWords` in
- * chrome/build-beat.tsx.
+ * It is deliberately NOT a runtime gate: a regex set cannot be the authority
+ * for what a person may read — it admits raw JSON and model instructions while
+ * deleting good host copy like "Funds do not leave your account until you
+ * approve.". The runtime answer is a fixed precedence ladder instead
+ * (`consentWords` in chrome/build-beat.tsx).
  *
  * It lives OUTSIDE src/chrome deliberately: the law's source sweep scans that
  * tree for developer configuration phrases, and this file has to spell those
@@ -51,9 +45,4 @@ export function consumerVoiceViolation(text: string): string | undefined {
     if (hit !== null) return `${label}: ${hit[0]}`;
   }
   return undefined;
-}
-
-/** Whether a sentence may be shown to a person as-is. */
-export function isConsumerSafe(text: string): boolean {
-  return consumerVoiceViolation(text) === undefined;
 }

--- a/packages/ui/src/hooks/scripted-transport.ts
+++ b/packages/ui/src/hooks/scripted-transport.ts
@@ -10,8 +10,7 @@ import type { ChatTransport, UIMessage, UIMessageChunk } from "ai";
  * default.
  *
  * A cue's `chunk` is exactly one SSE `data:` payload of the live wire
- * (`UIMessageChunk`), so a recording of a real build replays verbatim — see
- * the recorder hook in `use-vendo-thread.ts` (`__vendoDirectorRecord`).
+ * (`UIMessageChunk`), so a capture of a real build replays verbatim.
  */
 export interface DirectorCue {
   /** Milliseconds to wait after the previous cue before emitting this chunk. */

--- a/packages/ui/src/hooks/use-vendo-thread.ts
+++ b/packages/ui/src/hooks/use-vendo-thread.ts
@@ -20,46 +20,6 @@ const THREAD_ID_HEADER = "x-vendo-thread-id";
 const THREAD_ID_PATTERN = /^thr_.+$/;
 
 /**
- * Director-mode recorder: when `globalThis.__vendoDirectorRecord` is truthy,
- * tee every live stream's SSE `data:` payloads (with elapsed timestamps) into
- * `globalThis.__vendoDirectorRecording`. Each entry converts 1:1 into a
- * ScriptedTransport cue, so a real build replays verbatim. Inert otherwise.
- */
-function recordStream(response: Response): void {
-  const globals = globalThis as {
-    __vendoDirectorRecord?: boolean;
-    __vendoDirectorRecording?: Array<{ at: number; chunk: unknown }>;
-  };
-  if (!globals.__vendoDirectorRecord || !response.body) return;
-  const recording = (globals.__vendoDirectorRecording ??= []);
-  const startedAt = Date.now();
-  const reader = response.clone().body!.getReader();
-  const decoder = new TextDecoder();
-  let buffered = "";
-  const pump = (): Promise<void> =>
-    reader.read().then(({ done, value }) => {
-      if (done) return;
-      buffered += decoder.decode(value, { stream: true });
-      const frames = buffered.split("\n\n");
-      buffered = frames.pop() ?? "";
-      for (const frame of frames) {
-        for (const line of frame.split("\n")) {
-          if (!line.startsWith("data: ")) continue;
-          const data = line.slice(6);
-          if (data === "[DONE]") continue;
-          try {
-            recording.push({ at: Date.now() - startedAt, chunk: JSON.parse(data) });
-          } catch {
-            // Malformed frame: skip — the recording is tooling, never load-bearing.
-          }
-        }
-      }
-      return pump();
-    });
-  void pump().catch(() => undefined);
-}
-
-/**
  * §3.4's status channel, RECEIVED.
  *
  * The part name is written out rather than imported: `VENDO_STATUS_PART` lives
@@ -171,7 +131,6 @@ export function useVendoThread(threadId?: string) {
             activeThreadIdRef.current = returnedThreadId;
             setEffectiveThreadId(returnedThreadId);
           }
-          recordStream(response);
           // ENG-353: beat /threads/:id/heartbeat while this turn streams so
           // the server can idle-abort the turn if this tab closes on a
           // runtime that never surfaces the disconnect (`next dev`).


### PR DESCRIPTION
## What

Two things, both proven by deletion rather than by a new mechanism:

1. **Six unreachable surfaces removed** (177 lines), each verified dead across every package, `examples/`, `fixtures/`, `corpus/`, `docs/`, `docs-site/`, `scripts/`, every test dir **and the `vendo-web` checkout** — none has a single reference in source or in a test.
2. **`src/chrome/thread/` stops shipping an internal changelog to customers.** `scripts/eject-templates-lib.mjs` copies every file in that directory verbatim into the host's own repo, so those comments are read outside this company. They were an internal decision log; they now state constraints in plain words.

Net: **183 insertions, 360 deletions** across 14 files.

## The dead code, and why each one could never fire

| Removed | Why it was unreachable |
| --- | --- |
| `recordStream` + its per-turn call (`hooks/use-vendo-thread.ts`) | Teed every SSE frame into `globalThis.__vendoDirectorRecording` when `__vendoDirectorRecord` was set. **Nothing has ever set either global** — the only other mention in the repo is a doc comment. So a `Response.clone` + reader pump + SSE re-parser shipped in the public bundle and ran on every single turn to return at its first guard. `ScriptedTransport` (the replay half) stays; it is real. |
| `subscribeConversationCommands` + `commandListeners` (`chrome/overlay-registry.ts`) | Zero references anywhere. The `Set` was always empty, so both `for (const listener of commandListeners)` loops were no-ops. |
| `MorphToast.dockTo` / `.holdMs` / `dockToRef` | The sole production caller (`thread/parts.tsx`) passes neither, and neither test does. `dockToRef.current` was always `undefined`, so both ternaries always took the anchor branch. |
| `VendoSlot.emptyState.mark` | No caller sets it; it defaults to `"none"`, so its inline SVG has **never rendered**. |
| `VendoSlot.emptyState.layout` | No caller sets it; `"chips-first"` appears nowhere in the repo but its own type union, so the "or describe your own…" branch was unreachable. |
| `isConsumerSafe` (`src/consumer-voice.ts`) | Zero references — not even from the three test files that use `consumerVoiceViolation`. |

`emptyState`'s other sub-props (`suggestions`, `title`, `subtitle`, `ctaLabel`) have real callers in `examples/demo-bank` and stay. The orphaned `.fl-invite-mark` CSS rules stay too — see *deferred* below.

## Verified but NOT fixed here — every one needs a test edit

Law: a bug fix lands with a failing test first, in the existing behavior-named suite. `packages/ui/test/**` belongs to `ui-test-estate-recut`, so per the coordinator's routing rule these **stop here and are handed back**, each with the suite that should carry its proof. All eight were confirmed against current code, not taken from the catalog.

| Bug | Where | Proof belongs in |
| --- | --- | --- |
| `ConnectTray` never resets `cancelledRef` on mount, so under StrictMode (Next dev default) the poll loop at `connect-dock.tsx:81` never runs one iteration and no error is thrown — the row sits on "Connecting…" forever and every other row's + stays disabled. `connect-card.tsx:103-110` and `connected-accounts-panel.tsx:85-102` both carry the reset **with a comment naming StrictMode**; the tray is the copy that missed it. | `chrome/connect-dock.tsx:214-217` | `test/chrome/connect.test.tsx` (:256 is the same test, for `ConnectCard`) |
| `reconnect` and `connectAhead` call `completeConnection` with `popup` omitted, so `window.open` fires **after** `await client.connections.initiate(...)` — refused outright by Safari and Firefox. No `onRedirect` either, so there is no fallback link: the user gets a spinner, the full 120s poll, then a dead end. | `chrome/connected-accounts-panel.tsx:163-167`, `:183` | `test/chrome/connect.test.tsx` (:41 asserts the ordering, for `ConnectCard` only) |
| `ShareDialog` never destructures the grants hook's `error`, and `useResource` leaves `data` at `EMPTY` while flipping `isLoading` false on throw. A network blip renders **two false statements at once**: "You don't have access to this app." and "Nobody else yet — it's just you." | `chrome/share-dialog.tsx:133`, `:274-278`, `:384-388` | `test/chrome/share-dialog.test.tsx` |
| The eager run-strip effect depends on `automations.automations`, which `useResource` replaces with a fresh array every 5s poll (`setData(next)` is unconditional). So the effect tears down every tick and sets `cancelled = true`; any `listRuns` slower than `pollMs` hits the cancelled branch, deletes its key and throws the response away, and the next run re-fires it. On a deployment where `/runs` is slower than 5s the strip **never appears** and the panel issues one discarded request per trigger per 5s forever. The sweep 30 lines below already fetches the same data and already writes `recent`. | `chrome/automations-panel.tsx:228-255` | `test/chrome/automations-liveness.test.tsx` |
| The approval auto-scroll effect lists `scroll` in its deps, and `useStickToBottom` returns a fresh object literal every render (`scrolling.ts:222`). It marks the id "seen" **before** the 80ms timer fires and the cleanup clears that timer, so any re-render within 80ms — routine during a stream — kills the scroll permanently. | `chrome/thread/index.tsx:114-137` | `test/chrome/thread-and-overlay.test.tsx` |
| Dropdown filters use `includesString` (a substring test) while the dropdown is an exact-value picker, so picking "paid" also keeps "unpaid" and "partially paid", and picking "1" keeps 10 and 100. Separately, both the option list and the search box read raw accessor values while cells display `applyFormat` output, so searching a money column for `$2,500` matches nothing. The flagship model-facing component returns wrong rows for a filter the model was told it could ask for. | `kit/data/data-table.tsx:115`, `:140-151` | `test/kit/data-table.test.tsx` |
| `theme.motion` is a documented host dial, but the reduced-motion check is written five ways and only `automations-panel`'s helper honours it. `pin-ceremony.ts:241` checks `matchMedia` alone and animates through the Web Animations API, which the stylesheet's `animation: none` rule cannot suppress — a host setting `motion: "reduced"` still gets the full 480ms ghost flight. `morph-toast.tsx` contradicts itself: `:63` computes timings from `matchMedia` while `:112` stamps `data-vendo-motion` from `theme.motion`, so the CSS kills the transition while the component waits out a 640ms travel that no longer happens. | `chrome/pin-ceremony.ts:241`, `chrome/morph-toast.tsx:63` vs `:112` | `test/chrome/pin-ceremony.test.tsx` |
| `useResource`'s poll has no `document.visibilityState` gate (`approvals-feed.ts:60` has the one that exists), so `GET /automations` keeps firing from a hidden tab forever. The hidden-tab test is green only because it filters requests to `/runs` — the one poll that *is* gated. | `hooks/use-resource.ts:73-86` | `test/chrome/automations-liveness.test.tsx:122` |

## Rejected leads, with reasons

- **`escapeIntent` is dead** (`split-view.tsx`) — **false.** Live production caller at `vendo-overlay.tsx:582`, with e2e coverage at `smoke.spec.ts:213`.
- **`VendoSlot`'s `pin` prop is exercised only by the e2e harness** — **false.** `packages/vendo/src/cli/playground/app/scenarios.tsx:195,206` uses it, and `scripts/build-embed.mjs` bundles that into the shipped playground embed.
- **`NoPolicyNotice` / `PolicyNoticeBody` are dead** — **false.** Public API, frozen by `export-surface.test.ts:29`, mounted by the harness `/notice` route and driven by three specs (`smoke`, `screenshots`, `accessibility`), documented in `docs/host-components.md:109`. Only `AutomaticPolicyNotice` and the `automaticPolicyNotice` prop are dead — and both are referenced by tests, so they are routed above rather than cut here.
- **`theme.ts`, `kit/schema.ts`, `kit/kit-prompt.ts` are deletable re-export hops** — they *are* pure hops, but all three are alive: `theme.ts` has 16 in-repo and 7 cross-package importers, and the other two are the `@vendoai/ui/kit` published surface.
- **Deduplicate `wire-types.ts` against the console schema** — not touched. That mirror is intentional.
- **`ui` wire error-code enum should collapse into core's parser**, and **the "any unparseable failure becomes a validation error" bug** — `client-impl.ts`, `client.ts` and `hooks/use-app.ts` are **held by the undo/rollback deletion**. Deferred, file ownership named.
- **`VendoPalette`'s command registry / `onCommand` is dead** — confirmed unreachable at runtime (the chip strip that called `select()` was removed; `vendo-overlay.tsx:398` says so outright, and `useApps()` fires a `GET /apps` per mount purely to build the invisible list). But `registerConversationCommands`, `getConversationCommands` and the `useApps` request are all asserted by `palette-defaults.test.tsx` and `workspace-palette-slot.test.tsx`, and `examples/demo-bank` passes a dead `onCommand`. Only the fully-unreferenced half is cut here; the rest is routed.
- **`summarizeArgs` is dead**, **`automaticPolicyNotice` is dead**, **`split-view`'s `toggle` action is dead** — all three confirmed dead in production, all three referenced only by tests. Routed, not cut.
- **`consumer-voice.ts` should move out of `src/`** — correct (it compiles into `dist/consumer-voice.js` with no `exports`-map subpath), but its three importers are all test files. Routed.

## Deferred, with the reason

- **`chrome-css.ts`** — the largest verbosity finding in the package (725 of 2,541 lines are comment-only, ~59 unresolvable citations) plus ~20 dead `.fl-*` selectors and ten double-declared ones. This file is the **source of the committed `packages/mcp/src/shim/shim-html.gen.ts` artifact**, `build:mcp-shim` is a manual script wired into no build, and this PR does not regenerate the shim. Needs that decision first. The `.fl-invite-mark` rules orphaned by this PR are part of that slice.
- **`vendo-overlay.tsx`, `automations-panel.tsx`, `thread/parts.tsx`** — met and left alone; these hold the four flagged cognitive-complexity findings (76, 64, 59, 55 — confirmed by running sonarjs against `src/chrome`).
- **Stripping unresolvable citations from the rest of `src/`** — I attempted this mechanically and reverted it: a regex catches head-of-comment labels and simple parentheticals, but ~60 files also carry mid-sentence `§` references, `Wave 7 H2`, `RULING 23`, `Devin/Greptile review`, `LANE D` and `ui-lane-panels pick B`, so the pass left the same files half-clean. It needs prose judgment per file, not a sweep. `src/chrome/thread/` is done here and carries **zero** residue.

## Verification

Nothing in this PR changes rendered output: the two removed `VendoSlot` options were the *unreachable* branches of their defaults, and the removed `MorphToast` props were always `undefined`, so every render path is byte-identical. Everything else is comments and an inert recorder. **No user-visible change, so no browser screenshots** — stated rather than assumed.

- `pnpm build --filter=@vendoai/ui...` → exit 0 (`[ui] assembled eject templates v0.8.0: thread (10 files)`)
- `packages/ui` own `tsc -p tsconfig.json --noEmit` → exit 0 (note: this does **not** cover `test/`, so changed symbols were grepped repo-wide including every test dir — zero hits)
- root `pnpm typecheck` → exit 0, 42/42 tasks
- root `pnpm lint --force` → exit 0; `dependency-guard: OK (15 packages checked)`, `portability-gate: all legs green`
- 24 affected suites, 235 tests, three batches, all passing: palette-defaults, palette-singleton, workspace-palette-slot, export-surface, lane-cards-picks, slot-cta-pin, consumer-voice-law, registry-components, thread-and-overlay, transcript-beats, composer, error-surface, streaming-polish, user-bubble, boot-bar, slot-states, embeds, ssr, hooks, eject-templates, grant-set-thread, tool-humanization, knowledge-citations, steering

## vendo-web

**No companion PR needed.** `vendo-web` imports exactly one `@vendoai/ui` entry — `vendoai-ui-next/tree` — from four files (`apps/console/lib/host-components/corpus.ts:3`, `apps/console/components/console/preview/app-doc-preview.tsx:5`, `.../preview-payload.ts:8`, `apps/console/tests/host-components-jail-runtime.test.ts:27`). It never imports `@vendoai/ui`, `/chrome` or `/kit`, and this PR touches no file under `src/tree/`. The `VendoPalette` hits in that repo are prose inside `docs/eval/knowledge-cloud/inputs/corpus.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed six unreachable UI surfaces and cleaned thread template comments so ejected code no longer includes internal change logs. No user-visible changes.

- **Refactors**
  - Deleted director SSE recorder from `useVendoThread`.
  - Removed `subscribeConversationCommands` and its listeners from `overlay-registry`.
  - Dropped `MorphToast` props `dockTo` and `holdMs` (always docks to the activity anchor; standard holds).
  - Removed `VendoSlot.emptyState.mark` and `VendoSlot.emptyState.layout` (CTA always renders as a button).
  - Removed `isConsumerSafe` (keep using `consumerVoiceViolation` in tests).
  - Rewrote comments in `src/chrome/thread/*` to plain, external-facing guidance only.

- **Migration**
  - No changes required for in-repo consumers or `vendo-web`; removed options were not referenced.
  - If external code used these APIs, remove usages:
    - `MorphToast`: drop `dockTo`/`holdMs`.
    - `VendoSlot.emptyState`: drop `mark`/`layout`.
    - `overlay-registry`: stop calling `subscribeConversationCommands` (use `registerConversationCommands`/`getConversationCommands`).
    - `consumer-voice`: replace `isConsumerSafe` with direct `consumerVoiceViolation` checks if needed.

<sup>Written for commit 97a9f1ebd8b6c60deeab7ffd79d0ca768ed30870. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

