### PR TITLE
test(harnesses,apps,core,telemetry,actions): six assertions that could not fail, and one leaking temp dir

### DIFF
--- a/packages/actions/src/runtime/host-files.test.ts
+++ b/packages/actions/src/runtime/host-files.test.ts
@@ -1,8 +1,8 @@
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp as mkdtempRaw, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 // A real workerd run reports a "not implemented" Error with NO .code at all
 // when a build's "workerd" custom condition didn't resolve to
@@ -22,6 +22,18 @@ vi.mock("node:fs/promises", async (importOriginal) => {
 
 import { readOptionalVendoJson } from "./host-files.js";
 import { readOptionalVendoJson as readOnEdge } from "./host-files-edge.js";
+
+// Every case here needs a real temp dir; without this the file left one behind
+// per case on every run.
+const roots: string[] = [];
+const mkdtemp = async (prefix: string): Promise<string> => {
+  const root = await mkdtempRaw(prefix);
+  roots.push(root);
+  return root;
+};
+afterEach(async () => {
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
 
 describe("host config files, node entry", () => {
   it("reads and parses a .vendo file, resolving the dir from a host root", async () => {

--- a/packages/apps/src/box-agent.test.ts
+++ b/packages/apps/src/box-agent.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { BOX_CONTROL_PORT, pushBoxEnv, readBoxManifest, requestAppWithBootRetry, runBoxEdit, type BoxAgentClock } from "./box-agent.js";
+import { pushBoxEnv, readBoxManifest, requestAppWithBootRetry, runBoxEdit, type BoxAgentClock } from "./box-agent.js";
 import type { SandboxMachine } from "./sandbox.js";
 import { fakeBoxSandbox } from "./testing/fake-box.js";
 
@@ -86,10 +86,6 @@ describe("box-agent control-port transport", () => {
     const machine = await boxOf();
     await pushBoxEnv(machine, { RESEND_API_KEY: "granted" });
     expect(machine.state.env.RESEND_API_KEY).toBe("granted");
-  });
-
-  it("uses the dedicated control port, not the app $PORT", () => {
-    expect(BOX_CONTROL_PORT).toBe(8811);
   });
 
   it("retries the app port past a post-resume 502 boot race, then returns the ready response", async () => {

--- a/packages/core/src/security/tree-dos.test.ts
+++ b/packages/core/src/security/tree-dos.test.ts
@@ -84,20 +84,3 @@ describe("validateAppDocument fn:-requires-a-machine", () => {
   });
 });
 
-describe("validateTree DoS bound gaps (recorded by-contract)", () => {
-  it("does NOT bound the byte size of node data / props (delegated upstream)", () => {
-    // GAP (intentional, recorded for visibility): validateTree caps node COUNT,
-    // query COUNT, and generated-component SOURCE bytes — but it does not bound
-    // the size of `data` or a node's `props`. A single node can carry a
-    // multi-hundred-KB `data` blob and still PASS. This DoS bound is delegated to
-    // an upstream request-body limit (the HTTP layer), not the core validator.
-    const bigBlob = "y".repeat(400_000); // ~400 KB, well past any component cap
-    const result = validateTree({
-      formatVersion: VENDO_TREE_FORMAT,
-      root: "n0",
-      nodes: [{ id: "n0", component: "Text", props: { huge: bigBlob } }],
-      data: { huge: bigBlob },
-    });
-    expect(result.ok).toBe(true);
-  });
-});

--- a/packages/harnesses/src/screen-agent.test.ts
+++ b/packages/harnesses/src/screen-agent.test.ts
@@ -176,12 +176,6 @@ describe("the loadout (§4.2 — assembly tools only)", () => {
     expect(offered).not.toContain("vendo_make");
   });
 
-  it("caps the run at SCREEN_STEPS — the cap IS the definition of cheap", () => {
-    // Not a magic number in the test either: the constant is the contract, and a
-    // budget of one is a specialist while twenty is a resident.
-    expect(SCREEN_STEPS).toBe(10);
-  });
-
   it("spends the budget and no more — the cap is the shipped loop's, not a comment", async () => {
     // The screen agent IS `vendo()` with a closed loadout, so the cap it declares
     // has to reach the loop that enforces it. A model that never stops is what

--- a/packages/harnesses/src/turn-tools.test.ts
+++ b/packages/harnesses/src/turn-tools.test.ts
@@ -7,7 +7,7 @@ import { CAPABILITY_MISS_TOOL_NAME } from "./capability-miss.js";
 import { FIND_TOOLS_TOOL_NAME } from "./tool-search.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { DiscoveryRails, MetaTool } from "./discovery.js";
-import { APPROVAL_WAIT_MS, createTurnTools, type MirrorEvent } from "./turn-tools.js";
+import { createTurnTools, type MirrorEvent } from "./turn-tools.js";
 import { boundRegistry, ctx, readTool, testGuard } from "./test-doubles.test-util.js";
 
 function harness(options: {
@@ -48,12 +48,6 @@ function discoveryDouble(equipped: string[]): DiscoveryRails {
     meta: new Map([metaTool(CAPABILITY_MISS_TOOL_NAME), metaTool(FIND_TOOLS_TOOL_NAME)]),
   };
 }
-
-describe("APPROVAL_WAIT_MS", () => {
-  it("is the frozen 90s from build contract §1.4", () => {
-    expect(APPROVAL_WAIT_MS).toBe(90_000);
-  });
-});
 
 describe("turn.tools.list", () => {
   it("returns the equipped tools, titling untitled descriptors by name", async () => {

--- a/packages/harnesses/src/vendo/compaction-trigger.test.ts
+++ b/packages/harnesses/src/vendo/compaction-trigger.test.ts
@@ -23,12 +23,7 @@
  */
 import { jsonSchema, tool, type ModelMessage, type ToolSet, type UIMessage } from "ai";
 import { describe, expect, it } from "vitest";
-import {
-  estimatePromptTokens,
-  shouldCompact,
-  PRESERVE_RECENT_TOKENS,
-  TRIGGER_RATIO,
-} from "./compaction.js";
+import { estimatePromptTokens, shouldCompact } from "./compaction.js";
 import { turnModelMessages } from "./loop.js";
 
 const message = (role: "user" | "assistant", text: string): ModelMessage =>
@@ -95,11 +90,6 @@ describe("the prompt estimate", () => {
 });
 
 describe("the trigger", () => {
-  it("carries the ported cline ratios", () => {
-    expect(TRIGGER_RATIO).toBe(0.81);
-    expect(PRESERVE_RECENT_TOKENS).toBe(20_000);
-  });
-
   it("trips at 81% of the window — NOT at 80%", () => {
     const config = { contextWindowTokens: 100_000 };
     expect(shouldCompact(81_000, config)).toBe(true);

--- a/packages/vendo-telemetry/src/events.test.ts
+++ b/packages/vendo-telemetry/src/events.test.ts
@@ -104,10 +104,4 @@ describe("cloud prop keys", () => {
     }
   });
 
-  it("does not include the producer-set lane markers", () => {
-    // `cloud` and `cloudKeyHash` are set by the client itself, never
-    // accepted from callers — so they must not be in any allowed set.
-    expect(CLOUD_PROP_KEYS.has("cloud")).toBe(false);
-    expect(CLOUD_PROP_KEYS.has("cloudKeyHash")).toBe(false);
-  });
 });


### PR DESCRIPTION
Second slice of a *verified* disposition of the map's `## Test estate` section. The map's pattern 4 is "tests that cannot fail". It is a real pattern — and it is **six blocks, ~41 lines**, not a mass.

## The six

Each was read together with the code around it. In every case the test that actually proves the constant is doing its job sits immediately beside it, and stays.

| File | What it asserted | Why it can't fail | What proves it instead |
|---|---|---|---|
| `harnesses/turn-tools.test.ts` | `APPROVAL_WAIT_MS === 90_000` | constant vs its own literal | nothing in the file exercises the 90s wait — this was the whole `describe` |
| `harnesses/screen-agent.test.ts` | `SCREEN_STEPS === 10` | same | next `it` feeds `SCREEN_STEPS + 1` turns, asserts `model.calls === SCREEN_STEPS` |
| `harnesses/vendo/compaction-trigger.test.ts` | `TRIGGER_RATIO === 0.81`, `PRESERVE_RECENT_TOKENS === 20_000` | same | next `it`: "trips at 81% of the window — NOT at 80%" |
| `apps/box-agent.test.ts` | `BOX_CONTROL_PORT === 8811` | titled "uses the dedicated control port, **not the app $PORT**" but never compares the two | `fake-box.ts:109` routes on it; `box-harness.test.ts` drives the real port |
| `telemetry/events.test.ts` | `CLOUD_PROP_KEYS.has("cloud") === false` | a hand-written `Set` visibly lacking the string | the `it` above crosses `CLOUD_PROP_KEYS` against `EVENT_ALLOWLIST` |
| `core/security/tree-dos.test.ts` | `ok === true` for a 400 KB blob, to record that no byte bound exists | **worse than unfalsifiable — it goes RED the day someone adds the bound** | a gap belongs in prose, not in a test that punishes its own fix |

Every constant still has real production callers (checked repo-wide); nothing became a dead export.

## Plus one bug the duplication hid

`actions/runtime/host-files.test.ts` calls `mkdtemp` **five times** and had no `afterEach` and no `rm` anywhere. It is the only one of the 23 temp-dir harnesses in `packages/actions` with no cleanup, so it leaked a directory per case on every run. Now a cleanup stack.

## What I refused

Two candidates that look identical to the six and are not:

- **`apps/checking/deps.test.ts`'s `it("has source files to check")` stays.** It reads as a test guarding its own glob — but that is what it is *for*. If the glob broke, the architecture rule beside it would pass vacuously. A positive control is not a tautology.
- **`core/build-deadlines.test.ts`'s `BUILD_WATCHDOG_MS === 4 * 60_000` stays.** Weak, but it is the only pin on an absolute timeout a user waits through, and the two lines under it assert a real relation.

## Gates — one suite at a time, per package

| Package | Result | Coverage vs floor |
|---|---|---|
| harnesses | 565 pass / 14 skip | — |
| telemetry | 123 pass | — |
| core | 1097 pass | **97.06%** vs 97 |
| apps | 1045 pass / 18 skip | 92.84% vs 88 |
| actions | 616 pass / 4 skip | 92.07% vs 90 |

`pnpm lint` green — dependency-guard OK (15 packages), portability-gate all legs green. `turbo typecheck` green for all five.

Worth recording, because it bit repeatedly: **11 of 15 packages exclude `*.test.ts` from `typecheck`**, so I ran `tsc` over `src/**` including tests for each. It reports 9 errors in `apps/box-agent.test.ts` — the same 9 are on `origin/main` (verified by stashing), so this PR adds none. Not fixed here; that is its own change.

## vendo-web

No-op. Zero references to any deleted symbol or touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed six unfalsifiable constant-vs-literal assertions across tests and added temp-dir cleanup to stop leaks in `packages/actions`. Keeps the behavioral tests that prove the contracts; no production code changes.

- **Bug Fixes**
  - `packages/actions/src/runtime/host-files.test.ts`: wrap `mkdtemp`, add `afterEach` with `rm` to clean temp dirs and prevent one-per-case leaks.

- **Refactors**
  - Deleted constant-equality checks in tests (e.g., `APPROVAL_WAIT_MS`, `SCREEN_STEPS`, `TRIGGER_RATIO`, `PRESERVE_RECENT_TOKENS`, `BOX_CONTROL_PORT`, `CLOUD_PROP_KEYS`) and kept the adjacent behavioral assertions that enforce the same contracts.

<sup>Written for commit ef1a1cb1e69fb9d1dcdb0bebde50f3f8101ca21f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

