### PR TITLE
fix(harnesses): every rung bounds a message, including machine: "local"

### DIFF
--- a/.changeset/tame-moons-listen.md
+++ b/.changeset/tame-moons-listen.md
@@ -1,0 +1,15 @@
+---
+"@vendoai/harnesses": patch
+---
+
+`claudeCode({ machine: "local" })` now bounds a message the way the sandbox path
+always has. A live session's turn ends on a `result`, and a `result` that never
+arrives — an interrupted session, or a mid-build steer the model folded into the
+turn already running — used to leave `send()` pending forever. Because
+`ClaudeSession` answers pushed messages strictly in order, that took the whole
+thread with it: the user's next message waited behind a turn that had already
+silently lost, for the life of the process.
+
+Both rungs now share one `MESSAGE_BUDGET_MS`. On the local rung a breach
+interrupts the turn, drops the session, and throws — the disk stays warm, so the
+next message opens a fresh session that resumes rather than a cold start.

--- a/packages/harnesses/src/claude-code/box.ts
+++ b/packages/harnesses/src/claude-code/box.ts
@@ -38,7 +38,7 @@
 import { VENDO_DEV_PORT, VENDO_DEV_PORT_ENV, VendoError } from "@vendoai/core";
 import type { CheckoutFile, SyncFile, TreeState } from "../materialize.js";
 import { emptyTree } from "../materialize.js";
-import type { SessionMachine, SessionMessage } from "./machine.js";
+import { MESSAGE_BUDGET_MS, type SessionMachine, type SessionMessage } from "./machine.js";
 
 /** The subset of `SandboxAdapter` (`@vendoai/apps`) a session box needs.
  *  Structural so this subpath never widens the package's type surface.
@@ -73,8 +73,6 @@ const CONTROL_PORT = 8811;
 export const BOX_IDLE_TTL_MS = 5 * 60_000;
 /** The box holds each poll open this long before answering empty. */
 const POLL_WAIT_MS = 10_000;
-/** One message's bound. Longer than the approval wait, by design. */
-const MESSAGE_BUDGET_MS = 15 * 60_000;
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();

--- a/packages/harnesses/src/claude-code/local-steer-budget.test.ts
+++ b/packages/harnesses/src/claude-code/local-steer-budget.test.ts
@@ -1,0 +1,175 @@
+/**
+ * `machine: "local"` had no message budget, and a steer that the SDK answers
+ * with FEWER results than the session counted wedged the whole thread.
+ *
+ * **The seam, and why this file doubles the SDK rather than the session.**
+ * `createClaudeSession` (`@vendoai/apps/claude-turn`) counts the extra `result`
+ * messages a steer is expected to produce, and `local.ts` awaits `send()` until
+ * one of them settles the turn. Those are a producer and a consumer of the same
+ * invariant, and every existing test doubles one of them:
+ *
+ *   - `local-session.test.ts` doubles the whole `ClaudeSession`, so its `steer`
+ *     has no counter at all;
+ *   - `claude-session.test.ts` (in `@vendoai/apps`) doubles the SDK with a loop
+ *     that yields exactly one `result` per user message it reads — which IS the
+ *     counter's assumption, so the double can never disagree with it.
+ *
+ * So the counter's one-sidedness had no honest test anywhere. Here the session is
+ * REAL and only the SDK — genuinely a third party — is a double, and it answers
+ * the way `ClaudeSession.steer`'s own doc says the SDK behaves: the steered words
+ * are handed to the model at its next step boundary and ride the SAME turn, so
+ * the turn produces ONE result, not two.
+ *
+ * Against that, the count is one too high: the final `result` decrements the
+ * counter instead of settling the turn, and `send()` never resolves. The counter
+ * is safe in the other direction (a surplus result merely settles early, which is
+ * the trap it was built for) — it is only the SHORTFALL that hangs, and
+ * `createClaudeSession.interrupt` already names that hazard: "the results the
+ * steers were counting on may never arrive … the caller's promise would hang to
+ * the message budget". The box rung HAS that budget. This rung did not.
+ */
+import { describe, expect, test } from "vitest";
+import { createClaudeSession } from "@vendoai/apps/claude-turn";
+import { disposeLocalSessions, localMachine } from "./local.js";
+
+/** Well under the test timeout below: a budget is the hang-detector here, not a
+ *  second speed limit (see the testing note in CLAUDE.md). */
+const BUDGET_MS = 500;
+
+/**
+ * An SDK that ABSORBS a mid-turn message into the turn already running.
+ *
+ * One `result` for the whole turn, no matter how many user messages the input
+ * stream carried — the behaviour `ClaudeSession.steer` documents. The input loop
+ * stays open afterwards, exactly as a live session's does, so `end()` still has
+ * something to close.
+ */
+function absorbingSdk(prompts: string[]) {
+  return {
+    query: ({ prompt }: { prompt: unknown }) => ({
+      async *[Symbol.asyncIterator]() {
+        yield { type: "system", subtype: "init", session_id: "sess_absorb", model: "claude-test" };
+        for await (const message of prompt as AsyncIterable<{ message: { content: unknown } }>) {
+          const content = message.message.content;
+          prompts.push(typeof content === "string" ? content : "");
+          // Only the FIRST message opens a turn. Speaking gives the harness the
+          // one window a steer can land in.
+          if (prompts.length > 1) continue;
+          yield {
+            type: "assistant",
+            uuid: "asst_0",
+            message: { content: [{ type: "text", text: "building it" }] },
+          };
+          yield {
+            type: "result",
+            subtype: "success",
+            session_id: "sess_absorb",
+            usage: { input_tokens: 10, output_tokens: 4 },
+          };
+        }
+      },
+    }),
+  };
+}
+
+describe("machine: \"local\" — a steer the SDK absorbs must not hang the thread", () => {
+  test("the turn ends on the budget, loudly, instead of waiting forever", async () => {
+    const prompts: string[] = [];
+    const threadId = `thr_local_absorb_${Math.random().toString(36).slice(2)}`;
+    const machine = await localMachine({
+      threadId,
+      env: {},
+      messageBudgetMs: BUDGET_MS,
+      // The REAL session, over a doubled SDK.
+      openSession: (input) => createClaudeSession({ ...input, sdk: absorbingSdk(prompts) } as never),
+    });
+
+    let steered: Promise<boolean> | undefined;
+    const sending = machine.send({
+      prompt: "build me a reconciliation workbench",
+      // Mid-turn, from inside the SDK's own drain — the real situation.
+      emit: () => { steered ??= machine.steer("group by client instead"); },
+    });
+
+    // Before the budget existed this promise stayed pending for the life of the
+    // process and took the test's own timeout with it. Awaited FIRST because the
+    // steer below is fired from inside the SDK's drain, a turn of the loop later.
+    await expect(sending).rejects.toThrow(/budget/);
+    // The words DID land: this is not a refused steer, it is a landed one whose
+    // result never came.
+    await expect(steered).resolves.toBe(true);
+    expect(prompts).toEqual(["build me a reconciliation workbench", "group by client instead"]);
+
+    await disposeLocalSessions();
+  }, 20_000);
+
+  test("the next turn on that thread still runs — one wedged turn is not a dead thread", async () => {
+    // The queue inside `createClaudeSession` is strictly ordered, so a `send()`
+    // that never settles blocks every later one behind it. Ending the turn is
+    // only half the fix; the wedged session has to be DROPPED, or the thread is
+    // finished for the life of the process.
+    const first: string[] = [];
+    const second: string[] = [];
+    const threadId = `thr_local_absorb_next_${Math.random().toString(36).slice(2)}`;
+    let opens = 0;
+    const options = {
+      threadId,
+      env: {},
+      messageBudgetMs: BUDGET_MS,
+      openSession: (input: Record<string, unknown>) => {
+        opens += 1;
+        // Turn 1 gets the absorbing SDK; turn 2 gets a healthy one.
+        const sdk = opens === 1 ? absorbingSdk(first) : healthySdk(second);
+        return createClaudeSession({ ...input, sdk } as never);
+      },
+    };
+
+    const wedging = await localMachine(options as never);
+    let steered: Promise<boolean> | undefined;
+    await expect(wedging.send({
+      prompt: "one",
+      emit: () => { steered ??= wedging.steer("and also two"); },
+    })).rejects.toThrow(/budget/);
+    await expect(steered).resolves.toBe(true);
+
+    // A fresh turn, as the runtime would open it.
+    const next = await localMachine(options as never);
+    const events: unknown[] = [];
+    await next.send({ prompt: "three", emit: (event) => events.push(event) });
+
+    expect(second).toEqual(["three"]);
+    expect(events).toContainEqual({ type: "text", delta: "re: three" });
+    // The wedged session was replaced rather than reused.
+    expect(opens).toBe(2);
+
+    await disposeLocalSessions();
+  }, 20_000);
+});
+
+/** One result per message, the ordinary case — nothing here is under test except
+ *  that the thread is alive again. */
+function healthySdk(prompts: string[]) {
+  return {
+    query: ({ prompt }: { prompt: unknown }) => ({
+      async *[Symbol.asyncIterator]() {
+        yield { type: "system", subtype: "init", session_id: "sess_ok", model: "claude-test" };
+        for await (const message of prompt as AsyncIterable<{ message: { content: unknown } }>) {
+          const content = message.message.content;
+          const text = typeof content === "string" ? content : "";
+          prompts.push(text);
+          yield {
+            type: "assistant",
+            uuid: `asst_${prompts.length}`,
+            message: { content: [{ type: "text", text: `re: ${text}` }] },
+          };
+          yield {
+            type: "result",
+            subtype: "success",
+            session_id: "sess_ok",
+            usage: { input_tokens: 1, output_tokens: 1 },
+          };
+        }
+      },
+    }),
+  };
+}

--- a/packages/harnesses/src/claude-code/local.ts
+++ b/packages/harnesses/src/claude-code/local.ts
@@ -50,7 +50,7 @@ import { VendoError } from "@vendoai/core";
 import type { ClaudeTurnEvent } from "@vendoai/apps/claude-turn";
 import type { SyncFile, TreeState } from "../materialize.js";
 import { emptyTree, inWritableMount } from "../materialize.js";
-import type { SessionMachine, SessionMessage } from "./machine.js";
+import { MESSAGE_BUDGET_MS, type SessionMachine, type SessionMessage } from "./machine.js";
 
 /** The session runner is shared with the box — one implementation, two homes. Its
  *  OWN subpath, so importing it never drags the render seam's `./internal` in,
@@ -187,6 +187,33 @@ export interface LocalMachineOptions {
   env: Record<string, string>;
   /** Test seam — the real factory is loaded from {@link RUNNER}, with the SDK. */
   openSession?: (input: Record<string, unknown>) => LocalSession["session"];
+  /** Test seam; production uses {@link MESSAGE_BUDGET_MS}. */
+  messageBudgetMs?: number;
+}
+
+/** The sentinel the budget resolves with — a value `send()` can never produce,
+ *  so "finished" and "ran out of time" stay distinguishable. */
+const OUTRAN = Symbol("outran");
+
+/**
+ * `work`, or the budget — whichever lands first. `true` means the work finished.
+ *
+ * A rejection from `work` propagates as itself: a turn that FAILED is a fact the
+ * caller already knows how to carry, and dressing it up as a timeout would lose
+ * the session's own sentence. The timer is `unref`ed so an ordinary fast turn
+ * never holds the process open waiting for a budget nobody needs.
+ */
+async function withinBudget(work: Promise<void>, budgetMs: number): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const budget = new Promise<typeof OUTRAN>((resolve) => {
+    timer = setTimeout(() => resolve(OUTRAN), budgetMs);
+    timer.unref?.();
+  });
+  try {
+    return await Promise.race([work, budget]) !== OUTRAN;
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
 }
 
 export async function localMachine(options: LocalMachineOptions): Promise<SessionMachine> {
@@ -328,8 +355,31 @@ export async function localMachine(options: LocalMachineOptions): Promise<Sessio
         ? undefined
         : () => void held.session?.interrupt().catch(() => undefined);
       if (stop !== undefined) message.signal!.addEventListener("abort", stop, { once: true });
+      const running = held.session!;
       try {
-        await held.session!.send(message.prompt);
+        const sending = running.send(message.prompt);
+        if (!await withinBudget(sending, options.messageBudgetMs ?? MESSAGE_BUDGET_MS)) {
+          // A turn that outran its budget is one nobody can reason about any
+          // more — and it is not just this turn at stake. `ClaudeSession` answers
+          // pushed messages in order, so a `send()` left pending holds every
+          // later turn on this thread behind it: the user's next message would
+          // wait on a turn that already lost, silently, for the life of the
+          // process. So the SESSION goes, not just the turn. The disk stays warm
+          // (files and the SDK's own session file are still there), which makes
+          // the next message a fresh session that resumes rather than a cold
+          // start — the same recovery the box path takes when its box is gone.
+          void sending.catch(() => undefined);
+          await running.interrupt().catch(() => undefined);
+          if (held.session === running) held.session = undefined;
+          // Fire and forget on purpose: `end()` waits on the SDK's own loop, and
+          // waiting on the loop we just declared stuck is how one hang becomes
+          // two.
+          void running.end().catch(() => undefined);
+          throw new VendoError(
+            "sandbox-unavailable",
+            "the local session's message outran its budget",
+          );
+        }
       } finally {
         if (stop !== undefined) message.signal!.removeEventListener("abort", stop);
         // The turn is over; nothing may be attributed to it from here on.

--- a/packages/harnesses/src/claude-code/machine.ts
+++ b/packages/harnesses/src/claude-code/machine.ts
@@ -16,6 +16,22 @@
 import type { ClaudeTurnEvent } from "@vendoai/apps/claude-turn";
 import type { CheckoutFile, SyncFile, TreeState } from "../materialize.js";
 
+/**
+ * How long ONE message may run before the machine gives up on it. Longer than
+ * the approval wait, by design.
+ *
+ * It lives HERE, next to the port, because both rungs owe the caller the same
+ * answer and a second literal is how the two drift. It is the only thing
+ * standing between `send()` and a wait with no end: the session's own turn
+ * boundary is a `result` message, and a `result` that never arrives — an
+ * interrupted session, a steer the model absorbed into the turn already
+ * running — is indistinguishable from a turn that is merely slow. The box rung
+ * has always had this bound. The local rung ran without one until it was found
+ * to wedge a whole thread, because `ClaudeSession`'s send queue is strictly
+ * ordered: one turn that never settles is every later turn on that thread.
+ */
+export const MESSAGE_BUDGET_MS = 15 * 60_000;
+
 /** What opening a session needs. Fixed for the life of the session.
  *
  *  `tools` is deliberately absent: the session reaches the host's tools through


### PR DESCRIPTION
## The finding, verified

`machine: "local"` had no bound on a message, and the steer counter in
`createClaudeSession` (`@vendoai/apps/claude-turn`) is one-sided: safe when the
SDK produces *more* results than expected, a permanent hang when it produces
*fewer*.

All three sub-problems confirmed from the code:

1. **The whole thread wedges, not one turn.** `ClaudeSession.send` is
   `queue.then(run, run)` over a strictly ordered queue. A `sendOne` whose
   `settleTurn` never fires leaves that chain pending forever, so every later
   turn on the thread is pending behind it. Proven by a test that hung for the
   full 20s timeout on turn 2.
2. **`machine: "local"` had no budget at all.** `box.ts` bounds its poll loop at
   `MESSAGE_BUDGET_MS` and interrupts on breach; `local.ts:332` was a bare
   `await held.session!.send(...)`. The clincher is in the counter's own code —
   `interrupt()` says "the caller's promise would hang **to the message
   budget**". That mitigation did not exist on the rung a developer runs.
3. **The only test asserting the invariant baked it in.**
   `claude-session.test.ts`'s `fakeSessionSdk` yields exactly one `result` per
   user message it reads — which *is* the counter's assumption, so the double
   can never disagree with it. `local-session.test.ts` doubles the whole
   `ClaudeSession`, so its `steer` has no counter at all. Neither side could
   ever fail.

## What shipped

One `MESSAGE_BUDGET_MS` (15 min, unchanged) moves to `machine.ts`, next to the
port both rungs implement. On the local rung a breach interrupts the turn,
**drops the session**, and throws `VendoError("sandbox-unavailable")`.

Dropping is the part that unwedges the thread — ending the turn alone would
leave the stuck queue in place. The disk stays warm, so the next message opens a
fresh session that *resumes* rather than cold-starting: the same recovery the box
path already takes when its box is gone.

**A loud failure was chosen over every alternative.** A hang reports nothing,
blocks everything queued behind it, and is indistinguishable from slowness. No
budget was shortened and no guard weakened: this adds a bound where there was
none, at the value the sibling rung already used. `machine: "local"` stays — it
is bounded, not removed.

## The test: hermetic, and what it does and does not prove

`local-steer-budget.test.ts` runs the **real** `createClaudeSession` — the real
counter — through the **real** `local.ts` send path, doubling only the SDK, which
is a genuine third party rather than the counterparty across this seam. The
double behaves the way `ClaudeSession.steer`'s own doc says the SDK behaves: the
steered words ride the same turn, so the turn yields one `result`, not two.

Both tests hung for their full 20s timeout before the fix and pass in ~1.1s
after.

**It proves** the hang is reachable through production code from a landed steer,
that it takes the thread and not just the turn, and that the bound and the
session-drop fix both.

**It does not prove** which way the real Agent SDK behaves on a mid-turn push —
whether a steer yields its own `result` or is absorbed. **A live-SDK test could
not be run here**: no `ANTHROPIC_API_KEY` is reachable in this environment, and
the behaviour is decided inside the compiled `claude` CLI, not the JS wrapper, so
it cannot be read off the installed package either. That gap is *why the bound
matters* rather than an argument against it — the counter is unguarded in the
shortfall direction regardless of which way today's SDK happens to fall, and
`interrupt()` already documents one cause (a stopped session) that has nothing to
do with steering.

## Gates

- `pnpm build --filter=@vendoai/harnesses...` — 4/4 ✅
- `packages/harnesses` suite — **570 passed | 14 skipped, 0 failed** ✅
- `tsc -p tsconfig.json --noEmit` — clean ✅
- **The typecheck trap:** harnesses' tsconfig `exclude`s `src/**/*.test.ts`, so
  the package's own typecheck never saw the new file. Re-ran with `exclude: []`:
  0 errors in `local-steer-budget.test.ts` and 0 in the three files touched. The
  63 errors it surfaces are pre-existing, in other packages' test files.
- `pnpm lint --filter=@vendoai/harnesses` — dependency-guard + all portability
  legs green ✅

## vendo-web: no-op

Grepped `MESSAGE_BUDGET`, `localMachine`, `messageBudget`, `createClaudeSession`,
`steeredResults` — zero hits. The single `steer` match is the English word in a
comment: `apps/console/components/console/preview/previewable-doc.ts:49` ("let it
steer the jail"), about a preview jail. No companion PR needed. Nothing changed
here crosses a seam `vendo-web` reads — `localMachine`, `LocalMachineOptions` and
`MESSAGE_BUDGET_MS` are all internal to `@vendoai/harnesses` (not re-exported
from `.` or `./claude-code`), which is also why the changeset is `patch`.

## Not fixed, and out of file-set

**The root cause is not in this PR.** `steeredResults` and the double that bakes
in its assumption live in `packages/apps/src/claude-turn.ts` and
`packages/apps/src/claude-session.test.ts` — outside this piece's file-set
(`packages/apps/**` has live pieces). What landed is the floor: no rung is
unbounded, and no wedged turn takes its thread. The counter can still
over-count; it now costs one loud, bounded turn instead of the thread.

Also worth a follow-up: the finding named
`packages/harnesses/src/claude-code/claude-turn.ts`, which **does not exist** —
the counter is in `packages/apps`, and `local.ts`'s header comment references it
by bare filename, which is probably how the catalog acquired the wrong path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a message budget to `machine: "local"` to prevent thread hangs when a steer produces fewer `result` events than counted. `MESSAGE_BUDGET_MS` is now shared across rungs; on breach, the local session is dropped and an error is thrown so the next turn can resume cleanly.

- **Bug Fixes**
  - Shared `MESSAGE_BUDGET_MS` (15m) moved to `machine.ts`; `box.ts` now imports it.
  - `local.ts`: wrap `send()` with the budget; on timeout, interrupt and drop the session, then throw `VendoError("sandbox-unavailable")`. Added `messageBudgetMs` as a test seam.
  - Added `local-steer-budget.test.ts` to drive the real `createClaudeSession` through the local path and verify the fix and next-turn recovery.

<sup>Written for commit 7b1c1e62ef17e998a59567f02e814f42eced1182. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

