### PR TITLE
test(ui): raise the coverage floor to 90 and stop the comment lying about it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
       - name: Test with coverage (PGlite + PostgreSQL)
         run: pnpm turbo run test:coverage --continue --concurrency=2 ${{ matrix.filters }}
 
-  # The per-package coverage floors (vendo 78 / store 84 / ui 74, each in the
+  # The per-package coverage floors (vendo 78 / store 84 / ui 90, each in the
   # package's vitest config) live HERE, because a floor is only meaningful
   # against the whole suite's coverage. vitest replays the shards' blob reports
   # without re-running a single test, then reports and enforces.

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -12,8 +12,11 @@ export default defineConfig({
       // against the whole suite's merged coverage rather than any single shard.
       // RATCHET — this number only ever rises: when it goes red, add coverage,
       // never lower the floor.
-      // Last set 2026-08-07 to 90, against a measured 91.05% on main. Branches
-      // are not floored (88.69% when this was set).
+      // Last set 2026-08-08 to 90, against a measured 91.65% lines (11509/12557)
+      // on main — re-measured through the merge path after the undo/rollback
+      // deletion and four ui fixes landed. The 1.65 points of slack are
+      // deliberate: a floor with no room is a floor everyone learns to bypass.
+      // Branches are not floored (88.86% when this was set).
       thresholds: { lines: 90 },
     },
     environment: "jsdom",

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -8,9 +8,13 @@ export default defineConfig({
       reporter: ["text", "json-summary"],
       include: ["src/**/*.{ts,tsx}"],
       exclude: ["src/**/*.test.{ts,tsx}", "src/**/*.test-util.{ts,tsx}"],
-      // Ratcheted line-coverage floor (ENG-255): set at/just below the measured
-      // value so it can only rise. Regression below this fails CI.
-      thresholds: { lines: 74 },
+      // Line-coverage floor (ENG-255). CI enforces it in the coverage-merge job,
+      // against the whole suite's merged coverage rather than any single shard.
+      // RATCHET — this number only ever rises: when it goes red, add coverage,
+      // never lower the floor.
+      // Last set 2026-08-07 to 90, against a measured 91.05% on main. Branches
+      // are not floored (88.69% when this was set).
+      thresholds: { lines: 90 },
     },
     environment: "jsdom",
     include: ["test/**/*.test.ts?(x)"],


### PR DESCRIPTION
## What

`packages/ui` line-coverage floor **74 → 90**, and the comment above it rewritten
to state the ratchet policy honestly. `.github/workflows/ci.yml`'s floor list
updated to match (`ui 90`).

## Why

The floor sat ~17 points below reality, so it gated nothing. Worse, the comment
claimed it was "set at/just below the measured value so it can only rise" —
false. A comment that lies about a gate is worse than no comment.

## Re-measured on current main (`fed58ab57`)

The original measurement was taken on main `0d8f419c0`. Six PRs have landed in
`packages/ui` and its deps since — **#1036** (undo/rollback deleted across five
packages), **#1009 / #1027 / #1029 / #1040** (four ui bug fixes), **#1047** — so
it was re-measured through CI's own enforcement path: both ui shards with
`--coverage --coverage.thresholds.lines=0 --reporter=blob`, then
`vitest run --merge-reports --coverage`. The floor is only meaningful against
merged coverage, never a single shard. 119 files / 1068 tests, all passing.

| metric | measured (`fed58ab57`) | previously (`0d8f419c0`) | floor |
|---|---|---|---|
| **lines** | **91.65%** (11509/12557) | 91.05% (11371/12488) | **90** |
| branches | 88.86% (4620/5199) | 88.69% (4527/5104) | none |
| functions | 89.32% (803/899) | 89.05% | none |

**This PR's own `coverage-merge` job independently reports the same 91.65 / 88.86**,
so the local figure and CI's agree exactly.

## What moved, and why 90 is still the right floor

The undo/rollback deletion was predicted here to *lower* the ratio to ~90.88%,
because it removed source better covered than the package average. It did not:
the four ui fixes that landed alongside it each shipped tests, and the net moved
**up** 0.60 points. Total source grew by 69 lines while covered lines grew by 138.

So the floor stays at **90**, now with **1.65 points of headroom** rather than the
1.05 the original measurement implied — roughly 207 covered lines of slack.

Deliberately *not* raised to 91: that would cut headroom to 0.65 points (~82
lines), and a gate with no room is a gate people learn to bypass. Which is not
hypothetical — see below.

Enforcement was verified live, not assumed: replaying the same merged report at
`--coverage.thresholds.lines=92` fails with
`ERROR: Coverage for lines (91.65%) does not meet global threshold (92%)`, and at
90 it passes.

## Pre-existing red on main (not from this PR)

`main` at `fed58ab57` is already failing CI, and this PR inherits exactly that
failure and no other:

```
ERROR: Coverage for lines (96.99%) does not meet global threshold (97%)
@vendoai/core#test:coverage
```

`packages/core/vitest.config.ts` floors lines at **97** and core now measures
**96.99%** — short by 0.01 points, blocking every PR in the repo. It is the same
pathology this PR is written against, in the opposite direction: a floor pinned
so tight to its measurement that ordinary work trips it. Out of scope here;
flagged for a separate fix.

## Scope

`packages/ui/vitest.config.ts` + one comment line in `.github/workflows/ci.yml`.
**Zero source files, zero test files** — no tests were written to move this
number. `vendo 78` and `store 84` in the ci.yml comment were re-checked against
their configs and are still correct. No changeset: `vitest.config.ts` is not
published and the threshold has no effect on package output or API.
