### PR TITLE
chore(release): stay pre-1.0 and give the service key its changelog entry

### DIFF
--- a/.changeset/a-backend-gets-in-with-a-service-key.md
+++ b/.changeset/a-backend-gets-in-with-a-service-key.md
@@ -1,0 +1,19 @@
+---
+"@vendoai/mcp": minor
+"@vendoai/vendo": minor
+"@vendoai/core": patch
+---
+
+A host's own backend gets in at the MCP door with a service key — no per-user
+OAuth, no browser.
+
+`createVendo({ mcp: { serviceAuth: { keys: [...] } } })` arms the door's own
+`/token` endpoint for RFC 8693 token exchange: the backend POSTs
+`grant_type=urn:ietf:params:oauth:grant-type:token-exchange` with
+`client_id=vendo-service`, the key as `client_secret`, and one of its own user
+ids as `subject_token`, and gets back a ten-minute `vmat_` bearer token for
+that user. Keys are opaque strings the host mints itself (`openssl rand -hex
+32`); the door stores only their hashes, compares in constant time, and
+answers every failure with the same `invalid_client`. No refresh tokens —
+rotation is "exchange again." Audit rows carry a `svc:<hash>` client id so
+service-minted sessions are distinguishable from interactive ones.

--- a/.changeset/one-component-family.md
+++ b/.changeset/one-component-family.md
@@ -1,5 +1,5 @@
 ---
-"@vendoai/ui": major
+"@vendoai/ui": minor
 "@vendoai/core": minor
 "@vendoai/apps": minor
 ---


### PR DESCRIPTION
Two release-hygiene fixes ahead of re-cutting the 0.8.0 publish:

- **Flip the last `major` to `minor`** (`.changeset/one-component-family.md`). It was the only major in the staged set; left alone, the next `changeset version` run bumps the whole fixed group to **1.0.0**, against the deliberate pre-1.0 call in #926. Pre-1.0 minors carry breaking changes, same treatment #926 applied to every prior major.
- **Add the missing changeset for the MCP service-key feature** (#938 / #941 / #955). The feature landed with no changeset anywhere, so it would ship with zero changelog visibility. This is the headline capability for the first external evaluator, so the release notes should name it.

No code changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the 0.x line by changing the staged `@vendoai/ui` bump from major to minor and adding a changeset for the MCP service-key auth path. This avoids an unintended 1.0.0 release and makes the service-key feature visible in the changelog for `@vendoai/mcp`, `@vendoai/vendo`, and `@vendoai/core`.

<sup>Written for commit 6ecccd6a1dfcf97a60568d1e22642473cf2054b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

