### PR TITLE
docs(agents): the README stops promising a Cloud store slot that throws

### DIFF
--- a/packages/agents/README.md
+++ b/packages/agents/README.md
@@ -1,8 +1,9 @@
 # @vendoai/agents
 
 Spawn a governed, harness-grade agent in any Node backend in a few lines. One
-runtime, always host-run; a Vendo Cloud key fills every slot left unset — an
-explicit adapter always wins, and there is no hidden key-conditional behavior.
+runtime, always host-run; a Vendo Cloud key fills the sandbox slot when you
+leave it unset — an explicit adapter always wins, and there is no hidden
+key-conditional behavior.
 
 ```ts
 import { agent, tool, api, createGuard, e2b, postgres } from "@vendoai/agents";
@@ -46,8 +47,9 @@ silent new conversation. `session.threadId` is the id to hand your client.
 
 Every tool call passes the guard (`run` / `ask` / `block`); the dev's risk
 label is final and an unlabeled tool asks. Unset slots resolve down the
-ladder: store → Cloud tenant Postgres (`VENDO_API_KEY`) or the embedded
-zero-config store; sandbox → `E2B_API_KEY` or the Cloud pool. Egress binds at
+ladder: store → the embedded zero-config store (with `VENDO_API_KEY` set,
+pass `store` explicitly — Cloud tenant-store access is not wired yet);
+sandbox → `E2B_API_KEY` or the Cloud pool. Egress binds at
 box boot from host code only — a list adds to the harness's minimum, `"all"`
 lifts it, and every box boot writes one audit row saying which skin it got.
 

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * `@vendoai/agents` — spawn a governed, harness-grade agent in any Node
  * backend in a few lines. One runtime, always host-run; a Vendo Cloud key
- * fills every slot left unset. Harness factories live at
+ * fills the sandbox slot when it is left unset. Harness factories live at
  * `@vendoai/agents/harnesses` (`claudeCode`, `vendo`).
  */
 export {


### PR DESCRIPTION
Pre-first-publish truth pass on `@vendoai/agents` (it ships to npm for the first time in the 0.8.0 release).

README.md and the `src/index.ts` doc-comment promised **"a Vendo Cloud key fills every slot left unset"** — but `defaultStore()` (`src/agent.ts`) throws `VendoError("not-implemented")` when `VENDO_API_KEY` is set and no `store` is passed, and nothing in the repo wires the cloud store adapter (`provideCloudAdapters` is only ever called with `{ sandbox }`). A first-time user following the README as written gets a boot error.

Doc-only change: the claim now matches the code — Cloud key fills the **sandbox** slot; with a key set, pass `store` explicitly until tenant-store access lands.

Known and deferred, not in this PR: `awayRunner`, `agentComposition`, and `provideCloudAdapters` are internal umbrella wiring sitting on the public entrypoint; narrowing that is a real refactor (the umbrella imports them) and can happen pre-1.0 in 0.9.0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align `@vendoai/agents` docs with behavior: a Vendo Cloud key only fills the sandbox slot; pass `store` explicitly even when `VENDO_API_KEY` is set. Updates README and entrypoint doc-comment to prevent first-run boot errors from expecting an auto Cloud store.

<sup>Written for commit 934a3ee98e442ca090386833c42e4c8b503dc1d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

