### PR TITLE
docs(mcp): the Cloud service-key path, and a status label that names what is proven

### DIFF
--- a/docs-site/existing-agents/mcp.mdx
+++ b/docs-site/existing-agents/mcp.mdx
@@ -180,6 +180,10 @@ Revoking the key in the console refuses the next exchange.
     { "access_token": "vmat_…", "token_type": "Bearer", "expires_in": 600, "scope": "read write" }
     ```
 
+    The broker answers field for field the same on Cloud — only `access_token`
+    differs, a signed JWT there rather than an opaque string, and you hand it
+    over exactly the same way.
+
     Ten minutes and no refresh token — mint one per job and let it expire. While
     the door lists a key, an unknown key, a retired one and a wrong `client_id`
     all answer the same `invalid_client`: nothing tells a guesser which half they

--- a/docs-site/existing-agents/mcp.mdx
+++ b/docs-site/existing-agents/mcp.mdx
@@ -15,9 +15,14 @@ calls what it finds — your host actions, and Vendo's own `vendo_make`.
 
 <Note>
   **Status: experimental**, the same label the [MCP door](/capabilities/mcp)
-  carries: real, guard-bound, covered by protocol-level e2e, but out of the
-  main [quickstart](/quickstart) until the attended live-client matrix is
-  green.
+  carries — though the two halves are not at the same place. The first-party
+  service-key path below runs end to end in production: a key minted in the
+  console, exchanged for a token bound to one user, real tool calls proxied
+  through the hosted broker to a live deployment, and revocation refusing the
+  next exchange. The attended live-client matrix — a person driving Claude,
+  ChatGPT, or Cursor through the browser login and consent flow — is the open
+  item, and it is what keeps this page out of the main
+  [quickstart](/quickstart).
 </Note>
 
 ## 1. Open the door
@@ -98,13 +103,34 @@ backend** — a nightly job, a queue worker, a support console acting for someon
 who is not at a browser — the OAuth dance has nobody to run it: no browser to
 bounce, no consent page to click, and no third party to consent to.
 
-A service key is the first-party way in. You mint it, your backend holds it, and
-it exchanges the key plus one of **your** user ids for a short-lived token bound
-to that user. Nothing downstream changes: same guard, same approvals, same
-audit, and the tool call is attributed to the key (`svc:<hash8>`) as well as to
-the person. Per-user OAuth stays the story for anyone else's agent; a service
-key is for code you deploy, and it can name any user, so it is exactly as
-powerful as your backend already is.
+A service key is the first-party way in. It is minted once, your backend holds
+it, and it exchanges the key plus one of **your** user ids for a short-lived
+token bound to that user. Nothing downstream changes: same guard, same
+approvals, same audit, and the tool call is attributed to the key
+(`svc:<hash8>`) as well as to the person. Per-user OAuth stays the story for
+anyone else's agent; a service key is for code you deploy, and it can name any
+user, so it is exactly as powerful as your backend already is.
+
+One question picks your path: is your door fronted by the hosted broker —
+`VENDO_MCP_BROKER_URL` set — or serving its own OAuth surface?
+
+| | The key | The exchange |
+| --- | --- | --- |
+| **Self-hosted** | you mint it and list it, as below | your MCP URL plus `/token` |
+| **Vendo Cloud** | **Create service key** on the project's keys page in the console, under **Service keys**. The console pushes it to the broker and shows you the full key once | `https://<your tenant>.mcp.vendo.run/token` |
+
+The broker forwards to a public HTTPS address and refuses a private one, so it
+can never reach `localhost` — trying this on a laptop is the self-hosted path,
+whatever your account is.
+
+On Cloud the first two steps below are the console's, and there is no
+`serviceAuth` to configure: a door that trusts the broker serves no token
+endpoint of its own, so setting it there warns and does nothing. Step 3 posts
+the same form to your tenant's URL — what the console's MCP page shows as your
+`VENDO_MCP_BROKER_URL`, with `/token` in place of `/mcp`. Everything after that
+is identical on both paths: the same answer, ten minutes, no refresh token, the
+same `svc:<hash8>` attribution, and the same guard, approvals and audit.
+Revoking the key in the console refuses the next exchange.
 
 <Steps>
   <Step title="Mint a key">
@@ -179,10 +205,9 @@ powerful as your backend already is.
 </Steps>
 
 <Note>
-  A door pointed at an external authorization server (`mcp.remoteAs`, or a
-  declared `VENDO_MCP_BROKER_URL`) does not serve its own token endpoint, so the
-  exchange lives at that server instead: post to the issuer's own
-  `token_endpoint`.
+  Pointed at an authorization server of your own with `mcp.remoteAs`? Same
+  shape as the broker: the door serves no token endpoint, so the exchange lives
+  at that server instead — post to the issuer's own `token_endpoint`.
 </Note>
 
 ## What the agent gets


### PR DESCRIPTION
Docs only — one file, `docs-site/existing-agents/mcp.mdx`. No source changes.

## 1. The Cloud variant of the service-key walkthrough was missing

Section 3 walked the **self-hosted** path only: mint a key with `openssl`, list it in `mcp: { serviceAuth: { keys: [...] } }`, post the exchange to your own app's MCP URL + `/token`. For a Cloud customer whose door is fronted by the hosted broker, two of those three steps are wrong — and the page's only correction was a `<Note>` seventy lines below the steps that contradict it.

A reader now picks a row. One question decides it — is `VENDO_MCP_BROKER_URL` set — and a two-row table names the only two things that differ (where the key comes from, where you exchange it). Everything downstream is stated as identical, because it is.

The fact that decides it for anyone evaluating is now where they would read it:

> The broker forwards to a public HTTPS address and refuses a private one, so it can never reach `localhost` — trying this on a laptop is the self-hosted path, whatever your account is.

The `mcp.remoteAs` `<Note>` at the bottom drops the broker clause it now duplicates and keeps the case it uniquely covers.

### Every Cloud claim verified against what shipped

Checked against merged `runvendo/vendo-web` main — #289 (broker exchange + console management), #290 (the cut that is what actually shipped: one UI, opaque keys, hash identity), #295 (Cloud owns the forwarding address):

| Claim | Verified |
| --- | --- |
| Key is created on the **project's keys page**, under a **Service keys** section | `apps/console/app/(console)/p/[projectId]/keys/page.tsx`. #290 deleted the separate `/service-keys` route — one page carries both kinds |
| Button reads **Create service key** | `COPY.service.createButton` in `components/console/api-keys.tsx` |
| Full key shown once | `"The full key is shown once, at creation."` / `showOnceTitle: "Copy your service key now"` |
| Console pushes it to the broker | broker-first write order, `apps/console/lib/core/service-keys.ts` |
| Exchange at `https://<slug>.mcp.vendo.run/token` | `app.post("/token", …)` in `services/broker/src/app.ts`; issuer is `https://${tenant.slug}.mcp.vendo.run`. Not `/mcp/token`, not `/oauth/token` |
| Identical form | `TOKEN_EXCHANGE_GRANT_TYPE`, `SERVICE_CLIENT_ID = "vendo-service"`, `SERVICE_SUBJECT_TOKEN_TYPE` — byte-identical constants on both sides, with a comment in the broker saying not to vary them |
| 600s, `read write`, no refresh token | `ACCESS_TOKEN_SECONDS = 600`; the seam test asserts `not.toHaveProperty("refresh_token")` |
| Same `svc:<hash8>` attribution | `serviceClientId()` = `` `svc:${keyHash.slice(0, 8)}` `` — same derivation as `packages/mcp/src/oauth/server.ts:694` |
| Revoking refuses the next exchange | uniform `invalid_client`; revoke is broker-first and idempotent |
| Broker cannot reach `localhost` | `apps/console/lib/mcp-forwarding-address.ts` and the broker's `upstreamOriginSchema` both refuse loopback / RFC1918 / link-local (the SSRF fix in #295) |
| No `serviceAuth` to set on Cloud | `packages/vendo/src/compose-mcp.ts:92` warns and the door 404s its own `/token` when `remoteAs` is set |

One deliberate wording choice: the page says the exchange returns "the same answer, ten minutes, no refresh token" rather than claiming the token *string* is the same. The self-hosted door mints an opaque `vmat_…`; the broker mints an ES256 `at+jwt`. The response envelope is identical and you pass it as a bearer either way, so the difference is not worth a sentence — but it was not worth an inaccuracy either.

## 2. The status banner stops averaging two different things

`experimental` stays — the label is earned by the half that has not been proven, and that half is real. But the banner was reporting one verdict for two very different states.

Before:

> **Status: experimental**, the same label the [MCP door](/capabilities/mcp) carries: real, guard-bound, covered by protocol-level e2e, but out of the main [quickstart](/quickstart) until the attended live-client matrix is green.

After:

> **Status: experimental**, the same label the [MCP door](/capabilities/mcp) carries — though the two halves are not at the same place. The first-party service-key path below runs end to end in production: a key minted in the console, exchanged for a token bound to one user, real tool calls proxied through the hosted broker to a live deployment, and revocation refusing the next exchange. The attended live-client matrix — a person driving Claude, ChatGPT, or Cursor through the browser login and consent flow — is the open item, and it is what keeps this page out of the main [quickstart](/quickstart).

Nothing beyond the 2026-08-07 production run is claimed, and the open item is named rather than implied.

## Gates

- `npx vitest run src/mcp-byo-docs.docs.test.ts src/your-agent-docs.docs.test.ts` — 55 passed. `mcp-byo-docs` is the docs-rot test that pins this page; nothing it pins needed to move, and no test was touched.
- `npx turbo run typecheck lint --filter=@vendoai/vendo` — clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update MCP docs to add the Cloud service-key path and fix guidance that assumed self-hosted only. The page now shows how to choose the path based on `VENDO_MCP_BROKER_URL`, uses the Cloud token endpoint at https://<tenant>.mcp.vendo.run/token, notes there’s no `serviceAuth` on Cloud, explains the broker can’t reach `localhost`, and clarifies the token response is field-for-field the same with only `access_token` differing (JWT on Cloud vs opaque `vmat_…`).

Clarify the status banner: the first‑party service-key flow is production-proven end to end, while the attended third‑party client flow remains the open item.

<sup>Written for commit 9ca3524d5ba38bd5374079cd254486b1590e9d4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

