### PR TITLE
chore(deps): clear new audit advisories (nanoid; ignore two unfixed image-size highs)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,7 @@ overrides:
   brace-expansion@>=4 <5.0.9: '>=5.0.9 <6'
   undici@>=7 <7.29.0: '>=7.29.0 <8'
   ip-address@>=10 <10.3.1: '>=10.3.1 <11'
+  nanoid@<3.3.17: '>=3.3.17 <4'
 
 importers:
 
@@ -236,7 +237,7 @@ importers:
         version: 6.0.28(zod@3.25.76)
       next:
         specifier: '>=16.2.11'
-        version: 16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -339,7 +340,7 @@ importers:
         version: 1.24.0(react@19.2.4)
       next:
         specifier: '>=16.2.11'
-        version: 16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-auth:
         specifier: '>=5.0.0-beta.32'
         version: 5.0.0-beta.32(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
@@ -6751,8 +6752,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -8577,7 +8578,7 @@ snapshots:
   '@ai-sdk/provider-utils@2.2.8(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       secure-json-parse: 2.7.0
       zod: 3.25.76
 
@@ -14278,7 +14279,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   napi-build-utils@2.0.0:
     optional: true
@@ -14304,6 +14305,33 @@ snapshots:
       '@auth/core': 0.41.3
       next: 16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
+
+  next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@next/env': 16.2.11
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.43
+      caniuse-lite: 1.0.30001805
+      postcss: 8.5.25
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.4)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.2.11
+      '@next/swc-darwin-x64': 16.2.11
+      '@next/swc-linux-arm64-gnu': 16.2.11
+      '@next/swc-linux-arm64-musl': 16.2.11
+      '@next/swc-linux-x64-gnu': 16.2.11
+      '@next/swc-linux-x64-musl': 16.2.11
+      '@next/swc-win32-arm64-msvc': 16.2.11
+      '@next/swc-win32-x64-msvc': 16.2.11
+      '@opentelemetry/api': 1.9.1
+      '@playwright/test': 1.61.1
+      sharp: 0.35.3(@types/node@20.19.43)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@types/node'
+      - babel-plugin-macros
 
   next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@22.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
@@ -14745,7 +14773,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,6 +28,25 @@ allowBuilds:
   unrs-resolver: true
   workerd: true
 
+# 2026-08-07 advisories: image-size GHSA-w3rx-r6r6-pgpr (ICNS parser infinite
+# loop) and GHSA-5p2g-fcmc-qvqq (JXL/HEIF parsers infinite loop), both HIGH,
+# via examples/mastra-agent > @mastra/memory > image-size. Not a
+# stale-lockfile case like every floor in `overrides` below: GitHub's own
+# advisory records report first_patched_version: null for both, and
+# image-size's last release anywhere (npm or GitHub) is 2.0.2 from April
+# 2025 — the "patched >=2.0.3" pnpm audit prints does not exist. Checked
+# upstream too: @mastra/memory 1.26.0 (2026-08-05, its current latest) still
+# pins image-size exactly at 1.2.1, so no version bump anywhere in the chain
+# reaches a fix. Ignored by advisory ID (pnpm's own mechanism for this,
+# `pnpm audit --ignore <GHSA-ID>`, which persists here) rather than an
+# `overrides` floor that can't resolve to a real package version. Re-check
+# both IDs whenever image-size cuts a new release; drop the ignores once one
+# ships >=2.0.3.
+auditConfig:
+  ignoreGhsas:
+    - GHSA-w3rx-r6r6-pgpr
+    - GHSA-5p2g-fcmc-qvqq
+
 minimumReleaseAgeExclude:
   - '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.214'
   - '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.214'
@@ -181,3 +200,11 @@ overrides:
   # 10.x line that is actually installed rather than the advisory's open-ended
   # "<=10.3.0", so a hypothetical 9.x consumer is not dragged across a major.
   "ip-address@>=10 <10.3.1": ">=10.3.1 <11"
+  # 2026-08-07 advisory: nanoid custom generators loop indefinitely when size
+  # is zero, GHSA-2v37-7h3g-55p8 (<3.3.17). Arrives via
+  # examples/{ai-sdk-agent,demo-bank}>next>postcss>nanoid (16 paths) — postcss
+  # declares `nanoid: ^3.3.16`, so the patch is already inside its declared
+  # range and the lockfile was simply pinned to 3.3.16. Bounded to the 3.x
+  # line that is actually installed; the advisory's other range (>=4.0.0
+  # <5.1.6) has no consumer in this tree.
+  "nanoid@<3.3.17": ">=3.3.17 <4"


### PR DESCRIPTION
## Summary

The required `audit` check started failing repo-wide ~21:20 UTC today (main's last green run was 21:13) on 4 freshly published advisories: `pnpm audit --prod --audit-level high` found 1 low + 3 high.

- **nanoid** `GHSA-2v37-7h3g-55p8` (<3.3.17, high) — via `next>postcss>nanoid` (16 paths, `examples/ai-sdk-agent` + `examples/demo-bank`). Stale-lockfile case: postcss declares `nanoid: ^3.3.16`, so 3.3.17 is already inside its declared range. Closed with a bounded `nanoid@<3.3.17: >=3.3.17 <4` floor in `pnpm-workspace.yaml`, matching the existing convention.
- **image-size** `GHSA-w3rx-r6r6-pgpr` (ICNS parser infinite loop) and `GHSA-5p2g-fcmc-qvqq` (JXL/HEIF parsers infinite loop), both high, via `examples/mastra-agent > @mastra/memory > image-size`. Verified there is no fix to float to: GitHub's own advisory API reports `first_patched_version: null` for both, and image-size's last release anywhere (npm or GitHub) is `2.0.2` from April 2025 — the "patched >=2.0.3" pnpm audit prints does not exist on the registry. Checked upstream too: `@mastra/memory` 1.26.0 (2026-08-05, its current latest) still pins `image-size` exactly at `1.2.1`, so no version bump anywhere in the chain reaches a fix. Ignored by advisory ID via pnpm's own `auditConfig.ignoreGhsas` in `pnpm-workspace.yaml` (the block `pnpm audit --ignore <GHSA-ID>` itself writes), documented the same way this file documents its `overrides` floors, with the condition to drop it (image-size ships >=2.0.3).
- **@ai-sdk/provider-utils** `GHSA-866g-f22w-33x8` (low) — the same advisory #939 left unmasked. Still `first_patched_version: null` upstream (the "patched >=3.0.98" pnpm audit prints refers to npm versions of `@ai-sdk/provider-utils` that don't exist), and still below the gate's `--audit-level high` threshold, so it does not block.

## Verification

```
$ pnpm audit --prod --audit-level high
3 vulnerabilities found
Severity: 1 low | 2 high (2 ignored)
$ echo $?
0
```

`pnpm install --frozen-lockfile` succeeds; lockfile diff is scoped to the nanoid bump and its resolution graph. No `packages/*` package.json touched, so no changeset and no typecheck run (per repo convention).

## Test plan
- [x] `pnpm audit --prod --audit-level high` exits 0 locally
- [x] `pnpm install --frozen-lockfile` succeeds with a clean, scoped lockfile diff
- [ ] CI `audit` job goes green on this PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks the required audit check by flooring `nanoid` to a safe version and ignoring two unfixed `image-size` advisories. `pnpm audit --prod --audit-level high` now exits 0.

- **Dependencies**
  - Added override: `"nanoid@<3.3.17": ">=3.3.17 <4"` to fix GHSA-2v37-7h3g-55p8 via `next > postcss > nanoid`; updated lockfile to `nanoid@3.3.17`.
  - Ignored `image-size` GHSA-w3rx-r6r6-pgpr and GHSA-5p2g-fcmc-qvqq via `auditConfig.ignoreGhsas` (no patched version available yet). Remove once `image-size >=2.0.3` exists.
  - Left `@ai-sdk/provider-utils` GHSA-866g-f22w-33x8 as-is (low; no fix; below gating threshold).

<sup>Written for commit ac9cb915b482f631ffbcbd94dcabe7ac9ea51183. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

