### PR TITLE
chore(packages): the four blocking-lint rules reach zero, 38 findings out

### DIFF
--- a/packages/actions/src/sync/static-ts.oracle.test.ts
+++ b/packages/actions/src/sync/static-ts.oracle.test.ts
@@ -19,7 +19,6 @@ import {
  * is safe and intended (see `oracleRead`).
  */
 
-type CaseMode = "match" | "divergent" | "permissive";
 
 interface BaseCase {
   name: string;

--- a/packages/apps/src/interchange.test.ts
+++ b/packages/apps/src/interchange.test.ts
@@ -39,14 +39,6 @@ const document = (overrides: Partial<AppDocument> = {}): AppDocument => ({
   ...overrides,
 });
 
-const codeEdit = JSON.stringify({
-  rung: 2,
-  files: [
-    { path: "/app/server.js", content: "export const ready = true;" },
-    { path: "/app/node_modules/cache/index.js", content: "export const cache = true;" },
-  ],
-});
-
 describe(".vendoapp interchange through createApps", () => {
   it("round-trips a copy with fresh ownership and empty data", async () => {
     const store = memoryStore();

--- a/packages/apps/src/lifecycle.test.ts
+++ b/packages/apps/src/lifecycle.test.ts
@@ -63,7 +63,6 @@ const setup = (withModel = true) => {
 
 describe("apps lifecycle", () => {
   it("disarms changed triggers on edit while preserving unchanged trigger edits", async () => {
-    const store = memoryStore();
     const original: AppDocument = {
       format: VENDO_APP_FORMAT,
       id: "app_trigger_arm",

--- a/packages/apps/src/model-params.test.ts
+++ b/packages/apps/src/model-params.test.ts
@@ -8,7 +8,6 @@
  */
 import type { LanguageModel } from "ai";
 import { describe, expect, it } from "vitest";
-import { askModel } from "./generation/engine.js";
 import {
   UNKNOWN_MODEL_MAX_OUTPUT_TOKENS,
   acceptsSamplingParams,

--- a/packages/harnesses/src/claude-code/claude-code-box.live.test.ts
+++ b/packages/harnesses/src/claude-code/claude-code-box.live.test.ts
@@ -298,13 +298,11 @@ live("claudeCode() — live, in a real e2b box", () => {
       thread: "m_box_env",
       say: "Write the full output of `env | sort` to user/files/env.txt. Then say done.",
     });
-    let text = "";
     try {
-      for await (const event of claudeCode({ sandbox: sandbox(), model: MODEL, maxTurns: 12 })
-        .run(h.turn as never)) {
-        if (event.type === "text") text += event.delta;
-        if (event.type === "error") text += `\n[error] ${event.message}`;
-      }
+      // Drained to drive the turn; the proof is the env dump the agent writes,
+      // not anything the stream says.
+      for await (const _event of claudeCode({ sandbox: sandbox(), model: MODEL, maxTurns: 12 })
+        .run(h.turn as never)) { /* no-op */ }
     } finally {
       delete process.env["VENDO_LANE_E_BOX_CANARY"];
     }

--- a/packages/mcp/src/door.test.ts
+++ b/packages/mcp/src/door.test.ts
@@ -3396,22 +3396,6 @@ function mcpRequest(accessToken: string, sessionId?: string, resource = BASE) {
   });
 }
 
-/** `mcpRequest` covers initialize and tools/list; this is any other method on a
- *  live session, over raw HTTP. */
-function mcpCall(accessToken: string, sessionId: string, name: string, args: Record<string, unknown>) {
-  return new Request(BASE, {
-    method: "POST",
-    headers: {
-      authorization: `Bearer ${accessToken}`,
-      accept: "application/json, text/event-stream",
-      "content-type": "application/json",
-      "mcp-session-id": sessionId,
-      "mcp-protocol-version": "2025-11-25",
-    },
-    body: JSON.stringify({ jsonrpc: "2.0", id: 42, method: "tools/call", params: { name, arguments: args } }),
-  });
-}
-
 /** The standalone SSE stream a client opens for server-initiated notifications.
  *  `accept` is a parameter so a test can send the GET the transport REJECTS. */
 function sseRequest(accessToken: string, sessionId: string, accept = "text/event-stream") {
@@ -3423,39 +3407,6 @@ function sseRequest(accessToken: string, sessionId: string, accept = "text/event
       "mcp-protocol-version": "2025-11-25",
     },
   });
-}
-
-/** The first SSE frame already buffered on a stream. Reading does NOT cancel the
- *  body, which is what lets a test hold a stream the server still believes in. */
-async function firstFrame(response: Response): Promise<string> {
-  const reader = response.body!.getReader();
-  const { value } = await reader.read();
-  reader.releaseLock();
-  return new TextDecoder().decode(value);
-}
-
-/** The next frame on a stream that is supposed to still be REACHABLE, or `""`.
- *  The wait never costs a passing run anything: the frame is already buffered by
- *  the time the assertion reads, so only a deaf stream ever reaches the deadline. */
-async function frameOrNone(response: Response, ms = 5_000): Promise<string> {
-  const reader = response.body!.getReader();
-  let arrived = false;
-  const read = reader.read()
-    .then(({ value }) => { arrived = true; return value === undefined ? "" : new TextDecoder().decode(value); })
-    .catch(() => { arrived = true; return ""; });
-  let timer: ReturnType<typeof setTimeout>;
-  try {
-    return await Promise.race([
-      read,
-      new Promise<string>((resolve) => { timer = setTimeout(() => resolve(""), ms); }),
-    ]);
-  } finally {
-    clearTimeout(timer!);
-    // Released only when the read actually finished, so a test may read the same
-    // stream again: releasing under a PENDING read rejects it, and nothing would
-    // be left to observe that rejection.
-    if (arrived) reader.releaseLock();
-  }
 }
 
 async function pkceChallenge(verifier: string): Promise<string> {

--- a/packages/store/src/workspace-fs.parity.ts
+++ b/packages/store/src/workspace-fs.parity.ts
@@ -25,5 +25,9 @@ type Assert<T extends true> = T;
  *  consumer of `@vendoai/store` would then need the interpreter's types
  *  installed — reintroducing the dependency this file exists to prevent.
  *  Unexported, TypeScript checks it here and elides the import from the
- *  emitted declaration. */
-type WorkspaceFsIsUpstreamFileSystem = Assert<WorkspaceFs extends UpstreamFileSystem ? true : false>;
+ *  emitted declaration.
+ *
+ *  Named with a leading underscore because declaring it is the whole point:
+ *  it has no reader by design, and unexported-and-unread is exactly what
+ *  no-unused-vars flags. */
+type _WorkspaceFsIsUpstreamFileSystem = Assert<WorkspaceFs extends UpstreamFileSystem ? true : false>;

--- a/packages/store/src/workspace.test.ts
+++ b/packages/store/src/workspace.test.ts
@@ -2,7 +2,6 @@ import { VendoError, type Principal } from "@vendoai/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { backends, type MadeBackend } from "./backends.test-util.js";
 import { FILES_STORE_MAX_BYTES } from "./files-store.js";
-import { dbFor } from "./store.js";
 import { workspaceStore, WORKSPACE_HISTORY_LIMIT, WORKSPACE_INLINE_MAX_BYTES } from "./workspace.js";
 
 const user: Principal = { kind: "user", subject: "user_ws" };

--- a/packages/store/src/workspace.ts
+++ b/packages/store/src/workspace.ts
@@ -1,10 +1,10 @@
-import { VendoError, type FilesAdapter, type Membership, type Principal, type RunContext, type WorkspaceFs } from "@vendoai/core";
+import type { FilesAdapter, Membership, Principal, RunContext, WorkspaceFs } from "@vendoai/core";
 import { storeFiles } from "./files-store.js";
 import { appAccess, orgOfPath } from "./helpers/app-access.js";
 import { backendOf } from "./helpers/backend.js";
 import type { VendoStore } from "./store.js";
 import { workspaceOpsRows } from "./workspace-ops-rows.js";
-import { HOST_MOUNT, normalizePath, pathForbidden, pathNotFound, WorkspaceStoreFs } from "./workspace-fs.js";
+import { HOST_MOUNT, normalizePath, pathNotFound, WorkspaceStoreFs } from "./workspace-fs.js";
 import { workspaceRows, type AppMount, type WorkspaceHistoryEntry } from "./workspace-rows.js";
 
 /** Build contract §9.7 — what the façade needs to know about the caller: who
@@ -100,11 +100,6 @@ export function workspaceStore(store: VendoStore, options: { files?: FilesAdapte
   const canWrite = async (caller: WorkspaceCaller, path: string): Promise<boolean> =>
     await access.can(runContextOf(caller), "editor", { path });
 
-  /** §9.4's two codes, chosen by a LIVE viewer read: see `pathNotFound` and
-      `pathForbidden`, which own the words both doors refuse in. */
-  const refusal = async (caller: WorkspaceCaller, path: string): Promise<VendoError> =>
-    await canRead(caller, path) ? pathForbidden(path) : pathNotFound(path);
-
   /** Build contract §9.7 — owner derivation is a PURE FUNCTION OF THE PATH, in
       every door and not just the façade: the org for `/orgs/<org>/**`, the
       bound subject for `/user/**`. Deriving it from the principal instead made
@@ -155,7 +150,8 @@ export function workspaceStore(store: VendoStore, options: { files?: FilesAdapte
       const normalized = normalizePath(path);
       if (!(await canRead(caller, normalized))) {
         // The failing predicate IS the viewer check, so this is never
-        // `forbidden` — see `refusal`.
+        // `forbidden`: a caller who cannot even read is not told the path is
+        // there (§9.4).
         throw pathNotFound(normalized);
       }
       return await rows.history(ownerOfPath(caller, normalized), normalized);

--- a/packages/ui/e2e/harness/main.tsx
+++ b/packages/ui/e2e/harness/main.tsx
@@ -50,8 +50,6 @@ import { createRoot } from "react-dom/client";
 import "./styles.css";
 
 const NOW = "2026-07-11T12:00:00.000Z";
-const ok = async (): Promise<ToolOutcome> => ({ status: "ok", output: { accepted: true } });
-
 const destructiveApproval: ApprovalRequest = {
   id: "apr_destructive",
   call: {

--- a/packages/ui/src/chrome/automations-panel.tsx
+++ b/packages/ui/src/chrome/automations-panel.tsx
@@ -165,6 +165,137 @@ export interface AutomationsPanelProps {
   pollMs?: number;
 }
 
+/** The trigger row's one-line state, in precedence order.
+
+    §9.9 — `stopped` is the SERVER's word on the automation itself and it
+    outranks any run row: the fire-time check stops a run before its first tool
+    call, so a run left looking live cannot be allowed to report "running now"
+    about something that will not run again until it is taken on. */
+function TriggerStateLine({ stopped, runningRun, runningStep, enabled, waitingOn, nextRun, celebrating, reduced }: {
+  stopped: boolean;
+  runningRun: RunRecord | undefined;
+  runningStep: string;
+  enabled: boolean;
+  waitingOn: number;
+  nextRun: string | null;
+  celebrating: boolean;
+  reduced: boolean;
+}) {
+  if (stopped) {
+    return (
+      <div className="fl-auto-sub">
+        <span className="fl-auto-live fl-auto-wait" aria-hidden="true" />
+        Stopped
+      </div>
+    );
+  }
+  if (runningRun) {
+    return (
+      <div className="fl-auto-sub">
+        <span className="fl-act-spin" aria-hidden="true" />
+        <span className="fl-auto-nextrun">running now{runningStep}</span>
+      </div>
+    );
+  }
+  return (
+    <div className="fl-auto-sub">
+      {enabled ? (
+        <span
+          className={`fl-auto-live${waitingOn > 0 ? " fl-auto-wait" : ""}`}
+          aria-hidden="true"
+          style={celebrating && !reduced
+            ? { animation: "fl-connect-pop .55s cubic-bezier(.22,1,.36,1) both" }
+            : undefined}
+        />
+      ) : null}
+      {enabled
+        ? waitingOn > 0
+          ? `Enabled · waiting on ${waitingOn} permission${waitingOn === 1 ? "" : "s"}`
+          : "Enabled"
+        : "Disabled"}
+      {nextRun ? <span className="fl-auto-nextrun">· {nextRun}</span> : null}
+    </div>
+  );
+}
+
+/** One row of the open Run history: what happened, and — when the run stopped
+    on a permission nobody had allowed — the way to allow it and run again. */
+function RunHistoryRow({ appName, run, asks, stopBusy, rerunBusy, onStop, onRerun, onDecide }: {
+  appName: string;
+  run: RunRecord;
+  /** The asks this run is waiting on someone to allow; empty for every other
+      kind of run, which is what decides whether it can be re-run from here. */
+  asks: ApprovalRequest[];
+  stopBusy: boolean | undefined;
+  rerunBusy: boolean | undefined;
+  onStop: () => void;
+  onRerun: () => void;
+  onDecide: (approve: boolean) => Promise<void>;
+}) {
+  return (
+    <article>
+      <div className="fl-act-row">
+        <span className={`fl-act-ic ${run.status === "error" ? "fl-act-x" : "fl-act-tick"}`} aria-hidden="true">
+          {run.status === "error" ? "✕" : "✓"}
+        </span>
+        <strong className="fl-act-lbl">{RUN_STATUS_LABEL[run.status]}</strong>
+        <time className="fl-act-sub" dateTime={run.startedAt}>{formatAuditTime(run.startedAt)}</time>
+        {run.status === "running" ? (
+          <button
+            className="fl-btn fl-btn-ceremony"
+            type="button"
+            disabled={stopBusy}
+            onClick={onStop}
+          >Stop</button>
+        ) : null}
+        {asks.length > 0 ? (
+          <button
+            className="fl-btn fl-btn-primary"
+            type="button"
+            disabled={rerunBusy}
+            onClick={onRerun}
+          >Grant &amp; re-run</button>
+        ) : null}
+      </div>
+      {run.summary ? <p className="fl-act-peek">{run.summary}</p> : null}
+      {/* Ruling 11 — a failed UNATTENDED run tells its owner what did not happen
+          and that nothing changed. The run's own code and reason are written for
+          whoever runs the deployment (the scheduler's refusals name billing
+          allowances and console URLs), so they ride the dev-mode rail — the same
+          seam the queue row's server preview uses. */}
+      {run.error ? (
+        <>
+          {/* A run that stopped for a missing permission needs no sentence of
+              ours: its own summary already says what it needed and what to do,
+              and the card below is the doing. The generic line would also be
+              WRONG here twice over — the steps before the miss really did run,
+              and once the permission is allowed a "hasn't been allowed" line
+              becomes a stale claim on a row that never changes. */}
+          {needsPermission(run) ? null : (
+            <p role="alert" className="fl-error">
+              {`This run didn’t finish — nothing in your account was changed.`}
+            </p>
+          )}
+          {developmentMode()
+            ? <p className="fl-act-sub">{`${run.error.code}: ${run.error.message}`}</p>
+            : null}
+        </>
+      ) : null}
+      {/* The consent card the person answers, right where the failure is: the
+          SAME card the arming ceremony uses, so one permission reads one way
+          everywhere. Allowing it re-runs the automation. */}
+      {asks.length > 0 ? (
+        <GrantSetCard
+          name={appName}
+          permissions={grantSetPermissions(asks)}
+          state="parked"
+          onDecide={onDecide}
+        />
+      ) : null}
+    </article>
+  );
+}
+
 /** 08-ui §4; 07-automations §5 — controls, grant capture, previews, history, kill switch.
     The trigger/flow labels (triggerLabel, automationFlow) moved to
     automation-card.tsx (2026-07 demo feedback), shared with the read-only
@@ -602,43 +733,16 @@ export function AutomationsPanel({ pollMs = AUTOMATIONS_POLL_MS }: AutomationsPa
                             the app name above is the group's heading and has to
                             keep primacy over its rows. */}
                         <span className="fl-auto-node-t">{label.title}</span>
-                        <div className="fl-auto-sub">
-                          {/* §9.9 — `stopped` is the SERVER's word on the automation
-                              itself and it outranks any run row: the fire-time check
-                              stops a run before its first tool call, so a run left
-                              looking live cannot be allowed to report "running now"
-                              about something that will not run again until it is
-                              taken on. */}
-                          {row.stopped !== undefined ? (
-                            <>
-                              <span className="fl-auto-live fl-auto-wait" aria-hidden="true" />
-                              Stopped
-                            </>
-                          ) : runningRun ? (
-                            <>
-                              <span className="fl-act-spin" aria-hidden="true" />
-                              <span className="fl-auto-nextrun">running now{runningStep}</span>
-                            </>
-                          ) : (
-                            <>
-                              {row.enabled ? (
-                                <span
-                                  className={`fl-auto-live${waitingOn > 0 ? " fl-auto-wait" : ""}`}
-                                  aria-hidden="true"
-                                  style={celebrating && !reduced
-                                    ? { animation: "fl-connect-pop .55s cubic-bezier(.22,1,.36,1) both" }
-                                    : undefined}
-                                />
-                              ) : null}
-                              {row.enabled
-                                ? waitingOn > 0
-                                  ? `Enabled · waiting on ${waitingOn} permission${waitingOn === 1 ? "" : "s"}`
-                                  : "Enabled"
-                                : "Disabled"}
-                              {nextRun ? <span className="fl-auto-nextrun">· {nextRun}</span> : null}
-                            </>
-                          )}
-                        </div>
+                        <TriggerStateLine
+                          stopped={row.stopped !== undefined}
+                          runningRun={runningRun}
+                          runningStep={runningStep}
+                          enabled={row.enabled}
+                          waitingOn={waitingOn}
+                          nextRun={nextRun}
+                          celebrating={celebrating}
+                          reduced={reduced}
+                        />
                         {/* §9.9 — WHY it stopped, in the server's own consumer sentence
                             (the same one the stopped run row carries, so the list and the
                             card never say two different things). The card in the app is
@@ -846,74 +950,19 @@ export function AutomationsPanel({ pollMs = AUTOMATIONS_POLL_MS }: AutomationsPa
                           // and therefore whether it can be re-run from here.
                           const runAsks = needsPermission(run) ? asksForRun(appId, run) : [];
                           return (
-                          <article key={run.id}>
-                            <div className="fl-act-row">
-                              <span className={`fl-act-ic ${run.status === "error" ? "fl-act-x" : "fl-act-tick"}`} aria-hidden="true">
-                                {run.status === "error" ? "✕" : "✓"}
-                              </span>
-                              <strong className="fl-act-lbl">{RUN_STATUS_LABEL[run.status]}</strong>
-                              <time className="fl-act-sub" dateTime={run.startedAt}>{formatAuditTime(run.startedAt)}</time>
-                              {run.status === "running" ? (
-                                <button
-                                  className="fl-btn fl-btn-ceremony"
-                                  type="button"
-                                  disabled={busy[`stop-${run.id}`]}
-                                  onClick={() => void stopRun(key, run.id)}
-                                >Stop</button>
-                              ) : null}
-                              {runAsks.length > 0 ? (
-                                <button
-                                  className="fl-btn fl-btn-primary"
-                                  type="button"
-                                  disabled={busy[`rerun-${run.id}`]}
-                                  onClick={() => void during(`rerun-${run.id}`, () =>
-                                    grantAndRerun(appId, trigger.id, key, run, runAsks, row.grantSetId, true))}
-                                >Grant &amp; re-run</button>
-                              ) : null}
-                            </div>
-                            {run.summary ? <p className="fl-act-peek">{run.summary}</p> : null}
-                            {/* Ruling 11 — a failed UNATTENDED run tells its owner what
-                                did not happen and that nothing changed. The run's own
-                                code and reason are written for whoever runs the
-                                deployment (the scheduler's refusals name billing
-                                allowances and console URLs), so they ride the dev-mode
-                                rail — the same seam the queue row's server preview
-                                uses. */}
-                            {run.error ? (
-                              <>
-                                {/* A run that stopped for a missing permission
-                                    needs no sentence of ours: its own summary
-                                    already says what it needed and what to do,
-                                    and the card below is the doing. The generic
-                                    line would also be WRONG here twice over — the
-                                    steps before the miss really did run, and once
-                                    the permission is allowed a "hasn't been
-                                    allowed" line becomes a stale claim on a row
-                                    that never changes. */}
-                                {needsPermission(run) ? null : (
-                                  <p role="alert" className="fl-error">
-                                    {`This run didn’t finish — nothing in your account was changed.`}
-                                  </p>
-                                )}
-                                {developmentMode()
-                                  ? <p className="fl-act-sub">{`${run.error.code}: ${run.error.message}`}</p>
-                                  : null}
-                              </>
-                            ) : null}
-                            {/* The consent card the person answers, right where
-                                the failure is: the SAME card the arming ceremony
-                                uses, so one permission reads one way everywhere.
-                                Allowing it re-runs the automation. */}
-                            {runAsks.length > 0 ? (
-                              <GrantSetCard
-                                name={entry.app.name}
-                                permissions={grantSetPermissions(runAsks)}
-                                state="parked"
-                                onDecide={approve =>
-                                  grantAndRerun(appId, trigger.id, key, run, runAsks, row.grantSetId, approve)}
-                              />
-                            ) : null}
-                          </article>
+                            <RunHistoryRow
+                              key={run.id}
+                              appName={entry.app.name}
+                              run={run}
+                              asks={runAsks}
+                              stopBusy={busy[`stop-${run.id}`]}
+                              rerunBusy={busy[`rerun-${run.id}`]}
+                              onStop={() => void stopRun(key, run.id)}
+                              onRerun={() => void during(`rerun-${run.id}`, () =>
+                                grantAndRerun(appId, trigger.id, key, run, runAsks, row.grantSetId, true))}
+                              onDecide={approve =>
+                                grantAndRerun(appId, trigger.id, key, run, runAsks, row.grantSetId, approve)}
+                            />
                           );
                         })}
                       </div>

--- a/packages/ui/src/chrome/thread/parts.tsx
+++ b/packages/ui/src/chrome/thread/parts.tsx
@@ -1,6 +1,6 @@
-import { riskLabelSchema, type ApprovalRequest, type Json, type RiskLabel, type UIPayload, type VendoAutomationPart, type VendoBuildFailedPart, type VendoConnectPart, type VendoGrantSetPart, type VendoTurnErrorPart, type VendoViewPart } from "@vendoai/core";
-import { isToolUIPart, type UIMessage } from "ai";
-import { useEffect, useRef, useState } from "react";
+import { riskLabelSchema, type RiskLabel, type UIPayload, type VendoAutomationPart, type VendoBuildFailedPart, type VendoConnectPart, type VendoGrantSetPart, type VendoTurnErrorPart, type VendoViewPart } from "@vendoai/core";
+import { isToolUIPart, type DynamicToolUIPart, type ToolUIPart, type UIMessage } from "ai";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { useVendoProvider } from "../../context.js";
 import { useSplitView } from "../split-view.js";
 import { useApprovalSheetPresentation } from "../../hooks/use-mobile-takeover.js";
@@ -119,6 +119,71 @@ function ThreadConnect({ ask, live, sendMessage }: {
   );
 }
 
+/** The shape both of a turn's terminal failures wear (spec §15 — the ✕ stays in
+    the record): the failed tool call's own beat vocabulary, plus one line saying
+    what the failure MEANS for the reader. `detail` is optional because an
+    unprefixed turn error yields no safe sentence of ours to show. */
+function ThreadErrorBlock({ marker, headline, detail }: {
+  /** The data attribute the E2E and a host's own styling select on, so it stays
+      per-failure rather than collapsing into one shared name. */
+  marker: "data-vendo-build-failed" | "data-vendo-turn-error";
+  headline: ReactNode;
+  detail: ReactNode | undefined;
+}) {
+  return (
+    <div className="fl-buildfail" {...{ [marker]: "" }}>
+      <div className="fl-beat fl-beat-error">
+        <span className="fl-beat-ic fl-beat-x" aria-hidden="true">
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round">
+            <path d="M18 6 6 18M6 6l12 12" />
+          </svg>
+        </span>
+        <span className="fl-beat-label">{headline}</span>
+      </div>
+      {detail === undefined ? null : <div className="fl-approval-more" role="alert">{detail}</div>}
+    </div>
+  );
+}
+
+/** A native tool call at its transcript position: the connector's ConnectCard
+    when the call ended `connect-required`, otherwise its build beat.
+
+    Spec §1 — THE TRANSCRIPT SHOWS THE WORK: every tool call leaves a beat at
+    its position in the conversation (this reverses lane pick C1, which sent
+    progress to a status ribbon above the composer and kept the transcript
+    beat-free). Two exceptions:
+      · the settled turn folds its beats into one summary row (hideBeats) —
+        but a failed or declined call is content, not progress, so its ✕ beat
+        stays visible either way (spec §15: the ✕ stays in the record);
+      · D1 — an app-building call renders no beat, from the moment the build
+        starts, because its card IS that step (the summary still counts it). */
+function ToolCallPart({ part, risks, count, connectLive, hideBeats, sendMessage, siblingParts }: {
+  part: ToolUIPart | DynamicToolUIPart;
+  risks: Map<string, RiskLabel>;
+  count: number;
+  connectLive: boolean;
+  hideBeats: boolean;
+  sendMessage?: ((message: { text: string }) => unknown) | undefined;
+  siblingParts?: UIMessage["parts"] | undefined;
+}) {
+  // 04-actions §3 — a connector call that ended `connect-required` renders
+  // its ConnectCard IN PLACE (2026-07 demo feedback: the card used to hang
+  // off the bottom of the list and vanish after the continuation; now it
+  // lives at its transcript position and settles into a Connected record).
+  // The typed outcome on the native tool part is the source of truth WHEN the
+  // wire carries one; ThreadPart's data-vendo-connect branch covers the harness
+  // wire, which does not.
+  if (part.state === "output-available") {
+    const ask = nativeConnectAsk(part.output);
+    if (ask !== undefined) return <ThreadConnect ask={ask} live={connectLive} sendMessage={sendMessage} />;
+  }
+  // The narration check runs FIRST: a failed build is content (its ✕ stays in
+  // the record), but its record is the build-failed block, not a second ✕.
+  if (narratedByAppCard(part, siblingParts ?? [])) return null;
+  if (hideBeats && !toolCallIsContent(part)) return null;
+  return <BuildBeat part={part} risk={risks.get(part.toolCallId) ?? "read"} count={count} />;
+}
+
 /** One stream part in a turn: text (user verbatim / assistant markdown with the
     ENG-217 caret choreography), assistant files, tool build beats, and the
     jailed generated-view app card (06-apps §§8–9). */
@@ -169,33 +234,17 @@ export function ThreadPart({ part, partKey, role, restored, count = 1, risks, co
     return <SentAttachment part={part} />;
   }
   if (isToolUIPart(part)) {
-    // 04-actions §3 — a connector call that ended `connect-required` renders
-    // its ConnectCard IN PLACE (2026-07 demo feedback: the card used to hang
-    // off the bottom of the list and vanish after the continuation; now it
-    // lives at its transcript position and settles into a Connected record).
-    // The typed outcome on the native tool part is the source of truth WHEN the
-    // wire carries one; the data-vendo-connect branch below covers the harness
-    // wire, which does not.
-    if (part.state === "output-available") {
-      const ask = nativeConnectAsk(part.output);
-      if (ask !== undefined) return <ThreadConnect ask={ask} live={connectLive} sendMessage={sendMessage} />;
-    }
-    // Spec §1 — THE TRANSCRIPT SHOWS THE WORK: every tool call leaves a beat at
-    // its position in the conversation (this reverses lane pick C1, which sent
-    // progress to a status ribbon above the composer and kept the transcript
-    // beat-free). Two exceptions:
-    //   · the settled turn folds its beats into one summary row (hideBeats) —
-    //     but a failed or declined call is content, not progress, so its ✕ beat
-    //     stays visible either way (spec §15: the ✕ stays in the record);
-    //   · D1 — an app-building call renders no beat, from the moment the build
-    //     starts, because its card IS that step (the summary still counts it).
-    const risk = risks.get(part.toolCallId) ?? "read";
-    // The narration check runs FIRST: a failed build is content (its ✕ stays in
-    // the record), but its record is the build-failed block, not a second ✕.
-    if (narratedByAppCard(part, siblingParts ?? [])) return null;
-    if (toolCallIsContent(part)) return <BuildBeat part={part} risk={risk} count={count} />;
-    if (hideBeats) return null;
-    return <BuildBeat part={part} risk={risk} count={count} />;
+    return (
+      <ToolCallPart
+        part={part}
+        risks={risks}
+        count={count}
+        connectLive={connectLive}
+        hideBeats={hideBeats}
+        sendMessage={sendMessage}
+        siblingParts={siblingParts}
+      />
+    );
   }
   if (part.type === "data-vendo-connect") {
     // The connect ask's OTHER shape, and the ONLY one a harness turn produces: the
@@ -231,17 +280,11 @@ export function ThreadPart({ part, partKey, role, restored, count = 1, risks, co
     const data = partData(part) as Partial<VendoBuildFailedPart>;
     if (typeof data.reason !== "string" || data.reason.length === 0) return null;
     return (
-      <div className="fl-buildfail" data-vendo-build-failed="">
-        <div className="fl-beat fl-beat-error">
-          <span className="fl-beat-ic fl-beat-x" aria-hidden="true">
-            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round">
-              <path d="M18 6 6 18M6 6l12 12" />
-            </svg>
-          </span>
-          <span className="fl-beat-label">Couldn&apos;t build the app</span>
-        </div>
-        <div className="fl-approval-more" role="alert">{BUILD_FAILURE_COPY}</div>
-      </div>
+      <ThreadErrorBlock
+        marker="data-vendo-build-failed"
+        headline={<>Couldn&apos;t build the app</>}
+        detail={BUILD_FAILURE_COPY}
+      />
     );
   }
   if (part.type === "data-vendo-turn-error") {
@@ -258,17 +301,11 @@ export function ThreadPart({ part, partKey, role, restored, count = 1, risks, co
     // is the record either way.
     const message = turnErrorSentence(data.message);
     return (
-      <div className="fl-buildfail" data-vendo-turn-error="">
-        <div className="fl-beat fl-beat-error">
-          <span className="fl-beat-ic fl-beat-x" aria-hidden="true">
-            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round">
-              <path d="M18 6 6 18M6 6l12 12" />
-            </svg>
-          </span>
-          <span className="fl-beat-label">The response didn&rsquo;t finish</span>
-        </div>
-        {message === undefined ? null : <div className="fl-approval-more" role="alert">{message}</div>}
-      </div>
+      <ThreadErrorBlock
+        marker="data-vendo-turn-error"
+        headline={<>The response didn&rsquo;t finish</>}
+        detail={message}
+      />
     );
   }
   if (part.type === "data-vendo-grant-set") {
@@ -421,6 +458,64 @@ function GrantSetConsent({ toolCallId, grantSetId, name, permissions, siblingPar
     threads) keep the full-size interactive card. */
 const PREVIEW_CANVAS_WIDTH = 720;
 const PREVIEW_MAX_HEIGHT = 300;
+
+/** The app card's body. Inside a split view it is a scaled, inert PREVIEW
+    (2026-07 demo feedback): the full app renders on a fixed-width canvas and
+    transform-scales to the card width, with the Expand pill prominent, because
+    the stage is the interactive venue. While the app is FEATURED on the stage
+    the preview blurs under a centered "Full screened" label; collapse clears
+    it. Everywhere else the body IS the full-size interactive card. */
+function AppCardBody({ compact, shellRef, canvasRef, previewHeight, previewScale, featured, activate, splitExpanded, view }: {
+  compact: boolean;
+  shellRef: React.RefObject<HTMLDivElement | null>;
+  canvasRef: React.RefObject<HTMLDivElement | null>;
+  previewHeight: number;
+  previewScale: number;
+  featured: boolean;
+  /** The card's activation, when the split view offers one. */
+  activate: (() => void) | undefined;
+  splitExpanded: boolean;
+  /** The rendered app, built once by the caller: one element for both venues,
+      so a preview and a full-size card can never show different things. */
+  view: ReactNode;
+}) {
+  if (!compact) return <div className="fl-appcard-body">{view}</div>;
+  return (
+    <div
+      ref={shellRef}
+      className="fl-appcard-body fl-appcard-preview"
+      {...(featured ? { "data-vendo-staged": "" } : {})}
+      style={{ height: Math.min(previewHeight, PREVIEW_MAX_HEIGHT) }}
+    >
+      <div
+        ref={canvasRef}
+        className="fl-appcard-canvas"
+        style={{ width: PREVIEW_CANVAS_WIDTH, transform: `scale(${previewScale})` }}
+        {...(featured ? { "aria-hidden": true } : {})}
+      >
+        {view}
+      </div>
+      {featured ? (
+        <div className="fl-appcard-veil" role="status">Full screened</div>
+      ) : (
+        <>
+          {previewHeight > PREVIEW_MAX_HEIGHT ? <div className="fl-appcard-fade" aria-hidden="true" /> : null}
+          {/* The prominent expand affordance, on compact-mode cards only:
+              expanded-rail cards keep the bar's Feature button + card click as
+              the stage-selection affordances. */}
+          {activate !== undefined && !splitExpanded ? (
+            <button type="button" className="fl-embed-expand" aria-label="Expand this view" onClick={activate}>
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                <path d="M8 3H5a2 2 0 0 0-2 2v3M16 3h3a2 2 0 0 1 2 2v3M8 21H5a2 2 0 0 1-2-2v-3M16 21h3a2 2 0 0 0 2-2v-3" />
+              </svg>
+              Expand
+            </button>
+          ) : null}
+        </>
+      )}
+    </div>
+  );
+}
 
 /** The in-thread generated-view card (06-apps §§8–9), split-view aware: it
     registers its FINAL payload with the enclosing overlay's workspace (when
@@ -622,58 +717,23 @@ function ThreadAppCard({ appId, payload, restored, buildKey }: { appId: string; 
         ) : null}
         <span className="fl-boot-hairline" aria-hidden="true" />
       </div>
-      {compact ? (
-        // Compact preview (2026-07 demo feedback): the full app renders on a
-        // fixed-width canvas, transform-scaled to the card — inert (the stage
-        // is the interactive venue) with the Expand pill prominent. While the
-        // app is FEATURED on the stage, the preview blurs under a centered
-        // "Full screened" label; collapse clears it.
-        <div
-          ref={shellRef}
-          className="fl-appcard-body fl-appcard-preview"
-          {...(featured ? { "data-vendo-staged": "" } : {})}
-          style={{ height: Math.min(previewHeight, PREVIEW_MAX_HEIGHT) }}
-        >
-          <div
-            ref={canvasRef}
-            className="fl-appcard-canvas"
-            style={{ width: PREVIEW_CANVAS_WIDTH, transform: `scale(${previewScale})` }}
-            {...(featured ? { "aria-hidden": true } : {})}
-          >
-            <PayloadView
-              payload={payload}
-              components={components}
-              onAction={({ action, payload: actionPayload }) => client.apps.call(appId, action, actionPayload ?? {})}
-            />
-          </div>
-          {featured ? (
-            <div className="fl-appcard-veil" role="status">Full screened</div>
-          ) : (
-            <>
-              {previewHeight > PREVIEW_MAX_HEIGHT ? <div className="fl-appcard-fade" aria-hidden="true" /> : null}
-              {/* The prominent expand affordance, on compact-mode cards only:
-                  expanded-rail cards keep the bar's Feature button + card
-                  click as the stage-selection affordances. */}
-              {activate !== undefined && split?.expanded !== true ? (
-                <button type="button" className="fl-embed-expand" aria-label="Expand this view" onClick={activate}>
-                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-                    <path d="M8 3H5a2 2 0 0 0-2 2v3M16 3h3a2 2 0 0 1 2 2v3M8 21H5a2 2 0 0 1-2-2v-3M16 21h3a2 2 0 0 0 2-2v-3" />
-                  </svg>
-                  Expand
-                </button>
-              ) : null}
-            </>
-          )}
-        </div>
-      ) : (
-        <div className="fl-appcard-body">
+      <AppCardBody
+        compact={compact}
+        shellRef={shellRef}
+        canvasRef={canvasRef}
+        previewHeight={previewHeight}
+        previewScale={previewScale}
+        featured={featured}
+        activate={activate}
+        splitExpanded={split?.expanded === true}
+        view={
           <PayloadView
             payload={payload}
             components={components}
             onAction={({ action, payload: actionPayload }) => client.apps.call(appId, action, actionPayload ?? {})}
           />
-        </div>
-      )}
+        }
+      />
     </div>
   );
 }

--- a/packages/ui/src/chrome/vendo-overlay.tsx
+++ b/packages/ui/src/chrome/vendo-overlay.tsx
@@ -12,7 +12,7 @@ import { inertBehind } from "./inert-behind.js";
 import { LauncherFace, LauncherToast, useLauncherStatus } from "./launcher-status.js";
 import { deliverPrefill, PrefillScopeContext, registerOverlayOpener } from "./overlay-registry.js";
 import { usePinAction, usePinNudge } from "./pin-ceremony.js";
-import { IDLE_RUN_ACTIVITY, runActivity, subscribeRunActivity } from "./run-activity.js";
+import { IDLE_RUN_ACTIVITY, runActivity, subscribeRunActivity, type VendoBeat } from "./run-activity.js";
 import {
   escapeIntent,
   expandedStageRect,
@@ -21,6 +21,7 @@ import {
   SplitViewContext,
   splitViewReducer,
   type MorphRect,
+  type SplitEmbed,
   type SplitViewContextValue,
 } from "./split-view.js";
 import { appTitle } from "./thread/message-data.js";
@@ -193,6 +194,169 @@ function canReceiveFocus(element: HTMLElement | null): element is HTMLElement {
   return style.display !== "none" && style.visibility !== "hidden";
 }
 
+interface EmbedGhost {
+  id: number;
+  mode: "in" | "out";
+  from: MorphRect;
+  target(): MorphRect;
+  clipTo(): MorphRect | undefined;
+  clone: HTMLElement;
+}
+
+/** A laid-out element's rect, or `undefined` where there is no layout to read
+    (jsdom rects are 0) — which is how the flight opts itself out. */
+const rectOf = (element: Element | null | undefined): MorphRect | undefined => {
+  const rect = element?.getBoundingClientRect();
+  return rect !== undefined && rect.width > 0 && rect.height > 0
+    ? { top: rect.top, left: rect.left, width: rect.width, height: rect.height }
+    : undefined;
+};
+
+/** The flying copy: inert, and pinned to the width it starts at. */
+const makeClone = (element: HTMLElement, width: number): HTMLElement => {
+  const clone = element.cloneNode(true) as HTMLElement;
+  clone.style.width = `${width}px`;
+  clone.style.margin = "0";
+  clone.style.pointerEvents = "none";
+  return clone;
+};
+
+/** The FLIP-style shared-element flight of the featured embed between its rail
+    card and the stage: measured start, computed target (expandedStageRect — a
+    mid-transition DOM read would return the compact layout). `null` when either
+    end has no layout to fly between, so the panes just snap. */
+function embedFlight(
+  dialog: React.RefObject<HTMLDivElement | null>,
+  targetAppId: string,
+  expanding: boolean,
+): Omit<EmbedGhost, "id"> | null {
+  const escaped = typeof CSS !== "undefined" && typeof CSS.escape === "function"
+    ? CSS.escape(targetAppId)
+    : targetAppId;
+  const cardEl = dialog.current?.querySelector<HTMLElement>(`[data-vendo-app-embed="${escaped}"]`);
+  const clipTo = () => rectOf(dialog.current);
+  if (expanding) {
+    const from = rectOf(cardEl);
+    if (!cardEl || !from) return null;
+    const to = expandedStageRect({ width: window.innerWidth, height: window.innerHeight });
+    return { mode: "in", from, target: () => to, clipTo, clone: makeClone(cardEl, from.width) };
+  }
+  const stageEl = dialog.current?.querySelector<HTMLElement>(".fl-stage");
+  const from = rectOf(stageEl);
+  let last = rectOf(cardEl);
+  if (!stageEl || !cardEl || !from || !last) return null;
+  // Track the card LIVE: it shifts and rewraps while the panel contracts, and
+  // the flight must converge on wherever it settles.
+  const target = () => {
+    last = rectOf(cardEl) ?? last;
+    return last as MorphRect;
+  };
+  return { mode: "out", from, target, clipTo, clone: makeClone(stageEl, from.width) };
+}
+
+/** The workspace's left pane: the featured app rendered large, with the build's
+    own beat rail under it. Stays mounted through expanded → collapsing →
+    collapsed (`mounted`) so the featured app does not blink out before the panes
+    finish sliding. */
+function WorkspaceStage({ mounted, expanded, featured, beats, pinNudge, pin, onPinned }: {
+  mounted: boolean;
+  expanded: boolean;
+  featured: SplitEmbed | undefined;
+  beats: readonly VendoBeat[];
+  /** The stage pin's one-time invite (§10.1 — the user pins, never the agent). */
+  pinNudge: string | undefined;
+  /** The host's pin seam; absent when the host wires none. */
+  pin: ((app: { appId: string; payload: unknown }) => void) | undefined;
+  /** Run after a pin from the stage: it CLOSES the whole overlay, so the user
+      lands back in the product with the app pinned. */
+  onPinned: () => void;
+}) {
+  const { client, components } = useVendoProvider();
+  return (
+    <div className="fl-split-stage" {...(expanded ? {} : { "aria-hidden": true })}>
+      {!mounted ? null : (
+        <>
+          {featured ? (
+            <div className="fl-stage" key={featured.appId}>
+              <div className="fl-stage-bar">
+                <span className="fl-appcard-dot" aria-hidden="true" />
+                <span className="fl-stage-name">{appTitle(featured.payload) ?? "Your app"}</span>
+                {/* Pin from fullscreen (2026-07 demo feedback): the same host
+                    onPin seam the in-thread card bar uses. */}
+                {pin ? (
+                  <button
+                    type="button"
+                    className="fl-barpin fl-stage-pin"
+                    {...(pinNudge === undefined ? {} : { "data-vendo-pin": pinNudge })}
+                    onClick={() => {
+                      pin({ appId: featured.appId, payload: featured.payload });
+                      onPinned();
+                    }}
+                  >
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                      <path d="M12 17v5M9 3h6l-1 7 3 3H7l3-3-1-7Z" />
+                    </svg>
+                    Pin to dashboard
+                  </button>
+                ) : null}
+              </div>
+              <div className="fl-stage-body">
+                <PayloadView
+                  // Registrations come from the typed in-thread card
+                  // (ThreadAppCard receives VendoViewPart payloads).
+                  payload={featured.payload as UIPayload}
+                  components={components}
+                  onAction={({ action, payload: actionPayload }) =>
+                    client.apps.call(featured.appId, action, actionPayload ?? {})}
+                />
+              </div>
+            </div>
+          ) : (
+            <div className="fl-stage-empty" role="status">
+              <p>Views you build land here.</p>
+              <p>Ask for a view in the conversation and it renders large on this stage.</p>
+            </div>
+          )}
+          {/* The build's own progress, under whatever the stage is showing: the
+              empty stage while the first view is still being made, the view
+              itself once it lands. */}
+          <BeatRail beats={beats} />
+        </>
+      )}
+    </div>
+  );
+}
+
+/** The split-view expand/collapse affordance (2026-07). Hidden below the
+    breakpoint — the takeover is already full-bleed. A fresh app embed landing
+    while collapsed pulses it once (data-vendo-suggest). */
+function WorkspaceToggle({ hidden, expanded, suggest, onToggle }: {
+  hidden: boolean;
+  expanded: boolean;
+  suggest: boolean;
+  onToggle: () => void;
+}) {
+  if (hidden) return null;
+  const label = expanded ? "Collapse workspace" : "Expand workspace";
+  return (
+    <button
+      className="fl-overlay-close fl-overlay-expand"
+      type="button"
+      aria-label={label}
+      aria-pressed={expanded}
+      {...(suggest && !expanded ? { "data-vendo-suggest": "" } : {})}
+      onClick={onToggle}
+    >
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d={expanded
+          ? "M8 3v3a2 2 0 0 1-2 2H3M21 8h-3a2 2 0 0 1-2-2V3M3 16h3a2 2 0 0 1 2 2v3M16 21v-3a2 2 0 0 1 2-2h3"
+          : "M8 3H5a2 2 0 0 0-2 2v3M21 8V5a2 2 0 0 0-2-2h-3M3 16v3a2 2 0 0 0 2 2h3M16 21h3a2 2 0 0 0 2-2v-3"} />
+      </svg>
+      <span className="fl-sr-only">{label}</span>
+    </button>
+  );
+}
+
 /** 08-ui §4 — floating modal launcher with focus containment and restoration.
  *  Supported entry API (ENG-220): positioned launcher by default, controlled +
  *  uncontrolled programmatic open/close, panel portaled to document.body with
@@ -222,7 +386,6 @@ export function VendoOverlay({
   const [conversationEpoch, setConversationEpoch] = useState(0);
   const theme = useVendoTheme();
   const takeover = useMobileTakeover();
-  const { client, components } = useVendoProvider();
   const pin = usePinAction();
 
   // 2026-07 demo feedback — the expandable split-view workspace (split-view.tsx
@@ -311,14 +474,7 @@ export function VendoOverlay({
   // layout). Skipped under reduced motion (everything snaps), in the
   // takeover, when there is no featured embed, and in layout-less
   // environments (jsdom rects are 0).
-  const [embedGhost, setEmbedGhost] = useState<{
-    id: number;
-    mode: "in" | "out";
-    from: MorphRect;
-    target(): MorphRect;
-    clipTo(): MorphRect | undefined;
-    clone: HTMLElement;
-  } | null>(null);
+  const [embedGhost, setEmbedGhost] = useState<EmbedGhost | null>(null);
   const ghostSeq = useRef(0);
   const setWorkspace = (next: boolean, featureAppId?: string, auto = false) => {
     if (next === splitState.expanded) {
@@ -327,55 +483,11 @@ export function VendoOverlay({
     // The compact card's Expand affordance names WHICH app to stage; the
     // feature dispatch below lands in the same commit as the expand, but the
     // ghost flight must read the target NOW (state hasn't reduced yet).
-    const targetAppId = featureAppId
-      ?? (featured !== undefined ? featured.appId : undefined);
+    const targetAppId = featureAppId ?? featured?.appId;
     const reduced = typeof matchMedia === "function" && matchMedia("(prefers-reduced-motion: reduce)").matches;
-    const rectOf = (element: Element | null | undefined): MorphRect | undefined => {
-      const rect = element?.getBoundingClientRect();
-      return rect !== undefined && rect.width > 0 && rect.height > 0
-        ? { top: rect.top, left: rect.left, width: rect.width, height: rect.height }
-        : undefined;
-    };
-    const makeClone = (element: HTMLElement, width: number): HTMLElement => {
-      const clone = element.cloneNode(true) as HTMLElement;
-      clone.style.width = `${width}px`;
-      clone.style.margin = "0";
-      clone.style.pointerEvents = "none";
-      return clone;
-    };
     if (!takeover.active && !reduced && targetAppId !== undefined && typeof window !== "undefined") {
-      const escaped = typeof CSS !== "undefined" && typeof CSS.escape === "function"
-        ? CSS.escape(targetAppId)
-        : targetAppId;
-      const cardEl = dialog.current?.querySelector<HTMLElement>(`[data-vendo-app-embed="${escaped}"]`);
-      const clipTo = () => rectOf(dialog.current);
-      if (next) {
-        const from = rectOf(cardEl);
-        if (cardEl && from) {
-          const to = expandedStageRect({ width: window.innerWidth, height: window.innerHeight });
-          setEmbedGhost({
-            id: ++ghostSeq.current,
-            mode: "in",
-            from,
-            target: () => to,
-            clipTo,
-            clone: makeClone(cardEl, from.width),
-          });
-        }
-      } else {
-        const stageEl = dialog.current?.querySelector<HTMLElement>(".fl-stage");
-        const from = rectOf(stageEl);
-        let last = rectOf(cardEl);
-        if (stageEl && cardEl && from && last) {
-          // Track the card LIVE: it shifts and rewraps while the panel
-          // contracts, and the flight must converge on wherever it settles.
-          const target = () => {
-            last = rectOf(cardEl) ?? last;
-            return last as MorphRect;
-          };
-          setEmbedGhost({ id: ++ghostSeq.current, mode: "out", from, target, clipTo, clone: makeClone(stageEl, from.width) });
-        }
-      }
+      const flight = embedFlight(dialog, targetAppId, next);
+      if (flight !== null) setEmbedGhost({ id: ++ghostSeq.current, ...flight });
     }
     if (featureAppId !== undefined) dispatchSplit({ type: "feature", appId: featureAppId });
     dispatchSplit(next ? { type: "expand", ...(auto ? { auto: true } : {}) } : { type: "collapse" });
@@ -638,30 +750,12 @@ export function VendoOverlay({
         onKeyDown={onKeyDown}
       >
         <strong className="fl-sr-only">Vendo</strong>
-        {/* The split-view expand/collapse affordance (2026-07). Hidden below
-            the breakpoint — the takeover is already full-bleed. A fresh app
-            embed landing while collapsed pulses it once (data-vendo-suggest). */}
-        {!takeover.active ? (
-          <button
-            className="fl-overlay-close fl-overlay-expand"
-            type="button"
-            aria-label={expanded ? "Collapse workspace" : "Expand workspace"}
-            aria-pressed={expanded}
-            {...(suggestExpand && !expanded ? { "data-vendo-suggest": "" } : {})}
-            onClick={() => setWorkspace(!splitState.expanded)}
-          >
-            {expanded ? (
-              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                <path d="M8 3v3a2 2 0 0 1-2 2H3M21 8h-3a2 2 0 0 1-2-2V3M3 16h3a2 2 0 0 1 2 2v3M16 21v-3a2 2 0 0 1 2-2h3" />
-              </svg>
-            ) : (
-              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                <path d="M8 3H5a2 2 0 0 0-2 2v3M21 8V5a2 2 0 0 0-2-2h-3M3 16v3a2 2 0 0 0 2 2h3M16 21h3a2 2 0 0 0 2-2v-3" />
-              </svg>
-            )}
-            <span className="fl-sr-only">{expanded ? "Collapse workspace" : "Expand workspace"}</span>
-          </button>
-        ) : null}
+        <WorkspaceToggle
+          hidden={takeover.active}
+          expanded={expanded}
+          suggest={suggestExpand}
+          onToggle={() => setWorkspace(!splitState.expanded)}
+        />
         {/* ENG-221: the explicit fresh-start affordance — closing never discards
             the conversation, so THIS is how a new one begins. Shares the close
             button's quiet header treatment; .fl-overlay-new only shifts it left. */}
@@ -683,60 +777,19 @@ export function VendoOverlay({
             stage pane is width-0 and empty; the rail IS the whole panel. */}
         <SplitViewContext.Provider value={splitContextValue}>
           <div className="fl-split">
-            <div className="fl-split-stage" key="stage" {...(expanded ? {} : { "aria-hidden": true })}>
-              {stagePhase !== "collapsed" ? (
-                <>
-                {featured ? (
-                  <div className="fl-stage" key={featured.appId}>
-                    <div className="fl-stage-bar">
-                      <span className="fl-appcard-dot" aria-hidden="true" />
-                      <span className="fl-stage-name">{appTitle(featured.payload) ?? "Your app"}</span>
-                      {/* Pin from fullscreen (2026-07 demo feedback): the same
-                          host onPin seam the in-thread card bar uses. A pin
-                          from the stage CLOSES the whole overlay — the user
-                          lands back in the product with the app pinned. */}
-                      {pin ? (
-                        <button
-                          type="button"
-                          className="fl-barpin fl-stage-pin"
-                          {...(stageNudge === undefined ? {} : { "data-vendo-pin": stageNudge })}
-                          onClick={() => {
-                            pin({ appId: featured.appId, payload: featured.payload });
-                            dispatchSplit({ type: "collapse" });
-                            setOpen(false);
-                          }}
-                        >
-                          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-                            <path d="M12 17v5M9 3h6l-1 7 3 3H7l3-3-1-7Z" />
-                          </svg>
-                          Pin to dashboard
-                        </button>
-                      ) : null}
-                    </div>
-                    <div className="fl-stage-body">
-                      <PayloadView
-                        // Registrations come from the typed in-thread card
-                        // (ThreadAppCard receives VendoViewPart payloads).
-                        payload={featured.payload as UIPayload}
-                        components={components}
-                        onAction={({ action, payload: actionPayload }) =>
-                          client.apps.call(featured.appId, action, actionPayload ?? {})}
-                      />
-                    </div>
-                  </div>
-                ) : (
-                  <div className="fl-stage-empty" role="status">
-                    <p>Views you build land here.</p>
-                    <p>Ask for a view in the conversation and it renders large on this stage.</p>
-                  </div>
-                )}
-                {/* The build's own progress, under whatever the stage is
-                    showing: the empty stage while the first view is still
-                    being made, the view itself once it lands. */}
-                <BeatRail beats={beats} />
-                </>
-              ) : null}
-            </div>
+            <WorkspaceStage
+              key="stage"
+              mounted={stagePhase !== "collapsed"}
+              expanded={expanded}
+              featured={featured}
+              beats={beats}
+              pinNudge={stageNudge}
+              pin={pin}
+              onPinned={() => {
+                dispatchSplit({ type: "collapse" });
+                setOpen(false);
+              }}
+            />
             <div className="fl-split-rail" key="rail">
               <PrefillScopeContext.Provider value={prefillScope.current}>
                 <Thread

--- a/packages/ui/test/chrome/app-load-retry.test.tsx
+++ b/packages/ui/test/chrome/app-load-retry.test.tsx
@@ -3,24 +3,11 @@
 // pinned app forever: useApp recorded the error, every surface kept rendering
 // "Loading app…", and only a full page reload got the user out. The load now
 // retries with backoff, and a load that really is dead offers a way back in.
-import type { AppDocument } from "@vendoai/core";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { VendoProvider, createVendoClient, type VendoClient } from "../../src/index.js";
 import { VendoSlot } from "../../src/chrome/index.js";
 import { createWireServer } from "../wire-server.js";
-
-const pinned: AppDocument = {
-  format: "vendo/app@1",
-  id: "app_1",
-  name: "Invoices",
-  ui: "tree",
-  tree: {
-    formatVersion: "vendo-genui/v2",
-    root: "root",
-    nodes: [{ id: "root", component: "Text", props: { text: "Invoices app surface" } }],
-  },
-};
 
 describe("useApp load retry (Keystone graduates A5)", () => {
   let wire: Awaited<ReturnType<typeof createWireServer>>;

--- a/packages/vendo/src/cli/cloud/client.ts
+++ b/packages/vendo/src/cli/cloud/client.ts
@@ -12,8 +12,6 @@ import {
 import { deploymentIdentityHeaders } from "../../deployment-identity.js";
 import { CLI_VERSION } from "../shared.js";
 
-const DEFAULT_CLOUD_URL = "https://console.vendo.run";
-
 export function isVendoKey(key: string): boolean {
   return /^vnd_[0-9a-f]{40}$/.test(key);
 }

--- a/packages/vendo/src/cli/cloud/device-login.test.ts
+++ b/packages/vendo/src/cli/cloud/device-login.test.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { runDeviceLogin, runLoginCommand } from "./device-login.js";
 import { telemetryCapture } from "../telemetry.test-util.js";
 

--- a/packages/vendo/src/cli/cloud/index.test.ts
+++ b/packages/vendo/src/cli/cloud/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { runCloud } from "./index.js";
 
 function output() {

--- a/packages/vendo/src/cli/theme/font-stack.ts
+++ b/packages/vendo/src/cli/theme/font-stack.ts
@@ -272,7 +272,6 @@ function appliedToJsx(mod: BoundModule, local: string, declaration: TS.Declarati
 export function layoutFontBindings(source: string): FontBinding[] {
   const mod = boundModule(source, "layout.tsx");
   if (mod === null) return scanFontBindings(source);
-  const { ts, sf } = mod;
   const bindings: FontBinding[] = [];
 
   for (const font of GEIST_FONTS) {

--- a/packages/vendo/src/hosted-store.test-util.ts
+++ b/packages/vendo/src/hosted-store.test-util.ts
@@ -1,4 +1,4 @@
-import { VendoError, canonicalJson, type VendoRecord } from "@vendoai/core";
+import { VendoError, canonicalJson, type BlobStore, type RecordStore, type VendoRecord } from "@vendoai/core";
 import { memoryStoreAdapter } from "@vendoai/core/conformance";
 
 const decoder = new TextDecoder();
@@ -14,290 +14,298 @@ export interface RecordedRequest {
   bytes?: Uint8Array;
 }
 
+type Body = Record<string, unknown>;
+
+/** Reports a route this fake does not serve, already bound to the request that
+ *  hit it. Returns `never`, so every caller may `return` it. */
+type Miss = (detail?: string) => never;
+
+/** A route this fake does not serve is a HOLE IN THE FAKE, and it throws out of
+ * `fetch` so that nothing can read it as the console's own answer. It used to
+ * answer `not-found`, which is exactly what a live console says when it refuses
+ * — so a test driving an unserved op family saw a plausible rejection, concluded
+ * the code handled it, and proved nothing. No production path makes `fetch`
+ * reject with this name, so the signal cannot be mistaken for one. Serve the
+ * route here, or assert this throw. */
+function unserved(method: string, path: string, detail?: string): never {
+  const error = new Error(
+    `fakeConsole does not serve ${method} ${path}`
+    + `${detail === undefined ? "" : ` (${detail})`} — implement it in hosted-store.test-util.ts`,
+  );
+  error.name = "FakeConsoleUnservedRoute";
+  throw error;
+}
+
+const isUnserved = (error: unknown): boolean =>
+  error instanceof Error && error.name === "FakeConsoleUnservedRoute";
+
+const STATUS: Record<string, number> = {
+  validation: 400,
+  unauthorized: 401,
+  blocked: 403,
+  "not-found": 404,
+  conflict: 409,
+};
+const json = (body: unknown, status = 200): Response => Response.json(body, { status });
+const envelope = (code: string, message: string): Response =>
+  json({ error: { code, message } }, STATUS[code] ?? 503);
+
+const sameValue = (
+  current: VendoRecord,
+  expected: { data: unknown; refs?: Record<string, string> },
+): boolean =>
+  canonicalJson(current.data) === canonicalJson(expected.data)
+  && canonicalJson(current.refs ?? null) === canonicalJson(expected.refs ?? null);
+
+/** The seven records ops, for BOTH records doors: the Store Wire v1 door takes
+ *  the op from the path and the collection from the body, the per-collection
+ *  legacy door takes the collection from the path and the method from the
+ *  trailing segments — same seven operations, two spellings of the two atomic
+ *  ones, so one dispatcher answers both and they cannot drift apart. */
+async function recordsOp(records: RecordStore, op: string, body: Body, miss: Miss): Promise<Response> {
+  switch (op) {
+    case "get":
+      return json({ record: await records.get(body.id as string) });
+    case "put":
+      return json({ record: await records.put(body.record as never) });
+    case "delete":
+      await records.delete(body.id as string);
+      return json({ ok: true });
+    case "list":
+      return json(await records.list((body.query ?? {}) as never));
+    case "claim":
+      return recordsClaim(records, body);
+    case "insertIfAbsent":
+    case "atomic/insert-if-absent":
+      return json({ record: await records.atomic!.insertIfAbsent(body.record as never) });
+    case "compareAndSwap":
+    case "atomic/compare-and-swap":
+      return json({
+        record: await records.atomic!.compareAndSwap(
+          body.record as never,
+          body.expectedRevision as string,
+        ),
+      });
+    default:
+      return miss(`unknown records op: ${op}`);
+  }
+}
+
+/** Compare-and-set over a whole record value: the claim lands only while the
+ *  stored value still equals `expected`, and an absent `replacement` means the
+ *  claim is a delete. */
+async function recordsClaim(records: RecordStore, body: Body): Promise<Response> {
+  const expected = body.expected as { id: string; data: unknown; refs?: Record<string, string> };
+  const current = await records.get(expected.id);
+  if (current === null || !sameValue(current, expected)) return json({ claimed: false });
+  const replacement = body.replacement as { data: unknown; refs?: Record<string, string> } | undefined;
+  if (replacement === undefined) {
+    await records.delete(expected.id);
+  } else {
+    await records.put({
+      id: expected.id,
+      data: replacement.data as never,
+      ...(replacement.refs === undefined ? {} : { refs: replacement.refs }),
+    });
+  }
+  return json({ claimed: true });
+}
+
+/** Store Wire v1 blobs door: JSON POST, bytes base64 on the wire. */
+async function blobsWireOp(blobs: BlobStore, op: string, body: Body, miss: Miss): Promise<Response> {
+  switch (op) {
+    case "put": {
+      const contentType = body.contentType as string | undefined;
+      await blobs.put(
+        body.key as string,
+        Uint8Array.from(atob(body.bytes as string), (char) => char.charCodeAt(0)),
+        contentType === undefined ? undefined : { contentType },
+      );
+      return json({ ok: true });
+    }
+    case "get": {
+      const blob = await blobs.get(body.key as string);
+      if (blob === null) return json({ blob: null });
+      let binary = "";
+      for (const byte of blob.bytes) binary += String.fromCharCode(byte);
+      return json({
+        blob: {
+          bytes: btoa(binary),
+          ...(blob.contentType === undefined ? {} : { contentType: blob.contentType }),
+        },
+      });
+    }
+    case "delete":
+      await blobs.delete(body.key as string);
+      return json({ ok: true });
+    case "list":
+      return json({ keys: await blobs.list((body.prefix as string | undefined) ?? "") });
+    default:
+      return miss(`unknown blobs op: ${op}`);
+  }
+}
+
+/** The per-namespace legacy blobs door: REST verbs, bytes raw on the wire, the
+ *  key in the trailing path segments. `null` for a verb it does not serve, so
+ *  the router reports the hole against the whole request rather than on this
+ *  door's behalf. */
+async function blobsRestOp(
+  blobs: BlobStore,
+  request: Request,
+  url: URL,
+  recorded: RecordedRequest,
+  keySegments: string[],
+): Promise<Response | null> {
+  if (keySegments.length === 0 && request.method === "GET") {
+    return json({ keys: await blobs.list(url.searchParams.get("prefix") ?? "") });
+  }
+  const key = keySegments.join("/");
+  if (request.method === "PUT") {
+    const contentType = recorded.contentType ?? undefined;
+    await blobs.put(key, recorded.bytes ?? new Uint8Array(), contentType === undefined ? undefined : { contentType });
+    return json({ ok: true });
+  }
+  if (request.method === "GET") {
+    const blob = await blobs.get(key);
+    if (blob === null) return envelope("not-found", "Blob not found.");
+    return new Response(blob.bytes.slice().buffer as ArrayBuffer, {
+      headers: blob.contentType === undefined ? {} : { "content-type": blob.contentType },
+    });
+  }
+  if (request.method === "DELETE") {
+    await blobs.delete(key);
+    return json({ ok: true });
+  }
+  return null;
+}
+
+/** The console's session-registry doors: register == touch, adopt retires the
+ *  registration, stale/claim implement the host-driven sweep's list and
+ *  mutual-exclusion legs with the engine's idleness predicate. */
+function sessionsOp(sessions: Map<string, number>, op: string, body: Body, miss: Miss): Response {
+  const now = typeof body.now === "number" ? body.now : Date.now();
+  const cutoff = now - (typeof body.idleMs === "number" ? body.idleMs : 0);
+  switch (op) {
+    case "register": {
+      // Mirrors the console's clamp (vendo-web session-registry.ts): touch
+      // never moves a subject's stamp BACKWARD.
+      const subject = body.subject as string;
+      sessions.set(subject, Math.max(sessions.get(subject) ?? now, now));
+      return json({ ok: true });
+    }
+    case "adopt": {
+      const from = body.from as string;
+      if (!sessions.has(from)) return json({ report: null });
+      sessions.delete(from);
+      // Data movement is the engine's job (console-side tests prove it with
+      // real per-org stores); the fake answers the report shape.
+      return json({ report: { apps: 0, threads: 0, states: 0, skipped: 0 } });
+    }
+    case "stale":
+      return json({
+        subjects: [...sessions.entries()]
+          .filter(([, touched]) => touched <= cutoff)
+          .map(([subject]) => subject),
+      });
+    case "claim": {
+      const subject = body.subject as string;
+      const touched = sessions.get(subject);
+      if (touched === undefined || touched > cutoff) return json({ claimed: false });
+      sessions.delete(subject);
+      return json({ claimed: true });
+    }
+    default:
+      return miss(`unknown session method: ${op}`);
+  }
+}
+
+/** Everything the handler learns from the request before routing: the recorded
+ *  shape the caller asserts against, with the body parsed into it. */
+async function record(request: Request): Promise<RecordedRequest> {
+  const recorded: RecordedRequest = {
+    url: request.url,
+    method: request.method,
+    authorization: request.headers.get("authorization"),
+    contentType: request.headers.get("content-type"),
+    deploymentHost: request.headers.get("x-vendo-deployment-host"),
+    deploymentName: request.headers.get("x-vendo-deployment-name"),
+  };
+  const raw = new Uint8Array(await request.arrayBuffer());
+  if (recorded.contentType === "application/json") {
+    recorded.json = JSON.parse(decoder.decode(raw));
+  } else if (raw.length > 0) {
+    recorded.bytes = raw;
+  }
+  return recorded;
+}
+
 /** In-memory fake of the console's /api/v1/store surface (the wire the
  * adapter must speak — see apps/console/lib/api/store-handlers.ts). Records
  * ride the reference memoryStoreAdapter, which already mirrors the store
  * engine's reserved-collection semantics (append-only audit, state id
  * grammar, cross-subject refusals), so parity failures surface as real
- * envelopes. Sessions mirror the console's registry doors: register == touch,
- * adopt retires the registration, stale/claim implement the host-driven
- * sweep's list and mutual-exclusion legs with the engine's idleness
- * predicate. The erase cascade itself is the console's concern (proven in the
- * console repo against real per-org engines); here it answers the wire shape
- * and records the call. */
+ * envelopes. Sessions mirror the console's registry doors. The erase cascade
+ * itself is the console's concern (proven in the console repo against real
+ * per-org engines); here it answers the wire shape and records the call. */
 export function fakeConsole() {
   const adapter = memoryStoreAdapter();
   const requests: RecordedRequest[] = [];
   const eraseCalls: unknown[] = [];
   const sessions = new Map<string, number>();
 
-  /** A route this fake does not serve is a HOLE IN THE FAKE, and it throws out
-   * of `fetch` so that nothing can read it as the console's own answer. It used
-   * to answer `not-found`, which is exactly what a live console says when it
-   * refuses — so a test driving an unserved op family saw a plausible rejection,
-   * concluded the code handled it, and proved nothing. No production path makes
-   * `fetch` reject with this name, so the signal cannot be mistaken for one.
-   * Serve the route here, or assert this throw. */
-  const unserved = (method: string, path: string, detail?: string): never => {
-    const error = new Error(
-      `fakeConsole does not serve ${method} ${path}`
-      + `${detail === undefined ? "" : ` (${detail})`} — implement it in hosted-store.test-util.ts`,
-    );
-    error.name = "FakeConsoleUnservedRoute";
-    throw error;
-  };
-  const isUnserved = (error: unknown): boolean =>
-    error instanceof Error && error.name === "FakeConsoleUnservedRoute";
+  const route = async (
+    request: Request,
+    url: URL,
+    recorded: RecordedRequest,
+    miss: Miss,
+  ): Promise<Response> => {
+    const segments = url.pathname.split("/").filter(Boolean).map(decodeURIComponent);
+    // /api/v1/store/...
+    if (segments[0] !== "api" || segments[1] !== "v1" || segments[2] !== "store") {
+      miss("not the console's store mount");
+    }
+    const rest = segments.slice(3);
+    const body = (recorded.json ?? {}) as Body;
+    const post = request.method === "POST";
 
-  const STATUS: Record<string, number> = {
-    validation: 400,
-    unauthorized: 401,
-    blocked: 403,
-    "not-found": 404,
-    conflict: 409,
+    // Store Wire v1 records door (STORE_WIRE_PATHS): one route per op, the
+    // collection rides the body. The per-collection legacy door below keeps
+    // serving the StoreAdapter surface over the same in-memory state.
+    if (rest[0] === "records" && rest.length === 2 && post) {
+      return recordsOp(adapter.records(body.collection as string), rest[1]!, body, miss);
+    }
+    if (rest[0] === "blobs" && rest.length === 2 && post) {
+      return blobsWireOp(adapter.blobs(body.namespace as string), rest[1]!, body, miss);
+    }
+    if (rest[0] === "records" && post) {
+      return recordsOp(adapter.records(rest[1]!), rest.slice(2).join("/"), body, miss);
+    }
+    if (rest[0] === "sessions" && post) {
+      return sessionsOp(sessions, rest[1]!, body, miss);
+    }
+    if (rest[0] === "blobs") {
+      const served = await blobsRestOp(adapter.blobs(rest[1]!), request, url, recorded, rest.slice(2));
+      if (served !== null) return served;
+    }
+    if (rest[0] === "erase" && post) {
+      eraseCalls.push(recorded.json);
+      if (typeof body.subject === "string") sessions.delete(body.subject);
+      return json({ report: { vendo_apps: 1, vendo_threads: 2 } });
+    }
+    return miss();
   };
-  const json = (body: unknown, status = 200): Response => Response.json(body, { status });
-  const envelope = (code: string, message: string): Response =>
-    json({ error: { code, message } }, STATUS[code] ?? 503);
-
-  const sameValue = (
-    current: VendoRecord,
-    expected: { data: unknown; refs?: Record<string, string> },
-  ): boolean =>
-    canonicalJson(current.data) === canonicalJson(expected.data)
-    && canonicalJson(current.refs ?? null) === canonicalJson(expected.refs ?? null);
 
   const handler = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     const request = new Request(input, init);
     const url = new URL(request.url);
-    const recorded: RecordedRequest = {
-      url: request.url,
-      method: request.method,
-      authorization: request.headers.get("authorization"),
-      contentType: request.headers.get("content-type"),
-      deploymentHost: request.headers.get("x-vendo-deployment-host"),
-      deploymentName: request.headers.get("x-vendo-deployment-name"),
-    };
-    const raw = new Uint8Array(await request.arrayBuffer());
-    if (recorded.contentType === "application/json") {
-      recorded.json = JSON.parse(decoder.decode(raw));
-    } else if (raw.length > 0) {
-      recorded.bytes = raw;
-    }
+    const recorded = await record(request);
     requests.push(recorded);
     if (recorded.authorization === null) {
       return envelope("unauthorized", "Valid API key required.");
     }
-
+    const miss: Miss = (detail?: string) => unserved(request.method, url.pathname, detail);
     try {
-      const miss = (detail?: string): never => unserved(request.method, url.pathname, detail);
-      const segments = url.pathname.split("/").filter(Boolean).map(decodeURIComponent);
-      // /api/v1/store/...
-      if (segments[0] !== "api" || segments[1] !== "v1" || segments[2] !== "store") {
-        miss("not the console's store mount");
-      }
-      const rest = segments.slice(3);
-
-      // Store Wire v1 records door (STORE_WIRE_PATHS): one route per op, the
-      // collection rides the body. The per-collection legacy door below keeps
-      // serving the StoreAdapter surface over the same in-memory state.
-      if (rest[0] === "records" && rest.length === 2 && request.method === "POST") {
-        const body = recorded.json as Record<string, unknown>;
-        const records = adapter.records(body.collection as string);
-        switch (rest[1]) {
-          case "get":
-            return json({ record: await records.get(body.id as string) });
-          case "put":
-            return json({ record: await records.put(body.record as never) });
-          case "delete":
-            await records.delete(body.id as string);
-            return json({ ok: true });
-          case "list":
-            return json(await records.list((body.query ?? {}) as never));
-          case "claim": {
-            const expected = body.expected as { id: string; data: unknown; refs?: Record<string, string> };
-            const current = await records.get(expected.id);
-            if (current === null || !sameValue(current, expected)) return json({ claimed: false });
-            const replacement = body.replacement as { data: unknown; refs?: Record<string, string> } | undefined;
-            if (replacement === undefined) {
-              await records.delete(expected.id);
-            } else {
-              await records.put({
-                id: expected.id,
-                data: replacement.data as never,
-                ...(replacement.refs === undefined ? {} : { refs: replacement.refs }),
-              });
-            }
-            return json({ claimed: true });
-          }
-          case "insertIfAbsent":
-            return json({ record: await records.atomic!.insertIfAbsent(body.record as never) });
-          case "compareAndSwap":
-            return json({
-              record: await records.atomic!.compareAndSwap(
-                body.record as never,
-                body.expectedRevision as string,
-              ),
-            });
-          default:
-            return miss(`unknown records op: ${rest[1]}`);
-        }
-      }
-
-      // Store Wire v1 blobs door: JSON POST, bytes base64 on the wire.
-      if (rest[0] === "blobs" && rest.length === 2 && request.method === "POST") {
-        const body = recorded.json as Record<string, unknown>;
-        const blobs = adapter.blobs(body.namespace as string);
-        switch (rest[1]) {
-          case "put": {
-            const contentType = body.contentType as string | undefined;
-            await blobs.put(
-              body.key as string,
-              Uint8Array.from(atob(body.bytes as string), (char) => char.charCodeAt(0)),
-              contentType === undefined ? undefined : { contentType },
-            );
-            return json({ ok: true });
-          }
-          case "get": {
-            const blob = await blobs.get(body.key as string);
-            if (blob === null) return json({ blob: null });
-            let binary = "";
-            for (const byte of blob.bytes) binary += String.fromCharCode(byte);
-            return json({
-              blob: {
-                bytes: btoa(binary),
-                ...(blob.contentType === undefined ? {} : { contentType: blob.contentType }),
-              },
-            });
-          }
-          case "delete":
-            await blobs.delete(body.key as string);
-            return json({ ok: true });
-          case "list":
-            return json({ keys: await blobs.list((body.prefix as string | undefined) ?? "") });
-          default:
-            return miss(`unknown blobs op: ${rest[1]}`);
-        }
-      }
-
-      if (rest[0] === "records" && request.method === "POST") {
-        const collection = rest[1]!;
-        const method = rest.slice(2).join("/");
-        const body = recorded.json as Record<string, unknown>;
-        const records = adapter.records(collection);
-        switch (method) {
-          case "get":
-            return json({ record: await records.get(body.id as string) });
-          case "put":
-            return json({ record: await records.put(body.record as never) });
-          case "delete":
-            await records.delete(body.id as string);
-            return json({ ok: true });
-          case "list":
-            return json(await records.list((body.query ?? {}) as never));
-          case "claim": {
-            const expected = body.expected as { id: string; data: unknown; refs?: Record<string, string> };
-            const current = await records.get(expected.id);
-            if (current === null || !sameValue(current, expected)) return json({ claimed: false });
-            const replacement = body.replacement as { data: unknown; refs?: Record<string, string> } | undefined;
-            if (replacement === undefined) {
-              await records.delete(expected.id);
-            } else {
-              await records.put({
-                id: expected.id,
-                data: replacement.data as never,
-                ...(replacement.refs === undefined ? {} : { refs: replacement.refs }),
-              });
-            }
-            return json({ claimed: true });
-          }
-          case "atomic/insert-if-absent":
-            return json({ record: await records.atomic!.insertIfAbsent(body.record as never) });
-          case "atomic/compare-and-swap":
-            return json({
-              record: await records.atomic!.compareAndSwap(
-                body.record as never,
-                body.expectedRevision as string,
-              ),
-            });
-          default:
-            return miss(`unknown records method: ${method}`);
-        }
-      }
-
-      if (rest[0] === "sessions" && request.method === "POST") {
-        const body = recorded.json as Record<string, unknown>;
-        const now = typeof body.now === "number" ? body.now : Date.now();
-        const idleMs = typeof body.idleMs === "number" ? body.idleMs : 0;
-        const cutoff = now - idleMs;
-        switch (rest[1]) {
-          case "register": {
-            // Mirrors the console's clamp (vendo-web session-registry.ts):
-            // touch never moves a subject's stamp BACKWARD.
-            const subject = body.subject as string;
-            sessions.set(subject, Math.max(sessions.get(subject) ?? now, now));
-            return json({ ok: true });
-          }
-          case "adopt": {
-            const from = body.from as string;
-            if (!sessions.has(from)) return json({ report: null });
-            sessions.delete(from);
-            // Data movement is the engine's job (console-side tests prove it
-            // with real per-org stores); the fake answers the report shape.
-            return json({ report: { apps: 0, threads: 0, states: 0, skipped: 0 } });
-          }
-          case "stale":
-            return json({
-              subjects: [...sessions.entries()]
-                .filter(([, touched]) => touched <= cutoff)
-                .map(([subject]) => subject),
-            });
-          case "claim": {
-            const subject = body.subject as string;
-            const touched = sessions.get(subject);
-            if (touched === undefined || touched > cutoff) return json({ claimed: false });
-            sessions.delete(subject);
-            return json({ claimed: true });
-          }
-          default:
-            return miss(`unknown session method: ${rest[1]}`);
-        }
-      }
-
-      if (rest[0] === "blobs") {
-        const namespace = rest[1]!;
-        const blobs = adapter.blobs(namespace);
-        if (rest.length === 2 && request.method === "GET") {
-          const keys = await blobs.list(url.searchParams.get("prefix") ?? "");
-          return json({ keys });
-        }
-        const key = rest.slice(2).join("/");
-        if (request.method === "PUT") {
-          const contentType = recorded.contentType ?? undefined;
-          await blobs.put(key, recorded.bytes ?? new Uint8Array(), contentType === undefined ? undefined : { contentType });
-          return json({ ok: true });
-        }
-        if (request.method === "GET") {
-          const blob = await blobs.get(key);
-          if (blob === null) return envelope("not-found", "Blob not found.");
-          return new Response(blob.bytes.slice().buffer as ArrayBuffer, {
-            headers: blob.contentType === undefined ? {} : { "content-type": blob.contentType },
-          });
-        }
-        if (request.method === "DELETE") {
-          await blobs.delete(key);
-          return json({ ok: true });
-        }
-      }
-
-      if (rest[0] === "erase" && request.method === "POST") {
-        eraseCalls.push(recorded.json);
-        const body = recorded.json as { subject?: string };
-        if (typeof body.subject === "string") sessions.delete(body.subject);
-        return json({ report: { vendo_apps: 1, vendo_threads: 2 } });
-      }
-
-      return miss();
+      return await route(request, url, recorded, miss);
     } catch (error) {
       if (isUnserved(error)) throw error;
       if (error instanceof VendoError) return envelope(error.code, error.message);

--- a/packages/vendo/src/org-automation-sponsorship.test.ts
+++ b/packages/vendo/src/org-automation-sponsorship.test.ts
@@ -207,11 +207,6 @@ async function sharedAutomation(
   return app;
 }
 
-const payloadOf = (surface: any): Record<string, unknown> => {
-  expect(surface.kind).toBe("tree");
-  return surface.payload as Record<string, unknown>;
-};
-
 describe("a third party's edit through the real apps path invalidates the sponsorship", () => {
   it("invalidates when an EDITOR who is not the sponsor lands a document edit", async () => {
     const booted = await boot();

--- a/packages/vendo/src/turn-id.e2e.test.ts
+++ b/packages/vendo/src/turn-id.e2e.test.ts
@@ -19,7 +19,6 @@ import type { AuditEvent, Principal, ToolDescriptor, ToolRegistry } from "@vendo
 import { defineHarness } from "@vendoai/harnesses";
 import { createStore, type VendoStore } from "@vendoai/store";
 import type { LanguageModel } from "ai";
-import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
 import { afterEach, describe, expect, it } from "vitest";
 import { createVendo } from "./server.js";
 
@@ -58,54 +57,6 @@ function hostTools(): ToolRegistry {
       return { status: "ok", output: { ok: true } };
     },
   };
-}
-
-/**
- * A store the way a HOST supplies one: the whole public `VendoStore` surface,
- * delegating to a real store so records genuinely work — but not the handle
- * `@vendoai/store` minted, so it has no SQL handle and `storeServesHarnessTurns`
- * refuses it. That deployment keeps `agent.stream`, which is the route this file
- * had no coverage for. (Same shape as `nonSqlStore` in harness-wire.test.ts.)
- */
-function nonSqlStore(backing: VendoStore): VendoStore {
-  return {
-    records: (collection) => backing.records(collection),
-    blobs: (namespace) => backing.blobs(namespace),
-    ensureSchema: () => backing.ensureSchema(),
-    close: () => backing.close(),
-    raw: () => backing.raw(),
-  };
-}
-
-const USAGE = {
-  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
-  outputTokens: { total: 0, text: 0, reasoning: 0 },
-} as const;
-
-/** Two guarded reads, then an answer: two audit rows that must name the same turn. */
-function twoReadsThenAnswer(): LanguageModel {
-  let step = 0;
-  return new MockLanguageModelV3({
-    doStream: async () => {
-      step += 1;
-      if (step <= 2) {
-        return {
-          stream: simulateReadableStream({ chunks: [
-            { type: "tool-call" as const, toolCallId: `call_${step}`, toolName: READ_TOOL, input: "{}" },
-            { type: "finish" as const, usage: USAGE, finishReason: { unified: "tool-calls" as const, raw: undefined } },
-          ] }),
-        };
-      }
-      return {
-        stream: simulateReadableStream({ chunks: [
-          { type: "text-start" as const, id: "answer" },
-          { type: "text-delta" as const, id: "answer", delta: "Two invoices." },
-          { type: "text-end" as const, id: "answer" },
-          { type: "finish" as const, usage: USAGE, finishReason: { unified: "stop" as const, raw: undefined } },
-        ] }),
-      };
-    },
-  });
 }
 
 const auditRows = async (store: VendoStore): Promise<AuditEvent[]> => {


### PR DESCRIPTION
The four rules the census picked go blocking in a separate, already-frozen PR. That PR cannot land while `packages/*` still reports findings for them — a gate that is red on day one is a gate everybody learns to bypass. This clears the runway and, more usefully, **measures how fast it re-dirties**.

## The count, measured at three heads

Re-measured by running the flip branch's frozen `eslint.blocking.config.mjs` unmodified, because the number moved 33 → 36 → 33 inside a single session before this branch existed:

| Head | Blocking findings | |
| --- | ---: | --- |
| `c4d7c76f3` — original base | **33** → 0 | the census backlog |
| `89d555358` — after +14 PRs | **6** came back → 0 | all six from one PR |
| `261902948` — after +5 more PRs | **0** new → still 0 | current head |

## Which PRs dirty this gate — the part worth keeping

Of the **eighteen** PRs that landed while this was open, **exactly one produced findings**: **#1036**, the undo/rollback deletion. The four UI bug fixes (#1027, #1029, #1040, #1009), the core cut (#1024) and #1050 produced **zero**.

**Deletion PRs are this gate's risk; ordinary work is not.** That is a much narrower claim than "main moves and findings come back", and it means the flip does not need a frozen repo — it needs to not land in the middle of a big deletion.

#1036's three sites: a dead `store` binding in `apps/src/lifecycle.test.ts`, a dead `dbFor` import in `store/src/workspace.test.ts`, and `refusal` in `store/src/workspace.ts`.

### `refusal` was checked, not deleted on sight

It lives in **shipped source**, so a dead store there could have been a refusal that never fires. It wasn't: its only caller was the `undo()` door #1036 removed, and `history()` refuses through the **viewer** predicate and already throws `pathNotFound` directly — which its own comment explains, because a caller who cannot even read is never told the path is there (§9.4). Dead, not swallowed. Deleting it orphaned `pathForbidden` and `VendoError` (both removed) and left a comment pointing at a function that no longer exists, which now says what it means instead.

## What changed

**31 deletions** — that is what "pure-deletion rules" means, the finding *is* the dead thing: three dead SSE/tools-call helpers in mcp's door test; two dead fixtures and two dead engine doubles left behind when the cases that used them went; a dead `DEFAULT_CLOUD_URL`; a `const { ts, sf }` nothing read; five unused imports.

**Two that are not deletions**, each with the reason written down:
- `store/src/workspace-fs.parity.ts` — the assertion alias has no reader **by design**: exporting it would put `import type … from "just-bash"` into every consumer's `.d.ts`, the dependency the file exists to prevent. Deleting it deletes the compile-time guard. It takes the config's own documented `^_` prefix.
- `harnesses/.../claude-code-box.live.test.ts` — the `text` accumulator nothing read is gone; the stream is still drained, because draining it is what drives the turn the assertions read.

**Five complexity findings become the shapes they already were.** No logic reshuffled to game the metric.

### `hosted-store.test-util.ts` — split, not moved, not exempted

It scored **92**. Two causes, neither essential: one `handler` carried five route families inline, and **the records ops were written twice** — once for the Store Wire v1 door (op in path, collection in body), once for the per-collection legacy door — two copies of one protocol, free to drift apart. Now one `recordsOp` both doors call, a named handler per family, and a `route` that reads as the route table it is. #1047's throwing `unserved` is preserved exactly as it landed.

**Moving it out of `src/` was checked and rejected**: `*.test-util.ts` is a repo-wide convention (ten packages), already excluded by every `tsconfig.json` and dropped from every coverage set. It has never shipped, so there was nothing to move it out of. **A narrow exemption was rejected too** — the flip config's opening line forbids per-file disables, and this complexity was incidental.

### The four UI ones

`TriggerStateLine` + `RunHistoryRow` out of the automations panel; `ThreadErrorBlock` (one shape for the two terminal failures that carried it twice), `ToolCallPart` + `AppCardBody` out of thread parts; `embedFlight`, `WorkspaceStage` + `WorkspaceToggle` out of the overlay.

Behaviour-preserving, verified by rendering every view at the base and at this branch and hashing: **14 of 16 byte-identical**, including `overlay`, `automations`, `thread-dark`, `approval`, `build-failed-banner`, `thread-humanized`, `thread-citations`, `tree-jail`, `tree-themed`, `appframe`. The two that differ (`slot-failed`, `slot-states`) **also differ between two runs of byte-identical code**, so the delta is headless-Chromium glyph rasterization, not this diff.

## One finding cleared itself

The unused `catch (reason)` in `connected-accounts-panel.tsx` is gone because **#1009 gave `reason` a real use** (`alreadyGone(reason)`). That file is no longer in this diff.

## Not done here

**No `eslint-disable` added anywhere. No rule weakened. No threshold raised.** The lockfile is byte-identical to `main`. Every test file touched is touched for a dead binding *inside that file* — no test was changed to make source code pass.

> **For the flip worker:** this zero is true at this SHA only. Re-measure at your own head, and check whether a large deletion PR landed in between — that is the one thing shown to reintroduce findings.