### PR TITLE
fix(deps): nanoid 3.3.17 clears GHSA-2v37-7h3g-55p8 (audit still red on image-size, which has no upstream fix)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,7 +236,7 @@ importers:
         version: 6.0.28(zod@3.25.76)
       next:
         specifier: '>=16.2.11'
-        version: 16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -339,7 +339,7 @@ importers:
         version: 1.24.0(react@19.2.4)
       next:
         specifier: '>=16.2.11'
-        version: 16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-auth:
         specifier: '>=5.0.0-beta.32'
         version: 5.0.0-beta.32(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
@@ -6751,8 +6751,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -8577,7 +8577,7 @@ snapshots:
   '@ai-sdk/provider-utils@2.2.8(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       secure-json-parse: 2.7.0
       zod: 3.25.76
 
@@ -14278,7 +14278,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   napi-build-utils@2.0.0:
     optional: true
@@ -14304,6 +14304,33 @@ snapshots:
       '@auth/core': 0.41.3
       next: 16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
+
+  next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@next/env': 16.2.11
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.43
+      caniuse-lite: 1.0.30001805
+      postcss: 8.5.25
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.4)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.2.11
+      '@next/swc-darwin-x64': 16.2.11
+      '@next/swc-linux-arm64-gnu': 16.2.11
+      '@next/swc-linux-arm64-musl': 16.2.11
+      '@next/swc-linux-x64-gnu': 16.2.11
+      '@next/swc-linux-x64-musl': 16.2.11
+      '@next/swc-win32-arm64-msvc': 16.2.11
+      '@next/swc-win32-x64-msvc': 16.2.11
+      '@opentelemetry/api': 1.9.1
+      '@playwright/test': 1.61.1
+      sharp: 0.35.3(@types/node@20.19.43)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@types/node'
+      - babel-plugin-macros
 
   next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@22.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
@@ -14745,7 +14772,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## What

Lockfile-only bump: `nanoid` 3.3.16 → **3.3.17**, clearing **GHSA-2v37-7h3g-55p8** (CVE-2026-67213).

## Why the gate went red (not any PR's fault)

Three advisories were re-scored on 2026-08-07 within five minutes of each other — `updated_at` 20:50:35Z (nanoid), 20:54:42Z and 20:55:24Z (image-size). `main` passed `audit` before that window and every open branch failed after it. Nothing in any PR's diff caused this.

## The brief we started from was wrong on one load-bearing point

The reported picture was "nanoid, two advisories, 16 paths". The reality is **two different packages**:

| Advisory | Package | Vulnerable | First patched | Fixable today? |
|---|---|---|---|---|
| GHSA-2v37-7h3g-55p8 | nanoid | `<3.3.17` | **3.3.17** | ✅ fixed here |
| GHSA-5p2g-fcmc-qvqq | **image-size** | `<=2.0.2` | **none (`null`)** | ❌ |
| GHSA-w3rx-r6r6-pgpr | **image-size** | `<=2.0.2` | **none (`null`)** | ❌ |

`GHSA-5p2g-fcmc-qvqq` is an **image-size** advisory, not a nanoid one.

## Option taken: a plain dependency update (no override, no pin)

`postcss@8.5.25` already declares `nanoid: ^3.3.16`, and `@ai-sdk/provider-utils@2.2.8` declares `^3.3.8`. The patched 3.3.17 satisfies both, so this needed **no `pnpm.overrides`, no pin, and no manifest edit at all** — just a lockfile re-resolution. That is the best available outcome: the ecosystem's own fix, nothing for us to remember to remove later.

## Are we actually exposed? No — dev/demo-time only

Both bugs are the same shape: a zero-valued size field spins an infinite loop, so a DoS *if attacker-controlled input reaches the parser*.

- **nanoid** — `customAlphabet`/`customRandom` called with `size: 0` never satisfy the loop's exit condition.
- **image-size** — a crafted ICNS/JXL/HEIF box with a size of `0` never advances the offset, hanging the event loop.

All 16 nanoid paths root in `examples/*` or `fixtures/host-app` (via `next > postcss`), and both image-size paths are `examples/mastra-agent > @mastra/memory`. `grep` over `packages/*/package.json` finds **neither package**: no published `@vendoai/*` package depends on either, so nothing in a shipped tarball is exposed, and no changeset is needed. Worth pushing upstream, but not an emergency.

## ⚠️ This does not make `audit` green — image-size cannot be fixed

Deliberately **not** papered over. The evidence that both remaining highs are a dead end:

- `npm view image-size@'>=2.0.3'` → **`E404 No match found for version >=2.0.3`**
- Registry `time.modified` = **2025-04-02** — 71 versions, max is `2.0.2`, nothing in 16 months
- `@mastra/memory` **hard-pins `image-size: 1.2.1`** (exact, not a range) in *every* version, including latest `1.26.0` and `1.26.1-alpha.0`

So option 1 is impossible (nothing to update to) and **option 2 is impossible too** — an override needs a target version that exists. A `pnpm.patch` would fix the real bug but not the gate, since `pnpm audit` resolves by version number.

Getting `audit` green needs an owner decision, which is out of scope for this PR:
- **(a)** Drop `@mastra/memory` from `examples/mastra-agent` — but the example genuinely uses it (`new Memory()` in `weather-agent.ts`), so this deletes what the example exists to demonstrate.
- **(b)** Wait for upstream. No ETA; queue stays frozen.
- **(c)** Scope the audit to *published* packages. Notably this is not a threshold cut — the job's own comment says it gates "the PRODUCTION dependency graph (**what ships in the published tarballs**)", and every example is `private: true`. Under a correctly-scoped gate neither finding would ever have gated, and it would still catch anything in the ten shipped packages.

No audit ignore, no lowered `--audit-level`, no `--no-audit`, no change to the job's blocking status.

## Lockfile diff: 34 insertions, 7 deletions — no unexpected version moves

- `nanoid@3.3.16` → `nanoid@3.3.17` (the only version change in the diff)
- Two `examples/*` importers re-keyed onto an existing `next@16.2.11(@babel/core@7.29.7)(…)` peer variation, adding one snapshot block. **Same `next` version**, peer-key churn only.
- **Zero major-version moves.** `@anthropic-ai/claude-agent-sdk` entries are byte-identical to `main` (verified by diffing the grep output including line numbers).

## Gates (foreground, full logs kept)

| Gate | Result |
|---|---|
| `pnpm install --frozen-lockfile` | ✅ clean |
| `pnpm build --filter=demo-bank...` | ✅ 14/14 — a real `next build` through postcss+nanoid |
| `pnpm typecheck` | ✅ 42/42 |
| `pnpm lint` | ✅ 3/3 (0 errors) |
| `pnpm test:affected` | 46/48 — **2 pre-existing failures, neither in CI's gate** |
| `pnpm audit --prod --audit-level high` | nanoid **gone**; 3 high → 2 high (both image-size) |

### The two test failures are pre-existing and not gated

Neither defines a `test:coverage` script, so CI's `test-rest` job (`turbo run test:coverage`) never runs them.

1. **`@vendoai-corpus/express-host`** › `doctor.e2e.test.ts` — environmental: `model credential: none found`.
2. **`@vendoai-fixtures/existing-agents-e2e`** › `marked-diff.test.ts` — a **real pre-existing bug from #1001** (`a39d857c5`), worth a separate fix: that PR added `"@vendoai-fixtures/test-kit": "workspace:*"` to `examples/mastra-agent`'s devDependencies, but the starter deriver strips `@vendoai/*` and `vendoai` and not `@vendoai-fixtures/*`, so `expect(starterPackage).not.toContain("@vendoai")` now fails on that surviving line.

## Two gotchas worth recording

- **`test:affected` degenerates into the full suite for a lockfile change** — turbo sees a changed root file and marks every package affected (48 tasks, 45 min here). Structural, not a flake.
- **A non-frozen `pnpm install` drops `@anthropic-ai/claude-agent-sdk`**, an *optional* peer of `packages/apps` and `packages/harnesses`. That red-herringed a `TS2307` build failure in `@vendoai/harnesses`. CI's `--frozen-lockfile` honours the lockfile entry and installs it, so the gate above is CI-faithful.

## vendo-web: no companion needed

`runvendo/vendo-web` has **no `audit` job at all** — workflows are only `broker.yml`, `console-staging.yml`, `console.yml`, `machine-proxy.yml`, and `grep -rn audit .github/ package.json` returns nothing. It carries `nanoid@3.3.16` transitively (4 lockfile refs) and **no image-size**, so it deserves the same bump on hygiene grounds but is not blocking anything and is not held to this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lockfile-only bump to `nanoid` 3.3.17 to clear GHSA-2v37-7h3g-55p8; no manifest changes. Audit remains red due to `image-size` advisories with no upstream fix.

- **Dependencies**
  - Updated `nanoid` to 3.3.17 via lockfile re-resolve; satisfies `postcss` and `@ai-sdk/provider-utils` without overrides.
  - Audit: `nanoid` cleared; remaining highs are `image-size` (no patched version; pinned via `@mastra/memory`).

<sup>Written for commit 4ce78768bb5ff9908a0dd12487f6c1e0558c3455. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

