### PR TITLE
fix(fixtures,ci): strip `workspace:` specs by property, and run the suite that checks it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,7 +310,7 @@ jobs:
       - name: Turbo remote cache (GitHub-cache backed)
         uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
       - run: pnpm install --frozen-lockfile
-      # Four suites CI never executed. Each has a `test` script and no
+      # Five suites CI never executed. Each has a `test` script and no
       # `test:coverage`, so test-rest's turbo run passes over them and no step
       # named them — they ran only in release.yml's unfiltered `pnpm test`,
       # which is the worst possible place to first learn a suite is red. That is
@@ -330,9 +330,10 @@ jobs:
       # only their workspace deps built. That is what the `^...` step below
       # builds (14 tasks, replayed from the remote cache that typecheck-lint's
       # `pnpm build` fills). Sequential steps, not one parallel turbo run, for
-      # the same reason as the redteam/automations steps further down. All four
+      # the same reason as the redteam/automations steps further down. All five
       # are hermetic — scripted models, temp PGlite stores, no network, no keys;
-      # ai-sdk-agent's two live journeys self-skip without a key.
+      # ai-sdk-agent's two live journeys self-skip without a key, as do
+      # existing-agents-e2e's two (VENDO_LIVE_JOURNEY=1).
       - name: Build the orphan suites' workspace deps (no example builds)
         run: pnpm turbo run build --filter=@vendoai/bench^... --filter=@vendoai-corpus/express-host^... --filter=@vendoai-examples/ai-sdk-agent^... --filter=@vendoai-examples/mastra-agent^...
       # Perf-budget arithmetic: stats, report, budgets, and the create-total
@@ -350,6 +351,15 @@ jobs:
       # handler, against the example's own composeVendo and checked-in
       # .vendo/tools.json. Added by #1001 and never once run in CI until now.
       - run: pnpm --filter @vendoai-examples/mastra-agent test
+      # The fifth, and the one that motivated the rest: the BYO-agent
+      # marked-diff contract, which derives each example's pre-Vendo starter and
+      # round-trips the marked diff back. Same rationale as above, and the
+      # sharpest case of it — #1001 added a devDependency to
+      # examples/mastra-agent and left this suite red on main for ~17h while
+      # every affected probe and cache key stayed clean. Needs no build of its
+      # own (it reads the example trees as text), so it is not in the `^...`
+      # filter above; ~3s.
+      - run: pnpm --filter @vendoai-fixtures/existing-agents-e2e test
       # Same skip contract as test-shards: `--affected` marks a package when it
       # or ANY of its workspace deps changed (verified: a one-line core edit
       # marks every fixture and demo below), so a skip here can never hide a

--- a/fixtures/existing-agents-e2e/src/marked-diff.test.ts
+++ b/fixtures/existing-agents-e2e/src/marked-diff.test.ts
@@ -56,7 +56,18 @@ describe("starterPackageJson", () => {
       name: "@vendoai-examples/ai-sdk-agent",
       scripts: { dev: "next dev", test: "vitest run" },
       dependencies: { "@vendoai/vendo": "workspace:*", ai: "6.0.28", vendoai: "workspace:*" },
-      devDependencies: { "@vendoai/core": "workspace:*", vitest: "^3", typescript: "^5" },
+      devDependencies: {
+        "@vendoai/core": "workspace:*",
+        // The scope the check missed in #1001, when it matched `@vendoai/` only.
+        "@vendoai-fixtures/test-kit": "workspace:*",
+        // …and the case scope-matching still cannot see: a real workspace
+        // package with no `@vendoai` prefix. `demo-bank` in an example's
+        // devDependencies survives every name rule and lands an unresolvable
+        // `workspace:` spec in a starter that the journey `npm install`s.
+        "demo-bank": "workspace:*",
+        vitest: "^3",
+        typescript: "^5",
+      },
     }))) as { name: string; scripts: Record<string, string>; dependencies: Record<string, string>; devDependencies: Record<string, string> };
     expect(stripped.name).toBe("journey-starter-ai-sdk-agent");
     expect(stripped.scripts).toEqual({ dev: "next dev" });
@@ -79,8 +90,18 @@ describe.each(EXAMPLES)("examples/%s marked diff", (example) => {
     expect(derivation.vendoOwned).toContain(".vendo/tools.json");
     expect(derivation.vendoOwned.some((rel) => rel.endsWith("lib/vendo.ts"))).toBe(true);
     expect(derivation.vendoOwned.some((rel) => rel.includes("api/vendo/"))).toBe(true);
-    const starterPackage = await readFile(path.join(starter, "package.json"), "utf8");
-    expect(starterPackage).not.toContain("@vendoai");
+    // What the starter's manifest must satisfy, asserted on the dependency
+    // entries rather than as a substring of the file: `not.toContain("@vendoai")`
+    // read the description prose too, and named a scope prefix instead of the
+    // property that matters — that the journey's `npm install`, run in a temp dir
+    // outside this monorepo, can resolve every line.
+    const manifest = JSON.parse(await readFile(path.join(starter, "package.json"), "utf8")) as Record<string, unknown>;
+    const deps = Object.entries(Object.assign(
+      {},
+      ...["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"].map((field) => manifest[field] ?? {}),
+    ) as Record<string, string>);
+    expect(deps.filter(([name]) => name === "vendoai" || /^@vendoai[/-]/.test(name)), "Vendo package survived into the starter").toEqual([]);
+    expect(deps.filter(([, version]) => version.startsWith("workspace:")), "workspace: dependency survived; npm cannot resolve it outside the monorepo").toEqual([]);
 
     // …and the marked diff alone brings the example back exactly.
     const applied = await applyMarkedDiff(exampleDir, starter);

--- a/fixtures/existing-agents-e2e/src/marked-diff.ts
+++ b/fixtures/existing-agents-e2e/src/marked-diff.ts
@@ -92,11 +92,18 @@ export function starterPackageJson(source: string): string {
   for (const field of ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"]) {
     const section = pkg[field];
     if (typeof section !== "object" || section === null) continue;
-    for (const name of Object.keys(section)) {
+    for (const [name, version] of Object.entries(section as Record<string, unknown>)) {
       // Every `@vendoai`-scoped name, not just `@vendoai/*`: the workspace's
       // test rigs live under `@vendoai-fixtures/*` and are no more part of a
       // framework starter than vitest is.
-      if (name === "vendoai" || name.startsWith("@vendoai") || name === "vitest") {
+      //
+      // …and every `workspace:` spec whatever its name, because that is the
+      // property the journey actually needs: it runs `npm install` on the
+      // starter in a temp dir OUTSIDE this monorepo, where the protocol does
+      // not resolve. Scope matching alone still misses the workspace packages
+      // that are not `@vendoai`-scoped — `demo-bank` is one — and #1001 showed
+      // the scope list is the part that drifts.
+      if (name === "vendoai" || name.startsWith("@vendoai") || String(version).startsWith("workspace:") || name === "vitest") {
         delete (section as Record<string, unknown>)[name];
       }
     }


### PR DESCRIPTION
**Rebased and narrowed.** #1045 landed the immediate bug fix and #1048 wired four orphan suites while this PR was open. What remains is the part neither did — verified against pristine current `main`, not assumed.

## What is superseded

The reported failure is **fixed on `main`**. Pristine checkout at `fed58ab57`, frozen install:

```
✓ src/marked-diff.test.ts (10 tests) 676ms
Test Files  1 passed | 2 skipped (3)
```

#1045 widened the deriver's prefix from `@vendoai/` to `@vendoai`. That half of this PR is dead and is dropped — #1045's line is kept verbatim below, untouched.

## What survives, and the evidence for each

### 1. The deriver still matches by name only

The property the journey needs is that **every spec in the derived starter resolves under a plain `npm install` in a temp dir outside this monorepo.** Scope matching cannot see the workspace packages that are not `@vendoai`-scoped. `demo-bank` is one.

On **pristine current `main`**, adding one line to `examples/mastra-agent`:

```diff
   "devDependencies": {
+    "demo-bank": "workspace:*",
```

…lands it verbatim in the derived starter:

```
starter devDependencies: {
  ...
  "demo-bank": "workspace:*"     ← npm cannot resolve this outside the monorepo
}
```

Same failure shape as #1001, one scope away, and the current fix structurally cannot catch it. The check now also drops any `workspace:` spec whatever its name. **Purely additive** — #1045's prefix is kept as-is.

### 2. The assertion on `main` is still the fragile proxy

`expect(starterPackage).not.toContain("@vendoai")` — a substring scan over the whole file. It reads description prose, and it names a scope prefix instead of the property. With the `demo-bank` line above present, **it reports `10 passed` while the starter is uninstallable.**

It now enumerates the dependency entries and asserts no Vendo-scoped name and no `workspace:` version, each with its own message. **Strictly stronger, not looser** — put #1045's deriver back under the new assertion and it fails, precisely:

```
× starterPackageJson > drops every Vendo package and the example test rig
  → expected { 'demo-bank': 'workspace:*', …(1) } to deeply equal { typescript: '^5' }
× examples/mastra-agent marked diff > derives a starter and round-trips back
  → workspace: dependency survived; npm cannot resolve it outside the monorepo:
    expected [ [ 'demo-bank', 'workspace:*' ] ] to deeply equal []
```

Three-way check: main's deriver + main's assertion + `demo-bank` → **passes** (the hole). Main's deriver + this assertion + `demo-bank` → **fails** (the guard works). This deriver + `demo-bank` → **stripped, starter clean** (the fix).

### 3. CI still does not run this suite

#1048 wired bench, express-host, ai-sdk-agent, and mastra-agent. But:

```
$ git show origin/main:.github/workflows/ci.yml | grep -c "existing-agents-e2e"
0
```

The one suite that started this whole thread is still the one nobody can see. It joins #1048's unguarded block for the same documented reasons. It needs no build of its own (it reads the example trees as text), so it stays out of the `^...` filter — ~3s. #1048's block comment goes from "Four suites" to "Five".

## Verified

Rebased onto `fed58ab57`, conflicts in `marked-diff.ts` and `ci.yml` resolved in favour of the landed versions plus the additive change. Frozen reinstall for the new lockfile; suite 10 passed / 2 skipped; `typecheck` clean; `dependency-guard` OK (30 packages); `ci.yml` re-parsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)