### PR TITLE
fix(fixtures): the derived starter drops @vendoai-fixtures/* too, not just @vendoai/*

### DIFF
--- a/fixtures/existing-agents-e2e/src/marked-diff.ts
+++ b/fixtures/existing-agents-e2e/src/marked-diff.ts
@@ -93,7 +93,10 @@ export function starterPackageJson(source: string): string {
     const section = pkg[field];
     if (typeof section !== "object" || section === null) continue;
     for (const name of Object.keys(section)) {
-      if (name === "vendoai" || name.startsWith("@vendoai/") || name === "vitest") {
+      // Every `@vendoai`-scoped name, not just `@vendoai/*`: the workspace's
+      // test rigs live under `@vendoai-fixtures/*` and are no more part of a
+      // framework starter than vitest is.
+      if (name === "vendoai" || name.startsWith("@vendoai") || name === "vitest") {
         delete (section as Record<string, unknown>)[name];
       }
     }


### PR DESCRIPTION
## What

One-line widening in `fixtures/existing-agents-e2e/src/marked-diff.ts`: `starterPackageJson` now strips every `@vendoai`-scoped dependency, not only `@vendoai/*`.

## Why

`examples/mastra-agent marked diff > derives a starter and round-trips back to the example` is red on `main`. It asserts the starter derived from each example is Vendo-free:

```
expect(starterPackage).not.toContain("@vendoai");
```

`starterPackageJson` deleted `vendoai`, `@vendoai/*`, and `vitest`. #1001 added `"@vendoai-fixtures/test-kit": "workspace:*"` to `examples/mastra-agent`'s devDependencies, which matches none of those, so it survived into the derived starter's `package.json` and the assertion fails.

This suite is not in the per-PR required checks, so it first surfaced in the release workflow's full-suite dry run (run 31224697313) — it was green at the v0.8.0 tag (e45a1c058).

The dependency itself is correct and stays. `test-kit` is the example's own test rig, imported only from `examples/mastra-agent/e2e/`, a directory `EXAMPLE_ONLY` already excludes from both the starter and the marked diff. So the derivation was the incomplete side: `@vendoai-fixtures/*` belongs in exactly the bucket `vitest` is already stripped for. The assertion is untouched.

Side benefit: the env-gated live journey runs a plain `npm install` on the derived starter, which would have choked on a `workspace:*` spec for a package that does not exist outside the pnpm workspace.

`local-pack.ts:104` has an identical-looking `@vendoai/` prefix check and is deliberately left alone — it rewrites *published* packages to `file:` tarball specs, so it must not match the private fixture scope.

No published package changed, so no changeset (`privatePackages.version = false`; same as #1001).

## Verification

Red → green on the exact test, in `fixtures/existing-agents-e2e/`:

Before (at `origin/main`):
```
 ❯ src/marked-diff.test.ts:83:32
     83|     expect(starterPackage).not.toContain("@vendoai");
 Test Files  1 failed (1)
      Tests  1 failed | 9 passed (10)
```

After:
```
 ✓ src/marked-diff.test.ts (10 tests) 166ms
 ↓ src/journey-ai-sdk.e2e.test.ts (1 test | 1 skipped)
 ↓ src/journey-mastra.e2e.test.ts (1 test | 1 skipped)
 Test Files  1 passed | 2 skipped (3)
      Tests  10 passed | 2 skipped (12)
```

- [x] `pnpm build` green (exit 0)
- [x] `pnpm typecheck` green — 42/42 tasks
- [x] `pnpm lint` green (exit 0) — dependency-guard + portability-gate + eslint; only pre-existing `demo-bank` warnings
- [x] `@vendoai-fixtures/existing-agents-e2e` suite green (worker-capped, `VITEST_MIN/MAX_FORKS=1/2`)
- [ ] Screenshots — n/a, no UI

Full suite is CI's job; the `ci` check on this PR is the gate of record.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Broaden the starter derivation to remove all `@vendoai`-scoped dependencies, including `@vendoai-fixtures/*`. This fixes the marked-diff in `examples/mastra-agent` and prevents `workspace:*` deps in generated starters.

- **Bug Fixes**
  - Update `starterPackageJson` to use `name.startsWith("@vendoai")` while still removing `vendoai` and `vitest`.
  - Leave `local-pack.ts` unchanged to avoid touching the private fixture scope.

<sup>Written for commit 9466c1cdd109a332b4d3e94b862d085463f56ca6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

