### PR TITLE
fix(corpus): the Express host's doctor e2e boots a development composition, as `npm run dev` does

### DIFF
--- a/corpus/hosts/express-host/e2e/doctor.e2e.test.ts
+++ b/corpus/hosts/express-host/e2e/doctor.e2e.test.ts
@@ -25,7 +25,9 @@ function runDoctor(url: string): Promise<{ code: number | null; output: string }
 describe("vendo doctor on the Express host", () => {
   // Express discovery lands in a parallel lane; this pins its expected behavior.
   it("recognizes the committed wiring and completes a live status probe", async () => {
-    const host = await startTestHost(scriptedModel([textTurn("unused")]), { trustedOrigin: true });
+    // `vendo doctor` probes the /doctor/* routes a development composition
+    // mounts, which is what a reader has after `npm run dev`.
+    const host = await startTestHost(scriptedModel([textTurn("unused")]), { trustedOrigin: true, development: true });
     try {
       const result = await runDoctor(host.baseUrl);
       expect(result.code, result.output).toBe(0);

--- a/corpus/hosts/express-host/e2e/harness.ts
+++ b/corpus/hosts/express-host/e2e/harness.ts
@@ -41,19 +41,28 @@ async function reserveLoopbackPort(): Promise<number> {
 
 export async function startTestHost(
   model: LanguageModel,
-  options: { trustedOrigin?: boolean } = {},
+  options: { trustedOrigin?: boolean; development?: boolean } = {},
 ): Promise<TestHost> {
   const dataDir = await mkdtemp(join(tmpdir(), "relay-express-e2e-"));
   const store = createStore({ dataDir });
   const port = options.trustedOrigin === true ? await reserveLoopbackPort() : 0;
   const previousBaseUrl = process.env.VENDO_BASE_URL;
   if (options.trustedOrigin === true) process.env.VENDO_BASE_URL = `http://127.0.0.1:${port}`;
+  // The composition reads NODE_ENV once, at createVendo time, to decide whether
+  // the development-only routes get mounted at all (#989). Under vitest it is
+  // "test", so a `development: true` opt-in has to be spelled here for any e2e
+  // that reaches a dev-only route — this host's `dev` script sets
+  // NODE_ENV=development, which is what those e2es stand in for.
+  const previousNodeEnv = process.env.NODE_ENV;
+  if (options.development === true) process.env.NODE_ENV = "development";
   let relay: ReturnType<typeof createRelayServer>;
   try {
     relay = createRelayServer({ model, store });
   } finally {
     if (previousBaseUrl === undefined) delete process.env.VENDO_BASE_URL;
     else process.env.VENDO_BASE_URL = previousBaseUrl;
+    if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = previousNodeEnv;
   }
   let server: Server;
   try {


### PR DESCRIPTION
`@vendoai-corpus/express-host` has been red on `main` since #989 (c3b7589a9, Aug 7). It does not run in the per-PR required checks, so nobody saw it until the release workflow's full-suite dry run (31224697313).

## What broke

#989 closed a real fail-open. The `/doctor/*` probes used to be mounted on every deployment behind a per-request `environment("NODE_ENV") === "production"` refusal — which answers "not production" for an unset NODE_ENV, and `undefined` on every edge runtime. Mounting is now the whole access control, decided once per composition behind `deps.development`.

That PR taught its own fixtures (`mcp-door.test-util.ts`) to say `development: true`, and this host's `dev` script already sets `NODE_ENV=development`. What it missed is that the corpus e2e harness composes the host **in-process under vitest**, where `NODE_ENV` is `"test"`. So the host the doctor e2e booted mounted no probes:

```
broken: the doctor probes answered 404 while /doctor/base-url — mounted by every
composition in every environment — answered like a Vendo wire. […] Most likely this
composition never declared itself development […]
```

Two failures (`auth/present`, `auth/act-as`), doctor exits 1, the test asserts 0. Doctor was right — it diagnosed the composition correctly and even printed the fix. The harness was the thing standing in for `npm run dev` without doing what `npm run dev` does.

## The change

Test-only, and declared as such: `startTestHost` gains a `development` opt-in beside the existing `trustedOrigin` one, spelled at the single call site that reaches a dev-only route. It sets `NODE_ENV=development` across `createVendo` and restores it after — the same env dance the line above already does for `VENDO_BASE_URL`, because the composition reads both once, at compose time. The other five e2es compose exactly as they did.

No product code moved. The gate #989 installed is correct and stays closed by default.

## Proof

Before, `corpus/hosts/express-host`:

```
 ❯ e2e/doctor.e2e.test.ts (1 test | 1 failed) 1552ms
   × recognizes the committed wiring and completes a live status probe
     AssertionError: expected 1 to be +0
```

After, the whole host suite:

```
 ✓ e2e/approval.e2e.test.ts (1 test) 1130ms
 ✓ e2e/doctor.e2e.test.ts (1 test) 1552ms
 ✓ e2e/generated-view.e2e.test.ts (1 test) 1184ms
 ✓ e2e/fetch-adapter.e2e.test.ts (1 test) 2ms
 ✓ e2e/chat-tool.e2e.test.ts (1 test) 1069ms
 ✓ e2e/status.e2e.test.ts (1 test) 889ms

 Test Files  6 passed (6)
      Tests  6 passed (6)
```

`pnpm build` green, `typecheck` green on the package, `dependency-guard` + `portability-gate` green. No changeset: the package is `private: true` and nothing under `packages/` was touched.

## One thing left alone

`e2e/generated-view.e2e.test.ts:16` hand-rolls a scripted model with no reviewer turn, which is a one-call-out-of-step hazard now that the reviewer pass is mandatory (#928) — the shape `reviewerTurn()` in `fixtures/integration/src/harness.ts` exists for. It passes today and it is not this failure, so it is not in this PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Start the doctor e2e for `@vendoai-corpus/express-host` in development mode, matching npm run dev. This mounts the /doctor/* routes so the probe succeeds and the suite passes again.

- Bug Fixes
  - Added a `development` opt-in to `startTestHost`; temporarily sets NODE_ENV=development during composition and restores it after.
  - Updated the doctor e2e to pass `{ development: true }` at the call site.
  - No product code changes; other e2es unchanged.

<sup>Written for commit 305139205b0cbe72bcf68bffa211b71e4f887a8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

