### PR TITLE
test(vendo): fakeConsole stops answering for the 16 wire ops it never served

### DIFF
--- a/packages/vendo/src/hosted-store.test-util.ts
+++ b/packages/vendo/src/hosted-store.test-util.ts
@@ -31,6 +31,24 @@ export function fakeConsole() {
   const eraseCalls: unknown[] = [];
   const sessions = new Map<string, number>();
 
+  /** A route this fake does not serve is a HOLE IN THE FAKE, and it throws out
+   * of `fetch` so that nothing can read it as the console's own answer. It used
+   * to answer `not-found`, which is exactly what a live console says when it
+   * refuses — so a test driving an unserved op family saw a plausible rejection,
+   * concluded the code handled it, and proved nothing. No production path makes
+   * `fetch` reject with this name, so the signal cannot be mistaken for one.
+   * Serve the route here, or assert this throw. */
+  const unserved = (method: string, path: string, detail?: string): never => {
+    const error = new Error(
+      `fakeConsole does not serve ${method} ${path}`
+      + `${detail === undefined ? "" : ` (${detail})`} — implement it in hosted-store.test-util.ts`,
+    );
+    error.name = "FakeConsoleUnservedRoute";
+    throw error;
+  };
+  const isUnserved = (error: unknown): boolean =>
+    error instanceof Error && error.name === "FakeConsoleUnservedRoute";
+
   const STATUS: Record<string, number> = {
     validation: 400,
     unauthorized: 401,
@@ -72,10 +90,11 @@ export function fakeConsole() {
     }
 
     try {
+      const miss = (detail?: string): never => unserved(request.method, url.pathname, detail);
       const segments = url.pathname.split("/").filter(Boolean).map(decodeURIComponent);
       // /api/v1/store/...
       if (segments[0] !== "api" || segments[1] !== "v1" || segments[2] !== "store") {
-        return envelope("not-found", "unknown route");
+        miss("not the console's store mount");
       }
       const rest = segments.slice(3);
 
@@ -121,7 +140,7 @@ export function fakeConsole() {
               ),
             });
           default:
-            return envelope("not-found", `unknown records op: ${rest[1]}`);
+            return miss(`unknown records op: ${rest[1]}`);
         }
       }
 
@@ -157,7 +176,7 @@ export function fakeConsole() {
           case "list":
             return json({ keys: await blobs.list((body.prefix as string | undefined) ?? "") });
           default:
-            return envelope("not-found", `unknown blobs op: ${rest[1]}`);
+            return miss(`unknown blobs op: ${rest[1]}`);
         }
       }
 
@@ -202,7 +221,7 @@ export function fakeConsole() {
               ),
             });
           default:
-            return envelope("not-found", `unknown records method: ${method}`);
+            return miss(`unknown records method: ${method}`);
         }
       }
 
@@ -241,7 +260,7 @@ export function fakeConsole() {
             return json({ claimed: true });
           }
           default:
-            return envelope("not-found", `unknown session method: ${rest[1]}`);
+            return miss(`unknown session method: ${rest[1]}`);
         }
       }
 
@@ -278,8 +297,9 @@ export function fakeConsole() {
         return json({ report: { vendo_apps: 1, vendo_threads: 2 } });
       }
 
-      return envelope("not-found", "unknown route");
+      return miss();
     } catch (error) {
+      if (isUnserved(error)) throw error;
       if (error instanceof VendoError) return envelope(error.code, error.message);
       return envelope("unavailable", error instanceof Error ? error.message : String(error));
     }

--- a/packages/vendo/src/hosted-store.test.ts
+++ b/packages/vendo/src/hosted-store.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   STORE_WIRE_PATHS,
+  VendoError,
   storeWireBlobsDeleteRequestSchema,
   storeWireBlobsGetRequestSchema,
   storeWireBlobsListRequestSchema,
@@ -1150,5 +1151,29 @@ describe("hostedStore keeps its StoreAdapter surface and gains the op surface", 
     // the adapter's.
     await store.ops.lifecycle.sessionRegister("anon_1", 1_000);
     expect(await store.sessions.stale(1, 100_000)).toEqual(["anon_1"]);
+  });
+
+  // 16 of the 32 ops have no door in the fake: all 6 transcripts, all 3
+  // harness, all 5 workspace, lifecycle.promote and /status. It used to answer
+  // them with a `not-found` envelope — the SAME answer a live console sends
+  // when it refuses — so a test exercising one of those families read a
+  // plausible rejection and asserted nothing. The fake now throws out of
+  // `fetch`, which no console answer can be mistaken for.
+  it("never stands in for a door it does not serve", async () => {
+    const store = hosted(fakeConsole());
+    const unserved: Array<[string, () => Promise<unknown>]> = [
+      ["transcripts", () => store.ops.transcripts.listThreads()],
+      ["harness", () => store.ops.harness.get("app_1", "sub_1")],
+      ["workspace", () => store.ops.workspace.index()],
+      ["lifecycle.promote", () => store.ops.lifecycle.promote("app_1", "org_1")],
+      ["status", () => store.ops.status()],
+    ];
+    for (const [family, call] of unserved) {
+      const error = await call().then(() => undefined, (reason: unknown) => reason);
+      expect(error, family).toBeInstanceOf(Error);
+      expect((error as Error).name, family).toBe("FakeConsoleUnservedRoute");
+      // Not a VendoError: a wire-legal code would be the console's own voice.
+      expect(error, family).not.toBeInstanceOf(VendoError);
+    }
   });
 });


### PR DESCRIPTION
## The lie

`fakeConsole` (`packages/vendo/src/hosted-store.test-util.ts`) is the double for the hosted console. It serves **16 of the 32** ops the real adapter emits, and had no door for the other 16:

| family | ops | path |
| --- | --- | --- |
| `transcripts.*` | 6 (putThread, getThread, listThreads, deleteThread, putMessage, recordAnswer) | `/transcripts/*` |
| `harness.*` | 3 (get, set, clear) | `/harness/*` |
| `workspace.*` | 5 (index, read, commit, history, undo) | `/workspace/*` |
| `lifecycle.promote` | 1 | `/lifecycle/promote` |
| `status` | 1 | `GET /status` |

Every one fell through to `envelope("not-found", "unknown route")` — **the same answer a live console sends when it refuses.** So a test exercising one of those families saw a plausible rejection, concluded the code handled the refusal correctly, and passed while asserting nothing. Same failure class as the fakes that agreed with themselves. (The envelope was not even wire-correct: Store Wire v1 answers an unknown op with an enveloped `not-implemented`/501.)

Verified against the source, not the brief: the adapter's own routes (`hostedStore`'s per-collection records/blobs/sessions/erase legs, `hostedStoreOps`' 7 records + 4 blobs + `lifecycle.erase`/`adopt`/`session.*`) are all served; the 16 above are not. The count in the brief was exactly right.

## The mechanism

An unserved route now **throws out of `fetch`** with `name: "FakeConsoleUnservedRoute"`, naming the method, the path, and the file to add the door to. No production path makes `fetch` reject that way, so a hole in the fake can never be read as the console's voice. The four per-family `unknown … op` fallthroughs go the same way, and the handler's catch rethrows the signal instead of laundering it into a 503 envelope.

**Deliberately not implementing the 16 families.** That would be a second, hand-written in-memory copy of `createStoreOps` (`packages/store/src/ops.ts`), free to disagree with the console in fresh ways — the mock-the-counterparty failure over again, and ~200 lines of it. The throw makes the gap unconsumable and points the next author at the exact door to add when a test needs one.

## Does anything break? No — and that is the finding

Instrumented run (fake logs every unserved route it is asked for, keeps the old envelope) across **all six suites that import it** — `hosted-store`, `hosted-store-notice`, `hosted-sessions`, `app-access-door`, `automations-defer`, `server` — **215 tests, zero requests to an unserved route.** Those six are the complete blast radius; nothing else imports the util, directly or transitively. So no test was passing on a fake refusal: the gap was **latent, not load-bearing.** No vacuous assertion and no hidden product defect surfaced.

The new test is the lock. Reverting the throw to the old envelope fails it with the lie spelled out:

```
AssertionError: transcripts: expected 'VendoError' to be 'FakeConsoleUnservedRoute'
```

## Gate

- `pnpm build --filter=@vendoai/vendo...` — 13/13 ✅
- `vitest run` over all 6 fakeConsole consumers + the new test — **215 + 52 passed** ✅
- `pnpm typecheck --filter=@vendoai/vendo` ✅; plus a throwaway config that **includes** the test estate (which `tsconfig.json` excludes): 98 errors on this branch, 98 on the pristine tree, diff is two line-number shifts of pre-existing errors — **no new type errors**
- `pnpm lint` ✅

The full `packages/vendo` suite is CI's job; this PR's green `ci` check is the gate of record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `fakeConsole` to throw `FakeConsoleUnservedRoute` for the 16 store‑wire ops it doesn’t implement, instead of replying with a `not-found` envelope. This prevents tests from mistaking a fake gap for a real console refusal and adds a test to lock the behavior.

- **Bug Fixes**
  - Unserved routes now throw out of `fetch` with `FakeConsoleUnservedRoute` (covers `transcripts.*`, `harness.*`, `workspace.*`, `lifecycle.promote`, and `GET /status`).
  - Unknown per-family op fallthroughs now throw and are rethrown by the handler; no envelope wrapping.
  - Added a test that asserts the throw and that it is not a `VendoError`; existing suites remain green.

<sup>Written for commit d455871a7891e7bc23f3a552ee5e96bddb9ba234. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

