### PR TITLE
test(ci,corpus,examples): CI runs the last four suites it never executed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,6 +310,46 @@ jobs:
       - name: Turbo remote cache (GitHub-cache backed)
         uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
       - run: pnpm install --frozen-lockfile
+      # Four suites CI never executed. Each has a `test` script and no
+      # `test:coverage`, so test-rest's turbo run passes over them and no step
+      # named them — they ran only in release.yml's unfiltered `pnpm test`,
+      # which is the worst possible place to first learn a suite is red. That is
+      # not hypothetical: the Express host's doctor e2e went red on main when
+      # #989 tightened the /doctor/* mounting gate and stayed red for hours,
+      # invisible to every PR, until a release dry run tripped over it (#1046).
+      #
+      # UNGUARDED by the skip probe below, and deliberately still without a
+      # `test:coverage` script, because both of those decide on turbo's
+      # dependency graph and these suites' real inputs are not in it: they read
+      # examples/ and corpus/ trees off disk and drive the CLI at the repo root.
+      # A probe would therefore skip exactly the PR that fixes one of them.
+      #
+      # They are invoked per package rather than through `turbo run test`, which
+      # would also run each example's own `build` — a full `next build` nobody
+      # needs, since these suites import the example's `src/` directly and need
+      # only their workspace deps built. That is what the `^...` step below
+      # builds (14 tasks, replayed from the remote cache that typecheck-lint's
+      # `pnpm build` fills). Sequential steps, not one parallel turbo run, for
+      # the same reason as the redteam/automations steps further down. All four
+      # are hermetic — scripted models, temp PGlite stores, no network, no keys;
+      # ai-sdk-agent's two live journeys self-skip without a key.
+      - name: Build the orphan suites' workspace deps (no example builds)
+        run: pnpm turbo run build --filter=@vendoai/bench^... --filter=@vendoai-corpus/express-host^... --filter=@vendoai-examples/ai-sdk-agent^... --filter=@vendoai-examples/mastra-agent^...
+      # Perf-budget arithmetic: stats, report, budgets, and the create-total
+      # guard. Pure functions — no bench actually runs here.
+      - run: pnpm --filter @vendoai/bench test
+      # The Express corpus host: six e2e that boot the real relay on loopback
+      # over real HTTP (status, chat-tool, approvals, generated view, the fetch
+      # adapter, and `vendo doctor` against the running wire).
+      - run: pnpm --filter @vendoai-corpus/express-host test
+      # The AI SDK example's four-touch diff: guarded action, generated UI,
+      # approvals. The two cloud-posture journeys gate on a live key and skip.
+      - run: pnpm --filter @vendoai-examples/ai-sdk-agent test
+      # The Mastra example's SEAM suite — a real Mastra Agent turn parking a
+      # risky tool call, approving it over the wire, and executing the real
+      # handler, against the example's own composeVendo and checked-in
+      # .vendo/tools.json. Added by #1001 and never once run in CI until now.
+      - run: pnpm --filter @vendoai-examples/mastra-agent test
       # Same skip contract as test-shards: `--affected` marks a package when it
       # or ANY of its workspace deps changed (verified: a one-line core edit
       # marks every fixture and demo below), so a skip here can never hide a

--- a/examples/mastra-agent/package.json
+++ b/examples/mastra-agent/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "vitest run --passWithNoTests",
+    "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint"
   },


### PR DESCRIPTION
## What

Four suites existed in the tree and neither of CI's two discovery mechanisms ever reached them:

| Suite | Tests | Result on its first CI run |
|---|---|---|
| `@vendoai/bench` | 30 | green |
| `@vendoai-corpus/express-host` | 6 e2e | green (after #1046) |
| `@vendoai-examples/ai-sdk-agent` | 4 + 2 live-gated | green |
| `@vendoai-examples/mastra-agent` | 5 (the seam suite) | green |

Each has a `test` script and no `test:coverage`, so `test-rest`'s `turbo run test:coverage` passes over them, and no step named them. They are wired as explicit steps in the `integration` job — the same mechanism `demo-bank` already uses.

## Why this is not cosmetic

**`release.yml` runs an unfiltered `pnpm test`, so these suites *were* caught — at release time.** That is the worst possible place to first learn a suite is red: the discovery happens when the tarball is being cut, by whoever is publishing, on a change that merged hours or days earlier.

**#1046 is exactly that bill arriving.** The Express host's doctor e2e went red on `main` the moment #989 tightened the `/doctor/*` mounting gate, stayed red for hours — invisible to every PR merged in that window — and surfaced in a release dry run. This PR moves that discovery to the PR that causes it.

I found and diagnosed the same failure independently while wiring this up (same cause, same fix, same `development` option name); #1046 landed first, so nothing of that fix remains in this diff. It is a clean confirmation of the diagnosis: the doctor's behaviour was the intended security posture, the test was stale, and no product code needed touching.

## Two design points, honoured

- **The four steps are UNGUARDED by the `integration` job's affected probe.** Two of them read `examples/` and `corpus/` trees off disk and drive the repo-root CLI — inputs turbo's dependency graph cannot see. A probe would skip exactly the PR that fixes one of them, which is precisely how the #1046 failure landed clean. This run proves the point: the probe declared the scope unaffected and skipped all five pre-existing steps, while the four new ones ran.
- **No `test:coverage` scripts were added**, for the same reason.

## Build and server requirements

All four import their own `src/` directly and need only their **workspace deps** built, not their own build — so no `next build` runs here. One `turbo run build --filter=<pkg>^...` step covers all four. They are invoked per package rather than through `turbo run test`, which *would* trigger each example's `next build`. They stay sequential steps rather than one parallel turbo run, for the reason already stated on the redteam/automations steps.

`express-host` boots the real Express relay on loopback over real HTTP with a temp PGlite store per test — the same shape the `redteam-e2e` and `automations-e2e` steps already run in this job. All four are hermetic: scripted models, no network, no keys. `ai-sdk-agent`'s two cloud-posture journeys self-skip without a live key.

## Cost — measured on this PR's own CI run

Run [31227226683](https://github.com/runvendo/vendo/actions/runs/31227226683), `integration` job, steps 8–12:

| Step | Wall clock |
|---|---|
| Build the orphan suites' workspace deps | **1s** — `14 successful, 14 total` · `FULL TURBO` |
| `@vendoai/bench` | 6s |
| `@vendoai-corpus/express-host` | 17s |
| `@vendoai-examples/ai-sdk-agent` | 11s |
| `@vendoai-examples/mastra-agent` | 16s |
| **Total added** | **51s** |

**+51 seconds.** I had estimated 4–6 min from local timings; that was contention on a shared box, not the real number. `integration` goes from 7m47s to ~8m40s on `main`, so it stays roughly level with the longest vendo shard (8m13s) and **CI's wall clock barely moves**. `timeout-minutes: 30` is untouched. The dep-build step is a pure remote-cache replay, because `typecheck-lint`'s unguarded `pnpm build` fills the same cache.

At 51s there is no tradeoff worth bringing to you: a separate parallel job would save nothing and cost a second install.

## The seam suite

`examples/mastra-agent`'s `test` drops `--passWithNoTests`. Its suite is exactly the kind `CLAUDE.md` demands — a real Mastra `Agent.generate()` turn parking a risky tool call through the example's own `composeVendo` and checked-in `.vendo/tools.json`, approving it over the wire, and executing the real handler, with only the model scripted and the store in a temp dir. It had never run in CI. With that flag, the day its include pattern stops matching, the suite reports green with zero tests.

**It runs 5/5 green in CI**, so the seam it claims to prove is real — the park, the `vendo/approval-ref@1` envelope reaching the loop without blocking, the wire approval executing the real handler, `vendo_make`'s `vendo/app-ref@1`, `vendo_delegate`, and the fail-closed path when the principal is absent from the request context.

## `CLAUDE.md`

No correction needed — the `hermetic-extras` claim was already removed by **#1000** (`docs: make the docs match the repo after the day's cuts`). The paragraph on `main` today lists `typecheck-lint`, `test-shards`, `test-rest`, `coverage-merge`, and `ci`, which matches `ci.yml`'s eight jobs exactly. The stale claim survives only in older checkouts.

## Not fixed here (reported, not touched)

- `ai-sdk-agent`'s `byo-agent` e2e logs `the validate gate could not read /user/apps/…/app.vendo back, so app_… was not gated — store is closed`. The app-validate gate silently no-ops when the store closes under it. The test passes; the warning suggests a real ordering issue worth a look.
- `vendo doctor` reports `ok: the app's root page renders (HTTP 404)` against the Express host, because its client bundle is not built in the e2e. A 404 reported as `ok` is a weak probe.
- #1044 is still open and wires a fifth orphan (`existing-agents-e2e`) into the same spot in this job. Whichever lands second needs a trivial conflict resolution.

## Verification

CI run [31227226683](https://github.com/runvendo/vendo/actions/runs/31227226683) is green across all 17 jobs, and the `integration` log shows each of the four suites reporting its own test counts: `30 passed (30)`, `6 passed (6)`, `4 passed | 2 skipped (6)`, `5 passed (5)`. Locally: `turbo run typecheck lint` on the touched scope, `dependency-guard`, `portability-gate`. No UI surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
