### PR TITLE
fix(vendo,harnesses): two checks stop reporting a verdict they never reached

### DIFF
--- a/.changeset/two-probes-stop-blessing-a-check-they-never-ran.md
+++ b/.changeset/two-probes-stop-blessing-a-check-they-never-ran.md
@@ -1,0 +1,27 @@
+---
+"@vendoai/vendo": patch
+"@vendoai/harnesses": patch
+---
+
+Two checks stop reporting a verdict they never reached.
+
+`vendo doctor`'s render probe GETs the app origin's `/` and never reads the body, so a
+status line is the whole observation. It failed on 5xx and blessed everything else as
+"the app's root page renders" — which made `ok: the app's root page renders (HTTP 404)`
+the line every healthy run printed, on the one status that means the server is saying
+there is no page here.
+
+A 5xx still fails `E-LIVE-006` unchanged; that is the crashing-site case the gate exists
+for. A 4xx is now a note that names the status and says no page was reached, because a
+host serving nothing at `/` — every page under a basePath, an auth layer in front — is
+healthy, and doctor cannot tell that from a route you meant to have. That is the same
+judgement the probe's own unreachable-origin branch already declines to make. A 2xx
+passes as "answered HTTP 200": true, and the most this probe can know.
+
+In the screen agent, a save that landed bytes the render seam would not paint was told
+"validate found nothing to fix". `validateWrittenApps` is fail-open by design and returns
+no failures both when validate passed and for every way it could not reach a verdict — a
+guard that denied the call, an answer it cannot parse, a workspace that closed under it,
+each reported to the operator only. The hand cannot tell those apart, so it no longer
+claims to: it states the failed paint, which is the fact it has. When the gate did produce
+findings, the note is still the repair instruction verbatim.

--- a/packages/harnesses/src/screen-agent.test.ts
+++ b/packages/harnesses/src/screen-agent.test.ts
@@ -110,8 +110,10 @@ function harness(options: {
   /** Force every commit to answer `conflict`, so nothing lands. */
   conflict?: boolean;
   authoredApp?: boolean;
+  /** Guard verdicts by tool name, so a test can take a verb away from the loop. */
+  guardPolicy?: Record<string, "run" | "ask" | "block">;
 }): Harness {
-  const guard = testGuard();
+  const guard = testGuard(options.guardPolicy);
   const descriptors = options.tools ?? [spendSummary, sendMoney, validate, searchComponents, vendoMake];
   const registry = boundRegistry(
     Object.fromEntries(descriptors.map((descriptor) => [
@@ -251,6 +253,23 @@ describe("assembly writes through the real path and the seam paints it", () => {
     expect(screen.authoredCalls).toHaveLength(0);
     // The front door is what turns this into a fall-through: it finds no ROW.
     expect(result.kind).toBe("assembled");
+  });
+
+  /** The gate is FAIL-OPEN by design (`validate-gate.ts`): a validate that could
+   *  not run is not a finding. But "could not run" and "ran and found nothing" are
+   *  different facts, and this hand reported the second for both — so a loop whose
+   *  gate never executed was told its document had been checked and cleared. */
+  it("never claims validate cleared a document when the gate could not run at all", async () => {
+    const screen = harness({
+      turns: [saveApp(BROKEN_APP), textTurn("done")],
+      guardPolicy: { validate: "block" },
+    });
+    await screen.assemble("show me my spending");
+
+    // The note rides back as the save_app tool result, so it is in the next prompt.
+    const note = JSON.stringify(screen.model.prompts[1] ?? "");
+    expect(note).toContain("did not reach the person's screen");
+    expect(note).not.toContain("validate found nothing to fix");
   });
 
   it("a commit that did not land is told to the model, not swallowed", async () => {

--- a/packages/harnesses/src/screen-agent.ts
+++ b/packages/harnesses/src/screen-agent.ts
@@ -396,11 +396,16 @@ export async function assembleScreen(
           workspace: turn.workspace,
           paths: [`${directory}/${APP_FILE}`],
         }));
+        // No instruction covers BOTH "validate cleared it" and every way the gate
+        // could not reach a verdict — a denied call, an unreadable answer, a
+        // workspace that closed under it — each of which the gate reports to the
+        // operator and returns empty for, its fail-open being deliberate. So this
+        // hand cannot say which happened, and claiming the first told the loop its
+        // document had been checked when nothing had checked it. The failed paint
+        // is the fact this hand does have, and it is enough to act on.
         return {
           saved: true,
-          note: instruction
-            ?? "That save landed but did not reach the person's screen, and validate found nothing to fix."
-            + " Save a simpler document.",
+          note: instruction ?? "That save landed but did not reach the person's screen. Save a simpler document.",
         };
       }
       return { saved: true, note: "Run validate on it now." };

--- a/packages/vendo/src/cli/doctor-probe-checks.ts
+++ b/packages/vendo/src/cli/doctor-probe-checks.ts
@@ -176,15 +176,28 @@ export async function checkLiveStatus(run: DoctorRun, e2bResolvable: ((root: str
 /** Render gate (0.4.1 E2E cert M3): a live wire proves nothing about the
  *  PAGES — the certified invoify install had every page 500ing (registry
  *  passed across the Server Component boundary) while doctor exited 0. One
- *  cheap GET of the app root catches a site that is down for users. */
+ *  cheap GET of the app root catches a site that is down for users.
+ *
+ *  It catches THAT and nothing more, so it claims nothing more. A status line
+ *  is the whole observation: doctor never parses the body, so even a 200 is
+ *  "the server answered", not "the page is right" — and a 4xx is the server
+ *  answering that there is no page here at all, which is the same fact the
+ *  catch below already declines to judge. Reporting either as `ok: the app's
+ *  root page renders` made 404 the blessing every healthy run printed and left
+ *  the check unable to fail on anything but 5xx. */
 export async function checkRootRender(run: DoctorRun): Promise<void> {
   const { statusUrl, fetchImpl } = run;
   try {
     const response = await fetchImpl(`${new URL(statusUrl).origin}/`, { headers: { accept: "text/html" } });
     if (response.status >= 500) {
       run.fail("live/render", "E-LIVE-006", `the app's root page returned ${response.status} — the site is crashing for users even though the wire answers (typical cause: the component registry declared in a Server Component layout; move it into your own "use client" file with the provider). Check the dev server log.`);
+    } else if (response.status >= 400) {
+      // Not a pass and not a failure: a host that serves nothing at `/` — every
+      // page under a basePath, an auth layer in front — is healthy, and doctor
+      // cannot tell that apart from a route you meant to have.
+      run.note(`  the app's root page answered HTTP ${response.status}, so this run did not reach a page to check. If you expected a page at ${new URL(statusUrl).origin}/, check your routes; a host that serves nothing there is fine.`);
     } else {
-      run.pass("live/render", `the app's root page renders (HTTP ${response.status})`);
+      run.pass("live/render", `the app's root page answered HTTP ${response.status}`);
     }
   } catch {
     // The wire answered but the origin root didn't resolve at all — hosts

--- a/packages/vendo/src/cli/doctor.test.ts
+++ b/packages/vendo/src/cli/doctor.test.ts
@@ -1741,6 +1741,49 @@ describe("vendo doctor error codes + fix_refs", () => {
     expect(messages.errors.join("\n")).toContain("root page returned 500");
   });
 
+  // The other half of the render gate: it fails on 5xx and blessed EVERYTHING
+  // else, so `ok: the app's root page renders (HTTP 404)` was the line every
+  // healthy run printed. A 404 is the one status that means the opposite — no
+  // page is served at `/` — which the catch below already calls none of doctor's
+  // business. So the probe may report the status it saw; it may not claim a
+  // render it never observed.
+  it("does not claim the root page renders when the origin answers 404", async () => {
+    const root = await healthy();
+    const messages = output();
+    expect(await doctor({
+      targetDir: root,
+      fetchImpl: successfulProbeFetch() as unknown as typeof fetch,
+      output: messages.sink,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    })).toBe(0);
+    const rootLines = [...messages.logs, ...messages.errors].filter((line) => line.includes("root page"));
+    expect(rootLines.join("\n")).toContain("404");
+    expect(rootLines.some((line) => line.startsWith("ok:"))).toBe(false);
+    expect(rootLines.join("\n")).not.toContain("renders");
+  });
+
+  // A 2xx proves the server answered, not that the page is correct — so the pass
+  // says what was observed rather than asserting a render doctor cannot see.
+  it("reports the observed status when the root page answers 200", async () => {
+    const root = await healthy();
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url === "http://localhost:3000/") return new Response("<html></html>", { status: 200 });
+      if (url.endsWith("/status")) return Response.json({ posture: "unconfigured", version: CLI_VERSION, blocks: { store: true, sandbox: "cloud" } });
+      if (url.endsWith("/doctor/present")) return Response.json({ ok: true });
+      if (url.endsWith("/doctor/act-as")) return Response.json({ ok: true });
+      return Response.json({}, { status: 404 });
+    });
+    const messages = output();
+    expect(await doctor({
+      targetDir: root,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      output: messages.sink,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    })).toBe(0);
+    expect(messages.logs.join("\n")).toContain("ok: the app's root page answered HTTP 200");
+  });
+
   // Split-brain guard (0.4.2 re-run): a direct @vendoai/vendo dep pinned to
   // an older range beats the vendoai umbrella's for the app import, so the
   // CLI upgrades while /status silently serves the old runtime.


### PR DESCRIPTION
Two findings surfaced while previously-unrun suites were wired into CI (#1048). Both were reproduced first, both got a failing test that was watched failing before any fix, and the tests are their own commit.

## Verdicts up front

| Finding | Verdict |
|---|---|
| `vendo doctor` reports `ok` for an HTTP 404 | **Real defect.** A shipped, user-facing probe that could not fail. |
| The app-validate gate no-ops when the store closes under it | **Not a fail-open — refuted.** Its headline is cosmetic, but it concealed one real, production-reachable false claim. |

Severity, not flattened: finding 2 is a shipped user-facing probe that could not fail. Finding 1's headline is cosmetic — a deliberate, correctly-reasoned fail-open whose log line was already honest — but it concealed one real false claim, now fixed. Neither half inflates the other.

## Finding 2 — doctor's render probe could not fail

Reproduced from doctor's own tests: `successfulProbeFetch()` 404s anything it does not explicitly serve, including the app origin's `/`, so **most of doctor's own test runs printed `ok: the app's root page renders (HTTP 404)`.**

**Why it happened — this is the reusable lesson.** `checkRootRender` GETs `/` and **never reads the body**, so a status line is the entire observation. It then failed on exactly one narrow condition — `>= 500` — and passed *everything else* as "the app's root page renders". A check that only rejects one narrow failure mode passes everything else, forever, and reads as proof. 404 is the one status that means the opposite of "renders": the server saying there is no page here. The probe's own unreachable-origin `catch` already declares that "hosts that serve no page at / are not doctor's business" — so the pass branch was contradicting the catch branch about the same fact.

Following the doctor-diagnosis precedent in this same file (report what was observed; never assert a conclusion the code cannot support), this adds **no new confident claim and no new error code**:

- `>= 500` → **fails `E-LIVE-006`, wording unchanged.** The crashing-site case the gate was built for (0.4.1 invoify cert). Its existing test still passes.
- `>= 400` → a **note** naming the status and saying no page was reached. Not a pass, not a failure: a host serving nothing at `/` (every page under a `basePath`, an auth layer in front) is healthy, and doctor cannot distinguish that from a route you meant to have. Same judgement the `catch` already refuses to make.
- `2xx`/`3xx` → passes as `answered HTTP 200`. Doctor never parsed the body, so "the server answered" is true and "the page renders" was never observed.

`docs-site/reference/cli.mdx` already documents this as "a 5xx there fails doctor", so it stays accurate.

## Finding 1 — the fail-open framing is refuted

Reproduced in `examples/ai-sdk-agent`: `the validate gate could not read …/app.vendo back, so app_… was not gated — [vendo] store is closed`, suite green.

**1. Is the gate load-bearing? No — it cannot refuse an app, so there is no "open" to fail.**

The enforcing floor is the **paint seam**, not this gate. `render-seam.ts` compiles and checks every commit, and a `block` finding means nothing paints and the last good view stays. `validateWrittenApps` runs *downstream* of that, and its only power is to produce one repair prompt. All three call sites say so:

- `validate-gate.ts:24-27` — "FAIL-OPEN, everywhere. A validate that could not run is not a finding", with the reasoning: treating it as one would spend the builder's fix round repairing an app nobody said was broken, and could end a turn because a guard happened to be busy.
- `claude-code/index.ts:629-630` — "the seam already refuses to paint a lie, so an unfixed app costs a screen, never the truth."
- `screen-agent.ts:516-518` — "Whatever survives it stands — the screen has already painted."

The deliberate fail-open is correct and stays. The log line was already honest: it says the gate did not run, and why.

**2. What closes the store? Test lifecycle only.** `vendo_make` returns an app-ref before the build settles, by design. The example's test polls `/open` until 200 — which is **paint, not build completion** — then `afterEach` closes the store while the screen agent's mandatory reviewer pass is still in flight. There are no `SIGTERM`/`SIGINT` handlers closing the store anywhere in the repo, so a real dying process logs nothing at all. No test files were changed for this; the leaked background build is the example test's own issue and deserves its own change if wanted.

**3. The one thing that genuinely lied — and this is the more valuable finding.** `validateWrittenApps` returns an empty array **both** when validate passed **and** for every way it could not reach a verdict. The `save_app` hand read that as the first case only:

> That save landed but did not reach the person's screen, and validate found nothing to fix.

With the guard blocking `validate`, the gate logs `was not gated — blocked` and **the model is told its document was checked and cleared.** That is the silent-success shape aimed at the *model*, not an operator log, and it needs no shutdown — a denied call, an unparseable answer, or an open breaker is enough, so it is production-reachable. The hand cannot distinguish those cases, so it no longer claims to: it states the failed paint, which is the fact it has. When the gate did produce findings, the note is still the repair instruction verbatim.

The same no-op also appears in `packages/vendo/src/ladder.e2e.test.ts` as `could not validate app_digest … — Tool validate was not found` — further evidence the gate routinely does not run in tests.

## Test plan

- `packages/vendo/src/cli/doctor.test.ts` — 404 must not be reported as a render; 200 reports the observed status. Both watched failing before the fix.
- `packages/harnesses/src/screen-agent.test.ts` — with the guard blocking `validate`, the note must not claim validate cleared the document. Watched failing (`expected … not to contain 'validate found nothing to fix'`) with the gate's own `was not gated — blocked` line in the same output. Drives the real `screenAssembler` over the real workspace and render seam; `harness()` gained one optional `guardPolicy` passthrough to `testGuard`.

## CI note — `test-rest (group-b)` is pre-existing, not from this PR

`group-b` fails on `@vendoai/core#test:coverage`: `Coverage for lines (96.99%) does not meet global threshold (97%)`. All 1067 core tests pass; it is purely a threshold miss.

Ownership established against the merge base rather than assumed:

- This PR changes 5 files, **none in `packages/core`** (`git diff --name-only 89d555358 HEAD -- packages/core` is empty).
- The **identical** failure is on main's tip `89d555358` — this PR's merge base, i.e. #1048 — with the same numbers and the same failing task:

| | branch (job 93028291595) | merge base `89d555358` (job 93026928418) |
|---|---|---|
| error | `lines (96.99%) does not meet global threshold (97%)` | `lines (96.99%) does not meet global threshold (97%)` |
| failed task | `@vendoai/core#test:coverage` | `@vendoai/core#test:coverage` |

**Main is currently red and this branch inherited it.** Raising core's coverage is a separate change and is not in this PR's scope.

Everything else on this PR is green, including all four `vendo` shards, `integration` (which runs the ai-sdk-agent suite this started from), `typecheck-lint`, `conformance`, `audit`, and Greptile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)