### PR TITLE
test(core): pin the Kit prompt in the package that generates it — main's coverage floor is green again

### DIFF
--- a/packages/core/src/kit/kit-prompt.test.ts
+++ b/packages/core/src/kit/kit-prompt.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { kitPrompt } from "./kit-prompt.js";
+import { KIT_SPECS } from "./specs.js";
+
+/**
+ * W2 §The Kit — the GENERATED model-facing prompt section. The generator was
+ * hoisted from `@vendoai/ui` to core (see kit/index.js); `@vendoai/apps` renders
+ * the COMPONENTS section of the generation contract from it
+ * (generation/contracts/sections.ts). ui's registry test reaches this code
+ * through a re-export shim, so the render contract itself was never pinned in
+ * the package that owns it — these tests pin it here.
+ */
+describe("kitPrompt() — the generated model-facing Kit section", () => {
+  it("leads with the two laws, and drops them on request", () => {
+    expect(kitPrompt()).toContain("# The Kit");
+    expect(kitPrompt({ omitPreamble: true })).not.toContain("# The Kit");
+  });
+
+  it("renders a prop as `name` [class] (required) — doc, and omits the marker when optional", () => {
+    const prompt = kitPrompt({ only: ["Money"] });
+    expect(prompt).toContain("- `cents` [data] (required) — amount in integer cents (minor units)");
+    expect(prompt).toContain("- `currency` [config] — ISO 4217 code, default USD");
+  });
+
+  it("labels the example block for its count", () => {
+    // DateTime carries two examples, Money one; the model reads the label.
+    expect(kitPrompt({ only: ["DateTime"] })).toContain("Examples:");
+    const money = kitPrompt({ only: ["Money"], omitPreamble: true });
+    expect(money).toContain("Example:");
+    expect(money).not.toContain("Examples:");
+  });
+
+  it("titles each group, in the reading order the model is taught", () => {
+    const prompt = kitPrompt();
+    const titles = [
+      "# Layout",
+      "# Values (semantic — formatted for you)",
+      "# Data",
+      "# Charts",
+      "# Forms & actions",
+      "# Feedback & interactive",
+    ];
+    const positions = titles.map((t) => prompt.indexOf(t));
+    expect(positions, `missing group heading: ${titles.filter((t, i) => positions[i] === -1).join(", ")}`)
+      .not.toContain(-1);
+    expect(positions).toEqual([...positions].sort((a, b) => a - b));
+  });
+
+  it("drops the group headings when scoped — scoped output is a flat list", () => {
+    const scoped = kitPrompt({ only: ["Money", "DataTable"] });
+    expect(scoped).toContain("## <Money>");
+    expect(scoped).toContain("## <DataTable>");
+    expect(scoped).not.toContain("# Values (semantic — formatted for you)");
+    expect(scoped).not.toContain("# Data\n");
+  });
+
+  it("teaches every registered component and nothing that is not registered", () => {
+    const prompt = kitPrompt();
+    for (const spec of KIT_SPECS) expect(prompt, `missing <${spec.name}>`).toContain(`## <${spec.name}>`);
+    const taught = [...prompt.matchAll(/^## <(\w+)>$/gm)].map((m) => m[1]);
+    expect(taught.sort()).toEqual(KIT_SPECS.map((s) => s.name).sort());
+  });
+});


### PR DESCRIPTION
## `main` was red; this makes it green honestly

CI's `test-rest (group-b)` has been failing on every PR with:

> `ERROR: Coverage for lines (96.99%) does not meet global threshold (97%)` — `@vendoai/core#test:coverage`

All core tests passed. It was purely the ratio.

## The specific cause — measured, not guessed

The leading hypothesis was #1036 (`delete undo and rollback entirely`). **It is not.** I ran core's coverage at three points:

| commit | lines | result |
|---|---|---|
| `354f23173` — #1036, the undo deletion | **97.02%** (9297/9582, 60 files, 1094 tests) | green |
| `fed58ab57` — `main` HEAD | **96.99%** (9194/9479, 57 files, 1067 tests) | **red** |

Only one commit touched `packages/core` in between: **#1024 `cut(core): nine dead exports, one assertion vocabulary, three merged suites`**.

Diffing the two per-file `coverage-summary.json` reports shows exactly what moved:

| file | before | after | Δ uncovered |
|---|---|---|---|
| `src/semantics.ts` | 135/135 | 66/66 | **0** |
| `src/conformance/index.ts` | 343/343 | 323/323 | **0** |
| `src/conformance/store-ops.ts` | 670/674 | 656/660 | **0** |
| `src/sse-keepalive.ts` | 59/59 | 48/48 | **0** |
| `src/conformance/knowledge.ts` | 247/252 | 239/244 | **0** |
| `src/conformance/app-access.ts` | 248/248 | 246/246 | **0** |
| `src/conformance/assertions.ts` | 0/0 | 21/21 | **0** |

#1024 deleted 103 lines and **every one of them was a covered line**. The uncovered-line count is *identical* on both sides — **285 before, 285 after**. Nothing got worse; the denominator shrank. 285/9582 = 2.97% uncovered → 285/9479 = 3.01% uncovered, and the floor was breached by **exactly one line** (9194 covered, 9195 needed).

So the mechanism the team suspected was right; the PR was not. Deleting well-covered dead code lowers the ratio.

## The fix, and why the alternatives were wrong

Since no code lost its tests, "restore the lost coverage" had no target — but hunting for the honest line surfaced a genuine hole.

`kitPrompt()` generates the model-facing COMPONENTS section of the generation contract, consumed in production by `packages/apps/src/generation/contracts/sections.ts:75`. W3 **hoisted it from `@vendoai/ui` into core** — and its tests stayed behind in `packages/ui/test/kit/registry.test.ts`, which reaches this code through a pure re-export shim (`packages/ui/src/kit/kit-prompt.ts` is one `export {} from "@vendoai/core"` line). Core owned the generator and pinned none of it: the entire module (lines 31-49, 63-86) read as uncovered, its coverage credit landing in ui's ledger.

That is real, load-bearing, consumer-facing code tested in the wrong package. Six tests now pin core's own render contract, deliberately covering behaviour **ui never asserted**:

- `omitPreamble` — untested anywhere before
- the group titles and their reading order (a lost `GROUP_TITLE` entry silently feeds the model a raw key like `values`)
- the documented flat-list shape of scoped output (`if (!options.only)`)
- the exact prop line `` - `cents` [data] (required) — … `` — ui only did a loose `/config/` regex
- the singular/plural example label

### Every test is proven able to fail

Each was run against a distinct mutation of `kit-prompt.ts`, and each mutant was killed by its own test (source restored clean after every run):

| mutation | test that failed |
|---|---|
| `if (options.omitPreamble)` (inverted) | leads with the two laws |
| `const req = ""` (required marker dropped) | renders a prop as `name [class] (required)` |
| `> 1 ? "Example:" : "Examples:"` (flipped) | labels the example block |
| group sort reversed | titles each group, in reading order |
| `GROUP_TITLE.values` entry deleted | titles each group, in reading order |
| headings emitted when scoped | drops group headings when scoped |
| one component silently filtered out | teaches every registered component |

**What I did not do:**
- **Did not lower the floor.** It stays at 97. The measured value is now 97.38%, so the ratchet keeps its meaning.
- **Did not exclude or delete any source file** from the coverage set.
- **Did not write filler.** Every assertion above fails for a real reason, demonstrated.
- **Did not touch `packages/ui`.** Its registry drift test is untouched, and its floor is another PR's business.

## Result

`@vendoai/core`: **97.38% lines, 1073 tests, 58 files, exit 0.** One file added, nothing else — no source change, no floor change, no lockfile change.

## Other floors — near-miss report

Reported separately to the conductor so nobody's floor gets changed by surprise; no floor other than none is touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tests in `@vendoai/core` to pin the generated Kit prompt (`kitPrompt()`), restoring coverage above the 97% floor so CI on `main` is green again.

- **Bug Fixes**
  - Added `packages/core/src/kit/kit-prompt.test.ts` to cover the prompt generator hoisted from `@vendoai/ui` (coverage now counted in core).
  - Asserted: omit preamble, group titles/order, flat scoped output, prop line formatting, example labels, and registry completeness.
  - No source or floor changes; `@vendoai/core` coverage is now 97.38%.

<sup>Written for commit 02e35e8e2b0198e1272d81034cea59d7958fccf9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

