### PR TITLE
test(telemetry,knowledge,agents,vendoai): cover the guards the floors were pinned against, size all four in lines

### DIFF
--- a/packages/agents/vitest.config.ts
+++ b/packages/agents/vitest.config.ts
@@ -7,8 +7,11 @@ export default defineConfig({
       reporter: ["text", "json-summary"],
       include: ["src/**/*.{ts,tsx}"],
       exclude: ["src/**/*.test.{ts,tsx}", "src/**/*.test-util.{ts,tsx}"],
-      // Ratcheted floor, sibling-package style — set just below measured; it can only rise.
-      thresholds: { lines: 93 },
+      // Ratcheted floor, sized in LINES rather than points: 713 lines means one
+      // point is ~7 lines, so 93 against a measured 94.24 READ like comfortable
+      // slack while tolerating only 9 new uncovered lines — thinner than
+      // telemetry's, and invisible in percent. 91 tolerates 24.
+      thresholds: { lines: 91 },
     },
     include: ["src/**/*.test.ts"],
     environment: "node",

--- a/packages/knowledge/src/agent-tools.test.ts
+++ b/packages/knowledge/src/agent-tools.test.ts
@@ -136,6 +136,67 @@ async function envelopeOf(outcome: Awaited<ReturnType<ToolRegistry["execute"]>>)
 const search = (registry: ToolRegistry, args: Json, id = "call_t2") =>
   registry.execute({ id, tool: VENDO_KNOWLEDGE_SEARCH_TOOL, args }, ctx);
 
+/** Every parseInput rejection. This tool's arguments are MODEL-generated, so
+    a shape the schema forbids is a routine event, not a programming error:
+    each one must come back as a structured validation outcome the agent can
+    read and retry from, never a throw out of execute(). */
+describe("vendo_knowledge_search input validation", () => {
+  const rejectionFor = async (args: Json): Promise<{ code: string; message: string }> => {
+    const outcome = await search(createKnowledgeTools(memoryKnowledgeAdapter({ docs })), args);
+    expect(outcome.status).toBe("error");
+    if (outcome.status !== "error") throw new Error("expected an error outcome");
+    return outcome.error;
+  };
+
+  it("rejects input that is not an object", async () => {
+    // An array is typeof "object": the Array.isArray half of the guard is the
+    // only thing standing between it and a query read off index-less input.
+    for (const args of ["wire transfers", 7, null, [{ query: "wire transfers" }]] as Json[]) {
+      expect(await rejectionFor(args)).toMatchObject({
+        code: "validation",
+        message: "tool input must be an object",
+      });
+    }
+  });
+
+  it("rejects a non-boolean lookup", async () => {
+    expect(await rejectionFor({ query: "wire transfers", lookup: "true" })).toMatchObject({
+      code: "validation",
+      message: "lookup must be a boolean",
+    });
+  });
+
+  it("rejects a readMore that is not an object", async () => {
+    for (const readMore of ["doc-transfers", ["doc-transfers"]] as Json[]) {
+      expect(await rejectionFor({ query: "wire transfers", readMore })).toMatchObject({
+        code: "validation",
+        message: "readMore must be an object",
+      });
+    }
+  });
+
+  it("rejects a readMore without a usable docId", async () => {
+    for (const readMore of [{}, { docId: "" }, { docId: "   " }, { docId: 7 }] as Json[]) {
+      expect(await rejectionFor({ query: "wire transfers", readMore })).toMatchObject({
+        code: "validation",
+        message: "readMore.docId must be a non-empty string",
+      });
+    }
+  });
+
+  it("rejects a present-but-blank readMore.chunkId", async () => {
+    for (const chunkId of ["", "   ", 7] as Json[]) {
+      expect(await rejectionFor({
+        query: "wire transfers",
+        readMore: { docId: "doc-transfers", chunkId },
+      })).toMatchObject({
+        code: "validation",
+        message: "readMore.chunkId must be a non-empty string",
+      });
+    }
+  });
+});
+
 describe("tool policy: intent + escalation + refusal (T2)", () => {
   it("passes only { principal } as knowledge context — includeInternal is never set", async () => {
     const adapter = spyAdapter(memoryKnowledgeAdapter({ docs }));

--- a/packages/knowledge/src/http.test.ts
+++ b/packages/knowledge/src/http.test.ts
@@ -91,6 +91,23 @@ describe("httpKnowledge — posture-shaped surface", () => {
     expect((thrown as VendoError).code).toBe("not-implemented");
   });
 
+  it("names the route when the endpoint answers 200 with a body that is not the wire", async () => {
+    // The BYO implementor's most likely mistake: a live endpoint that answers
+    // successfully in its own shape. It must be told which route disagreed and
+    // which contract it failed, not handed a generic parse error.
+    const ownShape: typeof fetch = async () =>
+      new Response(JSON.stringify({ status: "ok", results: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    const adapter = httpKnowledge({ url: "https://byo.example/kb", fetch: ownShape });
+    const thrown = await adapter.status().catch((error: unknown) => error);
+    expect(thrown).toBeInstanceOf(VendoError);
+    expect((thrown as VendoError).code).toBe("not-implemented");
+    expect((thrown as Error).message).toContain("https://byo.example/kb/status");
+    expect((thrown as Error).message).toContain("vendo/knowledge-wire@1");
+  });
+
   it("names the endpoint when it is unreachable", async () => {
     const down: typeof fetch = async () => { throw new TypeError("fetch failed"); };
     const adapter = httpKnowledge({ url: "https://byo.example/kb", fetch: down });

--- a/packages/knowledge/src/ingest/ingest.test.ts
+++ b/packages/knowledge/src/ingest/ingest.test.ts
@@ -100,6 +100,36 @@ describe("parseSourceFile", () => {
     })).toThrow(/collide/);
   });
 
+  it("treats a heading-less glossary file as one entry named after the file", () => {
+    const docs = parseSourceFile({
+      source,
+      path: "glossary/pricing-terms.md",
+      raw: "Interchange is the fee the card network charges per authorization.\n",
+    });
+    expect(docs).toHaveLength(1);
+    expect(docs[0]).toMatchObject({
+      id: "glossary#glossary/pricing-terms.md#pricing-terms",
+      title: "pricing-terms",
+      text: "Interchange is the fee the card network charges per authorization.",
+    });
+  });
+
+  it("yields no docs for a glossary file with nothing in it", () => {
+    expect(parseSourceFile({ source, path: "glossary.md", raw: "\n   \n" })).toEqual([]);
+  });
+
+  it("names the offending entry when a JSON array element lacks a term or a definition", () => {
+    expect(() => parseSourceFile({ source, path: "api.json", raw: '[{"name": "GET /accounts"}]' }))
+      .toThrow(/api\.json: entry 0 must carry string term\/name and definition\/description/);
+    expect(() => parseSourceFile({ source, path: "api.json", raw: '[{"description": "List accounts."}]' }))
+      .toThrow(/entry 0 must carry/);
+  });
+
+  it("names the offending term when a JSON object maps it to a non-string", () => {
+    expect(() => parseSourceFile({ source, path: "terms.json", raw: '{"APR": {"rate": 1}}' }))
+      .toThrow(/terms\.json: value for term "APR" must be a string definition/);
+  });
+
   it("titles a prose doc from its first h1, fence-aware", () => {
     const docs = parseSourceFile({
       source: { name: "docs", glob: "**/*.md", kind: "docs", visibility: "public" },
@@ -109,6 +139,18 @@ describe("parseSourceFile", () => {
     expect(docs).toHaveLength(1);
     expect(docs[0]!.title).toBe("Real Title");
     expect(docs[0]!.id).toBe("docs#guide.md");
+  });
+
+  it("falls back from an h1 to the first heading of any level, then to the file name", () => {
+    const prose = { name: "docs", glob: "**/*.md", kind: "docs", visibility: "public" } as const;
+    const h2Only = parseSourceFile({ source: prose, path: "guide.md", raw: "## Getting started\nBody.\n" });
+    expect(h2Only[0]!.title).toBe("Getting started");
+    const headingless = parseSourceFile({
+      source: prose,
+      path: "docs/release-notes.md",
+      raw: "Body with no heading at all.\n",
+    });
+    expect(headingless[0]!.title).toBe("release-notes");
   });
 });
 
@@ -151,6 +193,23 @@ describe("ingestSources", () => {
     });
     const second = await ingestSources(config, { root });
     expect(second).toEqual(first);
+  });
+
+  it("skips a source whose directory does not exist instead of failing the whole ingest", async () => {
+    // A renamed or not-yet-created folder in .vendo/knowledge.json matches
+    // nothing; the sources that do exist still ingest.
+    const withMissing: KnowledgeConfig = {
+      ...config,
+      sources: [
+        { name: "handbook", glob: "handbook/**/*.md", kind: "docs", visibility: "public" },
+        config.sources[1]!,
+      ],
+    };
+    const docs = await ingestSources(withMissing, { root });
+    expect(docs.map((doc) => doc.id)).toEqual([
+      "glossary#glossary.md#term-a",
+      "glossary#glossary.md#term-b",
+    ]);
   });
 
   it("rejects an invalid config loudly instead of ingesting a subset", async () => {

--- a/packages/knowledge/src/local/lexical.test.ts
+++ b/packages/knowledge/src/local/lexical.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { KnowledgeContext, KnowledgeDoc } from "@vendoai/core";
 import { knowledgeAdapterConformance, memoryStoreAdapter, runConformance } from "@vendoai/core/conformance";
 import { KNOWLEDGE_CHUNKS_COLLECTION, KNOWLEDGE_DOCS_COLLECTION } from "../collections.js";
-import { vendoKnowledge } from "./lexical.js";
+import { bindKnowledgeStore, vendoKnowledge } from "./lexical.js";
 
 const ctx: KnowledgeContext = { principal: { kind: "user", subject: "user_lexical_test" } };
 
@@ -189,5 +189,28 @@ describe("vendoKnowledge — fetch, store rows, and lifecycle", () => {
   it("fails loudly when no store is bound instead of reading as an empty corpus", async () => {
     const unbound = vendoKnowledge();
     await expect(unbound.search({ text: "anything" }, ctx)).rejects.toThrow(/no store bound/);
+  });
+});
+
+/** The composition seam vendo's `selectKnowledge` drives (compose-selection.ts):
+    a store-less `vendoKnowledge()` is handed the store createVendo composed,
+    and everything else passes through. Both halves were only ever pinned from
+    `packages/vendo` through the package barrel, so this package — which owns
+    the code — measured neither. */
+describe("bindKnowledgeStore — the composition seam", () => {
+  it("hands a store-less vendoKnowledge() the composed store so it can actually serve", async () => {
+    const store = memoryStoreAdapter();
+    const bound = bindKnowledgeStore(vendoKnowledge(), store);
+    await bound.upsert!(CORPUS);
+    const result = await bound.search({ text: "How long do refunds take?" }, ctx);
+    expect(result.hits[0]!.ref.docId).toBe("docs#refunds.md");
+    // The store it was handed is the one it wrote through — not a private one.
+    const rows = (await store.records(KNOWLEDGE_DOCS_COLLECTION).list({ limit: 1000 })).records;
+    expect(rows).toHaveLength(CORPUS.length);
+  });
+
+  it("passes an adapter that already owns a store through untouched", () => {
+    const own = vendoKnowledge({ store: memoryStoreAdapter() });
+    expect(bindKnowledgeStore(own, memoryStoreAdapter())).toBe(own);
   });
 });

--- a/packages/vendo-telemetry/src/base-props.test.ts
+++ b/packages/vendo-telemetry/src/base-props.test.ts
@@ -37,6 +37,16 @@ function gitRepoDir(originUrl?: string): string {
   return dir;
 }
 
+/** A repo whose config PATH resolves but cannot be read: `.git/config` is a
+    directory, so the read fails EISDIR. This is the unexpected filesystem
+    shape both never-throw guards exist for — a `.git` that isn't a git dir at
+    all is already covered by the malformed-pointer cases. */
+function unreadableGitConfigDir(): string {
+  const dir = tempDir();
+  mkdirSync(join(dir, ".git", "config"), { recursive: true });
+  return dir;
+}
+
 function expectedHash(input: string): string {
   return createHash("sha256").update(PROJECT_ID_SALT + input).digest("hex");
 }
@@ -133,6 +143,12 @@ describe("projectProps.projectIdHash", () => {
     expect(projectProps({}, checkout).projectIdHash).toBe(expectedHash("github.com/runvendo/vendo"));
   });
 
+  it("falls back to package.json when the git config path exists but cannot be read", () => {
+    const dir = unreadableGitConfigDir();
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "unreadable-git-app" }));
+    expect(projectProps({}, dir).projectIdHash).toBe(expectedHash("unreadable-git-app"));
+  });
+
   it("never throws on unreadable or malformed git state", () => {
     const broken = tempDir();
     writeFileSync(join(broken, ".git"), "not a real gitdir pointer");
@@ -166,6 +182,12 @@ describe("repoHost", () => {
     writeFileSync(join(broken, ".git"), "not a real gitdir pointer");
     expect(() => repoHost(broken)).not.toThrow();
     expect(repoHost(broken)).toBeUndefined();
+  });
+
+  it("never throws when the git config path exists but cannot be read", () => {
+    const dir = unreadableGitConfigDir();
+    expect(() => repoHost(dir)).not.toThrow();
+    expect(repoHost(dir)).toBeUndefined();
   });
 });
 

--- a/packages/vendo-telemetry/src/client.test.ts
+++ b/packages/vendo-telemetry/src/client.test.ts
@@ -128,6 +128,39 @@ describe("createTelemetry.track", () => {
     expect(String(deps.fetchImpl.mock.calls[0]![0])).toContain("us.i.posthog.com");
   });
 
+  it("still posts when cwd resolution fails", async () => {
+    // The real shape: a dev server whose working directory was deleted under
+    // it, so getcwd() fails. deps.cwd is unset, so projectProps resolves the
+    // default itself and throws inside the client's constructor. The spy is
+    // released before the await so nothing else in the run sees a broken cwd.
+    const deps = makeDeps();
+    const cwdSpy = vi.spyOn(process, "cwd").mockImplementation(() => {
+      throw new Error("ENOENT: no such file or directory, uv_cwd");
+    });
+    let t;
+    try {
+      t = createTelemetry(deps);
+    } finally {
+      cwdSpy.mockRestore();
+    }
+    await t.track("init_started", { framework: "next" });
+    expect(deps.fetchImpl).toHaveBeenCalledOnce();
+    const body = JSON.parse((deps.fetchImpl.mock.calls[0]![1] as { body: string }).body);
+    // Project props are simply absent; the event still carries the base props.
+    expect(body.properties.projectIdHash).toBeUndefined();
+    expect(body.properties.vendoVersion).toBe("9.9.9");
+  });
+
+  it("swallows an event name outside the allowlist instead of throwing at the caller", async () => {
+    // An untyped JS caller can name an event the allowlist has never heard of.
+    // Looking up its prop allowlist yields undefined and filtering throws —
+    // which must never reach the build or dev server that called track().
+    const deps = makeDeps();
+    const t = createTelemetry(deps);
+    await expect(t.track("not_a_real_event" as never, { framework: "next" })).resolves.toBeUndefined();
+    expect(deps.fetchImpl).not.toHaveBeenCalled();
+  });
+
   it("returns after the telemetry timeout when fetch never settles", async () => {
     vi.useFakeTimers();
     try {

--- a/packages/vendo-telemetry/src/config.test.ts
+++ b/packages/vendo-telemetry/src/config.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { loadConfig, saveConfig, configPath, configDir } from "./config.js";
+import { loadConfig, saveConfig, configPath, configDir, type TelemetryConfig } from "./config.js";
 
 let home: string;
 beforeEach(() => {
@@ -43,6 +43,18 @@ describe("config store", () => {
     writeFileSync(configPath(home), JSON.stringify({ optedOut: true }), "utf8");
     const c = loadConfig(home, {});
     expect(c.optedOut).toBe(true);
+  });
+
+  it("regenerates and rewrites the config when the file on disk is corrupt", () => {
+    mkdirSync(configDir(home), { recursive: true });
+    writeFileSync(configPath(home), "{ truncated wri", "utf8");
+    const c = loadConfig(home, {});
+    expect(c.anonymousId).toMatch(/[0-9a-f-]{36}/);
+    expect(c.optedOut).toBe(false);
+    // A corrupt file is replaced, not just worked around in memory: the next
+    // process must read the same id back instead of minting another one.
+    expect((JSON.parse(readFileSync(configPath(home), "utf8")) as TelemetryConfig).anonymousId).toBe(c.anonymousId);
+    expect(loadConfig(home, {}).anonymousId).toBe(c.anonymousId);
   });
 
   it("does not mint or persist a tracking id when an env opt-out is set", () => {

--- a/packages/vendo-telemetry/vitest.config.ts
+++ b/packages/vendo-telemetry/vitest.config.ts
@@ -8,9 +8,14 @@ export default defineConfig({
       reporter: ["text", "json-summary"],
       include: ["src/**/*.{ts,tsx}"],
       exclude: ["src/**/*.test.{ts,tsx}", "src/**/*.test-util.{ts,tsx}"],
-      // Ratcheted line-coverage floor (ENG-255): set at/just below the measured
-      // value so it can only rise. Regression below this fails CI.
-      thresholds: { lines: 98 },
+      // Ratcheted line-coverage floor (ENG-255), sized in LINES rather than
+      // points: this package is only 422 lines, so one point is ~4 lines and a
+      // floor of 98 tolerated 8 new uncovered lines even with coverage at
+      // 100.00% — less than one feature's worth of never-throw catch blocks,
+      // which is what every uncovered line here has ever been. 95 tolerates 22.
+      // Lines are at 100.00%, so deleting covered code can no longer move the
+      // ratio at all — the denominator-shrink failure is off the table here.
+      thresholds: { lines: 95 },
     },
   },
 });

--- a/packages/vendoai/vitest.config.ts
+++ b/packages/vendoai/vitest.config.ts
@@ -10,9 +10,12 @@ export default defineConfig({
       // auth-presets/* are one-line re-exports mirroring @vendoai/vendo's
       // per-preset subpaths; alias.test.ts asserts the export map instead.
       exclude: ["src/**/*.test.{ts,tsx}", "src/**/*.test-util.{ts,tsx}", "src/auth-presets/**"],
-      // Ratcheted line-coverage floor (ENG-255): set at/just below the measured
-      // value so it can only rise. Regression below this fails CI.
-      thresholds: { lines: 49 },
+      // NO line-coverage floor here, deliberately. Once auth-presets/* is
+      // excluded this package is 4 measured lines, 2 of them covered: the
+      // highest floor that could tolerate even 20 new uncovered lines is 8%, so
+      // any percentage here is decorative rather than a gate. Coverage is still
+      // REPORTED (the reporter above) — there is just nothing honest to enforce
+      // on an alias shim. Don't add a number back without lines to back it.
     },
   },
 });


### PR DESCRIPTION
`@vendoai/telemetry` tolerated **2 new uncovered lines** before its coverage floor tripped; `knowledge` tolerated **5**. Both sit in the `group-b` CI job. A gate that fails for reasons unrelated to quality is a gate people route around — the same disease #1050 fixed in `core`.

## What was actually uncovered

**telemetry (416/422 → 422/422, 100.00%)** — all six uncovered lines were the closing brace of an empty `catch`: the never-throw guards this package's entire contract rests on, none of them exercised. Reached through real failures, not mocks:

| guard | how the test breaks it for real |
|---|---|
| `projectIdHash` git-config read | `.git/config` is a **directory** → EISDIR → falls back to `package.json` |
| `repoHost` same | same fixture → returns `undefined` |
| `loadConfig` corrupt file | a truncated `telemetry.json` → regenerated **and rewritten** |
| `createTelemetry` cwd guard | `process.cwd()` throws the way a deleted working directory makes it throw |
| `track` catch | an event name outside the allowlist (an untyped JS caller) |

**knowledge (850/880 → 879/880, 99.89%)** — the headline is the same shape #1050 found in `core`: **`bindKnowledgeStore` is the composition seam `packages/vendo/src/compose-selection.ts` (`selectKnowledge`) drives, and both of its branches were only ever pinned from `packages/vendo/src/knowledge-resolution.test.ts` through the package barrel** — so the package that owns the code measured neither line. Also unpinned: every `parseInput` rejection (this tool's arguments are model-generated, so a forbidden shape is a routine event, not a programming error), the BYO template's "your endpoint answered with something that is not `vendo/knowledge-wire@1`" diagnostic, `parse.ts`'s `stem` and both docs-title fallbacks, and a configured source directory that does not exist.

## Headroom, in lines

Addition slack `= ⌊covered/floor⌋ − lines`; deletion slack `= (covered − floor·lines)/(1 − floor)`.

| package | before | after | floor | **+lines** | −lines |
|---|---|---|---|---|---|
| `telemetry` | 416/422 | **422/422** | 98 → **95** | 2 → **22** | 121 → 422 |
| `knowledge` | 850/880 | **879/880** | 96 (unchanged) | 5 → **35** | 130 → 855 |

`telemetry`'s floor moves **98 → 95**. Points are the wrong unit at this size: 422 lines means one point is ~4 lines, so a floor of 98 tolerated only **8** new uncovered lines *even with coverage at 100.00%* — under one feature's worth of `catch` blocks in a package whose uncovered residue has always been exactly that. This is a deliberate ratchet reduction taken only after there was genuinely nothing honest left to cover. `knowledge` needed no floor change: 96 now tolerates 35 lines.

At 100.00% coverage `telemetry` is also structurally immune to the denominator-shrink failure that broke `main` — deleting covered lines cannot move a 100% ratio.

## Two more floors, from the same audit

Auditing all thirteen floors against the rule surfaced exactly two failures, both fixed here.

**`agents` 93 → 91.** The genuinely fragile floor in the repo, and invisible in percent: 94.24 against 93 *reads* like comfortable slack, but on a 713-line package a point is ~7 lines, so it tolerated **9** new uncovered lines — thinner than telemetry's 8. 91 tolerates 24.

**`vendoai` loses its floor entirely** rather than getting a new number. With `auth-presets/*` excluded the package is **4 measured lines, 2 covered**; the highest floor that could tolerate even 20 new uncovered lines is **8%**. A percentage gate on a 4-line alias shim measures nothing, so 49 was decorative. Coverage is still reported — there is just nothing honest to enforce.

### All 13 floors against the rule

Measured % are CI whole-suite values; totals are exact, from a zero-test v8 coverage probe validated against telemetry's known 422 (and which independently returned `core` = 9479 against 9443 back-solved from the merged report).

| package | floor | meas % | lines | +lines | rule |
|---|---|---|---|---|---|
| `vendo` | 78 | 88.55 | 18820 | 2545 | PASS |
| `ui` | 90 | 91.65 | 12557 | 229 | PASS |
| `core` | 97 | 97.38 | 9479 | 37 | PASS |
| `apps` | 88 | 92.81 | 9300 | 507 | PASS |
| `actions` | 90 | 92.07 | 7344 | 169 | PASS |
| `store` | 84 | 94.34 | 4082 | 502 | PASS |
| `mcp` | 90 | 92.99 | 2355 | 78 | PASS |
| `automations` | 91 | 95.34 | 1935 | 92 | PASS |
| `guard` | 96 | 97.70 | 1657 | 29 | PASS |
| `knowledge` | 96 | 99.88 | 880 | **35** (was 5) | PASS |
| `agents` | **91** | 94.24 | 713 | **24** (was 9) | PASS |
| `telemetry` | **95** | 100.00 | 422 | **22** (was 2) | PASS |
| `vendoai` | **none** | 50.00 | 4 | n/a | n/a |

**Every thin floor in the repo is a small package** — `vendoai` 4, `telemetry` 422, `agents` 713, `knowledge` 880, `guard` 1657. Points squeeze small packages and are free money for large ones: `vendo` at floor 78 tolerates 2545 new uncovered lines. That is the argument for sizing floors in lines.

### The gate was watched biting, not asserted

| replay | result |
|---|---|
| `agents` at 95 (above its 94.24) | **FAIL** — `Coverage for lines (94.24%) does not meet global threshold (95%)` |
| `agents` at its new 91 | PASS |
| `knowledge` at 100 (above its 99.88) | **FAIL** |
| `knowledge` at its 96 | PASS |
| `vendoai` at 60 | **FAIL** — the mechanism is live; the config simply no longer sets one, so removal is real rather than a no-op |

`telemetry` is the one exception and deliberately so: at 100.00% no threshold can sit above the measurement, which is the statement rather than a gap in the evidence.

## One line left uncovered, on purpose

`agent-tools.ts:206`, the non-`VendoError` arm of `errorOutcome`. Its only caller is the `parseInput` catch and `parseInput` throws nothing else, so reaching it means mocking an internal or exporting one for the test. That is filler, not coverage.

## Verification

Every new test was run against a **distinct mutation** of the source it covers and confirmed killed by its own test: **19 mutants, 19 killed, 0 survivors.**

- `telemetry` 5/5 — catch→rethrow for each of the three never-throw guards, guard removal for the cwd case, catch→rethrow for `track`.
- `knowledge` 14/14 — including both directions of `bindKnowledgeStore` (never rebind / always rebind), and one precise mutation per `parseInput` branch (drop `Array.isArray`, invert the `lookup` type test, gut the `readMore` object test, drop each blank-string check).

Each mutation is at the exact line its test pins, and each was reverted immediately after. No test file was touched to make a source change pass, nothing is skipped, no file is excluded from the coverage set, and no floor was raised to a number the tree does not clear.

## The pattern worth naming: code that moves packages leaves its tests behind

This is the second time tonight. #1050 found a code generator hoisted between packages with its tests left in the original, reaching it through a re-export shim. This PR found `bindKnowledgeStore` — production code in `@vendoai/knowledge`, both branches exercised only from `packages/vendo` through the package barrel. In both cases the suite was green, the behaviour was genuinely tested, and the package that *owned* the code pinned none of it, so its floor was measuring a smaller surface than it appeared to. A re-export is invisible to a per-package coverage floor: the consumer's tests cover the consumer's lines, and the producer's floor never notices its own code is unpinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises `@vendoai/telemetry` coverage to 100% and fills `knowledge` gaps at validation, HTTP, and ingest seams. Switches fragile coverage gates to line-based thresholds, adjusting `agents` and removing `vendoai`’s floor to reduce noisy CI.

- **Test Coverage**
  - `@vendoai/telemetry`: exercises unreadable `.git/config` dir (EISDIR) fallback, corrupt `telemetry.json` regeneration/rewrites, cwd failure during client init, and unknown event names (swallowed without throwing); coverage now 422/422.
  - `knowledge`: covers `bindKnowledgeStore` (binding and passthrough), all `parseInput` rejections for the search tool, HTTP adapter diagnostic when response isn’t `vendo/knowledge-wire@1`, glossary/markdown title fallbacks, and skipping missing source directories; coverage now 879/880.

- **Coverage Floors**
  - Line-based thresholds: `@vendoai/telemetry` set to `lines: 95`, `agents` to `lines: 91`; `vendoai` floor removed (alias shim; coverage still reported). `knowledge` unchanged.

<sup>Written for commit 9b52ca7e0d0b5c75f42d335152def8a332cc0e82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

