### PR TITLE
fix(vendo): typecheck the test files too, and clear the 96 errors that were hiding there

### DIFF
--- a/packages/vendo/package.json
+++ b/packages/vendo/package.json
@@ -95,7 +95,7 @@
     "build": "tsc -p tsconfig.json",
     "test": "vitest run",
     "conformance": "vitest run src/conformance.test.ts",
-    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.docs-check.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.docs-check.json --noEmit && tsc -p tsconfig.test.json --noEmit",
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {

--- a/packages/vendo/src/app-memory.e2e.test.ts
+++ b/packages/vendo/src/app-memory.e2e.test.ts
@@ -36,7 +36,7 @@ afterEach(async () => {
 });
 
 const principal: Principal = { kind: "user", subject: "user_memory" };
-const ctx = { principal, venue: "chat" as const, presence: "present" as const };
+const ctx = { principal, venue: "chat" as const, presence: "present" as const, sessionId: "ses_memory" };
 
 /** The smallest document the compiler renders and the seam paints. */
 const SPENDING = `<App name="Spending">

--- a/packages/vendo/src/app-rebuild.e2e.test.ts
+++ b/packages/vendo/src/app-rebuild.e2e.test.ts
@@ -32,6 +32,7 @@ import {
   type SandboxAdapter,
   type SandboxMachine,
 } from "@vendoai/apps";
+import { inMemoryBoxFiles } from "@vendoai/apps/testing";
 import {
   DEFAULT_TRIGGER_ID,
   VENDO_APP_FORMAT,
@@ -42,12 +43,11 @@ import {
   type FilesAdapter,
   type Principal,
   type RunContext,
-  type VendoStore,
   type WorkspaceFs,
 } from "@vendoai/core";
 import { createGuard } from "@vendoai/guard";
 import { wrapWorkspaceForRender } from "@vendoai/harnesses";
-import { appAccess, createStore, workspaceStore } from "@vendoai/store";
+import { appAccess, createStore, workspaceStore, type VendoStore } from "@vendoai/store";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const cleanups: Array<() => Promise<void>> = [];
@@ -140,6 +140,9 @@ function snapshotHoldingSandbox(): SandboxAdapter & { snapshots: Set<string> } {
       },
       async stop() { /* sleep */ },
       async destroy() { /* gone; taken refs stay valid */ },
+      // The seam's ONE in-memory implementation (@vendoai/apps/testing), so no
+      // two fakes can drift over what reading a box file means.
+      files: inMemoryBoxFiles(new Map()),
     };
   };
   return {

--- a/packages/vendo/src/box-inference.test.ts
+++ b/packages/vendo/src/box-inference.test.ts
@@ -7,6 +7,7 @@ import {
   type Principal,
 } from "@vendoai/core";
 import type { SandboxAdapter, SandboxMachine } from "@vendoai/apps";
+import { inMemoryBoxFiles } from "@vendoai/apps/testing";
 import { createStore, type VendoStore } from "@vendoai/store";
 import type { LanguageModel } from "ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -57,6 +58,9 @@ function captureSandbox(specs: SandboxSpec[]): SandboxAdapter {
     async snapshot() { return "fake:snap"; },
     async stop() { /* sleep */ },
     async destroy() { /* gone */ },
+    // The seam's ONE in-memory implementation (@vendoai/apps/testing), so no
+    // two fakes can drift over what reading a box file means.
+    files: inMemoryBoxFiles(new Map()),
   };
   return {
     async create(spec) {

--- a/packages/vendo/src/box-wire.test.ts
+++ b/packages/vendo/src/box-wire.test.ts
@@ -7,6 +7,7 @@ import {
   type Principal,
 } from "@vendoai/core";
 import { createAppTokens, type SandboxAdapter, type SandboxMachine } from "@vendoai/apps";
+import { inMemoryBoxFiles } from "@vendoai/apps/testing";
 import { createStore, type VendoStore } from "@vendoai/store";
 import type { LanguageModel } from "ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -62,6 +63,9 @@ function boxSandbox(handler: BoxHandler): SandboxAdapter {
     async snapshot() { return "fake:snap"; },
     async stop() { /* sleep */ },
     async destroy() { /* gone */ },
+    // The seam's ONE in-memory implementation (@vendoai/apps/testing), so no
+    // two fakes can drift over what reading a box file means.
+    files: inMemoryBoxFiles(new Map()),
   };
   return {
     async create() { return machine; },

--- a/packages/vendo/src/cli/cloud/client.test.ts
+++ b/packages/vendo/src/cli/cloud/client.test.ts
@@ -44,12 +44,12 @@ describe("cloud client", () => {
       auth: "key",
       apiKey: "vnd_test",
       fetchImpl,
-    })).rejects.toMatchObject<Partial<CloudError>>({
+    })).rejects.toMatchObject({
       name: "CloudError",
       code: "cloud-required",
       message: "Upgrade required",
       status: 402,
-    });
+    } satisfies Partial<CloudError>);
     expect(fetchImpl).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
       headers: expect.objectContaining({ "user-agent": `vendo-cli/${CLI_VERSION}` }),
     }));
@@ -72,7 +72,7 @@ describe("cloud client", () => {
       auth: "key",
       apiKey: "vnd_test",
       fetchImpl,
-    })).rejects.toMatchObject<Partial<CloudError>>({
+    })).rejects.toMatchObject({
       name: "CloudError",
       code: "meter-exhausted",
       message: "Vendo Cloud paused usage — the $100.00 included this billing period is used up "
@@ -80,7 +80,7 @@ describe("cloud client", () => {
         + "Upgrade your plan (https://console.vendo.run/billing) "
         + "or bring your own infrastructure (https://docs.vendo.run/byo).",
       status: 402,
-    });
+    } satisfies Partial<CloudError>);
   });
 
   it("attaches the deployment-identity headers to every key-authed request", async () => {

--- a/packages/vendo/src/cli/cloud/device-login.test.ts
+++ b/packages/vendo/src/cli/cloud/device-login.test.ts
@@ -83,11 +83,11 @@ describe("runDeviceLogin", () => {
 
     expect(exit).toBe(0);
     // Claim request carries NO identity hint — the human chooses the account.
-    expect(requests[0].url).toBe("https://console.test/api/v1/agent/claim");
-    expect(JSON.parse(requests[0].body)).toEqual({});
+    expect(requests[0]!.url).toBe("https://console.test/api/v1/agent/claim");
+    expect(JSON.parse(requests[0]!.body)).toEqual({});
     // Polls are form-encoded with the auth.md grant type + claim token.
-    expect(requests[1].contentType).toContain("application/x-www-form-urlencoded");
-    const poll = new URLSearchParams(requests[1].body);
+    expect(requests[1]!.contentType).toContain("application/x-www-form-urlencoded");
+    const poll = new URLSearchParams(requests[1]!.body);
     expect(poll.get("grant_type")).toBe("urn:workos:agent-auth:grant-type:claim");
     expect(poll.get("claim_token")).toBe(CEREMONY.claim_token);
     // slow_down added 5s to the 5s interval (RFC 8628 §3.5).
@@ -488,7 +488,7 @@ describe("pending claim persistence", () => {
     expect(exit).toBe(0);
     // No new claim was opened — the first request already polls the token endpoint.
     expect(requests.some((request) => request.url.endsWith("/api/v1/agent/claim"))).toBe(false);
-    expect(new URLSearchParams(requests[0].body).get("claim_token")).toBe(`vct_${"c".repeat(64)}`);
+    expect(new URLSearchParams(requests[0]!.body).get("claim_token")).toBe(`vct_${"c".repeat(64)}`);
     // The human is told the old code is still the one to approve.
     expect(messages.logs.join("\n")).toContain(
       "Resuming pending approval — code WXYZ-PQRS, approve at https://console.test/claim?code=WXYZ-PQRS",
@@ -517,7 +517,7 @@ describe("pending claim persistence", () => {
     });
     expect(exit).toBe(0);
     // A fresh ceremony was opened for THIS project…
-    expect(requests[0].url).toBe("https://console.test/api/v1/agent/claim");
+    expect(requests[0]!.url).toBe("https://console.test/api/v1/agent/claim");
     // …the key lands here, not in the other project…
     expect(await readFile(join(thisProject, ".env.local"), "utf8")).toContain(`VENDO_API_KEY=${KEY}`);
     await expect(readFile(join(otherProject, ".env.local"), "utf8")).rejects.toThrow();
@@ -576,8 +576,8 @@ describe("pending claim persistence", () => {
     });
     expect(exit).toBe(0);
     // The stale claim is ignored: a fresh ceremony opens and its token is polled.
-    expect(requests[0].url).toBe("https://console.test/api/v1/agent/claim");
-    expect(new URLSearchParams(requests[1].body).get("claim_token")).toBe(CEREMONY.claim_token);
+    expect(requests[0]!.url).toBe("https://console.test/api/v1/agent/claim");
+    expect(new URLSearchParams(requests[1]!.body).get("claim_token")).toBe(CEREMONY.claim_token);
   });
 
   it("removes the pending claim when the human denies the request", async () => {
@@ -684,7 +684,7 @@ describe("bounded --wait budget (#479)", () => {
     expect(exit).toBe(0);
     // No new claim opened — it polls the persisted claim_token directly.
     expect(requests.some((request) => request.url.endsWith("/api/v1/agent/claim"))).toBe(false);
-    expect(new URLSearchParams(requests[0].body).get("claim_token")).toBe(`vct_${"c".repeat(64)}`);
+    expect(new URLSearchParams(requests[0]!.body).get("claim_token")).toBe(`vct_${"c".repeat(64)}`);
     // The key landed and the pending file is gone.
     const envLocal = await readFile(join(projectCwd, ".env.local"), "utf8");
     expect(envLocal).toContain(`VENDO_API_KEY=${KEY}`);

--- a/packages/vendo/src/cli/doctor-mcp-discovery.e2e.test.ts
+++ b/packages/vendo/src/cli/doctor-mcp-discovery.e2e.test.ts
@@ -84,6 +84,7 @@ describe("vendo doctor MCP discovery live", () => {
       sandbox: {
         create: async () => { throw new Error("not used by doctor"); },
         resume: async () => { throw new Error("not used by doctor"); },
+        destroy: async () => { throw new Error("not used by doctor"); },
       },
     });
     cleanup.push(async () => {

--- a/packages/vendo/src/cli/doctor-version-skew.test.ts
+++ b/packages/vendo/src/cli/doctor-version-skew.test.ts
@@ -72,7 +72,7 @@ describe("doctor names an install that is behind npm latest", () => {
 
 describe("the npm latest lookup fails soft", () => {
   it("reads the dist-tag document", async () => {
-    const fetchImpl = vi.fn(async () => Response.json({ latest: "1.2.3", next: "2.0.0-rc.1" }));
+    const fetchImpl = vi.fn<typeof fetch>(async () => Response.json({ latest: "1.2.3", next: "2.0.0-rc.1" }));
     expect(await npmLatestVersion("@vendoai/vendo", fetchImpl as unknown as typeof fetch)).toBe("1.2.3");
     expect(String(fetchImpl.mock.calls[0]?.[0])).toBe("https://registry.npmjs.org/-/package/@vendoai/vendo/dist-tags");
   });

--- a/packages/vendo/src/cli/extract/claude-harness.test.ts
+++ b/packages/vendo/src/cli/extract/claude-harness.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { claudeHarness } from "./claude-harness.js";
+import { claudeHarness, type ClaudeHarnessOptions } from "./claude-harness.js";
 
 const SDK = (messages: Array<Record<string, unknown>>) => ({
   query: () => (async function* () {
@@ -55,7 +55,7 @@ describe("claudeHarness", () => {
           captured = input.options;
           return (async function* () { yield { type: "result", result: "ok" }; })();
         },
-      }) as unknown as Awaited<ReturnType<NonNullable<Parameters<typeof claudeHarness>[0]["loadSdk"]>>>,
+      }) as unknown as Awaited<ReturnType<NonNullable<ClaudeHarnessOptions["loadSdk"]>>>,
     });
     await harness.run({
       root: "/x",
@@ -77,7 +77,7 @@ describe("claudeHarness", () => {
           captured = input.options;
           return (async function* () { yield { type: "result", result: "ok" }; })();
         },
-      }) as unknown as Awaited<ReturnType<NonNullable<Parameters<typeof claudeHarness>[0]["loadSdk"]>>>,
+      }) as unknown as Awaited<ReturnType<NonNullable<ClaudeHarnessOptions["loadSdk"]>>>,
     });
     const root = realpathSync(mkdtempSync(join(tmpdir(), "vendo-claude-harness-")));
     const outside = realpathSync(mkdtempSync(join(tmpdir(), "vendo-claude-outside-")));

--- a/packages/vendo/src/cli/extract/npx-engine-harness.test.ts
+++ b/packages/vendo/src/cli/extract/npx-engine-harness.test.ts
@@ -206,7 +206,7 @@ describe("npxEngineHarness", () => {
       expect(order[0]).toMatch(/^progress:/);
       expect(order[0]).toMatch(/250MB/);
       expect(order[0]).toMatch(/cach/i);
-      expect(order.indexOf("exec-called")).toBeGreaterThan(order.indexOf(order[0]));
+      expect(order.indexOf("exec-called")).toBeGreaterThan(order.indexOf(order[0]!));
       expect(order.indexOf("exec-called")).toBe(1);
     });
 

--- a/packages/vendo/src/cli/init.test.ts
+++ b/packages/vendo/src/cli/init.test.ts
@@ -1018,7 +1018,8 @@ describe("vendo init (zero-question)", () => {
       tools: Record<string, { disabled: boolean }>;
     };
     const { tools } = await extractServerActions(root);
-    for (const tool of tools.filter((entry) => entry.binding.module.endsWith("internal.ts"))) {
+    for (const tool of tools.filter((entry) =>
+      entry.binding.kind === "server-action" && entry.binding.module.endsWith("internal.ts"))) {
       overrides.tools[tool.name] = { disabled: true };
     }
     await writeFile(join(root, ".vendo", "overrides.json"), JSON.stringify(overrides, null, 2));

--- a/packages/vendo/src/cli/sync.test.ts
+++ b/packages/vendo/src/cli/sync.test.ts
@@ -14,7 +14,8 @@ afterEach(() => {
 const report = (
   breaking: Array<{ tool: string; change: "removed" }> = [],
   changed: string[] = [],
-  toolSchemas = { total: 0, inputs: { known: 0, unknown: [] }, outputs: { known: 0, unknown: [] } },
+  toolSchemas: { total: number; inputs: { known: number; unknown: string[] }; outputs: { known: number; unknown: string[] } }
+    = { total: 0, inputs: { known: 0, unknown: [] }, outputs: { known: 0, unknown: [] } },
 ) => ({
   tools: { added: [], removed: [], changed },
   breaking,
@@ -138,7 +139,7 @@ describe("vendo sync", () => {
   });
 
   it("pushes --report to the Cloud API with key auth", async () => {
-    const fetchImpl = vi.fn(async () => new Response("{}", { status: 200 })) as typeof fetch;
+    const fetchImpl = vi.fn<typeof fetch>(async () => new Response("{}", { status: 200 }));
 
     await expect(runSync({
       targetDir: ".",

--- a/packages/vendo/src/cli/theme/extract-theme.live.test.ts
+++ b/packages/vendo/src/cli/theme/extract-theme.live.test.ts
@@ -125,7 +125,7 @@ describe.skipIf(!live || cliAvailability === null)("extractTheme live accuracy (
         const value = validateSlotValue(slot, String(raw));
         if (value === null) continue;
         // Accepted values overwrite ONLY needed slots — exact reads always win.
-        (slots as Record<string, unknown>)[slot] = value;
+        (slots as unknown as Record<string, unknown>)[slot] = value;
         filled.add(slot);
       }
 

--- a/packages/vendo/src/cloud-apps.test.ts
+++ b/packages/vendo/src/cloud-apps.test.ts
@@ -81,8 +81,8 @@ describe("cloudApps", () => {
   });
 
   it("defaults the base URL to the Vendo console", async () => {
-    const fetchImpl = vi.fn(async () => Response.json(snapshot));
-    const client = cloudApps({ apiKey: "vnd_secret", fetch: fetchImpl as unknown as typeof fetch });
+    const fetchImpl = vi.fn<typeof fetch>(async () => Response.json(snapshot));
+    const client = cloudApps({ apiKey: "vnd_secret", fetch: fetchImpl });
     await client.share(doc.id, doc);
     expect(String(fetchImpl.mock.calls[0]![0])).toBe("https://console.vendo.run/api/v1/apps/share");
   });

--- a/packages/vendo/src/cloud-config.test.ts
+++ b/packages/vendo/src/cloud-config.test.ts
@@ -74,8 +74,8 @@ describe("cloudConfig.fetch", () => {
   });
 
   it("defaults the base URL to the Vendo console", async () => {
-    const fetchImpl = vi.fn(async () => publishedResponse());
-    const client = cloudConfig({ apiKey: "vnd_secret", fetch: fetchImpl as unknown as typeof fetch });
+    const fetchImpl = vi.fn<typeof fetch>(async () => publishedResponse());
+    const client = cloudConfig({ apiKey: "vnd_secret", fetch: fetchImpl });
     await client.fetch();
     expect(String(fetchImpl.mock.calls[0]![0])).toBe("https://console.vendo.run/api/v1/config");
   });

--- a/packages/vendo/src/cloud-secrets.test.ts
+++ b/packages/vendo/src/cloud-secrets.test.ts
@@ -49,8 +49,8 @@ describe("cloudSecrets", () => {
   });
 
   it("defaults the base URL to the Vendo console", async () => {
-    const fetchImpl = vi.fn(async () => Response.json({ value: "v" }));
-    const provider = cloudSecrets({ apiKey: "vnd_secret", fetch: fetchImpl as unknown as typeof fetch });
+    const fetchImpl = vi.fn<typeof fetch>(async () => Response.json({ value: "v" }));
+    const provider = cloudSecrets({ apiKey: "vnd_secret", fetch: fetchImpl });
     await provider.get("NAME");
     expect(String(fetchImpl.mock.calls[0]![0])).toBe("https://console.vendo.run/api/v1/secrets/NAME");
   });

--- a/packages/vendo/src/compaction-state.e2e.test.ts
+++ b/packages/vendo/src/compaction-state.e2e.test.ts
@@ -153,7 +153,7 @@ async function compose(): Promise<Composed> {
 
 /** The prompt of the call that carried `marker`, as sent to the provider. */
 function promptCarrying(model: MockLanguageModelV3, marker: string): string {
-  const call = model.doStreamCalls.findLast((entry) => JSON.stringify(entry.prompt).includes(marker));
+  const call = [...model.doStreamCalls].reverse().find((entry) => JSON.stringify(entry.prompt).includes(marker));
   expect(call, `no provider call carried ${marker}`).toBeDefined();
   return JSON.stringify(call?.prompt);
 }

--- a/packages/vendo/src/compound-parity.test.ts
+++ b/packages/vendo/src/compound-parity.test.ts
@@ -247,7 +247,7 @@ async function runAutomations(fixture: Fixture): Promise<{ trace: Trace; finalSt
   });
 
   const engine = createAutomations({
-    apps: { call: async () => ({ status: "ok", output: {} }) } as AppsRuntime,
+    apps: { call: async () => ({ status: "ok", output: {} }) } as unknown as AppsRuntime,
     guard,
     store,
     tools: {

--- a/packages/vendo/src/config-coherence.test.ts
+++ b/packages/vendo/src/config-coherence.test.ts
@@ -28,7 +28,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createVendo, type Vendo } from "./server.js";
 
 const principal: Principal = { kind: "user", subject: "user_coherence" };
-const ctx: RunContext = { principal, venue: "chat", presence: "present", runId: "run_coherence" };
+const ctx: RunContext = { principal, venue: "chat", presence: "present", sessionId: "ses_coherence" };
 
 const cleanups: Array<() => Promise<void>> = [];
 afterEach(async () => {

--- a/packages/vendo/src/connections.test.ts
+++ b/packages/vendo/src/connections.test.ts
@@ -156,8 +156,8 @@ describe("cloudConnections", () => {
   });
 
   it("defaults the base URL to the Vendo console", async () => {
-    const cloudFetch = vi.fn(async () => Response.json({ connections: [] }));
-    const service = cloudConnections({ apiKey: "vnd_secret", fetch: cloudFetch as unknown as typeof fetch });
+    const cloudFetch = vi.fn<typeof fetch>(async () => Response.json({ connections: [] }));
+    const service = cloudConnections({ apiKey: "vnd_secret", fetch: cloudFetch });
     await service.list(ada);
     expect(cloudFetch.mock.calls[0]![0]).toContain("https://console.vendo.run/api/v1/connections");
   });
@@ -288,7 +288,7 @@ describe("unconfiguredConnections", () => {
 
 describe("catalog posture", () => {
   it("cloud rides the console's catalog endpoint", async () => {
-    const cloudFetch = vi.fn(async () =>
+    const cloudFetch = vi.fn<typeof fetch>(async () =>
       Response.json({ available: [{ toolkit: "gmail", connector: "composio" }] }));
     const cloud = cloudConnections({ apiKey: "vnd_secret", baseUrl: "https://cloud.test", fetch: cloudFetch as unknown as typeof fetch });
     await expect(cloud.catalog()).resolves.toEqual([{ toolkit: "gmail", connector: "composio" }]);
@@ -322,8 +322,8 @@ describe("adapter rule", () => {
       const byo = byoConnections([fakeConnector("composio", { user_ada: [adaGmail] })]);
       expect(await byo.list(ada)).toEqual([adaGmail]);
 
-      const cloudFetch = vi.fn(async () => Response.json({ connections: [] }));
-      const cloud = cloudConnections({ apiKey: "vnd_arg", baseUrl: "https://arg.test", fetch: cloudFetch as unknown as typeof fetch });
+      const cloudFetch = vi.fn<typeof fetch>(async () => Response.json({ connections: [] }));
+      const cloud = cloudConnections({ apiKey: "vnd_arg", baseUrl: "https://arg.test", fetch: cloudFetch });
       await cloud.list(ada);
       expect(cloudFetch.mock.calls[0]![0]).toContain("https://arg.test/");
 

--- a/packages/vendo/src/dev-creds/model-edge.test.ts
+++ b/packages/vendo/src/dev-creds/model-edge.test.ts
@@ -5,7 +5,7 @@ import { bindVendoModelSlots, devModel, vendoModel } from "./model-edge.js";
 describe("dev-creds model, edge entry", () => {
   it("fails a model call with wiring guidance instead of reaching for Node resolution", async () => {
     const model = devModel();
-    const call = (model as { doStream: (options: unknown) => Promise<unknown> }).doStream({});
+    const call = (model as unknown as { doStream: (options: unknown) => Promise<unknown> }).doStream({});
     await expect(call).rejects.toThrow(/pass `model:`/);
     await expect(call).rejects.toThrow(/VENDO_API_KEY/);
   });
@@ -15,7 +15,7 @@ describe("dev-creds model, edge entry", () => {
     // "#dev-creds/model", so the edge condition must resolve them too.
     expect(() => bindVendoModelSlots(vendoModel("vendo"), { judge: "vendo-judge" })).not.toThrow();
     const model = vendoModel("vendo");
-    const call = (model as { doGenerate: (options: unknown) => Promise<unknown> }).doGenerate({});
+    const call = (model as unknown as { doGenerate: (options: unknown) => Promise<unknown> }).doGenerate({});
     await expect(call).rejects.toThrow(/pass `model:`/);
   });
 

--- a/packages/vendo/src/hosted-store.test.ts
+++ b/packages/vendo/src/hosted-store.test.ts
@@ -20,7 +20,7 @@ import {
 } from "@vendoai/core";
 import { storeAdapterConformance } from "@vendoai/core/conformance";
 import { createStore, secretStore, storeSecrets, type VendoStore } from "@vendoai/store";
-import { hostedStore, hostedStoreOps } from "./hosted-store.js";
+import { hostedStore, hostedStoreOps, type HostedStore } from "./hosted-store.js";
 import { fakeConsole } from "./hosted-store.test-util.js";
 
 const encoder = new TextEncoder();
@@ -203,8 +203,8 @@ describe("hostedStore wire", () => {
   });
 
   it("defaults the base URL to the Vendo console", async () => {
-    const cloudFetch = vi.fn(async () => Response.json({ record: null }));
-    const store = hostedStore({ apiKey: "vnd_secret", fetch: cloudFetch as unknown as typeof fetch });
+    const cloudFetch = vi.fn<typeof fetch>(async () => Response.json({ record: null }));
+    const store = hostedStore({ apiKey: "vnd_secret", fetch: cloudFetch });
     await store.records("invoices").get("x");
     expect(cloudFetch.mock.calls[0]![0]).toBe("https://console.vendo.run/api/v1/store/records/invoices/get");
   });
@@ -221,7 +221,7 @@ describe("hostedStore wire", () => {
 });
 
 describe("hostedStore error mapping", () => {
-  const adapterFor = (fetchImpl: unknown): VendoStore =>
+  const adapterFor = (fetchImpl: unknown): HostedStore =>
     hostedStore({ apiKey: "vnd_secret", baseUrl: "https://cloud.test", fetch: fetchImpl as typeof fetch });
   const respond = (code: string, message: string, status: number, extra: Record<string, unknown> = {}) =>
     vi.fn(async () => Response.json({ error: { code, message, ...extra } }, { status }));

--- a/packages/vendo/src/hosted-workspace-cas.live.test.ts
+++ b/packages/vendo/src/hosted-workspace-cas.live.test.ts
@@ -37,7 +37,7 @@ const LIVE_TIMEOUT_MS = 60_000;
 
 const run = globalThis.crypto.randomUUID().replace(/-/g, "").slice(0, 12);
 const org = `org_cas_${run}`;
-const memberships: Membership[] = [{ org, role: "member" }] as Membership[];
+const memberships: Membership[] = [{ org }];
 const alice: Principal = { kind: "user", subject: `user_cas_a_${run}` };
 const bob: Principal = { kind: "user", subject: `user_cas_b_${run}` };
 const PATH = `/orgs/${org}/shared/plan.md`;

--- a/packages/vendo/src/knowledge-governance.test.ts
+++ b/packages/vendo/src/knowledge-governance.test.ts
@@ -115,7 +115,10 @@ async function knowledgeCallingModel(): Promise<{ model: LanguageModel; prompts:
       call += 1;
       return {
         stream: simulateReadableStream({
-          chunks: searching
+          // Spread so the chunk element type is inferred from BOTH branches:
+          // handed the conditional directly, `simulateReadableStream<T>` resolves
+          // `T` from the first arm alone and then rejects the second.
+          chunks: [...(searching
             ? [
               { type: "tool-call" as const, toolCallId: "call_kb", toolName: "vendo_knowledge_search", input: JSON.stringify({ query: "escalation" }) },
               { type: "finish" as const, usage, finishReason: { unified: "tool-calls" as const, raw: undefined } },
@@ -125,7 +128,7 @@ async function knowledgeCallingModel(): Promise<{ model: LanguageModel; prompts:
               { type: "text-delta" as const, id: "t1", delta: "Done." },
               { type: "text-end" as const, id: "t1" },
               { type: "finish" as const, usage, finishReason: { unified: "stop" as const, raw: undefined } },
-            ],
+            ])],
         }),
       };
     },

--- a/packages/vendo/src/mandatory-reviewer.e2e.test.ts
+++ b/packages/vendo/src/mandatory-reviewer.e2e.test.ts
@@ -361,7 +361,7 @@ describe("the mandatory reviewer pass on a finished screen", () => {
     expect(walked.writerPrompts).toHaveLength(2);
     // The screen reached the person and the row reached the store.
     expect(walked.chunks.filter((chunk) => chunk["type"] === "data-vendo-view").length).toBeGreaterThan(0);
-    const stored = await walked.vendo.apps.get(receipt.id, { principal, venue: "chat", presence: "present" });
+    const stored = await walked.vendo.apps.get(receipt.id, { principal, venue: "chat", presence: "present", sessionId: "ses_reviewer" });
     expect(stored?.name).toBe("Upcoming bills");
   }, 120_000);
 

--- a/packages/vendo/src/mastra.test.ts
+++ b/packages/vendo/src/mastra.test.ts
@@ -252,7 +252,7 @@ describe("@vendoai/vendo/mastra — open-schema args bridge", () => {
       async doStream() {
         throw new Error("doStream not scripted");
       },
-    } as unknown as LanguageModel;
+    } as unknown as ConstructorParameters<typeof Agent>[0]["model"];
     const agent = new Agent({
       id: "bridge-agent",
       name: "Bridge Agent",

--- a/packages/vendo/src/mcp-door.test-util.ts
+++ b/packages/vendo/src/mcp-door.test-util.ts
@@ -447,7 +447,7 @@ export async function bearer(vendo: Vendo): Promise<string> {
 }
 
 export interface DoorSession {
-  listTools(): Promise<Array<{ name: string; description?: string; annotations?: unknown; outputSchema?: unknown }>>;
+  listTools(): Promise<Array<{ name: string; description?: string; annotations?: unknown; inputSchema?: unknown; outputSchema?: unknown }>>;
   callTool(name: string, args: Record<string, unknown>): Promise<{ isError?: boolean; text: string }>;
 }
 

--- a/packages/vendo/src/orgs-materialize.live.test.ts
+++ b/packages/vendo/src/orgs-materialize.live.test.ts
@@ -36,6 +36,7 @@ import {
   type Principal,
   type RunContext,
 } from "@vendoai/core";
+import type { SandboxAdapter } from "@vendoai/apps";
 import { e2bSandbox } from "@vendoai/apps/e2b";
 import { claudeCode } from "@vendoai/harnesses/claude-code";
 import { appAccess, createStore, type VendoStore } from "@vendoai/store";
@@ -160,13 +161,13 @@ live("a real box reaches a real team's app", () => {
     const vendo = createVendo({
       model: {} as LanguageModel,
       store,
-      sandbox: reapingSandbox(),
+      sandbox: reapingSandbox() as unknown as SandboxAdapter,
       harness: claudeCode({ model: MODEL, maxTurns: 14 }),
       auth: {
         principal: async () => acting,
         memberships: async (principal: Principal) => memberships[principal.subject] ?? [],
       },
-    } as Parameters<typeof createVendo>[0]);
+    });
 
     // Dana, the org admin, owns the team's app and shares it with Kim.
     await store.records("vendo_apps").put({

--- a/packages/vendo/src/orgs-materialize.test.ts
+++ b/packages/vendo/src/orgs-materialize.test.ts
@@ -27,6 +27,7 @@ import {
   type Principal,
   type RunContext,
 } from "@vendoai/core";
+import type { SandboxAdapter } from "@vendoai/apps";
 import { createSessionRoutes } from "@vendoai/apps/box-door";
 import { claudeCode } from "@vendoai/harnesses/claude-code";
 import { appAccess, createStore, type VendoStore } from "@vendoai/store";
@@ -150,7 +151,7 @@ async function boot(store: VendoStore, sandbox: ReturnType<typeof fakeSandbox>):
     // Never reached: the thinker is the scripted box, not a provider.
     model: {} as LanguageModel,
     store,
-    sandbox,
+    sandbox: sandbox as unknown as SandboxAdapter,
     harness: claudeCode(),
     mcp: { baseUrl: "https://host.test" },
     // One preset, four seams (09-vendo §2.1) — `memberships` is the one this
@@ -163,7 +164,7 @@ async function boot(store: VendoStore, sandbox: ReturnType<typeof fakeSandbox>):
         async principal(subject: string) { return { kind: "user" as const, subject }; },
       },
     },
-  } as Parameters<typeof createVendo>[0]);
+  });
   return vendo;
 }
 

--- a/packages/vendo/src/pack.test.ts
+++ b/packages/vendo/src/pack.test.ts
@@ -1,5 +1,6 @@
 import {
   VENDO_MAKE_TOOL,
+  VENDO_TREE_FORMAT,
   VENDO_VIEW_STREAM,
   parseVendoToolEnvelope,
   vendoAppRefSchema,
@@ -75,7 +76,7 @@ function makeTool(options: {
       if (options.stream !== false) {
         stream?.({
           id: `vendo-view-${options.appId}`,
-          part: { type: "data-vendo-view", appId: options.appId, payload: { kind: "tree" } },
+          part: { type: "data-vendo-view", appId: options.appId, payload: { kind: "tree", formatVersion: VENDO_TREE_FORMAT } },
         });
       }
       if (options.gate !== undefined) await options.gate;

--- a/packages/vendo/src/placement-tools.e2e.test.ts
+++ b/packages/vendo/src/placement-tools.e2e.test.ts
@@ -28,7 +28,7 @@ import {
   VENDO_MAKE_TOOL,
   makeReceiptSchema,
   type ToolListing,
-  type ToolOutcome,
+  type ToolResult,
 } from "@vendoai/core";
 import { defineHarness } from "@vendoai/harnesses";
 import type { VendoStore } from "@vendoai/store";
@@ -82,7 +82,7 @@ interface Host {
 
 /** What a turn does after it has listed, so a test can drive a real CALL
  *  through the same guard-bound registry the listing came from. */
-type OnTurn = (tools: { call(name: string, args: unknown): Promise<ToolOutcome> }) => Promise<void>;
+type OnTurn = (tools: { call(name: string, args: unknown): Promise<ToolResult> }) => Promise<void>;
 
 /** One firing of a scheduled automation. `runUnattendedTurn` carries no app,
  *  and 05 §6 binds an away run's captured authority to the app it runs for, so
@@ -258,7 +258,7 @@ describe("THE LAW, for a tool whose whole effect is on a person's screen", () =>
    * placement" half is read straight out of the store's rows.
    */
   it("builds a slot-bearing make on an unattended run and takes no slot", async () => {
-    const outcomes: ToolOutcome[] = [];
+    const outcomes: ToolResult[] = [];
     const { vendo, store } = await host(async (tools) => {
       outcomes.push(await tools.call(VENDO_MAKE_TOOL, {
         request: "my spending this month",

--- a/packages/vendo/src/request-connection.seam.test.ts
+++ b/packages/vendo/src/request-connection.seam.test.ts
@@ -147,7 +147,7 @@ async function mount(element: ReactElement): Promise<void> {
 }
 
 const thread = (threadId: string, client: ReturnType<typeof createVendoClient>) =>
-  createElement(VendoProvider, { client }, createElement(VendoThread, { threadId }));
+  createElement(VendoProvider, { client, children: createElement(VendoThread, { threadId }) });
 
 /** Poll the painted DOM. The budget is the test's own — a tighter inner clock
  *  would report a product bug whenever the machine is merely busy. */

--- a/packages/vendo/src/review.fixture.test.ts
+++ b/packages/vendo/src/review.fixture.test.ts
@@ -151,6 +151,7 @@ export default function Page() {
         principal: { kind: "user", subject: user },
         venue: "app",
         presence: "present",
+        sessionId: "ses_review_fixture",
       });
       if (app === null) throw new Error("no app row to rewrite");
       return printWire(

--- a/packages/vendo/src/sandbox.test.ts
+++ b/packages/vendo/src/sandbox.test.ts
@@ -241,7 +241,7 @@ const wireOf = (console_: ReturnType<typeof fakeConsole>): string[] =>
 /** The conformance app contract, in-process behind the mock relay: env from
  * the box ctx, egress simulated with the provider-faithful allowlist rule
  * (same rule as the fake sandbox harness). */
-const conformanceApp: BoxApp = (request, ctx) => {
+const conformanceApp: BoxApp = (request, ctx): Awaited<ReturnType<BoxApp>> => {
   const env = /^\/conformance\/env\/([A-Za-z_][A-Za-z0-9_]*)$/.exec(request.path);
   if (env?.[1] !== undefined) {
     return { status: 200, headers: {}, body: ctx.env[env[1]] ?? "" };
@@ -517,9 +517,9 @@ describe("cloudSandbox", () => {
   });
 
   it("defaults the base URL to the Vendo console", async () => {
-    const cloudFetch = vi.fn(async () =>
+    const cloudFetch = vi.fn<typeof fetch>(async () =>
       Response.json({ id: `m_${"0".repeat(24)}`, url: "https://m.test" }, { status: 201 }));
-    const adapter = cloudSandbox({ apiKey: "vnd_secret", fetch: cloudFetch as unknown as typeof fetch });
+    const adapter = cloudSandbox({ apiKey: "vnd_secret", fetch: cloudFetch });
     await adapter.create({ env: {} });
     expect(cloudFetch.mock.calls[0]![0]).toBe(`https://console.vendo.run${CLOUD_SANDBOX_PATH}`);
   });

--- a/packages/vendo/src/screen-floor-door.e2e.test.ts
+++ b/packages/vendo/src/screen-floor-door.e2e.test.ts
@@ -248,7 +248,7 @@ describe("the assembly loop always hears the floor's verdict on what it saved", 
     expect(walked.prompts[1] ?? "").not.toContain("does not pass");
     // The screen reached the surface and the row reached the store.
     expect(walked.chunks.filter((chunk) => chunk["type"] === "data-vendo-view").length).toBeGreaterThan(0);
-    const stored = await walked.vendo.apps.get(receipt.id, { principal, venue: "chat", presence: "present" });
+    const stored = await walked.vendo.apps.get(receipt.id, { principal, venue: "chat", presence: "present", sessionId: "ses_floor_door" });
     expect(stored?.name).toBe("Spending");
   }, 120_000);
 });

--- a/packages/vendo/src/screen-route.e2e.test.ts
+++ b/packages/vendo/src/screen-route.e2e.test.ts
@@ -216,10 +216,10 @@ describe("vendo_make routed through the screen agent (blueprint §1 point 2)", (
     expect(painted.at(-1)?.payload["streaming"]).toBe(false);
 
     // ── the row: `authored` made a written file into an APP ───────────────────
-    const stored = await walked.vendo.apps.get(receipt.id, { principal, venue: "chat", presence: "present" });
+    const stored = await walked.vendo.apps.get(receipt.id, { principal, venue: "chat", presence: "present", sessionId: "ses_screen_route" });
     expect(stored?.name).toBe("Spending");
     // And it lists, which is the half that was silently missing before `authored`.
-    const listed = await walked.vendo.apps.list({ principal, venue: "chat", presence: "present" });
+    const listed = await walked.vendo.apps.list({ principal, venue: "chat", presence: "present", sessionId: "ses_screen_route" });
     expect(listed.map((app) => app.id)).toContain(receipt.id);
 
     // ── and nothing ran behind it ─────────────────────────────────────────────

--- a/packages/vendo/src/served-apps-wire.test.ts
+++ b/packages/vendo/src/served-apps-wire.test.ts
@@ -7,6 +7,7 @@ import {
   type Principal,
 } from "@vendoai/core";
 import type { SandboxAdapter, SandboxMachine } from "@vendoai/apps";
+import { inMemoryBoxFiles } from "@vendoai/apps/testing";
 import { createStore, type VendoStore } from "@vendoai/store";
 import type { LanguageModel } from "ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -46,7 +47,7 @@ const ADA: Principal = { kind: "user", subject: "user_ada" };
 function servingSandbox(): SandboxAdapter {
   const machine: SandboxMachine = {
     id: "served_box",
-    async request(request) {
+    async request(request): Promise<Awaited<ReturnType<SandboxMachine["request"]>>> {
       if (request.method === "GET" && request.path === "/") {
         return {
           status: 200,
@@ -60,6 +61,9 @@ function servingSandbox(): SandboxAdapter {
     async snapshot() { return "fake:served-snap"; },
     async stop() { /* sleep */ },
     async destroy() { /* gone */ },
+    // The seam's ONE in-memory implementation (@vendoai/apps/testing), so no
+    // two fakes can drift over what reading a box file means.
+    files: inMemoryBoxFiles(new Map()),
   };
   return {
     async create() { return machine; },

--- a/packages/vendo/src/server-agent-seam.test.ts
+++ b/packages/vendo/src/server-agent-seam.test.ts
@@ -7,6 +7,7 @@
  * a real turn, the real `/status` venue, the real Cloud adapter's HTTP call.
  */
 import type { SandboxAdapter, SandboxMachine } from "@vendoai/apps";
+import { inMemoryBoxFiles } from "@vendoai/apps/testing";
 import { agent } from "@vendoai/agents";
 import { defineHarness, harnessAdapters } from "@vendoai/harnesses";
 import { createStore, type VendoStore } from "@vendoai/store";
@@ -55,6 +56,9 @@ const fakeSandbox = (): SandboxAdapter & { created: unknown[] } => {
     snapshot: async () => "fake:snap",
     stop: async () => {},
     destroy: async () => {},
+    // The seam's ONE in-memory implementation (@vendoai/apps/testing), so no
+    // two fakes can drift over what reading a box file means.
+    files: inMemoryBoxFiles(new Map()),
   } satisfies SandboxMachine;
   return {
     created,

--- a/packages/vendo/src/server-api.docs.test.ts
+++ b/packages/vendo/src/server-api.docs.test.ts
@@ -69,7 +69,7 @@ const modelsRow = (page: string): string | undefined =>
 const documentedSeats = (row: string | undefined): string[] | undefined =>
   row
     ?.match(/\{([^}]*)\}/)?.[1]
-    .split(",")
+    ?.split(",")
     .map((seat) => seat.trim().replace(/[`?]/g, ""))
     .filter((seat) => seat.length > 0);
 

--- a/packages/vendo/src/server-lazy.test.ts
+++ b/packages/vendo/src/server-lazy.test.ts
@@ -47,7 +47,7 @@ describe("createVendo construction purity (Workers global scope)", () => {
     expect(ensureSchema).not.toHaveBeenCalled();
     await vendo.guardedTools.execute(
       { id: "call_lazy", tool: "vendo_apps_list", args: {} },
-      { principal, venue: "byo", presence: "absent", sessionId: "session_lazy" },
+      { principal, venue: "chat", presence: "present", sessionId: "session_lazy" },
     ).catch(() => undefined);
     expect(ensureSchema).toHaveBeenCalledTimes(1);
   });

--- a/packages/vendo/src/server-venue.test.ts
+++ b/packages/vendo/src/server-venue.test.ts
@@ -3,7 +3,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import type { LanguageModel } from "ai";
-import type { Principal, SandboxAdapter } from "@vendoai/core";
+import type { SandboxAdapter } from "@vendoai/apps";
+import type { Principal } from "@vendoai/core";
 import { createStore, type VendoStore } from "@vendoai/store";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/vendo/src/server.test.ts
+++ b/packages/vendo/src/server.test.ts
@@ -20,7 +20,7 @@ import { appStore, createStore, secretStore, storeSecrets, type VendoStore } fro
 import { createHmac, randomBytes } from "node:crypto";
 import { exportJWK, generateKeyPair, SignJWT } from "jose";
 import type { LanguageModel } from "ai";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
 // authJs now ships on its own subpath (@vendoai/vendo/auth/auth-js), not
 // "./server.js" — corpus-triage Task 9.
 import { authJs } from "./auth-presets/auth-js.js";
@@ -133,7 +133,11 @@ async function screenModel(turns: ScreenTurn[], prompts?: string[]): Promise<Lan
 }
 
 async function setup(
-  resolver = vi.fn(async () => principal),
+  // `null` is a real answer from this seam — it is how an anonymous session is
+  // expressed (`CreateVendoConfig["principal"]` is `=> Promise<Principal | null>`),
+  // and a dozen cases below pass exactly that. Inferring the parameter from the
+  // default would pin it to the non-null half.
+  resolver: Mock<() => Promise<Principal | null>> = vi.fn(async () => principal),
   options: Pick<Partial<CreateVendoConfig>, "guard" | "development"> = {},
 ): Promise<{ vendo: Vendo; resolver: typeof resolver }> {
   const store = await tempStore("vendo-wire-");
@@ -223,7 +227,7 @@ function stubRouteBlocks(vendo: Vendo): void {
   vi.spyOn(vendo.automations, "dryRun").mockResolvedValue({ steps: [], grantsMissing: [] });
   vi.spyOn(vendo.automations.runs, "list").mockResolvedValue({ runs: [] });
   vi.spyOn(vendo.automations.runs, "get").mockResolvedValue({
-    id: "run_x", appId: "app_wire", trigger: { kind: "schedule" }, status: "ok",
+    id: "run_x", appId: "app_wire", triggerId: "trg_wire", trigger: { kind: "schedule" }, status: "ok",
     startedAt: new Date().toISOString(), steps: [],
   });
   vi.spyOn(vendo.automations.runs, "stop").mockResolvedValue();
@@ -659,6 +663,7 @@ describe("09 §3 public wire", () => {
     const custom: SandboxAdapter = {
       create: vi.fn(async () => { throw new Error("not called"); }),
       resume: vi.fn(async () => { throw new Error("not called"); }),
+      destroy: vi.fn(async () => { throw new Error("not called"); }),
     };
     const store = await tempStore("vendo-wire-custom-");
     const statusFor = async (
@@ -2751,7 +2756,10 @@ describe("surfaces.agent through createVendo", () => {
           };
           return {
             stream: simulateReadableStream({
-              chunks: step === "search"
+              // Spread so the chunk element type is inferred from BOTH branches:
+              // handed the conditional directly, `simulateReadableStream<T>`
+              // resolves `T` from the first arm alone and then rejects the second.
+              chunks: [...(step === "search"
                 ? [
                   {
                     type: "tool-call" as const,
@@ -2766,7 +2774,7 @@ describe("surfaces.agent through createVendo", () => {
                   { type: "text-delta" as const, id: "t1", delta: "Done." },
                   { type: "text-end" as const, id: "t1" },
                   finish,
-                ],
+                ])],
             }),
           };
         },

--- a/packages/vendo/src/stream-resume.e2e.test.ts
+++ b/packages/vendo/src/stream-resume.e2e.test.ts
@@ -122,6 +122,7 @@ describe("stream resume (blueprint §4.1 item 5)", () => {
       messages: [userTurn()],
       trigger: "submit-message",
       messageId: "m1",
+      abortSignal: undefined,
     }));
     expect(textOf(uninterrupted)).toBe("One. Two. Three. Four.");
 
@@ -136,6 +137,7 @@ describe("stream resume (blueprint §4.1 item 5)", () => {
       messages: [userTurn()],
       trigger: "submit-message",
       messageId: "m1",
+      abortSignal: undefined,
     });
     // Read a bit of it, then vanish — the socket dies, the fetch is NEVER
     // aborted (a recycled isolate, a dropped connection, a closed tab on a

--- a/packages/vendo/src/turn-id.e2e.test.ts
+++ b/packages/vendo/src/turn-id.e2e.test.ts
@@ -187,7 +187,7 @@ describe("the turn id (contract §3.5)", () => {
         risk: "write",
       }],
       execute: async () => ({ status: "ok", output: { sent: true } }),
-      toolkitOf: (tool) => (tool.startsWith("gmail_") ? "gmail" : undefined),
+      toolkitOf: (tool: string) => (tool.startsWith("gmail_") ? "gmail" : undefined),
       connections: {
         list: async () => [],
         initiate: async () => ({ id: "conn_1", status: "pending", redirectUrl: "https://example.test" }),

--- a/packages/vendo/src/vendo-make-matrix.e2e.test.ts
+++ b/packages/vendo/src/vendo-make-matrix.e2e.test.ts
@@ -397,7 +397,7 @@ async function walk(options: ScriptOptions & {
   return { receipts, results, views, vendo, prompts, box };
 }
 
-const ctx = { principal, venue: "chat" as const, presence: "present" as const };
+const ctx = { principal, venue: "chat" as const, presence: "present" as const, sessionId: "ses_matrix" };
 
 describe("the six-type matrix — every `vendo_make` ask type, one deployment", () => {
   it("TYPE 1 · a new simple screen is assembled, the row is real, the view is painted", async () => {
@@ -590,7 +590,7 @@ describe("the six-type matrix — every `vendo_make` ask type, one deployment", 
 
     // Screen painted — where an outside agent's screen can be: on the row, read
     // back through the runtime's own door.
-    const outsideCtx = { principal: { kind: "user" as const, subject: "user_parity" }, venue: "mcp" as const, presence: "present" as const };
+    const outsideCtx = { principal: { kind: "user" as const, subject: "user_parity" }, venue: "mcp" as const, presence: "present" as const, sessionId: "ses_parity" };
     const stored = await host.vendo.apps.get(receipt.id, outsideCtx);
     expect(stored?.name).toBe("Spending");
     const opened = await host.vendo.apps.open(receipt.id, outsideCtx);

--- a/packages/vendo/src/wire/apps.grants.test.ts
+++ b/packages/vendo/src/wire/apps.grants.test.ts
@@ -47,6 +47,8 @@ const wireFor = (list: () => Promise<Array<{ id: string }>>): {
       segments: routeSegments(path),
       params: {},
       context: async () => ctx,
+      // Only `/tick` sweeps (wire/misc.ts); no route under test calls it.
+      sweep: async () => {},
       deps,
     },
   };
@@ -136,6 +138,8 @@ const openWire = (options: {
     segments: routeSegments(path),
     params: { appId: options.appId },
     context: async () => ctx,
+    // Only `/tick` sweeps (wire/misc.ts); no route under test calls it.
+    sweep: async () => {},
     deps,
   };
 };

--- a/packages/vendo/src/wire/apps.placements.test.ts
+++ b/packages/vendo/src/wire/apps.placements.test.ts
@@ -58,6 +58,8 @@ const wireFor = (url: string, init?: RequestInit): { wire: WireContext; calls: C
       segments: routeSegments(path),
       params: {},
       context: async () => ctx,
+      // Only `/tick` sweeps (wire/misc.ts); no route under test calls it.
+      sweep: async () => {},
       deps,
     },
   };

--- a/packages/vendo/src/wire/apps.resolve-person.test.ts
+++ b/packages/vendo/src/wire/apps.resolve-person.test.ts
@@ -57,6 +57,8 @@ const resolveWire = (options: {
       segments: routeSegments(path),
       params: { appId: "app_1" },
       context: async () => ctxFor(options.memberships ?? IN_ONE_ORG),
+      // Only `/tick` sweeps (wire/misc.ts); no route under test calls it.
+      sweep: async () => {},
       deps,
     },
   };

--- a/packages/vendo/src/wire/box.served.test.ts
+++ b/packages/vendo/src/wire/box.served.test.ts
@@ -46,6 +46,8 @@ const wireFor = (url: string, method = "GET", seen: Seen[] = []): {
         presence: "present",
         sessionId: "s_kim",
       }),
+      // Only `/tick` sweeps (wire/misc.ts); no route under test calls it.
+      sweep: async () => {},
       deps,
     },
   };

--- a/packages/vendo/tsconfig.test.json
+++ b/packages/vendo/tsconfig.test.json
@@ -1,0 +1,22 @@
+{
+  // The test estate. `tsconfig.json` excludes it so `dist` stays free of test
+  // scaffolding, which also meant nothing ever typechecked it. Its own program,
+  // never built — same shape as `apps`, `guard`, `knowledge`, `automations` and
+  // `vendo-telemetry`.
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    // Two tests import `@vendoai/apps/box-door`, whose export map points at the
+    // zero-dependency `box/turn-routes.mjs` control-port runtime and carries no
+    // `types`. Reading the JS gives them the real inferred signature instead of
+    // an ambient re-declaration that could drift from it. There is no `.js`
+    // under `src`, so this widens nothing else.
+    "allowJs": true
+  },
+  "include": ["src", "vitest.setup.ts"],
+  // The playground fixtures stay out, for the same reason `tsconfig.json` keeps
+  // them out: `dirty/` and `typeonly/` are deliberately broken inputs that
+  // `closure-guard.test.ts` feeds to a real `tsc` and asserts fail. Compiling
+  // them here would report their planted errors as ours.
+  "exclude": ["src/**/__fixtures__/**"]
+}


### PR DESCRIPTION
## The trap

`packages/vendo/tsconfig.json` excludes `*.test.ts`, `*.test.tsx` and
`*.test-util.ts` so `dist` stays free of test scaffolding. The side effect was
that the package's **entire test estate — 212 files — had never been
typechecked by anything**, local or CI.

Demonstrated on this branch, before and after, with one deliberate error
planted in `src/pack.test.ts`:

```
# const deslopDeliberate: number = "1053";

$ tsc -p tsconfig.json --noEmit           # the old typecheck
exit 0                                     # <- the trap
$ pnpm build --filter=@vendoai/vendo       # the old build
exit 0                                     # <- the trap
$ pnpm --filter=@vendoai/vendo typecheck   # this PR's typecheck
src/pack.test.ts(515,7): error TS2322: Type 'string' is not assignable to type 'number'.
exit 1                                     # <- closed
```

The error was then reverted; the demonstration is not in the diff.

## The fix

`packages/vendo/tsconfig.test.json`, same shape as the five that already exist
(`knowledge`, `vendo-telemetry` — #979; `guard`; `automations` — #1002; `apps` —
**#1028**, whose mechanism this reuses verbatim), plus a third `tsc` on the
package's `typecheck` script so CI and local agree.

Two deviations, both about what this package holds that `apps` does not:

| Deviation | Why |
| --- | --- |
| `exclude: ["src/**/__fixtures__/**"]` | Same reason `tsconfig.json` excludes it: `cli/playground/__fixtures__/dirty/` and `typeonly/` are **deliberately broken** inputs `closure-guard.test.ts` hands to a real `tsc` and asserts fail. Compiling them reports their planted errors as ours — that is the 98-vs-96 delta. |
| `allowJs` | Two tests import `@vendoai/apps/box-door`, whose export map points at the zero-dependency `box/turn-routes.mjs` control-port runtime and carries **no `types`**. Reading the JS gives them the real inferred signature instead of an ambient re-declaration that could drift from it. There is no `.js` under `src`, so this widens nothing else. |

## The 96 errors

**96 across 50 files. All cleared. 0 product changes, 0 suppressions, 0 real
product defects.** No `as any`, no `as never`, no `@ts-expect-error`, no
`@ts-nocheck`, no product type widened, and **no assertion changed** — every
`expect(...)` in the diff is byte-identical except nine that gained a bare `!`
at a known-populated array index, which is that file's own existing idiom
(`scriptedFetch`'s `tokenResponses[0]!`).

The count moved 98 → 96 (fixtures excluded) → 1 → 0. The **1** is worth naming:
annotating `served-apps-wire.test.ts`'s fake `request()` return type unmasked a
missing `files` underneath the header error that had been shadowing it. A
mid-job re-surface, not a regression.

### Triage of the 58 that needed judgement

`TS2345` (30), `TS2741` (11), `TS2322` (11), `TS2339` (6) — each one is
potentially "the fake does not match what it fakes". Verdicts:

| Site | Verdict | What it was |
| --- | --- | --- |
| `server.test.ts` ×11 | **type-wrong** (in the test) | `setup(resolver = vi.fn(async () => principal))` inferred `Mock<() => Promise<Principal>>`, but `null` is a real answer from that seam — it is how an anonymous session is expressed (`CreateVendoConfig["principal"]` is `=> Promise<Principal \| null>`) and eleven cases below pass exactly that. Named explicitly. |
| `placement-tools.e2e.test.ts` | **fake-wrong** — a layer conflation | Its local `OnTurn` typed `turn.tools.call` as returning `ToolOutcome`. That is the **guard/registry** union (`"blocked"`); `TurnTools.call` answers the **harness** union `ToolResult` (`"denied"`), and `harnesses/turn-tools.ts:153` `toToolResult` is the translation. They overlap only on `"ok"`/`"error"`, so a probe written against `ToolOutcome` **could never match a real refusal**. The one firing this test parks IS `{status: "denied", needs: {kind: "approval"}}`, sitting mistyped in a `ToolOutcome[]` — but nothing here discriminates on it, so **no assertion was masked**. Retyped to `ToolResult`. Product code already keeps the two layers apart correctly. |
| `mcp-door.test-util.ts` | **fake-wrong** | `DoorSession.listTools()` omitted `inputSchema` from its declared return shape. The real door stamps it on every listed tool (`mcp/src/door.ts:813`), `openDoor` is a real streamable-HTTP client against `vendo.handler` so the value was always there, and the parity test reads it — a hand-written mirror of a wire response that had not kept the field. |
| `hosted-workspace-cas.live.test.ts` | **fake-wrong, inert** | Asserted a membership `role`. There is none — the host asserts `org`, `teams`, `admin`. Verified inert: `accessForPath` returns `{decision: true}` unconditionally for a non-policy org path once `membership.org` matches, so `admin` never enters this test's decision and alice/bob get identical access either way. |
| `config-coherence.test.ts` | **fake-wrong, inert** | Set `runId`, which does not exist, and omitted the **required** `sessionId` — which the same file spells correctly twice at l. 216/227. |
| `server-lazy.test.ts` | **fake-wrong, inert** | Ran on `venue: "byo", presence: "absent"`. Neither exists; `VENUES` is chat/app/automation/mcp and presence is present/away. The real BYO tuple is `ai-sdk.ts:52`'s chat/present, which is what it now uses. The lazy-init path does not branch on either. |
| `pack.test.ts` | **fake-wrong, inert** | Streamed a `UIPayload` with no `formatVersion`, a shape no real producer emits (`genui/wire/compile.ts:533`). `pack.ts:202` reads only `part.appId`. |
| 5 `SandboxMachine` doubles | **fake-wrong, inert** | Served no `files`. They now serve it from `inMemoryBoxFiles` (`@vendoai/apps/testing`), the seam's ONE in-memory implementation — the same resolution #1028 used for the five doubles in `apps`, so no two fakes can drift over what reading a box file means. |
| 2 `SandboxAdapter` doubles | **incidental** | No `destroy`. Both fixtures' other members already throw `"not called"` / `"not used by doctor"`, and `server.test.ts` asserts `.create`/`.resume` were never called. `destroy` now throws to match. |
| 13 `RunContext` fixtures | **incidental** | Omitted the required `sessionId`. Fixed at 8 sites (six are one shared `const ctx`). |
| 5 `WireContext` fakes | **incidental** | No `sweep`. Only `/tick` calls it (`wire/misc.ts:109`); no route under test does. No-op with that reason. |
| `app-rebuild.e2e.test.ts`, `server-venue.test.ts` | **incidental** | `VendoStore` / `SandboxAdapter` imported from `@vendoai/core`, which has never exported either. The umbrella's own barrel already gets both right. |
| `hosted-store.test.ts` | **type-wrong** (in the test) | A local helper annotated `hostedStore(...)` as `VendoStore`; it returns `HostedStore`, which is where the `erase` door this block exercises lives. |
| `orgs-materialize{,.live}.test.ts` | **type-wrong** (in the test) | Cast the whole config `as Parameters<typeof createVendo>[0]`. Narrowed to the one genuinely divergent slot — a deliberately partial sandbox double — so the rest of the config is now honestly checked. |
| `init.test.ts`, `claude-harness.test.ts`, `client.test.ts`, `sync.test.ts`, `compaction-state`, `stream-resume`, `request-connection.seam`, `served-apps-wire`, `sandbox` | **type-wrong / incidental** | Union not narrowed on its discriminant; `Parameters<>` on a defaulted param widening to `\| undefined`; a type argument handed to a `.rejects`-promisified matcher that has none; an un-annotated default inferring `never[]`; `findLast` needing lib ES2023; a required-key-optional-value `abortSignal`; `createElement`'s positional children not merging into typechecked props; and whole-function return-union inference turning an omitted header into `{"content-type"?: undefined}`. |

**No product defect found, and nothing needed product code.** Two product-side
observations logged and deliberately **not** fixed here: `@vendoai/apps`'s
`./box-door` export carries no `types` (any consumer gets implicit `any`), and
`AutomationsConfig["apps"]` is typed as the whole `AppsRuntime` while
`run-execution.ts` reads exactly `config.apps.call`.

### The three escape hatches, and why

All three are casts through `unknown` (never `any`/`never`), each because two
real types genuinely do not overlap and neither is ours to change:

1. **`mastra.test.ts`** — `@mastra/core@1.51.0` vendors its own aliased
   `@ai-sdk/provider` copies (`provider-v6` = 3.0.14), where a provider tool's
   `type` is `"provider-defined"`; the repo pins `@ai-sdk/provider@3.0.2`, where
   it is `"provider"`. A genuine dependency skew. The scripted model only ever
   fills `new Agent({ model })`, so it is now cast to that slot rather than to
   ai-sdk's `LanguageModel`.
2. **`compound-parity.test.ts`** — `AutomationsConfig["apps"]: AppsRuntime`,
   34 members, of which the engine reads one. Cast through `unknown` rather
   than stub 33 members it never touches.
3. **`dev-creds/model-edge.test.ts`** ×2 — `LanguageModel` includes `string`,
   so probing the model's own low-level `doStream`/`doGenerate` needs the step
   `model-edge.ts:53` already takes in the other direction.

### One honest limit on what this catches

`fakeConsole` (`hosted-store.test-util.ts`) — the fake that was found this week
failing to serve 16 real wire operations — produced **zero** type errors in this
run, before and after. It answers string-matched paths and returns no declared
type, so a typechecker has nothing to compare. **This wiring closes the
declared-shape class of fake drift; it does not close the string-routed class.**

## Gates

| Gate | Result |
| --- | --- |
| `pnpm build --filter=@vendoai/vendo...` | 13/13 successful |
| `pnpm --filter=@vendoai/vendo typecheck` (all **three** projects) | exit 0 |
| `pnpm lint` | dependency-guard OK (30 packages), portability-gate all legs green, turbo lint 3/3 |
| `pnpm test` | **CI's job** — see below |

The `packages/vendo` suite was **not** run locally: CLAUDE.md reserves the full
suite for CI and names the green `ci` check the gate of record, and the box is
being shared with two other lanes tonight. The claim this PR needs CI to
confirm is narrow and stated above: **no assertion moved.** The `dependency-guard`
leg does cover the one new cross-package edge (`@vendoai/apps/testing`, which
imports no vitest and is already shipped code).

## Tandem

No-op for `vendo-web`: repo-internal build configuration plus test-file
typings. It emits nothing `vendo-web` reads — no `.vendo/components/`, no
`vendo_*` collection, no blob namespace — and no published API surface moves.

## Changeset

None. `tsconfig.test.json` is not in the package's `files`, and `typecheck` is
not published behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Typecheck all `packages/vendo` test files by adding a dedicated `tsconfig.test.json` and wiring it into the `typecheck` script; fixed 96 test-only type issues uncovered by this. No product or API changes.

- **Refactors**
  - Added `packages/vendo/tsconfig.test.json`; updated `typecheck` to run `tsc -p tsconfig.test.json` alongside the existing projects.
  - Set `exclude: ["src/**/__fixtures__/**"]` and `allowJs: true` to correctly type imports like `@vendoai/apps/box-door`.
  - Fixed 96 test-only type errors across 50 files (e.g., nullable `principal` in auth seam, `ToolResult` vs `ToolOutcome`, required `sessionId`, include `formatVersion`, add `inMemoryBoxFiles` from `@vendoai/apps/testing`, add missing `inputSchema`, type-safe `fetch` mocks).
  - CI and local `pnpm --filter=@vendoai/vendo typecheck` now catch test type drift; assertions and product behavior are unchanged.

<sup>Written for commit aa88c4985dde7fbb69ab7bdf2de6e6892a9560bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

