### PR TITLE
test(ui): drop the /page scenario #1014 left behind in two list-driven browser specs

### DIFF
--- a/packages/ui/e2e/accessibility.spec.ts
+++ b/packages/ui/e2e/accessibility.spec.ts
@@ -6,7 +6,6 @@ const chromeScenarios = [
   "thread",
   "thread-citations",
   "overlay",
-  "page",
   "palette",
   "approval",
   "activity",
@@ -41,7 +40,6 @@ for (const scenario of chromeScenarios) {
       await expect(page.locator(".fl-cite--open .fl-cite-pop")).toBeVisible();
     }
     if (scenario === "overlay") await expect(page.getByRole("dialog", { name: "Vendo assistant" })).toBeVisible();
-    if (scenario === "page") await expect(page.getByRole("tab", { name: "Apps" })).toHaveAttribute("aria-selected", "true");
     if (scenario === "palette") await expect(page.getByRole("dialog", { name: "Vendo assistant" })).toBeVisible();
     if (scenario === "activity") await expect(page.getByText("Invoices list").first()).toBeVisible();
     if (scenario === "automations") await expect(page.getByRole("switch")).toBeVisible();

--- a/packages/ui/e2e/screenshots.spec.ts
+++ b/packages/ui/e2e/screenshots.spec.ts
@@ -4,7 +4,6 @@ import { openScenario, screenshotPath } from "./helpers.js";
 const shots = [
   { scenario: "thread", file: "thread-dark", ready: 'article[aria-label="Approval for Email send"]' },
   { scenario: "overlay", file: "overlay", ready: '[role="dialog"][aria-label="Vendo assistant"]' },
-  { scenario: "page", file: "page", ready: '[role="tab"][aria-selected="true"]' },
   { scenario: "palette", file: "palette", ready: '[role="dialog"][aria-label="Vendo assistant"]' },
   { scenario: "approval", file: "approval", ready: 'article[aria-label="Approval for Delete invoice"]' },
   { scenario: "thread-humanized", file: "thread-humanized", ready: 'article[aria-label="Approval for Transfer funds"]' },
@@ -33,7 +32,6 @@ for (const shot of shots) {
     );
     await openScenario(page, shot.scenario);
     await expect(page.locator(shot.ready).first()).toBeVisible();
-    if (shot.scenario === "page") await expect(page.getByRole("tab", { name: "Apps" })).toHaveAttribute("aria-selected", "true");
     if (shot.scenario === "thread-citations") {
       // Both Surface-2 states settled, with the first citation popover
       // expanded (the mockup's "one expanded" grounded state).


### PR DESCRIPTION
PR #1014 cut `VendoPage` and carefully repointed every spec whose *subject* was
the page. It missed the two specs where `page` was merely **one entry in a
scenario list**, so both have been red on `main` ever since — invisibly, because
the `packages/ui` browser suite is a **local-only** gate (the 2026-08-06
decision: headless CI mis-resolves `:focus-visible` and `light-dark()`). Nobody
saw it unless they happened to run it.

## Diagnosis, verified on pristine `origin/main`

Full browser suite on unmodified `origin/main`: **3 failed / 80 passed**.

| Spec | Cause |
|---|---|
| `accessibility.spec.ts:26` (`page` case) | `getByRole("tab", { name: "Apps" })` — element not found |
| `screenshots.spec.ts:23` (`captures page.png`) | `[role="tab"][aria-selected="true"]` — element not found |
| `extreme-content.spec.ts:48` | **load-dependent flake, not a real failure** — see below |

`case "/page"` is absent from `e2e/harness/main.tsx`, and the "Apps" tablist
came from `chrome/center/apps-page.tsx`, deleted by #1014. `VendoPage` is gone
from `src/` entirely; these two lines were the last references to the scenario
anywhere in the e2e tree.

Worth noting for the next reader: the failures got *past* `openScenario`
because the harness's `default:` case still renders
`<main data-scenario="page">` with an "Unknown browser scenario" alert. So a
deleted scenario does not fail where you'd expect — it fails later, at the
readiness assertion. A missing route is not self-announcing here.

## Resolution: remove the `page` entry, keep both specs

Not a restore (the product surface is deliberately gone — Yousef's call, twice
confirmed in #1014) and not a repoint (the assertion is specific to the
workspace tablist, not general). This applies #1014's **own stated convention**:

> Where `VendoPage` was one item in a list rather than the subject
> (`export-surface`, `ssr`, `s1-recipe`), only the `VendoPage` entry was removed
> so the surrounding contract coverage survives.

Same situation, two files it didn't reach. Four lines deleted.

## Coverage lost, on the record

- the axe WCAG 2.1 A/AA audit of the full-page workspace surface
- its render/settled-state smoke and PNG capture

Both audited `VendoPage`. **Zero live product coverage is lost** — the surface
does not exist. The other 10 accessibility scenarios and 14 screenshot
scenarios are untouched. This is completing #1014's cut, not deleting to get
green.

## On the screenshot baseline: there was never one

A repointed screenshot spec would need a fresh baseline, and a baseline captured
from a broken state is worse than no test. That risk does not apply here:

- `screenshots.spec.ts` calls `page.screenshot({ path })` — a **capture**, not
  `toHaveScreenshot()`. Nothing is compared.
- `toHaveScreenshot` appears **nowhere** in the suite; there are no visual
  baselines at all.
- `e2e/screenshots/` is **gitignored**; no `page.png` is or was tracked in git.
- `e2e/README.md` already documents it: *"`screenshots.spec.ts` — writes PNGs;
  a capture job, not a gate."*

So no baseline was created, rebased, or blessed. The spec's real assertive value
is its readiness selectors, which is what the deleted entry could no longer
satisfy.

## The third failure is a flake, and here is the evidence

`extreme-content.spec.ts:48` clicks "Show 342 earlier messages" in a
virtualized 400-message thread; it fails with *"element is not stable"* →
*"`fl-turn-actions` intercepts pointer events"* → *"element was detached from
the DOM"*. Three full-suite runs on `origin/main`:

| Run | Load avg | Result |
|---|---|---|
| 1 | ~15 | 3 failed (incl. `extreme-content`) |
| 2 | ~13 → 5 | **2 failed** — `extreme-content` **passed** |
| 3 | ~9 | 3 failed (incl. `extreme-content`) |

It tracks machine load, not code, and it passed again on the green run below.
This is exactly the class `playwright.config.ts` already anticipates —
*"a couple of timing-sensitive beats … can miss the expect window under that
load. Retry in CI so infrastructure jitter never reddens the gate"* — with
`retries: 0` locally by design. **Left alone deliberately:** it is not a product
defect and not this PR's scope. Flagging it so it is on the record rather than
rediscovered.

## Is anything else unwatched?

**No.** The two `/page` specs were the only genuinely-red specs in the whole
`packages/ui` browser suite — deterministic across all three pristine runs.
Everything else either passes or is an already-annotated `test.fixme`
quarantine (7 skipped: the `stage` voice-lane and `activity` ledger cases, each
carrying a dated reason and an owner decision it's waiting on). Stating that
plainly since it's the good outcome: the local-only gate was hiding these two
and nothing more.

## Gates (foreground, scoped, alone)

- `pnpm --filter @vendoai/ui test:browser` — **81 passed, 7 skipped, 0 failed**
  (from 3 failed / 80 passed)
- `pnpm build --filter=@vendoai/ui...` ✅
- `pnpm typecheck` 42/42 ✅ · `pnpm lint` 3/3 ✅

No changeset: test-only, no published surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the stale `/page` scenario from two list-driven browser specs to fix local browser test failures after `VendoPage` was removed. No product changes; the `@vendoai/ui` browser suite is green again.

- **Bug Fixes**
  - Dropped `page` from scenario lists in `e2e/accessibility.spec.ts` and `e2e/screenshots.spec.ts`.
  - Removed readiness assertions tied to the old workspace tablist.
  - Result: `pnpm --filter @vendoai/ui test:browser` → 81 passed, 7 skipped, 0 failed.

<sup>Written for commit a680b9cf9c38378ff87dde5562b6ed243c77b307. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

