### PR TITLE
feat(actions,demo-bank): sync names the judgments an extraction stranded, and the demo gates on it

### DIFF
--- a/examples/demo-bank/src/vendo/tool-grades.test.ts
+++ b/examples/demo-bank/src/vendo/tool-grades.test.ts
@@ -1,0 +1,72 @@
+import { promises as fs } from "node:fs"
+import path from "node:path"
+import {
+  applyJudgment,
+  bindingIdentity,
+  judgmentsFileSchema,
+  overridesFileSchema,
+  pruneJudgments,
+  toolsFileSchema,
+} from "@vendoai/actions"
+import { mergeOverrides } from "@vendoai/actions/sync"
+import { describe, expect, it } from "vitest"
+
+/**
+ * Maple's committed grades have to still apply, because on this demo nothing
+ * else can supply them: `predev` runs `vendo sync . --no-ai`, which cannot grade
+ * without a model key, so `.vendo/judgments.json` is the ONLY grade source on
+ * the keyless BYO path this repo documents.
+ *
+ * Live 2026-08-08 (#1056): every generated view rendered empty, in the thread
+ * and pinned to the home hero, because all 22 grades had gone inert. Maple moved
+ * its `/maple` prefix out of the OpenAPI paths into the spec's `servers` url, so
+ * `tools.json` regenerated as `GET /api/goals` while the judgments still said
+ * `GET /maple/api/goals`. `applyJudgment` holds a judgment inert when its
+ * recorded binding no longer matches the tool's — correct, so a handler that
+ * moved never inherits someone else's grade, and silent. The tools fell back to
+ * `ungraded`, which the guard withholds exactly like `destructive`, so plain
+ * reads parked as `pending-approval` and everything bound to them rendered
+ * empty. `vendo doctor` said "19/22 tools ungraded" and still exited 0.
+ *
+ * Both checks run the REAL functions — `pruneJudgments`, and `applyJudgment` then
+ * `mergeOverrides` (the composition the runtime's `effectiveHostTool` performs).
+ * A test that reimplemented the binding comparison could only ever agree with
+ * itself.
+ */
+
+const vendoDir = path.join(process.cwd(), ".vendo")
+
+const readVendoFile = async (file: string): Promise<unknown> =>
+  JSON.parse(await fs.readFile(path.join(vendoDir, file), "utf8")) as unknown
+
+const readLayers = async () => ({
+  tools: toolsFileSchema.parse(await readVendoFile("tools.json")).tools,
+  judgments: judgmentsFileSchema.parse(await readVendoFile("judgments.json")),
+  overrides: overridesFileSchema.parse(await readVendoFile("overrides.json")),
+})
+
+describe("Maple's committed grades still reach its tools", () => {
+  /** The #1056 defect itself. Asserted on the judgment layer ALONE, because
+   *  `overrides.json` is keyed by tool NAME and so never drifted — the three
+   *  tools carrying a `risk` there were exactly the three that still looked
+   *  graded while the other 19 were stranded, which is how this stayed hidden. */
+  it("strands no standing judgment on a binding that moved", async () => {
+    const { tools, judgments } = await readLayers()
+    const live = pruneJudgments(judgments, tools).tools
+    const identityByName = new Map(tools.map(tool => [tool.name, bindingIdentity(tool.binding)]))
+    const stranded = Object.entries(judgments.tools)
+      .filter(([name]) => live[name] === undefined)
+      .map(([name, judgment]) =>
+        `${name}: graded against "${judgment.binding}", tool is now "${identityByName.get(name) ?? "absent from the catalog"}"`)
+    expect(stranded).toEqual([])
+  })
+
+  it("leaves no tool ungraded, so a read runs instead of asking", async () => {
+    const { tools, judgments, overrides } = await readLayers()
+    const judged = tools.map(tool => applyJudgment({ ...tool }, judgments.tools[tool.name]))
+    const ungraded = mergeOverrides(judged, overrides)
+      .filter(tool => tool.risk === "ungraded")
+      .map(tool => tool.name)
+    expect(ungraded).toEqual([])
+  })
+})

--- a/packages/actions/src/sync/index.ts
+++ b/packages/actions/src/sync/index.ts
@@ -4,11 +4,13 @@ import path from "node:path";
 import { canonicalJson, descriptorHash, VendoError, type JsonSchema, type ToolSemantics } from "@vendoai/core";
 import {
   VENDO_TOOLS_FORMAT,
+  judgmentsFileSchema,
   overridesFileSchema,
   schemaIsBlind,
   toolsFileSchema,
   type BreakingChange,
   type ExtractedTool,
+  type JudgmentsFile,
   type OverridesFile,
   type SyncReport,
   type ToolOverride,
@@ -212,16 +214,85 @@ async function sourceHash(root: string, srcPath: string, cache: Map<string, stri
   return cache.get(srcPath);
 }
 
+/** Read for ONE reason: to report standing judgments this extraction stranded.
+ *  Fail-soft, unlike `readOverrides` — a malformed judgments file is the
+ *  judgment pass's own loud failure (the same call sync's runtime and doctor
+ *  copies make), and sync must not refuse to extract because the AI layer's
+ *  cache is unreadable. */
+async function readJudgments(file: string): Promise<JudgmentsFile | null> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(file, "utf8");
+  } catch {
+    return null;
+  }
+  try {
+    return judgmentsFileSchema.parse(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
 /** The previous machine layer + the authored layer of `.vendo/`. */
 interface VendoDirState {
   previousTools: ExtractedTool[];
   overrides: OverridesFile | null;
+  judgments: JudgmentsFile | null;
 }
 
 async function loadVendoDir(out: string, warnings: string[]): Promise<VendoDirState> {
   const previous = await readPrevious(path.join(out, "tools.json"), warnings);
   const overrides = await readOverrides(path.join(out, "overrides.json"));
-  return { previousTools: previous?.tools ?? [], overrides };
+  const judgments = await readJudgments(path.join(out, "judgments.json"));
+  return { previousTools: previous?.tools ?? [], overrides, judgments };
+}
+
+/**
+ * Standing judgments this extraction stranded — the grades a host still has on
+ * disk and no longer gets.
+ *
+ * `applyJudgment` holds a judgment INERT when its recorded binding no longer
+ * matches the tool's, so a handler that moved never inherits a grade meant for
+ * whatever used to answer there. Correct, and silent: the tool quietly falls
+ * back to `ungraded`, which the guard withholds exactly like `destructive`, so
+ * every call asks. #1056 was 22 of 22 stranded that way — Maple moved its
+ * `/maple` prefix out of the OpenAPI paths into the spec's `servers` url, and
+ * nothing said so. `vendo doctor` counted the ungraded tools but cannot fail,
+ * and `pruneJudgments` would have deleted the entries loudly except it only
+ * runs inside the KEYED judge pass. On the keyless path — `vendo sync --no-ai`,
+ * the documented BYO posture, which cannot grade at all — a stranded judgment
+ * was therefore never applied, never pruned, and never mentioned.
+ *
+ * Only tools the catalog still carries. A judgment for a tool that is simply
+ * GONE is ordinary churn the next keyed sync prunes; naming it here would be
+ * noise, and unlike a hand-authored override (whose miss is a typo worth
+ * reporting) this file is machine-written.
+ *
+ * ONE line, not one per tool: the failure mode is systematic — a mount point or
+ * a path convention moves and stalls the whole catalog at once — so 22 warnings
+ * would be a wall saying one thing. The count carries the scale, one worked
+ * before/after carries the diagnosis (it is what makes a prefix change obvious),
+ * and the name list caps like the `blind:` line's does.
+ */
+function strandedJudgments(tools: readonly ExtractedTool[], judgments: JudgmentsFile | null): string[] {
+  if (judgments === null) return [];
+  const stranded: Array<{ name: string; was: string; now: string }> = [];
+  for (const tool of [...tools].sort((a, b) => a.name.localeCompare(b.name))) {
+    const judgment = judgments.tools[tool.name];
+    if (judgment === undefined) continue;
+    const now = bindingIdentity(tool.binding);
+    if (judgment.binding === now) continue;
+    stranded.push({ name: tool.name, was: judgment.binding, now });
+  }
+  const first = stranded[0];
+  if (first === undefined) return [];
+  const names = stranded.map(({ name }) => name);
+  const shown = names.slice(0, 6).join(", ");
+  return [
+    `${stranded.length}/${tools.length} standing judgments no longer match their tool, so those tools are ungraded`
+    + ` and ask on every call — ${first.name} was graded against "${first.was}", now "${first.now}".`
+    + ` Re-run \`vendo sync\` with a model key to re-grade: ${shown}${names.length > 6 ? ` +${names.length - 6} more` : ""}`,
+  ];
 }
 
 /** What survives a wholesale regeneration of the machine layer, keyed by tool
@@ -257,7 +328,7 @@ export async function vendoSync(options: {
   clearAliasCache(); // same-process re-runs (watch mode) must see tsconfig edits
   const warnings: string[] = [];
   const toolsPath = path.join(out, "tools.json");
-  const { previousTools, overrides } = await loadVendoDir(out, warnings);
+  const { previousTools, overrides, judgments } = await loadVendoDir(out, warnings);
 
   const extraction = await runExtractors(root);
   warnings.push(...extraction.warnings);
@@ -311,6 +382,9 @@ export async function vendoSync(options: {
       }
     }
   }
+  // The same courtesy the authored layer above has always had, for the machine
+  // layer that silently loses a grade instead of a label.
+  warnings.push(...strandedJudgments(extracted.tools, judgments));
 
   const mergedPrevious = mergeOverrides(previousTools, overrides);
   const mergedNext = mergeOverrides(extracted.tools, overrides);

--- a/packages/actions/src/sync/index.ts
+++ b/packages/actions/src/sync/index.ts
@@ -215,10 +215,9 @@ async function sourceHash(root: string, srcPath: string, cache: Map<string, stri
 }
 
 /** Read for ONE reason: to report standing judgments this extraction stranded.
- *  Fail-soft, unlike `readOverrides` — a malformed judgments file is the
- *  judgment pass's own loud failure (the same call sync's runtime and doctor
- *  copies make), and sync must not refuse to extract because the AI layer's
- *  cache is unreadable. */
+ *  Fail-soft, unlike `readOverrides` — a malformed judgments file is the judgment
+ *  pass's own loud failure, the same call the runtime and doctor readers make, and
+ *  sync must not refuse to extract because the AI layer's cache is unreadable. */
 async function readJudgments(file: string): Promise<JudgmentsFile | null> {
   let raw: string;
   try {
@@ -277,9 +276,11 @@ async function loadVendoDir(out: string, warnings: string[]): Promise<VendoDirSt
 function strandedJudgments(tools: readonly ExtractedTool[], judgments: JudgmentsFile | null): string[] {
   if (judgments === null) return [];
   const stranded: Array<{ name: string; was: string; now: string }> = [];
+  let judged = 0;
   for (const tool of [...tools].sort((a, b) => a.name.localeCompare(b.name))) {
     const judgment = judgments.tools[tool.name];
     if (judgment === undefined) continue;
+    judged += 1;
     const now = bindingIdentity(tool.binding);
     if (judgment.binding === now) continue;
     stranded.push({ name: tool.name, was: judgment.binding, now });
@@ -288,8 +289,10 @@ function strandedJudgments(tools: readonly ExtractedTool[], judgments: Judgments
   if (first === undefined) return [];
   const names = stranded.map(({ name }) => name);
   const shown = names.slice(0, 6).join(", ");
+  // Out of the tools that CARRY a judgment, not the whole catalog: "3/30" would
+  // read as thirty judgments and understate a total break.
   return [
-    `${stranded.length}/${tools.length} standing judgments no longer match their tool, so those tools are ungraded`
+    `${stranded.length}/${judged} standing judgments no longer match their tool, so those tools are ungraded`
     + ` and ask on every call — ${first.name} was graded against "${first.was}", now "${first.now}".`
     + ` Re-run \`vendo sync\` with a model key to re-grade: ${shown}${names.length > 6 ? ` +${names.length - 6} more` : ""}`,
   ];

--- a/packages/actions/src/sync/sync.synthetic.test.ts
+++ b/packages/actions/src/sync/sync.synthetic.test.ts
@@ -187,6 +187,44 @@ describe("validation and route classification", () => {
     expect(report.warnings.some((warning) => warning.includes("connector_missing"))).toBe(false);
   });
 
+  /** #1056: a standing judgment whose binding moved is held INERT by
+   *  `applyJudgment`, so its tool silently falls back to `ungraded` and asks on
+   *  every call. Nothing said so on the keyless path — the only path that cannot
+   *  re-grade — because `pruneJudgments` runs solely inside the keyed judge pass.
+   *  Sync is where a host finds out. */
+  it("warns when a standing judgment's binding no longer matches its tool", async () => {
+    const { root, out } = await temporaryHost();
+    await writeSpec(root, { "/api/items": { get: operation("listItems") } });
+    await writeFile(out, "judgments.json", JSON.stringify({
+      format: "vendo/judgments@1",
+      tools: {
+        host_listItems: { binding: "GET /mount/api/items", fields: { risk: "read" }, evidence: "return items;" },
+        host_departed: { binding: "GET /api/departed", fields: { risk: "read" }, evidence: "return gone;" },
+      },
+    }));
+
+    const report = await vendoSync({ root, out });
+    const stranded = report.warnings.filter((warning) => warning.includes("standing judgment"));
+    expect(stranded).toHaveLength(1);
+    expect(stranded[0]).toContain("1/1 standing judgments no longer match their tool");
+    expect(stranded[0]).toContain(`host_listItems was graded against "GET /mount/api/items", now "GET /api/items"`);
+    // A judgment for a tool the catalog no longer carries is ordinary churn the
+    // next keyed sync prunes — not a stranded grade, so not this host's problem.
+    expect(stranded[0]).not.toContain("host_departed");
+  });
+
+  it("stays silent when every standing judgment still binds to its tool", async () => {
+    const { root, out } = await temporaryHost();
+    await writeSpec(root, { "/api/items": { get: operation("listItems") } });
+    await writeFile(out, "judgments.json", JSON.stringify({
+      format: "vendo/judgments@1",
+      tools: { host_listItems: { binding: "GET /api/items", fields: { risk: "read" }, evidence: "return items;" } },
+    }));
+
+    const report = await vendoSync({ root, out });
+    expect(report.warnings.filter((warning) => warning.includes("standing judgment"))).toEqual([]);
+  });
+
   it("reports loud wrapper errors and honors the per-slot ignore list", async () => {
     const inlineHost = await temporaryHost();
     await writeFile(


### PR DESCRIPTION
Follow-up to #1056, which fixed the stranded grades. This makes the next one
visible, and gates the demo against it.

## The defect class

`applyJudgment` holds a standing judgment **inert** when its recorded binding no
longer matches the tool's — deliberately, so a handler that moved never inherits
a grade meant for whatever used to answer there. The tool then falls back to
`ungraded`, which the guard withholds exactly like `destructive`, so every call
asks and everything bound to it renders empty.

#1056 was 22 of 22 stranded that way, and **nothing failed**:

| | why it didn't catch it |
|---|---|
| `vendo doctor` | counted it correctly — `19/22 tools ungraded` — but warnings never reach its exit code, so it **exited 0** the whole time |
| `pruneJudgments` | would have deleted the entries loudly, but runs **only inside the keyed judge pass** |
| `vendo sync --no-ai` | never loaded `judgments.json` at all |

So on the keyless path — the documented BYO posture, and the one path that
*cannot re-grade* — a stranded judgment was never applied, never pruned, and
never mentioned.

## B — `vendo sync` reports stranded judgments (`packages/actions`)

Sync already extends this courtesy to the **authored** layer
(`host override X did not match any extracted tool`). This is the same courtesy
for the **machine** layer, which loses a grade rather than a label — and it
protects every Vendo host, not just our demo.

```
warning: 22/22 standing judgments no longer match their tool, so those tools are
ungraded and ask on every call — host_auth_create was graded against
"POST /maple/api/auth/{}", now "POST /api/auth/{}". Re-run `vendo sync` with a
model key to re-grade: host_auth_create, host_auth_get, … +16 more
```

One line, not one per tool: the failure mode is systematic (a mount point moves
and strands the whole catalog at once), so the count carries the scale, one
worked before/after carries the diagnosis, and the name list caps like the
`blind:` line's does. Verified against the real regression by re-introducing the
`/maple` prefix — and silent when every judgment still binds.

A judgment for a tool the catalog no longer carries stays silent: ordinary churn
the next keyed sync prunes, and unlike a hand-authored override (whose miss is a
typo) this file is machine-written. Reading the file is fail-soft, matching the
two other readers outside the judge pass.

## A — the demo's hard gate (`examples/demo-bank`)

Two properties, both through the **real** functions — `pruneJudgments`, and
`applyJudgment` then `mergeOverrides` (the composition the runtime's
`effectiveHostTool` performs). Neither reimplements the binding comparison; a
test that did could only ever agree with itself.

The stranding check asserts on the judgment layer **alone**, because
`overrides.json` is keyed by tool NAME and so never drifted — the three tools
carrying a `risk` there were exactly the three that still looked graded while the
other 19 were stranded. That is how this hid behind a "19/22" that read like
partial coverage rather than a systematic break.

Verified it catches the real thing: re-introducing the `/maple` prefix fails both
assertions and names all 22 tools with their before/after binding.

## Deliberately out of scope

**Doctor's `warn`-vs-exit-code semantics are not touched.** That is a CLI
contract change with repo-wide blast radius and it needs its own review. B closes
the visibility gap without going near it: sync reports on the path doctor never
gated, and A supplies the hard failure for this repo. Left as a clean boundary
rather than folded in.

## Gate

`pnpm build --filter=demo-bank... --filter=@vendoai/actions...` · typecheck ·
lint (0 errors; 4 pre-existing warnings in untouched files) · `dependency-guard`
OK (30 packages) · `portability-gate` all legs green.

Tests: `@vendoai/actions` **618 passed** (+2) · `demo-bank` **117 passed** (+2).

No UI-affecting change — `examples/demo-bank/.vendo/` is byte-identical to `main`,
so #1056's browser proof still stands unaltered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `vendo sync` warn when standing judgments no longer match their tools, and add a demo-bank gate to ensure committed grades still apply. The warning now reports a ratio over judged tools (not the whole catalog) for clearer signal.

- **New Features**
  - `@vendoai/actions`: `vendo sync` now reads `judgments.json` (fail-soft) and emits one warning summarizing stranded judgments (count over judged tools, first before/after binding, capped name list). Judgments for removed tools are ignored.
  - `examples/demo-bank`: Added tests that assert no standing judgment is stranded and no tool remains `ungraded` by exercising `pruneJudgments`, `applyJudgment`, and `mergeOverrides`.

<sup>Written for commit 0714feda730f5ca82d5538e208185839b1972d5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

