### PR TITLE
fix(demo-bank,ui): two regressions from tonight — the demo's copy points at a deleted page, and #1051's per-row fix missed the connect tray

### DIFF
--- a/.changeset/one-connect-no-longer-freezes-the-whole-tray.md
+++ b/.changeset/one-connect-no-longer-freezes-the-whole-tray.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/ui": patch
+---
+
+Starting one connect in the connect tray no longer makes every other connector inert. The tray tracked the connect in flight as a single toolkit for the whole surface and disabled every add button off it, so on a host with a full catalog the first click froze all 55 remaining connectors for the length of the 120s poll — with no cancel, and no disabled styling anywhere to say why, so the tray looked interactive and simply ignored every click. Connect state is now keyed per row, the way `ConnectedAccountsPanel` already keyed it: several connects can run at once, each row keeps its own spinner, its own failure reason and its own "your browser blocked the sign-in window" link, and no add button disables at all — the row that is connecting shows its progress dots instead of a button, so there is nothing left to grey out.

--- a/examples/demo-bank/src/demo-script/engine.ts
+++ b/examples/demo-bank/src/demo-script/engine.ts
@@ -11,8 +11,9 @@
  *   the same chunk vocabulary (text deltas, dynamic-tool parts,
  *   `data-vendo-view` / `data-vendo-approval` / `data-vendo-connect` wire
  *   parts), so the thread chrome renders it exactly like a live turn;
- * - host tools execute FOR REAL through `vendo.guardedTools` (guard-audited →
- *   the Activity panel fills; the transfer parks a genuine approval the
+ * - host tools execute FOR REAL through `vendo.guardedTools` (guard-audited, so
+ *   the audit trail is real even though Maple mounts no surface that reads it;
+ *   the transfer parks a genuine approval the
  *   in-thread ApprovalCard resumes through the BYO parked-call machinery);
  * - the turn persists to the same `vendo_threads` row a live turn would, so
  *   history survives reopen and the resume upsert works over the plain wire.
@@ -353,7 +354,7 @@ async function confirmTransfer(
   }
   await streamText(
     writer,
-    `Done — $200.00 moved to savings.${balanceLine} The posted transfer is in your transactions, and the approval is recorded in Activity.`,
+    `Done — $200.00 moved to savings.${balanceLine} The posted transfer is in your transactions.`,
     signal,
   );
 }
@@ -392,7 +393,7 @@ async function enableAutomation(
 }
 
 /** The WHOLE automation card, in-thread: the `data-vendo-automation` part the
- *  chrome renders with the same card vocabulary as Workspace → Automations.
+ *  chrome renders with the same card vocabulary as the AutomationsPanel.
  *  Streamed under a stable reconciliation id, so the approval resume's
  *  re-emission flips the SAME card from "waiting on N permissions" to live. */
 async function automationCardPart(writer: Writer, ctx: RunContext, key: AutomationKey): Promise<void> {
@@ -507,7 +508,7 @@ async function automationArmedConfirmation(context: BeatContext, key: Automation
   if (key === "weekly") {
     await streamText(
       writer,
-      "Set. Every Friday at 5:00 PM I'll put together that week's spending by category and have the digest drafted for you — sending is always yours, one tap. It's live under Workspace → Automations — you can pause it anytime.",
+      "Set. Every Friday at 5:00 PM I'll put together that week's spending by category and have the digest drafted for you — sending is always yours, one tap. It never sends on its own.",
       signal,
     );
     await gmailDeliveryMoment(
@@ -519,7 +520,7 @@ async function automationArmedConfirmation(context: BeatContext, key: Automation
   }
   await streamText(
     writer,
-    "Armed — if checking dips below $2,000, an alert will be drafted for you that same morning. It's live under Workspace → Automations.",
+    "Armed — if checking dips below $2,000, an alert will be drafted for you that same morning.",
     signal,
   );
   await gmailDeliveryMoment(
@@ -529,8 +530,8 @@ async function automationArmedConfirmation(context: BeatContext, key: Automation
   );
 }
 
-/** The approval-resume leg for a grant-SET decision (weekly/low-balance). The deciding
- *  surface (the in-thread set card or the workspace panel) already settled
+/** The approval-resume leg for a grant-SET decision (weekly/low-balance). The
+ *  deciding surface — in Maple, the in-thread set card — already settled
  *  the WHOLE set over the wire with ONE decision — the automations engine's
  *  subscriber minted (or discarded) every grant; nothing is bulk-approved
  *  silently here. This leg settles the parked tool part, re-emits the
@@ -553,7 +554,7 @@ async function automationGrantResume(
     await automationCardPart(writer, ctx, key);
     await streamText(
       writer,
-      "No problem — I've switched the automation off. Nothing will run, and the declined request is recorded in Activity.",
+      "No problem — I've switched the automation off. Nothing will run.",
       signal,
     );
     return;
@@ -638,7 +639,7 @@ async function lowBalanceBeat(context: BeatContext): Promise<void> {
 async function gmailConnectedBeat({ writer, signal }: BeatContext): Promise<void> {
   await streamText(
     writer,
-    "Gmail is connected — anything I draft for you lands there, ready to send with one tap. Your automations are fully live; they're under Workspace → Automations whenever you want to pause them.",
+    "Gmail is connected — anything I draft for you lands there, ready to send with one tap. Your automations are fully live, and every one of them drafts rather than sends — nothing leaves without you.",
     signal,
   );
 }
@@ -736,7 +737,7 @@ type ApprovalToolPart = {
  *  tool_use with NO tool_result, and the first real-agent prompt in the same
  *  thread 400s on replay. Settling the dangling part as denied yields the
  *  matched tool-approval-response + tool-result pair. Server-side the guard
- *  asks simply stay pending — the workspace panel can still decide them. */
+ *  asks simply stay pending; Maple mounts no surface that decides them. */
 function settleAbandonedScriptedApprovals(messages: UIMessage[]): void {
   for (const message of messages) {
     if (message.role !== "assistant") continue;
@@ -829,7 +830,7 @@ export async function scriptedThreadsResponse(request: Request): Promise<Respons
         await automationGrantResume({ writer, ctx, signal }, grantKey, responded.toolCallId, approved);
       } else if (!approved) {
         write(writer, { type: "tool-output-denied", toolCallId: responded.toolCallId });
-        await streamText(writer, "No problem — I've cancelled it. Nothing moved, and the declined request is recorded in Activity.", signal);
+        await streamText(writer, "No problem — I've cancelled it. Nothing moved.", signal);
       } else {
         const resolution = approvalId === undefined ? null : await parkedOutcome(approvalId, principal.subject);
         if (resolution?.state === "executed" && resolution.outcome !== undefined) {
@@ -837,7 +838,7 @@ export async function scriptedThreadsResponse(request: Request): Promise<Respons
           await confirmTransfer(writer, ctx, resolution.outcome, signal);
         } else {
           write(writer, { type: "tool-output-error", toolCallId: responded.toolCallId, errorText: "The approved call did not resume." });
-          await streamText(writer, "Something interrupted the transfer — your accounts are untouched. Check Activity for the record.", signal);
+          await streamText(writer, "Something interrupted the transfer — your accounts are untouched. You can try again.", signal);
         }
       }
       write(writer, { type: "finish-step" });

--- a/packages/ui/e2e/connect-tray-per-row.spec.ts
+++ b/packages/ui/e2e/connect-tray-per-row.spec.ts
@@ -43,8 +43,13 @@ test("one connect in flight leaves every other connector clickable", async ({ pa
 
   // Still live, not merely styled as such: a second connect starts and keeps its
   // own dots beside the first.
-  await tray.getByRole("button", { name: "Connect Gmail" }).click();
-  await expect(tray.getByRole("status", { name: "Connecting Gmail" })).toBeVisible();
+  await tray.getByRole("button", { name: "Connect QuickBooks" }).click();
+  await expect(tray.getByRole("status", { name: "Connecting QuickBooks" })).toBeVisible();
   await expect(tray.getByRole("status", { name: "Connecting Slack" })).toBeVisible();
+  // The only VISIBLE difference this fix makes. A tray with one shared
+  // `connecting` looked identical to a working one — the 55 inert buttons carried
+  // no disabled styling at all — so two rows connecting at once is the state a
+  // screenshot can actually tell apart from the old behaviour.
+  await page.screenshot({ path: screenshotPath("connect-tray-two-in-flight"), animations: "disabled" });
   release();
 });

--- a/packages/ui/e2e/connect-tray-per-row.spec.ts
+++ b/packages/ui/e2e/connect-tray-per-row.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+import { openScenario, parkRequest, screenshotPath } from "./helpers.js";
+
+/**
+ * The connect tray's in-flight state, measured the way the browser pass measured
+ * it: count the add buttons, and count how many of them the browser will refuse
+ * to click.
+ *
+ * The tray held ONE `connecting` toolkit for the whole surface and disabled every
+ * add button off it, so starting a single connect made every other connector
+ * inert for the full 120s poll — no cancel, and no disabled styling to say why
+ * (`{spinners: 1, disabledAdds: 55, totalAdds: 55}` on Maple's 56-toolkit
+ * catalog). #1051 gave the connected-accounts panel per-key state; the tray is
+ * the second caller that never got it.
+ *
+ * `parkRequest` fakes nothing — it holds the REAL initiate open so the in-flight
+ * moment stays still long enough to photograph and count.
+ */
+test("one connect in flight leaves every other connector clickable", async ({ page }) => {
+  const release = await parkRequest(page, "**/connections/initiate");
+  await openScenario(page, "affordances");
+  await page.getByRole("button", { name: "Connect tools" }).click();
+  const tray = page.locator(".fl-tray");
+  await expect(tray).toBeVisible();
+
+  await tray.getByRole("button", { name: "Connect Slack" }).click();
+  await expect(tray.getByRole("status", { name: "Connecting Slack" })).toBeVisible();
+
+  const counted = await tray.evaluate(node => {
+    const adds = [...node.querySelectorAll<HTMLButtonElement>("button.fl-picker-add")];
+    return {
+      spinners: node.querySelectorAll(".fl-picker-connecting").length,
+      disabledAdds: adds.filter(button => button.disabled).length,
+      totalAdds: adds.length,
+    };
+  });
+  // Photographed before it is judged, so a failing run leaves the reproduction
+  // behind rather than only an assertion message.
+  await page.screenshot({ path: screenshotPath("connect-tray-in-flight"), animations: "disabled" });
+  // The connecting row renders its dots INSTEAD of a button, so the add buttons
+  // still on screen ARE the other connectors — and none of them is disabled.
+  expect(counted).toEqual({ spinners: 1, disabledAdds: 0, totalAdds: 1 });
+
+  // Still live, not merely styled as such: a second connect starts and keeps its
+  // own dots beside the first.
+  await tray.getByRole("button", { name: "Connect Gmail" }).click();
+  await expect(tray.getByRole("status", { name: "Connecting Gmail" })).toBeVisible();
+  await expect(tray.getByRole("status", { name: "Connecting Slack" })).toBeVisible();
+  release();
+});

--- a/packages/ui/src/chrome/connect-dock.tsx
+++ b/packages/ui/src/chrome/connect-dock.tsx
@@ -204,14 +204,20 @@ export function ConnectTray({ onClose, anchorRef, closing = false }: {
   const { options: connectors, resolved, failed, retry } = useConnectorCatalog();
   const { connections, refresh } = useConnections();
   const [query, setQuery] = useState("");
-  const [connecting, setConnecting] = useState<string>();
   const [justConnected, setJustConnected] = useState<string>();
-  const [error, setError] = useState<string>();
-  // The broker's redirect URL, once initiate lands, for a connect whose sign-in
-  // window the browser refused. The tray opened the window in the click, but
-  // offered nothing when it was refused anyway — the row sat on its dots for the
-  // whole poll with nowhere to sign in.
-  const [blockedUrl, setBlockedUrl] = useState<string>();
+  // All three keyed by toolkit, the way #1051 keyed the panel's `busy` and
+  // `blocked`: a connect is a per-ROW flow, and one connect's state standing in
+  // for the surface is what made a single connect disable every other connector
+  // for the whole 120s poll — silently, since nothing rendered as disabled.
+  const [connecting, setConnecting] = useState<Record<string, boolean>>({});
+  const [errors, setErrors] = useState<Record<string, string | undefined>>({});
+  // Connects whose sign-in window the browser refused. The tray opened the
+  // window in the click, but offered nothing when it was refused anyway — the
+  // row sat on its dots for the whole poll with nowhere to sign in. One notice
+  // per waiting connect: a shared one let the second connect erase a link the
+  // first still needed. `url` is the broker's own redirect, known only once
+  // initiate lands, so the notice explains itself before the link can exist.
+  const [blocked, setBlocked] = useState<Record<string, { name: string; url?: string } | undefined>>({});
   // 3-A′ — toolkits whose brand mark failed to load fall back to the monogram.
   const [failedLogos, setFailedLogos] = useState<ReadonlySet<string>>(new Set());
   const trayRef = useRef<HTMLDivElement>(null);
@@ -303,9 +309,13 @@ export function ConnectTray({ onClose, anchorRef, closing = false }: {
   const connect = async (row: TrayRow) => {
     // Before the first await, or the browser blocks it (openConnectPopup).
     const popup = openConnectPopup();
-    setConnecting(row.toolkit);
-    setError(undefined);
-    setBlockedUrl(undefined);
+    const key = row.toolkit;
+    const clearBlocked = () => setBlocked(current => ({ ...current, [key]: undefined }));
+    setConnecting(current => ({ ...current, [key]: true }));
+    // Only THIS row's leftovers clear: a sibling connect may still be failing
+    // in place, or still waiting on a sign-in link that is its only way through.
+    setErrors(current => ({ ...current, [key]: undefined }));
+    setBlocked(current => ({ ...current, [key]: popup === null ? { name: row.name } : undefined }));
     try {
       await completeConnection(
         client,
@@ -315,26 +325,28 @@ export function ConnectTray({ onClose, anchorRef, closing = false }: {
         // Refused anyway: the connect is initiated and the poll is running, so
         // the same URL in a tab still finishes it.
         url => {
-          if (popup === null && !cancelledRef.current) setBlockedUrl(url);
+          if (popup === null && !cancelledRef.current) setBlocked(current => ({ ...current, [key]: { name: row.name, url } }));
         },
       );
       if (cancelledRef.current) return;
-      setBlockedUrl(undefined);
+      clearBlocked();
       await refresh();
       setJustConnected(row.toolkit);
     } catch (reason) {
       if (!cancelledRef.current) {
-        setBlockedUrl(undefined);
-        setError(connectRefusalCopy(reason, row.name));
+        // This connect is over, so its link is stale — a retry needs a fresh
+        // initiate, and the refusal copy says so.
+        clearBlocked();
+        setErrors(current => ({ ...current, [key]: connectRefusalCopy(reason, row.name) }));
       }
     } finally {
-      if (!cancelledRef.current) setConnecting(undefined);
+      if (!cancelledRef.current) setConnecting(current => ({ ...current, [key]: false }));
     }
   };
 
   const item = (row: TrayRow) => {
     const isConnected = row.account !== undefined;
-    const isConnecting = connecting === row.toolkit;
+    const isConnecting = connecting[row.toolkit] === true;
     // Lane pick 3-A′ — real brand marks in the tray rows; the two-letter
     // monogram stays as the fallback for toolkits without a mapped domain or
     // whose mark failed to load.
@@ -367,11 +379,13 @@ export function ConnectTray({ onClose, anchorRef, closing = false }: {
               <span className="fl-typing" aria-hidden="true"><span /><span /><span /></span>
             </span>
           ) : (
+            // No `disabled`: the row that IS connecting renders its dots above
+            // instead of this button, so a second click on the same row is
+            // already impossible — and every other row stays a live "+".
             <button
               type="button"
               className="fl-picker-add"
               aria-label={`Connect ${row.name}`}
-              disabled={connecting !== undefined}
               onClick={() => void connect(row)}
             >+</button>
           )}
@@ -399,15 +413,23 @@ export function ConnectTray({ onClose, anchorRef, closing = false }: {
             </svg>
           </button>
         </div>
-        {error !== undefined ? <div role="alert" className="fl-att-error">{error}</div> : null}
-        {blockedUrl === undefined ? null : (
-          <div role="status" className="fl-connect-blocked">
-            <span>Your browser blocked the sign-in window. Open it yourself — we’ll pick it up from here.</span>
-            <a className="fl-btn fl-btn-primary" href={blockedUrl} target="_blank" rel="noreferrer">
-              Open sign-in in a new tab
-            </a>
+        {Object.entries(errors).map(([key, message]) => message === undefined ? null : (
+          <div key={key} role="alert" className="fl-att-error">{message}</div>
+        ))}
+        {Object.entries(blocked).map(([key, entry]) => entry === undefined ? null : (
+          // The window never opened, but the connect did: the poll is running on
+          // that account, so the same URL in a tab finishes it. One notice per
+          // connect still waiting — each names its own service, since the tray
+          // has many.
+          <div key={key} role="status" className="fl-connect-blocked">
+            <span>Your browser blocked the {entry.name} sign-in window. Open it yourself — we’ll pick it up from here.</span>
+            {entry.url === undefined ? null : (
+              <a className="fl-btn fl-btn-primary" href={entry.url} target="_blank" rel="noreferrer">
+                Open sign-in in a new tab
+              </a>
+            )}
           </div>
-        )}
+        ))}
         {rows.connected.length > 0 ? (
           <>
             <div className="fl-picker-group">Connected</div>

--- a/packages/ui/test/chrome/affordances-eng225.test.tsx
+++ b/packages/ui/test/chrome/affordances-eng225.test.tsx
@@ -463,4 +463,99 @@ describe("connect dock + tray (ENG-225)", () => {
     const link = await within(tray).findByRole("link", { name: "Open sign-in in a new tab" });
     expect(link.getAttribute("href")).toBe("https://connect.test/oauth/1");
   });
+
+  /* --- per-ROW connect state (the #1051 treatment, second caller) --------- */
+
+  // The fixture already has gmail connected (`ca_1`), so a tray that must offer
+  // TWO connectable rows needs a third toolkit listed.
+  const TWO_AVAILABLE = [...CONNECTORS, { toolkit: "notion", label: "Notion" }];
+
+  /** Hold every `ca_new` status read open so a started connect stays in flight
+   *  for the whole test — the fixture's initiate otherwise mints an account
+   *  that is already `active` and the poll ends on its first read. */
+  const holdThePoll = () => {
+    for (let index = 0; index < 16; index += 1) {
+      wire.state.failures.push({
+        method: "GET", path: "/connections/ca_new", code: "unavailable", message: "broker busy", status: 503,
+      });
+    }
+  };
+
+  const openTray = async (): Promise<HTMLElement> => {
+    render(
+      <VendoProvider client={client} connectors={TWO_AVAILABLE}><VendoThread threadId="thr_1" /></VendoProvider>,
+    );
+    await screen.findByText("Existing thread");
+    fireEvent.click(await screen.findByRole("button", { name: "Connect tools" }));
+    return screen.findByRole("dialog", { name: "Connect tools" });
+  };
+
+  // The tray tracked `connecting` as ONE toolkit for the whole panel and
+  // disabled every add button off it, so the first connect made every OTHER
+  // connector inert for the full 120s poll — with no cancel, and no disabled
+  // styling to say why. Measured in a real browser as
+  // `{spinners: 1, disabledAdds: 55, totalAdds: 55}`. The row that is actually
+  // connecting shows its dots INSTEAD of a button, so no add button needs to
+  // disable at all.
+  it("leaves every other connector clickable while one connect is in flight", async () => {
+    const popup = { location: { replace: vi.fn() }, close: vi.fn() };
+    vi.stubGlobal("open", vi.fn(() => popup));
+    holdThePoll();
+    const tray = await openTray();
+
+    fireEvent.click(await within(tray).findByRole("button", { name: "Connect Slack" }));
+    await within(tray).findByRole("status", { name: "Connecting Slack" });
+
+    const adds = within(tray).getAllByRole("button", { name: /^Connect / });
+    expect(adds.map(button => (button as HTMLButtonElement).disabled)).toEqual(adds.map(() => false));
+    expect(within(tray).getByRole("button", { name: "Connect Notion" })).toBeTruthy();
+  });
+
+  it("keeps a spinner per connect when two run at once", async () => {
+    const popup = { location: { replace: vi.fn() }, close: vi.fn() };
+    vi.stubGlobal("open", vi.fn(() => popup));
+    holdThePoll();
+    const tray = await openTray();
+
+    fireEvent.click(await within(tray).findByRole("button", { name: "Connect Slack" }));
+    fireEvent.click(await within(tray).findByRole("button", { name: "Connect Notion" }));
+
+    // One `connecting` string could only ever name the last row clicked, so the
+    // first row's dots vanished the moment the second connect started.
+    await waitFor(() => expect(within(tray).getAllByRole("status", { name: /^Connecting / })).toHaveLength(2));
+  });
+
+  // The blocked half, exactly as #1051 keyed it on the panel: two refused
+  // windows shared one notice, so the second connect overwrote a link the first
+  // still needed to get through.
+  it("offers a sign-in link per blocked connect, not one shared notice", async () => {
+    vi.stubGlobal("open", vi.fn(() => null));
+    holdThePoll();
+    const tray = await openTray();
+
+    fireEvent.click(await within(tray).findByRole("button", { name: "Connect Slack" }));
+    await within(tray).findByRole("link", { name: "Open sign-in in a new tab" });
+    fireEvent.click(await within(tray).findByRole("button", { name: "Connect Notion" }));
+
+    await waitFor(() => expect(within(tray).getAllByRole("link", { name: "Open sign-in in a new tab" })).toHaveLength(2));
+  });
+
+  it("keeps each failed connect's reason, rather than the last one only", async () => {
+    vi.stubGlobal("open", vi.fn(() => ({ location: { replace: vi.fn() }, close: vi.fn() })));
+    for (let index = 0; index < 2; index += 1) {
+      wire.state.failures.push({
+        method: "POST", path: "/connections/initiate", code: "unavailable", message: "broker down", status: 503,
+      });
+    }
+    const tray = await openTray();
+
+    fireEvent.click(await within(tray).findByRole("button", { name: "Connect Slack" }));
+    await within(tray).findByText(/Slack/, { selector: ".fl-att-error" });
+    fireEvent.click(await within(tray).findByRole("button", { name: "Connect Notion" }));
+
+    // A shared `error` string is also cleared by the NEXT connect's start, so
+    // Slack's reason disappeared off a click that said nothing about Slack.
+    await within(tray).findByText(/Notion/, { selector: ".fl-att-error" });
+    expect(within(tray).getByText(/Slack/, { selector: ".fl-att-error" })).toBeTruthy();
+  });
 });


### PR DESCRIPTION
Two of the ~21 findings from tonight's fresh-eyes pass over Maple are regressions from tonight's own work. These are those two. Everything else in that report is someone else's lane.

---

## Regression 1 — the demo script sent the viewer to a page we deleted tonight

#1014 cut `VendoPage` and the `/vendo` + `/vendo/workspace` routes deliberately, with **no substitute destination**. Navigation and the palette were cleaned up. The demo's own scripted copy was not — and it streams on screen during the connect beat, in front of whoever is being shown the demo:

> *"It's live under Workspace → Automations — you can pause it anytime."*

Verified in a real browser, signed in as the demo user:

| route | before tonight | now |
| --- | --- | --- |
| `/maple/vendo/workspace` | the workspace, Automations tab | **404** |
| `/maple/vendo` | the workspace | **404** |

### What the copy was promising, and why there is no honest place to point it

The brief said not to invent a destination and not to repoint at a substitute. There is none to repoint at, and that is the finding rather than a constraint I worked around — **a Maple user cannot pause an automation anywhere**, by three independent routes:

- **No panel.** `AutomationsPanel` and `ActivityPanel` still ship in `@vendoai/ui`, but nothing in `examples/` mounts either — the deleted `/vendo/workspace` was the only mount, via `VendoPage` ("thread sidebar, apps, automations, accounts, orgs and activity tabs" — its own doc comment).
- **Not the thread card.** The in-thread automation card is read-only *by design*: "No toggle, no run history, no dry-run controls: management stays in the panel" (`automation-card.tsx:20`).
- **Not by asking.** The agent has no tool for it: "There is no separate automations tool" (`vendo/server.ts:96`). So "just tell me to pause it" would have been a *new* false promise.

So the copy had to stop promising one. What replaces it is the reassurance the pause clause was standing in for, and unlike the destination it is **true**: these automations *draft*, they never send. That is the frozen law the away-drill pins — an automation "may **not** move money, message humans, or delete" — so it is a property of the engine, not a claim about a screen.

| # | before | after |
| --- | --- | --- |
| 511 | …one tap. `It's live under Workspace → Automations — you can pause it anytime.` | …one tap. **It never sends on its own.** |
| 523 | …that same morning. `It's live under Workspace → Automations.` | …that same morning. *(deleted — "Armed —" already carries the liveness claim)* |
| 642 | …fully live; `they're under Workspace → Automations whenever you want to pause them.` | …fully live, **and every one of them drafts rather than sends — nothing leaves without you.** |

### Why this fixes ten sites and not three

Grepping the deletion rather than the phrase turned up that **"the declined request is recorded in Activity" is the same regression** — Activity was another of that page's tabs. Four such lines, same file, same beat set, same deleted surface.

They are worse than dead, and this is the part worth reading: **Maple's own left nav has an "Activity" entry**, and it resolves 200. It is the bank's notification feed — deposits, card use, security alerts, off `useNotifications()`. So that copy sent people somewhere real that will never contain what they were told to look for. The record itself is real and server-side; what was false was implying a screen shows it. Each line keeps its true half and drops the promise:

| # | before | after |
| --- | --- | --- |
| 357 | …in your transactions, `and the approval is recorded in Activity.` | …in your transactions. *(`/transactions` is real and does contain it)* |
| 557 | I've switched the automation off. Nothing will run, `and the declined request is recorded in Activity.` | I've switched the automation off. Nothing will run. |
| 833 | I've cancelled it. Nothing moved, `and the declined request is recorded in Activity.` | I've cancelled it. Nothing moved. |
| 841 | your accounts are untouched. `Check Activity for the record.` | your accounts are untouched. **You can try again.** |

Three code comments naming the same deleted surface are corrected in passing (395, 15, 740). Ten sites, one deletion, one file.

### Real browser — the beat actually run, not the string grepped

Maple booted locally (`MAPLE_STORE=local`), signed in, demo reset, **"Email me a weekly summary"** tapped, the real standing-grant set approved through the live guard, and the armed confirmation read off the screen:

| before | after |
| --- | --- |
| ![before](https://gist.githubusercontent.com/yousefh409/14597d82c0dae58ae5b56a32192ead94/raw/maple-weekly-before.png) | ![after](https://gist.githubusercontent.com/yousefh409/14597d82c0dae58ae5b56a32192ead94/raw/maple-weekly-after.png) |

```
before → Set. … one tap. It's live under Workspace → Automations — you can pause it anytime.
after  → Set. … one tap. It never sends on its own.
```

The transfer beat too — approved through the real parked approval:

```
before → Done — $200.00 moved to savings. … and the approval is recorded in Activity.
after  → Done — $200.00 moved to savings. The posted transfer is in your transactions.
```

### The full grep, including what I did NOT change

`"Workspace →"`, `/vendo/workspace`, `"Show activity"`, `"Activity pane"`, `"recorded in Activity"`, `"in Activity"`, `"pause it anytime"` across all of `examples/` and `packages/`:

**Fixed — 10 sites, all `examples/demo-bank/src/demo-script/engine.ts`** (above).

**Left alone, and flagged: library copy that assumes the host mounted a panel Maple doesn't.** These are honest for a host that mounts `ActivityPanel` / `AutomationsPanel`, and dead in Maple. Changing them is a product decision about `@vendoai/ui`'s voice, not a mechanical fix, so they are **not** in this PR:

| site | copy | reaches Maple's screen? |
| --- | --- | --- |
| `packages/ui/src/chrome/thread/parts.tsx:761` | `"Runs as you · recorded in Activity"` | **yes** — renders in the thread |
| `packages/ui/src/chrome/vendo-toasts.tsx:158` | `hint: "recorded in Activity"` | **yes** — approval-required toast |
| `packages/ui/src/chrome/build-beat.tsx:264` | `"It runs as you, and you can pause it anytime."` | **yes** — the same false pause promise I just removed from the demo, in the library |
| `packages/guard/src/guard.ts:2132` | `"Review these approvals in Activity before retrying"` | server-side refusal message |

**Left alone, correct as written:** `vendo-palette.tsx:41` still ships the `show-activity` command — that is a host-wired destination, and Maple's `VendoLayer:34` already handles it honestly in a post-deletion comment (falls back to opening the overlay); removing a command kind is a breaking API change. Code/test comments naming `AutomationsPanel`/`ActivityPanel` (`automation-card.tsx:16`, `morph-toast.tsx:16`, `thread/message.tsx:13`, `chrome-css.ts:462,1694`, `activity-semantics.ts:4`, and two test comments) are accurate — those components still ship. `playground/app/scenarios.tsx:163` titles the real panel. `e2e/harness/main.tsx:1972` mirrors the real toast hint and should follow it if it changes.

**Unrelated residue from the same deletion, noted not fixed:** `nav.ts:1` imports `Sparkles` unused and `VendoLayer.tsx:37` has an unused `_command` — both lint *warnings* already on `main`.

---

## Regression 2 — #1051's per-row connect fix landed in only one of two callers

#1051 keyed `ConnectedAccountsPanel`'s connect state per row. `ConnectTray` is the second caller of the same shared flow and kept **one** `connecting`, **one** `error`, **one** `blockedUrl` for the whole surface — so the panel and the tray disagreed about whether a connect is a row's business or the surface's.

The tray's was the worse half. `disabled={connecting !== undefined}` hung every add button off that single value:

> `{spinners: 1, disabledAdds: 55, totalAdds: 55}`

One click froze all 55 other connectors for the full 120s poll, with no cancel — and because `.fl-picker-add` carries no `:disabled` styling, **nothing on screen said why**. The tray looked live and ignored every click.

### The fix — keyed by toolkit, mirroring the panel

- **`connecting`** — several connects run at once, each row keeping its own dots.
- **`errors`** — a failed connect's reason survives a sibling connect *starting*. It used to be wiped by the next connect's opening `setError(undefined)`, so Slack's failure vanished off a click that said nothing about Slack.
- **`blocked`** — one notice per waiting connect, each naming its own service, so a second refused window cannot overwrite a link the first still needs. Same shape as the panel including `{ name, url? }`, so the notice explains itself before the broker's URL exists.

### Should a disabled connector look disabled?

**The right fix removed the question rather than answering it.** `disabled` is **gone**, not restyled: the connecting row renders its dots *instead of* its button, so a second click on the same row was already impossible, and every other row is legitimately live. There is nothing left to grey out. Styling 55 buttons as disabled would have made an honest picture of a state that should never have existed — the bug was the disabling, not the missing cue for it.

### Real browser

`{spinners, disabledAdds, totalAdds}` measured on `/affordances` with the real `initiate` **parked** (nothing stubbed — `parkRequest` only holds a real request open):

| | before | after |
| --- | --- | --- |
| one connect in flight | `{1, `**`1`**`, 1}` | `{1, `**`0`**`, 1}` |

**The before/after screenshots of that moment are pixel-identical, and that is the point** — a tray with one shared `connecting` looked exactly like a working one. That is the half the reporter measured as "no visible disabled state", and it is why a screenshot alone could never have caught this:

| before — QuickBooks' `+` at full contrast, and inert | after — same pixels, live |
| --- | --- |
| ![before](https://gist.githubusercontent.com/yousefh409/14597d82c0dae58ae5b56a32192ead94/raw/tray-before.png) | ![after](https://gist.githubusercontent.com/yousefh409/14597d82c0dae58ae5b56a32192ead94/raw/tray-after.png) |

So here is the state that *is* visibly different, and was unreachable before this PR — two connects in flight at once:

![two](https://gist.githubusercontent.com/yousefh409/14597d82c0dae58ae5b56a32192ead94/raw/tray-two-in-flight.png)

### Tests, failing first, in their own commit

Four unit tests + one browser spec, watched failing on the unfixed tray (`38017a008`), fix in `1341c8f00`:

```
× leaves every other connector clickable …  → expected [ true ] to deeply equal [ false ]
× keeps a spinner per connect when two run at once → expected [ <span> ] to have a length of 2 but got 1
× offers a sign-in link per blocked connect  → expected [ <a> ] to have a length of 2 but got 1
× keeps each failed connect's reason         → Unable to find /Slack/ in .fl-att-error
browser → disabledAdds: 1, expected 0
```

The third is the *identical* failing assertion #1051 recorded for the panel. The browser spec photographs the tray **before** it judges it, so a failing run leaves the reproduction behind rather than only a message.

### Two honest limits

1. **The clear-on-settle half is not separately reproducible**, exactly as #1051's author found: every `POST /connections/initiate` answers with the same `ca_new`, so two concurrent connects share one broker account and always settle together. Keying closes both halves by construction; I did not fake a test around it.
2. **The literal `55` is not reproducible on this machine.** That count comes from Maple's ~56-toolkit Cloud catalog; there is no `.env.local` here, so the keyless local demo serves an empty catalog ("No tools are available to connect yet") and the dock has nothing to disable. The count is N-independent — `connecting !== undefined` is one boolean shared by every row — so the browser-measured `1/1 → 0/1` and the reported `55/55` are the same expression. I did not manufacture a 56-connector fixture to produce a prettier number.

### One follow-up this fix exposes, not introduced by it

`openConnectPopup()` opens a **named** window (`"vendo-connect"`), so two concurrent connects reuse the *same* window: the second `location.replace` steals the first's, and whichever settles first calls `popup.close()` on it. That is already reachable in `ConnectedAccountsPanel` post-#1051 (its chips disable per key by design) — the tray's surface-wide `disabled` was accidentally masking it. Whether two simultaneous sign-ins should get two windows is a behaviour decision, so it is **flagged, not bundled**.

---

## Gates

- `pnpm build --filter=@vendoai/ui... --filter=demo-bank...` — green
- `pnpm typecheck --filter=@vendoai/ui --filter=demo-bank` — green
- `pnpm lint` on the touched scope — green (dependency-guard, portability-gate all legs; demo-bank 0 errors / 4 pre-existing warnings). `@vendoai/ui` has no lint task of its own.
- `pnpm test:affected` — green (**36/36 tasks**, 31m41s — the whole affected graph, not just the two touched packages)
- `pnpm --filter @vendoai/ui test:browser` (the UI gate of record — CI runs no browser suites) — green on the rebased head: **82 passed, 7 skipped, 0 failed** (4.0m). The two `/page` failures #1051 flagged as pre-existing are gone — #1055 removed those scenarios. The known load-dependent `extreme-content.spec.ts:48` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two regressions: the demo script no longer points at a deleted Vendo workspace, and the connect tray now tracks connect state per row so one connect doesn’t freeze every other connector.

- **Bug Fixes**
  - `demo-bank`: Removed references to `VendoPage` and `/vendo/workspace`. Replaced false “pause anytime” and “recorded in Activity” lines with accurate copy (automations draft; transfers appear in transactions). Updated related comments.
  - `@vendoai/ui`: Made `ConnectTray` state per toolkit (`connecting`, `errors`, `blocked`) to match the panel. Removed the global disabled state; the connecting row shows dots instead of a “+”. Supports multiple connects at once and keeps per-row failure/blocked messages. Added unit and browser tests and a patch changeset.

<sup>Written for commit 3335c9213a9dd5a564c0b8a4f78304865bb37cc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

