### PR TITLE
fix(ui): each connect gets its own sign-in window, and chrome copy stops naming a surface the host may not mount

### DIFF
--- a/.changeset/chrome-copy-stops-naming-a-surface-the-host-may-not-mount.md
+++ b/.changeset/chrome-copy-stops-naming-a-surface-the-host-may-not-mount.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/ui": patch
+---
+
+Three pieces of chrome copy no longer name a place the host may not have. The morph toast's fallback subtitle read "Runs as you · recorded in Activity", the approval-required toast hinted "recorded in Activity", and a recurring Slack post was described as "It runs as you, and you can pause it anytime" — all three point at an Activity or automations surface that `@vendoai/ui` ships but cannot know the host mounted. A host that mounts neither (the Maple demo mounts neither) was promising, in its own voice, something it could not honour. Each line now keeps only what is true on every host: the morph toast falls back to the bare "Runs as you" that `venueByline` already uses, the toast hint says what approving means ("Runs as you once approved") instead of where it goes, and the Slack automation sentence ends after "It runs as you." No host is made wrong by the new wording, and none of it invents a destination.

--- a/.changeset/each-connect-gets-its-own-sign-in-window.md
+++ b/.changeset/each-connect-gets-its-own-sign-in-window.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/ui": patch
+---
+
+Two connects started at once now get two sign-in windows instead of fighting over one. Every connect surface opened its window under the same fixed name, and a window name is precisely what makes `window.open` hand back a window that is already open — so the second connect inherited the first's window, replaced a sign-in page that was still mid-flow, and then had that window closed underneath it by whichever connect finished first. The window is now named after the same per-row key the surface already keys its connect state by, so concurrent connects — which the connected-accounts panel and the connect tray both allow by design — stay independent from the click through to the broker's consent page.

--- a/packages/ui/e2e/harness/main.tsx
+++ b/packages/ui/e2e/harness/main.tsx
@@ -1967,7 +1967,7 @@ function ToastsScenario() {
   useEffect(() => {
     vendoToast({ text: "Invoice watcher ran: 3 reminders drafted and queued for review.", durationMs: 0, actions: [{ label: "View", onAction: () => undefined }] });
     vendoToast({ text: "Morning digest failed to send — the connected inbox returned an error.", state: "error", durationMs: 0 });
-    vendoToast({ kind: "approval-required", text: "Waiting on you: Send email to finance@example.com", hint: "recorded in Activity", actions: [{ label: "Approve", primary: true, onAction: () => undefined }] });
+    vendoToast({ kind: "approval-required", text: "Waiting on you: Send email to finance@example.com", hint: "Runs as you once approved", actions: [{ label: "Approve", primary: true, onAction: () => undefined }] });
   }, []);
   return (
     <VendoProvider client={baseClient} components={components} theme={mapleTheme}>

--- a/packages/ui/src/chrome/build-beat.tsx
+++ b/packages/ui/src/chrome/build-beat.tsx
@@ -261,7 +261,7 @@ export function toolPresentation(
   let consequence: ToolConsequence | undefined;
   if (toolkit === "slack" && typeof flat.channel === "string") {
     description ??= trigger
-      ? `Vendo will post to ${flat.channel} on your behalf, ${trigger}. It runs as you, and you can pause it anytime.`
+      ? `Vendo will post to ${flat.channel} on your behalf, ${trigger}. It runs as you.`
       : `Vendo will post to ${flat.channel} on your behalf, running as you.`;
     sub = trigger ? `Posts to ${flat.channel} ${trigger}` : `Posts to ${flat.channel} as you`;
     if (typeof flat.message === "string" && flat.message.trim().length > 0) {

--- a/packages/ui/src/chrome/connect-card.tsx
+++ b/packages/ui/src/chrome/connect-card.tsx
@@ -129,7 +129,7 @@ export function ConnectCard({ connector, toolkit, message, onConnected, live = t
     // FIRST, before any await: a popup opened after one is blocked outright in
     // Safari and Firefox (openConnectPopup). A blocked window is not a dead end
     // — the same poll runs and the card offers the URL as a link instead.
-    const popup = openConnectPopup();
+    const popup = openConnectPopup(toolkit);
     setPhase(popup === null ? "popup-blocked" : "connecting");
     setError(undefined);
     setRedirectUrl(undefined);

--- a/packages/ui/src/chrome/connect-dock.tsx
+++ b/packages/ui/src/chrome/connect-dock.tsx
@@ -36,15 +36,22 @@ const POPUP_HEIGHT = 680;
  *
  * Returns `null` when the browser blocked it anyway — the caller keeps going and
  * offers the same URL as a plain link.
+ *
+ * @param key Identifies THIS connect, and must be the same key the caller keys
+ * its own per-row connect state by. It becomes the window's name, and a name is
+ * what makes `window.open` return a window that is ALREADY OPEN: every connect
+ * surface here permits concurrent connects, so one shared name meant the second
+ * connect inherited the first's window, replaced a sign-in page still in flight,
+ * and had it closed underneath by whichever connect settled first.
  */
-export function openConnectPopup(): Window | null {
+export function openConnectPopup(key: string): Window | null {
   // Centered on the screen the browser is on, so the consent page lands where
   // the eye already is rather than in a corner behind the app.
   const left = Math.max(0, Math.round((window.screen.width - POPUP_WIDTH) / 2));
   const top = Math.max(0, Math.round((window.screen.height - POPUP_HEIGHT) / 2));
   return window.open(
     "about:blank",
-    "vendo-connect",
+    `vendo-connect-${key}`,
     `popup=yes,width=${POPUP_WIDTH},height=${POPUP_HEIGHT},left=${left},top=${top}`,
   ) ?? null;
 }
@@ -308,8 +315,8 @@ export function ConnectTray({ onClose, anchorRef, closing = false }: {
 
   const connect = async (row: TrayRow) => {
     // Before the first await, or the browser blocks it (openConnectPopup).
-    const popup = openConnectPopup();
     const key = row.toolkit;
+    const popup = openConnectPopup(key);
     const clearBlocked = () => setBlocked(current => ({ ...current, [key]: undefined }));
     setConnecting(current => ({ ...current, [key]: true }));
     // Only THIS row's leftovers clear: a sibling connect may still be failing

--- a/packages/ui/src/chrome/connected-accounts-panel.tsx
+++ b/packages/ui/src/chrome/connected-accounts-panel.tsx
@@ -228,7 +228,7 @@ export function ConnectedAccountsPanel({ undoMs = 10_000 }: ConnectedAccountsPan
    * plain link and finishing there settles the row as normal.
    */
   const connect = async (key: string, name: string, input: { toolkit: string; connector?: string }) => {
-    const popup = openConnectPopup();
+    const popup = openConnectPopup(key);
     const clearBlocked = () => setBlocked(current => ({ ...current, [key]: undefined }));
     setError(undefined);
     setBlocked(current => ({ ...current, [key]: popup === null ? { name } : undefined }));

--- a/packages/ui/src/chrome/thread/parts.tsx
+++ b/packages/ui/src/chrome/thread/parts.tsx
@@ -818,7 +818,7 @@ export function ThreadApprovals({ approvals, risks, guardApprovals, cardRefs, re
                     onMorph({
                       startRect: { top: rect.top, left: rect.left, width: rect.width, height: rect.height },
                       title: `${presentation.title} — approved`,
-                      sub: presentation.sub ?? "Runs as you · recorded in Activity",
+                      sub: presentation.sub ?? "Runs as you",
                       logoUrl: presentation.logoUrl,
                       theme,
                     });

--- a/packages/ui/src/chrome/vendo-toasts.tsx
+++ b/packages/ui/src/chrome/vendo-toasts.tsx
@@ -155,7 +155,11 @@ function ApprovalToasts({ pollMs }: { pollMs: number }) {
       const dismiss = vendoToast({
         kind: "approval-required",
         text: `Waiting on you: ${toolTitle(approval.call.tool, tools[approval.call.tool])}`,
-        hint: "recorded in Activity",
+        // Not a destination: the library cannot know whether this host mounts
+        // a surface that shows the record. What IS true on every host is what
+        // approving MEANS — the same "Runs as you" the approval card and the
+        // morph toast say.
+        hint: "Runs as you once approved",
         actions: [{
           label: "Approve",
           primary: true,

--- a/packages/ui/test/chrome/affordances-eng225.test.tsx
+++ b/packages/ui/test/chrome/affordances-eng225.test.tsx
@@ -540,6 +540,27 @@ describe("connect dock + tray (ENG-225)", () => {
     await waitFor(() => expect(within(tray).getAllByRole("link", { name: "Open sign-in in a new tab" })).toHaveLength(2));
   });
 
+  // Keying the tray's state let two connects run at once, which exposed that
+  // `openConnectPopup` named every window the same thing — and a NAME is what
+  // makes `window.open` hand back an EXISTING window. So the second connect
+  // took over the first's sign-in page, and the first settle closed it under
+  // the other. Pre-existing in the panel post-#1051; the tray's old
+  // surface-wide `disabled` was hiding it here.
+  it("gives each concurrent connect its own sign-in window", async () => {
+    const open = vi.fn(() => ({ location: { replace: vi.fn() }, close: vi.fn() }));
+    vi.stubGlobal("open", open);
+    holdThePoll();
+    const tray = await openTray();
+
+    fireEvent.click(await within(tray).findByRole("button", { name: "Connect Slack" }));
+    fireEvent.click(await within(tray).findByRole("button", { name: "Connect Notion" }));
+
+    expect(open.mock.calls.map(call => call[1])).toEqual([
+      "vendo-connect-slack",
+      "vendo-connect-notion",
+    ]);
+  });
+
   it("keeps each failed connect's reason, rather than the last one only", async () => {
     vi.stubGlobal("open", vi.fn(() => ({ location: { replace: vi.fn() }, close: vi.fn() })));
     for (let index = 0; index < 2; index += 1) {

--- a/packages/ui/test/chrome/connect.test.tsx
+++ b/packages/ui/test/chrome/connect.test.tsx
@@ -580,6 +580,35 @@ describe("ConnectCard and ConnectedAccountsPanel", () => {
     ));
   });
 
+  // Two connect-ahead chips are meant to run at once — #1051 keyed `busy` and
+  // `blocked` per row precisely so they can. But `openConnectPopup` opened a
+  // window under one fixed NAME, and a name is what makes `window.open` reuse an
+  // existing window: the second chip took over the first's window, the first's
+  // sign-in page was replaced mid-flow, and whichever settled first closed the
+  // window the other was still using. The window has to be keyed the same way
+  // the state around it is.
+  it("gives each concurrent connect-ahead its own sign-in window", async () => {
+    const { open } = allowPopups();
+    wire.state.connections = [];
+    render(
+      <VendoProvider
+        client={client}
+        connectors={[{ toolkit: "slack", connector: "composio" }, { toolkit: "hubspot", label: "HubSpot CRM" }]}
+      >
+        <ConnectedAccountsPanel />
+      </VendoProvider>,
+    );
+    expect(await screen.findByText(/No connected accounts yet/)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Connect Slack" }));
+    fireEvent.click(screen.getByRole("button", { name: "Connect HubSpot CRM" }));
+
+    // The window NAME is the whole mechanism — same name, same window.
+    expect(open.mock.calls.map(call => call[1])).toEqual([
+      "vendo-connect-connect-slack",
+      "vendo-connect-connect-hubspot",
+    ]);
+  });
+
   it("hides connect-ahead entirely when the host configured no connectors", async () => {
     wire.state.connections = [];
     // The AUTO catalog is what feeds connect-ahead, and the fixture's is

--- a/packages/ui/test/chrome/lane-cards-picks.test.tsx
+++ b/packages/ui/test/chrome/lane-cards-picks.test.tsx
@@ -40,6 +40,26 @@ describe("lane-cards picks", () => {
     await wire?.close();
   });
 
+  // A recurring Slack post used to be described as "It runs as you, and you can
+  // pause it anytime." Pausing needs a management surface, and `@vendoai/ui`
+  // cannot know whether the host mounted one — Maple mounts none, so the library
+  // was promising, in the host's voice, something the host could not honour. The
+  // sentence keeps every claim that is true on EVERY host and drops the one that
+  // depends on a screen (#1014 deleted the only surface that ever backed it).
+  it("describes a recurring Slack post without promising a place to pause it", () => {
+    const recurring = toolPresentation("slack_SLACK_SEND_MESSAGE", {
+      channel: "#renewals",
+      text: "Morning digest",
+      trigger: "every weekday at 8am",
+    });
+    expect(recurring.description).toBe(
+      "Vendo will post to #renewals on your behalf, every weekday at 8am. It runs as you.",
+    );
+    // The one-off sibling never carried the promise, and still doesn't.
+    expect(toolPresentation("slack_SLACK_SEND_MESSAGE", { channel: "#renewals", text: "Hi" }).description)
+      .toBe("Vendo will post to #renewals on your behalf, running as you.");
+  });
+
   it("1-A: synthesizes a structured consequence from the real Slack inputs", () => {
     const presentation = toolPresentation("slack_SLACK_SEND_MESSAGE", slackApproval.call.args);
     expect(presentation.consequence).toEqual({


### PR DESCRIPTION
The two follow-ups #1060 surfaced, both approved for one PR. Same root cause as #1060's regression 1 in the second half: **copy naming a place the reader cannot get to.**

---

## 1 — Each connect gets its own sign-in window

I flagged this on #1060 as exposed-not-introduced, and the ruling was to give each connect its own window rather than block the second one. Blocking would re-create the bug #1060 just removed.

`openConnectPopup()` named every window `"vendo-connect"`. A window name is not a label — it is `window.open`'s **lookup key**, so the second concurrent connect was never given a window: it was handed the *first one's*. Its sign-in page was replaced mid-flow, and then closed underneath it by whichever connect settled first.

The window is now named after the caller's own per-row state key — keyed the same way the state around it is keyed, which is what makes the two agree:

| caller | key | granularity |
| --- | --- | --- |
| `ConnectTray.connect` | `row.toolkit` | per toolkit |
| `ConnectedAccountsPanel.connect` | `connect-<toolkit>` / `reconnect-<id>` | per **account** — so two expired rows of one toolkit reconnect independently |
| `ConnectCard.connect` | `toolkit` | per toolkit |

The caller's key is the right granularity by construction: it is exactly the level at which that surface already permits two connects to coexist.

The parameter is **required, not optional**. It is internal (neither `index` re-exports it), all three call sites are in this diff, and a default value would silently reintroduce the collision for the next caller.

### Failing test first (`98a08b1e4`), fix in `75d8b3238`

One test per surface that permits concurrency by design, watched failing:

```
× gives each concurrent connect-ahead its own sign-in window
× gives each concurrent connect its own sign-in window
  → expected [ 'vendo-connect', 'vendo-connect' ] to deeply equal
             [ 'vendo-connect-slack', 'vendo-connect-notion' ]
```

`['vendo-connect', 'vendo-connect']` **is** the bug — one name, therefore one window. The name is asserted directly because it is the mechanism: jsdom has no real window to observe reuse on, and the name is the whole contract.

---

## 2 — Chrome copy stops naming a surface the host may not mount

`@vendoai/ui` ships `ActivityPanel` and `AutomationsPanel`, but it cannot know whether the **host** mounted them. Maple mounts neither, so the library was putting a promise in the host's voice that the host could not honour. All three of these reach the screen.

| site | before | after |
| --- | --- | --- |
| `thread/parts.tsx` — morph toast subtitle fallback | `Runs as you · recorded in Activity` | `Runs as you` |
| `vendo-toasts.tsx` — approval-required toast hint | `recorded in Activity` | `Runs as you once approved` |
| `build-beat.tsx` — recurring Slack post description | `It runs as you, and you can pause it anytime.` | `It runs as you.` |

**Host-neutrality was the binding constraint**, per the brief: a host that *does* mount the panels must not be made wrong either. So each line keeps only what is true on every deployment, and none of them names a destination.

Why each is the honest choice rather than merely a shorter one:

- **The morph toast's new fallback is not invented.** `venueByline` (`approval-card.tsx:71`) *already* returns bare `"Runs as you"` when there is no venue phrase. This stops being a second, wronger fallback for the same idea — it is now the same string the approval card has always used, so the two agree. `/approval-two-money` still shows the fuller form (`Runs as you · asked here in chat`), untouched.
- **The toast hint says what approving MEANS rather than where the record goes.** That is the one thing a person needs before tapping Approve, it is true on every deployment, and it reuses the same "Runs as you" vocabulary.
- **The Slack sentence loses only the pause clause**, and now matches its own one-off sibling (`running as you`) which never carried the promise.

### What I deliberately did NOT write

The recurring-Slack line was the tempting one: having removed a false reassurance, the obvious move is to replace it with "this one approval covers every run." **I did not, because I could not verify it from that call site** — `toolPresentation` receives args and a trigger string, and carries no grant semantics telling me whether approving mints a standing grant or authorises one run. Swapping one unverified promise for another is precisely the failure this change exists to close, so the sentence simply ends after what is certain.

### Browser proof, and honestly which is which

- **Morph toast — the REAL code path, real browser.** `/thread-ordinary-consent` → Approve → the toast reads **"Runs as you"**. (Also reproduced on `/thread` and `/thread-humanized`; all three hit the fallback, since the fallback only shows when `toolPresentation` yields no `sub`.)

  ![morph](https://gist.githubusercontent.com/yousefh409/14597d82c0dae58ae5b56a32192ead94/raw/copy-morph-sub.png)

- **Toast hint — the rendered string, real browser**, on `/toasts`:

  ![hint](https://gist.githubusercontent.com/yousefh409/14597d82c0dae58ae5b56a32192ead94/raw/copy-toast-hint.png)

  Stated plainly: that scenario passes `hint` as a harness **fixture literal**, so the screenshot proves the string renders, not that the library produced it. The library's own path (`VendoToasts` raising a toast off a pending approval) is covered by the existing *"raises a toast for an approval that parks AFTER mount"* test, which renders the real component. I updated the harness fixture in step so it stays a **mirror** of the real hint instead of drifting into fiction of its own — the same mirror discipline `CLAUDE.md` asks for.

- **The Slack sentence has no screen to photograph.** Nothing in this repo renders a Slack automation consent — no harness scenario, and none of Maple's beats (its automations draft through Gmail, and the standing-grant card is a different component). So it is pinned by a test in the existing `lane-cards-picks` suite instead, **watched failing against the old string first**:

  ```
  × describes a recurring Slack post without promising a place to pause it
    → expected 'Vendo will post to #renewals on your …' to be '…' // Object.is equality
  ```

  I did not invent a fixture whose only purpose was to be photographed — same call as not manufacturing a 56-connector fixture on #1060.

---

## Gates

Run on the rebased head (main now contains #1060):

- `pnpm build --filter=@vendoai/ui... --filter=@vendoai/vendo...` — green
- `pnpm typecheck --filter=@vendoai/ui` — green
- `pnpm lint --filter=@vendoai/ui` — green (dependency-guard 30 packages; portability-gate **all legs**)
- `@vendoai/ui` vitest — **119 files / 1081 tests passed**
- `pnpm --filter @vendoai/ui test:browser` (the UI gate of record — CI runs no browser suites) — **82 passed, 7 skipped, 0 failed** (3.7m). The known load-dependent `extreme-content.spec.ts:48` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two issues: concurrent connects now open separate sign-in windows, and chrome copy stops referring to Activity/Automations surfaces a host may not mount.

- Bug Fixes
  - Connect popups are now keyed per row and opened as `vendo-connect-<key>` via `openConnectPopup(key)`, so concurrent connects (tray, connected accounts, card) don’t reuse the same window.
  - Host‑neutral copy in `@vendoai/ui`: morph toast fallback is "Runs as you"; approval-required toast hint is "Runs as you once approved"; recurring Slack post description ends at "It runs as you."

<sup>Written for commit dad18f9d9dc355ae8942d8bd6151899775bffaa7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

