### PR TITLE
fix(cli): resolve E-WIRE-004 false-positives and correct E-MCP probe paths

### DIFF
--- a/packages/vendo/src/cli/doctor-mcp-checks.ts
+++ b/packages/vendo/src/cli/doctor-mcp-checks.ts
@@ -1,12 +1,11 @@
 import { join } from "node:path";
+import { joinUrl } from "@vendoai/core";
+import { resolveVendoUrls } from "../urls.js";
 import type { DoctorErrorCode } from "./doctor-codes.js";
 import type { DoctorRun } from "./doctor-report.js";
 import { remoteUrls, sameUrl, validateRegistryServer } from "./mcp/registry.js";
 import { readOptional } from "./shared.js";
 
-/** Fetch a discovery document, grade it, and hand it back so a follow-up check
- *  can read what it advertised. A non-JSON error page still names its status;
- *  only a fetch that never answered is "unreachable". */
 type ResolveDocument = (
   id: string,
   code: DoctorErrorCode,
@@ -57,7 +56,7 @@ async function checkBrokerAuthorizationServer(
     await resolves(
       "mcp/authorization-server",
       "E-MCP-002",
-      `${advertised.replace(/\/+$/, "")}/.well-known/oauth-authorization-server`,
+      joinUrl(advertised, "/.well-known/oauth-authorization-server").href,
       (body) => body.issuer === advertised,
       `MCP authorization-server metadata at ${advertised} resolves`,
     );
@@ -92,7 +91,7 @@ async function checkRegistryAuthChallenge(run: DoctorRun, origin: string): Promi
     else run.fail("mcp/registry-auth-local", "E-MCP-007", "local MCP registry auth challenge must start with v=MCPv1");
   }
   try {
-    const response = await run.fetchImpl(`${origin}/.well-known/mcp-registry-auth`, {
+    const response = await run.fetchImpl(joinUrl(origin, "/.well-known/mcp-registry-auth").href, {
       headers: { accept: "text/plain" },
     });
     if (response.ok) {
@@ -114,13 +113,20 @@ export async function checkMcpDiscovery(run: DoctorRun, mcpPosture: "local" | "b
   run.note(mcpPosture === "broker"
     ? "MCP door mode: broker — an external authorization server fronts it (VENDO_MCP_BROKER_URL, or mcp.remoteAs)"
     : "MCP door mode: local — the door serves its own OAuth surface (set VENDO_MCP_BROKER_URL to front it with a broker)");
-  const origin = new URL(run.statusUrl).origin;
-  const mountPath = `${new URL(run.statusUrl).pathname.replace(/\/$/, "")}/mcp`;
+  const urls = resolveVendoUrls(run.env);
+  const base = urls ? urls.publicUrl.href : new URL(run.statusUrl).origin;
+  let mountPath = `${new URL(run.statusUrl).pathname.replace(/\/$/, "")}/mcp`;
+  if (urls) {
+    const basePath = urls.publicUrl.pathname.replace(/\/$/, "");
+    if (basePath.length > 0 && mountPath.startsWith(basePath)) {
+      mountPath = mountPath.slice(basePath.length);
+    }
+  }
   const resolves = documentResolver(run);
   const resource = await resolves(
     "mcp/protected-resource",
     "E-MCP-001",
-    `${origin}/.well-known/oauth-protected-resource${mountPath}`,
+    joinUrl(base, `/.well-known/oauth-protected-resource${mountPath}`).href,
     (body) => typeof body.resource === "string",
     "MCP protected-resource metadata resolves",
   );
@@ -130,7 +136,7 @@ export async function checkMcpDiscovery(run: DoctorRun, mcpPosture: "local" | "b
     await resolves(
       "mcp/authorization-server",
       "E-MCP-002",
-      `${origin}/.well-known/oauth-authorization-server${mountPath}`,
+      joinUrl(base, `/.well-known/oauth-authorization-server${mountPath}`).href,
       (body) => typeof body.issuer === "string",
       "MCP authorization-server metadata resolves",
     );
@@ -138,11 +144,11 @@ export async function checkMcpDiscovery(run: DoctorRun, mcpPosture: "local" | "b
   await resolves(
     "mcp/server-card",
     "E-MCP-003",
-    `${origin}/.well-known/mcp/server-card.json`,
+    joinUrl(base, "/.well-known/mcp/server-card.json").href,
     (body) => typeof body.name === "string" && Array.isArray(body.transports),
     "MCP server card parses",
   );
 
-  await checkServerJson(run, `${origin}${mountPath}`);
-  await checkRegistryAuthChallenge(run, origin);
+  await checkServerJson(run, joinUrl(base, mountPath).href);
+  await checkRegistryAuthChallenge(run, base);
 }

--- a/packages/vendo/src/cli/doctor-mcp-checks.ts
+++ b/packages/vendo/src/cli/doctor-mcp-checks.ts
@@ -118,7 +118,7 @@ export async function checkMcpDiscovery(run: DoctorRun, mcpPosture: "local" | "b
   let mountPath = `${new URL(run.statusUrl).pathname.replace(/\/$/, "")}/mcp`;
   if (urls) {
     const basePath = urls.publicUrl.pathname.replace(/\/$/, "");
-    if (basePath.length > 0 && mountPath.startsWith(basePath)) {
+    if (basePath.length > 0 && (mountPath === basePath || mountPath.startsWith(`${basePath}/`))) {
       mountPath = mountPath.slice(basePath.length);
     }
   }

--- a/packages/vendo/src/cli/doctor-wiring-checks.ts
+++ b/packages/vendo/src/cli/doctor-wiring-checks.ts
@@ -26,15 +26,21 @@ async function hasDependency(root: string): Promise<boolean> {
 function checkGenericWiring(run: DoctorRun, wiring: VendoWiring): void {
   if (wiring.server) run.pass("wiring/server", "createVendo server wiring found");
   else run.fail("wiring/server", "E-WIRE-007", "no createVendo server wiring found — import createVendo from @vendoai/vendo/server and mount vendo.handler on your runtime's request entry");
-  if (wiring.client) run.pass("wiring/client", "<VendoProvider> wraps the client");
-  else run.warn("wiring/client", "E-WIRE-008", "no <VendoProvider> found in the host source — the @vendoai/ui hooks and embeds need it; ignore this if the host renders a fully custom surface");
+  if (wiring.client) {
+    run.pass("wiring/client", wiring.legacyRoot ? "<VendoRoot> wraps the client (legacy)" : "<VendoProvider> wraps the client");
+  } else {
+    run.warn("wiring/client", "E-WIRE-008", "no <VendoProvider> found in the host source — the @vendoai/ui hooks and embeds need it; ignore this if the host renders a fully custom surface");
+  }
 }
 
 function checkExpressWiring(run: DoctorRun, wiring: VendoWiring): void {
   if (wiring.server) run.pass("wiring/express-server", "Express server is wired");
   else run.fail("wiring/express-server", "E-WIRE-001", "Express server is not wired with createVendo from @vendoai/vendo/server");
-  if (wiring.client) run.pass("wiring/express-client", "<VendoProvider> wraps the client");
-  else run.fail("wiring/express-client", "E-WIRE-002", "Express client is not wrapped in <VendoProvider>");
+  if (wiring.client) {
+    run.pass("wiring/express-client", wiring.legacyRoot ? "<VendoRoot> wraps the client (legacy)" : "<VendoProvider> wraps the client");
+  } else {
+    run.fail("wiring/express-client", "E-WIRE-002", "Express client is not wrapped in <VendoProvider>");
+  }
 }
 
 async function nextRoutePath(root: string): Promise<string | null> {
@@ -93,10 +99,10 @@ async function checkServerActionsWiring(run: DoctorRun, routePath: string): Prom
 /** The mount may live in ANY layout, not just the root one (i18n/route-group
  *  hosts mount in e.g. app/[locale]/layout.tsx — the literal root-layout grep
  *  fought exactly that correct wiring in the 0.4.1 E2E cert). */
-async function checkProviderMount(run: DoctorRun, wiringClient: boolean): Promise<void> {
+async function checkProviderMount(run: DoctorRun, wiring: VendoWiring): Promise<void> {
   const { root } = run;
-  if (wiringClient) {
-    run.pass("wiring/next-root", "<VendoProvider> wraps the app");
+  if (wiring.client) {
+    run.pass("wiring/next-root", wiring.legacyRoot ? "<VendoRoot> wraps the app (legacy)" : "<VendoProvider> wraps the app");
   } else {
     // The exact paste, not a description of it: init never edits user source,
     // so this is the one step a by-the-book install still owes, and doctor is
@@ -111,12 +117,12 @@ async function checkProviderMount(run: DoctorRun, wiringClient: boolean): Promis
   }
 }
 
-async function checkNextWiring(run: DoctorRun, wiringClient: boolean): Promise<void> {
+async function checkNextWiring(run: DoctorRun, wiring: VendoWiring): Promise<void> {
   const routePath = await nextRoutePath(run.root);
   if (routePath !== null) run.pass("wiring/next-route", "catch-all handler is wired");
   else run.fail("wiring/next-route", "E-WIRE-003", "missing app/api/vendo/[...vendo]/route.ts");
   if (routePath !== null) await checkServerActionsWiring(run, routePath);
-  await checkProviderMount(run, wiringClient);
+  await checkProviderMount(run, wiring);
 }
 
 /** VendoRoot is gone in this release (spec 2026-08-06 §B2). A host that still
@@ -144,7 +150,7 @@ export async function checkWiring(run: DoctorRun): Promise<void> {
   const wiring = await detectVendoWiring(root);
   if (framework === "unknown") checkGenericWiring(run, wiring);
   else if (framework === "express") checkExpressWiring(run, wiring);
-  else await checkNextWiring(run, wiring.client);
+  else await checkNextWiring(run, wiring);
 
   // Visible surface (0.4.1 E2E cert B3): <VendoProvider> is a context provider
   // that renders NOTHING — two certified stacks ended doctor-green with no

--- a/packages/vendo/src/cli/doctor-wiring-checks.ts
+++ b/packages/vendo/src/cli/doctor-wiring-checks.ts
@@ -27,7 +27,7 @@ function checkGenericWiring(run: DoctorRun, wiring: VendoWiring): void {
   if (wiring.server) run.pass("wiring/server", "createVendo server wiring found");
   else run.fail("wiring/server", "E-WIRE-007", "no createVendo server wiring found — import createVendo from @vendoai/vendo/server and mount vendo.handler on your runtime's request entry");
   if (wiring.client) {
-    run.pass("wiring/client", wiring.legacyRoot ? "<VendoRoot> wraps the client (legacy)" : "<VendoProvider> wraps the client");
+    run.pass("wiring/client", (wiring.legacyRoot && !wiring.provider) ? "<VendoRoot> wraps the client (legacy)" : "<VendoProvider> wraps the client");
   } else {
     run.warn("wiring/client", "E-WIRE-008", "no <VendoProvider> found in the host source — the @vendoai/ui hooks and embeds need it; ignore this if the host renders a fully custom surface");
   }
@@ -37,7 +37,7 @@ function checkExpressWiring(run: DoctorRun, wiring: VendoWiring): void {
   if (wiring.server) run.pass("wiring/express-server", "Express server is wired");
   else run.fail("wiring/express-server", "E-WIRE-001", "Express server is not wired with createVendo from @vendoai/vendo/server");
   if (wiring.client) {
-    run.pass("wiring/express-client", wiring.legacyRoot ? "<VendoRoot> wraps the client (legacy)" : "<VendoProvider> wraps the client");
+    run.pass("wiring/express-client", (wiring.legacyRoot && !wiring.provider) ? "<VendoRoot> wraps the client (legacy)" : "<VendoProvider> wraps the client");
   } else {
     run.fail("wiring/express-client", "E-WIRE-002", "Express client is not wrapped in <VendoProvider>");
   }
@@ -102,7 +102,7 @@ async function checkServerActionsWiring(run: DoctorRun, routePath: string): Prom
 async function checkProviderMount(run: DoctorRun, wiring: VendoWiring): Promise<void> {
   const { root } = run;
   if (wiring.client) {
-    run.pass("wiring/next-root", wiring.legacyRoot ? "<VendoRoot> wraps the app (legacy)" : "<VendoProvider> wraps the app");
+    run.pass("wiring/next-root", (wiring.legacyRoot && !wiring.provider) ? "<VendoRoot> wraps the app (legacy)" : "<VendoProvider> wraps the app");
   } else {
     // The exact paste, not a description of it: init never edits user source,
     // so this is the one step a by-the-book install still owes, and doctor is

--- a/packages/vendo/src/cli/doctor-wiring-checks.ts
+++ b/packages/vendo/src/cli/doctor-wiring-checks.ts
@@ -93,23 +93,9 @@ async function checkServerActionsWiring(run: DoctorRun, routePath: string): Prom
 /** The mount may live in ANY layout, not just the root one (i18n/route-group
  *  hosts mount in e.g. app/[locale]/layout.tsx — the literal root-layout grep
  *  fought exactly that correct wiring in the 0.4.1 E2E cert). */
-async function checkProviderMount(run: DoctorRun): Promise<void> {
+async function checkProviderMount(run: DoctorRun, wiringClient: boolean): Promise<void> {
   const { root } = run;
-  let rootWired = false;
-  const mountCandidates = [
-    ...await walk(join(root, "app"), (rel) => /(^|[\\/])layout\.(?:tsx|jsx|js)$/.test(rel)),
-    ...await walk(join(root, "src", "app"), (rel) => /(^|[\\/])layout\.(?:tsx|jsx|js)$/.test(rel)),
-    // A pages-only host has no layout to wrap: init hands it pages/_app, so
-    // that is where the mount lives. Without this the check can never pass on
-    // a router shape init explicitly supports.
-    ...["pages", join("src", "pages")].flatMap((pages) =>
-      ["_app.tsx", "_app.jsx", "_app.js"].map((file) => join(root, pages, file))),
-  ];
-  for (const path of mountCandidates) {
-    const source = await readFile(path, "utf8").catch(() => "");
-    if (source.includes("<VendoProvider")) rootWired = true;
-  }
-  if (rootWired) {
+  if (wiringClient) {
     run.pass("wiring/next-root", "<VendoProvider> wraps the app");
   } else {
     // The exact paste, not a description of it: init never edits user source,
@@ -125,12 +111,12 @@ async function checkProviderMount(run: DoctorRun): Promise<void> {
   }
 }
 
-async function checkNextWiring(run: DoctorRun): Promise<void> {
+async function checkNextWiring(run: DoctorRun, wiringClient: boolean): Promise<void> {
   const routePath = await nextRoutePath(run.root);
   if (routePath !== null) run.pass("wiring/next-route", "catch-all handler is wired");
   else run.fail("wiring/next-route", "E-WIRE-003", "missing app/api/vendo/[...vendo]/route.ts");
   if (routePath !== null) await checkServerActionsWiring(run, routePath);
-  await checkProviderMount(run);
+  await checkProviderMount(run, wiringClient);
 }
 
 /** VendoRoot is gone in this release (spec 2026-08-06 §B2). A host that still
@@ -158,7 +144,7 @@ export async function checkWiring(run: DoctorRun): Promise<void> {
   const wiring = await detectVendoWiring(root);
   if (framework === "unknown") checkGenericWiring(run, wiring);
   else if (framework === "express") checkExpressWiring(run, wiring);
-  else await checkNextWiring(run);
+  else await checkNextWiring(run, wiring.client);
 
   // Visible surface (0.4.1 E2E cert B3): <VendoProvider> is a context provider
   // that renders NOTHING — two certified stacks ended doctor-green with no

--- a/packages/vendo/src/cli/framework.ts
+++ b/packages/vendo/src/cli/framework.ts
@@ -16,6 +16,7 @@ export interface VendoWiring {
       VendoRoot (Maple's is), so this is the import from @vendoai, or the tag
       with no <VendoProvider> anywhere in the source. */
   legacyRoot: boolean;
+  provider: boolean;
 }
 
 /** What counts as a visible surface: the shipped chrome (<VendoOverlay> and
@@ -103,5 +104,6 @@ export async function detectVendoWiring(root: string): Promise<VendoWiring> {
     client: provider || legacyTag,
     surface,
     legacyRoot: legacyImport || (legacyTag && !provider),
+    provider,
   };
 }


### PR DESCRIPTION
## What

- Modifies `doctor-wiring-checks.ts` to rely on the `wiring.client` property computed by `detectVendoWiring` instead of performing a strict regex grep for `<VendoProvider>` on `layout.tsx` files.
- Updates `doctor-mcp-checks.ts` to strictly adhere to the `resolveVendoUrls` and `joinUrl` standards introduced in #957 for constructing URL probes to `.well-known` discovery endpoints.

Fixes #990

## Why

- **E-WIRE-004:** Installations (like Maple) that use a level of indirection (e.g., abstracting the provider via `VendoRoot.tsx`) were being incorrectly flagged as broken because the strict file-system grep missed them. 
- **E-MCP Probes:** The discovery probes were bypassing `VENDO_BASE_URL` entirely and blindly checking the root origin. This caused false failures when the application was legitimately served under a path prefix like `/maple`. Using `@vendoai/core`'s native URL resolution laws ensures the doctor resolves paths exactly as the server does.

## Verification

- [x] `pnpm build && pnpm test && pnpm typecheck && pnpm lint` green
- [ ] Screenshots attached (if UI-affecting)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false-positive doctor errors by relying on detected wiring (counts legacy `<VendoRoot>` only when no `<VendoProvider>` is present) and by building MCP discovery URLs against the real app base and sub-paths. Fixes #990.

- **Bug Fixes**
  - Wiring: `doctor-wiring-checks` now uses `detectVendoWiring().client` for Next/Express, labels legacy only if `<VendoProvider>` is absent, and removes file greps to stop E‑WIRE‑004.
  - MCP: `doctor-mcp-checks` builds all discovery and auth-challenge URLs with `resolveVendoUrls(run.env).publicUrl` and `joinUrl` from `@vendoai/core`, trims base paths to avoid double prefixes, and falls back to the `statusUrl` origin when env URLs are missing (protected-resource, authorization-server, server-card, registry-auth, and broker issuer).

<sup>Written for commit 19241a6b9413e1bdce20a8829511a104390ba6ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

