### PR TITLE
feat(genbench): slice 1 — one case through the real Vendo pipeline, scored and screenshotted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ packages/vendo/.wire-parity.*
 # Harness/test run outputs — write-only sinks, never committed
 corpus/reports/
 fixtures/existing-agents-e2e/.artifacts/
+genbench/runs/

--- a/genbench/README.md
+++ b/genbench/README.md
@@ -1,0 +1,69 @@
+# genbench
+
+Answers "why not build this in-house?" with numbers.
+
+It runs hand-written prompts through contenders — the real Vendo pipeline today,
+raw-Claude baselines later — against one fictional banking product defined
+entirely in JSON, scores what comes back with deterministic checks, and measures
+time and money. Every contender gets the same model, the same tools, the same
+schemas and the same design brief, because that equivalence is the whole claim.
+
+## Run it
+
+```sh
+pnpm build                                  # genbench reads the built @vendoai/* dists
+ANTHROPIC_API_KEY=… pnpm genbench run --prompt spend-overview
+```
+
+Each case writes `runs/<run>/<contender>/<case>/`:
+
+| file | what it is |
+| --- | --- |
+| `artifact.vendo` | the document the contender actually saved |
+| `screenshot.png` | that document rendered through the product's own compile + the Kit |
+| `result.json` | the five floor verdicts, timings, tokens and dollars |
+
+and one `runs/<run>/preview.html` — the screenshots side by side under their
+verdicts and numbers. It opens automatically on macOS.
+
+Flags: `--prompt <id>` for one case, `--models sonnet,opus,haiku`,
+`--lane build` (deferred).
+
+## The world
+
+`world.json` is the entire product: identity, a `VendoTheme`, a plain-English
+style rubric, and ~4 tools. A tool that declares `data` returns rows and is
+graded `read`; one that only declares `takes` mutates and is graded `write`.
+Input schemas are derived from `takes` (a name → type map), output schemas from
+the example rows.
+
+**Money is in integer cents**, as the Kit's `format="money"` and the demo host
+both expect. This is load-bearing: a world authored in dollars lets a 100×
+scale error slip past the fabrication check, which is exactly the bug the
+regression test in `src/floor.test.ts` pins down.
+
+`cases.json` holds the prompts. A case may override any tool's data — that is
+how the empty state is tested — and its `pass` lines are the correctness rubric
+a pinned judge will grade in a later slice.
+
+## The floor
+
+Five deterministic checks, no model involved:
+
+- **delivered** — an artifact came back at all
+- **renders** — the compiled screen painted at least one element
+- **valid** — the product's *own* checks floor blocks nothing in the saved bytes.
+  Not the same as "something painted": the agent can save again after its last
+  good view, and the seam keeps the older screen
+- **honestData** — every number and date on screen is a value a tool returned,
+  or a sum, count, min, max or mean of one numeric field across one tool's rows.
+  Nothing else is allowed
+- **wiredActions** — every tool the tree names exists, and its arguments fit the
+  derived input schema
+
+## Known limits
+
+Charts and generated islands are client-only, so they leave an empty band in a
+server-rendered screenshot. Every result counts them (`clientOnly`, `islands`)
+and the preview says so out loud, so the gap is never silent — but a shot with a
+chart in it does understate what the product built.

--- a/genbench/cases.json
+++ b/genbench/cases.json
@@ -1,0 +1,45 @@
+[
+  {
+    "id": "spend-overview",
+    "lane": "screen",
+    "prompt": "Show me where my money went this month.",
+    "pass": [
+      "shows every spending category the tool returned",
+      "each category's amount matches the tool's number exactly",
+      "housing is presented as the largest category",
+      "shows a total for the month equal to the sum of the categories"
+    ]
+  },
+  {
+    "id": "pending-transfers",
+    "lane": "screen",
+    "prompt": "Show my pending transfers and give me a way to cancel one.",
+    "pass": [
+      "lists both pending transfers and neither completed one",
+      "shows each pending transfer's recipient, amount, and date",
+      "offers a cancel control on each pending transfer",
+      "the cancel control targets the transfer it sits on"
+    ]
+  },
+  {
+    "id": "account-balances",
+    "lane": "screen",
+    "prompt": "Show me all my accounts and what I'm worth in total.",
+    "pass": [
+      "lists all three accounts with name and balance",
+      "shows the credit account's balance as negative",
+      "shows a total equal to the sum of the three balances"
+    ]
+  },
+  {
+    "id": "no-pending-transfers",
+    "lane": "screen",
+    "prompt": "Show my pending transfers and give me a way to cancel one.",
+    "pass": [
+      "says there are no transfers rather than showing an empty table",
+      "invents no transfer rows",
+      "offers no cancel control"
+    ],
+    "data": { "list_transfers": { "data": [] } }
+  }
+]

--- a/genbench/package.json
+++ b/genbench/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@vendoai/genbench",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Why not build this in-house? Runs hand-written prompts through the real Vendo pipeline and raw-Claude baselines against one fictional product, and scores them. Not published.",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "genbench": "node --import tsx src/run.ts",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@vendoai/apps": "workspace:*",
+    "@vendoai/core": "workspace:*",
+    "@vendoai/guard": "workspace:*",
+    "@vendoai/harnesses": "workspace:*",
+    "@vendoai/store": "workspace:*",
+    "@vendoai/ui": "workspace:*",
+    "@vendoai/vendo": "workspace:*"
+  },
+  "devDependencies": {
+    "@ai-sdk/anthropic": "3.0.12",
+    "@ai-sdk/provider": "3.0.2",
+    "@playwright/test": "^1.49.0",
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.2.0",
+    "@types/react-dom": "^19.2.0",
+    "ai": "6.0.28",
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/genbench/src/fixtures/duplicate-cases.json
+++ b/genbench/src/fixtures/duplicate-cases.json
@@ -1,0 +1,4 @@
+[
+  { "id": "same", "lane": "screen", "prompt": "one", "pass": [] },
+  { "id": "same", "lane": "screen", "prompt": "two", "pass": [] }
+]

--- a/genbench/src/floor.test.ts
+++ b/genbench/src/floor.test.ts
@@ -1,0 +1,152 @@
+import type { UIPayload } from "@vendoai/core";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+import { bindingsFromPayload, buildIndex, honestData, wiredActions, type DataIndex } from "./floor.js";
+import { loadWorld, type World } from "./world.js";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+
+let world: World;
+let index: DataIndex;
+beforeAll(async () => {
+  world = await loadWorld(join(root, "world.json"));
+  index = buildIndex(world);
+});
+
+describe("honestData — literals", () => {
+  it("accepts a number a tool returned, however it is formatted", () => {
+    // Authored as 285000 cents, shown as dollars.
+    expect(honestData("Rent $2,850.00", index).pass).toBe(true);
+    expect(honestData("Rent 2850", index).pass).toBe(true);
+    // The raw cents are the tool's own literal, so they are honest too — showing
+    // them unformatted is a style fault for the judge, not a fabrication.
+    expect(honestData("Rent 285000", index).pass).toBe(true);
+  });
+
+  it("accepts a negative balance shown with a minus", () => {
+    expect(honestData("Maple Credit -$1,288.40", index).pass).toBe(true);
+  });
+
+  it("accepts a date a tool returned, in either notation", () => {
+    expect(honestData("Sent Aug 1", index).pass).toBe(true);
+    expect(honestData("Sent 2026-08-01", index).pass).toBe(true);
+  });
+
+  it("consumes the day out of a human date rather than reading it as a number", () => {
+    // "Jul 24" is a real transfer date; 24 is not a value any tool returns, so a
+    // date pass that leaves its digits behind would wrongly flag it.
+    expect(honestData("Dana Whitfield · Jul 24", index).pass).toBe(true);
+  });
+});
+
+describe("honestData — derivables", () => {
+  it("accepts the sum of one numeric field across one tool's rows", () => {
+    // 2850.00 + 612.45 + 438.20 + 184.41 + 96.75 + 61.30
+    expect(honestData("Total spent $4,243.11", index).pass).toBe(true);
+    // 9412.20 + 28141.35 - 1288.40
+    expect(honestData("Net worth $36,265.15", index).pass).toBe(true);
+  });
+
+  it("accepts a row count and the largest row", () => {
+    expect(honestData("3 accounts", index).pass).toBe(true);
+    expect(honestData("Largest category $2,850.00", index).pass).toBe(true);
+  });
+
+  it("rejects a total that is off by a cent", () => {
+    const result = honestData("Total spent $4,243.12", index);
+    expect(result.pass).toBe(false);
+    expect(result.offenders[0]?.kind).toBe("number");
+  });
+});
+
+describe("honestData — the negative control", () => {
+  it("flips to fail when a world number is perturbed by one digit", () => {
+    // Alex Rivera's transfer is 250.00. Show it honestly, then move one digit.
+    expect(honestData("Alex Rivera $250.00", index).pass).toBe(true);
+
+    const perturbed = honestData("Alex Rivera $260.00", index);
+    expect(perturbed.pass).toBe(false);
+    expect(perturbed.offenders).toEqual([
+      expect.objectContaining({ kind: "number", text: "$260.00" }),
+    ]);
+  });
+
+  it("catches a money amount shown a hundred times too small", () => {
+    // Regression, from a real run on 2026-08-08: the writer passed raw cents to
+    // <Stat format="money">, which divides by 100, and the screen showed
+    // "$42.43" for a month of spending that really was $4,243.11 — with every
+    // category equally wrong. A currency scale error is the worst thing a
+    // banking screen can do, so the floor has to see it.
+    expect(honestData("Total spent this month $42.43", index).pass).toBe(false);
+    expect(honestData("housing $28.50", index).pass).toBe(false);
+  });
+
+  it("flips to fail on a date no tool returned", () => {
+    const result = honestData("Scheduled Aug 3", index);
+    expect(result.pass).toBe(false);
+    expect(result.offenders[0]).toMatchObject({ kind: "date" });
+  });
+});
+
+describe("bindingsFromPayload", () => {
+  const payload = {
+    formatVersion: "vendo-genui/v2",
+    root: "a",
+    queries: [{ name: "transfers", tool: "list_transfers", input: { limit: 10 } }],
+    nodes: [
+      { id: "a", component: "Stack", children: ["b"] },
+      { id: "b", component: "Button", props: { onPress: { action: "cancel_transfer", payload: { id: "tr_1" } } } },
+    ],
+  } as unknown as UIPayload;
+
+  it("finds both the tree's queries and the nodes' action props", () => {
+    expect(bindingsFromPayload(payload)).toEqual([
+      { tool: "list_transfers", args: { limit: 10 }, where: "query transfers" },
+      { tool: "cancel_transfer", args: { id: "tr_1" }, where: "node b" },
+    ]);
+  });
+
+  it("ignores a host component's own fn reference, which names no tool", () => {
+    const withFn = {
+      formatVersion: "vendo-genui/v2",
+      root: "a",
+      nodes: [{ id: "a", component: "Card", props: { onPress: { action: "fn:refresh" } } }],
+    } as unknown as UIPayload;
+    expect(bindingsFromPayload(withFn)).toEqual([]);
+  });
+});
+
+describe("wiredActions", () => {
+  const at = (tool: string, args: unknown) => [{ tool, args, where: "node b" }];
+
+  it("passes a real tool called with the arguments it declares", () => {
+    expect(wiredActions(at("cancel_transfer", { id: "tr_1" }), world).pass).toBe(true);
+  });
+
+  it("fails a tool the world does not have", () => {
+    const result = wiredActions(at("delete_account", { id: "x" }), world);
+    expect(result.pass).toBe(false);
+    expect(result.bindings[0]).toMatchObject({ known: false, why: 'no tool named "delete_account"' });
+  });
+
+  it("fails a missing required argument", () => {
+    const result = wiredActions(at("cancel_transfer", {}), world);
+    expect(result.pass).toBe(false);
+    expect(result.bindings[0]).toMatchObject({ known: true, argsValid: false, why: 'missing required argument "id"' });
+  });
+
+  it("fails an argument the tool does not declare", () => {
+    const result = wiredActions(at("cancel_transfer", { id: "tr_1", force: true }), world);
+    expect(result.bindings[0]).toMatchObject({ argsValid: false, why: 'unknown argument "force"' });
+  });
+
+  it("fails an argument of the wrong type", () => {
+    const result = wiredActions(at("list_transfers", { limit: "10" }), world);
+    expect(result.bindings[0]).toMatchObject({ argsValid: false, why: 'argument "limit" should be a number' });
+  });
+
+  it("passes vacuously when a screen binds nothing", () => {
+    expect(wiredActions([], world)).toEqual({ pass: true, bindings: [] });
+  });
+});

--- a/genbench/src/floor.ts
+++ b/genbench/src/floor.ts
@@ -1,0 +1,255 @@
+import type { Json, UIPayload } from "@vendoai/core";
+import type { Shot } from "./render.js";
+import type { World } from "./world.js";
+
+export interface Offender {
+  readonly kind: "number" | "date";
+  readonly text: string;
+  readonly why: string;
+}
+
+export interface HonestDataResult {
+  readonly pass: boolean;
+  readonly offenders: readonly Offender[];
+}
+
+export interface Binding {
+  readonly tool: string;
+  readonly known: boolean;
+  readonly argsValid: boolean;
+  readonly where: string;
+  readonly why?: string;
+}
+
+export interface WiredActionsResult {
+  readonly pass: boolean;
+  readonly bindings: readonly Binding[];
+}
+
+export interface FloorResult {
+  readonly delivered: boolean;
+  readonly renders: boolean;
+  readonly valid: boolean;
+  /** Why `valid` is false, in the product's own words. */
+  readonly blocking: readonly string[];
+  readonly honestData: HonestDataResult;
+  readonly wiredActions: WiredActionsResult;
+  readonly pass: boolean;
+}
+
+// ---------------------------------------------------------------- honest data
+
+/** Money and counts collapse onto one key so "$2,850.00", "2850" and the raw
+ *  2850 are the same fact. Sign is a display choice the style rubric owns, so
+ *  the index compares magnitudes. */
+const numberKey = (value: number): string => String(Math.round(Math.abs(value) * 100) / 100);
+
+/** The same amount authored in dollars may be shown in cents, and vice versa. */
+const numberKeys = (value: number): string[] => [numberKey(value), numberKey(value / 100), numberKey(value * 100)];
+
+const MONTHS = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"];
+const ISO_DATE = /\b(\d{4})-(\d{2})-(\d{2})\b/g;
+const HUMAN_DATE =
+  /\b(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\.?\s+(\d{1,2})(?:st|nd|rd|th)?(?:,?\s+(\d{4}))?\b/gi;
+const NUMBER = /-?\$?\d[\d,]*(?:\.\d+)?/g;
+
+/** A date is indexed at both precisions, because "Aug 1" carries no year. */
+const dateKeys = (year: string | undefined, month: string, day: string): string[] => {
+  const monthDay = `${month.padStart(2, "0")}-${day.padStart(2, "0")}`;
+  return year === undefined ? [monthDay] : [monthDay, `${year}-${monthDay}`];
+};
+
+export interface DataIndex {
+  readonly numbers: ReadonlySet<string>;
+  readonly dates: ReadonlySet<string>;
+}
+
+/** "One tool's rows" — the array itself, or the single array a response
+ *  envelope wraps it in, which is how real hosts return collections. */
+function rowsOf(data: unknown): readonly unknown[] {
+  if (Array.isArray(data)) return data;
+  if (typeof data !== "object" || data === null) return [];
+  const arrays = Object.values(data).filter((value): value is unknown[] => Array.isArray(value));
+  return arrays.length === 1 ? arrays[0]! : [];
+}
+
+function walkNumbers(value: unknown, onNumber: (n: number) => void, onDate: (iso: string) => void): void {
+  if (Array.isArray(value)) {
+    for (const item of value) walkNumbers(item, onNumber, onDate);
+    return;
+  }
+  if (typeof value === "object" && value !== null) {
+    for (const item of Object.values(value)) walkNumbers(item, onNumber, onDate);
+    return;
+  }
+  if (typeof value === "number") onNumber(value);
+  if (typeof value === "string") {
+    for (const [, year, month, day] of value.matchAll(ISO_DATE)) onDate(`${year!}-${month!}-${day!}`);
+  }
+}
+
+/** Every literal number and date the case's tools return, plus the closed set of
+ *  values a contender is allowed to compute: sum, count, min, max and mean of one
+ *  numeric field across one tool's rows. Anything else on screen is invented. */
+export function buildIndex(world: World): DataIndex {
+  const numbers = new Set<string>();
+  const dates = new Set<string>();
+  const add = (n: number): void => {
+    for (const key of numberKeys(n)) numbers.add(key);
+  };
+
+  for (const tool of world.tools) {
+    walkNumbers(tool.data, add, (iso) => {
+      const [year, month, day] = iso.split("-") as [string, string, string];
+      for (const key of dateKeys(year, month, day)) dates.add(key);
+    });
+
+    const rows = rowsOf(tool.data);
+    add(rows.length);
+    const columns = new Map<string, number[]>();
+    for (const row of rows) {
+      if (typeof row !== "object" || row === null) continue;
+      for (const [field, value] of Object.entries(row as Record<string, unknown>)) {
+        if (typeof value !== "number") continue;
+        const seen = columns.get(field) ?? [];
+        seen.push(value);
+        columns.set(field, seen);
+      }
+    }
+    for (const values of columns.values()) {
+      const sum = values.reduce((total, value) => total + value, 0);
+      add(sum);
+      add(sum / values.length);
+      add(Math.min(...values));
+      add(Math.max(...values));
+    }
+  }
+  return { numbers, dates };
+}
+
+export function honestData(visibleText: string, index: DataIndex): HonestDataResult {
+  const offenders: Offender[] = [];
+  // Dates are consumed first and blanked out, so "Aug 1" never leaves a stray
+  // `1` for the number pass to flag.
+  let remaining = visibleText;
+  const takeDates = (pattern: RegExp, iso: boolean): void => {
+    remaining = remaining.replace(pattern, (match, a: string, b: string, c: string | undefined) => {
+      const keys = iso ? dateKeys(a, b, c!) : dateKeys(c, String(MONTHS.indexOf(a.slice(0, 3).toLowerCase()) + 1), b);
+      if (!keys.some((key) => index.dates.has(key))) {
+        offenders.push({ kind: "date", text: match, why: "no tool returned this date" });
+      }
+      return " ".repeat(match.length);
+    });
+  };
+  takeDates(ISO_DATE, true);
+  takeDates(HUMAN_DATE, false);
+
+  for (const match of remaining.matchAll(NUMBER)) {
+    const text = match[0];
+    const value = Number(text.replace(/[$,]/g, ""));
+    if (!Number.isFinite(value)) continue;
+    if (index.numbers.has(numberKey(value))) continue;
+    offenders.push({
+      kind: "number",
+      text,
+      why: "not a value any tool returned, and not a sum, count, min, max or mean of one",
+    });
+  }
+  return { pass: offenders.length === 0, offenders };
+}
+
+// -------------------------------------------------------------- wired actions
+
+interface RawBinding {
+  readonly tool: string;
+  readonly args: unknown;
+  readonly where: string;
+}
+
+/** Walk the compiled payload for everything that names a tool: the tree's
+ *  queries, and every `{ action, payload }` prop on any node, at any depth. */
+export function bindingsFromPayload(payload: UIPayload): readonly RawBinding[] {
+  const found: RawBinding[] = [];
+  const queries = (payload as { queries?: Array<{ name: string; tool: string; input?: Json }> }).queries ?? [];
+  for (const query of queries) {
+    found.push({ tool: query.tool, args: query.input ?? {}, where: `query ${query.name}` });
+  }
+
+  const collect = (value: unknown, where: string): void => {
+    if (Array.isArray(value)) {
+      for (const item of value) collect(item, where);
+      return;
+    }
+    if (typeof value !== "object" || value === null) return;
+    const record = value as Record<string, unknown>;
+    // `fn:` names a host component's own function, never a tool, so it is not a
+    // tool binding to grade. No host components are registered in this bench.
+    if (typeof record.action === "string" && !record.action.startsWith("fn:")) {
+      found.push({ tool: record.action, args: record.payload ?? {}, where });
+    }
+    for (const item of Object.values(record)) collect(item, where);
+  };
+  const nodes = (payload as { nodes?: Array<{ id: string; props?: unknown }> }).nodes ?? [];
+  for (const node of nodes) collect(node.props, `node ${node.id}`);
+  return found;
+}
+
+/** The derived input schemas are all `{type:"object", properties, required,
+ *  additionalProperties:false}`, so validating them takes four rules, not a
+ *  schema library. */
+function checkArgs(args: unknown, schema: Record<string, unknown>): string | undefined {
+  if (typeof args !== "object" || args === null || Array.isArray(args)) return "arguments are not an object";
+  const properties = (schema.properties ?? {}) as Record<string, { type?: string }>;
+  const required = (schema.required ?? []) as string[];
+  const given = args as Record<string, unknown>;
+  for (const name of required) {
+    if (!Object.hasOwn(given, name)) return `missing required argument "${name}"`;
+  }
+  for (const [name, value] of Object.entries(given)) {
+    const expected = properties[name]?.type;
+    if (expected === undefined) return `unknown argument "${name}"`;
+    if (typeof value !== expected) return `argument "${name}" should be a ${expected}`;
+  }
+  return undefined;
+}
+
+export function wiredActions(bindings: readonly RawBinding[], world: World): WiredActionsResult {
+  const graded = bindings.map((binding): Binding => {
+    const tool = world.tools.find((candidate) => candidate.name === binding.tool);
+    if (tool === undefined) {
+      return { ...binding, known: false, argsValid: false, why: `no tool named "${binding.tool}"` };
+    }
+    const why = checkArgs(binding.args, tool.descriptor.inputSchema as Record<string, unknown>);
+    return { tool: binding.tool, where: binding.where, known: true, argsValid: why === undefined, ...(why === undefined ? {} : { why }) };
+  });
+  return { pass: graded.every((binding) => binding.known && binding.argsValid), bindings: graded };
+}
+
+// ---------------------------------------------------------------------- floor
+
+export function runFloor(input: {
+  world: World;
+  artifact: string | undefined;
+  /** What the product's own checks floor blocks in the delivered artifact. */
+  blocking: readonly string[];
+  payload: UIPayload | undefined;
+  shot: Shot | undefined;
+}): FloorResult {
+  const delivered = input.artifact !== undefined && input.artifact.trim() !== "";
+  const renders = input.shot?.renders === true;
+  const valid = delivered && input.blocking.length === 0;
+  const data = honestData(input.shot?.visibleText ?? "", buildIndex(input.world));
+  const actions =
+    input.payload === undefined
+      ? { pass: false, bindings: [] }
+      : wiredActions(bindingsFromPayload(input.payload), input.world);
+  return {
+    delivered,
+    renders,
+    valid,
+    blocking: input.blocking,
+    honestData: data,
+    wiredActions: actions,
+    pass: delivered && renders && valid && data.pass && actions.pass,
+  };
+}

--- a/genbench/src/meter.ts
+++ b/genbench/src/meter.ts
@@ -1,0 +1,114 @@
+import type { LanguageModelV3, LanguageModelV3Middleware, LanguageModelV3Usage } from "@ai-sdk/provider";
+import { wrapLanguageModel, type LanguageModel } from "ai";
+
+export type ModelAlias = "opus" | "sonnet" | "haiku";
+
+/** Pinned ids. Each one was checked against the live API through
+ *  `@ai-sdk/anthropic` before being written here. */
+export const MODEL_IDS: Readonly<Record<ModelAlias, string>> = {
+  opus: "claude-opus-5",
+  sonnet: "claude-sonnet-5",
+  haiku: "claude-haiku-4-5-20251001",
+};
+
+interface ModelPrice {
+  readonly inputPerMTok: number;
+  readonly outputPerMTok: number;
+}
+
+const PRICING: Readonly<Record<string, ModelPrice>> = {
+  "claude-opus-5": { inputPerMTok: 5, outputPerMTok: 25 },
+  "claude-sonnet-5": { inputPerMTok: 3, outputPerMTok: 15 },
+  "claude-haiku-4-5-20251001": { inputPerMTok: 1, outputPerMTok: 5 },
+};
+
+/** Cache reads bill at a tenth of the input rate; 5-minute cache writes at 1.25x. */
+const CACHE_READ_MULTIPLIER = 0.1;
+const CACHE_WRITE_MULTIPLIER = 1.25;
+
+/** The screen agent builds its Turn with no `maxOutputTokens`, so the provider
+ *  default applies and a long document can truncate mid-write with no error.
+ *  The meter fills the gap only when the caller left it unset. */
+const MAX_OUTPUT_TOKENS_FLOOR = 32_000;
+
+export interface UsageTotals {
+  /** Input tokens billed at the full rate — cache reads and writes are excluded. */
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cacheReadTokens: number;
+  readonly cacheWriteTokens: number;
+  readonly calls: number;
+}
+
+export interface Meter {
+  /** Hand this to the driver. Every contender is metered by this same wrapper,
+   *  which is what makes the columns comparable. */
+  readonly model: LanguageModel;
+  /** Milliseconds since the meter was created. The run's only clock. */
+  elapsedMs(): number;
+  totals(): UsageTotals;
+  usd(): number;
+}
+
+export function meteredModel(base: LanguageModelV3, modelId: string): Meter {
+  const startedAt = performance.now();
+  const totals = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, calls: 0 };
+
+  const record = (usage: LanguageModelV3Usage): void => {
+    const cacheRead = usage.inputTokens.cacheRead ?? 0;
+    const cacheWrite = usage.inputTokens.cacheWrite ?? 0;
+    // `noCache` is what the full input rate applies to. Providers that only
+    // report a total get the same number by subtraction.
+    const uncached =
+      usage.inputTokens.noCache ?? Math.max(0, (usage.inputTokens.total ?? 0) - cacheRead - cacheWrite);
+    totals.inputTokens += uncached;
+    totals.outputTokens += usage.outputTokens.total ?? 0;
+    totals.cacheReadTokens += cacheRead;
+    totals.cacheWriteTokens += cacheWrite;
+    totals.calls += 1;
+  };
+
+  const middleware: LanguageModelV3Middleware = {
+    specificationVersion: "v3",
+    transformParams: async ({ params }) => ({
+      ...params,
+      maxOutputTokens: params.maxOutputTokens ?? MAX_OUTPUT_TOKENS_FLOOR,
+    }),
+    wrapGenerate: async ({ doGenerate }) => {
+      const result = await doGenerate();
+      record(result.usage);
+      return result;
+    },
+    wrapStream: async ({ doStream }) => {
+      const result = await doStream();
+      return {
+        ...result,
+        stream: result.stream.pipeThrough(
+          new TransformStream({
+            transform(part, controller) {
+              if (part.type === "finish") record(part.usage);
+              controller.enqueue(part);
+            },
+          }),
+        ),
+      };
+    },
+  };
+
+  return {
+    model: wrapLanguageModel({ model: base, middleware }),
+    elapsedMs: () => Math.round(performance.now() - startedAt),
+    totals: () => ({ ...totals }),
+    usd: () => usdFor({ ...totals }, modelId),
+  };
+}
+
+export function usdFor(usage: UsageTotals, modelId: string): number {
+  const price = PRICING[modelId];
+  if (!price) throw new Error(`genbench: no price for model "${modelId}"`);
+  const input =
+    usage.inputTokens +
+    usage.cacheReadTokens * CACHE_READ_MULTIPLIER +
+    usage.cacheWriteTokens * CACHE_WRITE_MULTIPLIER;
+  return (input * price.inputPerMTok + usage.outputTokens * price.outputPerMTok) / 1_000_000;
+}

--- a/genbench/src/render.ts
+++ b/genbench/src/render.ts
@@ -1,0 +1,81 @@
+import { chromium, type Browser } from "@playwright/test";
+import {
+  defaultVendoTheme,
+  resolveTheme,
+  themeCssVariables,
+  type Json,
+  type ToolOutcome,
+  type UIPayload,
+  type VendoTheme,
+} from "@vendoai/core";
+import { PayloadView } from "@vendoai/ui/tree";
+import { createElement } from "react";
+import { renderToString } from "react-dom/server";
+
+/** A banking app's column. Every contender is shot at the same size, so the
+ *  screenshots stack side by side in the report. */
+const VIEWPORT = { width: 480, height: 900 } as const;
+
+const noAction = async (): Promise<ToolOutcome> => ({ status: "ok", output: null });
+
+/** Payload -> a standalone document. The Kit styles entirely through
+ *  `var(--vendo-*)` with baked-in fallbacks and ships no stylesheet, so the
+ *  host theme arrives as the one `:root` block below and nothing else is
+ *  needed to paint it in the host's brand. */
+export function treeHtml(payload: UIPayload, theme: VendoTheme): string {
+  const body = renderToString(
+    createElement(PayloadView, {
+      payload,
+      components: {},
+      data: (payload as { data?: Record<string, Json> }).data,
+      onAction: noAction,
+    }),
+  );
+  const vars = Object.entries(themeCssVariables(resolveTheme(defaultVendoTheme, theme)))
+    .map(([name, value]) => `${name}: ${value};`)
+    .join("");
+  return `<!doctype html>
+<html><head><meta charset="utf-8"><title>genbench</title><style>
+:root{${vars}}
+html,body{margin:0;padding:0;background:var(--vendo-color-background);}
+.vendo-root{padding:20px;font-family:var(--vendo-font-family);font-size:var(--vendo-font-size);color:var(--vendo-color-text);}
+</style></head><body><div class="vendo-root">${body}</div></body></html>`;
+}
+
+export interface Shot {
+  readonly png: Buffer;
+  /** `document.body.innerText` — the same extraction for every contender, which
+   *  is what makes the fabrication check comparable across artifact formats. */
+  readonly visibleText: string;
+  /** At least one element actually took up space on the page. */
+  readonly renders: boolean;
+}
+
+export interface Shooter {
+  shot(html: string): Promise<Shot>;
+  close(): Promise<void>;
+}
+
+/** One browser for the whole run; every case reuses it. */
+export async function openBrowser(): Promise<Shooter> {
+  const browser: Browser = await chromium.launch();
+  return {
+    async shot(html) {
+      const page = await browser.newPage({ viewport: { ...VIEWPORT } });
+      try {
+        await page.setContent(html, { waitUntil: "load" });
+        const { visibleText, renders } = await page.evaluate(() => {
+          const painted = [...document.querySelectorAll(".vendo-root *")].some((element) => {
+            const box = element.getBoundingClientRect();
+            return box.width > 0 && box.height > 0;
+          });
+          return { visibleText: document.body.innerText, renders: painted };
+        });
+        return { png: await page.screenshot({ fullPage: true }), visibleText, renders };
+      } finally {
+        await page.close();
+      }
+    },
+    close: () => browser.close(),
+  };
+}

--- a/genbench/src/report.ts
+++ b/genbench/src/report.ts
@@ -1,0 +1,156 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { Binding, FloorResult, Offender } from "./floor.js";
+import type { CaseResult } from "./run.js";
+
+const escape = (value: string): string =>
+  value.replace(/[&<>"]/g, (char) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[char]!);
+
+const verdict = (ok: boolean): string =>
+  `<span class="v ${ok ? "ok" : "no"}">${ok ? "✓" : "✕"} ${ok ? "pass" : "fail"}</span>`;
+
+const CHECKS = ["delivered", "renders", "valid", "honestData", "wiredActions"] as const;
+
+const passes = (floor: FloorResult): boolean[] => [
+  floor.delivered,
+  floor.renders,
+  floor.valid,
+  floor.honestData.pass,
+  floor.wiredActions.pass,
+];
+
+const offenderList = (offenders: readonly Offender[]): string =>
+  offenders.length === 0
+    ? ""
+    : `<ul class="notes">${offenders
+        .map((o) => `<li><code>${escape(o.text)}</code> <span>${escape(o.why)}</span></li>`)
+        .join("")}</ul>`;
+
+const bindingList = (bindings: readonly Binding[]): string =>
+  bindings.length === 0
+    ? `<ul class="notes"><li><span>no tool bindings on this screen</span></li></ul>`
+    : `<ul class="notes">${bindings
+        .map(
+          (b) =>
+            `<li><code>${escape(b.tool)}</code> <span>${escape(b.where)}${
+              b.why === undefined ? "" : ` — ${escape(b.why)}`
+            }</span> ${b.known && b.argsValid ? '<i class="ok">✓</i>' : '<i class="no">✕</i>'}</li>`,
+        )
+        .join("")}</ul>`;
+
+/** Islands and Kit charts both need the browser, so both leave a gap in a
+ *  server-rendered shot. Says so in as many words, and counts them. */
+function clientOnlyNote(islands: number, charts: number): string {
+  const parts = [
+    islands > 0 ? `${islands} generated island${islands === 1 ? "" : "s"}` : "",
+    charts > 0 ? `${charts} chart${charts === 1 ? "" : "s"}` : "",
+  ].filter(Boolean);
+  if (parts.length === 0) return "";
+  const subject = parts.join(" and ");
+  const verb = islands + charts === 1 ? "is" : "are";
+  return `<p class="warn">${subject} on this screen ${verb} client-only — leaving an empty band in this server-rendered shot</p>`;
+}
+
+const metric = (label: string, value: string): string =>
+  `<div><dt>${label}</dt><dd>${escape(value)}</dd></div>`;
+
+async function column(runDir: string, result: CaseResult): Promise<string> {
+  const shot = await readFile(join(runDir, result.contender, result.case, "screenshot.png")).catch(() => undefined);
+  const scored = passes(result.floor);
+  const total = scored.filter(Boolean).length;
+  const { usage } = result.cost;
+  const tokens = usage.inputTokens + usage.outputTokens + usage.cacheReadTokens + usage.cacheWriteTokens;
+
+  return `<section class="col">
+  <header>
+    <div><h2>${escape(result.contender)}</h2><p>${escape(result.model)}</p></div>
+    <span class="score ${total === 5 ? "ok" : "no"}">${total}/5</span>
+  </header>
+  <figure>${
+    shot === undefined
+      ? `<div class="blank">nothing rendered</div>`
+      : `<img alt="${escape(result.case)} rendered by ${escape(result.contender)}" src="data:image/png;base64,${shot.toString("base64")}">`
+  }</figure>
+  ${result.failure === undefined ? "" : `<p class="failure">${escape(result.failure)}</p>`}
+  ${clientOnlyNote(result.islands, result.clientOnly)}
+  <dl class="floor">${CHECKS.map((name, index) => `<div><dt>${name}</dt><dd>${verdict(scored[index]!)}</dd></div>`).join("")}</dl>
+  ${
+    result.floor.blocking.length === 0
+      ? ""
+      : `<ul class="notes">${result.floor.blocking.map((why) => `<li><span>${escape(why)}</span></li>`).join("")}</ul>`
+  }
+  ${result.floor.honestData.pass ? "" : offenderList(result.floor.honestData.offenders)}
+  ${bindingList(result.floor.wiredActions.bindings)}
+  <dl class="metrics">
+    ${metric("first render", result.timing.firstRenderMs === undefined ? "—" : `${result.timing.firstRenderMs} ms`)}
+    ${metric("settled", `${result.timing.settledMs} ms`)}
+    ${metric("tokens", tokens.toLocaleString("en-US"))}
+    ${metric("cost", `$${result.cost.usd.toFixed(4)}`)}
+  </dl>
+</section>`;
+}
+
+const CSS = `
+:root{--ink:#17171a;--sec:#5c5c66;--ter:#8e8e99;--page:#f6f5f3;--card:#fff;--line:#e6e4e0;--ok:#1d7a4f;--no:#b4342a;}
+*{box-sizing:border-box}
+body{margin:0;background:var(--page);color:var(--ink);
+  font:450 15px/1.5 ui-sans-serif,-apple-system,"Segoe UI",sans-serif;
+  -webkit-font-smoothing:antialiased;border-top:3px solid var(--ink);}
+.wrap{max-width:1240px;margin:0 auto;padding:32px 24px 64px}
+h1{margin:0;font-size:28px;font-weight:600;letter-spacing:-.02em}
+.prompt{margin:8px 0 0;font-size:15px;color:var(--sec);max-width:62ch}
+.meta{margin:16px 0 0;font:450 11px/1 ui-monospace,SFMono-Regular,Menlo,monospace;
+  letter-spacing:.08em;text-transform:uppercase;color:var(--ter)}
+.meta span+span::before{content:"·";margin:0 8px;color:var(--line)}
+/* Capped, not fluid: the screenshots are shot at a fixed 480px, so letting a
+   single column stretch to the full page would upscale and blur the one
+   artifact the whole page exists to show. */
+.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(360px,540px));gap:24px;margin-top:32px;justify-content:center}
+.col{background:var(--card);border-radius:10px;padding:20px;box-shadow:0 1px 2px rgba(0,0,0,.04),0 8px 24px rgba(0,0,0,.05)}
+.col>header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px}
+h2{margin:0;font-size:15px;font-weight:600}
+.col>header p{margin:2px 0 0;font-size:12px;color:var(--ter)}
+.score{font:600 13px/1 ui-monospace,Menlo,monospace;padding:5px 8px;border-radius:6px}
+.score.ok{color:var(--ok);background:#e8f3ed}.score.no{color:var(--no);background:#fbeceb}
+figure{margin:16px 0 0;background:var(--page);border:1px solid var(--line);border-radius:8px;overflow:hidden}
+img{display:block;width:100%}
+.blank{padding:48px 16px;text-align:center;font-size:13px;color:var(--ter)}
+.failure{margin:12px 0 0;font-size:13px;color:var(--no)}
+.warn{margin:12px 0 0;padding:8px 10px;border-radius:6px;background:#fdf6e7;font-size:12px;color:#7a5a12}
+dl{margin:0}dl>div{display:flex;align-items:baseline;justify-content:space-between}
+.floor{margin-top:20px;border-top:1px solid var(--line)}
+.floor>div{padding:7px 0;border-bottom:1px solid var(--line)}
+.floor dt{font-size:13px;color:var(--sec)}
+.v{font:600 13px/1 ui-monospace,Menlo,monospace}.ok{color:var(--ok)}.no{color:var(--no)}
+.notes{margin:10px 0 0;padding:0;list-style:none}
+.notes li{display:flex;gap:8px;align-items:baseline;padding:4px 0;font-size:12px;color:var(--ter)}
+.notes code{font:450 12px/1.4 ui-monospace,Menlo,monospace;color:var(--ink);background:var(--page);padding:1px 5px;border-radius:4px}
+.notes i{margin-left:auto;font-style:normal}
+.metrics{display:grid;grid-template-columns:repeat(4,1fr);gap:8px;margin-top:20px;padding-top:16px;border-top:1px solid var(--line)}
+.metrics>div{display:block}
+.metrics dt{font:450 10px/1 ui-monospace,Menlo,monospace;letter-spacing:.08em;text-transform:uppercase;color:var(--ter)}
+.metrics dd{margin:6px 0 0;font:450 15px/1 ui-monospace,Menlo,monospace;font-variant-numeric:tabular-nums}
+`;
+
+/** One self-contained page per run: the screenshots side by side, each under its
+ *  own floor verdicts and numbers. Images are inlined, so the file can be moved
+ *  or attached anywhere and still render. */
+export async function writePreview(input: {
+  runDir: string;
+  runId: string;
+  results: readonly CaseResult[];
+}): Promise<string> {
+  const first = input.results[0];
+  const columns = await Promise.all(input.results.map(async (result) => await column(input.runDir, result)));
+  const html = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>genbench · ${escape(first?.case ?? input.runId)}</title>
+<style>${CSS}</style></head><body><div class="wrap">
+<h1>${escape(first?.case ?? "run")}</h1>
+<p class="prompt">${escape(first?.prompt ?? "")}</p>
+<p class="meta"><span>${escape(input.runId)}</span><span>world ${escape(first?.world ?? "")}</span><span>${escape(first?.lane ?? "screen")} lane</span></p>
+<div class="grid">${columns.join("")}</div>
+</div></body></html>`;
+  const path = join(input.runDir, "preview.html");
+  await writeFile(path, html);
+  return path;
+}

--- a/genbench/src/run.ts
+++ b/genbench/src/run.ts
@@ -1,0 +1,226 @@
+import { createAnthropic } from "@ai-sdk/anthropic";
+import type { UIPayload } from "@vendoai/core";
+import { spawn } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runFloor, type FloorResult } from "./floor.js";
+import { meteredModel, MODEL_IDS, type Meter, type ModelAlias, type UsageTotals } from "./meter.js";
+import { openBrowser, treeHtml } from "./render.js";
+import { writePreview } from "./report.js";
+import { vendoDriver } from "./vendo.js";
+import { loadCases, loadWorld, worldForCase, type Case, type Lane, type World } from "./world.js";
+
+export type HarnessId = "vendo" | "diy" | "claude-code";
+
+export interface ContenderId {
+  readonly harness: HarnessId;
+  readonly model: ModelAlias;
+  /** Folder and report-column name, e.g. `vendo-sonnet`. */
+  readonly slug: string;
+}
+
+export interface RunRequest {
+  /** Already scoped to this case's data overrides. */
+  readonly world: World;
+  readonly testCase: Case;
+  /** Already metered — the run's only source of tokens, dollars and time. */
+  readonly meter: Meter;
+}
+
+export interface RunOutcome {
+  readonly artifact?: string;
+  /** What the product's own checks floor refuses to paint in the delivered
+   *  artifact. Empty means the bytes on disk are the screen that painted. */
+  readonly blocking: readonly string[];
+  /** The settled screen, as the product itself compiled it. */
+  readonly payload?: UIPayload;
+  readonly snapshots: ReadonlyArray<{ atMs: number; payload: UIPayload }>;
+  readonly firstRenderMs?: number;
+  readonly settledMs: number;
+  /** The contender's own failure sentence, when it has one. */
+  readonly failure?: string;
+}
+
+export interface Contender {
+  readonly harness: HarnessId;
+  run(request: RunRequest): Promise<RunOutcome>;
+}
+
+export interface CaseResult {
+  readonly run: string;
+  readonly contender: string;
+  readonly model: string;
+  readonly case: string;
+  readonly prompt: string;
+  readonly lane: Lane;
+  readonly floor: FloorResult;
+  readonly timing: { firstRenderMs?: number; settledMs: number };
+  readonly cost: { usage: UsageTotals; usd: number };
+  /** Nodes the writer generated as islands. They are client-only, so they are
+   *  blank in a server-rendered screenshot — a non-zero count means the shot
+   *  understates what the product actually built. */
+  readonly islands: number;
+  /** Kit charts on the screen. They are recharts-backed and measure their
+   *  container in the browser, so they leave an empty band in a server-rendered
+   *  shot for the same reason islands do. Counted so the gap is never silent. */
+  readonly clientOnly: number;
+  readonly world: string;
+  readonly failure?: string;
+}
+
+const DRIVERS: Partial<Record<HarnessId, () => Contender>> = { vendo: vendoDriver };
+
+interface Args {
+  readonly only?: string;
+  readonly lane: Lane;
+  readonly models: readonly ModelAlias[];
+}
+
+export function parseArgs(argv: readonly string[]): Args {
+  const rest = argv[0] === "run" ? argv.slice(1) : argv;
+  let only: string | undefined;
+  let lane: Lane = "screen";
+  let models: readonly ModelAlias[] = ["sonnet"];
+  let index = 0;
+  while (index < rest.length) {
+    const flag = rest[index];
+    const value = rest[index + 1];
+    if (value === undefined) throw new Error(`genbench: "${flag}" needs a value`);
+    if (flag === "--prompt") only = value;
+    else if (flag === "--lane") lane = asLane(value);
+    else if (flag === "--models") models = value.split(",").map(asAlias);
+    else throw new Error(`genbench: unexpected argument "${flag}"`);
+    index += 2;
+  }
+  return { ...(only === undefined ? {} : { only }), lane, models };
+}
+
+function asLane(value: string): Lane {
+  if (value !== "screen" && value !== "build") throw new Error(`genbench: unknown lane "${value}"`);
+  return value;
+}
+
+function asAlias(value: string): ModelAlias {
+  if (!Object.hasOwn(MODEL_IDS, value)) throw new Error(`genbench: unknown model "${value}"`);
+  return value as ModelAlias;
+}
+
+/** Every contender that has a driver today, in every requested model. The diy
+ *  and claude-code columns join here the day their drivers land. */
+export function contenders(models: readonly ModelAlias[]): readonly ContenderId[] {
+  return Object.keys(DRIVERS).flatMap((harness) =>
+    models.map((model) => ({ harness: harness as HarnessId, model, slug: `${harness}-${model}` })),
+  );
+}
+
+/** The recharts-backed Kit components (packages/ui/src/kit/charts/). */
+const CHARTS = new Set(["LineChart", "BarChart", "DonutChart", "Sparkline"]);
+
+const nodesOf = (payload: UIPayload | undefined): ReadonlyArray<{ source?: string; component?: string }> =>
+  (payload as { nodes?: Array<{ source?: string; component?: string }> } | undefined)?.nodes ?? [];
+
+const countIslands = (payload: UIPayload | undefined): number =>
+  nodesOf(payload).filter((node) => node.source === "generated").length;
+
+const countClientOnly = (payload: UIPayload | undefined): number =>
+  nodesOf(payload).filter((node) => node.component !== undefined && CHARTS.has(node.component)).length;
+
+async function main(argv: readonly string[]): Promise<number> {
+  const args = parseArgs(argv);
+  if (args.lane === "build") {
+    console.log("build lane: deferred");
+    return 0;
+  }
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (apiKey === undefined || apiKey === "") {
+    console.error("genbench: ANTHROPIC_API_KEY is not set");
+    return 1;
+  }
+
+  const root = dirname(dirname(fileURLToPath(import.meta.url)));
+  const world = await loadWorld(join(root, "world.json"));
+  const all = await loadCases(join(root, "cases.json"));
+  const cases = all.filter((entry) => entry.lane === args.lane && (args.only === undefined || entry.id === args.only));
+  if (cases.length === 0) throw new Error(`genbench: no case matches --prompt "${args.only ?? ""}"`);
+
+  const runId = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+  const runDir = join(root, "runs", runId);
+  const anthropic = createAnthropic({ apiKey });
+  const shooter = await openBrowser();
+  const results: CaseResult[] = [];
+
+  try {
+    for (const contender of contenders(args.models)) {
+      const driver = DRIVERS[contender.harness]!();
+      for (const testCase of cases) {
+        const modelId = MODEL_IDS[contender.model];
+        const meter = meteredModel(anthropic(modelId), modelId);
+        const scoped = worldForCase(world, testCase);
+        console.log(`· ${contender.slug} / ${testCase.id}`);
+
+        const outcome = await driver.run({ world: scoped, testCase, meter });
+        const html = outcome.payload === undefined ? undefined : treeHtml(outcome.payload, world.theme);
+        const shot = html === undefined ? undefined : await shooter.shot(html);
+        const floor = runFloor({
+          world: scoped,
+          artifact: outcome.artifact,
+          blocking: outcome.blocking,
+          payload: outcome.payload,
+          shot,
+        });
+
+        const caseDir = join(runDir, contender.slug, testCase.id);
+        await mkdir(caseDir, { recursive: true });
+        if (outcome.artifact !== undefined) await writeFile(join(caseDir, "artifact.vendo"), outcome.artifact);
+        if (shot !== undefined) await writeFile(join(caseDir, "screenshot.png"), shot.png);
+
+        const result: CaseResult = {
+          run: runId,
+          contender: contender.slug,
+          model: modelId,
+          case: testCase.id,
+          prompt: testCase.prompt,
+          lane: testCase.lane,
+          floor,
+          timing: {
+            ...(outcome.firstRenderMs === undefined ? {} : { firstRenderMs: outcome.firstRenderMs }),
+            settledMs: outcome.settledMs,
+          },
+          cost: { usage: meter.totals(), usd: meter.usd() },
+          islands: countIslands(outcome.payload),
+          clientOnly: countClientOnly(outcome.payload),
+          world: world.hash,
+          ...(outcome.failure === undefined ? {} : { failure: outcome.failure }),
+        };
+        await writeFile(join(caseDir, "result.json"), `${JSON.stringify(result, null, 2)}\n`);
+        results.push(result);
+        console.log(
+          `  floor ${[floor.delivered, floor.renders, floor.valid, floor.honestData.pass, floor.wiredActions.pass].filter(Boolean).length}/5` +
+            ` · ${result.timing.settledMs}ms · $${result.cost.usd.toFixed(4)}`,
+        );
+      }
+    }
+  } finally {
+    await shooter.close();
+  }
+
+  const preview = await writePreview({ runDir, runId, results });
+  console.log(preview);
+  if (process.platform === "darwin") spawn("open", [preview], { detached: true, stdio: "ignore" }).unref();
+  return results.every((result) => result.floor.pass) ? 0 : 1;
+}
+
+// Only when run as the command — importing this module from a test must not
+// start a benchmark.
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  main(process.argv.slice(2)).then(
+    (code) => {
+      process.exitCode = code;
+    },
+    (error: unknown) => {
+      console.error(error instanceof Error ? error.message : error);
+      process.exitCode = 1;
+    },
+  );
+}

--- a/genbench/src/vendo.test.ts
+++ b/genbench/src/vendo.test.ts
@@ -1,0 +1,107 @@
+/**
+ * The revision seam: the artifact this driver reports and the payload it reports
+ * beside it must describe the SAME save.
+ *
+ * A SEAM test — the real store, the real guard, the real apps runtime and the
+ * real render seam decide what lands and what paints. Only the MODEL is a
+ * double, so what is measured is the driver's reading of what actually happened.
+ */
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+import type { Meter } from "./meter.js";
+import { vendoDriver } from "./vendo.js";
+import { loadWorld, type Case, type World } from "./world.js";
+
+type StreamPart = Awaited<ReturnType<MockLanguageModelV3["doStream"]>>["stream"] extends ReadableStream<infer Part>
+  ? Part
+  : never;
+
+const ZERO_USAGE = {
+  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 0, text: 0, reasoning: 0 },
+} as const;
+
+const saveTurn = (content: string, id: string): StreamPart[] => [
+  { type: "tool-call", toolCallId: id, toolName: "save_app", input: JSON.stringify({ content }) },
+  { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "tool-calls", raw: undefined } },
+];
+
+const stopTurn = (): StreamPart[] => [
+  { type: "text-start", id: "t1" },
+  { type: "text-delta", id: "t1", delta: "done" },
+  { type: "text-end", id: "t1" },
+  { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "stop", raw: undefined } },
+];
+
+/** A meter over a model that replays the given turns, so the loop — not a real
+ *  model — decides what lands. */
+function scripted(turns: StreamPart[][]): Meter {
+  const remaining = turns.map((turn) => [...turn]);
+  let tick = 0;
+  const model = new MockLanguageModelV3({
+    doStream: async () => {
+      const chunks = remaining.shift();
+      if (chunks === undefined) throw new Error("scripted model exhausted");
+      return { stream: simulateReadableStream({ chunks }) };
+    },
+  });
+  return {
+    model,
+    elapsedMs: () => (tick += 1),
+    totals: () => ({ inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, calls: 0 }),
+    usd: () => 0,
+  };
+}
+
+/** One node under the root is the render seam's whole gate, so this is the
+ *  smallest document that legitimately paints. */
+const PAINTS = `<App name="Spending">
+  <Stack>
+    <Text text="This month" />
+  </Stack>
+</App>`;
+
+/** Compiles clean and reports NO issues, but leaves a childless root — the
+ *  compiler's degraded floor. The seam lands its bytes and paints nothing. */
+const LANDS_UNPAINTED = `<App name="Spending">
+</App>`;
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+let world: World;
+beforeAll(async () => {
+  world = await loadWorld(join(root, "world.json"));
+});
+
+const caseFor = (id: string): Case => ({ id, lane: "screen", prompt: "Show this month's spending", pass: [] });
+
+describe("the vendo driver reports one revision", () => {
+  it("does not report an earlier revision's view beside a final save that never painted", async () => {
+    const outcome = await vendoDriver().run({
+      world,
+      testCase: caseFor("stale-view"),
+      meter: scripted([saveTurn(PAINTS, "c1"), saveTurn(LANDS_UNPAINTED, "c2"), stopTurn()]),
+    });
+
+    // The earlier save really did paint — without this the case proves nothing.
+    expect(outcome.snapshots.length).toBeGreaterThan(0);
+    expect(outcome.artifact).toBe(LANDS_UNPAINTED);
+    expect(outcome.payload).toBeUndefined();
+    expect(outcome.blocking.join(" ")).toContain("render");
+    expect(outcome.failure).toBeDefined();
+  });
+
+  it("keeps the view when the final save is the one that painted", async () => {
+    const outcome = await vendoDriver().run({
+      world,
+      testCase: caseFor("settled-view"),
+      meter: scripted([saveTurn(PAINTS, "c1"), stopTurn()]),
+    });
+
+    expect(outcome.artifact).toBe(PAINTS);
+    expect(outcome.payload).toBeDefined();
+    expect(outcome.blocking).toEqual([]);
+    expect(outcome.failure).toBeUndefined();
+  });
+});

--- a/genbench/src/vendo.ts
+++ b/genbench/src/vendo.ts
@@ -37,8 +37,10 @@ export function vendoDriver(): Contender {
   return { harness: "vendo", run };
 }
 
-/** The product's own verdict on the bytes that landed: `block` findings are
- *  exactly what the render seam refuses to paint on. */
+/** The product's own verdict on the bytes that landed — the render seam's three
+ *  paint gates (`render-seam.ts`), in its order: it compiles, it has something
+ *  to draw, and it passes the checks floor. Anything here is a reason the seam
+ *  would have painted nothing. */
 async function blockingFindings(
   apps: ReturnType<typeof createApps>,
   appId: AppId,
@@ -50,6 +52,10 @@ async function blockingFindings(
   if (compiled.issues.some((issue) => issue.code === "compile-failed" || issue.code === "missing-app")) {
     return compiled.issues.map((issue) => `${issue.code}: ${issue.message}`);
   }
+  // The compiler is total, so clean issues are not a screen: a childless root is
+  // its degraded floor, and those bytes land without drawing anything.
+  const root = compiled.tree.nodes.find((node) => node.id === compiled.tree.root);
+  if ((root?.children?.length ?? 0) === 0) return ["nothing to render: the document compiled to an empty root"];
   const findings = await floor.check({ appId, compiled });
   return findings.filter((finding) => finding.severity === "block").map((finding) => finding.message);
 }
@@ -171,18 +177,27 @@ async function run(request: RunRequest): Promise<RunOutcome> {
     // older screen. Re-checking the saved bytes through the product's OWN floor
     // is the only way to tell a finished screen from a stale one.
     const blocking = artifact === undefined ? [] : await blockingFindings(apps, appId, artifact, ctx);
+    // `blocking` is the seam's own paint gate re-run on the bytes that landed, so
+    // a non-empty list means THIS revision never reached a screen and the last
+    // view belongs to an earlier save. Reporting that view here would grade a
+    // screenshot against an artifact it does not describe.
+    const painted = blocking.length === 0 ? snapshots.at(-1) : undefined;
+    let failure = outcome.kind === "assembled" ? undefined : outcome.why;
+    if (outcome.kind === "assembled" && blocking.length > 0) {
+      failure = "the delivered document does not render, so no screen is reported for it";
+    }
     return {
       ...(artifact === undefined ? {} : { artifact }),
       blocking,
       // The seam emits a skeleton first and the settled view last; the last one
       // is the screen a person is left looking at.
-      ...(snapshots.at(-1) === undefined ? {} : { payload: snapshots.at(-1)!.payload }),
+      ...(painted === undefined ? {} : { payload: painted.payload }),
       snapshots,
       // The seam only emits once a payload actually renders, so the first
       // snapshot IS first render.
       ...(snapshots[0] === undefined ? {} : { firstRenderMs: snapshots[0].atMs }),
       settledMs,
-      ...(outcome.kind === "assembled" ? {} : { failure: outcome.why }),
+      ...(failure === undefined ? {} : { failure }),
     };
   } finally {
     await store.close();

--- a/genbench/src/vendo.ts
+++ b/genbench/src/vendo.ts
@@ -1,0 +1,190 @@
+import { createApps, hostDesignBrief } from "@vendoai/apps";
+import type { AppId, Principal, RunContext, ToolRegistry, UIPayload, WorkspaceFs } from "@vendoai/core";
+import { createGuard } from "@vendoai/guard";
+import { screenAssembler } from "@vendoai/harnesses";
+import { createStore, workspaceStore } from "@vendoai/store";
+import { vendoVerbsRegistry } from "@vendoai/vendo";
+import type { Contender, RunOutcome, RunRequest } from "./run.js";
+import type { World } from "./world.js";
+
+const PRINCIPAL: Principal = { kind: "user", subject: "genbench" };
+
+/** The world's tools as a registry the guard can bind. Reads answer with the
+ *  case's canned rows; a write reports success without inventing a row, because
+ *  nothing in a screen run should depend on its output. */
+export function worldRegistry(world: World): ToolRegistry {
+  return {
+    async descriptors() {
+      return world.tools.map((tool) => tool.descriptor);
+    },
+    async execute(call) {
+      const tool = world.tools.find((candidate) => candidate.name === call.tool);
+      if (tool === undefined) {
+        return { status: "error", error: { code: "not-found", message: `no tool ${call.tool}` } };
+      }
+      return { status: "ok", output: (tool.data ?? { ok: true }) as never };
+    },
+  };
+}
+
+/** Identity plus the style rubric, in the one field the product already feeds to
+ *  `hostDesignBrief`. Every contender is handed this same text. */
+export function designRules(world: World): string {
+  return [`${world.app}.`, "", ...world.style.map((line) => `- ${line}`)].join("\n");
+}
+
+export function vendoDriver(): Contender {
+  return { harness: "vendo", run };
+}
+
+/** The product's own verdict on the bytes that landed: `block` findings are
+ *  exactly what the render seam refuses to paint on. */
+async function blockingFindings(
+  apps: ReturnType<typeof createApps>,
+  appId: AppId,
+  artifact: string,
+  ctx: RunContext,
+): Promise<string[]> {
+  const floor = apps.floor(ctx);
+  const compiled = await floor.compile(artifact);
+  if (compiled.issues.some((issue) => issue.code === "compile-failed" || issue.code === "missing-app")) {
+    return compiled.issues.map((issue) => `${issue.code}: ${issue.message}`);
+  }
+  const findings = await floor.check({ appId, compiled });
+  return findings.filter((finding) => finding.severity === "block").map((finding) => finding.message);
+}
+
+async function run(request: RunRequest): Promise<RunOutcome> {
+  const { world, testCase, meter } = request;
+  const appId = `app_${testCase.id.replaceAll("-", "_")}` as AppId;
+  const ctx: RunContext = {
+    principal: PRINCIPAL,
+    venue: "chat",
+    presence: "present",
+    sessionId: `genbench_${testCase.id}`,
+  };
+
+  // Private to this case: `memory://` skips the shared single-writer lock, so a
+  // distinct suffix keeps two cases from ever meeting.
+  const store = createStore({ dataDir: `memory://genbench-${testCase.id}` });
+  await store.ensureSchema();
+  // `autopilot` because this loop can show nobody an approval card — the screen
+  // agent runs non-interactive, so a parked call would just stall the run.
+  const guard = createGuard({ store, policy: "autopilot" });
+
+  // The assembly verbs (`validate`, `vendo_apps_*`) only exist once the runtime
+  // does, so the registry is spliced after `createApps` returns.
+  let appsTools: ToolRegistry | undefined;
+  const host = worldRegistry(world);
+  const combined: ToolRegistry = {
+    async descriptors(listCtx) {
+      return [...(await host.descriptors(listCtx)), ...(appsTools === undefined ? [] : await appsTools.descriptors(listCtx))];
+    },
+    async execute(call, callCtx) {
+      if (world.tools.some((tool) => tool.name === call.tool)) return host.execute(call, callCtx);
+      if (appsTools !== undefined) return appsTools.execute(call, callCtx);
+      return { status: "error", error: { code: "not-found", message: `no tool ${call.tool}` } };
+    },
+  };
+  const boundTools = guard.bind(combined);
+
+  const workspaces = workspaceStore(store);
+  const screenWorkspace = async (screenCtx: RunContext): Promise<WorkspaceFs> =>
+    await workspaces.open(screenCtx.principal);
+
+  const snapshots: Array<{ atMs: number; payload: UIPayload }> = [];
+  let appsRef: ReturnType<typeof createApps> | undefined;
+  const assembler = screenAssembler({
+    models: { default: meter.model },
+    tools: boundTools,
+    workspace: screenWorkspace,
+    // Wiring all three halves is what makes the emitted payload carry REAL
+    // resolved query data; unwired, the seam falls back to a bare compile and
+    // paints blank values.
+    render: (screenCtx) => ({
+      authoredApp: (input) => appsRef!.authored(input, screenCtx),
+      commitSource: (input) => appsRef!.commitSource(input, screenCtx),
+      floor: appsRef!.floor(screenCtx),
+    }),
+    design: () => hostDesignBrief({ theme: world.theme, designRules: designRules(world) }),
+  });
+
+  const apps = createApps({
+    store,
+    guard,
+    tools: boundTools,
+    catalog: [],
+    model: meter.model,
+    theme: world.theme,
+    designRules: designRules(world),
+    screen: assembler,
+  });
+  appsRef = apps;
+  // `apps.agentTools()` carries the data verbs, but `validate` is a vendo-verb
+  // and lives one layer up (packages/vendo/src/compose-apps.ts:452). Without it
+  // the screen agent's brief still tells it to "call `validate` on what you
+  // saved" and the call fails, so it spends its whole step budget blind. Same
+  // ports the product wires; the catalog is empty here, so the component search
+  // has nothing to find.
+  const verbs = vendoVerbsRegistry({
+    validate: (input, verbCtx) =>
+      apps.validate(
+        {
+          ...(input.appId === undefined ? {} : { appId: input.appId as AppId }),
+          ...(input.document === undefined ? {} : { document: input.document }),
+        },
+        verbCtx,
+      ),
+    searchComponents: async () => [],
+    schedule: async () => {
+      throw new Error("genbench: the screen lane arms no schedules");
+    },
+  });
+  const runtimeTools = apps.agentTools();
+  appsTools = {
+    async descriptors(listCtx) {
+      return [...(await runtimeTools.descriptors(listCtx)), ...(await verbs.descriptors(listCtx))];
+    },
+    async execute(call, callCtx) {
+      const fromVerbs = await verbs.descriptors(callCtx);
+      if (fromVerbs.some((descriptor) => descriptor.name === call.tool)) return verbs.execute(call, callCtx);
+      return runtimeTools.execute(call, callCtx);
+    },
+  };
+
+  try {
+    const outcome = await assembler.assemble(
+      {
+        appId,
+        request: testCase.prompt,
+        onView: (part) => snapshots.push({ atMs: meter.elapsedMs(), payload: part.payload }),
+      },
+      ctx,
+    );
+    const settledMs = meter.elapsedMs();
+    // A fresh handle: the assembler's own workspace has already committed, and
+    // reading through a new one is the honest read of what actually landed.
+    const fresh = await workspaces.open(PRINCIPAL);
+    const artifact = await fresh.readFile(`/user/apps/${appId}/app.vendo`).catch(() => undefined);
+    // The document on disk is not always the document that painted: the agent
+    // can save again after its last good view, and the seam silently keeps the
+    // older screen. Re-checking the saved bytes through the product's OWN floor
+    // is the only way to tell a finished screen from a stale one.
+    const blocking = artifact === undefined ? [] : await blockingFindings(apps, appId, artifact, ctx);
+    return {
+      ...(artifact === undefined ? {} : { artifact }),
+      blocking,
+      // The seam emits a skeleton first and the settled view last; the last one
+      // is the screen a person is left looking at.
+      ...(snapshots.at(-1) === undefined ? {} : { payload: snapshots.at(-1)!.payload }),
+      snapshots,
+      // The seam only emits once a payload actually renders, so the first
+      // snapshot IS first render.
+      ...(snapshots[0] === undefined ? {} : { firstRenderMs: snapshots[0].atMs }),
+      settledMs,
+      ...(outcome.kind === "assembled" ? {} : { failure: outcome.why }),
+    };
+  } finally {
+    await store.close();
+  }
+}

--- a/genbench/src/world.test.ts
+++ b/genbench/src/world.test.ts
@@ -1,0 +1,100 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { jsonSchemaFromExample, loadCases, loadWorld, riskOf, worldForCase } from "./world.js";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const worldPath = join(root, "world.json");
+const casesPath = join(root, "cases.json");
+
+describe("jsonSchemaFromExample", () => {
+  it("describes a row array by its first row, with every field required", () => {
+    expect(jsonSchemaFromExample([{ id: "tr_1", amount: 250, ok: true }])).toEqual({
+      type: "array",
+      items: {
+        type: "object",
+        properties: { id: { type: "string" }, amount: { type: "number" }, ok: { type: "boolean" } },
+        required: ["id", "amount", "ok"],
+        additionalProperties: false,
+      },
+    });
+  });
+
+  it("describes an empty array without inventing a row shape", () => {
+    expect(jsonSchemaFromExample([])).toEqual({ type: "array" });
+  });
+
+  it("recurses into nested objects", () => {
+    expect(jsonSchemaFromExample({ meta: { page: 1 } })).toEqual({
+      type: "object",
+      properties: {
+        meta: { type: "object", properties: { page: { type: "number" } }, required: ["page"], additionalProperties: false },
+      },
+      required: ["meta"],
+      additionalProperties: false,
+    });
+  });
+});
+
+describe("riskOf", () => {
+  it("grades a tool that returns rows as a read", () => {
+    expect(riskOf({ does: "x", data: [] })).toBe("read");
+  });
+
+  it("grades a tool that only takes arguments as a write", () => {
+    expect(riskOf({ does: "x", takes: { id: "string" } })).toBe("write");
+  });
+});
+
+describe("the authored world", () => {
+  it("derives an input schema from the takes map, not from example values", async () => {
+    const world = await loadWorld(worldPath);
+    const cancel = world.tools.find((tool) => tool.name === "cancel_transfer");
+    expect(cancel?.descriptor.inputSchema).toEqual({
+      type: "object",
+      properties: { id: { type: "string" } },
+      required: ["id"],
+      additionalProperties: false,
+    });
+  });
+
+  it("keeps every write tool off the read grade, so the loadout filter can drop it", async () => {
+    const world = await loadWorld(worldPath);
+    expect(world.tools.find((tool) => tool.name === "cancel_transfer")?.descriptor.risk).toBe("write");
+    expect(world.tools.find((tool) => tool.name === "list_transfers")?.descriptor.risk).toBe("read");
+  });
+});
+
+describe("worldForCase", () => {
+  it("replaces only the named tool's data and re-derives its output schema", async () => {
+    const world = await loadWorld(worldPath);
+    const cases = await loadCases(casesPath);
+    const empty = cases.find((entry) => entry.id === "no-pending-transfers")!;
+    const scoped = worldForCase(world, empty);
+
+    const transfers = scoped.tools.find((tool) => tool.name === "list_transfers")!;
+    expect(transfers.data).toEqual({ data: [] });
+    expect(transfers.descriptor.outputSchema).toEqual({
+      type: "object",
+      properties: { data: { type: "array" } },
+      required: ["data"],
+      additionalProperties: false,
+    });
+
+    const accounts = scoped.tools.find((tool) => tool.name === "list_accounts")!;
+    expect(accounts.data).toEqual(world.tools.find((tool) => tool.name === "list_accounts")!.data);
+  });
+
+  it("returns the world untouched when the case overrides nothing", async () => {
+    const world = await loadWorld(worldPath);
+    const cases = await loadCases(casesPath);
+    const plain = cases.find((entry) => entry.id === "spend-overview")!;
+    expect(worldForCase(world, plain)).toBe(world);
+  });
+});
+
+describe("loadCases", () => {
+  it("rejects a duplicate case id", async () => {
+    await expect(loadCases(join(root, "src", "fixtures", "duplicate-cases.json"))).rejects.toThrow(/duplicate case id/);
+  });
+});

--- a/genbench/src/world.ts
+++ b/genbench/src/world.ts
@@ -1,0 +1,148 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import type { JsonSchema, ToolDescriptor, VendoTheme } from "@vendoai/core";
+
+/** The world file, as authored. `theme` is a VendoTheme verbatim and is handed
+ *  to every contender unchanged. */
+export interface WorldFile {
+  readonly app: string;
+  readonly theme: VendoTheme;
+  readonly style: readonly string[];
+  readonly tools: Readonly<Record<string, WorldTool>>;
+}
+
+export interface WorldTool {
+  readonly does: string;
+  /** Parameter name -> JSON Schema type name. Every key is required. */
+  readonly takes?: Readonly<Record<string, string>>;
+  /** Example rows the tool returns. Their shape derives `outputSchema`, and
+   *  their literal values are the only numbers and dates a contender may show. */
+  readonly data?: unknown;
+}
+
+export interface DerivedTool {
+  readonly name: string;
+  readonly descriptor: ToolDescriptor;
+  readonly data: unknown;
+}
+
+export interface World {
+  readonly app: string;
+  readonly theme: VendoTheme;
+  readonly style: readonly string[];
+  readonly tools: readonly DerivedTool[];
+  /** sha256 of the authored file — two runs only compare if these match. */
+  readonly hash: string;
+}
+
+export type Lane = "screen" | "build";
+
+export interface Case {
+  readonly id: string;
+  readonly lane: Lane;
+  readonly prompt: string;
+  readonly pass: readonly string[];
+  /** Per-case tool-data override, e.g. an empty state. Replaces `data` for the
+   *  named tools only; every other tool keeps the world's data. */
+  readonly data?: Readonly<Record<string, unknown>>;
+}
+
+/** A tool that returns rows is a read; one that only takes arguments mutates.
+ *  This decides the assembly loadout — the screen agent admits host tools only
+ *  when `risk === "read"` (screen-agent.ts:449) — while every tool, read or not,
+ *  still reaches the writer's brief and so can back an action. */
+export function riskOf(tool: WorldTool): ToolDescriptor["risk"] {
+  return tool.data === undefined ? "write" : "read";
+}
+
+/** One example value in, one JSON Schema out. Arrays describe their first row;
+ *  every object key is required, because the world authors complete rows. */
+export function jsonSchemaFromExample(value: unknown): JsonSchema {
+  if (Array.isArray(value)) {
+    const first = value[0];
+    return first === undefined
+      ? { type: "array" }
+      : { type: "array", items: jsonSchemaFromExample(first) };
+  }
+  if (value === null) return { type: "null" };
+  if (typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>);
+    return {
+      type: "object",
+      properties: Object.fromEntries(entries.map(([k, v]) => [k, jsonSchemaFromExample(v)])),
+      required: entries.map(([k]) => k),
+      additionalProperties: false,
+    };
+  }
+  if (typeof value === "number") return { type: "number" };
+  if (typeof value === "boolean") return { type: "boolean" };
+  return { type: "string" };
+}
+
+function inputSchemaFrom(takes: WorldTool["takes"]): JsonSchema {
+  const entries = Object.entries(takes ?? {});
+  return {
+    type: "object",
+    properties: Object.fromEntries(entries.map(([name, type]) => [name, { type }])),
+    required: entries.map(([name]) => name),
+    additionalProperties: false,
+  };
+}
+
+function derive(name: string, tool: WorldTool, data: unknown): DerivedTool {
+  return {
+    name,
+    data,
+    descriptor: {
+      name,
+      description: tool.does,
+      inputSchema: inputSchemaFrom(tool.takes),
+      ...(data === undefined ? {} : { outputSchema: jsonSchemaFromExample(data) }),
+      risk: riskOf(tool),
+    },
+  };
+}
+
+export async function loadWorld(path: string): Promise<World> {
+  const source = await readFile(path, "utf8");
+  const file = JSON.parse(source) as WorldFile;
+  return {
+    app: file.app,
+    theme: file.theme,
+    style: file.style,
+    tools: Object.entries(file.tools).map(([name, tool]) => derive(name, tool, tool.data)),
+    hash: createHash("sha256").update(JSON.stringify(file)).digest("hex").slice(0, 16),
+  };
+}
+
+export async function loadCases(path: string): Promise<readonly Case[]> {
+  const cases = JSON.parse(await readFile(path, "utf8")) as Case[];
+  const seen = new Set<string>();
+  for (const testCase of cases) {
+    if (seen.has(testCase.id)) throw new Error(`genbench: duplicate case id "${testCase.id}"`);
+    seen.add(testCase.id);
+  }
+  return cases;
+}
+
+/** The world this case actually runs against: the named tools' data (and the
+ *  outputSchema derived from it) replaced, everything else untouched. */
+export function worldForCase(world: World, testCase: Case): World {
+  const overrides = testCase.data;
+  if (overrides === undefined) return world;
+  return {
+    ...world,
+    tools: world.tools.map((tool) => {
+      if (!Object.hasOwn(overrides, tool.name)) return tool;
+      const data = overrides[tool.name];
+      return {
+        ...tool,
+        data,
+        descriptor: {
+          ...tool.descriptor,
+          ...(data === undefined ? {} : { outputSchema: jsonSchemaFromExample(data) }),
+        },
+      };
+    }),
+  };
+}

--- a/genbench/tsconfig.json
+++ b/genbench/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "noEmit": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}

--- a/genbench/vitest.config.ts
+++ b/genbench/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // Worker caps live in config, not in the root `test` scripts: a cap in a
+    // command line only applies when someone types that command, so a bare
+    // `npx vitest`, an IDE runner and a debug run all escaped it. Env
+    // (VITEST_MIN/MAX_FORKS, VITEST_MIN/MAX_THREADS) still wins, so CI is
+    // unchanged. Both halves are required: vitest 2.1 defaults the min to the
+    // CPU count independently of the max, and a max-only cap makes Tinypool
+    // throw `minThreads and maxThreads must not conflict` before any test runs.
+    poolOptions: {
+      forks: { minForks: 1, maxForks: 2 },
+      threads: { minThreads: 1, maxThreads: 2 },
+    },
+    environment: "node",
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+  },
+});

--- a/genbench/world.json
+++ b/genbench/world.json
@@ -1,0 +1,66 @@
+{
+  "app": "Maple, a consumer banking app",
+  "theme": {
+    "colors": {
+      "background": "#FFFFFF",
+      "surface": "#FFFFFF",
+      "text": "#1A1A1A",
+      "muted": "#6B7280",
+      "accent": "#0F6B4E",
+      "accentText": "#FFFFFF",
+      "danger": "#C43E2F",
+      "border": "#E5E7EB"
+    },
+    "typography": { "fontFamily": "Inter, sans-serif", "baseSize": "14px" },
+    "radius": { "small": "8px", "medium": "8px", "large": "8px" },
+    "density": "comfortable",
+    "motion": "full"
+  },
+  "style": [
+    "uses the theme exactly: brand green, Inter, 8px corners — no invented colors or fonts",
+    "money always shows 2 decimals with currency symbol",
+    "destructive actions ask for confirmation",
+    "dates shown as 'Aug 1' style, never ISO"
+  ],
+  "tools": {
+    "list_accounts": {
+      "does": "Every account the signed-in customer holds. The rows are the `data` array. `balance` is in CENTS: 941220 is $9,412.20.",
+      "data": {
+        "data": [
+          { "id": "acc_checking", "name": "Maple Checking", "kind": "checking", "mask": "4471", "balance": 941220 },
+          { "id": "acc_savings", "name": "Maple Savings", "kind": "savings", "mask": "8820", "balance": 2814135 },
+          { "id": "acc_credit", "name": "Maple Credit", "kind": "credit", "mask": "0934", "balance": -128840 }
+        ]
+      }
+    },
+    "get_spending": {
+      "does": "This month's spending totalled per category, largest first. The rows are the `data` array. `amount` is in CENTS: 285000 is $2,850.00.",
+      "data": {
+        "data": [
+          { "category": "housing", "amount": 285000 },
+          { "category": "groceries", "amount": 61245 },
+          { "category": "dining", "amount": 43820 },
+          { "category": "subscriptions", "amount": 18441 },
+          { "category": "transport", "amount": 9675 },
+          { "category": "coffee", "amount": 6130 }
+        ]
+      }
+    },
+    "list_transfers": {
+      "does": "Recent transfers, newest first. The rows are the `data` array. `amount` is in CENTS: 25000 is $250.00.",
+      "takes": { "limit": "number" },
+      "data": {
+        "data": [
+          { "id": "tr_1", "to": "Alex Rivera", "amount": 25000, "date": "2026-08-01", "status": "pending" },
+          { "id": "tr_2", "to": "Jordan Avery", "amount": 6000, "date": "2026-07-30", "status": "pending" },
+          { "id": "tr_3", "to": "Mission St Property", "amount": 285000, "date": "2026-07-28", "status": "completed" },
+          { "id": "tr_4", "to": "Dana Whitfield", "amount": 12550, "date": "2026-07-24", "status": "completed" }
+        ]
+      }
+    },
+    "cancel_transfer": {
+      "does": "Cancel a pending transfer. The money is returned to the source account.",
+      "takes": { "id": "string" }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint:report": "node scripts/lint-report.mjs",
     "deps:guard": "node scripts/dependency-guard.mjs",
     "corpus": "pnpm --filter @vendoai/corpus-harness corpus",
+    "genbench": "pnpm --filter @vendoai/genbench genbench",
     "corpus:ui-parity": "pnpm --filter @vendoai/corpus-harness ui-parity",
     "test:coverage": "VITEST_MIN_FORKS=1 VITEST_MAX_FORKS=2 VITEST_MIN_THREADS=1 VITEST_MAX_THREADS=2 turbo run test:coverage --continue --concurrency=4",
     "changeset": "changeset",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -822,6 +822,67 @@ importers:
         specifier: ^5.6.0
         version: 5.9.3
 
+  genbench:
+    dependencies:
+      '@vendoai/apps':
+        specifier: workspace:*
+        version: link:../packages/apps
+      '@vendoai/core':
+        specifier: workspace:*
+        version: link:../packages/core
+      '@vendoai/guard':
+        specifier: workspace:*
+        version: link:../packages/guard
+      '@vendoai/harnesses':
+        specifier: workspace:*
+        version: link:../packages/harnesses
+      '@vendoai/store':
+        specifier: workspace:*
+        version: link:../packages/store
+      '@vendoai/ui':
+        specifier: workspace:*
+        version: link:../packages/ui
+      '@vendoai/vendo':
+        specifier: workspace:*
+        version: link:../packages/vendo
+    devDependencies:
+      '@ai-sdk/anthropic':
+        specifier: 3.0.12
+        version: 3.0.12(zod@4.4.3)
+      '@ai-sdk/provider':
+        specifier: 3.0.2
+        version: 3.0.2
+      '@playwright/test':
+        specifier: ^1.49.0
+        version: 1.61.1
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.0
+      '@types/react':
+        specifier: ^19.2.0
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.0
+        version: 19.2.3(@types/react@19.2.17)
+      ai:
+        specifier: 6.0.28
+        version: 6.0.28(zod@4.4.3)
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
+      tsx:
+        specifier: ^4.19.0
+        version: 4.23.0
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@22.20.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)
+
   packages/actions:
     dependencies:
       '@vendoai/core':
@@ -8552,12 +8613,25 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.5(zod@3.25.76)
       zod: 3.25.76
 
+  '@ai-sdk/anthropic@3.0.12(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.2
+      '@ai-sdk/provider-utils': 4.0.5(zod@4.4.3)
+      zod: 4.4.3
+
   '@ai-sdk/gateway@3.0.11(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.2
       '@ai-sdk/provider-utils': 4.0.4(zod@3.25.76)
       '@vercel/oidc': 3.1.0
       zod: 3.25.76
+
+  '@ai-sdk/gateway@3.0.11(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.2
+      '@ai-sdk/provider-utils': 4.0.4(zod@4.4.3)
+      '@vercel/oidc': 3.1.0
+      zod: 4.4.3
 
   '@ai-sdk/gateway@3.0.151(zod@3.25.76)':
     dependencies:
@@ -8620,6 +8694,13 @@ snapshots:
       eventsource-parser: 3.1.0
       zod: 3.25.76
 
+  '@ai-sdk/provider-utils@4.0.4(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.2
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
+
   '@ai-sdk/provider-utils@4.0.40(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.14
@@ -8633,6 +8714,13 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.1.0
       zod: 3.25.76
+
+  '@ai-sdk/provider-utils@4.0.5(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.2
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
 
   '@ai-sdk/provider-utils@5.0.7(zod@3.25.76)':
     dependencies:
@@ -11494,6 +11582,14 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.4(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
+
+  ai@6.0.28(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.11(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.2
+      '@ai-sdk/provider-utils': 4.0.4(zod@4.4.3)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.4.3
 
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
   - "corpus/harness"
   - "corpus/hosts/*"
   - "bench"
+  - "genbench"
 
 # pnpm 9 ran every dependency build script; pnpm 11 (strictDepBuilds) requires
 # an explicit allowlist. These five are the deps with build scripts in the


### PR DESCRIPTION
## What this is

`genbench` answers **"why not build this in-house?"** with numbers.

It runs hand-written prompts through contenders against one fictional banking
product (Maple) defined entirely in JSON, scores the results with deterministic
checks, and measures time and money. Every contender gets the same model, the
same tools, the same schemas and the same design brief — that equivalence *is*
the claim the benchmark rests on.

**Slice 1 is one case through the Vendo contender, end to end.** No diy driver,
no claude-code driver, no judge, no scoreboard — those are later slices. The
contender interface and the preview template already take N columns.

## How to run it

```sh
pnpm build                                   # genbench reads the built @vendoai/* dists
ANTHROPIC_API_KEY=… pnpm genbench run --prompt spend-overview
```

Writes `genbench/runs/<run>/<contender>/<case>/{artifact.vendo, screenshot.png, result.json}`
plus a `preview.html` that opens automatically on macOS.

Flags: `--prompt <id>`, `--models sonnet,opus,haiku`, `--lane build` (deferred).

## The pipeline is the product's own

Composed headless from the workspace packages — in-memory store, guard-bound
world registry whose handlers return the canned rows, the real `screenAssembler`,
the real `hostDesignBrief`. The screenshot is the payload the product itself
compiled, server-rendered through the Kit with the host theme as `--vendo-*`
variables.

Two things that composition needs and the `ladder.e2e` fixture does not:

- **`validate` is a vendo-verb**, not an `apps.agentTools()` verb. A composition
  that stops at `@vendoai/apps` leaves the screen agent calling a tool that
  isn't there — its own brief tells it to — and it burns the whole step budget
  blind. Wired from `@vendoai/vendo` exactly as `compose-apps.ts:452` does.
- **`valid` re-checks the saved bytes** through the product's own checks floor.
  "Something painted" is not the same as "the document on disk is the screen":
  the agent can save again after its last good view and the seam keeps the older
  one. Without this the floor scored an *empty* screen 5/5.

## The floor caught a real bug on the verification run

Money in `world.json` is **integer cents**, matching the Kit's `format="money"`
and the demo host. That is load-bearing, not cosmetic: authored in dollars, the
cents/dollars normalisation in the fabrication check lets a 100× scale error
slip through. Authored in cents, the same check catches it.

On the live run it did. The writer emitted
`value={sum(spending.data, "amount") / 100}` with `format="money"` — dividing
twice — so the screen read:

> **Total spent $42.43** — where the truth is **$4,243.11**

…while all six category rows underneath were correct. `honestData` flagged
exactly `$42.43` and nothing else. Zero false positives, one true positive, on
the highest-severity error a banking screen can make.

`floor 4/5 · 167224ms · $0.4105` · exit 1.

## Gates

| gate | result |
| --- | --- |
| `pnpm build` | pass (22/22) |
| `npx vitest run` in `genbench/` | pass — 28 tests, 2 files |
| `pnpm typecheck` | pass |
| `pnpm lint` | pass (4 pre-existing demo-bank warnings, untouched) |

The fabrication check has a proven-failing negative control: perturbing a world
number by one digit flips `honestData` to fail, and the 100× regression above is
pinned by its own test.

## Known limits

Charts and generated islands are client-only, so they leave an empty band in a
server-rendered shot. Every result counts them (`clientOnly`, `islands`) and the
preview says so out loud — the gap is never silent, but a shot containing a
chart does understate what the product built. Whether slice 2 needs a client
bundle for the screenshot path is a call for review.

## Screenshots

`*.png` is globally gitignored (`.gitignore:26`) and CLAUDE.md forbids
committing verification artifacts, so the images are not attached here. They are
on disk in the run folder:

- Maple screen: `genbench/runs/2026-08-08T08-44-50/vendo-sonnet/spend-overview/screenshot.png`
- Preview page: `genbench/runs/2026-08-08T08-44-50/preview.html`

Opening the preview is a one-liner: `open genbench/runs/2026-08-08T08-44-50/preview.html`.

## Base branch

The contract named `yousefh409/benchmark` as the base, but that branch no longer
exists on the remote and its content is already in `main` (this branch descends
from it). Targeting `main`; retarget if that's wrong.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@vendoai/genbench` slice 1 to run one case through the real Vendo screen-assembly pipeline, score it with five checks, screenshot it, and show a single-page preview with timing and cost. Also fixes the revision seam so the screenshot and checks reflect the same saved artifact.

- **New Features**
  - CLI: `pnpm genbench run --prompt spend-overview` (requires `ANTHROPIC_API_KEY`); writes artifacts under `genbench/runs/<run>/<contender>/<case>/` and a self-contained `preview.html`.
  - Uses the product pipeline headless: in-memory store + guard, real `screenAssembler` and `hostDesignBrief`; wires `validate` from `@vendoai/vendo`; re-checks the saved bytes through the product floor.
  - Five checks: delivered, renders, valid (blocking findings), honestData (only literals/derivables from tool data), wiredActions (tools exist and args fit schema).
  - Metering wrapper for `claude-opus-5`, `claude-sonnet-5`, `claude-haiku-4-5-20251001`; reports tokens, time, and USD; sets a safe `maxOutputTokens` when unset.
  - Server-rendered screenshots via Playwright and the Kit; counts client-only islands/charts so gaps are called out in the preview.
  - World authored in `genbench/world.json` (Maple; money in integer cents); cases in `genbench/cases.json`; tests for the floor and world utils; `.gitignore` ignores `genbench/runs/`; workspace script `pnpm genbench`.
  - Revision seam: only report a screen for the saved artifact if it compiles, has something to draw, and passes the checks floor; if the delivered bytes don’t render, drop earlier views and record the reason. Seam test added to prevent stale-view grading.

- **Dependencies**
  - Adds `@ai-sdk/anthropic`, `ai`, `@playwright/test`, `react`, `react-dom`, `vitest`, `tsx`, `typescript`; new workspace package `@vendoai/genbench`.

<sup>Written for commit 0146c9ce3594d7ececb3ae30123a23976eef59c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

