### PR TITLE
feat(genbench): slice 2 — the page is real, and pressing things is how "wired" is decided

### DIFF
--- a/genbench/README.md
+++ b/genbench/README.md
@@ -20,11 +20,14 @@ Each case writes `runs/<run>/<contender>/<case>/`:
 | file | what it is |
 | --- | --- |
 | `artifact.vendo` | the document the contender actually saved |
-| `screenshot.png` | that document rendered through the product's own compile + the Kit |
-| `result.json` | the five floor verdicts, timings, tokens and dollars |
+| `page.html` | the real screen: a root, the payload, and the product's own renderer bundled in. This is the only way pixels are made — for the DIY and claude-code contenders it IS the artifact |
+| `screenshot.png` | that page, shot once it has settled |
+| `result.json` | the five floor verdicts, the click trace, console errors, timings, tokens and dollars |
 
-and one `runs/<run>/preview.html` — the screenshots side by side under their
-verdicts and numbers. It opens automatically on macOS.
+and one `runs/<run>/preview.html` — every contender's live page side by side,
+scrollable, under its verdicts and numbers, with the judge's screenshot demoted
+to a thumbnail. It opens automatically on macOS. A case that outruns its
+five-minute budget is recorded `failure: "timeout"` and the run moves on.
 
 Flags: `--prompt <id>` for one case, `--models sonnet,opus,haiku`,
 `--lane build` (deferred).
@@ -51,19 +54,25 @@ a pinned judge will grade in a later slice.
 Five deterministic checks, no model involved:
 
 - **delivered** — an artifact came back at all
-- **renders** — the compiled screen painted at least one element
+- **renders** — the page mounted and took up space, with nothing on the console
 - **valid** — the product's *own* checks floor blocks nothing in the saved bytes.
   Not the same as "something painted": the agent can save again after its last
   good view, and the seam keeps the older screen
 - **honestData** — every number and date on screen is a value a tool returned,
   or a sum, count, min, max or mean of one numeric field across one tool's rows.
   Nothing else is allowed
-- **wiredActions** — every tool the tree names exists, and its arguments fit the
-  derived input schema
+- **wiredActions** — the probe pressed every control on the page and every call
+  that fired names a real tool with schema-valid arguments. A control that fires
+  nothing fails: naming a tool in a document is not being wired to it, which is
+  the difference `src/probe.test.ts` exists to keep honest
 
 ## Known limits
 
-Charts and generated islands are client-only, so they leave an empty band in a
-server-rendered screenshot. Every result counts them (`clientOnly`, `islands`)
-and the preview says so out loud, so the gap is never silent — but a shot with a
-chart in it does understate what the product built.
+The page loads no webfont — a shot must not depend on what a CDN felt like
+serving — so `world.json`'s `Inter` resolves to the system sans stack. Every
+contender is shot in the same face, which is what comparability needs; the
+brand's own typeface is not what is being measured.
+
+The probe presses one control per fresh page, so a screen with many controls
+costs many reloads. Multi-step flows are only followed one step past a
+`[role=dialog]` confirmation.

--- a/genbench/cases.json
+++ b/genbench/cases.json
@@ -11,6 +11,17 @@
     ]
   },
   {
+    "id": "spend-chart",
+    "lane": "screen",
+    "prompt": "Chart my spending by category this month, largest first.",
+    "pass": [
+      "draws a chart of the categories rather than only listing them",
+      "every category the tool returned is on the chart",
+      "each category's amount matches the tool's number exactly",
+      "housing reads as the largest category"
+    ]
+  },
+  {
     "id": "pending-transfers",
     "lane": "screen",
     "prompt": "Show my pending transfers and give me a way to cancel one.",

--- a/genbench/package.json
+++ b/genbench/package.json
@@ -29,6 +29,7 @@
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
     "ai": "6.0.28",
+    "esbuild": "^0.25.12",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "tsx": "^4.19.0",

--- a/genbench/src/floor.test.ts
+++ b/genbench/src/floor.test.ts
@@ -1,8 +1,8 @@
-import type { UIPayload } from "@vendoai/core";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { beforeAll, describe, expect, it } from "vitest";
-import { bindingsFromPayload, buildIndex, honestData, wiredActions, type DataIndex } from "./floor.js";
+import { buildIndex, honestData, wiredActions, type DataIndex } from "./floor.js";
+import type { Probed } from "./probe.js";
 import { loadWorld, type World } from "./world.js";
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
@@ -89,64 +89,44 @@ describe("honestData — the negative control", () => {
   });
 });
 
-describe("bindingsFromPayload", () => {
-  const payload = {
-    formatVersion: "vendo-genui/v2",
-    root: "a",
-    queries: [{ name: "transfers", tool: "list_transfers", input: { limit: 10 } }],
-    nodes: [
-      { id: "a", component: "Stack", children: ["b"] },
-      { id: "b", component: "Button", props: { onPress: { action: "cancel_transfer", payload: { id: "tr_1" } } } },
-    ],
-  } as unknown as UIPayload;
-
-  it("finds both the tree's queries and the nodes' action props", () => {
-    expect(bindingsFromPayload(payload)).toEqual([
-      { tool: "list_transfers", args: { limit: 10 }, where: "query transfers" },
-      { tool: "cancel_transfer", args: { id: "tr_1" }, where: "node b" },
-    ]);
-  });
-
-  it("ignores a host component's own fn reference, which names no tool", () => {
-    const withFn = {
-      formatVersion: "vendo-genui/v2",
-      root: "a",
-      nodes: [{ id: "a", component: "Card", props: { onPress: { action: "fn:refresh" } } }],
-    } as unknown as UIPayload;
-    expect(bindingsFromPayload(withFn)).toEqual([]);
-  });
-});
-
 describe("wiredActions", () => {
-  const at = (tool: string, args: unknown) => [{ tool, args, where: "node b" }];
+  const pressed = (name: string, args: unknown): Probed[] => [
+    { label: "Cancel", confirmed: false, calls: [{ name, args }] },
+  ];
 
   it("passes a real tool called with the arguments it declares", () => {
-    expect(wiredActions(at("cancel_transfer", { id: "tr_1" }), world).pass).toBe(true);
+    expect(wiredActions(pressed("cancel_transfer", { id: "tr_1" }), world).pass).toBe(true);
+  });
+
+  it("fails a control that was pressed and called nothing", () => {
+    const result = wiredActions([{ label: "Cancel", confirmed: false, calls: [] }], world);
+    expect(result.pass).toBe(false);
+    expect(result.bindings[0]).toMatchObject({ where: "Cancel", known: false, why: "pressing it called nothing" });
   });
 
   it("fails a tool the world does not have", () => {
-    const result = wiredActions(at("delete_account", { id: "x" }), world);
+    const result = wiredActions(pressed("delete_account", { id: "x" }), world);
     expect(result.pass).toBe(false);
     expect(result.bindings[0]).toMatchObject({ known: false, why: 'no tool named "delete_account"' });
   });
 
   it("fails a missing required argument", () => {
-    const result = wiredActions(at("cancel_transfer", {}), world);
+    const result = wiredActions(pressed("cancel_transfer", {}), world);
     expect(result.pass).toBe(false);
     expect(result.bindings[0]).toMatchObject({ known: true, argsValid: false, why: 'missing required argument "id"' });
   });
 
   it("fails an argument the tool does not declare", () => {
-    const result = wiredActions(at("cancel_transfer", { id: "tr_1", force: true }), world);
+    const result = wiredActions(pressed("cancel_transfer", { id: "tr_1", force: true }), world);
     expect(result.bindings[0]).toMatchObject({ argsValid: false, why: 'unknown argument "force"' });
   });
 
   it("fails an argument of the wrong type", () => {
-    const result = wiredActions(at("list_transfers", { limit: "10" }), world);
+    const result = wiredActions(pressed("list_transfers", { limit: "10" }), world);
     expect(result.bindings[0]).toMatchObject({ argsValid: false, why: 'argument "limit" should be a number' });
   });
 
-  it("passes vacuously when a screen binds nothing", () => {
+  it("passes vacuously when a screen has nothing to press", () => {
     expect(wiredActions([], world)).toEqual({ pass: true, bindings: [] });
   });
 });

--- a/genbench/src/floor.ts
+++ b/genbench/src/floor.ts
@@ -1,4 +1,4 @@
-import type { Json, UIPayload } from "@vendoai/core";
+import type { Probed } from "./probe.js";
 import type { Shot } from "./render.js";
 import type { World } from "./world.js";
 
@@ -14,10 +14,12 @@ export interface HonestDataResult {
 }
 
 export interface Binding {
-  readonly tool: string;
+  /** The control that was pressed. */
+  readonly where: string;
+  /** Absent when the press fired nothing at all. */
+  readonly tool?: string;
   readonly known: boolean;
   readonly argsValid: boolean;
-  readonly where: string;
   readonly why?: string;
 }
 
@@ -160,40 +162,6 @@ export function honestData(visibleText: string, index: DataIndex): HonestDataRes
 
 // -------------------------------------------------------------- wired actions
 
-interface RawBinding {
-  readonly tool: string;
-  readonly args: unknown;
-  readonly where: string;
-}
-
-/** Walk the compiled payload for everything that names a tool: the tree's
- *  queries, and every `{ action, payload }` prop on any node, at any depth. */
-export function bindingsFromPayload(payload: UIPayload): readonly RawBinding[] {
-  const found: RawBinding[] = [];
-  const queries = (payload as { queries?: Array<{ name: string; tool: string; input?: Json }> }).queries ?? [];
-  for (const query of queries) {
-    found.push({ tool: query.tool, args: query.input ?? {}, where: `query ${query.name}` });
-  }
-
-  const collect = (value: unknown, where: string): void => {
-    if (Array.isArray(value)) {
-      for (const item of value) collect(item, where);
-      return;
-    }
-    if (typeof value !== "object" || value === null) return;
-    const record = value as Record<string, unknown>;
-    // `fn:` names a host component's own function, never a tool, so it is not a
-    // tool binding to grade. No host components are registered in this bench.
-    if (typeof record.action === "string" && !record.action.startsWith("fn:")) {
-      found.push({ tool: record.action, args: record.payload ?? {}, where });
-    }
-    for (const item of Object.values(record)) collect(item, where);
-  };
-  const nodes = (payload as { nodes?: Array<{ id: string; props?: unknown }> }).nodes ?? [];
-  for (const node of nodes) collect(node.props, `node ${node.id}`);
-  return found;
-}
-
 /** The derived input schemas are all `{type:"object", properties, required,
  *  additionalProperties:false}`, so validating them takes four rules, not a
  *  schema library. */
@@ -213,16 +181,31 @@ function checkArgs(args: unknown, schema: Record<string, unknown>): string | und
   return undefined;
 }
 
-export function wiredActions(bindings: readonly RawBinding[], world: World): WiredActionsResult {
-  const graded = bindings.map((binding): Binding => {
-    const tool = world.tools.find((candidate) => candidate.name === binding.tool);
-    if (tool === undefined) {
-      return { ...binding, known: false, argsValid: false, why: `no tool named "${binding.tool}"` };
+/** What the probe actually saw fire, graded against the world. A control that was
+ *  pressed and asked for nothing is the failure this replaced a static scan to
+ *  catch: a screen can name a tool in its document and still be dead in a
+ *  browser. A screen with nothing to press passes vacuously. */
+export function wiredActions(trace: readonly Probed[], world: World): WiredActionsResult {
+  const bindings = trace.flatMap((candidate): Binding[] => {
+    if (candidate.calls.length === 0) {
+      return [{ where: candidate.label, known: false, argsValid: false, why: "pressing it called nothing" }];
     }
-    const why = checkArgs(binding.args, tool.descriptor.inputSchema as Record<string, unknown>);
-    return { tool: binding.tool, where: binding.where, known: true, argsValid: why === undefined, ...(why === undefined ? {} : { why }) };
+    return candidate.calls.map((call): Binding => {
+      const tool = world.tools.find((known) => known.name === call.name);
+      if (tool === undefined) {
+        return { where: candidate.label, tool: call.name, known: false, argsValid: false, why: `no tool named "${call.name}"` };
+      }
+      const why = checkArgs(call.args, tool.descriptor.inputSchema as Record<string, unknown>);
+      return {
+        where: candidate.label,
+        tool: call.name,
+        known: true,
+        argsValid: why === undefined,
+        ...(why === undefined ? {} : { why }),
+      };
+    });
   });
-  return { pass: graded.every((binding) => binding.known && binding.argsValid), bindings: graded };
+  return { pass: bindings.every((binding) => binding.known && binding.argsValid), bindings };
 }
 
 // ---------------------------------------------------------------------- floor
@@ -232,17 +215,14 @@ export function runFloor(input: {
   artifact: string | undefined;
   /** What the product's own checks floor blocks in the delivered artifact. */
   blocking: readonly string[];
-  payload: UIPayload | undefined;
+  trace: readonly Probed[];
   shot: Shot | undefined;
 }): FloorResult {
   const delivered = input.artifact !== undefined && input.artifact.trim() !== "";
   const renders = input.shot?.renders === true;
   const valid = delivered && input.blocking.length === 0;
   const data = honestData(input.shot?.visibleText ?? "", buildIndex(input.world));
-  const actions =
-    input.payload === undefined
-      ? { pass: false, bindings: [] }
-      : wiredActions(bindingsFromPayload(input.payload), input.world);
+  const actions = wiredActions(input.trace, input.world);
   return {
     delivered,
     renders,

--- a/genbench/src/mount.tsx
+++ b/genbench/src/mount.tsx
@@ -1,0 +1,71 @@
+/**
+ * The browser half of a benchmark page: the PRODUCT's own renderer, mounted the
+ * way a host mounts it, with one recorder standing in for the host's tools.
+ * Bundled once per run by `render.ts` and inlined into every page.
+ */
+import {
+  defaultVendoTheme,
+  resolveTheme,
+  themeCssVariables,
+  type Json,
+  type ToolOutcome,
+  type UIPayload,
+  type VendoTheme,
+} from "@vendoai/core";
+import { applyThemeVars } from "@vendoai/ui/kit";
+import { PayloadView } from "@vendoai/ui/tree";
+import { useEffect, type JSX } from "react";
+import { createRoot } from "react-dom/client";
+
+declare global {
+  interface Window {
+    /** The one seam every contender's page answers through — the renderer's own
+     *  action dispatch is wired to it below, and a hand-written page calls it
+     *  directly. It answers with the case's canned rows, so a runtime refetch
+     *  resolves instead of hanging. */
+    vendo: {
+      calls: Array<{ name: string; args: Json }>;
+      callTool(name: string, args: Json): ToolOutcome;
+    };
+    /** Set once the tree has committed and had two frames to draw. */
+    __settled?: boolean;
+  }
+}
+
+const read = <T,>(id: string): T => JSON.parse(document.getElementById(id)!.textContent!) as T;
+
+const tools = read<Record<string, Json>>("tools");
+window.vendo = {
+  calls: [],
+  callTool(name, args) {
+    window.vendo.calls.push({ name, args });
+    return Object.hasOwn(tools, name)
+      ? { status: "ok", output: tools[name]! }
+      : { status: "error", error: { code: "not-found", message: `no tool ${name}` } };
+  },
+};
+
+applyThemeVars(themeCssVariables(resolveTheme(defaultVendoTheme, read<VendoTheme>("theme"))));
+const payload = read<UIPayload>("payload");
+
+function Screen(): JSX.Element {
+  // Two frames after the commit: the Kit's charts size themselves off a
+  // ResizeObserver, so the frame that mounts one is never the frame that draws it.
+  useEffect(() => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        window.__settled = true;
+      });
+    });
+  }, []);
+  return (
+    <PayloadView
+      payload={payload}
+      components={{}}
+      data={(payload as { data?: Record<string, Json> }).data}
+      onAction={async ({ action, payload: args }) => window.vendo.callTool(action, args ?? {})}
+    />
+  );
+}
+
+createRoot(document.getElementById("root")!).render(<Screen />);

--- a/genbench/src/probe.test.ts
+++ b/genbench/src/probe.test.ts
@@ -1,0 +1,69 @@
+/**
+ * The negative control for `wiredActions`.
+ *
+ * A screen that names a tool in its document and a screen that actually calls one
+ * are the same screen to any static scan — the whole reason this check moved into
+ * a browser. So the pair below differs by one thing only: whether the button's
+ * handler is attached. If the dead one ever passes, this check is measuring
+ * nothing.
+ *
+ * A real browser, the real probe, the real grader — no doubles.
+ */
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { wiredActions } from "./floor.js";
+import { probe } from "./probe.js";
+import { openBrowser, type Shooter } from "./render.js";
+import { loadWorld, type World } from "./world.js";
+
+/** The recorder every real benchmark page carries, in its smallest honest form.
+ *  `page.html` gets it from the bundled mount; this fixture declares it inline so
+ *  the control is a page and not a mock. */
+const fixture = (handler: string): string => `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>control</title></head><body>
+<div id="root"><button id="go">Cancel transfer</button></div>
+<script>
+  window.vendo = { calls: [], callTool(name, args) { window.vendo.calls.push({ name, args }); return { status: "ok", output: null }; } };
+  ${handler}
+  window.__settled = true;
+</script>
+</body></html>`;
+
+const WIRED = fixture(`document.getElementById("go").addEventListener("click", () =>
+  window.vendo.callTool("cancel_transfer", { id: "tr_1" }));`);
+
+/** The dead one: the handler is never attached. It looks identical. */
+const DEAD = fixture("");
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+let world: World;
+let shooter: Shooter;
+beforeAll(async () => {
+  world = await loadWorld(join(root, "world.json"));
+  shooter = await openBrowser();
+}, 60_000);
+afterAll(async () => await shooter.close());
+
+const traceOf = async (html: string): ReturnType<typeof probe> => {
+  const visit = await shooter.visit(html);
+  try {
+    return await probe(visit);
+  } finally {
+    await visit.close();
+  }
+};
+
+describe("the click probe grades what a browser actually does", () => {
+  it("passes a button whose handler calls a real tool with valid arguments", async () => {
+    const trace = await traceOf(WIRED);
+    expect(trace).toEqual([{ label: "Cancel transfer", confirmed: false, calls: [{ name: "cancel_transfer", args: { id: "tr_1" } }] }]);
+    expect(wiredActions(trace, world).pass).toBe(true);
+  });
+
+  it("fails the same button with no handler attached", async () => {
+    const trace = await traceOf(DEAD);
+    expect(trace).toEqual([{ label: "Cancel transfer", confirmed: false, calls: [] }]);
+    expect(wiredActions(trace, world).pass).toBe(false);
+  });
+});

--- a/genbench/src/probe.ts
+++ b/genbench/src/probe.ts
@@ -1,0 +1,58 @@
+import type { Visit } from "./render.js";
+
+/**
+ * The click probe — identical for every contender, because the page is the only
+ * thing that differs.
+ *
+ * It presses everything a person could press and records what each press asks
+ * the host to do, through the one recorder every page answers with
+ * (`window.vendo.callTool`). A screen that LOOKS wired and a screen that IS
+ * wired are indistinguishable from the artifact alone; they are not
+ * indistinguishable here.
+ */
+
+/** Everything a person can press. A disabled control is not actionable, so it is
+ *  not a candidate — grading it would fail a screen for being careful. */
+const ACTIONABLE = "button:not([disabled]), [role=button]:not([aria-disabled=true]), a[href]";
+
+/** A press that never lands says "fired nothing", which is the verdict either
+ *  way; this only stops one stuck control from spending the case's whole budget. */
+const CLICK_MS = 5_000;
+
+export interface Fired {
+  readonly name: string;
+  readonly args: unknown;
+}
+
+export interface Probed {
+  readonly label: string;
+  /** A `[role=dialog]` stood between the press and the call, and was confirmed. */
+  readonly confirmed: boolean;
+  readonly calls: readonly Fired[];
+}
+
+export async function probe(visit: Visit): Promise<Probed[]> {
+  const trace: Probed[] = [];
+  const candidates = await visit.page.locator(ACTIONABLE).count();
+  for (let index = 0; index < candidates; index += 1) {
+    // The shot was taken on a page nobody had touched yet, so the first candidate
+    // already has its fresh screen and only the later ones need one.
+    if (index > 0) await visit.reset();
+    const element = visit.page.locator(ACTIONABLE).nth(index);
+    const text = await element.innerText().catch(() => "");
+    const aria = await element.getAttribute("aria-label").catch(() => null);
+    await element.click({ timeout: CLICK_MS }).catch(() => undefined);
+
+    const dialog = visit.page.locator("[role=dialog]").first();
+    const confirmed = await dialog.isVisible().catch(() => false);
+    if (confirmed) {
+      // The primary action sits last in a confirmation; everything before it is a
+      // way out, and taking one of those would record the press as firing nothing.
+      await dialog.locator(ACTIONABLE).last().click({ timeout: CLICK_MS }).catch(() => undefined);
+    }
+
+    const calls = await visit.page.evaluate(() => window.vendo.calls);
+    trace.push({ label: (text || aria || "").trim() || `control ${index + 1}`, confirmed, calls });
+  }
+  return trace;
+}

--- a/genbench/src/render.ts
+++ b/genbench/src/render.ts
@@ -1,45 +1,58 @@
-import { chromium, type Browser } from "@playwright/test";
-import {
-  defaultVendoTheme,
-  resolveTheme,
-  themeCssVariables,
-  type Json,
-  type ToolOutcome,
-  type UIPayload,
-  type VendoTheme,
-} from "@vendoai/core";
-import { PayloadView } from "@vendoai/ui/tree";
-import { createElement } from "react";
-import { renderToString } from "react-dom/server";
+import { chromium, type Browser, type Page } from "@playwright/test";
+import type { Json, UIPayload } from "@vendoai/core";
+import { build } from "esbuild";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { World } from "./world.js";
 
 /** A banking app's column. Every contender is shot at the same size, so the
  *  screenshots stack side by side in the report. */
 const VIEWPORT = { width: 480, height: 900 } as const;
 
-const noAction = async (): Promise<ToolOutcome> => ({ status: "ok", output: null });
+/** How long a page gets to commit and draw before the shot is taken anyway. */
+const SETTLE_MS = 30_000;
 
-/** Payload -> a standalone document. The Kit styles entirely through
- *  `var(--vendo-*)` with baked-in fallbacks and ships no stylesheet, so the
- *  host theme arrives as the one `:root` block below and nothing else is
- *  needed to paint it in the host's brand. */
-export function treeHtml(payload: UIPayload, theme: VendoTheme): string {
-  const body = renderToString(
-    createElement(PayloadView, {
-      payload,
-      components: {},
-      data: (payload as { data?: Record<string, Json> }).data,
-      onAction: noAction,
-    }),
-  );
-  const vars = Object.entries(themeCssVariables(resolveTheme(defaultVendoTheme, theme)))
-    .map(([name, value]) => `${name}: ${value};`)
-    .join("");
+/** `mount.tsx` as one browser script, built once for the whole run. The page has
+ *  no network, so the bundle is inlined and nothing about a shot depends on what
+ *  a CDN felt like serving. */
+export async function bundleMount(): Promise<string> {
+  const result = await build({
+    entryPoints: [join(dirname(fileURLToPath(import.meta.url)), "mount.tsx")],
+    bundle: true,
+    format: "iife",
+    platform: "browser",
+    jsx: "automatic",
+    minify: true,
+    write: false,
+    define: { "process.env.NODE_ENV": '"production"' },
+  });
+  return result.outputFiles[0]!.text;
+}
+
+const jsonScript = (id: string, value: unknown): string =>
+  `<script type="application/json" id="${id}">${JSON.stringify(value).replaceAll("<", "\\u003c")}</script>`;
+
+/**
+ * The page a contender is judged on: a root to mount into, the case's data, and
+ * the script that paints it. The theme rides as JSON and is applied through the
+ * product's own `applyThemeVars`, so nothing here re-implements theming.
+ *
+ * The later DIY and claude-code contenders write this file themselves — the page
+ * IS their artifact, and they bypass the compile entirely. Everything a page can
+ * rely on is therefore in the markup below and nowhere else.
+ */
+export function pageHtml(payload: UIPayload, world: World, bundle: string): string {
+  const tools = Object.fromEntries(world.tools.map((tool) => [tool.name, (tool.data ?? { ok: true }) as Json]));
   return `<!doctype html>
-<html><head><meta charset="utf-8"><title>genbench</title><style>
-:root{${vars}}
-html,body{margin:0;padding:0;background:var(--vendo-color-background);}
-.vendo-root{padding:20px;font-family:var(--vendo-font-family);font-size:var(--vendo-font-size);color:var(--vendo-color-text);}
-</style></head><body><div class="vendo-root">${body}</div></body></html>`;
+<html lang="en"><head><meta charset="utf-8"><title>genbench</title><style>
+html,body{margin:0;padding:0;background:var(--vendo-color-background,#fff);}
+#root{padding:20px;}
+</style></head><body><div id="root"></div>
+${jsonScript("payload", payload)}
+${jsonScript("theme", world.theme)}
+${jsonScript("tools", tools)}
+<script>${bundle.replaceAll("</script", "<\\/script")}</script>
+</body></html>`;
 }
 
 export interface Shot {
@@ -47,12 +60,22 @@ export interface Shot {
   /** `document.body.innerText` — the same extraction for every contender, which
    *  is what makes the fabrication check comparable across artifact formats. */
   readonly visibleText: string;
-  /** At least one element actually took up space on the page. */
+  /** Something took up space AND the browser reported no errors doing it. */
   readonly renders: boolean;
+  readonly consoleErrors: readonly string[];
+}
+
+export interface Visit {
+  readonly page: Page;
+  shot(): Promise<Shot>;
+  /** The same page again, from scratch — what the click probe puts between two
+   *  candidates so neither inherits the other's state. */
+  reset(): Promise<void>;
+  close(): Promise<void>;
 }
 
 export interface Shooter {
-  shot(html: string): Promise<Shot>;
+  visit(html: string): Promise<Visit>;
   close(): Promise<void>;
 }
 
@@ -60,21 +83,44 @@ export interface Shooter {
 export async function openBrowser(): Promise<Shooter> {
   const browser: Browser = await chromium.launch();
   return {
-    async shot(html) {
+    async visit(html) {
       const page = await browser.newPage({ viewport: { ...VIEWPORT } });
-      try {
+      const consoleErrors: string[] = [];
+      page.on("console", (message) => {
+        if (message.type() === "error") consoleErrors.push(message.text());
+      });
+      page.on("pageerror", (error) => consoleErrors.push(error.message));
+
+      const paint = async (): Promise<void> => {
         await page.setContent(html, { waitUntil: "load" });
-        const { visibleText, renders } = await page.evaluate(() => {
-          const painted = [...document.querySelectorAll(".vendo-root *")].some((element) => {
-            const box = element.getBoundingClientRect();
-            return box.width > 0 && box.height > 0;
-          });
-          return { visibleText: document.body.innerText, renders: painted };
-        });
-        return { png: await page.screenshot({ fullPage: true }), visibleText, renders };
-      } finally {
-        await page.close();
-      }
+        // A page that never sets the signal is a page that never finished, and
+        // saying so is worth more than an exception that ends the whole run.
+        await page
+          .waitForFunction(() => window.__settled === true, undefined, { timeout: SETTLE_MS })
+          .catch(() => consoleErrors.push(`the page never settled within ${SETTLE_MS}ms`));
+      };
+      await paint();
+
+      return {
+        page,
+        async shot() {
+          const { visibleText, mounted } = await page.evaluate(() => ({
+            visibleText: document.body.innerText,
+            mounted: [...document.querySelectorAll("#root *")].some((element) => {
+              const box = element.getBoundingClientRect();
+              return box.width > 0 && box.height > 0;
+            }),
+          }));
+          return {
+            png: await page.screenshot({ fullPage: true }),
+            visibleText,
+            renders: mounted && consoleErrors.length === 0,
+            consoleErrors: [...consoleErrors],
+          };
+        },
+        reset: paint,
+        close: () => page.close(),
+      };
     },
     close: () => browser.close(),
   };

--- a/genbench/src/report.ts
+++ b/genbench/src/report.ts
@@ -28,34 +28,30 @@ const offenderList = (offenders: readonly Offender[]): string =>
 
 const bindingList = (bindings: readonly Binding[]): string =>
   bindings.length === 0
-    ? `<ul class="notes"><li><span>no tool bindings on this screen</span></li></ul>`
+    ? `<ul class="notes"><li><span>nothing on this screen to press</span></li></ul>`
     : `<ul class="notes">${bindings
         .map(
           (b) =>
-            `<li><code>${escape(b.tool)}</code> <span>${escape(b.where)}${
+            `<li><code>${escape(b.where)}</code> <span>${escape(b.tool ?? "—")}${
               b.why === undefined ? "" : ` — ${escape(b.why)}`
             }</span> ${b.known && b.argsValid ? '<i class="ok">✓</i>' : '<i class="no">✕</i>'}</li>`,
         )
         .join("")}</ul>`;
 
-/** Islands and Kit charts both need the browser, so both leave a gap in a
- *  server-rendered shot. Says so in as many words, and counts them. */
-function clientOnlyNote(islands: number, charts: number): string {
-  const parts = [
-    islands > 0 ? `${islands} generated island${islands === 1 ? "" : "s"}` : "",
-    charts > 0 ? `${charts} chart${charts === 1 ? "" : "s"}` : "",
-  ].filter(Boolean);
-  if (parts.length === 0) return "";
-  const subject = parts.join(" and ");
-  const verb = islands + charts === 1 ? "is" : "are";
-  return `<p class="warn">${subject} on this screen ${verb} client-only — leaving an empty band in this server-rendered shot</p>`;
-}
+/** `renders` can fail for a reason no screenshot shows, so the reason is on the
+ *  page next to the verdict. */
+const consoleNote = (errors: readonly string[]): string =>
+  errors.length === 0
+    ? ""
+    : `<p class="warn">${errors.length} console error${errors.length === 1 ? "" : "s"} while painting: ${escape(errors[0]!)}</p>`;
 
 const metric = (label: string, value: string): string =>
   `<div><dt>${label}</dt><dd>${escape(value)}</dd></div>`;
 
 async function column(runDir: string, result: CaseResult): Promise<string> {
-  const shot = await readFile(join(runDir, result.contender, result.case, "screenshot.png")).catch(() => undefined);
+  const caseDir = join(result.contender, result.case);
+  const shot = await readFile(join(runDir, caseDir, "screenshot.png")).catch(() => undefined);
+  const page = await readFile(join(runDir, caseDir, "page.html"), "utf8").catch(() => undefined);
   const scored = passes(result.floor);
   const total = scored.filter(Boolean).length;
   const { usage } = result.cost;
@@ -67,12 +63,18 @@ async function column(runDir: string, result: CaseResult): Promise<string> {
     <span class="score ${total === 5 ? "ok" : "no"}">${total}/5</span>
   </header>
   <figure>${
-    shot === undefined
+    page === undefined
       ? `<div class="blank">nothing rendered</div>`
-      : `<img alt="${escape(result.case)} rendered by ${escape(result.contender)}" src="data:image/png;base64,${shot.toString("base64")}">`
+      : `<iframe title="${escape(result.case)} as ${escape(result.contender)} built it" src="${escape(caseDir)}/page.html" loading="lazy"></iframe>`
   }</figure>
+  ${
+    shot === undefined
+      ? ""
+      : `<div class="judge"><img alt="the screenshot ${escape(result.case)} was scored from"
+        src="data:image/png;base64,${shot.toString("base64")}"><p>what the judge saw</p></div>`
+  }
   ${result.failure === undefined ? "" : `<p class="failure">${escape(result.failure)}</p>`}
-  ${clientOnlyNote(result.islands, result.clientOnly)}
+  ${consoleNote(result.consoleErrors)}
   <dl class="floor">${CHECKS.map((name, index) => `<div><dt>${name}</dt><dd>${verdict(scored[index]!)}</dd></div>`).join("")}</dl>
   ${
     result.floor.blocking.length === 0
@@ -112,9 +114,16 @@ h2{margin:0;font-size:15px;font-weight:600}
 .col>header p{margin:2px 0 0;font-size:12px;color:var(--ter)}
 .score{font:600 13px/1 ui-monospace,Menlo,monospace;padding:5px 8px;border-radius:6px}
 .score.ok{color:var(--ok);background:#e8f3ed}.score.no{color:var(--no);background:#fbeceb}
-figure{margin:16px 0 0;background:var(--page);border:1px solid var(--line);border-radius:8px;overflow:hidden}
-img{display:block;width:100%}
+figure{margin:16px 0 0;background:#fff;border:1px solid var(--line);border-radius:8px;overflow:hidden}
+iframe{display:block;width:100%;height:660px;border:0;background:#fff}
 .blank{padding:48px 16px;text-align:center;font-size:13px;color:var(--ter)}
+/* The judge's evidence, not the artifact: small, captioned, and inlined so it
+   survives the file being moved. The live page above it does not. */
+.judge{display:flex;align-items:center;gap:10px;margin-top:10px}
+.judge img{display:block;width:72px;max-height:88px;object-fit:cover;object-position:top;
+  border:1px solid var(--line);border-radius:4px;background:var(--page)}
+.judge p{margin:0;font:450 10px/1 ui-monospace,SFMono-Regular,Menlo,monospace;
+  letter-spacing:.08em;text-transform:uppercase;color:var(--ter)}
 .failure{margin:12px 0 0;font-size:13px;color:var(--no)}
 .warn{margin:12px 0 0;padding:8px 10px;border-radius:6px;background:#fdf6e7;font-size:12px;color:#7a5a12}
 dl{margin:0}dl>div{display:flex;align-items:baseline;justify-content:space-between}
@@ -132,9 +141,10 @@ dl{margin:0}dl>div{display:flex;align-items:baseline;justify-content:space-betwe
 .metrics dd{margin:6px 0 0;font:450 15px/1 ui-monospace,Menlo,monospace;font-variant-numeric:tabular-nums}
 `;
 
-/** One self-contained page per run: the screenshots side by side, each under its
- *  own floor verdicts and numbers. Images are inlined, so the file can be moved
- *  or attached anywhere and still render. */
+/** One page per run: every contender's REAL screen side by side, live and
+ *  scrollable, each under its own floor verdicts and numbers. It stays a single
+ *  static file you can `open` — the live frames are relative links into the run
+ *  folder beside it, and the judge's screenshots are inlined. */
 export async function writePreview(input: {
   runDir: string;
   runId: string;

--- a/genbench/src/run.ts
+++ b/genbench/src/run.ts
@@ -6,7 +6,8 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runFloor, type FloorResult } from "./floor.js";
 import { meteredModel, MODEL_IDS, type Meter, type ModelAlias, type UsageTotals } from "./meter.js";
-import { openBrowser, treeHtml } from "./render.js";
+import { probe, type Probed } from "./probe.js";
+import { bundleMount, openBrowser, pageHtml } from "./render.js";
 import { writePreview } from "./report.js";
 import { vendoDriver } from "./vendo.js";
 import { loadCases, loadWorld, worldForCase, type Case, type Lane, type World } from "./world.js";
@@ -57,14 +58,15 @@ export interface CaseResult {
   readonly floor: FloorResult;
   readonly timing: { firstRenderMs?: number; settledMs: number };
   readonly cost: { usage: UsageTotals; usd: number };
-  /** Nodes the writer generated as islands. They are client-only, so they are
-   *  blank in a server-rendered screenshot — a non-zero count means the shot
-   *  understates what the product actually built. */
+  /** Nodes the writer generated as islands rather than assembling from the Kit. */
   readonly islands: number;
-  /** Kit charts on the screen. They are recharts-backed and measure their
-   *  container in the browser, so they leave an empty band in a server-rendered
-   *  shot for the same reason islands do. Counted so the gap is never silent. */
+  /** Kit charts on the screen — the parts that only exist once a browser has
+   *  measured them, and so the reason the page is mounted for real. */
   readonly clientOnly: number;
+  /** Every control the probe pressed and what each one asked the host to do. */
+  readonly trace: readonly Probed[];
+  /** What the browser complained about while painting this screen. */
+  readonly consoleErrors: readonly string[];
   readonly world: string;
   readonly failure?: string;
 }
@@ -117,6 +119,11 @@ export function contenders(models: readonly ModelAlias[]): readonly ContenderId[
 /** The recharts-backed Kit components (packages/ui/src/kit/charts/). */
 const CHARTS = new Set(["LineChart", "BarChart", "DonutChart", "Sparkline"]);
 
+/** One case's whole budget — generation, paint and probe. A contender that hangs
+ *  costs the run this much and no more; the case is recorded failed and the next
+ *  one starts. */
+const CASE_TIMEOUT_MS = 5 * 60_000;
+
 const nodesOf = (payload: UIPayload | undefined): ReadonlyArray<{ source?: string; component?: string }> =>
   (payload as { nodes?: Array<{ source?: string; component?: string }> } | undefined)?.nodes ?? [];
 
@@ -147,6 +154,7 @@ async function main(argv: readonly string[]): Promise<number> {
   const runId = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
   const runDir = join(root, "runs", runId);
   const anthropic = createAnthropic({ apiKey });
+  const bundle = await bundleMount();
   const shooter = await openBrowser();
   const results: CaseResult[] = [];
 
@@ -159,22 +167,41 @@ async function main(argv: readonly string[]): Promise<number> {
         const scoped = worldForCase(world, testCase);
         console.log(`· ${contender.slug} / ${testCase.id}`);
 
-        const outcome = await driver.run({ world: scoped, testCase, meter });
-        const html = outcome.payload === undefined ? undefined : treeHtml(outcome.payload, world.theme);
-        const shot = html === undefined ? undefined : await shooter.shot(html);
+        // Raced against the clock as one unit: generation, paint and probe all
+        // spend the person's wait, so one budget covers all three.
+        const done = await Promise.race([
+          (async () => {
+            const outcome = await driver.run({ world: scoped, testCase, meter });
+            if (outcome.payload === undefined) return { outcome, trace: [] as Probed[] };
+            const html = pageHtml(outcome.payload, scoped, bundle);
+            const visit = await shooter.visit(html);
+            try {
+              return { outcome, html, shot: await visit.shot(), trace: await probe(visit) };
+            } finally {
+              await visit.close();
+            }
+          })(),
+          new Promise<undefined>((settle) => setTimeout(() => settle(undefined), CASE_TIMEOUT_MS).unref()),
+        ]);
+
+        const outcome = done?.outcome;
+        const shot = done?.shot;
+        const trace = done?.trace ?? [];
         const floor = runFloor({
           world: scoped,
-          artifact: outcome.artifact,
-          blocking: outcome.blocking,
-          payload: outcome.payload,
+          artifact: outcome?.artifact,
+          blocking: outcome?.blocking ?? [],
+          trace,
           shot,
         });
 
         const caseDir = join(runDir, contender.slug, testCase.id);
         await mkdir(caseDir, { recursive: true });
-        if (outcome.artifact !== undefined) await writeFile(join(caseDir, "artifact.vendo"), outcome.artifact);
+        if (outcome?.artifact !== undefined) await writeFile(join(caseDir, "artifact.vendo"), outcome.artifact);
+        if (done?.html !== undefined) await writeFile(join(caseDir, "page.html"), done.html);
         if (shot !== undefined) await writeFile(join(caseDir, "screenshot.png"), shot.png);
 
+        const failure = done === undefined ? "timeout" : outcome?.failure;
         const result: CaseResult = {
           run: runId,
           contender: contender.slug,
@@ -184,14 +211,16 @@ async function main(argv: readonly string[]): Promise<number> {
           lane: testCase.lane,
           floor,
           timing: {
-            ...(outcome.firstRenderMs === undefined ? {} : { firstRenderMs: outcome.firstRenderMs }),
-            settledMs: outcome.settledMs,
+            ...(outcome?.firstRenderMs === undefined ? {} : { firstRenderMs: outcome.firstRenderMs }),
+            settledMs: outcome?.settledMs ?? meter.elapsedMs(),
           },
           cost: { usage: meter.totals(), usd: meter.usd() },
-          islands: countIslands(outcome.payload),
-          clientOnly: countClientOnly(outcome.payload),
+          islands: countIslands(outcome?.payload),
+          clientOnly: countClientOnly(outcome?.payload),
+          trace,
+          consoleErrors: shot?.consoleErrors ?? [],
           world: world.hash,
-          ...(outcome.failure === undefined ? {} : { failure: outcome.failure }),
+          ...(failure === undefined ? {} : { failure }),
         };
         await writeFile(join(caseDir, "result.json"), `${JSON.stringify(result, null, 2)}\n`);
         results.push(result);

--- a/genbench/tsconfig.json
+++ b/genbench/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
     "noEmit": true,
     "resolveJsonModule": true
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -867,6 +867,9 @@ importers:
       ai:
         specifier: 6.0.28
         version: 6.0.28(zod@4.4.3)
+      esbuild:
+        specifier: ^0.25.12
+        version: 0.25.12
       react:
         specifier: 19.2.7
         version: 19.2.7


### PR DESCRIPTION
Stacked on #1064. Base is `yousefh409/genbench-slice-1`, **not** main — review that one first.

## What changed

Slice 1 scored a screen it had server-rendered itself. Charts and generated islands only exist once a browser has measured them, so every one of them was an empty band in the shot, and `wiredActions` meant "a tool name appears somewhere in the document". Both are now measured for real.

- **One mount.** `src/mount.tsx` (~70 lines) is bundled once per run by esbuild and inlined into every page. A benchmark page is `<div id=root>` + payload JSON + theme JSON + the case's canned rows + the bundle. The **product's own** `PayloadView` from `@vendoai/ui/tree` mounts it, the theme is applied through the product's own `applyThemeVars`, and the renderer's real `onAction` seam dispatches into `window.vendo.callTool`. No product file was touched.
- **`window.vendo.callTool` is the one seam.** It records every call and answers with the case-scoped world's rows, so a runtime refetch resolves. The later DIY and claude-code contenders write `page.html` themselves — the page IS their artifact, they bypass the compile, and they call the same global.
- **The SSR path is deleted.** `treeHtml`, `renderToString` and the two `bindingsFromPayload` tests that asserted server-rendered behaviour are **removed on purpose** — there is now exactly one way to make pixels.
- **`src/probe.ts` (~58 lines)** presses every actionable element, one per freshly re-painted page, follows a `[role=dialog]` confirmation, and records what each press asked the host to do.
- **`wiredActions` grades that trace.** Every recorded call must name a real world tool with schema-valid args, and *a control that is pressed and calls nothing fails*. `renders` now means mounted with a clean console.
- **The preview embeds the real page** — live and scrollable in an iframe — and demotes the judge's screenshot to a captioned thumbnail. Still a single static file you `open`.
- **Five minutes per case**, then `failure: "timeout"` and the run continues. `result.json` gains `trace` and `consoleErrors`, nothing else. Timing semantics are unchanged.

## How to run it

```sh
pnpm build
ANTHROPIC_API_KEY=… pnpm genbench run --prompt spend-chart
```

## Charts now draw — evidence

Live run, `spend-chart` (a seed case added for exactly this), sonnet:

```
· vendo-sonnet / spend-chart
  floor 4/5 · 43965ms · $0.1737     firstRender 10569ms · 102,415 tokens
  renders ✓   consoleErrors []   clientOnly 1
```

The shot is a drawn horizontal bar chart — six categories, brand green, real bars — over the amounts table. Under slice 1 that whole band was blank. Screenshot: `genbench/runs/2026-08-08T09-45-35/vendo-sonnet/spend-chart/screenshot.png` (PNGs are gitignored, so it is not in the diff); the live page beside it is `…/page.html`.

The 5th check that fails is `honestData`, on `$750.00 / $1,500.00 / $2,250.00 / $3,000.00` — recharts' own x-axis tick labels, which land in `document.body.innerText` now that the chart exists. `honestData` is not in this slice's scope so it was left alone. **This one needs a decision** (see below).

## The probe caught something — trace excerpt

Live run, `pending-transfers`, sonnet — `floor 4/5 · 134372ms · $0.3511`:

```json
"trace": [
  { "label": "Cancel transfer", "confirmed": false,
    "calls": [{ "name": "cancel_transfer", "args": {} }] }
],
"bindings": [
  { "where": "Cancel transfer", "tool": "cancel_transfer",
    "known": true, "argsValid": false, "why": "missing required argument \"id\"" }
]
```

The model built `<Form onSubmit=\"cancel_transfer\">` around a `<Select valueField=\"id\">`. The rendered Select *displays* "Alex Rivera" as chosen, but pressing submit without touching it fires `cancel_transfer` with no `id`. Slice 1's static scan read the document, saw the tool named, and passed it.

## Negative control

`src/probe.test.ts` — a real browser, two fixture pages identical but for one line: whether the button's handler is attached. The wired one passes `wiredActions`, the dead one fails. If that ever stops being true, the check is measuring nothing.

## Two things for your call

1. **Chart axis ticks fail `honestData`.** Exclude text inside `svg.recharts-surface`, accept that a charted screen cannot pass, or treat ticks as derivable the way sums and means already are?
2. **The Select that shows a choice it does not hold.** Probe limitation, or a real defect in `packages/ui`'s Form/Select defaulting? This lane is read-only on product packages, so nothing was changed either way.

## Notes

- `pnpm-lock.yaml` moves by 3 lines: `esbuild` is declared as a genbench devDependency. It was already a root devDependency and a direct dependency of `packages/apps`, so no new resolution — the alternative was an undeclared import that resolves by directory walk, which breaks quietly later.
- The page loads no webfont, so `world.json`'s `Inter` resolves to the system sans stack. That is deliberate: a shot must not depend on what a CDN served. Every contender is shot in the same face, and the README says so.
- Only `genbench/` changed (plus the lockfile line above).

## Gate

`pnpm build` ✓ · `npx vitest run` in `genbench/` ✓ 31/31, run twice · `pnpm typecheck` ✓ · `pnpm lint` ✓

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move genbench from server-rendered screenshots to real, mounted pages and grade wiring by pressing controls in a browser. Charts now draw, and wiring is validated via calls to `window.vendo.callTool`; the preview shows the live page.

- **New Features**
  - Real browser mount: `src/mount.tsx` bundled once with `esbuild`, inlined into each page; mounts `PayloadView` from `@vendoai/ui/tree`, applies theme via `applyThemeVars` from `@vendoai/ui/kit`, and dispatches actions to `window.vendo.callTool`.
  - Probing and grading: `src/probe.ts` clicks each actionable control (follows `[role=dialog]`); `wiredActions` grades recorded calls (a press that calls nothing fails). `renders` now means mounted with a clean console.
  - One path to pixels: removed SSR (`treeHtml`, `renderToString`) and related tests.
  - Output and preview: save `page.html` per case; preview embeds it in an iframe and shows the judge’s screenshot as a small captioned thumbnail.
  - Budget and results: 5-minute per-case timeout is recorded as `failure: "timeout"`; `result.json` adds `trace` and `consoleErrors`. Added `spend-chart` case to verify charts render.

- **Dependencies**
  - Added `esbuild` as a `genbench` devDependency.

<sup>Written for commit 89fcc2fd72048d012a4c4bacb55bac0516cc9a74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

