### PR TITLE
feat(ui): add surface-aware customization starters

### DIFF
--- a/packages/ui/src/chrome/index.ts
+++ b/packages/ui/src/chrome/index.ts
@@ -31,6 +31,7 @@ export { VendoTrigger, type VendoTriggerProps } from "./vendo-trigger.js";
 export { VendoPalette, type VendoCommand } from "./vendo-palette.js";
 export { type HotkeyChord, type PaletteHotkey } from "./palette-hotkey.js";
 export { VendoSlot } from "./vendo-slot.js";
+export { VendoSurface, useVendoSurface, type VendoSurfaceValue } from "./vendo-surface.js";
 export { VendoThread, type VendoThreadProps } from "./thread/index.js";
 export { VendoToasts, vendoToast, dismissAllVendoToasts, type VendoToastsProps, type VendoToastInput, type VendoToastAction } from "./vendo-toasts.js";
 export { WaitingQueue, type WaitingQueueProps } from "./waiting-queue.js";

--- a/packages/ui/src/chrome/thread/composer.tsx
+++ b/packages/ui/src/chrome/thread/composer.tsx
@@ -214,6 +214,18 @@ export function useComposer({ busy, sendMessage, steer }: {
     dispatch(text, pending, context);
   };
 
+  /** A prefill is an invitation to continue writing, so focus it with the
+   * caret after the supplied text rather than selecting or prepending to it. */
+  const prefillDraft = (text: string) => {
+    setDraft(text);
+    requestAnimationFrame(() => {
+      const textarea = textareaRef.current;
+      if (!textarea) return;
+      textarea.focus();
+      textarea.setSelectionRange(text.length, text.length);
+    });
+  };
+
   // The enclosing overlay's prefill scope (null for embedded threads/pages):
   // registry-delivered prompts are directed at one overlay's composer.
   const prefillScope = useContext(PrefillScopeContext);
@@ -231,11 +243,10 @@ export function useComposer({ busy, sendMessage, steer }: {
   // fresh conversation).
   useEffect(() => {
     const prefill = (prompt: string, sendNow: boolean, context?: string) => {
-      // An empty hand-off must not wipe a draft in progress.
-      if (prompt.length > 0) setDraft(prompt);
       // Never into the textarea: the grounding is for the model only.
       if (context !== undefined && context.length > 0) contextRef.current = context;
       if (sendNow) queueMicrotask(() => sendRef.current(prompt));
+      else if (prompt.length > 0) prefillDraft(prompt);
     };
     const onPrefill = (event: Event) => {
       const detail = (event as CustomEvent<{ prompt?: string; send?: boolean; context?: string }>).detail;
@@ -284,7 +295,7 @@ export function useComposer({ busy, sendMessage, steer }: {
     draft, setDraft, files, setFiles, dragDepth, setDragDepth,
     attachmentPreviews, attachmentReads, retryRead: startRead,
     dockOpen, setDockOpen, dockButtonRef,
-    queued, setQueued, attachError, fileRef, textareaRef, send,
+    queued, setQueued, attachError, fileRef, textareaRef, prefillDraft, send,
   };
 }
 

--- a/packages/ui/src/chrome/thread/index.tsx
+++ b/packages/ui/src/chrome/thread/index.tsx
@@ -6,6 +6,7 @@ import { useVendoThread } from "../../hooks/use-vendo-thread.js";
 import { ChromeRoot } from "../chrome-root.js";
 import { defaultVendoGreeting, hasSeen, markSeen, type VendoDiscoverability, type VendoGreeting } from "../discoverability.js";
 import { MorphToast, type MorphToastProps } from "../morph-toast.js";
+import type { VendoSurfaceValue } from "../vendo-surface.js";
 import { Composer, dragHasFiles, useComposer } from "./composer.js";
 import { MessageList } from "./message-list.js";
 import { useMessageWindow, useStickToBottom } from "./scrolling.js";
@@ -47,6 +48,8 @@ export interface VendoThreadProps {
    * provider's `greeting`. Distinct from `greeting` above (the returning-user
    * landing headline) — this one renders once per user, ever. */
   firstRunGreeting?: VendoGreeting;
+  /** Host-owned UI-only discovery copy supplied by VendoOverlay. */
+  surface?: VendoSurfaceValue;
   /** Rendered directly above the composer in both landing and conversation
    * layouts — the seam VendoOverlay uses for its command chip strip (the
    * one-surface ⌘K design). Presentation-only; the thread never reads it. */
@@ -63,6 +66,7 @@ export function VendoThread({
   onThreadId,
   discoverability,
   firstRunGreeting,
+  surface,
   composerAccessory,
 }: VendoThreadProps) {
   const thread = useVendoThread(threadId);
@@ -75,6 +79,7 @@ export function VendoThread({
   const dial = discoverability ?? providerDial;
   const contextGreeting = useVendoGreeting();
   const tutorial = firstRunGreeting ?? contextGreeting ?? defaultVendoGreeting;
+  const surfaceStarters = surface?.starters ?? [];
   const [tutorialActive, setTutorialActive] = useState(false);
   // Arming is REACTIVE, not mount-only: surfaces that don't remount their
   // thread (a host flipping threadId props on one instance) become eligible
@@ -173,10 +178,9 @@ export function VendoThread({
   const composerApi = useComposer({
     busy,
     sendMessage: message => thread.sendMessage(message),
-    // A message typed mid-turn is offered to that turn before it queues.
     ...(thread.steer === undefined ? {} : { steer: thread.steer }),
   });
-  const { setDraft, setQueued, textareaRef, send } = composerApi;
+  const { prefillDraft, setQueued, send } = composerApi;
   const risks = useMemo(() => riskByCall(thread.messages), [thread.messages]);
   const guardApprovals = useMemo(() => approvalByCall(thread.messages), [thread.messages]);
   // Grant SETS (demo-live-readiness): a parked call claimed by a
@@ -268,8 +272,7 @@ export function VendoThread({
     if (!message) return;
     thread.setMessages(thread.messages.slice(0, lastUserIndex));
     setQueued(null);
-    setDraft(userText(message));
-    requestAnimationFrame(() => textareaRef.current?.focus());
+    prefillDraft(userText(message));
   };
 
   // Regenerate the last assistant turn (re-issues from the preserved
@@ -448,15 +451,15 @@ export function VendoThread({
               // behaviors would read as one). Chips PREFILL, never send.
               <div className="fl-greeting" role="group" aria-label="Getting started">
                 <p className="fl-greeting-intro">{tutorial.intro}</p>
+                {surface?.label ? <p className="fl-intro">{surface.label}</p> : null}
                 <div className="fl-chips fl-greeting-chips">
-                  {tutorial.prompts.slice(0, 3).map((text, i) => (
+                  {(surfaceStarters.length > 0 ? surfaceStarters : tutorial.prompts).slice(0, 3).map((text, i) => (
                     <button
                       type="button"
                       className="fl-chip"
                       key={`${i}-${text}`}
                       onClick={() => {
-                        setDraft(text);
-                        requestAnimationFrame(() => textareaRef.current?.focus());
+                        prefillDraft(text);
                       }}
                     >
                       {text}
@@ -468,6 +471,23 @@ export function VendoThread({
               <>
                 <h1 className="fl-greet">{greeting}</h1>
                 {intro ? <p className="fl-intro">{intro}</p> : null}
+                {surface?.label ? <p className="fl-intro">{surface.label}</p> : null}
+                {surfaceStarters.length > 0 ? (
+                  <div className="fl-chips fl-greeting-chips">
+                    {surfaceStarters.slice(0, 3).map((text, i) => (
+                      <button
+                        type="button"
+                        className="fl-chip"
+                        key={`${i}-${text}`}
+                        onClick={() => {
+                          prefillDraft(text);
+                        }}
+                      >
+                        {text}
+                      </button>
+                    ))}
+                  </div>
+                ) : null}
               </>
             )}
             {!tutorialActive && suggestions.length > 0 ? (

--- a/packages/ui/src/chrome/vendo-overlay.tsx
+++ b/packages/ui/src/chrome/vendo-overlay.tsx
@@ -26,6 +26,7 @@ import {
 } from "./split-view.js";
 import { appTitle } from "./thread/message-data.js";
 import { VendoThread, type VendoThreadProps } from "./thread/index.js";
+import { useVendoSurface } from "./vendo-surface.js";
 
 const FOCUSABLE = "button:not([disabled]),input:not([disabled]),textarea:not([disabled]),select:not([disabled]),a[href],[tabindex]:not([tabindex='-1'])";
 
@@ -387,6 +388,8 @@ export function VendoOverlay({
   const theme = useVendoTheme();
   const takeover = useMobileTakeover();
   const pin = usePinAction();
+  const { client, components, onPin } = useVendoContext();
+  const surface = useVendoSurface();
 
   // 2026-07 demo feedback — the expandable split-view workspace (split-view.tsx
   // owns the pure state machine). Expanded, the featured microapp renders
@@ -796,6 +799,7 @@ export function VendoOverlay({
                   key={`${conversationKey ?? 0}:${conversationEpoch}`}
                   discoverability={dial}
                   firstRunGreeting={greeting}
+                  surface={surface}
                   onThreadId={setPanelThreadId}
                 />
               </PrefillScopeContext.Provider>

--- a/packages/ui/src/chrome/vendo-surface.tsx
+++ b/packages/ui/src/chrome/vendo-surface.tsx
@@ -1,0 +1,24 @@
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+
+/** Host-owned discovery copy for the current product surface. It stays in the
+ * UI tree and is never part of a thread request or model context. */
+export interface VendoSurfaceValue {
+  label: string;
+  starters: readonly string[];
+}
+
+const VendoSurfaceContext = createContext<VendoSurfaceValue | undefined>(undefined);
+
+/** Scope explicit, host-authored starters to a page or route. Place the
+ * corresponding VendoOverlay inside this boundary. */
+export function VendoSurface({ label, starters, children }: VendoSurfaceValue & { children: ReactNode }): ReactNode {
+  const value = useMemo<VendoSurfaceValue>(
+    () => ({ label, starters: starters.slice(0, 3) }),
+    [label, starters],
+  );
+  return <VendoSurfaceContext.Provider value={value}>{children}</VendoSurfaceContext.Provider>;
+}
+
+export function useVendoSurface(): VendoSurfaceValue | undefined {
+  return useContext(VendoSurfaceContext);
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -8,6 +8,7 @@ export {
 } from "./client.js";
 export { VendoProvider, hostComponentMap, useVendoProvider, useVendoDiscoverability, useVendoGreeting, useVendoTheme, useVendoTools, type ConnectorOption, type HostComponentsInput } from "./context.js";
 export { defaultVendoGreeting, type VendoDiscoverability, type VendoGreeting } from "./chrome/discoverability.js";
+export { VendoSurface, useVendoSurface, type VendoSurfaceValue } from "./chrome/vendo-surface.js";
 export type { ToolMeta, ToolMetaMap } from "./chrome/humanize.js";
 export type { VendoAppEmbedProps, VendoApprovalEmbedProps, VendoApprovalEmbedState, VendoToolResultProps } from "./embeds.js";
 // Existing-agents Lane B — the components behind the frozen prop contracts,

--- a/packages/ui/test/chrome/export-surface.test.ts
+++ b/packages/ui/test/chrome/export-surface.test.ts
@@ -30,6 +30,7 @@ const VALUE_EXPORTS = [
   "VendoOverlay",
   "VendoPalette",
   "VendoSlot",
+  "VendoSurface",
   // Existing-agents Lane B — the three BYO-chat embeds.
   "VendoAppEmbed",
   "VendoApprovalEmbed",
@@ -91,6 +92,7 @@ const VALUE_EXPORTS = [
   // the ejected thread's app cards read the context via useSplitView.
   "SplitViewContext",
   "useSplitView",
+  "useVendoSurface",
   "ChromeRoot",
   "useCopyFeedback",
   "ConnectDockButton",
@@ -150,6 +152,7 @@ const TYPE_EXPORTS = [
   // Discoverability (ui-usage-dx §6) — the dial + greeting config shapes.
   "VendoDiscoverability",
   "VendoGreeting",
+  "VendoSurfaceValue",
 ];
 
 // vitest's jsdom environment rewrites import.meta.url to a non-file scheme,

--- a/packages/ui/test/chrome/surface-starters.test.tsx
+++ b/packages/ui/test/chrome/surface-starters.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { VendoProvider, createVendoClient, type VendoClient } from "../../src/index.js";
+import { VendoOverlay, VendoSurface } from "../../src/chrome/index.js";
+import { createWireServer } from "../wire-server.js";
+
+describe("surface-aware overlay starters", () => {
+  let wire: Awaited<ReturnType<typeof createWireServer>>;
+  let client: VendoClient;
+
+  beforeEach(async () => {
+    window.localStorage.clear();
+    wire = await createWireServer();
+    client = createVendoClient({ baseUrl: wire.url });
+  });
+
+  afterEach(async () => {
+    cleanup();
+    await wire.close();
+  });
+
+  const posts = () => wire.requests.filter(request => request.method === "POST" && request.path === "/threads");
+  const dialog = () => screen.getByRole("dialog", { name: "Vendo assistant" });
+
+  it("shows at most three host starters and pre-fills without sending", async () => {
+    render(
+      <VendoProvider client={client}>
+        <VendoSurface label="Client: Acme Holdings" starters={["Build a readiness workspace", "Plan this week", "Create a document chase", "Do not show"]}>
+          <VendoOverlay defaultOpen />
+        </VendoSurface>
+      </VendoProvider>,
+    );
+
+    expect(await screen.findByText("Client: Acme Holdings")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Build a readiness workspace" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Plan this week" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Create a document chase" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Do not show" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "What can you do here?" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Build a readiness workspace" }));
+    const composer = within(dialog()).getByRole("textbox", { name: "Message" }) as HTMLTextAreaElement;
+    expect(composer.value).toBe("Build a readiness workspace");
+    await waitFor(() => {
+      expect(composer.selectionStart).toBe(composer.value.length);
+      expect(composer.selectionEnd).toBe(composer.value.length);
+    });
+    expect(posts()).toHaveLength(0);
+  });
+
+  it("updates empty-state starters without resetting an existing composer draft", async () => {
+    const view = (label: string, starter: string) => (
+      <VendoProvider client={client}>
+        <VendoSurface label={label} starters={[starter]}>
+          <VendoOverlay defaultOpen />
+        </VendoSurface>
+      </VendoProvider>
+    );
+    const { rerender } = render(view("Client: Acme Holdings", "Review Acme invoices"));
+
+    expect(await screen.findByRole("button", { name: "Review Acme invoices" })).toBeTruthy();
+    const composer = within(dialog()).getByRole("textbox", { name: "Message" }) as HTMLTextAreaElement;
+    fireEvent.change(composer, { target: { value: "Keep this draft" } });
+
+    rerender(view("Client: Beacon Labs", "Review Beacon invoices"));
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Review Beacon invoices" })).toBeTruthy());
+    expect(screen.queryByRole("button", { name: "Review Acme invoices" })).toBeNull();
+    expect((within(dialog()).getByRole("textbox", { name: "Message" }) as HTMLTextAreaElement).value).toBe("Keep this draft");
+    expect(posts()).toHaveLength(0);
+  });
+
+  it("keeps the generic greeting when no surface is mounted", async () => {
+    render(<VendoProvider client={client}><VendoOverlay defaultOpen /></VendoProvider>);
+    expect(await screen.findByRole("button", { name: "What can you do here?" })).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Closes #558.

Adds `VendoSurface`, a scoped `@vendoai/ui` context component that lets hosts pass a label and starters to the conversation overlay.

Behavior:
- `VendoOverlay` reads the nearest `VendoSurface` reactively.
- On an empty conversation, the overlay renders the host label and up to three prefill-only starter chips.
- Clicking a starter pre-fills the composer and places the caret at the end; it never sends a `/threads` request.
- Surface starters replace generic first-run prompt chips when present, while retaining the greeting intro.
- Changing `VendoSurface` on navigation updates the starters without resetting an existing conversation or draft.
- Label and starters stay UI-only and are never added to thread payloads or model context.
- `VendoSlot.emptyState.suggestions` are unchanged.

Tests:
- `pnpm build`
- `pnpm --filter @vendoai/ui test`
- `pnpm typecheck`
- `pnpm lint`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `VendoSurface` to `@vendoai/ui` so hosts can show a surface label and up to three starters in `VendoOverlay` and `VendoThread` empty states. Starters prefill the composer with the caret at the end and never send a request.

- **New Features**
  - Exported `VendoSurface`, `useVendoSurface`, and `VendoSurfaceValue` from `@vendoai/ui` and `chrome/index`.
  - `VendoOverlay` reads the nearest surface and passes it to `VendoThread`; empty state (first‑run and returning) shows the label and up to 3 starters.
  - Clicking a starter pre‑fills and focuses the composer; no POST to `/threads`.
  - Changing `VendoSurface` updates starters without resetting a draft or conversation; surface data is UI‑only and never sent. When no surface is mounted, generic greeting/suggestions remain.

- **Migration**
  - Optional: wrap `VendoOverlay` with `VendoSurface` and pass `{ label, starters }`. No breaking changes.

<sup>Written for commit 858564e35a5f8e69e180e134c594875d29033882. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

