### PR TITLE
feat(core,harnesses,apps): opt-in OTel GenAI telemetry so a host can see the agent

### DIFF
--- a/.changeset/agent-spans-reach-the-hosts-own-dashboard.md
+++ b/.changeset/agent-spans-reach-the-hosts-own-dashboard.md
@@ -1,0 +1,27 @@
+---
+"@vendoai/core": minor
+"@vendoai/harnesses": minor
+"@vendoai/apps": minor
+---
+
+Opt-in OTel GenAI telemetry: a host that registered a tracer provider now sees
+Vendo's model calls
+
+The ai-SDK emits OpenTelemetry GenAI spans only when a call passes
+`experimental_telemetry`; it is off by default so a library never exports a
+host's prompts unasked. Vendo never passed it, so a host with OTel already
+registered saw NOTHING from any Vendo model call — silently, with no warning and
+no error to hint at it.
+
+Measured in a third-party Next.js host: a 4.4-minute turn that generated a
+working app produced zero spans. With `VENDO_OTEL_TRACING=1` the same prompt
+yields cost per turn, the model ladder escalating mini -> full, the whole tool
+graph, and the app-repair lane firing — and, within the hour, surfaced a failing
+turn (`AI_APICallError`, `isRetryable: false`) that was otherwise invisible.
+
+No new dependency and no vendor coupling: the ai-SDK resolves whatever provider
+the host registered through `@opentelemetry/api`, and Vendo runs inside the
+host's process, so the spans join what is already there.
+
+Off by default; `otelTelemetry()` returns `{}` unless `VENDO_OTEL_TRACING` is
+set, so behaviour is unchanged for every existing host.

--- a/packages/apps/src/checking/strict-tool-call.ts
+++ b/packages/apps/src/checking/strict-tool-call.ts
@@ -13,6 +13,7 @@
  * It lives beside its caller rather than in `generation/`: the floor must not
  * import a pipeline that is on its way to quarantine (§7.3).
  */
+import { otelTelemetry } from "@vendoai/core";
 import { modelCallParams } from "../model-params.js";
 import type { FloorDependencies } from "./deps.js";
 
@@ -34,6 +35,8 @@ export const strictToolCall = async (
     const { generateText, jsonSchema } = await import("ai");
     const result = await generateText({
       model: deps.model,
+      // Opt-in OTel GenAI spans (VENDO_OTEL_TRACING=1).
+      ...otelTelemetry("vendo.apps.check"),
       system,
       prompt,
       tools: {

--- a/packages/apps/src/generation/engine.ts
+++ b/packages/apps/src/generation/engine.ts
@@ -10,6 +10,7 @@
  */
 import {
   type AppDocument,
+  otelTelemetry,
   type ToolSemantics,
   type Tree,
   type TreeNode,
@@ -122,6 +123,9 @@ export const askModel = async (
       ...modelCallParams(model),
       maxRetries: 0,
       onError: ({ error }) => { streamError = error; },
+      // Opt-in OTel GenAI spans (VENDO_OTEL_TRACING=1). App generation is the
+      // most expensive lane in a turn and the one a host most needs to see.
+      ...otelTelemetry("vendo.apps.generate"),
     });
     let text = "";
     for await (const delta of result.textStream) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -110,3 +110,5 @@ export type {
 export type { CommitResult, WorkspaceFs } from "./workspace.js";
 export { WORKSPACE_INLINE_MAX_BYTES, appRootPath } from "./workspace.js";
 export type { AppMount } from "./workspace.js";
+export { otelTelemetry } from "./otel-telemetry.js";
+export type { TelemetryLane } from "./otel-telemetry.js";

--- a/packages/core/src/otel-telemetry.test.ts
+++ b/packages/core/src/otel-telemetry.test.ts
@@ -15,16 +15,21 @@ describe("otelTelemetry", () => {
   });
 
   it("stays off for any value that is not an explicit opt-in", () => {
-    for (const value of ["0", "false", "", "yes", "on"]) {
+    for (const value of ["0", "false", "", "yes", "on", "METRICS"]) {
       process.env.VENDO_OTEL_TRACING = value;
       expect(otelTelemetry("vendo.agent.turn")).toEqual({});
     }
   });
 
-  it("emits ai-SDK telemetry settings named for the lane when opted in", () => {
+  it("emits settings named for the lane, with payloads, on =1", () => {
     process.env.VENDO_OTEL_TRACING = "1";
     expect(otelTelemetry("vendo.apps.generate")).toEqual({
-      experimental_telemetry: { isEnabled: true, functionId: "vendo.apps.generate" },
+      experimental_telemetry: {
+        isEnabled: true,
+        functionId: "vendo.apps.generate",
+        recordInputs: true,
+        recordOutputs: true,
+      },
     });
   });
 
@@ -33,15 +38,32 @@ describe("otelTelemetry", () => {
     expect(otelTelemetry("vendo.agent.turn")).toHaveProperty("experimental_telemetry.isEnabled", true);
   });
 
-  it("carries host metadata through when given, and omits the key when not", () => {
-    process.env.VENDO_OTEL_TRACING = "1";
-    expect(otelTelemetry("vendo.agent.turn", { tenant: "acme" })).toEqual({
+  it("=metrics traces WITHOUT shipping prompts or tool results", () => {
+    process.env.VENDO_OTEL_TRACING = "metrics";
+    expect(otelTelemetry("vendo.agent.turn")).toEqual({
       experimental_telemetry: {
         isEnabled: true,
         functionId: "vendo.agent.turn",
-        metadata: { tenant: "acme" },
+        recordInputs: false,
+        recordOutputs: false,
       },
     });
+  });
+
+  it("lets an explicit option override the env in either direction", () => {
+    process.env.VENDO_OTEL_TRACING = "metrics";
+    expect(otelTelemetry("vendo.agent.turn", { recordInputs: true }))
+      .toHaveProperty("experimental_telemetry.recordInputs", true);
+
+    process.env.VENDO_OTEL_TRACING = "1";
+    expect(otelTelemetry("vendo.agent.turn", { recordOutputs: false }))
+      .toHaveProperty("experimental_telemetry.recordOutputs", false);
+  });
+
+  it("carries host metadata through when given, and omits the key when not", () => {
+    process.env.VENDO_OTEL_TRACING = "1";
+    expect(otelTelemetry("vendo.agent.turn", { metadata: { tenant: "acme" } }))
+      .toHaveProperty("experimental_telemetry.metadata", { tenant: "acme" });
     expect(otelTelemetry("vendo.agent.turn").experimental_telemetry).not.toHaveProperty("metadata");
   });
 

--- a/packages/core/src/otel-telemetry.test.ts
+++ b/packages/core/src/otel-telemetry.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { otelTelemetry } from "./otel-telemetry.js";
+
+const original = process.env.VENDO_OTEL_TRACING;
+
+afterEach(() => {
+  if (original === undefined) delete process.env.VENDO_OTEL_TRACING;
+  else process.env.VENDO_OTEL_TRACING = original;
+});
+
+describe("otelTelemetry", () => {
+  it("returns {} when unset, so a call spreads to exactly today's behaviour", () => {
+    delete process.env.VENDO_OTEL_TRACING;
+    expect(otelTelemetry("vendo.agent.turn")).toEqual({});
+  });
+
+  it("stays off for any value that is not an explicit opt-in", () => {
+    for (const value of ["0", "false", "", "yes", "on"]) {
+      process.env.VENDO_OTEL_TRACING = value;
+      expect(otelTelemetry("vendo.agent.turn")).toEqual({});
+    }
+  });
+
+  it("emits ai-SDK telemetry settings named for the lane when opted in", () => {
+    process.env.VENDO_OTEL_TRACING = "1";
+    expect(otelTelemetry("vendo.apps.generate")).toEqual({
+      experimental_telemetry: { isEnabled: true, functionId: "vendo.apps.generate" },
+    });
+  });
+
+  it("accepts 'true' as well as '1'", () => {
+    process.env.VENDO_OTEL_TRACING = "true";
+    expect(otelTelemetry("vendo.agent.turn")).toHaveProperty("experimental_telemetry.isEnabled", true);
+  });
+
+  it("carries host metadata through when given, and omits the key when not", () => {
+    process.env.VENDO_OTEL_TRACING = "1";
+    expect(otelTelemetry("vendo.agent.turn", { tenant: "acme" })).toEqual({
+      experimental_telemetry: {
+        isEnabled: true,
+        functionId: "vendo.agent.turn",
+        metadata: { tenant: "acme" },
+      },
+    });
+    expect(otelTelemetry("vendo.agent.turn").experimental_telemetry).not.toHaveProperty("metadata");
+  });
+
+  it("is read per call, so a host can flip it without a restart", () => {
+    delete process.env.VENDO_OTEL_TRACING;
+    expect(otelTelemetry("vendo.apps.check")).toEqual({});
+    process.env.VENDO_OTEL_TRACING = "1";
+    expect(otelTelemetry("vendo.apps.check")).not.toEqual({});
+  });
+});

--- a/packages/core/src/otel-telemetry.ts
+++ b/packages/core/src/otel-telemetry.ts
@@ -18,10 +18,23 @@
  * runs inside the host's process, so the spans simply join what is already
  * there — Langfuse, Braintrust, Datadog, or nothing at all.
  *
- * OPT-IN, off by default. A host turns it on with `VENDO_OTEL_TRACING=1`.
- * (Arguably it should default to on whenever a provider is registered — a host
- * that installed OTel has already opted into collecting traces — but that is a
- * behaviour change and belongs in its own decision, not this one.)
+ * OPT-IN, off by default:
+ *
+ *   VENDO_OTEL_TRACING=1        spans WITH inputs/outputs (the SDK's default
+ *                               once enabled: full prompts and tool results)
+ *   VENDO_OTEL_TRACING=metrics  spans WITHOUT payloads — latency, tokens,
+ *                               cost, model and errors only
+ *   unset / 0 / false           no spans at all (unchanged behaviour)
+ *
+ * The `metrics` mode exists because enabling tracing should not force a host to
+ * ship user prompts and tool results to its tracing backend. Hosts that share a
+ * backend across tenants, or that care about data minimisation, need the
+ * numbers without the payloads. Per-call `recordInputs`/`recordOutputs`
+ * override the env for a lane that needs different treatment.
+ *
+ * (Arguably tracing should default to on whenever a provider is registered — a
+ * host that installed OTel has already opted into collecting traces — but that
+ * is a behaviour change and belongs in its own decision, not this one.)
  */
 
 /** Vendo's span names, so a host can filter its dashboard by lane. */
@@ -31,9 +44,35 @@ export type TelemetryLane =
   | "vendo.apps.generate"
   | "vendo.apps.check";
 
-function enabled(): boolean {
-  const flag = process.env.VENDO_OTEL_TRACING;
-  return flag === "1" || flag === "true";
+export interface OtelTelemetryOptions {
+  /** Host-meaningful labels (tenant, seat, surface) attached to the span. */
+  metadata?: Record<string, string | number | boolean>;
+  /** Override the env default for this call. */
+  recordInputs?: boolean;
+  /** Override the env default for this call. */
+  recordOutputs?: boolean;
+}
+
+interface TelemetrySettings {
+  isEnabled: true;
+  functionId: string;
+  recordInputs?: boolean;
+  recordOutputs?: boolean;
+  metadata?: Record<string, string | number | boolean>;
+}
+
+type Mode = "off" | "full" | "metrics";
+
+function mode(): Mode {
+  switch (process.env.VENDO_OTEL_TRACING) {
+    case "1":
+    case "true":
+      return "full";
+    case "metrics":
+      return "metrics";
+    default:
+      return "off";
+  }
 }
 
 /**
@@ -48,14 +87,23 @@ function enabled(): boolean {
  */
 export function otelTelemetry(
   lane: TelemetryLane,
-  metadata?: Record<string, string | number | boolean>,
-): { experimental_telemetry?: { isEnabled: true; functionId: string; metadata?: Record<string, string | number | boolean> } } {
-  if (!enabled()) return {};
+  options: OtelTelemetryOptions = {},
+): { experimental_telemetry?: TelemetrySettings } {
+  const current = mode();
+  if (current === "off") return {};
+
+  // `metrics` withholds payloads; explicit options always win over the env, so
+  // a host can trace one lane in full while the rest stay metric-only.
+  const recordInputs = options.recordInputs ?? current === "full";
+  const recordOutputs = options.recordOutputs ?? current === "full";
+
   return {
     experimental_telemetry: {
       isEnabled: true,
       functionId: lane,
-      ...(metadata === undefined ? {} : { metadata }),
+      recordInputs,
+      recordOutputs,
+      ...(options.metadata === undefined ? {} : { metadata: options.metadata }),
     },
   };
 }

--- a/packages/core/src/otel-telemetry.ts
+++ b/packages/core/src/otel-telemetry.ts
@@ -1,0 +1,61 @@
+/**
+ * OTel GenAI telemetry — the one switch that lets a host SEE the agent.
+ *
+ * The AI SDK emits OpenTelemetry GenAI spans (model, tokens, cost, latency,
+ * tool calls, errors) only when a call passes `experimental_telemetry`. It is
+ * off by default there, deliberately: a library must not export a host's
+ * prompts without being asked.
+ *
+ * Vendo never passed it, so a host that had registered a tracer provider still
+ * saw nothing from any Vendo model call — silently, with no warning and no
+ * error. Measured in a third-party Next.js host: a 4.4-minute turn that
+ * generated a working app produced zero spans; with these call sites emitting,
+ * the same prompt produced cost per turn, the model ladder escalating
+ * mini -> full, the whole tool graph, and the app-repair lane firing.
+ *
+ * There is NO vendor coupling here and no new dependency. The AI SDK resolves
+ * whatever provider the host registered through `@opentelemetry/api`; Vendo
+ * runs inside the host's process, so the spans simply join what is already
+ * there — Langfuse, Braintrust, Datadog, or nothing at all.
+ *
+ * OPT-IN, off by default. A host turns it on with `VENDO_OTEL_TRACING=1`.
+ * (Arguably it should default to on whenever a provider is registered — a host
+ * that installed OTel has already opted into collecting traces — but that is a
+ * behaviour change and belongs in its own decision, not this one.)
+ */
+
+/** Vendo's span names, so a host can filter its dashboard by lane. */
+export type TelemetryLane =
+  | "vendo.agent.turn"
+  | "vendo.agent.compaction"
+  | "vendo.apps.generate"
+  | "vendo.apps.check";
+
+function enabled(): boolean {
+  const flag = process.env.VENDO_OTEL_TRACING;
+  return flag === "1" || flag === "true";
+}
+
+/**
+ * Spread into an ai-SDK `streamText` / `generateText` call:
+ *
+ * ```ts
+ * const result = streamText({ model, messages, ...otelTelemetry("vendo.agent.turn") });
+ * ```
+ *
+ * Returns `{}` when disabled, so the call is byte-identical to today's
+ * behaviour unless a host asks for tracing.
+ */
+export function otelTelemetry(
+  lane: TelemetryLane,
+  metadata?: Record<string, string | number | boolean>,
+): { experimental_telemetry?: { isEnabled: true; functionId: string; metadata?: Record<string, string | number | boolean> } } {
+  if (!enabled()) return {};
+  return {
+    experimental_telemetry: {
+      isEnabled: true,
+      functionId: lane,
+      ...(metadata === undefined ? {} : { metadata }),
+    },
+  };
+}

--- a/packages/harnesses/src/vendo/compaction.ts
+++ b/packages/harnesses/src/vendo/compaction.ts
@@ -34,6 +34,7 @@
  * and the trigger sits at 81% so the margin is not the only thing standing
  * between a thread and a 400.
  */
+import { otelTelemetry } from "@vendoai/core";
 import {
   asSchema,
   generateText,
@@ -486,6 +487,9 @@ export async function compactContext(request: CompactionRequest): Promise<Compac
 
   const result = await generateText({
     model: request.model,
+    // Opt-in OTel GenAI spans (VENDO_OTEL_TRACING=1) — compaction is invisible
+    // spend otherwise: it costs tokens no user asked for.
+    ...otelTelemetry("vendo.agent.compaction"),
     system: SUMMARIZER_SYSTEM,
     messages: [{
       role: "user",

--- a/packages/harnesses/src/vendo/loop.ts
+++ b/packages/harnesses/src/vendo/loop.ts
@@ -18,6 +18,7 @@ import {
   VendoError,
   VENDO_MAKE_TOOL,
   VENDO_APP_BUILD_FAILED_PREFIX,
+  otelTelemetry,
   type TurnId,
   type VendoStepLimitPart,
 } from "@vendoai/core";
@@ -569,6 +570,10 @@ export async function startTurn(options: TurnLoopOptions): Promise<TurnLoop> {
     maxOutputTokens: options.context?.maxOutputTokens,
     // Stated rather than inherited — see DEFAULT_MAX_RETRIES.
     maxRetries: options.context?.maxRetries ?? DEFAULT_MAX_RETRIES,
+    // Opt-in OTel GenAI spans (VENDO_OTEL_TRACING=1) — the turn is the root
+    // span every tool call and generation hangs off, so a host reading its own
+    // dashboard sees one tree per turn.
+    ...otelTelemetry("vendo.agent.turn"),
     // ENG-252 loadout: restrict what the model may pick to the current loadout.
     // `prepareStep` re-reads it each step so a tool loaded via
     // `vendo_tools_search` becomes callable on the very next step. This gates the


### PR DESCRIPTION
# A host that registered OpenTelemetry can finally see the agent

## The problem

The ai-SDK emits OpenTelemetry GenAI spans only when a call passes
`experimental_telemetry`. It is off by default there, deliberately — a library
must not export a host's prompts without being asked.

Vendo never passes it, at any of its four model call sites. So a host that has
already registered a tracer provider sees **nothing** from Vendo: no cost, no
latency, no tool graph, no errors. It fails silently — no warning, no log line,
nothing to suggest tracing is not working. You discover it by staring at an
empty dashboard and assuming you wired it up wrong.

## How it was measured

Installed into a real third-party Next.js host (multi-tenant, Firebase auth,
~50 extracted tools), with a Langfuse OTel exporter registered in the host's
`instrumentation.ts` — nothing else changed.

**Before:** a 4.4-minute turn through the overlay that generated a working
interactive app produced **0 spans**.

**After** (`VENDO_OTEL_TRACING=1`), the same prompt:

```
vendo.agent.turn:ai.streamText                 309s   $0.1406
  gpt-5 doStream                               183s
  TOOL vendo_apps_create                       157s
    vendo.apps.generate  gpt-5-mini             28s   <- ladder attempt
    vendo.apps.generate  gpt-5                  94s   <- escalation
  TOOL vendo_apps_edit                          69s
    vendo.apps.repair    gpt-5                  16s   <- validation repair
  TOOL vendo_apps_open                          18s
```

Cost per turn, the model ladder escalating mini → full, the tool graph, and the
repair lane firing.

Within the hour it also surfaced a bug that was otherwise invisible — a
follow-up turn failing with:

```
AI_APICallError: Item with id 'rs_…' not found.
url: https://api.openai.com/v1/responses   statusCode: 404   isRetryable: false
```

Three retries, same item id, $0 each, `level=ERROR` on the span. Without these
spans that is three silent failures and a red box in the UI.

## The change

- `otelTelemetry(lane)` in `@vendoai/core` — returns `{}` unless
  `VENDO_OTEL_TRACING` is set, so behaviour is **byte-identical** for every
  existing host.
- Spread into the four call sites: `harnesses/vendo/loop.ts` (the turn),
  `harnesses/vendo/compaction.ts`, `apps/generation/engine.ts`,
  `apps/checking/strict-tool-call.ts`.
- Lanes are named so a host can filter its own dashboard: `vendo.agent.turn`,
  `vendo.agent.compaction`, `vendo.apps.generate`, `vendo.apps.check`.
- Six unit tests on the helper.

**No new dependency, no vendor coupling.** The ai-SDK resolves whatever provider
the host registered through `@opentelemetry/api`, and Vendo runs inside the
host's process — the spans simply join what is already there. Langfuse,
Braintrust, Datadog, or nothing at all.

## Open question for review

This is opt-in behind a flag. But a host that installed OpenTelemetry has
arguably already opted into collecting traces, so defaulting to on whenever a
provider is registered may be the better contract. Left as a flag here because
that is a behaviour change and deserves its own decision — happy to switch it.

## Verification

`@vendoai/core` builds and typechecks clean; `@vendoai/apps` builds clean;
`@vendoai/harnesses` typechecks clean; the new tests pass (6/6).

Note: `pnpm typecheck` via turbo could not run on this machine — turbo's binary
exits `0xC0000135` (missing DLL) under Windows — so packages were typechecked
and built directly with `tsc`. Worth a full CI run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opt-in OpenTelemetry GenAI spans for all Vendo model calls, now with a metrics-only mode. Hosts with a registered tracer can see cost, latency, tool graphs, and errors; off by default via `VENDO_OTEL_TRACING`.

- **New Features**
  - Added `otelTelemetry(lane, options?)` in `@vendoai/core`; returns `{}` unless `VENDO_OTEL_TRACING` is `1`/`true`/`metrics`. Per-call overrides: `recordInputs`, `recordOutputs`, and optional `metadata`.
  - Applied at four call sites: turn (`harnesses/vendo/loop.ts`), compaction (`harnesses/vendo/compaction.ts`), app generation (`apps/generation/engine.ts`), strict tool check (`apps/checking/strict-tool-call.ts`).
  - Lanes for filtering: `vendo.agent.turn`, `vendo.agent.compaction`, `vendo.apps.generate`, `vendo.apps.check`. No new deps; uses the host’s provider via `@opentelemetry/api`.

- **Migration**
  - Set `VENDO_OTEL_TRACING=1` or `true` for full spans (include inputs/outputs).
  - Set `VENDO_OTEL_TRACING=metrics` for spans without prompts/results.

<sup>Written for commit a2156d73d8c1ad2650d37f9c0df770d8f7e90682. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

