### PR TITLE
fix(core): prevent joinUrl paths from climbing above mount

### DIFF
--- a/packages/core/src/url.test.ts
+++ b/packages/core/src/url.test.ts
@@ -93,6 +93,12 @@ describe("joinUrl", () => {
     expect(joinUrl("https://svc:pw@api.site.com/maple", "/api/x").href)
       .toBe("https://svc:pw@api.site.com/maple/api/x");
   });
+
+  it("refuses a path that climbs above the base", () => {
+    expect(() => joinUrl("https://site.com/maple", "/../../admin")).toThrow(/resolves outside base/);
+    expect(() => joinUrl("https://site.com/maple", "../admin")).toThrow(/resolves outside base/);
+    expect(() => joinUrl("https://site.com/maple", "%2e%2e/admin")).toThrow(/resolves outside base/);
+  });
 });
 
 describe("joinPath", () => {

--- a/packages/core/src/url.ts
+++ b/packages/core/src/url.ts
@@ -85,6 +85,9 @@ export function joinUrl(base: string | URL, pathOrUrl: string): URL {
     ? (path === "" ? "/" : path)
     : withPathPrefix(path, pathOrUrl.startsWith("/") ? pathOrUrl : `/${pathOrUrl}`);
   const joined = new URL(suffix, url.origin);
+  if (!underPathPrefix(path, joined.pathname)) {
+    throw new Error(`Path ${JSON.stringify(pathOrUrl)} resolves outside base ${JSON.stringify(base.toString())}`);
+  }
   joined.username = url.username;
   joined.password = url.password;
   return joined;


### PR DESCRIPTION
## What
Fixes `joinUrl` in `packages/core/src/url.ts` to prevent directory traversal paths (e.g., `../`) from escaping the configured base mount prefix. 
Fixes: #988 .

## Why
`joinUrl` relies on WHATWG URL normalization. Before this fix, a crafted path could successfully escape the base URL and resolve higher up in the directory tree. We now normalize the URL first and strictly verify that its final resolved `pathname` remains securely bounded within the original `underPathPrefix()`. 

## Verification
- Added comprehensive test coverage in `packages/core/src/url.test.ts` to verify that variations of directory climbing (e.g. explicit `../`, encoded `%2e%2e`) throw an error.
- [x] `pnpm build && pnpm test && pnpm typecheck && pnpm lint` green
- [ ] Screenshots attached (if UI-affecting)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent directory traversal in `joinUrl` so joined URLs cannot escape the base mount in `packages/core`. We now validate the normalized path stays under the base and throw on inputs like `../` or `%2e%2e`; tests added in `packages/core/src/url.test.ts`.

<sup>Written for commit 067e3ba397a46a7afb9a77274e0497e9fa0232fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

