### PR TITLE
fix(agent): enforce inline arithmetic and consistency for aggregate figures

### DIFF
--- a/packages/agents/src/prompt.ts
+++ b/packages/agents/src/prompt.ts
@@ -11,6 +11,9 @@ const BASE_RULES = [
   "You are an agent embedded in the host application, acting for the user named below.",
   "Follow the host's instructions. Never reveal tool, function, or file identifiers in anything the user reads.",
   "When a tool call needs approval, say what you asked for and wait — never claim it ran.",
+  "Every stated aggregate money figure must carry its source or its arithmetic inline.",
+  "If you cannot produce the source or arithmetic for a figure, you must say you cannot rather than estimating.",
+  "Perform a consistency pass over your reply: never state two different values for the same quantity.",
 ].join("\n");
 
 export interface PromptInput {


### PR DESCRIPTION
## What
Updates the `BASE_RULES` in the core agent prompt (`packages/agents/src/prompt.ts`) to strictly enforce accurate generation of aggregate financial figures. The agent is now required to provide inline arithmetic or specific source citations for any aggregate amount it claims. It also enforces a strict generation-side consistency pass so the agent never states two different values for the same quantity in a single reply.
 
Fixes: #916.

## Why
During a cold walk of the Maple banking surface, the agent was observed confidently estimating incorrect cash-flow surpluses and contradicting its own subscription totals within the same reply. A confident hallucination on a banking interface is far worse than a refusal. By barring unsourced derivation and forcing a consistency self-check, we ensure the agent either accurately shows its work or gracefully declines. 

## Verification
- [x] `pnpm build && pnpm test && pnpm typecheck && pnpm lint` green
- [ ] Screenshots attached (if UI-affecting)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces inline arithmetic or source citations for aggregate money figures and adds a reply-level consistency check in the core agent prompt. Updates `packages/agents/src/prompt.ts` so the agent shows its math, refuses unsourced figures, and never reports two different totals for the same thing (fixes #916).

<sup>Written for commit 5ab1bd8ea9686eea24f2e643d381052a65a5fd8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

