### PR TITLE
fix(vendo): send store:false on the openai rung

### DIFF
--- a/packages/vendo/src/dev-creds/model.ts
+++ b/packages/vendo/src/dev-creds/model.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { acceptsSamplingParams, UNKNOWN_MODEL_MAX_OUTPUT_TOKENS } from "@vendoai/apps";
 import { meterExhaustedFromError, VendoError } from "@vendoai/core";
-import type { LanguageModel } from "ai";
+import { wrapLanguageModel, type LanguageModel, type LanguageModelMiddleware } from "ai";
 import { resolveCloudBaseUrl } from "../cli/cloud/client.js";
 import {
   describeDevCredential,
@@ -83,6 +83,11 @@ interface ProviderSpec {
   /** DEPRECATED agent-slot pin, kept working as a fallback under VENDO_MODEL. */
   modelEnv: string;
   install: string;
+  /** Options this rung sends on every call, keyed by ai-SDK
+   *  `providerOptions` namespace. NOT a construction setting: the ai-SDK reads
+   *  `providerOptions` per request, so passing these to the provider factory
+   *  never reaches the wire. */
+  callDefaults?: { namespace: string; options: Record<string, unknown> };
 }
 
 const DEFAULT_MODELS: Record<string, ProviderSpec> = {
@@ -101,6 +106,12 @@ const DEFAULT_MODELS: Record<string, ProviderSpec> = {
     fast: "gpt-5-mini",
     modelEnv: "VENDO_DEV_OPENAI_MODEL",
     install: "npm install ai@^6 @ai-sdk/openai@^3",
+    // Responses is the only stateful wire in this table. Its default sends
+    // prior turns as `item_reference` ids for OpenAI to resolve, so any org
+    // that does not retain items (Zero Data Retention) loses every tool-using
+    // turn at step two. Unconditional, not a flag: OpenAI cannot be asked
+    // whether an org retains data before the call that needs the answer.
+    callDefaults: { namespace: "openai", options: { store: false } },
   },
   google: {
     module: "@ai-sdk/google",
@@ -321,6 +332,27 @@ export class DevModelController {
     return FAST_SLOTS.has(this.slot) ? spec.fast : spec.model;
   }
 
+  /** Applies a rung's {@link ProviderSpec.callDefaults} to every request. */
+  private withCallDefaults(model: LanguageModelV3Like, spec: ProviderSpec): LanguageModelV3Like {
+    const defaults = spec.callDefaults;
+    if (defaults === undefined) return model;
+    const middleware: LanguageModelMiddleware = {
+      specificationVersion: "v3",
+      transformParams: async ({ params }) => {
+        const existing = params.providerOptions ?? {};
+        return {
+          ...params,
+          providerOptions: {
+            ...existing,
+            // Caller last: an explicit per-call value overrides the default.
+            [defaults.namespace]: { ...defaults.options, ...existing[defaults.namespace] },
+          },
+        } as typeof params;
+      },
+    };
+    return wrapLanguageModel({ model: model as never, middleware }) as unknown as LanguageModelV3Like;
+  }
+
   /** The shared delegate rung: load the provider module (an install failure
    *  resolves unavailable with the exact install command), pick the model id
    *  (per-slot precedence above), and hand the factory-built model back. */
@@ -343,7 +375,7 @@ export class DevModelController {
       config: { apiKey: string; baseURL?: string },
     ) => (model: string) => LanguageModelV3Like;
     const modelId = this.modelId(spec);
-    const model = factory(config)(modelId);
+    const model = this.withCallDefaults(factory(config)(modelId), spec);
     this.announce(`${describeDevCredential(credential)} → ${modelId}${announceSuffix}`);
     return { mode: "delegate", model, credential };
   }

--- a/packages/vendo/tests/dev-creds/model.test.ts
+++ b/packages/vendo/tests/dev-creds/model.test.ts
@@ -243,8 +243,40 @@ describe("call-time sampling params on the resolved rung", () => {
     });
     expect(await controller.doGenerate({ prompt: [], temperature: 0 })).toEqual({
       modelId: "gpt-5",
-      options: { prompt: [], temperature: 0 },
+      options: { prompt: [], temperature: 0, providerOptions: { openai: { store: false } } },
     });
+  });
+
+  it("sends store:false on every openai call, so a run never depends on OpenAI retaining items", async () => {
+    const controller = new DevModelController({
+      env: { OPENAI_API_KEY: "sk-o" },
+      importModule: optionsEcho("createOpenAI"),
+    });
+    const generated = await controller.doGenerate({ prompt: [] }) as { options: Record<string, unknown> };
+    expect(generated.options["providerOptions"]).toEqual({ openai: { store: false } });
+    const streamed = await controller.doStream({ prompt: [] }) as { options: Record<string, unknown> };
+    expect(streamed.options["providerOptions"]).toEqual({ openai: { store: false } });
+  });
+
+  it("lets a caller override the rung's call default rather than forcing it", async () => {
+    const controller = new DevModelController({
+      env: { OPENAI_API_KEY: "sk-o" },
+      importModule: optionsEcho("createOpenAI"),
+    });
+    const generated = await controller.doGenerate({
+      prompt: [],
+      providerOptions: { openai: { store: true } },
+    }) as { options: Record<string, unknown> };
+    expect(generated.options["providerOptions"]).toEqual({ openai: { store: true } });
+  });
+
+  it("adds no call defaults to a rung that has none — anthropic's wire is already stateless", async () => {
+    const controller = new DevModelController({
+      env: { ANTHROPIC_API_KEY: "sk-a" },
+      importModule: optionsEcho("createAnthropic"),
+    });
+    const generated = await controller.doGenerate({ prompt: [] }) as { options: Record<string, unknown> };
+    expect(generated.options["providerOptions"]).toBeUndefined();
   });
 
   it("leaves a sampling-era Claude resolution untouched", async () => {


### PR DESCRIPTION
Fixes #1004.

## The bug

A BYO `OPENAI_API_KEY` on an org that does not retain response items loses every tool-using turn at step two:

```
Item with id 'fc_xxxx' not found.
Items are not persisted for Zero Data Retention organizations.
```

Single-step answers work, so the key and model resolve fine. In the UI it reads only as "Something went wrong and the response didn't finish", and `vendo doctor` stays green because its probe turn never reaches a second step.

## Why only OpenAI

Probed all three wires with the same tool-call history against a mock server:

| Provider | Sends prior turns as | Stateful |
| --- | --- | --- |
| OpenAI Responses | `{"type":"item_reference","id":"fc_xxxx"}` | yes |
| Anthropic Messages | full item inline | no |
| Google `generateContent` | full item inline | no |

Not a data-retention problem, a stateful-wire problem. Responses is the only one that keeps state server-side and refers back to it, so it is the only rung that needed changing.

## The change

`store: false` makes the openai provider send items inline like the other two.

It cannot be set at construction. `openai(id, { store: false })` still emits `item_reference`; the ai-SDK reads `providerOptions` per call, so it rides a middleware wrapper applied where the rung is built. Set unconditionally rather than behind a flag, since OpenAI cannot be asked whether an org retains data before the call that needs the answer. A caller's own `providerOptions` still wins.

One thing to be aware of: reasoning under `store: false` travels as `reasoning.encrypted_content`, which the provider began sending in 3.0.25 and completed in 3.0.35. `^3` resolves well past that today, so no floor is added here, but it is worth knowing if you ever pin lower.

## Verification

Through `vendoModel()` itself, not just the provider:

```
url                 : https://api.openai.com/v1/responses
store on the wire   : false
sends item_reference: false
sends args inline   : true
```

Against a real ZDR key in `examples/demo-bank`, the request that previously failed now completes: app generated and pinned in 7.6s, zero `Item with id` errors in the log.

`pnpm build`, `pnpm typecheck`, `pnpm lint` green. Affected suites green (59 tests in `dev-creds` and `provider-deps`); leaving the full run to CI per CLAUDE.md. Three tests added: the default rides `doGenerate` and `doStream`, a caller can override it, and a rung without `callDefaults` gets nothing added.

## Prior art

Same bug against vercel/ai#10060 and #7543, openai/openai-agents-python#605, agno-agi/agno#4511. Twenty hit it too (twentyhq/twenty#20877): a ZDR-only env flag was proposed, the maintainer asked for one path for everyone, and twentyhq/twenty#20888 shipped plain `store: false`.
