### PR TITLE
fix(store): decode drill path percent-encoding with fileURLToPath

### DIFF
--- a/packages/store/tests/durability.drill.test.ts
+++ b/packages/store/tests/durability.drill.test.ts
@@ -2,6 +2,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterAll, describe, expect, it } from "vitest";
 import { backends } from "../src/backends.test-util.js";
 import { createStore, grantStore, threadStore } from "../src/index.js";
@@ -46,7 +47,7 @@ for (const backend of backends()) {
       const dataDir = await mkdtemp(join(tmpdir(), "vendo-store-drill-"));
       dirs.push(dataDir);
       const fixture = new URL("../src/__fixtures__/drill-writer.mjs", import.meta.url);
-      const child = spawn(process.execPath, [fixture.pathname, dataDir], { stdio: ["ignore", "pipe", "pipe"] });
+      const child = spawn(process.execPath, [fileURLToPath(fixture), dataDir], { stdio: ["ignore", "pipe", "pipe"] });
       await waitForMarker(child);
       const exited = new Promise<void>((resolve) => child.once("exit", () => resolve()));
       expect(child.kill("SIGKILL")).toBe(true);

--- a/packages/store/tests/split-brain.drill.test.ts
+++ b/packages/store/tests/split-brain.drill.test.ts
@@ -2,6 +2,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterAll, describe, expect, it } from "vitest";
 import { createStore, grantStore, threadStore } from "../src/index.js";
 
@@ -50,7 +51,7 @@ describe("pglite", () => {
     const dataDir = await mkdtemp(join(tmpdir(), "vendo-split-brain-"));
     dirs.push(dataDir);
     const fixture = new URL("../src/__fixtures__/drill-writer.mjs", import.meta.url);
-    const writer = spawn(process.execPath, [fixture.pathname, dataDir], { stdio: ["ignore", "pipe", "pipe"] });
+    const writer = spawn(process.execPath, [fileURLToPath(fixture), dataDir], { stdio: ["ignore", "pipe", "pipe"] });
     await waitForMarker(writer);
 
     // Second opener (this process) on the same dir: it must NOT start a second


### PR DESCRIPTION
## What
Replaces `fixture.pathname` with `fileURLToPath(fixture)` inside `durability.drill.test.ts` and `split-brain.drill.test.ts` when spawning the child test process. 
Fixes: #898.

## Why
When the project repository is located inside a directory with spaces in the absolute path (e.g. `C:\Cool Code\`), `new URL(...).pathname` preserves those spaces as percent-encoded entities (`%20`). Passing `%20` directly to the `spawn()` function causes the test drill to crash entirely, as the OS cannot locate a file with literal percent signs in its name. The built-in Node.js `fileURLToPath` gracefully handles this decoding and returns an OS-compliant file path.

## Verification
- [x] `pnpm build && pnpm test && pnpm typecheck && pnpm lint` green
- [ ] Screenshots attached (if UI-affecting)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decode drill fixture URLs to file paths with `fileURLToPath` when spawning child test processes, so drill tests run from directories with spaces. Fixes #898.

**Changes**
- Replace `fixture.pathname` with `fileURLToPath(fixture)` in `durability.drill.test.ts` and `split-brain.drill.test.ts`.
- Prevent `spawn` failures on percent-encoded paths (e.g., `%20`) across platforms; test-only change.

<sup>Written for commit d78d63c46ba2c3891a90c3d89db2064709dbc64d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

