### PR TITLE
feat(genbench): the in-house column arrives — one call, one page, and a fairness test that can fail

### DIFF
--- a/genbench/README.md
+++ b/genbench/README.md
@@ -2,11 +2,36 @@
 
 Answers "why not build this in-house?" with numbers.
 
-It runs hand-written prompts through contenders — the real Vendo pipeline today,
-raw-Claude baselines later — against one fictional banking product defined
-entirely in JSON, scores what comes back with deterministic checks, and measures
-time and money. Every contender gets the same model, the same tools, the same
-schemas and the same design brief, because that equivalence is the whole claim.
+It runs hand-written prompts through contenders — the real Vendo pipeline and a
+raw-Claude baseline today, `claude-code` next — against one fictional banking
+product defined entirely in JSON, scores what comes back with deterministic
+checks, and measures time and money. Every contender gets the same model, the
+same tools, the same schemas and the same design brief, because that equivalence
+is the whole claim.
+
+## The contenders
+
+| contender | what it is |
+| --- | --- |
+| `vendo` | the real product: the screen assembler, the guard, the apps runtime, the compiler and the Kit. Its artifact is a `.vendo` document, and the page is that document mounted through the product's own renderer |
+| `diy` | the in-house build: ONE `streamText` call, one HTML document, no product. Its artifact IS the page — no compile, no Kit, no mount |
+
+Both are handed the same thing, and that is asserted rather than asserted-to-be:
+`src/diy.test.ts` compares the prompt the diy driver really put on the wire
+against the design brief the vendo driver composes (`hostDesignBrief`), the
+descriptors its registry serves, and the responses that registry really returns
+— byte for byte. If either side drifts, the test fails and the comparison is
+void. It is the benchmark's credibility, so it is the first test to read.
+
+Both pages then carry the SAME injected recorder (`seam` in `src/render.ts`), so
+`window.vendo.callTool` means one thing whoever wrote the page, and the same
+screenshot, the same click probe and the same floor code run after that point.
+
+Every contender for a case runs **at once**. They share the browser and nothing
+else — a page each, a meter each, a clock each — and one contender's crash or
+five-minute timeout is recorded as its own failure without touching its
+siblings. Column order is the declaration order in `DRIVERS`, never the order
+they finished.
 
 ## Run it
 
@@ -19,15 +44,29 @@ Each case writes `runs/<run>/<contender>/<case>/`:
 
 | file | what it is |
 | --- | --- |
-| `artifact.vendo` | the document the contender actually saved |
-| `page.html` | the real screen: a root, the payload, and the product's own renderer bundled in. This is the only way pixels are made — for the DIY and claude-code contenders it IS the artifact |
+| `artifact.vendo` | the document the contender actually saved (vendo only — for a contender that writes HTML, `page.html` IS the artifact) |
+| `page.html` | the real screen: for vendo a root, the payload and the product's own renderer bundled in; for diy the document it wrote. This is the only way pixels are made |
 | `screenshot.png` | that page, shot once it has settled |
 | `result.json` | the five floor verdicts, the click trace, console errors, timings, tokens and dollars |
 
-and one `runs/<run>/preview.html` — every contender's live page side by side,
-scrollable, under its verdicts and numbers, with the judge's screenshot demoted
-to a thumbnail. It opens automatically on macOS. A case that outruns its
-five-minute budget is recorded `failure: "timeout"` and the run moves on.
+and one `runs/<run>/preview.html`, which is where a person actually looks:
+
+- **one section per case**, its prompt as the heading
+- **a column per contender**, in a fixed order, each live and scrollable under
+  its own verdicts and numbers, with the judge's screenshot demoted to a
+  thumbnail
+- **the world-data panel** — collapsed: every tool the case's screens could
+  call, what it does, and the exact response it answers with, overrides
+  applied. It is what makes any number on any screen checkable by eye
+- **the tool-call feed** — pinned to the bottom. Press anything in any embedded
+  screen and the call it fired lands there, tagged with the contender whose
+  frame fired it: `14:32:05 · diy-sonnet · cancel_transfer {id: tr_1}`. A
+  control that fires nothing writes nothing, which is the same verdict the floor
+  reaches
+
+It opens automatically on macOS and stays one static file — no server, offline,
+forever. A contender that outruns its five-minute budget is recorded
+`failure: "timeout"`; its siblings finish normally.
 
 Flags: `--prompt <id>` for one case, `--models sonnet,opus,haiku`,
 `--lane build` (deferred).
@@ -57,7 +96,10 @@ Five deterministic checks, no model involved:
 - **renders** — the page mounted and took up space, with nothing on the console
 - **valid** — the product's *own* checks floor blocks nothing in the saved bytes.
   Not the same as "something painted": the agent can save again after its last
-  good view, and the seam keeps the older screen
+  good view, and the seam keeps the older screen. A contender with no compile
+  step has nothing to block, so for `diy` this check collapses onto `delivered`
+  — the checks that do the work on a hand-written page are `renders`,
+  `honestData` and `wiredActions`, and all three are the same code
 - **honestData** — every number and date on screen is a value a tool returned,
   or a sum, count, min, max or mean of one numeric field across one tool's rows.
   Nothing else is allowed
@@ -66,12 +108,44 @@ Five deterministic checks, no model involved:
   nothing fails: naming a tool in a document is not being wired to it, which is
   the difference `src/probe.test.ts` exists to keep honest
 
+## What honestData does not read
+
+Two things are cut out of the text the fabrication check grades, both of them
+things a chart writes to measure with rather than to say. The cut is made in the
+browser, by hiding the containers before reading `document.body.innerText` and
+restoring them before the screenshot, so the *picture* is untouched:
+
+- **`.recharts-cartesian-axis-tick-labels`** — the scale. A chart of the
+  spending case draws `$0.00 / $750.00 / $1,500.00 / $2,250.00 / $3,000.00` down
+  its axis, and not one of those is a value any tool returned. Graded, every
+  honest chart fails; ungraded, the check keeps its meaning everywhere else.
+- **`#recharts_measurement_span`** — an offscreen scratch pad at `top:-20000px`
+  holding the last string recharts sized. No human has ever seen it, and
+  `innerText` reports it anyway.
+
+**The cost, stated plainly:** the exclusion is a whole tick layer, so the
+category axis goes with the scale. A number or date that appears **only** on a
+chart axis and nowhere else on the screen is therefore not graded. Everything
+else still is — a fabricated number in the screen's own copy fails exactly as
+before. `src/axis.test.ts` pins both halves in a real browser: it proves the
+labels really are in the page's own text, really would fail, are gone from the
+extraction, and that the screen's own copy is still caught. It fails loudly if
+recharts ever moves that text.
+
 ## Known limits
 
-The page loads no webfont — a shot must not depend on what a CDN felt like
-serving — so `world.json`'s `Inter` resolves to the system sans stack. Every
-contender is shot in the same face, which is what comparability needs; the
-brand's own typeface is not what is being measured.
+`world.json` names **Onest**, the face the product itself vendors
+(`packages/ui/src/chrome/onest-font.gen.ts`), so the style rubric asks for the
+brand's real typeface rather than a font this repo has nothing to do with. The
+page still loads no webfont — a shot must not depend on what a CDN felt like
+serving — and `ONEST_FONT_CSS` is not on any public entry of `@vendoai/ui`, so
+Onest resolves to the system sans stack, exactly as `Inter` did. **The
+typography line of the style rubric is therefore still not gradeable from
+pixels.** Every contender is shot in the same face, which is what comparability
+needs.
+
+Changing the font changed `world.hash`, so runs from before this slice do not
+compare with runs after it.
 
 The probe presses one control per fresh page, so a screen with many controls
 costs many reloads. Multi-step flows are only followed one step past a

--- a/genbench/src/axis.test.ts
+++ b/genbench/src/axis.test.ts
@@ -1,0 +1,106 @@
+/**
+ * The chart calibration.
+ *
+ * A chart has to invent numbers to measure with: recharts picks a scale and
+ * draws "$0.00 / $750.00 / $1,500.00 / $3,000.00" down the axis, and not one of
+ * those is a value a tool returned. Grading them as fabrication fails every
+ * honest chart, so the axis containers are cut out of the text the floor reads.
+ *
+ * Cutting anything out of a fabrication check is only safe if the cut is exactly
+ * that: so this pins the pair. The scale labels really are in the page's own
+ * text (and really would fail), they are gone from the extraction, and a
+ * fabricated number in the screen's OWN copy still fails.
+ *
+ * A real browser, the real bundle, real recharts — no doubles.
+ */
+import type { UIPayload } from "@vendoai/core";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { buildIndex, honestData } from "./floor.js";
+import { bundleMount, openBrowser, pageHtml, type Shooter, type Shot } from "./render.js";
+import { loadWorld, type World } from "./world.js";
+
+/** The spending case's own rows, plotted. `format="money"` is what turns the
+ *  scale into dollars, which is what makes the tick labels look like data. */
+const SPEND = [
+  { category: "housing", amount: 285000 },
+  { category: "groceries", amount: 61245 },
+  { category: "dining", amount: 43820 },
+  { category: "subscriptions", amount: 18441 },
+  { category: "transport", amount: 9675 },
+  { category: "coffee", amount: 6130 },
+];
+
+const charted = (headline: string): UIPayload => ({
+  formatVersion: "vendo-genui/v2",
+  root: "root",
+  nodes: [
+    { id: "root", component: "Stack", props: { gap: 12 }, children: ["headline", "chart"] },
+    { id: "headline", component: "Text", props: { text: headline } },
+    { id: "chart", component: "BarChart", props: { data: SPEND, xKey: "category", series: ["amount"], format: "money" } },
+  ],
+});
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+let world: World;
+let bundle: string;
+let shooter: Shooter;
+beforeAll(async () => {
+  world = await loadWorld(join(root, "world.json"));
+  bundle = await bundleMount();
+  shooter = await openBrowser();
+}, 120_000);
+afterAll(async () => await shooter.close());
+
+/** The shot the floor grades, and beside it the page's own untouched text —
+ *  the control that says the exclusion removed something real. */
+async function seen(headline: string): Promise<{ shot: Shot; raw: string; ticks: string[] }> {
+  const visit = await shooter.visit(pageHtml(charted(headline), world, bundle, "vendo-sonnet"));
+  try {
+    const shot = await visit.shot();
+    const raw = await visit.page.evaluate(() => document.body.innerText);
+    const ticks = await visit.page.evaluate(() =>
+      [...document.querySelectorAll(".recharts-cartesian-axis-tick-value")].map((node) => node.textContent ?? ""),
+    );
+    return { shot, raw, ticks };
+  } finally {
+    await visit.close();
+  }
+}
+
+describe("chart axis ticks are measuring marks, not data", () => {
+  it("drops the scale labels the chart drew, and only those", async () => {
+    const { shot, raw, ticks } = await seen("Total spent $4,243.11");
+    const scale = ticks.filter((tick) => tick.startsWith("$"));
+
+    // The control: the chart really did draw money labels, and they really are
+    // in the text the page reports for itself.
+    expect(scale.length).toBeGreaterThan(1);
+    expect(scale.filter((tick) => raw.includes(tick))).toEqual(scale);
+    // …and, ungraded, they really would read as fabrication.
+    expect(honestData(raw, buildIndex(world)).pass).toBe(false);
+
+    // What the floor actually reads: none of them, and the screen intact.
+    expect(scale.filter((tick) => shot.visibleText.includes(tick))).toEqual([]);
+    expect(shot.visibleText).toContain("Total spent $4,243.11");
+    expect(honestData(shot.visibleText, buildIndex(world)).pass).toBe(true);
+
+    // The cost, pinned rather than hidden: the exclusion is a whole tick layer,
+    // so the category axis goes with the scale. Numbers and dates that appear
+    // ONLY on a chart axis are therefore ungraded — README says so out loud.
+    expect(raw).toContain("housing");
+    expect(shot.visibleText).not.toContain("housing");
+  }, 120_000);
+
+  it("still fails a fabricated number in the screen's own copy", async () => {
+    // One cent off the real total — the same perturbation floor.test.ts pins,
+    // now on a page that also carries a chart.
+    const { shot } = await seen("Total spent $4,243.12");
+    const result = honestData(shot.visibleText, buildIndex(world));
+
+    expect(shot.visibleText).toContain("$4,243.12");
+    expect(result.pass).toBe(false);
+    expect(result.offenders).toEqual([expect.objectContaining({ kind: "number", text: "$4,243.12" })]);
+  }, 120_000);
+});

--- a/genbench/src/diy.test.ts
+++ b/genbench/src/diy.test.ts
@@ -1,0 +1,221 @@
+/**
+ * The fairness assertion.
+ *
+ * Every number this benchmark reports rests on one claim: the in-house
+ * contender was handed EXACTLY what the product's own pipeline was handed. So
+ * the bytes are compared. The design brief the vendo driver composes, the
+ * descriptors its registry serves, and the responses that registry really
+ * returns must all appear verbatim in the prompt the diy driver sends. If
+ * either side ever drifts — a reformatted brief, a hand-rolled schema dump, a
+ * different canned response — this test fails and the comparison is void.
+ *
+ * Only the MODEL is a double: the prompt under test is the one the driver
+ * actually put on the wire, not a string a helper was asked for.
+ */
+import { hostDesignBrief } from "@vendoai/apps";
+import type { RunContext } from "@vendoai/core";
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+import { diyDriver, diySystemPrompt } from "./diy.js";
+import type { Meter } from "./meter.js";
+import { authoredPage, openBrowser } from "./render.js";
+import { designRules, worldRegistry } from "./vendo.js";
+import { cannedResponse, loadCases, loadWorld, worldForCase, type Case, type World } from "./world.js";
+
+type Sent = Parameters<MockLanguageModelV3["doStream"]>[0]["prompt"];
+
+const ZERO_USAGE = {
+  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 0, text: 0, reasoning: 0 },
+} as const;
+
+const CTX: RunContext = {
+  principal: { kind: "user", subject: "genbench" },
+  venue: "chat",
+  presence: "present",
+  sessionId: "genbench_fairness",
+};
+
+const PAGE = `<!doctype html><html lang="en"><head><title>t</title></head><body><p>hi</p></body></html>`;
+
+/** A meter over a model that answers with `text` in two deltas and keeps the
+ *  prompt it was sent. Two deltas so the chunk loop is exercised, not skipped. */
+function replying(text: string): { meter: Meter; sent: () => Sent } {
+  let prompt: Sent = [];
+  const half = Math.ceil(text.length / 2);
+  const model = new MockLanguageModelV3({
+    doStream: async (options) => {
+      prompt = options.prompt;
+      return {
+        stream: simulateReadableStream({
+          chunks: [
+            { type: "text-start", id: "t" },
+            { type: "text-delta", id: "t", delta: text.slice(0, half) },
+            { type: "text-delta", id: "t", delta: text.slice(half) },
+            { type: "text-end", id: "t" },
+            { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "stop", raw: undefined } },
+          ],
+        }),
+      };
+    },
+  });
+  let tick = 0;
+  return {
+    meter: {
+      model,
+      elapsedMs: () => (tick += 1),
+      totals: () => ({ inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, calls: 0 }),
+      usd: () => 0,
+    },
+    sent: () => prompt,
+  };
+}
+
+const systemOf = (prompt: Sent): string =>
+  prompt
+    .filter((message) => message.role === "system")
+    .map((message) => message.content as string)
+    .join("\n");
+
+const userOf = (prompt: Sent): string =>
+  prompt
+    .filter((message) => message.role === "user")
+    .flatMap((message) => (message.content as Array<{ type: string; text?: string }>))
+    .map((part) => part.text ?? "")
+    .join("");
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+let world: World;
+let cases: readonly Case[];
+beforeAll(async () => {
+  world = await loadWorld(join(root, "world.json"));
+  cases = await loadCases(join(root, "cases.json"));
+});
+
+/** The prompt the driver really sent for this case's world. */
+async function promptFor(scoped: World, testCase: Case): Promise<{ system: string; user: string }> {
+  const { meter, sent } = replying(PAGE);
+  await diyDriver().run({ world: scoped, testCase, meter });
+  return { system: systemOf(sent()), user: userOf(sent()) };
+}
+
+describe("diy is handed exactly what vendo is handed", () => {
+  it("carries the product's own design brief verbatim — identity, theme JSON and style lines", async () => {
+    const { system } = await promptFor(world, cases[0]!);
+    const brief = hostDesignBrief({ theme: world.theme, designRules: designRules(world) });
+
+    // Not a substring of a substring: the whole block, exactly as the vendo
+    // driver hands it to the screen assembler.
+    expect(brief).toContain(JSON.stringify(world.theme, null, 2));
+    expect(brief).toContain(world.style[0]!);
+    expect(system).toContain(brief);
+  });
+
+  it("carries every descriptor the vendo registry serves, byte for byte", async () => {
+    const { system } = await promptFor(world, cases[0]!);
+    const descriptors = await worldRegistry(world).descriptors();
+
+    expect(descriptors.length).toBe(world.tools.length);
+    for (const descriptor of descriptors) {
+      expect(system).toContain(JSON.stringify(descriptor, null, 2));
+    }
+  });
+
+  it("carries the response that registry actually returns for each tool", async () => {
+    const { system } = await promptFor(world, cases[0]!);
+    const registry = worldRegistry(world);
+
+    for (const descriptor of await registry.descriptors()) {
+      const outcome = await registry.execute({ id: "c1", tool: descriptor.name, args: {} }, CTX);
+      expect(outcome.status).toBe("ok");
+      expect(system).toContain(JSON.stringify((outcome as { output: unknown }).output, null, 2));
+    }
+  });
+
+  it("is scoped to the case, so an overridden world reaches diy and the authored one does not", async () => {
+    const empty = cases.find((entry) => entry.id === "no-pending-transfers")!;
+    const { system } = await promptFor(worldForCase(world, empty), empty);
+
+    expect(system).toContain(JSON.stringify({ data: [] }, null, 2));
+    expect(system).not.toContain("Alex Rivera");
+  });
+
+  it("sends the case prompt as the user message, unchanged", async () => {
+    const { user } = await promptFor(world, cases[0]!);
+    expect(user).toBe(cases[0]!.prompt);
+  });
+});
+
+describe("the page answers the way the prompt promised", () => {
+  /** A SEAM test: the real injected recorder, in a real browser, called exactly
+   *  the way the prompt tells the model to call it.
+   *
+   *  Regression, from a real run on 2026-08-08: the prompt said `callTool`
+   *  "answers with the response shown under returns", and the recorder actually
+   *  answers with that response wrapped in a `ToolOutcome`. The model believed
+   *  the prompt, read `res.data`, got `undefined`, and rendered "No pending
+   *  transfers right now" over a tool holding two of them. A prompt that lies
+   *  about the seam does not measure the contender — it measures the lie. */
+  it("wraps the canned response in the envelope the prompt describes", async () => {
+    const shooter = await openBrowser();
+    try {
+      const visit = await shooter.visit(
+        authoredPage(`<!doctype html><html lang="en"><head><title>t</title></head><body><p>x</p></body></html>`, world, "diy-sonnet"),
+      );
+      try {
+        const answered = await visit.page.evaluate(() =>
+          (window as unknown as { vendo: { callTool(name: string, args: unknown): unknown } }).vendo.callTool(
+            "list_transfers",
+            { limit: 20 },
+          ),
+        );
+        const transfers = world.tools.find((tool) => tool.name === "list_transfers")!;
+
+        expect(answered).toEqual({ status: "ok", output: cannedResponse(transfers) });
+        // …and the prompt says exactly that, so the model is not guessing.
+        expect(diySystemPrompt(world)).toContain(`{ status: "ok", output:`);
+      } finally {
+        await visit.close();
+      }
+    } finally {
+      await shooter.close();
+    }
+  }, 120_000);
+});
+
+describe("the diy driver", () => {
+  it("reports the document it was given as the page", async () => {
+    const { meter } = replying(PAGE);
+    const outcome = await diyDriver().run({ world, testCase: cases[0]!, meter });
+
+    expect(outcome.page).toBe(PAGE);
+    expect(outcome.failure).toBeUndefined();
+  });
+
+  it("takes the document out of a fenced answer", async () => {
+    const { meter } = replying(`Here you go:\n\n\`\`\`html\n${PAGE}\n\`\`\`\n`);
+    const outcome = await diyDriver().run({ world, testCase: cases[0]!, meter });
+
+    expect(outcome.page).toBe(PAGE);
+  });
+
+  it("reports first paint at the settle, because a whole document is the unit", async () => {
+    const { meter } = replying(PAGE);
+    const outcome = await diyDriver().run({ world, testCase: cases[0]!, meter });
+
+    expect(outcome.firstRenderMs).toBe(outcome.settledMs);
+    // One entry per chunk boundary: the stream's shape is the evidence that the
+    // whole wait was one silence.
+    expect(outcome.snapshots.length).toBe(2);
+  });
+
+  it("fails honestly when the model answers without a document", async () => {
+    const { meter } = replying("I can't help with that.");
+    const outcome = await diyDriver().run({ world, testCase: cases[0]!, meter });
+
+    expect(outcome.page).toBeUndefined();
+    expect(outcome.failure).toBeDefined();
+  });
+});

--- a/genbench/src/diy.ts
+++ b/genbench/src/diy.ts
@@ -1,0 +1,68 @@
+/**
+ * The in-house build: one Claude call, one HTML document, no product.
+ *
+ * This is the honest shape of "why not just wire the model up ourselves?" — a
+ * team that has the same theme, the same tool schemas and the same data, and
+ * asks the model for a screen. There is no compile, no Kit and no mount: the
+ * document it writes IS the page that is shot and probed, and every floor check
+ * after that point is the same code the vendo column faces.
+ */
+import { hostDesignBrief } from "@vendoai/apps";
+import { streamText } from "ai";
+import type { Contender, RunOutcome, RunRequest } from "./run.js";
+import { designRules } from "./vendo.js";
+import { cannedResponse, type World } from "./world.js";
+
+/** Exactly what the vendo contender receives, as one prompt: the same design
+ *  brief the screen assembler is given, and the same descriptors and responses
+ *  its tool registry serves. `diy.test.ts` pins that equality byte for byte —
+ *  it is the only reason the two columns may be compared at all. */
+export function diySystemPrompt(world: World): string {
+  const tools = world.tools
+    .map((tool) => `${JSON.stringify(tool.descriptor, null, 2)}\nreturns: ${JSON.stringify(cannedResponse(tool), null, 2)}`)
+    .join("\n\n");
+  return `Write the screen the user asks for.
+
+${hostDesignBrief({ theme: world.theme, designRules: designRules(world) })}
+
+HOST TOOLS — call one from the page with \`vendo.callTool(name, args)\`. It is
+already on \`window\`, and it answers with { status: "ok", output: <the value
+shown under \`returns\`> } or { status: "error", error: { code, message } }.
+
+${tools}
+
+Return ONE complete working HTML document and nothing else: self-contained,
+inline CSS and inline JS, no build step and no network requests.`;
+}
+
+/** A whole document is the unit, and models fence one as often as not. */
+const unfence = (text: string): string => /```(?:html)?\n?([\s\S]*?)```/.exec(text)?.[1]?.trim() ?? text.trim();
+
+export function diyDriver(): Contender {
+  return { harness: "diy", run };
+}
+
+async function run({ world, testCase, meter }: RunRequest): Promise<RunOutcome> {
+  const result = streamText({ model: meter.model, system: diySystemPrompt(world), prompt: testCase.prompt });
+
+  const snapshots: Array<{ atMs: number }> = [];
+  let answer = "";
+  for await (const chunk of result.textStream) {
+    answer += chunk;
+    snapshots.push({ atMs: meter.elapsedMs() });
+  }
+  const settledMs = meter.elapsedMs();
+
+  const page = unfence(answer);
+  const delivered = /<html[\s>]|<!doctype html/i.test(page);
+  return {
+    ...(delivered ? { page } : {}),
+    blocking: [],
+    snapshots,
+    // A one-shot document paints nothing until it is whole, so first paint IS
+    // the settle. That gap against a column that streams is the measurement.
+    ...(delivered ? { firstRenderMs: settledMs } : {}),
+    settledMs,
+    ...(delivered ? {} : { failure: "the model answered without an HTML document" }),
+  };
+}

--- a/genbench/src/floor.ts
+++ b/genbench/src/floor.ts
@@ -210,6 +210,16 @@ export function wiredActions(trace: readonly Probed[], world: World): WiredActio
 
 // ---------------------------------------------------------------------- floor
 
+/** The five checks in report order, each under the name the report prints. One
+ *  list, so a score and a column can never disagree about what was checked. */
+export const checks = (floor: FloorResult): ReadonlyArray<{ name: string; pass: boolean }> => [
+  { name: "delivered", pass: floor.delivered },
+  { name: "renders", pass: floor.renders },
+  { name: "valid", pass: floor.valid },
+  { name: "honestData", pass: floor.honestData.pass },
+  { name: "wiredActions", pass: floor.wiredActions.pass },
+];
+
 export function runFloor(input: {
   world: World;
   artifact: string | undefined;

--- a/genbench/src/mount.tsx
+++ b/genbench/src/mount.tsx
@@ -19,10 +19,9 @@ import { createRoot } from "react-dom/client";
 
 declare global {
   interface Window {
-    /** The one seam every contender's page answers through — the renderer's own
-     *  action dispatch is wired to it below, and a hand-written page calls it
-     *  directly. It answers with the case's canned rows, so a runtime refetch
-     *  resolves instead of hanging. */
+    /** The one seam every contender's page answers through, injected by
+     *  `render.ts` into hand-written and product-rendered pages alike. The
+     *  renderer's action dispatch is wired to it below. */
     vendo: {
       calls: Array<{ name: string; args: Json }>;
       callTool(name: string, args: Json): ToolOutcome;
@@ -33,17 +32,6 @@ declare global {
 }
 
 const read = <T,>(id: string): T => JSON.parse(document.getElementById(id)!.textContent!) as T;
-
-const tools = read<Record<string, Json>>("tools");
-window.vendo = {
-  calls: [],
-  callTool(name, args) {
-    window.vendo.calls.push({ name, args });
-    return Object.hasOwn(tools, name)
-      ? { status: "ok", output: tools[name]! }
-      : { status: "error", error: { code: "not-found", message: `no tool ${name}` } };
-  },
-};
 
 applyThemeVars(themeCssVariables(resolveTheme(defaultVendoTheme, read<VendoTheme>("theme"))));
 const payload = read<UIPayload>("payload");

--- a/genbench/src/render.ts
+++ b/genbench/src/render.ts
@@ -3,7 +3,7 @@ import type { Json, UIPayload } from "@vendoai/core";
 import { build } from "esbuild";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { World } from "./world.js";
+import { cannedResponse, type World } from "./world.js";
 
 /** A banking app's column. Every contender is shot at the same size, so the
  *  screenshots stack side by side in the report. */
@@ -33,32 +33,95 @@ const jsonScript = (id: string, value: unknown): string =>
   `<script type="application/json" id="${id}">${JSON.stringify(value).replaceAll("<", "\\u003c")}</script>`;
 
 /**
+ * The one seam every contender's page answers through, injected as the SAME
+ * bytes whoever wrote the page: the recorder the click probe reads, answering
+ * with the case's canned rows so a runtime refetch resolves instead of hanging.
+ *
+ * It also posts every call to the parent frame. That is what lets the report
+ * page show a press in an embedded screen as it happens, tagged with the
+ * contender whose frame fired it — with no server and no shared state.
+ */
+function seam(world: World, contender: string): string {
+  const tools = Object.fromEntries(world.tools.map((tool) => [tool.name, cannedResponse(tool) as Json]));
+  return `${jsonScript("tools", tools)}
+<script>
+(function () {
+  var tools = JSON.parse(document.getElementById("tools").textContent);
+  var contender = ${JSON.stringify(contender)};
+  window.vendo = {
+    calls: [],
+    callTool: function (name, args) {
+      window.vendo.calls.push({ name: name, args: args });
+      try {
+        parent.postMessage({ genbench: "call", contender: contender, name: name, args: args, ts: Date.now() }, "*");
+      } catch (ignored) {}
+      return Object.hasOwn(tools, name)
+        ? { status: "ok", output: tools[name] }
+        : { status: "error", error: { code: "not-found", message: "no tool " + name } };
+    },
+  };
+})();
+</script>`;
+}
+
+/**
  * The page a contender is judged on: a root to mount into, the case's data, and
  * the script that paints it. The theme rides as JSON and is applied through the
  * product's own `applyThemeVars`, so nothing here re-implements theming.
- *
- * The later DIY and claude-code contenders write this file themselves — the page
- * IS their artifact, and they bypass the compile entirely. Everything a page can
- * rely on is therefore in the markup below and nowhere else.
  */
-export function pageHtml(payload: UIPayload, world: World, bundle: string): string {
-  const tools = Object.fromEntries(world.tools.map((tool) => [tool.name, (tool.data ?? { ok: true }) as Json]));
+export function pageHtml(payload: UIPayload, world: World, bundle: string, contender: string): string {
   return `<!doctype html>
 <html lang="en"><head><meta charset="utf-8"><title>genbench</title><style>
 html,body{margin:0;padding:0;background:var(--vendo-color-background,#fff);}
 #root{padding:20px;}
-</style></head><body><div id="root"></div>
+</style>
+${seam(world, contender)}
+</head><body><div id="root"></div>
 ${jsonScript("payload", payload)}
 ${jsonScript("theme", world.theme)}
-${jsonScript("tools", tools)}
 <script>${bundle.replaceAll("</script", "<\\/script")}</script>
 </body></html>`;
 }
 
+/** Where the harness gets to speak in a document it did not write. */
+const ENTRY = /<head[^>]*>|<body[^>]*>/i;
+
+/**
+ * A contender that wrote its own document gets the seam and the settle signal
+ * injected, and nothing else: the page it wrote is the page that mounts, is shot
+ * and is probed. The settle belongs to the harness because a hand-written page
+ * has no reason to know the shooter is waiting for it.
+ */
+export function authoredPage(html: string, world: World, contender: string): string {
+  const injected = `${seam(world, contender)}
+<script>addEventListener("load", function () {
+  requestAnimationFrame(function () { requestAnimationFrame(function () { window.__settled = true; }); });
+});</script>`;
+  const entry = ENTRY.exec(html);
+  return entry === null ? injected + html : html.replace(entry[0], () => entry[0] + injected);
+}
+
+/**
+ * What a chart writes to measure with, rather than to say.
+ *
+ * The tick layer — NOT `.recharts-cartesian-axis`, which holds the line and no
+ * text — carries a scale recharts computed: "$750.00 / $1,500.00 / $2,250.00" is
+ * arithmetic no tool returned. The measurement span is worse: an offscreen
+ * scratch pad at `top:-20000px` holding the last string recharts sized, which no
+ * human has ever seen and which `innerText` reports anyway.
+ *
+ * Both are hidden for the extraction and restored before the shot. Nothing else
+ * is, so a fabricated number in the screen's own copy still lands in
+ * `visibleText` and still fails. `axis.test.ts` pins both halves in a real
+ * browser, and fails loudly if recharts ever moves the text.
+ */
+const CHART_SCAFFOLDING = ".recharts-cartesian-axis-tick-labels, #recharts_measurement_span";
+
 export interface Shot {
   readonly png: Buffer;
-  /** `document.body.innerText` — the same extraction for every contender, which
-   *  is what makes the fabrication check comparable across artifact formats. */
+  /** The page's visible text minus chart axis ticks — the same extraction for
+   *  every contender, which is what makes the fabrication check comparable
+   *  across artifact formats. */
   readonly visibleText: string;
   /** Something took up space AND the browser reported no errors doing it. */
   readonly renders: boolean;
@@ -104,13 +167,25 @@ export async function openBrowser(): Promise<Shooter> {
       return {
         page,
         async shot() {
-          const { visibleText, mounted } = await page.evaluate(() => ({
-            visibleText: document.body.innerText,
-            mounted: [...document.querySelectorAll("#root *")].some((element) => {
-              const box = element.getBoundingClientRect();
-              return box.width > 0 && box.height > 0;
-            }),
-          }));
+          const { visibleText, mounted } = await page.evaluate((selector: string) => {
+            // `visibility`, not `display`: Chrome's `innerText` reports SVG text
+            // in a `display:none` subtree, and reports it correctly hidden here.
+            const scaffolding = [...document.querySelectorAll<SVGElement | HTMLElement>(selector)];
+            const was = scaffolding.map((element) => element.style.visibility);
+            for (const element of scaffolding) element.style.visibility = "hidden";
+            const visibleText = document.body.innerText;
+            scaffolding.forEach((element, index) => (element.style.visibility = was[index]!));
+            return {
+              visibleText,
+              // Anywhere in the body, not just under `#root`: a contender that
+              // wrote its own document has no root to mount into, and grading it
+              // as blank for that would be measuring the harness.
+              mounted: [...document.querySelectorAll("body *")].some((element) => {
+                const box = element.getBoundingClientRect();
+                return box.width > 0 && box.height > 0;
+              }),
+            };
+          }, CHART_SCAFFOLDING);
           return {
             png: await page.screenshot({ fullPage: true }),
             visibleText,

--- a/genbench/src/report.test.ts
+++ b/genbench/src/report.test.ts
@@ -1,0 +1,114 @@
+/**
+ * What the one page a person actually opens has to get right: a column per
+ * contender in a fixed order however the row finished, one section per case, and
+ * beside each case the data its screens were graded against — the case's own,
+ * overrides applied, or the panel is worse than useless.
+ */
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+import type { FloorResult } from "./floor.js";
+import { writePreview } from "./report.js";
+import type { CaseResult } from "./run.js";
+import { loadCases, loadWorld, worldForCase, type World } from "./world.js";
+
+const PASSING: FloorResult = {
+  delivered: true,
+  renders: true,
+  valid: true,
+  blocking: [],
+  honestData: { pass: true, offenders: [] },
+  wiredActions: { pass: true, bindings: [] },
+  pass: true,
+};
+
+const resultFor = (contender: string, testCase: string, prompt: string): CaseResult => ({
+  run: "run-1",
+  contender,
+  model: "claude-sonnet-5",
+  case: testCase,
+  prompt,
+  lane: "screen",
+  floor: PASSING,
+  timing: { firstRenderMs: 1_000, settledMs: 2_000 },
+  cost: { usage: { inputTokens: 1, outputTokens: 1, cacheReadTokens: 0, cacheWriteTokens: 0, calls: 1 }, usd: 0.01 },
+  islands: 0,
+  clientOnly: 0,
+  trace: [],
+  consoleErrors: [],
+  world: "hash",
+});
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+let world: World;
+let emptyWorld: World;
+beforeAll(async () => {
+  world = await loadWorld(join(root, "world.json"));
+  const cases = await loadCases(join(root, "cases.json"));
+  emptyWorld = worldForCase(world, cases.find((entry) => entry.id === "no-pending-transfers")!);
+});
+
+/** The page escapes everything it prints — a tool name on it came out of a
+ *  model — so an assertion about JSON on the page has to be escaped too. */
+const onPage = (value: unknown): string =>
+  JSON.stringify(value, null, 2).replace(/[&<>"]/g, (char) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[char]!);
+
+const preview = async (results: readonly CaseResult[], worlds: Record<string, World>): Promise<string> => {
+  const runDir = await mkdtemp(join(tmpdir(), "genbench-report-"));
+  await writeFile(join(runDir, "preview-input.json"), "{}");
+  return await readFile(await writePreview({ runDir, runId: "run-1", results, worlds }), "utf8");
+};
+
+describe("the preview page", () => {
+  it("keeps the column order it was given, whoever finished first", async () => {
+    const html = await preview(
+      [resultFor("vendo-sonnet", "pending-transfers", "Show my pending transfers."), resultFor("diy-sonnet", "pending-transfers", "Show my pending transfers.")],
+      { "pending-transfers": world },
+    );
+
+    expect(html.indexOf("vendo-sonnet")).toBeLessThan(html.indexOf("diy-sonnet"));
+  });
+
+  it("gives every case its own section rather than stacking them under one prompt", async () => {
+    const html = await preview(
+      [
+        resultFor("vendo-sonnet", "pending-transfers", "Show my pending transfers."),
+        resultFor("diy-sonnet", "pending-transfers", "Show my pending transfers."),
+        resultFor("vendo-sonnet", "spend-overview", "Show me where my money went."),
+        resultFor("diy-sonnet", "spend-overview", "Show me where my money went."),
+      ],
+      { "pending-transfers": world, "spend-overview": world },
+    );
+
+    expect(html.split(`class="case"`).length - 1).toBe(2);
+    expect(html).toContain("Show my pending transfers.");
+    expect(html).toContain("Show me where my money went.");
+  });
+
+  it("shows the case's own tool data, overrides applied, not the authored world", async () => {
+    const html = await preview([resultFor("vendo-sonnet", "no-pending-transfers", "Show my pending transfers.")], {
+      "no-pending-transfers": emptyWorld,
+    });
+
+    expect(html).toContain("World data");
+    expect(html).toContain("cancel_transfer");
+    // The empty override is what these screens were graded against…
+    expect(html).toContain(onPage({ data: [] }));
+    // …so the authored rows must not be sitting beside them as if they were.
+    expect(html).not.toContain("Alex Rivera");
+    // A write tool answers with its acknowledgement, the same one the page gives.
+    expect(html).toContain(onPage({ ok: true }));
+  });
+
+  it("carries the listener that turns a press in an embedded page into a feed row", async () => {
+    const html = await preview([resultFor("vendo-sonnet", "spend-overview", "Show me where my money went.")], {
+      "spend-overview": world,
+    });
+
+    expect(html).toContain(`<ol id="feed">`);
+    expect(html).toContain(`addEventListener("message"`);
+    expect(html).toContain(`call.genbench !== "call"`);
+  });
+});

--- a/genbench/src/report.ts
+++ b/genbench/src/report.ts
@@ -1,23 +1,14 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import type { Binding, FloorResult, Offender } from "./floor.js";
+import { checks, type Binding, type Offender } from "./floor.js";
 import type { CaseResult } from "./run.js";
+import { cannedResponse, type World } from "./world.js";
 
 const escape = (value: string): string =>
   value.replace(/[&<>"]/g, (char) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[char]!);
 
 const verdict = (ok: boolean): string =>
   `<span class="v ${ok ? "ok" : "no"}">${ok ? "✓" : "✕"} ${ok ? "pass" : "fail"}</span>`;
-
-const CHECKS = ["delivered", "renders", "valid", "honestData", "wiredActions"] as const;
-
-const passes = (floor: FloorResult): boolean[] => [
-  floor.delivered,
-  floor.renders,
-  floor.valid,
-  floor.honestData.pass,
-  floor.wiredActions.pass,
-];
 
 const offenderList = (offenders: readonly Offender[]): string =>
   offenders.length === 0
@@ -32,9 +23,10 @@ const bindingList = (bindings: readonly Binding[]): string =>
     : `<ul class="notes">${bindings
         .map(
           (b) =>
-            `<li><code>${escape(b.where)}</code> <span>${escape(b.tool ?? "—")}${
-              b.why === undefined ? "" : ` — ${escape(b.why)}`
-            }</span> ${b.known && b.argsValid ? '<i class="ok">✓</i>' : '<i class="no">✕</i>'}</li>`,
+            `<li><code>${escape(b.where)}</code> <span>${[b.tool, b.why]
+              .filter((part) => part !== undefined)
+              .map(escape)
+              .join(" — ")}</span> ${b.known && b.argsValid ? '<i class="ok">✓</i>' : '<i class="no">✕</i>'}</li>`,
         )
         .join("")}</ul>`;
 
@@ -52,15 +44,15 @@ async function column(runDir: string, result: CaseResult): Promise<string> {
   const caseDir = join(result.contender, result.case);
   const shot = await readFile(join(runDir, caseDir, "screenshot.png")).catch(() => undefined);
   const page = await readFile(join(runDir, caseDir, "page.html"), "utf8").catch(() => undefined);
-  const scored = passes(result.floor);
-  const total = scored.filter(Boolean).length;
+  const scored = checks(result.floor);
+  const total = scored.filter((check) => check.pass).length;
   const { usage } = result.cost;
   const tokens = usage.inputTokens + usage.outputTokens + usage.cacheReadTokens + usage.cacheWriteTokens;
 
   return `<section class="col">
   <header>
     <div><h2>${escape(result.contender)}</h2><p>${escape(result.model)}</p></div>
-    <span class="score ${total === 5 ? "ok" : "no"}">${total}/5</span>
+    <span class="score ${total === scored.length ? "ok" : "no"}">${total}/${scored.length}</span>
   </header>
   <figure>${
     page === undefined
@@ -75,7 +67,7 @@ async function column(runDir: string, result: CaseResult): Promise<string> {
   }
   ${result.failure === undefined ? "" : `<p class="failure">${escape(result.failure)}</p>`}
   ${consoleNote(result.consoleErrors)}
-  <dl class="floor">${CHECKS.map((name, index) => `<div><dt>${name}</dt><dd>${verdict(scored[index]!)}</dd></div>`).join("")}</dl>
+  <dl class="floor">${scored.map((check) => `<div><dt>${check.name}</dt><dd>${verdict(check.pass)}</dd></div>`).join("")}</dl>
   ${
     result.floor.blocking.length === 0
       ? ""
@@ -92,22 +84,56 @@ async function column(runDir: string, result: CaseResult): Promise<string> {
 </section>`;
 }
 
+/** The case's own truth, collapsed: every tool the screens could call, what it
+ *  does, and the exact response it answers with — case overrides applied. It is
+ *  what makes any number on any screen above checkable by eye. */
+function worldPanel(world: World | undefined): string {
+  if (world === undefined) return "";
+  const tools = world.tools
+    .map(
+      (tool) => `<div class="tool">
+      <p><code>${escape(tool.name)}</code> ${escape(tool.descriptor.description ?? "")}</p>
+      <pre>${escape(JSON.stringify(cannedResponse(tool), null, 2))}</pre>
+    </div>`,
+    )
+    .join("");
+  return `<details class="world">
+  <summary><span class="chev">▸</span>World data · ${world.tools.length} tools · the only numbers these screens may show</summary>
+  <div class="tools">${tools}</div>
+</details>`;
+}
+
+async function caseSection(runDir: string, testCase: string, results: readonly CaseResult[], world: World | undefined): Promise<string> {
+  const columns = await Promise.all(results.map(async (result) => await column(runDir, result)));
+  return `<section class="case">
+  <p class="case-id">${escape(testCase)}</p>
+  <h2 class="prompt">${escape(results[0]?.prompt ?? "")}</h2>
+  ${worldPanel(world)}
+  <div class="grid">${columns.join("")}</div>
+</section>`;
+}
+
 const CSS = `
-:root{--ink:#17171a;--sec:#5c5c66;--ter:#8e8e99;--page:#f6f5f3;--card:#fff;--line:#e6e4e0;--ok:#1d7a4f;--no:#b4342a;}
+:root{--ink:#17171a;--sec:#5c5c66;--ter:#8e8e99;--page:#f6f5f3;--card:#fff;--line:#e6e4e0;--ok:#1d7a4f;--no:#b4342a;--feed:136px;}
 *{box-sizing:border-box}
 body{margin:0;background:var(--page);color:var(--ink);
   font:450 15px/1.5 ui-sans-serif,-apple-system,"Segoe UI",sans-serif;
   -webkit-font-smoothing:antialiased;border-top:3px solid var(--ink);}
-.wrap{max-width:1240px;margin:0 auto;padding:32px 24px 64px}
+/* Room for the fixed call feed, so the last column is never hidden under it. */
+.wrap{max-width:1240px;margin:0 auto;padding:32px 24px calc(var(--feed) + 32px)}
 h1{margin:0;font-size:28px;font-weight:600;letter-spacing:-.02em}
-.prompt{margin:8px 0 0;font-size:15px;color:var(--sec);max-width:62ch}
 .meta{margin:16px 0 0;font:450 11px/1 ui-monospace,SFMono-Regular,Menlo,monospace;
   letter-spacing:.08em;text-transform:uppercase;color:var(--ter)}
 .meta span+span::before{content:"·";margin:0 8px;color:var(--line)}
+/* The prompt is the heading a person reads; the case id is a filename. */
+.case{margin-top:48px}
+.case-id{margin:0;font:450 11px/1 ui-monospace,SFMono-Regular,Menlo,monospace;
+  letter-spacing:.08em;text-transform:uppercase;color:var(--ter)}
+.prompt{margin:10px 0 0;font-size:20px;font-weight:500;line-height:1.35;letter-spacing:-.01em;max-width:62ch}
 /* Capped, not fluid: the screenshots are shot at a fixed 480px, so letting a
    single column stretch to the full page would upscale and blur the one
    artifact the whole page exists to show. */
-.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(360px,540px));gap:24px;margin-top:32px;justify-content:center}
+.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(360px,540px));gap:24px;margin-top:24px;justify-content:center}
 .col{background:var(--card);border-radius:10px;padding:20px;box-shadow:0 1px 2px rgba(0,0,0,.04),0 8px 24px rgba(0,0,0,.05)}
 .col>header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px}
 h2{margin:0;font-size:15px;font-weight:600}
@@ -139,27 +165,116 @@ dl{margin:0}dl>div{display:flex;align-items:baseline;justify-content:space-betwe
 .metrics>div{display:block}
 .metrics dt{font:450 10px/1 ui-monospace,Menlo,monospace;letter-spacing:.08em;text-transform:uppercase;color:var(--ter)}
 .metrics dd{margin:6px 0 0;font:450 15px/1 ui-monospace,Menlo,monospace;font-variant-numeric:tabular-nums}
+
+/* ---- the world panel: closed by default, because it is the reference you
+       reach for, not the thing you came to look at ---- */
+.world{margin:20px 0 0;background:var(--card);border-radius:10px;box-shadow:0 1px 2px rgba(0,0,0,.04)}
+.world>summary{display:flex;align-items:center;gap:8px;padding:13px 16px;cursor:pointer;list-style:none;
+  font:450 11px/1 ui-monospace,SFMono-Regular,Menlo,monospace;letter-spacing:.08em;
+  text-transform:uppercase;color:var(--sec)}
+.world>summary::-webkit-details-marker{display:none}
+.chev{display:inline-block;color:var(--ter);transition:transform 150ms ease-out}
+.world[open] .chev{transform:rotate(90deg)}
+.tools{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:20px;padding:4px 16px 18px}
+.tool p{margin:0;font-size:13px;line-height:1.5;color:var(--sec);max-width:58ch}
+.tool code{font:600 12px/1.4 ui-monospace,SFMono-Regular,Menlo,monospace;color:var(--ink)}
+/* Uncapped on purpose: this panel exists so a person can check a number against
+   the truth, and a scroll box that clips at row two reads as the whole answer. */
+.tool pre{margin:8px 0 0;padding:10px 12px;background:var(--page);border-radius:6px;
+  font:450 11px/1.55 ui-monospace,SFMono-Regular,Menlo,monospace;color:var(--sec)}
+
+/* ---- the call feed: every press in every embedded screen, as it happens ---- */
+.feed{position:fixed;inset:auto 0 0 0;z-index:2;height:var(--feed);display:flex;flex-direction:column;
+  background:var(--card);border-top:1px solid var(--line);box-shadow:0 -6px 24px rgba(0,0,0,.06)}
+.feed-label{flex:none;margin:0;padding:12px 24px 8px;
+  font:450 10px/1 ui-monospace,SFMono-Regular,Menlo,monospace;letter-spacing:.08em;
+  text-transform:uppercase;color:var(--ter)}
+#feed{flex:1;min-height:0;overflow-y:auto;margin:0;padding:0 24px 12px;list-style:none}
+#feed:empty::after{display:block;font-size:13px;color:var(--ter);
+  content:"press a control in any screen above — every call it makes lands here"}
+#feed li{display:flex;gap:10px;align-items:baseline;padding:6px 0;border-top:1px solid var(--line);
+  font:450 12px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace;
+  transition:opacity 150ms ease-out,transform 150ms ease-out}
+#feed li:first-child{border-top:0}
+#feed time{color:var(--ter);font-variant-numeric:tabular-nums}
+#feed .who{font-weight:600;color:var(--sec)}
+#feed code{color:var(--ink);background:var(--page);padding:1px 5px;border-radius:4px}
+#feed .args{color:var(--ter);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+@starting-style{#feed li{opacity:0;transform:translateY(-4px)}}
+@media (prefers-reduced-motion:reduce){#feed li{transition:opacity 150ms ease-out}}
 `;
 
-/** One page per run: every contender's REAL screen side by side, live and
- *  scrollable, each under its own floor verdicts and numbers. It stays a single
- *  static file you can `open` — the live frames are relative links into the run
- *  folder beside it, and the judge's screenshots are inlined. */
+/**
+ * The feed's whole mechanism: every embedded page's `vendo.callTool` posts to
+ * its parent (see `seam` in `render.ts`), and this is the parent. Text goes in
+ * through `textContent`, never markup — a tool name in this feed came out of a
+ * model, and the report must not let one write HTML into itself.
+ *
+ * No server, no shared state: the file works from disk, offline, forever.
+ */
+const FEED_SCRIPT = `
+addEventListener("message", function (event) {
+  var call = event.data;
+  if (call === null || typeof call !== "object" || call.genbench !== "call") return;
+  var row = document.createElement("li");
+  var when = document.createElement("time");
+  when.textContent = new Date(call.ts).toLocaleTimeString("en-US", { hour12: false });
+  var who = document.createElement("span");
+  who.className = "who";
+  who.textContent = call.contender;
+  var tool = document.createElement("code");
+  tool.textContent = call.name;
+  var args = document.createElement("span");
+  args.className = "args";
+  args.textContent = "{" + Object.keys(call.args || {}).map(function (key) {
+    var value = call.args[key];
+    return key + ": " + (typeof value === "string" ? value : JSON.stringify(value));
+  }).join(", ") + "}";
+  row.append(when, who, tool, args);
+  document.getElementById("feed").prepend(row);
+});
+`;
+
+/**
+ * One page per run: every contender's REAL screen side by side under its own
+ * verdicts and numbers, each case with the data those screens were graded
+ * against, and one live feed of what pressing anything actually calls.
+ *
+ * It stays a single static file you can `open` — the live frames are relative
+ * links into the run folder beside it, and the judge's screenshots are inlined.
+ */
 export async function writePreview(input: {
   runDir: string;
   runId: string;
   results: readonly CaseResult[];
+  worlds: Readonly<Record<string, World>>;
 }): Promise<string> {
   const first = input.results[0];
-  const columns = await Promise.all(input.results.map(async (result) => await column(input.runDir, result)));
+  // Grouped in first-seen order, and each group in the order the row was run:
+  // which contender finished first never moves a column.
+  const order = [...new Set(input.results.map((result) => result.case))];
+  const sections = await Promise.all(
+    order.map(
+      async (testCase) =>
+        await caseSection(
+          input.runDir,
+          testCase,
+          input.results.filter((result) => result.case === testCase),
+          input.worlds[testCase],
+        ),
+    ),
+  );
+
   const html = `<!doctype html>
 <html lang="en"><head><meta charset="utf-8"><title>genbench · ${escape(first?.case ?? input.runId)}</title>
 <style>${CSS}</style></head><body><div class="wrap">
-<h1>${escape(first?.case ?? "run")}</h1>
-<p class="prompt">${escape(first?.prompt ?? "")}</p>
+<h1>genbench</h1>
 <p class="meta"><span>${escape(input.runId)}</span><span>world ${escape(first?.world ?? "")}</span><span>${escape(first?.lane ?? "screen")} lane</span></p>
-<div class="grid">${columns.join("")}</div>
-</div></body></html>`;
+${sections.join("")}
+</div>
+<aside class="feed"><p class="feed-label">tool calls</p><ol id="feed"></ol></aside>
+<script>${FEED_SCRIPT}</script>
+</body></html>`;
   const path = join(input.runDir, "preview.html");
   await writeFile(path, html);
   return path;

--- a/genbench/src/run.test.ts
+++ b/genbench/src/run.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Every contender for a case runs at once, so one column's crash or one
+ * column's silence has to stay its own. `attempt` is where that is decided: it
+ * turns a driver's exception and a driver's hang into ordinary results, which is
+ * what lets the row be gathered with `Promise.all` — and so what keeps the
+ * report's column order the contender order, whatever order they finish in.
+ */
+import { describe, expect, it } from "vitest";
+import { attempt, contenders } from "./run.js";
+
+describe("attempt", () => {
+  it("hands back what the work returned", async () => {
+    expect(await attempt(async () => "a screen", 1_000)).toEqual({ done: "a screen" });
+  });
+
+  it("keeps a healthy sibling when one contender throws and another never answers", async () => {
+    const row = await Promise.all([
+      attempt(async () => "vendo", 100),
+      attempt(async () => {
+        throw new Error("diy exploded");
+      }, 100),
+      attempt(() => new Promise<string>(() => undefined), 100),
+    ]);
+
+    expect(row).toEqual([{ done: "vendo" }, { failure: "diy exploded" }, { failure: "timeout" }]);
+  });
+});
+
+describe("contenders", () => {
+  it("lists every driver in one fixed order, so the columns never shuffle", () => {
+    expect(contenders(["sonnet"]).map((contender) => contender.slug)).toEqual(["vendo-sonnet", "diy-sonnet"]);
+  });
+
+  it("gives each contender its own slug per model", () => {
+    expect(contenders(["sonnet", "haiku"]).map((contender) => contender.slug)).toEqual([
+      "vendo-sonnet",
+      "vendo-haiku",
+      "diy-sonnet",
+      "diy-haiku",
+    ]);
+  });
+});

--- a/genbench/src/run.ts
+++ b/genbench/src/run.ts
@@ -4,10 +4,11 @@ import { spawn } from "node:child_process";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { runFloor, type FloorResult } from "./floor.js";
+import { diyDriver } from "./diy.js";
+import { checks, runFloor, type FloorResult } from "./floor.js";
 import { meteredModel, MODEL_IDS, type Meter, type ModelAlias, type UsageTotals } from "./meter.js";
 import { probe, type Probed } from "./probe.js";
-import { bundleMount, openBrowser, pageHtml } from "./render.js";
+import { authoredPage, bundleMount, openBrowser, pageHtml, type Shot } from "./render.js";
 import { writePreview } from "./report.js";
 import { vendoDriver } from "./vendo.js";
 import { loadCases, loadWorld, worldForCase, type Case, type Lane, type World } from "./world.js";
@@ -36,7 +37,12 @@ export interface RunOutcome {
   readonly blocking: readonly string[];
   /** The settled screen, as the product itself compiled it. */
   readonly payload?: UIPayload;
-  readonly snapshots: ReadonlyArray<{ atMs: number; payload: UIPayload }>;
+  /** A contender that writes its own document returns it here instead of a
+   *  payload: these bytes ARE the artifact, and they mount unchanged. */
+  readonly page?: string;
+  /** When the contender had something new to show. Only the clock is shared —
+   *  what each snapshot holds is the driver's own business. */
+  readonly snapshots: ReadonlyArray<{ atMs: number }>;
   readonly firstRenderMs?: number;
   readonly settledMs: number;
   /** The contender's own failure sentence, when it has one. */
@@ -71,7 +77,9 @@ export interface CaseResult {
   readonly failure?: string;
 }
 
-const DRIVERS: Partial<Record<HarnessId, () => Contender>> = { vendo: vendoDriver };
+/** Declaration order is column order — the report never sorts by who finished
+ *  first. The claude-code column joins here the day its driver lands. */
+const DRIVERS: Partial<Record<HarnessId, () => Contender>> = { vendo: vendoDriver, diy: diyDriver };
 
 interface Args {
   readonly only?: string;
@@ -108,8 +116,7 @@ function asAlias(value: string): ModelAlias {
   return value as ModelAlias;
 }
 
-/** Every contender that has a driver today, in every requested model. The diy
- *  and claude-code columns join here the day their drivers land. */
+/** Every contender that has a driver today, in every requested model. */
 export function contenders(models: readonly ModelAlias[]): readonly ContenderId[] {
   return Object.keys(DRIVERS).flatMap((harness) =>
     models.map((model) => ({ harness: harness as HarnessId, model, slug: `${harness}-${model}` })),
@@ -119,10 +126,27 @@ export function contenders(models: readonly ModelAlias[]): readonly ContenderId[
 /** The recharts-backed Kit components (packages/ui/src/kit/charts/). */
 const CHARTS = new Set(["LineChart", "BarChart", "DonutChart", "Sparkline"]);
 
-/** One case's whole budget — generation, paint and probe. A contender that hangs
- *  costs the run this much and no more; the case is recorded failed and the next
- *  one starts. */
+/** One contender's whole budget for one case — generation, paint and probe. A
+ *  contender that hangs costs the run this much and no more; its column is
+ *  recorded failed and its siblings keep their own clocks. */
 const CASE_TIMEOUT_MS = 5 * 60_000;
+
+/**
+ * One contender's whole attempt as a settled value.
+ *
+ * Its own crash and its own silence become results here, never exceptions, so
+ * the row can be gathered with `Promise.all`: a column that dies takes down
+ * nothing but itself, and every column keeps its place.
+ */
+export async function attempt<T>(work: () => Promise<T>, budgetMs: number): Promise<{ done?: T; failure?: string }> {
+  return await Promise.race([
+    work().then(
+      (done) => ({ done }),
+      (error: unknown) => ({ failure: error instanceof Error ? error.message : String(error) }),
+    ),
+    new Promise<{ failure: string }>((settle) => setTimeout(() => settle({ failure: "timeout" }), budgetMs).unref()),
+  ]);
+}
 
 const nodesOf = (payload: UIPayload | undefined): ReadonlyArray<{ source?: string; component?: string }> =>
   (payload as { nodes?: Array<{ source?: string; component?: string }> } | undefined)?.nodes ?? [];
@@ -157,84 +181,103 @@ async function main(argv: readonly string[]): Promise<number> {
   const bundle = await bundleMount();
   const shooter = await openBrowser();
   const results: CaseResult[] = [];
+  /** The world each case was actually graded against — what the report's data
+   *  panel shows, so a person can check any number on any screen against it. */
+  const worlds: Record<string, World> = {};
+
+  /** One column of one case, start to finish, reporting rather than throwing. */
+  const runOne = async (contender: ContenderId, testCase: Case, scoped: World): Promise<CaseResult> => {
+    const modelId = MODEL_IDS[contender.model];
+    // Its own meter, so a sibling's tokens and a sibling's clock are never
+    // charged to this column.
+    const meter = meteredModel(anthropic(modelId), modelId);
+
+    // Raced against the clock as one unit: generation, paint and probe all spend
+    // the person's wait, so one budget covers all three.
+    const { done, failure: broke } = await attempt(async () => {
+      const outcome = await DRIVERS[contender.harness]!().run({ world: scoped, testCase, meter });
+      // Either the product compiled a payload into a page, or the contender
+      // wrote the page itself. From here on both are just a page.
+      const html =
+        outcome.page !== undefined
+          ? authoredPage(outcome.page, scoped, contender.slug)
+          : outcome.payload === undefined
+            ? undefined
+            : pageHtml(outcome.payload, scoped, bundle, contender.slug);
+      if (html === undefined) return { outcome, trace: [] as Probed[] };
+      const visit = await shooter.visit(html);
+      try {
+        return { outcome, html, shot: await visit.shot(), trace: await probe(visit) };
+      } finally {
+        await visit.close();
+      }
+    }, CASE_TIMEOUT_MS);
+
+    const outcome = done?.outcome;
+    const shot: Shot | undefined = done?.shot;
+    const trace = done?.trace ?? [];
+    // Whatever the contender actually delivered: a document for vendo, the page
+    // itself for a contender that writes HTML.
+    const floor = runFloor({
+      world: scoped,
+      artifact: outcome?.artifact ?? outcome?.page,
+      blocking: outcome?.blocking ?? [],
+      trace,
+      shot,
+    });
+
+    const caseDir = join(runDir, contender.slug, testCase.id);
+    await mkdir(caseDir, { recursive: true });
+    if (outcome?.artifact !== undefined) await writeFile(join(caseDir, "artifact.vendo"), outcome.artifact);
+    if (done?.html !== undefined) await writeFile(join(caseDir, "page.html"), done.html);
+    if (shot !== undefined) await writeFile(join(caseDir, "screenshot.png"), shot.png);
+
+    const failure = broke ?? outcome?.failure;
+    const result: CaseResult = {
+      run: runId,
+      contender: contender.slug,
+      model: modelId,
+      case: testCase.id,
+      prompt: testCase.prompt,
+      lane: testCase.lane,
+      floor,
+      timing: {
+        ...(outcome?.firstRenderMs === undefined ? {} : { firstRenderMs: outcome.firstRenderMs }),
+        settledMs: outcome?.settledMs ?? meter.elapsedMs(),
+      },
+      cost: { usage: meter.totals(), usd: meter.usd() },
+      islands: countIslands(outcome?.payload),
+      clientOnly: countClientOnly(outcome?.payload),
+      trace,
+      consoleErrors: shot?.consoleErrors ?? [],
+      world: world.hash,
+      ...(failure === undefined ? {} : { failure }),
+    };
+    await writeFile(join(caseDir, "result.json"), `${JSON.stringify(result, null, 2)}\n`);
+    console.log(
+      `· ${contender.slug} / ${testCase.id} · floor ${checks(floor).filter((check) => check.pass).length}/5` +
+        ` · ${result.timing.settledMs}ms · $${result.cost.usd.toFixed(4)}`,
+    );
+    return result;
+  };
 
   try {
-    for (const contender of contenders(args.models)) {
-      const driver = DRIVERS[contender.harness]!();
-      for (const testCase of cases) {
-        const modelId = MODEL_IDS[contender.model];
-        const meter = meteredModel(anthropic(modelId), modelId);
-        const scoped = worldForCase(world, testCase);
-        console.log(`· ${contender.slug} / ${testCase.id}`);
-
-        // Raced against the clock as one unit: generation, paint and probe all
-        // spend the person's wait, so one budget covers all three.
-        const done = await Promise.race([
-          (async () => {
-            const outcome = await driver.run({ world: scoped, testCase, meter });
-            if (outcome.payload === undefined) return { outcome, trace: [] as Probed[] };
-            const html = pageHtml(outcome.payload, scoped, bundle);
-            const visit = await shooter.visit(html);
-            try {
-              return { outcome, html, shot: await visit.shot(), trace: await probe(visit) };
-            } finally {
-              await visit.close();
-            }
-          })(),
-          new Promise<undefined>((settle) => setTimeout(() => settle(undefined), CASE_TIMEOUT_MS).unref()),
-        ]);
-
-        const outcome = done?.outcome;
-        const shot = done?.shot;
-        const trace = done?.trace ?? [];
-        const floor = runFloor({
-          world: scoped,
-          artifact: outcome?.artifact,
-          blocking: outcome?.blocking ?? [],
-          trace,
-          shot,
-        });
-
-        const caseDir = join(runDir, contender.slug, testCase.id);
-        await mkdir(caseDir, { recursive: true });
-        if (outcome?.artifact !== undefined) await writeFile(join(caseDir, "artifact.vendo"), outcome.artifact);
-        if (done?.html !== undefined) await writeFile(join(caseDir, "page.html"), done.html);
-        if (shot !== undefined) await writeFile(join(caseDir, "screenshot.png"), shot.png);
-
-        const failure = done === undefined ? "timeout" : outcome?.failure;
-        const result: CaseResult = {
-          run: runId,
-          contender: contender.slug,
-          model: modelId,
-          case: testCase.id,
-          prompt: testCase.prompt,
-          lane: testCase.lane,
-          floor,
-          timing: {
-            ...(outcome?.firstRenderMs === undefined ? {} : { firstRenderMs: outcome.firstRenderMs }),
-            settledMs: outcome?.settledMs ?? meter.elapsedMs(),
-          },
-          cost: { usage: meter.totals(), usd: meter.usd() },
-          islands: countIslands(outcome?.payload),
-          clientOnly: countClientOnly(outcome?.payload),
-          trace,
-          consoleErrors: shot?.consoleErrors ?? [],
-          world: world.hash,
-          ...(failure === undefined ? {} : { failure }),
-        };
-        await writeFile(join(caseDir, "result.json"), `${JSON.stringify(result, null, 2)}\n`);
-        results.push(result);
-        console.log(
-          `  floor ${[floor.delivered, floor.renders, floor.valid, floor.honestData.pass, floor.wiredActions.pass].filter(Boolean).length}/5` +
-            ` · ${result.timing.settledMs}ms · $${result.cost.usd.toFixed(4)}`,
-        );
-      }
+    for (const testCase of cases) {
+      const scoped = worldForCase(world, testCase);
+      worlds[testCase.id] = scoped;
+      // The whole row at once. The contenders share only the browser, and each
+      // gets its own page in it; the order of `results` is the order of
+      // `contenders`, whatever order they finish in.
+      const row = await Promise.all(
+        contenders(args.models).map(async (contender) => await runOne(contender, testCase, scoped)),
+      );
+      results.push(...row);
     }
   } finally {
     await shooter.close();
   }
 
-  const preview = await writePreview({ runDir, runId, results });
+  const preview = await writePreview({ runDir, runId, results, worlds });
   console.log(preview);
   if (process.platform === "darwin") spawn("open", [preview], { detached: true, stdio: "ignore" }).unref();
   return results.every((result) => result.floor.pass) ? 0 : 1;

--- a/genbench/src/vendo.ts
+++ b/genbench/src/vendo.ts
@@ -5,7 +5,7 @@ import { screenAssembler } from "@vendoai/harnesses";
 import { createStore, workspaceStore } from "@vendoai/store";
 import { vendoVerbsRegistry } from "@vendoai/vendo";
 import type { Contender, RunOutcome, RunRequest } from "./run.js";
-import type { World } from "./world.js";
+import { cannedResponse, type World } from "./world.js";
 
 const PRINCIPAL: Principal = { kind: "user", subject: "genbench" };
 
@@ -22,7 +22,7 @@ export function worldRegistry(world: World): ToolRegistry {
       if (tool === undefined) {
         return { status: "error", error: { code: "not-found", message: `no tool ${call.tool}` } };
       }
-      return { status: "ok", output: (tool.data ?? { ok: true }) as never };
+      return { status: "ok", output: cannedResponse(tool) as never };
     },
   };
 }

--- a/genbench/src/world.ts
+++ b/genbench/src/world.ts
@@ -35,6 +35,12 @@ export interface World {
   readonly hash: string;
 }
 
+/** What a tool answers with, wherever it is asked: the registry the vendo run
+ *  binds, the recorder every benchmark page carries, and the diy prompt. One
+ *  definition, so a read's rows and a write's bare acknowledgement cannot mean
+ *  one thing to one contender and another to the next. */
+export const cannedResponse = (tool: DerivedTool): unknown => tool.data ?? { ok: true };
+
 export type Lane = "screen" | "build";
 
 export interface Case {

--- a/genbench/world.json
+++ b/genbench/world.json
@@ -11,13 +11,13 @@
       "danger": "#C43E2F",
       "border": "#E5E7EB"
     },
-    "typography": { "fontFamily": "Inter, sans-serif", "baseSize": "14px" },
+    "typography": { "fontFamily": "Onest, sans-serif", "baseSize": "14px" },
     "radius": { "small": "8px", "medium": "8px", "large": "8px" },
     "density": "comfortable",
     "motion": "full"
   },
   "style": [
-    "uses the theme exactly: brand green, Inter, 8px corners — no invented colors or fonts",
+    "uses the theme exactly: brand green, Onest, 8px corners — no invented colors or fonts",
     "money always shows 2 decimals with currency symbol",
     "destructive actions ask for confirmation",
     "dates shown as 'Aug 1' style, never ISO"


### PR DESCRIPTION
Stacked on #1065 (`yousefh409/genbench-slice-2`). Review that first; this diff is
only the slice-3 commit.

genbench had one column, so it could not answer its own question. Now it has
two, they run side by side, and the claim that they were handed the same thing
is a test that fails when it isn't true.

## How to run it

```sh
pnpm build                                   # genbench reads the built @vendoai/* dists
ANTHROPIC_API_KEY=… pnpm --filter @vendoai/genbench genbench run --prompt pending-transfers
```

It opens `runs/<run>/preview.html` on macOS. Scoped gate:

```sh
pnpm build
cd genbench && npx vitest run --maxWorkers=2 --minWorkers=2   # 51 passed
pnpm typecheck && pnpm lint
```

## What to look at

**`src/diy.test.ts` first.** It is the reason any number in this benchmark means
anything. It runs the real diy driver against a mock model, captures the prompt
the driver *actually put on the wire*, and asserts that prompt contains, byte
for byte:

- `hostDesignBrief({ theme, designRules })` — the exact block the vendo driver
  hands the screen assembler, identity and theme JSON and style lines included
- every descriptor `worldRegistry(world).descriptors()` serves, as
  `JSON.stringify(descriptor, null, 2)`
- for each tool, the response that registry's **real `execute`** returns

Nothing in it is a paraphrase, so it fails on drift on either side. Proof it
can fail: replacing `hostDesignBrief(...)` with a hand-rolled block that reads
identically (`THEME TOKENS:\n${JSON.stringify(world.theme)}…`) turns it red.

It also caught a live bug during this slice. The prompt told the model
`callTool` "answers with the response shown under `returns`"; the recorder
actually answers with that response wrapped in a `ToolOutcome`. The model
believed the prompt, read `res.data`, and rendered **"No pending transfers right
now"** over a tool holding two of them. There is now a browser-backed seam test
pinning the prompt's promise against what the page really returns, and the diy
column renders the transfers correctly.

**Then `src/axis.test.ts`** — the honestData calibration, and the one place this
PR takes something away from a check. Read the "What honestData does not read"
section of the README with it; the cost is stated there and pinned by the test.

## Deliberate changes to existing behaviour

| change | why it moves verdicts |
| --- | --- |
| `visibleText` drops `.recharts-cartesian-axis-tick-labels` and `#recharts_measurement_span` | a spending chart draws `$0.00 / $750.00 / $1,500.00 / $2,250.00 / $3,000.00` down its axis — none of it from a tool — so **every honest chart failed honestData**. The measurement span is an offscreen scratch pad at `top:-20000px` that nobody has ever seen and `innerText` reported anyway. Cut in the browser and restored before the screenshot, so pixels are untouched |
| `renders` looks for a box anywhere in `body`, not only under `#root` | a contender that writes its own document has no `#root`. Left alone, **every diy page would have failed `renders` for a harness detail** |
| `world.json`: `Inter` → `Onest` | Onest is the face the product itself vendors. This changes `world.hash`, so runs from before this slice do not compare with runs after it |

No existing test was modified. The 17 honestData tests and both probe tests pass
untouched.

## The live run

`pnpm genbench run --prompt pending-transfers`, run `2026-08-08T19-28-14`:

| | floor | first paint | settled | cost |
| --- | --- | --- | --- | --- |
| **vendo-sonnet** | 4/5 | 56.6 s | 98.4 s | $0.2163 |
| **diy-sonnet** | 4/5 | 34.0 s | 34.0 s | $0.0757 |

Both fail the same check, for opposite reasons, and that is the interesting part:

- **vendo** — `cancel_transfer` fires with `{}`. That is the known open Kit forms
  defect (the form drops its field value); it is reported truthfully here and
  **not worked around**.
- **diy** — one Cancel button fires nothing at all, and two more controls are
  dead. Its `first paint` equals its `settled` because a one-shot document paints
  nothing until it is whole: 34 s of blank screen versus vendo's 57 s to first
  pixels out of a 98 s total.

An earlier run on the same code is worth knowing about: the model wrote
`renderError('We couldn\\'t load…')` into its inline JS, the whole script failed
to parse, and the screen sat on "Fetching your transfers…" forever — 3/5, and a
perfect illustration of what the benchmark exists to measure. The variance
between runs is real and this is a single sample.

## Verified in a real browser

Chromium, the real `preview.html` over `file://`, real clicks. 3 frames loaded,
0 console errors on the report page. Clicking **Cancel transfer** inside the
vendo iframe produced a live feed row, and the diy page's own load call landed
there by itself:

```
12:31:23  vendo-sonnet  cancel_transfer  {}
12:31:20  diy-sonnet    list_transfers   {limit: 20}
```

The `{}` is the Kit forms defect, visible to a human without opening a JSON file.

Screenshots (gitignored under `genbench/runs/`, not force-added — pull the branch
and re-run, or grab them from the run folder):

- `genbench/runs/2026-08-08T19-28-14/evidence-1-preview.png` — two live columns, feed already logging
- `genbench/runs/2026-08-08T19-28-14/evidence-2-world-panel.png` — the world-data panel open, every row of truth visible
- `genbench/runs/2026-08-08T19-28-14/evidence-3-feed.png` — the feed after a real click

## Parked for you

`world.json` now says Onest, but **no page renders in Onest**, so the
typography line of the style rubric is still not gradeable from pixels.
`ONEST_FONT_CSS` is not exported from any public entry of `@vendoai/ui` (only
`CHROME_CSS`, which would restyle every contender's page), the `exports` map
blocks a deep import, and there is no standalone font file in the repo. Making
this real needs a one-line public export from a product package — your call, not
mine. Stated in the README's Known limits so nobody reads the rubric as graded.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the in-house `diy` contender: one `streamText` call that returns a full HTML page, run side-by-side with `vendo`. A new fairness test compares the exact bytes sent to each column and fails on drift.

- **New Features**
  - New `diy` driver builds its prompt from the same design brief, tool descriptors, and canned responses as `vendo`.
  - Fairness test (`src/diy.test.ts`) captures the real prompt and checks it byte-for-byte against `hostDesignBrief`, registry descriptors, and tool outputs.
  - Shared seam injected into all pages so `window.vendo.callTool` behaves identically; also posts calls to the parent for the live feed.
  - Preview page now groups by case, keeps a fixed column order, shows a world-data panel (overrides applied), and streams a real-time tool-call feed.
  - Cases run both contenders concurrently; `attempt` turns crashes/timeouts into results so one dead column doesn’t block the row.

- **Behavior changes**
  - `honestData` stops grading Recharts axis tick labels and `#recharts_measurement_span`; pixels are unchanged. `src/axis.test.ts` pins the exclusion and its cost.
  - `renders` now checks for any box in `body`, not only under `#root`, so authored documents are graded correctly.
  - `world.json` switches font to Onest (from the product) which changes `world.hash`; typography is still not graded due to no public `ONEST_FONT_CSS` export from `@vendoai/ui`.

<sup>Written for commit da463a2bdbaf726bbc73681dcb23ab78e332bc02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

