### PR TITLE
docs: mark the vendo() harness, app generation, and genui as consult-first zones

### DIFF
--- a/packages/apps/src/generation/CLAUDE.md
+++ b/packages/apps/src/generation/CLAUDE.md
@@ -1,16 +1,17 @@
-# STOP — Yousef-involved zone
+# STOP — author-involved zone
 
-This folder is the core of the product. Yousef is personally involved in
-every change here. Never edit this folder on your own initiative.
+This folder is the core of the product. The author is personally involved
+in every change here. Never edit this folder on your own initiative.
 
 Before changing ANY file under this folder:
 
 1. Write up the proposed change as markdown IN CHAT: what changes, why,
    and the edits themselves — file-by-file, with the new code shown.
-2. Wait for Yousef's direction. He may redirect, trim, or rewrite the
-   approach — iterate the write-up until he says go.
+2. Wait for the author's direction. They may redirect, trim, or rewrite
+   the approach — iterate the write-up until they say go.
 3. Only then apply the edits, exactly as agreed.
 
 Never delegate work in this folder to subagents or background workers —
-it is worked in-session, with Yousef. If a broader task merely touches
-this folder, pause at the boundary and consult him before crossing it.
+it is worked in-session, with the author. If a broader task merely
+touches this folder, pause at the boundary and consult them before
+crossing it.

--- a/packages/apps/src/generation/CLAUDE.md
+++ b/packages/apps/src/generation/CLAUDE.md
@@ -1,0 +1,16 @@
+# STOP — Yousef-involved zone
+
+This folder is the core of the product. Yousef is personally involved in
+every change here. Never edit this folder on your own initiative.
+
+Before changing ANY file under this folder:
+
+1. Write up the proposed change as markdown IN CHAT: what changes, why,
+   and the edits themselves — file-by-file, with the new code shown.
+2. Wait for Yousef's direction. He may redirect, trim, or rewrite the
+   approach — iterate the write-up until he says go.
+3. Only then apply the edits, exactly as agreed.
+
+Never delegate work in this folder to subagents or background workers —
+it is worked in-session, with Yousef. If a broader task merely touches
+this folder, pause at the boundary and consult him before crossing it.

--- a/packages/core/src/genui/CLAUDE.md
+++ b/packages/core/src/genui/CLAUDE.md
@@ -1,16 +1,17 @@
-# STOP — Yousef-involved zone
+# STOP — author-involved zone
 
-This folder is the core of the product. Yousef is personally involved in
-every change here. Never edit this folder on your own initiative.
+This folder is the core of the product. The author is personally involved
+in every change here. Never edit this folder on your own initiative.
 
 Before changing ANY file under this folder:
 
 1. Write up the proposed change as markdown IN CHAT: what changes, why,
    and the edits themselves — file-by-file, with the new code shown.
-2. Wait for Yousef's direction. He may redirect, trim, or rewrite the
-   approach — iterate the write-up until he says go.
+2. Wait for the author's direction. They may redirect, trim, or rewrite
+   the approach — iterate the write-up until they say go.
 3. Only then apply the edits, exactly as agreed.
 
 Never delegate work in this folder to subagents or background workers —
-it is worked in-session, with Yousef. If a broader task merely touches
-this folder, pause at the boundary and consult him before crossing it.
+it is worked in-session, with the author. If a broader task merely
+touches this folder, pause at the boundary and consult them before
+crossing it.

--- a/packages/core/src/genui/CLAUDE.md
+++ b/packages/core/src/genui/CLAUDE.md
@@ -1,0 +1,16 @@
+# STOP — Yousef-involved zone
+
+This folder is the core of the product. Yousef is personally involved in
+every change here. Never edit this folder on your own initiative.
+
+Before changing ANY file under this folder:
+
+1. Write up the proposed change as markdown IN CHAT: what changes, why,
+   and the edits themselves — file-by-file, with the new code shown.
+2. Wait for Yousef's direction. He may redirect, trim, or rewrite the
+   approach — iterate the write-up until he says go.
+3. Only then apply the edits, exactly as agreed.
+
+Never delegate work in this folder to subagents or background workers —
+it is worked in-session, with Yousef. If a broader task merely touches
+this folder, pause at the boundary and consult him before crossing it.

--- a/packages/harnesses/src/vendo/CLAUDE.md
+++ b/packages/harnesses/src/vendo/CLAUDE.md
@@ -1,16 +1,17 @@
-# STOP — Yousef-involved zone
+# STOP — author-involved zone
 
-This folder is the core of the product. Yousef is personally involved in
-every change here. Never edit this folder on your own initiative.
+This folder is the core of the product. The author is personally involved
+in every change here. Never edit this folder on your own initiative.
 
 Before changing ANY file under this folder:
 
 1. Write up the proposed change as markdown IN CHAT: what changes, why,
    and the edits themselves — file-by-file, with the new code shown.
-2. Wait for Yousef's direction. He may redirect, trim, or rewrite the
-   approach — iterate the write-up until he says go.
+2. Wait for the author's direction. They may redirect, trim, or rewrite
+   the approach — iterate the write-up until they say go.
 3. Only then apply the edits, exactly as agreed.
 
 Never delegate work in this folder to subagents or background workers —
-it is worked in-session, with Yousef. If a broader task merely touches
-this folder, pause at the boundary and consult him before crossing it.
+it is worked in-session, with the author. If a broader task merely
+touches this folder, pause at the boundary and consult them before
+crossing it.

--- a/packages/harnesses/src/vendo/CLAUDE.md
+++ b/packages/harnesses/src/vendo/CLAUDE.md
@@ -1,0 +1,16 @@
+# STOP — Yousef-involved zone
+
+This folder is the core of the product. Yousef is personally involved in
+every change here. Never edit this folder on your own initiative.
+
+Before changing ANY file under this folder:
+
+1. Write up the proposed change as markdown IN CHAT: what changes, why,
+   and the edits themselves — file-by-file, with the new code shown.
+2. Wait for Yousef's direction. He may redirect, trim, or rewrite the
+   approach — iterate the write-up until he says go.
+3. Only then apply the edits, exactly as agreed.
+
+Never delegate work in this folder to subagents or background workers —
+it is worked in-session, with Yousef. If a broader task merely touches
+this folder, pause at the boundary and consult him before crossing it.


### PR DESCRIPTION
Folder-scoped CLAUDE.md files in `packages/harnesses/src/vendo/`, `packages/apps/src/generation/`, and `packages/core/src/genui/`.

These three folders are the core of the product. The CLAUDE.md (auto-loaded whenever an agent works with files in the folder) requires: write the proposed change up as markdown in chat, iterate with Yousef until he says go, only then edit — and never hand the folder to subagents or background workers.

Docs-only change, no code touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marked `packages/harnesses/src/vendo/`, `packages/apps/src/generation/`, and `packages/core/src/genui/` as consult-first zones with folder-scoped `CLAUDE.md` requiring an in-chat proposal and author approval before any edit. Docs only; no code changes, and no delegation to subagents or background workers in these folders.

<sup>Written for commit e86d0bae0c17f30b92bfc8124d52de07432416c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

