### PR TITLE
genbench: claude-code contender driver (fenced; wiring follows slice 3)

### DIFF
--- a/genbench/package.json
+++ b/genbench/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@ai-sdk/anthropic": "3.0.12",
     "@ai-sdk/provider": "3.0.2",
+    "@anthropic-ai/claude-agent-sdk": ">=0.3.0 <1",
     "@playwright/test": "^1.49.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.2.0",

--- a/genbench/src/claude-code.test.ts
+++ b/genbench/src/claude-code.test.ts
@@ -1,0 +1,217 @@
+/**
+ * The claude-code contender, with everything real except the SDK.
+ *
+ * The double is the SDK boundary and nothing else: it writes into the workspace
+ * the driver actually made, on disk, so the file-watching, the snapshots and the
+ * cleanup are the driver's own behaviour and not a fixture's.
+ */
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { hostDesignBrief } from "@vendoai/apps";
+import { existsSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+import { claudeCodeDriver, worldBlock, type AgentSdk } from "./claude-code.js";
+import { meteredModel, MODEL_IDS, usdFor, type Meter } from "./meter.js";
+import { designRules } from "./vendo.js";
+import { loadCases, loadWorld, worldForCase, type Case, type World } from "./world.js";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+let world: World;
+beforeAll(async () => {
+  world = await loadWorld(join(root, "world.json"));
+});
+
+const caseFor = (id: string): Case => ({ id, lane: "screen", prompt: "Show my pending transfers", pass: [] });
+
+/** The run's clock, and nothing else the driver may lean on: this contender is
+ *  billed by the SDK's own session, so a meter it actually used would be a lie. */
+function clock(): Meter {
+  let tick = 0;
+  return {
+    model: "claude-sonnet-5",
+    elapsedMs: () => (tick += 1),
+    totals: () => ({ inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, calls: 0 }),
+    usd: () => 0,
+  };
+}
+
+const SDK_USAGE = {
+  input_tokens: 1_200,
+  output_tokens: 8_400,
+  cache_read_input_tokens: 5_000,
+  cache_creation_input_tokens: 900,
+} as const;
+
+interface Seen {
+  prompt?: string;
+  options?: Record<string, unknown>;
+}
+
+/** A session that writes each revision in turn and then finishes, exactly as the
+ *  real one does: one message per write, one `result` at the end. */
+function writingSdk(revisions: readonly string[], seen: Seen, subtype = "success"): AgentSdk {
+  return {
+    query({ prompt, options }) {
+      seen.prompt = prompt;
+      seen.options = options;
+      return {
+        async *[Symbol.asyncIterator]() {
+          for (const html of revisions) {
+            await writeFile(join(options["cwd"] as string, "index.html"), html);
+            yield { type: "user", message: { content: [{ type: "tool_result" }] } };
+          }
+          yield { type: "result", subtype, usage: SDK_USAGE, total_cost_usd: 0.0421, num_turns: revisions.length };
+        },
+      };
+    },
+  };
+}
+
+/** A session that never answers — the shape a wall-clock bound exists for. */
+function hangingSdk(seen: Seen): AgentSdk {
+  return {
+    query({ options }) {
+      seen.options = options;
+      return {
+        async *[Symbol.asyncIterator]() {
+          await new Promise<void>(() => undefined);
+          yield {};
+        },
+      };
+    },
+  };
+}
+
+const workspaceOf = (seen: Seen): string => seen.options!["cwd"] as string;
+
+describe("the world block", () => {
+  it("is the product's own design brief, byte for byte", async () => {
+    const brief = hostDesignBrief({ theme: world.theme, designRules: designRules(world) });
+
+    // Not a vacuous containment: the brief carries the theme the screen agent is
+    // handed and the host's own rules, or the two contenders are told different
+    // things about the same world.
+    expect(brief).toContain("THEME TOKENS:");
+    expect(brief).toContain("Maple, a consumer banking app");
+    expect(worldBlock(world)).toContain(brief);
+  });
+
+  it("carries every derived tool schema and the rows it returns", () => {
+    const block = worldBlock(world);
+    const tools: unknown = JSON.parse(block.slice(block.indexOf("[")));
+
+    expect(tools).toEqual(world.tools.map((tool) => ({ tool: tool.descriptor, returns: tool.data })));
+  });
+});
+
+describe("driving Claude Code", () => {
+  it("hands the session the world block, the case's prompt and a file-only loadout", async () => {
+    const seen: Seen = {};
+    await claudeCodeDriver({ sdk: writingSdk(["<html></html>"], seen) }).run({
+      world,
+      testCase: caseFor("pending-transfers"),
+      meter: clock(),
+    });
+
+    expect(seen.prompt).toContain(worldBlock(world));
+    expect(seen.prompt).toContain("Show my pending transfers");
+    expect(seen.options).toMatchObject({
+      cwd: expect.any(String),
+      model: MODEL_IDS.sonnet,
+      tools: ["Read", "Write", "Edit"],
+      permissionMode: "bypassPermissions",
+      settingSources: [],
+    });
+  });
+
+  it("snapshots every write of index.html, in order, on the run's clock", async () => {
+    const seen: Seen = {};
+    const outcome = await claudeCodeDriver({ sdk: writingSdk(["<p>one</p>", "<p>two</p>", "<p>three</p>"], seen) }).run({
+      world,
+      testCase: caseFor("pending-transfers"),
+      meter: clock(),
+    });
+
+    expect(outcome.writes.map((write) => write.html)).toEqual(["<p>one</p>", "<p>two</p>", "<p>three</p>"]);
+    const times = outcome.writes.map((write) => write.atMs);
+    expect(times).toEqual([...times].sort((a, b) => a - b));
+    expect(outcome.artifact).toBe("<p>three</p>");
+    expect(outcome.firstRenderMs).toBe(times[0]);
+    expect(outcome.settledMs).toBeGreaterThanOrEqual(times.at(-1)!);
+    expect(outcome.failure).toBeUndefined();
+    expect(existsSync(workspaceOf(seen))).toBe(false);
+  });
+
+  it("reports the SDK's own tokens, priced from genbench's one table", async () => {
+    const outcome = await claudeCodeDriver({ model: "opus", sdk: writingSdk(["<p>done</p>"], {}) }).run({
+      world,
+      testCase: caseFor("pending-transfers"),
+      meter: clock(),
+    });
+
+    const usage = { inputTokens: 1_200, outputTokens: 8_400, cacheReadTokens: 5_000, cacheWriteTokens: 900, calls: 1 };
+    expect(outcome.usage).toEqual(usage);
+    expect(outcome.usd).toBe(usdFor(usage, MODEL_IDS.opus));
+  });
+
+  it("reports a session that ended badly as a failure, with whatever it wrote", async () => {
+    const outcome = await claudeCodeDriver({
+      sdk: writingSdk(["<p>half</p>"], {}, "error_max_turns"),
+    }).run({ world, testCase: caseFor("pending-transfers"), meter: clock() });
+
+    expect(outcome.artifact).toBe("<p>half</p>");
+    expect(outcome.failure).toBe("error_max_turns");
+  });
+
+  it("gives back a timeout instead of throwing when the session outruns its budget", async () => {
+    const seen: Seen = {};
+    const outcome = await claudeCodeDriver({ sdk: hangingSdk(seen), timeoutMs: 50 }).run({
+      world,
+      testCase: caseFor("pending-transfers"),
+      meter: clock(),
+    });
+
+    expect(outcome.failure).toBe("timeout");
+    expect(outcome.artifact).toBeUndefined();
+    expect(outcome.writes).toEqual([]);
+    // A workspace left behind by the one path that does not finish is the leak
+    // nobody would notice until a laptop ran out of disk.
+    expect(existsSync(workspaceOf(seen))).toBe(false);
+  });
+});
+
+/** ONE live session, off unless asked for. Every double above answers the
+ *  question "does the driver read a session correctly"; only this one answers
+ *  "are these the options a real engine accepts", which no fixture can. */
+const LIVE = process.env.GENBENCH_LIVE === "1" && (process.env.ANTHROPIC_API_KEY ?? "") !== "";
+
+describe.skipIf(!LIVE)("one live session", () => {
+  it(
+    "builds a real page for a real case, and says what it cost",
+    async () => {
+      const testCase = (await loadCases(join(root, "cases.json"))).find((entry) => entry.id === "pending-transfers")!;
+      const modelId = MODEL_IDS.sonnet;
+      const meter = meteredModel(createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY! })(modelId), modelId);
+
+      const outcome = await claudeCodeDriver({ model: "sonnet" }).run({
+        world: worldForCase(world, testCase),
+        testCase,
+        meter,
+      });
+
+      const { usage } = outcome;
+      const tokens = usage.inputTokens + usage.outputTokens + usage.cacheReadTokens + usage.cacheWriteTokens;
+      console.log(
+        `live claude-code · ${outcome.settledMs} ms · ${outcome.writes.length} writes · ` +
+          `${tokens.toLocaleString("en-US")} tokens · $${outcome.usd.toFixed(4)} · ${outcome.artifact?.length ?? 0} bytes`,
+      );
+      expect(outcome.failure).toBeUndefined();
+      // The two seams the page is measured through, in the bytes it left behind.
+      expect(outcome.artifact).toContain("__settled");
+      expect(outcome.artifact).toContain("callTool");
+    },
+    12 * 60_000,
+  );
+});

--- a/genbench/src/claude-code.ts
+++ b/genbench/src/claude-code.ts
@@ -1,0 +1,236 @@
+/**
+ * The claude-code contender — the strong in-house baseline.
+ *
+ * Not a single generation call: a coding agent with hands, working in a scratch
+ * directory, writing and rewriting one page until it is happy. It is handed the
+ * SAME world every other column gets — `hostDesignBrief` for the theme and the
+ * host's rules, the derived tool schemas, the rows each read answers with — and
+ * the page contract the Vendo column gets for free from the renderer.
+ *
+ * It is billed by its OWN session, not by genbench's metered model: the SDK
+ * spawns its own engine and never touches `meter.model`. So the tokens ride the
+ * outcome instead, priced through the same `usdFor` table as every other column
+ * (`ClaudeCodeOutcome`). The meter is still the run's clock, and the only one.
+ */
+import { hostDesignBrief } from "@vendoai/apps";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { MODEL_IDS, usdFor, type ModelAlias, type UsageTotals } from "./meter.js";
+import type { Contender, RunOutcome, RunRequest } from "./run.js";
+import { designRules } from "./vendo.js";
+import type { Case, World } from "./world.js";
+
+/** The bits of the Agent SDK this driver uses. Narrow on purpose, exactly as
+ *  `packages/apps/src/claude-turn.ts` keeps it: the real message union has ~40
+ *  members and this loop branches on one. */
+export interface AgentSdk {
+  query(params: {
+    prompt: string;
+    options: Record<string, unknown>;
+  }): AsyncIterable<Record<string, unknown>>;
+}
+
+export interface ClaudeCodeOptions {
+  /** Which model the session thinks with. The run's matrix picks it. */
+  readonly model?: ModelAlias;
+  /** Test seam — production loads the Agent SDK from the declared dependency. */
+  readonly sdk?: AgentSdk;
+  /** Test seam; production uses {@link WALL_CLOCK_MS}. */
+  readonly timeoutMs?: number;
+}
+
+export interface ClaudeCodeOutcome extends RunOutcome {
+  /** The artifact IS the page: no compile, no payload, no Kit (`render.ts`). */
+  readonly format: "html";
+  /** One per observed write of `index.html`, oldest first, on the run's clock.
+   *  `RunOutcome.snapshots` cannot carry these — it is typed to the product's
+   *  compiled `UIPayload`, which this contender never produces. */
+  readonly writes: ReadonlyArray<{ atMs: number; html: string }>;
+  /** What the SDK's own session spent, and that spend at genbench's prices. */
+  readonly usage: UsageTotals;
+  readonly usd: number;
+}
+
+/** Agentic builds are slower than one generation call, so the bound is wider
+ *  than the case budget in `run.ts` — a wall clock, not a step count. */
+const WALL_CLOCK_MS = 10 * 60_000;
+
+const PAGE = "index.html";
+
+/** Every contender is handed the same world in the same words: the product's own
+ *  design brief (theme tokens + the host's rules), then the derived tool schemas
+ *  and the rows each read answers with. Both halves come from the functions the
+ *  Vendo column itself is built on, so the two can never be told different
+ *  things about one world. */
+export function worldBlock(world: World): string {
+  return [
+    hostDesignBrief({ theme: world.theme, designRules: designRules(world) }),
+    "",
+    "HOST TOOLS — `returns` is exactly what calling that tool answers with, and the only data allowed on the screen:",
+    JSON.stringify(
+      world.tools.map((tool) => ({ tool: tool.descriptor, returns: tool.data })),
+      null,
+      2,
+    ),
+  ].join("\n");
+}
+
+/** What the benchmark page IS for a contender that writes the file itself. The
+ *  Vendo column gets all of this from the product — `window.vendo.callTool` and
+ *  `window.__settled` are wired by `mount.tsx`, the theme by `applyThemeVars` —
+ *  so stating it here is what keeps the columns judged on the screen rather than
+ *  on knowing the harness. */
+const PAGE_CONTRACT = `Write ONE file, \`${PAGE}\`, in the current directory. Nothing else is read.
+
+- SELF-CONTAINED. Inline every style and script. The page is opened with no network at all, so a CDN link, a webfont URL or an import of anything paints a blank screen.
+- WIRED. Define this before you draw, with TOOLS holding the \`returns\` rows above, keyed by tool name:
+  window.vendo = { calls: [], callTool(name, args) { this.calls.push({ name, args }); return TOOLS[name] ? { status: "ok", output: TOOLS[name] } : { status: "error", error: { code: "not-found", message: "no tool " + name } }; } };
+  Every control a person can press must call window.vendo.callTool("<tool name>", { ...arguments }) with arguments its input schema accepts. A step that confirms before acting must carry role="dialog", or the call behind it is never seen.
+- FINISHED. Set window.__settled = true once the screen has drawn; a page that never sets it is recorded as never having finished.
+- HONEST. Every number and date on the screen must be a value in the rows above, or a sum, count, min, max or mean of one numeric field across one tool's rows. Anything else is graded as invented.
+- It is shot at 480x900, and the file you leave behind is the only thing anyone sees.`;
+
+const brief = (world: World, testCase: Case): string =>
+  [worldBlock(world), "", PAGE_CONTRACT, "", `TASK: ${testCase.prompt}`].join("\n");
+
+function sessionOptions(workspace: string, modelId: string, abort: AbortController): Record<string, unknown> {
+  return {
+    cwd: workspace,
+    model: modelId,
+    abortController: abort,
+    // The contender IS Claude Code, so it thinks with Claude Code's own system
+    // prompt. Only the loadout below is ours.
+    systemPrompt: { type: "preset", preset: "claude_code" },
+    // `tools` is the availability list; `allowedTools` would only auto-approve
+    // what is already there. One file in a scratch directory needs no shell and
+    // no network, and nothing here can ask a person anything.
+    tools: ["Read", "Write", "Edit"],
+    permissionMode: "bypassPermissions",
+    allowDangerouslySkipPermissions: true,
+    // The operator's own CLAUDE.md, settings, skills and any `.mcp.json` the
+    // session writes itself stay out: a laptop's private tooling would silently
+    // become this column's advantage.
+    settingSources: [],
+    strictMcpConfig: true,
+  };
+}
+
+/** By dynamic import, so a run of the Vendo column alone never loads the SDK's
+ *  ~250MB platform binary. */
+async function loadAgentSdk(): Promise<AgentSdk> {
+  return (await import("@anthropic-ai/claude-agent-sdk")) as unknown as AgentSdk;
+}
+
+const numberOf = (value: unknown): number => (typeof value === "number" && Number.isFinite(value) ? value : 0);
+
+/** The SDK's own `usage` block in the vocabulary the report already speaks. Its
+ *  `input_tokens` excludes both cache halves, exactly as the meter's `noCache`
+ *  does, so both columns price the same fact. `calls` counts the SDK's turns —
+ *  the model calls inside one are the engine's business and are not reported. */
+function record(totals: Record<keyof UsageTotals, number>, raw: unknown): void {
+  const usage = (typeof raw === "object" && raw !== null ? raw : {}) as Record<string, unknown>;
+  totals.inputTokens += numberOf(usage["input_tokens"]);
+  totals.outputTokens += numberOf(usage["output_tokens"]);
+  totals.cacheReadTokens += numberOf(usage["cache_read_input_tokens"]);
+  totals.cacheWriteTokens += numberOf(usage["cache_creation_input_tokens"]);
+  totals.calls += 1;
+}
+
+/** A `Contender` whose outcome is the wider one: `run.ts` reads it through the
+ *  base interface, and the wiring that gives this column its tokens and its page
+ *  reads the rest. */
+export interface ClaudeCodeContender extends Contender {
+  run(request: RunRequest): Promise<ClaudeCodeOutcome>;
+}
+
+export function claudeCodeDriver(options: ClaudeCodeOptions = {}): ClaudeCodeContender {
+  return { harness: "claude-code", run: async (request) => await run(request, options) };
+}
+
+async function run(request: RunRequest, options: ClaudeCodeOptions): Promise<ClaudeCodeOutcome> {
+  const { world, testCase, meter } = request;
+  const modelId = MODEL_IDS[options.model ?? "sonnet"];
+  const workspace = await mkdtemp(join(tmpdir(), `genbench-${testCase.id}-`));
+  const page = join(workspace, PAGE);
+  const writes: Array<{ atMs: number; html: string }> = [];
+  const usage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, calls: 0 };
+  let billed = 0;
+  let failure: string | undefined;
+  let settledMs = 0;
+
+  /** The page as it stands, when it has changed. A write is only on disk once
+   *  the tool that made it has returned, so looking between messages sees every
+   *  revision and never half of one. */
+  const observe = async (): Promise<void> => {
+    const html = await readFile(page, "utf8").catch(() => undefined);
+    if (html === undefined || html === writes.at(-1)?.html) return;
+    writes.push({ atMs: meter.elapsedMs(), html });
+  };
+
+  const abort = new AbortController();
+  try {
+    const sdk = options.sdk ?? (await loadAgentSdk());
+    const drain = (async () => {
+      const messages = sdk.query({
+        prompt: brief(world, testCase),
+        options: sessionOptions(workspace, modelId, abort),
+      });
+      for await (const message of messages) {
+        await observe();
+        if (message["type"] !== "result") continue;
+        record(usage, message["usage"]);
+        billed += numberOf(message["total_cost_usd"]);
+        // The SDK's own word for how it ended, kept verbatim: `error_max_turns`
+        // and a crash are different failures and the report should say which.
+        if (message["subtype"] !== "success") failure = String(message["subtype"]);
+      }
+    })();
+    const finished = await Promise.race([
+      drain.then(() => true),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), options.timeoutMs ?? WALL_CLOCK_MS).unref()),
+    ]);
+    if (!finished) {
+      // The session is told to stop, and the run does not wait to see it happen:
+      // a loop that already outran its budget is not one to hand the clock back
+      // to. Its rejection is absorbed so it cannot surface as an unhandled one.
+      abort.abort();
+      void drain.catch(() => undefined);
+      failure = "timeout";
+    }
+  } catch (error) {
+    failure = error instanceof Error ? error.message : String(error);
+  } finally {
+    // Whatever is on disk when the session ends is what it delivered — a run
+    // that timed out still delivered the last page it wrote.
+    await observe();
+    settledMs = meter.elapsedMs();
+    await rm(workspace, { recursive: true, force: true });
+  }
+
+  const usd = usdFor(usage, modelId);
+  // Two prices for one session is a measurement problem, not a driver bug. The
+  // shared table wins, because that is what makes the columns comparable — but
+  // a real gap is said out loud rather than quietly averaged away.
+  if (billed > 0 && Math.abs(billed - usd) > Math.max(billed, usd) * 0.05) {
+    console.warn(`  claude-code: the SDK billed $${billed.toFixed(4)}, priced here at $${usd.toFixed(4)}`);
+  }
+
+  const first = writes[0];
+  const last = writes.at(-1);
+  return {
+    format: "html",
+    ...(last === undefined ? {} : { artifact: last.html }),
+    // Nothing stands between these bytes and the browser: no compile to fail, so
+    // no finding the product's own floor could raise about them.
+    blocking: [],
+    snapshots: [],
+    writes,
+    usage,
+    usd,
+    // The first page on disk is the first moment there was anything to paint.
+    ...(first === undefined ? {} : { firstRenderMs: first.atMs }),
+    settledMs,
+    ...(failure === undefined ? {} : { failure }),
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -852,6 +852,9 @@ importers:
       '@ai-sdk/provider':
         specifier: 3.0.2
         version: 3.0.2
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: '>=0.3.0 <1'
+        version: 0.3.214(@anthropic-ai/sdk@0.112.3(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(zod@4.4.3)
       '@playwright/test':
         specifier: ^1.49.0
         version: 1.61.1
@@ -8836,12 +8839,34 @@ snapshots:
       '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.214
       '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.214
 
+  '@anthropic-ai/claude-agent-sdk@0.3.214(@anthropic-ai/sdk@0.112.3(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.112.3(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
+      zod: 4.4.3
+    optionalDependencies:
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.214
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.214
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.214
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.214
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.214
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.214
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.214
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.214
+
   '@anthropic-ai/sdk@0.112.3(zod@3.25.76)':
     dependencies:
       json-schema-to-ts: 3.1.1
       standardwebhooks: 1.0.0
     optionalDependencies:
       zod: 3.25.76
+
+  '@anthropic-ai/sdk@0.112.3(zod@4.4.3)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 4.4.3
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -10242,6 +10267,30 @@ snapshots:
       raw-body: 3.0.2
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 2.1.0(hono@4.13.0)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.13.0
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     optionalDependencies:
       '@cfworker/json-schema': 4.1.1
     transitivePeerDependencies:


### PR DESCRIPTION
The strong in-house baseline for the buy-vs-build benchmark: **Claude Code with
hands** — a coding agent in a scratch directory, writing and rewriting one
`index.html` — not a single generation call.

## Fair by construction

The session's brief is assembled from the functions the Vendo column is already
built on, imported rather than copied, so a second description of the world
cannot drift from the first:

- `hostDesignBrief({ theme, designRules })` — the identical theme tokens and
  host rules the screen agent thinks with (`packages/apps`, via `vendo.ts`'s own
  `designRules`)
- the tool schemas `world.ts` derives, and the rows each read answers with
- the page contract the Vendo column gets for free from the product:
  `window.vendo.callTool(name, args)`, `window.__settled`, a `role="dialog"`
  confirmation step, no network. Stating these is what keeps the columns judged
  on the screen instead of on knowing the harness.

## Measurement

Billed by its own session — the SDK spawns its own engine and never touches
`meter.model` — so the SDK's tokens ride the outcome and are priced through the
same `usdFor` table as every other column. A >5% gap between the SDK's own
`total_cost_usd` and that table is warned about, never silently averaged. The
meter is still the run's only clock: snapshot `atMs` and `settledMs` come from
it.

Loadout: `Read`/`Write`/`Edit` in a temp dir that dies with the case, no shell,
no network, `settingSources: []` so a laptop's own CLAUDE.md and skills never
become this column's advantage. A ten-minute wall clock ends a session that will
not end itself, and the page it had written by then is still what it delivered.

## Live smoke (real session, real browser)

`pending-transfers`, sonnet, opened from disk in headless Chromium at 480x900:

| | |
| --- | --- |
| settled | 53,444 ms (first page on disk at 50,709 ms) |
| tokens | 39,632 (4 in · 6,454 out · 18,802 cache read · 14,372 cache write) |
| cost | $0.1564 at genbench prices |
| artifact | 10,616 bytes, one write |
| renders standalone | yes — settled, mounted, **zero console errors** |
| wired | both Cancel controls fire `cancel_transfer` with the row's own id (`tr_1`, `tr_2`) through a `role="dialog"` confirmation |

Screenshots and the artifact live in the run evidence, not in the repo.

## The fence

This branch touches **only** `genbench/src/claude-code.ts`,
`genbench/src/claude-code.test.ts`, and the SDK dependency in
`genbench/package.json` + lockfile. `run.ts`, `report.ts`, `world.ts`,
`floor.ts`, `probe.ts`, `render.ts`, `cases.json` and `world.json` are
untouched, so this column is **not yet in the matrix** and changes no existing
run.

### Wiring that follows slice 3

Three seams in `run.ts`, shared with the `diy` column (also html-format), which
is why they wait for it rather than landing twice:

1. **matrix** — `DRIVERS` gains `"claude-code": (model) => claudeCodeDriver({ model })`,
   its type widens to `(model: ModelAlias) => Contender`, and the call site
   passes `contender.model`.
2. **page** — an outcome with `format: "html"` skips `pageHtml()`; its
   `artifact` *is* `page.html` (as `README.md` already says it should be).
3. **cost** — `cost:` reads the outcome's own `usage`/`usd` when present, since
   this contender is not metered by `meter.model`.

Until then the driver is dead code with a green suite behind it.

## Tests

`claude-code.test.ts` mocks the SDK boundary and nothing else — the double
writes into the workspace the driver really made, so the file watching,
snapshots and cleanup are the driver's own behaviour. Covers world-block
equality against the shared serializer, snapshot order and `atMs` monotonicity,
the timeout path returning a failure instead of throwing, workspace cleanup on
both paths, and SDK usage priced through `usdFor`. Each assertion was proven to
fail against a deliberately broken driver before being trusted. The live smoke
is an eighth test, gated on `GENBENCH_LIVE=1` plus a key, and skips cleanly.

Gate (scoped, foreground): `pnpm build` ✓ · `npx vitest run` in `genbench/` ✓
(38 passed, 1 skipped, run twice) · `pnpm typecheck` ✓ · `pnpm lint` ✓


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `claude-code` contender that uses `@anthropic-ai/claude-agent-sdk` to build a single `index.html` in a temp dir, recording writes and pricing usage with genbench rates. Fenced until slice-3 wiring; no existing runs change.

- New Features
  - `claude-code` driver: agent writes `index.html` in a scratch dir with `Read`/`Write`/`Edit`, no shell/network/settings, 10‑min wall‑clock timeout, cleans workspace.
  - Prompt includes the same world as Vendo: `hostDesignBrief(...)` plus derived tool schemas and rows; enforces page contract (`window.vendo.callTool`, `window.__settled`, role="dialog").
  - Captures ordered write snapshots and timing; reports SDK `usage` and computes `usd` via `usdFor` with a warning if SDK bill differs by >5%.

- Dependencies
  - Added `@anthropic-ai/claude-agent-sdk` (>=0.3.0 <1).

<sup>Written for commit d5fc16e23c5e01064aa289d97caf56703c09e431. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

