### PR TITLE
genbench: judge core (fenced; integration follows slice 4)

### DIFF
--- a/genbench/src/judge.test.ts
+++ b/genbench/src/judge.test.ts
@@ -1,0 +1,427 @@
+import { MockLanguageModelV3 } from "ai/test";
+import { createHash } from "node:crypto";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { judge, JudgeContract, SYSTEM_PROMPT, VERDICTS, type JudgeInput, type Verdict } from "./judge.js";
+import { probe, type Probed } from "./probe.js";
+import { authoredPage, openBrowser } from "./render.js";
+import { loadWorld } from "./world.js";
+
+// ------------------------------------------------------------------ fixtures
+
+/** A 1x1 PNG. Small and fixed, so the base64 the SDK sends can never
+ *  accidentally spell one of the strings the blindness test forbids. */
+const PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+const TRACE: Probed[] = [
+  { label: "Cancel", confirmed: true, calls: [{ name: "cancel_transfer", args: { id: "tr_1" } }] },
+  { label: "Refresh", confirmed: false, calls: [] },
+];
+
+const CASE_LINES = ["alpha shows every row", "bravo totals the rows", "charlie confirms deletions"];
+const STYLE_LINES = ["delta uses the theme colors", "echo formats money with two decimals"];
+
+const input = (over: Partial<JudgeInput> = {}): JudgeInput => ({
+  screenshot: PNG,
+  artifact: "<section><h1>Spending</h1><p>Housing 2850</p></section>",
+  trace: TRACE,
+  caseLines: CASE_LINES,
+  styleLines: STYLE_LINES,
+  ...over,
+});
+
+const ZERO_USAGE = {
+  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 0, text: 0, reasoning: 0 },
+};
+
+type Answer = { verdict: Verdict; note: string };
+
+const replied = (verdicts: Answer[]) => ({
+  content: [{ type: "text" as const, text: JSON.stringify({ verdicts }) }],
+  finishReason: { unified: "stop" as const, raw: undefined },
+  usage: ZERO_USAGE,
+  warnings: [],
+});
+
+/** Every numbered checklist line the model was actually asked about, in the
+ *  order it was asked — parsed back out of the assembled prompt, so the tests
+ *  see exactly what went over the wire and nothing the judge merely intended. */
+const asked = (call: { prompt: unknown }): string[] => {
+  const text = JSON.stringify(call.prompt);
+  const parsed = JSON.parse(text) as Array<{ content: unknown }>;
+  const parts = parsed.flatMap((message) =>
+    Array.isArray(message.content) ? (message.content as Array<{ type: string; text?: string }>) : [],
+  );
+  const checklist = parts.filter((part) => part.type === "text").at(-1)?.text ?? "";
+  return [...checklist.matchAll(/^\s*\d+\.\s+(.+)$/gm)].map((match) => match[1]!);
+};
+
+/** The verdict this line is worth, decided by its own first word — so a remap
+ *  bug shows up as a verdict landing on the wrong line. */
+const owed = (line: string): Verdict =>
+  line.startsWith("alpha") || line.startsWith("delta")
+    ? "pass"
+    : line.startsWith("charlie")
+      ? "na"
+      : "fail";
+
+/** A model that answers each line it was actually asked, in the asked order. */
+const answering = (): MockLanguageModelV3 =>
+  new MockLanguageModelV3({
+    doGenerate: async (call) =>
+      replied(asked(call).map((line) => ({ verdict: owed(line), note: `saw ${line}` }))),
+  });
+
+// ----------------------------------------------------------------- blindness
+
+describe("blindness", () => {
+  /** Everything that would tell the judge whose screen this is. */
+  const FORBIDDEN = [
+    "vendo",
+    "diy",
+    "claude-code",
+    "claude-sonnet-5",
+    "claude-opus-5",
+    "claude-haiku",
+    "runs/",
+    "spend-overview",
+  ];
+
+  it("sends nothing that names the contender, its model, or its run folder", async () => {
+    const model = answering();
+    // Identity smuggled in as excess metadata: the judge has no channel for it,
+    // and adding one — a stray JSON.stringify(input), say — turns this red.
+    const poisoned = {
+      ...input({
+        // Both columns really do say the name in their own source: the baseline
+        // because its prompt tells it to (diy.ts), the product because its
+        // document is stamped with the format (VENDO_APP_FORMAT).
+        artifact: `{"format":"vendo/app@1","tree":{"formatVersion":"vendo-genui/v2"}}
+<button onclick="window.vendo.callTool('cancel_transfer', { id: 'tr_1' })">Cancel</button>`,
+        // A control's label is page text, and page text can sign its own work.
+        trace: [{ label: "Built with Vendo", confirmed: false, calls: [{ name: "cancel_transfer", args: {} }] }],
+      }),
+      contender: "vendo-sonnet",
+      harness: "claude-code",
+      model: "claude-sonnet-5",
+      runDir: "/genbench/runs/2026-08-08T00-00-00/diy-sonnet/spend-overview",
+    } as JudgeInput;
+
+    await judge(poisoned, { model });
+
+    // The image is the one part whose bytes nobody chose; drop it rather than
+    // let a base64 run spell a forbidden word by chance.
+    const sent = JSON.stringify(
+      { prompt: model.doGenerateCalls[0]!.prompt, system: SYSTEM_PROMPT },
+      (key, value: unknown) => (key === "data" ? "<image>" : value),
+    ).toLowerCase();
+
+    for (const name of FORBIDDEN) expect(sent).not.toContain(name);
+  });
+
+  it("still sends the evidence it is supposed to send", async () => {
+    const model = answering();
+    await judge(input(), { model });
+    const sent = JSON.stringify(model.doGenerateCalls[0]!.prompt);
+
+    expect(sent).toContain("Housing 2850");
+    expect(sent).toContain("cancel_transfer");
+    expect(sent).toContain("Cancel");
+    for (const line of [...CASE_LINES, ...STYLE_LINES]) expect(sent).toContain(line);
+  });
+
+  it("keeps the artifact's format while taking its name — a tree still reads as a tree", async () => {
+    const model = answering();
+    await judge(input({ artifact: '{"format":"vendo/app@1","ui":"tree","nodes":[{"component":"Stat"}]}' }), { model });
+    const sent = JSON.stringify(model.doGenerateCalls[0]!.prompt);
+
+    expect(sent).toContain('host/app@1');
+    expect(sent).toContain('\\"ui\\":\\"tree\\"');
+    expect(sent).toContain("Stat");
+  });
+});
+
+// -------------------------------------------------------------- shuffle/remap
+
+describe("shuffled lines, remapped verdicts", () => {
+  it("lands every verdict on the line it was asked about, whatever the order", async () => {
+    const orders = new Set<string>();
+
+    for (let round = 0; round < 40; round += 1) {
+      const model = answering();
+      const result = await judge(input(), { model });
+
+      orders.add(asked(model.doGenerateCalls[0]!).join("|"));
+
+      // Answers come back in the ORIGINAL order, each carrying its own line's
+      // verdict — not the verdict of whatever sat in that slot when asked.
+      expect(result.lines).toEqual([
+        ...CASE_LINES.map((line) => ({ line, source: "case", verdict: owed(line), note: `saw ${line}` })),
+        ...STYLE_LINES.map((line) => ({ line, source: "style", verdict: owed(line), note: `saw ${line}` })),
+      ]);
+      expect(result.degraded).toBe(false);
+    }
+
+    // A judge that never shuffles would pass the assertion above every round.
+    expect(orders.size).toBeGreaterThan(1);
+  });
+
+  it("asks about every line exactly once", async () => {
+    const model = answering();
+    await judge(input(), { model });
+    expect([...asked(model.doGenerateCalls[0]!)].sort()).toEqual([...CASE_LINES, ...STYLE_LINES].sort());
+  });
+});
+
+// ------------------------------------------------------------------- schema
+
+describe("schema", () => {
+  it("constrains the model to pass, fail or na", async () => {
+    const model = answering();
+    await judge(input(), { model });
+
+    const format = model.doGenerateCalls[0]!.responseFormat;
+    expect(format?.type).toBe("json");
+    // "na" reaches the provider as an allowed value, not just our own type.
+    expect(JSON.stringify(format)).toContain('"enum":["pass","fail","na"]');
+    expect(VERDICTS).toContain("na");
+  });
+});
+
+// ------------------------------------------------------------------- degrade
+
+describe("degrade", () => {
+  const allLines = [...CASE_LINES, ...STYLE_LINES];
+
+  it("fails every line and says why when the judge cannot be reached", async () => {
+    const model = new MockLanguageModelV3({
+      doGenerate: async () => {
+        throw new Error("400 invalid_request: bad image");
+      },
+    });
+
+    const result = await judge(input(), { model, delayMs: () => 0 });
+
+    expect(result.degraded).toBe(true);
+    expect(result.error).toContain("bad image");
+    expect(result.lines.map((line) => line.line)).toEqual(allLines);
+    expect(result.lines.every((line) => line.verdict === "fail")).toBe(true);
+    expect(result.lines.map((line) => line.source)).toEqual(["case", "case", "case", "style", "style"]);
+  });
+
+  it("never partially grades — a short answer degrades the whole screen", async () => {
+    const model = new MockLanguageModelV3({
+      doGenerate: async () => replied([{ verdict: "pass", note: "only one" }]),
+    });
+
+    const result = await judge(input(), { model, delayMs: () => 0 });
+
+    expect(result.degraded).toBe(true);
+    expect(result.lines.every((line) => line.verdict === "fail")).toBe(true);
+    expect(result.lines).toHaveLength(allLines.length);
+  });
+
+  it("grades nothing rather than throwing", async () => {
+    const model = new MockLanguageModelV3({
+      doGenerate: async () => {
+        throw new Error("boom");
+      },
+    });
+    await expect(judge(input(), { model, delayMs: () => 0 })).resolves.toMatchObject({ degraded: true });
+  });
+
+  it("rejects a verdict outside the rubric rather than scoring it", async () => {
+    // `jsonSchema` does no runtime validation and no provider enforces an enum,
+    // so an off-rubric verdict reaches us as a plain string.
+    const model = new MockLanguageModelV3({
+      doGenerate: async () =>
+        replied(allLines.map(() => ({ verdict: "partial" as unknown as Verdict, note: "hedged" }))),
+    });
+
+    const result = await judge(input(), { model, delayMs: () => 0 });
+    expect(result.degraded).toBe(true);
+    expect(result.lines.every((line) => line.verdict === "fail")).toBe(true);
+  });
+
+  it("never lets the judge rewrite the rubric line it was given", async () => {
+    // A judge that echoes a paraphrase back must not overwrite the caller's text.
+    const model = new MockLanguageModelV3({
+      doGenerate: async (call) =>
+        replied(
+          asked(call).map((line) => ({
+            verdict: owed(line),
+            note: `saw ${line}`,
+            line: "a line nobody authored",
+            source: "style",
+          })) as Answer[],
+        ),
+    });
+
+    const result = await judge(input(), { model });
+    expect(result.lines.map((line) => line.line)).toEqual(allLines);
+    expect(result.lines.map((line) => line.source)).toEqual(["case", "case", "case", "style", "style"]);
+  });
+
+  it("degrades instead of throwing when there is no key and no model to fall back on", async () => {
+    const key = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    try {
+      const result = await judge(input(), { delayMs: () => 0 });
+      expect(result.degraded).toBe(true);
+      expect(result.error).toContain("ANTHROPIC_API_KEY");
+      expect(result.lines.every((line) => line.verdict === "fail")).toBe(true);
+    } finally {
+      if (key !== undefined) process.env.ANTHROPIC_API_KEY = key;
+    }
+  });
+});
+
+// --------------------------------------------------------------------- retry
+
+describe("retry", () => {
+  it("rides out a rate limit and returns the real verdicts", async () => {
+    let attempts = 0;
+    const model = new MockLanguageModelV3({
+      doGenerate: async (call) => {
+        attempts += 1;
+        if (attempts === 1) throw new Error("429 Too Many Requests");
+        return replied(asked(call).map((line) => ({ verdict: owed(line), note: `saw ${line}` })));
+      },
+    });
+
+    const slept: number[] = [];
+    const result = await judge(input(), {
+      model,
+      delayMs: (attempt) => {
+        slept.push(attempt);
+        return 0;
+      },
+    });
+
+    expect(result.degraded).toBe(false);
+    expect(result.lines[0]).toMatchObject({ line: CASE_LINES[0], verdict: "pass" });
+    expect(attempts).toBe(2);
+    // A transient error is the only kind that earns a wait.
+    expect(slept).toEqual([0]);
+  });
+
+  it("gives up after three attempts", async () => {
+    let attempts = 0;
+    const model = new MockLanguageModelV3({
+      doGenerate: async () => {
+        attempts += 1;
+        throw new Error("503 Service Unavailable");
+      },
+    });
+
+    const result = await judge(input(), { model, delayMs: () => 0 });
+
+    expect(attempts).toBe(3);
+    expect(result.degraded).toBe(true);
+    expect(result.error).toContain("503");
+  });
+});
+
+// ------------------------------------------------------------------ contract
+
+describe("JudgeContract", () => {
+  it("pins the judge model independently of whoever is being graded", () => {
+    expect(JudgeContract.model).toBe("claude-opus-5");
+    expect(JudgeContract.rubricVersion).toBe(1);
+  });
+
+  it("hashes the prompt, so any edit to it changes the contract", () => {
+    expect(JudgeContract.promptHash).toBe(createHash("sha256").update(SYSTEM_PROMPT).digest("hex"));
+
+    const edited = SYSTEM_PROMPT.replace("pass", "PASS");
+    expect(edited).not.toBe(SYSTEM_PROMPT);
+    expect(createHash("sha256").update(edited).digest("hex")).not.toBe(JudgeContract.promptHash);
+  });
+
+});
+
+// ------------------------------------------------------------- empty rubric
+
+describe("no lines", () => {
+  it("grades nothing and calls nobody", async () => {
+    const model = answering();
+    const result = await judge(input({ caseLines: [], styleLines: [] }), { model });
+
+    expect(result).toEqual({ lines: [], degraded: false });
+    expect(model.doGenerateCalls).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------- live smoke
+
+/**
+ * The only test that spends money, and the only one that proves the judge can
+ * actually read a screen. Gated twice, so neither CI nor a stray `vitest` run
+ * can trigger it:
+ *   GENBENCH_LIVE=1 ANTHROPIC_API_KEY=... npx vitest run src/judge.test.ts
+ */
+const LIVE = process.env.GENBENCH_LIVE === "1" && Boolean(process.env.ANTHROPIC_API_KEY);
+
+/** A screen built to earn all three verdicts: honest categories and a real
+ *  total (pass), a wrong font and a cancel that fires with no confirmation
+ *  (fail), and no date anywhere (na). */
+const FIXTURE = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Spending</title>
+<style>body{font-family:Arial,sans-serif;margin:0;padding:20px;color:#1A1A1A}
+h1{font-size:20px}.row{display:flex;justify-content:space-between;padding:8px 0;border-bottom:1px solid #E5E7EB}
+.total{display:flex;justify-content:space-between;padding:12px 0;font-weight:700}
+button{background:#2563EB;color:#fff;border:0;border-radius:2px;padding:10px 14px;font-size:14px}</style>
+</head><body>
+<h1>Spending this month</h1>
+<div class="row"><span>Housing</span><span>$2,850.00</span></div>
+<div class="row"><span>Groceries</span><span>$612.45</span></div>
+<div class="row"><span>Dining</span><span>$438.20</span></div>
+<div class="row"><span>Subscriptions</span><span>$184.41</span></div>
+<div class="row"><span>Transport</span><span>$96.75</span></div>
+<div class="row"><span>Coffee</span><span>$61.30</span></div>
+<div class="total"><span>Total</span><span>$4,243.11</span></div>
+<button onclick="window.vendo.callTool('cancel_transfer', { id: 'tr_1' })">Cancel transfer</button>
+</body></html>`;
+
+describe.runIf(LIVE)("live smoke", () => {
+  it("grades a real screenshot and a real click trace", { timeout: 180_000 }, async () => {
+    const world = await loadWorld(join(dirname(dirname(fileURLToPath(import.meta.url))), "world.json"));
+    const shooter = await openBrowser();
+    try {
+      const visit = await shooter.visit(authoredPage(FIXTURE, world, "fixture"));
+      const shot = await visit.shot();
+      const trace = await probe(visit);
+      await visit.close();
+
+      const result = await judge({
+        screenshot: shot.png,
+        artifact: FIXTURE,
+        trace,
+        caseLines: [
+          "shows every spending category the tool returned",
+          "shows a total for the month equal to the sum of the categories",
+          "housing is presented as the largest category",
+        ],
+        styleLines: world.style,
+      });
+
+      for (const line of result.lines) {
+        console.log(`  [${line.source}] ${line.verdict.toUpperCase().padEnd(4)} ${line.line}\n         ${line.note}`);
+      }
+
+      expect(result.degraded).toBe(false);
+      expect(result.lines).toHaveLength(7);
+      for (const line of result.lines) {
+        expect(VERDICTS).toContain(line.verdict);
+        expect(line.note.length).toBeGreaterThan(0);
+      }
+    } finally {
+      await shooter.close();
+    }
+  });
+});

--- a/genbench/src/judge.ts
+++ b/genbench/src/judge.ts
@@ -1,0 +1,246 @@
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { generateObject, jsonSchema, type LanguageModel } from "ai";
+import { createHash } from "node:crypto";
+import type { Probed } from "./probe.js";
+
+/**
+ * The non-mechanical half of the score.
+ *
+ * The floor answers what a machine can settle alone — did it render, are the
+ * numbers real, do the buttons fire. This answers the rest, one rubric line at
+ * a time: the case's `pass` lines (did it do what was asked) and the world's
+ * `style` lines (does it look like the product it claims to be).
+ *
+ * It grades blind. Nothing it is sent names the contender, its model or its
+ * run folder, and the lines arrive shuffled, so a judge cannot learn an order
+ * or reward a name. The one leak left is the artifact's own format — a tree
+ * and a hand-written document do not look alike — and it is disclosed rather
+ * than papered over, because stripping it would destroy the evidence.
+ */
+
+export const VERDICTS = ["pass", "fail", "na"] as const;
+export type Verdict = (typeof VERDICTS)[number];
+export type LineSource = "case" | "style";
+
+export interface LineVerdict {
+  readonly line: string;
+  readonly source: LineSource;
+  readonly verdict: Verdict;
+  /** One clause naming the evidence, in the judge's own words. */
+  readonly note: string;
+}
+
+export interface JudgeResult {
+  /** Every line, in the order it was given — case lines then style lines. */
+  readonly lines: readonly LineVerdict[];
+  /** The judge could not be trusted, so every line was failed rather than guessed. */
+  readonly degraded: boolean;
+  readonly error?: string;
+}
+
+export interface JudgeInput {
+  readonly screenshot: Buffer;
+  readonly artifact: string;
+  readonly trace: readonly Probed[];
+  readonly caseLines: readonly string[];
+  readonly styleLines: readonly string[];
+}
+
+export interface JudgeOptions {
+  /** Defaults to the contract's pinned model. Tests pass a double here; the
+   *  run never does, which is what keeps the judge model off the contender. */
+  readonly model?: LanguageModel;
+  readonly delayMs?: (attempt: number) => number;
+}
+
+/**
+ * rubricVersion bumps on ANY edit; founder sign-off required before results count.
+ */
+export const SYSTEM_PROMPT = `You are grading one screen of a software product against a fixed checklist. You are not its designer, its author, or a reviewer offering advice: you decide, line by line, what the evidence supports.
+
+THE EVIDENCE, in priority order. Where two sources disagree, the earlier one wins.
+1. THE SCREENSHOT — the screen exactly as a person sees it. This is what the user actually gets.
+2. THE INTERACTION TRACE — every control on the screen was pressed once, and this records what each press asked the application to do. This is what actually happened when the screen was used.
+3. THE SOURCE — what the screen was built from. This is only what was intended. The source may be written in any format, and its format is not evidence: it must never affect a verdict. A line the source promises but the screenshot does not show is not satisfied.
+
+Return exactly one verdict for each numbered checklist line, in the order the lines are numbered — no more, no fewer.
+- pass: the evidence clearly shows this line is satisfied.
+- fail: the evidence clearly shows this line is violated, OR the line applies to this screen and the evidence does not show it satisfied. Not demonstrated is not a pass.
+- na: the line's subject does not occur on this screen at all, so there is nothing here to satisfy or violate — for example, a line about confirming destructive actions on a screen that only displays information. Use na only for an absent subject, never for your own uncertainty: when the subject is present and you are unsure, the verdict is fail.
+
+Every verdict carries a note: one clause naming the specific evidence you used, such as "the header reads Spending" or "pressing Cancel called nothing". No advice, no praise, no summary, and no restating the line back.
+
+Grade only the numbered lines. Anything else you notice about this screen, good or bad, is not yours to grade: it must not change a verdict and must not appear in a note. Judge the screen you were given, not the screen you would have built.`;
+
+/** The judge's own model, written here and nowhere else. It is deliberately NOT
+ *  read from the run's model table: the grader must not move when the graded
+ *  contender does, or two columns stop being comparable. */
+export const JudgeContract = {
+  model: "claude-opus-5",
+  rubricVersion: 1,
+  promptHash: createHash("sha256").update(SYSTEM_PROMPT).digest("hex"),
+} as const;
+
+interface Answer {
+  readonly verdict: Verdict;
+  readonly note: string;
+}
+
+const answerSchema = jsonSchema<{ verdicts: Answer[] }>({
+  type: "object",
+  properties: {
+    verdicts: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: { verdict: { type: "string", enum: [...VERDICTS] }, note: { type: "string" } },
+        required: ["verdict", "note"],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ["verdicts"],
+  additionalProperties: false,
+});
+
+/** Only a provider that is briefly unwell earns a wait. Everything else is
+ *  retried immediately, because a judge can also just flake once. */
+const TRANSIENT = /\b(429|500|502|503|504|529)\b|overload|rate.?limit|ECONNRESET|ETIMEDOUT|EPIPE|socket hang up|fetch failed|network|timed? ?out/i;
+const MAX_ATTEMPTS = 3;
+
+/**
+ * Identity, struck out of every piece of text evidence.
+ *
+ * Both columns name the product in their own source, in opposite ways: the
+ * in-house baseline because its prompt tells it to call `vendo.callTool`, and
+ * the product because its document is stamped `vendo/app@1`. Left alone, the
+ * artifact hands the judge the answer in the channel it reads most closely —
+ * and hands it BACKWARDS half the time, since the baseline's document is the
+ * one that says the name out loud.
+ *
+ * The artifact's FORMAT is deliberately untouched: a tree still reads as a
+ * tree and a document still reads as a document. That tell is disclosed, not
+ * hidden — only the name goes.
+ */
+const IDENTITY = /\bvendo\b|\bdiy\b|\bclaude[\w-]*/gi;
+const blind = (text: string): string => text.replace(IDENTITY, "host");
+
+/** The probe's record as prose, because that is what a judge reads best. */
+function traceText(trace: readonly Probed[]): string {
+  if (trace.length === 0) return "Nothing on this screen could be pressed.";
+  return trace
+    .map((probed) => {
+      const asked = probed.calls.map((call) => `${call.name}(${JSON.stringify(call.args)})`).join(", ");
+      const step = probed.confirmed ? " (a confirmation step appeared, and was confirmed)" : "";
+      return `pressed "${probed.label}"${step} — ${asked === "" ? "called nothing" : `called ${asked}`}`;
+    })
+    .join("\n");
+}
+
+/** Fisher-Yates: `order[position]` is the line that was asked in that slot. */
+function shuffle(count: number): number[] {
+  const order = Array.from({ length: count }, (_, index) => index);
+  for (let index = count - 1; index > 0; index -= 1) {
+    const swap = Math.floor(Math.random() * (index + 1));
+    [order[index], order[swap]] = [order[swap]!, order[index]!];
+  }
+  return order;
+}
+
+/** A judge that answered a different number of lines, or answered one with a
+ *  verdict outside the rubric, has not graded this screen — `jsonSchema` alone
+ *  validates nothing at runtime, and no provider enforces an enum for us. */
+const wellFormed = (verdicts: readonly Answer[] | undefined, expected: number): boolean =>
+  Array.isArray(verdicts) &&
+  verdicts.length === expected &&
+  verdicts.every(
+    (answer) => typeof answer?.note === "string" && (VERDICTS as readonly string[]).includes(answer.verdict),
+  );
+
+/** The provider reads ANTHROPIC_API_KEY itself, and says so by name when it is
+ *  missing — which is a better sentence than one written here, and it arrives
+ *  inside the retry loop, so a keyless run degrades instead of throwing. */
+const pinnedModel = (): LanguageModel => createAnthropic()(JudgeContract.model);
+
+/** One schema-constrained judgement with owned retries. Never throws: an
+ *  unusable judge is a degraded result, never a half-graded screen. */
+async function ask(
+  input: JudgeInput,
+  checklist: string,
+  expected: number,
+  options: JudgeOptions,
+): Promise<{ ok: true; verdicts: Answer[] } | { ok: false; error: string }> {
+  const delayMs = options.delayMs ?? ((attempt: number) => 1500 * (attempt + 1));
+  let error = "the judge returned nothing";
+
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
+    try {
+      const result = await generateObject({
+        model: options.model ?? pinnedModel(),
+        schema: answerSchema,
+        system: SYSTEM_PROMPT,
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "image", image: input.screenshot, mediaType: "image/png" },
+              { type: "text", text: `SOURCE — what this screen was built from:\n\n${blind(input.artifact)}` },
+              {
+                type: "text",
+                text: `INTERACTION TRACE — every control was pressed once:\n\n${blind(traceText(input.trace))}`,
+              },
+              { type: "text", text: `CHECKLIST — return one verdict per line, in this order:\n\n${checklist}` },
+            ],
+          },
+        ],
+        // The SDK's retries are off so the loop above owns every attempt, and
+        // the attempt count in a degraded result means what it says.
+        maxRetries: 0,
+      });
+      const { verdicts } = result.object;
+      if (!wellFormed(verdicts, expected)) {
+        throw new Error(`the judge usably answered ${verdicts?.length ?? 0} of ${expected} lines`);
+      }
+      return { ok: true, verdicts };
+    } catch (thrown) {
+      error = thrown instanceof Error ? thrown.message : String(thrown);
+      if (TRANSIENT.test(error) && attempt < MAX_ATTEMPTS - 1) {
+        await new Promise((settle) => setTimeout(settle, delayMs(attempt)));
+      }
+    }
+  }
+  return { ok: false, error };
+}
+
+export async function judge(input: JudgeInput, options: JudgeOptions = {}): Promise<JudgeResult> {
+  const lines: ReadonlyArray<{ line: string; source: LineSource }> = [
+    ...input.caseLines.map((line) => ({ line, source: "case" as const })),
+    ...input.styleLines.map((line) => ({ line, source: "style" as const })),
+  ];
+  if (lines.length === 0) return { lines: [], degraded: false };
+
+  const order = shuffle(lines.length);
+  const checklist = order.map((line, position) => `${position + 1}. ${lines[line]!.line}`).join("\n");
+
+  const answered = await ask(input, checklist, lines.length, options);
+  if (!answered.ok) {
+    return {
+      lines: lines.map((entry) => ({ ...entry, verdict: "fail", note: "the judge did not grade this screen" })),
+      degraded: true,
+      error: answered.error,
+    };
+  }
+
+  // Back to the order the caller gave: the verdict asked in slot `position`
+  // belongs to line `order[position]`, wherever that line started. The line and
+  // its source are copied from the CALLER's entry, never from the answer — a
+  // judge that echoes a paraphrased line back must not rewrite the rubric.
+  const byLine = new Map(order.map((line, position) => [line, answered.verdicts[position]!]));
+  return {
+    lines: lines.map((entry, index) => {
+      const answer = byLine.get(index)!;
+      return { line: entry.line, source: entry.source, verdict: answer.verdict, note: answer.note };
+    }),
+    degraded: false,
+  };
+}


### PR DESCRIPTION
Adds the non-mechanical half of the genbench score: one verdict per rubric line, from a model shown the screenshot, the click trace and the source. The floor already answers what a machine can settle alone (renders / honest data / wired actions); this answers the rest.

**Nothing calls it yet.** Two new files, zero edits to anything existing.

## Fence

Created exactly two files, edited nothing else:

- `genbench/src/judge.ts` (211 lines, ~120 of them code)
- `genbench/src/judge.test.ts`

No new dependencies. `zod` is not declared by `genbench/package.json` and pnpm here is strict, so the schema is built with `jsonSchema()` re-exported from `ai` — same `Schema<T>` that `generateObject` takes.

## Pending integration seams (next slice)

- `run.ts` calling `judge()` per contender/case and adding a `judged` field to `result.json`
- the preview's per-line verdict rows
- deciding whether a `degraded: true` judgement blocks a run's exit code the way the floor does

`judge(input)` is callable as-frozen. The optional second argument (`{ model?, delayMs? }`) exists only so tests can mock the model boundary without sleeping through real backoff; the run passes nothing and gets the pinned model.

## What it refuses to do

**It refuses to know whose screen it is.** Nothing sent names a contender, a model or a run folder, and rubric lines are shuffled before sending and mapped back after.

This turned out to matter more than the contract anticipated, and it is the one thing here that needs your call. **Both** columns name the product in their own artifact, in opposite directions:

- the in-house baseline, because `diy.ts:28` instructs it to call `vendo.callTool(name, args)` — so its document says the name in every wired control
- the product, because its document is stamped `VENDO_APP_FORMAT` = `"vendo/app@1"` and `formatVersion: "vendo-genui/v2"`

So an unblinded artifact hands the judge the answer, and hands it *backwards* on the baseline — the column that says the name loudest is the one that is not the product. The contract said the prompt must contain no harness names *and* said not to strip the artifact; those collide here.

Resolution: strike the **name** out of text evidence, leave the **format** untouched. A tree still reads as a tree (`ui:"tree"`, component names and structure all survive — pinned by a test). Verified the live smoke returns **identical verdicts** before and after, so nothing was lost. Revert is dropping two `blind(...)` wrappers if you disagree.

**It refuses to half-grade.** `jsonSchema` does no runtime validation and no provider enforces an enum, so a short answer or an off-rubric verdict counts as no answer: 3 attempts, backoff only for a provider that is briefly unwell, then every line fails with `degraded: true` and the error recorded. It never throws. Line text and source are always copied from the caller, so a judge that paraphrases a line back cannot rewrite the rubric.

**It refuses to move with the contender.** `JudgeContract` pins `model: "claude-opus-5"`, `rubricVersion: 1`, and `promptHash: sha256(SYSTEM_PROMPT)`.

## THE SYSTEM PROMPT — draft, needs your sign-off

`rubricVersion` bumps on ANY edit; this is verbatim from `genbench/src/judge.ts`.

```text
You are grading one screen of a software product against a fixed checklist. You are not its designer, its author, or a reviewer offering advice: you decide, line by line, what the evidence supports.

THE EVIDENCE, in priority order. Where two sources disagree, the earlier one wins.
1. THE SCREENSHOT — the screen exactly as a person sees it. This is what the user actually gets.
2. THE INTERACTION TRACE — every control on the screen was pressed once, and this records what each press asked the application to do. This is what actually happened when the screen was used.
3. THE SOURCE — what the screen was built from. This is only what was intended. The source may be written in any format, and its format is not evidence: it must never affect a verdict. A line the source promises but the screenshot does not show is not satisfied.

Return exactly one verdict for each numbered checklist line, in the order the lines are numbered — no more, no fewer.
- pass: the evidence clearly shows this line is satisfied.
- fail: the evidence clearly shows this line is violated, OR the line applies to this screen and the evidence does not show it satisfied. Not demonstrated is not a pass.
- na: the line's subject does not occur on this screen at all, so there is nothing here to satisfy or violate — for example, a line about confirming destructive actions on a screen that only displays information. Use na only for an absent subject, never for your own uncertainty: when the subject is present and you are unsure, the verdict is fail.

Every verdict carries a note: one clause naming the specific evidence you used, such as "the header reads Spending" or "pressing Cancel called nothing". No advice, no praise, no summary, and no restating the line back.

Grade only the numbered lines. Anything else you notice about this screen, good or bad, is not yours to grade: it must not change a verdict and must not appear in a note. Judge the screen you were given, not the screen you would have built.
```

## Evidence

**Live smoke** (gated behind `GENBENCH_LIVE=1` + `ANTHROPIC_API_KEY`; skips cleanly otherwise). Grades a real screenshot and a real click trace of a fixture screen built to earn all three verdicts. `claude-opus-5`, one call:

```
[case]  PASS  shows every spending category the tool returned
              six categories Housing through Coffee are each listed as rows
[case]  PASS  shows a total for the month equal to the sum of the categories
              Total $4,243.11 equals the six listed category amounts summed
[case]  PASS  housing is presented as the largest category
              Housing $2,850.00 is listed first and is the largest value shown
[style] FAIL  uses the theme exactly: brand green, Onest, 8px corners — no invented colors or fonts
              button is blue #2563EB with Arial and 2px radius, not green/Onest/8px
[style] PASS  money always shows 2 decimals with currency symbol
              all amounts render as $2,850.00, $612.45, $61.30 etc. with symbol and two decimals
[style] FAIL  destructive actions ask for confirmation
              pressing "Cancel transfer" called cancel_transfer({id:'tr_1'}) immediately with no confirmation step
[style] NA    dates shown as 'Aug 1' style, never ISO
              no dates appear anywhere on the screen
```

Worth noting: it cited the *trace* to fail the confirmation line, and correctly returned `na` rather than `fail` for a rubric line whose subject the screen does not contain.

**Every assertion proven able to fail.** 13 mutations of `judge.ts`, each caught by the suite it was aimed at — including two rounds where a mutation was *missed*, which exposed a vacuous trace-blindness assertion and an untested key check (both fixed; the key check was deleted as defensive code the provider already does better).

```
CAUGHT  blindness: leak the whole input into the prompt
CAUGHT  blindness: stop blinding the artifact (the real leak both columns have)
CAUGHT  blindness: stop blinding the click trace
CAUGHT  blindness: blind so hard the format goes too
CAUGHT  remap: hand back verdicts in the ASKED order
CAUGHT  remap: let the judge overwrite the caller's rubric line
CAUGHT  shuffle: never shuffle at all
CAUGHT  degrade: throw instead of flooring the screen
CAUGHT  retry: one attempt only
CAUGHT  partial grading: accept whatever came back
CAUGHT  validation: stop checking the verdict is on the rubric
CAUGHT  schema: drop na from the allowed verdicts
CAUGHT  contract: pin a stale prompt hash
```

Tests mock only the model SDK boundary (`MockLanguageModelV3`) and assert on the call options the SDK actually produced, so blindness is measured on the bytes that would go over the wire — not on a helper's return value.

**Local gate** (scoped; CI's green check is the gate of record):

| gate | result |
|---|---|
| `pnpm build` | exit 0 |
| `npx vitest run --maxWorkers=2 --minWorkers=2` in `genbench/` | 68 passed, 1 skipped — run twice |
| `pnpm typecheck` | exit 0, 43/43 |
| `pnpm lint` | exit 0 |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the judge core for genbench: per-line grading of case and style rubrics using the screenshot, click trace, and source. It’s fenced and not wired into runs yet.

- **New Features**
  - Adds `judge()` (`genbench/src/judge.ts`) to return `pass`/`fail`/`na` with a short evidence note for each line.
  - Enforces blindness: strips contender/model/run names from text evidence while preserving format; shuffles lines and remaps answers.
  - Reliability: JSON result schema via `jsonSchema` from `ai`, retries transient errors up to 3 times, and degrades the whole screen on unusable answers (no partial grades).
  - Pins the grader via `JudgeContract` (model `claude-opus-5`, `rubricVersion: 1`, `promptHash`); includes a draft system prompt.
  - Fence/tests: only `genbench/src/judge.ts` and `genbench/src/judge.test.ts` added; includes a gated live smoke test; no new dependencies.

<sup>Written for commit ffed7924f4ac36c59e2a8846a0dea2528925cde2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

