### PR TITLE
test: typecheck the six test suites that were never checked (174 latent errors fixed)

### DIFF
--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -52,7 +52,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "vitest run",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit",
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {

--- a/packages/actions/tests/connectors/mcp-headers.test.ts
+++ b/packages/actions/tests/connectors/mcp-headers.test.ts
@@ -121,7 +121,7 @@ describe("mcpConnector per-principal headers", () => {
       scope: { kind: "tool" },
       duration: "task",
       contextKey: "session_ada",
-      source: "approval",
+      source: "approval" as unknown as PermissionGrant["source"],
       grantedAt: "2026-07-15T00:00:00Z",
     };
     const outcome = await connector.execute(

--- a/packages/actions/tests/judgments.test.ts
+++ b/packages/actions/tests/judgments.test.ts
@@ -215,6 +215,6 @@ describe("pruneJudgments", () => {
       [tool()],
     );
     expect(pruned.format).toBe(VENDO_JUDGMENTS_FORMAT);
-    expect((pruned as Record<string, unknown>).generatedAt).toBe("2026-07-28");
+    expect((pruned as JudgmentsFile & Record<string, unknown>).generatedAt).toBe("2026-07-28");
   });
 });

--- a/packages/actions/tests/presets/away-token.test.ts
+++ b/packages/actions/tests/presets/away-token.test.ts
@@ -1,6 +1,6 @@
 import type { PermissionGrant, Principal } from "@vendoai/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { auth0Preset, clerkPreset, type AwayTokenPreset } from "../../src/presets/index.js";
+import { auth0Preset, clerkPreset, type AwayTokenClaims, type AwayTokenPreset } from "../../src/presets/index.js";
 
 const principal: Principal = { kind: "user", subject: "provider-user" };
 const grant: PermissionGrant = {
@@ -15,7 +15,7 @@ const grant: PermissionGrant = {
 };
 const secret = "vendo-away-token-secret-at-least-32-bytes";
 
-type ExpressRequest = { headers: Record<string, string | undefined>; vendoAwayToken?: unknown };
+type ExpressRequest = { headers: Record<string, string | undefined>; vendoAwayToken?: AwayTokenClaims };
 
 describe.each([
   ["Clerk", "clerk", clerkPreset],

--- a/packages/actions/tests/runtime/registry.test.ts
+++ b/packages/actions/tests/runtime/registry.test.ts
@@ -604,7 +604,7 @@ describe("host HTTP execution", () => {
   });
 
   it("expands array path arguments as individually encoded catch-all segments", async () => {
-    const request = vi.fn(async () => new Response(JSON.stringify({ ok: true }), {
+    const request = vi.fn<(input: URL, init?: RequestInit) => Promise<Response>>(async () => new Response(JSON.stringify({ ok: true }), {
       headers: { "content-type": "application/json" },
     }));
     const actions = createActions({
@@ -918,7 +918,7 @@ describe("host HTTP execution — trpc bindings (04 §1 tRPC HTTP envelope)", ()
     description: "tRPC query polls.list",
     inputSchema: { type: "object", properties: {} },
     risk: "read",
-    binding: { kind: "trpc", procedure: "polls.list", type: "query", mount: "/api/trpc", ...extras },
+    binding: { kind: "trpc", procedure: "polls.list", type: "query", mount: "/api/trpc", ...extras } as ExtractedTool["binding"],
   });
 
   function capturingFetch(status: number, payload: unknown): { fetch: typeof fetch; seen: Array<{ url: string; method?: string; body?: unknown }> } {

--- a/packages/actions/tests/sync/sync.synthetic.test.ts
+++ b/packages/actions/tests/sync/sync.synthetic.test.ts
@@ -75,7 +75,7 @@ describe("sync public helpers", () => {
         host_items_list: { risk: "destructive", disabled: true, description: "new" },
         host_typo_target: { confirmEach: true },
       },
-    });
+    } as Parameters<typeof mergeOverrides>[1]);
     expect(merged[0]).toMatchObject({ risk: "destructive", disabled: true, description: "new" });
     expect(descriptorHash(merged[0]!)).not.toBe(before);
     expect(merged).toHaveLength(1);

--- a/packages/actions/tsconfig.test.json
+++ b/packages/actions/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "noEmit": true
+  },
+  "include": ["src", "tests"]
+}

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "vitest run",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit",
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {

--- a/packages/agents/tests/agent.test.ts
+++ b/packages/agents/tests/agent.test.ts
@@ -1,4 +1,4 @@
-import type { SandboxAdapter } from "@vendoai/apps";
+import type { SandboxAdapter, SandboxMachine } from "@vendoai/apps";
 import type { AuditEvent, ToolRegistry } from "@vendoai/core";
 import type { VendoGuard } from "@vendoai/guard";
 import { defineHarness, harnessAdapters } from "@vendoai/harnesses";
@@ -32,7 +32,7 @@ const fakeSandbox = (): SandboxAdapter & { created: unknown[] } => {
     snapshot: async () => "fake:snap",
     stop: async () => {},
     destroy: async () => {},
-  };
+  } as Omit<SandboxMachine, "files"> as SandboxMachine;
   return {
     created,
     async create(spec) {
@@ -61,7 +61,7 @@ const fakeGuard = (): VendoGuard & { reports: AuditEvent[]; bound: ToolRegistry[
       bound.push(tools);
       return tools;
     },
-    approvals: { pending: async () => [], decide: async () => {}, revoke: async () => {} },
+    approvals: { pending: async () => [], decide: async () => {}, revoke: async () => {} } as Omit<VendoGuard["approvals"], "parkedCallTtlMs"> as VendoGuard["approvals"],
     freeze: async () => {},
     unfreeze: async () => {},
     frozen: async () => false,

--- a/packages/agents/tests/away.test.ts
+++ b/packages/agents/tests/away.test.ts
@@ -48,7 +48,7 @@ function taskRegistry(over: Partial<ToolRegistry> = {}): ToolRegistry & { calls:
     calls,
     ctxs,
     async descriptors(ctx) {
-      ctxs.push(ctx);
+      ctxs.push(ctx as RunContext | undefined);
       return [readDescriptor];
     },
     async execute(call) {

--- a/packages/agents/tests/door.test.ts
+++ b/packages/agents/tests/door.test.ts
@@ -15,7 +15,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import type { SandboxAdapter } from "@vendoai/apps";
+import type { SandboxAdapter, SandboxMachine } from "@vendoai/apps";
 // The REAL box door and the REAL in-box session opener, over a fake transport:
 // what the box does with `toolDoor` is the other half of this seam.
 import { createSessionRoutes } from "@vendoai/apps/box-door";
@@ -99,7 +99,7 @@ function fakeSandbox(script: (box: BoxRun) => Promise<void>) {
         snapshot: async () => "fake:snap",
         stop: async () => {},
         destroy: async () => {},
-      };
+      } as SandboxMachine;
     },
     resume: async () => {
       throw new Error("a conversation box is destroyed, never resumed");

--- a/packages/agents/tests/session.test.ts
+++ b/packages/agents/tests/session.test.ts
@@ -47,7 +47,7 @@ describe("session", () => {
     const session = await support.session("u_42");
     const response = await session.stream("hello from the user");
     expect(await response.text()).toContain("hello from the harness");
-    const messages = await threadMessageStore(store).list(principal, session.threadId as never);
+    const messages = await threadMessageStore<{ id: string; role: string }>(store).list(principal, session.threadId as never);
     expect(messages.map((m) => m.role)).toEqual(["user", "assistant"]);
   });
 
@@ -88,7 +88,7 @@ describe("session", () => {
     expect(resumed.threadId).toBe(first.threadId);
     await (await resumed.stream("second")).text();
     expect(seen).toHaveLength(3); // user, assistant, user
-    const messages = await threadMessageStore(store).list(principal, first.threadId as never);
+    const messages = await threadMessageStore<{ id: string; role: string }>(store).list(principal, first.threadId as never);
     expect(messages.map((m) => m.role)).toEqual(["user", "assistant", "user", "assistant"]);
   });
 
@@ -193,7 +193,7 @@ describe("session", () => {
           decisions.push([ids, decision, by]);
         },
         revoke: async () => {},
-      },
+      } as Omit<VendoGuard["approvals"], "parkedCallTtlMs"> as VendoGuard["approvals"],
       freeze: async () => {},
       unfreeze: async () => {},
       frozen: async () => false,

--- a/packages/agents/tsconfig.test.json
+++ b/packages/agents/tsconfig.test.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "noEmit": true,
+    // `tests/door.test.ts` imports `@vendoai/apps/box-door`, whose export map
+    // points at the zero-dependency `box/turn-routes.mjs` control-port runtime
+    // and carries no `types`. There is no `.js` under `src` or `tests`, so this
+    // widens nothing else.
+    "allowJs": true
+  },
+  "include": ["src", "tests"]
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,7 +46,7 @@
     "build": "tsc -p tsconfig.json && tsc -p tsconfig.cjs.json && node -e \"require('node:fs').writeFileSync('dist/cjs/package.json', JSON.stringify({ type: 'commonjs' }) + '\\n')\"",
     "conformance": "vitest run tests/contract-coverage.e2e.test.ts",
     "test": "vitest run",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit",
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {

--- a/packages/core/tests/app-access.test.ts
+++ b/packages/core/tests/app-access.test.ts
@@ -27,6 +27,7 @@ const ctx = (subject: string, memberships?: Membership[]): RunContext => ({
   principal: { kind: "user", subject },
   venue: "app",
   presence: "present",
+  sessionId: "session_app_access",
   ...(memberships === undefined ? {} : { memberships }),
 });
 

--- a/packages/core/tests/conformance/index.test.ts
+++ b/packages/core/tests/conformance/index.test.ts
@@ -159,16 +159,16 @@ describe("StoreAdapter conformance", () => {
       refs: { owner: "user_1" },
     };
 
-    const inserted = await records.atomic.insertIfAbsent(input);
+    const inserted = await records.atomic!.insertIfAbsent(input);
     expect(inserted).toMatchObject({
       id: input.id,
       data: input.data,
       refs: input.refs,
       revision: "1",
     });
-    expect(await records.atomic.insertIfAbsent({ ...input, data: { status: "duplicate" } })).toBeNull();
-    expect(await records.atomic.compareAndSwap({ id: "missing", data: {} }, "1")).toBeNull();
-    expect(await records.atomic.compareAndSwap({ ...input, data: { status: "wrong revision" } }, "0")).toBeNull();
+    expect(await records.atomic!.insertIfAbsent({ ...input, data: { status: "duplicate" } })).toBeNull();
+    expect(await records.atomic!.compareAndSwap({ id: "missing", data: {} }, "1")).toBeNull();
+    expect(await records.atomic!.compareAndSwap({ ...input, data: { status: "wrong revision" } }, "0")).toBeNull();
 
     input.data.nested.count = 2;
     input.refs.owner = "mutated";
@@ -177,7 +177,7 @@ describe("StoreAdapter conformance", () => {
       refs: { owner: "user_1" },
     });
 
-    const swapped = await records.atomic.compareAndSwap({
+    const swapped = await records.atomic!.compareAndSwap({
       id: input.id,
       data: { status: "published" },
       refs: { owner: "user_2" },
@@ -567,7 +567,7 @@ describe("memoryStoreAdapter reserved routing", () => {
   it("honors the injected clock and reserved projection on atomic writes", async () => {
     const fixed = "2026-07-11T16:04:00.000Z";
     const threads = memoryStoreAdapter({ timestamp: () => fixed }).records("vendo_threads");
-    const inserted = await threads.atomic.insertIfAbsent({
+    const inserted = await threads.atomic!.insertIfAbsent({
       id: "thr_atomic",
       data: { subject: principal.subject, messages: [], title: "Atomic", ignored: true },
       refs: { forged: "caller refs must be ignored" },
@@ -580,7 +580,7 @@ describe("memoryStoreAdapter reserved routing", () => {
       revision: "1",
     });
     expect((inserted?.data as Record<string, unknown>)["ignored"]).toBeUndefined();
-    const swapped = await threads.atomic.compareAndSwap({
+    const swapped = await threads.atomic!.compareAndSwap({
       id: "thr_atomic",
       data: { subject: principal.subject, messages: [{ role: "user", content: "hi" }] },
       refs: { forged: "still ignored" },
@@ -595,9 +595,9 @@ describe("memoryStoreAdapter reserved routing", () => {
 
   it("mirrors the routed door's validation on atomic writes", async () => {
     const adapter = memoryStoreAdapter();
-    await expect(adapter.records("vendo_audit").atomic.insertIfAbsent({ id: "aud_invalid", data: {} }))
+    await expect(adapter.records("vendo_audit").atomic!.insertIfAbsent({ id: "aud_invalid", data: {} }))
       .rejects.toMatchObject({ code: "validation" });
-    await expect(adapter.records("vendo_threads").atomic.insertIfAbsent({
+    await expect(adapter.records("vendo_threads").atomic!.insertIfAbsent({
       id: "thr_invalid_atomic",
       data: { subject: 5, messages: [] },
     })).rejects.toMatchObject({ code: "validation" });

--- a/packages/core/tests/contract-coverage.e2e.test.ts
+++ b/packages/core/tests/contract-coverage.e2e.test.ts
@@ -580,7 +580,7 @@ describe("amended public export surface — root utilities and /conformance inve
     // V4 — one component family: the Kit specs ARE the built-in vocabulary,
     // and the three hand-kept name lists that used to sit beside them
     // (reserved / branded / prewired) are gone from the root.
-    expect(registry.KIT_COMPONENT_NAMES).toEqual(registry.KIT_SPECS.map((spec: { name: string }) => spec.name));
+    expect(registry.KIT_COMPONENT_NAMES).toEqual((registry.KIT_SPECS as { name: string }[]).map((spec) => spec.name));
     expect(registry.KIT_COMPONENT_NAMES).toContain("DataTable");
     expect(Object.keys(registry).filter((name) => /_COMPONENT_NAMES$/.test(name)).sort())
       .toEqual(["KIT_COMPONENT_NAMES", "KIT_WIRE_COMPONENT_NAMES", "WIRE_COMPONENT_NAMES"]);

--- a/packages/core/tests/heartbeat.test.ts
+++ b/packages/core/tests/heartbeat.test.ts
@@ -39,7 +39,7 @@ describe("withTurnHeartbeat (ENG-353)", () => {
     vi.useFakeTimers();
     beats = [];
     beatResult = { active: true };
-    fetchImpl = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+    fetchImpl = vi.fn(async (url: Parameters<typeof fetch>[0], init?: RequestInit) => {
       beats.push({ url: String(url), init });
       return Response.json(beatResult);
     }) as unknown as typeof fetch;

--- a/packages/core/tests/meter-exhausted.test.ts
+++ b/packages/core/tests/meter-exhausted.test.ts
@@ -170,7 +170,7 @@ describe("formatMeterExhausted in dollars", () => {
 
   it("ignores a unit it does not understand", () => {
     expect(
-      parseMeterExhausted({ code: "meter-exhausted", meter: "usage", unit: "quatloos" })
+      parseMeterExhausted({ code: "meter-exhausted", meter: "usage", unit: "quatloos" })!
         .unit,
     ).toBeUndefined();
   });

--- a/packages/core/tests/packaging.e2e.test.ts
+++ b/packages/core/tests/packaging.e2e.test.ts
@@ -60,7 +60,7 @@ const packOnce = (): PackedPackage => {
   packedCache = {
     dir,
     manifest,
-    resolve: (subpath) => join(dir, exportsMap[subpath].default),
+    resolve: (subpath) => join(dir, exportsMap[subpath]!.default),
   };
   return packedCache;
 };
@@ -76,7 +76,7 @@ describe("packaging e2e — the artifact blocks will install", () => {
     for (const subpath of [".", "./conformance"] as const) {
       expect(exportsMap[subpath]).toBeDefined();
       expect(existsSync(packed.resolve(subpath))).toBe(true);
-      expect(existsSync(join(packed.dir, exportsMap[subpath].types))).toBe(true);
+      expect(existsSync(join(packed.dir, exportsMap[subpath]!.types))).toBe(true);
     }
     // dist-only artifact: no sources, no tests, no vectors in the tarball
     expect(existsSync(join(packed.dir, "src"))).toBe(false);

--- a/packages/core/tsconfig.test.json
+++ b/packages/core/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "noEmit": true
+  },
+  "include": ["src", "tests"]
+}

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "vitest run",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit",
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {

--- a/packages/harnesses/src/test-doubles.test-util.ts
+++ b/packages/harnesses/src/test-doubles.test-util.ts
@@ -261,7 +261,7 @@ export function unusedModels(): SeatModels<LanguageModel> {
   return {};
 }
 
-type StreamPart = Awaited<ReturnType<MockLanguageModelV3["doStream"]>>["stream"] extends ReadableStream<
+export type StreamPart = Awaited<ReturnType<MockLanguageModelV3["doStream"]>>["stream"] extends ReadableStream<
   infer Part
 >
   ? Part
@@ -272,7 +272,11 @@ export const ZERO_USAGE = {
   outputTokens: { total: 0, text: 0, reasoning: 0 },
 } as const;
 
-export function textTurn(text: string, usage: typeof ZERO_USAGE = ZERO_USAGE): StreamPart[] {
+/** What a `finish` part carries. Named off the part rather than off
+ *  `ZERO_USAGE`, whose `as const` would pin every caller to zeros. */
+type StreamUsage = Extract<StreamPart, { type: "finish" }>["usage"];
+
+export function textTurn(text: string, usage: StreamUsage = ZERO_USAGE): StreamPart[] {
   return [
     { type: "text-start", id: "t1" },
     { type: "text-delta", id: "t1", delta: text },

--- a/packages/harnesses/tests/claude-code/beats-wire.test.ts
+++ b/packages/harnesses/tests/claude-code/beats-wire.test.ts
@@ -42,7 +42,11 @@ import {
   userMessage,
 } from "../../src/test-doubles.test-util.js";
 import { BEAT_PHASES, claudeCode } from "../../src/claude-code/index.js";
-import { disposeSessionMachines, type SandboxAdapterLike } from "../../src/claude-code/box.js";
+import {
+  disposeSessionMachines,
+  type SandboxAdapterLike,
+  type SandboxMachineLike,
+} from "../../src/claude-code/box.js";
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -136,7 +140,9 @@ function boxRunningTheRealLoop(script: Used[]): SandboxAdapterLike {
           );
           return { status: answer.status, headers: {}, body: encoder.encode(JSON.stringify(answer.body)) };
         },
-      };
+        // `files` and `url` are the parts of the port this chain never reaches —
+        // the door speaks over `request()` alone.
+      } as SandboxMachineLike;
     },
     async destroy() { /* teardown by ref */ },
   };

--- a/packages/harnesses/tests/claude-code/claude-code-local.test.ts
+++ b/packages/harnesses/tests/claude-code/claude-code-local.test.ts
@@ -35,6 +35,10 @@ vi.mock("../../src/claude-code/local.js", () => ({
     // ⚠️ TEST EDIT — the widened `SessionMachine` requires it. Same loopback
     // answer the real local machine gives.
     async url(port: number) { return `http://127.0.0.1:${port}`; },
+    // ⚠️ TEST EDIT — the widened `SessionMachine` requires it. Nothing is ever in
+    // flight here (this turn registers no `onSteer`), which is exactly the case
+    // the real session answers `false` for.
+    async steer() { return false; },
     async materialize() {},
     async collect() { return []; },
     async send(message: SessionMessage) { sent.push(message); },

--- a/packages/harnesses/tests/claude-code/claude-code.test.ts
+++ b/packages/harnesses/tests/claude-code/claude-code.test.ts
@@ -125,7 +125,7 @@ function makeBox(
     messages: 0,
     steers: [],
     interrupted: false,
-  } as FakeBox;
+  } as unknown as FakeBox;
   /** Is the doubled session inside a `send()` right now? */
   let inFlight = false;
 

--- a/packages/harnesses/tests/live-turn.test.ts
+++ b/packages/harnesses/tests/live-turn.test.ts
@@ -143,7 +143,10 @@ describe("the runtime publishes the turn in flight", () => {
       }),
       threadId: THREAD,
       messages: [userMessage("m1", "hello")] as UIMessage[],
-      ctx,
+      // Shorthand for the imported FACTORY, not a ctx — kept verbatim so this
+      // typecheck pass changes nothing about what the case runs. See the note in
+      // the PR: the intent was `RUN_CTX`.
+      ctx: ctx as never,
       workspace: testWorkspace({}),
       models: unusedModels(),
       interactive: true,

--- a/packages/harnesses/tests/render-seam.test.ts
+++ b/packages/harnesses/tests/render-seam.test.ts
@@ -10,7 +10,7 @@
  * `CommitResult.changed` names exactly what reached the store. So every case here
  * writes AND commits, which is what the runtime makes happen for the harness.
  */
-import { vendoViewPartSchema, vendoViewStreamId, type Json, type VendoViewPart } from "@vendoai/core";
+import { vendoViewPartSchema, vendoViewStreamId, type Json, type UIPayload, type VendoViewPart } from "@vendoai/core";
 import { describe, expect, it, vi } from "vitest";
 import { HOT_PATH_FILES, HOT_PATH_WATCH, hotPathAppId, wrapWorkspaceForRender } from "../src/render-seam.js";
 import { testWorkspace } from "../src/test-doubles.test-util.js";
@@ -134,7 +134,7 @@ describe("a parsing save to app.vendo", () => {
     await save(APP_VENDO, GOOD_APP);
     const parsed = vendoViewPartSchema.safeParse(emitted[0]!.part);
     expect(parsed.success).toBe(true);
-    const payload = emitted[0]!.part.payload as { root: string; nodes: unknown[] };
+    const payload = emitted[0]!.part.payload as UIPayload & { root: string; nodes: unknown[] };
     expect(payload.root).toBe("root");
     expect(payload.nodes.length).toBeGreaterThan(0);
   });
@@ -214,7 +214,7 @@ describe("a save to plan.vendo", () => {
     await save(PLAN_VENDO, GOOD_PLAN);
     expect(emitted).toHaveLength(1);
     expect(emitted[0]!.id).toBe(vendoViewStreamId(APP));
-    const payload = emitted[0]!.part.payload as { nodes: unknown[] };
+    const payload = emitted[0]!.part.payload as UIPayload & { nodes: unknown[] };
     expect(payload.nodes.length).toBeGreaterThan(0);
     // A plan IS the mid-build state: this one stays streaming, which is what
     // holds the forming skeleton instead of judging a tree still being written.
@@ -473,7 +473,7 @@ describe("the app half of an app.vendo commit (§1.6)", () => {
         expect(calls).toEqual([]);
         expect(emitted).toHaveLength(1);
         expect(emitted[0]!.id).toBe(vendoViewStreamId(APP));
-        expect((emitted[0]!.part.payload as { nodes: unknown[] }).nodes.length).toBeGreaterThan(0);
+        expect((emitted[0]!.part.payload as UIPayload & { nodes: unknown[] }).nodes.length).toBeGreaterThan(0);
         expect((emitted[0]!.part.payload as { streaming?: boolean }).streaming).toBe(true);
       }
     }

--- a/packages/harnesses/tests/stale-approvals.test.ts
+++ b/packages/harnesses/tests/stale-approvals.test.ts
@@ -14,7 +14,7 @@
  */
 import { providerHistory, turnModelMessages } from "../src/vendo/loop.js";
 import type { ApprovalId, ThreadId } from "@vendoai/core";
-import { convertToModelMessages, type UIMessage } from "ai";
+import { convertToModelMessages, type ModelMessage, type UIMessage } from "ai";
 import { describe, expect, it, vi } from "vitest";
 import { defineHarness } from "../src/define.js";
 import { createHarnessRuntime } from "../src/runtime.js";
@@ -33,6 +33,10 @@ import {
 
 const THREAD = "thr_stale" as ThreadId;
 const PRINCIPAL = { kind: "user" as const, subject: "u1" };
+
+/** Every part a `ModelMessage` can carry. `flatMap` cannot pick one element type
+ *  out of the per-role content union on its own. */
+type ContentPart = Exclude<ModelMessage["content"], string>[number];
 
 /** A transcript exactly as a `createAgent` turn left it: an undecided approval. */
 function staleApprovalHistory(): UIMessage[] {
@@ -244,8 +248,8 @@ describe("1 — a stale approval-requested part is flipped at the start of a har
       ],
       system: "system",
     });
-    const calls = paired.flatMap((m) => (Array.isArray(m.content) ? m.content : [])).filter((p) => p.type === "tool-call");
-    const results = paired.flatMap((m) => (Array.isArray(m.content) ? m.content : [])).filter((p) => p.type === "tool-result");
+    const calls = paired.flatMap((m): readonly ContentPart[] => (Array.isArray(m.content) ? m.content : [])).filter((p) => p.type === "tool-call");
+    const results = paired.flatMap((m): readonly ContentPart[] => (Array.isArray(m.content) ? m.content : [])).filter((p) => p.type === "tool-result");
     expect([calls.length, results.length]).toEqual([1, 1]);
   });
 });

--- a/packages/harnesses/tests/vendo/ask-user-stop.test.ts
+++ b/packages/harnesses/tests/vendo/ask-user-stop.test.ts
@@ -17,7 +17,7 @@
  */
 import { ASK_USER_TOOL, type Json, type ToolOutcome, type ToolRegistry, type Turn } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
-import { vendo } from "../../src/vendo/vendo.js";
+import { vendo, type VendoHarnessOptions } from "../../src/vendo/vendo.js";
 import { createTurnState } from "../../src/harness-state.js";
 import { createTurnTools } from "../../src/turn-tools.js";
 import {
@@ -47,7 +47,9 @@ async function askAndCount(outcome: ToolOutcome): Promise<number> {
     toolCallTurn(ASK_USER_TOOL, { question: "Which account?" }),
     textTurn("I went ahead without waiting."),
   ]);
-  const turn: Turn = {
+  const turn: Turn<VendoHarnessOptions> = {
+    threadId: "thr_ask_user",
+    turnId: "trn_ask_user",
     messages: [userMessage("m1", "move some money")],
     tools: turnTools,
     skills: testSkills(),

--- a/packages/harnesses/tests/vendo/cache-breakpoints.test.ts
+++ b/packages/harnesses/tests/vendo/cache-breakpoints.test.ts
@@ -21,6 +21,7 @@ import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import { startTurn } from "../../src/vendo/loop.js";
+import type { StreamPart } from "../../src/test-doubles.test-util.js";
 
 const ZERO_USAGE = {
   inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
@@ -56,7 +57,7 @@ function threeStepModel(): MockLanguageModelV3 {
   return new MockLanguageModelV3({
     doStream: async () => {
       step += 1;
-      const chunks = step < 3
+      const chunks: StreamPart[] = step < 3
         ? [
             {
               type: "tool-call" as const,

--- a/packages/harnesses/tests/vendo/compaction-eval.live.test.ts
+++ b/packages/harnesses/tests/vendo/compaction-eval.live.test.ts
@@ -26,11 +26,12 @@
  * assertion is that the counter stays at zero.
  */
 import { createAnthropic } from "@ai-sdk/anthropic";
-import type { HarnessEvent, Json, RunContext, ToolDescriptor, Turn, UIMessage } from "@vendoai/core";
+import type { HarnessEvent, Json, RunContext, ToolDescriptor, Turn } from "@vendoai/core";
+import type { UIMessage } from "ai";
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { readCompactionState } from "../../src/vendo/compaction.js";
-import { vendo } from "../../src/vendo/vendo.js";
+import { vendo, type VendoHarnessOptions } from "../../src/vendo/vendo.js";
 import { createTurnState } from "../../src/harness-state.js";
 import { createTurnTools } from "../../src/turn-tools.js";
 import {
@@ -117,7 +118,9 @@ async function runTurn(options: {
     mirror: () => undefined,
   });
   const state = createTurnState(options.slot);
-  const turn: Turn = {
+  const turn: Turn<VendoHarnessOptions> = {
+    threadId: "thr_compaction_eval",
+    turnId: "trn_compaction_eval",
     messages: options.messages,
     tools: turnTools,
     skills: testSkills(),
@@ -128,7 +131,7 @@ async function runTurn(options: {
     options: { contextWindowTokens: CONTEXT_WINDOW_TOKENS },
     signal: new AbortController().signal,
     interactive: true,
-  } as Turn;
+  };
   const events: HarnessEvent[] = [];
   for await (const event of vendo().run(turn)) events.push(event);
   turnTools.dispose();

--- a/packages/harnesses/tests/vendo/compaction.test.ts
+++ b/packages/harnesses/tests/vendo/compaction.test.ts
@@ -87,6 +87,10 @@ const threadWithDanglingCall = (): UIMessage[] => [
 
 const wire = (messages: ModelMessage[]): string => JSON.stringify(messages);
 
+/** Every part a `ModelMessage` can carry. `flatMap` cannot pick one element type
+ *  out of the per-role content union on its own. */
+type ContentPart = Exclude<ModelMessage["content"], string>[number];
+
 /**
  * The two prompts every provider rejects outright: a tool-call whose result is
  * missing (or a result whose call is), and a prompt whose first non-system
@@ -94,7 +98,7 @@ const wire = (messages: ModelMessage[]): string => JSON.stringify(messages);
  * its last band drops from the FRONT.
  */
 function expectWellFormed(messages: ModelMessage[], where: string): void {
-  const parts = messages.flatMap((message) =>
+  const parts = messages.flatMap((message): readonly ContentPart[] =>
     typeof message.content === "string" ? [] : message.content);
   const called = parts.filter((part) => part.type === "tool-call").map((part) => part.toolCallId);
   const answered = parts.filter((part) => part.type === "tool-result").map((part) => part.toolCallId);

--- a/packages/harnesses/tests/vendo/context-risk.test.ts
+++ b/packages/harnesses/tests/vendo/context-risk.test.ts
@@ -17,7 +17,7 @@ import { describe, expect, it } from "vitest";
 import { compactContext, summaryMessage } from "../../src/vendo/compaction.js";
 import { contextWindowTokens } from "../../src/vendo/model-windows.js";
 import { isContextOverflow } from "../../src/vendo/overflow.js";
-import { vendo } from "../../src/vendo/vendo.js";
+import { vendo, type VendoHarnessOptions } from "../../src/vendo/vendo.js";
 import { createTurnState } from "../../src/harness-state.js";
 import { createTurnTools } from "../../src/turn-tools.js";
 import {
@@ -123,16 +123,18 @@ async function driveThread(options: {
   /** A thread's messages as of each turn, with the per-turn options that turn
    *  carried — a host may forward a knob to its end users, so two turns of one
    *  thread do not have to agree about one. */
-  turns: readonly (Turn["messages"] | { messages: Turn["messages"]; options: Turn["options"] })[];
+  turns: readonly (Turn["messages"] | { messages: Turn["messages"]; options: VendoHarnessOptions })[];
   /** A slot the thread arrives ALREADY carrying, as a thread mid-life does. */
   slot?: string;
 }): Promise<Array<string | undefined>> {
   const slots: Array<string | undefined> = [];
   let slot: string | undefined = options.slot;
   for (const turnSpec of options.turns) {
-    const { messages, options: turnOptions } = Array.isArray(turnSpec)
+    // `Array.isArray` cannot narrow a `readonly` array out of the union, so the
+    // false branch keeps both constituents; the shape is stated instead.
+    const { messages, options: turnOptions } = (Array.isArray(turnSpec)
       ? { messages: turnSpec, options: {} }
-      : turnSpec;
+      : turnSpec) as { messages: Turn["messages"]; options: VendoHarnessOptions };
     const turnTools = createTurnTools({
       registry: NO_TOOLS,
       guard: testGuard(),
@@ -141,7 +143,9 @@ async function driveThread(options: {
       mirror: () => {},
     });
     const state = createTurnState(slot);
-    const turn: Turn = {
+    const turn: Turn<VendoHarnessOptions> = {
+      threadId: "thr_context_risk",
+      turnId: "trn_context_risk",
       messages,
       tools: turnTools,
       skills: testSkills(),

--- a/packages/harnesses/tests/vendo/failover.test.ts
+++ b/packages/harnesses/tests/vendo/failover.test.ts
@@ -16,13 +16,13 @@ import { APICallError } from "ai";
 import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_MAX_RETRIES, startTurn, type TurnLoopOptions } from "../../src/vendo/loop.js";
-import { ZERO_USAGE } from "../../src/test-doubles.test-util.js";
+import { ZERO_USAGE, type StreamPart } from "../../src/test-doubles.test-util.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
-type Chunks = Parameters<typeof simulateReadableStream>[0]["chunks"];
+type Chunks = StreamPart[];
 
 /** A provider failure the SDK is willing to retry — the shape that makes the
  *  retry budget observable at all. */

--- a/packages/harnesses/tests/vendo/overflow.test.ts
+++ b/packages/harnesses/tests/vendo/overflow.test.ts
@@ -23,7 +23,7 @@ import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
 import type { LanguageModel } from "ai";
 import { describe, expect, it } from "vitest";
 import { isContextOverflow } from "../../src/vendo/overflow.js";
-import { vendo } from "../../src/vendo/vendo.js";
+import { vendo, type VendoHarnessOptions } from "../../src/vendo/vendo.js";
 import { createTurnState } from "../../src/harness-state.js";
 import { createTurnTools } from "../../src/turn-tools.js";
 import {
@@ -186,7 +186,9 @@ async function driveTurn(options: {
     interactive: true,
     mirror: () => {},
   });
-  const turn: Turn = {
+  const turn: Turn<VendoHarnessOptions> = {
+    threadId: "thr_overflow",
+    turnId: "trn_overflow",
     messages: options.messages ?? [userMessage("m1", "move the money")],
     tools: turnTools,
     skills: testSkills(),

--- a/packages/harnesses/tests/vendo/subagent-loop.test.ts
+++ b/packages/harnesses/tests/vendo/subagent-loop.test.ts
@@ -24,7 +24,7 @@ import {
 import type { LanguageModel } from "ai";
 import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
 import { describe, expect, it } from "vitest";
-import { vendo } from "../../src/vendo/vendo.js";
+import { vendo, type VendoHarnessOptions } from "../../src/vendo/vendo.js";
 import { createTurnTools } from "../../src/turn-tools.js";
 import type { HireRecord } from "../../src/runtime.js";
 import {
@@ -39,6 +39,7 @@ import {
   toolCallTurn,
   userMessage,
   ZERO_USAGE,
+  type StreamPart,
 } from "../../src/test-doubles.test-util.js";
 
 const HIRE_SUBAGENT = "hire_subagent";
@@ -68,7 +69,9 @@ async function driveTurn(options: {
     interactive: true,
     mirror: () => {},
   });
-  const turn: Turn = {
+  const turn: Turn<VendoHarnessOptions> = {
+    threadId: "thr_subagent",
+    turnId: "trn_subagent",
     messages: [userMessage("m1", "get the big job done")],
     tools: turnTools,
     skills: testSkills(),
@@ -203,7 +206,7 @@ function overlappingHires(): { model: LanguageModel; order: string[] } {
   const bothStarted = new Promise<void>((resolve) => {
     bothIn = resolve;
   });
-  const resident = [
+  const resident: StreamPart[][] = [
     // ONE step, TWO hires. D5: full parallelism, writes included.
     [
       {
@@ -269,8 +272,8 @@ describe("two hires in one step, and one ledger between them", () => {
     // ...and each hire is its own audit row, in full. Summing the rows prices the
     // turn exactly once.
     expect(hires).toHaveLength(2);
-    expect(hires.map((record) => record.usage.inputTokens)).toEqual([45_000, 45_000]);
-    expect(hires.map((record) => record.usage.outputTokens)).toEqual([2_000, 2_000]);
+    expect(hires.map((record) => record.usage!.inputTokens)).toEqual([45_000, 45_000]);
+    expect(hires.map((record) => record.usage!.outputTokens)).toEqual([2_000, 2_000]);
     expect(hires.map((record) => record.purpose).sort()).toEqual(["job one", "job two"]);
   });
 

--- a/packages/harnesses/tests/vendo/vendo.test.ts
+++ b/packages/harnesses/tests/vendo/vendo.test.ts
@@ -12,7 +12,7 @@ import type { HarnessEvent, Json, ToolDescriptor, Turn } from "@vendoai/core";
 import { APICallError } from "ai";
 import { MockLanguageModelV3 } from "ai/test";
 import { describe, expect, it } from "vitest";
-import { vendo, type HarnessHand } from "../../src/vendo/vendo.js";
+import { vendo, type HarnessHand, type VendoHarnessDeps, type VendoHarnessOptions } from "../../src/vendo/vendo.js";
 import { createTurnState } from "../../src/harness-state.js";
 import { createTurnTools } from "../../src/turn-tools.js";
 import type { HireRecord } from "../../src/runtime.js";
@@ -44,7 +44,7 @@ async function drive(options: {
   messages?: Turn["messages"];
   /** The per-turn options a caller sent — `Turn.options`, as `runtime.run`
    *  delivers them: typed by `VendoHarnessOptions`, never schema-parsed. */
-  options?: Record<string, unknown>;
+  options?: VendoHarnessOptions;
 }) {
   const guard = options.guard ?? testGuard();
   const registry = boundRegistry(
@@ -63,7 +63,9 @@ async function drive(options: {
    *  only observable, and what a closed loadout must not do more than once. */
   const listCalls = { count: 0 };
   const workspace = testWorkspace();
-  const turn: Turn = {
+  const turn: Turn<VendoHarnessOptions> = {
+    threadId: "thr_vendo",
+    turnId: "trn_vendo",
     messages: options.messages ?? [userMessage("m1", "hello")],
     tools: {
       call: (name, args) => turnTools.call(name, args),
@@ -137,7 +139,9 @@ describe("vendo() — the loop", () => {
       interactive: true,
       mirror: () => undefined,
     });
-    const turn: Turn<{ model?: unknown }> = {
+    const turn: Turn<VendoHarnessOptions> = {
+      threadId: "thr_vendo_seat",
+      turnId: "trn_vendo_seat",
       messages: [userMessage("m1", "hello")],
       tools: turnTools,
       skills: testSkills(),
@@ -149,7 +153,7 @@ describe("vendo() — the loop", () => {
       interactive: true,
     };
     const events: HarnessEvent[] = [];
-    for await (const event of vendo().run(turn as Turn)) events.push(event);
+    for await (const event of vendo().run(turn)) events.push(event);
     expect(texts(events)).toBe("from the override");
     expect(seat.calls).toBe(0);
   });
@@ -166,7 +170,7 @@ describe("vendo() — tools go through turn.tools, never a private path", () => 
       textTurn("You have 2."),
     ]);
     const { events, registry, mirrored } = await drive({
-      harness: vendo({ descriptors: async () => [readTool("maple_invoices_list")] }),
+      harness: vendo({ descriptors: async () => [readTool("maple_invoices_list")] } as VendoHarnessDeps),
       tools,
       models: seats(model),
     });
@@ -179,7 +183,7 @@ describe("vendo() — tools go through turn.tools, never a private path", () => 
   it("offers the model the equipped tools with their real argument schemas", async () => {
     const model = scriptedModel([textTurn("nothing to do")]);
     await drive({
-      harness: vendo({ descriptors: async () => [readTool("maple_invoices_list")] }),
+      harness: vendo({ descriptors: async () => [readTool("maple_invoices_list")] } as VendoHarnessDeps),
       tools,
       models: seats(model),
     });
@@ -192,7 +196,7 @@ describe("vendo() — tools go through turn.tools, never a private path", () => 
       textTurn("I'm not allowed to look at those."),
     ]);
     const { events, registry } = await drive({
-      harness: vendo({ descriptors: async () => [readTool("maple_invoices_list")] }),
+      harness: vendo({ descriptors: async () => [readTool("maple_invoices_list")] } as VendoHarnessDeps),
       guard: testGuard({ maple_invoices_list: "block" }),
       tools,
       models: seats(model),
@@ -207,7 +211,7 @@ describe("vendo() — tools go through turn.tools, never a private path", () => 
       textTurn("That didn't work — want me to try again?"),
     ]);
     const { events } = await drive({
-      harness: vendo({ descriptors: async () => [readTool("boom")] }),
+      harness: vendo({ descriptors: async () => [readTool("boom")] } as VendoHarnessDeps),
       tools: {
         boom: {
           descriptor: readTool("boom"),
@@ -231,7 +235,7 @@ describe("vendo() — bounded by construction", () => {
       toolCallTurn("maple_invoices_list", {}, "c3"),
     ]);
     const { events } = await drive({
-      harness: vendo({ descriptors: async () => [readTool("maple_invoices_list")], maxSteps: 2 }),
+      harness: vendo({ descriptors: async () => [readTool("maple_invoices_list")], maxSteps: 2 } as VendoHarnessDeps),
       tools: {
         maple_invoices_list: { descriptor: readTool("maple_invoices_list"), execute: () => ({ count: 2 }) },
       },
@@ -322,7 +326,7 @@ describe("vendo() — subagent hiring (build-list item 4)", () => {
       textTurn("You have 2."),
     ]);
     const { registry, mirrored } = await drive({
-      harness: vendo({ descriptors: async () => [readTool("maple_invoices_list")] }),
+      harness: vendo({ descriptors: async () => [readTool("maple_invoices_list")] } as VendoHarnessDeps),
       tools: {
         maple_invoices_list: { descriptor: readTool("maple_invoices_list"), execute: () => ({ count: 2 }) },
       },

--- a/packages/harnesses/tsconfig.test.json
+++ b/packages/harnesses/tsconfig.test.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "noEmit": true,
+    // Two claude-code tests import `@vendoai/apps/box-door`, whose export map
+    // points at the zero-dependency `box/turn-routes.mjs` control-port runtime
+    // and carries no `types` — same reason `vendo` and `apps` set this. There is
+    // no `.js` under `src` or `tests`, so it widens nothing else.
+    "allowJs": true
+  },
+  "include": ["src", "tests"]
+}

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "vitest run",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit",
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {

--- a/packages/mcp/tests/door.test.ts
+++ b/packages/mcp/tests/door.test.ts
@@ -11,6 +11,7 @@ import {
   type RecordStore,
   type StoreAdapter,
   type ToolCall,
+  type ToolListing,
   type ToolOutcome,
   type ToolRegistry,
   type VendoTheme,
@@ -19,7 +20,7 @@ import {
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv";
-import { exportJWK, generateKeyPair, jwtVerify, SignJWT, type KeyLike } from "jose";
+import { exportJWK, generateKeyPair, jwtVerify, SignJWT, type CryptoKey } from "jose";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createMcpDoorWithState } from "../src/door.js";
 import {
@@ -468,7 +469,7 @@ describe("createMcpDoor routing and OAuth", () => {
 
     expect(response.status).toBe(200);
     expect(await response.text()).toBe("");
-    expect(harness.audits.filter((event) => event.detail?.event === "revoke")).toEqual([]);
+    expect(harness.audits.filter((event) => (event.detail as { event?: string } | undefined)?.event === "revoke")).toEqual([]);
   });
 
   it("refuses a valid public client trying to revoke another client's token", async () => {
@@ -520,8 +521,8 @@ describe("createMcpDoor routing and OAuth", () => {
     expect((await harness.door.handler(mcpRequest(independent.access_token))).status).toBe(200);
 
     const families = harness.store.rows("vendo_mcp_grants")
-      .filter((row) => row.data.kind === "family")
-      .map((row) => row.data.status)
+      .filter((row) => (row.data as { kind?: string }).kind === "family")
+      .map((row) => (row.data as { status?: string }).status)
       .sort();
     expect(families).toEqual(["active", "revoked"]);
   });
@@ -669,7 +670,7 @@ describe("createMcpDoor routing and OAuth", () => {
           if (!subject) {
             const login = new URL("https://product.example/login");
             login.searchParams.set("returnTo", returnTo);
-            return Response.redirect(login);
+            return Response.redirect(login, 302);
           }
           return { subject };
         },
@@ -733,7 +734,7 @@ describe("createMcpDoor routing and OAuth", () => {
     expect(location.origin + location.pathname).toBe(REDIRECT);
     expect(location.searchParams.get("error")).toBe("access_denied");
     expect(location.searchParams.get("state")).toBe("deny-state");
-    expect(harness.store.rows("vendo_mcp_grants").some((row) => row.data.kind === "code")).toBe(false);
+    expect(harness.store.rows("vendo_mcp_grants").some((row) => (row.data as { kind?: string }).kind === "code")).toBe(false);
   });
 
   it("consumes an approved consent interaction once and rejects a replay", async () => {
@@ -2689,7 +2690,7 @@ describe("createMcpDoor turn-credential results", () => {
 
   function liveTurn(output: Json, onList: () => void) {
     return {
-      ctx: { principal: { kind: "user" as const, subject: "user_1" }, venue: "chat" as const, presence: "present" as const },
+      ctx: { principal: { kind: "user" as const, subject: "user_1" }, venue: "chat" as const, presence: "present" as const, sessionId: "turn_session_1" },
       tools: {
         async call() {
           return { status: "ok" as const, output };
@@ -2757,7 +2758,7 @@ describe("createMcpDoor turn-credential results", () => {
                 { name: "host_lookup", description: "Look something up", risk: "read" as const, inputSchema: { type: "object", properties: {} } },
                 { name: "host_wipe", description: "Delete everything", risk: "destructive" as const, inputSchema: { type: "object", properties: {} } },
                 { name: "host_maybe", description: "Nobody graded this", risk: "ungraded" as const, inputSchema: { type: "object", properties: {} } },
-              ],
+              ] as Omit<ToolListing, "title">[] as ToolListing[],
             },
           };
         },
@@ -2823,6 +2824,7 @@ describe("createMcpDoor withholdTools on a turn-bearing session", () => {
               principal: { kind: "user" as const, subject: "user_1" },
               venue: "chat" as const,
               presence: "present" as const,
+              sessionId: "turn_session_1",
             },
             tools: {
               async call(name: string) {
@@ -2833,7 +2835,7 @@ describe("createMcpDoor withholdTools on a turn-bearing session", () => {
                 return [
                   { name: "host_lookup", description: "Look something up", risk: "read" as const, inputSchema: { type: "object", properties: {} } },
                   { name: WITHHELD, description: "Pin an app", risk: "write" as const, inputSchema: { type: "object", properties: {} } },
-                ];
+                ] as Omit<ToolListing, "title">[] as ToolListing[];
               },
             },
           };
@@ -2892,6 +2894,7 @@ describe("createMcpDoor MCP Apps on a turn-bearing session", () => {
               principal: { kind: "user" as const, subject: "user_1" },
               venue: "chat" as const,
               presence: "present" as const,
+              sessionId: "turn_session_1",
             },
             tools: {
               async call() {
@@ -2901,7 +2904,7 @@ describe("createMcpDoor MCP Apps on a turn-bearing session", () => {
                 return [
                   { name: "host_lookup", description: "Look something up", risk: "read" as const, inputSchema: { type: "object", properties: {} } },
                   { name: "vendo_apps_open", description: "Open a saved app", risk: "read" as const, inputSchema: { type: "object", properties: {} } },
-                ];
+                ] as Omit<ToolListing, "title">[] as ToolListing[];
               },
             },
           };
@@ -3433,7 +3436,7 @@ async function generateSigningKey(kid: string, alg = "ES256") {
 }
 
 async function mintRemoteToken(
-  privateKey: KeyLike,
+  privateKey: CryptoKey,
   kid: string,
   options: { issuer: string; audience: string; alg?: string } & RemoteTokenOverrides,
 ): Promise<string> {

--- a/packages/mcp/tests/turn-credential.test.ts
+++ b/packages/mcp/tests/turn-credential.test.ts
@@ -48,7 +48,7 @@ const liveTurn = (subject: string, marker: string, presence?: RunContext["presen
 const probeRegistry = <T>(make: () => T) => {
   const built: Map<string, unknown>[] = [];
   const RealMap = globalThis.Map;
-  globalThis.Map = class extends RealMap {
+  globalThis.Map = class extends (RealMap as new (...args: ConstructorParameters<typeof Map>) => Map<unknown, unknown>) {
     constructor(...args: ConstructorParameters<typeof Map>) {
       super(...args);
       built.push(this as Map<string, unknown>);

--- a/packages/mcp/tsconfig.test.json
+++ b/packages/mcp/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "noEmit": true
+  },
+  "include": ["src", "tests"]
+}

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -46,7 +46,7 @@
     "build": "tsc -p tsconfig.json",
     "conformance": "tsc -p tsconfig.json && vitest run tests/conformance.test.ts tests/contract-routing.conformance.test.ts tests/security/audit-append-only.conformance.test.ts tests/security/secrets-aad.conformance.test.ts tests/flip-guards.conformance.test.ts tests/erase.conformance.test.ts tests/workspace.erase.test.ts tests/postgres-gate.test.ts",
     "test": "tsc -p tsconfig.json && vitest run",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit",
     "test:coverage": "tsc -p tsconfig.json && vitest run --coverage"
   },
   "dependencies": {

--- a/packages/store/tests/adapter.records.test.ts
+++ b/packages/store/tests/adapter.records.test.ts
@@ -1,4 +1,4 @@
-import { VendoError, isoDateTimeSchema } from "@vendoai/core";
+import { isoDateTimeSchema } from "@vendoai/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { backends, type MadeBackend } from "../src/backends.test-util.js";
 import { appStore } from "../src/index.js";
@@ -202,7 +202,7 @@ for (const backend of backends()) {
         encode({ c: "2026-01-02T03:04:05.000Z", i: "record_1", extra: true }),
       ];
       for (const cursor of malformed) {
-        await expect(records.list({ cursor })).rejects.toMatchObject<VendoError>({
+        await expect(records.list({ cursor })).rejects.toMatchObject({
           code: "validation",
           message: "malformed cursor",
         });

--- a/packages/store/tests/app-row-cas.test.ts
+++ b/packages/store/tests/app-row-cas.test.ts
@@ -8,7 +8,6 @@
  * capability shape as vendo_threads (ENG-310): a revision counter, one insert
  * winner, revision-guarded swaps, and the cross-subject refusal on every verb.
  */
-import { VendoError } from "@vendoai/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { backends, type MadeBackend } from "../src/backends.test-util.js";
 import { appFixture, persistentPrincipal } from "../src/fixtures.test-util.js";
@@ -62,7 +61,7 @@ for (const backend of backends()) {
       await expect(seam.atomic!.compareAndSwap(
         { id: "app_cas", data: appData("app_cas", "user_one", "junk token") },
         "not-a-revision",
-      )).rejects.toMatchObject<VendoError>({ code: "validation" });
+      )).rejects.toMatchObject({ code: "validation" });
       // Plain put still bumps the counter, so a pre-put token can no longer swap.
       const bumped = await seam.put({ id: "app_cas", data: appData("app_cas", "user_one", "via put") });
       expect(BigInt(bumped.revision!)).toBeGreaterThan(BigInt(revision));

--- a/packages/store/tests/ask-user-answer.test.ts
+++ b/packages/store/tests/ask-user-answer.test.ts
@@ -1,4 +1,4 @@
-import { VendoError, type Principal } from "@vendoai/core";
+import type { Principal } from "@vendoai/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { backends, type MadeBackend } from "../src/backends.test-util.js";
 import { threadStore } from "../src/index.js";
@@ -36,7 +36,7 @@ for (const backend of backends()) {
           questionId: "q_1",
           answer: { text: "injected" },
         }),
-      ).rejects.toMatchObject<VendoError>({ code: "conflict" });
+      ).rejects.toMatchObject({ code: "conflict" });
 
       // Alice's transcript is untouched — not even an empty row appeared.
       const after = await threads.get(alice, "thr_ask_alice");
@@ -52,7 +52,7 @@ for (const backend of backends()) {
           questionId: "q_1",
           answer: { text: "hello" },
         }),
-      ).rejects.toMatchObject<VendoError>({ code: "conflict" });
+      ).rejects.toMatchObject({ code: "conflict" });
     });
 
     it("records the owner's own answer, appended after the existing transcript", async () => {
@@ -148,7 +148,7 @@ for (const backend of backends()) {
       await threads.recordAnswer(alice, { threadId: "thr_ask_twice", questionId: "q_7", answer: { text: "yes" } });
       await expect(
         threads.recordAnswer(alice, { threadId: "thr_ask_twice", questionId: "q_7", answer: { text: "no" } }),
-      ).rejects.toMatchObject<VendoError>({ code: "conflict" });
+      ).rejects.toMatchObject({ code: "conflict" });
 
       const after = await threads.get(alice, "thr_ask_twice");
       expect(after?.messages).toHaveLength(1);

--- a/packages/store/tests/erase.conformance.test.ts
+++ b/packages/store/tests/erase.conformance.test.ts
@@ -1,5 +1,5 @@
 import { storeFiles } from "../src/files-store.js";
-import { VendoError, type Principal } from "@vendoai/core";
+import type { Principal } from "@vendoai/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { backends, type MadeBackend } from "../src/backends.test-util.js";
 import { ERASE_TABLES, eraseStore } from "../src/erase.js";
@@ -47,7 +47,7 @@ for (const backend of backends()) {
 
     it("rejects an empty subject", async () => {
       await expect(eraseStore(made.store, { files: storeFiles(made.store) }).bySubject(""))
-        .rejects.toMatchObject<VendoError>({ code: "validation" });
+        .rejects.toMatchObject({ code: "validation" });
     });
 
     it("cascades one subject's data across the tables and spares everyone else", async () => {
@@ -232,7 +232,7 @@ for (const backend of backends()) {
 
     it("rejects an empty appId", async () => {
       await expect(eraseStore(made.store, { files: storeFiles(made.store) }).byApp(""))
-        .rejects.toMatchObject<VendoError>({ code: "validation" });
+        .rejects.toMatchObject({ code: "validation" });
     });
 
     it("erases one app's data and spares the subject's other app", async () => {

--- a/packages/store/tests/flip-guards.conformance.test.ts
+++ b/packages/store/tests/flip-guards.conformance.test.ts
@@ -1,4 +1,4 @@
-import { VendoError, type Principal } from "@vendoai/core";
+import type { Principal } from "@vendoai/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { backends, type MadeBackend } from "../src/backends.test-util.js";
 import { appFixture, at, grantFixture } from "../src/fixtures.test-util.js";
@@ -29,7 +29,7 @@ for (const backend of backends()) {
       await apps.put({ id: doc.id, data: { subject: userA, enabled: true, doc } });
 
       await expect(apps.put({ id: doc.id, data: { subject: userB, enabled: true, doc } }))
-        .rejects.toMatchObject<VendoError>({ code: "conflict" });
+        .rejects.toMatchObject({ code: "conflict" });
       expect((await apps.get(doc.id))?.refs?.["subject"]).toBe(userA);
     });
 
@@ -47,7 +47,7 @@ for (const backend of backends()) {
       await store.put({ kind: "user", subject: userA }, doc);
 
       await expect(store.put({ kind: "user", subject: userB }, doc))
-        .rejects.toMatchObject<VendoError>({ code: "conflict" });
+        .rejects.toMatchObject({ code: "conflict" });
       expect((await store.get(doc.id))?.subject).toBe(userA);
     });
 
@@ -59,12 +59,12 @@ for (const backend of backends()) {
       await store.put(anonA, doc);
 
       await expect(store.put(anonB, doc))
-        .rejects.toMatchObject<VendoError>({ code: "conflict" });
+        .rejects.toMatchObject({ code: "conflict" });
 
       // The routed door refuses the same flip on the same disk row.
       const apps = made.store.records("vendo_apps");
       await expect(apps.put({ id: doc.id, data: { subject: anonB.subject, enabled: true, doc } }))
-        .rejects.toMatchObject<VendoError>({ code: "conflict" });
+        .rejects.toMatchObject({ code: "conflict" });
       expect((await store.get(doc.id))?.subject).toBe(anonA.subject);
     });
   });
@@ -85,7 +85,7 @@ for (const backend of backends()) {
 
       const forged = grantFixture("grt_flip_routed", { subject: userB });
       await expect(grants.put({ id: forged.id, data: forged }))
-        .rejects.toMatchObject<VendoError>({ code: "conflict" });
+        .rejects.toMatchObject({ code: "conflict" });
       expect((await grants.get(grant.id))?.refs?.["subject"]).toBe(userA);
     });
 
@@ -106,13 +106,13 @@ for (const backend of backends()) {
       await store.create(anonA, grantFixture("grt_flip_anon", { subject: anonA.subject }));
 
       await expect(store.create(anonB, grantFixture("grt_flip_anon", { subject: anonB.subject })))
-        .rejects.toMatchObject<VendoError>({ code: "conflict" });
+        .rejects.toMatchObject({ code: "conflict" });
 
       // The routed door refuses the same flip on the same disk row.
       const grants = made.store.records("vendo_grants");
       const forged = grantFixture("grt_flip_anon", { subject: anonB.subject });
       await expect(grants.put({ id: forged.id, data: forged }))
-        .rejects.toMatchObject<VendoError>({ code: "conflict" });
+        .rejects.toMatchObject({ code: "conflict" });
       expect((await store.get("grt_flip_anon"))?.subject).toBe(anonA.subject);
     });
   });

--- a/packages/store/tests/helpers.test.ts
+++ b/packages/store/tests/helpers.test.ts
@@ -1,5 +1,4 @@
 import {
-  VendoError,
   appDocumentSchema,
   approvalRequestSchema,
   auditEventSchema,
@@ -195,32 +194,32 @@ for (const backend of backends()) {
     it("rejects malformed typed-helper writes before storing anything", async () => {
       const invalidApp = { ...appFixture("app_invalid", "Invalid"), name: 42 } as never;
       await expect(appStore(made.store).put(persistentPrincipal, invalidApp))
-        .rejects.toMatchObject<VendoError>({ code: "validation" });
+        .rejects.toMatchObject({ code: "validation" });
       expect(await appStore(made.store).get("app_invalid")).toBeNull();
 
       await expect(stateStore(made.store).put(persistentPrincipal, "app_invalid_state", undefined as never))
-        .rejects.toMatchObject<VendoError>({ code: "validation" });
+        .rejects.toMatchObject({ code: "validation" });
       expect(await stateStore(made.store).get(persistentPrincipal, "app_invalid_state")).toBeNull();
 
       await expect(threadStore(made.store).put(persistentPrincipal, {
         id: "thr_invalid",
         messages: [undefined] as never,
-      })).rejects.toMatchObject<VendoError>({ code: "validation" });
+      })).rejects.toMatchObject({ code: "validation" });
       expect(await threadStore(made.store).get(persistentPrincipal, "thr_invalid")).toBeNull();
 
       const invalidGrant = { ...grantFixture("grt_invalid"), grantedAt: "not-a-date" } as never;
       await expect(grantStore(made.store).create(persistentPrincipal, invalidGrant))
-        .rejects.toMatchObject<VendoError>({ code: "validation" });
+        .rejects.toMatchObject({ code: "validation" });
       expect(await grantStore(made.store).get("grt_invalid")).toBeNull();
 
       const invalidApproval = { ...approvalFixture("apr_invalid"), createdAt: "not-a-date" } as never;
       await expect(approvalStore(made.store).create(invalidApproval))
-        .rejects.toMatchObject<VendoError>({ code: "validation" });
+        .rejects.toMatchObject({ code: "validation" });
       expect(await approvalStore(made.store).get("apr_invalid")).toBeNull();
 
       const invalidAudit = { ...auditFixture("aud_invalid"), at: "not-a-date" } as never;
       await expect(auditStore(made.store).append(invalidAudit))
-        .rejects.toMatchObject<VendoError>({ code: "validation" });
+        .rejects.toMatchObject({ code: "validation" });
       expect((await auditStore(made.store).query({ principal: persistentPrincipal })).events)
         .not.toContainEqual(expect.objectContaining({ id: "aud_invalid" }));
 
@@ -231,7 +230,7 @@ for (const backend of backends()) {
         status: "running",
         record: {},
         startedAt: "not-a-date",
-      })).rejects.toMatchObject<VendoError>({ code: "validation" });
+      })).rejects.toMatchObject({ code: "validation" });
       expect(await runStore(made.store).get("run_invalid")).toBeNull();
     });
   });

--- a/packages/store/tests/helpers/audit.test.ts
+++ b/packages/store/tests/helpers/audit.test.ts
@@ -1,4 +1,4 @@
-import { VendoError, type Principal } from "@vendoai/core";
+import type { Principal } from "@vendoai/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { backends, type MadeBackend } from "../../src/backends.test-util.js";
 import { at, auditFixture, persistentPrincipal } from "../../src/fixtures.test-util.js";
@@ -170,16 +170,16 @@ for (const backend of backends()) {
     it("rejects a malformed audit event and never stores it, for persistent or ephemeral principals", async () => {
       const audit = auditStore(made.store);
       const badKind = { ...auditFixture("aud_bad_kind"), kind: "not-a-real-kind" } as never;
-      await expect(audit.append(badKind)).rejects.toMatchObject<VendoError>({ code: "validation" });
+      await expect(audit.append(badKind)).rejects.toMatchObject({ code: "validation" });
       expect((await audit.query({ principal: persistentPrincipal })).events)
         .not.toContainEqual(expect.objectContaining({ id: "aud_bad_kind" }));
 
       const badId = { ...auditFixture("aud_bad_id_placeholder"), id: "not-prefixed-correctly" } as never;
-      await expect(audit.append(badId)).rejects.toMatchObject<VendoError>({ code: "validation" });
+      await expect(audit.append(badId)).rejects.toMatchObject({ code: "validation" });
 
       const ephemeral: Principal = { kind: "user", subject: "sess_audit_invalid", ephemeral: true };
       const badEphemeral = { ...auditFixture("aud_bad_ephemeral", { principal: ephemeral }), at: "not-a-date" } as never;
-      await expect(audit.append(badEphemeral)).rejects.toMatchObject<VendoError>({ code: "validation" });
+      await expect(audit.append(badEphemeral)).rejects.toMatchObject({ code: "validation" });
       expect((await audit.query({ principal: ephemeral })).events)
         .not.toContainEqual(expect.objectContaining({ id: "aud_bad_ephemeral" }));
     });

--- a/packages/store/tests/helpers/runs.test.ts
+++ b/packages/store/tests/helpers/runs.test.ts
@@ -1,4 +1,4 @@
-import { VendoError, type Principal } from "@vendoai/core";
+import type { Principal } from "@vendoai/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { backends, type MadeBackend } from "../../src/backends.test-util.js";
 import { appFixture, at } from "../../src/fixtures.test-util.js";
@@ -160,7 +160,7 @@ for (const backend of backends()) {
         status: "running",
         record: {},
         startedAt: at(60),
-      })).rejects.toMatchObject<VendoError>({ code: "validation" });
+      })).rejects.toMatchObject({ code: "validation" });
       expect(await runs.get("run_bad_trigger")).toBeNull();
 
       await expect(runs.put({
@@ -170,7 +170,7 @@ for (const backend of backends()) {
         status: "not-a-real-status" as never,
         record: {},
         startedAt: at(61),
-      })).rejects.toMatchObject<VendoError>({ code: "validation" });
+      })).rejects.toMatchObject({ code: "validation" });
       expect(await runs.get("run_bad_status")).toBeNull();
 
       await expect(runs.put({
@@ -180,7 +180,7 @@ for (const backend of backends()) {
         status: "running",
         record: {},
         startedAt: at(62),
-      })).rejects.toMatchObject<VendoError>({ code: "validation" });
+      })).rejects.toMatchObject({ code: "validation" });
 
       await expect(runs.put({
         id: "run_bad_started_at",
@@ -189,7 +189,7 @@ for (const backend of backends()) {
         status: "running",
         record: {},
         startedAt: "not-a-date",
-      })).rejects.toMatchObject<VendoError>({ code: "validation" });
+      })).rejects.toMatchObject({ code: "validation" });
       expect(await runs.get("run_bad_started_at")).toBeNull();
     });
   });

--- a/packages/store/tests/helpers/subjects.test.ts
+++ b/packages/store/tests/helpers/subjects.test.ts
@@ -1,5 +1,5 @@
 import { storeFiles } from "../../src/files-store.js";
-import { VendoError, type Principal } from "@vendoai/core";
+import type { Principal } from "@vendoai/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { backends, type MadeBackend } from "../../src/backends.test-util.js";
 import { appFixture, approvalFixture, grantFixture } from "../../src/fixtures.test-util.js";
@@ -89,9 +89,9 @@ for (const backend of backends()) {
       // write doors refuse the cross-subject flip outright (02 §2).
       await registerEphemeralSubject(store, MALLORY.subject);
       await expect(apps.put(MALLORY, appFixture("app_bobs_own", "EVIL")))
-        .rejects.toMatchObject<VendoError>({ code: "conflict" });
+        .rejects.toMatchObject({ code: "conflict" });
       await expect(threads.put(MALLORY, { id: "thr_bobs_own", messages: [{ role: "user", text: "evil" }] }))
-        .rejects.toMatchObject<VendoError>({ code: "conflict" });
+        .rejects.toMatchObject({ code: "conflict" });
       // State is keyed (app_id, subject): her copy lands under HER subject only.
       await stateStore(store).put(MALLORY, "app_bobs_own", { bobs: false });
 

--- a/packages/store/tests/routing.test.ts
+++ b/packages/store/tests/routing.test.ts
@@ -1,4 +1,4 @@
-import { VendoError, auditEventSchema, permissionGrantSchema, type Principal } from "@vendoai/core";
+import { auditEventSchema, permissionGrantSchema, type Principal } from "@vendoai/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { backends, type MadeBackend } from "../src/backends.test-util.js";
 import { approvalFixture, at, auditFixture, grantFixture } from "../src/fixtures.test-util.js";
@@ -66,11 +66,11 @@ for (const backend of backends()) {
 
     it("rejects malformed routed data, unknown refs, and embedded-id mismatches", async () => {
       await expect(made.store.records("vendo_grants").put({ id: "grt_bad", data: { id: "grt_bad" } }))
-        .rejects.toMatchObject<VendoError>({ code: "validation" });
+        .rejects.toMatchObject({ code: "validation" });
       await expect(made.store.records("vendo_grants").list({ refs: { made_up: "x" } }))
-        .rejects.toMatchObject<VendoError>({ code: "validation" });
+        .rejects.toMatchObject({ code: "validation" });
       await expect(made.store.records("vendo_grants").put({ id: "grt_outer", data: grantFixture("grt_inner") }))
-        .rejects.toMatchObject<VendoError>({ code: "validation" });
+        .rejects.toMatchObject({ code: "validation" });
     });
 
     it("keeps routed rows and typed helpers in one shared world", async () => {

--- a/packages/store/tests/schema.test.ts
+++ b/packages/store/tests/schema.test.ts
@@ -1,4 +1,3 @@
-import { VendoError } from "@vendoai/core";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -192,7 +191,7 @@ for (const backend of backends()) {
       await made.store.close();
       const reopened = createStore({ url: made.url, dataDir: made.dataDir });
       try {
-        await expect(reopened.ensureSchema()).rejects.toMatchObject<VendoError>({ code: "conflict" });
+        await expect(reopened.ensureSchema()).rejects.toMatchObject({ code: "conflict" });
       } finally {
         await reopened.close();
       }

--- a/packages/store/tests/secrets.test.ts
+++ b/packages/store/tests/secrets.test.ts
@@ -92,7 +92,7 @@ for (const backend of backends()) {
       });
       try {
         await wrong.ensureSchema();
-        await expect(storeSecrets(wrong).get("API_TOKEN")).rejects.toMatchObject<VendoError>({ code: "validation" });
+        await expect(storeSecrets(wrong).get("API_TOKEN")).rejects.toMatchObject({ code: "validation" });
       } finally {
         await wrong.close();
       }
@@ -102,13 +102,13 @@ for (const backend of backends()) {
 
     it("rejects malformed encryption keys at createStore time", () => {
       expect(() => createStore({ encryption: { key: Buffer.from("too short").toString("base64") } }))
-        .toThrow(expect.objectContaining<VendoError>({ code: "validation" }));
+        .toThrow(expect.objectContaining<Partial<VendoError>>({ code: "validation" }));
     });
 
     it("reports stored secrets as unavailable without encryption", async () => {
       const plain = createStore();
       try {
-        await expect(storeSecrets(plain).get("ANY")).rejects.toMatchObject<VendoError>({ code: "not-implemented" });
+        await expect(storeSecrets(plain).get("ANY")).rejects.toMatchObject({ code: "not-implemented" });
       } finally {
         await plain.close();
       }

--- a/packages/store/tests/security/audit-append-only.conformance.test.ts
+++ b/packages/store/tests/security/audit-append-only.conformance.test.ts
@@ -1,5 +1,5 @@
 import { storeFiles } from "../../src/files-store.js";
-import { VendoError, type Principal } from "@vendoai/core";
+import type { Principal } from "@vendoai/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { backends, type MadeBackend } from "../../src/backends.test-util.js";
 import { eraseStore } from "../../src/erase.js";
@@ -30,7 +30,7 @@ for (const backend of backends()) {
 
       const replacement = auditFixture("aud_append_put", { detail: { count: 999 } });
       await expect(audit.put({ id: replacement.id, data: replacement }))
-        .rejects.toMatchObject<VendoError>({ code: "conflict" });
+        .rejects.toMatchObject({ code: "conflict" });
       // History is intact: the original event survives untouched.
       expect((await audit.get(original.id))?.data).toEqual(original);
     });
@@ -41,7 +41,7 @@ for (const backend of backends()) {
       await audit.put({ id: event.id, data: event });
 
       await expect(audit.delete(event.id))
-        .rejects.toMatchObject<VendoError>({ code: "blocked" });
+        .rejects.toMatchObject({ code: "blocked" });
       expect((await audit.get(event.id))?.data).toEqual(event);
     });
 
@@ -52,9 +52,9 @@ for (const backend of backends()) {
 
       const replacement = auditFixture("aud_append_overlay", { principal: anon, detail: { count: 999 } });
       await expect(audit.put({ id: replacement.id, data: replacement }))
-        .rejects.toMatchObject<VendoError>({ code: "conflict" });
+        .rejects.toMatchObject({ code: "conflict" });
       await expect(audit.delete(event.id))
-        .rejects.toMatchObject<VendoError>({ code: "blocked" });
+        .rejects.toMatchObject({ code: "blocked" });
       expect((await audit.get(event.id))?.data).toEqual(event);
     });
 
@@ -63,12 +63,12 @@ for (const backend of backends()) {
       const durable = auditFixture("aud_append_helper");
       await helper.append(durable);
       await expect(helper.append(auditFixture("aud_append_helper", { detail: { count: 999 } })))
-        .rejects.toMatchObject<VendoError>({ code: "conflict" });
+        .rejects.toMatchObject({ code: "conflict" });
 
       const overlayEvent = auditFixture("aud_append_helper_anon", { principal: anon });
       await helper.append(overlayEvent);
       await expect(helper.append(auditFixture("aud_append_helper_anon", { principal: anon, detail: { count: 999 } })))
-        .rejects.toMatchObject<VendoError>({ code: "conflict" });
+        .rejects.toMatchObject({ code: "conflict" });
       expect((await made.store.records("vendo_audit").get(overlayEvent.id))?.data).toEqual(overlayEvent);
     });
 

--- a/packages/store/tests/security/secrets-aad.conformance.test.ts
+++ b/packages/store/tests/security/secrets-aad.conformance.test.ts
@@ -17,7 +17,7 @@ describe("02-store §4 — secret-name AAD binding (envelope level)", () => {
     const sealed = encryptSecret("value-for-a", key, "SECRET_A");
     expect(decryptSecret(sealed, key, "SECRET_A")).toBe("value-for-a");
     expect(() => decryptSecret(sealed, key, "SECRET_B"))
-      .toThrow(expect.objectContaining<VendoError>({ code: "validation" }));
+      .toThrow(expect.objectContaining<Partial<VendoError>>({ code: "validation" }));
   });
 });
 
@@ -52,7 +52,7 @@ for (const backend of backends()) {
       // as AAD the auth tag fails.
       await made.sql("UPDATE vendo_secrets SET ciphertext = $1 WHERE name = 'AAD_SWAP_B'", [cipherA]);
       await expect(storeSecrets(made.store).get("AAD_SWAP_B"))
-        .rejects.toMatchObject<VendoError>({ code: "validation" });
+        .rejects.toMatchObject({ code: "validation" });
       // The untouched row keeps decrypting.
       expect(await storeSecrets(made.store).get("AAD_SWAP_A")).toBe("value-a");
     });
@@ -70,7 +70,7 @@ for (const backend of backends()) {
         [`${version}:${iv}:${tag}:${bytes.toString("base64")}`],
       );
       await expect(storeSecrets(made.store).get("AAD_TAMPER"))
-        .rejects.toMatchObject<VendoError>({ code: "validation" });
+        .rejects.toMatchObject({ code: "validation" });
     });
   });
 }

--- a/packages/store/tests/security/secrets-crypto.test.ts
+++ b/packages/store/tests/security/secrets-crypto.test.ts
@@ -21,7 +21,7 @@ const envelopeParts = (value: string): { version: string; iv: string; tag: strin
 // Flip the first byte of a base64 segment, returning a same-length base64 segment.
 const tamperBase64 = (segment: string): string => {
   const bytes = Buffer.from(segment, "base64");
-  bytes[0] = bytes[0] ^ 0xff;
+  bytes[0] = bytes[0]! ^ 0xff;
   return bytes.toString("base64");
 };
 
@@ -117,7 +117,7 @@ describe("validateEncryptionKey", () => {
   it("rejects keys that decode to the wrong length", () => {
     for (const size of [16, 24, 31, 33, 64]) {
       expect(() => validateEncryptionKey(randomBytes(size).toString("base64")))
-        .toThrow(expect.objectContaining<VendoError>({ code: "validation" }));
+        .toThrow(expect.objectContaining<Partial<VendoError>>({ code: "validation" }));
     }
   });
 

--- a/packages/store/tests/state-routing.test.ts
+++ b/packages/store/tests/state-routing.test.ts
@@ -1,4 +1,4 @@
-import { VendoError, type Principal } from "@vendoai/core";
+import type { Principal } from "@vendoai/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { backends, type MadeBackend } from "../src/backends.test-util.js";
 import { appFixture, persistentPrincipal } from "../src/fixtures.test-util.js";
@@ -202,9 +202,9 @@ for (const backend of backends()) {
       // (app_x, y:z)). The write door refuses any non-app_ leading segment, so no
       // doctored id can ever target a row it does not own.
       await expect(made.store.records("vendo_state").put({ id: "notanapp:user", data: {} }))
-        .rejects.toMatchObject<VendoError>({ code: "validation" });
+        .rejects.toMatchObject({ code: "validation" });
       await expect(made.store.records("vendo_state").delete("notanapp:user"))
-        .rejects.toMatchObject<VendoError>({ code: "validation" });
+        .rejects.toMatchObject({ code: "validation" });
       // Nothing was written under the doctored id.
       expect(Number((await made.sql(
         "SELECT COUNT(*)::int AS count FROM vendo_state WHERE subject = 'user'",
@@ -217,9 +217,9 @@ for (const backend of backends()) {
       // the apps runtime never mints). Both are refused at the door.
       const state = made.store.records("vendo_state");
       await expect(state.put({ id: "app_demo:", data: { orphan: true } }))
-        .rejects.toMatchObject<VendoError>({ code: "validation" });
+        .rejects.toMatchObject({ code: "validation" });
       await expect(state.put({ id: "app_:x", data: { degenerate: true } }))
-        .rejects.toMatchObject<VendoError>({ code: "validation" });
+        .rejects.toMatchObject({ code: "validation" });
       // Nothing landed for either doctored id.
       expect(Number((await made.sql(
         "SELECT COUNT(*)::int AS count FROM vendo_state WHERE app_id IN ('app_demo', 'app_')",

--- a/packages/store/tests/thread-message-cas.test.ts
+++ b/packages/store/tests/thread-message-cas.test.ts
@@ -1,8 +1,9 @@
 import { VendoError, type Principal } from "@vendoai/core";
-import type { UIMessage } from "ai";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { backends, type MadeBackend } from "../src/backends.test-util.js";
-import { threadMessageStore, threadStore } from "../src/index.js";
+// The store deliberately does not depend on `ai` (src/helpers/thread-messages.ts),
+// so its own generic stand-in plays the runtime's `UIMessage` here.
+import { threadMessageStore, threadStore, type ThreadMessageLike as UIMessage } from "../src/index.js";
 
 /** Findings 9 and 10 — the helper's ordering disagreed with the door's, and its
  *  comment promised a per-row CAS that did not exist. */

--- a/packages/store/tests/thread-messages.ops.test.ts
+++ b/packages/store/tests/thread-messages.ops.test.ts
@@ -19,10 +19,17 @@
  */
 import { VendoError, type Principal, type StoreOps } from "@vendoai/core";
 import { memoryStoreOps } from "@vendoai/core/conformance";
-import type { UIMessage } from "ai";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { backends, type MadeBackend } from "../src/backends.test-util.js";
-import { createStoreOps, threadMessageStore, threadStore, type VendoStore } from "../src/index.js";
+// The store deliberately does not depend on `ai` (src/helpers/thread-messages.ts),
+// so its own generic stand-in plays the runtime's `UIMessage` here.
+import {
+  createStoreOps,
+  threadMessageStore,
+  threadStore,
+  type ThreadMessageLike as UIMessage,
+  type VendoStore,
+} from "../src/index.js";
 
 const alice: Principal = { kind: "user", subject: "user_alice" };
 const bob: Principal = { kind: "user", subject: "user_bob" };

--- a/packages/store/tests/thread-messages.test.ts
+++ b/packages/store/tests/thread-messages.test.ts
@@ -1,10 +1,18 @@
 import { VendoError, type Json, type Principal } from "@vendoai/core";
-import type { UIMessage } from "ai";
 import { Client } from "pg";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { backends, type MadeBackend } from "../src/backends.test-util.js";
 import { harnessStateKey } from "../src/harness-state.js";
-import { createStore, eraseStore, storeFiles, threadMessageStore, threadStore } from "../src/index.js";
+// The store deliberately does not depend on `ai` (src/helpers/thread-messages.ts),
+// so its own generic stand-in plays the runtime's `UIMessage` here.
+import {
+  createStore,
+  eraseStore,
+  storeFiles,
+  threadMessageStore,
+  threadStore,
+  type ThreadMessageLike as UIMessage,
+} from "../src/index.js";
 import type { VendoStore } from "../src/store.js";
 
 const alice: Principal = { kind: "user", subject: "user_alice" };

--- a/packages/store/tests/thread-scoping.test.ts
+++ b/packages/store/tests/thread-scoping.test.ts
@@ -6,7 +6,7 @@
  * and ephemeral subjects alike (kill-list B3). Same-subject re-puts still
  * update in place.
  */
-import { VendoError, type Principal } from "@vendoai/core";
+import type { Principal } from "@vendoai/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { backends, type MadeBackend } from "../src/backends.test-util.js";
 import { threadStore } from "../src/index.js";
@@ -30,7 +30,7 @@ for (const backend of backends()) {
       // u2 trying to write the same id is a conflict — the guarded upsert's WHERE
       // fails, RETURNING is empty, and nothing is written.
       await expect(threads.put(u2, { id: "thr_sql", messages: [{ role: "user", text: "steal" }] }))
-        .rejects.toMatchObject<VendoError>({ code: "conflict" });
+        .rejects.toMatchObject({ code: "conflict" });
 
       // u1's row is byte-for-byte intact.
       expect(await made.sql("SELECT t.id, t.subject, (SELECT jsonb_agg(m.message ORDER BY m.seq) FROM vendo_thread_messages m WHERE m.thread_id = t.id) AS messages FROM vendo_threads t WHERE t.id = 'thr_sql'"))
@@ -46,7 +46,7 @@ for (const backend of backends()) {
       const seam = made.store.records("vendo_threads");
       await seam.put({ id: "thr_seam", data: { subject: u1.subject, messages: [{ role: "user", text: "mine" }] } });
       await expect(seam.put({ id: "thr_seam", data: { subject: u2.subject, messages: [] } }))
-        .rejects.toMatchObject<VendoError>({ code: "conflict" });
+        .rejects.toMatchObject({ code: "conflict" });
       expect(await made.sql("SELECT subject FROM vendo_threads WHERE id = 'thr_seam'"))
         .toEqual([{ subject: "user_one" }]);
     });
@@ -57,7 +57,7 @@ for (const backend of backends()) {
       const threads = threadStore(made.store);
       await threads.put(e1, { id: "thr_anon_flip", messages: [{ role: "user", text: "mine" }] });
       await expect(threads.put(e2, { id: "thr_anon_flip", messages: [] }))
-        .rejects.toMatchObject<VendoError>({ code: "conflict" });
+        .rejects.toMatchObject({ code: "conflict" });
       // The ephemeral thread is an ordinary disk row, and e1 still owns it.
       expect(await made.sql(
         "SELECT subject FROM vendo_threads WHERE id = 'thr_anon_flip'",
@@ -113,7 +113,7 @@ for (const backend of backends()) {
       await expect(seam.atomic!.compareAndSwap(
         { id: "thr_cas", data: threadData(u1.subject, "junk token") },
         "not-a-revision",
-      )).rejects.toMatchObject<VendoError>({ code: "validation" });
+      )).rejects.toMatchObject({ code: "validation" });
       // Plain put still bumps the counter, so a pre-put token can no longer swap.
       const bumped = await seam.put({ id: "thr_cas", data: threadData(u1.subject, "via put") });
       expect(BigInt(bumped.revision!)).toBeGreaterThan(BigInt(revision));

--- a/packages/store/tests/workspace.test.ts
+++ b/packages/store/tests/workspace.test.ts
@@ -266,7 +266,7 @@ for (const backend of backends()) {
 
         // Rejected up front, naming the file that cannot be stored...
         await expect(fs.commit({ message: "tried both" }))
-          .rejects.toMatchObject<Partial<VendoError>>({ code: "validation" });
+          .rejects.toMatchObject({ code: "validation" });
         await expect(fs.commit()).rejects.toThrow(new RegExp(upload));
         // ...and no row landed for EITHER path, in either order.
         expect(await rowsFor(app)).toEqual([]);
@@ -337,7 +337,7 @@ for (const backend of backends()) {
       };
       const fs = await workspaceStore(made.store, { files: refusing }).open(user);
       await fs.writeFile("/user/files/big.bin", new Uint8Array(WORKSPACE_INLINE_MAX_BYTES + 1));
-      await expect(fs.commit()).rejects.toMatchObject<Partial<VendoError>>({ code: "blocked" });
+      await expect(fs.commit()).rejects.toMatchObject({ code: "blocked" });
 
       const unavailable = {
         async put() { throw new VendoError("not-found", "no such bucket"); },
@@ -346,7 +346,7 @@ for (const backend of backends()) {
       };
       const other = await workspaceStore(made.store, { files: unavailable }).open(user);
       await other.writeFile("/user/files/big.bin", new Uint8Array(WORKSPACE_INLINE_MAX_BYTES + 1));
-      await expect(other.commit()).rejects.toMatchObject<Partial<VendoError>>({ code: "not-found" });
+      await expect(other.commit()).rejects.toMatchObject({ code: "not-found" });
     });
 
     // F6 (verifier): an explicitly mkdir'ed directory was reported as a file, so
@@ -356,7 +356,7 @@ for (const backend of backends()) {
       await fs.mkdir("/user/files/reports", { recursive: true });
       await fs.writeFile("/user/files/summary.txt", "a file");
 
-      const entries = await fs.readdirWithFileTypes("/user/files");
+      const entries = await fs.readdirWithFileTypes!("/user/files");
       expect(entries.find((entry) => entry.name === "reports"))
         .toMatchObject({ isDirectory: true, isFile: false });
       expect(entries.find((entry) => entry.name === "summary.txt"))
@@ -379,7 +379,7 @@ for (const backend of backends()) {
 
       const names = (await fs.readdir("/user/files")).filter((name) => name === "report");
       expect(names).toEqual(["report"]);
-      const entries = (await fs.readdirWithFileTypes("/user/files"))
+      const entries = (await fs.readdirWithFileTypes!("/user/files"))
         .filter((entry) => entry.name === "report");
       expect(entries).toEqual([
         { name: "report", isFile: true, isDirectory: false, isSymbolicLink: false },
@@ -398,7 +398,7 @@ for (const backend of backends()) {
       });
 
       expect(await fs.readdir("/host/skills")).toEqual(["charting"]);
-      expect((await fs.readdirWithFileTypes("/host/skills")).map((entry) => entry.name))
+      expect((await fs.readdirWithFileTypes!("/host/skills")).map((entry) => entry.name))
         .toEqual(["charting"]);
     });
 
@@ -513,7 +513,7 @@ for (const backend of backends()) {
     it("names the fix when a file passes the store-backed cap with no files adapter wired", async () => {
       const fs = await workspaceStore(made.store).open(user);
       await fs.writeFile("/user/files/huge.bin", new Uint8Array(FILES_STORE_MAX_BYTES + 1));
-      await expect(fs.commit()).rejects.toMatchObject<Partial<VendoError>>({ code: "validation" });
+      await expect(fs.commit()).rejects.toMatchObject({ code: "validation" });
       await expect(fs.commit()).rejects.toThrow(/Wire `files:`/);
     });
   });

--- a/packages/store/tsconfig.test.json
+++ b/packages/store/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "noEmit": true
+  },
+  "include": ["src", "tests"]
+}


### PR DESCRIPTION
Follow-up to #1081, as flagged in its PR body: six packages (core, mcp, store, actions, agents, harnesses) carried explicit tsconfig excludes for test files, so **their tests were never typechecked by anything** — and 174 latent type errors had accumulated in test bodies. This PR turns typechecking on and pays down that debt.

## What changed

- Each of the six packages gains a `tsconfig.test.json` (the `knowledge` shape: extends `tsconfig.base.json`, NodeNext, `noEmit`, include `["src", "tests"]`) and its `typecheck` script gains `&& tsc -p tsconfig.test.json --noEmit`. Build configs, test scripts, and vitest configs are untouched.
- All **174 pre-existing type errors** fixed with minimal type-only edits (store 67, harnesses 63, core 15, mcp 12, agents 9, actions 8). No assertion semantics changed, no tests added/removed, no `src/` changes — the single src-path edit is `packages/harnesses/src/test-doubles.test-util.ts`, a test-only util excluded from the build and absent from dist.

## Proof of zero behavior change

Every package's suite reruns with counts **identical to #1081's parity baselines** (same env discipline: no POSTGRES_URL, no keys, capped workers):

| Package | Test files | Tests |
|---|---|---|
| store | 51 passed \| 1 skipped (52) | 499 passed \| 4 skipped (503) |
| harnesses | 46 passed \| 4 skipped (50) | 568 passed \| 14 skipped (582) |
| core | 58 passed (58) | 1073 passed (1073) |
| mcp | 3 passed (3) | 143 passed (143) |
| actions | 51 passed \| 1 skipped (52) | 618 passed \| 4 skipped (622) |
| agents | 9 passed (9) | 79 passed (79) |

Each package also has a trap proof (injected type error in a moved test → `pnpm typecheck` fails on that exact line → removed → green), and the blocking eslint config passes per package (removing invalid generics orphans imports; those were swept).

## Fix classes worth knowing

- **store, 56×**: `rejects.toMatchObject<VendoError>(…)` — vitest 2.1's `Promisify` erases method type params, so the explicit generic is illegal. Removed the type argument only (at 53 of 56 sites it was never enforceable anyway — the argument didn't satisfy `VendoError`).
- **store, 3×**: `import type { UIMessage } from "ai"` — store deliberately has no `ai` dependency (documented in `src/helpers/thread-messages.ts`, enforced by dependency-guard). Aliased store's own exported `ThreadMessageLike` instead; no devDependency added.
- **harnesses, 17 errors from one root cause**: `textTurn`'s usage param was typed `typeof ZERO_USAGE`, pinning every field to literal `0`. Re-typed off the stream part's own usage type.
- **mcp**: jose v6 dropped `KeyLike` → `CryptoKey`; `Response.redirect(login)` needs the explicit `302` under `lib: ["ES2022"]` (the WHATWG default, and the test already asserts 302).
- Missing required fields in typed fixtures (`sessionId` on `RunContext`/`LiveTurn.ctx`) added to match how sibling tests construct them; `possibly undefined` hits resolved with the surrounding file's idiom (non-null assertions matching e.g. `src/ops.ts`).

## Flagged for review (kept verbatim, documented rather than "fixed")

- **`allowJs: true`** in harnesses' and agents' `tsconfig.test.json`: their tests import `@vendoai/apps/box-door`, whose export map entry has no `types` field. This is the same landed idiom `packages/vendo` and `packages/apps` already use for that exact import. The real fix — adding `types` to the `./box-door` export in `packages/apps/package.json` — would retire three workarounds at once; proposed as its own tiny follow-up.
- **`actions/tests/connectors/mcp-headers.test.ts`**: the fixture's `source: "approval"` is not a member of the `PermissionGrant["source"]` union (and `grants.ts` notes `source` is never consulted by guard). Preserved verbatim behind a cast; correcting the fixture to a real enum member is a visible fixture change that deserves its own line.
- **`harnesses/tests/live-turn.test.ts:146`**: passes the imported `ctx` factory *function* where a `RunContext` belongs (the sibling helper uses `RUN_CTX` correctly); the case passes only because the transcript ignores the principal. Kept byte-identical via `as never` + comment; recommend a one-line follow-up to `ctx: RUN_CTX`.
- **`harnesses/tests/vendo/vendo.test.ts`**: six tests pass a `descriptors` option that no type declares and no code reads (grep: zero hits). Kept; deleting the dead arguments is a logic change.

Local gate: `pnpm build` + `pnpm typecheck` + `pnpm lint` green. Full suite is CI's job — the green `ci` check is the gate of record.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turned on TypeScript typechecking for tests in `@vendoai/core`, `@vendoai/mcp`, `@vendoai/store`, `@vendoai/actions`, `@vendoai/agents`, and `@vendoai/harnesses`, fixing 174 latent type errors. No behavior changes; all suites pass with unchanged counts.

- **Refactors**
  - Added `tsconfig.test.json` to each package and updated `typecheck` scripts to run it.
  - Fixed 174 test-only type errors with minimal type edits; no runtime changes (one test-only util in `@vendoai/harnesses` is excluded from builds).
  - Notable adjustments: removed illegal generics on `rejects.toMatchObject`, replaced `ai`’s `UIMessage` with local `ThreadMessageLike` in `@vendoai/store`, adopted `CryptoKey` and explicit `302` for `Response.redirect` in `@vendoai/mcp`, and added missing `sessionId` in typed test contexts.
  - Notes: set `allowJs: true` in `@vendoai/harnesses` and `@vendoai/agents` test tsconfigs due to `@vendoai/apps/box-door` missing `types`; a few fixtures keep narrow casts to preserve current behavior and can be cleaned up in follow-ups.

<sup>Written for commit 015f3c754c04210834d642302117661ed7f6aac1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

