### PR TITLE
ci: gate on explicit success so abandoned lanes cannot pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,7 +274,16 @@ jobs:
           RESULTS: ${{ toJSON(needs.*.result) }}
         run: |
           echo "$RESULTS"
-          [[ "$RESULTS" != *failure* && "$RESULTS" != *cancelled* ]]
+          # Whitelist: every needed lane must report exactly `success`. GitHub
+          # reports infrastructural kills (outage, concurrency cancellation)
+          # as `abandoned` or `skipped`, which the old blacklist let through —
+          # a green required check while lanes never ran a line of code (#924).
+          bad="$(printf '%s' "$RESULTS" | grep -oE '"[a-z_]+"|null' | grep -v '"success"' || true)"
+          if [ -n "$bad" ]; then
+            echo "gate failed: lanes did not all report success: $bad"
+            exit 1
+          fi
+          echo "all lanes succeeded"
 
   integration:
     runs-on: ubuntu-latest


### PR DESCRIPTION
closes #924

the aggregate `ci` gate blacklisted `failure` and `cancelled`, but github reports infrastructural kills (outage, concurrency cancellation) as `abandoned` — which fell through as success, so the required check went green while lanes never ran a line of code. observed 2026-08-06: two lanes died before checkout during a github actions outage and the gate reported green anyway.

changes:
- whitelist instead of blacklist: every needed lane must report exactly `success`; anything else (`abandoned`, `skipped`, `failure`, `cancelled`, ...) fails the gate
- shell-only grep pipeline, no new dependencies on the runner

verification (local simulation of the run script):
- `["success","success","success","success"]` -> pass
- with `abandoned` / `skipped` / `failure` in the array -> gate fails and names the lane result

note on skips: coverage-merge is the only needed job with a skip path, and it only skips when test-shards is `cancelled` — which must fail the gate anyway, so the strict whitelist cannot false-positive on a legitimately skipped lane.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require explicit success from all CI lanes so abandoned or skipped jobs can’t mark the gate green. Fixes #924 by ensuring required checks only pass when every needed job ran and succeeded.

- **Bug Fixes**
  - Switch from blacklist to whitelist: only "success" passes; any other result fails (`abandoned`, `skipped`, `failure`, `cancelled`, ...).
  - Shell-only grep pipeline; no new runner dependencies.
  - Clear output: lists non-success lanes and exits 1; otherwise prints confirmation.

<sup>Written for commit 5a03836a6b90450ca1b2021525d6b6063d019f94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

