### PR TITLE
fix(demo-bank): a date-only `to` bound cut the whole day, so "last night" views rendered empty

### DIFF
--- a/examples/demo-bank/src/server/transactions.ts
+++ b/examples/demo-bank/src/server/transactions.ts
@@ -8,6 +8,17 @@ export interface TxQuery {
 }
 export interface Page<T> { data: T[]; nextCursor?: string; total: number }
 
+/** `to` is documented as an inclusive "ISO date upper bound", but a bare
+ *  `YYYY-MM-DD` parses to 00:00 UTC — the START of that day — so an
+ *  inclusive-looking `to=2026-08-09` dropped every transaction ON Aug 9, and
+ *  `from=2026-08-09&to=2026-08-09` returned nothing at all. The agent reads
+ *  that empty 200 as "no spending", so a generated "last night" view renders
+ *  an empty table under prose that correctly names the charges. Widen a
+ *  date-only bound to the end of its day; a full timestamp is honoured as
+ *  given, so callers that want an exact instant still get one. */
+const upperBound = (to: string): number =>
+  /^\d{4}-\d{2}-\d{2}$/.test(to) ? +new Date(`${to}T23:59:59.999Z`) : +new Date(to)
+
 export function listTransactions(q: TxQuery = {}): Page<Transaction> {
   let rows = getStore().transactions.slice()
   if (q.search) {
@@ -19,7 +30,7 @@ export function listTransactions(q: TxQuery = {}): Page<Transaction> {
   if (q.cardId) rows = rows.filter(t => t.cardId === q.cardId)
   if (q.status) rows = rows.filter(t => t.status === q.status)
   if (q.from) rows = rows.filter(t => +new Date(t.timestamp) >= +new Date(q.from!))
-  if (q.to) rows = rows.filter(t => +new Date(t.timestamp) <= +new Date(q.to!))
+  if (q.to) rows = rows.filter(t => +new Date(t.timestamp) <= upperBound(q.to!))
   if (q.min != null) rows = rows.filter(t => Math.abs(t.amount) >= q.min!)
   if (q.max != null) rows = rows.filter(t => Math.abs(t.amount) <= q.max!)
 

--- a/examples/demo-bank/tests/server/__tests__/transactions.test.ts
+++ b/examples/demo-bank/tests/server/__tests__/transactions.test.ts
@@ -19,6 +19,20 @@ describe("listTransactions", () => {
     expect(listTransactions({ accountId: "acc_savings" }).data.every(t => t.accountId === "acc_savings")).toBe(true)
     expect(listTransactions({ min: 100000 }).data.every(t => Math.abs(t.amount) >= 100000)).toBe(true)
   })
+  it("treats a date-only `to` as through end of day, so a same-day window is not empty", () => {
+    // The planted charge lands at 01:14 local on the seeded day (08:14Z).
+    // `to` is documented as an inclusive date bound, so asking for that one
+    // day has to return it — a bare date parses to 00:00 UTC, which used to
+    // cut the whole day and hand the agent an empty 200 to narrate.
+    const sameDay = listTransactions({ from: "2026-06-29", to: "2026-06-29" })
+    expect(sameDay.total).toBeGreaterThan(0)
+    expect(sameDay.data.some(t => t.id === "txn_doordash_87")).toBe(true)
+    expect(listTransactions({ to: "2026-06-29" }).data.some(t => t.id === "txn_doordash_87")).toBe(true)
+  })
+  it("honours a full timestamp `to` exactly, without widening it", () => {
+    const untilMidnight = listTransactions({ from: "2026-06-29", to: "2026-06-29T00:00:00.000Z" })
+    expect(untilMidnight.data.some(t => t.id === "txn_doordash_87")).toBe(false)
+  })
 })
 
 describe("getTransaction", () => {


### PR DESCRIPTION
Found by the nightly demo-QA rig (`eng-nightly-demo-qa`, 2026-08-09).

## The bug

`GET /api/transactions` documents `to` as an inclusive *"ISO date upper bound"*. But the filter compares against a bare parse:

```ts
if (q.to) rows = rows.filter(t => +new Date(t.timestamp) <= +new Date(q.to!))
```

`new Date("2026-08-09")` is `2026-08-09T00:00:00Z` — the **start** of that day. So an inclusive-looking `to=2026-08-09` excludes everything that happened *on* Aug 9, and the most natural single-day window returns nothing at all.

Measured against the running demo, before the fix:

| query | total |
| --- | --- |
| `from=2026-08-09&to=2026-08-09` | **0** |
| `from=2026-08-08&to=2026-08-09` | 4 — silently **missing** the 1:14 AM DoorDash |
| `from=2026-08-08&to=2026-08-10` | 6 |

## Why it matters beyond an off-by-one

The empty result is a `200` with `total: 0`, not an error. The agent reads that as "no spending" and the generated view honestly renders **"No transactions found for that window"** / **"Total $0.00"** — while the prose, built from a separate and wider tool read, correctly names the real charges.

The flagship *"Where did my money go last night?"* demo produced exactly that contradiction on **3 of 6** turns tonight. One turn rendered `Total spent last night $0.00 / Transactions 0` under prose reading *"Five charges hit between the evening and early morning — the big one is a $418 United Airlines authorization."* Every one of those charges is real and visible on `/transactions`.

The planted 1:14 AM DoorDash charge is precisely the row a day-bounded "last night" query drops, so the demo's signature moment is the most exposed to this.

## The fix

Widen a **date-only** bound to the end of its day. A full timestamp is honoured exactly as given, so any caller wanting a precise instant is unaffected — both behaviours are pinned by tests.

## Verification

Local gate on the touched scope, Node 24:

- `pnpm build` — **21/21, exit 0**
- `examples/demo-bank` vitest — **25 files, 119 tests, all passing**
- `tsc --noEmit` — **exit 0**
- The new test **fails on `main`'s code** (`expected 0 to be greater than 0`) and passes with the fix — confirmed by reverting the one line and re-running.

Real browser, production build (`next build && next start`), 6 fresh turns of *"Where did my money go last night? Show me a spending view."*:

| | before | after |
| --- | --- | --- |
| view painted with data | 3/6 | **6/6** |
| empty view under confident prose | **3/6** | **0/6** |

After the fix every trial binds the real charges — `$87.00`, `$52.18`, `$25.59`, `$28.59`, `$418.00` — and the API returns `total=2` for the same-day window that used to return `0`.

Screenshots are on the mini at `/Users/vendo/dev/vendo-qa/shots/2026-08-09/`:
- `07-generated-app.png` — **before**: the empty "Last night's spending" table, `Total $0.00`, under prose naming five charges.
- `pr/after-fixed.png` — **after**: a bound donut (`$7,655.96`) plus category table, prose correctly citing the `$87.00` DoorDash at 1:14 AM.

## Note

This is long-standing, not a regression from this week — the two filter lines date back to the original transaction repositories (`af98a593c`). It surfaces intermittently because whether a given generation emits `to=2026-08-09` (empty) or `to=2026-08-10` (correct) is luck, which is why some nights score 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `GET /api/transactions` date filter so a date-only `to` value is treated as inclusive through the end of that day. This restores expected results for same-day and “last night” views.

- **Bug Fixes**
  - Treat `to=YYYY-MM-DD` as `23:59:59.999Z`; full timestamps remain exact.
  - Updated `listTransactions` to apply the widened upper bound only for date-only inputs.
  - Added tests to ensure a same-day window returns real charges and timestamp-bounded queries behave as before.

<sup>Written for commit 1f196b79fb2241adc55e6303944accd8e585424d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

