### PR TITLE
fix(release): skip private packages in the publish loop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,4 +104,8 @@ jobs:
             fi
             echo "publish $name@$version"
             npm publish "$tarball" --access public --provenance
-          done < <(pnpm -r --filter './packages/*' exec node -e "process.stdout.write(require('./package.json').name+'\n')")
+          # Private packages are enumerated out here, not skipped in the loop:
+          # `npm publish` throws EPRIVATE before it ever reaches the registry
+          # (libnpmpublish/lib/publish.js), and under `set -e` that aborts the
+          # release partway through, after earlier packages are already live.
+          done < <(pnpm -r --filter './packages/*' exec node -e "const p=require('./package.json'); if (!p.private) process.stdout.write(p.name+'\n')")


### PR DESCRIPTION
## What breaks without this

`release.yml`'s publish loop enumerates **every** workspace under `packages/*` — 15 names, including `@vendoai/box-template`, which is `private: true` (`packages/box-template/package.json:4`, the only private package in the repo).

`npm publish` throws `EPRIVATE` unconditionally on a private manifest — it is the very first statement in the function, before any registry or auth logic:

```js
// libnpmpublish/lib/publish.js:14-21
const publish = async (manifest, tarballData, opts) => {
  if (manifest.private) {
    throw Object.assign(
      new Error(`This package has been marked as private ...`),
      { code: 'EPRIVATE' }
    )
  }
```

The step runs under `set -euo pipefail` (`.github/workflows/release.yml:84`), so that throw **aborts the whole release partway through** — after ~11 packages have already been published, which is irreversible.

The existing "already on the registry" guard (`:101`) does not save it. `@vendoai/box-template` has never been published (`npm view` → `E404`), so the guard's lookup fails, the `continue` is not taken, and the loop falls straight through to `npm publish`.

`box-template` lands at position 11–12 of 15 in the topological order, so the blast radius is roughly ten already-live packages before the abort.

## Why the dry run never caught it

The two paths use **different commands**.

Dry run (`:75`) — `pnpm publish`, which skips private packages silently:

```
pnpm -r --filter './packages/*' publish --dry-run --no-git-checks --access public
```

Real publish (`:88`, `:107`) — `pnpm pack` + `npm publish`, which does **not**:

```
pnpm -r --filter './packages/*' exec pnpm pack --out /tmp/vendo-tarballs/%s-%v.tgz
...
done < <(pnpm -r --filter './packages/*' exec node -e "process.stdout.write(require('./package.json').name+'\n')")
```

So a green `workflow_dispatch` dry run proves nothing about the private-package case. The dry run exercises the one tool that tolerates it.

## The fix

Filter at the enumeration step, on the package's **own `private` field** — not a hardcoded `box-template` exclusion, which would silently rot the day someone adds a second private package.

`!p.private` is the same truthiness test npm itself applies in `manifest.private`, so the loop's set can never disagree with what `npm publish` will accept.

Publish order, the `--provenance` flag, the OIDC permissions, and the packing step are all untouched. `box-template` still gets packed into `/tmp/vendo-tarballs`; that tarball is simply never looked up, which is inert.

## Evidence

Both lists produced by running the enumeration command against this tree.

| Before (15) | After (14) |
|---|---|
| `@vendoai/core` | `@vendoai/telemetry` |
| `@vendoai/telemetry` | `@vendoai/core` |
| `@vendoai/actions` | `@vendoai/actions` |
| `@vendoai/apps` | `@vendoai/apps` |
| `@vendoai/knowledge` | `@vendoai/knowledge` |
| `@vendoai/guard` | `@vendoai/guard` |
| `@vendoai/store` | `@vendoai/store` |
| `@vendoai/ui` | `@vendoai/mcp` |
| `@vendoai/mcp` | `@vendoai/ui` |
| `@vendoai/automations` | `@vendoai/automations` |
| `@vendoai/harnesses` | `@vendoai/harnesses` |
| **`@vendoai/box-template`** | — |
| `@vendoai/agents` | `@vendoai/agents` |
| `@vendoai/vendo` | `@vendoai/vendo` |
| `vendoai` | `vendoai` |

Exact set difference:

```
$ comm -23 <(sort before) <(sort after)
@vendoai/box-template
$ comm -13 <(sort before) <(sort after)
(empty)
before=15 after=14
```

One name removed, none added, and the `vendoai` umbrella is still last so a mid-run failure can never leave an installable umbrella pointing at unpublished deps. (Ties in the topological order break nondeterministically between runs — hence `core`/`telemetry` and `ui`/`mcp` swapping — but the dependency ordering that matters is preserved.)

---

## ⚠️ This PR does NOT unblock the release

**`@vendoai/harnesses` and `@vendoai/agents` have never been published.** Independently verified against the registry:

```
$ npm view @vendoai/harnesses versions
npm error code E404 — '@vendoai/harnesses@*' is not in this registry.

$ npm view @vendoai/agents versions
npm error code E404 — '@vendoai/agents@*' is not in this registry.

$ npm view @vendoai/agent versions
[ '0.4.0' ... '0.7.0' ]   # 13 versions

$ npm view @vendoai/engine versions
[ '0.1.0', '0.1.1' ]
```

They are renames of `@vendoai/agent` and `@vendoai/engine`, both of which exist. Both new names sit in the publish set **before** the umbrella, and a brand-new package name has no trusted publisher configured on npmjs — so OIDC publishing of those two will fail on its own terms, in the same mid-release way.

**This needs a human decision before any `v*` tag is pushed.** It is deliberately not addressed here: no token was added, and the workflow was not changed for it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip private packages in the release publish loop to prevent `EPRIVATE` aborts and partial releases. Only non-private workspaces are enumerated for `npm publish`; packing and publish order stay the same.

- **Bug Fixes**
  - Filter by each package’s `private` field during enumeration, excluding `@vendoai/box-template` and any future private packages.
  - Avoids mid-run failures under `set -e` when `npm publish` rejects private manifests.

- **Migration**
  - Before pushing a `v*` tag, set up trusted publishing (or publish an initial version manually) for `@vendoai/harnesses` and `@vendoai/agents`; these new names aren’t on npm yet and will still fail OIDC publishing.

<sup>Written for commit 3849c81a90ff9e0003fdd984126e77970b94e952. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

