### PR TITLE
refactor(harnesses): unify jsonEqual, drop dead adapter slot, fix stale comments

### DIFF
--- a/packages/harnesses/src/harness-sandbox.ts
+++ b/packages/harnesses/src/harness-sandbox.ts
@@ -62,13 +62,11 @@ export interface ToolDoorPort {
 }
 
 /** The composed adapters a harness may be handed. Mirrors `ComposedAdapters`
- *  (the boot gate's view) plus the blob door session artifacts need. */
+ *  (the boot gate's view), plus the MCP door a machine-backed harness needs. */
 export interface HarnessAdapters {
   /** `SandboxAdapter` from `@vendoai/apps`; typed loosely so the root entry of
    *  this package never pulls a provider SDK into scope. */
   sandbox?: unknown;
-  /** `FilesAdapter` — where a harness parks an artifact too big for `turn.state`. */
-  files?: unknown;
   /** The host's MCP door, for a harness whose thinker runs on a machine. */
   toolDoor?: ToolDoorPort;
 }

--- a/packages/harnesses/src/harness-state.ts
+++ b/packages/harnesses/src/harness-state.ts
@@ -5,6 +5,7 @@
  */
 import type { ThreadId, TurnState } from "@vendoai/core";
 import type { UIMessage } from "ai";
+import { jsonEqual } from "./json-equal.js";
 
 /**
  * Where an opaque `turn.state` lives between turns.
@@ -81,26 +82,6 @@ export function createTurnState(initial: string | undefined): TurnState & { pend
  */
 export type HistoryChange = "append" | "prefix-truncation" | "arbitrary-edit";
 
-/** Structural JSON equality, key-order independent (both sides are
- *  wire-serializable UIMessage parts, and the wire drops undefined props). */
-function jsonEqual(left: unknown, right: unknown): boolean {
-  if (left === right) return true;
-  if (Array.isArray(left) || Array.isArray(right)) {
-    return Array.isArray(left)
-      && Array.isArray(right)
-      && left.length === right.length
-      && left.every((item, index) => jsonEqual(item, right[index]));
-  }
-  if (typeof left !== "object" || typeof right !== "object" || left === null || right === null) {
-    return false;
-  }
-  const leftRecord = left as Record<string, unknown>;
-  const rightRecord = right as Record<string, unknown>;
-  const keys = Object.keys(leftRecord).filter((key) => leftRecord[key] !== undefined);
-  const rightKeys = Object.keys(rightRecord).filter((key) => rightRecord[key] !== undefined);
-  return keys.length === rightKeys.length && keys.every((key) => jsonEqual(leftRecord[key], rightRecord[key]));
-}
-
 export function classifyHistory(
   persisted: readonly UIMessage[],
   incoming: readonly UIMessage[],
@@ -109,7 +90,7 @@ export function classifyHistory(
   for (let index = 0; index < overlap; index += 1) {
     const before = persisted[index]!;
     const after = incoming[index]!;
-    if (before.id !== after.id || before.role !== after.role || !jsonEqual(before.parts, after.parts)) {
+    if (before.id !== after.id || before.role !== after.role || !jsonEqual(before.parts, after.parts, true)) {
       return "arbitrary-edit";
     }
   }

--- a/packages/harnesses/src/json-equal.ts
+++ b/packages/harnesses/src/json-equal.ts
@@ -1,0 +1,33 @@
+/**
+ * Structural JSON equality, key-order independent — the ONE copy two seams share
+ * (`transcript-rules.ts` and `harness-state.ts`). Both compare wire-serializable
+ * UIMessage parts; a second private copy of the same comparison is how the two
+ * drifted apart on undefined-key handling before this was unified.
+ *
+ * `ignoreUndefined` is the ONLY difference the two callers ever needed:
+ *  - transcript-rules leaves it off (its `isApprovalResponse` check must treat a
+ *    part carrying an explicit `undefined` prop as DISTINCT — the conservative,
+ *    reject-the-flip direction);
+ *  - harness-state turns it on, because a message that round-tripped the wire
+ *    (which drops `undefined`) must not read as an edit against a stored copy
+ *    that still carries one, or it would falsely clear the harness session.
+ */
+export function jsonEqual(left: unknown, right: unknown, ignoreUndefined = false): boolean {
+  if (left === right) return true;
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return Array.isArray(left) && Array.isArray(right)
+      && left.length === right.length
+      && left.every((item, index) => jsonEqual(item, right[index], ignoreUndefined));
+  }
+  if (typeof left !== "object" || typeof right !== "object" || left === null || right === null) {
+    return false;
+  }
+  const leftRecord = left as Record<string, unknown>;
+  const rightRecord = right as Record<string, unknown>;
+  const keep = (record: Record<string, unknown>) =>
+    Object.keys(record).filter((key) => !ignoreUndefined || record[key] !== undefined);
+  const leftKeys = keep(leftRecord);
+  const rightKeys = keep(rightRecord);
+  return leftKeys.length === rightKeys.length
+    && leftKeys.every((key) => jsonEqual(leftRecord[key], rightRecord[key], ignoreUndefined));
+}

--- a/packages/harnesses/src/runtime.ts
+++ b/packages/harnesses/src/runtime.ts
@@ -523,8 +523,8 @@ export function createHarnessRuntime(deps: HarnessRuntimeDeps): HarnessRuntime {
                   // said "something went wrong". Claiming the slot first is what
                   // keeps the two the same sentence.
                   recordTurnError(event.message, (part) => writer.write(part as never));
-                  // …and the SCREEN's — the same ai-SDK error chunk `createAgent`
-                  // raised, so the host renders its banner, its Retry and its
+                  // …and the SCREEN's — the same ai-SDK error chunk the legacy
+                  // agent path raised, so the host renders its banner, its Retry and its
                   // detail line. Splicing the sentence into the assistant's prose
                   // instead would read as the agent talking and would offer the
                   // user nothing to act on.
@@ -643,12 +643,6 @@ export function createHarnessRuntime(deps: HarnessRuntimeDeps): HarnessRuntime {
 }
 
 /**
- * Build contract §6 + the store write law: one row per NEW OR EDITED message,
- * ordered by `seq`, never by timestamp. Re-sending an untouched history costs
- * nothing, so a turn lands O(messages changed) rows — not O(thread), and never
- * O(tokens).
- */
-/**
  * States that mean "the call was announced and never resolved". A turn that ended
  * mid-call (an abort inside a tool, a harness that stopped awaiting) leaves one,
  * and `convertToModelMessages` turns it into an assistant tool-call with no
@@ -688,6 +682,12 @@ const PERSIST_RETRY_DELAYS_MS = [100, 500] as const;
 
 const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
+/**
+ * Build contract §6 + the store write law: one row per NEW OR EDITED message,
+ * ordered by `seq`, never by timestamp. Re-sending an untouched history costs
+ * nothing, so a turn lands O(messages changed) rows — not O(thread), and never
+ * O(tokens).
+ */
 async function persistTurn(
   transcript: TranscriptStore,
   input: TurnRunInput<unknown>,
@@ -809,7 +809,7 @@ async function reportRun(
 /**
  * Flip stale `approval-requested` parts and resolve their guard-side approvals —
  * the shipped `abandonPendingApprovals` semantics, applied by the runtime so a
- * harness turn leaves the same paired history a `createAgent` turn does.
+ * harness turn leaves the same paired history the legacy agent path produced.
  */
 async function abandonStaleApprovals(
   guard: Guard,

--- a/packages/harnesses/src/transcript-rules.ts
+++ b/packages/harnesses/src/transcript-rules.ts
@@ -3,13 +3,14 @@
  * what a client may change about stored history, and how a superseded approval
  * resolves.
  *
- * They live beside the runtime rather than inside a door because two doors read
- * them (the harness runtime and, until it is deleted, `createAgent`), and a
- * second copy of "may a client rewrite this message?" is a security answer that
- * could drift.
+ * They live beside the runtime rather than inside a door because more than one
+ * door reads them (the harness runtime here, and the umbrella's thread door in
+ * `@vendoai/vendo`), and a second copy of "may a client rewrite this message?"
+ * is a security answer that could drift.
  */
 import { VendoError, type ApprovalId } from "@vendoai/core";
 import { isToolUIPart, type UIMessage } from "ai";
+import { jsonEqual } from "./json-equal.js";
 
 // System-role messages are rejected: the system prompt is assembled server-side
 // (03 §3); accepting one from the client would be a prompt-injection channel.
@@ -27,25 +28,6 @@ export function upsertMessage(messages: UIMessage[], message: UIMessage): void {
   const index = messages.findIndex((candidate) => candidate.id === message.id);
   if (index === -1) messages.push(message);
   else messages[index] = message;
-}
-
-/** Structural JSON equality, key-order independent (both sides are
- *  wire-serializable UIMessage parts). */
-function jsonEqual(left: unknown, right: unknown): boolean {
-  if (left === right) return true;
-  if (Array.isArray(left) || Array.isArray(right)) {
-    return Array.isArray(left) && Array.isArray(right)
-      && left.length === right.length
-      && left.every((item, index) => jsonEqual(item, right[index]));
-  }
-  if (typeof left !== "object" || typeof right !== "object" || left === null || right === null) {
-    return false;
-  }
-  const leftRecord = left as Record<string, unknown>;
-  const rightRecord = right as Record<string, unknown>;
-  const keys = Object.keys(leftRecord);
-  return keys.length === Object.keys(rightRecord).length
-    && keys.every((key) => jsonEqual(leftRecord[key], rightRecord[key]));
 }
 
 /** AGENT-12: is `incoming` the one client-writable change to a stored part —

--- a/packages/harnesses/src/turn-tools.ts
+++ b/packages/harnesses/src/turn-tools.ts
@@ -29,7 +29,7 @@ export const APPROVAL_WAIT_MS = 90_000;
  * yielded"). This is the ai-SDK tool-part mirror ONLY — the `data-vendo-*` parts
  * (view, approval, connect, build-failed, citations) are written by the SHIPPED
  * bridge inside `guardedCall`/`previewApproval`, so a harness produces the
- * identical wire a `createAgent` turn does.
+ * identical wire the legacy agent path produced.
  */
 export type MirrorEvent = ({
   /** The turn that made this call, stamped once by {@link createTurnTools} from

--- a/packages/harnesses/src/wire.ts
+++ b/packages/harnesses/src/wire.ts
@@ -8,7 +8,7 @@
  * The `data-vendo-*` parts are NOT written here: the view channel, the approval
  * card, the connect card, the build-failed banner and the citations part all come
  * from the shipped bridge (`guardedCall`/`previewApproval` in ./tool-bridge.ts),
- * so a harness turn produces the identical wire a `createAgent` turn does.
+ * so a harness turn produces the identical wire the legacy agent path produced.
  *
  * ONE addition, and deliberately NOT in core's stream-parts.ts: `status` (§1.5)
  * has no existing part and must be screen-only. The ai-SDK's own
@@ -107,8 +107,8 @@ export function writeView(writer: Writer, part: VendoViewPart): void {
 /**
  * §1.5 `error` → the screen's failure affordance. The ai-SDK error chunk is what
  * the thread UI renders as a banner with Retry and (for a Vendo-shaped message) a
- * detail line — the same affordance `createAgent`'s `onError` produces, carrying
- * the same `wireErrorMessage` string, meter-exhausted sentence included.
+ * detail line — the same affordance the legacy agent path's `onError` produced,
+ * carrying the same `wireErrorMessage` string, meter-exhausted sentence included.
  */
 export function writeError(writer: Writer, message: string): void {
   writer.write({ type: "error", errorText: message });


### PR DESCRIPTION
Small, mechanical cleanup surfaced during a walkthrough of `@vendoai/harnesses`. No behavior change.

- **Dead code:** remove the `files` slot from `HarnessAdapters` — never written by any composer, never read by any harness.
- **De-duplication:** the two `jsonEqual` helpers (`transcript-rules.ts`, `harness-state.ts`) had drifted apart on undefined-key handling. Unified into `src/json-equal.ts` as one function with an `ignoreUndefined` flag; each call site keeps its exact prior behavior (transcript-rules strict, harness-state undefined-insensitive with `true`).
- **Comment hygiene:** move the orphaned `persistTurn` doc comment down to its function; correct stale references to the deleted `createAgent` path in surviving comments.

Gate (touched scope): build · typecheck · harnesses unit suite (564 passing) · lint (dependency-guard + portability-gate) all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the structural JSON equality helper and removes the unused `files` slot from `HarnessAdapters` in `@vendoai/harnesses`. Also cleans up stale comments; no behavior changes.

- **Refactors**
  - Removed dead `files` field from `HarnessAdapters`.
  - Consolidated two `jsonEqual` helpers into `src/json-equal.ts` with an `ignoreUndefined` flag; `transcript-rules` stays strict, `harness-state` ignores undefined to match wire round-trips.
  - Moved the `persistTurn` doc comment to its function and updated stale `createAgent` references to the legacy agent path (including in `@vendoai/vendo` references).

<sup>Written for commit 9c7cbe9ef53fe90cd1f86bbb597075b8930b0687. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

