### PR TITLE
Ux/dock and element picker

### DIFF
--- a/.changeset/docked-panel.md
+++ b/.changeset/docked-panel.md
@@ -1,0 +1,45 @@
+---
+"@vendoai/ui": minor
+---
+
+Dock the conversation panel beside the product — opt-in.
+
+`VendoOverlay` takes a `placement` prop. `"dock"` parks the panel against the
+right edge at full height and reflows the host page into the remaining width,
+so the surface being reshaped stays visible and clickable while the panel is
+open. `dockWidth` (default `420`) sets the panel width and, with it, how far
+the page reflows. Below the mobile breakpoint both still collapse to the
+full-bleed takeover.
+
+`placement` defaults to `"center"`, the centered modal that has always
+shipped, so this release changes nothing for an existing host: the scrim, the
+body scroll-lock, `inertBehind` and `aria-modal` are all still there unless a
+host asks for `placement="dock"`.
+
+Docked is deliberately NON-modal — no scrim, no body scroll-lock, no
+`inertBehind`, no focus trap, and no `aria-modal` — because a modal that
+covers the page is the wrong shape for a tool whose job is editing that page.
+The page reflows via a width reduction on `documentElement` (not `body`,
+whose width is usually author-controlled), torn down on close, unmount, and
+placement flips. Host chrome that is itself `position: fixed` is anchored to
+the viewport rather than to `documentElement`, so it does not reflow with
+this; such elements can read `--vendo-dock-w` to inset themselves.
+
+The reflow is owned centrally and refcounted: `data-vendo-dock` and
+`--vendo-dock-w` live on the one `documentElement` every overlay shares, so
+closing one of two open docked panels no longer hands the page back its full
+width while the other is still open.
+
+The workspace expander stays a centered-placement feature — a full-height rail
+has nowhere to grow a stage into — so it is hidden while docked. For the same
+reason a docked conversation does not auto-stage a built app: staging on the
+user's behalf there would strand an app they could neither see nor collapse.
+The embed still lands in the rail.
+
+**An indeterminate progress bar** sweeps along the top edge of the framed page
+while a turn runs, driven by the existing cross-tree run-activity store. No
+percentage: `RunActivity`'s `done`/`total` count steps already begun, not a
+forecast, and inventing a completion estimate would break the same "no fake
+percentage, no completion jump" rule the app-boot hairline already follows.
+
+Public API added: `placement` and `dockWidth` on `VendoOverlay`.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,36 @@ recommendations, `vendo sync --json` for a machine-readable sync report, and
 a `vendo-setup` skill shipped inside the npm tarball that init offers to
 write into `.claude/skills/`.
 
+## The docked panel
+
+The conversation surface can sit **beside** the product instead of on top of
+it. `<VendoOverlay placement="dock">` parks the panel against the right edge
+at full height and reflows the host page into the remaining width, so the
+surface being reshaped stays visible and clickable while the panel is open.
+Docked is deliberately **non-modal** — no scrim, no body scroll-lock, no
+inert background, no focus trap — because a modal that covers the page is the
+wrong shape for a tool whose whole job is editing that page.
+
+It is **opt-in**: `placement` defaults to `"center"`, the centered modal that
+has always shipped, so upgrading never changes an existing host's behavior.
+
+```tsx
+<VendoOverlay />                                    // the centered modal box (default)
+<VendoOverlay placement="dock" dockWidth={420} />   // the docked side panel
+```
+
+| Prop | Default | What it does |
+| --- | --- | --- |
+| `placement` | `"center"` | `"center"` for the centered modal, `"dock"` for the side panel |
+| `dockWidth` | `420` | Docked width in px — also how far the host page reflows |
+
+Below the mobile breakpoint both collapse to the existing full-bleed
+takeover, which still owns small screens. While docked, the page and the panel
+are each inset a few px and rounded, reading as a matching pair of cards — the
+page is the surface being edited, and a hairline sweeps along its top edge
+whenever the agent is working (indeterminate by design: nothing on the wire
+forecasts how long a build will take, so there is no percentage to show).
+
 <img src="assets/kicker-04-packages.svg" alt="04 · Packages">
 
 ## Packages

--- a/packages/ui/src/chrome/chrome-css.ts
+++ b/packages/ui/src/chrome/chrome-css.ts
@@ -1146,6 +1146,104 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the S1 des
    would otherwise sit under a takeover overlay panel (2147483001). */
 .fl-overlay-scrim.fl-takeover { z-index: 2147483002; }
 
+/* ---------- docked side panel (DevTools posture) ---------- */
+/* The NON-MODAL placement, and the default above the mobile breakpoint. The
+   panel parks against the right edge at full height and the host page REFLOWS
+   beside it — documentElement's width shrinks by --vendo-dock-w — so the
+   surface the user came here to reshape is never underneath the thing they are
+   reshaping it with. No scrim, no scroll-lock, no inert background, no focus
+   trap: the page stays live and clickable while the panel is open, which is
+   the entire point of the posture (the centered modal, placement="center",
+   keeps all four). Mutually exclusive with the takeover — below the
+   breakpoint there is no room to dock, so small screens still go full-bleed. */
+/* The framed-page look (2026-08): while docked, the host page itself shrinks
+   a few px on every edge, gains a hairline border and rounded corners, and
+   sits on a neutral canvas — reading as "this is the surface being edited",
+   the same signal DevTools' element-inspect overlay gives. overflow: auto
+   (not hidden) so the page's own scroll keeps working — any overflow value
+   other than visible still clips content to the border-radius. Colors use
+   the CSS system keywords Canvas/CanvasText rather than a --vendo-* token:
+   html sits OUTSIDE the .vendo-root theme boundary (that's only stamped on
+   the portaled panel), and the system pair adapts to light/dark on its own. */
+/* The reserved column is the panel's width plus a gap on EACH side of it, so
+   the page frame and the panel sit inset from the viewport by the same amount
+   and are separated by exactly one gap. Both are rounded on all four corners
+   and read as a matching pair of floating cards. */
+html[data-vendo-dock] {
+  /* html is content-box by default, so the 2px frame border would land OUTSIDE
+     the reserved width and push the page 4px past the viewport. */
+  box-sizing: border-box;
+  width: calc(100% - var(--vendo-dock-w, 420px) - (var(--vendo-dock-gap, 5px) * 3));
+  margin: var(--vendo-dock-gap, 5px)
+    calc(var(--vendo-dock-w, 420px) + (var(--vendo-dock-gap, 5px) * 2))
+    var(--vendo-dock-gap, 5px) var(--vendo-dock-gap, 5px);
+  overflow: auto;
+  border-radius: 10px;
+  border: 2px solid #111111;
+  box-shadow: 0 1px 3px color-mix(in srgb, CanvasText 10%, transparent);
+  background: color-mix(in srgb, CanvasText 6%, Canvas);
+  transition: width .34s cubic-bezier(.22, 1, .36, 1), margin .34s cubic-bezier(.22, 1, .36, 1); }
+/* Inset by the same gap on all four sides rather than flush to the viewport
+   edge, so the rounded corners have room to show instead of being cropped by
+   the screen. A FULL border (not just border-left) gives the radius an edge to
+   follow the whole way round. */
+.fl-overlay-panel.fl-dock { left: auto; transform: none;
+  right: var(--vendo-dock-gap, 5px); top: var(--vendo-dock-gap, 5px);
+  width: var(--vendo-dock-w, 420px);
+  height: calc(100dvh - (var(--vendo-dock-gap, 5px) * 2));
+  max-width: none; max-height: none;
+  border: 1px solid var(--vendo-border-strong); border-radius: 10px;
+  box-shadow: -16px 0 44px color-mix(in srgb, var(--vendo-fg) 12%, transparent);
+  animation: fl-dock-in .34s cubic-bezier(.22, 1, .36, 1) both; }
+/* Travels its own width PLUS the inset, so it starts fully off-screen instead
+   of peeking in by the gap. */
+@keyframes fl-dock-in {
+  from { transform: translateX(calc(100% + var(--vendo-dock-gap, 5px))); }
+  to { transform: translateX(0); } }
+/* Compact-when-empty and the split workspace are centered-BOX behaviors: a
+   full-height rail has no dead glass to trim and no room for a stage. */
+.fl-overlay-panel.fl-dock:has(.fl-landing) { height: calc(100dvh - (var(--vendo-dock-gap, 5px) * 2)); }
+.fl-overlay-panel.fl-dock[data-vendo-expanded] { width: var(--vendo-dock-w, 420px);
+  height: calc(100dvh - (var(--vendo-dock-gap, 5px) * 2)); }
+.fl-overlay-panel.fl-dock .fl-split-stage { display: none; }
+.fl-overlay-panel.fl-dock .fl-split-rail { flex-basis: 100%; }
+/* The launcher steps aside rather than hiding under the panel, so the pill
+   stays a live toggle while docked. */
+.fl-launcher[data-vendo-launcher="bottom-right"][data-vendo-docked] {
+  right: calc(18px + var(--vendo-dock-w, 420px) + (var(--vendo-dock-gap, 5px) * 2)); }
+@media (prefers-reduced-motion: reduce) {
+  html[data-vendo-dock] { transition: none; }
+  .fl-overlay-panel.fl-dock { animation: fl-dock-fade .16s ease both; }
+  @keyframes fl-dock-fade { from { opacity: 0; } to { opacity: 1; } }
+}
+
+/* ---------- the edit-in-progress bar ---------- */
+/* Rides the TOP EDGE of the framed page while a turn runs. Inset to match
+   html[data-vendo-dock] exactly: one gap on the left, the panel column plus
+   two gaps on the right, and pushed down by the frame's 2px border so it sits
+   just inside the black edge rather than straddling it. z-index 2147483050
+   sits in the unused …005–…099 lane — above the approval sheet, below toasts.
+   pointer-events: none because it is pure signal and must never eat a click
+   aimed at the page underneath. */
+.fl-editing-bar { position: fixed; z-index: 2147483050; pointer-events: none;
+  top: calc(var(--vendo-dock-gap, 5px) + 2px);
+  left: calc(var(--vendo-dock-gap, 5px) + 2px);
+  right: calc(var(--vendo-dock-w, 420px) + (var(--vendo-dock-gap, 5px) * 2) + 2px);
+  height: 2px; overflow: hidden; border-radius: 2px; }
+/* Indeterminate by design — see EditingBar in vendo-overlay.tsx. The static
+   base is a dim full-width fill so reduced-motion users still get an honest
+   "something is running" signal rather than nothing at all. */
+.fl-editing-bar-sweep { display: block; width: 100%; height: 100%; border-radius: 2px;
+  background: color-mix(in srgb, var(--vendo-accent) 45%, transparent); }
+@media (prefers-reduced-motion: no-preference) {
+  .fl-editing-bar-sweep { width: 32%;
+    background: linear-gradient(90deg, transparent,
+      var(--vendo-accent) 35%, var(--vendo-accent) 65%, transparent);
+    animation: fl-editing-sweep 1.4s cubic-bezier(.45, .05, .55, .95) infinite; }
+  @keyframes fl-editing-sweep {
+    from { transform: translateX(-110%); } to { transform: translateX(420%); } }
+}
+
 /* ---------- mobile input + touch ergonomics (ENG-228) ---------- */
 /* iOS Safari auto-zooms any focused text input under 16px, and 44px is the
    HIG touch-target floor. Keyed to small viewports OR coarse pointers so

--- a/packages/ui/src/chrome/vendo-overlay.tsx
+++ b/packages/ui/src/chrome/vendo-overlay.tsx
@@ -95,6 +95,24 @@ export interface VendoOverlayProps {
    * provider's `greeting`.
    */
   greeting?: VendoGreeting;
+  /**
+   * Where the panel sits while open.
+   *
+   * `"center"` (the default) is the centered modal box: scrim, body
+   * scroll-lock, inert background and focus trap. It stays the default so
+   * upgrading never changes an existing host's behavior.
+   *
+   * `"dock"` is the opt-in DevTools posture: a full-height side panel against
+   * the right edge, with the host page REFLOWED beside it. It is deliberately
+   * NON-modal — none of those four containments — because the page is the
+   * thing being reshaped and has to stay visible and clickable while the panel
+   * is open. Below the mobile breakpoint both collapse to the full-bleed
+   * takeover, which owns small screens either way.
+   */
+  placement?: "dock" | "center";
+  /** Docked panel width in CSS px (default 420) — also the amount the host
+   *  page reflows by, so the two can never disagree. */
+  dockWidth?: number;
 }
 
 /** Whisper caption duration — long enough to read two short lines, short
@@ -251,6 +269,140 @@ function EmbedMorphGhost({ from, target, clipTo, clone, mode, onDone }: {
       style={{ top: from.top, left: from.left, width: from.width, height: from.height }}
     >
       <div ref={scaleRef} className="fl-embed-ghost-scale" style={{ width: from.width }} />
+    </div>
+  );
+}
+
+/** The page reflow is owned CENTRALLY, not per panel: `data-vendo-dock` and
+    `--vendo-dock-w` live on the one documentElement every overlay shares, so a
+    second docked panel closing must not hand the page back its width while the
+    first is still open. Refcounted — the last release restores what was there.
+    The width is the newest acquirer's, which is also what the panels look
+    like: whichever docked last is the one against the edge. */
+let dockHolders = 0;
+let dockWidthBefore = "";
+
+function acquireDock(width: number): () => void {
+  const root = document.documentElement;
+  if (dockHolders === 0) dockWidthBefore = root.style.getPropertyValue("--vendo-dock-w");
+  dockHolders += 1;
+  root.style.setProperty("--vendo-dock-w", `${width}px`);
+  root.setAttribute("data-vendo-dock", "");
+  return () => {
+    dockHolders -= 1;
+    if (dockHolders > 0) return;
+    root.removeAttribute("data-vendo-dock");
+    if (dockWidthBefore === "") root.style.removeProperty("--vendo-dock-w");
+    else root.style.setProperty("--vendo-dock-w", dockWidthBefore);
+  };
+}
+
+/** The docked posture only exists where there is room for it: the takeover
+ *  owns everything below the breakpoint, so `docked` is the desktop answer,
+ *  and every modality behavior keys off it. `dockedOpen` narrows that to the
+ *  panel actually being open — the page frame the editing bar pins to, and the
+ *  launcher's step-aside, both need the panel on screen. */
+function dockPosture(placement: "dock" | "center", takeoverActive: boolean, open: boolean): {
+  docked: boolean;
+  dockedOpen: boolean;
+} {
+  const docked = placement === "dock" && !takeoverActive;
+  return { docked, dockedOpen: docked && open };
+}
+
+/** What the placement decides about the panel's own chrome, resolved once so
+ *  the JSX below stays flat.
+ *
+ *  Docked has no scrim at all: there is nothing to dim (the page is not
+ *  "behind" the panel, it is beside it) and nothing to click through to
+ *  dismiss — the close X and the launcher are the toggles. Nor does it claim
+ *  `aria-modal`, which would tell assistive tech the rest of the page is
+ *  unavailable — the opposite of true. */
+function placementChrome(docked: boolean, takeover: boolean, onScrimClick: () => void): {
+  scrim: ReactNode;
+  panelClass: string;
+  modal: { "aria-modal"?: "true" };
+  /** The workspace expander is hidden below the breakpoint (the takeover is
+   *  already full-bleed) and while docked, where a full-height rail has no
+   *  room for a stage beside it — the workspace stays a centered-box feature. */
+  stageHidden: boolean;
+} {
+  return {
+    /* Click-outside-to-dismiss: the visible frosted scrim reads as clickable,
+       so honor it. Dismissal fires on click (not mousedown) so the full
+       press-release is consumed by the scrim — closing on mousedown lets the
+       mouseup land on the revealed page and steal the restored focus. */
+    scrim: docked ? null : <div className="fl-overlay-scrim" onClick={onScrimClick} />,
+    /* ENG-228: below the breakpoint the panel goes full-bleed (`.fl-takeover`,
+       the designed Intercom-style mode). */
+    panelClass: `fl-overlay-panel${takeover ? " fl-takeover" : ""}${docked ? " fl-dock" : ""}`,
+    modal: docked ? {} : { "aria-modal": "true" },
+    stageHidden: takeover || docked,
+  };
+}
+
+/** The page-level effects the two placements split, in their own hook so the
+ *  overlay component stays under the complexity ceiling.
+ *
+ *  Modal: lock body scroll and make everything behind the portal inert (the
+ *  scrim + panel live in their own body-level subtree). Restored on close AND
+ *  on unmount-while-open via the effect cleanup.
+ *
+ *  Docked: deliberately NEITHER containment — the page beside it is the
+ *  subject of the conversation and must stay scrollable and clickable — and
+ *  instead documentElement carries the width reduction (see
+ *  `html[data-vendo-dock]` in chrome-css) so the host page lays out in the
+ *  remaining space rather than being covered. Stamped on the ROOT element
+ *  rather than body because body's width is usually author-controlled, and
+ *  torn down on close/unmount/placement-flip so a host is never left narrow.
+ *  Host chrome that is itself `position: fixed` is anchored to the viewport,
+ *  not to documentElement, so it does not reflow with this — such elements can
+ *  read `--vendo-dock-w` to inset themselves. */
+function usePlacementEffects(
+  open: boolean,
+  docked: boolean,
+  dockWidth: number,
+  portalRoot: { current: HTMLElement | null },
+): void {
+  useEffect(() => {
+    if (!open || docked) return;
+    const { body } = document;
+    const previousOverflow = body.style.overflow;
+    body.style.overflow = "hidden";
+    const release = inertBehind(portalRoot.current);
+    return () => {
+      release();
+      body.style.overflow = previousOverflow;
+    };
+  }, [open, docked, portalRoot]);
+
+  useEffect(() => {
+    if (!open || !docked || typeof document === "undefined") return;
+    return acquireDock(dockWidth);
+  }, [open, docked, dockWidth]);
+}
+
+/** The edit-in-progress bar: a hairline sweeping along the TOP EDGE of the
+    framed host page for as long as a turn is running, so work reads as
+    happening TO THE PAGE rather than only inside the panel.
+
+    Indeterminate on purpose. `RunActivity` does expose `done`/`total`, but
+    those count tool steps the turn has ALREADY BEGUN — not a forecast — so
+    rendering them as a percentage would be a fabricated completion estimate.
+    The codebase already settled this for the app-boot hairline ("no fake
+    percentage, no completion jump"); this follows the same law and the same
+    sweep vocabulary.
+
+    Geometry mirrors `html[data-vendo-dock]`: same gap inset on the left, and
+    the panel's column plus two gaps reserved on the right, so the bar lines
+    up with the frame it belongs to. Docked only — there is no page frame to
+    pin it to in the centered/takeover placements. */
+function EditingBar() {
+  const activity = useSyncExternalStore(subscribeRunActivity, runActivity, () => IDLE_RUN_ACTIVITY);
+  if (!activity.running) return null;
+  return (
+    <div className="fl-editing-bar" role="presentation" aria-hidden="true">
+      <span className="fl-editing-bar-sweep" />
     </div>
   );
 }
@@ -444,6 +596,8 @@ export function VendoOverlay({
   thread: Thread = VendoThread,
   discoverability,
   greeting,
+  placement = "center",
+  dockWidth = 420,
 }: VendoOverlayProps = {}) {
   const controlled = openProp !== undefined;
   const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
@@ -464,6 +618,7 @@ export function VendoOverlay({
     useRememberedConversation(conversationKey);
   const theme = useVendoTheme();
   const takeover = useMobileTakeover();
+  const { docked, dockedOpen } = dockPosture(placement, takeover.active, open);
   const pin = usePinAction();
 
   // 2026-07 demo feedback — the expandable split-view workspace (split-view.tsx
@@ -494,6 +649,8 @@ export function VendoOverlay({
   const [suggestExpand, setSuggestExpand] = useState(false);
   const splitStateRef = useRef(splitState);
   splitStateRef.current = splitState;
+  const dockedRef = useRef(docked);
+  dockedRef.current = docked;
   const suggestTimer = useRef<number | undefined>(undefined);
   useEffect(() => () => window.clearTimeout(suggestTimer.current), []);
   useEffect(() => {
@@ -517,6 +674,10 @@ export function VendoOverlay({
   // on the user's behalf. It is keyed by the BUILD, so a new build the user
   // ASKED for can still stage after they collapsed the previous one.
   const autoStage = useCallback((appId: string, buildKey: string) => {
+    // The docked posture has no stage — it is display:none and its toggle is
+    // hidden — so staging on the user's behalf here would strand an app they
+    // can neither see nor collapse. The embed still lands in the rail.
+    if (dockedRef.current) return;
     const state = splitStateRef.current;
     if (state.autoStaged.includes(buildKey)) return;
     dispatchSplit({ type: "auto-stage", buildKey });
@@ -670,22 +831,10 @@ export function VendoOverlay({
     }
   }, [open]);
 
-  // While open: lock body scroll and make everything behind the portal inert
-  // (the scrim + panel live in their own body-level subtree). Restored on
-  // close AND on unmount-while-open via the effect cleanup.
-  useEffect(() => {
-    if (!open) return;
-    const { body } = document;
-    const previousOverflow = body.style.overflow;
-    body.style.overflow = "hidden";
-    const release = inertBehind(portalRoot.current);
-    return () => {
-      release();
-      body.style.overflow = previousOverflow;
-    };
-  }, [open]);
+  usePlacementEffects(open, docked, dockWidth, portalRoot);
 
   const close = () => setOpen(false);
+  const panelChrome = placementChrome(docked, takeover.active, close);
 
   // The prefill scope: this overlay's composer registers under it, so a
   // delivered prompt reaches THIS overlay's thread — not an embedded
@@ -801,7 +950,9 @@ export function VendoOverlay({
       close();
       return;
     }
-    if (event.key !== "Tab") return;
+    // Docked is non-modal: Tab must be able to walk OUT of the panel and into
+    // the page, so the wrap-around trap is a modal-only behavior.
+    if (event.key !== "Tab" || docked) return;
     const focusable = [...(dialog.current?.querySelectorAll<HTMLElement>(FOCUSABLE) ?? [])];
     if (focusable.length === 0) return;
     const first = focusable[0]!;
@@ -832,23 +983,18 @@ export function VendoOverlay({
       // state (and any in-flight stream) lives on underneath.
       style={{ ...themeCssVariables(theme), fontFamily: "var(--vendo-font-family)", fontSize: "var(--vendo-font-size)", ...(open ? {} : { display: "none" }) } as CSSProperties}
     >
-      {/* Click-outside-to-dismiss: the visible frosted scrim reads as clickable,
-          so honor it. Dismissal fires on click (not mousedown) so the full
-          press-release is consumed by the scrim — closing on mousedown lets the
-          mouseup land on the revealed page and steal the restored focus. */}
-      <div className="fl-overlay-scrim" onClick={close} />
-      {/* ENG-228: below the breakpoint the panel goes full-bleed (`.fl-takeover`,
-          the designed Intercom-style mode) and carries the virtual-keyboard
-          inset var so the composer stays above the on-screen keyboard. */}
+      {panelChrome.scrim}
+      {/* The panel carries the virtual-keyboard inset var in the takeover so
+          the composer stays above the on-screen keyboard. */}
       <div
         ref={dialog}
         id="vendo-overlay-dialog"
-        className={`fl-overlay-panel${takeover.active ? " fl-takeover" : ""}`}
+        className={panelChrome.panelClass}
         {...(expanded ? { "data-vendo-expanded": "" } : {})}
         {...(embedGhost ? { "data-vendo-ghost": embedGhost.mode } : {})}
         style={takeover.style}
         role="dialog"
-        aria-modal="true"
+        {...panelChrome.modal}
         aria-label="Vendo assistant"
         onKeyDown={onKeyDown}
       >
@@ -871,7 +1017,7 @@ export function VendoOverlay({
           <span className="fl-sr-only">Previous conversations</span>
         </button>
         <WorkspaceToggle
-          hidden={takeover.active}
+          hidden={panelChrome.stageHidden}
           expanded={expanded}
           suggest={suggestExpand}
           onToggle={() => setWorkspace(!splitState.expanded)}
@@ -931,6 +1077,8 @@ export function VendoOverlay({
           </div>
         </SplitViewContext.Provider>
       </div>
+      {/* Pinned to the framed page, so it only exists in the docked posture. */}
+      {dockedOpen ? <EditingBar /> : null}
       {/* The embed's shared-element flight rides ABOVE the panel (the panel
           clips overflow, and mid-flight the ghost straddles both panes). */}
       {embedGhost ? (
@@ -958,6 +1106,9 @@ export function VendoOverlay({
           {...styleProp(launcherOffsetStyle)}
           // Blob-only orb when the host clears the label (`label: null`).
           {...(launcherLabel === null ? { "data-vendo-launcher-bare": "" } : {})}
+          // Steps aside instead of hiding under the docked panel, so the pill
+          // stays a live toggle rather than becoming unreachable while open.
+          {...(dockedOpen ? { "data-vendo-docked": "" } : {})}
           // Present only while the whisper is live: keys the one-time pulse
           // (suppressed under prefers-reduced-motion — the caption still shows).
           {...(whisperActive && !open ? { "data-vendo-whisper": "" } : {})}


### PR DESCRIPTION
A new sidebar
A Zap tool for removing page elements
A screenshot tool that provides visual context to the AI
A theme carousel
Undo and “Restore All” options for reverting changes
A border around the webpage to clearly indicate when the user is in editing mode
[https://www.loom.com/share/f2f223b49eeb447bb36b0a7dfb0f2ba1](url)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in docked placement for `VendoOverlay` that parks the panel beside the page and reflows the page so users can edit in place. The default remains the centered modal; docked is deliberately non-modal.

- Public API: `VendoOverlay` adds `placement` ("center" default, "dock") and `dockWidth` (px, default 420) in `@vendoai/ui`.
- Docked behavior: no scrim, no scroll-lock, no inert background, no focus trap, no `aria-modal`. Reflow applies to `documentElement` via `data-vendo-dock` and `--vendo-dock-w`, refcounted across multiple panels.
- Mobile: both placements still collapse to the full-bleed takeover.
- UI adjustments: workspace expander is hidden while docked; auto-stage is disabled in docked mode (embeds still land in the rail); launcher shifts left to stay clickable.
- Feedback: an indeterminate editing bar sweeps along the top edge of the framed page while a turn runs.
- Adoption: no change unless you opt in. To use the side panel, set `placement="dock"` and optionally `dockWidth`.

<sup>Written for commit 9a2cea2e8a6800aa6f7d304c906db508089f8cc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



