### PR TITLE
chore(apps): shrink the testing subpath and root type surface to real consumers

### DIFF
--- a/.changeset/apps-trims-testing-and-type-surface.md
+++ b/.changeset/apps-trims-testing-and-type-surface.md
@@ -1,0 +1,28 @@
+---
+"@vendoai/apps": minor
+---
+
+The published surface shrinks to what consumers actually import.
+
+**`@vendoai/apps/testing` exports three names**, down from 32:
+`inMemoryBoxFiles`, `scriptedLanguageModel` and `ScriptedModelCall` — the ones
+imported outside this package. The other 29 fixtures (the sandbox fakes, the
+guard and store doubles, the assemblers, the row seeds) are this package's own;
+they still exist, and this package's tests now name the module they come from
+instead of the published barrel.
+
+**Eleven free-floating type exports leave the package root.** Each was reachable
+from no public value, schema, `AppsRuntime` method or `AppsConfig` field, and
+had no importer anywhere: `ManifestTriggerResult`, `ManifestTriggerSync`,
+`VendoManifest`, `VendoManifestSchedule`, `PlacementRow`, `PlacementStore`,
+`GeneratedAppDocument`, `CheckingLayer`, and the `Check`, `CheckInput` and
+`Finding` re-exports — those three are `@vendoai/core`'s types, and a host
+writing an `AppsConfig.checks` entry imports them from core, where a pack is
+authorable without depending on this block.
+
+Everything anchored to surviving surface stays exported, including
+`AuthoredAppResult`, `EditFailure`, `BuildEnvContext`, `BuiltBoxEnv`,
+`InferenceResolver`, `AppMachineStatus`, `PublishRecord`, `ShareSnapshot`,
+`ReviewStanding`, `RemixRejection`, `ReviewQueueEntry`, `ShipDiffPin`,
+`ShipDiffGenerated`, `Skeleton`, `AutomationPlan`, `GenerationDependencies`,
+`PlacementEntry`, `PinForkInput` and `PinForkResult`.

--- a/packages/apps/src/index.ts
+++ b/packages/apps/src/index.ts
@@ -23,19 +23,9 @@ export {
   type PinRebaseResult,
   type VersionEntry,
 } from "./runtime.js";
-// Placement rows — "show this app in that slot", off the document and in the
-// generic records collection.
-export type {
-  PlacementRow,
-  PlacementStore,
-} from "./placements.js";
 export type { SandboxAdapter, SandboxMachine, SandboxResumePolicy } from "./sandbox.js";
-// execution-v2 skin contract (Lane C): the manifest shapes, the per-app box
-// token, and the box env assembly Lane B consumes at provision.
-export type {
-  VendoManifest,
-  VendoManifestSchedule,
-} from "./manifest.js";
+// execution-v2 skin contract (Lane C): the per-app box token and the box env
+// assembly Lane B consumes at provision.
 export {
   createAppTokens,
   type AppTokens,
@@ -46,15 +36,10 @@ export {
   type BuiltBoxEnv,
   type InferenceResolver,
 } from "./box-env.js";
-// A machine app's vendo.json schedules are doc triggers: the shapes
-// `AppsRuntime.machine`'s syncManifest and report answer with. The converter's
-// own constants stay internal to it — nothing outside needs them yet, and an
-// export is additive the day something does.
-export type {
-  AppMachineStatus,
-  ManifestTriggerResult,
-  ManifestTriggerSync,
-} from "./manifest-triggers.js";
+// The doctor's view of a machine-bearing app — what `AppsRuntime.machine.report`
+// answers with. The converter's own shapes stay internal to it: no public door
+// hands one out, and an export is additive the day one does.
+export type { AppMachineStatus } from "./manifest-triggers.js";
 export {
   shareSnapshotSchema,
   publishRecordSchema,
@@ -90,14 +75,6 @@ export {
 // HostToolInfo is the tool slice GenerationDependencies (and external
 // harnesses) speak.
 export type { HostToolInfo } from "./generation/engine.js";
-// The checking layer's contract: the shape a host writes an AppsConfig.checks
-// entry in, and the finding shape every check reports (checking/types.ts).
-export type {
-  Check,
-  CheckInput,
-  CheckingLayer,
-  Finding,
-} from "./checking/types.js";
 // The plan→layout function. The exports map closes deep imports, and this is a
 // pure, deterministic function of the public AppPlan — so a demo or harness
 // surface can render a plan's skeleton without booting the engine.
@@ -115,10 +92,8 @@ export {
   acceptsSamplingParams,
   UNKNOWN_MODEL_MAX_OUTPUT_TOKENS,
 } from "./model-params.js";
-export {
-  type GeneratedAppDocument,
-  type GenerationDependencies,
-} from "./generation/engine.js";
+// The generation seam AppsConfig.pipeline is a slice of.
+export type { GenerationDependencies } from "./generation/engine.js";
 // What app generation mounts itself with: the tools it declares and the skill
 // it teaches the pattern with. The umbrella composes them (`server.ts`), which
 // is the only layer holding both these values and the live runtime they act

--- a/packages/apps/src/testing/index.ts
+++ b/packages/apps/src/testing/index.ts
@@ -1,9 +1,11 @@
-export * from "./authoring-assembler.js";
-export * from "./box-files.js";
-export * from "./fake-sandbox.js";
-export * from "./fake-sandbox-stateful.js";
-export * from "./fake-box.js";
-export * from "./guard-fixture.js";
-export * from "./memory-store.js";
-export * from "./seed-app-row.js";
-export * from "./scripted-model.js";
+/**
+ * `@vendoai/apps/testing` — the published test surface, and nothing else.
+ *
+ * These three are what a consumer outside this package writes tests with: the
+ * ONE in-memory implementation of the sandbox files seam, and the deterministic
+ * language model. Every other fixture in this directory is ours (the fakes, the
+ * guard and store doubles, the seeds); this package's own tests import them from
+ * their module, so they stay free to change without a major bump.
+ */
+export { inMemoryBoxFiles } from "./box-files.js";
+export { scriptedLanguageModel, type ScriptedModelCall } from "./scripted-model.js";

--- a/packages/apps/src/types.ts
+++ b/packages/apps/src/types.ts
@@ -153,7 +153,8 @@ export interface AppsConfig {
   /** The island smoke-render gate (on unless explicitly `false`): every
    *  generated island renders once headless before it can reach a screen. */
   pipeline?: GenerationDependencies["pipeline"];
-  /** The host's own checks over a generated app (checking/types.ts). APPENDED
+  /** The host's own checks over a generated app (`Check` is `@vendoai/core`'s —
+   *  a pack is authorable without depending on this block). APPENDED
    *  to the built-in fact checks and the reviewer — a host can add findings,
    *  never remove or replace a built-in one. */
   checks?: readonly Check[];

--- a/packages/apps/tests/access.test.ts
+++ b/packages/apps/tests/access.test.ts
@@ -11,13 +11,11 @@ import {
 import { appAccessConformance } from "@vendoai/core/conformance";
 import { describe, expect, it } from "vitest";
 import { createApps, type AppsConfig, type AppsRuntime } from "../src/index.js";
-import {
-  basicLanguageModel,
-  guardFixture,
-  memoryStore,
-  scriptedAssembler,
-  seedAppRow,
-} from "../src/testing/index.js";
+import { scriptedAssembler } from "../src/testing/authoring-assembler.js";
+import { guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { basicLanguageModel } from "../src/testing/scripted-model.js";
+import { seedAppRow } from "../src/testing/seed-app-row.js";
 // One copy of the AppAccess stand-in, shared with served-orgs.test.ts.
 import { seedGrantRows as seedGrants, storeAccessFixture as storeAccess } from "./app-access-fixture.js";
 

--- a/packages/apps/tests/agent-tools.test.ts
+++ b/packages/apps/tests/agent-tools.test.ts
@@ -10,17 +10,12 @@ import {
 import { describe, expect, it } from "vitest";
 import { agentToolDescriptors } from "../src/agent-tools.js";
 import { createApps, type AppsRuntime, type PlacementEntry } from "../src/index.js";
-import {
-  authoringAssembler,
-  basicLanguageModel,
-  bindTools,
-  fakeBoxSandbox,
-  guardFixture,
-  memoryStore,
-  scriptedAssembler,
-  seedAppRow,
-  scriptedLanguageModel,
-} from "../src/testing/index.js";
+import { authoringAssembler, scriptedAssembler } from "../src/testing/authoring-assembler.js";
+import { fakeBoxSandbox } from "../src/testing/fake-box.js";
+import { bindTools, guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { basicLanguageModel, scriptedLanguageModel } from "../src/testing/scripted-model.js";
+import { seedAppRow } from "../src/testing/seed-app-row.js";
 import { seedGrantRows, storeAccessFixture } from "./app-access-fixture.js";
 
 const ctx: RunContext = {

--- a/packages/apps/tests/app-data.test.ts
+++ b/packages/apps/tests/app-data.test.ts
@@ -7,7 +7,11 @@ import {
   createAppData,
 } from "../src/app-data.js";
 import { createApps, type AppsRuntime } from "../src/index.js";
-import { basicLanguageModel, guardFixture, memoryStore, scriptedAssembler, seedAppRow } from "../src/testing/index.js";
+import { scriptedAssembler } from "../src/testing/authoring-assembler.js";
+import { guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { basicLanguageModel } from "../src/testing/scripted-model.js";
+import { seedAppRow } from "../src/testing/seed-app-row.js";
 
 const tools: ToolRegistry = {
   async descriptors() {

--- a/packages/apps/tests/app-memory.test.ts
+++ b/packages/apps/tests/app-memory.test.ts
@@ -10,7 +10,10 @@ import type { AppId, RunContext } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
 import { APP_MEMORY_DECISIONS_MAX_BYTES, APP_MEMORY_MAX_ASKS } from "../src/app-memory.js";
 import { createApps, type AppsRuntime } from "../src/index.js";
-import { authoringAssembler, basicLanguageModel, guardFixture, memoryStore } from "../src/testing/index.js";
+import { authoringAssembler } from "../src/testing/authoring-assembler.js";
+import { guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { basicLanguageModel } from "../src/testing/scripted-model.js";
 
 const ctx: RunContext = {
   principal: { kind: "user", subject: "user_memory" },

--- a/packages/apps/tests/app-token.test.ts
+++ b/packages/apps/tests/app-token.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { memoryStore } from "../src/testing/index.js";
+import { memoryStore } from "../src/testing/memory-store.js";
 import { APP_TOKEN_COLLECTION, createAppTokens } from "../src/app-token.js";
 
 const APP = "app_box_1";

--- a/packages/apps/tests/authored.test.ts
+++ b/packages/apps/tests/authored.test.ts
@@ -23,12 +23,15 @@ import {
 } from "@vendoai/core";
 import { describe, expect, it, vi } from "vitest";
 import { inMemoryBoxFiles } from "../src/testing/box-files.js";
+import { bindTools, guardFixture, type GuardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { scriptedLanguageModel } from "../src/testing/scripted-model.js";
+import { seedAppRow } from "../src/testing/seed-app-row.js";
 import { createAppHistory } from "../src/history.js";
 import { createApps, pinComponentName, type AppsRuntime, type PinBaseline } from "../src/index.js";
 import { detectPinDrift } from "../src/pins.js";
 import type { SandboxAdapter, SandboxMachine } from "../src/sandbox.js";
 import { seedGrantRows, storeAccessFixture } from "./app-access-fixture.js";
-import { bindTools, guardFixture, memoryStore, scriptedLanguageModel, seedAppRow, type GuardFixture } from "../src/testing/index.js";
 
 const APP_ID = "app_authored";
 

--- a/packages/apps/tests/automation-audit.test.ts
+++ b/packages/apps/tests/automation-audit.test.ts
@@ -15,7 +15,10 @@
 import { VENDO_APP_FORMAT, type AppDocument, type RunContext, type ScreenAssembler, type ToolRegistry } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
 import { createApps } from "../src/index.js";
-import { guardFixture, memoryStore, scriptedLanguageModel, seedAppRow } from "../src/testing/index.js";
+import { guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { scriptedLanguageModel } from "../src/testing/scripted-model.js";
+import { seedAppRow } from "../src/testing/seed-app-row.js";
 
 const APP_ID = "app_audit_ladder";
 

--- a/packages/apps/tests/automation-second.test.ts
+++ b/packages/apps/tests/automation-second.test.ts
@@ -21,7 +21,10 @@
 import { VENDO_APP_FORMAT, type AppDocument, type AppId, type RunContext, type ScreenAssembler, type ToolRegistry } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
 import { createApps } from "../src/index.js";
-import { guardFixture, memoryStore, scriptedLanguageModel, seedAppRow } from "../src/testing/index.js";
+import { guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { scriptedLanguageModel } from "../src/testing/scripted-model.js";
+import { seedAppRow } from "../src/testing/seed-app-row.js";
 
 const APP_ID = "app_two_automations";
 

--- a/packages/apps/tests/box-door.test.ts
+++ b/packages/apps/tests/box-door.test.ts
@@ -1,10 +1,13 @@
 import { VENDO_APP_FORMAT, type AppDocument, type RunContext, type ToolRegistry } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
 import { inMemoryBoxFiles } from "../src/testing/box-files.js";
+import { guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { basicLanguageModel } from "../src/testing/scripted-model.js";
+import { seedAppRow } from "../src/testing/seed-app-row.js";
 import { createMachineLane } from "../src/box-lane.js";
 import { createApps, type AppsConfig } from "../src/index.js";
 import type { SandboxAdapter, SandboxMachine } from "../src/sandbox.js";
-import { basicLanguageModel, guardFixture, memoryStore, seedAppRow } from "../src/testing/index.js";
 
 const model = basicLanguageModel();
 const decoder = new TextDecoder();

--- a/packages/apps/tests/build-failure.test.ts
+++ b/packages/apps/tests/build-failure.test.ts
@@ -3,7 +3,10 @@ import { VendoError } from "@vendoai/core";
 import { describe, expect, it, vi } from "vitest";
 import { buildFailureReason } from "../src/build-messages.js";
 import { createApps, type AppsRuntime } from "../src/index.js";
-import { basicLanguageModel, guardFixture, memoryStore, scriptedAssembler } from "../src/testing/index.js";
+import { scriptedAssembler } from "../src/testing/authoring-assembler.js";
+import { guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { basicLanguageModel } from "../src/testing/scripted-model.js";
 
 // Incident (runvendo/vendo#492): the pack's vendo_make returns fast with a
 // vendo/app-ref@1 while the build streams server-side. When the build turn

--- a/packages/apps/tests/call.test.ts
+++ b/packages/apps/tests/call.test.ts
@@ -2,7 +2,9 @@ import type { AppDocument, RunContext, ToolCall, ToolRegistry } from "@vendoai/c
 import { VENDO_APP_FORMAT } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
 import { createApps } from "../src/index.js";
-import { guardFixture, memoryStore, seedAppRow } from "../src/testing/index.js";
+import { guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { seedAppRow } from "../src/testing/seed-app-row.js";
 
 // execution-v2 Wave 1.5 — the v1 MachineSessions fn: path is deleted. Until
 // the in-runtime v2 fn path lands (fn/schedules lane), an fn: ref settles as a

--- a/packages/apps/tests/checking/commit-gate.test.ts
+++ b/packages/apps/tests/checking/commit-gate.test.ts
@@ -36,14 +36,11 @@ import {
 } from "@vendoai/core";
 import { describe, expect, it, vi } from "vitest";
 import { createApps, type AppsRuntime } from "../../src/index.js";
-import {
-  basicLanguageModel,
-  guardFixture,
-  memoryStore,
-  scriptedAssembler,
-  seedAppRow,
-  type AssemblerAnswer,
-} from "../../src/testing/index.js";
+import { scriptedAssembler, type AssemblerAnswer } from "../../src/testing/authoring-assembler.js";
+import { guardFixture } from "../../src/testing/guard-fixture.js";
+import { memoryStore } from "../../src/testing/memory-store.js";
+import { basicLanguageModel } from "../../src/testing/scripted-model.js";
+import { seedAppRow } from "../../src/testing/seed-app-row.js";
 import { blocks } from "../../src/checking/floor.js";
 
 const ctx: RunContext = {

--- a/packages/apps/tests/checking/declared-tool-schemas.test.ts
+++ b/packages/apps/tests/checking/declared-tool-schemas.test.ts
@@ -27,7 +27,9 @@ import {
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import { createApps } from "../../src/index.js";
-import { guardFixture, memoryStore, scriptedLanguageModel } from "../../src/testing/index.js";
+import { guardFixture } from "../../src/testing/guard-fixture.js";
+import { memoryStore } from "../../src/testing/memory-store.js";
+import { scriptedLanguageModel } from "../../src/testing/scripted-model.js";
 
 const TOOL = "host_getSpendingInsights";
 const CATEGORIES = ["dining", "groceries", "other"] as const;

--- a/packages/apps/tests/checking/validate-door.test.ts
+++ b/packages/apps/tests/checking/validate-door.test.ts
@@ -25,13 +25,10 @@ import {
 } from "@vendoai/core";
 import { beforeEach, describe, expect, it } from "vitest";
 import { createApps, type AppsRuntime } from "../../src/index.js";
-import {
-  authoringAssembler,
-  guardFixture,
-  memoryStore,
-  scriptedLanguageModel,
-  type ScriptedModelCall,
-} from "../../src/testing/index.js";
+import { authoringAssembler } from "../../src/testing/authoring-assembler.js";
+import { guardFixture } from "../../src/testing/guard-fixture.js";
+import { memoryStore } from "../../src/testing/memory-store.js";
+import { scriptedLanguageModel, type ScriptedModelCall } from "../../src/testing/scripted-model.js";
 
 const ctx: RunContext = {
   principal: { kind: "user", subject: "user_ada" },

--- a/packages/apps/tests/cloud.test.ts
+++ b/packages/apps/tests/cloud.test.ts
@@ -6,7 +6,9 @@ import {
   shareSnapshotSchema,
   type CloudAppsClient,
 } from "../src/index.js";
-import { guardFixture, memoryStore, seedAppRow } from "../src/testing/index.js";
+import { guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { seedAppRow } from "../src/testing/seed-app-row.js";
 
 // ADAPTER RULE (see selectConnections in the umbrella's server.ts): the apps
 // block never reads the environment. Share/publish ride an INJECTED Cloud

--- a/packages/apps/tests/create-unsaved.test.ts
+++ b/packages/apps/tests/create-unsaved.test.ts
@@ -3,8 +3,11 @@ import { describe, expect, it } from "vitest";
 import { createAgentTools } from "../src/agent-tools.js";
 import { createApps, type AppsRuntime } from "../src/index.js";
 import { assembleTree } from "../src/runtime.js";
+import { authoringAssembler } from "../src/testing/authoring-assembler.js";
 import { fakeBoxSandbox } from "../src/testing/fake-box.js";
-import { authoringAssembler, basicLanguageModel, guardFixture, memoryStore } from "../src/testing/index.js";
+import { guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { basicLanguageModel } from "../src/testing/scripted-model.js";
 
 /**
  * Regression guard for the LIVE deployed-Maple failure (2026-07-27): the

--- a/packages/apps/tests/data-unavailable.test.ts
+++ b/packages/apps/tests/data-unavailable.test.ts
@@ -27,7 +27,9 @@ import {
 } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
 import { createApps } from "../src/index.js";
-import { bindTools, guardFixture, memoryStore, seedAppRow } from "../src/testing/index.js";
+import { bindTools, guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { seedAppRow } from "../src/testing/seed-app-row.js";
 
 const APP_ID = "app_data_unavailable";
 

--- a/packages/apps/tests/e2b/e2b.live.test.ts
+++ b/packages/apps/tests/e2b/e2b.live.test.ts
@@ -4,7 +4,8 @@ import { sandboxAdapterConformance, type SandboxConformanceHarness } from "../..
 import { requestAppWithBootRetry } from "../../src/box-agent.js";
 import { createMachineLifecycle } from "../../src/machine-lifecycle.js";
 import type { SandboxMachine } from "../../src/sandbox.js";
-import { memoryStore, seedAppRow } from "../../src/testing/index.js";
+import { memoryStore } from "../../src/testing/memory-store.js";
+import { seedAppRow } from "../../src/testing/seed-app-row.js";
 import { e2bSandbox } from "../../src/e2b/index.js";
 
 // ============================================================================

--- a/packages/apps/tests/e2b/secrets-egress.live.test.ts
+++ b/packages/apps/tests/e2b/secrets-egress.live.test.ts
@@ -6,7 +6,9 @@ import { boxAllowlist } from "../../src/egress-approval.js";
 import { createApps } from "../../src/index.js";
 import type { BuildMachineEnv } from "../../src/machine-lifecycle.js";
 import type { SandboxMachine } from "../../src/sandbox.js";
-import { guardFixture, memoryStore, seedAppRow } from "../../src/testing/index.js";
+import { guardFixture } from "../../src/testing/guard-fixture.js";
+import { memoryStore } from "../../src/testing/memory-store.js";
+import { seedAppRow } from "../../src/testing/seed-app-row.js";
 import { e2bSandbox } from "../../src/e2b/index.js";
 
 // ============================================================================

--- a/packages/apps/tests/egress-approval.test.ts
+++ b/packages/apps/tests/egress-approval.test.ts
@@ -7,7 +7,7 @@ import {
   normalizeEgressDomain,
   unapprovedEgress,
 } from "../src/egress-approval.js";
-import { memoryStore } from "../src/testing/index.js";
+import { memoryStore } from "../src/testing/memory-store.js";
 
 const app = (overrides: Partial<AppDocument> = {}): AppDocument => ({
   format: VENDO_APP_FORMAT,

--- a/packages/apps/tests/egress-failopen.test.ts
+++ b/packages/apps/tests/egress-failopen.test.ts
@@ -16,7 +16,10 @@ import { describe, expect, it } from "vitest";
 import { createMachineLane } from "../src/box-lane.js";
 import { createMachineLifecycle } from "../src/machine-lifecycle.js";
 import type { SandboxAdapter } from "../src/sandbox.js";
-import { fakeStatefulSandbox, guardFixture, memoryStore, seedAppRow } from "../src/testing/index.js";
+import { fakeStatefulSandbox } from "../src/testing/fake-sandbox-stateful.js";
+import { guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { seedAppRow } from "../src/testing/seed-app-row.js";
 
 type CreateSpec = { template?: string; env: Record<string, string>; allowedDomains?: string[] };
 

--- a/packages/apps/tests/egress-flow.test.ts
+++ b/packages/apps/tests/egress-flow.test.ts
@@ -3,12 +3,10 @@ import { VENDO_APP_FORMAT } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
 import { createMachineLane } from "../src/box-lane.js";
 import { createApps, type AppsConfig } from "../src/index.js";
-import {
-  fakeStatefulSandbox,
-  guardFixture,
-  memoryStore,
-  seedAppRow,
-} from "../src/testing/index.js";
+import { fakeStatefulSandbox } from "../src/testing/fake-sandbox-stateful.js";
+import { guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { seedAppRow } from "../src/testing/seed-app-row.js";
 
 /** execution-v2 Wave 2 Lane E — the grant flow end to end on the fake adapter:
     approve → the box door opens; unapproved → loud error; manifest growth

--- a/packages/apps/tests/fn-runtime.e2e.test.ts
+++ b/packages/apps/tests/fn-runtime.e2e.test.ts
@@ -8,9 +8,12 @@ import {
 } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
 import { inMemoryBoxFiles } from "../src/testing/box-files.js";
+import { guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { basicLanguageModel } from "../src/testing/scripted-model.js";
+import { seedAppRow } from "../src/testing/seed-app-row.js";
 import { createApps } from "../src/index.js";
 import type { SandboxAdapter, SandboxMachine } from "../src/sandbox.js";
-import { basicLanguageModel, guardFixture, memoryStore, seedAppRow } from "../src/testing/index.js";
 
 /**
  * execution-v2 Lane D gate (fake adapter): a tree whose query names

--- a/packages/apps/tests/fork-pin.test.ts
+++ b/packages/apps/tests/fork-pin.test.ts
@@ -7,13 +7,11 @@ import type { AppDocument, RunContext, ScreenAssembler, StoreAdapter, ToolRegist
 import { describe, expect, it } from "vitest";
 import { createApps, type AppsConfig, type AppsRuntime, type PinBaseline } from "../src/index.js";
 import { detectPinDrift, pinComponentName } from "../src/pins.js";
-import {
-  basicLanguageModel,
-  guardFixture,
-  memoryStore,
-  scriptedAssembler,
-  seedAppRow,
-} from "../src/testing/index.js";
+import { scriptedAssembler } from "../src/testing/authoring-assembler.js";
+import { guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { basicLanguageModel } from "../src/testing/scripted-model.js";
+import { seedAppRow } from "../src/testing/seed-app-row.js";
 
 const ctx: RunContext = {
   principal: { kind: "user", subject: "user_gesture" },

--- a/packages/apps/tests/generation/lanes.test.ts
+++ b/packages/apps/tests/generation/lanes.test.ts
@@ -6,7 +6,7 @@ import {
 } from "@vendoai/core";
 import type { LanguageModel } from "ai";
 import { describe, expect, it } from "vitest";
-import { scriptedLanguageModel, type ScriptedModelCall } from "../../src/testing/index.js";
+import { scriptedLanguageModel, type ScriptedModelCall } from "../../src/testing/scripted-model.js";
 import type { GeneratedAppDocument, HostToolInfo } from "../../src/generation/engine.js";
 import {
   escalatedServer,

--- a/packages/apps/tests/inclient.test.ts
+++ b/packages/apps/tests/inclient.test.ts
@@ -3,14 +3,11 @@ import { describe, expect, it } from "vitest";
 import { createInClientApprovals } from "../src/inclient.js";
 import { createApps, type AppsRuntime } from "../src/index.js";
 import { pinComponentName, type InClientApproval, type PinBaseline } from "../src/pins.js";
-import {
-  authoringAssembler,
-  basicLanguageModel,
-  guardFixture,
-  memoryStore,
-  scriptedAssembler,
-  seedAppRow,
-} from "../src/testing/index.js";
+import { authoringAssembler, scriptedAssembler } from "../src/testing/authoring-assembler.js";
+import { guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { basicLanguageModel } from "../src/testing/scripted-model.js";
+import { seedAppRow } from "../src/testing/seed-app-row.js";
 import { appVersionHash } from "../src/version-hash.js";
 
 const tools: ToolRegistry = {

--- a/packages/apps/tests/interchange.test.ts
+++ b/packages/apps/tests/interchange.test.ts
@@ -4,11 +4,9 @@ import { unzipSync, zipSync } from "fflate";
 import { describe, expect, it } from "vitest";
 import { createApps } from "../src/index.js";
 import { pinComponentName } from "../src/pins.js";
-import {
-  guardFixture,
-  memoryStore,
-  seedAppRow,
-} from "../src/testing/index.js";
+import { guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { seedAppRow } from "../src/testing/seed-app-row.js";
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();

--- a/packages/apps/tests/jail-packages.test.ts
+++ b/packages/apps/tests/jail-packages.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it } from "vitest";
 import { createApps } from "../src/index.js";
 import { stripServerAuthoritativeFields } from "../src/open.js";
 import { pinComponentName, type PinBaseline } from "../src/pins.js";
-import { guardFixture, memoryStore, scriptedLanguageModel, seedAppRow } from "../src/testing/index.js";
+import { guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { scriptedLanguageModel } from "../src/testing/scripted-model.js";
+import { seedAppRow } from "../src/testing/seed-app-row.js";
 
 /**
  * The venue wall for CDN package loading.

--- a/packages/apps/tests/lifecycle.test.ts
+++ b/packages/apps/tests/lifecycle.test.ts
@@ -4,13 +4,11 @@ import { describe, expect, it, vi } from "vitest";
 import { createApps, type AppsRuntime } from "../src/index.js";
 import { createAppHistory } from "../src/history.js";
 import { enabledAfterDocumentEdit } from "../src/persistence.js";
-import {
-  basicLanguageModel,
-  guardFixture,
-  memoryStore,
-  scriptedAssembler,
-  seedAppRow,
-} from "../src/testing/index.js";
+import { scriptedAssembler } from "../src/testing/authoring-assembler.js";
+import { guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { basicLanguageModel } from "../src/testing/scripted-model.js";
+import { seedAppRow } from "../src/testing/seed-app-row.js";
 
 const tools: ToolRegistry = {
   async descriptors() {

--- a/packages/apps/tests/machine-lifecycle.test.ts
+++ b/packages/apps/tests/machine-lifecycle.test.ts
@@ -4,7 +4,9 @@ import { describe, expect, it } from "vitest";
 import { createMachineLifecycle, type LifecycleClock } from "../src/machine-lifecycle.js";
 import { documentFromRecord } from "../src/persistence.js";
 import { inMemoryBoxFiles } from "../src/testing/box-files.js";
-import { fakeStatefulSandbox, memoryStore, seedAppRow } from "../src/testing/index.js";
+import { fakeStatefulSandbox } from "../src/testing/fake-sandbox-stateful.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { seedAppRow } from "../src/testing/seed-app-row.js";
 
 const app = (id = "app_machine_test"): AppDocument => ({
   format: VENDO_APP_FORMAT,

--- a/packages/apps/tests/machine-runtime.test.ts
+++ b/packages/apps/tests/machine-runtime.test.ts
@@ -4,13 +4,10 @@ import { unzipSync } from "fflate";
 import { describe, expect, it } from "vitest";
 import { createMachineLane } from "../src/box-lane.js";
 import { createApps, type AppsConfig } from "../src/index.js";
-import {
-  fakeStatefulSandbox,
-  guardFixture,
-  memoryStore,
-  seedAppRow,
-  type FakeStatefulSandbox,
-} from "../src/testing/index.js";
+import { fakeStatefulSandbox, type FakeStatefulSandbox } from "../src/testing/fake-sandbox-stateful.js";
+import { guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { seedAppRow } from "../src/testing/seed-app-row.js";
 
 const decoder = new TextDecoder();
 

--- a/packages/apps/tests/one-floor.test.ts
+++ b/packages/apps/tests/one-floor.test.ts
@@ -33,7 +33,10 @@ import {
 } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
 import { createApps } from "../src/index.js";
-import { guardFixture, memoryStore, scriptedLanguageModel, seedAppRow } from "../src/testing/index.js";
+import { guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { scriptedLanguageModel } from "../src/testing/scripted-model.js";
+import { seedAppRow } from "../src/testing/seed-app-row.js";
 import type { FloorDependencies } from "../src/checking/deps.js";
 import { blocks } from "../src/checking/floor.js";
 import { wireCompileOptionsFor } from "../src/wire-options.js";

--- a/packages/apps/tests/placement-rows.test.ts
+++ b/packages/apps/tests/placement-rows.test.ts
@@ -5,7 +5,7 @@ import {
   placementStore,
   type PlacementRow,
 } from "../src/placements.js";
-import { memoryStore } from "../src/testing/index.js";
+import { memoryStore } from "../src/testing/memory-store.js";
 
 const row = (slot: string, appId: string, placedAt = "2026-08-05T12:00:00.000Z"): PlacementRow =>
   ({ slot, appId, placedBy: "user_ada", placedAt });

--- a/packages/apps/tests/placement-runtime.test.ts
+++ b/packages/apps/tests/placement-runtime.test.ts
@@ -7,15 +7,11 @@ import {
   placementStore,
 } from "../src/placements.js";
 import { seedGrantRows, storeAccessFixture } from "./app-access-fixture.js";
-import {
-  authoringAssembler,
-  basicLanguageModel,
-  guardFixture,
-  memoryStore,
-  scriptedAssembler,
-  scriptedLanguageModel,
-  seedAppRow,
-} from "../src/testing/index.js";
+import { authoringAssembler, scriptedAssembler } from "../src/testing/authoring-assembler.js";
+import { guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { basicLanguageModel, scriptedLanguageModel } from "../src/testing/scripted-model.js";
+import { seedAppRow } from "../src/testing/seed-app-row.js";
 
 const ctx: RunContext = {
   principal: { kind: "user", subject: "user_ada" },

--- a/packages/apps/tests/read-graded-call.test.ts
+++ b/packages/apps/tests/read-graded-call.test.ts
@@ -2,7 +2,9 @@ import type { AppDocument, RunContext, ToolCall, ToolDescriptor, ToolRegistry } 
 import { VENDO_APP_FORMAT } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
 import { createApps } from "../src/index.js";
-import { guardFixture, memoryStore, seedAppRow } from "../src/testing/index.js";
+import { guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { seedAppRow } from "../src/testing/seed-app-row.js";
 
 /**
  * A READ through `apps.call` takes the QUERY arm.

--- a/packages/apps/tests/rebase.test.ts
+++ b/packages/apps/tests/rebase.test.ts
@@ -4,14 +4,11 @@ import { createAppHistory } from "../src/history.js";
 import { createApps, type AppsRuntime, type PinBaseline } from "../src/index.js";
 import { detectPinDrift, pinComponentName } from "../src/pins.js";
 import { appVersionHash } from "../src/version-hash.js";
-import {
-  basicLanguageModel,
-  guardFixture,
-  memoryStore,
-  scriptedAssembler,
-  seedAppRow,
-  type AssemblerAnswer,
-} from "../src/testing/index.js";
+import { scriptedAssembler, type AssemblerAnswer } from "../src/testing/authoring-assembler.js";
+import { guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { basicLanguageModel } from "../src/testing/scripted-model.js";
+import { seedAppRow } from "../src/testing/seed-app-row.js";
 
 const ctx: RunContext = {
   principal: { kind: "user", subject: "user_rebase" },

--- a/packages/apps/tests/redaction.test.ts
+++ b/packages/apps/tests/redaction.test.ts
@@ -4,15 +4,12 @@ import { describe, expect, it } from "vitest";
 import { createMachineLane } from "../src/box-lane.js";
 import { createApps, type AppsConfig } from "../src/index.js";
 import { collectSecretValues, redactSecretJson, redactSecretText } from "../src/redaction.js";
-import {
-  basicLanguageModel,
-  fakeBoxSandbox,
-  fakeStatefulSandbox,
-  guardFixture,
-  memoryStore,
-  seedAppRow,
-  type FakeBoxAgent,
-} from "../src/testing/index.js";
+import { fakeBoxSandbox, type FakeBoxAgent } from "../src/testing/fake-box.js";
+import { fakeStatefulSandbox } from "../src/testing/fake-sandbox-stateful.js";
+import { guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { basicLanguageModel } from "../src/testing/scripted-model.js";
+import { seedAppRow } from "../src/testing/seed-app-row.js";
 
 const STRIPE_VALUE = "vendo_fixture_4eC39HqLyjWDarjtT1zdp7dc";
 

--- a/packages/apps/tests/review.test.ts
+++ b/packages/apps/tests/review.test.ts
@@ -4,7 +4,11 @@ import { createInClientApprovals } from "../src/inclient.js";
 import { createApps, type AppsRuntime } from "../src/index.js";
 import { pinComponentName, type PinBaseline } from "../src/pins.js";
 import { createReviewLifecycle } from "../src/review.js";
-import { basicLanguageModel, guardFixture, memoryStore, scriptedAssembler, seedAppRow } from "../src/testing/index.js";
+import { scriptedAssembler } from "../src/testing/authoring-assembler.js";
+import { guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { basicLanguageModel } from "../src/testing/scripted-model.js";
+import { seedAppRow } from "../src/testing/seed-app-row.js";
 import { appVersionHash } from "../src/version-hash.js";
 
 const tools: ToolRegistry = {

--- a/packages/apps/tests/runtime.e2e.test.ts
+++ b/packages/apps/tests/runtime.e2e.test.ts
@@ -7,11 +7,9 @@ import {
 import { zipSync } from "fflate";
 import { describe, expect, it } from "vitest";
 import { createApps } from "../src/index.js";
-import {
-  guardFixture,
-  memoryStore,
-  seedAppRow,
-} from "../src/testing/index.js";
+import { guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { seedAppRow } from "../src/testing/seed-app-row.js";
 
 /**
  * E2E of ownership/interchange authority (06-apps §7, 01-core §10), exercised

--- a/packages/apps/tests/screen-route.test.ts
+++ b/packages/apps/tests/screen-route.test.ts
@@ -25,9 +25,12 @@
 import type { AppId, RunContext, ScreenAssembler, ScreenRequest, ToolRegistry, VendoViewPart } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
 import { createAgentTools } from "../src/agent-tools.js";
+import { authoringAssembler, scriptedAssembler } from "../src/testing/authoring-assembler.js";
 import { fakeBoxSandbox } from "../src/testing/fake-box.js";
+import { guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { basicLanguageModel } from "../src/testing/scripted-model.js";
 import { createApps, type AppsRuntime } from "../src/index.js";
-import { authoringAssembler, basicLanguageModel, guardFixture, memoryStore, scriptedAssembler } from "../src/testing/index.js";
 
 const ctx: RunContext = {
   principal: { kind: "user", subject: "user_screen" },

--- a/packages/apps/tests/security/app-data-isolation.test.ts
+++ b/packages/apps/tests/security/app-data-isolation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createAppData } from "../../src/app-data.js";
-import { memoryStore } from "../../src/testing/index.js";
+import { memoryStore } from "../../src/testing/memory-store.js";
 
 // Red-team suite for per-app state isolation (06-apps §6).
 // App state is keyed by the TRUSTED appId (derived from the run token / ctx in the

--- a/packages/apps/tests/security/interchange-authority.test.ts
+++ b/packages/apps/tests/security/interchange-authority.test.ts
@@ -3,12 +3,10 @@ import { VENDO_APP_FORMAT } from "@vendoai/core";
 import { zipSync } from "fflate";
 import { describe, expect, it } from "vitest";
 import { createApps } from "../../src/index.js";
-import {
-  fakeSandbox,
-  guardFixture,
-  memoryStore,
-  scriptedLanguageModel,
-} from "../../src/testing/index.js";
+import { fakeSandbox } from "../../src/testing/fake-sandbox.js";
+import { guardFixture } from "../../src/testing/guard-fixture.js";
+import { memoryStore } from "../../src/testing/memory-store.js";
+import { scriptedLanguageModel } from "../../src/testing/scripted-model.js";
 
 // Red-team suite for the .vendoapp interchange boundary (06-apps §7).
 // Import is COPY-ONLY: a document is untrusted data, never authority (01-core §10).

--- a/packages/apps/tests/served-apps.test.ts
+++ b/packages/apps/tests/served-apps.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it } from "vitest";
 import { createAppHistory } from "../src/history.js";
 import { createApps } from "../src/index.js";
 import { fakeBoxSandbox, type FakeBoxAgent } from "../src/testing/fake-box.js";
-import { basicLanguageModel, guardFixture, memoryStore, seedAppRow } from "../src/testing/index.js";
+import { guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { basicLanguageModel } from "../src/testing/scripted-model.js";
+import { seedAppRow } from "../src/testing/seed-app-row.js";
 
 /**
  * execution-v2 Wave 4 — layer 3 (machine-everything), experimental, on the

--- a/packages/apps/tests/served-orgs.test.ts
+++ b/packages/apps/tests/served-orgs.test.ts
@@ -8,7 +8,9 @@ import {
 import { describe, expect, it } from "vitest";
 import { createApps, type AppsConfig, type AppsRuntime, type BoxRequest } from "../src/index.js";
 import { fakeBoxSandbox } from "../src/testing/fake-box.js";
-import { guardFixture, memoryStore, seedAppRow } from "../src/testing/index.js";
+import { guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { seedAppRow } from "../src/testing/seed-app-row.js";
 import { storeAccessFixture, seedGrantRows } from "./app-access-fixture.js";
 
 /**

--- a/packages/apps/tests/tool-shapes.test.ts
+++ b/packages/apps/tests/tool-shapes.test.ts
@@ -18,7 +18,9 @@ import {
 import { describe, expect, it } from "vitest";
 import { toolLine } from "../src/automation-plan.js";
 import { createApps } from "../src/index.js";
-import { guardFixture, memoryStore, scriptedLanguageModel } from "../src/testing/index.js";
+import { guardFixture } from "../src/testing/guard-fixture.js";
+import { memoryStore } from "../src/testing/memory-store.js";
+import { scriptedLanguageModel } from "../src/testing/scripted-model.js";
 
 const ctx: RunContext = {
   principal: { kind: "user", subject: "user_shapes" },


### PR DESCRIPTION
The published surface of `@vendoai/apps` shrinks to what real consumers import.
Two items, verified by fresh greps across `packages/`, `examples/`, `fixtures/`,
`corpus/`, `genbench/` and `scripts/`, plus both of the package's typecheck
configs.

## A — `@vendoai/apps/testing` exports 3 names, down from 32

Three fixtures are imported outside this package:

| export | importers |
| --- | --- |
| `inMemoryBoxFiles` | `packages/vendo/tests/{app-rebuild.e2e,server-agent-seam,box-wire,served-apps-wire,box-inference}.test.ts` |
| `scriptedLanguageModel` | `fixtures/automations-e2e/tests/{agentic-consent,automation-refusal}.e2e.test.ts` |
| `ScriptedModelCall` | `fixtures/automations-e2e/tests/automation-refusal.e2e.test.ts` |

The barrel now exports exactly those. Nothing else was needed for declaration
emit: `inMemoryBoxFiles` returns `SandboxMachine["files"]` (already public) and
`scriptedLanguageModel` returns `ai`'s `LanguageModel`.

The other 29 fixtures still exist — they are this package's own. Its ~45 test
files now import the module a fixture lives in (`../src/testing/guard-fixture.js`)
instead of going through the published barrel. No second barrel, and no fixture
is published just because a test wanted it.

## B — 11 free-floating root type exports deleted

Rule applied: a type referenced, directly or transitively, by `AppsRuntime`,
`AppsConfig`, or the signature of a kept exported value/schema stays exported —
otherwise a consumer cannot name what the API hands them. Everything else in the
dead list goes.

| type | verdict |
| --- | --- |
| `AuthoredAppResult` | KEPT — anchor: `AppsRuntime.authored` return |
| `EditFailure` | KEPT — anchor: `EditResult.failure` (`EditResult` is imported by `packages/vendo`) |
| `BuildEnvContext` | KEPT — anchor: `buildEnv(app, ctx)` parameter |
| `BuiltBoxEnv` | KEPT — anchor: `buildEnv` return |
| `InferenceResolver` | KEPT — anchor: `BuildEnvContext.inference` |
| `AppMachineStatus` | KEPT — anchor: `AppsRuntime.machine.report` return |
| `ManifestTriggerResult` | DELETED — free-floating |
| `ManifestTriggerSync` | DELETED — free-floating |
| `PublishRecord` | KEPT — anchor: `AppsRuntime.publish` return (LIVE door) |
| `ShareSnapshot` | KEPT — anchor: `AppsRuntime.share` return (LIVE door) |
| `ReviewStanding` | KEPT — anchor: `InClientVenueState` (imported by `packages/vendo`) |
| `RemixRejection` | KEPT — anchor: `AppsRuntime.review.reject` return |
| `ReviewQueueEntry` | KEPT — anchor: `AppsRuntime.review.queue` return |
| `ShipDiffGenerated` | KEPT — anchor: `ShipDiff.generated` ← `AppsRuntime.inClient.shipDiff` |
| `ShipDiffPin` | KEPT — anchor: `ShipDiff.pins` ← `AppsRuntime.inClient.shipDiff` |
| `Skeleton` | KEPT — anchor: `skeletonFromPlan` return |
| `AutomationPlan` | KEPT — anchor: `planAutomation` return (`AutomationPlanResult`) |
| `GeneratedAppDocument` | DELETED — free-floating |
| `GenerationDependencies` | KEPT — anchor: `AppsConfig.pipeline` is `GenerationDependencies["pipeline"]` |
| `VendoManifest` | DELETED — free-floating |
| `VendoManifestSchedule` | DELETED — free-floating |
| `PlacementRow` | DELETED — free-floating |
| `PlacementStore` | DELETED — free-floating |
| `PlacementEntry` | KEPT — anchor: `AppsRuntime.placements` return |
| `PinForkInput` | KEPT — anchor: `AppsRuntime.pins.fork` parameter |
| `PinForkResult` | KEPT — anchor: `AppsRuntime.pins.fork` return |
| `Check` | DELETED — `@vendoai/core` re-export |
| `CheckInput` | DELETED — `@vendoai/core` re-export |
| `CheckingLayer` | DELETED — free-floating |
| `Finding` | DELETED — `@vendoai/core` re-export |

19 kept, 11 deleted.

Notes on the two judgment calls:

- **`ManifestTriggerResult` / `ManifestTriggerSync`** were anchored to
  `AppsRuntime.machine.syncManifest`, which was retired in an earlier cleanup;
  the index comment still claimed the anchor existed. `createManifestTriggers`
  is internal (`runtime-context.ts`), so no public door hands either shape out.
- **`Check` / `CheckInput` / `Finding`** are `export type { … } from "@vendoai/core"`
  (`checking/types.ts`), and core publishes them from its root
  (`export * from "./capability.js"`). `AppsConfig.checks: readonly Check[]` is
  still fully nameable — a host imports `Check` from core, which is where every
  real consumer already gets it and where a pack has to be authorable from
  anyway. `AppsConfig.checks`' doc comment now says so.

## Gate

`pnpm build` ✅ · `pnpm test:affected` ✅ (36/36 tasks) · `pnpm typecheck` ✅
(42/42) · `pnpm lint` ✅. No UI surface touched.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shrinks the public surface of `@vendoai/apps` to what real consumers use. The testing subpath now exposes 3 fixtures, and 11 unused root type exports are removed to reduce API noise.

- **Refactors**
  - `@vendoai/apps/testing` now exports only: `inMemoryBoxFiles`, `scriptedLanguageModel`, `ScriptedModelCall` (down from 32).
  - Removed 11 unanchored root type exports, including `ManifestTriggerResult`, `ManifestTriggerSync`, `VendoManifest`, `VendoManifestSchedule`, `PlacementRow`, `PlacementStore`, `GeneratedAppDocument`, `CheckingLayer`, and the re-exports `Check`, `CheckInput`, `Finding` (import these from `@vendoai/core`).
  - All types referenced by `AppsRuntime`, `AppsConfig`, or other kept public signatures remain exported.

- **Migration**
  - If you imported `Check`, `CheckInput`, or `Finding` from `@vendoai/apps`, import them from `@vendoai/core`.
  - Only the three listed fixtures are public under `@vendoai/apps/testing`. If you used any other fixture, replace it with your own test double.

<sup>Written for commit fa87baaec8067d51916e4914e1dd77991aaa59ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

