### PR TITLE
test: rot-proof the doctor e2e against npm version drift

### DIFF
--- a/packages/vendo/tests/cli/doctor-mcp-discovery.e2e.test.ts
+++ b/packages/vendo/tests/cli/doctor-mcp-discovery.e2e.test.ts
@@ -125,7 +125,11 @@ describe("vendo doctor MCP discovery live", () => {
       liveTurn: async () => ({ attempted: true, ok: true, rung: "env-key", credential: "stub", reply: "ok", elapsedMs: 1 }),
       cloudProbe: async () => ({ present: false, ok: false, unlocks: ["x"] }),
     })).toBe(0);
-    expect(errors).toEqual([]);
+    // The npm `latest` lookup stays live, but its hint fires whenever the
+    // published version runs ahead of the workspace one — true on every
+    // release, and nothing to do with MCP discovery. Drop that one class only:
+    // `broken:` lines and every other `warning:` still have to be absent.
+    expect(errors.filter((line) => !/^warning: installed @vendoai\/vendo .+ is behind latest /.test(line))).toEqual([]);
     expect(logs).toContain("ok: server.json remote agrees with the live MCP door");
   }, 180_000);
 });


### PR DESCRIPTION
## What

One test fix. `tests/cli/doctor-mcp-discovery.e2e.test.ts` asserts `errors` is empty, but the doctor's live registry check legitimately emits `warning: installed @vendoai/vendo X is behind latest Y` whenever the published version drifts ahead of the workspace — i.e., the test breaks on every release and heals when versions realign. It passes on main today only because 0.9.0 just shipped.

The fix filters exactly that one warning class before the empty-check; every other `broken:`/`warning:` line remains fully asserted, and version-skew behavior keeps its dedicated owner suite (`tests/cli/doctor-version-skew.test.ts`, run green alongside). The live registry call is kept — no mock.

Proven both ways: with drift simulated the old assertion reproduces the reported failure; with drift simulated **plus** an injected fake discovery failure, the fixed assertion still fails on the real error (the filter does not over-swallow).

## Context

Originally scoped to fix six `test:affected` failures, but #1088 had already handled the other five (docs-orphaned doc-sync tests and the knowledge eval, dropped per Yousef's call). This is the remainder.

## Testing

`packages/vendo`: the 4 touched/owner test files — 20/20 green (capped workers). Package typecheck clean, root build 21/21, root lint green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the doctor MCP discovery e2e by filtering the expected npm “installed `@vendoai/vendo` X is behind latest Y” warning from the error list, so releases don’t break the test. The live registry lookup stays; all other “broken:” and “warning:” lines must still be absent.

<sup>Written for commit 3484f54a2960199377b0fe9ec8caa073b7749e25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

