### PR TITLE
refactor(harnesses): rehome claude-turn — the claude-code driver leaves @vendoai/apps entirely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ docs/verification/w4-pipeline/samples.ndjson
 # throwaway design exploration (never committed)
 design-canvas/
 packages/apps/box/claude-turn.mjs
+packages/apps/box/turn-routes.mjs
 
 # Agent working notes and factory process exhaust — useful locally, not shipped.
 # Lane contracts, raw proof logs, and eval run dumps stay on their branches.

--- a/genbench/src/claude-code.ts
+++ b/genbench/src/claude-code.ts
@@ -19,8 +19,8 @@ import { worldBlock } from "./vendo.js";
 import type { Case, World } from "./world.js";
 
 /** The bits of the Agent SDK this driver uses. Narrow on purpose, exactly as
- *  `packages/apps/src/claude-turn.ts` keeps it: the real message union has ~40
- *  members and this loop branches on one. */
+ *  `packages/harnesses/src/claude-code/claude-turn.ts` keeps it: the real
+ *  message union has ~40 members and this loop branches on one. */
 export interface AgentSdk {
   query(params: {
     prompt: string;

--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -3,7 +3,14 @@
  * slot left unset (adapter rule, no second code paths), an explicit adapter
  * always wins, and every failure is a boot error with a way out.
  */
-import type { SandboxAdapter, SandboxMachine } from "@vendoai/apps";
+import {
+  HOT_PATH_WATCH,
+  hotPathAppId,
+  repairInstruction,
+  validateWrittenApps,
+  type SandboxAdapter,
+  type SandboxMachine,
+} from "@vendoai/apps";
 import { e2bSandbox } from "@vendoai/apps/e2b";
 import { selectSandbox } from "@vendoai/apps/sandbox-ladder";
 import {
@@ -261,6 +268,14 @@ export function agent(config: AgentConfig): VendoAgent {
   provideHarnessAdapters(config.harness, {
     ...(sandbox === undefined ? {} : { sandbox }),
     ...(door === undefined ? {} : { toolDoor: door.port }),
+    // The app-document vocabulary a machine-backed driver needs (the hot-path
+    // watch set and the validate gate) — injected because `@vendoai/harnesses`
+    // no longer imports `@vendoai/apps`. Same fill as the umbrella's
+    // (`packages/vendo/src/harness-turn.ts`), so both composed paths stay
+    // byte-identical to when the driver imported these itself.
+    hotPaths: { watch: HOT_PATH_WATCH, appId: hotPathAppId },
+    validateApps: validateWrittenApps,
+    repairInstruction,
   });
   const liveTurn: SessionDeps["liveTurn"] = door === undefined
     ? undefined

--- a/packages/agents/tests/door.test.ts
+++ b/packages/agents/tests/door.test.ts
@@ -7,7 +7,7 @@
  * door port existing at all. Anything that mocks one side of that reproduces
  * the bug with a green suite, so the seam is driven whole here: the REAL
  * `agent()`, the REAL `claudeCode()` driver, the REAL box control-port wire
- * (`@vendoai/apps/box-door`), the REAL MCP door this package mounts, and the
+ * (`@vendoai/harnesses/box-door`), the REAL MCP door this package mounts, and the
  * REAL `createClaudeSession` the box hands the credential to. The two things
  * scripted are the ones a unit test genuinely cannot run: the e2b provider and
  * the Agent SDK.
@@ -18,8 +18,8 @@ import path from "node:path";
 import type { SandboxAdapter, SandboxMachine } from "@vendoai/apps";
 // The REAL box door and the REAL in-box session opener, over a fake transport:
 // what the box does with `toolDoor` is the other half of this seam.
-import { createSessionRoutes } from "@vendoai/apps/box-door";
-import { createClaudeSession, VENDO_MCP_SERVER } from "@vendoai/apps/claude-turn";
+import { createSessionRoutes } from "@vendoai/harnesses/box-door";
+import { createClaudeSession, VENDO_MCP_SERVER } from "@vendoai/harnesses/claude-turn";
 import { harnessAdapters } from "@vendoai/harnesses";
 import { createStore } from "@vendoai/store";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/agents/tsconfig.test.json
+++ b/packages/agents/tsconfig.test.json
@@ -5,7 +5,7 @@
     "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
     "noEmit": true,
-    // `tests/door.test.ts` imports `@vendoai/apps/box-door`, whose export map
+    // `tests/door.test.ts` imports `@vendoai/harnesses/box-door`, whose export map
     // points at the zero-dependency `box/turn-routes.mjs` control-port runtime
     // and carries no `types`. There is no `.js` under `src` or `tests`, so this
     // widens nothing else.

--- a/packages/apps/box/README.md
+++ b/packages/apps/box/README.md
@@ -17,6 +17,13 @@ code, runs it, curls its own endpoints, and reports a structured result.
   npm-installed into `/opt/vendo-box/node_modules` at **template-build time**,
   so install size is a template concern, never a wake concern.
 - `build-template.mjs` — the e2b template builder (the recipe).
+- The conversational session door and its SDK loop — `turn-routes.mjs` and
+  `claude-turn.mjs` — are baked from `@vendoai/harnesses` (the claude-code
+  driver owns its box-side half): the routes from that package's
+  `box/turn-routes.mjs`, the runner from its compiled
+  `dist/claude-code/claude-turn.js`, both staged in here at bake time for the
+  e2b `copy()` reason below. The supervisor delegates every `/session/*`
+  request to them.
 - The universal app template — Vite + React 19 with `@vendoai/ui` installed —
   is baked from `packages/box-template` (staged in here at bake time, for the
   same e2b `copy()` reason as `claude-turn.mjs`). It lands at

--- a/packages/apps/box/build-template.mjs
+++ b/packages/apps/box/build-template.mjs
@@ -41,10 +41,17 @@ const PKG_DIR = "/opt/vendo-box/pkg";
 // e2b resolves every copy() source against THIS SCRIPT's directory, and a
 // source that climbs out of it fails the build before it starts (measured
 // 2026-08-01: `../dist/...` → TemplateError; chdir does not move the base).
-// The compiled turn runner is therefore STAGED in beside the harness files and
-// removed again below — it is a build artifact, and .gitignore says so.
+// The session-door files are therefore STAGED in beside the harness files and
+// removed again below — build artifacts, and .gitignore says so. Both live in
+// `@vendoai/harnesses` (the claude-code driver owns its box-side half): the
+// runner is that package's compiled `dist/claude-code/claude-turn.js`, the
+// session routes its shipped `box/turn-routes.mjs`. Run `pnpm build` before
+// this script so harnesses' dist is current — the same precondition the
+// `pnpm pack` of core and ui below already imposes.
 process.chdir(here);
 const STAGED_RUNNER = "claude-turn.mjs";
+const STAGED_SESSION_ROUTES = "turn-routes.mjs";
+const HARNESSES_DIR = path.join(here, "../../harnesses");
 
 // ─── the app template, staged in for the same e2b reason ─────────────────────
 //
@@ -60,15 +67,17 @@ const stagedTemplate = path.join(here, STAGED_TEMPLATE);
 const stagedPkg = path.join(here, STAGED_PKG);
 const cleanStaged = () => {
   rmSync(path.join(here, STAGED_RUNNER), { force: true });
+  rmSync(path.join(here, STAGED_SESSION_ROUTES), { force: true });
   rmSync(stagedTemplate, { recursive: true, force: true });
   rmSync(stagedPkg, { recursive: true, force: true });
 };
 
 cleanStaged();
-// Stage the compiled turn runner AFTER cleanStaged() — it removes STAGED_RUNNER,
-// so staging it before the clean (as this script originally did) left the build
-// with no claude-turn.mjs to copy.
-copyFileSync(path.join(here, "../dist/claude-turn.js"), path.join(here, STAGED_RUNNER));
+// Stage the session-door files AFTER cleanStaged() — it removes them, so staging
+// before the clean (as this script originally did) left the build with no
+// claude-turn.mjs to copy.
+copyFileSync(path.join(HARNESSES_DIR, "dist/claude-code/claude-turn.js"), path.join(here, STAGED_RUNNER));
+copyFileSync(path.join(HARNESSES_DIR, "box/turn-routes.mjs"), path.join(here, STAGED_SESSION_ROUTES));
 const skipped = new Set(["node_modules", "dist", "package-lock.json"]);
 cpSync(SOURCE_TEMPLATE, stagedTemplate, {
   recursive: true,
@@ -137,11 +146,11 @@ const template = Template()
   .copy("harness.mjs", "/opt/vendo-box/harness.mjs", { user: "root" })
   .copy("agent-sdk.mjs", "/opt/vendo-box/agent-sdk.mjs", { user: "root" })
   .copy("bootstrap.mjs", "/opt/vendo-box/bootstrap.mjs", { user: "root" })
-  // Wave 2 lane E — the conversational turn door and the SDK loop behind it.
-  // `claude-turn.mjs` is the COMPILED `packages/apps/src/claude-turn.ts`, the
-  // same module `machine: "local"` runs on the host: one implementation, two
-  // homes. Run `pnpm build` before this script so dist/ is current.
-  .copy("turn-routes.mjs", "/opt/vendo-box/turn-routes.mjs", { user: "root" })
+  // Wave 2 lane E — the conversational turn door and the SDK loop behind it,
+  // both staged in from `@vendoai/harnesses` above. `claude-turn.mjs` is the
+  // COMPILED `packages/harnesses/src/claude-code/claude-turn.ts`, the same
+  // module `machine: "local"` runs on the host: one implementation, two homes.
+  .copy(STAGED_SESSION_ROUTES, "/opt/vendo-box/turn-routes.mjs", { user: "root" })
   .copy(STAGED_RUNNER, "/opt/vendo-box/claude-turn.mjs", { user: "root" })
   // The materialized workspace's home. It is emptied and rewritten every turn,
   // so the SDK's session deliberately stays at its $HOME default — the snapshot

--- a/packages/apps/box/harness.mjs
+++ b/packages/apps/box/harness.mjs
@@ -35,7 +35,6 @@ import { appendFileSync, mkdirSync, readFileSync, statSync, writeFileSync } from
 import http from "node:http";
 import path from "node:path";
 import { runAgentTask as defaultRunAgentTask } from "./agent-sdk.mjs";
-import { createSessionRoutes } from "./turn-routes.mjs";
 
 const RESPAWN_DELAY_MS = 1_000;
 const RUN_WATCH_INTERVAL_MS = 2_000;
@@ -242,12 +241,26 @@ export const createHarness = (options = {}) => {
 
   // Wave 2 lane E — the conversational door beside the layer-3 builder's. Same
   // control port, same supervisor, a different kind of turn.
-  const turnRoutes = options.turnRoutes ?? createSessionRoutes({ env: boundaryEnv() });
+  //
+  // Loaded LAZILY, on the first /session request, because the module's repo home
+  // is `@vendoai/harnesses` (the claude-code driver owns its box-side half) and
+  // `build-template.mjs` stages it in beside this file only at image bake. A
+  // static import would fail in the monorepo, where this supervisor's own tests
+  // run; in the image the file is always there, staged by the same build that
+  // staged this one. The "/session" prefix mirrors the module's own `owns()`.
+  let turnRoutes = options.turnRoutes;
+  const sessionRoutes = async () => {
+    if (turnRoutes === undefined) {
+      const { createSessionRoutes } = await import("./turn-routes.mjs");
+      turnRoutes = createSessionRoutes({ env: boundaryEnv() });
+    }
+    return turnRoutes;
+  };
 
   const handle = async (request, response) => {
     const url = new URL(request.url ?? "/", "http://box.internal");
     const route = `${request.method} ${url.pathname}`;
-    if (turnRoutes.owns(url.pathname)) {
+    if (url.pathname.startsWith("/session")) {
       let payload;
       try {
         const body = await readBody(request);
@@ -256,7 +269,7 @@ export const createHarness = (options = {}) => {
         sendJson(response, 400, { error: "body must be JSON" });
         return;
       }
-      const answer = await turnRoutes.handle(request.method, url.pathname, request.headers, payload);
+      const answer = await (await sessionRoutes()).handle(request.method, url.pathname, request.headers, payload);
       sendJson(response, answer.status, answer.body);
       return;
     }

--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -50,13 +50,6 @@
     "./internal": {
       "types": "./dist/internal.d.ts",
       "default": "./dist/internal.js"
-    },
-    "./claude-turn": {
-      "types": "./dist/claude-turn.d.ts",
-      "default": "./dist/claude-turn.js"
-    },
-    "./box-door": {
-      "default": "./box/turn-routes.mjs"
     }
   },
   "files": [

--- a/packages/apps/src/internal.ts
+++ b/packages/apps/src/internal.ts
@@ -18,7 +18,7 @@ export { stripServerAuthoritativeFields } from "./open.js";
 export { createAppFloor, type AppFloorOptions } from "./checking/floor.js";
 
 /**
- * The Claude Agent SDK turn lives at `@vendoai/apps/claude-turn`, NOT here.
+ * The Claude Agent SDK turn lives at `@vendoai/harnesses/claude-turn`, NOT here.
  *
  * This subpath rides every composed host's server path (the render seam and
  * this file share a module graph). Re-exporting the SDK turn from

--- a/packages/apps/tests/sdk-absent.e2e.test.ts
+++ b/packages/apps/tests/sdk-absent.e2e.test.ts
@@ -1,0 +1,81 @@
+/**
+ * D1, the APPS half — a consumer who has NOT installed the ~250MB Agent SDK
+ * can still import this package.
+ *
+ * The measured failure this pins: `@vendoai/apps/internal` re-exported the SDK
+ * turn, the render seam imports `./internal` statically on every composed
+ * host's server path, and a bundler that folds `import(CONST)` therefore
+ * demanded `@anthropic-ai/claude-agent-sdk` at BUILD time from a Next.js host
+ * that had no reason to install it. The turn runner has since moved to
+ * `@vendoai/harnesses` (claude-code/claude-turn.ts), which carries its own
+ * half of this pin (`tests/claude-code/sdk-absent.e2e.test.ts`) — the halves
+ * are split per package because each probes its OWN dist, and only a
+ * package's own test task is guaranteed to run after its build.
+ *
+ * Proven in a SUBPROCESS whose module resolver genuinely cannot find the SDK —
+ * an in-workspace test would pass on a hoisted copy and prove nothing. A loader
+ * hook refuses that one specifier and nothing else, which is exactly what a
+ * consumer's node_modules looks like.
+ */
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { afterAll, describe, expect, test } from "vitest";
+
+const PACKAGE_DIR = join(dirname(fileURLToPath(import.meta.url)), "..");
+const dist = (path: string): string => pathToFileURL(join(PACKAGE_DIR, path)).href;
+
+const work = mkdtempSync(join(tmpdir(), "vendo-apps-sdk-absent-"));
+afterAll(() => { rmSync(work, { recursive: true, force: true }); });
+
+/** Refuses exactly one specifier, the way a machine that never installed it does. */
+writeFileSync(join(work, "hide-sdk.mjs"), `
+export async function resolve(specifier, context, next) {
+  if (specifier === "@anthropic-ai/claude-agent-sdk") {
+    const error = new Error("Cannot find package '@anthropic-ai/claude-agent-sdk'");
+    error.code = "ERR_MODULE_NOT_FOUND";
+    throw error;
+  }
+  return next(specifier, context);
+}
+`);
+writeFileSync(join(work, "register.mjs"), `
+import { register } from "node:module";
+register("./hide-sdk.mjs", import.meta.url);
+`);
+
+const runProbe = (body: string): string => {
+  const script = join(work, `probe-${Math.random().toString(36).slice(2)}.mjs`);
+  writeFileSync(script, body);
+  return execFileSync(process.execPath, ["--import", join(work, "register.mjs"), script], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+};
+
+describe("D1 · a host that never installed the Agent SDK", () => {
+  test("the loader hook really does hide it — otherwise the case below is vacuous", () => {
+    const output = runProbe(`
+      try {
+        await import("@anthropic-ai/claude-agent-sdk");
+        console.log("RESOLVED");
+      } catch (error) {
+        console.log("HIDDEN", error.code);
+      }
+    `);
+    expect(output).toContain("HIDDEN ERR_MODULE_NOT_FOUND");
+  });
+
+  test("@vendoai/apps and its cross-block internals both import", () => {
+    const output = runProbe(`
+      const apps = await import(${JSON.stringify(dist("dist/index.js"))});
+      const internal = await import(${JSON.stringify(dist("dist/internal.js"))});
+      if (typeof apps.createApps !== "function") throw new Error("apps did not load");
+      if (typeof internal.assembleTree !== "function") throw new Error("internals did not load");
+      console.log("APPS_OK");
+    `);
+    expect(output).toContain("APPS_OK");
+  });
+});

--- a/packages/harnesses/box/turn-routes.mjs
+++ b/packages/harnesses/box/turn-routes.mjs
@@ -32,6 +32,12 @@
  * Everything interesting about the SDK loop lives in `claude-turn.mjs`, which is
  * the SAME module `machine: "local"` runs on the host — one implementation, two
  * homes.
+ *
+ * This file lives in `@vendoai/harnesses` (the claude-code driver's package —
+ * the box-side half of the session protocol the driver speaks), but it RUNS in
+ * the box: `packages/apps/box/build-template.mjs` stages it into the machine
+ * image beside the supervisor, which delegates every `/session/*` request here.
+ * It imports nothing but node builtins, so it works from either home.
  */
 import { randomUUID } from "node:crypto";
 import { chmodSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -38,10 +38,18 @@
     "./claude-code": {
       "types": "./dist/claude-code/index.d.ts",
       "default": "./dist/claude-code/index.js"
+    },
+    "./claude-turn": {
+      "types": "./dist/claude-code/claude-turn.d.ts",
+      "default": "./dist/claude-code/claude-turn.js"
+    },
+    "./box-door": {
+      "default": "./box/turn-routes.mjs"
     }
   },
   "files": [
     "dist",
+    "box",
     "README.md"
   ],
   "scripts": {
@@ -51,7 +59,6 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@vendoai/apps": "workspace:*",
     "@vendoai/core": "workspace:*",
     "@vendoai/guard": "workspace:*",
     "zod": "^3.25.0"

--- a/packages/harnesses/src/claude-code/claude-turn.ts
+++ b/packages/harnesses/src/claude-code/claude-turn.ts
@@ -6,8 +6,10 @@
  * purpose:
  *
  *   - inside the box, copied into the template as `/opt/vendo-box/claude-turn.mjs`
- *     (`build-template.mjs`), driven by the supervisor's session routes;
- *   - on the host, imported from `dist` for `machine: "local"`.
+ *     (`packages/apps/box/build-template.mjs` stages this package's compiled
+ *     `dist/claude-code/claude-turn.js`), driven by the supervisor's session
+ *     routes (`packages/harnesses/box/turn-routes.mjs`);
+ *   - on the host, imported by `claude-code/local.ts` for `machine: "local"`.
  *
  * **The tools are the HOST's own MCP door now.** They used to be an in-process
  * MCP server this file BUILT — every handler round-tripping to the host over an
@@ -24,14 +26,15 @@
  * itself (the door lists LIVE, so a tool `find_tools` equips mid-conversation
  * needs no session reopen), and the `callTool` port in both drivers.
  *
- * It therefore imports NOTHING from the workspace, and — the rule that matters —
- * it never NAMES the Agent SDK. Whoever supplies the machine supplies the SDK:
- * the box door loads it from the machine image, `machine: "local"` loads it from
- * the optional peer that `@vendoai/harnesses` declares. A module that named the
- * package itself was reachable from every composed host's build graph, and a
- * bundler that folds `import(CONST)` then refused to build a host that has no
- * reason to install a ~250MB platform binary. Keep it that way — the emitted
- * `dist/claude-turn.js` is copied verbatim into a machine image.
+ * It therefore imports NOTHING — not even a sibling in this package — and, the
+ * rule that matters, it never NAMES the Agent SDK. Whoever supplies the machine
+ * supplies the SDK: the box door loads it from the machine image, `machine:
+ * "local"` loads it from the optional peer that `@vendoai/harnesses` declares.
+ * A module that named the package itself was reachable from every composed
+ * host's build graph, and a bundler that folds `import(CONST)` then refused to
+ * build a host that has no reason to install a ~250MB platform binary. Keep it
+ * that way — the emitted `dist/claude-code/claude-turn.js` is copied verbatim
+ * into a machine image.
  *
  * There is no local permission system left (design §3, "claudeCode() specifics";
  * harness-redesign D1). The session runs in `bypassPermissions` because the two
@@ -330,8 +333,8 @@ const PLANNING_TOOL = "TodoWrite";
 /**
  * Everything `query()` is told, once, for the life of the session.
  *
- * A sibling function rather than a sibling MODULE: `dist/claude-turn.js` is
- * copied verbatim into the machine image (module header), so this file has no
+ * A sibling function rather than a sibling MODULE: `dist/claude-code/claude-turn.js`
+ * is copied verbatim into the machine image (module header), so this file has no
  * relative imports to give it.
  */
 function sessionOptions(

--- a/packages/harnesses/src/claude-code/index.ts
+++ b/packages/harnesses/src/claude-code/index.ts
@@ -21,16 +21,26 @@ import {
   type HarnessEvent,
   type Turn,
 } from "@vendoai/core";
-import type { BeatPhase as LoopBeatPhase, ClaudeTurnEvent } from "@vendoai/apps/claude-turn";
+import type { BeatPhase as LoopBeatPhase, ClaudeTurnEvent } from "./claude-turn.js";
 import type { UIMessage } from "ai";
 import { z } from "zod";
 import { defineHarness } from "../define.js";
-import { harnessAdapters, type ToolDoorPort } from "../harness-sandbox.js";
+import { harnessAdapters, type HarnessAdapters } from "../harness-sandbox.js";
 import { checkoutWorkspace, type SyncFile } from "../materialize.js";
-import { HOT_PATH_WATCH, repairInstruction, validateWrittenApps } from "@vendoai/apps";
 import type { SessionMachine } from "./machine.js";
 import { localMachine } from "./local.js";
 import { boxMachine, type SandboxAdapterLike } from "./box.js";
+
+// The session machine's own seams, re-exported for the callers that drive it
+// directly rather than through `claudeCode()`: the umbrella's live box proofs,
+// and a host process that wants to reap idle conversation boxes on shutdown
+// (`disposeLocalSessions` in ./local.js is the `machine: "local"` counterpart).
+export {
+  boxMachine,
+  disposeSessionMachines,
+  type SandboxAdapterLike,
+  type SandboxMachineLike,
+} from "./box.js";
 
 /** The knobs a TURN may still carry (harness-declared; see optionsSchema). */
 export interface ClaudeCodeTurnOptions {
@@ -121,8 +131,14 @@ const optionsSchema = z.object({
 
 /** Host-side dependencies arrive by factory closure (design §3), which is how a
  *  host who did not wire `createVendo({ sandbox })` hands one straight to the
- *  harness. Composition fills the same slot through `provideHarnessAdapters`. */
-export interface ClaudeCodeDeps {
+ *  harness. Composition fills the same slots through `provideHarnessAdapters`;
+ *  an explicitly passed value always wins (the adapter rule). The three apps
+ *  hooks are the app-document vocabulary this package no longer imports —
+ *  `HOT_PATH_WATCH`/`hotPathAppId`, `validateWrittenApps`, `repairInstruction`
+ *  in `@vendoai/apps`. Without them the driver still runs, minus the mid-turn
+ *  hot-path sync and the validate gate ({@link warnNoAppsHooksOnce}). */
+export interface ClaudeCodeDeps
+  extends Pick<HarnessAdapters, "hotPaths" | "validateApps" | "repairInstruction"> {
   sandbox?: SandboxAdapterLike;
 }
 
@@ -341,6 +357,26 @@ function warnNoOriginOnce(): void {
   );
 }
 
+/**
+ * A runtime driven BARE — no composition filled the apps hooks and the host
+ * passed none — loses the mid-turn hot-path sync (skeletons paint at turn end
+ * instead of in seconds) and the end-of-turn validate gate. A deployment fact,
+ * said once, same shape as {@link warnNoOriginOnce}: composed paths always
+ * inject the real implementations, so this only reaches a host driving the
+ * runtime directly.
+ */
+let noAppsHooksWarned = false;
+function warnNoAppsHooksOnce(): void {
+  if (noAppsHooksWarned) return;
+  noAppsHooksWarned = true;
+  console.error(
+    "[vendo] claudeCode() is running without the apps hooks (hotPaths / validateApps / "
+    + "repairInstruction), so mid-turn hot-path sync and the finish-line validate gate are "
+    + "OFF. Compose through createVendo/createAgent to get them, or pass them to claudeCode() "
+    + "directly.",
+  );
+}
+
 /** A callback-driven producer, consumed by the generator that must `yield`. */
 function eventQueue<T>() {
   const buffered: T[] = [];
@@ -395,12 +431,25 @@ export function claudeCode(
         ...(turn.options?.maxTurns === undefined ? {} : { maxTurns: turn.options.maxTurns }),
       };
       const state = readState(turn.state.get());
+      const composed = harnessAdapters(harness);
+
+      // The apps hooks — the hot-path vocabulary and the validate gate, which
+      // used to be value imports from `@vendoai/apps` and now arrive injected:
+      // the constructor's own arg wins, composition fills what the host left
+      // unset (the adapter rule). A runtime driven bare has neither, keeps
+      // running, and the operator hears exactly what it lost, once.
+      const hotPaths = options.hotPaths ?? composed.hotPaths;
+      const validateApps = options.validateApps ?? composed.validateApps;
+      const repairInstruction = options.repairInstruction ?? composed.repairInstruction;
+      if (hotPaths === undefined || validateApps === undefined || repairInstruction === undefined) {
+        warnNoAppsHooksOnce();
+      }
 
       // The DOOR is resolved before the machine, because its origin is part of
       // the box's network boundary and that is fixed at create. Only its
       // deployment half is read here; the per-conversation credential is minted
       // below, once there is a machine to say whether it is carrying a session.
-      const doorPort = harnessAdapters(harness).toolDoor as ToolDoorPort | undefined;
+      const doorPort = composed.toolDoor;
       const doorUrl = doorPort?.url;
       if (doorPort !== undefined && doorUrl === undefined
         && doorPort.autoMounted !== true && resolved.machine !== "local") {
@@ -443,7 +492,7 @@ export function claudeCode(
       if (resolved.machine === "local") {
         machine = await localMachine({ threadId: threadOf(turn), env: boxEnv });
       } else {
-        const sandbox = (options.sandbox ?? harnessAdapters(harness).sandbox) as
+        const sandbox = (options.sandbox ?? composed.sandbox) as
           | SandboxAdapterLike
           | undefined;
         if (sandbox === undefined) {
@@ -479,6 +528,9 @@ export function claudeCode(
         turn.workspace,
         machine.tree,
         !machine.carriesSession,
+        // The injected hot-path vocabulary decides what `syncHot` may land; no
+        // vocabulary, nothing is hot — and nothing collects mid-turn either.
+        (path) => hotPaths?.appId(path) !== undefined,
       );
 
       // The host's MCP door — the ONLY way this harness reaches the world now
@@ -537,9 +589,11 @@ export function claudeCode(
 
         /** Sync on WRITE, not on a tick — the native PostToolUse hook drives this.
          *  Still by SHAPE, because the app whose plan lands first may have an id
-         *  the turn only just invented. */
+         *  the turn only just invented. A no-op on the bare path: no vocabulary,
+         *  no hot set to collect. */
         const syncHot = async (): Promise<void> => {
-          const hot = await machine.collect(HOT_PATH_WATCH);
+          if (hotPaths === undefined) return;
+          const hot = await machine.collect(hotPaths.watch);
           for (const path of await checkout.syncHot(hot)) landed.add(path);
         };
 
@@ -590,7 +644,9 @@ export function claudeCode(
               ? {}
               : { pluginPath: machine.pluginPath, skillNames }),
             emit: (event) => events.push(event),
-            onFileWritten: () => syncHotNow(),
+            // No hook without a vocabulary: a wrote-event with nothing to
+            // collect would round-trip the machine for an empty diff.
+            ...(hotPaths === undefined ? {} : { onFileWritten: () => syncHotNow() }),
             signal: turn.signal,
           }).then(() => events.close(), (error: unknown) => {
             // The thinker failed; the user hears one plain sentence and the turn
@@ -626,10 +682,14 @@ export function claudeCode(
          * not at all, and a second round is the person waiting longer for the same
          * answer. Whatever survives it is reported as it stands — the seam already
          * refuses to paint a lie, so an unfixed app costs a screen, never the truth.
+         *
+         * The gate itself is INJECTED (`validateApps` + `repairInstruction`) —
+         * every composed path supplies the real one; a bare runtime has none,
+         * skips the round, and was warned above.
          */
-        if (!turn.signal.aborted) {
+        if (!turn.signal.aborted && validateApps !== undefined && repairInstruction !== undefined) {
           await serialize(syncHot).catch(() => undefined);
-          const failures = await validateWrittenApps({
+          const failures = await validateApps({
             tools: turn.tools,
             workspace: turn.workspace,
             paths: [...landed],

--- a/packages/harnesses/src/claude-code/local.ts
+++ b/packages/harnesses/src/claude-code/local.ts
@@ -47,20 +47,21 @@ import { chmodSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { VendoError } from "@vendoai/core";
-import type { ClaudeTurnEvent } from "@vendoai/apps/claude-turn";
+import type { ClaudeTurnEvent } from "./claude-turn.js";
 import type { SyncFile, TreeState } from "../materialize.js";
 import { emptyTree, inWritableMount } from "../materialize.js";
 import { MESSAGE_BUDGET_MS, type SessionMachine, type SessionMessage } from "./machine.js";
 
-/** The session runner is shared with the box — one implementation, two homes. Its
- *  OWN subpath, so importing it never drags the render seam's `./internal` in,
- *  and `./internal` never drags this in. */
-const RUNNER = "@vendoai/apps/claude-turn";
+/** The session runner is shared with the box — one implementation, two homes.
+ *  A sibling module in this package now; still loaded lazily below, so a host
+ *  that never opts into `machine: "local"` never evaluates it. */
+const RUNNER = "./claude-turn.js";
 
 /**
  * The SDK, from HERE, because this package declares the optional peer
- * (`@vendoai/apps` declares it too, for the box door) — and this function is
- * the ONLY place in the shipped packages that names it on a host path.
+ * (`@vendoai/apps` declares it too, for the box's layer-3 agent engine) — and
+ * this function is the ONLY place in the shipped packages that names it on a
+ * host path.
  *
  * `turbopackIgnore`/`webpackIgnore` keep it out of a host's BUILD: a bundler
  * that resolves this specifier refuses to build a Next.js host that has not

--- a/packages/harnesses/src/claude-code/machine.ts
+++ b/packages/harnesses/src/claude-code/machine.ts
@@ -13,7 +13,7 @@
  * created — materialize it and re-seed the thread from our transcript) or WARM
  * (its disk already carries both the files and the native session).
  */
-import type { ClaudeTurnEvent } from "@vendoai/apps/claude-turn";
+import type { ClaudeTurnEvent } from "./claude-turn.js";
 import type { CheckoutFile, SyncFile, TreeState } from "../materialize.js";
 
 /**

--- a/packages/harnesses/src/harness-sandbox.ts
+++ b/packages/harnesses/src/harness-sandbox.ts
@@ -19,7 +19,7 @@
  * survive `createUIMessageStream`'s deferral of `execute`, and a slot that is
  * silently empty is exactly the failure mode this file exists to close.
  */
-import type { Harness } from "@vendoai/core";
+import type { AppId, Finding, Harness, TurnTools, WorkspaceFs } from "@vendoai/core";
 
 /**
  * The host's own MCP door, as a harness that runs a MACHINE needs it.
@@ -61,6 +61,34 @@ export interface ToolDoorPort {
   revoke(token: string): void;
 }
 
+/**
+ * The hot-path vocabulary, as a machine-backed driver needs it: which shapes to
+ * watch on the machine's disk mid-turn, and which paths count as hot when the
+ * collected files come home.
+ *
+ * Injected — this package no longer depends on `@vendoai/apps`, where the real
+ * vocabulary (`HOT_PATH_WATCH`, `hotPathAppId`) lives. Composition hands the
+ * driver the real one; a bare host-driven runtime without it simply has no
+ * mid-turn hot sync, and the driver says so once.
+ */
+export interface HotPathsPort {
+  /** Watch shapes for the machine's mid-turn collect (`*` = one segment). */
+  watch: readonly string[];
+  /** The appId a hot-path write belongs to, or undefined if this is not one. */
+  appId(path: string): string | undefined;
+}
+
+/** One app document that did not pass the validate gate — a structural mirror
+ *  of `AppValidationFailure` in `@vendoai/apps` (validate-gate.ts). Restated
+ *  because this package no longer imports apps; the composition site assigns
+ *  the real functions into {@link HarnessAdapters}, so drift between the two
+ *  shapes fails to compile there, by name. */
+export interface AppValidationFailureLike {
+  path: string;
+  appId: AppId;
+  findings: readonly Finding[];
+}
+
 /** The composed adapters a harness may be handed. Mirrors `ComposedAdapters`
  *  (the boot gate's view), plus the MCP door a machine-backed harness needs. */
 export interface HarnessAdapters {
@@ -73,6 +101,19 @@ export interface HarnessAdapters {
    *  subpath); typed loosely for the same reason as `sandbox` — the slot is a
    *  drawer, not a contract. */
   toolSearch?: unknown;
+  /** The hot-path vocabulary (`HOT_PATH_WATCH` + `hotPathAppId` in apps). */
+  hotPaths?: HotPathsPort;
+  /** The builder's validate gate (`validateWrittenApps` in apps). Property
+   *  style, not method style, so `strictFunctionTypes` checks the assignment
+   *  at the composition site in both directions. */
+  validateApps?: (input: {
+    tools: Pick<TurnTools, "call">;
+    workspace: Pick<WorkspaceFs, "readFile">;
+    paths: readonly string[];
+    review?: boolean;
+  }) => Promise<readonly AppValidationFailureLike[]>;
+  /** The gate's failures as one instruction (`repairInstruction` in apps). */
+  repairInstruction?: (failures: readonly AppValidationFailureLike[]) => string | undefined;
 }
 
 const slots = new WeakMap<object, HarnessAdapters>();

--- a/packages/harnesses/src/index.ts
+++ b/packages/harnesses/src/index.ts
@@ -67,4 +67,11 @@ export {
 // relatively. A barrel export with no reader is surface nobody asked for.
 // `harnessAdapters` is the READ side: a harness constructed at boot (the host
 // wrote `harness: claudeCode()`) collects the composed slots at turn time.
-export { harnessAdapters, provideHarnessAdapters, type HarnessAdapters, type ToolDoorPort } from "./harness-sandbox.js";
+export {
+  harnessAdapters,
+  provideHarnessAdapters,
+  type AppValidationFailureLike,
+  type HarnessAdapters,
+  type HotPathsPort,
+  type ToolDoorPort,
+} from "./harness-sandbox.js";

--- a/packages/harnesses/src/materialize.ts
+++ b/packages/harnesses/src/materialize.ts
@@ -26,7 +26,6 @@
  * view, so this file never speaks about views.
  */
 import { createHash } from "node:crypto";
-import { hotPathAppId } from "@vendoai/apps";
 import type { WorkspaceFs } from "@vendoai/core";
 
 /** §3.1's frozen mounts: `/host`, `/user`, and one `/orgs/<org>` per asserted
@@ -41,7 +40,7 @@ const IN_MOUNT = /^\/(?:host|user|orgs\/[^/]+)(?:\/|$)/;
  * A SHAPE, and deliberately not a permission — it is the only question a walk of
  * a real disk can answer, because a disk has no store to ask. Both machines ask
  * it: `claude-code/local.ts` here, and the box door's own copy in
- * `packages/apps/box/turn-routes.mjs`. Whether a carried path may LAND is
+ * `packages/harnesses/box/turn-routes.mjs`. Whether a carried path may LAND is
  * `canCommit`'s, per file, against live rows.
  */
 export const inWritableMount = (path: string): boolean =>
@@ -141,7 +140,7 @@ export interface WorkspaceCheckout {
 
 /**
  * The box door's whole-tree walk skips files over this to protect the proxy's
- * body limit (`packages/apps/box/turn-routes.mjs`), so a machine can report a
+ * body limit (`packages/harnesses/box/turn-routes.mjs`), so a machine can report a
  * checked-out file ABSENT while still holding it. Under the default files
  * store (5 MiB cap) no checked-out file reaches this size; a BYO adapter (s3)
  * has no cap. Absent-means-deleted must not apply to such a file: keeping a
@@ -165,6 +164,13 @@ export async function checkoutWorkspace(
    * the newer state. That is the whole stale-clobber fix.
    */
   reseed = true,
+  /**
+   * Which paths `syncHot` may land — the hot-path vocabulary, injected because
+   * this package no longer imports `@vendoai/apps` (composition hands the driver
+   * `hotPathAppId`; see `HotPathsPort`). Omitted, `syncHot` lands nothing, which
+   * is exactly the bare-runtime deployment where nobody watches hot paths.
+   */
+  isHot: (path: string) => boolean = () => false,
 ): Promise<WorkspaceCheckout> {
   const files: CheckoutFile[] = [];
   const { hashes, oversized } = tree;
@@ -221,7 +227,7 @@ export async function checkoutWorkspace(
       // this is the backstop that makes it true, and it stays a skip so one
       // refused org path can never take the caller's own work down with it.
       if (!(await syncable(path))) continue;
-      if (options.hotOnly && hotPathAppId(path) === undefined) continue;
+      if (options.hotOnly && !isHot(path)) continue;
       const hash = contentHash(entry.bytes);
       if (hashes.get(path) === hash) continue;
       await workspace.writeFile(path, entry.bytes);

--- a/packages/harnesses/src/test-doubles.test-util.ts
+++ b/packages/harnesses/src/test-doubles.test-util.ts
@@ -334,6 +334,32 @@ export function seats(model: LanguageModel): ResolvedModels<LanguageModel> {
   return { default: model, reviewer: model, judge: model, fill: model };
 }
 
+/**
+ * The apps hooks a composed deployment injects into `claudeCode()`
+ * (`provideHarnessAdapters` — see `HarnessAdapters`), as this package's suites
+ * need them: the hot-path vocabulary restated (`HOT_PATH_WATCH` /
+ * `hotPathAppId` in `@vendoai/apps`, which this package no longer imports),
+ * and a validate gate that always passes. The REAL vocabulary and gate joined
+ * to the driver are covered in `packages/vendo/tests/`, where both blocks are
+ * legal.
+ */
+export function testAppsHooks() {
+  const APP_PATH = /^\/(?:user|orgs\/[^/]+)\/apps\/([^/]+)\/(?:app|plan)\.vendo$/;
+  return {
+    hotPaths: {
+      watch: [
+        "/user/apps/*/app.vendo",
+        "/user/apps/*/plan.vendo",
+        "/orgs/*/apps/*/app.vendo",
+        "/orgs/*/apps/*/plan.vendo",
+      ] as readonly string[],
+      appId: (path: string): string | undefined => APP_PATH.exec(path)?.[1],
+    },
+    validateApps: async (): Promise<never[]> => [],
+    repairInstruction: (): string | undefined => undefined,
+  };
+}
+
 export async function readSse(response: Response): Promise<Array<Record<string, unknown>>> {
   const raw = await response.text();
   const blocks = raw.slice(0, -2).split("\n\n");

--- a/packages/harnesses/tests/claude-code/beats-wire.test.ts
+++ b/packages/harnesses/tests/claude-code/beats-wire.test.ts
@@ -7,10 +7,12 @@
  * the two together cover the seam end to end:
  *
  *   scripted SDK stream
- *     → the REAL `createClaudeSession` loop, imported from `dist` — the very file
- *       `build-template.mjs` copies into the machine image
- *     → the REAL box door (`packages/apps/box/turn-routes.mjs`), over a transport
- *       adapter instead of a socket
+ *     → the REAL `createClaudeSession` loop (`src/claude-code/claude-turn.ts`,
+ *       whose compiled dist is what `build-template.mjs` copies into the machine
+ *       image — that the built artifact still imports and exports the loop is
+ *       pinned by `sdk-absent.e2e.test.ts`'s runner probe)
+ *     → the REAL box door (`packages/harnesses/box/turn-routes.mjs`), over a
+ *       transport adapter instead of a socket
  *     → the REAL `box.ts` poll loop and its `message.emit` forward
  *     → the REAL `claude-code/index.ts` queue passthrough
  *     → the REAL harness runtime and the REAL wire writer
@@ -26,8 +28,8 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
 import type { ThreadId } from "@vendoai/core";
-import { createSessionRoutes } from "@vendoai/apps/box-door";
-import { createClaudeSession } from "@vendoai/apps/claude-turn";
+import { createSessionRoutes } from "../../box/turn-routes.mjs";
+import { createClaudeSession } from "../../src/claude-code/claude-turn.js";
 import { createHarnessRuntime } from "../../src/runtime.js";
 import { VENDO_STATUS_PART } from "../../src/wire.js";
 import {

--- a/packages/harnesses/tests/claude-code/box-turn-routes.test.ts
+++ b/packages/harnesses/tests/claude-code/box-turn-routes.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
 // The box door is plain JS shipped into the machine image; the tests drive the
 // real module, with only the SDK session injected.
-import { createSessionRoutes } from "../box/turn-routes.mjs";
+import { createSessionRoutes } from "../../box/turn-routes.mjs";
 
 const TOKEN = "bxt_test";
 const roots: string[] = [];

--- a/packages/harnesses/tests/claude-code/claude-beats.test.ts
+++ b/packages/harnesses/tests/claude-code/claude-beats.test.ts
@@ -16,7 +16,7 @@ import {
   createClaudeSession,
   type BeatPhase,
   type ClaudeTurnEvent,
-} from "../src/claude-turn.js";
+} from "../../src/claude-code/claude-turn.js";
 
 /** One step of a scripted turn: prose, a tool the model used, or both. */
 interface ScriptStep {
@@ -272,14 +272,11 @@ describe("a beat is our copy, never the model's", () => {
  * THE MIRROR SEAM — and where its teeth actually are.
  *
  * `claude-turn.ts` restates core's `BeatPhase` instead of importing it, because
- * that file imports NOTHING (module header: the emitted `dist/claude-turn.js` is
- * copied verbatim into a machine image).
+ * that file imports NOTHING (module header: the emitted
+ * `dist/claude-code/claude-turn.js` is copied verbatim into a machine image).
  *
- * The COMPILE-TIME half of that seam deliberately does not live here. Nothing in
- * this repo typechecks a test file — `packages/apps/tsconfig.json` excludes
- * `src/**` + `*.test.ts`, no package defines a `lint` script, and vitest is not
- * run with `--typecheck` — so a type-level assertion in this file would be pure
- * decoration. It lives in gated production code instead: `BEAT_PHASES` in
+ * The COMPILE-TIME half of that seam deliberately does not live here. It lives
+ * in gated production code instead: `BEAT_PHASES` in
  * `harnesses/src/claude-code/index.ts` fails when CORE gains a phase the mirror
  * lacks, and the `yield` beside it fails in the other direction. Both were
  * verified red by adding a seventh phase to each side in turn.

--- a/packages/harnesses/tests/claude-code/claude-code-local.test.ts
+++ b/packages/harnesses/tests/claude-code/claude-code-local.test.ts
@@ -22,7 +22,7 @@ import type { SessionMachine, SessionMessage } from "../../src/claude-code/machi
 import { emptyTree } from "../../src/materialize.js";
 import { createTurnState } from "../../src/harness-state.js";
 import { provideHarnessAdapters } from "../../src/harness-sandbox.js";
-import { testWorkspace, unusedModels, userMessage } from "../../src/test-doubles.test-util.js";
+import { testAppsHooks, testWorkspace, unusedModels, userMessage } from "../../src/test-doubles.test-util.js";
 
 /** Every message the doubled local machine was sent, in order. */
 const sent: SessionMessage[] = [];
@@ -96,7 +96,7 @@ const doorWarnings = (): string[] => errors.filter((line) => line.includes("[ven
  */
 describe("machine: \"local\" and the MCP door's origin", () => {
   test("a REACHABLE door is handed over, and nothing is said", async () => {
-    const harness = claudeCode({ machine: "local" });
+    const harness = claudeCode({ machine: "local", ...testAppsHooks() });
     provideHarnessAdapters(harness, {
       toolDoor: { url: "http://127.0.0.1:3000/api/vendo/mcp", mint: () => "vtk_ok", revoke: () => undefined },
     });
@@ -108,7 +108,7 @@ describe("machine: \"local\" and the MCP door's origin", () => {
   });
 
   test("NO origin: the operator is warned ONCE, naming the fix, and the turn still runs", async () => {
-    const harness = claudeCode({ machine: "local" });
+    const harness = claudeCode({ machine: "local", ...testAppsHooks() });
     provideHarnessAdapters(harness, {
       toolDoor: { url: undefined, mint: () => "vtk_x", revoke: () => undefined },
     });

--- a/packages/harnesses/tests/claude-code/claude-code.test.ts
+++ b/packages/harnesses/tests/claude-code/claude-code.test.ts
@@ -11,13 +11,13 @@ import {
 } from "@vendoai/core";
 import { afterEach, describe, expect, test, vi } from "vitest";
 // The REAL box door, driven over a fake transport — see the block comment below.
-// A package subpath, not a relative climb: the door is the wire contract between
-// these two blocks, and `harnesses → apps` is a layer-legal edge.
-import { createSessionRoutes } from "@vendoai/apps/box-door";
+// A sibling of the driver since the claude-turn rehome: this package owns the
+// box-side half of the session protocol it speaks.
+import { createSessionRoutes } from "../../box/turn-routes.mjs";
 import { assertHarnessComposable } from "../../src/compose.js";
 import { createTurnState } from "../../src/harness-state.js";
 import { provideHarnessAdapters } from "../../src/harness-sandbox.js";
-import { testWorkspace, unusedModels, userMessage } from "../../src/test-doubles.test-util.js";
+import { testAppsHooks, testWorkspace, unusedModels, userMessage } from "../../src/test-doubles.test-util.js";
 import { boxEgress, claudeCode, inferenceEnv, promptFor, truncated } from "../../src/claude-code/index.js";
 import { boxMachine, disposeSessionMachines, type SandboxAdapterLike, type SandboxMachineLike } from "../../src/claude-code/box.js";
 
@@ -26,14 +26,14 @@ const encoder = new TextEncoder();
 
 /**
  * A stand-in for a REAL box: it speaks the same control-port wire the machine
- * image speaks (`packages/apps/box/turn-routes.mjs`), so what is under test is
+ * image speaks (`packages/harnesses/box/turn-routes.mjs`), so what is under test is
  * our driver and our sync-back — never a mock of our own code. The SDK loop is
  * the one thing scripted, because a unit test cannot run a model.
  */
 /**
  * A stand-in for a real box that speaks the REAL protocol: the fake machine's
  * `request()` is a thin transport adapter over the ACTUAL box door
- * (`packages/apps/box/turn-routes.mjs`), with only the SDK session scripted.
+ * (`packages/harnesses/box/turn-routes.mjs`), with only the SDK session scripted.
  *
  * A hand-written fake let a live BLOCKER hide: it accepted `hello`
  * unconditionally, so it modelled a protocol the real box does not implement.
@@ -1046,7 +1046,10 @@ describe("a turn on a real box wire", () => {
       if (commit !== undefined) { landed = commit.changed; release(); }
     }, 20);
     const guard = setTimeout(release, 8_000);
-    await drain(claudeCode({ sandbox }), turn);
+    // The hot-path vocabulary arrives injected now (composition's job); the
+    // doubles' copy is what makes the mid-turn sync live in this harness-only
+    // suite. The REAL vocabulary joined to the driver: packages/vendo/tests.
+    await drain(claudeCode({ sandbox, ...testAppsHooks() }), turn);
     clearInterval(watcher);
     clearTimeout(guard);
     // ONLY the hot path: the mid-turn sync never drags the rest of the tree along.
@@ -1073,7 +1076,7 @@ describe("a turn on a real box wire", () => {
       if (commit !== undefined) { landed = commit.changed; release(); }
     }, 20);
     const guard = setTimeout(release, 8_000);
-    await drain(claudeCode({ sandbox }), turn);
+    await drain(claudeCode({ sandbox, ...testAppsHooks() }), turn);
     clearInterval(watcher);
     clearTimeout(guard);
     expect(landed).toEqual(["/user/apps/app_brandnew/plan.vendo"]);

--- a/packages/harnesses/tests/claude-code/claude-session.test.ts
+++ b/packages/harnesses/tests/claude-code/claude-session.test.ts
@@ -17,7 +17,7 @@ import {
   VENDO_MCP_SERVER,
   type ClaudeSession,
   type ClaudeTurnEvent,
-} from "../src/claude-turn.js";
+} from "../../src/claude-code/claude-turn.js";
 
 interface ScriptedTurn {
   say?: string;

--- a/packages/harnesses/tests/claude-code/claude-turn.test.ts
+++ b/packages/harnesses/tests/claude-code/claude-turn.test.ts
@@ -6,7 +6,7 @@ import {
   createClaudeSession,
   VENDO_MCP_SERVER,
   type ClaudeTurnEvent,
-} from "../src/claude-turn.js";
+} from "../../src/claude-code/claude-turn.js";
 
 /**
  * A stand-in for the SDK's own stream: it yields the message shapes the real one

--- a/packages/harnesses/tests/claude-code/local-session.test.ts
+++ b/packages/harnesses/tests/claude-code/local-session.test.ts
@@ -14,7 +14,7 @@
  */
 import { describe, expect, test } from "vitest";
 import { localMachine, disposeLocalSessions } from "../../src/claude-code/local.js";
-import type { ClaudeTurnEvent } from "@vendoai/apps/claude-turn";
+import type { ClaudeTurnEvent } from "../../src/claude-code/claude-turn.js";
 
 /** A session double that captures the sinks it was OPENED with, and replays each
  *  `send()` through them — exactly what the real SDK session does. */

--- a/packages/harnesses/tests/claude-code/local-steer-budget.test.ts
+++ b/packages/harnesses/tests/claude-code/local-steer-budget.test.ts
@@ -3,16 +3,16 @@
  * with FEWER results than the session counted wedged the whole thread.
  *
  * **The seam, and why this file doubles the SDK rather than the session.**
- * `createClaudeSession` (`@vendoai/apps/claude-turn`) counts the extra `result`
+ * `createClaudeSession` (`claude-code/claude-turn.ts`) counts the extra `result`
  * messages a steer is expected to produce, and `local.ts` awaits `send()` until
  * one of them settles the turn. Those are a producer and a consumer of the same
  * invariant, and every existing test doubles one of them:
  *
  *   - `local-session.test.ts` doubles the whole `ClaudeSession`, so its `steer`
  *     has no counter at all;
- *   - `claude-session.test.ts` (in `@vendoai/apps`) doubles the SDK with a loop
- *     that yields exactly one `result` per user message it reads — which IS the
- *     counter's assumption, so the double can never disagree with it.
+ *   - `claude-session.test.ts` doubles the SDK with a loop that yields exactly
+ *     one `result` per user message it reads — which IS the counter's
+ *     assumption, so the double can never disagree with it.
  *
  * So the counter's one-sidedness had no honest test anywhere. Here the session is
  * REAL and only the SDK — genuinely a third party — is a double, and it answers
@@ -29,7 +29,7 @@
  * the message budget". The box rung HAS that budget. This rung did not.
  */
 import { describe, expect, test } from "vitest";
-import { createClaudeSession } from "@vendoai/apps/claude-turn";
+import { createClaudeSession } from "../../src/claude-code/claude-turn.js";
 import { disposeLocalSessions, localMachine } from "../../src/claude-code/local.js";
 
 /** Well under the test timeout below: a budget is the hang-detector here, not a

--- a/packages/harnesses/tests/claude-code/sdk-absent.e2e.test.ts
+++ b/packages/harnesses/tests/claude-code/sdk-absent.e2e.test.ts
@@ -22,8 +22,6 @@ import { afterAll, describe, expect, test } from "vitest";
 
 const PACKAGE_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const dist = (path: string): string => pathToFileURL(join(PACKAGE_DIR, path)).href;
-const appsDist = (path: string): string =>
-  pathToFileURL(join(PACKAGE_DIR, "..", "apps", path)).href;
 
 const work = mkdtempSync(join(tmpdir(), "vendo-sdk-absent-"));
 afterAll(() => { rmSync(work, { recursive: true, force: true }); });
@@ -66,17 +64,18 @@ describe("D1 · a host that never installed the Agent SDK", () => {
     expect(output).toContain("HIDDEN ERR_MODULE_NOT_FOUND");
   });
 
-  test("@vendoai/apps, its cross-block internals, and the turn runner itself all import", () => {
+  test("the built turn runner itself imports — the artifact the machine image carries", () => {
+    // Only THIS package's dist: the apps-side halves of the same pin (the apps
+    // root and `./internal` importing SDK-free) live in apps' own suite
+    // (`packages/apps/tests/sdk-absent.e2e.test.ts`), because a test here
+    // reading apps' dist by file path needs apps BUILT, and since the
+    // claude-turn rehome nothing orders apps' build before this suite.
     const output = runProbe(`
-      const apps = await import(${JSON.stringify(appsDist("dist/index.js"))});
-      const internal = await import(${JSON.stringify(appsDist("dist/internal.js"))});
       const runner = await import(${JSON.stringify(dist("dist/claude-code/claude-turn.js"))});
-      if (typeof apps.createApps !== "function") throw new Error("apps did not load");
-      if (typeof internal.assembleTree !== "function") throw new Error("internals did not load");
       if (typeof runner.createClaudeSession !== "function") throw new Error("runner did not load");
-      console.log("APPS_OK");
+      console.log("RUNNER_OK");
     `);
-    expect(output).toContain("APPS_OK");
+    expect(output).toContain("RUNNER_OK");
   });
 
   test("claudeCode() composes with a sandbox and passes the boot gate", () => {

--- a/packages/harnesses/tests/claude-code/sdk-absent.e2e.test.ts
+++ b/packages/harnesses/tests/claude-code/sdk-absent.e2e.test.ts
@@ -70,7 +70,7 @@ describe("D1 · a host that never installed the Agent SDK", () => {
     const output = runProbe(`
       const apps = await import(${JSON.stringify(appsDist("dist/index.js"))});
       const internal = await import(${JSON.stringify(appsDist("dist/internal.js"))});
-      const runner = await import(${JSON.stringify(appsDist("dist/claude-turn.js"))});
+      const runner = await import(${JSON.stringify(dist("dist/claude-code/claude-turn.js"))});
       if (typeof apps.createApps !== "function") throw new Error("apps did not load");
       if (typeof internal.assembleTree !== "function") throw new Error("internals did not load");
       if (typeof runner.createClaudeSession !== "function") throw new Error("runner did not load");

--- a/packages/harnesses/tests/claude-code/situation-staleness.test.ts
+++ b/packages/harnesses/tests/claude-code/situation-staleness.test.ts
@@ -12,7 +12,7 @@
  */
 import { describe, expect, test } from "vitest";
 import { disposeLocalSessions, localMachine } from "../../src/claude-code/local.js";
-import type { ClaudeTurnEvent } from "@vendoai/apps/claude-turn";
+import type { ClaudeTurnEvent } from "../../src/claude-code/claude-turn.js";
 
 /** Records the input of every session OPEN — the only channel a system prompt
  *  travels on, exactly as the real SDK session does. */

--- a/packages/harnesses/tests/materialize.test.ts
+++ b/packages/harnesses/tests/materialize.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "vitest";
 import { checkoutWorkspace, contentHash, inWritableMount } from "../src/materialize.js";
-import { testWorkspace } from "../src/test-doubles.test-util.js";
+import { testAppsHooks, testWorkspace } from "../src/test-doubles.test-util.js";
+
+/** The injected hot-path predicate, exactly as the driver passes it
+ *  (claude-code/index.ts): a path the vocabulary maps to an appId is hot. */
+const isHot = (path: string): boolean => testAppsHooks().hotPaths.appId(path) !== undefined;
 
 const bytes = (text: string): Uint8Array => new TextEncoder().encode(text);
 const file = (path: string, text: string) => ({ path, bytes: bytes(text) });
@@ -206,7 +210,7 @@ describe("syncAll — diff-based per file, never wholesale (§3.5)", () => {
 describe("syncHot — the skeleton renders mid-turn (§3.5)", () => {
   test("commits ONLY the hot paths, leaving the rest for turn end", async () => {
     const workspace = testWorkspace({});
-    const checkout = await checkoutWorkspace(workspace);
+    const checkout = await checkoutWorkspace(workspace, undefined, true, isHot);
     const files = [
       file("/user/apps/app_1/plan.vendo", "plan"),
       file("/user/memory/notes.md", "later"),
@@ -217,7 +221,7 @@ describe("syncHot — the skeleton renders mid-turn (§3.5)", () => {
 
   test("a hot path already synced and unchanged is not committed twice", async () => {
     const workspace = testWorkspace({});
-    const checkout = await checkoutWorkspace(workspace);
+    const checkout = await checkoutWorkspace(workspace, undefined, true, isHot);
     const files = [file("/user/apps/app_1/app.vendo", "<App/>")];
     expect(await checkout.syncHot(files)).toEqual(["/user/apps/app_1/app.vendo"]);
     expect(await checkout.syncHot(files)).toEqual([]);
@@ -226,7 +230,7 @@ describe("syncHot — the skeleton renders mid-turn (§3.5)", () => {
 
   test("a hot path that changed again after a mid-turn sync lands again", async () => {
     const workspace = testWorkspace({});
-    const checkout = await checkoutWorkspace(workspace);
+    const checkout = await checkoutWorkspace(workspace, undefined, true, isHot);
     await checkout.syncHot([file("/user/apps/app_1/app.vendo", "<App/>")]);
     expect(await checkout.syncHot([file("/user/apps/app_1/app.vendo", "<App>2</App>")])).toEqual([
       "/user/apps/app_1/app.vendo",
@@ -235,7 +239,7 @@ describe("syncHot — the skeleton renders mid-turn (§3.5)", () => {
 
   test("a TEAM app's hot path syncs mid-turn too — the skeleton paints either way", async () => {
     const workspace = testWorkspace({});
-    const checkout = await checkoutWorkspace(workspace);
+    const checkout = await checkoutWorkspace(workspace, undefined, true, isHot);
     expect(await checkout.syncHot([file("/orgs/acme/apps/app_1/plan.vendo", "plan")])).toEqual([
       "/orgs/acme/apps/app_1/plan.vendo",
     ]);
@@ -243,7 +247,7 @@ describe("syncHot — the skeleton renders mid-turn (§3.5)", () => {
 
   test("syncHot never deletes — a partial view of the disk is not a deletion", async () => {
     const workspace = testWorkspace({ "/user/memory/keep.md": "keep" });
-    const checkout = await checkoutWorkspace(workspace);
+    const checkout = await checkoutWorkspace(workspace, undefined, true, isHot);
     expect(await checkout.syncHot([])).toEqual([]);
     expect(await workspace.exists("/user/memory/keep.md")).toBe(true);
   });

--- a/packages/harnesses/tests/runtime.test.ts
+++ b/packages/harnesses/tests/runtime.test.ts
@@ -4,7 +4,6 @@
  * EXISTING ai-SDK UIMessage stream, persists the transcript, and enforces the
  * frozen routing table. Harness adapters contain no persistence and no wire code.
  */
-import { wrapWorkspaceForRender } from "@vendoai/apps";
 import { defineHarness } from "../src/define.js";
 import { SSE_KEEPALIVE_FRAME, type Harness, type HarnessEvent, type ThreadId, type Turn } from "@vendoai/core";
 import type { UIMessage } from "ai";
@@ -46,10 +45,11 @@ function fixture(options: {
   /** Composition's publish hook — how the process's own doors (and the steer
    *  route) reach the turn in flight. */
   liveTurn?: Parameters<typeof createHarnessRuntime>[0]["liveTurn"];
-  /** Fill the runtime's generic `wrapWorkspace` slot with the REAL render seam,
-   *  exactly as composition does (harness-turn.ts) — the runtime itself no
-   *  longer wraps anything on its own. */
-  seam?: boolean;
+  /** Fill the runtime's generic `wrapWorkspace` slot — the runtime itself no
+   *  longer wraps anything on its own. The REAL render seam joined to this slot
+   *  is pinned in `packages/vendo/tests/render-wrap-slot.test.ts`, where both
+   *  blocks are legal; here a fake wrap pins the slot's own mechanics. */
+  wrapWorkspace?: Parameters<typeof createHarnessRuntime>[0]["wrapWorkspace"];
 } = {}) {
   const guard = options.guard ?? testGuard();
   const registry = boundRegistry(
@@ -72,12 +72,7 @@ function fixture(options: {
     transcript: countingTranscript,
     harnessState: options.harnessState ?? memoryHarnessStateStore(),
     ...(options.liveTurn === undefined ? {} : { liveTurn: options.liveTurn }),
-    ...(options.seam === true ? {
-      wrapWorkspace: (workspace, opts) => wrapWorkspaceForRender(workspace, {
-        turnId: opts.turnId,
-        emit: opts.emit,
-      }),
-    } : {}),
+    ...(options.wrapWorkspace === undefined ? {} : { wrapWorkspace: options.wrapWorkspace }),
   });
   /** Run a turn AND drain the response, exactly as a host route does. The
    *  stream's onFinish (persistence, state, audit) only fires on consumption —
@@ -544,35 +539,57 @@ describe("turn.state across turns (§1.3)", () => {
   });
 });
 
-describe("the render seam rides the wrapWorkspace slot (§1.6)", () => {
-  // The runtime no longer imports the seam: composition injects it through the
-  // generic `wrapWorkspace` slot, which `seam: true` reproduces here. What these
-  // pin is the SLOT — the wrap sees every commit, and its `emit` reaches the
-  // wire's view channel.
-  it("a harness writing plan.vendo puts the skeleton on screen", async () => {
-    const f = fixture({ seam: true });
+describe("the wrapWorkspace slot (§1.6)", () => {
+  // The runtime knows nothing about apps: composition injects the render seam
+  // through this generic slot, and the REAL seam joined to it is pinned in
+  // `packages/vendo/tests/render-wrap-slot.test.ts` (both blocks are legal
+  // there). What THESE pin is the SLOT itself — the wrap sees every commit,
+  // and its `emit` reaches the wire as a data part — with a fake wrap, so the
+  // mechanics stay covered where they live.
+  const commitEmittingWrap: NonNullable<Parameters<typeof createHarnessRuntime>[0]["wrapWorkspace"]> =
+    (workspace, opts) => {
+      const wrapped = Object.create(workspace) as typeof workspace;
+      wrapped.commit = async (commitOpts?: { message?: string }) => {
+        const result = await workspace.commit(commitOpts);
+        if (result.status === "ok" && result.changed.length > 0) {
+          // A view-shaped part (the slot's emit feeds the wire's view channel),
+          // carrying the commit's own changed set so the assertion can see it.
+          opts.emit("vendo-view:app_7", {
+            type: "data-vendo-view",
+            appId: "app_7",
+            payload: {},
+            changed: result.changed,
+          });
+        }
+        return result;
+      };
+      return wrapped;
+    };
+
+  it("the wrap sees the turn-end commit and its emit reaches the wire", async () => {
+    const f = fixture({ wrapWorkspace: commitEmittingWrap });
     const harness = defineHarness({
       name: "builder",
       async *run(turn) {
         yield { type: "status", label: "Sketching the layout" };
-        await turn.workspace.writeFile(
-          "/user/apps/app_7/plan.vendo",
-          `<Plan name="Invoices"><Group title="Unpaid"><Leaf component="DataTable" /></Group></Plan>`,
-        );
+        await turn.workspace.writeFile("/user/apps/app_7/plan.vendo", "<Plan name=\"Invoices\" />");
       },
     });
     const parts = await f.run(harness);
     const view = parts.find((part) => part.type === "data-vendo-view");
     expect(view).toBeDefined();
-    expect(view).toMatchObject({ id: "vendo-view:app_7", data: { appId: "app_7" } });
+    expect(view).toMatchObject({
+      id: "vendo-view:app_7",
+      data: { changed: ["/user/apps/app_7/plan.vendo"] },
+    });
   });
 
-  it("an unparseable write puts nothing on screen", async () => {
-    const f = fixture({ seam: true });
+  it("a wrap that emits nothing puts nothing on the wire", async () => {
+    const f = fixture({ wrapWorkspace: commitEmittingWrap });
     const harness = defineHarness({
-      name: "builder",
-      async *run(turn) {
-        await turn.workspace.writeFile("/user/apps/app_7/app.vendo", "half-written garba");
+      name: "reader",
+      async *run() {
+        yield { type: "text", delta: "read-only turn" };
       },
     });
     const parts = await f.run(harness);
@@ -587,7 +604,6 @@ describe("write = commit for in-process hands (§3.5 + the commit-cadence seam)"
     const workspace = testWorkspace();
     // Stands in for lane D's workspace_write: the tool stages, the runtime lands it.
     const f = fixture({
-      seam: true,
       tools: {
         workspace_write: {
           descriptor: readTool("workspace_write", "write"),
@@ -602,15 +618,18 @@ describe("write = commit for in-process hands (§3.5 + the commit-cadence seam)"
       name: "editor",
       async *run(turn) {
         await turn.tools.call("workspace_write", {});
-        // The commit already happened, so the view is on the wire BEFORE the
-        // harness says anything.
+        // The commit already happened — mid-turn, on the tool's own call, which
+        // is what puts a view on the wire BEFORE the harness says anything
+        // (the wire half: render-wrap-slot.test.ts in the umbrella).
         expect(workspace.commits).toHaveLength(1);
         expect(workspace.commits[0]!.changed).toEqual(["/user/apps/app_9/plan.vendo"]);
         yield { type: "text", delta: "Done." };
       },
     });
     const parts = await f.run(harness, { workspace });
-    expect(parts.some((part) => part.type === "data-vendo-view")).toBe(true);
+    // The expects above ran inside the harness, where a throw becomes an error
+    // part — so the proof the turn got past them is the delta after them.
+    expect(JSON.stringify(parts)).toContain("Done.");
   });
 
   it("turn end lands whatever the harness staged and never committed", async () => {

--- a/packages/harnesses/tsconfig.test.json
+++ b/packages/harnesses/tsconfig.test.json
@@ -5,11 +5,11 @@
     "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
     "noEmit": true,
-    // Two claude-code tests import `@vendoai/apps/box-door`, whose export map
-    // points at the zero-dependency `box/turn-routes.mjs` control-port runtime
-    // and carries no `types` — same reason `vendo` and `apps` set this. There is
-    // no `.js` under `src` or `tests`, so it widens nothing else.
+    // The claude-code tests import this package's own `box/turn-routes.mjs` —
+    // the zero-dependency session-door runtime the machine image carries, which
+    // has no `.d.ts` — same reason `vendo` and `apps` set this. There is no
+    // `.js` under `src` or `tests`, so it widens nothing else.
     "allowJs": true
   },
-  "include": ["src", "tests"]
+  "include": ["src", "box", "tests"]
 }

--- a/packages/mcp/src/door.ts
+++ b/packages/mcp/src/door.ts
@@ -1561,8 +1561,8 @@ async function turnTools(
 }
 
 /**
- * Contract §1.1's three statuses onto the MCP wire — the SAME mapping the
- * in-process projection uses (`guardedProjection` in `apps/src/claude-turn.ts`):
+ * Contract §1.1's three statuses onto the MCP wire — the same mapping the
+ * (now-retired) in-process projection used before door-ctx moved tools here:
  * a denial is text the model narrates, never a protocol error it reads as a bug.
  */
 function turnResult(result: ToolResult): CallToolResult {

--- a/packages/vendo/src/agent-doubles.test-util.ts
+++ b/packages/vendo/src/agent-doubles.test-util.ts
@@ -14,15 +14,19 @@ import type {
   Guard,
   GuardDecision,
   Json,
+  Principal,
   ResolvedModels,
   RunContext,
+  SeatModels,
+  SkillListing,
+  ThreadId,
   ToolCall,
   ToolDescriptor,
   ToolOutcome,
   ToolRegistry,
   WorkspaceFs,
 } from "@vendoai/core";
-import type { LanguageModel } from "ai";
+import type { LanguageModel, UIMessage } from "ai";
 import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
 import { InMemoryFs } from "just-bash";
 export type TestGuard = Guard & {
@@ -331,4 +335,62 @@ export function scriptedModel(turns: StreamPart[][]): ScriptedModel {
 /** `ResolvedModels` whose every seat is one scripted model. */
 export function seats(model: LanguageModel): ResolvedModels<LanguageModel> {
   return { default: model, reviewer: model, judge: model, fill: model };
+}
+
+// ─── the harness-runtime doubles, mirrored from `@vendoai/harnesses`
+//     (test-doubles.test-util.ts) for the cross-block seam tests that live in
+//     THIS package because they need both blocks (the claude-code live box
+//     proofs, the render-seam wrapWorkspace slot) ────────────────────────────
+
+export function userMessage(id: string, text: string): UIMessage {
+  return { id, role: "user", parts: [{ type: "text", text }] };
+}
+
+/** No seats at all — for suites where the harness under test is scripted or a
+ *  real external loop rather than a seat-reading `vendo()`. */
+export function unusedModels(): SeatModels<LanguageModel> {
+  return {};
+}
+
+export function testSkills(entries: Array<SkillListing & { body: string }> = []) {
+  return {
+    async list(): Promise<SkillListing[]> {
+      return entries.map(({ name, description }) => ({ name, description }));
+    },
+    async load(name: string): Promise<string> {
+      const entry = entries.find((candidate) => candidate.name === name);
+      if (entry === undefined) throw new Error(`no such skill: ${name}`);
+      return entry.body;
+    },
+  };
+}
+
+/** Lane D's `threadMessageStore(store)` return value, in memory: one row per
+ *  message, reassembled by seq. */
+export function testTranscript() {
+  const rows = new Map<string, Array<{ id: string; seq: number; message: UIMessage }>>();
+  return {
+    rows,
+    async upsert(_principal: Principal, threadId: ThreadId, message: UIMessage, seq: number): Promise<void> {
+      const thread = rows.get(threadId) ?? [];
+      const existing = thread.findIndex((row) => row.id === message.id);
+      const row = { id: message.id, seq, message: structuredClone(message) };
+      if (existing === -1) thread.push(row);
+      else thread[existing] = row;
+      rows.set(threadId, thread);
+    },
+    async list(_principal: Principal, threadId: ThreadId): Promise<UIMessage[]> {
+      return [...(rows.get(threadId) ?? [])]
+        .sort((left, right) => left.seq - right.seq)
+        .map((row) => structuredClone(row.message));
+    },
+  };
+}
+
+export async function readSse(response: Response): Promise<Array<Record<string, unknown>>> {
+  const raw = await response.text();
+  const blocks = raw.slice(0, -2).split("\n\n");
+  return blocks
+    .filter((block) => block.startsWith("data: ") && block !== "data: [DONE]")
+    .map((block) => JSON.parse(block.slice("data: ".length)) as Record<string, unknown>);
 }

--- a/packages/vendo/src/harness-turn.ts
+++ b/packages/vendo/src/harness-turn.ts
@@ -31,7 +31,14 @@ import {
   type WorkspaceFs,
 } from "@vendoai/core";
 import { ThreadRepository, type Thread, type ThreadSummary } from "./threads.js";
-import { wrapWorkspaceForRender, type RenderSeamOptions } from "@vendoai/apps";
+import {
+  HOT_PATH_WATCH,
+  hotPathAppId,
+  repairInstruction,
+  validateWrittenApps,
+  wrapWorkspaceForRender,
+  type RenderSeamOptions,
+} from "@vendoai/apps";
 import type { VendoGuard } from "@vendoai/guard";
 import { harnessStateStore, threadMessageStore, workspaceStore, type VendoStore } from "@vendoai/store";
 import {
@@ -243,6 +250,17 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
   if (config.toolSearch !== undefined) {
     provideHarnessAdapters(config.harness, { toolSearch: config.toolSearch });
   }
+  // The app-document vocabulary a machine-backed driver needs: the hot-path
+  // watch set, and the finish-line validate gate. `@vendoai/harnesses` no
+  // longer imports `@vendoai/apps`, so composition hands the driver the REAL
+  // implementations here — which is what keeps the composed path byte-identical
+  // to when the driver imported them itself. Filled unconditionally: the slots
+  // are inert on a harness that never reads them.
+  provideHarnessAdapters(config.harness, {
+    hotPaths: { watch: HOT_PATH_WATCH, appId: hotPathAppId },
+    validateApps: validateWrittenApps,
+    repairInstruction,
+  });
 
   /** The thread's harness-state slot, when this store can hold one. The slot
    *  carries a native session ref and vendo()'s searched-in loadout, so it has

--- a/packages/vendo/tests/claude-code-box.live.test.ts
+++ b/packages/vendo/tests/claude-code-box.live.test.ts
@@ -5,14 +5,23 @@
  * Gated on `E2B_API_KEY` + `ANTHROPIC_API_KEY` + `VENDO_BOX_TEMPLATE` (the
  * template `packages/apps/box/build-template.mjs` bakes — it carries the turn
  * door and `claude-turn.mjs`). Skipped otherwise, like every `.live.test.ts`.
+ *
+ * It lives in the UMBRELLA's suite because it needs both blocks — the real e2b
+ * adapter (`@vendoai/apps/e2b`) driving the harness driver (`@vendoai/harnesses`)
+ * — and harnesses no longer depends on apps.
  */
 import { e2bSandbox } from "@vendoai/apps/e2b";
 import type { Json, ToolResult, Turn } from "@vendoai/core";
 import { afterAll, describe, expect, test } from "vitest";
-import { createTurnState } from "../../src/harness-state.js";
-import { testWorkspace, unusedModels, userMessage } from "../../src/test-doubles.test-util.js";
-import { boxEgress, claudeCode } from "../../src/claude-code/index.js";
-import { boxMachine, disposeSessionMachines, type SandboxAdapterLike } from "../../src/claude-code/box.js";
+import { createTurnState } from "@vendoai/harnesses";
+import {
+  boxEgress,
+  boxMachine,
+  claudeCode,
+  disposeSessionMachines,
+  type SandboxAdapterLike,
+} from "@vendoai/harnesses/claude-code";
+import { testWorkspace, unusedModels, userMessage } from "../src/agent-doubles.test-util.js";
 
 const ready = process.env["E2B_API_KEY"] !== undefined
   && process.env["ANTHROPIC_API_KEY"] !== undefined

--- a/packages/vendo/tests/claude-code-composed.test.ts
+++ b/packages/vendo/tests/claude-code-composed.test.ts
@@ -27,7 +27,7 @@ import type { LanguageModel, UIMessage } from "ai";
 import type { Principal, ToolDescriptor, ToolRegistry } from "@vendoai/core";
 // The REAL box door, over a fake transport — a package subpath, not a relative
 // climb, because the door is the wire contract between the two blocks.
-import { createSessionRoutes } from "@vendoai/apps/box-door";
+import { createSessionRoutes } from "@vendoai/harnesses/box-door";
 import { claudeCode } from "@vendoai/harnesses/claude-code";
 import { createStore, type VendoStore } from "@vendoai/store";
 import { afterEach, describe, expect, it } from "vitest";
@@ -79,7 +79,7 @@ interface BoxDoor {
  * A stand-in for a real box, adapted from the fake in
  * `packages/harnesses/src/claude-code/claude-code.test.ts` and cut down to what
  * ONE turn touches: `request()` is a transport adapter over the ACTUAL box door
- * (`packages/apps/box/turn-routes.mjs`), so what this exercises is our driver
+ * (`packages/harnesses/box/turn-routes.mjs`), so what this exercises is our driver
  * and the composition — never a mock of our own code. The SDK loop is the one
  * thing scripted, because a test cannot run a model.
  */

--- a/packages/vendo/tests/orgs-materialize.live.test.ts
+++ b/packages/vendo/tests/orgs-materialize.live.test.ts
@@ -16,7 +16,7 @@
  * is exactly the deployment shape a workspace-only host has.
  *
  * **The template matters here**, because this lane changes the box IMAGE (the
- * `/session/collect` walk in `packages/apps/box/turn-routes.mjs`): a run against
+ * `/session/collect` walk in `packages/harnesses/box/turn-routes.mjs`): a run against
  * an image baked before the change collects `/user/` paths only and the team
  * file's edit never leaves the box. Proven on `vendo-box-orgs`
  * (`cnbt9dwz9ktvlplqhlq1`), a LANE-named template — never the shared `vendo-box`

--- a/packages/vendo/tests/orgs-materialize.test.ts
+++ b/packages/vendo/tests/orgs-materialize.test.ts
@@ -10,7 +10,7 @@
  *
  * Everything here is REAL except the model: a real store, the real `can()`, real
  * grants, the real composition, and the real box door
- * (`packages/apps/box/turn-routes.mjs`) over an in-process transport with a real
+ * (`packages/harnesses/box/turn-routes.mjs`) over an in-process transport with a real
  * temp dir for the box's disk. Only the SDK loop is scripted, because a test
  * cannot run a model — so what the script does to that disk is exactly what a
  * model's Write tool would do.
@@ -28,7 +28,7 @@ import {
   type RunContext,
 } from "@vendoai/core";
 import type { SandboxAdapter } from "@vendoai/apps";
-import { createSessionRoutes } from "@vendoai/apps/box-door";
+import { createSessionRoutes } from "@vendoai/harnesses/box-door";
 import { claudeCode } from "@vendoai/harnesses/claude-code";
 import { appAccess, createStore, type VendoStore } from "@vendoai/store";
 import { afterEach, describe, expect, it } from "vitest";

--- a/packages/vendo/tests/render-wrap-slot.test.ts
+++ b/packages/vendo/tests/render-wrap-slot.test.ts
@@ -1,0 +1,135 @@
+/**
+ * The render seam riding the harness runtime's generic `wrapWorkspace` slot —
+ * §1.6, the PRODUCER/CONSUMER pair with no stub on either side.
+ *
+ * The runtime (`@vendoai/harnesses`) no longer imports the seam; composition
+ * injects `wrapWorkspaceForRender` (`@vendoai/apps`) through the slot, exactly
+ * as `harness-turn.ts` does. These tests moved here from
+ * `packages/harnesses/tests/runtime.test.ts` when harnesses dropped its apps
+ * dependency: the pair they pin spans both blocks, so the umbrella — which
+ * depends on both — is where they can keep driving the REAL wrap. What they
+ * pin is the SLOT: the wrap sees every commit, and its `emit` reaches the
+ * wire's view channel.
+ */
+import { wrapWorkspaceForRender } from "@vendoai/apps";
+import type { Harness, ThreadId } from "@vendoai/core";
+import {
+  createHarnessRuntime,
+  defineHarness,
+  memoryHarnessStateStore,
+  type TurnRunInput,
+} from "@vendoai/harnesses";
+import { describe, expect, it } from "vitest";
+import {
+  boundRegistry,
+  ctx,
+  readSse,
+  readTool,
+  testGuard,
+  testSkills,
+  testTranscript,
+  testWorkspace,
+  unusedModels,
+  userMessage,
+} from "../src/agent-doubles.test-util.js";
+
+const THREAD = "thr_1" as ThreadId;
+
+function fixture(options: {
+  tools?: Record<string, { descriptor: ReturnType<typeof readTool>; execute: () => unknown }>;
+} = {}) {
+  const guard = testGuard();
+  const registry = boundRegistry(
+    (options.tools ?? {}) as Parameters<typeof boundRegistry>[0],
+    guard,
+  );
+  const runtime = createHarnessRuntime({
+    tools: registry,
+    guard,
+    skills: testSkills(),
+    transcript: testTranscript(),
+    harnessState: memoryHarnessStateStore(),
+    // The slot fill under test — verbatim what composition does
+    // (`packages/vendo/src/harness-turn.ts`).
+    wrapWorkspace: (workspace, opts) => wrapWorkspaceForRender(workspace, {
+      turnId: opts.turnId,
+      emit: opts.emit,
+    }),
+  });
+  const run = async (
+    harness: Harness,
+    over: Partial<TurnRunInput> = {},
+  ): Promise<Array<Record<string, unknown>>> => readSse(await runtime.run({
+    harness,
+    threadId: THREAD,
+    messages: [userMessage("m1", "hello")],
+    ctx: ctx(),
+    workspace: testWorkspace(),
+    models: unusedModels(),
+    interactive: true,
+    ...over,
+  }));
+  return { run };
+}
+
+describe("the render seam rides the wrapWorkspace slot (§1.6)", () => {
+  it("a harness writing plan.vendo puts the skeleton on screen", async () => {
+    const f = fixture();
+    const harness = defineHarness({
+      name: "builder",
+      async *run(turn) {
+        yield { type: "status", label: "Sketching the layout" };
+        await turn.workspace.writeFile(
+          "/user/apps/app_7/plan.vendo",
+          `<Plan name="Invoices"><Group title="Unpaid"><Leaf component="DataTable" /></Group></Plan>`,
+        );
+      },
+    });
+    const parts = await f.run(harness);
+    const view = parts.find((part) => part.type === "data-vendo-view");
+    expect(view).toBeDefined();
+    expect(view).toMatchObject({ id: "vendo-view:app_7", data: { appId: "app_7" } });
+  });
+
+  it("an unparseable write puts nothing on screen", async () => {
+    const f = fixture();
+    const harness = defineHarness({
+      name: "builder",
+      async *run(turn) {
+        await turn.workspace.writeFile("/user/apps/app_7/app.vendo", "half-written garba");
+      },
+    });
+    const parts = await f.run(harness);
+    expect(parts.some((part) => part.type === "data-vendo-view")).toBe(false);
+  });
+
+  it("a workspace tool edit lands on its own call, not at turn end (§3.5)", async () => {
+    const PLAN = `<Plan name="Invoices"><Group title="Unpaid"><Leaf component="DataTable" /></Group></Plan>`;
+    const workspace = testWorkspace();
+    // Stands in for lane D's workspace_write: the tool stages, the runtime lands it.
+    const f = fixture({
+      tools: {
+        workspace_write: {
+          descriptor: readTool("workspace_write", "write"),
+          execute: () => {
+            void workspace.writeFile("/user/apps/app_9/plan.vendo", PLAN);
+            return { written: true };
+          },
+        },
+      },
+    });
+    const harness = defineHarness({
+      name: "editor",
+      async *run(turn) {
+        await turn.tools.call("workspace_write", {});
+        // The commit already happened, so the view is on the wire BEFORE the
+        // harness says anything.
+        expect(workspace.commits).toHaveLength(1);
+        expect(workspace.commits[0]!.changed).toEqual(["/user/apps/app_9/plan.vendo"]);
+        yield { type: "text", delta: "Done." };
+      },
+    });
+    const parts = await f.run(harness, { workspace });
+    expect(parts.some((part) => part.type === "data-vendo-view")).toBe(true);
+  });
+});

--- a/packages/vendo/tsconfig.test.json
+++ b/packages/vendo/tsconfig.test.json
@@ -6,7 +6,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": true,
-    // Two tests import `@vendoai/apps/box-door`, whose export map points at the
+    // Two tests import `@vendoai/harnesses/box-door`, whose export map points at the
     // zero-dependency `box/turn-routes.mjs` control-port runtime and carries no
     // `types`. Reading the JS gives them the real inferred signature instead of
     // an ambient re-declaration that could drift from it. There is no `.js`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1086,9 +1086,6 @@ importers:
       '@anthropic-ai/claude-agent-sdk':
         specifier: '>=0.3.0 <1'
         version: 0.3.214(@anthropic-ai/sdk@0.112.3(zod@3.25.76))(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(zod@3.25.76)
-      '@vendoai/apps':
-        specifier: workspace:*
-        version: link:../apps
       '@vendoai/core':
         specifier: workspace:*
         version: link:../core

--- a/scripts/dependency-guard.mjs
+++ b/scripts/dependency-guard.mjs
@@ -76,24 +76,18 @@ const LAYERS = {
   // the harness runtime (build contract 2026-07-30 §2): the second multi-block
   // package after the umbrella. It runs any Harness — building the Turn, mapping
   // the guard's outcomes, mirroring onto today's wire — and since the engine
-  // fold it OWNS the turn loop too. The runtime's ROOT ENTRY reaches core (the
-  // contract) and guard only: the render seam, validate gate and screen agent
-  // moved out (apps, apps, and the umbrella respectively), and hot-path views
-  // ride the runtime's generic `wrapWorkspace` slot. The apps edges that REMAIN
-  // are the DRIVER-SIDE ones, none of them on the root entry's module graph:
-  //   - `claude-code/local.ts` loads the session runner for `machine: "local"`
-  //     (`@vendoai/apps/claude-turn`), and the driver imports that module's
-  //     event types (`machine.ts`, `index.ts`);
-  //   - `claude-code/index.ts` value-imports `HOT_PATH_WATCH`,
-  //     `repairInstruction` and `validateWrittenApps` from the apps root (the
-  //     mid-turn hot sync and the builder's validate gate);
-  //   - `materialize.ts` value-imports `hotPathAppId` from the apps root (the
-  //     sync-back seam's hot-path filter — reached by the drivers only);
-  //   - the claude-code tests drive the real box-door/claude-turn/e2b seams.
-  // Severing the edge means rehoming claude-turn and the hot-path vocabulary,
-  // which is its own decision, not a side effect.
-  // It is NOT the umbrella: no store, no actions.
-  "@vendoai/harnesses": ["@vendoai/core", "@vendoai/apps", "@vendoai/guard"],
+  // fold it OWNS the turn loop too. core (the contract) and guard ONLY: the
+  // render seam, validate gate and screen agent moved out (apps, apps, and the
+  // umbrella respectively), hot-path views ride the runtime's generic
+  // `wrapWorkspace` slot, and the claude-code driver is apps-free since the
+  // claude-turn rehome — the session runner (`claude-code/claude-turn.ts`) and
+  // the box session door (`box/turn-routes.mjs`) live HERE now, and the apps
+  // vocabulary the driver still uses (hot paths, the validate gate) arrives
+  // INJECTED through `provideHarnessAdapters` from composition (the umbrella
+  // and @vendoai/agents), never imported. The e2b/box-door seam tests live in
+  // packages/vendo/tests, where both blocks are legal.
+  // It is NOT the umbrella: no store, no actions, no apps.
+  "@vendoai/harnesses": ["@vendoai/core", "@vendoai/guard"],
   // the standalone agent runtime (agents-v0 spec, 2026-08-04): the open-source
   // front door Vendo's embed consumes across a real seam. It assembles what the
   // umbrella assembles — harness runtime (harnesses), guard, store, host tools


### PR DESCRIPTION
`@vendoai/harnesses` no longer depends on `@vendoai/apps` — the claude-code driver is entirely its own. The guard's layer entry for harnesses is now `core + guard` only, and the gate passes with the edge removed.

## Scout: what was session-box vs shared in `packages/apps/box/`

- **Session-box (the claudeCode conversation):** `turn-routes.mjs` (every route is `/session/*`; it holds the live session and loads the runner) and the compiled `claude-turn.js` runner. Cleanly separable as FILES — both are zero-import and land side-by-side in `/opt/vendo-box`.
- **Shared / app-serving:** `harness.mjs` (the supervisor — it serves the layer-3 `/agent/*` builder routes AND delegates `/session/*`), `agent-sdk.mjs`, `bootstrap.mjs`, and `build-template.mjs`. There is ONE machine image for both kinds of box, built by one recipe, supervised by one process — so the *image build* is not separable and stays in apps.
- `packages/box-template/` is the universal **app** template (what generated apps are built from, client-side, layered `core + ui`) — the wrong home for server session infrastructure; not touched.

## The moves

| from | to |
|---|---|
| `packages/apps/src/claude-turn.ts` | `packages/harnesses/src/claude-code/claude-turn.ts` (still imports NOTHING; compiled to `dist/claude-code/claude-turn.js` for the image copy) |
| `packages/apps/box/turn-routes.mjs` | `packages/harnesses/box/turn-routes.mjs` (shipped; exported as `@vendoai/harnesses/box-door`) |
| `packages/apps/tests/{claude-turn,claude-session,claude-beats,box-turn-routes}.test.ts` | `packages/harnesses/tests/claude-code/` |
| `packages/harnesses/tests/claude-code/claude-code-box.live.test.ts` (needs real e2b) | `packages/vendo/tests/` |
| `runtime.test.ts`'s three real-render-seam tests (needed `wrapWorkspaceForRender` from apps) | `packages/vendo/tests/render-wrap-slot.test.ts`; harnesses keeps fake-wrap tests pinning the slot's own mechanics |

`@vendoai/apps` drops its `./claude-turn` and `./box-door` exports; `@vendoai/harnesses` gains `./claude-turn` and `./box-door`. Nothing else in this repo imported them (repo-wide sweep); **vendo-web is out of scope and was not checked** — if it reads either subpath, it needs the same one-line respell to `@vendoai/harnesses/...`.

## How the image build sources the runner now

`build-template.mjs` (stays in apps — it is the ONE shared image recipe) stages both session files in from harnesses before the e2b `copy()`: the runner from `packages/harnesses/dist/claude-code/claude-turn.js`, the door from `packages/harnesses/box/turn-routes.mjs`. This is a release-time manual script (needs `E2B_API_KEY`), not a turbo task, and it already reads sibling packages without manifest edges (`pnpm pack` of core and ui) under its documented "run `pnpm build` first" precondition — so no build-order edge is needed and none was added; adding an `apps → harnesses` manifest edge would invert the layering for a file copy turbo never schedules.

The supervisor's static `import "./turn-routes.mjs"` became a **lazy import on the first `/session` request**: in the image the file is always there (staged by the same build), in the monorepo the supervisor's own tests no longer resolve a file that moved packages. Trade: a hypothetically broken image fails on the first session request (500 with the message) instead of at boot; the template build itself fails loudly if staging fails, so the file can't be missing in a built image.

## The injected-config seam

The driver's remaining apps VALUE imports became injected config, on the pattern the de-apps lane established (`provideHarnessAdapters` slots + constructor deps, constructor wins):

```ts
// HarnessAdapters (and ClaudeCodeDeps picks the same three)
hotPaths?: { watch: readonly string[]; appId(path: string): string | undefined } // HOT_PATH_WATCH + hotPathAppId
validateApps?: (input: { tools; workspace; paths; review? }) => Promise<readonly AppValidationFailureLike[]> // validateWrittenApps
repairInstruction?: (failures: readonly AppValidationFailureLike[]) => string | undefined
```

`AppValidationFailureLike` restates apps' failure shape structurally (over core's `AppId`/`Finding`, property-style fields), so drift in either direction fails to compile at the composition site. `materialize.ts`'s `hotPathAppId` use became an `isHot` predicate parameter on `checkoutWorkspace`.

Both composed paths inject the real implementations unconditionally — `packages/vendo/src/harness-turn.ts` and `packages/agents/src/agent.ts` — so **composed behavior is byte-identical**: same watch shapes, same `validateWrittenApps({ ..., review: true })`, same repair round.

## The bare-path trade (deliberate)

A host driving the runtime directly, without composition and without passing the hooks, loses the mid-turn hot-path sync (skeletons paint at turn end) and the finish-line validate gate. The driver logs one operator line per process (`warnNoAppsHooksOnce`, same shape as `warnNoOriginOnce`) naming what's off and both ways to turn it on. Everything else — checkout, diff sync-back, the door, the session — is unchanged on the bare path.

## Gate (all green, rebased on main)

- `pnpm build` — 21/21 tasks
- typecheck: harnesses, apps, vendo, agents (+mcp) — clean
- worker-capped units (`VITEST_MIN/MAX_FORKS=1/2`, `VITEST_MIN/MAX_THREADS=1/2`, excluding `*.live`/`*.e2e`): harnesses 533 ✓ · apps 1011 ✓ · agents 85 ✓ · vendo 2037 ✓ (plus the harnesses `sdk-absent` e2e against the built dist: 4 ✓)
- `pnpm lint` — dependency-guard OK with the apps edge removed; portability-gate all legs green (full build first)

Test intent preserved everywhere: the box-door seam tests still drive the REAL door (now a sibling file), the e2b live proofs moved to the umbrella with the same assertions, and the real-render-seam tests kept their exact assertions in `render-wrap-slot.test.ts`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decouples the Claude code driver from `@vendoai/apps` by moving the session runner and session door into `@vendoai/harnesses`, with apps hooks injected by composition. Composed hosts behave the same; bare runs skip mid-turn hot sync and the validate gate with a one-time warning.

- **Refactors**
  - Moved: `claude-turn.ts` → `@vendoai/harnesses/claude-code/claude-turn`; `turn-routes.mjs` → `@vendoai/harnesses/box/turn-routes.mjs`. New subpaths: `@vendoai/harnesses/claude-turn`, `@vendoai/harnesses/box-door`. `@vendoai/apps` drops both exports.
  - Image build now stages both the compiled runner and the door from `@vendoai/harnesses`; supervisor lazily imports `/session` routes on first request.
  - Driver’s apps value imports are now injected via `provideHarnessAdapters` (`hotPaths`, `validateApps`, `repairInstruction`). `@vendoai/vendo` and `@vendoai/agents` inject the real ones, preserving composed behavior.
  - `checkoutWorkspace()` takes an `isHot` predicate (driver passes the injected vocabulary).
  - Tests reshaped: box-door/e2b and render-seam tests run in `@vendoai/vendo`; SDK-absent pin split per package so each probes its own dist; harnesses’ suite only probes the built runner. Layer guard: `@vendoai/harnesses` root depends only on `@vendoai/core` and `@vendoai/guard`.

- **Migration**
  - Replace imports:
    - `@vendoai/apps/claude-turn` → `@vendoai/harnesses/claude-turn`
    - `@vendoai/apps/box-door` → `@vendoai/harnesses/box-door`
  - Composed hosts: no changes; `createHarnessTurns()`/`agent()` inject `hotPaths`, `validateApps`, `repairInstruction`.
  - Bare `claudeCode()` use: pass `hotPaths`, `validateApps`, `repairInstruction` to retain mid-turn hot sync and the validate gate.
  - Template bake: run `pnpm build` before `packages/apps/box/build-template.mjs` so `@vendoai/harnesses/dist/claude-code/claude-turn.js` and `@vendoai/harnesses/box/turn-routes.mjs` are present.

<sup>Written for commit 53d3fc20bdfbb627bcd7be41484131648868e596. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

