### PR TITLE
refactor(store): drop the orphaned vendo_sessions table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,8 @@ generated UI in a sandboxed, brand-native surface.
 - Local gate = `pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint`
   on the touched scope. The FULL suite runs only in CI — the PR's green `ci`
   check is the gate of record; never run the full suite locally.
+- After any `@vendoai` npm release, bump `vendo-web`'s `@vendoai` deps to the
+  new version in the same session.
 
 ## Tests
 

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -12,8 +12,8 @@ import type { Db } from "./db-postgres.js";
     required and this migration does not attempt it.
 
     v4 (kill-list §B3) added `vendo_sessions`, the guest-session registry. Guest
-    sessions are gone; the table's CREATE is removed here and databases that
-    already have it keep it as an orphan until the cleanup stage drops it.
+    sessions are gone; the table's CREATE is removed here and ADDITIVE_DDL now
+    drops the orphan left behind on databases that already had it.
 
     v5 (ENG-356, knowledge design v2 (2026-07-22) R1) adds the dedicated
     knowledge record collections `vendo_knowledge_docs` / `vendo_knowledge_chunks`.
@@ -289,6 +289,10 @@ const ADDITIVE_DDL = [
   // receipt written before the column existed genuinely has no known owner, and
   // every write path has supplied one since.
   "ALTER TABLE vendo_effects ADD COLUMN IF NOT EXISTS subject text NOT NULL DEFAULT ''",
+  // Guest sessions are gone, so the v4 registry is an orphan on any database that
+  // booted before its CREATE was removed. The version gate would never re-run the
+  // DDL loop on those databases, so the drop lives here and runs every boot.
+  "DROP TABLE IF EXISTS vendo_sessions",
 ] as const;
 
 // v2 backfill (runs once, only when upgrading from a version < 2 — 02 §4 keys

--- a/packages/store/tests/schema.test.ts
+++ b/packages/store/tests/schema.test.ts
@@ -186,6 +186,32 @@ for (const backend of backends()) {
       expect(rows.some((row) => /\(principal\)/.test(String(row.indexdef)))).toBe(true);
     });
 
+    it("drops a leftover vendo_sessions table", async () => {
+      // Guest sessions are gone and the CREATE was removed without a version bump,
+      // so a database that booted on v4 still carries the orphan; ADDITIVE_DDL's
+      // drop is the only thing that removes it.
+      await made.sql("CREATE TABLE vendo_sessions (subject text PRIMARY KEY, touched_at timestamptz NOT NULL)");
+
+      await made.store.ensureSchema();
+
+      const rows = await made.sql(
+        `SELECT table_name FROM information_schema.tables
+         WHERE table_schema = 'public' AND table_name = 'vendo_sessions'`,
+      );
+      expect(rows).toEqual([]);
+    });
+
+    it("is a no-op on a database that never had vendo_sessions", async () => {
+      // The previous test left it dropped; running again must not error.
+      await made.store.ensureSchema();
+
+      const rows = await made.sql(
+        `SELECT table_name FROM information_schema.tables
+         WHERE table_schema = 'public' AND table_name = 'vendo_sessions'`,
+      );
+      expect(rows).toEqual([]);
+    });
+
     it("rejects a future schema version as a conflict", async () => {
       await made.sql("UPDATE vendo_meta SET value = '999'::jsonb WHERE key = 'schema_version'");
       await made.store.close();


### PR DESCRIPTION
## What

Two small changes closing out this project's upstream side.

### 1. Retire `vendo_sessions`

Guest sessions were deleted earlier in this project (#1089, the 31 ops → 27
identity refactor). That change removed the `CREATE TABLE vendo_sessions` and
its index but **deliberately deferred the `DROP TABLE`** so existing tenants
kept their rows until the hosted side had erased the orphaned guest data. This
PR completes the retirement.

**Why `ADDITIVE_DDL` and no `SCHEMA_VERSION` bump.** The version gate in
`migrate()` runs the `DDL` loop only while `version < SCHEMA_VERSION`. Every
database that actually has the orphan is already on the current version, so a
statement added to `DDL` would never run there — the one place it is needed.
`ADDITIVE_DDL` runs on every boot, unconditionally, which is exactly what an
idempotent `DROP TABLE IF EXISTS` wants. This matches the in-file precedent
already sitting in `ADDITIVE_DDL`: the `DROP INDEX IF EXISTS
vendo_apps_subject_trigger_idx` / `ALTER TABLE vendo_apps DROP COLUMN IF EXISTS
trigger_kind` pair. No version bump for the same reason those needed none.

**Sequencing.** This lands in `main` but only reaches tenants on the **next npm
release** and a subsequent console bump. The hosted cleanup that erases orphaned
`anonymous_*` subject data runs before then, so the intended order — erase the
data, then drop the table — is preserved naturally. **No release is cut here.**

**Tests.** `packages/store/tests/schema.test.ts` covers both sides: a database
that HAD the table (create it, run `ensureSchema()`, assert it is gone) and one
that never had it (clean no-op, not an error). Proven to fail: removing the DDL
line turns both red with `expected [ { table_name: 'vendo_sessions' } ] to
deeply equal []`; restoring it turns them green.

### 2. One line in `CLAUDE.md`

> After any `@vendoai` npm release, bump `vendo-web`'s `@vendoai` deps to the
> new version in the same session.

Added to the end of `## Rules`, next to the existing PR/gate shipping rules
where a release-running agent will see it. This one line is the entire surviving
deliverable of a shipping-procedure amendment whose automation was deliberately
cut for being too much machinery for the problem — so it lives as a rule, not a
script.

## Gate

```
npx turbo run build --filter=@vendoai/store          EXIT=0
npx turbo run typecheck --filter=@vendoai/store      EXIT=0
npx vitest run tests/schema.test.ts                  EXIT=0  (18 passed)
node scripts/dependency-guard.mjs                    EXIT=0
npx eslint --config eslint.blocking.config.mjs …     EXIT=0
```

Full `@vendoai/store` package suite: **475 passed | 4 skipped (479)**, 49 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops the orphaned `vendo_sessions` table from the `@vendoai/store` schema using an idempotent drop in `ADDITIVE_DDL`, so it cleans up on all tenants without a schema version bump. Also adds a small rule to bump `vendo-web` `@vendoai` deps after any `@vendoai` release.

- **Refactors**
  - Remove leftover `vendo_sessions` via "DROP TABLE IF EXISTS" in `ADDITIVE_DDL`; no `SCHEMA_VERSION` bump so it runs on already-upgraded DBs.
  - Add tests to verify the table is dropped when present and a no-op when absent.
  - Update `CLAUDE.md`: after any `@vendoai` release, bump `vendo-web` `@vendoai` deps in the same session.

<sup>Written for commit 4de4f2347788a3fbf2f79bfab666ca102ecfbde3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

