### PR TITLE
fix(automations): indexed webhook app lookup; truthful agentic crash code

### DIFF
--- a/packages/automations/src/ingestion-surface.ts
+++ b/packages/automations/src/ingestion-surface.ts
@@ -14,7 +14,6 @@ import { allRecords, appRef, id, message, parseAppRow } from "./rows.js";
 import { triggerKey } from "./sponsorship.js";
 import { durationMs, validateTrigger } from "./steps.js";
 import {
-  APPS,
   DELIVERIES,
   SCHEDULE,
   WEBHOOK,
@@ -255,10 +254,10 @@ const createWebhookRefusals = (
 const createWebhookDoor = (
   deps: Pick<
     IngestionSurfaceDeps,
-    "config" | "now" | "iso" | "firesLocally" | "armedTriggers" | "armedFor" | "startRun"
+    "config" | "now" | "iso" | "firesLocally" | "appsFiringOn" | "armedTriggers" | "armedFor" | "startRun"
   > & WebhookRefusals,
 ): Pick<AutomationsEngine, "webhook"> => {
-  const { config, now, iso, firesLocally, armedTriggers, armedFor, startRun } = deps;
+  const { config, now, iso, firesLocally, appsFiringOn, armedTriggers, armedFor, startRun } = deps;
   const { envelope, rejectWebhook } = deps;
   const inFlightDeliveries = new Set<string>();
   const webhook: AutomationsEngine["webhook"] = async (request) => {
@@ -296,7 +295,8 @@ const createWebhookDoor = (
       .filter((entry) => entry.startsWith("v1,"))
       .map((entry) => entry.slice(3));
     const signed = signedWebhookBytes(headerResult.data.id, headerResult.data.timestamp, rawBytes);
-    const appRecords = await allRecords(config.store.records(APPS));
+    // Indexed per-kind ref, same as the tick — never a scan of every app row.
+    const appRecords = await appsFiringOn("external");
     const rows = appRecords.map(parseAppRow);
     const armed = await armedFor(rows);
     // Verified per (app, TRIGGER): each external trigger holds its own secret, so

--- a/packages/automations/src/run-execution.ts
+++ b/packages/automations/src/run-execution.ts
@@ -236,7 +236,9 @@ const createAgenticRunner = (
       await terminal(run, ctx, report.status, report.summary);
     } catch (error) {
       if (await finishStoppedIfNeeded(run)) return;
-      await terminal(run, ctx, "error", message(error), { code: "not-implemented", message: message(error) });
+      // "error", not "not-implemented": that code means "no runner configured"
+      // (above); a runner that crashed is an outage, not a missing feature.
+      await terminal(run, ctx, "error", message(error), { code: "error", message: message(error) });
     }
   };
 


### PR DESCRIPTION
Two findings from a source walkthrough of packages/automations.

**Webhook door scanned every app row per delivery.** `webhook()` read the whole `vendo_apps` collection on each incoming delivery (`allRecords(store.records(APPS))`), while `tick()` and `emit()` already use the indexed per-kind ref query. Switched to `appsFiringOn("external")` — same dual-spelling ref handling (current + pre-list) the other two inlets rely on, so behavior is unchanged; the read is just indexed now.

**Agentic crashes were labeled `not-implemented`.** Any exception thrown by a configured `AgentRunner` landed on the run row as `code: "not-implemented"` — the code that means "no runner configured". An outage was indistinguishable from a missing feature in run history. Crashes now land as `code: "error"`; the real `not-implemented` path (no runner) is untouched, as is the only code surfaces act on (`needs-permission`).

Gate: build, affected tests (including the automations-e2e fixture suite), typecheck, lint — all green locally on this base.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the webhook handler to an indexed app lookup and fixed agent runner crash reporting. This reduces per-delivery reads and makes outages show as "error" instead of "not-implemented".

- **Bug Fixes**
  - Webhook door now uses `appsFiringOn("external")` instead of scanning all apps; matches `tick`/`emit` and keeps behavior unchanged.
  - Agent runner exceptions now record `{ code: "error" }`; the true no-runner path still uses `{ code: "not-implemented" }`.

<sup>Written for commit 55e83c814c4745dd475da13af85b1aab51b7d960. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

