### PR TITLE
refactor(automations): named module compartments replace the flat engine-context bag

### DIFF
--- a/packages/automations/src/app-rows.ts
+++ b/packages/automations/src/app-rows.ts
@@ -16,32 +16,38 @@ import {
   type TriggerSource,
   type VendoRecord,
 } from "@vendoai/core";
-import type { AutomationsEngineContext } from "./engine-context.js";
+import type { EngineBase } from "./engine-context.js";
 import { allRecords, parseAppRow } from "./rows.js";
 import { triggerOf } from "./sponsorship.js";
 import { validateTrigger } from "./steps.js";
 import { APPS, type AppRow } from "./types.js";
 
-export type AppRowsDeps = Pick<AutomationsEngineContext, "config">;
+export type AppRowsDeps = { base: EngineBase };
 
-export type AppRowsAccess = Pick<
-  AutomationsEngineContext,
-  | "appRecord"
-  | "editableAppOrNull"
-  | "editableApp"
-  | "declaredTrigger"
-  | "writeApp"
-  | "canEdit"
-  | "appsFiringOn"
->;
+export interface AppRowsAccess {
+  /** The app row and its record, or null when there is none. */
+  appRecord(appId: string): Promise<{ record: VendoRecord; row: AppRow } | null>;
+  /** The app, for a caller allowed to CHANGE it — null when absent OR refused. */
+  editableAppOrNull(appId: string, ctx: RunContext): Promise<{ record: VendoRecord; row: AppRow } | null>;
+  /** The same door, existence-masked, for callers that must refuse. */
+  editableApp(appId: string, ctx: RunContext): Promise<{ record: VendoRecord; row: AppRow }>;
+  /** The named trigger of an app, validated. */
+  declaredTrigger(doc: AppDocument, triggerId: string): Trigger;
+  /** The app row write that re-derives the per-kind trigger refs. */
+  writeApp(record: VendoRecord, row: AppRow): Promise<void>;
+  /** §9.3's `can(editor)`, through the config seam. */
+  canEdit(ctx: RunContext, row: AppRow, appId: string): Promise<boolean>;
+  /** The app rows that fire on this trigger kind, by its per-kind ref. */
+  appsFiringOn(kind: TriggerSource["kind"], refs?: Record<string, string>): Promise<VendoRecord[]>;
+}
 
 type AppReader = Pick<
-  AutomationsEngineContext,
+  AppRowsAccess,
   "appRecord" | "canEdit" | "editableAppOrNull" | "editableApp" | "declaredTrigger" | "writeApp"
 >;
 
 /** One app row: the read, the edit gate over it, and the write. */
-const createAppReader = ({ config }: AppRowsDeps): AppReader => {
+const createAppReader = ({ base: { config } }: AppRowsDeps): AppReader => {
   const appRecord = async (appId: string): Promise<{ record: VendoRecord; row: AppRow } | null> => {
     const record = await config.store.records(APPS).get(appId);
     return record === null ? null : { record, row: parseAppRow(record) };
@@ -103,8 +109,8 @@ const createAppReader = ({ config }: AppRowsDeps): AppReader => {
 
 /** The queries the tick and emit fire from. */
 const createAppQueries = (
-  { config }: AppRowsDeps,
-): Pick<AutomationsEngineContext, "appsFiringOn"> => {
+  { base: { config } }: AppRowsDeps,
+): Pick<AppRowsAccess, "appsFiringOn"> => {
   /** The app rows that fire on this trigger kind, by its per-kind ref. */
   const appsFiringOn = async (
     kind: TriggerSource["kind"],

--- a/packages/automations/src/armed.ts
+++ b/packages/automations/src/armed.ts
@@ -5,19 +5,28 @@
  * Lifted out of `createAutomationsEngine` unchanged.
  */
 import { type Trigger, type VendoRecord } from "@vendoai/core";
-import type { AutomationsEngineContext } from "./engine-context.js";
+import type { AppRowsAccess } from "./app-rows.js";
+import type { EngineBase } from "./engine-context.js";
 import { allRecords } from "./rows.js";
 import { triggerKey, triggersOf } from "./sponsorship.js";
 import { ARMED, type AppRow } from "./types.js";
 
-export type ArmedDeps = Pick<AutomationsEngineContext, "config" | "writeApp">;
+export type ArmedDeps = { base: EngineBase; appRows: AppRowsAccess };
 
-export type ArmedAccess = Pick<
-  AutomationsEngineContext,
-  "setArmed" | "armedTriggers" | "armedFor" | "isArmed" | "disarmTrigger"
->;
+export interface ArmedAccess {
+  /** Turn ONE (app, trigger) arm row on or off. */
+  setArmed(appId: string, triggerId: string, armed: boolean): Promise<void>;
+  /** This app's armed triggers, given the armed keys already fetched. */
+  armedTriggers(row: AppRow, armed: ReadonlySet<string>): Trigger[];
+  /** The armed set for these app rows. */
+  armedFor(rows: readonly AppRow[]): Promise<Set<string>>;
+  /** The same question for one trigger. */
+  isArmed(row: AppRow, triggerId: string): Promise<boolean>;
+  /** Turn ONE trigger off, leaving the app's others exactly as they were. */
+  disarmTrigger(record: VendoRecord, row: AppRow, triggerId: string): Promise<void>;
+}
 
-export const createArmed = ({ config, writeApp }: ArmedDeps): ArmedAccess => {
+export const createArmed = ({ base: { config }, appRows }: ArmedDeps): ArmedAccess => {
   const setArmed = async (appId: string, triggerId: string, armed: boolean): Promise<void> => {
     const id = triggerKey(appId, triggerId);
     if (armed) await config.store.records(ARMED).put({ id, data: { appId, triggerId }, refs: { app_id: appId } });
@@ -65,7 +74,7 @@ export const createArmed = ({ config, writeApp }: ArmedDeps): ArmedAccess => {
     for (const trigger of remaining) await setArmed(row.doc.id, trigger.id, true);
     await setArmed(row.doc.id, triggerId, false);
     row.enabled = remaining.length > 0;
-    await writeApp(record, row);
+    await appRows.writeApp(record, row);
   };
 
   return { setArmed, armedTriggers, armedFor, isArmed, disarmTrigger };

--- a/packages/automations/src/arming-surface.ts
+++ b/packages/automations/src/arming-surface.ts
@@ -6,44 +6,35 @@
  * Lifted out of `createAutomationsEngine` unchanged.
  */
 import { VendoError, type Json } from "@vendoai/core";
-import type { AutomationsEngineContext } from "./engine-context.js";
+import type { AppRowsAccess } from "./app-rows.js";
+import type { ArmedAccess } from "./armed.js";
+import type { ConsentAccess } from "./consent.js";
+import type { EngineBase } from "./engine-context.js";
+import type { GrantsAccess } from "./grants.js";
 import type { AutomationsEngine, RunPlan } from "./index.js";
 import { appRef } from "./rows.js";
+import type { SponsorshipGateAccess } from "./sponsorship-gate.js";
 import { currentIntentHash, markSponsored, triggerKey, writeSponsorship } from "./sponsorship.js";
 import { evaluate, stepArgs, validateForEachItems } from "./steps.js";
 import { SCHEDULE, WEBHOOK } from "./types.js";
 import { base64url } from "./webhook-signature.js";
 
-export type ArmingSurfaceDeps = Pick<
-  AutomationsEngineContext,
-  | "config"
-  | "iso"
-  | "firesLocally"
-  | "editableApp"
-  | "declaredTrigger"
-  | "writeApp"
-  | "setArmed"
-  | "disarmTrigger"
-  | "descriptors"
-  | "liveGrant"
-  | "captureGrants"
-  | "sponsorships"
-  | "sponsoredEra"
->;
+export type ArmingSurfaceDeps = {
+  base: EngineBase;
+  appRows: AppRowsAccess;
+  armed: ArmedAccess;
+  grants: GrantsAccess;
+  sponsorship: SponsorshipGateAccess;
+  consent: ConsentAccess;
+};
 
 /** 07 §3's arm/disarm pair. */
-const createArmDoors = (
-  deps: Pick<
-    ArmingSurfaceDeps,
-    "config" | "iso" | "firesLocally" | "editableApp" | "declaredTrigger" | "writeApp"
-    | "setArmed" | "disarmTrigger" | "descriptors" | "captureGrants" | "sponsorships" | "sponsoredEra"
-  >,
-): Pick<AutomationsEngine, "enable" | "disable"> => {
-  const { config, iso, firesLocally, editableApp, declaredTrigger, writeApp } = deps;
-  const { setArmed, disarmTrigger, descriptors, captureGrants, sponsorships, sponsoredEra } = deps;
+const createArmDoors = (deps: ArmingSurfaceDeps): Pick<AutomationsEngine, "enable" | "disable"> => {
+  const { base: { config, iso, firesLocally }, appRows, armed } = deps;
+  const { grants, sponsorship, consent } = deps;
   const enable: AutomationsEngine["enable"] = async (appId, triggerId, ctx) => {
-    const found = await editableApp(appId, ctx);
-    const trigger = declaredTrigger(found.row.doc, triggerId);
+    const found = await appRows.editableApp(appId, ctx);
+    const trigger = appRows.declaredTrigger(found.row.doc, triggerId);
     // fn: steps run in the APP's own sandbox machine (packages/apps/src/fn.ts
     // POSTs /fn/<name> to it), not in this process — so when some other
     // authority fires this trigger, that authority is the one that has to wake
@@ -59,10 +50,10 @@ const createArmDoors = (
         + "explicit local `store:` to createVendo to keep this composition firing its own schedule and external triggers.",
       );
     }
-    const { missing, grantSetId } = await captureGrants(
+    const { missing, grantSetId } = await consent.captureGrants(
       found.row.doc,
       trigger,
-      await descriptors(ctx),
+      await grants.descriptors(ctx),
       ctx,
     );
     // §9.9 — enabling is what names the sponsor: the person arming an
@@ -70,7 +61,7 @@ const createArmDoors = (
     // A re-enable refreshes both, which is how an invalidated automation comes
     // back. Per TRIGGER, because that is the thing they just looked at and
     // allowed.
-    await writeSponsorship(sponsorships(), {
+    await writeSponsorship(sponsorship.sponsorships(), {
       appId,
       triggerId: trigger.id,
       sponsor: ctx.principal.subject,
@@ -80,10 +71,10 @@ const createArmDoors = (
     });
     // The era marker outlives an erase of the sponsor, so a vanished row can
     // never be misread as "never sponsored" (§9.9 fails closed).
-    await markSponsored(sponsoredEra(), appId, trigger.id, iso());
-    await setArmed(appId, trigger.id, true);
+    await markSponsored(sponsorship.sponsoredEra(), appId, trigger.id, iso());
+    await armed.setArmed(appId, trigger.id, true);
     found.row.enabled = true;
-    await writeApp(found.record, found.row);
+    await appRows.writeApp(found.record, found.row);
     const key = triggerKey(appId, trigger.id);
     if (trigger.on.kind === "schedule") {
       const cursor = await config.store.records(SCHEDULE).get(key);
@@ -102,8 +93,8 @@ const createArmDoors = (
   };
 
   const disable: AutomationsEngine["disable"] = async (appId, triggerId, ctx) => {
-    const found = await editableApp(appId, ctx);
-    await disarmTrigger(found.record, found.row, triggerId);
+    const found = await appRows.editableApp(appId, ctx);
+    await armed.disarmTrigger(found.record, found.row, triggerId);
   };
 
   return { enable, disable };
@@ -111,13 +102,13 @@ const createArmDoors = (
 
 /** Preview: what ONE trigger would run, nothing executes. */
 const createDryRunDoor = (
-  deps: Pick<ArmingSurfaceDeps, "editableApp" | "declaredTrigger" | "descriptors" | "liveGrant">,
+  deps: Pick<ArmingSurfaceDeps, "appRows" | "grants">,
 ): Pick<AutomationsEngine, "dryRun"> => {
-  const { editableApp, declaredTrigger, descriptors, liveGrant } = deps;
+  const { appRows, grants } = deps;
   const dryRun: AutomationsEngine["dryRun"] = async (appId, triggerId, ctx, event) => {
-    const found = await editableApp(appId, ctx);
-    const trigger = declaredTrigger(found.row.doc, triggerId);
-    const byName = await descriptors(ctx);
+    const found = await appRows.editableApp(appId, ctx);
+    const trigger = appRows.declaredTrigger(found.row.doc, triggerId);
+    const byName = await grants.descriptors(ctx);
     const plan: RunPlan = { steps: [], grantsMissing: [] };
     const add = async (stepId: string, tool: string): Promise<void> => {
       if (tool.startsWith("fn:")) {
@@ -126,7 +117,7 @@ const createDryRunDoor = (
       }
       const descriptor = byName.get(tool);
       if (descriptor === undefined) throw new VendoError("validation", `unknown tool in automation: ${tool}`);
-      const granted = await liveGrant(found.row.subject, appId, triggerId, descriptor);
+      const granted = await grants.liveGrant(found.row.subject, appId, triggerId, descriptor);
       plan.steps.push({ id: stepId, tool, wouldAsk: descriptor.confirmEach === true || !granted });
       if (!descriptor.confirmEach && !granted && !plan.grantsMissing.includes(tool)) plan.grantsMissing.push(tool);
     };

--- a/packages/automations/src/consent.ts
+++ b/packages/automations/src/consent.ts
@@ -21,8 +21,12 @@ import {
   type Trigger,
   type VendoRecord,
 } from "@vendoai/core";
-import type { AutomationsEngineContext } from "./engine-context.js";
+import type { AppRowsAccess } from "./app-rows.js";
+import type { ArmedAccess } from "./armed.js";
+import type { EngineBase } from "./engine-context.js";
+import type { GrantsAccess } from "./grants.js";
 import { allRecords, clone, id, parseRunRecord } from "./rows.js";
+import type { RunRowsAccess } from "./run-rows.js";
 import { declaredSurface } from "./sponsorship.js";
 import { consentKey, declaredSlug } from "./steps.js";
 import {
@@ -36,35 +40,48 @@ import {
   type InternalRunRecord,
 } from "./types.js";
 
-export type ConsentDeps = Pick<
-  AutomationsEngineContext,
-  | "config"
-  | "iso"
-  | "appRecord"
-  | "disarmTrigger"
-  | "liveGrant"
-  | "anyLiveAutomationGrant"
-  | "mintGrant"
-  | "terminal"
->;
+export type ConsentDeps = {
+  base: EngineBase;
+  appRows: AppRowsAccess;
+  armed: ArmedAccess;
+  grants: GrantsAccess;
+  runRows: RunRowsAccess;
+};
 
-export type ConsentAccess = Pick<
-  AutomationsEngineContext,
-  | "writeCapture"
-  | "isPendingAsk"
-  | "pendingCaptures"
-  | "spendApproval"
-  | "handleDecision"
-  | "consentSurface"
-  | "captureGrants"
-  | "needsPermission"
->;
+export interface ConsentAccess {
+  /** A capture row, keyed by the approval it is the ask for. */
+  writeCapture(approvalId: string, capture: Capture): Promise<void>;
+  /** Is this approval still an open question? */
+  isPendingAsk(approvalId: string): Promise<boolean>;
+  /** Every still-pending capture for the subject, parsed. */
+  pendingCaptures(subject: string): Promise<Array<{ id: string; data: Capture }>>;
+  /** Claim the approval's one-time transition before granting anything. */
+  spendApproval(record: VendoRecord): Promise<boolean>;
+  /** The guard's decision subscriber: mint, clear, and disarm on a bare no. */
+  handleDecision(approvalId: string, approved: boolean): Promise<void>;
+  /** The tools a consent moment covers. */
+  consentSurface(trigger: Trigger, byName: Map<string, ToolDescriptor>): Promise<ConsentItem[]>;
+  /** 07 §3 — the asks arming has to raise for this subject. */
+  captureGrants(
+    doc: AppDocument,
+    trigger: Trigger,
+    byName: Map<string, ToolDescriptor>,
+    ctx: RunContext,
+  ): Promise<{ missing: ApprovalRequest[]; grantSetId: string }>;
+  /** A step met a permission nobody has granted. The run ends HERE, loudly. */
+  needsPermission(
+    run: InternalRunRecord,
+    ctx: RunContext,
+    step: Step,
+    approvalId: string,
+  ): Promise<void>;
+}
 
-type CaptureRows = Pick<AutomationsEngineContext, "writeCapture" | "isPendingAsk" | "pendingCaptures">;
+type CaptureRows = Pick<ConsentAccess, "writeCapture" | "isPendingAsk" | "pendingCaptures">;
 
 /** The capture collection itself: the row a pending ask is remembered by, and
  *  the two reads that say which asks are still open. */
-const createCaptureRows = ({ config }: Pick<ConsentDeps, "config">): CaptureRows => {
+const createCaptureRows = ({ base: { config } }: Pick<ConsentDeps, "base">): CaptureRows => {
   /** A capture row, keyed by the approval it is the ask for. Captures are a
    *  GENERIC collection and the 02-store §5 erase cascade finds generic rows by
    *  their refs, so the refs are derived HERE rather than at each writer: an
@@ -109,13 +126,11 @@ const createCaptureRows = ({ config }: Pick<ConsentDeps, "config">): CaptureRows
 /** The one `onApprovalDecision` half: spend the approval, mint the standing
  *  grant, and disarm a consent moment that ended with nothing granted. */
 const createDecisionSubscriber = (
-  deps: Pick<
-    ConsentDeps,
-    "config" | "iso" | "appRecord" | "disarmTrigger" | "anyLiveAutomationGrant" | "mintGrant"
-  > & Pick<CaptureRows, "pendingCaptures">,
-): Pick<AutomationsEngineContext, "spendApproval" | "handleDecision"> => {
-  const { config, iso, appRecord, disarmTrigger } = deps;
-  const { anyLiveAutomationGrant, mintGrant, pendingCaptures } = deps;
+  deps: Pick<ConsentDeps, "base" | "appRows" | "armed" | "grants">
+    & Pick<CaptureRows, "pendingCaptures">,
+): Pick<ConsentAccess, "spendApproval" | "handleDecision"> => {
+  const { base: { config, iso }, appRows, armed } = deps;
+  const { grants, pendingCaptures } = deps;
   /**
    * Spends the approval this consent moment rode in on — through the guard when
    * it offers the seam, so the spend contends with a concurrent
@@ -154,7 +169,7 @@ const createDecisionSubscriber = (
         const data = approvalRowSchema.parse(approval.data);
         // Spend before granting: a yes the person took back at this instant
         // must arm nothing, and only one of the two can win the transition.
-        if (await spendApproval(approval)) await mintGrant(data.request, parsed.triggerId);
+        if (await spendApproval(approval)) await grants.mintGrant(data.request, parsed.triggerId);
       }
       await config.store.records(CAPTURES).delete(approvalId);
       if (!approved) {
@@ -167,10 +182,13 @@ const createDecisionSubscriber = (
         // trigger's ask must never disarm a sibling that is running fine.
         const outstanding = (await pendingCaptures(parsed.subject)).some((candidate) =>
           candidate.data.appId === parsed.appId && candidate.data.triggerId === parsed.triggerId);
-        if (!outstanding && !(await anyLiveAutomationGrant(parsed.subject, parsed.appId, parsed.triggerId))) {
-          const found = await appRecord(parsed.appId);
+        if (
+          !outstanding
+          && !(await grants.anyLiveAutomationGrant(parsed.subject, parsed.appId, parsed.triggerId))
+        ) {
+          const found = await appRows.appRecord(parsed.appId);
           if (found !== null && found.row.subject === parsed.subject && found.row.enabled) {
-            await disarmTrigger(found.record, found.row, parsed.triggerId);
+            await armed.disarmTrigger(found.record, found.row, parsed.triggerId);
           }
         }
       }
@@ -199,7 +217,7 @@ const createDecisionSubscriber = (
       const runId = data.request.ctx.trigger?.runId;
       const runRow = runId === undefined ? null : await config.store.records(RUNS).get(runId);
       const triggerId = runRow === null ? undefined : parseRunRecord(runRow).triggerId;
-      if (await spendApproval(approval)) await mintGrant(data.request, triggerId);
+      if (await spendApproval(approval)) await grants.mintGrant(data.request, triggerId);
     }
   };
 
@@ -207,7 +225,7 @@ const createDecisionSubscriber = (
 };
 
 /** What a consent moment COVERS, before anything is asked. */
-const createConsentSurface = (): Pick<AutomationsEngineContext, "consentSurface"> => {
+const createConsentSurface = (): Pick<ConsentAccess, "consentSurface"> => {
   /** The tools a consent moment covers. Steps DECLARE their surface; an agentic
    *  run declares one too when it was authored with one (`run.tools`), and falls
    *  back to every bound descriptor THE LAW would still let it reach away when it
@@ -275,11 +293,11 @@ const createConsentSurface = (): Pick<AutomationsEngineContext, "consentSurface"
 
 /** 07 §3's arming half: the asks enable() has to raise for this subject. */
 const createGrantCapture = (
-  deps: Pick<ConsentDeps, "config" | "iso" | "liveGrant">
+  deps: Pick<ConsentDeps, "base" | "grants">
     & Pick<CaptureRows, "writeCapture" | "pendingCaptures">
-    & Pick<AutomationsEngineContext, "consentSurface">,
-): Pick<AutomationsEngineContext, "captureGrants"> => {
-  const { config, iso, liveGrant, writeCapture, pendingCaptures, consentSurface } = deps;
+    & Pick<ConsentAccess, "consentSurface">,
+): Pick<ConsentAccess, "captureGrants"> => {
+  const { base: { config, iso }, grants, writeCapture, pendingCaptures, consentSurface } = deps;
   /** The tools a consent moment has to ask THIS subject about: the automation's
    *  surface minus whatever they already hold a live standing grant for.
    *
@@ -325,7 +343,7 @@ const createGrantCapture = (
             authored,
             await config.resolveRisk?.({ id: id("call_"), tool, args: { slug } }, authored, ctx),
           );
-      if (await liveGrant(subject, appId, triggerId, descriptor, slug)) continue;
+      if (await grants.liveGrant(subject, appId, triggerId, descriptor, slug)) continue;
       const pending = pendingForApp.get(consentKey(item));
       if (pending !== undefined) {
         const approval = await config.store.records(APPROVALS).get(pending.id);
@@ -382,10 +400,10 @@ const createGrantCapture = (
 
 /** The fire-time half: a step met a permission nobody granted. */
 const createPermissionMiss = (
-  deps: Pick<ConsentDeps, "config" | "terminal">
+  deps: Pick<ConsentDeps, "base" | "runRows">
     & Pick<CaptureRows, "writeCapture" | "isPendingAsk" | "pendingCaptures">,
-): Pick<AutomationsEngineContext, "needsPermission"> => {
-  const { config, terminal, writeCapture, isPendingAsk, pendingCaptures } = deps;
+): Pick<ConsentAccess, "needsPermission"> => {
+  const { base: { config }, runRows, writeCapture, isPendingAsk, pendingCaptures } = deps;
   /**
    * A step met a permission nobody has granted. The run ends HERE, loudly.
    *
@@ -477,7 +495,7 @@ const createPermissionMiss = (
       }
     }
     const named = slug === undefined ? `use ${step.tool}` : serviceToolPhrase(slug);
-    await terminal(
+    await runRows.terminal(
       run,
       ctx,
       "error",

--- a/packages/automations/src/document-edit-surface.ts
+++ b/packages/automations/src/document-edit-surface.ts
@@ -6,27 +6,25 @@
  * Lifted out of `createAutomationsEngine` unchanged.
  */
 import type { AppDocument, Trigger } from "@vendoai/core";
-import type { AutomationsEngineContext } from "./engine-context.js";
+import type { EngineBase } from "./engine-context.js";
 import type { AutomationsEngine } from "./index.js";
+import type { SponsorshipGateAccess } from "./sponsorship-gate.js";
 import { currentIntentHash, triggersOf, writeSponsorship } from "./sponsorship.js";
 
-export type DocumentEditSurfaceDeps = Pick<
-  AutomationsEngineContext,
-  "iso" | "sponsorships" | "sponsorshipState"
->;
+export type DocumentEditSurfaceDeps = { base: EngineBase; sponsorship: SponsorshipGateAccess };
 
 export const createDocumentEditSurface = (
-  { iso, sponsorships, sponsorshipState }: DocumentEditSurfaceDeps,
+  { base: { iso }, sponsorship }: DocumentEditSurfaceDeps,
 ): Pick<AutomationsEngine, "onDocumentEdit"> => {
   const onTriggerEdit = async (next: AppDocument, trigger: Trigger, editor: string): Promise<void> => {
     // Through the migrating door: an edit is the other way a pre-list row can be
     // reached before its automation ever fires again, and a row nobody can see
     // is a row a third party's edit cannot invalidate.
-    const state = await sponsorshipState(next, trigger.id);
+    const state = await sponsorship.sponsorshipState(next, trigger.id);
     if (state.kind !== "row" || state.row.status !== "active") return;
     const row = state.row;
     if (editor !== row.sponsor) {
-      await writeSponsorship(sponsorships(), {
+      await writeSponsorship(sponsorship.sponsorships(), {
         ...row,
         status: "invalidated",
         reason: "edit",
@@ -43,7 +41,7 @@ export const createDocumentEditSurface = (
     // card rather than here.
     const hash = currentIntentHash(next, trigger);
     if (hash !== row.intentHash) {
-      await writeSponsorship(sponsorships(), { ...row, intentHash: hash });
+      await writeSponsorship(sponsorship.sponsorships(), { ...row, intentHash: hash });
     }
   };
 

--- a/packages/automations/src/engine-context.ts
+++ b/packages/automations/src/engine-context.ts
@@ -1,48 +1,26 @@
 /**
- * The slice of `createAutomationsEngine`' closure its modules read.
+ * The primitives `createAutomationsEngine`' closure holds, and the wiring that
+ * builds its modules over them.
  *
  * `createAutomationsEngine` is an ASSEMBLER: every door it returns, and every
- * helper those doors lean on, lives in a module beside its contract and is
- * handed the pieces of the closure it needs. Every one of them names its
- * dependencies as a `Pick` of this one type, and returns a `Pick` of it too,
- * which keeps a single description of what the closure offers and lets
- * `createEngineContext` below wire them in dependency order.
+ * helper those doors lean on, lives in a module beside its contract. Each module
+ * declares what it offers as its OWN interface, in its own file, and is handed
+ * the other modules BY NAME — so a call site says where the function it calls
+ * lives. `EngineBase` below is the only thing they all share.
  *
  * Internal — not exported from the package root.
  */
-import type {
-  AppDocument,
-  ApprovalRequest,
-  Json,
-  PermissionGrant,
-  RecordStore,
-  RunContext,
-  RunId,
-  Step,
-  ToolDescriptor,
-  ToolOutcome,
-  Trigger,
-  TriggerSource,
-  VendoRecord,
-} from "@vendoai/core";
-import { createAppRows } from "./app-rows.js";
-import { createArmed } from "./armed.js";
-import { createConsent } from "./consent.js";
-import { createGrants } from "./grants.js";
-import { createRunExecution } from "./run-execution.js";
-import { createRunRows } from "./run-rows.js";
-import { createSponsorshipGate } from "./sponsorship-gate.js";
-import type { AutomationsConfig, RunRecord, RunStatus } from "./index.js";
-import type { Sponsorship } from "./sponsorship.js";
-import type {
-  AppRow,
-  Capture,
-  ConsentItem,
-  FiredSchedule,
-  InternalRunRecord,
-} from "./types.js";
+import { createAppRows, type AppRowsAccess } from "./app-rows.js";
+import { createArmed, type ArmedAccess } from "./armed.js";
+import { createConsent, type ConsentAccess } from "./consent.js";
+import { createGrants, type GrantsAccess } from "./grants.js";
+import { createRunExecution, type RunExecutionAccess } from "./run-execution.js";
+import { createRunRows, type RunRowsAccess } from "./run-rows.js";
+import { createSponsorshipGate, type SponsorshipGateAccess } from "./sponsorship-gate.js";
+import type { AutomationsConfig } from "./index.js";
 
-export interface AutomationsEngineContext {
+/** The closure primitives every module reads. */
+export interface EngineBase {
   config: AutomationsConfig;
   /** The clock, through the testability seam. */
   now(): Date;
@@ -56,148 +34,22 @@ export interface AutomationsEngineContext {
   abortControllers: Map<string, AbortController>;
   /** Whether THIS engine instance fires this trigger kind itself (07 §1). */
   firesLocally(kind: "schedule" | "external"): boolean;
+}
 
-  // ── app-rows.ts ────────────────────────────────────────────────────────────
-  /** The app row and its record, or null when there is none. */
-  appRecord(appId: string): Promise<{ record: VendoRecord; row: AppRow } | null>;
-  /** The app, for a caller allowed to CHANGE it — null when absent OR refused. */
-  editableAppOrNull(appId: string, ctx: RunContext): Promise<{ record: VendoRecord; row: AppRow } | null>;
-  /** The same door, existence-masked, for callers that must refuse. */
-  editableApp(appId: string, ctx: RunContext): Promise<{ record: VendoRecord; row: AppRow }>;
-  /** The named trigger of an app, validated. */
-  declaredTrigger(doc: AppDocument, triggerId: string): Trigger;
-  /** The app row write that re-derives the per-kind trigger refs. */
-  writeApp(record: VendoRecord, row: AppRow): Promise<void>;
-  /** §9.3's `can(editor)`, through the config seam. */
-  canEdit(ctx: RunContext, row: AppRow, appId: string): Promise<boolean>;
-  /** The app rows that fire on this trigger kind, by its per-kind ref. */
-  appsFiringOn(kind: TriggerSource["kind"], refs?: Record<string, string>): Promise<VendoRecord[]>;
-
-  // ── armed.ts ───────────────────────────────────────────────────────────────
-  /** Turn ONE (app, trigger) arm row on or off. */
-  setArmed(appId: string, triggerId: string, armed: boolean): Promise<void>;
-  /** This app's armed triggers, given the armed keys already fetched. */
-  armedTriggers(row: AppRow, armed: ReadonlySet<string>): Trigger[];
-  /** The armed set for these app rows. */
-  armedFor(rows: readonly AppRow[]): Promise<Set<string>>;
-  /** The same question for one trigger. */
-  isArmed(row: AppRow, triggerId: string): Promise<boolean>;
-  /** Turn ONE trigger off, leaving the app's others exactly as they were. */
-  disarmTrigger(record: VendoRecord, row: AppRow, triggerId: string): Promise<void>;
-
-  // ── grants.ts ──────────────────────────────────────────────────────────────
-  /** The bound tool surface, by name, for a present-time ceremony. */
-  descriptors(ctx: RunContext): Promise<Map<string, ToolDescriptor>>;
-  /** Every LIVE standing grant this (app, trigger) holds for the subject. */
-  liveAutomationGrants(
-    subject: string,
-    appId: string,
-    triggerId: string,
-    tool?: string,
-  ): Promise<PermissionGrant[]>;
-  /** Whether this exact descriptor (and service action) is already granted. */
-  liveGrant(
-    subject: string,
-    appId: string,
-    triggerId: string,
-    descriptor: ToolDescriptor,
-    slug?: string,
-  ): Promise<boolean>;
-  /** The service-action slugs THIS firing holds a live grant for. */
-  grantedServiceSlugs(subject: string, appId: string, triggerId: string): Promise<string[]>;
-  /** Whether the TRIGGER holds ANY live automation-source standing grant. */
-  anyLiveAutomationGrant(subject: string, appId: string, triggerId: string): Promise<boolean>;
-  /** The standing grant a decided approval mints, scoped to its slug. */
-  mintGrant(request: ApprovalRequest, triggerId: string | undefined): Promise<string>;
-
-  // ── run-rows.ts ────────────────────────────────────────────────────────────
-  /** A `run`-kind audit event under the run's own away context. */
-  audit(ctx: RunContext, status: string, extra?: Record<string, Json>): Promise<void>;
-  /** The run row write that never overwrites a terminal row. */
-  writeRun(record: InternalRunRecord): Promise<boolean>;
-  /** The terminal landing every door ends on. */
-  terminal(
-    run: InternalRunRecord,
-    ctx: RunContext,
-    status: Extract<RunStatus, "ok" | "error" | "stopped">,
-    summary: string,
-    error?: NonNullable<RunRecord["error"]>,
-  ): Promise<void>;
-  /** Append one step outcome to the in-flight run. */
-  appendOutcome(run: InternalRunRecord, step: Step, outcome: ToolOutcome): void;
-  /** Land the run on the failure a step's own expressions produced. */
-  failStep(run: InternalRunRecord, ctx: RunContext, step: Step, error: unknown): Promise<void>;
-  /** Whether this run has already ended — stopped here, or terminal on disk. */
-  finishStoppedIfNeeded(run: InternalRunRecord): Promise<boolean>;
-
-  // ── sponsorship-gate.ts ────────────────────────────────────────────────────
-  /** The sponsorship collection. */
-  sponsorships(): RecordStore;
-  /** The era markers that outlive an erase of the sponsor. */
-  sponsoredEra(): RecordStore;
-  /** The ONE sponsorship read every gate goes through. */
-  sponsorshipState(
-    doc: AppDocument,
-    triggerId: string,
-  ): Promise<{ kind: "none" } | { kind: "erased" } | { kind: "row"; row: Sponsorship; revision?: string }>;
-  /** Every sponsorship row for these apps' triggers, in ONE query. */
-  sponsorshipsFor(rows: readonly AppRow[]): Promise<Map<string, Sponsorship>>;
-  /** The run's context before any seam is consulted. */
-  baseRunContext(run: InternalRunRecord, subject: string): RunContext;
-  /** §9.9 — the run's identity is its SPONSOR. */
-  runContext(doc: AppDocument, run: InternalRunRecord, subject: string): Promise<RunContext>;
-  /** §9.9's fire-time gate, in ONE place. */
-  sponsorshipRefusal(
-    app: AppRow,
-    trigger: Trigger,
-    ctx: RunContext,
-  ): Promise<{ reason: NonNullable<Sponsorship["reason"]>; summary: string } | undefined>;
-
-  // ── consent.ts ─────────────────────────────────────────────────────────────
-  /** A capture row, keyed by the approval it is the ask for. */
-  writeCapture(approvalId: string, capture: Capture): Promise<void>;
-  /** Is this approval still an open question? */
-  isPendingAsk(approvalId: string): Promise<boolean>;
-  /** Every still-pending capture for the subject, parsed. */
-  pendingCaptures(subject: string): Promise<Array<{ id: string; data: Capture }>>;
-  /** Claim the approval's one-time transition before granting anything. */
-  spendApproval(record: VendoRecord): Promise<boolean>;
-  /** The guard's decision subscriber: mint, clear, and disarm on a bare no. */
-  handleDecision(approvalId: string, approved: boolean): Promise<void>;
-  /** The tools a consent moment covers. */
-  consentSurface(trigger: Trigger, byName: Map<string, ToolDescriptor>): Promise<ConsentItem[]>;
-  /** 07 §3 — the asks arming has to raise for this subject. */
-  captureGrants(
-    doc: AppDocument,
-    trigger: Trigger,
-    byName: Map<string, ToolDescriptor>,
-    ctx: RunContext,
-  ): Promise<{ missing: ApprovalRequest[]; grantSetId: string }>;
-  /** A step met a permission nobody has granted. The run ends HERE, loudly. */
-  needsPermission(
-    run: InternalRunRecord,
-    ctx: RunContext,
-    step: Step,
-    approvalId: string,
-  ): Promise<void>;
-
-  // ── run-execution.ts ───────────────────────────────────────────────────────
-  /** Mint the run id synchronously; run the automation on the returned promise. */
-  launchRun(
-    app: AppRow,
-    declared: Trigger,
-    kind: TriggerSource["kind"],
-    event: Json,
-    lineage?: RunId,
-  ): { runId: RunId; done: Promise<void> };
-  /** The same launch, awaited — for the doors that fire one run at a time. */
-  startRun(app: AppRow, trigger: Trigger, kind: TriggerSource["kind"], event: Json): Promise<RunId>;
-  /** Fired schedules, with bounded parallelism and an optional per-run timeout. */
-  runFiredSchedules(fired: readonly FiredSchedule[]): Promise<RunId[]>;
+/** The engine's modules, by name — what every surface is handed a slice of. */
+export interface EngineModules {
+  base: EngineBase;
+  appRows: AppRowsAccess;
+  armed: ArmedAccess;
+  grants: GrantsAccess;
+  runRows: RunRowsAccess;
+  sponsorship: SponsorshipGateAccess;
+  consent: ConsentAccess;
+  execution: RunExecutionAccess;
 }
 
 /** 07 §1 — `createAutomationsEngine`' closure, wired in dependency order. */
-export const createEngineContext = (config: AutomationsConfig): AutomationsEngineContext => {
+export const createEngineModules = (config: AutomationsConfig): EngineModules => {
   const now = (): Date => config.now?.() ?? new Date();
   const iso = (): string => now().toISOString();
   const stopped = new Set<string>();
@@ -207,13 +59,13 @@ export const createEngineContext = (config: AutomationsConfig): AutomationsEngin
   const firesLocally = (kind: "schedule" | "external"): boolean =>
     config.localTriggerKinds === undefined || config.localTriggerKinds.has(kind);
 
-  const base = { config, now, iso, stopped, active, abortControllers, firesLocally };
-  const appRows = createAppRows(base);
-  const armed = createArmed({ ...base, ...appRows });
-  const grants = createGrants(base);
-  const runRows = createRunRows(base);
-  const sponsorship = createSponsorshipGate({ ...base, ...appRows });
-  const consent = createConsent({ ...base, ...appRows, ...armed, ...grants, ...runRows });
-  const execution = createRunExecution({ ...base, ...grants, ...runRows, ...sponsorship, ...consent });
-  return { ...base, ...appRows, ...armed, ...grants, ...runRows, ...sponsorship, ...consent, ...execution };
+  const base: EngineBase = { config, now, iso, stopped, active, abortControllers, firesLocally };
+  const appRows = createAppRows({ base });
+  const armed = createArmed({ base, appRows });
+  const grants = createGrants({ base });
+  const runRows = createRunRows({ base });
+  const sponsorship = createSponsorshipGate({ base, appRows });
+  const consent = createConsent({ base, appRows, armed, grants, runRows });
+  const execution = createRunExecution({ base, grants, runRows, sponsorship, consent });
+  return { base, appRows, armed, grants, runRows, sponsorship, consent, execution };
 };

--- a/packages/automations/src/engine.ts
+++ b/packages/automations/src/engine.ts
@@ -1,6 +1,6 @@
 import { createArmingSurface } from "./arming-surface.js";
 import { createDocumentEditSurface } from "./document-edit-surface.js";
-import { createEngineContext } from "./engine-context.js";
+import { createEngineModules } from "./engine-context.js";
 import { createIngestionSurface } from "./ingestion-surface.js";
 import { createListSurface } from "./list-surface.js";
 import { createRunsSurface } from "./runs-surface.js";
@@ -9,24 +9,25 @@ import type { AutomationsConfig, AutomationsEngine } from "./index.js";
 /**
  * 07 §1 — construct the arming, listing, ingestion and run-history surface.
  *
- * An assembler, and nothing else: `createEngineContext` wires the closure
+ * An assembler, and nothing else: `createEngineModules` wires the closure
  * (engine-context.ts), and every door below is a module returning its slice of
- * `AutomationsEngine`. The engine's internal shapes moved to types.ts (the row
- * schemas and the doors that read them used to sit ~2,000 lines apart in this
- * file); nothing here is exported from the package root, so no importer changes.
+ * `AutomationsEngine`, handed the modules it reads BY NAME. The engine's
+ * internal shapes moved to types.ts (the row schemas and the doors that read
+ * them used to sit ~2,000 lines apart in this file); nothing here is exported
+ * from the package root, so no importer changes.
  */
 export const createAutomationsEngine = (config: AutomationsConfig): AutomationsEngine => {
-  const ctx = createEngineContext(config);
+  const modules = createEngineModules(config);
   // Returned as a thenable so a guard that awaits subscribers (ours does)
   // makes decide() deterministic through resumption; guards that don't still
   // get fire-and-forget behavior.
   config.guard.onApprovalDecision((approvalId, approved) =>
-    ctx.handleDecision(approvalId, approved) as unknown as void);
+    modules.consent.handleDecision(approvalId, approved) as unknown as void);
   return {
-    ...createArmingSurface(ctx),
-    ...createListSurface(ctx),
-    ...createIngestionSurface(ctx),
-    ...createDocumentEditSurface(ctx),
-    runs: createRunsSurface(ctx),
+    ...createArmingSurface(modules),
+    ...createListSurface(modules),
+    ...createIngestionSurface(modules),
+    ...createDocumentEditSurface(modules),
+    runs: createRunsSurface(modules),
   };
 };

--- a/packages/automations/src/grants.ts
+++ b/packages/automations/src/grants.ts
@@ -16,31 +16,47 @@ import {
   type RunContext,
   type ToolDescriptor,
 } from "@vendoai/core";
-import type { AutomationsEngineContext } from "./engine-context.js";
+import type { EngineBase } from "./engine-context.js";
 import { allRecords, id } from "./rows.js";
 import { scopeCovers } from "./steps.js";
 import { GRANTS } from "./types.js";
 
-export type GrantsDeps = Pick<AutomationsEngineContext, "config" | "now" | "iso">;
+export type GrantsDeps = { base: EngineBase };
 
-export type GrantsAccess = Pick<
-  AutomationsEngineContext,
-  | "descriptors"
-  | "liveAutomationGrants"
-  | "liveGrant"
-  | "grantedServiceSlugs"
-  | "anyLiveAutomationGrant"
-  | "mintGrant"
->;
+export interface GrantsAccess {
+  /** The bound tool surface, by name, for a present-time ceremony. */
+  descriptors(ctx: RunContext): Promise<Map<string, ToolDescriptor>>;
+  /** Every LIVE standing grant this (app, trigger) holds for the subject. */
+  liveAutomationGrants(
+    subject: string,
+    appId: string,
+    triggerId: string,
+    tool?: string,
+  ): Promise<PermissionGrant[]>;
+  /** Whether this exact descriptor (and service action) is already granted. */
+  liveGrant(
+    subject: string,
+    appId: string,
+    triggerId: string,
+    descriptor: ToolDescriptor,
+    slug?: string,
+  ): Promise<boolean>;
+  /** The service-action slugs THIS firing holds a live grant for. */
+  grantedServiceSlugs(subject: string, appId: string, triggerId: string): Promise<string[]>;
+  /** Whether the TRIGGER holds ANY live automation-source standing grant. */
+  anyLiveAutomationGrant(subject: string, appId: string, triggerId: string): Promise<boolean>;
+  /** The standing grant a decided approval mints, scoped to its slug. */
+  mintGrant(request: ApprovalRequest, triggerId: string | undefined): Promise<string>;
+}
 
 type GrantReads = Pick<
-  AutomationsEngineContext,
+  GrantsAccess,
   "descriptors" | "liveAutomationGrants" | "liveGrant" | "grantedServiceSlugs" | "anyLiveAutomationGrant"
 >;
 
 /** The reads: the bound surface, and the ONE live-grant query the three
  *  fire-time questions are asked from. */
-const createGrantReads = ({ config, now }: Pick<GrantsDeps, "config" | "now">): GrantReads => {
+const createGrantReads = ({ base: { config, now } }: GrantsDeps): GrantReads => {
   // `ctx` rides through so the projection seam (design §12) is not silently
   // dropped here. Both callers — enable and dryRun — are PRESENT-time
   // ceremonies, so nothing is withheld: the owner must still see and grant
@@ -132,8 +148,8 @@ const createGrantReads = ({ config, now }: Pick<GrantsDeps, "config" | "now">): 
 
 /** The write: what a decided approval turns into. */
 const createGrantMint = (
-  { config, iso }: Pick<GrantsDeps, "config" | "iso">,
-): Pick<AutomationsEngineContext, "mintGrant"> => {
+  { base: { config, iso } }: GrantsDeps,
+): Pick<GrantsAccess, "mintGrant"> => {
   const mintGrant = async (request: ApprovalRequest, triggerId: string | undefined): Promise<string> => {
     // A connector dispatch is granted at the width of its SLUG, never its tool
     // name: "allow use_service_tool" would be consent to the broker's whole

--- a/packages/automations/src/ingestion-surface.ts
+++ b/packages/automations/src/ingestion-surface.ts
@@ -8,9 +8,12 @@
 import { webhookSubject, type Json, type Trigger } from "@vendoai/core";
 import { Cron } from "croner";
 import { z } from "zod";
-import type { AutomationsEngineContext } from "./engine-context.js";
+import type { AppRowsAccess } from "./app-rows.js";
+import type { ArmedAccess } from "./armed.js";
+import type { EngineBase } from "./engine-context.js";
 import type { AutomationsEngine } from "./index.js";
 import { allRecords, appRef, id, message, parseAppRow } from "./rows.js";
+import type { RunExecutionAccess } from "./run-execution.js";
 import { triggerKey } from "./sponsorship.js";
 import { durationMs, validateTrigger } from "./steps.js";
 import {
@@ -25,29 +28,18 @@ import {
 } from "./types.js";
 import { readLimitedBody, signedWebhookBytes, verifySignature } from "./webhook-signature.js";
 
-export type IngestionSurfaceDeps = Pick<
-  AutomationsEngineContext,
-  | "config"
-  | "now"
-  | "iso"
-  | "firesLocally"
-  | "appsFiringOn"
-  | "armedTriggers"
-  | "armedFor"
-  | "startRun"
-  | "runFiredSchedules"
->;
+export type IngestionSurfaceDeps = {
+  base: EngineBase;
+  appRows: AppRowsAccess;
+  armed: ArmedAccess;
+  execution: RunExecutionAccess;
+};
 
 /** Schedules: the cursor claim, and the convenience timer around it. */
 const createTickDoor = (
-  deps: Pick<
-    IngestionSurfaceDeps,
-    "config" | "now" | "firesLocally" | "appsFiringOn"
-    | "armedTriggers" | "armedFor" | "runFiredSchedules"
-  >,
+  deps: IngestionSurfaceDeps,
 ): Pick<AutomationsEngine, "tick" | "start"> => {
-  const { config, now, firesLocally, appsFiringOn } = deps;
-  const { armedTriggers, armedFor, runFiredSchedules } = deps;
+  const { base: { config, now, firesLocally }, appRows, armed, execution } = deps;
   let tickTail: Promise<void> = Promise.resolve();
   const runTick: AutomationsEngine["tick"] = async (providedNow) => {
     // Cloud (or whatever other authority) already fires schedule automations for this
@@ -60,12 +52,12 @@ const createTickDoor = (
     // app for every subject, then batch every schedule cursor in one query (was an N+1 get).
     // Still ONE ref query with a trigger LIST: the ref says "this app has a schedule trigger
     // somewhere in its list", and the loop below picks out which ones.
-    const appRecords = await appsFiringOn("schedule");
+    const appRecords = await appRows.appsFiringOn("schedule");
     const rows = appRecords.map(parseAppRow);
-    const armed = await armedFor(rows);
+    const armedKeys = await armed.armedFor(rows);
     // Every armed schedule trigger, as (app, trigger) pairs — the unit that fires,
     // holds a cursor, and is claimed.
-    const dueTriggers = rows.flatMap((row) => armedTriggers(row, armed)
+    const dueTriggers = rows.flatMap((row) => armed.armedTriggers(row, armedKeys)
       .filter((trigger) => trigger.on.kind === "schedule")
       .map((trigger) => ({ row, trigger })));
     const scheduleRecords = config.store.records(SCHEDULE);
@@ -122,7 +114,7 @@ const createTickDoor = (
       if (!claimed) continue;
       fired.push({ row, trigger, scheduledFor, firedAt: atIso });
     }
-    return await runFiredSchedules(fired);
+    return await execution.runFiredSchedules(fired);
   };
 
   const tick: AutomationsEngine["tick"] = (providedNow) => {
@@ -148,9 +140,9 @@ const createTickDoor = (
 
 /** Host product events — THE host seam (vendo.emit). */
 const createEmitDoor = (
-  deps: Pick<IngestionSurfaceDeps, "config" | "appsFiringOn" | "armedTriggers" | "armedFor" | "startRun">,
+  deps: IngestionSurfaceDeps,
 ): Pick<AutomationsEngine, "emit"> => {
-  const { config, appsFiringOn, armedTriggers, armedFor, startRun } = deps;
+  const { base: { config }, appRows, armed, execution } = deps;
   const emit: AutomationsEngine["emit"] = async (event, payload, principal) => {
     // Ruling 2026-08-01 — an event emitted by a MEMBER of the org fires that
     // org's automations. Matching only the emitter's own subject meant an
@@ -173,13 +165,13 @@ const createEmitDoor = (
     const ids: string[] = [];
     // Indexed refs per owner (never a scan): the emitter, then each asserted org.
     for (const subject of [principal.subject, ...orgs]) {
-      const records = await appsFiringOn("host-event", { subject });
+      const records = await appRows.appsFiringOn("host-event", { subject });
       const rows = records.map(parseAppRow).filter((row) => row.subject === subject);
-      const armed = await armedFor(rows);
+      const armedKeys = await armed.armedFor(rows);
       for (const row of rows) {
         // Every matching trigger fires, not just the first: an app may listen to
         // one event from two triggers, and they are two automations.
-        for (const trigger of armedTriggers(row, armed)) {
+        for (const trigger of armed.armedTriggers(row, armedKeys)) {
           const source = trigger.on;
           // Membership is what makes the org's row reachable; whether this run may
           // proceed at all is the ordinary fire-time gate's call inside startRun
@@ -187,7 +179,7 @@ const createEmitDoor = (
           // so an org automation nobody holds any more stops loudly instead of
           // running for whoever touched the event.
           if (source.kind === "host-event" && source.event === event) {
-            ids.push(await startRun(row, trigger, "host-event", payload));
+            ids.push(await execution.startRun(row, trigger, "host-event", payload));
           }
         }
       }
@@ -209,7 +201,7 @@ type WebhookRefusals = {
 
 /** How a delivery is turned away — with the audit row that says it was. */
 const createWebhookRefusals = (
-  { config, iso }: Pick<IngestionSurfaceDeps, "config" | "iso">,
+  { base: { config, iso } }: Pick<IngestionSurfaceDeps, "base">,
 ): WebhookRefusals => {
   const envelope = (status: number, code: string, text: string): Response => Response.json(
     { error: { code, message: text } },
@@ -241,12 +233,9 @@ const createWebhookRefusals = (
 
 /** External events (Composio/webhooks), mounted by the umbrella. */
 const createWebhookDoor = (
-  deps: Pick<
-    IngestionSurfaceDeps,
-    "config" | "now" | "iso" | "firesLocally" | "appsFiringOn" | "armedTriggers" | "armedFor" | "startRun"
-  > & WebhookRefusals,
+  deps: IngestionSurfaceDeps & WebhookRefusals,
 ): Pick<AutomationsEngine, "webhook"> => {
-  const { config, now, iso, firesLocally, appsFiringOn, armedTriggers, armedFor, startRun } = deps;
+  const { base: { config, now, iso, firesLocally }, appRows, armed, execution } = deps;
   const { envelope, rejectWebhook } = deps;
   const inFlightDeliveries = new Set<string>();
   const webhook: AutomationsEngine["webhook"] = async (request) => {
@@ -285,14 +274,14 @@ const createWebhookDoor = (
       .map((entry) => entry.slice(3));
     const signed = signedWebhookBytes(headerResult.data.id, headerResult.data.timestamp, rawBytes);
     // Indexed per-kind ref, same as the tick — never a scan of every app row.
-    const appRecords = await appsFiringOn("external");
+    const appRecords = await appRows.appsFiringOn("external");
     const rows = appRecords.map(parseAppRow);
-    const armed = await armedFor(rows);
+    const armedKeys = await armed.armedFor(rows);
     // Verified per (app, TRIGGER): each external trigger holds its own secret, so
     // a signature that verifies for one says nothing about a sibling's.
     const verified: Array<{ row: AppRow; trigger: Trigger }> = [];
     for (const row of rows) {
-      for (const trigger of armedTriggers(row, armed)) {
+      for (const trigger of armed.armedTriggers(row, armedKeys)) {
         if (trigger.on.kind !== "external" || trigger.on.connector !== source) continue;
         const secretRecord = await config.store.records(WEBHOOK).get(triggerKey(row.doc.id, trigger.id));
         if (secretRecord === null) continue;
@@ -348,7 +337,7 @@ const createWebhookDoor = (
           deduped += 1;
           continue;
         }
-        ids.push(await startRun(row, trigger, "external", body));
+        ids.push(await execution.startRun(row, trigger, "external", body));
       } finally {
         inFlightDeliveries.delete(deliveryKey);
       }

--- a/packages/automations/src/list-surface.ts
+++ b/packages/automations/src/list-surface.ts
@@ -5,27 +5,28 @@
  *
  * Lifted out of `createAutomationsEngine` unchanged.
  */
-import type { AutomationsEngineContext } from "./engine-context.js";
+import type { AppRowsAccess } from "./app-rows.js";
+import type { ArmedAccess } from "./armed.js";
+import type { ConsentAccess } from "./consent.js";
+import type { EngineBase } from "./engine-context.js";
 import type { AutomationsEngine } from "./index.js";
 import { stopFor } from "./messages.js";
 import { allRecords, parseAppRow } from "./rows.js";
+import type { SponsorshipGateAccess } from "./sponsorship-gate.js";
 import { sponsorshipSchema, triggerKey, triggersOf } from "./sponsorship.js";
 import { APPS } from "./types.js";
 
-export type ListSurfaceDeps = Pick<
-  AutomationsEngineContext,
-  | "config"
-  | "canEdit"
-  | "armedTriggers"
-  | "armedFor"
-  | "pendingCaptures"
-  | "sponsorships"
-  | "sponsorshipsFor"
->;
+export type ListSurfaceDeps = {
+  base: EngineBase;
+  appRows: AppRowsAccess;
+  armed: ArmedAccess;
+  sponsorship: SponsorshipGateAccess;
+  consent: ConsentAccess;
+};
 
 export const createListSurface = (deps: ListSurfaceDeps): Pick<AutomationsEngine, "list"> => {
-  const { config, canEdit, armedTriggers, armedFor, pendingCaptures } = deps;
-  const { sponsorships, sponsorshipsFor } = deps;
+  const { base: { config }, appRows, armed } = deps;
+  const { sponsorship, consent } = deps;
 
   const list: AutomationsEngine["list"] = async (ctx) => {
     const subject = ctx.principal.subject;
@@ -42,7 +43,7 @@ export const createListSurface = (deps: ListSurfaceDeps): Pick<AutomationsEngine
       for (const record of await allRecords(config.store.records(APPS), { refs: { subject: org } })) {
         const row = parseAppRow(record);
         if (row.subject !== org || seen.has(row.doc.id)) continue;
-        if (await canEdit(ctx, row, row.doc.id)) {
+        if (await appRows.canEdit(ctx, row, row.doc.id)) {
           seen.add(row.doc.id);
           rows.push(row);
         }
@@ -58,7 +59,7 @@ export const createListSurface = (deps: ListSurfaceDeps): Pick<AutomationsEngine
     // Deduped: sponsorship is per (app, trigger), so sponsoring two triggers of
     // one app must still fetch that app once.
     const sponsoredElsewhere = [...new Set(
-      (await allRecords(sponsorships(), { refs: { subject } }))
+      (await allRecords(sponsorship.sponsorships(), { refs: { subject } }))
         .map((record) => sponsorshipSchema.safeParse(record.data))
         .flatMap((parsed) => parsed.success ? [parsed.data.appId] : [])
         .filter((appId) => !seen.has(appId)),
@@ -69,14 +70,14 @@ export const createListSurface = (deps: ListSurfaceDeps): Pick<AutomationsEngine
       const row = parseAppRow(record);
       // Sponsoring is not access: an editor whose grant was revoked keeps the
       // row but loses the door, so `can(editor)` still decides.
-      if (await canEdit(ctx, row, row.doc.id)) rows.push(row);
+      if (await appRows.canEdit(ctx, row, row.doc.id)) rows.push(row);
     }
     // Pending-captures projection: an armed trigger with outstanding standing-grant
     // asks is NOT plain enabled — surfaces render "waiting on N permissions"
     // from here (reload-safe; never from an enable() result held in memory).
     // Keyed per (app, trigger), because that is the unit a person allowed.
     const outstanding = new Map<string, { pendingGrants: number; grantSetId?: string }>();
-    for (const capture of await pendingCaptures(subject)) {
+    for (const capture of await consent.pendingCaptures(subject)) {
       const key = triggerKey(capture.data.appId, capture.data.triggerId);
       const entry = outstanding.get(key) ?? { pendingGrants: 0 };
       entry.pendingGrants += 1;
@@ -84,8 +85,8 @@ export const createListSurface = (deps: ListSurfaceDeps): Pick<AutomationsEngine
       outstanding.set(key, entry);
     }
     const automations = rows.filter((row) => triggersOf(row.doc).length > 0);
-    const sponsorRows = await sponsorshipsFor(automations);
-    const armed = await armedFor(automations);
+    const sponsorRows = await sponsorship.sponsorshipsFor(automations);
+    const armedKeys = await armed.armedFor(automations);
     const entries: Awaited<ReturnType<AutomationsEngine["list"]>> = [];
     for (const row of automations) {
       // "…and names a wider editor set when one exists": the count comes from
@@ -95,7 +96,7 @@ export const createListSurface = (deps: ListSurfaceDeps): Pick<AutomationsEngine
       const editors = config.appAccess?.list === undefined
         ? undefined
         : (await config.appAccess.list(ctx, row.doc.id)).length;
-      const armedHere = new Set(armedTriggers(row, armed).map((trigger) => trigger.id));
+      const armedHere = new Set(armed.armedTriggers(row, armedKeys).map((trigger) => trigger.id));
       entries.push({
         app: row.doc,
         triggers: triggersOf(row.doc).map((trigger) => {
@@ -105,14 +106,14 @@ export const createListSurface = (deps: ListSurfaceDeps): Pick<AutomationsEngine
           // sponsorship row (captured from their own Principal when they took the
           // automation on), so it reads the same for everyone; Vendo still holds no
           // directory and invents no name for anybody.
-          const sponsorship = sponsorRows.get(key);
-          const sponsor = sponsorship?.sponsor ?? row.subject;
-          const display = sponsorship?.display ?? (sponsor === subject ? ctx.principal.display : undefined);
+          const sponsorRow = sponsorRows.get(key);
+          const sponsor = sponsorRow?.sponsor ?? row.subject;
+          const display = sponsorRow?.display ?? (sponsor === subject ? ctx.principal.display : undefined);
           // A stopped automation says so HERE, in the same sentence the
           // stopped run row uses, so the list is a way back to it rather than a
           // place it silently disappeared from.
-          const stopped = sponsorship?.status === "invalidated"
-            ? stopFor(sponsorship.reason ?? "edit", row.doc.name)
+          const stopped = sponsorRow?.status === "invalidated"
+            ? stopFor(sponsorRow.reason ?? "edit", row.doc.name)
             : undefined;
           return {
             trigger,

--- a/packages/automations/src/run-execution.ts
+++ b/packages/automations/src/run-execution.ts
@@ -16,9 +16,13 @@ import {
   type Trigger,
   type TriggerSource,
 } from "@vendoai/core";
-import type { AutomationsEngineContext } from "./engine-context.js";
+import type { ConsentAccess } from "./consent.js";
+import type { EngineBase } from "./engine-context.js";
+import type { GrantsAccess } from "./grants.js";
 import { IDENTITY_UNAVAILABLE } from "./messages.js";
 import { clone, id, message } from "./rows.js";
+import type { RunRowsAccess } from "./run-rows.js";
+import type { SponsorshipGateAccess } from "./sponsorship-gate.js";
 import type { Sponsorship } from "./sponsorship.js";
 import {
   errorForOutcome,
@@ -30,30 +34,28 @@ import {
 } from "./steps.js";
 import type { AppRow, FiredSchedule, InternalRunRecord } from "./types.js";
 
-export type RunExecutionDeps = Pick<
-  AutomationsEngineContext,
-  | "config"
-  | "iso"
-  | "stopped"
-  | "active"
-  | "abortControllers"
-  | "grantedServiceSlugs"
-  | "audit"
-  | "writeRun"
-  | "terminal"
-  | "appendOutcome"
-  | "failStep"
-  | "finishStoppedIfNeeded"
-  | "baseRunContext"
-  | "runContext"
-  | "sponsorshipRefusal"
-  | "needsPermission"
->;
+export type RunExecutionDeps = {
+  base: EngineBase;
+  grants: GrantsAccess;
+  runRows: RunRowsAccess;
+  sponsorship: SponsorshipGateAccess;
+  consent: ConsentAccess;
+};
 
-export type RunExecutionAccess = Pick<
-  AutomationsEngineContext,
-  "launchRun" | "startRun" | "runFiredSchedules"
->;
+export interface RunExecutionAccess {
+  /** Mint the run id synchronously; run the automation on the returned promise. */
+  launchRun(
+    app: AppRow,
+    declared: Trigger,
+    kind: TriggerSource["kind"],
+    event: Json,
+    lineage?: RunId,
+  ): { runId: RunId; done: Promise<void> };
+  /** The same launch, awaited — for the doors that fire one run at a time. */
+  startRun(app: AppRow, trigger: Trigger, kind: TriggerSource["kind"], event: Json): Promise<RunId>;
+  /** Fired schedules, with bounded parallelism and an optional per-run timeout. */
+  runFiredSchedules(fired: readonly FiredSchedule[]): Promise<RunId[]>;
+}
 
 type StepsRunner = {
   continueSteps(
@@ -76,12 +78,9 @@ type AgenticRunner = {
 
 /** A steps run: the tool calls a trigger DECLARES, in order. */
 const createStepsRunner = (
-  deps: Pick<
-    RunExecutionDeps,
-    "config" | "terminal" | "appendOutcome" | "failStep" | "finishStoppedIfNeeded" | "needsPermission"
-  >,
+  deps: Pick<RunExecutionDeps, "base" | "runRows" | "consent">,
 ): StepsRunner => {
-  const { config, terminal, appendOutcome, failStep, finishStoppedIfNeeded, needsPermission } = deps;
+  const { base: { config }, runRows, consent } = deps;
   const executeCall = async (
     appId: string,
     step: Step,
@@ -106,7 +105,7 @@ const createStepsRunner = (
     const steps = trigger.run.steps;
     const stepOutputs: Record<string, Json> = {};
     for (let stepIndex = 0; stepIndex < steps.length; stepIndex += 1) {
-      if (await finishStoppedIfNeeded(run)) return;
+      if (await runRows.finishStoppedIfNeeded(run)) return;
       const step = steps[stepIndex] as Step;
       let items: Json[] | undefined;
       const outputs: Json[] = [];
@@ -119,7 +118,7 @@ const createStepsRunner = (
           items = validateForEachItems(step, evaluated);
         }
       } catch (error) {
-        await failStep(run, ctx, step, error);
+        await runRows.failStep(run, ctx, step, error);
         return;
       }
 
@@ -127,12 +126,12 @@ const createStepsRunner = (
         ? [{}]
         : items.map((item, index) => ({ item, index }));
       for (const iteration of iterations) {
-        if (await finishStoppedIfNeeded(run)) return;
+        if (await runRows.finishStoppedIfNeeded(run)) return;
         let args: Record<string, Json>;
         try {
           args = await stepArgs(step, event, stepOutputs, iteration.item);
         } catch (error) {
-          await failStep(run, ctx, step, error);
+          await runRows.failStep(run, ctx, step, error);
           return;
         }
         // Derived, not random: the guard's effect ledger tells "this call again"
@@ -155,15 +154,15 @@ const createStepsRunner = (
           args,
         };
         const outcome = await executeCall(app.doc.id, step, call, ctx);
-        if (await finishStoppedIfNeeded(run)) return;
-        appendOutcome(run, step, outcome);
+        if (await runRows.finishStoppedIfNeeded(run)) return;
+        runRows.appendOutcome(run, step, outcome);
         if (outcome.status === "pending-approval") {
-          await needsPermission(run, ctx, step, outcome.approvalId);
+          await consent.needsPermission(run, ctx, step, outcome.approvalId);
           return;
         }
         if (outcome.status !== "ok") {
           const error = errorForOutcome(outcome);
-          await terminal(run, ctx, "error", `stopped at ${step.id}: ${error.message}`, error);
+          await runRows.terminal(run, ctx, "error", `stopped at ${step.id}: ${error.message}`, error);
           return;
         }
         if (items === undefined) stepOutputs[step.id] = outcome.output;
@@ -172,7 +171,7 @@ const createStepsRunner = (
       if (items !== undefined) stepOutputs[step.id] = outputs;
     }
     const okCount = run.steps.filter((entry) => entry.outcome === "ok").length;
-    await terminal(run, ctx, "ok", `${okCount} ${okCount === 1 ? "step" : "steps"} ok`);
+    await runRows.terminal(run, ctx, "ok", `${okCount} ${okCount === 1 ? "step" : "steps"} ok`);
   };
 
   return { continueSteps };
@@ -180,9 +179,9 @@ const createStepsRunner = (
 
 /** An agentic run: one dispatch through the core `AgentRunner` seam. */
 const createAgenticRunner = (
-  deps: Pick<RunExecutionDeps, "config" | "iso" | "terminal" | "finishStoppedIfNeeded" | "grantedServiceSlugs">,
+  deps: Pick<RunExecutionDeps, "base" | "runRows" | "grants">,
 ): AgenticRunner => {
-  const { config, iso, terminal, finishStoppedIfNeeded, grantedServiceSlugs } = deps;
+  const { base: { config, iso }, runRows, grants } = deps;
   const runAgentic = async (
     trigger: Trigger,
     run: InternalRunRecord,
@@ -191,7 +190,7 @@ const createAgenticRunner = (
   ): Promise<void> => {
     if (trigger.run.kind !== "agentic") throw new VendoError("validation", "agentic run expected");
     if (config.runner === undefined) {
-      await terminal(
+      await runRows.terminal(
         run,
         ctx,
         "error",
@@ -208,7 +207,7 @@ const createAgenticRunner = (
       // guard's decision at call time.
       const listingCtx: RunContext = {
         ...ctx,
-        grantedServiceSlugs: await grantedServiceSlugs(
+        grantedServiceSlugs: await grants.grantedServiceSlugs(
           ctx.principal.subject,
           run.appId,
           run.triggerId,
@@ -226,19 +225,19 @@ const createAgenticRunner = (
       }, listingCtx);
       // Cross-instance stops cannot reach this process's controller, so the persisted
       // terminal-row check remains the best-effort fallback for a late result.
-      if (await finishStoppedIfNeeded(run)) return;
+      if (await runRows.finishStoppedIfNeeded(run)) return;
       run.steps = report.toolCalls.map(({ call, outcome }) => ({
         id: call.id,
         tool: call.tool,
         outcome,
         at: iso(),
       }));
-      await terminal(run, ctx, report.status, report.summary);
+      await runRows.terminal(run, ctx, report.status, report.summary);
     } catch (error) {
-      if (await finishStoppedIfNeeded(run)) return;
+      if (await runRows.finishStoppedIfNeeded(run)) return;
       // "error", not "not-implemented": that code means "no runner configured"
       // (above); a runner that crashed is an outage, not a missing feature.
-      await terminal(run, ctx, "error", message(error), { code: "error", message: message(error) });
+      await runRows.terminal(run, ctx, "error", message(error), { code: "error", message: message(error) });
     }
   };
 
@@ -248,14 +247,10 @@ const createAgenticRunner = (
 /** The launch every firing goes through: the §9.9 gate, then one of the two
  *  runners above. */
 const createRunLauncher = (
-  deps: Pick<
-    RunExecutionDeps,
-    "iso" | "stopped" | "active" | "abortControllers" | "audit" | "writeRun" | "terminal"
-    | "baseRunContext" | "runContext" | "sponsorshipRefusal"
-  > & StepsRunner & AgenticRunner,
-): Pick<AutomationsEngineContext, "launchRun"> => {
-  const { iso, stopped, active, abortControllers, audit, writeRun, terminal } = deps;
-  const { baseRunContext, runContext, sponsorshipRefusal, continueSteps, runAgentic } = deps;
+  deps: Pick<RunExecutionDeps, "base" | "runRows" | "sponsorship"> & StepsRunner & AgenticRunner,
+): Pick<RunExecutionAccess, "launchRun"> => {
+  const { base: { iso, stopped, active, abortControllers }, runRows, sponsorship } = deps;
+  const { continueSteps, runAgentic } = deps;
   // Mint the run and its record synchronously (so the id is known immediately), then
   // execute the whole automation on the returned `done` promise. Splitting the id from the
   // completion lets the tick collect runIds without blocking on each run to finish, and lets
@@ -306,13 +301,13 @@ const createRunLauncher = (
         //    callback or access seam threw. That throw used to escape here, and
         //    the schedule path swallows a rejected run, so the whole firing
         //    vanished: no row, no audit, nothing to look at.
-        let ctx = baseRunContext(record, app.subject);
+        let ctx = sponsorship.baseRunContext(record, app.subject);
         let stop:
           | { reason?: NonNullable<Sponsorship["reason"]>; summary: string; detail?: string }
           | undefined;
         try {
-          ctx = await runContext(app.doc, record, app.subject);
-          stop = await sponsorshipRefusal(app, trigger, ctx);
+          ctx = await sponsorship.runContext(app.doc, record, app.subject);
+          stop = await sponsorship.sponsorshipRefusal(app, trigger, ctx);
         } catch (error) {
           // The consumer sentence and the operator's detail part ways here:
           // `summary` is rendered verbatim in the automations panel, so
@@ -320,8 +315,8 @@ const createRunLauncher = (
           stop = { summary: IDENTITY_UNAVAILABLE(app.doc.name), detail: message(error) };
         }
         if (stop !== undefined) {
-          await writeRun(record);
-          await audit(
+          await runRows.writeRun(record);
+          await runRows.audit(
             ctx,
             stop.reason === undefined ? "sponsorship-check-failed" : "sponsorship-invalidated",
             {
@@ -330,14 +325,14 @@ const createRunLauncher = (
               ...(stop.detail === undefined ? {} : { detail: stop.detail }),
             },
           );
-          await terminal(record, ctx, "error", stop.summary, {
+          await runRows.terminal(record, ctx, "error", stop.summary, {
             code: stop.reason === undefined ? "error" : "blocked",
             message: stop.summary,
           });
           return;
         }
-        await writeRun(record);
-        await audit(ctx, "running");
+        await runRows.writeRun(record);
+        await runRows.audit(ctx, "running");
         active.add(runId);
         try {
           if (trigger.run.kind === "steps") {
@@ -362,9 +357,9 @@ const createRunLauncher = (
 /** How a launched run is WAITED on: one at a time for the doors that need the
  *  id back, and bounded parallelism with an optional per-run timeout for a tick. */
 const createRunPacing = (
-  deps: Pick<RunExecutionDeps, "config"> & Pick<AutomationsEngineContext, "launchRun">,
-): Pick<AutomationsEngineContext, "startRun" | "runFiredSchedules"> => {
-  const { config, launchRun } = deps;
+  deps: Pick<RunExecutionDeps, "base"> & Pick<RunExecutionAccess, "launchRun">,
+): Pick<RunExecutionAccess, "startRun" | "runFiredSchedules"> => {
+  const { base: { config }, launchRun } = deps;
   const startRun = async (
     app: AppRow,
     trigger: Trigger,

--- a/packages/automations/src/run-rows.ts
+++ b/packages/automations/src/run-rows.ts
@@ -13,20 +13,36 @@ import {
   type Step,
   type ToolOutcome,
 } from "@vendoai/core";
-import type { AutomationsEngineContext } from "./engine-context.js";
+import type { EngineBase } from "./engine-context.js";
 import type { RunRecord, RunStatus } from "./index.js";
 import { id, message, parseRunRecord, syncRun, terminalStatus } from "./rows.js";
 import { outcomeDetail } from "./steps.js";
 import { RUNS, type InternalRunRecord } from "./types.js";
 
-export type RunRowsDeps = Pick<AutomationsEngineContext, "config" | "iso" | "stopped">;
+export type RunRowsDeps = { base: EngineBase };
 
-export type RunRowsAccess = Pick<
-  AutomationsEngineContext,
-  "audit" | "writeRun" | "terminal" | "appendOutcome" | "failStep" | "finishStoppedIfNeeded"
->;
+export interface RunRowsAccess {
+  /** A `run`-kind audit event under the run's own away context. */
+  audit(ctx: RunContext, status: string, extra?: Record<string, Json>): Promise<void>;
+  /** The run row write that never overwrites a terminal row. */
+  writeRun(record: InternalRunRecord): Promise<boolean>;
+  /** The terminal landing every door ends on. */
+  terminal(
+    run: InternalRunRecord,
+    ctx: RunContext,
+    status: Extract<RunStatus, "ok" | "error" | "stopped">,
+    summary: string,
+    error?: NonNullable<RunRecord["error"]>,
+  ): Promise<void>;
+  /** Append one step outcome to the in-flight run. */
+  appendOutcome(run: InternalRunRecord, step: Step, outcome: ToolOutcome): void;
+  /** Land the run on the failure a step's own expressions produced. */
+  failStep(run: InternalRunRecord, ctx: RunContext, step: Step, error: unknown): Promise<void>;
+  /** Whether this run has already ended — stopped here, or terminal on disk. */
+  finishStoppedIfNeeded(run: InternalRunRecord): Promise<boolean>;
+}
 
-export const createRunRows = ({ config, iso, stopped }: RunRowsDeps): RunRowsAccess => {
+export const createRunRows = ({ base: { config, iso, stopped } }: RunRowsDeps): RunRowsAccess => {
   const audit = async (ctx: RunContext, status: string, extra: Record<string, Json> = {}): Promise<void> => {
     const event: AuditEvent = {
       id: id("aud_"),

--- a/packages/automations/src/runs-surface.ts
+++ b/packages/automations/src/runs-surface.ts
@@ -5,43 +5,44 @@
  * Lifted out of `createAutomationsEngine` unchanged.
  */
 import { VendoError, type RunId } from "@vendoai/core";
-import type { AutomationsEngineContext } from "./engine-context.js";
+import type { AppRowsAccess } from "./app-rows.js";
+import type { ArmedAccess } from "./armed.js";
+import type { EngineBase } from "./engine-context.js";
 import type { AutomationsEngine, RunRecord } from "./index.js";
 import { parseRunRecord, publicRun } from "./rows.js";
+import type { RunExecutionAccess } from "./run-execution.js";
+import type { RunRowsAccess } from "./run-rows.js";
+import type { SponsorshipGateAccess } from "./sponsorship-gate.js";
 import { triggerOf } from "./sponsorship.js";
 import { RUNS, RUNS_PAGE_LIMIT } from "./types.js";
 
-export type RunsSurfaceDeps = Pick<
-  AutomationsEngineContext,
-  | "config"
-  | "stopped"
-  | "active"
-  | "abortControllers"
-  | "editableAppOrNull"
-  | "isArmed"
-  | "runContext"
-  | "terminal"
-  | "launchRun"
->;
+export type RunsSurfaceDeps = {
+  base: EngineBase;
+  appRows: AppRowsAccess;
+  armed: ArmedAccess;
+  runRows: RunRowsAccess;
+  sponsorship: SponsorshipGateAccess;
+  execution: RunExecutionAccess;
+};
 
 /** The run history anyone who can edit the app reads. */
 const createRunReadDoors = (
-  deps: Pick<RunsSurfaceDeps, "config" | "editableAppOrNull">,
+  deps: Pick<RunsSurfaceDeps, "base" | "appRows">,
 ): Pick<AutomationsEngine["runs"], "get" | "list"> => {
-  const { config, editableAppOrNull } = deps;
+  const { base: { config }, appRows } = deps;
   const runsGet: AutomationsEngine["runs"]["get"] = async (runId, ctx) => {
     const stored = await config.store.records(RUNS).get(runId);
     if (stored === null) return null;
     const run = parseRunRecord(stored);
     // §8 editor = edit: the person the automation RUNS AS sees its history, not
     // only the app's owner. Ownership-only when no access seam is configured.
-    return await editableAppOrNull(run.appId, ctx) === null ? null : publicRun(run);
+    return await appRows.editableAppOrNull(run.appId, ctx) === null ? null : publicRun(run);
   };
 
   const runsList: AutomationsEngine["runs"]["list"] = async (filter, ctx) => {
     // Scope BEFORE paginating: filtering after the page both under-fills pages
     // and leaks a cursor (an existence oracle) to non-viewers.
-    if (filter.appId !== undefined && await editableAppOrNull(filter.appId, ctx) === null) {
+    if (filter.appId !== undefined && await appRows.editableAppOrNull(filter.appId, ctx) === null) {
       return { runs: [] };
     }
     const refs = {
@@ -70,7 +71,7 @@ const createRunReadDoors = (
         if (filter.triggerId !== undefined && run.triggerId !== filter.triggerId) continue;
         let mine = visible.get(run.appId);
         if (mine === undefined) {
-          mine = await editableAppOrNull(run.appId, ctx) !== null;
+          mine = await appRows.editableAppOrNull(run.appId, ctx) !== null;
           visible.set(run.appId, mine);
         }
         if (mine) runs.push(publicRun(run));
@@ -86,27 +87,23 @@ const createRunReadDoors = (
 
 /** The two doors that CHANGE a run: the kill switch, and "run it again". */
 const createRunControlDoors = (
-  deps: Pick<
-    RunsSurfaceDeps,
-    "config" | "stopped" | "active" | "abortControllers" | "editableAppOrNull"
-    | "isArmed" | "runContext" | "terminal" | "launchRun"
-  >,
+  deps: RunsSurfaceDeps,
 ): Pick<AutomationsEngine["runs"], "stop" | "rerun"> => {
-  const { config, stopped, active, abortControllers, editableAppOrNull } = deps;
-  const { isArmed, runContext, terminal, launchRun } = deps;
+  const { base: { config, stopped, active, abortControllers }, appRows } = deps;
+  const { armed, runRows, sponsorship, execution } = deps;
   const runsStop: AutomationsEngine["runs"]["stop"] = async (runId, ctx) => {
     const stored = await config.store.records(RUNS).get(runId);
     if (stored === null) throw new VendoError("not-found", `run not found: ${runId}`);
     const run = parseRunRecord(stored);
-    const app = await editableAppOrNull(run.appId, ctx);
+    const app = await appRows.editableAppOrNull(run.appId, ctx);
     if (app === null) throw new VendoError("not-found", `run not found: ${runId}`);
     if (run.status !== "running") {
       throw new VendoError("conflict", `run cannot be stopped from status ${run.status}`);
     }
     stopped.add(runId);
     abortControllers.get(runId)?.abort();
-    const runCtx = await runContext(app.row.doc, run, app.row.subject);
-    await terminal(run, runCtx, "stopped", "stopped by user");
+    const runCtx = await sponsorship.runContext(app.row.doc, run, app.row.subject);
+    await runRows.terminal(run, runCtx, "stopped", "stopped by user");
     if (!active.has(runId)) stopped.delete(runId);
   };
 
@@ -126,13 +123,13 @@ const createRunControlDoors = (
     const stored = await config.store.records(RUNS).get(runId);
     if (stored === null) throw new VendoError("not-found", `run not found: ${runId}`);
     const run = parseRunRecord(stored);
-    const app = await editableAppOrNull(run.appId, ctx);
+    const app = await appRows.editableAppOrNull(run.appId, ctx);
     if (app === null) throw new VendoError("not-found", `run not found: ${runId}`);
     const declared = triggerOf(app.row.doc, run.triggerId);
     if (declared === undefined) {
       throw new VendoError("conflict", `app has no trigger "${run.triggerId}" any more`);
     }
-    if (!await isArmed(app.row, run.triggerId)) {
+    if (!await armed.isArmed(app.row, run.triggerId)) {
       throw new VendoError("conflict", "this automation is off — turn it on to run it again");
     }
     // A run row from before the event was persisted has nothing to re-fire.
@@ -148,7 +145,7 @@ const createRunControlDoors = (
     // what proves the trigger still exists and is armed, but firing an edited
     // step list under the original lineage would move a completed call's
     // positional id off its own receipt and run it a second time.
-    const { runId: freshId, done } = launchRun(
+    const { runId: freshId, done } = execution.launchRun(
       app.row,
       run.__trigger ?? declared,
       run.trigger.kind,

--- a/packages/automations/src/sponsorship-gate.ts
+++ b/packages/automations/src/sponsorship-gate.ts
@@ -11,7 +11,8 @@ import {
   type RunContext,
   type Trigger,
 } from "@vendoai/core";
-import type { AutomationsEngineContext } from "./engine-context.js";
+import type { AppRowsAccess } from "./app-rows.js";
+import type { EngineBase } from "./engine-context.js";
 import { stopFor } from "./messages.js";
 import { allRecords } from "./rows.js";
 import {
@@ -28,26 +29,41 @@ import {
 } from "./sponsorship.js";
 import type { AppRow, InternalRunRecord } from "./types.js";
 
-export type SponsorshipGateDeps = Pick<AutomationsEngineContext, "config" | "iso" | "canEdit">;
+export type SponsorshipGateDeps = { base: EngineBase; appRows: AppRowsAccess };
 
-export type SponsorshipGateAccess = Pick<
-  AutomationsEngineContext,
-  | "sponsorships"
-  | "sponsoredEra"
-  | "sponsorshipState"
-  | "sponsorshipsFor"
-  | "baseRunContext"
-  | "runContext"
-  | "sponsorshipRefusal"
->;
+export interface SponsorshipGateAccess {
+  /** The sponsorship collection. */
+  sponsorships(): RecordStore;
+  /** The era markers that outlive an erase of the sponsor. */
+  sponsoredEra(): RecordStore;
+  /** The ONE sponsorship read every gate goes through. */
+  sponsorshipState(
+    doc: AppDocument,
+    triggerId: string,
+  ): Promise<{ kind: "none" } | { kind: "erased" } | { kind: "row"; row: Sponsorship; revision?: string }>;
+  /** Every sponsorship row for these apps' triggers, in ONE query. */
+  sponsorshipsFor(rows: readonly AppRow[]): Promise<Map<string, Sponsorship>>;
+  /** The run's context before any seam is consulted. */
+  baseRunContext(run: InternalRunRecord, subject: string): RunContext;
+  /** §9.9 — the run's identity is its SPONSOR. */
+  runContext(doc: AppDocument, run: InternalRunRecord, subject: string): Promise<RunContext>;
+  /** §9.9's fire-time gate, in ONE place. */
+  sponsorshipRefusal(
+    app: AppRow,
+    trigger: Trigger,
+    ctx: RunContext,
+  ): Promise<{ reason: NonNullable<Sponsorship["reason"]>; summary: string } | undefined>;
+}
 
 type SponsorshipReader = Pick<
-  AutomationsEngineContext,
+  SponsorshipGateAccess,
   "sponsorships" | "sponsoredEra" | "sponsorshipState" | "sponsorshipsFor"
 >;
 
 /** The sponsorship rows, and the ONE read every gate goes through. */
-const createSponsorshipReader = ({ config }: Pick<SponsorshipGateDeps, "config">): SponsorshipReader => {
+const createSponsorshipReader = (
+  { base: { config } }: Pick<SponsorshipGateDeps, "base">,
+): SponsorshipReader => {
   const sponsorships = (): RecordStore => config.store.records(SPONSORSHIPS);
   const sponsoredEra = (): RecordStore => config.store.records(SPONSORED);
 
@@ -87,10 +103,9 @@ const createSponsorshipReader = ({ config }: Pick<SponsorshipGateDeps, "config">
 
 /** §9.9 — who a firing runs as, and whether it may run at all. */
 const createRunIdentity = (
-  deps: Pick<SponsorshipGateDeps, "config" | "iso" | "canEdit">
-    & Pick<SponsorshipReader, "sponsorships" | "sponsorshipState">,
-): Pick<AutomationsEngineContext, "baseRunContext" | "runContext" | "sponsorshipRefusal"> => {
-  const { config, iso, canEdit, sponsorships, sponsorshipState } = deps;
+  deps: SponsorshipGateDeps & Pick<SponsorshipReader, "sponsorships" | "sponsorshipState">,
+): Pick<SponsorshipGateAccess, "baseRunContext" | "runContext" | "sponsorshipRefusal"> => {
+  const { base: { config, iso }, appRows, sponsorships, sponsorshipState } = deps;
   /** The run's context before any seam is consulted — a pure function of the run
    *  and a subject, so it cannot fail. It is what a failed identity resolution
    *  still audits under: a fire that cannot even resolve who it runs as must
@@ -173,7 +188,7 @@ const createRunIdentity = (
     // above), "grants" is the person still being there and having lost access —
     // which is exactly what a failed `can(editor)` means. They produce different
     // consumer sentences, so the label is not cosmetic.
-    if (!await canEdit(ctx, app, app.doc.id)) return await invalidate("grants");
+    if (!await appRows.canEdit(ctx, app, app.doc.id)) return await invalidate("grants");
     return undefined;
   };
 


### PR DESCRIPTION
## Before / after

`engine-context.ts` held ONE flat interface with ~40 functions contributed by
seven modules. Every module declared its deps as `Pick<AutomationsEngineContext,
"x" | "y">`, received one flattened bag, and called helpers bare — so no call
site said where a function lived.

```
BEFORE                                  AFTER

AutomationsEngineContext (155 lines)    EngineBase { config, now, iso, stopped,
  config, now, iso, stopped, ...                     active, abortControllers,
  appRecord, editableApp, ...                        firesLocally }
  setArmed, armedFor, ...
  liveGrant, mintGrant, ...             app-rows.ts        → AppRowsAccess
  terminal, failStep, ...               armed.ts           → ArmedAccess
  sponsorshipRefusal, ...               grants.ts          → GrantsAccess
  captureGrants, needsPermission, ...   run-rows.ts        → RunRowsAccess
  launchRun, startRun, ...              sponsorship-gate.ts→ SponsorshipGateAccess
        │                               consent.ts         → ConsentAccess
        │  Pick<…, "x"|"y">             run-execution.ts   → RunExecutionAccess
        ▼                                       │
  every module + every surface                  │  createConsent({ base, appRows,
  gets one flattened bag                        ▼               armed, grants, runRows })
  liveGrant(...)   terminal(...)         grants.liveGrant(...)  runRows.terminal(...)
```

`engine-context.ts` shrinks from 219 lines to 71: `EngineBase`, the
`EngineModules` registry, and `createEngineModules` wiring the modules in
dependency order. The five surfaces (arming, list, ingestion, runs,
document-edit) likewise take named modules rather than Picks of the bag.

Net **-96 lines** across 14 files.

## Zero public-API change

`git diff origin/main -- packages/automations/src/index.ts` is **empty** — the
public surface is byte-identical. Nothing outside `packages/automations/src`
ever referenced `AutomationsEngineContext`.

## Test adjustments

**None.** The four test files import only `../src/index.js` and
`../src/sponsorship.js`, neither of which changed. All 98 tests pass unchanged.

## What moved, precisely

- Per-function doc comments moved from the master inventory onto each module's
  own interface, keeping the contract references (07 §, §9.3, §9.9) with their
  modules. No comment was rewritten beyond the two whose subject was the deleted
  type (the `engine-context.ts` header and the `engine.ts` assembler note).
- `createEngineContext` → `createEngineModules`: it returns the named modules
  now, not a flattened context. One call site.
- Two LOCAL variable renames, forced by the compartment names now occupying
  those identifiers in the same scope (no engine function was renamed):
  - `const armed = await armedFor(rows)` → `armedKeys` (list-surface ×1,
    ingestion-surface ×3) — the `armed` module is what `armedFor` is called on.
  - `const sponsorship = sponsorRows.get(key)` → `sponsorRow` (list-surface ×1)
    — matches the `sponsorRows` map it comes from.

## Gate

```
pnpm build         21/21 successful
pnpm test:affected 32/32 tasks — automations 98 passed, vendo 2056 passed | 42 skipped
pnpm typecheck     42/42 successful
pnpm lint          4/4 successful, 0 errors
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the automations engine to replace the flat `AutomationsEngineContext` with named module compartments for clearer dependencies and call sites. No behavior or public API changes.

- **Refactors**
  - Added `EngineBase` for shared primitives; each module now exposes its own `XxxAccess` interface.
  - Replaced `createEngineContext` with `createEngineModules`; modules are wired in dependency order and passed by name.
  - Call sites now reference modules explicitly (e.g., `grants.liveGrant`, `runRows.terminal`).
  - Updated all surfaces (arming, list, ingestion, runs, document-edit) to consume named modules.
  - Moved doc comments to each module’s interface; only local variable renames where needed to avoid name collisions.
  - `engine-context.ts` shrinks significantly; net −96 lines across 14 files.
  - Tests unchanged and still passing; `src/index.ts` is byte-identical (no public API change).

<sup>Written for commit 2efb7fb226e455c168031ebf65507715df7b9524. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

