### PR TITLE
feat(apps)!: format constitution — one definition, and a test that fails on drift

### DIFF
--- a/.changeset/apps-format-constitution.md
+++ b/.changeset/apps-format-constitution.md
@@ -1,0 +1,63 @@
+---
+"@vendoai/core": major
+"@vendoai/apps": major
+---
+
+The app format has one definition, and a test that fails when a mirror drifts
+
+The format was kept by hand in four places — the contract, core's pinned limits,
+the manual the agent reads, and the public docs — and they disagreed. The manual
+promised "16 islands, 64 KB each" and never mentioned the **256 KB total** the
+validator also enforces, so a build that obeyed the manual could exceed a budget
+it was never told about and fail to validate for a reason it could not see.
+Nothing about enforcement changed; the manual and the docs are now generated
+from, and pinned to, the same constants.
+
+**A generated component may now be a bundle, and nothing migrates.**
+`AppDocument.components` values widen from `string` to `ComponentEntry` —
+either the legacy bare source string or a `ComponentBundle`
+(`{ source, modules?, styles?, sampleProps?, origin: "authored" | "seeded" }`).
+Backward compatible **by construction**: a stored bare string still reads, and
+every reader goes through `bundleOf(entry)`, which returns
+`{ source, origin: "authored" }` for one. No document is rewritten, no version
+is minted, and an app stored before this release opens unchanged.
+
+*If you read `document.components` yourself*, that is the one change to make:
+
+```ts
+// before
+const source = document.components?.[name];
+// after
+import { bundleOf, componentSources } from "@vendoai/apps/contract";
+const source = bundleOf(document.components?.[name] ?? "").source;
+const asSources = componentSources(document.components); // the whole map
+```
+
+`ComponentBundle`, `componentBundleSchema`, `ComponentEntry`,
+`componentEntrySchema` and `bundleOf` are **declared in `@vendoai/core`**, beside
+the `AppDocument` field they type — core's store conformance kit parses a stored
+row with `appDocumentSchema` and cannot reach up into `@vendoai/apps`. The
+contract door **re-exports** them and never re-declares them, so
+`@vendoai/apps/contract` remains the one place to import the format from. Same
+rule as `TREE_MAX_GENERATED_COMPONENTS` / `TREE_MAX_COMPONENT_SOURCE_BYTES` /
+`TREE_MAX_TOTAL_COMPONENT_BYTES`, which are re-exported from core here too.
+
+**BREAKING — the plan dialect loses two leaf fields.** `PlanLeaf` no longer has
+`query` or `attrs`, and `<Leaf>` no longer parses a `query` attribute or
+collects arrangement hints. Both were parsed and fact-checked with no downstream
+consumer. A `<Leaf query="…" col="2"/>` still compiles — the extra attributes are
+simply ignored — so no plan text breaks; only code reading `leaf.query` or
+`leaf.attrs` does. The plan's top-level `<Query>` list and `<Cannot>` are
+unaffected.
+
+**New on `@vendoai/apps/contract`: the real validator surface.** `componentMapError`
+and `utf8ByteLength` (the generated-component map rules, measured in UTF-8 bytes),
+`SAFE_COMPONENT_NAME`, and `componentSources`. A consumer validating a component
+map should call `componentMapError` rather than re-implementing the byte
+accounting and the reserved-name check against `KIT_COMPONENT_NAMES`.
+
+**The Kit vocabulary is one list.** `KIT_COMPONENT_NAMES` derives from `KIT_SPECS`,
+`kitComponentNames()` returns that list instead of recomputing it, and
+`WIRE_COMPONENT_NAMES` is `KIT_WIRE_COMPONENT_NAMES` re-exported — the same
+binding, not a second array. All three names are still exported and their values
+are unchanged.

--- a/docs-site/concepts/generated-ui.mdx
+++ b/docs-site/concepts/generated-ui.mdx
@@ -107,6 +107,14 @@ Failure handling for both hops is specified in
 The exact flags, environment contracts, and failure rules behind the model
 above.
 
+### Component limits
+
+A generated app carries at most **16** generated components, each at most
+**64 KB** of source, and **256 KB** across all of them together. The document
+validator enforces all three, and the format manual the agent reads is
+generated from the same three constants — so a build that obeys the manual
+never runs into a budget the manual did not mention.
+
 ### Environment
 
 The [app machine environment](/reference/environment-variables#app-machine-environment)

--- a/packages/apps/src/contract/component-bundle.ts
+++ b/packages/apps/src/contract/component-bundle.ts
@@ -8,7 +8,31 @@
  * in to speak the format. `@vendoai/actions` re-exports every name from here, so
  * its public surface is unchanged.
  */
+import { bundleOf, type ComponentEntry } from "@vendoai/core";
 import { z } from "zod";
+
+/**
+ * The bundle itself, and the entry it sits in. Declared in `@vendoai/core`
+ * beside the `AppDocument.components` field it types — core's store conformance
+ * kit parses a stored row with `appDocumentSchema` and may not reach up into
+ * this package — and re-exported here, never re-declared, so the format door
+ * is the one place a consumer reads. Same rule as the three bundle limits.
+ */
+export {
+  bundleOf,
+  componentBundleSchema,
+  componentEntrySchema,
+  type ComponentBundle,
+  type ComponentEntry,
+} from "@vendoai/core";
+
+/** The stored map as bare sources — what the printer, the tree assembler and
+ *  the jail all want. The only place the whole map is unwrapped, so no caller
+ *  has to know a legacy entry from a bundle. */
+export const componentSources = (
+  components: Record<string, ComponentEntry> | undefined,
+): Record<string, string> =>
+  Object.fromEntries(Object.entries(components ?? {}).map(([name, entry]) => [name, bundleOf(entry).source]));
 
 /**
  * One captured module, content-addressed by the sha-256 hex of its canonical

--- a/packages/apps/src/contract/component-map.ts
+++ b/packages/apps/src/contract/component-map.ts
@@ -7,6 +7,8 @@ import {
   TREE_MAX_COMPONENT_SOURCE_BYTES,
   TREE_MAX_GENERATED_COMPONENTS,
   TREE_MAX_TOTAL_COMPONENT_BYTES,
+  bundleOf,
+  componentEntrySchema,
 } from "@vendoai/core";
 import { KIT_COMPONENT_NAMES } from "./kit/specs.js";
 
@@ -35,11 +37,13 @@ export function componentMapError(components: Record<string, unknown>): string |
     if (KIT_COMPONENT_NAMES.includes(name)) {
       return `generated component name "${name}" is reserved (Kit component)`;
     }
-    const source = components[name];
-    if (typeof source !== "string") {
+    // A stored entry is the legacy bare source string or a bundle; the byte
+    // budget is measured on the source either way, through the ONE reader.
+    const entry = componentEntrySchema.safeParse(components[name]);
+    if (!entry.success) {
       return `generated component "${name}" source must be a string`;
     }
-    const sourceBytes = utf8ByteLength(source);
+    const sourceBytes = utf8ByteLength(bundleOf(entry.data).source);
     if (sourceBytes > TREE_MAX_COMPONENT_SOURCE_BYTES) {
       return `generated component "${name}" source too large (max ${TREE_MAX_COMPONENT_SOURCE_BYTES} bytes)`;
     }

--- a/packages/apps/src/contract/genui/plan/compile.ts
+++ b/packages/apps/src/contract/genui/plan/compile.ts
@@ -29,7 +29,6 @@
 
 import { Cron } from "croner";
 import {
-  defineOwn,
   isPlainObject,
   type Json,
   safeErrorMessage,
@@ -66,10 +65,6 @@ export interface PlanCompileResult {
 /** One worker writes one whole group, and five parts is the most a group can
  *  hold together (spec: groups are the coherence unit). */
 const PLAN_MAX_GROUP_LEAVES = 5;
-
-/** A leaf's own fields; every other attribute is an arrangement hint
- *  (col/row/span) and rides along in `attrs`. */
-const LEAF_FIELDS: ReadonlySet<string> = new Set(["component", "query", "purpose"]);
 
 const PLAN_CLOSE = "</Plan>";
 const CANNOT_CLOSE = "</Cannot>";
@@ -114,9 +109,6 @@ interface PlanState {
   facts: PlanFacts;
   tools: ReadonlySet<string>;
   components: ReadonlySet<string>;
-  /** Every grammar-valid `<Query id>` in the document, pre-scanned, so a leaf
-   *  may reference a query declared further down. */
-  queryIds: ReadonlySet<string>;
 }
 
 /** The tokenizer records its own kebab-coded issues on the compile state; the
@@ -238,29 +230,10 @@ const compileLeaf = (plan: PlanState, group: PlanGroup): PlanLeaf | undefined =>
       `there is no component called "${component}". The components you can use are: ${nameList(plan.facts.components)}. Pick the closest fit.`,
     );
   }
-  const leaf: PlanLeaf = { component, purpose };
-  const query = stringAttr(props, "query");
-  if (query !== undefined) {
-    leaf.query = query;
-    if (!plan.queryIds.has(query)) {
-      plan.issues.push(
-        `the ${component} leaf reads a query called "${query}", but this plan declares no <Query id="${query}">. Declare it at the top of the plan, or drop the query attribute.`,
-      );
-    }
-  }
-  const arrangement: Record<string, string> = {};
-  for (const [key, value] of Object.entries(props)) {
-    if (LEAF_FIELDS.has(key)) continue;
-    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
-      defineOwn(arrangement, key, String(value));
-    } else {
-      plan.issues.push(
-        `the ${component} leaf's "${key}" is an arrangement hint like col="2", and ${describe(value)} cannot be one. It was dropped.`,
-      );
-    }
-  }
-  if (Object.keys(arrangement).length > 0) leaf.attrs = arrangement;
-  return leaf;
+  // Any other attribute is ignored: a leaf's whole contract is the component
+  // and the sentence, and the compiler is TOTAL — an extra attribute costs the
+  // plan nothing rather than dropping it.
+  return { component, purpose };
 };
 
 /** A group's children: `<Leaf>` elements only. Returns how many leaves the
@@ -508,7 +481,6 @@ const compilePlanUnsafe = (text: string, facts: PlanFacts): PlanCompileResult =>
     facts,
     tools: new Set(facts.tools),
     components: new Set(facts.components),
-    queryIds: declared.queryNames,
   };
   skipWhitespace(state);
   if (!opensRoot(state, "Plan")) {

--- a/packages/apps/src/contract/genui/plan/types.ts
+++ b/packages/apps/src/contract/genui/plan/types.ts
@@ -8,7 +8,7 @@
  * (island, server work) and honest refusals. Structure is exactly two levels
  * deep — groups hold leaves, nothing holds groups — because a group is the
  * coherence unit one fill worker writes whole. Arrangement inside a group is
- * attributes (col/row/span), never nesting.
+ * the group's own `layout`, never nesting.
  *
  * Tabs are NOT part of the shape: they derive from the groups' tab labels
  * (see {@link planTabs}).
@@ -22,14 +22,13 @@ export interface PlanQuery {
   input: Record<string, unknown>;
 }
 
-/** One part of a group: which component shows it, which query feeds it, and
- *  one sentence of what it is for. `attrs` carries arrangement hints
- *  (col/row/span) as written. */
+/** One part of a group: which component shows it, and one sentence of what it
+ *  is for. Nothing else — the skeleton reads the component, the fill worker
+ *  reads the purpose, and a field no consumer reads is a field the format
+ *  would have to define normatively for nothing. */
 export interface PlanLeaf {
   component: string;
-  query?: string;
   purpose: string;
-  attrs?: Record<string, string>;
 }
 
 /** A handful of parts that must tell one story — written by one worker. */

--- a/packages/apps/src/contract/kit/specs.ts
+++ b/packages/apps/src/contract/kit/specs.ts
@@ -428,18 +428,22 @@ export const KIT_SPECS: KitComponentSpec[] = [
   },
 ];
 
-/** All registered component names. */
+/**
+ * THE component vocabulary — one list, derived from the specs, and the single
+ * definition every other name here is a view of (the ui renderer maps them to
+ * `KIT_COMPONENTS`). Nothing recomputes `KIT_SPECS.map(name)` a second time.
+ */
+export const KIT_COMPONENT_NAMES: readonly string[] = KIT_SPECS.map((spec) => spec.name);
+
+/** The same list, as the mutable array `@vendoai/ui`'s registry wants. */
 export function kitComponentNames(): string[] {
-  return KIT_SPECS.map((s) => s.name);
+  return [...KIT_COMPONENT_NAMES];
 }
 
 /** Look up a single spec by name. */
 export function kitSpec(name: string): KitComponentSpec | undefined {
   return KIT_SPECS.find((s) => s.name === name);
 }
-
-/** Every Kit component name (the ui renderer maps them to `KIT_COMPONENTS`). */
-export const KIT_COMPONENT_NAMES: readonly string[] = KIT_SPECS.map((spec) => spec.name);
 
 /** Kit components whose props cannot be expressed as wire attribute values
  *  (element-valued `content` slots). They stay renderable and usable inside
@@ -456,8 +460,10 @@ export const KIT_WIRE_COMPONENT_NAMES: readonly string[] = KIT_COMPONENT_NAMES.f
   !KIT_WIRE_UNSAFE_NAMES.includes(name));
 
 /** The full component vocabulary a wire tree may name without a source map.
- *  One family since V4: the Kit is the only built-in set. */
-export const WIRE_COMPONENT_NAMES: readonly string[] = KIT_WIRE_COMPONENT_NAMES;
+ *  One family since V4: the Kit is the only built-in set, so this is the same
+ *  list under the name the compiler and the fact checks read it by — a
+ *  re-export, never a second list to keep in step. */
+export { KIT_WIRE_COMPONENT_NAMES as WIRE_COMPONENT_NAMES };
 
 /** Prop name → class for one Kit component (law-1 enforcement handle). */
 export function kitPropClasses(name: string): Readonly<Record<string, PropClass>> | undefined {

--- a/packages/apps/src/server/checking/facts.ts
+++ b/packages/apps/src/server/checking/facts.ts
@@ -376,7 +376,9 @@ const prewiredPropsIssues = (node: TreeNode): FactIssue[] => {
 
 export const catalogIssues = async (
   tree: Tree,
-  components: Record<string, string> | undefined,
+  /** Names only — the generated map's KEYS are the vocabulary this check
+   *  measures against, so an entry's shape is none of its business. */
+  components: Record<string, unknown> | undefined,
   catalog: NormalizedCatalog,
 ): Promise<FactIssue[]> => {
   const hostCatalog = new Map(catalog.map((component) => [component.name, component]));

--- a/packages/apps/src/server/checking/floor.ts
+++ b/packages/apps/src/server/checking/floor.ts
@@ -22,6 +22,7 @@ import {
   type AppId,
 } from "@vendoai/core";
 import {
+  bundleOf,
   compileWire,
   type AppDocument,
   type Check,
@@ -65,7 +66,8 @@ const islandsCheck = (deps: FloorDependencies): Check => ({
   kind: "fact",
   run: async ({ document, request }) => {
     const components = Object.fromEntries(Object.entries(document.components ?? {})
-      .filter(([name]) => !isPinComponentName(name)));
+      .filter(([name]) => !isPinComponentName(name))
+      .map(([name, entry]) => [name, bundleOf(entry).source]));
     if (Object.keys(components).length === 0) return [];
     const prepared = await prepareIslands(
       components,

--- a/packages/apps/src/server/checking/reviewer.ts
+++ b/packages/apps/src/server/checking/reviewer.ts
@@ -10,6 +10,7 @@
  * does not throw in the first place).
  */
 import {
+  componentSources,
   printWire,
   type AppDocument,
   type AppPlan,
@@ -93,7 +94,7 @@ const printedApp = (app: AppDocument): string | undefined => {
   const tree = treeOf(app);
   if (tree === undefined) return undefined;
   return printWire(
-    { tree, components: app.components ?? {}, name: app.name },
+    { tree, components: componentSources(app.components), name: app.name },
     { includeIds: false },
   );
 };

--- a/packages/apps/src/server/doors/build-surface.ts
+++ b/packages/apps/src/server/doors/build-surface.ts
@@ -19,6 +19,7 @@ import {
 import {
   compilePlan,
   compileWire,
+  componentSources,
   type AppDocument,
   type AppPlan,
   type PlanDisplay,
@@ -215,7 +216,11 @@ const paintSettledTree = async (
   appId: AppId,
 ): Promise<void> => {
   if (onView === undefined || app.tree?.formatVersion !== VENDO_TREE_FORMAT) return;
-  const tree = assembleTree({ tree: app.tree, components: app.components, componentTools: app.componentTools });
+  const tree = assembleTree({
+    tree: app.tree,
+    components: componentSources(app.components),
+    componentTools: app.componentTools,
+  });
   stripServerAuthoritativeFields(tree);
   const resolver = createProgressiveQueryResolver(caller, app, ctx);
   resolver.update(tree);

--- a/packages/apps/src/server/persistence/app-source.ts
+++ b/packages/apps/src/server/persistence/app-source.ts
@@ -30,6 +30,7 @@ import {
   type WorkspaceFs,
 } from "@vendoai/core";
 import {
+  componentSources,
   printWire,
   appSourceFileSchema,
   type AppDocument,
@@ -204,7 +205,7 @@ export async function checkoutApp(
   if (tree !== undefined) {
     await workspace.writeFile(
       `${directory}/app.vendo`,
-      printWire({ tree, components: doc.components ?? {}, name: doc.name }, { includeIds: true }),
+      printWire({ tree, components: componentSources(doc.components), name: doc.name }, { includeIds: true }),
     );
   }
 

--- a/packages/apps/src/server/persistence/edit-journal.ts
+++ b/packages/apps/src/server/persistence/edit-journal.ts
@@ -13,6 +13,7 @@ import {
   type RunContext,
 } from "@vendoai/core";
 import {
+  bundleOf,
   type AppDocument,
   type ScreenAssembler,
   type Tree,
@@ -62,13 +63,24 @@ const pinnedSubtree = (app: AppDocument, componentName: string): unknown[] => {
   return tree.nodes.filter(({ id }) => included.has(id));
 };
 
+/** One component's source, or undefined when the document has no such entry.
+ *  Absence stays distinct from an empty source, which is what the raw `!==`
+ *  compared before bundles existed. */
+const sourceOf = (document: AppDocument, componentName: string): string | undefined => {
+  const entry = document.components?.[componentName];
+  return entry === undefined ? undefined : bundleOf(entry).source;
+};
+
 export const touchedPinSlots = (previous: AppDocument, next: AppDocument): string[] => {
   const previousPins = new Map((previous.pins ?? []).map((pin) => [pin.slot, pin]));
   return (next.pins ?? []).flatMap((pin) => {
     const prior = previousPins.get(pin.slot);
     if (prior?.base !== pin.base) return [pin.slot];
     const componentName = pinComponentName(pin.slot);
-    if (previous.components?.[componentName] !== next.components?.[componentName]) return [pin.slot];
+    // Through `bundleOf`, not on the raw entry: a bare source string compares by
+    // VALUE but a bundle compares by identity, so a raw `!==` would report every
+    // pinned slot as touched on every edit the moment a bundle is stored.
+    if (sourceOf(previous, componentName) !== sourceOf(next, componentName)) return [pin.slot];
     // Subtree serialization intentionally over-reports reordered nodes as touched.
     return JSON.stringify(pinnedSubtree(previous, componentName)) === JSON.stringify(pinnedSubtree(next, componentName))
       ? []

--- a/packages/apps/src/server/persistence/open.ts
+++ b/packages/apps/src/server/persistence/open.ts
@@ -7,6 +7,7 @@ import {
   type UIPayload,
 } from "@vendoai/core";
 import {
+  componentSources,
   validateTree,
   type AppDocument,
   type TreeQuery,
@@ -345,14 +346,14 @@ export const createAppOpener = (
     }
     const payload = {
       ...tree,
-      ...(app.components === undefined ? {} : { components: structuredClone(app.components) }),
+      ...(app.components === undefined ? {} : { components: componentSources(app.components) }),
       // W4b — the stamped per-island tool manifests ride the payload beside
       // the sources; the renderer exposes ONLY these tools to each island.
       ...(app.componentTools === undefined ? {} : { componentTools: structuredClone(app.componentTools) }),
     } as unknown as UIPayload;
     return app.components === undefined
       ? { kind: "tree", payload }
-      : { kind: "tree", payload, components: structuredClone(app.components) };
+      : { kind: "tree", payload, components: componentSources(app.components) };
   }
   // 01-core §8 — an unregistered format tag is a contained failure: the payload
   // passes through untouched (no query resolution) and the renderer shows the
@@ -360,5 +361,5 @@ export const createAppOpener = (
   const payload = stripServerAuthoritativeFields(structuredClone(app.tree));
   return app.components === undefined
     ? { kind: "tree", payload }
-    : { kind: "tree", payload, components: structuredClone(app.components) };
+    : { kind: "tree", payload, components: componentSources(app.components) };
 };

--- a/packages/apps/src/server/remix/ship-diff.ts
+++ b/packages/apps/src/server/remix/ship-diff.ts
@@ -1,8 +1,9 @@
 import type {
   AppId,
 } from "@vendoai/core";
-import type {
-  AppDocument,
+import {
+  bundleOf,
+  type AppDocument,
 } from "../../contract/index.js";
 import { appVersionHash } from "./version-hash.js";
 import { pinComponentName, pinForkSource, type PinBaseline } from "./pins.js";
@@ -61,7 +62,7 @@ export const computeShipDiff = (
   const pins = (doc.pins ?? []).map((pin): ShipDiffPin => {
     const component = pinComponentName(pin.slot);
     const baseline = baselines.find((candidate) => candidate.slot === pin.slot);
-    const shipped = doc.components?.[component] ?? "";
+    const shipped = bundleOf(doc.components?.[component] ?? "").source;
     return {
       slot: pin.slot,
       component,
@@ -77,9 +78,9 @@ export const computeShipDiff = (
   const pinnedComponents = new Set(pins.map((pin) => pin.component));
   const generated = Object.entries(doc.components ?? {})
     .filter(([name]) => !pinnedComponents.has(name))
-    .map(([name, source]): ShipDiffGenerated => ({
+    .map(([name, entry]): ShipDiffGenerated => ({
       component: name,
-      diff: unifiedDiff(`generated/${name}.tsx`, "", source),
+      diff: unifiedDiff(`generated/${name}.tsx`, "", bundleOf(entry).source),
     }));
   return {
     appId: doc.id,

--- a/packages/apps/src/server/skills/format-reference.ts
+++ b/packages/apps/src/server/skills/format-reference.ts
@@ -12,7 +12,23 @@
  * worse than a missing one. The component half is INTERPOLATED from the same
  * generated schemas the engine's workers read, so it cannot drift from the code.
  */
+import {
+  TREE_MAX_COMPONENT_SOURCE_BYTES,
+  TREE_MAX_GENERATED_COMPONENTS,
+  TREE_MAX_TOTAL_COMPONENT_BYTES,
+} from "../../contract/index.js";
 import { componentsPromptSection } from "../generation/contracts/sections.js";
+
+/** The bundle budgets as the manual says them. Written from the contract's own
+ *  constants, never typed in: the manual used to state a count and a
+ *  per-island cap and never mention the TOTAL the validator also enforces, so
+ *  a model that obeyed the manual could build a megabyte of islands and watch
+ *  the app fail to validate for a budget it was never told about.
+ *  `format-conformance.e2e.test.ts` holds all three mirrors together. */
+const KB = 1_024;
+const ISLAND_BUDGET = `At most ${TREE_MAX_GENERATED_COMPONENTS} islands, ${
+  TREE_MAX_COMPONENT_SOURCE_BYTES / KB} KB of source each, and ${
+  TREE_MAX_TOTAL_COMPONENT_BYTES / KB} KB across all of them together. Past any one of those the app stops validating.`;
 
 const DIALECT = `# The .vendo format
 
@@ -37,11 +53,11 @@ read from the first \`<Plan\` to the last \`</Plan>\`.
 <Plan name="Invoices workspace">
   <Query id="invoices" tool="maple_invoices_list" input={{ limit: 100 }}/>
   <Group tab="Overview" title="Health" layout="grid">
-    <Leaf component="Stat" query="invoices" purpose="Total outstanding across every open invoice" col="1"/>
-    <Leaf component="BarChart" query="invoices" purpose="Invoiced amount per month over the last year" col="2"/>
+    <Leaf component="Stat" purpose="Total outstanding across every open invoice"/>
+    <Leaf component="BarChart" purpose="Invoiced amount per month over the last year"/>
   </Group>
   <Group tab="Overdue">
-    <Leaf component="DataTable" query="invoices" purpose="Overdue invoices, worst first"/>
+    <Leaf component="DataTable" purpose="Overdue invoices, worst first"/>
   </Group>
   <Cannot>This product has no way to send email, so reminders land in the app's own log instead.</Cannot>
 </Plan>
@@ -80,22 +96,19 @@ element and you never write one. A group with no \`tab\` sits above the tab bar.
 A group holds \`<Leaf>\` elements only — **at most five**; extras are dropped. A
 group inside a group does not exist.
 
-### \`<Leaf component query purpose …/>\` — self-closing
+### \`<Leaf component purpose/>\` — self-closing
 
 | attribute | | |
 |---|---|---|
 | \`component\` | required | the component that shows this part. One that does not exist is kept and reported. |
 | \`purpose\` | required | one sentence, written so a stranger could build the part from it and nothing else. |
-| \`query\` | optional | the \`id\` of a \`<Query>\` anywhere in the document — declaring it later is fine. |
 
-Any other attribute is kept verbatim as an arrangement HINT for whoever fills the
-leaf in (\`col="1"\`, \`row="2"\`, \`span="2"\` by convention). Nothing enforces a hint
-and nothing renders one: real arrangement is \`<Group layout="grid">\` and the
-\`Grid\` component in app.vendo. Never copy a hint onto a component in app.vendo —
-an unknown prop fails validation.
+Those two are the whole leaf; any other attribute is ignored. Arrangement is
+\`<Group layout="grid">\` and the \`Grid\` component in app.vendo, and which query
+feeds a part is decided in app.vendo, where the part is actually written.
 
-A misspelled \`purpose\` becomes a hint, and the leaf is then dropped for having no
-purpose. Read the findings.
+A misspelled \`purpose\` leaves the leaf with no purpose, and it is dropped. Read
+the findings.
 
 ### \`<Server kind why served schedule/>\` — self-closing, at most one
 
@@ -175,8 +188,8 @@ The content is raw TSX, verbatim to the **first** \`</Island>\`, with an
 and its hooks, the whole Kit, and \`fmt\` (\`fmt.money(cents)\`,
 \`fmt.dateTime(iso)\`, \`fmt.percent(ratio)\`, \`fmt.num(n)\`) are already in scope,
 and nothing else can load. The name must be PascalCase and must not collide with
-a host, Kit or prewired component name. Reference it as \`<PascalName/>\`. At most
-16 islands, 64 KB each.
+a host, Kit or prewired component name. Reference it as \`<PascalName/>\`.
+${ISLAND_BUDGET}
 
 Write an island for a custom visual or client-side logic. Never for a chart — the
 Kit's charts already render their own empty state.
@@ -313,13 +326,13 @@ The ask: "show me where my spend is going, and which invoices are late."
   <Query id="expenses" tool="maple_expenses_list" input={{ limit: 500 }}/>
   <Query id="invoices" tool="maple_invoices_list" input={{ status: "overdue" }}/>
   <Group tab="Spend" title="Where it goes" layout="grid">
-    <Leaf component="Stat" query="expenses" purpose="Total spend across every expense in the window" col="1"/>
-    <Leaf component="BarChart" query="expenses" purpose="Spend per month, so a rising trend is visible" col="2"/>
-    <Leaf component="DataTable" query="expenses" purpose="Every expense, biggest first, with vendor and date"/>
+    <Leaf component="Stat" purpose="Total spend across every expense in the window"/>
+    <Leaf component="BarChart" purpose="Spend per month, so a rising trend is visible"/>
+    <Leaf component="DataTable" purpose="Every expense, biggest first, with vendor and date"/>
   </Group>
   <Group tab="Late">
-    <Leaf component="Stat" query="invoices" purpose="How many invoices are overdue right now"/>
-    <Leaf component="DataTable" query="invoices" purpose="Overdue invoices, longest overdue first"/>
+    <Leaf component="Stat" purpose="How many invoices are overdue right now"/>
+    <Leaf component="DataTable" purpose="Overdue invoices, longest overdue first"/>
   </Group>
   <Cannot>This product cannot send email, so chasing a late invoice still happens outside it.</Cannot>
 </Plan>

--- a/packages/apps/tests/checking/reviewer.test.ts
+++ b/packages/apps/tests/checking/reviewer.test.ts
@@ -93,7 +93,7 @@ const reported = (findings: unknown): { tool: string; input: unknown } =>
 const scheduledPlan = (): AppPlan => ({
   name: "Invoices",
   queries: [{ id: "invoices", tool: "host_listInvoices", input: {} }],
-  groups: [{ tab: "Overview", leaves: [{ component: "DataTable", query: "invoices", purpose: "open invoices" }] }],
+  groups: [{ tab: "Overview", leaves: [{ component: "DataTable", purpose: "open invoices" }] }],
   server: { kind: "steps", schedule: "every Friday", why: "Chasing overdue invoices happens when nobody has the app open." },
   cannot: [],
 });

--- a/packages/apps/tests/contract/genui/plan/compile.test.ts
+++ b/packages/apps/tests/contract/genui/plan/compile.test.ts
@@ -48,24 +48,14 @@ describe("compilePlan", () => {
           title: "Health",
           layout: "grid",
           leaves: [
-            {
-              component: "StatTile",
-              query: "invoices",
-              purpose: "Total outstanding across every open invoice",
-              attrs: { col: "1" },
-            },
-            {
-              component: "BarChart",
-              query: "invoices",
-              purpose: "Invoiced amount per month over the last year",
-              attrs: { col: "2", span: "2" },
-            },
+            { component: "StatTile", purpose: "Total outstanding across every open invoice" },
+            { component: "BarChart", purpose: "Invoiced amount per month over the last year" },
           ],
         },
         {
           tab: "Overview",
           leaves: [
-            { component: "DataTable", query: "clients", purpose: "Clients with the most outstanding, worst first" },
+            { component: "DataTable", purpose: "Clients with the most outstanding, worst first" },
           ],
         },
         {
@@ -73,7 +63,7 @@ describe("compilePlan", () => {
           title: "Payment history",
           waitsForServer: true,
           leaves: [
-            { component: "DataTable", query: "invoices", purpose: "Every payment recorded against an invoice" },
+            { component: "DataTable", purpose: "Every payment recorded against an invoice" },
           ],
         },
       ],
@@ -109,7 +99,7 @@ describe("compilePlan", () => {
       {
         title: "Everyone",
         leaves: [
-          { component: "DataTable", query: "clients", purpose: "Every client with their outstanding balance" },
+          { component: "DataTable", purpose: "Every client with their outstanding balance" },
         ],
       },
     ]);
@@ -190,18 +180,6 @@ describe("compilePlan", () => {
     expect(result.issues).toEqual([
       'the schedule "0 9 * *" reads as a cron but has 4 fields instead of 5. Write a 5-field cron ("0 9 * * 5"), or just say the cadence in words ("every Friday morning").',
     ]);
-  });
-
-  it("reports a leaf reading a query the plan never declared", () => {
-    const result = compilePlan(
-      `<Plan name="Dangling"><Query id="invoices" tool="host_listInvoices"/>
-         <Group><Leaf component="DataTable" query="overdue" purpose="Overdue invoices, worst first"/></Group></Plan>`,
-      FACTS,
-    );
-    expect(result.issues).toEqual([
-      'the DataTable leaf reads a query called "overdue", but this plan declares no <Query id="overdue">. Declare it at the top of the plan, or drop the query attribute.',
-    ]);
-    expect(result.plan?.groups[0]?.leaves[0]?.query).toBe("overdue");
   });
 
   it("reports missing structure instead of throwing", () => {
@@ -314,28 +292,6 @@ describe("compilePlan", () => {
       "<Leaf> holds nothing — write it as one self-closing element; its content was ignored.",
     );
     expect(result.plan?.groups[0]?.leaves).toStrictEqual([{ component: "StatTile", purpose: "Total outstanding" }]);
-  });
-
-  it("drops a leaf's arrangement hint when its value is a list, not a primitive", () => {
-    const result = compilePlan(
-      `<Plan name="List hint"><Group><Leaf component="StatTile" purpose="Total outstanding" tags={[1,2]}/></Group></Plan>`,
-      FACTS,
-    );
-    expect(result.issues).toEqual([
-      'the StatTile leaf\'s "tags" is an arrangement hint like col="2", and a list cannot be one. It was dropped.',
-    ]);
-    expect(result.plan?.groups[0]?.leaves[0]?.attrs).toBeUndefined();
-  });
-
-  it("drops a leaf's arrangement hint when its value is null, not a primitive", () => {
-    const result = compilePlan(
-      `<Plan name="Null hint"><Group><Leaf component="StatTile" purpose="Total outstanding" tags={null}/></Group></Plan>`,
-      FACTS,
-    );
-    expect(result.issues).toEqual([
-      'the StatTile leaf\'s "tags" is an arrangement hint like col="2", and null cannot be one. It was dropped.',
-    ]);
-    expect(result.plan?.groups[0]?.leaves[0]?.attrs).toBeUndefined();
   });
 
   it("reports loose text sitting inside a group", () => {

--- a/packages/apps/tests/fork-pin.test.ts
+++ b/packages/apps/tests/fork-pin.test.ts
@@ -8,10 +8,11 @@ import type {
   StoreAdapter,
   ToolRegistry,
 } from "@vendoai/core";
-import type {
-  AppDocument,
-  ScreenAssembler,
-  Tree,
+import {
+  bundleOf,
+  type AppDocument,
+  type ScreenAssembler,
+  type Tree,
 } from "../src/contract/index.js";
 import { describe, expect, it } from "vitest";
 import { createApps, type AppsConfig, type AppsRuntime, type PinBaseline } from "../src/server/index.js";
@@ -90,7 +91,8 @@ const labelAsked = (instruction: string): string | undefined => {
 const relabelScreen = (runtime: () => AppsRuntime, seen: string[] = []): ScreenAssembler =>
   scriptedAssembler(runtime, (request, current) => {
     seen.push(request.request);
-    const source = current?.components?.[COMPONENT];
+    const entry = current?.components?.[COMPONENT];
+    const source = entry === undefined ? undefined : bundleOf(entry).source;
     const label = labelAsked(request.request);
     if (source === undefined || label === undefined) {
       return { kind: "unavailable", why: `nothing in "${request.request}" names a change I can make to ${COMPONENT}` };

--- a/packages/apps/tests/format-conformance.e2e.test.ts
+++ b/packages/apps/tests/format-conformance.e2e.test.ts
@@ -1,0 +1,128 @@
+/**
+ * THE FORMAT CONSTITUTION.
+ *
+ * The app format has four mirrors — the contract, `@vendoai/core`'s pinned
+ * limits, the manual the model reads (`skills/format-reference.ts`) and the
+ * public docs page. Every one of them used to be maintained by hand, and they
+ * disagreed: the manual promised "16 islands, 64 KB each" and never mentioned
+ * the 256 KB TOTAL the validator also enforces, so a model that obeyed the
+ * manual could write a megabyte of islands and watch the whole app fail to
+ * validate for a reason it was never told about.
+ *
+ * This file is the one place a format number or a component name is written by
+ * hand. Everything else derives, and this test fails the moment any mirror
+ * drifts from another — a test, not a convention.
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import {
+  TREE_MAX_COMPONENT_SOURCE_BYTES as CORE_MAX_COMPONENT_SOURCE_BYTES,
+  TREE_MAX_GENERATED_COMPONENTS as CORE_MAX_GENERATED_COMPONENTS,
+  TREE_MAX_TOTAL_COMPONENT_BYTES as CORE_MAX_TOTAL_COMPONENT_BYTES,
+} from "@vendoai/core";
+import {
+  KIT_COMPONENT_NAMES,
+  KIT_SPECS,
+  KIT_WIRE_COMPONENT_NAMES,
+  KIT_WIRE_UNSAFE_NAMES,
+  TREE_MAX_COMPONENT_SOURCE_BYTES,
+  TREE_MAX_GENERATED_COMPONENTS,
+  TREE_MAX_TOTAL_COMPONENT_BYTES,
+  WIRE_COMPONENT_NAMES,
+} from "../src/contract/index.js";
+import { VENDO_FORMAT_REFERENCE } from "../src/server/skills/format-reference.js";
+
+const KB = 1_024;
+
+/** d4 — the three bundle budgets, stated once, here. Changing any of them is a
+ *  format change, and it has to be made in this file first. */
+const LIMITS = {
+  generatedComponents: 16,
+  componentSourceBytes: 64 * KB,
+  totalComponentBytes: 256 * KB,
+} as const;
+
+/** The component vocabulary a generated app may name without a source map. */
+const VOCABULARY = [
+  "Accordion", "Badge", "BarChart", "Button", "Callout", "Card", "CardList", "Checkbox", "DataTable",
+  "DatePicker", "DateTime", "Disclaimer", "Divider", "DonutChart", "EnumBadge", "Form", "Grid", "Input",
+  "LineChart", "Money", "Num", "Percent", "Progress", "Row", "Select", "Sparkline", "Stack", "Stat",
+  "Surface", "Tabs", "Text", "Textarea",
+];
+
+const DOCS_FORMAT_PAGE = readFileSync(
+  new URL("../../../docs-site/concepts/generated-ui.mdx", import.meta.url),
+  "utf8",
+);
+
+describe("the three bundle limits have ONE definition", () => {
+  it("core holds the values this file pins", () => {
+    expect(CORE_MAX_GENERATED_COMPONENTS).toBe(LIMITS.generatedComponents);
+    expect(CORE_MAX_COMPONENT_SOURCE_BYTES).toBe(LIMITS.componentSourceBytes);
+    expect(CORE_MAX_TOTAL_COMPONENT_BYTES).toBe(LIMITS.totalComponentBytes);
+  });
+
+  it("the contract re-exports core's constants rather than re-declaring them", () => {
+    expect(TREE_MAX_GENERATED_COMPONENTS).toBe(CORE_MAX_GENERATED_COMPONENTS);
+    expect(TREE_MAX_COMPONENT_SOURCE_BYTES).toBe(CORE_MAX_COMPONENT_SOURCE_BYTES);
+    expect(TREE_MAX_TOTAL_COMPONENT_BYTES).toBe(CORE_MAX_TOTAL_COMPONENT_BYTES);
+  });
+});
+
+describe("the manual states every limit, generated from the contract", () => {
+  it("says all three numbers in one sentence", () => {
+    expect(VENDO_FORMAT_REFERENCE).toContain(
+      `At most ${LIMITS.generatedComponents} islands, ${LIMITS.componentSourceBytes / KB} KB of source each, and ${
+        LIMITS.totalComponentBytes / KB} KB across all of them together.`,
+    );
+  });
+
+  it("never states a budget the validator does not enforce", () => {
+    // Any KB figure in the manual has to be one of the two the enforcer knows.
+    const stated = [...VENDO_FORMAT_REFERENCE.matchAll(/(\d+) KB/g)].map((match) => Number(match[1]));
+    expect(stated.length).toBeGreaterThan(0);
+    expect([...new Set(stated)].sort((left, right) => left - right)).toEqual([
+      LIMITS.componentSourceBytes / KB,
+      LIMITS.totalComponentBytes / KB,
+    ]);
+  });
+
+  it("teaches the plan dialect's leaf as component + purpose, and nothing else", () => {
+    // d2 — `leaf.attrs` and `leaf.query` are gone from the grammar, so the
+    // manual must not send a model writing either.
+    expect(VENDO_FORMAT_REFERENCE).toContain("### `<Leaf component purpose/>` — self-closing");
+    expect(VENDO_FORMAT_REFERENCE).not.toContain('<Leaf component="Stat" query=');
+  });
+});
+
+describe("the public docs page states the same format", () => {
+  it("quotes the three limits the validator enforces", () => {
+    const stated = /at most \*\*(\d+)\*\* generated components, each at most\s+\*\*(\d+) KB\*\* of source, and \*\*(\d+) KB\*\* across all of them/
+      .exec(DOCS_FORMAT_PAGE);
+    expect(stated, "docs-site/concepts/generated-ui.mdx must state the three component limits").not.toBeNull();
+    expect([Number(stated?.[1]), Number(stated?.[2]) * KB, Number(stated?.[3]) * KB]).toEqual([
+      TREE_MAX_GENERATED_COMPONENTS,
+      TREE_MAX_COMPONENT_SOURCE_BYTES,
+      TREE_MAX_TOTAL_COMPONENT_BYTES,
+    ]);
+  });
+});
+
+describe("the component vocabulary is ONE list", () => {
+  it("is the list this file pins", () => {
+    expect([...KIT_COMPONENT_NAMES].sort()).toEqual(VOCABULARY);
+  });
+
+  it("derives from the specs — nothing recomputes it", () => {
+    expect(KIT_COMPONENT_NAMES).toEqual(KIT_SPECS.map((spec) => spec.name));
+  });
+
+  it("names the wire subset once, under two names", () => {
+    // WIRE_COMPONENT_NAMES is KIT_WIRE_COMPONENT_NAMES re-exported: the same
+    // binding, so the two can never say different things.
+    expect(WIRE_COMPONENT_NAMES).toBe(KIT_WIRE_COMPONENT_NAMES);
+    expect(KIT_WIRE_COMPONENT_NAMES).toEqual(
+      KIT_COMPONENT_NAMES.filter((name) => !KIT_WIRE_UNSAFE_NAMES.includes(name)),
+    );
+  });
+});

--- a/packages/apps/tests/generation/skeleton.test.ts
+++ b/packages/apps/tests/generation/skeleton.test.ts
@@ -95,7 +95,7 @@ describe("skeletonFromPlan", () => {
 
   it("carries the plan's queries onto the tree so fragments have something to bind to", () => {
     const skeleton = skeletonFromPlan(plan(
-      [{ leaves: [{ component: "DataTable", query: "invoices", purpose: "invoices" }] }],
+      [{ leaves: [{ component: "DataTable", purpose: "invoices" }] }],
       { queries: [{ id: "invoices", tool: "host_listInvoices", input: { status: "overdue" } }] },
     ));
     expect(skeleton.tree.queries).toEqual([

--- a/packages/apps/tests/rebase.test.ts
+++ b/packages/apps/tests/rebase.test.ts
@@ -4,6 +4,7 @@ import {
   type ToolRegistry,
 } from "@vendoai/core";
 import {
+  bundleOf,
   compileWire,
   type AppDocument,
 } from "../src/contract/index.js";
@@ -98,7 +99,8 @@ const buildingScreen = (
   runtime: () => AppsRuntime,
   options: BuilderOptions,
 ) => scriptedAssembler(runtime, (request, current) => {
-  const source = current?.components?.[COMPONENT];
+  const entry = current?.components?.[COMPONENT];
+  const source = entry === undefined ? undefined : bundleOf(entry).source;
   options.seen?.push({ instruction: request.request, source });
   const overridden = options.override?.(request.request);
   if (overridden !== undefined) return overridden;

--- a/packages/core/src/app-document.ts
+++ b/packages/core/src/app-document.ts
@@ -5,6 +5,54 @@ import { sha256Hex } from "./sha256.js";
 import { DEFAULT_TRIGGER_ID, triggerSchema, type Trigger } from "./triggers.js";
 import { uiPayloadSchema, type UIPayload } from "./genui/tree-node.js";
 
+/**
+ * The seat's contents — what one entry of {@link AppDocument.components} holds.
+ *
+ * A bundle has exactly two origins and both live INSIDE the document, so
+ * nothing is attached at open time by hash-matching a baseline the fork may
+ * have drifted from.
+ *
+ * It is declared HERE, beside the field it types, for the same reason
+ * `appDocumentSchema` is: core's own store conformance kit parses a stored app
+ * row with that schema, and core may not reach up into `@vendoai/apps`. The
+ * format door (`@vendoai/apps/contract`) re-exports these names rather than
+ * re-declaring them, so consumers still read one place.
+ */
+export interface ComponentBundle {
+  source: string;
+  /** Sub-modules the entry imports, keyed by the specifier that names them. */
+  modules?: Record<string, string>;
+  styles?: string;
+  /** The rehearsal seed a preview renders with, spread onto the props. */
+  sampleProps?: Record<string, unknown>;
+  /** `"authored"` — a generated island. `"seeded"` — captured from a host
+   *  component the person forked. */
+  origin: "authored" | "seeded";
+}
+
+/** 01-core §9 */
+export const componentBundleSchema = z.object({
+  source: z.string(),
+  modules: z.record(z.string()).optional(),
+  styles: z.string().optional(),
+  sampleProps: z.record(z.unknown()).optional(),
+  origin: z.enum(["authored", "seeded"]),
+}).passthrough() satisfies z.ZodType<ComponentBundle>;
+
+/**
+ * Backward compatible by construction: a stored `components` value is either
+ * the legacy bare source string every app written before bundles carries, or a
+ * bundle. Nothing migrates — every reader goes through {@link bundleOf}.
+ */
+export type ComponentEntry = string | ComponentBundle;
+
+/** 01-core §9 */
+export const componentEntrySchema: z.ZodType<ComponentEntry> = z.union([z.string(), componentBundleSchema]);
+
+/** The one reader. A bare source string reads as an authored bundle. */
+export const bundleOf = (entry: ComponentEntry): ComponentBundle =>
+  typeof entry === "string" ? { source: entry, origin: "authored" } : entry;
+
 /** 01-core §9 */
 export interface StorageDecl {
   about: string;
@@ -174,7 +222,7 @@ export interface AppDocument {
   description?: string;
   ui?: "tree" | "http";
   tree?: UIPayload;
-  components?: Record<string, string>;
+  components?: Record<string, ComponentEntry>;
   /**
    * W4b — the compiler-stamped per-island tool manifest: for each generated
    * component, the registry tool names its source reaches through the ambient
@@ -249,7 +297,7 @@ const appDocumentShapeSchema = z.object({
   description: z.string().optional(),
   ui: z.enum(["tree", "http"]).optional(),
   tree: uiPayloadSchema.optional(),
-  components: z.record(z.string()).optional(),
+  components: z.record(componentEntrySchema).optional(),
   componentTools: z.record(z.array(z.string())).optional(),
   storage: z.record(storageDeclSchema).optional(),
   source: z.record(appSourceFileSchema).optional(),

--- a/packages/vendo/tests/drift-rebase.fixture.test.ts
+++ b/packages/vendo/tests/drift-rebase.fixture.test.ts
@@ -9,6 +9,7 @@ import {
   VENDO_APP_FORMAT,
 } from "@vendoai/core";
 import {
+  componentSources,
   printWire,
 } from "@vendoai/apps/contract";
 import { createStore } from "@vendoai/store";
@@ -149,7 +150,7 @@ export default function Page() {
       const app = await active!.apps.get(appUnderEdit!, ctx);
       if (app === null) throw new Error("no app row to rewrite");
       return printWire(
-        { tree: app.tree as never, components: app.components ?? {}, name: app.name },
+        { tree: app.tree as never, components: componentSources(app.components), name: app.name },
         { includeIds: true },
       );
     };

--- a/packages/vendo/tests/inclient.fixture.test.ts
+++ b/packages/vendo/tests/inclient.fixture.test.ts
@@ -9,6 +9,7 @@ import {
   VENDO_APP_FORMAT,
 } from "@vendoai/core";
 import {
+  componentSources,
   printWire,
 } from "@vendoai/apps/contract";
 import { createStore } from "@vendoai/store";
@@ -148,7 +149,7 @@ export default function Page() {
       const app = await composed!.apps.get(appUnderEdit!, ctx);
       if (app === null) throw new Error("no app row to rewrite");
       return printWire(
-        { tree: app.tree as never, components: app.components ?? {}, name: app.name },
+        { tree: app.tree as never, components: componentSources(app.components), name: app.name },
         { includeIds: true },
       );
     };

--- a/packages/vendo/tests/review.fixture.test.ts
+++ b/packages/vendo/tests/review.fixture.test.ts
@@ -8,6 +8,7 @@ import {
   type Principal,
 } from "@vendoai/core";
 import {
+  componentSources,
   printWire,
 } from "@vendoai/apps/contract";
 import { createStore } from "@vendoai/store";
@@ -162,7 +163,7 @@ export default function Page() {
       });
       if (app === null) throw new Error("no app row to rewrite");
       return printWire(
-        { tree: app.tree as never, components: app.components ?? {}, name: app.name },
+        { tree: app.tree as never, components: componentSources(app.components), name: app.name },
         { includeIds: true },
       );
     };


### PR DESCRIPTION
**S3 (#1118) and S7 (#1120) are both MERGED.** This branch now sits on plain
`main` (rebased `--onto origin/main 2a31709af`, zero conflicts), so the diff
against `main` is exactly this slice — **26 files, +396 / −143**.

## What this fixes

The app format had four hand-kept mirrors — the contract, `@vendoai/core`'s
pinned limits, the manual the model reads, and the public docs page — and they
disagreed. The manual promised "16 islands, 64 KB each" and never mentioned the
**256 KB total** the validator also enforces, so a model that obeyed the manual
could write a megabyte of islands and watch the whole app fail to validate for
a budget it was never told about.

`packages/apps/tests/format-conformance.e2e.test.ts` is now the constitution:
the three limits and the component vocabulary are written by hand exactly once,
there, and every mirror is checked against it.

- `skills/format-reference.ts` states all three budgets, interpolated from
  `TREE_MAX_*`. No format number is typed into the manual any more (d4 — the
  manual states all three, enforcement is unchanged).
- `docs-site/concepts/generated-ui.mdx` gains a "Component limits" section
  stating the same three, pinned by the same test.
- The component bundle lands on the document: `ComponentBundle` /
  `ComponentEntry` / `bundleOf`, and `AppDocument.components` widens to hold
  either the legacy bare source string or a bundle. Backward compatible by
  construction — every reader goes through `bundleOf` (or `componentSources`
  for a whole map), so nothing migrates.
- The Kit vocabulary is one list (3 → 1): `KIT_COMPONENT_NAMES` derives from the
  specs, `kitComponentNames()` returns it instead of recomputing it, and
  `WIRE_COMPONENT_NAMES` is `KIT_WIRE_COMPONENT_NAMES` **re-exported** rather
  than a second binding — `expect(WIRE_COMPONENT_NAMES).toBe(KIT_WIRE_COMPONENT_NAMES)`.
- d2 — `leaf.attrs` and `leaf.query` leave the plan grammar. Both were parsed
  and fact-checked with no downstream consumer, and the constitution would
  otherwise have had to normatively define two fields nothing reads. `cannot`
  and the plan's own top-level `queries` list stay.

## Where the bundle shape is declared, and why "one definition" still holds

`ComponentBundle` / `ComponentEntry` / `bundleOf` and their schemas are
**declared in `@vendoai/core`**, beside the `AppDocument.components` field they
type — not in `contract/component-bundle.ts`. Reviewers should read that as
keeping the headline promise, not breaking it:

- S3 left `AppDocument` and `appDocumentSchema` in core on purpose: core's own
  store conformance kit parses a stored app row with `appDocumentSchema`
  (`core/src/conformance/memory-store.ts`), so the document shape has to be
  readable from below. Widening `components` therefore requires the entry shape
  to be visible from core, and **core may not reach up into `@vendoai/apps`**
  (dependency-guard).
- The contract **re-exports** the five names and never re-declares them, so
  there is still exactly ONE declaration site and
  **`@vendoai/apps/contract` is still the only door** — unchanged from outside.
- This is the same rule S3 already applied twice, and the same rule this slice
  applies to the three `TREE_MAX_*` constants. `format-conformance.e2e.test.ts`
  pins it: the contract's re-exports are asserted identical to core's values, so
  a second declaration would fail the suite.

## The four conformance legs, proven one at a time

Each: plant, run, revert, `git status --porcelain` empty.

**1 — change `TREE_MAX_TOTAL_COMPONENT_BYTES` in core** (`262_144` → `524_288`, core rebuilt):
```
FAIL  tests/format-conformance.e2e.test.ts > the three bundle limits have ONE definition > core holds the values this file pins
AssertionError: expected 524288 to be 262144 // Object.is equality
```
(3 further assertions also went red: the manual sentence, the manual's KB set, and the docs page.)

**2 — hand-edit a number in `format-reference.ts`** (`${TREE_MAX_COMPONENT_SOURCE_BYTES / KB}` → `32`):
```
FAIL  tests/format-conformance.e2e.test.ts > the manual states every limit, generated from the contract > says all three numbers in one sentence
AssertionError: expected '# The .vendo format\n\nAn app is two …' to contain 'At most 16 islands, 64 KB of source e…'
FAIL  ... > never states a budget the validator does not enforce
AssertionError: expected [ 32, 256 ] to deeply equal [ 64, 256 ]
```

**3 — hand-edit the docs-site format page** (`**64 KB** of source` → `**128 KB** of source`):
```
FAIL  tests/format-conformance.e2e.test.ts > the public docs page states the same format > quotes the three limits the validator enforces
AssertionError: expected [ 16, 131072, 262144 ] to deeply equal [ 16, 65536, 262144 ]
```

**4 — add a name to the kit list** (a `Timeline` spec appended to `KIT_SPECS`):
```
FAIL  tests/format-conformance.e2e.test.ts > the component vocabulary is ONE list > is the list this file pins
AssertionError: expected [ 'Accordion', 'Badge', …(31) ] to deeply equal [ 'Accordion', 'Badge', …(30) ]
```

Legs 2, 3 and 4 are the ones that matter: they are the manual and the public
docs disagreeing with enforcement, which is the drift the spec cares about.

## Gates

```
$ pnpm exec turbo run build typecheck --filter=@vendoai/apps --filter=@vendoai/core
Tasks: 4 successful, 4 total          exit 0

$ cd packages/apps && VITEST_… npx vitest run tests/format-conformance.e2e.test.ts \
    tests/skills tests/contract/genui tests/contract/kit
Test Files  12 passed (12)            exit 0
     Tests  390 passed (390)

$ cd packages/apps && VITEST_… npx vitest run          # the whole apps package
Test Files  111 passed | 3 skipped (114)               exit 0
     Tests  1493 passed | 18 skipped (1511)

$ cd packages/core && VITEST_… npx vitest run
Test Files  40 passed (40)            exit 0
     Tests  583 passed (583)

$ pnpm lint                           exit 0
dependency-guard: OK (30 packages checked)

$ pnpm corpus validate                exit 0
```

The plan's gate names `tests/genui` / `tests/kit`; post-S3 those live at
`tests/contract/genui` and `tests/contract/kit`.

## Greps

```
$ grep -rn "COMPONENT_BUNDLE_MAX" packages                                    → 0 lines
$ grep -rn "TREE_MAX_GENERATED_COMPONENTS\s*=" packages --include='*.ts'      → 1 line
  packages/core/src/genui/tree-limits.ts:11
$ grep -rn "\b16\b.*island\|64 ?KB\|65536" .../skills/format-reference.ts     → 0 lines
$ grep -rn "leaf\.attrs\|leaf\.query" packages/apps/src                       → 0 lines
```

## genbench — GATE PASSED

Measured on this branch against the re-baseline recorded on merged main
(`e2128aad8`). `vendo-sonnet`, floor / judged:

| case | re-baseline | this branch | verdict |
|---|---|---|---|
| spend-overview | 2/5 · 0/8 *(300s timeout, un-diagnostic)* | **4/5 · 5/6** | **better** — delivered a screen where the baseline delivered none |
| spend-chart | 5/5 · 4/6 | 5/5 · 4/6 | **exact match** |
| pending-transfers | 5/5 · 4/8 | 4/5 · 4/8 | judged **match**, floor −1 |
| account-balances | 5/5 · 3/5 | 5/5 · 3/5 | **exact match** |
| no-pending-transfers | 4/5 · 3/5 | 4/5 · 2/5 | judged −1 |

Three exact matches, one materially improved case, two single-point movements.
The two manual changes this slice makes — the island-budget sentence now naming
three numbers instead of two, and `<Leaf>` documented as `component` + `purpose`
only — did not move generation.

**Why the two −1s are not a regression.** In the same run, `diy-sonnet` — a
raw-Claude contender no slice can influence, which never sees the Vendo manual —
scored **1/5 judged on `account-balances` against 5/5 in the baseline**. A
four-point swing on an uninfluenceable column is direct, same-run evidence that
the judged metric carries far more variance than a two-run sample suggests, and
it dwarfs both single-point movements here. The earlier working rule that
"accuracy is quiet, so any judged delta is signal" was drawn from two runs and
has been **explicitly retracted**; this note records that so nobody later reads
these −1s as a regression that was waved through.

**Note on the first run of this branch, discarded.** An initial run scored
`2/5 · 0/8` on 13 of 15 rows across *all three* contenders. That was not a
quality collapse: every one of those rows carries
`"failure": "browser.newPage: Target page, context or browser has been closed"`
in `genbench/runs/<id>/**/result.json`. genbench holds **one shared browser for
the whole run** (`genbench/src/run.ts:303`, closed at `:429`) with no liveness
check and no rebuild; two concurrent genbench runs on one box killed it, and
every subsequent row fell to the "no screen was delivered" rubric. Worth fixing
separately — the console table shows only the score, so a dead browser is
indistinguishable from a quality collapse unless you open the per-case JSON.

## Two defects found by independent audit, fixed here

1. **The widening leaked into `@vendoai/vendo` and broke root typecheck.** Three
   fixture tests passed `app.components` straight into `printWire`, whose
   parameter is still `Record<string, string>`. They now go through
   `componentSources`. **Root cause of the miss: my gate ran
   `turbo typecheck --filter=@vendoai/apps --filter=@vendoai/core`, which never
   reaches `@vendoai/vendo`.** Root `pnpm typecheck` is now the gate — 42/42
   tasks, exit 0.
2. **"Every reader goes through `bundleOf`" was false in my own code.**
   `edit-journal.ts`'s `touchedPinSlots` compared raw `components` entries with
   `!==` — a value compare for a bare source string, an **identity** compare for
   a bundle, so every pinned slot would read as touched on every edit the moment
   a bundle is stored. Latent today (no OSS producer writes a bundle yet) but
   `appDocumentSchema` now accepts one from the store. Routed through
   `bundleOf`, keeping absence distinct from an empty source so pre-bundle
   behavior is unchanged. The changeset tells third parties to make exactly this
   change; it is now true of our own code.

## Divergences from the brief, called out

1. **`ComponentBundle` is declared in `@vendoai/core`, not in
   `contract/component-bundle.ts`.** S3 left `AppDocument` and
   `appDocumentSchema` in core (core's own store conformance kit parses a
   stored row with them, and core may not reach up into `@vendoai/apps`), so
   widening `AppDocument.components` requires the entry shape to be visible
   from core. The contract **re-exports** the five names and never re-declares
   them — the same ruling the brief applies to the three `TREE_MAX_*`
   constants. From outside, `@vendoai/apps/contract` is unchanged as the door.
2. **One new contract name: `componentSources(components)`.** The widening left
   six sites needing "the map as bare sources"; six copies of the same
   `Object.fromEntries(… bundleOf(…).source)` would have been new duplication.
   One helper, six callers.
3. **Seven files outside the owned list carry a one-line `bundleOf` read** —
   the unavoidable consequence of "every reader goes through `bundleOf`":
   `server/checking/{facts,floor,reviewer}.ts`,
   `server/doors/build-surface.ts`,
   `server/persistence/{open,app-source}.ts`, `server/remix/ship-diff.ts`.
   Each is a single read routed through the seam; conflicts with S4/S6/S7
   resolve by taking either side plus the `bundleOf` wrap.
4. **Test-body edits beyond the named deletions**, stated out loud: the same
   type-widening adaptation in `tests/{fork-pin,rebase}.test.ts` (a
   `components[…]` read now goes through `bundleOf`), and a removed `query:`
   key in one `PlanLeaf` fixture literal in each of
   `tests/checking/reviewer.test.ts` and `tests/generation/skeleton.test.ts` —
   the field no longer exists.
5. **Tests deleted, named:** the `leaf.attrs` / `leaf.query` cases in
   `tests/contract/genui/plan/compile.test.ts` — "reports a leaf reading a
   query the plan never declared", and the two "drops a leaf's arrangement hint
   …" cases. They die with the plan dialect's two consumerless leaf fields.
6. ~~No changeset.~~ **Resolved — added.**
   `.changeset/apps-format-constitution.md` (major, `@vendoai/core` +
   `@vendoai/apps`) covers exactly this slice: the widened components map and
   why it is backward compatible by construction, the two removed plan-dialect
   fields, the newly exported validator surface, and the one-list Kit
   vocabulary. `pnpm changeset status --since=origin/main` exits 0.
7. ~~Observation about `<Server kind="steps"|"agentic">` declaring an inert
   lane.~~ **Withdrawn — the premise was wrong.** S7's evidence: `agentic` is
   re-homed to the automation door (d1), driven by `automation-audit` and
   `automation-second`; `steps` has five live consumers and is the
   *deterministic* automation mode (`automation/plan.ts` selects a separate
   `stepsContract()` and validates `trigger.run.kind === "steps"`, and
   `packages/vendo/tests/ladder.e2e.test.ts:129` drives `<Server kind="steps">`
   through the whole ladder to an armed automation). The grammar is accurate,
   the manual documenting all three kinds is accurate, and no lane is silently
   inert — §4.3 required them to stop being *escalation* kinds, which they have.
   No change to `format-reference.ts`.

## Carry-in for S9 (the console)

The console's `preview-payload.ts` imports `RESERVED_COMPONENT_NAMES` from
`@vendoai/core` — a name that no longer exists in OSS (zero hits in `packages/`,
it survives only in the frozen 0.4.8 pin) — and hand-re-implements
`componentMapError`'s byte accounting. The contract door now exports the real
validator surface, verified present on the built `dist/contract/index.js`:
`componentMapError`, `utf8ByteLength`, `SAFE_COMPONENT_NAME`, and the three
`TREE_MAX_*` re-exports (plus `bundleOf` / `componentSources`). S9 deletes the
re-implementation instead of chasing a constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
