### PR TITLE
fix(apps): make the browser-safety promise a mechanism, and retract a false dedup claim

### DIFF
--- a/.changeset/apps-contract-door-and-server-half.md
+++ b/.changeset/apps-contract-door-and-server-half.md
@@ -48,3 +48,20 @@ produces those shapes stays behind `@vendoai/apps`.
 3. **`@vendoai/ui`, `@vendoai/store`, `@vendoai/actions` and `@vendoai/mcp` now
    depend on `@vendoai/apps`** and read the app format from
    `@vendoai/apps/contract`. Their own public surfaces are unchanged.
+
+**Known tradeoffs, stated plainly:**
+
+- **One name, still two declarations.** `@vendoai/ui` no longer keeps its own
+  copy of the `/apps/*` wire shapes — it re-exports them from the contract
+  door. That removes a copy; it does not yet make one definition. The engine's
+  server door declares its own richer `EditResult` (with `failure`,
+  `graduated`, `box`, `pendingEgress`, `automation`) beside the contract's
+  four-field wire shape, so the name has two declarations inside
+  `@vendoai/apps`, one per door. Unifying them decides which fields the wire
+  may expose, which is a behavior change and not part of this move.
+- **Install weight.** `@vendoai/apps` declares `esbuild`, `jsdom`, `fflate` and
+  `react-dom` as hard dependencies, so a browser-only consumer of
+  `@vendoai/apps/contract` still installs the engine's dependency set. The
+  contract door itself bundles clean for a browser target (enforced by a new
+  leg in `scripts/portability-gate.mjs`); it is the install graph, not the
+  bundle, that carries the weight. Pre-existing, amplified by this split.

--- a/packages/apps/src/contract/wire-types.ts
+++ b/packages/apps/src/contract/wire-types.ts
@@ -2,11 +2,17 @@
  * The app-generation half of the wire — the shapes `/apps/*` returns.
  *
  * These were hand-copied into `@vendoai/ui` because "ui depends on core only"
- * and the producer lives in the server half, so the consumer re-declared them
- * "verbatim from the frozen contract text". That was a promise rather than a
- * mechanism. They live here now: the contract door is browser-safe, so the one
- * definition is reachable from both sides of the seam, and `@vendoai/ui`
- * re-exports these names unchanged.
+ * and the producer lives in the server half. They live HERE now, on a door a
+ * browser can import, so `@vendoai/ui` re-exports them instead of restating
+ * them — one fewer copy, and ui's public surface is unchanged.
+ *
+ * NOT yet one definition. The server half declares its own richer `EditResult`
+ * (`server/runtime/types.ts`) carrying `failure`, `graduated`, `box`,
+ * `pendingEgress` and `automation`; this one is the four-field wire shape a
+ * surface reads. Two declarations of the same name ship from this package, one
+ * per door. Unifying them is a behavior question — which fields the wire is
+ * allowed to expose — not a move, so it is deliberately left to the slice that
+ * owns unifications rather than smuggled into a reorganization.
  *
  * The chat / connections / automations / status shapes stay in `@vendoai/ui` —
  * they are not app-generation vocabulary and have no producer here.

--- a/packages/ui/src/wire-types.ts
+++ b/packages/ui/src/wire-types.ts
@@ -6,10 +6,15 @@
  * wire returns but core does not export are declared here, verbatim from the
  * frozen contract text. "Cannot drift because both sides copied the same frozen
  * text" turned out to be a promise rather than a mechanism, so the shapes the
- * producer and this consumer BOTH speak have moved to their producer's own
- * contract — `core/src/app-surfaces.ts` and the app-generation contract door,
- * `@vendoai/apps/contract` — and are re-exported below. The client's public
- * surface is unchanged; there is now only one definition to drift from.
+ * producer and this consumer BOTH speak are no longer restated here: they are
+ * re-exported below from `core/src/app-surfaces.ts` and from the
+ * app-generation contract door, `@vendoai/apps/contract`. The client's public
+ * surface is unchanged, and this file no longer carries a second copy.
+ *
+ * That removes ui's copy; it does not by itself make one definition. The app
+ * engine's server door still declares its own richer `EditResult`, so the name
+ * has two declarations inside `@vendoai/apps` — see the note in
+ * `apps/src/contract/wire-types.ts`.
  */
 import {
   type AppDocument,

--- a/scripts/dependency-guard.mjs
+++ b/scripts/dependency-guard.mjs
@@ -144,6 +144,11 @@ const LAYERS = {
  * root is the node-only engine and `@vendoai/apps/contract` is its browser-safe
  * half, so a ban list would let a future node-only subpath through by default.
  * Browser code reaches the contract and never the root.
+ *
+ * Keyed on the CONSUMER's package name, so it covers `packages/*` only —
+ * `examples/` and `fixtures/` are scanned for layering but get no subpath rule.
+ * That matches the intended scope (the ban exists to keep the browser package
+ * off the node-only door), but it is worth knowing before you rely on it.
  */
 const ONLY_SUBPATHS = {
   "@vendoai/ui": { "@vendoai/apps": ["@vendoai/apps/contract"] },

--- a/scripts/portability-gate.mjs
+++ b/scripts/portability-gate.mjs
@@ -232,6 +232,32 @@ try {
   fail(`fixture worker did not boot under workerd: ${error instanceof Error ? error.message : String(error)}`);
 }
 
+// ---- Leg D: the app-generation CONTRACT door bundles for a BROWSER ----
+// `@vendoai/apps/contract` is the browser-safe half of the app engine, and
+// `scripts/dependency-guard.mjs`'s ONLY_SUBPATHS rule makes it the one door
+// @vendoai/ui may reach. That rule enforces which SPECIFIER ui writes; nothing
+// enforced what the specifier RESOLVES to. A single `import "node:fs"` inside
+// src/contract/ passed lint, typecheck and the whole suite, and surfaced only
+// in a customer's `next build` — so the headline layering claim was a
+// convention, not a mechanism. This is the mechanism.
+try {
+  await esbuild.build({
+    entryPoints: [join(root, "packages/apps/dist/contract/index.js")],
+    bundle: true,
+    format: "esm",
+    platform: "browser",
+    write: false,
+  });
+  ok("@vendoai/apps/contract bundles for a browser target (no node built-ins)");
+} catch (error) {
+  fail(
+    "@vendoai/apps/contract does NOT bundle for a browser target — something under "
+    + "packages/apps/src/contract/ reached a node built-in or a node-only package. "
+    + "That door is imported by @vendoai/ui and by browser consumers; it must stay "
+    + `platform-clean. ${error instanceof Error ? error.message : String(error)}`,
+  );
+}
+
 if (failures > 0) {
   console.error(`portability-gate: ${failures} failure(s)`);
   process.exit(1);


### PR DESCRIPTION
Two follow-ups to #1118, both raised by the independent review of that PR. Five files, no behavior change, no test touched.

## 1. The contract door's browser-safety had no mechanism

"`@vendoai/apps/contract` is browser-safe" is a headline promise of the app-generation split — it is *why* `@vendoai/ui` is allowed to reach the app engine at all. Nothing enforced it.

`ONLY_SUBPATHS` in `scripts/dependency-guard.mjs` checks which **specifier** ui writes. Nothing checked what that specifier **resolves to**. Adding `import { readFile } from "node:fs"` to any file under `packages/apps/src/contract/` today leaves `pnpm lint`, `pnpm typecheck` and the entire suite green — the failure surfaces in a customer's `next build`, which is the worst place to find it.

`scripts/portability-gate.mjs` gains a fourth leg beside the three Worker legs:

```js
await esbuild.build({
  entryPoints: [join(root, "packages/apps/dist/contract/index.js")],
  bundle: true, format: "esm", platform: "browser", write: false,
});
```

**It passes today**, so this locks in a property we already have rather than fixing a break:

```
portability-gate: ok — @vendoai/apps/contract bundles for a browser target (no node built-ins)
portability-gate: all legs green
```

**Proof it can fail** — `import { readFile } from "node:fs"` planted in `contract/theme.ts`, built, gate run, then reverted:

```
portability-gate: BROKEN — @vendoai/apps/contract does NOT bundle for a browser target —
something under packages/apps/src/contract/ reached a node built-in or a node-only package.
That door is imported by @vendoai/ui and by browser consumers; it must stay platform-clean.
Build failed with 1 error:
portability-gate: 1 failure(s)
```

Reverted, the gate is green again and `git diff --stat` on the file is empty. This project's whole theme is replacing promises with mechanisms; the layering claim should not have shipped as a convention.

## 2. Retracting a false "one definition" claim

`packages/apps/src/contract/wire-types.ts` and `packages/ui/src/wire-types.ts` both claimed the wire types now have a single definition, and the changeset repeated it. **That is not true.**

| | `contract/wire-types.ts` | `server/runtime/types.ts` |
|---|---|---|
| `EditResult` | 4 fields | 9 fields — adds `failure`, `graduated`, `box`, `pendingEgress`, `automation` |

Both ship from `@vendoai/apps`, one per door. Reading `.graduated` off ui's `EditResult` is a type error; it is present on the engine's. A browser consumer typed with the contract shape cannot see the fields that distinguish *"edit rejected, nothing persisted"* from *"edit succeeded"* — and the console will point at exactly that door.

What #1118 actually did was **remove `@vendoai/ui`'s hand-copied third copy**. That is worth saying and is now what the comments say. The irony was sharp: the file mocked the previous state as *"a promise rather than a mechanism"* and then shipped the same promise.

**The duplication is deliberately not fixed here.** Unifying the two decides which fields the wire is allowed to expose — a behavior change, not a move — so it belongs to the slice that owns unifications, which has it as an assigned carry-in. Shipping a false claim in a public changelog was the defect; the duplication is someone else's job.

## 3. Two honesty fixes

- `scripts/dependency-guard.mjs`: one comment noting `ONLY_SUBPATHS` is keyed on the **consumer's package name**, so it covers `packages/*` only — `examples/` and `fixtures/` are scanned for layering but get no subpath rule. That is the intended scope; it just should not surprise the next reader.
- The changeset gains a sentence naming a real tradeoff: `@vendoai/apps` declares `esbuild`, `jsdom`, `fflate` and `react-dom` as hard dependencies, so a browser-only consumer of `/contract` still installs the engine's dependency set. The door itself bundles clean (leg above); it is the **install graph**, not the bundle, that carries the weight. Pre-existing shape, amplified by the split — better stated than discovered.

## Gate

| gate | result |
|---|---|
| `pnpm build` | **PASS** — 0 errors |
| `pnpm exec turbo run typecheck` | **PASS** — 0 errors |
| `pnpm lint` | **PASS** — `dependency-guard: OK (30 packages checked)`, `portability-gate: all legs green` (now 7 legs) |

No test file is touched and no source behavior changes: the two `wire-types.ts` edits are comments only, and the guard edit is a comment. The one executable change is the new gate leg, which is additive and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces the browser-safety promise for `@vendoai/apps/contract` by adding a browser bundling gate, and corrects a misleading “one definition” claim about wire types. No behavior changes; this locks in the layering contract and clarifies scope/tradeoffs.

- New Features
  - Added a `portability-gate` leg that bundles `packages/apps/dist/contract/index.js` with `platform: "browser"` to block Node built-ins in `@vendoai/apps/contract`.

- Bug Fixes
  - Updated comments: `EditResult` still has two declarations (contract vs server); #1118 only removed `@vendoai/ui`’s copy.
  - Clarified `ONLY_SUBPATHS` is keyed to `packages/*` consumers; `examples/` and `fixtures/` have no subpath rule.
  - Stated install-weight tradeoff: browser-only consumers of `@vendoai/apps/contract` still install `esbuild`, `jsdom`, `fflate`, and `react-dom`.

<sup>Written for commit 63cbfbb676579a468cea13c2fb007c5d3536d6d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

