### PR TITLE
fix(vendo): scope init's dependency repairs to the host — --ignore-workspace for nested non-member apps

### DIFF
--- a/.changeset/vendo-init-scopes-dep-repairs-to-the-host.md
+++ b/.changeset/vendo-init-scopes-dep-repairs-to-the-host.md
@@ -15,7 +15,9 @@ next 16 tree), and under an older pnpm the add aborts against the ancestor's
 store, so init only warns (E-DEP-003) and the zod floor never applies —
 leaving the build red on `zod ./v4 not exported`.
 
-The host's own `pnpm-lock.yaml` is what proves it is not a member: pnpm keeps
-exactly one lockfile, at the workspace root, never inside a member package.
-Genuine workspace members — and hosts that are their own workspace root —
-keep today's behavior exactly.
+Membership is decided by the ancestor workspace's own `packages:` globs
+matched against the host's relative path, so a genuine member keeps ordinary
+workspace behavior even if it carries a stale leaf lockfile, and a host that
+has never installed is still recognized as a non-member. A pattern form the
+reader does not model resolves to "member", which is the pre-existing
+behavior.

--- a/.changeset/vendo-init-scopes-dep-repairs-to-the-host.md
+++ b/.changeset/vendo-init-scopes-dep-repairs-to-the-host.md
@@ -1,0 +1,21 @@
+---
+"@vendoai/vendo": patch
+---
+
+`vendo init`'s two dependency repairs — the provider install and the zod floor
+bump — now run with `pnpm add --ignore-workspace` when the host is an
+independent pnpm project nested inside an unrelated pnpm workspace.
+
+pnpm picks its workspace root by walking up to the nearest
+`pnpm-workspace.yaml`, so an unqualified `pnpm add` in a repo that merely sits
+inside someone else's monorepo installs against that ancestor. Two ways that
+goes wrong: the ancestor's `overrides` rewrite the host's own pins (a host
+pinning `next@14.2.5` under an ancestor pinning `next: ">=16.2.11"` gets a
+next 16 tree), and under an older pnpm the add aborts against the ancestor's
+store, so init only warns (E-DEP-003) and the zod floor never applies —
+leaving the build red on `zod ./v4 not exported`.
+
+The host's own `pnpm-lock.yaml` is what proves it is not a member: pnpm keeps
+exactly one lockfile, at the workspace root, never inside a member package.
+Genuine workspace members — and hosts that are their own workspace root —
+keep today's behavior exactly.

--- a/packages/vendo/src/cli/provider-deps.ts
+++ b/packages/vendo/src/cli/provider-deps.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { readFile } from "node:fs/promises";
-import { dirname, join, relative, resolve } from "node:path";
+import { dirname, join, relative, resolve, sep } from "node:path";
 import type { DevCredential, EnvKeyProvider } from "../dev-creds/resolve.js";
 import { installedVersion, installedZodVersion } from "./dep-versions.js";
 import type { Output } from "./shared.js";
@@ -40,13 +40,16 @@ async function isInstalled(root: string, moduleName: string): Promise<boolean> {
   return (await installedVersion(root, moduleName)) !== null;
 }
 
-async function fileExists(root: string, name: string): Promise<boolean> {
+async function readIfExists(root: string, name: string): Promise<string | null> {
   try {
-    await readFile(join(root, name));
-    return true;
+    return await readFile(join(root, name), "utf8");
   } catch {
-    return false;
+    return null;
   }
+}
+
+async function fileExists(root: string, name: string): Promise<boolean> {
+  return (await readIfExists(root, name)) !== null;
 }
 
 export interface InstallCommand {
@@ -57,6 +60,61 @@ export interface InstallCommand {
   cwd: string;
 }
 
+/** The `packages:` globs of a pnpm-workspace.yaml, or null when the block is
+    not in the plain block-sequence form this reader understands. A missing
+    `packages:` key is an empty member list, which is what pnpm does with a
+    settings-only workspace file. */
+function workspacePackageGlobs(manifest: string): string[] | null {
+  const lines = manifest.split("\n");
+  const start = lines.findIndex((line) => /^packages:\s*(#.*)?$/.test(line));
+  if (start === -1) return /^packages:/m.test(manifest) ? null : [];
+  const globs: string[] = [];
+  for (const line of lines.slice(start + 1)) {
+    if (/^\s*(#.*)?$/.test(line)) continue;
+    const entry = /^\s*-\s+(.*)$/.exec(line);
+    if (entry === null) break;
+    globs.push((entry[1] as string).replace(/\s+#.*$/, "").trim().replace(/^(["'])(.*)\1$/, "$2"));
+  }
+  return globs;
+}
+
+/** The `*` / `**` / `?` subset of pnpm's package patterns, or null for a
+    pattern using brace/extglob syntax this does not model. */
+function globToRegExp(pattern: string): RegExp | null {
+  if (/[{}()[\]+@|!]/.test(pattern)) return null;
+  let source = "";
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern[index] as string;
+    if (char === "*" && pattern[index + 1] === "*") {
+      const slash = pattern[index + 2] === "/";
+      source += slash ? "(?:.*/)?" : ".*";
+      index += slash ? 2 : 1;
+    } else if (char === "*") source += "[^/]*";
+    else if (char === "?") source += "[^/]";
+    else source += char.replace(/[.\\^$+?()[\]{}|]/, "\\$&");
+  }
+  return new RegExp(`^${source}$`);
+}
+
+/** Whether a workspace root's `packages:` globs claim this relative path.
+    Anything unreadable counts as a member — the conservative answer, since a
+    member is what init already treats every nested app as today. */
+function workspaceClaims(manifest: string, relativePath: string): boolean {
+  const globs = workspacePackageGlobs(manifest);
+  if (globs === null) return true;
+  const path = relativePath.split(sep).join("/");
+  let claimed = false;
+  for (const glob of globs) {
+    const negated = glob.startsWith("!");
+    const pattern = globToRegExp(negated ? glob.slice(1) : glob);
+    if (pattern === null) return true;
+    if (!pattern.test(path)) continue;
+    if (negated) return false;
+    claimed = true;
+  }
+  return claimed;
+}
+
 /** True when the host is an independent pnpm project sitting INSIDE someone
     else's pnpm workspace — a repo cloned into an unrelated monorepo. pnpm
     picks its workspace root by walking up to the nearest
@@ -65,14 +123,15 @@ export interface InstallCommand {
     own pins (this repo's `next: ">=16.2.11"` gave a host pinning 14.2.5 a
     next 16 tree), and under pnpm 9 the add aborts on the ancestor's store
     (ERR_PNPM_UNEXPECTED_STORE), so the repair never happens at all.
-    The app's own `pnpm-lock.yaml` is the proof it is not a member: pnpm keeps
-    exactly one lockfile, at the workspace root, never inside a member
-    package. An app that is its own workspace root already wins the walk. */
+    Membership is the workspace's own answer — its `packages:` globs — not the
+    presence of a leaf lockfile: a real member can carry a stale or copied one,
+    and cutting it loose would write the repair to that leaf instead of the
+    workspace. An app that is its own workspace root already wins pnpm's walk. */
 async function nestedOutsidePnpmWorkspace(appRoot: string): Promise<boolean> {
-  if (!(await fileExists(appRoot, "pnpm-lock.yaml"))) return false;
   if (await fileExists(appRoot, "pnpm-workspace.yaml")) return false;
   for (let dir = dirname(appRoot); ; dir = dirname(dir)) {
-    if (await fileExists(dir, "pnpm-workspace.yaml")) return true;
+    const manifest = await readIfExists(dir, "pnpm-workspace.yaml");
+    if (manifest !== null) return !workspaceClaims(manifest, relative(dir, appRoot));
     if (dirname(dir) === dir) return false;
   }
 }

--- a/packages/vendo/src/cli/provider-deps.ts
+++ b/packages/vendo/src/cli/provider-deps.ts
@@ -57,6 +57,26 @@ export interface InstallCommand {
   cwd: string;
 }
 
+/** True when the host is an independent pnpm project sitting INSIDE someone
+    else's pnpm workspace — a repo cloned into an unrelated monorepo. pnpm
+    picks its workspace root by walking up to the nearest
+    `pnpm-workspace.yaml`, so an unqualified `pnpm add` there installs against
+    the ANCESTOR: under pnpm 11 the ancestor's overrides rewrite the host's
+    own pins (this repo's `next: ">=16.2.11"` gave a host pinning 14.2.5 a
+    next 16 tree), and under pnpm 9 the add aborts on the ancestor's store
+    (ERR_PNPM_UNEXPECTED_STORE), so the repair never happens at all.
+    The app's own `pnpm-lock.yaml` is the proof it is not a member: pnpm keeps
+    exactly one lockfile, at the workspace root, never inside a member
+    package. An app that is its own workspace root already wins the walk. */
+async function nestedOutsidePnpmWorkspace(appRoot: string): Promise<boolean> {
+  if (!(await fileExists(appRoot, "pnpm-lock.yaml"))) return false;
+  if (await fileExists(appRoot, "pnpm-workspace.yaml")) return false;
+  for (let dir = dirname(appRoot); ; dir = dirname(dir)) {
+    if (await fileExists(dir, "pnpm-workspace.yaml")) return true;
+    if (dirname(dir) === dir) return false;
+  }
+}
+
 /** Lockfile-sniffed installer, resolved the way package managers resolve
     their own root: walk UP from the app dir to the NEAREST lockfile or
     workspace marker. A nested workspace app usually carries neither in its
@@ -67,7 +87,8 @@ export async function installCommandFor(root: string): Promise<InstallCommand> {
   const appRoot = resolve(root);
   for (let dir = appRoot; ; dir = dirname(dir)) {
     if ((await fileExists(dir, "pnpm-lock.yaml")) || (await fileExists(dir, "pnpm-workspace.yaml"))) {
-      return { command: "pnpm", args: ["add"], cwd: appRoot };
+      const args = (await nestedOutsidePnpmWorkspace(appRoot)) ? ["add", "--ignore-workspace"] : ["add"];
+      return { command: "pnpm", args, cwd: appRoot };
     }
     if (await fileExists(dir, "yarn.lock")) return { command: "yarn", args: ["add"], cwd: appRoot };
     if ((await fileExists(dir, "bun.lockb")) || (await fileExists(dir, "bun.lock"))) {

--- a/packages/vendo/tests/cli/provider-deps.test.ts
+++ b/packages/vendo/tests/cli/provider-deps.test.ts
@@ -62,20 +62,59 @@ describe("installCommandFor", () => {
     expect(await installCommandFor(app)).toEqual({ command: "pnpm", args: ["add"], cwd: app });
   });
 
+  /** An app nested under a workspace root that claims `globs`. */
+  async function nestedUnderWorkspace(globs: string, appPath: string[], leafLockfile = true): Promise<string> {
+    const ancestor = await tempRoot();
+    await writeFile(join(ancestor, "pnpm-workspace.yaml"), `packages:\n${globs}overrides:\n  next: '>=16'\n`);
+    const app = join(ancestor, ...appPath);
+    await mkdir(app, { recursive: true });
+    await writeFile(join(app, "package.json"), JSON.stringify({ name: appPath.at(-1) }));
+    if (leafLockfile) await writeFile(join(app, "pnpm-lock.yaml"), "");
+    return app;
+  }
+
   it("ignores an ANCESTOR workspace the host is not a member of", async () => {
     // A repo cloned into an unrelated monorepo (the corpus clones hosts into
     // this repo's own tree). pnpm walks up to the nearest pnpm-workspace.yaml,
     // so an unqualified `pnpm add` installs against the ancestor: its
     // overrides rewrite the host's pins under pnpm 11, and the add aborts on
-    // the ancestor's store under pnpm 9. The host's own lockfile is the proof
-    // it is not a member — pnpm keeps one lockfile, at the workspace root.
-    const ancestor = await tempRoot();
-    await writeFile(join(ancestor, "pnpm-workspace.yaml"), "packages:\n  - pkgs/*\noverrides:\n  next: '>=16'\n");
-    const app = join(ancestor, ".repos", "skateshop");
-    await mkdir(app, { recursive: true });
-    await writeFile(join(app, "package.json"), JSON.stringify({ name: "skateshop" }));
-    await writeFile(join(app, "pnpm-lock.yaml"), "");
+    // the ancestor's store under pnpm 9.
+    const app = await nestedUnderWorkspace("  - pkgs/*\n", [".repos", "skateshop"]);
     expect(await installCommandFor(app)).toEqual({ command: "pnpm", args: ["add", "--ignore-workspace"], cwd: app });
+  });
+
+  it("ignores it for a non-member that never installed, lockfile or not", async () => {
+    // Membership is the workspace's answer, not the leaf's install state — a
+    // freshly cloned host has no lockfile yet and is still not a member.
+    const app = await nestedUnderWorkspace("  - pkgs/*\n", [".repos", "skateshop"], false);
+    expect(await installCommandFor(app)).toEqual({ command: "pnpm", args: ["add", "--ignore-workspace"], cwd: app });
+  });
+
+  it("keeps a real member on the workspace even when it carries a stale lockfile", async () => {
+    // A member can retain a copied or stale leaf pnpm-lock.yaml. Reading that
+    // as "not a member" cut it loose from its own workspace and wrote the
+    // repair into the leaf lockfile instead (Greptile P1, live reproduction).
+    const app = await nestedUnderWorkspace("  - pkgs/*\n", ["pkgs", "web"]);
+    expect(await installCommandFor(app)).toEqual({ command: "pnpm", args: ["add"], cwd: app });
+  });
+
+  it("honors a `!` exclusion — an excluded dir is not a member", async () => {
+    const app = await nestedUnderWorkspace("  - pkgs/*\n  - '!pkgs/vendored'\n", ["pkgs", "vendored"]);
+    expect(await installCommandFor(app)).toEqual({ command: "pnpm", args: ["add", "--ignore-workspace"], cwd: app });
+  });
+
+  it("treats a pattern it cannot model as a member — the conservative side", async () => {
+    // Brace/extglob syntax is not modelled; guessing "not a member" would cut
+    // a real member loose, so an unreadable pattern keeps today's behavior.
+    const app = await nestedUnderWorkspace("  - '{apps,pkgs}/*'\n", ["apps", "web"]);
+    expect(await installCommandFor(app)).toEqual({ command: "pnpm", args: ["add"], cwd: app });
+  });
+
+  it("matches deep globs the way pnpm does", async () => {
+    const nested = await nestedUnderWorkspace("  - 'apps/**'\n", ["apps", "team", "web"]);
+    expect((await installCommandFor(nested)).args).toEqual(["add"]);
+    const tooDeep = await nestedUnderWorkspace("  - 'apps/*'\n", ["apps", "team", "web"]);
+    expect((await installCommandFor(tooDeep)).args).toEqual(["add", "--ignore-workspace"]);
   });
 
   it("leaves a nested app that is its own workspace root alone", async () => {

--- a/packages/vendo/tests/cli/provider-deps.test.ts
+++ b/packages/vendo/tests/cli/provider-deps.test.ts
@@ -62,6 +62,34 @@ describe("installCommandFor", () => {
     expect(await installCommandFor(app)).toEqual({ command: "pnpm", args: ["add"], cwd: app });
   });
 
+  it("ignores an ANCESTOR workspace the host is not a member of", async () => {
+    // A repo cloned into an unrelated monorepo (the corpus clones hosts into
+    // this repo's own tree). pnpm walks up to the nearest pnpm-workspace.yaml,
+    // so an unqualified `pnpm add` installs against the ancestor: its
+    // overrides rewrite the host's pins under pnpm 11, and the add aborts on
+    // the ancestor's store under pnpm 9. The host's own lockfile is the proof
+    // it is not a member — pnpm keeps one lockfile, at the workspace root.
+    const ancestor = await tempRoot();
+    await writeFile(join(ancestor, "pnpm-workspace.yaml"), "packages:\n  - pkgs/*\noverrides:\n  next: '>=16'\n");
+    const app = join(ancestor, ".repos", "skateshop");
+    await mkdir(app, { recursive: true });
+    await writeFile(join(app, "package.json"), JSON.stringify({ name: "skateshop" }));
+    await writeFile(join(app, "pnpm-lock.yaml"), "");
+    expect(await installCommandFor(app)).toEqual({ command: "pnpm", args: ["add", "--ignore-workspace"], cwd: app });
+  });
+
+  it("leaves a nested app that is its own workspace root alone", async () => {
+    // Its own pnpm-workspace.yaml wins pnpm's upward walk, so the ancestor
+    // never applies and --ignore-workspace would cut its own members loose.
+    const ancestor = await tempRoot();
+    await writeFile(join(ancestor, "pnpm-workspace.yaml"), "packages:\n  - pkgs/*\n");
+    const app = join(ancestor, ".repos", "monorepo-host");
+    await mkdir(app, { recursive: true });
+    await writeFile(join(app, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n");
+    await writeFile(join(app, "pnpm-lock.yaml"), "");
+    expect(await installCommandFor(app)).toEqual({ command: "pnpm", args: ["add"], cwd: app });
+  });
+
   it("targets a nested npm-workspace app from the lockfile root", async () => {
     const workspace = await tempRoot();
     await writeFile(join(workspace, "package-lock.json"), "{}");
@@ -358,6 +386,31 @@ describe("ensureZodFloor in a hoisted workspace (checker round 1)", () => {
     expect(messages.errors.join("\n")).toContain("zod@3.23.8");
     expect(messages.errors.join("\n")).toContain("pnpm add zod@^3.25.0");
     expect(messages.errors.join("\n")).not.toContain("npm install");
+  });
+
+  it("scopes the bump to a host nested inside an unrelated workspace", async () => {
+    // The repair that never landed: under the corpus's nesting the bump ran
+    // against the ancestor workspace, so the host's zod stayed below the floor.
+    const ancestor = await tempRoot();
+    await writeFile(join(ancestor, "pnpm-workspace.yaml"), "packages:\n  - packages/*\n");
+    const app = join(ancestor, ".repos", "skateshop");
+    await mkdir(app, { recursive: true });
+    await writeFile(join(app, "package.json"), JSON.stringify({ name: "skateshop" }));
+    await writeFile(join(app, "pnpm-lock.yaml"), "");
+    await installZodVersion(app, "3.23.8");
+
+    const calls: Array<{ command: string; args: string[]; cwd: string }> = [];
+    const messages = output();
+    await ensureZodFloor({
+      root: app,
+      output: messages.sink,
+      yes: true,
+      run: async (command, args, cwd) => {
+        calls.push({ command, args, cwd });
+        return 0;
+      },
+    });
+    expect(calls).toEqual([{ command: "pnpm", args: ["add", "--ignore-workspace", ZOD_FLOOR_SPEC], cwd: app }]);
   });
 
   it("performs the --yes bump with the workspace's package manager from the app dir", async () => {


### PR DESCRIPTION
## The bug

`vendo init` performs two dependency repairs on the host — the provider install (`ai@^6` + `@ai-sdk/*`) and the zod floor bump — by spawning a child `pnpm add` built in `packages/vendo/src/cli/provider-deps.ts` and run from `ensureHostDeps` (`init.ts:1243`). The command carried no `--ignore-workspace`.

pnpm picks its workspace root by walking **up** to the nearest `pnpm-workspace.yaml`, and it does that regardless of whether the directory is a member of that workspace. So when the host app merely *sits inside* an unrelated pnpm workspace — the corpus clones hosts into `corpus/.repos/<repo>` inside this very monorepo, but any non-member nesting hits it — the repair installs against the **ancestor**, not the host. Two failure faces:

**1. Override leak (pnpm 11).** The ancestor's `overrides` rewrite the host's own pins. This repo pins `next: ">=16.2.11"` (`pnpm-workspace.yaml:95`), so a host pinning `next@14.2.5` (skateshop does) ends up with `node_modules/next` 16.x. Reproduced in a scratch sandbox: an ancestor workspace pinning `is-odd: 3.0.1` over a nested non-member app declaring `is-odd: 2.0.0`; a repair-shaped `pnpm add is-even@1.0.0` inside the app installed **is-odd 3.0.1**, and wrote a lockfile into the ancestor. The same command with `--ignore-workspace` installed **is-odd 2.0.0** and left the ancestor untouched.

**2. Dead repair (pnpm 9).** Under the host's own `packageManager` pin (skateshop pins `pnpm@9.5.0`), the add aborts with `ERR_PNPM_UNEXPECTED_STORE` against the ancestor's store. Init treats a failed repair as non-fatal, so it warns (E-DEP-003) and exits 0 — the zod floor never applies and the host build then fails on `zod ./v4 not exported`.

**Corpus evidence:** the corpus run scored skateshop baseline-green → post-init-red on **both** typecheck and build — the repair that exists to prevent exactly that failure is the thing that never lands. (That scorecard came from the corpus run; what I re-verified directly here is the mechanism and skateshop's shape.) skateshop's shape is the trigger: `packageManager: pnpm@9.5.0`, `next: 14.2.5`, its own `pnpm-lock.yaml`, no `pnpm-workspace.yaml` of its own, sitting under this repo's workspace root.

## The fix

One decision point in the pnpm branch of the repair-command builder, so **both** repairs inherit it: when the host is an independent pnpm project nested inside someone else's workspace, emit `pnpm add --ignore-workspace ...`.

The membership test is the host's own `pnpm-lock.yaml`: pnpm keeps exactly one lockfile, at the workspace root, never inside a member package — so a lockfile in the app dir under an ancestor `pnpm-workspace.yaml` is proof the app is not a member. A host that is its own workspace root already wins pnpm's upward walk, so it is excluded (ignoring the workspace there would cut its own members loose). Genuine workspace members, npm/yarn/bun hosts, and standalone hosts keep today's behavior byte-for-byte.

`--ignore-workspace` is supported by both pnpm versions in play (verified against pnpm 9.5.0 and 11.10.0).

## Proof

- **Unit** — three new cases in `packages/vendo/tests/cli/provider-deps.test.ts`: nested non-member ⇒ `--ignore-workspace`; nested app that is its own workspace root ⇒ unchanged; and the zod repair itself (`ensureZodFloor`) inheriting the flag. Proven able to fail: with the fix short-circuited, both new command assertions go red (`- "--ignore-workspace"` missing from the received args) while all 20 pre-existing cases stay green; restored ⇒ 22/22.
- **Real-world seam** — the **built** `dist/cli/provider-deps.js` run against the real corpus host dirs: `corpus/.repos/skateshop` ⇒ `pnpm add --ignore-workspace`, `corpus/.repos/nextcrm` ⇒ `pnpm add --ignore-workspace`, `corpus/.repos/invoify` (npm host) ⇒ `npm install` (unchanged), `packages/vendo` (genuine member) ⇒ `pnpm add` (unchanged). Plus the sandbox install described above, where the override provably stops leaking.
- **Gate** — `pnpm build` ✅ · `pnpm typecheck` ✅ · `pnpm lint` ✅ · `packages/vendo` tests for the touched area (`provider-deps` + `doctor` + `init`): 3 files, **201 passed**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `vendo init` installing repairs into an ancestor `pnpm` workspace for nested non-member apps. Repairs now run with `pnpm add --ignore-workspace` so provider deps and the `zod` floor install in the host, avoiding override leaks and `pnpm` 9 aborts.

- **Bug Fixes**
  - Decide membership from the ancestor `pnpm-workspace.yaml` `packages:` globs (supports `*`, `**`, `?`, `!`); treat unreadable patterns as “member” and ignore leaf lockfiles.
  - Apply `--ignore-workspace` to both repairs: provider install (`ai@^6`, `@ai-sdk/*`) and the `zod` floor bump.
  - No change for true workspace roots/members or `npm`/`yarn`/`bun`; verified on `pnpm` 9 and 11.

<sup>Written for commit 35e40e39b23a39f2b4ff5b1b7a5d64483c7a451e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

