### PR TITLE
fix(vendo): clientRoot finds nested root layouts — init/doctor stop naming a phantom app/layout.tsx

### DIFF
--- a/.changeset/vendo-clientroot-nested-layout.md
+++ b/.changeset/vendo-clientroot-nested-layout.md
@@ -1,0 +1,19 @@
+---
+"@vendoai/vendo": patch
+---
+
+`vendo init` and `vendo doctor` find a nested root layout instead of naming a
+file that does not exist
+
+An app-router host whose routes all live under an i18n segment or a route group
+(`app/[locale]/layout.tsx`, `app/(shop)/layout.tsx`) has no `app/layout.tsx` —
+that nested file IS its root layout. Both commands probed for the literal
+`app/layout.tsx` and, finding nothing, named it anyway: init printed a paste for
+a phantom file, and doctor's E-WIRE-004 demanded the same one. A user who
+followed that instruction created a SECOND root layout, which is the one edit
+that breaks such a host.
+
+Both now resolve the client root to the shallowest `layout.{tsx,jsx,js}` under
+the app directory (lexicographic on a tie), so the paste and the doctor fix name
+the file the host actually has. Hosts with a real `app/layout.tsx`, pages-only
+hosts (`pages/_app.tsx`), and hosts with no client root at all are unchanged.

--- a/packages/vendo/src/cli/shared.ts
+++ b/packages/vendo/src/cli/shared.ts
@@ -1,9 +1,10 @@
 import { readFileSync } from "node:fs";
 import { access, mkdir, readFile, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { dirname, join, sep } from "node:path";
 import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
 import { initTelemetry, repoHost, type Telemetry } from "@vendoai/telemetry";
+import { walk } from "./theme/walk.js";
 
 export const CLI_VERSION = "0.9.0";
 
@@ -270,23 +271,34 @@ export async function appDirectory(root: string): Promise<string> {
   return join(root, "app");
 }
 
+const LAYOUT_FILE = /(^|[\\/])layout\.(?:tsx|jsx|js)$/;
+
 /** The file whose client root the <VendoProvider> paste belongs in, and the
-    child expression it wraps there. A pages-only host has NO app/layout.tsx to
-    wrap — its client root is pages/_app.tsx, and the paste mounts there
-    unchanged. (Where the API route segment
+    child expression it wraps there. The app router's ROOT layout is whichever
+    layout sits shallowest — an i18n or route-group host (`app/[locale]/`,
+    `app/(shop)/`) has no app/layout.tsx at all, so a literal app/layout.tsx
+    probe named a file that does not exist and told the user to create a SECOND
+    root layout, which is how you break such a host rather than mount in it.
+    Shallowest wins, lexicographic on a tie (walk() sorts, and sort is stable).
+    A pages-only host has no layout to wrap — its client root is pages/_app.tsx,
+    and the paste mounts there unchanged. (Where the API route segment
     gets scaffolded is a separate, deliberate choice — see appDirectory.)
     Keyed on the layout FILE, not on a router probe: the scaffold creates app/
-    mid-run, and the answer must be the same before and after it.
+    mid-run, and the answer must be the same before and after it. The
+    conventional app/layout.tsx survives only as the last resort — a host with
+    no layout and no pages/ has no client root yet, and that is where Next
+    wants the one it must create.
 
     Shared with doctor on purpose: init tells the user which file to paste into
     and doctor grades whether they did. Two copies of this rule meant doctor
     failed every pages-only host forever, naming a file init never mentioned. */
 export async function clientRoot(root: string): Promise<{ file: string; children: string }> {
-  const layout = join(await appDirectory(root), "layout.tsx");
-  if (!(await exists(layout))) {
-    for (const pages of [join(root, "src", "pages"), join(root, "pages")]) {
-      if (await exists(pages)) return { file: join(pages, "_app.tsx"), children: "<Component {...pageProps} />" };
-    }
+  const app = await appDirectory(root);
+  const [layout] = (await walk(app, (file) => LAYOUT_FILE.test(file)))
+    .sort((a, b) => a.split(sep).length - b.split(sep).length);
+  if (layout !== undefined) return { file: layout, children: "{children}" };
+  for (const pages of [join(root, "src", "pages"), join(root, "pages")]) {
+    if (await exists(pages)) return { file: join(pages, "_app.tsx"), children: "<Component {...pageProps} />" };
   }
-  return { file: layout, children: "{children}" };
+  return { file: join(app, "layout.tsx"), children: "{children}" };
 }

--- a/packages/vendo/tests/cli/doctor.test.ts
+++ b/packages/vendo/tests/cli/doctor.test.ts
@@ -1718,6 +1718,30 @@ describe("vendo doctor error codes + fix_refs", () => {
     expect(wire004).not.toContain(join("app", "layout.tsx"));
   });
 
+  /** The nextcrm shape (corpus, pinned 5b6a555): an i18n host whose root
+      layout IS app/[locale]/layout.tsx. Naming the phantom app/layout.tsx sent
+      the user to create a SECOND root layout — the fix doctor asks for must be
+      one this host can actually apply. */
+  it("names the nested root layout, not a phantom app/layout.tsx, on an i18n host", async () => {
+    const root = await healthy();
+    await rm(join(root, "app", "layout.tsx"));
+    await mkdir(join(root, "app", "[locale]", "(routes)"), { recursive: true });
+    await writeFile(join(root, "app", "[locale]", "layout.tsx"),
+      "export default ({children}) => <html><body>{children}</body></html>;");
+    await writeFile(join(root, "app", "[locale]", "(routes)", "layout.tsx"),
+      "export default ({children}) => <main>{children}</main>;");
+    const messages = output();
+    expect(await doctor({
+      targetDir: root,
+      fetchImpl: successfulProbeFetch(),
+      output: messages.sink,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    })).toBe(1);
+    const wire004 = messages.errors.join("\n");
+    expect(wire004).toContain(join("app", "[locale]", "layout.tsx"));
+    expect(wire004).not.toContain(join("app", "[locale]", "(routes)", "layout.tsx"));
+  });
+
   // Render gate (0.4.1 E2E cert M3): the certified invoify install had every
   // page 500ing while doctor exited 0 — a live wire proves nothing about the
   // pages users load.

--- a/packages/vendo/tests/cli/init.test.ts
+++ b/packages/vendo/tests/cli/init.test.ts
@@ -1849,6 +1849,62 @@ describe("the mount paste (init never edits user-authored source)", () => {
     await expect(readFile(join(root, "vendo", "vendo-root.tsx"))).rejects.toMatchObject({ code: "ENOENT" });
     expect(sink.logs.join("\n")).not.toContain("Last steps are yours:");
   });
+
+  /** The nextcrm shape (corpus, pinned 5b6a555): every route lives under
+      app/[locale]/, so the app router's ROOT layout is app/[locale]/layout.tsx
+      and app/layout.tsx does not exist. Naming the phantom told the user to
+      create a second root layout — the one edit that breaks such a host. */
+  it("names the shallowest nested layout when the host has no app/layout.tsx", async () => {
+    const root = await fixture();
+    await rm(join(root, "app", "layout.tsx"));
+    await mkdir(join(root, "app", "[locale]", "(auth)"), { recursive: true });
+    await writeFile(join(root, "app", "[locale]", "layout.tsx"),
+      "export default function Layout({ children }) { return <html><body>{children}</body></html>; }\n");
+    await writeFile(join(root, "app", "[locale]", "(auth)", "layout.tsx"),
+      "export default function AuthLayout({ children }) { return <main>{children}</main>; }\n");
+    const sink = output();
+    expect(await run(root, sink, { agent: true })).toBe(0);
+    const plan = JSON.parse(sink.logs.join("\n")) as { mount?: { file: string; lines: string[] } };
+    expect(plan.mount?.file).toBe(join("app", "[locale]", "layout.tsx"));
+    // The paste still wraps {children}, and the theme import walks out of the
+    // deeper directory.
+    expect(plan.mount?.lines.at(-1)).toContain("{children}</VendoProvider>");
+    expect(plan.mount?.lines).toContain('import theme from "../../.vendo/theme.json";');
+  });
+
+  it("keeps naming app/layout.tsx when a root layout sits beside nested ones", async () => {
+    const root = await fixture();
+    await mkdir(join(root, "app", "(shop)"), { recursive: true });
+    await writeFile(join(root, "app", "(shop)", "layout.tsx"),
+      "export default function ShopLayout({ children }) { return <main>{children}</main>; }\n");
+    const sink = output();
+    expect(await run(root, sink, { agent: true })).toBe(0);
+    expect((JSON.parse(sink.logs.join("\n")) as { mount?: { file: string } }).mount?.file)
+      .toBe(join("app", "layout.tsx"));
+  });
+
+  it("still names pages/_app.tsx on a Pages-Router host with no layouts at all", async () => {
+    const root = await fixture();
+    await rm(join(root, "app", "layout.tsx"));
+    await mkdir(join(root, "pages"), { recursive: true });
+    await writeFile(join(root, "pages", "index.tsx"), "export default () => <main />;\n");
+    const sink = output();
+    expect(await run(root, sink, { agent: true })).toBe(0);
+    const plan = JSON.parse(sink.logs.join("\n")) as { mount?: { file: string; lines: string[] } };
+    expect(plan.mount?.file).toBe(join("pages", "_app.tsx"));
+    expect(plan.mount?.lines.at(-1)).toContain("<Component {...pageProps} /></VendoProvider>");
+  });
+
+  /** No layout and no pages/ means the host has no client root yet — the
+      conventional app/layout.tsx is the address of the one it must create. */
+  it("falls back to app/layout.tsx only when the host has no client root at all", async () => {
+    const root = await fixture();
+    await rm(join(root, "app", "layout.tsx"));
+    const sink = output();
+    expect(await run(root, sink, { agent: true })).toBe(0);
+    expect((JSON.parse(sink.logs.join("\n")) as { mount?: { file: string } }).mount?.file)
+      .toBe(join("app", "layout.tsx"));
+  });
 });
 
 describe("init telemetry enrichment", () => {


### PR DESCRIPTION
## The bug

`clientRoot` (`packages/vendo/src/cli/shared.ts`) resolved the client mount file
by probing for a literal `app/layout.tsx` (or `src/app/layout.tsx`), falling back
to `pages/_app.tsx` — and when **none** of those existed it returned the
nonexistent `app/layout.tsx` path anyway.

Next's app router does not require a layout at `app/`. A host whose routes all
live under an i18n segment or a route group has its root layout **nested**, and
that nested file *is* the root layout.

Both of the commands that mount Vendo share `clientRoot` on purpose
(`mountStep` in `init.ts`, `checkProviderMount` in `doctor-wiring-checks.ts`), so
both named the phantom:

- `vendo init` printed `File: app/layout.tsx` — a file the repo does not have.
- `vendo doctor` failed `E-WIRE-004` telling the user to paste into that same
  nonexistent file.

## Why this is worse than a cosmetic wrong path

Doctor's *detection* already walks every layout, so a user who ignores the
instruction and guesses correctly does pass. A user who **follows** the
instruction creates `app/layout.tsx` — which demotes the real root layout to a
nested one and gives the host two `<html>`/`<body>` roots. The by-the-book path
either leaves doctor red forever or breaks the app.

## Corpus evidence

`corpus` host **nextcrm** (`pdovhomilja/nextcrm-app`, pinned
`5b6a555022217607cba72df357d437a481fccbf4`) is exactly this shape — its layer-1
`files.expected` check is red, and `init.first.log` names `app/layout.tsx`. The
tree at that SHA:

```
app/[locale]/layout.tsx            <- the real root layout
app/[locale]/(auth)/layout.tsx
app/[locale]/(routes)/layout.tsx
app/[locale]/(routes)/admin/layout.tsx
app/[locale]/(routes)/admin/invoices/layout.tsx
```

No `app/layout.*`. No `pages/`.

## The fix

`clientRoot` now resolves to the **shallowest** `layout.{tsx,jsx,js}` under the
app directory, lexicographic on a tie (`walk()` sorts and `Array#sort` is
stable). Depth 0 is the conventional root layout, so every existing host answers
exactly as before; a nested-root host now gets its real file. Falling out of the
same change: a host whose root layout is `app/layout.jsx` — same bug class — is
fixed for free.

Precedence is unchanged in intent: an app-router layout beats `pages/_app.tsx`,
which beats the last-resort `app/layout.tsx` (kept deliberately — a host with no
layout **and** no `pages/` has no client root yet, and that is where Next wants
the one it must create).

## Proof

**Unit** (`tests/cli/init.test.ts`, `tests/cli/doctor.test.ts`) — 5 new tests:
nested `[locale]` + `(auth)` host names the shallowest file (and the theme
import walks out the extra level); root layout beside nested ones still wins;
pages-only host still gets `pages/_app.tsx`; no-client-root host still gets the
`app/layout.tsx` address; doctor's E-WIRE-004 names the nested root, not the
deeper `(routes)` layout.

Reverted the fix, watched them go red, restored:

```
× doctor > names the nested root layout, not a phantom app/layout.tsx, on an i18n host
  → expected 'broken: no client entry mounts <Vendo…' to contain 'app/[locale]/layout.tsx'
× init > names the shallowest nested layout when the host has no app/layout.tsx
  → expected 'app/layout.tsx' to be 'app/[locale]/layout.tsx'
Tests  2 failed | 182 passed (184)
```

**Real host** — shallow-cloned nextcrm at the pinned SHA and ran the BUILT CLI
(`bin/vendo.mjs`) against it, not a fixture:

```
ONE STEP LEFT — paste this yourself (init never edits your files)
  File: app/[locale]/layout.tsx
    import theme from "../../.vendo/theme.json";
    … then wrap: <VendoProvider baseUrl="/api/vendo" theme={theme as VendoTheme}>{children}</VendoProvider>
```

and `vendo doctor` in the same tree:

```
broken: no client entry mounts <VendoProvider> … In app/[locale]/layout.tsx, paste: …
```

**Gate** — `pnpm build`, `pnpm typecheck`, `pnpm lint` green; scoped vitest
(`init`, `doctor`, `doctor-codes`, `shared`, `eject`) 202 passed. Full suite is
CI's job.

No UI surface is touched.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `vendo init` and `vendo doctor` so they target the real client root in Next.js apps with nested root layouts, instead of naming a phantom `app/layout.tsx` that could break the app. `clientRoot` now picks the correct layout file (e.g., `app/[locale]/layout.tsx`) and keeps existing fallbacks.

- **Bug Fixes**
  - `clientRoot` walks `app/` and selects the shallowest `layout.{tsx,jsx,js}` (lexicographic on tie).
  - Precedence kept: app-router layout > `pages/_app.tsx` > `app/layout.tsx` (last resort when no client root exists).
  - `init` and `doctor` now print the actual file path and the paste still wraps `{children}`.

<sup>Written for commit 14fc262760c69cbddb866c4e20556ada1648bada. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

