### PR TITLE
feat(workbench): harness dev workbench — whole-graph hot reload + live internals pane

### DIFF
--- a/.changeset/workbench-dev-diagnostics.md
+++ b/.changeset/workbench-dev-diagnostics.md
@@ -1,6 +1,7 @@
 ---
 "@vendoai/harnesses": minor
 "@vendoai/ui": minor
+"@vendoai/vendo": minor
 ---
 
 A dev-only workbench diagnostics channel behind `VENDO_WORKBENCH`, and the feed
@@ -15,3 +16,5 @@ reach the wire and nothing is ever persisted.
 `@vendoai/ui` gains the receiving half: `publishWorkbenchPart` files a chunk,
 `useWorkbenchFeed` reads the turns back in the producer's own `seq` order, and
 `developmentMode` decides whether such a surface renders at all.
+`@vendoai/vendo/react` re-exports all three, so a host on the umbrella package
+can build the pane without reaching for `@vendoai/ui` directly.

--- a/.changeset/workbench-dev-diagnostics.md
+++ b/.changeset/workbench-dev-diagnostics.md
@@ -1,0 +1,17 @@
+---
+"@vendoai/harnesses": minor
+"@vendoai/ui": minor
+---
+
+A dev-only workbench diagnostics channel behind `VENDO_WORKBENCH`, and the feed
+store that reads it.
+
+`@vendoai/harnesses` reports what a turn is doing about itself — step starts and
+ends, guarded tool calls, context and compaction, loadout, hires, errors — on a
+transient `data-vendo-debug` part. The gate is `VENDO_WORKBENCH=1` on the
+server, read once per turn: unset, no channel is registered, so nothing can
+reach the wire and nothing is ever persisted.
+
+`@vendoai/ui` gains the receiving half: `publishWorkbenchPart` files a chunk,
+`useWorkbenchFeed` reads the turns back in the producer's own `seq` order, and
+`developmentMode` decides whether such a surface renders at all.

--- a/examples/demo-bank/next.config.ts
+++ b/examples/demo-bank/next.config.ts
@@ -11,26 +11,77 @@ const nextConfig: NextConfig = {
   // is not a function"), so it stays external too — including @vendoai/store,
   // which loads PGlite for the local default store.
   serverExternalPackages: ["esbuild", "@electric-sql/pglite", "@vendoai/store"],
-  transpilePackages: ["@vendoai/ui"],
-  // Dev-only: resolve @vendoai/ui to its TypeScript source so edits in
-  // packages/ui/src hot-reload here instead of waiting on a `pnpm build`.
-  // Turbopack matches the request verbatim, so every entry point in the
-  // package's exports map needs its own line — and its NodeNext `.js`
-  // specifiers only resolve to `.ts` because this app's tsconfig is NodeNext
-  // too. `next build` skips the block and resolves dist/ like a published
-  // install would.
+  // Dev-only: resolve the whole @vendoai workspace graph to its TypeScript
+  // source so edits anywhere in packages/*/src hot-reload here instead of
+  // waiting on a `pnpm build`. Turbopack matches the request verbatim, so
+  // every entry point in every package's exports map needs its own line — and
+  // their NodeNext `.js` specifiers only resolve to `.ts` because this app's
+  // tsconfig is NodeNext too. Whole graph or nothing, deliberately: aliasing
+  // only part of it leaves one bundle holding a src copy and a dist copy of
+  // the same module, and state keyed by module identity (harnesses' WeakMap of
+  // adapter slots, store's of internals) then splits silently across the two.
+  // @vendoai/store is the lone holdout — it is externalized for PGlite above,
+  // and node cannot require .ts. `next build` skips the block entirely and
+  // resolves dist/ like a published install would.
   ...(process.env.NODE_ENV === "development"
     ? {
+        transpilePackages: [
+          "@vendoai/actions",
+          "@vendoai/agents",
+          "@vendoai/apps",
+          "@vendoai/automations",
+          "@vendoai/core",
+          "@vendoai/guard",
+          "@vendoai/harnesses",
+          "@vendoai/knowledge",
+          "@vendoai/mcp",
+          "@vendoai/telemetry",
+          "@vendoai/ui",
+          "@vendoai/vendo",
+        ],
         turbopack: {
           resolveAlias: {
+            "@vendoai/actions": "../../packages/actions/src/index.ts",
+            "@vendoai/actions/presets": "../../packages/actions/src/presets/index.ts",
+            "@vendoai/actions/presets/auth-js": "../../packages/actions/src/presets/auth-js.ts",
+            "@vendoai/actions/sync": "../../packages/actions/src/sync/public.ts",
+            "@vendoai/agents": "../../packages/agents/src/index.ts",
+            "@vendoai/apps": "../../packages/apps/src/server/index.ts",
+            "@vendoai/apps/contract": "../../packages/apps/src/contract/index.ts",
+            "@vendoai/apps/e2b": "../../packages/apps/src/server/escalation/e2b/index.ts",
+            "@vendoai/apps/testing": "../../packages/apps/src/server/testing/index.ts",
+            "@vendoai/automations": "../../packages/automations/src/index.ts",
+            "@vendoai/core": "../../packages/core/src/index.ts",
+            "@vendoai/core/conformance": "../../packages/core/src/conformance/index.ts",
+            "@vendoai/guard": "../../packages/guard/src/index.ts",
+            "@vendoai/harnesses": "../../packages/harnesses/src/index.ts",
+            "@vendoai/harnesses/vendo": "../../packages/harnesses/src/vendo/index.ts",
+            "@vendoai/harnesses/claude-code": "../../packages/harnesses/src/claude-code/index.ts",
+            "@vendoai/harnesses/claude-turn": "../../packages/harnesses/src/claude-code/claude-turn.ts",
+            // No line for @vendoai/harnesses/box-door: it ships as source
+            // (box/turn-routes.mjs), so there is no dist copy to bypass.
+            "@vendoai/knowledge": "../../packages/knowledge/src/index.ts",
+            "@vendoai/mcp": "../../packages/mcp/src/index.ts",
+            "@vendoai/telemetry": "../../packages/vendo-telemetry/src/index.ts",
             "@vendoai/ui": "../../packages/ui/src/index.ts",
             "@vendoai/ui/chrome": "../../packages/ui/src/chrome/index.ts",
             "@vendoai/ui/tree": "../../packages/ui/src/tree/index.ts",
             "@vendoai/ui/kit": "../../packages/ui/src/kit/index.ts",
+            "@vendoai/vendo": "../../packages/vendo/src/index.ts",
+            "@vendoai/vendo/server": "../../packages/vendo/src/server.ts",
+            "@vendoai/vendo/extract": "../../packages/vendo/src/cli/extract/index.ts",
+            "@vendoai/vendo/react": "../../packages/vendo/src/react.tsx",
+            "@vendoai/vendo/ai-sdk": "../../packages/vendo/src/ai-sdk.ts",
+            "@vendoai/vendo/mastra": "../../packages/vendo/src/mastra.ts",
+            "@vendoai/vendo/auth/auth0": "../../packages/vendo/src/auth-presets/auth0.ts",
+            "@vendoai/vendo/auth/auth-js": "../../packages/vendo/src/auth-presets/auth-js.ts",
+            "@vendoai/vendo/auth/clerk": "../../packages/vendo/src/auth-presets/clerk.ts",
+            "@vendoai/vendo/auth/jwt": "../../packages/vendo/src/auth-presets/jwt.ts",
+            "@vendoai/vendo/auth/supabase": "../../packages/vendo/src/auth-presets/supabase.ts",
           },
         },
       }
-    : {}),
+    : { transpilePackages: ["@vendoai/ui"] }),
   // Test boots (away-drill e2e) get their own dist dir → own dev-server lock,
   // so they never fight a concurrent `pnpm dev`. Nested under .next so
   // gitignore/scanner rules that skip .next cover it.

--- a/examples/demo-bank/src/components/vendo/VendoLayer.tsx
+++ b/examples/demo-bank/src/components/vendo/VendoLayer.tsx
@@ -5,6 +5,7 @@ import { withBasePath } from "@/lib/base-path";
 import { useVendoOverlay } from "@vendoai/ui";
 import { VendoOverlay, VendoPalette, VendoThread, type VendoCommand, type VendoThreadProps } from "@vendoai/ui/chrome";
 import { MapleMark } from "@/components/ui/maple-mark";
+import { VendoWorkbench } from "@/components/vendo/workbench/VendoWorkbench";
 import { mapleScenarios } from "@/vendo/scenarios";
 
 /** The overlay's thread with the Maple scenario cards on the empty landing.
@@ -70,6 +71,9 @@ export function VendoLayer() {
         hotkey={(event) => (event.metaKey || event.ctrlKey) && !event.shiftKey && event.key.toLowerCase() === "j"}
         onCommand={onCommand}
       />
+      {/* The harness workbench: dev-only diagnostics, docked beside the
+          overlay. Renders nothing outside `next dev`. */}
+      <VendoWorkbench />
     </>
   );
 }

--- a/examples/demo-bank/src/components/vendo/workbench/VendoWorkbench.tsx
+++ b/examples/demo-bank/src/components/vendo/workbench/VendoWorkbench.tsx
@@ -26,6 +26,16 @@ export function VendoWorkbench() {
   return developmentMode() ? <WorkbenchPane /> : null;
 }
 
+/**
+ * `inertBehind` (@vendoai/ui) inerts every body child while the overlay is open,
+ * and this pane is one — so with the chat up it was not merely dimmed by the
+ * scrim, it was `inert`: no clicks, no keyboard, no screen reader. The workbench
+ * reports on the turn THAT chat is running, which is exactly when it has to be
+ * live, so it declares itself the way the mechanism asks a Vendo surface to
+ * (`EXEMPT` in inert-behind.ts). The CSS raises it over the scrim to match.
+ */
+const ABOVE_MODAL = { "data-vendo-portal": "" };
+
 function WorkbenchPane() {
   const feed = useWorkbenchFeed();
   const [collapsed, setCollapsed] = useState(true);
@@ -34,7 +44,7 @@ function WorkbenchPane() {
 
   if (collapsed) {
     return (
-      <button type="button" className={styles.rail} onClick={() => setCollapsed(false)}>
+      <button type="button" className={styles.rail} onClick={() => setCollapsed(false)} {...ABOVE_MODAL}>
         workbench{feed.length === 0 ? "" : ` · ${feed.length}`}
       </button>
     );
@@ -45,13 +55,17 @@ function WorkbenchPane() {
   const status = turnStatus(parts);
   const loadout = eventsOf(parts, "loadout").at(-1)?.event;
   const steps = rows(parts).filter(row => row.kind === "step").length;
-  const contextPct = status.context === undefined
+  // The badge is one number, so it names the turn's own thinker: the resident is
+  // the first loop to measure its window, and a screen run's separate reading has
+  // its own gauge in the panel rather than overwriting this one.
+  const context = status.contexts[0]?.event;
+  const contextPct = context === undefined
     ? undefined
-    : share(status.context.estTokens, status.context.windowTokens);
+    : share(context.estTokens, context.windowTokens);
   const Panel = PANELS[tab];
 
   return (
-    <aside className={styles.pane} aria-label="Harness workbench">
+    <aside className={styles.pane} aria-label="Harness workbench" {...ABOVE_MODAL}>
       <header className={styles.head}>
         <div className={styles.headTop}>
           <h2 className={styles.title}>Harness Workbench</h2>

--- a/examples/demo-bank/src/components/vendo/workbench/VendoWorkbench.tsx
+++ b/examples/demo-bank/src/components/vendo/workbench/VendoWorkbench.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import clsx from "clsx";
+import { useState } from "react";
+import { developmentMode, useWorkbenchFeed } from "@vendoai/ui";
+import { pushDemoFeed } from "./demo-feed";
+import { count, duration, eventsOf, rows, share, turnStatus } from "./model";
+import { ContextPanel, GuardPanel, RawPanel, TimelinePanel, ToolsPanel } from "./panels";
+import { Chip, Empty } from "./parts";
+import styles from "./workbench.module.css";
+
+const TABS = ["timeline", "context", "tools", "guard", "raw"] as const;
+type Tab = (typeof TABS)[number];
+
+const PANELS = {
+  timeline: TimelinePanel,
+  context: ContextPanel,
+  tools: ToolsPanel,
+  guard: GuardPanel,
+  raw: RawPanel,
+} satisfies Record<Tab, unknown>;
+
+/** Dev-only. In a production build this renders nothing at all — the hook and
+ *  its subscription never mount. */
+export function VendoWorkbench() {
+  return developmentMode() ? <WorkbenchPane /> : null;
+}
+
+function WorkbenchPane() {
+  const feed = useWorkbenchFeed();
+  const [collapsed, setCollapsed] = useState(true);
+  const [picked, setPicked] = useState<string>();
+  const [tab, setTab] = useState<Tab>("timeline");
+
+  if (collapsed) {
+    return (
+      <button type="button" className={styles.rail} onClick={() => setCollapsed(false)}>
+        workbench{feed.length === 0 ? "" : ` · ${feed.length}`}
+      </button>
+    );
+  }
+
+  const turn = feed.find(candidate => candidate.turnId === picked) ?? feed.at(-1);
+  const parts = turn?.parts ?? [];
+  const status = turnStatus(parts);
+  const loadout = eventsOf(parts, "loadout").at(-1)?.event;
+  const steps = rows(parts).filter(row => row.kind === "step").length;
+  const contextPct = status.context === undefined
+    ? undefined
+    : share(status.context.estTokens, status.context.windowTokens);
+  const Panel = PANELS[tab];
+
+  return (
+    <aside className={styles.pane} aria-label="Harness workbench">
+      <header className={styles.head}>
+        <div className={styles.headTop}>
+          <h2 className={styles.title}>Harness Workbench</h2>
+          <span className={styles.chipDev}>dev only</span>
+          <div className={styles.headActions}>
+            <button type="button" className={styles.ghostBtn} onClick={pushDemoFeed}>demo feed</button>
+            <button type="button" className={styles.ghostBtn} onClick={() => setCollapsed(true)}>hide</button>
+          </div>
+        </div>
+
+        {feed.length === 0 ? null : (
+          <div className={styles.turnSwitch} role="tablist" aria-label="Turn">
+            {feed.map(candidate => (
+              <button
+                type="button"
+                key={candidate.turnId}
+                role="tab"
+                aria-selected={candidate.turnId === turn?.turnId}
+                className={clsx(styles.tsBtn, candidate.turnId === turn?.turnId && styles.tsBtnOn)}
+                onClick={() => setPicked(candidate.turnId)}
+              >
+                {candidate.turnId}
+                <span className={styles.tsId}>{candidate.parts.length}</span>
+              </button>
+            ))}
+          </div>
+        )}
+
+        {turn === undefined ? null : (
+          <div className={styles.status}>
+            <div className={styles.stat}>
+              <div className={styles.lbl}>status</div>
+              <div className={styles.val}>
+                <span className={clsx(styles.pulse, status.running && styles.pulseRun)} />
+                {status.running ? "running" : "idle"}
+                {status.outcome === undefined ? null : <Chip tone={status.outcome.tone}>{status.outcome.label}</Chip>}
+              </div>
+            </div>
+            <div className={clsx(styles.stat, styles.statProg)}>
+              <div className={styles.lbl}>step</div>
+              <div className={styles.val}>
+                {status.step ?? "—"} <span className={styles.dim}>/ {status.maxSteps ?? "—"}</span>
+              </div>
+              <div className={clsx(styles.prog, !status.running && styles.progDone)}>
+                <i style={{ width: `${share(status.step ?? 0, status.maxSteps ?? 0)}%` }} />
+              </div>
+            </div>
+            <div className={styles.stat}>
+              <div className={styles.lbl}>elapsed</div>
+              <div className={styles.val}>{duration(status.elapsedMs)}</div>
+            </div>
+            <div className={styles.stat}>
+              <div className={styles.lbl}>agents</div>
+              <div className={styles.val}>
+                {status.agents.map(agent => <Chip key={agent} tone="mute">{agent}</Chip>)}
+              </div>
+            </div>
+          </div>
+        )}
+      </header>
+
+      <nav className={styles.tabs} role="tablist" aria-label="Workbench view">
+        {TABS.map(name => (
+          <button
+            type="button"
+            key={name}
+            role="tab"
+            aria-selected={name === tab}
+            className={clsx(styles.tab, name === tab && styles.tabOn)}
+            onClick={() => setTab(name)}
+          >
+            {name}
+            <span className={styles.tabN}>
+              {name === "timeline" ? steps
+                : name === "context" ? (contextPct === undefined ? "—" : `${contextPct}%`)
+                : name === "tools" ? (loadout?.active.length ?? "—")
+                : name === "guard" ? eventsOf(parts, "tool").length
+                : count(parts.length)}
+            </span>
+          </button>
+        ))}
+      </nav>
+
+      <div className={styles.body} role="tabpanel">
+        {turn === undefined
+          ? (
+            <Empty
+              title="No turn has reported yet"
+              detail="Ask Maple something — the harness publishes its diagnostics as the turn runs."
+            />
+          )
+          : <Panel parts={parts} />}
+      </div>
+    </aside>
+  );
+}

--- a/examples/demo-bank/src/components/vendo/workbench/demo-feed.ts
+++ b/examples/demo-bank/src/components/vendo/workbench/demo-feed.ts
@@ -1,7 +1,25 @@
-/** A canned `data-vendo-debug` sequence, pushed through the real receiver door
- *  so the pane can be looked at before a harness is wired to it. Dev tooling
- *  for this pane only — it proves nothing about the producer, which publishes
- *  the same parts over the wire. */
+/**
+ * A canned `data-vendo-debug` sequence, pushed through the real receiver door so
+ * the pane can be looked at before a harness is wired to it. Dev tooling for this
+ * pane only — it proves nothing about the producer, which publishes the same
+ * parts over the wire.
+ *
+ * Every beat here is one the PRODUCER can actually emit, and that is the whole
+ * discipline of this file: a demo richer than reality teaches the pane to render
+ * a turn no harness will ever send. So —
+ *  - no `tool` beat for `find_tools`, `hire_subagent`, `save_app` or `escalate`:
+ *    those are harness HANDS, run in-process, and only `turn.tools.call()` reaches
+ *    the workbench (`turn-tools.ts`). A search leaves one trace, the loadout it
+ *    re-publishes;
+ *  - `stopReason` is the ai-SDK's own finish reason, and steps count from zero;
+ *  - `searchedIn` carries the tool NAMES a search loaded, never the query;
+ *  - `alwaysActive` is `active.filter(isAlwaysActive)`, so only a `vendo_` name
+ *    (or a connector-discovery tool) can appear in it, and a closed loadout
+ *    withholds nothing because its active set IS its equipped set;
+ *  - a hire and the screen agent share the RESIDENT'S turn — the channel is keyed
+ *    on the runtime's turnId — so their parts interleave with its own on one
+ *    stream, each counting its own steps from zero.
+ */
 import { publishWorkbenchPart, type WorkbenchEvent, type WorkbenchPart } from "@vendoai/ui";
 
 type Beat = [agent: WorkbenchPart["agent"], offsetMs: number, event: WorkbenchEvent];
@@ -29,49 +47,99 @@ Explain why the user's Maple card (•••• 4417) keeps getting declined.
 ## Critical Context
 - cardId crd_4417. Decline codes: 05 ×2, 57 ×1.`;
 
-const DECLINES: Beat[] = [
-  ["resident", 0, { kind: "step-start", step: 1, maxSteps: 20, activeTools: ["find_tools", "vendo_make", "ask_user"] }],
-  ["resident", 210, { kind: "tool", step: 1, toolCallId: "c1", name: "find_tools", argsPreview: '{ query: "card declines, card controls" }', status: "ok", guard: "run", approval: "auto", durationMs: 210 }],
-  ["resident", 240, { kind: "loadout", active: ["find_tools", "vendo_make", "ask_user", "host_listCards", "host_getCardPan", "host_setCardControls", "host_getIssuerRules"], searchedIn: ["card declines, card controls, spending limits", "monthly spend by category"], alwaysActive: ["find_tools", "vendo_make", "ask_user", "hire_subagent"], withheldCount: 94 }],
-  ["resident", 940, { kind: "step-end", step: 1, stopReason: "toolUse", durationMs: 940, usage: { inputTokens: 4212, outputTokens: 128 } }],
-  ["resident", 1_100, { kind: "step-start", step: 2, maxSteps: 20, activeTools: ["host_listCards", "host_getSpendingInsights"] }],
-  ["resident", 1_440, { kind: "tool", step: 2, toolCallId: "c2", name: "host_listCards", argsPreview: '{ status: "active" }', status: "ok", guard: "run", approval: "auto", durationMs: 340 }],
-  ["resident", 2_560, { kind: "tool", step: 2, toolCallId: "c3", name: "host_getSpendingInsights", argsPreview: '{ window: "30d", groupBy: "declineReason" }', status: "ok", guard: "run", approval: "auto", durationMs: 812 }],
-  ["resident", 2_720, { kind: "step-end", step: 2, stopReason: "toolUse", durationMs: 1_620, usage: { inputTokens: 9480, outputTokens: 96 } }],
-  ["resident", 2_900, { kind: "context", estTokens: 21_400, windowTokens: 200_000, triggerTokens: 162_000 }],
-  ["resident", 3_000, { kind: "step-start", step: 3, maxSteps: 20, activeTools: ["host_getCardPan", "host_getCardTransactions"] }],
-  ["resident", 11_100, { kind: "tool", step: 3, toolCallId: "c4", name: "host_getCardPan", argsPreview: '{ cardId: "crd_4417", reveal: "last4" }', status: "ok", guard: "ask", approval: "approved", durationMs: 8_100 }],
-  ["resident", 12_200, { kind: "tool", step: 3, toolCallId: "c5", name: "host_getCardTransactions", argsPreview: '{ cardId: "crd_4417", status: "declined", limit: 25 }', status: "ok", guard: "run", approval: "auto", durationMs: 486 }],
-  ["resident", 12_620, { kind: "step-end", step: 3, stopReason: "toolUse", durationMs: 9_620, usage: { inputTokens: 12_910, outputTokens: 402 } }],
-  ["resident", 12_700, { kind: "step-start", step: 4, maxSteps: 20, activeTools: ["host_setCardControls"] }],
-  ["resident", 102_600, { kind: "tool", step: 4, toolCallId: "c6", name: "host_setCardControls", argsPreview: '{ cardId: "crd_4417", controls: { onlineTx: false } }', status: "denied", guard: "ask", approval: "timed-out", durationMs: 90_000 }],
-  ["resident", 102_800, { kind: "step-end", step: 4, stopReason: "toolUse", durationMs: 91_400, usage: { inputTokens: 14_220, outputTokens: 188 } }],
-  ["resident", 103_000, { kind: "step-start", step: 5, maxSteps: 20, activeTools: ["hire_subagent"] }],
-  ["resident", 103_900, { kind: "tool", step: 5, toolCallId: "c7", name: "hire_subagent", argsPreview: '{ goal: "do issuer rules explain the declines?" }', status: "ok", guard: "run", approval: "auto", durationMs: 4_410 }],
-  ["subagent", 104_200, { kind: "tool", step: 5, toolCallId: "c8", name: "host_disputeTransaction", argsPreview: '{ txnId: "txn_88a1" }', status: "denied", guard: "block", approval: "denied", durationMs: 12 }],
-  ["subagent", 108_300, { kind: "subagent", label: "issuer-rule check", steps: 7, maxSteps: 12, report: "All three declines carry issuer rule R-118, which rejects card-not-present charges to MCC 5967 on cards issued in the last 90 days. Balance was never the cause." }],
-  ["resident", 108_400, { kind: "error", code: "context-overflow", message: "prompt 203,880 > 200,000 — retried once" }],
-  ["resident", 108_450, { kind: "shed", dropped: 2 }],
-  ["resident", 109_000, { kind: "compaction", reason: "overflow-retry", summary: SUMMARY }],
-  ["resident", 109_100, { kind: "context", estTokens: 87_400, windowTokens: 200_000, triggerTokens: 162_000 }],
-  ["resident", 109_200, { kind: "step-end", step: 5, stopReason: "toolUse", durationMs: 4_900, usage: { inputTokens: 15_040, outputTokens: 620 } }],
-  ["resident", 112_400, { kind: "step-start", step: 6, maxSteps: 20, activeTools: ["vendo_make"] }],
-  ["resident", 112_500, { kind: "tool", step: 6, toolCallId: "c9", name: "vendo_make", argsPreview: '{ appId: "app_declines", intent: "Declined charges explainer" }', status: "ok", guard: "run", approval: "auto", durationMs: 2_910 }],
+/** The starting toolbelt `computeInitialLoadout` cuts, plus the two hands. The
+ *  loop re-reads this each step, so every `step-start` in a turn that never
+ *  searches reports the same set. */
+const STARTING_TOOLS = [
+  "find_tools",
+  "hire_subagent",
+  "vendo_make",
+  "ask_user",
+  "host_listCards",
+  "host_getSpendingInsights",
 ];
 
-/** The screen agent: a closed loadout, no compaction, no sub-run — the turn
- *  that shows the pane's empty states are answers, not gaps. */
+/** …and the same set after `find_tools` pulled four more in. */
+const SEARCHED_IN = [
+  "host_getCardPan",
+  "host_getCardTransactions",
+  "host_setCardControls",
+  "host_getIssuerRules",
+];
+const EXPANDED_TOOLS = [...STARTING_TOOLS, ...SEARCHED_IN];
+
+/** A turn that never searches: `find_tools` is equipped and unused. */
+const BALANCE: Beat[] = [
+  ["resident", 0, { kind: "loadout", active: STARTING_TOOLS, searchedIn: [], alwaysActive: ["vendo_make"], withheldCount: 98 }],
+  ["resident", 40, { kind: "context", estTokens: 6_100, windowTokens: 200_000, triggerTokens: 162_000 }],
+  ["resident", 90, { kind: "step-start", step: 0, maxSteps: 20, activeTools: STARTING_TOOLS }],
+  ["resident", 260, { kind: "tool", step: 0, toolCallId: "b1", name: "host_listCards", argsPreview: '{ status: "active" }', status: "ok", guard: "run", approval: "auto", durationMs: 168 }],
+  ["resident", 480, { kind: "step-end", step: 0, stopReason: "tool-calls", durationMs: 390, usage: { inputTokens: 5_980, outputTokens: 74 } }],
+  ["resident", 620, { kind: "step-start", step: 1, maxSteps: 20, activeTools: STARTING_TOOLS }],
+  ["resident", 1_450, { kind: "step-end", step: 1, stopReason: "stop", durationMs: 830, usage: { inputTokens: 6_340, outputTokens: 212 } }],
+];
+
+/** A turn that searches and then hires. The hire drives the same loop, so it
+ *  opens a step of its OWN — its step 0 is not the resident's. */
+const DECLINES: Beat[] = [
+  ["resident", 0, { kind: "loadout", active: STARTING_TOOLS, searchedIn: [], alwaysActive: ["vendo_make"], withheldCount: 98 }],
+  ["resident", 40, { kind: "context", estTokens: 8_200, windowTokens: 200_000, triggerTokens: 162_000 }],
+  ["resident", 120, { kind: "step-start", step: 0, maxSteps: 20, activeTools: STARTING_TOOLS }],
+  ["resident", 380, { kind: "loadout", active: EXPANDED_TOOLS, searchedIn: SEARCHED_IN, alwaysActive: ["vendo_make"], withheldCount: 94 }],
+  ["resident", 940, { kind: "step-end", step: 0, stopReason: "tool-calls", durationMs: 820, usage: { inputTokens: 4_212, outputTokens: 128 } }],
+  ["resident", 1_100, { kind: "step-start", step: 1, maxSteps: 20, activeTools: EXPANDED_TOOLS }],
+  ["resident", 1_440, { kind: "tool", step: 1, toolCallId: "c2", name: "host_listCards", argsPreview: '{ status: "active" }', status: "ok", guard: "run", approval: "auto", durationMs: 340 }],
+  ["resident", 2_560, { kind: "tool", step: 1, toolCallId: "c3", name: "host_getSpendingInsights", argsPreview: '{ window: "30d", groupBy: "declineReason" }', status: "ok", guard: "run", approval: "auto", durationMs: 812 }],
+  ["resident", 2_720, { kind: "step-end", step: 1, stopReason: "tool-calls", durationMs: 1_620, usage: { inputTokens: 9_480, outputTokens: 96 } }],
+  ["resident", 3_000, { kind: "step-start", step: 2, maxSteps: 20, activeTools: EXPANDED_TOOLS }],
+  ["resident", 11_100, { kind: "tool", step: 2, toolCallId: "c4", name: "host_getCardPan", argsPreview: '{ cardId: "crd_4417", reveal: "last4" }', status: "ok", guard: "ask", approval: "approved", durationMs: 8_100 }],
+  ["resident", 12_200, { kind: "tool", step: 2, toolCallId: "c5", name: "host_getCardTransactions", argsPreview: '{ cardId: "crd_4417", status: "declined", limit: 25 }', status: "ok", guard: "run", approval: "auto", durationMs: 486 }],
+  ["resident", 12_620, { kind: "step-end", step: 2, stopReason: "tool-calls", durationMs: 9_620, usage: { inputTokens: 12_910, outputTokens: 402 } }],
+  ["resident", 12_700, { kind: "step-start", step: 3, maxSteps: 20, activeTools: EXPANDED_TOOLS }],
+  ["resident", 102_600, { kind: "tool", step: 3, toolCallId: "c6", name: "host_setCardControls", argsPreview: '{ cardId: "crd_4417", controls: { onlineTx: false } }', status: "denied", guard: "ask", approval: "timed-out", durationMs: 90_000 }],
+  ["resident", 102_800, { kind: "step-end", step: 3, stopReason: "tool-calls", durationMs: 90_100, usage: { inputTokens: 14_220, outputTokens: 188 } }],
+  ["resident", 103_000, { kind: "step-start", step: 4, maxSteps: 20, activeTools: EXPANDED_TOOLS }],
+  ["subagent", 103_100, { kind: "context", estTokens: 5_900, windowTokens: 200_000, triggerTokens: 162_000 }],
+  ["subagent", 103_200, { kind: "step-start", step: 0, maxSteps: 12, activeTools: ["host_getIssuerRules", "host_getCardTransactions", "host_disputeTransaction"] }],
+  ["subagent", 104_200, { kind: "tool", step: 0, toolCallId: "c8", name: "host_disputeTransaction", argsPreview: '{ txnId: "txn_88a1" }', status: "denied", guard: "block", approval: "denied", durationMs: 12 }],
+  ["subagent", 107_900, { kind: "step-end", step: 0, stopReason: "stop", durationMs: 4_700, usage: { inputTokens: 6_120, outputTokens: 244 } }],
+  ["subagent", 108_300, { kind: "subagent", label: "issuer-rule check", steps: 1, maxSteps: 12, report: "All three declines carry issuer rule R-118, which rejects card-not-present charges to MCC 5967 on cards issued in the last 90 days. Balance was never the cause." }],
+  ["resident", 109_200, { kind: "step-end", step: 4, stopReason: "tool-calls", durationMs: 6_200, usage: { inputTokens: 15_040, outputTokens: 620 } }],
+  ["resident", 109_400, { kind: "step-start", step: 5, maxSteps: 20, activeTools: EXPANDED_TOOLS }],
+  ["resident", 111_800, { kind: "step-end", step: 5, stopReason: "stop", durationMs: 2_400, usage: { inputTokens: 16_100, outputTokens: 486 } }],
+];
+
+/** The screen agent's closed loadout — `vendo({ tools })`, the drive `vendo_make`
+ *  starts inside the resident's own step. It searches nothing in and withholds
+ *  nothing, which is what makes the tools tab's closed reading an answer. */
+const SCREEN_TOOLS = ["search_components", "validate", "save_app", "escalate", "host_getSpendingInsights"];
+
+/** A turn under real window pressure that ends by painting a screen. */
 const SPEND: Beat[] = [
-  ["screen", 0, { kind: "step-start", step: 1, maxSteps: 10, activeTools: ["search_components", "save_app", "validate", "escalate"] }],
-  ["screen", 100, { kind: "loadout", active: ["search_components", "save_app", "validate", "escalate", "host_getSpendingInsights"], searchedIn: [], alwaysActive: ["save_app", "validate", "escalate"], withheldCount: 119 }],
-  ["screen", 640, { kind: "tool", step: 1, toolCallId: "s1", name: "search_components", argsPreview: '{ query: "stat tile, category bar list" }', status: "ok", guard: "run", approval: "auto", durationMs: 640 }],
-  ["screen", 2_100, { kind: "step-end", step: 1, stopReason: "toolUse", durationMs: 2_100, usage: { inputTokens: 6_040, outputTokens: 188 } }],
-  ["screen", 2_400, { kind: "context", estTokens: 38_900, windowTokens: 200_000, triggerTokens: 162_000 }],
-  ["screen", 2_500, { kind: "step-start", step: 2, maxSteps: 10, activeTools: ["save_app", "validate"] }],
-  ["screen", 3_700, { kind: "tool", step: 2, toolCallId: "s2", name: "save_app", argsPreview: '{ appId: "app_spend", version: "draft" }', status: "ok", guard: "run", approval: "auto", durationMs: 1_200 }],
-  ["screen", 4_120, { kind: "tool", step: 2, toolCallId: "s3", name: "validate", argsPreview: '{ appId: "app_spend" }', status: "error", guard: "run", approval: "auto", durationMs: 420 }],
-  ["screen", 4_300, { kind: "step-end", step: 2, stopReason: "endTurn", durationMs: 1_800, usage: { inputTokens: 13_660, outputTokens: 142 } }],
-  ["screen", 4_400, { kind: "step-limit", steps: 2 }],
+  ["resident", 0, { kind: "loadout", active: STARTING_TOOLS, searchedIn: [], alwaysActive: ["vendo_make"], withheldCount: 98 }],
+  // The host set a `contextTokenBudget`, so the floor sheds before anything else
+  // measures — and the trigger below still trips on what is left.
+  ["resident", 40, { kind: "shed", dropped: 2 }],
+  ["resident", 60, { kind: "context", estTokens: 178_400, windowTokens: 200_000, triggerTokens: 162_000 }],
+  ["resident", 3_400, { kind: "compaction", reason: "trigger", summary: SUMMARY }],
+  ["resident", 3_500, { kind: "step-start", step: 0, maxSteps: 20, activeTools: STARTING_TOOLS }],
+  ["resident", 3_900, { kind: "tool", step: 0, toolCallId: "s0", name: "host_getSpendingInsights", argsPreview: '{ window: "90d", groupBy: "category" }', status: "ok", guard: "run", approval: "auto", durationMs: 402 }],
+  ["resident", 4_400, { kind: "step-end", step: 0, stopReason: "tool-calls", durationMs: 900, usage: { inputTokens: 41_200, outputTokens: 96 } }],
+  ["resident", 4_600, { kind: "step-start", step: 1, maxSteps: 20, activeTools: STARTING_TOOLS }],
+  ["screen", 4_800, { kind: "loadout", active: SCREEN_TOOLS, searchedIn: [], alwaysActive: [], withheldCount: 0 }],
+  ["screen", 4_900, { kind: "context", estTokens: 38_900, windowTokens: 200_000, triggerTokens: 162_000 }],
+  ["screen", 5_000, { kind: "step-start", step: 0, maxSteps: 10, activeTools: SCREEN_TOOLS }],
+  ["screen", 5_640, { kind: "tool", step: 0, toolCallId: "s1", name: "search_components", argsPreview: '{ query: "stat tile, category bar list" }', status: "ok", guard: "run", approval: "auto", durationMs: 640 }],
+  ["screen", 7_100, { kind: "step-end", step: 0, stopReason: "tool-calls", durationMs: 2_100, usage: { inputTokens: 6_040, outputTokens: 188 } }],
+  ["screen", 7_400, { kind: "step-start", step: 1, maxSteps: 10, activeTools: SCREEN_TOOLS }],
+  ["screen", 8_120, { kind: "tool", step: 1, toolCallId: "s2", name: "validate", argsPreview: '{ appId: "app_spend" }', status: "error", guard: "run", approval: "auto", durationMs: 420 }],
+  ["screen", 9_300, { kind: "step-end", step: 1, stopReason: "stop", durationMs: 1_900, usage: { inputTokens: 13_660, outputTokens: 142 } }],
+  // The resident's own `vendo_make` call closes only once the drive above is
+  // done, which is why its beat lands last.
+  ["resident", 9_500, { kind: "tool", step: 1, toolCallId: "s3", name: "vendo_make", argsPreview: '{ appId: "app_spend", intent: "Spending by category" }', status: "ok", guard: "run", approval: "auto", durationMs: 4_900 }],
+  ["resident", 9_700, { kind: "step-end", step: 1, stopReason: "tool-calls", durationMs: 5_100, usage: { inputTokens: 48_900, outputTokens: 310 } }],
+  ["resident", 9_900, { kind: "step-start", step: 2, maxSteps: 20, activeTools: STARTING_TOOLS }],
+  ["resident", 11_200, { kind: "step-end", step: 2, stopReason: "stop", durationMs: 1_300, usage: { inputTokens: 49_400, outputTokens: 168 } }],
 ];
 
 function publish(turnId: string, beats: Beat[], at: number): void {
@@ -85,6 +153,7 @@ function publish(turnId: string, beats: Beat[], at: number): void {
 
 export function pushDemoFeed(): void {
   const now = Date.now();
+  publish("thr_balance", BALANCE, now - 400_000);
   publish("thr_declines", DECLINES, now - 200_000);
   publish("thr_spend", SPEND, now - 40_000);
 }

--- a/examples/demo-bank/src/components/vendo/workbench/demo-feed.ts
+++ b/examples/demo-bank/src/components/vendo/workbench/demo-feed.ts
@@ -1,0 +1,90 @@
+/** A canned `data-vendo-debug` sequence, pushed through the real receiver door
+ *  so the pane can be looked at before a harness is wired to it. Dev tooling
+ *  for this pane only — it proves nothing about the producer, which publishes
+ *  the same parts over the wire. */
+import { publishWorkbenchPart, type WorkbenchEvent, type WorkbenchPart } from "@vendoai/ui";
+
+type Beat = [agent: WorkbenchPart["agent"], offsetMs: number, event: WorkbenchEvent];
+
+const SUMMARY = `## Goal
+Explain why the user's Maple card (•••• 4417) keeps getting declined.
+
+## Constraints & Preferences
+- Lead with the cause, then the fix. Keep it short.
+- Never change card controls without approval.
+
+## Progress
+### Done
+- Pulled active cards and 30d insights.
+- Found 3 declines in 8 days, all merchant category 5967.
+### Blocked
+- host_setCardControls sits behind an approval the user never answered.
+
+## Key Decisions
+- Attribute the declines to the issuer's category rule, not to balance.
+
+## Next Steps
+1. Re-offer the control change as an explicit choice, never an auto-action.
+
+## Critical Context
+- cardId crd_4417. Decline codes: 05 ×2, 57 ×1.`;
+
+const DECLINES: Beat[] = [
+  ["resident", 0, { kind: "step-start", step: 1, maxSteps: 20, activeTools: ["find_tools", "vendo_make", "ask_user"] }],
+  ["resident", 210, { kind: "tool", step: 1, toolCallId: "c1", name: "find_tools", argsPreview: '{ query: "card declines, card controls" }', status: "ok", guard: "run", approval: "auto", durationMs: 210 }],
+  ["resident", 240, { kind: "loadout", active: ["find_tools", "vendo_make", "ask_user", "host_listCards", "host_getCardPan", "host_setCardControls", "host_getIssuerRules"], searchedIn: ["card declines, card controls, spending limits", "monthly spend by category"], alwaysActive: ["find_tools", "vendo_make", "ask_user", "hire_subagent"], withheldCount: 94 }],
+  ["resident", 940, { kind: "step-end", step: 1, stopReason: "toolUse", durationMs: 940, usage: { inputTokens: 4212, outputTokens: 128 } }],
+  ["resident", 1_100, { kind: "step-start", step: 2, maxSteps: 20, activeTools: ["host_listCards", "host_getSpendingInsights"] }],
+  ["resident", 1_440, { kind: "tool", step: 2, toolCallId: "c2", name: "host_listCards", argsPreview: '{ status: "active" }', status: "ok", guard: "run", approval: "auto", durationMs: 340 }],
+  ["resident", 2_560, { kind: "tool", step: 2, toolCallId: "c3", name: "host_getSpendingInsights", argsPreview: '{ window: "30d", groupBy: "declineReason" }', status: "ok", guard: "run", approval: "auto", durationMs: 812 }],
+  ["resident", 2_720, { kind: "step-end", step: 2, stopReason: "toolUse", durationMs: 1_620, usage: { inputTokens: 9480, outputTokens: 96 } }],
+  ["resident", 2_900, { kind: "context", estTokens: 21_400, windowTokens: 200_000, triggerTokens: 162_000 }],
+  ["resident", 3_000, { kind: "step-start", step: 3, maxSteps: 20, activeTools: ["host_getCardPan", "host_getCardTransactions"] }],
+  ["resident", 11_100, { kind: "tool", step: 3, toolCallId: "c4", name: "host_getCardPan", argsPreview: '{ cardId: "crd_4417", reveal: "last4" }', status: "ok", guard: "ask", approval: "approved", durationMs: 8_100 }],
+  ["resident", 12_200, { kind: "tool", step: 3, toolCallId: "c5", name: "host_getCardTransactions", argsPreview: '{ cardId: "crd_4417", status: "declined", limit: 25 }', status: "ok", guard: "run", approval: "auto", durationMs: 486 }],
+  ["resident", 12_620, { kind: "step-end", step: 3, stopReason: "toolUse", durationMs: 9_620, usage: { inputTokens: 12_910, outputTokens: 402 } }],
+  ["resident", 12_700, { kind: "step-start", step: 4, maxSteps: 20, activeTools: ["host_setCardControls"] }],
+  ["resident", 102_600, { kind: "tool", step: 4, toolCallId: "c6", name: "host_setCardControls", argsPreview: '{ cardId: "crd_4417", controls: { onlineTx: false } }', status: "denied", guard: "ask", approval: "timed-out", durationMs: 90_000 }],
+  ["resident", 102_800, { kind: "step-end", step: 4, stopReason: "toolUse", durationMs: 91_400, usage: { inputTokens: 14_220, outputTokens: 188 } }],
+  ["resident", 103_000, { kind: "step-start", step: 5, maxSteps: 20, activeTools: ["hire_subagent"] }],
+  ["resident", 103_900, { kind: "tool", step: 5, toolCallId: "c7", name: "hire_subagent", argsPreview: '{ goal: "do issuer rules explain the declines?" }', status: "ok", guard: "run", approval: "auto", durationMs: 4_410 }],
+  ["subagent", 104_200, { kind: "tool", step: 5, toolCallId: "c8", name: "host_disputeTransaction", argsPreview: '{ txnId: "txn_88a1" }', status: "denied", guard: "block", approval: "denied", durationMs: 12 }],
+  ["subagent", 108_300, { kind: "subagent", label: "issuer-rule check", steps: 7, maxSteps: 12, report: "All three declines carry issuer rule R-118, which rejects card-not-present charges to MCC 5967 on cards issued in the last 90 days. Balance was never the cause." }],
+  ["resident", 108_400, { kind: "error", code: "context-overflow", message: "prompt 203,880 > 200,000 — retried once" }],
+  ["resident", 108_450, { kind: "shed", dropped: 2 }],
+  ["resident", 109_000, { kind: "compaction", reason: "overflow-retry", summary: SUMMARY }],
+  ["resident", 109_100, { kind: "context", estTokens: 87_400, windowTokens: 200_000, triggerTokens: 162_000 }],
+  ["resident", 109_200, { kind: "step-end", step: 5, stopReason: "toolUse", durationMs: 4_900, usage: { inputTokens: 15_040, outputTokens: 620 } }],
+  ["resident", 112_400, { kind: "step-start", step: 6, maxSteps: 20, activeTools: ["vendo_make"] }],
+  ["resident", 112_500, { kind: "tool", step: 6, toolCallId: "c9", name: "vendo_make", argsPreview: '{ appId: "app_declines", intent: "Declined charges explainer" }', status: "ok", guard: "run", approval: "auto", durationMs: 2_910 }],
+];
+
+/** The screen agent: a closed loadout, no compaction, no sub-run — the turn
+ *  that shows the pane's empty states are answers, not gaps. */
+const SPEND: Beat[] = [
+  ["screen", 0, { kind: "step-start", step: 1, maxSteps: 10, activeTools: ["search_components", "save_app", "validate", "escalate"] }],
+  ["screen", 100, { kind: "loadout", active: ["search_components", "save_app", "validate", "escalate", "host_getSpendingInsights"], searchedIn: [], alwaysActive: ["save_app", "validate", "escalate"], withheldCount: 119 }],
+  ["screen", 640, { kind: "tool", step: 1, toolCallId: "s1", name: "search_components", argsPreview: '{ query: "stat tile, category bar list" }', status: "ok", guard: "run", approval: "auto", durationMs: 640 }],
+  ["screen", 2_100, { kind: "step-end", step: 1, stopReason: "toolUse", durationMs: 2_100, usage: { inputTokens: 6_040, outputTokens: 188 } }],
+  ["screen", 2_400, { kind: "context", estTokens: 38_900, windowTokens: 200_000, triggerTokens: 162_000 }],
+  ["screen", 2_500, { kind: "step-start", step: 2, maxSteps: 10, activeTools: ["save_app", "validate"] }],
+  ["screen", 3_700, { kind: "tool", step: 2, toolCallId: "s2", name: "save_app", argsPreview: '{ appId: "app_spend", version: "draft" }', status: "ok", guard: "run", approval: "auto", durationMs: 1_200 }],
+  ["screen", 4_120, { kind: "tool", step: 2, toolCallId: "s3", name: "validate", argsPreview: '{ appId: "app_spend" }', status: "error", guard: "run", approval: "auto", durationMs: 420 }],
+  ["screen", 4_300, { kind: "step-end", step: 2, stopReason: "endTurn", durationMs: 1_800, usage: { inputTokens: 13_660, outputTokens: 142 } }],
+  ["screen", 4_400, { kind: "step-limit", steps: 2 }],
+];
+
+function publish(turnId: string, beats: Beat[], at: number): void {
+  beats.forEach(([agent, offsetMs, event], index) => {
+    publishWorkbenchPart({
+      type: "data-vendo-debug",
+      data: { turnId, seq: index + 1, at: at + offsetMs, agent, event } satisfies WorkbenchPart,
+    });
+  });
+}
+
+export function pushDemoFeed(): void {
+  const now = Date.now();
+  publish("thr_declines", DECLINES, now - 200_000);
+  publish("thr_spend", SPEND, now - 40_000);
+}

--- a/examples/demo-bank/src/components/vendo/workbench/model.ts
+++ b/examples/demo-bank/src/components/vendo/workbench/model.ts
@@ -1,0 +1,129 @@
+/** Reading the workbench feed. Every value here is derived from parts the
+ *  harness actually sent — nothing is filled in, and a fact the feed does not
+ *  carry (a model name, a cost) simply has no row in the pane. */
+import type { WorkbenchEvent, WorkbenchPart } from "@vendoai/ui";
+
+export type Tone = "ok" | "warn" | "bad" | "info" | "sys" | "mute";
+
+/** Parts of one step, gathered: `step-start`, its `tool` calls, `step-end`.
+ *  Everything else stands on its own line in the timeline. */
+export type Row =
+  | { kind: "step"; step: number; parts: WorkbenchPart[] }
+  | { kind: "event"; part: WorkbenchPart };
+
+type Of<K extends WorkbenchEvent["kind"]> = WorkbenchPart & { event: Extract<WorkbenchEvent, { kind: K }> };
+
+export function eventsOf<K extends WorkbenchEvent["kind"]>(
+  parts: readonly WorkbenchPart[],
+  kind: K,
+): Of<K>[] {
+  return parts.filter((part): part is Of<K> => part.event.kind === kind);
+}
+
+export function rows(parts: readonly WorkbenchPart[]): Row[] {
+  const out: Row[] = [];
+  const steps = new Map<number, Extract<Row, { kind: "step" }>>();
+  for (const part of parts) {
+    if (!("step" in part.event)) {
+      out.push({ kind: "event", part });
+      continue;
+    }
+    const { step } = part.event;
+    let group = steps.get(step);
+    if (group === undefined) {
+      group = { kind: "step", step, parts: [] };
+      steps.set(step, group);
+      out.push(group);
+    }
+    group.parts.push(part);
+  }
+  return out;
+}
+
+export interface TurnStatus {
+  /** A step opened and never closed — the only running signal the feed gives. */
+  running: boolean;
+  step?: number;
+  maxSteps?: number;
+  elapsedMs: number;
+  agents: WorkbenchPart["agent"][];
+  outcome?: { label: string; tone: Tone };
+  context?: Extract<WorkbenchEvent, { kind: "context" }>;
+}
+
+export function turnStatus(parts: readonly WorkbenchPart[]): TurnStatus {
+  const starts = eventsOf(parts, "step-start");
+  const ended = new Set(eventsOf(parts, "step-end").map(part => part.event.step));
+  const last = starts.at(-1);
+  const error = eventsOf(parts, "error").at(-1);
+  const limit = eventsOf(parts, "step-limit").at(-1);
+  const context = eventsOf(parts, "context").at(-1);
+  const running = starts.some(part => !ended.has(part.event.step));
+  return {
+    running,
+    ...(last === undefined ? {} : { step: last.event.step, maxSteps: last.event.maxSteps }),
+    elapsedMs: parts.length === 0 ? 0 : parts[parts.length - 1]!.at - parts[0]!.at,
+    agents: [...new Set(parts.map(part => part.agent))],
+    ...(error !== undefined
+      ? { outcome: { label: error.event.code, tone: "bad" as const } }
+      : limit !== undefined
+        ? { outcome: { label: "step limit", tone: "warn" as const } }
+        : running
+          ? {}
+          : { outcome: { label: "settled", tone: "ok" as const } }),
+    ...(context === undefined ? {} : { context: context.event }),
+  };
+}
+
+export const TONES: Record<WorkbenchEvent["kind"], Tone> = {
+  "step-start": "mute",
+  "step-end": "mute",
+  tool: "mute",
+  context: "info",
+  compaction: "sys",
+  shed: "warn",
+  loadout: "info",
+  subagent: "sys",
+  error: "bad",
+  "step-limit": "warn",
+};
+
+/** One line for the raw feed and for the timeline's standalone rows. */
+export function describe(event: WorkbenchEvent): string {
+  switch (event.kind) {
+    case "step-start":
+      return `step ${event.step} of ${event.maxSteps} · ${event.activeTools.length} ${event.activeTools.length === 1 ? "tool" : "tools"} active`;
+    case "step-end":
+      return `${event.stopReason} · ${duration(event.durationMs)}`;
+    case "tool":
+      return `${event.name} ${event.status} · ${duration(event.durationMs)}`;
+    case "context":
+      return `${count(event.estTokens)} / ${count(event.windowTokens)} tok · trigger ${count(event.triggerTokens)}`;
+    case "compaction":
+      return `fired on ${event.reason} · summary ${event.summary.split("\n").length} lines`;
+    case "shed":
+      return `shed ${event.dropped} tool ${event.dropped === 1 ? "result" : "results"}`;
+    case "loadout":
+      return `${event.active.length} active · ${event.withheldCount} withheld`;
+    case "subagent":
+      return `${event.label} · ${event.steps} of ${event.maxSteps} steps`;
+    case "error":
+      return `${event.code} — ${event.message}`;
+    case "step-limit":
+      return `stopped at ${event.steps} steps`;
+  }
+}
+
+export function count(value: number): string {
+  return value.toLocaleString("en-US");
+}
+
+export function duration(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(2)}s`;
+  return `${Math.floor(ms / 60_000)}m ${Math.round((ms % 60_000) / 1000)}s`;
+}
+
+export function share(value: number, of: number): number {
+  return of <= 0 ? 0 : Math.min(100, Math.round((value / of) * 100));
+}

--- a/examples/demo-bank/src/components/vendo/workbench/model.ts
+++ b/examples/demo-bank/src/components/vendo/workbench/model.ts
@@ -8,10 +8,15 @@ export type Tone = "ok" | "warn" | "bad" | "info" | "sys" | "mute";
 /** Parts of one step, gathered: `step-start`, its `tool` calls, `step-end`.
  *  Everything else stands on its own line in the timeline. */
 export type Row =
-  | { kind: "step"; step: number; parts: WorkbenchPart[] }
+  | { kind: "step"; agent: WorkbenchPart["agent"]; step: number; parts: WorkbenchPart[] }
   | { kind: "event"; part: WorkbenchPart };
 
-type Of<K extends WorkbenchEvent["kind"]> = WorkbenchPart & { event: Extract<WorkbenchEvent, { kind: K }> };
+export type Of<K extends WorkbenchEvent["kind"]> = WorkbenchPart & { event: Extract<WorkbenchEvent, { kind: K }> };
+
+/** A step belongs to the loop that took it. The resident, the screen agent and a
+ *  hire share one turn and one channel, and each counts its own steps from zero —
+ *  so the step NUMBER alone names three different steps. */
+const stepKey = (part: WorkbenchPart, step: number): string => `${part.agent}:${step}`;
 
 export function eventsOf<K extends WorkbenchEvent["kind"]>(
   parts: readonly WorkbenchPart[],
@@ -22,17 +27,18 @@ export function eventsOf<K extends WorkbenchEvent["kind"]>(
 
 export function rows(parts: readonly WorkbenchPart[]): Row[] {
   const out: Row[] = [];
-  const steps = new Map<number, Extract<Row, { kind: "step" }>>();
+  const steps = new Map<string, Extract<Row, { kind: "step" }>>();
   for (const part of parts) {
     if (!("step" in part.event)) {
       out.push({ kind: "event", part });
       continue;
     }
     const { step } = part.event;
-    let group = steps.get(step);
+    const key = stepKey(part, step);
+    let group = steps.get(key);
     if (group === undefined) {
-      group = { kind: "step", step, parts: [] };
-      steps.set(step, group);
+      group = { kind: "step", agent: part.agent, step, parts: [] };
+      steps.set(key, group);
       out.push(group);
     }
     group.parts.push(part);
@@ -40,25 +46,43 @@ export function rows(parts: readonly WorkbenchPart[]): Row[] {
   return out;
 }
 
+/** The latest window reading EACH agent took, in the order the agents first
+ *  measured. A window is a fact about one loop's seat: the screen agent's 200k
+ *  reading says nothing about the resident's 32k one, and reading the last one on
+ *  the wire just reports whichever loop happened to measure most recently. */
+export function contextByAgent(parts: readonly WorkbenchPart[]): Of<"context">[] {
+  const latest = new Map<WorkbenchPart["agent"], Of<"context">>();
+  for (const part of eventsOf(parts, "context")) latest.set(part.agent, part);
+  return [...latest.values()];
+}
+
 export interface TurnStatus {
-  /** A step opened and never closed — the only running signal the feed gives. */
   running: boolean;
   step?: number;
   maxSteps?: number;
   elapsedMs: number;
   agents: WorkbenchPart["agent"][];
   outcome?: { label: string; tone: Tone };
-  context?: Extract<WorkbenchEvent, { kind: "context" }>;
+  /** One reading per agent that measured its window — see {@link contextByAgent}. */
+  contexts: Of<"context">[];
 }
 
-export function turnStatus(parts: readonly WorkbenchPart[]): TurnStatus {
+/** How long a quiet feed still counts as work in progress. A turn's first facts —
+ *  the window reading, the summarizer's compaction — land BEFORE step 0 opens, so
+ *  there is no step boundary to read yet and "no open step" is not the same thing
+ *  as "over". Recency is what separates the two, and once a step has closed the
+ *  boundaries are authoritative again. */
+const RECENT_MS = 2_000;
+
+export function turnStatus(parts: readonly WorkbenchPart[], now = Date.now()): TurnStatus {
   const starts = eventsOf(parts, "step-start");
-  const ended = new Set(eventsOf(parts, "step-end").map(part => part.event.step));
+  const ended = new Set(eventsOf(parts, "step-end").map(part => stepKey(part, part.event.step)));
   const last = starts.at(-1);
   const error = eventsOf(parts, "error").at(-1);
   const limit = eventsOf(parts, "step-limit").at(-1);
-  const context = eventsOf(parts, "context").at(-1);
-  const running = starts.some(part => !ended.has(part.event.step));
+  const latest = parts.at(-1);
+  const running = starts.some(part => !ended.has(stepKey(part, part.event.step)))
+    || (ended.size === 0 && latest !== undefined && now - latest.at < RECENT_MS);
   return {
     running,
     ...(last === undefined ? {} : { step: last.event.step, maxSteps: last.event.maxSteps }),
@@ -71,7 +95,7 @@ export function turnStatus(parts: readonly WorkbenchPart[]): TurnStatus {
         : running
           ? {}
           : { outcome: { label: "settled", tone: "ok" as const } }),
-    ...(context === undefined ? {} : { context: context.event }),
+    contexts: contextByAgent(parts),
   };
 }
 

--- a/examples/demo-bank/src/components/vendo/workbench/panels.tsx
+++ b/examples/demo-bank/src/components/vendo/workbench/panels.tsx
@@ -2,16 +2,28 @@
 
 import clsx from "clsx";
 import { useState } from "react";
-import type { WorkbenchPart } from "@vendoai/ui";
+import type { WorkbenchEvent, WorkbenchPart } from "@vendoai/ui";
 import { Chevron, Chip, Disclosure, Empty, SectionHead } from "./parts";
 import { count, describe, duration, eventsOf, rows, share, TONES, type Tone } from "./model";
 import styles from "./workbench.module.css";
 
 type PanelProps = { parts: readonly WorkbenchPart[] };
 
-const GUARD_TONE: Record<string, Tone> = { run: "ok", ask: "warn", block: "bad" };
-const STATUS_TONE: Record<string, Tone> = { ok: "mute", denied: "bad", error: "bad" };
-const APPROVAL_TONE: Record<string, Tone> = { auto: "mute", approved: "ok", "timed-out": "bad", denied: "bad" };
+/** Keyed by the union itself, so a new guard decision or approval outcome in
+ *  `@vendoai/ui` is a build error here rather than an uncoloured cell. */
+type Call = Extract<WorkbenchEvent, { kind: "tool" }>;
+const GUARD_TONE: Record<NonNullable<Call["guard"]>, Tone> = { run: "ok", ask: "warn", block: "bad" };
+const STATUS_TONE: Record<Call["status"], Tone> = { ok: "mute", denied: "bad", error: "bad" };
+const APPROVAL_TONE: Record<NonNullable<Call["approval"]>, Tone> = {
+  auto: "mute", approved: "ok", "timed-out": "bad", denied: "bad",
+};
+
+/** Membership, flipped into a NEW set — React state is never mutated in place. */
+const toggled = (set: ReadonlySet<string>, key: string): Set<string> => {
+  const next = new Set(set);
+  if (!next.delete(key)) next.add(key);
+  return next;
+};
 
 /** Which agent spoke — only worth saying when it is not the turn's own. */
 function AgentTag({ agent }: { agent: WorkbenchPart["agent"] }) {
@@ -23,12 +35,7 @@ function AgentTag({ agent }: { agent: WorkbenchPart["agent"] }) {
 
 export function TimelinePanel({ parts }: PanelProps) {
   const [open, setOpen] = useState<ReadonlySet<string>>(new Set());
-  const toggle = (id: string) =>
-    setOpen(current => {
-      const next = new Set(current);
-      if (!next.delete(id)) next.add(id);
-      return next;
-    });
+  const toggle = (id: string) => setOpen(current => toggled(current, id));
   const list = rows(parts);
   if (list.length === 0) {
     return <Empty title="Nothing on the wire yet" detail="Diagnostics appear here the moment a turn starts." />;
@@ -130,14 +137,14 @@ export function TimelinePanel({ parts }: PanelProps) {
                         <AgentTag agent={call.agent} />
                         {call.event.guard === undefined
                           ? null
-                          : <Chip tone={GUARD_TONE[call.event.guard] ?? "mute"}>{call.event.guard}</Chip>}
+                          : <Chip tone={GUARD_TONE[call.event.guard]}>{call.event.guard}</Chip>}
                         {/* The approval only earns a chip when it says something
                             the status does not — "denied · denied" is one fact. */}
                         {call.event.approval === undefined || call.event.approval === "auto"
                           || call.event.approval === call.event.status
                           ? null
-                          : <Chip tone={APPROVAL_TONE[call.event.approval] ?? "mute"}>{call.event.approval}</Chip>}
-                        <Chip tone={STATUS_TONE[call.event.status] ?? "mute"}>{call.event.status}</Chip>
+                          : <Chip tone={APPROVAL_TONE[call.event.approval]}>{call.event.approval}</Chip>}
+                        <Chip tone={STATUS_TONE[call.event.status]}>{call.event.status}</Chip>
                         <span className={styles.dur}>{duration(call.event.durationMs)}</span>
                       </span>
                     </div>
@@ -176,6 +183,9 @@ export function ContextPanel({ parts }: PanelProps) {
   const sheds = eventsOf(parts, "shed");
   const pct = latest === undefined ? 0 : share(latest.estTokens, latest.windowTokens);
   const triggerPct = latest === undefined ? 0 : share(latest.triggerTokens, latest.windowTokens);
+  // Anchor the legend on whichever side keeps it inside the card, arrow on the
+  // anchored edge — a legend that runs off the edge is worse than no legend.
+  const flip = triggerPct > 50;
   return (
     <div>
       {latest === undefined ? (
@@ -195,15 +205,12 @@ export function ContextPanel({ parts }: PanelProps) {
             <span className={styles.gaugeTrigger} style={{ left: `${triggerPct}%` }} />
           </div>
           <div className={styles.gaugeLegend}>
-            {triggerPct > 50 ? (
-              <span className={styles.gaugeMark} style={{ right: `${100 - triggerPct}%` }}>
-                compaction trigger · {triggerPct}% · {count(latest.triggerTokens)} ▲
-              </span>
-            ) : (
-              <span className={styles.gaugeMark} style={{ left: `${triggerPct}%` }}>
-                ▲ compaction trigger · {triggerPct}% · {count(latest.triggerTokens)}
-              </span>
-            )}
+            <span
+              className={styles.gaugeMark}
+              style={flip ? { right: `${100 - triggerPct}%` } : { left: `${triggerPct}%` }}
+            >
+              {flip ? "" : "▲ "}compaction trigger · {triggerPct}% · {count(latest.triggerTokens)}{flip ? " ▲" : ""}
+            </span>
           </div>
         </div>
       )}
@@ -364,6 +371,11 @@ export function ToolsPanel({ parts }: PanelProps) {
 
 /* ---------------------------------------------------------------- guard */
 
+/** Only the outcomes worth colouring; `auto` and no-approval stay plain. */
+const APPROVAL_CLASS: Record<string, string | undefined> = {
+  approved: styles.gApprovalOk, "timed-out": styles.gApprovalBad, denied: styles.gApprovalBad,
+};
+
 export function GuardPanel({ parts }: PanelProps) {
   const calls = eventsOf(parts, "tool");
   if (calls.length === 0) {
@@ -400,20 +412,14 @@ export function GuardPanel({ parts }: PanelProps) {
               <td>
                 {call.event.guard === undefined
                   ? <span className={styles.e2}>—</span>
-                  : <Chip tone={GUARD_TONE[call.event.guard] ?? "mute"}>{call.event.guard}</Chip>}
+                  : <Chip tone={GUARD_TONE[call.event.guard]}>{call.event.guard}</Chip>}
               </td>
               {/* Plain words, not a chip: most rows say "auto", and a column of
                   identical badges is noise the eye has to step over. */}
-              <td
-                className={clsx(
-                  styles.gApproval,
-                  APPROVAL_TONE[call.event.approval ?? ""] === "ok" && styles.gApprovalOk,
-                  APPROVAL_TONE[call.event.approval ?? ""] === "bad" && styles.gApprovalBad,
-                )}
-              >
+              <td className={clsx(styles.gApproval, APPROVAL_CLASS[call.event.approval ?? ""])}>
                 {call.event.approval ?? "—"}
               </td>
-              <td><Chip tone={STATUS_TONE[call.event.status] ?? "mute"}>{call.event.status}</Chip></td>
+              <td><Chip tone={STATUS_TONE[call.event.status]}>{call.event.status}</Chip></td>
               <td className={clsx(styles.r, styles.dur)}>{duration(call.event.durationMs)}</td>
             </tr>
           ))}
@@ -461,11 +467,7 @@ export function RawPanel({ parts }: PanelProps) {
             key={kind}
             className={clsx(styles.fchip, !off.has(kind) && styles.fchipOn)}
             aria-pressed={!off.has(kind)}
-            onClick={() => setOff(current => {
-              const next = new Set(current);
-              if (!next.delete(kind)) next.add(kind);
-              return next;
-            })}
+            onClick={() => setOff(current => toggled(current, kind))}
           >
             {kind}
           </button>

--- a/examples/demo-bank/src/components/vendo/workbench/panels.tsx
+++ b/examples/demo-bank/src/components/vendo/workbench/panels.tsx
@@ -4,7 +4,7 @@ import clsx from "clsx";
 import { useState } from "react";
 import type { WorkbenchEvent, WorkbenchPart } from "@vendoai/ui";
 import { Chevron, Chip, Disclosure, Empty, SectionHead } from "./parts";
-import { count, describe, duration, eventsOf, rows, share, TONES, type Tone } from "./model";
+import { contextByAgent, count, describe, duration, eventsOf, rows, share, TONES, type Of, type Tone } from "./model";
 import styles from "./workbench.module.css";
 
 type PanelProps = { parts: readonly WorkbenchPart[] };
@@ -86,7 +86,8 @@ export function TimelinePanel({ parts }: PanelProps) {
           );
         }
 
-        const id = `step:${row.step}`;
+        // The agent is part of the identity: two loops' step 1s are two rows.
+        const id = `step:${row.agent}:${row.step}`;
         const isOpen = open.has(id);
         const start = row.parts.find(part => part.event.kind === "step-start");
         const end = row.parts.find(part => part.event.kind === "step-end");
@@ -108,6 +109,7 @@ export function TimelinePanel({ parts }: PanelProps) {
                 head={(
                   <>
                     <Chevron open={isOpen} />
+                    <AgentTag agent={row.agent} />
                     <span className={styles.stepSum}>
                       <span className={styles.stepName}>{calls[0]?.event.name ?? "no tool calls"}</span>
                       {calls.length > 1 ? <span className={styles.stepExtra}>+{calls.length - 1} more</span> : null}
@@ -175,45 +177,59 @@ export function TimelinePanel({ parts }: PanelProps) {
 
 /* -------------------------------------------------------------- context */
 
-export function ContextPanel({ parts }: PanelProps) {
-  const [open, setOpen] = useState<number | undefined>(undefined);
-  const readings = eventsOf(parts, "context");
-  const latest = readings.at(-1)?.event;
-  const compactions = eventsOf(parts, "compaction");
-  const sheds = eventsOf(parts, "shed");
-  const pct = latest === undefined ? 0 : share(latest.estTokens, latest.windowTokens);
-  const triggerPct = latest === undefined ? 0 : share(latest.triggerTokens, latest.windowTokens);
+/** One agent's window, as THAT agent measured it. Each loop in a turn has its own
+ *  seat and its own window, so each gets its own gauge rather than the last
+ *  reading on the wire standing in for all of them. */
+function Gauge({ reading }: { reading: Of<"context"> }) {
+  const { estTokens, windowTokens, triggerTokens } = reading.event;
+  const pct = share(estTokens, windowTokens);
+  const triggerPct = share(triggerTokens, windowTokens);
   // Anchor the legend on whichever side keeps it inside the card, arrow on the
   // anchored edge — a legend that runs off the edge is worse than no legend.
   const flip = triggerPct > 50;
   return (
+    <div className={styles.gaugeCard}>
+      <div className={styles.gaugeTop}>
+        <span className={styles.big}>{count(estTokens)}</span>
+        <span className={styles.of}>/ {count(windowTokens)} tok</span>
+        <Chip tone={pct >= triggerPct ? "warn" : "info"}>{pct}%</Chip>
+        <AgentTag agent={reading.agent} />
+        <span className={styles.gaugeLab}>est. prompt tokens</span>
+      </div>
+      <div className={styles.gauge}>
+        <span className={styles.gaugeFill} style={{ width: `${pct}%` }} />
+        <span className={styles.gaugeTrigger} style={{ left: `${triggerPct}%` }} />
+      </div>
+      <div className={styles.gaugeLegend}>
+        <span
+          className={styles.gaugeMark}
+          style={flip ? { right: `${100 - triggerPct}%` } : { left: `${triggerPct}%` }}
+        >
+          {flip ? "" : "▲ "}compaction trigger · {triggerPct}% · {count(triggerTokens)}{flip ? " ▲" : ""}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function ContextPanel({ parts }: PanelProps) {
+  const [open, setOpen] = useState<number | undefined>(undefined);
+  const readings = eventsOf(parts, "context");
+  const gauges = contextByAgent(parts);
+  // The turn's own thinker leads, so the compaction note below is about the
+  // prompt the RESIDENT measured and not about a screen run's separate window.
+  const lead = gauges[0]?.event;
+  const compactions = eventsOf(parts, "compaction");
+  const sheds = eventsOf(parts, "shed");
+  const pct = lead === undefined ? 0 : share(lead.estTokens, lead.windowTokens);
+  const triggerPct = lead === undefined ? 0 : share(lead.triggerTokens, lead.windowTokens);
+  return (
     <div>
-      {latest === undefined ? (
+      {gauges.length === 0 ? (
         <div className={styles.sec}>
           <Empty title="No context readings this turn" detail="The harness reports the window as it fills." />
         </div>
-      ) : (
-        <div className={styles.gaugeCard}>
-          <div className={styles.gaugeTop}>
-            <span className={styles.big}>{count(latest.estTokens)}</span>
-            <span className={styles.of}>/ {count(latest.windowTokens)} tok</span>
-            <Chip tone={pct >= triggerPct ? "warn" : "info"}>{pct}%</Chip>
-            <span className={styles.gaugeLab}>est. prompt tokens</span>
-          </div>
-          <div className={styles.gauge}>
-            <span className={styles.gaugeFill} style={{ width: `${pct}%` }} />
-            <span className={styles.gaugeTrigger} style={{ left: `${triggerPct}%` }} />
-          </div>
-          <div className={styles.gaugeLegend}>
-            <span
-              className={styles.gaugeMark}
-              style={flip ? { right: `${100 - triggerPct}%` } : { left: `${triggerPct}%` }}
-            >
-              {flip ? "" : "▲ "}compaction trigger · {triggerPct}% · {count(latest.triggerTokens)}{flip ? " ▲" : ""}
-            </span>
-          </div>
-        </div>
-      )}
+      ) : gauges.map(reading => <Gauge key={reading.agent} reading={reading} />)}
 
       {readings.length > 1 ? (
         <div className={styles.sec}>
@@ -223,7 +239,9 @@ export function ContextPanel({ parts }: PanelProps) {
               {readings.map(reading => (
                 <tr key={reading.seq}>
                   <td className={clsx(styles.tKey, styles.mono)} style={{ width: 64 }}>#{reading.seq}</td>
-                  <td className={styles.mono}>{count(reading.event.estTokens)} tok</td>
+                  <td className={styles.mono}>
+                    {count(reading.event.estTokens)} tok <AgentTag agent={reading.agent} />
+                  </td>
                   <td className={clsx(styles.r, styles.mono)}>
                     {share(reading.event.estTokens, reading.event.windowTokens)}%
                   </td>
@@ -239,7 +257,7 @@ export function ContextPanel({ parts }: PanelProps) {
         {compactions.length === 0 ? (
           <Empty
             title="No compaction this turn"
-            detail={latest === undefined
+            detail={lead === undefined
               ? "Nothing was folded — the harness reported no window pressure."
               : `The prompt sat at ${pct}% — the ${triggerPct}% trigger was never reached.`}
           />
@@ -288,6 +306,12 @@ export function ContextPanel({ parts }: PanelProps) {
 
 /* ---------------------------------------------------------------- tools */
 
+/** The name the harness mounts its search hand under (`FIND_TOOLS_TOOL_NAME`).
+ *  Whether it is in the loadout's `active` list is the only thing that says this
+ *  agent CAN search; an empty `searchedIn` on its own says only that it has not
+ *  searched yet. */
+const FIND_TOOLS = "find_tools";
+
 export function ToolsPanel({ parts }: PanelProps) {
   const loadout = eventsOf(parts, "loadout").at(-1)?.event;
   const subagents = eventsOf(parts, "subagent");
@@ -312,7 +336,7 @@ export function ToolsPanel({ parts }: PanelProps) {
           <div className={styles.sec}>
             <SectionHead label="always active" count={loadout.alwaysActive.length} />
             {loadout.alwaysActive.length === 0
-              ? <Empty title="Nothing is always active" detail="Every tool in this run had to be searched for." />
+              ? <Empty title="Nothing is always active" detail="Every tool on this loadout is one the harness curated." />
               : (
                 <div className={styles.pills}>
                   {loadout.alwaysActive.map(name => <span className={styles.pill} key={name}>{name}</span>)}
@@ -322,22 +346,27 @@ export function ToolsPanel({ parts }: PanelProps) {
 
           <div className={styles.sec}>
             <SectionHead label="searched in via find_tools" count={loadout.searchedIn.length} />
-            {loadout.searchedIn.length === 0
+            {/* `searchedIn` is what a search LOADED — tool names, not queries: the
+                query itself is a harness-hand argument and never reaches the wire. */}
+            {loadout.searchedIn.length > 0
               ? (
-                <Empty
-                  title="find_tools not in this loadout"
-                  detail="This agent runs closed — it cannot pull new tools mid-run."
-                />
-              )
-              : loadout.searchedIn.map(query => (
-                <div className={styles.query} key={query}>
-                  <svg width="11" height="11" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
-                    <circle cx="6" cy="6" r="4.2" />
-                    <path d="M9.2 9.2 12.5 12.5" />
-                  </svg>
-                  find_tools(<span className={styles.queryText}>&quot;{query}&quot;</span>)
+                <div className={styles.pills}>
+                  {loadout.searchedIn.map(name => <span className={styles.pill} key={name}>{name}</span>)}
                 </div>
-              ))}
+              )
+              : loadout.active.includes(FIND_TOOLS)
+                ? (
+                  <Empty
+                    title="No searches yet this turn"
+                    detail="find_tools is equipped — this agent can still pull tools in mid-run."
+                  />
+                )
+                : (
+                  <Empty
+                    title="find_tools not in this loadout"
+                    detail="This agent runs closed — it cannot pull new tools mid-run."
+                  />
+                )}
           </div>
         </>
       )}

--- a/examples/demo-bank/src/components/vendo/workbench/panels.tsx
+++ b/examples/demo-bank/src/components/vendo/workbench/panels.tsx
@@ -1,0 +1,485 @@
+"use client";
+
+import clsx from "clsx";
+import { useState } from "react";
+import type { WorkbenchPart } from "@vendoai/ui";
+import { Chevron, Chip, Disclosure, Empty, SectionHead } from "./parts";
+import { count, describe, duration, eventsOf, rows, share, TONES, type Tone } from "./model";
+import styles from "./workbench.module.css";
+
+type PanelProps = { parts: readonly WorkbenchPart[] };
+
+const GUARD_TONE: Record<string, Tone> = { run: "ok", ask: "warn", block: "bad" };
+const STATUS_TONE: Record<string, Tone> = { ok: "mute", denied: "bad", error: "bad" };
+const APPROVAL_TONE: Record<string, Tone> = { auto: "mute", approved: "ok", "timed-out": "bad", denied: "bad" };
+
+/** Which agent spoke — only worth saying when it is not the turn's own. */
+function AgentTag({ agent }: { agent: WorkbenchPart["agent"] }) {
+  if (agent === "resident") return null;
+  return <Chip tone={agent === "screen" ? "info" : "sys"}>{agent}</Chip>;
+}
+
+/* ------------------------------------------------------------- timeline */
+
+export function TimelinePanel({ parts }: PanelProps) {
+  const [open, setOpen] = useState<ReadonlySet<string>>(new Set());
+  const toggle = (id: string) =>
+    setOpen(current => {
+      const next = new Set(current);
+      if (!next.delete(id)) next.add(id);
+      return next;
+    });
+  const list = rows(parts);
+  if (list.length === 0) {
+    return <Empty title="Nothing on the wire yet" detail="Diagnostics appear here the moment a turn starts." />;
+  }
+  return (
+    <div>
+      {list.map((row, index) => {
+        if (row.kind === "event") {
+          const { part } = row;
+          const body = part.event.kind === "compaction" ? part.event.summary
+            : part.event.kind === "subagent" ? part.event.report
+            : undefined;
+          const id = `event:${index}`;
+          const isOpen = open.has(id);
+          const tone = TONES[part.event.kind];
+          const head = (
+            <>
+              {body === undefined ? <span style={{ width: 9, flex: "none" }} /> : <Chevron open={isOpen} />}
+              <Chip tone={tone}>{part.event.kind}</Chip>
+              {/* Never say "subagent" twice — the kind chip already said it. */}
+              {part.event.kind === part.agent ? null : <AgentTag agent={part.agent} />}
+              <span className={styles.evtText}>{describe(part.event)}</span>
+            </>
+          );
+          return (
+            <div className={styles.node} key={id}>
+              <div className={styles.railCol}>
+                <span
+                  className={clsx(
+                    styles.mark,
+                    tone === "sys" && styles.markSys,
+                    tone === "bad" && styles.markBad,
+                    tone === "warn" && styles.markWarn,
+                    tone === "info" && styles.markInfo,
+                  )}
+                />
+              </div>
+              <div>
+                {body === undefined
+                  ? <div className={styles.evt}>{head}</div>
+                  : (
+                    <Disclosure open={isOpen} onToggle={() => toggle(id)} className={styles.evt} head={head}>
+                      <pre className={styles.summary}>{body}</pre>
+                    </Disclosure>
+                  )}
+              </div>
+            </div>
+          );
+        }
+
+        const id = `step:${row.step}`;
+        const isOpen = open.has(id);
+        const start = row.parts.find(part => part.event.kind === "step-start");
+        const end = row.parts.find(part => part.event.kind === "step-end");
+        const calls = eventsOf(row.parts, "tool");
+        const usage = end?.event.kind === "step-end" ? end.event.usage : undefined;
+        const live = end === undefined;
+        return (
+          <div className={styles.node} key={id}>
+            <div className={styles.railCol}>
+              <span className={clsx(styles.num, live && styles.numLive)}>
+                {String(row.step).padStart(2, "0")}
+              </span>
+            </div>
+            <div>
+              <Disclosure
+                open={isOpen}
+                onToggle={() => toggle(id)}
+                className={styles.stepBtn}
+                head={(
+                  <>
+                    <Chevron open={isOpen} />
+                    <span className={styles.stepSum}>
+                      <span className={styles.stepName}>{calls[0]?.event.name ?? "no tool calls"}</span>
+                      {calls.length > 1 ? <span className={styles.stepExtra}>+{calls.length - 1} more</span> : null}
+                    </span>
+                    <span className={styles.stepMeta}>
+                      {usage === undefined ? null : (
+                        <span className={styles.tok}>
+                          {count(usage.inputTokens ?? 0)} in · {count(usage.outputTokens ?? 0)} out
+                        </span>
+                      )}
+                      {end?.event.kind === "step-end"
+                        ? <span className={styles.dur}>{duration(end.event.durationMs)}</span>
+                        : null}
+                      <Chip tone={live ? "info" : "mute"}>
+                        {end?.event.kind === "step-end" ? end.event.stopReason : "in flight"}
+                      </Chip>
+                    </span>
+                  </>
+                )}
+              >
+                <div className={styles.expPad}>
+                  {calls.map(call => (
+                    <div className={styles.call} key={call.event.toolCallId}>
+                      <span className={styles.callName}>{call.event.name}</span>
+                      <span className={styles.callArgs}>{call.event.argsPreview}</span>
+                      <span className={styles.callRight}>
+                        <AgentTag agent={call.agent} />
+                        {call.event.guard === undefined
+                          ? null
+                          : <Chip tone={GUARD_TONE[call.event.guard] ?? "mute"}>{call.event.guard}</Chip>}
+                        {/* The approval only earns a chip when it says something
+                            the status does not — "denied · denied" is one fact. */}
+                        {call.event.approval === undefined || call.event.approval === "auto"
+                          || call.event.approval === call.event.status
+                          ? null
+                          : <Chip tone={APPROVAL_TONE[call.event.approval] ?? "mute"}>{call.event.approval}</Chip>}
+                        <Chip tone={STATUS_TONE[call.event.status] ?? "mute"}>{call.event.status}</Chip>
+                        <span className={styles.dur}>{duration(call.event.durationMs)}</span>
+                      </span>
+                    </div>
+                  ))}
+                  <div className={styles.mini}>
+                    {start?.event.kind === "step-start" ? (
+                      <div className={styles.miniRow}>
+                        <Chip tone="mute">loadout</Chip>
+                        <span>
+                          {start.event.activeTools.length} {start.event.activeTools.length === 1 ? "tool" : "tools"}
+                          {" active · step cap "}{start.event.maxSteps}
+                        </span>
+                      </div>
+                    ) : null}
+                    {calls.length === 0
+                      ? <div className={clsx(styles.miniRow, styles.miniFaint)}>no tool calls in this step</div>
+                      : null}
+                  </div>
+                </div>
+              </Disclosure>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------- context */
+
+export function ContextPanel({ parts }: PanelProps) {
+  const [open, setOpen] = useState<number | undefined>(undefined);
+  const readings = eventsOf(parts, "context");
+  const latest = readings.at(-1)?.event;
+  const compactions = eventsOf(parts, "compaction");
+  const sheds = eventsOf(parts, "shed");
+  const pct = latest === undefined ? 0 : share(latest.estTokens, latest.windowTokens);
+  const triggerPct = latest === undefined ? 0 : share(latest.triggerTokens, latest.windowTokens);
+  return (
+    <div>
+      {latest === undefined ? (
+        <div className={styles.sec}>
+          <Empty title="No context readings this turn" detail="The harness reports the window as it fills." />
+        </div>
+      ) : (
+        <div className={styles.gaugeCard}>
+          <div className={styles.gaugeTop}>
+            <span className={styles.big}>{count(latest.estTokens)}</span>
+            <span className={styles.of}>/ {count(latest.windowTokens)} tok</span>
+            <Chip tone={pct >= triggerPct ? "warn" : "info"}>{pct}%</Chip>
+            <span className={styles.gaugeLab}>est. prompt tokens</span>
+          </div>
+          <div className={styles.gauge}>
+            <span className={styles.gaugeFill} style={{ width: `${pct}%` }} />
+            <span className={styles.gaugeTrigger} style={{ left: `${triggerPct}%` }} />
+          </div>
+          <div className={styles.gaugeLegend}>
+            {triggerPct > 50 ? (
+              <span className={styles.gaugeMark} style={{ right: `${100 - triggerPct}%` }}>
+                compaction trigger · {triggerPct}% · {count(latest.triggerTokens)} ▲
+              </span>
+            ) : (
+              <span className={styles.gaugeMark} style={{ left: `${triggerPct}%` }}>
+                ▲ compaction trigger · {triggerPct}% · {count(latest.triggerTokens)}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {readings.length > 1 ? (
+        <div className={styles.sec}>
+          <SectionHead label="readings" count={readings.length} />
+          <table className={styles.t}>
+            <tbody>
+              {readings.map(reading => (
+                <tr key={reading.seq}>
+                  <td className={clsx(styles.tKey, styles.mono)} style={{ width: 64 }}>#{reading.seq}</td>
+                  <td className={styles.mono}>{count(reading.event.estTokens)} tok</td>
+                  <td className={clsx(styles.r, styles.mono)}>
+                    {share(reading.event.estTokens, reading.event.windowTokens)}%
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+
+      <div className={styles.sec}>
+        <SectionHead label="compaction history" count={compactions.length} />
+        {compactions.length === 0 ? (
+          <Empty
+            title="No compaction this turn"
+            detail={latest === undefined
+              ? "Nothing was folded — the harness reported no window pressure."
+              : `The prompt sat at ${pct}% — the ${triggerPct}% trigger was never reached.`}
+          />
+        ) : compactions.map(part => (
+          <div className={styles.cmp} key={part.seq}>
+            <Disclosure
+              open={open === part.seq}
+              onToggle={() => setOpen(current => (current === part.seq ? undefined : part.seq))}
+              className={styles.cmpBtn}
+              head={(
+                <>
+                  <Chevron open={open === part.seq} />
+                  <span className={styles.cmpWhen}>#{part.seq}</span>
+                  <span className={styles.cmpWhat}>{describe(part.event)}</span>
+                  <Chip tone="sys">{part.event.reason}</Chip>
+                </>
+              )}
+            >
+              <pre className={styles.summary}>{part.event.summary}</pre>
+            </Disclosure>
+          </div>
+        ))}
+      </div>
+
+      <div className={styles.sec}>
+        <SectionHead label="shed events" count={sheds.length} />
+        {sheds.length === 0
+          ? <Empty title="Nothing shed" detail="No provider call overflowed this turn." />
+          : (
+            <table className={styles.t}>
+              <tbody>
+                {sheds.map(part => (
+                  <tr key={part.seq}>
+                    <td className={clsx(styles.tKey, styles.mono)} style={{ width: 64 }}>#{part.seq}</td>
+                    <td>{describe(part.event)}</td>
+                    <td className={clsx(styles.r, styles.mono)}>−{part.event.dropped}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+      </div>
+    </div>
+  );
+}
+
+/* ---------------------------------------------------------------- tools */
+
+export function ToolsPanel({ parts }: PanelProps) {
+  const loadout = eventsOf(parts, "loadout").at(-1)?.event;
+  const subagents = eventsOf(parts, "subagent");
+  if (loadout === undefined && subagents.length === 0) {
+    return <Empty title="No loadout reported" detail="The harness publishes the tool set as it assembles it." />;
+  }
+  return (
+    <div>
+      {loadout === undefined ? null : (
+        <>
+          <div className={styles.sec}>
+            <div className={styles.loadout}>
+              <span className={styles.big}>{loadout.active.length}</span>
+              <span className={styles.of}>active</span>
+              <Chip tone="info">{loadout.withheldCount} withheld</Chip>
+            </div>
+            <div className={styles.pills}>
+              {loadout.active.map(name => <span className={styles.pill} key={name}>{name}</span>)}
+            </div>
+          </div>
+
+          <div className={styles.sec}>
+            <SectionHead label="always active" count={loadout.alwaysActive.length} />
+            {loadout.alwaysActive.length === 0
+              ? <Empty title="Nothing is always active" detail="Every tool in this run had to be searched for." />
+              : (
+                <div className={styles.pills}>
+                  {loadout.alwaysActive.map(name => <span className={styles.pill} key={name}>{name}</span>)}
+                </div>
+              )}
+          </div>
+
+          <div className={styles.sec}>
+            <SectionHead label="searched in via find_tools" count={loadout.searchedIn.length} />
+            {loadout.searchedIn.length === 0
+              ? (
+                <Empty
+                  title="find_tools not in this loadout"
+                  detail="This agent runs closed — it cannot pull new tools mid-run."
+                />
+              )
+              : loadout.searchedIn.map(query => (
+                <div className={styles.query} key={query}>
+                  <svg width="11" height="11" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                    <circle cx="6" cy="6" r="4.2" />
+                    <path d="M9.2 9.2 12.5 12.5" />
+                  </svg>
+                  find_tools(<span className={styles.queryText}>&quot;{query}&quot;</span>)
+                </div>
+              ))}
+          </div>
+        </>
+      )}
+
+      <div className={styles.sec}>
+        <SectionHead label="hired sub-runs" count={subagents.length} />
+        {subagents.length === 0
+          ? <Empty title="No subagent hired" detail="Nothing in this turn delegated to a sub-run." />
+          : subagents.map(part => (
+            <div className={styles.subCard} key={part.seq}>
+              <div className={styles.subHead}>
+                <span className={styles.subName}>{part.event.label}</span>
+                <span className={styles.pushRight}>
+                  <Chip tone="ok">{part.event.steps} / {part.event.maxSteps} steps</Chip>
+                </span>
+              </div>
+              {part.event.report === undefined
+                ? <div className={styles.e2}>No report came back.</div>
+                : (
+                  <div className={styles.quote}>
+                    <em className={styles.quoteLabel}>report back</em>
+                    {part.event.report}
+                  </div>
+                )}
+            </div>
+          ))}
+      </div>
+    </div>
+  );
+}
+
+/* ---------------------------------------------------------------- guard */
+
+export function GuardPanel({ parts }: PanelProps) {
+  const calls = eventsOf(parts, "tool");
+  if (calls.length === 0) {
+    return <Empty title="No tool calls this turn" detail="Nothing reached the guard, so nothing was decided." />;
+  }
+  const tally = (decision: string) => calls.filter(call => call.event.guard === decision).length;
+  return (
+    <div>
+      <div className={styles.guardSum}>
+        <span>{calls.length} tool calls this turn</span>
+        <Chip tone="ok">{tally("run")} run</Chip>
+        <Chip tone="warn">{tally("ask")} ask</Chip>
+        <Chip tone={tally("block") > 0 ? "bad" : "mute"}>{tally("block")} block</Chip>
+      </div>
+      <table className={styles.g}>
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>tool</th>
+            <th>decision</th>
+            <th>approval</th>
+            <th>status</th>
+            <th className={styles.r}>duration</th>
+          </tr>
+        </thead>
+        <tbody>
+          {calls.map(call => (
+            <tr key={call.event.toolCallId}>
+              <td className={styles.gStep}>{String(call.event.step).padStart(2, "0")}</td>
+              <td className={styles.gName}>
+                {call.event.name}
+                {call.agent === "resident" ? null : <span className={styles.gSub}>{call.agent}</span>}
+              </td>
+              <td>
+                {call.event.guard === undefined
+                  ? <span className={styles.e2}>—</span>
+                  : <Chip tone={GUARD_TONE[call.event.guard] ?? "mute"}>{call.event.guard}</Chip>}
+              </td>
+              {/* Plain words, not a chip: most rows say "auto", and a column of
+                  identical badges is noise the eye has to step over. */}
+              <td
+                className={clsx(
+                  styles.gApproval,
+                  APPROVAL_TONE[call.event.approval ?? ""] === "ok" && styles.gApprovalOk,
+                  APPROVAL_TONE[call.event.approval ?? ""] === "bad" && styles.gApprovalBad,
+                )}
+              >
+                {call.event.approval ?? "—"}
+              </td>
+              <td><Chip tone={STATUS_TONE[call.event.status] ?? "mute"}>{call.event.status}</Chip></td>
+              <td className={clsx(styles.r, styles.dur)}>{duration(call.event.durationMs)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ raw */
+
+export function RawPanel({ parts }: PanelProps) {
+  const [query, setQuery] = useState("");
+  const [off, setOff] = useState<ReadonlySet<string>>(new Set());
+  const kinds = [...new Set(parts.map(part => part.event.kind))];
+  const start = parts[0]?.at ?? 0;
+  const needle = query.trim().toLowerCase();
+  const shown = parts.filter(part =>
+    !off.has(part.event.kind)
+    && (needle === "" || `${part.event.kind} ${part.agent} ${describe(part.event)}`.toLowerCase().includes(needle)));
+  return (
+    <div className={styles.rawCard}>
+      <div className={styles.rawHead}>
+        <span className={styles.rawLabel}>stream</span>
+        <span className={styles.rawTitle}>data-vendo-debug</span>
+        <span className={clsx(styles.rawLabel, styles.pushRight)}>{shown.length} / {parts.length}</span>
+        <button
+          type="button"
+          className={styles.ghostBtn}
+          onClick={() => void navigator.clipboard?.writeText(JSON.stringify(parts, null, 2))}
+        >
+          copy
+        </button>
+      </div>
+      <div className={styles.filter}>
+        <input
+          value={query}
+          onChange={event => setQuery(event.target.value)}
+          placeholder="filter events…"
+          aria-label="Filter events"
+        />
+        {kinds.map(kind => (
+          <button
+            type="button"
+            key={kind}
+            className={clsx(styles.fchip, !off.has(kind) && styles.fchipOn)}
+            aria-pressed={!off.has(kind)}
+            onClick={() => setOff(current => {
+              const next = new Set(current);
+              if (!next.delete(kind)) next.add(kind);
+              return next;
+            })}
+          >
+            {kind}
+          </button>
+        ))}
+      </div>
+      {shown.length === 0
+        ? <div className={styles.feedEmpty}>No events match this filter.</div>
+        : shown.map(part => (
+          <div className={styles.frow} key={part.seq}>
+            <span className={styles.frowAt}>+{((part.at - start) / 1000).toFixed(2)}</span>
+            <span><Chip tone={TONES[part.event.kind]}>{part.event.kind}</Chip></span>
+            <span className={styles.frowMsg}>{describe(part.event)}</span>
+          </div>
+        ))}
+    </div>
+  );
+}

--- a/examples/demo-bank/src/components/vendo/workbench/parts.tsx
+++ b/examples/demo-bank/src/components/vendo/workbench/parts.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import clsx from "clsx";
+import type { ReactNode } from "react";
+import type { Tone } from "./model";
+import styles from "./workbench.module.css";
+
+export function Chip({ tone = "mute", children }: { tone?: Tone; children: ReactNode }) {
+  return <span className={clsx(styles.chip, styles[tone])}>{children}</span>;
+}
+
+export function SectionHead({ label, count }: { label: string; count?: ReactNode }) {
+  return (
+    <div className={styles.secHead}>
+      {label}
+      {count === undefined ? null : <span className={styles.secN}>{count}</span>}
+      <span className={styles.rule} />
+    </div>
+  );
+}
+
+/** The empty state IS the answer here: "no compaction this turn" is a fact
+ *  about the run, not a missing panel. */
+export function Empty({ title, detail }: { title: string; detail: string }) {
+  return (
+    <div className={styles.empty}>
+      <div className={styles.e1}>{title}</div>
+      <div className={styles.e2}>{detail}</div>
+    </div>
+  );
+}
+
+export function Chevron({ open }: { open: boolean }) {
+  return (
+    <svg className={clsx(styles.chev, open && styles.chevOpen)} viewBox="0 0 12 12" aria-hidden="true">
+      <path d="M4.5 2.5 8 6l-3.5 3.5" />
+    </svg>
+  );
+}
+
+/** A row that opens. The body animates on grid rows so it never needs a
+ *  measured height, and it stays mounted so the chevron and the content move
+ *  together. */
+export function Disclosure(
+  { open, onToggle, head, className, children }:
+  { open: boolean; onToggle: () => void; head: ReactNode; className?: string; children: ReactNode },
+) {
+  return (
+    <>
+      <button type="button" className={className} aria-expanded={open} onClick={onToggle}>
+        {head}
+      </button>
+      <div className={clsx(styles.exp, open && styles.expOpen)}>
+        <div className={styles.expInner}>{children}</div>
+      </div>
+    </>
+  );
+}

--- a/examples/demo-bank/src/components/vendo/workbench/parts.tsx
+++ b/examples/demo-bank/src/components/vendo/workbench/parts.tsx
@@ -5,15 +5,15 @@ import type { ReactNode } from "react";
 import type { Tone } from "./model";
 import styles from "./workbench.module.css";
 
-export function Chip({ tone = "mute", children }: { tone?: Tone; children: ReactNode }) {
+export function Chip({ tone, children }: { tone: Tone; children: ReactNode }) {
   return <span className={clsx(styles.chip, styles[tone])}>{children}</span>;
 }
 
-export function SectionHead({ label, count }: { label: string; count?: ReactNode }) {
+export function SectionHead({ label, count }: { label: string; count: ReactNode }) {
   return (
     <div className={styles.secHead}>
       {label}
-      {count === undefined ? null : <span className={styles.secN}>{count}</span>}
+      <span className={styles.secN}>{count}</span>
       <span className={styles.rule} />
     </div>
   );
@@ -43,7 +43,7 @@ export function Chevron({ open }: { open: boolean }) {
  *  together. */
 export function Disclosure(
   { open, onToggle, head, className, children }:
-  { open: boolean; onToggle: () => void; head: ReactNode; className?: string; children: ReactNode },
+  { open: boolean; onToggle: () => void; head: ReactNode; className: string; children: ReactNode },
 ) {
   return (
     <>

--- a/examples/demo-bank/src/components/vendo/workbench/workbench.module.css
+++ b/examples/demo-bank/src/components/vendo/workbench/workbench.module.css
@@ -1,0 +1,1178 @@
+/* Harness Workbench — dev-only chrome, docked against Maple.
+   Warm-neutral dark so it reads as a tool rather than as product: the greys are
+   tuned to the same warmth as Maple's own (globals.css), one step darker than
+   ink. Values carried from the approved mockup. */
+
+.pane {
+  --w-bg: #141312;
+  --w-surface: #1a1917;
+  --w-raise: #211f1c;
+  --w-raise-2: #272421;
+  --w-line: #2a2724;
+  --w-line-2: #38342f;
+  --w-text: #edeae4;
+  --w-soft: #a39d94;
+  --w-muted: #7a746c;
+  --w-faint: #544e48;
+
+  --ok: #63c38e;
+  --ok-bg: rgb(99 195 142 / 0.12);
+  --ok-line: rgb(99 195 142 / 0.26);
+  --warn: #e4a65e;
+  --warn-bg: rgb(228 166 94 / 0.12);
+  --warn-line: rgb(228 166 94 / 0.28);
+  --bad: #e37a6c;
+  --bad-bg: rgb(227 122 108 / 0.12);
+  --bad-line: rgb(227 122 108 / 0.28);
+  --info: #82a8f2;
+  --info-bg: rgb(130 168 242 / 0.12);
+  --info-line: rgb(130 168 242 / 0.28);
+  --sys: #ac95e2;
+  --sys-bg: rgb(172 149 226 / 0.12);
+  --sys-line: rgb(172 149 226 / 0.28);
+
+  --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+  --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+
+  position: fixed;
+  inset: 0 0 0 auto;
+  z-index: 60;
+  display: flex;
+  flex-direction: column;
+  width: min(480px, 100vw);
+  background: var(--w-bg);
+  color: var(--w-text);
+  font-size: 13px;
+  box-shadow: -1px 0 0 rgb(0 0 0 / 0.5), -24px 0 44px rgb(17 17 17 / 0.1);
+}
+
+.pane * {
+  box-sizing: border-box;
+  border-color: var(--w-line);
+}
+
+/* `:where` so the reset carries ZERO specificity — a plain `.pane button`
+   out-ranks every class below it and silently eats their padding, borders and
+   backgrounds. */
+:where(.pane) button {
+  font: inherit;
+  color: inherit;
+  background: none;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+}
+
+.pane :focus-visible {
+  outline: 2px solid var(--info);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* Collapsed — a rail on the right edge, the only thing left on screen. */
+.rail {
+  position: fixed;
+  top: 50%;
+  right: 0;
+  z-index: 60;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 10px 8px;
+  writing-mode: vertical-rl;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 10px;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: #a39d94;
+  background: #1a1917;
+  border: 1px solid #2a2724;
+  border-right: 0;
+  border-radius: 8px 0 0 8px;
+  cursor: pointer;
+  transition: color 120ms ease, transform 160ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.rail:hover {
+  color: #edeae4;
+}
+
+.rail:active {
+  transform: translateY(-50%) scale(0.98);
+}
+
+/* ---------------------------------------------------------------- header */
+.head {
+  flex: none;
+  background: var(--w-surface);
+  border-bottom: 1px solid var(--w-line);
+}
+
+.headTop {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 13px 16px 11px;
+}
+
+.title {
+  margin: 0;
+  font-size: 13.5px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+}
+
+.chipDev {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--w-muted);
+  border: 1px solid var(--w-line-2);
+  border-radius: 4px;
+  padding: 2px 5px;
+}
+
+.headActions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.ghostBtn {
+  font-size: 11px;
+  color: var(--w-muted);
+  padding: 3px 8px;
+  border-radius: 5px;
+  border: 1px solid var(--w-line-2);
+  transition: color 120ms ease, transform 160ms var(--ease-out);
+}
+
+.ghostBtn:hover {
+  color: var(--w-text);
+}
+
+.ghostBtn:active {
+  transform: scale(0.97);
+}
+
+.turnSwitch {
+  display: flex;
+  gap: 2px;
+  overflow-x: auto;
+  margin: 0 16px 10px;
+  background: var(--w-bg);
+  border: 1px solid var(--w-line);
+  border-radius: 8px;
+  padding: 2px;
+}
+
+.tsBtn {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+  white-space: nowrap;
+  padding: 5px 11px;
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--w-soft);
+  transition: transform 160ms var(--ease-out), background 120ms ease, color 120ms ease;
+}
+
+.tsBtn:hover {
+  color: var(--w-text);
+}
+
+.tsBtn:active {
+  transform: scale(0.98);
+}
+
+.tsBtnOn {
+  background: var(--w-line);
+  color: var(--w-text);
+  box-shadow: 0 1px 0 rgb(0 0 0 / 0.3);
+}
+
+.tsId {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--w-faint);
+}
+
+.tsBtnOn .tsId {
+  color: var(--w-muted);
+}
+
+/* Wraps rather than scrolls: a clipped stat reads as a bug, and the pane is
+   narrow enough that "agents" lands on a second line on a busy turn. */
+.status {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  row-gap: 12px;
+  padding: 0 16px 12px;
+}
+
+.stat {
+  flex: none;
+  padding: 0 14px;
+  border-left: 1px solid var(--w-line);
+}
+
+.stat:first-child {
+  padding-left: 0;
+  border-left: 0;
+}
+
+.lbl {
+  font-size: 9.5px;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--w-muted);
+  margin-bottom: 5px;
+}
+
+.val {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12.5px;
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  color: var(--w-text);
+  white-space: nowrap;
+}
+
+.dim {
+  color: var(--w-muted);
+}
+
+.pulse {
+  position: relative;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex: none;
+  background: var(--ok);
+}
+
+.pulseRun {
+  background: var(--info);
+}
+
+.pulseRun::after {
+  content: "";
+  position: absolute;
+  inset: -4px;
+  border-radius: 50%;
+  border: 1px solid var(--info);
+  opacity: 0.5;
+  animation: wb-ring 1.7s ease-out infinite;
+}
+
+@keyframes wb-ring {
+  from {
+    transform: scale(0.5);
+    opacity: 0.6;
+  }
+  to {
+    transform: scale(1.25);
+    opacity: 0;
+  }
+}
+
+.statProg {
+  width: 112px;
+}
+
+.prog {
+  height: 3px;
+  border-radius: 99px;
+  background: var(--w-line-2);
+  margin-top: 7px;
+  overflow: hidden;
+}
+
+.prog > i {
+  display: block;
+  height: 100%;
+  border-radius: 99px;
+  background: var(--info);
+  transition: width 260ms var(--ease-out);
+}
+
+.progDone > i {
+  background: var(--ok);
+}
+
+/* ------------------------------------------------------------------ tabs */
+.tabs {
+  display: flex;
+  gap: 2px;
+  padding: 0 16px;
+  background: var(--w-surface);
+  border-bottom: 1px solid var(--w-line);
+  flex: none;
+}
+
+.tab {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 9px 10px 10px;
+  font-size: 12.5px;
+  text-transform: capitalize;
+  color: var(--w-muted);
+  transition: color 120ms ease;
+}
+
+.tab:hover {
+  color: var(--w-soft);
+}
+
+.tabOn {
+  color: var(--w-text);
+}
+
+.tabOn::after {
+  content: "";
+  position: absolute;
+  left: 8px;
+  right: 8px;
+  bottom: -1px;
+  height: 2px;
+  background: var(--w-text);
+  border-radius: 2px;
+}
+
+.tabN {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--w-faint);
+}
+
+.tabOn .tabN {
+  color: var(--w-muted);
+}
+
+.body {
+  flex: 1;
+  overflow: auto;
+  padding: 14px 16px 40px;
+}
+
+/* --------------------------------------------------------------- shared */
+.sec {
+  margin-bottom: 22px;
+}
+
+.secHead {
+  display: flex;
+  align-items: baseline;
+  gap: 9px;
+  margin-bottom: 9px;
+  font-size: 10px;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--w-muted);
+}
+
+.secN {
+  font-family: var(--mono);
+  letter-spacing: 0;
+  text-transform: none;
+  font-size: 11px;
+  color: var(--w-faint);
+}
+
+.rule {
+  flex: 1;
+  height: 1px;
+  background: var(--w-line);
+}
+
+.chip {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  line-height: 1.5;
+  padding: 1px 6px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.ok {
+  color: var(--ok);
+  background: var(--ok-bg);
+  border-color: var(--ok-line);
+}
+
+.warn {
+  color: var(--warn);
+  background: var(--warn-bg);
+  border-color: var(--warn-line);
+}
+
+.bad {
+  color: var(--bad);
+  background: var(--bad-bg);
+  border-color: var(--bad-line);
+}
+
+.info {
+  color: var(--info);
+  background: var(--info-bg);
+  border-color: var(--info-line);
+}
+
+.sys {
+  color: var(--sys);
+  background: var(--sys-bg);
+  border-color: var(--sys-line);
+}
+
+.mute {
+  color: var(--w-muted);
+  background: var(--w-raise);
+  border-color: var(--w-line-2);
+}
+
+.tok {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  font-variant-numeric: tabular-nums;
+  color: var(--w-muted);
+  white-space: nowrap;
+}
+
+.dur {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  font-variant-numeric: tabular-nums;
+  color: var(--w-soft);
+  white-space: nowrap;
+}
+
+.empty {
+  border: 1px dashed var(--w-line-2);
+  border-radius: 9px;
+  padding: 18px 16px;
+  text-align: center;
+}
+
+.e1 {
+  font-size: 12.5px;
+  color: var(--w-soft);
+  margin-bottom: 4px;
+}
+
+.e2 {
+  font-size: 11.5px;
+  color: var(--w-muted);
+}
+
+.quote {
+  border-left: 2px solid var(--w-line-2);
+  padding: 2px 0 2px 11px;
+  margin: 8px 0 2px;
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--w-soft);
+}
+
+.quoteLabel {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--w-muted);
+}
+
+/* Disclosure body — grid-rows so the height animates without a measured px. */
+.exp {
+  display: grid;
+  grid-template-rows: 0fr;
+  opacity: 0;
+  transition: grid-template-rows 190ms var(--ease-out), opacity 150ms ease;
+}
+
+.expOpen {
+  grid-template-rows: 1fr;
+  opacity: 1;
+}
+
+.expInner {
+  overflow: hidden;
+  min-height: 0;
+}
+
+.expPad {
+  padding: 2px 8px 14px 4px;
+}
+
+.chev {
+  width: 9px;
+  height: 9px;
+  flex: none;
+  stroke: var(--w-faint);
+  stroke-width: 2;
+  fill: none;
+  transition: transform 150ms var(--ease-out);
+}
+
+.chevOpen {
+  transform: rotate(90deg);
+}
+
+/* -------------------------------------------------------------- timeline */
+.node {
+  display: grid;
+  grid-template-columns: 30px 1fr;
+  column-gap: 10px;
+}
+
+.railCol {
+  position: relative;
+  display: flex;
+  justify-content: center;
+}
+
+.railCol::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: #302c28;
+}
+
+.node:first-child .railCol::before {
+  top: 14px;
+}
+
+.node:last-child .railCol::before {
+  bottom: calc(100% - 14px);
+}
+
+.num {
+  position: relative;
+  margin-top: 5px;
+  width: 22px;
+  height: 18px;
+  border-radius: 5px;
+  background: var(--w-raise);
+  border: 1px solid var(--w-line-2);
+  display: grid;
+  place-items: center;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--w-soft);
+}
+
+.numLive {
+  border-color: var(--info-line);
+  color: var(--info);
+  background: var(--info-bg);
+}
+
+.mark {
+  position: relative;
+  margin-top: 8px;
+  width: 9px;
+  height: 9px;
+  border-radius: 2px;
+  transform: rotate(45deg);
+  background: var(--w-bg);
+  border: 1.5px solid var(--w-line-2);
+}
+
+.markSys {
+  border-color: var(--sys);
+  background: var(--sys-bg);
+}
+
+.markBad {
+  border-color: var(--bad);
+  background: var(--bad-bg);
+}
+
+.markWarn {
+  border-color: var(--warn);
+  background: var(--warn-bg);
+}
+
+.markInfo {
+  border-color: var(--info);
+  background: var(--info-bg);
+}
+
+.stepBtn {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  text-align: left;
+  padding: 7px 8px 7px 4px;
+  border-radius: 7px;
+  transition: background 120ms ease;
+}
+
+.stepBtn:hover {
+  background: var(--w-surface);
+}
+
+.stepSum {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  min-width: 0;
+  flex: 1;
+}
+
+.stepName {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--w-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.stepExtra {
+  flex: none;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  white-space: nowrap;
+  color: var(--w-faint);
+}
+
+.stepMeta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: none;
+}
+
+.evt {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  text-align: left;
+  padding: 5px 8px 5px 4px;
+  border-radius: 7px;
+  font-size: 11.5px;
+  color: var(--w-soft);
+  transition: background 120ms ease;
+}
+
+button.evt:hover {
+  background: var(--w-surface);
+}
+
+.evtText {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.evtText b {
+  font-weight: 500;
+  color: var(--w-text);
+}
+
+.call {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  column-gap: 14px;
+  row-gap: 4px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: var(--w-surface);
+  border: 1px solid var(--w-line);
+  margin-bottom: 6px;
+}
+
+.callName {
+  grid-column: 1;
+  grid-row: 1;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--w-text);
+}
+
+.callArgs {
+  grid-column: 1;
+  grid-row: 2;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--w-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.callRight {
+  grid-column: 2;
+  grid-row: 1 / 3;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 6px;
+  align-self: center;
+}
+
+.mini {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 8px;
+}
+
+.miniRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11.5px;
+  color: var(--w-soft);
+}
+
+.miniFaint {
+  color: var(--w-faint);
+}
+
+/* --------------------------------------------------------------- context */
+.gaugeCard {
+  background: var(--w-surface);
+  border: 1px solid var(--w-line);
+  border-radius: 10px;
+  padding: 15px 16px 17px;
+  margin-bottom: 20px;
+}
+
+.gaugeTop {
+  display: flex;
+  align-items: baseline;
+  gap: 9px;
+  margin-bottom: 14px;
+}
+
+.big {
+  font-family: var(--mono);
+  font-size: 23px;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+}
+
+.of {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  color: var(--w-muted);
+}
+
+.gaugeLab {
+  margin-left: auto;
+  font-size: 10px;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--w-muted);
+}
+
+.gauge {
+  position: relative;
+  height: 10px;
+  border-radius: 5px;
+  background: var(--w-raise);
+  border: 1px solid var(--w-line);
+}
+
+.gaugeFill {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  border-radius: 5px 3px 3px 5px;
+  background: linear-gradient(90deg, #5c8fe0, #82a8f2);
+  transition: width 260ms var(--ease-out);
+}
+
+.gaugeTrigger {
+  position: absolute;
+  top: -5px;
+  bottom: -5px;
+  width: 1.5px;
+  background: var(--warn);
+  border-radius: 2px;
+}
+
+.gaugeLegend {
+  position: relative;
+  height: 14px;
+  margin-top: 9px;
+}
+
+/* Anchored to the trigger line, and on whichever side keeps it inside the
+   card — a legend that runs off the edge is worse than no legend. */
+.gaugeMark {
+  position: absolute;
+  white-space: nowrap;
+  color: var(--warn);
+  font-family: var(--mono);
+  font-size: 10.5px;
+}
+
+.t {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.t th {
+  text-align: left;
+  font-size: 9.5px;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--w-muted);
+  font-weight: 500;
+  padding: 0 10px 7px 0;
+  border-bottom: 1px solid var(--w-line);
+}
+
+.t td {
+  padding: 7px 10px 7px 0;
+  border-bottom: 1px solid var(--w-line);
+  font-size: 12px;
+  color: var(--w-soft);
+}
+
+.t tr:last-child td {
+  border-bottom: 0;
+}
+
+.tKey {
+  color: var(--w-text);
+}
+
+.r {
+  text-align: right;
+  padding-right: 0 !important;
+}
+
+.mono {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.cmp {
+  background: var(--w-surface);
+  border: 1px solid var(--w-line);
+  border-radius: 9px;
+  margin-bottom: 7px;
+  overflow: hidden;
+}
+
+.cmpBtn {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  text-align: left;
+  transition: background 120ms ease;
+}
+
+.cmpBtn:hover {
+  background: var(--w-raise);
+}
+
+.cmpWhen {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--w-muted);
+  width: 60px;
+  flex: none;
+}
+
+.cmpWhat {
+  font-size: 12px;
+  color: var(--w-text);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.summary {
+  margin: 0;
+  padding: 2px 14px 14px;
+  font-family: var(--mono);
+  font-size: 11px;
+  line-height: 1.65;
+  color: var(--w-soft);
+  white-space: pre-wrap;
+}
+
+/* ----------------------------------------------------------------- tools */
+.loadout {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.pill {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--w-soft);
+  background: var(--w-surface);
+  border: 1px solid var(--w-line);
+  border-radius: 5px;
+  padding: 3px 7px;
+}
+
+.pillOff {
+  color: var(--w-faint);
+  background: transparent;
+  border-style: dashed;
+}
+
+.query {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 10px 0 6px;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--w-soft);
+}
+
+.queryText {
+  color: var(--info);
+}
+
+.subCard {
+  background: var(--w-surface);
+  border: 1px solid var(--w-line);
+  border-radius: 10px;
+  padding: 12px 13px;
+  margin-bottom: 7px;
+}
+
+.subHead {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin-bottom: 4px;
+}
+
+.subName {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--w-text);
+}
+
+.pushRight {
+  margin-left: auto;
+}
+
+/* ----------------------------------------------------------------- guard */
+.guardSum {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-bottom: 12px;
+  font-size: 11.5px;
+  color: var(--w-muted);
+}
+
+.g {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.g th {
+  position: sticky;
+  top: 0;
+  background: var(--w-bg);
+  text-align: left;
+  font-size: 9.5px;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--w-muted);
+  font-weight: 500;
+  padding: 0 10px 7px 0;
+  border-bottom: 1px solid var(--w-line-2);
+}
+
+.g td {
+  padding: 7px 8px 7px 0;
+  border-bottom: 1px solid var(--w-line);
+  vertical-align: middle;
+  font-size: 12px;
+  color: var(--w-soft);
+}
+
+.gStep {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--w-faint);
+  width: 26px;
+}
+
+.gName {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--w-text);
+}
+
+.gApproval {
+  font-family: var(--mono);
+  font-size: 11px;
+  white-space: nowrap;
+  color: var(--w-muted);
+}
+
+.gApprovalOk {
+  color: var(--ok);
+}
+
+.gApprovalBad {
+  color: var(--bad);
+}
+
+.gSub {
+  display: block;
+  font-size: 10px;
+  color: var(--w-faint);
+  margin-top: 2px;
+}
+
+/* ------------------------------------------------------------------- raw */
+.rawCard {
+  background: var(--w-surface);
+  border: 1px solid var(--w-line);
+  border-radius: 10px;
+  overflow: hidden;
+  margin-bottom: 20px;
+}
+
+.rawHead {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 9px 12px;
+  border-bottom: 1px solid var(--w-line);
+  background: var(--w-raise);
+}
+
+.rawTitle {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--w-text);
+}
+
+.rawLabel {
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--w-muted);
+}
+
+.filter {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 12px;
+  border-bottom: 1px solid var(--w-line);
+  flex-wrap: wrap;
+}
+
+.filter input {
+  flex: 1;
+  min-width: 140px;
+  background: var(--w-bg);
+  border: 1px solid var(--w-line-2);
+  border-radius: 6px;
+  padding: 5px 9px;
+  color: var(--w-text);
+  font-family: var(--mono);
+  font-size: 11.5px;
+}
+
+.filter input::placeholder {
+  color: var(--w-faint);
+}
+
+.fchip {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  padding: 3px 7px;
+  border-radius: 5px;
+  border: 1px solid var(--w-line-2);
+  color: var(--w-faint);
+  transition: color 120ms ease, border-color 120ms ease, background 120ms ease,
+    transform 160ms var(--ease-out);
+}
+
+.fchipOn {
+  color: var(--w-text);
+  border-color: #4a443d;
+  background: var(--w-line);
+}
+
+.fchip:active {
+  transform: scale(0.97);
+}
+
+.frow {
+  display: grid;
+  grid-template-columns: 46px 92px 1fr;
+  column-gap: 10px;
+  align-items: baseline;
+  padding: 5px 12px;
+  border-bottom: 1px solid rgb(42 39 36 / 0.6);
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+.frow:last-child {
+  border-bottom: 0;
+}
+
+.frowAt {
+  color: var(--w-faint);
+  font-variant-numeric: tabular-nums;
+}
+
+.frowMsg {
+  color: var(--w-soft);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.feedEmpty {
+  padding: 22px;
+  text-align: center;
+  font-size: 12px;
+  color: var(--w-muted);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pane *,
+  .rail {
+    animation: none !important;
+    transition-duration: 1ms !important;
+  }
+}

--- a/examples/demo-bank/src/components/vendo/workbench/workbench.module.css
+++ b/examples/demo-bank/src/components/vendo/workbench/workbench.module.css
@@ -680,11 +680,6 @@ button.evt:hover {
   white-space: nowrap;
 }
 
-.evtText b {
-  font-weight: 500;
-  color: var(--w-text);
-}
-
 .call {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
@@ -816,8 +811,6 @@ button.evt:hover {
   margin-top: 9px;
 }
 
-/* Anchored to the trigger line, and on whichever side keeps it inside the
-   card — a legend that runs off the edge is worse than no legend. */
 .gaugeMark {
   position: absolute;
   white-space: nowrap;
@@ -829,17 +822,6 @@ button.evt:hover {
 .t {
   width: 100%;
   border-collapse: collapse;
-}
-
-.t th {
-  text-align: left;
-  font-size: 9.5px;
-  letter-spacing: 0.09em;
-  text-transform: uppercase;
-  color: var(--w-muted);
-  font-weight: 500;
-  padding: 0 10px 7px 0;
-  border-bottom: 1px solid var(--w-line);
 }
 
 .t td {
@@ -939,12 +921,6 @@ button.evt:hover {
   border: 1px solid var(--w-line);
   border-radius: 5px;
   padding: 3px 7px;
-}
-
-.pillOff {
-  color: var(--w-faint);
-  background: transparent;
-  border-style: dashed;
 }
 
 .query {

--- a/examples/demo-bank/src/components/vendo/workbench/workbench.module.css
+++ b/examples/demo-bank/src/components/vendo/workbench/workbench.module.css
@@ -36,7 +36,13 @@
 
   position: fixed;
   inset: 0 0 0 auto;
-  z-index: 60;
+  /* Over the overlay. `.fl-overlay-scrim` is a full-viewport click-to-dismiss
+     layer at 2147483000 (2147483002 in takeover) and the panel sits at
+     2147483001, so anything below is not merely dimmed: every click on this pane
+     landed on the scrim and closed the chat instead. The workbench reports on the
+     turn that chat is running, so it has to stay live while the chat is open —
+     and the scrim keeps its dismiss click everywhere the pane is not. */
+  z-index: 2147483003;
   display: flex;
   flex-direction: column;
   width: min(480px, 100vw);
@@ -74,7 +80,8 @@
   position: fixed;
   top: 50%;
   right: 0;
-  z-index: 60;
+  /* Same layer as `.pane` — a rail under the scrim cannot be clicked open. */
+  z-index: 2147483003;
   transform: translateY(-50%);
   display: flex;
   align-items: center;
@@ -531,7 +538,11 @@
 /* -------------------------------------------------------------- timeline */
 .node {
   display: grid;
-  grid-template-columns: 30px 1fr;
+  /* `minmax(0, 1fr)`, never `1fr`: a grid track's automatic minimum is its
+     content's, so a step row whose meta (tokens · duration · stop reason) is
+     wider than the 480px pane pushes the track past the pane instead of letting
+     the row's own ellipsis do the work — and the stop-reason chip clips off. */
+  grid-template-columns: 30px minmax(0, 1fr);
   column-gap: 10px;
 }
 
@@ -921,20 +932,6 @@ button.evt:hover {
   border: 1px solid var(--w-line);
   border-radius: 5px;
   padding: 3px 7px;
-}
-
-.query {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin: 10px 0 6px;
-  font-family: var(--mono);
-  font-size: 11px;
-  color: var(--w-soft);
-}
-
-.queryText {
-  color: var(--info);
 }
 
 .subCard {

--- a/packages/harnesses/src/index.ts
+++ b/packages/harnesses/src/index.ts
@@ -46,7 +46,11 @@ export {
   type HarnessStateStore,
   type HistoryChange,
 } from "./harness-state.js";
-export { THREAD_ID_HEADER, VENDO_STATUS_PART } from "./wire.js";
+export { THREAD_ID_HEADER, VENDO_DEBUG_PART, VENDO_STATUS_PART } from "./wire.js";
+// The dev-only workbench channel's vocabulary (`VENDO_WORKBENCH=1`). Types only:
+// a diagnostics pane has to be able to NAME what it reads off the part, and a
+// wire shape a consumer cannot name is one it has to re-declare and drift from.
+export type { WorkbenchAgent, WorkbenchEvent, WorkbenchPart } from "./workbench.js";
 // The engine the doors share. These used to live in `@vendoai/agent`; they are
 // here because the runtime above is their only long-term caller, and a rail can
 // only drift by being changed for every door at once.

--- a/packages/harnesses/src/runtime.ts
+++ b/packages/harnesses/src/runtime.ts
@@ -54,7 +54,8 @@ import {
 } from "./harness-state.js";
 import { createTurnTools, type MirrorEvent } from "./turn-tools.js";
 import { specificWireErrorMessage } from "./wire-error.js";
-import { TextChannel, writeError, writeMirror, writeStatus, writeTurnError, writeView } from "./wire.js";
+import { emitWorkbench, openWorkbench } from "./workbench.js";
+import { TextChannel, writeDebug, writeError, writeMirror, writeStatus, writeTurnError, writeView } from "./wire.js";
 
 /**
  * `turn.messages` is OURS and read-only (§1). A frozen array still hands out live
@@ -367,6 +368,10 @@ export function createHarnessRuntime(deps: HarnessRuntimeDeps): HarnessRuntime {
         generateId: () => assistantMessageId,
         execute: async ({ writer }) => {
           turnWriter = writer;
+          // The dev-only diagnostics channel, open for exactly this turn. Off
+          // (the production case) this registers nothing and every emit below —
+          // here, in the loop, in the guarded-call path — is a map miss.
+          const closeWorkbench = openWorkbench(turnId, (part) => writeDebug(writer, part));
           const text = new TextChannel(writer);
           const mirror = (event: MirrorEvent): void => {
             // Close the open text part first, so a reply that spans tool calls
@@ -477,6 +482,11 @@ export function createHarnessRuntime(deps: HarnessRuntimeDeps): HarnessRuntime {
                   break;
                 case "error":
                   failure = { message: event.message, ...(event.code === undefined ? {} : { code: event.code }) };
+                  emitWorkbench(turnId, "resident", {
+                    kind: "error",
+                    code: event.code ?? "harness",
+                    message: event.message,
+                  });
                   text.break();
                   surfaced = event.message;
                   // The TRANSCRIPT's failure affordance, and it goes FIRST. The
@@ -522,6 +532,7 @@ export function createHarnessRuntime(deps: HarnessRuntimeDeps): HarnessRuntime {
             // this path lost the one sentence that said what to do about it.
             const message = specificWireErrorMessage(error) ?? HARNESS_FAILED;
             failure = { message, code: "harness" };
+            emitWorkbench(turnId, "resident", { kind: "error", code: "harness", message });
             // Same two carriers as a reported `error` event above — the screen's
             // banner/Retry and the transcript's record. A thrown failure used to
             // be spoken as prose instead, which read as the agent talking, gave
@@ -547,6 +558,7 @@ export function createHarnessRuntime(deps: HarnessRuntimeDeps): HarnessRuntime {
             // approvals a fresh user turn supersedes.
             await abandonUnanswered(deps.guard, input, tools.unansweredApprovals());
             tools.dispose();
+            closeWorkbench();
           }
         },
         onFinish: async ({ messages }) => {

--- a/packages/harnesses/src/turn-tools.ts
+++ b/packages/harnesses/src/turn-tools.ts
@@ -14,6 +14,7 @@ import type {
 } from "@vendoai/core";
 import type { CapabilityMissReporter } from "./capability-miss.js";
 import { guardedCall, previewApproval, type ToolBridgeOptions } from "./tool-bridge.js";
+import { emitWorkbench, workbenchCursor, type WorkbenchEvent } from "./workbench.js";
 
 /**
  * Build contract §1.4 — the frozen bound on an interactive approval wait. A
@@ -74,6 +75,16 @@ export interface TurnToolsOptions {
 
 let counter = 0;
 const mintToolCallId = (): string => `hcall_${(counter += 1)}_${globalThis.crypto.randomUUID()}`;
+
+/** The workbench's account of one call (dev-only; see ./workbench.ts). */
+type ToolFact = Extract<WorkbenchEvent, { kind: "tool" }>;
+
+/** Enough of the arguments to recognize the call and no more — a diagnostics
+ *  part must never become a second copy of a 300KB input. */
+const argsPreview = (args: Json): string => {
+  const text = JSON.stringify(args) ?? "";
+  return text.length <= 200 ? text : `${text.slice(0, 200)}…`;
+};
 
 /**
  * §1.4's race: the approvalId only exists once the guard has been consulted, but
@@ -248,9 +259,28 @@ export function createTurnTools(options: TurnToolsOptions): RuntimeTurnTools {
 
     async call(name, args): Promise<ToolResult> {
       const toolCallId = mintToolCallId();
+      const startedAt = Date.now();
+      // Where the turn is standing when the call BEGINS. A hire runs nested
+      // inside the resident's still-open `hire_subagent` call, so reading the
+      // cursor at the end would file that call under the hire it made.
+      const at = workbenchCursor(options.ctx.turnId);
+      let guard: ToolFact["guard"];
+      let approval: ToolFact["approval"];
       mirror({ kind: "call", toolCallId, name, args });
       const finish = (result: ToolResult, outcome?: ToolOutcome): ToolResult => {
         mirror({ kind: "result", toolCallId, name, result, ...(outcome === undefined ? {} : { outcome }) });
+        if (outcome?.status === "blocked") guard = "block";
+        emitWorkbench(options.ctx.turnId, at.agent, {
+          kind: "tool",
+          step: at.step,
+          toolCallId,
+          name,
+          argsPreview: argsPreview(args),
+          status: result.status,
+          ...(guard === undefined ? {} : { guard }),
+          ...(approval === undefined ? {} : { approval }),
+          durationMs: Date.now() - startedAt,
+        });
         return result;
       };
 
@@ -286,6 +316,8 @@ export function createTurnTools(options: TurnToolsOptions): RuntimeTurnTools {
         const ask = await previewApproval(descriptor, bridge, args, { toolCallId }, (id) => {
           approvalId = id;
         });
+        guard = ask ? "ask" : "run";
+        approval = ask ? undefined : "auto";
 
         if (ask) {
           if (approvalId !== undefined) {
@@ -313,6 +345,7 @@ export function createTurnTools(options: TurnToolsOptions): RuntimeTurnTools {
           // only come from a surface that knows the call is parked.
           mirror({ kind: "approval", toolCallId, approvalId });
           const approved = await waiter.wait(approvalId, approvalWaitMs);
+          approval = approved === undefined ? "timed-out" : approved ? "approved" : "denied";
           if (approved === undefined) {
             return finish({
               status: "denied",

--- a/packages/harnesses/src/turn-tools.ts
+++ b/packages/harnesses/src/turn-tools.ts
@@ -260,9 +260,7 @@ export function createTurnTools(options: TurnToolsOptions): RuntimeTurnTools {
     async call(name, args): Promise<ToolResult> {
       const toolCallId = mintToolCallId();
       const startedAt = Date.now();
-      // Where the turn is standing when the call BEGINS. A hire runs nested
-      // inside the resident's still-open `hire_subagent` call, so reading the
-      // cursor at the end would file that call under the hire it made.
+      // Read BEFORE the call runs, not after — see `workbenchCursor`.
       const at = workbenchCursor(options.ctx.turnId);
       let guard: ToolFact["guard"];
       let approval: ToolFact["approval"];

--- a/packages/harnesses/src/vendo/loop.ts
+++ b/packages/harnesses/src/vendo/loop.ts
@@ -629,9 +629,6 @@ export async function startTurn(options: TurnLoopOptions): Promise<TurnLoop> {
         ...(active === undefined ? {} : { activeTools: active }),
       };
     },
-    // The other half of the workbench's step boundary — the SDK's own per-step
-    // hook, so the loop keeps no bookkeeping of its own beyond the two lines
-    // above.
     onStepFinish: (finished) => {
       debug({
         kind: "step-end",

--- a/packages/harnesses/src/vendo/loop.ts
+++ b/packages/harnesses/src/vendo/loop.ts
@@ -44,6 +44,7 @@ import {
   type CompactionState,
 } from "./compaction.js";
 import { failoverModel, type ResolvedModel } from "./failover.js";
+import { emitWorkbench, type WorkbenchAgent, type WorkbenchEvent } from "../workbench.js";
 
 // AGENT-7: the default agent-loop step cap (unchanged from the previously
 // hardcoded value); hosts raise or lower it via context.maxSteps.
@@ -280,6 +281,9 @@ export interface TurnPromptInput {
    *  summarizer pass is a provider call, and a caller that hung up before the
    *  first token must not keep paying for one (AGENT-3). */
   signal?: AbortSignal;
+  /** The workbench's ear, already bound to the turn and the agent (dev-only; see
+   *  `../workbench.ts`). Unset — every caller but `startTurn` — is silence. */
+  workbench?: (event: WorkbenchEvent) => void;
 }
 
 export interface TurnPrompt {
@@ -355,10 +359,20 @@ export async function turnModelMessages(input: TurnPromptInput): Promise<TurnPro
   // never shrinks — in the one conversion every rail here shares.
   const promptTokens = (): number =>
     estimatePromptTokens({ system, messages: projected(), tools: input.tools ?? {} });
+  /** Shed, and tell the workbench what it cost: whole messages the provider will
+   *  not see. Reasoning and old tool payloads go first and are not counted — a
+   *  message that lost its payload is still a message. */
+  const shed = (budget: number, prompt: number): ModelMessage[] => {
+    const kept = shedToBudget(converted, budget, prompt);
+    if (kept.length < converted.length) {
+      input.workbench?.({ kind: "shed", dropped: converted.length - kept.length });
+    }
+    return kept;
+  };
   // Budgeting runs on the CONVERTED form because that is the form the provider
   // bills, and it runs before the breakpoints below because shedding changes
   // which message is the stable prefix's last one.
-  if (tokenBudget !== undefined) converted = shedToBudget(converted, tokenBudget, promptTokens());
+  if (tokenBudget !== undefined) converted = shed(tokenBudget, promptTokens());
   // The window the model actually has, against the prompt this turn is actually
   // sending. The host's own `historyWindow` slice is already applied above and is
   // not negotiable (Q2b): what the host cut is gone, and this decides about what
@@ -366,6 +380,12 @@ export async function turnModelMessages(input: TurnPromptInput): Promise<TurnPro
   let compacted: CompactionState | undefined;
   if (compaction !== undefined) {
     const tripped = promptTokens();
+    input.workbench?.({
+      kind: "context",
+      estTokens: tripped,
+      windowTokens: compaction.contextWindowTokens,
+      triggerTokens: triggerTokens(compaction),
+    });
     // `force` is the overflow retry's re-entry: the provider has already said no,
     // so the estimate has nothing left to decide.
     if (compaction.force === true || shouldCompact(tripped, compaction)) {
@@ -392,7 +412,7 @@ export async function turnModelMessages(input: TurnPromptInput): Promise<TurnPro
         // caused sheds the history and then stops, still over budget — the old
         // floor charged the messages against the WHOLE window and so quietly shed
         // nothing at all in that case, which is the same blindness one layer down.
-        converted = shedToBudget(converted, triggerTokens(compaction), tripped);
+        converted = shed(triggerTokens(compaction), tripped);
       } else {
         // One pass folded `tail[0..cut)` into whatever the summary already held, so
         // the boundary moves to the newest message that pass read.
@@ -401,6 +421,13 @@ export async function turnModelMessages(input: TurnPromptInput): Promise<TurnPro
         tail = tail.slice(cut);
         converted = await convert(tail);
         compacted = { version: 1, summary: result.summary, boundaryMessageId: absorbed };
+        input.workbench?.({
+          kind: "compaction",
+          // `force` is only ever set by the overflow retry, so it is exactly the
+          // difference between "the estimate said so" and "the provider did".
+          reason: compaction.force === true ? "overflow-retry" : "trigger",
+          summary: result.summary,
+        });
       }
     }
   }
@@ -500,6 +527,10 @@ export interface TurnLoopOptions {
   compaction?: TurnCompaction;
   /** Model messages this turn already produced, for a retry that continues it. */
   resume?: readonly ModelMessage[];
+  /** Which of the turn's loops this drive is, for the workbench's diagnostics
+   *  only (dev-only; see `../workbench.ts`). Defaults to the resident, because a
+   *  caller that has never heard of the workbench is the turn's own thinker. */
+  workbenchAgent?: WorkbenchAgent;
 }
 
 /** The per-turn knobs, one shape for every drive of the loop so no caller can
@@ -548,6 +579,13 @@ function turnModel(options: TurnLoopOptions): LanguageModel {
 
 export async function startTurn(options: TurnLoopOptions): Promise<TurnLoop> {
   const maxSteps = options.context?.maxSteps ?? DEFAULT_MAX_STEPS;
+  /** The workbench's ear for this drive. Off (every production turn) this is a
+   *  map miss and returns; see `../workbench.ts`. */
+  const debug = (event: WorkbenchEvent): void =>
+    emitWorkbench(options.turnId, options.workbenchAgent ?? "resident", event);
+  /** The step the loop is on and when it began — the workbench's only state. */
+  let step = 0;
+  let stepStartedAt = Date.now();
   const { messages: modelMessages, compacted } = await turnModelMessages({
     messages: options.messages,
     system: options.system,
@@ -559,6 +597,7 @@ export async function startTurn(options: TurnLoopOptions): Promise<TurnLoop> {
     ...(options.compaction === undefined ? {} : { compaction: options.compaction }),
     ...(options.resume === undefined ? {} : { resume: options.resume }),
     ...(options.signal === undefined ? {} : { signal: options.signal }),
+    workbench: debug,
   });
   const { activeTools } = options;
   const result = streamText({
@@ -580,10 +619,28 @@ export async function startTurn(options: TurnLoopOptions): Promise<TurnLoop> {
     // the turn with the most to cache had no hook at all. It is returned on
     // every turn now, and the loadout rides the same result rather than growing
     // a second per-step hook beside it.
-    prepareStep: ({ messages }) => ({
-      messages: advanceCacheBreakpoint(messages),
-      ...(activeTools === undefined ? {} : { activeTools: activeTools() }),
-    }),
+    prepareStep: ({ messages, stepNumber }) => {
+      const active = activeTools?.();
+      step = stepNumber;
+      stepStartedAt = Date.now();
+      debug({ kind: "step-start", step, maxSteps, activeTools: active ?? [] });
+      return {
+        messages: advanceCacheBreakpoint(messages),
+        ...(active === undefined ? {} : { activeTools: active }),
+      };
+    },
+    // The other half of the workbench's step boundary — the SDK's own per-step
+    // hook, so the loop keeps no bookkeeping of its own beyond the two lines
+    // above.
+    onStepFinish: (finished) => {
+      debug({
+        kind: "step-end",
+        step,
+        stopReason: finished.finishReason,
+        durationMs: Date.now() - stepStartedAt,
+        usage: { inputTokens: finished.usage.inputTokens, outputTokens: finished.usage.outputTokens },
+      });
+    },
     // AGENT-3: cancellation reaches the provider call itself; the loop never
     // starts another step once the signal fires.
     abortSignal: options.signal,
@@ -598,6 +655,7 @@ export async function startTurn(options: TurnLoopOptions): Promise<TurnLoop> {
       try {
         const [finishReason, steps] = await Promise.all([result.finishReason, result.steps]);
         if (finishReason !== "tool-calls" || steps.length < maxSteps) return undefined;
+        debug({ kind: "step-limit", steps: steps.length });
         return {
           type: "data-vendo-step-limit",
           limit: maxSteps,

--- a/packages/harnesses/src/vendo/vendo.ts
+++ b/packages/harnesses/src/vendo/vendo.ts
@@ -31,6 +31,7 @@ import {
   type VendoToolSearchConfig,
 } from "./tool-search.js";
 import { wireErrorMessage } from "../wire-error.js";
+import { emitWorkbench, type WorkbenchAgent } from "../workbench.js";
 import { harnessAdapters } from "../harness-sandbox.js";
 import type { UsageTotals } from "../runtime.js";
 import {
@@ -364,12 +365,24 @@ async function runSubagent(
     compaction,
     signal: turn.signal,
     turnId: turn.turnId,
+    // A hire shares the resident's turn, so it shares its workbench channel; the
+    // tag is the only thing that tells the two loops apart on it.
+    workbenchAgent: "subagent",
   });
-  const [text, usage] = await Promise.all([loop.result.text, loop.result.totalUsage]);
-  return {
-    summary: text.trim() || "The specialist finished without a summary.",
-    usage: usageOf(usage, model),
-  };
+  const [text, usage, steps] = await Promise.all([
+    loop.result.text,
+    loop.result.totalUsage,
+    loop.result.steps,
+  ]);
+  const summary = text.trim() || "The specialist finished without a summary.";
+  emitWorkbench(turn.turnId, "subagent", {
+    kind: "subagent",
+    label: skill ?? input.instructions.slice(0, 60),
+    steps: steps.length,
+    maxSteps: SUBAGENT_MAX_STEPS,
+    report: summary,
+  });
+  return { summary, usage: usageOf(usage, model) };
 }
 
 export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions> {
@@ -441,6 +454,11 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
       // nothing to discover, so it fills the same object once and stops.)
       const residentTools: ToolSet = {};
       let equipped: string[] = [];
+      // Which loop this drive is, for the workbench only. A CLOSED loadout is the
+      // screen agent's shape (`vendo({ tools, maxSteps })` — packages/vendo's
+      // screen-agent.ts) and an open one is the thread's resident thinker; the
+      // two share a turn and a channel, so something has to name them apart.
+      const workbenchAgent: WorkbenchAgent = deps.tools === undefined ? "resident" : "screen";
       /** Each helper's spend, yielded as its own `usage` event after the stream
        *  drains — the one metering channel every brain has. No receipt path:
        *  per-hire audit rows are gone (Option 1, 2026-08-09), exactly matching
@@ -490,6 +508,18 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
       // included only if it is named. The open path keeps the discovery rail — the
       // listing re-read after every call — and hires by default.
       let activeToolNames: () => string[];
+      /** What the model may pick right now, and what it may not — a fact only
+       *  this file holds, because the loadout is the brain's own strategy. */
+      const emitLoadout = (): void => {
+        const active = activeToolNames();
+        emitWorkbench(turn.turnId, workbenchAgent, {
+          kind: "loadout",
+          active,
+          searchedIn: [...loaded],
+          alwaysActive: active.filter(isAlwaysActive),
+          withheldCount: equipped.filter((name) => !active.includes(name)).length,
+        });
+      };
       if (deps.tools === undefined) {
         const refresh = async (): Promise<void> => {
           equipped = await refreshEquipped(turn, residentTools, refresh);
@@ -523,6 +553,7 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
               // search; re-reading the listing NOW is what makes a found tool
               // callable on the very next step.
               await refresh();
+              emitLoadout();
               return { loaded: matches.map((match) => match.name), tools: matches };
             },
           });
@@ -539,6 +570,7 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
         equipped = await equipClosedLoadout(turn, residentTools, deps.tools, hireSubagent);
         activeToolNames = () => equipped;
       }
+      emitLoadout();
 
       // ONE attempt at the turn. The overflow retry re-enters through the same
       // function so the two attempts cannot drift on any input but the two the
@@ -560,6 +592,7 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
           // §3.5 — the runtime already minted it and put it on the Turn, so
           // passing it is simply true.
           turnId: turn.turnId,
+          workbenchAgent,
           // The loadout, in the loop's own vocabulary: `prepareStep` re-reads
           // this each step and restricts what the model may PICK, so a tool
           // searched in through `find_tools` is choosable on the next step and

--- a/packages/harnesses/src/wire.ts
+++ b/packages/harnesses/src/wire.ts
@@ -27,6 +27,7 @@ import {
 } from "@vendoai/core";
 import type { UIMessage, UIMessageStreamWriter } from "ai";
 import type { MirrorEvent } from "./turn-tools.js";
+import type { WorkbenchPart } from "./workbench.js";
 
 /**
  * The one wire name this lane adds. Transient, so it is screen-only by the SDK's
@@ -34,6 +35,15 @@ import type { MirrorEvent } from "./turn-tools.js";
  * for. It lives here rather than in core because §1.6 freezes stream-parts.ts.
  */
 export const VENDO_STATUS_PART = "data-vendo-status" as const;
+
+/**
+ * The workbench's part — dev-only diagnostics (`VENDO_WORKBENCH=1`), on the same
+ * transient mechanism and for the same reason: a fact about how the turn is
+ * thinking is screen-only by definition, and persisting one would put the
+ * machine's internals in the user's history forever. Off, nothing opens a channel
+ * and none of these are ever written (see ./workbench.ts).
+ */
+export const VENDO_DEBUG_PART = "data-vendo-debug" as const;
 
 /** The effective thread id every turn response carries (03 §1), so a caller
  *  that began without one can adopt it. Every door that serves a turn stamps the
@@ -97,6 +107,11 @@ export function writeStatus(writer: Writer, beat: { label: string; phase?: BeatP
     },
     transient: true,
   } as never);
+}
+
+/** One workbench fact, on the same transient mechanism as `status` above. */
+export function writeDebug(writer: Writer, part: WorkbenchPart): void {
+  writer.write({ type: VENDO_DEBUG_PART, data: part, transient: true } as never);
 }
 
 /** §1.6 hot-path render seam — today's part, today's stable per-app stream id. */

--- a/packages/harnesses/src/workbench.ts
+++ b/packages/harnesses/src/workbench.ts
@@ -1,0 +1,129 @@
+/**
+ * The workbench — a DEV-ONLY diagnostics channel for one turn.
+ *
+ * A turn's loop already holds every fact a developer wants while watching it
+ * think: which step it is on, what it may pick from, what the guard said about a
+ * call, how big the prompt got, what it summarized away. None of it is a product
+ * surface — it is the machine talking about itself — so it rides the wire the
+ * same way `status` does: a TRANSIENT `data-vendo-debug` part, which the ai-SDK
+ * delivers to the client and never adds to message history (see
+ * `VENDO_STATUS_PART` in ./wire.ts). Nothing here is ever persisted.
+ *
+ * The whole gate is `VENDO_WORKBENCH=1` on the SERVER, read once per turn by
+ * {@link openWorkbench}. Unset, no channel is registered, so every {@link
+ * emitWorkbench} is a map miss and returns — there is no second flag to check and
+ * no part can reach the wire.
+ */
+import type { TurnId } from "@vendoai/core";
+
+/** Which loop is speaking. The resident is the turn's own thinker; `screen` is
+ *  the closed-loadout drive that paints; `subagent` is a hire, which shares the
+ *  resident's turn and therefore its channel. */
+export type WorkbenchAgent = "resident" | "screen" | "subagent";
+
+/** One diagnostic fact. Additive by design — a new member is a pane that has not
+ *  learned to render it yet, never a break. */
+export type WorkbenchEvent =
+  | { kind: "step-start"; step: number; maxSteps: number; activeTools: readonly string[] }
+  | {
+      kind: "step-end";
+      step: number;
+      stopReason: string;
+      durationMs: number;
+      usage?: { inputTokens?: number; outputTokens?: number };
+    }
+  | {
+      kind: "tool";
+      step: number;
+      toolCallId: string;
+      name: string;
+      argsPreview: string;
+      status: "ok" | "denied" | "error";
+      guard?: "run" | "ask" | "block";
+      approval?: "auto" | "approved" | "timed-out" | "denied";
+      durationMs: number;
+    }
+  | { kind: "context"; estTokens: number; windowTokens: number; triggerTokens: number }
+  | { kind: "compaction"; reason: "trigger" | "overflow-retry"; summary: string }
+  | { kind: "shed"; dropped: number }
+  | {
+      kind: "loadout";
+      active: readonly string[];
+      searchedIn: readonly string[];
+      alwaysActive: readonly string[];
+      withheldCount: number;
+    }
+  | { kind: "subagent"; label: string; steps: number; maxSteps: number; report?: string }
+  | { kind: "error"; code: string; message: string }
+  | { kind: "step-limit"; steps: number };
+
+/** What one `data-vendo-debug` part carries. `seq` is per TURN — a hire's events
+ *  interleave with the resident's on one ordered stream, which is the order they
+ *  actually happened in. */
+export interface WorkbenchPart {
+  turnId: string;
+  seq: number;
+  at: number;
+  agent: WorkbenchAgent;
+  event: WorkbenchEvent;
+}
+
+interface Channel {
+  write: (part: WorkbenchPart) => void;
+  seq: number;
+  /** The last emitter and the step it was on — see {@link workbenchCursor}. */
+  agent: WorkbenchAgent;
+  step: number;
+}
+
+const channels = new Map<TurnId, Channel>();
+
+/**
+ * Open the turn's channel, and hand back its closer.
+ *
+ * The flag is read HERE and nowhere else: a turn that starts with the workbench
+ * off registers nothing, so it cannot be turned on halfway through a turn and
+ * cannot emit half a stream.
+ */
+export function openWorkbench(turnId: TurnId, write: (part: WorkbenchPart) => void): () => void {
+  // `typeof process` first: this package bundles for a Worker target too (the
+  // portability gate checks it), and a runtime without `process` at all would
+  // otherwise take the turn down before it started.
+  const flag = typeof process === "undefined" ? undefined : process.env.VENDO_WORKBENCH;
+  if (flag !== "1") return () => {};
+  channels.set(turnId, { write, seq: 0, agent: "resident", step: 0 });
+  return () => {
+    channels.delete(turnId);
+  };
+}
+
+/** One fact, if anyone is listening. A closed turn (or a turn that never opened
+ *  a channel, which is every turn in production) costs one map lookup. */
+export function emitWorkbench(
+  turnId: TurnId | undefined,
+  agent: WorkbenchAgent,
+  event: WorkbenchEvent,
+): void {
+  if (turnId === undefined) return;
+  const channel = channels.get(turnId);
+  if (channel === undefined) return;
+  channel.agent = agent;
+  if (event.kind === "step-start") channel.step = event.step;
+  channel.write({ turnId, seq: channel.seq, at: Date.now(), agent, event });
+  channel.seq += 1;
+}
+
+/**
+ * Where the turn is standing right now, for a call site that holds no step of its
+ * own — the guarded-call path serves the resident, the screen agent and a hire
+ * through one function and cannot tell them apart.
+ *
+ * Read at the START of a call, so a hire's own tool events carry the hire while
+ * the `hire_subagent` call that is still open above them carries the resident.
+ */
+export function workbenchCursor(turnId: TurnId | undefined): { agent: WorkbenchAgent; step: number } {
+  const channel = turnId === undefined ? undefined : channels.get(turnId);
+  return channel === undefined
+    ? { agent: "resident", step: 0 }
+    : { agent: channel.agent, step: channel.step };
+}

--- a/packages/harnesses/src/workbench.ts
+++ b/packages/harnesses/src/workbench.ts
@@ -1,12 +1,9 @@
 /**
  * The workbench — a DEV-ONLY diagnostics channel for one turn.
  *
- * A turn's loop already holds every fact a developer wants while watching it
- * think: which step it is on, what it may pick from, what the guard said about a
- * call, how big the prompt got, what it summarized away. None of it is a product
- * surface — it is the machine talking about itself — so it rides the wire the
- * same way `status` does: a TRANSIENT `data-vendo-debug` part, which the ai-SDK
- * delivers to the client and never adds to message history (see
+ * The machine talking about itself is never a product surface, so it rides the
+ * wire the way `status` does: a TRANSIENT `data-vendo-debug` part, which the
+ * ai-SDK delivers to the client and never adds to message history (see
  * `VENDO_STATUS_PART` in ./wire.ts). Nothing here is ever persisted.
  *
  * The whole gate is `VENDO_WORKBENCH=1` on the SERVER, read once per turn by
@@ -116,10 +113,9 @@ export function emitWorkbench(
 /**
  * Where the turn is standing right now, for a call site that holds no step of its
  * own — the guarded-call path serves the resident, the screen agent and a hire
- * through one function and cannot tell them apart.
- *
- * Read at the START of a call, so a hire's own tool events carry the hire while
- * the `hire_subagent` call that is still open above them carries the resident.
+ * through one function and cannot tell them apart. Read at the START of a call,
+ * so a hire's own tool events carry the hire while the `hire_subagent` call still
+ * open above them carries the resident.
  */
 export function workbenchCursor(turnId: TurnId | undefined): { agent: WorkbenchAgent; step: number } {
   const channel = turnId === undefined ? undefined : channels.get(turnId);

--- a/packages/harnesses/tests/workbench.test.ts
+++ b/packages/harnesses/tests/workbench.test.ts
@@ -1,0 +1,204 @@
+/**
+ * The workbench — the dev-only diagnostics channel (`VENDO_WORKBENCH=1`).
+ *
+ * Everything here goes through the REAL wire: a real `vendo()` turn on the real
+ * runtime, written by the real `UIMessageStreamWriter` and read back off the real
+ * SSE response. A suite that collected the facts from the sink directly would
+ * prove the sink talks to itself — the claim is that a fact a loop emitted
+ * arrives at a browser, and only the wire can say that.
+ *
+ * Two claims, and the first one is the product one:
+ *  - flag unset, the channel does not exist: no part, anywhere, ever;
+ *  - flag set, the turn's own steps, calls and compaction arrive in the order
+ *    they happened, numbered, under this turn's id.
+ */
+import type { Harness, ThreadId } from "@vendoai/core";
+import { simulateReadableStream, MockLanguageModelV3 } from "ai/test";
+import type { LanguageModel, UIMessage } from "ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarnessRuntime, type TurnRunInput } from "../src/runtime.js";
+import { vendo, type VendoHarnessOptions } from "../src/vendo/vendo.js";
+import { VENDO_DEBUG_PART } from "../src/wire.js";
+import type { WorkbenchEvent, WorkbenchPart } from "../src/workbench.js";
+import {
+  boundRegistry,
+  ctx,
+  readSse,
+  readTool,
+  scriptedModel,
+  seats,
+  testGuard,
+  testSkills,
+  testTranscript,
+  testWorkspace,
+  textTurn,
+  toolCallTurn,
+  userMessage,
+  ZERO_USAGE,
+  type TestTool,
+} from "../src/test-doubles.test-util.js";
+
+const THREAD = "thr_workbench" as ThreadId;
+
+afterEach(() => {
+  delete process.env.VENDO_WORKBENCH;
+});
+
+/** One `vendo()` turn on the real runtime, drained as a host route drains it. */
+function fixture(model: LanguageModel, tools: Record<string, TestTool> = {}) {
+  const guard = testGuard();
+  const transcript = testTranscript();
+  const runtime = createHarnessRuntime({
+    tools: boundRegistry(tools, guard),
+    guard,
+    skills: testSkills(),
+    transcript,
+  });
+  const run = async (
+    over: Partial<TurnRunInput<VendoHarnessOptions>> = {},
+  ): Promise<Array<Record<string, unknown>>> =>
+    readSse(await runtime.run<VendoHarnessOptions>({
+      harness: vendo() as Harness<VendoHarnessOptions>,
+      threadId: THREAD,
+      messages: [userMessage("m1", "what is my balance?")],
+      ctx: ctx(),
+      workspace: testWorkspace(),
+      models: seats(model),
+      interactive: true,
+      ...over,
+    }));
+  return { run, transcript };
+}
+
+/** The workbench's own parts, off the wire, in wire order. */
+const facts = (parts: Array<Record<string, unknown>>): WorkbenchPart[] =>
+  parts
+    .filter((part) => part.type === VENDO_DEBUG_PART)
+    .map((part) => part.data as WorkbenchPart);
+
+const kinds = (parts: WorkbenchPart[]): WorkbenchEvent["kind"][] =>
+  parts.map((part) => part.event.kind);
+
+const only = <K extends WorkbenchEvent["kind"]>(
+  parts: WorkbenchPart[],
+  kind: K,
+): Array<Extract<WorkbenchEvent, { kind: K }>> =>
+  parts
+    .map((part) => part.event)
+    .filter((event): event is Extract<WorkbenchEvent, { kind: K }> => event.kind === kind);
+
+/** A turn that calls one tool and then answers. */
+const answeringModel = (): LanguageModel =>
+  scriptedModel([toolCallTurn("balance", { account: "checking" }), textTurn("You have $10.")]);
+
+const balanceTool = (): Record<string, TestTool> => ({
+  balance: { descriptor: readTool("balance"), execute: () => ({ amount: 10 }) },
+});
+
+describe("the flag is the whole gate", () => {
+  it("emits NOTHING when VENDO_WORKBENCH is unset — no part reaches the wire", async () => {
+    const f = fixture(answeringModel(), balanceTool());
+    const parts = await f.run();
+    // The turn really ran: a tool was called and an answer came back.
+    expect(parts.some((part) => part.type === "tool-output-available")).toBe(true);
+    expect(facts(parts)).toEqual([]);
+    expect(parts.some((part) => String(part.type).includes("debug"))).toBe(false);
+  });
+});
+
+describe("with the flag set, the turn narrates itself", () => {
+  it("puts step boundaries and the guarded call on the wire, numbered, under one turn id", async () => {
+    process.env.VENDO_WORKBENCH = "1";
+    const f = fixture(answeringModel(), balanceTool());
+    const parts = facts(await f.run());
+    expect(parts.length).toBeGreaterThan(0);
+
+    // One turn, one sequence: `seq` is dense and ordered, and every part names
+    // the turn the runtime minted.
+    const turnIds = new Set(parts.map((part) => part.turnId));
+    expect(turnIds.size).toBe(1);
+    expect([...turnIds][0]).toMatch(/^trn_[0-9a-f]{32}$/);
+    expect(parts.map((part) => part.seq)).toEqual(parts.map((_part, index) => index));
+    expect(parts.every((part) => part.agent === "resident")).toBe(true);
+    expect(parts.every((part) => part.at > 0)).toBe(true);
+
+    // Two steps: the tool call, then the answer.
+    expect(only(parts, "step-start").map((event) => event.step)).toEqual([0, 1]);
+    const firstStep = only(parts, "step-start")[0]!;
+    expect(firstStep.maxSteps).toBe(20);
+    expect(firstStep.activeTools).toContain("balance");
+    expect(only(parts, "step-end").map((event) => event.stopReason)).toEqual(["tool-calls", "stop"]);
+    expect(only(parts, "step-end").every((event) => event.durationMs >= 0)).toBe(true);
+
+    // The call, as the guarded path actually decided it.
+    const call = only(parts, "tool")[0]!;
+    expect(call.name).toBe("balance");
+    expect(call.status).toBe("ok");
+    expect(call.guard).toBe("run");
+    expect(call.approval).toBe("auto");
+    expect(call.argsPreview).toContain("checking");
+    expect(call.step).toBe(0);
+    // …and it is filed inside the step that made it, not after the step ended.
+    expect(kinds(parts).indexOf("tool")).toBeLessThan(kinds(parts).indexOf("step-end"));
+
+    // The loadout the brain equipped, and the window it measured itself against.
+    const loadout = only(parts, "loadout")[0]!;
+    expect(loadout.active).toContain("balance");
+    const context = only(parts, "context")[0]!;
+    expect(context.triggerTokens).toBeLessThan(context.windowTokens);
+    expect(context.estTokens).toBeGreaterThan(0);
+  });
+
+  it("is screen-only: not one debug part lands in the transcript", async () => {
+    process.env.VENDO_WORKBENCH = "1";
+    const f = fixture(answeringModel(), balanceTool());
+    await f.run();
+    const stored = await f.transcript.list({ kind: "user", subject: "u1" }, THREAD);
+    expect(JSON.stringify(stored)).not.toContain(VENDO_DEBUG_PART);
+    expect(JSON.stringify(stored)).not.toContain("step-start");
+  });
+});
+
+/** A thread big enough that the tail alone exceeds the preserved budget, so the
+ *  cut has something above it to summarize. */
+const hugeThread = (): UIMessage[] => [
+  userMessage("m1", `JANUARY STATEMENTS ${"o".repeat(60_000)}`),
+  { id: "m2", role: "assistant", parts: [{ type: "text", text: `NOTES ${"a".repeat(60_000)}` }] },
+  userMessage("m3", "so what is my balance?"),
+];
+
+/** A seat that summarizes on `generateText` and answers on `streamText` — the
+ *  thread's own seat does both, which is what compaction is. */
+const compactingSeat = (summary: string, reply: string): LanguageModel =>
+  new MockLanguageModelV3({
+    doGenerate: async () => ({
+      content: [{ type: "text" as const, text: summary }],
+      finishReason: { unified: "stop" as const, raw: undefined },
+      usage: ZERO_USAGE,
+      warnings: [],
+    }),
+    doStream: async () => ({ stream: simulateReadableStream({ chunks: textTurn(reply) }) }),
+  }) as unknown as LanguageModel;
+
+describe("compaction", () => {
+  it("reports the summary the summarizer actually wrote", async () => {
+    process.env.VENDO_WORKBENCH = "1";
+    const summary = "## Goal\nThe user is reconciling January statements.";
+    const f = fixture(compactingSeat(summary, "You have $10."));
+    const history = hugeThread();
+    // The past arrives from the store, as a real thread's does — a client may not
+    // post the assistant's own words (`validateUpsert`).
+    for (const [seq, message] of history.slice(0, -1).entries()) {
+      await f.transcript.upsert({ kind: "user", subject: "u1" }, THREAD, message, seq);
+    }
+    const parts = facts(await f.run({
+      messages: history,
+      // A window this thread cannot fit in, so the trigger trips on the estimate.
+      options: { contextWindowTokens: 1_000 },
+    }));
+    const compaction = only(parts, "compaction")[0];
+    expect(compaction).toBeDefined();
+    expect(compaction!.reason).toBe("trigger");
+    expect(compaction!.summary).toBe(summary);
+  });
+});

--- a/packages/harnesses/tests/workbench.test.ts
+++ b/packages/harnesses/tests/workbench.test.ts
@@ -159,6 +159,67 @@ describe("with the flag set, the turn narrates itself", () => {
   });
 });
 
+describe("the two endings a turn can have that its steps do not say", () => {
+  it("names the step cap that stopped the turn", async () => {
+    process.env.VENDO_WORKBENCH = "1";
+    // One permitted step, and a model that still wanted a tool call after it: the
+    // turn ended because of the cap, not because the model was finished.
+    const f = fixture(scriptedModel([toolCallTurn("balance", { account: "checking" })]), balanceTool());
+    const parts = facts(await f.run({ options: { maxSteps: 1 } }));
+    expect(only(parts, "step-start").map((event) => event.maxSteps)).toEqual([1]);
+    expect(only(parts, "step-limit")).toEqual([{ kind: "step-limit", steps: 1 }]);
+    // …and it is the LAST thing the turn says: the cap is only knowable once the
+    // stream has drained.
+    expect(kinds(parts).at(-1)).toBe("step-limit");
+  });
+
+  it("puts a hired sub-run on the resident's own channel, under its own seat", async () => {
+    process.env.VENDO_WORKBENCH = "1";
+    // Three provider calls, in the order the turn makes them: the resident hires,
+    // the specialist answers, the resident answers. `hire_subagent` is the
+    // harness's own hand, so it is spelled here rather than imported.
+    const f = fixture(
+      scriptedModel([
+        toolCallTurn("hire_subagent", { instructions: "check the issuer rules" }),
+        textTurn("Rule R-118 rejects that category."),
+        textTurn("An issuer rule is blocking the card."),
+      ]),
+      balanceTool(),
+    );
+    const parts = facts(await f.run());
+
+    const hire = only(parts, "subagent");
+    expect(hire).toEqual([{
+      kind: "subagent",
+      label: "check the issuer rules",
+      steps: 1,
+      maxSteps: 12,
+      report: "Rule R-118 rejects that category.",
+    }]);
+
+    // One turn, one dense sequence — the hire's parts are interleaved with the
+    // resident's rather than carried on a channel of their own.
+    expect(new Set(parts.map((part) => part.turnId)).size).toBe(1);
+    expect(parts.map((part) => part.seq)).toEqual(parts.map((_part, index) => index));
+    const seats = parts.map((part) => part.agent);
+    expect(new Set(seats)).toEqual(new Set(["resident", "subagent"]));
+    // The hire's whole run is filed INSIDE a resident step: the resident is still
+    // speaking after the specialist has reported.
+    expect(seats.slice(seats.lastIndexOf("subagent") + 1)).toContain("resident");
+
+    // Each seat counts its OWN steps from zero, which is the only thing that keeps
+    // the resident's step 0 and the hire's step 0 apart on one stream.
+    const seat = (agent: WorkbenchPart["agent"]) => parts.filter((part) => part.agent === agent);
+    expect(only(seat("resident"), "step-start").map((event) => event.step)).toEqual([0, 1]);
+    expect(only(seat("subagent"), "step-start").map((event) => event.step)).toEqual([0]);
+    // The hire builds its own prompt, so it measures its own window too.
+    expect(only(seat("subagent"), "context")).toHaveLength(1);
+    // …and the hiring call itself never reaches the wire: a hand runs in-process
+    // and only `turn.tools.call()` is a `tool` fact.
+    expect(only(parts, "tool").map((event) => event.name)).not.toContain("hire_subagent");
+  });
+});
+
 /** A thread big enough that the tail alone exceeds the preserved budget, so the
  *  cut has something above it to summarize. */
 const hugeThread = (): UIMessage[] => [

--- a/packages/ui/src/chrome/workbench-store.ts
+++ b/packages/ui/src/chrome/workbench-store.ts
@@ -113,16 +113,13 @@ function notify(): void {
 export function publishWorkbenchPart(chunk: { type: string; data?: unknown }): void {
   const part = workbenchPart(chunk);
   if (part === undefined) return;
-  const parts = byTurn.get(part.turnId);
-  if (parts === undefined) {
-    byTurn.set(part.turnId, [part]);
-  } else {
-    const at = parts.findIndex(existing => existing.seq > part.seq);
-    if (at === -1) parts.push(part);
-    else parts.splice(at, 0, part);
-  }
-  // Turns keep the order their first part arrived in; every snapshot is fresh
-  // so a reader can compare identities to spot new news.
+  const parts = byTurn.get(part.turnId) ?? [];
+  const at = parts.findIndex(existing => existing.seq > part.seq);
+  parts.splice(at === -1 ? parts.length : at, 0, part);
+  // `set` on a key the map already holds leaves its position alone, so turns
+  // keep the order their first part arrived in; every snapshot is fresh so a
+  // reader can compare identities to spot new news.
+  byTurn.set(part.turnId, parts);
   feed = [...byTurn].map(([turnId, list]) => ({ turnId, parts: [...list] }));
   notify();
 }

--- a/packages/ui/src/chrome/workbench-store.ts
+++ b/packages/ui/src/chrome/workbench-store.ts
@@ -1,0 +1,149 @@
+/**
+ * The workbench feed: what the harness says about ITSELF while a turn runs,
+ * for a dev-only surface to read.
+ *
+ * The channel is the transient `data-vendo-debug` part, so the same rule the
+ * beats live under applies here — a diagnostic in `message.parts` would be
+ * persisted history, and a diagnostic is not history. `onData` hands the chunk
+ * over and the SDK drops it; this module is where it lands.
+ *
+ * A module singleton for the same reason `run-activity` is one: the reader is a
+ * pane docked OUTSIDE the conversation's React tree, so the two cannot share
+ * state through a provider.
+ *
+ * Facts only. Parts are kept per turn and ordered by the producer's own `seq`
+ * (never by arrival — a subagent's parts interleave with the turn's own), and
+ * nothing here derives, repairs or invents a field the harness did not send.
+ */
+import { useSyncExternalStore } from "react";
+
+/** One thing the harness did, as it reported it. The producer pins this shape
+    on the wire; the receiver reads it as sent. */
+export type WorkbenchEvent =
+  | { kind: "step-start"; step: number; maxSteps: number; activeTools: readonly string[] }
+  | { kind: "step-end"; step: number; stopReason: string; durationMs: number;
+      usage?: { inputTokens?: number; outputTokens?: number } }
+  | { kind: "tool"; step: number; toolCallId: string; name: string; argsPreview: string;
+      status: "ok" | "denied" | "error"; guard?: "run" | "ask" | "block";
+      approval?: "auto" | "approved" | "timed-out" | "denied"; durationMs: number }
+  | { kind: "context"; estTokens: number; windowTokens: number; triggerTokens: number }
+  | { kind: "compaction"; reason: "trigger" | "overflow-retry"; summary: string }
+  | { kind: "shed"; dropped: number }
+  | { kind: "loadout"; active: readonly string[]; searchedIn: readonly string[];
+      alwaysActive: readonly string[]; withheldCount: number }
+  | { kind: "subagent"; label: string; steps: number; maxSteps: number; report?: string }
+  | { kind: "error"; code: string; message: string }
+  | { kind: "step-limit"; steps: number };
+
+/** One event, addressed: whose turn, where in it, and which agent spoke. */
+export type WorkbenchPart = {
+  turnId: string;
+  seq: number;
+  at: number;
+  agent: "resident" | "screen" | "subagent";
+  event: WorkbenchEvent;
+};
+
+/** One turn's parts, oldest `seq` first. */
+export interface WorkbenchTurn {
+  turnId: string;
+  parts: readonly WorkbenchPart[];
+}
+
+/** Written out rather than imported for the same reason `data-vendo-status` is
+    in `use-vendo-thread`: the constant lives in @vendoai/harnesses, and
+    @vendoai/ui may depend on core alone (scripts/dependency-guard.mjs). */
+const DEBUG_PART = "data-vendo-debug";
+
+/** The three seats and the ten kinds, as runtime sets. `Record<…, true>` so the
+    build breaks if either closed union gains or loses a member. */
+const AGENTS: Record<WorkbenchPart["agent"], true> = { resident: true, screen: true, subagent: true };
+const EVENT_KINDS: Record<WorkbenchEvent["kind"], true> = {
+  "step-start": true,
+  "step-end": true,
+  tool: true,
+  context: true,
+  compaction: true,
+  shed: true,
+  loadout: true,
+  subagent: true,
+  error: true,
+  "step-limit": true,
+};
+
+const NO_TURNS: readonly WorkbenchTurn[] = [];
+
+const byTurn = new Map<string, WorkbenchPart[]>();
+const listeners = new Set<() => void>();
+let feed: readonly WorkbenchTurn[] = NO_TURNS;
+
+/**
+ * A chunk, after the receiver has decided it is a part it can file. The
+ * ADDRESS is the whole requirement — a chunk the pane cannot place in a turn,
+ * in order, under a seat, is not a diagnostic it can show. The event's own
+ * fields are read as sent (the kind is checked, its payload is not repaired):
+ * the producer owns the shape, and a receiver that patched it would be the
+ * author of a fact the harness never reported.
+ */
+function workbenchPart(chunk: { type: string; data?: unknown }): WorkbenchPart | undefined {
+  if (chunk.type !== DEBUG_PART) return undefined;
+  if (typeof chunk.data !== "object" || chunk.data === null) return undefined;
+  const candidate = chunk.data as Partial<WorkbenchPart>;
+  if (typeof candidate.turnId !== "string" || candidate.turnId.length === 0) return undefined;
+  if (typeof candidate.seq !== "number" || typeof candidate.at !== "number") return undefined;
+  if (typeof candidate.agent !== "string" || !Object.hasOwn(AGENTS, candidate.agent)) return undefined;
+  const event = candidate.event as { kind?: unknown } | undefined;
+  if (typeof event !== "object" || event === null) return undefined;
+  if (typeof event.kind !== "string" || !Object.hasOwn(EVENT_KINDS, event.kind)) return undefined;
+  return {
+    turnId: candidate.turnId,
+    seq: candidate.seq,
+    at: candidate.at,
+    agent: candidate.agent,
+    event: event as WorkbenchEvent,
+  };
+}
+
+function notify(): void {
+  for (const listener of listeners) listener();
+}
+
+/** One `onData` chunk, offered. Anything that is not a debug part is ignored,
+ *  so the caller needs no branch of its own. */
+export function publishWorkbenchPart(chunk: { type: string; data?: unknown }): void {
+  const part = workbenchPart(chunk);
+  if (part === undefined) return;
+  const parts = byTurn.get(part.turnId);
+  if (parts === undefined) {
+    byTurn.set(part.turnId, [part]);
+  } else {
+    const at = parts.findIndex(existing => existing.seq > part.seq);
+    if (at === -1) parts.push(part);
+    else parts.splice(at, 0, part);
+  }
+  // Turns keep the order their first part arrived in; every snapshot is fresh
+  // so a reader can compare identities to spot new news.
+  feed = [...byTurn].map(([turnId, list]) => ({ turnId, parts: [...list] }));
+  notify();
+}
+
+export function subscribeWorkbench(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function workbenchFeed(): readonly WorkbenchTurn[] {
+  return feed;
+}
+
+/** Test/host teardown: forget every turn. */
+export function resetWorkbench(): void {
+  byTurn.clear();
+  feed = NO_TURNS;
+  notify();
+}
+
+/** Every turn the harness has reported diagnostics for, oldest turn first. */
+export function useWorkbenchFeed(): readonly WorkbenchTurn[] {
+  return useSyncExternalStore(subscribeWorkbench, workbenchFeed, workbenchFeed);
+}

--- a/packages/ui/src/hooks/use-vendo-thread.ts
+++ b/packages/ui/src/hooks/use-vendo-thread.ts
@@ -13,6 +13,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useVendoProvider } from "../context.js";
 import { currentSituation } from "../situation.js";
 import { publishThreadRun, retireThreadRun, type VendoBeat } from "../chrome/run-activity.js";
+import { publishWorkbenchPart } from "../chrome/workbench-store.js";
 
 export type VendoThreadApproval = ToolUIPart | DynamicToolUIPart | VendoApprovalPart;
 
@@ -173,6 +174,11 @@ export function useVendoThread(threadId?: string) {
     onData: chunk => {
       const beat = vendoBeat(chunk);
       if (beat !== undefined) setBeats(current => [...current, beat]);
+      // §3.4's sibling channel: `data-vendo-debug` carries what the HARNESS did,
+      // for the dev-only workbench. Transient by the same construction — it
+      // lands in a module store, never in `message.parts`. Non-debug chunks are
+      // ignored there, so this needs no branch here.
+      publishWorkbenchPart(chunk);
     },
   });
   const running = chat.status === "submitted" || chat.status === "streaming";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -14,6 +14,16 @@ export type { VendoAppEmbedProps, VendoApprovalEmbedProps, VendoApprovalEmbedSta
 // a BYO chat page needs only `@vendoai/ui`.
 export { VendoAppEmbed, VendoApprovalEmbed, VendoToolResult } from "./chrome/embeds.js";
 export * from "./hooks/index.js";
+// Dev-only rails: the `data-vendo-debug` feed a host's workbench pane reads,
+// and the check that decides whether such a surface renders at all.
+export { developmentMode } from "./chrome/dev-mode.js";
+export {
+  publishWorkbenchPart,
+  useWorkbenchFeed,
+  type WorkbenchEvent,
+  type WorkbenchPart,
+  type WorkbenchTurn,
+} from "./chrome/workbench-store.js";
 export { announcePin, onPinAnnounced } from "./pin-events.js";
 export { defaultVendoTheme, resolveTheme, themeCssVariables } from "./theme.js";
 export * from "./wire-types.js";

--- a/packages/ui/test/chrome/workbench-store.test.ts
+++ b/packages/ui/test/chrome/workbench-store.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  publishWorkbenchPart,
+  resetWorkbench,
+  subscribeWorkbench,
+  workbenchFeed,
+  type WorkbenchEvent,
+  type WorkbenchPart,
+} from "../../src/chrome/workbench-store.js";
+
+afterEach(() => resetWorkbench());
+
+function chunk(part: Partial<WorkbenchPart> & { event?: unknown }, type = "data-vendo-debug") {
+  return { type, data: { turnId: "thr_a", seq: 1, at: 1_000, agent: "resident", ...part } };
+}
+
+const STEP_START: WorkbenchEvent = { kind: "step-start", step: 1, maxSteps: 20, activeTools: ["find_tools"] };
+const STEP_END: WorkbenchEvent = { kind: "step-end", step: 1, stopReason: "toolUse", durationMs: 940 };
+
+describe("workbench store", () => {
+  it("files a debug part under its turn and hands it back", () => {
+    publishWorkbenchPart(chunk({ event: STEP_START }));
+    expect(workbenchFeed()).toEqual([
+      { turnId: "thr_a", parts: [{ turnId: "thr_a", seq: 1, at: 1_000, agent: "resident", event: STEP_START }] },
+    ]);
+  });
+
+  it("orders a turn's parts by seq, not by arrival", () => {
+    publishWorkbenchPart(chunk({ seq: 3, event: { kind: "shed", dropped: 2 } }));
+    publishWorkbenchPart(chunk({ seq: 1, event: STEP_START }));
+    publishWorkbenchPart(chunk({ seq: 2, agent: "subagent", event: { kind: "subagent", label: "issuer rules", steps: 7, maxSteps: 12 } }));
+    expect(workbenchFeed()[0]!.parts.map(part => part.seq)).toEqual([1, 2, 3]);
+  });
+
+  it("keys by turn, keeping turns in the order their first part arrived", () => {
+    publishWorkbenchPart(chunk({ turnId: "thr_b", event: STEP_START }));
+    publishWorkbenchPart(chunk({ turnId: "thr_a", event: STEP_START }));
+    publishWorkbenchPart(chunk({ turnId: "thr_b", seq: 2, event: STEP_END }));
+    const feed = workbenchFeed();
+    expect(feed.map(turn => turn.turnId)).toEqual(["thr_b", "thr_a"]);
+    expect(feed[0]!.parts).toHaveLength(2);
+    expect(feed[1]!.parts).toHaveLength(1);
+  });
+
+  it("ignores chunks that are not debug parts, and parts it cannot address", () => {
+    publishWorkbenchPart(chunk({ event: STEP_START }, "data-vendo-status"));
+    publishWorkbenchPart({ type: "data-vendo-debug", data: "not an object" });
+    publishWorkbenchPart(chunk({ turnId: "", event: STEP_START }));
+    publishWorkbenchPart(chunk({ seq: "1" as unknown as number, event: STEP_START }));
+    publishWorkbenchPart(chunk({ agent: "operator" as WorkbenchPart["agent"], event: STEP_START }));
+    publishWorkbenchPart(chunk({ event: { kind: "telepathy" } }));
+    publishWorkbenchPart(chunk({}));
+    expect(workbenchFeed()).toEqual([]);
+  });
+
+  it("notifies subscribers on every filed part and stops once unsubscribed", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeWorkbench(listener);
+    publishWorkbenchPart(chunk({ event: STEP_START }));
+    publishWorkbenchPart(chunk({ event: STEP_START }, "data-vendo-status"));
+    expect(listener).toHaveBeenCalledTimes(1);
+    unsubscribe();
+    publishWorkbenchPart(chunk({ seq: 2, event: STEP_END }));
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("hands back a stable snapshot until a part lands, and a fresh one after", () => {
+    const before = workbenchFeed();
+    expect(workbenchFeed()).toBe(before);
+    publishWorkbenchPart(chunk({ event: STEP_START }));
+    expect(workbenchFeed()).not.toBe(before);
+  });
+
+  it("forgets every turn on reset", () => {
+    publishWorkbenchPart(chunk({ event: STEP_START }));
+    resetWorkbench();
+    expect(workbenchFeed()).toEqual([]);
+  });
+});

--- a/packages/vendo/src/react.tsx
+++ b/packages/vendo/src/react.tsx
@@ -67,6 +67,15 @@ export {
   ScriptedTransport,
   type DirectorCue,
   type DirectorScript,
+  // chrome/dev-mode.ts + chrome/workbench-store.ts — the dev-only workbench
+  // rails: the check that decides whether such a surface renders at all, and
+  // the `data-vendo-debug` feed a host's pane reads.
+  developmentMode,
+  publishWorkbenchPart,
+  useWorkbenchFeed,
+  type WorkbenchEvent,
+  type WorkbenchPart,
+  type WorkbenchTurn,
   // pin-events.ts — the bus a slot re-reads on, for a host that pins from its
   // own control instead of a Vendo surface.
   announcePin,


### PR DESCRIPTION
## What

1. **Dev-only whole-@vendoai-graph source aliasing in Maple** — `examples/demo-bank/next.config.ts` aliases every `@vendoai/*` package to its package source so a change anywhere in the graph hot-reloads into the demo without a rebuild/relink step; `@vendoai/store` stays pinned to `dist` (PGlite's native binary isn't buildable from source in the aliased path).
2. **Flag-gated diagnostics channel** — `VENDO_WORKBENCH=1` turns on a transient `data-vendo-debug` parts channel (`packages/harnesses/src/workbench.ts` + emit sites in the harness loop). With the flag unset, zero parts are emitted — seam-tested end to end (real emit → real read), and emit sites are fail-proofed so a workbench error never breaks a turn.
3. **Docked dev pane in Maple** — a docked pane rendering the live channel: turn timeline, context/gauge, tools/loadout, guard, and raw parts, backed by a small feed store in `packages/ui` and pane components in `examples/demo-bank`.

## Why

Dev velocity: today, seeing what a harness turn actually did (tool calls, context window state, guard decisions, retries, subagent hires) means printf-debugging the loop or reading raw parts by hand. This gives Maple a live, truthful window into a running turn, gated off in prod builds and off by default in dev.

## Author-zone note

`packages/harnesses/src/vendo/loop.ts` and `vendo.ts` carry the actual instrumentation: an optional workbench callback slot, context/compaction/step emits, per-agent tagging (resident vs. hire vs. screen agent), and retry/step-limit/subagent-hire events. These are edits to the shared agent loop, not just plumbing — written up in chat and approved by Yousef before this PR was opened.

## Verification

- [x] Full local gate green: `pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint`
- [x] Fresh-eyes browser walk against a live Maple session (HEAD `f4e0f330d`), covering: live turns with the pane docked, guard approve + a real 90s approval timeout, forced compaction with a real summary, a screen-agent run tagged correctly at the 10-step cap, transient-on-reload (parts don't survive a page reload), and flag-off producing zero frames.
- [x] That walk found 5 bugs in the pane (pane inert under the chat modal, tools tab collapsing three loadout states into one, context gauge overwritten across agents, timeline steps keyed on step-number instead of (agent, step), and stop-reason chips clipping past the pane edge) — all fixed and re-verified live at `f4e0f330d`.

### Screenshots

Evidence is attached as assets on a draft, evidence-only GitHub release (`workbench-evidence-2026-08-09` — not a product release, never published) since this PR carries no image diffs.

| | |
|---|---|
| ![Pane docked during a live turn](https://github.com/runvendo/vendo/releases/download/untagged-88f458b2792785af24ff/01-live-turn.png) | **Pane docked during a live turn** — timeline and raw-parts feed updating against a real in-flight turn. |
| ![Guard approval timeout at 90s](https://github.com/runvendo/vendo/releases/download/untagged-88f458b2792785af24ff/02b-timeout-full.png) | **Guard approval timeout row** — the pane recording a real 90s approval timeout end to end. |
| ![Forced compaction with real summary](https://github.com/runvendo/vendo/releases/download/untagged-88f458b2792785af24ff/03-compaction-summary.png) | **Forced compaction** — a real compaction summary rendered in the context tab. |
| ![Screen-agent run tagged at 10-step cap](https://github.com/runvendo/vendo/releases/download/untagged-88f458b2792785af24ff/04-screen-agent-timeline.png) | **Screen-agent tagging** — a screen-agent run correctly tagged and capped at 10 steps in its own timeline. |
| ![VENDO_WORKBENCH unset, zero frames](https://github.com/runvendo/vendo/releases/download/untagged-88f458b2792785af24ff/06-flag-off.png) | **Flag off** — `VENDO_WORKBENCH` unset produces zero debug parts. |
| ![Fixed tools tab, three loadout states plus hire](https://github.com/runvendo/vendo/releases/download/untagged-88f458b2792785af24ff/06-bug2-tools-searched-in-and-hire.png) | **Fixed — tools tab** — three honest loadout states (closed / open-unsearched / searched) plus a hire's own loadout, post-fix. |
| ![Fixed context tab, per-agent gauge](https://github.com/runvendo/vendo/releases/download/untagged-88f458b2792785af24ff/03-bug3-context-per-agent.png) | **Fixed — context tab** — one context gauge per agent instead of the last writer clobbering the rest, post-fix. |

Full walk (18 shots) in `/tmp/workbench-proof-shots/`, the 5-bug fix pass (9 shots) in `/tmp/workbench-fix-shots/`, and the pane-vs-Maple layout pass (10 shots) in `/tmp/workbench-pane-shots/` — available on request, not all embedded here.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dev-only harness workbench with a live diagnostics channel and a docked pane to inspect turn internals, plus whole-graph hot reload in the Maple demo to speed iteration.

- **New Features**
  - Dev-only source aliasing: `examples/demo-bank/next.config.ts` resolves `@vendoai/*` to source during `next dev` for hot reload; `@vendoai/store` stays on `dist`. Production unchanged.
  - Flag-gated diagnostics in `@vendoai/harnesses`: `VENDO_WORKBENCH=1` opens a transient `data-vendo-debug` channel per turn and emits step boundaries, tool calls (guard/approval), context/compaction, loadout, hires, and errors. Flag off emits nothing and never persists.
  - Feed store in `@vendoai/ui`: `publishWorkbenchPart`, `useWorkbenchFeed`, and `developmentMode`. Parts are per-turn and ordered by producer `seq`.
  - Docked workbench pane in the demo app: Timeline, Context, Tools, Guard, and Raw tabs; dev-only; includes a demo-feed trigger for UI inspection.
  - Re-exports from `@vendoai/vendo/react` so hosts can import `developmentMode`, `publishWorkbenchPart`, and `useWorkbenchFeed` without reaching into `@vendoai/ui`.

- **Bug Fixes**
  - Pane remains interactive under the chat modal and renders above the scrim.
  - Tools tab shows correct loadout states (closed, open-unsearched, searched) and hire loadouts.
  - Context gauges are per agent; no cross-agent overwrite.
  - Timeline keys steps by (agent, step); turn status reflects multi-loop turns correctly.
  - Layout fixes: prevent chip clipping and ensure step rows ellipsize within the pane.

<sup>Written for commit f4e0f330d498b3c2dd6ca8235b99b75c30e42b8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

