### PR TITLE
fix(workbench): bounded turn retention + structural feed updates

### DIFF
--- a/.changeset/workbench-bounded-turn-retention.md
+++ b/.changeset/workbench-bounded-turn-retention.md
@@ -1,0 +1,17 @@
+---
+"@vendoai/ui": patch
+---
+
+The workbench feed keeps the last 20 turns, and an update costs only the turn it
+landed in
+
+The store held every turn a dev session had ever seen, and rebuilt the whole
+snapshot on each part — copying every retained turn's parts array. A long
+session therefore grew without bound, and each diagnostic got slower as history
+piled up behind it.
+
+Turns are now capped at 20, the oldest first-seen dropped as newer ones arrive,
+and a published part replaces only its own turn's entry: every other turn keeps
+the exact object and array the previous snapshot handed out, so a reader that
+compares identities sees precisely which turn is news. Ordering, `seq` sorting,
+and the fresh outer snapshot per part are unchanged.

--- a/packages/ui/src/chrome/workbench-store.ts
+++ b/packages/ui/src/chrome/workbench-store.ts
@@ -73,7 +73,13 @@ const EVENT_KINDS: Record<WorkbenchEvent["kind"], true> = {
 
 const NO_TURNS: readonly WorkbenchTurn[] = [];
 
-const byTurn = new Map<string, WorkbenchPart[]>();
+/** Turns kept before the oldest is dropped: the store is a module singleton
+    that outlives every turn, so a dev session must not grow without bound. */
+const MAX_TURNS = 20;
+
+/** Holds the snapshot entries themselves, so a turn nothing landed in keeps the
+    object and array the last snapshot handed out. */
+const byTurn = new Map<string, WorkbenchTurn>();
 const listeners = new Set<() => void>();
 let feed: readonly WorkbenchTurn[] = NO_TURNS;
 
@@ -113,14 +119,18 @@ function notify(): void {
 export function publishWorkbenchPart(chunk: { type: string; data?: unknown }): void {
   const part = workbenchPart(chunk);
   if (part === undefined) return;
-  const parts = byTurn.get(part.turnId) ?? [];
+  const parts = [...(byTurn.get(part.turnId)?.parts ?? [])];
   const at = parts.findIndex(existing => existing.seq > part.seq);
   parts.splice(at === -1 ? parts.length : at, 0, part);
   // `set` on a key the map already holds leaves its position alone, so turns
-  // keep the order their first part arrived in; every snapshot is fresh so a
-  // reader can compare identities to spot new news.
-  byTurn.set(part.turnId, parts);
-  feed = [...byTurn].map(([turnId, list]) => ({ turnId, parts: [...list] }));
+  // keep the order their first part arrived in; only the turn the part landed
+  // in gets a new entry, so a reader can compare identities to spot new news.
+  byTurn.set(part.turnId, { turnId: part.turnId, parts });
+  if (byTurn.size > MAX_TURNS) {
+    const oldest = byTurn.keys().next().value;
+    if (oldest !== undefined) byTurn.delete(oldest);
+  }
+  feed = [...byTurn.values()];
   notify();
 }
 

--- a/packages/ui/test/chrome/workbench-store.test.ts
+++ b/packages/ui/test/chrome/workbench-store.test.ts
@@ -71,6 +71,24 @@ describe("workbench store", () => {
     expect(workbenchFeed()).not.toBe(before);
   });
 
+  it("keeps only the most recent turns, dropping the oldest first-seen", () => {
+    for (let n = 1; n <= 21; n += 1) publishWorkbenchPart(chunk({ turnId: `thr_${n}`, event: STEP_START }));
+    const feed = workbenchFeed();
+    expect(feed).toHaveLength(20);
+    expect(feed[0]!.turnId).toBe("thr_2");
+    expect(feed.at(-1)!.turnId).toBe("thr_21");
+  });
+
+  it("rebuilds only the turn that changed, leaving the others' entries untouched", () => {
+    publishWorkbenchPart(chunk({ turnId: "thr_a", event: STEP_START }));
+    const before = workbenchFeed()[0]!;
+    publishWorkbenchPart(chunk({ turnId: "thr_b", event: STEP_START }));
+    publishWorkbenchPart(chunk({ turnId: "thr_b", seq: 2, event: STEP_END }));
+    const after = workbenchFeed()[0]!;
+    expect(after).toBe(before);
+    expect(after.parts).toBe(before.parts);
+  });
+
   it("forgets every turn on reset", () => {
     publishWorkbenchPart(chunk({ event: STEP_START }));
     resetWorkbench();


### PR DESCRIPTION
Fixes the Greptile P2 on #1130: https://github.com/runvendo/vendo/pull/1130#discussion_r3747246283

## The problem

`packages/ui/src/chrome/workbench-store.ts` had two costs that compound over a
dev session:

1. `byTurn` was an unbounded module-level `Map`, cleared only by
   `resetWorkbench()`. Every turn a session ever saw was retained.
2. Every accepted part rebuilt the entire snapshot —
   `[...byTurn].map(([turnId, list]) => ({ turnId, parts: [...list] }))` — so a
   single diagnostic allocated a fresh wrapper and a fresh copied array for
   **every** retained turn. Each update cost O(total history), and every turn's
   identity changed on every part, so a reader could never tell which turn was
   actually news.

## The fix

The map now holds the `WorkbenchTurn` snapshot entries themselves rather than
raw parts arrays. Two consequences fall out:

- **Bounded retention.** `MAX_TURNS = 20`; once the map exceeds it, the oldest
  first-seen turn is dropped (`Map` iteration order is insertion order, and
  `set` on an existing key leaves its position alone, so the existing
  first-part-arrival ordering is preserved).
- **Structural sharing.** A published part replaces only its own turn's entry.
  Every other turn keeps the exact object and array the previous snapshot handed
  out. The outer array is still rebuilt per part — that is what the existing
  "fresh snapshot" contract requires — but it is now O(20), not O(history).

No public API change. Ordering, `seq` sorting, the ignore rules, and the
fresh-outer-snapshot behaviour are all unchanged; every existing assertion in
`workbench-store.test.ts` is untouched.

## Test proof

Two tests added to `packages/ui/test/chrome/workbench-store.test.ts`:

- `keeps only the most recent turns, dropping the oldest first-seen` — publishes
  21 turns, asserts 20 remain and that `thr_1` (not `thr_21`) is the one gone.
- `rebuilds only the turn that changed, leaving the others' entries untouched` —
  publishes to turn A, captures its entry, then publishes twice to turn B, and
  asserts A's entry **and** A's `parts` array are still reference-identical
  (`toBe`).

Both were written first and run against the old implementation to confirm they
fail for the right reasons:

```
AssertionError: expected [ { turnId: 'thr_1', …(1) }, …(20) ] to have a length of 20 but got 21
AssertionError: expected { Object (turnId, parts) } to be { Object (turnId, parts) } // Object.is equality
Tests  2 failed | 7 passed (9)
```

With the fix applied: `Tests  9 passed (9)`.

## Gate

| step | result |
| --- | --- |
| `vitest run test/chrome/workbench-store.test.ts test/chrome/steering.test.tsx` (packages/ui) | 0 — 13 passed |
| `pnpm build` | 0 |
| `pnpm --filter @vendoai/ui typecheck` | 0 |
| `pnpm lint` | 0 |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounded the workbench feed to the most recent 20 turns and switched to structural updates so only the changed turn is rebuilt. This prevents unbounded growth and makes each update O(20) with no API or ordering changes.

- **Bug Fixes**
  - Keep only the last 20 turns, evicting the oldest first-seen.
  - Store `WorkbenchTurn` entries in the map; replace only the updated turn so other turns keep object/array identity.

<sup>Written for commit 31ccb180a0760c9c76950d122d3e30cad653105c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

