### PR TITLE
feat(cli): the banner and the purple renderer — pretty.ts gains text/secret/block, and three rendering bugs die

### DIFF
--- a/packages/vendo/src/cli/banner.ts
+++ b/packages/vendo/src/cli/banner.ts
@@ -1,0 +1,202 @@
+/**
+ * The vendo banner — the real logo at terminal resolution.
+ *
+ * The art is DATA, not drawing code: the Vendo mark (four stepped squares and
+ * the flowing ribbon) and the lowercase wordmark, rasterized from the logo to
+ * half-block cells (`█ ▀ ▄`) at two pixel rows per text row. Colour is one
+ * left-to-right #6c3bff → #a78bfa ramp mapped across the art's COLUMNS, so the
+ * gradient runs through the whole mark instead of restarting on every row;
+ * terminals without truecolor get the ANSI magenta pair.
+ *
+ * Three arrival concepts ship (the CLI plays BANNER_CONCEPT). Whichever plays,
+ * the last frame is the settled frame — a terminal that drops every frame in
+ * between still lands on the finished mark. It plays once and never loops, and
+ * only a TTY with colour ever sees it: the gate is pretty.ts's usePrettyOutput.
+ */
+
+const ESC = "\u001b";
+const RESET = `${ESC}[39m`;
+
+/** Brand ramp endpoints — vendo purple → lilac. */
+const RAMP_FROM = [0x6c, 0x3b, 0xff] as const;
+const RAMP_TO = [0xa7, 0x8b, 0xfa] as const;
+/** The bright band that leads the flow and shimmer passes. */
+const BAND: Record<BannerColorMode, string> = {
+  truecolor: `${ESC}[38;2;246;241;255m`,
+  ansi: `${ESC}[97m`,
+};
+
+export type BannerColorMode = "truecolor" | "ansi";
+export type BannerConcept = "assembly" | "flow" | "shimmer";
+
+/** 12 rows × 72 columns — wordmark beside the mark; fits an 80-column window
+    and costs less than half the scrollback of the large art. */
+export const BANNER_COMPACT: readonly string[] = [
+  "                                                                        ",
+  "                ▄▄█████▄                                                ",
+  "   ████   ██████████████▄                                               ",
+  "   ████▄▄▄██▀▀▀▀█████████                                               ",
+  "       ███     ▄████████                                     ██         ",
+  " ▄▄▄▄  ▀▀▀ ▄▄▄█████████     ██    ██ ▄██████▄ ██▄████▄ ▄████▄██ ▄██████▄",
+  " ████      ███████████      ▀█▄  ▄█▀ ██▄▄▄▄██ ██    ██ ██    ██ ██    ██",
+  "       ███    ▀████████▄     ██  ██  ██▀▀▀▀▀▀ ██    ██ ██    ██ ██    ██",
+  "       ███  ▄▄▄█████████▄     ▀██▀    ▀████▀  ██    ██ ▀██████▀ ▀██████▀",
+  "           ██████████████                                               ",
+  "           ▀▀▀▀████████▀                                                ",
+  "                 ▀▀▀▀                                                   ",
+];
+
+/** 25 rows × 44 columns — wordmark stacked under the mark. */
+export const BANNER_LARGE: readonly string[] = [
+  "                                            ",
+  "                                 ▄▄▄        ",
+  "                            ▄▄█████████▄    ",
+  "      ▄▄▄▄▄▄      ▄▄██▄▄▄▄▄██████████████   ",
+  "      ██████     ████████████████████████▄  ",
+  "      ██████     ██████▀▀▀████████████████  ",
+  "      ▀▀▀▀▀██████          ██████████████▀  ",
+  "           ██████          █████████████▀   ",
+  "           ██████       ▄▄█████████████     ",
+  "  ██████          ▄███████████████████      ",
+  "  ██████          ████████████████████      ",
+  "  ██████          ▀███████████████████      ",
+  "           ██████       ▀▀█████████████▄    ",
+  "           ██████        ▄███████████████   ",
+  "           ▀▀▀▀▀▀  ▄▄▄▄▄▄████████████████▄  ",
+  "                  ████████████████████████  ",
+  "                  ▀██████████████████████▀  ",
+  "                    ▀▀▀▀▀▀██████████████▀   ",
+  "                            ▀████████▀▀     ",
+  "                                            ",
+  "                                 ██         ",
+  "██    ██ ▄██████▄ ██▄████▄ ▄████▄██ ▄██████▄",
+  "▀█▄  ▄█▀ ██▄▄▄▄██ ██    ██ ██    ██ ██    ██",
+  " ██  ██  ██▀▀▀▀▀▀ ██    ██ ██    ██ ██    ██",
+  "  ▀██▀    ▀████▀  ██    ██ ▀██████▀ ▀██████▀",
+];
+
+/** The dim line under the banner: what the product is, and where the docs are. */
+export const BANNER_TAGLINE = " Customize your product with an embedded agent — docs.vendo.run";
+
+/** The arrival the CLI plays. Decided: the flow. */
+export const BANNER_CONCEPT: BannerConcept = "flow";
+
+/** Frames per concept — ~1.0-1.4s at the default 90ms cadence. */
+const FRAME_COUNT: Record<BannerConcept, number> = { assembly: 14, flow: 15, shimmer: 11 };
+/** How many columns the shimmer band covers. */
+const SHIMMER_BAND = 6;
+/** How many columns the flow's leading edge burns bright. */
+const FLOW_BAND = 2;
+
+/** Which part of the art a frame shows: rows/cols past the reveal are blank,
+    columns inside the band burn bright instead of taking the ramp. */
+interface FrameView {
+  rows?: number;
+  cols?: number;
+  band?: readonly [number, number];
+}
+
+function rampColor(column: number, width: number, mode: BannerColorMode): string {
+  if (mode === "ansi") return column * 2 < width ? `${ESC}[35m` : `${ESC}[95m`;
+  const position = width <= 1 ? 0 : column / (width - 1);
+  const mix = (channel: number): number =>
+    Math.round(RAMP_FROM[channel]! + (RAMP_TO[channel]! - RAMP_FROM[channel]!) * position);
+  return `${ESC}[38;2;${mix(0)};${mix(1)};${mix(2)}m`;
+}
+
+function paintRow(row: string, width: number, mode: BannerColorMode, view: FrameView): string {
+  let painted = "";
+  let open = "";
+  for (let column = 0; column < row.length; column += 1) {
+    const glyph = view.cols !== undefined && column >= view.cols ? " " : row[column]!;
+    if (glyph === " ") {
+      painted += " ";
+      continue;
+    }
+    const banded = view.band !== undefined && column >= view.band[0] && column < view.band[1];
+    const color = banded ? BAND[mode] : rampColor(column, width, mode);
+    if (color !== open) {
+      painted += color;
+      open = color;
+    }
+    painted += glyph;
+  }
+  return open === "" ? painted : `${painted}${RESET}`;
+}
+
+function paintFrame(art: readonly string[], mode: BannerColorMode, view: FrameView = {}): string {
+  const width = Math.max(...art.map((row) => row.length));
+  return art
+    .map((row, index) =>
+      view.rows !== undefined && index >= view.rows ? " ".repeat(row.length) : paintRow(row, width, mode, view))
+    .join("\n");
+}
+
+/** The settled banner — every concept's last frame, and what a run that never
+    animates prints. */
+export function renderBanner(art: readonly string[], mode: BannerColorMode): string {
+  return paintFrame(art, mode);
+}
+
+/**
+ * The arrival, as ANSI frames. LAW: the last frame ALWAYS equals the settled
+ * frame, for every concept — the animation can only ever be a faster way to
+ * arrive at `renderBanner`, never a different picture.
+ */
+export function bannerFrames(
+  art: readonly string[],
+  mode: BannerColorMode,
+  concept: BannerConcept,
+): string[] {
+  const count = FRAME_COUNT[concept];
+  const width = Math.max(...art.map((row) => row.length));
+  const frames: string[] = [];
+  for (let index = 0; index < count - 1; index += 1) {
+    const progress = (index + 1) / count;
+    if (concept === "assembly") {
+      // The mark lands top-down; nothing below the edge is drawn yet.
+      frames.push(paintFrame(art, mode, { rows: Math.ceil(progress * art.length) }));
+    } else if (concept === "flow") {
+      // A band passes and the mark crystallizes behind it.
+      const edge = Math.round(progress * width);
+      frames.push(paintFrame(art, mode, { cols: edge, band: [edge - FLOW_BAND, edge] }));
+    } else {
+      // Complete on frame one; one bright band walks across it.
+      const edge = Math.round(progress * (width + SHIMMER_BAND));
+      frames.push(paintFrame(art, mode, { band: [edge - SHIMMER_BAND, edge] }));
+    }
+  }
+  frames.push(renderBanner(art, mode));
+  return frames;
+}
+
+/** Truecolor when the terminal says so; ANSI magenta otherwise. */
+export function bannerColorMode(
+  env: Record<string, string | undefined> = process.env,
+): BannerColorMode {
+  const colorterm = (env.COLORTERM ?? "").toLowerCase();
+  if (colorterm === "truecolor" || colorterm === "24bit") return "truecolor";
+  return /truecolor|24bit|direct/i.test(env.TERM ?? "") ? "truecolor" : "ansi";
+}
+
+/**
+ * Play the frames in place: cursor-up over the block and redraw, once. No
+ * alternate screen buffer — the settled banner stays in the scrollback as the
+ * top of the transcript. A resize mid-play costs one ragged frame, then the
+ * settled one.
+ */
+export async function playBanner(
+  write: (chunk: string) => void,
+  frames: readonly string[],
+  frameMs = 90,
+): Promise<void> {
+  const [first, ...rest] = frames;
+  if (first === undefined) return;
+  const rows = first.split("\n").length;
+  write(`${first}\n`);
+  for (const frame of rest) {
+    await new Promise<void>((settle) => { setTimeout(settle, frameMs); });
+    write(`${ESC}[${rows}A`);
+    write(`${frame.split("\n").map((row) => `${ESC}[2K${row}`).join("\n")}\n`);
+  }
+}

--- a/packages/vendo/src/cli/pretty.ts
+++ b/packages/vendo/src/cli/pretty.ts
@@ -1,19 +1,24 @@
 import { stdin, stdout } from "node:process";
 import { createInterface } from "node:readline/promises";
+import { Writable } from "node:stream";
+import { BANNER_COMPACT, BANNER_TAGLINE, bannerColorMode, renderBanner } from "./banner.js";
 import type { Output } from "./shared.js";
 
 /**
  * The vendo CLI's TTY visual system (init first; doctor/sync can adopt the
- * same primitives later). Clack-style vertical-bar layout: one `┌ vendo init`
- * header, `◇`/`◆` section markers on a dim `│` rail, colored diff markers,
- * a dots spinner for the slow phases, and ONE deliberately emphasized block —
- * Vendo Cloud — in the brand accent (blue/cyan family, calm not neon).
+ * same primitives later). Clack-style vertical-bar layout: the banner, one
+ * `┌ vendo init` header, `◇`/`◆` section markers on a dim `│` rail, colored
+ * diff markers, a braille spinner for the slow phases, and ONE deliberately
+ * emphasized block — Vendo Cloud. The accent is the brand purple family;
+ * green, yellow and red keep their meanings: added, changed, broken.
  *
  * Degradation contract: this module is only selected when stdout is a real
  * TTY and none of NO_COLOR / CI / TERM=dumb opt out (see usePrettyOutput).
  * Every other run — tests, pipes, CI — keeps today's exact plain strings,
  * because runInit's emissions are unchanged: this is a renderer over the
- * existing Output seam, not a second copy of the copy.
+ * existing Output seam, not a second copy of the copy. The collapse rules
+ * below are pure string rules over those exact plain strings; the renderer
+ * restyles and groups, and never writes copy of its own.
  */
 
 const ESC = "\u001b";
@@ -25,9 +30,12 @@ const dim = style("2", "22");
 const red = style("31", "39");
 const green = style("32", "39");
 const yellow = style("33", "39");
-const blue = style("34", "39");
-const cyan = style("36", "39");
-const brightCyan = style("96", "39");
+/** The accent — brand lilac. Truecolor terminals get the real ramp in the
+    banner; the rail's markers stay ANSI so they follow the user's theme. */
+const lilac = style("95", "39");
+/** Re-arm sequences for the two colors that can wrap a whole line. */
+const REOPEN_YELLOW = `${ESC}[33m`;
+const REOPEN_RED = `${ESC}[31m`;
 
 /** TTY + no opt-outs → the pretty renderer; anything else keeps plain output.
     NO_COLOR and CI follow the "present and non-empty" convention. */
@@ -61,7 +69,7 @@ export interface SelectInput {
 }
 
 export interface PrettyOutput extends Output {
-  /** Dots spinner for a slow phase; any log/error line clears the frame. */
+  /** Braille spinner for a slow phase; any log/error line clears the frame. */
   spin(label: string): void;
   stopSpin(): void;
   /** The styled [Y/n] confirm — Enter accepts the default, answer echoed. */
@@ -71,17 +79,48 @@ export interface PrettyOutput extends Output {
       1-9 only: keep lists at nine options or fewer (a longer list stays
       arrow-navigable, but two-digit entry is deliberately not built). */
   select(question: string, options: SelectOption[], defaultIndex?: number): Promise<string>;
-  /** The `└ Done in Xs` footer (red `Failed` when init exits non-zero). */
-  done(durationMs: number, ok: boolean): void;
+  /** A free-text answer; Enter returns "" and the caller decides what a skip
+      means. Non-TTY stdin never prompts — "" stands. */
+  text(question: string, hint?: string): Promise<string>;
+  /** A secret: the typing is not echoed and only a masked receipt reaches the
+      transcript. The value itself is NEVER written to the terminal. */
+  secret(question: string, hint?: string): Promise<string>;
+  /** A pretty-only result block. It has no plain sibling on purpose: callers
+      keep emitting their plain lines, and this restyles nothing — it is for
+      blocks the pretty run composes itself. */
+  block(title: string, lines: string[], marker?: "◆" | "◇"): void;
+  /** The `└ Done in Xs` footer (red `Failed` when the command exits non-zero);
+      `stats` is the dim tail that says what the run actually achieved. */
+  done(durationMs: number, ok: boolean, stats?: string): void;
 }
 
 const FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 const BAR = dim("│");
 const CLEAR_LINE = `\r${ESC}[2K`;
 
-/** Inline `code spans` in the calm command color. */
-function styleInline(text: string): string {
-  return text.replace(/`([^`]+)`/g, (_match, code: string) => bold(cyan(code)));
+/** The five always-printed catalog lines, collapsed into one block. */
+const CATALOG_PREFIXES = ["tools: ", "tool schemas: ", "pins: ", "catalog.json: ", "components: "];
+const CATALOG_COMPONENTS = "components: ";
+const JUDGMENT_HEAD = /^judgment \(.+\): (.+)$/;
+const JUDGMENT_QUEUED = "loosenings queued";
+/** The paste block's ASCII frame — dropped; the block rides the rail instead. */
+const PASTE_RULE = "─".repeat(64);
+const PASTE_HEAD = /^(ONE|\d+) STEPS? LEFT — paste th(?:is|ese) yourself \((.+)\)$/;
+const PASTE_FILE = /^ {2}File: (.+)$/;
+const WIRED = /^(Wired \(\d+ files?\)):$/;
+const DIFF_MARKER = /^ {2}([+~]) (.+)$/;
+const THEME = /^Theme: (.*)$/;
+const SYNC_THEME = /^theme: (.+)$/;
+const CLOUD_ABSENT = /^Vendo Cloud \(optional\): not configured\. A key unlocks (.+)\.$/;
+const CLOUD_PRESENT = /^Vendo Cloud: (.+)$/;
+const CTA = /`?vendo (cloud )?login`?/;
+const CTA_ALL = /`?vendo (cloud )?login`?/g;
+
+/** Inline `code spans` in the accent color. The span's close resets the
+    foreground to default, so a span inside a colored line bleaches everything
+    after it — `reopen` re-arms the enclosing color (error() passes it). */
+function styleInline(text: string, reopen = ""): string {
+  return text.replace(/`([^`]+)`/g, (_match, code: string) => `${bold(lilac(code))}${reopen}`);
 }
 
 /** The plain-terminal select for non-pretty interactive runs: numbered list +
@@ -114,33 +153,291 @@ export async function plainSelect(
   }
 }
 
-export function createPrettyOutput(
-  write: (chunk: string) => void = (chunk) => { stdout.write(chunk); },
-  input: SelectInput = stdin,
-  promptOutput: NodeJS.WritableStream & { isTTY?: boolean } = stdout,
-): PrettyOutput {
+/** The plain-terminal free-text prompt — plainSelect's sibling, same non-TTY
+    guard: a piped run never prompts and answers "". */
+export async function plainText(
+  question: string,
+  hint?: string,
+  input: NodeJS.ReadableStream & { isTTY?: boolean } = stdin,
+  output: NodeJS.WritableStream & { isTTY?: boolean } = stdout,
+): Promise<string> {
+  if (input.isTTY !== true || output.isTTY !== true) return "";
+  output.write(`${question}\n`);
+  if (hint !== undefined) output.write(`  ${hint}\n`);
+  const prompt = createInterface({ input, output });
+  try {
+    return (await prompt.question("> ")).trim();
+  } finally {
+    prompt.close();
+  }
+}
+
+/** Readline's echo goes here so a typed secret never reaches the terminal. */
+const MUTED = new Writable({ write(_chunk, _encoding, callback) { callback(); } });
+
+/** What is safe to put in a transcript: proof the value arrived, never the
+    value. Anything short enough for the tail to BE the secret shows dots only. */
+function maskedReceipt(value: string): string {
+  if (value === "") return "skipped";
+  return value.length > 8 ? `•••••••• (…${value.slice(-4)})` : "•".repeat(value.length);
+}
+
+/** The plain-terminal secret prompt — same non-TTY guard as plainSelect; the
+    typing is swallowed and only the masked receipt is echoed. */
+export async function plainSecret(
+  question: string,
+  hint?: string,
+  input: NodeJS.ReadableStream & { isTTY?: boolean } = stdin,
+  output: NodeJS.WritableStream & { isTTY?: boolean } = stdout,
+): Promise<string> {
+  if (input.isTTY !== true || output.isTTY !== true) return "";
+  output.write(`${question}\n`);
+  if (hint !== undefined) output.write(`  ${hint}\n`);
+  output.write("> ");
+  const prompt = createInterface({ input, output: MUTED, terminal: true });
+  try {
+    const answer = (await prompt.question("")).trim();
+    output.write(`${maskedReceipt(answer)}\n`);
+    return answer;
+  } finally {
+    prompt.close();
+  }
+}
+
+/** What the string rules below are allowed to draw on. */
+interface Rail {
+  bar(): void;
+  body(text: string, reopen?: string): void;
+  section(marker: string, title: string): void;
+}
+
+/** What a collapse rule is still holding, and how much leading indent the rail
+    is currently absorbing. */
+interface RenderState {
+  /** Leading spaces the rail swallows: the first level inside a section, and
+      nothing at all under a plain narrative line (whose sub-lines are its
+      hierarchy, not the rail's). */
+  absorb: number;
+  catalog: string[];
+  judgment: { summary: string; details: string[] } | null;
+  paste: { count: number; why: string; titled: boolean } | null;
+}
+
+function flushCatalog(state: RenderState, rail: Rail): void {
+  if (state.catalog.length === 0) return;
+  const lines = state.catalog;
+  state.catalog = [];
+  rail.section(lilac("◆"), bold("Catalog"));
+  const counts = lines.filter((entry) => !entry.startsWith(CATALOG_COMPONENTS));
+  if (counts.length > 0) rail.body(counts.join(" · "));
+  for (const entry of lines.filter((line) => line.startsWith(CATALOG_COMPONENTS))) rail.body(entry);
+}
+
+function flushJudgment(state: RenderState, rail: Rail): void {
+  if (state.judgment === null) return;
+  const { summary, details } = state.judgment;
+  state.judgment = null;
+  rail.section(lilac("◆"), bold("Judgment"));
+  const queued = details.filter((detail) => detail.includes(JUDGMENT_QUEUED));
+  // Every detail line keeps its own count clause; the long name lists behind
+  // the colon are what --json and `vendo sync` are for.
+  const counted = details
+    .filter((detail) => !detail.includes(JUDGMENT_QUEUED))
+    .map((detail) => detail.trim().split(": ")[0]!);
+  rail.body([summary, ...counted].join(" · "));
+  for (const entry of queued) rail.body(entry.trim());
+}
+
+/** The exact-shape rules: one plain string in, one styled section out. */
+function renderNamed(raw: string, rail: Rail): boolean {
+  const wired = WIRED.exec(raw);
+  if (wired !== null) {
+    rail.section(lilac("◆"), bold(wired[1]!));
+    return true;
+  }
+  if (raw === "Already wired — nothing to change.") {
+    rail.section(lilac("◇"), `${bold("Already wired")} — nothing to change`);
+    return true;
+  }
+  const marker = DIFF_MARKER.exec(raw);
+  if (marker !== null) {
+    rail.body(`${marker[1] === "+" ? green("+") : yellow("~")} ${dim(lilac(marker[2]!))}`);
+    return true;
+  }
+  const theme = THEME.exec(raw);
+  if (theme !== null) {
+    rail.section(lilac("◆"), bold("Your brand"));
+    rail.body(theme[1]!);
+    return true;
+  }
+  const syncTheme = SYNC_THEME.exec(raw);
+  if (syncTheme !== null) {
+    rail.section(lilac("◇"), bold("Theme"));
+    rail.body(syncTheme[1]!);
+    return true;
+  }
+  if (raw.startsWith("Theme lives in ")) {
+    rail.body(dim(raw));
+    return true;
+  }
+  if (raw === "Last steps are yours:") {
+    rail.section(lilac("◇"), bold("Last steps are yours"));
+    return true;
+  }
+  return renderCloud(raw, rail);
+}
+
+/** The one emphasized block: brand header + ✦ bullets + the → CTA. */
+function renderCloud(raw: string, rail: Rail): boolean {
+  const absent = CLOUD_ABSENT.exec(raw);
+  if (absent !== null) {
+    rail.section(lilac("◆"), bold(lilac("Vendo Cloud")));
+    for (const bullet of absent[1]!.split("; ")) rail.body(`${lilac("✦")} ${lilac(bullet)}`);
+    return true;
+  }
+  const present = CLOUD_PRESENT.exec(raw);
+  if (present !== null) {
+    rail.section(lilac("◆"), bold(lilac("Vendo Cloud")));
+    rail.body(`${lilac("✦")} ${lilac(present[1]!)}`);
+    return true;
+  }
+  return false;
+}
+
+/** Generic detail lines. The rail absorbs the first indent level only, so the
+    narrative keeps its hierarchy; the CTA decorates the TRIMMED text and the
+    kept indent goes back in front, so the arrow never pushes a line right of
+    its siblings. */
+function renderIndented(raw: string, state: RenderState, rail: Rail): void {
+  const indent = raw.length - raw.trimStart().length;
+  const rest = raw.slice(indent);
+  const keep = " ".repeat(Math.max(0, indent - state.absorb));
+  if (indent === 0) state.absorb = 0;
+  if (CTA.test(rest)) {
+    const cta = rest.replace(CTA_ALL, (match) => bold(lilac(match.replaceAll("`", ""))));
+    rail.body(`${keep}${bold(lilac("→"))} ${cta}`);
+    return;
+  }
+  rail.body(`${keep}${rest}`);
+}
+
+/** The 64-dash paste frame becomes a ◇ section on the rail. */
+function renderPaste(raw: string, state: RenderState, rail: Rail): void {
+  const open = state.paste;
+  if (raw === PASTE_RULE) {
+    if (open === null) state.paste = { count: 0, why: "", titled: false };
+    else {
+      if (open.why !== "") rail.body(dim(open.why));
+      state.paste = null;
+    }
+    return;
+  }
+  const head = PASTE_HEAD.exec(raw);
+  if (head !== null) {
+    state.paste = { count: head[1] === "ONE" ? 1 : Number(head[1]), why: head[2]!, titled: false };
+    return;
+  }
+  const file = open === null ? null : PASTE_FILE.exec(raw);
+  if (file !== null && open !== null) {
+    if (open.titled) rail.bar();
+    else {
+      open.titled = true;
+      rail.section(lilac("◇"), bold(open.count === 1 ? `One paste left — ${file[1]}` : `${open.count} pastes left`));
+      if (open.count === 1) return;
+    }
+    rail.body(bold(file[1]!));
+    return;
+  }
+  renderIndented(raw, state, rail);
+}
+
+function renderRaw(raw: string, state: RenderState, rail: Rail): void {
+  if (raw === "") {
+    flushCatalog(state, rail);
+    flushJudgment(state, rail);
+    rail.bar();
+    return;
+  }
+  if (state.paste !== null || raw === PASTE_RULE) {
+    renderPaste(raw, state, rail);
+    return;
+  }
+  if (CATALOG_PREFIXES.some((prefix) => raw.startsWith(prefix))) {
+    flushJudgment(state, rail);
+    state.catalog.push(raw);
+    return;
+  }
+  flushCatalog(state, rail);
+  const judged = JUDGMENT_HEAD.exec(raw);
+  if (judged !== null) {
+    state.judgment = { summary: judged[1]!, details: [] };
+    return;
+  }
+  if (state.judgment !== null) {
+    if (raw.startsWith("  ")) {
+      state.judgment.details.push(raw);
+      return;
+    }
+    flushJudgment(state, rail);
+  }
+  if (renderNamed(raw, rail)) return;
+  renderIndented(raw, state, rail);
+}
+
+export interface PrettyOptions {
+  /** The header command — `┌  vendo init`. */
+  command?: string;
+  write?: (chunk: string) => void;
+  input?: SelectInput;
+  promptOutput?: NodeJS.WritableStream & { isTTY?: boolean };
+  /** The settled banner above the header. */
+  banner?: boolean;
+  env?: Record<string, string | undefined>;
+}
+
+export function createPrettyOutput(options: PrettyOptions = {}): PrettyOutput {
+  const {
+    command = "vendo init",
+    write = (chunk: string): void => { stdout.write(chunk); },
+    input = stdin as SelectInput,
+    promptOutput = stdout,
+    banner = true,
+    env = process.env,
+  } = options;
   let headerPrinted = false;
   let lastWasBar = false;
   let timer: ReturnType<typeof setInterval> | null = null;
   let frame = 0;
+  const state: RenderState = { absorb: 0, catalog: [], judgment: null, paste: null };
 
   const line = (text: string): void => {
     write(`${text}\n`);
     lastWasBar = text === BAR;
   };
-  const bar = (): void => {
-    if (!lastWasBar) line(BAR);
+  const rail: Rail = {
+    bar: (): void => {
+      if (!lastWasBar) line(BAR);
+    },
+    body: (text: string, reopen = ""): void => line(`${BAR}  ${styleInline(text, reopen)}`),
+    section: (marker: string, title: string): void => {
+      rail.bar();
+      line(`${marker}  ${title}`);
+      state.absorb = 2;
+    },
   };
   const ensureHeader = (): void => {
     if (headerPrinted) return;
     headerPrinted = true;
-    line(`${dim("┌")}  ${bold("vendo init")}`);
+    if (banner) {
+      write(`${renderBanner(BANNER_COMPACT, bannerColorMode(env))}\n\n${dim(BANNER_TAGLINE)}\n\n`);
+    }
+    line(`${dim("┌")}  ${bold(command)}`);
     line(BAR);
   };
-  const body = (text: string): void => line(`${BAR}  ${styleInline(text)}`);
-  const section = (marker: string, title: string): void => {
-    bar();
-    line(`${marker}  ${title}`);
+  /** Nothing may be printed on top of a half-collapsed block. */
+  const flush = (): void => {
+    flushCatalog(state, rail);
+    flushJudgment(state, rail);
   };
 
   const clearFrame = (): void => {
@@ -152,111 +449,62 @@ export function createPrettyOutput(
     timer = null;
     write(CLEAR_LINE);
   };
-
-  /** The emphasized block: brand-blue header + ✦ bullets. */
-  const cloudHeader = (): void => section(blue("◆"), bold(blue("Vendo Cloud")));
-  const cloudBullet = (text: string): void => body(`${blue("✦")} ${blue(text)}`);
-
-  const render = (raw: string): void => {
-    if (raw === "") {
-      bar();
-      return;
-    }
-    const wired = raw.match(/^(Wired \(\d+ files?\)):$/);
-    if (wired !== null) {
-      section(cyan("◆"), bold(wired[1]!));
-      return;
-    }
-    if (raw === "Already wired — nothing to change.") {
-      section(cyan("◇"), `${bold("Already wired")} — nothing to change`);
-      return;
-    }
-    const marker = raw.match(/^ {2}([+~]) (.+)$/);
-    if (marker !== null) {
-      body(`${marker[1] === "+" ? green("+") : yellow("~")} ${dim(cyan(marker[2]!))}`);
-      return;
-    }
-    const theme = raw.match(/^Theme: (.*)$/);
-    if (theme !== null) {
-      section(cyan("◇"), bold("Theme captured"));
-      body(theme[1]!);
-      return;
-    }
-    if (raw.startsWith("Theme lives in ")) {
-      body(dim(raw));
-      return;
-    }
-    const cloudAbsent = raw.match(/^Vendo Cloud \(optional\): not configured\. A key unlocks (.+)\.$/);
-    if (cloudAbsent !== null) {
-      cloudHeader();
-      for (const bullet of cloudAbsent[1]!.split("; ")) cloudBullet(bullet);
-      return;
-    }
-    const cloud = raw.match(/^Vendo Cloud: (.+)$/);
-    if (cloud !== null) {
-      cloudHeader();
-      cloudBullet(cloud[1]!);
-      return;
-    }
-    if (/`?vendo (cloud )?login`?/.test(raw)) {
-      // The CTA: bright, factual, pointing at the free Cloud key.
-      body(`${bold(brightCyan("→"))} ${raw.replace(/`?vendo (cloud )?login`?/g, (m) => bold(brightCyan(m.replaceAll("`", ""))))}`);
-      return;
-    }
-    if (raw === "Last steps are yours:") {
-      section(cyan("◇"), bold("Last steps are yours"));
-      return;
-    }
-    // Generic indented detail (paste steps, progress lines): the plain
-    // two-space indent becomes the rail; deeper nesting is preserved.
-    const indented = raw.match(/^ {2}(.*)$/);
-    if (indented !== null) {
-      body(indented[1]!);
-      return;
-    }
-    body(raw);
+  /** Every prompt interrupts the transcript: settle what is buffered first. */
+  const settle = (): void => {
+    stopSpin();
+    ensureHeader();
+    flush();
   };
 
   return {
     log(message) {
       clearFrame();
       ensureHeader();
-      if (message.startsWith("\n")) bar();
-      for (const raw of message.replace(/^\n+/, "").split("\n")) render(raw);
+      if (message.startsWith("\n")) {
+        flush();
+        rail.bar();
+      }
+      for (const raw of message.replace(/^\n+/, "").split("\n")) renderRaw(raw, state, rail);
     },
     error(message) {
       clearFrame();
       ensureHeader();
-      if (message.startsWith("\n")) bar();
+      flush();
+      if (message.startsWith("\n")) rail.bar();
       for (const raw of message.replace(/^\n+/, "").split("\n")) {
         const warning = raw.match(/^\s*warning: (.*)$/);
-        if (warning !== null) body(yellow(`⚠ ${warning[1]!}`));
+        if (warning !== null) rail.body(yellow(`⚠ ${warning[1]!}`), REOPEN_YELLOW);
         else if (raw.startsWith("Vendo Cloud: ")) {
-          cloudHeader();
-          body(yellow(`⚠ ${raw.slice("Vendo Cloud: ".length)}`));
-        } else body(red(`✖ ${raw}`));
+          rail.section(lilac("◆"), bold(lilac("Vendo Cloud")));
+          rail.body(yellow(`⚠ ${raw.slice("Vendo Cloud: ".length)}`), REOPEN_YELLOW);
+        } else rail.body(red(`✖ ${raw}`), REOPEN_RED);
       }
     },
     spin(label) {
       stopSpin();
       ensureHeader();
+      flush();
       const draw = (): void => {
         frame = (frame + 1) % FRAMES.length;
-        write(`${CLEAR_LINE}${cyan(FRAMES[frame]!)}  ${dim(label)}`);
+        write(`${CLEAR_LINE}${lilac(FRAMES[frame]!)}  ${dim(label)}`);
       };
       timer = setInterval(draw, 80);
       timer.unref?.();
       draw();
     },
     stopSpin,
+    block(title, lines, marker = "◆") {
+      settle();
+      rail.section(lilac(marker), bold(title));
+      for (const text of lines) rail.body(text);
+    },
     async confirm(question, defaultYes = false) {
       // usePrettyOutput gates on stdout only; a piped/closed stdin can still
       // reach here (vendo init < file). Never block readline on a non-TTY —
       // the default stands, mirroring the plain askYesNo guard.
       if (input.isTTY !== true) return defaultYes;
-      stopSpin();
-      ensureHeader();
-      section(cyan("◇"), bold(question));
+      settle();
+      rail.section(lilac("◇"), bold(question));
       // SelectInput is the raw-key slice of the same real stream readline
       // needs; the default (stdin) satisfies both.
       const prompt = createInterface({
@@ -268,8 +516,49 @@ export function createPrettyOutput(
           `${BAR}  ${dim(defaultYes ? "Y/n" : "y/N")} ${dim("›")} `,
         )).trim().toLowerCase();
         const accepted = answer === "" ? defaultYes : ["y", "yes"].includes(answer);
-        line(`${BAR}  ${cyan("●")} ${accepted ? "Yes" : "No"}`);
+        line(`${BAR}  ${lilac("●")} ${accepted ? "Yes" : "No"}`);
         return accepted;
+      } finally {
+        prompt.close();
+      }
+    },
+    async text(question, hint) {
+      // Same stdin guard as confirm: no keypress source → no question, and ""
+      // is the skip the caller already has to handle.
+      if (input.isTTY !== true) return "";
+      settle();
+      rail.section(lilac("◇"), bold(question));
+      if (hint !== undefined) line(`${BAR}  ${dim(hint)}`);
+      const prompt = createInterface({
+        input: input as unknown as NodeJS.ReadableStream,
+        output: promptOutput,
+      });
+      try {
+        const answer = (await prompt.question(`${BAR}  ${dim("›")} `)).trim();
+        line(`${BAR}  ${lilac("●")} ${answer === "" ? dim("skipped") : answer}`);
+        return answer;
+      } finally {
+        prompt.close();
+      }
+    },
+    async secret(question, hint) {
+      if (input.isTTY !== true) return "";
+      settle();
+      rail.section(lilac("◇"), bold(question));
+      if (hint !== undefined) line(`${BAR}  ${dim(hint)}`);
+      write(`${BAR}  ${dim("›")} `);
+      // The echo goes to a sink, so the secret is never drawn; the receipt
+      // below is the only trace it leaves.
+      const prompt = createInterface({
+        input: input as unknown as NodeJS.ReadableStream,
+        output: MUTED,
+        terminal: true,
+      });
+      try {
+        const answer = (await prompt.question("")).trim();
+        write("\n");
+        line(`${BAR}  ${lilac("●")} ${dim(maskedReceipt(answer))}`);
+        return answer;
       } finally {
         prompt.close();
       }
@@ -277,12 +566,11 @@ export function createPrettyOutput(
     async select(question, options, defaultIndex = 0) {
       // Same stdin guard as confirm: no keypress source → the default option.
       if (input.isTTY !== true) return (options[defaultIndex] ?? options[0])!.value;
-      stopSpin();
-      ensureHeader();
-      section(cyan("◇"), bold(question));
+      settle();
+      rail.section(lilac("◇"), bold(question));
       let index = defaultIndex;
       const optionLine = (option: SelectOption, at: number): string => {
-        const marker = at === index ? cyan("●") : dim("○");
+        const marker = at === index ? lilac("●") : dim("○");
         const label = at === index ? option.label : dim(option.label);
         const hint = option.hint === undefined ? "" : ` ${dim(`(${option.hint})`)}`;
         return `${BAR}  ${marker} ${label}${hint}`;
@@ -354,15 +642,15 @@ export function createPrettyOutput(
       });
       // Collapse the option list to the chosen answer.
       write(`${ESC}[${options.length}A${ESC}[0J`);
-      line(`${BAR}  ${cyan("●")} ${options[chosen]!.label}`);
+      line(`${BAR}  ${lilac("●")} ${options[chosen]!.label}`);
       return options[chosen]!.value;
     },
-    done(durationMs, ok) {
-      stopSpin();
-      ensureHeader();
-      bar();
+    done(durationMs, ok, stats) {
+      settle();
+      rail.bar();
       const seconds = `${(durationMs / 1000).toFixed(1)}s`;
-      line(`${dim("└")}  ${ok ? green(`Done in ${seconds}`) : red(`Failed after ${seconds}`)}`);
+      const tail = stats === undefined ? "" : ` ${dim(`— ${stats}`)}`;
+      line(`${dim("└")}  ${ok ? green(`Done in ${seconds}`) : red(`Failed after ${seconds}`)}${tail}`);
     },
   };
 }

--- a/packages/vendo/src/cli/pretty.ts
+++ b/packages/vendo/src/cli/pretty.ts
@@ -90,13 +90,17 @@ export interface PrettyOutput extends Output {
       blocks the pretty run composes itself. */
   block(title: string, lines: string[], marker?: "◆" | "◇"): void;
   /** The `└ Done in Xs` footer (red `Failed` when the command exits non-zero);
-      `stats` is the dim tail that says what the run actually achieved. */
+      `stats` is the dim tail that says what the run actually achieved, and a
+      dim star line closes the run. */
   done(durationMs: number, ok: boolean, stats?: string): void;
 }
 
 const FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 const BAR = dim("│");
 const CLEAR_LINE = `\r${ESC}[2K`;
+/** The star ask, demoted from an interactive question to a dim last line —
+    pretty-only, so a piped or NO_COLOR run never sees it. */
+const STAR_FOOTER = "Star us: vendo.run/star · docs.vendo.run";
 
 /** The five always-printed catalog lines, collapsed into one block. */
 const CATALOG_PREFIXES = ["tools: ", "tool schemas: ", "pins: ", "catalog.json: ", "components: "];
@@ -651,6 +655,7 @@ export function createPrettyOutput(options: PrettyOptions = {}): PrettyOutput {
       const seconds = `${(durationMs / 1000).toFixed(1)}s`;
       const tail = stats === undefined ? "" : ` ${dim(`— ${stats}`)}`;
       line(`${dim("└")}  ${ok ? green(`Done in ${seconds}`) : red(`Failed after ${seconds}`)}${tail}`);
+      line(`   ${dim(STAR_FOOTER)}`);
     },
   };
 }

--- a/packages/vendo/tests/cli/banner.test.ts
+++ b/packages/vendo/tests/cli/banner.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import {
+  BANNER_COMPACT,
+  BANNER_CONCEPT,
+  BANNER_LARGE,
+  BANNER_TAGLINE,
+  bannerColorMode,
+  bannerFrames,
+  playBanner,
+  renderBanner,
+  type BannerConcept,
+} from "../../src/cli/banner.js";
+
+const ESC = "\u001b";
+const CONCEPTS: BannerConcept[] = ["assembly", "flow", "shimmer"];
+
+/** Drop SGR/cursor sequences so the art itself can be asserted. */
+function stripAnsi(text: string): string {
+  return text.split(ESC).map((chunk, index) => {
+    if (index === 0) return chunk;
+    return chunk.replace(/^\[[0-9;]*[A-Za-z]/, "");
+  }).join("");
+}
+
+describe("banner art", () => {
+  it("is the approved art: 12 rows × 72 columns compact, 25 × 44 large", () => {
+    expect(BANNER_COMPACT).toHaveLength(12);
+    expect([...new Set(BANNER_COMPACT.map((row) => row.length))]).toEqual([72]);
+    expect(BANNER_LARGE).toHaveLength(25);
+    expect([...new Set(BANNER_LARGE.map((row) => row.length))]).toEqual([44]);
+    // Half-blocks, never figlet letters.
+    expect(BANNER_COMPACT.join("")).toMatch(/[█▀▄]/);
+    expect(BANNER_TAGLINE).toContain("docs.vendo.run");
+  });
+
+  it("the CLI plays the flow", () => {
+    expect(BANNER_CONCEPT).toBe("flow");
+  });
+
+  it("colours the art without changing a single glyph", () => {
+    for (const mode of ["truecolor", "ansi"] as const) {
+      expect(stripAnsi(renderBanner(BANNER_COMPACT, mode))).toBe(BANNER_COMPACT.join("\n"));
+      expect(stripAnsi(renderBanner(BANNER_LARGE, mode))).toBe(BANNER_LARGE.join("\n"));
+    }
+  });
+
+  it("ramps brand purple → lilac across the columns in truecolor, and falls back to ANSI magenta", () => {
+    // The large art inks both edges of the grid, so both ends of the ramp show.
+    const truecolor = renderBanner(BANNER_LARGE, "truecolor");
+    expect(truecolor).toContain(`${ESC}[38;2;108;59;255m`); // #6c3bff, column 0
+    expect(truecolor).toContain(`${ESC}[38;2;167;139;250m`); // #a78bfa, last column
+
+    const ansi = renderBanner(BANNER_COMPACT, "ansi");
+    expect(ansi).not.toContain("38;2;");
+    expect(ansi).toContain(`${ESC}[35m`);
+    expect(ansi).toContain(`${ESC}[95m`);
+  });
+});
+
+describe("bannerColorMode", () => {
+  it.each([
+    ["COLORTERM=truecolor", { COLORTERM: "truecolor" }, "truecolor"],
+    ["COLORTERM=24bit", { COLORTERM: "24bit" }, "truecolor"],
+    ["TERM says direct", { TERM: "xterm-direct" }, "truecolor"],
+    ["plain xterm", { TERM: "xterm" }, "ansi"],
+    ["256 colours only", { TERM: "xterm-256color" }, "ansi"],
+    ["nothing declared", {}, "ansi"],
+  ] as const)("%s → %s", (_name, env, expected) => {
+    expect(bannerColorMode(env)).toBe(expected);
+  });
+});
+
+describe("bannerFrames", () => {
+  it.each(CONCEPTS)("%s: the last frame IS the settled frame", (concept) => {
+    const frames = bannerFrames(BANNER_COMPACT, "truecolor", concept);
+    expect(frames.at(-1)).toBe(renderBanner(BANNER_COMPACT, "truecolor"));
+    // …and it is an arrival, not a still: something happens before it.
+    expect(frames[0]).not.toBe(frames.at(-1));
+    expect(frames.length).toBeGreaterThan(8);
+  });
+
+  it.each(CONCEPTS)("%s: every frame is the same height, so the cursor-up redraw lands", (concept) => {
+    for (const frame of bannerFrames(BANNER_COMPACT, "ansi", concept)) {
+      expect(frame.split("\n")).toHaveLength(BANNER_COMPACT.length);
+    }
+  });
+
+  it("flow: the mark crystallizes behind a band moving left to right", () => {
+    const frames = bannerFrames(BANNER_COMPACT, "ansi", "flow");
+    const inked = (frame: string): number => stripAnsi(frame).replace(/[^█▀▄]/g, "").length;
+    // More of the mark is drawn on every frame, and nothing ever moves: what
+    // is drawn is exactly a left prefix of the settled art.
+    let previous = -1;
+    for (const frame of frames) {
+      expect(inked(frame)).toBeGreaterThanOrEqual(previous);
+      previous = inked(frame);
+      stripAnsi(frame).split("\n").forEach((row, index) => {
+        expect(row).toHaveLength(BANNER_COMPACT[index]!.length);
+        expect(BANNER_COMPACT[index]!.startsWith(row.trimEnd())).toBe(true);
+      });
+    }
+    expect(inked(frames.at(-1)!)).toBe(inked(renderBanner(BANNER_COMPACT, "ansi")));
+  });
+
+  it("assembly: the mark lands top-down", () => {
+    const frames = bannerFrames(BANNER_COMPACT, "ansi", "assembly");
+    const drawnRows = (frame: string): number =>
+      stripAnsi(frame).split("\n").filter((row) => row.trim() !== "").length;
+    expect(drawnRows(frames[0]!)).toBeLessThan(drawnRows(frames.at(-1)!));
+    for (const [index, frame] of frames.entries()) {
+      if (index === 0) continue;
+      expect(drawnRows(frame)).toBeGreaterThanOrEqual(drawnRows(frames[index - 1]!));
+    }
+  });
+
+  it("shimmer: the whole mark is there on frame one — a dropped frame costs nothing", () => {
+    const frames = bannerFrames(BANNER_COMPACT, "ansi", "shimmer");
+    expect(stripAnsi(frames[0]!)).toBe(BANNER_COMPACT.join("\n"));
+    // Only the highlight moves: the band is bright white, and it is gone by
+    // the settled frame.
+    expect(frames[0]).toContain(`${ESC}[97m`);
+    expect(frames.at(-1)).not.toContain(`${ESC}[97m`);
+  });
+});
+
+describe("playBanner", () => {
+  it("redraws in place, plays once, and ends on the settled frame", async () => {
+    const chunks: string[] = [];
+    const frames = bannerFrames(BANNER_COMPACT, "ansi", BANNER_CONCEPT);
+    await playBanner((chunk) => { chunks.push(chunk); }, frames, 0);
+    const written = chunks.join("");
+    // Cursor-up over the block for every frame after the first — and no
+    // alternate screen buffer, ever.
+    expect(written.split(`${ESC}[${BANNER_COMPACT.length}A`)).toHaveLength(frames.length);
+    expect(written).not.toContain("?1049h");
+    expect(written.endsWith(`${frames.at(-1)!.split("\n").map((row) => `${ESC}[2K${row}`).join("\n")}\n`))
+      .toBe(true);
+
+    // Played once: nothing is written after it resolves.
+    const settled = chunks.length;
+    await new Promise((resolve) => { setTimeout(resolve, 20); });
+    expect(chunks).toHaveLength(settled);
+  });
+
+  it("writes nothing when there are no frames", async () => {
+    const chunks: string[] = [];
+    await playBanner((chunk) => { chunks.push(chunk); }, [], 0);
+    expect(chunks).toHaveLength(0);
+  });
+});

--- a/packages/vendo/tests/cli/pretty.test.ts
+++ b/packages/vendo/tests/cli/pretty.test.ts
@@ -1,6 +1,7 @@
 import { PassThrough, Writable } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createPrettyOutput, plainSelect, usePrettyOutput, type SelectInput } from "../../src/cli/pretty.js";
+import { plainSecret, plainText } from "../../src/cli/pretty.js";
 
 const ESC = "\u001b";
 
@@ -85,16 +86,37 @@ describe("usePrettyOutput (selection)", () => {
 describe("createPrettyOutput (visual system)", () => {
   it("opens with the vendo init header exactly once", () => {
     const out = sink();
-    const pretty = createPrettyOutput(out.write);
+    const pretty = createPrettyOutput({ write: out.write, banner: false });
     pretty.log("hello");
     pretty.log("again");
     expect(out.plain()).toContain("┌  vendo init");
     expect(out.plain().match(/┌ {2}vendo init/g)).toHaveLength(1);
   });
 
+  it("names the command it was created for", () => {
+    const out = sink();
+    createPrettyOutput({ write: out.write, banner: false, command: "vendo sync" }).log("hello");
+    expect(out.plain()).toContain("┌  vendo sync");
+  });
+
+  it("prints the settled banner and the tagline above the header, and skips both when asked", () => {
+    const withBanner = sink();
+    createPrettyOutput({ write: withBanner.write, env: { COLORTERM: "truecolor" } }).log("hello");
+    const plain = withBanner.plain();
+    expect(plain).toContain("▄▄█████▄");
+    expect(plain).toContain("Customize your product with an embedded agent");
+    expect(plain.indexOf("▄▄█████▄")).toBeLessThan(plain.indexOf("┌  vendo init"));
+    // Truecolor terminals get the real brand ramp.
+    expect(withBanner.raw()).toContain(`${ESC}[38;2;`);
+
+    const without = sink();
+    createPrettyOutput({ write: without.write, banner: false }).log("hello");
+    expect(without.plain()).not.toContain("▄▄█████▄");
+  });
+
   it("renders the wired section with colored diff markers and bar-prefixed paths", () => {
     const out = sink();
-    const pretty = createPrettyOutput(out.write);
+    const pretty = createPrettyOutput({ write: out.write, banner: false });
     pretty.log("\nWired (3 files):");
     pretty.log("  + vendo/registry.tsx");
     pretty.log("  + app/api/vendo/[...vendo]/route.ts");
@@ -103,15 +125,15 @@ describe("createPrettyOutput (visual system)", () => {
     expect(plain).toContain("◆  Wired (3 files)");
     expect(plain).toContain("│  + vendo/registry.tsx");
     expect(plain).toContain("│  ~ package.json");
-    // + green, ~ yellow, paths dimmed-cyan.
+    // + green, ~ yellow, paths dimmed in the accent.
     expect(out.raw()).toContain(`${ESC}[32m+${ESC}[39m`);
     expect(out.raw()).toContain(`${ESC}[33m~${ESC}[39m`);
-    expect(out.raw()).toContain(`${ESC}[36mpackage.json${ESC}[39m`);
+    expect(out.raw()).toContain(`${ESC}[95mpackage.json${ESC}[39m`);
   });
 
   it("renders Vendo Cloud as the emphasized section: header, ✦ bullets, → CTA", () => {
     const out = sink();
-    const pretty = createPrettyOutput(out.write);
+    const pretty = createPrettyOutput({ write: out.write, banner: false });
     pretty.log("\nVendo Cloud (optional): not configured. A key unlocks team sharing & org governance; hosted automations; the MCP broker.");
     pretty.log("Run `vendo login` to claim a free API key; it lands in .env.local.");
     const plain = out.plain();
@@ -122,35 +144,90 @@ describe("createPrettyOutput (visual system)", () => {
     // The CTA line gets the arrow treatment and keeps the command visible.
     expect(plain).toContain("→ ");
     expect(plain).toContain("vendo login");
-    // The header is bold + brand blue (the most prominent block on screen).
-    expect(out.raw()).toContain(`${ESC}[34mVendo Cloud${ESC}[39m`);
+    // The header is bold + the brand accent (the most prominent block on screen).
+    expect(out.raw()).toContain(`${ESC}[95mVendo Cloud${ESC}[39m`);
     expect(out.raw()).toContain(`${ESC}[1m`);
   });
 
   it("renders a configured Vendo Cloud key under the same emphasized header", () => {
     const out = sink();
-    const pretty = createPrettyOutput(out.write);
+    const pretty = createPrettyOutput({ write: out.write, banner: false });
     pretty.log("\nVendo Cloud: VENDO_API_KEY present and well-formed.");
     const plain = out.plain();
     expect(plain).toContain("◆  Vendo Cloud");
     expect(plain).toContain("✦ VENDO_API_KEY present and well-formed.");
   });
 
-  it("renders the theme summary as a captured section", () => {
+  it("renders the theme summary as the brand payoff block", () => {
     const out = sink();
-    const pretty = createPrettyOutput(out.write);
+    const pretty = createPrettyOutput({ write: out.write, banner: false });
     pretty.log("Theme: accent #2b7fff · background #fafafa");
     pretty.log("Type: Inter · radius 8px");
     pretty.log("Theme lives in .vendo/theme.json — edit it anytime; it is the source of truth.");
     const plain = out.plain();
-    expect(plain).toContain("◇  Theme captured");
+    expect(plain).toContain("◆  Your brand");
     expect(plain).toContain("│  accent #2b7fff · background #fafafa");
     expect(plain).toContain("│  Type: Inter · radius 8px");
   });
 
+  it("collapses sync's five catalog lines into one ◆ Catalog block of two lines", () => {
+    const out = sink();
+    const pretty = createPrettyOutput({ write: out.write, banner: false });
+    pretty.log("tools: +2 -0 ~1");
+    pretty.log("tool schemas: inputs 11/13 · outputs 11/13");
+    pretty.log("pins: 3 captured, 1 drifted");
+    pretty.log("catalog.json: 5 discovered, 5 registered");
+    pretty.log("components: 2 captured, 1 updated");
+    pretty.done(4200, true);
+    const block = out.plain().split("\n").filter((entry) => entry.includes("Catalog")
+      || entry.includes("tools:") || entry.includes("components:"));
+    expect(block[0]).toContain("◆  Catalog");
+    expect(block[1]).toBe("│  tools: +2 -0 ~1 · tool schemas: inputs 11/13 · outputs 11/13 · pins: 3 captured, 1 drifted · catalog.json: 5 discovered, 5 registered");
+    expect(block[2]).toBe("│  components: 2 captured, 1 updated");
+    expect(block).toHaveLength(3);
+  });
+
+  it("collapses the judgment narrative to its counts plus the line that needs the user", () => {
+    const out = sink();
+    const pretty = createPrettyOutput({ write: out.write, banner: false });
+    pretty.log("judgment (claude-code): 12 tools judged");
+    pretty.log("  hardened (3): createInvoice, sendEmail, refund");
+    pretty.log("  schemas inferred (4): createInvoice.input, refund.output");
+    pretty.log("  2 loosenings queued — review with `vendo sync --review`");
+    pretty.log("  rejected by the skeptic (1): deleteAccount");
+    pretty.log("\nTheme: accent #7c3bed");
+    const plain = out.plain();
+    expect(plain).toContain("◆  Judgment");
+    expect(plain).toContain("│  12 tools judged · hardened (3) · schemas inferred (4) · rejected by the skeptic (1)");
+    expect(plain).toContain("│  2 loosenings queued — review with vendo sync --review");
+    // The long name lists are gone; --json and `vendo sync` still carry them.
+    expect(plain).not.toContain("createInvoice, sendEmail, refund");
+    // The block settles before the next section opens.
+    expect(plain.indexOf("◆  Judgment")).toBeLessThan(plain.indexOf("◆  Your brand"));
+  });
+
+  it("turns the 64-dash paste frame into a ◇ section with an indented code block", () => {
+    const out = sink();
+    const rule = "─".repeat(64);
+    const pretty = createPrettyOutput({ write: out.write, banner: false });
+    pretty.log(`\n${rule}`);
+    pretty.log("ONE STEP LEFT — paste this yourself (init never edits your files)");
+    pretty.log("\n  File: app/layout.tsx");
+    pretty.log("    import { VendoProvider } from \"@vendoai/vendo/react\";");
+    pretty.log("\n  Without it, nothing on the page can reach Vendo.");
+    pretty.log("  Then confirm it landed: npx vendo doctor");
+    pretty.log(rule);
+    const plain = out.plain();
+    expect(plain).toContain("◇  One paste left — app/layout.tsx");
+    expect(plain).toContain("│    import { VendoProvider } from \"@vendoai/vendo/react\";");
+    expect(plain).toContain("│  init never edits your files");
+    expect(plain).not.toContain(rule);
+    expect(plain).not.toContain("ONE STEP LEFT");
+  });
+
   it("renders warnings yellow with ⚠ and other errors red with ✖", () => {
     const out = sink();
-    const pretty = createPrettyOutput(out.write);
+    const pretty = createPrettyOutput({ write: out.write, banner: false });
     pretty.error("warning: extraction skipped app/broken.ts");
     pretty.error("vendo init failed");
     const plain = out.plain();
@@ -160,9 +237,55 @@ describe("createPrettyOutput (visual system)", () => {
     expect(out.raw()).toContain(`${ESC}[31m✖ vendo init failed${ESC}[39m`);
   });
 
+  // BUG 1. The `code` span closes with a foreground reset, so without the
+  // re-arm every character after the first span in a warning printed white —
+  // the loudest half of the most security-sensitive line in the install.
+  it("keeps a warning yellow past an inline code span", () => {
+    const out = sink();
+    const pretty = createPrettyOutput({ write: out.write, banner: false });
+    pretty.error("warning: .env.local holds a secret — add it to `.gitignore` before you commit");
+    expect(out.raw()).toContain(`${ESC}[39m${ESC}[22m${ESC}[33m before you commit`);
+    // Same for a red error line.
+    pretty.error("cannot read `package.json` — is this a project root?");
+    expect(out.raw()).toContain(`${ESC}[39m${ESC}[22m${ESC}[31m — is this a project root?`);
+  });
+
+  // BUG 2. The rail may absorb the FIRST indent level, and only inside a
+  // section; under a narrative line the indent IS the hierarchy.
+  it("absorbs a section's first indent level but keeps a narrative's sub-lines indented", () => {
+    const out = sink();
+    const pretty = createPrettyOutput({ write: out.write, banner: false });
+    pretty.log("brief: drafting from 12 judged tools");
+    pretty.log("  theme: filling brand slots");
+    pretty.log("\nLast steps are yours:");
+    pretty.log("  In app/layout.tsx:");
+    pretty.log("    import { VendoRoot } from \"@vendoai/vendo/react\";");
+    const plain = out.plain();
+    expect(plain).toContain("│  brief: drafting from 12 judged tools");
+    expect(plain).toContain("│    theme: filling brand slots");
+    expect(plain).toContain("◇  Last steps are yours");
+    expect(plain).toContain("│  In app/layout.tsx:");
+    expect(plain).toContain("│    import { VendoRoot }");
+  });
+
+  // BUG 3. The CTA decorates the trimmed text; the kept indent goes back in
+  // front, so the arrow lands on the siblings' column instead of shoving the
+  // line three spaces right of them.
+  it("aligns a CTA line with its siblings in the agent tail", () => {
+    const out = sink();
+    const pretty = createPrettyOutput({ write: out.write, banner: false });
+    pretty.log("\nAgent tail:");
+    pretty.log("  auth: none wired");
+    pretty.log("  cloud key: none — fetch https://vendo.run/auth.md and run `vendo login`, then re-run init");
+    const lines = out.plain().split("\n");
+    const sibling = lines.find((entry) => entry.includes("auth: none wired"))!;
+    const cta = lines.find((entry) => entry.includes("cloud key: none"))!;
+    expect(cta.indexOf("→")).toBe(sibling.indexOf("auth:"));
+  });
+
   it("renders the last-steps section and closes with the done footer", () => {
     const out = sink();
-    const pretty = createPrettyOutput(out.write);
+    const pretty = createPrettyOutput({ write: out.write, banner: false });
     pretty.log("\nLast steps are yours:");
     pretty.log("  In app/layout.tsx:");
     pretty.log("    import { VendoRoot } from \"@vendoai/vendo/react\";");
@@ -177,19 +300,37 @@ describe("createPrettyOutput (visual system)", () => {
     expect(plain).toContain("└  Done in 4.2s");
   });
 
+  it("carries what the run achieved in the footer", () => {
+    const out = sink();
+    const pretty = createPrettyOutput({ write: out.write, banner: false });
+    pretty.done(12400, true, "14 tools · brand captured · 1 paste left");
+    expect(out.plain()).toContain("└  Done in 12.4s — 14 tools · brand captured · 1 paste left");
+  });
+
   it("closes with a red failure footer when init fails", () => {
     const out = sink();
-    const pretty = createPrettyOutput(out.write);
+    const pretty = createPrettyOutput({ write: out.write, banner: false });
     pretty.error("boom");
     pretty.done(900, false);
     expect(out.plain()).toContain("└  Failed after 0.9s");
     expect(out.raw()).toContain(`${ESC}[31mFailed after 0.9s${ESC}[39m`);
   });
 
+  it("block: a pretty-only result block on the rail", () => {
+    const out = sink();
+    const pretty = createPrettyOutput({ write: out.write, banner: false });
+    pretty.block("Your stack", ["Next.js · App Router · TypeScript · pnpm", "Clerk auth (@clerk/nextjs)"]);
+    pretty.block("Where will this deploy?", ["https://app.acme.com"], "◇");
+    const plain = out.plain();
+    expect(plain).toContain("◆  Your stack");
+    expect(plain).toContain("│  Next.js · App Router · TypeScript · pnpm");
+    expect(plain).toContain("◇  Where will this deploy?");
+  });
+
   it("select: arrow keys move the selection, Enter accepts, list collapses to the answer", async () => {
     const out = sink();
     const keys = fakeInput();
-    const pretty = createPrettyOutput(out.write, keys.input);
+    const pretty = createPrettyOutput({ write: out.write, input: keys.input, banner: false });
     const choice = pretty.select("Which auth should Vendo wire?", [
       { value: "none", label: "none — stay anonymous, add it later" },
       { value: "clerk", label: "clerk() — Clerk", hint: "detected @clerk/nextjs" },
@@ -209,7 +350,7 @@ describe("createPrettyOutput (visual system)", () => {
   it("select: number keys pick directly without Enter", async () => {
     const out = sink();
     const keys = fakeInput();
-    const pretty = createPrettyOutput(out.write, keys.input);
+    const pretty = createPrettyOutput({ write: out.write, input: keys.input, banner: false });
     const choice = pretty.select("Which auth should Vendo wire?", [
       { value: "none", label: "none" },
       { value: "authJs", label: "authJs()" },
@@ -224,17 +365,26 @@ describe("createPrettyOutput (visual system)", () => {
     // vitest's stdin is not a TTY: the styled confirm must never block
     // readline — the default stands (stdout-TTY selection is stdout-only).
     const out = sink();
-    const pretty = createPrettyOutput(out.write);
+    const pretty = createPrettyOutput({ write: out.write, banner: false });
     await expect(pretty.confirm("Wire auth: authJs()?", true)).resolves.toBe(true);
     await expect(pretty.confirm("Log in to Vendo Cloud now?", false)).resolves.toBe(false);
     expect(out.plain()).not.toContain("Wire auth");
     expect(out.plain()).not.toContain("Log in");
   });
 
+  it("text and secret return the empty skip without prompting when stdin is not a TTY", async () => {
+    const out = sink();
+    const pretty = createPrettyOutput({ write: out.write, banner: false });
+    await expect(pretty.text("Where will this deploy?")).resolves.toBe("");
+    await expect(pretty.secret("Paste your provider key")).resolves.toBe("");
+    expect(out.plain()).not.toContain("Where will this deploy?");
+    expect(out.plain()).not.toContain("Paste your provider key");
+  });
+
   it("select: one pasted chunk containing '2\\r' picks option 2", async () => {
     const out = sink();
     const keys = fakeInput();
-    const pretty = createPrettyOutput(out.write, keys.input);
+    const pretty = createPrettyOutput({ write: out.write, input: keys.input, banner: false });
     const choice = pretty.select("Which auth should Vendo wire?", [
       { value: "none", label: "none" },
       { value: "authJs", label: "authJs()" },
@@ -247,7 +397,7 @@ describe("createPrettyOutput (visual system)", () => {
   it("select: several keys in one chunk are all consumed (two arrow-downs move twice)", async () => {
     const out = sink();
     const keys = fakeInput();
-    const pretty = createPrettyOutput(out.write, keys.input);
+    const pretty = createPrettyOutput({ write: out.write, input: keys.input, banner: false });
     const choice = pretty.select("Which auth should Vendo wire?", [
       { value: "none", label: "none" },
       { value: "authJs", label: "authJs()" },
@@ -261,7 +411,7 @@ describe("createPrettyOutput (visual system)", () => {
   it("select: an escape sequence split across chunks still moves", async () => {
     const out = sink();
     const keys = fakeInput();
-    const pretty = createPrettyOutput(out.write, keys.input);
+    const pretty = createPrettyOutput({ write: out.write, input: keys.input, banner: false });
     const choice = pretty.select("Which auth should Vendo wire?", [
       { value: "none", label: "none" },
       { value: "authJs", label: "authJs()" },
@@ -274,10 +424,10 @@ describe("createPrettyOutput (visual system)", () => {
 
   it("select returns the default option without prompting when stdin is not a TTY", async () => {
     const out = sink();
-    const pretty = createPrettyOutput(out.write, {
-      isTTY: false,
-      on: () => undefined,
-      off: () => undefined,
+    const pretty = createPrettyOutput({
+      write: out.write,
+      banner: false,
+      input: { isTTY: false, on: () => undefined, off: () => undefined },
     });
     await expect(pretty.select("Which auth should Vendo wire?", [
       { value: "none", label: "none — stay anonymous" },
@@ -293,10 +443,20 @@ describe("createPrettyOutput (visual system)", () => {
     ])).toBe("none");
   });
 
+  it("plainText and plainSecret answer the empty skip without prompting when not a TTY", async () => {
+    expect(await plainText("Where will this deploy?")).toBe("");
+    expect(await plainSecret("Paste your provider key")).toBe("");
+  });
+
   it("confirm parses y / n / Enter-default / other text through a real readline", async () => {
     const out = sink();
     const io = promptStreams();
-    const pretty = createPrettyOutput(out.write, io.input, io.output);
+    const pretty = createPrettyOutput({
+      write: out.write,
+      input: io.input,
+      promptOutput: io.output,
+      banner: false,
+    });
 
     const enterAccepts = pretty.confirm("Wire auth: authJs()?", true);
     io.input.write("\n");
@@ -319,6 +479,53 @@ describe("createPrettyOutput (visual system)", () => {
     expect(plain).toContain("◇  Wire auth: authJs()?");
     expect(plain).toContain("● Yes");
     expect(plain).toContain("● No");
+  });
+
+  it("text asks on the rail, echoes the answer, and calls an empty answer a skip", async () => {
+    const out = sink();
+    const io = promptStreams();
+    const pretty = createPrettyOutput({
+      write: out.write,
+      input: io.input,
+      promptOutput: io.output,
+      banner: false,
+    });
+
+    const answered = pretty.text("Where will this deploy?", "e.g. https://app.acme.com — Enter to skip");
+    io.input.write("https://app.acme.com\n");
+    expect(await answered).toBe("https://app.acme.com");
+
+    const skipped = pretty.text("Where will this deploy?");
+    io.input.write("\n");
+    expect(await skipped).toBe("");
+
+    const plain = out.plain();
+    expect(plain).toContain("◇  Where will this deploy?");
+    expect(plain).toContain("│  e.g. https://app.acme.com — Enter to skip");
+    expect(plain).toContain("● https://app.acme.com");
+    expect(plain).toContain("● skipped");
+  });
+
+  it("secret echoes a masked receipt and never the value", async () => {
+    const out = sink();
+    const io = promptStreams();
+    (io.input as PassThrough & { setRawMode?: (mode: boolean) => void }).setRawMode = () => undefined;
+    const pretty = createPrettyOutput({
+      write: out.write,
+      input: io.input,
+      promptOutput: io.output,
+      banner: false,
+    });
+
+    const answered = pretty.secret("Paste your provider key", "ANTHROPIC_API_KEY");
+    io.input.write("sk-ant-secret-a41c\n");
+    expect(await answered).toBe("sk-ant-secret-a41c");
+
+    const plain = out.plain();
+    expect(plain).toContain("◇  Paste your provider key");
+    expect(plain).toContain("● •••••••• (…a41c)");
+    expect(plain).not.toContain("sk-ant-secret-a41c");
+    expect(io.echoed()).not.toContain("sk-ant-secret-a41c");
   });
 
   it("plainSelect drives the numbered list: pick, Enter-default, out-of-range and garbage settle on the default", async () => {
@@ -353,10 +560,27 @@ describe("createPrettyOutput (visual system)", () => {
     expect(await text).toBe("none");
   });
 
+  it("plainText and plainSecret drive a real readline, and only plainSecret hides the typing", async () => {
+    const asked = promptStreams();
+    const answer = plainText("Where will this deploy?", "Enter to skip", asked.input, asked.output);
+    asked.input.write("https://app.acme.com\n");
+    expect(await answer).toBe("https://app.acme.com");
+    expect(asked.echoed()).toContain("Where will this deploy?");
+    expect(asked.echoed()).toContain("  Enter to skip");
+
+    const secret = promptStreams();
+    (secret.input as PassThrough & { setRawMode?: (mode: boolean) => void }).setRawMode = () => undefined;
+    const key = plainSecret("Paste your provider key", undefined, secret.input, secret.output);
+    secret.input.write("sk-ant-secret-a41c\n");
+    expect(await key).toBe("sk-ant-secret-a41c");
+    expect(secret.echoed()).toContain("•••••••• (…a41c)");
+    expect(secret.echoed()).not.toContain("sk-ant-secret-a41c");
+  });
+
   it("spins during slow phases and clears the frame before any log line", () => {
     vi.useFakeTimers();
     const out = sink();
-    const pretty = createPrettyOutput(out.write);
+    const pretty = createPrettyOutput({ write: out.write, banner: false });
     pretty.spin("Capturing your theme");
     vi.advanceTimersByTime(300);
     expect(out.plain()).toContain("Capturing your theme");

--- a/packages/vendo/tests/cli/pretty.test.ts
+++ b/packages/vendo/tests/cli/pretty.test.ts
@@ -307,6 +307,19 @@ describe("createPrettyOutput (visual system)", () => {
     expect(out.plain()).toContain("└  Done in 12.4s — 14 tools · brand captured · 1 paste left");
   });
 
+  // The star ask is a dim footer line now, not a question. It is pretty-only:
+  // usePrettyOutput already keeps plain, piped, NO_COLOR, CI and TERM=dumb runs
+  // out of this renderer entirely.
+  it("closes the run with the dim star line", () => {
+    const out = sink();
+    const pretty = createPrettyOutput({ write: out.write, banner: false });
+    pretty.done(12400, true, "14 tools · brand captured");
+    const lines = out.plain().trimEnd().split("\n");
+    expect(lines.at(-2)).toContain("└  Done in 12.4s");
+    expect(lines.at(-1)).toBe("   Star us: vendo.run/star · docs.vendo.run");
+    expect(out.raw()).toContain(`${ESC}[2mStar us: vendo.run/star · docs.vendo.run${ESC}[22m`);
+  });
+
   it("closes with a red failure footer when init fails", () => {
     const out = sink();
     const pretty = createPrettyOutput({ write: out.write, banner: false });


### PR DESCRIPTION
The vendo CLI gets its face: the brand banner, the purple marker set, three new
renderer primitives, and three rendering bugs die. Slice 1 of the init/sync
redesign — renderer only. `init.ts` is untouched, so the degradation contract is
untouched with it.

## What lands

**`packages/vendo/src/cli/banner.ts` (new)** — the Vendo mark and wordmark as
data: half-block art (12×72 compact, 25×44 large), lifted verbatim from the
approved mock, coloured by one `#6c3bff → #a78bfa` ramp mapped across the art's
**columns** so the gradient runs through the whole mark instead of restarting on
every row. Terminals without truecolor get the ANSI magenta pair.

- `bannerColorMode(env?)` → `truecolor | ansi`
- `renderBanner(art, mode)` → the settled frame
- `bannerFrames(art, mode, concept)` — all three approved concepts ship
  (`assembly`, `flow`, `shimmer`). **LAW, and it has a test per concept: the last
  frame ALWAYS equals the settled frame.** A terminal that drops every frame in
  between still lands on the finished mark.
- `playBanner(write, frames, frameMs = 90)` — cursor-up redraws, **no alternate
  screen buffer**, plays once, never loops.
- `BANNER_CONCEPT = "flow"` — the decided arrival.

**`pretty.ts`** — `createPrettyOutput` takes an options object
(`{ command, write, input, promptOutput, banner, env }`), every field optional.
`usePrettyOutput` is byte-for-byte unchanged: same body, same gate, same
semantics. New on `PrettyOutput`: `text()`, `secret()` (masked receipt; the value
is never written to the terminal), `block()`, and `done(ms, ok, stats?)` so the
footer can say what the run achieved. `plainText` / `plainSecret` join
`plainSelect` with its exact non-TTY guard.

Collapse rules — pure string rules over the exact plain strings the callers
already emit; the renderer restyles and groups, and never writes copy of its own:
sync's five catalog lines → `◆ Catalog` + 2; the judgment narrative's nine flat
lines → `◆ Judgment` + counts + the one line that needs the user; the 64-dash
paste frame → `◇ One paste left — app/layout.tsx` with a real indented code block.

The accent moves cyan → the purple family (`◈ ◇ ◆ ● ✦ ⠹`). Green, yellow and red
keep their meanings: added, changed, broken.

## The three bugs, each proven red first

**1 · The warning colour died at the first backtick.** An inline `` `code` ``
span closes with a foreground reset, so every character after the first span in a
yellow warning printed white — the loudest half of the gitignore warning stopped
looking like a warning. `styleInline(text, reopen?)` now re-arms the enclosing
colour; `error()` passes yellow/red.

```
RED (fix reverted):
   × createPrettyOutput (visual system) > keeps a warning yellow past an inline code span 21ms
     → expected '[2m┌[22m  [1mvendo …' to contain '[39m[22m[33m before…'
      Tests  1 failed | 40 skipped (41)
```

**2 · The judgment narrative's indentation was eaten.** The rail absorbed every
leading two-space indent, so sub-lines sat flush with their headline exactly
where the run is slowest. Now the rail absorbs the FIRST level only, and only
inside a section; under a plain narrative line the indent IS the hierarchy.

```
RED (fix reverted):
   × createPrettyOutput (visual system) > absorbs a section's first indent level but keeps a narrative's sub-lines indented 30ms
     → expected '┌  vendo init\n│\n│  brief: drafting …' to contain '│    theme: filling brand slots'
      Tests  1 failed | 40 skipped (41)
```

**3 · One agent-tail line sat three spaces right of its siblings.** The CTA rule
fired on the raw string and prefixed the arrow ahead of the indent. Now the
indent is trimmed before the arrow is applied and re-applied after.

```
RED (fix reverted):
   × createPrettyOutput (visual system) > aligns a CTA line with its siblings in the agent tail 21ms
     → expected 3 to be 5 // Object.is equality
      Tests  1 failed | 40 skipped (41)
```

All three restored, green:

```
 ✓ tests/cli/pretty.test.ts (41 tests) 58ms
 ✓ tests/cli/banner.test.ts (21 tests) 103ms
 Test Files  2 passed (2)
      Tests  62 passed (62)
```

## The degradation contract held

The pinned `usePrettyOutput` block in `tests/cli/pretty.test.ts` (the TTY gate,
`NO_COLOR`, `CI`, `TERM=dumb`, and the empty-string no-color.org semantics) is
untouched, along with the import line that names it:

```
$ git diff origin/main -- packages/vendo/tests/cli/pretty.test.ts \
    | grep '^-' | grep -E 'usePrettyOutput|NO_COLOR|TERM=dumb|CI set|no-color.org'
(no output)
```

## Verified in a real terminal

Every shot below is the real renderer driven through a real PTY (`pty.fork`,
104×60), the resulting byte stream replayed through a terminal emulator, and the
final screen photographed — not a mockup and not a pipe.

| | |
|---|---|
| ![Truecolor, settled](https://github.com/runvendo/vendo/releases/download/untagged-bce703a2850432efdeaf/01-truecolor-settled.png) | **Truecolor, settled** — the banner, the tagline, the purple marker set. Also visible: **(d)** the warning stays yellow past `` `.env.local` ``, **(e)** `theme: filling brand slots` keeps its indent under `brief: drafted`, **(f)** the `→ cloud key` arrow sits on `auth:`/`gate:`'s column. |
| ![Mid-animation](https://github.com/runvendo/vendo/releases/download/untagged-bce703a2850432efdeaf/02-flow-mid-animation.png) | **The flow, mid-arrival** — the mark is settled behind the bright leading band and empty ahead of it. One pass, then it stays. |
| ![TERM=xterm](https://github.com/runvendo/vendo/releases/download/untagged-bce703a2850432efdeaf/03-term-xterm-ansi.png) | **`TERM=xterm`** — the ANSI-magenta fallback. Same layout, same legibility, no truecolor. |
| ![NO_COLOR=1 on a TTY](https://github.com/runvendo/vendo/releases/download/untagged-bce703a2850432efdeaf/04-no-color-tty.png) | **`NO_COLOR=1` on a TTY** — no banner, no rail, no colour. Today's exact plain strings, byte for byte. |

## One thing to know

`text()`, `secret()` and `block()` ship with **no production caller yet** — slice
S2 wires them into `init.ts` within the week. The banner, the purple accent, the
collapse rules and the three bug fixes are all live on this slice, because
`createPrettyOutput()`'s existing zero-argument call site picks them up unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a branded CLI banner with a purple accent and expands the renderer with `text()`, `secret()`, and `block()`. Fixes three rendering glitches and keeps plain output byte-for-byte unchanged.

- **New Features**
  - Added `packages/vendo/src/cli/banner.ts`: compact and large half‑block art, truecolor column ramp with ANSI fallback, and a tagline under the banner.
  - APIs: `bannerColorMode(env?)`, `renderBanner(art, mode)`, `bannerFrames(art, mode, concept)`, `playBanner(write, frames, frameMs)`, `BANNER_CONCEPT="flow"` — animations play once; last frame equals the settled frame; no alt screen buffer.
  - `createPrettyOutput(options)` now accepts `{ command, write, input, promptOutput, banner, env }` and adds `text()`, `secret()` (masked receipt; value never printed), `block()`, and `done(ms, ok, stats?)`.
  - Collapse rules restyle existing plain strings only: catalog 5 lines → `◆ Catalog` + 2 lines; judgment narrative → counts + the one actionable line; 64‑dash paste frame → `◇` section with an indented code block.
  - Accent moves to purple (`◈ ◇ ◆ ● ✦ ⠹`), spinner uses braille frames. `plainText`/`plainSecret` join `plainSelect` with the same non‑TTY guard. `usePrettyOutput` unchanged; non‑TTY/`NO_COLOR`/`CI`/`TERM=dumb` runs keep exact plain output.
  - Footer adds a dim “Star us: vendo.run/star · docs.vendo.run” line (pretty‑only).

- **Bug Fixes**
  - Kept warning color after inline code spans by re‑arming the enclosing color.
  - Restored indentation: the rail absorbs only the first indent level inside sections; narrative sub‑lines keep their indent.
  - Aligned CTA lines by trimming before decorating and reapplying indent so arrows line up with siblings.

<sup>Written for commit 5601cabd9cda6786955a2c056d8ab694417da825. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

