### PR TITLE
chore: pending breaking changesets ship as minors — 0.x stays pre-1.0

### DIFF
--- a/.changeset/apps-contract-door-and-server-half.md
+++ b/.changeset/apps-contract-door-and-server-half.md
@@ -1,10 +1,10 @@
 ---
-"@vendoai/core": major
-"@vendoai/apps": major
-"@vendoai/actions": major
-"@vendoai/store": major
-"@vendoai/mcp": major
-"@vendoai/ui": major
+"@vendoai/core": minor
+"@vendoai/apps": minor
+"@vendoai/actions": minor
+"@vendoai/store": minor
+"@vendoai/mcp": minor
+"@vendoai/ui": minor
 ---
 
 App generation moves into one package, behind two doors

--- a/.changeset/apps-format-constitution.md
+++ b/.changeset/apps-format-constitution.md
@@ -1,6 +1,6 @@
 ---
-"@vendoai/core": major
-"@vendoai/apps": major
+"@vendoai/core": minor
+"@vendoai/apps": minor
 ---
 
 The app format has one definition, and a test that fails when a mirror drifts

--- a/.changeset/apps-remix-becomes-a-seed.md
+++ b/.changeset/apps-remix-becomes-a-seed.md
@@ -1,10 +1,10 @@
 ---
-"@vendoai/apps": major
-"@vendoai/core": major
-"@vendoai/ui": major
-"@vendoai/vendo": major
-"@vendoai/actions": major
-"vendoai": major
+"@vendoai/apps": minor
+"@vendoai/core": minor
+"@vendoai/ui": minor
+"@vendoai/vendo": minor
+"@vendoai/actions": minor
+"vendoai": minor
 ---
 
 Remix is a seeded app: the pins subsystem is gone

--- a/.changeset/kills-zombies-and-comment-rot.md
+++ b/.changeset/kills-zombies-and-comment-rot.md
@@ -1,8 +1,8 @@
 ---
-"@vendoai/core": major
-"@vendoai/apps": major
-"@vendoai/store": major
-"@vendoai/agents": major
+"@vendoai/core": minor
+"@vendoai/apps": minor
+"@vendoai/store": minor
+"@vendoai/agents": minor
 "@vendoai/knowledge": minor
 "@vendoai/actions": minor
 "@vendoai/ui": minor

--- a/.changeset/one-briefing-pack-for-both-rungs.md
+++ b/.changeset/one-briefing-pack-for-both-rungs.md
@@ -1,6 +1,6 @@
 ---
-"@vendoai/apps": major
-"@vendoai/vendo": major
+"@vendoai/apps": minor
+"@vendoai/vendo": minor
 ---
 
 One briefing pack, assembled once, handed to both generation rungs

--- a/.changeset/one-claude-code-integration-and-the-automation-door.md
+++ b/.changeset/one-claude-code-integration-and-the-automation-door.md
@@ -1,5 +1,5 @@
 ---
-"@vendoai/apps": major
+"@vendoai/apps": minor
 "@vendoai/harnesses": minor
 ---
 

--- a/.changeset/one-definition-per-concept-and-one-door-in.md
+++ b/.changeset/one-definition-per-concept-and-one-door-in.md
@@ -1,7 +1,7 @@
 ---
-"@vendoai/apps": major
-"@vendoai/mcp": major
-"@vendoai/automations": major
+"@vendoai/apps": minor
+"@vendoai/mcp": minor
+"@vendoai/automations": minor
 "@vendoai/store": minor
 "@vendoai/core": minor
 ---

--- a/.changeset/vendo-drops-try-and-playground.md
+++ b/.changeset/vendo-drops-try-and-playground.md
@@ -1,5 +1,5 @@
 ---
-"@vendoai/vendo": major
+"@vendoai/vendo": minor
 ---
 
 The playground and the hosted try surface are gone, and with them two entry


### PR DESCRIPTION
The accumulated `major` changesets would take every 0.9.0 package to 1.0.0 on the next Version Packages merge. 1.0 is a deliberate milestone, not a side effect of a release train — per Yousef's call (2026-08-10), breaking changes ship as 0.x minors until we choose to cut 1.0. Converts all pending `major` entries to `minor` (0.9.0 → 0.10.0); no code changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converts all pending `major` changesets to `minor` so 0.x packages stay pre-1.0. Prevents accidental 1.0 bumps; next release moves 0.9.x → 0.10.x across `@vendoai/*`, with no code changes.

<sup>Written for commit a8f7fbd987f5243371d262dcfb073e359f7569f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

