### PR TITLE
fix(vendo,demo-bank): doctor catches an unset mount base URL; Maple's spec and corpus stop teaching a wrong API

### DIFF
--- a/.changeset/doctor-catches-an-unset-mount-base-url.md
+++ b/.changeset/doctor-catches-an-unset-mount-base-url.md
@@ -1,0 +1,13 @@
+---
+"@vendoai/vendo": patch
+---
+
+`vendo doctor`'s mount-agreement check (E-CFG-003) now fires when the OpenAPI
+spec declares a relative `servers[0].url` and `VENDO_BASE_URL` is unset.
+
+It used to return early in exactly that case, so the check was silent in the one
+posture that breaks. With no base URL the wire learns the bare request ORIGIN
+(`onRequestOrigin`) and stored binding paths are prefix-free by law (spec
+2026-08-06 §B1), so a path-mounted host serves every host tool one prefix short
+of the real endpoint: every page renders and every tool call 404s. The existing
+disagree/agree branches and the error code are unchanged.

--- a/examples/demo-bank/.vendo/tools.json
+++ b/examples/demo-bank/.vendo/tools.json
@@ -207,7 +207,7 @@
       },
       "inputSchemaSource": "declared",
       "outputSchemaSource": "declared",
-      "srcHash": "sha256:b0e1443e377bd2e13d505fb33febab4b1c62285700fa0ccaa3993fc063f265bb"
+      "srcHash": "sha256:040140ea40d1985cef514df49fe6a915c394006acab143a09b0216dbbdc62b65"
     },
     {
       "name": "host_demo_reset_create",
@@ -236,7 +236,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "Account id, e.g. acct_checking"
+            "description": "Account id, e.g. acc_checking"
           }
         },
         "required": [
@@ -311,7 +311,7 @@
       },
       "inputSchemaSource": "declared",
       "outputSchemaSource": "declared",
-      "srcHash": "sha256:b0e1443e377bd2e13d505fb33febab4b1c62285700fa0ccaa3993fc063f265bb"
+      "srcHash": "sha256:040140ea40d1985cef514df49fe6a915c394006acab143a09b0216dbbdc62b65"
     },
     {
       "name": "host_getBudgets",
@@ -373,7 +373,7 @@
       },
       "inputSchemaSource": "declared",
       "outputSchemaSource": "declared",
-      "srcHash": "sha256:b0e1443e377bd2e13d505fb33febab4b1c62285700fa0ccaa3993fc063f265bb"
+      "srcHash": "sha256:040140ea40d1985cef514df49fe6a915c394006acab143a09b0216dbbdc62b65"
     },
     {
       "name": "host_getCashflowInsights",
@@ -425,7 +425,7 @@
       },
       "inputSchemaSource": "declared",
       "outputSchemaSource": "declared",
-      "srcHash": "sha256:b0e1443e377bd2e13d505fb33febab4b1c62285700fa0ccaa3993fc063f265bb"
+      "srcHash": "sha256:040140ea40d1985cef514df49fe6a915c394006acab143a09b0216dbbdc62b65"
     },
     {
       "name": "host_getProfile",
@@ -504,7 +504,7 @@
       },
       "inputSchemaSource": "declared",
       "outputSchemaSource": "declared",
-      "srcHash": "sha256:b0e1443e377bd2e13d505fb33febab4b1c62285700fa0ccaa3993fc063f265bb"
+      "srcHash": "sha256:040140ea40d1985cef514df49fe6a915c394006acab143a09b0216dbbdc62b65"
     },
     {
       "name": "host_getRecurringInsights",
@@ -582,7 +582,7 @@
       },
       "inputSchemaSource": "declared",
       "outputSchemaSource": "declared",
-      "srcHash": "sha256:b0e1443e377bd2e13d505fb33febab4b1c62285700fa0ccaa3993fc063f265bb"
+      "srcHash": "sha256:040140ea40d1985cef514df49fe6a915c394006acab143a09b0216dbbdc62b65"
     },
     {
       "name": "host_getSpendingInsights",
@@ -641,7 +641,7 @@
       },
       "inputSchemaSource": "declared",
       "outputSchemaSource": "declared",
-      "srcHash": "sha256:b0e1443e377bd2e13d505fb33febab4b1c62285700fa0ccaa3993fc063f265bb"
+      "srcHash": "sha256:040140ea40d1985cef514df49fe6a915c394006acab143a09b0216dbbdc62b65"
     },
     {
       "name": "host_getTransaction",
@@ -771,7 +771,7 @@
       },
       "inputSchemaSource": "declared",
       "outputSchemaSource": "declared",
-      "srcHash": "sha256:b0e1443e377bd2e13d505fb33febab4b1c62285700fa0ccaa3993fc063f265bb"
+      "srcHash": "sha256:040140ea40d1985cef514df49fe6a915c394006acab143a09b0216dbbdc62b65"
     },
     {
       "name": "host_listAccounts",
@@ -851,7 +851,7 @@
       },
       "inputSchemaSource": "declared",
       "outputSchemaSource": "declared",
-      "srcHash": "sha256:b0e1443e377bd2e13d505fb33febab4b1c62285700fa0ccaa3993fc063f265bb"
+      "srcHash": "sha256:040140ea40d1985cef514df49fe6a915c394006acab143a09b0216dbbdc62b65"
     },
     {
       "name": "host_listAccountTransactions",
@@ -1001,7 +1001,7 @@
       },
       "inputSchemaSource": "declared",
       "outputSchemaSource": "declared",
-      "srcHash": "sha256:b0e1443e377bd2e13d505fb33febab4b1c62285700fa0ccaa3993fc063f265bb"
+      "srcHash": "sha256:040140ea40d1985cef514df49fe6a915c394006acab143a09b0216dbbdc62b65"
     },
     {
       "name": "host_listCards",
@@ -1085,7 +1085,7 @@
       },
       "inputSchemaSource": "declared",
       "outputSchemaSource": "declared",
-      "srcHash": "sha256:b0e1443e377bd2e13d505fb33febab4b1c62285700fa0ccaa3993fc063f265bb"
+      "srcHash": "sha256:040140ea40d1985cef514df49fe6a915c394006acab143a09b0216dbbdc62b65"
     },
     {
       "name": "host_listCardTransactions",
@@ -1235,7 +1235,7 @@
       },
       "inputSchemaSource": "declared",
       "outputSchemaSource": "declared",
-      "srcHash": "sha256:b0e1443e377bd2e13d505fb33febab4b1c62285700fa0ccaa3993fc063f265bb"
+      "srcHash": "sha256:040140ea40d1985cef514df49fe6a915c394006acab143a09b0216dbbdc62b65"
     },
     {
       "name": "host_listGoals",
@@ -1293,7 +1293,7 @@
       },
       "inputSchemaSource": "declared",
       "outputSchemaSource": "declared",
-      "srcHash": "sha256:b0e1443e377bd2e13d505fb33febab4b1c62285700fa0ccaa3993fc063f265bb"
+      "srcHash": "sha256:040140ea40d1985cef514df49fe6a915c394006acab143a09b0216dbbdc62b65"
     },
     {
       "name": "host_listNotifications",
@@ -1361,7 +1361,7 @@
       },
       "inputSchemaSource": "declared",
       "outputSchemaSource": "declared",
-      "srcHash": "sha256:b0e1443e377bd2e13d505fb33febab4b1c62285700fa0ccaa3993fc063f265bb"
+      "srcHash": "sha256:040140ea40d1985cef514df49fe6a915c394006acab143a09b0216dbbdc62b65"
     },
     {
       "name": "host_listPayees",
@@ -1416,7 +1416,7 @@
       },
       "inputSchemaSource": "declared",
       "outputSchemaSource": "declared",
-      "srcHash": "sha256:b0e1443e377bd2e13d505fb33febab4b1c62285700fa0ccaa3993fc063f265bb"
+      "srcHash": "sha256:040140ea40d1985cef514df49fe6a915c394006acab143a09b0216dbbdc62b65"
     },
     {
       "name": "host_listScheduledPayments",
@@ -1483,7 +1483,7 @@
       },
       "inputSchemaSource": "declared",
       "outputSchemaSource": "declared",
-      "srcHash": "sha256:b0e1443e377bd2e13d505fb33febab4b1c62285700fa0ccaa3993fc063f265bb"
+      "srcHash": "sha256:040140ea40d1985cef514df49fe6a915c394006acab143a09b0216dbbdc62b65"
     },
     {
       "name": "host_listTransactions",
@@ -1667,7 +1667,7 @@
       },
       "inputSchemaSource": "declared",
       "outputSchemaSource": "declared",
-      "srcHash": "sha256:b0e1443e377bd2e13d505fb33febab4b1c62285700fa0ccaa3993fc063f265bb"
+      "srcHash": "sha256:040140ea40d1985cef514df49fe6a915c394006acab143a09b0216dbbdc62b65"
     },
     {
       "name": "host_transferMoney",
@@ -1832,7 +1832,7 @@
       },
       "inputSchemaSource": "declared",
       "outputSchemaSource": "declared",
-      "srcHash": "sha256:b0e1443e377bd2e13d505fb33febab4b1c62285700fa0ccaa3993fc063f265bb"
+      "srcHash": "sha256:040140ea40d1985cef514df49fe6a915c394006acab143a09b0216dbbdc62b65"
     },
     {
       "name": "host_voice_create",

--- a/examples/demo-bank/openapi.json
+++ b/examples/demo-bank/openapi.json
@@ -58,7 +58,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Account id, e.g. acct_checking"
+            "description": "Account id, e.g. acc_checking"
           }
         ],
         "responses": {

--- a/examples/demo-bank/src/server/orders.ts
+++ b/examples/demo-bank/src/server/orders.ts
@@ -28,7 +28,7 @@ let orderCounter = 0
 export function placeOrder(input: PlaceOrderInput = {}): Transaction {
   const store = getStore()
   const checking = store.accounts.find((a) => a.kind === "checking")
-  const accountId = checking?.id ?? store.accounts[0]?.id ?? "acct_checking"
+  const accountId = checking?.id ?? store.accounts[0]?.id ?? "acc_checking"
 
   const minute = input.minute ?? 18 + ((orderCounter * 7) % 40)
   const orderNo = 9900 + ((orderCounter * 13) % 99)

--- a/examples/demo-bank/src/server/transfers.ts
+++ b/examples/demo-bank/src/server/transfers.ts
@@ -23,7 +23,7 @@ export function transferMoney(input: TransferMoneyInput = {}): Transaction {
   const store = getStore()
   const checking = store.accounts.find((a) => a.kind === "checking")
   const account = checking ?? store.accounts[0]
-  const accountId = account?.id ?? "acct_checking"
+  const accountId = account?.id ?? "acc_checking"
 
   const amount = input.amount ?? 0
   // Validate BEFORE any mutation: a finite positive integer number of cents.

--- a/examples/demo-bank/src/vendo/knowledge.ts
+++ b/examples/demo-bank/src/vendo/knowledge.ts
@@ -45,8 +45,9 @@ export const mapleKnowledgeDocs: KnowledgeDoc[] = [
     visibility: "public",
     title: "Available balance",
     text: "Available balance: the money you can spend right now — the current balance minus "
-      + "pending card authorizations and holds. Checks you deposit may show in the current "
-      + "balance before they are available.",
+      + "pending card authorizations and holds. Maple does not report one: an account carries a "
+      + "single `balance` and nothing else, so there is no separate available figure to quote. "
+      + "Pending and authorized transactions are listed individually and are not deducted from it.",
     source: "help.maple.bank/glossary#available-balance",
   },
   {
@@ -54,10 +55,12 @@ export const mapleKnowledgeDocs: KnowledgeDoc[] = [
     kind: "api",
     visibility: "public",
     title: "GET /api/accounts",
-    text: "GET /api/accounts returns the authenticated customer's accounts. Response fields: id, "
-      + "type (checking | savings), name, currentBalanceCents, availableBalanceCents, currency. "
-      + "Supports ?type= to filter by account type. Balances are integers in cents — divide by "
-      + "100 for display.",
+    text: "GET /api/accounts returns the authenticated customer's accounts as { data: [...] }. "
+      + "Each account carries: id (e.g. acc_checking), name, kind (checking | savings | credit | "
+      + "investing), mask, balance, accountNumber (masked), sparkline (number[]), and optionally "
+      + "routingNumber and apy. It takes NO query parameters — there is no filter, so read every "
+      + "account and narrow by `kind` yourself. balance is an integer in cents, negative on credit "
+      + "accounts — divide by 100 for display.",
     source: "developers.maple.bank/reference/accounts",
   },
   {

--- a/packages/actions/src/sync/openapi.ts
+++ b/packages/actions/src/sync/openapi.ts
@@ -124,8 +124,10 @@ async function readDocument(specPath: string): Promise<JsonObject> {
  * url carries its own path on `binding.baseUrl` instead), so every spec that
  * does not opt in is untouched.
  *
- * Read here and applied by the caller across ALL extractors, not folded into the
- * bindings below: see `runExtractors`.
+ * Read, never applied: stored binding paths are PREFIX-FREE (spec 2026-08-06 §B1)
+ * and core's `joinUrl` attaches the prefix once at call time from VENDO_BASE_URL —
+ * folding it in here is what produced /maple/maple/… (#914). The one consumer is
+ * doctor's mount-agreement check, which compares this against VENDO_BASE_URL.
  */
 export async function openApiMountPath(specPath: string): Promise<string> {
   const servers = (await readDocument(specPath)).servers;

--- a/packages/actions/tests/sync/openapi.test.ts
+++ b/packages/actions/tests/sync/openapi.test.ts
@@ -2,7 +2,9 @@ import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import type { RunContext } from "@vendoai/core";
 import type { OpenApiBinding, RouteBinding } from "../../src/formats.js";
+import { createActions } from "../../src/runtime/registry.js";
 import { runExtractors } from "../../src/sync/extractors.js";
 import { openApiMountPath } from "../../src/sync/openapi.js";
 
@@ -83,5 +85,47 @@ describe("a host mounted under a subpath", () => {
 
   it("collapses the OpenAPI operation and the route handler behind it, as before", async () => {
     expect(await paths([{ url: "/cadence" }])).toHaveLength((await paths([{ url: "/" }])).length);
+  });
+});
+
+/** THE SEAM, both halves real: a spec with a relative server url is extracted by
+ *  the real extractors, and the URL the runtime actually calls is read off the
+ *  registry's own outbound fetch. Neither side asserts anything about the other,
+ *  so they cannot agree on a prefix-free path and still 404 together — the
+ *  failure mode the prefix-free law is accused of. */
+describe("the mount the runtime actually calls", () => {
+  const ctx: RunContext = {
+    principal: { kind: "user", subject: "user_1" },
+    venue: "chat",
+    presence: "present",
+    sessionId: "session_1",
+  };
+
+  async function calledUrl(servers: unknown, baseUrl: string): Promise<string> {
+    const { tools } = await runExtractors(await host(servers));
+    const seen: string[] = [];
+    const actions = createActions({
+      tools,
+      baseUrl,
+      fetch: (async (input: URL | RequestInfo) => {
+        seen.push(String(input));
+        return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+      }) as typeof fetch,
+    });
+    await actions.execute({ id: "1", tool: "host_getDashboard", args: {} }, ctx);
+    return seen[0]!;
+  }
+
+  it("reaches the mounted endpoint, prefixed exactly once, via VENDO_BASE_URL", async () => {
+    expect(await calledUrl([{ url: "/cadence" }], "https://host.example/cadence"))
+      .toBe("https://host.example/cadence/api/dashboard");
+  });
+
+  /** The mount hazard, reproduced: nothing in extraction can save a base URL
+   *  that drops the prefix — the call lands one prefix short and 404s while
+   *  every page renders. Doctor's E-CFG-003 is the check that catches it. */
+  it("lands one prefix short when the base URL drops the mount", async () => {
+    expect(await calledUrl([{ url: "/cadence" }], "https://host.example"))
+      .toBe("https://host.example/api/dashboard");
   });
 });

--- a/packages/vendo/src/cli/doctor-config-checks.ts
+++ b/packages/vendo/src/cli/doctor-config-checks.ts
@@ -24,13 +24,25 @@ export async function checkConfigFiles(run: DoctorRun): Promise<void> {
 
 /** Spec 2026-08-06 §B1 — the deployment's path prefix has exactly one home:
  *  VENDO_BASE_URL. A spec that declares a DIFFERENT relative server mount is the
- *  #914 shape by another route: every page renders and every tool call 404s. */
+ *  #914 shape by another route: every page renders and every tool call 404s.
+ *  An UNSET base URL is that same disagreement, and the posture it actually
+ *  bites in: with no base URL the wire learns the bare request ORIGIN
+ *  (`onRequestOrigin`), so a prefix-free stored path lands one prefix short. */
 export async function checkMountAgreement(run: DoctorRun): Promise<void> {
   const { root, env } = run;
   const specPath = await firstOpenApiSpec(root);
   const declaredMount = specPath === null ? "" : await openApiMountPath(specPath);
+  if (declaredMount === "") return;
+  const spec = relative(root, specPath!);
+  const symptom = "404s every host tool while every page renders";
+  const fix = `Set VENDO_BASE_URL to the app's FULL public URL including ${JSON.stringify(declaredMount)}, or drop the relative server from the spec.`;
   const configuredBase = env["VENDO_BASE_URL"];
-  if (declaredMount === "" || configuredBase === undefined || configuredBase.trim() === "") return;
+  if (configuredBase === undefined || configuredBase.trim() === "") {
+    run.fail("config/mount", "E-CFG-003",
+      `${spec} declares servers[0].url ${JSON.stringify(declaredMount)} but VENDO_BASE_URL is unset — the wire then serves host `
+      + `tools from the bare request origin, which ${symptom}. ${fix}`);
+    return;
+  }
   let basePath = "";
   try {
     basePath = publicBase(configuredBase).path;
@@ -39,9 +51,8 @@ export async function checkMountAgreement(run: DoctorRun): Promise<void> {
   }
   if (basePath !== declaredMount) {
     run.fail("config/mount", "E-CFG-003",
-      `${relative(root, specPath!)} declares servers[0].url ${JSON.stringify(declaredMount)} but VENDO_BASE_URL's path is `
-      + `${JSON.stringify(basePath)} — one of them is wrong, and the disagreement 404s every host tool while every page renders. `
-      + `Set VENDO_BASE_URL to the app's FULL public URL including ${JSON.stringify(declaredMount)}, or drop the relative server from the spec.`);
+      `${spec} declares servers[0].url ${JSON.stringify(declaredMount)} but VENDO_BASE_URL's path is `
+      + `${JSON.stringify(basePath)} — one of them is wrong, and the disagreement ${symptom}. ${fix}`);
   } else {
     run.pass("config/mount", `the OpenAPI server mount and VENDO_BASE_URL agree on ${JSON.stringify(declaredMount)}`);
   }

--- a/packages/vendo/tests/cli/doctor.test.ts
+++ b/packages/vendo/tests/cli/doctor.test.ts
@@ -1488,6 +1488,23 @@ describe("vendo doctor error codes + fix_refs", () => {
     });
   });
 
+  /** The posture the hazard actually occurs in: no base URL at all, so the wire
+   *  learns the bare request ORIGIN and serves every host tool one prefix short.
+   *  The check used to return early here — silent in the one case that breaks. */
+  it("fails E-CFG-003 when the spec declares a mount and VENDO_BASE_URL is unset", async () => {
+    const root = await healthy();
+    await writeFile(join(root, "openapi.json"), specWithMount, "utf8");
+    const { report } = await jsonChecks({
+      targetDir: root,
+      fetchImpl: successfulProbeFetch(),
+      env: {},
+    });
+    expect(report.checks.find((check) => check.id === "config/mount")).toMatchObject({
+      status: "broken",
+      error_code: "E-CFG-003",
+    });
+  });
+
   it("passes config/mount when the spec and VENDO_BASE_URL agree", async () => {
     const root = await healthy();
     await writeFile(join(root, "openapi.json"), specWithMount, "utf8");


### PR DESCRIPTION
## What

Four reported host-tool defects. **Three were real and are fixed. One was not a defect** — its *doc comment* was, and only that is corrected. Details per defect below.

---

### 1. `vendo sync` and the relative OpenAPI mount — NOT A DEFECT (comment only)

**Reported:** `openApiMountPath` documents itself as "applied by the caller across ALL extractors — see `runExtractors`", but `runExtractors` never calls it, so a spec with `servers: [{"url": "/maple"}]` yields bindings without the mount and every tool call 404s.

**Found:** the comment is stale; the behavior is deliberate and correct.

`mounted()` was **deleted on purpose** in #957 — commit `2357b2268`, titled *"fix(actions): stored tool paths are prefix-free — `mounted()` deleted (#914)"*, under conductor ruling #14 ("spec law wins"). Baking the prefix into stored paths is exactly what produced `/maple/maple/…` in #914. The law has been pinned by a regression test ever since:

```
packages/actions/tests/sync/openapi.test.ts
  "keeps stored paths prefix-free whatever the spec's relative server declares"
```

The prefix has one home — `VENDO_BASE_URL` — and `core`'s `joinUrl` attaches it once at call time. Implementing the requested change would require **deleting that regression test**, and because `withPathPrefix` is idempotent it would not even change the resolved URL in a correctly configured deployment. I re-applied `mounted()` locally to measure it:

| test | with `mounted()` re-added |
| --- | --- |
| `keeps stored paths prefix-free …` (existing) | ❌ `/cadence/api/dashboard` ≠ `/api/dashboard` |
| `reaches the mounted endpoint … via VENDO_BASE_URL` (new seam) | ✅ **unchanged** — idempotent join |
| `lands one prefix short when the base URL drops the mount` (new seam) | ❌ prefix appears anyway |

So the requested change is a **no-op in the correct posture and a corruption otherwise**. Only the lying comment is fixed.

**The reported 404 symptom is real** — but its cause is defect 2, not extraction. It happens when the base URL lacks the mount, which is precisely what `doctor` was failing to catch.

#### New seam test (no mock on either side)

`packages/actions/tests/sync/openapi.test.ts` now runs a real spec with a relative server url through the **real extractors**, into a **real `createActions` registry**, and reads the URL off the registry's **own outbound fetch** — producer and consumer can no longer agree on a prefix-free path and 404 together:

- `VENDO_BASE_URL=https://host.example/cadence` → `https://host.example/cadence/api/dashboard` (prefixed exactly once)
- `VENDO_BASE_URL=https://host.example` → `https://host.example/api/dashboard` (**one prefix short — the hazard**)

Both proven able to fail: sabotaging `withPathPrefix` to never attach reddens the first; re-adding `mounted()` reddens the second.

---

### 2. `vendo doctor` disarmed itself in the one posture that breaks — FIXED

`checkMountAgreement` returned early when `VENDO_BASE_URL` was unset — the zero-config dev posture, which is **exactly** where the failure occurs:

- stored binding paths are prefix-free by law (spec 2026-08-06 §B1), and
- with no base URL the wire learns the **bare request ORIGIN** (`compose-wire.ts` `onRequestOrigin` → `server.ts:355` passes `url.origin`, no path),
- so a path-mounted host serves every host tool one prefix short. Every page renders; every tool call 404s.

`E-CFG-003` now fires there. The existing disagree/agree branches keep their behavior and the three messages share one fix sentence. Error code and its registry entry are unchanged.

**Proven able to fail:** restoring the early return reddens the new test with `expected undefined to match object { status: 'broken' }` — i.e. the check emitted *nothing at all*.

---

### 3. Maple's OpenAPI example taught a wrong id — FIXED

`openapi.json` said `"Account id, e.g. acct_checking"`; the seeded ids are `acc_*` (`src/server/seed.ts:16`). Live on a real dev server:

```
GET /maple/api/accounts/acct_checking   <- what openapi.json taught -> HTTP 404
     {"error":{"message":"Account not found","code":"not_found"}}
GET /maple/api/accounts/acc_checking    <- the real seeded id       -> HTTP 200
     {"data":{"id":"acc_checking","name":"Maple Checking","kind":"checking",…}}
```

The same `acct_` typo was the fallback account id in `src/server/transfers.ts:26` and `src/server/orders.ts:31` — both fixed.

`.vendo/tools.json` **is** checked in and **is** regenerated by the example's own `predev`/`prebuild` hook (`vendo sync . --no-ai`). Ran it: the corrected description carried through plus the spec's `srcHash` (the spec is every OpenAPI tool's source file). Reported `tools: +0 -0 ~0` — nothing added, removed, or changed.

Worth noting the AI judge had **already caught this** and its note is still in `.vendo/judgments.json`: *"The real seeded ids are acc_checking, … (NOT acct_*)"*.

---

### 4. Maple's knowledge corpus documented an API that doesn't exist — FIXED

`src/vendo/knowledge.ts` claimed `GET /api/accounts` returns `currentBalanceCents` / `availableBalanceCents` / `type` / `currency` and supports `?type=`. Read the handler first (`src/app/api/accounts/route.ts` is literally `GET() { return ok(listAccounts()) }` — it reads no params), then confirmed live:

```
envelope : ["data"]
fields   : id, name, kind, mask, balance, accountNumber, routingNumber, sparkline
ids      : acc_checking, acc_savings, acc_savings_joint, acc_credit, acc_investing, acc_business, acc_moneymarket
kinds    : checking, savings, credit, investing
knowledge.ts claimed fields present? NONE of currentBalanceCents/availableBalanceCents/type/currency
?type=checking honored? -> 7 of 7 accounts -> filter IGNORED (no such param)
```

Rewritten to the real contract, including the `{ data: [...] }` envelope and "narrow by `kind` yourself".

The **"Available balance"** glossary entry described a concept Maple doesn't implement. It now keeps the definition (it's a real banking term a user may ask about) and then says Maple doesn't report one: an account carries a single `balance`, so there is no separate figure to quote.

## Why

Three of these make the agent confidently wrong: two teach it field names and ids that don't exist, and the third lets a path-mounted host ship with a silently dead tool surface. The fourth was a stale comment that made a correct, spec-mandated design read as a bug — worth correcting so the next reader doesn't "fix" it back into #914.

## Verification

- [x] `pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint` on the touched scope — **build 21/21**, **typecheck 42/42**, **lint 0 errors** (4 pre-existing warnings, untouched files)
- Tests on touched packages: `@vendoai/actions` **620 passed**, `@vendoai/vendo` **2068 passed**, `demo-bank` **117 passed**
- Both new tests proven able to fail by reverting their fix (details per defect above)
- Live-verified against a real Maple dev server for defects 3 and 4 (transcripts above)
- Full suite is CI's job — the green `ci` check is the gate of record

**Two pre-existing failures, not from this branch:** `tests/mcp-byo-docs.docs.test.ts` and `tests/your-agent-docs.docs.test.ts` both assert a `"Bring your own agent"` group in `docs-site/docs.json`, which the docs reorg in #1133 (current `main` HEAD) renamed. Confirmed by stashing this branch's changes and re-running on clean `main` — same two failures. Left alone as out of scope.

- [ ] Screenshots attached (if UI-affecting) — n/a, no UI surface touched

## Not in scope

The runtime honesty problem (model asserting facts after failed tool calls), `genbench/`, and `packages/harnesses/src/vendo/` are untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `vendo doctor` so it flags a missing `VENDO_BASE_URL` when the spec uses a relative server mount, preventing 404s on mounted hosts. Also corrects Maple demo docs and examples to match the real API and clarifies the OpenAPI mount behavior comment.

- **Bug Fixes**
  - `@vendoai/vendo`: `E-CFG-003` now fires when `servers[0].url` is relative and `VENDO_BASE_URL` is unset; added a doctor test for this posture.
  - `@vendoai/actions`: clarified `openApiMountPath` comment to reflect prefix-free stored paths and single-prefix joining via `VENDO_BASE_URL`; added an end-to-end seam test that shows URLs are prefixed exactly once and the one-prefix-short hazard when the base URL drops the mount.
  - Maple demo: corrected account id example to `acc_*`; fixed fallback ids in transfers/orders; updated `GET /api/accounts` knowledge to the real contract (envelope, fields, no `?type=`) and noted Maple exposes only a single `balance`; regenerated `.vendo/tools.json`.

<sup>Written for commit ad44b5512026b93736f1221e40563179b3dbdb3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

