### PR TITLE
fix(apps): a remix survives its own edit door

### DIFF
--- a/.changeset/apps-remix-survives-its-own-edit.md
+++ b/.changeset/apps-remix-survives-its-own-edit.md
@@ -1,0 +1,36 @@
+---
+"@vendoai/apps": patch
+---
+
+A remix survives its own edit door. Three defects, all of which destroy work a
+person can see on screen, all of which returned 200.
+
+**The island gate no longer runs over a seeded seat.** Its rules are the
+GENERATED-island contract — no imports, ambient Kit only, no hand-typed constant
+feeding displayed math — and captured host source cannot satisfy them by
+construction (the demo host's own capture blocks on `pad = 6`, SVG chart
+padding). `seed.from` writes its row without the floor, so the document was born
+un-admittable: the next edit ran the floor, got the unsatisfiable blocks back
+verbatim as repair instructions, and the only edit that cleared them was to stop
+rendering the island. The person's fork was replaced by plain host components,
+the bundle orphaned and the app renamed, while the card still rendered and the
+✦ pill still said "Remixed". A capture with no default export is still refused,
+by the seed doors themselves, where it always was.
+
+**A fork records the version that says where it came from.** `seed.from` is the
+one create that does not go through `persistEdit`, so it now appends its own
+history entry. Without it a remix arrived with no history at all — and a
+review-kind remix failed closed to pending the moment its current version
+stopped being approved, because the reviewer's serve path reads the newest
+approved snapshot out of history.
+
+**A file save no longer deletes a legacy remix's source.** The save's
+seeded-bundle carry-forward was keyed on `origin === "seeded"`, but a component
+entry may be a bare source string — the shape every remix forked before the
+seeded bundle existed is stored in — and those read back as `authored`, so the
+carry never fired and a save that omitted the component dropped the remix
+outright.
+
+All three now key on the component's NAME (`isSeedComponentName`). The origin
+cannot carry this: a compiled `app.vendo` prints its components as bare source
+strings, so an origin test reads `authored` on exactly the path that matters.

--- a/packages/apps/src/contract/seed.ts
+++ b/packages/apps/src/contract/seed.ts
@@ -199,9 +199,11 @@ export const seedForkSource = (source: string): string => {
  * components but not its `seed` — a checkout prints seeded sources into
  * `app.vendo` alongside the model's islands.
  *
- * It does NOT buy an admission exemption. Seeded source used to skip the island
- * gate entirely; it now faces the same floor as anything else, because a bundle
- * a host captured is still a bundle this runtime is about to render.
+ * The NAME is the signal every one of those seams has to use — a bare source
+ * string reads back as `origin: "authored"`, so `bundleOf` cannot tell a printed
+ * seeded seat from a model island. The island gate's exemption
+ * (`server/checking/floor.ts`) and the file save's carry-forward
+ * (`server/doors/write-surface.ts`) both key on it for that reason.
  */
 export const isSeedComponentName = (name: string): boolean =>
   /^Pinned[A-Za-z0-9]*[0-9a-f]{8}$/.test(name);

--- a/packages/apps/src/server/checking/floor.ts
+++ b/packages/apps/src/server/checking/floor.ts
@@ -24,6 +24,7 @@ import {
 import {
   bundleOf,
   compileWire,
+  isSeedComponentName,
   type AppDocument,
   type Check,
   type Finding,
@@ -57,17 +58,27 @@ const documentOf = (appId: AppId, compiled: WireCompileResult): AppDocument => (
  * (`smokeRenderIslands`) — the same two the create validator runs, ordered the
  * same way, so a cheap failure never pays for a render.
  *
- * EVERY seat faces it, seeded ones included. Seeded source used to be skipped
- * here on the grounds that it was host source rather than a model island — but
- * the floor is what stands between a document and a screen, and a bundle this
- * runtime is about to render is a bundle whichever side wrote it. A capture
- * that cannot pass the gate is a capture that cannot render.
+ * SEEDED seats are skipped. These rules are the GENERATED-island contract — no
+ * imports, ambient Kit only, no hand-typed constant feeding displayed math — and
+ * captured HOST source cannot satisfy them by construction: it brings its own
+ * imports and its numbers are the host's own (the real Maple capture blocks on
+ * `pad = 6`, SVG chart padding). Every block reaches the builder verbatim as a
+ * repair instruction, and on source the person did not write the only edit that
+ * clears it is to stop rendering the island — so the fork is silently replaced
+ * by plain host components. A capture missing a default export is refused at the
+ * seed doors themselves (generation/engine.ts, remix/seed-surface.ts).
+ *
+ * By NAME, never by `origin`: this check also runs over a compiled `app.vendo`,
+ * whose components are bare source strings, and `bundleOf` reads those as
+ * `authored` — an origin test would silently do nothing on exactly the path
+ * that matters.
  */
 const islandsCheck = (deps: FloorDependencies): Check => ({
   name: "islands-render",
   kind: "fact",
   run: async ({ document, request }) => {
     const components = Object.fromEntries(Object.entries(document.components ?? {})
+      .filter(([name]) => !isSeedComponentName(name))
       .map(([name, entry]) => [name, bundleOf(entry).source]));
     if (Object.keys(components).length === 0) return [];
     const prepared = await prepareIslands(

--- a/packages/apps/src/server/doors/write-surface.ts
+++ b/packages/apps/src/server/doors/write-surface.ts
@@ -12,7 +12,7 @@ import {
   type RunContext,
 } from "@vendoai/core";
 import {
-  bundleOf,
+  isSeedComponentName,
   type AppDocument,
   type WireCompileResult,
 } from "../../contract/index.js";
@@ -78,8 +78,14 @@ const authoredDocument = (
   // not a file save's to drop. The compile still wins for a name it does carry
   // (a seeded island IS editable through the wire); a save whose text omits it
   // keeps the stored bundle, furnishings and all.
+  //
+  // By NAME, never by `origin`: `componentEntrySchema` still accepts a bare
+  // source string, which is how every remix forked before the seed rewrite is
+  // stored, and `bundleOf` reads those as `authored`. Keyed on the origin, the
+  // carry never fires for them and a save that omits the component deletes the
+  // remix outright.
   const carried = Object.entries(previous?.components ?? {})
-    .filter(([name, entry]) => bundleOf(entry).origin === "seeded" && compiled.components[name] === undefined);
+    .filter(([name]) => isSeedComponentName(name) && compiled.components[name] === undefined);
   const components = { ...Object.fromEntries(carried), ...compiled.components };
   if (Object.keys(components).length === 0) {
     delete document.components;

--- a/packages/apps/src/server/remix/seed-surface.ts
+++ b/packages/apps/src/server/remix/seed-surface.ts
@@ -37,6 +37,7 @@ export type SeedSurfaceDeps = Pick<
   AppsRuntimeContext,
   | "config"
   | "apps"
+  | "history"
   | "placementRows"
   | "requireOwned"
   | "persistEdit"
@@ -105,6 +106,16 @@ const seedFrom = async (
   const seeded = seedOnto(minted, baseline);
   if (input.slot !== undefined) seeded.seed = { ...seeded.seed!, slot: input.slot };
   await deps.apps.put(appRecordInput(seeded, ctx.principal.subject, false, "seed"));
+  // The version that says where this app came from. `seed.from` is the one
+  // create that does not go through `persistEdit`, so it is the one create that
+  // has to append its own — without it a remix arrives with no history at all,
+  // and a review-kind remix fails closed to pending the moment its current
+  // version stops being approved (`serveDocFor`, remix/review.ts).
+  await deps.history.append(seeded.id, seeded, {
+    at: new Date().toISOString(),
+    intent: `Remix the host component "${baseline.slot}"`,
+    rung: deps.rungFor(seeded),
+  });
   if (input.slot !== undefined) {
     // "Show the remix in THIS slot" is a placement ROW. The seed on the
     // document is provenance, never location.

--- a/packages/apps/tests/authored.test.ts
+++ b/packages/apps/tests/authored.test.ts
@@ -470,6 +470,23 @@ describe("a save whose text left a seeded component out", () => {
     expect(doc?.components?.Extra).toBeUndefined();
   });
 
+  it("keeps a LEGACY remix's bare-string source — the shape every older fork is stored in", async () => {
+    const { runtime, store } = stand();
+    await runtime.authored({ appId: APP_ID, compiled: compiled(SPEND) }, ctx());
+    // `componentEntrySchema` still accepts a bare source string, and that is how
+    // every remix forked before the seeded bundle existed sits in the store.
+    // `bundleOf` reads it as `authored`, so a carry keyed on the origin drops it.
+    await seedAppRow(store, {
+      ...(await rowOf(store))!.doc!,
+      seed: { component: slot, baseline: "sha256:hostsource" },
+      components: { [name]: "export default () => null;" },
+    }, "u1");
+
+    await runtime.authored({ appId: APP_ID, compiled: compiled(SPEND) }, ctx());
+
+    expect(bundleOf((await rowOf(store))!.doc!.components![name]!).source).toBe("export default () => null;");
+  });
+
   it("still lets the file EDIT a seeded component, exactly as an engine edit may", async () => {
     const { runtime, store } = stand();
     await runtime.authored({ appId: APP_ID, compiled: compiled(SPEND) }, ctx());

--- a/packages/apps/tests/seed-survives-edit.test.ts
+++ b/packages/apps/tests/seed-survives-edit.test.ts
@@ -1,0 +1,102 @@
+/**
+ * The two things a remix has to survive, proven against a REAL capture.
+ *
+ * `seed.test.ts` already proves a seeded bundle faces admission. Its fixture is
+ * a three-line component, so it proves the gate RUNS and says nothing about
+ * whether real host source can pass it. This file uses the capture the demo
+ * host actually ships (`examples/demo-bank/.vendo/remixable/NetWorthView.json`,
+ * the same 10681 bytes the ✦ affordance seeds), which is the only way to see
+ * what the gate does to code a person did not write.
+ */
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { seedComponentName, type RunContext, type ShapeType, type ToolRegistry } from "@vendoai/core";
+import type { AppDocument, NormalizedCatalog, SeedBaseline } from "../src/contract/index.js";
+import { createApps } from "../src/server/index.js";
+import { createCheckingLayer } from "../src/server/checking/layer.js";
+import { floorChecks } from "../src/server/checking/floor.js";
+import type { FloorDependencies } from "../src/server/checking/deps.js";
+import { guardFixture } from "../src/server/testing/guard-fixture.js";
+import { memoryStore } from "../src/server/testing/memory-store.js";
+import { scriptedLanguageModel } from "../src/server/testing/scripted-model.js";
+
+const owner: RunContext = {
+  principal: { kind: "user", subject: "user_ada" },
+  venue: "app",
+  presence: "present",
+  sessionId: "session_ada",
+};
+
+const tools: ToolRegistry = {
+  async descriptors() { return []; },
+  async execute() { return { status: "error", error: { code: "not-found", message: "no fixture tools" } }; },
+};
+
+/** The host's own capture, read rather than retyped — a hand-written stand-in is
+ *  exactly what let this through (precedent: ui/test/chrome/consent-class-line). */
+const captured = JSON.parse(
+  readFileSync("../../examples/demo-bank/.vendo/remixable/NetWorthView.json", "utf8"),
+) as SeedBaseline;
+
+const COMPONENT = seedComponentName(captured.slot);
+
+const runtime = (store = memoryStore()) => createApps({
+  store,
+  guard: guardFixture(),
+  tools,
+  catalog: [],
+  seedBaselines: [captured],
+  model: scriptedLanguageModel(() => "<Edit></Edit>"),
+});
+
+const floorDeps = (): FloorDependencies => ({
+  model: scriptedLanguageModel(() => '<App name="unused"/>'),
+  catalog: [] as NormalizedCatalog,
+  tools: [],
+  toolShapes: {} as Record<string, ShapeType>,
+});
+
+describe("a seeded app survives its own edit door", () => {
+  /**
+   * REGRESSION 1 — the wire edit door destroys a remixed app and returns 200.
+   *
+   * The floor is not decoration on the edit path: `validateWrittenApps`
+   * (server/generation/validate-gate.ts) runs it over every `app.vendo` the
+   * builder writes and hands every `block` straight back as a repair
+   * instruction. A block on source the person did not write cannot be repaired
+   * — the builder's only way to clear it is to stop rendering the island, which
+   * is what "the generated node was replaced by plain host components" is.
+   *
+   * So: whatever `seed.from` mints, the floor has to admit. The producer and
+   * the consumer are both real here; neither is stubbed.
+   */
+  it("mints a document its own checking floor admits", async () => {
+    const app = await runtime().seed.from({ component: captured.slot }, owner);
+
+    // It really is the seeded seat, or this proves nothing.
+    expect(app.components?.[COMPONENT]).toBeDefined();
+
+    const deps = floorDeps();
+    const findings = await createCheckingLayer({ deps, checks: floorChecks(deps) })
+      .run({ document: app as AppDocument, request: "" });
+
+    expect(findings.filter(({ severity }) => severity === "block")).toEqual([]);
+  });
+
+  /**
+   * REGRESSION 2 — a fork no longer writes its history entry.
+   *
+   * The ✦ gesture used to go through `persistEdit`, the ONE document write, so
+   * the app arrived with the version that says where it came from. `seed.from`
+   * puts the row itself, so a fresh remix has no history at all.
+   */
+  it("records the version that says where the app came from", async () => {
+    const store = memoryStore();
+    const app = await runtime(store).seed.from({ component: captured.slot }, owner);
+
+    const versions = await runtime(store).history(app.id, owner).list();
+
+    expect(versions).toHaveLength(1);
+    expect(versions[0]?.intent).toMatch(new RegExp(captured.slot));
+  });
+});

--- a/packages/apps/tests/seed.test.ts
+++ b/packages/apps/tests/seed.test.ts
@@ -8,11 +8,10 @@
  * The two that were broken have their own proofs below, and each one is written
  * so that putting the old code back turns the assertion around:
  *
- *  1. SEEDED BUNDLES FACE ADMISSION. The checking floor used to filter seeded
- *     components out of the island gate entirely, on the grounds that captured
- *     host source is not a model island. That meant a capture the jail could
- *     never render was admitted without complaint. Restore the filter and the
- *     bad document below is admitted.
+ *  1. A SEEDED SEAT SKIPS THE ISLAND GATE, BY NAME. The gate's rules are the
+ *     generated-island contract, which captured host source cannot satisfy by
+ *     construction — running it over a real capture blocks a remix the person
+ *     can see on screen. Drop the filter and the real capture below is refused.
  *
  *  2. THE SEAT HOLDS ITS OWN CONTENTS. The jail furnishings used to be
  *     hash-matched against the live host baseline at open time, so the moment
@@ -20,6 +19,7 @@
  *     no imports, no sub-modules and no styles — silently, with nothing on the
  *     payload to say anything was missing. Now they live in the stored bundle.
  */
+import { readFileSync } from "node:fs";
 import {
   VENDO_APP_FORMAT,
   seedComponentName,
@@ -225,17 +225,30 @@ describe("seed.reseed — a plain swap for the pristine new component", () => {
 });
 
 // ===========================================================================
-// PROOF 1 — the admission skip is GONE, not merely deleted.
+// PROOF 1 — a seeded seat is exempt from the island gate, BY NAME.
 //
-// The floor used to drop every seeded component before the island gate ran:
+// This block used to be written the other way round: a seeded bundle with no
+// default export was expected to come back blocked, and restoring the floor's
+// `.filter(([name]) => !isSeedComponentName(name))` was called the regression.
+// That was a proof of a premise that is false, and its fixture is why it looked
+// true — three hand-typed lines that happen to obey the generated-island
+// contract. The contract is written for source a MODEL wrote: no imports,
+// ambient Kit only, no hand-typed constant feeding displayed math. Captured host
+// source obeys none of it (the capture below blocks on `pad = 6`, SVG chart
+// padding), and every block reaches the builder verbatim as a repair
+// instruction — so on source the person did not write, the only edit that clears
+// it is to stop rendering the remix.
 //
-//     .filter(([name]) => !isSeedComponentName(name))
-//
-// Put that line back in `server/checking/floor.ts` and this test goes GREEN in
-// the wrong direction: the findings list comes back empty and the bad document
-// below is admitted. That is the whole reason this is written as a refusal and
-// not as a happy path.
+// What is true is asserted below, against the capture the demo host actually
+// ships rather than a toy: the seat is admitted, the SAME source under an
+// ordinary name is still gated, and a capture the jail could not render is
+// refused at the seed door itself.
 // ===========================================================================
+
+/** The host's own capture, read rather than retyped. */
+const CAPTURE = (JSON.parse(
+  readFileSync("../../examples/demo-bank/.vendo/remixable/NetWorthView.json", "utf8"),
+) as SeedBaseline).source;
 
 const floorDeps = (): FloorDependencies => ({
   model: scriptedLanguageModel(() => '<App name="unused"/>'),
@@ -244,11 +257,7 @@ const floorDeps = (): FloorDependencies => ({
   toolShapes: {} as Record<string, ShapeType>,
 });
 
-/** A seeded seat whose source the jail could never render: no default export,
- *  which is the component-bundle rule every island has to satisfy. */
-const BAD_SEEDED_SOURCE = "export const NetWorthCard = () => <strong>$1.2M</strong>;";
-
-const seededDocument = (source: string): AppDocument => ({
+const documentWith = (name: string, source: string): AppDocument => ({
   format: VENDO_APP_FORMAT,
   id: "app_admission",
   name: "Seeded",
@@ -258,35 +267,43 @@ const seededDocument = (source: string): AppDocument => ({
     root: "root",
     nodes: [
       { id: "root", component: "Stack", source: "prewired", children: ["seat"] },
-      { id: "seat", component: COMPONENT, source: "generated" },
+      { id: "seat", component: name, source: "generated" },
     ],
   },
   seed: { component: SLOT, baseline: "sha256:maple-base" },
-  components: { [COMPONENT]: { source, origin: "seeded" } },
+  // Tagged `seeded` in BOTH cases, so the only difference between the two tests
+  // below is the component's name.
+  components: { [name]: { source, origin: "seeded" } },
 } as AppDocument);
 
-describe("PROOF — a seeded bundle faces admission like anything else", () => {
-  it("REFUSES a seeded bundle that violates a component-bundle rule", async () => {
-    const deps = floorDeps();
-    const layer = createCheckingLayer({ deps, checks: floorChecks(deps) });
+const blocksOn = async (document: AppDocument): Promise<string[]> => {
+  const deps = floorDeps();
+  const findings = await createCheckingLayer({ deps, checks: floorChecks(deps) }).run({ document, request: "" });
+  return findings.filter(({ severity }) => severity === "block").map(({ message }) => message);
+};
 
-    const findings = await layer.run({ document: seededDocument(BAD_SEEDED_SOURCE), request: "" });
-
-    // The name really is a seeded one — so the old skip would really have
-    // caught it, which is what makes this a proof rather than a coincidence.
+describe("PROOF — the island gate skips a seeded seat, and skips it by name", () => {
+  it("admits a seat holding the host's real captured source", async () => {
     expect(isSeedComponentName(COMPONENT)).toBe(true);
-    const blocks = findings.filter(({ severity }) => severity === "block");
-    expect(blocks.length).toBeGreaterThan(0);
-    expect(blocks.map(({ message }) => message).join("\n")).toMatch(/export default/);
+
+    expect(await blocksOn(documentWith(COMPONENT, CAPTURE))).toEqual([]);
   });
 
-  it("admits the same seat once its source satisfies the rule", async () => {
-    const deps = floorDeps();
-    const layer = createCheckingLayer({ deps, checks: floorChecks(deps) });
+  it("still gates the SAME source under a name that is not a seeded one", async () => {
+    const blocks = await blocksOn(documentWith("Ordinary", CAPTURE));
 
-    const findings = await layer.run({ document: seededDocument(SOURCE), request: "" });
+    // The `origin: "seeded"` tag is identical in both documents: it is the name
+    // that buys the exemption, and it has to be — a compiled `app.vendo` prints
+    // its components as bare source strings, which all read back as `authored`.
+    expect(blocks.length).toBeGreaterThan(0);
+  });
 
-    expect(findings.filter(({ severity }) => severity === "block")).toEqual([]);
+  it("refuses a capture the jail could never render at the seed door itself", async () => {
+    const runtime = runtimeWith(memoryStore(), {
+      seedBaselines: [{ ...baseline(), source: "export const total = 1;" }],
+    });
+
+    await expect(runtime.seed.from({ component: SLOT }, owner)).rejects.toThrow(/no default export/);
   });
 });
 


### PR DESCRIPTION
Three defects in the remix path. Each destroys work the person can see on screen, and each returns **200**.

## 1. The island gate ran over seeded seats (`server/checking/floor.ts`)

The gate's rules are the **generated-island contract** — no imports, ambient Kit only, law 1 "a hand-typed constant feeding displayed math is invented data". Captured **host** source cannot satisfy that by construction. The demo host's own capture blocks on `pad = 6`, which is SVG chart padding:

```
island "PinnedNetWorthView965099a8" computes displayed values from the hand-typed
constant pad = 6 — a constant feeding displayed math is invented data (law 1)
```

`seed.from` writes its row directly with no floor, so **the document is born un-admittable**. Any later edit runs the floor, gets the unsatisfiable blocks handed back verbatim as repair instructions, and the only edit that clears them is to stop rendering the island: the fork is replaced by plain host components, the bundle orphaned, the app renamed. The card still renders and the ✦ pill still says "Remixed", so the person cannot tell.

The filter is restored **by NAME, not by `origin`** — load-bearing, and commented as such. The floor also runs over a compiled `app.vendo`, whose components are bare source strings; `bundleOf` reads those as `origin: "authored"`, so an origin-based skip would silently do nothing on the exact path that matters.

Nothing real is lost: both seed doors already check a capture has a default export themselves (`generation/engine.ts:174`, `remix/seed-surface.ts:180`).

## 2. A fork appended no history entry (`server/remix/seed-surface.ts`)

`seedFrom` calls `deps.apps.put(...)` directly instead of going through `persistEdit`, so it is the only create in the runtime that bypasses the one document write — and a fresh remix arrived with no history at all. Beyond the missing UI row: `serveDocFor` (`remix/review.ts:154`) falls back to `history.documents()` for the newest approved snapshot, so an empty history makes a review-kind remix **fail closed to pending** the moment its current version stops being approved.

## 3. The file save deleted a legacy remix's source (`server/doors/write-surface.ts`)

The seeded-bundle carry-forward was keyed on `origin === "seeded"`. But `componentEntrySchema` still accepts a bare source string, which is how **every remix forked before the seeded bundle existed** is stored — `bundleOf` reads it as `"authored"`, the carry does not fire, and a file-authored save that omits the component **deletes the remix outright**. Same one-token cure: key it on `isSeedComponentName(name)`.

## The old proof test was false, and is rewritten rather than deleted

`packages/apps/tests/seed.test.ts` — *"REFUSES a seeded bundle that violates a component-bundle rule"* — asserted the behaviour this PR removes. It is a proof of a premise that is empirically false, and **its fixture is a three-line component; that toy is the reason the change shipped green**.

It now runs the host's **real** capture (`examples/demo-bank/.vendo/remixable/NetWorthView.json`, 10681 bytes of source) and asserts what is actually true:

- a seeded seat holding that capture is **admitted**;
- the **same source, same `origin: "seeded"` tag**, under an ordinary name is still **gated** — proving the exemption is the name, not the tag;
- a capture with no default export is **refused at the seed door itself**.

## The seam test

`packages/apps/tests/seed-survives-edit.test.ts` drives the real `seed.from` into the real `floorChecks` with nothing stubbed on either side, and asserts the invariant the regression broke: **whatever the seed door mints, the checking floor must admit.**

Red on current main:

```
 ❯ tests/seed-survives-edit.test.ts (2 tests | 2 failed) 716ms
   × mints a document its own checking floor admits 700ms
     → expected [ { severity: 'block', …(2) }, …(1) ] to deeply equal []
   × records the version that says where the app came from 14ms
     → expected [] to have a length of 1 but got +0
```

Green with the fix:

```
 ✓ tests/seed-survives-edit.test.ts (2 tests) 618ms
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Defect 3 has its own case in `authored.test.ts` ("keeps a LEGACY remix's bare-string source"), verified red against the origin-keyed carry (`Cannot read properties of undefined (reading 'PinnedDashboardHeader22c8fbd4')`) and green with the fix.

## Gate

- `turbo run build typecheck --filter=@vendoai/apps --filter=@vendoai/ui --filter=@vendoai/vendo` — 16/16
- `packages/apps` full suite — 1520 passed, 18 skipped, 113 files
- `packages/vendo` seed/review/in-client/drift fixtures — 10 passed
- **root** `pnpm typecheck` — 42/42
- `pnpm lint` — 0 errors

No UI change, so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three bugs that caused remixed apps to lose work after edits while still returning 200. Seeded seats now skip the island gate by name, `seed.from` writes a history version, and legacy remixes keep their source on save.

- **Bug Fixes**
  - Skip island checks for seeded seats by `isSeedComponentName` (not `origin`) to avoid blocking captured host code; seed doors still reject captures with no default export.
  - `seed.from` appends a history entry so remixes have provenance and review flows don’t fail closed.
  - File-save carry-forward keys on name to preserve remixes stored as bare source strings; prevents accidental deletion when omitted from file edits.

- **Refactors**
  - Added `seed-survives-edit.test.ts`, rewrote `seed.test.ts` to use the real capture, and added a legacy-source case in `authored.test.ts`.

<sup>Written for commit 6069b1e4f7bdfddd8cca8b01472a8486bb58c583. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

