### PR TITLE
test(vendo): docs-nav gates follow the renamed groups from #1133

### DIFF
--- a/packages/vendo/tests/mcp-byo-docs.docs.test.ts
+++ b/packages/vendo/tests/mcp-byo-docs.docs.test.ts
@@ -42,10 +42,10 @@ describe("the BYO-over-MCP page is published", () => {
     expect(text).toMatch(/^description: "/m);
   });
 
-  it("sits in the Bring-your-own-agent nav group", async () => {
+  it("sits in the MCP nav group", async () => {
     const docs = await readJson<DocsJson>("docs-site/docs.json");
-    const group = docs.navigation.groups.find((entry) => entry.group === "Bring your own agent");
-    expect(group, "the 'Bring your own agent' group must exist").toBeDefined();
+    const group = docs.navigation.groups.find((entry) => entry.group === "Expose your product over MCP");
+    expect(group, "the 'Expose your product over MCP' group must exist").toBeDefined();
     expect(group?.pages).toContain(NAV_ENTRY);
   });
 

--- a/packages/vendo/tests/your-agent-docs.docs.test.ts
+++ b/packages/vendo/tests/your-agent-docs.docs.test.ts
@@ -10,7 +10,8 @@ import { describe, expect, it } from "vitest";
  *
  * What it holds, and why each claim is load-bearing:
  *  1. the page is published and every nav entry still resolves, with this page
- *     FIRST in its group (it is the on-ramp);
+ *     directly behind its group's overview (it is the on-ramp that overview
+ *     hands off to);
  *  2. every tool name the page puts in a reader's system prompt really exists
  *     in the registry the page is describing;
  *  3. `vendo_make`'s four documented arguments are its real schema properties on
@@ -53,11 +54,13 @@ describe("the BYO on-ramp page is published", () => {
     expect(text).toMatch(/^description: "/m);
   });
 
-  it("is the FIRST entry in the Bring-your-own-agent group", async () => {
+  it("follows its group's overview, ahead of the framework quickstarts", async () => {
     const docs = await readJson<DocsJson>("docs-site/docs.json");
-    const group = docs.navigation.groups.find((entry) => entry.group === "Bring your own agent");
-    expect(group, "the 'Bring your own agent' group must exist").toBeDefined();
-    expect(group?.pages[0]).toBe(NAV_ENTRY);
+    const group = docs.navigation.groups.find((entry) => entry.group === "You already have an agent");
+    expect(group, "the 'You already have an agent' group must exist").toBeDefined();
+    // The overview is the door the landing page opens; this page is the on-ramp it
+    // hands off to, so it stays directly behind the overview and ahead of the rest.
+    expect(group?.pages.slice(0, 2)).toEqual(["existing-agents/index", NAV_ENTRY]);
   });
 
   it("leaves no nav entry pointing at a file that does not exist", async () => {


### PR DESCRIPTION
## What

`main` is red, and has been since #1133 merged. That PR regrouped the docs sidebar — group names became plain-English situations and the three scattered MCP pages were gathered into one new group — but two docs-rot gates in `@vendoai/vendo` still asserted the retired `"Bring your own agent"` group by name, so they fail on `main` itself. This is a **test-only change, and legitimately so**: the docs changed on purpose (#1133 documents the regrouping as an explicit renames-only table, with the page set byte-identical and zero URLs moved), and these two tests pin the old reality. The docs are right; the assertions are stale.

Two assertions move:

- **`tests/mcp-byo-docs.docs.test.ts`** — `existing-agents/mcp` now sits in `"Expose your product over MCP"`, the new group that matches door three.
- **`tests/your-agent-docs.docs.test.ts`** — its group is now `"You already have an agent"`, and inside it `existing-agents/index` deliberately leads: the landing page's door one opens on that overview, whose first card hands off to `existing-agents/your-agent` as "the full on-ramp". So instead of pinning position zero, the gate pins the on-ramp *directly behind* the overview and ahead of the framework quickstarts — the same load-bearing claim ("this page is the on-ramp"), stated against the nav that actually shipped.

No product source, no docs, and no other assertion is touched. Nothing else in the repo referenced the old group names — a repo-wide grep for all six retired names hits only these two files.

## Evidence `main` is red on exactly these two

Latest `main` run — [CI #31371240744](https://github.com/runvendo/vendo/actions/runs/31371240744) on `fb867d9` — `ci` **failure**, from two shards and the coverage merge:

```
failure  test-shards (vendo-3, @vendoai/vendo, packages/vendo, 3/4)
failure  test-shards (vendo-4, @vendoai/vendo, packages/vendo, 4/4)
failure  coverage-merge
failure  ci
```

The merge job replays every shard, so it names both failures together and nothing else:

```
FAIL tests/your-agent-docs.docs.test.ts > the BYO on-ramp page is published
                                        > is the FIRST entry in the Bring-your-own-agent group
FAIL tests/mcp-byo-docs.docs.test.ts    > the BYO-over-MCP page is published
                                        > sits in the Bring-your-own-agent nav group
Test Files  2 failed | 188 passed | 10 skipped (200)
```

Every other job on that run — `typecheck-lint`, `integration`, `conformance`, `audit`, `test-rest` ×2, the `store` and `ui` shards, `vendo-1`, `vendo-2` — is green. The redness is these two assertions and nothing more.

## Verification

Scoped gate, vitest workers capped at 2:

- `vitest run tests/mcp-byo-docs.docs.test.ts tests/your-agent-docs.docs.test.ts` → **2 files, 55 tests passed**. The same two tests are the ones failing on `main`, so `main`'s own red run is the proof these assertions can fail.
- `turbo run build typecheck --filter=@vendoai/vendo` → green, including `tsconfig.test.json`.
- `eslint --config eslint.blocking.config.mjs` on both files, plus `dependency-guard` (30 packages) and `portability-gate` (all legs) → green.

No changeset: test-only, no published behavior changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update docs navigation tests in `@vendoai/vendo` to match the sidebar regrouping from #1133, fixing the red CI on `main`. Tests now assert the new group names and the on-ramp’s position behind the overview.

- **Bug Fixes**
  - `tests/mcp-byo-docs.docs.test.ts`: assert `existing-agents/mcp` lives in "Expose your product over MCP".
  - `tests/your-agent-docs.docs.test.ts`: assert group is "You already have an agent" and the page follows the overview (`["existing-agents/index", "existing-agents/your-agent"]`).

<sup>Written for commit 66296f4044c81310989abe1c0844d3bb0480beb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

