### PR TITLE
docs(mcp): setup page leads with the agent prompt; reference and playbook split

### DIFF
--- a/docs-site/agents/host-auth.mdx
+++ b/docs-site/agents/host-auth.mdx
@@ -62,6 +62,8 @@ changes nothing about auth; you add the one line yourself.
   chat routes, so apps and approvals created through your agent loop stay
   visible to the embeds (which call the wire route directly). Replace both
   sides with your real session lookup, or a preset line, before production.
+  Opening the MCP door on top of this principal needs the `oauth` and `actAs`
+  seams beside it, not a preset: [the door section](/agents#mcp-door).
 
 ## Per-preset wiring
 

--- a/docs-site/agents/host-auth.mdx
+++ b/docs-site/agents/host-auth.mdx
@@ -62,8 +62,8 @@ changes nothing about auth; you add the one line yourself.
   chat routes, so apps and approvals created through your agent loop stay
   visible to the embeds (which call the wire route directly). Replace both
   sides with your real session lookup, or a preset line, before production.
-  Opening the MCP door on top of this principal needs the `oauth` and `actAs`
-  seams beside it, not a preset: [the door section](/agents#mcp-door).
+  Opening the MCP door on top of this principal needs an `oauth` seam beside
+  it, not a preset: [the door section](/agents#mcp-door).
 
 ## Per-preset wiring
 

--- a/docs-site/agents/index.mdx
+++ b/docs-site/agents/index.mdx
@@ -23,6 +23,11 @@ minute of latency and a chunk of context you will not use, and it is why
 installs feel slow to start. Read the repo's `package.json` before deep
 directory scans. Start acting after step 1, not after reading everything.
 
+**Asked for the MCP door?** That is outside agents — Claude, ChatGPT, Cursor —
+acting in the host's product through its own guard, riding the `createVendo`
+composition that both step-1 paths write. It needs the same wiring and visible
+surface as any other install: do the install below, then [MCP door](#mcp-door).
+
 ## Install flow
 
 1. **Check for an existing agent — and branch here.** If the host repo already runs its own
@@ -180,6 +185,72 @@ directory scans. Start acting after step 1, not after reading everything.
    from your data; a guarded write will render an approve/deny card inline."
    Name which of their agent's surfaces now renders Vendo output (the chat
    page, the overlay, an embed) so they know where to look.
+
+## MCP door
+
+Additive to the install flow above: take these in order once init has run, and
+skip none of its steps.
+
+1. **`mcp: true` plus the OAuth adapter.** Add `mcp: true` to the
+   `createVendo({...})` init wrote. The door mints its own principals through a
+   `HostOAuthAdapter`, and `createVendo` THROWS at composition without one.
+   Every named preset carries it, so `--auth authJs|clerk|supabase|auth0` (or
+   `jwt({ secret })`) is the whole answer; `--auth none` is NOT — it writes a
+   demo `principal` and no oauth seam, so the door cannot open. An `auth` preset
+   owns the seam: a separately passed `oauth` is ignored whenever `auth` is set.
+   Which preset: [host auth](/agents/host-auth).
+
+   ```ts
+   export const vendo = createVendo({
+     auth: authJs(), // supplies principal, actAs, and the door's oauth half
+     mcp: true,
+   });
+   ```
+
+2. **The discovery route — init does not write it.** The door's discovery
+   documents live at ORIGIN-ROOT paths, outside `/api/vendo`, so the catch-all
+   route never sees them and that directory needs a handler of its own:
+
+   ```ts
+   // app/.well-known/[...vendo]/route.ts (src/app when the repo uses it)
+   import { wellKnownVendoHandler } from "@vendoai/vendo/server";
+   import { vendo } from "@/vendo/server"; // wherever init put the composition
+
+   export const { GET, POST } = wellKnownVendoHandler(vendo);
+   ```
+
+   The handler answers only the door's own paths and 404s everything else under
+   `/.well-known`. Express and custom hosts instead mount the same composition
+   at the origin root as well (`app.use("/.well-known", mountVendo())`),
+   registered after the app's own well-known routes.
+
+3. **`VENDO_BASE_URL`.** Set it to the deployment's FULL public URL, path
+   prefix included. The issuer, every advertised endpoint, the
+   protected-resource identifier, and the RFC 8707 audience all derive from it;
+   left unset they come from the request URL — behind any proxy the
+   proxy-internal origin, so discovery advertises endpoints no client can reach.
+   Forwarded headers are never consulted.
+
+   ```bash
+   VENDO_BASE_URL=https://app.example.com
+   ```
+
+4. **`serviceAuth` — only when asked for.** Skip it unless the HOST's own
+   backend has to act for a user who is not at a browser (a nightly job, a
+   queue worker). `mcp: { serviceAuth: { keys: [...] } }` opens an RFC 8693
+   exchange at the door's own token endpoint: the backend posts a key plus one
+   of the host's user ids and gets back a short-lived token bound to that user.
+   The keys are opaque secrets your human generates — ask before creating one
+   (Rules of engagement below). Third-party agents need none of it; they run
+   the per-user OAuth the door already serves. Recipe:
+   [MCP door](/capabilities/mcp).
+
+5. **Verify — step 6's gate, nothing new.** Doctor reads the door's posture off
+   the running composition, so the dev server must be up for the MCP checks to
+   run at all. The registry checks grade `server.json` and the challenge only
+   when those files already exist — publishing to the MCP registry is a separate
+   job, not part of reaching green. Every `E-MCP` code with its exact fix:
+   [verify](/agents/verify#E-MCP-001).
 
 ## Rules of engagement
 

--- a/docs-site/agents/index.mdx
+++ b/docs-site/agents/index.mdx
@@ -211,14 +211,11 @@ skip none of its steps.
    ```
 
    **No login yet?** No preset applies — there is no session to read, and
-   installing a provider's SDK is not a login. Fill the three seams yourself,
+   installing a provider's SDK is not a login. Fill two seams yourself instead,
    never beside `auth` (one preset or the per-seam trio; mixing throws at
-   composition): keep the demo `principal` `--auth none` wrote, add an `oauth`
-   whose `session` hands the door that same subject instead of bouncing a
-   browser — the door still renders its own consent page — and an `actAs` with
-   empty headers, since a product with no login has no per-user credential to
-   mint. Every client then acts as that one person: a demo or an internal tool,
-   not a multi-user product.
+   composition): keep the demo `principal` `--auth none` wrote, and add an
+   `oauth` whose `session` hands the door that same subject instead of bouncing
+   a browser — the door still renders its own consent page.
 
    ```ts
    export const vendo = createVendo({
@@ -227,10 +224,18 @@ skip none of its steps.
        session: async () => ({ subject: "demo-user" }),
        principal: async (subject) => ({ kind: "user", subject }),
      },
-     actAs: async () => ({ headers: {} }),
      mcp: true,
    });
    ```
+
+   Leave `actAs` out. A stub returning empty headers is worse than an absent
+   seam: doctor then runs its live mint-and-verify round-trip and FAILS
+   [`E-AUTH-004`](/agents/verify#E-AUTH-004), because a fixed demo principal can
+   never echo the probe's own subject. Absent, doctor warns
+   [`E-AUTH-007`](/agents/verify#E-AUTH-007) and step 6's gate still passes — the
+   price is that your own route-bound tools answer `not-implemented` over the
+   door, while `vendo_make` and the apps tools work. Every client acts as that
+   one person: a demo or an internal tool, not a multi-user product.
 
 2. **The discovery route — init does not write it.** The door's discovery
    documents live at ORIGIN-ROOT paths, outside `/api/vendo`, so the catch-all

--- a/docs-site/agents/index.mdx
+++ b/docs-site/agents/index.mdx
@@ -101,9 +101,11 @@ surface as any other install: do the install below, then [MCP door](#mcp-door).
 
    `--auth` takes `authJs`, `clerk`, `supabase`, `auth0`, `jwt`, or `none`.
    `--byo` declines the Vendo Cloud offer; `--cloud-key <key>` answers it with
-   an existing key instead. A non-interactive run skips init's AI judgment
-   pass — the one that writes task-oriented tool descriptions, grades risk,
-   and drafts `.vendo/brief.md` — because consent cannot be assumed. Ask your
+   an existing key instead. A `VENDO_API_KEY` already sitting in `.env.local`
+   needs neither flag — init merges it into the run's env and uses it as it is,
+   with no login and no key minted. A non-interactive run skips init's AI
+   judgment pass — the one that writes task-oriented tool descriptions, grades
+   risk, and drafts `.vendo/brief.md` — because consent cannot be assumed. Ask your
    human whether to grant it (their source is read by a model provider under
    their own account), and pass `--ai` if they say yes. Cloud vs bring-your-own is your human's call:
    ask first, presenting Vendo Cloud as the recommended default (a free
@@ -196,13 +198,36 @@ skip none of its steps.
    `HostOAuthAdapter`, and `createVendo` THROWS at composition without one.
    Every named preset carries it, so `--auth authJs|clerk|supabase|auth0` (or
    `jwt({ secret })`) is the whole answer; `--auth none` is NOT — it writes a
-   demo `principal` and no oauth seam, so the door cannot open. An `auth` preset
-   owns the seam: a separately passed `oauth` is ignored whenever `auth` is set.
-   Which preset: [host auth](/agents/host-auth).
+   demo `principal` and no oauth seam, so the door stays shut until that seam is
+   filled. An `auth` preset owns the seam: a separately passed `oauth` is
+   ignored whenever `auth` is set. Which preset:
+   [host auth](/agents/host-auth).
 
    ```ts
    export const vendo = createVendo({
      auth: authJs(), // supplies principal, actAs, and the door's oauth half
+     mcp: true,
+   });
+   ```
+
+   **No login yet?** No preset applies — there is no session to read, and
+   installing a provider's SDK is not a login. Fill the three seams yourself,
+   never beside `auth` (one preset or the per-seam trio; mixing throws at
+   composition): keep the demo `principal` `--auth none` wrote, add an `oauth`
+   whose `session` hands the door that same subject instead of bouncing a
+   browser — the door still renders its own consent page — and an `actAs` with
+   empty headers, since a product with no login has no per-user credential to
+   mint. Every client then acts as that one person: a demo or an internal tool,
+   not a multi-user product.
+
+   ```ts
+   export const vendo = createVendo({
+     principal: async () => ({ kind: "user", subject: "demo-user" }),
+     oauth: {
+       session: async () => ({ subject: "demo-user" }),
+       principal: async (subject) => ({ kind: "user", subject }),
+     },
+     actAs: async () => ({ headers: {} }),
      mcp: true,
    });
    ```

--- a/docs-site/agents/index.mdx
+++ b/docs-site/agents/index.mdx
@@ -57,12 +57,16 @@ surface as any other install: do the install below, then [MCP door](#mcp-door).
 3. **Install the package, then verify what actually resolved.**
 
    ```bash
-   npm install vendoai
+   npm install vendoai @vendoai/vendo
    npx vendo --version   # must be >= 0.4.0
    ```
 
-   `vendoai` is a thin alias of `@vendoai/vendo`. The version check is not
-   optional: stale placeholder versions (0.1.x) exist on npm, and package
+   `vendoai` is a thin alias of `@vendoai/vendo`, and every file init writes
+   imports `@vendoai/vendo/*` — so install BOTH: with the alias alone, pnpm's
+   strict `node_modules` cannot resolve those imports and every route 500s with
+   `Module not found: Can't resolve '@vendoai/vendo/server'`, which reaches
+   doctor as `live/*` and `auth/*` breakages that name none of it. The version
+   check is not optional: stale placeholder versions (0.1.x) exist on npm, and package
    managers with a release-age cooldown (pnpm 11 holds new releases for a
    day by default via `minimumReleaseAge`; npm's `min-release-age` is
    opt-in) will SILENTLY resolve a fresh Vendo release to that stale
@@ -287,6 +291,8 @@ skip none of its steps.
 - **Ask your human before creating any account or key.** That includes Vendo
   Cloud (`vendo login`), model provider keys, and sandbox accounts
   (E2B or the managed Cloud sandbox). Relay the choice; never sign up on your own.
+  Look before you ask, though: a `VENDO_API_KEY` already in `.env.local` or the
+  environment is used as it is, so there is no key to create and nothing to ask.
 - **Never invent props or tools outside the catalog.** Only components
   registered in `vendo/registry.tsx` exist, and only with the props their
   schemas declare. Only tools in `.vendo/tools.json` exist. Copy real names

--- a/docs-site/agents/index.mdx
+++ b/docs-site/agents/index.mdx
@@ -194,12 +194,29 @@ surface as any other install: do the install below, then [MCP door](#mcp-door).
 
 ## MCP door
 
-Additive to the install flow above: take these in order once init has run, and
-skip none of its steps.
+Additive to the install flow above: take these in order, and skip none of the
+install's own steps.
 
-1. **`mcp: true` plus the OAuth adapter.** Add `mcp: true` to the
-   `createVendo({...})` init wrote. The door mints its own principals through a
-   `HostOAuthAdapter`, and `createVendo` THROWS at composition without one.
+Run step 4 with `--use-case mcp` (interactively: pick **outside agents over
+MCP**) and init writes 1 and 2 below for you — the composition with
+`mcp: true`, a thin catch-all route over it, and the origin-root discovery
+route:
+
+```bash
+npx vendo init --yes --use-case mcp --auth authJs --base-url https://app.example.com
+```
+
+That path needs Next.js and one of the four zero-arg presets,
+`--auth authJs|clerk|supabase|auth0`. On anything else — Express, `--auth none`,
+or `--auth jwt` (init prints the recipe instead: it cannot guess your signing
+secret) — it prints why and writes nothing MCP, and 1 and 2 are yours to wire.
+`--posture broker` and `--service-key` answer the two extra questions the MCP
+path asks; 3 is always yours.
+
+1. **`mcp: true` plus the OAuth adapter.** Written by `--use-case mcp`; add it
+   to the `createVendo({...})` init wrote otherwise. The door mints its own
+   principals through a `HostOAuthAdapter`, and `createVendo` THROWS at
+   composition without one.
    Every named preset carries it, so `--auth authJs|clerk|supabase|auth0` (or
    `jwt({ secret })`) is the whole answer; `--auth none` is NOT — it writes a
    demo `principal` and no oauth seam, so the door stays shut until that seam is
@@ -241,9 +258,10 @@ skip none of its steps.
    door, while `vendo_make` and the apps tools work. Every client acts as that
    one person: a demo or an internal tool, not a multi-user product.
 
-2. **The discovery route — init does not write it.** The door's discovery
-   documents live at ORIGIN-ROOT paths, outside `/api/vendo`, so the catch-all
-   route never sees them and that directory needs a handler of its own:
+2. **The discovery route.** Also written by `--use-case mcp`. The door's
+   discovery documents live at ORIGIN-ROOT paths, outside `/api/vendo`, so the
+   catch-all route never sees them and that directory needs a handler of its
+   own:
 
    ```ts
    // app/.well-known/[...vendo]/route.ts (src/app when the repo uses it)
@@ -269,13 +287,21 @@ skip none of its steps.
    VENDO_BASE_URL=https://app.example.com
    ```
 
+   `--base-url` only writes it into `.env.example`; setting it where the host
+   deploys stays your human's. Doctor FAILS
+   [`E-MCP-009`](/agents/verify#E-MCP-009) on an MCP-wired project with neither
+   this variable nor `mcp: { baseUrl }`.
+
 4. **`serviceAuth` — only when asked for.** Skip it unless the HOST's own
    backend has to act for a user who is not at a browser (a nightly job, a
    queue worker). `mcp: { serviceAuth: { keys: [...] } }` opens an RFC 8693
    exchange at the door's own token endpoint: the backend posts a key plus one
    of the host's user ids and gets back a short-lived token bound to that user.
    The keys are opaque secrets your human generates — ask before creating one
-   (Rules of engagement below). Third-party agents need none of it; they run
+   (Rules of engagement below). On the MCP init path, `--service-key` generates
+   one into `.env.local` and wires it, but only under local posture: a
+   broker-fronted door serves no token endpoint of its own, so the key is the
+   console's to create there. Third-party agents need none of it; they run
    the per-user OAuth the door already serves. Recipe:
    [MCP door](/capabilities/mcp).
 

--- a/docs-site/agents/verify.mdx
+++ b/docs-site/agents/verify.mdx
@@ -497,7 +497,8 @@ leave for a present-only install; this never blocks doctor.
 
 ## MCP door
 
-These checks run only when the composition reports `blocks.mcp: true`.
+These checks run only when the composition reports `blocks.mcp: true`. Wiring
+the door from scratch: [MCP door](/agents#mcp-door).
 
 ### E-MCP-001 {#E-MCP-001}
 

--- a/docs-site/capabilities/mcp.mdx
+++ b/docs-site/capabilities/mcp.mdx
@@ -234,6 +234,9 @@ When the door is served on a different origin than the one host routes resolve
 against, `mcp.baseUrl` carries the door's public base explicitly:
 `createVendo({ mcp: { baseUrl: "https://app.example.com" }, oauth })`.
 
+`vendo doctor` fails `E-MCP-009` on an MCP-wired composition with neither — a
+static check, so it catches this with no dev server and no network.
+
 <Warning>
   Under a path prefix, `VENDO_BASE_URL` must be the full public base *including*
   that prefix (`https://site.com/app`), or the door advertises OAuth endpoints

--- a/docs-site/capabilities/mcp.mdx
+++ b/docs-site/capabilities/mcp.mdx
@@ -1,134 +1,86 @@
 ---
-title: "MCP door: expose Vendo tools to Claude, ChatGPT, Cursor"
+title: "MCP door reference: options, OAuth adapter, wire contracts"
 sidebarTitle: "MCP door"
-description: "Serve your product's tools to Claude, ChatGPT, Cursor, and other MCP clients through one guarded, OAuth-authenticated door that shares your policy."
+description: "Reference for the MCP door: the mcp option, the HostOAuthAdapter contract, token and federation machinery, tool curation, consent theming, and the wire contracts behind them."
 ---
 
-Make your product installable in Claude, ChatGPT, Cursor, and Claude Code —
-with those agents acting as the person who signed in, not a service account.
-Every call through the door runs the same guard-bound registry, policy,
-approvals, and audit as chat.
+The door serves your product's tools to MCP clients — Claude, ChatGPT, Cursor,
+Claude Code — with the client acting as the person who signed in, not a service
+account. Every call through it runs the same guard-bound registry, policy,
+approvals, and audit as chat. To set the door up and connect a client, see
+[Set up the MCP door](/existing-agents/mcp).
 
 **Status: experimental.** `mcp: true` is real, guard-bound, and covered by
 protocol-level e2e (`fixtures/mcp-e2e`), but it stays out of the main
-[quickstart](/quickstart) path until the attended live client matrix is
-demonstrably green: a real Claude, ChatGPT, and Cursor client each completing
-one real tool call against a running door.
+[quickstart](/quickstart) path until a real Claude, ChatGPT, and Cursor client
+have each completed one attended tool call against a running door.
 `fixtures/mcp-e2e/tests/live-claude.e2e.test.ts` (env-gated behind
-`VENDO_LIVE_MCP=1`) is the harness for the Claude leg today; equivalent
-attended runs against ChatGPT and Cursor are still outstanding. The door
-graduates into the quickstart's main flow once all three are green and someone
-records the run.
-
-<CardGroup cols={2}>
-  <Card title="See it end to end" icon="route" href="/existing-agents/mcp">
-    A full walkthrough: an outside agent acting as the signed-in user, and the
-    screen landing on your own page.
-  </Card>
-  <Card title="Publish it to the MCP registry" icon="tower-broadcast" href="/capabilities/mcp-registry">
-    Make the deployed door discoverable through the official registry.
-  </Card>
-</CardGroup>
+`VENDO_LIVE_MCP=1`) is the Claude leg; ChatGPT and Cursor are outstanding.
 
 ## When to use it
 
-- You want an installable MCP server that exposes your product's tools to
-  third-party agents.
-- Users of those agents should act as themselves in your product, with the same
-  policy and approvals you enforce in-product.
-- You already own a session and consent flow you can plug in behind an OAuth
-  seam.
+The door is the third-party-agent story: an installable MCP server that exposes
+your product's tools to agents you do not run, whose users act as themselves in
+your product under the same policy and approvals you enforce in-product.
 
-Skip it if you only need to pull remote MCP tools into your own agent. That is
-what `mcpConnector` does, and it runs the other direction. See
-[Connectors](/capabilities/connected-accounts#connectors).
+Two adjacent cases are not the door:
 
-Also skip it if the agent is your own, running in process with `createVendo`
-in your backend (an AI SDK or Mastra loop you already ship). That case needs
-no OAuth dance and no door: spread the guarded tool pack into your loop
-through the `@vendoai/vendo/ai-sdk` or `@vendoai/vendo/mastra` subpath. See
-[Use with your existing agent](/existing-agents). The door remains the
-third-party-agent story.
+- **Pulling remote MCP tools into your own agent** runs the other direction.
+  That is `mcpConnector` — see
+  [Connectors](/capabilities/connected-accounts#connectors).
+- **Your own agent, in process** with `createVendo` in your backend (an AI SDK
+  or Mastra loop you already ship) needs no OAuth dance and no door. Spread the
+  guarded tool pack into your loop through the `@vendoai/vendo/ai-sdk` or
+  `@vendoai/vendo/mastra` subpath — see
+  [Use with your existing agent](/existing-agents).
 
-One exception to that last one: a backend of yours that has to act for a user
-who is **not** at a browser — a nightly job, a queue worker — can run neither
-the OAuth dance nor the in-process pack. `mcp: { serviceAuth: { keys } }` opens
-first-party service auth at the door's own token endpoint for exactly that:
-your backend posts a key you generated (`openssl rand -hex 32`) plus one of your
-user ids to the door's token endpoint for a ten-minute token bound to that user, then
-talks MCP with it like any other client. Per-user OAuth stays the story for
-anyone else's agent;
-a service key is for code you deploy. See
-[Your own backend, as one of your users](/existing-agents/mcp).
+A backend of yours acting for a user who is **not** at a browser — a nightly
+job, a queue worker — can run neither the OAuth dance nor the in-process pack.
+`mcp: { serviceAuth: { keys } }` opens first-party service auth at the door's own
+token endpoint for exactly that: your backend posts a key you generated
+(`openssl rand -hex 32`) plus one of your user ids and receives a ten-minute
+token bound to that user — no refresh token — then talks MCP with it like any
+other client. Nothing downstream changes: the same guard, approvals, and audit,
+with the call attributed to the person and to the key as `svc:<hash8>` (the
+presented key's digest, so the audit row names which key acted without the value
+going near it). A service key is for code you deploy and can name any user, so
+it is exactly as powerful as your backend already is; per-user OAuth stays the
+story for anyone else's agent.
+
+Two edges. While the door lists a key, a wrong `client_id`, an unknown key, and
+a retired one all answer the same `invalid_client` — nothing tells a guesser
+which half of the credential they have right. A door that lists no key answers
+every attempt, a valid key included, with `unsupported_grant_type`: it is not
+refusing the exchange, it is not offering one. So closing the exchange means
+removing `serviceAuth`, not emptying it — `keys: []`, or a blank entry (the
+usual sign of an unset environment variable), is a composition error, because a
+key nothing can ever match would advertise the grant and then refuse every
+attempt. The exchange itself is in
+[Set up the MCP door](/existing-agents/mcp).
 
 ## Enable the door
 
-Set `mcp: true` and pass a `HostOAuthAdapter`. The recommended shape has two
-methods: `session` looks up the current host user (or bounces the browser to
-your login), and `principal` resolves that subject to a live principal on every
-door request. The door renders the consent page itself.
+Two keys open the door: `mcp` (`true` for defaults, or the object form under
+[Configure the door through the umbrella](#configure-the-door-through-the-umbrella))
+and `oauth`, a `HostOAuthAdapter`. `oauth` is required whenever `mcp` is
+enabled — the door mints its principals through that adapter, so `createVendo`
+throws at composition without one. An `auth` preset carrying an oauth half
+satisfies the same seam.
 
-```ts
-// lib/vendo.ts
-import { createVendo } from "@vendoai/vendo/server";
-import type { HostOAuthAdapter } from "@vendoai/vendo";
-
-const oauth: HostOAuthAdapter = {
-  async session(request, { returnTo }) {
-    // Return the current host subject, or redirect the browser
-    // to login. Send the user back through `returnTo` so the
-    // door resumes the exact authorization request without a
-    // login → authorize → login loop.
-    const user = await resolveSession(request);
-    if (user) return { subject: user.id };
-
-    const login = new URL("/login", request.url);
-    login.searchParams.set("returnTo", returnTo);
-    return Response.redirect(login);
-  },
-  async principal(subject) {
-    // Re-resolved on every bearer-authenticated MCP request.
-    // Return null to revoke.
-    const user = await lookupUser(subject);
-    return user
-      ? { kind: "user", subject: user.id, display: user.name }
-      : null;
-  },
-};
-
-export const vendo = createVendo({
-  model,
-  principal: resolvePrincipal,
-  mcp: true,
-  oauth,
-});
-```
-
-Then re-export the handler from your catch-all route:
-
-```ts
-// app/api/vendo/[...vendo]/route.ts
-import { nextVendoHandler } from "@vendoai/vendo/server";
-import { vendo } from "@/lib/vendo";
-
-export const { GET, POST, PUT, PATCH, DELETE } =
-  nextVendoHandler(vendo);
-```
-
-`oauth` is required when `mcp` is true. Without it, `createVendo` throws: the
-door cannot mint principals otherwise. The full adapter contract, including
-the legacy authorize-only mode, is in
-[HostOAuthAdapter](#hostoauthadapter).
+The recommended shape is two methods: `session` looks up the current host user
+(or bounces the browser to your login), and `principal` resolves that subject to
+a live principal on every door request. With `session` defined the door renders
+the consent page itself. The full contract, including the legacy authorize-only
+mode, is in [HostOAuthAdapter](#hostoauthadapter).
 
 ## Curate the tool menu
 
 By default the door offers every merged, enabled tool whose `audience` is
-`end-user` or unset. That default exists because an MCP client speaks for a
-person, so the door offers what that person's own auth admits. Operator and
-internal tools stay off it.
+`end-user` or unset: an MCP client speaks for a person, so the door offers what
+that person's own auth admits. Operator and internal tools stay off it.
 
-Most products want a shorter, deliberate menu. Name it in
-`.vendo/overrides.json` under `surfaces.mcp`:
+A shorter, deliberate menu is named in `.vendo/overrides.json` under
+`surfaces.mcp`:
 
 ```json
 {
@@ -151,10 +103,9 @@ the same for your in-product agent's loadout. Both keys are optional and
 independent; `surfaces` accepts only `agent` and `mcp`, so a misspelled surface
 name fails loudly when the file parses.
 
-A menu is curation, not a permission boundary. It changes what a surface
-offers. Your policy, approvals, audit, `disabled`, and audience exclusions
-decide what may run, and none of them read this block. Keep a destructive tool
-on the menu if users need it: the guard still parks it.
+A menu is curation, not a permission boundary. Your policy, approvals, audit,
+`disabled`, and audience exclusions decide what may run, and none of them read
+this block. A destructive tool can stay on the menu: the guard still parks it.
 
 An entry naming a tool that does not exist or is disabled warns once at boot
 and is skipped. The rest of the menu still applies, because a stale name in a
@@ -166,11 +117,11 @@ curated away. They are the runtime's plumbing, not your API.
 ### Title your tools
 
 Tool names are wire identifiers and extracted descriptions are often raw route
-text. Give a tool a `title` and every surface that shows it to a person uses
-that label instead: the door's `tools/list`, and your approval cards.
+text. A tool's `title` is what every surface that shows it to a person uses
+instead: the door's `tools/list`, and your approval cards.
 
-`vendo sync`'s AI enrichment pass proposes titles for you while it reads your
-handlers. A `title` in `.vendo/overrides.json` always wins over what it wrote.
+`vendo sync`'s AI enrichment pass proposes titles while it reads your handlers.
+A `title` in `.vendo/overrides.json` always wins over what it wrote.
 
 ### Annotations on the wire
 
@@ -190,68 +141,39 @@ safety about a tool nobody has graded — and `true` would be the opposite guess
 Omitting them leaves the client on the spec's conservative defaults. Grade the
 tool (`vendo sync`, or `.vendo/overrides.json`) and the hints appear.
 
-Annotations are hints for presentation. The guard is what decides.
-
-Annotations ride on every listing, whether or not you curate a menu. One
-consequence worth knowing before you upgrade: a `read` tool now asserts
-`readOnlyHint: true`, and some clients use that to skip their own confirmation
-prompt for read calls. Your server-side perimeter is unchanged. If a
+Annotations are presentation hints — the guard is what decides — and they ride
+every listing whether or not you curate a menu. One consequence: some clients
+use `readOnlyHint: true` to skip their own confirmation prompt, so if a
 `read`-labelled tool is not actually side-effect free, fix its `risk` in
 `.vendo/overrides.json`; that label was already driving your policy and
 approvals.
 
 ## Consent page
 
-The door renders the consent page for you when your adapter uses `session`. It
+The door renders the consent page itself when your adapter uses `session`. It
 owns the approve and deny buttons, CSRF-protects the POST, rejects a replayed
 approval, escapes the attacker-controllable `client_name` value from dynamic
 client registration, and issues the standard OAuth authorization-code redirect.
-You do not write any of that.
 
 ### Theme it
 
 The consent page styles itself from the same `--vendo-*` CSS custom properties
 the rest of your product UI reads: `--vendo-color-*`, `--vendo-font-*`,
-`--vendo-radius-*`, and `--vendo-space-*`. When you configure Vendo through
-`createVendo`, the umbrella hands your resolved `.vendo/theme.json` to the door
-automatically. Edit `.vendo/theme.json` to restyle the page; no consent-specific
-configuration is needed.
+`--vendo-radius-*`, and `--vendo-space-*`. `createVendo` hands your resolved
+`.vendo/theme.json` to the door automatically, so `.vendo/theme.json` is the
+only place to edit; there is no consent-specific configuration.
 
-The same theme also carries into apps rendered inside MCP clients. See
+The same theme carries into apps rendered inside MCP clients. See
 [Saved apps ride along](#saved-apps-ride-along).
 
 ### Replace the page
 
-If you need a custom consent page (different copy, a compliance disclosure, a
-branded layout the tokens cannot express), add an `authorize` method alongside
-`session`. The door still owns CSRF, single-use replay protection, and the
-OAuth redirect; you only own the rendered HTML. Post `transaction`,
-`csrf_token`, and `decision=approve|deny` to the `action` URL the door supplies
-in `ctx.consent`.
-
-```ts
-const oauth: HostOAuthAdapter = {
-  async session(request, { returnTo }) {
-    /* as above */
-  },
-  async authorize(request, { clientName, scopes, consent }) {
-    // `consent` is present because `session` is defined.
-    // Render your own page and post the door's form values
-    // back to `consent.action`.
-    return new Response(
-      renderConsent({ clientName, scopes, consent }),
-      {
-        headers: {
-          "content-type": "text/html; charset=utf-8"
-        }
-      }
-    );
-  },
-  async principal(subject) {
-    /* as above */
-  },
-};
-```
+An `authorize` method alongside `session` replaces the rendered page — for
+different copy, a compliance disclosure, or a branded layout the tokens cannot
+express. The door still owns CSRF, single-use replay protection, and the OAuth
+redirect; you own only the HTML. It supplies `ctx.consent`, and your page posts
+`transaction`, `csrf_token`, and `decision=approve|deny` to the `action` URL
+there. The signature is in [HostOAuthAdapter](#hostoauthadapter).
 
 Always HTML-escape `clientName` before rendering it. Clients register their own
 name through dynamic client registration or a Client ID Metadata Document, so
@@ -259,24 +181,19 @@ that value is attacker-controllable and can carry phishing text or markup.
 
 ## Connect a client
 
-Point the client at `https://your-app.example.com/api/vendo/mcp`. The client
-discovers OAuth from the `WWW-Authenticate` challenge on its first `401`,
-walks the user through your `authorize` step, and starts calling tools.
+The door's MCP endpoint is the `mcp` path under the wire, for example
+`https://your-app.example.com/api/vendo/mcp`. A client discovers OAuth from the
+`WWW-Authenticate` challenge on its first `401`, walks the user through your
+authorize step, and then calls tools.
 
-Verify the door from the host root:
-
-```bash
-npx vendo doctor
-```
-
-When the door is open, doctor verifies both OAuth metadata documents resolve,
-the server card parses, and, if you have started registry paperwork, that
-your `server.json` and `mcp-registry-auth` challenge match the live door.
-`GET /status` returns `blocks.mcp: true`. See
+`GET /status` reports the door as `blocks.mcp: true`. `vendo doctor`, run from
+the host root, verifies that both OAuth metadata documents resolve, that the
+server card parses, and — if registry paperwork has started — that your
+`server.json` and `mcp-registry-auth` challenge match the live door. See
 [HTTP routes](/reference/http-routes) for the door's route table and
 [Handler options](/reference/handler-options) for the `mcp` and `oauth` options.
 
-To make the deployed door discoverable through the official registry, follow
+Making a deployed door discoverable through the official registry is
 [Publish to the MCP registry](/capabilities/mcp-registry).
 
 ### The connect page
@@ -284,8 +201,7 @@ To make the deployed door discoverable through the official registry, follow
 The door serves a themed page at `{mount}/connect`, for example
 `https://your-app.example.com/api/vendo/mcp/connect`. It shows your product
 name, the exact MCP URL to paste, and per-client setup steps for Claude,
-ChatGPT, and Cursor, including a one-click Cursor install link. Link users to
-it from your settings or docs.
+ChatGPT, and Cursor, including a one-click Cursor install link.
 
 The page is unauthenticated and reads no user data: it shows only what your
 public server card already advertises. Like the consent page it ships zero
@@ -294,63 +210,45 @@ JavaScript and it themes itself from `.vendo/theme.json`.
 ## Route the discovery paths
 
 The door's transport and OAuth endpoints mount under the wire at
-`/api/vendo/mcp`, so your existing catch-all handler already serves them. The
-OAuth discovery documents live at the origin root, outside `/api/vendo`, so
-the catch-all never sees them. Init does not scaffold that route: add it by
-hand as a two-line re-export of the shipped handler. On Next.js it goes at
-`app/.well-known/[...vendo]/route.ts` (under `src/app` when present) —
-`examples/demo-bank` has the reference wiring.
+`/api/vendo/mcp`, so an existing catch-all handler already serves them. The
+OAuth discovery documents live at the origin root, outside `/api/vendo`, so the
+catch-all never sees them; `wellKnownVendoHandler` (exported from
+`@vendoai/vendo/server`) is the handler for those, mounted at the origin root —
+`app/.well-known/[...vendo]/route.ts` on Next.js, a second `mountVendo()` at
+`/.well-known` on Express. `examples/demo-bank` has the reference wiring.
 
-```ts
-// app/.well-known/[...vendo]/route.ts
-import { wellKnownVendoHandler } from "@vendoai/vendo/server";
-import { vendo } from "@/lib/vendo";
-
-export const { GET, POST } = wellKnownVendoHandler(vendo);
-```
-
-`wellKnownVendoHandler` answers only the door's own discovery paths and
-returns 404 for anything else under `/.well-known`. If your app also serves
-its own well-known documents, register those routes separately; the exact
-paths the door owns are listed in
-[Well-known discovery paths](#well-known-discovery-paths).
-
-On Express, the adapter that `vendo init` generates reconstructs the full path
-from `req.originalUrl`, so the same handler serves both bases:
-
-```ts
-app.use("/api/vendo", mountVendo());
-app.use("/.well-known", mountVendo());
-```
-
-Because the door 404s every other well-known path, register your app's own
-well-known routes before that second mount.
+An app that serves its own well-known documents must register those routes
+separately — and, on Express, before that second mount. The exact paths the door
+owns are in [Well-known discovery paths](#well-known-discovery-paths).
 
 ## Set VENDO_BASE_URL
 
-Set `VENDO_BASE_URL` to your product's full public URL — path prefix included
-— in every real deployment:
-
-```bash
-VENDO_BASE_URL=https://app.example.com
-```
-
-Behind a reverse proxy (Railway, Fly, any TLS terminator), the request
-reaching your process carries the proxy-internal origin, so without
-`VENDO_BASE_URL` the door publishes discovery documents that point at an
-unreachable origin. It also gives door-first traffic a base to resolve host
-routes against. The full list of what it controls is in
+`VENDO_BASE_URL` is your product's full public URL, path prefix included, and
+every real deployment needs it. Behind a reverse proxy (Railway, Fly, any TLS
+terminator) the request reaching your process carries the proxy-internal origin,
+so without it the door publishes discovery documents that point at an
+unreachable origin. The full list of what it controls is in
 [VENDO_BASE_URL duties](#vendo_base_url-duties).
 
-If your composition serves the door on a different origin than the one host
-routes resolve against, pass the door's public base explicitly:
+When the door is served on a different origin than the one host routes resolve
+against, `mcp.baseUrl` carries the door's public base explicitly:
 `createVendo({ mcp: { baseUrl: "https://app.example.com" }, oauth })`.
+
+<Warning>
+  Under a path prefix, `VENDO_BASE_URL` must be the full public base *including*
+  that prefix (`https://site.com/app`), or the door advertises OAuth endpoints
+  that 404. Two known bugs bite that configuration today —
+  [#866](https://github.com/runvendo/vendo/issues/866) (the login redirect and
+  the consent form drop the prefix) and
+  [#867](https://github.com/runvendo/vendo/issues/867) — so verify the sign-in
+  bounce end to end before pointing a real client at a prefixed deployment. A
+  deployment served at an origin root is unaffected.
+</Warning>
 
 ## Configure the door through the umbrella
 
-`mcp: true` opens the door with defaults. To pass door-specific settings
-through `createVendo`, for example when you front the door with a hosted
-broker or a different origin, replace `true` with an object:
+The object form carries door-specific settings through `createVendo` — a
+different origin, an external authorization server, federation:
 
 ```ts
 export const vendo = createVendo({
@@ -370,8 +268,8 @@ export const vendo = createVendo({
 });
 ```
 
-`baseUrl`, `remoteAs`, and `federation` live under `mcp: { … }`; they are
-not top-level `createVendo` keys.
+`baseUrl`, `remoteAs`, `federation`, and `serviceAuth` live under `mcp: { … }`;
+they are not top-level `createVendo` keys.
 
 ## How door calls reach host tools
 
@@ -387,94 +285,82 @@ MCP bearer to your host routes. Door tool calls reach host APIs through the same
   same clean degradation as an away automation.
 
 The OAuth-authenticated user is the authority. Risky tools still stop at your
-per-call guard decision, whatever the token's scopes.
+per-call guard decision, whatever the token's scopes, and the door adds no
+exemption either way. On the `cautious` preset that means reads answer straight
+away while writes, `vendo_apps_pin` and `vendo_apps_unpin` among them, wait for
+the person.
+
+<Warning>
+  Approving a parked call does not resume it. The agent has to call again, **on
+  the same MCP session**: the door mints a fresh call id per `tools/call` except
+  for an identical still-parked call in the same session, and guard's one-off
+  approval is pinned to that exact id — so a client that reconnects between
+  attempts mints a new id and parks again. Real clients hold one session for a
+  conversation, so this only traps scripts that connect per call.
+</Warning>
 
 ## Delegate to an external authorization server
 
-If your product already runs its own OAuth authorization server, or you use an
-identity provider that issues bearer tokens for your APIs, point the door at it
-with `remoteAs` instead of letting the door mint tokens itself. The door then
-authenticates every MCP request by verifying the inbound bearer as a JWT signed
-by that issuer.
-
-```ts
-export const vendo = createVendo({
-  model,
-  principal: resolvePrincipal,
-  oauth,
-  mcp: {
-    remoteAs: {
-      issuer: "https://auth.example.com",
-      audience: "https://app.example.com/api/vendo/mcp",
-      // jwksUri is optional; the door discovers it from the
-      // issuer's RFC 8414 metadata when omitted.
-    },
-  },
-});
-```
-
-Use `remoteAs` when the external server is authoritative for user identity for
-your product. Skip it if you want the door to run its own OAuth surface. The
-exact token requirements and endpoint behavior in this mode are specified in
+`mcp.remoteAs` points the door at an authorization server you already run, or an
+identity provider that issues bearer tokens for your APIs, instead of letting
+the door mint tokens itself. The door then authenticates every MCP request by
+verifying the inbound bearer as a JWT signed by that issuer. It takes an
+`issuer`, an `audience`, and an optional `jwksUri` — omitted, the door discovers
+the JWKS from the issuer's RFC 8414 metadata. The exact token requirements and
+endpoint behavior in this mode are in
 [remoteAs token requirements](#remoteas-token-requirements).
 
-When a hosted broker fronts the door, you do not need the object form at all:
-set `VENDO_MCP_BROKER_URL` to your tenant's MCP endpoint and leave `mcp: true`.
+Use `remoteAs` when the external server is authoritative for user identity;
+skip it when the door should run its own OAuth surface. A door in this mode
+serves no token endpoint of its own, so a service-key exchange lives at that
+issuer's own `token_endpoint` instead; passing `mcp.serviceAuth` alongside an
+explicit `mcp.remoteAs` warns at composition and does nothing.
+
+A hosted broker in front of the door needs no object form at all:
+`VENDO_MCP_BROKER_URL` set to your tenant's MCP endpoint, with `mcp: true`, is
+the whole switch.
 
 ```bash
 VENDO_MCP_BROKER_URL=https://acme.mcp.vendo.run/mcp
 ```
 
-Broker mode is something you **declare**, not something Vendo discovers. That
-one variable is the whole switch: the URL's origin becomes the issuer, the URL
-itself becomes the expected token audience, and the door stops serving its own
-`/authorize`, `/token` and `/register`. Nothing is registered anywhere and
-nothing is fetched at boot, so no deploy can repoint another one; a URL the
-door cannot verify tokens against fails loudly rather than quietly reverting to
-a local OAuth surface. An explicit `mcp.remoteAs` still wins over it.
+Broker mode is **declared**, never discovered. The URL's origin becomes the
+issuer, the URL itself becomes the expected token audience, and the door stops
+serving its own `/authorize`, `/token`, and `/register`. Nothing is registered
+anywhere and nothing is fetched at boot, so no deploy can repoint another one; a
+URL the door cannot verify tokens against fails loudly rather than quietly
+reverting to a local OAuth surface. An explicit `mcp.remoteAs` still wins over
+it.
 
-So does an explicit `mcp.serviceAuth`: its exchange only exists at the door's own
+So does an explicit `mcp.serviceAuth`: its exchange exists only at the door's own
 `/token`, so configuring it is a choice of local authorization server, and this
 variable — a default — leaves it alone. To front a `serviceAuth` door with a
-broker, move the exchange to the broker and drop `serviceAuth`.
+broker, move the exchange to the broker and drop `serviceAuth`. The broker's own
+exchange answers field for field the same as the door's, except that its
+`access_token` is a signed JWT rather than an opaque string. It also forwards
+only to a public HTTPS address, so it can never reach `localhost` — a laptop is
+the self-hosted path whatever the account.
 
 ## Federate login from an external authorization server
 
-`federation` adds a signed handshake so an external authorization server can
+`mcp.federation` adds a signed handshake so an external authorization server can
 have your host complete the interactive login-and-consent step, then hand the
-answer back. This is useful when the external server owns tokens (see
-`remoteAs` above) but does not know how to authenticate your users; your app
-does.
+answer back. It applies when the external server owns tokens (see `remoteAs`
+above) but does not know how to authenticate your users; your app does.
 
-```ts
-export const vendo = createVendo({
-  model,
-  principal: resolvePrincipal,
-  oauth,
-  mcp: {
-    federation: {
-      secret: process.env.VENDO_MCP_FEDERATION_SECRET!
-    },
-  },
-});
-```
-
-Set `VENDO_MCP_FEDERATION_SECRET` to a high-entropy secret shared with the
-external authorization server; the composition reads it directly, so the
-`mcp: { federation }` object above is only needed when the secret comes from
-somewhere other than that variable. That server crafts an HS256-signed request JWT
-and redirects the user's browser to
-`GET /api/vendo/mcp/federate?request=<compact JWS>`. The exact claims the
-request JWT must carry are listed in
-[Federation JWT claims](#federation-jwt-claims).
+`VENDO_MCP_FEDERATION_SECRET` is the high-entropy secret shared with that
+server, and the composition reads it directly — the `mcp: { federation }` object
+is only needed when the secret comes from somewhere other than that variable.
+The external server crafts an HS256-signed request JWT and redirects the user's
+browser to `GET /api/vendo/mcp/federate?request=<compact JWS>`. The claims that
+JWT must carry are in [Federation JWT claims](#federation-jwt-claims).
 
 The door verifies the request, then authenticates the user through your
 adapter:
 
 - If your adapter implements `authorize`, the door calls
-  `oauth.authorize(request, { clientName, scopes })`. This is the same
-  authorize step your local flow uses, so you do not need a separate consent
-  UI.
+  `oauth.authorize(request, { clientName, scopes })` — the same authorize step
+  your local flow uses, so no separate consent UI is needed.
 - If your adapter is session-only (no `authorize`), the door calls
   `oauth.session(request, { returnTo })` with the federate request URL as
   `returnTo`, so a logged-out user bounces to your login page and resumes the
@@ -505,13 +391,12 @@ curl -X POST https://app.example.com/api/vendo/mcp/revoke \
   -d "token_type_hint=refresh_token"
 ```
 
-Returning `null` from your `oauth.principal(subject)` remains the account-level
-kill switch and takes effect on the next transport request. That's the fastest
-way to sever every client for a user from your product's settings UI: the
-door re-resolves the principal on each transport request and closes live MCP
-sessions the moment the lookup fails.
+Returning `null` from your `oauth.principal(subject)` is the account-level kill
+switch: the door re-resolves the principal on every transport request and closes
+live MCP sessions the moment the lookup fails — the fastest way to sever every
+client for a user from your product's settings UI.
 
-What each revocation retires, and how the endpoint answers, is specified in
+What each revocation retires, and how the endpoint answers, is in
 [Revocation semantics](#revocation-semantics).
 
 ## Saved apps ride along
@@ -526,8 +411,13 @@ agent asks for a screen in plain language exactly as your own agent does, and
 `vendo_apps_pin` / `vendo_apps_unpin` put a saved app into one of your product's
 slots. None of it hands the agent any UI: `vendo_make` answers with a four-field
 receipt of words, and the screen arrives on the person's own page in your
-product, on a channel the agent is not on. The full walkthrough is
-[Bring your own agent over MCP](/existing-agents/mcp).
+product, on a channel the agent is not on.
+
+A build can come back `failed`, with a reason: the checks floor rejects a screen
+whose bindings claim data your host does not return, or whose props do not
+type-check. Nothing is painted and whatever held the slot stays. The reason is
+the agent's to act on — a narrower retry on the same `app` beats rebuilding from
+scratch.
 
 ### HTTP apps open in-product
 
@@ -552,8 +442,6 @@ on `kind` rather than sniffing shape:
 - `productName` comes from your MCP server identity, so the CTA always names
   your product.
 - `appName` is best-effort; the door omits it when the app has no title.
-- The card themes itself from the same `--vendo-*` CSS tokens as the consent
-  page, so no extra configuration is needed to match your brand.
 
 Tree apps still render inline through the shim; only served-app (layer 3)
 link-outs use the card.
@@ -567,10 +455,9 @@ also propagates the tokens into the sandboxed frame that hosts generated
 components, so payload UI, notices, link-out cards, and generated components
 all inherit your theme.
 
-You do not configure this per-app. When you use `createVendo({ mcp: true })`,
-the umbrella forwards your validated `.vendo/theme.json` to the door and the
-door serves it in the shim. Edit `.vendo/theme.json` to restyle both the
-consent page and MCP-rendered apps in one place.
+There is no per-app configuration: the door serves your validated
+`.vendo/theme.json` in the shim, so one edit restyles the consent page and
+MCP-rendered apps alike.
 
 ## Door reference
 
@@ -617,12 +504,9 @@ ordinary 404 rather than a 500.
 
 - **Discovery and audience binding.** The door derives its OAuth discovery
   documents (issuer, endpoint URLs, the protected-resource `resource`) and its
-  token audience binding from `VENDO_BASE_URL` when set, so clients see your
-  full public URL — path prefix included — instead of an unreachable
-  proxy-internal one. Forwarded
-  headers such as `X-Forwarded-Host` are never trusted. Without it, the door
-  falls back to the request URL, which is fine for local development and wrong
-  behind a proxy.
+  token audience binding from `VENDO_BASE_URL` when set; forwarded headers such
+  as `X-Forwarded-Host` are never trusted. Without it the door falls back to the
+  request URL — fine for local development, wrong behind a proxy.
 - **Route-binding base.** Host tools that bind to routes need a base origin.
   The wire normally learns its own origin from the first in-product request,
   but door requests never teach it (only wire routes do); `VENDO_BASE_URL`

--- a/docs-site/existing-agents/mcp.mdx
+++ b/docs-site/existing-agents/mcp.mdx
@@ -1,105 +1,110 @@
 ---
-title: "Bring your own agent over MCP"
+title: "Set up the MCP door"
 sidebarTitle: "Any agent over MCP"
-description: "Let Claude Code, Claude, Cursor, or any MCP client act in your product as the signed-in user: guarded host tools, vendo_make for screens, and the screen landing on your own page."
+description: "Open one URL and Claude Code, Claude, ChatGPT, or Cursor acts in your product as the person who signed in — through your own guard, approvals, and audit."
 ---
 
-The [AI SDK](/existing-agents/ai-sdk) and [Mastra](/existing-agents/mastra)
-walkthroughs are for an agent you run in process with `createVendo`. Open the
-[MCP door](/capabilities/mcp) instead and an agent you do **not** run acts in
-your product as the person who signed in, through the same guard, approvals,
-and audit your own surfaces use.
+import { AgentPrompt } from "/snippets/agent-prompt.jsx"
 
-Nothing to build on the agent's side: it reads the door's `tools/list` and
-calls what it finds — your host actions, and Vendo's own `vendo_make`.
+## What you get
 
-<Note>
-  **Status: experimental**, the same label the [MCP door](/capabilities/mcp)
-  carries — though the two halves are not at the same place. The first-party
-  service-key path below runs end to end in production: a key minted in the
-  console, exchanged for a token bound to one user, real tool calls proxied
-  through the hosted broker to a live deployment, and revocation refusing the
-  next exchange. The attended live-client matrix — a person driving Claude,
-  ChatGPT, or Cursor through the browser login and consent flow — is the open
-  item, and it is what keeps this page out of the main
-  [quickstart](/quickstart).
-</Note>
-
-## 1. Open the door
-
-Pick **outside agents over MCP** in `npx vendo init` and this is scaffolded for
-you: the composition with `mcp: true`, the origin-root discovery route, and a
-thin catch-all route over the same instance. Two of the three below stop being
-host decisions the moment init is the one *creating* the composition — writing
-`mcp: true` into a file it authors is not editing your code, and the discovery
-route is a new file at a fixed path with a fixed two-line body.
-
-Exactly two things stay yours, because they are the two init genuinely cannot
-do: set `VENDO_BASE_URL` in your deploy platform, and point a client at the
-door. `npx vendo doctor` **fails** (`E-MCP-009`) on an MCP-wired project with no
-base URL — the door's discovery, issuer and token audience all derive from it,
-so without it the door advertises whatever origin a request happened to carry.
-
-By hand, it is three things: `mcp: true`, an OAuth adapter, and the origin-root
-discovery route.
-
-```ts
-// app/api/vendo/[...vendo]/vendo.ts
-export const vendo = createVendo({
-  model,
-  principal: resolvePrincipal,
-  mcp: true,
-  oauth, // a HostOAuthAdapter: session() + principal()
-});
-```
-
-```ts
-// app/.well-known/[...vendo]/route.ts
-import { wellKnownVendoHandler } from "@vendoai/vendo/server";
-import { vendo } from "../../api/vendo/[...vendo]/vendo";
-
-export const { GET, POST } = wellKnownVendoHandler(vendo);
-```
-
-The composition lives in its own module for two reasons: a Next.js route module
-may export only route handlers, and the discovery route must import the **same
-instance** your catch-all serves. `wellKnownVendoHandler` resolves its path set
-by instance identity, so a second `createVendo` call in that file answers 404 on
-every well-known path.
-
-The OAuth adapter needs no separate decision when an auth preset is already
-wired: `createVendo({ auth })` fills the principal, actAs **and oauth** seams
-from one preset, and every zero-arg preset — `clerk()`, `authJs()`,
-`supabase()`, `auth0()` — carries all three. `jwt()` does not, which is why init
-declines to open the door on a `jwt` or anonymous composition rather than
-writing a `mcp: true` that throws at startup.
-
-Your existing catch-all route already serves the transport, and
-`npx vendo doctor` checks the wiring. The adapter contract and the consent page
-are on [MCP door](/capabilities/mcp).
-
-## 2. Connect any client
-
-Hand the client one URL:
+One URL any MCP client can install. The agent reads the door's `tools/list`,
+calls your host actions and Vendo's `vendo_make`, and acts as the person who
+signed in — same guard, approvals, and audit as your own UI.
 
 ```
 https://your-app.example.com/api/vendo/mcp
 ```
 
-The OAuth is nobody's code. The door answers the client's first
-unauthenticated request with the RFC 9728 challenge; the client registers
-itself through dynamic client registration, runs PKCE, and sends the person to
-**your** login and the door's own consent page.
+<Note>
+  **Status: experimental.** The service-key path below runs end to end in
+  production. The attended live-client matrix — a person driving Claude,
+  ChatGPT, or Cursor through the browser login and consent flow — is the open
+  item, and it keeps this page out of the [quickstart](/quickstart).
+</Note>
 
-The door also serves a page for people at
-`https://your-app.example.com/api/vendo/mcp/connect` — your product's name, the
-URL to paste, and per-client steps for Claude, ChatGPT, and Cursor. Link users
-to it from your settings.
+## Set up the door (once)
 
-## 3. Claude Code: install the plugin
+<AgentPrompt
+  lead={<>Paste this prompt and it wires the door against the <a href="/agents">agent playbook</a>.</>}
+  prompt={"Set up Vendo's MCP door in this repo. Read https://vendo.run/agents.md and follow it exactly. Ask me before creating any account or key. You're done when `vendo doctor --json` reports all green."}
+/>
 
-Claude Code users can skip the paste. The Vendo plugin is a manifest, the
-connection, and one skill:
+Rather run it yourself? Pick **outside agents over MCP** in `npx vendo init`, or
+answer that question up front:
+
+```bash
+npx vendo init --use-case mcp
+```
+
+Init writes the composition with `mcp: true`, a thin catch-all route over the
+same instance, and the origin-root discovery route. Exactly two things stay
+yours, because they are the two init cannot do: set `VENDO_BASE_URL` in your
+deploy platform, and point a client at the door.
+
+It opens the door only on a Next.js app with an auth preset already wired — the
+door mints its own principals through an OAuth adapter, and `clerk()`,
+`authJs()`, `supabase()` and `auth0()` each carry that half. Anything else and
+init says so and writes nothing MCP: wire a preset and re-run, or do it by hand
+below.
+
+Either way, gate on doctor. It checks both metadata documents resolve and the
+server card parses, and it **fails** (`E-MCP-009`) on an MCP-wired project with
+no base URL — the door's discovery, issuer and token audience all derive from
+it, so without it the door advertises whatever origin a request happened to
+carry:
+
+```bash
+npx vendo doctor
+```
+
+### By hand
+
+The same three things, for a repo init did not scaffold. First, `mcp: true`
+plus an OAuth adapter — one `auth` preset fills that seam along with
+`principal` and `actAs`:
+
+```ts
+// lib/vendo.ts
+import { authJs } from "@vendoai/vendo/auth/auth-js";
+import { createVendo } from "@vendoai/vendo/server";
+
+export const vendo = createVendo({
+  auth: authJs(), // supplies principal, actAs, and the door's oauth half
+  mcp: true,
+});
+```
+
+Move the composition `vendo init` wrote into `lib/vendo.ts` and re-export
+`nextVendoHandler(vendo)` from your catch-all route — that route already serves
+the door's transport and OAuth endpoints. Your own `oauth` adapter instead of a
+preset works too; see [Enable the door](/capabilities/mcp#enable-the-door).
+
+Second, the discovery route. It lives at the origin root, outside
+`/api/vendo`, so the catch-all never sees it:
+
+```ts
+// app/.well-known/[...vendo]/route.ts
+import { wellKnownVendoHandler } from "@vendoai/vendo/server";
+import { vendo } from "@/lib/vendo";
+
+export const { GET, POST } = wellKnownVendoHandler(vendo);
+```
+
+It must import the **same instance** your catch-all serves:
+`wellKnownVendoHandler` resolves its path set by instance identity, so a second
+`createVendo` call in that file answers 404 on every well-known path.
+
+Third, the public origin — path prefix included. Without it the door
+advertises OAuth endpoints nobody outside your process can reach:
+
+```bash
+VENDO_BASE_URL=https://your-app.example.com
+```
+
+## Connect — pick your client
+
+### Claude Code
 
 ```bash
 /plugin marketplace add runvendo/vendo
@@ -112,163 +117,122 @@ Point it at your deployment:
 export VENDO_MCP_URL=https://your-app.example.com/api/vendo/mcp
 ```
 
-This one is client-side — it tells the plugin on your machine which server to
-talk to. It is not `VENDO_MCP_BROKER_URL`, which is set in your deployment's own
-environment to name the broker fronting its door.
-
-Signing in is the same OAuth dance, run by Claude Code itself. The skill is the
-only thing the plugin adds beyond the connection: when an answer wants to be
-looked at instead of read out, how to phrase the request, when to name a
-destination, and never to describe a screen it has not seen. Source:
+Claude Code runs the sign-in itself. Beyond the connection the plugin adds one
+skill: reach for a screen when an answer wants to be looked at instead of read
+out, and never describe one it has not seen. Source:
 [`examples/claude-code-plugin`](https://github.com/runvendo/vendo/tree/main/examples/claude-code-plugin).
 
-## Your own backend, as one of your users
+### Cursor, Claude, ChatGPT — any MCP client
 
-Everything above is an agent you do not run. When the caller is **your own
-backend** — a nightly job, a queue worker, a support console acting for someone
-who is not at a browser — the OAuth dance has nobody to run it: no browser to
-bounce, no consent page to click, and no third party to consent to.
+Paste the URL:
 
-A service key is the first-party way in. It is minted once, your backend holds
-it, and it exchanges the key plus one of **your** user ids for a short-lived
-token bound to that user. Nothing downstream changes: same guard, same
-approvals, same audit, and the tool call is attributed to the key
-(`svc:<hash8>`) as well as to the person. Per-user OAuth stays the story for
-anyone else's agent; a service key is for code you deploy, and it can name any
-user, so it is exactly as powerful as your backend already is.
+```
+https://your-app.example.com/api/vendo/mcp
+```
 
-One question picks your path: is your door fronted by the hosted broker —
-`VENDO_MCP_BROKER_URL` set — or serving its own OAuth surface?
+The OAuth is nobody's code. The client registers itself, runs PKCE, and sends
+the person to **your** login and the door's own consent page.
 
-| | The key | The exchange |
-| --- | --- | --- |
-| **Self-hosted** | you mint it and list it, as below | your MCP URL plus `/token` |
-| **Vendo Cloud** | **Create service key** on the project's keys page in the console, under **Service keys**. The console pushes it to the broker and shows you the full key once | `https://<your tenant>.mcp.vendo.run/token` |
+For your users, the door already serves a themed page at
+`https://your-app.example.com/api/vendo/mcp/connect` — your product's name, the
+URL to paste, and per-client steps. Link to it from your settings:
+[The connect page](/capabilities/mcp#the-connect-page).
 
-The broker forwards to a public HTTPS address and refuses a private one, so it
-can never reach `localhost` — trying this on a laptop is the self-hosted path,
-whatever your account is.
+### Service key — your backend acts as one of your users
 
-On Cloud the first two steps below are the console's, and there is no
-`serviceAuth` to configure: a door that trusts the broker serves no token
-endpoint of its own, so setting it there warns and does nothing. Step 3 posts
-the same form to your tenant's URL — what the console's MCP page shows as your
-`VENDO_MCP_BROKER_URL`, with `/token` in place of `/mcp`. Everything after that
-is identical on both paths: the same answer, ten minutes, no refresh token, the
-same `svc:<hash8>` attribution, and the same guard, approvals and audit.
-Revoking the key in the console refuses the next exchange.
+A nightly job or queue worker has no browser to bounce. Your backend exchanges
+a service key plus one of **your** user ids for a short-lived token bound to
+that user; nothing downstream changes.
 
-<Steps>
-  <Step title="Mint a key">
-    A key is any opaque non-empty string — the door never parses one — so a
-    shell one-liner is the whole ceremony:
+Mint a key — any opaque string; the door never parses one:
 
-    ```bash
-    echo "VENDO_SERVICE_KEY=$(openssl rand -hex 32)" >> .env
-    ```
+```bash
+echo "VENDO_SERVICE_KEY=$(openssl rand -hex 32)" >> .env
+```
 
-    Vendo neither generates nor stores it. That file is the only copy.
-  </Step>
+List it on the door:
 
-  <Step title="List it on the door">
-    ```ts
-    export const vendo = createVendo({
-      model,
-      principal: resolvePrincipal,
-      oauth,
-      mcp: { serviceAuth: { keys: [process.env.VENDO_SERVICE_KEY!] } },
-    });
-    ```
+```ts
+export const vendo = createVendo({
+  auth: authJs(),
+  mcp: { serviceAuth: { keys: [process.env.VENDO_SERVICE_KEY!] } },
+});
+```
 
-    The door never writes a key down — it compares digests and nothing lands in
-    your store. Rotate by listing both keys until the old one is out of use,
-    then drop the old one. Dropping the last key closes the exchange rather
-    than tightening it: remove `serviceAuth` itself — an empty `keys` is a
-    composition error — and the door stops serving the grant at all.
-  </Step>
+On Vendo Cloud, create the key on the project's keys page in the console under
+**Service keys** instead — there is no `serviceAuth` to configure, and the
+exchange below posts to `https://<your tenant>.mcp.vendo.run/token`.
 
-  <Step title="Exchange it for one user's token">
-    One RFC 8693 form post, at your MCP URL plus `/token` — from any language:
+Then one RFC 8693 form post, from any language:
 
-    ```bash
-    curl -s https://your-app.example.com/api/vendo/mcp/token \
-      -d grant_type=urn:ietf:params:oauth:grant-type:token-exchange \
-      -d client_id=vendo-service \
-      -d client_secret=$VENDO_SERVICE_KEY \
-      -d subject_token=user_1904 \
-      -d subject_token_type=urn:vendo:params:oauth:token-type:user-id
-    ```
+<CodeGroup>
 
-    `subject_token` is one of **your** user ids, in your own spelling. The answer
-    is an ordinary OAuth token response:
+```bash curl
+curl -s https://your-app.example.com/api/vendo/mcp/token \
+  -d grant_type=urn:ietf:params:oauth:grant-type:token-exchange \
+  -d client_id=vendo-service \
+  -d client_secret="$VENDO_SERVICE_KEY" \
+  -d subject_token=user_1904 \
+  -d subject_token_type=urn:vendo:params:oauth:token-type:user-id
+```
 
-    ```json
-    { "access_token": "vmat_…", "token_type": "Bearer", "expires_in": 600, "scope": "read write" }
-    ```
+```python Python
+import os
+import httpx
 
-    The broker answers field for field the same on Cloud — only `access_token`
-    differs, a signed JWT there rather than an opaque string, and you hand it
-    over exactly the same way.
+response = httpx.post(
+    "https://your-app.example.com/api/vendo/mcp/token",
+    data={
+        "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+        "client_id": "vendo-service",
+        "client_secret": os.environ["VENDO_SERVICE_KEY"],
+        "subject_token": "user_1904",
+        "subject_token_type": "urn:vendo:params:oauth:token-type:user-id",
+    },
+)
+access_token = response.json()["access_token"]
+```
 
-    Ten minutes and no refresh token — mint one per job and let it expire. While
-    the door lists a key, an unknown key, a retired one and a wrong `client_id`
-    all answer the same `invalid_client`: nothing tells a guesser which half they
-    have right. A door that lists no key is not refusing the exchange, it is not
-    offering one — every attempt, a valid key included, answers
-    `unsupported_grant_type`.
-  </Step>
+```ts TypeScript
+const response = await fetch("https://your-app.example.com/api/vendo/mcp/token", {
+  method: "POST",
+  body: new URLSearchParams({
+    grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+    client_id: "vendo-service",
+    client_secret: process.env.VENDO_SERVICE_KEY!,
+    subject_token: "user_1904",
+    subject_token_type: "urn:vendo:params:oauth:token-type:user-id",
+  }),
+});
+const { access_token: accessToken } = await response.json();
+```
 
-  <Step title="Talk MCP with it">
-    ```ts
-    { authorization: `Bearer ${accessToken}` }
-    ```
+</CodeGroup>
 
-    Hand that header to any MCP client and the session is an ordinary one: the
-    same `tools/list`, the same `vendo_make`, the same policy on every call.
+`subject_token` is one of **your** user ids, in your own spelling. The answer
+is an ordinary OAuth token response:
 
-    The exchange never checks the user id — your product stays the authority on
-    who its users are — so a user id nothing recognizes still mints a
-    valid-looking token. It dies on the first MCP request with
-    `401 invalid_token`, which is exactly what an expired token answers: check
-    the id against your own records before you go looking at the key.
-  </Step>
-</Steps>
+```json
+{
+  "access_token": "vmat_…",
+  "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+  "token_type": "Bearer",
+  "expires_in": 600,
+  "scope": "read write"
+}
+```
 
-<Note>
-  Pointed at an authorization server of your own with `mcp.remoteAs`? Same
-  shape as the broker: the door serves no token endpoint, so the exchange lives
-  at that server instead — post to the issuer's own `token_endpoint`.
+Send it as `authorization: Bearer <access_token>`; the MCP session is an
+ordinary one. Ten minutes, no refresh token — mint one per job. The exchange
+never checks the user id, so an id your product does not recognize mints a
+valid-looking token that dies on the first MCP request with
+`401 invalid_token`: check the id against your own records before you suspect
+the key.
 
-  A declared `VENDO_MCP_BROKER_URL` does not do that to you. It is a default,
-  and `serviceAuth` is something you asked for: configuring it keeps the door's
-  own `/token` and the exchange above, broker variable or not.
-</Note>
+## See it work
 
-## What the agent gets
-
-| Tool | What it does |
-| --- | --- |
-| `vendo_<your action>` | one per host action on the door's menu, guard-wrapped per call |
-| `vendo_make` | makes the person a screen from a plain-language request |
-| `vendo_apps_list` · `vendo_apps_open` · `vendo_apps_call` | the saved-apps viewer: list them, render one through the MCP Apps shim, and route its interactions back through the guard |
-| `vendo_apps_pin` · `vendo_apps_unpin` | put a saved app into one of your product's slots, or clear it |
-
-Your host tools are curated with `surfaces.mcp` in `.vendo/overrides.json`; the
-`vendo_*` tools are never curated away. See
-[Curate the tool menu](/capabilities/mcp).
-
-### `vendo_make`
-
-| Argument | |
-| --- | --- |
-| `request` (required) | prose — what the person wants, in the agent's own words. No component names, no layout, and no figures the agent computed: the screen binds live host data itself and hardcoded numbers fail its checks |
-| `context` | background the product cannot see from its side: what the person said earlier in that conversation, a constraint they mentioned |
-| `app` | change one specific existing app, by id or by the name the person used. Left out, Vendo decides whether to continue the last one or start something new |
-| `slot` | the id of a slot in your product. The screen lands there instead of in the person's apps list |
-
-### The receipt law
-
-`vendo_make` answers with four fields of words, never UI:
+Ask the connected agent for a screen. It calls `vendo_make` with prose, and
+gets back four fields of words — never UI:
 
 ```json
 {
@@ -279,221 +243,22 @@ Your host tools are curated with `surfaces.mcp` in `.vendo/overrides.json`; the
 }
 ```
 
-`say` is one line in the person's voice, written to be said close to verbatim.
-`status` is `"ready"`, `"building"`, or `"failed"`, and `"building"` is an
-honest answer rather than an error — an escalated build outlives the call, and
-there is nothing to poll. The agent never receives the tree, the components, a
-payload, or a URL, which is exactly what stops it narrating a screen it cannot
-see. **Pixels go server → your page; words go to the agent.**
-
-## Where the screen lands
-
-By default, the person's own apps list in your product. Pass `slot` and it
-lands in that spot on your page instead — the same `<VendoSlot>` your
-in-product surfaces fill:
-
-```tsx
-// app/page.tsx — a slot an outside agent can target by id
-import { VendoSlot } from "@vendoai/ui/chrome";
-
-<VendoSlot id="home-hero">
-  <YourOriginalCard />
-</VendoSlot>
-```
-
-Add `@vendoai/ui` as a direct dependency. Empty, the slot renders your own
-children; targeted, it shows a build skeleton, then the live screen or the
-failure with a retry — no blank hole in any state. One app per slot per person:
-placing a second one evicts the first.
-
-Slot ids are yours, and nothing enumerates them for an outside agent: tell the
-agent the id, or let the person say it. The plugin skill is taught never to
-invent one — an invented id puts the screen where nobody is looking, and that
-does not look like an error.
-
-`vendo_apps_pin` and `vendo_apps_unpin` move an app the person already has in
-and out of a slot. Both are writes, judged like any other write: under a
-`cautious` policy the first one parks in your approvals queue. The routes
-behind all three are in [HTTP routes](/reference/http-routes).
-
-<Note>
-  Running your own agent in your own backend as well? Its tool outputs render
-  inline in that chat with `<VendoToolResult>` — see
-  [Embeds and envelopes](/existing-agents/embeds). Over MCP the slot is the
-  destination, and the outside agent's own chat stays text.
-</Note>
-
-## Walk through it
-
-What the whole thing looks like end to end, run against the
-[`demo-bank`](https://github.com/runvendo/vendo/tree/main/examples/demo-bank)
-host (Maple) with an outside MCP client. Every screenshot below is that run.
-
-<Steps>
-  <Step title="Sign the agent in">
-    Point the client at the door and let it do the OAuth itself — discovery,
-    dynamic client registration, PKCE, your login, the door's consent page:
-
-    ```bash
-    export ANTHROPIC_API_KEY=sk-ant-…
-    pnpm --filter demo-bank mcp:agent https://your-app.example.com \
-      "make me something to watch my spending on"
-    ```
-
-    The client's `tools/list` then carries your host actions and the `vendo_*`
-    tools together. Nothing about the connection is your code.
-  </Step>
-
-  <Step title="Show the agent where a view can land">
-    A slot is your markup, and nothing enumerates slots for an outside agent —
-    so the agent has to be told the id, or the person has to say it. Empty, the
-    slot is whatever you put in it:
-
-    <Frame caption="The host's own hero slot before anything is placed — Maple's markup, not Vendo's.">
-      <img src="/images/existing-agents/mcp-walk-slot-empty.png" alt="Maple dashboard with an empty Vendo hero slot inviting the person to describe a view" />
-    </Frame>
-  </Step>
-
-  <Step title="Ask for a view with a destination">
-    The person says where it goes, the agent passes that slot id:
-
-    ```json
-    {
-      "request": "A breakdown of this month's spending by category, largest first",
-      "slot": "home-hero"
-    }
-    ```
-
-    The agent gets back four fields of words. The screen goes to the page, bound
-    to live host data it read itself — nothing in the request was a number the
-    agent computed:
-
-    <Frame caption="The same slot, filled. The figures come from the host's own spending endpoint, read at render time.">
-      <img src="/images/existing-agents/mcp-walk-slot-filled.png" alt="The Maple hero slot now showing a generated spending breakdown with a donut chart and a category table of live amounts" />
-    </Frame>
-  </Step>
-
-  <Step title="Or ask with no destination, and place it after">
-    Leave `slot` out and the screen goes to the person's apps list. To move it
-    onto the page later, the agent calls `vendo_apps_pin` with the app — by id,
-    or by the name the person used.
-
-    That is a write, so under a `cautious` policy it parks. The person sees the
-    tool, the app, the slot, and the exact arguments before anything moves:
-
-    <Frame caption="The parked pin in Maple's approvals queue. The agent is told an approval is pending; nothing has changed yet.">
-      <img src="/images/existing-agents/mcp-walk-approval.png" alt="Approval card reading Needs your approval, Pin the app to your page, showing the app name, the slot, and the vendo_apps_pin arguments with Deny and Approve buttons" />
-    </Frame>
-
-    Approve it and the agent's retry goes through. The reply names whatever was
-    evicted, so the agent can say what moved:
-
-    ```json
-    { "app": "app_5a3948bc…", "slot": "home-hero", "evicted": "app_c0d6b562…" }
-    ```
-
-    <Frame caption="The pinned app in the hero slot, replacing what held it.">
-      <img src="/images/existing-agents/mcp-walk-pinned.png" alt="The Maple hero slot showing a pinned savings goals table with each goal and its target amount" />
-    </Frame>
-
-    <Warning>
-      Approving does not resume the parked call — the agent has to call again,
-      **on the same MCP session**. The door reuses the parked call's id for an
-      identical retry within that session, and the approval is pinned to that
-      id; a client that reconnects between attempts mints a new id and parks
-      again. Real clients hold one session for the conversation, so this is
-      only a trap for scripts that connect per call.
-    </Warning>
-  </Step>
-
-  <Step title="Take it back out">
-    `vendo_apps_unpin` clears the slot. The app itself is untouched — it stays
-    in the person's apps and can go back any time — and the slot returns to
-    your own children:
-
-    <Frame caption="After unpinning. This is the same screenshot as step 2, because the page really is identical again.">
-      <img src="/images/existing-agents/mcp-walk-slot-empty.png" alt="The Maple dashboard back to its own hero slot invitation after the pinned app was removed" />
-    </Frame>
-
-    Pass the app id rather than the name if the person has two apps with the
-    same title: the tool refuses the guess and hands the agent both candidates
-    to ask about.
-  </Step>
-
-  <Step title="Check it is per person">
-    A placement belongs to the person who made it. Signed in as a different
-    Maple user, the same slot on the same page is untouched:
-
-    <Frame caption="A second user's dashboard. The first user's pinned app is not there, and their apps list is their own.">
-      <img src="/images/existing-agents/mcp-walk-other-user.png" alt="The Maple dashboard for a second signed-in user, showing the empty hero slot invitation rather than the first user's pinned app" />
-    </Frame>
-  </Step>
-</Steps>
-
-### Two things that are not bugs
-
-**A build can come back `failed`, with a reason.** The checks floor rejects a
-screen whose bindings claim data your host does not return, or whose props do
-not type-check — nothing is painted and whatever held the slot stays. The agent
-gets that sentence and should retry once on the same `app` with a narrower
-request rather than rebuilding from scratch.
-
-**Placing is a write, and writes park.** Reading is not: on Maple's policy the
-agent's `host_*` reads answer straight away, while every `vendo_apps_pin` and
-`vendo_apps_unpin` waits for the person. Your policy decides where that line
-sits — the door adds no exemption to it either way.
-
-<Warning>
-  Mounted under a path prefix? `VENDO_BASE_URL` must be the full public base
-  including that prefix (`https://site.com/app`), or the door advertises OAuth
-  endpoints that 404. Two known bugs bite in that configuration today —
-  [#866](https://github.com/runvendo/vendo/issues/866) (the login redirect and
-  the consent form drop the prefix) and
-  [#867](https://github.com/runvendo/vendo/issues/867) — so verify the sign-in
-  bounce end to end before pointing a real client at a prefixed deployment. A
-  deployment served at an origin root is unaffected.
-</Warning>
-
-## The perimeter does not move
-
-- Every door call runs the guard-bound registry — policy, approvals, audit —
-  under the OAuth'd subject. The door adds no second authority path.
-- A parked call waits in **your** approvals queue. The agent is told an
-  approval is pending and moves on; the person approves in your UI, and the
-  agent learns the outcome on a later turn if it matters.
-- Door calls reach host routes through the `actAs` seam, never by forwarding
-  the MCP bearer. Without a grant or a consent record, the call fails closed.
-- Returning `null` from `oauth.principal(subject)` kills every live session for
-  that person on the next request.
-
-## Verify
-
-```bash
-npx vendo doctor
-```
-
-With the door open, doctor checks both OAuth metadata documents resolve and the
-server card parses; `GET /status` reports `blocks.mcp`. For an end-to-end proof
-with no Vendo code in the agent's process:
-
-```bash
-export ANTHROPIC_API_KEY=sk-ant-…
-pnpm --filter demo-bank mcp:agent http://localhost:3000 \
-  "make me something I can watch this month's spending on"
-```
-
-It prints the receipt, narrates `say`, and asserts the receipt law itself: if a
-tree, components, a machine, or a snapshot ref ever appear in a receipt, it
-exits non-zero and says which one.
+The screen itself lands in the person's apps list in your product, or in a
+`<VendoSlot>` on your own page when the agent passes a `slot` id. Mounting one:
+[Put it where you want it](/existing-agents/your-agent).
 
 ## Next
 
 <CardGroup cols={2}>
-  <Card title="MCP door internals" href="/capabilities/mcp">
-    The adapter contract, the consent page, menus, `remoteAs`, federation, and
+  <Card title="MCP door reference" icon="book" href="/capabilities/mcp">
+    Every tool on the door, the adapter contract, the consent page, menus, and
     revocation.
   </Card>
-  <Card title="Publish to the MCP registry" href="/capabilities/mcp-registry">
-    Make the deployed door discoverable through the official registry.
+  <Card title="Guard, policy, approvals" icon="shield-check" href="/concepts/tools-and-safety">
+    How a door call is graded, and where a write parks for the person.
+  </Card>
+  <Card title="Go to production" icon="rocket" href="/deploy/deploying">
+    Your own Postgres, sandbox, and model key, plus what every deployment must
+    set.
   </Card>
 </CardGroup>

--- a/docs-site/existing-agents/mcp.mdx
+++ b/docs-site/existing-agents/mcp.mdx
@@ -26,6 +26,7 @@ https://your-app.example.com/api/vendo/mcp
 ## Set up the door (once)
 
 <AgentPrompt
+  title="Set up with your coding agent"
   lead={<>Paste this prompt and it wires the door against the <a href="/agents">agent playbook</a>.</>}
   prompt={"Set up Vendo's MCP door in this repo. Read https://vendo.run/agents.md and follow it exactly. Ask me before creating any account or key. You're done when `vendo doctor --json` reports all green."}
 />

--- a/docs-site/existing-agents/mcp.mdx
+++ b/docs-site/existing-agents/mcp.mdx
@@ -78,7 +78,9 @@ export const vendo = createVendo({
 Move the composition `vendo init` wrote into `lib/vendo.ts` and re-export
 `nextVendoHandler(vendo)` from your catch-all route — that route already serves
 the door's transport and OAuth endpoints. Your own `oauth` adapter instead of a
-preset works too; see [Enable the door](/capabilities/mcp#enable-the-door).
+preset works too; see [Enable the door](/capabilities/mcp#enable-the-door). No
+login in your product yet? That adapter is the path, with a fixed subject — the
+shape is in the playbook's [door section](/agents#mcp-door).
 
 Second, the discovery route. It lives at the origin root, outside
 `/api/vendo`, so the catch-all never sees it:
@@ -159,9 +161,10 @@ export const vendo = createVendo({
 });
 ```
 
-On Vendo Cloud, create the key on the project's keys page in the console under
-**Service keys** instead — there is no `serviceAuth` to configure, and the
-exchange below posts to `https://<your tenant>.mcp.vendo.run/token`.
+Fronting the door with a hosted broker — `VENDO_MCP_BROKER_URL` set, which a
+Cloud key alone does not do — moves the exchange there instead: drop
+`serviceAuth`, create the key on the project's keys page in the console under
+**Service keys**, and post to `https://<your tenant>.mcp.vendo.run/token`.
 
 Then one RFC 8693 form post, from any language:
 

--- a/docs-site/snippets/agent-prompt.jsx
+++ b/docs-site/snippets/agent-prompt.jsx
@@ -5,7 +5,7 @@
     Mintlify snippet rules honored: no npm imports (React hooks are
     pre-injected), named exports only, browser built-ins only. */}
 
-export const AgentPrompt = ({ prompt, lead }) => {
+export const AgentPrompt = ({ prompt, lead, title = "Or install with your coding agent" }) => {
   const AGENT_LOGOS = [
   {
     name: "Claude Code",
@@ -73,9 +73,7 @@ export const AgentPrompt = ({ prompt, lead }) => {
     <div className="vendo-agent-prompt not-prose">
       <div className="vendo-agent-prompt-head">
         <div className="vendo-agent-prompt-text">
-          <span className="vendo-agent-prompt-title">
-            Or install with your coding agent
-          </span>
+          <span className="vendo-agent-prompt-title">{title}</span>
           <span className="vendo-agent-prompt-lead">{lead}</span>
         </div>
         <div className="vendo-agent-prompt-logos">


### PR DESCRIPTION
## The problem

`/existing-agents/mcp` was a setup page in name only. Someone arriving to *open
the door* had to read past option tables, the `HostOAuthAdapter` contract, wire
formats, and federation claims before reaching anything they could act on. The
reference material and the setup path were interleaved in one page, so neither
job was served: no one could set the door up quickly, and no one could look a
field up quickly either.

## The approved shape

**Setup page (`/existing-agents/mcp`) — five sections, prompt-first.**

1. **What you get** — the one URL, and the experimental status note.
2. **Set up the door (once)** — the `AgentPrompt` card leads. The prompt itself
   is one line that points the agent at `vendo.run/agents.md`, so the actual
   procedure stays centralized in the playbook instead of being duplicated
   here. A short **By hand** block follows for people who want the three things
   themselves (`mcp: true` + auth preset, the `.well-known` route,
   `VENDO_BASE_URL`).
3. **Connect — pick your client** — Claude Code, any MCP client, service key.
4. **See it work** — what `vendo_make` returns and where the screen lands.
5. **Next** — three cards out to reference, guard, and production.

**Playbook (`/agents`) — the procedure lives here.** A new `## MCP door`
section carries the five ordered steps, additive to the install flow, plus a
pointer at the top of the page for agents told to open the MCP door.
`/agents/verify` now links back to it so a doctor failure leads to the wiring.

**Reference (`/capabilities/mcp`) — pure reference.** Setup prose removed; it
links out to the setup page and stays a lookup surface.

## Source-verified corrections made along the way

These are behavior fixes, not just reorganization — each read off the source,
not the old prose:

- **All five auth presets carry the OAuth adapter.** `authJs`, `clerk`,
  `supabase`, `auth0`, and `jwt({ secret })` each fill the door's `oauth` seam
  along with `principal` and `actAs`. A separately passed `oauth` is *ignored*
  whenever `auth` is set — the preset owns the seam.
- **`--auth none` cannot open the door.** It writes a demo `principal` and no
  oauth seam, and `createVendo` throws at composition when `mcp: true` has no
  `HostOAuthAdapter`. The old text implied any auth choice would do.
- **The `serviceAuth` no-op nuance was wrong, and now distinguishes explicit
  from declared.** `mcp.serviceAuth` passed alongside an *explicit*
  `mcp.remoteAs` warns at composition and does nothing (that door serves no
  `/token` of its own). But a *declared* `VENDO_MCP_BROKER_URL` is a default —
  it leaves an explicit `serviceAuth` alone rather than overriding it. Those two
  cases were previously collapsed into one blanket claim.
- **Broker mode details confirmed against `vendo-web` `origin/main`.** Broker
  mode is declared, never discovered (origin becomes issuer, URL becomes
  expected audience, door stops serving `/authorize`, `/token`, `/register`).
  The broker forwards only to a public HTTPS address, so it can never reach
  `localhost`. Its exchange answers field for field like the door's, except
  `access_token` is a signed JWT rather than an opaque string.

## Screenshots

Local Mintlify dev server, real browser.

**Setup page, top to bottom** — the five sections in order:

![Setup page top to bottom](https://raw.githubusercontent.com/runvendo/vendo/assets/mcp-setup-page/02-setup-page-top-to-bottom.png)

**Setup page, top of viewport:**

![Setup page top](https://raw.githubusercontent.com/runvendo/vendo/assets/mcp-setup-page/01-setup-page-full.png)

**The `AgentPrompt` card up close** — it now leads the setup section:

![AgentPrompt card](https://raw.githubusercontent.com/runvendo/vendo/assets/mcp-setup-page/03-agentprompt-card.png)

**Reference page (`/capabilities/mcp`), top** — pure reference, links out to setup:

![Reference page top](https://raw.githubusercontent.com/runvendo/vendo/assets/mcp-setup-page/04-reference-page-top.png)

**Playbook MCP-door section (`/agents#mcp-door`)** — the five ordered steps:

![Playbook MCP door section](https://raw.githubusercontent.com/runvendo/vendo/assets/mcp-setup-page/05-playbook-mcp-door-section.png)

## Orphaned images

Dropping the old step-by-step walkthrough leaves 4 images unreferenced under
`docs-site/images/existing-agents/`:

- `mcp-walk-approval.png`
- `mcp-walk-other-user.png`
- `mcp-walk-pinned.png`
- `mcp-walk-slot-empty.png`

They are **left in place deliberately** — not deleted in this PR. (The fifth,
`mcp-walk-slot-filled.png`, is still used by `/existing-agents/your-agent`.)

## Sequencing

S3 has merged (#1142, plus the five-question init in #1146), this branch is
rebased over it, and the PR is ready. Both surfaces now route through
`vendo init --use-case mcp`, and the by-hand seams are demoted to the no-init
path (Express, `--auth none`, `--auth jwt`) — the stale "init does not write
it" claims are gone. One nuance: that flag documents `main`, not the current
release — npm `latest` is 0.10.0 and ships neither `--use-case` nor `planMcp`,
so the pages are accurate the day the next release cuts, exactly as
`quickstart.mdx` already documents `--use-case` on main today.

## Gates

`pnpm build`, `pnpm test:affected`, `pnpm typecheck`, `pnpm lint` all green, plus
`packages/vendo` `tests/cli/doctor-codes.docs.test.ts` (the test that reads the
playbook) green. `mint broken-links` from `docs-site/`: no broken links.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reorganized MCP docs to make setup fast and clear: the setup page now leads with an agent prompt and concise steps, while reference and playbook content are split for lookup. Also updated the agent playbook install steps to install both `vendoai` and `@vendoai/vendo`, preventing module resolution errors and noisy doctor failures.

- **Refactors**
  - Split docs into three surfaces: setup (`/existing-agents/mcp`, prompt‑first), playbook (`/agents#mcp-door` procedure), and reference (`/capabilities/mcp`, pure lookup).
  - Setup now shows the minimal wiring: `mcp: true` plus an auth preset (or, for a login‑less repo, `principal` + `oauth.session/principal` with a fixed subject and no `actAs`), origin‑root discovery via `wellKnownVendoHandler`, and `VENDO_BASE_URL` requirements. Connect guidance covers Claude Code, any MCP client, and the service‑key path; linked the themed connect page (`{mount}/connect`).
  - Playbook adds the ordered MCP steps, including the login‑less path (leave `actAs` out to avoid doctor failures) and a tighter verify gate; `verify` links back to it. Host auth notes that a principal‑only stub needs an `oauth` seam beside it, not a preset.
  - Install flow: install BOTH `vendoai` and `@vendoai/vendo` (init imports subpaths under `@vendoai/vendo`; the alias alone 500s with “Module not found”). Keep the version check, and note that `vendo init` auto‑uses a `VENDO_API_KEY` already in `.env.local` with no login or key minting.
  - AgentPrompt now accepts a `title`; the setup page leads with a custom title (“Set up with your coding agent”), dropping the “Or install” phrasing.

- **Bug Fixes**
  - Clarified auth behavior: all presets carry the OAuth adapter; mixing an `auth` preset with `oauth`/per‑seam config is ignored or throws at composition. `--auth none` cannot open the door.
  - Documented broker mode as declared, not discovered: set `VENDO_MCP_BROKER_URL` (origin becomes issuer, URL becomes audience); explicit `mcp.remoteAs` wins; `mcp.serviceAuth` is local‑only and ignored when `remoteAs` is explicit. Broker forwards only to public HTTPS; its exchange mirrors the door’s except `access_token` is a JWT.
  - Expanded `VENDO_BASE_URL` duties behind proxies and under path prefixes; noted known prefix issues (#866, #867). Added note that approving a parked call does not resume it — the client must retry on the same MCP session.

<sup>Written for commit 548dcbf2e727ea6b2aade79b59efb48107a47324. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


