### PR TITLE
test(vendo): re-pin the two docs-nav tests to the reorganized sidebar

### DIFF
--- a/packages/vendo/tests/mcp-byo-docs.docs.test.ts
+++ b/packages/vendo/tests/mcp-byo-docs.docs.test.ts
@@ -22,6 +22,8 @@ const readJson = async <T>(path: string): Promise<T> => JSON.parse(await read(pa
 
 const PAGE = "docs-site/existing-agents/mcp.mdx";
 const NAV_ENTRY = "existing-agents/mcp";
+/** The third door's group — the three MCP pages sit together here (#1133). */
+const NAV_GROUP = "Expose your product over MCP";
 
 interface DocsJson {
   navigation: { groups: { group: string; pages: string[] }[] };
@@ -42,10 +44,10 @@ describe("the BYO-over-MCP page is published", () => {
     expect(text).toMatch(/^description: "/m);
   });
 
-  it("sits in the Bring-your-own-agent nav group", async () => {
+  it("sits in the MCP door's nav group", async () => {
     const docs = await readJson<DocsJson>("docs-site/docs.json");
-    const group = docs.navigation.groups.find((entry) => entry.group === "Bring your own agent");
-    expect(group, "the 'Bring your own agent' group must exist").toBeDefined();
+    const group = docs.navigation.groups.find((entry) => entry.group === NAV_GROUP);
+    expect(group, `the '${NAV_GROUP}' group must exist`).toBeDefined();
     expect(group?.pages).toContain(NAV_ENTRY);
   });
 

--- a/packages/vendo/tests/your-agent-docs.docs.test.ts
+++ b/packages/vendo/tests/your-agent-docs.docs.test.ts
@@ -10,7 +10,7 @@ import { describe, expect, it } from "vitest";
  *
  * What it holds, and why each claim is load-bearing:
  *  1. the page is published and every nav entry still resolves, with this page
- *     FIRST in its group (it is the on-ramp);
+ *     opening its group behind the door's overview (it is the on-ramp);
  *  2. every tool name the page puts in a reader's system prompt really exists
  *     in the registry the page is describing;
  *  3. `vendo_make`'s four documented arguments are its real schema properties on
@@ -31,6 +31,9 @@ const readJson = async <T>(path: string): Promise<T> => JSON.parse(await read(pa
 
 const PAGE = "docs-site/existing-agents/your-agent.mdx";
 const NAV_ENTRY = "existing-agents/your-agent";
+/** The first door's group, and the overview that opens it (#1133). */
+const NAV_GROUP = "You already have an agent";
+const NAV_OVERVIEW = "existing-agents/index";
 const AGENT_TOOLS = "packages/apps/src/server/doors/agent-tools.ts";
 const PACK = "packages/vendo/src/pack.ts";
 
@@ -53,11 +56,11 @@ describe("the BYO on-ramp page is published", () => {
     expect(text).toMatch(/^description: "/m);
   });
 
-  it("is the FIRST entry in the Bring-your-own-agent group", async () => {
+  it("opens the door's group, right behind its overview", async () => {
     const docs = await readJson<DocsJson>("docs-site/docs.json");
-    const group = docs.navigation.groups.find((entry) => entry.group === "Bring your own agent");
-    expect(group, "the 'Bring your own agent' group must exist").toBeDefined();
-    expect(group?.pages[0]).toBe(NAV_ENTRY);
+    const group = docs.navigation.groups.find((entry) => entry.group === NAV_GROUP);
+    expect(group, `the '${NAV_GROUP}' group must exist`).toBeDefined();
+    expect(group?.pages.slice(0, 2)).toEqual([NAV_OVERVIEW, NAV_ENTRY]);
   });
 
   it("leaves no nav entry pointing at a file that does not exist", async () => {


### PR DESCRIPTION
## What

Main is red at `fb867d903` and every PR forked from it inherits the failure. Two shards, one cause:

```
test-shards (vendo-3)  tests/mcp-byo-docs.docs.test.ts
test-shards (vendo-4)  tests/your-agent-docs.docs.test.ts
AssertionError: the 'Bring your own agent' group must exist
```

`coverage-merge` and the `ci` aggregate fail as a cascade of those two. This unblocks #1137.

## Intentional, not accidental

The docs-site reorg (#1133, commit `9a9cd3ab2`) renamed the nav groups on purpose — its own body carries the rename table, and its commit message says *"Sidebar groups were product nouns … They now name where the reader stands."* Relevant to these two tests:

| Was | Now |
| --- | --- |
| `Bring your own agent` | `You already have an agent` *(Recommended)* |
| — | `Expose your product over MCP` *(new, Experimental)* |

Both pages are still published and still in the nav — nothing was dropped:

- `existing-agents/mcp` moved out of door one into the new MCP group, deliberately: *"the three MCP pages … are now gathered into one group that matches door three."*
- `existing-agents/your-agent` is still at the top of door one, now behind `existing-agents/index`, which is the page the landing card and the README both link to (`href="/existing-agents"`).

So the tests are stale mirrors, and `docs-site/docs.json` is correct as-is.

## The change

Test-only, both files under `packages/vendo/tests/`. The group names move into named constants at the top of each file next to the existing `PAGE` / `NAV_ENTRY` constants, and point at the current groups.

The one judgement call is the on-ramp's ordering claim. The old assertion was `pages[0] === "existing-agents/your-agent"`, and its docblock explains why: *"with this page FIRST in its group (it is the on-ramp)."* That is now literally false — the door's overview opens the group. Dropping to a bare `toContain` would delete the ordering promise, so it becomes the true version instead:

```ts
expect(group?.pages.slice(0, 2)).toEqual([NAV_OVERVIEW, NAV_ENTRY]);
```

The on-ramp still has to be at the top of its door, right behind the overview. Same strength, current truth. Every other assertion in both files is untouched, including the two `leaves no nav entry pointing at a file that does not exist` sweeps that would have caught a genuinely dropped page.

**No changeset** — nothing shipped changes. No package source and no docs content touched; the diff is two test files.

## Verification

```
$ cd packages/vendo && VITEST_MIN_FORKS=1 VITEST_MAX_FORKS=2 VITEST_MIN_THREADS=1 VITEST_MAX_THREADS=2 \
    npx vitest run tests/mcp-byo-docs.docs.test.ts tests/your-agent-docs.docs.test.ts

 RUN  v3.2.7 /home/ubuntu/worktrees/mainfix/packages/vendo

 ✓ tests/mcp-byo-docs.docs.test.ts (29 tests) 55ms
 ✓ tests/your-agent-docs.docs.test.ts (26 tests) 55ms

 Test Files  2 passed (2)
      Tests  55 passed (55)
```

Root `pnpm typecheck` — `42 successful, 42 total`. Root `pnpm lint` — `4 successful, 4 total`. Not UI-affecting; no rendered output changes.

## Pattern worth noting, not fixed here

This is the third time a hand-typed list mirroring a structure that lives elsewhere has survived a rename and gone stale. These two tests retype nav group names that `docs-site/docs.json` already owns. The cheap version would be for the group lookup to key off the page id — find the group that *contains* `existing-agents/your-agent` and assert its shape — so a rename can never break the test but a page falling out of the nav still does. Deliberately **not** built here; main is red and #1137 is queued behind this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two failing docs-nav tests in `vendo` by aligning them with the reorganized sidebar. Updates group names and ordering checks to match the current `docs-site/docs.json`, unblocking CI.

- **Bug Fixes**
  - Point tests to the new groups: "You already have an agent" and "Expose your product over MCP" in `docs-site/docs.json`.
  - Update the on-ramp ordering to expect `[existing-agents/index, existing-agents/your-agent]`.
  - Test-only changes in `packages/vendo/tests/mcp-byo-docs.docs.test.ts` and `packages/vendo/tests/your-agent-docs.docs.test.ts`; no product or docs content changes.

<sup>Written for commit ba3247e0f869af5679f92f974e27bd924723736c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

