### PR TITLE
feat(cli): init scaffolds the MCP door — planMcp, the origin-root discovery route, E-MCP-009

### DIFF
--- a/docs-site/agents/verify.mdx
+++ b/docs-site/agents/verify.mdx
@@ -584,6 +584,21 @@ does not start with `v=MCPv1`, usually a stale or hand-edited deployed copy.
 [E-MCP-007](#E-MCP-007)); DNS verification is an alternative to serving it
 over HTTP.
 
+### E-MCP-009 {#E-MCP-009}
+
+**Symptom:** The MCP door is wired but `VENDO_BASE_URL` is not set.
+
+**Cause:** The composition passes `mcp` to `createVendo`, and neither
+`VENDO_BASE_URL` nor `mcp: { baseUrl }` names the deployment's public origin.
+The door's discovery documents, its issuer, its resource identifiers and its
+RFC 8707 audience binding all derive from that one value, so the door
+advertises whatever origin the request happened to carry. Nothing looks wrong
+locally; it surfaces later, in someone else's terminal, as "Claude can't find
+my server".
+
+**Fix:** Set `VENDO_BASE_URL` to the deployment's full public URL — path prefix
+included — where you deploy, or pass `mcp: { baseUrl }` in the composition.
+
 ## Machine schedules
 
 ### E-SCHED-001 {#E-SCHED-001}

--- a/docs-site/existing-agents/mcp.mdx
+++ b/docs-site/existing-agents/mcp.mdx
@@ -27,11 +27,24 @@ calls what it finds — your host actions, and Vendo's own `vendo_make`.
 
 ## 1. Open the door
 
-Three things, all host decisions, none of them scaffolded by `vendo init`:
-`mcp: true`, an OAuth adapter, and the origin-root discovery route.
+Pick **outside agents over MCP** in `npx vendo init` and this is scaffolded for
+you: the composition with `mcp: true`, the origin-root discovery route, and a
+thin catch-all route over the same instance. Two of the three below stop being
+host decisions the moment init is the one *creating* the composition — writing
+`mcp: true` into a file it authors is not editing your code, and the discovery
+route is a new file at a fixed path with a fixed two-line body.
+
+Exactly two things stay yours, because they are the two init genuinely cannot
+do: set `VENDO_BASE_URL` in your deploy platform, and point a client at the
+door. `npx vendo doctor` **fails** (`E-MCP-009`) on an MCP-wired project with no
+base URL — the door's discovery, issuer and token audience all derive from it,
+so without it the door advertises whatever origin a request happened to carry.
+
+By hand, it is three things: `mcp: true`, an OAuth adapter, and the origin-root
+discovery route.
 
 ```ts
-// lib/vendo.ts
+// app/api/vendo/[...vendo]/vendo.ts
 export const vendo = createVendo({
   model,
   principal: resolvePrincipal,
@@ -43,10 +56,23 @@ export const vendo = createVendo({
 ```ts
 // app/.well-known/[...vendo]/route.ts
 import { wellKnownVendoHandler } from "@vendoai/vendo/server";
-import { vendo } from "@/lib/vendo";
+import { vendo } from "../../api/vendo/[...vendo]/vendo";
 
 export const { GET, POST } = wellKnownVendoHandler(vendo);
 ```
+
+The composition lives in its own module for two reasons: a Next.js route module
+may export only route handlers, and the discovery route must import the **same
+instance** your catch-all serves. `wellKnownVendoHandler` resolves its path set
+by instance identity, so a second `createVendo` call in that file answers 404 on
+every well-known path.
+
+The OAuth adapter needs no separate decision when an auth preset is already
+wired: `createVendo({ auth })` fills the principal, actAs **and oauth** seams
+from one preset, and every zero-arg preset — `clerk()`, `authJs()`,
+`supabase()`, `auth0()` — carries all three. `jwt()` does not, which is why init
+declines to open the door on a `jwt` or anonymous composition rather than
+writing a `mcp: true` that throws at startup.
 
 Your existing catch-all route already serves the transport, and
 `npx vendo doctor` checks the wiring. The adapter contract and the consent page

--- a/packages/vendo/src/cli/doctor-codes.ts
+++ b/packages/vendo/src/cli/doctor-codes.ts
@@ -54,6 +54,7 @@ export const DOCTOR_ERROR_CODES = {
   "E-MCP-006": "server.json is invalid JSON",
   "E-MCP-007": "the local MCP registry auth challenge is malformed",
   "E-MCP-008": "the live MCP registry auth challenge is malformed",
+  "E-MCP-009": "the MCP door is wired but VENDO_BASE_URL is not set (discovery advertises the wrong origin)",
   "E-SCHED-001": "apps declare vendo.json schedules but no schedule caller is configured",
   "E-TURN-001": "the live model turn did not answer",
   "E-TURN-002": "the live model turn cannot run while the dev server is down",

--- a/packages/vendo/src/cli/doctor-mcp-checks.ts
+++ b/packages/vendo/src/cli/doctor-mcp-checks.ts
@@ -4,6 +4,63 @@ import type { DoctorRun } from "./doctor-report.js";
 import { remoteUrls, sameUrl, validateRegistryServer } from "./mcp/registry.js";
 import { readOptional } from "./shared.js";
 
+/** Where a Vendo composition lives: the two shapes init writes (the MCP path's
+    split `vendo.ts`, the ordinary inline route) and the runtime-neutral /
+    Express module, under both root layouts. A host that opened the door
+    somewhere else entirely is not named here on purpose — E-MCP-009 is a hard
+    FAIL, so it fires on evidence, never on a guess. */
+const COMPOSITION_PATHS: readonly string[][] = [
+  ["app", "api", "vendo", "[...vendo]", "vendo.ts"],
+  ["src", "app", "api", "vendo", "[...vendo]", "vendo.ts"],
+  ["app", "api", "vendo", "[...vendo]", "route.ts"],
+  ["src", "app", "api", "vendo", "[...vendo]", "route.ts"],
+  ["vendo", "server.ts"],
+  ["src", "vendo", "server.ts"],
+  ["vendo", "server.mjs"],
+  ["src", "vendo", "server.mjs"],
+];
+
+/** Does this composition open the MCP door, and does it name its own public
+    base URL while doing it? `mcp: { baseUrl }` is host config that beats the
+    environment default, so a composition carrying one needs no variable. */
+function mcpComposition(source: string): { wired: boolean; baseUrl: boolean } {
+  const code = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+  return {
+    wired: /\bcreateVendo\s*\(/.test(code) && /(^|[\s{,])mcp\s*:/.test(code),
+    baseUrl: /\bmcp\s*:\s*\{[^}]*\bbaseUrl\b/.test(code),
+  };
+}
+
+/**
+ * E-MCP-009 — an MCP-wired host that never set `VENDO_BASE_URL`.
+ *
+ * A FAILURE, not a warning. The door's discovery documents, its issuer, its
+ * resource identifiers and its RFC 8707 audience binding all derive from that
+ * one value; without it the door advertises whatever origin the request
+ * happened to carry. Nothing is red at install time — it surfaces hours later,
+ * in someone else's terminal, as "Claude can't find my server". This is the
+ * static half, so it runs with no dev server and no network.
+ */
+export async function checkMcpBaseUrl(run: DoctorRun): Promise<void> {
+  const { root, env } = run;
+  const sources = await Promise.all(
+    COMPOSITION_PATHS.map((segments) => readOptional(join(root, ...segments))),
+  );
+  const compositions = sources.filter((source) => source !== null).map(mcpComposition);
+  if (!compositions.some((composition) => composition.wired)) return;
+  if (compositions.some((composition) => composition.wired && composition.baseUrl)) {
+    run.pass("mcp/base-url", "the MCP door's public base URL is set in the composition (mcp.baseUrl)");
+  } else if ((env.VENDO_BASE_URL ?? "") !== "") {
+    run.pass("mcp/base-url", "VENDO_BASE_URL is set — the MCP door's discovery advertises the right origin");
+  } else {
+    run.fail("mcp/base-url", "E-MCP-009",
+      "the MCP door is wired but VENDO_BASE_URL is not set — discovery, the issuer and the token audience all derive "
+      + "from it, so the door advertises whatever origin a request happens to carry and outside agents are pointed at "
+      + "the wrong server (it surfaces later as \"Claude can't find my server\"). Set VENDO_BASE_URL to this "
+      + "deployment's public origin where you deploy, or pass mcp: { baseUrl } in the composition.");
+  }
+}
+
 /** Fetch a discovery document, grade it, and hand it back so a follow-up check
  *  can read what it advertised. A non-JSON error page still names its status;
  *  only a fetch that never answered is "unreachable". */

--- a/packages/vendo/src/cli/doctor-mcp-checks.ts
+++ b/packages/vendo/src/cli/doctor-mcp-checks.ts
@@ -20,14 +20,46 @@ const COMPOSITION_PATHS: readonly string[][] = [
   ["src", "vendo", "server.mjs"],
 ];
 
+/**
+ * The `mcp: { … }` object with every NESTED object and array removed, so a
+ * top-level key can be matched without a nested one shadowing it. Null when
+ * `mcp` is absent or is the boolean form.
+ *
+ * Balanced braces, not a character class: `[^}]*` cannot cross a closing brace,
+ * so it stopped at the first nested option's `}` and never reached a `baseUrl`
+ * declared after it. `serviceAuth`, `remoteAs` and `federation` all nest — and
+ * the local service-key path scaffolds one — so the old scan hard-failed
+ * E-MCP-009 on a correctly configured deployment purely because of the order
+ * the author wrote their properties in.
+ */
+function mcpObjectTopLevel(code: string): string | null {
+  const opened = /\bmcp\s*:\s*\{/.exec(code);
+  if (opened === null) return null;
+  let depth = 0;
+  let top = "";
+  // Start ON the opening brace so the first step takes depth to 1.
+  for (let index = opened.index + opened[0].length - 1; index < code.length; index += 1) {
+    const char = code[index]!;
+    if (char === "{" || char === "[") depth += 1;
+    else if (char === "}" || char === "]") depth -= 1;
+    else if (depth === 1) top += char;
+    if (depth === 0) return top;
+  }
+  return top;
+}
+
 /** Does this composition open the MCP door, and does it name its own public
     base URL while doing it? `mcp: { baseUrl }` is host config that beats the
     environment default, so a composition carrying one needs no variable. */
 function mcpComposition(source: string): { wired: boolean; baseUrl: boolean } {
-  const code = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+  // A line comment is `//` that is NOT the `//` in a URL scheme. Stripping every
+  // `//` truncated the line at the first `https://` — which both hid a `baseUrl`
+  // written after one and left the braces unbalanced for the walk below, failing
+  // E-MCP-009 on a correct composition. Every value this checker reads is a URL.
+  const code = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
   return {
     wired: /\bcreateVendo\s*\(/.test(code) && /(^|[\s{,])mcp\s*:/.test(code),
-    baseUrl: /\bmcp\s*:\s*\{[^}]*\bbaseUrl\b/.test(code),
+    baseUrl: /\bbaseUrl\s*:/.test(mcpObjectTopLevel(code) ?? ""),
   };
 }
 

--- a/packages/vendo/src/cli/doctor-wiring-checks.ts
+++ b/packages/vendo/src/cli/doctor-wiring-checks.ts
@@ -1,7 +1,8 @@
 import { readFile } from "node:fs/promises";
 import { dirname, join, relative } from "node:path";
 import { detectFramework, detectVendoWiring, type VendoWiring } from "./framework.js";
-import { importsGeneratedMap, missingRegistrations, registrationKey, requiredServerActions, serverActionsWiring } from "./init-scaffolds.js";
+import { importsGeneratedMap, importsSplitComposition, missingRegistrations, registrationKey, requiredServerActions, serverActionsWiring } from "./init-scaffolds.js";
+import { checkMcpBaseUrl } from "./doctor-mcp-checks.js";
 import type { DoctorRun } from "./doctor-report.js";
 import { walk } from "./theme/walk.js";
 import { clientRoot, exists, readOptional } from "./shared.js";
@@ -59,14 +60,14 @@ async function checkServerActionsWiring(run: DoctorRun, routePath: string): Prom
   const { root } = run;
   const registrations = await requiredServerActions(root);
   if (registrations.length === 0) return;
-  const routeSource = await readFile(routePath, "utf8").catch(() => "");
-  const wiring = serverActionsWiring(routeSource);
+  const { path: compositionPath, source } = await compositionOf(routePath);
+  const wiring = serverActionsWiring(source);
   if (wiring === "unknown") {
     // No recognizable createVendo({ … }) — the same shape init declines to
     // name a paste for. Nothing honest to grade.
     return;
   }
-  if (wiring === "wired" && !importsGeneratedMap(routeSource)) {
+  if (wiring === "wired" && !importsGeneratedMap(source)) {
     // The route passes a map it composes itself (a local object, an aliased
     // import). Init leaves that alone by design, and there is no generated
     // map to grade against — so doctor says nothing rather than guessing.
@@ -85,9 +86,22 @@ async function checkServerActionsWiring(run: DoctorRun, routePath: string): Prom
           : `${relative(root, mapPath)} does not register ${missing.map(registrationKey).join(", ")}`]),
         // Scoped to the call on purpose: an import line alone is not
         // wiring, and it is exactly where a half-applied paste lands.
-        ...(wiring === "unwired" ? [`${relative(root, routePath)} does not pass serverActions inside createVendo({ … })`] : []),
+        ...(wiring === "unwired" ? [`${relative(root, compositionPath)} does not pass serverActions inside createVendo({ … })`] : []),
       ].join("; ")}. Re-run \`npx vendo init\`: it prints the exact paste for each (it never rewrites a file you already have).`);
   }
+}
+
+/** Which file holds this route's `createVendo({ … })`. The MCP path splits the
+ *  composition into a sibling `vendo.ts` — a Next.js route module may export
+ *  only route handlers, and the origin-root discovery route has to import the
+ *  SAME instance — so a thin route.ts is WIRED, not unrecognized. Grading the
+ *  thin file instead would go silent on a host that is correctly wired. */
+async function compositionOf(routePath: string): Promise<{ path: string; source: string }> {
+  const source = await readFile(routePath, "utf8").catch(() => "");
+  if (!importsSplitComposition(source)) return { path: routePath, source };
+  const split = join(dirname(routePath), "vendo.ts");
+  const splitSource = await readOptional(split);
+  return splitSource === null ? { path: routePath, source } : { path: split, source: splitSource };
 }
 
 /** The mount may live in ANY layout, not just the root one (i18n/route-group
@@ -170,6 +184,9 @@ export async function checkWiring(run: DoctorRun): Promise<void> {
   }
 
   await checkLegacyRoot(run, wiring.legacyRoot);
+  // Static, so it fires on a project nobody has started yet — which is exactly
+  // when a missing base URL is still cheap to fix.
+  await checkMcpBaseUrl(run);
 
   if (await hasDependency(root)) run.pass("wiring/dependency", "@vendoai/vendo dependency is declared");
   else run.fail("wiring/dependency", "E-WIRE-005", "@vendoai/vendo (or vendoai alias) is not declared");

--- a/packages/vendo/src/cli/init-mcp.ts
+++ b/packages/vendo/src/cli/init-mcp.ts
@@ -1,0 +1,209 @@
+/**
+ * 10-mcp — what `vendo init` writes when the user wants outside agents (Claude,
+ * ChatGPT, Cursor) to act in their product as the signed-in user.
+ *
+ * Two of the three things the docs call "host decisions" stop being decisions
+ * the moment the user picks this path: init CREATES the composition, so writing
+ * `mcp: true` into it is not editing anyone's code, and the origin-root
+ * discovery route is a new file at a fixed path with a fixed two-line body.
+ * Exactly two things stay the user's, and they are the two init genuinely
+ * cannot do — set the base URL where they deploy, and point a client at the
+ * door. They are `steps`, named rather than buried.
+ *
+ * PURE: no fs, no network, no clock. Every file body, step line and environment
+ * line is decided from the answers alone, so the whole plan is assertable
+ * without a temp directory — and the caller stays the only thing that touches
+ * the disk.
+ */
+import { randomBytes } from "node:crypto";
+import { join, relative, sep } from "node:path";
+import { MCP_MOUNT } from "../door-paths.js";
+import type { AuthMatch } from "./init-auth.js";
+import { compositionModuleSource, routeSource } from "./init-scaffolds.js";
+
+/** Which authorization server fronts the door. DECLARED by the operator and
+    nothing else (10-mcp §3.1) — init prints environment lines, it never
+    discovers posture and never reaches a broker to find out. */
+export type McpPosture = "local" | "broker";
+
+export interface McpPlanInput {
+  root: string;
+  /** The host's app directory (`app` or `src/app`), already resolved. */
+  appDir: string;
+  framework: "next" | "express" | "custom";
+  /**
+   * The preset the fresh composition wired, or null. `mcp: true` is written
+   * ONLY when this is non-null: the door mints its own principals through a
+   * `HostOAuthAdapter` and composition THROWS without one (compose-mcp.ts:77-82).
+   * Every zero-arg preset carries the oauth half (auth-presets/identity.ts:215-231);
+   * `jwt` and "none" do not, and both surface here as null.
+   */
+  authWired: AuthMatch | null;
+  /** Does the host have a live `"use server"` surface? The composition imports
+      the generated registration map when it does. The map itself stays the
+      caller's to plan: an EXISTING one is compared by the keys it registers,
+      which a pure planner cannot read. */
+  serverActions: boolean;
+  /** Is a Vendo Cloud key in hand this run? Gates the posture select: a keyless
+      run never sees it — local is the default and the broker keeps today's
+      one-line pointer. */
+  cloudKey: boolean;
+  posture: McpPosture;
+  /** Did the user say yes to "will your own backend call these tools
+      machine-to-machine?" */
+  serviceKey: boolean;
+  /** The public origin captured earlier this run, or null when the user skipped
+      the question. */
+  baseUrl: string | null;
+}
+
+/** A file the MCP path creates. Always new — `before` is null for every one of
+    them — so the caller renders the diff it already knows how to render. */
+export interface McpChange {
+  absolute: string;
+  /** Root-relative, posix-style: the path the summary prints. */
+  path: string;
+  after: string;
+}
+
+export interface McpPlan {
+  /** The files the MCP path adds ALONGSIDE the route the caller already plans:
+      the composition module and the origin-root discovery route. */
+  changes: McpChange[];
+  /** The thin `route.ts` body. Separate from `changes` because the route is the
+      one file the caller may already have on disk, and a pure planner cannot
+      know that — the caller pushes it with the `before` it already read. Null
+      when the plan is `blocked`. */
+  routeSource: string | null;
+  /**
+   * The generated service key, for the caller to write to `.env.local`.
+   * Present on local posture with a yes, and NOWHERE else. `serviceAuth` is
+   * local-door mechanics: the RFC 8693 exchange lives at the door's own
+   * `/token`, which a broker-fronted door does not serve — and an explicit
+   * local `serviceAuth` is host config that beats the env default, so
+   * generating one under broker posture would quietly hold the door LOCAL
+   * against the posture the user just chose (compose-mcp.ts:98-113).
+   */
+  serviceKeyValue?: string;
+  /** The lines the run ends on. The FIRST is ALWAYS the base URL: a door whose
+      discovery points at the wrong origin surfaces hours later as "Claude can't
+      find my server". */
+  steps: string[];
+  /** Environment lines the operator sets where they deploy (broker posture). */
+  envLines: string[];
+  /** Why nothing was written. Set means the other fields are empty. */
+  blocked?: string;
+}
+
+/** A fresh service key: 32 random bytes, hex. `planMcp` mints one itself when
+    the answers call for it; this is separately callable so the shape can be
+    asserted without a plan. */
+export function generateServiceKey(): string {
+  return randomBytes(32).toString("hex");
+}
+
+/**
+ * The origin-root discovery route (`app/.well-known/[...vendo]/route.ts`).
+ *
+ * A two-line body over the SAME instance the wire route serves:
+ * `wellKnownVendoHandler` resolves its path set by instance identity
+ * (server.ts:447-452), so a second `createVendo` call in this file would answer
+ * 404 on every well-known path — which is precisely the bug this route exists
+ * to prevent.
+ */
+export function wellKnownRouteSource(specifier: string): string {
+  return `// The door's discovery documents live at ORIGIN-ROOT paths, outside\n` +
+    `// /api/vendo, so Next.js never routes them to the catch-all. This file is\n` +
+    `// that handler. It MUST share the wire's instance — the path set is resolved\n` +
+    `// by instance identity, so a second createVendo() here 404s every path.\n` +
+    `import { wellKnownVendoHandler } from "@vendoai/vendo/server";\n` +
+    `import { vendo } from ${JSON.stringify(specifier)};\n\n` +
+    `export const { GET, POST } = wellKnownVendoHandler(vendo);\n`;
+}
+
+/** An import specifier from one generated directory to another, posix-style and
+    always explicitly relative. */
+function specifierBetween(fromDir: string, target: string): string {
+  const path = relative(fromDir, target).split(sep).join("/");
+  return path.startsWith(".") ? path : `./${path}`;
+}
+
+/** The keyless sign-in pointer — today's two lines of prose, kept exactly where
+    they are useful. A run with no Cloud key is never shown the posture select,
+    so this is the whole story it gets. */
+const KEYLESS_SIGN_IN =
+  "Sign-in: your app serves its own OAuth — nothing to configure. Set VENDO_MCP_BROKER_URL "
+  + "to front it with an external authorization server (e.g. Vendo Cloud's broker) — "
+  + "same client URL either way.";
+
+export function planMcp(input: McpPlanInput): McpPlan {
+  const { root, appDir, framework, authWired, serverActions, cloudKey, posture, serviceKey, baseUrl } = input;
+  const refuse = (why: string): McpPlan => ({ changes: [], routeSource: null, steps: [], envLines: [], blocked: why });
+
+  if (framework !== "next") {
+    return refuse(
+      "MCP scaffolding is Next.js-only: the discovery documents live at origin-root paths, which only a "
+      + "file-routed app directory can claim. Open the door by hand instead — pass `mcp: true` to createVendo "
+      + "and serve the well-known paths from your runtime: https://docs.vendo.run/existing-agents/mcp.",
+    );
+  }
+  if (authWired === null) {
+    return refuse(
+      "The MCP door mints its own principals through an OAuth adapter and cannot open without one, so "
+      + "nothing MCP was written. Wire an auth preset — auth: clerk(), authJs(), supabase() or auth0() all "
+      + "carry it — then re-run `npx vendo init`. (jwt() and an anonymous composition do not carry the "
+      + "oauth half: https://docs.vendo.run/existing-agents/mcp.)",
+    );
+  }
+
+  const wiringDir = join(appDir, "api", "vendo", "[...vendo]");
+  const wellKnownDir = join(appDir, ".well-known", "[...vendo]");
+  const composition = join(wiringDir, "vendo.ts");
+  const change = (absolute: string, after: string): McpChange => ({
+    absolute,
+    path: relative(root, absolute).split(sep).join("/"),
+    after,
+  });
+
+  // `serviceAuth` is wired only under local posture: see McpPlan.serviceKeyValue.
+  const serviceAuth = posture === "local" && serviceKey;
+  const changes: McpChange[] = [
+    change(composition, compositionModuleSource({ serverActions, auth: authWired, serviceAuth })),
+    change(
+      join(wellKnownDir, "route.ts"),
+      wellKnownRouteSource(specifierBetween(wellKnownDir, join(wiringDir, "vendo"))),
+    ),
+  ];
+
+  // The client-facing URL is derived from the base URL and NEVER from the broker
+  // URL, so it is the same in both postures — switching posture later invalidates
+  // nothing a user already configured in Claude, ChatGPT or Cursor.
+  const clientBase = baseUrl ?? "https://<your deployment>";
+  const steps = [
+    baseUrl === null
+      ? "Set VENDO_BASE_URL in your deploy platform to this deployment's public origin — without it the door's discovery points at the wrong origin and clients cannot find your server"
+      : `Set VENDO_BASE_URL in your deploy platform — ${baseUrl}, captured earlier, is in .env.example`,
+    `Point any MCP client at ${clientBase}${MCP_MOUNT}`,
+    `Setup page for your users ships free at ${MCP_MOUNT}/connect (Claude · ChatGPT · Cursor copy included)`,
+    "Claude Code: /plugin marketplace add runvendo/vendo → /plugin install vendo@vendo",
+  ];
+  if (!cloudKey) steps.push(KEYLESS_SIGN_IN);
+  if (serviceKey) {
+    steps.push(serviceAuth
+      ? `Your backend exchanges VENDO_SERVICE_KEY at ${clientBase}${MCP_MOUNT}/token for a 10-minute token acting as a named user — svc: attribution in the audit`
+      : "Create the service key on the console's keys page (Service keys) — it lands in the broker; exchange it at your tenant URL /token");
+  }
+
+  return {
+    changes,
+    routeSource: routeSource({ serverActions, auth: authWired, mcp: { serviceAuth } }),
+    ...(serviceAuth ? { serviceKeyValue: generateServiceKey() } : {}),
+    steps,
+    envLines: posture === "broker"
+      ? [
+          "VENDO_MCP_BROKER_URL=<your tenant MCP endpoint, from the console MCP page>",
+          "VENDO_MCP_FEDERATION_SECRET=<from the console MCP page>",
+        ]
+      : [],
+  };
+}

--- a/packages/vendo/src/cli/init-scaffolds.ts
+++ b/packages/vendo/src/cli/init-scaffolds.ts
@@ -48,7 +48,23 @@ function authImportLine(auth: AuthMatch | null): string {
   return auth === null ? "" : `import { ${auth.preset} } from ${JSON.stringify(AUTH_PRESET_SPECIFIER[auth.preset])};\n`;
 }
 
-export function routeSource(options: { serverActions: boolean; auth: AuthMatch | null }): string {
+export function routeSource(options: {
+  serverActions: boolean;
+  auth: AuthMatch | null;
+  /** The MCP path (10-mcp): the composition moves to its own module and this
+      file becomes the thin handler over it. A Next.js route module may not
+      export anything but route handlers, and the origin-root discovery route
+      has to import the SAME instance — so `vendo` cannot live here. */
+  mcp?: { serviceAuth: boolean };
+}): string {
+  if (options.mcp !== undefined) {
+    return `// Next.js route modules may export only route handlers, so the composition\n` +
+      `// lives next door in ./vendo — import it from anywhere that needs the SAME\n` +
+      `// instance (app/.well-known/[...vendo]/route.ts does).\n` +
+      `import { nextVendoHandler } from "@vendoai/vendo/server";\n` +
+      `import { vendo } from "./vendo";\n\n` +
+      `export const { GET, POST, PUT, PATCH, DELETE } = nextVendoHandler(vendo);\n`;
+  }
   return authImportLine(options.auth) +
     `import { createVendo, guard, nextVendoHandler } from "@vendoai/vendo/server";\n` +
     (options.serverActions ? `import { serverActions } from "./vendo-actions";\n` : "") +
@@ -59,6 +75,42 @@ export function routeSource(options: { serverActions: boolean; auth: AuthMatch |
     `  guard: guard({ policy: {} }), // .vendo/policy.json: destructive asks, reads run\n` +
     `});\n\n` +
     `export const { GET, POST, PUT, PATCH, DELETE } = nextVendoHandler(vendo);\n`;
+}
+
+/**
+ * The MCP path's composition module (`app/api/vendo/[...vendo]/vendo.ts`) — the
+ * file the thin route and the origin-root discovery route BOTH import, so the
+ * two share one instance.
+ *
+ * `auth` is non-null by construction: the door mints its own principals through
+ * the preset's oauth half and composition throws without one, so `planMcp`
+ * blocks before it ever reaches this function (10-mcp §3).
+ */
+export function compositionModuleSource(options: {
+  serverActions: boolean;
+  auth: AuthMatch;
+  /** Wire first-party service auth off the environment (local posture only). */
+  serviceAuth: boolean;
+}): string {
+  return authImportLine(options.auth) +
+    `import { createVendo, guard } from "@vendoai/vendo/server";\n` +
+    (options.serverActions ? `import { serverActions } from "./vendo-actions";\n` : "") +
+    (options.serviceAuth
+      ? `\n// Machine-to-machine: your backend exchanges this key plus a user id at\n` +
+        `// /api/vendo/mcp/token (RFC 8693) for a 10-minute token acting as that named\n` +
+        `// user — svc: attribution in the audit. The key stays in the environment.\n` +
+        `const serviceKey = process.env.VENDO_SERVICE_KEY ?? "";\n`
+      : "") +
+    `\nexport const vendo = createVendo({\n` +
+    authConfigLines(options.auth) +
+    (options.serverActions ? `  serverActions,\n` : "") +
+    `  guard: guard({ policy: {} }), // .vendo/policy.json: destructive asks, reads run\n` +
+    `  // The door outside agents reach, through the SAME guard-bound path your own\n` +
+    `  // surface uses. Discovery derives from VENDO_BASE_URL — set it where you deploy.\n` +
+    (options.serviceAuth
+      ? `  mcp: serviceKey === "" ? true : { serviceAuth: { keys: [serviceKey] } },\n`
+      : `  mcp: true,\n`) +
+    `});\n`;
 }
 
 /**
@@ -114,6 +166,15 @@ export function serverActionsWiring(source: string): ServerActionsWiring {
   // Unrecognized composition: no honest paste to name, nothing honest to grade.
   if (call === null) return "unknown";
   return /(^|[\s{,])serverActions\b/.test(source.slice(source.indexOf(call[0]))) ? "wired" : "unwired";
+}
+
+/** Is this a THIN route over the split composition — the shape the MCP path
+    writes, where `createVendo` lives in `./vendo` because a Next.js route
+    module may export only handlers? The composition, not the route, is the file
+    to grade for server-action wiring; without this a thin route reads as an
+    unrecognized composition and doctor goes quiet on a host that is wired. */
+export function importsSplitComposition(source: string): boolean {
+  return /from\s+["']\.\/vendo["']/.test(source);
 }
 
 /** Does this route source the GENERATED map? A route that composes its own

--- a/packages/vendo/tests/cli/doctor-codes.test.ts
+++ b/packages/vendo/tests/cli/doctor-codes.test.ts
@@ -48,6 +48,7 @@ describe("doctor error-code registry", () => {
         "E-MCP-006": "server.json is invalid JSON",
         "E-MCP-007": "the local MCP registry auth challenge is malformed",
         "E-MCP-008": "the live MCP registry auth challenge is malformed",
+        "E-MCP-009": "the MCP door is wired but VENDO_BASE_URL is not set (discovery advertises the wrong origin)",
         "E-SCHED-001": "apps declare vendo.json schedules but no schedule caller is configured",
         "E-TOOLS-001": "every extracted host tool is disabled or excluded (zero live host tools)",
         "E-TOOLS-002": "the extracted tool surface is empty (zero host tools)",

--- a/packages/vendo/tests/cli/doctor.test.ts
+++ b/packages/vendo/tests/cli/doctor.test.ts
@@ -1679,6 +1679,35 @@ describe("vendo doctor error codes + fix_refs", () => {
       const { report } = await jsonChecks({ targetDir: await healthy(), fetchImpl: successfulProbeFetch() });
       expect(report.checks.some((entry) => entry.id === "mcp/base-url")).toBe(false);
     });
+
+    // Regression (Greptile P1 on #1142): the scan was `mcp:\s*\{[^}]*baseUrl`,
+    // and a character class cannot cross a closing brace — so a NESTED option
+    // written before baseUrl (serviceAuth, remoteAs, federation; the local
+    // service-key path scaffolds one) ended the window at its own `}` and
+    // baseUrl was never seen. E-MCP-009 is a hard FAIL, so that rejected a
+    // correctly configured deployment over property ORDER alone.
+    it.each([
+      ["a nested option BEFORE baseUrl", '{ serviceAuth: { keys: ["k1", "k2"] }, baseUrl: "https://app.acme.com" }'],
+      ["a nested option AFTER baseUrl", '{ baseUrl: "https://app.acme.com", serviceAuth: { keys: ["k1"] } }'],
+      ["two nested options around it", '{ federation: { secret: "s" }, baseUrl: "https://app.acme.com", remoteAs: { issuer: "https://i", audience: "https://a" } }'],
+    ])("passes with %s — order must not decide the verdict", async (_label, mcp) => {
+      const { report } = await jsonChecks({
+        targetDir: await mcpHost(`import { createVendo } from "@vendoai/vendo/server";\nexport const vendo = createVendo({ mcp: ${mcp} });\n`),
+        fetchImpl: successfulProbeFetch(),
+      });
+      expect(report.checks.find((entry) => entry.id === "mcp/base-url")).toMatchObject({ status: "ok" });
+    });
+
+    // …and the nested option must not smuggle a pass either: a baseUrl that is
+    // not the door's own top-level option leaves the deployment unconfigured.
+    it("still fails when the only baseUrl sits inside a nested option", async () => {
+      const { report } = await jsonChecks({
+        targetDir: await mcpHost('import { createVendo } from "@vendoai/vendo/server";\nexport const vendo = createVendo({ mcp: { remoteAs: { issuer: "https://i", audience: "https://a", baseUrl: "https://nope" } } });\n'),
+        fetchImpl: successfulProbeFetch(),
+      });
+      expect(report.checks.find((entry) => entry.id === "mcp/base-url"))
+        .toMatchObject({ status: "broken", error_code: "E-MCP-009" });
+    });
   });
 
   // Regression (review 4): a tool a human disabled is one the runtime never

--- a/packages/vendo/tests/cli/doctor.test.ts
+++ b/packages/vendo/tests/cli/doctor.test.ts
@@ -1592,6 +1592,95 @@ describe("vendo doctor error codes + fix_refs", () => {
     expect(report.checks.some((entry) => entry.id === "wiring/server-actions")).toBe(false);
   });
 
+  // The MCP path splits the composition out of route.ts — a Next.js route
+  // module may export only handlers, and the origin-root discovery route has to
+  // import the SAME instance. Doctor must grade the file that holds
+  // createVendo, or it goes silent on a host that is correctly wired.
+  describe("the split composition the MCP path writes", () => {
+    async function splitHost(composition: string): Promise<string> {
+      const root = await healthy();
+      await mkdir(join(root, "app", "actions"), { recursive: true });
+      await writeFile(join(root, "app", "actions", "later.ts"),
+        '"use server";\n\nexport async function later() {\n  return 1;\n}\n');
+      await writeFile(join(root, "app", "api", "vendo", "[...vendo]", "vendo-actions.ts"),
+        'export const serverActions = {\n  "app/actions/later.ts#later": async () => 1,\n};\n');
+      await writeFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts"),
+        'import { nextVendoHandler } from "@vendoai/vendo/server";\nimport { vendo } from "./vendo";\n\nexport const { GET, POST } = nextVendoHandler(vendo);\n');
+      await writeFile(join(root, "app", "api", "vendo", "[...vendo]", "vendo.ts"), composition);
+      return root;
+    }
+
+    it("reads a thin route.ts as wired, not missing", async () => {
+      const root = await splitHost('import { createVendo } from "@vendoai/vendo/server";\nimport { serverActions } from "./vendo-actions";\nexport const vendo = createVendo({ serverActions, mcp: true });\n');
+      const { report } = await jsonChecks({
+        targetDir: root,
+        fetchImpl: successfulProbeFetch(),
+        env: { VENDO_BASE_URL: "https://app.acme.com" },
+      });
+      expect(report.checks.find((entry) => entry.id === "wiring/next-route")).toMatchObject({ status: "ok" });
+      expect(report.checks.find((entry) => entry.id === "wiring/server-actions")).toMatchObject({ status: "ok" });
+    });
+
+    it("names the composition, not the thin route, when the wiring is missing there", async () => {
+      const root = await splitHost('import { createVendo } from "@vendoai/vendo/server";\nexport const vendo = createVendo({ mcp: true });\n');
+      const { report } = await jsonChecks({
+        targetDir: root,
+        fetchImpl: successfulProbeFetch(),
+        env: { VENDO_BASE_URL: "https://app.acme.com" },
+      });
+      const check = report.checks.find((entry) => entry.id === "wiring/server-actions");
+      expect(check).toMatchObject({ status: "broken", error_code: "E-WIRE-009" });
+      expect(check?.message).toContain("app/api/vendo/[...vendo]/vendo.ts does not pass serverActions");
+    });
+  });
+
+  // The one thing the MCP path must not do: a door whose discovery points at
+  // the wrong origin is invisible at install time and surfaces hours later, in
+  // someone else's terminal, as "Claude can't find my server". A FAILURE.
+  describe("E-MCP-009 — an MCP-wired host with no base URL", () => {
+    async function mcpHost(composition: string): Promise<string> {
+      const root = await healthy();
+      await writeFile(join(root, "app", "api", "vendo", "[...vendo]", "vendo.ts"), composition);
+      return root;
+    }
+    const wired = 'import { createVendo } from "@vendoai/vendo/server";\nexport const vendo = createVendo({ mcp: true });\n';
+
+    it("fails, and exits 1", async () => {
+      const { exit, report } = await jsonChecks({
+        targetDir: await mcpHost(wired),
+        fetchImpl: successfulProbeFetch(),
+      });
+      expect(exit).toBe(1);
+      const check = report.checks.find((entry) => entry.id === "mcp/base-url");
+      expect(check).toMatchObject({ status: "broken", error_code: "E-MCP-009" });
+      expect(check?.message).toContain("VENDO_BASE_URL is not set");
+    });
+
+    it("passes once VENDO_BASE_URL is set", async () => {
+      const { report } = await jsonChecks({
+        targetDir: await mcpHost(wired),
+        fetchImpl: successfulProbeFetch(),
+        env: { VENDO_BASE_URL: "https://app.acme.com" },
+      });
+      expect(report.checks.find((entry) => entry.id === "mcp/base-url")).toMatchObject({ status: "ok" });
+    });
+
+    // Host config beats the environment default, so a composition that names
+    // its own public origin needs no variable.
+    it("passes on mcp: { baseUrl } with no variable at all", async () => {
+      const { report } = await jsonChecks({
+        targetDir: await mcpHost('import { createVendo } from "@vendoai/vendo/server";\nexport const vendo = createVendo({ mcp: { baseUrl: "https://app.acme.com" } });\n'),
+        fetchImpl: successfulProbeFetch(),
+      });
+      expect(report.checks.find((entry) => entry.id === "mcp/base-url")).toMatchObject({ status: "ok" });
+    });
+
+    it("says nothing at all when no door is wired", async () => {
+      const { report } = await jsonChecks({ targetDir: await healthy(), fetchImpl: successfulProbeFetch() });
+      expect(report.checks.some((entry) => entry.id === "mcp/base-url")).toBe(false);
+    });
+  });
+
   // Regression (review 4): a tool a human disabled is one the runtime never
   // dispatches — hard-failing on its registration demands work that buys
   // nothing. The rest of doctor honors overrides; this check does too.

--- a/packages/vendo/tests/cli/init-mcp.test.ts
+++ b/packages/vendo/tests/cli/init-mcp.test.ts
@@ -1,0 +1,256 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { doorWellKnownPaths } from "../../src/door-paths.js";
+import { generateServiceKey, planMcp, wellKnownRouteSource, type McpPlan, type McpPlanInput } from "../../src/cli/init-mcp.js";
+
+const cleanup: string[] = [];
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+const clerk = { preset: "clerk", dependency: "@clerk/nextjs" } as const;
+
+function plan(overrides: Partial<McpPlanInput> = {}): McpPlan {
+  return planMcp({
+    root: "/host",
+    appDir: "/host/app",
+    framework: "next",
+    authWired: clerk,
+    serverActions: true,
+    cloudKey: true,
+    posture: "local",
+    serviceKey: false,
+    baseUrl: "https://app.acme.com",
+    ...overrides,
+  });
+}
+
+describe("planMcp — the files", () => {
+  it("writes the composition and the origin-root discovery route alongside a thin route", () => {
+    const { changes, routeSource } = plan();
+    expect(changes.map((change) => change.path)).toEqual([
+      "app/api/vendo/[...vendo]/vendo.ts",
+      "app/.well-known/[...vendo]/route.ts",
+    ]);
+    // A Next.js route module may export only route handlers, so the route is
+    // thin and the composition lives next door.
+    expect(routeSource).toContain(`import { vendo } from "./vendo";`);
+    expect(routeSource).not.toMatch(/import\s*\{[^}]*\bcreateVendo\b/);
+  });
+
+  it("opens the door in the composition it authors, with the preset that carries the oauth seam", () => {
+    const [composition] = plan().changes;
+    expect(composition!.after).toContain(`import { clerk } from "@vendoai/vendo/auth/clerk";`);
+    expect(composition!.after).toContain("auth: clerk(),");
+    expect(composition!.after).toContain("mcp: true,");
+    expect(composition!.after).toContain("export const vendo = createVendo({");
+  });
+
+  it("points the discovery route at the SAME instance the wire serves", () => {
+    const wellKnown = plan().changes[1]!;
+    // Instance identity is how wellKnownVendoHandler resolves its path set
+    // (server.ts:447-452) — a second createVendo() here 404s every path.
+    expect(wellKnown.after).toContain(`import { vendo } from "../../api/vendo/[...vendo]/vendo";`);
+    expect(wellKnown.after).not.toMatch(/import\s*\{[^}]*\bcreateVendo\b/);
+    expect(wellKnown.after).toContain("export const { GET, POST } = wellKnownVendoHandler(vendo);");
+  });
+
+  it("imports the generated action map only when the host has server actions", () => {
+    expect(plan().changes[0]!.after).toContain(`import { serverActions } from "./vendo-actions";`);
+    expect(plan({ serverActions: false }).changes[0]!.after).not.toContain("./vendo-actions");
+  });
+});
+
+describe("planMcp — what it refuses to write", () => {
+  it("writes nothing without an oauth seam: mcp: true would throw at composition", () => {
+    const blocked = plan({ authWired: null });
+    expect(blocked.blocked).toMatch(/cannot open without one/);
+    expect(blocked.changes).toEqual([]);
+    expect(blocked.routeSource).toBeNull();
+    expect(blocked.steps).toEqual([]);
+  });
+
+  it("writes nothing off the Next.js app router — the discovery paths are origin-root", () => {
+    for (const framework of ["express", "custom"] as const) {
+      const blocked = plan({ framework });
+      expect(blocked.blocked).toMatch(/Next\.js-only/);
+      expect(blocked.changes).toEqual([]);
+    }
+  });
+});
+
+describe("planMcp — the service key", () => {
+  it("generates and wires one under local posture", () => {
+    const local = plan({ serviceKey: true });
+    expect(local.serviceKeyValue).toMatch(/^[0-9a-f]{64}$/);
+    expect(local.changes[0]!.after).toContain("const serviceKey = process.env.VENDO_SERVICE_KEY");
+    expect(local.changes[0]!.after).toContain(`mcp: serviceKey === "" ? true : { serviceAuth: { keys: [serviceKey] } },`);
+    expect(local.steps.at(-1)).toContain("/api/vendo/mcp/token");
+  });
+
+  // serviceAuth is local-door mechanics: the RFC 8693 exchange lives at the
+  // door's own /token, which a broker-fronted door does not serve — and an
+  // explicit local serviceAuth beats the env default, so generating one here
+  // would quietly hold the door LOCAL against the posture just chosen.
+  it("generates nothing under broker posture and points at the console instead", () => {
+    const broker = plan({ serviceKey: true, posture: "broker" });
+    expect(broker.serviceKeyValue).toBeUndefined();
+    expect(broker.changes[0]!.after).toContain("mcp: true,");
+    expect(broker.changes[0]!.after).not.toContain("serviceAuth");
+    expect(broker.steps.at(-1)).toContain("console's keys page");
+  });
+
+  it("says nothing about service keys when the answer was no", () => {
+    const none = plan();
+    expect(none.serviceKeyValue).toBeUndefined();
+    expect(none.steps.join("\n")).not.toContain("VENDO_SERVICE_KEY");
+  });
+
+  it("mints 32 hex bytes", () => {
+    expect(generateServiceKey()).toMatch(/^[0-9a-f]{64}$/);
+    expect(generateServiceKey()).not.toBe(generateServiceKey());
+  });
+});
+
+describe("planMcp — the two steps that stay the user's", () => {
+  it("puts the base URL FIRST, always", () => {
+    expect(plan().steps[0]).toContain("Set VENDO_BASE_URL");
+    expect(plan({ baseUrl: null }).steps[0]).toContain("Set VENDO_BASE_URL");
+    expect(plan({ posture: "broker", serviceKey: true }).steps[0]).toContain("Set VENDO_BASE_URL");
+  });
+
+  it("names the captured origin when there is one, and the risk when there is not", () => {
+    expect(plan().steps[0]).toContain("https://app.acme.com, captured earlier, is in .env.example");
+    expect(plan({ baseUrl: null }).steps[0]).toContain("points at the wrong origin");
+  });
+
+  it("points clients at the same URL in BOTH postures — it derives from the base URL, never the broker", () => {
+    const client = "Point any MCP client at https://app.acme.com/api/vendo/mcp";
+    expect(plan().steps).toContain(client);
+    expect(plan({ posture: "broker" }).steps).toContain(client);
+  });
+});
+
+describe("planMcp — the sign-in posture", () => {
+  it("prints the operator's two broker lines under broker posture, and nothing under local", () => {
+    expect(plan({ posture: "broker" }).envLines).toEqual([
+      "VENDO_MCP_BROKER_URL=<your tenant MCP endpoint, from the console MCP page>",
+      "VENDO_MCP_FEDERATION_SECRET=<from the console MCP page>",
+    ]);
+    expect(plan().envLines).toEqual([]);
+  });
+
+  // The posture select only appears when a Cloud key is in hand; a keyless run
+  // gets local as the default and today's one-line pointer.
+  it("adds the keyless pointer only when no Cloud key is in hand", () => {
+    expect(plan({ cloudKey: false }).steps.join("\n")).toContain("Sign-in: your app serves its own OAuth");
+    expect(plan().steps.join("\n")).not.toContain("Sign-in: your app serves its own OAuth");
+  });
+});
+
+describe("wellKnownRouteSource", () => {
+  it("is a two-line body over the specifier it is handed", () => {
+    const source = wellKnownRouteSource("../../api/vendo/[...vendo]/vendo");
+    expect(source).toContain(`import { wellKnownVendoHandler } from "@vendoai/vendo/server";`);
+    expect(source).toContain(`import { vendo } from "../../api/vendo/[...vendo]/vendo";`);
+  });
+});
+
+/**
+ * THE SEAM. The generator and the consumer are the two halves that can
+ * disagree, so neither is stubbed: the scaffold is written THROUGH planMcp,
+ * the generated composition is BOOTED, and the door is asked for every path in
+ * `doorWellKnownPaths` — the one authority the wire and the composition share.
+ * A harness that mocked either half could never catch the failure this exists
+ * to catch (a second createVendo() in the discovery route, which resolves an
+ * empty path set and 404s all of them).
+ *
+ * The generated files are written verbatim and loaded through a real
+ * `node_modules/@vendoai/vendo` link, so `@vendoai/vendo/server` and
+ * `@vendoai/vendo/auth/clerk` resolve exactly as they do in a host.
+ */
+describe("the generated MCP door answers every well-known path (seam)", () => {
+  const PACKAGE_ROOT = resolve(new URL("../..", import.meta.url).pathname);
+  const BASE_URL = "https://app.acme.com/maple";
+
+  async function bootGeneratedDoor(): Promise<{
+    wellKnown: { GET(request: Request): Promise<Response> };
+    wire: { GET(request: Request): Promise<Response> };
+  }> {
+    // The host tree lives under the package (never inside another suite's dist
+    // — see the testing section of CLAUDE.md) so the generated modules load
+    // through the SAME resolver a Next.js host uses: extensionless relative
+    // imports, and `@vendoai/vendo/*` off a real node_modules link.
+    const root = await mkdtemp(join(PACKAGE_ROOT, ".mcp-seam-"));
+    cleanup.push(root);
+    const built = planMcp({
+      root,
+      appDir: join(root, "app"),
+      framework: "next",
+      authWired: clerk,
+      serverActions: false,
+      cloudKey: true,
+      posture: "local",
+      serviceKey: true,
+      baseUrl: BASE_URL,
+    });
+    const routePath = join(root, "app", "api", "vendo", "[...vendo]", "route.ts");
+    const files = [
+      { absolute: routePath, after: built.routeSource! },
+      ...built.changes,
+    ];
+    for (const file of files) {
+      await mkdir(dirname(file.absolute), { recursive: true });
+      await writeFile(file.absolute, file.after);
+    }
+    await mkdir(join(root, "node_modules", "@vendoai"), { recursive: true });
+    await symlink(PACKAGE_ROOT, join(root, "node_modules", "@vendoai", "vendo"), "dir");
+
+    // The one value the whole door derives from. A path prefix is deliberate:
+    // it is what makes the four exact paths six, and the prefixed spellings are
+    // the ones a spec client actually asks for (RFC 8414 §3 / RFC 9728 §3.1).
+    vi.stubEnv("VENDO_BASE_URL", BASE_URL);
+    vi.stubEnv("VENDO_SERVICE_KEY", generateServiceKey());
+    return {
+      wellKnown: await import(pathToFileURL(join(root, "app", ".well-known", "[...vendo]", "route.ts")).href),
+      wire: await import(pathToFileURL(routePath).href),
+    };
+  }
+
+  it("answers all six, over the same instance the wire route serves", async () => {
+    const { wellKnown, wire } = await bootGeneratedDoor();
+    const paths = [...doorWellKnownPaths("/maple")];
+    expect(paths).toHaveLength(6);
+
+    for (const path of paths) {
+      const response = await wellKnown.GET(new Request(`https://app.acme.com${path}`));
+      expect(response.status, path).toBe(200);
+      expect(await response.json(), path).toBeTypeOf("object");
+    }
+
+    // The documents are the door's own, not a generic 200: discovery names the
+    // configured public origin, prefix included.
+    const resource = await wellKnown.GET(new Request(`https://app.acme.com/.well-known/oauth-protected-resource/maple/api/vendo/mcp`));
+    expect((await resource.json() as { resource?: string }).resource).toBe(`${BASE_URL}/api/vendo/mcp`);
+    const issuer = await wellKnown.GET(new Request(`https://app.acme.com/.well-known/oauth-authorization-server/maple/api/vendo/mcp`));
+    const metadata = await issuer.json() as { issuer?: string; grant_types_supported?: string[] };
+    expect(metadata.issuer).toBe(`${BASE_URL}/api/vendo/mcp`);
+    // The generated serviceAuth wiring is live: the exchange grant is advertised.
+    expect(metadata.grant_types_supported).toContain("urn:ietf:params:oauth:grant-type:token-exchange");
+
+    // The generated wire route serves the door itself, and challenges with the
+    // discovery URL the route above answers — the two halves agree.
+    const door = await wire.GET(new Request("https://app.acme.com/api/vendo/mcp"));
+    expect(door.status).toBe(401);
+    expect(door.headers.get("www-authenticate"))
+      .toContain(`${BASE_URL}/.well-known/oauth-protected-resource/api/vendo/mcp`);
+
+    // …and only its own set: the generated route does not shadow a host's other
+    // well-known documents.
+    const foreign = await wellKnown.GET(new Request("https://app.acme.com/.well-known/openid-configuration"));
+    expect(foreign.status).toBe(404);
+  });
+});

--- a/packages/vendo/tests/cli/init-scaffolds.test.ts
+++ b/packages/vendo/tests/cli/init-scaffolds.test.ts
@@ -5,7 +5,7 @@ import { execPath } from "node:process";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
-import { customServerSource, expressServerSource, routeSource } from "../../src/cli/init-scaffolds.js";
+import { compositionModuleSource, customServerSource, expressServerSource, routeSource } from "../../src/cli/init-scaffolds.js";
 
 const run = promisify(execFile);
 
@@ -65,5 +65,44 @@ describe("the scaffolds init writes", () => {
       expect(source).not.toContain("catalog: registry");
       expect(source).not.toContain(`from "./registry`);
     }
+  });
+});
+
+/** The MCP path is the ONLY path that splits the composition, and the non-MCP
+    route is byte-identical to what it has always been (the auth-preset suites
+    pin those bytes). */
+describe("the MCP path's split composition", () => {
+  const clerk = { preset: "clerk", dependency: "@clerk/nextjs" } as const;
+
+  it("leaves today's inline route untouched when no mcp arm is passed", () => {
+    const inline = routeSource({ serverActions: true, auth: clerk });
+    expect(inline).toContain("const vendo = createVendo({");
+    expect(inline).toContain("export const { GET, POST, PUT, PATCH, DELETE } = nextVendoHandler(vendo);");
+    expect(inline).not.toContain(`from "./vendo"`);
+  });
+
+  it("makes route.ts thin on the MCP path — a route module may export only handlers", () => {
+    const thin = routeSource({ serverActions: true, auth: clerk, mcp: { serviceAuth: false } });
+    expect(thin).toContain(`import { vendo } from "./vendo";`);
+    expect(thin).toContain("export const { GET, POST, PUT, PATCH, DELETE } = nextVendoHandler(vendo);");
+    expect(thin).not.toMatch(/import\s*\{[^}]*\bcreateVendo\b/);
+    // Nothing the route exports may be a non-handler, so the preset and the
+    // action map move out with the composition.
+    expect(thin).not.toContain("@vendoai/vendo/auth/clerk");
+    expect(thin).not.toContain("./vendo-actions");
+  });
+
+  it("opens the door in the composition module, and wires serviceAuth off the environment only when asked", () => {
+    const plain = compositionModuleSource({ serverActions: true, auth: clerk, serviceAuth: false });
+    expect(plain).toContain("export const vendo = createVendo({");
+    expect(plain).toContain("auth: clerk(),");
+    expect(plain).toContain("serverActions,");
+    expect(plain).toContain("mcp: true,");
+    expect(plain).not.toContain("VENDO_SERVICE_KEY");
+
+    const service = compositionModuleSource({ serverActions: false, auth: clerk, serviceAuth: true });
+    expect(service).toContain(`const serviceKey = process.env.VENDO_SERVICE_KEY ?? "";`);
+    expect(service).toContain(`mcp: serviceKey === "" ? true : { serviceAuth: { keys: [serviceKey] } },`);
+    expect(service).not.toContain("./vendo-actions");
   });
 });


### PR DESCRIPTION
`vendo init` can now scaffold the MCP door. Two of the three things the docs call
"host decisions" stop being decisions the moment init is the one **creating** the
composition — writing `mcp: true` into a file it authors is not editing anyone's
code, and the origin-root discovery route is a new file at a fixed path with a
fixed two-line body. Exactly two things stay the user's, and they are the two init
genuinely cannot do.

`planMcp` **ships with no production caller yet — slice S2 wires it into `init.ts` next.**

## What lands

**`src/cli/init-mcp.ts` (new)** — `planMcp(input) → McpPlan`. Pure: no fs, no
network, no clock. Plus `wellKnownRouteSource(specifier)` and
`generateServiceKey()` (32 hex bytes).

**Five files, not four.** A Next.js route module may export only route handlers,
so the composition moves to its own module:

```
+ app/api/vendo/[...vendo]/route.ts          (thin)
+ app/api/vendo/[...vendo]/vendo.ts          (the composition)
+ app/api/vendo/[...vendo]/vendo-actions.ts
+ app/.well-known/[...vendo]/route.ts
~ package.json
```

Both routes import the **same instance**: `wellKnownVendoHandler` resolves its
path set by instance identity (`server.ts:447-452`), so a second `createVendo` in
the discovery route answers 404 on every well-known path.

**`mcp: true` only with an oauth seam.** The door mints its own principals through
the preset's oauth half and composition throws without one
(`compose-mcp.ts:77-82`). Zero-arg presets carry it
(`auth-presets/identity.ts:215-231`); `jwt` and an anonymous composition do not,
so `planMcp` refuses with the reason rather than scaffolding a startup crash.

**`serviceAuth` under local posture only.** The RFC 8693 exchange lives at the
door's own `/token`, which a broker-fronted door does not serve — and an explicit
local `serviceAuth` is host config that beats the env default, so generating one
under broker posture would quietly hold the door LOCAL against the posture the
user just chose (`compose-mcp.ts:98-113`). Broker posture points at the console
instead.

**Doctor** learns the split composition, so a thin `route.ts` that imports
`./vendo` is graded as **wired**, not unrecognized — without it E-WIRE-009 went
silent on a correctly wired host. And **E-MCP-009** (append-only) is new: an
MCP-wired project with no `VENDO_BASE_URL` **fails**. Not a warning. A door whose
discovery points at the wrong origin is invisible at install time and surfaces
hours later, in someone else's terminal, as "Claude can't find my server".

The **non-MCP route is byte-identical**. `routeSource`'s `mcp?` arm is optional,
so `init.ts` compiles untouched.

## One file outside this slice's fence

`docs-site/agents/verify.mdx` gains a 15-line, append-only `E-MCP-009` section.
It is **required, not scope creep**: `packages/vendo/tests/cli/doctor-codes.docs.test.ts`
enforces a strict 1:1 mapping between `DOCTOR_ERROR_CODES` and the verify page's
anchored headings, so a new code without its `{#E-MCP-009}` anchor fails that
(pinned) test. Fence exception granted by the conductor.

## The seam test

The scaffold is written **through `planMcp`**, the generated composition is
**booted** through a real `node_modules/@vendoai/vendo` link (so
`@vendoai/vendo/server` and `@vendoai/vendo/auth/clerk` resolve exactly as they do
in a host), and the door is asked for every path in `doorWellKnownPaths`. No stub
on either side.

Assertion list — `doorWellKnownPaths("/maple")`, all six, each `200` with a JSON
body:

```
/.well-known/oauth-protected-resource/api/vendo/mcp
/.well-known/oauth-authorization-server/api/vendo/mcp
/.well-known/oauth-protected-resource/maple/api/vendo/mcp
/.well-known/oauth-authorization-server/maple/api/vendo/mcp
/.well-known/mcp/server-card.json
/.well-known/mcp-server-card
```

…plus: the protected-resource document names `https://app.acme.com/maple/api/vendo/mcp`;
the authorization-server document's `issuer` matches and advertises
`urn:ietf:params:oauth:grant-type:token-exchange` (the generated `serviceAuth`
wiring is live); the generated **wire** route answers the door mount with `401`
and a `WWW-Authenticate` naming the very discovery URL the other route serves; and
`/.well-known/openid-configuration` still `404`s.

```
 ✓ tests/cli/init-mcp.test.ts (17 tests) 7774ms
   ✓ the generated MCP door answers every well-known path (seam) > answers all six, over the same instance the wire route serves  7711ms
 Test Files  1 passed (1)
      Tests  17 passed (17)
```

## The auth-presets diff

```
$ git diff origin/main --stat -- packages/vendo/tests/auth-presets/
(empty)
```

## Recording

One asciinema recording, rendered with `agg`, on the build box:
`/tmp/s3-demo/s3.gif` (and `s3.cast`). GitHub has no CLI image-upload path, so the
transcript is inline below.

Two caveats, stated plainly:

- The init **UI** scenes (the scaffold summary block and the posture select) cannot
  be driven from this branch — `init.ts` is slice S2's file and `planMcp` has no
  caller yet. Scene 1 therefore prints the planner's real return value rather than
  a fabricated terminal.
- `vendo doctor` has **not** adopted the pretty renderer yet (it prints plain
  `ok:` / `broken:` — that adoption is a different slice), so E-MCP-009 shows as a
  hard `broken:` line and exit 1, not red.

<details><summary>Transcript</summary>

```
vendo init — the MCP door  slice S3: planMcp · the origin-root discovery route · E-MCP-009

1 ── what planMcp plans. (Pure: no fs, no network, no clock.)
    init.ts belongs to slice S2, so this prints the planner's own output.

$ node show-plan.mjs
◆  Wired for MCP (5 files)
│  + app/api/vendo/[...vendo]/route.ts        (thin — a route module may export only handlers)
│  + app/api/vendo/[...vendo]/vendo.ts        (mcp: true — your Clerk preset already carries the OAuth adapter)
│  + app/api/vendo/[...vendo]/vendo-actions.ts
│  + app/.well-known/[...vendo]/route.ts       (OAuth + registry discovery — lives at the origin root)
│  ~ package.json
│  
◇  Two steps are yours
│  Set VENDO_BASE_URL in your deploy platform — https://app.acme.com, captured earlier, is in .env.example
│  Point any MCP client at https://app.acme.com/api/vendo/mcp
│  Setup page for your users ships free at /api/vendo/mcp/connect (Claude · ChatGPT · Cursor copy included)
│  Claude Code: /plugin marketplace add runvendo/vendo → /plugin install vendo@vendo
│  Your backend exchanges VENDO_SERVICE_KEY at https://app.acme.com/api/vendo/mcp/token for a 10-minute token acting as a named user — svc: attribution in the audit
│  
◇  With a Cloud key — the posture select, broker chosen
│      VENDO_MCP_BROKER_URL=<your tenant MCP endpoint, from the console MCP page>
│      VENDO_MCP_FEDERATION_SECRET=<from the console MCP page>
│  same client URL either way
│  
◇  Keyless run — no select at all, local is the default
│  Sign-in: your app serves its own OAuth — nothing to configure. Set VENDO_MCP_BROKER_URL to front it with an external authorization server (e.g. Vendo Cloud's broker) — same client URL either way.
│  
◇  No oauth seam — nothing MCP is written
│  ⚠ The MCP door mints its own principals through an OAuth adapter and cannot open without one, so nothing MCP was written. Wire an auth preset — auth: clerk(), authJs(), supabase() or auth0() all carry it — then re-run `npx vendo init`. (jwt() and an anonymous composition do not carry the oauth half: https://docs.vendo.run/existing-agents/mcp.)
│  files written: 0

2 ── the two files that make the door work, as written

$ cat 'app/api/vendo/[...vendo]/vendo.ts'
import { clerk } from "@vendoai/vendo/auth/clerk";
import { createVendo, guard } from "@vendoai/vendo/server";

export const vendo = createVendo({
  auth: clerk(),
  guard: guard({ policy: {} }),
  mcp: true,
});

$ cat 'app/.well-known/[...vendo]/route.ts'
import { wellKnownVendoHandler } from "@vendoai/vendo/server";
import { vendo } from "../../api/vendo/[...vendo]/vendo";

export const { GET, POST } = wellKnownVendoHandler(vendo);

3 ── vendo doctor on that project, with no VENDO_BASE_URL

$ npx vendo doctor
ok: catch-all handler is wired
broken: the MCP door is wired but VENDO_BASE_URL is not set — discovery, the issuer and the token audience all derive from it, so the door advertises whatever origin a request happens to carry and outside agents are pointed at the wrong server (it surfaces later as "Claude can't find my server"). Set VENDO_BASE_URL to this deployment's public origin where you deploy, or pass mcp: { baseUrl } in the composition.
ok: @vendoai/vendo dependency is declared
exit 1 — E-MCP-009 is a FAILURE, not a warning

4 ── set it, and the same project is green on that check

$ VENDO_BASE_URL=https://app.acme.com npx vendo doctor
ok: VENDO_BASE_URL is set — the MCP door's discovery advertises the right origin

5 ── the seam: the scaffold is written THROUGH planMcp, the generated
    composition is BOOTED, and the door is asked for every path in
    doorWellKnownPaths. No stub on either side.

$ vitest run tests/cli/init-mcp.test.ts

 RUN  v3.2.7 /home/ubuntu/worktrees/s3/packages/vendo

 ✓ tests/cli/init-mcp.test.ts (17 tests) 7774ms
   ✓ the generated MCP door answers every well-known path (seam) > answers all six, over the same instance the wire route serves  7711ms

 Test Files  1 passed (1)
      Tests  17 passed (17)
   Start at  08:43:38
   Duration  11.76s (transform 6.23s, setup 39ms, collect 3.38s, tests 7.77s, environment 0ms, prepare 156ms)
```

</details>

## Gate

```
build          Tasks: 21 successful, 21 total          (1m24s)
test:affected  Tasks: 30 successful, 31 total          (19m30s)
typecheck      Tasks: 42 successful, 42 total          (42s)
lint           Tasks:  4 successful,  4 total          (34s)  — 0 errors
```

The one non-green task is `demo-bank#test` — 2 failures in
`tests/vendo/away-drill.test.ts`, which spawns a real dev server and was starved
during a 19-minute run with three workers on one box. **Re-run alone under the
machine lock: 4/4 pass.** It is also unreachable from this diff — that test
imports `@vendoai/core|actions|apps|automations|guard|store` and nothing from
`@vendoai/vendo`, while this slice touches only `packages/vendo/src/cli/**` and
docs.

```
 ✓ tests/vendo/away-drill.test.ts (4 tests) 14455ms
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Not rebased: merge base stays `29c2b4961`, `git merge-tree` against `origin/main`
(`fb867d903`) reports zero conflicts, and none of the 136 files that landed on
main since then overlap this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MCP door scaffolding to `vendo init` via a new pure planner (`planMcp`) that generates a split composition and the origin-root discovery route for Next.js apps. Also adds a strict `vendo doctor` check (E-MCP-009) for missing `VENDO_BASE_URL`, with a parser fix so `mcp.baseUrl` detection works regardless of property order and URLs.

- **New Features**
  - `planMcp` plans:
    - Split composition: thin `route.ts` imports `./vendo`; both routes import the same instance to avoid 404s.
    - Origin-root discovery route: `app/.well-known/[...vendo]/route.ts` that reuses the same `vendo`.
  - Writes `mcp: true` only when an auth preset is present; refuses `jwt`/anonymous.
  - Service auth: generates `VENDO_SERVICE_KEY` and wires `serviceAuth` only under local posture; broker posture prints two env lines instead.
  - Non-MCP route remains byte-identical.
  - `vendo doctor`:
    - Recognizes the split composition (thin route is graded as wired).
    - Adds E-MCP-009 (fail): MCP door wired but `VENDO_BASE_URL` not set; passes if `mcp.baseUrl` is set in code or `VENDO_BASE_URL` is set.
  - Helpers/tests/docs: `wellKnownRouteSource()`, `generateServiceKey()`, seam test validating all well-known paths and auth metadata; docs updated with E-MCP-009 and init scaffolding notes.
  - Note: `planMcp` ships without a production caller; it will be wired in the next slice.

- **Bug Fixes**
  - E-MCP-009 no longer false-fails on valid compositions due to option order or `https://` in lines: uses a balanced-brace scan of `mcp` top-level options and safe line-comment stripping; tests cover nested-before/after and nested-only cases.

<sup>Written for commit 74fc8161e4e65a19a658492862bea4cf90704076. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

