### PR TITLE
feat(cli): the renderer finishes the brand block and the paste block's docs link

### DIFF
--- a/packages/vendo/src/cli/pretty.ts
+++ b/packages/vendo/src/cli/pretty.ts
@@ -18,7 +18,9 @@ import type { Output } from "./shared.js";
  * because runInit's emissions are unchanged: this is a renderer over the
  * existing Output seam, not a second copy of the copy. The collapse rules
  * below are pure string rules over those exact plain strings; the renderer
- * restyles and groups, and never writes copy of its own.
+ * restyles and groups. The copy it owns is the block TITLES and the one docs
+ * pointer (MOUNT_DOCS) that cannot live in the caller without changing the
+ * --agent plan's pinned JSON; every fact on screen is still the caller's.
  */
 
 const ESC = "\u001b";
@@ -111,9 +113,24 @@ const JUDGMENT_QUEUED = "loosenings queued";
 const PASTE_RULE = "─".repeat(64);
 const PASTE_HEAD = /^(ONE|\d+) STEPS? LEFT — paste th(?:is|ese) yourself \((.+)\)$/;
 const PASTE_FILE = /^ {2}File: (.+)$/;
+/** The mount snippet elides the child expression, and it genuinely differs by
+    router — `{children}` in an app-router layout, `<Component {...pageProps} />`
+    in a pages `_app` — so the block owes the exact per-router wording. This
+    pointer is the renderer's and not the caller's: init's `mount.lines` is
+    pinned byte-for-byte by the --agent plan, and a line added there would
+    change that JSON. Emitted here, the --agent path never sees it. */
+const MOUNT_WRAP = "… then wrap: <VendoProvider";
+const MOUNT_DOCS = "docs.vendo.run/quickstart#the-client-mount — exact wording for layout.tsx and _app.tsx";
 const WIRED = /^(Wired \(\d+ files?\)):$/;
 const DIFF_MARKER = /^ {2}([+~]) (.+)$/;
 const THEME = /^Theme: (.*)$/;
+/** The four slots the brand block shows. The caller keeps emitting all seven:
+    that same line is what drives init's "No host evidence for…" report, so
+    narrowing it would silently stop reporting surface/mutedText/border. */
+const BRAND_SLOTS = ["accent", "background", "text", "danger"] as const;
+const PALETTE_ENTRY = /(\w+) (#[0-9a-fA-F]{6})$/;
+/** Any SGR the caller already wrote — stripped before the hexes are parsed. */
+const SGR = new RegExp(`${ESC}\\[[0-9;]*m`, "g");
 const SYNC_THEME = /^theme: (.+)$/;
 const CLOUD_ABSENT = /^Vendo Cloud \(optional\): not configured\. A key unlocks (.+)\.$/;
 const CLOUD_PRESENT = /^Vendo Cloud: (.+)$/;
@@ -252,6 +269,27 @@ function flushJudgment(state: RenderState, rail: Rail): void {
   for (const entry of queued) rail.body(entry.trim());
 }
 
+/** A block of the extracted colour. The truecolor escape lives HERE, never in
+    a caller: this renderer is only built when usePrettyOutput() is true, so a
+    NO_COLOR / CI / TERM=dumb / piped run can never reach it. */
+function swatch(hex: string): string {
+  const [r, g, b] = [1, 3, 5].map((at) => parseInt(hex.slice(at, at + 2), 16));
+  return `${ESC}[48;2;${r};${g};${b}m  ${ESC}[49m`;
+}
+
+/** Swatch first, four slots, from the hexes already in the caller's line. */
+function brandLine(palette: string): string {
+  const slots = new Map<string, string>();
+  for (const entry of palette.replace(SGR, "").split(" · ")) {
+    const pair = PALETTE_ENTRY.exec(entry.trim());
+    if (pair !== null) slots.set(pair[1]!, pair[2]!);
+  }
+  const shown = BRAND_SLOTS
+    .filter((slot) => slots.has(slot))
+    .map((slot) => `${swatch(slots.get(slot)!)} ${slots.get(slot)!} ${slot}`);
+  return shown.length === 0 ? palette : shown.join("   ");
+}
+
 /** The exact-shape rules: one plain string in, one styled section out. */
 function renderNamed(raw: string, rail: Rail): boolean {
   const wired = WIRED.exec(raw);
@@ -270,8 +308,8 @@ function renderNamed(raw: string, rail: Rail): boolean {
   }
   const theme = THEME.exec(raw);
   if (theme !== null) {
-    rail.section(lilac("◆"), bold("Your brand"));
-    rail.body(theme[1]!);
+    rail.section(lilac("◆"), bold("Your brand, captured"));
+    rail.body(brandLine(theme[1]!));
     return true;
   }
   const syncTheme = SYNC_THEME.exec(raw);
@@ -353,6 +391,11 @@ function renderPaste(raw: string, state: RenderState, rail: Rail): void {
     return;
   }
   renderIndented(raw, state, rail);
+  // Under the snippet it explains, at the snippet's own indent.
+  if (raw.trimStart().startsWith(MOUNT_WRAP)) {
+    const indent = raw.length - raw.trimStart().length;
+    rail.body(`${" ".repeat(Math.max(0, indent - state.absorb))}${dim(MOUNT_DOCS)}`);
+  }
 }
 
 function renderRaw(raw: string, state: RenderState, rail: Rail): void {

--- a/packages/vendo/tests/cli/pretty.test.ts
+++ b/packages/vendo/tests/cli/pretty.test.ts
@@ -158,16 +158,48 @@ describe("createPrettyOutput (visual system)", () => {
     expect(plain).toContain("✦ VENDO_API_KEY present and well-formed.");
   });
 
-  it("renders the theme summary as the brand payoff block", () => {
+  it("renders the theme summary as the brand payoff block: four slots, swatch first", () => {
     const out = sink();
     const pretty = createPrettyOutput({ write: out.write, banner: false });
-    pretty.log("Theme: accent #2b7fff · background #fafafa");
-    pretty.log("Type: Inter · radius 8px");
+    pretty.log("Theme: accent #7c3bed · background #ffffff · surface #f8fafc · text #0f172a"
+      + " · mutedText #64748b · border #e2e8f0 · danger #dc2626");
+    pretty.log("Type: Inter · headings Sora · radius 12px");
     pretty.log("Theme lives in .vendo/theme.json — edit it anytime; it is the source of truth.");
     const plain = out.plain();
-    expect(plain).toContain("◆  Your brand");
-    expect(plain).toContain("│  accent #2b7fff · background #fafafa");
-    expect(plain).toContain("│  Type: Inter · radius 8px");
+    expect(plain).toContain("◆  Your brand, captured");
+    for (const slot of ["#7c3bed accent", "#ffffff background", "#0f172a text", "#dc2626 danger"]) {
+      expect(plain).toContain(slot);
+    }
+    expect(plain.indexOf("#7c3bed accent")).toBeLessThan(plain.indexOf("#dc2626 danger"));
+    expect(plain).toContain("│  Type: Inter · headings Sora · radius 12px");
+    // The caller still emits all seven — the block shows the four a person
+    // recognises as "our brand".
+    expect(plain).not.toContain("surface");
+    expect(plain).not.toContain("mutedText");
+    expect(plain).not.toContain("border");
+    // Each shown slot is a truecolor swatch, and it is the extracted colour.
+    expect(out.raw()).toContain(`${ESC}[48;2;124;59;237m  ${ESC}[49m #7c3bed accent`);
+    expect(out.raw()).toContain(`${ESC}[48;2;220;38;38m  ${ESC}[49m #dc2626 danger`);
+  });
+
+  /** The regression this rule exists for: init's own swatch() wrote a
+      truecolor escape whenever stdout was a TTY, which leaked under NO_COLOR.
+      The escape now lives behind usePrettyOutput, so the gate is the fix. */
+  it.each([
+    ["NO_COLOR on a TTY", { isTTY: true }, { NO_COLOR: "1" }],
+    ["CI on a TTY", { isTTY: true }, { CI: "true" }],
+    ["TERM=dumb on a TTY", { isTTY: true }, { TERM: "dumb" }],
+    ["piped stdout", { isTTY: false }, {}],
+  ] as const)("emits no escape at all for the brand block under %s", (_name, stream, env) => {
+    const out = sink();
+    // The real call site's shape (init.ts): the gate picks the renderer, and
+    // the plain path just writes the caller's string.
+    const message = "Theme: accent #7c3bed · background #ffffff · surface #f8fafc · text #0f172a"
+      + " · mutedText #64748b · border #e2e8f0 · danger #dc2626";
+    if (usePrettyOutput(stream, env)) createPrettyOutput({ write: out.write, banner: false }).log(message);
+    else out.write(`${message}\n`);
+    expect(out.raw()).not.toContain(ESC);
+    expect(out.raw()).toContain("accent #7c3bed");
   });
 
   it("collapses sync's five catalog lines into one ◆ Catalog block of two lines", () => {
@@ -223,6 +255,36 @@ describe("createPrettyOutput (visual system)", () => {
     expect(plain).toContain("│  init never edits your files");
     expect(plain).not.toContain(rule);
     expect(plain).not.toContain("ONE STEP LEFT");
+  });
+
+  it("points the mount paste at the docs for the child expression it elides", () => {
+    const out = sink();
+    const rule = "─".repeat(64);
+    const pretty = createPrettyOutput({ write: out.write, banner: false });
+    pretty.log(`\n${rule}`);
+    pretty.log("ONE STEP LEFT — paste this yourself (init never edits your files)");
+    pretty.log("\n  File: app/layout.tsx");
+    pretty.log("    import { VendoProvider } from \"@vendoai/vendo/react\";");
+    pretty.log("    … then wrap: <VendoProvider baseUrl=\"/api/vendo\" theme={theme as VendoTheme}>{children}</VendoProvider>");
+    pretty.log("\n  Without it, nothing on the page can reach Vendo.");
+    pretty.log(rule);
+    const plain = out.plain();
+    expect(plain).toContain("docs.vendo.run/quickstart#the-client-mount — exact wording for layout.tsx and _app.tsx");
+    // Right under the wrap line it explains, and dim.
+    expect(plain.indexOf("</VendoProvider>")).toBeLessThan(plain.indexOf("docs.vendo.run/quickstart"));
+    expect(out.raw()).toContain(`${ESC}[2mdocs.vendo.run/quickstart#the-client-mount`);
+  });
+
+  it("leaves a paste block with no mount snippet without the docs pointer", () => {
+    const out = sink();
+    const rule = "─".repeat(64);
+    const pretty = createPrettyOutput({ write: out.write, banner: false });
+    pretty.log(`\n${rule}`);
+    pretty.log("ONE STEP LEFT — paste this yourself (init never edits your files)");
+    pretty.log("\n  File: app/actions.ts");
+    pretty.log("    export const runtime = \"nodejs\";");
+    pretty.log(rule);
+    expect(out.plain()).not.toContain("docs.vendo.run/quickstart");
   });
 
   it("renders warnings yellow with ⚠ and other errors red with ✖", () => {


### PR DESCRIPTION
Two renderer rules the init/sync redesign still owed. Both are deliberately at the renderer layer, and each would break something if it lived in `init.ts`.

## A — the brand block

`◆ Your brand` becomes `◆ Your brand, captured`: four headline slots (accent, background, text, danger), each with a truecolor swatch drawn first, parsed out of the hexes already present in the plain `Theme:` line the caller emits.

**Why the caller still emits all seven.** That same line is what drives init's `No host evidence for …` report. Narrowing it to four would silently stop reporting neutral defaults for `surface`, `mutedText` and `border`. So the plain string keeps all seven; the renderer displays four.

**Why the swatch lives here and not in `init.ts`.** A swatch written by the caller is exactly the escape that leaked under `NO_COLOR` on a TTY — `init.ts`'s own `swatch()` gates on `stdout.isTTY` alone, which is still true when a user has asked for no colour. This renderer is only constructed when `usePrettyOutput()` is true, so putting the escape here is what fixes that leak for good.

## B — the paste block's docs link

The `◇ One paste left` block gains one dim line under the wrap snippet, at the snippet's own indent:

```
docs.vendo.run/quickstart#the-client-mount — exact wording for layout.tsx and _app.tsx
```

It is needed because the snippet is not blind-paste-complete: the child expression differs by router (`{children}` in an app-router `layout.tsx`, `<Component {...pageProps} />` in a pages `_app.tsx`). The anchor matches the real heading — `## The client mount` in `docs-site/quickstart.mdx:126`.

**Why it is the renderer's line.** init's `mount.lines` is pinned byte-for-byte by the `--agent` plan assertion at `packages/vendo/tests/cli/init.test.ts:1815`, a must-not-change test. Adding this line to `mount.lines` would change the `--agent` JSON and break the compatibility contract. Emitted from the renderer, `mount.lines` is untouched and the `--agent` JSON stays byte-identical — `init.ts:1285` gates the renderer on `options.agent !== true`, so this line can never reach the `--agent` path. It also fires only for the mount snippet, so an actions-only paste block never gets a client-mount pointer.

## The NO_COLOR no-escape test

The regression this change exists to prevent, as a table over the four degraded conditions, shaped like the real call site (the gate picks the renderer; the plain path just writes the caller's string):

```
✓ emits no escape at all for the brand block under NO_COLOR on a TTY
✓ emits no escape at all for the brand block under CI on a TTY
✓ emits no escape at all for the brand block under TERM=dumb on a TTY
✓ emits no escape at all for the brand block under piped stdout
```

`tests/cli/pretty.test.ts` — **48 tests passed**. The `describe("usePrettyOutput (selection)")` block is untouched.

## Gate

`flock /tmp/vendo-gate.lock … pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint` → **GATE_EXIT=0**

```
build      Tasks:    21 successful, 21 total     Time: 1m32.081s
test       Tasks:    31 successful, 31 total     Time: 25m31.956s
typecheck  Tasks:    42 successful, 42 total     Time: 48.021s
lint       Tasks:     4 successful,  4 total     Time: 38.308s

@vendoai/vendo:test:  Test Files  191 passed | 10 skipped (201)
demo-bank:test:       Test Files   25 passed (25)
demo-bank:lint: ✖ 4 problems (0 errors, 4 warnings)   # pre-existing warnings, no errors
```

The known `away-drill` contention flake did not appear — demo-bank's 25 test files all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the CLI pretty renderer: the brand block now shows four key colors with truecolor swatches, and the paste block adds a pointer to the client-mount docs. Swatch rendering moves into the renderer to honor NO_COLOR/CI and keep `--agent` JSON unchanged.

- New Features
  - Brand block: “Your brand, captured” showing accent, background, text, and danger with swatches parsed from the `Theme:` line. The caller still emits all seven slots.
  - Paste block: adds a dim line under the mount wrap snippet pointing to docs.vendo.run/quickstart#the-client-mount (only for mount snippets).

- Bug Fixes
  - Stops color escape leaks under NO_COLOR/CI/TERM=dumb/piped by gating swatches behind `usePrettyOutput()`.
  - Preserves `--agent` byte-identical output; the docs pointer is emitted only by the renderer.

<sup>Written for commit 570a5d2f3b2cbef5b70475f1fef75aa7c6ea4279. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

