### PR TITLE
feat(cli): sync adopts the renderer — spinners, a footer, and the theme fill it was throwing away

### DIFF
--- a/packages/vendo/src/cli/sync-flow.ts
+++ b/packages/vendo/src/cli/sync-flow.ts
@@ -73,8 +73,26 @@ export interface SyncFlowOptions {
   choose?: (question: string, options: SelectOption[], defaultIndex: number) => Promise<string>;
   judge?: Pick<JudgmentPassOptions,
     "harness" | "harnesses" | "resolveCredential" | "confirm" | "onProgress">;
+  /** The renderer's spinner, for the two phases that can hold the terminal for
+   *  minutes: extraction and the judgment pass. Absent (plain runs, CI, pipes)
+   *  → nothing spins and the printed lines stay exactly what they are today. */
+  spinner?: { spin: (label: string) => void; stopSpin: () => void };
   /** Test seam: the wall-clock budget for each Cloud reconcile. */
   baselineBudgetMs?: number;
+}
+
+/** A slow phase under the caller's spinner, when it supplied one. */
+async function withSpin<T>(
+  spinner: SyncFlowOptions["spinner"],
+  label: string,
+  run: () => Promise<T>,
+): Promise<T> {
+  spinner?.spin(label);
+  try {
+    return await run();
+  } finally {
+    spinner?.stopSpin();
+  }
 }
 
 export interface SyncFlowResult {
@@ -444,10 +462,15 @@ async function runGradingStages(input: {
   if (selection.skip) return { judged, themeDraft };
 
   // A one-time install narrates the slowest step it is about to take; an
-  // incremental sync stays as quiet as it is today.
-  if (mode === "full" && selection.engine !== undefined) {
-    output.log(`\nReading your product (${selection.engine.credential})…`);
-  }
+  // incremental sync stays as quiet as it is today. With a renderer attached
+  // that same narration becomes the spinner's label instead of a printed line.
+  const credential = selection.engine === undefined ? null : selection.engine.credential;
+  const narration = mode === "full" && credential !== null
+    ? `Reading your product (${credential})…`
+    : null;
+  if (narration !== null && options.spinner === undefined) output.log(`\n${narration}`);
+  const spinLabel = narration
+    ?? `Judging what moved…${credential === null ? "" : ` (${credential})`}`;
   try {
     // `--yes` means every question is already answered, so it must not reach
     // the aggregated loosening review either: an unattended run cannot
@@ -456,7 +479,7 @@ async function runGradingStages(input: {
     // nothing downstream can acquire a way to block.
     const attended = options.interactive && !options.yes;
     const loosenings = attended || options.review === true ? "review" : "queue";
-    const pass = await runJudgmentPass({
+    const pass = await withSpin(options.spinner, spinLabel, () => runJudgmentPass({
       root,
       out: vendoDir,
       mode,
@@ -471,7 +494,7 @@ async function runGradingStages(input: {
       ...(options.judge?.harnesses === undefined ? {} : { harnesses: options.judge.harnesses }),
       ...(options.judge?.resolveCredential === undefined ? {} : { resolveCredential: options.judge.resolveCredential }),
       ...(options.judge?.onProgress === undefined ? {} : { onProgress: options.judge.onProgress }),
-    });
+    }));
     // The pass already printed the count and `vendo sync --review`; say WHY
     // they were held, so an unattended caller doesn't read it as a refusal.
     if (loosenings === "queue" && pass.status === "judged" && pass.queued > 0) {
@@ -639,12 +662,16 @@ export async function runSyncFlow(options: SyncFlowOptions): Promise<SyncFlowRes
   // otherwise sync structural-only with no signal why (#567).
   const env = await readEnvFiles(root);
 
-  const report: SyncReportWithWarnings = await (options.sync ?? vendoSync)({
-    root,
-    out: vendoDir,
-    // The CLI needs the report to compute exit 2 vs 3; it applies strictness.
-    strict: false,
-  });
+  const report: SyncReportWithWarnings = await withSpin(
+    options.spinner,
+    "Re-reading your product…",
+    () => (options.sync ?? vendoSync)({
+      root,
+      out: vendoDir,
+      // The CLI needs the report to compute exit 2 vs 3; it applies strictness.
+      strict: false,
+    }),
+  );
   printSyncReport(report, output);
 
   const notes_ = { note, noteError };

--- a/packages/vendo/src/cli/sync.ts
+++ b/packages/vendo/src/cli/sync.ts
@@ -1,11 +1,13 @@
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
 import { stdin, stdout } from "node:process";
 import { vendoSync, type SyncReportWithWarnings } from "@vendoai/actions/sync";
 import type { ToolImpact } from "../sync-impact.js";
 import { pushSyncReport } from "./cloud/services.js";
 import type { JudgmentPassOptions } from "./judge/pass.js";
+import { createPrettyOutput, usePrettyOutput, type PrettyOutput } from "./pretty.js";
 import { runSyncFlow, type SyncFlowResult } from "./sync-flow.js";
-import { consoleOutput, invokedByPackageScript, withCommandRun, type Output, type TelemetryOptions } from "./shared.js";
+import { applyThemeDraft, toVendoTheme } from "./theme/extract-theme.js";
+import { consoleOutput, invokedByPackageScript, withCommandRun, writeText, type Output, type TelemetryOptions } from "./shared.js";
 
 export interface SyncReportPayload {
   report: SyncReportWithWarnings;
@@ -142,17 +144,61 @@ async function pushReport(
 }
 
 /**
+ * The theme fill `sync --full` used to pay for and throw away: full mode runs
+ * the prose stages, waits on the model to fill the still-open brand slots, and
+ * hands them back as `themeDraft`. `vendo init` consumes it (finalizeTheme);
+ * `vendo sync` never read it — computed, never written, never printed. Same
+ * two exports and the same merge law init uses, so there is one theme path.
+ */
+async function writeThemeDraft(root: string, flow: SyncFlowResult, output: Output): Promise<void> {
+  if (flow.themeSummary === null || flow.themeDraft === null) return;
+  const summary = applyThemeDraft(flow.themeSummary, flow.themeDraft);
+  // `(model)` is the provenance assembleTheme stamps on a slot the draft
+  // filled — an exact read is never overwritten, so this is exactly what the
+  // tokens bought.
+  const filled = Object.keys(summary.matched).filter((slot) => summary.matched[slot] === "(model)");
+  if (filled.length === 0) return;
+  await writeText(join(root, ".vendo", "theme.json"), `${JSON.stringify(toVendoTheme(summary.slots), null, 2)}\n`);
+  output.log(`theme: ${filled.length} slot${filled.length === 1 ? "" : "s"} filled by the AI pass (${filled.join(", ")}) → .vendo/theme.json`);
+}
+
+/** The footer's "what moved", read off the report this run just printed. The
+ *  footer REPORTS the outcome; it never decides it. */
+function whatMoved(flow: SyncFlowResult): string | undefined {
+  const moved: string[] = [];
+  const { added, removed, changed } = flow.report.tools;
+  if (added.length > 0) moved.push(`+${added.length} tool${added.length === 1 ? "" : "s"}`);
+  if (removed.length > 0) moved.push(`-${removed.length} tool${removed.length === 1 ? "" : "s"}`);
+  if (changed.length > 0) moved.push(`~${changed.length} changed`);
+  if ((flow.baselines?.pushed.length ?? 0) + (flow.components?.pushed.length ?? 0) > 0) {
+    moved.push("pushed to Cloud");
+  }
+  return moved.length === 0 ? undefined : moved.join(" · ");
+}
+
+/**
  * sync = the shared flow (sync-flow.ts) in "incremental" mode, plus the two
  * things that are the COMMAND's and not the flow's: the `--report` push and
  * the exit codes. Fail-soft on purpose — a sync problem must never break a
  * build — where `vendo init` runs the same flow in "full" mode and fails loud.
  */
 async function sync(options: SyncOptions): Promise<number> {
-  const output = options.output ?? consoleOutput;
   const json = options.json === true;
+  // The same renderer `vendo init` uses, over the same Output seam and the
+  // same gate: it restyles the exact plain strings below, and is selected only
+  // for a human terminal. `--json` owns its stdout byte-for-byte, an injected
+  // output is the caller's, and a package-script run (predev/prebuild) keeps
+  // today's output — that one is the most-seen sync output there is.
+  const pretty: PrettyOutput | null =
+    options.output === undefined && !json && !invokedByPackageScript() && usePrettyOutput()
+      ? createPrettyOutput({ command: "vendo sync" })
+      : null;
+  const output = options.output ?? pretty ?? consoleOutput;
+  const started = Date.now();
   // In --json mode, human lines that duplicate report fields are dropped and
   // CLI-level events collect into `notes`; stdout carries exactly one object.
   const notes: string[] = [];
+  const note = (message: string): void => { if (json) notes.push(message); else output.log(message); };
   const noteError = (message: string): void => { if (json) notes.push(message); else output.error(message); };
   try {
     const root = resolve(options.targetDir);
@@ -177,12 +223,18 @@ async function sync(options: SyncOptions): Promise<number> {
       ...(options.url === undefined ? {} : { url: options.url }),
       ...(options.sync === undefined ? {} : { sync: options.sync }),
       ...(options.fetchImpl === undefined ? {} : { fetchImpl: options.fetchImpl }),
-      ...(options.confirm === undefined ? {} : { confirm: options.confirm }),
+      ...(options.confirm === undefined
+        ? (pretty === null ? {} : { confirm: pretty.confirm })
+        : { confirm: options.confirm }),
+      ...(pretty === null
+        ? {}
+        : { choose: pretty.select, spinner: { spin: pretty.spin, stopSpin: pretty.stopSpin } }),
       ...(options.judge === undefined ? {} : { judge: options.judge }),
       ...(options.pushComponents === undefined ? {} : { pushComponents: options.pushComponents }),
       ...(options.baselineBudgetMs === undefined ? {} : { baselineBudgetMs: options.baselineBudgetMs }),
     });
     notes.push(...flow.notes);
+    await writeThemeDraft(root, flow, { log: note, error: noteError });
     const report = flow.report;
 
     const reportUnkeyed = options.report !== true
@@ -211,6 +263,7 @@ async function sync(options: SyncOptions): Promise<number> {
       };
       output.log(JSON.stringify(result, null, 2));
     }
+    pretty?.done(Date.now() - started, exitCode === 0, whatMoved(flow));
     return exitCode;
   } catch (error) {
     const message = `sync failed soft: ${error instanceof Error ? error.message : "unknown error"}`;
@@ -231,6 +284,7 @@ async function sync(options: SyncOptions): Promise<number> {
     } else {
       output.error(`warning: ${message}`);
     }
+    pretty?.done(Date.now() - started, exitCode === 0);
     return exitCode;
   }
 }

--- a/packages/vendo/tests/cli/sync-flow.test.ts
+++ b/packages/vendo/tests/cli/sync-flow.test.ts
@@ -169,6 +169,59 @@ describe("runSyncFlow", () => {
   });
 });
 
+/**
+ * The two phases that can hold a terminal for minutes — extraction and the
+ * judgment pass — get the caller's spinner when it has one. Full mode's
+ * "Reading your product (…)…" line is the SAME string either way: the label
+ * when a renderer is attached, the printed line when there is none.
+ */
+describe("the slow phases spin when the caller supplies one", () => {
+  const scripted = {
+    id: "scripted",
+    availability: async () => "a scripted engine",
+    run: async () => "```json\n" + JSON.stringify({ tools: [], narrative: "" }) + "\n```",
+  };
+
+  it("labels extraction and the judgment pass in both modes", async () => {
+    const seen: Record<string, { labels: string[]; stops: number; logs: string[] }> = {};
+    for (const mode of ["full", "incremental"] as const) {
+      const labels: string[] = [];
+      let stops = 0;
+      const { output, logs } = captureOutput();
+      await runSyncFlow({
+        root: await host(), output, mode, interactive: true, yes: false, sync: scan,
+        fetchImpl: offline,
+        confirm: async () => true,
+        judge: { harnesses: [scripted] },
+        spinner: { spin: (label) => labels.push(label), stopSpin: () => { stops += 1; } },
+      });
+      seen[mode] = { labels, stops, logs };
+    }
+    expect(seen.full!.labels).toEqual([
+      "Re-reading your product…",
+      "Reading your product (a scripted engine)…",
+    ]);
+    expect(seen.full!.stops).toBe(2);
+    // The line became the label; it is not ALSO printed.
+    expect(seen.full!.logs.join("\n")).not.toContain("Reading your product");
+    expect(seen.incremental!.labels).toEqual([
+      "Re-reading your product…",
+      "Judging what moved… (a scripted engine)",
+    ]);
+  });
+
+  it("without a spinner full mode prints exactly the line it prints today", async () => {
+    const { output, logs } = captureOutput();
+    await runSyncFlow({
+      root: await host(), output, mode: "full", interactive: true, yes: false, sync: scan,
+      fetchImpl: offline,
+      confirm: async () => true,
+      judge: { harnesses: [scripted] },
+    });
+    expect(logs).toContain("\nReading your product (a scripted engine)…");
+  });
+});
+
 describe("the AI flag matrix (one rule, both modes)", () => {
   it("interactive with no flag ASKS, every run — nothing is persisted", async () => {
     const dir = await host();

--- a/packages/vendo/tests/cli/sync.test.ts
+++ b/packages/vendo/tests/cli/sync.test.ts
@@ -936,3 +936,63 @@ describe("vendo sync wrapper coherence", () => {
     });
   });
 });
+
+/**
+ * `sync --full` runs the prose stages and pays the tokens and the wait for the
+ * model to fill the still-open brand slots — and then threw the result away:
+ * `vendo init` consumed `themeDraft`, `vendo sync` never read it. The seam is
+ * the point, so nothing here is stubbed on either side of it: the real flow
+ * runs the real theme stage and the real merge, and the assertion is the file
+ * on disk.
+ */
+describe("sync --full writes the theme fill it paid for", () => {
+  const offline = (async () => { throw new Error("offline"); }) as unknown as typeof fetch;
+  const dirs: string[] = [];
+  afterEach(async () => {
+    await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  async function host(): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), "vendo-sync-theme-"));
+    dirs.push(dir);
+    await mkdir(join(dir, ".vendo"), { recursive: true });
+    return dir;
+  }
+
+  it("merges the draft into .vendo/theme.json and names the slots it filled", async () => {
+    const root = await host();
+    const messages = captureOutput();
+    const stages: string[] = [];
+    const harness = {
+      id: "scripted",
+      availability: async () => "a scripted engine",
+      run: async (input: { instructions: string }) => {
+        const theme = input.instructions.includes("filling the theme's brand slots");
+        stages.push(theme ? "theme" : "judgment");
+        return "```json\n" + JSON.stringify(theme
+          ? { slots: { accent: "#112233", fontFamily: "Inter, sans-serif" } }
+          : { tools: [], narrative: "" }) + "\n```";
+      },
+    };
+
+    const exit = await runSync({
+      targetDir: root,
+      output: messages.output,
+      fetchImpl: offline,
+      sync: async () => report(),
+      full: true,
+      ai: true,
+      yes: true,
+      judge: { harnesses: [harness] },
+    });
+
+    expect(exit).toBe(0);
+    expect(stages).toContain("theme");
+    const written = JSON.parse(await readFile(join(root, ".vendo", "theme.json"), "utf8")) as {
+      colors: { accent: string }; typography: { fontFamily: string };
+    };
+    expect(written.colors.accent).toBe("#112233");
+    expect(written.typography.fontFamily).toBe("Inter, sans-serif");
+    expect(messages.logs.join("\n")).toContain("filled by the AI pass (accent, fontFamily)");
+  });
+});


### PR DESCRIPTION
`vendo sync` was 100% plain `console.log`: no rail, no colour, no spinner, and **no ending** — the last stage that ran was the last thing on screen, even when an AI pass had just held the terminal for minutes. It now creates the same renderer `vendo init` uses, over the same `Output` seam, so the exact plain strings it already emits get restyled. The renderer writes no copy of its own.

## What changed

- **It spins.** The two phases that can hold a terminal for minutes — extraction and the judgment pass — get a spinner through a new `spinner?: { spin, stopSpin }` seam on `SyncFlowOptions`, wired at exactly two call sites. Full mode's `Reading your product (…)…` becomes that spinner's **label**; with no spinner it stays exactly the line it is today.
- **It has an ending.** A footer with elapsed time and what moved. It **reports** the exit code; it never decides it.
- **Bug: `sync --full` paid for a theme fill and threw it away.** Full mode ran the prose stages, paid the tokens and the wait for the model to fill the still-open brand slots, and returned them as `themeDraft`. `vendo init` consumes it via `finalizeTheme`; `vendo sync` never read it — computed, never written to `theme.json`, never printed. It is now applied through `applyThemeDraft` + `toVendoTheme` — the *same two exports* init uses, so there is one theme path — written, and announced. This is also what makes the redesigned `◇ Theme` block truthful.

## Bug-4 fail-first proof

The new test is a real seam: the real flow runs the real theme stage and the real merge, and the assertion is the file on disk. Nothing is stubbed on either side.

**RED** — with the `writeThemeDraft` call reverted (`#2563eb` is the neutral default, i.e. the draft thrown away):

```
FAIL  tests/cli/sync.test.ts > sync --full writes the theme fill it paid for > merges the draft into .vendo/theme.json and names the slots it filled
AssertionError: expected '#2563eb' to be '#112233' // Object.is equality

Expected: "#112233"
Received: "#2563eb"

 ❯ tests/cli/sync.test.ts:994:35
```

**GREEN** — call restored:

```
 ✓ tests/cli/sync.test.ts (38 tests | 37 skipped) 77ms
 Test Files  1 passed (1)
      Tests  1 passed | 37 skipped (38)
```

## The recording

A real interactive `vendo sync` in a real PTY: real CLI, real extraction over a real project, real theme reconcile, real prompts, real judgment pass. Only the **model** is scripted (no model credential on the build box) and the impact endpoint is a stub implementing the documented wire contract. Everything on screen is the shipped renderer.

```
                ▄▄█████▄
   ████   ██████████████▄
   ████▄▄▄██▀▀▀▀█████████
       ███     ▄████████                                     ██
 ▄▄▄▄  ▀▀▀ ▄▄▄█████████     ██    ██ ▄██████▄ ██▄████▄ ▄████▄██ ▄██████▄
 ████      ███████████      ▀█▄  ▄█▀ ██▄▄▄▄██ ██    ██ ██    ██ ██    ██
       ███    ▀████████▄     ██  ██  ██▀▀▀▀▀▀ ██    ██ ██    ██ ██    ██
       ███  ▄▄▄█████████▄     ▀██▀    ▀████▀  ██    ██ ▀██████▀ ▀██████▀
           ██████████████
           ▀▀▀▀████████▀
                 ▀▀▀▀
 Customize your product with an embedded agent — docs.vendo.run
┌  vendo sync
│
⠙  Re-reading your product…
◆  Catalog
│  tools: +1 -0 ~1 · tool schemas: inputs 1/5 · outputs 0/5 — blind: host_accounts_list, … · pins: 0 captured, 0 drifted · catalog.json: 0 discovered, 0 registered
│  components: 0 captured, 0 updated
│
◇  Theme
│  1 slot re-read from your app (accent) → .vendo/theme.json
│
◇  Let your Claude Code login read this codebase to draft tool descriptions, review risk, write the product brief, and fill unresolved theme slots? Source goes to your model provider under your account.
│  Y/n › y
│  ● Yes
⠼  Judging what moved… (your Claude Code login)
│  judgment: 1 loosening needs a human decision
│    host_invoices_create
│      risk: destructive → read
│        "await db.invoices.create({ data: body, status: "draft" })"
│        creates a draft; nothing is sent until send() runs
│
◇  Apply 1 loosening across 1 tool to .vendo/judgments.json?
│  y/N › y
│  ● Yes
│
◆  Judgment
│  2 tools judged · hardened (3) · loosenings approved (1) · Invoice creation only ever writes a draft.
│  impact: host_invoices_create breaks 2 automations, 1 app, 3 grants
│  impact: host_invoices_list no saved references
│
└  Done in 10.3s — +1 tool · ~1 changed
```

The five always-printed catalog lines collapse to two, the theme line becomes `◇ Theme`, the judgment narrative becomes `◆ Judgment`, the loosening confirm keeps `y/N` (default **No** — a loosening that lands because someone hit Enter is not a human decision), and the run ends. GIF and asciicast: `/home/ubuntu/s4-artifacts/{sync.gif,sync.cast,transcript.txt}` on the build machine.

## The degradation contract, proven in a real TTY

`vendo sync --json` — zero ANSI bytes, stdout parses as exactly one object, stderr empty:

```
=== --json in a REAL TTY ===
has ANSI escape: False
stdout parses as exactly one object: ['ok', 'exitCode', 'report', 'impact', 'notes', 'theme', 'baselines', 'components']
```

A `predev` run in a real TTY — no banner, no rail, today's bytes:

```
=== predev (package script) in a REAL TTY ===
has ANSI escape: False
tools: +1 -0 ~1
tool schemas: inputs 1/5 · outputs 0/5 — blind: …
pins: 0 captured, 0 drifted
catalog.json: 0 discovered, 0 registered
components: 0 captured, 0 updated
theme: 1 slot re-read from your app (accent) → .vendo/theme.json
AI polish (descriptions, risk review, brief, theme): off (--no-ai) — extractor defaults stand.
impact: host_invoices_create breaks 2 automations, 1 app, 3 grants
```

**Why the pretty gate carries `!invokedByPackageScript()`**: npm inherits the terminal, so a `predev`/`prebuild` hook has a real TTY. Without that condition the most-seen sync output in the world would grow a rail; with it, it is byte-for-byte what it is today.

**Known difference from the design mock**: the mock draws a `◇ Impact` section. The renderer has no impact rule, so `impact:` lines ride the rail as plain body lines under `◆ Judgment` (visible above). That is the intended shipped behaviour here, not a bug — adding the rule would be renderer-authored copy.

## Untouched

`--json` (one object on stdout, every human line in `notes[]`), exit codes 0/1/2/3, the AI-consent wording, `predev`/`prebuild` non-interactivity and their hook strings, and non-TTY/piped output. No pinned test was edited.

## Results

Scoped suites on the pushed tree (`sync`, `sync-flow`, `sync-flow.unattended`, `telemetry-exit`):

```
 ✓ tests/cli/sync.test.ts (38 tests)
 ✓ tests/cli/sync-flow.test.ts (38 tests)
 ✓ tests/cli/sync-flow.unattended.test.ts (3 tests)
 ✓ tests/cli/telemetry-exit.test.ts (1 test)
 Test Files  4 passed (4)
      Tests  80 passed (80)
```

`pnpm --filter @vendoai/vendo typecheck`: **exit 0** across all three tsconfigs.

Full local gate (`pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint`) run twice. **This package is green in both** — the second run reports `Test Files 192 passed | 10 skipped (202)` / `Tests 2140 passed | 42 skipped (2182)` for `@vendoai/vendo`, zero failures.

### One known flake, outside this slice

The second gate exited 1 on a single out-of-fence failure, `demo-bank`'s `tests/vendo/away-drill.test.ts`:

```
Error: Hook timed out in 240000ms.
 ❯ tests/vendo/away-drill.test.ts:334:1
     334| beforeAll(async () => {
     335|   const port = await freePort();
```

It is a server-boot `beforeAll` competing with 2110 concurrently running tests. Evidence that it is box contention and not a regression:

| run | result |
| --- | --- |
| gate 1, same four files | `✓ away-drill.test.ts (4 tests) 46997ms` |
| gate 2, under load | `Hook timed out in 240000ms` — all 4 tests skipped |
| isolated, quiet box | `✓ away-drill.test.ts (4 tests) 25455ms` — exit 0 |

`CLAUDE.md` names this exact shape: a wall-clock budget tighter than the machine's real speed reports a product bug when the box is merely busy. This slice touches no `demo-bank` file, and the flake is tracked separately as a repo-health item — deliberately not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`vendo sync` now uses the same renderer as `vendo init`, adding spinners for long steps and a clear footer. Full mode also writes the theme fill it computed to `.vendo/theme.json`.

- **New Features**
  - Adopted the pretty renderer over the existing `Output` seam; restyles existing messages only.
  - Added spinners for extraction and judgment via a new `spinner` option on `SyncFlowOptions`.
  - Added a footer with elapsed time and a short “what moved” summary; it reports the exit code but does not decide it.
  - Pretty mode only in real TTYs and not for package scripts; `--json` output remains a single object with no ANSI.

- **Bug Fixes**
  - `sync --full` now applies `themeDraft` using `applyThemeDraft` + `toVendoTheme`, writes `.vendo/theme.json`, and reports which slots were filled.

<sup>Written for commit 23a68f3755001ca2696e10619e4a7543cbf1b9df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

