### PR TITLE
feat(cli): init asks the five questions — use case, models select, BYO paste, base URL, live check

### DIFF
--- a/docs-site/connect/knowledge.mdx
+++ b/docs-site/connect/knowledge.mdx
@@ -42,9 +42,8 @@ pass instead of guessing a layout.
   <Step title="Get a key">
     ```bash
     npx vendo login
-    #   1. Open https://console.vendo.run/claim?code=BCDF-GHJK
-    #   2. Confirm the code: BCDF-GHJK
-    # Approved — wrote VENDO_API_KEY (…a1b2) to .env.local.
+    # Opening your browser — approve the code BCDF-GHJK there…
+    # Approved — VENDO_API_KEY saved to .env.local (…a1b2)
     ```
 
     You approve the code in the browser and the minted key is written to

--- a/docs-site/deploy/vendo-cloud.mdx
+++ b/docs-site/deploy/vendo-cloud.mdx
@@ -45,9 +45,8 @@ approve the code while signed in to the console, and the minted
 
 ```bash
 vendo login
-#   1. Open https://console.vendo.run/claim?code=BCDF-GHJK
-#   2. Confirm the code: BCDF-GHJK
-# Approved — wrote VENDO_API_KEY (…a1b2) to .env.local.
+# Opening your browser — approve the code BCDF-GHJK there…
+# Approved — VENDO_API_KEY saved to .env.local (…a1b2)
 ```
 
 `vendo cloud device-login` is the same command, kept as an alias.

--- a/docs-site/quickstart.mdx
+++ b/docs-site/quickstart.mdx
@@ -21,6 +21,13 @@ npm install @vendoai/vendo
 npx vendo init
 ```
 
+Init asks five questions, and the last one is a single Enter to decline: how
+people will use your agent (embedded, your own agent loop, or MCP), whether
+the agent acts as your signed-in user, how models run, whether an AI pass may
+read your source, and where this will deploy. Every one has a flag answer, so
+an unattended run never needs a prompt — `--use-case`, `--auth`, `--cloud-key`
+/ `--byo`, `--ai` / `--no-ai`, and `--base-url`.
+
 <Note>
   Right after a Vendo release, package managers with a release cooldown hold
   the new version back. pnpm 11 (`minimumReleaseAge`, one day by default)
@@ -126,14 +133,23 @@ runtime (Node 20 or later); non-Next wiring is
 ## The client mount
 
 Init never writes a client file: it prints one paste, naming your layout file
-and the exact lines.
+and the exact lines. The wrapped child differs by router — this page carries
+both, which is why the terminal block links here.
 
 ```tsx
-// app/layout.tsx
+// app/layout.tsx — App Router
 import { VendoProvider } from "@vendoai/vendo/react";
 
 // then wrap the app:
 <VendoProvider baseUrl="/api/vendo">{children}</VendoProvider>
+```
+
+```tsx
+// pages/_app.tsx — Pages Router
+import { VendoProvider } from "@vendoai/vendo/react";
+
+// then wrap the app:
+<VendoProvider baseUrl="/api/vendo"><Component {...pageProps} /></VendoProvider>
 ```
 
 `baseUrl` is where the wire is mounted, path prefix included — a deployment

--- a/packages/vendo/src/cli.ts
+++ b/packages/vendo/src/cli.ts
@@ -38,6 +38,11 @@ Options:
   --cloud-key <key>          Init only: write this Vendo Cloud key to .env.local instead of the login offer
   --wait <seconds>           Login only: bound this call's polling to N seconds (agents loop re-runs; each resumes the same request), then exit resumably
   --byo                      Init only: decline the Vendo Cloud offer (bring your own model key)
+  --use-case <name>          Init only: how people will use the agent (embedded, agent-loop, mcp)
+  --base-url <url>           Init only: this deployment's public URL — written to .env.example, never .env.local
+  --posture <name>           Init only, --use-case mcp: how outside agents sign in (local, broker)
+  --service-key              Init only, --use-case mcp: set up a machine-to-machine service key
+  --check / --no-check       Init only: run vendo doctor at the end (offered only when no paste is outstanding)
   --ai                       Init/sync: run the AI judgment pass without asking (works non-interactively)
   --engine <name>            Init/sync: pin the AI engine (claude, codex, npx) instead of first-available
   --theme <slot=value>       Init only: override a theme slot value directly (repeatable)
@@ -75,12 +80,17 @@ function options(args: string[], name: string): string[] {
 /** `--ai`/`--no-ai` is the canonical pair on BOTH init and sync (decision 2).
     `--ai-polish` (init) and `--no-watermark` (sync) are the documented older
     spellings and stay accepted so pinned scripts and hooks keep working. */
-const INIT_FLAGS = new Set(["--agent", "--yes", "--force", "--byo", "--ai", "--ai-polish", "--no-ai"]);
-const INIT_VALUE_OPTIONS = ["--auth", "--framework", "--cloud-key", "--theme", "--engine"];
+const INIT_FLAGS = new Set([
+  "--agent", "--yes", "--force", "--byo", "--ai", "--ai-polish", "--no-ai",
+  "--service-key", "--check", "--no-check",
+]);
+const INIT_VALUE_OPTIONS = ["--auth", "--framework", "--cloud-key", "--theme", "--engine", "--use-case", "--base-url", "--posture"];
 /** Agent-install-dx: every init wizard question has a value-flag answer; a
     bad value fails as loudly as an unknown flag, with the valid choices. */
 const INIT_AUTH_VALUES = ["authJs", "clerk", "supabase", "auth0", "jwt", "none"];
 const INIT_FRAMEWORK_VALUES = ["next", "express", "custom"];
+const INIT_USE_CASE_VALUES = ["embedded", "agent-loop", "mcp"];
+const INIT_POSTURE_VALUES = ["local", "broker"];
 /** The user-facing engine families (judge/engine.ts's ENGINE_FAMILIES values) —
     one ladder, so `init --engine` and `sync --engine` accept the same names. */
 const ENGINE_VALUES = ["claude", "codex", "npx"];
@@ -121,7 +131,8 @@ function optionErrors(args: string[], flags: Set<string>, valueOptions: string[]
 function target(args: string[]): string {
   const optionValues = new Set<string>();
   for (const name of ["--url", "--key", "--api-url", "--apply",
-    "--auth", "--framework", "--cloud-key", "--theme", "--engine"]) {
+    "--auth", "--framework", "--cloud-key", "--theme", "--engine",
+    "--use-case", "--base-url", "--posture"]) {
     for (let index = 0; index < args.length; index += 1) {
       if (args[index] === name && args[index + 1] !== undefined) optionValues.add(args[index + 1]!);
     }
@@ -176,6 +187,27 @@ async function initCommand(args: string[]): Promise<number> {
   if (badTheme !== undefined) {
     problems.push(`--theme takes slot=value (example: vendo init --theme accent=#7c3bed), got ${JSON.stringify(badTheme)}`);
   }
+  const useCase = option(args, "--use-case");
+  if (useCase !== undefined && !INIT_USE_CASE_VALUES.includes(useCase)) {
+    problems.push(`--use-case must be one of ${INIT_USE_CASE_VALUES.join(", ")} (example: vendo init --use-case mcp)`);
+  }
+  const baseUrl = option(args, "--base-url");
+  if (baseUrl !== undefined && !/^https?:\/\/\S+$/.test(baseUrl)) {
+    problems.push(`--base-url must be this deployment's full public URL (example: vendo init --base-url https://app.acme.com), got ${JSON.stringify(baseUrl)}`);
+  }
+  const posture = option(args, "--posture");
+  if (posture !== undefined && !INIT_POSTURE_VALUES.includes(posture)) {
+    problems.push(`--posture must be local or broker (example: vendo init --use-case mcp --posture broker)`);
+  }
+  // Both answers belong to questions only the MCP path asks — silently
+  // ignoring them would leave an operator believing they took effect.
+  const serviceKey = args.includes("--service-key");
+  if ((posture !== undefined || serviceKey) && useCase !== "mcp") {
+    problems.push(`${posture === undefined ? "--service-key" : "--posture"} only applies to --use-case mcp (pass --use-case mcp, or drop it)`);
+  }
+  if (args.includes("--check") && args.includes("--no-check")) {
+    problems.push("--check and --no-check answer the same question — pass one or the other");
+  }
   if (problems.length > 0) {
     console.error(`vendo init: ${problems.join("; ")}\n\n${HELP}`);
     return 1;
@@ -191,6 +223,11 @@ async function initCommand(args: string[]): Promise<number> {
     ...(args.includes("--byo") ? { byo: true } : {}),
     ...(initAi ? { ai: true } : args.includes("--no-ai") ? { ai: false } : {}),
     ...(engine === undefined ? {} : { engine }),
+    ...(useCase === undefined ? {} : { useCase: useCase as InitOptions["useCase"] }),
+    ...(baseUrl === undefined ? {} : { baseUrl }),
+    ...(posture === undefined ? {} : { posture: posture as InitOptions["posture"] }),
+    ...(serviceKey ? { serviceKey: true } : {}),
+    ...(args.includes("--check") ? { check: true } : args.includes("--no-check") ? { check: false } : {}),
     ...(themePairs.length === 0 ? {} : {
       themeAnswers: Object.fromEntries(themePairs.map((pair) => {
         const at = pair.indexOf("=");

--- a/packages/vendo/src/cli/cloud-init.ts
+++ b/packages/vendo/src/cli/cloud-init.ts
@@ -2,9 +2,10 @@ import { execFile, type ExecFileException } from "node:child_process";
 import { realpath } from "node:fs/promises";
 import { stdin, stdout } from "node:process";
 import { dirname, join, relative, resolve } from "node:path";
-import type { DevCredential } from "../dev-creds/resolve.js";
+import { ENV_KEY_VARS, type DevCredential } from "../dev-creds/resolve.js";
 import { runDeviceLogin } from "./cloud/device-login.js";
 import { cloudDoctor, type CloudDoctorResult } from "./doctor-live.js";
+import type { SelectOption } from "./pretty.js";
 import {
   askYesNo,
   cloudProjectProps,
@@ -28,8 +29,9 @@ import {
 
 /** Upsert one NAME=value line in .env.local without clobbering other lines.
     Exported for init's --cloud-key flag, which lands a supplied key exactly
-    where the mint below would. Every caller follows the write with
-    `warnEnvLocalNotIgnored` — a secret just landed on disk. */
+    where the mint below would, and for the bring-your-own-key paste. Every
+    caller follows the write with `ensureEnvLocalIgnored` — a secret just
+    landed on disk. */
 export async function upsertEnvLocal(root: string, name: string, value: string): Promise<void> {
   const path = join(root, ".env.local");
   const current = (await readOptional(path)) ?? "";
@@ -40,11 +42,17 @@ export async function upsertEnvLocal(root: string, name: string, value: string):
     : `${current}${current === "" || current.endsWith("\n") ? "" : "\n"}${line}\n`);
 }
 
-/** One loud line when the file we just wrote a secret into would be committed.
-    Never blocks the write (the key is already minted and unrecoverable) — the
-    dev needs to know, not to be stopped. Three honest outcomes, each with the
-    remediation that actually works for it. */
-export async function warnEnvLocalNotIgnored(root: string, output: Output): Promise<void> {
+/** What git says about the .env.local a secret just landed in. */
+type EnvLocalState =
+  /** Ignored, or outside a work tree — nothing to leak into. */
+  | { kind: "safe" }
+  /** Not ignored and not tracked: one line in .gitignore fixes it. */
+  | { kind: "add"; name: string }
+  /** Already in the index — .gitignore alone will not stop the next commit. */
+  | { kind: "tracked"; name: string }
+  | { kind: "unknown"; name: string; reason: string };
+
+async function envLocalState(root: string): Promise<EnvLocalState> {
   // The write follows symlinks, so the file git must be asked about is the REAL
   // one: a .env.local that is itself gitignored can point straight at a tracked
   // file, and asking about the link would call that safe. Both sides resolved,
@@ -56,23 +64,66 @@ export async function warnEnvLocalNotIgnored(root: string, output: Output): Prom
   const file = await realpath(link).catch(() => link);
   const name = relative(await realpath(root).catch(() => root), file);
   const where = dirname(file);
-  if (!(await insideWorkTree(where))) return;
+  if (!(await insideWorkTree(where))) return { kind: "safe" };
 
   const verdict = await gitCheckIgnore(where, file);
-  if (verdict.kind === "ignored") return;
-  if (verdict.kind === "unknown") {
-    output.error(`warning: ${name} holds a secret and git could not say whether it is ignored (${verdict.reason}) — check it yourself before you commit.`);
-    return;
-  }
+  if (verdict.kind === "ignored") return { kind: "safe" };
+  if (verdict.kind === "unknown") return { kind: "unknown", name, reason: verdict.reason };
   // check-ignore answers from the patterns alone, so it calls a TRACKED file
   // "not ignored" even when a pattern matches it — and a file already in the
   // index commits no matter what .gitignore says. Only `git rm --cached` undoes
   // that, so the index is what decides between the two remedies.
-  if (await gitTracks(where, file)) {
-    output.error(`warning: ${name} holds a secret and is TRACKED by git — .gitignore alone will NOT stop the next commit: run \`git rm --cached ${name}\`, then add \`${name}\` to .gitignore.`);
-    return;
+  if (await gitTracks(where, file)) return { kind: "tracked", name };
+  return { kind: "add", name };
+}
+
+function reportEnvLocalRisk(state: EnvLocalState, output: Output): void {
+  if (state.kind === "unknown") {
+    output.error(`warning: ${state.name} holds a secret and git could not say whether it is ignored (${state.reason}) — check it yourself before you commit.`);
+  } else if (state.kind === "tracked") {
+    output.error(`warning: ${state.name} holds a secret and is TRACKED by git — .gitignore alone will NOT stop the next commit: run \`git rm --cached ${state.name}\`, then add \`${state.name}\` to .gitignore.`);
   }
-  output.error(`warning: ${name} holds a secret and is NOT gitignored — add \`${name}\` to .gitignore before you commit.`);
+}
+
+/** One loud line when the file we just wrote a secret into would be committed.
+    Never blocks the write (the key is already minted and unrecoverable) — the
+    dev needs to know, not to be stopped. Three honest outcomes, each with the
+    remediation that actually works for it. Kept for `vendo login`, which
+    writes the key from OUTSIDE an install and so has no mandate to edit the
+    repo's .gitignore; init uses `ensureEnvLocalIgnored` instead. */
+export async function warnEnvLocalNotIgnored(root: string, output: Output): Promise<void> {
+  const state = await envLocalState(root);
+  reportEnvLocalRisk(state, output);
+  if (state.kind === "add") {
+    output.error(`warning: ${state.name} holds a secret and is NOT gitignored — add \`${state.name}\` to .gitignore before you commit.`);
+  }
+}
+
+/** init's version: a secret in an unignored, UNTRACKED file is a one-line fix
+    init can simply make, so it makes it and says so. The tracked case is the
+    one branch init must not silently fix — .gitignore does nothing for a file
+    already in the index — so it keeps the warning, verbatim. Returns the line
+    added, or null when nothing was written. */
+export async function ensureEnvLocalIgnored(root: string, output: Output): Promise<string | null> {
+  const state = await envLocalState(root);
+  reportEnvLocalRisk(state, output);
+  if (state.kind !== "add") return null;
+  const path = join(root, ".gitignore");
+  const current = (await readOptional(path)) ?? "";
+  await writeText(path, `${current}${current === "" || current.endsWith("\n") ? "" : "\n"}${state.name}\n`);
+  output.log(`Added ${state.name} to .gitignore`);
+  return state.name;
+}
+
+/** Which variable a pasted provider key belongs in, read off the key's own
+    prefix. null means "cannot tell" — ask, never guess: a key in the wrong
+    variable fails at the first turn as a provider mismatch, not a bad key. */
+export function providerKeyVar(key: string): string | null {
+  const value = key.trim();
+  if (value.startsWith("sk-ant-")) return "ANTHROPIC_API_KEY";
+  if (value.startsWith("sk-")) return "OPENAI_API_KEY";
+  if (value.startsWith("AIza")) return "GOOGLE_GENERATIVE_AI_API_KEY";
+  return null;
 }
 
 /** Is this path inside a git working tree? Answered by walking up for a `.git`
@@ -152,8 +203,17 @@ export interface CloudStepOptions {
   apiUrl?: string;
   /** Fetch seam for the default ceremony (tests script the console with it). */
   fetchImpl?: typeof fetch;
+  /** How models run, answered up front instead of asked (--cloud-key ⇒
+      "cloud", --byo ⇒ "byo"). */
+  models?: ModelsAnswer;
   /** Seams (tests). */
   confirm?: (question: string, defaultYes?: boolean) => Promise<boolean>;
+  /** The models question as a select — Cloud first and recommended, BYO one
+      keystroke away, "decide later" the graceful exit. Absent (plain
+      terminals, tests) keeps today's confirm. */
+  select?: (question: string, options: SelectOption[]) => Promise<string>;
+  /** The masked prompt behind "bring my own key". */
+  askSecret?: (question: string, hint?: string) => Promise<string>;
   cloudProbe?: (options: { env?: Record<string, string | undefined> }) => Promise<CloudDoctorResult>;
   /** The whole ceremony in one seam (default: runDeviceLogin). */
   deviceLogin?: () => Promise<number>;
@@ -166,7 +226,21 @@ export interface CloudStepResult {
   keyPresent: boolean;
   keyValid: boolean;
   wroteEnvLocal: boolean;
+  /** The provider variable a bring-your-own-key paste landed in this run —
+      re-merged by the caller exactly like a minted VENDO_API_KEY, so THIS
+      run's model passes already benefit from the key just pasted. */
+  wroteKeyVar?: string;
 }
+
+/** The three answers to "how do you want to run models?". */
+export type ModelsAnswer = "cloud" | "byo" | "later";
+
+const MODELS_QUESTION = "How do you want to run models?";
+const MODELS_OPTIONS: SelectOption[] = [
+  { value: "cloud", label: "Vendo Cloud — free key in ~30s", hint: "recommended" },
+  { value: "byo", label: "Bring my own key (ANTHROPIC_API_KEY / OPENAI_API_KEY / GOOGLE_…)" },
+  { value: "later", label: "Decide later" },
+];
 
 /** init's cloud step (design §6). Never changes init's exit code. Tracked as
     `command_run` command "cloud-init" (TELEMETRY.md): ok is "the step ended
@@ -223,6 +297,16 @@ async function cloudStep(options: CloudStepOptions, failure: { failedStep?: stri
 
   // A starter model key only helps when the local ladder has nothing better.
   const laddersWantKey = credential.rung === "none" || credential.rung === "vendo-cloud";
+  const tty = options.isTty ?? (stdin.isTTY === true && stdout.isTTY === true);
+  const answered = options.models ?? (options.byo === true ? "byo" : undefined);
+
+  // Bring-your-own with no key in the environment: the branch that settles
+  // itself instead of assigning homework. Only where a human can actually
+  // paste — unattended runs keep the one-line pointer below.
+  if (answered === "byo" && laddersWantKey && tty && options.askSecret !== undefined) {
+    return pasteProviderKey(options, options.askSecret);
+  }
+
   if (options.yes || options.byo === true || !laddersWantKey) {
     if (laddersWantKey) {
       if (options.byo === true) {
@@ -236,9 +320,15 @@ async function cloudStep(options: CloudStepOptions, failure: { failedStep?: stri
     return { keyPresent: false, keyValid: false, wroteEnvLocal: false };
   }
 
-  const tty = options.isTty ?? (stdin.isTTY === true && stdout.isTTY === true);
   const confirm = options.confirm ?? askYesNo;
-  if (!(await confirm("Log in to Vendo Cloud now for a free API key (starter model allowance included)?", false))) {
+  const chosen: ModelsAnswer = answered
+    ?? (options.select === undefined
+      ? (await confirm("Log in to Vendo Cloud now for a free API key (starter model allowance included)?", false) ? "cloud" : "later")
+      : (await options.select(MODELS_QUESTION, MODELS_OPTIONS)) as ModelsAnswer);
+  if (chosen === "byo" && options.askSecret !== undefined) {
+    return pasteProviderKey(options, options.askSecret);
+  }
+  if (chosen !== "cloud") {
     if (tty) {
       output.log("Skipped — run `vendo login` any time; the key lands in .env.local.");
     } else {
@@ -248,6 +338,12 @@ async function cloudStep(options: CloudStepOptions, failure: { failedStep?: stri
     }
     return { keyPresent: false, keyValid: false, wroteEnvLocal: false };
   }
+
+  // The key is about to land in .env.local, so make the file safe to hold a
+  // secret BEFORE it holds one: one consented line instead of a wall of
+  // yellow after the fact. Doing it here also keeps the ceremony's own
+  // after-the-write check silent, so the run reports the fix once.
+  await ensureEnvLocalIgnored(root, output);
 
   // The `vendo login` ceremony end to end: approve a code in the browser
   // (TTY opens it), and the minted key lands in .env.local — init picks it
@@ -269,6 +365,35 @@ async function cloudStep(options: CloudStepOptions, failure: { failedStep?: stri
     output.error("Vendo Cloud login did not complete; run `vendo login` and re-run `vendo init`.");
     return { keyPresent: false, keyValid: false, wroteEnvLocal: false };
   }
-  output.log("Production always needs a real server-side key.");
   return { keyPresent: true, keyValid: true, wroteEnvLocal: true };
+}
+
+/** "Bring my own key", answered at the moment the user has already decided,
+    with the key on their clipboard: paste it, land it in .env.local through
+    the same generic writer the mint uses, and report only the last four
+    characters. An unrecognisable prefix asks which variable rather than
+    guessing one. */
+async function pasteProviderKey(
+  options: CloudStepOptions,
+  askSecret: NonNullable<CloudStepOptions["askSecret"]>,
+): Promise<CloudStepResult> {
+  const { root, output } = options;
+  const key = (await askSecret(
+    "Paste your key (ANTHROPIC_API_KEY / OPENAI_API_KEY / GOOGLE_…) — lands in .env.local, never committed:",
+  )).trim();
+  if (key === "") {
+    output.log("Run `vendo login` to claim a free API key; it lands in .env.local.");
+    return { keyPresent: false, keyValid: false, wroteEnvLocal: false };
+  }
+  const detected = providerKeyVar(key);
+  const name = detected ?? (options.select === undefined
+    ? ENV_KEY_VARS[0]!.envVar
+    : await options.select(
+      "Which variable is that key for?",
+      ENV_KEY_VARS.map(({ envVar, provider }) => ({ value: envVar, label: envVar, hint: provider })),
+    ));
+  await upsertEnvLocal(root, name, key);
+  output.log(`${name} saved to .env.local (…${key.slice(-4)})`);
+  await ensureEnvLocalIgnored(root, output);
+  return { keyPresent: false, keyValid: false, wroteEnvLocal: false, wroteKeyVar: name };
 }

--- a/packages/vendo/src/cli/cloud-init.ts
+++ b/packages/vendo/src/cli/cloud-init.ts
@@ -309,12 +309,18 @@ async function cloudStep(options: CloudStepOptions, failure: { failedStep?: stri
     return { keyPresent: false, keyValid: false, wroteEnvLocal: false };
   }
 
+  // The select is for a terminal a human is actually watching — pretty or
+  // not. The non-TTY guard stops it PROMPTING, but it does not stop it
+  // answering: its silent fallback is the first option, and the first option
+  // is Cloud, so an unattended run would start a device login nobody asked
+  // for. The confirm's default is No, which is the answer an unshown question
+  // must have, so a non-TTY run keeps taking it.
   const confirm = options.confirm ?? askYesNo;
   const chosen: ModelsAnswer = answered
-    ?? (options.select === undefined
+    ?? (options.select === undefined || !tty
       ? (await confirm("Log in to Vendo Cloud now for a free API key (starter model allowance included)?", false) ? "cloud" : "later")
       : (await options.select(MODELS_QUESTION, MODELS_OPTIONS)) as ModelsAnswer);
-  if (chosen === "byo" && options.askSecret !== undefined) {
+  if (chosen === "byo" && tty && options.askSecret !== undefined) {
     return pasteProviderKey(options, options.askSecret);
   }
   if (chosen !== "cloud") {

--- a/packages/vendo/src/cli/cloud-init.ts
+++ b/packages/vendo/src/cli/cloud-init.ts
@@ -85,25 +85,14 @@ function reportEnvLocalRisk(state: EnvLocalState, output: Output): void {
   }
 }
 
-/** One loud line when the file we just wrote a secret into would be committed.
-    Never blocks the write (the key is already minted and unrecoverable) — the
-    dev needs to know, not to be stopped. Three honest outcomes, each with the
-    remediation that actually works for it. Kept for `vendo login`, which
-    writes the key from OUTSIDE an install and so has no mandate to edit the
-    repo's .gitignore; init uses `ensureEnvLocalIgnored` instead. */
-export async function warnEnvLocalNotIgnored(root: string, output: Output): Promise<void> {
-  const state = await envLocalState(root);
-  reportEnvLocalRisk(state, output);
-  if (state.kind === "add") {
-    output.error(`warning: ${state.name} holds a secret and is NOT gitignored — add \`${state.name}\` to .gitignore before you commit.`);
-  }
-}
-
-/** init's version: a secret in an unignored, UNTRACKED file is a one-line fix
-    init can simply make, so it makes it and says so. The tracked case is the
-    one branch init must not silently fix — .gitignore does nothing for a file
-    already in the index — so it keeps the warning, verbatim. Returns the line
-    added, or null when nothing was written. */
+/** The single answer to "we just wrote a secret to disk". A secret in an
+    unignored, UNTRACKED file is a one-line fix, so it gets made and reported
+    instead of turned into homework. The tracked case is the one branch that
+    must not be silently "fixed" — .gitignore does nothing for a file already
+    in the index — so it keeps its warning, verbatim, and so does the case
+    where git cannot answer at all. Never blocks the write: the key is already
+    minted and unrecoverable, so the dev needs to know, not to be stopped.
+    Returns the line added, or null when nothing was written. */
 export async function ensureEnvLocalIgnored(root: string, output: Output): Promise<string | null> {
   const state = await envLocalState(root);
   reportEnvLocalRisk(state, output);

--- a/packages/vendo/src/cli/cloud/device-login.ts
+++ b/packages/vendo/src/cli/cloud/device-login.ts
@@ -6,7 +6,7 @@ import { isVendoKey, resolveCloudBaseUrl } from "./client.js";
 import { errorMessage, printJson } from "./output.js";
 import { deletePendingClaim, readPendingClaim, writePendingClaim } from "./pending-claim.js";
 import { writeCloudSession, type CloudSession } from "./session.js";
-import { upsertEnvLocal, warnEnvLocalNotIgnored } from "../cloud-init.js";
+import { ensureEnvLocalIgnored, upsertEnvLocal } from "../cloud-init.js";
 import { browserOpenCommand, CLI_VERSION, consoleOutput, withCommandRun, type Output, type TelemetryOptions } from "../shared.js";
 
 /**
@@ -22,6 +22,9 @@ import { browserOpenCommand, CLI_VERSION, consoleOutput, withCommandRun, type Ou
  * the console-envelope-shaped cloudFetch would flatten to http-400 — so this
  * command talks to both endpoints with a raw (injectable) fetch instead.
  */
+
+/** How long the ceremony may run before it explains itself (see noteStall). */
+const STALL_MS = 20_000;
 
 const CLAIM_PATH = "/api/v1/agent/claim";
 const TOKEN_PATH = "/api/v1/oauth/token";
@@ -225,7 +228,6 @@ export async function runDeviceLogin(
     let verificationUriComplete: string;
     if (resume !== null) {
       output.log(`Resuming pending approval — code ${resume.user_code}, approve at ${resume.verification_uri_complete}`);
-      output.log(`Waiting for approval (the code expires in ${Math.max(1, Math.round((resume.expires_at - now()) / 60_000))} minutes)…`);
       claimToken = resume.claim_token;
       deadline = resume.expires_at;
       intervalMs = Math.max(resume.interval, 1) * 1000;
@@ -255,15 +257,18 @@ export async function runDeviceLogin(
       const ceremony = ceremonyFrom(claim.body);
 
       const approvalUrl = ceremony.verification_uri_complete ?? ceremony.verification_uri;
-      output.log("Vendo Cloud device login — ask your human to approve this request:");
-      output.log(`  1. Open ${approvalUrl}`);
-      output.log(`  2. Confirm the code: ${ceremony.user_code}`);
       const tty = options.isTty ?? (process.stdout.isTTY === true);
       if (tty) {
-        output.log("Opening your browser… (approve there, then come back here)");
+        // One line. The browser is already opening, so the code IS the whole
+        // instruction; the URL is not lost — the stall notice below carries it
+        // as the recovery path if the browser never came up.
+        output.log(`Opening your browser — approve the code ${ceremony.user_code} there…`);
         (options.openBrowser ?? defaultOpenBrowser)(approvalUrl);
+      } else {
+        // The agent path: a human is being told what to do by proxy, so the
+        // URL and the code both have to be on screen.
+        output.log(`Vendo Cloud device login — approve the code ${ceremony.user_code} at ${approvalUrl}`);
       }
-      output.log(`Waiting for approval (the code expires in ${Math.round(ceremony.expires_in / 60)} minutes)…`);
 
       claimToken = ceremony.claim_token;
       deadline = now() + ceremony.expires_in * 1000;
@@ -284,6 +289,21 @@ export async function runDeviceLogin(
         cwd: root,
       }, pendingHome);
     }
+
+    // The expiry sentence used to lead the wait, where it is pure noise — an
+    // approval that lands in ten seconds never needed it. It arrives when it
+    // becomes relevant instead: once, after the ceremony has visibly stalled,
+    // carrying the URL as the recovery path a TTY run no longer prints up top.
+    const ceremonyStarted = now();
+    let stallNoted = false;
+    const noteStall = (): void => {
+      if (stallNoted || now() - ceremonyStarted < STALL_MS) return;
+      stallNoted = true;
+      output.log(
+        `Still waiting — the code expires in ${Math.max(1, Math.round((deadline - now()) / 60_000))} minutes. `
+        + `Approve at ${verificationUriComplete}`,
+      );
+    };
 
     const pollBody = new URLSearchParams({
       grant_type: CLAIM_GRANT_TYPE,
@@ -343,9 +363,9 @@ export async function runDeviceLogin(
         }
         // Never print the key itself — .env.local is the hand-off, last4 the
         // receipt. A resumed run names the full path: it may differ from cwd.
-        output.log(`Approved — wrote VENDO_API_KEY (…${key.slice(-4)}) to ${
-          resume !== null ? join(root, ".env.local") : ".env.local"}.`);
-        await warnEnvLocalNotIgnored(root, output);
+        output.log(`Approved — VENDO_API_KEY saved to ${
+          resume !== null ? join(root, ".env.local") : ".env.local"} (…${key.slice(-4)})`);
+        await ensureEnvLocalIgnored(root, output);
         if (options.rerunHint !== false) {
           output.log("Re-run `vendo init` to finish wiring (it picks the key up from .env.local).");
         }
@@ -398,6 +418,7 @@ export async function runDeviceLogin(
         const result = await pollOnce();
         if (result === "approved") return 0;
         if (result === "slow_down") intervalMs += 5000;
+        noteStall();
       }
       await deletePendingClaim(claimCwd, pendingHome);
       throw new Error("The code expired before it was approved; run `vendo login` again.");
@@ -410,6 +431,7 @@ export async function runDeviceLogin(
       const result = await pollOnce();
       if (result === "approved") return 0;
       if (result === "slow_down") intervalMs += 5000;
+      noteStall();
       if (now() >= deadline) {
         await deletePendingClaim(claimCwd, pendingHome);
         throw new Error("The code expired before it was approved; run `vendo login` again.");

--- a/packages/vendo/src/cli/doctor-live.ts
+++ b/packages/vendo/src/cli/doctor-live.ts
@@ -157,12 +157,16 @@ async function readTurnStream(
  * ------------------------------------------------------------------------ */
 
 /** Human-facing list of what a Cloud key unlocks over OSS single-player. Shown
- *  whether or not a key is present, so a keyless dev sees the offer. */
+ *  whether or not a key is present, so a keyless dev sees the offer.
+ *
+ *  Two bullets, not four. SSO/roles, registry publishing and the adapter-slot
+ *  list are all true and all irrelevant to a person forty seconds into their
+ *  first install; they belong in the console, not the ceremony. Neither line
+ *  may contain "; " — that is the separator every caller joins and the
+ *  renderer splits on. */
 export const CLOUD_UNLOCKS: readonly string[] = [
-  "a free starter model allowance (keyless first turns)",
-  "team sharing and org governance (roles, SSO)",
-  "hosted deploys of your enabled automations",
-  "registry publishing, and hosted defaults for the adapter slots you leave unset (managed inference, the sandbox pool, the hosted store, the connections broker)",
+  "a free API key — starter model allowance, no card",
+  "hosted automations, sharing, and the console",
 ];
 
 export interface CloudDoctorResult {

--- a/packages/vendo/src/cli/init-auth.ts
+++ b/packages/vendo/src/cli/init-auth.ts
@@ -168,8 +168,12 @@ export async function resolveScaffoldAuth(
     return { wired: detection.wired, advice: authAdvisory(detection, compositionPath) };
   }
   if (detection.wired !== null) {
+    // The mechanism (`wire auth: clerk()`) is what happens; what is being
+    // DECIDED is whether the agent acts as the person at the keyboard or as a
+    // stand-in. Same default, same picker fall-through — the question just
+    // says what it means. The scaffold comment carries the mechanism.
     const accepted = await confirmAuth(
-      `Detected ${detection.wired.dependency} — wire auth: ${detection.wired.preset}()?`,
+      `Should the agent act as your signed-in ${AUTH_FAMILY_INFO[detection.wired.preset].name} user?`,
       true,
     );
     if (accepted) return { wired: detection.wired, advice: null };

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -806,24 +806,37 @@ async function planMcpScaffold(input: {
     cloudKey,
     posture,
     serviceKey,
-    ...(baseUrl === null ? {} : { baseUrl }),
+    // Not optional: a null base URL is an ANSWER the plan reads, and it is
+    // what makes steps[] lead with the recoverable version of E-MCP-009's
+    // failure instead of assuming an origin.
+    baseUrl,
   });
   if (mcp.blocked !== undefined) {
+    // Nothing MCP was written and the reason says what to do about it. The
+    // rest of the install stands — this is an advisory, not a failure.
     output.error(`warning: ${mcp.blocked}`);
     return null;
   }
-  // The composition init is already CREATING becomes the MCP one — same file,
-  // mcp: true — and the origin-root discovery route joins the change set. A
-  // composition init did not write this run is left alone, as always.
-  const composition = changes.find((change) => change.before === null && change.path.endsWith("route.ts"));
-  if (composition !== undefined) {
-    composition.after = mcp.routeSource;
-    composition.diff = diff(composition.path, null, mcp.routeSource);
+  // The route init is already CREATING becomes the MCP one — same file, the
+  // thin body over the composition module. The planner cannot know whether
+  // that file exists, so it hands back the source and the caller pushes it
+  // with the `before` it already read; a route init did not write this run
+  // has no planned change here and is left alone, as always.
+  const route = changes.find((change) => change.before === null && change.path.endsWith(`${sep}route.ts`));
+  if (route !== undefined && mcp.routeSource !== null) {
+    route.after = mcp.routeSource;
+    route.diff = diff(route.path, null, mcp.routeSource);
   }
+  // The composition module and the origin-root discovery route are both new.
   for (const change of mcp.changes) {
     if (changes.some((planned) => planned.absolute === change.absolute)) continue;
-    const path = relative(root, change.absolute);
-    changes.push({ absolute: change.absolute, path, before: null, after: change.after, diff: diff(path, null, change.after) });
+    changes.push({
+      absolute: change.absolute,
+      path: change.path,
+      before: null,
+      after: change.after,
+      diff: diff(change.path, null, change.after),
+    });
   }
   if (mcp.serviceKeyValue !== undefined) {
     await upsertEnvLocal(root, "VENDO_SERVICE_KEY", mcp.serviceKeyValue);
@@ -1388,7 +1401,11 @@ async function resolveModelCredential(input: {
     select: pretty === null ? plainSelect : pretty.select,
     askSecret: pretty === null ? plainSecret : pretty.secret,
     ...(pretty === null ? {} : { confirm: pretty.confirm }),
-    ...(options.cloudKey !== undefined ? { models: "cloud" as const } : {}),
+    // --byo is an ANSWER to the models question, so it rides `models`.
+    // --cloud-key is not: it lands the key in .env.local before this step
+    // runs, so the probe finds it and the question never gets asked. Passing
+    // "cloud" here instead would send a run that ALREADY HAS a key into the
+    // mint ceremony — a live device login for a key the user just supplied.
     ...(options.byo === true ? { models: "byo" as const } : {}),
     ...(options.cloud ?? {}),
   });
@@ -1544,6 +1561,83 @@ async function ensureHostDeps(input: {
   });
 }
 
+/** The run's ending, as its own phase — the same reason wireAndScaffold and
+ *  resolveModelCredential are their own functions. The last question, then
+ *  everything still the user's to paste, then the live check on the runs that
+ *  owe nothing, and finally the stats the footer carries. Returns those stats;
+ *  it never decides the exit code. */
+async function finishRun(input: {
+  root: string;
+  options: InitOptions;
+  output: Output;
+  pretty: PrettyOutput | null;
+  interactive: boolean;
+  useCase: InitUseCase;
+  mcp: ReturnType<typeof planMcp> | null;
+  mount: ManualEdit | null;
+  edits: ManualEdit[];
+  manualSteps: string[];
+  credential: DevCredential;
+  cloud: { keyValid: boolean };
+  compositionPath: string | null;
+  framework: Exclude<HostFramework, "unknown"> | "custom";
+  authWired: AuthMatch | null;
+  layout: LayoutWiring;
+  toolCount: number;
+  brandCaptured: boolean;
+}): Promise<string> {
+  const {
+    root, options, output, pretty, interactive, useCase, mcp, mount, edits, manualSteps,
+    credential, cloud, compositionPath, framework, authWired, layout, toolCount, brandCaptured,
+  } = input;
+
+  // Where will this deploy? — every path but MCP, which needed the answer
+  // before it wrote. One Enter declines and the placeholder stands. The answer
+  // is written to .env.example inside, so there is nothing to read back here.
+  if (useCase !== "mcp") await captureBaseUrl({ root, options, output, pretty, interactive });
+
+  // Variant B: the wired route stays (it serves apps and approvals to the
+  // embeds) — what is added is the one snippet for their own loop.
+  const handSteps = [
+    ...(mount === null ? [] : [mount]),
+    ...edits,
+    ...(useCase === "agent-loop" ? await agentLoopSteps(root) : []),
+  ];
+  printClosingSteps({ output, handSteps, manualSteps, credential, cloud, compositionPath });
+  if (mcp !== null) {
+    const lines = [...mcp.steps, ...mcp.envLines];
+    if (pretty === null) for (const line of lines) output.log(`  ${line}`);
+    else pretty.block("Steps that are yours", lines, "◇");
+  }
+
+  // The live check offers itself ONLY when nothing is left to paste: doctor
+  // grades the paste, and the paste happens after init exits.
+  const checkPassed = handSteps.length === 0
+    && await offerLiveCheck({ root, options, output, pretty, interactive });
+
+  // Agent tail (agent-install-dx): the --yes-or-non-TTY path is agent-driven
+  // — the run's FINAL block is the repo-specific pointers an agent parses.
+  // Interactive human runs keep the clack-style output untouched; --agent
+  // never reaches here (its read-only JSON plan returned above).
+  if (options.yes === true || !interactive) {
+    output.log("\nAgent tail:");
+    const tail = await agentTailLines({ root, framework, compositionPath, authWired, layout, edits, cloudKeyMissing: credential.rung === "none" });
+    for (const line of tail) output.log(`  ${line}`);
+  }
+  // The run's LAST word is the outstanding paste (self-serve audit F5: the
+  // one step that matters used to scroll off-screen). The frame itself stays
+  // up-screen — the agent tail's "the lines above" pointers depend on that
+  // order — so the closer is a one-line echo of it, not a second copy. A human
+  // terminal has the paste block six lines up and legible, and gets the count
+  // in the footer instead.
+  if (handSteps.length > 0 && pretty === null) {
+    output.log(handSteps.length === 1
+      ? `\n→ Don't forget the paste in ${handSteps[0]!.file} (frame above)`
+      : `\n→ Don't forget the ${handSteps.length} pastes above (frame above)`);
+  }
+  return runStats({ toolCount, brandCaptured, handSteps: handSteps.length, checkPassed });
+}
+
 export async function runInit(options: InitOptions): Promise<number> {
   // The clack-style renderer rides the SAME Output seam: it restyles the
   // exact plain messages below, and is selected only for a human terminal
@@ -1620,10 +1714,9 @@ export async function runInit(options: InitOptions): Promise<number> {
     // extra answers change the composition's own source, so that path needs
     // all three BEFORE it writes. Every other path asks the URL at the end,
     // where it is one Enter to decline.
-    let baseUrl: string | null = null;
     let mcp: ReturnType<typeof planMcp> | null = null;
     if (useCase === "mcp") {
-      baseUrl = await captureBaseUrl({ root, options, output, pretty, interactive });
+      const baseUrl = await captureBaseUrl({ root, options, output, pretty, interactive });
       mcp = await planMcpScaffold({
         root, options, output, pretty, interactive, changes, baseUrl,
         framework: plan.framework, authWired, cloudKey: cloud.keyValid,
@@ -1718,55 +1811,15 @@ export async function runInit(options: InitOptions): Promise<number> {
       output.error(`warning: installed ai@${aiVersion} is unsupported — Vendo supports ai@6; downgrade (npm install ai@^6 @ai-sdk/anthropic@^3 @ai-sdk/react@^3) or track github.com/runvendo/vendo/issues/478`);
     }
 
-    // Where will this deploy? — every path but MCP, which needed the answer
-    // before it wrote. One Enter declines and the placeholder stands.
-    if (useCase !== "mcp") baseUrl = await captureBaseUrl({ root, options, output, pretty, interactive });
-
-    // Variant B: the wired route stays (it serves apps and approvals to the
-    // embeds) — what is added is the one snippet for their own loop.
-    const handSteps = [
-      ...(mount === null ? [] : [mount]),
-      ...edits,
-      ...(useCase === "agent-loop" ? await agentLoopSteps(root) : []),
-    ];
-    printClosingSteps({ output, handSteps, manualSteps, credential, cloud, compositionPath });
-    if (mcp !== null) {
-      const lines = [...mcp.steps, ...mcp.envLines];
-      if (pretty === null) for (const line of lines) output.log(`  ${line}`);
-      else pretty.block("Steps that are yours", lines, "◇");
-    }
-
-    // The live check offers itself ONLY when nothing is left to paste: doctor
-    // grades the paste, and the paste happens after init exits.
-    const checkPassed = handSteps.length === 0
-      && await offerLiveCheck({ root, options, output, pretty, interactive });
-
-    // Agent tail (agent-install-dx): the --yes-or-non-TTY path is agent-driven
-    // — the run's FINAL block is the repo-specific pointers an agent parses.
-    // Interactive human runs keep the clack-style output untouched; --agent
-    // never reaches here (its read-only JSON plan returned above).
-    if (options.yes === true || !interactive) {
-      output.log("\nAgent tail:");
-      const tail = await agentTailLines({ root, framework: plan.framework, compositionPath, authWired, layout, edits, cloudKeyMissing: credential.rung === "none" });
-      for (const line of tail) output.log(`  ${line}`);
-    }
-    // The run's LAST word is the outstanding paste (self-serve audit F5: the
-    // one step that matters used to scroll off-screen). The frame itself
-    // stays up-screen — the agent tail's "the lines above" pointers depend on
-    // that order — so the closer is a one-line echo of it, not a second copy.
-    // A human terminal has the paste block six lines up and legible, and gets
-    // the count in the footer instead.
-    if (handSteps.length > 0 && pretty === null) {
-      output.log(handSteps.length === 1
-        ? `\n→ Don't forget the paste in ${handSteps[0]!.file} (frame above)`
-        : `\n→ Don't forget the ${handSteps.length} pastes above (frame above)`);
-    }
-    pretty?.done(Date.now() - started, true, runStats({
-      toolCount,
-      brandCaptured: themeSummary !== null,
-      handSteps: handSteps.length,
-      checkPassed,
-    }));
+    // Called on its OWN line, never inside `pretty?.done(…)`: optional
+    // chaining short-circuits its arguments, so a null `pretty` — every
+    // non-TTY run — would skip the entire ending without a trace.
+    const stats = await finishRun({
+      root, options, output, pretty, interactive, useCase, mcp, mount, edits, manualSteps,
+      credential, cloud, compositionPath, framework: plan.framework, authWired, layout,
+      toolCount, brandCaptured: themeSummary !== null,
+    });
+    pretty?.done(Date.now() - started, true, stats);
     return 0;
   } catch (error) {
     await telemetry.track("init_failed", {

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -37,7 +37,7 @@ import {
   serverActionsWiring,
   VENDO_ENV_EXAMPLE,
 } from "./init-scaffolds.js";
-import { createPrettyOutput, plainSelect, plainText, usePrettyOutput, type PrettyOutput, type SelectOption } from "./pretty.js";
+import { createPrettyOutput, plainSecret, plainSelect, plainText, usePrettyOutput, type PrettyOutput, type SelectOption } from "./pretty.js";
 import { contrastingText } from "./theme/color.js";
 import {
   applyThemeDraft,
@@ -1446,9 +1446,14 @@ async function resolveModelCredential(input: {
     env: effectiveEnv,
     // The step's own command_run row rides init's telemetry seams.
     ...(options.telemetry === undefined ? {} : { telemetry: options.telemetry }),
-    // A human terminal answers the models question as a select and can paste
-    // a provider key inline; a plain one keeps today's confirm.
-    ...(pretty === null ? {} : { confirm: pretty.confirm, select: pretty.select, askSecret: pretty.secret }),
+    // The models select and the bring-your-own paste belong to every human
+    // terminal, not just a colourful one: NO_COLOR is a normal thing for a
+    // developer to set, and a question that only exists in pretty mode is a
+    // feature that disappears for them. The plain pair carries plainSelect's
+    // non-TTY guard, and cloud-init only reaches for either on a real TTY.
+    select: pretty === null ? plainSelect : pretty.select,
+    askSecret: pretty === null ? plainSecret : pretty.secret,
+    ...(pretty === null ? {} : { confirm: pretty.confirm }),
     ...(options.cloudKey !== undefined ? { models: "cloud" as const } : {}),
     ...(options.byo === true ? { models: "byo" as const } : {}),
     ...(options.cloud ?? {}),

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -240,39 +240,15 @@ export interface InitOptions {
 
 const THEME_PALETTE_SLOTS = ["accent", "background", "surface", "text", "mutedText", "border", "danger"] as const;
 
-/** The four slots a person recognises as "our brand". Surface, mutedText and
-    border are still captured and still written — they are just not what the
-    payoff shot of the install is for. */
-const BRAND_SLOTS = ["accent", "background", "text", "danger"] as const;
-
-/** ANSI truecolor swatch, PRETTY-ONLY: usePrettyOutput already excludes
-    NO_COLOR / CI / TERM=dumb, so the escape can only reach a terminal that
-    asked for colour. The old TTY-only gate leaked it under NO_COLOR. */
-function brandSwatch(hex: string): string {
-  const match = /^#([0-9a-f]{6})$/i.exec(hex);
-  if (match === null) return "  ";
-  const [r, g, b] = [0, 2, 4].map((index) => parseInt(match[1]!.slice(index, index + 2), 16));
-  return `\u001b[48;2;${r};${g};${b}m  \u001b[0m`;
-}
-
 /** One-glance confirm (§B2): the extracted palette, where each slot came
     from is visible in defaulted/errors, and theme.json stays the editable
-    source of truth. A human terminal gets the payoff shot of the whole
-    install instead — the four brand slots, swatch first; every other run
-    keeps the plain lines byte for byte. */
-function printThemeSummary(summary: ThemeSummary, output: Output, pretty: PrettyOutput | null): void {
+    source of truth. One emission, plain — the renderer's `Theme:` rule turns
+    it into the ◆ block. Nothing here may carry colour: an ANSI swatch written
+    at this layer is exactly the escape that leaked under NO_COLOR. */
+function printThemeSummary(summary: ThemeSummary, output: Output): void {
   const headings = summary.slots.headingFamily === summary.slots.fontFamily
     ? ""
     : ` · headings ${summary.slots.headingFamily}`;
-  if (pretty !== null) {
-    pretty.block("Your brand, captured", [
-      BRAND_SLOTS.map((slot) => `${brandSwatch(summary.slots[slot])} ${summary.slots[slot]} ${slot}`).join("   "),
-      `${summary.slots.fontFamily}${headings} · radius ${summary.slots.radius}`,
-      ".vendo/theme.json — yours to edit anytime",
-    ]);
-    for (const error of summary.errors) output.error(`warning: ${error}`);
-    return;
-  }
   const palette = THEME_PALETTE_SLOTS
     .map((slot) => `${slot} ${summary.slots[slot]}`)
     .join(" · ");
@@ -717,14 +693,14 @@ export function runStats(input: {
   brandCaptured: boolean;
   handSteps: number;
   checkPassed: boolean;
-}): string[] {
+}): string {
   return [
     `${input.toolCount} tool${input.toolCount === 1 ? "" : "s"}`,
     ...(input.brandCaptured ? ["brand captured"] : []),
     input.handSteps > 0
       ? `${input.handSteps} paste${input.handSteps === 1 ? "" : "s"} left`
       : input.checkPassed ? "agent live" : "wired",
-  ];
+  ].join(" · ");
 }
 
 /** Variant B — the user's own agent loop. Which snippet prints is read off
@@ -1240,9 +1216,8 @@ async function finalizeTheme(input: {
   themePath: string;
   options: InitOptions;
   output: Output;
-  pretty: PrettyOutput | null;
 }): Promise<void> {
-  const { themeSummary, themeDraft, themePath, options, output, pretty } = input;
+  const { themeSummary, themeDraft, themePath, options, output } = input;
   const summary = themeDraft === null ? themeSummary : applyThemeDraft(themeSummary, themeDraft);
   // --theme answers land first; the review prompt then covers only the
   // uncertain slots the flags left unanswered (non-interactive runs keep
@@ -1259,44 +1234,7 @@ async function finalizeTheme(input: {
   }
   if (Object.keys(answers).length > 0) applyThemeAnswers(summary, answers, output);
   await writeText(themePath, `${JSON.stringify(toVendoTheme(summary.slots), null, 2)}\n`);
-  printThemeSummary(summary, output, pretty);
-}
-
-/** The per-router mount wording the terminal snippet cannot carry: the child
-    expression genuinely differs ({children} in app/layout.tsx, <Component
-    {...pageProps} /> in a pages-only _app.tsx), so one literal would be wrong
-    for half of hosts. */
-const DOCS_MOUNT = "docs.vendo.run/quickstart#the-client-mount";
-
-/** The same closing steps for a human terminal: on the rail as a ◇ section
-    rather than inside two 64-dash rules that break it, the code indented so
-    it reads as code, and "init never edits your files" demoted from a shout
-    to the dim why-line under it. */
-function printPrettyClosingSteps(pretty: PrettyOutput, handSteps: ManualEdit[], manualSteps: string[]): void {
-  if (handSteps.length > 0) {
-    const numbered = handSteps.length > 1;
-    pretty.block(
-      handSteps.length === 1 ? `One paste left — ${handSteps[0]!.file}` : `${handSteps.length} pastes left`,
-      [
-        ...handSteps.flatMap((step, at) => [
-          ...(numbered ? [`${at + 1} · ${step.file}`] : []),
-          ...step.lines.map((line) => `  ${line}`),
-          // The child expression genuinely differs by router, so the mount
-          // snippet is not blind-paste-complete; the docs carry both.
-          ...(step.lines.some((line) => line.includes("VendoProvider")) ? [`  ${DOCS_MOUNT}`] : []),
-          `  ${step.why}`,
-          "",
-        ]),
-        "init never edits your files.",
-        "then: npx vendo doctor — verifies the paste and runs a live turn",
-      ],
-      "◇",
-    );
-    return;
-  }
-  // Express and custom hosts have no single host file to name, so their
-  // wiring keeps the compact list, restyled to match.
-  if (manualSteps.length > 0) pretty.block("Last steps are yours", manualSteps, "◇");
+  printThemeSummary(summary, output);
 }
 
 /** Done — the pastes init cannot take (it only ever CREATES files in your
@@ -1305,18 +1243,13 @@ function printPrettyClosingSteps(pretty: PrettyOutput, handSteps: ManualEdit[], 
  *  can see, or server-action tools that silently fail closed. */
 function printClosingSteps(input: {
   output: Output;
-  pretty: PrettyOutput | null;
   handSteps: ManualEdit[];
   manualSteps: string[];
   credential: DevCredential;
   cloud: { keyValid: boolean };
   compositionPath: string | null;
 }): void {
-  const { output, pretty, handSteps, manualSteps, credential, cloud, compositionPath } = input;
-  if (pretty !== null) {
-    printPrettyClosingSteps(pretty, handSteps, manualSteps);
-    return;
-  }
+  const { output, handSteps, manualSteps, credential, cloud, compositionPath } = input;
   if (handSteps.length > 0) {
     const rule = "─".repeat(64);
     output.log(`\n${rule}`);
@@ -1423,14 +1356,15 @@ async function resolveModelCredential(input: {
   }
   let credential = await (options.resolveCredential ?? resolveDevCredential)({ env: effectiveEnv });
   if (credential.rung === "env-key") {
-    // Their key is a decision already made, so there is no prompt either way
-    // — but a human terminal still learns the door exists, which the plain
-    // line never says.
-    if (pretty === null) {
-      output.log(`Model: ${describeDevCredential(credential)} — production uses this same key server-side.`);
-    } else {
-      output.log(`Models: your ${credential.envVar} · Vendo Cloud adds hosted automations + console — \`vendo login\` anytime`);
-    }
+    // Their key is a decision already made, so this stays a statement and
+    // never a prompt — but it now names the door. A BYO user used to finish
+    // init without learning Vendo Cloud exists at all, because the offer
+    // vanishes entirely on this branch. The renderer's CTA rule picks the
+    // command out; the copy is written once, here.
+    output.log(
+      `Model: ${describeDevCredential(credential)} — Vendo Cloud adds hosted automations + the console; `
+      + "run `vendo login` anytime.",
+    );
   }
   const cloud = await runCloudStep({
     root,
@@ -1733,7 +1667,7 @@ export async function runInit(options: InitOptions): Promise<number> {
     // finally the uncertain-slot review. Skipped entirely when theme.json
     // pre-existed this run (the flow reconciles that one instead).
     if (themeSummary !== null) {
-      await finalizeTheme({ themeSummary, themeDraft: flow.themeDraft, themePath, options, output, pretty });
+      await finalizeTheme({ themeSummary, themeDraft: flow.themeDraft, themePath, options, output });
     }
 
     // Judgment state, one line: a pass that ran already narrated itself (it
@@ -1795,7 +1729,7 @@ export async function runInit(options: InitOptions): Promise<number> {
       ...edits,
       ...(useCase === "agent-loop" ? await agentLoopSteps(root) : []),
     ];
-    printClosingSteps({ output, pretty, handSteps, manualSteps, credential, cloud, compositionPath });
+    printClosingSteps({ output, handSteps, manualSteps, credential, cloud, compositionPath });
     if (mcp !== null) {
       const lines = [...mcp.steps, ...mcp.envLines];
       if (pretty === null) for (const line of lines) output.log(`  ${line}`);

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -37,7 +37,7 @@ import {
   serverActionsWiring,
   VENDO_ENV_EXAMPLE,
 } from "./init-scaffolds.js";
-import { createPrettyOutput, plainSelect, usePrettyOutput, type PrettyOutput, type SelectOption } from "./pretty.js";
+import { createPrettyOutput, plainSelect, plainText, usePrettyOutput, type PrettyOutput, type SelectOption } from "./pretty.js";
 import { contrastingText } from "./theme/color.js";
 import {
   applyThemeDraft,
@@ -691,10 +691,14 @@ export async function captureBaseUrl(input: {
   interactive: boolean;
 }): Promise<string | null> {
   const { root, options, output, pretty, interactive } = input;
+  // plainText carries plainSelect's guard — a non-TTY input or output returns
+  // the fallback and never prompts — so a piped run stays byte-identical while
+  // a NO_COLOR terminal still gets the question. Making this pretty-only would
+  // silently delete the feature for anyone who sets NO_COLOR.
   const ask = options.baseUrl !== undefined
     ? async () => options.baseUrl!
     : options.askText
-      ?? (options.yes === true || !interactive || pretty === null ? undefined : pretty.text);
+      ?? (options.yes === true || !interactive ? undefined : (pretty === null ? plainText : pretty.text));
   if (ask === undefined) return null;
   const url = (await ask("Where will this deploy?", "e.g. https://app.acme.com — Enter to skip")).trim();
   if (url === "") return null;

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -1,4 +1,3 @@
-import { spawn } from "node:child_process";
 import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, relative, resolve, sep } from "node:path";
@@ -8,13 +7,23 @@ import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
 import { scrubErrorDetail, type Telemetry } from "@vendoai/telemetry";
 import { detectDepVersions, installedAiVersion } from "./dep-versions.js";
-import { AUTH_MD_URL, runCloudStep, upsertEnvLocal, warnEnvLocalNotIgnored, type CloudStepOptions } from "./cloud-init.js";
+import { AUTH_MD_URL, ensureEnvLocalIgnored, runCloudStep, upsertEnvLocal, type CloudStepOptions } from "./cloud-init.js";
+import { runDoctor } from "./doctor.js";
 import type { InitPolishSeam } from "./init-judgment.js";
+import { planMcp, type McpPosture } from "./init-mcp.js";
 import { runSyncFlow, type SyncFlowResult } from "./sync-flow.js";
 import { BRIEF_TEMPLATE } from "./extract/stages.js";
 import { ENV_KEY_VARS, resolveDevCredential, describeDevCredential, type DevCredential } from "../dev-creds/resolve.js";
 import { detectFramework, detectVendoWiring, workspaceHostCandidates, type HostFramework } from "./framework.js";
-import { resolveScaffoldAuth, type AuthMatch, type AuthPresetName, type ConfirmAuth, type SelectAuth } from "./init-auth.js";
+import {
+  AUTH_FAMILY_INFO,
+  detectAuthPreset,
+  resolveScaffoldAuth,
+  type AuthMatch,
+  type AuthPresetName,
+  type ConfirmAuth,
+  type SelectAuth,
+} from "./init-auth.js";
 import { ensureProviderDeps, ensureZodFloor, type InstallRunner } from "./provider-deps.js";
 import {
   customServerSource,
@@ -43,6 +52,7 @@ import {
   clientRoot,
   cloudProjectProps,
   consoleOutput,
+  detectPackageManager,
   envFileValueSync,
   errorClass,
   exists,
@@ -105,8 +115,18 @@ export interface ManualEdit {
   why: string;
 }
 
+/** How the host's people will reach the agent — the run's FIRST question. It
+    decides what gets scaffolded and how the run ends; the wired route is the
+    same in all three, so picking wrong costs nothing. */
+export type InitUseCase = "embedded" | "agent-loop" | "mcp";
+
+export const INIT_USE_CASES: readonly InitUseCase[] = ["embedded", "agent-loop", "mcp"];
+
 export interface InitPlan {
   framework: Exclude<HostFramework, "unknown"> | "custom";
+  /** --use-case only: absent on a run that never named one, so an unattended
+      plan stays byte-identical to the one agents parse today. */
+  useCase?: InitUseCase;
   root: string;
   writes: string[];
   codeChanges: Array<{ path: string; diff: string }>;
@@ -147,6 +167,22 @@ export interface InitOptions {
   cloudKey?: string;
   /** --byo: answer the cloud-login offer with "no — bring my own key". */
   byo?: boolean;
+  /** --use-case: answer the first question without asking. Unattended runs
+      take "embedded" — today's behaviour, so no existing script changes. */
+  useCase?: InitUseCase;
+  /** --base-url: answer "where will this deploy?" without asking. Written to
+      .env.example ONLY, by replacing init's own localhost placeholder — never
+      .env.local, where a production URL would repoint local dev's discovery,
+      callbacks and credential forwarding at the deployed origin. */
+  baseUrl?: string;
+  /** --posture: how outside agents sign in (MCP use case only). */
+  posture?: McpPosture;
+  /** --service-key: set up a machine-to-machine key (MCP use case only). */
+  serviceKey?: boolean;
+  /** --check / --no-check: run `vendo doctor` at the end. Only OFFERED when
+      the run owes no paste — doctor grades the paste, and the paste happens
+      after init exits. Never changes init's exit code either way. */
+  check?: boolean;
   /** --ai / --no-ai (`--ai-polish` is the legacy spelling of `--ai`): `true`
       runs the judgment pass with no prompt, `false` forces it off, and
       `undefined` asks in an interactive run and skips otherwise. No answer is
@@ -179,7 +215,8 @@ export interface InitOptions {
   extract?: InitPolishSeam;
   /** Test seam: the detect+confirm auth question, asked only in interactive
       runs when exactly one auth family is detected and init is creating the
-      composition. Mirrors the AI-polish consent's confirm shape. */
+      composition — and the MCP service-key confirm, which has the same shape.
+      Mirrors the AI-polish consent's confirm shape. */
   confirmAuth?: (question: string, defaultYes: boolean) => Promise<boolean>;
   /** Test seam: the auth picker shown when the confirm is declined or when
       several families are detected. Receives the choice list (value/label/
@@ -188,36 +225,58 @@ export interface InitOptions {
   /** Test seam: interactivity override for the auth confirm (default: TTY),
       mirroring the judgment step's `interactive`. */
   interactive?: boolean;
-  /** Test seam: the star ask — the ONE consent question that ends a fully
-      successful interactive run. Mirrors the auth confirm's shape. */
-  confirmStar?: (question: string, defaultYes: boolean) => Promise<boolean>;
-  /** Test seam: the gh spawn behind a "yes" to the star ask. */
-  spawnStar?: (command: string, args: string[]) => StarProcess;
+  /** Test seam: the use-case question, and the MCP posture select that hangs
+      off it. Mirrors the auth picker's shape. */
+  selectUseCase?: (question: string, options: SelectOption[]) => Promise<string>;
+  /** Test seam: the free-text asks (the base URL). "" is a decline. */
+  askText?: (question: string, hint?: string) => Promise<string>;
+  /** Test seam: the live-check offer. Mirrors the auth confirm's shape. */
+  confirmCheck?: (question: string, defaultYes: boolean) => Promise<boolean>;
+  /** Test seam: the live check itself (default: `vendo doctor`). */
+  runCheck?: (root: string) => Promise<boolean>;
   /** Uncertain-slot review — asked ONLY when the model reports uncertainty. */
   themeReview?: (summary: ThemeSummary) => Promise<Record<string, string>>;
 }
 
 const THEME_PALETTE_SLOTS = ["accent", "background", "surface", "text", "mutedText", "border", "danger"] as const;
 
-/** ANSI truecolor swatch when interactive; plain hex otherwise. */
-function swatch(hex: string): string {
+/** The four slots a person recognises as "our brand". Surface, mutedText and
+    border are still captured and still written — they are just not what the
+    payoff shot of the install is for. */
+const BRAND_SLOTS = ["accent", "background", "text", "danger"] as const;
+
+/** ANSI truecolor swatch, PRETTY-ONLY: usePrettyOutput already excludes
+    NO_COLOR / CI / TERM=dumb, so the escape can only reach a terminal that
+    asked for colour. The old TTY-only gate leaked it under NO_COLOR. */
+function brandSwatch(hex: string): string {
   const match = /^#([0-9a-f]{6})$/i.exec(hex);
-  if (!match || !stdout.isTTY) return "";
+  if (match === null) return "  ";
   const [r, g, b] = [0, 2, 4].map((index) => parseInt(match[1]!.slice(index, index + 2), 16));
-  return `\u001b[48;2;${r};${g};${b}m  \u001b[0m `;
+  return `\u001b[48;2;${r};${g};${b}m  \u001b[0m`;
 }
 
 /** One-glance confirm (§B2): the extracted palette, where each slot came
     from is visible in defaulted/errors, and theme.json stays the editable
-    source of truth. */
-function printThemeSummary(summary: ThemeSummary, output: Output): void {
-  const palette = THEME_PALETTE_SLOTS
-    .map((slot) => `${swatch(summary.slots[slot])}${slot} ${summary.slots[slot]}`)
-    .join(" · ");
-  output.log(`Theme: ${palette}`);
+    source of truth. A human terminal gets the payoff shot of the whole
+    install instead — the four brand slots, swatch first; every other run
+    keeps the plain lines byte for byte. */
+function printThemeSummary(summary: ThemeSummary, output: Output, pretty: PrettyOutput | null): void {
   const headings = summary.slots.headingFamily === summary.slots.fontFamily
     ? ""
     : ` · headings ${summary.slots.headingFamily}`;
+  if (pretty !== null) {
+    pretty.block("Your brand, captured", [
+      BRAND_SLOTS.map((slot) => `${brandSwatch(summary.slots[slot])} ${summary.slots[slot]} ${slot}`).join("   "),
+      `${summary.slots.fontFamily}${headings} · radius ${summary.slots.radius}`,
+      ".vendo/theme.json — yours to edit anytime",
+    ]);
+    for (const error of summary.errors) output.error(`warning: ${error}`);
+    return;
+  }
+  const palette = THEME_PALETTE_SLOTS
+    .map((slot) => `${slot} ${summary.slots[slot]}`)
+    .join(" · ");
+  output.log(`Theme: ${palette}`);
   output.log(`Type: ${summary.slots.fontFamily}${headings} · radius ${summary.slots.radius}`);
   const missing = summary.defaulted.filter((slot) =>
     (THEME_PALETTE_SLOTS as readonly string[]).includes(slot) || slot === "fontFamily");
@@ -244,6 +303,48 @@ async function defaultThemeReview(summary: ThemeSummary): Promise<Record<string,
     prompt.close();
   }
   return overrides;
+}
+
+/** The framework the run scaffolds for. "unknown" detection lands on the
+    runtime-neutral custom scaffold — the safe default that exists now
+    (guessing the Next layout into a Worker host was the field failure). */
+async function resolveFramework(
+  root: string,
+  options: InitOptions,
+): Promise<Exclude<HostFramework, "unknown"> | "custom"> {
+  const detected = options.framework ?? await detectFramework(root);
+  return detected === "unknown" ? "custom" : detected;
+}
+
+const FRAMEWORK_NAMES: Record<Exclude<HostFramework, "unknown"> | "custom", string> = {
+  next: "Next.js",
+  express: "Express",
+  custom: "Custom runtime",
+};
+
+/** The detection read-back, printed before the first question. Nothing here
+    is newly computed — framework, router style, language, package manager and
+    auth family are all detected today and none of them is ever shown, so the
+    first thing the user sees is a question about a package they were never
+    told we found. Print, never re-detect. */
+export async function stackLines(
+  root: string,
+  framework: Exclude<HostFramework, "unknown"> | "custom",
+): Promise<string[]> {
+  const router = await detectRouter(root, framework);
+  const auth = await detectAuthPreset(root);
+  return [
+    [
+      FRAMEWORK_NAMES[framework],
+      ...(router === "none" ? [] : [router === "app" ? "App Router" : "Pages Router"]),
+      await exists(join(root, "tsconfig.json")) ? "TypeScript" : "JavaScript",
+      await detectPackageManager(root),
+    ].join(" · "),
+    ...(auth.matches.length === 0 ? [] : [
+      `${auth.matches.map((match) => AUTH_FAMILY_INFO[match.preset].name).join(" / ")} auth `
+      + `(${auth.matches.map((match) => match.dependency).join(", ")})`,
+    ]),
+  ];
 }
 
 /** Telemetry `router` enum (init_completed): app | pages | none, from the
@@ -552,42 +653,243 @@ async function agentTailLines(args: {
   return lines;
 }
 
-/** The slice of the spawned gh process the star step observes (injectable —
-    tests drive it with a plain EventEmitter). */
-export interface StarProcess {
-  on(event: "error", listener: (error: Error) => void): unknown;
-  on(event: "exit", listener: (code: number | null) => void): unknown;
+const USE_CASE_OPTIONS: SelectOption[] = [
+  { value: "embedded", label: "Embedded in my app — chat + generated UI", hint: "recommended" },
+  { value: "agent-loop", label: "Through my own agent loop (AI SDK / Mastra)" },
+  { value: "mcp", label: "From outside agents over MCP — Claude, ChatGPT, Cursor, or any MCP agent (experimental)" },
+];
+
+/** The run's FIRST question. Every path shares the same wired route, so a
+    wrong pick costs nothing; the right one saves a docs round trip. --yes and
+    non-interactive runs take "embedded" — today's behaviour, so no existing
+    script changes shape. */
+async function resolveUseCase(input: {
+  options: InitOptions;
+  pretty: PrettyOutput | null;
+  interactive: boolean;
+}): Promise<InitUseCase> {
+  const { options, pretty, interactive } = input;
+  if (options.useCase !== undefined) return options.useCase;
+  if (options.yes === true || !interactive) return "embedded";
+  const select = options.selectUseCase ?? (pretty === null ? plainSelect : pretty.select);
+  const picked = await select("How will people use your agent?", USE_CASE_OPTIONS);
+  return (INIT_USE_CASES as readonly string[]).includes(picked) ? picked as InitUseCase : "embedded";
 }
 
-const STAR_REPO = "runvendo/vendo";
-// Tracked star link (vendo-web star-worker): captures star_link_clicked
-// {src: cli} server-side, then redirects to the repo.
-const STAR_LINK = "https://vendo.run/star?src=cli";
+const BASE_URL_PLACEHOLDER = "VENDO_BASE_URL=http://localhost:3000";
 
-/** Star the repo via gh (agent-install-dx §CLI-5). Every failure mode — gh
-    not installed (spawn error), a non-zero exit, a throwing seam, or a gh
-    that hangs past `timeoutMs` — is plain `false`: the caller prints the
-    repo URL instead, one line, no error noise. Exported for the timeout's
-    direct unit test only. */
-export function starViaGh(spawnStar: NonNullable<InitOptions["spawnStar"]>, timeoutMs = 5_000): Promise<boolean> {
-  return new Promise((resolveStar) => {
-    let timer: ReturnType<typeof setTimeout> | null = null;
-    const settle = (starred: boolean): void => {
-      if (timer !== null) clearTimeout(timer);
-      resolveStar(starred);
+/** "Where will this deploy?" — one Enter to decline, and the answer replaces
+    init's OWN placeholder in .env.example. Nowhere else: a production URL in
+    .env.local would repoint local dev's discovery, callbacks and credential
+    forwarding at the deployed origin, and dev already trusts the request's
+    own origin. Returns the captured URL, or null when skipped. */
+export async function captureBaseUrl(input: {
+  root: string;
+  options: InitOptions;
+  output: Output;
+  pretty: PrettyOutput | null;
+  interactive: boolean;
+}): Promise<string | null> {
+  const { root, options, output, pretty, interactive } = input;
+  const ask = options.baseUrl !== undefined
+    ? async () => options.baseUrl!
+    : options.askText
+      ?? (options.yes === true || !interactive || pretty === null ? undefined : pretty.text);
+  if (ask === undefined) return null;
+  const url = (await ask("Where will this deploy?", "e.g. https://app.acme.com — Enter to skip")).trim();
+  if (url === "") return null;
+  const path = join(root, ".env.example");
+  const current = await readOptional(path);
+  if (current === null || !current.includes(BASE_URL_PLACEHOLDER)) return url;
+  await writeText(path, current.replace(BASE_URL_PLACEHOLDER, `VENDO_BASE_URL=${url}`));
+  output.log("written to .env.example — set it in your deploy platform's env");
+  return url;
+}
+
+/** The footer's stats. It never claims more than the run achieved: an
+    outstanding paste renders "1 paste left", never "agent live". */
+export function runStats(input: {
+  toolCount: number;
+  brandCaptured: boolean;
+  handSteps: number;
+  checkPassed: boolean;
+}): string[] {
+  return [
+    `${input.toolCount} tool${input.toolCount === 1 ? "" : "s"}`,
+    ...(input.brandCaptured ? ["brand captured"] : []),
+    input.handSteps > 0
+      ? `${input.handSteps} paste${input.handSteps === 1 ? "" : "s"} left`
+      : input.checkPassed ? "agent live" : "wired",
+  ];
+}
+
+/** Variant B — the user's own agent loop. Which snippet prints is read off
+    the same package.json init already parses (`ai` → AI SDK, `@mastra/core`
+    → Mastra); the generated route stays either way, because it is what
+    serves apps and approvals to the embeds. Mastra's principal step is a
+    step of its own, not a footnote: vendoMastraTools reads the principal off
+    the request context and a call without one fails closed. */
+async function agentLoopSteps(root: string): Promise<ManualEdit[]> {
+  let dependencies: Record<string, unknown> = {};
+  try {
+    const manifest = JSON.parse((await readOptional(join(root, "package.json"))) ?? "{}") as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
     };
-    let child: StarProcess;
-    try {
-      child = spawnStar("gh", ["api", "-X", "PUT", `user/starred/${STAR_REPO}`]);
-    } catch {
-      settle(false);
-      return;
-    }
-    timer = setTimeout(() => settle(false), timeoutMs);
-    timer.unref?.();
-    child.on("error", () => settle(false));
-    child.on("exit", (code) => settle(code === 0));
+    dependencies = { ...manifest.dependencies, ...manifest.devDependencies };
+  } catch {
+    // No readable manifest — neither snippet is honest, so print neither.
+  }
+  if (Object.hasOwn(dependencies, "@mastra/core")) {
+    return [
+      {
+        file: join("src", "mastra", "agents", "<your-agent>.ts"),
+        lines: [
+          `import { vendoMastraTools } from "@vendoai/vendo/mastra";`,
+          `… then spread the pack: tools: async () => ({ ...yourTools, ...(await vendoMastraTools(vendo)) })`,
+        ],
+        why: "Your loop, your model — Vendo adds guarded vendo_* tools, vendo_make (inline micro-apps) and vendo_delegate. https://docs.vendo.run/existing-agents/mastra",
+      },
+      {
+        file: join("app", "api", "chat", "route.ts"),
+        lines: [
+          `import { VENDO_PRINCIPAL_KEY } from "@vendoai/vendo/mastra";`,
+          `… then set the per-request principal: requestContext.set(VENDO_PRINCIPAL_KEY, principal);`,
+        ],
+        why: "vendoMastraTools reads the principal off the request context — a call without one fails closed, so an install that skips this looks broken at the first tool call.",
+      },
+    ];
+  }
+  if (Object.hasOwn(dependencies, "ai")) {
+    return [{
+      file: join("app", "api", "chat", "route.ts"),
+      lines: [
+        `import { vendoTools } from "@vendoai/vendo/ai-sdk";`,
+        `… then inside streamText: tools: { ...yourTools, ...(await vendoTools(vendo, { principal })) }`,
+      ],
+      why: "Your loop, your model — Vendo adds guarded vendo_* tools, vendo_make (inline micro-apps) and vendo_delegate. https://docs.vendo.run/existing-agents/ai-sdk",
+    }];
+  }
+  return [];
+}
+
+const POSTURE_OPTIONS: SelectOption[] = [
+  {
+    value: "broker",
+    label: "Vendo Cloud broker — keys managed in the console, stable tenant URL, OAuth surface stays off your domain",
+    hint: "recommended with your Cloud account",
+  },
+  { value: "local", label: "Local — your app serves its own OAuth (zero config, fully standard)" },
+];
+
+/** Variant C. Init asks two more questions here and then WRITES what it
+ *  legitimately owns: it creates the composition file, so putting `mcp: true`
+ *  and a serviceAuth key into a file it is authoring is not editing anyone's
+ *  code. It never discovers posture and never reaches a broker — it prints
+ *  environment lines for the operator, exactly as the console would.
+ *
+ *  The posture select only appears when the run holds a Cloud key: a keyless
+ *  run cannot use a broker, so local is simply the default. */
+async function planMcpScaffold(input: {
+  root: string;
+  options: InitOptions;
+  output: Output;
+  pretty: PrettyOutput | null;
+  interactive: boolean;
+  changes: PlannedChange[];
+  framework: Exclude<HostFramework, "unknown"> | "custom";
+  authWired: AuthMatch | null;
+  cloudKey: boolean;
+  baseUrl: string | null;
+}): Promise<ReturnType<typeof planMcp> | null> {
+  const { root, options, output, pretty, interactive, changes, framework, authWired, cloudKey, baseUrl } = input;
+  const ask = options.yes === true || !interactive;
+
+  let posture: McpPosture = options.posture ?? "local";
+  if (options.posture === undefined && cloudKey && !ask) {
+    const select = options.selectUseCase ?? (pretty === null ? plainSelect : pretty.select);
+    posture = (await select("How should outside agents sign in?", POSTURE_OPTIONS)) as McpPosture;
+  }
+
+  let serviceKey = options.serviceKey === true;
+  if (options.serviceKey === undefined && !ask) {
+    const confirm = options.confirmAuth ?? (pretty === null ? askYesNo : pretty.confirm);
+    serviceKey = await confirm("Will your own backend call these tools machine-to-machine?", false);
+  }
+
+  const mcp = planMcp({
+    root,
+    appDir: await appDirectory(root),
+    framework,
+    authWired,
+    serverActions: (await requiredServerActions(root)).length > 0,
+    cloudKey,
+    posture,
+    serviceKey,
+    ...(baseUrl === null ? {} : { baseUrl }),
   });
+  if (mcp.blocked !== undefined) {
+    output.error(`warning: ${mcp.blocked}`);
+    return null;
+  }
+  // The composition init is already CREATING becomes the MCP one — same file,
+  // mcp: true — and the origin-root discovery route joins the change set. A
+  // composition init did not write this run is left alone, as always.
+  const composition = changes.find((change) => change.before === null && change.path.endsWith("route.ts"));
+  if (composition !== undefined) {
+    composition.after = mcp.routeSource;
+    composition.diff = diff(composition.path, null, mcp.routeSource);
+  }
+  for (const change of mcp.changes) {
+    if (changes.some((planned) => planned.absolute === change.absolute)) continue;
+    const path = relative(root, change.absolute);
+    changes.push({ absolute: change.absolute, path, before: null, after: change.after, diff: diff(path, null, change.after) });
+  }
+  if (mcp.serviceKeyValue !== undefined) {
+    await upsertEnvLocal(root, "VENDO_SERVICE_KEY", mcp.serviceKeyValue);
+    output.log(`Generated VENDO_SERVICE_KEY → .env.local (…${mcp.serviceKeyValue.slice(-4)})`);
+    await ensureEnvLocalIgnored(root, output);
+  }
+  return mcp;
+}
+
+/** The live check — `vendo doctor`, the one thing that turns "wired" into
+ *  "proven". It only OFFERS itself when the run owes no hand step: doctor
+ *  grades whether the <VendoProvider> paste landed, and the paste happens
+ *  after init exits, so offering it on a run that still owes one would fail a
+ *  run that did nothing wrong. Nothing here can change init's exit code. */
+async function offerLiveCheck(input: {
+  root: string;
+  options: InitOptions;
+  output: Output;
+  pretty: PrettyOutput | null;
+  interactive: boolean;
+}): Promise<boolean> {
+  const { root, options, output, pretty, interactive } = input;
+  try {
+    if (options.check === false) return false;
+    if (options.check !== true) {
+      const confirm = options.confirmCheck
+        ?? (options.yes === true || !interactive || stdin.isTTY !== true
+          ? undefined
+          : (pretty === null ? askYesNo : pretty.confirm));
+      if (confirm === undefined) return false;
+      if (!(await confirm("Start your dev server and run a live check now?", true))) return false;
+    }
+    pretty?.spin("vendo doctor — starting dev server…");
+    const check = options.runCheck ?? (async (target: string) =>
+      (await runDoctor({ targetDir: target, yes: true, output })) === 0);
+    const passed = await check(root);
+    pretty?.stopSpin();
+    output.log(passed
+      ? "Live turn passed — your door answers"
+      : "The live check did not pass — `npx vendo doctor` prints what is missing.");
+    return passed;
+  } catch {
+    // Best-effort by design: init already succeeded.
+    pretty?.stopSpin();
+    return false;
+  }
 }
 
 /** Whether the visible surface is already mounted in the host's own source —
@@ -784,12 +1086,9 @@ async function buildPlan(options: InitOptions, confirmAuth?: ConfirmAuth, select
   layout: LayoutWiring;
 }> {
   const root = resolve(options.targetDir);
-  // "unknown" detection lands on the runtime-neutral custom scaffold — the
-  // safe default that exists now (guessing the Next layout into a Worker
-  // host was the field failure; the non-interactive guard still demands an
-  // explicit --framework so agents never inherit a guess silently).
-  const detected = options.framework ?? await detectFramework(root);
-  const framework: "next" | "express" | "custom" = detected === "unknown" ? "custom" : detected;
+  // The non-interactive guard still demands an explicit --framework, so
+  // agents never inherit resolveFramework's custom fall-through silently.
+  const framework = await resolveFramework(root, options);
   const scaffold = framework === "custom"
     ? await planCustomComposition(root, options, confirmAuth, selectAuth)
     : framework === "express"
@@ -852,6 +1151,9 @@ async function buildPlan(options: InitOptions, confirmAuth?: ConfirmAuth, select
     layout,
     plan: {
       framework,
+      // Only when the run named one: an unattended plan stays byte-identical
+      // to the one agents parse today.
+      ...(options.useCase === undefined ? {} : { useCase: options.useCase }),
       root,
       writes,
       codeChanges: changes.map(({ path, diff: rendered }) => ({ path, diff: rendered })),
@@ -934,8 +1236,9 @@ async function finalizeTheme(input: {
   themePath: string;
   options: InitOptions;
   output: Output;
+  pretty: PrettyOutput | null;
 }): Promise<void> {
-  const { themeSummary, themeDraft, themePath, options, output } = input;
+  const { themeSummary, themeDraft, themePath, options, output, pretty } = input;
   const summary = themeDraft === null ? themeSummary : applyThemeDraft(themeSummary, themeDraft);
   // --theme answers land first; the review prompt then covers only the
   // uncertain slots the flags left unanswered (non-interactive runs keep
@@ -952,7 +1255,44 @@ async function finalizeTheme(input: {
   }
   if (Object.keys(answers).length > 0) applyThemeAnswers(summary, answers, output);
   await writeText(themePath, `${JSON.stringify(toVendoTheme(summary.slots), null, 2)}\n`);
-  printThemeSummary(summary, output);
+  printThemeSummary(summary, output, pretty);
+}
+
+/** The per-router mount wording the terminal snippet cannot carry: the child
+    expression genuinely differs ({children} in app/layout.tsx, <Component
+    {...pageProps} /> in a pages-only _app.tsx), so one literal would be wrong
+    for half of hosts. */
+const DOCS_MOUNT = "docs.vendo.run/quickstart#the-client-mount";
+
+/** The same closing steps for a human terminal: on the rail as a ◇ section
+    rather than inside two 64-dash rules that break it, the code indented so
+    it reads as code, and "init never edits your files" demoted from a shout
+    to the dim why-line under it. */
+function printPrettyClosingSteps(pretty: PrettyOutput, handSteps: ManualEdit[], manualSteps: string[]): void {
+  if (handSteps.length > 0) {
+    const numbered = handSteps.length > 1;
+    pretty.block(
+      handSteps.length === 1 ? `One paste left — ${handSteps[0]!.file}` : `${handSteps.length} pastes left`,
+      [
+        ...handSteps.flatMap((step, at) => [
+          ...(numbered ? [`${at + 1} · ${step.file}`] : []),
+          ...step.lines.map((line) => `  ${line}`),
+          // The child expression genuinely differs by router, so the mount
+          // snippet is not blind-paste-complete; the docs carry both.
+          ...(step.lines.some((line) => line.includes("VendoProvider")) ? [`  ${DOCS_MOUNT}`] : []),
+          `  ${step.why}`,
+          "",
+        ]),
+        "init never edits your files.",
+        "then: npx vendo doctor — verifies the paste and runs a live turn",
+      ],
+      "◇",
+    );
+    return;
+  }
+  // Express and custom hosts have no single host file to name, so their
+  // wiring keeps the compact list, restyled to match.
+  if (manualSteps.length > 0) pretty.block("Last steps are yours", manualSteps, "◇");
 }
 
 /** Done — the pastes init cannot take (it only ever CREATES files in your
@@ -961,13 +1301,18 @@ async function finalizeTheme(input: {
  *  can see, or server-action tools that silently fail closed. */
 function printClosingSteps(input: {
   output: Output;
+  pretty: PrettyOutput | null;
   handSteps: ManualEdit[];
   manualSteps: string[];
   credential: DevCredential;
   cloud: { keyValid: boolean };
   compositionPath: string | null;
 }): void {
-  const { output, handSteps, manualSteps, credential, cloud, compositionPath } = input;
+  const { output, pretty, handSteps, manualSteps, credential, cloud, compositionPath } = input;
+  if (pretty !== null) {
+    printPrettyClosingSteps(pretty, handSteps, manualSteps);
+    return;
+  }
   if (handSteps.length > 0) {
     const rule = "─".repeat(64);
     output.log(`\n${rule}`);
@@ -1013,46 +1358,6 @@ function printClosingSteps(input: {
         : "no model key resolved here, so the agent is live only if your composition passes its own model."}`);
   }
   output.log(`${handSteps.length === 0 ? "" : "\n"}Verify everything: \`npx vendo doctor\` (it can start the server and run a live turn).`);
-}
-
-/** Star ask (agent-install-dx §CLI-5): the interactive success screen
- *  ends with ONE consent question — never shown non-interactively (the
- *  playbook owns the agent-path ask; deterministic runs stay that way),
- *  and never fatal: nothing in this step can change init's exit code.
- *  Yes stars via gh; any failure degrades to the repo URL, one line.
- *  No does nothing — no guilt text. */
-async function askForStar(input: {
-  options: InitOptions;
-  pretty: PrettyOutput | null;
-  output: Output;
-  telemetry: Telemetry;
-}): Promise<void> {
-  const { options, pretty, output, telemetry } = input;
-  try {
-    // Consent guard: an unshown prompt is NEVER a yes. On a non-TTY
-    // stdin (programmatic `interactive: true`, `init < file`) both real
-    // confirms would resolve the default — pretty.confirm returns it,
-    // askYesNo would block — and starring is an account action, so the
-    // answer without a real keyboard is false, regardless of path.
-    const confirmStar = options.confirmStar
-      ?? (async (question: string, defaultYes: boolean) =>
-        stdin.isTTY === true
-          ? (pretty === null ? askYesNo : pretty.confirm)(question, defaultYes)
-          : false);
-    if (await confirmStar(`Star ${STAR_REPO} to support the project?`, true)) {
-      const starred = await starViaGh(
-        options.spawnStar ?? ((command, args) => spawn(command, args, { stdio: "ignore" })),
-      );
-      if (!starred) output.log(`Star it anytime: ${STAR_LINK}`);
-      // Star attribution: `starred` is an exact star-from-the-CLI signal
-      // (closed outcome enum; counts-and-enums promise holds).
-      await telemetry.track("star_prompt", { outcome: starred ? "starred" : "star-failed" });
-    } else {
-      await telemetry.track("star_prompt", { outcome: "declined" });
-    }
-  } catch {
-    // The ask is best-effort by design; init already succeeded.
-  }
 }
 
 /** An undetectable framework has NO safe default: a non-interactive run
@@ -1114,7 +1419,14 @@ async function resolveModelCredential(input: {
   }
   let credential = await (options.resolveCredential ?? resolveDevCredential)({ env: effectiveEnv });
   if (credential.rung === "env-key") {
-    output.log(`Model: ${describeDevCredential(credential)} — production uses this same key server-side.`);
+    // Their key is a decision already made, so there is no prompt either way
+    // — but a human terminal still learns the door exists, which the plain
+    // line never says.
+    if (pretty === null) {
+      output.log(`Model: ${describeDevCredential(credential)} — production uses this same key server-side.`);
+    } else {
+      output.log(`Models: your ${credential.envVar} · Vendo Cloud adds hosted automations + console — \`vendo login\` anytime`);
+    }
   }
   const cloud = await runCloudStep({
     root,
@@ -1130,7 +1442,11 @@ async function resolveModelCredential(input: {
     env: effectiveEnv,
     // The step's own command_run row rides init's telemetry seams.
     ...(options.telemetry === undefined ? {} : { telemetry: options.telemetry }),
-    ...(pretty === null ? {} : { confirm: pretty.confirm }),
+    // A human terminal answers the models question as a select and can paste
+    // a provider key inline; a plain one keeps today's confirm.
+    ...(pretty === null ? {} : { confirm: pretty.confirm, select: pretty.select, askSecret: pretty.secret }),
+    ...(options.cloudKey !== undefined ? { models: "cloud" as const } : {}),
+    ...(options.byo === true ? { models: "byo" as const } : {}),
     ...(options.cloud ?? {}),
   });
   // Same-run pickup: a starter key minted just now lands in .env.local —
@@ -1139,6 +1455,15 @@ async function resolveModelCredential(input: {
     const minted = envFileValueSync(root, "VENDO_API_KEY");
     if (minted !== null) {
       effectiveEnv = { ...effectiveEnv, VENDO_API_KEY: minted };
+      credential = await (options.resolveCredential ?? resolveDevCredential)({ env: effectiveEnv });
+    }
+  }
+  // A provider key the user just pasted counts the same way: this run's
+  // model passes benefit from it, not the next one.
+  if (cloud.wroteKeyVar !== undefined) {
+    const pasted = envFileValueSync(root, cloud.wroteKeyVar);
+    if (pasted !== null) {
+      effectiveEnv = { ...effectiveEnv, [cloud.wroteKeyVar]: pasted };
       credential = await (options.resolveCredential ?? resolveDevCredential)({ env: effectiveEnv });
     }
   }
@@ -1309,9 +1634,15 @@ export async function runInit(options: InitOptions): Promise<number> {
   const interactive = options.interactive
     ?? (!invokedByPackageScript() && Boolean(stdin.isTTY) && Boolean(stdout.isTTY));
   if (!await guardUndetectedFramework({ root, options, output, interactive })) return 1;
-  // (No stdin-TTY guard on these defaults, unlike the star ask's: an unshown
-  // auth confirm resolving its default just wires the detected preset — the
-  // very accept the non-interactive path performs silently anyway.)
+
+  // The read-back first: every fact below is already detected for other
+  // reasons, and showing it is the moment the tool proves it looked.
+  if (pretty !== null) pretty.block("Your stack", await stackLines(root, await resolveFramework(root, options)));
+  const useCase = await resolveUseCase({ options, pretty, interactive });
+
+  // (No stdin-TTY guard on these defaults: an unshown auth confirm resolving
+  // its default just wires the detected preset — the very accept the
+  // non-interactive path performs silently anyway.)
   const confirmAuth = options.yes === true || !interactive
     ? undefined
     : (options.confirmAuth ?? (pretty === null ? askYesNo : pretty.confirm));
@@ -1331,7 +1662,7 @@ export async function runInit(options: InitOptions): Promise<number> {
     if (options.cloudKey !== undefined) {
       await upsertEnvLocal(root, "VENDO_API_KEY", options.cloudKey);
       output.log("Wrote VENDO_API_KEY to .env.local (--cloud-key).");
-      await warnEnvLocalNotIgnored(root, output);
+      await ensureEnvLocalIgnored(root, output);
     }
     const { credential, cloud } = await resolveModelCredential({ root, env, options, output, pretty });
     // A key that landed in .env.local THIS run (--cloud-key upsert or the
@@ -1342,7 +1673,23 @@ export async function runInit(options: InitOptions): Promise<number> {
       telemetry = telemetryFor(options, output, root);
     }
 
+    // The MCP door derives every discovery URL from VENDO_BASE_URL and both
+    // extra answers change the composition's own source, so that path needs
+    // all three BEFORE it writes. Every other path asks the URL at the end,
+    // where it is one Enter to decline.
+    let baseUrl: string | null = null;
+    let mcp: ReturnType<typeof planMcp> | null = null;
+    if (useCase === "mcp") {
+      baseUrl = await captureBaseUrl({ root, options, output, pretty, interactive });
+      mcp = await planMcpScaffold({
+        root, options, output, pretty, interactive, changes, baseUrl,
+        framework: plan.framework, authWired, cloudKey: cloud.keyValid,
+      });
+    }
+
+    pretty?.spin("Wiring your app…");
     const wiringMs = await wireAndScaffold({ root, changes, force: options.force === true });
+    pretty?.stopSpin();
 
     // Summary — what changed. What was LEARNED is the shared flow's report,
     // printed by the flow itself a few lines down.
@@ -1377,7 +1724,7 @@ export async function runInit(options: InitOptions): Promise<number> {
     // finally the uncertain-slot review. Skipped entirely when theme.json
     // pre-existed this run (the flow reconciles that one instead).
     if (themeSummary !== null) {
-      await finalizeTheme({ themeSummary, themeDraft: flow.themeDraft, themePath, options, output });
+      await finalizeTheme({ themeSummary, themeDraft: flow.themeDraft, themePath, options, output, pretty });
     }
 
     // Judgment state, one line: a pass that ran already narrated itself (it
@@ -1428,8 +1775,28 @@ export async function runInit(options: InitOptions): Promise<number> {
       output.error(`warning: installed ai@${aiVersion} is unsupported — Vendo supports ai@6; downgrade (npm install ai@^6 @ai-sdk/anthropic@^3 @ai-sdk/react@^3) or track github.com/runvendo/vendo/issues/478`);
     }
 
-    const handSteps = [...(mount === null ? [] : [mount]), ...edits];
-    printClosingSteps({ output, handSteps, manualSteps, credential, cloud, compositionPath });
+    // Where will this deploy? — every path but MCP, which needed the answer
+    // before it wrote. One Enter declines and the placeholder stands.
+    if (useCase !== "mcp") baseUrl = await captureBaseUrl({ root, options, output, pretty, interactive });
+
+    // Variant B: the wired route stays (it serves apps and approvals to the
+    // embeds) — what is added is the one snippet for their own loop.
+    const handSteps = [
+      ...(mount === null ? [] : [mount]),
+      ...edits,
+      ...(useCase === "agent-loop" ? await agentLoopSteps(root) : []),
+    ];
+    printClosingSteps({ output, pretty, handSteps, manualSteps, credential, cloud, compositionPath });
+    if (mcp !== null) {
+      const lines = [...mcp.steps, ...mcp.envLines];
+      if (pretty === null) for (const line of lines) output.log(`  ${line}`);
+      else pretty.block("Steps that are yours", lines, "◇");
+    }
+
+    // The live check offers itself ONLY when nothing is left to paste: doctor
+    // grades the paste, and the paste happens after init exits.
+    const checkPassed = handSteps.length === 0
+      && await offerLiveCheck({ root, options, output, pretty, interactive });
 
     // Agent tail (agent-install-dx): the --yes-or-non-TTY path is agent-driven
     // — the run's FINAL block is the repo-specific pointers an agent parses.
@@ -1439,20 +1806,24 @@ export async function runInit(options: InitOptions): Promise<number> {
       output.log("\nAgent tail:");
       const tail = await agentTailLines({ root, framework: plan.framework, compositionPath, authWired, layout, edits, cloudKeyMissing: credential.rung === "none" });
       for (const line of tail) output.log(`  ${line}`);
-    } else {
-      await askForStar({ options, pretty, output, telemetry });
     }
-    // The run's LAST word is the outstanding paste, on both paths (self-serve
-    // audit F5: interactive installs used to end on the star ask with the one
-    // step that matters scrolled off-screen). The frame itself stays up-screen
-    // — the agent tail's "the lines above" pointers depend on that order — so
-    // the closer is a one-line echo of it, not a second copy.
-    if (handSteps.length > 0) {
+    // The run's LAST word is the outstanding paste (self-serve audit F5: the
+    // one step that matters used to scroll off-screen). The frame itself
+    // stays up-screen — the agent tail's "the lines above" pointers depend on
+    // that order — so the closer is a one-line echo of it, not a second copy.
+    // A human terminal has the paste block six lines up and legible, and gets
+    // the count in the footer instead.
+    if (handSteps.length > 0 && pretty === null) {
       output.log(handSteps.length === 1
         ? `\n→ Don't forget the paste in ${handSteps[0]!.file} (frame above)`
         : `\n→ Don't forget the ${handSteps.length} pastes above (frame above)`);
     }
-    pretty?.done(Date.now() - started, true);
+    pretty?.done(Date.now() - started, true, runStats({
+      toolCount,
+      brandCaptured: themeSummary !== null,
+      handSteps: handSteps.length,
+      checkPassed,
+    }));
     return 0;
   } catch (error) {
     await telemetry.track("init_failed", {

--- a/packages/vendo/tests/cli.test.ts
+++ b/packages/vendo/tests/cli.test.ts
@@ -31,6 +31,11 @@ describe("vendo CLI commands", () => {
     expect(help).toContain("--ai");
     expect(help).toContain("--no-ai");
     expect(help).toContain("--theme <slot=value>");
+    expect(help).toContain("--use-case <name>");
+    expect(help).toContain("--base-url <url>");
+    expect(help).toContain("--posture <name>");
+    expect(help).toContain("--service-key");
+    expect(help).toContain("--check / --no-check");
     // The interview flags are gone with the interview.
     expect(help).not.toContain("--brief <text>");
     expect(help).not.toContain("Init/refine: module exporting");
@@ -91,14 +96,17 @@ describe("vendo CLI commands", () => {
     cleanup.push(root);
 
     expect(await main(["init", root, "--agent", "--yes", "--force", "--byo", "--ai",
-      "--auth", "clerk", "--framework", "next", "--theme", "accent=#7c3bed"])).toBe(0);
+      "--auth", "clerk", "--framework", "next", "--theme", "accent=#7c3bed",
+      "--use-case", "mcp", "--base-url", "https://app.acme.com", "--posture", "broker",
+      "--service-key", "--no-check"])).toBe(0);
 
     expect(await readdir(root)).toEqual([]); // --agent stayed read-only
     // Value-flag values are never mistaken for the target dir, and the
-    // --framework answer reaches the plan.
-    const plan = JSON.parse(log.mock.calls.flat().join("\n")) as { root: string; framework: string };
+    // --framework and --use-case answers reach the plan.
+    const plan = JSON.parse(log.mock.calls.flat().join("\n")) as { root: string; framework: string; useCase: string };
     expect(plan.root).toBe(root);
     expect(plan.framework).toBe("next");
+    expect(plan.useCase).toBe("mcp");
 
     // --cloud-key parses too — and --agent STILL writes nothing (the
     // read-only promise beats the key-landing side effect).
@@ -131,6 +139,25 @@ describe("vendo CLI commands", () => {
     // The two answers to the one Cloud question are mutually exclusive.
     expect(await main(["init", root, "--cloud-key", `vnd_${"a".repeat(40)}`, "--byo"])).toBe(1);
     expect(error.mock.calls.flat().join("\n")).toContain("--cloud-key and --byo answer the same question");
+
+    expect(await main(["init", root, "--use-case", "sidecar"])).toBe(1);
+    expect(error.mock.calls.flat().join("\n")).toContain("--use-case must be one of embedded, agent-loop, mcp");
+
+    expect(await main(["init", root, "--base-url", "app.acme.com"])).toBe(1);
+    expect(error.mock.calls.flat().join("\n")).toContain("--base-url must be this deployment's full public URL");
+
+    expect(await main(["init", root, "--use-case", "mcp", "--posture", "hybrid"])).toBe(1);
+    expect(error.mock.calls.flat().join("\n")).toContain("--posture must be local or broker");
+
+    // The MCP-only answers fail loudly outside the MCP path rather than
+    // being dropped, which would leave an operator believing they took hold.
+    expect(await main(["init", root, "--posture", "broker"])).toBe(1);
+    expect(error.mock.calls.flat().join("\n")).toContain("--posture only applies to --use-case mcp");
+    expect(await main(["init", root, "--service-key"])).toBe(1);
+    expect(error.mock.calls.flat().join("\n")).toContain("--service-key only applies to --use-case mcp");
+
+    expect(await main(["init", root, "--check", "--no-check"])).toBe(1);
+    expect(error.mock.calls.flat().join("\n")).toContain("--check and --no-check answer the same question");
 
     expect(await readdir(root)).toEqual([]); // nothing ever ran
     error.mockRestore();

--- a/packages/vendo/tests/cli/cloud-init.test.ts
+++ b/packages/vendo/tests/cli/cloud-init.test.ts
@@ -156,6 +156,32 @@ describe("runCloudStep", () => {
     expect(messages.logs.join("\n")).toContain("Skipped — run `vendo login`");
   });
 
+  it("a non-TTY run never reaches the select or the paste, however they were wired", async () => {
+    // The plain pair's guard stops them PROMPTING, not answering: plainSelect's
+    // silent fallback is the first option, and the first option is Cloud — so a
+    // guard alone would turn every unattended run into a device login nobody
+    // asked for. An unshown question keeps the confirm's default: No.
+    const root = await tempRoot();
+    const messages = output();
+    let minted = 0;
+    const result = await runCloudStep({
+      root,
+      output: messages.sink,
+      yes: false,
+      isTty: false,
+      credential: noKey,
+      cloudProbe: async () => ({ present: false, ok: false, unlocks: ["x"] }),
+      select: async () => { throw new Error("selected on a non-TTY"); },
+      askSecret: async () => { throw new Error("prompted on a non-TTY"); },
+      deviceLogin: async () => { minted += 1; return 0; },
+    });
+    expect(minted).toBe(0);
+    expect(result).toEqual({ keyPresent: false, keyValid: false, wroteEnvLocal: false });
+    await expect(readFile(join(root, ".env.local"))).rejects.toMatchObject({ code: "ENOENT" });
+    // …and the agent pointer is what an unshown prompt leaves behind, as today.
+    expect(messages.logs.join("\n")).toContain(AUTH_MD_URL);
+  });
+
   it("bring-your-own lands the pasted key in .env.local with a masked receipt", async () => {
     const root = await tempRoot();
     const messages = output();

--- a/packages/vendo/tests/cli/cloud-init.test.ts
+++ b/packages/vendo/tests/cli/cloud-init.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DevCredential } from "../../src/dev-creds/resolve.js";
-import { AUTH_MD_URL, agentKeyPointerLines, runCloudStep, upsertEnvLocal } from "../../src/cli/cloud-init.js";
+import { AUTH_MD_URL, agentKeyPointerLines, providerKeyVar, runCloudStep, upsertEnvLocal } from "../../src/cli/cloud-init.js";
 import { telemetryCapture } from "../../src/cli/telemetry.test-util.js";
 
 const cleanup: Array<() => Promise<void>> = [];
@@ -126,6 +126,79 @@ describe("runCloudStep", () => {
     expect(result).toEqual({ keyPresent: true, keyValid: true, wroteEnvLocal: true });
     const envLocal = await readFile(join(root, ".env.local"), "utf8");
     expect(envLocal).toContain(`VENDO_API_KEY=${goodKey}`);
+    // "Production always needs a real server-side key." is gone: true, and
+    // nothing a person can act on 40 seconds into a local install.
+    expect(messages.logs.join("\n")).not.toContain("Production always needs");
+  });
+
+  it("asks the models question as a select when one is available; Cloud is the first option", async () => {
+    const asked: Array<{ question: string; values: string[] }> = [];
+    const messages = output();
+    const result = await runCloudStep({
+      root: await tempRoot(),
+      output: messages.sink,
+      yes: false,
+      isTty: true,
+      credential: noKey,
+      cloudProbe: async () => ({ present: false, ok: false, unlocks: ["x"] }),
+      confirm: async () => { throw new Error("confirmed"); },
+      select: async (question, options) => {
+        asked.push({ question, values: options.map((option) => option.value) });
+        return "later";
+      },
+    });
+    expect(asked).toEqual([{
+      question: "How do you want to run models?",
+      values: ["cloud", "byo", "later"],
+    }]);
+    // "Decide later" leaves a fully working keyless install — OSS law intact.
+    expect(result).toEqual({ keyPresent: false, keyValid: false, wroteEnvLocal: false });
+    expect(messages.logs.join("\n")).toContain("Skipped — run `vendo login`");
+  });
+
+  it("bring-your-own lands the pasted key in .env.local with a masked receipt", async () => {
+    const root = await tempRoot();
+    const messages = output();
+    const result = await runCloudStep({
+      root,
+      output: messages.sink,
+      yes: false,
+      isTty: true,
+      byo: true,
+      credential: noKey,
+      cloudProbe: async () => ({ present: false, ok: false, unlocks: ["x"] }),
+      askSecret: async () => "sk-ant-api03-abcdefgh",
+    });
+    expect(result.wroteKeyVar).toBe("ANTHROPIC_API_KEY");
+    expect(await readFile(join(root, ".env.local"), "utf8")).toContain("ANTHROPIC_API_KEY=sk-ant-api03-abcdefgh");
+    const joined = messages.logs.join("\n");
+    expect(joined).toContain("ANTHROPIC_API_KEY saved to .env.local (…efgh)");
+    expect(joined).not.toContain("sk-ant-api03-abcdefgh");
+  });
+
+  it("an unrecognisable key prefix asks which variable rather than guessing one", async () => {
+    const root = await tempRoot();
+    const asked: string[] = [];
+    await runCloudStep({
+      root,
+      output: output().sink,
+      yes: false,
+      isTty: true,
+      byo: true,
+      credential: noKey,
+      cloudProbe: async () => ({ present: false, ok: false, unlocks: ["x"] }),
+      askSecret: async () => "opaque-token-1234",
+      select: async (question) => { asked.push(question); return "GOOGLE_GENERATIVE_AI_API_KEY"; },
+    });
+    expect(asked).toEqual(["Which variable is that key for?"]);
+    expect(await readFile(join(root, ".env.local"), "utf8")).toContain("GOOGLE_GENERATIVE_AI_API_KEY=opaque-token-1234");
+  });
+
+  it("reads the variable off the key's own prefix, and says so honestly when it cannot", () => {
+    expect(providerKeyVar("sk-ant-api03-x")).toBe("ANTHROPIC_API_KEY");
+    expect(providerKeyVar("sk-proj-x")).toBe("OPENAI_API_KEY");
+    expect(providerKeyVar("AIzaSyX")).toBe("GOOGLE_GENERATIVE_AI_API_KEY");
+    expect(providerKeyVar("opaque")).toBeNull();
   });
 
   it("runs the REAL default ceremony against a scripted console and lands the key", async () => {

--- a/packages/vendo/tests/cli/cloud/device-login.test.ts
+++ b/packages/vendo/tests/cli/cloud/device-login.test.ts
@@ -307,10 +307,42 @@ describe("runDeviceLogin", () => {
     });
     expect(exit).toBe(0);
     expect(opened).toEqual(["https://console.test/claim?code=BCDF-GHJK"]);
-    // The printed URL + code stay — the browser open is best-effort, text is the fallback.
-    const joined = messages.logs.join("\n");
-    expect(joined).toContain("BCDF-GHJK");
-    expect(joined).toContain("https://console.test/claim?code=BCDF-GHJK");
+    // The browser is already opening, so the code IS the whole instruction:
+    // ONE line, no numbered list, no URL competing with it. The URL is not
+    // lost — the stall notice below carries it if the browser never came up.
+    expect(messages.logs[0]).toBe("Opening your browser — approve the code BCDF-GHJK there…");
+    expect(messages.logs.join("\n")).not.toContain("https://console.test/claim");
+  });
+
+  it("holds the expiry sentence back until the ceremony has visibly stalled", async () => {
+    // Leading with "the code expires in 10 minutes" is noise for an approval
+    // that lands in ten seconds. It arrives when it becomes relevant, once,
+    // and carries the URL a TTY run no longer prints up front.
+    const { fetchImpl } = scriptedFetch([
+      { status: 400, body: { error: "authorization_pending" } },
+      { status: 400, body: { error: "authorization_pending" } },
+      { status: 200, body: { access_token: KEY, token_type: "Bearer" } },
+    ]);
+    const messages = output();
+    // Each poll advances the clock 15s: the first lands inside the 20s
+    // window, the second past it.
+    let clock = Date.parse("2026-08-10T00:00:00Z");
+    const exit = await runDeviceLogin(["--api-url", "https://console.test"], {
+      output: messages.sink,
+      fetchImpl,
+      root: await tempRoot(),
+      home: await tempRoot(),
+      sleep: async () => { clock += 15_000; },
+      now: () => clock,
+      env: {},
+      isTty: true,
+      openBrowser: () => {},
+    });
+    expect(exit).toBe(0);
+    const stalls = messages.logs.filter((line) => line.startsWith("Still waiting —"));
+    expect(stalls).toHaveLength(1);
+    expect(stalls[0]).toContain("minutes");
+    expect(stalls[0]).toContain("https://console.test/claim?code=BCDF-GHJK");
   });
 
   it("never launches a browser for a non-TTY (agent) caller", async () => {

--- a/packages/vendo/tests/cli/init.test.ts
+++ b/packages/vendo/tests/cli/init.test.ts
@@ -1,4 +1,3 @@
-import { EventEmitter } from "node:events";
 import { mkdtemp, readFile, readdir, rm, writeFile, mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -8,7 +7,7 @@ import { createGuard } from "@vendoai/guard";
 import { createStore } from "@vendoai/store";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ExtractionHarness } from "../../src/cli/extract/harness.js";
-import { runInit, starViaGh } from "../../src/cli/init.js";
+import { runInit } from "../../src/cli/init.js";
 import type { Output } from "../../src/cli/shared.js";
 
 const cleanup: string[] = [];
@@ -299,7 +298,9 @@ describe("vendo init (zero-question)", () => {
         return true; // Enter/Y
       },
     })).toBe(0);
-    expect(asked).toEqual([{ question: "Detected next-auth — wire auth: authJs()?", defaultYes: true }]);
+    // The question says what is being DECIDED — whether the agent acts as the
+    // person at the keyboard — not the mechanism it wires.
+    expect(asked).toEqual([{ question: "Should the agent act as your signed-in Auth.js user?", defaultYes: true }]);
     const route = await readFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts"), "utf8");
     expect(route).toContain("auth: authJs(),");
     expect(sink.logs.join("\n")).not.toContain("Auth:");
@@ -1494,139 +1495,6 @@ describe("vendo init (zero-question)", () => {
     expect(sink.errors.join("\n")).not.toContain("not usable");
   });
 
-  // Agent-install-dx (§CLI-5): the star ask — ONE consent question at the end
-  // of a fully successful INTERACTIVE run. Yes stars via gh (any failure
-  // degrades to the repo URL, one line, no error noise); no does nothing.
-  // Never shown non-interactively, and never able to change init's exit code.
-  it("interactive success ends with the star ask; yes stars runvendo/vendo via gh", async () => {
-    const root = await fixture();
-    const asked: Array<{ question: string; defaultYes: boolean }> = [];
-    const spawned: Array<{ command: string; args: string[] }> = [];
-    const sink = output();
-    expect(await run(root, sink, {
-      interactive: true,
-      confirmStar: async (question, defaultYes) => {
-        asked.push({ question, defaultYes });
-        return true; // Enter/Y
-      },
-      spawnStar: (command, args) => {
-        spawned.push({ command, args });
-        const child = new EventEmitter();
-        setImmediate(() => child.emit("exit", 0));
-        return child;
-      },
-    })).toBe(0);
-    expect(asked).toEqual([{ question: "Star runvendo/vendo to support the project?", defaultYes: true }]);
-    expect(spawned).toEqual([{ command: "gh", args: ["api", "-X", "PUT", "user/starred/runvendo/vendo"] }]);
-    // The star landed: no fallback URL line.
-    expect(sink.logs.join("\n")).not.toContain("github.com/runvendo/vendo");
-  });
-
-  it("a missing or failing gh degrades to one repo-URL line and leaves the exit code alone", async () => {
-    // gh absent: spawn emits ENOENT.
-    const missing = await fixture();
-    const missingSink = output();
-    expect(await run(missing, missingSink, {
-      interactive: true,
-      confirmStar: async () => true,
-      spawnStar: () => {
-        const child = new EventEmitter();
-        setImmediate(() => child.emit("error", new Error("spawn gh ENOENT")));
-        return child;
-      },
-    })).toBe(0);
-    const missingUrls = missingSink.logs.filter((line) => line.includes("https://vendo.run/star?src=cli"));
-    expect(missingUrls).toHaveLength(1);
-    expect(missingSink.errors.join("\n")).not.toContain("gh"); // no error noise
-
-    // gh present but the call fails (non-zero exit): same one-line fallback.
-    const failing = await fixture();
-    const failingSink = output();
-    expect(await run(failing, failingSink, {
-      interactive: true,
-      confirmStar: async () => true,
-      spawnStar: () => {
-        const child = new EventEmitter();
-        setImmediate(() => child.emit("exit", 1));
-        return child;
-      },
-    })).toBe(0);
-    expect(failingSink.logs.filter((line) => line.includes("https://vendo.run/star?src=cli"))).toHaveLength(1);
-
-    // Even a spawn seam that throws synchronously never fails the init.
-    const throwing = await fixture();
-    const throwingSink = output();
-    expect(await run(throwing, throwingSink, {
-      interactive: true,
-      confirmStar: async () => true,
-      spawnStar: () => { throw new Error("no spawn at all"); },
-    })).toBe(0);
-    expect(throwingSink.logs.filter((line) => line.includes("https://vendo.run/star?src=cli"))).toHaveLength(1);
-  });
-
-  it("declining the star ask does nothing: no gh, no URL, no guilt text", async () => {
-    const root = await fixture();
-    let spawnCount = 0;
-    const sink = output();
-    expect(await run(root, sink, {
-      interactive: true,
-      confirmStar: async () => false,
-      spawnStar: () => {
-        spawnCount += 1;
-        return new EventEmitter();
-      },
-    })).toBe(0);
-    expect(spawnCount).toBe(0);
-    const logs = sink.logs.join("\n");
-    expect(logs).not.toContain("github.com/runvendo/vendo");
-    expect(logs).not.toContain("vendo.run/star");
-    expect(logs).not.toContain("Star");
-  });
-
-  it("the star ask never fires non-interactively: --yes, non-TTY, and --agent stay deterministic", async () => {
-    const seams = {
-      confirmStar: async () => { throw new Error("star prompted"); },
-      spawnStar: (): EventEmitter => { throw new Error("star spawned"); },
-    };
-    // Non-TTY (vitest default interactivity): no prompt.
-    const nonTty = await fixture();
-    expect(await run(nonTty, output(), seams)).toBe(0);
-    // --yes on a TTY: no prompt.
-    const flagged = await fixture();
-    expect(await run(flagged, output(), { yes: true, interactive: true, ...seams })).toBe(0);
-    // --agent: the read-only JSON plan carries no prompt either.
-    const agent = await fixture();
-    const agentSink = output();
-    expect(await run(agent, agentSink, { agent: true, ...seams })).toBe(0);
-    expect(agentSink.logs.join("\n")).not.toContain("Star");
-  });
-
-  it("an unshown prompt is never a yes: interactive override without a TTY stdin means no star", async () => {
-    // A programmatic runInit({ interactive: true }) with piped stdin (vitest
-    // has no TTY) must not auto-star off the confirm's Y default — the
-    // question was never actually shown, so the answer is false.
-    const root = await fixture();
-    const sink = output();
-    expect(await run(root, sink, {
-      interactive: true,
-      // No confirmStar seam: the real default path must decline on its own.
-      spawnStar: (): EventEmitter => { throw new Error("star spawned"); },
-    })).toBe(0);
-    expect(sink.logs.join("\n")).not.toContain("github.com/runvendo/vendo");
-  });
-
-  it("a gh that hangs resolves the star as false after the timeout", async () => {
-    // A child that never emits: the timer settles the promise instead.
-    await expect(starViaGh(() => new EventEmitter(), 25)).resolves.toBe(false);
-  });
-
-  it("a star step that blows up entirely never changes init's exit code", async () => {
-    const root = await fixture();
-    expect(await run(root, output(), {
-      interactive: true,
-      confirmStar: async () => { throw new Error("terminal went away"); },
-    })).toBe(0);
-  });
 
   it("emits a read-only agent plan with code changes, extraction, and the layout mount", async () => {
     const root = await fixture();
@@ -1681,7 +1549,6 @@ describe("the AI flag matrix — identical on init and sync (decision 2)", () =>
           harnesses: [themeHarness({ slots: {} })],
           confirm: async (question: string) => { asked.push(question); return false; },
         },
-        confirmStar: async () => false,
       })).toBe(0);
       // The prompt fires on the FIRST run and again on the second: nothing
       // about the answer is persisted to .vendo/ or anywhere else.
@@ -1693,7 +1560,7 @@ describe("the AI flag matrix — identical on init and sync (decision 2)", () =>
 
   it("interactive with --ai runs without asking; with --no-ai it is off", async () => {
     const on = output();
-    expect(await run(await fixture(), on, { interactive: true, ai: true, extract: probeOnly, confirmStar: async () => false })).toBe(0);
+    expect(await run(await fixture(), on, { interactive: true, ai: true, extract: probeOnly })).toBe(0);
     expect(on.logs.join("\n")).toContain("AI polish: unavailable"); // the gate opened
 
     const off = output();
@@ -1705,7 +1572,6 @@ describe("the AI flag matrix — identical on init and sync (decision 2)", () =>
         availability: async () => { throw new Error("must not probe"); },
         run: async () => { throw new Error("must not run"); },
       }], confirm: async () => { throw new Error("prompted"); } },
-      confirmStar: async () => false,
     })).toBe(0);
     expect(off.logs.join("\n")).toContain("off (--no-ai)");
   });
@@ -1920,54 +1786,6 @@ describe("init telemetry enrichment", () => {
     return { events, telemetry: { home, env, posthogKey: "phc_test", fetchImpl } };
   }
 
-  it("star_prompt telemetry mirrors the ask's closed outcomes and stays silent non-interactively", async () => {
-    // Consented + gh succeeds → starred.
-    const starredRoot = await fixture();
-    const starredTele = await telemetrySink();
-    expect(await run(starredRoot, output(), {
-      interactive: true,
-      telemetry: starredTele.telemetry,
-      confirmStar: async () => true,
-      spawnStar: () => {
-        const child = new EventEmitter();
-        setImmediate(() => child.emit("exit", 0));
-        return child;
-      },
-    })).toBe(0);
-    expect(starredTele.events().find((e) => e.event === "star_prompt")?.properties.outcome).toBe("starred");
-
-    // Consented + gh fails → star-failed.
-    const failedRoot = await fixture();
-    const failedTele = await telemetrySink();
-    expect(await run(failedRoot, output(), {
-      interactive: true,
-      telemetry: failedTele.telemetry,
-      confirmStar: async () => true,
-      spawnStar: () => {
-        const child = new EventEmitter();
-        setImmediate(() => child.emit("exit", 1));
-        return child;
-      },
-    })).toBe(0);
-    expect(failedTele.events().find((e) => e.event === "star_prompt")?.properties.outcome).toBe("star-failed");
-
-    // Declined → declined.
-    const declinedRoot = await fixture();
-    const declinedTele = await telemetrySink();
-    expect(await run(declinedRoot, output(), {
-      interactive: true,
-      telemetry: declinedTele.telemetry,
-      confirmStar: async () => false,
-      spawnStar: () => new EventEmitter(),
-    })).toBe(0);
-    expect(declinedTele.events().find((e) => e.event === "star_prompt")?.properties.outcome).toBe("declined");
-
-    // Non-interactive default run: the ask never shows, so no event at all.
-    const silentRoot = await fixture();
-    const silentTele = await telemetrySink();
-    expect(await run(silentRoot, output(), { telemetry: silentTele.telemetry })).toBe(0);
-    expect(silentTele.events().some((e) => e.event === "star_prompt")).toBe(false);
-  });
 
 
   it("init_completed carries the project-shape enums and versions (anonymous lane)", async () => {
@@ -2100,5 +1918,99 @@ describe("vendo init (custom runtime)", () => {
     const plan = JSON.parse(sink.logs.join("\n")) as { framework: string; writes: string[] };
     expect(plan.framework).toBe("custom");
     expect(plan.writes.join("\n")).not.toContain("app/api/vendo");
+  });
+});
+
+describe("the five questions", () => {
+  it("asks the use case first and takes embedded unattended; --use-case answers it without asking", async () => {
+    const asked: Array<{ question: string; values: string[] }> = [];
+    const root = await fixture();
+    expect(await run(root, output(), {
+      interactive: true,
+      selectUseCase: async (question, options) => {
+        asked.push({ question, values: options.map((option) => option.value) });
+        return "embedded";
+      },
+    })).toBe(0);
+    expect(asked).toEqual([{
+      question: "How will people use your agent?",
+      values: ["embedded", "agent-loop", "mcp"],
+    }]);
+
+    // Unattended: no question, and the plan stays byte-identical to today's.
+    const quiet = await fixture();
+    const quietSink = output();
+    expect(await run(quiet, quietSink, {
+      yes: true,
+      selectUseCase: async () => { throw new Error("prompted"); },
+    })).toBe(0);
+    expect(quietSink.logs.join("\n")).not.toContain("How will people use your agent?");
+  });
+
+  it("--use-case agent-loop adds the snippet for the loop package.json already names", async () => {
+    const aiSdk = await fixture();
+    await writeFile(join(aiSdk, "package.json"), JSON.stringify({
+      name: "host",
+      dependencies: { next: "16.0.0", ai: "6.0.0" },
+    }));
+    const aiSink = output();
+    expect(await run(aiSdk, aiSink, { useCase: "agent-loop" })).toBe(0);
+    const aiLogs = aiSink.logs.join("\n");
+    expect(aiLogs).toContain("2 STEPS LEFT");
+    expect(aiLogs).toContain('import { vendoTools } from "@vendoai/vendo/ai-sdk";');
+
+    // Mastra's principal step is a step of its own — a call without one fails
+    // closed, so an install that skips it looks broken at the first tool call.
+    const mastra = await fixture();
+    await writeFile(join(mastra, "package.json"), JSON.stringify({
+      name: "host",
+      dependencies: { next: "16.0.0", "@mastra/core": "1.0.0" },
+    }));
+    const mastraSink = output();
+    expect(await run(mastra, mastraSink, { useCase: "agent-loop" })).toBe(0);
+    const mastraLogs = mastraSink.logs.join("\n");
+    expect(mastraLogs).toContain("3 STEPS LEFT");
+    expect(mastraLogs).toContain("vendoMastraTools");
+    expect(mastraLogs).toContain("VENDO_PRINCIPAL_KEY");
+  });
+
+  it("--base-url replaces init's own .env.example placeholder and never touches .env.local", async () => {
+    const root = await fixture();
+    expect(await run(root, output(), { baseUrl: "https://app.acme.com" })).toBe(0);
+    const example = await readFile(join(root, ".env.example"), "utf8");
+    expect(example).toContain("VENDO_BASE_URL=https://app.acme.com");
+    expect(example).not.toContain("VENDO_BASE_URL=http://localhost:3000");
+    // A production URL in .env.local would repoint local dev's discovery,
+    // callbacks and forwarding at the deployed origin.
+    await expect(readFile(join(root, ".env.local"))).rejects.toMatchObject({ code: "ENOENT" });
+
+    // Enter declines: the placeholder stands, byte for byte.
+    const skipped = await fixture();
+    expect(await run(skipped, output(), { interactive: true, askText: async () => "" })).toBe(0);
+    expect(await readFile(join(skipped, ".env.example"), "utf8")).toContain("VENDO_BASE_URL=http://localhost:3000");
+  });
+
+  it("offers the live check only when nothing is left to paste, and never changes the exit code", async () => {
+    // A run that still owes the mount paste: doctor would grade that paste,
+    // so offering the check would fail a run that did nothing wrong.
+    const owing = await fixture();
+    expect(await run(owing, output(), {
+      interactive: true,
+      confirmCheck: async () => { throw new Error("prompted"); },
+      runCheck: async () => { throw new Error("ran"); },
+    })).toBe(0);
+
+    // Already mounted: the ask fires, and a check that blows up is still 0.
+    const mounted = await fixture();
+    await writeFile(join(mounted, "app", "layout.tsx"),
+      'import { VendoProvider } from "@vendoai/vendo/react";\n'
+      + "export default function Layout({ children }) { return <VendoProvider>{children}</VendoProvider>; }\n");
+    const asked: string[] = [];
+    expect(await run(mounted, output(), {
+      interactive: true,
+      confirmCheck: async (question) => { asked.push(question); return true; },
+      runCheck: async () => { throw new Error("doctor exploded"); },
+    })).toBe(0);
+    expect(asked).toEqual(["Start your dev server and run a live check now?"]);
   });
 });

--- a/packages/vendo/tests/cli/onboarding-safety.test.ts
+++ b/packages/vendo/tests/cli/onboarding-safety.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ensureEnvLocalIgnored, warnEnvLocalNotIgnored } from "../../src/cli/cloud-init.js";
+import { ensureEnvLocalIgnored } from "../../src/cli/cloud-init.js";
 import { workspaceHostCandidates } from "../../src/cli/framework.js";
 import { runInit } from "../../src/cli/init.js";
 import type { Output } from "../../src/cli/shared.js";
@@ -93,42 +93,49 @@ describe("the .env.local secret write warns when git would commit it", () => {
     return root;
   }
 
-  it("warns, naming the fix, when .env.local is not ignored", async () => {
+  it("ADDS the ignore line for an untracked .env.local and reports it, once", async () => {
+    const root = await repo();
     const sink = output();
-    await warnEnvLocalNotIgnored(await repo(), sink.output);
-    const warning = sink.errors.join("\n");
-    expect(warning).toContain("NOT gitignored");
-    expect(warning).toContain("add `.env.local` to .gitignore");
-    expect(sink.logs).toEqual([]);
+    expect(await ensureEnvLocalIgnored(root, sink.output)).toBe(".env.local");
+    expect(await readFile(join(root, ".gitignore"), "utf8")).toBe(".env.local\n");
+    expect(sink.logs).toEqual(["Added .env.local to .gitignore"]);
+    expect(sink.errors).toEqual([]);
+    // Idempotent: the second run finds it ignored and says nothing at all.
+    const again = output();
+    expect(await ensureEnvLocalIgnored(root, again.output)).toBeNull();
+    expect(again.logs).toEqual([]);
+    expect(again.errors).toEqual([]);
   });
 
-  it("stays silent when .gitignore covers .env.local", async () => {
+  it("stays silent when .gitignore already covers .env.local", async () => {
     const root = await repo();
     await writeFile(join(root, ".gitignore"), ".env*.local\n");
     const sink = output();
-    await warnEnvLocalNotIgnored(root, sink.output);
+    expect(await ensureEnvLocalIgnored(root, sink.output)).toBeNull();
     expect(sink.errors).toEqual([]);
+    expect(sink.logs).toEqual([]);
   });
 
-  it("an ALREADY TRACKED .env.local gets the remediation that actually works", async () => {
+  it("an ALREADY TRACKED .env.local is the one branch init must not silently fix", async () => {
     // git check-ignore reports a tracked file as NOT ignored even when a
-    // pattern matches it, so "add it to .gitignore" would be both the wrong
-    // advice and useless: the file is in the index and commits anyway.
+    // pattern matches it, so adding the line would be both the wrong advice
+    // and useless: the file is in the index and commits anyway.
     const root = await repo();
     await writeFile(join(root, ".gitignore"), ".env*.local\n");
     execFileSync("git", ["add", "-f", ".env.local"], { cwd: root });
     const sink = output();
-    await warnEnvLocalNotIgnored(root, sink.output);
+    expect(await ensureEnvLocalIgnored(root, sink.output)).toBeNull();
     const warning = sink.errors.join("\n");
     expect(warning).toContain("TRACKED by git");
     expect(warning).toContain("git rm --cached .env.local");
-    expect(warning).not.toContain("is NOT gitignored");
+    expect(sink.logs).toEqual([]);
   });
 
   it("stays silent outside a git repo — nothing to leak into", async () => {
     const sink = output();
-    await warnEnvLocalNotIgnored(await tempDir("vendo-gitignore-nogit-"), sink.output);
+    expect(await ensureEnvLocalIgnored(await tempDir("vendo-gitignore-nogit-"), sink.output)).toBeNull();
     expect(sink.errors).toEqual([]);
+    expect(sink.logs).toEqual([]);
   });
 
   it("a symlinked .env.local is judged by the file the write really lands in", async () => {
@@ -142,7 +149,7 @@ describe("the .env.local secret write warns when git would commit it", () => {
     await rm(join(root, ".env.local"));
     await symlink(join(root, "config", "dev.env"), join(root, ".env.local"));
     const sink = output();
-    await warnEnvLocalNotIgnored(root, sink.output);
+    expect(await ensureEnvLocalIgnored(root, sink.output)).toBeNull();
     const warning = sink.errors.join("\n");
     expect(warning).toContain("TRACKED by git");
     expect(warning).toContain(join("config", "dev.env"));
@@ -154,35 +161,10 @@ describe("the .env.local secret write warns when git would commit it", () => {
     const root = await repo();
     await writeFile(join(root, ".git", "config"), "[core\nnot valid\n");
     const sink = output();
-    await warnEnvLocalNotIgnored(root, sink.output);
+    expect(await ensureEnvLocalIgnored(root, sink.output)).toBeNull();
     const warning = sink.errors.join("\n");
     expect(warning).toContain("could not say whether it is ignored");
     expect(warning).toContain("bad config line");
-  });
-
-  it("init ADDS the ignore line for an untracked .env.local and reports it", async () => {
-    const root = await repo();
-    const sink = output();
-    expect(await ensureEnvLocalIgnored(root, sink.output)).toBe(".env.local");
-    expect(await readFile(join(root, ".gitignore"), "utf8")).toBe(".env.local\n");
-    expect(sink.logs).toEqual(["Added .env.local to .gitignore"]);
-    expect(sink.errors).toEqual([]);
-    // Idempotent: the second run finds it ignored and says nothing.
-    const again = output();
-    expect(await ensureEnvLocalIgnored(root, again.output)).toBeNull();
-    expect(again.logs).toEqual([]);
-  });
-
-  it("a TRACKED .env.local is the one branch init must not silently fix", async () => {
-    // .gitignore does nothing for a file already in the index, so adding the
-    // line would be a lie: this case keeps the warning that actually works.
-    const root = await repo();
-    execFileSync("git", ["add", "-f", ".env.local"], { cwd: root });
-    const sink = output();
-    expect(await ensureEnvLocalIgnored(root, sink.output)).toBeNull();
-    await expect(readFile(join(root, ".gitignore"))).rejects.toMatchObject({ code: "ENOENT" });
-    expect(sink.errors.join("\n")).toContain("TRACKED by git");
-    expect(sink.errors.join("\n")).toContain("git rm --cached .env.local");
   });
 
   it("--cloud-key adds the ignore line right after the write, and never blocks it", async () => {

--- a/packages/vendo/tests/cli/onboarding-safety.test.ts
+++ b/packages/vendo/tests/cli/onboarding-safety.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { warnEnvLocalNotIgnored } from "../../src/cli/cloud-init.js";
+import { ensureEnvLocalIgnored, warnEnvLocalNotIgnored } from "../../src/cli/cloud-init.js";
 import { workspaceHostCandidates } from "../../src/cli/framework.js";
 import { runInit } from "../../src/cli/init.js";
 import type { Output } from "../../src/cli/shared.js";
@@ -160,13 +160,39 @@ describe("the .env.local secret write warns when git would commit it", () => {
     expect(warning).toContain("bad config line");
   });
 
-  it("--cloud-key surfaces the warning right after the write, and never blocks it", async () => {
+  it("init ADDS the ignore line for an untracked .env.local and reports it", async () => {
+    const root = await repo();
+    const sink = output();
+    expect(await ensureEnvLocalIgnored(root, sink.output)).toBe(".env.local");
+    expect(await readFile(join(root, ".gitignore"), "utf8")).toBe(".env.local\n");
+    expect(sink.logs).toEqual(["Added .env.local to .gitignore"]);
+    expect(sink.errors).toEqual([]);
+    // Idempotent: the second run finds it ignored and says nothing.
+    const again = output();
+    expect(await ensureEnvLocalIgnored(root, again.output)).toBeNull();
+    expect(again.logs).toEqual([]);
+  });
+
+  it("a TRACKED .env.local is the one branch init must not silently fix", async () => {
+    // .gitignore does nothing for a file already in the index, so adding the
+    // line would be a lie: this case keeps the warning that actually works.
+    const root = await repo();
+    execFileSync("git", ["add", "-f", ".env.local"], { cwd: root });
+    const sink = output();
+    expect(await ensureEnvLocalIgnored(root, sink.output)).toBeNull();
+    await expect(readFile(join(root, ".gitignore"))).rejects.toMatchObject({ code: "ENOENT" });
+    expect(sink.errors.join("\n")).toContain("TRACKED by git");
+    expect(sink.errors.join("\n")).toContain("git rm --cached .env.local");
+  });
+
+  it("--cloud-key adds the ignore line right after the write, and never blocks it", async () => {
     const root = await pagesHost();
     execFileSync("git", ["init", "-q"], { cwd: root });
     const sink = output();
     expect(await run(root, sink, { cloudKey: `vnd_${"a".repeat(40)}` })).toBe(0);
     expect(await readFile(join(root, ".env.local"), "utf8")).toContain("VENDO_API_KEY=vnd_");
-    expect(sink.errors.join("\n")).toContain("NOT gitignored");
+    expect(sink.logs.join("\n")).toContain("Added .env.local to .gitignore");
+    expect(await readFile(join(root, ".gitignore"), "utf8")).toContain(".env.local");
   });
 });
 


### PR DESCRIPTION
`vendo init` now asks the five questions the install actually turns on, and answers them where it can.

**Use case** (new, first) — embedded / your own agent loop / MCP. Unattended runs take `embedded`, today's behaviour, so no existing script changes shape. **Models** — the Cloud offer stops being a `y/N` that defaults to *No* and becomes the question it really is: a three-way select, Cloud first and recommended, bring-your-own one keystroke away, decide-later the graceful exit. The BYO branch now settles itself — paste the key, it lands in `.env.local` through the same writer the mint uses, masked receipt, variable read off the key's own prefix (an unrecognisable one asks). **Base URL** (new, one Enter to decline) — `VENDO_BASE_URL` is load-bearing for discovery, credential forwarding and box callbacks, and init never asked; the answer goes to `.env.example` and nowhere else. **Live check** — offered only when the run owes no paste, because doctor grades the paste and the paste happens after init exits.

Two questions leave. The star ask becomes the footer line S1 ships in `done()`, and the gitignore wall becomes a consented action: init adds `.env.local` to `.gitignore` and says so. Auth keeps its confirm, its default and its picker fall-through — only the wording changes, from the mechanism (`wire auth: clerk()?`) to the decision (`Should the agent act as your signed-in Clerk user?`). The AI-consent question is untouched, deliberately: it names which credential is about to read the user's source.

### The collapse — DONE-MEANS 21, 23, 43

init's exact plain strings, through the landed renderer:

```
◆  Wired (3 files)
│  + app/api/vendo/[...vendo]/route.ts
│  + app/api/vendo/[...vendo]/vendo-actions.ts
│  ~ package.json
│
◆  Catalog
│  tools: +2 -0 ~1 · tool schemas: inputs 11/13 · outputs 9/13 · pins: 3 captured, 1 drifted · catalog.json: 4 discovered, 4 registered
│  components: 2 captured, 1 updated
│
◆  Judgment
│  14 tools judged · hardened (3) · schemas inferred (4) · rejected by the skeptic (1)
│  2 loosenings queued — review with vendo sync --review
```

`Wired` holds files only; the five catalog lines lift into their own block; `Judgment` is a summary plus the one line that needs a human later. Nothing in `sync-flow.ts` was touched to get there — the renderer's rules act on the plain strings wherever they are emitted.

### Questions asked

| | Today | This PR |
|---|---|---|
| Use case | not asked | **+1** select, embedded default |
| Auth | confirm `Y/n` | same confirm, same default, reworded |
| Models / Cloud | confirm `y/N`, default No | same count, now a 3-way select |
| Provider key paste | not asked | **+1** only on BYO with no key in the environment |
| AI consent | confirm / select | **unchanged** |
| Base URL | not asked | **+1** text, Enter to skip |
| MCP posture | not asked | **+1** MCP path only, and only with a Cloud key |
| Service key | not asked | **+1** MCP path only |
| Live check | not asked | **+1** only when no paste is outstanding |
| Star the repo | confirm `Y/n` | **−1** footer line |
| Gitignore | warning wall | **−1** init adds the line |

**5 on a standard install** — use case, auth, models, AI consent, base URL, and the last is one Enter to decline. **9 worst case**, which is nobody's first install: the five plus every conditional at once.

### Notes for the reviewer

- **`star_prompt` was retired on purpose.** No prompt means no event; the ask is gone, so the analytics event has nothing to report. Not dropped by accident.
- **Order divergence, forced by correctness.** The MCP posture and service-key answers change the composition's own source, and the MCP door derives every discovery URL from `VENDO_BASE_URL` — so on that path all three are asked before init writes, not after. Every other path asks the base URL at the end.
- **`--cloud-key` deliberately does not answer the models question.** It lands the key in `.env.local` before the cloud step runs, so the probe finds it and the question never fires. Routing it through the select instead would send a run that already has a key into the mint ceremony — a live device login for a key the user just supplied.
- **The plain prompts are gated on a real TTY, not on the renderer.** `plainSelect`'s non-TTY guard stops it prompting but not answering, and its silent fallback is the first option — which is Vendo Cloud. Gating on the renderer alone would have started a device login on every unattended run. Pinned by a test that wires both seams to throw.
- Piped, non-TTY and `--agent` output is unchanged; the `--agent` JSON gains `useCase` only when a run names one.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigns `vendo init` to ask five focused questions with safe defaults: use case, models (Cloud/BYO/decide later), BYO paste, base URL, and a live check. Removes the star prompt, clarifies auth wording, and keeps non‑TTY/`--agent` output unchanged.

- New Features
  - `vendo init` now asks: use case; models (3‑way: Cloud/BYO/decide later); BYO key paste (writes masked key to `.env.local`); base URL (to `.env.example` only); optional live check when no paste is pending. MCP adds posture and service key when selected.
  - New flags: `--use-case`, `--base-url`, `--posture`, `--service-key`, `--check/--no-check` (every question has a flag answer; unattended runs stay non‑interactive). `--cloud-key` writes to `.env.local` and suppresses the models prompt.
  - Auth prompt reworded to the decision: “Should the agent act as your signed‑in Clerk user?” (same default and fall‑through).
  - Cloud device login prints one instruction line (“Opening your browser — approve the code …”), and only shows the URL after ~20s stall as recovery.

- Refactors
  - Secret handling: `ensureEnvLocalIgnored` auto‑adds `.env.local` to `.gitignore` for untracked files and reports it; tracked files still warn.
  - Interactive safety: plain prompts run only on a real TTY (NO_COLOR supported); prevents unintended Cloud logins; non‑TTY/`--agent` output is byte‑for‑byte unchanged.
  - Renderer owns grouping and copy; removed duplicate styling/ANSI; concise footer stats under Wired/Catalog/Judgment. Doctor’s Cloud unlocks trimmed to two bullets.
  - Removed the star prompt and its analytics event. Updated docs, CLI help, and tests to the new flow.

<sup>Written for commit b49103a8ceff6f235b075573f5ffccc16a703b86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

