### PR TITLE
feat(cli): sync's impact lines get their own ◇ Impact block

### DIFF
--- a/packages/vendo/src/cli/pretty.ts
+++ b/packages/vendo/src/cli/pretty.ts
@@ -132,6 +132,10 @@ const PALETTE_ENTRY = /(\w+) (#[0-9a-fA-F]{6})$/;
 /** Any SGR the caller already wrote — stripped before the hexes are parsed. */
 const SGR = new RegExp(`${ESC}\\[[0-9;]*m`, "g");
 const SYNC_THEME = /^theme: (.+)$/;
+/** One `impact:` line per changed tool at the end of a sync — one block. */
+const IMPACT_LINE = "impact: ";
+/** Weight on the references, because that count is what the answer turns on. */
+const IMPACT_BREAKS = /^(.+ breaks )(.+)$/;
 const CLOUD_ABSENT = /^Vendo Cloud \(optional\): not configured\. A key unlocks (.+)\.$/;
 const CLOUD_PRESENT = /^Vendo Cloud: (.+)$/;
 const CTA = /`?vendo (cloud )?login`?/;
@@ -240,6 +244,7 @@ interface RenderState {
       hierarchy, not the rail's). */
   absorb: number;
   catalog: string[];
+  impact: string[];
   judgment: { summary: string; details: string[] } | null;
   paste: { count: number; why: string; titled: boolean } | null;
 }
@@ -252,6 +257,17 @@ function flushCatalog(state: RenderState, rail: Rail): void {
   const counts = lines.filter((entry) => !entry.startsWith(CATALOG_COMPONENTS));
   if (counts.length > 0) rail.body(counts.join(" · "));
   for (const entry of lines.filter((line) => line.startsWith(CATALOG_COMPONENTS))) rail.body(entry);
+}
+
+function flushImpact(state: RenderState, rail: Rail): void {
+  if (state.impact.length === 0) return;
+  const lines = state.impact;
+  state.impact = [];
+  rail.section(lilac("◇"), bold("Impact"));
+  for (const entry of lines) {
+    const breaks = IMPACT_BREAKS.exec(entry);
+    rail.body(breaks === null ? entry : `${breaks[1]!}${bold(breaks[2]!)}`);
+  }
 }
 
 function flushJudgment(state: RenderState, rail: Rail): void {
@@ -402,6 +418,7 @@ function renderRaw(raw: string, state: RenderState, rail: Rail): void {
   if (raw === "") {
     flushCatalog(state, rail);
     flushJudgment(state, rail);
+    flushImpact(state, rail);
     rail.bar();
     return;
   }
@@ -409,6 +426,13 @@ function renderRaw(raw: string, state: RenderState, rail: Rail): void {
     renderPaste(raw, state, rail);
     return;
   }
+  if (raw.startsWith(IMPACT_LINE)) {
+    flushCatalog(state, rail);
+    flushJudgment(state, rail);
+    state.impact.push(raw.slice(IMPACT_LINE.length));
+    return;
+  }
+  flushImpact(state, rail);
   if (CATALOG_PREFIXES.some((prefix) => raw.startsWith(prefix))) {
     flushJudgment(state, rail);
     state.catalog.push(raw);
@@ -455,7 +479,7 @@ export function createPrettyOutput(options: PrettyOptions = {}): PrettyOutput {
   let lastWasBar = false;
   let timer: ReturnType<typeof setInterval> | null = null;
   let frame = 0;
-  const state: RenderState = { absorb: 0, catalog: [], judgment: null, paste: null };
+  const state: RenderState = { absorb: 0, catalog: [], impact: [], judgment: null, paste: null };
 
   const line = (text: string): void => {
     write(`${text}\n`);
@@ -485,6 +509,7 @@ export function createPrettyOutput(options: PrettyOptions = {}): PrettyOutput {
   const flush = (): void => {
     flushCatalog(state, rail);
     flushJudgment(state, rail);
+    flushImpact(state, rail);
   };
 
   const clearFrame = (): void => {

--- a/packages/vendo/tests/cli/pretty.test.ts
+++ b/packages/vendo/tests/cli/pretty.test.ts
@@ -238,6 +238,36 @@ describe("createPrettyOutput (visual system)", () => {
     expect(plain.indexOf("◆  Judgment")).toBeLessThan(plain.indexOf("◆  Your brand"));
   });
 
+  it("gives sync's impact lines their own ◇ Impact block", () => {
+    const out = sink();
+    const pretty = createPrettyOutput({ write: out.write, banner: false, command: "vendo sync" });
+    pretty.log("impact: sendEmail breaks 2 automations, 1 app, 3 grants");
+    pretty.log("impact: createInvoice no saved references");
+    pretty.done(4200, true);
+    const block = out.plain().split("\n").filter((entry) => entry.includes("Impact")
+      || entry.includes("sendEmail") || entry.includes("createInvoice"));
+    expect(block[0]).toContain("◇  Impact");
+    expect(block[1]).toBe("│  sendEmail breaks 2 automations, 1 app, 3 grants");
+    expect(block[2]).toBe("│  createInvoice no saved references");
+    expect(block).toHaveLength(3);
+    // The title replaces the prefix; every fact is still the caller's.
+    expect(out.plain()).not.toContain("impact: ");
+    expect(out.raw()).toContain(`${ESC}[1m2 automations, 1 app, 3 grants${ESC}[22m`);
+  });
+
+  it.each([
+    ["NO_COLOR on a TTY", { isTTY: true }, { NO_COLOR: "1" }],
+    ["CI on a TTY", { isTTY: true }, { CI: "true" }],
+    ["TERM=dumb on a TTY", { isTTY: true }, { TERM: "dumb" }],
+    ["piped stdout", { isTTY: false }, {}],
+  ] as const)("leaves the impact line exactly as sync emits it under %s", (_name, stream, env) => {
+    const out = sink();
+    const message = "impact: sendEmail breaks 2 automations, 1 app, 3 grants";
+    if (usePrettyOutput(stream, env)) createPrettyOutput({ write: out.write, banner: false }).log(message);
+    else out.write(`${message}\n`);
+    expect(out.raw()).toBe(`${message}\n`);
+  });
+
   it("turns the 64-dash paste frame into a ◇ section with an indented code block", () => {
     const out = sink();
     const rule = "─".repeat(64);


### PR DESCRIPTION
One renderer rule: the `impact:` lines `vendo sync` already prints collapse into their own `◇ Impact` block, the same shape as the existing CATALOG / JUDGMENT / THEME / PASTE / SYNC_THEME rules.

## The exact strings it matches

Both are emitted by `printImpact` in `packages/vendo/src/cli/sync-flow.ts`, one line per changed tool:

- `packages/vendo/src/cli/sync-flow.ts:287` — `` `impact: ${entry.tool} no saved references` ``
- `packages/vendo/src/cli/sync-flow.ts:288` — `` `impact: ${entry.tool} breaks ${references.join(", ")}` ``

Those are the only two producers of an `impact: ` line in the repo. The rule keys on the `impact: ` prefix, strips it (the block title replaces it), and puts weight on the reference list after ` breaks `.

`impact unknown — dev server not reachable at …` (sync-flow.ts:530) is deliberately untouched: it is not an `impact: ` line and still renders as an ordinary rail line.

Nothing outside the renderer changed. No new fact, no reworded line, no change to `sync.ts` or `sync-flow.ts` — the renderer restyles and groups the caller's exact plain strings, and the only copy it owns is the block title, as it already does for "Catalog" and "Judgment".

## Before / after

Before — the lines ride the rail as plain body lines under whatever section is open:

```
┌  vendo sync
│
◆  Judgment
│  3 tools judged · hardened (1)
│  impact: sendEmail breaks 2 automations, 1 app, 3 grants
│  impact: createInvoice no saved references
```

After:

```
┌  vendo sync
│
◆  Judgment
│  3 tools judged · hardened (1)
│
◇  Impact
│  sendEmail breaks 2 automations, 1 app, 3 grants
│  createInvoice no saved references
│
└  Done in 4.2s — +2 tools · pushed to Cloud
   Star us: vendo.run/star · docs.vendo.run
```

Matches the `◇ Impact` block in the approved redesign mock.

## Degradation

Pretty-only by construction — the renderer is built only when `usePrettyOutput()` is true. Proven by a new `it.each` over NO_COLOR on a TTY / CI on a TTY / TERM=dumb on a TTY / piped stdout, each asserting the output is byte-for-byte `impact: sendEmail breaks 2 automations, 1 app, 3 grants\n` — not a single escape, prefix intact. All four pass. `--json`, the predev/prebuild hooks, exit codes and the agent tail are untouched; the pinned `usePrettyOutput (selection)` describe block is unchanged.

## Gate

- `npx vitest run tests/cli/pretty.test.ts` (in `packages/vendo`) — 53 passed / 53, 1 file passed, 67ms
- `pnpm --filter @vendoai/vendo typecheck` — exit 0, no diagnostics
- `pnpm lint` — 4 tasks successful / 4 total, 0 errors (4 pre-existing `no-unused-vars` warnings in `demo-bank`, untouched)

Yousef approved this as a renderer-only follow-up to the four init-redesign slices, the same shape as #1144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated ◇ Impact block to the pretty CLI output for `vendo sync` by grouping its `impact:` lines, matching the redesign. Non-pretty and JSON outputs are unchanged.

- Strips the `impact:` prefix and bolds the references after "breaks".
- Leaves `impact unknown — dev server not reachable…` as a normal rail line.
- Only affects pretty output; raw output, `NO_COLOR`/`CI`/`TERM=dumb`, piped stdout, and `--json` remain byte-for-byte identical.
- Adds tests in `packages/vendo/tests/cli/pretty.test.ts` to cover the new block and raw preservation.

<sup>Written for commit 09aa658868f7137ecfaec221b131fa1fecc5c8ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

