### PR TITLE
fix(cli): the device-login receipt stops printing raw JSON into a human's terminal

### DIFF
--- a/packages/vendo/src/cli/cloud-init.ts
+++ b/packages/vendo/src/cli/cloud-init.ts
@@ -203,6 +203,10 @@ export interface CloudStepOptions {
   select?: (question: string, options: SelectOption[]) => Promise<string>;
   /** The masked prompt behind "bring my own key". */
   askSecret?: (question: string, hint?: string) => Promise<string>;
+  /** The pretty renderer is driving: the ceremony drops its machine-readable
+      receipt, which is noise under a rail. Every machine-consumed path keeps
+      it — see DeviceLoginOptions.pretty. */
+  pretty?: boolean;
   cloudProbe?: (options: { env?: Record<string, string | undefined> }) => Promise<CloudDoctorResult>;
   /** The whole ceremony in one seam (default: runDeviceLogin). */
   deviceLogin?: () => Promise<number>;
@@ -351,6 +355,7 @@ async function cloudStep(options: CloudStepOptions, failure: { failedStep?: stri
       root,
       isTty: tty,
       rerunHint: false,
+      ...(options.pretty === true ? { pretty: true } : {}),
       ...(options.fetchImpl === undefined ? {} : { fetchImpl: options.fetchImpl }),
       ...(options.sleep === undefined ? {} : { sleep: options.sleep }),
     },

--- a/packages/vendo/src/cli/cloud/device-login.ts
+++ b/packages/vendo/src/cli/cloud/device-login.ts
@@ -46,6 +46,20 @@ export interface DeviceLoginOptions {
   /** init runs the ceremony inline and picks the key up in the same run —
       it suppresses the standalone "re-run `vendo init`" tail. */
   rerunHint?: boolean;
+  /**
+   * The pretty renderer is driving this ceremony, so a human is reading a rail
+   * and the machine-readable receipt below is noise sitting under the three
+   * lines of state. Suppressed there and NOWHERE else: `--agent`, `--json`,
+   * piped, non-TTY, CI and standalone `vendo login` all keep it byte for byte,
+   * because something parses each of those.
+   *
+   * Passed explicitly rather than inferred. `usePrettyOutput()` answers "is
+   * this terminal colour-capable", which is a different question — standalone
+   * `vendo login` in the same terminal has no renderer and must keep its
+   * receipt — and inferring it from `rerunHint` would give that flag a second
+   * meaning for the next reader to break silently.
+   */
+  pretty?: boolean;
   /** Where ~/.vendo lives (default: the home directory) — the pending-claim
       file that lets a fresh run resume a still-open ceremony (#479). */
   home?: string;
@@ -369,7 +383,9 @@ export async function runDeviceLogin(
         if (options.rerunHint !== false) {
           output.log("Re-run `vendo init` to finish wiring (it picks the key up from .env.local).");
         }
-        printJson(output, { deviceLogin: true, wroteEnvLocal: true, keyLast4: key.slice(-4) });
+        if (options.pretty !== true) {
+          printJson(output, { deviceLogin: true, wroteEnvLocal: true, keyLast4: key.slice(-4) });
+        }
         return "approved";
       }
 
@@ -402,12 +418,14 @@ export async function runDeviceLogin(
     // is not a failure. A re-run resumes this same claim (#479).
     const pendingExit = (): number => {
       output.log(`Still waiting on approval — code ${userCode}. Re-run \`vendo login\` to resume (it continues this same request).`);
-      printJson(output, {
-        deviceLogin: true,
-        pending: true,
-        userCode,
-        verificationUriComplete,
-      });
+      if (options.pretty !== true) {
+        printJson(output, {
+          deviceLogin: true,
+          pending: true,
+          userCode,
+          verificationUriComplete,
+        });
+      }
       return 0;
     };
 

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -1400,7 +1400,9 @@ async function resolveModelCredential(input: {
     // non-TTY guard, and cloud-init only reaches for either on a real TTY.
     select: pretty === null ? plainSelect : pretty.select,
     askSecret: pretty === null ? plainSecret : pretty.secret,
-    ...(pretty === null ? {} : { confirm: pretty.confirm }),
+    // The SAME gate that selected the renderer above: a rail is on screen, so
+    // the ceremony's machine-readable receipt would be noise under it.
+    ...(pretty === null ? {} : { confirm: pretty.confirm, pretty: true }),
     // --byo is an ANSWER to the models question, so it rides `models`.
     // --cloud-key is not: it lands the key in .env.local before this step
     // runs, so the probe finds it and the question never gets asked. Passing


### PR DESCRIPTION
`runDeviceLogin` printed its machine-readable receipt unconditionally, so a raw JSON object landed in the human's terminal immediately after the ceremony — directly under the three lines of state the init redesign had just collapsed the login down to. That undercut DONE-MEANS #16 in the one place that deliverable is actually about, and it was visible in #1146's own recording:

```
│  Opening your browser — approve the code F7K-2QM there…
│  Approved — VENDO_API_KEY saved to .env.local (…c3d4)
│  {
│    "deviceLogin": true,
│    "wroteEnvLocal": true,
│    "keyLast4": "c3d4"
│  }
```

Now suppressed only when the pretty renderer is driving the run.

### Why an explicit pass-through and not an inferred one

The parameter is deliberate, not incidental. Two cheaper-looking options are both wrong:

- **`usePrettyOutput()` inside `device-login`** answers *"is this terminal colour-capable"*, which is a different question from *"is a renderer driving this run"*. Standalone `vendo login` in that same terminal has no renderer and must keep its receipt — that gate would have silenced it too, a behaviour change well past the bug.
- **Inferring it from `rerunHint === false`** works on every real path today, and gives that flag a second meaning — "init runs the ceremony inline" *and* "a human is reading a rail". The next person to change one breaks the other silently.

So `init.ts` passes `pretty: true` at the same `pretty === null` gate that selected the renderer in the first place, and `CloudStepOptions` / `DeviceLoginOptions` each carry the boolean. Three lines.

### Two-direction proof, against the real ceremony

Both runs drive the actual `runDeviceLogin` against a scripted console; the only difference is the flag.

```
=== MACHINE PATH (pretty NOT set) — the receipt must survive
  | Vendo Cloud device login — approve the code F7K-2QM at https://cloud.test/claim?code=F7K-2QM
  | Approved — VENDO_API_KEY saved to .env.local (…aaaa)
  | Re-run `vendo init` to finish wiring (it picks the key up from .env.local).
  | {
  |   "deviceLogin": true,
  |   "wroteEnvLocal": true,
  |   "keyLast4": "aaaa"
  | }
  receipt present: true

=== RAILED PATH (pretty: true) — the receipt must be gone
  | Vendo Cloud device login — approve the code F7K-2QM at https://cloud.test/claim?code=F7K-2QM
  | Approved — VENDO_API_KEY saved to .env.local (…aaaa)
  | Re-run `vendo init` to finish wiring (it picks the key up from .env.local).
  receipt present: false

=== lines the railed path dropped:
  - {   "deviceLogin": true,   "wroteEnvLocal": true,   "keyLast4": "aaaa" }

RESULT: PASS
```

Exactly one line differs, and it is the receipt. The machine path is byte-identical to today — which is the direction that matters, since `--agent` output is pinned by a must-not-change test.

### Checks

- scoped vitest — `device-login`, `cloud-init`, `init`, `cli`, `onboarding-safety`: **167 passed (167)**
- `pnpm --filter @vendoai/vendo typecheck`: exit 0
- `pnpm lint`: exit 0 (dependency-guard OK, portability-gate all legs green)

Both `printJson` call sites are gated — the approval receipt and the `--wait` pending-exit receipt.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop printing the device-login JSON receipt to human terminals when the pretty renderer is active, keeping the login output clean. Machine-consumed paths are unchanged.

- **Bug Fixes**
  - Added `pretty?: boolean` to `DeviceLoginOptions` and `CloudStepOptions`; `init.ts` passes `pretty: true` when the renderer is used.
  - Gated both `printJson` receipts (approval and `--wait` pending) behind `options.pretty !== true`.
  - Preserved receipts for `--agent`, `--json`, piped, non-TTY, CI, and standalone `vendo login`.

<sup>Written for commit d8a8f12e334a147e886c3f4a7e7c9dd59d71adad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

