### PR TITLE
fix(cli): the judgment summary carries counts, not the model's prose

### DIFF
--- a/packages/vendo/src/cli/judge/pass.ts
+++ b/packages/vendo/src/cli/judge/pass.ts
@@ -1029,7 +1029,9 @@ function reportNarrative(input: {
   const { output, credential, judged, routed, patched, repairedStages, notes } = input;
   const { approved, declined, queued } = input.loosenings;
   output.log(`judgment (${sanitize(credential)}): ${routed.judgedNames.length} tools judged`);
-  if (routed.hardenedFields.length > 0) output.log(`  hardened (${routed.hardenedFields.length}): ${listed(routed.hardenedFields)}`);
+  // "fields", not "tools": one entry per hardened FIELD (see hardenedFields
+  // above), so this count routinely exceeds the tool count beside it.
+  if (routed.hardenedFields.length > 0) output.log(`  hardened fields (${routed.hardenedFields.length}): ${listed(routed.hardenedFields)}`);
   if (patched.written.length > 0) {
     output.log(`  schemas inferred (${patched.written.length}): ${listed(patched.written.map((entry) => `${entry.tool}.${entry.slot}`))}`);
   }

--- a/packages/vendo/src/cli/pretty.ts
+++ b/packages/vendo/src/cli/pretty.ts
@@ -109,11 +109,41 @@ const CATALOG_PREFIXES = ["tools: ", "tool schemas: ", "pins: ", "catalog.json: 
 const CATALOG_COMPONENTS = "components: ";
 const JUDGMENT_HEAD = /^judgment \(.+\): (.+)$/;
 const JUDGMENT_QUEUED = "loosenings queued";
-/** A judgment detail that is a TALLY — `hardened fields (18): …`, `loosenings
-    approved (1)`. The pass emits the model's free-text prose at the same
-    indent as its tallies, so "indented" cannot decide what belongs in the
-    counts summary; this shape can. */
-const JUDGMENT_COUNT = /^([^:]+ \(\d+\))(?::|$)/;
+/** EVERY tally `reportJudgment` prints under the head line, verbatim and in
+    its order — packages/vendo/src/cli/judge/pass.ts:1034-1075. Only these join
+    the counts summary.
+
+    An allowlist and not a shape, because the pass emits the model's free-text
+    at the SAME indent as its tallies, and prose can wear any shape: `The
+    proposal adds (2): examples` matches `<words> (N):` perfectly, so a shape
+    test lifts it into the summary and eats its tail. Prose cannot be on this
+    list, so it cannot impersonate a tally.
+
+    THE FAILURE THIS TRADES FOR: add a tally to pass.ts and not here, and it
+    renders as prose on its own body line instead of joining the summary —
+    visibly demoted, never garbled or truncated. Keep the two in step. */
+const JUDGMENT_TALLIES = [
+  "hardened fields",
+  "schemas inferred",
+  "schema proposals refused",
+  "loosenings approved",
+  "loosenings declined and dropped",
+  "rejected by the skeptic",
+  "unexamined after one re-ask, rejected",
+  "no evidence → rejected",
+  "malformed proposals ignored",
+  "risk grade contradicted its own reason, dropped",
+  "wholly rejected, left unjudged",
+  "proposals for unknown tools ignored",
+];
+/** `<allowed label> (12)` → that segment; anything else → null. The count must
+    close the label, so a tally's name list never reaches the summary. */
+function judgmentTally(text: string): string | null {
+  const label = JUDGMENT_TALLIES.find((entry) => text.startsWith(`${entry} (`));
+  if (label === undefined) return null;
+  const count = /^ \((\d+)\)(?::|$)/.exec(text.slice(label.length));
+  return count === null ? null : `${label} (${count[1]!})`;
+}
 /** The paste block's ASCII frame — dropped; the block rides the rail instead. */
 const PASTE_RULE = "─".repeat(64);
 const PASTE_HEAD = /^(ONE|\d+) STEPS? LEFT — paste th(?:is|ese) yourself \((.+)\)$/;
@@ -290,11 +320,11 @@ function flushJudgment(state: RenderState, rail: Rail): void {
   for (const detail of details) {
     const text = detail.trim();
     if (text === "") continue;
-    const count = JUDGMENT_COUNT.exec(text);
+    const tally = judgmentTally(text);
     if (text.includes(JUDGMENT_QUEUED)) queued.push(text);
     // The long name lists behind the colon are what --json and `vendo sync`
     // are for; the count clause in front of it is the summary's share.
-    else if (count !== null) counted.push(count[1]!);
+    else if (tally !== null) counted.push(tally);
     else narrative.push(text);
   }
   rail.body([summary, ...counted].join(" · "));

--- a/packages/vendo/src/cli/pretty.ts
+++ b/packages/vendo/src/cli/pretty.ts
@@ -109,7 +109,7 @@ const CATALOG_PREFIXES = ["tools: ", "tool schemas: ", "pins: ", "catalog.json: 
 const CATALOG_COMPONENTS = "components: ";
 const JUDGMENT_HEAD = /^judgment \(.+\): (.+)$/;
 const JUDGMENT_QUEUED = "loosenings queued";
-/** A judgment detail that is a TALLY — `hardened (18): …`, `loosenings
+/** A judgment detail that is a TALLY — `hardened fields (18): …`, `loosenings
     approved (1)`. The pass emits the model's free-text prose at the same
     indent as its tallies, so "indented" cannot decide what belongs in the
     counts summary; this shape can. */

--- a/packages/vendo/src/cli/pretty.ts
+++ b/packages/vendo/src/cli/pretty.ts
@@ -109,6 +109,11 @@ const CATALOG_PREFIXES = ["tools: ", "tool schemas: ", "pins: ", "catalog.json: 
 const CATALOG_COMPONENTS = "components: ";
 const JUDGMENT_HEAD = /^judgment \(.+\): (.+)$/;
 const JUDGMENT_QUEUED = "loosenings queued";
+/** A judgment detail that is a TALLY — `hardened (18): …`, `loosenings
+    approved (1)`. The pass emits the model's free-text prose at the same
+    indent as its tallies, so "indented" cannot decide what belongs in the
+    counts summary; this shape can. */
+const JUDGMENT_COUNT = /^([^:]+ \(\d+\))(?::|$)/;
 /** The paste block's ASCII frame — dropped; the block rides the rail instead. */
 const PASTE_RULE = "─".repeat(64);
 const PASTE_HEAD = /^(ONE|\d+) STEPS? LEFT — paste th(?:is|ese) yourself \((.+)\)$/;
@@ -275,14 +280,26 @@ function flushJudgment(state: RenderState, rail: Rail): void {
   const { summary, details } = state.judgment;
   state.judgment = null;
   rail.section(lilac("◆"), bold("Judgment"));
-  const queued = details.filter((detail) => detail.includes(JUDGMENT_QUEUED));
-  // Every detail line keeps its own count clause; the long name lists behind
-  // the colon are what --json and `vendo sync` are for.
-  const counted = details
-    .filter((detail) => !detail.includes(JUDGMENT_QUEUED))
-    .map((detail) => detail.trim().split(": ")[0]!);
+  // Three populations at one indent: the tallies, the one line that needs the
+  // user, and the model's prose. Only tallies join the summary — splitting a
+  // sentence on ": " both put free-text in a counts line and cut it mid-token.
+  // A blank line is dropped rather than joined, so no `·  ·` can appear.
+  const queued: string[] = [];
+  const counted: string[] = [];
+  const narrative: string[] = [];
+  for (const detail of details) {
+    const text = detail.trim();
+    if (text === "") continue;
+    const count = JUDGMENT_COUNT.exec(text);
+    if (text.includes(JUDGMENT_QUEUED)) queued.push(text);
+    // The long name lists behind the colon are what --json and `vendo sync`
+    // are for; the count clause in front of it is the summary's share.
+    else if (count !== null) counted.push(count[1]!);
+    else narrative.push(text);
+  }
   rail.body([summary, ...counted].join(" · "));
-  for (const entry of queued) rail.body(entry.trim());
+  for (const entry of queued) rail.body(entry);
+  for (const entry of narrative) rail.body(dim(entry));
 }
 
 /** A block of the extracted colour. The truecolor escape lives HERE, never in

--- a/packages/vendo/tests/cli/pretty.test.ts
+++ b/packages/vendo/tests/cli/pretty.test.ts
@@ -255,6 +255,10 @@ describe("createPrettyOutput (visual system)", () => {
     pretty.log("  ");
     pretty.log("  DELETE and PATCH are stubs. DELETE's entire body is `const { id } = await params; return NextResponse.json({ deleted: true })`");
     pretty.log("  On semantics: the response fields are named, not described");
+    // Prose wearing a tally's SHAPE — `<words> (N): <words>`. Only the label
+    // allowlist can tell this from a real tally; a shape test lifts
+    // "The proposal adds (2)" into the summary and eats ": examples".
+    pretty.log("  The proposal adds (2): examples");
     pretty.done(4200, true);
     const body = out.plain().split("\n").filter((entry) => entry.startsWith("│  "));
     const summary = body.find((entry) => entry.includes("4 tools judged"))!;
@@ -266,6 +270,8 @@ describe("createPrettyOutput (visual system)", () => {
     expect(summary).not.toContain("On semantics");
     // The mid-token cut the ": " split used to make.
     expect(summary).not.toContain("NextResponse.json({ deleted");
+    // Prose that imitates a tally contributes nothing and keeps its tail.
+    expect(summary).not.toContain("The proposal adds");
     for (const segment of summary.slice("│  ".length).split(" · ")) {
       expect(segment.trim()).not.toBe("");
     }
@@ -273,6 +279,7 @@ describe("createPrettyOutput (visual system)", () => {
     // The prose is still shown — whole, below the summary, one line each.
     expect(body).toContain("│  Two handler files back all four tools");
     expect(body).toContain("│  On semantics: the response fields are named, not described");
+    expect(body).toContain("│  The proposal adds (2): examples");
     expect(out.plain()).toContain("return NextResponse.json({ deleted: true })");
     // The blank separator lines never became empty body rows either.
     expect(body.some((entry) => entry.trim() === "│")).toBe(false);

--- a/packages/vendo/tests/cli/pretty.test.ts
+++ b/packages/vendo/tests/cli/pretty.test.ts
@@ -238,6 +238,46 @@ describe("createPrettyOutput (visual system)", () => {
     expect(plain.indexOf("◆  Judgment")).toBeLessThan(plain.indexOf("◆  Your brand"));
   });
 
+  it("keeps the model's prose out of the judgment summary, blanks and all", () => {
+    const out = sink();
+    const pretty = createPrettyOutput({ write: out.write, banner: false, command: "vendo sync" });
+    // A real run: four tools, tallies counted per FIELD, and the model's
+    // multi-sentence narrative emitted at the same indent as the tallies —
+    // blank separator lines and internal `: ` included.
+    pretty.log("judgment (claude-code): 4 tools judged");
+    pretty.log("  hardened (18): createInvoice.risk, createInvoice.description, listInvoices.title");
+    pretty.log("  schemas inferred (6): createInvoice.inputSchema, listInvoices.outputSchema");
+    pretty.log("  loosenings approved (1)");
+    pretty.log("  rejected by the skeptic (1): deleteInvoice");
+    pretty.log("  Two handler files back all four tools");
+    pretty.log("  ");
+    pretty.log("  The store is a module-level literal, const invoices = [...]. POST is the only handler that touches it — invoices.push(created) — so it is the only genuine write in the product. It is a write, not destructive");
+    pretty.log("  ");
+    pretty.log("  DELETE and PATCH are stubs. DELETE's entire body is `const { id } = await params; return NextResponse.json({ deleted: true })`");
+    pretty.log("  On semantics: the response fields are named, not described");
+    pretty.done(4200, true);
+    const body = out.plain().split("\n").filter((entry) => entry.startsWith("│  "));
+    const summary = body.find((entry) => entry.includes("4 tools judged"))!;
+
+    // Counts only — every segment is a tally, and the prose is nowhere in it.
+    expect(summary).toBe("│  4 tools judged · hardened (18) · schemas inferred (6) · loosenings approved (1) · rejected by the skeptic (1)");
+    expect(summary).not.toContain("·  ·");
+    expect(summary).not.toContain("handler files");
+    expect(summary).not.toContain("On semantics");
+    // The mid-token cut the ": " split used to make.
+    expect(summary).not.toContain("NextResponse.json({ deleted");
+    for (const segment of summary.slice("│  ".length).split(" · ")) {
+      expect(segment.trim()).not.toBe("");
+    }
+
+    // The prose is still shown — whole, below the summary, one line each.
+    expect(body).toContain("│  Two handler files back all four tools");
+    expect(body).toContain("│  On semantics: the response fields are named, not described");
+    expect(out.plain()).toContain("return NextResponse.json({ deleted: true })");
+    // The blank separator lines never became empty body rows either.
+    expect(body.some((entry) => entry.trim() === "│")).toBe(false);
+  });
+
   it("gives sync's impact lines their own ◇ Impact block", () => {
     const out = sink();
     const pretty = createPrettyOutput({ write: out.write, banner: false, command: "vendo sync" });

--- a/packages/vendo/tests/cli/pretty.test.ts
+++ b/packages/vendo/tests/cli/pretty.test.ts
@@ -223,17 +223,17 @@ describe("createPrettyOutput (visual system)", () => {
     const out = sink();
     const pretty = createPrettyOutput({ write: out.write, banner: false });
     pretty.log("judgment (claude-code): 12 tools judged");
-    pretty.log("  hardened (3): createInvoice, sendEmail, refund");
+    pretty.log("  hardened fields (3): createInvoice.risk, sendEmail.audience, refund.confirmEach");
     pretty.log("  schemas inferred (4): createInvoice.input, refund.output");
     pretty.log("  2 loosenings queued — review with `vendo sync --review`");
     pretty.log("  rejected by the skeptic (1): deleteAccount");
     pretty.log("\nTheme: accent #7c3bed");
     const plain = out.plain();
     expect(plain).toContain("◆  Judgment");
-    expect(plain).toContain("│  12 tools judged · hardened (3) · schemas inferred (4) · rejected by the skeptic (1)");
+    expect(plain).toContain("│  12 tools judged · hardened fields (3) · schemas inferred (4) · rejected by the skeptic (1)");
     expect(plain).toContain("│  2 loosenings queued — review with vendo sync --review");
     // The long name lists are gone; --json and `vendo sync` still carry them.
-    expect(plain).not.toContain("createInvoice, sendEmail, refund");
+    expect(plain).not.toContain("createInvoice.risk, sendEmail.audience, refund.confirmEach");
     // The block settles before the next section opens.
     expect(plain.indexOf("◆  Judgment")).toBeLessThan(plain.indexOf("◆  Your brand"));
   });
@@ -245,7 +245,7 @@ describe("createPrettyOutput (visual system)", () => {
     // multi-sentence narrative emitted at the same indent as the tallies —
     // blank separator lines and internal `: ` included.
     pretty.log("judgment (claude-code): 4 tools judged");
-    pretty.log("  hardened (18): createInvoice.risk, createInvoice.description, listInvoices.title");
+    pretty.log("  hardened fields (18): createInvoice.risk, createInvoice.description, listInvoices.title");
     pretty.log("  schemas inferred (6): createInvoice.inputSchema, listInvoices.outputSchema");
     pretty.log("  loosenings approved (1)");
     pretty.log("  rejected by the skeptic (1): deleteInvoice");
@@ -260,7 +260,7 @@ describe("createPrettyOutput (visual system)", () => {
     const summary = body.find((entry) => entry.includes("4 tools judged"))!;
 
     // Counts only — every segment is a tally, and the prose is nowhere in it.
-    expect(summary).toBe("│  4 tools judged · hardened (18) · schemas inferred (6) · loosenings approved (1) · rejected by the skeptic (1)");
+    expect(summary).toBe("│  4 tools judged · hardened fields (18) · schemas inferred (6) · loosenings approved (1) · rejected by the skeptic (1)");
     expect(summary).not.toContain("·  ·");
     expect(summary).not.toContain("handler files");
     expect(summary).not.toContain("On semantics");


### PR DESCRIPTION
## What the cold walk saw

Verbatim, from a real `vendo sync`:

```
◆  Judgment
│  4 tools judged · hardened (18) · schemas inferred (6) · loosenings approved (1) · rejected by the skeptic (1) · Two handler fil
es back all four tools ·  · The store is a module-level literal, const invoices = [...]. POST is the only handler that touches it
— invoices.push(created) — so it is the only genuine write in the product. It is a write, not destructive ·  · DELETE and PATCH ar
e stubs. DELETE's entire body is `const { id } = await params; return NextResponse.json({ deleted ·  · Suspicious, and the reason
I did not propose an audience narrowing ·  · On semantics ·  · Surfaces
```

Four defects, one root cause.

## Which layer was wrong: the renderer

The judgment pass emits **three different populations at the same two-space
indent**:

- tallies — `judge/pass.ts:1032-1072`, shape `  hardened fields (18): a.b, c.d`
- the one line that needs the user — `judge/pass.ts:1048`
- the model's free-text narrative — `judge/pass.ts:1087-1089`, `output.log("  " + sanitize(line))` per line, blank lines included

`pretty.ts:447-453` collected *any* indented line after the `judgment (…)` head
as a "detail", and `flushJudgment` at `pretty.ts:281-284` turned each one into a
summary segment with `detail.trim().split(": ")[0]`. So:

1. **Prose in the counts line** — "indented" was the wrong predicate. Prose is
   indented too.
2. **`·  ·`** — a blank narrative line trimmed to `""` and was joined anyway.
3. **Mid-token cut** — `split(": ")` was meant to drop a tally's name list. On
   a sentence it cuts at the first internal colon:
   `…return NextResponse.json({ deleted: true })` → `…json({ deleted`. Same
   mechanism produced the bare `On semantics` and `Surfaces` fragments.

The caller is not joining anything here — the renderer is the joining layer, and
it was joining on shape-blindness. Fix stays in `pretty.ts`: a tally-shaped
detail (`pretty.ts` `JUDGMENT_COUNT`) joins the summary; blank lines are
dropped; everything else renders dim on its own body line, whole.

## Defect 4: the number was right, the label was the lie — renamed

`routed.hardenedFields` is pushed **once per hardened FIELD**, as `tool.field`
(`packages/vendo/src/cli/judge/pass.ts:933`), and `JUDGMENT_FIELDS`
(`pass.ts:238`) has seven entries — so 18 across 4 tools is arithmetically
correct. Not a counting bug.

But `hardened (18)` sitting beside `4 tools judged` reads as "18 of 4 tools" to
anyone who has not read `pass.ts:933`. The pass's own tally line got away with
it because it prints the list that explains it; the summary drops that list, so
the label has to stand on its own.

Renamed at **`packages/vendo/src/cli/judge/pass.ts:1032`**:
`hardened (N)` → `hardened fields (N)`. The tally line and the summary segment
are produced by the same template literal, so they move together and cannot
drift.

Nothing pinned carried the old string: non-TTY/piped stdout, `--agent`,
`sync --json` `notes[]` and the predev/prebuild hook strings never name it, and
the corpus harness (`corpus/harness/src/ai/matrix.ts`) reads the structured
`counts.hardened` field, which is untouched. The only test occurrences were
`pretty.test.ts`'s simulated caller input, updated to match — including its
fixture list, which now uses the `tool.field` shape the pass actually emits.

## Fail-first

New test `keeps the model's prose out of the judgment summary, blanks and all`,
run against `main`'s `pretty.ts` (the rename is applied, so only the renderer
differs):

```
 FAIL  tests/cli/pretty.test.ts > createPrettyOutput (visual system) > keeps the model's prose out of the judgment summary, blanks and all
Expected: "│  4 tools judged · hardened fields (18) · schemas inferred (6) · loosenings approved (1) · rejected by the skeptic (1)"
Received: "│  4 tools judged · hardened fields (18) · schemas inferred (6) · loosenings approved (1) · rejected by the skeptic (1) · Two handler files back all four tools ·  · The store is a module-level literal, const invoices = [...]. POST is the only handler that touches it — invoices.push(created) — so it is the only genuine write in the product. It is a write, not destructive ·  · DELETE and PATCH are stubs. DELETE's entire body is `const { id } = await params; return NextResponse.json({ deleted · On semantics"
```

That reproduces the cold walk's `·  ·` and its `…json({ deleted` cut exactly.

## Review follow-up — Greptile P1: the matcher was still a shape test

The first pass replaced "is this line indented?" with "does this line look like
a tally?". Narrower, and still a shape question about content the renderer does
not own — so prose could still impersonate a tally and still get cut at a colon.
Greptile's example matched exactly:

```
  The proposal adds (2): examples
```

Red, against the shape matcher:

```
 FAIL  tests/cli/pretty.test.ts > createPrettyOutput (visual system) > keeps the model's prose out of the judgment summary, blanks and all
Expected: "│  4 tools judged · hardened fields (18) · schemas inferred (6) · loosenings approved (1) · rejected by the skeptic (1)"
Received: "│  4 tools judged · hardened fields (18) · schemas inferred (6) · loosenings approved (1) · rejected by the skeptic (1) · The proposal adds (2)"
```

`The proposal adds (2)` in the counts summary, `: examples` eaten.

**Fix:** `JUDGMENT_TALLIES` in `pretty.ts` — an allowlist of the twelve labels
`reportJudgment` actually prints (`judge/pass.ts:1034-1075`). Prose is not on
the list, so it cannot impersonate a tally. That is a real distinction between
structured output and free text, not a tighter guess at one. I cross-checked the
allowlist against the emitter mechanically, both directions: 12 emitted, 12
allowed, nothing missing and nothing stale.

The trade is commented at the allowlist so the next reader sees it: **a tally
added to `pass.ts` and not added here renders as prose on its own body line —
visibly demoted, never garbled or truncated.**

Green:

```
 ✓ tests/cli/pretty.test.ts (54 tests | 53 skipped) 12ms
 Test Files  1 passed (1)
      Tests  1 passed | 53 skipped (54)
```

Rendered, with the impersonating line in the input:

```
◆  Judgment
│  4 tools judged · hardened fields (18) · schemas inferred (6) · loosenings approved (1) · rejected by the skeptic (1)
│  The proposal adds (2): examples
│  On semantics: the response fields are named, not described
```

## Before / after

Same eleven caller lines, rendered through the real `createPrettyOutput`.

Before:

```
◆  Judgment
│  4 tools judged · hardened (18) · schemas inferred (6) · loosenings approved (1) · rejected by the skeptic (1) · Two handler files back all four tools ·  · The store is a module-level literal, const invoices = [...]. POST is the only handler that touches it — invoices.push(created) — so it is the only genuine write in the product. It is a write, not destructive ·  · DELETE and PATCH are stubs. DELETE's entire body is `const { id } = await params; return NextResponse.json({ deleted · On semantics
```

After:

```
┌  vendo sync
│
◆  Judgment
│  4 tools judged · hardened fields (18) · schemas inferred (6) · loosenings approved (1) · rejected by the skeptic (1)
│  Two handler files back all four tools
│  The store is a module-level literal, const invoices = [...]. POST is the only handler that touches it — invoices.push(created) — so it is the only genuine write in the product. It is a write, not destructive
│  DELETE and PATCH are stubs. DELETE's entire body is const { id } = await params; return NextResponse.json({ deleted: true })
│  On semantics: the response fields are named, not described
│
└  Done in 4.2s
   Star us: vendo.run/star · docs.vendo.run
```

## Contract

Pretty-only. `sync --json`, non-TTY/piped stdout, `--agent`, exit codes and the
predev/prebuild hook strings are untouched — the renderer is only constructed
when `usePrettyOutput()` is true, and no caller string changed.

## Gate

- `vitest run tests/cli/{sync-flow,sync,pretty}.test.ts tests/cli/judge/{pass,parse}.test.ts` — `Test Files  5 passed (5)`, `Tests  195 passed (195)` (the judge suites joined the scope once `pass.ts` was touched); re-run after the allowlist, same result
- `pnpm --filter @vendoai/vendo typecheck` — exit 0
- `pnpm lint` — exit 0, `Tasks: 4 successful, 4 total`; eslint also run directly on all three changed files, clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
