### PR TITLE
fix(cli): the piped device-login keeps its numbered contract, and the Cloud line stops being circular

### DIFF
--- a/packages/vendo/src/cli/cloud/device-login.ts
+++ b/packages/vendo/src/cli/cloud/device-login.ts
@@ -394,8 +394,12 @@ export async function runDeviceLogin(
         }
         // Never print the key itself — .env.local is the hand-off, last4 the
         // receipt. A resumed run names the full path: it may differ from cwd.
-        output.log(`Approved — VENDO_API_KEY saved to ${
-          resume !== null ? join(root, ".env.local") : ".env.local"} (…${key.slice(-4)})`);
+        // Same split as the ceremony above: the rail's phrasing is the rail's,
+        // and every non-pretty path keeps the pinned piped wording byte for byte.
+        const envLocalPath = resume !== null ? join(root, ".env.local") : ".env.local";
+        output.log(options.pretty === true
+          ? `Approved — VENDO_API_KEY saved to ${envLocalPath} (…${key.slice(-4)})`
+          : `Approved — wrote VENDO_API_KEY (…${key.slice(-4)}) to ${envLocalPath}.`);
         await ensureEnvLocalIgnored(root, output);
         if (options.rerunHint !== false) {
           output.log("Re-run `vendo init` to finish wiring (it picks the key up from .env.local).");

--- a/packages/vendo/src/cli/cloud/device-login.ts
+++ b/packages/vendo/src/cli/cloud/device-login.ts
@@ -39,8 +39,9 @@ export interface DeviceLoginOptions {
   /** Injectable pacing seam — tests run the ceremony in microseconds. */
   sleep?: (ms: number) => Promise<void>;
   now?: () => number;
-  /** TTY seam — a watching human gets the browser opened for them; a non-TTY
-      (agent) caller keeps the URL + code contract untouched. */
+  /** TTY seam — a watching human gets the browser opened for them. What the
+      ceremony PRINTS is `pretty`'s call, not this one: the numbered URL + code
+      contract holds on every non-pretty path, TTY or not. */
   isTty?: boolean;
   openBrowser?: (url: string) => void;
   /** init runs the ceremony inline and picks the key up in the same run —
@@ -242,6 +243,9 @@ export async function runDeviceLogin(
     let verificationUriComplete: string;
     if (resume !== null) {
       output.log(`Resuming pending approval — code ${resume.user_code}, approve at ${resume.verification_uri_complete}`);
+      if (options.pretty !== true) {
+        output.log(`Waiting for approval (the code expires in ${Math.max(1, Math.round((resume.expires_at - now()) / 60_000))} minutes)…`);
+      }
       claimToken = resume.claim_token;
       deadline = resume.expires_at;
       intervalMs = Math.max(resume.interval, 1) * 1000;
@@ -272,16 +276,28 @@ export async function runDeviceLogin(
 
       const approvalUrl = ceremony.verification_uri_complete ?? ceremony.verification_uri;
       const tty = options.isTty ?? (process.stdout.isTTY === true);
-      if (tty) {
-        // One line. The browser is already opening, so the code IS the whole
-        // instruction; the URL is not lost — the stall notice below carries it
-        // as the recovery path if the browser never came up.
-        output.log(`Opening your browser — approve the code ${ceremony.user_code} there…`);
-        (options.openBrowser ?? defaultOpenBrowser)(approvalUrl);
+      if (options.pretty === true) {
+        if (tty) {
+          // One line. The browser is already opening, so the code IS the whole
+          // instruction; the URL is not lost — the stall notice below carries
+          // it as the recovery path if the browser never came up.
+          output.log(`Opening your browser — approve the code ${ceremony.user_code} there…`);
+          (options.openBrowser ?? defaultOpenBrowser)(approvalUrl);
+        } else {
+          output.log(`Vendo Cloud device login — approve the code ${ceremony.user_code} at ${approvalUrl}`);
+        }
       } else {
-        // The agent path: a human is being told what to do by proxy, so the
-        // URL and the code both have to be on screen.
-        output.log(`Vendo Cloud device login — approve the code ${ceremony.user_code} at ${approvalUrl}`);
+        // Everything else — piped, --agent, CI, standalone `vendo login` —
+        // keeps the numbered ceremony byte for byte. Something parses each of
+        // those, so the collapse above is the rail's alone.
+        output.log("Vendo Cloud device login — ask your human to approve this request:");
+        output.log(`  1. Open ${approvalUrl}`);
+        output.log(`  2. Confirm the code: ${ceremony.user_code}`);
+        if (tty) {
+          output.log("Opening your browser… (approve there, then come back here)");
+          (options.openBrowser ?? defaultOpenBrowser)(approvalUrl);
+        }
+        output.log(`Waiting for approval (the code expires in ${Math.round(ceremony.expires_in / 60)} minutes)…`);
       }
 
       claimToken = ceremony.claim_token;
@@ -304,14 +320,15 @@ export async function runDeviceLogin(
       }, pendingHome);
     }
 
-    // The expiry sentence used to lead the wait, where it is pure noise — an
-    // approval that lands in ten seconds never needed it. It arrives when it
-    // becomes relevant instead: once, after the ceremony has visibly stalled,
-    // carrying the URL as the recovery path a TTY run no longer prints up top.
+    // Pretty only, and the other half of the collapse above: the rail states
+    // the expiry when it becomes relevant — once, after the ceremony has
+    // visibly stalled — instead of leading with it, carrying the URL as the
+    // recovery path the collapsed line no longer prints up top. Every other
+    // path already printed the expiry up front, exactly as it always did.
     const ceremonyStarted = now();
     let stallNoted = false;
     const noteStall = (): void => {
-      if (stallNoted || now() - ceremonyStarted < STALL_MS) return;
+      if (options.pretty !== true || stallNoted || now() - ceremonyStarted < STALL_MS) return;
       stallNoted = true;
       output.log(
         `Still waiting — the code expires in ${Math.max(1, Math.round((deadline - now()) / 60_000))} minutes. `

--- a/packages/vendo/src/cli/doctor-live.ts
+++ b/packages/vendo/src/cli/doctor-live.ts
@@ -165,8 +165,8 @@ async function readTurnStream(
  *  may contain "; " — that is the separator every caller joins and the
  *  renderer splits on. */
 export const CLOUD_UNLOCKS: readonly string[] = [
-  "a free API key — starter model allowance, no card",
-  "hosted automations, sharing, and the console",
+  "a free starter model allowance — no card, no model key of your own",
+  "hosted automations, team sharing, and the console",
 ];
 
 export interface CloudDoctorResult {

--- a/packages/vendo/tests/cli/cloud/device-login.test.ts
+++ b/packages/vendo/tests/cli/cloud/device-login.test.ts
@@ -291,9 +291,9 @@ describe("runDeviceLogin", () => {
 
   // The piped ceremony is a parsed contract, not prose: the numbered form and
   // its exact wording are what an agent (and every non-pretty caller: --agent,
-  // CI, standalone `vendo login`) reads the URL and the code out of. The
-  // one-line collapse belongs to the pretty rail and NOWHERE else.
-  it("keeps the four-line numbered ceremony byte for byte on the non-pretty path", async () => {
+  // CI, standalone `vendo login`) reads the URL, the code and the outcome out
+  // of. The rail's phrasings belong to the pretty path and NOWHERE else.
+  it("keeps the five-line ceremony byte for byte on the non-pretty path", async () => {
     const opened: string[] = [];
     const { fetchImpl } = scriptedFetch([
       { status: 200, body: { access_token: KEY, token_type: "Bearer" } },
@@ -310,11 +310,12 @@ describe("runDeviceLogin", () => {
       openBrowser: (url) => opened.push(url),
     });
     expect(exit).toBe(0);
-    expect(messages.logs.slice(0, 4)).toEqual([
+    expect(messages.logs.slice(0, 5)).toEqual([
       "Vendo Cloud device login — ask your human to approve this request:",
       "  1. Open https://console.test/claim?code=BCDF-GHJK",
       "  2. Confirm the code: BCDF-GHJK",
       "Waiting for approval (the code expires in 10 minutes)…",
+      `Approved — wrote VENDO_API_KEY (…${KEY.slice(-4)}) to .env.local.`,
     ]);
     expect(opened).toEqual([]);
   });

--- a/packages/vendo/tests/cli/cloud/device-login.test.ts
+++ b/packages/vendo/tests/cli/cloud/device-login.test.ts
@@ -289,6 +289,36 @@ describe("runDeviceLogin", () => {
     expect(messages.errors.join("\n")).toContain("Too many open claims");
   });
 
+  // The piped ceremony is a parsed contract, not prose: the numbered form and
+  // its exact wording are what an agent (and every non-pretty caller: --agent,
+  // CI, standalone `vendo login`) reads the URL and the code out of. The
+  // one-line collapse belongs to the pretty rail and NOWHERE else.
+  it("keeps the four-line numbered ceremony byte for byte on the non-pretty path", async () => {
+    const opened: string[] = [];
+    const { fetchImpl } = scriptedFetch([
+      { status: 200, body: { access_token: KEY, token_type: "Bearer" } },
+    ]);
+    const messages = output();
+    const exit = await runDeviceLogin(["--api-url", "https://console.test"], {
+      output: messages.sink,
+      fetchImpl,
+      root: await tempRoot(),
+      home: await tempRoot(),
+      sleep: async () => {},
+      env: {},
+      isTty: false,
+      openBrowser: (url) => opened.push(url),
+    });
+    expect(exit).toBe(0);
+    expect(messages.logs.slice(0, 4)).toEqual([
+      "Vendo Cloud device login — ask your human to approve this request:",
+      "  1. Open https://console.test/claim?code=BCDF-GHJK",
+      "  2. Confirm the code: BCDF-GHJK",
+      "Waiting for approval (the code expires in 10 minutes)…",
+    ]);
+    expect(opened).toEqual([]);
+  });
+
   it("opens the browser at verification_uri_complete when a TTY human is watching", async () => {
     const opened: string[] = [];
     const { fetchImpl } = scriptedFetch([
@@ -303,6 +333,7 @@ describe("runDeviceLogin", () => {
       sleep: async () => {},
       env: {},
       isTty: true,
+      pretty: true,
       openBrowser: (url) => opened.push(url),
     });
     expect(exit).toBe(0);
@@ -314,7 +345,7 @@ describe("runDeviceLogin", () => {
     expect(messages.logs.join("\n")).not.toContain("https://console.test/claim");
   });
 
-  it("holds the expiry sentence back until the ceremony has visibly stalled", async () => {
+  it("holds the expiry sentence back until the pretty ceremony has visibly stalled", async () => {
     // Leading with "the code expires in 10 minutes" is noise for an approval
     // that lands in ten seconds. It arrives when it becomes relevant, once,
     // and carries the URL a TTY run no longer prints up front.
@@ -336,6 +367,7 @@ describe("runDeviceLogin", () => {
       now: () => clock,
       env: {},
       isTty: true,
+      pretty: true,
       openBrowser: () => {},
     });
     expect(exit).toBe(0);


### PR DESCRIPTION
Two output regressions a cold walk found against the pre-redesign baseline (`fc902aa26`).

## Bug 1 — the piped ceremony lost its numbered contract

The redesign collapsed the ceremony to one line on **every** path. Piped/non-TTY is a parsed
contract, not prose — and `device-login.ts` still documented that seam as "(agent) caller keeps the
URL + code contract untouched" while it no longer did.

The collapse was approved for the human path only, so the gate is `pretty` — the same flag #1148
already threads through to decide whether the machine-readable receipt prints. Pretty keeps the
collapse; every other path — piped, `--agent`, CI, standalone `vendo login` — gets the baseline
ceremony back byte for byte.

Three deliberate calls inside that gate:

- **The stall notice is pretty-only.** It is the other half of the collapse: pretty holds the expiry
  back until it is relevant, non-pretty prints it up front as it always did. Leaving the notice on
  the piped path would add an unpinned fifth line to any run that waits >20s — the normal case — and
  print the expiry twice.
- **The resume branch gets its baseline `Waiting for approval (…)` line back**, so gating the stall
  does not leave a non-pretty resume with no expiry at all.
- **The approval receipt is gated the same way.** #1146 rephrased `Approved — wrote VENDO_API_KEY
  (…a1b2) to .env.local.` into `Approved — VENDO_API_KEY saved to .env.local (…a1b2)`. Same break,
  same file, same gate: the rail keeps the new wording, piped keeps the pinned one.

### Baseline vs new — before this PR

Real `vendo login` piped into a file against a scripted console, ephemeral port normalised to
`CONSOLE`, both from built `dist`.

```diff
--- baseline (fc902aa26)
+++ origin/main (c0f2df93a)
-Vendo Cloud device login — ask your human to approve this request:
-  1. Open http://CONSOLE/claim?code=BCDF-GHJK
-  2. Confirm the code: BCDF-GHJK
-Waiting for approval (the code expires in 10 minutes)…
+Vendo Cloud device login — approve the code BCDF-GHJK at http://CONSOLE/claim?code=BCDF-GHJK
-Approved — wrote VENDO_API_KEY (…aaaa) to .env.local.
+Approved — VENDO_API_KEY saved to .env.local (…aaaa)
 Re-run `vendo init` to finish wiring (it picks the key up from .env.local).
```

Held past the 20s stall window (25 pending polls), `main` added a further line the baseline never
printed:

```
Still waiting — the code expires in 10 minutes. Approve at http://CONSOLE/claim?code=BCDF-GHJK
```

### Baseline vs new — after this PR

Fast approval (2 pending polls) and held past the stall window (25 pending polls, ~25s):

```
$ diff baseline-fast.txt  fixed-fast.txt      # exit 0
$ diff baseline-stall.txt fixed-stall.txt     # exit 0
$ md5sum baseline-fast.txt fixed-fast.txt baseline-stall.txt fixed-stall.txt
4dbc9de486e5483f2c8db61679241117  baseline-fast.txt
4dbc9de486e5483f2c8db61679241117  fixed-fast.txt
4dbc9de486e5483f2c8db61679241117  baseline-stall.txt
4dbc9de486e5483f2c8db61679241117  fixed-stall.txt
```

Empty. A piped `vendo login` is byte-identical to pre-redesign main, end to end, including a run
that stalls:

```
Vendo Cloud device login — ask your human to approve this request:
  1. Open http://CONSOLE/claim?code=BCDF-GHJK
  2. Confirm the code: BCDF-GHJK
Waiting for approval (the code expires in 10 minutes)…
Approved — wrote VENDO_API_KEY (…aaaa) to .env.local.
Re-run `vendo init` to finish wiring (it picks the key up from .env.local).
{
  "deviceLogin": true,
  "wroteEnvLocal": true,
  "keyLast4": "aaaa"
}
```

### The new pinning test

`tests/cli/cloud/device-login.test.ts` — "keeps the five-line ceremony byte for byte on the
non-pretty path": a full non-pretty run asserting `logs.slice(0, 5)` equals the exact five strings
(the numbered ceremony, the expiry line and the approval receipt) and that no browser was launched.
All five are pinned together, so none can drift alone. The two TTY tests that cover the collapse now
pass `pretty: true`, which is what they were always describing. No pinned test was edited.

## Bug 2 — the Cloud line stopped being circular

"A key unlocks **a free API key**" is a tautology. Two bullets still, neither containing `"; "` (the
separator every caller joins on and the rail splits on):

```diff
-  "a free API key — starter model allowance, no card",
-  "hosted automations, sharing, and the console",
+  "a free starter model allowance — no card, no model key of your own",
+  "hosted automations, team sharing, and the console",
```

Rendered:

> Vendo Cloud (optional): not configured. A key unlocks a free starter model allowance — no card, no
> model key of your own; hosted automations, team sharing, and the console.

and the rail splits it back into exactly two bullets (verified against `CLOUD_ABSENT` in
`pretty.ts`).

## Gate

```
Test Files  3 passed (3)
     Tests  58 passed (58)
```
(`device-login.test.ts`, `cloud-init.test.ts`, `doctor-live.test.ts`)

`pnpm --filter @vendoai/vendo typecheck` → exit 0. `pnpm lint` → exit 0 (dependency-guard OK 30
packages, portability-gate all legs green, 4 pre-existing demo-bank warnings, 0 errors). Full suite
is CI's job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
