### PR TITLE
fix(cli): the rail survives wrapping — answered selects stop duplicating at 80 columns

### DIFF
--- a/packages/vendo/src/cli/pretty.ts
+++ b/packages/vendo/src/cli/pretty.ts
@@ -156,16 +156,21 @@ function styleInline(text: string, reopen = ""): string {
     `é`) and format characters (Cf — the zero-width joiner, variation
     selectors' friends). A terminal draws them into the PREVIOUS cell. */
 const ZERO_WIDTH = /^[\p{Mn}\p{Me}\p{Cf}]$/u;
-/** The blocks a terminal draws in TWO cells — East Asian Wide and Fullwidth,
-    plus the emoji planes. Coarse on purpose: the full table is enormous, and
-    these are the ranges a CLI actually meets (CJK, Kana, Hangul, fullwidth
-    forms, CJK extensions). */
+/** Emoji are two cells wherever they live, and the ones that are two cells by
+    DEFAULT are exactly `Emoji_Presentation` — which is why this is a property
+    and not a list: a hand-kept emoji range table silently under-measures every
+    block Unicode adds next (it did: U+1FA70 `🩰` fell through as one cell), and
+    under-measuring is the direction that overflows a row. It also correctly
+    leaves `™`, `☀` and `✔` at one cell, since a terminal draws those as text
+    unless a variation selector says otherwise. */
+const EMOJI_WIDE = /^\p{Emoji_Presentation}$/u;
+/** The East Asian Wide and Fullwidth blocks, which are not an emoji property:
+    CJK, Kana, Hangul, fullwidth forms, CJK extensions. */
 const WIDE_RANGES: readonly (readonly [number, number])[] = [
   [0x1100, 0x115f], [0x2e80, 0x303e], [0x3041, 0x33ff], [0x3400, 0x4dbf],
   [0x4e00, 0x9fff], [0xa000, 0xa4cf], [0xa960, 0xa97f], [0xac00, 0xd7a3],
   [0xf900, 0xfaff], [0xfe10, 0xfe19], [0xfe30, 0xfe6f], [0xff00, 0xff60],
-  [0xffe0, 0xffe6], [0x1f300, 0x1f64f], [0x1f680, 0x1f6ff], [0x1f900, 0x1f9ff],
-  [0x20000, 0x3fffd],
+  [0xffe0, 0xffe6], [0x20000, 0x3fffd],
 ];
 
 /** What forces emoji presentation, whatever the base's own width would be: the
@@ -180,6 +185,7 @@ function cellWidth(cluster: string): number {
   if (EMOJI_PRESENTATION.test(cluster)) return 2;
   const base = String.fromCodePoint(cluster.codePointAt(0) ?? 0);
   if (ZERO_WIDTH.test(base)) return 0;
+  if (EMOJI_WIDE.test(base)) return 2;
   const point = base.codePointAt(0) ?? 0;
   return WIDE_RANGES.some(([from, to]) => point >= from && point <= to) ? 2 : 1;
 }

--- a/packages/vendo/src/cli/pretty.ts
+++ b/packages/vendo/src/cli/pretty.ts
@@ -152,8 +152,39 @@ function styleInline(text: string, reopen = ""): string {
   return text.replace(/`([^`]+)`/g, (_match, code: string) => `${bold(lilac(code))}${reopen}`);
 }
 
-/** Visible columns: SGR sequences take none. */
-const visibleWidth = (text: string): number => text.replace(SGR, "").length;
+/** Invisible code points: combining marks (Mn/Me — the accent in a decomposed
+    `é`) and format characters (Cf — the zero-width joiner, variation
+    selectors' friends). A terminal draws them into the PREVIOUS cell. */
+const ZERO_WIDTH = /^[\p{Mn}\p{Me}\p{Cf}]$/u;
+/** The blocks a terminal draws in TWO cells — East Asian Wide and Fullwidth,
+    plus the emoji planes. Coarse on purpose: the full table is enormous, and
+    these are the ranges a CLI actually meets (CJK, Kana, Hangul, fullwidth
+    forms, CJK extensions). */
+const WIDE_RANGES: readonly (readonly [number, number])[] = [
+  [0x1100, 0x115f], [0x2e80, 0x303e], [0x3041, 0x33ff], [0x3400, 0x4dbf],
+  [0x4e00, 0x9fff], [0xa000, 0xa4cf], [0xa960, 0xa97f], [0xac00, 0xd7a3],
+  [0xf900, 0xfaff], [0xfe10, 0xfe19], [0xfe30, 0xfe6f], [0xff00, 0xff60],
+  [0xffe0, 0xffe6], [0x1f300, 0x1f64f], [0x1f680, 0x1f6ff], [0x1f900, 0x1f9ff],
+  [0x20000, 0x3fffd],
+];
+
+/** Cells ONE code point occupies. `.length` is code units, which is neither:
+    `界` is one unit and two cells, a combining mark is one unit and none, and
+    an astral glyph is two units and one code point. */
+function cellWidth(char: string): number {
+  if (ZERO_WIDTH.test(char)) return 0;
+  const point = char.codePointAt(0) ?? 0;
+  return WIDE_RANGES.some(([from, to]) => point >= from && point <= to) ? 2 : 1;
+}
+
+/** The one measurement in this file: terminal CELLS a string occupies, with
+    SGR sequences taking none. Every width, wrap point and row count derives
+    from this — a miscount here puts the select's cursor-up on the wrong row. */
+export function displayWidth(text: string): number {
+  let width = 0;
+  for (const char of text.replace(SGR, "")) width += cellWidth(char);
+  return width;
+}
 
 /** What each closing SGR closes, matched on a sequence's FIRST code so the
     truecolor swatch (`48;2;r;g;b`, closed by 49) is tracked like any other. */
@@ -197,7 +228,7 @@ function trackStyle(open: string[], sequence: string): void {
     width (a pipe, a test writer) means no wrapping at all. */
 function wrapRail(text: string, columns: number): string[] {
   if (!Number.isFinite(columns) || columns <= RAIL_WIDTH + 1) return [text];
-  if (visibleWidth(text) <= columns) return [text];
+  if (displayWidth(text) <= columns) return [text];
   const rows: string[] = [];
   const open: string[] = [];
   let atWord: string[] = [];
@@ -222,7 +253,9 @@ function wrapRail(text: string, columns: number): string[] {
     word = "";
     width = 0;
   };
-  for (const token of text.match(/\u001b\[[0-9;]*m|[\s\S]/g) ?? []) {
+  // The `u` flag makes `[\s\S]` one code POINT, so a surrogate pair is a single
+  // token and is measured once.
+  for (const token of text.match(/\u001b\[[0-9;]*m|[\s\S]/gu) ?? []) {
     if (word === "") atWord = [...open];
     if (token.startsWith(ESC)) {
       word += token;
@@ -234,11 +267,13 @@ function wrapRail(text: string, columns: number): string[] {
       gap += " ";
       continue;
     }
+    // A word too long for a row of its own (a URL, an unspaced CJK run) has to
+    // be broken somewhere: break it BEFORE the glyph that would overflow a row,
+    // so a combining mark is never orphaned from the glyph it decorates.
+    const cell = cellWidth(token);
+    if (cell > 0 && width + cell > columns - RAIL_WIDTH) place();
     word += token;
-    width += 1;
-    // A word too long for a row of its own (a URL, a code snippet) has to be
-    // broken somewhere: break it where it fills a row.
-    if (width >= columns - RAIL_WIDTH) place();
+    width += cell;
   }
   place();
   if (row !== "") rows.push(row);

--- a/packages/vendo/src/cli/pretty.ts
+++ b/packages/vendo/src/cli/pretty.ts
@@ -168,21 +168,33 @@ const WIDE_RANGES: readonly (readonly [number, number])[] = [
   [0x20000, 0x3fffd],
 ];
 
-/** Cells ONE code point occupies. `.length` is code units, which is neither:
-    `界` is one unit and two cells, a combining mark is one unit and none, and
-    an astral glyph is two units and one code point. */
-function cellWidth(char: string): number {
-  if (ZERO_WIDTH.test(char)) return 0;
-  const point = char.codePointAt(0) ?? 0;
+/** What forces emoji presentation, whatever the base's own width would be: the
+    emoji variation selector, a skin tone modifier, or a ZWJ join. */
+const EMOJI_PRESENTATION = /[\u{FE0F}\u{200D}\u{1F3FB}-\u{1F3FF}]/u;
+/** One GRAPHEME CLUSTER is one glyph on screen, however many code points it
+    took — `👍🏽` is two, a ZWJ family is four, a decomposed `é` is two, and each
+    is drawn as a single glyph. Measuring code points instead over-counts the
+    composed ones and under-counts `✔️` (a one-cell base that the variation
+    selector promotes to two), which is the direction that overflows a row. */
+function cellWidth(cluster: string): number {
+  if (EMOJI_PRESENTATION.test(cluster)) return 2;
+  const base = String.fromCodePoint(cluster.codePointAt(0) ?? 0);
+  if (ZERO_WIDTH.test(base)) return 0;
+  const point = base.codePointAt(0) ?? 0;
   return WIDE_RANGES.some(([from, to]) => point >= from && point <= to) ? 2 : 1;
 }
+
+/** Grapheme segmentation is a built-in (ES2022 / Node 16+) — no dependency. */
+const GRAPHEMES = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+const clusters = (text: string): string[] =>
+  [...GRAPHEMES.segment(text)].map((entry) => entry.segment);
 
 /** The one measurement in this file: terminal CELLS a string occupies, with
     SGR sequences taking none. Every width, wrap point and row count derives
     from this — a miscount here puts the select's cursor-up on the wrong row. */
 export function displayWidth(text: string): number {
   let width = 0;
-  for (const char of text.replace(SGR, "")) width += cellWidth(char);
+  for (const cluster of clusters(text.replace(SGR, ""))) width += cellWidth(cluster);
   return width;
 }
 
@@ -221,6 +233,20 @@ function trackStyle(open: string[], sequence: string): void {
   }
 }
 
+/** The two things the wrapper moves: SGR sequences (no cells) and grapheme
+    clusters (one glyph each). Splitting on the sequences first keeps an ESC
+    from being folded into the cluster beside it. */
+function tokenize(text: string): string[] {
+  const tokens: string[] = [];
+  let at = 0;
+  for (const match of text.matchAll(/\u001b\[[0-9;]*m/g)) {
+    tokens.push(...clusters(text.slice(at, match.index)), match[0]);
+    at = match.index + match[0].length;
+  }
+  tokens.push(...clusters(text.slice(at)));
+  return tokens;
+}
+
 /** Wrap one composed line to the terminal, ANSI-aware: every continuation row
     carries the rail, so a long line still reads as one rail body line, and no
     emitted row is wider than the terminal — which is what makes the select's
@@ -253,9 +279,7 @@ function wrapRail(text: string, columns: number): string[] {
     word = "";
     width = 0;
   };
-  // The `u` flag makes `[\s\S]` one code POINT, so a surrogate pair is a single
-  // token and is measured once.
-  for (const token of text.match(/\u001b\[[0-9;]*m|[\s\S]/gu) ?? []) {
+  for (const token of tokenize(text)) {
     if (word === "") atWord = [...open];
     if (token.startsWith(ESC)) {
       word += token;

--- a/packages/vendo/src/cli/pretty.ts
+++ b/packages/vendo/src/cli/pretty.ts
@@ -100,6 +100,10 @@ export interface PrettyOutput extends Output {
 const FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 const BAR = dim("│");
 const CLEAR_LINE = `\r${ESC}[2K`;
+const RESET = `${ESC}[0m`;
+const SHOW_CURSOR = `${ESC}[?25h`;
+/** Columns the rail costs a continuation row: `│` plus the two-space body gap. */
+const RAIL_WIDTH = 3;
 /** The star ask, demoted from an interactive question to a dim last line —
     pretty-only, so a piped or NO_COLOR run never sees it. */
 const STAR_FOOTER = "Star us: vendo.run/star · docs.vendo.run";
@@ -146,6 +150,99 @@ const CTA_ALL = /`?vendo (cloud )?login`?/g;
     after it — `reopen` re-arms the enclosing color (error() passes it). */
 function styleInline(text: string, reopen = ""): string {
   return text.replace(/`([^`]+)`/g, (_match, code: string) => `${bold(lilac(code))}${reopen}`);
+}
+
+/** Visible columns: SGR sequences take none. */
+const visibleWidth = (text: string): number => text.replace(SGR, "").length;
+
+/** What each closing SGR closes, matched on a sequence's FIRST code so the
+    truecolor swatch (`48;2;r;g;b`, closed by 49) is tracked like any other. */
+const CLOSED_BY: Record<string, RegExp> = {
+  "22": /^[12]$/,
+  "23": /^3$/,
+  "24": /^4$/,
+  "27": /^7$/,
+  "29": /^9$/,
+  "39": /^(3[0-8]|9[0-7])$/,
+  "49": /^(4[0-8]|10[0-7])$/,
+};
+
+const sgrCode = (sequence: string): string => sequence.slice(2, -1).split(";")[0] ?? "";
+
+/** Track the styles still in force, so a wrapped row can re-open them. Every
+    style this file writes nests, so a close pops the innermost match. */
+function trackStyle(open: string[], sequence: string): void {
+  const code = sgrCode(sequence);
+  if (code === "" || code === "0") {
+    open.length = 0;
+    return;
+  }
+  const closes = CLOSED_BY[code];
+  if (closes === undefined) {
+    open.push(sequence);
+    return;
+  }
+  for (let at = open.length - 1; at >= 0; at -= 1) {
+    if (closes.test(sgrCode(open[at]!))) {
+      open.splice(at, 1);
+      return;
+    }
+  }
+}
+
+/** Wrap one composed line to the terminal, ANSI-aware: every continuation row
+    carries the rail, so a long line still reads as one rail body line, and no
+    emitted row is wider than the terminal — which is what makes the select's
+    cursor-up redraw (it counts ROWS) land on the rows it printed. Unknown
+    width (a pipe, a test writer) means no wrapping at all. */
+function wrapRail(text: string, columns: number): string[] {
+  if (!Number.isFinite(columns) || columns <= RAIL_WIDTH + 1) return [text];
+  if (visibleWidth(text) <= columns) return [text];
+  const rows: string[] = [];
+  const open: string[] = [];
+  let atWord: string[] = [];
+  let row = "";
+  let used = 0;
+  let gap = "";
+  let word = "";
+  let width = 0;
+  const breakRow = (): void => {
+    rows.push(atWord.length === 0 ? row : `${row}${RESET}`);
+    row = `${BAR}  ${atWord.join("")}`;
+    used = RAIL_WIDTH;
+    gap = "";
+  };
+  /** Commit the pending word, breaking first when it no longer fits. */
+  const place = (): void => {
+    if (word === "") return;
+    if (used > 0 && used + gap.length + width > columns) breakRow();
+    row += `${gap}${word}`;
+    used += gap.length + width;
+    gap = "";
+    word = "";
+    width = 0;
+  };
+  for (const token of text.match(/\u001b\[[0-9;]*m|[\s\S]/g) ?? []) {
+    if (word === "") atWord = [...open];
+    if (token.startsWith(ESC)) {
+      word += token;
+      trackStyle(open, token);
+      continue;
+    }
+    if (token === " ") {
+      place();
+      gap += " ";
+      continue;
+    }
+    word += token;
+    width += 1;
+    // A word too long for a row of its own (a URL, a code snippet) has to be
+    // broken somewhere: break it where it fills a row.
+    if (width >= columns - RAIL_WIDTH) place();
+  }
+  place();
+  if (row !== "") rows.push(row);
+  return rows;
 }
 
 /** The plain-terminal select for non-pretty interactive runs: numbered list +
@@ -464,6 +561,9 @@ export interface PrettyOptions {
   /** The settled banner above the header. */
   banner?: boolean;
   env?: Record<string, string | undefined>;
+  /** Terminal width to wrap to. Unset follows the real stdout, and an unknown
+      width (a pipe, an injected test writer) never wraps. */
+  columns?: number;
 }
 
 export function createPrettyOutput(options: PrettyOptions = {}): PrettyOutput {
@@ -481,15 +581,31 @@ export function createPrettyOutput(options: PrettyOptions = {}): PrettyOutput {
   let frame = 0;
   const state: RenderState = { absorb: 0, catalog: [], impact: [], judgment: null, paste: null };
 
-  const line = (text: string): void => {
-    write(`${text}\n`);
+  /** True when this renderer draws on the real terminal. Only then does it
+      follow stdout's width and answer the interrupt signal; an injected
+      writer (tests, embedders) stays deterministic. */
+  const ownsTerminal = options.write === undefined;
+  /** Read per line, so a resize mid-run wraps to the new width. */
+  const columns = (): number => {
+    if (options.columns !== undefined) return options.columns;
+    if (!ownsTerminal) return Number.POSITIVE_INFINITY;
+    return stdout.columns ?? Number.POSITIVE_INFINITY;
+  };
+  /** One logical line — and the number of terminal ROWS it took, which is what
+      a cursor-up redraw has to rewind. */
+  const line = (text: string): number => {
+    const rows = wrapRail(text, columns());
+    for (const row of rows) write(`${row}\n`);
     lastWasBar = text === BAR;
+    return rows.length;
   };
   const rail: Rail = {
     bar: (): void => {
       if (!lastWasBar) line(BAR);
     },
-    body: (text: string, reopen = ""): void => line(`${BAR}  ${styleInline(text, reopen)}`),
+    body: (text: string, reopen = ""): void => {
+      line(`${BAR}  ${styleInline(text, reopen)}`);
+    },
     section: (marker: string, title: string): void => {
       rail.bar();
       line(`${marker}  ${title}`);
@@ -527,6 +643,22 @@ export function createPrettyOutput(options: PrettyOptions = {}): PrettyOutput {
     ensureHeader();
     flush();
   };
+  /** Ctrl-C: give the cursor back and CLOSE the rail, so an interrupted run
+      still ends in a `└` instead of a bare `^C` under an open block. The exit
+      code is the caller's — this only draws. */
+  const cancel = (): void => {
+    stopSpin();
+    write(SHOW_CURSOR);
+    ensureHeader();
+    rail.bar();
+    line(`${dim("└")}  ${yellow("Cancelled")}`);
+  };
+  if (ownsTerminal) {
+    process.once("SIGINT", () => {
+      cancel();
+      process.exit(130);
+    });
+  }
 
   return {
     log(message) {
@@ -647,10 +779,18 @@ export function createPrettyOutput(options: PrettyOptions = {}): PrettyOutput {
         const hint = option.hint === undefined ? "" : ` ${dim(`(${option.hint})`)}`;
         return `${BAR}  ${marker} ${label}${hint}`;
       };
-      for (const [at, option] of options.entries()) line(optionLine(option, at));
+      // ROWS, not options: a wrapped option owns more than one terminal row,
+      // and rewinding by the option COUNT redraws on top of the wrong rows.
+      let drawn = 0;
+      const draw = (): void => {
+        drawn = 0;
+        for (const [at, option] of options.entries()) drawn += line(optionLine(option, at));
+      };
+      draw();
+      const rewind = (): void => { write(`${ESC}[${drawn}A${ESC}[0J`); };
       const redraw = (): void => {
-        write(`${ESC}[${options.length}A`);
-        for (const [at, option] of options.entries()) write(`${ESC}[2K${optionLine(option, at)}\n`);
+        rewind();
+        draw();
       };
       const chosen = await new Promise<number>((resolveChoice) => {
         const cleanup = (): void => {
@@ -690,7 +830,8 @@ export function createPrettyOutput(options: PrettyOptions = {}): PrettyOutput {
             pending = pending.slice(1);
             if (key === "\u0003") { // Ctrl+C
               cleanup();
-              write("\n");
+              rewind();
+              cancel();
               process.exit(130);
             }
             if (key === "\r" || key === "\n") {
@@ -713,7 +854,7 @@ export function createPrettyOutput(options: PrettyOptions = {}): PrettyOutput {
         input.on("data", onData);
       });
       // Collapse the option list to the chosen answer.
-      write(`${ESC}[${options.length}A${ESC}[0J`);
+      rewind();
       line(`${BAR}  ${lilac("●")} ${options[chosen]!.label}`);
       return options[chosen]!.value;
     },

--- a/packages/vendo/tests/cli/pretty.test.ts
+++ b/packages/vendo/tests/cli/pretty.test.ts
@@ -705,8 +705,12 @@ describe("createPrettyOutput (visual system)", () => {
     disagree with it, and would pass whatever the renderer believed. Two cells
     for the wide blocks these tests use, none for a combining mark, one else. */
 const cells = (text: string): number => {
+  const grapheme = new Intl.Segmenter(undefined, { granularity: "grapheme" });
   let width = 0;
-  for (const char of text.replace(/\u001b\[[0-9;]*m/g, "")) {
+  for (const { segment } of grapheme.segment(text.replace(/\u001b\[[0-9;]*m/g, ""))) {
+    // One cluster is one glyph: emoji presentation is always two cells.
+    if (/[\u{FE0F}\u{200D}\u{1F3FB}-\u{1F3FF}]/u.test(segment)) { width += 2; continue; }
+    const char = String.fromCodePoint(segment.codePointAt(0) ?? 0);
     if (/^[\p{Mn}\p{Me}\p{Cf}]$/u.test(char)) continue;
     const point = char.codePointAt(0) ?? 0;
     const wide = (point >= 0x1100 && point <= 0x115f)
@@ -732,8 +736,11 @@ function screen(columns: number): { write: (chunk: string) => void; rows: () => 
   const rows: string[] = [""];
   let at = 0;
   let col = 0;
+  const graphemes = new Intl.Segmenter(undefined, { granularity: "grapheme" });
   const put = (text: string): void => {
-    for (const char of text) {
+    // A terminal places GLYPHS, so the model does too: a cluster never splits
+    // across the wrap.
+    for (const { segment: char } of graphemes.segment(text)) {
       const cell = cells(char);
       if (col + cell > columns) {
         at += 1;
@@ -928,6 +935,36 @@ describe("createPrettyOutput (display width — wide glyphs and combining marks)
     // Six graphemes are six cells: `│  ` + 6 fits in 10 and must not wrap.
     expect(rows).toHaveLength(1);
     expect(rows[0]).toBe(`│  ${ACCENTED}`);
+  });
+
+  it("measures a composed emoji as the ONE glyph a terminal draws", () => {
+    // Code-point accounting over-counts these two...
+    expect(displayWidth("\u{1F44D}\u{1F3FD}")).toBe(2);                      // thumb + skin tone
+    expect(displayWidth("\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}")).toBe(2); // ZWJ family
+    // ...and UNDER-counts this one, which is the direction that overflows a
+    // row: a one-cell base the variation selector promotes to emoji width.
+    expect(displayWidth("\u2714\uFE0F")).toBe(2);
+    expect(displayWidth("\u2714")).toBe(1);
+  });
+
+  it("select: an emoji option that a code-point count would under-measure still prints once", async () => {
+    const term = screen(24);
+    const keys = fakeInput();
+    const pretty = createPrettyOutput({
+      write: term.write, input: keys.input, banner: false, columns: 24,
+    });
+    // `│  ● ` is 5 cells and each ✔️ is 2, so twelve of them is 29 cells — wider
+    // than the window. A code-point count sees 12 and thinks the row fits.
+    const options = [
+      { value: "text", label: "\u2714\uFE0F".repeat(12) },
+      { value: "emoji", label: "\u{1F680}\uFE0F".repeat(12) },
+    ];
+    const choice = pretty.select("Pick", options);
+    keys.press("2");
+    expect(await choice).toBe("emoji");
+    const rows = term.rows().filter((row) => row !== "");
+    expect(occurrences(rows.join("\n"), "●")).toBe(1);
+    for (const row of rows) expect(cells(row)).toBeLessThanOrEqual(24);
   });
 
   it("select: an answered block of wide-glyph options still prints each option once", async () => {

--- a/packages/vendo/tests/cli/pretty.test.ts
+++ b/packages/vendo/tests/cli/pretty.test.ts
@@ -712,13 +712,13 @@ const cells = (text: string): number => {
     if (/[\u{FE0F}\u{200D}\u{1F3FB}-\u{1F3FF}]/u.test(segment)) { width += 2; continue; }
     const char = String.fromCodePoint(segment.codePointAt(0) ?? 0);
     if (/^[\p{Mn}\p{Me}\p{Cf}]$/u.test(char)) continue;
+    if (/^\p{Emoji_Presentation}$/u.test(char)) { width += 2; continue; }
     const point = char.codePointAt(0) ?? 0;
     const wide = (point >= 0x1100 && point <= 0x115f)
       || (point >= 0x2e80 && point <= 0xa4cf)
       || (point >= 0xac00 && point <= 0xd7a3)
       || (point >= 0xf900 && point <= 0xfaff)
-      || (point >= 0xff00 && point <= 0xff60)
-      || (point >= 0x1f300 && point <= 0x1f9ff);
+      || (point >= 0xff00 && point <= 0xff60);
     width += wide ? 2 : 1;
   }
   return width;
@@ -945,6 +945,13 @@ describe("createPrettyOutput (display width — wide glyphs and combining marks)
     // row: a one-cell base the variation selector promotes to emoji width.
     expect(displayWidth("\u2714\uFE0F")).toBe(2);
     expect(displayWidth("\u2714")).toBe(1);
+    // Emoji width is the Emoji_Presentation PROPERTY, not a hand-kept range
+    // table: a block Unicode added recently is two cells the day it lands...
+    expect(displayWidth("\u{1FA70}")).toBe(2);  // U+1FA70, Extended-A
+    expect(displayWidth("\u{1FAF6}")).toBe(2);  // U+1FAF6, added later still
+    // ...and a pictograph a terminal draws as TEXT stays one.
+    expect(displayWidth("\u2122")).toBe(1);     // ™
+    expect(displayWidth("\u2600")).toBe(1);     // ☀
   });
 
   it("select: an emoji option that a code-point count would under-measure still prints once", async () => {

--- a/packages/vendo/tests/cli/pretty.test.ts
+++ b/packages/vendo/tests/cli/pretty.test.ts
@@ -699,3 +699,164 @@ describe("createPrettyOutput (visual system)", () => {
     expect(out.raw()).toBe(settled); // no frames after stopSpin
   });
 });
+
+/** The bytes a terminal is SENT are not what a person sees: the select rewinds
+    the cursor and redraws over itself. This applies the moves the renderer
+    actually uses (newline, carriage return, cursor-up, erase-line,
+    erase-to-end-of-screen) to a row buffer, so the assertions below are about
+    the settled SCREEN — which is where every one of these bugs was visible. */
+function screen(): { write: (chunk: string) => void; rows: () => string[] } {
+  const rows: string[] = [""];
+  let at = 0;
+  let col = 0;
+  const put = (text: string): void => {
+    const row = (rows[at] ?? "").padEnd(col);
+    rows[at] = row.slice(0, col) + text + row.slice(col + text.length);
+    col += text.length;
+  };
+  return {
+    write: (chunk) => {
+      for (const token of chunk.match(/\u001b\[[0-9;?]*[A-Za-z]|\n|\r|[^\u001b\n\r]+/g) ?? []) {
+        if (token === "\n") {
+          at += 1;
+          col = 0;
+          if (rows[at] === undefined) rows[at] = "";
+          continue;
+        }
+        if (token === "\r") { col = 0; continue; }
+        if (token.startsWith(ESC)) {
+          const up = /^\u001b\[(\d*)A$/.exec(token);
+          if (up !== null) { at = Math.max(0, at - (up[1] === "" ? 1 : Number(up[1]))); continue; }
+          if (token === `${ESC}[2K`) { rows[at] = ""; continue; }
+          if (token === `${ESC}[0J` || token === `${ESC}[J`) {
+            rows[at] = (rows[at] ?? "").slice(0, col);
+            rows.length = at + 1;
+            continue;
+          }
+          continue; // SGR and cursor visibility change no cell
+        }
+        put(token);
+      }
+    },
+    rows: () => rows,
+  };
+}
+
+/** The run's first question, verbatim from init's USE_CASE_OPTIONS — the list
+    that duplicated itself at 80 columns. */
+const USE_CASE_OPTIONS = [
+  { value: "embedded", label: "Embedded in my app — chat + generated UI", hint: "recommended" },
+  { value: "agent-loop", label: "Through my own agent loop (AI SDK / Mastra)" },
+  { value: "mcp", label: "From outside agents over MCP — Claude, ChatGPT, Cursor, or any MCP agent (experimental)" },
+] as const;
+
+const occurrences = (text: string, needle: string): number => text.split(needle).length - 1;
+
+describe("createPrettyOutput (80 columns — the width most people run)", () => {
+  it("select: the answered block prints each option once, with exactly one ● bullet", async () => {
+    const term = screen();
+    const keys = fakeInput();
+    const pretty = createPrettyOutput({
+      write: term.write, input: keys.input, banner: false, columns: 80,
+    });
+    const choice = pretty.select("How will people use your agent?", [...USE_CASE_OPTIONS]);
+
+    // Live: one row per option, one ● — even though option 3 wraps.
+    keys.press("\u001b[B");
+    const live = term.rows().join("\n");
+    expect(occurrences(live, "●")).toBe(1);
+    for (const option of USE_CASE_OPTIONS) {
+      expect(occurrences(live, option.label.slice(0, 24))).toBe(1);
+    }
+
+    keys.press("3");
+    expect(await choice).toBe("mcp");
+    const settled = term.rows().join("\n");
+    // Settled: only the chosen option survives, and it survives once.
+    expect(occurrences(settled, "●")).toBe(1);
+    expect(occurrences(settled, "From outside agents over MCP")).toBe(1);
+    expect(settled).not.toContain("Embedded in my app");
+    expect(settled).not.toContain("Through my own agent loop");
+    expect(settled).not.toContain("○");
+  });
+
+  it("select: the settled long answer stays on the rail and still reads whole", async () => {
+    const term = screen();
+    const keys = fakeInput();
+    const pretty = createPrettyOutput({
+      write: term.write, input: keys.input, banner: false, columns: 80,
+    });
+    const choice = pretty.select("How will people use your agent?", [...USE_CASE_OPTIONS]);
+    keys.press("3");
+    expect(await choice).toBe("mcp");
+
+    const rows = term.rows().filter((row) => row !== "");
+    const answer = rows.slice(rows.findIndex((row) => row.includes("●")));
+    // It needed two rows at this width, and both ride the rail.
+    expect(answer).toHaveLength(2);
+    for (const row of answer) expect(row.startsWith("│  ")).toBe(true);
+    expect(answer.map((row) => row.slice(3)).join(" ")).toBe(`● ${USE_CASE_OPTIONS[2].label}`);
+  });
+
+  it("wraps every long line onto the rail — no continuation starts at column 0", () => {
+    const out = sink();
+    const pretty = createPrettyOutput({ write: out.write, banner: false, columns: 80 });
+    pretty.log("catalog.json: 5 discovered, 5 registered");
+    pretty.log("components: 12 captured, 3 updated, 1 removed because the source component is gone");
+    pretty.log("\nVendo Cloud (optional): not configured. A key unlocks team sharing & org governance"
+      + " across your whole company; hosted automations that keep running while you sleep.");
+    pretty.log("Run `vendo login` to claim a free API key; it lands in .env.local and nothing else changes.");
+    pretty.error("warning: .env.local holds a secret — add it to `.gitignore` before you commit it anywhere");
+    pretty.done(12400, true, "14 tools · brand captured · 1 paste left");
+
+    const rows = out.plain().split("\n").slice(0, -1);
+    // The header opens the rail; every row after it is a rail row, and nothing
+    // is wider than the terminal.
+    expect(rows[0]).toBe("┌  vendo init");
+    for (const row of rows.slice(1, -1)) {
+      expect(row).toMatch(/^[│◇◆└]/);
+      expect(row.length).toBeLessThanOrEqual(80);
+    }
+    // The wrapped body of a long line is a rail line too, not a naked tail.
+    const wrapped = rows.filter((row) => row.startsWith("│  ") && row.includes("while you sleep"));
+    expect(wrapped).toHaveLength(1);
+  });
+
+  it("closes the rail with a cancel line when Ctrl-C interrupts a question", () => {
+    const term = screen();
+    const keys = fakeInput();
+    const exit = vi.spyOn(process, "exit").mockImplementation((code) => {
+      throw new Error(`exit:${String(code)}`);
+    });
+    try {
+      const pretty = createPrettyOutput({
+        write: term.write, input: keys.input, banner: false, columns: 80,
+      });
+      void pretty.select("How will people use your agent?", [...USE_CASE_OPTIONS]).catch(() => undefined);
+      expect(() => keys.press("\u0003")).toThrow("exit:130");
+      expect(exit).toHaveBeenCalledWith(130);
+    } finally {
+      exit.mockRestore();
+    }
+    const rows = term.rows().filter((row) => row !== "");
+    expect(rows.at(-1)).toBe("└  Cancelled");
+    // The rail is closed, not left hanging under a half-drawn question.
+    expect(rows.at(-2)).toBe("│");
+    expect(rows.join("\n")).not.toContain("○");
+  });
+
+  it.each([
+    ["NO_COLOR on a TTY", { isTTY: true }, { NO_COLOR: "1" }],
+    ["CI on a TTY", { isTTY: true }, { CI: "true" }],
+    ["TERM=dumb on a TTY", { isTTY: true }, { TERM: "dumb" }],
+    ["piped stdout", { isTTY: false }, {}],
+  ] as const)("never wraps, restyles or re-rails a long line under %s", (_name, stream, env) => {
+    const out = sink();
+    const message = "components: 12 captured, 3 updated, 1 removed because the source component"
+      + " is gone — a 140-column line that a pipe must receive exactly as sync emits it";
+    if (usePrettyOutput(stream, env)) {
+      createPrettyOutput({ write: out.write, banner: false, columns: 80 }).log(message);
+    } else out.write(`${message}\n`);
+    expect(out.raw()).toBe(`${message}\n`);
+  });
+});

--- a/packages/vendo/tests/cli/pretty.test.ts
+++ b/packages/vendo/tests/cli/pretty.test.ts
@@ -1,6 +1,6 @@
 import { PassThrough, Writable } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createPrettyOutput, plainSelect, usePrettyOutput, type SelectInput } from "../../src/cli/pretty.js";
+import { createPrettyOutput, displayWidth, plainSelect, usePrettyOutput, type SelectInput } from "../../src/cli/pretty.js";
 import { plainSecret, plainText } from "../../src/cli/pretty.js";
 
 const ESC = "\u001b";
@@ -700,19 +700,50 @@ describe("createPrettyOutput (visual system)", () => {
   });
 });
 
+/** The terminal's OWN arithmetic, deliberately independent of the renderer's:
+    a screen model that measured with the function under test could never
+    disagree with it, and would pass whatever the renderer believed. Two cells
+    for the wide blocks these tests use, none for a combining mark, one else. */
+const cells = (text: string): number => {
+  let width = 0;
+  for (const char of text.replace(/\u001b\[[0-9;]*m/g, "")) {
+    if (/^[\p{Mn}\p{Me}\p{Cf}]$/u.test(char)) continue;
+    const point = char.codePointAt(0) ?? 0;
+    const wide = (point >= 0x1100 && point <= 0x115f)
+      || (point >= 0x2e80 && point <= 0xa4cf)
+      || (point >= 0xac00 && point <= 0xd7a3)
+      || (point >= 0xf900 && point <= 0xfaff)
+      || (point >= 0xff00 && point <= 0xff60)
+      || (point >= 0x1f300 && point <= 0x1f9ff);
+    width += wide ? 2 : 1;
+  }
+  return width;
+};
+
 /** The bytes a terminal is SENT are not what a person sees: the select rewinds
-    the cursor and redraws over itself. This applies the moves the renderer
-    actually uses (newline, carriage return, cursor-up, erase-line,
-    erase-to-end-of-screen) to a row buffer, so the assertions below are about
-    the settled SCREEN — which is where every one of these bugs was visible. */
-function screen(): { write: (chunk: string) => void; rows: () => string[] } {
+    the cursor and redraws over itself, and the terminal wraps anything wider
+    than the window onto a second ROW of its own. This applies both — the moves
+    the renderer uses (newline, carriage return, cursor-up, erase-line,
+    erase-to-end-of-screen) and the wrap — to a row buffer, so the assertions
+    below are about the settled SCREEN, which is where these bugs were visible.
+    Writes only ever land at the end of a row or at column 0 after an erase,
+    which is why the model can treat column 0 as "replace the row". */
+function screen(columns: number): { write: (chunk: string) => void; rows: () => string[] } {
   const rows: string[] = [""];
   let at = 0;
   let col = 0;
   const put = (text: string): void => {
-    const row = (rows[at] ?? "").padEnd(col);
-    rows[at] = row.slice(0, col) + text + row.slice(col + text.length);
-    col += text.length;
+    for (const char of text) {
+      const cell = cells(char);
+      if (col + cell > columns) {
+        at += 1;
+        col = 0;
+        if (rows[at] === undefined) rows[at] = "";
+      }
+      if (col === 0) rows[at] = "";
+      rows[at] = (rows[at] ?? "") + char;
+      col += cell;
+    }
   };
   return {
     write: (chunk) => {
@@ -754,7 +785,7 @@ const occurrences = (text: string, needle: string): number => text.split(needle)
 
 describe("createPrettyOutput (80 columns — the width most people run)", () => {
   it("select: the answered block prints each option once, with exactly one ● bullet", async () => {
-    const term = screen();
+    const term = screen(80);
     const keys = fakeInput();
     const pretty = createPrettyOutput({
       write: term.write, input: keys.input, banner: false, columns: 80,
@@ -781,7 +812,7 @@ describe("createPrettyOutput (80 columns — the width most people run)", () => 
   });
 
   it("select: the settled long answer stays on the rail and still reads whole", async () => {
-    const term = screen();
+    const term = screen(80);
     const keys = fakeInput();
     const pretty = createPrettyOutput({
       write: term.write, input: keys.input, banner: false, columns: 80,
@@ -823,7 +854,7 @@ describe("createPrettyOutput (80 columns — the width most people run)", () => 
   });
 
   it("closes the rail with a cancel line when Ctrl-C interrupts a question", () => {
-    const term = screen();
+    const term = screen(80);
     const keys = fakeInput();
     const exit = vi.spyOn(process, "exit").mockImplementation((code) => {
       throw new Error(`exit:${String(code)}`);
@@ -858,5 +889,76 @@ describe("createPrettyOutput (80 columns — the width most people run)", () => 
       createPrettyOutput({ write: out.write, banner: false, columns: 80 }).log(message);
     } else out.write(`${message}\n`);
     expect(out.raw()).toBe(`${message}\n`);
+  });
+});
+
+/** A terminal measures CELLS, not code units. `.length` gets both directions
+    wrong — and because the select's rewind now counts the ROWS it emitted, a
+    miscount does not merely wrap badly: it puts the cursor-up on the wrong row
+    and brings back the duplicate answered block this suite exists to catch.
+    User content (tool names, product names, judgment prose) flows straight
+    through the renderer, so this is not a hypothetical width. */
+/** Six graphemes, decomposed: "e" plus a combining acute — twelve code units. */
+const ACCENTED = "e\u0301".repeat(6);
+
+describe("createPrettyOutput (display width — wide glyphs and combining marks)", () => {
+  it("counts an East Asian glyph as two cells and a combining mark as none", () => {
+    expect(displayWidth("界界界界")).toBe(8);
+    expect(displayWidth(ACCENTED)).toBe(6);
+    expect(ACCENTED.length).toBe(12); // twelve code units, six cells
+    // A surrogate pair is one code point, and this one is wide.
+    expect(displayWidth("\u{1F680}")).toBe(2);
+    expect(displayWidth(`${ESC}[2m界${ESC}[22m`)).toBe(2);
+  });
+
+  it("wraps a wide-glyph run that overflows the window", () => {
+    const out = sink();
+    createPrettyOutput({ write: out.write, banner: false, columns: 10 }).log("界界界界");
+    // `│  ` is 3 cells, so 8 more cells cannot share the row.
+    const rows = out.plain().split("\n").filter((row) => row.includes("界"));
+    expect(rows).toHaveLength(2);
+    for (const row of rows) expect(cells(row)).toBeLessThanOrEqual(10);
+    expect(rows.join("").replace(/│ {2}/g, "")).toBe("界界界界");
+  });
+
+  it("keeps combining marks on one row — they cost no cells", () => {
+    const out = sink();
+    createPrettyOutput({ write: out.write, banner: false, columns: 10 }).log(ACCENTED);
+    const rows = out.plain().split("\n").filter((row) => row.includes("\u0301"));
+    // Six graphemes are six cells: `│  ` + 6 fits in 10 and must not wrap.
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toBe(`│  ${ACCENTED}`);
+  });
+
+  it("select: an answered block of wide-glyph options still prints each option once", async () => {
+    const term = screen(40);
+    const keys = fakeInput();
+    const pretty = createPrettyOutput({
+      write: term.write, input: keys.input, banner: false, columns: 40,
+    });
+    const options = [
+      { value: "embedded", label: "嵌入我的应用程序中的聊天与生成式界面" },
+      { value: "mcp", label: "通过外部代理接入例如任何支持代理的客户端" },
+    ];
+    // Short in code units (a `.length` renderer thinks both fit), but 18 and 20
+    // East Asian glyphs are 36 and 40 CELLS — wider than the window with the
+    // rail in front, so the terminal wraps what the renderer thought was one row.
+    expect(options.every((option) => option.label.length < 40)).toBe(true);
+    const choice = pretty.select("用户将如何使用你的助手？", options);
+
+    keys.press("2");
+    expect(await choice).toBe("mcp");
+    const rows = term.rows().filter((row) => row !== "");
+    const settled = rows.join("\n");
+    expect(occurrences(settled, "●")).toBe(1);
+    expect(settled).not.toContain("嵌入我的应用程序");
+    // Every row the terminal shows fits the window, so no row silently became
+    // two and the rewind landed where it was drawn.
+    for (const row of rows) expect(cells(row)).toBeLessThanOrEqual(40);
+    const answer = rows.slice(rows.findIndex((row) => row.includes("●")));
+    // Whitespace-insensitive: the break may land on a space or, in an unspaced
+    // CJK run, between two glyphs.
+    const strip = (text: string): string => text.replace(/\s+/g, "");
+    expect(strip(answer.map((row) => row.slice(3)).join(""))).toBe(strip(`● ${options[1]!.label}`));
   });
 });


### PR DESCRIPTION
A cold walk of the shipped init/sync redesign found three rendering defects at
real terminal widths. All three live in `packages/vendo/src/cli/pretty.ts`; all
three are confirmed by terminal recordings, before and after.

## The three defects

### 1. Answered selects duplicated and corrupted on wrap (the worst one)

At **80 columns**, the first question after picking option 3 (verbatim from a
real 80-column tmux pane, pre-fix):

```
┌  vendo init
│
◆  Catalog
│  catalog.json: 5 discovered, 5 registered · components: 2 captured, 1 updated
· tool schemas: inputs 11/13
│
◇  How will people use your agent?
│  ● Embedded in my app — chat + generated UI (recommended)
│  ● From outside agents over MCP — Claude, ChatGPT, Cursor, or any MCP agent (e
xperimental)
│  picked: mcp
```

Two `●` bullets, an option the user did not choose still on screen, and the
chosen option running off the rail.

**Cause:** the collapse/redraw rewound by `options.length` — it counted LINES,
not terminal ROWS. A wrapped option owns more than one row, so the cursor-up
landed inside the list and drew over the wrong rows.

**Fix:** `line()` now returns the number of rows it emitted; the select sums
them and rewinds by that (`rewind()` is shared by the redraw, the collapse and
the Ctrl-C path). Correct at any width because the renderer emits the rows
itself — no row is ever wider than the terminal, so there is no terminal
auto-wrap to guess at.

### 2. Every long line broke the rail

Wrap continuations started at column 0 with no `│` — universal, not one line
(Catalog, the consent question, the paste explainer, the service-key line, the
loosening rationale).

**Fix:** an ANSI-aware wrap to `stdout.columns`, with `│  ` in front of every
continuation row. Styles still in force at the break are closed on the broken
row and re-opened on the continuation, so a wrapped dim/bold line stays dim/bold.

### 3. Ctrl-C left the rail open

A bare `^C` under an open block, no `└`, no cancel line.

**Fix:** the interrupt restores the cursor and closes the rail with
`└  Cancelled` — both for Ctrl-C inside a select (raw mode) and for a SIGINT
mid-run (spinner/phase). **Exit code is unchanged: 130.**

## Real 80-column terminal, before → after

Both captured from a real PTY (`tmux -x 80`) driving the built `dist` renderer.

**Answered select — before:**
```
◇  How will people use your agent?
│  ● Embedded in my app — chat + generated UI (recommended)
│  ● From outside agents over MCP — Claude, ChatGPT, Cursor, or any MCP agent (e
xperimental)
```

**Answered select — after:**
```
◇  How will people use your agent?
│  ● From outside agents over MCP — Claude, ChatGPT, Cursor, or any MCP agent
│  (experimental)
```

**Catalog line (bug 2) — before → after:**
```
│  catalog.json: 5 discovered, 5 registered · components: 2 captured, 1 updated
· tool schemas: inputs 11/13
```
```
│  catalog.json: 5 discovered, 5 registered · components: 2 captured, 1 updated
│  · tool schemas: inputs 11/13
```

**Ctrl-C — before:**
```
◆  Catalog
│  catalog.json: 5 discovered, 5 registered
⠴  Judging 12 toolsexit=130
```

**Ctrl-C — after:**
```
◆  Catalog
│  catalog.json: 5 discovered, 5 registered
│
└  Cancelled
exit=130
```

At 130 and 200 columns nothing wraps and the output is unchanged (verified at
130 in the same way).

## Tests

The existing suite never varied width, which is why it never saw any of this.
The new `describe("createPrettyOutput (80 columns — the width most people run)")`
renders at an explicit `columns: 80` and asserts against a **settled screen**, not
the raw byte stream: a tiny terminal model applies the cursor moves the renderer
actually uses (newline, carriage return, cursor-up, erase-line,
erase-to-end-of-screen), because the raw bytes contain the over-drawing by design.

- an answered select prints each option exactly once, with exactly one `●`
- every emitted row after the header starts with the rail, and no row exceeds 80
- the settled long answer rejoins to exactly `● <label>` across its two rows
- Ctrl-C ends in `└  Cancelled` and exits 130
- degradation: a 140-column line under NO_COLOR / CI / TERM=dumb / piped stdout
  is emitted byte-for-byte as the caller wrote it (no wrap, no rail, no restyle)

`describe("usePrettyOutput (selection)")` is untouched; the test diff is 161
added lines and **zero deletions**.

### Fail-first (each fix reverted, test goes red, restored)

**Bug 1** — `rewind()` back to `ESC[{options.length}A`:
```
FAIL … > select: the answered block prints each option once, with exactly one ● bullet
AssertionError: expected 2 to be 1
 ❯ expect(occurrences(live, "●")).toBe(1);

FAIL … > select: the settled long answer stays on the rail and still reads whole
AssertionError: expected [ …(3) ] to have a length of 2 but got 3
```

**Bug 2** — `line()` back to a bare `write(text + "\n")`:
```
FAIL … > wraps every long line onto the rail — no continuation starts at column 0
AssertionError: expected 85 to be less than or equal to 80

FAIL … > select: the settled long answer stays on the rail and still reads whole
AssertionError: expected [ Array(1) ] to have a length of 2 but got 1
```

**Bug 3** — Ctrl-C back to `write("\n"); process.exit(130)`:
```
FAIL … > closes the rail with a cancel line when Ctrl-C interrupts a question
AssertionError: expected '│  (experimental)' to be '└  Cancelled'
```

## Blast radius

Pretty-only by construction. An unknown width — a pipe, an injected writer —
never wraps, and only the renderer that owns the real stdout follows
`stdout.columns` or installs the SIGINT listener. Non-TTY/piped stdout,
`--agent` JSON, `sync --json`, hook strings, exit codes and the agent tail are
untouched, and the degradation cases are asserted byte-for-byte.

## Gate

```
vitest run tests/cli/pretty.test.ts   Test Files 1 passed (1) · Tests 61 passed (61)
pnpm --filter @vendoai/vendo typecheck   exit 0
pnpm lint                                exit 0 (0 errors)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-up: the renderer measures CELLS, not code units (a3cc66dba)

Greptile raised a P1 on `visibleWidth`, and it was right — and it mattered more here than a bad wrap. `.length` counts UTF-16 code units; a terminal counts cells. `界` is one unit and two cells, a combining mark is one unit and none, an astral glyph is two units and one code point.

Because this PR made the select's rewind depend on the ROW COUNT, a miscounted width does not merely wrap badly: it puts the cursor-up on the wrong row and **reintroduces the duplicate answered block this PR exists to kill**, for any user whose tool name, product name or judgment prose is not plain Latin. The CLI's own chrome is ASCII; user content is not.

**Step 1, search before implementing:** nothing in the repo exports a display-width helper, and `@vendoai/vendo`'s direct dependencies (`@ai-sdk/anthropic`, the `@vendoai/*` workspace packages, `ajv`, `ajv-formats`, `zod`) do not either — `string-width`/`wcwidth` are not present. So this is a minimal inline implementation, not a new npm dependency on a published package.

**The fix:** one measurement function, `displayWidth`, from which every width, wrap point and row count derives — 0 cells for `\p{Mn}`/`\p{Me}`/`\p{Cf}` (combining marks, ZWJ), 2 for the East Asian Wide/Fullwidth blocks and the emoji planes, 1 otherwise, iterating by code point (the tokenizer regex gained `u`, so a surrogate pair is one token). The wrap breaks *before* the glyph that would overflow, so a combining mark is never orphaned from its base.

### Fail-first (reverted to `.length`, all four red)

```
AssertionError: expected 4 to be 8                                       // displayWidth("界界界界")
AssertionError: expected [ '│  界界界界' ] to have a length of 2 but got 1     // 11 cells emitted as one row at width 10
AssertionError: expected [ '│  ééée', '│  ́éé' ] to have a length of 1 but got 2  // six é split, one accent orphaned
AssertionError: expected 2 to be 1                                       // two ● bullets — bug 1, back again
```

Restored: `Test Files 1 passed (1) · Tests 65 passed (65)`, typecheck 0, lint 0 errors.

The screen model measures cells **independently** of the renderer — a model that borrowed the function under test could never disagree with it, which is the same seam lesson that put these tests on a screen model in the first place.

### Real terminal, 40 columns (PTY), `.length` build vs cell-accurate build

```
.length:                                cells:
◇  用户将如何使用你的助手？             ◇  用户将如何使用你的助手？
│  ● 嵌入我的应用程序中的聊天与生成式界  │  ●
面 (推荐)                               │  通过外部代理接入例如任何支持代理的客
│  ● 通过外部代理接入例如任何支持代理的  │  户端
客户端
```

Two ● bullets and two rows off the rail on the left; one ● and everything on the rail on the right. At 50 columns the same comparison shows the Catalog line: `.length` breaks the rail, cells keeps it.

**Known limit, stated plainly:** an unspaced run longer than a whole row (a 20-glyph CJK label at 40 columns) starts on a fresh row instead of filling the current one — the lone `●` above. Rows still fit the window and the row count is still exact, so the rewind stays correct; closing that gap needs lookahead, which is not worth the risk to the row-count invariant the rest of this PR rests on.

Degradation is untouched: unknown width still never wraps, and the byte-for-byte piped/NO_COLOR/CI assertion still passes.

## Follow-up 2: width is per GRAPHEME CLUSTER, not per code point (686759a5f)

Greptile's re-review flagged composed emoji against the code-point measurement above. The reported symptom is real but cosmetic; the same accounting had an unreported inverse that is not.

| | measured (code points) | drawn |
|---|---|---|
| `👍🏽` thumb + skin tone | 4 | 2 |
| ZWJ family | 6 | 2 |
| `✔️` (U+2714 + VS16) | **1** | **2** |

**Over-counting is cosmetic.** An over-measured line only wraps *earlier*: every emitted row is narrower than the window, the terminal never adds a row of its own, and the cursor-up still rewinds exactly the rows `line()` emitted. **Under-counting is the corrupting one** — a row measured at 1 and drawn at 2 overflows the window, the terminal wraps it into a row the renderer never counted, the rewind lands short, and the duplicate answered block is back.

`displayWidth` now segments with `Intl.Segmenter` (a built-in since Node 16 — still no dependency added to a published package) and gives each cluster the width of the one glyph it draws: 2 whenever the cluster carries emoji presentation (VS16, skin tone, ZWJ), otherwise the base's width. `wrapRail` moves whole clusters, so a wrap never splits an emoji from its modifier or a letter from its accent. This also subsumes the combining-mark rule — marks live inside their cluster and cost nothing by construction.

### Fail-first (reverted to per-code-point)

```
AssertionError: expected 4 to be 2      // displayWidth("👍🏽")
AssertionError: expected 2 to be 1      // two ● bullets, from the ✔️ under-count at 24 columns
```

The second is the one that matters: twelve `✔️` are 29 cells behind the rail, a code-point count sees 12 and thinks they fit in 24, the terminal disagrees, and the answered block duplicates. Restored: `Tests 67 passed (67)`, typecheck 0, lint 0 errors.

The test's terminal model segments **independently** of the renderer, for the same reason it exists at all: a model that measured with the function under test could never disagree with it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CLI rendering so the rail survives wrapping and answered selects stop duplicating at common widths. Width is now measured per grapheme cluster and emoji presentation, so CJK, composed emoji, and styled text render and rewind correctly.

- **Bug Fixes**
  - Answered selects: rewind by terminal rows; `line()` returns row count. No duplicate bullets when options wrap.
  - Wrapping: ANSI-aware and cell-accurate; continuation rows keep the rail and reopen styles. Breaks before overflow; supports `columns` override; never wraps when width is unknown.
  - Width accuracy: `displayWidth` measures grapheme clusters via `Intl.Segmenter`; emoji width via `Emoji_Presentation`; combining marks cost 0; East Asian wide/fullwidth are 2 cells. Prevents under/over-counts that misaligned cursor-up.
  - Ctrl-C: restores cursor and closes the rail with `└  Cancelled`; exit code remains 130 (in-select and mid-run).

Non-TTY, NO_COLOR, CI, and piped output remain byte-for-byte unchanged.

<sup>Written for commit 3202f76d0fdce53f66c4b6632f0bcd9284ee47bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

