### PR TITLE
feat(store): appData — the owner-stamped family for what generated apps invent

### DIFF
--- a/.changeset/store-app-data-family.md
+++ b/.changeset/store-app-data-family.md
@@ -1,0 +1,44 @@
+---
+"@vendoai/core": minor
+"@vendoai/store": minor
+"@vendoai/vendo": minor
+---
+
+`appData` — the store family for everything generated apps invent.
+
+The `StoreOps` contract grows from 27 ops across 7 families to 35 across 8. The
+new family is `appData`, and it exists because generic `records.*` made every
+app's data one flat namespace with no answer to "whose row is this".
+
+**Every appData row is owner-stamped, by the runtime.** `appData.put` writes
+`refs.subject = <caller>` from the host's login session. Generated code has no
+field for the owner and cannot invent one: a caller that supplies `refs.subject`
+itself is refused with `validation`, never silently overwritten. Unstamped rows
+cannot exist.
+
+**Reads are auto-scoped, so permission IS the query.** `list` ANDs the stamp
+into `query.refs`, `get` returns `null` for another owner's row, and `delete`
+no-ops on one — the read and the delete share a transaction, so a foreign row
+cannot be raced out from under the check. Caller refs still filter alongside the
+stamp. There is no rules language and no policy DSL to get wrong.
+
+The stamp is `refs.subject`, deliberately not a new column: the erase cascade
+already deletes stamped rows and the GIN index on `refs` already serves scoped
+reads, so this ships with **no schema change**. `@vendoai/store` gains one
+composer, `app-data-rows.ts`, as the single place that spells
+`app:<appId>:<collection>` and the `<owner>/` file-key prefix.
+
+**File twins take a required owner.** `putFile`/`getFile`/`listFiles`/
+`deleteFile` live in the app's existing blob namespace under an `<owner>/` key
+prefix, which `listFiles` strips on the way out. One new erase selector sweeps
+those keys on the subject axis, so a member's files inside a *promoted* org app
+— an app the org owns, which the subject cascade never reached — now die with
+the member.
+
+All eight verbs speak `vendo/store-wire@1` at `/app-data/*` with exported
+request schemas, and are implemented by the local Postgres backend, the Cloud
+client, and the in-core memory reference. Ten conformance cases pin the
+behavior in one place and every backend runs them. `StoreWireStatus` also gains
+an optional `deprecated` list so a mount can announce ops it is retiring.
+
+`StoreAdapter` — the BYO seam — is untouched.

--- a/.changeset/store-app-data-family.md
+++ b/.changeset/store-app-data-family.md
@@ -18,9 +18,11 @@ cannot exist.
 
 **Reads are auto-scoped, so permission IS the query.** `list` ANDs the stamp
 into `query.refs`, `get` returns `null` for another owner's row, and `delete`
-no-ops on one — the read and the delete share a transaction, so a foreign row
-cannot be raced out from under the check. Caller refs still filter alongside the
-stamp. There is no rules language and no policy DSL to get wrong.
+no-ops on one — one owner-predicated statement, so there is no window in which a
+foreign row can be raced out from under a check. A `put` against an id another
+owner holds is refused with `conflict` rather than overwriting and re-stamping
+it. Caller refs still filter alongside the stamp. There is no rules language and
+no policy DSL to get wrong.
 
 The stamp is `refs.subject`, deliberately not a new column: the erase cascade
 already deletes stamped rows and the GIN index on `refs` already serves scoped
@@ -37,7 +39,7 @@ the member.
 
 All eight verbs speak `vendo/store-wire@1` at `/app-data/*` with exported
 request schemas, and are implemented by the local Postgres backend, the Cloud
-client, and the in-core memory reference. Ten conformance cases pin the
+client, and the in-core memory reference. Eleven conformance cases pin the
 behavior in one place and every backend runs them. `StoreWireStatus` also gains
 an optional `deprecated` list so a mount can announce ops it is retiring.
 

--- a/packages/core/src/conformance/memory-store-ops.ts
+++ b/packages/core/src/conformance/memory-store-ops.ts
@@ -209,6 +209,9 @@ export function memoryStoreOps(): StoreOps {
       name. The real backend composes both in one place, which core cannot
       import. */
   const appCollection = (target: AppDataTarget): string => {
+    if (target.appId === "" || target.appId.includes(":")) {
+      throw new VendoError("validation", `app data appId "${target.appId}" must be non-empty and free of ":"`);
+    }
     if (!APP_DATA_COLLECTION_PATTERN.test(target.collection)) {
       throw new VendoError("validation", `app data collection "${target.collection}" is not a legal name`);
     }
@@ -229,6 +232,10 @@ export function memoryStoreOps(): StoreOps {
     async put(target, record) {
       const collection = appCollection(target);
       refuseSubject(record.refs, "put");
+      const held = col(collection).get(record.id);
+      if (held !== undefined && held.refs?.["subject"] !== target.owner) {
+        throw new VendoError("conflict", `app data id "${record.id}" is already held in this collection`);
+      }
       return records.put(collection, { ...record, refs: { ...record.refs, subject: target.owner } });
     },
     async get(target, id) {

--- a/packages/core/src/conformance/memory-store-ops.ts
+++ b/packages/core/src/conformance/memory-store-ops.ts
@@ -1,11 +1,13 @@
 import { VendoError } from "../errors.js";
 import type { IsoDateTime } from "../ids.js";
 import { VENDO_STORE_WIRE_FORMAT, type StoreWireStatus } from "../store-wire.js";
-import type {
-  RecordInput,
-  RecordQuery,
-  StoreOps,
-  VendoRecord,
+import {
+  APP_DATA_COLLECTION_PATTERN,
+  type AppDataTarget,
+  type RecordInput,
+  type RecordQuery,
+  type StoreOps,
+  type VendoRecord,
 } from "../store.js";
 
 // ---------------------------------------------------------------------------
@@ -195,6 +197,66 @@ export function memoryStoreOps(): StoreOps {
     },
     async list(namespace, prefix = "") {
       return [...ns(namespace).keys()].filter((k) => k.startsWith(prefix));
+    },
+  };
+
+  // ---------------------------------------------------------------------------
+  // appData family
+  // ---------------------------------------------------------------------------
+
+  /** The reference's own copy of the naming grammar — rows land in one
+      collection per app+collection, files in the blob namespace of the same
+      name. The real backend composes both in one place, which core cannot
+      import. */
+  const appCollection = (target: AppDataTarget): string => {
+    if (!APP_DATA_COLLECTION_PATTERN.test(target.collection)) {
+      throw new VendoError("validation", `app data collection "${target.collection}" is not a legal name`);
+    }
+    return `app:${target.appId}:${target.collection}`;
+  };
+
+  /** Files are scoped by key prefix rather than by a stamp, so the owner leg
+      never reaches the caller — `listFiles` strips it back off. */
+  const ownedKey = (target: AppDataTarget, key: string): string => `${target.owner}/${key}`;
+
+  const refuseSubject = (refs: Record<string, string> | undefined, verb: string): void => {
+    if (refs !== undefined && "subject" in refs) {
+      throw new VendoError("validation", `appData.${verb} may not supply refs.subject; the owner is stamped from the session`);
+    }
+  };
+
+  const appData: StoreOps["appData"] = {
+    async put(target, record) {
+      const collection = appCollection(target);
+      refuseSubject(record.refs, "put");
+      return records.put(collection, { ...record, refs: { ...record.refs, subject: target.owner } });
+    },
+    async get(target, id) {
+      const record = await records.get(appCollection(target), id);
+      return record?.refs?.["subject"] === target.owner ? record : null;
+    },
+    async list(target, query = {}) {
+      const collection = appCollection(target);
+      refuseSubject(query.refs, "list");
+      return records.list(collection, { ...query, refs: { ...query.refs, subject: target.owner } });
+    },
+    async delete(target, id) {
+      const collection = appCollection(target);
+      if (col(collection).get(id)?.refs?.["subject"] !== target.owner) return;
+      await records.delete(collection, id);
+    },
+    async putFile(target, key, bytes, meta) {
+      await blobs.put(appCollection(target), ownedKey(target, key), bytes, meta);
+    },
+    async getFile(target, key) {
+      return blobs.get(appCollection(target), ownedKey(target, key));
+    },
+    async listFiles(target, prefix = "") {
+      const keys = await blobs.list(appCollection(target), ownedKey(target, prefix));
+      return keys.map((key) => key.slice(target.owner.length + 1));
+    },
+    async deleteFile(target, key) {
+      await blobs.delete(appCollection(target), ownedKey(target, key));
     },
   };
 
@@ -472,12 +534,13 @@ export function memoryStoreOps(): StoreOps {
   return {
     records,
     blobs,
+    appData,
     transcripts,
     harness,
     workspace,
     lifecycle,
     async status(): Promise<StoreWireStatus> {
-      return { format: VENDO_STORE_WIRE_FORMAT, ops: 27 };
+      return { format: VENDO_STORE_WIRE_FORMAT, ops: 35 };
     },
   };
 }

--- a/packages/core/src/conformance/store-ops.ts
+++ b/packages/core/src/conformance/store-ops.ts
@@ -347,13 +347,38 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         assert(await ops.appData.get(other, "secret") === null, "get read another owner's row");
       }),
 
-      opsCase(opts, "appData.delete does not delete another owner's row", async (ops) => {
+      /** Both halves, deliberately: a `delete` that does nothing at all also
+          leaves the other owner's row alone, so the negative assertion on its
+          own is passed by an empty function. */
+      opsCase(opts, "appData.delete deletes only the caller's own row", async (ops) => {
         await seedApp(ops, "app_delscope");
         const owner = { appId: "app_delscope", collection: "notes", owner: "own_a" };
         const other = { appId: "app_delscope", collection: "notes", owner: "own_b" };
         await ops.appData.put(owner, { id: "keep", data: { v: 1 } });
         await ops.appData.delete(other, "keep");
         assert(await ops.appData.get(owner, "keep") !== null, "delete destroyed another owner's row");
+        await ops.appData.delete(owner, "keep");
+        assert(await ops.appData.get(owner, "keep") === null, "delete left the owner's own row behind");
+      }),
+
+      /** `put` has `records.put`'s blast radius — an unconditional upsert on
+          (collection, id) — so an id another owner holds must be refused, not
+          overwritten and re-stamped into a row the loser can neither read nor
+          delete. */
+      opsCase(opts, "appData.put refuses an id another owner holds", async (ops) => {
+        await seedApp(ops, "app_putconflict");
+        const owner = { appId: "app_putconflict", collection: "notes", owner: "own_a" };
+        const other = { appId: "app_putconflict", collection: "notes", owner: "own_b" };
+        await ops.appData.put(owner, { id: "taken", data: { v: 1 } });
+        await assertThrowsCode(
+          () => ops.appData.put(other, { id: "taken", data: { v: 2 } }),
+          "conflict",
+          "a put against an id another owner holds",
+        );
+        const still = await ops.appData.get(owner, "taken");
+        assert(still !== null, "the refused put destroyed the holder's row");
+        assertDeepEqual(still!.data, { v: 1 }, "the refused put overwrote the holder's row");
+        assert(await ops.appData.get(other, "taken") === null, "the refused put re-stamped the row");
       }),
 
       opsCase(opts, "appData.list honors caller refs alongside the owner scope", async (ops) => {
@@ -384,6 +409,9 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         assert(await ops.appData.getFile(other, "receipt.bin") === null, "getFile read another owner's file");
         await ops.appData.deleteFile(other, "receipt.bin");
         assert(await ops.appData.getFile(owner, "receipt.bin") !== null, "deleteFile destroyed another owner's file");
+        // The positive half — without it an empty deleteFile passes the line above.
+        await ops.appData.deleteFile(owner, "receipt.bin");
+        assert(await ops.appData.getFile(owner, "receipt.bin") === null, "deleteFile left the owner's own file behind");
       }),
 
       /** The owner prefix is the backend's scoping mechanism, not part of the
@@ -416,12 +444,29 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         assert(put.id === "ok", "a legal box: collection was not accepted");
 
         for (const collection of ["has spaces", "a/b"]) {
+          const illegal = { appId: "app_grammar", collection, owner: "own_a" };
           await assertThrowsCode(
-            () => ops.appData.put({ appId: "app_grammar", collection, owner: "own_a" }, { id: "no", data: {} }),
+            () => ops.appData.put(illegal, { id: "no", data: {} }),
             "validation",
-            `the collection name ${JSON.stringify(collection)}`,
+            `the collection name ${JSON.stringify(collection)} on put`,
+          );
+          // A read verb too: the name is composed on every verb, not just writes.
+          await assertThrowsCode(
+            () => ops.appData.get(illegal, "no"),
+            "validation",
+            `the collection name ${JSON.stringify(collection)} on get`,
           );
         }
+
+        // The appId shares the name with the collection and is parsed back out
+        // of it on the assumption it holds no colon, so it carries its own
+        // refusal: "app_grammar:box" + "evil" would otherwise be the same
+        // drawer as "app_grammar" + "box:evil".
+        await assertThrowsCode(
+          () => ops.appData.put({ appId: "app_grammar:box", collection: "evil", owner: "own_a" }, { id: "no", data: {} }),
+          "validation",
+          "an appId containing a colon",
+        );
       }),
 
       // =====================================================================

--- a/packages/core/src/conformance/store-ops.ts
+++ b/packages/core/src/conformance/store-ops.ts
@@ -73,8 +73,23 @@ const numberField = (entry: unknown, field: string, message: string): number => 
 
 /** A thread's harness state rides the harness slot under this synthetic appId
     (the store's `harnessStateKey`), which is what makes deleteThread's cascade
-    onto harness state observable through the 27 ops. */
+    onto harness state observable through the 35 ops. */
 const harnessSlot = (threadId: string): string => `harness_state:${threadId}`;
+
+/** appData rows live in the app's own drawer, and the local backend fails an
+    app-scoped write closed when the app has no row — so every appData case
+    seeds one first, with the shape the typed `vendo_apps` door accepts. */
+const seedApp = async (ops: StoreOps, appId: string): Promise<void> => {
+  await ops.records.put("vendo_apps", {
+    id: appId,
+    data: {
+      subject: "user_1",
+      enabled: true,
+      doc: { format: "vendo/app@1", id: appId, name: appId },
+    },
+    refs: { subject: "user_1" },
+  });
+};
 
 // ---------------------------------------------------------------------------
 // suite
@@ -264,6 +279,149 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
           ["images/a.png", "images/b.png"],
           "blob prefix list returned the wrong keys",
         );
+      }),
+
+      // =====================================================================
+      // appData
+      // =====================================================================
+
+      opsCase(opts, "appData.put stamps the target owner as refs.subject", async (ops) => {
+        await seedApp(ops, "app_stamp");
+        const target = { appId: "app_stamp", collection: "notes", owner: "own_a" };
+        const put = await ops.appData.put(target, { id: "n1", data: { text: "hi" } });
+        assert(
+          put.refs?.["subject"] === "own_a",
+          `put should stamp the owner as refs.subject, got ${String(put.refs?.["subject"])}`,
+        );
+        const got = await ops.appData.get(target, "n1");
+        assert(got?.refs?.["subject"] === "own_a", "the stamped record did not read back for its owner");
+      }),
+
+      /** Generated code has no field for the owner, so a `refs.subject` in the
+          record is a caller trying to write as someone else. Refused, never
+          silently overwritten with the real owner. */
+      opsCase(opts, "appData.put refuses a caller-supplied refs.subject", async (ops) => {
+        await seedApp(ops, "app_putsub");
+        const target = { appId: "app_putsub", collection: "notes", owner: "own_a" };
+        await assertThrowsCode(
+          () => ops.appData.put(target, { id: "n1", data: {}, refs: { subject: "own_b" } }),
+          "validation",
+          "a caller-supplied refs.subject on appData.put",
+        );
+        assert(await ops.appData.get(target, "n1") === null, "the refused put wrote its row anyway");
+      }),
+
+      opsCase(opts, "appData.list refuses a caller-supplied refs.subject", async (ops) => {
+        await seedApp(ops, "app_listsub");
+        const target = { appId: "app_listsub", collection: "notes", owner: "own_a" };
+        await assertThrowsCode(
+          () => ops.appData.list(target, { refs: { subject: "own_b" } }),
+          "validation",
+          "a caller-supplied refs.subject on appData.list",
+        );
+      }),
+
+      opsCase(opts, "appData.list never returns another owner's rows", async (ops) => {
+        await seedApp(ops, "app_scope");
+        const a = { appId: "app_scope", collection: "notes", owner: "own_a" };
+        const b = { appId: "app_scope", collection: "notes", owner: "own_b" };
+        await ops.appData.put(a, { id: "mine", data: {} });
+        await ops.appData.put(b, { id: "theirs", data: {} });
+        assertDeepEqual(
+          (await ops.appData.list(a)).records.map((r) => r.id),
+          ["mine"],
+          "list returned rows outside the target owner's scope",
+        );
+        assertDeepEqual(
+          (await ops.appData.list(b)).records.map((r) => r.id),
+          ["theirs"],
+          "list returned rows outside the target owner's scope",
+        );
+      }),
+
+      opsCase(opts, "appData.get returns null for another owner's row", async (ops) => {
+        await seedApp(ops, "app_getscope");
+        const owner = { appId: "app_getscope", collection: "notes", owner: "own_a" };
+        const other = { appId: "app_getscope", collection: "notes", owner: "own_b" };
+        await ops.appData.put(owner, { id: "secret", data: { v: 1 } });
+        assert(await ops.appData.get(other, "secret") === null, "get read another owner's row");
+      }),
+
+      opsCase(opts, "appData.delete does not delete another owner's row", async (ops) => {
+        await seedApp(ops, "app_delscope");
+        const owner = { appId: "app_delscope", collection: "notes", owner: "own_a" };
+        const other = { appId: "app_delscope", collection: "notes", owner: "own_b" };
+        await ops.appData.put(owner, { id: "keep", data: { v: 1 } });
+        await ops.appData.delete(other, "keep");
+        assert(await ops.appData.get(owner, "keep") !== null, "delete destroyed another owner's row");
+      }),
+
+      opsCase(opts, "appData.list honors caller refs alongside the owner scope", async (ops) => {
+        await seedApp(ops, "app_refs");
+        const a = { appId: "app_refs", collection: "notes", owner: "own_a" };
+        const b = { appId: "app_refs", collection: "notes", owner: "own_b" };
+        await ops.appData.put(a, { id: "inv", data: {}, refs: { kind: "invoice" } });
+        await ops.appData.put(a, { id: "memo", data: {}, refs: { kind: "memo" } });
+        await ops.appData.put(b, { id: "their_inv", data: {}, refs: { kind: "invoice" } });
+        assertDeepEqual(
+          (await ops.appData.list(a, { refs: { kind: "invoice" } })).records.map((r) => r.id),
+          ["inv"],
+          "the caller's refs filter and the owner scope did not both apply",
+        );
+      }),
+
+      opsCase(opts, "appData file twins round-trip and stay owner-isolated", async (ops) => {
+        await seedApp(ops, "app_files");
+        const owner = { appId: "app_files", collection: "notes", owner: "own_a" };
+        const other = { appId: "app_files", collection: "notes", owner: "own_b" };
+        const bytes = new Uint8Array([0, 7, 255]);
+        await ops.appData.putFile(owner, "receipt.bin", bytes, { contentType: "application/octet-stream" });
+        const got = await ops.appData.getFile(owner, "receipt.bin");
+        assert(got !== null, "the stored file returned null for its owner");
+        assertBytesEqual(got!.bytes, bytes, "file bytes did not round-trip");
+        assert(got!.contentType === "application/octet-stream", "file contentType did not round-trip");
+
+        assert(await ops.appData.getFile(other, "receipt.bin") === null, "getFile read another owner's file");
+        await ops.appData.deleteFile(other, "receipt.bin");
+        assert(await ops.appData.getFile(owner, "receipt.bin") !== null, "deleteFile destroyed another owner's file");
+      }),
+
+      /** The owner prefix is the backend's scoping mechanism, not part of the
+          caller's key space: a generated app that stored `receipt.bin` must get
+          `receipt.bin` back, and its prefix filters are its own keys' prefixes. */
+      opsCase(opts, "appData.listFiles returns keys without the owner prefix", async (ops) => {
+        await seedApp(ops, "app_listfiles");
+        const owner = { appId: "app_listfiles", collection: "notes", owner: "own_a" };
+        const other = { appId: "app_listfiles", collection: "notes", owner: "own_b" };
+        await ops.appData.putFile(owner, "images/a.png", new Uint8Array([1]));
+        await ops.appData.putFile(owner, "docs/a.txt", new Uint8Array([2]));
+        await ops.appData.putFile(other, "images/b.png", new Uint8Array([3]));
+
+        assertDeepEqual(
+          (await ops.appData.listFiles(owner)).sort(),
+          ["docs/a.txt", "images/a.png"],
+          "listFiles returned prefixed keys or crossed owners",
+        );
+        assertDeepEqual(
+          await ops.appData.listFiles(owner, "images/"),
+          ["images/a.png"],
+          "the prefix filter was not relative to the caller's own key space",
+        );
+      }),
+
+      opsCase(opts, "appData refuses a collection name outside the grammar", async (ops) => {
+        await seedApp(ops, "app_grammar");
+        const legal = { appId: "app_grammar", collection: "box:inbox", owner: "own_a" };
+        const put = await ops.appData.put(legal, { id: "ok", data: {} });
+        assert(put.id === "ok", "a legal box: collection was not accepted");
+
+        for (const collection of ["has spaces", "a/b"]) {
+          await assertThrowsCode(
+            () => ops.appData.put({ appId: "app_grammar", collection, owner: "own_a" }, { id: "no", data: {} }),
+            "validation",
+            `the collection name ${JSON.stringify(collection)}`,
+          );
+        }
       }),
 
       // =====================================================================
@@ -786,7 +944,7 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         const status = await ops.status();
         assert(status.format === VENDO_STORE_WIRE_FORMAT, `status.format should be ${VENDO_STORE_WIRE_FORMAT}`);
         assert(typeof status.ops === "number", "status.ops should be a number");
-        assert(status.ops === 27, `status.ops should be 27, got ${status.ops}`);
+        assert(status.ops === 35, `status.ops should be 35, got ${status.ops}`);
       }),
     ],
   };

--- a/packages/core/src/store-wire.ts
+++ b/packages/core/src/store-wire.ts
@@ -152,8 +152,7 @@ export const storeWireBlobsListRequestSchema = z.object({
 // ---------------------------------------------------------------------------
 
 /** The owner on the target is the runtime's stamp from the host's login
-    session, never something generated code names. File bytes are base64 on the
-    wire, exactly like `blobs.put`. */
+    session, never something generated code names. */
 export const appDataTargetSchema = z.object({
   appId: z.string().min(1),
   collection: z.string().regex(APP_DATA_COLLECTION_PATTERN),
@@ -180,6 +179,7 @@ export const storeWireAppDataDeleteRequestSchema = z.object({
   id: z.string().min(1),
 }).passthrough();
 
+/** File bytes are base64-encoded on the wire, exactly like `blobs.put`. */
 export const storeWireAppDataPutFileRequestSchema = z.object({
   target: appDataTargetSchema,
   key: z.string().min(1),

--- a/packages/core/src/store-wire.ts
+++ b/packages/core/src/store-wire.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { VendoError, safeErrorMessage, vendoErrorCodeSchema, type VendoErrorCode } from "./errors.js";
 import {
+  APP_DATA_COLLECTION_PATTERN,
   recordQuerySchema,
 } from "./store.js";
 
@@ -28,6 +29,15 @@ export const STORE_WIRE_PATHS = {
   "blobs.get": "/blobs/get",
   "blobs.delete": "/blobs/delete",
   "blobs.list": "/blobs/list",
+  // appData (8)
+  "appData.put": "/app-data/put",
+  "appData.get": "/app-data/get",
+  "appData.list": "/app-data/list",
+  "appData.delete": "/app-data/delete",
+  "appData.putFile": "/app-data/putFile",
+  "appData.getFile": "/app-data/getFile",
+  "appData.listFiles": "/app-data/listFiles",
+  "appData.deleteFile": "/app-data/deleteFile",
   // transcripts (6)
   "transcripts.putThread": "/transcripts/putThread",
   "transcripts.getThread": "/transcripts/getThread",
@@ -135,6 +145,61 @@ export const storeWireBlobsDeleteRequestSchema = z.object({
 export const storeWireBlobsListRequestSchema = z.object({
   namespace: z.string().min(1),
   prefix: z.string().optional(),
+}).passthrough();
+
+// ---------------------------------------------------------------------------
+// appData
+// ---------------------------------------------------------------------------
+
+/** The owner on the target is the runtime's stamp from the host's login
+    session, never something generated code names. File bytes are base64 on the
+    wire, exactly like `blobs.put`. */
+export const appDataTargetSchema = z.object({
+  appId: z.string().min(1),
+  collection: z.string().regex(APP_DATA_COLLECTION_PATTERN),
+  owner: z.string().min(1),
+}).passthrough();
+
+export const storeWireAppDataPutRequestSchema = z.object({
+  target: appDataTargetSchema,
+  record: recordInputSchema,
+}).passthrough();
+
+export const storeWireAppDataGetRequestSchema = z.object({
+  target: appDataTargetSchema,
+  id: z.string().min(1),
+}).passthrough();
+
+export const storeWireAppDataListRequestSchema = z.object({
+  target: appDataTargetSchema,
+  query: recordQuerySchema.optional(),
+}).passthrough();
+
+export const storeWireAppDataDeleteRequestSchema = z.object({
+  target: appDataTargetSchema,
+  id: z.string().min(1),
+}).passthrough();
+
+export const storeWireAppDataPutFileRequestSchema = z.object({
+  target: appDataTargetSchema,
+  key: z.string().min(1),
+  bytes: z.string().min(1), // base64
+  contentType: z.string().optional(),
+}).passthrough();
+
+export const storeWireAppDataGetFileRequestSchema = z.object({
+  target: appDataTargetSchema,
+  key: z.string().min(1),
+}).passthrough();
+
+export const storeWireAppDataListFilesRequestSchema = z.object({
+  target: appDataTargetSchema,
+  prefix: z.string().optional(),
+}).passthrough();
+
+export const storeWireAppDataDeleteFileRequestSchema = z.object({
+  target: appDataTargetSchema,
+  key: z.string().min(1),
 }).passthrough();
 
 // ---------------------------------------------------------------------------
@@ -275,12 +340,15 @@ export interface StoreWireStatus {
   format: typeof VENDO_STORE_WIRE_FORMAT;
   minClientVersion?: string;
   ops: number;
+  /** Op names this mount still serves but is retiring. */
+  deprecated?: readonly string[];
 }
 
 export const storeWireStatusSchema = z.object({
   format: z.literal(VENDO_STORE_WIRE_FORMAT),
   minClientVersion: z.string().optional(),
   ops: z.number(),
+  deprecated: z.array(z.string()).optional(),
 }).passthrough() satisfies z.ZodType<StoreWireStatus>;
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -88,12 +88,25 @@ export interface StoreAdapter {
 }
 
 // ---------------------------------------------------------------------------
-// StoreOps — the named-operation contract for the 27-op / 7-family store.
+// StoreOps — the named-operation contract for the 35-op / 8-family store.
 // Both the local backend (store/ops.ts) and the cloud client
 // (hosted-store.ts) implement this interface.
 // ---------------------------------------------------------------------------
 
 import type { StoreWireStatus } from "./store-wire.js";
+
+/** The grammar a collection name invented by generated code must satisfy:
+    a short slug, optionally `box:`-prefixed. */
+export const APP_DATA_COLLECTION_PATTERN = /^(box:)?[A-Za-z0-9_-]{1,64}$/;
+
+/** Where one appData op lands. */
+export interface AppDataTarget {
+  appId: string;
+  collection: string;
+  /** Stamped by the RUNTIME from the host's login session — generated code has
+      no field for it, and a caller that supplies `refs.subject` is refused. */
+  owner: string;
+}
 
 /** The scope of a destructive erase: exactly ONE of subject or appId.
     A union (not two optionals) so `erase({})` and a both-set target are
@@ -102,7 +115,7 @@ export type EraseTarget =
   | { subject: string; appId?: never }
   | { appId: string; subject?: never };
 
-/** The typed contract for all 27 store operations across 7 families.
+/** The typed contract for all 35 store operations across 8 families.
     Lean by design — this is the CONTRACT interface, not the implementation. */
 export interface StoreOps {
   records: {
@@ -119,6 +132,18 @@ export interface StoreOps {
     get(namespace: string, key: string): Promise<{ bytes: Uint8Array; contentType?: string } | null>;
     delete(namespace: string, key: string): Promise<void>;
     list(namespace: string, prefix?: string): Promise<string[]>;
+  };
+  /** Everything generated apps invent. Reads are auto-scoped to the target's
+      owner and writes are stamped with it, so no verb here takes a subject. */
+  appData: {
+    put(target: AppDataTarget, record: RecordInput): Promise<VendoRecord>;
+    get(target: AppDataTarget, id: string): Promise<VendoRecord | null>;
+    list(target: AppDataTarget, query?: RecordQuery): Promise<{ records: VendoRecord[]; cursor?: string }>;
+    delete(target: AppDataTarget, id: string): Promise<void>;
+    putFile(target: AppDataTarget, key: string, bytes: Uint8Array, meta?: { contentType?: string }): Promise<void>;
+    getFile(target: AppDataTarget, key: string): Promise<{ bytes: Uint8Array; contentType?: string } | null>;
+    listFiles(target: AppDataTarget, prefix?: string): Promise<string[]>;
+    deleteFile(target: AppDataTarget, key: string): Promise<void>;
   };
   transcripts: {
     putThread(thread: { id: string; subject: string; messages: unknown[]; title?: string }): Promise<VendoRecord>;

--- a/packages/core/tests/store-wire.test.ts
+++ b/packages/core/tests/store-wire.test.ts
@@ -19,6 +19,14 @@ import {
   storeWireBlobsGetRequestSchema,
   storeWireBlobsDeleteRequestSchema,
   storeWireBlobsListRequestSchema,
+  storeWireAppDataPutRequestSchema,
+  storeWireAppDataGetRequestSchema,
+  storeWireAppDataListRequestSchema,
+  storeWireAppDataDeleteRequestSchema,
+  storeWireAppDataPutFileRequestSchema,
+  storeWireAppDataGetFileRequestSchema,
+  storeWireAppDataListFilesRequestSchema,
+  storeWireAppDataDeleteFileRequestSchema,
   storeWireTranscriptsPutThreadRequestSchema,
   storeWireTranscriptsGetThreadRequestSchema,
   storeWireTranscriptsListThreadsRequestSchema,
@@ -39,12 +47,13 @@ import {
 } from "../src/index.js";
 
 describe("vendo/store-wire@1", () => {
-  it("exposes the format constant and 27 mount-relative paths", () => {
+  it("exposes the format constant and 35 mount-relative paths", () => {
     expect(VENDO_STORE_WIRE_FORMAT).toBe("vendo/store-wire@1");
-    // 7 families: records(7) + blobs(4) + transcripts(6) + harness(3) + workspace(4) + lifecycle(2) + status(1) = 27
-    expect(Object.keys(STORE_WIRE_PATHS)).toHaveLength(27);
+    // 8 families: records(7) + blobs(4) + appData(8) + transcripts(6) + harness(3) + workspace(4) + lifecycle(2) + status(1) = 35
+    expect(Object.keys(STORE_WIRE_PATHS)).toHaveLength(35);
     expect(STORE_WIRE_PATHS.status).toBe("/status");
     expect(STORE_WIRE_PATHS["records.get"]).toBe("/records/get");
+    expect(STORE_WIRE_PATHS["appData.put"]).toBe("/app-data/put");
     expect(STORE_WIRE_PATHS["lifecycle.promote"]).toBe("/lifecycle/promote");
   });
 
@@ -103,6 +112,43 @@ describe("vendo/store-wire@1", () => {
     expect(storeWireBlobsListRequestSchema.parse({ namespace: "avatars", prefix: "u1" }).prefix).toBe("u1");
   });
 
+  it("parses appData request DTOs — the collection grammar and the owner stamp bite", () => {
+    const target = { appId: "app_1", collection: "invoices", owner: "sub_1" };
+
+    expect(storeWireAppDataPutRequestSchema.parse({
+      target,
+      record: { id: "inv1", data: { total: 42 } },
+    }).record.id).toBe("inv1");
+    expect(storeWireAppDataGetRequestSchema.parse({ target, id: "inv1" }).id).toBe("inv1");
+    expect(storeWireAppDataListRequestSchema.parse({
+      target: { ...target, collection: "box:notes" },
+      query: { limit: 50 },
+    }).query?.limit).toBe(50);
+    expect(storeWireAppDataDeleteRequestSchema.parse({ target, id: "inv1" }).target.appId).toBe("app_1");
+
+    expect(storeWireAppDataPutFileRequestSchema.parse({
+      target,
+      key: "sub_1/scan.png",
+      bytes: btoa("fake-image"),
+      contentType: "image/png",
+    }).contentType).toBe("image/png");
+    expect(storeWireAppDataGetFileRequestSchema.parse({ target, key: "sub_1/scan.png" }).key).toBe("sub_1/scan.png");
+    expect(storeWireAppDataListFilesRequestSchema.parse({ target, prefix: "sub_1/" }).prefix).toBe("sub_1/");
+    expect(storeWireAppDataDeleteFileRequestSchema.parse({ target, key: "sub_1/scan.png" }).key).toBe("sub_1/scan.png");
+
+    // Generated code invents collection names, so the grammar is the fence.
+    expect(storeWireAppDataGetRequestSchema.safeParse({
+      target: { ...target, collection: "has spaces" }, id: "inv1",
+    }).success).toBe(false);
+    expect(storeWireAppDataGetRequestSchema.safeParse({
+      target: { ...target, collection: "a/b" }, id: "inv1",
+    }).success).toBe(false);
+    // The runtime always stamps an owner; an unstamped target is not a request.
+    expect(storeWireAppDataGetRequestSchema.safeParse({
+      target: { ...target, owner: "" }, id: "inv1",
+    }).success).toBe(false);
+  });
+
   it("parses transcripts request DTOs", () => {
     expect(storeWireTranscriptsPutThreadRequestSchema.parse({
       thread: { id: "t1", subject: "sub_user1", messages: [{ role: "user", content: "hi" }] },
@@ -159,9 +205,10 @@ describe("vendo/store-wire@1", () => {
   it("status doubles as the discovery handshake: format + ops count", () => {
     const status: StoreWireStatus = {
       format: VENDO_STORE_WIRE_FORMAT,
-      ops: 27,
+      ops: 35,
     };
-    expect(storeWireStatusSchema.parse(status).ops).toBe(27);
+    expect(storeWireStatusSchema.parse(status).ops).toBe(35);
+    expect(storeWireStatusSchema.parse({ ...status, deprecated: ["records.put"] }).deprecated).toEqual(["records.put"]);
     expect(storeWireStatusSchema.safeParse({ ...status, format: "vendo/store-wire@2" }).success).toBe(false);
   });
 

--- a/packages/store/src/app-data-rows.ts
+++ b/packages/store/src/app-data-rows.ts
@@ -1,0 +1,128 @@
+import {
+  APP_DATA_COLLECTION_PATTERN,
+  type AppDataTarget,
+  type BlobStore,
+  type RecordInput,
+  type RecordQuery,
+  type VendoRecord,
+} from "@vendoai/core";
+import type { Db } from "./db.js";
+import { createRecordStore } from "./records.js";
+import type { VendoStore } from "./store.js";
+import { invalid } from "./validate.js";
+
+/** The ref key the owner stamp rides. Deliberately a REF and not a column: the
+ *  erase cascade already sweeps stamped rows (`refs @> $1::jsonb`) and the GIN
+ *  index on `refs` already serves the scoped read, so appData needs no schema
+ *  of its own. */
+export const APP_DATA_OWNER_REF = "subject";
+
+/** The one place in this package that spells an appData name. Rows land in
+ *  `app:<appId>:<collection>` and their file twins in the blob namespace of the
+ *  same shape, which is what keeps `eraseStore().byApp`'s
+ *  `namespace LIKE 'app:<appId>:%'` sweeping both with the app. */
+export function appDataCollection(target: AppDataTarget): string {
+  if (target.appId === "") invalid("app data needs an appId");
+  if (!APP_DATA_COLLECTION_PATTERN.test(target.collection)) {
+    invalid(
+      `app data collection ${JSON.stringify(target.collection)} is not a legal name`
+      + ` (letters, digits, "_" and "-", up to 64, optionally "box:"-prefixed)`,
+    );
+  }
+  return `app:${target.appId}:${target.collection}`;
+}
+
+/** The blob twin of {@link appDataCollection} — the same string, by design. */
+export function appDataNamespace(target: AppDataTarget): string {
+  return appDataCollection(target);
+}
+
+/** Files carry no refs, so their owner rides the key instead of a stamp. */
+export function appDataFileKey(owner: string, key: string): string {
+  return `${owner}/${key}`;
+}
+
+/** A caller who supplies `refs.subject` is writing (or reading) as someone
+ *  else. Refused, never silently overwritten with the real owner — and refused
+ *  BEFORE anything is written, so a refused put leaves no row. */
+export function refuseCallerOwner(refs: Record<string, string> | undefined): void {
+  if (refs?.[APP_DATA_OWNER_REF] !== undefined) {
+    invalid(
+      `app data may not supply refs.${APP_DATA_OWNER_REF};`
+      + " the runtime stamps the owner from the host's session",
+    );
+  }
+}
+
+/** Row-level access to one app+collection drawer, scoped to one owner: writes
+ *  are stamped with it and reads are filtered by it, so no verb here takes a
+ *  subject. */
+export interface AppDataRows {
+  put(record: RecordInput): Promise<VendoRecord>;
+  get(id: string): Promise<VendoRecord | null>;
+  list(query?: RecordQuery): Promise<{ records: VendoRecord[]; cursor?: string }>;
+  delete(id: string): Promise<void>;
+}
+
+export function appDataRows(db: Db, target: AppDataTarget): AppDataRows {
+  const records = createRecordStore(db, appDataCollection(target));
+  const owned = (record: VendoRecord | null): boolean =>
+    record?.refs?.[APP_DATA_OWNER_REF] === target.owner;
+
+  return {
+    async put(record) {
+      refuseCallerOwner(record.refs);
+      return await records.put({
+        ...record,
+        refs: { ...record.refs, [APP_DATA_OWNER_REF]: target.owner },
+      });
+    },
+
+    async get(id) {
+      const record = await records.get(id);
+      return owned(record) ? record : null;
+    },
+
+    async list(query = {}) {
+      refuseCallerOwner(query.refs);
+      return await records.list({
+        ...query,
+        refs: { ...query.refs, [APP_DATA_OWNER_REF]: target.owner },
+      });
+    },
+
+    /** Read-then-check, so a foreign row survives. Both statements go through
+     *  the `db` handed in — hand this a transaction-scoped handle and the check
+     *  and the delete are ONE transaction, which is the only way the row cannot
+     *  change owner between them. */
+    async delete(id) {
+      if (!owned(await records.get(id))) return;
+      await records.delete(id);
+    },
+  };
+}
+
+/** The file twins of one owner's drawer: a BlobStore whose keys are the
+ *  caller's own, with `<owner>/` put on and taken off at the seam. The `list`
+ *  prefix is therefore relative to the caller's key space — it is concatenated
+ *  onto the owner leg before the query, not filtered after the strip. */
+export function appDataFiles(store: VendoStore, target: AppDataTarget): BlobStore {
+  const blobs = store.blobs(appDataNamespace(target));
+  const owned = (key: string): string => appDataFileKey(target.owner, key);
+
+  return {
+    async put(key, bytes, meta) {
+      await blobs.put(owned(key), bytes, meta);
+    },
+    async get(key) {
+      return await blobs.get(owned(key));
+    },
+    async delete(key) {
+      await blobs.delete(owned(key));
+    },
+    async list(prefix = "") {
+      const keys = await blobs.list(owned(prefix));
+      return keys.map((key) => key.slice(target.owner.length + 1));
+    },
+  };
+}

--- a/packages/store/src/app-data-rows.ts
+++ b/packages/store/src/app-data-rows.ts
@@ -1,5 +1,6 @@
 import {
   APP_DATA_COLLECTION_PATTERN,
+  VendoError,
   type AppDataTarget,
   type BlobStore,
   type RecordInput,
@@ -7,6 +8,7 @@ import {
   type VendoRecord,
 } from "@vendoai/core";
 import type { Db } from "./db.js";
+import { jsonParam } from "./helpers/utils.js";
 import { createRecordStore } from "./records.js";
 import type { VendoStore } from "./store.js";
 import { invalid } from "./validate.js";
@@ -22,7 +24,13 @@ export const APP_DATA_OWNER_REF = "subject";
  *  same shape, which is what keeps `eraseStore().byApp`'s
  *  `namespace LIKE 'app:<appId>:%'` sweeping both with the app. */
 export function appDataCollection(target: AppDataTarget): string {
-  if (target.appId === "") invalid("app data needs an appId");
+  // The appId goes into the name unescaped, and `appScopeId` parses it back on
+  // the assumption that segment is colon-free. A colon in the appId collapses
+  // two different drawers onto one string: appId "a:box" + collection "evil"
+  // and appId "a" + collection "box:evil" both spell `app:a:box:evil`.
+  if (target.appId === "" || target.appId.includes(":")) {
+    invalid(`app data appId ${JSON.stringify(target.appId)} must be non-empty and free of ":"`);
+  }
   if (!APP_DATA_COLLECTION_PATTERN.test(target.collection)) {
     invalid(
       `app data collection ${JSON.stringify(target.collection)} is not a legal name`
@@ -65,22 +73,49 @@ export interface AppDataRows {
 }
 
 export function appDataRows(db: Db, target: AppDataTarget): AppDataRows {
-  const records = createRecordStore(db, appDataCollection(target));
-  const owned = (record: VendoRecord | null): boolean =>
-    record?.refs?.[APP_DATA_OWNER_REF] === target.owner;
+  const collection = appDataCollection(target);
+  const records = createRecordStore(db, collection);
+  const stamp = { [APP_DATA_OWNER_REF]: target.owner };
 
   return {
+    /** An id another owner holds is a `conflict`, not an overwrite:
+     *  `records.put` is an unconditional upsert on (collection, id), so without
+     *  this a caller could destroy and re-stamp a row it can neither read nor
+     *  delete. The refusal never names the holder — it only says the id is
+     *  taken, which is all a caller who cannot see the row may learn.
+     *
+     *  Race-free rather than check-then-write: the insert decides the create
+     *  atomically, and when it loses, `FOR UPDATE` locks the row that beat it,
+     *  so a concurrent writer blocks instead of interleaving. That lock lives
+     *  until COMMIT, so this needs a transaction-scoped handle (ops.ts hands
+     *  one in) — a bare `BEGIN` is READ COMMITTED, where an unlocked read would
+     *  see a snapshot the following write does not honor. */
     async put(record) {
       refuseCallerOwner(record.refs);
-      return await records.put({
-        ...record,
-        refs: { ...record.refs, [APP_DATA_OWNER_REF]: target.owner },
-      });
+      const stamped = { ...record, refs: { ...record.refs, ...stamp } };
+      const created = await records.atomic!.insertIfAbsent(stamped);
+      if (created !== null) return created;
+
+      const held = await db.query(
+        "SELECT refs FROM vendo_records WHERE collection = $1 AND id = $2 FOR UPDATE",
+        [collection, record.id],
+      );
+      const row = held.rows[0];
+      // No row means the holder deleted it while we looked; the upsert below
+      // recreates it as ours.
+      if (row !== undefined
+        && (row["refs"] as Record<string, string> | null)?.[APP_DATA_OWNER_REF] !== target.owner) {
+        throw new VendoError(
+          "conflict",
+          `app data id ${JSON.stringify(record.id)} is already held in this collection`,
+        );
+      }
+      return await records.put(stamped);
     },
 
     async get(id) {
       const record = await records.get(id);
-      return owned(record) ? record : null;
+      return record?.refs?.[APP_DATA_OWNER_REF] === target.owner ? record : null;
     },
 
     async list(query = {}) {
@@ -91,13 +126,19 @@ export function appDataRows(db: Db, target: AppDataTarget): AppDataRows {
       });
     },
 
-    /** Read-then-check, so a foreign row survives. Both statements go through
-     *  the `db` handed in — hand this a transaction-scoped handle and the check
-     *  and the delete are ONE transaction, which is the only way the row cannot
-     *  change owner between them. */
+    /** ONE owner-predicated statement, so a foreign row survives with no window
+     *  to race — a read-then-delete has one, because `createRecordStore.delete`
+     *  carries no owner predicate and would delete a row that changed hands
+     *  between the two statements. That missing predicate is why the composer
+     *  reaches the table directly here instead of going through the door.
+     *  `refs @> …` rides the same GIN index the scoped read does, and the
+     *  door's skipped `requireKnownApp` pre-check was only an error signal — a
+     *  delete never creates rows. */
     async delete(id) {
-      if (!owned(await records.get(id))) return;
-      await records.delete(id);
+      await db.query(
+        "DELETE FROM vendo_records WHERE collection = $1 AND id = $2 AND refs @> $3::jsonb",
+        [collection, id, jsonParam(stamp)],
+      );
     },
   };
 }

--- a/packages/store/src/erase.ts
+++ b/packages/store/src/erase.ts
@@ -181,6 +181,18 @@ export function eraseStore(store: VendoStore, options: { files: FilesAdapter }):
       await del(report, "vendo_audit", "subject = $1", [subject]);
       // Generic and door-owned rows carry the subject only as a ref (§2/§3).
       await del(report, "vendo_records", "refs @> $1::jsonb", [subjectRef]);
+      // An appData file twin carries no refs: its owner is the leading key leg
+      // (`<owner>/<key>`) inside the app's own namespace. For the subject's own
+      // apps the cascade above already took them with the namespace, but a
+      // PROMOTED org app belongs to the ORG (§9.7 — `subject = $1` never
+      // reaches it), so without this selector a departing member's files inside
+      // an org app would outlive them.
+      await del(
+        report,
+        "vendo_blobs",
+        "namespace LIKE 'app:%' AND key LIKE $1 ESCAPE '\\'",
+        [`${escapeLike(subject)}/%`],
+      );
       await del(report, "vendo_mcp_clients", "refs @> $1::jsonb", [subjectRef]);
       await del(report, "vendo_mcp_grants", "refs @> $1::jsonb", [subjectRef]);
       // Knowledge corpus rows the subject axis reaches carry the subject only as

--- a/packages/store/src/helpers/backend.ts
+++ b/packages/store/src/helpers/backend.ts
@@ -16,7 +16,7 @@ type StoreBackend =
  * "Unknown VendoStore handle" for anything this package did not mint — which is
  * every hosted deployment, and is why a key-only host could not serve a harness
  * turn. The rows exist either way; only the road to them differs. So: the SQL
- * handle when there is one, the store's own 27-op surface when there is not, and
+ * handle when there is one, the store's own 35-op surface when there is not, and
  * a named refusal only when the store offers neither.
  *
  * SQL wins when both are present. It is the same database, one hop shorter.

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -3,9 +3,20 @@
  *  keep the PGlite wasm engine out of the bundle graph. */
 export { createStore } from "./create-store.js";
 export { type VendoStore } from "./store.js";
-// The StoreOps local backend (02-store): the 27-op named-operation contract
+// The StoreOps local backend (02-store): the 35-op named-operation contract
 // served off this store's own Postgres, transactions at verb boundaries.
 export { createStoreOps } from "./ops.js";
+// The one composer of appData names and the owner stamp: everything that
+// serves the family (the local backend here, the surfaces above it) spells
+// `app:<appId>:<collection>` and `<owner>/<key>` through these and nowhere else.
+export {
+  appDataFiles,
+  appDataRows,
+  appDataCollection,
+  appDataNamespace,
+  appDataFileKey,
+  APP_DATA_OWNER_REF,
+} from "./app-data-rows.js";
 // The reserved-collection map (02-store §2): exported so remote StoreAdapters
 // (the umbrella's hostedStore) can mirror this engine's per-collection
 // capability shape — claim on non-routed collections, atomic on generic

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -5,10 +5,6 @@ export { createStore } from "./create-store.js";
 export { maybeDbFor, type VendoStore } from "./store.js";
 // The StoreOps local backend (02-store): the 35-op named-operation contract
 // served off this store's own Postgres, transactions at verb boundaries.
-// `createStoreOps` opens the handle eagerly, so a caller composing it for an
-// arbitrary store asks `maybeDbFor` first — that pair is `backendOf`'s
-// three-way answer (own ops / SQL handle / neither) at a seam outside this
-// package.
 export { createStoreOps } from "./ops.js";
 // The one composer of appData names and the owner stamp: everything that
 // serves the family (the local backend here, the surfaces above it) spells

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -2,9 +2,13 @@
  *  Postgres-only consumers: import from `@vendoai/store/postgres` instead to
  *  keep the PGlite wasm engine out of the bundle graph. */
 export { createStore } from "./create-store.js";
-export { type VendoStore } from "./store.js";
+export { maybeDbFor, type VendoStore } from "./store.js";
 // The StoreOps local backend (02-store): the 35-op named-operation contract
 // served off this store's own Postgres, transactions at verb boundaries.
+// `createStoreOps` opens the handle eagerly, so a caller composing it for an
+// arbitrary store asks `maybeDbFor` first — that pair is `backendOf`'s
+// three-way answer (own ops / SQL handle / neither) at a seam outside this
+// package.
 export { createStoreOps } from "./ops.js";
 // The one composer of appData names and the owner stamp: everything that
 // serves the family (the local backend here, the surfaces above it) spells

--- a/packages/store/src/ops.ts
+++ b/packages/store/src/ops.ts
@@ -7,6 +7,7 @@ import {
   type StoreOps,
   type VendoRecord,
 } from "@vendoai/core";
+import { appDataFiles, appDataRows } from "./app-data-rows.js";
 import type { Db, Query } from "./db.js";
 import { eraseStore } from "./erase.js";
 import { storeFiles, storeFilesForDb } from "./files-store.js";
@@ -91,7 +92,7 @@ const decoder = new TextDecoder();
 
 /**
  * 02-store — the LOCAL backend of the StoreOps named-operation contract
- * (core/store.ts): the 27 ops served straight off this store's own Postgres,
+ * (core/store.ts): the 35 ops served straight off this store's own Postgres,
  * through the EXISTING helpers — routing doors, thread rows, workspace rows, the
  * erase cascade. Logic unchanged; what this layer adds is the atomic scope:
  * every multi-statement verb runs inside ONE
@@ -238,6 +239,42 @@ export function createStoreOps(
       },
       async list(namespace, prefix) {
         return await store.blobs(namespace).list(prefix);
+      },
+    },
+
+    // -----------------------------------------------------------------------
+    // appData — everything generated apps invent. The composer
+    // (app-data-rows.ts) owns the naming, the owner stamp and the refusal of a
+    // caller-supplied one; this block only decides the transaction scope.
+    // -----------------------------------------------------------------------
+    appData: {
+      async put(target, record) {
+        return await db.transaction((q) => appDataRows(txDb(q), target).put(record));
+      },
+      async get(target, id) {
+        return await appDataRows(db, target).get(id);
+      },
+      async list(target, query) {
+        return await appDataRows(db, target).list(query);
+      },
+      /** The ownership read and the delete share ONE transaction (the rows door
+       *  gets the tx handle), so a row cannot change hands between them. */
+      async delete(target, id) {
+        await db.transaction((q) => appDataRows(txDb(q), target).delete(id));
+      },
+      /** The file twins are single-statement blob verbs, exactly like the blobs
+       *  family above, so none of them opens a transaction. */
+      async putFile(target, key, bytes, meta) {
+        await appDataFiles(store, target).put(key, bytes, meta);
+      },
+      async getFile(target, key) {
+        return await appDataFiles(store, target).get(key);
+      },
+      async listFiles(target, prefix) {
+        return await appDataFiles(store, target).list(prefix);
+      },
+      async deleteFile(target, key) {
+        await appDataFiles(store, target).delete(key);
       },
     },
 
@@ -600,7 +637,7 @@ export function createStoreOps(
     },
 
     async status() {
-      return { format: VENDO_STORE_WIRE_FORMAT, ops: 27 };
+      return { format: VENDO_STORE_WIRE_FORMAT, ops: 35 };
     },
   };
 }

--- a/packages/store/src/ops.ts
+++ b/packages/store/src/ops.ts
@@ -257,10 +257,8 @@ export function createStoreOps(
       async list(target, query) {
         return await appDataRows(db, target).list(query);
       },
-      /** The ownership read and the delete share ONE transaction (the rows door
-       *  gets the tx handle), so a row cannot change hands between them. */
       async delete(target, id) {
-        await db.transaction((q) => appDataRows(txDb(q), target).delete(id));
+        await appDataRows(db, target).delete(id);
       },
       /** The file twins are single-statement blob verbs, exactly like the blobs
        *  family above, so none of them opens a transaction. */

--- a/packages/store/src/postgres.ts
+++ b/packages/store/src/postgres.ts
@@ -34,6 +34,15 @@ export function createStore(config: PostgresStoreConfig): VendoStore {
 // The rest of the store surface is engine-agnostic — the same modules the
 // main entry exports (keep this list in lockstep with index.ts).
 export { createStoreOps } from "./ops.js";
+export { maybeDbFor } from "./store.js";
+export {
+  appDataFiles,
+  appDataRows,
+  appDataCollection,
+  appDataNamespace,
+  appDataFileKey,
+  APP_DATA_OWNER_REF,
+} from "./app-data-rows.js";
 export {
   DEDICATED_RECORD_COLLECTIONS,
   RESERVED_COLLECTIONS,

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -15,7 +15,7 @@ export interface VendoStore extends StoreAdapter {
   ensureSchema(): Promise<void>;
   close(): Promise<void>;
   raw(): unknown;
-  /** The 27-op named-operation surface, when this store carries one (the Cloud
+  /** The 35-op named-operation surface, when this store carries one (the Cloud
    *  hosted store does; a local store's lives behind `createStoreOps`). It is
    *  what lets the helpers that need a transcript, a workspace or harness state
    *  serve a store with no SQL handle — see `backendOf`. */

--- a/packages/store/src/workspace-ops-rows.ts
+++ b/packages/store/src/workspace-ops-rows.ts
@@ -7,7 +7,7 @@ import type {
 } from "./workspace-rows.js";
 
 /**
- * The workspace pair over the 27-op contract instead of this store's own
+ * The workspace pair over the 35-op contract instead of this store's own
  * Postgres — what makes a hosted store (a key, no database) serve the same
  * `WorkspaceStoreFs` a local one does, byte for byte. The façade above
  * (workspace.ts) is unchanged, and so are its permission checks: `can()` reads

--- a/packages/vendo/src/compose-adapters.ts
+++ b/packages/vendo/src/compose-adapters.ts
@@ -31,7 +31,7 @@ import { cloudSandbox } from "./sandbox.js";
 /** 09-vendo §2 — the adapter rule, applied at the one seam that may read the
  *  environment. */
 export const composeAdapters = (composition: VendoComposition): Pick<VendoComposition,
-  "store" | "files" | "sandbox" | "secrets" | "inference" | "configCloud"
+  "store" | "files" | "ops" | "sandbox" | "secrets" | "inference" | "configCloud"
   | "surfaceRoot" | "readSurfaceFile" | "memoizeOnce"> => {
   const { config, composed } = composition;
   // Persistence, selected by the adapter rule at this composition seam
@@ -40,7 +40,7 @@ export const composeAdapters = (composition: VendoComposition): Pick<VendoCompos
   // production-owned — VENDO_STORE_ENCRYPTION_KEY encrypts at rest; without
   // it dev stores locally unencrypted while production secret writes fail
   // closed).
-  const { store, files } = selectStore(
+  const { store, files, ops } = selectStore(
     composed?.store ?? config.store,
     composed?.files ?? config.files,
   );
@@ -111,6 +111,7 @@ export const composeAdapters = (composition: VendoComposition): Pick<VendoCompos
   return {
     store,
     files,
+    ops,
     sandbox,
     secrets,
     inference,

--- a/packages/vendo/src/compose-context.ts
+++ b/packages/vendo/src/compose-context.ts
@@ -35,6 +35,7 @@ import type {
   RiskLabel,
   RunContext,
   SecretsProvider,
+  StoreOps,
   ToolCall,
   ToolRegistry,
 } from "@vendoai/core";
@@ -128,6 +129,9 @@ export interface VendoComposition {
   store: VendoStore;
   /** THE files adapter for this deployment (build contract §3.4). */
   files: FilesAdapter;
+  /** The 35-op StoreOps surface for this deployment — the store's own when it
+   *  carries one, the local backend otherwise. */
+  ops: StoreOps;
   sandbox: ReturnType<typeof selectSandbox>;
   secrets: SecretsProvider;
   inference: ReturnType<typeof resolveModels>;

--- a/packages/vendo/src/compose-context.ts
+++ b/packages/vendo/src/compose-context.ts
@@ -130,8 +130,9 @@ export interface VendoComposition {
   /** THE files adapter for this deployment (build contract §3.4). */
   files: FilesAdapter;
   /** The 35-op StoreOps surface for this deployment — the store's own when it
-   *  carries one, the local backend otherwise. */
-  ops: StoreOps;
+   *  carries one, the local backend over its SQL handle otherwise, and absent
+   *  when the store offers neither (`backendOf`'s third answer). */
+  ops: StoreOps | undefined;
   sandbox: ReturnType<typeof selectSandbox>;
   secrets: SecretsProvider;
   inference: ReturnType<typeof resolveModels>;

--- a/packages/vendo/src/compose-store.ts
+++ b/packages/vendo/src/compose-store.ts
@@ -4,9 +4,10 @@
  *
  * Moved out of server.ts with the composition that calls it.
  */
-import type { FilesAdapter } from "@vendoai/core";
+import type { FilesAdapter, StoreOps } from "@vendoai/core";
 import {
   createStore,
+  createStoreOps,
   storeFiles,
   threadMessageStore,
   type VendoStore,
@@ -93,6 +94,17 @@ export function storeServesHarnessTurns(store: VendoStore): boolean {
   }
 }
 
+/** ADAPTER RULE, the ops half of the SAME seam: one store, one named-operation
+    surface, chosen here beside it. A store that carries its own `ops` wins —
+    `VendoStore.ops` is declared optional for exactly this, and the hosted
+    store's client is the same `vendo/store-wire@1` the local backend would be
+    re-encoding, one hop shorter. Everything else gets the local backend over
+    the store's own SQL handle, holding THE files adapter so app files and blobs
+    land in the one place the erase cascade reads. */
+export function selectStoreOps(store: VendoStore, files: FilesAdapter): StoreOps {
+  return store.ops ?? createStoreOps(store, { files });
+}
+
 export function selectStore(
   configured: VendoStore | undefined,
   configuredFiles: FilesAdapter | undefined,
@@ -100,6 +112,8 @@ export function selectStore(
   store: VendoStore;
   /** THE files adapter for this deployment. Every consumer takes it from here. */
   files: FilesAdapter;
+  /** THE 35-op surface for this deployment, over that same store and adapter. */
+  ops: StoreOps;
 } {
   const selected = ((): VendoStore => {
     if (configured !== undefined) return configured;
@@ -110,7 +124,11 @@ export function selectStore(
       ? { allowUnencryptedSecrets: environment("NODE_ENV") !== "production" }
       : { encryption: { key: encryptionKey } });
   })();
-  return { store: selected, files: selectFiles(configuredFiles, selected) };
+  // ONE files instance, shared by the return and the ops surface below — the
+  // whole reason selectFiles resolves once (the workspace writes blobs, the
+  // erase cascade deletes them).
+  const files = selectFiles(configuredFiles, selected);
+  return { store: selected, files, ops: selectStoreOps(selected, files) };
 }
 
 /** The hosted-store automations notice, printed at most once per process. */

--- a/packages/vendo/src/compose-store.ts
+++ b/packages/vendo/src/compose-store.ts
@@ -8,6 +8,7 @@ import type { FilesAdapter, StoreOps } from "@vendoai/core";
 import {
   createStore,
   createStoreOps,
+  maybeDbFor,
   storeFiles,
   threadMessageStore,
   type VendoStore,
@@ -98,11 +99,18 @@ export function storeServesHarnessTurns(store: VendoStore): boolean {
     surface, chosen here beside it. A store that carries its own `ops` wins —
     `VendoStore.ops` is declared optional for exactly this, and the hosted
     store's client is the same `vendo/store-wire@1` the local backend would be
-    re-encoding, one hop shorter. Everything else gets the local backend over
-    the store's own SQL handle, holding THE files adapter so app files and blobs
-    land in the one place the erase cascade reads. */
-export function selectStoreOps(store: VendoStore, files: FilesAdapter): StoreOps {
-  return store.ops ?? createStoreOps(store, { files });
+    re-encoding, one hop shorter. A store with a SQL handle gets the local
+    backend over it, holding THE files adapter so app files and blobs land in
+    the one place the erase cascade reads.
+
+    `undefined` for a store with NEITHER — the same three-way answer
+    `@vendoai/store`'s own `backendOf` gives, and the reason this resolves the
+    handle here instead of calling `createStoreOps` unconditionally: that call
+    opens the handle eagerly, so composition would crash at boot for a host
+    whose store has none, where today it refuses at the op that needed one. */
+export function selectStoreOps(store: VendoStore, files: FilesAdapter): StoreOps | undefined {
+  if (store.ops !== undefined) return store.ops;
+  return maybeDbFor(store) === undefined ? undefined : createStoreOps(store, { files });
 }
 
 export function selectStore(
@@ -112,8 +120,9 @@ export function selectStore(
   store: VendoStore;
   /** THE files adapter for this deployment. Every consumer takes it from here. */
   files: FilesAdapter;
-  /** THE 35-op surface for this deployment, over that same store and adapter. */
-  ops: StoreOps;
+  /** THE 35-op surface for this deployment, over that same store and adapter —
+      absent when the store offers neither its own ops nor a SQL handle. */
+  ops: StoreOps | undefined;
 } {
   const selected = ((): VendoStore => {
     if (configured !== undefined) return configured;

--- a/packages/vendo/src/hosted-store.ts
+++ b/packages/vendo/src/hosted-store.ts
@@ -50,7 +50,7 @@ export interface HostedStore extends VendoStore {
     bySubject(subject: string): Promise<EraseReport>;
     byApp(appId: string): Promise<EraseReport>;
   };
-  /** The 27-op named-operation surface over the same mount and the same key —
+  /** The 35-op named-operation surface over the same mount and the same key —
    * `vendo/store-wire@1` (see {@link hostedStoreOps}). Additive: the
    * StoreAdapter doors above are unchanged and keep their own routes. */
   ops: StoreOps;
@@ -306,10 +306,10 @@ export function hostedStore(options: HostedStoreOptions): HostedStore {
 }
 
 // ---------------------------------------------------------------------------
-// The 27-op StoreOps client — store design v1, `vendo/store-wire@1`
+// The 35-op StoreOps client — store design v1, `vendo/store-wire@1`
 // ---------------------------------------------------------------------------
 
-/** The 27 named ops — STORE_WIRE_PATHS' keys ARE the op names, and stay the
+/** The 35 named ops — STORE_WIRE_PATHS' keys ARE the op names, and stay the
  * op names even where the console's door sits at a different path. */
 type StoreWireOp = keyof typeof STORE_WIRE_PATHS;
 
@@ -348,7 +348,7 @@ const raiseWireError = async (response: Response): Promise<never> => {
 };
 
 /**
- * The Cloud client for the whole 27-op store contract, speaking
+ * The Cloud client for the whole 35-op store contract, speaking
  * `vendo/store-wire@1` over the console's store mount: bearer key, deployment
  * identity and per-request abort budget shared with {@link hostedStore}, the
  * same adapter rule (behavior comes ONLY from the constructor arguments),
@@ -438,6 +438,44 @@ export function hostedStoreOps(options: HostedStoreOptions): StoreOps {
 
   const cursorQuery = (query?: { cursor?: string; limit?: number }): Record<string, unknown> => ({ ...query });
 
+  /** The one file-read posture, shared by `blobs.get` and `appData.getFile` so
+      the two can never drift: a missing file is null at the seam (01-core §12),
+      whether the service answers `{blob: null}` or an ENVELOPED not-found. A
+      bare 404 has already degraded to not-implemented and stays loud — a
+      misdeployed base URL must not read as an empty blob store forever. */
+  const fileOf = async (
+    op: StoreWireOp,
+    path: string,
+    body: unknown,
+  ): Promise<{ bytes: Uint8Array; contentType?: string } | null> => {
+    let payload: unknown;
+    try {
+      payload = await post(op, path, body);
+    } catch (error) {
+      if (error instanceof VendoError && error.code === "not-found") return null;
+      throw error;
+    }
+    const blob = field<Record<string, unknown> | null>(
+      payload,
+      "blob",
+      "invalid blob",
+      (value) => value === null || (typeof value === "object" && value !== null && typeof (value as { bytes?: unknown }).bytes === "string"),
+    );
+    if (blob === null) return null;
+    return {
+      bytes: base64ToBytes(blob["bytes"] as string),
+      ...(typeof blob["contentType"] === "string" ? { contentType: blob["contentType"] } : {}),
+    };
+  };
+
+  const keysOf = (payload: unknown): string[] =>
+    field<string[]>(
+      payload,
+      "keys",
+      "invalid blob list",
+      (value) => Array.isArray(value) && value.every((key) => typeof key === "string"),
+    );
+
   /** The workspace family's owner, passed through only when the caller named
       one — a mount that binds its own owner must not be handed `undefined`. */
   const owned = (opts?: { owner?: string }): Record<string, unknown> =>
@@ -491,42 +529,55 @@ export function hostedStoreOps(options: HostedStoreOptions): StoreOps {
         });
       },
       async get(namespace, key) {
-        let payload: unknown;
-        try {
-          payload = await post("blobs.get", P["blobs.get"], { namespace, key });
-        } catch (error) {
-          // A missing blob is null at the seam (01-core §12), whether the
-          // service answers `{blob: null}` or an ENVELOPED not-found. A bare
-          // 404 has already degraded to not-implemented and stays loud: a
-          // misdeployed base URL must not read as an empty blob store forever.
-          if (error instanceof VendoError && error.code === "not-found") return null;
-          throw error;
-        }
-        const blob = field<Record<string, unknown> | null>(
-          payload,
-          "blob",
-          "invalid blob",
-          (value) => value === null || (typeof value === "object" && value !== null && typeof (value as { bytes?: unknown }).bytes === "string"),
-        );
-        if (blob === null) return null;
-        return {
-          bytes: base64ToBytes(blob["bytes"] as string),
-          ...(typeof blob["contentType"] === "string" ? { contentType: blob["contentType"] } : {}),
-        };
+        return fileOf("blobs.get", P["blobs.get"], { namespace, key });
       },
       async delete(namespace, key) {
         await mutate("blobs.delete", P["blobs.delete"], { namespace, key });
       },
       async list(namespace, prefix) {
-        return field<string[]>(
-          await post("blobs.list", P["blobs.list"], {
-            namespace,
-            ...(prefix === undefined || prefix === "" ? {} : { prefix }),
-          }),
-          "keys",
-          "invalid blob list",
-          (value) => Array.isArray(value) && value.every((key) => typeof key === "string"),
-        );
+        return keysOf(await post("blobs.list", P["blobs.list"], {
+          namespace,
+          ...(prefix === undefined || prefix === "" ? {} : { prefix }),
+        }));
+      },
+    },
+    // Everything generated apps invent. The whole address rides ONE `target`
+    // (appId + collection + owner) instead of a collection string, because the
+    // owner is the runtime's stamp: the service scopes reads and stamps writes
+    // from it, so no verb here takes a subject. Files are the blobs shape over
+    // the same target — base64 bytes out, the same missing-file posture back.
+    appData: {
+      async put(target, record) {
+        return recordOf(await mutate("appData.put", P["appData.put"], { target, record }));
+      },
+      async get(target, id) {
+        return nullableRecordOf(await post("appData.get", P["appData.get"], { target, id }));
+      },
+      async list(target, query) {
+        return listOf(await post("appData.list", P["appData.list"], { target, query: query ?? {} }));
+      },
+      async delete(target, id) {
+        await mutate("appData.delete", P["appData.delete"], { target, id });
+      },
+      async putFile(target, key, bytes, meta) {
+        await mutate("appData.putFile", P["appData.putFile"], {
+          target,
+          key,
+          bytes: bytesToBase64(bytes),
+          ...(meta?.contentType === undefined ? {} : { contentType: meta.contentType }),
+        });
+      },
+      async getFile(target, key) {
+        return fileOf("appData.getFile", P["appData.getFile"], { target, key });
+      },
+      async listFiles(target, prefix) {
+        return keysOf(await post("appData.listFiles", P["appData.listFiles"], {
+          target,
+          ...(prefix === undefined || prefix === "" ? {} : { prefix }),
+        }));
+      },
+      async deleteFile(target, key) {
+        await mutate("appData.deleteFile", P["appData.deleteFile"], { target, key });
       },
     },
     transcripts: {

--- a/packages/vendo/src/hosted-store.ts
+++ b/packages/vendo/src/hosted-store.ts
@@ -544,8 +544,7 @@ export function hostedStoreOps(options: HostedStoreOptions): StoreOps {
     // Everything generated apps invent. The whole address rides ONE `target`
     // (appId + collection + owner) instead of a collection string, because the
     // owner is the runtime's stamp: the service scopes reads and stamps writes
-    // from it, so no verb here takes a subject. Files are the blobs shape over
-    // the same target — base64 bytes out, the same missing-file posture back.
+    // from it, so no verb here takes a subject.
     appData: {
       async put(target, record) {
         return recordOf(await mutate("appData.put", P["appData.put"], { target, record }));

--- a/packages/vendo/tests/hosted-store.test.ts
+++ b/packages/vendo/tests/hosted-store.test.ts
@@ -5,6 +5,14 @@ import { describe, expect, it, vi } from "vitest";
 import {
   STORE_WIRE_PATHS,
   VendoError,
+  storeWireAppDataDeleteFileRequestSchema,
+  storeWireAppDataDeleteRequestSchema,
+  storeWireAppDataGetFileRequestSchema,
+  storeWireAppDataGetRequestSchema,
+  storeWireAppDataListFilesRequestSchema,
+  storeWireAppDataListRequestSchema,
+  storeWireAppDataPutFileRequestSchema,
+  storeWireAppDataPutRequestSchema,
   storeWireBlobsDeleteRequestSchema,
   storeWireBlobsGetRequestSchema,
   storeWireBlobsListRequestSchema,
@@ -465,7 +473,7 @@ describe("demo-host journey through the store seam", () => {
 });
 
 // ---------------------------------------------------------------------------
-// hostedStoreOps — the 27-op client over `vendo/store-wire@1`.
+// hostedStoreOps — the 35-op client over `vendo/store-wire@1`.
 //
 // Unit tests over an injected fake fetch: they pin the route, the request body
 // and the response decoding for every op — records and blobs against the
@@ -505,6 +513,14 @@ const DOORS: Record<string, { method: string; path: string; keyed?: true }> = {
   "blobs.get": { method: "POST", path: P["blobs.get"] },
   "blobs.delete": { method: "POST", path: P["blobs.delete"], keyed: true },
   "blobs.list": { method: "POST", path: P["blobs.list"] },
+  "appData.put": { method: "POST", path: P["appData.put"], keyed: true },
+  "appData.get": { method: "POST", path: P["appData.get"] },
+  "appData.list": { method: "POST", path: P["appData.list"] },
+  "appData.delete": { method: "POST", path: P["appData.delete"], keyed: true },
+  "appData.putFile": { method: "POST", path: P["appData.putFile"], keyed: true },
+  "appData.getFile": { method: "POST", path: P["appData.getFile"] },
+  "appData.listFiles": { method: "POST", path: P["appData.listFiles"] },
+  "appData.deleteFile": { method: "POST", path: P["appData.deleteFile"], keyed: true },
   "transcripts.putThread": { method: "POST", path: P["transcripts.putThread"], keyed: true },
   "transcripts.getThread": { method: "POST", path: P["transcripts.getThread"] },
   "transcripts.listThreads": { method: "POST", path: P["transcripts.listThreads"] },
@@ -567,6 +583,14 @@ const ALL_BODIES: Record<string, unknown> = {
   [door("blobs.get")]: { blob: { bytes: btoa("blob bytes"), contentType: "text/plain" } },
   [door("blobs.delete")]: { ok: true },
   [door("blobs.list")]: { keys: ["images/a.png"] },
+  [door("appData.put")]: { record: wireRecord },
+  [door("appData.get")]: { record: wireRecord },
+  [door("appData.list")]: { records: [wireRecord], cursor: "cur_app_data" },
+  [door("appData.delete")]: { ok: true },
+  [door("appData.putFile")]: { ok: true },
+  [door("appData.getFile")]: { blob: { bytes: btoa("file bytes"), contentType: "text/plain" } },
+  [door("appData.listFiles")]: { keys: ["receipts/a.pdf"] },
+  [door("appData.deleteFile")]: { ok: true },
   [door("transcripts.putThread")]: { record: wireRecord },
   [door("transcripts.getThread")]: { record: wireRecord },
   [door("transcripts.listThreads")]: { records: [wireRecord], cursor: "cur_threads" },
@@ -582,8 +606,12 @@ const ALL_BODIES: Record<string, unknown> = {
   [door("workspace.history")]: { entries: [{ commitId: "wsc_1" }] },
   [door("lifecycle.erase")]: { report: { vendo_apps: 1 } },
   [door("lifecycle.promote")]: { ok: true },
-  [door("status")]: { format: "vendo/store-wire@1", ops: 27 },
+  [door("status")]: { format: "vendo/store-wire@1", ops: 35 },
 };
+
+/** Where an appData op lands: the app, the collection it invented, and the
+ * owner the runtime stamped — never a subject the caller names. */
+const APP_DATA_TARGET = { appId: "app_1", collection: "invoices", owner: "sub_1" };
 
 const driveEveryOp = async (ops: ReturnType<typeof wireFake>["ops"]): Promise<void> => {
   await ops.records.get("invoices", "inv_1");
@@ -597,6 +625,14 @@ const driveEveryOp = async (ops: ReturnType<typeof wireFake>["ops"]): Promise<vo
   await ops.blobs.get("uploads", "a.png");
   await ops.blobs.delete("uploads", "a.png");
   await ops.blobs.list("uploads");
+  await ops.appData.put(APP_DATA_TARGET, { id: "inv_1", data: { total: 5 } });
+  await ops.appData.get(APP_DATA_TARGET, "inv_1");
+  await ops.appData.list(APP_DATA_TARGET);
+  await ops.appData.delete(APP_DATA_TARGET, "inv_1");
+  await ops.appData.putFile(APP_DATA_TARGET, "receipts/a.pdf", new Uint8Array([1]));
+  await ops.appData.getFile(APP_DATA_TARGET, "receipts/a.pdf");
+  await ops.appData.listFiles(APP_DATA_TARGET);
+  await ops.appData.deleteFile(APP_DATA_TARGET, "receipts/a.pdf");
   await ops.transcripts.putThread({ id: "thr_1", subject: "sub_1", messages: [] });
   await ops.transcripts.getThread("thr_1");
   await ops.transcripts.listThreads();
@@ -615,24 +651,24 @@ const driveEveryOp = async (ops: ReturnType<typeof wireFake>["ops"]): Promise<vo
   await ops.status();
 };
 
-describe("hostedStoreOps — the 27-op wire client", () => {
-  it("routes all 27 ops to the console's real door, with a key on exactly the mutations", async () => {
+describe("hostedStoreOps — the 35-op wire client", () => {
+  it("routes all 35 ops to the console's real door, with a key on exactly the mutations", async () => {
     const { calls, ops } = wireFake(ALL_BODIES);
     await driveEveryOp(ops);
 
     const expected = Object.values(DOORS);
-    expect(calls).toHaveLength(27);
+    expect(calls).toHaveLength(35);
     expect(calls.map((call) => `${call.method} ${call.path}`))
       .toEqual(expected.map((route) => `${route.method} ${route.path}`));
     expect(calls.map((call) => call.idempotencyKey === null ? "read" : "keyed"))
       .toEqual(expected.map((route) => route.keyed === true ? "keyed" : "read"));
-    // 16 mutations, 11 reads — and the /status handshake is the one GET with
+    // 20 mutations, 15 reads — and the /status handshake is the one GET with
     // no body at all.
-    expect(expected.filter((route) => route.keyed === true)).toHaveLength(16);
+    expect(expected.filter((route) => route.keyed === true)).toHaveLength(20);
     expect(calls.at(-1)).toMatchObject({ path: P.status, method: "GET", body: undefined });
     // Distinct keys across distinct operations (one per logical mutation).
     const keys = calls.map((call) => call.idempotencyKey).filter((key) => key !== null);
-    expect(new Set(keys).size).toBe(16);
+    expect(new Set(keys).size).toBe(20);
   });
 
   it("records: seven ops on the wire door, collection on the body, records/cursor decoded", async () => {
@@ -780,6 +816,39 @@ describe("hostedStoreOps — the 27-op wire client", () => {
     }
   });
 
+  it("appData requests validate against the EXPORTED store-wire v1 request schemas", async () => {
+    const { calls, ops } = wireFake(ALL_BODIES);
+    await ops.appData.put(APP_DATA_TARGET, { id: "inv_1", data: { total: 5 } });
+    await ops.appData.get(APP_DATA_TARGET, "inv_1");
+    await ops.appData.list(APP_DATA_TARGET, { limit: 10 });
+    await ops.appData.delete(APP_DATA_TARGET, "inv_1");
+    await ops.appData.putFile(APP_DATA_TARGET, "receipts/a.pdf", new Uint8Array([7]), {
+      contentType: "application/pdf",
+    });
+    await ops.appData.getFile(APP_DATA_TARGET, "receipts/a.pdf");
+    await ops.appData.listFiles(APP_DATA_TARGET, "receipts/");
+    await ops.appData.deleteFile(APP_DATA_TARGET, "receipts/a.pdf");
+
+    const CONTRACT: [keyof typeof P, { safeParse(value: unknown): { success: boolean } }][] = [
+      ["appData.put", storeWireAppDataPutRequestSchema],
+      ["appData.get", storeWireAppDataGetRequestSchema],
+      ["appData.list", storeWireAppDataListRequestSchema],
+      ["appData.delete", storeWireAppDataDeleteRequestSchema],
+      ["appData.putFile", storeWireAppDataPutFileRequestSchema],
+      ["appData.getFile", storeWireAppDataGetFileRequestSchema],
+      ["appData.listFiles", storeWireAppDataListFilesRequestSchema],
+      ["appData.deleteFile", storeWireAppDataDeleteFileRequestSchema],
+    ];
+    expect(calls).toHaveLength(CONTRACT.length);
+    for (const [index, [op, schema]] of CONTRACT.entries()) {
+      const call = calls[index]!;
+      expect(`${call.method} ${call.path}`).toBe(`POST ${P[op]}`);
+      expect(schema.safeParse(call.body).success, op).toBe(true);
+      // The whole address rides ONE target — the owner is the runtime's stamp.
+      expect(call.body).toMatchObject({ target: APP_DATA_TARGET });
+    }
+  });
+
   it("transcripts: six ops over thread ids and message payloads", async () => {
     const { calls, ops } = wireFake(ALL_BODIES);
     const thread = { id: "thr_1", subject: "sub_1", messages: [{ role: "user" }], title: "Budget" };
@@ -864,9 +933,9 @@ describe("hostedStoreOps — the 27-op wire client", () => {
 
   it("status: the GET handshake, parsed as vendo/store-wire@1", async () => {
     const { calls, ops } = wireFake(ALL_BODIES);
-    expect(await ops.status()).toMatchObject({ format: "vendo/store-wire@1", ops: 27 });
+    expect(await ops.status()).toMatchObject({ format: "vendo/store-wire@1", ops: 35 });
     expect(calls[0]).toMatchObject({ path: "/status", method: "GET" });
-    await expect(wireFake({ [door("status")]: { format: "vendo/store-wire@2", ops: 27 } }).ops.status())
+    await expect(wireFake({ [door("status")]: { format: "vendo/store-wire@2", ops: 35 } }).ops.status())
       .rejects.toThrow(/invalid status/);
   });
 
@@ -1032,7 +1101,7 @@ describe("hostedStore keeps its StoreAdapter surface and gains the op surface", 
     expect(typeof store.blobs).toBe("function");
     expect(typeof store.erase.bySubject).toBe("function");
     expect(Object.keys(store.ops).sort()).toEqual([
-      "blobs", "harness", "lifecycle", "records", "status", "transcripts", "workspace",
+      "appData", "blobs", "harness", "lifecycle", "records", "status", "transcripts", "workspace",
     ]);
 
     // The op surface rides the SAME mount, key and identity headers as the
@@ -1055,8 +1124,9 @@ describe("hostedStore keeps its StoreAdapter surface and gains the op surface", 
     expect(await store.ops.blobs.list("uploads", "images/")).toEqual(["images/a.png"]);
   });
 
-  // 15 of the 27 ops have no door in the fake: all 6 transcripts, all 3
-  // harness, all 4 workspace, lifecycle.promote and /status. It used to answer
+  // 23 of the 35 ops have no door in the fake: all 8 appData, all 6
+  // transcripts, all 3 harness, all 4 workspace, lifecycle.promote and
+  // /status. It used to answer
   // them with a `not-found` envelope — the SAME answer a live console sends
   // when it refuses — so a test exercising one of those families read a
   // plausible rejection and asserted nothing. The fake now throws out of


### PR DESCRIPTION
## `appData` — the store family for everything generated apps invent

Generic `records.*` made every app's data one flat namespace with no answer to
"whose row is this". This is the first slice of taking it off the hosted store
wire: `StoreOps` goes from 27 ops across 7 families to **35 across 8**, and the
new family is `appData`.

`StoreAdapter` — the BYO seam — is untouched.

### The two rules that make it safe

**Owner-stamped, by the runtime.** `appData.put` writes `refs.subject = <caller>`
from the host's login session. Generated code has no field for the owner and
cannot invent one: a caller supplying `refs.subject` itself is refused with
`validation`. Unstamped rows cannot exist.

**Permission IS the query.** Every statement carries the owner itself — `list`
ANDs the stamp into `query.refs`, `get` returns `null` for a foreign row,
`delete` is a single owner-predicated statement, and `put` refuses (`conflict`)
an id another owner holds rather than upserting over it. No rules language, no
policy DSL.

### No schema change

The stamp is `refs.subject`, deliberately not a new column: `erase.ts` already
deletes stamped rows and the GIN index on `refs` already serves scoped reads.
`@vendoai/store` gains one composer, `app-data-rows.ts`, as the single place
that spells `app:<appId>:<collection>` and the `<owner>/` file-key prefix.

File twins live in the app's existing blob namespace under an `<owner>/` key
prefix, which `listFiles` strips on the way out. One new erase selector sweeps
those keys on the subject axis, so a member's files inside a *promoted* org app
— which the org owns, and which the subject cascade never reached — now die
with the member. `byApp` is unchanged.

### Proof

Eleven conformance cases live in `packages/core/src/conformance/store-ops.ts`
and **nowhere else**; all three backends run them — the local Postgres backend,
the Cloud client, and the in-core memory reference. Each guard was proven to
fail: reverting the stamp reddens the isolation cases, reverting the `put` guard
reddens `appData.put refuses an id another owner holds`, and the delete cases
assert both halves (the foreign row survives AND the caller's own row goes), so
an empty `delete` cannot pass.

### Two follow-ups worth knowing about

- `selectStoreOps` returns `StoreOps | undefined`. Composing `createStoreOps`
  unconditionally opened the store's SQL handle at boot, which turned a designed
  refusal into a crash for a host whose store has neither its own `ops` nor a
  handle (it broke three existing tests). It now gives `backendOf`'s own
  three-way answer.
- `StoreWireStatus` gains an optional `deprecated` list so a mount can announce
  ops it is retiring. No producer yet — the later slices use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `appData`, an owner-stamped store family for app-created data and files. StoreOps grows from 27 to 35 ops across 8 families, with runtime-scoped reads/writes and no schema changes, supported in local Postgres, the hosted client, and memory reference.

- **New Features**
  - `appData` family: 8 ops (`put/get/list/delete` + file twins) at `/app-data/*`; files base64 on the wire.
  - Runtime stamps `refs.subject`; callers cannot set it. Reads auto-scope by owner. `put` returns `conflict` if the id is held by another owner.
  - Namespacing: rows in `app:<appId>:<collection>`; files under `<owner>/key` with `listFiles` stripping the prefix. Collection names follow `APP_DATA_COLLECTION_PATTERN`.
  - Conformance: 11 cases cover stamping, scoping, conflicts, and files; all backends pass. `status` now reports `ops: 35` and may include `deprecated`.
  - Composition: `selectStoreOps` chooses the store’s own ops when present, else the local backend via `maybeDbFor`; exposed as `VendoComposition.ops`. Exports added from `@vendoai/store`.

- **Bug Fixes**
  - Transaction-safe `appData.put` refuses cross-owner overwrite; `delete` uses a single owner-predicated statement to avoid races.
  - `erase.bySubject` now sweeps appData files in promoted org apps via the owner key prefix.
  - Prevent boot crashes when no ops or SQL handle: `selectStoreOps` returns `undefined` instead of eagerly opening a handle.
  - Hosted client shares file-read and list decoding helpers for `blobs.*` and `appData.*` to keep behaviors consistent.

<sup>Written for commit 5feae61bfac7c2352729d830d21e298862f28661. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

