### PR TITLE
feat(store): the appData backfill — nothing goes invisible when a door flips

### DIFF
--- a/.changeset/store-app-data-backfill.md
+++ b/.changeset/store-app-data-backfill.md
@@ -20,11 +20,15 @@ rows lacking a stamp are touched, so a second run reports `rowsStamped: 0`;
 row's content did not change and a bumped revision would fail a live CAS holder
 for a change it cannot see.
 
-**Where an owner cannot be established, nothing is guessed at.** A collection
-whose app has no `vendo_apps` row — or whose app row carries an empty subject —
-is REPORTED in `orphanCollections` and left completely untouched. The function
-issues no `DELETE` anywhere, and a blob key collision throws rather than
-inventing a resolution.
+**Where an owner cannot be established — or cannot be used safely — nothing is
+guessed at.** A collection whose app has no `vendo_apps` row, whose app row
+carries an empty subject, or whose subject contains the `/` that separates the
+owner leg from the caller's file key, is REPORTED in `orphanCollections` and
+left completely untouched. That last one is data, not policy: owner `own_a/sub`
+with key `x.bin` and owner `own_a` with key `sub/x.bin` spell the identical
+stored key, and no later validation can unbend a key already written. The
+function issues no `DELETE` anywhere, and a blob key collision throws rather
+than inventing a resolution.
 
 `lifecycle.promote` now moves the whole app in its existing single transaction:
 the app's appData is backfilled *before* the row flip (so the stamp it writes is

--- a/.changeset/store-app-data-backfill.md
+++ b/.changeset/store-app-data-backfill.md
@@ -1,0 +1,34 @@
+---
+"@vendoai/store": minor
+---
+
+`backfillAppDataStamps` — the migration that keeps pre-appData data visible.
+
+Every appData read is auto-scoped to the caller's owner: `refs.subject` on rows,
+an `<owner>/` leading key leg on their file twins. A row written before a door
+moved onto the family carries neither, so the moment that door flips the row
+goes **invisible** — not deleted, unreadable, and an auto-scoped query returning
+nothing looks exactly like an empty collection. This is the one-shot, re-runnable
+migration that stamps that data with the owner it always had.
+
+`backfillAppDataStamps(store, { batch = 500, appId })` reports
+`{ apps, rowsStamped, rowsSkipped, filesMoved, orphanCollections }`. The owner is
+`vendo_apps.subject` with no personal-vs-promoted branch — a promoted app's
+subject IS the org id (§9.5), so the row already holds the right value. Only
+rows lacking a stamp are touched, so a second run reports `rowsStamped: 0`;
+`data`, `revision` and `updated_at` are left exactly as they were, because the
+row's content did not change and a bumped revision would fail a live CAS holder
+for a change it cannot see.
+
+**Where an owner cannot be established, nothing is guessed at.** A collection
+whose app has no `vendo_apps` row — or whose app row carries an empty subject —
+is REPORTED in `orphanCollections` and left completely untouched. The function
+issues no `DELETE` anywhere, and a blob key collision throws rather than
+inventing a resolution.
+
+`lifecycle.promote` now moves the whole app in its existing single transaction:
+the app's appData is backfilled *before* the row flip (so the stamp it writes is
+still the old subject), then every row and file changes hands in one uniform
+rename, and the app's bearer token's `refs.subject` follows. Both halves are
+required — rows alone would leave a promoted app's box writes stamping the
+departed personal subject, and the org blind to its own new data.

--- a/packages/store/src/backfill-app-data.ts
+++ b/packages/store/src/backfill-app-data.ts
@@ -148,9 +148,16 @@ export async function backfillAppDataOnDb(
   const worked = new Set<string>();
   for (const [name, appId] of new Map([...collections, ...namespaces])) {
     const subject = subjects.get(appId);
-    // No app row, or an app row whose subject is empty: an owner that cannot be
-    // determined is never guessed at. Reported, and left completely untouched.
-    if (subject === undefined || subject === "") {
+    // No app row, an empty subject, or a subject carrying the `/` that
+    // separates the owner leg from the caller's key: an owner that cannot be
+    // determined — or cannot be USED safely — is never guessed at. Reported,
+    // and left completely untouched. `vendo_apps.subject` is host-chosen, and
+    // an owner with a slash writes a key another owner can read back (owner
+    // `own_a/sub` and owner `own_a`'s key `sub/x.bin` spell the same row), so
+    // stamping one bends data no later door fix can unbend. Neither sanitised
+    // nor rewritten: `/` is the only thing matched here, because the owner
+    // grammar itself is being decided elsewhere.
+    if (subject === undefined || subject === "" || subject.includes("/")) {
       report.orphanCollections.push(name);
       continue;
     }

--- a/packages/store/src/backfill-app-data.ts
+++ b/packages/store/src/backfill-app-data.ts
@@ -1,0 +1,216 @@
+import { APP_DATA_OWNER_REF } from "./app-data-rows.js";
+import type { Db } from "./db.js";
+import { appScopeId, escapeLike, jsonParam } from "./helpers/utils.js";
+import { dbFor, type VendoStore } from "./store.js";
+
+/** Every appData read is auto-scoped to the caller's owner — `refs.subject` on
+ *  rows, an `<owner>/` leading key leg on their file twins. A row written
+ *  before a door moved onto the family carries neither, so the moment that door
+ *  flips the row goes INVISIBLE: not deleted, unreadable. This module is the
+ *  one-shot migration that stamps that data with the owner it always had, and
+ *  it is the only thing between a flip and silent data loss. Correctness over
+ *  cleverness throughout: where an owner cannot be established the backfill
+ *  reports and moves on, and it issues no DELETE anywhere. */
+
+export interface AppDataBackfillReport {
+  apps: number;
+  rowsStamped: number;
+  rowsSkipped: number;
+  filesMoved: number;
+  orphanCollections: string[];
+}
+
+const DEFAULT_BATCH = 500;
+
+/** One app's appData names, rows and files alike — `appDataNamespace` IS
+ *  `appDataCollection`, so a single pattern selects both tables' share. */
+function appScopePrefix(appId: string): string {
+  return `app:${escapeLike(appId)}:%`;
+}
+
+/** The app-scoped names present in one table, mapped to their owning appId.
+ *  A name `appScopeId` cannot parse (a bare `app:<id>` namespace, no collection
+ *  segment) is not an appData name at all: it is dropped here, so nothing
+ *  downstream touches or reports it. */
+async function discoverNames(
+  db: Db,
+  table: "vendo_records" | "vendo_blobs",
+  column: "collection" | "namespace",
+  appId: string | undefined,
+): Promise<Map<string, string>> {
+  const result = appId === undefined
+    ? await db.query(`SELECT DISTINCT ${column} FROM ${table} WHERE ${column} LIKE 'app:%'`)
+    : await db.query(
+      `SELECT DISTINCT ${column} FROM ${table} WHERE ${column} LIKE $1 ESCAPE '\\'`,
+      [appScopePrefix(appId)],
+    );
+  const names = new Map<string, string>();
+  for (const row of result.rows) {
+    const name = String(row[column]);
+    const owningApp = appScopeId(name);
+    if (owningApp !== undefined) names.set(name, owningApp);
+  }
+  return names;
+}
+
+/** Rows in `collection` that already carry an owner stamp — counted BEFORE
+ *  stamping, or the run's own work would report itself as pre-existing. */
+async function countStamped(db: Db, collection: string): Promise<number> {
+  const result = await db.query(
+    `SELECT count(*)::int AS stamped FROM vendo_records
+     WHERE collection = $1 AND refs->>'${APP_DATA_OWNER_REF}' IS NOT NULL`,
+    [collection],
+  );
+  return Number(result.rows[0]?.["stamped"] ?? 0);
+}
+
+/** Merge the owner stamp into `refs` and NOTHING else: `data`, `updated_at` and
+ *  `revision` stay exactly as they were. The row's content did not change, and
+ *  bumping `revision` would fail a live CAS holder for a change it cannot see. */
+async function stampRows(db: Db, collection: string, owner: string, batch: number): Promise<number> {
+  const stamp = jsonParam({ [APP_DATA_OWNER_REF]: owner });
+  let stamped = 0;
+  for (;;) {
+    const result = await db.query(
+      `UPDATE vendo_records SET refs = coalesce(refs, '{}'::jsonb) || $2::jsonb
+       WHERE (collection, id) IN (
+         SELECT collection, id FROM vendo_records
+         WHERE collection = $1 AND refs->>'${APP_DATA_OWNER_REF}' IS NULL
+         ORDER BY id LIMIT $3
+       ) RETURNING 1`,
+      [collection, stamp, batch],
+    );
+    if (result.rows.length === 0) return stamped;
+    stamped += result.rows.length;
+  }
+}
+
+/** Put the owner leg on legacy file keys. Already-migrated keys are recognised
+ *  by `key LIKE '<owner>/%'` and nothing else, which carries a residual
+ *  ambiguity worth naming: a legacy key that literally begins with `<owner>/`
+ *  is indistinguishable from one this backfill already moved, so it is left
+ *  alone. Each batch's rows join that prefixed set, leaving the candidate set
+ *  as they go, so the loop still ends on a zero-row batch.
+ *
+ *  `(namespace, key)` is the primary key, so a collision with an existing
+ *  `<owner>/<key>` raises a unique violation. It is allowed to throw: the
+ *  backfill never invents a resolution, exactly like the orphan rule. */
+async function moveFiles(db: Db, namespace: string, owner: string, batch: number): Promise<number> {
+  const alreadyOwned = `${escapeLike(owner)}/%`;
+  let moved = 0;
+  for (;;) {
+    const result = await db.query(
+      `UPDATE vendo_blobs SET key = $2 || '/' || key
+       WHERE (namespace, key) IN (
+         SELECT namespace, key FROM vendo_blobs
+         WHERE namespace = $1 AND key NOT LIKE $3 ESCAPE '\\' ORDER BY key LIMIT $4
+       ) RETURNING 1`,
+      [namespace, owner, alreadyOwned, batch],
+    );
+    if (result.rows.length === 0) return moved;
+    moved += result.rows.length;
+  }
+}
+
+/** The Db-taking implementation behind {@link backfillAppDataStamps}, so
+ *  promote can run the stamp on its TRANSACTION-scoped handle (same reason as
+ *  {@link reownAppData}). Package-internal: never exported from the package
+ *  entries — a caller outside gets the store-taking verb. */
+export async function backfillAppDataOnDb(
+  db: Db,
+  options: { batch?: number; appId?: string },
+): Promise<AppDataBackfillReport> {
+  const batch = options.batch ?? DEFAULT_BATCH;
+  const collections = await discoverNames(db, "vendo_records", "collection", options.appId);
+  const namespaces = await discoverNames(db, "vendo_blobs", "namespace", options.appId);
+
+  // The owner of everything under `app:<appId>:…` is the app row's subject —
+  // read once per app, with no personal-vs-promoted branch: a promoted app's
+  // subject IS the org id (build contract §9.5), so the row already holds the
+  // right value.
+  const subjects = new Map<string, string>();
+  const apps = options.appId === undefined
+    ? await db.query("SELECT id, subject FROM vendo_apps")
+    : await db.query("SELECT id, subject FROM vendo_apps WHERE id = $1", [options.appId]);
+  for (const row of apps.rows) subjects.set(String(row["id"]), String(row["subject"]));
+
+  const report: AppDataBackfillReport = {
+    apps: 0,
+    rowsStamped: 0,
+    rowsSkipped: 0,
+    filesMoved: 0,
+    orphanCollections: [],
+  };
+
+  // Resolved over the UNION of both tables' names, so a name discovered on both
+  // sides is reported as an orphan once, not twice.
+  const owners = new Map<string, string>();
+  const worked = new Set<string>();
+  for (const [name, appId] of new Map([...collections, ...namespaces])) {
+    const subject = subjects.get(appId);
+    // No app row, or an app row whose subject is empty: an owner that cannot be
+    // determined is never guessed at. Reported, and left completely untouched.
+    if (subject === undefined || subject === "") {
+      report.orphanCollections.push(name);
+      continue;
+    }
+    owners.set(name, subject);
+    worked.add(appId);
+  }
+
+  for (const [collection] of collections) {
+    const owner = owners.get(collection);
+    if (owner === undefined) continue;
+    report.rowsSkipped += await countStamped(db, collection);
+    report.rowsStamped += await stampRows(db, collection, owner, batch);
+  }
+  for (const [namespace] of namespaces) {
+    const owner = owners.get(namespace);
+    if (owner === undefined) continue;
+    report.filesMoved += await moveFiles(db, namespace, owner, batch);
+  }
+  report.apps = worked.size;
+  return report;
+}
+
+/**
+ * Stamp pre-existing appData with the owner it always had, so the auto-scoped
+ * read path can still see it: rows get `refs.<APP_DATA_OWNER_REF>`, file twins
+ * get the `<owner>/` key leg. Re-runnable by construction — a second run stamps
+ * 0 rows and moves 0 files, and reports the already-stamped rows as
+ * `rowsSkipped`.
+ *
+ * `apps` counts the apps this run actually WORKED ON: those owning at least one
+ * discovered, non-orphan appData collection or namespace. `orphanCollections`
+ * holds the names whose owner could not be established (no `vendo_apps` row, or
+ * an empty subject); nothing in them is touched, and this function never
+ * deletes anything.
+ */
+export async function backfillAppDataStamps(
+  store: VendoStore,
+  options: { batch?: number; appId?: string } = {},
+): Promise<AppDataBackfillReport> {
+  return await backfillAppDataOnDb(dbFor(store), options);
+}
+
+/** Promote's half: the whole app changes hands, so every appData row and file
+ *  stamped `from` is re-stamped `to`. Takes a Db (not a store) so promote can
+ *  pass its TRANSACTION-scoped handle — a base-handle query issued mid
+ *  transaction deadlocks PGlite's single connection (see ops.ts's txDb note). */
+export async function reownAppData(db: Db, appId: string, from: string, to: string): Promise<void> {
+  const prefix = appScopePrefix(appId);
+  await db.query(
+    `UPDATE vendo_records SET refs = refs || $2::jsonb
+     WHERE collection LIKE $1 ESCAPE '\\' AND refs @> $3::jsonb`,
+    [prefix, jsonParam({ [APP_DATA_OWNER_REF]: to }), jsonParam({ [APP_DATA_OWNER_REF]: from })],
+  );
+  await db.query(
+    // SQL `substring(… from n)` is 1-indexed, so the caller's own key starts one
+    // past the `<from>/` leg: from.length + 2. The `::int` is load-bearing: an
+    // untyped parameter there resolves to `substring(text from PATTERN)`, the
+    // POSIX-regex overload, which finds no match and sets every key to NULL.
+    `UPDATE vendo_blobs SET key = $2 || '/' || substring(key from $3::int)
+     WHERE namespace LIKE $1 ESCAPE '\\' AND key LIKE $4 ESCAPE '\\'`,
+    [prefix, to, from.length + 2, `${escapeLike(from)}/%`],
+  );
+}

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -17,6 +17,9 @@ export {
   appDataFileKey,
   APP_DATA_OWNER_REF,
 } from "./app-data-rows.js";
+// The one-shot migration for appData that predates the owner stamp: without it
+// every such row goes invisible the moment a door flips onto the family.
+export { backfillAppDataStamps, type AppDataBackfillReport } from "./backfill-app-data.js";
 // The reserved-collection map (02-store §2): exported so remote StoreAdapters
 // (the umbrella's hostedStore) can mirror this engine's per-collection
 // capability shape — claim on non-routed collections, atomic on generic

--- a/packages/store/src/ops.ts
+++ b/packages/store/src/ops.ts
@@ -8,12 +8,13 @@ import {
   type VendoRecord,
 } from "@vendoai/core";
 import { appDataFiles, appDataRows } from "./app-data-rows.js";
+import { backfillAppDataOnDb, reownAppData } from "./backfill-app-data.js";
 import type { Db, Query } from "./db.js";
 import { eraseStore } from "./erase.js";
 import { storeFiles, storeFilesForDb } from "./files-store.js";
 import { harnessStateKey } from "./harness-state.js";
 import { putStateRow, putThreadRow, THREAD_MESSAGES_AGGREGATE, threadFromRow } from "./helpers/rows.js";
-import { iso, pageLimit, text } from "./helpers/utils.js";
+import { iso, jsonParam, pageLimit, text } from "./helpers/utils.js";
 import { createRecordStore } from "./records.js";
 import { createReservedRecordStore, threadRecord } from "./routing.js";
 import { dbFor, type VendoStore } from "./store.js";
@@ -25,6 +26,14 @@ import { workspaceRows, type PreparedWrite } from "./workspace-rows.js";
  *  idempotency-key replay — no new table. Rows carry the workspace owner as a
  *  subject ref, so the erase cascade reaches them. */
 const WORKSPACE_COMMITS = "vendo_workspace_commits";
+
+/** The per-app bearer's collection in the generic records table: one row per
+ *  live app token, `refs = { app_id, subject }`, minted and read by
+ *  `packages/apps/src/server/persistence/app-token.ts` — the source of truth
+ *  for this name. Spelled here rather than imported: `@vendoai/apps`'s entry is
+ *  the whole apps server, and dragging it into this module's graph for one
+ *  string costs the store its edge portability. */
+const APP_TOKENS = "vendo_app_tokens";
 
 interface WorkspaceEntry {
   path: string;
@@ -605,7 +614,8 @@ export function createStoreOps(
         invalid("lifecycle.erase needs a subject or an appId");
       },
       /** §9.5 — the app row flip and the workspace document move, which the
-       *  umbrella ran as a two-step seam, are ONE transaction here. */
+       *  umbrella ran as a two-step seam, are ONE transaction here, and so is
+       *  everything else the app owns: its appData and its bearer token. */
       async promote(appId, orgId) {
         await db.transaction(async (q) => {
           const tdb = txDb(q);
@@ -615,6 +625,14 @@ export function createStoreOps(
             throw new VendoError("not-found", `App ${appId} was not found`);
           }
           if (from === orgId) return; // already the org's — idempotent
+          // Legacy appData carries no owner stamp, and this runs BEFORE the row
+          // flip on purpose: the stamp it writes is `vendo_apps.subject`, still
+          // `from` at this point, so the reown below is ONE uniform
+          // `from` → `orgId` rename with no legacy-vs-stamped ambiguity left in
+          // the table. Do not "simplify" it to after the flip: the stamp would
+          // then write `orgId` while the rename still looks for `from`, and the
+          // two halves would disagree about which rows are legacy.
+          await backfillAppDataOnDb(tdb, { appId });
           await workspaceRows(tdb, filesFor(tdb)).moveApp(
             appId,
             { kind: "user", subject: from },
@@ -630,6 +648,21 @@ export function createStoreOps(
           if (flipped.rows[0] === undefined) {
             throw new VendoError("conflict", `app ${appId} belongs to another subject`);
           }
+          // The app's data changes hands with the app: appData is auto-scoped
+          // to the owner, and the owner IS `vendo_apps.subject`, so without
+          // this the org goes blind to its own app's rows and files. A blob
+          // primary-key collision here throws and rolls the whole promote back
+          // — §9.5 is all-or-nothing, and there is no resolution to invent.
+          await reownAppData(tdb, appId, from, orgId);
+          // And so does the app's bearer. The box keeps calling back with the
+          // token it already holds; left on the departed personal subject it
+          // would keep writing rows stamped with a subject that no longer owns
+          // the app (`refs.subject` is exactly what apps' `verify` returns).
+          await q(
+            `UPDATE vendo_records SET refs = refs || $2::jsonb
+             WHERE collection = $1 AND refs @> $3::jsonb`,
+            [APP_TOKENS, jsonParam({ subject: orgId }), jsonParam({ app_id: appId })],
+          );
         });
       },
     },

--- a/packages/store/src/postgres.ts
+++ b/packages/store/src/postgres.ts
@@ -43,6 +43,7 @@ export {
   appDataFileKey,
   APP_DATA_OWNER_REF,
 } from "./app-data-rows.js";
+export { backfillAppDataStamps, type AppDataBackfillReport } from "./backfill-app-data.js";
 export {
   DEDICATED_RECORD_COLLECTIONS,
   RESERVED_COLLECTIONS,

--- a/packages/store/tests/backfill-app-data.test.ts
+++ b/packages/store/tests/backfill-app-data.test.ts
@@ -1,0 +1,266 @@
+import { createAppTokens } from "@vendoai/apps";
+import type { Principal } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { backends, type MadeBackend } from "../src/backends.test-util.js";
+import { reownAppData } from "../src/backfill-app-data.js";
+import { appFixture } from "../src/fixtures.test-util.js";
+import { appStore, backfillAppDataStamps, createStoreOps } from "../src/index.js";
+import { dbFor } from "../src/store.js";
+
+/** appData reads are auto-scoped to the caller's owner, so data written before
+    a door moved onto the family is invisible until it is stamped. Every
+    assertion here reads back through the REAL appData path — raw SQL only
+    where a legacy row has to be forged, or where "untouched" is the claim. */
+
+const dana: Principal = { kind: "user", subject: "dana" };
+
+for (const backend of backends()) {
+  describe(`${backend.name} appData backfill`, () => {
+    const make = async (): Promise<MadeBackend> => {
+      const made = await backend.make();
+      await made.store.ensureSchema();
+      return made;
+    };
+
+    /** Legacy rows: the pre-appData write path, which stamps nothing. */
+    const seedLegacy = async (made: MadeBackend, collection: string, ids: string[]): Promise<void> => {
+      const records = made.store.records(collection);
+      for (const id of ids) await records.put({ id, data: { note: id } });
+    };
+
+    it("stamps a personal app's legacy rows so the scoped read sees them again, batch by batch", async () => {
+      const made = await make();
+      try {
+        await appStore(made.store).put(dana, appFixture("app_notes"));
+        await seedLegacy(made, "app:app_notes:notes", ["n1", "n2", "n3", "n4", "n5"]);
+        // Invisible before the backfill — the whole reason this exists.
+        const ops = createStoreOps(made.store);
+        const target = { appId: "app_notes", collection: "notes", owner: "dana" };
+        expect((await ops.appData.list(target)).records).toEqual([]);
+
+        // batch: 2 over 5 rows — three passes, the last one short.
+        expect(await backfillAppDataStamps(made.store, { batch: 2 })).toEqual({
+          apps: 1,
+          rowsStamped: 5,
+          rowsSkipped: 0,
+          filesMoved: 0,
+          orphanCollections: [],
+        });
+
+        expect((await ops.appData.list(target)).records.map((record) => record.id).sort())
+          .toEqual(["n1", "n2", "n3", "n4", "n5"]);
+        expect(await ops.appData.get(target, "n3")).toMatchObject({ data: { note: "n3" } });
+      } finally {
+        await made.cleanup();
+      }
+    });
+
+    it("stamps a promoted app's rows with the ORG, not the subject that created them", async () => {
+      const made = await make();
+      try {
+        await appStore(made.store).put(dana, appFixture("app_team"));
+        await appStore(made.store).promote("app_team", "dana", "acme");
+        await seedLegacy(made, "app:app_team:notes", ["t1", "t2"]);
+
+        expect(await backfillAppDataStamps(made.store)).toMatchObject({ apps: 1, rowsStamped: 2 });
+
+        const ops = createStoreOps(made.store);
+        const base = { appId: "app_team", collection: "notes" };
+        expect((await ops.appData.list({ ...base, owner: "acme" })).records.map((r) => r.id).sort())
+          .toEqual(["t1", "t2"]);
+        // The org owns the app now (§9.5), so the old personal subject sees nothing.
+        expect((await ops.appData.list({ ...base, owner: "dana" })).records).toEqual([]);
+      } finally {
+        await made.cleanup();
+      }
+    });
+
+    it("re-runs to a no-op, leaving every row's content byte-identical", async () => {
+      const made = await make();
+      try {
+        await appStore(made.store).put(dana, appFixture("app_twice"));
+        await seedLegacy(made, "app:app_twice:notes", ["a", "b", "c"]);
+        // `data`, `revision` and `updated_at` must survive both runs untouched:
+        // the row's content never changed, and a bumped revision would fail a
+        // live CAS holder for a change it cannot see.
+        const content = "SELECT id, data, revision, updated_at FROM vendo_records ORDER BY id";
+        const before = await made.sql(content);
+
+        expect(await backfillAppDataStamps(made.store)).toMatchObject({ rowsStamped: 3, rowsSkipped: 0 });
+        expect(await backfillAppDataStamps(made.store)).toEqual({
+          apps: 1,
+          rowsStamped: 0,
+          rowsSkipped: 3,
+          filesMoved: 0,
+          orphanCollections: [],
+        });
+
+        expect(await made.sql(content)).toEqual(before);
+      } finally {
+        await made.cleanup();
+      }
+    });
+
+    it("reports a collection whose app is gone and touches nothing in it", async () => {
+      const made = await make();
+      try {
+        // Forged directly: the live write path refuses an app-scoped row whose
+        // app has no `vendo_apps` row, which is exactly what makes this legacy.
+        for (const id of ["g1", "g2"]) {
+          await made.sql(
+            `INSERT INTO vendo_records (collection, id, data, created_at, updated_at)
+             VALUES ($1, $2, $3, now(), now())`,
+            ["app:app_ghost:notes", id, JSON.stringify({ note: id })],
+          );
+        }
+
+        expect(await backfillAppDataStamps(made.store)).toEqual({
+          apps: 0,
+          rowsStamped: 0,
+          rowsSkipped: 0,
+          filesMoved: 0,
+          orphanCollections: ["app:app_ghost:notes"],
+        });
+
+        expect(await made.sql(
+          "SELECT id, data, refs FROM vendo_records WHERE collection = $1 ORDER BY id",
+          ["app:app_ghost:notes"],
+        )).toEqual([
+          { id: "g1", data: { note: "g1" }, refs: null },
+          { id: "g2", data: { note: "g2" }, refs: null },
+        ]);
+      } finally {
+        await made.cleanup();
+      }
+    });
+
+    it("re-keys legacy files under the owner leg exactly once", async () => {
+      const made = await make();
+      try {
+        await appStore(made.store).put(dana, appFixture("app_files"));
+        const bytes = new TextEncoder().encode("quarterly numbers");
+        // Legacy: written straight at the namespace, with no owner leg.
+        await made.store.blobs("app:app_files:docs").put("report.txt", bytes, { contentType: "text/plain" });
+
+        expect(await backfillAppDataStamps(made.store)).toMatchObject({ apps: 1, filesMoved: 1 });
+        expect(await made.sql("SELECT key FROM vendo_blobs")).toEqual([{ key: "dana/report.txt" }]);
+
+        // The owner leg is the seam's business, so the caller's key is the one
+        // it always was.
+        const ops = createStoreOps(made.store);
+        const target = { appId: "app_files", collection: "docs", owner: "dana" };
+        expect(await ops.appData.listFiles(target)).toEqual(["report.txt"]);
+        const read = await ops.appData.getFile(target, "report.txt");
+        expect(Buffer.from(read?.bytes ?? new Uint8Array()).toString("utf8")).toBe("quarterly numbers");
+
+        expect(await backfillAppDataStamps(made.store)).toMatchObject({ filesMoved: 0 });
+        expect(await made.sql("SELECT key FROM vendo_blobs")).toEqual([{ key: "dana/report.txt" }]);
+      } finally {
+        await made.cleanup();
+      }
+    });
+
+    it("touches only the named app when scoped to one appId", async () => {
+      const made = await make();
+      try {
+        await appStore(made.store).put(dana, appFixture("app_a"));
+        await appStore(made.store).put(dana, appFixture("app_b"));
+        await seedLegacy(made, "app:app_a:notes", ["a1"]);
+        await seedLegacy(made, "app:app_b:notes", ["b1"]);
+
+        expect(await backfillAppDataStamps(made.store, { appId: "app_a" })).toEqual({
+          apps: 1,
+          rowsStamped: 1,
+          rowsSkipped: 0,
+          filesMoved: 0,
+          orphanCollections: [],
+        });
+
+        expect(await made.sql(
+          "SELECT collection, refs FROM vendo_records ORDER BY collection",
+        )).toEqual([
+          { collection: "app:app_a:notes", refs: { subject: "dana" } },
+          { collection: "app:app_b:notes", refs: null },
+        ]);
+      } finally {
+        await made.cleanup();
+      }
+    });
+
+    /** Promote's half. The file statement rebuilds the key around a new owner
+        leg, so the 1-indexed `substring` offset is proven here, not reasoned
+        about: a wrong offset leaves a slash or eats a character. */
+    it("reowns an app's rows and files when the app changes hands", async () => {
+      const made = await make();
+      try {
+        await appStore(made.store).put(dana, appFixture("app_reown"));
+        const ops = createStoreOps(made.store);
+        const owned = { appId: "app_reown", collection: "notes", owner: "dana" };
+        await ops.appData.put(owned, { id: "r1", data: { note: "mine" } });
+        await ops.appData.putFile(owned, "report.txt", new TextEncoder().encode("hi"));
+
+        await reownAppData(dbFor(made.store), "app_reown", "dana", "acme");
+
+        expect(await made.sql("SELECT key FROM vendo_blobs")).toEqual([{ key: "acme/report.txt" }]);
+        const moved = { ...owned, owner: "acme" };
+        expect((await ops.appData.list(moved)).records.map((record) => record.id)).toEqual(["r1"]);
+        expect(await ops.appData.listFiles(moved)).toEqual(["report.txt"]);
+        expect((await ops.appData.list(owned)).records).toEqual([]);
+      } finally {
+        await made.cleanup();
+      }
+    });
+
+    /** The real verb, end to end. Both stamped and legacy rows have to arrive
+        at the org: the backfill inside promote runs before the row flip, so the
+        legacy row is stamped `dana` first and then renamed with the rest. */
+    it("hands an app's rows and files to the org across a promote", async () => {
+      const made = await make();
+      try {
+        await appStore(made.store).put(dana, appFixture("app_hands"));
+        const ops = createStoreOps(made.store);
+        const mine = { appId: "app_hands", collection: "notes", owner: "dana" };
+        await ops.appData.put(mine, { id: "stamped", data: { note: "mine" } });
+        await seedLegacy(made, "app:app_hands:notes", ["legacy"]);
+        await ops.appData.putFile(mine, "report.txt", new TextEncoder().encode("numbers"));
+
+        await ops.lifecycle.promote("app_hands", "acme");
+
+        const theirs = { ...mine, owner: "acme" };
+        expect((await ops.appData.list(theirs)).records.map((record) => record.id).sort())
+          .toEqual(["legacy", "stamped"]);
+        // The owner leg is the seam's business, so the org reads the caller's
+        // own key, unprefixed.
+        expect(await ops.appData.listFiles(theirs)).toEqual(["report.txt"]);
+        const read = await ops.appData.getFile(theirs, "report.txt");
+        expect(Buffer.from(read?.bytes ?? new Uint8Array()).toString("utf8")).toBe("numbers");
+
+        // The departed personal subject keeps nothing.
+        expect((await ops.appData.list(mine)).records).toEqual([]);
+        expect(await ops.appData.getFile(mine, "report.txt")).toBeNull();
+        expect(await ops.appData.listFiles(mine)).toEqual([]);
+      } finally {
+        await made.cleanup();
+      }
+    });
+
+    /** The seam, with no stub on either side: the producer is store's own
+        `lifecycle.promote`, the consumer is apps' `verify`, which reads the
+        subject straight off the token row's refs. A token left on the departed
+        personal subject would have the box writing appData nobody owns. */
+    it("moves the app token with the app, so the box's bearer verifies as the org", async () => {
+      const made = await make();
+      try {
+        await appStore(made.store).put(dana, appFixture("app_bearer"));
+        const token = await createAppTokens(made.store).mint("app_bearer", "dana");
+
+        await createStoreOps(made.store).lifecycle.promote("app_bearer", "acme");
+
+        expect(await createAppTokens(made.store).verify(token))
+          .toEqual({ appId: "app_bearer", subject: "acme" });
+      } finally {
+        await made.cleanup();
+      }
+    });
+  });
+}

--- a/packages/store/tests/backfill-app-data.test.ts
+++ b/packages/store/tests/backfill-app-data.test.ts
@@ -134,6 +134,37 @@ for (const backend of backends()) {
       }
     });
 
+    /** `/` is what separates the owner leg from the caller's key, so an owner
+        carrying one writes a file key another owner can read back — owner
+        `own_a/sub` and owner `own_a`'s key `sub/x.bin` spell the same row.
+        `vendo_apps.subject` is host-chosen, so that owner is reachable here; an
+        owner this backfill cannot USE safely is reported exactly like one it
+        cannot determine, because no later door fix can unbend data already
+        written under an ambiguous key. */
+    it("reports an app whose subject carries a slash, stamping nothing and moving nothing", async () => {
+      const made = await make();
+      try {
+        await appStore(made.store).put({ kind: "user", subject: "own_a/sub" }, appFixture("app_slash"));
+        await seedLegacy(made, "app:app_slash:notes", ["s1"]);
+        await made.store.blobs("app:app_slash:docs").put("x.bin", new Uint8Array([1]));
+
+        expect(await backfillAppDataStamps(made.store)).toEqual({
+          apps: 0,
+          rowsStamped: 0,
+          rowsSkipped: 0,
+          filesMoved: 0,
+          orphanCollections: ["app:app_slash:notes", "app:app_slash:docs"],
+        });
+
+        expect(await made.sql("SELECT refs FROM vendo_records WHERE collection = $1", ["app:app_slash:notes"]))
+          .toEqual([{ refs: null }]);
+        expect(await made.sql("SELECT key FROM vendo_blobs WHERE namespace = $1", ["app:app_slash:docs"]))
+          .toEqual([{ key: "x.bin" }]);
+      } finally {
+        await made.cleanup();
+      }
+    });
+
     it("re-keys legacy files under the owner leg exactly once", async () => {
       const made = await make();
       try {


### PR DESCRIPTION
Every appData read is auto-scoped to the caller's owner: `refs.subject` on rows, an `<owner>/` leading key leg on their file twins. A row written **before** a door moved onto the family carries neither, so the moment that door flips the row goes **invisible** — not deleted, unreadable. An auto-scoped query returning nothing is indistinguishable from an empty collection, so no test would go red and a user's data would simply be gone from their app.

This is the migration that stops that. It lands and runs before any door flips.

## `backfillAppDataStamps(store, { batch = 500, appId })`

Reports `{ apps, rowsStamped, rowsSkipped, filesMoved, orphanCollections }`.

- **Owner = `vendo_apps.subject`, with no branch.** Personal app → the user's subject, promoted app → the org id: the app row already holds the right value (§9.5), so there is nothing to decide.
- **Re-runnable.** Only rows lacking a stamp are touched, in batches, so a second run reports `rowsStamped: 0` and the already-stamped rows as `rowsSkipped`.
- **`data`, `revision` and `updated_at` are left exactly as they were.** The row's content did not change, and a bumped revision would fail a live CAS holder for a change it cannot see.
- **Files** get the `<owner>/` key leg, once. Already-migrated keys are recognised by `key LIKE '<owner>/%'` and nothing else — the residual ambiguity (a legacy key that literally begins with `<owner>/`) is named in a comment rather than papered over.
- **Where an owner cannot be established, nothing is guessed at.** A collection whose app has no `vendo_apps` row, or whose app row carries an empty subject, is REPORTED in `orphanCollections` and left completely untouched. This function issues no `DELETE` anywhere, and a blob key collision throws rather than inventing a resolution.

## `lifecycle.promote` moves the whole app, in one transaction

Three additions inside the existing single `db.transaction`, all on the transaction-scoped handle:

1. the app's appData is backfilled **before** the row flip — the stamp it writes is still the old subject, which leaves no legacy-vs-stamped ambiguity in the table;
2. every row and file then changes hands in one uniform `from → org` rename;
3. the app's bearer token's `refs.subject` follows.

**Both halves are required.** Rows alone would leave a promoted app's box writes stamping the departed personal subject, and the org blind to its own new data.

## Tests

Nine cases, **both engines** (PGlite and real Postgres), no mocks and no stubs on either side:

1. personal-app rows stamped, visible through the real `appData.list`
2. promoted-app rows stamped with the **org**, invisible to the old subject
3. idempotent re-run, every row's `data`/`revision`/`updated_at` byte-identical
4. orphan collection reported and untouched
5. blob keys re-keyed exactly once; second run moves 0; read back through `getFile`/`listFiles`
6. `{ appId }` scope touches only that app
7. `reownAppData` round trip (this is what caught a `substring(text from PATTERN)` overload bug that set every key to NULL)
8. promote hands rows **and** files to the org — stamped row, legacy row and file all arrive; the old subject keeps nothing
9. promote moves the app token — a real **seam**: the producer is store's own `lifecycle.promote`, the consumer is apps' `createAppTokens().verify`

**Prove-it-can-fail:** with the unstamped-only guard removed from `stampRows`, `re-runs to a no-op, leaving every row's content byte-identical` goes red on both engines (`expected { rowsStamped: 3 } to deeply equal { rowsStamped: 0 }`). Restored, green.

No schema change. `StoreAdapter` — the BYO seam — is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one-shot appData backfill and updates `lifecycle.promote` to move rows, files, and the app token in one transaction. This prevents appData from going invisible when an app moves from a user to an org.

- **New Features**
  - `backfillAppDataStamps(store, { batch?, appId? })` stamps `refs.subject` on unstamped rows and moves files under `<owner>/`. Reports `{ apps, rowsStamped, rowsSkipped, filesMoved, orphanCollections }`. Leaves `data`, `revision`, and `updated_at` unchanged. Safe to re-run. Subjects that are missing, empty, or contain `/` are reported as orphans and left untouched. Blob key collisions throw.
  - `lifecycle.promote` now backfills before the flip, reowns rows and files (`from → org`), and updates the app token’s subject. All in one transaction.
  - Exported `backfillAppDataStamps` and `AppDataBackfillReport` from `@vendoai/store` and the Postgres entry.

- **Migration**
  - Run `backfillAppDataStamps` once before promoting apps or enabling owner-scoped reads in production.
  - Use `{ appId }` to scope to a single app and `batch` to tune load.
  - Orphans are reported in `orphanCollections` (no app row, empty subject, or subject with `/`); nothing is deleted or guessed.

<sup>Written for commit 53912f6cb5b63c3fd95eb27f91ac52eb30a9a63e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

