### PR TITLE
fix(store): appData's owner boundary — a crafted subject, and a race that overwrote a foreign row

### DIFF
--- a/.changeset/app-data-owner-is-fenced.md
+++ b/.changeset/app-data-owner-is-fenced.md
@@ -1,0 +1,22 @@
+---
+"@vendoai/core": patch
+"@vendoai/store": patch
+---
+
+`appData` fences the owner, so a path-like subject can no longer read another
+user's files.
+
+The owner is the first path segment of every appData file key (`<owner>/<key>`),
+and nothing checked it. `appId` was fenced against `":"` and `collection`
+against `APP_DATA_COLLECTION_PATTERN`; the owner went in raw. So owner
+`own_a/sub` reading `x.bin` read owner `own_a`'s file `sub/x.bin` — a silent
+cross-user read for any host whose subject ids contain a slash, which
+`org/user`, an email-derived id, or a URI-style OIDC subject all can.
+
+`APP_DATA_OWNER_PATTERN` (`/^[^/]+$/`) is now enforced at the wire schema and at
+the store composer, on every one of the eight verbs, with the `validation` code.
+Deliberately **not** a slug grammar: a subject is the host's own user id in the
+host's own spelling, so `auth0|64f…`, `user:with:colons` and
+`person@example.com` all still pass. Only `/` is refused — and it is refused,
+never rewritten, because a sanitised owner would land two different people in
+one drawer.

--- a/.changeset/app-data-put-is-one-statement.md
+++ b/.changeset/app-data-put-is-one-statement.md
@@ -1,0 +1,24 @@
+---
+"@vendoai/store": patch
+---
+
+`appData.put` decides the owner conflict in ONE statement, so an absent-row race
+can no longer destroy a foreign owner's data.
+
+`put` read then wrote: `insertIfAbsent`, then `SELECT … FOR UPDATE`, then an
+unconditional upsert. `FOR UPDATE` locks **nothing** when it returns no row, so
+a holder who deleted the id after the insert lost and before the select ran left
+the composer looking at an absent row — and the upsert then overwrote and
+re-stamped whichever owner had taken the id in the meantime, silently destroying
+a row that owner could still neither read nor delete. The existing `conflict`
+refusal closed the common case and not this one.
+
+The put is now a single owner-predicated upsert: `ON CONFLICT … DO UPDATE …
+WHERE refs @> <owner stamp>`, which takes the conflicting row's lock before it
+evaluates its predicate, so a foreign holder makes the statement touch no rows
+and the caller gets `conflict`. Absent, or already ours, still succeeds. No
+application-level locking, no widened transaction, no schema change.
+
+Proven on real Postgres with a second connection churning the id at the
+composer's statement boundaries (`packages/store/tests/app-data-put-race.test.ts`);
+PGlite is single-connection and cannot express the interleave.

--- a/packages/core/src/conformance/memory-store-ops.ts
+++ b/packages/core/src/conformance/memory-store-ops.ts
@@ -3,6 +3,7 @@ import type { IsoDateTime } from "../ids.js";
 import { VENDO_STORE_WIRE_FORMAT, type StoreWireStatus } from "../store-wire.js";
 import {
   APP_DATA_COLLECTION_PATTERN,
+  APP_DATA_OWNER_PATTERN,
   type AppDataTarget,
   type RecordInput,
   type RecordQuery,
@@ -204,10 +205,20 @@ export function memoryStoreOps(): StoreOps {
   // appData family
   // ---------------------------------------------------------------------------
 
+  /** The owner leg is fenced for the reason `ownedKey` shows: it is the first
+      path segment of every file key, so owner "a/b" and owner "a" writing
+      "b/…" would be one and the same key. */
+  const appOwner = (target: AppDataTarget): string => {
+    if (!APP_DATA_OWNER_PATTERN.test(target.owner)) {
+      throw new VendoError("validation", `app data owner "${target.owner}" must be non-empty and free of "/"`);
+    }
+    return target.owner;
+  };
+
   /** The reference's own copy of the naming grammar — rows land in one
       collection per app+collection, files in the blob namespace of the same
       name. The real backend composes both in one place, which core cannot
-      import. */
+      import. Every verb goes through here, so the owner fence rides along. */
   const appCollection = (target: AppDataTarget): string => {
     if (target.appId === "" || target.appId.includes(":")) {
       throw new VendoError("validation", `app data appId "${target.appId}" must be non-empty and free of ":"`);
@@ -215,12 +226,13 @@ export function memoryStoreOps(): StoreOps {
     if (!APP_DATA_COLLECTION_PATTERN.test(target.collection)) {
       throw new VendoError("validation", `app data collection "${target.collection}" is not a legal name`);
     }
+    appOwner(target);
     return `app:${target.appId}:${target.collection}`;
   };
 
   /** Files are scoped by key prefix rather than by a stamp, so the owner leg
       never reaches the caller — `listFiles` strips it back off. */
-  const ownedKey = (target: AppDataTarget, key: string): string => `${target.owner}/${key}`;
+  const ownedKey = (target: AppDataTarget, key: string): string => `${appOwner(target)}/${key}`;
 
   const refuseSubject = (refs: Record<string, string> | undefined, verb: string): void => {
     if (refs !== undefined && "subject" in refs) {

--- a/packages/core/src/conformance/store-ops.ts
+++ b/packages/core/src/conformance/store-ops.ts
@@ -339,12 +339,18 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         );
       }),
 
+      /** Both halves, deliberately — the same trap `delete` below calls out: a
+          `get` that returns null for EVERYONE also passes the negative
+          assertion on its own, so the owner's own read is asserted too. */
       opsCase(opts, "appData.get returns null for another owner's row", async (ops) => {
         await seedApp(ops, "app_getscope");
         const owner = { appId: "app_getscope", collection: "notes", owner: "own_a" };
         const other = { appId: "app_getscope", collection: "notes", owner: "own_b" };
         await ops.appData.put(owner, { id: "secret", data: { v: 1 } });
         assert(await ops.appData.get(other, "secret") === null, "get read another owner's row");
+        const mine = await ops.appData.get(owner, "secret");
+        assert(mine !== null, "get returned null for the owner's own row");
+        assertDeepEqual(mine!.data, { v: 1 }, "get returned the wrong row for its owner");
       }),
 
       /** Both halves, deliberately: a `delete` that does nothing at all also

--- a/packages/core/src/conformance/store-ops.ts
+++ b/packages/core/src/conformance/store-ops.ts
@@ -437,6 +437,56 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         );
       }),
 
+      /** The owner is the FIRST PATH SEGMENT of every appData file key
+          (`<owner>/<key>`), so an owner holding "/" is not a name, it is a
+          second key segment: owner "own_a/sub" reading "x.bin" reads owner
+          "own_a"'s "sub/x.bin". Hosts pick their own subject spelling and
+          path-like ones are ordinary, so the fence is the grammar and the
+          answer is a refusal — a sanitised owner would land two people in one
+          drawer. Every verb, because every verb composes the key. */
+      opsCase(opts, "appData refuses an owner outside the grammar", async (ops) => {
+        await seedApp(ops, "app_owner");
+        const owner = { appId: "app_owner", collection: "notes", owner: "own_a" };
+        await ops.appData.put(owner, { id: "n1", data: { v: 1 } });
+        await ops.appData.putFile(owner, "sub/x.bin", new Uint8Array([9]));
+
+        const crafted = { appId: "app_owner", collection: "notes", owner: "own_a/sub" };
+        const verbs: [string, () => Promise<unknown>][] = [
+          ["put", () => ops.appData.put(crafted, { id: "n2", data: {} })],
+          ["get", () => ops.appData.get(crafted, "n1")],
+          ["list", () => ops.appData.list(crafted)],
+          ["delete", () => ops.appData.delete(crafted, "n1")],
+          ["putFile", () => ops.appData.putFile(crafted, "y.bin", new Uint8Array([1]))],
+          ["getFile", () => ops.appData.getFile(crafted, "x.bin")],
+          ["listFiles", () => ops.appData.listFiles(crafted)],
+          ["deleteFile", () => ops.appData.deleteFile(crafted, "x.bin")],
+        ];
+        for (const [verb, run] of verbs) {
+          await assertThrowsCode(run, "validation", `appData.${verb} with an owner containing "/"`);
+        }
+        // A refusal, not a no-op that quietly worked on the foreign drawer.
+        assert(
+          await ops.appData.getFile(owner, "sub/x.bin") !== null,
+          "a crafted owner reached the real owner's file",
+        );
+        await assertThrowsCode(
+          () => ops.appData.get({ ...owner, owner: "" }, "n1"),
+          "validation",
+          "an empty appData owner",
+        );
+
+        // NOT a slug grammar: a subject is the host's own user id in the host's
+        // own spelling, and "auth0|…" and "user:with:colons" are contract
+        // elsewhere in this repo. Only "/" is refused.
+        for (const [index, exotic] of ["auth0|64f0", "user:with:colons", "person@example.com"].entries()) {
+          const target = { appId: "app_owner", collection: "notes", owner: exotic };
+          const put = await ops.appData.put(target, { id: `ok_${index}`, data: { who: exotic } });
+          assert(put.refs?.["subject"] === exotic, `the owner ${exotic} was not stamped`);
+          await ops.appData.putFile(target, "f.bin", new Uint8Array([2]));
+          assertDeepEqual(await ops.appData.listFiles(target), ["f.bin"], `listFiles broke for owner ${exotic}`);
+        }
+      }),
+
       opsCase(opts, "appData refuses a collection name outside the grammar", async (ops) => {
         await seedApp(ops, "app_grammar");
         const legal = { appId: "app_grammar", collection: "box:inbox", owner: "own_a" };

--- a/packages/core/src/store-wire.ts
+++ b/packages/core/src/store-wire.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { VendoError, safeErrorMessage, vendoErrorCodeSchema, type VendoErrorCode } from "./errors.js";
 import {
   APP_DATA_COLLECTION_PATTERN,
+  APP_DATA_OWNER_PATTERN,
   recordQuerySchema,
 } from "./store.js";
 
@@ -152,11 +153,13 @@ export const storeWireBlobsListRequestSchema = z.object({
 // ---------------------------------------------------------------------------
 
 /** The owner on the target is the runtime's stamp from the host's login
-    session, never something generated code names. */
+    session, never something generated code names. Fenced by
+    `APP_DATA_OWNER_PATTERN` because it is the first path segment of every
+    appData file key, so a "/" in it crosses into another owner's drawer. */
 export const appDataTargetSchema = z.object({
   appId: z.string().min(1),
   collection: z.string().regex(APP_DATA_COLLECTION_PATTERN),
-  owner: z.string().min(1),
+  owner: z.string().regex(APP_DATA_OWNER_PATTERN),
 }).passthrough();
 
 export const storeWireAppDataPutRequestSchema = z.object({

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -99,12 +99,24 @@ import type { StoreWireStatus } from "./store-wire.js";
     a short slug, optionally `box:`-prefixed. */
 export const APP_DATA_COLLECTION_PATTERN = /^(box:)?[A-Za-z0-9_-]{1,64}$/;
 
+/** The grammar an appData owner must satisfy: non-empty and free of "/".
+    Deliberately NOT a slug — a subject is the host's own user id in the host's
+    own spelling, and `auth0|64f…`, `user:with:colons` and
+    `https://idp.example/u/1` are all contract elsewhere in this repo. "/" is
+    the one character that cannot be allowed here, because appData files carry
+    their owner as the first path segment of the blob key (`<owner>/<key>`):
+    owner `a/b` and owner `a` writing `b/…` are the same key, so a "/" in an
+    owner is a silent cross-user file read. Refused, never rewritten — a
+    sanitised owner would map two people onto one drawer. */
+export const APP_DATA_OWNER_PATTERN = /^[^/]+$/;
+
 /** Where one appData op lands. */
 export interface AppDataTarget {
   appId: string;
   collection: string;
   /** Stamped by the RUNTIME from the host's login session — generated code has
-      no field for it, and a caller that supplies `refs.subject` is refused. */
+      no field for it, and a caller that supplies `refs.subject` is refused.
+      Must satisfy {@link APP_DATA_OWNER_PATTERN}. */
   owner: string;
 }
 

--- a/packages/core/tests/store-wire.test.ts
+++ b/packages/core/tests/store-wire.test.ts
@@ -149,6 +149,30 @@ describe("vendo/store-wire@1", () => {
     }).success).toBe(false);
   });
 
+  /** The owner is the first path segment of every appData file key, so a "/"
+      in it is a second key segment: owner "sub_1/scan" reading "png" is owner
+      "sub_1" reading "scan/png". Not a slug grammar though — a subject is the
+      host's own user id in the host's own spelling, and "auth0|…" and
+      "user:with:colons" are contract elsewhere in this repo. */
+  it("refuses an appData owner containing a slash, and keeps every other spelling", () => {
+    const target = { appId: "app_1", collection: "invoices", owner: "sub_1" };
+    for (const owner of ["sub_1/scan", "/sub_1", "sub_1/", "a/b/c"]) {
+      expect(
+        storeWireAppDataGetRequestSchema.safeParse({ target: { ...target, owner }, id: "inv1" }).success,
+        `owner ${JSON.stringify(owner)} should be refused`,
+      ).toBe(false);
+      expect(
+        storeWireAppDataPutFileRequestSchema.safeParse({ target: { ...target, owner }, key: "scan.png", bytes: btoa("x") }).success,
+        `owner ${JSON.stringify(owner)} should be refused on putFile`,
+      ).toBe(false);
+    }
+    for (const owner of ["auth0|64f0", "user:with:colons", "person@example.com", "own_a"]) {
+      expect(
+        storeWireAppDataGetRequestSchema.parse({ target: { ...target, owner }, id: "inv1" }).target.owner,
+      ).toBe(owner);
+    }
+  });
+
   it("parses transcripts request DTOs", () => {
     expect(storeWireTranscriptsPutThreadRequestSchema.parse({
       thread: { id: "t1", subject: "sub_user1", messages: [{ role: "user", content: "hi" }] },

--- a/packages/store/src/app-data-rows.ts
+++ b/packages/store/src/app-data-rows.ts
@@ -1,5 +1,6 @@
 import {
   APP_DATA_COLLECTION_PATTERN,
+  APP_DATA_OWNER_PATTERN,
   VendoError,
   type AppDataTarget,
   type BlobStore,
@@ -45,9 +46,21 @@ export function appDataNamespace(target: AppDataTarget): string {
   return appDataCollection(target);
 }
 
-/** Files carry no refs, so their owner rides the key instead of a stamp. */
+/** The owner leg of a target, checked. Every verb composes it, because an
+ *  owner outside the grammar is refused rather than repaired: rewriting one
+ *  would land two different people in one drawer. */
+export function appDataOwner(owner: string): string {
+  if (!APP_DATA_OWNER_PATTERN.test(owner)) {
+    invalid(`app data owner ${JSON.stringify(owner)} must be non-empty and free of "/"`);
+  }
+  return owner;
+}
+
+/** Files carry no refs, so their owner rides the key instead of a stamp — which
+ *  is exactly why {@link appDataOwner} exists: `<owner>/<key>` cannot tell
+ *  owner "a/b" apart from owner "a" writing "b/…". */
 export function appDataFileKey(owner: string, key: string): string {
-  return `${owner}/${key}`;
+  return `${appDataOwner(owner)}/${key}`;
 }
 
 /** A caller who supplies `refs.subject` is writing (or reading) as someone
@@ -75,7 +88,7 @@ export interface AppDataRows {
 export function appDataRows(db: Db, target: AppDataTarget): AppDataRows {
   const collection = appDataCollection(target);
   const records = createRecordStore(db, collection);
-  const stamp = { [APP_DATA_OWNER_REF]: target.owner };
+  const stamp = { [APP_DATA_OWNER_REF]: appDataOwner(target.owner) };
 
   return {
     /** An id another owner holds is a `conflict`, not an overwrite:
@@ -149,7 +162,8 @@ export function appDataRows(db: Db, target: AppDataTarget): AppDataRows {
  *  onto the owner leg before the query, not filtered after the strip. */
 export function appDataFiles(store: VendoStore, target: AppDataTarget): BlobStore {
   const blobs = store.blobs(appDataNamespace(target));
-  const owned = (key: string): string => appDataFileKey(target.owner, key);
+  const owner = appDataOwner(target.owner);
+  const owned = (key: string): string => appDataFileKey(owner, key);
 
   return {
     async put(key, bytes, meta) {
@@ -163,7 +177,7 @@ export function appDataFiles(store: VendoStore, target: AppDataTarget): BlobStor
     },
     async list(prefix = "") {
       const keys = await blobs.list(owned(prefix));
-      return keys.map((key) => key.slice(target.owner.length + 1));
+      return keys.map((key) => key.slice(owner.length + 1));
     },
   };
 }

--- a/packages/store/src/app-data-rows.ts
+++ b/packages/store/src/app-data-rows.ts
@@ -9,8 +9,8 @@ import {
   type VendoRecord,
 } from "@vendoai/core";
 import type { Db } from "./db.js";
-import { jsonParam } from "./helpers/utils.js";
-import { createRecordStore } from "./records.js";
+import { jsonParam, requireKnownApp } from "./helpers/utils.js";
+import { createRecordStore, recordFromRow } from "./records.js";
 import type { VendoStore } from "./store.js";
 import { invalid } from "./validate.js";
 
@@ -93,37 +93,54 @@ export function appDataRows(db: Db, target: AppDataTarget): AppDataRows {
   return {
     /** An id another owner holds is a `conflict`, not an overwrite:
      *  `records.put` is an unconditional upsert on (collection, id), so without
-     *  this a caller could destroy and re-stamp a row it can neither read nor
-     *  delete. The refusal never names the holder — it only says the id is
-     *  taken, which is all a caller who cannot see the row may learn.
+     *  a predicate a caller could destroy and re-stamp a row it can neither
+     *  read nor delete. The refusal never names the holder — it only says the
+     *  id is taken, which is all a caller who cannot see the row may learn.
      *
-     *  Race-free rather than check-then-write: the insert decides the create
-     *  atomically, and when it loses, `FOR UPDATE` locks the row that beat it,
-     *  so a concurrent writer blocks instead of interleaving. That lock lives
-     *  until COMMIT, so this needs a transaction-scoped handle (ops.ts hands
-     *  one in) — a bare `BEGIN` is READ COMMITTED, where an unlocked read would
-     *  see a snapshot the following write does not honor. */
+     *  ONE owner-predicated statement, like `delete` below, because a
+     *  read-then-write cannot express this: `SELECT … FOR UPDATE` locks NOTHING
+     *  when the row is absent, so a holder deleting the id while a third owner
+     *  recreates it leaves both racers seeing "absent" and both upserting, and
+     *  the loser's row is destroyed and re-stamped. Here the arbitration is the
+     *  database's — `ON CONFLICT … DO UPDATE` takes the conflicting row's lock
+     *  BEFORE it evaluates its `WHERE`, so a foreign holder makes the whole
+     *  statement touch no rows. The in-statement `vendo_apps` gate is the same
+     *  one `createRecordStore` carries on every row-creating write. */
     async put(record) {
       refuseCallerOwner(record.refs);
-      const stamped = { ...record, refs: { ...record.refs, ...stamp } };
-      const created = await records.atomic!.insertIfAbsent(stamped);
-      if (created !== null) return created;
-
-      const held = await db.query(
-        "SELECT refs FROM vendo_records WHERE collection = $1 AND id = $2 FOR UPDATE",
-        [collection, record.id],
+      // Pre-check for the clean unknown-app signal; the statement's own gate is
+      // the structural guarantee (a gate lost to a racing sweep writes nothing).
+      await requireKnownApp(db, target.appId);
+      const now = new Date().toISOString();
+      const result = await db.query(
+        `INSERT INTO vendo_records (collection, id, data, refs, created_at, updated_at, revision)
+         SELECT $1::text, $2::text, $3::jsonb, $4::jsonb, $5::timestamptz, $5::timestamptz, 1
+         WHERE EXISTS (SELECT 1 FROM vendo_apps WHERE id = $6)
+         ON CONFLICT (collection, id) DO UPDATE
+           SET data = EXCLUDED.data, refs = EXCLUDED.refs, updated_at = EXCLUDED.updated_at,
+               revision = vendo_records.revision + 1
+           WHERE vendo_records.refs @> $7::jsonb
+         RETURNING id, data, refs, created_at, updated_at, revision`,
+        [
+          collection,
+          record.id,
+          jsonParam(record.data),
+          jsonParam({ ...record.refs, ...stamp }),
+          now,
+          target.appId,
+          jsonParam(stamp),
+        ],
       );
-      const row = held.rows[0];
-      // No row means the holder deleted it while we looked; the upsert below
-      // recreates it as ours.
-      if (row !== undefined
-        && (row["refs"] as Record<string, string> | null)?.[APP_DATA_OWNER_REF] !== target.owner) {
-        throw new VendoError(
-          "conflict",
-          `app data id ${JSON.stringify(record.id)} is already held in this collection`,
-        );
-      }
-      return await records.put(stamped);
+      const row = result.rows[0];
+      if (row !== undefined) return recordFromRow(row);
+      // Nothing was written, so the outcome is already decided and this read
+      // only picks WHICH refusal to report: the app vanished under the
+      // pre-check, or the id belongs to someone else.
+      await requireKnownApp(db, target.appId);
+      throw new VendoError(
+        "conflict",
+        `app data id ${JSON.stringify(record.id)} is already held in this collection`,
+      );
     },
 
     async get(id) {

--- a/packages/store/src/records.ts
+++ b/packages/store/src/records.ts
@@ -27,7 +27,7 @@ export type DedicatedRecordTable =
   | "vendo_knowledge_docs"
   | "vendo_knowledge_chunks";
 
-function recordFromRow(row: Record<string, unknown>): VendoRecord {
+export function recordFromRow(row: Record<string, unknown>): VendoRecord {
   const refs = row["refs"] as Record<string, string> | null;
   const revision = row["revision"];
   if (revision !== undefined && !(typeof revision === "string" || typeof revision === "number" || typeof revision === "bigint")) {

--- a/packages/store/tests/app-data-put-race.test.ts
+++ b/packages/store/tests/app-data-put-race.test.ts
@@ -1,0 +1,110 @@
+import type { RecordInput } from "@vendoai/core";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { appDataRows } from "../src/app-data-rows.js";
+import { createDb, type Db, type Query } from "../src/db.js";
+import { createStore, type VendoStore } from "../src/index.js";
+
+/**
+ * The absent-row race on `appData.put`.
+ *
+ * `put` used to read then write: `insertIfAbsent`, then `SELECT … FOR UPDATE`,
+ * then an UNCONDITIONAL upsert. `FOR UPDATE` locks nothing when it returns no
+ * row, so a holder who deleted the id after the insert lost and before the
+ * select ran left the composer looking at an absent row — and the upsert then
+ * overwrote and re-stamped whichever owner had taken the id in the meantime,
+ * destroying data that owner could still neither read nor delete.
+ *
+ * PGlite cannot show this: it is single-connection and serializes
+ * transactions, so the interleave is unreachable there. Real Postgres only,
+ * which CI's store shards already set POSTGRES_URL for.
+ *
+ * The overlap is FORCED, not raced. The composer's own `Db` handle is paced,
+ * so a scripted holder churn runs on a SECOND real connection at each of the
+ * composer's statement boundaries: a fresh owner takes the id, deletes it, and
+ * another fresh owner takes it. Every step is a committed write from that
+ * other connection — nothing here is stubbed, and the assertion names no
+ * statement, only the invariant: a put that loses the id must refuse, and the
+ * owner who holds it must find their row exactly as they left it.
+ */
+const url = process.env["POSTGRES_URL"];
+if (!url) console.info("POSTGRES_URL not set — postgres leg skipped");
+
+const APP_ID = "app_put_race";
+const COLLECTION = "notes";
+const SCOPE = `app:${APP_ID}:${COLLECTION}`;
+const ID = "contested";
+
+/** The owners the churn hands the id to, and the data each one wrote. */
+const CHURN = { own_first: { who: "first" }, own_last: { who: "last" } };
+
+describe.runIf(url)("appData.put under a concurrent holder churn", () => {
+  let store: VendoStore;
+  let db: Db;
+  let churn: Client;
+
+  beforeAll(async () => {
+    store = createStore({ url });
+    await store.ensureSchema();
+    db = createDb({ url: url! });
+    churn = new Client({ connectionString: url });
+    await churn.connect();
+  });
+
+  afterAll(async () => {
+    if (churn) {
+      await churn.query("DELETE FROM vendo_records WHERE collection = $1", [SCOPE]);
+      await churn.query("DELETE FROM vendo_apps WHERE id = $1", [APP_ID]);
+      await churn.end();
+    }
+    if (db) await db.close();
+    if (store) await store.close();
+  });
+
+  /** One committed statement on the churn's own connection. */
+  const takeId = async (owner: keyof typeof CHURN): Promise<void> => {
+    await churn.query(
+      `INSERT INTO vendo_records (collection, id, data, refs, created_at, updated_at, revision)
+       VALUES ($1, $2, $3::jsonb, $4::jsonb, now(), now(), 1)`,
+      [SCOPE, ID, JSON.stringify(CHURN[owner]), JSON.stringify({ subject: owner })],
+    );
+  };
+  const dropId = async (): Promise<void> => {
+    await churn.query("DELETE FROM vendo_records WHERE collection = $1 AND id = $2", [SCOPE, ID]);
+  };
+
+  it("refuses, and leaves the owner who holds the id untouched", async () => {
+    await churn.query(
+      `INSERT INTO vendo_apps (id, subject, enabled, doc, created_at, updated_at)
+       VALUES ($1, $2, true, $3::jsonb, now(), now()) ON CONFLICT (id) DO NOTHING`,
+      [APP_ID, "user_1", JSON.stringify({ format: "vendo/app@1", id: APP_ID, name: APP_ID })],
+    );
+    await dropId();
+
+    // The churn script, one step per statement the composer aims at
+    // vendo_records: held by a foreigner, then gone, then held by another. The
+    // middle step is the one a read-then-write composer walks into.
+    const script = [() => takeId("own_first"), dropId, () => takeId("own_last")];
+    let step = 0;
+    const paced = (query: Query): Query => async (text, params) => {
+      if (text.includes("vendo_records") && step < script.length) await script[step++]!();
+      return await query(text, params);
+    };
+
+    const target = { appId: APP_ID, collection: COLLECTION, owner: "own_thief" };
+    const record: RecordInput = { id: ID, data: { who: "thief" } };
+    const put = db.transaction((query) => appDataRows({ ...db, query: paced(query) }, target).put(record));
+
+    await expect(put).rejects.toMatchObject({ code: "conflict" });
+    expect(step, "the churn never ran — the race was not forced").toBeGreaterThan(0);
+
+    const rows = (await churn.query(
+      "SELECT refs, data FROM vendo_records WHERE collection = $1 AND id = $2",
+      [SCOPE, ID],
+    )).rows as { refs: { subject: string }; data: unknown }[];
+    expect(rows).toHaveLength(1);
+    const holder = rows[0]!.refs.subject;
+    expect(holder, "the put re-stamped a row it had lost").not.toBe("own_thief");
+    expect(rows[0]!.data, "the put overwrote the holder's row").toEqual(CHURN[holder as keyof typeof CHURN]);
+  });
+});


### PR DESCRIPTION
Three defects in code that is **already merged to `main`** (#1155, the `appData` family). Two are security defects found by an independent validation run against real PGlite; the third is a conformance case that cannot fail. One commit each.

## 1 — `owner` was never validated, so a crafted subject read another owner's files

`appDataCollection` fenced `appId` against `":"` and `APP_DATA_COLLECTION_PATTERN` fenced `collection`. **Nothing fenced `owner`** — and `owner` is the first path segment of every appData file key (`appDataFileKey` = `${owner}/${key}`). So owner `own_a/sub` reading `x.bin` read owner `own_a`'s file `sub/x.bin`. The wire permitted it: `owner: z.string().min(1)`.

**What it allowed:** silent cross-user file reads for any host whose subject ids contain a slash — `org/user`, an email-derived id, a URI-style OIDC subject. Hosts choose their own subject spelling; `resolveSession` takes the JWT `sub` claim verbatim after a length check only (`packages/vendo/src/auth-presets/identity.ts:203`).

`APP_DATA_OWNER_PATTERN` (`/^[^/]+$/`) is now enforced at the wire schema and at the store composer, on all eight verbs, with the `validation` code. Refused, never rewritten — a sanitised owner would land two people in one drawer.

**Deliberately not a slug grammar.** Three committed contracts say a subject may hold `:`, `|`, and `/`-ish spellings: `packages/core/tests/app-access.test.ts:81-89` (`https://idp.example/u/1`, `auth0|…`), `packages/store/tests/state-routing.test.ts:62-70` (`user:with:colons`), and `docs-site/deploy/principals-and-orgs.mdx:50`, which tells hosts to prefix their subjects with `user:`. `/` is the only character that actually breaks anything, so it is the only one refused; `auth0|64f0`, `user:with:colons` and `person@example.com` are asserted to still work.

## 2 — the absent-row race overwrote a foreign owner's row (Greptile P1)

`put` read then wrote: `insertIfAbsent`, then `SELECT … FOR UPDATE`, then an unconditional upsert. **`FOR UPDATE` on zero rows locks nothing**, so a holder who deleted the id after the insert lost and before the select ran left the composer looking at an absent row — and the upsert then overwrote and re-stamped whichever owner had taken the id meanwhile.

**What it allowed:** silent destruction of another owner's row, re-stamped to the racer, with the victim left holding a row they could neither read nor delete. The existing `conflict` refusal closed the common case and not this one.

`put` is now ONE owner-predicated upsert — `ON CONFLICT … DO UPDATE … WHERE refs @> <owner stamp>` — which takes the conflicting row's lock *before* it evaluates the predicate, so a foreign holder makes the statement touch no rows and the caller gets `conflict`. No application-level locking, no widened transaction, no schema change.

## 3 — a conformance case that could not fail

`appData.get returns null for another owner's row` asserted only the negative, so an implementation whose `get` returns `null` for everyone passed it. Proven: stub the memory reference's `appData.get` to `return null` and five cases go red while this one stays **green**. The suite author identified exactly this trap for `delete` (the comment right below it) and did not carry it across to `get`. The owner's own read is now asserted too. Test-only commit, no production code.

Audited the siblings: `records.get missing returns null`, `records.delete makes get return null`, `records.delete missing resolves`, `blobs.get missing returns null`, `blobs.delete removes a blob`, `harness.get missing returns null` and `harness.clear removes state` are also negative-only, but each has a positive round-trip case in the same family that a uniformly-broken read fails, so none of them is unfailable at suite level. Left alone.

## Verification

Every fix was reverted and watched go red, then restored:

| fix | red case |
|---|---|
| 1 | `store-wire > refuses an appData owner containing a slash, and keeps every other spelling`; `memory reference > appData refuses an owner outside the grammar`; `pglite StoreOps conformance (local backend) > appData refuses an owner outside the grammar` — *"appData.put with an owner containing "/" did not throw"* |
| 2 | `appData.put under a concurrent holder churn > refuses, and leaves the owner who holds the id untouched` — the pre-fix put **resolved**, and the row came back `refs.subject: "own_thief"`, `data: {who:"thief"}`, i.e. `own_last`'s row destroyed and re-stamped |
| 3 | `memory reference > appData.get returns null for another owner's row`, with `appData.get` stubbed to return `null` — and the pre-fix case stayed green under the same stub |

The race test needs real Postgres with concurrent connections (PGlite is single-connection and cannot express the interleave). It **ran locally against a real `postgres:16`**, both red pre-fix and green post-fix. In CI it runs on the `store-*` shards, which set `POSTGRES_URL` at job level against a `postgres:16` service (`.github/workflows/ci.yml:64-97`).

`pnpm build`, `pnpm typecheck`, `pnpm lint` green; `pnpm test:affected` green apart from the two standing local-only failures (`@vendoai/genbench`'s missing chrome-headless-shell and `@vendoai/ui`'s `test:ui` Playwright task), which fail identically on clean `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two security issues in `appData`: fences the owner to stop cross-owner file access, and makes `appData.put` race-safe so it can’t overwrite another owner’s row. Also tightens a conformance test to catch broken `get` implementations.

- **Bug Fixes**
  - Enforced `APP_DATA_OWNER_PATTERN` (no “/”) for `owner` in `@vendoai/core` wire schema and `@vendoai/store` composer across all `appData` verbs. Prevents crafted owners like `a/b` from reading `a`’s files; non-slug subjects (e.g. `auth0|…`, `user:with:colons`, emails) still allowed.
  - Rewrote `appData.put` as a single owner-predicated upsert: `ON CONFLICT … DO UPDATE … WHERE refs @> <owner stamp>`. Returns `conflict` when another owner holds the id, blocking the absent-row race. No schema changes or app-level locking; verified on real Postgres with a new race test.
  - Updated conformance: `appData.get returns null for another owner's row` now also asserts the owner’s own read, closing a false-green gap.

<sup>Written for commit 04fb2d9a2fdcbcb31be0f3cb3c5f8b371d62b957. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

