### PR TITLE
feat(store): engine — the op family for Vendo's own drawers, behind an allowlist

### DIFF
--- a/.changeset/store-engine-family.md
+++ b/.changeset/store-engine-family.md
@@ -1,0 +1,46 @@
+---
+"@vendoai/core": minor
+"@vendoai/store": minor
+"@vendoai/vendo": minor
+---
+
+`engine` — the store family for Vendo's own drawers, behind an allowlist.
+
+The `StoreOps` contract grows from 35 ops across 8 families to 42 across 9. The
+new family is `engine`, and it is today's `records.*` family verb for verb —
+`get`, `put`, `delete`, `list`, `claim`, `insertIfAbsent`, `compareAndSwap`, same
+arguments, same returns, same routed doors — with one thing added in front of
+every verb: `assertEngineCollection(collection)`.
+
+**The point is the name and the gate, not new semantics.** Grants, approvals, the
+audit log, threads, runs, apps, effects, the automations schedules and deliveries,
+the guard's freeze switch — Vendo's own bookkeeping — all reached the store
+through the same generic `records.*` door a host uses for its own data. Nothing
+said which collections were Vendo's, so nothing could refuse a call that reached
+for one. `engine` says it, and refuses everything else with `blocked`.
+
+`ENGINE_COLLECTIONS` (`@vendoai/core`) is that list: 35 static names — the nine
+reserved collections, the four dedicated tables, and the 22 the blocks own on the
+generic table — plus exactly one dynamic pattern, `vendo:app-history:<id>`, built
+by `engineAppHistory(appId)`. It lives in core rather than `@vendoai/store`
+because `guard`, `automations` and `apps` all need to name their own collections
+and none of them may import the store; `@vendoai/store` is what *enforces* it. A
+refused name is told the allowlist version, the nearest allowed name when it
+looks like a typo, and where its data actually belongs — app data belongs to
+`appData`.
+
+**Per-collection policy did not move.** `engine` reaches the same
+`createReservedRecordStore` doors, so the audit log is still append-only through
+it, the effect ledger is still insert-once, and a collection with no atomic
+support still answers `not-implemented`. Two conformance cases pin exactly that,
+because a second door onto the same rows is the natural place for policy to
+quietly stop applying.
+
+Seven wire paths under `/engine/*` join `vendo/store-wire@1`, served by the local
+Postgres backend, the Cloud client and the in-core memory reference, with seven
+conformance cases run by all three. The seven collection-addressed request
+schemas are renamed `storeWireCollection*RequestSchema` — one body shape now
+serves both `/records/*` and `/engine/*` — and the old `storeWireRecords*` names
+stay exported as deprecated aliases.
+
+`records.*`, `StoreAdapter` and every existing call site are untouched.

--- a/packages/core/src/conformance/memory-store-ops.ts
+++ b/packages/core/src/conformance/memory-store-ops.ts
@@ -1,3 +1,4 @@
+import { assertEngineCollection } from "../engine-collections.js";
 import { VendoError } from "../errors.js";
 import type { IsoDateTime } from "../ids.js";
 import { VENDO_STORE_WIRE_FORMAT, type StoreWireStatus } from "../store-wire.js";
@@ -173,6 +174,60 @@ export function memoryStoreOps(): StoreOps {
       const prev = col(collection).get(record.id);
       if (!prev || prev.revision !== expectedRevision) return null;
       return putRecord(collection, record);
+    },
+  };
+
+  // ---------------------------------------------------------------------------
+  // engine family — `records`, behind the allowlist gate
+  // ---------------------------------------------------------------------------
+
+  /** MIRRORS the per-collection policy the real backend enforces in its typed
+      doors (packages/store/src/routing.ts), which the generic records table has
+      no idea about. Only the policy the conformance suite pins lives here — the
+      reference exists to prove the contract, not to re-implement routing. */
+  const APPEND_ONLY = new Set(["vendo_audit", "vendo_effects"]);
+  const INSERT_ONCE = new Set(["vendo_effects"]);
+
+  const engine: StoreOps["engine"] = {
+    async get(collection, id) {
+      assertEngineCollection(collection);
+      return records.get(collection, id);
+    },
+    async put(collection, record) {
+      assertEngineCollection(collection);
+      if (INSERT_ONCE.has(collection)) {
+        // A receipt that already exists is the truth about what executed, so a
+        // second put hands back the RECORDED row rather than overwriting it.
+        const held = await records.get(collection, record.id);
+        if (held) return held;
+      }
+      return records.put(collection, record);
+    },
+    async delete(collection, id) {
+      assertEngineCollection(collection);
+      if (APPEND_ONLY.has(collection)) {
+        throw new VendoError(
+          "blocked",
+          `${collection} is append-only; rows are erased only via the store erase API (02-store §5)`,
+        );
+      }
+      await records.delete(collection, id);
+    },
+    async list(collection, query) {
+      assertEngineCollection(collection);
+      return records.list(collection, query);
+    },
+    async claim(collection, expected, replacement) {
+      assertEngineCollection(collection);
+      return records.claim(collection, expected, replacement);
+    },
+    async insertIfAbsent(collection, record) {
+      assertEngineCollection(collection);
+      return records.insertIfAbsent(collection, record);
+    },
+    async compareAndSwap(collection, record, expectedRevision) {
+      assertEngineCollection(collection);
+      return records.compareAndSwap(collection, record, expectedRevision);
     },
   };
 
@@ -540,6 +595,7 @@ export function memoryStoreOps(): StoreOps {
 
   return {
     records,
+    engine,
     blobs,
     appData,
     transcripts,
@@ -547,7 +603,7 @@ export function memoryStoreOps(): StoreOps {
     workspace,
     lifecycle,
     async status(): Promise<StoreWireStatus> {
-      return { format: VENDO_STORE_WIRE_FORMAT, ops: 35 };
+      return { format: VENDO_STORE_WIRE_FORMAT, ops: 42 };
     },
   };
 }

--- a/packages/core/src/conformance/store-ops.ts
+++ b/packages/core/src/conformance/store-ops.ts
@@ -1,3 +1,4 @@
+import { ENGINE_ALLOWLIST_VERSION, engineAppHistory } from "../engine-collections.js";
 import type { VendoErrorCode } from "../errors.js";
 import { isoDateTimeSchema } from "../ids.js";
 import { VENDO_STORE_WIRE_FORMAT } from "../store-wire.js";
@@ -73,7 +74,7 @@ const numberField = (entry: unknown, field: string, message: string): number => 
 
 /** A thread's harness state rides the harness slot under this synthetic appId
     (the store's `harnessStateKey`), which is what makes deleteThread's cascade
-    onto harness state observable through the 35 ops. */
+    onto harness state observable through the 42 ops. */
 const harnessSlot = (threadId: string): string => `harness_state:${threadId}`;
 
 /** appData rows live in the app's own drawer, and the local backend fails an
@@ -245,6 +246,140 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         assertDeepEqual(swapped!.data, { v: 2 }, "compareAndSwap did not update data");
         const stale = await ops.records.compareAndSwap("conf_cas", { id: "cas1", data: { v: 3 } }, created.revision!);
         assert(stale === null, "compareAndSwap should return null on stale revision");
+      }),
+
+      // =====================================================================
+      // engine
+      // =====================================================================
+
+      opsCase(opts, "engine round-trips a record on an engine collection", async (ops) => {
+        const put = await ops.engine.put("vendo_workspace_commits", { id: "wc_1", data: { v: 1 }, refs: { subject: "user_1" } });
+        const got = await ops.engine.get("vendo_workspace_commits", "wc_1");
+        assertDeepEqual(got, put, "engine.get did not round-trip the stored record");
+        const listed = await ops.engine.list("vendo_workspace_commits", { ids: ["wc_1"] });
+        assertDeepEqual(listed.records.map((r) => r.id), ["wc_1"], "engine.list did not find the record it just stored");
+        await ops.engine.delete("vendo_workspace_commits", "wc_1");
+        assert(await ops.engine.get("vendo_workspace_commits", "wc_1") === null, "the deleted record remained readable");
+      }),
+
+      /** The deliveries dedupe the ingestion surface depends on
+          (packages/automations/src/ingestion-surface.ts): a redelivered webhook
+          must lose, and lose without touching what the first one recorded. */
+      opsCase(opts, "engine.insertIfAbsent returns record on first call, null on second", async (ops) => {
+        const first = await ops.engine.insertIfAbsent("automations:deliveries", { id: "dlv_1", data: { n: 1 } });
+        assert(first !== null, "engine.insertIfAbsent first call should return a record");
+        assert(first!.id === "dlv_1", "engine.insertIfAbsent did not echo id");
+        const second = await ops.engine.insertIfAbsent("automations:deliveries", { id: "dlv_1", data: { n: 2 } });
+        assert(second === null, "engine.insertIfAbsent second call should return null");
+        const got = await ops.engine.get("automations:deliveries", "dlv_1");
+        assertDeepEqual(got?.data, { n: 1 }, "engine.insertIfAbsent overwrote the recorded delivery");
+      }),
+
+      /** The schedule cursor claim: a runner holding a revision the schedule has
+          moved past may not write its stale cursor back over the live one. */
+      opsCase(opts, "engine.compareAndSwap succeeds on matching revision, null on stale", async (ops) => {
+        const created = await ops.engine.put("automations:schedule", { id: "sch_1", data: { cursor: 1 } });
+        assert(created.revision, "engine.put must return a revision for CAS");
+        const swapped = await ops.engine.compareAndSwap("automations:schedule", { id: "sch_1", data: { cursor: 2 } }, created.revision!);
+        assert(swapped !== null, "engine.compareAndSwap should succeed on matching revision");
+        assertDeepEqual(swapped!.data, { cursor: 2 }, "engine.compareAndSwap did not update data");
+        const stale = await ops.engine.compareAndSwap("automations:schedule", { id: "sch_1", data: { cursor: 3 } }, created.revision!);
+        assert(stale === null, "engine.compareAndSwap should return null on stale revision");
+      }),
+
+      /** Sequential, not concurrent: two callers read the same slot and both try
+          to take it, and the loser must be told the row moved on rather than
+          stamping its own claim over the winner's. */
+      opsCase(opts, "engine.claim lets exactly one of two callers win", async (ops) => {
+        await ops.engine.put("vendo_placement_slots", { id: "slot_1", data: { holder: null }, refs: { o: "a" } });
+        const expected = { id: "slot_1", data: { holder: null }, refs: { o: "a" } };
+        const first = await ops.engine.claim("vendo_placement_slots", expected, { data: { holder: "run_1" }, refs: { o: "a" } });
+        assert(first === true, "the first claim on a matching row should win");
+        const second = await ops.engine.claim("vendo_placement_slots", expected, { data: { holder: "run_2" }, refs: { o: "a" } });
+        assert(second === false, "the second claim on the same stale expectation should lose");
+        const after = await ops.engine.get("vendo_placement_slots", "slot_1");
+        assertDeepEqual(after?.data, { holder: "run_1" }, "the winner's replacement did not land");
+      }),
+
+      opsCase(opts, "engine refuses a collection outside the allowlist on every verb", async (ops) => {
+        await assertThrowsCode(
+          () => ops.engine.put("host_invoices", { id: "inv_1", data: { total: 1 } }),
+          "blocked",
+          "a non-engine collection on engine.put",
+        );
+        // A read verb too: the gate is on every verb, not just the writes.
+        await assertThrowsCode(
+          () => ops.engine.get("host_invoices", "inv_1"),
+          "blocked",
+          "a non-engine collection on engine.get",
+        );
+
+        // "blocked" with no explanation reads as a bug in Vendo, so the refusal
+        // must name the allowlist version it judged against and the door the
+        // caller actually wanted.
+        const refusal = await ops.engine.get("host_invoices", "inv_1").then(() => null, (error: unknown) => error);
+        const message = String((refusal as { message?: unknown } | null)?.message ?? refusal);
+        assert(message.includes(`v${ENGINE_ALLOWLIST_VERSION}`), `the refusal should name the allowlist version, got ${message}`);
+        assert(message.includes("appData"), `the refusal should point at the appData family, got ${message}`);
+
+        // A gate that throws after writing is not a gate.
+        assert(await ops.records.get("host_invoices", "inv_1") === null, "the refused put wrote its row anyway");
+      }),
+
+      /** `engine` is a NEW door onto the same routed doors the local backend
+          already had, so it inherits their per-collection law. A door that
+          quietly bypassed it would make the audit log deletable and the effect
+          ledger re-writable — the two things neither is allowed to be. */
+      opsCase(opts, "engine does not bypass the routed doors' append-only and insert-once policy", async (ops) => {
+        // Shape-valid rows: both collections are TYPED doors in the real
+        // backend, which refuses malformed data as `validation` long before
+        // policy is reached.
+        const audit = {
+          id: "aud_engine_policy",
+          at: new Date().toISOString(),
+          kind: "tool-call",
+          principal: { kind: "user", subject: "user_1" },
+          venue: "chat",
+          presence: "present",
+        };
+        await ops.engine.put("vendo_audit", { id: audit.id, data: audit });
+        await assertThrowsCode(
+          () => ops.engine.delete("vendo_audit", audit.id),
+          "blocked",
+          "deleting an audit event through the engine door",
+        );
+        assert(await ops.engine.get("vendo_audit", audit.id) !== null, "the refused delete erased the audit event anyway");
+
+        const first = await ops.engine.put("vendo_effects", { id: "eff_engine_policy", data: { subject: "user_1", outcome: { sent: 1 } } });
+        assertDeepEqual((first.data as Record<string, unknown>)["outcome"], { sent: 1 }, "the first receipt did not record its outcome");
+        const second = await ops.engine.put("vendo_effects", { id: "eff_engine_policy", data: { subject: "user_1", outcome: { sent: 2 } } });
+        assertDeepEqual(
+          (second.data as Record<string, unknown>)["outcome"],
+          { sent: 1 },
+          "the second put overwrote a receipt instead of returning the recorded one",
+        );
+        const held = await ops.engine.get("vendo_effects", "eff_engine_policy");
+        assertDeepEqual(
+          (held?.data as Record<string, unknown> | undefined)?.["outcome"],
+          { sent: 1 },
+          "the effect ledger kept the second outcome",
+        );
+      }),
+
+      /** There is exactly ONE dynamic engine collection and ONE builder for it.
+          Pin intents are rows INSIDE the app-history collection, not a second
+          drawer — a second pattern is how an allowlist rots into a wildcard. */
+      opsCase(opts, "engine accepts the one dynamic app-history pattern and refuses an illegal app id", async (ops) => {
+        const collection = engineAppHistory("app_x");
+        const put = await ops.engine.put(collection, { id: "ver_1", data: { version: 1 } });
+        const got = await ops.engine.get(collection, "ver_1");
+        assertDeepEqual(got, put, "the composed app-history collection did not round-trip");
+
+        await assertThrowsCode(
+          async () => engineAppHistory(""),
+          "validation",
+          "an empty app id handed to the app-history builder",
+        );
       }),
 
       // =====================================================================
@@ -989,7 +1124,7 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         const status = await ops.status();
         assert(status.format === VENDO_STORE_WIRE_FORMAT, `status.format should be ${VENDO_STORE_WIRE_FORMAT}`);
         assert(typeof status.ops === "number", "status.ops should be a number");
-        assert(status.ops === 35, `status.ops should be 35, got ${status.ops}`);
+        assert(status.ops === 42, `status.ops should be 42, got ${status.ops}`);
       }),
     ],
   };

--- a/packages/core/src/engine-collections.ts
+++ b/packages/core/src/engine-collections.ts
@@ -1,0 +1,147 @@
+import { VendoError } from "./errors.js";
+
+/** Named in every refusal so a caller can tell "this name was never an engine
+    collection" from "this build's list is older than yours". Bump it whenever
+    ENGINE_COLLECTIONS or ENGINE_COLLECTION_PATTERNS changes. */
+export const ENGINE_ALLOWLIST_VERSION = 1;
+
+/** The collections the `engine` op family may touch: Vendo's OWN internal
+    drawers, nothing a host or a generated app owns. The list lives in core
+    because guard, automations and apps all need it and none of them may import
+    @vendoai/store (layering); core imports nothing, so it is a literal here and
+    a drift test in @vendoai/store holds it to the real constants. */
+export const ENGINE_COLLECTIONS = [
+  // Reserved, routed through typed doors — mirrors RESERVED_COLLECTIONS,
+  // packages/store/src/routing.ts:53-63.
+  "vendo_grants",
+  "vendo_approvals",
+  "vendo_audit",
+  "vendo_threads",
+  "vendo_runs",
+  "vendo_apps",
+  "vendo_state",
+  "vendo_effects",
+  "vendo_app_grants",
+
+  // Dedicated tables — mirrors DEDICATED_RECORD_COLLECTIONS,
+  // packages/store/src/routing.ts:65-70.
+  "vendo_mcp_clients",
+  "vendo_mcp_grants",
+  "vendo_knowledge_docs",
+  "vendo_knowledge_chunks",
+
+  // Generic-table collections the blocks own.
+  "vendo_parked_call", // PARKED_COLLECTION, packages/vendo/src/byo-approvals.ts:47
+  "vendo_parked_call_outcome", // OUTCOME_COLLECTION, packages/vendo/src/byo-approvals.ts:48
+  // The next two, and guard:controls below, write rows carrying NEITHER a
+  // subject ref NOR an app ref, and that is deliberate: they are HOST-LEVEL
+  // CONFIG — the host's component registry, the pinned-baseline seed, the
+  // guard's freeze switch — not any user's or any app's data, so the erase
+  // cascade correctly never sweeps them. Do not "fix" them by adding a ref.
+  "vendo_host_components", // HOST_COMPONENTS_COLLECTION, packages/vendo/src/cli/cloud/host-components.ts:34
+  "vendo_pin_baselines", // PIN_BASELINES_COLLECTION, packages/vendo/src/cli/cloud/seed-baselines.ts:26
+  "vendo_placements", // PLACEMENTS_COLLECTION, packages/apps/src/server/persistence/placements.ts:48
+  "vendo_placement_slots", // PLACEMENT_SLOTS_COLLECTION, packages/apps/src/server/persistence/placements.ts:54
+  "vendo_app_tokens", // APP_TOKEN_COLLECTION, packages/apps/src/server/persistence/app-token.ts:12
+  "vendo_parked_action", // COLLECTION, packages/apps/src/server/persistence/parked-action.ts:50
+  "vendo_egress_approval", // COLLECTION, packages/apps/src/server/escalation/egress-approval.ts:96
+  "vendo_inclient_approvals", // COLLECTION, packages/apps/src/server/remix/inclient.ts:76
+  "vendo_remix_rejections", // COLLECTION, packages/apps/src/server/remix/review.ts:65
+  "vendo_slots", // SLOTS_COLLECTION, packages/apps/src/server/persistence/slots.ts:24
+  "vendo_workspace_commits", // WORKSPACE_COMMITS, packages/store/src/ops.ts:27
+  "automations:captures", // CAPTURES, packages/automations/src/types.ts:29
+  "automations:armed", // ARMED, packages/automations/src/types.ts:43
+  "automations:schedule", // SCHEDULE, packages/automations/src/types.ts:30
+  "automations:webhook", // WEBHOOK, packages/automations/src/types.ts:31
+  "automations:deliveries", // DELIVERIES, packages/automations/src/types.ts:32
+  "automations:sponsorships", // SPONSORSHIPS, packages/automations/src/sponsorship.ts:17
+  "automations:sponsored", // SPONSORED, packages/automations/src/sponsorship.ts:29
+  "guard:controls", // CONTROLS_COLLECTION, packages/guard/src/guard.ts:117 — host-level config, see above
+  "guard:approval-claims", // APPROVAL_CLAIMS_COLLECTION, packages/guard/src/guard.ts:111
+] as const;
+
+export type EngineCollection = typeof ENGINE_COLLECTIONS[number];
+
+/** The id grammar the app-history pattern accepts. Shared by the builder so a
+    name that cannot pass the gate is never composed in the first place. */
+const APP_HISTORY_ID = /^[A-Za-z0-9_-]{1,128}$/;
+
+/** The ONE dynamic engine collection: the per-app capped version log and
+    pin-intent trail, assembled at
+    packages/apps/src/server/persistence/history.ts:84. Pin intents are rows
+    INSIDE this collection, not a second drawer — there is one builder and one
+    pattern, and a second of either is how an allowlist rots.
+    Throws `validation` on an id the pattern would not accept: an empty or
+    colon-bearing id composes a name that lands in some other app's drawer. */
+export function engineAppHistory(appId: string): string {
+  if (!APP_HISTORY_ID.test(appId)) {
+    throw new VendoError(
+      "validation",
+      `app id ${JSON.stringify(appId)} is not a legal engine app-history id (expected ${APP_HISTORY_ID.source})`,
+    );
+  }
+  return `vendo:app-history:${appId}`;
+}
+
+/** Anchored and length-bounded on purpose: an unanchored or unbounded id part
+    matches any string that merely CONTAINS the prefix, which turns the
+    allowlist into a wildcard and the gate into decoration. */
+export const ENGINE_COLLECTION_PATTERNS = [
+  /^vendo:app-history:[A-Za-z0-9_-]{1,128}$/,
+] as const;
+
+export function isEngineCollection(collection: string): boolean {
+  return (ENGINE_COLLECTIONS as readonly string[]).includes(collection)
+    || ENGINE_COLLECTION_PATTERNS.some((pattern) => pattern.test(collection));
+}
+
+/** Classic two-row Levenshtein — small enough that a dependency would cost more
+    than it saves, and it runs only on the refusal path. */
+function distance(a: string, b: string): number {
+  let previous = Array.from({ length: b.length + 1 }, (_, i) => i);
+  for (let i = 1; i <= a.length; i += 1) {
+    const current = [i];
+    for (let j = 1; j <= b.length; j += 1) {
+      current.push(Math.min(
+        (previous[j] ?? 0) + 1,
+        (current[j - 1] ?? 0) + 1,
+        (previous[j - 1] ?? 0) + (a[i - 1] === b[j - 1] ? 0 : 1),
+      ));
+    }
+    previous = current;
+  }
+  return previous[b.length] ?? 0;
+}
+
+/** Nearest allowed name, or undefined when nothing is close enough to be a
+    typo. The dynamic patterns are not searched — there is no fixed string to
+    suggest. The bound is tight on purpose: at a loose one every wrong name
+    collects a confident, unrelated suggestion ("users" → "vendo_runs" is only
+    seven edits apart), which reads as Vendo guessing rather than helping. */
+function nearest(collection: string): string | undefined {
+  let best: string | undefined;
+  let bestDistance = 4; // exclusive bound: suggest only within distance 3
+  for (const candidate of ENGINE_COLLECTIONS) {
+    const d = distance(collection, candidate);
+    if (d < bestDistance) {
+      best = candidate;
+      bestDistance = d;
+    }
+  }
+  return best;
+}
+
+/** The gate itself. Refusals point at the right door, because "blocked" with no
+    alternative reads as a bug in Vendo rather than a wrong call. */
+export function assertEngineCollection(collection: string): void {
+  if (isEngineCollection(collection)) return;
+  const suggestion = nearest(collection);
+  throw new VendoError(
+    "blocked",
+    `collection ${JSON.stringify(collection)} is not an engine collection `
+    + `(engine allowlist v${ENGINE_ALLOWLIST_VERSION})`
+    + (suggestion === undefined ? "." : ` — did you mean ${JSON.stringify(suggestion)}?`)
+    + " App data belongs to the appData family (ops.appData.*), which takes an"
+    + " { appId, collection, owner } target.",
+  );
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,6 +38,7 @@ export * from "./slot-limits.js";
 export * from "./sse-keepalive.js";
 export * from "./store.js";
 export * from "./store-wire.js";
+export * from "./engine-collections.js";
 export * from "./stream-parts.js";
 export * from "./tool-envelopes.js";
 export * from "./tools.js";

--- a/packages/core/src/store-wire.ts
+++ b/packages/core/src/store-wire.ts
@@ -24,6 +24,14 @@ export const STORE_WIRE_PATHS = {
   "records.claim": "/records/claim",
   "records.insertIfAbsent": "/records/insertIfAbsent",
   "records.compareAndSwap": "/records/compareAndSwap",
+  // engine (7)
+  "engine.get": "/engine/get",
+  "engine.put": "/engine/put",
+  "engine.delete": "/engine/delete",
+  "engine.list": "/engine/list",
+  "engine.claim": "/engine/claim",
+  "engine.insertIfAbsent": "/engine/insertIfAbsent",
+  "engine.compareAndSwap": "/engine/compareAndSwap",
   // blobs (4)
   "blobs.put": "/blobs/put",
   "blobs.get": "/blobs/get",
@@ -77,30 +85,35 @@ const cursorQuerySchema = z.object({
 }).passthrough();
 
 // ---------------------------------------------------------------------------
-// records
+// records + engine — one collection-addressed body shape serves both
+//
+// The two families take the same seven verbs over the same `collection` + args
+// bodies; only the allowlist behind the door differs (engine names are gated by
+// assertEngineCollection). So the bodies are named for their SHAPE, not for one
+// family — a second copy would only be a copy that could drift.
 // ---------------------------------------------------------------------------
 
-export const storeWireRecordsGetRequestSchema = z.object({
+export const storeWireCollectionGetRequestSchema = z.object({
   collection: z.string().min(1),
   id: z.string().min(1),
 }).passthrough();
 
-export const storeWireRecordsPutRequestSchema = z.object({
+export const storeWireCollectionPutRequestSchema = z.object({
   collection: z.string().min(1),
   record: recordInputSchema,
 }).passthrough();
 
-export const storeWireRecordsDeleteRequestSchema = z.object({
+export const storeWireCollectionDeleteRequestSchema = z.object({
   collection: z.string().min(1),
   id: z.string().min(1),
 }).passthrough();
 
-export const storeWireRecordsListRequestSchema = z.object({
+export const storeWireCollectionListRequestSchema = z.object({
   collection: z.string().min(1),
   query: recordQuerySchema.optional(),
 }).passthrough();
 
-export const storeWireRecordsClaimRequestSchema = z.object({
+export const storeWireCollectionClaimRequestSchema = z.object({
   collection: z.string().min(1),
   expected: recordInputSchema,
   replacement: z.object({
@@ -109,16 +122,33 @@ export const storeWireRecordsClaimRequestSchema = z.object({
   }).passthrough().optional(),
 }).passthrough();
 
-export const storeWireRecordsInsertIfAbsentRequestSchema = z.object({
+export const storeWireCollectionInsertIfAbsentRequestSchema = z.object({
   collection: z.string().min(1),
   record: recordInputSchema,
 }).passthrough();
 
-export const storeWireRecordsCompareAndSwapRequestSchema = z.object({
+export const storeWireCollectionCompareAndSwapRequestSchema = z.object({
   collection: z.string().min(1),
   record: recordInputSchema,
   expectedRevision: z.string().min(1),
 }).passthrough();
+
+/** @deprecated Renamed to storeWireCollection*RequestSchema — one
+    collection-addressed body shape now serves both /records/* and /engine/*.
+    Removed in a later slice; nothing new should import these. */
+export const storeWireRecordsGetRequestSchema = storeWireCollectionGetRequestSchema;
+/** @deprecated Use storeWireCollectionPutRequestSchema. */
+export const storeWireRecordsPutRequestSchema = storeWireCollectionPutRequestSchema;
+/** @deprecated Use storeWireCollectionDeleteRequestSchema. */
+export const storeWireRecordsDeleteRequestSchema = storeWireCollectionDeleteRequestSchema;
+/** @deprecated Use storeWireCollectionListRequestSchema. */
+export const storeWireRecordsListRequestSchema = storeWireCollectionListRequestSchema;
+/** @deprecated Use storeWireCollectionClaimRequestSchema. */
+export const storeWireRecordsClaimRequestSchema = storeWireCollectionClaimRequestSchema;
+/** @deprecated Use storeWireCollectionInsertIfAbsentRequestSchema. */
+export const storeWireRecordsInsertIfAbsentRequestSchema = storeWireCollectionInsertIfAbsentRequestSchema;
+/** @deprecated Use storeWireCollectionCompareAndSwapRequestSchema. */
+export const storeWireRecordsCompareAndSwapRequestSchema = storeWireCollectionCompareAndSwapRequestSchema;
 
 // ---------------------------------------------------------------------------
 // blobs

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -88,7 +88,7 @@ export interface StoreAdapter {
 }
 
 // ---------------------------------------------------------------------------
-// StoreOps — the named-operation contract for the 35-op / 8-family store.
+// StoreOps — the named-operation contract for the 42-op / 9-family store.
 // Both the local backend (store/ops.ts) and the cloud client
 // (hosted-store.ts) implement this interface.
 // ---------------------------------------------------------------------------
@@ -115,10 +115,24 @@ export type EraseTarget =
   | { subject: string; appId?: never }
   | { appId: string; subject?: never };
 
-/** The typed contract for all 35 store operations across 8 families.
+/** The typed contract for all 42 store operations across 9 families.
     Lean by design — this is the CONTRACT interface, not the implementation. */
 export interface StoreOps {
   records: {
+    get(collection: string, id: string): Promise<VendoRecord | null>;
+    put(collection: string, record: RecordInput): Promise<VendoRecord>;
+    delete(collection: string, id: string): Promise<void>;
+    list(collection: string, query?: RecordQuery): Promise<{ records: VendoRecord[]; cursor?: string }>;
+    claim(collection: string, expected: RecordInput, replacement?: Pick<VendoRecord, "data" | "refs">): Promise<boolean>;
+    insertIfAbsent(collection: string, record: RecordInput): Promise<VendoRecord | null>;
+    compareAndSwap(collection: string, record: RecordInput, expectedRevision: string): Promise<VendoRecord | null>;
+  };
+  /** Vendo's OWN engine data — grants, approvals, audit, threads, runs, apps,
+      effects, and the automations and guard drawers — reached through the same
+      seven verbs as `records`. `assertEngineCollection` (engine-collections.ts)
+      gates the collection name on every verb, so nothing outside the allowlist
+      passes. NOT a place for host or generated-app data: that is `appData`. */
+  engine: {
     get(collection: string, id: string): Promise<VendoRecord | null>;
     put(collection: string, record: RecordInput): Promise<VendoRecord>;
     delete(collection: string, id: string): Promise<void>;

--- a/packages/core/tests/engine-collections.test.ts
+++ b/packages/core/tests/engine-collections.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { VendoError } from "../src/errors.js";
+import {
+  ENGINE_ALLOWLIST_VERSION,
+  ENGINE_COLLECTIONS,
+  assertEngineCollection,
+  engineAppHistory,
+  isEngineCollection,
+} from "../src/engine-collections.js";
+
+function codeOf(run: () => unknown): string {
+  try {
+    run();
+  } catch (error) {
+    return (error as VendoError).code;
+  }
+  throw new Error("expected a throw");
+}
+
+function messageOf(run: () => unknown): string {
+  try {
+    run();
+  } catch (error) {
+    return (error as VendoError).message;
+  }
+  throw new Error("expected a throw");
+}
+
+describe("engine allowlist", () => {
+  it("holds 35 distinct static collections", () => {
+    expect(ENGINE_ALLOWLIST_VERSION).toBe(1);
+    expect(ENGINE_COLLECTIONS).toHaveLength(35);
+    expect(new Set(ENGINE_COLLECTIONS).size).toBe(35);
+  });
+
+  it("admits one name from each group and refuses host/app data", () => {
+    expect(isEngineCollection("vendo_audit")).toBe(true); // reserved
+    expect(isEngineCollection("vendo_mcp_clients")).toBe(true); // dedicated table
+    expect(isEngineCollection("guard:controls")).toBe(true); // generic table
+    expect(isEngineCollection("users")).toBe(false);
+    expect(isEngineCollection("app:app_1:notes")).toBe(false);
+    expect(isEngineCollection("")).toBe(false);
+  });
+
+  // vendo_secrets has zero `.records()` call sites — it is served only by the
+  // dedicated secretStore door (packages/store/src/secrets.ts), so the engine
+  // family must never reach it.
+  it("does not admit vendo_secrets", () => {
+    expect(isEngineCollection("vendo_secrets")).toBe(false);
+    expect(codeOf(() => assertEngineCollection("vendo_secrets"))).toBe("blocked");
+  });
+
+  it("composes an app-history name that passes the gate", () => {
+    expect(engineAppHistory("app_x")).toBe("vendo:app-history:app_x");
+    expect(isEngineCollection(engineAppHistory("app_x"))).toBe(true);
+  });
+
+  it("refuses app ids that would compose someone else's drawer", () => {
+    expect(codeOf(() => engineAppHistory(""))).toBe("validation");
+    expect(codeOf(() => engineAppHistory("a:b"))).toBe("validation");
+    expect(codeOf(() => engineAppHistory("a".repeat(129)))).toBe("validation");
+  });
+
+  it("passes allowed names through silently", () => {
+    expect(() => assertEngineCollection("vendo_grants")).not.toThrow();
+    expect(() => assertEngineCollection(engineAppHistory("app_1"))).not.toThrow();
+  });
+
+  it("refuses an unknown name, naming the version and the right door", () => {
+    expect(codeOf(() => assertEngineCollection("users"))).toBe("blocked");
+    const message = messageOf(() => assertEngineCollection("users"));
+    expect(message).toContain("v1");
+    expect(message).toContain("appData");
+    // "users" is not a typo of anything here, so it collects no guess.
+    expect(message).not.toContain("did you mean");
+  });
+
+  it("suggests the nearest allowed name on a typo", () => {
+    expect(messageOf(() => assertEngineCollection("vendo_audi"))).toContain("vendo_audit");
+  });
+
+  it("invents no suggestion for a name nothing is close to", () => {
+    const far = "z".repeat(32);
+    expect(codeOf(() => assertEngineCollection(far))).toBe("blocked");
+    expect(messageOf(() => assertEngineCollection(far))).not.toContain("did you mean");
+  });
+
+  it("refuses app-history names the pattern does not accept", () => {
+    expect(codeOf(() => assertEngineCollection("vendo:app-history:"))).toBe("blocked");
+    expect(codeOf(() => assertEngineCollection("vendo:app-history:a/b"))).toBe("blocked");
+  });
+});

--- a/packages/core/tests/store-wire.test.ts
+++ b/packages/core/tests/store-wire.test.ts
@@ -15,6 +15,13 @@ import {
   storeWireRecordsClaimRequestSchema,
   storeWireRecordsInsertIfAbsentRequestSchema,
   storeWireRecordsCompareAndSwapRequestSchema,
+  storeWireCollectionGetRequestSchema,
+  storeWireCollectionPutRequestSchema,
+  storeWireCollectionDeleteRequestSchema,
+  storeWireCollectionListRequestSchema,
+  storeWireCollectionClaimRequestSchema,
+  storeWireCollectionInsertIfAbsentRequestSchema,
+  storeWireCollectionCompareAndSwapRequestSchema,
   storeWireBlobsPutRequestSchema,
   storeWireBlobsGetRequestSchema,
   storeWireBlobsDeleteRequestSchema,
@@ -47,14 +54,42 @@ import {
 } from "../src/index.js";
 
 describe("vendo/store-wire@1", () => {
-  it("exposes the format constant and 35 mount-relative paths", () => {
+  it("exposes the format constant and 42 mount-relative paths", () => {
     expect(VENDO_STORE_WIRE_FORMAT).toBe("vendo/store-wire@1");
-    // 8 families: records(7) + blobs(4) + appData(8) + transcripts(6) + harness(3) + workspace(4) + lifecycle(2) + status(1) = 35
-    expect(Object.keys(STORE_WIRE_PATHS)).toHaveLength(35);
+    // 9 families: records(7) + engine(7) + blobs(4) + appData(8) + transcripts(6) + harness(3) + workspace(4) + lifecycle(2) + status(1) = 42
+    expect(Object.keys(STORE_WIRE_PATHS)).toHaveLength(42);
     expect(STORE_WIRE_PATHS.status).toBe("/status");
     expect(STORE_WIRE_PATHS["records.get"]).toBe("/records/get");
+    expect(STORE_WIRE_PATHS["engine.get"]).toBe("/engine/get");
+    expect(STORE_WIRE_PATHS["engine.compareAndSwap"]).toBe("/engine/compareAndSwap");
     expect(STORE_WIRE_PATHS["appData.put"]).toBe("/app-data/put");
     expect(STORE_WIRE_PATHS["lifecycle.promote"]).toBe("/lifecycle/promote");
+  });
+
+  it("every engine door is its own path, distinct from its records twin", () => {
+    const verbs = ["get", "put", "delete", "list", "claim", "insertIfAbsent", "compareAndSwap"] as const;
+    for (const verb of verbs) {
+      const engine = STORE_WIRE_PATHS[`engine.${verb}`];
+      expect(engine).toBe(`/engine/${verb}`);
+      expect(engine).not.toBe(STORE_WIRE_PATHS[`records.${verb}`]);
+    }
+    const enginePaths = Object.entries(STORE_WIRE_PATHS)
+      .filter(([op]) => op.startsWith("engine."))
+      .map(([, path]) => path);
+    expect(enginePaths).toHaveLength(7);
+    expect(enginePaths.every((path) => path.startsWith("/engine/"))).toBe(true);
+  });
+
+  it("the storeWireRecords* names are aliases of the shared collection bodies", () => {
+    // Same shape serves /records/* and /engine/*; the old names stay exported
+    // until the removal slice, so they must BE the renamed schemas, not copies.
+    expect(storeWireRecordsGetRequestSchema).toBe(storeWireCollectionGetRequestSchema);
+    expect(storeWireRecordsPutRequestSchema).toBe(storeWireCollectionPutRequestSchema);
+    expect(storeWireRecordsDeleteRequestSchema).toBe(storeWireCollectionDeleteRequestSchema);
+    expect(storeWireRecordsListRequestSchema).toBe(storeWireCollectionListRequestSchema);
+    expect(storeWireRecordsClaimRequestSchema).toBe(storeWireCollectionClaimRequestSchema);
+    expect(storeWireRecordsInsertIfAbsentRequestSchema).toBe(storeWireCollectionInsertIfAbsentRequestSchema);
+    expect(storeWireRecordsCompareAndSwapRequestSchema).toBe(storeWireCollectionCompareAndSwapRequestSchema);
   });
 
   it("parses records request DTOs and rejects invalid ones", () => {
@@ -205,9 +240,9 @@ describe("vendo/store-wire@1", () => {
   it("status doubles as the discovery handshake: format + ops count", () => {
     const status: StoreWireStatus = {
       format: VENDO_STORE_WIRE_FORMAT,
-      ops: 35,
+      ops: 42,
     };
-    expect(storeWireStatusSchema.parse(status).ops).toBe(35);
+    expect(storeWireStatusSchema.parse(status).ops).toBe(42);
     expect(storeWireStatusSchema.parse({ ...status, deprecated: ["records.put"] }).deprecated).toEqual(["records.put"]);
     expect(storeWireStatusSchema.safeParse({ ...status, format: "vendo/store-wire@2" }).success).toBe(false);
   });

--- a/packages/store/src/helpers/backend.ts
+++ b/packages/store/src/helpers/backend.ts
@@ -16,7 +16,7 @@ type StoreBackend =
  * "Unknown VendoStore handle" for anything this package did not mint — which is
  * every hosted deployment, and is why a key-only host could not serve a harness
  * turn. The rows exist either way; only the road to them differs. So: the SQL
- * handle when there is one, the store's own 35-op surface when there is not, and
+ * handle when there is one, the store's own 42-op surface when there is not, and
  * a named refusal only when the store offers neither.
  *
  * SQL wins when both are present. It is the same database, one hop shorter.

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -3,7 +3,7 @@
  *  keep the PGlite wasm engine out of the bundle graph. */
 export { createStore } from "./create-store.js";
 export { maybeDbFor, type VendoStore } from "./store.js";
-// The StoreOps local backend (02-store): the 35-op named-operation contract
+// The StoreOps local backend (02-store): the 42-op named-operation contract
 // served off this store's own Postgres, transactions at verb boundaries.
 export { createStoreOps } from "./ops.js";
 // The one composer of appData names and the owner stamp: everything that

--- a/packages/store/src/ops.ts
+++ b/packages/store/src/ops.ts
@@ -1,4 +1,5 @@
 import {
+  assertEngineCollection,
   VENDO_STORE_WIRE_FORMAT,
   VendoError,
   type FilesAdapter,
@@ -92,7 +93,7 @@ const decoder = new TextDecoder();
 
 /**
  * 02-store — the LOCAL backend of the StoreOps named-operation contract
- * (core/store.ts): the 35 ops served straight off this store's own Postgres,
+ * (core/store.ts): the 42 ops served straight off this store's own Postgres,
  * through the EXISTING helpers — routing doors, thread rows, workspace rows, the
  * erase cascade. Logic unchanged; what this layer adds is the atomic scope:
  * every multi-statement verb runs inside ONE
@@ -214,6 +215,61 @@ export function createStoreOps(
         });
       },
       async compareAndSwap(collection, record, expectedRevision) {
+        return await db.transaction(async (q) => {
+          const door = recordsDoor(txDb(q), collection);
+          if (door.atomic === undefined) {
+            throw new VendoError("not-implemented", `${collection} does not support compareAndSwap`);
+          }
+          return await door.atomic.compareAndSwap(record, expectedRevision);
+        });
+      },
+    },
+
+    // -----------------------------------------------------------------------
+    // engine — the same seven verbs onto the same routed doors, with the same
+    // per-collection policy living there; the ONE addition is the allowlist
+    // gate, which is why the audit door is still append-only and the effects
+    // door still insert-once through this family.
+    // -----------------------------------------------------------------------
+    engine: {
+      async get(collection, id) {
+        assertEngineCollection(collection);
+        return await recordsDoor(db, collection).get(id);
+      },
+      async put(collection, record) {
+        assertEngineCollection(collection);
+        return await db.transaction((q) => recordsDoor(txDb(q), collection).put(record));
+      },
+      async delete(collection, id) {
+        assertEngineCollection(collection);
+        await db.transaction((q) => recordsDoor(txDb(q), collection).delete(id));
+      },
+      async list(collection, query) {
+        assertEngineCollection(collection);
+        return await recordsDoor(db, collection).list(query);
+      },
+      async claim(collection, expected, replacement) {
+        assertEngineCollection(collection);
+        return await db.transaction(async (q) => {
+          const door = recordsDoor(txDb(q), collection);
+          if (door.claim === undefined) {
+            throw new VendoError("not-implemented", `${collection} does not support claim`);
+          }
+          return await door.claim(expected, replacement);
+        });
+      },
+      async insertIfAbsent(collection, record) {
+        assertEngineCollection(collection);
+        return await db.transaction(async (q) => {
+          const door = recordsDoor(txDb(q), collection);
+          if (door.atomic === undefined) {
+            throw new VendoError("not-implemented", `${collection} does not support insertIfAbsent`);
+          }
+          return await door.atomic.insertIfAbsent(record);
+        });
+      },
+      async compareAndSwap(collection, record, expectedRevision) {
+        assertEngineCollection(collection);
         return await db.transaction(async (q) => {
           const door = recordsDoor(txDb(q), collection);
           if (door.atomic === undefined) {
@@ -635,7 +691,7 @@ export function createStoreOps(
     },
 
     async status() {
-      return { format: VENDO_STORE_WIRE_FORMAT, ops: 35 };
+      return { format: VENDO_STORE_WIRE_FORMAT, ops: 42 };
     },
   };
 }

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -15,7 +15,7 @@ export interface VendoStore extends StoreAdapter {
   ensureSchema(): Promise<void>;
   close(): Promise<void>;
   raw(): unknown;
-  /** The 35-op named-operation surface, when this store carries one (the Cloud
+  /** The 42-op named-operation surface, when this store carries one (the Cloud
    *  hosted store does; a local store's lives behind `createStoreOps`). It is
    *  what lets the helpers that need a transcript, a workspace or harness state
    *  serve a store with no SQL handle — see `backendOf`. */

--- a/packages/store/src/workspace-ops-rows.ts
+++ b/packages/store/src/workspace-ops-rows.ts
@@ -7,7 +7,7 @@ import type {
 } from "./workspace-rows.js";
 
 /**
- * The workspace pair over the 35-op contract instead of this store's own
+ * The workspace pair over the 42-op contract instead of this store's own
  * Postgres — what makes a hosted store (a key, no database) serve the same
  * `WorkspaceStoreFs` a local one does, byte for byte. The façade above
  * (workspace.ts) is unchanged, and so are its permission checks: `can()` reads

--- a/packages/store/tests/engine-allowlist.test.ts
+++ b/packages/store/tests/engine-allowlist.test.ts
@@ -1,0 +1,31 @@
+import { ENGINE_COLLECTIONS, isEngineCollection } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { DEDICATED_RECORD_COLLECTIONS, RESERVED_COLLECTIONS } from "../src/index.js";
+
+// The engine allowlist is a hand-maintained LITERAL in @vendoai/core: core
+// imports nothing (layering, scripts/dependency-guard.mjs), so it cannot read
+// the store's real routing constants. @vendoai/store can see both, so this test
+// is the thing that holds the literal to reality — it fails the day someone
+// adds a reserved or dedicated collection and forgets the list.
+
+const allowed = new Set<string>(ENGINE_COLLECTIONS);
+
+describe("engine allowlist mirrors the store's routing constants", () => {
+  it.each(RESERVED_COLLECTIONS)("reserved %s is an engine collection", (collection) => {
+    expect(allowed.has(collection)).toBe(true);
+    expect(isEngineCollection(collection)).toBe(true);
+  });
+
+  it.each(DEDICATED_RECORD_COLLECTIONS)("dedicated %s is an engine collection", (collection) => {
+    expect(allowed.has(collection)).toBe(true);
+    expect(isEngineCollection(collection)).toBe(true);
+  });
+
+  // vendo_secrets is deliberately absent: it has zero .records() call sites and
+  // is served only by the dedicated secretStore door (src/secrets.ts), so the
+  // engine family must never be a second way in.
+  it("does not allow vendo_secrets", () => {
+    expect(allowed.has("vendo_secrets")).toBe(false);
+    expect(isEngineCollection("vendo_secrets")).toBe(false);
+  });
+});

--- a/packages/vendo/src/compose-context.ts
+++ b/packages/vendo/src/compose-context.ts
@@ -129,7 +129,7 @@ export interface VendoComposition {
   store: VendoStore;
   /** THE files adapter for this deployment (build contract §3.4). */
   files: FilesAdapter;
-  /** The 35-op StoreOps surface for this deployment — the store's own when it
+  /** The 42-op StoreOps surface for this deployment — the store's own when it
    *  carries one, the local backend over its SQL handle otherwise, and absent
    *  when the store offers neither (`backendOf`'s third answer). */
   ops: StoreOps | undefined;

--- a/packages/vendo/src/compose-store.ts
+++ b/packages/vendo/src/compose-store.ts
@@ -120,7 +120,7 @@ export function selectStore(
   store: VendoStore;
   /** THE files adapter for this deployment. Every consumer takes it from here. */
   files: FilesAdapter;
-  /** THE 35-op surface for this deployment, over that same store and adapter —
+  /** THE 42-op surface for this deployment, over that same store and adapter —
       absent when the store offers neither its own ops nor a SQL handle. */
   ops: StoreOps | undefined;
 } {

--- a/packages/vendo/src/hosted-store.ts
+++ b/packages/vendo/src/hosted-store.ts
@@ -50,7 +50,7 @@ export interface HostedStore extends VendoStore {
     bySubject(subject: string): Promise<EraseReport>;
     byApp(appId: string): Promise<EraseReport>;
   };
-  /** The 35-op named-operation surface over the same mount and the same key —
+  /** The 42-op named-operation surface over the same mount and the same key —
    * `vendo/store-wire@1` (see {@link hostedStoreOps}). Additive: the
    * StoreAdapter doors above are unchanged and keep their own routes. */
   ops: StoreOps;
@@ -306,10 +306,10 @@ export function hostedStore(options: HostedStoreOptions): HostedStore {
 }
 
 // ---------------------------------------------------------------------------
-// The 35-op StoreOps client — store design v1, `vendo/store-wire@1`
+// The 42-op StoreOps client — store design v1, `vendo/store-wire@1`
 // ---------------------------------------------------------------------------
 
-/** The 35 named ops — STORE_WIRE_PATHS' keys ARE the op names, and stay the
+/** The 42 named ops — STORE_WIRE_PATHS' keys ARE the op names, and stay the
  * op names even where the console's door sits at a different path. */
 type StoreWireOp = keyof typeof STORE_WIRE_PATHS;
 
@@ -348,7 +348,7 @@ const raiseWireError = async (response: Response): Promise<never> => {
 };
 
 /**
- * The Cloud client for the whole 35-op store contract, speaking
+ * The Cloud client for the whole 42-op store contract, speaking
  * `vendo/store-wire@1` over the console's store mount: bearer key, deployment
  * identity and per-request abort budget shared with {@link hostedStore}, the
  * same adapter rule (behavior comes ONLY from the constructor arguments),
@@ -512,6 +512,44 @@ export function hostedStoreOps(options: HostedStoreOptions): StoreOps {
       async compareAndSwap(collection, record, expectedRevision) {
         return nullableRecordOf(
           await mutate("records.compareAndSwap", P["records.compareAndSwap"], {
+            collection,
+            record,
+            expectedRevision,
+          }),
+        );
+      },
+    },
+    // Vendo's OWN engine drawers, over the same collection-addressed bodies as
+    // `records` — a separate door so the service can gate the collection name
+    // (the allowlist) without gating the host's own `records` traffic.
+    engine: {
+      async get(collection, id) {
+        return nullableRecordOf(await post("engine.get", P["engine.get"], { collection, id }));
+      },
+      async put(collection, record) {
+        return recordOf(await mutate("engine.put", P["engine.put"], { collection, record }));
+      },
+      async delete(collection, id) {
+        await mutate("engine.delete", P["engine.delete"], { collection, id });
+      },
+      async list(collection, query) {
+        return listOf(await post("engine.list", P["engine.list"], { collection, query: query ?? {} }));
+      },
+      async claim(collection, expected, replacement) {
+        return claimedOf(await mutate("engine.claim", P["engine.claim"], {
+          collection,
+          expected,
+          ...(replacement === undefined ? {} : { replacement }),
+        }));
+      },
+      async insertIfAbsent(collection, record) {
+        return nullableRecordOf(
+          await mutate("engine.insertIfAbsent", P["engine.insertIfAbsent"], { collection, record }),
+        );
+      },
+      async compareAndSwap(collection, record, expectedRevision) {
+        return nullableRecordOf(
+          await mutate("engine.compareAndSwap", P["engine.compareAndSwap"], {
             collection,
             record,
             expectedRevision,

--- a/packages/vendo/tests/hosted-store.test.ts
+++ b/packages/vendo/tests/hosted-store.test.ts
@@ -17,6 +17,13 @@ import {
   storeWireBlobsGetRequestSchema,
   storeWireBlobsListRequestSchema,
   storeWireBlobsPutRequestSchema,
+  storeWireCollectionClaimRequestSchema,
+  storeWireCollectionCompareAndSwapRequestSchema,
+  storeWireCollectionDeleteRequestSchema,
+  storeWireCollectionGetRequestSchema,
+  storeWireCollectionInsertIfAbsentRequestSchema,
+  storeWireCollectionListRequestSchema,
+  storeWireCollectionPutRequestSchema,
   storeWireRecordsClaimRequestSchema,
   storeWireRecordsCompareAndSwapRequestSchema,
   storeWireRecordsDeleteRequestSchema,
@@ -473,7 +480,7 @@ describe("demo-host journey through the store seam", () => {
 });
 
 // ---------------------------------------------------------------------------
-// hostedStoreOps — the 35-op client over `vendo/store-wire@1`.
+// hostedStoreOps — the 42-op client over `vendo/store-wire@1`.
 //
 // Unit tests over an injected fake fetch: they pin the route, the request body
 // and the response decoding for every op — records and blobs against the
@@ -509,6 +516,13 @@ const DOORS: Record<string, { method: string; path: string; keyed?: true }> = {
   "records.claim": { method: "POST", path: P["records.claim"], keyed: true },
   "records.insertIfAbsent": { method: "POST", path: P["records.insertIfAbsent"], keyed: true },
   "records.compareAndSwap": { method: "POST", path: P["records.compareAndSwap"], keyed: true },
+  "engine.get": { method: "POST", path: P["engine.get"] },
+  "engine.put": { method: "POST", path: P["engine.put"], keyed: true },
+  "engine.delete": { method: "POST", path: P["engine.delete"], keyed: true },
+  "engine.list": { method: "POST", path: P["engine.list"] },
+  "engine.claim": { method: "POST", path: P["engine.claim"], keyed: true },
+  "engine.insertIfAbsent": { method: "POST", path: P["engine.insertIfAbsent"], keyed: true },
+  "engine.compareAndSwap": { method: "POST", path: P["engine.compareAndSwap"], keyed: true },
   "blobs.put": { method: "POST", path: P["blobs.put"], keyed: true },
   "blobs.get": { method: "POST", path: P["blobs.get"] },
   "blobs.delete": { method: "POST", path: P["blobs.delete"], keyed: true },
@@ -579,6 +593,13 @@ const ALL_BODIES: Record<string, unknown> = {
   [door("records.claim")]: { claimed: true },
   [door("records.insertIfAbsent")]: { record: wireRecord },
   [door("records.compareAndSwap")]: { record: null },
+  [door("engine.get")]: { record: wireRecord },
+  [door("engine.put")]: { record: wireRecord },
+  [door("engine.delete")]: { ok: true },
+  [door("engine.list")]: { records: [wireRecord], cursor: "cur_engine" },
+  [door("engine.claim")]: { claimed: true },
+  [door("engine.insertIfAbsent")]: { record: wireRecord },
+  [door("engine.compareAndSwap")]: { record: null },
   [door("blobs.put")]: { ok: true },
   [door("blobs.get")]: { blob: { bytes: btoa("blob bytes"), contentType: "text/plain" } },
   [door("blobs.delete")]: { ok: true },
@@ -606,12 +627,16 @@ const ALL_BODIES: Record<string, unknown> = {
   [door("workspace.history")]: { entries: [{ commitId: "wsc_1" }] },
   [door("lifecycle.erase")]: { report: { vendo_apps: 1 } },
   [door("lifecycle.promote")]: { ok: true },
-  [door("status")]: { format: "vendo/store-wire@1", ops: 35 },
+  [door("status")]: { format: "vendo/store-wire@1", ops: 42 },
 };
 
 /** Where an appData op lands: the app, the collection it invented, and the
  * owner the runtime stamped — never a subject the caller names. */
 const APP_DATA_TARGET = { appId: "app_1", collection: "invoices", owner: "sub_1" };
+
+/** A real name from the engine allowlist (core's ENGINE_COLLECTIONS) — the gate
+ * is server-side, but a made-up name would read as if any name were allowed. */
+const ENGINE_COLLECTION = "vendo_workspace_commits";
 
 const driveEveryOp = async (ops: ReturnType<typeof wireFake>["ops"]): Promise<void> => {
   await ops.records.get("invoices", "inv_1");
@@ -621,6 +646,13 @@ const driveEveryOp = async (ops: ReturnType<typeof wireFake>["ops"]): Promise<vo
   await ops.records.claim("invoices", { id: "inv_1", data: { total: 5 } });
   await ops.records.insertIfAbsent("invoices", { id: "inv_2", data: {} });
   await ops.records.compareAndSwap("invoices", { id: "inv_2", data: {} }, "1");
+  await ops.engine.get(ENGINE_COLLECTION, "wsc_1");
+  await ops.engine.put(ENGINE_COLLECTION, { id: "wsc_1", data: { paths: 1 } });
+  await ops.engine.delete(ENGINE_COLLECTION, "wsc_1");
+  await ops.engine.list(ENGINE_COLLECTION);
+  await ops.engine.claim(ENGINE_COLLECTION, { id: "wsc_1", data: { paths: 1 } });
+  await ops.engine.insertIfAbsent(ENGINE_COLLECTION, { id: "wsc_2", data: {} });
+  await ops.engine.compareAndSwap(ENGINE_COLLECTION, { id: "wsc_2", data: {} }, "1");
   await ops.blobs.put("uploads", "a.png", new Uint8Array([1]));
   await ops.blobs.get("uploads", "a.png");
   await ops.blobs.delete("uploads", "a.png");
@@ -651,24 +683,24 @@ const driveEveryOp = async (ops: ReturnType<typeof wireFake>["ops"]): Promise<vo
   await ops.status();
 };
 
-describe("hostedStoreOps — the 35-op wire client", () => {
-  it("routes all 35 ops to the console's real door, with a key on exactly the mutations", async () => {
+describe("hostedStoreOps — the 42-op wire client", () => {
+  it("routes all 42 ops to the console's real door, with a key on exactly the mutations", async () => {
     const { calls, ops } = wireFake(ALL_BODIES);
     await driveEveryOp(ops);
 
     const expected = Object.values(DOORS);
-    expect(calls).toHaveLength(35);
+    expect(calls).toHaveLength(42);
     expect(calls.map((call) => `${call.method} ${call.path}`))
       .toEqual(expected.map((route) => `${route.method} ${route.path}`));
     expect(calls.map((call) => call.idempotencyKey === null ? "read" : "keyed"))
       .toEqual(expected.map((route) => route.keyed === true ? "keyed" : "read"));
-    // 20 mutations, 15 reads — and the /status handshake is the one GET with
+    // 25 mutations, 17 reads — and the /status handshake is the one GET with
     // no body at all.
-    expect(expected.filter((route) => route.keyed === true)).toHaveLength(20);
+    expect(expected.filter((route) => route.keyed === true)).toHaveLength(25);
     expect(calls.at(-1)).toMatchObject({ path: P.status, method: "GET", body: undefined });
     // Distinct keys across distinct operations (one per logical mutation).
     const keys = calls.map((call) => call.idempotencyKey).filter((key) => key !== null);
-    expect(new Set(keys).size).toBe(20);
+    expect(new Set(keys).size).toBe(25);
   });
 
   it("records: seven ops on the wire door, collection on the body, records/cursor decoded", async () => {
@@ -781,7 +813,7 @@ describe("hostedStoreOps — the 35-op wire client", () => {
     await expect(bare.blobs.get("uploads", "gone.png")).rejects.toMatchObject({ code: "not-implemented" });
   });
 
-  it("records and blobs requests validate against the EXPORTED store-wire v1 request schemas", async () => {
+  it("records, engine and blobs requests validate against the EXPORTED store-wire v1 request schemas", async () => {
     const { calls, ops } = wireFake(ALL_BODIES);
     await ops.records.get("invoices", "inv_1");
     await ops.records.put("invoices", { id: "inv_1", data: { total: 5 } });
@@ -790,6 +822,13 @@ describe("hostedStoreOps — the 35-op wire client", () => {
     await ops.records.claim("invoices", { id: "inv_1", data: { total: 5 } }, { data: { total: 6 } });
     await ops.records.insertIfAbsent("invoices", { id: "inv_2", data: {} });
     await ops.records.compareAndSwap("invoices", { id: "inv_2", data: {} }, "1");
+    await ops.engine.get(ENGINE_COLLECTION, "wsc_1");
+    await ops.engine.put(ENGINE_COLLECTION, { id: "wsc_1", data: { paths: 1 } });
+    await ops.engine.delete(ENGINE_COLLECTION, "wsc_1");
+    await ops.engine.list(ENGINE_COLLECTION, { limit: 10 });
+    await ops.engine.claim(ENGINE_COLLECTION, { id: "wsc_1", data: { paths: 1 } }, { data: { paths: 2 } });
+    await ops.engine.insertIfAbsent(ENGINE_COLLECTION, { id: "wsc_2", data: {} });
+    await ops.engine.compareAndSwap(ENGINE_COLLECTION, { id: "wsc_2", data: {} }, "1");
     await ops.blobs.put("uploads", "a.bin", new Uint8Array([7]), { contentType: "application/octet-stream" });
     await ops.blobs.get("uploads", "a.bin");
     await ops.blobs.delete("uploads", "a.bin");
@@ -803,6 +842,16 @@ describe("hostedStoreOps — the 35-op wire client", () => {
       ["records.claim", storeWireRecordsClaimRequestSchema],
       ["records.insertIfAbsent", storeWireRecordsInsertIfAbsentRequestSchema],
       ["records.compareAndSwap", storeWireRecordsCompareAndSwapRequestSchema],
+      // ONE collection-addressed body shape, two doors: the engine ops send
+      // exactly what /records/* sends, so they validate against the same
+      // schema objects (the storeWireRecords* names above are its aliases).
+      ["engine.get", storeWireCollectionGetRequestSchema],
+      ["engine.put", storeWireCollectionPutRequestSchema],
+      ["engine.delete", storeWireCollectionDeleteRequestSchema],
+      ["engine.list", storeWireCollectionListRequestSchema],
+      ["engine.claim", storeWireCollectionClaimRequestSchema],
+      ["engine.insertIfAbsent", storeWireCollectionInsertIfAbsentRequestSchema],
+      ["engine.compareAndSwap", storeWireCollectionCompareAndSwapRequestSchema],
       ["blobs.put", storeWireBlobsPutRequestSchema],
       ["blobs.get", storeWireBlobsGetRequestSchema],
       ["blobs.delete", storeWireBlobsDeleteRequestSchema],
@@ -933,9 +982,9 @@ describe("hostedStoreOps — the 35-op wire client", () => {
 
   it("status: the GET handshake, parsed as vendo/store-wire@1", async () => {
     const { calls, ops } = wireFake(ALL_BODIES);
-    expect(await ops.status()).toMatchObject({ format: "vendo/store-wire@1", ops: 35 });
+    expect(await ops.status()).toMatchObject({ format: "vendo/store-wire@1", ops: 42 });
     expect(calls[0]).toMatchObject({ path: "/status", method: "GET" });
-    await expect(wireFake({ [door("status")]: { format: "vendo/store-wire@2", ops: 35 } }).ops.status())
+    await expect(wireFake({ [door("status")]: { format: "vendo/store-wire@2", ops: 42 } }).ops.status())
       .rejects.toThrow(/invalid status/);
   });
 
@@ -1101,7 +1150,7 @@ describe("hostedStore keeps its StoreAdapter surface and gains the op surface", 
     expect(typeof store.blobs).toBe("function");
     expect(typeof store.erase.bySubject).toBe("function");
     expect(Object.keys(store.ops).sort()).toEqual([
-      "appData", "blobs", "harness", "lifecycle", "records", "status", "transcripts", "workspace",
+      "appData", "blobs", "engine", "harness", "lifecycle", "records", "status", "transcripts", "workspace",
     ]);
 
     // The op surface rides the SAME mount, key and identity headers as the
@@ -1124,8 +1173,8 @@ describe("hostedStore keeps its StoreAdapter surface and gains the op surface", 
     expect(await store.ops.blobs.list("uploads", "images/")).toEqual(["images/a.png"]);
   });
 
-  // 23 of the 35 ops have no door in the fake: all 8 appData, all 6
-  // transcripts, all 3 harness, all 4 workspace, lifecycle.promote and
+  // 30 of the 42 ops have no door in the fake: all 7 engine, all 8 appData,
+  // all 6 transcripts, all 3 harness, all 4 workspace, lifecycle.promote and
   // /status. It used to answer
   // them with a `not-found` envelope — the SAME answer a live console sends
   // when it refuses — so a test exercising one of those families read a


### PR DESCRIPTION
`StoreOps` goes **35 ops / 8 families → 42 / 9**. The new family is `engine`, and it is today's `records.*` verb for verb — same seven verbs, same arguments, same routed doors — with one statement added in front of every one of them: `assertEngineCollection(collection)`.

## Why

Grants, approvals, the audit log, threads, runs, apps, effects, the automations drawers and the guard's freeze switch all reached the store through the same generic `records.*` door a host uses for its own data. Nothing said which collections were Vendo's, so nothing could refuse a call that reached for one. `engine` says it, and refuses everything else with `blocked`.

## The allowlist

`ENGINE_COLLECTIONS` (`packages/core/src/engine-collections.ts`) is 35 static names — the 9 reserved, the 4 dedicated tables, the 22 the blocks own on the generic table, each with a `file:line` citation of the constant that declares it — plus exactly **one** dynamic pattern, `vendo:app-history:<id>`, built by `engineAppHistory(appId)`.

It lives in `@vendoai/core`, not `@vendoai/store`, because the layering guard forbids `guard`, `automations` and `apps` from importing the store but lets all three import core. `@vendoai/store` is what *enforces* it, and `packages/store/tests/engine-allowlist.test.ts` holds the literal to the real `RESERVED_COLLECTIONS` / `DEDICATED_RECORD_COLLECTIONS` — it fails the day someone adds a reserved collection and forgets the list.

A refused name is told the allowlist version, the nearest allowed name when it looks like a typo, and where its data actually belongs:

```
collection "vendo_audi" is not an engine collection (engine allowlist v1) — did you
mean "vendo_audit"? App data belongs to the appData family (ops.appData.*), which
takes an { appId, collection, owner } target.
```

`vendo_secrets` is deliberately absent — it has zero `.records()` call sites and is served only by the dedicated `secretStore` door. Three entries (`vendo_host_components`, `vendo_pin_baselines`, `guard:controls`) carry neither a subject nor an app ref on purpose — host-level config, commented in place so nobody later "fixes" them.

## Policy did not move

`engine` reaches the same `createReservedRecordStore` doors, so the audit log is still append-only through it and the effect ledger still insert-once. Two conformance cases pin exactly that, because a second door onto the same rows is precisely where policy quietly stops applying.

## Surface

Seven `/engine/*` wire paths on `vendo/store-wire@1`, implemented by the local Postgres backend, the Cloud client and the in-core memory reference, with **seven conformance cases run by all three**. The seven collection-addressed request schemas are renamed `storeWireCollection*RequestSchema` — one body shape now serves both `/records/*` and `/engine/*` — with the old `storeWireRecords*` names kept as `@deprecated` aliases until the removal slice.

`records.*`, `StoreAdapter` and every existing call site are untouched.

## Verification

- `packages/core`: 94/94 (`store-wire`, `memory-store-ops`, `engine-collections`).
- `packages/store`: 144/144 on **both** backends — pglite and a real `postgres:16-alpine` container.
- `packages/vendo`: 52/52, all 42 ops routed to their own door with a key on exactly the 25 mutations.
- `pnpm build`, `pnpm typecheck`, `pnpm lint` green at the root.

**Prove-it-can-fail:** removing `assertEngineCollection` from `engine.put` turns exactly these red, and nothing else —
`pglite StoreOps conformance (local backend) > engine refuses a collection outside the allowlist on every verb`
`postgres StoreOps conformance (local backend) > engine refuses a collection outside the allowlist on every verb`

The console's `/engine/[op]` route is deliberately **not** in this PR — it needs release R2 on npm and a console dep bump first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `engine` StoreOps family to gate Vendo’s internal collections behind an allowlist. StoreOps grows to 42 ops across 9 families; semantics match `records.*`, and existing `records` call sites are untouched.

- **New Features**
  - Allowlist: `ENGINE_COLLECTIONS` in `@vendoai/core` (35 static names) plus `vendo:app-history:<id>` via `engineAppHistory(appId)`.
  - Enforcement: `assertEngineCollection(collection)` on every `engine` verb with clear refusals (version, nearest name, and “use appData” hint).
  - Policy intact: same routed doors; audit stays append-only and effects insert-once; pinned by conformance tests.
  - Wire/API: seven `/engine/*` paths in `vendo/store-wire@1`. Collection-addressed schemas renamed to `storeWireCollection*RequestSchema`; `storeWireRecords*` remain as deprecated aliases.
  - Implementations: supported by local Postgres backend, Cloud client, and in-memory reference. `status.ops` now reports 42.

- **Migration**
  - No breaking changes. Optionally update imports to `storeWireCollection*RequestSchema`. Console route for `/engine/[op]` will ship after the next release.

<sup>Written for commit fac780eb3204d5b6d6606df74e69cea172fbadbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

