### PR TITLE
fix(cli): --help works on every subcommand (#1154)

### DIFF
--- a/packages/vendo/src/cli.ts
+++ b/packages/vendo/src/cli.ts
@@ -302,6 +302,12 @@ async function syncCommand(args: string[]): Promise<number> {
   });
 }
 
+/** #1154: `--help`/`-h` after one of these command names asks for the help
+    text — without this it reaches optionErrors and comes back as
+    `unknown option: --help`, exit 1. The group commands (cloud/config/
+    knowledge/mcp) print their own help, and an unknown command stays loud. */
+const HELP_COMMANDS = new Set(["login", "init", "eject", "doctor", "sync"]);
+
 export async function main(argv: string[]): Promise<number> {
   const [command, ...args] = argv;
   if (command === undefined || command === "--help" || command === "-h") {
@@ -310,6 +316,10 @@ export async function main(argv: string[]): Promise<number> {
   }
   if (command === "--version" || command === "-v") {
     console.log(CLI_VERSION);
+    return 0;
+  }
+  if (HELP_COMMANDS.has(command) && (args.includes("--help") || args.includes("-h"))) {
+    console.log(HELP);
     return 0;
   }
   if (command === "login") return loginCommand(args);

--- a/packages/vendo/tests/cli.test.ts
+++ b/packages/vendo/tests/cli.test.ts
@@ -263,6 +263,28 @@ describe("vendo CLI commands", () => {
     log.mockRestore();
   });
 
+  // #1154: an agent's first move on a command it does not know is
+  // `vendo <command> --help`. Before the fix that reached optionErrors and came
+  // back as `unknown option: --help`, exit 1 — no help, no flags discovered.
+  it("prints help for --help/-h after any command name (#1154)", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const root = await mkdtemp(join(tmpdir(), "vendo-cli-help-"));
+    cleanup.push(root);
+
+    for (const argv of [["doctor", "--help"], ["init", "--help"], ["sync", "--help"],
+      ["login", "--help"], ["eject", "--help"], ["doctor", root, "-h"]]) {
+      log.mockClear();
+      expect(await main(argv)).toBe(0);
+      expect(log.mock.calls.flat().join("\n")).toContain("Usage: vendo <command>");
+    }
+    expect(error).not.toHaveBeenCalled();
+    expect(await readdir(root)).toEqual([]); // no command ever ran
+
+    log.mockRestore();
+    error.mockRestore();
+  });
+
   it("wires eject: --list routes, surface + dir + --force parse, help documents it", async () => {
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
     const error = vi.spyOn(console, "error").mockImplementation(() => {});


### PR DESCRIPTION
Fixes #1154

## What was wrong

`--help`/`-h` was only special-cased when it WAS the top-level command
(`cli.ts:307`). Once `doctor` was the command, `--help` was just another arg
handed to `doctorCommand`, which validated it against `DOCTOR_FLAGS` and
rejected it — same for `init`, `sync`, `login`, and (silently, no validation)
`eject`.

```
$ node bin/vendo.mjs doctor --help
vendo doctor: unknown option: --help
$ echo $?
1
```

## The fix

One dispatch-level check in `main`: if the command is a leaf command and
`--help`/`-h` appears anywhere after it, print the help and return 0 before any
validation runs.

Deliberately narrow on both sides:
- the group commands (`cloud`, `config`, `knowledge`, `mcp`) already print
  their own, more relevant help for `<group> --help` — they keep it;
- an unknown command stays loud (`vendo bogus --help` is still
  `Unknown command: bogus`, exit 1), so a typo'd command never reads as success.

Real binary, after the fix:

```
$ node bin/vendo.mjs doctor --help        # exit 0
vendo — install your product's agent

Usage: vendo <command> [dir] [options]
...
$ node bin/vendo.mjs cloud --help         # exit 0, still the cloud help
vendo cloud — Vendo Cloud API client
$ node bin/vendo.mjs bogus --help         # exit 1
Unknown command: bogus
```

## Fail-first proof

New test `prints help for --help/-h after any command name (#1154)` covers
`doctor`, `init`, `sync`, `login`, `eject` with `--help` plus `doctor -h`
(exit 0 + `Usage: vendo <command>` present + nothing written + no stderr).

With `packages/vendo/src/cli.ts` reverted (test unchanged) — RED on the very
first case, `doctor --help`:

```
 × vendo CLI commands > prints help for --help/-h after any command name (#1154) 5ms
   → expected 1 to be +0 // Object.is equality
 ❯ tests/cli.test.ts:278:32
    278|       expect(await main(argv)).toBe(0);

 Test Files  1 failed (1)
      Tests  1 failed | 12 skipped (13)
```

Fix restored — GREEN:

```
 ✓ tests/cli.test.ts (13 tests | 12 skipped) 2ms
 Test Files  1 passed (1)
      Tests  1 passed | 12 skipped (13)
```

## Local gate

`pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint` — exit 0.

```
build       Tasks:    21 successful, 21 total
test        @vendoai/vendo:test:  Test Files  192 passed | 10 skipped (202)
            Tasks:    31 successful, 31 total     Time: 4m55.434s
typecheck   Tasks:    42 successful, 42 total     Time: 15.852s
lint        Tasks:     4 successful, 4 total      Time: 9.707s
            (demo-bank: 4 pre-existing warnings, 0 errors)
```

No UI surface touched. Files owned by the concurrent #1153 fix
(`init-scaffolds.ts`, `init-mcp.ts`, `doctor-*.ts`) were not touched.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `--help`/`-h` so `vendo <command> --help` prints usage and exits 0 for leaf commands. Keeps group command help as-is and unknown commands still error. Fixes #1154.

- **Bug Fixes**
  - Added a dispatch-level check to show help when `--help`/`-h` appears after `login`, `init`, `eject`, `doctor`, or `sync`.
  - Left group commands (`cloud`, `config`, `knowledge`, `mcp`) unchanged; unknown commands still exit 1. Added tests covering `--help` and `-h` scenarios.

<sup>Written for commit 3aece050c2481c404191ff49b9d6dd4c9043514e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

