### PR TITLE
feat(apps): the agent's data tools move onto appData — one user stops seeing another's rows

### DIFF
--- a/.changeset/apps-data-tools-owner-stamped.md
+++ b/.changeset/apps-data-tools-owner-stamped.md
@@ -1,0 +1,31 @@
+---
+"@vendoai/apps": minor
+"@vendoai/vendo": minor
+---
+
+The agent's data tools move onto `appData` — one user can no longer see another's rows.
+
+`vendo_apps_data_list` / `_put` / `_delete` are how the embedded agent saves and
+reads an app's declared storage on the person's behalf. They landed in the
+generic `records` family, which has no answer to "whose row is this": every
+user of an app wrote into one flat collection, and the only thing between them
+was that nobody had asked.
+
+Now every one of those calls carries `ctx.principal.subject` — the LIVE caller,
+off the run context, never off the tool args — into the owner-stamped `appData`
+family. `put` stamps the row with that subject, `list` ANDs it into the query,
+`get` answers `null` for another owner's row and `delete` no-ops on one. A
+cross-user read is no longer forbidden; it is unexpressible. An id another owner
+already holds refuses with `conflict` rather than being taken over, and that
+refusal is surfaced honestly rather than swallowed. Declared file collections
+get the same treatment through the family's file twins.
+
+Nothing about what an app may declare changed. The guards keep their posts in
+the same order — the declaration check (with `state` still reserved), the
+declared-refs check, the 256 KB record cap, the 5 MB blob cap — and app state
+(`vendo_state`) stays on the `StoreAdapter` façade, deliberately.
+
+`AppsConfig` gains an optional `ops` slot that the umbrella fills with the same
+`StoreOps` surface the deployment already selected. Its absence is a real
+answer, not a failure: a store that offers neither its own ops nor a SQL handle
+keeps exactly today's behavior instead of crashing composition at boot.

--- a/packages/apps/src/server/doors/data-tools.ts
+++ b/packages/apps/src/server/doors/data-tools.ts
@@ -3,7 +3,9 @@
  * declared app data collection, over the same `requireOwned` gate every other
  * door reads.
  *
- * Lifted out of `createAgentTools` unchanged.
+ * Lifted out of `createAgentTools` unchanged. Every row is owned by the LIVE
+ * caller: the subject comes off the run context, never off the tool args, so
+ * generated code has no way to name someone else's drawer.
  */
 import {
   VendoError,
@@ -35,7 +37,9 @@ export const listAppData = async (
   };
   return {
     status: "ok",
-    output: await dependencies.data.records(app, args.collection as string).list(query) as unknown as Json,
+    output: await dependencies.data
+      .records(app, args.collection as string, ctx.principal.subject)
+      .list(query) as unknown as Json,
   };
 };
 
@@ -50,11 +54,13 @@ export const putAppData = async (
   }
   const app = await dependencies.requireOwned(args.appId as string, ctx);
   const refs = optionalRefs(args.refs);
-  const record = await dependencies.data.records(app, args.collection as string).put({
-    id: args.id as string,
-    data: args.data,
-    ...(refs === undefined ? {} : { refs }),
-  });
+  const record = await dependencies.data
+    .records(app, args.collection as string, ctx.principal.subject)
+    .put({
+      id: args.id as string,
+      data: args.data,
+      ...(refs === undefined ? {} : { refs }),
+    });
   return { status: "ok", output: record as unknown as Json };
 };
 
@@ -65,6 +71,8 @@ export const deleteAppData = async (
 ): Promise<ToolOutcome> => {
   const args = input(call.args, ["appId", "collection", "id"]);
   const app = await dependencies.requireOwned(args.appId as string, ctx);
-  await dependencies.data.records(app, args.collection as string).delete(args.id as string);
+  await dependencies.data
+    .records(app, args.collection as string, ctx.principal.subject)
+    .delete(args.id as string);
   return { status: "ok", output: { status: "ok" } };
 };

--- a/packages/apps/src/server/persistence/app-data.ts
+++ b/packages/apps/src/server/persistence/app-data.ts
@@ -1,9 +1,11 @@
 import {
+  type AppDataTarget,
   type AppId,
   type BlobStore,
   type Json,
   type RecordStore,
   type StoreAdapter,
+  type StoreOps,
   VendoError,
 } from "@vendoai/core";
 import type {
@@ -32,6 +34,43 @@ export const resolveAppStorage = (
   ? { kind: "files", blobs: store.blobs(`app:${appId}:${name}`) }
   : { kind: "records", records: store.records(`app:${appId}:${name}`) };
 
+/** The appData family, wearing the plain `RecordStore` / `BlobStore` face the
+ *  guards below already wrap. The owner rides in the target, so the store
+ *  stamps it onto every write and scopes every read to it — nothing here may
+ *  set `refs.subject`, which the family refuses. */
+const appDataRecords = (ops: StoreOps, target: AppDataTarget): RecordStore => ({
+  get: (id) => ops.appData.get(target, id),
+  put: (record) => ops.appData.put(target, record),
+  delete: (id) => ops.appData.delete(target, id),
+  list: (query) => ops.appData.list(target, query),
+});
+
+const appDataBlobs = (ops: StoreOps, target: AppDataTarget): BlobStore => ({
+  put: (key, bytes, meta) => ops.appData.putFile(target, key, bytes, meta),
+  get: (key) => ops.appData.getFile(target, key),
+  delete: (key) => ops.appData.deleteFile(target, key),
+  list: (prefix) => ops.appData.listFiles(target, prefix),
+});
+
+/** The ONE spelling of "which store backs this collection". `selectStoreOps`
+ *  gives a three-way answer — the store's own ops, the local backend over a SQL
+ *  handle, or nothing at all for a store with neither. Requiring `ops` would
+ *  crash composition at boot for that third store, where today it refuses at
+ *  the op that needed one; so a store without an ops surface keeps exactly
+ *  today's façade behavior, unowned, and a store with one gets owner stamping.
+ *  No other branch. */
+const backingFor = (
+  ops: StoreOps | undefined,
+  store: StoreAdapter,
+  target: AppDataTarget,
+  declaration: StorageDecl,
+): AppStorage => {
+  if (ops === undefined) return resolveAppStorage(store, target.appId, target.collection, declaration);
+  return declaration.kind === "files"
+    ? { kind: "files", blobs: appDataBlobs(ops, target) }
+    : { kind: "records", records: appDataRecords(ops, target) };
+};
+
 const allRecordIds = async (records: RecordStore): Promise<string[]> =>
   (await listAllRecords(records)).map((record) => record.id);
 
@@ -46,8 +85,8 @@ const clearBlobs = async (blobs: BlobStore): Promise<void> => {
 export interface AppDataAccess {
   getState(appId: AppId, subject: string): Promise<Json | null>;
   setState(appId: AppId, subject: string, data: Json): Promise<void>;
-  records(app: AppDocument, name: string): RecordStore;
-  blobs(app: AppDocument, name: string): BlobStore;
+  records(app: AppDocument, name: string, owner: string): RecordStore;
+  blobs(app: AppDocument, name: string, owner: string): BlobStore;
   clear(app: AppDocument, subject: string, historical?: readonly AppDocument[]): Promise<void>;
 }
 
@@ -98,7 +137,9 @@ const recordByteLength = (record: Parameters<RecordStore["put"]>[0]): number => 
 };
 
 /** 06-apps §6 — private app-data API consumed by lifecycle and later execution lanes. */
-export const createAppData = (store: StoreAdapter): AppDataAccess => ({
+export const createAppData = (
+  { ops, store }: { ops: StoreOps | undefined; store: StoreAdapter },
+): AppDataAccess => ({
   async getState(appId, subject) {
     const record = await store.records("vendo_state").get(`${appId}:${subject}`);
     return record === null ? null : structuredClone(record.data);
@@ -110,9 +151,9 @@ export const createAppData = (store: StoreAdapter): AppDataAccess => ({
       refs: { subject, app_id: appId },
     });
   },
-  records(app, name) {
+  records(app, name, owner) {
     const declaration = declaredStorage(app, name, "records");
-    const storage = resolveAppStorage(store, app.id, name, declaration);
+    const storage = backingFor(ops, store, { appId: app.id, collection: name, owner }, declaration);
     if (storage.kind !== "records") {
       throw new VendoError("not-found", `records collection not found: ${name}`);
     }
@@ -129,9 +170,9 @@ export const createAppData = (store: StoreAdapter): AppDataAccess => ({
       list: (query) => storage.records.list(query),
     };
   },
-  blobs(app, name) {
+  blobs(app, name, owner) {
     const declaration = declaredStorage(app, name, "files");
-    const storage = resolveAppStorage(store, app.id, name, declaration);
+    const storage = backingFor(ops, store, { appId: app.id, collection: name, owner }, declaration);
     if (storage.kind !== "files") {
       throw new VendoError("not-found", `files collection not found: ${name}`);
     }
@@ -156,7 +197,10 @@ export const createAppData = (store: StoreAdapter): AppDataAccess => ({
     }
     for (const [key, declaration] of declarations) {
       const name = key.slice(0, key.lastIndexOf(":"));
-      const storage = resolveAppStorage(store, app.id, name, declaration);
+      // Owner-scoped through the same backing the doors write: an appData list
+      // already sees only this subject's rows, so the sweep empties the
+      // caller's drawer and nobody else's.
+      const storage = backingFor(ops, store, { appId: app.id, collection: name, owner: subject }, declaration);
       if (storage.kind === "records") await clearRecords(storage.records);
       else await clearBlobs(storage.blobs);
     }

--- a/packages/apps/src/server/runtime/runtime-context.ts
+++ b/packages/apps/src/server/runtime/runtime-context.ts
@@ -256,7 +256,7 @@ const createStores = (
   const apps = config.store.records("vendo_apps");
   const placementRows = placementStore(config.store);
   const slots = createSlotRegistry(config.store);
-  const data = createAppData(config.store);
+  const data = createAppData({ ops: config.ops, store: config.store });
   const history = createAppHistory(config.store);
   // Lane E — parked egress approvals (approved state lives on the document's
   // egressApproved field; this collection holds only undecided cards).

--- a/packages/apps/src/server/runtime/types.ts
+++ b/packages/apps/src/server/runtime/types.ts
@@ -22,6 +22,7 @@ import type {
   RunContext,
   SecretsProvider,
   StoreAdapter,
+  StoreOps,
   ToolCall,
   ToolOutcome,
   ToolRegistry,
@@ -56,6 +57,14 @@ import type { SlotRegistry } from "../persistence/slots.js";
 /** 06-apps §1 plus block-plan decisions 3–4. */
 export interface AppsConfig {
   store: StoreAdapter;
+  /**
+   * The deployment's 35-op store surface, when it has one. App data goes
+   * through its `appData` family so every row is stamped with the live
+   * caller's subject and every read is scoped to it. Absent — a store that
+   * offers neither its own ops nor a SQL handle — app data falls back to the
+   * raw `store` façade collections, unowned, exactly as it landed before.
+   */
+  ops?: StoreOps;
   guard: Guard;
   tools: ToolRegistry;
   /**

--- a/packages/apps/tests/app-data.test.ts
+++ b/packages/apps/tests/app-data.test.ts
@@ -74,14 +74,15 @@ describe("app data persistence", () => {
         attachments: { about: "Invoice attachments", kind: "files" },
       },
     };
-    const data = createAppData(store);
+    const data = createAppData({ ops: undefined, store });
+    const owner = ctx.principal.subject;
 
-    expect(() => data.records(app, "missing")).toThrow(expect.objectContaining({ code: "not-found" }));
-    expect(() => data.blobs(app, "missing")).toThrow(expect.objectContaining({ code: "not-found" }));
-    expect(() => data.records(app, "attachments")).toThrow(expect.objectContaining({ code: "not-found" }));
-    expect(() => data.blobs(app, "notes")).toThrow(expect.objectContaining({ code: "not-found" }));
-    expect(() => data.records(app, "state")).toThrow(expect.objectContaining({ code: "validation" }));
-    expect(() => data.blobs(app, "state")).toThrow(expect.objectContaining({ code: "validation" }));
+    expect(() => data.records(app, "missing", owner)).toThrow(expect.objectContaining({ code: "not-found" }));
+    expect(() => data.blobs(app, "missing", owner)).toThrow(expect.objectContaining({ code: "not-found" }));
+    expect(() => data.records(app, "attachments", owner)).toThrow(expect.objectContaining({ code: "not-found" }));
+    expect(() => data.blobs(app, "notes", owner)).toThrow(expect.objectContaining({ code: "not-found" }));
+    expect(() => data.records(app, "state", owner)).toThrow(expect.objectContaining({ code: "validation" }));
+    expect(() => data.blobs(app, "state", owner)).toThrow(expect.objectContaining({ code: "validation" }));
   });
 
   it("round-trips records with refs filters and validates declared refs", async () => {
@@ -94,7 +95,7 @@ describe("app data persistence", () => {
         notes: { about: "Invoice notes", refs: { invoice_id: "host.invoice" } },
       },
     };
-    const records = createAppData(store).records(app, "notes");
+    const records = createAppData({ ops: undefined, store }).records(app, "notes", ctx.principal.subject);
 
     await records.put({ id: "note_1", data: { body: "first" }, refs: { invoice_id: "inv_1" } });
     await records.put({ id: "note_2", data: { body: "second" }, refs: { invoice_id: "inv_2" } });
@@ -125,13 +126,13 @@ describe("app data persistence", () => {
         attachments: { about: "Bounded attachments", kind: "files" },
       },
     };
-    const data = createAppData(store);
+    const data = createAppData({ ops: undefined, store });
 
-    await expect(data.records(app, "notes").put({
+    await expect(data.records(app, "notes", ctx.principal.subject).put({
       id: "oversized",
       data: { body: "x".repeat(APP_RECORD_MAX_BYTES) },
     })).rejects.toMatchObject({ code: "validation" });
-    await expect(data.blobs(app, "attachments").put(
+    await expect(data.blobs(app, "attachments", ctx.principal.subject).put(
       "oversized.bin",
       new Uint8Array(APP_BLOB_MAX_BYTES + 1),
     )).rejects.toMatchObject({ code: "validation" });

--- a/packages/apps/tests/security/app-data-isolation.test.ts
+++ b/packages/apps/tests/security/app-data-isolation.test.ts
@@ -1,3 +1,6 @@
+import { VENDO_APP_FORMAT } from "@vendoai/core";
+import { memoryStoreOps } from "@vendoai/core/conformance";
+import type { AppDocument } from "../../src/contract/index.js";
 import { describe, expect, it } from "vitest";
 import { createAppData } from "../../src/server/persistence/app-data.js";
 import { memoryStore } from "../../src/server/testing/memory-store.js";
@@ -8,10 +11,31 @@ import { memoryStore } from "../../src/server/testing/memory-store.js";
 // state, and one user's read must never surface another user's state for the same app.
 // This complements proxy-escalation.test.ts (which proves the ctx.appId is trusted);
 // here we prove the app-data layer itself keys on that appId with no cross-bleed.
+// Declared collections go further: the owner rides in the target, so a row is stamped
+// with the live caller and a list is scoped to them — a cross-owner read is not
+// forbidden, it is unexpressible. These cases run against core's reference StoreOps,
+// the same one the conformance suite holds the real backends to.
+
+const appData = () => createAppData({ ops: memoryStoreOps(), store: memoryStore() });
+
+/** One app, one records collection, one files collection — `createAppData` reads
+ *  only `id` and `storage`, and both owners below share all three. */
+const app: AppDocument = {
+  format: VENDO_APP_FORMAT,
+  id: "app_shared",
+  name: "Shared Notes",
+  storage: {
+    // `subject` is DECLARED on purpose: it clears the runtime's own undeclared-ref
+    // guard, so the spoofing case below lands on the store's refusal and not on a
+    // shallower one that would pass whether or not the family stamps the owner.
+    notes: { about: "Notes a user writes", refs: { subject: "host.user" } },
+    attachments: { about: "Files a user attaches", kind: "files" },
+  },
+};
 
 describe("app-data isolation", () => {
   it("keeps state for app A and app B independent under the same subject", async () => {
-    const data = createAppData(memoryStore());
+    const data = appData();
     await data.setState("app_A", "user_ada", { secret: "A-data" });
     await data.setState("app_B", "user_ada", { secret: "B-data" });
 
@@ -24,7 +48,7 @@ describe("app-data isolation", () => {
   });
 
   it("keeps the same app's state independent across subjects", async () => {
-    const data = createAppData(memoryStore());
+    const data = appData();
     await data.setState("app_A", "user_ada", { note: "adas" });
     await data.setState("app_A", "user_grace", { note: "graces" });
 
@@ -35,12 +59,79 @@ describe("app-data isolation", () => {
   });
 
   it("does not let one app overwrite another app's state via a shared subject", async () => {
-    const data = createAppData(memoryStore());
+    const data = appData();
     await data.setState("app_A", "user_ada", { v: 1 });
     await data.setState("app_B", "user_ada", { v: 2 });
     // Rewriting B must not touch A.
     await data.setState("app_B", "user_ada", { v: 3 });
     expect(await data.getState("app_A", "user_ada")).toEqual({ v: 1 });
     expect(await data.getState("app_B", "user_ada")).toEqual({ v: 3 });
+  });
+
+  it("lists only the caller's own rows when two owners share an app collection", async () => {
+    const data = appData();
+    await data.records(app, "notes", "user_ada").put({ id: "note_ada", data: { body: "adas" } });
+    await data.records(app, "notes", "user_grace").put({ id: "note_grace", data: { body: "graces" } });
+
+    const ada = await data.records(app, "notes", "user_ada").list();
+    const grace = await data.records(app, "notes", "user_grace").list();
+    expect(ada.records.map((record) => record.id)).toEqual(["note_ada"]);
+    expect(grace.records.map((record) => record.id)).toEqual(["note_grace"]);
+
+    // An id another owner already holds is refused, never quietly taken over.
+    await expect(data.records(app, "notes", "user_grace").put({
+      id: "note_ada",
+      data: { body: "stolen" },
+    })).rejects.toMatchObject({ code: "conflict" });
+  });
+
+  it("returns null for a get of another owner's row in the same collection", async () => {
+    const data = appData();
+    await data.records(app, "notes", "user_ada").put({ id: "secret", data: { body: "adas secret" } });
+
+    expect(await data.records(app, "notes", "user_grace").get("secret")).toBeNull();
+    // The owner's own read lands, so the null above cannot come from a wrong collection or id.
+    expect(await data.records(app, "notes", "user_ada").get("secret")).toMatchObject({
+      id: "secret",
+      data: { body: "adas secret" },
+    });
+  });
+
+  it("makes a delete of another owner's row a no-op", async () => {
+    const data = appData();
+    await data.records(app, "notes", "user_ada").put({ id: "keep", data: { body: "adas" } });
+
+    await data.records(app, "notes", "user_grace").delete("keep");
+    expect(await data.records(app, "notes", "user_ada").get("keep")).toMatchObject({ id: "keep" });
+
+    // The same call from the owner does delete, so "delete never works" cannot pass here.
+    await data.records(app, "notes", "user_ada").delete("keep");
+    expect(await data.records(app, "notes", "user_ada").get("keep")).toBeNull();
+  });
+
+  it("refuses a caller-supplied refs.subject instead of stamping it", async () => {
+    const data = appData();
+
+    await expect(data.records(app, "notes", "user_ada").put({
+      id: "spoofed",
+      data: { body: "for grace" },
+      refs: { subject: "user_grace" },
+    })).rejects.toMatchObject({ code: "validation" });
+
+    expect(await data.records(app, "notes", "user_ada").get("spoofed")).toBeNull();
+    expect(await data.records(app, "notes", "user_grace").get("spoofed")).toBeNull();
+  });
+
+  it("scopes a file collection to its owner for get and list alike", async () => {
+    const data = appData();
+    await data.blobs(app, "attachments", "user_ada").put(
+      "receipt.txt",
+      new TextEncoder().encode("adas receipt"),
+    );
+
+    expect(await data.blobs(app, "attachments", "user_grace").get("receipt.txt")).toBeNull();
+    expect(await data.blobs(app, "attachments", "user_grace").list()).toEqual([]);
+    expect(await data.blobs(app, "attachments", "user_ada").get("receipt.txt")).not.toBeNull();
+    expect(await data.blobs(app, "attachments", "user_ada").list()).toEqual(["receipt.txt"]);
   });
 });

--- a/packages/vendo/src/compose-apps.ts
+++ b/packages/vendo/src/compose-apps.ts
@@ -145,10 +145,14 @@ const machineEnvFor = (
 /** Persistence, permission and interchange: the seams the runtime reads and
  *  writes THROUGH. */
 const appsStoreSeams = (composition: VendoComposition, seams: AppsSeams): Partial<AppsConfig> => {
-  const { store, guard, boundTools, inference, catalog, seedBaselines, files } = composition;
+  const { store, ops, guard, boundTools, inference, catalog, seedBaselines, files } = composition;
   const { access } = seams;
   return {
     store,
+    // Adapter rule — the SAME ops surface the deployment selected, so app data
+    // lands owner-stamped through the named-operation family instead of the
+    // raw façade.
+    ops,
     guard,
     tools: boundTools,
     model: inference.agent.model,


### PR DESCRIPTION
`vendo_apps_data_list` / `_put` / `_delete` are how the embedded agent saves and reads an app's declared storage on the person's behalf. They landed in the generic `records` family, which has no answer to "whose row is this": every user of an app wrote into one flat collection, and the only thing between them was that nobody had asked.

Every one of those calls now carries `ctx.principal.subject` — the LIVE caller, off the run context, never off the tool args — into the owner-stamped `appData` family that S1 landed. `put` stamps the row, `list` ANDs the stamp into the query, `get` answers `null` for another owner's row and `delete` no-ops on one. A cross-user read is no longer forbidden; it is unexpressible. An id another owner already holds refuses with `conflict` rather than being taken over, and that refusal is surfaced honestly rather than swallowed. Declared file collections get the same treatment through the family's file twins.

`createAppData` takes `{ ops, store }` and its `records`/`blobs` take a required owner, so there is no way to reach a collection without naming whose drawer it is. `backingFor` is the one place that decides which store backs a collection, which leaves the guards exactly where they were and in the order they were: `declaredStorage` (with `state` still reserved) → `validateRecordRefs` → the 256 KB cap → put, and the 5 MB cap for blobs. `getState`/`setState` stay on the `StoreAdapter` façade over `vendo_state`, deliberately and permanently — that is out of scope here.

`AppsConfig` gains an optional `ops` slot the umbrella fills from the same `StoreOps` surface the deployment already selected. Its absence is a real answer, not a failure: `selectStoreOps` returns nothing for a store with neither its own ops nor a SQL handle, and requiring it would crash composition at boot for that store where today it refuses at the op that needed one.

## Tests

The isolation suite drops its adapter-only fake for core's reference `memoryStoreOps()` — the same implementation the conformance suite holds the real backends to — and adds five cases across the seam:

- cross-owner list blindness (both directions, on the id sets)
- a foreign `get` returns `null` while the owner's own `get` lands
- a foreign `delete` is a no-op while the owner's own `delete` works
- a spoofed `refs.subject` is refused by CODE (`validation`). The collection **declares** `subject` on purpose, so the runtime's own undeclared-ref guard is cleared and the refusal proved is the store's, not a shallower one that would pass whether or not the family stamps the owner.
- file-twin isolation across `get` and `list`

The three existing state cases are unchanged apart from the one-line factory call.

**Prove-it-can-fail:** hardcoding the owner in `createAppData`'s `records()` turned `lists only the caller's own rows when two owners share an app collection` RED with `expected [ 'note_grace', 'note_ada' ] to deeply equal [ 'note_ada' ]`, plus the foreign-`get` and foreign-`delete` cases. Restored, green.

## Known scope note

`clear` is owner-scoped, as specified — deleting an app empties the caller's drawer through the appData family. Rows belonging to other owners of the same app are reached by `lifecycle.erase({ appId })`, not by this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the agent’s data tools to owner-scoped `appData` so one user can’t read or overwrite another user’s rows. Calls now use the live caller from `ctx.principal.subject`, not tool args.

- **New Features**
  - `vendo_apps_data_list/_put/_delete` now go through `appData` with an owner: `put` stamps the subject, `list` scopes by subject, `get` returns null across owners, and `delete` is a no-op across owners.
  - If another owner already holds an id, `put` returns `conflict` instead of overwriting.
  - File collections get the same owner scoping as records.
  - Guards and limits are unchanged; app state stays on `vendo_state`.

- **Migration**
  - `createAppData` now takes `{ ops, store }`; pass your deployment’s `StoreOps` when available.
  - `records(app, name, owner)` and `blobs(app, name, owner)` now require an `owner`.
  - `AppsConfig` gains optional `ops`; composition wires it from the selected `StoreOps`.
  - No changes needed for app authors; runtime tools pass the owner automatically.

<sup>Written for commit 3f1fd1164d97075b56e35a47526677400c5ffe5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

