### PR TITLE
fix(cli): scaffolded imports resolve under pnpm; doctor names the failure (#1153)

### DIFF
--- a/docs-site/agents/verify.mdx
+++ b/docs-site/agents/verify.mdx
@@ -193,6 +193,29 @@ path prefix if it has one). The props are otherwise identical. A generated
 `vendo/vendo-root.tsx` is YOUR file now — edit it in place or fold it into your
 layout.
 
+### E-WIRE-011 {#E-WIRE-011}
+
+**Symptom:** The `vendoai` alias is installed, but `@vendoai/vendo` is not
+resolvable from the app. Every wired route answers a 500 whose page reads
+`Module not found: Can't resolve '@vendoai/vendo/server'`, and the live checks
+report the server as unreachable.
+
+**Cause:** `vendoai` is a thin alias that depends on `@vendoai/vendo`, so under
+pnpm's strict (non-flat) `node_modules` that package lives inside the alias's
+own nested resolution. Host source may only resolve its DIRECT dependencies, so
+the `@vendoai/vendo/*` imports in your wiring fail at compile time. npm and yarn
+hoist, which is why the same install works there.
+
+**Fix:** Add the package your wiring imports as a direct dependency — the
+message prints the exact command for your package manager:
+
+```bash
+pnpm add @vendoai/vendo
+```
+
+Keep the alias; both names ship the same wire, and `vendo init` performs this
+repair itself on any host where it can.
+
 ### E-CFG-001 {#E-CFG-001}
 
 **Symptom:** A required `.vendo/` file is missing; the message names it, one

--- a/packages/vendo/src/cli/doctor-codes.ts
+++ b/packages/vendo/src/cli/doctor-codes.ts
@@ -24,6 +24,7 @@ export const DOCTOR_ERROR_CODES = {
   "E-WIRE-008": "no <VendoProvider> found in an unknown-framework host's source",
   "E-WIRE-009": "detected \"use server\" actions are not registered or not wired into createVendo",
   "E-WIRE-010": "the host still names the removed <VendoRoot> (swap it for <VendoProvider>)",
+  "E-WIRE-011": "@vendoai/vendo is not resolvable from the app (a vendoai-alias-only install under pnpm)",
   "E-CFG-001": "a required .vendo/ config file is missing",
   "E-CFG-002": ".vendo/data/.gitignore is missing",
   "E-CFG-003": "the OpenAPI spec's relative server mount and VENDO_BASE_URL's path prefix disagree",

--- a/packages/vendo/src/cli/doctor-wiring-checks.ts
+++ b/packages/vendo/src/cli/doctor-wiring-checks.ts
@@ -1,6 +1,8 @@
 import { readFile } from "node:fs/promises";
 import { dirname, join, relative } from "node:path";
+import { installedVersion } from "./dep-versions.js";
 import { detectFramework, detectVendoWiring, type VendoWiring } from "./framework.js";
+import { vendoPackageInvocation } from "./provider-deps.js";
 import { importsGeneratedMap, importsSplitComposition, missingRegistrations, registrationKey, requiredServerActions, serverActionsWiring } from "./init-scaffolds.js";
 import { checkMcpBaseUrl } from "./doctor-mcp-checks.js";
 import type { DoctorRun } from "./doctor-report.js";
@@ -164,6 +166,24 @@ async function checkLegacyRoot(run: DoctorRun, legacyRoot: boolean): Promise<voi
   }
 }
 
+/** #1153: a declared dependency the host source cannot REACH. The `vendoai`
+ *  alias keeps `@vendoai/vendo` inside its own nested resolution, and under
+ *  pnpm's strict node_modules host source may only resolve its direct
+ *  dependencies — so every `@vendoai/vendo/*` import in the wiring fails at
+ *  compile time and the route answers Next's HTML error page. The live probes
+ *  can only read that as "unreachable" (E-LIVE-002 / E-AUTH-002 named none of
+ *  it), so the cause has to be named here, statically. Silent until the host
+ *  has installed at all: an empty tree is the install story, not this one. */
+async function checkVendoResolvable(run: DoctorRun): Promise<void> {
+  const { root } = run;
+  if (await installedVersion(root, "@vendoai/vendo") !== null) {
+    run.pass("wiring/vendo-resolvable", "host source can resolve @vendoai/vendo");
+  } else if (await installedVersion(root, "vendoai") !== null) {
+    run.fail("wiring/vendo-resolvable", "E-WIRE-011",
+      `the vendoai alias is installed but @vendoai/vendo is not resolvable from this app — the alias keeps its copy nested, so under pnpm every \`@vendoai/vendo/*\` import in your wiring fails to compile ("Module not found") and the route 500s before any live check can mean anything. Fix: ${await vendoPackageInvocation(root)} (keep the alias; both names ship the same wire).`);
+  }
+}
+
 /** The static half of doctor: is this host wired at all, does anything visible
  *  reach the agent, and is the dependency declared. No network. */
 export async function checkWiring(run: DoctorRun): Promise<void> {
@@ -190,4 +210,5 @@ export async function checkWiring(run: DoctorRun): Promise<void> {
 
   if (await hasDependency(root)) run.pass("wiring/dependency", "@vendoai/vendo dependency is declared");
   else run.fail("wiring/dependency", "E-WIRE-005", "@vendoai/vendo (or vendoai alias) is not declared");
+  await checkVendoResolvable(run);
 }

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -24,7 +24,7 @@ import {
   type ConfirmAuth,
   type SelectAuth,
 } from "./init-auth.js";
-import { ensureProviderDeps, ensureZodFloor, type InstallRunner } from "./provider-deps.js";
+import { ensureProviderDeps, ensureVendoPackage, ensureZodFloor, type InstallRunner } from "./provider-deps.js";
 import {
   customServerSource,
   expressServerSource,
@@ -204,6 +204,8 @@ export interface InitOptions {
   resolveCredential?: (options: { env: Record<string, string | undefined> }) => Promise<DevCredential>;
   /** Test seam: the provider-dependency install subprocess (provider-deps.ts). */
   installProvider?: InstallRunner;
+  /** Test seam: the `@vendoai/vendo` install subprocess (#1153). */
+  installVendo?: InstallRunner;
   /** Test seam: the zod-floor bump confirm (provider-deps.ts, FINDINGS F2),
       asked only in interactive runs. Mirrors the auth confirm's shape. */
   confirmZodBump?: (question: string, defaultYes: boolean) => Promise<boolean>;
@@ -1525,8 +1527,8 @@ async function runInstallSyncFlow(input: {
   });
 }
 
-/** The two dependency repairs a fresh install owes the host, both degrading to
- *  a printed command rather than failing the run. */
+/** The three dependency repairs a fresh install owes the host, each degrading
+ *  to a printed command rather than failing the run. */
 async function ensureHostDeps(input: {
   root: string;
   output: Output;
@@ -1536,6 +1538,15 @@ async function ensureHostDeps(input: {
   credential: DevCredential;
 }): Promise<void> {
   const { root, output, options, pretty, interactive, credential } = input;
+  // #1153: the scaffolds this run wrote import `@vendoai/vendo/*`, and a host
+  // installed under the `vendoai` alias alone cannot resolve them under pnpm's
+  // strict node_modules — the route fails to COMPILE and every request 500s.
+  await ensureVendoPackage({
+    root,
+    output,
+    ...(options.installVendo === undefined ? {} : { run: options.installVendo }),
+  });
+
   // The credential's runtime provider must be resolvable from the host or
   // the FIRST turn 500s (dev-creds/model.ts loads it host-side; nothing
   // declares @ai-sdk/* — 0.4.1 E2E cert finding). Install exactly what the

--- a/packages/vendo/src/cli/provider-deps.ts
+++ b/packages/vendo/src/cli/provider-deps.ts
@@ -3,7 +3,7 @@ import { readFile } from "node:fs/promises";
 import { dirname, join, relative, resolve, sep } from "node:path";
 import type { DevCredential, EnvKeyProvider } from "../dev-creds/resolve.js";
 import { installedVersion, installedZodVersion } from "./dep-versions.js";
-import type { Output } from "./shared.js";
+import { CLI_VERSION, type Output } from "./shared.js";
 
 /**
  * The starter model ladder resolves its provider from the HOST's
@@ -227,6 +227,49 @@ export async function ensureProviderDeps(options: EnsureProviderDepsOptions): Pr
   } else {
     options.output.error(
       `warning: could not install ${specs.join(" ")} — run \`${invocation}\` yourself before the first turn, or it fails at runtime (E-DEP-001).`,
+    );
+  }
+}
+
+/** The package every scaffold imports, pinned to the CLI that wrote them — the
+    same spec doctor's E-DEP-002 story names, so the repair can never mint the
+    split-brain install that check warns about. */
+export const VENDO_PACKAGE_SPEC = `@vendoai/vendo@${CLI_VERSION}`;
+
+/** The paste-ready `@vendoai/vendo` install for this host's package manager
+    and workspace shape — shared by init's failed-repair warning and doctor's
+    E-WIRE-011 story. */
+export async function vendoPackageInvocation(root: string): Promise<string> {
+  return invocationFor(await installCommandFor(root), [VENDO_PACKAGE_SPEC], root);
+}
+
+/**
+ * #1153: every scaffold imports `@vendoai/vendo/*`, but a host whose only
+ * direct dependency is the `vendoai` alias keeps that package inside the
+ * alias's OWN nested resolution. Under pnpm's strict node_modules host source
+ * may only resolve its direct dependencies, so the wired route never compiles
+ * ("Module not found: Can't resolve '@vendoai/vendo/server'") and every route
+ * 500s — a failure the live probes can only report as an unreachable server.
+ * Init wrote those imports, so init makes them resolvable, exactly as it does
+ * for the provider the first turn loads.
+ *
+ * Resolvability is the evidence, never package.json: a hoisting installer
+ * (npm, yarn) already satisfies the import through the alias's own dependency,
+ * and a host that has installed nothing yet is not this repair's business —
+ * its own install is the next thing to run.
+ */
+export async function ensureVendoPackage(options: { root: string; output: Output; run?: InstallRunner }): Promise<void> {
+  if (await isInstalled(options.root, "@vendoai/vendo")) return;
+  if (!(await isInstalled(options.root, "vendoai"))) return;
+
+  const install = await installCommandFor(options.root);
+  options.output.log(`Installing the package your wiring imports: ${VENDO_PACKAGE_SPEC} (${install.command})…`);
+  const code = await (options.run ?? defaultRunner)(install.command, [...install.args, VENDO_PACKAGE_SPEC], install.cwd);
+  if (code === 0) {
+    options.output.log(`Installed ${VENDO_PACKAGE_SPEC}.`);
+  } else {
+    options.output.error(
+      `warning: could not install ${VENDO_PACKAGE_SPEC} — the wiring imports @vendoai/vendo/* and the vendoai alias keeps its copy nested, so the route will not compile; run \`${await vendoPackageInvocation(options.root)}\` yourself (E-WIRE-011).`,
     );
   }
 }

--- a/packages/vendo/tests/cli/doctor-codes.test.ts
+++ b/packages/vendo/tests/cli/doctor-codes.test.ts
@@ -67,6 +67,7 @@ describe("doctor error-code registry", () => {
         "E-WIRE-008": "no <VendoProvider> found in an unknown-framework host's source",
         "E-WIRE-009": "detected "use server" actions are not registered or not wired into createVendo",
         "E-WIRE-010": "the host still names the removed <VendoRoot> (swap it for <VendoProvider>)",
+        "E-WIRE-011": "@vendoai/vendo is not resolvable from the app (a vendoai-alias-only install under pnpm)",
       }
     `);
   });

--- a/packages/vendo/tests/cli/doctor.test.ts
+++ b/packages/vendo/tests/cli/doctor.test.ts
@@ -63,6 +63,15 @@ async function healthy(base?: string): Promise<string> {
   return root;
 }
 
+/** A package the host can RESOLVE — the evidence the resolvability check reads
+    (#1153), which package.json cannot supply: a nested dependency is declared
+    by nobody the host imports from. */
+async function installedPackage(root: string, name: string): Promise<void> {
+  const dir = join(root, "node_modules", ...name.split("/"));
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, "package.json"), JSON.stringify({ name, version: CLI_VERSION }));
+}
+
 async function expressHost(wired: boolean): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), "vendo-doctor-express-"));
   cleanup.push(() => rm(root, { recursive: true, force: true }));
@@ -1117,6 +1126,32 @@ describe("vendo doctor error codes + fix_refs", () => {
     // The remediation surface is broad: wiring, config, live probes, auth, turn.
     const codes = new Set(failures.map((check) => check.error_code));
     expect(codes.size).toBeGreaterThan(4);
+  });
+
+  /** #1153: the alias-only install. `vendoai` DEPENDS on @vendoai/vendo, so
+      under pnpm's strict node_modules the host cannot resolve the
+      `@vendoai/vendo/*` imports its own wiring makes: the route fails to
+      compile, every request 500s with an HTML error page, and the live probes
+      can only call that "unreachable" (E-LIVE-002 / E-AUTH-002 name none of
+      it). The static check is where the cause gets named. */
+  it("names the unresolvable @vendoai/vendo behind a vendoai-alias-only install", async () => {
+    const root = await healthy();
+    await installedPackage(root, "vendoai");
+    const { exit, report } = await jsonChecks({ targetDir: root, fetchImpl: successfulProbeFetch() });
+    const check = report.checks.find((candidate) => candidate.id === "wiring/vendo-resolvable");
+    expect(check?.status).toBe("broken");
+    expect(check?.error_code).toBe("E-WIRE-011");
+    expect(check?.message).toContain("@vendoai/vendo is not resolvable");
+    expect(exit).toBe(1);
+  });
+
+  it("passes resolvability once @vendoai/vendo is reachable from the app", async () => {
+    const root = await healthy();
+    await installedPackage(root, "vendoai");
+    await installedPackage(root, "@vendoai/vendo");
+    const { exit, report } = await jsonChecks({ targetDir: root, fetchImpl: successfulProbeFetch() });
+    expect(report.checks.find((candidate) => candidate.id === "wiring/vendo-resolvable")?.status).toBe("ok");
+    expect(exit).toBe(0);
   });
 
   it("keeps passing checks lean: id always, no error_code or fix_ref", async () => {

--- a/packages/vendo/tests/cli/init.test.ts
+++ b/packages/vendo/tests/cli/init.test.ts
@@ -8,7 +8,7 @@ import { createStore } from "@vendoai/store";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ExtractionHarness } from "../../src/cli/extract/harness.js";
 import { runInit } from "../../src/cli/init.js";
-import type { Output } from "../../src/cli/shared.js";
+import { CLI_VERSION, type Output } from "../../src/cli/shared.js";
 
 const cleanup: string[] = [];
 
@@ -1495,6 +1495,30 @@ describe("vendo init (zero-question)", () => {
     expect(sink.errors.join("\n")).not.toContain("not usable");
   });
 
+
+  /** #1153: init writes `@vendoai/vendo/*` imports into the route it just
+      created, so it owes the host a resolvable @vendoai/vendo. A host that
+      installed only the `vendoai` alias keeps that package inside the alias's
+      own nested resolution — under pnpm the route never compiles and every
+      wired request 500s, which doctor's live probes could only report as an
+      unreachable server. */
+  it("adds @vendoai/vendo when the host installed only the vendoai alias", async () => {
+    const root = await fixture();
+    await mkdir(join(root, "node_modules", "vendoai"), { recursive: true });
+    await writeFile(join(root, "node_modules", "vendoai", "package.json"),
+      JSON.stringify({ name: "vendoai", version: CLI_VERSION }));
+    const installs: Array<{ command: string; args: string[] }> = [];
+    const sink = output();
+    expect(await run(root, sink, {
+      installVendo: async (command, args) => {
+        installs.push({ command, args });
+        return 0;
+      },
+    })).toBe(0);
+    expect(installs).toEqual([{ command: "npm", args: ["install", `@vendoai/vendo@${CLI_VERSION}`] }]);
+    expect(await readFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts"), "utf8"))
+      .toContain(`from "@vendoai/vendo/server"`);
+  });
 
   it("emits a read-only agent plan with code changes, extraction, and the layout mount", async () => {
     const root = await fixture();

--- a/packages/vendo/tests/cli/provider-deps.test.ts
+++ b/packages/vendo/tests/cli/provider-deps.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { ensureProviderDeps, ensureZodFloor, installCommandFor, providerModuleFor, zodBelowAiSdkFloor, ZOD_FLOOR_SPEC } from "../../src/cli/provider-deps.js";
+import { ensureProviderDeps, ensureVendoPackage, ensureZodFloor, installCommandFor, providerModuleFor, VENDO_PACKAGE_SPEC, zodBelowAiSdkFloor, ZOD_FLOOR_SPEC } from "../../src/cli/provider-deps.js";
 
 // Init installs the provider module the resolved credential loads at
 // runtime (0.4.1 E2E cert finding: nothing declares @ai-sdk/*, so a fresh
@@ -220,6 +220,61 @@ describe("ensureProviderDeps", () => {
     });
     expect(messages.errors.join("\n")).toContain("npm install ai@^6 @ai-sdk/anthropic@^3");
     expect(messages.errors.join("\n")).toContain("E-DEP-001");
+  });
+});
+
+/** #1153: `vendoai` is a thin alias that DEPENDS on @vendoai/vendo, so under
+ *  pnpm's strict node_modules that package sits inside the alias's own nested
+ *  resolution and the host cannot resolve the `@vendoai/vendo/*` imports every
+ *  scaffold writes — the wired route fails to compile and 500s. */
+describe("ensureVendoPackage", () => {
+  it("adds the package the wiring imports when only the alias resolves", async () => {
+    const root = await tempRoot();
+    await installModule(root, "vendoai");
+    await writeFile(join(root, "pnpm-lock.yaml"), "");
+    const calls: Array<{ command: string; args: string[]; cwd: string }> = [];
+    const messages = output();
+    await ensureVendoPackage({
+      root,
+      output: messages.sink,
+      run: async (command, args, cwd) => {
+        calls.push({ command, args, cwd });
+        return 0;
+      },
+    });
+    expect(calls).toEqual([{ command: "pnpm", args: ["add", VENDO_PACKAGE_SPEC], cwd: root }]);
+    expect(messages.logs.join("\n")).toContain(`Installed ${VENDO_PACKAGE_SPEC}.`);
+    expect(messages.errors).toEqual([]);
+  });
+
+  it("stays quiet when the host can already resolve @vendoai/vendo (a hoisted or direct install)", async () => {
+    const root = await tempRoot();
+    await installModule(root, "vendoai");
+    await installModule(root, "@vendoai/vendo");
+    const calls: unknown[] = [];
+    const messages = output();
+    await ensureVendoPackage({ root, output: messages.sink, run: async (...call) => (calls.push(call), 0) });
+    expect(calls).toEqual([]);
+    expect(messages.logs).toEqual([]);
+  });
+
+  it("is not the repair for a host that has installed nothing yet", async () => {
+    const root = await tempRoot();
+    const calls: unknown[] = [];
+    const messages = output();
+    await ensureVendoPackage({ root, output: messages.sink, run: async (...call) => (calls.push(call), 0) });
+    expect(calls).toEqual([]);
+    expect(messages.logs).toEqual([]);
+  });
+
+  it("degrades to the exact manual command when the install fails, never throws", async () => {
+    const root = await tempRoot();
+    await installModule(root, "vendoai");
+    await writeFile(join(root, "pnpm-lock.yaml"), "");
+    const messages = output();
+    await ensureVendoPackage({ root, output: messages.sink, run: async () => null });
+    expect(messages.errors.join("\n")).toContain(`pnpm add ${VENDO_PACKAGE_SPEC}`);
+    expect(messages.errors.join("\n")).toContain("E-WIRE-011");
   });
 });
 


### PR DESCRIPTION
Fixes #1153

## What was broken

A host that installs only the `vendoai` alias (the playbook's step 3) gets a
scaffold full of `@vendoai/vendo/*` imports it cannot resolve: `vendoai`
*depends on* `@vendoai/vendo`, so under pnpm's strict (non-flat)
`node_modules` that package lives inside the alias's own nested resolution and
host source may only reach its DIRECT dependencies. The wired route never
compiles — `Module not found: Can't resolve '@vendoai/vendo/server'` — and
every wired route 500s. Doctor's live probes could only read that HTML error
page as "unreachable" (`E-LIVE-002` / `E-AUTH-002`), so the four failures it
reported named none of the cause. Reproduced 3/3 in the recorded e2e walk.

## The fix

**Init makes the imports it wrote resolvable.** `ensureVendoPackage`
(`packages/vendo/src/cli/provider-deps.ts`) adds
`@vendoai/vendo@<cli version>` — the same pin `E-DEP-002` names, so the repair
can't mint the split-brain install that check warns about — beside the
existing provider and zod repairs in `ensureHostDeps`. It degrades to the
exact manual command instead of failing the run, exactly like its two
neighbours. Resolvability is the evidence, never `package.json`: a hoisting
installer (npm, yarn) already satisfies the import through the alias, and a
host that has installed nothing yet is not this repair's business.

This fixes the whole surface, not just the files init writes — the `vendoai`
alias does not even export `./mastra` or `./ai-sdk`, so rewriting scaffold
specifiers to follow the installed name would have left the framework
integration pastes (and every `@vendoai/vendo/*` line copied out of the docs)
still broken.

**Doctor names the failure statically:** new `E-WIRE-011` on check
`wiring/vendo-resolvable` — the alias resolves, `@vendoai/vendo` does not —
with the paste-ready command for the host's own package manager. Silent on a
host that has installed nothing (that is the install story, not this one).
Codes stay append-only; `docs-site/agents/verify.mdx` gains the matching
anchored section.

The `#879` half of the issue (live probes discarding the parsed error body)
is untouched and stays open.

## Fail-first proof

Regression tests: `ensureVendoPackage` (4, provider-deps), `E-WIRE-011` fires
and passes (2, doctor), and init's own repair through the `installVendo` seam
(1, init).

**Red — fix reverted (`git stash push -- packages/vendo/src docs-site`), tests kept:**

```
 FAIL  tests/cli/provider-deps.test.ts > ensureVendoPackage > adds the package the wiring imports when only the alias resolves
TypeError: (0 , ensureVendoPackage) is not a function

 FAIL  tests/cli/doctor.test.ts > vendo doctor error codes + fix_refs > names the unresolvable @vendoai/vendo behind a vendoai-alias-only install
AssertionError: expected undefined to be 'broken' // Object.is equality
- Expected: "broken"
+ Received: undefined

 FAIL  tests/cli/init.test.ts > vendo init (zero-question) > adds @vendoai/vendo when the host installed only the vendoai alias
AssertionError: expected [] to deeply equal [ { command: 'npm', args: [ …(2) ] } ]
- [ { "args": [ "install", "@vendoai/vendo@0.10.0" ], "command": "npm" } ]
+ []

 Test Files  4 failed (4)
      Tests  8 failed | 221 passed (229)
```

**Green — fix restored:**

```
 ✓ tests/cli/doctor.test.ts (102 tests) 658ms
 ✓ tests/cli/provider-deps.test.ts (31 tests) 48ms
 ✓ tests/cli/doctor-codes.test.ts (4 tests) 6ms
 ✓ tests/cli/init.test.ts (92 tests) 8297ms
 ✓ tests/cli/doctor-codes.docs.test.ts (1 test) 3ms

 Test Files  5 passed (5)
      Tests  230 passed (230)
```

## Gate

`pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint` on the
touched scope, foreground, exit 0:

```
 Tasks:    21 successful, 21 total     (build)
 Tasks:    31 successful, 31 total     (test:affected, 4m28s)
 Tasks:    42 successful, 42 total     (typecheck)
 Tasks:    4 successful, 4 total       (lint)
```

No UI surface is touched.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures scaffolded `@vendoai/vendo/*` imports resolve under pnpm when only the `vendoai` alias is installed, and adds a doctor check to name the failure with a clear fix. Prevents wired routes from failing to compile and returning 500s.

- **Bug Fixes**
  - Init: adds `@vendoai/vendo@<cli version>` via `ensureVendoPackage` when only `vendoai` is present; falls back to printing the exact install command if the subprocess fails.
  - Doctor: new `E-WIRE-011` on `wiring/vendo-resolvable` when `@vendoai/vendo` isn’t reachable but `vendoai` is; includes a paste-ready command for the host’s package manager.
  - Docs: added E-WIRE-011 troubleshooting section.

<sup>Written for commit 616e6684bfabb1388cf9f76f3a26400e5fdb5ef9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

