### PR TITLE
feat(cli): the banner arrival plays; the spinner survives the slow phases; walk residuals

### DIFF
--- a/docs-site/reference/cli.mdx
+++ b/docs-site/reference/cli.mdx
@@ -42,7 +42,6 @@ ONE STEP LEFT — paste this yourself (init never edits your files)
 
   <VendoProvider> is what the @vendoai/ui hooks and embeds read — until this
   lands, Vendo is wired but nothing on the page can reach it.
-  Then confirm it landed: npx vendo doctor
 ────────────────────────────────────────────────────────────────
 ```
 

--- a/packages/vendo/src/cli/banner.ts
+++ b/packages/vendo/src/cli/banner.ts
@@ -184,19 +184,35 @@ export function bannerColorMode(
  * alternate screen buffer — the settled banner stays in the scrollback as the
  * top of the transcript. A resize mid-play costs one ragged frame, then the
  * settled one.
+ *
+ * `signal` cuts it short, and the settled frame is drawn INSIDE abort() —
+ * synchronously, before abort() returns — so a caller that needs the screen
+ * mid-arrival prints its next line under the finished mark and never on top of
+ * a half-drawn one. That is what lets the arrival play over work the run was
+ * doing anyway without ever delaying a line.
  */
 export async function playBanner(
   write: (chunk: string) => void,
   frames: readonly string[],
   frameMs = 90,
+  signal?: AbortSignal,
 ): Promise<void> {
   const [first, ...rest] = frames;
   if (first === undefined) return;
   const rows = first.split("\n").length;
-  write(`${first}\n`);
-  for (const frame of rest) {
-    await new Promise<void>((settle) => { setTimeout(settle, frameMs); });
+  const redraw = (frame: string): void => {
     write(`${ESC}[${rows}A`);
     write(`${frame.split("\n").map((row) => `${ESC}[2K${row}`).join("\n")}\n`);
+  };
+  write(`${first}\n`);
+  let playing = true;
+  signal?.addEventListener("abort", () => {
+    if (playing) redraw(frames.at(-1)!);
+  }, { once: true });
+  for (const frame of rest) {
+    await new Promise<void>((settle) => { setTimeout(settle, frameMs); });
+    if (signal?.aborted === true) return;
+    redraw(frame);
   }
+  playing = false;
 }

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -11,7 +11,7 @@ import { AUTH_MD_URL, ensureEnvLocalIgnored, runCloudStep, upsertEnvLocal, type 
 import { runDoctor } from "./doctor.js";
 import type { InitPolishSeam } from "./init-judgment.js";
 import { planMcp, type McpPosture } from "./init-mcp.js";
-import { runSyncFlow, type SyncFlowResult } from "./sync-flow.js";
+import { rendererFlowOptions, runSyncFlow, type SyncFlowResult } from "./sync-flow.js";
 import { BRIEF_TEMPLATE } from "./extract/stages.js";
 import { ENV_KEY_VARS, resolveDevCredential, describeDevCredential, type DevCredential } from "../dev-creds/resolve.js";
 import { detectFramework, detectVendoWiring, workspaceHostCandidates, type HostFramework } from "./framework.js";
@@ -263,6 +263,33 @@ function printThemeSummary(summary: ThemeSummary, output: Output): void {
   }
   for (const error of summary.errors) output.error(`warning: ${error}`);
   output.log("Theme lives in .vendo/theme.json — edit it anytime; it is the source of truth.");
+}
+
+/** The model writes these notes, at whatever length it likes, in its own first
+    person — one ran to ~450 characters. On the rail the whole thing is a dim
+    hint, so the FIRST sentence is the share that earns the space: it is the
+    reading it chose, and the rest is the alternative it rejected (#1165). */
+export function firstSentence(note: string): string {
+  const end = /[.;](?:\s|$)/.exec(note);
+  const head = (end === null ? note : note.slice(0, end.index)).trim();
+  return head.length > 160 ? `${head.slice(0, 159).trimEnd()}…` : head;
+}
+
+/** The same review on the rail: a `◇` question per slot, the model's reasoning
+    as a dim hint under it, and the `●` receipt — instead of a 450-character
+    unstyled line at column 0, the one place the rail used to die (#1165). */
+export function prettyThemeReview(pretty: Pick<PrettyOutput, "text">) {
+  return async (summary: ThemeSummary): Promise<Record<string, string>> => {
+    const overrides: Record<string, string> = {};
+    for (const { slot, note } of summary.uncertain) {
+      const answer = await pretty.text(
+        `Theme ${slot} is uncertain — extracted ${summary.slots[slot]}. Replacement value, or Enter to keep`,
+        firstSentence(note),
+      );
+      if (answer !== "") overrides[slot] = answer;
+    }
+    return overrides;
+  };
 }
 
 /** Interactive review of model-flagged uncertain slots (the ONLY theme question). */
@@ -1231,8 +1258,9 @@ async function finalizeTheme(input: {
   themePath: string;
   options: InitOptions;
   output: Output;
+  pretty: PrettyOutput | null;
 }): Promise<void> {
-  const { themeSummary, themeDraft, themePath, options, output } = input;
+  const { themeSummary, themeDraft, themePath, options, pretty, output } = input;
   const summary = themeDraft === null ? themeSummary : applyThemeDraft(themeSummary, themeDraft);
   // --theme answers land first; the review prompt then covers only the
   // uncertain slots the flags left unanswered (non-interactive runs keep
@@ -1240,7 +1268,9 @@ async function finalizeTheme(input: {
   const answers: Record<string, string> = { ...(options.themeAnswers ?? {}) };
   const unanswered = summary.uncertain.filter((entry) => !Object.hasOwn(answers, entry.slot));
   if (unanswered.length > 0 && options.yes !== true) {
-    const reviewed = await (options.themeReview ?? defaultThemeReview)(
+    const review = options.themeReview
+      ?? (pretty === null ? defaultThemeReview : prettyThemeReview(pretty));
+    const reviewed = await review(
       unanswered.length === summary.uncertain.length ? summary : { ...summary, uncertain: unanswered },
     );
     for (const [slot, raw] of Object.entries(reviewed)) {
@@ -1276,7 +1306,9 @@ function printClosingSteps(input: {
       for (const line of step.lines) output.log(`    ${line}`);
       output.log(`\n  ${step.why}`);
     }
-    output.log("  Then confirm it landed: npx vendo doctor");
+    // No `Then confirm it landed: npx vendo doctor` here: the ending below
+    // already names doctor, six lines down, and saying it twice is the
+    // duplication the redesign set out to remove (#1164).
     output.log(rule);
   }
   // Express and custom hosts have no single host file to name, so their
@@ -1517,7 +1549,10 @@ async function runInstallSyncFlow(input: {
     ...(ai === undefined ? {} : { ai }),
     ...(options.force === true ? { force: true } : {}),
     ...(engine === undefined ? {} : { engine }),
-    ...(pretty === null ? {} : { confirm: pretty.confirm, choose: pretty.select }),
+    // The questions AND the spinner, in the one spelling sync uses: passing
+    // only the questions is what left every slow phase of an install frozen
+    // (#1163).
+    ...rendererFlowOptions(pretty),
     ...(extract.choose === undefined ? {} : { choose: extract.choose }),
     judge: {
       ...(extract.harnesses === undefined ? {} : { harnesses: extract.harnesses }),
@@ -1687,7 +1722,15 @@ export async function runInit(options: InitOptions): Promise<number> {
 
   // The read-back first: every fact below is already detected for other
   // reasons, and showing it is the moment the tool proves it looked.
-  if (pretty !== null) pretty.block("Your stack", await stackLines(root, await resolveFramework(root, options)));
+  if (pretty !== null) {
+    // Detect FIRST, print second: the banner's arrival plays over this work.
+    // It reads a handful of files, though, so the arrival is the longer of the
+    // two — awaiting the remainder is what makes it an arrival instead of a
+    // flash, and it is bounded by the frame budget (~1.3s), not by this run.
+    const stack = await stackLines(root, await resolveFramework(root, options));
+    await pretty.arrived;
+    pretty.block("Your stack", stack);
+  }
   const useCase = await resolveUseCase({ options, pretty, interactive });
 
   // (No stdin-TTY guard on these defaults: an unshown auth confirm resolving
@@ -1773,7 +1816,7 @@ export async function runInit(options: InitOptions): Promise<number> {
     // finally the uncertain-slot review. Skipped entirely when theme.json
     // pre-existed this run (the flow reconciles that one instead).
     if (themeSummary !== null) {
-      await finalizeTheme({ themeSummary, themeDraft: flow.themeDraft, themePath, options, output });
+      await finalizeTheme({ themeSummary, themeDraft: flow.themeDraft, themePath, options, output, pretty });
     }
 
     // Judgment state, one line: a pass that ran already narrated itself (it

--- a/packages/vendo/src/cli/pretty.ts
+++ b/packages/vendo/src/cli/pretty.ts
@@ -1,7 +1,7 @@
 import { stdin, stdout } from "node:process";
 import { createInterface } from "node:readline/promises";
 import { Writable } from "node:stream";
-import { BANNER_COMPACT, BANNER_TAGLINE, bannerColorMode, renderBanner } from "./banner.js";
+import { BANNER_COMPACT, BANNER_CONCEPT, BANNER_TAGLINE, bannerColorMode, bannerFrames, playBanner, type BannerColorMode } from "./banner.js";
 import type { Output } from "./shared.js";
 
 /**
@@ -32,9 +32,12 @@ const dim = style("2", "22");
 const red = style("31", "39");
 const green = style("32", "39");
 const yellow = style("33", "39");
-/** The accent — brand lilac. Truecolor terminals get the real ramp in the
-    banner; the rail's markers stay ANSI so they follow the user's theme. */
-const lilac = style("95", "39");
+/** The accent — brand lilac, the colour the banner's ramp ends on. A truecolor
+    terminal gets the real `#a78bfa`, so the rail matches the mark above it
+    instead of sitting a shade off in ANSI magenta (#1166); everything else
+    keeps bright magenta, which is what the fallback was always for. */
+const accentStyle = (mode: BannerColorMode): ((text: string) => string) =>
+  style(mode === "truecolor" ? "38;2;167;139;250" : "95", "39");
 /** Re-arm sequences for the two colors that can wrap a whole line. */
 const REOPEN_YELLOW = `${ESC}[33m`;
 const REOPEN_RED = `${ESC}[31m`;
@@ -95,6 +98,11 @@ export interface PrettyOutput extends Output {
       `stats` is the dim tail that says what the run actually achieved, and a
       dim star line closes the run. */
   done(durationMs: number, ok: boolean, stats?: string): void;
+  /** Settles when the banner has finished arriving. Printing never waits on it
+      — the first line cuts the arrival to the settled mark — so this is for the
+      one caller that wants the arrival SEEN: it awaits whatever is left of it
+      after its own detection work, and pays nothing it did not already spend. */
+  arrived: Promise<void>;
 }
 
 const FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
@@ -152,13 +160,18 @@ function judgmentTally(text: string): string | null {
 const PASTE_RULE = "─".repeat(64);
 const PASTE_HEAD = /^(ONE|\d+) STEPS? LEFT — paste th(?:is|ese) yourself \((.+)\)$/;
 const PASTE_FILE = /^ {2}File: (.+)$/;
-/** The mount snippet elides the child expression, and it genuinely differs by
-    router — `{children}` in an app-router layout, `<Component {...pageProps} />`
-    in a pages `_app` — so the block owes the exact per-router wording. This
-    pointer is the renderer's and not the caller's: init's `mount.lines` is
+/** The caller's one-line wrap instruction — `… then wrap: <VendoProvider …>
+    {children}</VendoProvider>` — destructured so the block can print the real
+    JSX instead of the prose: the open tag, a dim `…` for the app tree that is
+    already there, the close tag. The children capture is deliberately dropped;
+    the child expression genuinely differs by router (`{children}` in an
+    app-router layout, `<Component {...pageProps} />` in a pages `_app`), so one
+    literal in the terminal would be wrong for half of hosts and the docs
+    pointer below carries the exact per-router wording instead. */
+const MOUNT_WRAP = /^… then wrap: (<VendoProvider\b[^>]*>).*<\/VendoProvider>$/;
+/** This pointer is the renderer's and not the caller's: init's `mount.lines` is
     pinned byte-for-byte by the --agent plan, and a line added there would
     change that JSON. Emitted here, the --agent path never sees it. */
-const MOUNT_WRAP = "… then wrap: <VendoProvider";
 const MOUNT_DOCS = "docs.vendo.run/quickstart#the-client-mount — exact wording for layout.tsx and _app.tsx";
 const WIRED = /^(Wired \(\d+ files?\)):$/;
 const DIFF_MARKER = /^ {2}([+~]) (.+)$/;
@@ -183,8 +196,8 @@ const CTA_ALL = /`?vendo (cloud )?login`?/g;
 /** Inline `code spans` in the accent color. The span's close resets the
     foreground to default, so a span inside a colored line bleaches everything
     after it — `reopen` re-arms the enclosing color (error() passes it). */
-function styleInline(text: string, reopen = ""): string {
-  return text.replace(/`([^`]+)`/g, (_match, code: string) => `${bold(lilac(code))}${reopen}`);
+function styleInline(text: string, accent: (text: string) => string, reopen = ""): string {
+  return text.replace(/`([^`]+)`/g, (_match, code: string) => `${bold(accent(code))}${reopen}`);
 }
 
 /** Invisible code points: combining marks (Mn/Me — the accent in a decomposed
@@ -426,11 +439,14 @@ export async function plainSecret(
   }
 }
 
-/** What the string rules below are allowed to draw on. */
+/** What the string rules below are allowed to draw on. The accent rides the
+    rail rather than sitting in a module constant, because which purple it is
+    depends on the terminal this renderer was built for. */
 interface Rail {
   bar(): void;
   body(text: string, reopen?: string): void;
   section(marker: string, title: string): void;
+  accent(text: string): string;
 }
 
 /** What a collapse rule is still holding, and how much leading indent the rail
@@ -450,7 +466,7 @@ function flushCatalog(state: RenderState, rail: Rail): void {
   if (state.catalog.length === 0) return;
   const lines = state.catalog;
   state.catalog = [];
-  rail.section(lilac("◆"), bold("Catalog"));
+  rail.section(rail.accent("◆"), bold("Catalog"));
   const counts = lines.filter((entry) => !entry.startsWith(CATALOG_COMPONENTS));
   if (counts.length > 0) rail.body(counts.join(" · "));
   for (const entry of lines.filter((line) => line.startsWith(CATALOG_COMPONENTS))) rail.body(entry);
@@ -460,7 +476,7 @@ function flushImpact(state: RenderState, rail: Rail): void {
   if (state.impact.length === 0) return;
   const lines = state.impact;
   state.impact = [];
-  rail.section(lilac("◇"), bold("Impact"));
+  rail.section(rail.accent("◇"), bold("Impact"));
   for (const entry of lines) {
     const breaks = IMPACT_BREAKS.exec(entry);
     rail.body(breaks === null ? entry : `${breaks[1]!}${bold(breaks[2]!)}`);
@@ -471,7 +487,7 @@ function flushJudgment(state: RenderState, rail: Rail): void {
   if (state.judgment === null) return;
   const { summary, details } = state.judgment;
   state.judgment = null;
-  rail.section(lilac("◆"), bold("Judgment"));
+  rail.section(rail.accent("◆"), bold("Judgment"));
   // Three populations at one indent: the tallies, the one line that needs the
   // user, and the model's prose. Only tallies join the summary — splitting a
   // sentence on ": " both put free-text in a counts line and cut it mid-token.
@@ -519,27 +535,27 @@ function brandLine(palette: string): string {
 function renderNamed(raw: string, rail: Rail): boolean {
   const wired = WIRED.exec(raw);
   if (wired !== null) {
-    rail.section(lilac("◆"), bold(wired[1]!));
+    rail.section(rail.accent("◆"), bold(wired[1]!));
     return true;
   }
   if (raw === "Already wired — nothing to change.") {
-    rail.section(lilac("◇"), `${bold("Already wired")} — nothing to change`);
+    rail.section(rail.accent("◇"), `${bold("Already wired")} — nothing to change`);
     return true;
   }
   const marker = DIFF_MARKER.exec(raw);
   if (marker !== null) {
-    rail.body(`${marker[1] === "+" ? green("+") : yellow("~")} ${dim(lilac(marker[2]!))}`);
+    rail.body(`${marker[1] === "+" ? green("+") : yellow("~")} ${dim(rail.accent(marker[2]!))}`);
     return true;
   }
   const theme = THEME.exec(raw);
   if (theme !== null) {
-    rail.section(lilac("◆"), bold("Your brand, captured"));
+    rail.section(rail.accent("◆"), bold("Your brand, captured"));
     rail.body(brandLine(theme[1]!));
     return true;
   }
   const syncTheme = SYNC_THEME.exec(raw);
   if (syncTheme !== null) {
-    rail.section(lilac("◇"), bold("Theme"));
+    rail.section(rail.accent("◇"), bold("Theme"));
     rail.body(syncTheme[1]!);
     return true;
   }
@@ -548,7 +564,7 @@ function renderNamed(raw: string, rail: Rail): boolean {
     return true;
   }
   if (raw === "Last steps are yours:") {
-    rail.section(lilac("◇"), bold("Last steps are yours"));
+    rail.section(rail.accent("◇"), bold("Last steps are yours"));
     return true;
   }
   return renderCloud(raw, rail);
@@ -558,14 +574,14 @@ function renderNamed(raw: string, rail: Rail): boolean {
 function renderCloud(raw: string, rail: Rail): boolean {
   const absent = CLOUD_ABSENT.exec(raw);
   if (absent !== null) {
-    rail.section(lilac("◆"), bold(lilac("Vendo Cloud")));
-    for (const bullet of absent[1]!.split("; ")) rail.body(`${lilac("✦")} ${lilac(bullet)}`);
+    rail.section(rail.accent("◆"), bold(rail.accent("Vendo Cloud")));
+    for (const bullet of absent[1]!.split("; ")) rail.body(`${rail.accent("✦")} ${rail.accent(bullet)}`);
     return true;
   }
   const present = CLOUD_PRESENT.exec(raw);
   if (present !== null) {
-    rail.section(lilac("◆"), bold(lilac("Vendo Cloud")));
-    rail.body(`${lilac("✦")} ${lilac(present[1]!)}`);
+    rail.section(rail.accent("◆"), bold(rail.accent("Vendo Cloud")));
+    rail.body(`${rail.accent("✦")} ${rail.accent(present[1]!)}`);
     return true;
   }
   return false;
@@ -581,8 +597,8 @@ function renderIndented(raw: string, state: RenderState, rail: Rail): void {
   const keep = " ".repeat(Math.max(0, indent - state.absorb));
   if (indent === 0) state.absorb = 0;
   if (CTA.test(rest)) {
-    const cta = rest.replace(CTA_ALL, (match) => bold(lilac(match.replaceAll("`", ""))));
-    rail.body(`${keep}${bold(lilac("→"))} ${cta}`);
+    const cta = rest.replace(CTA_ALL, (match) => bold(rail.accent(match.replaceAll("`", ""))));
+    rail.body(`${keep}${bold(rail.accent("→"))} ${cta}`);
     return;
   }
   rail.body(`${keep}${rest}`);
@@ -609,18 +625,24 @@ function renderPaste(raw: string, state: RenderState, rail: Rail): void {
     if (open.titled) rail.bar();
     else {
       open.titled = true;
-      rail.section(lilac("◇"), bold(open.count === 1 ? `One paste left — ${file[1]}` : `${open.count} pastes left`));
+      rail.section(rail.accent("◇"), bold(open.count === 1 ? `One paste left — ${file[1]}` : `${open.count} pastes left`));
       if (open.count === 1) return;
     }
     rail.body(bold(file[1]!));
     return;
   }
-  renderIndented(raw, state, rail);
-  // Under the snippet it explains, at the snippet's own indent.
-  if (raw.trimStart().startsWith(MOUNT_WRAP)) {
-    const indent = raw.length - raw.trimStart().length;
-    rail.body(`${" ".repeat(Math.max(0, indent - state.absorb))}${dim(MOUNT_DOCS)}`);
+  const wrap = MOUNT_WRAP.exec(raw.trimStart());
+  if (wrap !== null) {
+    // The snippet's own indent, with the docs pointer under the JSX it explains.
+    const keep = " ".repeat(Math.max(0, raw.length - raw.trimStart().length - state.absorb));
+    rail.bar();
+    rail.body(`${keep}${wrap[1]!}`);
+    rail.body(`${keep}  ${dim("…")}`);
+    rail.body(`${keep}</VendoProvider>`);
+    rail.body(`${keep}${dim(MOUNT_DOCS)}`);
+    return;
   }
+  renderIndented(raw, state, rail);
 }
 
 function renderRaw(raw: string, state: RenderState, rail: Rail): void {
@@ -670,7 +692,7 @@ export interface PrettyOptions {
   write?: (chunk: string) => void;
   input?: SelectInput;
   promptOutput?: NodeJS.WritableStream & { isTTY?: boolean };
-  /** The settled banner above the header. */
+  /** The banner above the header — it arrives as an animation and settles. */
   banner?: boolean;
   env?: Record<string, string | undefined>;
   /** Terminal width to wrap to. Unset follows the real stdout, and an unknown
@@ -692,6 +714,9 @@ export function createPrettyOutput(options: PrettyOptions = {}): PrettyOutput {
   let timer: ReturnType<typeof setInterval> | null = null;
   let frame = 0;
   const state: RenderState = { absorb: 0, catalog: [], impact: [], judgment: null, paste: null };
+  /** Same capability probe the banner uses, so the rail and the mark above it
+      are the same purple on the same terminal. */
+  const lilac = accentStyle(bannerColorMode(env));
 
   /** True when this renderer draws on the real terminal. Only then does it
       follow stdout's width and answer the interrupt signal; an injected
@@ -716,19 +741,36 @@ export function createPrettyOutput(options: PrettyOptions = {}): PrettyOutput {
       if (!lastWasBar) line(BAR);
     },
     body: (text: string, reopen = ""): void => {
-      line(`${BAR}  ${styleInline(text, reopen)}`);
+      line(`${BAR}  ${styleInline(text, lilac, reopen)}`);
     },
     section: (marker: string, title: string): void => {
       rail.bar();
       line(`${marker}  ${title}`);
       state.absorb = 2;
     },
+    accent: lilac,
   };
+  /** The arrival, started at construction — so the frames play over the stack
+      detection the run does before its first line, and cost nothing. It is
+      never awaited: ensureHeader settles it, so the animation can only ever be
+      a faster way to arrive at the banner that printed here before. */
+  const arrival = banner ? new AbortController() : null;
+  const arrived = arrival === null
+    ? Promise.resolve()
+    : playBanner(
+      write,
+      bannerFrames(BANNER_COMPACT, bannerColorMode(env), BANNER_CONCEPT),
+      undefined,
+      arrival.signal,
+    );
   const ensureHeader = (): void => {
     if (headerPrinted) return;
     headerPrinted = true;
-    if (banner) {
-      write(`${renderBanner(BANNER_COMPACT, bannerColorMode(env))}\n\n${dim(BANNER_TAGLINE)}\n\n`);
+    // The mark is already on screen (abort settles it if it is still moving);
+    // this only adds the gap and the tagline under it.
+    if (arrival !== null) {
+      arrival.abort();
+      write(`\n${dim(BANNER_TAGLINE)}\n\n`);
     }
     line(`${dim("┌")}  ${bold(command)}`);
     line(BAR);
@@ -773,6 +815,7 @@ export function createPrettyOutput(options: PrettyOptions = {}): PrettyOutput {
   }
 
   return {
+    arrived,
     log(message) {
       clearFrame();
       ensureHeader();

--- a/packages/vendo/src/cli/sync-flow.ts
+++ b/packages/vendo/src/cli/sync-flow.ts
@@ -14,7 +14,7 @@ import type { ThemeStageInput } from "./extract/stages.js";
 import { runProseStages } from "./init-judgment.js";
 import { selectJudgmentEngines, type AvailableEngine } from "./judge/engine.js";
 import { runJudgmentPass, type JudgmentPassOptions } from "./judge/pass.js";
-import { plainSelect, type SelectOption } from "./pretty.js";
+import { plainSelect, type PrettyOutput, type SelectOption } from "./pretty.js";
 import {
   extractTheme,
   toVendoTheme,
@@ -79,6 +79,21 @@ export interface SyncFlowOptions {
   spinner?: { spin: (label: string) => void; stopSpin: () => void };
   /** Test seam: the wall-clock budget for each Cloud reconcile. */
   baselineBudgetMs?: number;
+}
+
+/** Everything a renderer contributes to a flow run: the questions AND the
+    spinner. ONE spelling for both commands on purpose — `vendo sync` passed the
+    spinner from day one and `vendo init` never did, so the slowest phases of
+    every install ran against a dead screen (#1163). A caller that overrides one
+    of these spreads its own value after this. */
+export function rendererFlowOptions(
+  pretty: Pick<PrettyOutput, "confirm" | "select" | "spin" | "stopSpin"> | null,
+): Pick<SyncFlowOptions, "confirm" | "choose" | "spinner"> {
+  return pretty === null ? {} : {
+    confirm: pretty.confirm,
+    choose: pretty.select,
+    spinner: { spin: pretty.spin, stopSpin: pretty.stopSpin },
+  };
 }
 
 /** A slow phase under the caller's spinner, when it supplied one. */
@@ -511,16 +526,23 @@ async function runGradingStages(input: {
   // The prose stages — the product brief and the theme fill — read the GRADED
   // catalog, so they run after the pass. Full mode only: `vendo sync` in
   // predev must not redraft a brief on every dev-server start.
+  //
+  // Under the spinner, and this is the phase that most needs it: the pass above
+  // answers in milliseconds when nothing changed, so its `finally` stopped the
+  // spinner right before the two model calls that own MINUTES of the run. That
+  // left the longest stretch of the install as a dead screen (#1163).
   if (mode === "full" && selection.engine !== undefined) {
-    const stages = await runProseStages({
+    const { harness } = selection.engine;
+    const tools = await exists(join(vendoDir, "tools.json"));
+    const stages = await withSpin(options.spinner, spinLabel, () => runProseStages({
       root,
       output,
       env,
-      harness: selection.engine.harness,
-      tools: await exists(join(vendoDir, "tools.json")),
+      harness,
+      tools,
       ...(options.force === true ? { force: true } : {}),
       ...(themeSummary === null ? {} : { theme: themeStageInput(themeSummary) }),
-    });
+    }));
     themeDraft = stages.theme ?? null;
   }
   return { judged, themeDraft };

--- a/packages/vendo/src/cli/sync.ts
+++ b/packages/vendo/src/cli/sync.ts
@@ -5,7 +5,7 @@ import type { ToolImpact } from "../sync-impact.js";
 import { pushSyncReport } from "./cloud/services.js";
 import type { JudgmentPassOptions } from "./judge/pass.js";
 import { createPrettyOutput, usePrettyOutput, type PrettyOutput } from "./pretty.js";
-import { runSyncFlow, type SyncFlowResult } from "./sync-flow.js";
+import { rendererFlowOptions, runSyncFlow, type SyncFlowResult } from "./sync-flow.js";
 import { applyThemeDraft, toVendoTheme } from "./theme/extract-theme.js";
 import { consoleOutput, invokedByPackageScript, withCommandRun, writeText, type Output, type TelemetryOptions } from "./shared.js";
 
@@ -223,12 +223,8 @@ async function sync(options: SyncOptions): Promise<number> {
       ...(options.url === undefined ? {} : { url: options.url }),
       ...(options.sync === undefined ? {} : { sync: options.sync }),
       ...(options.fetchImpl === undefined ? {} : { fetchImpl: options.fetchImpl }),
-      ...(options.confirm === undefined
-        ? (pretty === null ? {} : { confirm: pretty.confirm })
-        : { confirm: options.confirm }),
-      ...(pretty === null
-        ? {}
-        : { choose: pretty.select, spinner: { spin: pretty.spin, stopSpin: pretty.stopSpin } }),
+      ...rendererFlowOptions(pretty),
+      ...(options.confirm === undefined ? {} : { confirm: options.confirm }),
       ...(options.judge === undefined ? {} : { judge: options.judge }),
       ...(options.pushComponents === undefined ? {} : { pushComponents: options.pushComponents }),
       ...(options.baselineBudgetMs === undefined ? {} : { baselineBudgetMs: options.baselineBudgetMs }),

--- a/packages/vendo/tests/cli/banner.test.ts
+++ b/packages/vendo/tests/cli/banner.test.ts
@@ -123,6 +123,11 @@ describe("bannerFrames", () => {
   });
 });
 
+/** One in-place frame redraw, exactly as playBanner writes it. */
+function redraw(frame: string): string {
+  return `${ESC}[${BANNER_COMPACT.length}A${frame.split("\n").map((row) => `${ESC}[2K${row}`).join("\n")}\n`;
+}
+
 describe("playBanner", () => {
   it("redraws in place, plays once, and ends on the settled frame", async () => {
     const chunks: string[] = [];
@@ -146,5 +151,33 @@ describe("playBanner", () => {
     const chunks: string[] = [];
     await playBanner((chunk) => { chunks.push(chunk); }, [], 0);
     expect(chunks).toHaveLength(0);
+  });
+
+  it("an abort mid-arrival settles INSIDE abort(), then stops", async () => {
+    const chunks: string[] = [];
+    const frames = bannerFrames(BANNER_COMPACT, "ansi", BANNER_CONCEPT);
+    const arrival = new AbortController();
+    const played = playBanner((chunk) => { chunks.push(chunk); }, frames, 5, arrival.signal);
+    expect(chunks.join("")).toBe(`${frames[0]!}\n`);
+
+    arrival.abort();
+    // Synchronously, before abort() returned: whatever the caller prints on the
+    // very next statement lands under the FINISHED mark, never a half-drawn one.
+    expect(chunks.join("")).toBe(`${frames[0]!}\n${redraw(frames.at(-1)!)}`);
+
+    const settled = chunks.length;
+    await played;
+    await new Promise((resolve) => { setTimeout(resolve, 20); });
+    expect(chunks).toHaveLength(settled);
+  });
+
+  it("an abort after it already settled redraws nothing", async () => {
+    const chunks: string[] = [];
+    const frames = bannerFrames(BANNER_COMPACT, "ansi", BANNER_CONCEPT);
+    const arrival = new AbortController();
+    await playBanner((chunk) => { chunks.push(chunk); }, frames, 0, arrival.signal);
+    const settled = chunks.join("");
+    arrival.abort();
+    expect(chunks.join("")).toBe(settled);
   });
 });

--- a/packages/vendo/tests/cli/init.test.ts
+++ b/packages/vendo/tests/cli/init.test.ts
@@ -7,7 +7,7 @@ import { createGuard } from "@vendoai/guard";
 import { createStore } from "@vendoai/store";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ExtractionHarness } from "../../src/cli/extract/harness.js";
-import { runInit } from "../../src/cli/init.js";
+import { firstSentence, prettyThemeReview, runInit } from "../../src/cli/init.js";
 import { CLI_VERSION, type Output } from "../../src/cli/shared.js";
 
 const cleanup: string[] = [];
@@ -1673,7 +1673,10 @@ describe("the mount paste (init never edits user-authored source)", () => {
     expect(logs).toContain(`File: ${join("app", "layout.tsx")}`);
     expect(logs).toContain('import { VendoProvider } from "@vendoai/vendo/react";');
     expect(logs).toContain('<VendoProvider baseUrl="/api/vendo" theme={theme as VendoTheme}>{children}</VendoProvider>');
-    expect(logs).toContain("Then confirm it landed: npx vendo doctor");
+    // Doctor is named ONCE, at the ending — never a second time inside the
+    // paste frame (#1164).
+    expect(logs).not.toContain("Then confirm it landed: npx vendo doctor");
+    expect(logs.match(/npx vendo doctor/g)).toHaveLength(1);
     // No layout diff is even proposed.
     expect(logs).not.toContain("~ " + join("app", "layout.tsx"));
   });
@@ -2036,5 +2039,51 @@ describe("the five questions", () => {
       runCheck: async () => { throw new Error("doctor exploded"); },
     })).toBe(0);
     expect(asked).toEqual(["Start your dev server and run a live check now?"]);
+  });
+});
+
+/**
+ * #1165 — the uncertain-slot review used to hand a raw readline prompt a
+ * ~450-character string, so it landed at column 0 with no rail, no wrapping and
+ * the model's first person intact: the only place in the run where the rail
+ * died. On the rail it is a `◇` question with the reasoning as a dim hint.
+ */
+describe("the uncertain-theme-slot review", () => {
+  const NOTE = "app/page.module.css defines two neutrals: `--background: #fafafa` on the "
+    + "full-height `.page` wrapper and `--foreground: #fff` painting the `.main` content "
+    + "panel. I picked #fafafa because it is the only neutral distinct from the "
+    + "already-fixed background (#ffffff); a literal cards/panels reading of `.main` would "
+    + "instead give #ffffff, identical to background.";
+  const summary = {
+    slots: { surface: "#fafafa" },
+    uncertain: [{ slot: "surface", note: NOTE }],
+  } as unknown as Parameters<ReturnType<typeof prettyThemeReview>>[0];
+
+  it("asks through the renderer, with the model's reasoning trimmed to the reading it chose", async () => {
+    const asked: { question: string; hint?: string }[] = [];
+    const review = prettyThemeReview({
+      text: async (question: string, hint?: string) => { asked.push({ question, hint }); return ""; },
+    });
+    await expect(review(summary)).resolves.toEqual({});
+    expect(asked).toHaveLength(1);
+    expect(asked[0]!.question).toBe(
+      "Theme surface is uncertain — extracted #fafafa. Replacement value, or Enter to keep",
+    );
+    // The hint is the reading it CHOSE. The rejected alternative and the "I
+    // picked…" first person behind it are what made the line a wall.
+    expect(asked[0]!.hint!.length).toBeLessThan(NOTE.length / 2);
+    expect(asked[0]!.hint).not.toContain("I picked");
+    expect(asked[0]!.hint).toContain("app/page.module.css defines two neutrals");
+  });
+
+  it("keeps a typed replacement and treats Enter as keep", async () => {
+    await expect(prettyThemeReview({ text: async () => "#ffffff" })(summary))
+      .resolves.toEqual({ surface: "#ffffff" });
+    await expect(prettyThemeReview({ text: async () => "" })(summary)).resolves.toEqual({});
+  });
+
+  it("firstSentence caps a note that never ends a sentence", () => {
+    expect(firstSentence("x".repeat(400))).toHaveLength(160);
+    expect(firstSentence("Short and done. And more.")).toBe("Short and done");
   });
 });

--- a/packages/vendo/tests/cli/pretty.test.ts
+++ b/packages/vendo/tests/cli/pretty.test.ts
@@ -2,6 +2,7 @@ import { PassThrough, Writable } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createPrettyOutput, displayWidth, plainSelect, usePrettyOutput, type SelectInput } from "../../src/cli/pretty.js";
 import { plainSecret, plainText } from "../../src/cli/pretty.js";
+import { BANNER_COMPACT, BANNER_CONCEPT, bannerFrames } from "../../src/cli/banner.js";
 
 const ESC = "\u001b";
 
@@ -114,9 +115,88 @@ describe("createPrettyOutput (visual system)", () => {
     expect(without.plain()).not.toContain("▄▄█████▄");
   });
 
-  it("renders the wired section with colored diff markers and bar-prefixed paths", () => {
+  it("the banner ARRIVES: the flow plays in place, once, and settles into the mark", async () => {
+    vi.useFakeTimers();
+    const out = sink();
+    const frames = bannerFrames(BANNER_COMPACT, "truecolor", BANNER_CONCEPT);
+    const pretty = createPrettyOutput({ write: out.write, env: { COLORTERM: "truecolor" } });
+    // Construction starts it, so the arrival plays over the stack detection the
+    // run does before its first line. Frame one is NOT the mark yet.
+    expect(out.raw()).toBe(`${frames[0]!}\n`);
+    expect(out.plain()).not.toContain(BANNER_COMPACT.join("\n"));
+
+    await vi.advanceTimersByTimeAsync(90 * frames.length);
+    // One cursor-up redraw per frame after the first — in place, no alternate
+    // screen buffer, and it ends on the settled frame.
+    expect(out.raw().split(`${ESC}[${BANNER_COMPACT.length}A`)).toHaveLength(frames.length);
+    expect(out.raw()).not.toContain("?1049h");
+    expect(out.plain()).toContain(BANNER_COMPACT.join("\n"));
+
+    // Played once: the frames stop, and the header lands under the settled mark.
+    await pretty.arrived;
+    const settled = out.raw();
+    await vi.advanceTimersByTimeAsync(500);
+    expect(out.raw()).toBe(settled);
+    pretty.log("hello");
+    const plain = out.plain();
+    expect(plain).toContain("Customize your product with an embedded agent");
+    expect(plain.lastIndexOf(BANNER_COMPACT.join("\n"))).toBeLessThan(plain.indexOf("┌  vendo init"));
+  });
+
+  it("a line printed mid-arrival settles the mark first — the header never lands on a half-drawn one", () => {
+    const out = sink();
+    const frames = bannerFrames(BANNER_COMPACT, "truecolor", BANNER_CONCEPT);
+    const pretty = createPrettyOutput({ write: out.write, env: { COLORTERM: "truecolor" } });
+    // Not one frame has had time to tick; the run wants the screen anyway.
+    expect(out.raw()).toBe(`${frames[0]!}\n`);
+    pretty.log("hello");
+    const plain = out.plain();
+    // The mark is whole, and everything else is under it: the animation can
+    // never delay a line, and never costs one either.
+    expect(plain).toContain(BANNER_COMPACT.join("\n"));
+    expect(plain.indexOf(BANNER_COMPACT.join("\n")))
+      .toBeLessThan(plain.indexOf("Customize your product with an embedded agent"));
+    expect(plain.indexOf("Customize your product")).toBeLessThan(plain.indexOf("┌  vendo init"));
+  });
+
+  it("banner: false starts no arrival — no frames, no cursor games, and nothing to await", async () => {
     const out = sink();
     const pretty = createPrettyOutput({ write: out.write, banner: false });
+    pretty.log("hello");
+    expect(out.raw()).not.toContain(`${ESC}[${BANNER_COMPACT.length}A`);
+    await expect(pretty.arrived).resolves.toBeUndefined();
+  });
+
+  // `arrived` is what init awaits before its first block. It must settle on a
+  // run that never let the arrival finish too, or the wait becomes a hang.
+  it("arrived settles even when a line cut the arrival short", async () => {
+    vi.useFakeTimers();
+    const out = sink();
+    const pretty = createPrettyOutput({ write: out.write, env: { COLORTERM: "truecolor" } });
+    pretty.log("hello");
+    const waited = pretty.arrived;
+    await vi.advanceTimersByTimeAsync(90);
+    await expect(waited).resolves.toBeUndefined();
+  });
+
+  it.each([
+    ["non-TTY stdout", { isTTY: false }, {}],
+    ["NO_COLOR set", { isTTY: true }, { NO_COLOR: "1" }],
+    ["CI set", { isTTY: true }, { CI: "true" }],
+    ["TERM=dumb", { isTTY: true }, { TERM: "dumb" }],
+  ] as const)("never animates under %s — today's exact plain line, byte for byte", (_name, stream, env) => {
+    const out = sink();
+    const message = "Wired (1 file):";
+    if (usePrettyOutput(stream, env)) createPrettyOutput({ write: out.write, env }).log(message);
+    else out.write(`${message}\n`);
+    expect(out.raw()).toBe(`${message}\n`);
+  });
+
+  it("renders the wired section with colored diff markers and bar-prefixed paths", () => {
+    const out = sink();
+    // env pinned: the accent follows the terminal's colour depth now, so a bare
+    // process.env would make this assert whatever the machine happens to be.
+    const pretty = createPrettyOutput({ write: out.write, banner: false, env: {} });
     pretty.log("\nWired (3 files):");
     pretty.log("  + vendo/registry.tsx");
     pretty.log("  + app/api/vendo/[...vendo]/route.ts");
@@ -133,7 +213,7 @@ describe("createPrettyOutput (visual system)", () => {
 
   it("renders Vendo Cloud as the emphasized section: header, ✦ bullets, → CTA", () => {
     const out = sink();
-    const pretty = createPrettyOutput({ write: out.write, banner: false });
+    const pretty = createPrettyOutput({ write: out.write, banner: false, env: {} });
     pretty.log("\nVendo Cloud (optional): not configured. A key unlocks team sharing & org governance; hosted automations; the MCP broker.");
     pretty.log("Run `vendo login` to claim a free API key; it lands in .env.local.");
     const plain = out.plain();
@@ -147,6 +227,28 @@ describe("createPrettyOutput (visual system)", () => {
     // The header is bold + the brand accent (the most prominent block on screen).
     expect(out.raw()).toContain(`${ESC}[95mVendo Cloud${ESC}[39m`);
     expect(out.raw()).toContain(`${ESC}[1m`);
+  });
+
+  // The rail's accent shipped as ANSI magenta on every terminal while the mark
+  // right above it drew the real ramp, so the two were a shade apart (#1166).
+  it("takes the brand's truecolor accent where the terminal can show it, ANSI magenta where it cannot", () => {
+    const lines = (env: Record<string, string | undefined>): string => {
+      const out = sink();
+      const pretty = createPrettyOutput({ write: out.write, banner: false, env });
+      pretty.log("\nWired (1 file):");
+      pretty.log("  ~ package.json");
+      pretty.log("\nVendo Cloud: keyed");
+      return out.raw();
+    };
+    // #a78bfa — the colour the banner's ramp ends on, not a second purple.
+    const truecolor = lines({ COLORTERM: "truecolor" });
+    expect(truecolor).toContain(`${ESC}[38;2;167;139;250m◆`);
+    expect(truecolor).toContain(`${ESC}[38;2;167;139;250mkeyed${ESC}[39m`);
+    expect(truecolor).not.toContain(`${ESC}[95m`);
+
+    const ansi = lines({ TERM: "xterm-256color" });
+    expect(ansi).toContain(`${ESC}[95m◆`);
+    expect(ansi).not.toContain("38;2;167;139;250");
   });
 
   it("renders a configured Vendo Cloud key under the same emphasized header", () => {
@@ -350,6 +452,48 @@ describe("createPrettyOutput (visual system)", () => {
     // Right under the wrap line it explains, and dim.
     expect(plain.indexOf("</VendoProvider>")).toBeLessThan(plain.indexOf("docs.vendo.run/quickstart"));
     expect(out.raw()).toContain(`${ESC}[2mdocs.vendo.run/quickstart#the-client-mount`);
+  });
+
+  it("prints the mount paste as real JSX, with a dim … for the app tree already there", () => {
+    const out = sink();
+    const rule = "─".repeat(64);
+    const pretty = createPrettyOutput({ write: out.write, banner: false });
+    pretty.log(`\n${rule}`);
+    pretty.log("ONE STEP LEFT — paste this yourself (init never edits your files)");
+    pretty.log("\n  File: app/layout.tsx");
+    pretty.log("    import { VendoProvider } from \"@vendoai/vendo/react\";");
+    pretty.log("    import theme from \"../.vendo/theme.json\";");
+    pretty.log("    import type { VendoTheme } from \"@vendoai/vendo\";");
+    pretty.log("    … then wrap: <VendoProvider baseUrl=\"/api/vendo\" theme={theme as VendoTheme}>{children}</VendoProvider>");
+    pretty.log(rule);
+    const plain = out.plain();
+    // The prose instruction is gone; what is left reads as the code it is.
+    expect(plain).not.toContain("… then wrap:");
+    expect(plain).not.toContain("{children}");
+    expect(plain).toContain("│    <VendoProvider baseUrl=\"/api/vendo\" theme={theme as VendoTheme}>");
+    expect(plain).toContain("│      …");
+    expect(plain).toContain("│    </VendoProvider>");
+    // A blank rail line sets the wrap apart from the imports above it.
+    expect(plain).toContain("│    import type { VendoTheme } from \"@vendoai/vendo\";\n│\n│    <VendoProvider");
+    // The app tree is a dim PLACEHOLDER, not code to paste…
+    expect(out.raw()).toContain(`${ESC}[2m…${ESC}[22m`);
+    // …which is exactly what the docs pointer under it exists to resolve.
+    expect(plain.indexOf("│    </VendoProvider>")).toBeLessThan(plain.indexOf("docs.vendo.run/quickstart"));
+  });
+
+  it("keeps the real JSX when the host is a pages `_app` — the child expression differs, the shape does not", () => {
+    const out = sink();
+    const rule = "─".repeat(64);
+    const pretty = createPrettyOutput({ write: out.write, banner: false });
+    pretty.log(`\n${rule}`);
+    pretty.log("ONE STEP LEFT — paste this yourself (init never edits your files)");
+    pretty.log("\n  File: pages/_app.tsx");
+    pretty.log("    … then wrap: <VendoProvider baseUrl=\"/api/vendo\"><Component {...pageProps} /></VendoProvider>");
+    pretty.log(rule);
+    const plain = out.plain();
+    expect(plain).toContain("│    <VendoProvider baseUrl=\"/api/vendo\">");
+    expect(plain).toContain("│      …");
+    expect(plain).not.toContain("pageProps");
   });
 
   it("leaves a paste block with no mount snippet without the docs pointer", () => {

--- a/packages/vendo/tests/cli/sync-flow.test.ts
+++ b/packages/vendo/tests/cli/sync-flow.test.ts
@@ -7,7 +7,7 @@ import { claudeCliHarness } from "../../src/cli/extract/claude-cli-harness.js";
 import type { ExtractionHarness } from "../../src/cli/extract/harness.js";
 import { npxEngineHarness } from "../../src/cli/extract/npx-engine-harness.js";
 import type { Output } from "../../src/cli/shared.js";
-import { readEnvFiles, runSyncFlow, type SyncFlowOptions, type SyncFlowResult } from "../../src/cli/sync-flow.js";
+import { readEnvFiles, rendererFlowOptions, runSyncFlow, type SyncFlowOptions, type SyncFlowResult } from "../../src/cli/sync-flow.js";
 
 /**
  * The ONE flow `vendo init` (mode "full") and `vendo sync` (mode "incremental")
@@ -182,6 +182,24 @@ describe("the slow phases spin when the caller supplies one", () => {
     run: async () => "```json\n" + JSON.stringify({ tools: [], narrative: "" }) + "\n```",
   };
 
+  // Cause one of #1163: init handed the flow its questions and NOT its spinner,
+  // so `withSpin` was a no-op for every install. Both commands now build these
+  // options the same way, which is the only thing that keeps them in step.
+  it("a renderer contributes its spinner, not just its questions", () => {
+    const pretty = {
+      confirm: async () => true,
+      select: async () => "",
+      spin: () => {},
+      stopSpin: () => {},
+    };
+    const wired = rendererFlowOptions(pretty);
+    expect(wired.spinner).toBeDefined();
+    expect(wired.confirm).toBe(pretty.confirm);
+    expect(wired.choose).toBe(pretty.select);
+    // No renderer → the flow keeps today's plain behaviour, nothing added.
+    expect(rendererFlowOptions(null)).toEqual({});
+  });
+
   it("labels extraction and the judgment pass in both modes", async () => {
     const seen: Record<string, { labels: string[]; stops: number; logs: string[] }> = {};
     for (const mode of ["full", "incremental"] as const) {
@@ -197,11 +215,17 @@ describe("the slow phases spin when the caller supplies one", () => {
       });
       seen[mode] = { labels, stops, logs };
     }
+    // THREE phases in full mode, and the third is the one that matters: the
+    // judgment pass answers in milliseconds when nothing changed, so its
+    // `finally` used to stop the spinner right before the prose stages — the
+    // two model calls that own minutes of the run — leaving the longest stretch
+    // of an install as a dead screen (#1163).
     expect(seen.full!.labels).toEqual([
       "Re-reading your product…",
       "Reading your product (a scripted engine)…",
+      "Reading your product (a scripted engine)…",
     ]);
-    expect(seen.full!.stops).toBe(2);
+    expect(seen.full!.stops).toBe(3);
     // The line became the label; it is not ALSO printed.
     expect(seen.full!.logs.join("\n")).not.toContain("Reading your product");
     expect(seen.incremental!.labels).toEqual([


### PR DESCRIPTION
Closes the last two approved-spec gaps from the init/sync redesign — the banner's arrival and the paste block's real snippet — plus the four defects the fresh cold walk filed against the same file surface.

Fixes #1163 #1164 #1165 #1166

---

## 1. The flow arrival plays

`bannerFrames`, `playBanner` and the pinned `BANNER_CONCEPT = "flow"` all shipped; `ensureHeader` only ever drew the still. Now the arrival starts at renderer construction and plays over the stack detection the run does anyway.

`playBanner` takes an `AbortSignal` and draws the settled frame **inside `abort()`** — synchronously, before `abort()` returns — so a line printed mid-flight lands under the finished mark, never on top of a half-drawn one. Plays once, never loops, no alternate screen buffer, last frame is still the settled frame.

**One divergence from the mock, decided on evidence.** The mock says the animation "never adds a millisecond of wait" because it plays while init detects the stack. A real PTY run showed detection finishing in well under one frame — **1** cursor-up in the whole capture, a flash rather than an arrival. So init awaits `pretty.arrived` after its own detection and before its first block. That is the *"keep total <= 1.5s"* half of the approved envelope (15 frames x 90ms = 1.35s, minus whatever detection already spent); the abort path means nothing can ever be blocked *on* the animation. This is the one place I touched `init.ts` startup for the banner, and why.

**`vendo sync` deliberately keeps flash-then-settle** — it shares the renderer but prints immediately, so it gets the settled mark, not the arrival. That is restraint, not an oversight: `init` is once-per-project and the celebration moment, while `sync` is a repeated tool where an animation on every run would wear thin — and the mock's sync section promises the rail, not an arrival.

## 2. The paste block carries the real snippet

The caller's prose line becomes real JSX, renderer-side only:

```
◇  One paste left — app/layout.tsx
│    import { VendoProvider } from "@vendoai/vendo/react";
│    import theme from "../.vendo/theme.json";
│    import type { VendoTheme } from "@vendoai/vendo";
│
│    <VendoProvider baseUrl="/api/vendo" theme={theme as VendoTheme}>
│      …
│    </VendoProvider>
│    docs.vendo.run/quickstart#the-client-mount — exact wording for layout.tsx and _app.tsx
```

The `{children}` literal is gone, which was the whole point: it is wrong for a pages-only `_app.tsx`. `mount.lines`, the plain path and the `--agent` plan's pinned JSON are byte-identical — this is a rule over the exact strings the caller already emits.

Two notes where mock and code disagree, both left as-is: the mock's variant-A block draws the wrap on one line while its own paste section draws it on three (I took the three-line form the "real JSX" note is attached to), and the docs anchor is `#the-client-mount` in code vs `#mount` in the mock — #1164 item 3 flagged that one as cosmetic and presumed the real anchor wins.

## 3. #1163 — the slow phases never spin (MUST-FIX)

Two causes, and the second is not the one the issue guessed.

**Cause 1: init never passed the spinner.** `sync.ts` handed the flow `spinner: {...}`; `runInstallSyncFlow` handed it `confirm` and `choose` and nothing else, so `withSpin` was a no-op for every install. Both commands now build those options through one `rendererFlowOptions()` spelling — the only thing that keeps them from drifting apart again.

**Cause 2: the phase that owns the minutes runs outside `withSpin`.** The issue suspected `timer.unref?.()` or a blocked loop. A PTY probe cleared the renderer: **15** spinner frames across log lines during a 1.2s async wait, **1** during a 1.2s blocking one. The renderer survives progress lines fine. What actually happens is that `runJudgmentPass` answers `judgment: up to date` in milliseconds when nothing changed, `withSpin`'s `finally` stops the spinner — and *then* `runProseStages` (the brief draft and the theme fill, the two model calls that own 35s and 108s in the walk) runs with no spinner at all. `runProseStages` is now inside `withSpin`, which is where every measured dead gap lives.

## 4. #1164 — doctor named twice

`Then confirm it landed: npx vendo doctor` inside the paste frame is gone; the ending six lines down already names doctor. Emitting side, as the issue says. The surviving line keeps today's wording (`Verify everything: ...`) rather than the mock's `then: npx vendo doctor — ...` — flag it if you want the mock's copy instead, it is a one-line change plus its tests.

## 5. #1165 — the rail no longer dies at the theme prompt

The uncertain-slot review goes through `pretty.text()`: a `◇` question, the model's reasoning as a dim hint on the rail, the `●` receipt. The ~450-character note is trimmed to its first sentence — the reading it *chose* — which also drops the `I picked #fafafa because...` first person the issue called out. Plain path keeps the readline prompt exactly as it is.

## 6. #1166 — the rail accent follows the terminal

`lilac` consulted nothing; it was ANSI bright magenta on every terminal while the mark above it drew the real ramp. It now takes the same `bannerColorMode` probe: truecolor `#a78bfa` where the terminal can show it, ANSI magenta where it cannot. Threaded through `Rail.accent` rather than a module global, so two renderers in one process cannot bleed into each other.

---

## Fail-first proof

Each fix reverted, tests red, restored, green.

**Piece 1 — the arrival** (`ensureHeader` back to the static banner, `playBanner` back to no signal):

```
x createPrettyOutput > the banner ARRIVES: the flow plays in place, once, and settles into the mark
x createPrettyOutput > a line printed mid-arrival settles the mark first — the header never lands on a half-drawn one
x playBanner > an abort mid-arrival settles INSIDE abort(), then stops
  Tests  3 failed | 97 passed (100)
```

**Piece 2 — the paste block** (renderer back to printing the prose line):

```
FAIL  prints the mount paste as real JSX, with a dim … for the app tree already there
AssertionError: expected '┌  vendo init\n│\n◇  One paste left —…' not to contain '… then wrap:'
+ │    … then wrap: <VendoProvider baseUrl="/api/vendo" theme={theme as VendoTheme}>{children}</VendoProvider>
FAIL  keeps the real JSX when the host is a pages `_app` — the child expression differs, the shape does not
  Tests  2 failed | 98 passed (100)
```

**#1163** (helper drops the spinner; prose stages back outside `withSpin`):

```
FAIL  a renderer contributes its spinner, not just its questions
AssertionError: expected undefined to be defined
FAIL  labels extraction and the judgment pass in both modes
- Expected: [ "Re-reading your product…", "Reading your product (a scripted engine)…", "Reading your product (a scripted engine)…" ]
+ Received: [ "Re-reading your product…", "Reading your product (a scripted engine)…" ]
  Tests  2 failed | 37 passed (39)
```

**#1165 + #1166** (`firstSentence` back to identity; accent back to unconditional `95`):

```
FAIL  the uncertain-theme-slot review > asks through the renderer, with the model's reasoning trimmed…
AssertionError: expected 358 to be less than 179
FAIL  firstSentence caps a note that never ends a sentence
AssertionError: expected 'xxx…' to have a length of 160 but got 400
FAIL  takes the brand's truecolor accent where the terminal can show it, ANSI magenta where it cannot
AssertionError: expected '┌  vendo init…' to contain 'ESC[38;2;167;139;250m◆'
  Tests  3 failed | 170 passed (173)
```

## Gate

`pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint`, foreground, on the touched scope — all four green.

## Visual verification

A real `npx vendo init` against a scratch Next.js App Router host, recorded in a 110x40 PTY with a live Claude Code engine. 273.5s end to end, so all three behaviours appear in one run.

**The arrival** — 15 frames, in place, settling into the mark:

![banner arrival](https://raw.githubusercontent.com/runvendo/vendo/assets/banner-arrival-walk/init-banner-arrival.gif)

![mid-arrival](https://raw.githubusercontent.com/runvendo/vendo/assets/banner-arrival-walk/still-arrival-mid.png)

**The ending** — the paste block carrying the real snippet, the dim `…`, the docs pointer, and doctor named once:

![the ending](https://raw.githubusercontent.com/runvendo/vendo/assets/banner-arrival-walk/still-paste-block.png)

**The whole run** (3x, idle capped at 2s):

![full walk](https://raw.githubusercontent.com/runvendo/vendo/assets/banner-arrival-walk/init-walk.gif)

Measured off the raw asciicast, against the numbers in #1163:

| | walk on `main` | this branch |
|---|---|---|
| banner in-place redraws | 0 (still only) | **14** (all 15 frames) |
| spinner frames in the run | **1** | **3349** |
| rail accent, truecolor terminal | ANSI magenta only | **3377 truecolor**, 0 magenta |
| alternate screen buffer | never | never |
| `… then wrap:` / `{children}` in the paste | present | **gone** |
| `npx vendo doctor` mentions at the ending | 2 | **1** |

Raw artifacts on `assets/banner-arrival-walk`: [`init-batch.cast`](https://raw.githubusercontent.com/runvendo/vendo/assets/banner-arrival-walk/init-batch.cast) (`asciinema play`), [`init-walk.txt`](https://raw.githubusercontent.com/runvendo/vendo/assets/banner-arrival-walk/init-walk.txt) (full transcript).
