### PR TITLE
fix(store,apps): the byApp erase cascade reaches the app's own drawers

### DIFF
--- a/.changeset/erase-reaches-the-apps-own-drawers.md
+++ b/.changeset/erase-reaches-the-apps-own-drawers.md
@@ -1,0 +1,34 @@
+---
+"@vendoai/apps": patch
+"@vendoai/store": patch
+---
+
+The byApp erase cascade reaches two app drawers it never could.
+
+Two classes of row survived the app they belonged to, permanently, and both
+were invisible for the same reason: the cascade's selectors and the writers'
+row shapes were decided in different files and never compared.
+
+**The ref key.** In-client approvals (`vendo_inclient_approvals`) and remix
+rejections (`vendo_remix_rejections`) wrote their app reference as
+`refs.appId`. The cascade's byApp leg matches `refs @> {"app_id": …}` — the
+spelling every other writer in the repo uses (app tokens, placements, app data,
+armed automations, sponsorships, grants). Camel-cased, the containment check
+simply never matched, so an approval to mount an app in the host page outlived
+the app it approved. Both writers now spell `app_id`, and
+`backfillAppRefKey(store)` renames the key on rows already on disk: it touches
+`refs` and nothing else, deletes nothing, and is re-runnable by construction —
+a second run reports `rowsRenamed: 0`.
+
+**The version log.** `vendo:app-history:<id>` holds every stored version of an
+app plus its pin-intent trail. The byApp cascade reached generic rows two ways —
+an `app:<id>:` collection prefix, or refs containment — and app history
+satisfies neither: its name uses a different prefix, and its rows carry no refs
+at all. Every version of every deleted app was still in the table. The cascade
+now names the collection directly, through core's `engineAppHistory` builder —
+the same one the write side composes it with, so the two cannot drift — and it
+sits in the shared app-scoped step, so the bySubject leg sweeps it too.
+
+`createInClientApprovals` and `createAppHistory` are now exported from
+`@vendoai/apps`, so `@vendoai/store` can prove the cascade against the real
+writers rather than a hand-rolled copy of the rows they produce.

--- a/packages/apps/src/server/index.ts
+++ b/packages/apps/src/server/index.ts
@@ -59,6 +59,11 @@ export {
   type ShareSnapshot,
 } from "./persistence/cloud.js";
 export { inClientApprovalSchema, type InClientApproval } from "./remix/inclient.js";
+// The two app-scoped persistence doors, exported so `@vendoai/store` — a
+// declared consumer of this package — can prove its erase cascade against the
+// REAL writers instead of a hand-rolled copy of the rows they produce.
+export { createInClientApprovals, type InClientApprovalAccess } from "./remix/inclient.js";
+export { createAppHistory, type AppHistoryAccess } from "./persistence/history.js";
 export {
   seedBaselineSchema,
   seedComponentName,

--- a/packages/apps/src/server/remix/inclient.ts
+++ b/packages/apps/src/server/remix/inclient.ts
@@ -75,8 +75,12 @@ export interface InClientApprovalAccess {
 
 const COLLECTION = "vendo_inclient_approvals";
 
+/** `app_id`, NOT `appId`: this is a generic `vendo_records` row, and the erase
+ *  cascade's byApp leg matches `refs @> {"app_id": …}` (store/src/erase.ts).
+ *  Rows written under the camelCase key were never swept with their app and
+ *  outlived it forever — `backfillAppRefKey` renames the ones already on disk. */
 const allRecords = (records: RecordStore, appId: AppId) =>
-  listAllRecords(records, { refs: { appId } });
+  listAllRecords(records, { refs: { app_id: appId } });
 
 /** 06-apps §9 — hash-pinned in-client approvals over the store seam. */
 export const createInClientApprovals = (store: StoreAdapter): InClientApprovalAccess => {
@@ -112,7 +116,7 @@ export const createInClientApprovals = (store: StoreAdapter): InClientApprovalAc
       await records.put({
         id: `incl_${globalThis.crypto.randomUUID()}`,
         data: validated,
-        refs: { appId: validated.appId },
+        refs: { app_id: validated.appId },
       });
       return validated;
     },

--- a/packages/apps/src/server/remix/review.ts
+++ b/packages/apps/src/server/remix/review.ts
@@ -116,7 +116,9 @@ export const createReviewLifecycle = (deps: ReviewLifecycleDeps): ReviewLifecycl
     && baselines().some((baseline) => baseline.slot === doc.seed!.component && baseline.review === true);
 
   const rejectionsFor = async (appId: AppId): Promise<RemixRejection[]> => {
-    const records = await listAllRecords(rejections, { refs: { appId } });
+    // `app_id`, not `appId` — see the note on inclient.ts's `allRecords`: the
+    // erase cascade's byApp leg matches this exact ref key.
+    const records = await listAllRecords(rejections, { refs: { app_id: appId } });
     return records
       .flatMap((record) => {
         const parsed = remixRejectionSchema.safeParse(record.data);
@@ -259,7 +261,7 @@ export const createReviewLifecycle = (deps: ReviewLifecycleDeps): ReviewLifecycl
       await rejections.put({
         id: `remrej_${sha256Hex(`${rejection.appId}:${versionHash}`)}`,
         data: rejection,
-        refs: { appId: rejection.appId },
+        refs: { app_id: rejection.appId },
       });
       return rejection;
     },
@@ -267,7 +269,7 @@ export const createReviewLifecycle = (deps: ReviewLifecycleDeps): ReviewLifecycl
     rejections: rejectionsFor,
 
     async clear(appId) {
-      for (const record of await listAllRecords(rejections, { refs: { appId } })) {
+      for (const record of await listAllRecords(rejections, { refs: { app_id: appId } })) {
         await rejections.delete(record.id);
       }
     },

--- a/packages/apps/tests/review.test.ts
+++ b/packages/apps/tests/review.test.ts
@@ -304,7 +304,7 @@ describe("rejection", () => {
       runtime.review.reject({ appId: app.id, note: "Second racer." }, reviewer),
     ]);
     expect(results.some((result) => result.status === "fulfilled")).toBe(true);
-    const rows = (await store.records("vendo_remix_rejections").list({ refs: { appId: app.id } })).records;
+    const rows = (await store.records("vendo_remix_rejections").list({ refs: { app_id: app.id } })).records;
     expect(rows).toHaveLength(1);
     expect(await runtime.review.queue(reviewer)).toEqual([]);
   });
@@ -383,7 +383,7 @@ describe("rejection", () => {
     await seedAppRow(store, app, owner.principal.subject);
     await runtime.review.reject({ appId: app.id, note: "Nope." }, reviewer);
     await runtime.delete(app.id, owner);
-    expect((await store.records("vendo_remix_rejections").list({ refs: { appId: app.id } })).records).toEqual([]);
+    expect((await store.records("vendo_remix_rejections").list({ refs: { app_id: app.id } })).records).toEqual([]);
   });
 });
 

--- a/packages/store/src/backfill-app-data.ts
+++ b/packages/store/src/backfill-app-data.ts
@@ -200,6 +200,51 @@ export async function backfillAppDataStamps(
   return await backfillAppDataOnDb(dbFor(store), options);
 }
 
+/** The two generic-table collections that wrote their app ref under `appId`
+ *  instead of the `app_id` every other writer (and the erase cascade) uses. */
+const APP_REF_KEY_COLLECTIONS = ["vendo_inclient_approvals", "vendo_remix_rejections"] as const;
+
+export interface AppRefKeyBackfillReport {
+  /** Rows whose `refs.appId` became `refs.app_id` on this run. */
+  rowsRenamed: number;
+  /** Rows already carrying `app_id` — counted BEFORE the rename, so a run never
+   *  reports its own work as pre-existing. A second run renames 0 and skips
+   *  everything the first one fixed. */
+  rowsSkipped: number;
+}
+
+/**
+ * In-client approvals and remix rejections wrote their app ref as `refs.appId`;
+ * the erase cascade's byApp leg matches `refs @> {"app_id": …}`, so those rows
+ * were never swept with their app and outlived it permanently. The writers now
+ * spell `app_id`; this renames the key on the rows already on disk.
+ *
+ * Re-runnable by construction — the selector excludes anything that already
+ * carries `app_id`, so a second run reports `rowsRenamed: 0`. `data` is
+ * untouched and no row is ever deleted; only the ref KEY moves, so a live
+ * reader sees the same app id under the name every other collection uses.
+ */
+export async function backfillAppRefKey(store: VendoStore): Promise<AppRefKeyBackfillReport> {
+  const db = dbFor(store);
+  const collections = [...APP_REF_KEY_COLLECTIONS];
+  const skipped = await db.query(
+    `SELECT count(*)::int AS skipped FROM vendo_records
+     WHERE collection = ANY($1::text[]) AND refs ? 'app_id'`,
+    [collections],
+  );
+  const renamed = await db.query(
+    `UPDATE vendo_records
+     SET refs = (refs - 'appId') || jsonb_build_object('app_id', refs->>'appId')
+     WHERE collection = ANY($1::text[]) AND refs ? 'appId' AND NOT refs ? 'app_id'
+     RETURNING 1`,
+    [collections],
+  );
+  return {
+    rowsRenamed: renamed.rows.length,
+    rowsSkipped: Number(skipped.rows[0]?.["skipped"] ?? 0),
+  };
+}
+
 /** Promote's half: the whole app changes hands, so every appData row and file
  *  stamped `from` is re-stamped `to`. Takes a Db (not a store) so promote can
  *  pass its TRANSACTION-scoped handle — a base-handle query issued mid

--- a/packages/store/src/erase.ts
+++ b/packages/store/src/erase.ts
@@ -1,4 +1,4 @@
-import { encodeGrantPrincipal, type FilesAdapter } from "@vendoai/core";
+import { encodeGrantPrincipal, engineAppHistory, type FilesAdapter } from "@vendoai/core";
 import { escapeLike } from "./helpers/utils.js";
 import { dbFor, type VendoStore } from "./store.js";
 import { invalid } from "./validate.js";
@@ -129,6 +129,15 @@ export function eraseStore(store: VendoStore, options: { files: FilesAdapter }):
   const eraseAppData = async (report: EraseReport, appId: string): Promise<void> => {
     const prefix = `app:${escapeLike(appId)}:%`;
     await del(report, "vendo_records", "collection LIKE $1 ESCAPE '\\'", [prefix]);
+    // The capped version log (and the pin-intent trail inside it) is the one
+    // app-scoped drawer neither selector could see: its name is
+    // `vendo:app-history:<id>`, not the `app:<id>:` prefix above, and its rows
+    // carry NO refs at all (apps/src/server/persistence/history.ts:104), so the
+    // refs containment leg below never matched them either. Every stored version
+    // of every deleted app survived its app until this line existed. Named
+    // through core's ONE builder — the same one that composes it on the write
+    // side — so the two can never drift apart.
+    await del(report, "vendo_records", "collection = $1", [engineAppHistory(appId)]);
     await del(report, "vendo_blobs", "namespace LIKE $1 ESCAPE '\\'", [prefix]);
     await del(report, "vendo_state", "app_id = $1", [appId]);
     await del(report, "vendo_runs", "app_id = $1", [appId]);

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -20,6 +20,7 @@ export {
 // The one-shot migration for appData that predates the owner stamp: without it
 // every such row goes invisible the moment a door flips onto the family.
 export { backfillAppDataStamps, type AppDataBackfillReport } from "./backfill-app-data.js";
+export { backfillAppRefKey, type AppRefKeyBackfillReport } from "./backfill-app-data.js";
 // The reserved-collection map (02-store §2): exported so remote StoreAdapters
 // (the umbrella's hostedStore) can mirror this engine's per-collection
 // capability shape — claim on non-routed collections, atomic on generic

--- a/packages/store/src/postgres.ts
+++ b/packages/store/src/postgres.ts
@@ -44,6 +44,7 @@ export {
   APP_DATA_OWNER_REF,
 } from "./app-data-rows.js";
 export { backfillAppDataStamps, type AppDataBackfillReport } from "./backfill-app-data.js";
+export { backfillAppRefKey, type AppRefKeyBackfillReport } from "./backfill-app-data.js";
 export {
   DEDICATED_RECORD_COLLECTIONS,
   RESERVED_COLLECTIONS,

--- a/packages/store/tests/erase-app-drawers.test.ts
+++ b/packages/store/tests/erase-app-drawers.test.ts
@@ -1,0 +1,157 @@
+import { createAppHistory, createInClientApprovals } from "@vendoai/apps";
+import { describe, expect, it } from "vitest";
+import { backends, type MadeBackend } from "../src/backends.test-util.js";
+import { backfillAppRefKey } from "../src/backfill-app-data.js";
+import { eraseStore } from "../src/erase.js";
+import { storeFiles } from "../src/files-store.js";
+import { appFixture } from "../src/fixtures.test-util.js";
+
+/** 02-store §5 — the byApp cascade against the REAL apps-block writers. Two
+    drawers used to slip through it and outlive their app forever: the in-client
+    approvals / remix rejections, whose rows carried the app under `refs.appId`
+    while the cascade matches `app_id`, and the capped version log, whose name is
+    not the `app:<id>:` prefix and whose rows carry no refs at all. Both halves
+    are exercised end to end — written through the producer, erased through the
+    consumer, read back through the producer — because a test that forges the
+    rows itself can only ever agree with whatever the cascade happens to match. */
+
+const SUBJECT = "user_erase_seam";
+
+for (const backend of backends()) {
+  describe(`${backend.name} byApp erase reaches the app's own drawers`, () => {
+    const make = async (): Promise<MadeBackend> => {
+      const made = await backend.make();
+      await made.store.ensureSchema();
+      return made;
+    };
+
+    const seedApp = async (made: MadeBackend, id: string) => {
+      const doc = appFixture(id);
+      await made.store.records("vendo_apps").put({
+        id: doc.id,
+        data: { subject: SUBJECT, enabled: true, doc },
+      });
+      return doc;
+    };
+
+    const erase = (made: MadeBackend, appId: string) =>
+      eraseStore(made.store, { files: storeFiles(made.store) }).byApp(appId);
+
+    it("takes an in-client approval written through the real approvals door, and counts it", async () => {
+      const made = await make();
+      try {
+        const doc = await seedApp(made, "app_erase_inclient");
+        const approvals = createInClientApprovals(made.store);
+        await approvals.record({
+          appId: doc.id,
+          versionHash: "sha256:seam",
+          approvedBy: "host-console",
+          at: "2026-01-02T03:04:05.000Z",
+        });
+        expect(await approvals.list(doc.id)).toHaveLength(1);
+
+        const report = await erase(made, doc.id);
+
+        expect(await approvals.list(doc.id)).toEqual([]);
+        expect(await made.sql(
+          "SELECT id FROM vendo_records WHERE collection = 'vendo_inclient_approvals'",
+        )).toEqual([]);
+        expect(report.vendo_records).toBe(1);
+      } finally {
+        await made.cleanup();
+      }
+    });
+
+    it("takes the version log written through the real history door, and counts it", async () => {
+      const made = await make();
+      try {
+        const doc = await seedApp(made, "app_erase_history");
+        const history = createAppHistory(made.store);
+        await history.append(doc.id, doc, {
+          at: "2026-01-02T03:04:05.000Z",
+          intent: "first draft",
+          rung: 1,
+        });
+        await history.append(doc.id, doc, {
+          at: "2026-01-02T03:04:06.000Z",
+          intent: "second draft",
+          rung: 1,
+        });
+        expect(await history.documents(doc.id)).toHaveLength(2);
+
+        const report = await erase(made, doc.id);
+
+        expect(await history.documents(doc.id)).toEqual([]);
+        expect(report.vendo_records).toBe(2);
+      } finally {
+        await made.cleanup();
+      }
+    });
+
+    it("spares another app's drawers", async () => {
+      const made = await make();
+      try {
+        const target = await seedApp(made, "app_erase_target");
+        const bystander = await seedApp(made, "app_erase_bystander");
+        const approvals = createInClientApprovals(made.store);
+        const history = createAppHistory(made.store);
+        for (const doc of [target, bystander]) {
+          await approvals.record({
+            appId: doc.id,
+            versionHash: `sha256:${doc.id}`,
+            approvedBy: "host-console",
+            at: "2026-01-02T03:04:05.000Z",
+          });
+          await history.append(doc.id, doc, {
+            at: "2026-01-02T03:04:05.000Z",
+            intent: "first draft",
+            rung: 1,
+          });
+        }
+
+        expect((await erase(made, target.id)).vendo_records).toBe(2);
+
+        expect(await approvals.list(bystander.id)).toHaveLength(1);
+        expect(await history.documents(bystander.id)).toHaveLength(1);
+      } finally {
+        await made.cleanup();
+      }
+    });
+
+    it("renames a legacy appId ref so the cascade can reach it, and reports zero on a second run", async () => {
+      const made = await make();
+      try {
+        const doc = await seedApp(made, "app_erase_legacy");
+        // The pre-fix writer's row, forged the only way it can be: the producer
+        // no longer spells the key this way, and the whole point of the backfill
+        // is the rows that are already on disk.
+        await made.store.records("vendo_inclient_approvals").put({
+          id: "incl_legacy",
+          data: {
+            appId: doc.id,
+            versionHash: "sha256:legacy",
+            approvedBy: "host-console",
+            at: "2026-01-02T03:04:05.000Z",
+          },
+          refs: { appId: doc.id },
+        });
+        const approvals = createInClientApprovals(made.store);
+        // Invisible to the fixed reader until the key moves — the same shape of
+        // failure the erase cascade had.
+        expect(await approvals.list(doc.id)).toEqual([]);
+
+        expect(await backfillAppRefKey(made.store)).toEqual({ rowsRenamed: 1, rowsSkipped: 0 });
+        expect(await approvals.list(doc.id)).toHaveLength(1);
+        // Idempotent: the second run finds nothing left to rename and reports
+        // the row the first run fixed as already carrying the key.
+        expect(await backfillAppRefKey(made.store)).toEqual({ rowsRenamed: 0, rowsSkipped: 1 });
+
+        const report = await erase(made, doc.id);
+        expect(report.vendo_records).toBe(1);
+        expect(await approvals.list(doc.id)).toEqual([]);
+      } finally {
+        await made.cleanup();
+      }
+    });
+  });
+}


### PR DESCRIPTION
Two classes of row survived the app they belonged to, permanently. Both were
invisible for the same reason: the cascade's selectors and the writers' row
shapes were decided in different files and never compared against each other.

### Bug 1 — the ref key

In-client approvals (`vendo_inclient_approvals`) and remix rejections
(`vendo_remix_rejections`) wrote their app reference as **`refs.appId`**. The
erase cascade's byApp leg matches **`refs @> {"app_id": …}`** — the spelling
every other writer in this repo uses (app tokens, placements, app data, armed
automations, sponsorships, grants, app-access). Camel-cased, the containment
check simply never matched, so an approval to mount an app in the host page
outlived the app it approved, forever.

Five sites fixed — writes at `inclient.ts:119` and `review.ts:264`, reads at
`inclient.ts:83`, `review.ts:121`, `review.ts:272`.

`backfillAppRefKey(store)` renames the key on rows already on disk: it touches
`refs` and nothing else, deletes nothing, and is re-runnable by construction —
the selector excludes anything already carrying `app_id`, so a second run
reports `rowsRenamed: 0` and counts the first run's work as `rowsSkipped`.

### Bug 2 — the version log

`vendo:app-history:<id>` holds every stored version of an app plus its
pin-intent trail. The byApp cascade reached generic rows two ways — an
`app:<id>:` collection prefix (`erase.ts:130`) or refs containment
(`erase.ts:224`) — and app history satisfies **neither**: its name uses a
different prefix, and its rows carry **no refs at all**
(`packages/apps/src/server/persistence/history.ts:104`). A refs-based selector
cannot reach these rows no matter how correct it looks; it needs a
collection-name selector.

The cascade now names the collection directly, through core's
`engineAppHistory` builder — the same one the write side composes it with, so
the two cannot drift — and it sits in `eraseAppData`, the shared app-scoped
step, so the **bySubject** leg sweeps it too. (The plan placed it in `byApp`
only; `eraseAppData` is the function whose own docstring says "app-scoped data
shared by the subject and app cascades", and the byApp-only placement would
have left bySubject still leaking history.)

### Proven at the seam

`packages/store/tests/erase-app-drawers.test.ts` — written through the real
`createInClientApprovals` / `createAppHistory`, erased through the real
cascade, read back through the real readers. No stub on either side.

With both fixes reverted, all four cases go red, each for its own reason:

| case | failure with the fix reverted |
|---|---|
| takes an in-client approval written through the real approvals door, and counts it | `expected [ { …(4) } ] to deeply equal []` |
| takes the version log written through the real history door, and counts it | `expected [ …(2) ] to deeply equal []` |
| spares another app's drawers | `expected +0 to be 2` |
| renames a legacy appId ref so the cascade can reach it, and reports zero on a second run | `expected [ { appId: 'app_erase_legacy', …(3) } ] to deeply equal []` |

### One pre-existing test changed, as its own commit

`review.test.ts` reaches past the review API into the raw
`vendo_remix_rejections` row and queries it by `refs.appId` — the exact key
this PR corrects. One assertion goes red on the fix; the other asserts an empty
result and so kept passing **for the wrong reason** (a stale key matches
nothing, which is indistinguishable from `clear` working). Both now name the
key the writer writes. Isolated in `7fa052e12` so it can be reviewed or
reverted on its own; the new seam test does not depend on it.

### Also here

`createInClientApprovals` and `createAppHistory` are exported from
`@vendoai/apps` so `@vendoai/store` — a declared consumer — can prove the
cascade against the real writers instead of a hand-rolled copy of their rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the byApp erase cascade so deleting an app also removes its in‑client approvals, remix rejections, and version history. Prevents orphaned rows and keeps the byApp/bySubject cascades consistent.

- **Bug Fixes**
  - Standardized refs to `app_id` for `vendo_inclient_approvals` and `vendo_remix_rejections`; updated readers/writers and fixed the `apps` rejection test to query by `app_id`.
  - Cascade now deletes app history by collection via `engineAppHistory` in the shared app‑scoped step, covering rows with no refs and in both cascades.
  - Exported `createInClientApprovals` and `createAppHistory` from `@vendoai/apps`; added seam tests using the real writers.

- **Migration**
  - Run `backfillAppRefKey(store)` to rename legacy `refs.appId` to `refs.app_id` (idempotent); exported from `@vendoai/store` and `@vendoai/store/postgres`.

<sup>Written for commit 8a6580a8a919100d459ba74ef7cb5f87e6e61851. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

