### PR TITLE
refactor(automations): the block's 41 record sites move onto the engine family

### DIFF
--- a/.changeset/automations-engine-family.md
+++ b/.changeset/automations-engine-family.md
@@ -1,0 +1,29 @@
+---
+"@vendoai/automations": patch
+"@vendoai/core": patch
+"@vendoai/vendo": patch
+---
+
+automations reaches its own drawers through the `engine` op family
+
+Every collection this engine owns — `vendo_apps`, `vendo_runs`, `vendo_grants`,
+`vendo_approvals`, the captures, the arm rows, the schedule cursors, the webhook
+secrets, the delivery ledger, and both sponsorship drawers — was reached through
+the generic `store.records(...)` door a host uses for its own data. All 41 call
+sites now go through `ops.engine.*`, so the allowlist gate in
+`assertEngineCollection` applies to every one of them.
+
+`AutomationsConfig` gains an optional `ops: StoreOps` beside `store`, threaded
+from composition. It stays optional because `selectStoreOps` answers `undefined`
+for a store with neither its own ops surface nor a SQL handle, and because a
+host may construct the block directly with nothing but a `StoreAdapter`.
+
+`engineOverAdapter` (new, in core) is that store's engine family: the allowlist
+gate in front, the adapter's own record door behind. It lives in core because
+automations, guard and apps all need it and none of them may import
+`@vendoai/store`. Where `RecordStore.atomic` is absent it keeps exactly the
+degradation those blocks used to hand-roll — `insertIfAbsent` becomes a
+check-then-put, `compareAndSwap` a last write — so moving onto the family does
+not turn a working BYO adapter into a `not-implemented`.
+
+No behavior change: same collection, same verb, same arguments, same order.

--- a/packages/automations/src/app-rows.ts
+++ b/packages/automations/src/app-rows.ts
@@ -47,9 +47,9 @@ type AppReader = Pick<
 >;
 
 /** One app row: the read, the edit gate over it, and the write. */
-const createAppReader = ({ base: { config } }: AppRowsDeps): AppReader => {
+const createAppReader = ({ base: { config, engine } }: AppRowsDeps): AppReader => {
   const appRecord = async (appId: string): Promise<{ record: VendoRecord; row: AppData } | null> => {
-    const record = await config.store.records(APPS).get(appId);
+    const record = await engine.get(APPS, appId);
     return record === null ? null : { record, row: parseAppRow(record) };
   };
 
@@ -97,7 +97,7 @@ const createAppReader = ({ base: { config } }: AppRowsDeps): AppReader => {
     // derives them from columns and ignores caller refs; a generic StoreAdapter honors what we
     // pass here). ONE KEY PER KIND, because an app's triggers are a LIST: a single-valued ref
     // could only name one of them, and the others would never be queried at all.
-    await config.store.records(APPS).put({
+    await engine.put(APPS, {
       id: record.id,
       data: row,
       refs: { subject: row.subject, ...triggerKindRefs(row.doc.triggers) },
@@ -109,14 +109,14 @@ const createAppReader = ({ base: { config } }: AppRowsDeps): AppReader => {
 
 /** The queries the tick and emit fire from. */
 const createAppQueries = (
-  { base: { config } }: AppRowsDeps,
+  { base: { engine } }: AppRowsDeps,
 ): Pick<AppRowsAccess, "appsFiringOn"> => {
   /** The app rows that fire on this trigger kind, by its per-kind ref. */
   const appsFiringOn = async (
     kind: TriggerSource["kind"],
     refs: Record<string, string> = {},
   ): Promise<VendoRecord[]> =>
-    await allRecords(config.store.records(APPS), {
+    await allRecords(engine, APPS, {
       refs: { ...refs, [triggerKindRefKey(kind)]: TRIGGER_KIND_REF_PRESENT },
     });
 

--- a/packages/automations/src/armed.ts
+++ b/packages/automations/src/armed.ts
@@ -26,11 +26,11 @@ export interface ArmedAccess {
   disarmTrigger(record: VendoRecord, row: AppData, triggerId: string): Promise<void>;
 }
 
-export const createArmed = ({ base: { config }, appRows }: ArmedDeps): ArmedAccess => {
+export const createArmed = ({ base: { engine }, appRows }: ArmedDeps): ArmedAccess => {
   const setArmed = async (appId: string, triggerId: string, armed: boolean): Promise<void> => {
     const id = triggerKey(appId, triggerId);
-    if (armed) await config.store.records(ARMED).put({ id, data: { appId, triggerId }, refs: { app_id: appId } });
-    else await config.store.records(ARMED).delete(id);
+    if (armed) await engine.put(ARMED, { id, data: { appId, triggerId }, refs: { app_id: appId } });
+    else await engine.delete(ARMED, id);
   };
 
   /**
@@ -56,7 +56,7 @@ export const createArmed = ({ base: { config }, appRows }: ArmedDeps): ArmedAcce
     );
     return new Set<string>(keys.length === 0
       ? []
-      : (await allRecords(config.store.records(ARMED), { ids: keys })).map((record) => record.id));
+      : (await allRecords(engine, ARMED, { ids: keys })).map((record) => record.id));
   };
 
   /** The same question for one trigger, for the paths that hold a single app. */

--- a/packages/automations/src/arming-surface.ts
+++ b/packages/automations/src/arming-surface.ts
@@ -13,7 +13,6 @@ import type { EngineBase } from "./engine-context.js";
 import type { GrantsAccess } from "./grants.js";
 import type { AutomationsEngine, RunPlan } from "./index.js";
 import { appRef } from "./rows.js";
-import type { SponsorshipGateAccess } from "./sponsorship-gate.js";
 import { currentIntentHash, markSponsored, triggerKey, writeSponsorship } from "./sponsorship.js";
 import { evaluate, stepArgs, validateForEachItems } from "./steps.js";
 import { SCHEDULE, WEBHOOK } from "./types.js";
@@ -24,14 +23,13 @@ export type ArmingSurfaceDeps = {
   appRows: AppRowsAccess;
   armed: ArmedAccess;
   grants: GrantsAccess;
-  sponsorship: SponsorshipGateAccess;
   consent: ConsentAccess;
 };
 
 /** 07 §3's arm/disarm pair. */
 const createArmDoors = (deps: ArmingSurfaceDeps): Pick<AutomationsEngine, "enable" | "disable"> => {
   const { base: { engine, iso, firesLocally }, appRows, armed } = deps;
-  const { grants, sponsorship, consent } = deps;
+  const { grants, consent } = deps;
   const enable: AutomationsEngine["enable"] = async (appId, triggerId, ctx) => {
     const found = await appRows.editableApp(appId, ctx);
     const trigger = appRows.declaredTrigger(found.row.doc, triggerId);

--- a/packages/automations/src/arming-surface.ts
+++ b/packages/automations/src/arming-surface.ts
@@ -30,7 +30,7 @@ export type ArmingSurfaceDeps = {
 
 /** 07 §3's arm/disarm pair. */
 const createArmDoors = (deps: ArmingSurfaceDeps): Pick<AutomationsEngine, "enable" | "disable"> => {
-  const { base: { config, iso, firesLocally }, appRows, armed } = deps;
+  const { base: { engine, iso, firesLocally }, appRows, armed } = deps;
   const { grants, sponsorship, consent } = deps;
   const enable: AutomationsEngine["enable"] = async (appId, triggerId, ctx) => {
     const found = await appRows.editableApp(appId, ctx);
@@ -61,7 +61,7 @@ const createArmDoors = (deps: ArmingSurfaceDeps): Pick<AutomationsEngine, "enabl
     // A re-enable refreshes both, which is how an invalidated automation comes
     // back. Per TRIGGER, because that is the thing they just looked at and
     // allowed.
-    await writeSponsorship(sponsorship.sponsorships(), {
+    await writeSponsorship(engine, {
       appId,
       triggerId: trigger.id,
       sponsor: ctx.principal.subject,
@@ -71,22 +71,22 @@ const createArmDoors = (deps: ArmingSurfaceDeps): Pick<AutomationsEngine, "enabl
     });
     // The era marker outlives an erase of the sponsor, so a vanished row can
     // never be misread as "never sponsored" (§9.9 fails closed).
-    await markSponsored(sponsorship.sponsoredEra(), appId, trigger.id, iso());
+    await markSponsored(engine, appId, trigger.id, iso());
     await armed.setArmed(appId, trigger.id, true);
     found.row.enabled = true;
     await appRows.writeApp(found.record, found.row);
     const key = triggerKey(appId, trigger.id);
     if (trigger.on.kind === "schedule") {
-      const cursor = await config.store.records(SCHEDULE).get(key);
+      const cursor = await engine.get(SCHEDULE, key);
       if (cursor === null) {
-        await config.store.records(SCHEDULE).put({ id: key, data: { lastFiredAt: iso() }, refs: appRef(appId) });
+        await engine.put(SCHEDULE, { id: key, data: { lastFiredAt: iso() }, refs: appRef(appId) });
       }
     }
     if (trigger.on.kind === "external") {
-      const secret = await config.store.records(WEBHOOK).get(key);
+      const secret = await engine.get(WEBHOOK, key);
       if (secret === null) {
         const bytes = globalThis.crypto.getRandomValues(new Uint8Array(32));
-        await config.store.records(WEBHOOK).put({ id: key, data: { secret: base64url(bytes) }, refs: appRef(appId) });
+        await engine.put(WEBHOOK, { id: key, data: { secret: base64url(bytes) }, refs: appRef(appId) });
       }
     }
     return { enabled: true, missing, ...(missing.length === 0 ? {} : { grantSetId }) };

--- a/packages/automations/src/consent.ts
+++ b/packages/automations/src/consent.ts
@@ -81,7 +81,7 @@ type CaptureRows = Pick<ConsentAccess, "writeCapture" | "isPendingAsk" | "pendin
 
 /** The capture collection itself: the row a pending ask is remembered by, and
  *  the two reads that say which asks are still open. */
-const createCaptureRows = ({ base: { config } }: Pick<ConsentDeps, "base">): CaptureRows => {
+const createCaptureRows = ({ base: { engine } }: Pick<ConsentDeps, "base">): CaptureRows => {
   /** A capture row, keyed by the approval it is the ask for. Captures are a
    *  GENERIC collection and the 02-store §5 erase cascade finds generic rows by
    *  their refs, so the refs are derived HERE rather than at each writer: an
@@ -89,7 +89,7 @@ const createCaptureRows = ({ base: { config } }: Pick<ConsentDeps, "base">): Cap
    *  asked. (Approvals need none: `vendo_approvals` is reserved, derives its own
    *  refs, and is erased by its subject column.) */
   const writeCapture = async (approvalId: string, capture: Capture): Promise<void> => {
-    await config.store.records(CAPTURES).put({
+    await engine.put(CAPTURES, {
       id: approvalId,
       data: { ...capture },
       refs: { subject: capture.subject, app_id: capture.appId, trigger_id: capture.triggerId },
@@ -100,7 +100,7 @@ const createCaptureRows = ({ base: { config } }: Pick<ConsentDeps, "base">): Cap
    *  or already decided is stale, and stale asks are not what a person is
    *  waiting on. */
   const isPendingAsk = async (approvalId: string): Promise<boolean> => {
-    const approval = await config.store.records(APPROVALS).get(approvalId);
+    const approval = await engine.get(APPROVALS, approvalId);
     if (approval === null) return false;
     const parsed = approvalRowSchema.safeParse(approval.data);
     return parsed.success && parsed.data.status === "pending" && parsed.data.voidedAt === undefined;
@@ -111,7 +111,7 @@ const createCaptureRows = ({ base: { config } }: Pick<ConsentDeps, "base">): Cap
    *  "capture exists" ≈ "ask is pending"; volume stays tiny (undecided asks
    *  only), so an unindexed scan is fine on every adapter. */
   const pendingCaptures = async (subject: string): Promise<Array<{ id: string; data: Capture }>> => {
-    const records = await allRecords(config.store.records(CAPTURES));
+    const records = await allRecords(engine, CAPTURES);
     const captures: Array<{ id: string; data: Capture }> = [];
     for (const record of records) {
       const parsed = captureSchema.safeParse(record.data);
@@ -129,7 +129,7 @@ const createDecisionSubscriber = (
   deps: Pick<ConsentDeps, "base" | "appRows" | "armed" | "grants">
     & Pick<CaptureRows, "pendingCaptures">,
 ): Pick<ConsentAccess, "spendApproval" | "handleDecision"> => {
-  const { base: { config, iso }, appRows, armed } = deps;
+  const { base: { config, engine, iso }, appRows, armed } = deps;
   const { grants, pendingCaptures } = deps;
   /**
    * Spends the approval this consent moment rode in on — through the guard when
@@ -153,7 +153,7 @@ const createDecisionSubscriber = (
       return await config.guard.spendApproval(record.id, data.request.ctx.principal) === "spent";
     }
     if (data.voidedAt !== undefined) return false;
-    await config.store.records(APPROVALS).put({
+    await engine.put(APPROVALS, {
       id: record.id,
       data: { ...data, consumedAt: iso() },
     });
@@ -161,17 +161,17 @@ const createDecisionSubscriber = (
   };
 
   const handleDecision = async (approvalId: string, approved: boolean): Promise<void> => {
-    const capture = await config.store.records(CAPTURES).get(approvalId);
+    const capture = await engine.get(CAPTURES, approvalId);
     if (capture !== null) {
       const parsed = captureSchema.parse(capture.data);
-      const approval = await config.store.records(APPROVALS).get(approvalId);
+      const approval = await engine.get(APPROVALS, approvalId);
       if (approved && approval !== null) {
         const data = approvalRowSchema.parse(approval.data);
         // Spend before granting: a yes the person took back at this instant
         // must arm nothing, and only one of the two can win the transition.
         if (await spendApproval(approval)) await grants.mintGrant(data.request, parsed.triggerId);
       }
-      await config.store.records(CAPTURES).delete(approvalId);
+      await engine.delete(CAPTURES, approvalId);
       if (!approved) {
         // Deny is transactional at the DECISION (criterion 19, deny half),
         // but disarms ONLY a consent moment that ended with NOTHING granted:
@@ -194,7 +194,7 @@ const createDecisionSubscriber = (
       }
       return;
     }
-    const approval = await config.store.records(APPROVALS).get(approvalId);
+    const approval = await engine.get(APPROVALS, approvalId);
     if (approval === null || !approved) return;
     const data = approvalRowSchema.parse(approval.data);
     if (
@@ -215,7 +215,7 @@ const createDecisionSubscriber = (
       // Without it the grant would be app-wide and the next firing of a DIFFERENT
       // trigger would inherit authority nobody consented to for it.
       const runId = data.request.ctx.trigger?.runId;
-      const runRow = runId === undefined ? null : await config.store.records(RUNS).get(runId);
+      const runRow = runId === undefined ? null : await engine.get(RUNS, runId);
       const triggerId = runRow === null ? undefined : parseRunRecord(runRow).triggerId;
       if (await spendApproval(approval)) await grants.mintGrant(data.request, triggerId);
     }
@@ -297,7 +297,7 @@ const createGrantCapture = (
     & Pick<CaptureRows, "writeCapture" | "pendingCaptures">
     & Pick<ConsentAccess, "consentSurface">,
 ): Pick<ConsentAccess, "captureGrants"> => {
-  const { base: { config, iso }, grants, writeCapture, pendingCaptures, consentSurface } = deps;
+  const { base: { config, engine, iso }, grants, writeCapture, pendingCaptures, consentSurface } = deps;
   /** The tools a consent moment has to ask THIS subject about: the automation's
    *  surface minus whatever they already hold a live standing grant for.
    *
@@ -346,7 +346,7 @@ const createGrantCapture = (
       if (await grants.liveGrant(subject, appId, triggerId, descriptor, slug)) continue;
       const pending = pendingForApp.get(consentKey(item));
       if (pending !== undefined) {
-        const approval = await config.store.records(APPROVALS).get(pending.id);
+        const approval = await engine.get(APPROVALS, pending.id);
         const parsed = approval === null ? undefined : approvalRowSchema.safeParse(approval.data);
         if (parsed?.success === true && parsed.data.status === "pending") {
           // Adopt pre-set rows (and any stray sibling) into THE app's set so
@@ -359,7 +359,7 @@ const createGrantCapture = (
         }
         // A capture whose approval is gone or already decided is stale —
         // clear it and fall through to a fresh mint.
-        await config.store.records(CAPTURES).delete(pending.id);
+        await engine.delete(CAPTURES, pending.id);
       }
       const request: ApprovalRequest = {
         id: id("apr_"),
@@ -377,7 +377,7 @@ const createGrantCapture = (
         },
         createdAt: iso(),
       };
-      await config.store.records(APPROVALS).put({
+      await engine.put(APPROVALS, {
         id: request.id,
         data: { request, status: "pending", sessionId: ctx.sessionId },
       });
@@ -403,7 +403,7 @@ const createPermissionMiss = (
   deps: Pick<ConsentDeps, "base" | "runRows">
     & Pick<CaptureRows, "writeCapture" | "isPendingAsk" | "pendingCaptures">,
 ): Pick<ConsentAccess, "needsPermission"> => {
-  const { base: { config }, runRows, writeCapture, isPendingAsk, pendingCaptures } = deps;
+  const { base: { config, engine }, runRows, writeCapture, isPendingAsk, pendingCaptures } = deps;
   /**
    * A step met a permission nobody has granted. The run ends HERE, loudly.
    *
@@ -447,7 +447,7 @@ const createPermissionMiss = (
     step: Step,
     approvalId: string,
   ): Promise<void> => {
-    const approval = await config.store.records(APPROVALS).get(approvalId);
+    const approval = await engine.get(APPROVALS, approvalId);
     const parsed = approval === null ? undefined : approvalRowSchema.safeParse(approval.data);
     const request = parsed?.success === true ? parsed.data.request : undefined;
     const slug = request === undefined ? undefined : serviceToolSlug(request.call);
@@ -477,7 +477,7 @@ const createPermissionMiss = (
         // on the panel, and — when the ask below is closed — a capture still
         // sitting here would make the decision subscriber read a supersede as a
         // person's denial and disarm an automation nobody said no to.
-        await config.store.records(CAPTURES).delete(asked.id);
+        await engine.delete(CAPTURES, asked.id);
         // A STILL-OPEN arming ask for this same thing is now redundant: the
         // question is one question, and the run's ask is the one that carries
         // where it was met (`presence: "away"`, the appId, the run id). Left

--- a/packages/automations/src/document-edit-surface.ts
+++ b/packages/automations/src/document-edit-surface.ts
@@ -14,7 +14,7 @@ import { currentIntentHash, triggersOf, writeSponsorship } from "./sponsorship.j
 export type DocumentEditSurfaceDeps = { base: EngineBase; sponsorship: SponsorshipGateAccess };
 
 export const createDocumentEditSurface = (
-  { base: { iso }, sponsorship }: DocumentEditSurfaceDeps,
+  { base: { engine, iso }, sponsorship }: DocumentEditSurfaceDeps,
 ): Pick<AutomationsEngine, "onDocumentEdit"> => {
   const onTriggerEdit = async (next: AppDocument, trigger: Trigger, editor: string): Promise<void> => {
     // Through the migrating door: an edit is the other way a pre-list row can be
@@ -24,7 +24,7 @@ export const createDocumentEditSurface = (
     if (state.kind !== "row" || state.row.status !== "active") return;
     const row = state.row;
     if (editor !== row.sponsor) {
-      await writeSponsorship(sponsorship.sponsorships(), {
+      await writeSponsorship(engine, {
         ...row,
         status: "invalidated",
         reason: "edit",
@@ -41,7 +41,7 @@ export const createDocumentEditSurface = (
     // card rather than here.
     const hash = currentIntentHash(next, trigger);
     if (hash !== row.intentHash) {
-      await writeSponsorship(sponsorship.sponsorships(), { ...row, intentHash: hash });
+      await writeSponsorship(engine, { ...row, intentHash: hash });
     }
   };
 

--- a/packages/automations/src/engine-context.ts
+++ b/packages/automations/src/engine-context.ts
@@ -10,11 +10,13 @@
  *
  * Internal — not exported from the package root.
  */
+import { engineOverAdapter } from "@vendoai/core";
 import { createAppRows, type AppRowsAccess } from "./app-rows.js";
 import { createArmed, type ArmedAccess } from "./armed.js";
 import { createConsent, type ConsentAccess } from "./consent.js";
 import { createGrants, type GrantsAccess } from "./grants.js";
 import { createRunExecution, type RunExecutionAccess } from "./run-execution.js";
+import type { EngineOps } from "./rows.js";
 import { createRunRows, type RunRowsAccess } from "./run-rows.js";
 import { createSponsorshipGate, type SponsorshipGateAccess } from "./sponsorship-gate.js";
 import type { AutomationsConfig } from "./index.js";
@@ -22,6 +24,10 @@ import type { AutomationsConfig } from "./index.js";
 /** The closure primitives every module reads. */
 export interface EngineBase {
   config: AutomationsConfig;
+  /** Vendo's OWN drawers, through the named `engine` family — the allowlist
+   *  gate sits on every verb, so nothing outside it can be reached from here.
+   *  Host and generated-app data is not this door's business. */
+  engine: EngineOps;
   /** The clock, through the testability seam. */
   now(): Date;
   /** The same clock, as the ISO string every row and event is stamped with. */
@@ -59,7 +65,12 @@ export const createEngineModules = (config: AutomationsConfig): EngineModules =>
   const firesLocally = (kind: "schedule" | "external"): boolean =>
     config.localTriggerKinds === undefined || config.localTriggerKinds.has(kind);
 
-  const base: EngineBase = { config, now, iso, stopped, active, abortControllers, firesLocally };
+  // The composition's own 42-op surface when it resolved one; otherwise the
+  // same seven verbs over the adapter the host handed us. An unset slot is a
+  // route, not a downgrade.
+  const engine = config.ops?.engine ?? engineOverAdapter(config.store);
+
+  const base: EngineBase = { config, engine, now, iso, stopped, active, abortControllers, firesLocally };
   const appRows = createAppRows({ base });
   const armed = createArmed({ base, appRows });
   const grants = createGrants({ base });

--- a/packages/automations/src/grants.ts
+++ b/packages/automations/src/grants.ts
@@ -56,7 +56,7 @@ type GrantReads = Pick<
 
 /** The reads: the bound surface, and the ONE live-grant query the three
  *  fire-time questions are asked from. */
-const createGrantReads = ({ base: { config, now } }: GrantsDeps): GrantReads => {
+const createGrantReads = ({ base: { config, engine, now } }: GrantsDeps): GrantReads => {
   // `ctx` rides through so the projection seam (design §12) is not silently
   // dropped here. Both callers — enable and dryRun — are PRESENT-time
   // ceremonies, so nothing is withheld: the owner must still see and grant
@@ -80,7 +80,7 @@ const createGrantReads = ({ base: { config, now } }: GrantsDeps): GrantReads => 
     triggerId: string,
     tool?: string,
   ): Promise<PermissionGrant[]> => {
-    const records = await allRecords(config.store.records(GRANTS), {
+    const records = await allRecords(engine, GRANTS, {
       refs: { subject, app_id: appId, ...(tool === undefined ? {} : { tool }) },
     });
     const at = now().getTime();
@@ -148,7 +148,7 @@ const createGrantReads = ({ base: { config, now } }: GrantsDeps): GrantReads => 
 
 /** The write: what a decided approval turns into. */
 const createGrantMint = (
-  { base: { config, iso } }: GrantsDeps,
+  { base: { engine, iso } }: GrantsDeps,
 ): Pick<GrantsAccess, "mintGrant"> => {
   const mintGrant = async (request: ApprovalRequest, triggerId: string | undefined): Promise<string> => {
     // A connector dispatch is granted at the width of its SLUG, never its tool
@@ -171,7 +171,7 @@ const createGrantMint = (
       source: "automation",
       grantedAt: iso(),
     };
-    await config.store.records(GRANTS).put({
+    await engine.put(GRANTS, {
       id: grant.id,
       data: grant,
       refs: {

--- a/packages/automations/src/index.ts
+++ b/packages/automations/src/index.ts
@@ -19,6 +19,7 @@ import type {
   RunContext,
   RunId,
   StoreAdapter,
+  StoreOps,
   ToolOutcome,
   ToolRegistry,
   Trigger,
@@ -53,6 +54,15 @@ export interface AutomationsConfig {
   /** Core seam: run audit events + approval resumption (onApprovalDecision). */
   guard: Guard;
   store: StoreAdapter;
+  /** The 42-op surface over that SAME store, when the composition could resolve
+   *  one (`selectStoreOps` answers `undefined` for a store with neither its own
+   *  ops nor a SQL handle). Every drawer this engine owns — apps, runs, grants,
+   *  approvals, captures, the arm rows, the schedule cursors, the webhook
+   *  secrets, the delivery ledger, sponsorship — is reached through
+   *  `ops.engine.*`, so the allowlist gate applies to all of them. Unset, the
+   *  same seven verbs are served straight off the adapter's own record doors
+   *  (`engineOverAdapter`), which is what a host's BYO `StoreAdapter` gets. */
+  ops?: StoreOps;
   /** Absent → agentic runs unavailable, steps still work. */
   runner?: AgentRunner;
   /** The SAME per-call risk resolver the composition gave the guard. Arm-time

--- a/packages/automations/src/ingestion-surface.ts
+++ b/packages/automations/src/ingestion-surface.ts
@@ -39,7 +39,7 @@ export type IngestionSurfaceDeps = {
 const createTickDoor = (
   deps: IngestionSurfaceDeps,
 ): Pick<AutomationsEngine, "tick" | "start"> => {
-  const { base: { config, now, firesLocally }, appRows, armed, execution } = deps;
+  const { base: { engine, now, firesLocally }, appRows, armed, execution } = deps;
   let tickTail: Promise<void> = Promise.resolve();
   const runTick: AutomationsEngine["tick"] = async (providedNow) => {
     // Cloud (or whatever other authority) already fires schedule automations for this
@@ -60,11 +60,10 @@ const createTickDoor = (
     const dueTriggers = rows.flatMap((row) => armed.armedTriggers(row, armedKeys)
       .filter((trigger) => trigger.on.kind === "schedule")
       .map((trigger) => ({ row, trigger })));
-    const scheduleRecords = config.store.records(SCHEDULE);
     const cursorKeys = dueTriggers.map(({ row, trigger }) => triggerKey(row.doc.id, trigger.id));
     const cursorRecords = cursorKeys.length === 0
       ? []
-      : await allRecords(scheduleRecords, { ids: cursorKeys });
+      : await allRecords(engine, SCHEDULE, { ids: cursorKeys });
     const cursorById = new Map(cursorRecords.map((record) => [record.id, record]));
     const fired: FiredSchedule[] = [];
     for (const { row, trigger: declared } of dueTriggers) {
@@ -91,10 +90,7 @@ const createTickDoor = (
         scheduledFor = trigger.on.at;
       }
       if (scheduledFor === undefined) {
-        if (cursorRecord === null) {
-          if (scheduleRecords.atomic === undefined) await scheduleRecords.put(cursorRow(cursor));
-          else await scheduleRecords.atomic.insertIfAbsent(cursorRow(cursor));
-        }
+        if (cursorRecord === null) await engine.insertIfAbsent(SCHEDULE, cursorRow(cursor));
         continue;
       }
       const nextCursor = {
@@ -104,12 +100,15 @@ const createTickDoor = (
       };
       let claimed = true;
       if (cursorRecord === null) {
-        if (scheduleRecords.atomic === undefined) await scheduleRecords.put(cursorRow(nextCursor));
-        else claimed = await scheduleRecords.atomic.insertIfAbsent(cursorRow(nextCursor)) !== null;
-      } else if (scheduleRecords.atomic !== undefined && cursorRecord.revision !== undefined) {
-        claimed = await scheduleRecords.atomic.compareAndSwap(cursorRow(nextCursor), cursorRecord.revision) !== null;
+        claimed = await engine.insertIfAbsent(SCHEDULE, cursorRow(nextCursor)) !== null;
+      } else if (cursorRecord.revision !== undefined) {
+        claimed = await engine.compareAndSwap(SCHEDULE, cursorRow(nextCursor), cursorRecord.revision) !== null;
       } else {
-        await scheduleRecords.put(cursorRow(nextCursor));
+        // The cursor exists but carries NO revision, so there is nothing to
+        // compare against: an adapter without the optional atomic capability
+        // issues none. Last write wins, which is what a store that cannot
+        // linearize this can offer — one tick at a time is the norm.
+        await engine.put(SCHEDULE, cursorRow(nextCursor));
       }
       if (!claimed) continue;
       fired.push({ row, trigger, scheduledFor, firedAt: atIso });
@@ -235,7 +234,7 @@ const createWebhookRefusals = (
 const createWebhookDoor = (
   deps: IngestionSurfaceDeps & WebhookRefusals,
 ): Pick<AutomationsEngine, "webhook"> => {
-  const { base: { config, now, iso, firesLocally }, appRows, armed, execution } = deps;
+  const { base: { engine, now, iso, firesLocally }, appRows, armed, execution } = deps;
   const { envelope, rejectWebhook } = deps;
   const inFlightDeliveries = new Set<string>();
   const webhook: AutomationsEngine["webhook"] = async (request) => {
@@ -283,7 +282,7 @@ const createWebhookDoor = (
     for (const row of rows) {
       for (const trigger of armed.armedTriggers(row, armedKeys)) {
         if (trigger.on.kind !== "external" || trigger.on.connector !== source) continue;
-        const secretRecord = await config.store.records(WEBHOOK).get(triggerKey(row.doc.id, trigger.id));
+        const secretRecord = await engine.get(WEBHOOK, triggerKey(row.doc.id, trigger.id));
         if (secretRecord === null) continue;
         const secret = webhookSchema.safeParse(secretRecord.data);
         if (!secret.success) continue;
@@ -316,7 +315,6 @@ const createWebhookDoor = (
       }
       inFlightDeliveries.add(deliveryKey);
       try {
-        const deliveries = config.store.records(DELIVERIES);
         const delivery = {
           id: deliveryKey,
           data: {
@@ -327,13 +325,9 @@ const createWebhookDoor = (
           },
           refs: appRef(row.doc.id),
         };
-        if (deliveries.atomic === undefined) {
-          if (await deliveries.get(deliveryKey) !== null) {
-            deduped += 1;
-            continue;
-          }
-          await deliveries.put(delivery);
-        } else if (await deliveries.atomic.insertIfAbsent(delivery) === null) {
+        // Insert-ONCE: the delivery ledger is the only thing standing between a
+        // redelivered webhook and a second run of the automation.
+        if (await engine.insertIfAbsent(DELIVERIES, delivery) === null) {
           deduped += 1;
           continue;
         }

--- a/packages/automations/src/list-surface.ts
+++ b/packages/automations/src/list-surface.ts
@@ -13,7 +13,7 @@ import type { AutomationsEngine } from "./index.js";
 import { stopFor } from "./messages.js";
 import { allRecords, parseAppRow } from "./rows.js";
 import type { SponsorshipGateAccess } from "./sponsorship-gate.js";
-import { sponsorshipSchema, triggerKey, triggersOf } from "./sponsorship.js";
+import { SPONSORSHIPS, sponsorshipSchema, triggerKey, triggersOf } from "./sponsorship.js";
 import { APPS } from "./types.js";
 
 export type ListSurfaceDeps = {
@@ -25,12 +25,12 @@ export type ListSurfaceDeps = {
 };
 
 export const createListSurface = (deps: ListSurfaceDeps): Pick<AutomationsEngine, "list"> => {
-  const { base: { config }, appRows, armed } = deps;
+  const { base: { config, engine }, appRows, armed } = deps;
   const { sponsorship, consent } = deps;
 
   const list: AutomationsEngine["list"] = async (ctx) => {
     const subject = ctx.principal.subject;
-    const records = await allRecords(config.store.records(APPS), { refs: { subject } });
+    const records = await allRecords(engine, APPS, { refs: { subject } });
     const rows = records.map(parseAppRow).filter((row) => row.subject === subject);
     const seen = new Set(rows.map((row) => row.doc.id));
     // An ORG-held app's row subject is the org id (§9.5), so matching only the
@@ -40,7 +40,7 @@ export const createListSurface = (deps: ListSurfaceDeps): Pick<AutomationsEngine
     // come from the ctx (§9.1: asserted, never stored) and `can(editor)` still
     // decides each row.
     for (const org of new Set((ctx.memberships ?? []).map(({ org: id }) => id))) {
-      for (const record of await allRecords(config.store.records(APPS), { refs: { subject: org } })) {
+      for (const record of await allRecords(engine, APPS, { refs: { subject: org } })) {
         const row = parseAppRow(record);
         if (row.subject !== org || seen.has(row.doc.id)) continue;
         if (await appRows.canEdit(ctx, row, row.doc.id)) {
@@ -59,14 +59,14 @@ export const createListSurface = (deps: ListSurfaceDeps): Pick<AutomationsEngine
     // Deduped: sponsorship is per (app, trigger), so sponsoring two triggers of
     // one app must still fetch that app once.
     const sponsoredElsewhere = [...new Set(
-      (await allRecords(sponsorship.sponsorships(), { refs: { subject } }))
+      (await allRecords(engine, SPONSORSHIPS, { refs: { subject } }))
         .map((record) => sponsorshipSchema.safeParse(record.data))
         .flatMap((parsed) => parsed.success ? [parsed.data.appId] : [])
         .filter((appId) => !seen.has(appId)),
     )];
     for (const record of sponsoredElsewhere.length === 0
       ? []
-      : await allRecords(config.store.records(APPS), { ids: sponsoredElsewhere })) {
+      : await allRecords(engine, APPS, { ids: sponsoredElsewhere })) {
       const row = parseAppRow(record);
       // Sponsoring is not access: an editor whose grant was revoked keeps the
       // row but loses the door, so `can(editor)` still decides.

--- a/packages/automations/src/rows.ts
+++ b/packages/automations/src/rows.ts
@@ -5,8 +5,8 @@
  *
  * Lifted out of engine.ts unchanged.
  */
-import { VendoError, type VendoRecord } from "@vendoai/core";
-import type { AutomationsConfig, RunRecord, RunStatus } from "./index.js";
+import { VendoError, type StoreOps, type VendoRecord } from "@vendoai/core";
+import type { RunRecord, RunStatus } from "./index.js";
 import { appRowSchema, runRowDataSchema, type AppData, type InternalRunRecord } from "./types.js";
 
 /** Every engine-owned generic row belongs to ONE app, and the 02-store §5 erase
@@ -20,14 +20,19 @@ export const clone = <T>(value: T): T => globalThis.structuredClone(value);
 export const id = (prefix: string): string => `${prefix}${globalThis.crypto.randomUUID()}`;
 export const message = (error: unknown): string => error instanceof Error ? error.message : String(error);
 
+/** The seven verbs this engine reaches Vendo's own drawers through. Named once
+ *  here because every module holds one and none of them holds a store. */
+export type EngineOps = StoreOps["engine"];
+
 export const allRecords = async (
-  records: ReturnType<AutomationsConfig["store"]["records"]>,
+  engine: EngineOps,
+  collection: string,
   query: { refs?: Record<string, string>; ids?: string[] } = {},
 ): Promise<VendoRecord[]> => {
   const found: VendoRecord[] = [];
   let cursor: string | undefined;
   do {
-    const page = await records.list({ ...query, ...(cursor === undefined ? {} : { cursor }) });
+    const page = await engine.list(collection, { ...query, ...(cursor === undefined ? {} : { cursor }) });
     found.push(...page.records);
     if (page.cursor === undefined || page.cursor === cursor) break;
     cursor = page.cursor;

--- a/packages/automations/src/run-rows.ts
+++ b/packages/automations/src/run-rows.ts
@@ -42,7 +42,7 @@ export interface RunRowsAccess {
   finishStoppedIfNeeded(run: InternalRunRecord): Promise<boolean>;
 }
 
-export const createRunRows = ({ base: { config, iso, stopped } }: RunRowsDeps): RunRowsAccess => {
+export const createRunRows = ({ base: { config, engine, iso, stopped } }: RunRowsDeps): RunRowsAccess => {
   const audit = async (ctx: RunContext, status: string, extra: Record<string, Json> = {}): Promise<void> => {
     const event: AuditEvent = {
       id: id("aud_"),
@@ -58,7 +58,7 @@ export const createRunRows = ({ base: { config, iso, stopped } }: RunRowsDeps): 
   };
 
   const writeRun = async (record: InternalRunRecord): Promise<boolean> => {
-    const stored = await config.store.records(RUNS).get(record.id);
+    const stored = await engine.get(RUNS, record.id);
     if (stored !== null) {
       const current = parseRunRecord(stored);
       if (terminalStatus(current.status)) {
@@ -66,7 +66,7 @@ export const createRunRows = ({ base: { config, iso, stopped } }: RunRowsDeps): 
         return false;
       }
     }
-    await config.store.records(RUNS).put({
+    await engine.put(RUNS, {
       id: record.id,
       data: {
         appId: record.appId,
@@ -113,7 +113,7 @@ export const createRunRows = ({ base: { config, iso, stopped } }: RunRowsDeps): 
       run.status = "stopped";
       return true;
     }
-    const stored = await config.store.records(RUNS).get(run.id);
+    const stored = await engine.get(RUNS, run.id);
     if (stored !== null) {
       const current = parseRunRecord(stored);
       if (terminalStatus(current.status)) {

--- a/packages/automations/src/runs-surface.ts
+++ b/packages/automations/src/runs-surface.ts
@@ -29,9 +29,9 @@ export type RunsSurfaceDeps = {
 const createRunReadDoors = (
   deps: Pick<RunsSurfaceDeps, "base" | "appRows">,
 ): Pick<AutomationsEngine["runs"], "get" | "list"> => {
-  const { base: { config }, appRows } = deps;
+  const { base: { engine }, appRows } = deps;
   const runsGet: AutomationsEngine["runs"]["get"] = async (runId, ctx) => {
-    const stored = await config.store.records(RUNS).get(runId);
+    const stored = await engine.get(RUNS, runId);
     if (stored === null) return null;
     const run = parseRunRecord(stored);
     // §8 editor = edit: the person the automation RUNS AS sees its history, not
@@ -58,7 +58,7 @@ const createRunReadDoors = (
     // the store cursor always sits at the consumption boundary: pages never
     // overfill and the returned cursor never skips rows.
     for (let pages = 0; pages < 20 && runs.length < RUNS_PAGE_LIMIT; pages += 1) {
-      const page = await config.store.records(RUNS).list({
+      const page = await engine.list(RUNS, {
         refs,
         limit: RUNS_PAGE_LIMIT - runs.length,
         ...(cursor === undefined ? {} : { cursor }),
@@ -89,10 +89,10 @@ const createRunReadDoors = (
 const createRunControlDoors = (
   deps: RunsSurfaceDeps,
 ): Pick<AutomationsEngine["runs"], "stop" | "rerun"> => {
-  const { base: { config, stopped, active, abortControllers }, appRows } = deps;
+  const { base: { engine, stopped, active, abortControllers }, appRows } = deps;
   const { armed, runRows, sponsorship, execution } = deps;
   const runsStop: AutomationsEngine["runs"]["stop"] = async (runId, ctx) => {
-    const stored = await config.store.records(RUNS).get(runId);
+    const stored = await engine.get(RUNS, runId);
     if (stored === null) throw new VendoError("not-found", `run not found: ${runId}`);
     const run = parseRunRecord(stored);
     const app = await appRows.editableAppOrNull(run.appId, ctx);
@@ -120,7 +120,7 @@ const createRunControlDoors = (
    *  for anyone who cannot. A trigger nobody has armed is refused rather than
    *  fired — "run it again" may not be a way to run something switched off. */
   const runsRerun: AutomationsEngine["runs"]["rerun"] = async (runId, ctx) => {
-    const stored = await config.store.records(RUNS).get(runId);
+    const stored = await engine.get(RUNS, runId);
     if (stored === null) throw new VendoError("not-found", `run not found: ${runId}`);
     const run = parseRunRecord(stored);
     const app = await appRows.editableAppOrNull(run.appId, ctx);

--- a/packages/automations/src/sponsorship-gate.ts
+++ b/packages/automations/src/sponsorship-gate.ts
@@ -7,7 +7,6 @@
  */
 import {
   type AppDocument,
-  type RecordStore,
   type RunContext,
   type Trigger,
 } from "@vendoai/core";
@@ -18,7 +17,6 @@ import { allRecords } from "./rows.js";
 import {
   currentIntentHash,
   readSponsorship,
-  SPONSORED,
   SPONSORSHIPS,
   sponsorshipSchema,
   triggerKey,
@@ -32,10 +30,6 @@ import type { AppData, InternalRunRecord } from "./types.js";
 export type SponsorshipGateDeps = { base: EngineBase; appRows: AppRowsAccess };
 
 export interface SponsorshipGateAccess {
-  /** The sponsorship collection. */
-  sponsorships(): RecordStore;
-  /** The era markers that outlive an erase of the sponsor. */
-  sponsoredEra(): RecordStore;
   /** The ONE sponsorship read every gate goes through. */
   sponsorshipState(
     doc: AppDocument,
@@ -55,18 +49,12 @@ export interface SponsorshipGateAccess {
   ): Promise<{ reason: NonNullable<Sponsorship["reason"]>; summary: string } | undefined>;
 }
 
-type SponsorshipReader = Pick<
-  SponsorshipGateAccess,
-  "sponsorships" | "sponsoredEra" | "sponsorshipState" | "sponsorshipsFor"
->;
+type SponsorshipReader = Pick<SponsorshipGateAccess, "sponsorshipState" | "sponsorshipsFor">;
 
 /** The sponsorship rows, and the ONE read every gate goes through. */
 const createSponsorshipReader = (
-  { base: { config } }: Pick<SponsorshipGateDeps, "base">,
+  { base: { engine } }: Pick<SponsorshipGateDeps, "base">,
 ): SponsorshipReader => {
-  const sponsorships = (): RecordStore => config.store.records(SPONSORSHIPS);
-  const sponsoredEra = (): RecordStore => config.store.records(SPONSORED);
-
   /** The sponsorship as the gates see it: the row, or — when the row is gone but
    *  the app was sponsored once — the fact that its sponsor was ERASED.
    *
@@ -80,9 +68,9 @@ const createSponsorshipReader = (
     | { kind: "row"; row: Sponsorship; revision?: string }
   > => {
     const appId = doc.id;
-    const found = await readSponsorship(sponsorships(), appId, triggerId);
+    const found = await readSponsorship(engine, appId, triggerId);
     if (found !== undefined) return { kind: "row", ...found };
-    return await wasSponsored(sponsoredEra(), appId, triggerId) ? { kind: "erased" } : { kind: "none" };
+    return await wasSponsored(engine, appId, triggerId) ? { kind: "erased" } : { kind: "none" };
   };
 
   /** Every sponsorship row for these apps' triggers, in ONE query. */
@@ -91,21 +79,21 @@ const createSponsorshipReader = (
       triggersOf(row.doc).map((trigger) => triggerKey(row.doc.id, trigger.id)));
     if (keys.length === 0) return new Map();
     const byTrigger = new Map<string, Sponsorship>();
-    for (const record of await allRecords(sponsorships(), { ids: keys })) {
+    for (const record of await allRecords(engine, SPONSORSHIPS, { ids: keys })) {
       const parsed = sponsorshipSchema.safeParse(record.data);
       if (parsed.success) byTrigger.set(triggerKey(parsed.data.appId, parsed.data.triggerId), parsed.data);
     }
     return byTrigger;
   };
 
-  return { sponsorships, sponsoredEra, sponsorshipState, sponsorshipsFor };
+  return { sponsorshipState, sponsorshipsFor };
 };
 
 /** §9.9 — who a firing runs as, and whether it may run at all. */
 const createRunIdentity = (
-  deps: SponsorshipGateDeps & Pick<SponsorshipReader, "sponsorships" | "sponsorshipState">,
+  deps: SponsorshipGateDeps & Pick<SponsorshipReader, "sponsorshipState">,
 ): Pick<SponsorshipGateAccess, "baseRunContext" | "runContext" | "sponsorshipRefusal"> => {
-  const { base: { config, iso }, appRows, sponsorships, sponsorshipState } = deps;
+  const { base: { config, engine, iso }, appRows, sponsorshipState } = deps;
   /** The run's context before any seam is consulted — a pure function of the run
    *  and a subject, so it cannot fail. It is what a failed identity resolution
    *  still audits under: a fire that cannot even resolve who it runs as must
@@ -174,7 +162,7 @@ const createRunIdentity = (
     const refusal = (reason: NonNullable<Sponsorship["reason"]>) => stopFor(reason, app.doc.name);
     if (row.status !== "active") return refusal(row.reason ?? "edit");
     const invalidate = async (reason: NonNullable<Sponsorship["reason"]>) => {
-      await writeSponsorship(sponsorships(), {
+      await writeSponsorship(engine, {
         ...row,
         status: "invalidated",
         reason,

--- a/packages/automations/src/sponsorship.ts
+++ b/packages/automations/src/sponsorship.ts
@@ -5,10 +5,10 @@ import {
   type AppIntent,
   type IsoDateTime,
   type Json,
-  type RecordStore,
   type Trigger,
 } from "@vendoai/core";
 import { z } from "zod";
+import type { EngineOps } from "./rows.js";
 
 /** Build contract §9.9 — sponsorship lives in its OWN routed collection, never
  *  on the app row: the row is the automation's declaration, this is who it runs
@@ -120,11 +120,11 @@ export const currentIntentHash = (doc: AppDocument, trigger: Trigger | undefined
  *  to running as the app's owner. That is the intended answer: an unreadable
  *  sponsorship is not evidence that nobody took the automation on. */
 export const readSponsorship = async (
-  records: RecordStore,
+  engine: EngineOps,
   appId: string,
   triggerId: string,
 ): Promise<{ row: Sponsorship; revision?: string } | undefined> => {
-  const record = await records.get(triggerKey(appId, triggerId));
+  const record = await engine.get(SPONSORSHIPS, triggerKey(appId, triggerId));
   if (record === null) return undefined;
   const parsed = sponsorshipSchema.safeParse(record.data);
   if (!parsed.success) return undefined;
@@ -138,8 +138,8 @@ export const readSponsorship = async (
 const sponsorshipRefs = (row: Sponsorship): Record<string, string> =>
   ({ subject: row.sponsor, app_id: row.appId });
 
-export const writeSponsorship = async (records: RecordStore, row: Sponsorship): Promise<void> => {
-  await records.put({
+export const writeSponsorship = async (engine: EngineOps, row: Sponsorship): Promise<void> => {
+  await engine.put(SPONSORSHIPS, {
     id: triggerKey(row.appId, row.triggerId),
     data: { ...row },
     refs: sponsorshipRefs(row),
@@ -148,20 +148,20 @@ export const writeSponsorship = async (records: RecordStore, row: Sponsorship): 
 
 /** Record that this trigger is sponsored, without recording WHO. Idempotent. */
 export const markSponsored = async (
-  records: RecordStore,
+  engine: EngineOps,
   appId: string,
   triggerId: string,
   at: IsoDateTime,
 ): Promise<void> => {
   const id = triggerKey(appId, triggerId);
-  if (await records.get(id) !== null) return;
-  await records.put({ id, data: { appId, triggerId, since: at }, refs: { app_id: appId } });
+  if (await engine.get(SPONSORED, id) !== null) return;
+  await engine.put(SPONSORED, { id, data: { appId, triggerId, since: at }, refs: { app_id: appId } });
 };
 
 /** Has this trigger ever been sponsored? A `false` here is what keeps automations
  *  armed before this lane shipped running as their owner. */
 export const wasSponsored = async (
-  records: RecordStore,
+  engine: EngineOps,
   appId: string,
   triggerId: string,
-): Promise<boolean> => await records.get(triggerKey(appId, triggerId)) !== null;
+): Promise<boolean> => await engine.get(SPONSORED, triggerKey(appId, triggerId)) !== null;

--- a/packages/core/src/engine-over-adapter.ts
+++ b/packages/core/src/engine-over-adapter.ts
@@ -46,15 +46,17 @@ export function engineOverAdapter(store: StoreAdapter): StoreOps["engine"] {
       if (await records.get(record.id) !== null) return null;
       return await records.put(record);
     },
-    /** No emulation here, deliberately: a revision is the token this compares
-     *  against, and an adapter with no `atomic` never issues one — so a caller
-     *  holding a revision is talking to a door that has the capability. A
-     *  last-write-wins stand-in would silently drop the staleness check. */
+    /** Same degradation, and it is narrower than it looks. A revision is the
+     *  token this compares against, and `VendoRecord.revision` is documented as
+     *  present only when the store exposes `atomic` — so on a door that honors
+     *  that, no caller can ever hold a revision and this path is unreachable.
+     *  It is reached only by a door that hands out revisions it cannot enforce,
+     *  where the token means nothing and there is genuinely nothing to compare.
+     *  Last write wins, which is what the blocks did in their own
+     *  `atomic === undefined` branches before they moved onto this family. */
     compareAndSwap: async (collection, record, expectedRevision) => {
       const records = door(collection);
-      if (records.atomic === undefined) {
-        throw new VendoError("not-implemented", `${collection} does not support compareAndSwap`);
-      }
+      if (records.atomic === undefined) return await records.put(record);
       return await records.atomic.compareAndSwap(record, expectedRevision);
     },
   };

--- a/packages/core/src/engine-over-adapter.ts
+++ b/packages/core/src/engine-over-adapter.ts
@@ -1,0 +1,61 @@
+import { assertEngineCollection } from "./engine-collections.js";
+import { VendoError } from "./errors.js";
+import type { RecordStore, StoreAdapter, StoreOps } from "./store.js";
+
+/** The `engine` family over a bare {@link StoreAdapter}.
+ *
+ *  Every block that owns Vendo drawers (automations, guard, apps) reads them
+ *  through `ops.engine.*`, but `selectStoreOps` answers `undefined` for a store
+ *  with neither its own ops surface nor a SQL handle — and a host constructing a
+ *  block DIRECTLY passes only a `StoreAdapter`. This is that store's engine
+ *  family: the allowlist gate in front, the adapter's own record door behind.
+ *  It lives in core because none of those blocks may import `@vendoai/store`.
+ *
+ *  `records()` is called per verb and never cached: an adapter is free to mint a
+ *  fresh handle each time, and fixtures that wrap one to inject a failure depend
+ *  on it. */
+export function engineOverAdapter(store: StoreAdapter): StoreOps["engine"] {
+  const door = (collection: string): RecordStore => {
+    assertEngineCollection(collection);
+    return store.records(collection);
+  };
+  return {
+    get: async (collection, id) => await door(collection).get(id),
+    put: async (collection, record) => await door(collection).put(record),
+    delete: async (collection, id) => {
+      await door(collection).delete(id);
+    },
+    list: async (collection, query) => await door(collection).list(query),
+    claim: async (collection, expected, replacement) => {
+      const records = door(collection);
+      if (records.claim === undefined) {
+        throw new VendoError("not-implemented", `${collection} does not support claim`);
+      }
+      return await records.claim(expected, replacement);
+    },
+    /** `RecordStore.atomic` is OPTIONAL (02-store §4), so an adapter without it
+     *  gets the check-then-put every caller used to hand-roll behind an
+     *  `atomic === undefined` branch. It is not atomic and does not pretend to
+     *  be — it is what those call sites already did, in one place, so moving a
+     *  block onto this family does not quietly turn a working BYO adapter into
+     *  a `not-implemented`. An adapter that HAS the capability always gets the
+     *  real one. */
+    insertIfAbsent: async (collection, record) => {
+      const records = door(collection);
+      if (records.atomic !== undefined) return await records.atomic.insertIfAbsent(record);
+      if (await records.get(record.id) !== null) return null;
+      return await records.put(record);
+    },
+    /** No emulation here, deliberately: a revision is the token this compares
+     *  against, and an adapter with no `atomic` never issues one — so a caller
+     *  holding a revision is talking to a door that has the capability. A
+     *  last-write-wins stand-in would silently drop the staleness check. */
+    compareAndSwap: async (collection, record, expectedRevision) => {
+      const records = door(collection);
+      if (records.atomic === undefined) {
+        throw new VendoError("not-implemented", `${collection} does not support compareAndSwap`);
+      }
+      return await records.atomic.compareAndSwap(record, expectedRevision);
+    },
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,6 +39,7 @@ export * from "./sse-keepalive.js";
 export * from "./store.js";
 export * from "./store-wire.js";
 export * from "./engine-collections.js";
+export * from "./engine-over-adapter.js";
 export * from "./stream-parts.js";
 export * from "./tool-envelopes.js";
 export * from "./tools.js";

--- a/packages/core/tests/engine-over-adapter.test.ts
+++ b/packages/core/tests/engine-over-adapter.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import { engineOverAdapter } from "../src/engine-over-adapter.js";
+import type { VendoError } from "../src/errors.js";
+import type {
+  BlobStore,
+  RecordInput,
+  RecordQuery,
+  RecordStore,
+  StoreAdapter,
+  VendoRecord,
+} from "../src/store.js";
+
+/** Both on the engine allowlist (engine-collections.ts), so the gate lets them
+ *  through and the tests below are about the door, not the allowlist. */
+const AUDIT = "vendo_audit";
+const EFFECTS = "vendo_effects";
+
+/** `claim` and `atomic` are OPTIONAL on RecordStore (02-store §4). Which of them
+ *  a BYO adapter actually implements is the whole subject of this file, so the
+ *  fake takes them as capabilities rather than always offering both. */
+type Caps = { claim: boolean; atomic: boolean };
+
+type Fake = {
+  store: StoreAdapter;
+  /** How many times `records()` has been asked for a handle. */
+  doorCount: () => number;
+};
+
+function fakeAdapter(caps: Caps): Fake {
+  const tables = new Map<string, Map<string, VendoRecord>>();
+  let doors = 0;
+  let seq = 0;
+
+  const tableFor = (collection: string): Map<string, VendoRecord> => {
+    const found = tables.get(collection);
+    if (found !== undefined) return found;
+    const fresh = new Map<string, VendoRecord>();
+    tables.set(collection, fresh);
+    return fresh;
+  };
+
+  /** A revision is handed out only when this door claims `atomic`, mirroring
+   *  VendoRecord.revision's contract ("present when the store exposes atomic"). */
+  const write = (rows: Map<string, VendoRecord>, input: RecordInput): VendoRecord => {
+    const now = "2026-08-10T00:00:00.000Z";
+    const previous = rows.get(input.id);
+    seq += 1;
+    const record: VendoRecord = {
+      id: input.id,
+      data: input.data,
+      ...(input.refs === undefined ? {} : { refs: input.refs }),
+      createdAt: previous?.createdAt ?? now,
+      updatedAt: now,
+      ...(caps.atomic ? { revision: `r${seq}` } : {}),
+    };
+    rows.set(input.id, record);
+    return record;
+  };
+
+  const records = (collection: string): RecordStore => {
+    doors += 1;
+    const rows = tableFor(collection);
+    const door: RecordStore = {
+      get: async (id) => rows.get(id) ?? null,
+      put: async (input) => write(rows, input),
+      delete: async (id) => {
+        rows.delete(id);
+      },
+      list: async (query?: RecordQuery) => ({
+        records: [...rows.values()].filter(
+          (row) => query?.ids === undefined || query.ids.includes(row.id),
+        ),
+      }),
+    };
+    if (caps.claim) {
+      door.claim = async (expected) => rows.has(expected.id);
+    }
+    if (caps.atomic) {
+      door.atomic = {
+        insertIfAbsent: async (input) => (rows.has(input.id) ? null : write(rows, input)),
+        compareAndSwap: async (input, expectedRevision) =>
+          rows.get(input.id)?.revision === expectedRevision ? write(rows, input) : null,
+      };
+    }
+    return door;
+  };
+
+  return {
+    store: {
+      records,
+      blobs: (): BlobStore => {
+        throw new Error("the engine family never reaches for blobs");
+      },
+      ensureSchema: async () => undefined,
+    },
+    doorCount: () => doors,
+  };
+}
+
+const caught = async (run: Promise<unknown>): Promise<VendoError> =>
+  await run.then(
+    () => {
+      throw new Error("expected a rejection");
+    },
+    (error: unknown) => error as VendoError,
+  );
+
+describe("engineOverAdapter — the engine family over a bare StoreAdapter", () => {
+  it("carries the seven verbs through to the adapter's own record door", async () => {
+    const engine = engineOverAdapter(fakeAdapter({ claim: true, atomic: true }).store);
+
+    const put = await engine.put(AUDIT, { id: "a1", data: { n: 1 }, refs: { app: "app_1" } });
+    expect(put).toMatchObject({ id: "a1", data: { n: 1 }, refs: { app: "app_1" } });
+    expect(await engine.get(AUDIT, "a1")).toMatchObject({ id: "a1", data: { n: 1 } });
+    expect(await engine.get(AUDIT, "absent")).toBeNull();
+
+    const listed = await engine.list(AUDIT);
+    expect(listed.records.map((row) => row.id)).toEqual(["a1"]);
+    expect((await engine.list(AUDIT, { ids: ["absent"] })).records).toEqual([]);
+
+    expect(await engine.claim(AUDIT, { id: "a1", data: { n: 1 } })).toBe(true);
+
+    await engine.delete(AUDIT, "a1");
+    expect(await engine.get(AUDIT, "a1")).toBeNull();
+  });
+
+  it("gates the collection name on every verb, refusing with `blocked`", async () => {
+    const engine = engineOverAdapter(fakeAdapter({ claim: true, atomic: true }).store);
+    // App data belongs to the appData family; the allowlist is what says so.
+    const refusal = await caught(engine.put("host_invoices", { id: "inv_1", data: {} }));
+    expect(refusal.code).toBe("blocked");
+    expect(refusal.message).toContain("host_invoices");
+  });
+
+  it("asks for a fresh handle per verb and never caches one", async () => {
+    // Fixtures wrap `records()` to inject a failure on a chosen call, so a
+    // cached handle would quietly make those fixtures unreachable.
+    const fake = fakeAdapter({ claim: true, atomic: true });
+    const engine = engineOverAdapter(fake.store);
+    await engine.put(AUDIT, { id: "a1", data: {} });
+    await engine.get(AUDIT, "a1");
+    await engine.list(AUDIT);
+    expect(fake.doorCount()).toBe(3);
+  });
+
+  it("refuses claim with `not-implemented` on a door that does not offer it", async () => {
+    const engine = engineOverAdapter(fakeAdapter({ claim: false, atomic: true }).store);
+    const refusal = await caught(engine.claim(AUDIT, { id: "a1", data: {} }));
+    expect(refusal.code).toBe("not-implemented");
+    expect(refusal.message).toContain(AUDIT);
+  });
+
+  describe("a door WITH the atomic capability gets the real thing", () => {
+    it("insertIfAbsent lets the first writer win and answers null to the second", async () => {
+      const engine = engineOverAdapter(fakeAdapter({ claim: true, atomic: true }).store);
+      expect(await engine.insertIfAbsent(EFFECTS, { id: "e1", data: { v: 1 } }))
+        .toMatchObject({ id: "e1", data: { v: 1 } });
+      expect(await engine.insertIfAbsent(EFFECTS, { id: "e1", data: { v: 2 } })).toBeNull();
+    });
+
+    it("compareAndSwap honors the revision token and rejects a stale one", async () => {
+      const engine = engineOverAdapter(fakeAdapter({ claim: true, atomic: true }).store);
+      const created = await engine.put(EFFECTS, { id: "e1", data: { v: 1 } });
+      expect(created.revision).toBeDefined();
+      const revision = created.revision ?? "";
+
+      expect(await engine.compareAndSwap(EFFECTS, { id: "e1", data: { v: 2 } }, revision))
+        .toMatchObject({ data: { v: 2 } });
+      // The token has moved on, so the same revision no longer matches.
+      expect(await engine.compareAndSwap(EFFECTS, { id: "e1", data: { v: 3 } }, revision)).toBeNull();
+    });
+  });
+
+  describe("a door WITHOUT it degrades instead of failing closed", () => {
+    // The documented promise (engine-over-adapter.ts:36-56): moving a block onto
+    // this family must not turn a working BYO adapter into a `not-implemented`.
+    it("insertIfAbsent becomes check-then-put, keeping the first write", async () => {
+      const engine = engineOverAdapter(fakeAdapter({ claim: true, atomic: false }).store);
+      expect(await engine.insertIfAbsent(EFFECTS, { id: "e1", data: { v: 1 } }))
+        .toMatchObject({ id: "e1", data: { v: 1 } });
+      expect(await engine.insertIfAbsent(EFFECTS, { id: "e1", data: { v: 2 } })).toBeNull();
+      expect(await engine.get(EFFECTS, "e1")).toMatchObject({ data: { v: 1 } });
+    });
+
+    it("compareAndSwap becomes last-write-wins, because the token means nothing", async () => {
+      const engine = engineOverAdapter(fakeAdapter({ claim: true, atomic: false }).store);
+      const created = await engine.put(EFFECTS, { id: "e1", data: { v: 1 } });
+      // A door with no atomic hands out no revision, so no caller can hold one.
+      expect(created.revision).toBeUndefined();
+      expect(await engine.compareAndSwap(EFFECTS, { id: "e1", data: { v: 2 } }, "unenforceable"))
+        .toMatchObject({ data: { v: 2 } });
+      expect(await engine.get(EFFECTS, "e1")).toMatchObject({ data: { v: 2 } });
+    });
+  });
+});

--- a/packages/vendo/src/compose-automations.ts
+++ b/packages/vendo/src/compose-automations.ts
@@ -11,7 +11,7 @@ import { assembleSystemPrompt } from "./prompt.js";
 /** The automations engine, and the arming seam the apps runtime reads back. */
 export const composeAutomations = (composition: VendoComposition): Pick<VendoComposition,
   "hostedStoreComposed" | "automations" | "automationsForArming"> => {
-  const { store, apps, boundTools, guard, harness, files, capability, inference } = composition;
+  const { store, ops, apps, boundTools, guard, harness, files, capability, inference } = composition;
   const { system, resolveRisk, access, membershipsSeam, automationsMounted } = composition;
   // Wave 2 (Cloud auto): a keyed deployment's schedule- and external-triggered
   // automations already run on Vendo Cloud — its scheduler fires due schedules and
@@ -30,6 +30,11 @@ export const composeAutomations = (composition: VendoComposition): Pick<VendoCom
     tools: boundTools,
     guard,
     store,
+    // The engine family for this block's own drawers, over the SAME store.
+    // Absent for a store with neither its own ops nor a SQL handle — the block
+    // then serves the same verbs off the adapter itself, so an unset slot is a
+    // route, not a downgrade.
+    ...(ops === undefined ? {} : { ops }),
     // An agentic firing is ONE non-interactive harness run on the deployment's
     // own brain — the same runtime, the same guard-bound choke point and the same
     // durable workspace a chat turn gets, with `interactive: false` and the


### PR DESCRIPTION
Generic `records.*` is coming off the hosted store wire. `packages/automations`
is the first block through the door: all 41 `store.records(<collection>)` sites
become `ops.engine.*(<collection>, …)`, so the `assertEngineCollection` gate
applies to every drawer this engine owns.

```
$ grep -rn "\.records(" packages/automations/src --include='*.ts'
$ echo $?
1
```

Same collection, same verb, same arguments, same order. **Every existing test
passes unmodified** — no test file is touched by this PR.

## The config slot

`AutomationsConfig` gains an optional `ops: StoreOps` beside `store`, threaded
from `composeAutomations`. Optional, not required, for two reasons:
`selectStoreOps` answers `undefined` for a store with neither its own ops
surface nor a SQL handle, and a host may construct the block directly with
nothing but a `StoreAdapter` — which is exactly what this package's own tests
do.

`engineOverAdapter` (new, `packages/core/src/engine-over-adapter.ts`) is that
store's engine family: the allowlist gate in front, the adapter's own record
door behind. It lives in core because automations, guard and apps all need it
and none of them may import `@vendoai/store` (`scripts/dependency-guard.mjs`).

## The `atomic === undefined` branches

`ingestion-surface.ts` carried three explicit `atomic === undefined` capability
checks plus one implicit fallback branch, present only because
`RecordStore.atomic` is optional. They come out of the *call sites*, but they
are **not deleted from the product** — they move into `engineOverAdapter`, which
is the one place that knows it is talking to a bare adapter:

- `insertIfAbsent` on a door with no `atomic` → check-then-put. This is
  verbatim what `ingestion-surface.ts` already did for `automations:deliveries`.
- `compareAndSwap` on a door with no `atomic` → last write wins.

That second one is load-bearing and a test proves it. `memoryStoreWithoutAtomic`
(`tests/engine.test.ts:154`) strips `atomic` while the underlying store still
stamps `revision`, so the original guard was a **conjunction** —
`atomic !== undefined && cursorRecord.revision !== undefined` — and dropping the
`atomic` half made *retains single-instance schedule behavior when the atomic
capability is absent* throw `not-implemented`. The revision-shaped branch stays
at the call site, where it belongs: a cursor row with no revision has nothing to
compare against whatever the door can do.

## Also

`SponsorshipGateAccess.sponsorships()` and `sponsoredEra()` are deleted. They
existed only to hand a `RecordStore` to the four sponsorship helpers, and those
now name their own collection.

## Verification

- `packages/automations`: 98/98 pass, 4 files, zero test files modified.
- Prove-it-can-fail: routing the `automations:deliveries` `insertIfAbsent` to a
  plain `engine.put` turns three tests red on both the atomic and non-atomic
  paths — *dedupes a replayed delivery-id — the second delivery starts no second
  run*, *verifies HMAC vectors, dedupes deliveries, rejects bad/stale signatures
  once, and emits matching host events*, and *dedupes webhook deliveries when the
  store lacks atomic claims*. Restored, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `@vendoai/automations` to route all engine-owned drawers through `ops.engine.*`, moving shared helpers to the engine family and enforcing the allowlist everywhere. Added `engineOverAdapter` in `@vendoai/core` to support hosts without a 42-op surface. No behavior change.

- **Refactors**
  - Replaced 41 `store.records(<collection>)` sites with `ops.engine.*`; the allowlist now covers all engine drawers.
  - `EngineBase` now exposes engine ops; modules no longer hold store handles.
  - `AutomationsConfig` adds optional `ops: StoreOps`; `@vendoai/vendo` comp passes it, else we use `engineOverAdapter(config.store)`.
  - `engineOverAdapter` provides the same seven verbs with safe fallbacks when `atomic` is missing; `claim` is passed through (throws `not-implemented` if unsupported).
  - Moved `allRecords` and sponsorship helpers to accept engine ops and name their collections; removed `SponsorshipGateAccess.sponsorships()` and `sponsoredEra()`.

- **Bug Fixes**
  - Removed an orphaned `sponsorship` dep from `arming-surface` after the engine-family migration.
  - Restored core test coverage by adding `engineOverAdapter` tests in `@vendoai/core` and exporting it from the package index; no runtime changes.

<sup>Written for commit 1bf640e299d7158c0d64b12003e75b5a24bbd24f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

