### PR TITLE
docs(mcp): the docs-rot gate follows #1139's restructure — pinned facts restored to their new homes

### DIFF
--- a/docs-site/capabilities/mcp.mdx
+++ b/docs-site/capabilities/mcp.mdx
@@ -422,6 +422,11 @@ type-check. Nothing is painted and whatever held the slot stays. The reason is
 the agent's to act on — a narrower retry on the same `app` beats rebuilding from
 scratch.
 
+This page is the door's internals. To do it: [set up the
+door](/existing-agents/mcp) for the client, and follow [the make-and-place
+walkthrough](/existing-agents/your-agent) for what `vendo_make` answers with and
+where the screen lands.
+
 ### HTTP apps open in-product
 
 Rung-4 HTTP apps run on a machine-served origin the shim cannot host, so the

--- a/packages/vendo/tests/mcp-byo-docs.docs.test.ts
+++ b/packages/vendo/tests/mcp-byo-docs.docs.test.ts
@@ -8,8 +8,9 @@ import { describe, expect, it } from "vitest";
  * package import, so it runs without a build.
  *
  * What it holds:
- *  1. the page exists, is in the nav, and every nav entry still resolves;
- *  2. the page names the door's make-and-place contract and its links resolve;
+ *  1. the setup page exists, is in the nav, and every nav entry still resolves;
+ *  2. the setup page opens the door, the playbook teaches the make-and-place
+ *     contract, and both pages' links resolve;
  *  3. capabilities/mcp.mdx no longer claims the door cannot create;
  *  4. the HTTP reference carries the three placement routes;
  *  5. the plugin skill teaches slot targeting and pin etiquette;
@@ -20,8 +21,16 @@ const REPO_ROOT = new URL("../../../", import.meta.url);
 const read = (path: string): Promise<string> => readFile(new URL(path, REPO_ROOT), "utf8");
 const readJson = async <T>(path: string): Promise<T> => JSON.parse(await read(path)) as T;
 
-const PAGE = "docs-site/existing-agents/mcp.mdx";
+/** Opening the door and connecting a client. */
+const SETUP_PAGE = "docs-site/existing-agents/mcp.mdx";
 const NAV_ENTRY = "existing-agents/mcp";
+/** #1139 split the story in two, and this gate follows the split rather than
+    holding the docs to a shape they deliberately left: the setup page opens the
+    door, and the make-and-place CONTRACT — what `vendo_make` answers with, where
+    the screen lands, how a pin replaces what held a slot — is taught on the
+    product-agent playbook. Every fact below is still pinned; each is pinned in
+    the page whose job it is. Move a fact between the pages and move it here. */
+const CONTRACT_PAGE = "docs-site/existing-agents/your-agent.mdx";
 
 interface DocsJson {
   navigation: { groups: { group: string; pages: string[] }[] };
@@ -33,10 +42,10 @@ const pageExists = (id: string): boolean =>
   existsSync(new URL(`docs-site/${id}.mdx`, REPO_ROOT)) ||
   existsSync(new URL(`docs-site/${id}/index.mdx`, REPO_ROOT));
 
-describe("the BYO-over-MCP page is published", () => {
-  it("exists with Mintlify frontmatter", async () => {
-    expect(existsSync(new URL(PAGE, REPO_ROOT)), `${PAGE} must exist`).toBe(true);
-    const text = await read(PAGE);
+describe("the BYO-over-MCP pages are published", () => {
+  it.each([SETUP_PAGE, CONTRACT_PAGE])("%s exists with Mintlify frontmatter", async (page) => {
+    expect(existsSync(new URL(page, REPO_ROOT)), `${page} must exist`).toBe(true);
+    const text = await read(page);
     expect(text.startsWith("---\n")).toBe(true);
     expect(text).toMatch(/^title: "/m);
     expect(text).toMatch(/^description: "/m);
@@ -58,7 +67,21 @@ describe("the BYO-over-MCP page is published", () => {
   });
 });
 
-describe("the page teaches the door's make-and-place contract", () => {
+describe("the setup page opens the door", () => {
+  const mustMention: [label: string, needle: string | RegExp][] = [
+    ["the door URL to paste", "/api/vendo/mcp"],
+    ["the marketplace install", "/plugin marketplace add runvendo/vendo"],
+    ["the plugin install", "/plugin install vendo@vendo"],
+    ["the plugin's env var", "VENDO_MCP_URL"],
+    ["the door internals link", "/capabilities/mcp"],
+  ];
+
+  it.each(mustMention)("names %s", async (_label, needle) => {
+    expect(await read(SETUP_PAGE)).toMatch(needle);
+  });
+});
+
+describe("the playbook teaches the door's make-and-place contract", () => {
   const mustMention: [label: string, needle: string | RegExp][] = [
     ["the make tool", "vendo_make"],
     ["the slot argument", /`slot`/],
@@ -68,19 +91,16 @@ describe("the page teaches the door's make-and-place contract", () => {
     ["the building status", /"building"/],
     ["the host-side slot component", "VendoSlot"],
     ["the in-process embed it is not", "VendoToolResult"],
-    ["the door URL to paste", "/api/vendo/mcp"],
-    ["the marketplace install", "/plugin marketplace add runvendo/vendo"],
-    ["the plugin install", "/plugin install vendo@vendo"],
-    ["the plugin's env var", "VENDO_MCP_URL"],
-    ["the door internals link", "/capabilities/mcp"],
   ];
 
   it.each(mustMention)("names %s", async (_label, needle) => {
-    expect(await read(PAGE)).toMatch(needle);
+    expect(await read(CONTRACT_PAGE)).toMatch(needle);
   });
+});
 
-  it("links only to pages that exist", async () => {
-    const text = await read(PAGE);
+describe("both pages link only to pages that exist", () => {
+  it.each([SETUP_PAGE, CONTRACT_PAGE])("%s", async (page) => {
+    const text = await read(page);
     const targets = [...text.matchAll(/\]\((\/[^)\s#]*)(#[^)\s]*)?\)/g)].map((match) => match[1]!);
     const broken = [...new Set(targets)].filter((target) => !pageExists(target.replace(/^\//, "")));
     expect(broken).toEqual([]);


### PR DESCRIPTION
`main` has been red since #1139 merged. Six tests in `packages/vendo/tests/mcp-byo-docs.docs.test.ts` fail on every PR, because CI tests each branch merged with `main`.

Fixes the drift, not the restructure.

## What happened

#1139 — "docs(mcp): setup page leads with the agent prompt; reference and playbook split" — split the BYO-over-MCP story in two:

- **`existing-agents/mcp.mdx`** became *"Set up the MCP door"*: open the door, connect a client, service keys.
- The **make-and-place contract** — what `vendo_make` answers with, where the screen lands, how a pin replaces what held a slot — is taught on **`existing-agents/your-agent.mdx`**, the product-agent playbook.

The docs-rot gate still asserted all thirteen facts against the setup page. Five of them had moved to the playbook and one had been dropped outright, so the gate went red:

```
tests/mcp-byo-docs.docs.test.ts > the page teaches the door's make-and-place contract > names the pin tool
tests/mcp-byo-docs.docs.test.ts > the page teaches the door's make-and-place contract > names the unpin tool
tests/mcp-byo-docs.docs.test.ts > the page teaches the door's make-and-place contract > names the receipt's say field
tests/mcp-byo-docs.docs.test.ts > the page teaches the door's make-and-place contract > names the building status
tests/mcp-byo-docs.docs.test.ts > the page teaches the door's make-and-place contract > names the in-process embed it is not
tests/mcp-byo-docs.docs.test.ts > capabilities/mcp.mdx tells the truth about creation at the door > names vendo_make in the saved-apps section and points at the walkthrough
```

## What this changes

**The restructure stands.** It was deliberate. Two changes only:

**1. The gate follows the split.** The one contract block becomes two, each pinning the facts of the page whose job it is. I checked every one of the thirteen against both pages first:

| fact | setup page | playbook | pinned on |
|---|---|---|---|
| `/api/vendo/mcp` | ✅ | ✅ | setup |
| `/plugin marketplace add runvendo/vendo` | ✅ | — | setup |
| `/plugin install vendo@vendo` | ✅ | — | setup |
| `VENDO_MCP_URL` | ✅ | — | setup |
| `/capabilities/mcp` | ✅ | ✅ | setup |
| `vendo_make` | ✅ | ✅ | playbook |
| `` `slot` `` | ✅ | ✅ | playbook |
| `VendoSlot` | ✅ | ✅ | playbook |
| `vendo_apps_pin` | ❌ | ✅ | playbook |
| `vendo_apps_unpin` | ❌ | ✅ | playbook |
| `` `say` `` | ❌ | ✅ | playbook |
| `"building"` | ❌ | ✅ | playbook |
| `VendoToolResult` | ❌ | ✅ | playbook |

No fact leaves the gate — every one is still pinned, just where the docs now teach it. The frontmatter and link-resolution checks now cover both pages instead of one, so the playbook is held to the same bar.

**2. One dropped fact restored.** `capabilities/mcp.mdx`'s "Saved apps ride along" section lost its pointer to the walkthrough entirely — it kept `vendo_make` and `vendo_apps_pin` but nothing telling a reader where to go and do it. One line back, naming both new homes:

> This page is the door's internals. To do it: [set up the door](/existing-agents/mcp) for the client, and follow [the make-and-place walkthrough](/existing-agents/your-agent) for what `vendo_make` answers with and where the screen lands.

That is the only prose added. No restructuring of my own.

## Proof

The red proof is CI itself — [main's run 31417646840, `test-shards (vendo-3)`](https://github.com/runvendo/vendo/actions/runs/31417646840) — and it reproduces on an unmodified checkout of this branch's base:

```
Tests  6 failed | 23 passed (29)
```

…the same six, byte for byte. With this change:

```
Test Files  1 passed (1)
      Tests  31 passed (31)
```

## Gate

Scoped to the touched surface: `pnpm build` ✅ · `pnpm typecheck` ✅ · `pnpm lint` ✅ · the two docs gates (`mcp-byo-docs.docs.test.ts`, `doctor-codes.docs.test.ts`) 32/32 ✅.

---

This unblocks every open PR, not just mine. #1168 needs only a rerun once this lands.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the docs-rot gate after #1139 by splitting BYO-over-MCP assertions across the setup and playbook pages, and restoring the missing walkthrough pointer in `capabilities/mcp.mdx`. This makes `main` green again and unblocks open PRs.

- **Bug Fixes**
  - Updated `packages/vendo/tests/mcp-byo-docs.docs.test.ts` to follow the split: setup page covers door/open/client; playbook covers the make-and-place contract. Frontmatter and link checks now run on both pages.
  - Restored the walkthrough link in `docs-site/capabilities/mcp.mdx`, pointing to `/existing-agents/mcp` and `/existing-agents/your-agent`.
  - Kept all 13 facts pinned, just on their rightful pages; none removed.

<sup>Written for commit 66d7e95345323970d1280187ba3d6cc967f64e5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

