### PR TITLE
test(vendo): the MCP docs-rot gate follows #1139's content to its new home

### DIFF
--- a/packages/vendo/tests/mcp-byo-docs.docs.test.ts
+++ b/packages/vendo/tests/mcp-byo-docs.docs.test.ts
@@ -9,7 +9,8 @@ import { describe, expect, it } from "vitest";
  *
  * What it holds:
  *  1. the page exists, is in the nav, and every nav entry still resolves;
- *  2. the page names the door's make-and-place contract and its links resolve;
+ *  2. the docs name the door's make-and-place contract and the page's links
+ *     resolve;
  *  3. capabilities/mcp.mdx no longer claims the door cannot create;
  *  4. the HTTP reference carries the three placement routes;
  *  5. the plugin skill teaches slot targeting and pin etiquette;
@@ -22,6 +23,8 @@ const readJson = async <T>(path: string): Promise<T> => JSON.parse(await read(pa
 
 const PAGE = "docs-site/existing-agents/mcp.mdx";
 const NAV_ENTRY = "existing-agents/mcp";
+/** The playbook half of the split: where the make-and-place teaching lives. */
+const PLACEMENT_PAGE = "docs-site/existing-agents/your-agent.mdx";
 
 interface DocsJson {
   navigation: { groups: { group: string; pages: string[] }[] };
@@ -58,25 +61,33 @@ describe("the BYO-over-MCP page is published", () => {
   });
 });
 
-describe("the page teaches the door's make-and-place contract", () => {
-  const mustMention: [label: string, needle: string | RegExp][] = [
-    ["the make tool", "vendo_make"],
-    ["the slot argument", /`slot`/],
-    ["the pin tool", "vendo_apps_pin"],
-    ["the unpin tool", "vendo_apps_unpin"],
-    ["the receipt's say field", /`say`/],
-    ["the building status", /"building"/],
-    ["the host-side slot component", "VendoSlot"],
-    ["the in-process embed it is not", "VendoToolResult"],
-    ["the door URL to paste", "/api/vendo/mcp"],
-    ["the marketplace install", "/plugin marketplace add runvendo/vendo"],
-    ["the plugin install", "/plugin install vendo@vendo"],
-    ["the plugin's env var", "VENDO_MCP_URL"],
-    ["the door internals link", "/capabilities/mcp"],
+describe("the docs teach the door's make-and-place contract", () => {
+  /**
+   * #1139 split the story in two: the setup page owns the door, the connect
+   * step, and the first receipt; the placement page it hands off to owns the
+   * make-and-place teaching. Each needle is asserted against the page that
+   * carries it today, so the contract still has to be written down somewhere a
+   * reader following the setup page reaches.
+   */
+  const mustMention: [label: string, needle: string | RegExp, page: string][] = [
+    ["the make tool", "vendo_make", PAGE],
+    ["the slot argument", /`slot`/, PAGE],
+    ["the pin tool", "vendo_apps_pin", PLACEMENT_PAGE],
+    ["the unpin tool", "vendo_apps_unpin", PLACEMENT_PAGE],
+    ["the receipt's say field", /`say`/, PLACEMENT_PAGE],
+    ["the building status", /"building"/, PLACEMENT_PAGE],
+    ["the host-side slot component", "VendoSlot", PAGE],
+    ["the in-process embed it is not", "VendoToolResult", PLACEMENT_PAGE],
+    ["the door URL to paste", "/api/vendo/mcp", PAGE],
+    ["the marketplace install", "/plugin marketplace add runvendo/vendo", PAGE],
+    ["the plugin install", "/plugin install vendo@vendo", PAGE],
+    ["the plugin's env var", "VENDO_MCP_URL", PAGE],
+    ["the door internals link", "/capabilities/mcp", PAGE],
+    ["the hand-off to the placement page", "/existing-agents/your-agent", PAGE],
   ];
 
-  it.each(mustMention)("names %s", async (_label, needle) => {
-    expect(await read(PAGE)).toMatch(needle);
+  it.each(mustMention)("names %s", async (label, needle, page) => {
+    expect(await read(page), `${page} must name ${label}`).toMatch(needle);
   });
 
   it("links only to pages that exist", async () => {
@@ -96,14 +107,19 @@ describe("capabilities/mcp.mdx tells the truth about creation at the door", () =
     expect(text).not.toMatch(/creation and editing stay in-product/i);
   });
 
-  it("names vendo_make in the saved-apps section and points at the walkthrough", async () => {
+  it("names vendo_make and the pin tool in the saved-apps section", async () => {
     const text = await read(DOOR_PAGE);
     const start = text.indexOf("## Saved apps ride along");
     expect(start, "the saved-apps section must still exist").toBeGreaterThan(-1);
     const section = text.slice(start, text.indexOf("\n## ", start + 1));
     expect(section).toContain("vendo_make");
     expect(section).toContain("vendo_apps_pin");
-    expect(section).toContain("/existing-agents/mcp");
+  });
+
+  // #1139 lifted the walkthrough pointer out of the saved-apps section and into
+  // the reference page's opening, where every reader meets it.
+  it("points at the walkthrough", async () => {
+    expect(await read(DOOR_PAGE)).toContain("/existing-agents/mcp");
   });
 });
 


### PR DESCRIPTION
`origin/main` is red and every PR in the repo is blocked by it. This unblocks it.

#1139 split the MCP story — the setup page leads with the agent prompt and hands off, the reference and the playbook each took a half — and in doing so it moved content out of `docs-site/existing-agents/mcp.mdx`. The docs-rot suite `packages/vendo/tests/mcp-byo-docs.docs.test.ts` still asserted every needle against that one page, so it went red on five of them (`vendo_apps_pin`, `vendo_apps_unpin`, `` `say` ``, `"building"`, `VendoToolResult`) plus the saved-apps section's walkthrough link. Nothing was deleted from the documentation, so nothing is dropped from the gate: the make-and-place teaching is asserted against `docs-site/existing-agents/your-agent.mdx` (the placement page the setup page hands off to at `docs-site/existing-agents/mcp.mdx:252`), and `capabilities/mcp.mdx`'s walkthrough pointer is asserted page-wide because #1139 lifted it out of "Saved apps ride along" and into the page's opening (`capabilities/mcp.mdx:11`). One assertion is added rather than removed — the setup page must carry the `/existing-agents/your-agent` hand-off, which is what makes "somewhere a reader will find it" true and keeps the two pages from drifting apart silently. The restructure is intentional and stands: no product code and no documentation page is touched.

Gates on the touched scope, all green: the suite (31/31), `pnpm build` (21/21), `pnpm typecheck` (42/42), `pnpm lint`. Prove-it-can-fail: pointing "the pin tool" back at the old page reds `the docs teach the door's make-and-place contract > names the pin tool`, so the assertion still checks something.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update MCP docs-rot tests to follow #1139’s docs split across setup and placement pages, moving assertions to the right files and adding a hand-off link check to keep `main` green.

- **Bug Fixes**
  - Moved checks for `vendo_apps_pin`, `vendo_apps_unpin`, `say`, "building", and `VendoToolResult` to `docs-site/existing-agents/your-agent.mdx`.
  - Kept checks for `vendo_make`, `slot`, `VendoSlot`, install commands, env var, door URL, and door internals link on `docs-site/existing-agents/mcp.mdx`.
  - Added assertion that the setup page links to `/existing-agents/your-agent`.
  - Updated `capabilities/mcp.mdx` test to assert the walkthrough pointer page-wide.

<sup>Written for commit af99b2e6924a9376cfe4e93c539eec0dd574b11e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

