### PR TITLE
feat(store): records.* is deprecated — status() advertises it, doctor passes it on

### DIFF
--- a/.changeset/records-ops-are-deprecated.md
+++ b/.changeset/records-ops-are-deprecated.md
@@ -1,0 +1,49 @@
+---
+"@vendoai/core": minor
+"@vendoai/store": minor
+"@vendoai/vendo": minor
+---
+
+The generic `records.*` store ops are deprecated. They still work; they will be
+removed in `0.13.0`.
+
+**What is happening.** `records.*` was one untyped door onto every row in the
+store — a host's data, an app's data and Vendo's own bookkeeping all went through
+the same seven verbs, and nothing in the call said which was which. Two named
+families replaced it: `appData.*` for the rows and files a generated app invents
+(the owner is stamped for you, so one user's data cannot be read by another's app
+session), and `engine.*` for Vendo's own collections (the same seven verbs, behind
+the `ENGINE_COLLECTIONS` allowlist). Everything `records.*` can do, one of those
+two can do with the ownership question answered.
+
+**Nothing breaks in this release.** All seven `records.*` ops stay on the wire and
+keep their exact behaviour. This release only *announces* the retirement, in the
+two places a caller will actually see it:
+
+- `status()` (`GET /status`) now returns `minClientVersion` and `deprecated` — the
+  seven `records.*` op names — beside the existing `format` and `ops: 42`. Clients
+  that already parse the handshake get the notice for free; the fields are
+  optional on `StoreWireStatus`, so an older client ignores them.
+- `vendo doctor` warns `E-LIVE-008` when a mount advertises deprecated ops, naming
+  them and the removal release. It is a warning, never a failure — doctor still
+  exits 0.
+
+**What you need to do before `0.13.0`.** Find your `records.*` calls and move each
+one to the family that owns the data:
+
+- Rows and files belonging to a generated app → `appData.put/get/list/delete` and
+  `appData.putFile/getFile/listFiles/deleteFile`. The target carries `appId`,
+  `collection` and `owner`; you no longer invent a collection-name prefix to keep
+  users apart.
+- Vendo's own collections (threads, runs, grants, the audit log, effects, apps,
+  automations schedules and deliveries) → `engine.*`, same arguments, same
+  returns. A name outside the allowlist is refused with `blocked` and told where
+  its data belongs.
+
+If you host your own store mount, `STORE_WIRE_DEPRECATED_OPS` and
+`STORE_WIRE_DEPRECATED_REMOVED_IN` (both `@vendoai/core`) are what the handshake
+advertises, so your mount can say the same thing without hardcoding the list.
+`STORE_WIRE_MIN_CLIENT_VERSION` names the release the mount was built from.
+
+After `0.13.0`, a `records.*` call answers `not-implemented` (501). There is no
+flag to keep the old door open.

--- a/docs-site/agents/verify.mdx
+++ b/docs-site/agents/verify.mdx
@@ -440,6 +440,22 @@ project env. To use the managed Cloud sandbox instead, remove `E2B_API_KEY`
 from the server env and keep `VENDO_API_KEY` set. Restart the dev server and
 re-run `vendo doctor`.
 
+### E-LIVE-008 {#E-LIVE-008}
+
+**Symptom (warning):** `/status` lists store ops the wire has deprecated. The
+named ops still work today; the warning names the release that removes them.
+
+**Cause:** The generic `records.*` family is being retired in favour of two
+named families: `appData.*` for the rows and files an app invents (owner-stamped
+for you) and `engine.*` for Vendo's own collections (the same seven verbs behind
+an allowlist). The mount advertises the retirement on its handshake so callers
+find out before the removal, not after.
+
+**Fix:** Move each `records.*` call to the family that owns the data: app data
+to `appData.*`, Vendo's own collections to `engine.*`. Nothing breaks until the
+release named in the warning; after it, the deprecated ops answer
+`not-implemented`.
+
 ## Auth probes
 
 ### E-AUTH-001 {#E-AUTH-001}

--- a/packages/core/src/store-wire.ts
+++ b/packages/core/src/store-wire.ts
@@ -70,6 +70,25 @@ export const STORE_WIRE_PATHS = {
   status: "/status",
 } as const;
 
+/** The release this build of the wire ships in, advertised as
+    `StoreWireStatus.minClientVersion`. Rewritten from the published package
+    version by `scripts/sync-version-constants.mjs` at release cut, exactly like
+    the CLI and wire VERSION constants — so it always names the release that
+    carried this contract and there is no number to remember. */
+export const STORE_WIRE_MIN_CLIENT_VERSION = "0.10.0";
+
+/** The release that DROPS the ops below. Announced now, enforced there; this
+    constant is the one place to change when the removal slice is cut. */
+export const STORE_WIRE_DEPRECATED_REMOVED_IN = "0.13.0";
+
+/** Ops this wire still serves but is retiring: the generic `records.*` family,
+    superseded by `appData.*` (owner-stamped rows generated apps invent) and
+    `engine.*` (Vendo's own collections, behind an allowlist). Read off the path
+    table so it cannot claim an op that does not exist — and so it empties
+    itself the day `records.*` leaves. */
+export const STORE_WIRE_DEPRECATED_OPS: readonly string[] =
+  Object.keys(STORE_WIRE_PATHS).filter((op) => op.startsWith("records."));
+
 // ---------------------------------------------------------------------------
 // Shared schemas
 // ---------------------------------------------------------------------------

--- a/packages/core/src/store-wire.ts
+++ b/packages/core/src/store-wire.ts
@@ -78,7 +78,16 @@ export const STORE_WIRE_PATHS = {
 export const STORE_WIRE_MIN_CLIENT_VERSION = "0.10.0";
 
 /** The release that DROPS the ops below. Announced now, enforced there; this
-    constant is the one place to change when the removal slice is cut. */
+    constant is the one place to change when the removal slice is cut.
+
+    THIS NUMBER IS A PROMISE TO CUSTOMERS, not an internal note: it is printed
+    verbatim in the deprecation changeset and in doctor's E-LIVE-008 warning, so
+    a reader will plan a migration around it. It is derived, not chosen — the
+    announcement rides the release after the one publishing today, and the
+    removal must be one full release later than the announcement so nobody
+    upgrades into a break they were never told about. RE-CONFIRM IT AT THE
+    RELEASE CUT: if the announcement slips into a release of its own, this moves
+    with it. */
 export const STORE_WIRE_DEPRECATED_REMOVED_IN = "0.13.0";
 
 /** Ops this wire still serves but is retiring: the generic `records.*` family,

--- a/packages/core/tests/store-wire.test.ts
+++ b/packages/core/tests/store-wire.test.ts
@@ -1,5 +1,9 @@
+import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import {
+  STORE_WIRE_DEPRECATED_OPS,
+  STORE_WIRE_DEPRECATED_REMOVED_IN,
+  STORE_WIRE_MIN_CLIENT_VERSION,
   STORE_WIRE_PATHS,
   STORE_WIRE_STATUS_BY_CODE,
   VENDO_STORE_WIRE_FORMAT,
@@ -78,6 +82,34 @@ describe("vendo/store-wire@1", () => {
       .map(([, path]) => path);
     expect(enginePaths).toHaveLength(7);
     expect(enginePaths.every((path) => path.startsWith("/engine/"))).toBe(true);
+  });
+
+  it("names every records.* op as deprecated, and nothing else", () => {
+    expect([...STORE_WIRE_DEPRECATED_OPS].sort()).toEqual([
+      "records.claim",
+      "records.compareAndSwap",
+      "records.delete",
+      "records.get",
+      "records.insertIfAbsent",
+      "records.list",
+      "records.put",
+    ]);
+    // Advertised only — every deprecated op is still a served path.
+    for (const op of STORE_WIRE_DEPRECATED_OPS) {
+      expect(Object.keys(STORE_WIRE_PATHS)).toContain(op);
+    }
+    // The removal release must be a real version, not a placeholder.
+    expect(STORE_WIRE_DEPRECATED_REMOVED_IN).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it("advertises the release it ships in as minClientVersion", async () => {
+    // scripts/sync-version-constants.mjs rewrites the constant at release cut,
+    // the same invariant cli/shared.test.ts pins for CLI_VERSION — so the
+    // handshake can never name a release this build did not ship in.
+    const pkg = JSON.parse(
+      await readFile(new URL("../package.json", import.meta.url), "utf8"),
+    ) as { version: string };
+    expect(STORE_WIRE_MIN_CLIENT_VERSION).toBe(pkg.version);
   });
 
   it("the storeWireRecords* names are aliases of the shared collection bodies", () => {

--- a/packages/store/src/ops.ts
+++ b/packages/store/src/ops.ts
@@ -1,5 +1,7 @@
 import {
   assertEngineCollection,
+  STORE_WIRE_DEPRECATED_OPS,
+  STORE_WIRE_MIN_CLIENT_VERSION,
   VENDO_STORE_WIRE_FORMAT,
   VendoError,
   type FilesAdapter,
@@ -723,8 +725,16 @@ export function createStoreOps(
       },
     },
 
+    // The retirement of `records.*` is ADVERTISED here and nowhere else: every
+    // op below still serves it. A client learns from the handshake instead of
+    // from a 501 the day it goes.
     async status() {
-      return { format: VENDO_STORE_WIRE_FORMAT, ops: 42 };
+      return {
+        format: VENDO_STORE_WIRE_FORMAT,
+        minClientVersion: STORE_WIRE_MIN_CLIENT_VERSION,
+        ops: 42,
+        deprecated: STORE_WIRE_DEPRECATED_OPS,
+      };
     },
   };
 }

--- a/packages/store/tests/ops.test.ts
+++ b/packages/store/tests/ops.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { backends, type MadeBackend } from "../src/backends.test-util.js";
 import { auditFixture } from "../src/fixtures.test-util.js";
 import { createStoreOps } from "../src/index.js";
-import type { StoreOps } from "@vendoai/core";
+import { STORE_WIRE_MIN_CLIENT_VERSION, type StoreOps } from "@vendoai/core";
 
 // The local backend's OWN laws, beyond the shared conformance suite: the F4
 // cascade proven at the rows, and the per-collection policies the routed
@@ -68,6 +68,30 @@ for (const backend of backends()) {
         expect(replayed.data).toMatchObject({ outcome: { sent: true } });
         await expect(ops.records.compareAndSwap("vendo_effects", { id: "fx_1", data: receipt }, "1"))
           .rejects.toMatchObject({ code: "blocked" });
+      } finally {
+        await made.cleanup();
+      }
+    });
+
+    it("status() advertises the records.* retirement while still serving it", async () => {
+      const { made, ops } = await makeOps();
+      try {
+        const status = await ops.status();
+        expect(status.ops).toBe(42);
+        expect(status.minClientVersion).toBe(STORE_WIRE_MIN_CLIENT_VERSION);
+        expect([...status.deprecated ?? []].sort()).toEqual([
+          "records.claim",
+          "records.compareAndSwap",
+          "records.delete",
+          "records.get",
+          "records.insertIfAbsent",
+          "records.list",
+          "records.put",
+        ]);
+        // Advertised, not enforced: the announcement must not have taken the
+        // door out from under anyone.
+        await ops.records.put("vendo_threads", { id: "thr_dep", data: { subject: "user_dep", messages: [] } });
+        expect((await ops.records.get("vendo_threads", "thr_dep"))?.id).toBe("thr_dep");
       } finally {
         await made.cleanup();
       }

--- a/packages/vendo/src/cli/doctor-codes.ts
+++ b/packages/vendo/src/cli/doctor-codes.ts
@@ -40,6 +40,7 @@ export const DOCTOR_ERROR_CODES = {
   "E-LIVE-005": "the host /status does not report an execution venue (version skew)",
   "E-LIVE-006": "the app's root page returns a server error while the wire answers",
   "E-LIVE-007": "the selected e2b execution venue is unusable (E2B_API_KEY or the e2b package is missing)",
+  "E-LIVE-008": "the host still calls store ops the wire has deprecated and will remove",
   "E-AUTH-001": "present credentials did not reach the host API",
   "E-AUTH-002": "the present credential probe is unreachable",
   "E-AUTH-003": "the present credential probe cannot run while the dev server is down",

--- a/packages/vendo/src/cli/doctor-probe-checks.ts
+++ b/packages/vendo/src/cli/doctor-probe-checks.ts
@@ -142,7 +142,18 @@ function checkVersionSkew(run: DoctorRun, wireVersion: string): void {
  *  deprecation that becomes an outage. This is ADVERTISEMENT only: every named
  *  op still answers today, so it is a warning and never a failure — doctor is
  *  passing the mount's notice along, not refusing anything. A mount that
- *  announces nothing (older wire, or one that already dropped them) is silent. */
+ *  announces nothing (older wire, or one that already dropped them) is silent.
+ *
+ *  The asymmetry below is DELIBERATE, not a gap to close. Two different
+ *  documents are both called /status: the store-ops handshake
+ *  (`StoreWireStatus`, served by the hosted wire and forwarded by the console,
+ *  which spreads it whole) is the one that carries `deprecated`; the
+ *  composition /status this function reads (wire/misc.ts) does not, and must
+ *  not be taught to. `records.*` is a HOSTED-WIRE concern — a self-hosted
+ *  deployment on its own StoreAdapter has no `records.*` wire door to lose, so
+ *  there is nothing to warn it about. Reading the field off whatever answered
+ *  means the warning reaches exactly the population it concerns and stays quiet
+ *  for everyone else. Do not "fix" this by forwarding the field. */
 function checkStoreDeprecations(run: DoctorRun, deprecated: unknown): void {
   if (!Array.isArray(deprecated)) return;
   const ops = deprecated.filter((op): op is string => typeof op === "string" && op !== "");

--- a/packages/vendo/src/cli/doctor-probe-checks.ts
+++ b/packages/vendo/src/cli/doctor-probe-checks.ts
@@ -1,6 +1,7 @@
 import { createRequire } from "node:module";
 import { join } from "node:path";
 import { stdin, stdout } from "node:process";
+import { STORE_WIRE_DEPRECATED_REMOVED_IN } from "@vendoai/core";
 import { startDevServerForProbe } from "./doctor-live.js";
 import { CLI_VERSION, askYesNo } from "./shared.js";
 import { probeBody, type DoctorRun } from "./doctor-report.js";
@@ -136,6 +137,19 @@ function checkVersionSkew(run: DoctorRun, wireVersion: string): void {
   }
 }
 
+/** The store wire announces its own retirements on the handshake
+ *  (`StoreWireStatus.deprecated`), and a deprecation nobody reads is a
+ *  deprecation that becomes an outage. This is ADVERTISEMENT only: every named
+ *  op still answers today, so it is a warning and never a failure — doctor is
+ *  passing the mount's notice along, not refusing anything. A mount that
+ *  announces nothing (older wire, or one that already dropped them) is silent. */
+function checkStoreDeprecations(run: DoctorRun, deprecated: unknown): void {
+  if (!Array.isArray(deprecated)) return;
+  const ops = deprecated.filter((op): op is string => typeof op === "string" && op !== "");
+  if (ops.length === 0) return;
+  run.warn("live/store", "E-LIVE-008", `the store wire still serves ${ops.join(", ")}, but it has deprecated them and removes them in ${STORE_WIRE_DEPRECATED_REMOVED_IN}. Move an app's own rows and files to the appData ops (owner-stamped for you) and Vendo's own collections to the engine ops (same seven verbs, behind an allowlist); calls left on the deprecated ops start failing at that release`);
+}
+
 export interface LiveComposition {
   /** 10-mcp §1 — the door flag lives under blocks.mcp. Since the broker
    *  seam it is a posture ("local" | "broker" | false); older wires still
@@ -153,6 +167,7 @@ export async function checkLiveStatus(run: DoctorRun, e2bResolvable: ((root: str
     const body = await response.json() as {
       posture?: unknown;
       version?: unknown;
+      deprecated?: unknown;
       blocks?: { mcp?: unknown; sandbox?: unknown } | null;
     };
     if (!response.ok || typeof body.posture !== "string" || typeof body.version !== "string"
@@ -166,6 +181,7 @@ export async function checkLiveStatus(run: DoctorRun, e2bResolvable: ((root: str
       : body.blocks.mcp === true || body.blocks.mcp === "local" ? "local"
       : false;
     checkVenue(run, body.blocks.sandbox, e2bResolvable);
+    checkStoreDeprecations(run, body.deprecated);
     return { mcpPosture, live: true };
   } catch {
     run.fail("live/status", "E-LIVE-002", `/status is unreachable at ${statusUrl}/status — doctor expects the WIRE BASE (your app origin plus the mount path, e.g. http://localhost:3000/api/vendo); a bare site origin passed to --url is missing the /api/vendo part`);

--- a/packages/vendo/tests/cli/doctor-codes.test.ts
+++ b/packages/vendo/tests/cli/doctor-codes.test.ts
@@ -40,6 +40,7 @@ describe("doctor error-code registry", () => {
         "E-LIVE-005": "the host /status does not report an execution venue (version skew)",
         "E-LIVE-006": "the app's root page returns a server error while the wire answers",
         "E-LIVE-007": "the selected e2b execution venue is unusable (E2B_API_KEY or the e2b package is missing)",
+        "E-LIVE-008": "the host still calls store ops the wire has deprecated and will remove",
         "E-MCP-001": "MCP protected-resource metadata did not resolve",
         "E-MCP-002": "MCP authorization-server metadata did not resolve",
         "E-MCP-003": "the MCP server card did not parse",

--- a/packages/vendo/tests/cli/doctor.test.ts
+++ b/packages/vendo/tests/cli/doctor.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { ActAs, PermissionGrant, Principal } from "@vendoai/core";
+import { STORE_WIRE_DEPRECATED_REMOVED_IN, type ActAs, type PermissionGrant, type Principal } from "@vendoai/core";
 import { memoryStoreAdapter } from "@vendoai/core/conformance";
 import { extractServerActions } from "@vendoai/actions/sync";
 import type { VendoStore } from "@vendoai/store";
@@ -623,6 +623,45 @@ describe("vendo doctor", () => {
     expect(messages.errors).toContain(
       "warning: host /status does not report an execution venue; upgrade @vendoai/vendo to enable the venue check",
     );
+  });
+
+  it("warns, without failing, when /status advertises deprecated store ops", async () => {
+    const messages = output();
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.endsWith("/status")) {
+        return Response.json({
+          posture: "unconfigured",
+          version: CLI_VERSION,
+          blocks: { store: true, sandbox: "cloud" },
+          deprecated: ["records.get", "records.put"],
+        });
+      }
+      if (url.endsWith("/doctor/present")) return Response.json({ ok: true });
+      if (url.endsWith("/doctor/act-as")) return Response.json({ ok: true });
+      if (url.endsWith("/doctor/machines")) return Response.json({ scheduleCallerConfigured: false, machines: [] });
+      return Response.json({ error: { message: "unexpected probe" } }, { status: 404 });
+    });
+    expect(await doctor({
+      targetDir: await healthy(),
+      fetchImpl,
+      output: messages.sink,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    })).toBe(0);
+    expect(messages.errors).toContain(
+      `warning: the store wire still serves records.get, records.put, but it has deprecated them and removes them in ${STORE_WIRE_DEPRECATED_REMOVED_IN}. Move an app's own rows and files to the appData ops (owner-stamped for you) and Vendo's own collections to the engine ops (same seven verbs, behind an allowlist); calls left on the deprecated ops start failing at that release`,
+    );
+  });
+
+  it("says nothing about deprecations when /status advertises none", async () => {
+    const messages = output();
+    expect(await doctor({
+      targetDir: await healthy(),
+      fetchImpl: successfulProbeFetch({ store: true, sandbox: "cloud" }),
+      output: messages.sink,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    })).toBe(0);
+    expect(messages.errors.some((line) => line.includes("has deprecated them"))).toBe(false);
   });
 
   it("fails when /status reports an unknown execution venue", async () => {

--- a/scripts/sync-version-constants.mjs
+++ b/scripts/sync-version-constants.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
-// Keeps the hand-maintained version constants in @vendoai/vendo in lockstep
-// with its package.json. Runs as part of `pnpm changeset:version` so the
-// Version Packages PR is self-consistent; cli/shared.test.ts pins the
-// invariant either way.
+// Keeps the hand-maintained version constants in @vendoai/vendo and
+// @vendoai/core in lockstep with package.json (every published package is one
+// `fixed` group, so one version serves all of them). Runs as part of
+// `pnpm changeset:version` so the Version Packages PR is self-consistent;
+// cli/shared.test.ts and core's store-wire.test.ts pin the invariant either way.
 import { readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -15,6 +16,10 @@ const version = JSON.parse(
 const targets = [
   { file: "packages/vendo/src/cli/shared.ts", pattern: /(export const CLI_VERSION = ")[^"]+(")/ },
   { file: "packages/vendo/src/wire/shared.ts", pattern: /(export const VERSION = ")[^"]+(")/ },
+  {
+    file: "packages/core/src/store-wire.ts",
+    pattern: /(export const STORE_WIRE_MIN_CLIENT_VERSION = ")[^"]+(")/,
+  },
 ];
 
 for (const { file, pattern } of targets) {


### PR DESCRIPTION
## What

**Advertised only.** All seven `records.*` ops stay on the wire and keep their exact behaviour. Nothing refuses, nothing branches on the announcement. This slice makes the system *say* that `records.*` is going.

- **`status()`** (`packages/store/src/ops.ts:728`) now returns `minClientVersion` and `deprecated` — the seven `records.*` op names — beside the existing `format` and `ops: 42`. Both fields were already optional on `StoreWireStatus` (`packages/core/src/store-wire.ts:391`), so an older client ignores them.
- **`STORE_WIRE_DEPRECATED_OPS`** is read off `STORE_WIRE_PATHS`, so it cannot name an op that does not exist — and it empties itself the day `records.*` leaves the table.
- **`vendo doctor`** warns naming the deprecated ops and the removal release when a mount's `/status` carries a non-empty `deprecated`. A warning, never a failure: doctor still exits 0.
- **Changeset** is the deprecation notice: what is happening, what breaks (nothing, yet), and the exact per-family migration a caller has to do before the removal.

## Two decisions worth a look

**`minClientVersion` is not hardcoded.** `STORE_WIRE_MIN_CLIENT_VERSION` joins `scripts/sync-version-constants.mjs` — the mechanism that already rewrites `CLI_VERSION` and the wire `VERSION` from `package.json` on `pnpm changeset:version`. So the handshake always names the release the build actually shipped in, and there is no number for anyone to remember at the cut. A test pins the invariant either way (`packages/core/tests/store-wire.test.ts`), mirroring `cli/shared.test.ts`.

**The doctor code is `E-LIVE-008`, not `E-LIVE-007`.** `E-LIVE-007` is already the unusable-e2b-venue failure (`doctor-codes.ts:41`), and that registry is explicitly append-only — reusing it would rewrite a published `fix_ref` anchor. `E-LIVE-008` also gets its `verify.mdx` section, which `doctor-codes.docs.test.ts` requires 1:1.

## Sequencing

Gated behind the S7 migration groups — the call sites must be off `records.*` before the removal slice can land: #1171 (automations), #1170 (guard), #1169 (apps). This PR does not touch a single `records.*` call site.

The console needs **no** change: `handleStoreStatus` spreads `...status` (`vendo-web` `apps/console/lib/api/store-doors.ts:432`) over the engine's own `status()`, so both new fields flow through on a dependency bump.

## Tests

Every item ships with a test, and each was proven able to fail (constant emptied / call site neutered → red → restored → green):

- `packages/core/tests/store-wire.test.ts` — the deprecated list is exactly the seven `records.*` ops, every one of them still a served path, and `minClientVersion` equals the package version.
- `packages/store/tests/ops.test.ts` — `status()` advertises all three fields, and a `records.put`/`records.get` round-trip in the same test proves the announcement took nothing away.
- `packages/vendo/tests/cli/doctor.test.ts` — warns with the exact message and exits 0; silent when `/status` advertises none.

Local gate: build, typecheck, lint, and the three scoped suites all green.

> Note: `origin/main` is currently red on `packages/vendo/tests/mcp-byo-docs.docs.test.ts` (PR #1139's docs restructure); a fix is in flight elsewhere and is unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deprecates `records.*` store ops without removing them; `status()` advertises the change and `vendo doctor` relays a non-failing E-LIVE-008 warning. Removal is planned for `0.13.0`.

- New Features
  - `status()` now returns `format`, `ops: 42`, `minClientVersion`, and `deprecated` (the seven `records.*` ops).
  - `STORE_WIRE_DEPRECATED_OPS` and `STORE_WIRE_DEPRECATED_REMOVED_IN` (`0.13.0`) live in `@vendoai/core`; the ops list is derived from `STORE_WIRE_PATHS`.
  - `STORE_WIRE_MIN_CLIENT_VERSION` added in `@vendoai/core` and auto-synced by `scripts/sync-version-constants.mjs`.
  - `vendo doctor` warns with `E-LIVE-008` when the hosted wire advertises deprecations; docs add the E-LIVE-008 section; tests cover status fields, constants, and the warning.

<sup>Written for commit 3561dff48655a26cd39a7ff195b9708f45b906bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

