### PR TITLE
changeset: the init/sync redesign

### DIFF
--- a/.changeset/init-redesign.md
+++ b/.changeset/init-redesign.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/vendo": minor
+---
+
+`vendo init` and `vendo sync` redesigned — branded animated banner, five-question guided flow, labelled result blocks (Wired/Catalog/Judgment/Your brand/Impact), spinners on slow phases, timed footer; init scaffolds the MCP door end-to-end (`--use-case mcp`) and doctor gains `E-MCP-009` + `E-WIRE-011`; piped/CI/`--json`/`--agent` output stays byte-identical.


### PR DESCRIPTION
Covers PRs #1134 #1142 #1144 #1145 #1146 #1147 #1148 #1150 #1151 #1152 #1160 #1162 #1168 #1172. Minor bump.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Minor release for `@vendoai/vendo` redesigning `vendo init` and `vendo sync` with a guided flow and clearer output. Adds MCP scaffolding and new doctor checks while keeping CI/agent output unchanged.

- **New Features**
  - Guided init/sync with animated banner, 5-question flow, labeled result blocks (Wired/Catalog/Judgment/Your brand/Impact), spinners, and timed footer.
  - `vendo init --use-case mcp` scaffolds the MCP door end-to-end.
  - `vendo doctor` adds `E-MCP-009` and `E-WIRE-011`.
  - Piped/CI/`--json`/`--agent` output remains byte-identical.

<sup>Written for commit ec93a7614d4437b3c80d24b17bc68772c7a3f6de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

