### PR TITLE
docs(mcp): setup page describes local vs Cloud broker in plain terms

### DIFF
--- a/docs-site/existing-agents/mcp.mdx
+++ b/docs-site/existing-agents/mcp.mdx
@@ -59,6 +59,34 @@ carry:
 npx vendo doctor
 ```
 
+### Two ways to run it
+
+The door runs two ways, and the URL your users paste is the same in both.
+
+**Local — the default.** Everything lives in your app: it signs the person in,
+mints its own tokens, and serves its own consent page. You generate the service
+key yourself. No Vendo key, no account, nothing to configure.
+
+**Cloud broker.** Vendo hosts the login-and-token front for you at
+`https://<your tenant>.mcp.vendo.run`. You set two lines where you deploy, and
+the service key is the console's to create instead of your repo's. Your app
+still runs every tool call — only the sign-in front moves:
+
+```bash
+VENDO_MCP_BROKER_URL=<your tenant MCP endpoint, from the console MCP page>
+VENDO_MCP_FEDERATION_SECRET=<from the console MCP page>
+```
+
+Start local — it is the whole story for previews and evaluation. Move to the
+broker when real Claude, ChatGPT, or Cursor users connect to production and you
+would rather not run a public sign-in surface of your own.
+
+Init asks which one only when it finds a Cloud key; without one, local is simply
+the default (`--posture broker` answers it for a script). Under broker it prints
+those two lines and wires nothing — setting them where you deploy stays yours.
+The full behavior:
+[Delegate to an external authorization server](/capabilities/mcp#delegate-to-an-external-authorization-server).
+
 ### By hand
 
 The same three things, for a repo init did not scaffold. First, `mcp: true`
@@ -106,6 +134,10 @@ VENDO_BASE_URL=https://your-app.example.com
 ```
 
 ## Connect — pick your client
+
+Two kinds of visitor knock: a person's own client — Claude, ChatGPT, Cursor —
+which logs them in through a browser, or your own backend, which has no browser
+and swaps a service key for a token instead.
 
 ### Claude Code
 


### PR DESCRIPTION
The MCP setup page never said out loud that the door runs two ways, so a reader met the broker only as a one-line aside three sections down. This adds **Two ways to run it** under "Set up the door (once)" — local is the default and needs no Vendo key at all (your app signs people in, mints its own tokens, serves its own consent page, and you generate the service key yourself), Cloud broker moves only the login-and-token front to `{tenant}.mcp.vendo.run` for two env lines while your app still runs every tool call — plus which to pick (start local; broker when real Claude/ChatGPT/Cursor users hit production), what `vendo init` does with it (asks only when a Cloud key is present, `--posture broker` for scripts, prints the env lines and wires nothing), and one link to the reference section for depth. "Connect — pick your client" gains a single framing sentence: a person's own client logs in through a browser, your backend swaps a service key for a token. Docs only — every claim verified against `packages/vendo/src/cli/init-mcp.ts` (posture gating, env lines, `serviceAuth` local-only at :169) and `packages/vendo/src/compose-mcp.ts:97-113` (broker is declared, never discovered). Parent work: #1139.

![Two ways to run it, rendered](https://raw.githubusercontent.com/runvendo/vendo/assets/mcp-setup-page/09-two-postures.png)

Checks: `npx mint broken-links` from `docs-site/` → "no broken links found"; fences balanced (34); the `#delegate-to-an-external-authorization-server` anchor resolves in a real browser, and the page's five `##` sections are unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the MCP setup docs with a plain explanation of local vs Cloud broker, when to use each, the broker URL pattern, required env vars, and how `vendo init` behaves in both cases. Adds a short framing sentence to “Connect — pick your client” to explain browser login vs backend service key flow.

- Local is the default; Cloud broker fronts login at `https://<tenant>.mcp.vendo.run`.
- Env vars: `VENDO_MCP_BROKER_URL`, `VENDO_MCP_FEDERATION_SECRET`.
- `vendo init` asks posture only when a Cloud key is present; `--posture broker` is supported; it prints the env lines and doesn’t wire deployment.

<sup>Written for commit 748076992a627c072e2cec63831c49db4847f770. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

