### PR TITLE
test(vendo): the fakes learn the engine door before anything knocks on it

### DIFF
--- a/packages/vendo/src/byo-approvals.ts
+++ b/packages/vendo/src/byo-approvals.ts
@@ -7,6 +7,7 @@ import {
   type RecordStore,
   type RunContext,
   type StoreAdapter,
+  type StoreOps,
   type ToolCall,
   type ToolOutcome,
   type ToolRegistry,
@@ -104,6 +105,12 @@ export interface ByoApprovalsConfig {
    *  execute through) — both the parked call and its resume dispatch ride it. */
   tools: ToolRegistry;
   store: StoreAdapter;
+  /** THE named-operation surface for this deployment, beside the store it runs
+   *  over — `undefined` when the configured store offers neither its own `ops`
+   *  nor a SQL handle, exactly as `selectStoreOps` reports it. Threaded here
+   *  ahead of the parked-call drawers moving onto the `engine` family; the
+   *  drawers still reach the store through the record façade below. */
+  ops: StoreOps | undefined;
 }
 
 function now(): IsoDateTime {

--- a/packages/vendo/src/compose-actions.ts
+++ b/packages/vendo/src/compose-actions.ts
@@ -219,7 +219,7 @@ export const composeActions = (composition: VendoComposition): Pick<VendoComposi
   "configuredBaseUrl" | "urls" | "isDevelopmentEnv" | "connectorToolkits" | "resolvedConnectors"
   | "actionsConfig" | "actions" | "doctor" | "connectGate" | "boundTools" | "byoApprovals"
   | "parkedCallTtlMs"> => {
-  const { config, guard, store } = composition;
+  const { config, guard, store, ops } = composition;
   const posture = baseUrlPosture();
   // Connectors seam (adapter rule): explicit array wins, VENDO_API_KEY
   // defaults the Cloud tools connector for a wholly unset slot.
@@ -263,7 +263,7 @@ export const composeActions = (composition: VendoComposition): Pick<VendoComposi
   // parking registry the BYO tool pack executes through (guardedTools below),
   // the resume-on-decide subscriber (same onApprovalDecision seam apps and
   // automations ride), the wire's per-approval read, and the TTL sweep leg.
-  const byoApprovals = createByoApprovals({ guard, tools: boundTools, store });
+  const byoApprovals = createByoApprovals({ guard, tools: boundTools, store, ops });
   // The guard owns its approval lifecycle: whether the rules arrived as a spec
   // this composition completed or as a built instance, the number is read off
   // the guard, so a host that brings its own never loses the knob.

--- a/packages/vendo/src/hosted-store.test-util.ts
+++ b/packages/vendo/src/hosted-store.test-util.ts
@@ -1,4 +1,12 @@
-import { VendoError, canonicalJson, type BlobStore, type RecordStore, type VendoRecord } from "@vendoai/core";
+import {
+  STORE_WIRE_PATHS,
+  VendoError,
+  assertEngineCollection,
+  canonicalJson,
+  type BlobStore,
+  type RecordStore,
+  type VendoRecord,
+} from "@vendoai/core";
 import { memoryStoreAdapter } from "@vendoai/core/conformance";
 
 const decoder = new TextDecoder();
@@ -49,6 +57,19 @@ const STATUS: Record<string, number> = {
 const json = (body: unknown, status = 200): Response => Response.json(body, { status });
 const envelope = (code: string, message: string): Response =>
   json({ error: { code, message } }, STATUS[code] ?? 503);
+
+/** The engine door's routes, mount-relative path -> op name, read OFF the wire
+ *  contract instead of spelled out here. `engine` is the same seven verbs as
+ *  `records` over the same rows, so it reaches the same dispatcher and the same
+ *  in-memory state below — a test may write through one door and read back
+ *  through the other, which is the only way the two can be caught disagreeing.
+ *  Deriving the paths means a verb added to the contract arrives here served,
+ *  and a verb renamed there cannot leave this fake answering the old spelling. */
+const ENGINE_ROUTES = new Map(
+  Object.entries(STORE_WIRE_PATHS)
+    .filter(([op]) => op.startsWith("engine."))
+    .map(([op, path]) => [path, op.slice("engine.".length)]),
+);
 
 const sameValue = (
   current: VendoRecord,
@@ -231,6 +252,16 @@ export function fakeConsole() {
     // serving the StoreAdapter surface over the same in-memory state.
     if (rest[0] === "records" && rest.length === 2 && post) {
       return recordsOp(adapter.records(body.collection as string), rest[1]!, body, miss);
+    }
+    // The engine door: Vendo's OWN drawers, same seven verbs over the same rows,
+    // with the allowlist in front. The gate is served here rather than skipped
+    // because a fake that answers a collection the live door refuses lets a
+    // wrong call pass every test and fail in production.
+    const engineOp = post ? ENGINE_ROUTES.get(`/${rest.join("/")}`) : undefined;
+    if (engineOp !== undefined) {
+      const collection = body.collection as string;
+      assertEngineCollection(collection);
+      return recordsOp(adapter.records(collection), engineOp, body, miss);
     }
     if (rest[0] === "blobs" && rest.length === 2 && post) {
       return blobsWireOp(adapter.blobs(body.namespace as string), rest[1]!, body, miss);

--- a/packages/vendo/src/hosted-store.test-util.ts
+++ b/packages/vendo/src/hosted-store.test-util.ts
@@ -65,7 +65,7 @@ const envelope = (code: string, message: string): Response =>
  *  through the other, which is the only way the two can be caught disagreeing.
  *  Deriving the paths means a verb added to the contract arrives here served,
  *  and a verb renamed there cannot leave this fake answering the old spelling. */
-const ENGINE_ROUTES = new Map(
+const ENGINE_ROUTES = new Map<string, string>(
   Object.entries(STORE_WIRE_PATHS)
     .filter(([op]) => op.startsWith("engine."))
     .map(([op, path]) => [path, op.slice("engine.".length)]),

--- a/packages/vendo/tests/byo-approvals.e2e.test.ts
+++ b/packages/vendo/tests/byo-approvals.e2e.test.ts
@@ -10,7 +10,7 @@ import {
   type ToolRegistry,
 } from "@vendoai/core";
 import { createGuard, type VendoGuard } from "@vendoai/guard";
-import { createStore } from "@vendoai/store";
+import { createStore, createStoreOps } from "@vendoai/store";
 import { afterEach, describe, expect, it } from "vitest";
 import { createByoApprovals } from "../src/byo-approvals.js";
 
@@ -106,6 +106,9 @@ async function harness(options: { hideAbandonApprovals?: boolean } = {}) {
     guard: options.hideAbandonApprovals === true ? withoutAbandonApprovals(guard) : guard,
     tools: guard.bind(host.tools),
     store,
+    // The named-operation surface over the SAME handle, as the composition
+    // hands it down (compose-actions passes `composition.ops`).
+    ops: createStoreOps(store),
   });
   return { guard, store, host, byo };
 }
@@ -240,7 +243,7 @@ describe.sequential("existing-agents — parked BYO guarded calls", () => {
         return { status: "ok", output: {} };
       },
     };
-    const byo = createByoApprovals({ guard, tools: guard.bind(flaky), store });
+    const byo = createByoApprovals({ guard, tools: guard.bind(flaky), store, ops: createStoreOps(store) });
 
     const parked = await byo.registry.execute({ id: "call_6", tool: "host_flaky", args: {} }, ctx);
     if (parked.status !== "pending-approval") throw new Error("expected the mutation to park");
@@ -289,7 +292,7 @@ describe.sequential("existing-agents — parked BYO guarded calls", () => {
         return { status: "ok", output: { delivered: true } };
       },
     };
-    const byo = createByoApprovals({ guard, tools: guard.bind(slow), store });
+    const byo = createByoApprovals({ guard, tools: guard.bind(slow), store, ops: createStoreOps(store) });
 
     const parked = await byo.registry.execute({ id: "call_7", tool: "host_slowSend", args: {} }, ctx);
     if (parked.status !== "pending-approval") throw new Error("expected the mutation to park");

--- a/packages/vendo/tests/cli/cloud/host-components.test.ts
+++ b/packages/vendo/tests/cli/cloud/host-components.test.ts
@@ -2,9 +2,10 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
+import { STORE_WIRE_PATHS } from "@vendoai/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { runSync } from "../../../src/cli/sync.js";
-import { pushHostComponents, readPushComponents } from "../../../src/cli/cloud/host-components.js";
+import { HOST_COMPONENTS_COLLECTION, pushHostComponents, readPushComponents } from "../../../src/cli/cloud/host-components.js";
 
 const roots: string[] = [];
 
@@ -64,6 +65,30 @@ const remoteRow = (id: string, data?: unknown): [string, unknown] => [id, data !
   modules: { "src/lib/format.ts": hex("shared") },
 }];
 
+const VERBS = ["list", "put", "delete"] as const;
+
+/**
+ * Which record verb a request is, across BOTH spellings of the door.
+ *
+ * The façade (`store.records(collection)`) addresses a per-collection path,
+ * `/records/<collection>/<verb>`; the named-operation surface (`ops.engine.*`)
+ * addresses the verb and carries the collection in the body. The engine routes
+ * are read off `STORE_WIRE_PATHS` rather than written out here, so this double
+ * cannot drift from the contract the client actually routes by — the literal 42
+ * paths stay pinned in `packages/core/tests/store-wire.test.ts`, which is where
+ * a path belongs. The per-collection door has no entry in that map (it is not
+ * part of the wire contract), so it stays spelled out.
+ */
+function recordVerb(pathname: string, body: { collection?: string }): typeof VERBS[number] | undefined {
+  for (const verb of VERBS) {
+    if (pathname.endsWith(`/records/${HOST_COMPONENTS_COLLECTION}/${verb}`)) return verb;
+    if (pathname.endsWith(STORE_WIRE_PATHS[`engine.${verb}`]) && body.collection === HOST_COMPONENTS_COLLECTION) {
+      return verb;
+    }
+  }
+  return undefined;
+}
+
 /** The console store wire, as a fake: blob keys, blob bodies, and rows. */
 function fakeCloud(seed: { blobs?: string[]; records?: Array<[string, unknown]> } = {}) {
   const blobs = new Set(seed.blobs ?? []);
@@ -81,26 +106,31 @@ function fakeCloud(seed: { blobs?: string[]; records?: Array<[string, unknown]> 
       if (method === "DELETE") blobs.delete(blob[1]!);
       return json({});
     }
-    if (url.pathname.endsWith("/records/vendo_host_components/list")) {
-      return json({
-        records: [...records].map(([id, data]) => ({
-          id,
-          data,
-          createdAt: "2026-08-02T00:00:00.000Z",
-          updatedAt: "2026-08-02T00:00:00.000Z",
-        })),
-      });
+    // Past the blob branches every remaining body is the door's JSON.
+    const body = (init?.body === undefined || init.body === null
+      ? {}
+      : JSON.parse(String(init.body))) as { collection?: string; record?: { id: string; data: unknown }; id?: string };
+    switch (recordVerb(url.pathname, body)) {
+      case "list":
+        return json({
+          records: [...records].map(([id, data]) => ({
+            id,
+            data,
+            createdAt: "2026-08-02T00:00:00.000Z",
+            updatedAt: "2026-08-02T00:00:00.000Z",
+          })),
+        });
+      case "put": {
+        const record = body.record!;
+        records.set(record.id, record.data);
+        return json({ record: { ...record, createdAt: "2026-08-02T00:00:00.000Z", updatedAt: "2026-08-02T00:00:00.000Z" } });
+      }
+      case "delete":
+        records.delete(body.id!);
+        return json({});
+      default:
+        return json({ records: [] });
     }
-    if (url.pathname.endsWith("/records/vendo_host_components/put")) {
-      const record = (JSON.parse(String(init?.body)) as { record: { id: string; data: unknown } }).record;
-      records.set(record.id, record.data);
-      return json({ record: { ...record, createdAt: "2026-08-02T00:00:00.000Z", updatedAt: "2026-08-02T00:00:00.000Z" } });
-    }
-    if (url.pathname.endsWith("/records/vendo_host_components/delete")) {
-      records.delete((JSON.parse(String(init?.body)) as { id: string }).id);
-      return json({});
-    }
-    return json({ records: [] });
   }) as unknown as typeof fetch;
   return { fetchImpl, calls, blobs, records };
 }


### PR DESCRIPTION
Prep for S7d — the `records.*` → `ops.engine.*` call-site migration in `packages/vendo`. **This PR contains no call-site migration on purpose.** It is green with the flip absent, which is the whole point: a double taught the new door in the same commit as the code that starts calling it can never disagree with that code. That is how the host-component previews shipped four times with a green suite and a dead feature (CLAUDE.md, testing §1).

The flip lands in a follow-up PR on top of this one.

## Two halves

**1. `byo-approvals` gets its ops surface threaded, ahead of using it.**
`ByoApprovalsConfig` gains `ops: StoreOps | undefined` — the same three-way answer `selectStoreOps` gives — and `composeActions` passes `composition.ops` into it. Nothing consumes it yet; the parked-call drawers still reach the store through the record façade. It is wired rather than dead, and it means the flip is a pure body change: no signature churn, and no edit to `byo-approvals.e2e.test.ts`, whose three construction sites now pass `createStoreOps(store)` over the same handle the guard already runs on.

**2. `host-components.test.ts`'s fake cloud serves BOTH spellings of the records door.**
The façade (`store.records(collection)`) addresses a per-collection path, `/records/<collection>/<verb>`. The named-operation surface (`ops.engine.*`) addresses the verb and carries the collection in the body. The double now answers either.

The `/engine/*` routes are read off `STORE_WIRE_PATHS` rather than written out, so this double cannot drift from the contract the client actually routes by — the literal 42 paths stay pinned in `packages/core/tests/store-wire.test.ts`, which is where a path belongs. The per-collection path stays spelled out because it genuinely has **no entry in that map**: it is not part of the wire contract (`hostedStore.records()` builds it via `recordsPath`, `hosted-store.ts:89`), and deriving it would have been a fiction.

## What needed no change

`tests/cli/sync-flow.test.ts` — its `fakeStore` already matches on path suffixes (`/list`, `/put`, `/delete`, `:670,675,679`) and reads `body.record`/`body.id`, which are the same field names the engine door sends (`hosted-store.ts:527-536`). It serves the engine door as-is.

## Scope notes carried into the flip

- The two path assertions that name the door (`host-components.test.ts:173-174`, `sync-flow.test.ts:702`) move in the flip PR, declared there. Their entire content is *which door did the CLI knock on*, and after the flip there is exactly one correct answer.
- `threads.ts` is **out of scope** and stays on the `StoreAdapter` façade, like `mcp` and `knowledge`. Its double mirrors the routed door's `vendo_threads` projection and cross-subject `conflict` (`core/src/conformance/memory-store.ts:211-235`), which `memoryStoreOps` does not reproduce; switching it would have left its test green for a weaker reason.

## Verification

Local gate on the touched scope, each stage its own run: `pnpm build` ✅, `pnpm typecheck` ✅ (42/42), `pnpm lint` ✅. CI is the gate of record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares `packages/vendo` for migrating `records.*` to `ops.engine.*` by threading `ops` into BYO approvals and teaching all test doubles to serve the engine door alongside `/records/*`. Also fixes the engine route map typing in the console fake so lookups resolve correctly; no call-site changes.

- **Refactors**
  - Add `ops: StoreOps | undefined` to `ByoApprovalsConfig` and pass `composition.ops` from `composeActions`.
  - Update `byo-approvals.e2e.test.ts` to pass `ops` via `createStoreOps(store)`.
  - Teach `fakeConsole` (`hosted-store.test-util.ts`) to serve `/engine/*` derived from `@vendoai/core`’s `STORE_WIRE_PATHS`, enforce `assertEngineCollection`, and dispatch through the same `records` handler.
  - Update the cloud fake in `tests/cli/cloud/host-components.test.ts` to handle both `/records/<collection>/<verb>` and `engine.*`, reading routes from `STORE_WIRE_PATHS` and matching the collection in the body.

- **Bug Fixes**
  - Key the engine route table by plain `string` in `fakeConsole` so `.get()` lookups of assembled paths work; derivation from `STORE_WIRE_PATHS` is unchanged.

<sup>Written for commit e27aa678bae9447c1b641009fc82f04f79486a74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

