### PR TITLE
feat(ui): connect + automation cards join the sentence family

### DIFF
--- a/packages/apps/src/server/doors/make-tool.ts
+++ b/packages/apps/src/server/doors/make-tool.ts
@@ -244,6 +244,11 @@ const changeExistingApp = async (
   // Wave 9 — a ladder-authored automation raises its own card. Published
   // HERE, by the side that knows, rather than duck-typed out of this tool's
   // return value at the bridge: the receipt carries words only.
+  //
+  // The trigger goes over WHOLE, which is what carries the automation's terms
+  // (`Trigger.rules` — the sentences its author wrote) to the card with no
+  // second field to disagree with the document. The document's trigger is the
+  // one this edit authored and landed, so what the card lists is what runs.
   if (result.automation !== undefined && stream !== undefined) {
     stream({
       id: `vendo-automation-${result.app.id}`,

--- a/packages/apps/tests/automation-rules-seam.test.ts
+++ b/packages/apps/tests/automation-rules-seam.test.ts
@@ -1,0 +1,201 @@
+/**
+ * `Trigger.rules` — the automation's terms in its author's own words — from the
+ * plan that wrote them all the way to the part the card reads, with nothing
+ * hand-built in between.
+ *
+ * The words are display-only, which is exactly why they are easy to lose: no run
+ * fails when they go missing, so only a test that walks the whole path notices.
+ * And a test that walks HALF the path notices nothing either — a fixture part
+ * asserted against a fixture schema agrees with itself by construction. So this
+ * rides the real door (`vendo_make` with `app`, on the real streaming bridge),
+ * takes the part OUT of the stream the way the harness bridge does, and puts it
+ * through `vendoAutomationPartSchema` — the one gate the bridge applies before
+ * any renderer sees a part (`guardedCall` in @vendoai/harnesses).
+ *
+ * The sentences enter through the PLANNER's reply, so they travel the authoring
+ * path a real automation's terms travel: plan → `applyAutomationPlan` → the
+ * persisted row → `EditResult.automation.trigger` → the streamed part.
+ */
+import {
+  VENDO_APP_FORMAT,
+  VENDO_MAKE_TOOL,
+  VENDO_VIEW_STREAM,
+  vendoAutomationPartSchema,
+  type RunContext,
+  type ToolRegistry,
+  type VendoAutomationPart,
+  type VendoViewStreamUpdate,
+  type VendoViewStreamingToolCall,
+} from "@vendoai/core";
+import {
+  type AppDocument,
+  type ScreenAssembler,
+} from "../src/contract/index.js";
+import { describe, expect, it } from "vitest";
+import { createApps } from "../src/server/index.js";
+import { guardFixture } from "../src/server/testing/guard-fixture.js";
+import { memoryStore } from "../src/server/testing/memory-store.js";
+import { scriptedLanguageModel } from "../src/server/testing/scripted-model.js";
+import { seedAppRow } from "../src/server/testing/seed-app-row.js";
+
+const APP_ID = "app_rules_seam";
+
+const ASK = "nudge everyone with an overdue invoice every day";
+
+/**
+ * The terms as their author wrote them — including the blank one, deliberately.
+ *
+ * `triggerSchema.rules` is not `.min(1)` on purpose: this array validates a whole
+ * automation and, through `vendoAutomationPartSchema`, a whole card, so one
+ * sloppy sentence must cost that sentence and never the automation it describes.
+ * The blank rides in the MIDDLE, where a validator that rejected it would take
+ * the two good sentences down with it.
+ */
+const RULES = [
+  "Caps at $200 a bill — anything higher asks you first.",
+  "",
+  "Runs once a day and never touches an invoice already paid.",
+];
+
+const ctx: RunContext = {
+  principal: { kind: "user", subject: "user_ada" },
+  venue: "chat",
+  presence: "present",
+  sessionId: "session_ada",
+};
+
+const tools: ToolRegistry = {
+  async descriptors() {
+    return [{
+      name: "host_invoices_list",
+      description: "Every invoice with its amount and due date.",
+      inputSchema: { type: "object" },
+      risk: "read",
+    }];
+  },
+  async execute() {
+    return { status: "ok", output: { items: [] } };
+  },
+};
+
+const seedDoc: AppDocument = {
+  format: VENDO_APP_FORMAT,
+  id: APP_ID,
+  name: "Invoice board",
+  ui: "tree",
+  tree: {
+    formatVersion: "vendo-genui/v2",
+    root: "app",
+    nodes: [{ id: "app", component: "Stack", source: "prewired", children: [] }],
+  },
+};
+
+/** The plan the escalating screen agent leaves behind: server-shaped and
+ *  agentic, so no results collection and no board rewire come along for the ride. */
+const ESCALATED_PLAN = `<Plan name="Invoice board">
+  <Group title="Nudges">
+    <Leaf component="Text" purpose="One line saying the nudge automation runs daily"/>
+  </Group>
+  <Server kind="agentic" schedule="every day" why="Each invoice needs a judgment call on how firm the nudge should be."/>
+</Plan>`;
+
+const escalatingScreen: ScreenAssembler = {
+  assemble: async () => ({ kind: "escalate", why: "nudging every day happens while nobody is watching" }),
+};
+
+/** The automation planner's reply — the ONE thing on this path still running on
+ *  the model, and where the terms come from. `planTriggerSchema` is
+ *  `triggerSchema.omit({ id: true })`, so `rules` validates here or the plan is
+ *  refused outright. */
+const PLAN = JSON.stringify({
+  name: "Invoice nudge triage",
+  trigger: {
+    on: { kind: "schedule", every: "1d" },
+    run: { kind: "agentic", prompt: "Decide who deserves a gentle vs firm nudge.", budget: { maxToolCalls: 20 } },
+    rules: RULES,
+  },
+});
+
+const respond = (prompt: string): string =>
+  prompt.includes("You are the Vendo automation planner") ? PLAN : "";
+
+/** One ride through the real door, returning everything the stream carried. */
+const authorThroughTheDoor = async () => {
+  const store = memoryStore();
+  const runtime = createApps({
+    store,
+    guard: guardFixture(),
+    tools,
+    catalog: [],
+    model: scriptedLanguageModel((call) => respond(
+      call.prompt
+        .map((message) => typeof message.content === "string"
+          ? message.content
+          : message.content.map((part) => part.text ?? "").join(""))
+        .join("\n"),
+    )),
+    screen: escalatingScreen,
+    escalatedPlan: async () => ESCALATED_PLAN,
+    armAutomation: async () => ({ enabled: true, missing: [] }),
+  });
+  await seedAppRow(store, seedDoc, ctx.principal.subject);
+  const streamed: VendoViewStreamUpdate[] = [];
+  const call: VendoViewStreamingToolCall = {
+    id: "call_make_rules",
+    tool: VENDO_MAKE_TOOL,
+    args: { app: APP_ID, request: ASK },
+  };
+  // Attached exactly the way production attaches it (`makeAppTool` in
+  // @vendoai/vendo, `guardedCall` in @vendoai/harnesses) — a symbol property on
+  // the call object, which is the only way `stream` is defined inside the tool.
+  Object.defineProperty(call, VENDO_VIEW_STREAM, {
+    value: (update: VendoViewStreamUpdate) => { streamed.push(update); },
+  });
+  const outcome = await runtime.agentTools().execute(call, ctx);
+  return { runtime, outcome, streamed };
+};
+
+/** The automation part as it came off the stream — never built here. */
+const automationPart = (streamed: VendoViewStreamUpdate[]): VendoAutomationPart => {
+  const update = streamed.find(({ part }) => part.type === "data-vendo-automation");
+  if (update === undefined) {
+    throw new Error(`no data-vendo-automation part was streamed (got: ${streamed.map(({ part }) => part.type).join(", ") || "nothing"})`);
+  }
+  return update.part as VendoAutomationPart;
+};
+
+describe("an automation's terms, from the plan that wrote them to the streamed part", () => {
+  it("reach the part the real make tool emits, in the author's order", async () => {
+    const { outcome, streamed } = await authorThroughTheDoor();
+
+    // The call really did author an automation — otherwise every assertion
+    // below would be about a part that was never emitted.
+    expect(outcome.status).toBe("ok");
+    const part = automationPart(streamed);
+    expect(part.type).toBe("data-vendo-automation");
+    expect(part.trigger?.rules).toEqual(RULES);
+  });
+
+  it("survive the gate the bridge applies before any renderer sees the part", async () => {
+    const { streamed } = await authorThroughTheDoor();
+
+    const parsed = vendoAutomationPartSchema.safeParse(automationPart(streamed));
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.data?.trigger?.rules).toEqual(RULES);
+    // The blank sentence in the middle is still there: validation dropped
+    // nothing, so one sloppy sentence never costs the card the other two.
+    expect(parsed.data?.trigger?.rules?.[1]).toBe("");
+  });
+
+  it("are on the LANDED document, so what the card lists is what runs", async () => {
+    const { runtime } = await authorThroughTheDoor();
+
+    // Read back through the ordinary door, off the row the edit persisted.
+    const stored = await runtime.get(APP_ID, ctx);
+    if (stored === null) throw new Error(`app row ${APP_ID} is gone`);
+
+    expect(stored.triggers?.map(({ id }) => id)).toEqual(["main"]);
+    expect(stored.triggers?.[0]?.rules).toEqual(RULES);
+  });
+});

--- a/packages/core/src/stream-parts.ts
+++ b/packages/core/src/stream-parts.ts
@@ -246,10 +246,6 @@ export interface VendoAutomationPart {
   trigger?: Trigger;
   /** The document's one-line description, when it has one. */
   description?: string;
-  /** The rule in the agent's own sentences, one per constraint ("Caps at $200 a
-   *  bill — anything higher asks you first"). The card lists them under the
-   *  status line; a producer with nothing to say omits the field. */
-  rules?: string[];
   /** Standing-grant asks still undecided: the card reads
    *  "Enabled · waiting on N permissions" until the set is granted. */
   pendingGrants?: number;
@@ -260,9 +256,10 @@ export const vendoAutomationPartSchema = z.object({
   appId: appIdSchema,
   name: z.string().min(1),
   enabled: z.boolean(),
+  // The trigger carries the automation's terms as words (`Trigger.rules`) — the
+  // card lists them, and no second field on this part can disagree with it.
   trigger: triggerSchema.optional(),
   description: z.string().optional(),
-  rules: z.array(z.string().min(1)).optional(),
   pendingGrants: z.number().int().nonnegative().optional(),
 }).passthrough() satisfies z.ZodType<VendoAutomationPart>;
 

--- a/packages/core/src/stream-parts.ts
+++ b/packages/core/src/stream-parts.ts
@@ -246,6 +246,10 @@ export interface VendoAutomationPart {
   trigger?: Trigger;
   /** The document's one-line description, when it has one. */
   description?: string;
+  /** The rule in the agent's own sentences, one per constraint ("Caps at $200 a
+   *  bill — anything higher asks you first"). The card lists them under the
+   *  status line; a producer with nothing to say omits the field. */
+  rules?: string[];
   /** Standing-grant asks still undecided: the card reads
    *  "Enabled · waiting on N permissions" until the set is granted. */
   pendingGrants?: number;
@@ -258,6 +262,7 @@ export const vendoAutomationPartSchema = z.object({
   enabled: z.boolean(),
   trigger: triggerSchema.optional(),
   description: z.string().optional(),
+  rules: z.array(z.string().min(1)).optional(),
   pendingGrants: z.number().int().nonnegative().optional(),
 }).passthrough() satisfies z.ZodType<VendoAutomationPart>;
 

--- a/packages/core/src/triggers.ts
+++ b/packages/core/src/triggers.ts
@@ -143,6 +143,18 @@ export interface Trigger {
   id: string;
   on: TriggerSource;
   run: RunModel;
+  /**
+   * The automation's terms, in the sentences its author wrote — "Caps at $200 a
+   * bill — anything higher asks you first". DISPLAY ONLY: nothing here gates a
+   * run (`on` and `run` are the behavior), so a reader can trust that the words
+   * came from whoever authored the automation rather than from a renderer.
+   *
+   * It lives on the trigger because the trigger IS the automation the words
+   * describe, which is what carries them the whole way with no second wire:
+   * every surface that already forwards a trigger (the `data-vendo-automation`
+   * part in `make-tool.ts`) forwards these with it.
+   */
+  rules?: string[];
 }
 
 /** 01-core §11 */
@@ -150,6 +162,12 @@ export const triggerSchema = z.object({
   id: z.string().regex(TRIGGER_ID_PATTERN, "trigger id must match /^[A-Za-z_][A-Za-z0-9_]*$/"),
   on: triggerSourceSchema,
   run: runModelSchema,
+  // Deliberately NOT `.min(1)`: this validates a whole automation — and through
+  // `vendoAutomationPartSchema`, a whole card — so one empty sentence from a
+  // sloppy author must cost that sentence, never the automation it describes.
+  // The renderer is the one place that decides what is renderable (trim, drop,
+  // clamp, cap — `automationRules` in @vendoai/ui's automation card).
+  rules: z.array(z.string()).optional(),
 }).passthrough() satisfies z.ZodType<Trigger>;
 
 /** The id a legacy single-`trigger` document's one trigger takes on read.

--- a/packages/core/tests/stream-parts.test.ts
+++ b/packages/core/tests/stream-parts.test.ts
@@ -219,6 +219,41 @@ describe("vendoAutomationPartSchema", () => {
       enabled: true,
     }).success).toBe(false);
   });
+
+  /** The automation's terms ride the TRIGGER (`Trigger.rules`) — the document's
+   *  own field, forwarded whole by every producer that already forwards a
+   *  trigger — so this part has no second copy of them to disagree with.
+   *
+   *  A blank sentence must cost that sentence and nothing else. This part is
+   *  `safeParse`d at the bridge before the thread ever sees it, so a `min(1)`
+   *  on the array would have made one empty string from a sloppy author delete
+   *  the entire automation card; the renderer is the one place that decides
+   *  what is renderable (`@vendoai/ui`'s automation card trims, drops, clamps
+   *  and caps). */
+  it("carries the trigger's rule sentences, and one blank never fails the part", () => {
+    const withRules = (rules: unknown) => vendoAutomationPartSchema.safeParse({
+      type: "data-vendo-automation",
+      appId: "app_auto",
+      name: "PG&E autopay",
+      enabled: true,
+      trigger: {
+        id: "main",
+        on: { kind: "external", connector: "gmail", event: "new_bill_email" },
+        run: { kind: "steps", steps: [{ id: "pay", tool: "host_transferMoney" }] },
+        rules,
+      },
+    });
+    const kept = withRules(["Caps at $200 a bill — anything higher asks you first", "  "]);
+    expect(kept.success).toBe(true);
+    expect(kept.data!.trigger!.rules).toEqual([
+      "Caps at $200 a bill — anything higher asks you first",
+      "  ",
+    ]);
+    expect(withRules([]).success).toBe(true);
+    // A rule that is not a string at all is a broken producer, not a sloppy
+    // author: the array's element type still holds the line.
+    expect(withRules([{ text: "nope" }]).success).toBe(false);
+  });
 });
 
 /** demo-live-readiness 2026-07 (additive): the grant-set consent card part. */

--- a/packages/ui/src/chrome/automation-card.tsx
+++ b/packages/ui/src/chrome/automation-card.tsx
@@ -39,11 +39,18 @@ export function humanizeCron(cron: string): string | null {
   return `${day} at ${clock}`;
 }
 
-export function triggerLabel(trigger: Trigger): { title: string; sub: string } {
+/** One clause of the card, at the length a card can hold. The rule sentence's
+    action half has always clamped here (an agentic prompt is arbitrarily long);
+    the authored rule list clamps the same way, so no producer can push the card
+    past its own geometry. */
+const clamp = (text: string): string =>
+  text.length > 68 ? `${text.slice(0, 67).trimEnd()}…` : text;
+
+export function triggerLabel(trigger: Trigger): string {
   const source = trigger.on;
   if (source.kind === "schedule") {
-    if (source.every) return { title: `Every ${source.every}`, sub: "Schedule" };
-    if (source.at) return { title: source.at, sub: "Scheduled once" };
+    if (source.every) return `Every ${source.every}`;
+    if (source.at) return source.at;
     // The zone is named because the automation does not fire in the reader's:
     // the engine builds every cron with `{ timezone: "UTC" }`, so an 8 AM
     // Pacific request is stored as 16:00 and an unlabelled "Mondays at 4:00 PM"
@@ -53,41 +60,41 @@ export function triggerLabel(trigger: Trigger): { title: string; sub: string } {
     // carries its own zone.
     if (source.cron) {
       const clock = humanizeCron(source.cron);
-      return { title: clock === null ? source.cron : `${clock} UTC`, sub: "Schedule" };
+      return clock === null ? source.cron : `${clock} UTC`;
     }
-    return { title: "Scheduled", sub: "Schedule" };
+    return "Scheduled";
   }
-  if (source.kind === "external") {
-    return { title: humanizeToolName(source.event), sub: humanizeToolName(source.connector) };
-  }
-  return { title: humanizeToolName(source.event), sub: "Host event" };
+  return humanizeToolName(source.event);
 }
 
-export function automationFlow(trigger: Trigger | undefined): {
-  trigger: { title: string; sub: string };
-  action: { title: string; sub: string };
-} | undefined {
+/** The rule this automation runs by, as one sentence: what starts it → what it
+    then does. The card's title when the document wrote no description of its
+    own. (It replaced a two-box `trigger → action` diagram, whose second labels
+    — "Schedule", "1 action", "N steps" — named the boxes, not the rule, and
+    went with them.) */
+export function automationRule(trigger: Trigger | undefined): string | undefined {
   if (!trigger) return undefined;
-  if (trigger.run.kind === "agentic") {
-    const prompt = trigger.run.prompt.trim();
-    if (!prompt) return undefined;
-    return {
-      trigger: triggerLabel(trigger),
-      action: {
-        title: prompt.length > 68 ? `${prompt.slice(0, 67).trimEnd()}…` : prompt,
-        sub: "Agent run",
-      },
-    };
-  }
-  const firstStep = trigger.run.steps[0];
-  if (!firstStep) return undefined;
-  return {
-    trigger: triggerLabel(trigger),
-    action: {
-      title: humanizeToolName(firstStep.tool),
-      sub: trigger.run.steps.length === 1 ? "1 action" : `${trigger.run.steps.length} steps`,
-    },
-  };
+  const action = trigger.run.kind === "agentic"
+    ? trigger.run.prompt.trim()
+    : trigger.run.steps[0] === undefined ? "" : humanizeToolName(trigger.run.steps[0].tool);
+  return action.length === 0 ? undefined : `${triggerLabel(trigger)} → ${clamp(action)}`;
+}
+
+/** How many of an automation's terms a CARD shows, and how long each may be.
+    A card is the moment's record, not the settings page — the Automations panel
+    owns the full list — so the render is bounded no matter what the document
+    says. Blanks and non-strings drop here rather than upstream: the schema lets
+    them through on purpose, so one sloppy sentence can never cost the whole
+    automation card (see `Trigger.rules`). */
+const MAX_RULES = 6;
+
+function automationRules(rules: readonly string[]): string[] {
+  return rules
+    .filter((rule): rule is string => typeof rule === "string")
+    .map(rule => rule.trim())
+    .filter(rule => rule.length > 0)
+    .slice(0, MAX_RULES)
+    .map(clamp);
 }
 
 export interface AutomationCardProps {
@@ -95,14 +102,18 @@ export interface AutomationCardProps {
   name: string;
   /** Whether the automations engine reports it enabled. */
   enabled: boolean;
-  /** The document's trigger, for the flow nodes; omitted → identity only. */
+  /** The document's trigger: the source of the rule sentence AND of the terms
+   *  it runs by (`Trigger.rules`). Omitted → the name is all this card has. */
   trigger?: Trigger;
   /** The document's one-line description. Preferred over the composed
    *  `trigger → action` title: it is the human phrasing of the same rule. */
   description?: string;
-  /** E3 — the rule, as the agent wrote it: one plain sentence per constraint
-   *  ("Caps at $200 a bill — anything higher asks you first"). Rendered as a
-   *  tick list under the status line; omitted entirely when there are none. */
+  /** E3 — the automation's terms, one sentence each ("Caps at $200 a bill —
+   *  anything higher asks you first"), as a tick list under the status line;
+   *  omitted entirely when there are none. Defaults to the trigger's own
+   *  `rules`, which is where the document carries them and how the wire's
+   *  automation part delivers them — a host mounting this card from its own
+   *  data passes them here instead. */
   rules?: string[];
   /** Standing-grant asks still undecided (grant sets): the state line reads
    *  "Enabled · waiting on N permissions" until the set is granted. */
@@ -127,14 +138,17 @@ export function sponsorLabel(
 }
 
 /** The read-only automation card (the thread's record of a live automation). */
-export function AutomationCard({ name, enabled, trigger, description, rules = [], pendingGrants = 0, sponsor, editors }: AutomationCardProps) {
-  const flow = automationFlow(trigger);
+export function AutomationCard({ name, enabled, trigger, description, rules, pendingGrants = 0, sponsor, editors }: AutomationCardProps) {
   const waiting = enabled && pendingGrants > 0;
   // Law 3 and the title are ONE line now: the rule itself. The description is
-  // the human phrasing of that rule and wins when the document has one; the
+  // the human phrasing of that rule and wins when the document wrote one — a
+  // BLANK one is not a phrasing, and as the card's 14px title an empty string
+  // is a headless card, where as the old quiet line it was merely a gap. The
   // composed trigger → action is the honest fallback, and a document with
   // neither is only its name. The NAME is still the card's accessible name.
-  const rule = description ?? (flow ? `${flow.trigger.title} → ${flow.action.title}` : name);
+  const described = (description ?? "").trim();
+  const rule = described.length > 0 ? described : automationRule(trigger) ?? name;
+  const terms = automationRules(rules ?? trigger?.rules ?? []);
   // Whether it is on, and whose access it runs with — the state chip and the
   // byline row, folded into one quiet line. " · " is literal here (unlike the
   // approval notes) because these are clauses of one sentence about one thing.
@@ -150,13 +164,13 @@ export function AutomationCard({ name, enabled, trigger, description, rules = []
         <CardLine className="fl-auto-sentence">{rule}</CardLine>
         <div className="fl-auto-state">
           {enabled ? <span className={`fl-auto-live${waiting ? " fl-auto-wait" : ""}`} aria-hidden="true" /> : null}
-          {state}
+          <span className="fl-auto-state-copy">{state}</span>
         </div>
         {/* A real list: these are N distinct promises about how the automation
             behaves, and a reader has to be able to step through them. */}
-        {rules.length === 0 ? null : (
+        {terms.length === 0 ? null : (
           <ul className="fl-auto-rules" aria-label={`Rules for ${name}`}>
-            {rules.map((sentence, index) => <li key={index}>{TICK_GLYPH}{sentence}</li>)}
+            {terms.map((sentence, index) => <li key={index}>{TICK_GLYPH}{sentence}</li>)}
           </ul>
         )}
       </CardShell>

--- a/packages/ui/src/chrome/automation-card.tsx
+++ b/packages/ui/src/chrome/automation-card.tsx
@@ -1,25 +1,21 @@
 import type { Trigger } from "@vendoai/core";
-import {
-  BOLT_GLYPH,
-  CardByline,
-  CardHead,
-  CardLine,
-  CardShell,
-  CARD_EYEBROWS,
-  ToolkitLogo,
-} from "./card-shell.js";
+import { CardLine, CardShell, TICK_GLYPH } from "./card-shell.js";
 import { ChromeRoot } from "./chrome-root.js";
 import { humanizeToolName } from "./humanize.js";
 
 /** 2026-07 demo feedback — the automation, rendered AS an automation.
  *
- * The workspace Automations panel already ships the card vocabulary
- * (.fl-automation: identity head + trigger → action flow nodes); this module
- * extracts the read-only core so the THREAD can render it too — the
- * `data-vendo-automation` stream part lands one of these in the transcript
+ * The `data-vendo-automation` stream part lands one of these in the transcript
  * when a turn creates or arms an automation. No toggle, no run history, no
- * dry-run controls: management stays in the panel; the thread card is the
- * moment's record.
+ * dry-run controls: management stays in the workspace Automations panel; the
+ * thread card is the moment's record.
+ *
+ * A1 · Sentence + E3 · Rule list — the sentence family the approval card
+ * opened: the RULE is the title ("New PG&E bill → paid from Maple Checking"),
+ * one quiet status line under it says whether it is on and whose access it
+ * runs with, and the agent's own rule sentences follow as a tick list. The
+ * eyebrow, the bolt well and the trigger → action node diagram are gone — the
+ * diagram said in two boxes what the title now says in one line.
  */
 
 const DAY_NAMES = ["Sundays", "Mondays", "Tuesdays", "Wednesdays", "Thursdays", "Fridays", "Saturdays"];
@@ -101,8 +97,13 @@ export interface AutomationCardProps {
   enabled: boolean;
   /** The document's trigger, for the flow nodes; omitted → identity only. */
   trigger?: Trigger;
-  /** The document's one-line description. */
+  /** The document's one-line description. Preferred over the composed
+   *  `trigger → action` title: it is the human phrasing of the same rule. */
   description?: string;
+  /** E3 — the rule, as the agent wrote it: one plain sentence per constraint
+   *  ("Caps at $200 a bill — anything higher asks you first"). Rendered as a
+   *  tick list under the status line; omitted entirely when there are none. */
+  rules?: string[];
   /** Standing-grant asks still undecided (grant sets): the state line reads
    *  "Enabled · waiting on N permissions" until the set is granted. */
   pendingGrants?: number;
@@ -125,54 +126,39 @@ export function sponsorLabel(
   return editors !== undefined && editors > 1 ? `${who} · ${editors} people can edit` : who;
 }
 
-/** The read-only automation card (same chrome as the panel's list entry). */
-export function AutomationCard({ name, enabled, trigger, description, pendingGrants = 0, sponsor, editors }: AutomationCardProps) {
+/** The read-only automation card (the thread's record of a live automation). */
+export function AutomationCard({ name, enabled, trigger, description, rules = [], pendingGrants = 0, sponsor, editors }: AutomationCardProps) {
   const flow = automationFlow(trigger);
   const waiting = enabled && pendingGrants > 0;
-  const runsAs = sponsorLabel(sponsor, editors);
+  // Law 3 and the title are ONE line now: the rule itself. The description is
+  // the human phrasing of that rule and wins when the document has one; the
+  // composed trigger → action is the honest fallback, and a document with
+  // neither is only its name. The NAME is still the card's accessible name.
+  const rule = description ?? (flow ? `${flow.trigger.title} → ${flow.action.title}` : name);
+  // Whether it is on, and whose access it runs with — the state chip and the
+  // byline row, folded into one quiet line. " · " is literal here (unlike the
+  // approval notes) because these are clauses of one sentence about one thing.
+  const state = [
+    enabled
+      ? waiting ? `Enabled · waiting on ${pendingGrants} permission${pendingGrants === 1 ? "" : "s"}` : "Enabled"
+      : "Disabled",
+    sponsorLabel(sponsor, editors),
+  ].filter(clause => clause !== null).join(" · ");
   return (
     <ChromeRoot>
       <CardShell label={`Automation — ${name}`} className="fl-automation" data-vendo-automation-card="">
-        <CardHead
-          icon={<ToolkitLogo fallback={BOLT_GLYPH} />}
-          eyebrow={CARD_EYEBROWS.automationStatus}
-          title={name}
-          aside={
-            <span className="fl-auto-sub" style={{ marginLeft: "auto" }}>
-              {enabled ? <span className={`fl-auto-live${waiting ? " fl-auto-wait" : ""}`} aria-hidden="true" /> : null}
-              {enabled
-                ? waiting
-                  ? `Enabled · waiting on ${pendingGrants} permission${pendingGrants === 1 ? "" : "s"}`
-                  : "Enabled"
-                : "Disabled"}
-            </span>
-          }
-        />
-        {/* Law 3 — what this automation DOES, in the user's words. */}
-        <CardLine>{description ?? (flow ? `${flow.trigger.title} → ${flow.action.title}` : name)}</CardLine>
-        {runsAs === null ? null : <CardByline>{runsAs}</CardByline>}
-        {/* role="group": a bare <div> may not carry aria-label
-            (aria-prohibited-attr). The panel's copy of this node was fixed at
-            integration; the thread's copy was not. */}
-        {flow ? (
-          <div className="fl-auto-flow" role="group" aria-label={`Automation flow for ${name}`}>
-            <span className="fl-auto-node" style={{ flex: 1 }}>
-              <span className="fl-auto-node-ic" aria-hidden="true">↳</span>
-              <span>
-                <span className="fl-auto-node-t">{flow.trigger.title}</span>
-                <span className="fl-auto-node-s" style={{ display: "block" }}>{flow.trigger.sub}</span>
-              </span>
-            </span>
-            <span className="fl-auto-arrow" aria-hidden="true" />
-            <span className="fl-auto-node" style={{ flex: 1 }}>
-              <span className="fl-auto-node-ic" aria-hidden="true">✓</span>
-              <span>
-                <span className="fl-auto-node-t">{flow.action.title}</span>
-                <span className="fl-auto-node-s" style={{ display: "block" }}>{flow.action.sub}</span>
-              </span>
-            </span>
-          </div>
-        ) : null}
+        <CardLine className="fl-auto-sentence">{rule}</CardLine>
+        <div className="fl-auto-state">
+          {enabled ? <span className={`fl-auto-live${waiting ? " fl-auto-wait" : ""}`} aria-hidden="true" /> : null}
+          {state}
+        </div>
+        {/* A real list: these are N distinct promises about how the automation
+            behaves, and a reader has to be able to step through them. */}
+        {rules.length === 0 ? null : (
+          <ul className="fl-auto-rules" aria-label={`Rules for ${name}`}>
+            {rules.map((sentence, index) => <li key={index}>{TICK_GLYPH}{sentence}</li>)}
+          </ul>
+        )}
       </CardShell>
     </ChromeRoot>
   );

--- a/packages/ui/src/chrome/card-shell.tsx
+++ b/packages/ui/src/chrome/card-shell.tsx
@@ -2,15 +2,17 @@
  *
  *  Every consent/status card in the product is this shell with different
  *  CONTENTS: eyebrow · one-size icon well · title · the mandatory plain-words
- *  line · field rows or a list · actions · byline. Connect, standing-access,
- *  automation and the resolved record are contents only, and every surface that
- *  shows one (thread, waiting strip, activities, mobile sheet, voice, embeds)
- *  renders the SAME shell.
+ *  line · field rows or a list · actions · byline. Standing-access and the
+ *  resolved record are contents only, and every surface that shows one (thread,
+ *  waiting strip, activities, mobile sheet, voice, embeds) renders the SAME
+ *  shell.
  *
- *  The APPROVAL ask (M1 · Sentence) is the one card with no head and no rows:
- *  the ask itself is a bold question, and one quiet line under it carries every
- *  real input the question doesn't name plus what approving does. It is still
- *  this shell, and law 3 lives across that pair.
+ *  The SENTENCE family — the approval ask (M1), the connect row (C2) and the
+ *  automation rule (A1) — is headless: its first line IS the card (a question,
+ *  a toolkit name, a rule), with one quiet line under it carrying the rest.
+ *  Those three wear no eyebrow and no icon well (connect shows the toolkit's
+ *  raw mark, deliberately not a well: the well cropped the Gmail M). They are
+ *  still this shell, and law 3 lives across each pair of lines.
  *
  *  1. Ancestors may set width/max-width on `.fl-cardshell` — never undress it.
  *  2. ONE icon well (28px), ONE primary button (`.fl-btn-primary`), ONE
@@ -32,13 +34,12 @@ import { useState, type HTMLAttributes, type ReactNode } from "react";
 import { developmentMode } from "./dev-mode.js";
 import type { CardFieldRow } from "./field-rows.js";
 
-/** The eyebrow strings, once (six were hardcoded across the card files). The
-    approval ASK has no eyebrow: its question is the whole card (M1 · Sentence),
-    so the two approval entries are gone with it. */
+/** The eyebrow strings, once (six were hardcoded across the card files). Each
+    card that joined the sentence family took its entry with it: the approval
+    ask, the connect row and the automation rule are their own first line, so
+    only the kinds that still wear a head are left here. */
 export const CARD_EYEBROWS = {
-  connect: "Connect",
   standingAccess: "Standing access",
-  automationStatus: "Automation",
   resolved: "Approval",
   waiting: "Waiting on you",
 } as const;
@@ -68,7 +69,6 @@ export const TOOL_GLYPH = glyph(
   13,
 );
 export const LINK_GLYPH = glyph(<path d="M9 17H7A5 5 0 0 1 7 7h2M15 7h2a5 5 0 1 1 0 10h-2M8 12h8" />);
-export const BOLT_GLYPH = glyph(<path d="m13 2-9 12h8l-1 8 9-12h-8l1-8Z" />);
 export const CLOCK_GLYPH = glyph(<><circle cx="12" cy="12" r="10" /><path d="M12 6v6l4 2" /></>);
 /** The settled mark (was inlined five times). */
 export const TICK_GLYPH = (

--- a/packages/ui/src/chrome/chrome-css.ts
+++ b/packages/ui/src/chrome/chrome-css.ts
@@ -544,16 +544,20 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the S1 des
    notes line), and the button. It wraps rather than squeezing the copy when the
    host's card is narrow. */
 .fl-connect-row { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
-/* The mark is RAW: no well, no fill, no radius, no clipping. The 28px well
+/* A brand's mark, RAW: no well, no fill, no radius, no clipping. The 28px well
    (.fl-card-ic) cropped the Gmail M — the defect this row was drawn for — so
-   the logo keeps its own aspect ratio inside a 26px box. */
-/* Aligned to the NAME, not to the row: in a host's narrow card the access line
+   the logo keeps its own aspect ratio inside a 26px box. Shared with the
+   standing-access card's permission rows, which carried the same crop.
+   Aligned to the NAME, not to the row: in a host's narrow card the access line
    wraps to three lines and a centred mark floats away from the row it labels
-   (the button stays centred — it answers the whole row). */
-.fl-connect-mark { display: grid; place-items: center; width: 26px; height: 26px; flex-shrink: 0;
+   (the button stays centred — it answers the whole row).
+   Both children are sized: the remote logo can 404, and its fallback glyph
+   drawn at its own 15px beside 26px marks reads as a different component. */
+.fl-mark-raw { display: grid; place-items: center; width: 26px; height: 26px; flex-shrink: 0;
   align-self: flex-start; margin-top: 1px; color: var(--vendo-fg-muted); }
-.fl-connect-mark img { max-width: 26px; max-height: 26px; width: auto; height: auto;
+.fl-mark-raw img { max-width: 26px; max-height: 26px; width: auto; height: auto;
   object-fit: contain; display: block; }
+.fl-mark-raw svg { width: 20px; height: 20px; display: block; }
 .fl-connect-copy { flex: 1 1 200px; min-width: 0; }
 .fl-connect-name { font: 600 14px/1.35 var(--vendo-heading-font); letter-spacing: -.012em;
   color: var(--vendo-fg); overflow-wrap: anywhere; }
@@ -858,14 +862,26 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the S1 des
 /* A1 · Sentence — the RULE is the card's first line (its type rides with the
    approval's question, below, where .fl-card-line can no longer outrank it),
    with the live dot and the agency clause quiet under it. */
-.fl-auto-state { margin-top: 4px; display: flex; align-items: center; gap: 6px;
+/* min-width/overflow-wrap on the TEXT half, not the row: a flex item refuses to
+   shrink below its content by default, and this card sets overflow: hidden — so
+   an unbroken token (the sponsor's subject fallback is an opaque id) was clipped
+   at the card's edge instead of wrapping. The dot stays unshrinkable. */
+.fl-auto-state { margin-top: 4px; display: flex; align-items: flex-start; gap: 6px;
   font: 400 12px/1.5 var(--vendo-font); color: var(--vendo-fg-muted); }
+/* Optically centred on the FIRST line rather than on the block, so the dot
+   still sits beside "Enabled" when the agency clause wraps. */
+.fl-auto-state .fl-auto-live { margin-top: 6px; flex-shrink: 0; }
+.fl-auto-state-copy { min-width: 0; overflow-wrap: anywhere; }
 /* E3 · Rule list — the agent's own sentences, each behind a quiet tick. Between
    the rule and the status line in weight, because these are the terms. */
 .fl-auto-rules { list-style: none; margin: 11px 0 0; padding: 0;
   display: flex; flex-direction: column; gap: 7px; }
-.fl-auto-rules li { display: flex; align-items: flex-start; gap: 9px;
-  font-size: 12.5px; line-height: 1.45; color: color-mix(in srgb, var(--vendo-fg) 74%, var(--vendo-surface)); }
+/* min-width:0 + overflow-wrap: a flex item will not shrink below its content,
+   and this card clips (overflow: hidden), so one long unbroken token in an
+   authored sentence was cut off at the card's edge instead of wrapping. */
+.fl-auto-rules li { display: flex; align-items: flex-start; gap: 9px; min-width: 0;
+  overflow-wrap: anywhere; font-size: 12.5px; line-height: 1.45;
+  color: color-mix(in srgb, var(--vendo-fg) 74%, var(--vendo-surface)); }
 .fl-auto-rules svg { flex-shrink: 0; margin-top: 2px; color: var(--vendo-indicator); }
 /* The trigger → action node diagram, still the workspace Automations panel's
    vocabulary (the thread card says the same thing in its title line now). */
@@ -1569,7 +1585,6 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the S1 des
 
 /* 3-A′ · real brand marks in the tray rows (monogram = fallback). */
 .fl-picker-ic img { width: 15px; height: 15px; object-fit: contain; display: block; }
-.fl-automation .fl-auto-arrow { position: relative; }
 @media (prefers-reduced-motion: reduce) {
   .fl-approval-sheet { animation: fl-fade-in .18s ease both; }
 }
@@ -1784,9 +1799,6 @@ ul.fl-approval-sub { padding: 0; list-style: none; }
 /* Law 1 — the ancestors that size the shell (width only, never its dress):
    the strip, the mobile sheet, and the activities stack. */
 .fl-approval-sheet .fl-cardshell { width: 100%; max-width: none; min-width: 0; }
-/* The automation card's flow nodes are CONTENTS now: the panel's padded block
-   loses its own box because the shell owns the padding. */
-.fl-cardshell > .fl-auto-flow { margin-top: 12px; padding: 12px 0 0; }
 /* The morph pill's mark comes from the shared <ToolkitLogo> (which owns the
    onError fallback), so its size rides the CSS instead of img attributes. */
 .fl-morph-logo img, .fl-morph-logo svg { display: block; width: 18px; height: 18px; object-fit: contain; }

--- a/packages/ui/src/chrome/chrome-css.ts
+++ b/packages/ui/src/chrome/chrome-css.ts
@@ -539,10 +539,27 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the S1 des
 .fl-connect-done-ic { display: inline-grid; place-items: center; width: 15px; height: 15px;
   border-radius: 999px; background: var(--vendo-accent); color: var(--vendo-accent-fg); }
 .fl-connect-done-ic svg { width: 9px; height: 9px; }
-/* V5 connect states: the plain-words access line, the settled receipt beside
-   the badge, the blocked-popup fallback, and the collapsed Skipped record. */
-.fl-connect-access { color: var(--vendo-fg-muted); font-size: 12px; }
-.fl-connect-receipt { color: var(--vendo-fg-muted); font-size: 11.5px; }
+/* C2 · Integration row — the connect card at rest is ONE row: the toolkit's raw
+   mark, its name over the quiet why/access line (.fl-approval-sub, the family's
+   notes line), and the button. It wraps rather than squeezing the copy when the
+   host's card is narrow. */
+.fl-connect-row { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+/* The mark is RAW: no well, no fill, no radius, no clipping. The 28px well
+   (.fl-card-ic) cropped the Gmail M — the defect this row was drawn for — so
+   the logo keeps its own aspect ratio inside a 26px box. */
+/* Aligned to the NAME, not to the row: in a host's narrow card the access line
+   wraps to three lines and a centred mark floats away from the row it labels
+   (the button stays centred — it answers the whole row). */
+.fl-connect-mark { display: grid; place-items: center; width: 26px; height: 26px; flex-shrink: 0;
+  align-self: flex-start; margin-top: 1px; color: var(--vendo-fg-muted); }
+.fl-connect-mark img { max-width: 26px; max-height: 26px; width: auto; height: auto;
+  object-fit: contain; display: block; }
+.fl-connect-copy { flex: 1 1 200px; min-width: 0; }
+.fl-connect-name { font: 600 14px/1.35 var(--vendo-heading-font); letter-spacing: -.012em;
+  color: var(--vendo-fg); overflow-wrap: anywhere; }
+.fl-connect-act { display: flex; align-items: center; gap: 8px; margin-left: auto; flex-shrink: 0; }
+/* The lifecycle's one status voice, under the row. */
+.fl-connect-note { display: block; margin-top: 9px; }
 .fl-connect-blocked { display: flex; flex-direction: column; align-items: flex-start; gap: 9px;
   font-size: 12.5px; line-height: 1.45; color: var(--vendo-fg); }
 /* Two classes on purpose: .fl-cardshell (column, card padding) is declared far
@@ -838,6 +855,20 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the S1 des
 /* Grant-set wait state (mockup §2): enabled but permissions outstanding. */
 .fl-auto-wait { background: var(--vendo-warn);
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--vendo-warn) 18%, transparent); }
+/* A1 · Sentence — the RULE is the card's first line (its type rides with the
+   approval's question, below, where .fl-card-line can no longer outrank it),
+   with the live dot and the agency clause quiet under it. */
+.fl-auto-state { margin-top: 4px; display: flex; align-items: center; gap: 6px;
+  font: 400 12px/1.5 var(--vendo-font); color: var(--vendo-fg-muted); }
+/* E3 · Rule list — the agent's own sentences, each behind a quiet tick. Between
+   the rule and the status line in weight, because these are the terms. */
+.fl-auto-rules { list-style: none; margin: 11px 0 0; padding: 0;
+  display: flex; flex-direction: column; gap: 7px; }
+.fl-auto-rules li { display: flex; align-items: flex-start; gap: 9px;
+  font-size: 12.5px; line-height: 1.45; color: color-mix(in srgb, var(--vendo-fg) 74%, var(--vendo-surface)); }
+.fl-auto-rules svg { flex-shrink: 0; margin-top: 2px; color: var(--vendo-indicator); }
+/* The trigger → action node diagram, still the workspace Automations panel's
+   vocabulary (the thread card says the same thing in its title line now). */
 .fl-auto-flow { display: flex; align-items: center; padding: 14px 16px 16px; border-top: 1px solid var(--vendo-border); }
 .fl-auto-node { display: flex; align-items: center; gap: 10px; padding: 9px 12px; border-radius: 12px;
   background: var(--vendo-bg); border: 1px solid var(--vendo-border); }
@@ -1527,9 +1558,13 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the S1 des
   .fl-approval-sheet-scrim { animation: fl-fade-in .3s ease both; }
 }
 @keyframes fl-sheet-up { from { transform: translateY(100%); } to { transform: none; } }
-/* 1-H · thumb-zone decision buttons (same query as the ENG-228 block). */
+/* 1-H · thumb-zone decision buttons (same query as the ENG-228 block). The
+   connect row's cluster answers here too: on a phone it drops under the copy
+   and its buttons take the full width, the treatment it had while they rode
+   .fl-card-actions. */
 @media (max-width: 767px), (pointer: coarse) {
-  .fl-card-actions .fl-btn { padding: 14px 15px; font-size: 14px; flex: 1; }
+  .fl-card-actions .fl-btn, .fl-connect-act .fl-btn { padding: 14px 15px; font-size: 14px; flex: 1; }
+  .fl-connect-act { width: 100%; margin-left: 0; }
 }
 
 /* 3-A′ · real brand marks in the tray rows (monogram = fallback). */
@@ -1637,8 +1672,10 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the S1 des
    no eyebrow, no icon well, no risk pill, no field table, no amber. The quiet
    line under it carries every real input the question doesn't already name plus
    what approving does, so nothing is ever a disclosure away (the honesty law).
-   \`color: inherit\` keeps the settled receipt muted from the shell. */
-.fl-approval-ask { margin: 0; font: 550 14px/1.45 var(--vendo-font); letter-spacing: -.012em;
+   \`color: inherit\` keeps the settled receipt muted from the shell.
+   A1 · Sentence rides the same rule: the automation card's first line is its
+   RULE, and it is the same sentence in the same type. */
+.fl-approval-ask, .fl-auto-sentence { margin: 0; font: 550 14px/1.45 var(--vendo-font); letter-spacing: -.012em;
   color: inherit; overflow-wrap: anywhere; }
 /* pre-line: a flattened object/array input keeps its one-per-line shape
    (field-rows.ts), exactly as it did in the retired dd. */

--- a/packages/ui/src/chrome/connect-card.tsx
+++ b/packages/ui/src/chrome/connect-card.tsx
@@ -3,16 +3,7 @@ import { useVendoProvider } from "../context.js";
 import { useConnections } from "../hooks/use-connections.js";
 import { useConnectorCatalog } from "../hooks/use-connector-catalog.js";
 import { toolkitLogoUrl } from "./build-beat.js";
-import {
-  CardActions,
-  CardHead,
-  CardLine,
-  CardShell,
-  CARD_EYEBROWS,
-  LINK_GLYPH,
-  TICK_GLYPH,
-  ToolkitLogo,
-} from "./card-shell.js";
+import { CardShell, LINK_GLYPH, TICK_GLYPH, ToolkitLogo } from "./card-shell.js";
 import { ChromeRoot } from "./chrome-root.js";
 import { completeConnection, connectRefusalCopy, openConnectPopup } from "./connect-dock.js";
 import { developmentMode } from "./dev-mode.js";
@@ -49,6 +40,13 @@ export interface ConnectCardProps {
  *  changed. connected/skipped → the two settled records. failed → a refusal. */
 type Phase = "idle" | "connecting" | "popup-blocked" | "timed-out" | "connected" | "skipped" | "failed";
 
+/** One item of the dot-joined line, which carries FRAGMENTS rather than
+    sentences: its two copy sources are written as a full sentence (the model's
+    message) and as a sentence body (`toolkitAccessCopy`: "read and send mail as
+    you"), so one loses its full stop and the other gains its capital. */
+const fragment = (copy: string): string =>
+  copy.charAt(0).toUpperCase() + copy.slice(1).replace(/\.$/, "");
+
 /** 04-actions §3 / 08-ui §4 — the inline connect card: a connector call ended
  * `connect-required`, so offer the broker's OAuth redirect in place, poll the
  * connection status while the user completes it, then retry the call. Follows
@@ -56,9 +54,11 @@ type Phase = "idle" | "connecting" | "popup-blocked" | "timed-out" | "connected"
  * The initiate → OAuth window → poll-to-active loop is `completeConnection`,
  * shared with the connect dock (ENG-225).
  *
- * Brand-forward: the proper-case toolkit name (never the raw
- * slug), the toolkit's real mark in the icon well (link glyph fallback), and
- * an OAuth chip. The ask reads as the product, not the plumbing.
+ * C2 · Integration row — the sentence family the approval card opened: the
+ * toolkit's RAW mark (no well — a 28px well with a radius cropped the Gmail M),
+ * the proper-case name (never the raw slug), ONE quiet line carrying why we are
+ * asking and what connecting grants, and one button. The eyebrow, the icon well
+ * and the OAuth chip are gone; what the chip said rides that line as words.
  *
  * 2026-07 demo feedback — the full lifecycle lives ON the card: a spinner-led
  * "Connecting…" button while the OAuth window is open, and a permanent quiet
@@ -183,6 +183,29 @@ export function ConnectCard({ connector, toolkit, message, onConnected, live = t
 
   const waiting = phase === "connecting" || phase === "popup-blocked";
 
+  // The one quiet line, in the order a person asks it: why we need this (the
+  // model's own sentence), what connecting grants in plain words (never a scope
+  // string), and how it is secured — the three facts the retired message line,
+  // access line and OAuth chip carried between them. Settled, the same line
+  // becomes the receipt of what the account can now do.
+  const notes = connected
+    ? [`We can now ${accessCopy}.`]
+    : [fragment(message), fragment(accessCopy), "Secured with OAuth"];
+
+  // Every phase says what it is doing in ONE status voice under the row, so a
+  // screen reader has exactly one live region per state to read.
+  const status = connected || phase === "idle" || phase === "failed" ? null : (
+    <span role="status" className="fl-approval-more fl-connect-note">
+      {phase === "connecting"
+        ? `Finish signing in, then come back.${waitedSeconds >= 3 ? ` Still waiting · ${waitedSeconds}s` : ""}`
+        : phase === "popup-blocked"
+          // The window never opened, but the connect did: the poll is running on
+          // the same account, so the same URL in a tab finishes it.
+          ? "Your browser blocked the sign-in window. Open it yourself — we’ll pick it up from here."
+          : "Nothing changed — the sign-in never finished."}
+    </span>
+  );
+
   return (
     <ChromeRoot>
       <CardShell
@@ -190,83 +213,65 @@ export function ConnectCard({ connector, toolkit, message, onConnected, live = t
         className="fl-approval fl-item-in"
         data-vendo-connect-card={connected ? "connected" : phase}
       >
-        <CardHead
-          icon={<ToolkitLogo src={toolkitLogoUrl(toolkit)} fallback={LINK_GLYPH} />}
-          eyebrow={CARD_EYEBROWS.connect}
-          title={displayName}
-          aside={
-            <span
-              className="fl-chip"
-              title={connector}
-              style={{ marginLeft: "auto", padding: "2px 7px", fontSize: "10px", cursor: "default" }}
-            >
-              OAuth
-            </span>
-          }
-        />
-        <CardLine>{message}</CardLine>
-        {/* What the person is actually agreeing to, in words — never the
-            broker's scope strings (toolkitAccessCopy). */}
-        {connected ? null : <CardLine className="fl-connect-access">Connecting lets us {accessCopy}.</CardLine>}
-        {error ? <div role="alert" className="fl-error">{error}</div> : null}
-        <CardActions>
-          {connected ? (
-            // The permanent record: the button becomes a quiet connected badge
-            // — the card stays in the transcript as proof the account is live,
-            // with the one line saying what that account can now do.
-            <>
+        <div className="fl-connect-row">
+          {/* RAW, at its own aspect ratio: the 28px well cropped the Gmail M. */}
+          <ToolkitLogo src={toolkitLogoUrl(toolkit)} fallback={LINK_GLYPH} className="fl-connect-mark" />
+          <div className="fl-connect-copy">
+            <div className="fl-connect-name">{displayName}</div>
+            {/* Law 3's line, drawn the way the approval card draws its notes:
+                ONE line to the eye, a LIST to a screen reader, with the " · "
+                between items in CSS so it is never announced. */}
+            <ul className="fl-card-line fl-approval-sub" aria-label={`What connecting ${displayName} does`}>
+              {notes.map((item, index) => <li key={index}>{item}</li>)}
+            </ul>
+          </div>
+          <div className="fl-connect-act">
+            {connected ? (
+              // The permanent record: the button becomes a quiet connected badge
+              // — the card stays in the transcript as proof the account is live,
+              // and the line above says what that account can now do.
               <span role="status" className="fl-connect-done">
                 <span className="fl-connect-done-ic" aria-hidden="true">{TICK_GLYPH}</span>
                 Connected
               </span>
-              <span className="fl-connect-receipt">We can now {accessCopy}.</span>
-            </>
-          ) : phase === "popup-blocked" ? (
-            // The window never opened, but the connect did: the poll is running
-            // on the same account, so the same URL in a tab finishes it.
-            <div role="status" className="fl-connect-blocked">
-              <span>Your browser blocked the sign-in window. Open it yourself — we’ll pick it up from here.</span>
-              {redirectUrl === undefined ? null : (
+            ) : phase === "popup-blocked" ? (
+              redirectUrl === undefined ? null : (
                 <a className="fl-btn fl-btn-primary" href={redirectUrl} target="_blank" rel="noreferrer">
                   Open sign-in in a new tab
                 </a>
-              )}
-            </div>
-          ) : phase === "timed-out" ? (
-            <>
-              <span role="status" className="fl-approval-more">Nothing changed — the sign-in never finished.</span>
+              )
+            ) : phase === "timed-out" ? (
               <button className="fl-btn fl-btn-primary" type="button" onClick={() => void connect()}>Try again</button>
-            </>
-          ) : (
-            <>
-              <button
-                className="fl-btn fl-btn-primary"
-                type="button"
-                aria-label={`Connect ${displayName}`}
-                disabled={waiting}
-                onClick={() => void connect()}
-              >
-                {phase === "connecting" ? (
-                  <>
-                    <span className="fl-connect-spin" aria-hidden="true" />
-                    Connecting…
-                  </>
-                ) : `Connect ${displayName}`}
-              </button>
-              {/* The other real answer. A stale card is a record, not an ask,
-                  so it never offers one. */}
-              {live && !waiting ? (
-                <button className="fl-btn fl-btn-quiet" type="button" onClick={decline}>Not now</button>
-              ) : null}
-              {phase === "connecting" ? (
-                <span role="status" className="fl-approval-more">
-                  Finish signing in, then come back.
-                  {waitedSeconds >= 3 ? ` Still waiting · ${waitedSeconds}s` : ""}
-                </span>
-              ) : null}
-            </>
-          )}
-        </CardActions>
+            ) : (
+              <>
+                <button
+                  className="fl-btn fl-btn-primary"
+                  type="button"
+                  // The name carries the toolkit even though the label is one
+                  // word: the row already says Gmail, a screen reader's button
+                  // list does not.
+                  aria-label={`Connect ${displayName}`}
+                  disabled={waiting}
+                  onClick={() => void connect()}
+                >
+                  {phase === "connecting" ? (
+                    <>
+                      <span className="fl-connect-spin" aria-hidden="true" />
+                      Connecting…
+                    </>
+                  ) : "Connect"}
+                </button>
+                {/* The other real answer. A stale card is a record, not an ask,
+                    so it never offers one. */}
+                {live && !waiting ? (
+                  <button className="fl-btn fl-btn-quiet" type="button" onClick={decline}>Not now</button>
+                ) : null}
+              </>
+            )}
+          </div>
+        </div>
+        {status}
+        {error ? <div role="alert" className="fl-error">{error}</div> : null}
       </CardShell>
     </ChromeRoot>
   );

--- a/packages/ui/src/chrome/connect-card.tsx
+++ b/packages/ui/src/chrome/connect-card.tsx
@@ -193,17 +193,27 @@ export function ConnectCard({ connector, toolkit, message, onConnected, live = t
     : [fragment(message), fragment(accessCopy), "Secured with OAuth"];
 
   // Every phase says what it is doing in ONE status voice under the row, so a
-  // screen reader has exactly one live region per state to read.
+  // screen reader has exactly one live region per state to read. The blocked
+  // phase carries its recovery link INSIDE that region, under the sentence that
+  // explains it: an "Open sign-in in a new tab" button reached before the words
+  // "your browser blocked the sign-in window" is an instruction with no reason.
   const status = connected || phase === "idle" || phase === "failed" ? null : (
-    <span role="status" className="fl-approval-more fl-connect-note">
-      {phase === "connecting"
-        ? `Finish signing in, then come back.${waitedSeconds >= 3 ? ` Still waiting · ${waitedSeconds}s` : ""}`
-        : phase === "popup-blocked"
-          // The window never opened, but the connect did: the poll is running on
-          // the same account, so the same URL in a tab finishes it.
-          ? "Your browser blocked the sign-in window. Open it yourself — we’ll pick it up from here."
-          : "Nothing changed — the sign-in never finished."}
-    </span>
+    <div role="status" className={phase === "popup-blocked" ? "fl-connect-blocked fl-connect-note" : "fl-approval-more fl-connect-note"}>
+      {phase === "connecting" ? (
+        `Finish signing in, then come back.${waitedSeconds >= 3 ? ` Still waiting · ${waitedSeconds}s` : ""}`
+      ) : phase === "popup-blocked" ? (
+        <>
+          {/* The window never opened, but the connect did: the poll is running
+              on the same account, so the same URL in a tab finishes it. */}
+          <span>Your browser blocked the sign-in window. Open it yourself — we’ll pick it up from here.</span>
+          {redirectUrl === undefined ? null : (
+            <a className="fl-btn fl-btn-primary" href={redirectUrl} target="_blank" rel="noreferrer">
+              Open sign-in in a new tab
+            </a>
+          )}
+        </>
+      ) : "Nothing changed — the sign-in never finished."}
+    </div>
   );
 
   return (
@@ -215,13 +225,17 @@ export function ConnectCard({ connector, toolkit, message, onConnected, live = t
       >
         <div className="fl-connect-row">
           {/* RAW, at its own aspect ratio: the 28px well cropped the Gmail M. */}
-          <ToolkitLogo src={toolkitLogoUrl(toolkit)} fallback={LINK_GLYPH} className="fl-connect-mark" />
+          <ToolkitLogo src={toolkitLogoUrl(toolkit)} fallback={LINK_GLYPH} className="fl-mark-raw" />
           <div className="fl-connect-copy">
             <div className="fl-connect-name">{displayName}</div>
             {/* Law 3's line, drawn the way the approval card draws its notes:
                 ONE line to the eye, a LIST to a screen reader, with the " · "
-                between items in CSS so it is never announced. */}
-            <ul className="fl-card-line fl-approval-sub" aria-label={`What connecting ${displayName} does`}>
+                between items in CSS so it is never announced. Named for what it
+                holds: the ask's terms before, the account's receipt after. */}
+            <ul
+              className="fl-card-line fl-approval-sub"
+              aria-label={connected ? `What ${displayName} can now do` : `What connecting ${displayName} does`}
+            >
               {notes.map((item, index) => <li key={index}>{item}</li>)}
             </ul>
           </div>
@@ -235,11 +249,9 @@ export function ConnectCard({ connector, toolkit, message, onConnected, live = t
                 Connected
               </span>
             ) : phase === "popup-blocked" ? (
-              redirectUrl === undefined ? null : (
-                <a className="fl-btn fl-btn-primary" href={redirectUrl} target="_blank" rel="noreferrer">
-                  Open sign-in in a new tab
-                </a>
-              )
+              // The recovery link rides the status region below, under the
+              // sentence that explains why it is there.
+              null
             ) : phase === "timed-out" ? (
               <button className="fl-btn fl-btn-primary" type="button" onClick={() => void connect()}>Try again</button>
             ) : (

--- a/packages/ui/src/chrome/grant-set-card.tsx
+++ b/packages/ui/src/chrome/grant-set-card.tsx
@@ -158,7 +158,15 @@ export function GrantSetCard({ name, permissions, state, onDecide }: GrantSetCar
             const description = (presentation.description ?? "").trim();
             return (
               <li className="fl-grant" key={permission.approvalId}>
-                <ToolkitLogo {...(presentation.logoUrl === undefined ? {} : { src: presentation.logoUrl })} />
+                {/* A glyph is DRAWN for a well; a brand's logo is not — the 28px
+                    well's radius and fill cropped the real marks (the Gmail M),
+                    which is the defect the connect row was redrawn for. So a row
+                    that has a logo shows it RAW, and a host tool's glyph keeps
+                    the well it was drawn for (law 2's one size, unchanged). */}
+                <ToolkitLogo
+                  className={presentation.logoUrl === undefined ? "fl-card-ic" : "fl-mark-raw"}
+                  {...(presentation.logoUrl === undefined ? {} : { src: presentation.logoUrl })}
+                />
                 <span className="fl-grant-copy">
                   <b>{grantRowWord(permission.risk)}: {presentation.title}</b>
                   {description.length > 0 ? <span>{description}</span> : null}

--- a/packages/ui/src/chrome/thread/parts.tsx
+++ b/packages/ui/src/chrome/thread/parts.tsx
@@ -342,6 +342,7 @@ export function ThreadPart({ part, partKey, role, restored, count = 1, risks, co
         enabled={data.enabled === true}
         {...(data.trigger === undefined ? {} : { trigger: data.trigger })}
         {...(typeof data.description === "string" ? { description: data.description } : {})}
+        {...(Array.isArray(data.rules) ? { rules: data.rules.filter(rule => typeof rule === "string") } : {})}
         {...(typeof data.pendingGrants === "number" ? { pendingGrants: data.pendingGrants } : {})}
       />
     );

--- a/packages/ui/src/chrome/thread/parts.tsx
+++ b/packages/ui/src/chrome/thread/parts.tsx
@@ -342,7 +342,6 @@ export function ThreadPart({ part, partKey, role, restored, count = 1, risks, co
         enabled={data.enabled === true}
         {...(data.trigger === undefined ? {} : { trigger: data.trigger })}
         {...(typeof data.description === "string" ? { description: data.description } : {})}
-        {...(Array.isArray(data.rules) ? { rules: data.rules.filter(rule => typeof rule === "string") } : {})}
         {...(typeof data.pendingGrants === "number" ? { pendingGrants: data.pendingGrants } : {})}
       />
     );

--- a/packages/ui/test/chrome/approval-degraded.test.tsx
+++ b/packages/ui/test/chrome/approval-degraded.test.tsx
@@ -112,10 +112,13 @@ describe("degraded data never changes the card", () => {
   });
 
   it("brands a connector ask by its toolkit and survives a logo 404", () => {
-    // ⚠️ TEST EDIT (M1 · Sentence): the approval card has no icon well any more —
-    // the question is the whole card — so the toolkit mark and its 404 fallback
-    // are asserted where the ONE 28px well still lives: the standing-access
-    // card's permission rows. Nothing about the fallback changed.
+    // ⚠️ TEST EDIT (M1 · Sentence, then C2): the approval card has no icon well
+    // any more — the question is the whole card — so the toolkit mark and its
+    // 404 fallback are asserted on the standing-access card's permission rows,
+    // which still carry a mark. That mark is now RAW (`.fl-mark-raw`, shared
+    // with the connect row): it is the same remote logo, and the 28px well's
+    // radius and fill cropped it. The fallback contract is unchanged — a glyph,
+    // never an empty box — and the raw box sizes it.
     const grants = render(
       <VendoProvider client={client}>
         <GrantSetCard
@@ -125,14 +128,33 @@ describe("degraded data never changes the card", () => {
         />
       </VendoProvider>,
     ).container;
-    const well = grants.querySelector(".fl-grant .fl-card-ic")!;
-    const logo = well.querySelector("img")!;
+    const mark = grants.querySelector(".fl-grant .fl-mark-raw")!;
+    // Nothing crops a brand's logo on this card either: a row WITH a logo wears
+    // the raw mark. (A host tool has no logo, so its glyph keeps the well it was
+    // drawn for — asserted below.)
+    expect(grants.querySelector(".fl-grant .fl-card-ic")).toBeNull();
+    const logo = mark.querySelector("img")!;
     expect(logo.getAttribute("src")).toContain("logos.composio.dev");
-    // The CDN fails (unknown slug, offline, blocked): the well keeps a glyph
+    // The CDN fails (unknown slug, offline, blocked): the mark keeps a glyph
     // rather than an empty box — three of the four call sites had no onError.
     fireEvent.error(logo);
-    expect(well.querySelector("img")).toBeNull();
-    expect(well.querySelector("svg")).not.toBeNull();
+    expect(mark.querySelector("img")).toBeNull();
+    expect(mark.querySelector("svg")).not.toBeNull();
+    cleanup();
+
+    // A HOST tool has no brand mark to show raw, so its glyph keeps the 28px
+    // well — the shape a glyph was drawn for, and law 2's one well size.
+    const hostRow = render(
+      <VendoProvider client={client}>
+        <GrantSetCard
+          name="Low balance alert"
+          permissions={[{ approvalId: "apr_2", tool: "host_listAccounts", risk: "read" }]}
+          state="parked"
+        />
+      </VendoProvider>,
+    ).container;
+    expect(hostRow.querySelector(".fl-grant .fl-mark-raw")).toBeNull();
+    expect(hostRow.querySelector(".fl-grant .fl-card-ic svg")).not.toBeNull();
     cleanup();
 
     // The slug never reads as the ask.

--- a/packages/ui/test/chrome/automation-card.test.tsx
+++ b/packages/ui/test/chrome/automation-card.test.tsx
@@ -2,10 +2,12 @@
 // 2026-07 demo feedback — the in-thread automation card: the chrome renders a
 // `data-vendo-automation` stream part with the same card vocabulary as the
 // workspace Automations panel (read-only — management stays in the panel).
+import { vendoAutomationPartSchema } from "@vendoai/core";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { VendoProvider, createVendoClient } from "../../src/index.js";
 import { AutomationCard } from "../../src/chrome/index.js";
+import { CHROME_CSS } from "../../src/chrome/chrome-css.js";
 import { humanizeCron, triggerLabel } from "../../src/chrome/automation-card.js";
 import { ThreadPart } from "../../src/chrome/thread/parts.js";
 
@@ -40,14 +42,17 @@ describe("triggerLabel — which zone the clock is in", () => {
     // "Mondays at 4:00 PM" was read as the reader's OWN afternoon: someone who
     // asked for 8 AM Pacific was shown a time eight hours off with nothing on
     // screen to say so.
-    expect(scheduled("0 16 * * 1").title).toBe("Mondays at 4:00 PM UTC");
-    expect(scheduled("0 8 * * *").title).toBe("Daily at 8:00 AM UTC");
+    // ⚠️ TEST EDIT (A1 · Sentence): `triggerLabel` returns the label itself now
+    // — the second `sub` field ("Schedule", "Host event") labelled the retired
+    // diagram's boxes and had no other reader. Same labels, same zone rule.
+    expect(scheduled("0 16 * * 1")).toBe("Mondays at 4:00 PM UTC");
+    expect(scheduled("0 8 * * *")).toBe("Daily at 8:00 AM UTC");
   });
 
   it("leaves a raw cron expression alone — it shows no clock time to mislabel", () => {
     // "*/5 * * * *" is a cadence, not an hour. There is no hour on screen for a
     // reader to misplace, so a zone label here would be noise.
-    expect(scheduled("*/5 * * * *").title).toBe("*/5 * * * *");
+    expect(scheduled("*/5 * * * *")).toBe("*/5 * * * *");
   });
 });
 
@@ -88,7 +93,63 @@ describe("AutomationCard", () => {
     expect(screen.queryByRole("button", { name: "Run history" })).toBeNull();
     // No head, and no diagram saying in two boxes what the title says in words.
     expect(card.querySelector(".fl-card-eyebrow")).toBeNull();
+    expect(card.querySelector(".fl-card-ic")).toBeNull();
     expect(card.querySelector(".fl-auto-flow")).toBeNull();
+  });
+
+  /** An EMPTY description is not a phrasing. It used to empty a quiet line;
+      as the card's 14px title it empties the card's whole first line — the
+      `??` that only guards `undefined` walked straight into it. */
+  it("falls back to the composed rule when the description is blank", () => {
+    for (const description of ["", "   "]) {
+      render(
+        <VendoProvider client={client}>
+          <AutomationCard
+            name="Low balance alert"
+            enabled
+            description={description}
+            trigger={{
+              on: { kind: "schedule", cron: "0 8 * * *" },
+              run: { kind: "steps", steps: [{ id: "balance", tool: "host_listAccounts" }] },
+            }}
+          />
+        </VendoProvider>,
+      );
+      const card = screen.getByRole("article", { name: "Automation — Low balance alert" });
+      expect(card.querySelector(".fl-auto-sentence")!.textContent, JSON.stringify(description))
+        .toBe("Daily at 8:00 AM UTC → List accounts");
+      cleanup();
+    }
+  });
+
+  /** The card CLIPS (`.fl-automation` sets overflow: hidden), and a flex item
+      will not shrink below its content — so the two flex lines this redesign
+      introduced have to be told they may wrap, or a long unbroken token is cut
+      off at the card's edge. The sponsor half is the live case: `subject` is an
+      opaque id when no display name is known, and the byline row it replaced
+      wrapped by default. jsdom computes no layout, so the contract is asserted
+      on the shipped sheet (the mobile block's precedent) plus the DOM hooks. */
+  it("lets a long unbroken token wrap instead of clipping", () => {
+    render(
+      <VendoProvider client={client}>
+        <AutomationCard
+          name="Low balance alert"
+          enabled
+          description="Watches checking"
+          sponsor={{ subject: "auth0|6d5f4e3c2b1a0998877665544332211fedcba9876543210" }}
+          rules={[`pays ${"n".repeat(40)}`]}
+        />
+      </VendoProvider>,
+    );
+    const card = screen.getByRole("article", { name: "Automation — Low balance alert" });
+    // The id-shaped subject is displayed, not swallowed — and it is the text
+    // half of the flex row, so it is the half that may wrap.
+    expect(card.querySelector(".fl-auto-state-copy")!.textContent)
+      .toBe("Enabled · Runs with auth0|6d5f4e3c2b1a0998877665544332211fedcba9876543210's access");
+    expect(CHROME_CSS).toMatch(/\.fl-auto-state-copy \{[^}]*min-width: 0; overflow-wrap: anywhere/);
+    expect(CHROME_CSS).toMatch(/\.fl-auto-rules li \{[^}]*min-width: 0;\n\s*overflow-wrap: anywhere/);
+    // And the dot never shrinks to nothing to make room for that text.
+    expect(CHROME_CSS).toMatch(/\.fl-auto-state \.fl-auto-live \{[^}]*flex-shrink: 0/);
   });
 
   it("composes the rule from the trigger when the document has no description", () => {
@@ -178,22 +239,37 @@ describe("ThreadPart data-vendo-automation", () => {
     expect(card.textContent).not.toContain("waiting on");
   });
 
-  it("carries the part's rule sentences onto the card (the E3 list is wire-fed)", () => {
+  /** The wire carries the automation's terms on the TRIGGER — the document's own
+      field — so the part the producer already sends (make-tool forwards the
+      whole trigger) delivers them with nothing extra to keep in sync. Pinned
+      through the REAL part schema, because the bridge validates before this
+      renders: a part that fails there never reaches the card at all. */
+  it("carries the trigger's rule sentences onto the card, through the real part schema", () => {
+    const wire = {
+      type: "data-vendo-automation",
+      appId: "app_demo",
+      name: "PG&E autopay",
+      enabled: true,
+      description: "New PG&E bill → paid from Maple Checking",
+      trigger: {
+        id: "main",
+        on: { kind: "external", connector: "gmail", event: "new_bill_email" },
+        run: { kind: "steps", steps: [{ id: "pay", tool: "host_transferMoney" }] },
+        rules: [
+          "Caps at $200 a bill — anything higher asks you first",
+          // A blank sentence from a sloppy author must cost ITSELF and nothing
+          // else: the schema lets it through (so the card still arrives) and the
+          // renderer drops it. Before, `min(1)` here failed the whole part.
+          "   ",
+          "Skips if checking would drop below $500",
+        ],
+      },
+    };
+    const parsed = vendoAutomationPartSchema.safeParse(wire);
+    expect(parsed.success, "a blank rule must never fail the automation part").toBe(true);
     render(
       <VendoProvider client={client}>
-        <ThreadPart
-          part={part({
-            appId: "app_demo",
-            name: "PG&E autopay",
-            enabled: true,
-            description: "New PG&E bill → paid from Maple Checking",
-            rules: ["Caps at $200 a bill — anything higher asks you first", "Skips if checking would drop below $500"],
-          })}
-          partKey="m-2"
-          role="assistant"
-          restored={false}
-          risks={new Map()}
-        />
+        <ThreadPart part={part(parsed.data!)} partKey="m-2" role="assistant" restored={false} risks={new Map()} />
       </VendoProvider>,
     );
     const list = screen.getByRole("list", { name: "Rules for PG&E autopay" });
@@ -201,6 +277,38 @@ describe("ThreadPart data-vendo-automation", () => {
       "Caps at $200 a bill — anything higher asks you first",
       "Skips if checking would drop below $500",
     ]);
+  });
+
+  /** A card is the moment's record, not the settings page: whatever a document
+      says, the render is bounded — six sentences, each at the clamp the rule
+      sentence's own action half has always used. */
+  it("bounds what a document can push onto the card", () => {
+    render(
+      <VendoProvider client={client}>
+        <ThreadPart
+          part={part({
+            appId: "app_demo",
+            name: "Noisy",
+            enabled: true,
+            description: "Runs",
+            trigger: {
+              id: "main",
+              on: { kind: "schedule", cron: "0 8 * * *" },
+              run: { kind: "steps", steps: [{ id: "s", tool: "host_listAccounts" }] },
+              rules: [`${"x".repeat(400)} tail`, ...Array.from({ length: 20 }, (_, index) => `Rule ${index}`)],
+            },
+          })}
+          partKey="m-3"
+          role="assistant"
+          restored={false}
+          risks={new Map()}
+        />
+      </VendoProvider>,
+    );
+    const items = [...screen.getByRole("list", { name: "Rules for Noisy" }).querySelectorAll("li")];
+    expect(items).toHaveLength(6);
+    expect(items[0]!.textContent).toBe(`${"x".repeat(67)}…`);
+    expect(items[0]!.textContent!.length).toBeLessThanOrEqual(68);
   });
 
   it("reads 'waiting on N permissions' while the part carries pendingGrants (grant sets)", () => {

--- a/packages/ui/test/chrome/automation-card.test.tsx
+++ b/packages/ui/test/chrome/automation-card.test.tsx
@@ -52,13 +52,51 @@ describe("triggerLabel — which zone the clock is in", () => {
 });
 
 describe("AutomationCard", () => {
-  it("renders identity, enabled state, and the trigger → action flow", () => {
+  /** ⚠️ TEST EDIT (A1 · Sentence): this asserted the head's identity (the NAME
+      as the title) and the flow diagram's two node boxes with their sub labels
+      ("Schedule", "1 action"). The rule is the card's title now, so the same
+      facts are asserted where they render: the description IS the title, the
+      name is the card's accessible name, and the composed `trigger → action`
+      title is covered by the no-description case below (the diagram's sub
+      labels are gone with the diagram — they named the boxes, not the rule). */
+  it("renders the rule as its title, the enabled state, and the agency line", () => {
     render(
       <VendoProvider client={client}>
         <AutomationCard
           name="Low balance alert"
           enabled
           description="Emails you when checking dips below $2,000."
+          sponsor={{ subject: "user_1", display: "Dana" }}
+          trigger={{
+            on: { kind: "schedule", cron: "0 8 * * *" },
+            run: { kind: "steps", steps: [{ id: "balance", tool: "host_listAccounts" }] },
+          }}
+        />
+      </VendoProvider>,
+    );
+    // The name is what the card is CALLED, and it stays its accessible name.
+    const card = screen.getByRole("article", { name: "Automation — Low balance alert" });
+    // The rule, in the description's human phrasing, as the card's first line.
+    expect(card.querySelector(".fl-auto-sentence")!.textContent)
+      .toBe("Emails you when checking dips below $2,000.");
+    // §13 — whether it is on AND whose access it runs with, on one quiet line
+    // (this was the state chip plus the byline row).
+    expect(card.querySelector(".fl-auto-state")!.textContent)
+      .toBe("Enabled · Runs with Dana's access");
+    // Read-only: no toggle, no run history.
+    expect(screen.queryByRole("switch")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Run history" })).toBeNull();
+    // No head, and no diagram saying in two boxes what the title says in words.
+    expect(card.querySelector(".fl-card-eyebrow")).toBeNull();
+    expect(card.querySelector(".fl-auto-flow")).toBeNull();
+  });
+
+  it("composes the rule from the trigger when the document has no description", () => {
+    render(
+      <VendoProvider client={client}>
+        <AutomationCard
+          name="Low balance alert"
+          enabled={false}
           trigger={{
             on: { kind: "schedule", cron: "0 8 * * *" },
             run: { kind: "steps", steps: [{ id: "balance", tool: "host_listAccounts" }] },
@@ -67,19 +105,37 @@ describe("AutomationCard", () => {
       </VendoProvider>,
     );
     const card = screen.getByRole("article", { name: "Automation — Low balance alert" });
-    expect(card.textContent).toContain("Low balance alert");
-    expect(card.textContent).toContain("Enabled");
-    expect(card.textContent).toContain("Emails you when checking dips below $2,000.");
-    // The flow nodes: humanized cron trigger → humanized first step.
-    expect(card.textContent).toContain("Daily at 8:00 AM");
-    expect(card.textContent).toContain("List accounts");
-    // Read-only: no toggle, no run history.
-    expect(screen.queryByRole("switch")).toBeNull();
-    expect(screen.queryByRole("button", { name: "Run history" })).toBeNull();
-    // M30 — a plain <div> may not carry aria-label (aria-prohibited-attr): the
-    // flow block is a real group, exactly as the panel's copy of it is.
-    const flow = screen.getByRole("group", { name: "Automation flow for Low balance alert" });
-    expect(flow.className).toContain("fl-auto-flow");
+    // The humanized cron (zone named, because it fires in UTC) → the first step.
+    expect(card.querySelector(".fl-auto-sentence")!.textContent).toBe("Daily at 8:00 AM UTC → List accounts");
+    // Disabled says so, and drops the live dot rather than colouring it.
+    expect(card.querySelector(".fl-auto-state")!.textContent).toBe("Disabled");
+    expect(card.querySelector(".fl-auto-live")).toBeNull();
+  });
+
+  /** E3 · Rule list — the agent's own sentences about how the automation
+      behaves. A real <ul> with an accessible name: these are N distinct
+      promises, and a reader has to be able to step through them. */
+  it("lists the agent's rule sentences, and renders no list at all without them", () => {
+    const rules = [
+      "Caps at $200 a bill — anything higher asks you first",
+      "Only bills from billing@pge.com count",
+    ];
+    const { rerender } = render(
+      <VendoProvider client={client}>
+        <AutomationCard name="PG&E autopay" enabled rules={rules} description="New PG&E bill → paid from Maple Checking" />
+      </VendoProvider>,
+    );
+    const list = screen.getByRole("list", { name: "Rules for PG&E autopay" });
+    expect([...list.querySelectorAll("li")].map(item => item.textContent)).toEqual(rules);
+    // The tick is decoration beside each sentence, never the sentence itself.
+    expect(list.querySelectorAll("svg[aria-hidden='true']")).toHaveLength(2);
+
+    rerender(
+      <VendoProvider client={client}>
+        <AutomationCard name="PG&E autopay" enabled description="New PG&E bill → paid from Maple Checking" />
+      </VendoProvider>,
+    );
+    expect(screen.queryByRole("list", { name: "Rules for PG&E autopay" })).toBeNull();
   });
 });
 
@@ -110,12 +166,41 @@ describe("ThreadPart data-vendo-automation", () => {
       </VendoProvider>,
     );
     const card = screen.getByRole("article", { name: "Automation — Weekly spending summary" });
-    expect(card.textContent).toContain("Fridays at 5:00 PM");
-    expect(card.textContent).toContain("2 steps");
+    // ⚠️ TEST EDIT (A1 · Sentence): the trigger and the action used to be two
+    // node boxes with sub labels ("Schedule", "2 steps"). They are one rule
+    // sentence now, so the wire→card contract is asserted on that sentence —
+    // the humanized cron and the first step still both come off the part.
+    expect(card.querySelector(".fl-auto-sentence")!.textContent)
+      .toBe("Fridays at 5:00 PM UTC → Get spending insights");
     // Backward-compat: this is the OLD wire payload (no pendingGrants) — it
     // renders the plain enabled state, never the waiting copy.
     expect(card.textContent).toContain("Enabled");
     expect(card.textContent).not.toContain("waiting on");
+  });
+
+  it("carries the part's rule sentences onto the card (the E3 list is wire-fed)", () => {
+    render(
+      <VendoProvider client={client}>
+        <ThreadPart
+          part={part({
+            appId: "app_demo",
+            name: "PG&E autopay",
+            enabled: true,
+            description: "New PG&E bill → paid from Maple Checking",
+            rules: ["Caps at $200 a bill — anything higher asks you first", "Skips if checking would drop below $500"],
+          })}
+          partKey="m-2"
+          role="assistant"
+          restored={false}
+          risks={new Map()}
+        />
+      </VendoProvider>,
+    );
+    const list = screen.getByRole("list", { name: "Rules for PG&E autopay" });
+    expect([...list.querySelectorAll("li")].map(item => item.textContent)).toEqual([
+      "Caps at $200 a bill — anything higher asks you first",
+      "Skips if checking would drop below $500",
+    ]);
   });
 
   it("reads 'waiting on N permissions' while the part carries pendingGrants (grant sets)", () => {

--- a/packages/ui/test/chrome/card-shell.test.tsx
+++ b/packages/ui/test/chrome/card-shell.test.tsx
@@ -121,8 +121,11 @@ describe("one card shell, three laws", () => {
   });
 
   it("keeps one icon-well size and one primary-button style in the sheet itself", () => {
-    // Law 2, at the source: the shell owns 28px, and the only other well sizes
-    // left in the stylesheet belong to non-card furniture (rows, docks, pills).
+    // Law 2, at the source: the shell owns ONE well size, 28px, and the cards
+    // that kept a head use it. The sentence family's cards have no well at all;
+    // where they show a brand's logo they show it raw (`.fl-mark-raw`, 26px, no
+    // fill and no radius), because a well is drawn for a glyph and cropped the
+    // real marks — see connect.test.tsx and approval-degraded.test.tsx.
     expect(CHROME_CSS).toContain(".fl-card-ic { display: grid; place-items: center; width: 28px; height: 28px;");
     // Law 1: the ancestors that touch a shell may only size it.
     const ancestorRules = CHROME_CSS.split("\n").filter(line => /\.fl-\S+ (?:>\s*)?\.fl-cardshell/.test(line));

--- a/packages/ui/test/chrome/card-shell.test.tsx
+++ b/packages/ui/test/chrome/card-shell.test.tsx
@@ -50,12 +50,15 @@ afterEach(async () => {
 const provider = (node: React.ReactNode) => <VendoProvider client={client}>{node}</VendoProvider>;
 
 /** Every card kind, as a host actually mounts it. */
-/** ⚠️ TEST EDIT (M1 · Sentence): the approval card is the one kind with no HEAD.
-    Its ask is the card — a bold question plus one quiet line — so it wears no
-    eyebrow, no icon well and no title, and law 2's ONE-well rule is asserted
-    over the kinds that still have one. Law 1 (one shell, no bespoke geometry)
-    and law 3 (it always says what it does) still cover every kind. */
-const HEADLESS = new Set(["approval"]);
+/** ⚠️ TEST EDIT (M1 · Sentence, then C2 + A1): the SENTENCE FAMILY has no HEAD.
+    Each of these cards is its own first line — the approval's question, the
+    connect row's toolkit name, the automation's rule — so none wears an eyebrow
+    or a title, and law 2's ONE-well rule is asserted over the kinds that still
+    have a head. Connect does show a mark, deliberately NOT in the well: the
+    28px well's radius and fill cropped the Gmail M (connect.test.tsx pins the
+    raw mark). Law 1 (one shell, no bespoke geometry) and law 3 (it always says
+    what it does) still cover every kind, headless ones included. */
+const HEADLESS = new Set(["approval", "connect", "automation"]);
 
 const KINDS: Array<[string, React.ReactNode]> = [
   ["approval", <ApprovalCard approval={approval} onDecide={() => undefined} />],

--- a/packages/ui/test/chrome/connect-in-thread.test.tsx
+++ b/packages/ui/test/chrome/connect-in-thread.test.tsx
@@ -79,7 +79,10 @@ describe("connect card in the thread (both wire shapes)", () => {
 
     // Brand-forward: the toolkit's display name, never the raw slug.
     const card = await screen.findByRole("article", { name: "Connect Gmail" });
-    expect(card.textContent).toContain("Connect Gmail so the digest can land as a draft.");
+    // ⚠️ TEST EDIT (C2 · Integration row): the wire's message is the first item
+    // of the card's dot-joined notes line now, so its full stop is dropped —
+    // same sentence, same source (the part's `message`), asserted as it renders.
+    expect(card.textContent).toContain("Connect Gmail so the digest can land as a draft");
     expect(screen.getByRole("button", { name: "Connect Gmail" })).toBeTruthy();
     expect(cards()).toHaveLength(1);
   });

--- a/packages/ui/test/chrome/connect.test.tsx
+++ b/packages/ui/test/chrome/connect.test.tsx
@@ -57,11 +57,17 @@ describe("ConnectCard", () => {
 
     // ⚠️ TEST EDIT (C2 · Integration row): the model's sentence used to be its
     // own card line and kept its full stop. It is now the first item of the
-    // dot-joined notes line, where a trailing stop before " · " reads as a typo,
-    // so the same sentence is asserted as the fragment the line carries.
-    expect(screen.getByRole("article", { name: "Connect Gmail" }).textContent).toContain(
+    // dot-joined notes line, where a trailing stop before " · " reads as a typo.
+    // Asserted as the EXACT items the line renders — a substring check would
+    // pass just as well if the fragment shaping (stop dropped, access copy
+    // capitalized) were deleted, which is the whole reason it exists.
+    const notes = screen.getByRole("article", { name: "Connect Gmail" })
+      .querySelector("ul.fl-approval-sub")!;
+    expect([...notes.querySelectorAll("li")].map(item => item.textContent)).toEqual([
       "Connect your gmail account to run gmail_GMAIL_SEND_EMAIL",
-    );
+      "Read and send mail as you",
+      "Secured with OAuth",
+    ]);
     fireEvent.click(screen.getByRole("button", { name: "Connect Gmail" }));
 
     // THE defect this design exists for: Safari and Firefox judge a popup by
@@ -85,8 +91,12 @@ describe("ConnectCard", () => {
     expect(screen.queryByText(/retrying/i)).toBeNull();
     expect(screen.queryByRole("button", { name: "Connect Gmail" })).toBeNull();
     // The receipt: what the account can now do, in the same plain words the ask
-    // used — never an OAuth scope string.
+    // used — never an OAuth scope string. The line's NAME follows its contents
+    // into the past tense; "what connecting Gmail does" over a receipt is a
+    // screen reader being told the wrong thing.
     expect(screen.getByText("We can now read and send mail as you.")).toBeTruthy();
+    expect(screen.getByRole("list", { name: "What Gmail can now do" })).toBeTruthy();
+    expect(screen.queryByRole("list", { name: "What connecting Gmail does" })).toBeNull();
     expect(wire.requests).toContainEqual(
       expect.objectContaining({ method: "POST", path: "/connections/initiate", body: { toolkit: "gmail", connector: "composio" } }),
     );
@@ -142,12 +152,33 @@ describe("ConnectCard", () => {
       </VendoProvider>,
     );
     expect(container.querySelector(".fl-card-ic")).toBeNull();
-    const mark = container.querySelector(".fl-connect-mark img")!;
+    const mark = container.querySelector(".fl-mark-raw img")!;
     expect(mark.getAttribute("src")).toContain("gmail");
-    // The well's rule is `width: 100%; height: 100%` inside a 28px box; the raw
-    // mark caps both edges instead, so a wide logo letterboxes rather than fills.
+    // The well's rule is `width: 100%; height: 100%` inside a 28px box with a
+    // radius and a fill; the raw mark caps both edges instead, so a wide logo
+    // letterboxes rather than filling, and nothing clips it.
     const { CHROME_CSS } = await import("../../src/chrome/chrome-css.js");
-    expect(CHROME_CSS).toContain(".fl-connect-mark img { max-width: 26px; max-height: 26px;");
+    expect(CHROME_CSS).toContain(".fl-mark-raw img { max-width: 26px; max-height: 26px;");
+    expect(CHROME_CSS).toMatch(/\.fl-mark-raw \{(?![^}]*overflow: hidden)[^}]*\}/);
+    expect(CHROME_CSS).toMatch(/\.fl-mark-raw \{(?![^}]*background)[^}]*\}/);
+  });
+
+  /** The mark is REMOTE, so it can 404 — and the fallback is a glyph, which the
+      raw box must size like the logo it replaces. Undressed it drew at its own
+      15px beside 26px marks and read as a different component. */
+  it("sizes the fallback glyph when the logo 404s", async () => {
+    allowPopups();
+    const { container } = render(
+      <VendoProvider client={client}>
+        <ConnectCard connector="composio" toolkit="gmail" message="Connect gmail." onConnected={() => undefined} />
+      </VendoProvider>,
+    );
+    const mark = container.querySelector(".fl-mark-raw")!;
+    fireEvent.error(mark.querySelector("img")!);
+    expect(mark.querySelector("img")).toBeNull();
+    expect(mark.querySelector("svg")).not.toBeNull();
+    const { CHROME_CSS } = await import("../../src/chrome/chrome-css.js");
+    expect(CHROME_CSS).toContain(".fl-mark-raw svg { width: 20px; height: 20px;");
   });
 
   it("wears no eyebrow and no OAuth chip — the row says both in words", async () => {
@@ -188,7 +219,14 @@ describe("ConnectCard", () => {
 
     const link = await screen.findByRole("link", { name: "Open sign-in in a new tab" });
     expect(link.getAttribute("href")).toBe("https://connect.test/oauth/1");
-    expect(screen.getByRole("status").textContent).toContain("blocked the sign-in window");
+    const region = screen.getByRole("status");
+    expect(region.textContent).toContain("blocked the sign-in window");
+    // The REASON is read before the instruction: an "Open sign-in in a new tab"
+    // button reached first is an order with no explanation. Same order main had,
+    // and the recovery lives inside the one live region either way.
+    expect(region.contains(link)).toBe(true);
+    expect(region.textContent!.indexOf("blocked the sign-in window"))
+      .toBeLessThan(region.textContent!.indexOf("Open sign-in in a new tab"));
     // The poll never stopped: finishing in the tab settles the card as normal.
     const account = wire.state.connections.find(item => item.id === "ca_new")!;
     (account as { status: string }).status = "active";

--- a/packages/ui/test/chrome/connect.test.tsx
+++ b/packages/ui/test/chrome/connect.test.tsx
@@ -55,8 +55,12 @@ describe("ConnectCard", () => {
       </VendoProvider>,
     );
 
+    // ⚠️ TEST EDIT (C2 · Integration row): the model's sentence used to be its
+    // own card line and kept its full stop. It is now the first item of the
+    // dot-joined notes line, where a trailing stop before " · " reads as a typo,
+    // so the same sentence is asserted as the fragment the line carries.
     expect(screen.getByRole("article", { name: "Connect Gmail" }).textContent).toContain(
-      "Connect your gmail account to run gmail_GMAIL_SEND_EMAIL.",
+      "Connect your gmail account to run gmail_GMAIL_SEND_EMAIL",
     );
     fireEvent.click(screen.getByRole("button", { name: "Connect Gmail" }));
 
@@ -99,7 +103,11 @@ describe("ConnectCard", () => {
       </VendoProvider>,
     );
     const card = screen.getByRole("article", { name: "Connect Gmail" });
-    expect(card.textContent).toContain("Connecting lets us read and send mail as you.");
+    // ⚠️ TEST EDIT (C2 · Integration row): the access copy used to be wrapped in
+    // its own sentence ("Connecting lets us …"). It is now a note on the one
+    // quiet line, so it is asserted as that note — same words, same source
+    // (`toolkitAccessCopy`), same law: what this grants, before anyone clicks.
+    expect(card.textContent).toContain("Read and send mail as you");
     // The scope strings the broker actually asks for are the grant's IDENTIFIER,
     // not its meaning — a consent surface that shows them has said nothing.
     expect(card.textContent).not.toContain("googleapis.com");
@@ -120,7 +128,45 @@ describe("ConnectCard", () => {
       </VendoProvider>,
     );
     expect(screen.getByRole("article", { name: "Connect Gmail" }).textContent)
-      .toContain("Connecting lets us read your last 30 days of mail.");
+      .toContain("Read your last 30 days of mail");
+  });
+
+  /** C2 · Integration row — THE defect this layout was drawn for: the toolkit's
+   *  mark rode the shell's 28px icon well, whose radius and fill cropped the
+   *  Gmail M. The mark is now raw — its own aspect ratio, no well behind it. */
+  it("shows the toolkit's mark RAW: no icon well, nothing to crop it", async () => {
+    allowPopups();
+    const { container } = render(
+      <VendoProvider client={client}>
+        <ConnectCard connector="composio" toolkit="gmail" message="Connect gmail." onConnected={() => undefined} />
+      </VendoProvider>,
+    );
+    expect(container.querySelector(".fl-card-ic")).toBeNull();
+    const mark = container.querySelector(".fl-connect-mark img")!;
+    expect(mark.getAttribute("src")).toContain("gmail");
+    // The well's rule is `width: 100%; height: 100%` inside a 28px box; the raw
+    // mark caps both edges instead, so a wide logo letterboxes rather than fills.
+    const { CHROME_CSS } = await import("../../src/chrome/chrome-css.js");
+    expect(CHROME_CSS).toContain(".fl-connect-mark img { max-width: 26px; max-height: 26px;");
+  });
+
+  it("wears no eyebrow and no OAuth chip — the row says both in words", async () => {
+    allowPopups();
+    const { container } = render(
+      <VendoProvider client={client}>
+        <ConnectCard connector="composio" toolkit="gmail" message="Connect gmail." onConnected={() => undefined} />
+      </VendoProvider>,
+    );
+    const card = screen.getByRole("article", { name: "Connect Gmail" });
+    expect(container.querySelector(".fl-card-eyebrow")).toBeNull();
+    expect(container.querySelector(".fl-chip")).toBeNull();
+    // What the chip said, said as a word on the line the person actually reads.
+    expect(card.textContent).toContain("Secured with OAuth");
+    // The toolkit's name is the row's first line, not an eyebrow's afterthought.
+    expect(card.querySelector(".fl-connect-name")!.textContent).toBe("Gmail");
+    // ONE primary button, and it reads as the row's one action.
+    expect(card.querySelectorAll(".fl-btn-primary")).toHaveLength(1);
+    expect(screen.getByRole("button", { name: "Connect Gmail" }).textContent).toBe("Connect");
   });
 
   it("a blocked popup keeps the flow alive behind a plain link, and still completes", async () => {

--- a/packages/vendo/tests/request-connection.seam.test.ts
+++ b/packages/vendo/tests/request-connection.seam.test.ts
@@ -183,10 +183,14 @@ describe("request_connection: the agent asks, the chrome renders the ask", () =>
     const painted = await until("the connect card", card);
 
     expect(painted.getAttribute("data-vendo-connect-card")).toBe("idle");
-    // The message on the card is the sentence the MODEL wrote, carried whole.
-    expect(painted.textContent).toContain(REASON);
+    // ⚠️ TEST EDIT (C2 · Integration row): the model's sentence and the access
+    // copy used to be two card lines with their own full stops; they are the
+    // first two items of the card's ONE dot-joined line now, where a stop
+    // before " · " reads as a typo. Same two sentences, same two sources (the
+    // model's `reason` and `toolkitAccessCopy`), asserted as they render.
+    expect(painted.textContent).toContain(REASON.replace(/\.$/, ""));
     // Brand-forward, and plain about what connecting grants — never a scope.
-    expect(painted.textContent).toContain("Connecting lets us read and send mail as you.");
+    expect(painted.textContent).toContain("Read and send mail as you");
     expect(painted.textContent).not.toContain("googleapis.com");
     expect(button("Connect Gmail")).toBeTruthy();
     expect(button("Not now")).toBeTruthy();


### PR DESCRIPTION
## What

The approval card's **sentence** language (PR #1149) is now the family: the two remaining in-thread consent cards wear it, against the approved mockups (connect **C2 · Integration row**, automation **A1 · Sentence** + **E3 · Rule list**).

**ConnectCard → one integration row.** Raw toolkit mark, name, one quiet line, one button.

- The mark is **RAW** — no well, no fill, no radius, natural aspect in a 26px box. The shell's 28px `.fl-card-ic` cropped the Gmail M; that crop is the defect this row was drawn for, and `connect.test.tsx` now pins the raw mark and the CSS that caps both edges instead of filling.
- The retired message line, access line and OAuth chip say the same three things as one dot-joined line, on the approval family's own notes element (`.fl-approval-sub` — one line to the eye, a list to a screen reader, the `·` drawn in CSS): `Connect Gmail so Maple can find the PG&E statement in your inbox · Read and send mail as you · Secured with OAuth`. The copy sources are unchanged (the model's `message`, `toolkitAccessCopy`); each is rendered as the fragment the line carries, so a full stop never sits before a `·`.
- **Gone:** the `CONNECT` eyebrow, the icon well, the OAuth chip.
- **Every state still lives on the row**, with the same copy and the same recovery: `Connecting…` (spinner button, "Not now" withdrawn), popup-blocked (the sign-in link becomes the row's primary, the explanation the quiet note), timed-out (`Try again`), a failure's `role="alert"`, and connected — where the same quiet line becomes the receipt (`We can now read and send mail as you.`) beside the ✓ badge. Exactly ONE live region per state, so a screen reader has one thing to read. `Not now` and the Skipped record are untouched.

**AutomationCard → the rule, then its terms.**

- The **rule is the title** (14px/550): the description when the document has one — the human phrasing of the same rule — else the composed `trigger → action`. The name stays the card's accessible name.
- One quiet status line: green dot · `Enabled` (or `Disabled`, no dot; `Enabled · waiting on 2 permissions` unchanged) · the sponsor's agency (`Runs with Dana's access`), which was a separate byline row.
- **New `rules?: string[]`** — the agent's own sentences, each behind a quiet tick, as a real `<ul>` with an accessible name; omitted entirely when empty. It rides the wire as `VendoAutomationPart.rules` and is threaded by the thread part, so a producer that has terms to state can state them. No demo strings in the package.
- **Gone:** the `AUTOMATION` eyebrow, the bolt icon well, the `.fl-auto-flow` node-box diagram (it said in two boxes what the title says in one line), and the separate description line. The diagram's CSS stays — it is still the workspace Automations panel's vocabulary.

**Shell:** connect and automation join law 2's `HEADLESS` set (head half only); laws 1 and 3 are untouched and both cards still render `.fl-card-line`. `CARD_EYEBROWS.connect`, `CARD_EYEBROWS.automationStatus` and `BOLT_GLYPH` went with the heads that used them. CSS is additive and scoped — no other card reflows; the mcp shim regenerates byte-identical (it embeds no card CSS), so it is not in this PR. `CardByline` now has no caller but stays: it is the shell's byline slot, not something this change retires.

## Screenshots (real demo-bank, real Gmail connect, real transfer, real automation)

The row at rest — raw, uncropped Gmail mark:

![idle](https://raw.githubusercontent.com/runvendo/vendo/assets/card-family/.cards/01-connect-idle-card.png)

In context:

![context](https://raw.githubusercontent.com/runvendo/vendo/assets/card-family/.cards/02-connect-in-context.png)

Settled — the row becomes its own receipt:

![connected](https://raw.githubusercontent.com/runvendo/vendo/assets/card-family/.cards/03-connect-connected.png)

Connect receipt and approval ask, one family:

![approval](https://raw.githubusercontent.com/runvendo/vendo/assets/card-family/.cards/04-connected-and-approval.png)

The automation — rule, state, terms:

![automation](https://raw.githubusercontent.com/runvendo/vendo/assets/card-family/.cards/05-automation-card.png)

![automation in context](https://raw.githubusercontent.com/runvendo/vendo/assets/card-family/.cards/06-automation-in-context.png)

Mid-flight and the blocked-popup recovery (both produced live — the poll hung by a slow network, the popup refused):

![connecting](https://raw.githubusercontent.com/runvendo/vendo/assets/card-family/.cards/07-connect-connecting.png)

![blocked](https://raw.githubusercontent.com/runvendo/vendo/assets/card-family/.cards/08-connect-popup-blocked.png)

## Test changes

Every rewritten assertion has a replacement covering the same contract — none weakened. Each edit is marked `⚠️ TEST EDIT` at its site.

- `connect.test.tsx` — the model's message and the access copy are asserted as the fragments the one line carries (the sentence and its source are unchanged; only the trailing stop is gone, because a stop before `·` reads as a typo). **Added** two tests: the mark renders raw with no `.fl-card-ic` and the CSS caps both edges (the Gmail-crop regression, previously unpinned), and the card wears no eyebrow/chip while saying `Secured with OAuth` in words with ONE primary button.
- `connect-in-thread.test.tsx` — same fragment retarget for the wire part's `message`.
- `automation-card.test.tsx` — the head-identity test became "the rule is the title": the description is asserted as the title element, the name as the accessible name, and the state line as `Enabled · Runs with Dana's access` (which now also covers the sponsor byline that had no assertion here). **Added** the no-description case, which pins the composed `Daily at 8:00 AM UTC → List accounts` and the disabled state; the flow-diagram group/`fl-auto-flow` assertion is replaced by the rule list's own list-role + accessible-name contract. The wire test's `2 steps` node-sub assertion became the rule sentence `Fridays at 5:00 PM UTC → Get spending insights` — the same trigger-humanization and first-step contract, where it now renders. **Added** a wire→card test for `rules`.
- `card-shell.test.tsx` — `HEADLESS` gains connect and automation, with the reason in the comment. Law 1 and law 3 still assert over every kind.
- `packages/vendo/tests/request-connection.seam.test.ts` (seam, real registry → real card) — the two card-line assertions retarget to the same two sentences on the one line.
- Every new assertion was proved to fail: the mark's well, the sponsor clause, the list role and the wire-fed rules each went red on a reverted implementation and green again on restore.

## Verification

- [x] Scoped gate green: `@vendoai/core` + `@vendoai/ui` build, typecheck (core/ui/vendo), **ui vitest 113 files / 962 tests**, core vitest 40 files / 583 tests, vendo connect suites 22 tests, dependency-guard + portability-gate + blocking eslint clean
- [x] Real-browser walk on demo-bank (`MAPLE_CLIP=1`, port 3151): reset → "My PG&E bill looks high — check it, pay it from checking, and set it to autopay." → the connect row parks with the uncropped mark → Connect completes through the real broker path → approval parks → Approve → real payment posts → the automation card lands with its rule, state and three rule sentences. Connecting and popup-blocked captured live in the same host.
- [x] Full suite is CI's job — this PR's `ci` check is the gate of record

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Connect and Automation cards move to the sentence-first pattern to match the approval card. This unifies the UI, improves readability and accessibility, and adds optional rule sentences to automations.

- New Features
  - Connect card: C2 integration row with a raw toolkit mark, one notes line (message · access · “Secured with OAuth”), and one primary button. Connected state becomes a quiet receipt beside the ✓; connecting/blocked/timeout show a single status line under the row.
  - Automation card: The rule is the title (description, else composed trigger → action). State line shows Enabled/Disabled, pending grants (“waiting on N permissions”), and agency. New `rules?: string[]` render as a quiet ticked list.
  - Wire: Added `rules?: string[]` to `VendoAutomationPart` in `@vendoai/core`; threaded through the UI.
  - Shell: `connect` and `automation` join the headless set. Eyebrows, icon wells, the OAuth chip, and the automation diagram/bolt well are removed. `.fl-card-line` remains; CSS is additive.

- Bug Fixes
  - Gmail logo is no longer cropped (raw mark, capped edges).
  - One live region per state for clearer screen reader output.

<sup>Written for commit 3aa2ead3831bc25c2f8e525e0af11556e3b7011a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



---

## Review pass (second commit)

Independent review found nine things; all fixed in `dd48c365`, each with a test that was proved to fail without the fix.

1. **The standing-access card still cropped the same logos.** Its permission rows wore the 28px well — the exact defect this PR exists to remove — for the same remote toolkit marks. A row **with** a brand mark now shows it raw; a **host tool's glyph keeps the well it was drawn for** (law 2's one size, unchanged), which is the sharper rule and also what the design wants. The raw mark is one shared class now, `.fl-mark-raw`, used by both cards.
2. **Overflow clipping on the automation card.** `.fl-automation` sets `overflow: hidden`, and a flex item will not shrink below its content, so a long unbroken token clipped instead of wrapping — the live case is the sponsor's `subject` fallback (an opaque id) in the line that replaced the wrapping byline. Both halves get `min-width: 0` + `overflow-wrap`, the dot stays unshrinkable and is optically centred on the FIRST line.
3. **`rules` had no committed producer** — only the demo's own plumbing, which is the producer/consumer-mock-each-other trap. The terms now live on the automation **document** (`Trigger.rules`), which make-tool already forwards whole, so the part carries them with **no second field to disagree** and the part-level `rules` is gone. New seam test `packages/apps/tests/automation-rules-seam.test.ts` rides the real `vendo_make` door with `VENDO_VIEW_STREAM` attached the way production attaches it, takes the part **off the real stream** (never builds one), puts it through the real `vendoAutomationPartSchema`, and reads the landed document back through `runtime.get`. The demo staging now seeds the rules on the document too, so the film uses the committed mechanism.
4. **Validation coherence + bounds.** `min(1)` on the array meant one blank sentence failed the whole part at the bridge and deleted the card — and worse, made `planTriggerSchema` refuse the plan so **no automation landed at all** (found by the seam test's third flip). The schema accepts any string; the renderer is the one place that decides what is renderable: trim, drop blanks and non-strings, clamp each to the 68 chars the rule sentence already clamped to, cap at six. Pinned in `packages/core/tests/stream-parts.test.ts` and the ui test.
5. **`description: ""` emptied the title** (`??` only guards `undefined`) — trim-checked now, falling back to the composed rule.
6. **The fallback glyph was undressed** — 15px beside 26px logos. The raw box sizes both children; screenshot below.
7. **popup-blocked order regression** — the recovery link rendered before the sentence explaining it. The sentence leads again and the link rides inside the same live region.
8. **The notes line was mislabelled when settled** — "What connecting Gmail does" over a past-tense receipt. The name follows its contents.
9. **Test narrowing** — the three retargeted `toContain` assertions no longer pinned the fragment shaping they were rewritten for (deleting `fragment()` left them green). One now asserts the **exact** rendered items.

Cleanups included: the two dead shell-scoped CSS rules under a now-false comment, the retired diagram's `sub`/step-count computation (`automationFlow` → `automationRule`; `triggerLabel` returns the label), the drifted law-2 comment in `card-shell.test.tsx`, and the missing "no well on the automation card" assertion.

### Updated screenshots

Blocked-popup recovery, sentence first:

![blocked](https://raw.githubusercontent.com/runvendo/vendo/assets/card-family/.cards/08-connect-popup-blocked.png)

The mark's 404 fallback, sized to the slot the logo occupied (forced live by pointing the mark at an unreachable logo):

![fallback](https://raw.githubusercontent.com/runvendo/vendo/assets/card-family/.cards/09-connect-logo-fallback.png)

Standing access — a host tool's glyph keeps its well; a row with a brand mark shows it raw:

![grants](https://raw.githubusercontent.com/runvendo/vendo/assets/card-family/.cards/10-grant-set-marks.png)

### Gate, second pass

Rebased onto current `main` (which also picked up the `STORE_WIRE_MIN_CLIENT_VERSION` fix — the first push was conflicting against #1149's pre-squash commits, which is why no CI fired on it). Full workspace build; **ui 113 files / 966 tests**, **core 41 / 619**, **apps 114 files / 1534 tests** (includes the new seam test), vendo connect+pack suites 47 tests; typecheck core/apps/ui/vendo; dependency-guard, portability-gate, blocking eslint clean; demo-bank typechecks with the staging; mcp shim still byte-identical. Local Playwright (accessibility/axe, connect tray, smoke) 20 passed. Film re-run end to end after every change: the connect row, the settled receipt, the approval, and the automation card with its three rules — now sourced through `Trigger.rules` on the seeded document.
