### PR TITLE
fix(core): sync STORE_WIRE_MIN_CLIENT_VERSION to the shipped 0.12.0

### DIFF
--- a/packages/core/src/store-wire.ts
+++ b/packages/core/src/store-wire.ts
@@ -75,7 +75,7 @@ export const STORE_WIRE_PATHS = {
     version by `scripts/sync-version-constants.mjs` at release cut, exactly like
     the CLI and wire VERSION constants — so it always names the release that
     carried this contract and there is no number to remember. */
-export const STORE_WIRE_MIN_CLIENT_VERSION = "0.10.0";
+export const STORE_WIRE_MIN_CLIENT_VERSION = "0.12.0";
 
 /** The release that DROPS the ops below. Announced now, enforced there; this
     constant is the one place to change when the removal slice is cut.


### PR DESCRIPTION
Unblocks `main`. One line.

## The red

`packages/core/tests/store-wire.test.ts` — *"advertises the release it ships in as minClientVersion"* — `expected '0.10.0' to be '0.12.0'`. `packages/core/package.json` is `0.12.0`; the constant said `0.10.0`.

## Why

An ordering accident, not a broken mechanism. The version-packages PR (#1179, `447c21239`) ran `scripts/sync-version-constants.mjs` and bumped the lockstep group to `0.12.0` **before the constant existed on main**. #1177 merged after it (`031195f33`), carrying the value written when the release was still `0.11.0`. The sync had nothing to rewrite at the moment it ran.

## The fix

Ran the sync script rather than hand-editing, which also proves the registration end to end:

```
sync-version-constants: packages/vendo/src/cli/shared.ts already 0.12.0
sync-version-constants: packages/vendo/src/wire/shared.ts already 0.12.0
sync-version-constants: packages/core/src/store-wire.ts -> 0.12.0
```

The test is untouched — it is right, and it did its job: it caught a handshake advertising a release the build does not belong to, minutes after the bump.

**No changeset.** Nothing published ever carried the wrong value (npm latest is `0.11.0`, which predates the constant entirely), and the value is derived from `package.json` at every release cut rather than authored.

## Gate

`packages/core` `tests/store-wire.test.ts` 19/19 (`/tmp/s8afix-test-core.txt`, exit=0) and `pnpm typecheck` 42/42 (`/tmp/s8afix-typecheck.txt`, exit=0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync `STORE_WIRE_MIN_CLIENT_VERSION` to `0.12.0` to match `packages/core/package.json`, fixing the failing store-wire test and unblocking `main`. Updated via `scripts/sync-version-constants.mjs`; no changeset needed.

<sup>Written for commit 1c9482dbb7aa440d1b2cdb98518e4e3beafe5da5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

