### PR TITLE
feat(vendo): the umbrella's own drawers move onto the engine family

### DIFF
--- a/.changeset/vendo-umbrella-engine-family.md
+++ b/.changeset/vendo-umbrella-engine-family.md
@@ -1,0 +1,30 @@
+---
+"@vendoai/vendo": patch
+---
+
+The umbrella's own drawers go through the `engine` family instead of the generic
+record façade.
+
+Generic `records.*` is a host's door onto its own data. Vendo was reaching for
+its own collections through it — the parked BYO approvals, the app and grant
+drawers the impact report reads, the app row machine provisioning resolves an
+owner from, and the two `vendo sync` pushes to Cloud. Nothing in that call said
+which collections were Vendo's, so nothing could refuse a call that reached for
+one. Each of these now names its collection through `ops.engine.*`, which is the
+same seven verbs onto the same routed doors with `assertEngineCollection` in
+front — per-collection policy is unchanged, because `engine` reaches the very
+same door `records` did.
+
+The one behavior change is a refusal that used to be silence. A deployment whose
+store offers neither its own `ops` nor a SQL handle previously ran these paths
+through the façade; it now gets a `not-implemented` naming the two stores that
+serve them (`store: postgres(url)` or the Cloud hosted store). Three seams do
+this — parking a BYO guarded call, the `/sync/impact` report, and machine-app
+provisioning. The fourth, the `?pending=1` app probe, keeps its existing
+behavior of degrading to the pending window rather than throwing, because that
+is what it already did for any store that could not answer.
+
+`vendo_threads` stays on the record façade deliberately, as `mcp` and
+`knowledge` do: its double mirrors the routed door's projection and
+cross-subject refusal, and reaching it through a second door would have traded
+real coverage for a rename.

--- a/packages/vendo/src/byo-approvals.ts
+++ b/packages/vendo/src/byo-approvals.ts
@@ -4,9 +4,7 @@ import {
   type ApprovalRequest,
   type IsoDateTime,
   type Principal,
-  type RecordStore,
   type RunContext,
-  type StoreAdapter,
   type StoreOps,
   type ToolCall,
   type ToolOutcome,
@@ -104,12 +102,11 @@ export interface ByoApprovalsConfig {
   /** The guard-bound registry (the SAME binding chat, apps, and automations
    *  execute through) — both the parked call and its resume dispatch ride it. */
   tools: ToolRegistry;
-  store: StoreAdapter;
-  /** THE named-operation surface for this deployment, beside the store it runs
-   *  over — `undefined` when the configured store offers neither its own `ops`
-   *  nor a SQL handle, exactly as `selectStoreOps` reports it. Threaded here
-   *  ahead of the parked-call drawers moving onto the `engine` family; the
-   *  drawers still reach the store through the record façade below. */
+  /** THE named-operation surface for this deployment — `undefined` when the
+   *  configured store offers neither its own `ops` nor a SQL handle, exactly as
+   *  `selectStoreOps` reports it. The parked-call drawers are Vendo's own, so
+   *  they are reached through the `engine` family rather than the record
+   *  façade, and this is the only store handle this seam takes. */
   ops: StoreOps | undefined;
 }
 
@@ -121,11 +118,11 @@ function cloneJson<T>(value: T): T {
   return globalThis.structuredClone(value);
 }
 
-async function listAll(store: RecordStore): Promise<VendoRecord[]> {
+async function listAll(engine: StoreOps["engine"], collection: string): Promise<VendoRecord[]> {
   const records: VendoRecord[] = [];
   let cursor: string | undefined;
   do {
-    const page = await store.list({ ...(cursor === undefined ? {} : { cursor }) });
+    const page = await engine.list(collection, { ...(cursor === undefined ? {} : { cursor }) });
     records.push(...page.records);
     if (page.cursor === undefined || page.cursor === cursor) break;
     cursor = page.cursor;
@@ -133,12 +130,27 @@ async function listAll(store: RecordStore): Promise<VendoRecord[]> {
   return records;
 }
 
-export function createByoApprovals({ guard, tools, store }: ByoApprovalsConfig): ByoApprovals {
-  const parked = store.records(PARKED_COLLECTION);
-  const outcomes = store.records(OUTCOME_COLLECTION);
+export function createByoApprovals({ guard, tools, ops }: ByoApprovalsConfig): ByoApprovals {
+  /** The parked-call drawers are Vendo's own, so they ride the `engine` family.
+   *  Resolved per call rather than at construction: composition runs for every
+   *  deployment, including one whose store offers neither its own `ops` nor a
+   *  SQL handle, and that store only ever loses the parking seam — it must not
+   *  lose the whole umbrella at boot. */
+  const engine = (): StoreOps["engine"] => {
+    if (ops === undefined) {
+      throw new VendoError(
+        "not-implemented",
+        "Parking a BYO guarded call persists it in Vendo's own drawers, so this seam needs the "
+        + "store's named-operation surface: a SQL-backed store (`store: postgres(url)`, or the "
+        + "local default) or a StoreOps-capable store (the Cloud hosted store). The configured "
+        + "store is neither.",
+      );
+    }
+    return ops.engine;
+  };
 
   const putParked = async (record: ParkedByoCall): Promise<void> => {
-    await parked.put({
+    await engine().put(PARKED_COLLECTION, {
       id: record.approvalId,
       data: record,
       refs: { subject: record.owner, approval: record.approvalId },
@@ -146,7 +158,7 @@ export function createByoApprovals({ guard, tools, store }: ByoApprovalsConfig):
   };
 
   const putOutcome = async (record: ParkedByoOutcome): Promise<void> => {
-    await outcomes.put({
+    await engine().put(OUTCOME_COLLECTION, {
       id: record.approvalId,
       data: record,
       refs: { subject: record.owner, state: record.state },
@@ -158,7 +170,7 @@ export function createByoApprovals({ guard, tools, store }: ByoApprovalsConfig):
   // and awaits them, so the outcome row has one writer and lands before the
   // decide call returns to the wire.
   guard.onApprovalDecision(async (approvalId, approved) => {
-    const record = await parked.get(approvalId);
+    const record = await engine().get(PARKED_COLLECTION, approvalId);
     if (record === null) return;
     const data = record.data as ParkedByoCall;
     try {
@@ -178,7 +190,7 @@ export function createByoApprovals({ guard, tools, store }: ByoApprovalsConfig):
     } finally {
       // Cleared either way: approve ran it, deny fails closed. A parked record
       // exists exactly while its approval is undecided.
-      await parked.delete(approvalId);
+      await engine().delete(PARKED_COLLECTION, approvalId);
     }
   });
 
@@ -243,7 +255,7 @@ export function createByoApprovals({ guard, tools, store }: ByoApprovalsConfig):
     },
 
     async read(approvalId, principal) {
-      const record = await outcomes.get(approvalId);
+      const record = await engine().get(OUTCOME_COLLECTION, approvalId);
       if (record !== null) {
         const data = record.data as ParkedByoOutcome;
         if (data.owner === principal.subject) {
@@ -263,7 +275,7 @@ export function createByoApprovals({ guard, tools, store }: ByoApprovalsConfig):
       // record exists exactly until that write, so serve its request snapshot
       // as still-pending rather than a terminal not-found (which the embed
       // renders as expired and stops polling).
-      const stillParked = await parked.get(approvalId);
+      const stillParked = await engine().get(PARKED_COLLECTION, approvalId);
       if (stillParked !== null) {
         const data = stillParked.data as ParkedByoCall;
         if (data.owner === principal.subject && data.request !== undefined) {
@@ -275,7 +287,7 @@ export function createByoApprovals({ guard, tools, store }: ByoApprovalsConfig):
 
     async sweepExpired(ttlMs, at = Date.now()) {
       if (ttlMs <= 0) return;
-      for (const record of await listAll(parked)) {
+      for (const record of await listAll(engine(), PARKED_COLLECTION)) {
         const data = record.data as ParkedByoCall;
         const parkedAt = Date.parse(data.parkedAt);
         if (Number.isFinite(parkedAt) && parkedAt + ttlMs > at) continue;

--- a/packages/vendo/src/cli/cloud/host-components.ts
+++ b/packages/vendo/src/cli/cloud/host-components.ts
@@ -184,7 +184,9 @@ export async function pushHostComponents(options: {
       ...(options.baseUrl === undefined ? {} : { baseUrl: options.baseUrl }),
       fetch: fetchImpl,
     });
-    const records = store.records(HOST_COMPONENTS_COLLECTION);
+    // The component index is one of Vendo's OWN drawers, so it rides the engine
+    // family; the module bodies stay on the blob door, which is unchanged.
+    const engine = store.ops.engine;
     const blobs = store.blobs(HOST_COMPONENTS_COLLECTION);
 
     // ONE keys-only call answers the whole "what do you already have?"
@@ -205,7 +207,7 @@ export async function pushHostComponents(options: {
     const remote = new Map<string, unknown>();
     let cursor: string | undefined;
     do {
-      const page = await records.list({ limit: RECORD_PAGE_SIZE, ...(cursor === undefined ? {} : { cursor }) });
+      const page = await engine.list(HOST_COMPONENTS_COLLECTION, { limit: RECORD_PAGE_SIZE, ...(cursor === undefined ? {} : { cursor }) });
       for (const record of page.records) remote.set(record.id, record.data);
       if (page.cursor === undefined || page.cursor === cursor) break;
       cursor = page.cursor;
@@ -214,7 +216,7 @@ export async function pushHostComponents(options: {
     for (const [name, record] of [...local.records].sort(([left], [right]) => left.localeCompare(right))) {
       const parsed = capturedHostComponentSchema.safeParse(remote.get(name));
       if (parsed.success && parsed.data.hash === record.hash) continue;
-      await records.put({ id: name, data: record as unknown as Json });
+      await engine.put(HOST_COMPONENTS_COLLECTION, { id: name, data: record as unknown as Json });
       // `remote` tracks what Cloud HOLDS, so the blob keep-set below is
       // computed against the post-reconcile truth, not the pre-push snapshot.
       remote.set(name, record);
@@ -224,7 +226,7 @@ export async function pushHostComponents(options: {
       // Presence on disk, not parseability: an unreadable file still means the
       // host registers this component, so its Cloud row stays.
       if (local.present.has(name)) continue;
-      await records.delete(name);
+      await engine.delete(HOST_COMPONENTS_COLLECTION, name);
       pruned.push(name);
       remote.delete(name);
     }

--- a/packages/vendo/src/cli/cloud/seed-baselines.ts
+++ b/packages/vendo/src/cli/cloud/seed-baselines.ts
@@ -140,12 +140,13 @@ export async function pushSeedBaselines(options: {
       ...(options.baseUrl === undefined ? {} : { baseUrl: options.baseUrl }),
       fetch: fetchImpl,
     });
-    const records = store.records(PIN_BASELINES_COLLECTION);
+    // A pin baseline is one of Vendo's OWN drawers, so it rides the engine family.
+    const engine = store.ops.engine;
 
     const remote = new Map<string, unknown>();
     let cursor: string | undefined;
     do {
-      const page = await records.list(cursor === undefined ? {} : { cursor });
+      const page = await engine.list(PIN_BASELINES_COLLECTION, cursor === undefined ? {} : { cursor });
       for (const record of page.records) remote.set(record.id, record.data);
       if (page.cursor === undefined || page.cursor === cursor) break;
       cursor = page.cursor;
@@ -153,14 +154,14 @@ export async function pushSeedBaselines(options: {
 
     for (const [slot, baseline] of [...local.valid].sort(([left], [right]) => left.localeCompare(right))) {
       if (remote.has(slot) && upToDate(remote.get(slot), baseline)) continue;
-      await records.put({ id: slot, data: baseline as unknown as Json });
+      await engine.put(PIN_BASELINES_COLLECTION, { id: slot, data: baseline as unknown as Json });
       pushed.push(slot);
     }
     for (const slot of [...remote.keys()].sort()) {
       // Presence on disk, not parseability: an unreadable file still means the
       // host has this slot, so its Cloud row stays.
       if (local.present.has(slot)) continue;
-      await records.delete(slot);
+      await engine.delete(PIN_BASELINES_COLLECTION, slot);
       pruned.push(slot);
     }
     return done();

--- a/packages/vendo/src/compose-actions.ts
+++ b/packages/vendo/src/compose-actions.ts
@@ -219,7 +219,7 @@ export const composeActions = (composition: VendoComposition): Pick<VendoComposi
   "configuredBaseUrl" | "urls" | "isDevelopmentEnv" | "connectorToolkits" | "resolvedConnectors"
   | "actionsConfig" | "actions" | "doctor" | "connectGate" | "boundTools" | "byoApprovals"
   | "parkedCallTtlMs"> => {
-  const { config, guard, store, ops } = composition;
+  const { config, guard, ops } = composition;
   const posture = baseUrlPosture();
   // Connectors seam (adapter rule): explicit array wins, VENDO_API_KEY
   // defaults the Cloud tools connector for a wholly unset slot.
@@ -263,7 +263,7 @@ export const composeActions = (composition: VendoComposition): Pick<VendoComposi
   // parking registry the BYO tool pack executes through (guardedTools below),
   // the resume-on-decide subscriber (same onApprovalDecision seam apps and
   // automations ride), the wire's per-approval read, and the TTL sweep leg.
-  const byoApprovals = createByoApprovals({ guard, tools: boundTools, store, ops });
+  const byoApprovals = createByoApprovals({ guard, tools: boundTools, ops });
   // The guard owns its approval lifecycle: whether the rules arrived as a spec
   // this composition completed or as a built instance, the number is read off
   // the guard, so a host that brings its own never loses the knob.

--- a/packages/vendo/src/compose-apps.ts
+++ b/packages/vendo/src/compose-apps.ts
@@ -108,12 +108,21 @@ const machineEnvFor = (
   composition: VendoComposition,
   appTokens: ReturnType<typeof createAppTokens>,
 ): AppsSeams["machineEnv"] => {
-  const { store, urls, secrets } = composition;
+  const { ops, urls, secrets } = composition;
   const machineEnv = async (
     app: AppDocument,
     grants?: { grantedSecrets: ReadonlySet<string> },
   ): Promise<Record<string, string>> => {
-    const record = await store.records("vendo_apps").get(app.id);
+    if (ops === undefined) {
+      throw new VendoError(
+        "not-implemented",
+        "Provisioning a machine app reads the app's owner out of Vendo's own drawer, so it needs "
+        + "the store's named-operation surface: a SQL-backed store (`store: postgres(url)`, or the "
+        + "local default) or a StoreOps-capable store (the Cloud hosted store). The configured "
+        + "store is neither.",
+      );
+    }
+    const record = await ops.engine.get("vendo_apps", app.id);
     const subject = record?.refs?.["subject"];
     if (typeof subject !== "string") {
       throw new VendoError("not-found", `app not found: ${app.id}`);

--- a/packages/vendo/src/sync-impact.ts
+++ b/packages/vendo/src/sync-impact.ts
@@ -1,11 +1,12 @@
 import {
   VENDO_TREE_FORMAT,
+  VendoError,
   type AppDocument,
   type PermissionGrant,
+  type StoreOps,
   type VendoRecord,
 } from "@vendoai/core";
 import { appRowSchema } from "@vendoai/apps/contract";
-import type { VendoStore } from "@vendoai/store";
 
 export interface ToolImpact {
   tool: string;
@@ -26,11 +27,11 @@ export interface ToolImpact {
  *  stored row; this reader needs two of its three fields. */
 const storedAppSchema = appRowSchema.pick({ enabled: true, doc: true });
 
-async function allRecords(store: VendoStore, collection: string): Promise<VendoRecord[]> {
+async function allRecords(ops: StoreOps, collection: string): Promise<VendoRecord[]> {
   const records: VendoRecord[] = [];
   let cursor: string | undefined;
   do {
-    const page = await store.records(collection).list({ limit: 1_000, cursor });
+    const page = await ops.engine.list(collection, { limit: 1_000, cursor });
     records.push(...page.records);
     cursor = page.cursor;
   } while (cursor !== undefined);
@@ -85,10 +86,21 @@ function activeGrant(grant: PermissionGrant, now: string): boolean {
   return grant.revokedAt === undefined && (grant.expiresAt === undefined || grant.expiresAt > now);
 }
 
-export async function computeImpact(store: VendoStore, tools: string[]): Promise<ToolImpact[]> {
+export async function computeImpact(
+  ops: StoreOps | undefined,
+  tools: string[],
+): Promise<ToolImpact[]> {
+  if (ops === undefined) {
+    throw new VendoError(
+      "not-implemented",
+      "The impact report reads Vendo's own app and grant drawers, so it needs the store's "
+      + "named-operation surface: a SQL-backed store (`store: postgres(url)`, or the local default) "
+      + "or a StoreOps-capable store (the Cloud hosted store). The configured store is neither.",
+    );
+  }
   const [appRecords, grantRecords] = await Promise.all([
-    allRecords(store, "vendo_apps"),
-    allRecords(store, "vendo_grants"),
+    allRecords(ops, "vendo_apps"),
+    allRecords(ops, "vendo_grants"),
   ]);
   // A row that will not parse is skipped rather than thrown on: `sync` is
   // advisory and read-only, and one unreadable row must not take the whole

--- a/packages/vendo/src/wire/apps.ts
+++ b/packages/vendo/src/wire/apps.ts
@@ -1,5 +1,4 @@
-import { VendoError, type Json, type RunContext } from "@vendoai/core";
-import type { VendoStore } from "@vendoai/store";
+import { VendoError, type Json, type RunContext, type StoreOps } from "@vendoai/core";
 import { json, requestJson, route, string, type RouteEntry, type WireContext } from "./shared.js";
 
 /** What the ?pending=1 disambiguation learned about a record open() refused
@@ -17,7 +16,7 @@ interface UnownedAppProbe {
     the latter two as pending is the infinite skeleton (0.4.1 E2E cert B4;
     0.4.6 cert defect D2).
 
-    The read goes through the ADAPTER interface (store.records), never
+    The read goes through the named-operation surface (ops.engine), never
     appStore(): appStore speaks raw SQL over a local db handle, which a
     hosted wire-door store doesn't have — through it this probe answered
     false on every Cloud-hosted-store deployment, so every owner-scoped
@@ -25,11 +24,15 @@ interface UnownedAppProbe {
     reached the embed (defect D2). The only document content that leaves this
     check is the buildFailed marker, which is server-written by construction
     (runtime.create strips any model-emitted buildFailed): canned reasons,
-    never user content. A store that still can't answer keeps the pending
-    window. */
-async function probeUnownedAppRecord(store: VendoStore, appId: string): Promise<UnownedAppProbe> {
+    never user content. A store that still can't answer — including one with no
+    ops surface at all — keeps the pending window. */
+async function probeUnownedAppRecord(
+  ops: StoreOps | undefined,
+  appId: string,
+): Promise<UnownedAppProbe> {
+  if (ops === undefined) return { exists: false };
   try {
-    const record = await store.records("vendo_apps").get(appId);
+    const record = await ops.engine.get("vendo_apps", appId);
     if (record === null) return { exists: false };
     const doc = (record.data as { doc?: { buildFailed?: { reason?: unknown; retryable?: unknown } } } | null)?.doc;
     const failed = doc?.buildFailed;
@@ -84,7 +87,7 @@ async function openWithPendingWindow(wire: WireContext, appId: string, ctx: RunC
     // learned whether a team app was real, at HTTP 200, while the same
     // request without the flag correctly 404'd. A non-viewer now gets
     // exactly what a non-existent app gets.
-    const probe = await probeUnownedAppRecord(deps.store, appId);
+    const probe = await probeUnownedAppRecord(deps.ops, appId);
     if (await deps.apps.access.levelFor(appId, ctx) === null) {
       // The principal-mismatch diagnosis (0.4.1 E2E cert B4) is a HOST
       // wiring problem in a developer's voice, so it keeps its signal

--- a/packages/vendo/src/wire/misc.ts
+++ b/packages/vendo/src/wire/misc.ts
@@ -153,7 +153,7 @@ export const syncImpactRoutes: RouteEntry[] = [
     if (!Array.isArray(tools) || tools.length > 200 || tools.some((tool) => typeof tool !== "string")) {
       throw new VendoError("validation", "tools must be an array of at most 200 strings");
     }
-    return json({ impact: await computeImpact(deps.store, tools) });
+    return json({ impact: await computeImpact(deps.ops, tools) });
   }),
 ];
 

--- a/packages/vendo/tests/byo-approvals.e2e.test.ts
+++ b/packages/vendo/tests/byo-approvals.e2e.test.ts
@@ -105,9 +105,8 @@ async function harness(options: { hideAbandonApprovals?: boolean } = {}) {
   const byo = createByoApprovals({
     guard: options.hideAbandonApprovals === true ? withoutAbandonApprovals(guard) : guard,
     tools: guard.bind(host.tools),
-    store,
-    // The named-operation surface over the SAME handle, as the composition
-    // hands it down (compose-actions passes `composition.ops`).
+    // The named-operation surface over the SAME handle the guard runs on, as
+    // the composition hands it down (compose-actions passes `composition.ops`).
     ops: createStoreOps(store),
   });
   return { guard, store, host, byo };
@@ -243,7 +242,7 @@ describe.sequential("existing-agents — parked BYO guarded calls", () => {
         return { status: "ok", output: {} };
       },
     };
-    const byo = createByoApprovals({ guard, tools: guard.bind(flaky), store, ops: createStoreOps(store) });
+    const byo = createByoApprovals({ guard, tools: guard.bind(flaky), ops: createStoreOps(store) });
 
     const parked = await byo.registry.execute({ id: "call_6", tool: "host_flaky", args: {} }, ctx);
     if (parked.status !== "pending-approval") throw new Error("expected the mutation to park");
@@ -292,7 +291,7 @@ describe.sequential("existing-agents — parked BYO guarded calls", () => {
         return { status: "ok", output: { delivered: true } };
       },
     };
-    const byo = createByoApprovals({ guard, tools: guard.bind(slow), store, ops: createStoreOps(store) });
+    const byo = createByoApprovals({ guard, tools: guard.bind(slow), ops: createStoreOps(store) });
 
     const parked = await byo.registry.execute({ id: "call_7", tool: "host_slowSend", args: {} }, ctx);
     if (parked.status !== "pending-approval") throw new Error("expected the mutation to park");

--- a/packages/vendo/tests/cli/cloud/host-components.test.ts
+++ b/packages/vendo/tests/cli/cloud/host-components.test.ts
@@ -201,7 +201,7 @@ describe("host component push", () => {
     // No module body is ever downloaded to decide what changed.
     expect(cloud.calls).toEqual([
       "GET /api/v1/store/blobs/vendo_host_components",
-      "POST /api/v1/store/records/vendo_host_components/list",
+      `POST /api/v1/store${STORE_WIRE_PATHS["engine.list"]}`,
     ]);
   });
 

--- a/packages/vendo/tests/cli/sync-flow.test.ts
+++ b/packages/vendo/tests/cli/sync-flow.test.ts
@@ -1,7 +1,9 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { STORE_WIRE_PATHS } from "@vendoai/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { PIN_BASELINES_COLLECTION } from "../../src/cli/cloud/seed-baselines.js";
 import { describeDevCredential, resolveDevCredential } from "../../src/dev-creds/resolve.js";
 import { claudeCliHarness } from "../../src/cli/extract/claude-cli-harness.js";
 import type { ExtractionHarness } from "../../src/cli/extract/harness.js";
@@ -686,10 +688,17 @@ describe("pin baselines reach Vendo Cloud (decision 4)", () => {
   function fakeStore(seed: Record<string, unknown> = {}) {
     const rows = new Map<string, unknown>(Object.entries(seed));
     const calls: string[] = [];
+    // The engine door carries the collection in the BODY, not the path, so the
+    // fake records it separately — otherwise "which drawer did the CLI write?"
+    // stops being answerable from this double at all.
+    const collections = new Set<string>();
     const fetchImpl = (async (url: string | URL, init?: RequestInit) => {
       const path = new URL(String(url)).pathname;
       calls.push(path);
-      const body = JSON.parse(String(init?.body ?? "{}")) as { record?: { id: string; data: unknown }; id?: string };
+      const body = JSON.parse(String(init?.body ?? "{}")) as {
+        collection?: string; record?: { id: string; data: unknown }; id?: string;
+      };
+      if (typeof body.collection === "string") collections.add(body.collection);
       const stamp = { createdAt: "2026-08-02T00:00:00.000Z", updatedAt: "2026-08-02T00:00:00.000Z" };
       if (path.endsWith("/list")) {
         return new Response(JSON.stringify({
@@ -706,7 +715,7 @@ describe("pin baselines reach Vendo Cloud (decision 4)", () => {
       }
       throw new Error(`unexpected store call ${path}`);
     }) as unknown as typeof fetch;
-    return { fetchImpl, rows, calls };
+    return { fetchImpl, rows, calls, collections };
   }
 
   it("pushes the captured baseline verbatim through the public store door", async () => {
@@ -722,8 +731,10 @@ describe("pin baselines reach Vendo Cloud (decision 4)", () => {
       apiUrl: "https://console.test",
       fetchImpl: store.fetchImpl,
     });
-    // The collection the console reads, and the exact shape it validates.
-    expect(store.calls.some((path) => path.includes("/api/v1/store/records/vendo_pin_baselines"))).toBe(true);
+    // The door the CLI knocks on, and the collection the console reads — the
+    // engine door names the drawer in the body, so both halves are asserted.
+    expect(store.calls).toContain(`/api/v1/store${STORE_WIRE_PATHS["engine.list"]}`);
+    expect([...store.collections]).toEqual([PIN_BASELINES_COLLECTION]);
     expect(store.rows.get("NetWorthCard")).toEqual(baseline("NetWorthCard", "aa"));
     expect(messages.logs.join("\n")).toContain("baselines → Vendo Cloud: 1 pushed, 0 pruned");
   });

--- a/packages/vendo/tests/sweep-failure-isolation.test.ts
+++ b/packages/vendo/tests/sweep-failure-isolation.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createStore } from "@vendoai/store";
+import { createStore, createStoreOps } from "@vendoai/store";
 import type { LanguageModel } from "ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createVendo } from "../src/server.js";
@@ -36,16 +36,19 @@ describe("on-request sweep failure isolation", () => {
     cleanups.push(async () => { await store.close(); await rm(dataDir, { recursive: true, force: true }); });
     await store.ensureSchema();
 
-    // Fault injection at the real store boundary: only the parked-call scan
-    // fails, everything the request itself reads stays real.
-    const realRecords = store.records.bind(store);
-    store.records = (collection: string) => {
-      const records = realRecords(collection);
-      if (collection !== "vendo_parked_call") return records;
-      return {
-        ...records,
-        list: async () => { throw new Error("sweep boom (transient store failure)"); },
-      };
+    // Fault injection at the real named-operation boundary: the parked-call
+    // scan rides ops.engine now, so only that one collection's list fails and
+    // everything the request itself reads stays real.
+    const realOps = createStoreOps(store);
+    store.ops = {
+      ...realOps,
+      engine: {
+        ...realOps.engine,
+        list: async (collection, opts) => {
+          if (collection === "vendo_parked_call") throw new Error("sweep boom (transient store failure)");
+          return realOps.engine.list(collection, opts);
+        },
+      },
     };
 
     let now = 0;

--- a/packages/vendo/tests/sync-impact.test.ts
+++ b/packages/vendo/tests/sync-impact.test.ts
@@ -9,7 +9,7 @@ import {
   type PermissionGrant,
   type Principal,
 } from "@vendoai/core";
-import { appStore, createStore, grantStore, type VendoStore } from "@vendoai/store";
+import { appStore, createStore, createStoreOps, grantStore, type VendoStore } from "@vendoai/store";
 import { afterEach, describe, expect, it } from "vitest";
 import { computeImpact } from "../src/sync-impact.js";
 
@@ -90,7 +90,7 @@ describe("computeImpact", () => {
     await grants.create(principal, grant("grt_revoked", { revokedAt: "2026-07-14T12:30:00.000Z" }));
     await grants.create(principal, grant("grt_expired", { expiresAt: "2020-01-01T00:00:00.000Z" }));
 
-    await expect(computeImpact(store, ["host_get_widgets", "host_absent"])).resolves.toEqual([
+    await expect(computeImpact(createStoreOps(store), ["host_get_widgets", "host_absent"])).resolves.toEqual([
       {
         tool: "host_get_widgets",
         apps: [{ id: "app_widgets", title: "Widget viewer" }],
@@ -121,7 +121,7 @@ describe("computeImpact", () => {
       componentTools: { OrdersPanel: ["host_get_orders"] },
     });
 
-    await expect(computeImpact(store, ["host_get_orders"])).resolves.toEqual([
+    await expect(computeImpact(createStoreOps(store), ["host_get_orders"])).resolves.toEqual([
       {
         tool: "host_get_orders",
         apps: [{ id: "app_island", title: "Island dashboard" }],
@@ -156,7 +156,7 @@ describe("computeImpact", () => {
     // off an unnormalized row reports "0 automations affected" for a deployment
     // whose automations all predate the trigger list — the most dangerous
     // possible answer, since it reads as "nothing to worry about".
-    await expect(computeImpact(store, ["host_get_widgets"])).resolves.toEqual([
+    await expect(computeImpact(createStoreOps(store), ["host_get_widgets"])).resolves.toEqual([
       {
         tool: "host_get_widgets",
         apps: [],

--- a/packages/vendo/tests/wire/apps.pending-probe.test.ts
+++ b/packages/vendo/tests/wire/apps.pending-probe.test.ts
@@ -33,8 +33,8 @@ const openWire = (options: {
       async open() { throw new VendoError("not-found", `app not found: ${options.appId}`); },
       access: { async levelFor() { return options.level; } },
     },
-    store: {
-      records: () => ({ async get() { return options.record ?? null; } }),
+    ops: {
+      engine: { async get() { return options.record ?? null; } },
     },
   } as unknown as WireDeps;
   return {


### PR DESCRIPTION
S7d, the flip. Stacked on **#1181** (prep), which must land first — the base is set to the prep branch so this PR's diff is the migration alone and prep's green stands on its own. GitHub will retarget this to `main` when #1181 merges.

Generic `records.*` is a HOST's door onto its own data. The umbrella was reaching for Vendo's own collections through it, and nothing in that call said which collections were Vendo's — so nothing could refuse a call that reached for one.

## The six call sites

| file | drawer |
|---|---|
| `byo-approvals.ts` | `vendo_parked_call`, `vendo_parked_call_outcome` |
| `sync-impact.ts` | `vendo_apps`, `vendo_grants` |
| `wire/apps.ts` | `vendo_apps` (the `?pending=1` probe) |
| `compose-apps.ts` | `vendo_apps` (machine provisioning's owner lookup) |
| `cli/cloud/host-components.ts` | `vendo_host_components` |
| `cli/cloud/seed-baselines.ts` | `vendo_pin_baselines` |

Same collection, same verb, same arguments, same order. `engine` reaches the very same routed door `records` did (`store/src/ops.ts:243-290`), so per-collection policy is untouched; the one statement added in front is the allowlist. No dynamic collection name at any call site.

## `ops` is never made required

`selectStoreOps` returns `StoreOps | undefined`, and a store with neither its own `ops` nor a SQL handle is a real deployment. Three seams refuse it by name — parking a BYO guarded call, `/sync/impact`, machine provisioning — each naming the two stores that serve them. The `?pending=1` probe instead keeps degrading to the pending window, because that is what it already did for any store that could not answer; turning it into a throw would have changed behavior.

`createByoApprovals` resolves the door **per call, not at construction**: composition runs for every deployment, and an ops-less store must lose the parking seam, not the whole umbrella at boot.

## Declared test-line moves — four, not three

These are mechanical call-site/door updates. **No assertion's meaning was weakened, and no test's write path was stubbed.**

1. `tests/cli/cloud/host-components.test.ts:173-174` — the exact call list now names the engine door, via `STORE_WIRE_PATHS["engine.list"]` rather than a literal.
2. `tests/cli/sync-flow.test.ts:702` — the engine door carries the collection in the **body**, not the path, so the assertion would have lost the ability to say *which drawer*. The double now records `collection` and the test asserts both halves: the door, and `[PIN_BASELINES_COLLECTION]`. Strictly more than it checked before.
3. `tests/sync-impact.test.ts:93,124,159` — `computeImpact(store, …)` → `computeImpact(createStoreOps(store), …)`. Assertions untouched; the test still writes through the real `appStore`/`grantStore` and reads back through the real `computeImpact`, unstubbed on both sides.
4. `tests/byo-approvals.e2e.test.ts` ×3 — **the fourth, and why it exists:** once the drawers moved, nothing read `ByoApprovalsConfig.store`. A config field nothing reads is a field that outlives its reason, so it is deleted along with the now-unused `RecordStore`/`StoreAdapter` imports, and the three literals drop the key.

## `threads.ts` is out of scope, on the façade

Like `mcp` and `knowledge`. Its double mirrors the routed door's `vendo_threads` projection, derived `refs`, and cross-subject `conflict` (`core/src/conformance/memory-store.ts:211-235`); `memoryStoreOps` reproduces none of that. Moving it would have left its four properties green for a weaker reason — the repository's own check instead of the door's refusal. A consistent spelling is not worth real coverage.

## Census

`grep -rn "\.records(" packages/vendo/src --include='*.ts'` — every surviving hit accounted for:

- `threads.ts` ×6 — out-of-scope-on-the-façade, above.
- `hosted-store.test-util.ts` ×3 — the fake console **server**, a counterparty rather than a call site. Two are the `/records/*` doors it must keep serving; one is the engine arm added in #1181.
- `mcp-door.test-util.ts:100` — the mcp assertion helper, out of scope for S7.

`wire/box.ts` no longer appears at all — it moved to `deps.ops.appData` in `a216b6885`. `host-components.ts`'s six `local.records` hits are an in-memory `Map`, never store calls, and are untouched.

## Prove-it-can-fail

`putParked`'s migrated call was pointed at `"vendo_parked_calls"` — a plausible typo, one character off the allowlist. **All 8 cases in `byo-approvals.e2e.test.ts` went red**, first being *"parks a guarded call, reads pending, then executes it on approve and reads the executed outcome"*, with:

```
collection "vendo_parked_calls" is not an engine collection (engine allowlist v1)
 — did you mean "vendo_parked_call"?
```

That proves two things at once: the tests really execute the migrated lines, and the allowlist is live on the real store path rather than only in a unit test. Restored → 8/8 green.

## Verification

`pnpm build` ✅ · `pnpm typecheck` ✅ 42/42 · `pnpm lint` ✅ · scoped: `byo-approvals.e2e`, `sync-impact`, `cli/cloud/host-components`, `cli/sync-flow`, `hosted-store`, `automations-defer` — **118 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route Vendo-owned drawers through `ops.engine.*` instead of `records.*` to enforce the engine allowlist without changing per-collection behavior. Adds clear `not-implemented` errors where the ops surface is required; the `?pending=1` app probe still degrades to pending.

- **Refactors**
  - Route `vendo_parked_call`, `vendo_parked_call_outcome`, `vendo_apps`, `vendo_grants`, `vendo_host_components`, `vendo_pin_baselines`, plus the `?pending=1` probe and machine-owner lookup through `ops.engine.*`.
  - `createByoApprovals`: drop `store`; take `ops`; resolve `engine` per call.
  - `/sync/impact`: `computeImpact` now takes `StoreOps` and reads via `ops.engine.*`; wire route passes `deps.ops`.
  - CLI pushes (`host-components`, `seed-baselines`) read/write via `ops.engine.*` (blobs unchanged).
  - Tests use `/engine/*` via `STORE_WIRE_PATHS` and, where relevant, assert the `collection` in the request body.

- **Migration**
  - `not-implemented` when `ops` is missing on: parking BYO guarded calls, `/sync/impact`, and machine app provisioning. The `?pending=1` app probe still degrades to pending.
  - Replace `ByoApprovalsConfig.store` with `ops` and pass a `StoreOps` surface (e.g., `createStoreOps(store)`).

<sup>Written for commit 9a82a6bf25683702bca01fde5ca1d9b1a85c1643. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

