### PR TITLE
feat(store)!: the generic records.* family leaves the wire

### DIFF
--- a/.changeset/records-ops-are-removed.md
+++ b/.changeset/records-ops-are-removed.md
@@ -1,0 +1,57 @@
+---
+"@vendoai/core": minor
+"@vendoai/store": minor
+"@vendoai/vendo": minor
+---
+
+**Breaking.** The generic `records.*` store ops are gone. `/records/*` now
+answers `not-implemented` (501), naming the op you called. There is no flag,
+no fallback and no deprecation window left — this release IS the removal.
+
+**Do this.** Find every `ops.records.*` call and move it to the family that owns
+the data:
+
+- Rows and files a generated app invents → `ops.appData.put/get/list/delete` and
+  `ops.appData.putFile/getFile/listFiles/deleteFile`. The target carries
+  `{ appId, collection, owner }`; the owner is stamped on writes and scopes
+  reads, so you no longer prefix a collection name to keep users apart.
+- Vendo's own collections (threads, runs, grants, audit, effects, apps,
+  automations schedules and deliveries) → `ops.engine.*`. Same seven verbs, same
+  arguments, same returns, behind the `ENGINE_COLLECTIONS` allowlist. A name
+  outside it is refused with `blocked` and told where its data belongs.
+
+**If you wrote raw HTTP against the store wire,** the seven `/records/*` routes
+are the break: `POST /records/put` now returns
+
+```json
+{ "error": { "code": "not-implemented", "message": "the store wire no longer serves records.put — …" } }
+```
+
+with HTTP 501. `STORE_WIRE_PATHS` holds 35 ops across 8 families, and
+`status()` reports `ops: 35`.
+
+**The `StoreAdapter` façade is unchanged and still supported.**
+`store.records(collection)` and `store.blobs(namespace)` keep working exactly as
+they did — including `claim` and `atomic` feature detection. On `hostedStore`
+they are now built on the two surviving families: an `app:<appId>:<name>`
+collection or namespace rides `appData`, everything else rides `engine`. Two
+consequences on the hosted adapter only:
+
+- A collection outside the engine allowlist (a host's own `"invoices"`) no
+  longer has a home on the hosted mount and is refused with `blocked`. Local
+  and BYO stores are untouched.
+- An app-scoped drawer is owner-scoped now, like every other appData read.
+  `hostedStore({ owner })` names the owner; it defaults to the single-player
+  `"user_local"`, matching `createStoreOps`' bound workspace owner. Because
+  `appData` has no compare-and-set verbs, an app-scoped `RecordStore` omits
+  `claim` and `atomic` rather than advertising what it cannot serve.
+
+**Also removed, because they only existed to announce the retirement:**
+`STORE_WIRE_DEPRECATED_OPS`, `STORE_WIRE_DEPRECATED_REMOVED_IN` and
+`STORE_WIRE_MIN_CLIENT_VERSION` (all `@vendoai/core`), the `deprecated` and
+`minClientVersion` fields on `StoreWireStatus`, the seven deprecated
+`storeWireRecords*RequestSchema` aliases (use `storeWireCollection*RequestSchema`),
+and doctor's `E-LIVE-008` warning. The `E-LIVE-008` code stays listed in the
+registry and on the verify page — doctor codes are never reused — but nothing
+emits it any more. The handshake body still passes unknown keys through, so a
+client on this release reads an older mount's `/status` without complaint.

--- a/.changeset/records-ops-are-removed.md
+++ b/.changeset/records-ops-are-removed.md
@@ -42,9 +42,17 @@ consequences on the hosted adapter only:
   and BYO stores are untouched.
 - An app-scoped drawer is owner-scoped now, like every other appData read.
   `hostedStore({ owner })` names the owner; it defaults to the single-player
-  `"user_local"`, matching `createStoreOps`' bound workspace owner. Because
+  `"user_local"`, matching `createStoreOps`' bound workspace owner. **If you
+  serve more than one end user through one `hostedStore` instance, set it** —
+  on the default, every user's app rows and files land in one owner's drawer
+  and read each other. Construct one `hostedStore` per end user, or use
+  `ops.appData`, whose every verb names its owner at the call. Because
   `appData` has no compare-and-set verbs, an app-scoped `RecordStore` omits
   `claim` and `atomic` rather than advertising what it cannot serve.
+- One error string changed: a bare, envelope-less 404 from a blob read on the
+  hosted adapter now says `Vendo Cloud store request failed with 404` instead
+  of naming a "bare 404". Same behaviour — it still throws loudly rather than
+  reading as a missing blob — but stop grepping for the old wording.
 
 **Also removed, because they only existed to announce the retirement:**
 `STORE_WIRE_DEPRECATED_OPS`, `STORE_WIRE_DEPRECATED_REMOVED_IN` and

--- a/docs-site/agents/verify.mdx
+++ b/docs-site/agents/verify.mdx
@@ -442,19 +442,20 @@ re-run `vendo doctor`.
 
 ### E-LIVE-008 {#E-LIVE-008}
 
-**Symptom (warning):** `/status` lists store ops the wire has deprecated. The
-named ops still work today; the warning names the release that removes them.
+**Retired.** Doctor no longer emits this code. The warning existed for one
+release, while the generic `records.*` store-wire family was on its way out; the
+family is now gone, so there is nothing left to warn about. The code stays
+listed here because doctor codes are never reused — if you are reading it off an
+older run, the fix below is still the fix.
 
-**Cause:** The generic `records.*` family is being retired in favour of two
-named families: `appData.*` for the rows and files an app invents (owner-stamped
-for you) and `engine.*` for Vendo's own collections (the same seven verbs behind
-an allowlist). The mount advertises the retirement on its handshake so callers
-find out before the removal, not after.
+**What happened:** The generic `records.*` family was replaced by two named
+families: `appData.*` for the rows and files an app invents (owner-stamped for
+you) and `engine.*` for Vendo's own collections (the same seven verbs behind an
+allowlist). The hosted store's `/records/*` routes are gone.
 
 **Fix:** Move each `records.*` call to the family that owns the data: app data
-to `appData.*`, Vendo's own collections to `engine.*`. Nothing breaks until the
-release named in the warning; after it, the deprecated ops answer
-`not-implemented`.
+to `appData.*`, Vendo's own collections to `engine.*`. A call left on a
+`/records/*` route now answers `not-implemented` (HTTP 501) naming the op.
 
 ## Auth probes
 

--- a/packages/core/src/conformance/index.ts
+++ b/packages/core/src/conformance/index.ts
@@ -219,6 +219,55 @@ export function storeAdapterConformance(opts: {
         assertDeepEqual((await second.get("shared"))?.data, { collection: "b" }, "second collection collided");
       }),
 
+      /** 01-core §12: an adapter that offers `claim` must make it a
+          compare-and-set over the whole value — true for the one caller whose
+          expectation still holds, false for everyone else. Both halves of the
+          capability are OPTIONAL (an adapter with no database-level
+          compare-and-claim omits them), so an adapter that does not offer one
+          passes by not offering it; what it may not do is offer one that lies.
+          These three moved off the retired generic records WIRE family, whose
+          seven verbs the hosted store no longer serves: the behavior they pin
+          is the BYO seam's, and this is where a BYO adapter meets it. */
+      readyAdapterCase(opts, "01-core §12 — records.claim returns true on match, false on mismatch", async (adapter) => {
+        const records = adapter.records("conformance_claim");
+        if (records.claim === undefined) return;
+        await records.put({ id: "cl1", data: { v: 1 }, refs: { o: "a" } });
+        assert(await records.claim({ id: "cl1", data: { v: 999 } }) === false, "claim should return false on mismatch");
+        assert(
+          await records.claim({ id: "cl1", data: { v: 1 }, refs: { o: "a" } }, { data: { v: 2 }, refs: { o: "b" } }) === true,
+          "claim should return true on match",
+        );
+        assertDeepEqual((await records.get("cl1"))?.data, { v: 2 }, "claim did not apply replacement");
+      }),
+
+      /** 01-core §12: insertIfAbsent is insert-once — the second caller is told
+          it lost, and the first caller's row is left exactly as written. */
+      readyAdapterCase(opts, "01-core §12 — records.insertIfAbsent returns record on first call, null on second", async (adapter) => {
+        const records = adapter.records("conformance_insert_if_absent");
+        if (records.atomic === undefined) return;
+        const first = await records.atomic.insertIfAbsent({ id: "iia1", data: { n: 1 } });
+        assert(first !== null, "insertIfAbsent first call should return a record");
+        assert(first.id === "iia1", "insertIfAbsent did not echo id");
+        assert(await records.atomic.insertIfAbsent({ id: "iia1", data: { n: 2 } }) === null, "insertIfAbsent second call should return null");
+        assertDeepEqual((await records.get("iia1"))?.data, { n: 1 }, "insertIfAbsent overwrote existing record");
+      }),
+
+      /** 01-core §12: compareAndSwap lands only on the revision the caller
+          read; a stale revision is null at the seam, never an error. */
+      readyAdapterCase(opts, "01-core §12 — records.compareAndSwap succeeds on matching revision, null on stale", async (adapter) => {
+        const records = adapter.records("conformance_compare_and_swap");
+        if (records.atomic === undefined) return;
+        const created = await records.put({ id: "cas1", data: { v: 1 } });
+        assert(created.revision !== undefined, "put must return a revision for CAS");
+        const swapped = await records.atomic.compareAndSwap({ id: "cas1", data: { v: 2 } }, created.revision);
+        assert(swapped !== null, "compareAndSwap should succeed on matching revision");
+        assertDeepEqual(swapped.data, { v: 2 }, "compareAndSwap did not update data");
+        assert(
+          await records.atomic.compareAndSwap({ id: "cas1", data: { v: 3 } }, created.revision) === null,
+          "compareAndSwap should return null on stale revision",
+        );
+      }),
+
       /** 01-core §12: blobs round-trip bytes and content type. */
       readyAdapterCase(opts, "01-core §12 — blobs.put and get round-trip bytes and contentType", async (adapter) => {
         const blobs = adapter.blobs("conformance_blob_round_trip");

--- a/packages/core/src/conformance/memory-store-ops.ts
+++ b/packages/core/src/conformance/memory-store-ops.ts
@@ -101,7 +101,9 @@ export function memoryStoreOps(): StoreOps {
   const wsIdempotencyKeys = new Map<string, string>();
 
   // ---------------------------------------------------------------------------
-  // records family
+  // rows — the shared generic-collection implementation the engine and appData
+  // families are both built on. NOT an op family of its own: the wire's generic
+  // records family is gone, so nothing outside this module reaches these verbs.
   // ---------------------------------------------------------------------------
 
   const putRecord = (collection: string, input: RecordInput): VendoRecord => {
@@ -122,7 +124,7 @@ export function memoryStoreOps(): StoreOps {
     return copyRecord(record);
   };
 
-  const records: StoreOps["records"] = {
+  const rows: StoreOps["engine"] = {
     async get(collection, id) {
       const r = col(collection).get(id);
       return r ? copyRecord(r) : null;
@@ -179,7 +181,7 @@ export function memoryStoreOps(): StoreOps {
   };
 
   // ---------------------------------------------------------------------------
-  // engine family — `records`, behind the allowlist gate
+  // engine family — the generic rows above, behind the allowlist gate
   // ---------------------------------------------------------------------------
 
   /** MIRRORS the per-collection policy the real backend enforces in its typed
@@ -192,17 +194,17 @@ export function memoryStoreOps(): StoreOps {
   const engine: StoreOps["engine"] = {
     async get(collection, id) {
       assertEngineCollection(collection);
-      return records.get(collection, id);
+      return rows.get(collection, id);
     },
     async put(collection, record) {
       assertEngineCollection(collection);
       if (INSERT_ONCE.has(collection)) {
         // A receipt that already exists is the truth about what executed, so a
         // second put hands back the RECORDED row rather than overwriting it.
-        const held = await records.get(collection, record.id);
+        const held = await rows.get(collection, record.id);
         if (held) return held;
       }
-      return records.put(collection, record);
+      return rows.put(collection, record);
     },
     async delete(collection, id) {
       assertEngineCollection(collection);
@@ -212,23 +214,23 @@ export function memoryStoreOps(): StoreOps {
           `${collection} is append-only; rows are erased only via the store erase API (02-store §5)`,
         );
       }
-      await records.delete(collection, id);
+      await rows.delete(collection, id);
     },
     async list(collection, query) {
       assertEngineCollection(collection);
-      return records.list(collection, query);
+      return rows.list(collection, query);
     },
     async claim(collection, expected, replacement) {
       assertEngineCollection(collection);
-      return records.claim(collection, expected, replacement);
+      return rows.claim(collection, expected, replacement);
     },
     async insertIfAbsent(collection, record) {
       assertEngineCollection(collection);
-      return records.insertIfAbsent(collection, record);
+      return rows.insertIfAbsent(collection, record);
     },
     async compareAndSwap(collection, record, expectedRevision) {
       assertEngineCollection(collection);
-      return records.compareAndSwap(collection, record, expectedRevision);
+      return rows.compareAndSwap(collection, record, expectedRevision);
     },
   };
 
@@ -303,21 +305,21 @@ export function memoryStoreOps(): StoreOps {
       if (held !== undefined && held.refs?.["subject"] !== target.owner) {
         throw new VendoError("conflict", `app data id "${record.id}" is already held in this collection`);
       }
-      return records.put(collection, { ...record, refs: { ...record.refs, subject: target.owner } });
+      return rows.put(collection, { ...record, refs: { ...record.refs, subject: target.owner } });
     },
     async get(target, id) {
-      const record = await records.get(appCollection(target), id);
+      const record = await rows.get(appCollection(target), id);
       return record?.refs?.["subject"] === target.owner ? record : null;
     },
     async list(target, query = {}) {
       const collection = appCollection(target);
       refuseSubject(query.refs, "list");
-      return records.list(collection, { ...query, refs: { ...query.refs, subject: target.owner } });
+      return rows.list(collection, { ...query, refs: { ...query.refs, subject: target.owner } });
     },
     async delete(target, id) {
       const collection = appCollection(target);
       if (col(collection).get(id)?.refs?.["subject"] !== target.owner) return;
-      await records.delete(collection, id);
+      await rows.delete(collection, id);
     },
     async putFile(target, key, bytes, meta) {
       await blobs.put(appCollection(target), ownedKey(target, key), bytes, meta);
@@ -606,7 +608,6 @@ export function memoryStoreOps(): StoreOps {
   // ---------------------------------------------------------------------------
 
   return {
-    records,
     engine,
     blobs,
     appData,
@@ -615,7 +616,7 @@ export function memoryStoreOps(): StoreOps {
     workspace,
     lifecycle,
     async status(): Promise<StoreWireStatus> {
-      return { format: VENDO_STORE_WIRE_FORMAT, ops: 42 };
+      return { format: VENDO_STORE_WIRE_FORMAT, ops: 35 };
     },
   };
 }

--- a/packages/core/src/conformance/store-ops.ts
+++ b/packages/core/src/conformance/store-ops.ts
@@ -74,14 +74,14 @@ const numberField = (entry: unknown, field: string, message: string): number => 
 
 /** A thread's harness state rides the harness slot under this synthetic appId
     (the store's `harnessStateKey`), which is what makes deleteThread's cascade
-    onto harness state observable through the 42 ops. */
+    onto harness state observable through the 35 ops. */
 const harnessSlot = (threadId: string): string => `harness_state:${threadId}`;
 
 /** appData rows live in the app's own drawer, and the local backend fails an
     app-scoped write closed when the app has no row — so every appData case
     seeds one first, with the shape the typed `vendo_apps` door accepts. */
 const seedApp = async (ops: StoreOps, appId: string): Promise<void> => {
-  await ops.records.put("vendo_apps", {
+  await ops.engine.put("vendo_apps", {
     id: appId,
     data: {
       subject: "user_1",
@@ -121,139 +121,58 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
     seam: "StoreOps",
     cases: [
       // =====================================================================
-      // records
+      // engine
       // =====================================================================
 
-      opsCase(opts, "records.put echoes fields and stamps ISO timestamps", async (ops) => {
-        const input = { id: "put_echo", data: { nested: [1, "two"] }, refs: { owner: "user_1" } };
-        const record = await ops.records.put("conf_put", input);
-        assert(record.id === input.id, "put did not echo the record id");
-        assertDeepEqual(record.data, input.data, "put did not echo record data");
-        assertDeepEqual(record.refs, input.refs, "put did not echo record refs");
-        isoDateTimeSchema.parse(record.createdAt);
-        isoDateTimeSchema.parse(record.updatedAt);
-      }),
-
-      opsCase(opts, "records.get round-trips a put record", async (ops) => {
-        const put = await ops.records.put("conf_get", { id: "rt", data: { ok: true }, refs: { h: "1" } });
-        const got = await ops.records.get("conf_get", "rt");
-        assertDeepEqual(got, put, "get did not round-trip the stored record");
-      }),
-
-      opsCase(opts, "records.get missing returns null", async (ops) => {
-        assert(await ops.records.get("conf_miss", "absent") === null, "missing record did not return null");
-      }),
-
-      opsCase(opts, "records.put same id updates without timestamp regression", async (ops) => {
-        const first = await ops.records.put("conf_upd", { id: "s", data: { v: 1 }, refs: { o: "a" } });
-        const second = await ops.records.put("conf_upd", { id: "s", data: { v: 2 }, refs: { o: "b" } });
-        assertDeepEqual(second.data, { v: 2 }, "update did not replace data");
-        assertDeepEqual(second.refs, { o: "b" }, "update did not replace refs");
-        assert(second.createdAt === first.createdAt, "update changed createdAt");
-        assert(second.updatedAt >= first.updatedAt, "updatedAt regressed");
-      }),
-
-      opsCase(opts, "records.delete makes get return null", async (ops) => {
-        await ops.records.put("conf_del", { id: "del", data: {} });
-        await ops.records.delete("conf_del", "del");
-        assert(await ops.records.get("conf_del", "del") === null, "deleted record remained readable");
-      }),
-
-      opsCase(opts, "records.delete missing resolves", async (ops) => {
-        await ops.records.delete("conf_delmiss", "absent");
-      }),
-
-      opsCase(opts, "records.list returns everything put", async (ops) => {
-        for (const id of ["a", "b", "c"]) await ops.records.put("conf_la", { id, data: { id } });
-        const result = await ops.records.list("conf_la");
-        assertDeepEqual(result.records.map((r) => r.id).sort(), ["a", "b", "c"], "list omitted or added records");
-      }),
-
-      opsCase(opts, "records.list ids filters exactly", async (ops) => {
-        for (const id of ["ia", "ib", "ic"]) await ops.records.put("conf_li", { id, data: { id } });
-        const result = await ops.records.list("conf_li", { ids: ["ia", "ic"] });
-        assertDeepEqual(result.records.map((r) => r.id).sort(), ["ia", "ic"], "ids filter returned the wrong records");
-      }),
-
-      opsCase(opts, "records.list refs filters by exact containment", async (ops) => {
-        await ops.records.put("conf_lr", { id: "match", data: {}, refs: { owner: "one", kind: "inv" } });
-        await ops.records.put("conf_lr", { id: "wrong", data: {}, refs: { owner: "two", kind: "inv" } });
-        await ops.records.put("conf_lr", { id: "miss", data: {}, refs: { owner: "one" } });
-        const result = await ops.records.list("conf_lr", { refs: { owner: "one", kind: "inv" } });
-        assertDeepEqual(result.records.map((r) => r.id), ["match"], "refs filter was not exact key/value containment");
-      }),
-
-      opsCase(opts, "records.list limit and cursor paginate without loss or duplicates", async (ops) => {
-        const expected = ["pa", "pb", "pc", "pd", "pe"];
-        for (const id of expected) await ops.records.put("conf_pg", { id, data: { id } });
-        await assertPaginates("records.list", expected, async (cursor) => {
-          const page = await ops.records.list("conf_pg", { limit: PAGE, cursor });
-          return { ids: page.records.map((r) => r.id), cursor: page.cursor };
-        });
-      }),
-
-      opsCase(opts, "records.list repeats an identical query in the same order", async (ops) => {
-        for (const id of ["da", "db", "dc", "dd"]) await ops.records.put("conf_det", { id, data: { id } });
-        const first = await ops.records.list("conf_det");
-        const repeat = await ops.records.list("conf_det");
-        assertDeepEqual(repeat.records.map((r) => r.id), first.records.map((r) => r.id), "identical list calls returned different orders");
-        const firstPage = await ops.records.list("conf_det", { limit: PAGE });
-        const repeatPage = await ops.records.list("conf_det", { limit: PAGE });
-        assertDeepEqual(repeatPage.records.map((r) => r.id), firstPage.records.map((r) => r.id), "identical first pages returned different records");
-        assert(repeatPage.cursor === firstPage.cursor, "identical first pages returned different cursors");
-      }),
-
-      /** Store wire v1: every list op defaults to 100 per page and caps at 1000. */
-      opsCase(opts, "records.list defaults to 100 per page and refuses or clamps a limit above 1000", async (ops) => {
+      /** Store wire v1: every list op defaults to 100 per page and caps at
+          1000. Pinned on `engine.list` — the generic records family that used
+          to carry this case is gone, and the rule is the WIRE's, not the
+          StoreAdapter's, so it stays in this suite. */
+      opsCase(opts, "engine.list defaults to 100 per page and refuses or clamps a limit above 1000", async (ops) => {
+        const collection = engineAppHistory("conf_cap");
         const ids = Array.from({ length: 101 }, (_, i) => `cap_${String(i).padStart(3, "0")}`);
-        for (const id of ids) await ops.records.put("conf_cap", { id, data: { id } });
-        const defaulted = await ops.records.list("conf_cap");
+        for (const id of ids) await ops.engine.put(collection, { id, data: { id } });
+        const defaulted = await ops.engine.list(collection);
         assert(defaulted.records.length === 100, `the default page should hold 100 records, got ${defaulted.records.length}`);
         assert(defaulted.cursor !== undefined, "a truncated default page must return a cursor");
-        const overMax = await ops.records.list("conf_cap", { limit: 5000 }).catch((error: unknown) => {
+        const overMax = await ops.engine.list(collection, { limit: 5000 }).catch((error: unknown) => {
           assert((error as { code?: unknown }).code === "validation", `a limit above the 1000 max must be refused as validation, got ${String(error)}`);
           return null;
         });
         if (overMax !== null) assert(overMax.records.length <= 1000, "an accepted over-max limit was not clamped to 1000");
       }),
 
-      opsCase(opts, "records.claim returns true on match, false on mismatch", async (ops) => {
-        await ops.records.put("conf_cl", { id: "cl1", data: { v: 1 }, refs: { o: "a" } });
-        const miss = await ops.records.claim("conf_cl", { id: "cl1", data: { v: 999 } });
-        assert(miss === false, "claim should return false on mismatch");
-        const hit = await ops.records.claim("conf_cl", { id: "cl1", data: { v: 1 }, refs: { o: "a" } }, { data: { v: 2 }, refs: { o: "b" } });
-        assert(hit === true, "claim should return true on match");
-        const after = await ops.records.get("conf_cl", "cl1");
-        assertDeepEqual(after?.data, { v: 2 }, "claim did not apply replacement");
+      /** Store wire v1: a cursor is only followable if an identical query comes
+          back in an identical order. Same reason as the case above for living
+          on `engine.list`. */
+      opsCase(opts, "engine.list repeats an identical query in the same order", async (ops) => {
+        const collection = engineAppHistory("conf_det");
+        for (const id of ["da", "db", "dc", "dd"]) await ops.engine.put(collection, { id, data: { id } });
+        const first = await ops.engine.list(collection);
+        const repeat = await ops.engine.list(collection);
+        assertDeepEqual(repeat.records.map((r) => r.id), first.records.map((r) => r.id), "identical list calls returned different orders");
+        const firstPage = await ops.engine.list(collection, { limit: PAGE });
+        const repeatPage = await ops.engine.list(collection, { limit: PAGE });
+        assertDeepEqual(repeatPage.records.map((r) => r.id), firstPage.records.map((r) => r.id), "identical first pages returned different records");
+        assert(repeatPage.cursor === firstPage.cursor, "identical first pages returned different cursors");
       }),
 
-      opsCase(opts, "records.insertIfAbsent returns record on first call, null on second", async (ops) => {
-        const first = await ops.records.insertIfAbsent("conf_iia", { id: "iia1", data: { n: 1 } });
-        assert(first !== null, "insertIfAbsent first call should return a record");
-        assert(first!.id === "iia1", "insertIfAbsent did not echo id");
-        const second = await ops.records.insertIfAbsent("conf_iia", { id: "iia1", data: { n: 2 } });
-        assert(second === null, "insertIfAbsent second call should return null");
-        // original data unchanged
-        const got = await ops.records.get("conf_iia", "iia1");
-        assertDeepEqual(got?.data, { n: 1 }, "insertIfAbsent overwrote existing record");
+      /** Store wire v1: keyset pagination over `engine.list` walks the whole
+          set exactly once. */
+      opsCase(opts, "engine.list limit and cursor paginate without loss or duplicates", async (ops) => {
+        const collection = engineAppHistory("conf_pg");
+        const expected = ["pa", "pb", "pc", "pd", "pe"];
+        for (const id of expected) await ops.engine.put(collection, { id, data: { id } });
+        await assertPaginates("engine.list", expected, async (cursor) => {
+          const page = await ops.engine.list(collection, { limit: PAGE, cursor });
+          return { ids: page.records.map((r) => r.id), cursor: page.cursor };
+        });
       }),
-
-      opsCase(opts, "records.compareAndSwap succeeds on matching revision, null on stale", async (ops) => {
-        const created = await ops.records.put("conf_cas", { id: "cas1", data: { v: 1 } });
-        assert(created.revision, "put must return a revision for CAS");
-        const swapped = await ops.records.compareAndSwap("conf_cas", { id: "cas1", data: { v: 2 } }, created.revision!);
-        assert(swapped !== null, "compareAndSwap should succeed on matching revision");
-        assertDeepEqual(swapped!.data, { v: 2 }, "compareAndSwap did not update data");
-        const stale = await ops.records.compareAndSwap("conf_cas", { id: "cas1", data: { v: 3 } }, created.revision!);
-        assert(stale === null, "compareAndSwap should return null on stale revision");
-      }),
-
-      // =====================================================================
-      // engine
-      // =====================================================================
 
       opsCase(opts, "engine round-trips a record on an engine collection", async (ops) => {
         const put = await ops.engine.put("vendo_workspace_commits", { id: "wc_1", data: { v: 1 }, refs: { subject: "user_1" } });
+        isoDateTimeSchema.parse(put.createdAt);
+        isoDateTimeSchema.parse(put.updatedAt);
         const got = await ops.engine.get("vendo_workspace_commits", "wc_1");
         assertDeepEqual(got, put, "engine.get did not round-trip the stored record");
         const listed = await ops.engine.list("vendo_workspace_commits", { ids: ["wc_1"] });
@@ -322,8 +241,20 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         assert(message.includes(`v${ENGINE_ALLOWLIST_VERSION}`), `the refusal should name the allowlist version, got ${message}`);
         assert(message.includes("appData"), `the refusal should point at the appData family, got ${message}`);
 
-        // A gate that throws after writing is not a gate.
-        assert(await ops.records.get("host_invoices", "inv_1") === null, "the refused put wrote its row anyway");
+        // A gate that throws after writing is not a gate. The probe is an
+        // app-scoped name — outside the allowlist exactly like `host_invoices`,
+        // but reachable through the ONE surviving door onto those rows, so the
+        // refused write can be looked for instead of assumed away.
+        await seedApp(ops, "app_gate");
+        await assertThrowsCode(
+          () => ops.engine.put("app:app_gate:invoices", { id: "inv_1", data: { total: 1 } }),
+          "blocked",
+          "an app-scoped collection on engine.put",
+        );
+        assert(
+          await ops.appData.get({ appId: "app_gate", collection: "invoices", owner: "user_1" }, "inv_1") === null,
+          "the refused put wrote its row anyway",
+        );
       }),
 
       /** `engine` is a NEW door onto the same routed doors the local backend
@@ -502,7 +433,7 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         assert(await ops.appData.get(owner, "keep") === null, "delete left the owner's own row behind");
       }),
 
-      /** `put` has `records.put`'s blast radius — an unconditional upsert on
+      /** `put` has an unconditional upsert's blast radius — an unconditional upsert on
           (collection, id) — so an id another owner holds must be refused, not
           overwritten and re-stamped into a row the loser can neither read nor
           delete. */
@@ -1133,16 +1064,16 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
       // =====================================================================
 
       opsCase(opts, "lifecycle.erase removes one subject's records, threads, and harness state", async (ops) => {
-        await ops.records.put("conf_erase", { id: "gone", data: {}, refs: { subject: "erase_me" } });
-        await ops.records.put("conf_erase", { id: "keep", data: {}, refs: { subject: "other" } });
+        await ops.engine.put("vendo_parked_call", { id: "gone", data: {}, refs: { subject: "erase_me" } });
+        await ops.engine.put("vendo_parked_call", { id: "keep", data: {}, refs: { subject: "other" } });
         await ops.transcripts.putThread({ id: "thr_erase", subject: "erase_me", messages: [] });
         await ops.transcripts.putThread({ id: "thr_keep", subject: "other", messages: [] });
         await ops.harness.set("app_erase", "erase_me", { v: 1 });
 
         const report = await ops.lifecycle.erase({ subject: "erase_me" });
         assert(report !== null && report !== undefined, "erase must return a report");
-        assert(await ops.records.get("conf_erase", "gone") === null, "erase left the subject's record behind");
-        assert(await ops.records.get("conf_erase", "keep") !== null, "erase removed another subject's record");
+        assert(await ops.engine.get("vendo_parked_call", "gone") === null, "erase left the subject's record behind");
+        assert(await ops.engine.get("vendo_parked_call", "keep") !== null, "erase removed another subject's record");
         assert(await ops.transcripts.getThread("thr_erase") === null, "erase left the subject's thread behind");
         assert(await ops.transcripts.getThread("thr_keep") !== null, "erase removed another subject's thread");
         assert(await ops.harness.get("app_erase", "erase_me") === null, "erase left the subject's harness state behind");
@@ -1154,7 +1085,7 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
       opsCase(opts, "lifecycle.promote hands the app record to the org; an unknown app is not-found", async (ops) => {
         // A SHAPE-VALID app record: vendo_apps is a typed door, and a real
         // backend refuses data that does not parse as {subject, enabled, doc}.
-        await ops.records.put("vendo_apps", {
+        await ops.engine.put("vendo_apps", {
           id: "app_promote",
           data: {
             subject: "user_1",
@@ -1164,7 +1095,7 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
           refs: { subject: "user_1" },
         });
         await ops.lifecycle.promote("app_promote", "org_1");
-        const promoted = await ops.records.get("vendo_apps", "app_promote");
+        const promoted = await ops.engine.get("vendo_apps", "app_promote");
         assert(
           promoted?.refs?.["subject"] === "org_1",
           `promote should hand the app to the org, got subject ${String(promoted?.refs?.["subject"])}`,
@@ -1180,7 +1111,7 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         const status = await ops.status();
         assert(status.format === VENDO_STORE_WIRE_FORMAT, `status.format should be ${VENDO_STORE_WIRE_FORMAT}`);
         assert(typeof status.ops === "number", "status.ops should be a number");
-        assert(status.ops === 42, `status.ops should be 42, got ${status.ops}`);
+        assert(status.ops === 35, `status.ops should be 35, got ${status.ops}`);
       }),
     ],
   };

--- a/packages/core/src/store-wire.ts
+++ b/packages/core/src/store-wire.ts
@@ -17,14 +17,6 @@ export const VENDO_STORE_WIRE_FORMAT = "vendo/store-wire@1" as const;
     ONE keyset cursor (default 100, max 1000) on every list op.
     Unknown op → enveloped `not-implemented` (501). */
 export const STORE_WIRE_PATHS = {
-  // records (7)
-  "records.get": "/records/get",
-  "records.put": "/records/put",
-  "records.delete": "/records/delete",
-  "records.list": "/records/list",
-  "records.claim": "/records/claim",
-  "records.insertIfAbsent": "/records/insertIfAbsent",
-  "records.compareAndSwap": "/records/compareAndSwap",
   // engine (7)
   "engine.get": "/engine/get",
   "engine.put": "/engine/put",
@@ -70,34 +62,6 @@ export const STORE_WIRE_PATHS = {
   status: "/status",
 } as const;
 
-/** The release this build of the wire ships in, advertised as
-    `StoreWireStatus.minClientVersion`. Rewritten from the published package
-    version by `scripts/sync-version-constants.mjs` at release cut, exactly like
-    the CLI and wire VERSION constants — so it always names the release that
-    carried this contract and there is no number to remember. */
-export const STORE_WIRE_MIN_CLIENT_VERSION = "0.13.0";
-
-/** The release that DROPS the ops below. Announced now, enforced there; this
-    constant is the one place to change when the removal slice is cut.
-
-    THIS NUMBER IS A PROMISE TO CUSTOMERS, not an internal note: it is printed
-    verbatim in the deprecation changeset and in doctor's E-LIVE-008 warning, so
-    a reader will plan a migration around it. It is derived, not chosen — the
-    announcement rides the release after the one publishing today, and the
-    removal must be one full release later than the announcement so nobody
-    upgrades into a break they were never told about. RE-CONFIRM IT AT THE
-    RELEASE CUT: if the announcement slips into a release of its own, this moves
-    with it. */
-export const STORE_WIRE_DEPRECATED_REMOVED_IN = "0.13.0";
-
-/** Ops this wire still serves but is retiring: the generic `records.*` family,
-    superseded by `appData.*` (owner-stamped rows generated apps invent) and
-    `engine.*` (Vendo's own collections, behind an allowlist). Read off the path
-    table so it cannot claim an op that does not exist — and so it empties
-    itself the day `records.*` leaves. */
-export const STORE_WIRE_DEPRECATED_OPS: readonly string[] =
-  Object.keys(STORE_WIRE_PATHS).filter((op) => op.startsWith("records."));
-
 // ---------------------------------------------------------------------------
 // Shared schemas
 // ---------------------------------------------------------------------------
@@ -114,12 +78,12 @@ const cursorQuerySchema = z.object({
 }).passthrough();
 
 // ---------------------------------------------------------------------------
-// records + engine — one collection-addressed body shape serves both
+// engine — the collection-addressed body shape
 //
-// The two families take the same seven verbs over the same `collection` + args
-// bodies; only the allowlist behind the door differs (engine names are gated by
-// assertEngineCollection). So the bodies are named for their SHAPE, not for one
-// family — a second copy would only be a copy that could drift.
+// Named for its SHAPE, not for the family: `engine` takes seven verbs over a
+// `collection` + args body, and the appData family addresses the same rows
+// through a `target` instead. The generic records family that once shared
+// these bodies is gone; its paths answer an enveloped 501.
 // ---------------------------------------------------------------------------
 
 export const storeWireCollectionGetRequestSchema = z.object({
@@ -161,23 +125,6 @@ export const storeWireCollectionCompareAndSwapRequestSchema = z.object({
   record: recordInputSchema,
   expectedRevision: z.string().min(1),
 }).passthrough();
-
-/** @deprecated Renamed to storeWireCollection*RequestSchema — one
-    collection-addressed body shape now serves both /records/* and /engine/*.
-    Removed in a later slice; nothing new should import these. */
-export const storeWireRecordsGetRequestSchema = storeWireCollectionGetRequestSchema;
-/** @deprecated Use storeWireCollectionPutRequestSchema. */
-export const storeWireRecordsPutRequestSchema = storeWireCollectionPutRequestSchema;
-/** @deprecated Use storeWireCollectionDeleteRequestSchema. */
-export const storeWireRecordsDeleteRequestSchema = storeWireCollectionDeleteRequestSchema;
-/** @deprecated Use storeWireCollectionListRequestSchema. */
-export const storeWireRecordsListRequestSchema = storeWireCollectionListRequestSchema;
-/** @deprecated Use storeWireCollectionClaimRequestSchema. */
-export const storeWireRecordsClaimRequestSchema = storeWireCollectionClaimRequestSchema;
-/** @deprecated Use storeWireCollectionInsertIfAbsentRequestSchema. */
-export const storeWireRecordsInsertIfAbsentRequestSchema = storeWireCollectionInsertIfAbsentRequestSchema;
-/** @deprecated Use storeWireCollectionCompareAndSwapRequestSchema. */
-export const storeWireRecordsCompareAndSwapRequestSchema = storeWireCollectionCompareAndSwapRequestSchema;
 
 // ---------------------------------------------------------------------------
 // blobs
@@ -395,21 +342,17 @@ export const storeWireLifecyclePromoteRequestSchema = z.object({
 // status
 // ---------------------------------------------------------------------------
 
-/** GET /status — the discovery handshake. Clients learn the protocol version,
-    the min client version for negotiation, and counts. */
+/** GET /status — the discovery handshake. Clients learn the protocol version
+    and the op count. The body passes unknown keys through, so a mount that
+    still sends fields this build dropped is read, not refused. */
 export interface StoreWireStatus {
   format: typeof VENDO_STORE_WIRE_FORMAT;
-  minClientVersion?: string;
   ops: number;
-  /** Op names this mount still serves but is retiring. */
-  deprecated?: readonly string[];
 }
 
 export const storeWireStatusSchema = z.object({
   format: z.literal(VENDO_STORE_WIRE_FORMAT),
-  minClientVersion: z.string().optional(),
   ops: z.number(),
-  deprecated: z.array(z.string()).optional(),
 }).passthrough() satisfies z.ZodType<StoreWireStatus>;
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -88,7 +88,7 @@ export interface StoreAdapter {
 }
 
 // ---------------------------------------------------------------------------
-// StoreOps — the named-operation contract for the 42-op / 9-family store.
+// StoreOps — the named-operation contract for the 35-op / 8-family store.
 // Both the local backend (store/ops.ts) and the cloud client
 // (hosted-store.ts) implement this interface.
 // ---------------------------------------------------------------------------
@@ -127,23 +127,15 @@ export type EraseTarget =
   | { subject: string; appId?: never }
   | { appId: string; subject?: never };
 
-/** The typed contract for all 42 store operations across 9 families.
+/** The typed contract for all 35 store operations across 8 families.
     Lean by design — this is the CONTRACT interface, not the implementation. */
 export interface StoreOps {
-  records: {
-    get(collection: string, id: string): Promise<VendoRecord | null>;
-    put(collection: string, record: RecordInput): Promise<VendoRecord>;
-    delete(collection: string, id: string): Promise<void>;
-    list(collection: string, query?: RecordQuery): Promise<{ records: VendoRecord[]; cursor?: string }>;
-    claim(collection: string, expected: RecordInput, replacement?: Pick<VendoRecord, "data" | "refs">): Promise<boolean>;
-    insertIfAbsent(collection: string, record: RecordInput): Promise<VendoRecord | null>;
-    compareAndSwap(collection: string, record: RecordInput, expectedRevision: string): Promise<VendoRecord | null>;
-  };
   /** Vendo's OWN engine data — grants, approvals, audit, threads, runs, apps,
-      effects, and the automations and guard drawers — reached through the same
-      seven verbs as `records`. `assertEngineCollection` (engine-collections.ts)
-      gates the collection name on every verb, so nothing outside the allowlist
-      passes. NOT a place for host or generated-app data: that is `appData`. */
+      effects, and the automations and guard drawers — reached through seven
+      collection-addressed verbs. `assertEngineCollection`
+      (engine-collections.ts) gates the collection name on every verb, so
+      nothing outside the allowlist passes. NOT a place for host or
+      generated-app data: that is `appData`. */
   engine: {
     get(collection: string, id: string): Promise<VendoRecord | null>;
     put(collection: string, record: RecordInput): Promise<VendoRecord>;

--- a/packages/core/tests/store-wire.test.ts
+++ b/packages/core/tests/store-wire.test.ts
@@ -1,9 +1,5 @@
-import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import {
-  STORE_WIRE_DEPRECATED_OPS,
-  STORE_WIRE_DEPRECATED_REMOVED_IN,
-  STORE_WIRE_MIN_CLIENT_VERSION,
   STORE_WIRE_PATHS,
   STORE_WIRE_STATUS_BY_CODE,
   VENDO_STORE_WIRE_FORMAT,
@@ -12,13 +8,6 @@ import {
   storeWireErrorSchema,
   storeWireStatusSchema,
   parseStoreWireError,
-  storeWireRecordsGetRequestSchema,
-  storeWireRecordsPutRequestSchema,
-  storeWireRecordsDeleteRequestSchema,
-  storeWireRecordsListRequestSchema,
-  storeWireRecordsClaimRequestSchema,
-  storeWireRecordsInsertIfAbsentRequestSchema,
-  storeWireRecordsCompareAndSwapRequestSchema,
   storeWireCollectionGetRequestSchema,
   storeWireCollectionPutRequestSchema,
   storeWireCollectionDeleteRequestSchema,
@@ -58,24 +47,26 @@ import {
 } from "../src/index.js";
 
 describe("vendo/store-wire@1", () => {
-  it("exposes the format constant and 42 mount-relative paths", () => {
+  it("exposes the format constant and 35 mount-relative paths", () => {
     expect(VENDO_STORE_WIRE_FORMAT).toBe("vendo/store-wire@1");
-    // 9 families: records(7) + engine(7) + blobs(4) + appData(8) + transcripts(6) + harness(3) + workspace(4) + lifecycle(2) + status(1) = 42
-    expect(Object.keys(STORE_WIRE_PATHS)).toHaveLength(42);
+    // 8 families: engine(7) + blobs(4) + appData(8) + transcripts(6) + harness(3) + workspace(4) + lifecycle(2) + status(1) = 35
+    expect(Object.keys(STORE_WIRE_PATHS)).toHaveLength(35);
     expect(STORE_WIRE_PATHS.status).toBe("/status");
-    expect(STORE_WIRE_PATHS["records.get"]).toBe("/records/get");
     expect(STORE_WIRE_PATHS["engine.get"]).toBe("/engine/get");
     expect(STORE_WIRE_PATHS["engine.compareAndSwap"]).toBe("/engine/compareAndSwap");
     expect(STORE_WIRE_PATHS["appData.put"]).toBe("/app-data/put");
     expect(STORE_WIRE_PATHS["lifecycle.promote"]).toBe("/lifecycle/promote");
   });
 
-  it("every engine door is its own path, distinct from its records twin", () => {
+  it("every engine door is its own path, and no route is left on the retired generic family", () => {
     const verbs = ["get", "put", "delete", "list", "claim", "insertIfAbsent", "compareAndSwap"] as const;
     for (const verb of verbs) {
-      const engine = STORE_WIRE_PATHS[`engine.${verb}`];
-      expect(engine).toBe(`/engine/${verb}`);
-      expect(engine).not.toBe(STORE_WIRE_PATHS[`records.${verb}`]);
+      expect(STORE_WIRE_PATHS[`engine.${verb}`]).toBe(`/engine/${verb}`);
+    }
+    // The hard cut: no op name and no path may lead back to /records/*.
+    for (const [op, path] of Object.entries(STORE_WIRE_PATHS)) {
+      expect(op.startsWith("records."), `${op} is a retired generic records op`).toBe(false);
+      expect(path.startsWith("/records/"), `${op} still routes to ${path}`).toBe(false);
     }
     const enginePaths = Object.entries(STORE_WIRE_PATHS)
       .filter(([op]) => op.startsWith("engine."))
@@ -84,81 +75,41 @@ describe("vendo/store-wire@1", () => {
     expect(enginePaths.every((path) => path.startsWith("/engine/"))).toBe(true);
   });
 
-  it("names every records.* op as deprecated, and nothing else", () => {
-    expect([...STORE_WIRE_DEPRECATED_OPS].sort()).toEqual([
-      "records.claim",
-      "records.compareAndSwap",
-      "records.delete",
-      "records.get",
-      "records.insertIfAbsent",
-      "records.list",
-      "records.put",
-    ]);
-    // Advertised only — every deprecated op is still a served path.
-    for (const op of STORE_WIRE_DEPRECATED_OPS) {
-      expect(Object.keys(STORE_WIRE_PATHS)).toContain(op);
-    }
-    // The removal release must be a real version, not a placeholder.
-    expect(STORE_WIRE_DEPRECATED_REMOVED_IN).toMatch(/^\d+\.\d+\.\d+$/);
-  });
+  it("parses collection-addressed request DTOs and rejects invalid ones", () => {
+    expect(storeWireCollectionGetRequestSchema.parse({ collection: "users", id: "u1" }).id).toBe("u1");
+    expect(storeWireCollectionGetRequestSchema.safeParse({ collection: "", id: "u1" }).success).toBe(false);
 
-  it("advertises the release it ships in as minClientVersion", async () => {
-    // scripts/sync-version-constants.mjs rewrites the constant at release cut,
-    // the same invariant cli/shared.test.ts pins for CLI_VERSION — so the
-    // handshake can never name a release this build did not ship in.
-    const pkg = JSON.parse(
-      await readFile(new URL("../package.json", import.meta.url), "utf8"),
-    ) as { version: string };
-    expect(STORE_WIRE_MIN_CLIENT_VERSION).toBe(pkg.version);
-  });
-
-  it("the storeWireRecords* names are aliases of the shared collection bodies", () => {
-    // Same shape serves /records/* and /engine/*; the old names stay exported
-    // until the removal slice, so they must BE the renamed schemas, not copies.
-    expect(storeWireRecordsGetRequestSchema).toBe(storeWireCollectionGetRequestSchema);
-    expect(storeWireRecordsPutRequestSchema).toBe(storeWireCollectionPutRequestSchema);
-    expect(storeWireRecordsDeleteRequestSchema).toBe(storeWireCollectionDeleteRequestSchema);
-    expect(storeWireRecordsListRequestSchema).toBe(storeWireCollectionListRequestSchema);
-    expect(storeWireRecordsClaimRequestSchema).toBe(storeWireCollectionClaimRequestSchema);
-    expect(storeWireRecordsInsertIfAbsentRequestSchema).toBe(storeWireCollectionInsertIfAbsentRequestSchema);
-    expect(storeWireRecordsCompareAndSwapRequestSchema).toBe(storeWireCollectionCompareAndSwapRequestSchema);
-  });
-
-  it("parses records request DTOs and rejects invalid ones", () => {
-    expect(storeWireRecordsGetRequestSchema.parse({ collection: "users", id: "u1" }).id).toBe("u1");
-    expect(storeWireRecordsGetRequestSchema.safeParse({ collection: "", id: "u1" }).success).toBe(false);
-
-    expect(storeWireRecordsPutRequestSchema.parse({
+    expect(storeWireCollectionPutRequestSchema.parse({
       collection: "users",
       record: { id: "u1", data: { name: "Alice" } },
     }).record.id).toBe("u1");
-    expect(storeWireRecordsPutRequestSchema.safeParse({ collection: "users" }).success).toBe(false);
+    expect(storeWireCollectionPutRequestSchema.safeParse({ collection: "users" }).success).toBe(false);
 
-    expect(storeWireRecordsDeleteRequestSchema.parse({ collection: "users", id: "u1" }).collection).toBe("users");
+    expect(storeWireCollectionDeleteRequestSchema.parse({ collection: "users", id: "u1" }).collection).toBe("users");
 
-    expect(storeWireRecordsListRequestSchema.parse({ collection: "users" }).collection).toBe("users");
-    expect(storeWireRecordsListRequestSchema.parse({
+    expect(storeWireCollectionListRequestSchema.parse({ collection: "users" }).collection).toBe("users");
+    expect(storeWireCollectionListRequestSchema.parse({
       collection: "users",
       query: { refs: { org: "o1" }, limit: 50 },
     }).query?.limit).toBe(50);
 
-    expect(storeWireRecordsClaimRequestSchema.parse({
+    expect(storeWireCollectionClaimRequestSchema.parse({
       collection: "users",
       expected: { id: "u1", data: { status: "free" } },
       replacement: { data: { status: "claimed" } },
     }).expected.id).toBe("u1");
 
-    expect(storeWireRecordsInsertIfAbsentRequestSchema.parse({
+    expect(storeWireCollectionInsertIfAbsentRequestSchema.parse({
       collection: "users",
       record: { id: "u2", data: {} },
     }).record.id).toBe("u2");
 
-    expect(storeWireRecordsCompareAndSwapRequestSchema.parse({
+    expect(storeWireCollectionCompareAndSwapRequestSchema.parse({
       collection: "users",
       record: { id: "u1", data: {} },
       expectedRevision: "rev_1",
     }).expectedRevision).toBe("rev_1");
-    expect(storeWireRecordsCompareAndSwapRequestSchema.safeParse({
+    expect(storeWireCollectionCompareAndSwapRequestSchema.safeParse({
       collection: "users",
       record: { id: "u1", data: {} },
       expectedRevision: "",
@@ -296,10 +247,12 @@ describe("vendo/store-wire@1", () => {
   it("status doubles as the discovery handshake: format + ops count", () => {
     const status: StoreWireStatus = {
       format: VENDO_STORE_WIRE_FORMAT,
-      ops: 42,
+      ops: 35,
     };
-    expect(storeWireStatusSchema.parse(status).ops).toBe(42);
-    expect(storeWireStatusSchema.parse({ ...status, deprecated: ["records.put"] }).deprecated).toEqual(["records.put"]);
+    expect(storeWireStatusSchema.parse(status).ops).toBe(35);
+    // An older mount still sending fields this build dropped is READ, not
+    // refused — the body passes unknown keys through.
+    expect(storeWireStatusSchema.safeParse({ ...status, deprecated: ["records.put"], minClientVersion: "0.12.0" }).success).toBe(true);
     expect(storeWireStatusSchema.safeParse({ ...status, format: "vendo/store-wire@2" }).success).toBe(false);
   });
 

--- a/packages/guard/test/engine-family.test.ts
+++ b/packages/guard/test/engine-family.test.ts
@@ -1,7 +1,10 @@
 // Every drawer this block owns — approvals, grants, audit, the effect ledger,
 // the freeze switch, the transition receipts — is Vendo's OWN data, so it
-// reaches the store through the named `engine` family and its allowlist, never
-// through the generic `records.*` door a host uses for its own rows.
+// reaches the store through the named `engine` family and its allowlist. The
+// generic records family this once had to steer clear of is gone from StoreOps
+// entirely, so "never the generic door" is now a compile error rather than
+// something a spy has to catch at runtime; what is left to prove is that every
+// collection named is one the allowlist knows.
 //
 // The counterparty here is the REAL in-core StoreOps reference
 // (`memoryStoreOps`), gate included: the flow writes through the guard and
@@ -15,7 +18,7 @@ import { createMemoryStore } from "./fixtures/memory-store.js";
 import { alice, FixtureTools, call, context } from "./fixtures/tools.js";
 
 interface Op {
-  family: "engine" | "records";
+  family: "engine";
   verb: string;
   collection: string;
 }
@@ -40,7 +43,7 @@ function recordingOps(): { ops: StoreOps; traffic: Op[] } {
       (note(name, "compareAndSwap", c), door.compareAndSwap(c, record, revision)),
   });
   return {
-    ops: { ...real, engine: family("engine", real.engine), records: family("records", real.records) },
+    ops: { ...real, engine: family("engine", real.engine) },
     traffic,
   };
 }
@@ -81,10 +84,9 @@ async function exerciseEveryDrawer(): Promise<{ ops: StoreOps; traffic: Op[] }> 
 }
 
 describe("the guard's own drawers ride the engine family", () => {
-  it("never touches the generic records door, and names only allowlisted collections", async () => {
+  it("names only allowlisted collections", async () => {
     const { traffic } = await exerciseEveryDrawer();
 
-    expect(traffic.filter((op) => op.family === "records")).toEqual([]);
     const collections = [...new Set(traffic.map((op) => op.collection))].sort();
     expect(collections.filter((c) => !isEngineCollection(c))).toEqual([]);
     expect(collections).toEqual([

--- a/packages/store/src/ops.ts
+++ b/packages/store/src/ops.ts
@@ -1,7 +1,5 @@
 import {
   assertEngineCollection,
-  STORE_WIRE_DEPRECATED_OPS,
-  STORE_WIRE_MIN_CLIENT_VERSION,
   VENDO_STORE_WIRE_FORMAT,
   VendoError,
   type FilesAdapter,
@@ -104,7 +102,7 @@ const decoder = new TextDecoder();
 
 /**
  * 02-store — the LOCAL backend of the StoreOps named-operation contract
- * (core/store.ts): the 42 ops served straight off this store's own Postgres,
+ * (core/store.ts): the 35 ops served straight off this store's own Postgres,
  * through the EXISTING helpers — routing doors, thread rows, workspace rows, the
  * erase cascade. Logic unchanged; what this layer adds is the atomic scope:
  * every multi-statement verb runs inside ONE
@@ -192,55 +190,10 @@ export function createStoreOps(
 
   return {
     // -----------------------------------------------------------------------
-    // records — the routed doors, verbatim; per-collection policy lives there.
-    // -----------------------------------------------------------------------
-    records: {
-      async get(collection, id) {
-        return await recordsDoor(db, collection).get(id);
-      },
-      async put(collection, record) {
-        return await db.transaction((q) => recordsDoor(txDb(q), collection).put(record));
-      },
-      async delete(collection, id) {
-        await db.transaction((q) => recordsDoor(txDb(q), collection).delete(id));
-      },
-      async list(collection, query) {
-        return await recordsDoor(db, collection).list(query);
-      },
-      async claim(collection, expected, replacement) {
-        return await db.transaction(async (q) => {
-          const door = recordsDoor(txDb(q), collection);
-          if (door.claim === undefined) {
-            throw new VendoError("not-implemented", `${collection} does not support claim`);
-          }
-          return await door.claim(expected, replacement);
-        });
-      },
-      async insertIfAbsent(collection, record) {
-        return await db.transaction(async (q) => {
-          const door = recordsDoor(txDb(q), collection);
-          if (door.atomic === undefined) {
-            throw new VendoError("not-implemented", `${collection} does not support insertIfAbsent`);
-          }
-          return await door.atomic.insertIfAbsent(record);
-        });
-      },
-      async compareAndSwap(collection, record, expectedRevision) {
-        return await db.transaction(async (q) => {
-          const door = recordsDoor(txDb(q), collection);
-          if (door.atomic === undefined) {
-            throw new VendoError("not-implemented", `${collection} does not support compareAndSwap`);
-          }
-          return await door.atomic.compareAndSwap(record, expectedRevision);
-        });
-      },
-    },
-
-    // -----------------------------------------------------------------------
-    // engine — the same seven verbs onto the same routed doors, with the same
-    // per-collection policy living there; the ONE addition is the allowlist
-    // gate, which is why the audit door is still append-only and the effects
-    // door still insert-once through this family.
+    // engine — seven verbs onto the routed doors, with the per-collection
+    // policy living there; the ONE addition is the allowlist gate, which is why
+    // the audit door is still append-only and the effects door still
+    // insert-once through this family.
     // -----------------------------------------------------------------------
     engine: {
       async get(collection, id) {
@@ -725,16 +678,8 @@ export function createStoreOps(
       },
     },
 
-    // The retirement of `records.*` is ADVERTISED here and nowhere else: every
-    // op below still serves it. A client learns from the handshake instead of
-    // from a 501 the day it goes.
     async status() {
-      return {
-        format: VENDO_STORE_WIRE_FORMAT,
-        minClientVersion: STORE_WIRE_MIN_CLIENT_VERSION,
-        ops: 42,
-        deprecated: STORE_WIRE_DEPRECATED_OPS,
-      };
+      return { format: VENDO_STORE_WIRE_FORMAT, ops: 35 };
     },
   };
 }

--- a/packages/store/tests/ops.test.ts
+++ b/packages/store/tests/ops.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { backends, type MadeBackend } from "../src/backends.test-util.js";
 import { auditFixture } from "../src/fixtures.test-util.js";
 import { createStoreOps } from "../src/index.js";
-import { STORE_WIRE_MIN_CLIENT_VERSION, type StoreOps } from "@vendoai/core";
+import type { StoreOps } from "@vendoai/core";
 
 // The local backend's OWN laws, beyond the shared conformance suite: the F4
 // cascade proven at the rows, and the per-collection policies the routed
@@ -46,10 +46,10 @@ for (const backend of backends()) {
       const { made, ops } = await makeOps();
       try {
         const event = auditFixture("aud_ops_1");
-        await ops.records.put("vendo_audit", { id: event.id, data: event });
-        await expect(ops.records.put("vendo_audit", { id: event.id, data: event }))
+        await ops.engine.put("vendo_audit", { id: event.id, data: event });
+        await expect(ops.engine.put("vendo_audit", { id: event.id, data: event }))
           .rejects.toMatchObject({ code: "conflict" });
-        await expect(ops.records.delete("vendo_audit", event.id))
+        await expect(ops.engine.delete("vendo_audit", event.id))
           .rejects.toMatchObject({ code: "blocked" });
       } finally {
         await made.cleanup();
@@ -60,38 +60,27 @@ for (const backend of backends()) {
       const { made, ops } = await makeOps();
       try {
         const receipt = { subject: "user_fx", outcome: { sent: true } };
-        const first = await ops.records.insertIfAbsent("vendo_effects", { id: "fx_1", data: receipt });
+        const first = await ops.engine.insertIfAbsent("vendo_effects", { id: "fx_1", data: receipt });
         expect(first?.id).toBe("fx_1");
-        expect(await ops.records.insertIfAbsent("vendo_effects", { id: "fx_1", data: { subject: "user_fx", outcome: { sent: false } } })).toBeNull();
+        expect(await ops.engine.insertIfAbsent("vendo_effects", { id: "fx_1", data: { subject: "user_fx", outcome: { sent: false } } })).toBeNull();
         // Even the plain put hands back the RECORDED receipt, never a rewrite.
-        const replayed = await ops.records.put("vendo_effects", { id: "fx_1", data: { subject: "user_fx", outcome: { sent: false } } });
+        const replayed = await ops.engine.put("vendo_effects", { id: "fx_1", data: { subject: "user_fx", outcome: { sent: false } } });
         expect(replayed.data).toMatchObject({ outcome: { sent: true } });
-        await expect(ops.records.compareAndSwap("vendo_effects", { id: "fx_1", data: receipt }, "1"))
+        await expect(ops.engine.compareAndSwap("vendo_effects", { id: "fx_1", data: receipt }, "1"))
           .rejects.toMatchObject({ code: "blocked" });
       } finally {
         await made.cleanup();
       }
     });
 
-    it("status() advertises the records.* retirement while still serving it", async () => {
+    it("status() reports the 35 ops this wire serves", async () => {
       const { made, ops } = await makeOps();
       try {
         const status = await ops.status();
-        expect(status.ops).toBe(42);
-        expect(status.minClientVersion).toBe(STORE_WIRE_MIN_CLIENT_VERSION);
-        expect([...status.deprecated ?? []].sort()).toEqual([
-          "records.claim",
-          "records.compareAndSwap",
-          "records.delete",
-          "records.get",
-          "records.insertIfAbsent",
-          "records.list",
-          "records.put",
-        ]);
-        // Advertised, not enforced: the announcement must not have taken the
-        // door out from under anyone.
-        await ops.records.put("vendo_threads", { id: "thr_dep", data: { subject: "user_dep", messages: [] } });
-        expect((await ops.records.get("vendo_threads", "thr_dep"))?.id).toBe("thr_dep");
+        expect(status.ops).toBe(35);
+        // Nothing left to announce: the handshake carries the format and the
+        // count, and the retired generic family is not advertised as anything.
+        expect(Object.keys(status).sort()).toEqual(["format", "ops"]);
       } finally {
         await made.cleanup();
       }
@@ -100,11 +89,11 @@ for (const backend of backends()) {
     it("subject-guarded upserts refuse a cross-subject flip", async () => {
       const { made, ops } = await makeOps();
       try {
-        await ops.records.put("vendo_threads", {
+        await ops.engine.put("vendo_threads", {
           id: "thr_guard",
           data: { subject: "user_a", messages: [] },
         });
-        await expect(ops.records.put("vendo_threads", {
+        await expect(ops.engine.put("vendo_threads", {
           id: "thr_guard",
           data: { subject: "user_b", messages: [] },
         })).rejects.toMatchObject({ code: "conflict" });

--- a/packages/vendo/src/cli/doctor-probe-checks.ts
+++ b/packages/vendo/src/cli/doctor-probe-checks.ts
@@ -1,7 +1,6 @@
 import { createRequire } from "node:module";
 import { join } from "node:path";
 import { stdin, stdout } from "node:process";
-import { STORE_WIRE_DEPRECATED_REMOVED_IN } from "@vendoai/core";
 import { startDevServerForProbe } from "./doctor-live.js";
 import { CLI_VERSION, askYesNo } from "./shared.js";
 import { probeBody, type DoctorRun } from "./doctor-report.js";
@@ -137,30 +136,6 @@ function checkVersionSkew(run: DoctorRun, wireVersion: string): void {
   }
 }
 
-/** The store wire announces its own retirements on the handshake
- *  (`StoreWireStatus.deprecated`), and a deprecation nobody reads is a
- *  deprecation that becomes an outage. This is ADVERTISEMENT only: every named
- *  op still answers today, so it is a warning and never a failure — doctor is
- *  passing the mount's notice along, not refusing anything. A mount that
- *  announces nothing (older wire, or one that already dropped them) is silent.
- *
- *  The asymmetry below is DELIBERATE, not a gap to close. Two different
- *  documents are both called /status: the store-ops handshake
- *  (`StoreWireStatus`, served by the hosted wire and forwarded by the console,
- *  which spreads it whole) is the one that carries `deprecated`; the
- *  composition /status this function reads (wire/misc.ts) does not, and must
- *  not be taught to. `records.*` is a HOSTED-WIRE concern — a self-hosted
- *  deployment on its own StoreAdapter has no `records.*` wire door to lose, so
- *  there is nothing to warn it about. Reading the field off whatever answered
- *  means the warning reaches exactly the population it concerns and stays quiet
- *  for everyone else. Do not "fix" this by forwarding the field. */
-function checkStoreDeprecations(run: DoctorRun, deprecated: unknown): void {
-  if (!Array.isArray(deprecated)) return;
-  const ops = deprecated.filter((op): op is string => typeof op === "string" && op !== "");
-  if (ops.length === 0) return;
-  run.warn("live/store", "E-LIVE-008", `the store wire still serves ${ops.join(", ")}, but it has deprecated them and removes them in ${STORE_WIRE_DEPRECATED_REMOVED_IN}. Move an app's own rows and files to the appData ops (owner-stamped for you) and Vendo's own collections to the engine ops (same seven verbs, behind an allowlist); calls left on the deprecated ops start failing at that release`);
-}
-
 export interface LiveComposition {
   /** 10-mcp §1 — the door flag lives under blocks.mcp. Since the broker
    *  seam it is a posture ("local" | "broker" | false); older wires still
@@ -192,7 +167,6 @@ export async function checkLiveStatus(run: DoctorRun, e2bResolvable: ((root: str
       : body.blocks.mcp === true || body.blocks.mcp === "local" ? "local"
       : false;
     checkVenue(run, body.blocks.sandbox, e2bResolvable);
-    checkStoreDeprecations(run, body.deprecated);
     return { mcpPosture, live: true };
   } catch {
     run.fail("live/status", "E-LIVE-002", `/status is unreachable at ${statusUrl}/status — doctor expects the WIRE BASE (your app origin plus the mount path, e.g. http://localhost:3000/api/vendo); a bare site origin passed to --url is missing the /api/vendo part`);

--- a/packages/vendo/src/hosted-store.test-util.ts
+++ b/packages/vendo/src/hosted-store.test-util.ts
@@ -3,6 +3,7 @@ import {
   VendoError,
   assertEngineCollection,
   canonicalJson,
+  type AppDataTarget,
   type BlobStore,
   type RecordStore,
   type VendoRecord,
@@ -53,23 +54,28 @@ const STATUS: Record<string, number> = {
   blocked: 403,
   "not-found": 404,
   conflict: 409,
+  "not-implemented": 501,
 };
 const json = (body: unknown, status = 200): Response => Response.json(body, { status });
 const envelope = (code: string, message: string): Response =>
   json({ error: { code, message } }, STATUS[code] ?? 503);
 
-/** The engine door's routes, mount-relative path -> op name, read OFF the wire
- *  contract instead of spelled out here. `engine` is the same seven verbs as
- *  `records` over the same rows, so it reaches the same dispatcher and the same
- *  in-memory state below — a test may write through one door and read back
- *  through the other, which is the only way the two can be caught disagreeing.
- *  Deriving the paths means a verb added to the contract arrives here served,
- *  and a verb renamed there cannot leave this fake answering the old spelling. */
-const ENGINE_ROUTES = new Map<string, string>(
+/** A family's routes, mount-relative path -> verb, read OFF the wire contract
+ *  instead of spelled out here: a verb added to the contract arrives here
+ *  served, and a verb renamed there cannot leave this fake answering the old
+ *  spelling. */
+const routesOf = (family: string): Map<string, string> => new Map(
   Object.entries(STORE_WIRE_PATHS)
-    .filter(([op]) => op.startsWith("engine."))
-    .map(([op, path]) => [path, op.slice("engine.".length)]),
+    .filter(([op]) => op.startsWith(`${family}.`))
+    .map(([op, path]) => [path, op.slice(family.length + 1)]),
 );
+
+const ENGINE_ROUTES = routesOf("engine");
+const APP_DATA_ROUTES = routesOf("appData");
+
+/** The ref key the appData family stamps its owner on, and the one key a caller
+ *  may never supply — packages/store's APP_DATA_OWNER_REF, mirrored. */
+const OWNER_REF = "subject";
 
 const sameValue = (
   current: VendoRecord,
@@ -78,11 +84,9 @@ const sameValue = (
   canonicalJson(current.data) === canonicalJson(expected.data)
   && canonicalJson(current.refs ?? null) === canonicalJson(expected.refs ?? null);
 
-/** The seven records ops, for BOTH records doors: the Store Wire v1 door takes
- *  the op from the path and the collection from the body, the per-collection
- *  legacy door takes the collection from the path and the method from the
- *  trailing segments — same seven operations, two spellings of the two atomic
- *  ones, so one dispatcher answers both and they cannot drift apart. */
+/** The seven collection-addressed ops the engine door serves: the op comes
+ *  from the path, the collection from the body. The two atomic verbs keep their
+ *  second spelling so a body aimed at either name lands on the same row. */
 async function recordsOp(records: RecordStore, op: string, body: Body, miss: Miss): Promise<Response> {
   switch (op) {
     case "get":
@@ -166,38 +170,71 @@ async function blobsWireOp(blobs: BlobStore, op: string, body: Body, miss: Miss)
   }
 }
 
-/** The per-namespace legacy blobs door: REST verbs, bytes raw on the wire, the
- *  key in the trailing path segments. `null` for a verb it does not serve, so
- *  the router reports the hole against the whole request rather than on this
- *  door's behalf. */
-async function blobsRestOp(
-  blobs: BlobStore,
-  request: Request,
-  url: URL,
-  recorded: RecordedRequest,
-  keySegments: string[],
-): Promise<Response | null> {
-  if (keySegments.length === 0 && request.method === "GET") {
-    return json({ keys: await blobs.list(url.searchParams.get("prefix") ?? "") });
+/** Store Wire v1 appData door: an app's own rows and files, addressed by a
+ *  `{appId, collection, owner}` target instead of a collection string. Mirrors
+ *  packages/store's app-data-rows.ts — rows land in `app:<appId>:<collection>`
+ *  with the owner stamped on `refs.subject` (a caller that supplies it is
+ *  refused), reads are scoped to that stamp, and files ride the twin blob
+ *  namespace under an `<owner>/` key prefix. A fake that skipped the stamping
+ *  would let an unscoped read pass here and fail against the console. */
+async function appDataOp(
+  records: (collection: string) => RecordStore,
+  blobStore: (namespace: string) => BlobStore,
+  op: string,
+  body: Body,
+  miss: Miss,
+): Promise<Response> {
+  const target = body.target as AppDataTarget;
+  const scope = `app:${target.appId}:${target.collection}`;
+  const rows = records(scope);
+  const owned = (key: string): string => `${target.owner}/${key}`;
+  const refuseCallerOwner = (refs: Record<string, string> | undefined): void => {
+    if (refs?.[OWNER_REF] !== undefined) {
+      throw new VendoError(
+        "validation",
+        `app data may not supply refs.${OWNER_REF}; the runtime stamps the owner from the host's session`,
+      );
+    }
+  };
+  switch (op) {
+    case "put": {
+      const record = body.record as { id: string; data: unknown; refs?: Record<string, string> };
+      refuseCallerOwner(record.refs);
+      const held = await rows.get(record.id);
+      if (held !== null && held.refs?.[OWNER_REF] !== target.owner) {
+        throw new VendoError("conflict", `app data id ${JSON.stringify(record.id)} is already held in this collection`);
+      }
+      return json({
+        record: await rows.put({ ...record, refs: { ...record.refs, [OWNER_REF]: target.owner } } as never),
+      });
+    }
+    case "get": {
+      const record = await rows.get(body.id as string);
+      return json({ record: record?.refs?.[OWNER_REF] === target.owner ? record : null });
+    }
+    case "list": {
+      const query = (body.query ?? {}) as { refs?: Record<string, string> };
+      refuseCallerOwner(query.refs);
+      return json(await rows.list({ ...query, refs: { ...query.refs, [OWNER_REF]: target.owner } } as never));
+    }
+    case "delete": {
+      const record = await rows.get(body.id as string);
+      if (record?.refs?.[OWNER_REF] === target.owner) await rows.delete(body.id as string);
+      return json({ ok: true });
+    }
+    case "putFile":
+      return blobsWireOp(blobStore(scope), "put", { ...body, key: owned(body.key as string) }, miss);
+    case "getFile":
+      return blobsWireOp(blobStore(scope), "get", { ...body, key: owned(body.key as string) }, miss);
+    case "deleteFile":
+      return blobsWireOp(blobStore(scope), "delete", { ...body, key: owned(body.key as string) }, miss);
+    case "listFiles": {
+      const keys = await blobStore(scope).list(owned((body.prefix as string | undefined) ?? ""));
+      return json({ keys: keys.map((key) => key.slice(target.owner.length + 1)) });
+    }
+    default:
+      return miss(`unknown appData op: ${op}`);
   }
-  const key = keySegments.join("/");
-  if (request.method === "PUT") {
-    const contentType = recorded.contentType ?? undefined;
-    await blobs.put(key, recorded.bytes ?? new Uint8Array(), contentType === undefined ? undefined : { contentType });
-    return json({ ok: true });
-  }
-  if (request.method === "GET") {
-    const blob = await blobs.get(key);
-    if (blob === null) return envelope("not-found", "Blob not found.");
-    return new Response(blob.bytes.slice().buffer as ArrayBuffer, {
-      headers: blob.contentType === undefined ? {} : { "content-type": blob.contentType },
-    });
-  }
-  if (request.method === "DELETE") {
-    await blobs.delete(key);
-    return json({ ok: true });
-  }
-  return null;
 }
 
 /** Everything the handler learns from the request before routing: the recorded
@@ -247,13 +284,21 @@ export function fakeConsole() {
     const body = (recorded.json ?? {}) as Body;
     const post = request.method === "POST";
 
-    // Store Wire v1 records door (STORE_WIRE_PATHS): one route per op, the
-    // collection rides the body. The per-collection legacy door below keeps
-    // serving the StoreAdapter surface over the same in-memory state.
-    if (rest[0] === "records" && rest.length === 2 && post) {
-      return recordsOp(adapter.records(body.collection as string), rest[1]!, body, miss);
+    // The RETIRED generic records family. Every /records/* route — the Store
+    // Wire v1 door and the older per-collection one alike — answers an
+    // ENVELOPED 501 that names the op the caller asked for. There was no
+    // deprecation window, so this refusal is the only notice a caller who wrote
+    // raw HTTP against /records/* ever gets: it must be loud, and it must be
+    // the wire's own voice rather than a hole in this fake.
+    if (rest[0] === "records") {
+      const op = `records.${rest[rest.length - 1]}`;
+      return envelope(
+        "not-implemented",
+        `the store wire no longer serves ${op} — the generic records family was removed.`
+        + " Use the appData ops for an app's own rows and files, or the engine ops for Vendo's own collections.",
+      );
     }
-    // The engine door: Vendo's OWN drawers, same seven verbs over the same rows,
+    // The engine door: Vendo's OWN drawers, seven collection-addressed verbs
     // with the allowlist in front. The gate is served here rather than skipped
     // because a fake that answers a collection the live door refuses lets a
     // wrong call pass every test and fail in production.
@@ -263,15 +308,12 @@ export function fakeConsole() {
       assertEngineCollection(collection);
       return recordsOp(adapter.records(collection), engineOp, body, miss);
     }
+    const appDataOpName = post ? APP_DATA_ROUTES.get(`/${rest.join("/")}`) : undefined;
+    if (appDataOpName !== undefined) {
+      return appDataOp((c) => adapter.records(c), (n) => adapter.blobs(n), appDataOpName, body, miss);
+    }
     if (rest[0] === "blobs" && rest.length === 2 && post) {
       return blobsWireOp(adapter.blobs(body.namespace as string), rest[1]!, body, miss);
-    }
-    if (rest[0] === "records" && post) {
-      return recordsOp(adapter.records(rest[1]!), rest.slice(2).join("/"), body, miss);
-    }
-    if (rest[0] === "blobs") {
-      const served = await blobsRestOp(adapter.blobs(rest[1]!), request, url, recorded, rest.slice(2));
-      if (served !== null) return served;
     }
     if (rest[0] === "erase" && post) {
       eraseCalls.push(recorded.json);

--- a/packages/vendo/src/hosted-store.ts
+++ b/packages/vendo/src/hosted-store.ts
@@ -19,8 +19,7 @@ import {
   type EraseReport,
   type VendoStore,
 } from "@vendoai/store";
-import { consoleSender, raiseCloudError, toArrayBuffer } from "./cloud-console.js";
-import { deploymentIdentityHeaders } from "./deployment-identity.js";
+import { consoleSender, raiseCloudError } from "./cloud-console.js";
 
 /** The console mounts the hosted-store surface here
  * (apps/console/app/api/v1/store/*). */
@@ -37,6 +36,14 @@ export interface HostedStoreOptions {
   baseUrl?: string;
   /** Per-request abort timeout, in milliseconds. */
   timeoutMs?: number;
+  /** Whose drawer the StoreAdapter façade addresses when the collection (or
+   * blob namespace) is app-scoped — `app:<appId>:<name>`, which the appData
+   * family serves, and appData scopes every read and stamps every write with an
+   * owner. Named by a mount that serves more than one user; left unset, it is
+   * the single-player default, exactly as `createStoreOps`' bound workspace
+   * owner is. The op surface (`ops.appData`) is unaffected: every one of its
+   * verbs already carries the owner in its target. */
+  owner?: string;
   fetch?: typeof fetch;
 }
 
@@ -50,9 +57,10 @@ export interface HostedStore extends VendoStore {
     bySubject(subject: string): Promise<EraseReport>;
     byApp(appId: string): Promise<EraseReport>;
   };
-  /** The 42-op named-operation surface over the same mount and the same key —
-   * `vendo/store-wire@1` (see {@link hostedStoreOps}). Additive: the
-   * StoreAdapter doors above are unchanged and keep their own routes. */
+  /** The 35-op named-operation surface over the same mount and the same key —
+   * `vendo/store-wire@1` (see {@link hostedStoreOps}). The StoreAdapter doors
+   * above are built ON these ops: engine for Vendo's own collections, appData
+   * for an app's own drawers. */
   ops: StoreOps;
 }
 
@@ -84,16 +92,18 @@ function parseNullableRecord(value: unknown): VendoRecord | null {
   return parseRecord(value);
 }
 
-/** The console's records door is PER COLLECTION: the collection rides the
- * path, the method is the next segment (`/records/{collection}/put`). */
-const recordsPath = (collection: string): string => `/records/${encodeURIComponent(collection)}`;
+/** `app:<appId>:<collection>` is the app-scoped spelling of a record collection
+ * and of a blob namespace alike (01-core §12). Split back into the appData
+ * target it addresses, or undefined for a name that is not app-scoped. The
+ * appId segment is colon-free by construction, so the FIRST colon after the
+ * prefix ends it and everything after is the collection (`box:`-prefixed names
+ * keep their own colon). */
+const APP_SCOPE = /^app:([^:]+):(.+)$/;
 
-const blobsPath = (namespace: string): string => `/blobs/${encodeURIComponent(namespace)}`;
-
-/** Blob keys are paths ("images/a.png"); encode per segment so the key's own
- * separators survive as URL structure while each segment stays safe. */
-const blobKeyPath = (namespace: string, key: string): string =>
-  `${blobsPath(namespace)}/${key.split("/").map(encodeURIComponent).join("/")}`;
+const appScope = (scope: string): { appId: string; collection: string } | undefined => {
+  const match = APP_SCOPE.exec(scope);
+  return match === null ? undefined : { appId: match[1]!, collection: match[2]! };
+};
 
 /** The Cloud hosted-store adapter — the OSS side of the hosted-store seam
  * (docs/superpowers/specs/2026-07-18-hosted-store-onepager.md): a plain
@@ -133,33 +143,39 @@ export function hostedStore(options: HostedStoreOptions): HostedStore {
   };
   const sendJson = postJson(send);
 
+  // The StoreAdapter façade rides the SAME 35 ops as `ops` below — it has no
+  // doors of its own since the generic records family left the wire. A
+  // collection (or blob namespace) either names an app's own drawer, which the
+  // appData family serves with the owner stamped on, or it names one of Vendo's
+  // own, which the engine family serves behind its allowlist. There is no third
+  // home, so a host collection the allowlist does not know is refused by the
+  // service rather than quietly written somewhere. It reads a failure the way
+  // this adapter always has (raiseStoreError), not the way the protocol client
+  // does — see storeWireClient.
+  const facade = storeWireClient(options, raiseStoreError);
+  const owner = options.owner ?? "user_local";
+  const targetFor = (scope: { appId: string; collection: string }) => ({ ...scope, owner });
+
   const records = (collection: string): RecordStore => {
-    const prefix = recordsPath(collection);
+    const scope = appScope(collection);
+    if (scope !== undefined) {
+      const target = targetFor(scope);
+      // No claim and no atomic: the appData family has no compare-and-set verbs
+      // on the wire, and an adapter that advertises a capability it cannot
+      // serve is worse than one that omits it (01-core §12 makes both optional).
+      return {
+        get: (id) => facade.appData.get(target, id),
+        put: (record) => facade.appData.put(target, record),
+        delete: (id) => facade.appData.delete(target, id),
+        list: (query?: RecordQuery) => facade.appData.list(target, query),
+      };
+    }
+
     const store: RecordStore = {
-      async get(id) {
-        const payload = await sendJson(`${prefix}/get`, { id }) as { record?: unknown };
-        if (payload.record === undefined) invalidResponse("invalid record");
-        return parseNullableRecord(payload.record);
-      },
-      async put(record) {
-        const payload = await sendJson(`${prefix}/put`, { record }) as { record?: unknown };
-        if (payload.record === undefined || payload.record === null) invalidResponse("invalid record");
-        return parseRecord(payload.record);
-      },
-      async delete(id) {
-        await sendJson(`${prefix}/delete`, { id });
-      },
-      async list(query?: RecordQuery) {
-        const payload = await sendJson(
-          `${prefix}/list`,
-          { query: query ?? {} },
-        ) as { records?: unknown; cursor?: unknown };
-        if (!Array.isArray(payload.records)) invalidResponse("invalid list");
-        return {
-          records: (payload.records as unknown[]).map(parseRecord),
-          ...(typeof payload.cursor === "string" ? { cursor: payload.cursor } : {}),
-        };
-      },
+      get: (id) => facade.engine.get(collection, id),
+      put: (record) => facade.engine.put(collection, record),
+      delete: (id) => facade.engine.delete(collection, id),
+      list: (query?: RecordQuery) => facade.engine.list(collection, query),
     };
 
     // Capability mirror of the store engine's routing (02-store §2): routed
@@ -170,99 +186,34 @@ export function hostedStore(options: HostedStoreOptions): HostedStore {
     const reserved = (RESERVED_COLLECTIONS as readonly string[]).includes(collection);
     const dedicated = (DEDICATED_RECORD_COLLECTIONS as readonly string[]).includes(collection);
     if (!reserved) {
-      store.claim = async (expected: RecordInput, replacement?: Pick<VendoRecord, "data" | "refs">) => {
-        const payload = await sendJson(`${prefix}/claim`, {
-          expected,
-          ...(replacement === undefined ? {} : { replacement }),
-        }) as { claimed?: unknown };
-        if (typeof payload.claimed !== "boolean") invalidResponse("invalid claim");
-        return payload.claimed as boolean;
-      };
+      store.claim = (expected: RecordInput, replacement?: Pick<VendoRecord, "data" | "refs">) =>
+        facade.engine.claim(collection, expected, replacement);
     }
     if ((!reserved && !dedicated) || collection === "vendo_threads") {
       store.atomic = {
-        async insertIfAbsent(record) {
-          const payload = await sendJson(`${prefix}/atomic/insert-if-absent`, { record }) as { record?: unknown };
-          if (payload.record === undefined) invalidResponse("invalid record");
-          return parseNullableRecord(payload.record);
-        },
-        async compareAndSwap(record, expectedRevision) {
-          const payload = await sendJson(`${prefix}/atomic/compare-and-swap`, {
-            record,
-            expectedRevision,
-          }) as { record?: unknown };
-          if (payload.record === undefined) invalidResponse("invalid record");
-          return parseNullableRecord(payload.record);
-        },
+        insertIfAbsent: (record) => facade.engine.insertIfAbsent(collection, record),
+        compareAndSwap: (record, expectedRevision) => facade.engine.compareAndSwap(collection, record, expectedRevision),
       };
     }
     return store;
   };
 
   const blobs = (namespace: string): BlobStore => {
-    const prefix = blobsPath(namespace);
-    const keyPath = (key: string): string => blobKeyPath(namespace, key);
+    const scope = appScope(namespace);
+    if (scope !== undefined) {
+      const target = targetFor(scope);
+      return {
+        put: (key, bytes, meta) => facade.appData.putFile(target, key, bytes, meta),
+        get: (key) => facade.appData.getFile(target, key),
+        delete: (key) => facade.appData.deleteFile(target, key),
+        list: (prefix) => facade.appData.listFiles(target, prefix),
+      };
+    }
     return {
-      async put(key, bytes, meta) {
-        await send(keyPath(key), {
-          method: "PUT",
-          ...(meta?.contentType === undefined ? {} : { headers: { "content-type": meta.contentType } }),
-          body: toArrayBuffer(bytes),
-        });
-      },
-      async get(key) {
-        const response = await fetchImpl(`${base}${CONSOLE_STORE_PATH}${keyPath(key)}`, {
-          headers: {
-            authorization: `Bearer ${options.apiKey}`,
-            ...(await deploymentIdentityHeaders()),
-          },
-          signal: AbortSignal.timeout(timeoutMs),
-        });
-        // A missing blob is null at the seam (01-core §12) — but ONLY the
-        // console's enveloped not-found says "missing blob". A bare 404 (no
-        // envelope) is some other server answering — a misdeployed base URL
-        // must fail loudly, not read as an empty blob store forever.
-        if (response.status === 404) {
-          let payload: unknown;
-          try {
-            payload = JSON.parse(await response.text());
-          } catch {
-            payload = undefined;
-          }
-          const code = typeof payload === "object" && payload !== null && "error" in payload
-            ? (payload as { error?: { code?: unknown } }).error?.code
-            : undefined;
-          if (code === "not-found") return null;
-          throw new Error(
-            "Vendo Cloud store request failed with a bare 404 (no error envelope) — is the base URL a Vendo console?",
-          );
-        }
-        if (!response.ok) await raiseStoreError(response);
-        const contentType = response.headers.get("content-type");
-        return {
-          bytes: new Uint8Array(await response.arrayBuffer()),
-          ...(contentType === null ? {} : { contentType }),
-        };
-      },
-      async delete(key) {
-        await send(keyPath(key), { method: "DELETE" });
-      },
-      async list(prefixFilter?: string) {
-        const query = prefixFilter === undefined || prefixFilter === ""
-          ? ""
-          : `?prefix=${encodeURIComponent(prefixFilter)}`;
-        const response = await send(`${prefix}${query}`);
-        let payload: { keys?: unknown };
-        try {
-          payload = await response.json() as { keys?: unknown };
-        } catch {
-          payload = {};
-        }
-        if (!Array.isArray(payload.keys) || !payload.keys.every((key) => typeof key === "string")) {
-          invalidResponse("invalid blob list");
-        }
-        return payload.keys as string[];
-      },
+      put: (key, bytes, meta) => facade.blobs.put(namespace, key, bytes, meta),
+      get: (key) => facade.blobs.get(namespace, key),
+      delete: (key) => facade.blobs.delete(namespace, key),
+      list: (prefix) => facade.blobs.list(namespace, prefix),
     };
   };
 
@@ -306,10 +257,10 @@ export function hostedStore(options: HostedStoreOptions): HostedStore {
 }
 
 // ---------------------------------------------------------------------------
-// The 42-op StoreOps client — store design v1, `vendo/store-wire@1`
+// The 35-op StoreOps client — store design v1, `vendo/store-wire@1`
 // ---------------------------------------------------------------------------
 
-/** The 42 named ops — STORE_WIRE_PATHS' keys ARE the op names, and stay the
+/** The 35 named ops — STORE_WIRE_PATHS' keys ARE the op names, and stay the
  * op names even where the console's door sits at a different path. */
 type StoreWireOp = keyof typeof STORE_WIRE_PATHS;
 
@@ -348,22 +299,37 @@ const raiseWireError = async (response: Response): Promise<never> => {
 };
 
 /**
- * The Cloud client for the whole 42-op store contract, speaking
+ * The Cloud client for the whole 35-op store contract, speaking
  * `vendo/store-wire@1` over the console's store mount: bearer key, deployment
  * identity and per-request abort budget shared with {@link hostedStore}, the
  * same adapter rule (behavior comes ONLY from the constructor arguments),
  * cursors passed through untouched (the server paginates, never the client),
  * and ONE Idempotency-Key per logical mutation, replayed verbatim on a retry.
  *
- * Records and blobs speak the EXPORTED contract: STORE_WIRE_PATHS routes with
- * the storeWire*RequestSchema bodies — collection/namespace/key ride the JSON
- * body and blob bytes are base64 on the wire — so any conforming Store Wire v1
+ * Every family speaks the EXPORTED contract: STORE_WIRE_PATHS routes with the
+ * storeWire*RequestSchema bodies — collection/namespace/key ride the JSON body
+ * and blob bytes are base64 on the wire — so any conforming Store Wire v1
  * service (the console's wire mount, a BYO httpStore) accepts them verbatim.
  * Transcripts, harness, workspace, `lifecycle.promote` and `/status` answer at
  * their STORE_WIRE_PATHS path too; erase keeps `/erase` — T5's own note: it
  * "keeps its existing door until the cloud client moves it".
  */
 export function hostedStoreOps(options: HostedStoreOptions): StoreOps {
+  return storeWireClient(options, raiseWireError);
+}
+
+/** The client above, with the error mapping left to the caller. The two
+ * surfaces over this ONE wire read a failure differently and always have: the
+ * op surface is the PROTOCOL's client, so it reads the protocol's own envelope
+ * ({@link parseStoreWireError}); the StoreAdapter façade is the CONSOLE's
+ * client, so it keeps the console's mapping — the 402 meter refusal's crafted
+ * dollar sentence and the 401 key story are console answers no BYO mount
+ * sends. Same routes, same bodies, same key; only the reading of a non-2xx
+ * differs, exactly as it did when the façade had doors of its own. */
+function storeWireClient(
+  options: HostedStoreOptions,
+  raise: (response: Response) => Promise<never>,
+): StoreOps {
   const base = (options.baseUrl ?? "https://console.vendo.run").replace(/\/$/, "");
   const send = consoleSender({
     base,
@@ -371,7 +337,7 @@ export function hostedStoreOps(options: HostedStoreOptions): StoreOps {
     apiKey: options.apiKey,
     timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
     fetchImpl: options.fetch ?? defaultFetch,
-    raise: raiseWireError,
+    raise,
   });
 
   const call = async (op: StoreWireOp, path: string, init?: RequestInit): Promise<Response> => {
@@ -484,44 +450,8 @@ export function hostedStoreOps(options: HostedStoreOptions): StoreOps {
   const P = STORE_WIRE_PATHS;
 
   return {
-    records: {
-      async get(collection, id) {
-        return nullableRecordOf(await post("records.get", P["records.get"], { collection, id }));
-      },
-      async put(collection, record) {
-        return recordOf(await mutate("records.put", P["records.put"], { collection, record }));
-      },
-      async delete(collection, id) {
-        await mutate("records.delete", P["records.delete"], { collection, id });
-      },
-      async list(collection, query) {
-        return listOf(await post("records.list", P["records.list"], { collection, query: query ?? {} }));
-      },
-      async claim(collection, expected, replacement) {
-        return claimedOf(await mutate("records.claim", P["records.claim"], {
-          collection,
-          expected,
-          ...(replacement === undefined ? {} : { replacement }),
-        }));
-      },
-      async insertIfAbsent(collection, record) {
-        return nullableRecordOf(
-          await mutate("records.insertIfAbsent", P["records.insertIfAbsent"], { collection, record }),
-        );
-      },
-      async compareAndSwap(collection, record, expectedRevision) {
-        return nullableRecordOf(
-          await mutate("records.compareAndSwap", P["records.compareAndSwap"], {
-            collection,
-            record,
-            expectedRevision,
-          }),
-        );
-      },
-    },
-    // Vendo's OWN engine drawers, over the same collection-addressed bodies as
-    // `records` — a separate door so the service can gate the collection name
-    // (the allowlist) without gating the host's own `records` traffic.
+    // Vendo's OWN engine drawers, over collection-addressed bodies, with the
+    // allowlist gated service-side on every verb.
     engine: {
       async get(collection, id) {
         return nullableRecordOf(await post("engine.get", P["engine.get"], { collection, id }));

--- a/packages/vendo/src/hosted-store.ts
+++ b/packages/vendo/src/hosted-store.ts
@@ -39,10 +39,25 @@ export interface HostedStoreOptions {
   /** Whose drawer the StoreAdapter façade addresses when the collection (or
    * blob namespace) is app-scoped — `app:<appId>:<name>`, which the appData
    * family serves, and appData scopes every read and stamps every write with an
-   * owner. Named by a mount that serves more than one user; left unset, it is
-   * the single-player default, exactly as `createStoreOps`' bound workspace
-   * owner is. The op surface (`ops.appData`) is unaffected: every one of its
-   * verbs already carries the owner in its target. */
+   * owner. The op surface (`ops.appData`) is unaffected: every one of its verbs
+   * already carries the owner in its target.
+   *
+   * This option exists because the façade's signature has nowhere to put one:
+   * `records(collection)` takes a string, and the caller never had to think
+   * about ownership while the generic records family served these rows
+   * unscoped. It cannot be inferred — an owner is the host's own user id in the
+   * host's own spelling — so it is bound here, once, exactly as
+   * `createStoreOps`' `workspaceOwner` binds the workspace drawer.
+   *
+   * READ THIS BEFORE LEAVING IT UNSET. The default is the single-player
+   * `"user_local"`, and it is a real footgun for anyone else: a host that
+   * serves MORE THAN ONE end user through one `hostedStore` instance and takes
+   * the default puts every user's app rows and files in ONE owner's drawer,
+   * where they read each other's data. Nothing refuses it — `"user_local"` is a
+   * legal owner — so the symptom is cross-user reads in production, not an
+   * error at composition. A multi-user mount constructs one `hostedStore` per
+   * end user with that user's subject here, or stays on `ops.appData`, whose
+   * every verb names its owner at the call. */
   owner?: string;
   fetch?: typeof fetch;
 }

--- a/packages/vendo/tests/app-access-door.test.ts
+++ b/packages/vendo/tests/app-access-door.test.ts
@@ -51,9 +51,16 @@ const hosted = () => {
   return { console_, store };
 };
 
+/** Grant writes ride the ENGINE door now — `vendo_app_grants` is one of Vendo's
+ *  own collections, and since the generic records family left the wire the
+ *  collection rides the BODY instead of the path. Matching on the path alone
+ *  would silently match nothing and make the refusal case below pass no matter
+ *  what was written, so the collection is part of the predicate. */
 const grantPuts = (console_: ReturnType<typeof fakeConsole>): unknown[] =>
   console_.requests
-    .filter((entry) => entry.url.endsWith("/records/vendo_app_grants/put"))
+    .filter((entry) =>
+      entry.url.endsWith("/engine/put")
+      && (entry.json as { collection?: string } | undefined)?.collection === "vendo_app_grants")
     .map((entry) => entry.json);
 
 describe("§9.2 — an unparseable principal is refused on the HOSTED store too", () => {

--- a/packages/vendo/tests/cli/cloud/host-components.test.ts
+++ b/packages/vendo/tests/cli/cloud/host-components.test.ts
@@ -68,20 +68,14 @@ const remoteRow = (id: string, data?: unknown): [string, unknown] => [id, data !
 const VERBS = ["list", "put", "delete"] as const;
 
 /**
- * Which record verb a request is, across BOTH spellings of the door.
- *
- * The façade (`store.records(collection)`) addresses a per-collection path,
- * `/records/<collection>/<verb>`; the named-operation surface (`ops.engine.*`)
- * addresses the verb and carries the collection in the body. The engine routes
- * are read off `STORE_WIRE_PATHS` rather than written out here, so this double
- * cannot drift from the contract the client actually routes by — the literal 42
- * paths stay pinned in `packages/core/tests/store-wire.test.ts`, which is where
- * a path belongs. The per-collection door has no entry in that map (it is not
- * part of the wire contract), so it stays spelled out.
+ * Which engine verb a request is. The named-operation surface (`ops.engine.*`)
+ * addresses the verb and carries the collection in the body; the routes are read
+ * off `STORE_WIRE_PATHS` rather than written out here, so this cannot drift from
+ * the contract the client actually routes by — the literal 35 paths stay pinned
+ * in `packages/core/tests/store-wire.test.ts`, which is where a path belongs.
  */
-function recordVerb(pathname: string, body: { collection?: string }): typeof VERBS[number] | undefined {
+function engineVerb(pathname: string, body: { collection?: string }): typeof VERBS[number] | undefined {
   for (const verb of VERBS) {
-    if (pathname.endsWith(`/records/${HOST_COMPONENTS_COLLECTION}/${verb}`)) return verb;
     if (pathname.endsWith(STORE_WIRE_PATHS[`engine.${verb}`]) && body.collection === HOST_COMPONENTS_COLLECTION) {
       return verb;
     }
@@ -99,18 +93,14 @@ function fakeCloud(seed: { blobs?: string[]; records?: Array<[string, unknown]> 
     const method = init?.method ?? "GET";
     calls.push(`${method} ${url.pathname}${url.search}`);
     const json = (body: unknown) => new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } });
-    if (url.pathname.endsWith("/blobs/vendo_host_components")) return json({ keys: [...blobs] });
-    const blob = /\/blobs\/vendo_host_components\/([0-9a-f]{64})$/u.exec(url.pathname);
-    if (blob !== null) {
-      if (method === "PUT") blobs.add(blob[1]!);
-      if (method === "DELETE") blobs.delete(blob[1]!);
-      return json({});
-    }
-    // Past the blob branches every remaining body is the door's JSON.
     const body = (init?.body === undefined || init.body === null
       ? {}
-      : JSON.parse(String(init.body))) as { collection?: string; record?: { id: string; data: unknown }; id?: string };
-    switch (recordVerb(url.pathname, body)) {
+      : JSON.parse(String(init.body))) as { collection?: string; namespace?: string; key?: string; record?: { id: string; data: unknown }; id?: string };
+    // The blobs family: namespace + key ride the JSON body; list is keys-only.
+    if (url.pathname.endsWith(STORE_WIRE_PATHS["blobs.list"])) return json({ keys: [...blobs] });
+    if (url.pathname.endsWith(STORE_WIRE_PATHS["blobs.put"])) { blobs.add(body.key!); return json({}); }
+    if (url.pathname.endsWith(STORE_WIRE_PATHS["blobs.delete"])) { blobs.delete(body.key!); return json({}); }
+    switch (engineVerb(url.pathname, body)) {
       case "list":
         return json({
           records: [...records].map(([id, data]) => ({
@@ -200,7 +190,7 @@ describe("host component push", () => {
     // The whole round trip: list the blob KEYS, list the (source-free) index.
     // No module body is ever downloaded to decide what changed.
     expect(cloud.calls).toEqual([
-      "GET /api/v1/store/blobs/vendo_host_components",
+      `POST /api/v1/store${STORE_WIRE_PATHS["blobs.list"]}`,
       `POST /api/v1/store${STORE_WIRE_PATHS["engine.list"]}`,
     ]);
   });

--- a/packages/vendo/tests/cli/doctor.test.ts
+++ b/packages/vendo/tests/cli/doctor.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { STORE_WIRE_DEPRECATED_REMOVED_IN, type ActAs, type PermissionGrant, type Principal } from "@vendoai/core";
+import type { ActAs, PermissionGrant, Principal } from "@vendoai/core";
 import { memoryStoreAdapter } from "@vendoai/core/conformance";
 import { extractServerActions } from "@vendoai/actions/sync";
 import type { VendoStore } from "@vendoai/store";
@@ -625,7 +625,10 @@ describe("vendo doctor", () => {
     );
   });
 
-  it("warns, without failing, when /status advertises deprecated store ops", async () => {
+  it("says nothing about store-op deprecations, even against a mount that still advertises them", async () => {
+    // The generic records family is gone, so there is no deprecation window
+    // left to narrate. An older mount still sending `deprecated` on its
+    // handshake is read and ignored, never echoed as a warning.
     const messages = output();
     const fetchImpl = vi.fn(async (input: string | URL | Request) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
@@ -648,19 +651,7 @@ describe("vendo doctor", () => {
       output: messages.sink,
       telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
     })).toBe(0);
-    expect(messages.errors).toContain(
-      `warning: the store wire still serves records.get, records.put, but it has deprecated them and removes them in ${STORE_WIRE_DEPRECATED_REMOVED_IN}. Move an app's own rows and files to the appData ops (owner-stamped for you) and Vendo's own collections to the engine ops (same seven verbs, behind an allowlist); calls left on the deprecated ops start failing at that release`,
-    );
-  });
-
-  it("says nothing about deprecations when /status advertises none", async () => {
-    const messages = output();
-    expect(await doctor({
-      targetDir: await healthy(),
-      fetchImpl: successfulProbeFetch({ store: true, sandbox: "cloud" }),
-      output: messages.sink,
-      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
-    })).toBe(0);
+    expect(messages.errors.some((line) => line.includes("E-LIVE-008"))).toBe(false);
     expect(messages.errors.some((line) => line.includes("has deprecated them"))).toBe(false);
   });
 

--- a/packages/vendo/tests/hosted-store.test.ts
+++ b/packages/vendo/tests/hosted-store.test.ts
@@ -5,6 +5,8 @@ import { describe, expect, it, vi } from "vitest";
 import {
   STORE_WIRE_PATHS,
   VendoError,
+  engineAppHistory,
+  parseStoreWireError,
   storeWireAppDataDeleteFileRequestSchema,
   storeWireAppDataDeleteRequestSchema,
   storeWireAppDataGetFileRequestSchema,
@@ -24,13 +26,6 @@ import {
   storeWireCollectionInsertIfAbsentRequestSchema,
   storeWireCollectionListRequestSchema,
   storeWireCollectionPutRequestSchema,
-  storeWireRecordsClaimRequestSchema,
-  storeWireRecordsCompareAndSwapRequestSchema,
-  storeWireRecordsDeleteRequestSchema,
-  storeWireRecordsGetRequestSchema,
-  storeWireRecordsInsertIfAbsentRequestSchema,
-  storeWireRecordsListRequestSchema,
-  storeWireRecordsPutRequestSchema,
   type StoreAdapter,
 } from "@vendoai/core";
 import { storeAdapterConformance } from "@vendoai/core/conformance";
@@ -49,77 +44,176 @@ const hosted = (console_: ReturnType<typeof fakeConsole>) => hostedStore({
 describe("hostedStore conformance", () => {
   // The EXISTING StoreAdapter conformance suite (01-core §12 / 02-store §4),
   // run over the full HTTP round-trip against the in-memory console fake.
+  //
+  // The suite's own collection names are host-flavoured ("conformance_put"),
+  // and since the generic records family left the wire there is no door on the
+  // hosted mount that takes a name like that: every non-app-scoped collection
+  // now rides the engine family, whose allowlist the console enforces. So each
+  // case gets its own drawer under the ONE dynamic engine name
+  // (`vendo:app-history:<id>`) — the suite's assertions are untouched, the
+  // adapter under test is the real façade, and the allowlist stays a real gate
+  // instead of one this test asks the fake to drop.
+  const engineNamed = (adapter: StoreAdapter): StoreAdapter => ({
+    records: (collection) => adapter.records(engineAppHistory(collection)),
+    blobs: (namespace) => adapter.blobs(namespace),
+    ensureSchema: () => adapter.ensureSchema(),
+  });
   const suite = storeAdapterConformance({
     async makeAdapter() {
-      return { adapter: hosted(fakeConsole()) as StoreAdapter };
+      return { adapter: engineNamed(hosted(fakeConsole()) as StoreAdapter) };
     },
   });
   for (const c of suite.cases) it(c.name, c.run);
 });
 
-describe("hostedStore wire", () => {
-  it("speaks the console record wire shapes exactly, with key + deployment identity on every request", async () => {
+describe("hostedStore façade routing — the two homes a collection can have", () => {
+  it("an engine collection rides the engine door, over the collection-addressed body", async () => {
     const console_ = fakeConsole();
     const store = hosted(console_);
-    const records = store.records("invoices");
+    const apps = store.records("vendo_apps");
 
-    const put = await records.put({ id: "inv_1", data: { total: 5 }, refs: { owner: "user_a" } });
-    expect(put).toMatchObject({ id: "inv_1", data: { total: 5 }, refs: { owner: "user_a" } });
+    const doc = { format: "vendo/app@1", id: "app_1", name: "App" };
+    await apps.put({ id: "app_1", data: { subject: "user_1", enabled: true, doc } });
     expect(console_.requests[0]).toMatchObject({
       method: "POST",
-      url: "https://cloud.test/api/v1/store/records/invoices/put",
-      contentType: "application/json",
-      json: { record: { id: "inv_1", data: { total: 5 }, refs: { owner: "user_a" } } },
+      url: "https://cloud.test/api/v1/store/engine/put",
+      json: { collection: "vendo_apps", record: { id: "app_1" } },
     });
-
-    expect(await records.get("inv_1")).toEqual(put);
+    expect((await apps.get("app_1"))?.id).toBe("app_1");
     expect(console_.requests[1]).toMatchObject({
-      url: "https://cloud.test/api/v1/store/records/invoices/get",
-      json: { id: "inv_1" },
+      url: "https://cloud.test/api/v1/store/engine/get",
+      json: { collection: "vendo_apps", id: "app_1" },
     });
-    expect(await records.get("missing")).toBeNull();
+  });
 
-    const listed = await records.list({ refs: { owner: "user_a" }, limit: 10 });
-    expect(listed.records.map((record) => record.id)).toEqual(["inv_1"]);
+  it("an app-scoped collection rides the appData door, with the owner stamped on", async () => {
+    const console_ = fakeConsole();
+    const store = hostedStore({
+      apiKey: "vnd_secret",
+      baseUrl: "https://cloud.test",
+      owner: "user_1",
+      fetch: console_.handler as unknown as typeof fetch,
+    });
+    const notes = store.records("app:x:notes");
+
+    const put = await notes.put({ id: "n_1", data: { text: "hi" } });
+    expect(console_.requests[0]).toMatchObject({
+      method: "POST",
+      url: "https://cloud.test/api/v1/store/app-data/put",
+      json: { target: { appId: "x", collection: "notes", owner: "user_1" }, record: { id: "n_1" } },
+    });
+    // The owner is the RUNTIME's stamp, not something the caller named.
+    expect(put.refs).toMatchObject({ subject: "user_1" });
+    expect((await notes.get("n_1"))?.data).toEqual({ text: "hi" });
+    expect((await notes.list()).records.map((record) => record.id)).toEqual(["n_1"]);
+
+    // Another owner's façade cannot see the row — the appData scoping the
+    // generic records door never had.
+    const other = hostedStore({
+      apiKey: "vnd_secret",
+      baseUrl: "https://cloud.test",
+      owner: "user_2",
+      fetch: console_.handler as unknown as typeof fetch,
+    });
+    expect(await other.records("app:x:notes").get("n_1")).toBeNull();
+
+    // appData has no compare-and-set verbs on the wire, so the façade does not
+    // pretend to offer them.
+    expect(notes.claim).toBeUndefined();
+    expect(notes.atomic).toBeUndefined();
+  });
+
+  it("a retired /records/* path answers an enveloped 501 naming the op", async () => {
+    const console_ = fakeConsole();
+    const response = await console_.handler("https://cloud.test/api/v1/store/records/put", {
+      method: "POST",
+      headers: { authorization: "Bearer vnd_secret", "content-type": "application/json" },
+      body: JSON.stringify({ collection: "invoices", record: { id: "inv_1", data: {} } }),
+    });
+    expect(response.status).toBe(501);
+    const body = await response.json() as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("not-implemented");
+    expect(body.error.message).toContain("records.put");
+    // The client half reads that envelope back as the wire's own refusal.
+    expect(parseStoreWireError(response.status, body)).toMatchObject({ code: "not-implemented" });
+  });
+});
+
+describe("hostedStore wire", () => {
+  it("speaks the engine door's wire shapes exactly, with key + deployment identity on every request", async () => {
+    const console_ = fakeConsole();
+    const store = hosted(console_);
+    const runs = store.records("vendo_runs");
+
+    const run = {
+      appId: "app_1",
+      trigger: { kind: "schedule" },
+      status: "ok",
+      record: { steps: 1 },
+      startedAt: "2026-01-01T00:00:00.000Z",
+      finishedAt: "2026-01-01T00:00:01.000Z",
+    };
+    const put = await runs.put({ id: "run_1", data: run });
+    expect(put).toMatchObject({ id: "run_1" });
+    expect(console_.requests[0]).toMatchObject({
+      method: "POST",
+      url: "https://cloud.test/api/v1/store/engine/put",
+      contentType: "application/json",
+      json: { collection: "vendo_runs", record: { id: "run_1", data: run } },
+    });
+
+    expect(await runs.get("run_1")).toEqual(put);
+    expect(console_.requests[1]).toMatchObject({
+      url: "https://cloud.test/api/v1/store/engine/get",
+      json: { collection: "vendo_runs", id: "run_1" },
+    });
+    expect(await runs.get("missing")).toBeNull();
+
+    const listed = await runs.list({ refs: { app_id: "app_1" }, limit: 10 });
+    expect(listed.records.map((record) => record.id)).toEqual(["run_1"]);
     expect(console_.requests[3]).toMatchObject({
-      url: "https://cloud.test/api/v1/store/records/invoices/list",
-      json: { query: { refs: { owner: "user_a" }, limit: 10 } },
+      url: "https://cloud.test/api/v1/store/engine/list",
+      json: { collection: "vendo_runs", query: { refs: { app_id: "app_1" }, limit: 10 } },
     });
 
-    // claim: present on non-reserved collections, absent on routed ones.
+    // The capability mirror is UNCHANGED by the move onto the engine door:
+    // claim is absent on routed reserved collections, atomic rides generic
+    // collections and vendo_threads' revision counter only. mcp and knowledge
+    // feature-detect on exactly this shape.
     expect(store.records("vendo_apps").claim).toBeUndefined();
-    expect(records.claim).toBeDefined();
-    await expect(records.claim!({ id: "inv_1", data: { total: 5 }, refs: { owner: "user_a" } })).resolves.toBe(true);
-    expect(console_.requests[4]).toMatchObject({
-      url: "https://cloud.test/api/v1/store/records/invoices/claim",
-      json: { expected: { id: "inv_1", data: { total: 5 }, refs: { owner: "user_a" } } },
-    });
-    expect(await records.get("inv_1")).toBeNull();
-
-    // atomic: generic collections and vendo_threads carry it; other routed
-    // collections and the dedicated door tables do not (engine mirror).
     expect(store.records("vendo_threads").atomic).toBeDefined();
     expect(store.records("vendo_apps").atomic).toBeUndefined();
     expect(store.records("vendo_mcp_clients").atomic).toBeUndefined();
     expect(store.records("vendo_mcp_clients").claim).toBeDefined();
-    const inserted = await records.atomic!.insertIfAbsent({ id: "inv_2", data: { total: 7 } });
+
+    const slots = store.records("vendo_placement_slots");
+    await slots.put({ id: "slot_1", data: { holder: null } });
+    await expect(slots.claim!({ id: "slot_1", data: { holder: null } }, { data: { holder: "run_1" } }))
+      .resolves.toBe(true);
+    expect(console_.requests.at(-1)).toMatchObject({
+      url: "https://cloud.test/api/v1/store/engine/claim",
+      json: { collection: "vendo_placement_slots", expected: { id: "slot_1", data: { holder: null } } },
+    });
+
+    const history = store.records(engineAppHistory("app_1"));
+    const inserted = await history.atomic!.insertIfAbsent({ id: "ver_1", data: { version: 1 } });
     expect(inserted?.revision).toBe("1");
     expect(console_.requests.at(-1)).toMatchObject({
-      url: "https://cloud.test/api/v1/store/records/invoices/atomic/insert-if-absent",
-      json: { record: { id: "inv_2", data: { total: 7 } } },
+      url: "https://cloud.test/api/v1/store/engine/insertIfAbsent",
+      json: { collection: "vendo:app-history:app_1", record: { id: "ver_1", data: { version: 1 } } },
     });
-    const swapped = await records.atomic!.compareAndSwap({ id: "inv_2", data: { total: 8 } }, "1");
+    const swapped = await history.atomic!.compareAndSwap({ id: "ver_1", data: { version: 2 } }, "1");
     expect(swapped?.revision).toBe("2");
     expect(console_.requests.at(-1)).toMatchObject({
-      url: "https://cloud.test/api/v1/store/records/invoices/atomic/compare-and-swap",
-      json: { record: { id: "inv_2", data: { total: 8 } }, expectedRevision: "1" },
+      url: "https://cloud.test/api/v1/store/engine/compareAndSwap",
+      json: { collection: "vendo:app-history:app_1", expectedRevision: "1" },
     });
-    await expect(records.atomic!.compareAndSwap({ id: "inv_2", data: { total: 9 } }, "1")).resolves.toBeNull();
+    await expect(history.atomic!.compareAndSwap({ id: "ver_1", data: { version: 3 } }, "1")).resolves.toBeNull();
 
-    await records.delete("inv_2");
+    await history.delete("ver_1");
     expect(console_.requests.at(-1)).toMatchObject({
-      url: "https://cloud.test/api/v1/store/records/invoices/delete",
-      json: { id: "inv_2" },
+      url: "https://cloud.test/api/v1/store/engine/delete",
+      json: { collection: "vendo:app-history:app_1", id: "ver_1" },
     });
 
     for (const request of console_.requests) {
@@ -131,17 +225,29 @@ describe("hostedStore wire", () => {
     }
   });
 
-  it("speaks the blob wire: raw bytes through the API, per-segment key encoding, prefix list, 404 → null", async () => {
+  it("a collection the allowlist does not know is refused by the service, not written somewhere", async () => {
+    // The one behavior change the removal makes visible at the façade: a host's
+    // own collection has no home on the hosted mount any more.
+    const store = hosted(fakeConsole());
+    await expect(store.records("host_invoices").put({ id: "inv_1", data: {} }))
+      .rejects.toMatchObject({ code: "blocked" });
+  });
+
+  it("speaks the appData file wire for an app-scoped namespace: base64 JSON, owner-prefixed keys", async () => {
     const console_ = fakeConsole();
     const blobs = hosted(console_).blobs("app:app_x:uploads");
 
     const bytes = new Uint8Array([0, 1, 2, 255]);
     await blobs.put("images/a b.png", bytes, { contentType: "image/png" });
     expect(console_.requests[0]).toMatchObject({
-      method: "PUT",
-      url: "https://cloud.test/api/v1/store/blobs/app%3Aapp_x%3Auploads/images/a%20b.png",
-      contentType: "image/png",
-      bytes,
+      method: "POST",
+      url: "https://cloud.test/api/v1/store/app-data/putFile",
+      contentType: "application/json",
+      json: {
+        target: { appId: "app_x", collection: "uploads", owner: "user_local" },
+        key: "images/a b.png",
+        contentType: "image/png",
+      },
     });
 
     const got = await blobs.get("images/a b.png");
@@ -151,18 +257,32 @@ describe("hostedStore wire", () => {
     expect(await blobs.get("missing.bin")).toBeNull();
 
     await blobs.put("docs/readme.txt", encoder.encode("hi"));
+    // Keys come back the caller's own — the `<owner>/` leg is the seam's.
     expect(await blobs.list("images/")).toEqual(["images/a b.png"]);
     expect(console_.requests.at(-1)).toMatchObject({
-      method: "GET",
-      url: "https://cloud.test/api/v1/store/blobs/app%3Aapp_x%3Auploads?prefix=images%2F",
+      url: "https://cloud.test/api/v1/store/app-data/listFiles",
+      json: { target: { appId: "app_x", collection: "uploads", owner: "user_local" }, prefix: "images/" },
     });
 
     await blobs.delete("docs/readme.txt");
     expect(console_.requests.at(-1)).toMatchObject({
-      method: "DELETE",
-      url: "https://cloud.test/api/v1/store/blobs/app%3Aapp_x%3Auploads/docs/readme.txt",
+      url: "https://cloud.test/api/v1/store/app-data/deleteFile",
+      json: { key: "docs/readme.txt" },
     });
     expect(await blobs.list("")).toEqual(["images/a b.png"]);
+  });
+
+  it("a plain blob namespace rides the blobs door, bytes base64 on the body", async () => {
+    const console_ = fakeConsole();
+    const blobs = hosted(console_).blobs("uploads");
+    await blobs.put("a.png", new Uint8Array([7]), { contentType: "image/png" });
+    expect(console_.requests[0]).toMatchObject({
+      method: "POST",
+      url: "https://cloud.test/api/v1/store/blobs/put",
+      json: { namespace: "uploads", key: "a.png", bytes: btoa("\u0007"), contentType: "image/png" },
+    });
+    expect((await blobs.get("a.png"))?.contentType).toBe("image/png");
+    expect(await blobs.list("")).toEqual(["a.png"]);
   });
 
   it("speaks the erase wire: one POST per cascade, subject or app scoped", async () => {
@@ -182,8 +302,8 @@ describe("hostedStore wire", () => {
   it("defaults the base URL to the Vendo console", async () => {
     const cloudFetch = vi.fn<typeof fetch>(async () => Response.json({ record: null }));
     const store = hostedStore({ apiKey: "vnd_secret", fetch: cloudFetch });
-    await store.records("invoices").get("x");
-    expect(cloudFetch.mock.calls[0]![0]).toBe("https://console.vendo.run/api/v1/store/records/invoices/get");
+    await store.records("vendo_apps").get("x");
+    expect(cloudFetch.mock.calls[0]![0]).toBe("https://console.vendo.run/api/v1/store/engine/get");
   });
 
   it("ensureSchema and close are client no-ops; raw has no local handle", async () => {
@@ -264,10 +384,11 @@ describe("hostedStore error mapping", () => {
       Response.json({ error: { code: "not-found", message: "Blob not found." } }, { status: 404 }));
     await expect(adapterFor(enveloped).blobs("files").get("absent.bin")).resolves.toBeNull();
     // A bare 404 (no envelope) is some other server — a misdeployed base URL
-    // must not read as an empty blob store forever.
+    // must not read as an empty blob store forever. Only the ENVELOPED
+    // not-found is absence; anything else stays an error, loudly.
     const bare = vi.fn(async () => new Response("<html>not here</html>", { status: 404 }));
     await expect(adapterFor(bare).blobs("files").get("absent.bin"))
-      .rejects.toThrow(/bare 404/);
+      .rejects.toThrow(/failed with 404/);
   });
 
   it("carries unknown codes on a plain error and survives non-JSON bodies", async () => {
@@ -332,7 +453,7 @@ describe("adapter rule", () => {
         baseUrl: "https://arg.test",
         fetch: console_.handler as unknown as typeof fetch,
       });
-      await store.records("invoices").put({ id: "r", data: {} });
+      await store.records("vendo_placement_slots").put({ id: "r", data: {} });
       await store.blobs("files").put("k", new Uint8Array([1]));
       expect(console_.requests[0]!.url).toContain("https://arg.test/");
       expect(console_.requests[0]!.authorization).toBe("Bearer vnd_arg");
@@ -480,10 +601,10 @@ describe("demo-host journey through the store seam", () => {
 });
 
 // ---------------------------------------------------------------------------
-// hostedStoreOps — the 42-op client over `vendo/store-wire@1`.
+// hostedStoreOps — the 35-op client over `vendo/store-wire@1`.
 //
 // Unit tests over an injected fake fetch: they pin the route, the request body
-// and the response decoding for every op — records and blobs against the
+// and the response decoding for every op — engine, appData and blobs against the
 // EXPORTED store-wire v1 contract, the rest against the console's doors
 // (vendo-web apps/console/lib/api/store-handlers.ts + store-doors.ts). A fake
 // fetch proves only that the client talks to ITSELF — the real proof is this
@@ -509,13 +630,6 @@ const wireRecord = {
  * erase keeps the console's own route. `keyed` marks the mutations that carry
  * an Idempotency-Key. */
 const DOORS: Record<string, { method: string; path: string; keyed?: true }> = {
-  "records.get": { method: "POST", path: P["records.get"] },
-  "records.put": { method: "POST", path: P["records.put"], keyed: true },
-  "records.delete": { method: "POST", path: P["records.delete"], keyed: true },
-  "records.list": { method: "POST", path: P["records.list"] },
-  "records.claim": { method: "POST", path: P["records.claim"], keyed: true },
-  "records.insertIfAbsent": { method: "POST", path: P["records.insertIfAbsent"], keyed: true },
-  "records.compareAndSwap": { method: "POST", path: P["records.compareAndSwap"], keyed: true },
   "engine.get": { method: "POST", path: P["engine.get"] },
   "engine.put": { method: "POST", path: P["engine.put"], keyed: true },
   "engine.delete": { method: "POST", path: P["engine.delete"], keyed: true },
@@ -586,13 +700,6 @@ const wireFake = (bodies: Record<string, unknown> = {}) => {
 
 /** One well-formed answer per op, so the whole contract can be driven once. */
 const ALL_BODIES: Record<string, unknown> = {
-  [door("records.get")]: { record: wireRecord },
-  [door("records.put")]: { record: wireRecord },
-  [door("records.delete")]: { ok: true },
-  [door("records.list")]: { records: [wireRecord], cursor: "cur_records" },
-  [door("records.claim")]: { claimed: true },
-  [door("records.insertIfAbsent")]: { record: wireRecord },
-  [door("records.compareAndSwap")]: { record: null },
   [door("engine.get")]: { record: wireRecord },
   [door("engine.put")]: { record: wireRecord },
   [door("engine.delete")]: { ok: true },
@@ -627,7 +734,7 @@ const ALL_BODIES: Record<string, unknown> = {
   [door("workspace.history")]: { entries: [{ commitId: "wsc_1" }] },
   [door("lifecycle.erase")]: { report: { vendo_apps: 1 } },
   [door("lifecycle.promote")]: { ok: true },
-  [door("status")]: { format: "vendo/store-wire@1", ops: 42 },
+  [door("status")]: { format: "vendo/store-wire@1", ops: 35 },
 };
 
 /** Where an appData op lands: the app, the collection it invented, and the
@@ -639,13 +746,6 @@ const APP_DATA_TARGET = { appId: "app_1", collection: "invoices", owner: "sub_1"
 const ENGINE_COLLECTION = "vendo_workspace_commits";
 
 const driveEveryOp = async (ops: ReturnType<typeof wireFake>["ops"]): Promise<void> => {
-  await ops.records.get("invoices", "inv_1");
-  await ops.records.put("invoices", { id: "inv_1", data: { total: 5 } });
-  await ops.records.delete("invoices", "inv_1");
-  await ops.records.list("invoices");
-  await ops.records.claim("invoices", { id: "inv_1", data: { total: 5 } });
-  await ops.records.insertIfAbsent("invoices", { id: "inv_2", data: {} });
-  await ops.records.compareAndSwap("invoices", { id: "inv_2", data: {} }, "1");
   await ops.engine.get(ENGINE_COLLECTION, "wsc_1");
   await ops.engine.put(ENGINE_COLLECTION, { id: "wsc_1", data: { paths: 1 } });
   await ops.engine.delete(ENGINE_COLLECTION, "wsc_1");
@@ -683,74 +783,24 @@ const driveEveryOp = async (ops: ReturnType<typeof wireFake>["ops"]): Promise<vo
   await ops.status();
 };
 
-describe("hostedStoreOps — the 42-op wire client", () => {
-  it("routes all 42 ops to the console's real door, with a key on exactly the mutations", async () => {
+describe("hostedStoreOps — the 35-op wire client", () => {
+  it("routes all 35 ops to the console's real door, with a key on exactly the mutations", async () => {
     const { calls, ops } = wireFake(ALL_BODIES);
     await driveEveryOp(ops);
 
     const expected = Object.values(DOORS);
-    expect(calls).toHaveLength(42);
+    expect(calls).toHaveLength(35);
     expect(calls.map((call) => `${call.method} ${call.path}`))
       .toEqual(expected.map((route) => `${route.method} ${route.path}`));
     expect(calls.map((call) => call.idempotencyKey === null ? "read" : "keyed"))
       .toEqual(expected.map((route) => route.keyed === true ? "keyed" : "read"));
-    // 25 mutations, 17 reads — and the /status handshake is the one GET with
+    // 20 mutations, 15 reads — and the /status handshake is the one GET with
     // no body at all.
-    expect(expected.filter((route) => route.keyed === true)).toHaveLength(25);
+    expect(expected.filter((route) => route.keyed === true)).toHaveLength(20);
     expect(calls.at(-1)).toMatchObject({ path: P.status, method: "GET", body: undefined });
     // Distinct keys across distinct operations (one per logical mutation).
     const keys = calls.map((call) => call.idempotencyKey).filter((key) => key !== null);
-    expect(new Set(keys).size).toBe(25);
-  });
-
-  it("records: seven ops on the wire door, collection on the body, records/cursor decoded", async () => {
-    const { calls, ops } = wireFake(ALL_BODIES);
-
-    expect(await ops.records.get("invoices", "inv_1")).toMatchObject({ id: "inv_1", data: { total: 5 } });
-    expect(calls[0]).toMatchObject({ path: P["records.get"], body: { collection: "invoices", id: "inv_1" } });
-
-    expect(await ops.records.put("invoices", { id: "inv_1", data: { total: 5 } })).toMatchObject({ id: "inv_1" });
-    expect(calls[1]!.body).toEqual({ collection: "invoices", record: { id: "inv_1", data: { total: 5 } } });
-
-    await ops.records.delete("invoices", "inv_1");
-    expect(calls[2]!.body).toEqual({ collection: "invoices", id: "inv_1" });
-
-    expect(await ops.records.list("invoices", { refs: { owner: "user_a" }, limit: 10 })).toEqual({
-      records: [expect.objectContaining({ id: "inv_1" })],
-      cursor: "cur_records",
-    });
-    expect(calls[3]!.body).toEqual({ collection: "invoices", query: { refs: { owner: "user_a" }, limit: 10 } });
-    // An unqueried list still sends a query object, so a door reading
-    // `body.query ?? {}` never sees a bare body.
-    await ops.records.list("invoices");
-    expect(calls[4]!.body).toEqual({ collection: "invoices", query: {} });
-
-    expect(await ops.records.claim("invoices", { id: "inv_1", data: { total: 5 } }, { data: { total: 6 } })).toBe(true);
-    expect(calls[5]!.body).toEqual({
-      collection: "invoices",
-      expected: { id: "inv_1", data: { total: 5 } },
-      replacement: { data: { total: 6 } },
-    });
-
-    expect(await ops.records.insertIfAbsent("invoices", { id: "inv_2", data: {} })).toMatchObject({ id: "inv_1" });
-    expect(calls[6]).toMatchObject({
-      path: P["records.insertIfAbsent"],
-      body: { collection: "invoices", record: { id: "inv_2", data: {} } },
-    });
-
-    // A lost compare-and-swap is null at the seam, not an error.
-    expect(await ops.records.compareAndSwap("invoices", { id: "inv_2", data: {} }, "1")).toBeNull();
-    expect(calls[7]).toMatchObject({
-      path: P["records.compareAndSwap"],
-      body: { collection: "invoices", record: { id: "inv_2", data: {} }, expectedRevision: "1" },
-    });
-
-    // The collection rides the body VERBATIM — no path encoding to get wrong.
-    await ops.records.get("app:app_1:orders", "o_1");
-    expect(calls[8]).toMatchObject({
-      path: P["records.get"],
-      body: { collection: "app:app_1:orders", id: "o_1" },
-    });
+    expect(new Set(keys).size).toBe(20);
   });
 
   it("blobs: JSON POST on the wire door, bytes base64 on the body", async () => {
@@ -813,15 +863,8 @@ describe("hostedStoreOps — the 42-op wire client", () => {
     await expect(bare.blobs.get("uploads", "gone.png")).rejects.toMatchObject({ code: "not-implemented" });
   });
 
-  it("records, engine and blobs requests validate against the EXPORTED store-wire v1 request schemas", async () => {
+  it("engine and blobs requests validate against the EXPORTED store-wire v1 request schemas", async () => {
     const { calls, ops } = wireFake(ALL_BODIES);
-    await ops.records.get("invoices", "inv_1");
-    await ops.records.put("invoices", { id: "inv_1", data: { total: 5 } });
-    await ops.records.delete("invoices", "inv_1");
-    await ops.records.list("invoices", { limit: 10 });
-    await ops.records.claim("invoices", { id: "inv_1", data: { total: 5 } }, { data: { total: 6 } });
-    await ops.records.insertIfAbsent("invoices", { id: "inv_2", data: {} });
-    await ops.records.compareAndSwap("invoices", { id: "inv_2", data: {} }, "1");
     await ops.engine.get(ENGINE_COLLECTION, "wsc_1");
     await ops.engine.put(ENGINE_COLLECTION, { id: "wsc_1", data: { paths: 1 } });
     await ops.engine.delete(ENGINE_COLLECTION, "wsc_1");
@@ -835,16 +878,8 @@ describe("hostedStoreOps — the 42-op wire client", () => {
     await ops.blobs.list("uploads", "a");
 
     const CONTRACT: [keyof typeof P, { safeParse(value: unknown): { success: boolean } }][] = [
-      ["records.get", storeWireRecordsGetRequestSchema],
-      ["records.put", storeWireRecordsPutRequestSchema],
-      ["records.delete", storeWireRecordsDeleteRequestSchema],
-      ["records.list", storeWireRecordsListRequestSchema],
-      ["records.claim", storeWireRecordsClaimRequestSchema],
-      ["records.insertIfAbsent", storeWireRecordsInsertIfAbsentRequestSchema],
-      ["records.compareAndSwap", storeWireRecordsCompareAndSwapRequestSchema],
-      // ONE collection-addressed body shape, two doors: the engine ops send
-      // exactly what /records/* sends, so they validate against the same
-      // schema objects (the storeWireRecords* names above are its aliases).
+      // The collection-addressed body shape, named for its SHAPE rather than
+      // for a family — the engine ops are its one door now.
       ["engine.get", storeWireCollectionGetRequestSchema],
       ["engine.put", storeWireCollectionPutRequestSchema],
       ["engine.delete", storeWireCollectionDeleteRequestSchema],
@@ -982,22 +1017,22 @@ describe("hostedStoreOps — the 42-op wire client", () => {
 
   it("status: the GET handshake, parsed as vendo/store-wire@1", async () => {
     const { calls, ops } = wireFake(ALL_BODIES);
-    expect(await ops.status()).toMatchObject({ format: "vendo/store-wire@1", ops: 42 });
+    expect(await ops.status()).toMatchObject({ format: "vendo/store-wire@1", ops: 35 });
     expect(calls[0]).toMatchObject({ path: "/status", method: "GET" });
-    await expect(wireFake({ [door("status")]: { format: "vendo/store-wire@2", ops: 42 } }).ops.status())
+    await expect(wireFake({ [door("status")]: { format: "vendo/store-wire@2", ops: 35 } }).ops.status())
       .rejects.toThrow(/invalid status/);
   });
 
   it("passes cursors through untouched — the server paginates, never the client", async () => {
     const { calls, ops } = wireFake({
-      [door("records.list")]: { records: [], cursor: "opaque||server||cursor" },
+      [door("engine.list")]: { records: [], cursor: "opaque||server||cursor" },
       [door("workspace.history")]: { entries: [] },
     });
-    expect(await ops.records.list("invoices", { cursor: "opaque||prev", limit: 1000 })).toEqual({
+    expect(await ops.engine.list(ENGINE_COLLECTION, { cursor: "opaque||prev", limit: 1000 })).toEqual({
       records: [],
       cursor: "opaque||server||cursor",
     });
-    expect(calls[0]!.body).toEqual({ collection: "invoices", query: { cursor: "opaque||prev", limit: 1000 } });
+    expect(calls[0]!.body).toEqual({ collection: ENGINE_COLLECTION, query: { cursor: "opaque||prev", limit: 1000 } });
     // No cursor from the server means the page is the last one.
     expect(await ops.workspace.history({ cursor: "opaque||prev" })).toEqual({ entries: [] });
     expect(calls[1]!.body).toEqual({ cursor: "opaque||prev" });
@@ -1018,13 +1053,13 @@ describe("hostedStoreOps — the 42-op wire client", () => {
 
     // The write still resolves, and the server's ledger sees ONE logical
     // mutation: the retry replays the key verbatim rather than minting one.
-    expect(await ops.records.put("invoices", { id: "inv_1", data: { total: 5 } })).toMatchObject({ id: "inv_1" });
+    expect(await ops.engine.put(ENGINE_COLLECTION, { id: "inv_1", data: { total: 5 } })).toMatchObject({ id: "inv_1" });
     expect(seen).toHaveLength(2);
     expect(seen[0]).toBe(seen[1]);
     expect(seen[0]).toEqual(expect.stringMatching(/^idm_/));
 
     // A NEW logical operation mints a new key.
-    await ops.records.put("invoices", { id: "inv_1", data: { total: 6 } });
+    await ops.engine.put(ENGINE_COLLECTION, { id: "inv_1", data: { total: 6 } });
     expect(seen[2]).not.toBe(seen[0]);
   });
 
@@ -1055,7 +1090,7 @@ describe("hostedStoreOps — the 42-op wire client", () => {
         return Response.json({ error: { code: "conflict", message: "taken" } }, { status: 409 });
       }) as unknown as typeof fetch,
     });
-    await expect(ops.records.put("invoices", { id: "inv_1", data: {} }))
+    await expect(ops.engine.put(ENGINE_COLLECTION, { id: "inv_1", data: {} }))
       .rejects.toMatchObject({ code: "conflict" });
     expect(attempts).toBe(1);
   });
@@ -1067,10 +1102,10 @@ describe("hostedStoreOps — the 42-op wire client", () => {
       fetch: (async () => Response.json({ error: { code, message } }, { status })) as unknown as typeof fetch,
     });
     await expect(enveloped("conflict", "belongs to another subject", 409)
-      .records.put("vendo_threads", { id: "thr_1", data: {} }))
+      .engine.put("vendo_threads", { id: "thr_1", data: {} }))
       .rejects.toMatchObject({ code: "conflict", message: "belongs to another subject" });
     await expect(enveloped("blocked", "vendo_audit is append-only", 403)
-      .records.delete("vendo_audit", "aud_1"))
+      .engine.delete("vendo_audit", "aud_1"))
       .rejects.toMatchObject({ code: "blocked", message: "vendo_audit is append-only" });
     // The idempotency ledger's own refusal — same key, different body — is a
     // conflict the caller must see, never a swallowed replay.
@@ -1079,14 +1114,14 @@ describe("hostedStoreOps — the 42-op wire client", () => {
       .rejects.toMatchObject({ code: "conflict" });
     // An enveloped not-found stays not-found; a BARE 404 is a mount failure
     // and degrades to not-implemented rather than reading as absence.
-    await expect(enveloped("not-found", "unknown record", 404).records.get("invoices", "r"))
+    await expect(enveloped("not-found", "unknown record", 404).engine.get(ENGINE_COLLECTION, "r"))
       .rejects.toMatchObject({ code: "not-found" });
     const bare = hostedStoreOps({
       apiKey: "vnd_secret",
       baseUrl: "https://cloud.test",
       fetch: (async () => new Response("<html>nginx</html>", { status: 404 })) as unknown as typeof fetch,
     });
-    await expect(bare.records.get("invoices", "r")).rejects.toMatchObject({ code: "not-implemented" });
+    await expect(bare.engine.get(ENGINE_COLLECTION, "r")).rejects.toMatchObject({ code: "not-implemented" });
   });
 
   it("surfaces an unsupported op cleanly, naming it — never a silent fallback", async () => {
@@ -1129,9 +1164,9 @@ describe("hostedStoreOps — the 42-op wire client", () => {
       baseUrl: "https://cloud.test",
       fetch: (async () => Response.json(body)) as unknown as typeof fetch,
     });
-    await expect(answering({}).records.get("invoices", "r")).rejects.toThrow(/invalid record/);
-    await expect(answering({ records: "nope" }).records.list("invoices")).rejects.toThrow(/invalid list/);
-    await expect(answering({ claimed: "yes" }).records.claim("invoices", { id: "r", data: {} }))
+    await expect(answering({}).engine.get(ENGINE_COLLECTION, "r")).rejects.toThrow(/invalid record/);
+    await expect(answering({ records: "nope" }).engine.list(ENGINE_COLLECTION)).rejects.toThrow(/invalid list/);
+    await expect(answering({ claimed: "yes" }).engine.claim(ENGINE_COLLECTION, { id: "r", data: {} }))
       .rejects.toThrow(/invalid claim/);
     await expect(answering({ keys: [1] }).blobs.list("uploads")).rejects.toThrow(/invalid blob list/);
     await expect(answering({ blob: {} }).blobs.get("uploads", "a.png")).rejects.toThrow(/invalid blob/);
@@ -1149,33 +1184,32 @@ describe("hostedStore keeps its StoreAdapter surface and gains the op surface", 
     expect(typeof store.records).toBe("function");
     expect(typeof store.blobs).toBe("function");
     expect(typeof store.erase.bySubject).toBe("function");
+    // Eight families — the generic records family is gone from the op surface.
     expect(Object.keys(store.ops).sort()).toEqual([
-      "appData", "blobs", "engine", "harness", "lifecycle", "records", "status", "transcripts", "workspace",
+      "appData", "blobs", "engine", "harness", "lifecycle", "status", "transcripts", "workspace",
     ]);
 
     // The op surface rides the SAME mount, key and identity headers as the
-    // StoreAdapter surface, over its own wire doors — a record written through
+    // StoreAdapter surface, over the same wire doors — a record written through
     // one is readable through the other, which is what "one home, two
     // surfaces" has to mean.
-    await store.ops.records.put("invoices", { id: "inv_1", data: { total: 5 } });
+    await store.ops.engine.put(ENGINE_COLLECTION, { id: "wsc_1", data: { paths: 1 } });
     expect(console_.requests.at(-1)).toMatchObject({
-      url: "https://cloud.test/api/v1/store/records/put",
+      url: "https://cloud.test/api/v1/store/engine/put",
       authorization: "Bearer vnd_secret",
     });
-    expect(await store.records("invoices").get("inv_1")).toMatchObject({ id: "inv_1", data: { total: 5 } });
-    await store.ops.records.delete("invoices", "inv_1");
-    expect(await store.ops.records.get("invoices", "inv_1")).toBeNull();
+    expect(await store.records(ENGINE_COLLECTION).get("wsc_1")).toMatchObject({ id: "wsc_1", data: { paths: 1 } });
+    await store.ops.engine.delete(ENGINE_COLLECTION, "wsc_1");
+    expect(await store.ops.engine.get(ENGINE_COLLECTION, "wsc_1")).toBeNull();
 
-    // Blobs too: base64 JSON on the ops wire, REST bytes on the adapter, both
-    // surfaces on the same key.
+    // Blobs too, on the one door both surfaces now share.
     await store.ops.blobs.put("uploads", "images/a.png", new Uint8Array([7]), { contentType: "image/png" });
     expect(await store.blobs("uploads").get("images/a.png")).toMatchObject({ contentType: "image/png" });
     expect(await store.ops.blobs.list("uploads", "images/")).toEqual(["images/a.png"]);
   });
 
-  // 30 of the 42 ops have no door in the fake: all 7 engine, all 8 appData,
-  // all 6 transcripts, all 3 harness, all 4 workspace, lifecycle.promote and
-  // /status. It used to answer
+  // 16 of the 35 ops have no door in the fake: all 6 transcripts, all 3
+  // harness, all 4 workspace, lifecycle.promote and /status. It used to answer
   // them with a `not-found` envelope — the SAME answer a live console sends
   // when it refuses — so a test exercising one of those families read a
   // plausible rejection and asserted nothing. The fake now throws out of

--- a/packages/vendo/tests/server.test.ts
+++ b/packages/vendo/tests/server.test.ts
@@ -1080,9 +1080,14 @@ describe("09 §3 public wire", () => {
     // ensureSchema is a client no-op — the service owns its migrations.
     const hosted = compose({});
     cleanups.push(async () => { await hosted.store.close(); });
-    expect(await hosted.store.records("invoices").get("inv_1")).toBeNull();
+    // An ENGINE collection, not a host-invented one: since the generic records
+    // family left the wire the hosted façade has two doors, and a name outside
+    // the allowlist has no home on that mount at all. The probe has to be a
+    // call the live console would actually serve, or it proves the seam is
+    // wired by exercising something that could only ever be refused.
+    expect(await hosted.store.records("vendo_apps").get("app_1")).toBeNull();
     expect(consoleCalls).toEqual([{
-      url: "https://cloud-store.test/api/v1/store/records/invoices/get",
+      url: "https://cloud-store.test/api/v1/store/engine/get",
       authorization: "Bearer vnd_store_key",
     }]);
     expect(() => hosted.store.raw()).toThrow(/no local database/);

--- a/scripts/sync-version-constants.mjs
+++ b/scripts/sync-version-constants.mjs
@@ -16,10 +16,6 @@ const version = JSON.parse(
 const targets = [
   { file: "packages/vendo/src/cli/shared.ts", pattern: /(export const CLI_VERSION = ")[^"]+(")/ },
   { file: "packages/vendo/src/wire/shared.ts", pattern: /(export const VERSION = ")[^"]+(")/ },
-  {
-    file: "packages/core/src/store-wire.ts",
-    pattern: /(export const STORE_WIRE_MIN_CLIENT_VERSION = ")[^"]+(")/,
-  },
 ];
 
 for (const { file, pattern } of targets) {


### PR DESCRIPTION
Rebased onto `395fc1ee5` (guard #1170 and automations #1171 both landed). Zero file overlap with #1186, and branch protection is `strict: false`, so this can land while behind main.

## What goes

`StoreOps.records` and its seven `/records/*` routes. `STORE_WIRE_PATHS` holds **35** ops across 8 families (engine 7, blobs 4, appData 8, transcripts 6, harness 3, workspace 4, lifecycle 2, status 1); `status()` reports `ops: 35`; the hosted client drives 35. A call left on `/records/*` answers an **enveloped 501 naming the op** — the only notice a raw-HTTP caller gets, since there is no deprecation window.

The deprecation *advertisement* goes with it, because there is no gap left to announce: `STORE_WIRE_DEPRECATED_OPS`, `STORE_WIRE_DEPRECATED_REMOVED_IN`, `STORE_WIRE_MIN_CLIENT_VERSION`, the `deprecated`/`minClientVersion` fields on `StoreWireStatus`, the seven `storeWireRecords*RequestSchema` aliases, doctor's `E-LIVE-008` check, and — the landmine — the release-cut registration in `scripts/sync-version-constants.mjs`, which hard-fails `pnpm changeset:version` if the constant vanishes from under it.

## What stays

The `StoreAdapter` façade, permanently. `hostedStore(...).records(collection)` and `.blobs(namespace)` are re-implemented over the surviving families: an `app:<appId>:<name>` scope rides `appData`, everything else rides `engine`. **The capability mirror is unchanged** — `claim` absent on routed reserved collections, `atomic` on generic collections and `vendo_threads` only — so `mcp`'s seven feature-detection checks see exactly the shape they saw before. `mcp` (143 tests) and `knowledge` (102 tests) pass **unmodified**.

`E-LIVE-008` stays listed in the doctor registry and keeps its `verify.mdx` anchor (rewritten to say the family is gone). Codes are append-only and the docs test enforces 1:1 both ways; retiring the check without deleting the entry is the shape that keeps both invariants and touches neither test.

## Behaviour changes worth reading

- **A collection outside the engine allowlist has no home on the hosted mount** and is refused `blocked`. Local and BYO stores are untouched. This is the removal's real edge.
- **An app-scoped drawer on the hosted façade is owner-scoped now.** `hostedStore({ owner })` names the owner; it defaults to `"user_local"`, matching `createStoreOps`' bound workspace owner. `appData` has no compare-and-set verbs, so an app-scoped `RecordStore` omits `claim`/`atomic` rather than advertising what it cannot serve.
- The façade and the op surface keep reading a non-2xx **differently**, as they always have — the op client uses the protocol envelope, the façade keeps the console's 402/401 mapping (the crafted meter sentence). One wire client, two error readings, split at `storeWireClient`.
- **One error string changed.** A bare, envelope-less 404 on a hosted blob read now throws `Vendo Cloud store request failed with 404` instead of naming a `bare 404`. Behaviour is identical — loud, never read as a missing blob — but do not grep for the old wording.
- **`HostedStoreOptions.owner` is new public API with a footgun default.** It exists because `records(collection)` takes a string and has nowhere to put the appData owner the caller never had to think about. A host serving more than one end user through ONE `hostedStore` instance and taking the `"user_local"` default co-mingles every user's app rows in one drawer, and nothing refuses it — `"user_local"` is a legal owner — so the symptom is cross-user reads in production, not an error at composition. Written down at the definition and in the changeset.

## Changesets

`.changeset/records-ops-are-deprecated.md` (S8a, never released — npm's latest is 0.11.0) is **deleted here**: shipping it beside this one would publish "deprecated, removed in `0.13.0`" and "removed" in a single changelog. `records-ops-are-removed.md` is now the whole story.

## Test files changed, stated out loud

Five, each pinning something this slice deletes: `core/tests/store-wire.test.ts` (the alias and deprecation-constant tests), `store/tests/ops.test.ts` (`ops.records.*` → `ops.engine.*`, and the `status()` advertisement test), `vendo/tests/hosted-store.test.ts` (the records wire family, plus the rebuilt façade), `vendo/tests/cli/doctor.test.ts` (the `E-LIVE-008` warning test), and:

**`guard/test/engine-family.test.ts`** — the guard migration's acceptance test spied on BOTH op families and asserted the `records` leg saw no traffic. With the family gone the spy leg does not type-check (`TS2353`/`TS2339` at `:43`) and the assertion is vacuous, so the union at `:18`, the spy leg at `:43`, the assertion at `:87` and the header comment at `:4` go, and the case is retitled to what it still proves. The property is now enforced by the compiler — strictly stronger than a runtime spy. **Untouched in that file: the allowlist assertions, both `insertIfAbsent` cases, and the whole adapter-without-ops block** (which still exercises `store.records(...)`, the surviving façade). Guard's `src` needed no change; its `tsconfig.json` typechecks clean on its own.

This edit lives here rather than in a guard PR because the test cannot compile without this change and this change cannot compile without it — split, one side is red by construction.

## Conformance

The records cases moved to where the behaviour still lives, not deleted and not duplicated: `claim`, `insertIfAbsent` and `compareAndSwap` join **`storeAdapterConformance`** (`packages/core/src/conformance/index.ts`) as capability-conditional cases — 01-core §12 makes both optional — and the two WIRE rules (the 100/1000 page contract, list determinism) retarget onto `engine.list` in `storeOpsConformance`. The other ten had identical twins in the adapter suite already.

`hostedStore`'s mount of `storeAdapterConformance` names each case's drawer through the one dynamic engine name (`vendo:app-history:<id>`), because the suite's host-flavoured names no longer have a door. The fake console serves the engine allowlist as a real gate rather than dropping it for the test.

## Gate

`pnpm build` · `pnpm typecheck` · `pnpm lint` green, each its own run. Scoped: core (603), store ops + conformance (85), vendo hosted-store (59), mcp (143), knowledge (102), vendo doctor/type-surface/threads/conformance (121), apps conformance (24).

Proved-can-fail: routing `app:x:notes` to `engine` reddens *"an app-scoped collection rides the appData door, with the owner stamped on"*; answering the retired path `404` reddens *"a retired /records/* path answers an enveloped 501 naming the op"*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Breaking: removed the generic `records.*` wire family and its seven `/records/*` routes. The wire now exposes 35 ops across 8 families; calls to `/records/*` return an enveloped 501 “not-implemented” naming the op. The `StoreAdapter` façade now routes app‑scoped rows/files through `appData` and everything else through `engine` with the same capability surface.

- **Migration**
  - Replace `ops.records.*`: Vendo collections → `ops.engine.*`; app rows/files → `ops.appData.*` with target `{ appId, collection, owner }`.
  - Set the owner via `hostedStore({ owner })`; default is `"user_local"`. Multi-user hosts must set per user/request to avoid co‑mingling.
  - Hosted mount enforces the engine allowlist; local/BYO stores are unchanged.
  - `/records/*` now answers 501; `appData` has no compare‑and‑set, so no `claim`/`atomic` on app‑scoped stores.

- **Refactors**
  - Removed deprecation plumbing and schemas: `STORE_WIRE_DEPRECATED_OPS`, `STORE_WIRE_DEPRECATED_REMOVED_IN`, `STORE_WIRE_MIN_CLIENT_VERSION`, `StoreWireStatus.deprecated/minClientVersion`, `storeWireRecords*` schemas, doctor’s E‑LIVE‑008 check; docs mark E‑LIVE‑008 retired; dropped the release‑cut pattern.
  - Moved `claim`/`insertIfAbsent`/`compareAndSwap` conformance to the adapter suite; wire list rules now target `engine.list`.
  - Tests follow engine/blobs traffic and compile‑time enforcement: dropped the `records` spy leg in guard; `vendo` tests assert POST `/engine/put` for grants and sync blobs via `blobs.*`; server probe uses `vendo_apps` via the engine door.
  - One hosted blob 404 error string changed; behavior unchanged.

<sup>Written for commit 282ec4a14e2b7e01c7323ddfa3baf628f5601fbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

