### PR TITLE
feat(cli): the arrival composites — the scan runs under the wave, facts land as checkmarks

### DIFF
--- a/.changeset/composited-arrival.md
+++ b/.changeset/composited-arrival.md
@@ -1,0 +1,7 @@
+---
+"@vendoai/vendo": patch
+---
+
+`vendo init`'s banner arrival now composites over the detection scan: the wave keeps playing above while the tagline, the header and a checkmarked scan of your app build below it, so the facts land as `✓` lines instead of after a flash.
+
+The MCP path's closing steps gain real formatting — numbered headlines with their detail indented under them, and the two broker environment values as their own group.

--- a/packages/vendo/src/cli/banner.ts
+++ b/packages/vendo/src/cli/banner.ts
@@ -186,33 +186,41 @@ export function bannerColorMode(
  * settled one.
  *
  * `signal` cuts it short, and the settled frame is drawn INSIDE abort() —
- * synchronously, before abort() returns — so a caller that needs the screen
- * mid-arrival prints its next line under the finished mark and never on top of
- * a half-drawn one. That is what lets the arrival play over work the run was
- * doing anyway without ever delaying a line.
+ * synchronously, before abort() returns — so a run that has to end mid-arrival
+ * (an interrupt) leaves the finished mark behind, never a half-drawn one.
+ * Ordinary printing needs no abort: it goes BELOW the art (see `below`).
  */
 export async function playBanner(
   write: (chunk: string) => void,
   frames: readonly string[],
   frameMs = 90,
   signal?: AbortSignal,
+  /** SCREEN rows of content the caller has printed BELOW the art since it
+      started. When provided, each frame repaints the art in place above that
+      content (save cursor → up over content+art → paint → restore), so the run
+      keeps talking while the wave still plays. The caller maintains the count
+      and owes screen rows, not lines — a line that wraps is more than one. */
+  below?: { rows: number },
 ): Promise<void> {
   const [first, ...rest] = frames;
   if (first === undefined) return;
   const rows = first.split("\n").length;
-  const redraw = (frame: string): void => {
-    write(`${ESC}[${rows}A`);
-    write(`${frame.split("\n").map((row) => `${ESC}[2K${row}`).join("\n")}\n`);
+  const paint = (frame: string): void => {
+    const offset = rows + (below?.rows ?? 0);
+    write(`${ESC}7${ESC}[${offset}A`);
+    write(frame.split("\n").map((row) => `${ESC}[2K${row}`).join("\n"));
+    write(`${ESC}8`);
   };
   write(`${first}\n`);
   let playing = true;
+  const settleFrame = (): void => { paint(frames.at(-1)!); };
   signal?.addEventListener("abort", () => {
-    if (playing) redraw(frames.at(-1)!);
+    if (playing) settleFrame();
   }, { once: true });
   for (const frame of rest) {
     await new Promise<void>((settle) => { setTimeout(settle, frameMs); });
     if (signal?.aborted === true) return;
-    redraw(frame);
+    paint(frame);
   }
   playing = false;
 }

--- a/packages/vendo/src/cli/init-mcp.ts
+++ b/packages/vendo/src/cli/init-mcp.ts
@@ -95,6 +95,27 @@ export interface McpPlan {
   blocked?: string;
 }
 
+/** The plan's closing block, as a pretty run reads it: each step numbered by
+    its headline, its detail indented under it, and the environment values as a
+    closing group under one sentence that says where they go. A flat list of
+    `headline\ndetail` strings reads as a wall — the numbers and the indent are
+    what make it read as steps. (Plain runs print the same strings unnumbered:
+    the newline becomes an indent and nothing else, since a plain transcript is
+    parsed as often as it is read.) */
+export function mcpStepLines(plan: Pick<McpPlan, "steps" | "envLines">): string[] {
+  const lines: string[] = [];
+  plan.steps.forEach((step, index) => {
+    const [headline, ...detail] = step.split("\n");
+    lines.push(`${index + 1}. ${headline}`);
+    for (const rest of detail) lines.push(`   ${rest}`);
+  });
+  if (plan.envLines.length > 0) {
+    lines.push("", "Set where you deploy — both values live on the console's MCP page:");
+    for (const env of plan.envLines) lines.push(`   ${env}`);
+  }
+  return lines;
+}
+
 /** A fresh service key: 32 random bytes, hex. `planMcp` mints one itself when
     the answers call for it; this is separately callable so the shape can be
     asserted without a plan. */
@@ -179,19 +200,20 @@ export function planMcp(input: McpPlanInput): McpPlan {
   // URL, so it is the same in both postures — switching posture later invalidates
   // nothing a user already configured in Claude, ChatGPT or Cursor.
   const clientBase = baseUrl ?? "https://<your deployment>";
+  // Each step is "headline\ndetail…" — the caller numbers the headlines and
+  // indents the detail lines, so a step never wraps mid-phrase into a wall.
   const steps = [
     baseUrl === null
-      ? "Set VENDO_BASE_URL in your deploy platform to this deployment's public origin — without it the door's discovery points at the wrong origin and clients cannot find your server"
-      : `Set VENDO_BASE_URL in your deploy platform — ${baseUrl}, captured earlier, is in .env.example`,
-    `Point any MCP client at ${clientBase}${MCP_MOUNT}`,
-    `Setup page for your users ships free at ${MCP_MOUNT}/connect (Claude · ChatGPT · Cursor copy included)`,
-    "Claude Code: /plugin marketplace add runvendo/vendo → /plugin install vendo@vendo",
+      ? "Set `VENDO_BASE_URL` in your deploy platform to this deployment's public origin\nwithout it, discovery points at the wrong origin and clients cannot find your server"
+      : `Set \`VENDO_BASE_URL\` in your deploy platform\n\`${baseUrl}\` — captured earlier, already in .env.example`,
+    `Point any MCP client at \`${clientBase}${MCP_MOUNT}\`\nyour users' setup page ships free at \`${MCP_MOUNT}/connect\` — copy for Claude · ChatGPT · Cursor included`,
+    "Claude Code: `/plugin marketplace add runvendo/vendo` then `/plugin install vendo@vendo`",
   ];
   if (!cloudKey) steps.push(KEYLESS_SIGN_IN);
   if (serviceKey) {
     steps.push(serviceAuth
-      ? `Your backend exchanges VENDO_SERVICE_KEY at ${clientBase}${MCP_MOUNT}/token for a 10-minute token acting as a named user — svc: attribution in the audit`
-      : "Create the service key on the console's keys page (Service keys) — it lands in the broker; exchange it at your tenant URL /token");
+      ? `Your backend exchanges \`VENDO_SERVICE_KEY\` at \`${clientBase}${MCP_MOUNT}/token\`\nfor a 10-minute token acting as a named user — svc: attribution in the audit`
+      : "Create the service key on the console's keys page (Service keys)\nit lands in the broker — exchange it at `<your tenant URL>/token`");
   }
 
   return {
@@ -201,8 +223,8 @@ export function planMcp(input: McpPlanInput): McpPlan {
     steps,
     envLines: posture === "broker"
       ? [
-          "VENDO_MCP_BROKER_URL=<your tenant MCP endpoint, from the console MCP page>",
-          "VENDO_MCP_FEDERATION_SECRET=<from the console MCP page>",
+          "`VENDO_MCP_BROKER_URL=<your tenant MCP endpoint>`",
+          "`VENDO_MCP_FEDERATION_SECRET=<secret>`",
         ]
       : [],
   };

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -10,7 +10,7 @@ import { detectDepVersions, installedAiVersion } from "./dep-versions.js";
 import { AUTH_MD_URL, ensureEnvLocalIgnored, runCloudStep, upsertEnvLocal, type CloudStepOptions } from "./cloud-init.js";
 import { runDoctor } from "./doctor.js";
 import type { InitPolishSeam } from "./init-judgment.js";
-import { planMcp, type McpPosture } from "./init-mcp.js";
+import { mcpStepLines, planMcp, type McpPosture } from "./init-mcp.js";
 import { rendererFlowOptions, runSyncFlow, type SyncFlowResult } from "./sync-flow.js";
 import { BRIEF_TEMPLATE } from "./extract/stages.js";
 import { ENV_KEY_VARS, resolveDevCredential, describeDevCredential, type DevCredential } from "../dev-creds/resolve.js";
@@ -1653,9 +1653,11 @@ async function finishRun(input: {
   ];
   printClosingSteps({ output, handSteps, manualSteps, credential, cloud, compositionPath });
   if (mcp !== null) {
-    const lines = [...mcp.steps, ...mcp.envLines];
-    if (pretty === null) for (const line of lines) output.log(`  ${line}`);
-    else pretty.block("Steps that are yours", lines, "◇");
+    // A step is `headline\ndetail`: the pretty block numbers and indents it,
+    // and a plain transcript keeps the detail on its own indented line.
+    if (pretty === null) {
+      for (const line of [...mcp.steps, ...mcp.envLines]) output.log(`  ${line.replace(/\n/g, "\n    ")}`);
+    } else pretty.block("Steps that are yours", mcpStepLines(mcp), "◇");
   }
 
   // The live check offers itself ONLY when nothing is left to paste: doctor
@@ -1724,12 +1726,17 @@ export async function runInit(options: InitOptions): Promise<number> {
   // reasons, and showing it is the moment the tool proves it looked.
   if (pretty !== null) {
     // Detect FIRST, print second: the banner's arrival plays over this work.
-    // It reads a handful of files, though, so the arrival is the longer of the
-    // two — awaiting the remainder is what makes it an arrival instead of a
-    // flash, and it is bounded by the frame budget (~1.3s), not by this run.
+    // The reveal then narrates it — a beat of "Reading your app…" and the
+    // facts landing one by one — so the wave reads as detection time, and the
+    // section arrives as a rhythm instead of a burst after the arrival.
     const stack = await stackLines(root, await resolveFramework(root, options));
-    await pretty.arrived;
-    pretty.block("Your stack", stack);
+    // Each fact gets a labeled beat — the scan narrates what it is looking at
+    // while it lands the answer it already has.
+    const facts = stack.map((text, index) => ({
+      beat: index === 0 ? "Detecting your framework…" : index === 1 ? "Checking auth…" : undefined,
+      text,
+    }));
+    await pretty.revealBlock("Your stack", facts, { beat: "Reading your app…" });
   }
   const useCase = await resolveUseCase({ options, pretty, interactive });
 

--- a/packages/vendo/src/cli/pretty.ts
+++ b/packages/vendo/src/cli/pretty.ts
@@ -94,20 +94,37 @@ export interface PrettyOutput extends Output {
       keep emitting their plain lines, and this restyles nothing — it is for
       blocks the pretty run composes itself. */
   block(title: string, lines: string[], marker?: "◆" | "◇"): void;
+  /** The staggered sibling of block(): waits for the banner arrival, plays an
+      optional spinner beat (the detection narration), then lands the lines
+      ~stepMs apart so the section arrives as a rhythm instead of a burst.
+      A line carrying its own beat gets a labeled spinner moment first — the
+      scan finds things one at a time. Pretty-only, like block(). */
+  revealBlock(
+    title: string,
+    lines: Array<string | { beat?: string; text: string }>,
+    options?: { stepMs?: number; beat?: string },
+  ): Promise<void>;
   /** The `└ Done in Xs` footer (red `Failed` when the command exits non-zero);
       `stats` is the dim tail that says what the run actually achieved, and a
       dim star line closes the run. */
   done(durationMs: number, ok: boolean, stats?: string): void;
   /** Settles when the banner has finished arriving. Printing never waits on it
-      — the first line cuts the arrival to the settled mark — so this is for the
-      one caller that wants the arrival SEEN: it awaits whatever is left of it
-      after its own detection work, and pays nothing it did not already spend. */
+      and nothing cuts it short: the tagline, the header and the scan all print
+      BELOW the art while the frames repaint above them, so the run keeps
+      talking through the wave. This is for the one caller that wants the
+      arrival SEEN — it awaits whatever is left after its own work, and pays
+      nothing it did not already spend. A cancel still settles it instantly:
+      Ctrl-C aborts, which paints the finished mark before the run ends. */
   arrived: Promise<void>;
 }
 
 const FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 const BAR = dim("│");
 const CLEAR_LINE = `\r${ESC}[2K`;
+/** Splits a chunk into text, CSI sequences (none of which costs a cell) and the
+    two control characters that move the cursor on their own. Captured, so
+    `split` keeps them. */
+const SPLIT_CSI = new RegExp(`(${ESC}\\[[0-9;?]*[A-Za-z]|[\\n\\r])`);
 const RESET = `${ESC}[0m`;
 const SHOW_CURSOR = `${ESC}[?25h`;
 /** Columns the rail costs a continuation row: `│` plus the two-space body gap. */
@@ -703,12 +720,15 @@ export interface PrettyOptions {
 export function createPrettyOutput(options: PrettyOptions = {}): PrettyOutput {
   const {
     command = "vendo init",
-    write = (chunk: string): void => { stdout.write(chunk); },
     input = stdin as SelectInput,
     promptOutput = stdout,
     banner = true,
     env = process.env,
   } = options;
+  // `write` is a mutable binding: once the arrival starts, it is swapped for a
+  // row-counting wrapper so the paint loop knows how much content sits below
+  // the animating art. Everything in this closure writes through it.
+  let write = options.write ?? ((chunk: string): void => { stdout.write(chunk); });
   let headerPrinted = false;
   let lastWasBar = false;
   let timer: ReturnType<typeof setInterval> | null = null;
@@ -751,25 +771,80 @@ export function createPrettyOutput(options: PrettyOptions = {}): PrettyOutput {
     accent: lilac,
   };
   /** The arrival, started at construction — so the frames play over the stack
-      detection the run does before its first line, and cost nothing. It is
-      never awaited: ensureHeader settles it, so the animation can only ever be
-      a faster way to arrive at the banner that printed here before. */
+      detection the run does before its first line, and cost nothing. The
+      signal is the interrupt path only (cancel settles the mark); ordinary
+      lines print below the art and let the wave finish. */
   const arrival = banner ? new AbortController() : null;
+  /** Content rows printed below the art while the wave still plays — the art
+      repaints in place above them each frame. Counted by wrapping the writer,
+      which is the ONLY thing that models the cursor: everything in this closure
+      writes through it, and the art's own paint (which saves and restores the
+      cursor) is the one thing that does not. */
+  const below = { rows: 0 };
+  const rawWrite = write;
+  let arrivalLive = arrival !== null;
+  /** Column the cursor sits in, carried across chunks: a write that does not
+      end in a newline leaves the next one mid-row. */
+  let column = 0;
+  /** ROWS a chunk moves the cursor down, which is NOT its newline count: a line
+      wider than the window wraps onto rows of its own, and an art repaint that
+      rewound by the newline count would land inside the content — the desync
+      #1152 fixed for the rail, measured with the same `displayWidth`. */
+  const rowsWritten = (chunk: string): number => {
+    const limit = columns();
+    let rows = 0;
+    for (const token of chunk.split(SPLIT_CSI)) {
+      if (token === "") continue;
+      if (token === "\n") {
+        rows += 1;
+        column = 0;
+        continue;
+      }
+      if (token === "\r") {
+        column = 0;
+        continue;
+      }
+      if (token.startsWith(ESC)) {
+        // A cursor-up (the select's rewind, the scan's tick) gives rows back:
+        // what gets repainted under it is counted again as it is written.
+        const up = /^\[(\d*)A$/.exec(token.slice(1));
+        if (up !== null) rows -= Math.max(1, Number(up[1] === "" ? "1" : up[1]));
+        continue;
+      }
+      const width = displayWidth(token);
+      if (width === 0) continue;
+      if (!Number.isFinite(limit)) {
+        column += width;
+        continue;
+      }
+      rows += Math.floor((column + width - 1) / limit);
+      column = (column + width - 1) % limit + 1;
+    }
+    return rows;
+  };
+  write = (chunk: string): void => {
+    if (arrivalLive) below.rows += rowsWritten(chunk);
+    rawWrite(chunk);
+  };
   const arrived = arrival === null
     ? Promise.resolve()
     : playBanner(
-      write,
+      rawWrite,
       bannerFrames(BANNER_COMPACT, bannerColorMode(env), BANNER_CONCEPT),
-      undefined,
+      // 90ms/frame ≈ 1.3s wave — it no longer holds anything hostage: the
+      // header, the scan and its checkmarks all land BELOW the art while it
+      // plays, so a longer wave is spectacle over work, not before it.
+      90,
       arrival.signal,
-    );
+      below,
+    ).finally(() => { arrivalLive = false; });
   const ensureHeader = (): void => {
     if (headerPrinted) return;
     headerPrinted = true;
-    // The mark is already on screen (abort settles it if it is still moving);
-    // this only adds the gap and the tagline under it.
+    // The wave keeps playing ABOVE this — content builds below the art and
+    // the paint loop clears over it each frame. Nothing aborts the arrival
+    // anymore; it finishes on its own while the run talks.
     if (arrival !== null) {
-      arrival.abort();
       write(`\n${dim(BANNER_TAGLINE)}\n\n`);
     }
     line(`${dim("┌")}  ${bold(command)}`);
@@ -802,6 +877,10 @@ export function createPrettyOutput(options: PrettyOptions = {}): PrettyOutput {
       code is the caller's — this only draws. */
   const cancel = (): void => {
     stopSpin();
+    // The one path that still cuts the wave: an interrupted run must not leave
+    // a half-drawn mark in the scrollback, and abort() paints the settled frame
+    // synchronously, before the `└ Cancelled` line lands under it.
+    arrival?.abort();
     write(SHOW_CURSOR);
     ensureHeader();
     rail.bar();
@@ -1020,6 +1099,41 @@ export function createPrettyOutput(options: PrettyOptions = {}): PrettyOutput {
       const tail = stats === undefined ? "" : ` ${dim(`— ${stats}`)}`;
       line(`${dim("└")}  ${ok ? green(`Done in ${seconds}`) : red(`Failed after ${seconds}`)}${tail}`);
       line(`   ${dim(STAR_FOOTER)}`);
+    },
+    async revealBlock(title, lines, options = {}) {
+      const { stepMs = 120, beat } = options;
+      const pause = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+      const items = lines.map((entry) => (typeof entry === "string" ? { text: entry } : entry));
+      // The scan builds BELOW the art while the wave still plays: header, then
+      // per-fact spinner lines that flip to a green ✓ when "found". The facts
+      // were computed before any of this — the beats are pacing that spends
+      // the wave's time on the user's app, not on the logo. Each tick rewinds
+      // the ROWS the last one took (a wrapped line is more than one) and erases
+      // to the end of the screen; the writer counts the rewind, so the art's
+      // repaint above stays exactly as far up as the content really reaches.
+      const scanLine = async (label: string, ms: number, resolveTo?: string): Promise<void> => {
+        let rows = line(`${BAR}  ${FRAMES[0]!} ${dim(label)}`);
+        const rewind = (): void => { write(`${ESC}[${rows}A${ESC}[0J`); };
+        const ticks = Math.max(1, Math.round(ms / 80));
+        for (let i = 1; i <= ticks; i += 1) {
+          await pause(80);
+          rewind();
+          rows = line(`${BAR}  ${lilac(FRAMES[i % FRAMES.length]!)} ${dim(label)}`);
+        }
+        rewind();
+        if (resolveTo !== undefined) line(`${BAR}  ${green("✓")} ${resolveTo}`);
+      };
+      settle();
+      rail.section(lilac("◆"), bold(title));
+      if (beat !== undefined) await scanLine(beat, 380);
+      for (const item of items) {
+        if (item.beat !== undefined) await scanLine(item.beat, 480, item.text);
+        else {
+          await pause(stepMs);
+          rail.body(`${green("✓")} ${item.text}`);
+        }
+      }
+      await arrived;
     },
   };
 }

--- a/packages/vendo/tests/cli/banner.test.ts
+++ b/packages/vendo/tests/cli/banner.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   BANNER_COMPACT,
   BANNER_CONCEPT,
@@ -13,6 +13,10 @@ import {
 
 const ESC = "\u001b";
 const CONCEPTS: BannerConcept[] = ["assembly", "flow", "shimmer"];
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 /** Drop SGR/cursor sequences so the art itself can be asserted. */
 function stripAnsi(text: string): string {
@@ -123,13 +127,15 @@ describe("bannerFrames", () => {
   });
 });
 
-/** One in-place frame redraw, exactly as playBanner writes it. */
-function redraw(frame: string): string {
-  return `${ESC}[${BANNER_COMPACT.length}A${frame.split("\n").map((row) => `${ESC}[2K${row}`).join("\n")}\n`;
+/** One in-place frame repaint, exactly as playBanner writes it: save the
+    cursor, rewind over the content below plus the art, paint, restore. */
+function redraw(frame: string, below = 0): string {
+  return `${ESC}7${ESC}[${BANNER_COMPACT.length + below}A`
+    + `${frame.split("\n").map((row) => `${ESC}[2K${row}`).join("\n")}${ESC}8`;
 }
 
 describe("playBanner", () => {
-  it("redraws in place, plays once, and ends on the settled frame", async () => {
+  it("repaints in place, plays once, and ends on the settled frame", async () => {
     const chunks: string[] = [];
     const frames = bannerFrames(BANNER_COMPACT, "ansi", BANNER_CONCEPT);
     await playBanner((chunk) => { chunks.push(chunk); }, frames, 0);
@@ -138,8 +144,11 @@ describe("playBanner", () => {
     // alternate screen buffer, ever.
     expect(written.split(`${ESC}[${BANNER_COMPACT.length}A`)).toHaveLength(frames.length);
     expect(written).not.toContain("?1049h");
-    expect(written.endsWith(`${frames.at(-1)!.split("\n").map((row) => `${ESC}[2K${row}`).join("\n")}\n`))
-      .toBe(true);
+    // Every repaint is bracketed: the cursor ends where the caller left it, so
+    // a run printing below the art is never moved by a frame.
+    expect(written.split(`${ESC}7`)).toHaveLength(frames.length);
+    expect(written.split(`${ESC}8`)).toHaveLength(frames.length);
+    expect(written.endsWith(redraw(frames.at(-1)!))).toBe(true);
 
     // Played once: nothing is written after it resolves.
     const settled = chunks.length;
@@ -161,14 +170,49 @@ describe("playBanner", () => {
     expect(chunks.join("")).toBe(`${frames[0]!}\n`);
 
     arrival.abort();
-    // Synchronously, before abort() returned: whatever the caller prints on the
-    // very next statement lands under the FINISHED mark, never a half-drawn one.
+    // Synchronously, before abort() returned: an interrupted run leaves the
+    // FINISHED mark on screen, never a half-drawn one.
     expect(chunks.join("")).toBe(`${frames[0]!}\n${redraw(frames.at(-1)!)}`);
 
     const settled = chunks.length;
     await played;
     await new Promise((resolve) => { setTimeout(resolve, 20); });
     expect(chunks).toHaveLength(settled);
+  });
+
+  it("below mode: every frame rewinds over the caller's content as it grows", async () => {
+    vi.useFakeTimers();
+    const chunks: string[] = [];
+    const frames = bannerFrames(BANNER_COMPACT, "ansi", BANNER_CONCEPT);
+    // The caller prints two more rows between every frame, exactly as a run
+    // that keeps talking under the wave does.
+    const below = { rows: 0 };
+    const played = playBanner((chunk) => { chunks.push(chunk); }, frames, 10, undefined, below);
+    const growth: number[] = [];
+    for (let at = 1; at < frames.length; at += 1) {
+      below.rows += 2;
+      growth.push(below.rows);
+      await vi.advanceTimersByTimeAsync(10);
+    }
+    await played;
+
+    // One rewind per frame after the first, each over art + the content that
+    // existed when it painted — the arithmetic the art depends on.
+    const offsets = [...chunks.join("").matchAll(new RegExp(`${ESC}7${ESC}\\[(\\d+)A`, "g"))]
+      .map((match) => Number(match[1]));
+    expect(offsets).toEqual(growth.map((rows) => BANNER_COMPACT.length + rows));
+    // And the paint still ends on the settled frame, still bracketed.
+    expect(chunks.join("").endsWith(redraw(frames.at(-1)!, below.rows))).toBe(true);
+  });
+
+  it("below mode: an abort settles the mark above the content, not over it", () => {
+    const chunks: string[] = [];
+    const frames = bannerFrames(BANNER_COMPACT, "ansi", BANNER_CONCEPT);
+    const arrival = new AbortController();
+    const below = { rows: 5 };
+    void playBanner((chunk) => { chunks.push(chunk); }, frames, 5, arrival.signal, below);
+    arrival.abort();
+    expect(chunks.join("")).toBe(`${frames[0]!}\n${redraw(frames.at(-1)!, 5)}`);
   });
 
   it("an abort after it already settled redraws nothing", async () => {

--- a/packages/vendo/tests/cli/init-mcp.test.ts
+++ b/packages/vendo/tests/cli/init-mcp.test.ts
@@ -3,7 +3,7 @@ import { dirname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { doorWellKnownPaths } from "../../src/door-paths.js";
-import { generateServiceKey, planMcp, wellKnownRouteSource, type McpPlan, type McpPlanInput } from "../../src/cli/init-mcp.js";
+import { generateServiceKey, mcpStepLines, planMcp, wellKnownRouteSource, type McpPlan, type McpPlanInput } from "../../src/cli/init-mcp.js";
 
 const cleanup: string[] = [];
 afterEach(async () => {
@@ -117,28 +117,28 @@ describe("planMcp — the service key", () => {
 
 describe("planMcp — the two steps that stay the user's", () => {
   it("puts the base URL FIRST, always", () => {
-    expect(plan().steps[0]).toContain("Set VENDO_BASE_URL");
-    expect(plan({ baseUrl: null }).steps[0]).toContain("Set VENDO_BASE_URL");
-    expect(plan({ posture: "broker", serviceKey: true }).steps[0]).toContain("Set VENDO_BASE_URL");
+    expect(plan().steps[0]).toContain("Set `VENDO_BASE_URL`");
+    expect(plan({ baseUrl: null }).steps[0]).toContain("Set `VENDO_BASE_URL`");
+    expect(plan({ posture: "broker", serviceKey: true }).steps[0]).toContain("Set `VENDO_BASE_URL`");
   });
 
   it("names the captured origin when there is one, and the risk when there is not", () => {
-    expect(plan().steps[0]).toContain("https://app.acme.com, captured earlier, is in .env.example");
+    expect(plan().steps[0]).toContain("`https://app.acme.com` — captured earlier, already in .env.example");
     expect(plan({ baseUrl: null }).steps[0]).toContain("points at the wrong origin");
   });
 
   it("points clients at the same URL in BOTH postures — it derives from the base URL, never the broker", () => {
-    const client = "Point any MCP client at https://app.acme.com/api/vendo/mcp";
-    expect(plan().steps).toContain(client);
-    expect(plan({ posture: "broker" }).steps).toContain(client);
+    const client = "Point any MCP client at `https://app.acme.com/api/vendo/mcp`";
+    expect(plan().steps.map((step) => step.split("\n")[0])).toContain(client);
+    expect(plan({ posture: "broker" }).steps.map((step) => step.split("\n")[0])).toContain(client);
   });
 });
 
 describe("planMcp — the sign-in posture", () => {
   it("prints the operator's two broker lines under broker posture, and nothing under local", () => {
     expect(plan({ posture: "broker" }).envLines).toEqual([
-      "VENDO_MCP_BROKER_URL=<your tenant MCP endpoint, from the console MCP page>",
-      "VENDO_MCP_FEDERATION_SECRET=<from the console MCP page>",
+      "`VENDO_MCP_BROKER_URL=<your tenant MCP endpoint>`",
+      "`VENDO_MCP_FEDERATION_SECRET=<secret>`",
     ]);
     expect(plan().envLines).toEqual([]);
   });
@@ -148,6 +148,39 @@ describe("planMcp — the sign-in posture", () => {
   it("adds the keyless pointer only when no Cloud key is in hand", () => {
     expect(plan({ cloudKey: false }).steps.join("\n")).toContain("Sign-in: your app serves its own OAuth");
     expect(plan().steps.join("\n")).not.toContain("Sign-in: your app serves its own OAuth");
+  });
+});
+
+describe("mcpStepLines — the closing block reads as steps, not a wall", () => {
+  it("numbers every headline and indents its detail under it", () => {
+    const broker = plan({ posture: "broker", serviceKey: true });
+    const lines = mcpStepLines(broker);
+    // Every step's headline is numbered in order...
+    const numbered = lines.filter((line) => /^\d+\. /.test(line));
+    expect(numbered).toHaveLength(broker.steps.length);
+    expect(numbered.map((line) => line.split(". ")[0])).toEqual(
+      broker.steps.map((_step, index) => String(index + 1)),
+    );
+    // ...and every detail line is indented under the headline it belongs to,
+    // never left at the margin where it would read as another step.
+    for (const [index, step] of broker.steps.entries()) {
+      const [headline, ...detail] = step.split("\n");
+      const at = lines.indexOf(`${index + 1}. ${headline!}`);
+      expect(at).toBeGreaterThanOrEqual(0);
+      expect(lines.slice(at + 1, at + 1 + detail.length)).toEqual(detail.map((rest) => `   ${rest}`));
+    }
+  });
+
+  it("closes with the env values as their own group, and skips the group under local", () => {
+    const broker = plan({ posture: "broker" });
+    const lines = mcpStepLines(broker);
+    const at = lines.indexOf("");
+    // A blank line, one sentence saying where they go, then the values.
+    expect(at).toBeGreaterThan(0);
+    expect(lines[at + 1]).toContain("Set where you deploy");
+    expect(lines.slice(at + 2)).toEqual(broker.envLines.map((env) => `   ${env}`));
+    // Local posture has no env lines, so it gets no group and no blank line.
+    expect(mcpStepLines(plan()).filter((line) => line === "")).toEqual([]);
   });
 });
 

--- a/packages/vendo/tests/cli/init.test.ts
+++ b/packages/vendo/tests/cli/init.test.ts
@@ -192,6 +192,35 @@ describe("vendo init (zero-question)", () => {
     expect(logs).not.toContain("vendo refine");
   });
 
+  // A plain transcript is parsed as often as it is read, so the MCP steps keep
+  // their exact strings there — the newline inside a step becomes an indent and
+  // nothing else. (The pretty run numbers the same strings; mcpStepLines owns
+  // that half.)
+  it("mcp: the plain transcript indents each step's detail under its headline", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vendo-init-mcp-plain-"));
+    cleanup.push(root);
+    await mkdir(join(root, "app"), { recursive: true });
+    await writeFile(join(root, "package.json"), JSON.stringify({
+      name: "mcp-host",
+      dependencies: { next: "16.0.0", "@clerk/nextjs": "7.0.0" },
+    }));
+    await writeFile(join(root, "tsconfig.json"), "{}\n");
+    await writeFile(join(root, "app", "layout.tsx"),
+      "export default function Layout({ children }) { return <html><body>{children}</body></html>; }\n");
+    const sink = output();
+    expect(await run(root, sink, {
+      useCase: "mcp", yes: true, auth: "clerk", baseUrl: "https://app.acme.com",
+    })).toBe(0);
+    const logs = sink.logs.join("\n");
+    expect(logs).toContain(
+      "  Set `VENDO_BASE_URL` in your deploy platform\n"
+      + "    `https://app.acme.com` — captured earlier, already in .env.example",
+    );
+    // The headline of a step is never indented past two spaces, so a reader
+    // (and a grep) can still tell a step from its detail.
+    expect(logs).toContain("  Point any MCP client at `https://app.acme.com/api/vendo/mcp`\n    your users' setup page");
+  });
+
   it("is idempotent: a re-run changes nothing and says so", async () => {
     const root = await fixture();
     expect(await run(root, output())).toBe(0);

--- a/packages/vendo/tests/cli/pretty.test.ts
+++ b/packages/vendo/tests/cli/pretty.test.ts
@@ -2,7 +2,7 @@ import { PassThrough, Writable } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createPrettyOutput, displayWidth, plainSelect, usePrettyOutput, type SelectInput } from "../../src/cli/pretty.js";
 import { plainSecret, plainText } from "../../src/cli/pretty.js";
-import { BANNER_COMPACT, BANNER_CONCEPT, bannerFrames } from "../../src/cli/banner.js";
+import { BANNER_COMPACT, BANNER_CONCEPT, BANNER_TAGLINE, bannerFrames } from "../../src/cli/banner.js";
 
 const ESC = "\u001b";
 
@@ -100,15 +100,25 @@ describe("createPrettyOutput (visual system)", () => {
     expect(out.plain()).toContain("┌  vendo sync");
   });
 
-  it("prints the settled banner and the tagline above the header, and skips both when asked", () => {
+  it("prints the banner and the tagline above the header, and skips both when asked", async () => {
+    vi.useFakeTimers();
     const withBanner = sink();
-    createPrettyOutput({ write: withBanner.write, env: { COLORTERM: "truecolor" } }).log("hello");
+    const frames = bannerFrames(BANNER_COMPACT, "truecolor", BANNER_CONCEPT);
+    const pretty = createPrettyOutput({ write: withBanner.write, env: { COLORTERM: "truecolor" } });
+    pretty.log("hello");
     const plain = withBanner.plain();
-    expect(plain).toContain("▄▄█████▄");
+    // The art is on screen first and everything else lands under it — the
+    // tagline, then the header.
+    expect(plain.indexOf(stripAnsi(frames[0]!))).toBe(0);
     expect(plain).toContain("Customize your product with an embedded agent");
-    expect(plain.indexOf("▄▄█████▄")).toBeLessThan(plain.indexOf("┌  vendo init"));
+    expect(plain.indexOf("Customize your product")).toBeLessThan(plain.indexOf("┌  vendo init"));
     // Truecolor terminals get the real brand ramp.
     expect(withBanner.raw()).toContain(`${ESC}[38;2;`);
+    // …and the mark the wave settles on is the whole one.
+    await vi.advanceTimersByTimeAsync(90 * frames.length);
+    await pretty.arrived;
+    expect(withBanner.plain()).toContain("▄▄█████▄");
+    expect(withBanner.plain()).toContain(BANNER_COMPACT.join("\n"));
 
     const without = sink();
     createPrettyOutput({ write: without.write, banner: false }).log("hello");
@@ -143,20 +153,30 @@ describe("createPrettyOutput (visual system)", () => {
     expect(plain.lastIndexOf(BANNER_COMPACT.join("\n"))).toBeLessThan(plain.indexOf("┌  vendo init"));
   });
 
-  it("a line printed mid-arrival settles the mark first — the header never lands on a half-drawn one", () => {
+  // The header used to CUT the arrival. It does not any more: it prints below
+  // the art and the frames keep repainting above it, which is the whole point
+  // of the composited arrival.
+  it("a line printed mid-arrival lands below the art and never cuts the wave", async () => {
+    vi.useFakeTimers();
     const out = sink();
     const frames = bannerFrames(BANNER_COMPACT, "truecolor", BANNER_CONCEPT);
     const pretty = createPrettyOutput({ write: out.write, env: { COLORTERM: "truecolor" } });
     // Not one frame has had time to tick; the run wants the screen anyway.
     expect(out.raw()).toBe(`${frames[0]!}\n`);
     pretty.log("hello");
-    const plain = out.plain();
-    // The mark is whole, and everything else is under it: the animation can
-    // never delay a line, and never costs one either.
-    expect(plain).toContain(BANNER_COMPACT.join("\n"));
-    expect(plain.indexOf(BANNER_COMPACT.join("\n")))
-      .toBeLessThan(plain.indexOf("Customize your product with an embedded agent"));
-    expect(plain.indexOf("Customize your product")).toBeLessThan(plain.indexOf("┌  vendo init"));
+    // Frame one still stands: nothing settled the mark, and the header is under
+    // it. The wave was not aborted, it was composited over.
+    expect(out.plain()).not.toContain(BANNER_COMPACT.join("\n"));
+    expect(out.plain().indexOf("Customize your product")).toBeLessThan(out.plain().indexOf("┌  vendo init"));
+
+    // The next frame rewinds over the art AND the six rows the header cost
+    // (blank, tagline, blank, `┌`, `│`, the line itself).
+    await vi.advanceTimersByTimeAsync(90);
+    expect(out.raw()).toContain(`${ESC}7${ESC}[${BANNER_COMPACT.length + 6}A`);
+
+    await vi.advanceTimersByTimeAsync(90 * frames.length);
+    await expect(pretty.arrived).resolves.toBeUndefined();
+    expect(out.plain()).toContain(BANNER_COMPACT.join("\n"));
   });
 
   it("banner: false starts no arrival — no frames, no cursor games, and nothing to await", async () => {
@@ -168,14 +188,17 @@ describe("createPrettyOutput (visual system)", () => {
   });
 
   // `arrived` is what init awaits before its first block. It must settle on a
-  // run that never let the arrival finish too, or the wait becomes a hang.
-  it("arrived settles even when a line cut the arrival short", async () => {
+  // run that talked all the way through the wave, or the wait becomes a hang.
+  it("arrived settles on a run that printed all through the arrival", async () => {
     vi.useFakeTimers();
     const out = sink();
+    const frames = bannerFrames(BANNER_COMPACT, "truecolor", BANNER_CONCEPT);
     const pretty = createPrettyOutput({ write: out.write, env: { COLORTERM: "truecolor" } });
-    pretty.log("hello");
     const waited = pretty.arrived;
-    await vi.advanceTimersByTimeAsync(90);
+    for (let at = 0; at < frames.length; at += 1) {
+      pretty.log(`line ${at}`);
+      await vi.advanceTimersByTimeAsync(90);
+    }
     await expect(waited).resolves.toBeUndefined();
   });
 
@@ -923,10 +946,16 @@ const cells = (text: string): number => {
     below are about the settled SCREEN, which is where these bugs were visible.
     Writes only ever land at the end of a row or at column 0 after an erase,
     which is why the model can treat column 0 as "replace the row". */
-function screen(columns: number): { write: (chunk: string) => void; rows: () => string[] } {
+function screen(columns: number): {
+  write: (chunk: string) => void;
+  rows: () => string[];
+  /** Which row the cursor sits on — what the art's repaint has to rewind to. */
+  cursor: () => number;
+} {
   const rows: string[] = [""];
   let at = 0;
   let col = 0;
+  let saved = { at: 0, col: 0 };
   const graphemes = new Intl.Segmenter(undefined, { granularity: "grapheme" });
   const put = (text: string): void => {
     // A terminal places GLYPHS, so the model does too: a cluster never splits
@@ -945,7 +974,7 @@ function screen(columns: number): { write: (chunk: string) => void; rows: () => 
   };
   return {
     write: (chunk) => {
-      for (const token of chunk.match(/\u001b\[[0-9;?]*[A-Za-z]|\n|\r|[^\u001b\n\r]+/g) ?? []) {
+      for (const token of chunk.match(/\u001b[78]|\u001b\[[0-9;?]*[A-Za-z]|\n|\r|[^\u001b\n\r]+/g) ?? []) {
         if (token === "\n") {
           at += 1;
           col = 0;
@@ -954,6 +983,10 @@ function screen(columns: number): { write: (chunk: string) => void; rows: () => 
         }
         if (token === "\r") { col = 0; continue; }
         if (token.startsWith(ESC)) {
+          // Save/restore (ESC 7 / ESC 8) is how the art repaints above the
+          // content without moving the cursor the run prints at.
+          if (token === `${ESC}7`) { saved = { at, col }; continue; }
+          if (token === `${ESC}8`) { ({ at, col } = saved); continue; }
           const up = /^\u001b\[(\d*)A$/.exec(token);
           if (up !== null) { at = Math.max(0, at - (up[1] === "" ? 1 : Number(up[1]))); continue; }
           if (token === `${ESC}[2K`) { rows[at] = ""; continue; }
@@ -968,6 +1001,7 @@ function screen(columns: number): { write: (chunk: string) => void; rows: () => 
       }
     },
     rows: () => rows,
+    cursor: () => at,
   };
 }
 
@@ -1195,5 +1229,130 @@ describe("createPrettyOutput (display width — wide glyphs and combining marks)
     // CJK run, between two glyphs.
     const strip = (text: string): string => text.replace(/\s+/g, "");
     expect(strip(answer.map((row) => row.slice(3)).join(""))).toBe(strip(`● ${options[1]!.label}`));
+  });
+});
+
+/** THE COMPOSITED ARRIVAL. The wave plays while the run keeps printing under
+    it, and the art repaints itself by rewinding a ROW COUNT — so every
+    assertion here is really about that count. They are made against the screen
+    model above, which measures the terminal's own way, and never against the
+    renderer's belief about its own output: a model that asked the renderer how
+    wide its lines were could not disagree with it.
+
+    72 columns is the width the art fits EXACTLY, so the only thing that wraps
+    is a content line — which is the desync a newline count cannot see. */
+describe("createPrettyOutput (the composited arrival)", () => {
+  /** A host with three auth dependencies. 73 cells + the rail is 76: two
+      screen rows at 72 columns, one newline either way. */
+  const LONG_FACT = "Clerk / Auth.js / Supabase auth (@clerk/nextjs, next-auth, @supabase/ssr)";
+  const STACK_FACT = "Next.js · App Router · TypeScript · pnpm";
+  const SPINNER = /[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/;
+
+  const artRows = (term: { rows: () => string[] }): string[] =>
+    term.rows().slice(0, BANNER_COMPACT.length);
+
+  /** init's own reveal, verbatim in shape: a leading beat, then one labelled
+      beat per fact. Returns the settled screen, plus — for every frame the art
+      painted — the rows it rewound by and the row the cursor was really on. */
+  async function reveal(columns: number): Promise<{
+    term: ReturnType<typeof screen>;
+    paints: { rewound: number; cursorWas: number }[];
+  }> {
+    const term = screen(columns);
+    const paints: { rewound: number; cursorWas: number }[] = [];
+    const startsPaint = new RegExp(`^${ESC}7${ESC}\\[(\\d+)A$`);
+    const pretty = createPrettyOutput({
+      write: (chunk) => {
+        const paint = startsPaint.exec(chunk);
+        if (paint !== null) paints.push({ rewound: Number(paint[1]), cursorWas: term.cursor() });
+        term.write(chunk);
+      },
+      columns,
+      env: { COLORTERM: "truecolor" },
+    });
+    // The wrapping fact resolves FIRST, so it lands while the wave is still
+    // playing — which is where a mis-counted row shows up. (A narrow window
+    // does this to every fact; here one long one is enough.)
+    const revealed = pretty.revealBlock("Your stack", [
+      { beat: "Checking auth…", text: LONG_FACT },
+      { beat: "Detecting your framework…", text: STACK_FACT },
+    ], { beat: "Reading your app…" });
+    await vi.advanceTimersByTimeAsync(5000);
+    await revealed;
+    return { term, paints };
+  }
+
+  it("keeps the mark whole above a scan whose fact WRAPS — the row count, not the newline count", async () => {
+    vi.useFakeTimers();
+    const { term, paints } = await reveal(72);
+
+    // The arithmetic first, because everything else follows from it: the art
+    // starts at row zero, so the rows a frame rewinds by must equal the row the
+    // cursor was really on. A newline count is short from the wrapping line on.
+    expect(paints.length).toBeGreaterThan(8);
+    expect(paints.map((paint) => paint.rewound)).toEqual(paints.map((paint) => paint.cursorWas));
+
+    // The art is untouched and exactly where it started.
+    expect(artRows(term)).toEqual([...BANNER_COMPACT]);
+    const below = term.rows().slice(BANNER_COMPACT.length);
+    const settled = below.join("\n");
+    expect(settled).toContain(BANNER_TAGLINE.trim());
+    expect(settled).toContain("┌  vendo init");
+    expect(settled).toContain("◆  Your stack");
+    expect(settled).toContain(`│  ✓ ${STACK_FACT}`);
+
+    // The wrapping fact is one rail body line over two screen rows, and every
+    // row the terminal shows fits the window.
+    const at = below.findIndex((row) => row.includes("✓ Clerk"));
+    expect(below[at + 1]!.startsWith("│  ")).toBe(true);
+    // Whitespace-insensitive: the row break lands ON the space it broke at.
+    const strip = (text: string): string => text.replace(/\s+/g, "");
+    expect(strip(below.slice(at, at + 2).map((row) => row.slice(3)).join("")))
+      .toBe(strip(`✓ ${LONG_FACT}`));
+    for (const row of term.rows()) expect(cells(row)).toBeLessThanOrEqual(72);
+
+  });
+
+  it("resolves every beat into a ✓ fact and leaves no spinner behind", async () => {
+    vi.useFakeTimers();
+    const { term } = await reveal(100);
+    const settled = term.rows().slice(BANNER_COMPACT.length).join("\n");
+    // The scan narrated, then answered: the labels are rewritten in place, so
+    // the settled transcript is facts only.
+    expect(settled).toContain(`✓ ${STACK_FACT}`);
+    expect(settled).toContain(`✓ ${LONG_FACT}`);
+    expect(settled).not.toContain("Reading your app");
+    expect(settled).not.toContain("Detecting your framework");
+    expect(settled).not.toContain("Checking auth");
+    expect(settled).not.toMatch(SPINNER);
+    // …in the order they were handed over, under the section title.
+    expect(settled.indexOf("◆  Your stack")).toBeLessThan(settled.indexOf("✓ Clerk"));
+    expect(settled.indexOf("✓ Clerk")).toBeLessThan(settled.indexOf(STACK_FACT));
+    expect(artRows(term)).toEqual([...BANNER_COMPACT]);
+  });
+
+  it("Ctrl-C mid-wave settles the mark and closes the rail under it", () => {
+    const term = screen(72);
+    const keys = fakeInput();
+    const exit = vi.spyOn(process, "exit").mockImplementation((code) => {
+      throw new Error(`exit:${String(code)}`);
+    });
+    try {
+      const pretty = createPrettyOutput({
+        write: term.write, input: keys.input, columns: 72, env: { COLORTERM: "truecolor" },
+      });
+      // Not one frame has ticked: the mark on screen is the first frame.
+      expect(artRows(term)).not.toEqual([...BANNER_COMPACT]);
+      void pretty.select("How will people use your agent?", [...USE_CASE_OPTIONS]).catch(() => undefined);
+      expect(() => keys.press("\u0003")).toThrow("exit:130");
+    } finally {
+      exit.mockRestore();
+    }
+    // The interrupt is the one path that still cuts the wave, and it leaves the
+    // FINISHED mark behind — with the rail closed under it, not over it.
+    expect(artRows(term)).toEqual([...BANNER_COMPACT]);
+    const rows = term.rows().filter((row) => row !== "");
+    expect(rows.at(-1)).toBe("└  Cancelled");
+    expect(rows.join("\n")).not.toContain("○");
   });
 });


### PR DESCRIPTION
The banner arrival used to be a thing that happened *before* the run: the first
line printed cut it to the settled mark, so the wave was either spectacle you
waited on or spectacle you never saw. Now it composites. The frames repaint in
place **above** whatever the run has printed since, so the tagline, the header
and a narrated detection scan all build under a wave that is still playing — and
the facts about your app land as green checkmarks while it does.

**Provenance:** the behavior in `banner.ts`, `pretty.ts`, `init.ts` and
`init-mcp.ts` is Yousef's, locked live in a demo worktree and applied here
verbatim. What this PR adds on top is the hardening the demo deliberately
skipped: wrap safety, the stale contract comment, tests, and the cancel path.

## What changed

- **`playBanner` takes `below: { rows }`** — each frame saves the cursor, rewinds
  over content + art, paints, restores (`ESC 7` / `ESC 8`). The caller keeps
  talking; the art keeps arriving. The old status-line parameter is gone.
- **`revealBlock`** (new on `PrettyOutput`) is the scan: a labelled spinner beat
  per fact, rewritten in place into a `✓ fact`. `init` maps its stack lines onto
  beats — *Reading your app… / Detecting your framework… / Checking auth…* — so
  the wave's 1.3s is spent on the user's app instead of on the logo.
- **The write wrapper is now the one thing that models the cursor.** It counts
  **screen rows**, not newlines: `displayWidth` from #1152 for wrapped rows, and
  it gives rows back on a cursor-up, so the select's rewind and the scan's tick
  both stay accounted for. `revealBlock` therefore does no row arithmetic of its
  own, and the art's repaint is always exactly as far up as the content reaches.
- **Ctrl-C is the one path that still cuts the wave.** `cancel()` aborts the
  arrival, so an interrupted run leaves the finished mark in the scrollback, not
  a half-drawn one. (Removing `ensureHeader`'s abort had regressed this.)
- **init's MCP closing steps read as steps.** A plan step is
  `headline\ndetail`; `mcpStepLines` numbers the headlines and indents the detail
  for the pretty run, the plain transcript indents the detail under its headline,
  and the two broker env values get their own group under one sentence saying
  where they go. Some step copy was reworded in the locked patch (including the
  "exchange it at `<your tenant URL>/token`" phrasing) and the env names are code
  spans now.
- `arrived`'s doc comment was stale the moment nothing aborted; it now states the
  real contract (nothing cuts it, content coexists below, cancel settles it).

## Fail-first

The demo's counter was `chunk.match(/\n/g).length` and its scan rewound one row,
always:

```ts
// before — a newline count, and a row-blind rewind
if (arrivalLive) below.rows += (chunk.match(/\n/g) ?? []).length;
...
rawWrite(`${ESC}[1A${ESC}[2K${prefix}${green("✓")} ${resolveTo}\n`);
```

```ts
// after — screen rows, cursor-up included; the scan rewinds the rows it took
if (arrivalLive) below.rows += rowsWritten(chunk);
...
let rows = line(`${BAR}  ${FRAMES[0]!} ${dim(label)}`);
const rewind = (): void => { write(`${ESC}[${rows}A${ESC}[0J`); };
```

A fact one row wider than the window is all it takes. Put the naive version back
and the new test reports the desync directly — the art rewinds 20 rows while the
cursor is on row 21, from the wrapping line onward:

```
FAIL  tests/cli/pretty.test.ts > createPrettyOutput (the composited arrival)
      > keeps the mark whole above a scan whose fact WRAPS

AssertionError: expected [ Array(14) ] to deeply equal [ Array(14) ]
    19,          19,
-   21,      +   20,
-   21,      +   20,
```

With the fix: 107 passed in `banner.test.ts` + `pretty.test.ts`, 222 across the
four touched files.

The assertions are made against the test file's own terminal model (extended
here with `ESC 7` / `ESC 8`), which measures the screen the terminal's way — a
model that asked the renderer how wide its lines were could never disagree with
it.

## Tests

- `playBanner` below-mode paint math (offsets grow with `below.rows`, every paint
  bracketed, abort settles above the content).
- The write wrapper's row counting, including a wrapping fact: every frame's
  rewind equals the row the cursor was really on.
- `revealBlock` beats resolve to `✓` lines, in order, with no spinner left behind
  and the art untouched after the in-place rewrites.
- `ensureHeader` during the wave: the header lands below the art, the wave is not
  aborted, `arrived` still settles.
- Ctrl-C mid-wave settles the mark and closes the rail under it.
- `mcpStepLines` numbering/indent/env group, and the plain path's `\n → indent`
  mapping through a real `vendo init --use-case mcp` run.

## Verified in a real PTY

One `vhs` run of the built CLI against a freshly stripped copy of the coldwalk
host (`.vendo/`, `app/api/vendo/` and the well-known route moved out, never
deleted). The wave plays while the tagline, header and scan build below it; the
checkmarks land; nothing tears; the question appears; Ctrl-C settles the mark.

![the composited arrival](https://raw.githubusercontent.com/runvendo/vendo/assets/composited-arrival/init-composited-arrival.gif)

Mid-wave — the art is still arriving while the scan narrates under it:

![mid-wave](https://raw.githubusercontent.com/runvendo/vendo/assets/composited-arrival/still-midwave-scan-below.png)

The first fact lands while the wave still plays:

![first fact](https://raw.githubusercontent.com/runvendo/vendo/assets/composited-arrival/still-first-fact-lands.png)

Settled mark, both facts checkmarked, question up:

![settled](https://raw.githubusercontent.com/runvendo/vendo/assets/composited-arrival/still-settled-and-question.png)

Ctrl-C mid-run: the finished mark stays, the rail closes:

![cancelled](https://raw.githubusercontent.com/runvendo/vendo/assets/composited-arrival/still-ctrlc-settles-mark.png)

## Changeset

`.changeset/composited-arrival.md` — patch bump of `@vendoai/vendo`: the arrival
composites over the detection scan (checkmarked facts land while the wave plays),
and init's MCP closing steps gain real formatting.

## Gate

`pnpm build` ✓ · `pnpm test:affected` ✓ · `pnpm typecheck` ✓ · `pnpm lint` ✓.

`test:affected` first reported `automations-e2e` and `integration` red: both
booted `next dev` in the same fixture dir at once locally ("Another next dev
server is already running"). Re-run serially, both green (66 and 48 tests) — CI
gives them separate jobs.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworked the `vendo init` banner to composite over ongoing output: the wave keeps playing above while the scan narrates and facts land as green checkmarks. Terminal repainting is now row-aware, and Ctrl-C settles the finished mark.

- **New Features**
  - `playBanner` adds `below: { rows }` and repaints frames above content using `ESC 7/ESC 8`.
  - `PrettyOutput.revealBlock` plays labeled spinner beats, then rewrites each to `✓ fact`.
  - `mcpStepLines` formats MCP steps: numbered headlines, indented detail, grouped env lines.
  - Plain transcripts indent step detail (`\n → indent`) without numbering.

- **Bug Fixes**
  - Writer counts screen rows via `displayWidth` and accounts for cursor-up; no desync on wrapped lines.
  - Arrival is no longer cut by the first line; content builds below the art. `cancel()` aborts to settle the mark.
  - Tests cover repaint offsets, row counting, reveal correctness, header during wave, Ctrl-C, and MCP formatting.

<sup>Written for commit 81b257e25232a70c33b3b166027c43b989bd9ffa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

