### PR TITLE
ci(release): version PRs get real CI and tags actually push

### DIFF
--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -1,13 +1,19 @@
 name: Version Packages
 
 # Keeps a "chore: version packages" PR open on main whenever there are
-# pending changesets. Releasing = merge that PR, then push the v* tag
-# (release.yml does the publish). No `publish` input on purpose — publishing
-# stays on the tag so a release is always a deliberate act.
+# pending changesets. Releasing = merge that PR; the post-merge run of this
+# workflow pushes the `v<version>` tag, and release.yml (tag-triggered) does
+# the publish. No `publish` input on purpose — publishing stays on the tag so a
+# release is always a deliberate act.
 #
-# Known GitHub limitation: PRs opened by the default GITHUB_TOKEN do not
-# trigger CI. Close and reopen the Version Packages PR (or push any commit to
-# it) to run checks before merging.
+# RELEASE_PAT (optional repo secret, and what makes the automation real):
+# GitHub deliberately never triggers workflows from anything pushed with the
+# default GITHUB_TOKEN — not the version PR's commits, not the tag. Without the
+# secret this workflow behaves exactly as it did before: the version PR gets no
+# checks until you close and reopen it, and the tag lands but release.yml has to
+# be run by hand. With it, the version PR gets CI on open and the tag push fires
+# release.yml. Fine-grained PAT scoped to this repo only — Contents:
+# read+write, Pull requests: read+write — stored as the secret RELEASE_PAT.
 
 on:
   push:
@@ -25,16 +31,41 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+          # The PAT has to be here too, not just on the action: changesets/action
+          # pushes the version branch with a plain `git push`, so it uses the
+          # credentials checkout persists. The tag push below does the same.
+          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
+      - id: changesets
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: pnpm changeset:version
           commit: "chore: version packages"
           title: "chore: version packages"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+
+      # No changesets left = this push is the version PR landing (or an ordinary
+      # commit after a release, where the tag already exists and this no-ops), so
+      # package.json already holds the released version. `changeset tag` is
+      # deliberately not used: in a workspace it writes one `<pkg>@<version>` tag
+      # per package, and release.yml — like every release so far — is keyed on
+      # the single lockstep `v<version>`. packages/vendo is the version of record
+      # (scripts/sync-version-constants.mjs reads the same file).
+      - name: Push the release tag
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        run: |
+          set -euo pipefail
+          tag="v$(node -p "require('./packages/vendo/package.json').version")"
+          if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "$tag already exists — nothing to release"
+            exit 0
+          fi
+          git tag "$tag"
+          git push origin "refs/tags/$tag"
+          echo "pushed $tag -> $(git rev-parse HEAD)"


### PR DESCRIPTION
## What

`.github/workflows/version-packages.yml` only — no package code, no publishing credentials, no other workflow touched.

1. **Token.** `actions/checkout` and `changesets/action` now use `${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}`. Both need it: the action talks to the API with `GITHUB_TOKEN` (env wins over the `github-token` input in v1.9.0 — `process.env.GITHUB_TOKEN || getInput("github-token")`), but it pushes the version branch with a plain `git push`, i.e. with the credentials `checkout` persists as `http.https://github.com/.extraheader`. Without the secret, behavior is exactly today's.
2. **Tag.** A new final step pushes `v<version>` when `steps.changesets.outputs.hasChangesets == 'false'` — the post-merge run, where the version PR has just landed and `package.json` already holds the released version. Guarded by `git ls-remote`, so ordinary main pushes and re-runs no-op. `release.yml` stays the publish path, untouched.

`changeset tag` is deliberately **not** used, despite being the obvious move: in a workspace it writes one `<pkg>@<version>` tag per package (`@vendoai/core@0.14.0`, …), plus `@vendoai/telemetry@0.5.0` which is outside the fixed group on purpose. None of those match `release.yml`'s `tags: ["v*"]` filter, and every release in this repo's history is a single lockstep `vX.Y.Z`. `packages/vendo/package.json` is the version of record — `scripts/sync-version-constants.mjs` already reads the same file.

## Why

Both defects were observed end-to-end on v0.12.0 and v0.13.0 (2026-08-10). Merge strategy is irrelevant — both releases failed the same way.

### Defect 1 — the version PR gets zero CI

GitHub deliberately never triggers workflows from pushes made with the default `GITHUB_TOKEN`, so neither the PR-open nor the bot's force-pushes produce a `pull_request` event, and `ci.yml` (`on: pull_request`) never fires.

**PR #1179 → v0.12.0**

| time (UTC) | event |
| --- | --- |
| 19:15:16 | #1179 opened by `github-actions[bot]` — **zero checks** |
| 19:23:59 | `head_ref_force_pushed` by `github-actions[bot]` — still zero |
| 19:57:30 | `head_ref_force_pushed` by `github-actions[bot]` — still zero |
| 19:58:32 / 19:58:34 | **closed + reopened by `yousefh409`** (the manual bridge) |
| 19:58:45 | CI run [31426747721](https://github.com/runvendo/vendo/actions/runs/31426747721) finally starts — **43 min after the PR opened** |
| 20:10:54 | merged → `447c2123952cb49a1f2d01046f601e2f2a662fd1` |

**PR #1182 → v0.13.0**

| time (UTC) | event |
| --- | --- |
| 20:13:27 | #1182 opened by `github-actions[bot]` — **zero checks** |
| 20:44:44 → 23:22:21 | **six** `head_ref_force_pushed` by `github-actions[bot]` (20:44, 20:56, 21:15, 21:47, 22:06, 23:22) — still zero checks after all six |
| 23:26:28 / 23:26:30 | **closed + reopened by `yousefh409`** |
| 23:26:34 | CI run [31442360928](https://github.com/runvendo/vendo/actions/runs/31442360928) finally starts — **3 h 13 min after the PR opened** |
| 23:33:59 | merged → `ebcadde876e4f399adc0fc9bae9afc583f3157d9` |

### Defect 2 — the tag is never pushed, and the workflow still reports success

Straight from the source, not inferred: the workflow had **no tagging step at all**. On the post-merge run the changesets action finds no changesets, logs *"No changesets present or were removed by merging release PR. Not publishing because no publish script found."*, and returns — exit 0, job green, nothing tagged.

| time (UTC) | event |
| --- | --- |
| 20:10:57 | Version Packages run [31427759551](https://github.com/runvendo/vendo/actions/runs/31427759551) on `447c2123` — **success, no tag** |
| ~20:34 | `v0.12.0` created by hand (`gh api git/refs`) at `447c2123` = #1179's merge commit |
| 20:34:42 | Release run [31429705077](https://github.com/runvendo/vendo/actions/runs/31429705077) fires — **~24 min of dead air** after merge |
| 23:34:02 | Version Packages run [31442830369](https://github.com/runvendo/vendo/actions/runs/31442830369) on `ebcadde8` — **success, no tag** |
| ~23:42 | `v0.13.0` created by hand (`gh api git/refs`) at `ebcadde8` = #1182's merge commit |
| 23:42:28 | Release run [31443363215](https://github.com/runvendo/vendo/actions/runs/31443363215) fires |

Both tags point at exactly the version-PR merge commits and both are lightweight refs — the signature of the manual `gh api git/refs` bridge. Nothing in CI could have created them.

**Worth being straight about:** defect 2 was never a broken step — it was an unimplemented one. `.changeset/README.md:32` says *"Then commit, tag `vX.Y.Z`, and push the tag"*, and the old workflow header said *"Releasing = merge that PR, then push the v\* tag"* with no actor. The manual tag was the documented design. This PR automates it, which is the change of substance here: merging the version PR is now the whole deliberate act, and publishing still only ever happens off a `v*` tag. Say the word if you want the tag to stay a hand-push and I'll drop step 2.

## After merging, Yousef must add the `RELEASE_PAT` secret

Until this exists, both defects persist exactly as they are today — the fallback is deliberate so this PR can never make things worse, but it also fixes nothing on its own. **This applies to defect 2 as well:** a tag pushed with `GITHUB_TOKEN` also doesn't trigger workflows, so without the PAT the tag will land but `release.yml` still needs a manual nudge.

1. Go to <https://github.com/settings/personal-access-tokens/new> (or: your avatar → **Settings** → **Developer settings** → **Personal access tokens** → **Fine-grained tokens** → **Generate new token**).
2. **Token name:** `vendo-release`. **Resource owner:** `runvendo`. **Expiration:** your call (see the note below).
3. **Repository access:** *Only select repositories* → `runvendo/vendo`.
4. **Permissions → Repository permissions:**
   - **Contents:** *Read and write*
   - **Pull requests:** *Read and write*
   - (**Metadata: Read-only** is added automatically — leave it.)
5. **Generate token**, copy the value.
6. Go to <https://github.com/runvendo/vendo/settings/secrets/actions> → **New repository secret** → **Name:** `RELEASE_PAT` → paste → **Add secret**.

Note: when the PAT expires, the automation silently reverts to today's behavior (green workflow, no CI on the version PR, tag pushed but no publish) rather than failing loudly. A calendar reminder or a no-expiry token is the tradeoff.

## Verification

- `actionlint` clean on the changed file **and** on all four workflows (`.github/workflows/*.yml`, exit 0 both ways). `pnpm lint` does not cover workflow YAML — it is `dependency-guard` + `portability-gate` + eslint over `packages/*` — so actionlint is the real gate here.
- The tag step's shell was extracted verbatim and dry-run as a plain script, all four paths:
  - **Skip, against the real repo:** in a worktree at `0.13.0` with `v0.13.0` already on origin → `v0.13.0 already exists — nothing to release`, exit 0.
  - **Push, in a scratch bare-repo sandbox:** version `0.14.0`, no tag on origin → `* [new tag] v0.14.0 -> v0.14.0`, pointing at `HEAD`.
  - **Idempotent re-run** with the local tag deleted (a fresh runner's state) → skips, exit 0.
  - **Ordinary main push**, version unchanged → skips, exit 0.
- Lightweight `git tag` needs no git identity — verified in a repo with an empty `HOME`/`GIT_CONFIG_GLOBAL`, since on the post-merge run the changesets action returns early and may not have configured a git user.
- A step whose `if:` contains no status function carries an implicit `success()`, so a failing changesets step skips the tag push rather than tagging a broken release.

- [ ] `pnpm build && pnpm test && pnpm typecheck && pnpm lint` green — N/A, no package code is touched; see the actionlint + dry-run evidence above.
- [ ] Screenshots attached (if UI-affecting) — N/A.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Version Packages PR run CI and auto-push the `v<version>` tag after merge, so `release.yml` publishes without manual tagging. Only `.github/workflows/version-packages.yml` is changed.

- Bug Fixes
  - Use `${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}` for both `actions/checkout` and `changesets/action` so bot PR opens/updates trigger CI and tag pushes trigger workflows.
  - Add a step to create and push a single lockstep `v<version>` tag when no changesets remain (skips if it already exists). Publishing still runs via `release.yml`.

- Migration
  - Add repo secret `RELEASE_PAT` (fine-grained PAT, Contents: read/write; Pull requests: read/write). Without it, behavior falls back to today (no CI on the bot PR; tag push won’t trigger publish).

<sup>Written for commit f2535635b89a7d9b25f29943a85d7b469d45b1fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

