### PR TITLE
feat(vendo): deployment-identity headers carry the SDK version

### DIFF
--- a/packages/vendo/src/deployment-identity.ts
+++ b/packages/vendo/src/deployment-identity.ts
@@ -1,13 +1,16 @@
 /** Deployment-identity headers (cloud definition, interaction model): every
- * key-authenticated Vendo Cloud request carries `x-vendo-deployment-host` and
- * `x-vendo-deployment-name`; the console's shared auth middleware upserts the
- * deployment inventory and meters usage from these on real service calls —
- * there is no heartbeat. Shared by the CLI cloud client and the runtime Cloud
- * adapters (connections, sandbox), so this module carries NO static Node
- * import: builtins load through the runtime accessor (server.ts precedent)
- * and every lookup fails soft to "unknown" on edge/Worker targets — identity
- * headers must never take a request down. The console truncates and fails
- * open on its side (parseDeploymentHeaders), so sending is always safe. */
+ * key-authenticated Vendo Cloud request carries `x-vendo-deployment-host`,
+ * `x-vendo-deployment-name`, and `x-vendo-deployment-version`; the console's
+ * shared auth middleware upserts the deployment inventory and meters usage
+ * from these on real service calls — there is no heartbeat. Shared by the
+ * CLI cloud client and the runtime Cloud adapters (connections, sandbox), so
+ * this module carries NO static Node import: builtins load through the
+ * runtime accessor (server.ts precedent) and every lookup fails soft to
+ * "unknown" on edge/Worker targets — identity headers must never take a
+ * request down. The console truncates and fails open on its side
+ * (parseDeploymentHeaders), so sending is always safe. */
+
+import { VERSION } from "./wire/shared.js";
 
 type RuntimeProcess = {
   getBuiltinModule?: (id: string) => unknown;
@@ -59,7 +62,7 @@ function resolveDeploymentName(cwd: string): Promise<string> {
   return name;
 }
 
-/** The two identity headers for a key-authenticated Cloud request. */
+/** The three identity headers for a key-authenticated Cloud request. */
 export async function deploymentIdentityHeaders(): Promise<Record<string, string>> {
   const os = builtinModule<typeof import("node:os")>("node:os");
   let cwd: string | undefined;
@@ -71,5 +74,6 @@ export async function deploymentIdentityHeaders(): Promise<Record<string, string
   return {
     "x-vendo-deployment-host": headerSafe(os === undefined ? "" : os.hostname()),
     "x-vendo-deployment-name": headerSafe(cwd === undefined ? "" : await resolveDeploymentName(cwd)),
+    "x-vendo-deployment-version": headerSafe(VERSION),
   };
 }

--- a/packages/vendo/tests/cli/cloud/client.test.ts
+++ b/packages/vendo/tests/cli/cloud/client.test.ts
@@ -4,6 +4,7 @@ import { basename, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CloudError, cloudFetch, isVendoKey, resolveCloudBaseUrl } from "../../../src/cli/cloud/client.js";
 import { CLI_VERSION } from "../../../src/cli/shared.js";
+import { VERSION } from "../../../src/wire/shared.js";
 
 const cleanup: string[] = [];
 afterEach(async () => {
@@ -91,6 +92,7 @@ describe("cloud client", () => {
       headers: expect.objectContaining({
         "x-vendo-deployment-host": expect.any(String),
         "x-vendo-deployment-name": expect.any(String),
+        "x-vendo-deployment-version": VERSION,
       }),
     }));
   });


### PR DESCRIPTION
## Summary
- `deploymentIdentityHeaders()` gains a third header, `x-vendo-deployment-version`, sourced from `VERSION` in `packages/vendo/src/wire/shared.ts` and sanitized through the existing `headerSafe`.
- Signature and existing two headers are unchanged; no new options or config plumbing.

## Test plan
- [x] Added a case to `packages/vendo/tests/cli/cloud/client.test.ts` asserting the header equals `VERSION`; ran it red before the implementation, green after.
- [x] Ran every other test file in packages/vendo that greps for `x-vendo-deployment` (cloud-secrets, cloud-config, cloud-apps, sandbox, connections, turn-liveness) — all pass.
- [x] `pnpm --filter @vendoai/vendo typecheck` passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `x-vendo-deployment-version` to deployment identity headers. It carries the SDK `VERSION` to help track SDK versions per request, with no changes to the function signature or existing headers.

<sup>Written for commit 91b6a8ad0a63b06ef48945c2fe7ddaa844568f9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

