### PR TITLE
feat(core): one sink for everything Vendo says out loud

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,7 @@ export * from "./ids.js";
 export * from "./jcs.js";
 export * from "./knowledge.js";
 export * from "./knowledge-wire.js";
+export * from "./log.js";
 export * from "./meter-exhausted.js";
 export * from "./model-seats.js";
 export * from "./capability.js";

--- a/packages/core/src/log.ts
+++ b/packages/core/src/log.ts
@@ -1,0 +1,61 @@
+/** The one place a Vendo block says something out loud.
+ *
+ * Every block used to call `console.*` directly, so a host embedding Vendo had
+ * no way to route what Vendo says into its own observability — and no way to
+ * quieten it. This is the seam: a block emits a structured `VendoLogEvent`, the
+ * host swaps the sink with `setLogger`, and the default sink writes exactly the
+ * console line the bare call wrote.
+ *
+ * Byte-identical is a CONTRACT, not an aspiration. The migration of every bare
+ * call site is mechanical:
+ *
+ *   console.error("[vendo] x:", err)
+ *     → log({ code, level: "error", message: "[vendo] x:", data: { err } })
+ *
+ * so `data`'s KEY INSERTION ORDER is the original argument order — the default
+ * sink spreads `Object.values(data)` after the message, and object key order is
+ * insertion order for string keys. Reordering keys at a call site silently
+ * reorders that line's output. The `[vendo] ` prefix stays inside `message`
+ * (rather than being added by the sink) for the same reason: a custom sink gets
+ * the message the console showed, and no call site's text changes.
+ */
+
+export type VendoLogLevel = "debug" | "info" | "warn" | "error";
+
+/** A stable dotted id, `"<block>.<subject>"` — what an operator greps and what a
+ *  host keys an alert on. `string & {}` keeps the literals this repo uses as the
+ *  suggested set while the union grows one call site at a time. */
+export type VendoLogCode = string & {};
+
+export interface VendoLogEvent {
+  code: VendoLogCode;
+  level: VendoLogLevel;
+  message: string;
+  data?: Record<string, unknown>;
+}
+
+export type VendoLogger = (event: VendoLogEvent) => void;
+
+/** Which console method each level used before this file existed. */
+const METHODS: Record<VendoLogLevel, "debug" | "log" | "warn" | "error"> = {
+  debug: "debug",
+  info: "log",
+  warn: "warn",
+  error: "error",
+};
+
+/** The default sink: the bare `console.*` line, reassembled. */
+export const consoleLogger: VendoLogger = (event) => {
+  console[METHODS[event.level]](event.message, ...Object.values(event.data ?? {}));
+};
+
+let current: VendoLogger = consoleLogger;
+
+export function log(event: VendoLogEvent): void {
+  current(event);
+}
+
+/** Install a sink. `undefined` restores `consoleLogger`. */
+export function setLogger(logger: VendoLogger | undefined): void {
+  current = logger ?? consoleLogger;
+}

--- a/packages/core/tests/log.test.ts
+++ b/packages/core/tests/log.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { consoleLogger, log, setLogger } from "../src/log.js";
+
+// The migration these tests protect is mechanical:
+//   console.error("[vendo] x:", err)
+//     → log({ code, level: "error", message: "[vendo] x:", data: { err } })
+// so the default sink's output must be byte-identical to the bare console line
+// it replaces — same method, same argument list, argument for argument.
+
+const spies = () => ({
+  debug: vi.spyOn(console, "debug").mockImplementation(() => {}),
+  log: vi.spyOn(console, "log").mockImplementation(() => {}),
+  warn: vi.spyOn(console, "warn").mockImplementation(() => {}),
+  error: vi.spyOn(console, "error").mockImplementation(() => {}),
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  setLogger(undefined);
+});
+
+describe("the default sink", () => {
+  it("routes each level to the console method its bare call used", () => {
+    const cases = [
+      { level: "debug", method: "debug" },
+      { level: "info", method: "log" },
+      { level: "warn", method: "warn" },
+      { level: "error", method: "error" },
+    ] as const;
+    for (const { level, method } of cases) {
+      const console_ = spies();
+      log({ code: "core.log", level, message: "[vendo] plain" });
+      expect(console_[method].mock.calls).toEqual([["[vendo] plain"]]);
+      for (const other of ["debug", "log", "warn", "error"] as const) {
+        if (other !== method) expect(console_[other]).not.toHaveBeenCalled();
+      }
+      vi.restoreAllMocks();
+    }
+  });
+
+  it("reproduces `console.error(\"[vendo] x:\", err)` argument for argument", () => {
+    const console_ = spies();
+    const err = new Error("boom");
+    log({ code: "core.log", level: "error", message: "[vendo] x:", data: { err } });
+    expect(console_.error.mock.calls).toEqual([["[vendo] x:", err]]);
+  });
+
+  it("keeps data key insertion order as the original argument order", () => {
+    const console_ = spies();
+    const err = new Error("boom");
+    log({
+      code: "core.log",
+      level: "warn",
+      message: "[vendo] three:",
+      data: { path: "app.vendo", count: 2, err },
+    });
+    expect(console_.warn.mock.calls).toEqual([["[vendo] three:", "app.vendo", 2, err]]);
+  });
+});
+
+describe("the sink slot", () => {
+  it("routes events to an installed logger and prints nothing", () => {
+    const console_ = spies();
+    const seen: unknown[] = [];
+    setLogger((event) => seen.push(event));
+    log({ code: "core.log", level: "error", message: "[vendo] x:", data: { err: "e" } });
+    expect(seen).toEqual([
+      { code: "core.log", level: "error", message: "[vendo] x:", data: { err: "e" } },
+    ]);
+    for (const method of ["debug", "log", "warn", "error"] as const) {
+      expect(console_[method]).not.toHaveBeenCalled();
+    }
+  });
+
+  it("restores the console sink when cleared", () => {
+    const console_ = spies();
+    setLogger(() => {});
+    setLogger(undefined);
+    log({ code: "core.log", level: "info", message: "[vendo] back" });
+    expect(console_.log.mock.calls).toEqual([["[vendo] back"]]);
+  });
+
+  it("exports the default sink itself, which writes the same line", () => {
+    const console_ = spies();
+    consoleLogger({ code: "core.log", level: "info", message: "[vendo] direct", data: { a: 1 } });
+    expect(console_.log.mock.calls).toEqual([["[vendo] direct", 1]]);
+  });
+});


### PR DESCRIPTION
Adds `@vendoai/core`'s structured logger: `{ code, level, message, data }` events through a swappable sink.

The default sink is byte-identical to the bare `console.*` lines it replaces — same method, same argument list, argument for argument — so nothing a user sees changes today. `tests/log.test.ts` pins that, including the load-bearing case: `data` key insertion order IS original argument order, because the sink replays it as `...Object.values(data)`. Get that wrong and output silently reorders.

`setLogger(fn)` routes events to a host sink and prints nothing; `setLogger(undefined)` restores the console.

This is the foundation for two stacked PRs: the ~72-site `console.*` migration, and the SDK events pipeline.

## Not in this PR

The `render-seam.ts` swallow fix (approved as part of this work) is **deferred**: it lives in `packages/apps/src/server/generation/`, whose checked-in `CLAUDE.md` marks it an author-involved zone that background workers must not edit. Awaiting the author's direction. The same rule defers the `app_generated` emission and 9 of the 72 console sites.

## Gates

- `packages/core` full scope: 618/618 pass (run `pnpm --filter @vendoai/core build` first — a dist-less worktree fails 6 packaging tests for environmental reasons)
- typecheck: pass · `dependency-guard.mjs`: pass, 30 packages · blocking eslint: pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a single structured logging seam in `@vendoai/core` with a swappable sink so hosts can route or silence logs. The default sink exactly reproduces previous `console.*` output, enabling a safe, mechanical migration of existing call sites.

- **New Features**
  - Added `log`, `setLogger`, and `consoleLogger` to emit `{ code, level, message, data }` events and swap the sink.
  - Default sink maps levels to the original console method and replays args via `Object.values(data)`, preserving order and byte-identical output.
  - `setLogger(undefined)` restores the console sink; tests pin level mapping, arg order, and no-console when a custom sink is installed.

<sup>Written for commit e69284a19bb77ccec23f9eab62afe0781706fe9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

