### PR TITLE
refactor: migrate [vendo]-prefixed console sites to log() (S1b sweep)

### DIFF
--- a/packages/apps/src/server/checking/islands.ts
+++ b/packages/apps/src/server/checking/islands.ts
@@ -5,6 +5,7 @@
  * `tools` member chains (validated against the live registry when the host
  * supplied one).
  */
+import { log } from "@vendoai/core";
 import {
   KIT_COMPONENT_NAMES,
   WIRE_COMPONENT_NAMES,
@@ -275,7 +276,11 @@ export const prepareIslands = async (
       if (typeof error === "object" && error !== null && Array.isArray((error as { errors?: unknown }).errors)) {
         issues.push(`island "${name}" is not valid TSX: ${error instanceof Error ? error.message.split("\n")[0] : "syntax error"}`);
       } else {
-        console.warn(`[vendo] island TSX validation unavailable on this runtime (${error instanceof Error ? error.message.split("\n")[0] : String(error)}); islands ship unvalidated`);
+        log({
+          code: "apps.island-validation-unavailable",
+          level: "warn",
+          message: `[vendo] island TSX validation unavailable on this runtime (${error instanceof Error ? error.message.split("\n")[0] : String(error)}); islands ship unvalidated`,
+        });
         transform = undefined;
       }
     }

--- a/packages/apps/src/server/checking/smoke-render.ts
+++ b/packages/apps/src/server/checking/smoke-render.ts
@@ -30,6 +30,7 @@
  * of failing creates.
  */
 import {
+  log,
   type ShapeType,
 } from "@vendoai/core";
 import {
@@ -261,7 +262,11 @@ const workerModules = (async (): Promise<WorkerModules | undefined> => {
       () => createRequire(`${process.cwd()}/package.json`),
     ]);
     if (paths === undefined) {
-      console.warn("[vendo] smoke-render gate skipped: react/jsdom did not resolve to filesystem paths in this environment (bundled server); islands ship without the crash gate");
+      log({
+        code: "apps.smoke-render-gate-skipped",
+        level: "warn",
+        message: "[vendo] smoke-render gate skipped: react/jsdom did not resolve to filesystem paths in this environment (bundled server); islands ship without the crash gate",
+      });
       return undefined;
     }
     return { Worker, paths };

--- a/packages/apps/src/server/doors/build-surface.ts
+++ b/packages/apps/src/server/doors/build-surface.ts
@@ -10,6 +10,7 @@ import {
   VENDO_TREE_FORMAT,
   VendoError,
   describeShapeWithSemantics,
+  log,
   safeErrorMessage,
   type AppId,
   type RecordStore,
@@ -103,7 +104,11 @@ const startBuildWatchdog = (
         name: fallbackAppName(prompt),
         buildFailed: { reason: BUILD_WATCHDOG_REASON, retryable: true, at: new Date().toISOString(), prompt },
       }, subject, false, "screen-agent"));
-      console.error(`[vendo] app build watchdog (${appId}): no app record and no failure landed within ${buildWatchdogMs()}ms — persisted a terminal failed record so the embed resolves instead of polling forever.`);
+      log({
+        code: "apps.build-watchdog-fired",
+        level: "error",
+        message: `[vendo] app build watchdog (${appId}): no app record and no failure landed within ${buildWatchdogMs()}ms — persisted a terminal failed record so the embed resolves instead of polling forever.`,
+      });
     })().catch(() => undefined);
   }, buildWatchdogMs());
   (watchdog as { unref?: () => void }).unref?.();
@@ -133,7 +138,11 @@ const createBuildFailer = (bound: {
       buildFailed: { reason, retryable, at: new Date().toISOString(), prompt },
     }, subject, false, "screen-agent")).catch(() => undefined);
     clearTimeout(watchdog);
-    console.error(`[vendo] app build failed (${appId}): ${reason}${detail.map((line) => `\n  - ${line}`).join("")}`);
+    log({
+      code: "apps.build-failed",
+      level: "error",
+      message: `[vendo] app build failed (${appId}): ${reason}${detail.map((line) => `\n  - ${line}`).join("")}`,
+    });
     throw new VendoError(
       code,
       `${VENDO_APP_BUILD_FAILED_PREFIX}: ${reason}`,
@@ -193,7 +202,11 @@ const routeThroughAssembler = async (
     const stored = await apps.get(appId).catch(() => null);
     if (stored === null) return failBuild(NOTHING_RENDERABLE, true, [NOTHING_RENDERABLE]);
     clearTimeout(watchdog);
-    console.info(`[vendo] assembled app=${appId} total=${((Date.now() - createStartedAt) / 1000).toFixed(1)}s`);
+    log({
+      code: "apps.assembled",
+      level: "info",
+      message: `[vendo] assembled app=${appId} total=${((Date.now() - createStartedAt) / 1000).toFixed(1)}s`,
+    });
     return { kind: "assembled", document: withoutSession(documentFromRecord(stored)) };
   }
   if (routed.kind === "unavailable") {
@@ -319,7 +332,11 @@ const createCreateDoor = (
       // is not in the user's list and cannot be reopened. Far better than
       // discarding a working view, but never silent.
       unsavedReason = safeErrorMessage(error);
-      console.error(`[vendo] app not saved (${appId}): the view rendered but the store rejected it — ${unsavedReason}`);
+      log({
+        code: "apps.create-not-saved",
+        level: "error",
+        message: `[vendo] app not saved (${appId}): the view rendered but the store rejected it — ${unsavedReason}`,
+      });
     }
     clearTimeout(watchdog);
     if (unsavedReason !== undefined) {
@@ -341,10 +358,18 @@ const createCreateDoor = (
         console.info(findingLine(finding));
       }
     } catch (error) {
-      console.warn(`[vendo] server work skipped for ${appId} (the app stands without it): ${safeErrorMessage(error)}`);
+      log({
+        code: "apps.server-work-skipped",
+        level: "warn",
+        message: `[vendo] server work skipped for ${appId} (the app stands without it): ${safeErrorMessage(error)}`,
+      });
     }
     await paintSettledTree(caller, app, ctx, input.onView, appId);
-    console.info(`[vendo] gen create complete app=${appId} total=${((Date.now() - createStartedAt) / 1000).toFixed(1)}s`);
+    log({
+      code: "apps.gen-create-complete",
+      level: "info",
+      message: `[vendo] gen create complete app=${appId} total=${((Date.now() - createStartedAt) / 1000).toFixed(1)}s`,
+    });
     return structuredClone(app);
   };
 };

--- a/packages/apps/src/server/doors/make-tool.ts
+++ b/packages/apps/src/server/doors/make-tool.ts
@@ -7,6 +7,7 @@
  */
 import {
   isUnattended,
+  log,
   VENDO_VIEW_STREAM,
   VendoError,
   vendoViewStreamId,
@@ -144,7 +145,11 @@ const makeNewApp = async (
       }),
     }, ctx).catch((error: unknown) => {
       threw = error instanceof Error ? error.message : String(error);
-      console.warn(`[vendo] the screen agent could not serve ${appId} — ${threw}`);
+      log({
+        code: "apps.screen-agent-serve-failed",
+        level: "warn",
+        message: `[vendo] the screen agent could not serve ${appId} — ${threw}`,
+      });
       return undefined;
     });
   if (routed?.kind === "assembled") {
@@ -313,9 +318,13 @@ export const runMakeTool = async (
    */
   const remember = async (appId: string): Promise<void> => {
     await runtime.remember({ appId, ask: request }, ctx).catch((error: unknown) => {
-      console.warn(`[vendo] the ask was not recorded on ${appId}: ${
-        error instanceof Error ? error.message : String(error)
-      }`);
+      log({
+        code: "apps.ask-not-recorded",
+        level: "warn",
+        message: `[vendo] the ask was not recorded on ${appId}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      });
     });
   };
   const make: MakeCall = { runtime, dependencies, ctx, ask, stream, remember };

--- a/packages/apps/src/server/doors/write-surface.ts
+++ b/packages/apps/src/server/doors/write-surface.ts
@@ -6,6 +6,7 @@
  * Lifted out of `createApps` unchanged.
  */
 import {
+  log,
   VendoError,
   safeErrorMessage,
   type AppId,
@@ -112,7 +113,11 @@ const createRefusedSaveRecorder = (
     // screen, it just is not in the list. Never silent — and never a reason
     // to withhold the data the person can already see.
     const reason = safeErrorMessage(error);
-    console.error(`[vendo] app not saved (${appId}): the harness wrote it as a file but it did not land — ${reason}`);
+    log({
+      code: "apps.edit-not-saved",
+      level: "error",
+      message: `[vendo] app not saved (${appId}): the harness wrote it as a file but it did not land — ${reason}`,
+    });
     // …and when the save was an EDIT's, the refusal is that edit's answer:
     // the row still holds the pre-edit document, so `assembleEdit` reading
     // it back would report an unchanged app as the change (`editRefusals`).
@@ -397,7 +402,11 @@ const createEditDoor = (
         }
       } catch (error) {
         const reason = safeErrorMessage(error);
-        console.warn(`[vendo] the build this edit asked for did not run for ${appId}: ${reason}`);
+        log({
+          code: "apps.edit-build-skipped",
+          level: "warn",
+          message: `[vendo] the build this edit asked for did not run for ${appId}: ${reason}`,
+        });
         return failedEdit(previous, instruction, [reason]);
       }
     }

--- a/packages/apps/src/server/escalation/box-lane.ts
+++ b/packages/apps/src/server/escalation/box-lane.ts
@@ -6,6 +6,7 @@
  * Lifted out of `createApps` unchanged.
  */
 import {
+  log,
   VendoError,
   safeErrorMessage,
   type AppId,
@@ -179,7 +180,11 @@ const createBoxEditor = (
     // not roll back an edit that already succeeded inside the box — but never
     // SILENT: the reason is the only thing that says why nothing is scheduled.
     await manifestTriggers.sync(app, ctx).catch((error: unknown) => {
-      console.warn(`[vendo] vendo.json schedules for ${app.id} were not folded into triggers: ${safeErrorMessage(error)}`);
+      log({
+        code: "apps.schedules-not-folded",
+        level: "warn",
+        message: `[vendo] vendo.json schedules for ${app.id} were not folded into triggers: ${safeErrorMessage(error)}`,
+      });
     });
     // Sync the egress DECLARATION (mirrors vendo.json) onto the doc; the
     // owner-approval grant is a separate, guard-gated step (Lane E).

--- a/packages/apps/src/server/persistence/edit-journal.ts
+++ b/packages/apps/src/server/persistence/edit-journal.ts
@@ -6,6 +6,7 @@
  * Lifted out of `createApps` unchanged.
  */
 import {
+  log,
   VendoError,
   safeErrorMessage,
   type AppId,
@@ -91,7 +92,11 @@ const createEditNotices = (deps: Pick<AppsRuntimeContext, "config" | "history">)
     try {
       await config.onDocumentEdit(previous, next, subject);
     } catch (error) {
-      console.warn(`[vendo] onDocumentEdit hook failed for ${next.id}: ${safeErrorMessage(error)}`);
+      log({
+        code: "apps.on-document-edit-hook-failed",
+        level: "warn",
+        message: `[vendo] onDocumentEdit hook failed for ${next.id}: ${safeErrorMessage(error)}`,
+      });
     }
   };
 
@@ -106,7 +111,11 @@ const createEditNotices = (deps: Pick<AppsRuntimeContext, "config" | "history">)
     try {
       await history.discard(appId, versionId);
     } catch (error) {
-      console.error(`[vendo] a refused write left a stale version behind (${appId}): ${safeErrorMessage(error)}`);
+      log({
+        code: "apps.stale-version-after-refusal",
+        level: "error",
+        message: `[vendo] a refused write left a stale version behind (${appId}): ${safeErrorMessage(error)}`,
+      });
     }
   };
 
@@ -118,7 +127,11 @@ const createEditNotices = (deps: Pick<AppsRuntimeContext, "config" | "history">)
     try {
       await history.prune(appId);
     } catch (error) {
-      console.error(`[vendo] history for ${appId} could not be trimmed to its cap: ${safeErrorMessage(error)}`);
+      log({
+        code: "apps.history-prune-failed",
+        level: "error",
+        message: `[vendo] history for ${appId} could not be trimmed to its cap: ${safeErrorMessage(error)}`,
+      });
     }
   };
 

--- a/packages/apps/src/server/persistence/open.ts
+++ b/packages/apps/src/server/persistence/open.ts
@@ -1,4 +1,5 @@
 import {
+  log,
   VENDO_TREE_FORMAT,
   VendoError,
   safeErrorMessage,
@@ -95,7 +96,11 @@ export const createProgressiveQueryResolver = (
       : state.result === undefined
         ? "the call did not settle"
         : `the call answered "${state.result.status}"`;
-    console.warn(`[vendo] query "${state.query.name}" (tool "${state.query.tool}") resolved no data for app ${app.id} — ${why}; anything bound to it renders empty`);
+    log({
+      code: "apps.query-resolved-no-data",
+      level: "warn",
+      message: `[vendo] query "${state.query.name}" (tool "${state.query.tool}") resolved no data for app ${app.id} — ${why}; anything bound to it renders empty`,
+    });
   };
 
   const recompute = (notify = true): void => {
@@ -211,7 +216,11 @@ const additionalVenueState = async (
   try {
     return await venueState?.(app, ctx) ?? {};
   } catch (error) {
-    console.warn(`[vendo] venue state for app ${app.id} could not be resolved: ${safeErrorMessage(error)}; the app opens without it`);
+    log({
+      code: "apps.venue-state-unresolved",
+      level: "warn",
+      message: `[vendo] venue state for app ${app.id} could not be resolved: ${safeErrorMessage(error)}; the app opens without it`,
+    });
     return {};
   }
 };

--- a/packages/harnesses/src/claude-code/box.ts
+++ b/packages/harnesses/src/claude-code/box.ts
@@ -35,7 +35,7 @@
  * resumes on the same session) and worse for cost (a parked write holds a
  * sandbox for up to 90s). Recorded in the lane's close note as a deviation.
  */
-import { VENDO_DEV_PORT, VENDO_DEV_PORT_ENV, VendoError } from "@vendoai/core";
+import { log, VENDO_DEV_PORT, VENDO_DEV_PORT_ENV, VendoError } from "@vendoai/core";
 import type { CheckoutFile, SyncFile, TreeState } from "../materialize.js";
 import { emptyTree } from "../materialize.js";
 import { MESSAGE_BUDGET_MS, type SessionMachine, type SessionMessage } from "./machine.js";
@@ -227,7 +227,11 @@ export async function boxMachine(options: BoxMachineOptions): Promise<SessionMac
     if (await hello(existing.machine, existing.token)) {
       entry = existing;
     } else {
-      console.error("[vendo] claude-code: the box stopped answering; starting fresh");
+      log({
+        code: "harnesses.claude-code-box-stale",
+        level: "error",
+        message: "[vendo] claude-code: the box stopped answering; starting fresh",
+      });
       boxes.delete(options.threadId);
       await existing.machine.destroy().catch(() => undefined);
     }

--- a/packages/harnesses/src/claude-code/index.ts
+++ b/packages/harnesses/src/claude-code/index.ts
@@ -16,6 +16,7 @@
  */
 import {
   VENDO_MAKE_TOOL,
+  log,
   type BeatPhase,
   type Harness,
   type HarnessEvent,
@@ -348,13 +349,16 @@ let noOriginWarned = false;
 function warnNoOriginOnce(): void {
   if (noOriginWarned) return;
   noOriginWarned = true;
-  console.error(
-    "[vendo] claudeCode() has no origin to reach the MCP door, so this agent has "
-    + "NONE of your product's actions — only its own workspace. Set VENDO_BASE_URL "
-    + "(or `mcp: { baseUrl }`) to an origin this machine can reach. In development "
-    + "the wire learns its own LOOPBACK origin instead, so seeing this locally means "
-    + "NODE_ENV is not \"development\" or the host is not served over localhost.",
-  );
+  log({
+    code: "harnesses.claude-code-no-origin",
+    level: "error",
+    message:
+      "[vendo] claudeCode() has no origin to reach the MCP door, so this agent has "
+      + "NONE of your product's actions — only its own workspace. Set VENDO_BASE_URL "
+      + "(or `mcp: { baseUrl }`) to an origin this machine can reach. In development "
+      + "the wire learns its own LOOPBACK origin instead, so seeing this locally means "
+      + "NODE_ENV is not \"development\" or the host is not served over localhost.",
+  });
 }
 
 /**
@@ -369,12 +373,15 @@ let noAppsHooksWarned = false;
 function warnNoAppsHooksOnce(): void {
   if (noAppsHooksWarned) return;
   noAppsHooksWarned = true;
-  console.error(
-    "[vendo] claudeCode() is running without the apps hooks (hotPaths / validateApps / "
-    + "repairInstruction), so mid-turn hot-path sync and the finish-line validate gate are "
-    + "OFF. Compose through createVendo/createAgent to get them, or pass them to claudeCode() "
-    + "directly.",
-  );
+  log({
+    code: "harnesses.claude-code-no-apps-hooks",
+    level: "error",
+    message:
+      "[vendo] claudeCode() is running without the apps hooks (hotPaths / validateApps / "
+      + "repairInstruction), so mid-turn hot-path sync and the finish-line validate gate are "
+      + "OFF. Compose through createVendo/createAgent to get them, or pass them to claudeCode() "
+      + "directly.",
+  });
 }
 
 /** A callback-driven producer, consumed by the generator that must `yield`. */
@@ -467,11 +474,14 @@ export function claudeCode(
         // so without that check this branch also swallows every workspace-only
         // deployment that simply never named an origin, which is a supported
         // shape and not an error. Those fall through to the warning below.
-        console.error(
-          "[vendo] claudeCode() cannot reach the MCP door: set VENDO_BASE_URL (or "
-          + "`mcp: { baseUrl }`) to the deployment's public origin. The agent's tools "
-          + "travel over that door, so without it the model has no way to act.",
-        );
+        log({
+          code: "harnesses.claude-code-no-mcp-door",
+          level: "error",
+          message:
+            "[vendo] claudeCode() cannot reach the MCP door: set VENDO_BASE_URL (or "
+            + "`mcp: { baseUrl }`) to the deployment's public origin. The agent's tools "
+            + "travel over that door, so without it the model has no way to act.",
+        });
         yield { type: "error", message: "I can't use this product's actions right now." };
         return;
       }
@@ -501,11 +511,14 @@ export function claudeCode(
           // Still reachable by a host driving the runtime directly without a
           // sandbox — and it has to be loud for the operator and quiet for
           // the user.
-          console.error(
-            "[vendo] claudeCode() has no sandbox adapter. Hand it one directly — "
-            + "`harness: claudeCode({ sandbox: e2bSandbox({ apiKey }) })` — or pass "
-            + "`sandbox` into createHarnessTurns so composition fills the slot.",
-          );
+          log({
+            code: "harnesses.claude-code-no-sandbox",
+            level: "error",
+            message:
+              "[vendo] claudeCode() has no sandbox adapter. Hand it one directly — "
+              + "`harness: claudeCode({ sandbox: e2bSandbox({ apiKey }) })` — or pass "
+              + "`sandbox` into createHarnessTurns so composition fills the slot.",
+          });
           yield { type: "error", message: "I can't run right now — this assistant is missing its workspace machine." };
           return;
         }
@@ -651,7 +664,12 @@ export function claudeCode(
           }).then(() => events.close(), (error: unknown) => {
             // The thinker failed; the user hears one plain sentence and the turn
             // still lands whatever work reached the disk.
-            console.error("[vendo] claude-code turn failed", error);
+            log({
+              code: "harnesses.claude-code-turn-failed",
+              level: "error",
+              message: "[vendo] claude-code turn failed",
+              data: { error },
+            });
             events.push({ type: "error", message: "Something went wrong while I was working on that." });
             events.close();
           });
@@ -715,12 +733,22 @@ export function claudeCode(
         try {
           collected = await machine.collect();
         } catch (error) {
-          console.error("[vendo] claude-code could not read the workspace back", error);
+          log({
+            code: "harnesses.claude-code-workspace-read-failed",
+            level: "error",
+            message: "[vendo] claude-code could not read the workspace back",
+            data: { error },
+          });
         }
         if (collected !== undefined) {
           const files = collected;
           await serialize(() => checkout.syncAll(files)).catch((error: unknown) => {
-            console.error("[vendo] claude-code sync-back failed", error);
+            log({
+              code: "harnesses.claude-code-sync-back-failed",
+              level: "error",
+              message: "[vendo] claude-code sync-back failed",
+              data: { error },
+            });
           });
         }
         try {

--- a/packages/harnesses/src/runtime.ts
+++ b/packages/harnesses/src/runtime.ts
@@ -11,6 +11,7 @@
  */
 import {
   auditContext,
+  log,
   mintTurnId,
   VendoError,
   withSseKeepalive,
@@ -425,9 +426,16 @@ export function createHarnessRuntime(deps: HarnessRuntimeDeps): HarnessRuntime {
             } catch (error) {
               // A failed commit is the harness's to notice through its next read;
               // it must never take down a turn that already has a reply.
-              console.error("[vendo] harness runtime: workspace commit failed", {
-                threadId: input.threadId,
-                error: error instanceof Error ? error.message : String(error),
+              log({
+                code: "harnesses.runtime-commit-failed",
+                level: "error",
+                message: "[vendo] harness runtime: workspace commit failed",
+                data: {
+                  detail: {
+                    threadId: input.threadId,
+                    error: error instanceof Error ? error.message : String(error),
+                  },
+                },
               });
             }
           };
@@ -520,10 +528,17 @@ export function createHarnessRuntime(deps: HarnessRuntimeDeps): HarnessRuntime {
             // A harness that throws is a bug in the thinker, not in the user's
             // day. The real error goes to the operator's terminal; the user gets
             // a plain sentence, and NOTHING of the internals travels.
-            console.error("[vendo] harness run failed", {
-              harness: input.harness.name,
-              threadId: input.threadId,
-              error: error instanceof Error ? error.message : String(error),
+            log({
+              code: "harnesses.runtime-run-failed",
+              level: "error",
+              message: "[vendo] harness run failed",
+              data: {
+                detail: {
+                  harness: input.harness.name,
+                  threadId: input.threadId,
+                  error: error instanceof Error ? error.message : String(error),
+                },
+              },
             });
             // …unless the error is one Vendo itself crafted (the credential
             // ladder's `vendo login` guidance, the Cloud meter refusal), which
@@ -572,7 +587,14 @@ export function createHarnessRuntime(deps: HarnessRuntimeDeps): HarnessRuntime {
         // error we deliberately surfaced is NOT logged a second time here.
         onError: (error) => {
           const text = error instanceof Error ? error.message : String(error);
-          if (text !== surfaced) console.error("[vendo] harness stream error:", error);
+          if (text !== surfaced) {
+            log({
+              code: "harnesses.runtime-stream-error",
+              level: "error",
+              message: "[vendo] harness stream error:",
+              data: { error },
+            });
+          }
           // The record for failures the harness loop can never see: `execute`
           // itself rejecting (building the toolset, mounting the workspace,
           // minting a turn credential) — those never become a harness `error`
@@ -695,11 +717,18 @@ async function persistTurn(
         // By the time onFinish runs the reply is already on the wire, so throwing
         // here would corrupt a delivered stream. A thread silently vanishing after a
         // successful reply is data loss, so it is named LOUDLY instead.
-        console.error("[vendo] harness runtime: transcript persist failed — this turn was NOT saved", {
-          threadId: input.threadId,
-          subject: input.ctx.principal.subject,
-          attempts: attempt + 1,
-          error: error instanceof Error ? error.message : String(error),
+        log({
+          code: "harnesses.runtime-transcript-persist-failed",
+          level: "error",
+          message: "[vendo] harness runtime: transcript persist failed — this turn was NOT saved",
+          data: {
+            detail: {
+              threadId: input.threadId,
+              subject: input.ctx.principal.subject,
+              attempts: attempt + 1,
+              error: error instanceof Error ? error.message : String(error),
+            },
+          },
         });
         return;
       }
@@ -719,10 +748,17 @@ async function saveHarnessState(
   } catch (error) {
     // `turn.state` is disposable by contract: losing it costs a re-seed, never
     // correctness, so it must never take a delivered turn down with it.
-    console.error("[vendo] harness runtime: harness state not saved", {
-      threadId: input.threadId,
-      harness: input.harness.name,
-      error: error instanceof Error ? error.message : String(error),
+    log({
+      code: "harnesses.runtime-state-not-saved",
+      level: "error",
+      message: "[vendo] harness runtime: harness state not saved",
+      data: {
+        detail: {
+          threadId: input.threadId,
+          harness: input.harness.name,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      },
     });
   }
 }

--- a/packages/harnesses/src/wire-error.ts
+++ b/packages/harnesses/src/wire-error.ts
@@ -1,4 +1,4 @@
-import { VendoError, formatMeterExhausted, meterExhaustedFromError } from "@vendoai/core";
+import { log, VendoError, formatMeterExhausted, meterExhaustedFromError } from "@vendoai/core";
 
 /** The one gate raw errors pass on their way to the wire. Vendo's OWN errors
  *  (code + operator-crafted message) are safe and actionable, so they travel
@@ -14,7 +14,12 @@ import { VendoError, formatMeterExhausted, meterExhaustedFromError } from "@vend
  *  inventing a second error UX.
  */
 export function wireErrorMessage(error: unknown): string {
-  console.error("[vendo] turn stream error:", error);
+  log({
+    code: "harnesses.turn-stream-error",
+    level: "error",
+    message: "[vendo] turn stream error:",
+    data: { error },
+  });
   return specificWireErrorMessage(error) ?? GENERIC_TURN_ERROR;
 }
 

--- a/packages/knowledge/src/agent-tools.ts
+++ b/packages/knowledge/src/agent-tools.ts
@@ -1,4 +1,5 @@
 import {
+  log,
   VENDO_KNOWLEDGE_RESULT_KIND,
   VENDO_TOOL_TITLES,
   VendoError,
@@ -262,7 +263,11 @@ export function createKnowledgeTools(
       // Deduped by cause: a permanently broken engine costs one log line per
       // distinct failure, not one per turn.
       warned.add(full);
-      console.warn(`[vendo] knowledge engine failed — ${VENDO_KNOWLEDGE_SEARCH_TOOL} answers "unavailable" until this is fixed: ${full}`);
+      log({
+        code: "knowledge.engine-failed",
+        level: "warn",
+        message: `[vendo] knowledge engine failed — ${VENDO_KNOWLEDGE_SEARCH_TOOL} answers "unavailable" until this is fixed: ${full}`,
+      });
     }
     return raw.split(" — ")[0]!;
   };

--- a/packages/mcp/src/door.ts
+++ b/packages/mcp/src/door.ts
@@ -2,6 +2,7 @@ import {
   auditContext,
   type Guard,
   type Json,
+  log,
   type Membership,
   type Principal,
   publicBase,
@@ -575,8 +576,13 @@ class Door {
     try {
       return await this.#config.turnCredentials.resolve(token);
     } catch (error) {
-      console.error("[vendo] mcp door: turn credential lookup failed", {
-        error: error instanceof Error ? error.message : String(error),
+      log({
+        code: "mcp.turn-credential-lookup-failed",
+        level: "error",
+        message: "[vendo] mcp door: turn credential lookup failed",
+        data: {
+          detail: { error: error instanceof Error ? error.message : String(error) },
+        },
       });
       return null;
     }
@@ -963,10 +969,17 @@ class Door {
         decidedBy: decision.decidedBy,
       });
     } catch (error) {
-      console.error("[vendo] mcp door: apps-tool audit report failed", {
-        tool: name,
-        outcome: outcome.status,
-        error: error instanceof Error ? error.message : String(error),
+      log({
+        code: "mcp.apps-tool-audit-failed",
+        level: "error",
+        message: "[vendo] mcp door: apps-tool audit report failed",
+        data: {
+          detail: {
+            tool: name,
+            outcome: outcome.status,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        },
       });
     }
     return mapOutcome(outcome, identity.name);
@@ -1462,11 +1475,14 @@ function wireSchemaCompiler(): (wire: Record<string, unknown>, serialized: strin
     } catch (error) {
       if (error instanceof EvalError && !codegenWarned) {
         codegenWarned = true;
-        console.warn(
-          "[vendo] mcp door: this runtime forbids code generation, so declared tool output schemas "
-          + "cannot be validated before they are advertised and are omitted from tools/list. "
-          + "Tools still list and still run; the model just loses the declared result fields.",
-        );
+        log({
+          code: "mcp.output-schema-validation-off",
+          level: "warn",
+          message:
+            "[vendo] mcp door: this runtime forbids code generation, so declared tool output schemas "
+            + "cannot be validated before they are advertised and are omitted from tools/list. "
+            + "Tools still list and still run; the model just loses the declared result fields.",
+        });
       }
       return rememberVerdict(serialized, false);
     }
@@ -1778,11 +1794,14 @@ async function readHostIdentity(): Promise<HostIdentity> {
   const warnFallback = (reason: string): HostIdentity => {
     if (!identityFallbackWarned) {
       identityFallbackWarned = true;
-      console.warn(
-        `[vendo] mcp door: could not read a product name from ${path ?? "the host package"} (${reason}); `
-        + "the server card and the connect page will say \"vendo\". Set `name` in the host's "
-        + "package.json or run the door from the host's package root.",
-      );
+      log({
+        code: "mcp.product-name-unresolved",
+        level: "warn",
+        message:
+          `[vendo] mcp door: could not read a product name from ${path ?? "the host package"} (${reason}); `
+          + "the server card and the connect page will say \"vendo\". Set `name` in the host's "
+          + "package.json or run the door from the host's package root.",
+      });
     }
     return fallback;
   };

--- a/packages/mcp/src/oauth/server.ts
+++ b/packages/mcp/src/oauth/server.ts
@@ -1,10 +1,11 @@
-import type {
-  AuditEvent,
-  Guard,
-  Principal,
-  StoreAdapter,
-  StoreOps,
-  VendoRecord,
+import {
+  type AuditEvent,
+  type Guard,
+  log,
+  type Principal,
+  type StoreAdapter,
+  type StoreOps,
+  type VendoRecord,
 } from "@vendoai/core";
 import { engineOverAdapter, VendoError } from "@vendoai/core";
 import type {
@@ -900,11 +901,18 @@ export class OAuthServer {
     try {
       await this.#guard.report(audit);
     } catch (error) {
-      console.error("[vendo] mcp oauth: audit report failed", {
-        principal,
-        clientId,
-        event,
-        error: error instanceof Error ? error.message : String(error),
+      log({
+        code: "mcp.oauth-audit-report-failed",
+        level: "error",
+        message: "[vendo] mcp oauth: audit report failed",
+        data: {
+          detail: {
+            principal,
+            clientId,
+            event,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        },
       });
     }
   }

--- a/packages/store/src/db-postgres.ts
+++ b/packages/store/src/db-postgres.ts
@@ -5,6 +5,7 @@
  *  engine they can't run. The PGlite dev-mode default layers on top of this
  *  module in ./db.ts. Enforced by scripts/portability-gate.mjs. */
 import { Client, Pool } from "pg";
+import { log } from "@vendoai/core";
 
 /** 02-store §1 */
 export interface StoreConfig {
@@ -48,7 +49,12 @@ const ADVISORY_LOCK_KEY = 7_461_001;
 export function createPostgresDb(url: string): Db {
   const pool = new Pool({ connectionString: url });
   pool.on("error", (error) => {
-    console.error("[vendo] postgres pool: idle connection error (recovering)", error);
+    log({
+      code: "store.postgres-pool-error",
+      level: "error",
+      message: "[vendo] postgres pool: idle connection error (recovering)",
+      data: { error },
+    });
   });
   let closed = false;
   return {

--- a/packages/ui/src/chrome/connect-card.tsx
+++ b/packages/ui/src/chrome/connect-card.tsx
@@ -1,3 +1,4 @@
+import { log } from "@vendoai/core";
 import { useEffect, useRef, useState } from "react";
 import { useVendoProvider } from "../context.js";
 import { useConnections } from "../hooks/use-connections.js";
@@ -147,7 +148,11 @@ export function ConnectCard({ connector, toolkit, message, onConnected, live = t
       // Where a developer reads it: the host who forgot the connector needs the
       // sentence that names what to configure, and only they should see it.
       if (developmentMode()) {
-        console.warn(`[vendo] ConnectCard "${toolkit}": ${reason instanceof Error ? reason.message : String(reason)}`);
+        log({
+          code: "ui.connect-card-failed",
+          level: "warn",
+          message: `[vendo] ConnectCard "${toolkit}": ${reason instanceof Error ? reason.message : String(reason)}`,
+        });
       }
     }
   };

--- a/packages/ui/src/chrome/pin-ceremony.ts
+++ b/packages/ui/src/chrome/pin-ceremony.ts
@@ -22,6 +22,7 @@
  * Lifted from the Keystone demo's `pin-flight.ts`, which is where the sequence
  * was designed and proven on stage.
  */
+import { log } from "@vendoai/core";
 import { useCallback, useEffect, useState } from "react";
 import { useVendoProvider } from "../context.js";
 import { announcePin, onPinAnnounced, pinTaken } from "../pin-events.js";
@@ -366,7 +367,11 @@ export function usePinAction(): ((app: { appId: string; payload: unknown }) => v
             // toast because this path's surface is already dismissed by the
             // time the write answers, so there is nowhere inline left to say it.
             if (developmentMode()) {
-              console.warn(`[vendo] pin: placing ${app.appId} in "${pinSlot}" failed — ${String(reason)}`);
+              log({
+                code: "ui.pin-ceremony-place-failed",
+                level: "warn",
+                message: `[vendo] pin: placing ${app.appId} in "${pinSlot}" failed — ${String(reason)}`,
+              });
             }
             vendoToast({ text: "That didn’t go through — try again.", state: "error" });
             return;

--- a/packages/ui/src/chrome/remixable.tsx
+++ b/packages/ui/src/chrome/remixable.tsx
@@ -1,5 +1,5 @@
 import { isValidElement, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import { seedComponentName, type AppDocument, type Json, type TreeNode } from "@vendoai/core";
+import { log, seedComponentName, type AppDocument, type Json, type TreeNode } from "@vendoai/core";
 import { useVendoProvider } from "../context.js";
 import { useApp } from "../hooks/use-app.js";
 import { useResource } from "../hooks/use-resource.js";
@@ -177,7 +177,11 @@ function RemixedFork({ appId, slot, review, liveProps, menuOpen, onMenuToggle, o
 
   useEffect(() => {
     if (!isLoading && error !== undefined && developmentMode()) {
-      console.warn(`[vendo] Remixable "${slot}": the fork failed to load — ${error.message}`);
+      log({
+        code: "ui.remixable-fork-load-failed",
+        level: "warn",
+        message: `[vendo] Remixable "${slot}": the fork failed to load — ${error.message}`,
+      });
     }
   }, [error, isLoading, slot]);
 
@@ -206,7 +210,11 @@ function RemixedFork({ appId, slot, review, liveProps, menuOpen, onMenuToggle, o
       })
       .catch((reason: unknown) => {
         if (developmentMode()) {
-          console.warn(`[vendo] Remixable "${slot}": revert failed — ${reason instanceof Error ? reason.message : String(reason)}`);
+          log({
+            code: "ui.remixable-revert-failed",
+            level: "warn",
+            message: `[vendo] Remixable "${slot}": revert failed — ${reason instanceof Error ? reason.message : String(reason)}`,
+          });
         }
       })
       .finally(() => setReverting(false));
@@ -274,7 +282,11 @@ function RemixedFork({ appId, slot, review, liveProps, menuOpen, onMenuToggle, o
                     send: false,
                   });
                   if (!opened && developmentMode()) {
-                    console.warn(`[vendo] Remixable "${slot}": "Open in panel" opens the conversation surface — mount a VendoOverlay for it to land in.`);
+                    log({
+                    code: "ui.remixable-no-overlay",
+                    level: "warn",
+                    message: `[vendo] Remixable "${slot}": "Open in panel" opens the conversation surface — mount a VendoOverlay for it to land in.`,
+                  });
                   }
                 }}
               >
@@ -317,7 +329,11 @@ export function Remixable({ review = false, children }: RemixableProps) {
 
   useEffect(() => {
     if (slot === null && developmentMode()) {
-      console.warn("[vendo] <Remixable> must wrap exactly one statically importable component element; extract a component and wrap that (vendo sync says the same, loudly).");
+      log({
+        code: "ui.remixable-invalid-child",
+        level: "warn",
+        message: "[vendo] <Remixable> must wrap exactly one statically importable component element; extract a component and wrap that (vendo sync says the same, loudly).",
+      });
     }
   }, [slot]);
 
@@ -344,7 +360,11 @@ export function Remixable({ review = false, children }: RemixableProps) {
       .catch((reason: unknown) => {
         setLatched(false);
         if (developmentMode()) {
-          console.warn(`[vendo] Remixable "${slot}": the remix fork failed — ${reason instanceof Error ? reason.message : String(reason)}`);
+          log({
+            code: "ui.remixable-fork-create-failed",
+            level: "warn",
+            message: `[vendo] Remixable "${slot}": the remix fork failed — ${reason instanceof Error ? reason.message : String(reason)}`,
+          });
         }
       })
       .finally(() => {

--- a/packages/ui/src/chrome/vendo-palette.tsx
+++ b/packages/ui/src/chrome/vendo-palette.tsx
@@ -1,3 +1,4 @@
+import { log } from "@vendoai/core";
 import { useEffect, useMemo } from "react";
 import { useApps } from "../hooks/use-apps.js";
 import { developmentMode } from "./dev-mode.js";
@@ -58,12 +59,20 @@ export function VendoPalette({ onCommand, hotkey }: { onCommand?(command: VendoC
       if (command.kind === "new-conversation") {
         const opened = openVendoConversation({ newConversation: true });
         if (!opened && developmentMode()) {
-          console.warn("[vendo] VendoPalette: \"New conversation\" opens the conversation surface — mount a VendoOverlay for it to land in (or supply onCommand).");
+          log({
+            code: "ui.vendo-palette-no-overlay",
+            level: "warn",
+            message: "[vendo] VendoPalette: \"New conversation\" opens the conversation surface — mount a VendoOverlay for it to land in (or supply onCommand).",
+          });
         }
         return;
       }
       if (developmentMode()) {
-        console.warn(`[vendo] VendoPalette: "${command.label}" needs an onCommand handler to route (kind "${command.kind}").`);
+        log({
+          code: "ui.vendo-palette-no-oncommand",
+          level: "warn",
+          message: `[vendo] VendoPalette: "${command.label}" needs an onCommand handler to route (kind "${command.kind}").`,
+        });
       }
     },
   }), [commands, onCommand]);
@@ -73,7 +82,11 @@ export function VendoPalette({ onCommand, hotkey }: { onCommand?(command: VendoC
   useEffect(() => registerPaletteOpener(() => {
     const opened = openVendoConversation();
     if (!opened && developmentMode()) {
-      console.warn("[vendo] VendoPalette: nothing to open — mount a VendoOverlay for the conversation surface to land in.");
+      log({
+        code: "ui.vendo-palette-no-overlay",
+        level: "warn",
+        message: "[vendo] VendoPalette: nothing to open — mount a VendoOverlay for the conversation surface to land in.",
+      });
     }
   }), []);
 
@@ -94,7 +107,11 @@ export function VendoPalette({ onCommand, hotkey }: { onCommand?(command: VendoC
       event.preventDefault();
       const opened = openVendoConversation({ toggle: true });
       if (!opened && developmentMode()) {
-        console.warn("[vendo] VendoPalette: ⌘K opens the conversation surface — mount a VendoOverlay for it to land in.");
+        log({
+          code: "ui.vendo-palette-no-overlay",
+          level: "warn",
+          message: "[vendo] VendoPalette: ⌘K opens the conversation surface — mount a VendoOverlay for it to land in.",
+        });
       }
     };
     return registerPaletteHotkey(handler);

--- a/packages/ui/src/chrome/vendo-slot.tsx
+++ b/packages/ui/src/chrome/vendo-slot.tsx
@@ -1,4 +1,4 @@
-import type { Json, ToolOutcome, UIPayload } from "@vendoai/core";
+import { log, type Json, type ToolOutcome, type UIPayload } from "@vendoai/core";
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { useVendoProvider } from "../context.js";
 import { announcePin } from "../pin-events.js";
@@ -279,7 +279,11 @@ export function VendoSlot({ id, label, appId: appIdProp, pin, onAuthor, discover
   const suggest = (prompt: string) => {
     const opened = openVendoConversation({ prompt, send: false });
     if (!opened && developmentMode()) {
-      console.warn(`[vendo] VendoSlot "${id}": suggestions open the conversation surface — mount a VendoOverlay for them to land in.`);
+      log({
+        code: "ui.vendo-slot-no-overlay",
+        level: "warn",
+        message: `[vendo] VendoSlot "${id}": suggestions open the conversation surface — mount a VendoOverlay for them to land in.`,
+      });
     }
   };
 

--- a/packages/ui/src/chrome/vendo-trigger.tsx
+++ b/packages/ui/src/chrome/vendo-trigger.tsx
@@ -1,3 +1,4 @@
+import { log } from "@vendoai/core";
 import type { ReactNode } from "react";
 import { ChromeRoot } from "./chrome-root.js";
 import { developmentMode } from "./dev-mode.js";
@@ -37,7 +38,11 @@ export function VendoTrigger({ prompt, context, children }: VendoTriggerProps) {
           // prompts; the user presses Send themselves.
           const opened = openVendoConversation({ prompt: context ? `${prompt}\n\n${context}` : prompt });
           if (!opened && developmentMode()) {
-            console.warn("[vendo] VendoTrigger: no <VendoOverlay /> is mounted to open — this button is a no-op.");
+            log({
+              code: "ui.vendo-trigger-no-overlay",
+              level: "warn",
+              message: "[vendo] VendoTrigger: no <VendoOverlay /> is mounted to open — this button is a no-op.",
+            });
           }
         }}
       >

--- a/packages/ui/src/hooks/use-connector-catalog.ts
+++ b/packages/ui/src/hooks/use-connector-catalog.ts
@@ -1,6 +1,7 @@
 /** The connect dock's effective catalog: the host's explicit `connectors`
     prop when it passed one, else the wire's auto catalog — everything the
     server-side connectors advertise (`GET /connections/catalog`). */
+import { log } from "@vendoai/core";
 import { useCallback, useEffect, useState } from "react";
 import type { VendoClient } from "../client.js";
 import { useVendoProvider, type ConnectorOption } from "../context.js";
@@ -31,7 +32,12 @@ function fetchCatalog(client: VendoClient): Promise<CatalogResult> {
       // stays and the tray shows an honest error state with a retry. Warn
       // (never silently) and forget the promise so a retry refetches.
       catalogByClient.delete(client);
-      console.warn("[vendo] connector catalog fetch failed; the connect tray will offer a retry:", reason);
+      log({
+        code: "ui.connector-catalog-fetch-failed",
+        level: "warn",
+        message: "[vendo] connector catalog fetch failed; the connect tray will offer a retry:",
+        data: { reason },
+      });
       return { options: [], failed: true };
     },
   );

--- a/packages/ui/src/hooks/use-placements.ts
+++ b/packages/ui/src/hooks/use-placements.ts
@@ -16,6 +16,7 @@
  * slots telling the registry they exist, deduped and batched into one write.
  */
 import {
+  log,
   SLOTS_REPORT_MAX,
   SLOT_ID_MAX_CHARS,
   SLOT_LABEL_MAX_CHARS,
@@ -193,7 +194,11 @@ function createPoller(client: VendoClient): Poller {
       // report to fit instead; the route stays the strict backstop.
       if (slot.length === 0 || slot.length > SLOT_ID_MAX_CHARS) {
         if (developmentMode()) {
-          console.warn(`[vendo] VendoSlot id must be 1-${SLOT_ID_MAX_CHARS} characters — this slot is not reported, so nothing can offer it as a destination.`);
+          log({
+            code: "ui.vendo-slot-id-invalid",
+            level: "warn",
+            message: `[vendo] VendoSlot id must be 1-${SLOT_ID_MAX_CHARS} characters — this slot is not reported, so nothing can offer it as a destination.`,
+          });
         }
         return;
       }
@@ -222,7 +227,11 @@ function createPoller(client: VendoClient): Poller {
           // that mounts it, once the slots already in the registry are quiet.
           forget(batch.slice(SLOTS_REPORT_MAX));
           if (developmentMode()) {
-            console.warn(`[vendo] a page may report at most ${SLOTS_REPORT_MAX} slots at once — ${batch.length - sending.length} were held back for a later render.`);
+            log({
+              code: "ui.slots-report-overflow",
+              level: "warn",
+              message: `[vendo] a page may report at most ${SLOTS_REPORT_MAX} slots at once — ${batch.length - sending.length} were held back for a later render.`,
+            });
           }
         }
         void client.slots.report(sending).catch(() => forget(sending));

--- a/packages/ui/src/tree/jail/JailedComponent.tsx
+++ b/packages/ui/src/tree/jail/JailedComponent.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 import {
+  log,
   type Json,
   type ToolOutcome,
 } from "@vendoai/core";
@@ -396,8 +397,11 @@ export function JailedComponent({
       // shimmer skeleton that is indistinguishable from "still loading" — a
       // real captured component failed this way on a stale jail runtime and
       // took a browser investigation to find, because nothing anywhere said so.
-      // eslint-disable-next-line no-console
-      console.warn(`[vendo] "${name}" failed inside the jail and is showing a loading silhouette because the payload is mid-stream: ${error}`);
+      log({
+        code: "ui.jailed-component-mid-stream-error",
+        level: "warn",
+        message: `[vendo] "${name}" failed inside the jail and is showing a loading silhouette because the payload is mid-stream: ${error}`,
+      });
       return <FormingSkeleton name={name} />;
     }
     return <ContainedNotice label="Generated component error">{`${name}: ${error}`}</ContainedNotice>;

--- a/packages/vendo/src/catalog.ts
+++ b/packages/vendo/src/catalog.ts
@@ -1,6 +1,7 @@
 import { catalogFileSchema, type CatalogFile } from "@vendoai/actions";
 import {
   type JsonSchema,
+  log,
   VendoError,
 } from "@vendoai/core";
 import {
@@ -55,9 +56,12 @@ function diskPropsValidator(schema: JsonSchema, name: string): StandardSchema {
       },
     };
   } catch (error) {
-    console.warn(
-      `[vendo] catalog entry "${name}" has a props schema ajv could not compile (${error instanceof Error ? error.message : String(error)}); validating permissively.`,
-    );
+    log({
+      code: "vendo.catalog-props-schema-uncompilable",
+      level: "warn",
+      message:
+        `[vendo] catalog entry "${name}" has a props schema ajv could not compile (${error instanceof Error ? error.message : String(error)}); validating permissively.`,
+    });
     return permissivePropsSchema();
   }
 }
@@ -118,7 +122,11 @@ export function runtimeCatalogFromFile(
   for (const entry of parsed.entries) {
     const refusal = projectionRefusal(entry.name, source);
     if (refusal !== undefined) {
-      console.warn(`[vendo] ${refusal.message} Skipping that entry; the rest of the catalog loads. Rename the component to recover it.`);
+      log({
+        code: "vendo.catalog-entry-refused",
+        level: "warn",
+        message: `[vendo] ${refusal.message} Skipping that entry; the rest of the catalog loads. Rename the component to recover it.`,
+      });
       continue;
     }
     catalog.push({
@@ -144,9 +152,12 @@ export function runtimeCatalogFromJson(
   try {
     return runtimeCatalogFromFile(catalogFileSchema.parse(JSON.parse(raw)), file);
   } catch (error) {
-    console.error(
-      `[vendo] Failed to load host components from ${file}: ${parseIssue(error)}. Run "vendo sync" to regenerate the file.`,
-    );
+    log({
+      code: "vendo.catalog-load-failed",
+      level: "error",
+      message:
+        `[vendo] Failed to load host components from ${file}: ${parseIssue(error)}. Run "vendo sync" to regenerate the file.`,
+    });
     return [];
   }
 }
@@ -168,9 +179,12 @@ function derivedJsonSchema(schema: StandardSchema | undefined, name: string): Js
     ).jsonSchema as Record<string, unknown>;
     return derived;
   } catch (error) {
-    console.warn(
-      `[vendo] could not derive a JSON Schema for catalog entry "${name}" (${error instanceof Error ? error.message : String(error)}); the prompt will carry its description only.`,
-    );
+    log({
+      code: "vendo.catalog-json-schema-derivation-failed",
+      level: "warn",
+      message:
+        `[vendo] could not derive a JSON Schema for catalog entry "${name}" (${error instanceof Error ? error.message : String(error)}); the prompt will carry its description only.`,
+    });
     return undefined;
   }
 }

--- a/packages/vendo/src/cloud-tools.ts
+++ b/packages/vendo/src/cloud-tools.ts
@@ -1,7 +1,7 @@
 import { composioToolRisk, normalizeToolName, type Connector, type ConnectorAccountIdentity } from "@vendoai/actions";
 import type { RunContext, ToolCall, ToolDescriptor, ToolOutcome } from "@vendoai/core";
 import { deploymentIdentityHeaders } from "./deployment-identity.js";
-import { debugConnectorHttp, defaultFetch } from "@vendoai/core";
+import { debugConnectorHttp, defaultFetch, log } from "@vendoai/core";
 
 /** The Cloud tools adapter — the execution half of the zero-key Composio
  * seam (cloudConnections is the account half). Tools list and execute ride
@@ -81,15 +81,23 @@ export function cloudTools(options: CloudToolsOptions): Connector {
           response = await cloudFetch(`/api/v1/tools?toolkits=${encodeURIComponent(toolkits)}`);
         } catch (error) {
           toolkitToolCache.delete(toolkits);
-          console.warn("[vendo] Vendo Cloud tools broker unreachable; no connector tools loaded:", error instanceof Error ? error.message : error);
+          log({
+            code: "vendo.cloud-tools-unreachable",
+            level: "warn",
+            message: "[vendo] Vendo Cloud tools broker unreachable; no connector tools loaded:",
+            data: { error: error instanceof Error ? error.message : error },
+          });
           return [];
         }
         if (!response.ok) {
           toolkitToolCache.delete(toolkits);
           const message = (response.payload as { error?: { message?: unknown } }).error?.message;
-          console.warn(
-            `[vendo] Vendo Cloud tools broker returned ${response.status}; no connector tools loaded${typeof message === "string" && message ? `: ${message}` : "."}`,
-          );
+          log({
+            code: "vendo.cloud-tools-broker-error",
+            level: "warn",
+            message:
+              `[vendo] Vendo Cloud tools broker returned ${response.status}; no connector tools loaded${typeof message === "string" && message ? `: ${message}` : "."}`,
+          });
           return [];
         }
         const items = response.payload && typeof response.payload === "object"
@@ -131,7 +139,11 @@ export function cloudTools(options: CloudToolsOptions): Connector {
         // Degrade, do not throw: the console repeating a slug must not delete
         // the host's own tools. First one wins so the list stays stable.
         if (nextNormalizedToRaw.has(name)) {
-          console.warn(`[vendo] Cloud tools: skipping duplicate tool name ${name}`);
+          log({
+            code: "vendo.cloud-tools-duplicate-tool",
+            level: "warn",
+            message: `[vendo] Cloud tools: skipping duplicate tool name ${name}`,
+          });
           continue;
         }
         nextNormalizedToRaw.set(name, { raw: item.slug, toolkit: item.toolkit });

--- a/packages/vendo/src/compose-surfaces.ts
+++ b/packages/vendo/src/compose-surfaces.ts
@@ -7,6 +7,7 @@
 import { mergedHostSemantics, VENDO_TOOLS_FORMAT } from "@vendoai/actions";
 import { agentToolDescriptors, buildingAppsSkill } from "@vendoai/apps";
 import {
+  log,
   VendoError,
   type RunContext,
   type ToolRegistry,
@@ -139,7 +140,11 @@ export const composeSurfaces = (composition: VendoComposition): Pick<VendoCompos
           ?? (overridesRaw === undefined ? undefined : JSON.parse(overridesRaw) as unknown),
       });
     } catch (error) {
-      console.error(`[vendo] Failed to load .vendo tool semantics: ${error instanceof Error ? error.message : String(error)}. Run "vendo sync" to regenerate .vendo/tools.json.`);
+      log({
+        code: "vendo.tool-semantics-load-failed",
+        level: "error",
+        message: `[vendo] Failed to load .vendo tool semantics: ${error instanceof Error ? error.message : String(error)}. Run "vendo sync" to regenerate .vendo/tools.json.`,
+      });
       return undefined;
     }
   };

--- a/packages/vendo/src/compose-sweep.ts
+++ b/packages/vendo/src/compose-sweep.ts
@@ -2,6 +2,7 @@
  * The TTL sweep: expired parked BYO calls and stranded approvals, on one pass
  * and one cadence.
  */
+import { log } from "@vendoai/core";
 import type { VendoComposition } from "./compose-context.js";
 
 /** The sweep pass, and the unref'd timer that drives it on a long-lived host. */
@@ -23,8 +24,13 @@ export const composeSweep = (composition: VendoComposition): Pick<VendoCompositi
         try {
           await guard.sweepExpiredApprovals(parkedCallTtlMs, sweepNow());
         } catch (error) {
-          console.error("[vendo] approval TTL sweep failed", {
-            error: error instanceof Error ? error.message : String(error),
+          log({
+            code: "vendo.approval-ttl-sweep-failed",
+            level: "error",
+            message: "[vendo] approval TTL sweep failed",
+            data: {
+              detail: { error: error instanceof Error ? error.message : String(error) },
+            },
           });
         }
       }
@@ -42,7 +48,11 @@ export const composeSweep = (composition: VendoComposition): Pick<VendoCompositi
     startBackgroundSweep = (): void => {
       const sweepTimer = setInterval(() => {
         runSweep().catch((error: unknown) => {
-          console.warn(`[vendo] TTL sweep failed; will retry next interval: ${error instanceof Error ? error.message : String(error)}`);
+          log({
+            code: "vendo.ttl-sweep-retry",
+            level: "warn",
+            message: `[vendo] TTL sweep failed; will retry next interval: ${error instanceof Error ? error.message : String(error)}`,
+          });
         });
       }, sweepConfig.intervalMs);
       (sweepTimer as unknown as { unref?: () => void }).unref?.();

--- a/packages/vendo/src/connector-discovery.ts
+++ b/packages/vendo/src/connector-discovery.ts
@@ -1,4 +1,4 @@
-import { CONNECTOR_DISCOVERY_TOOLS, VENDO_TOOL_TITLES, type Json, type RunContext, type ToolDescriptor, type ToolOutcome, type ToolRegistry } from "@vendoai/core";
+import { CONNECTOR_DISCOVERY_TOOLS, log, VENDO_TOOL_TITLES, type Json, type RunContext, type ToolDescriptor, type ToolOutcome, type ToolRegistry } from "@vendoai/core";
 
 /**
  * The connector-discovery tools, projected as ordinary tools on the one registry
@@ -283,7 +283,12 @@ export function connectorDiscoveryRegistry(
         // A port failure is OURS, not the model's, and raw JS text teaches it
         // nothing it can act on while leaking our internals into the transcript.
         // Log the detail for us; hand the model a sentence about what to do.
-        console.error(`[vendo] ${call.tool} failed:`, error);
+        log({
+          code: "vendo.tool-call-failed",
+          level: "error",
+          message: `[vendo] ${call.tool} failed:`,
+          data: { error },
+        });
         return fail("error", `${call.tool} could not complete. Try again, or continue without it.`);
       }
     },

--- a/packages/vendo/src/dev-creds/model-edge.ts
+++ b/packages/vendo/src/dev-creds/model-edge.ts
@@ -14,6 +14,7 @@
  *  magic. Keep this module free of node builtins and CLI imports; the
  *  portability gate bundles it. */
 import type { LanguageModel } from "ai";
+import { log } from "@vendoai/core";
 
 import type { ConfigurableSlotModels, DevModelOptions, VendoModelOptions, VendoModelSlot } from "./model.js";
 
@@ -38,7 +39,11 @@ function refusingModel(provider: string, modelId: string): LanguageModel {
   const refuse = (): never => {
     if (!announced) {
       announced = true;
-      console.error(`[vendo] model: ${EDGE_MESSAGE}`);
+      log({
+        code: "vendo.model-edge-refused",
+        level: "error",
+        message: `[vendo] model: ${EDGE_MESSAGE}`,
+      });
     }
     throw new Error(EDGE_MESSAGE);
   };

--- a/packages/vendo/src/dev-creds/model.ts
+++ b/packages/vendo/src/dev-creds/model.ts
@@ -2,7 +2,7 @@ import { createRequire } from "node:module";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { acceptsSamplingParams, UNKNOWN_MODEL_MAX_OUTPUT_TOKENS } from "@vendoai/apps";
-import { meterExhaustedFromError, VendoError } from "@vendoai/core";
+import { log, meterExhaustedFromError, VendoError } from "@vendoai/core";
 import type { LanguageModel } from "ai";
 import { resolveCloudBaseUrl } from "../cli/cloud/client.js";
 import {
@@ -291,7 +291,13 @@ export class DevModelController {
    *  terminal is where the honest message must land. */
   resolve(): Promise<Resolution> {
     this.resolution ??= this.resolveOnce().then((resolution) => {
-      if (resolution.mode === "unavailable") console.error(`[vendo] ${resolution.message}`);
+      if (resolution.mode === "unavailable") {
+        log({
+          code: "vendo.model-resolution-unavailable",
+          level: "error",
+          message: `[vendo] ${resolution.message}`,
+        });
+      }
       return resolution;
     });
     return this.resolution;
@@ -301,7 +307,11 @@ export class DevModelController {
     if (this.announced) return;
     this.announced = true;
     const slot = this.slot === "agent" ? "" : ` (${this.slot})`;
-    console.log(`[vendo] model${slot}: ${line}`);
+    log({
+      code: "vendo.model-announce",
+      level: "info",
+      message: `[vendo] model${slot}: ${line}`,
+    });
   }
 
   /** The string-tier model id for the resolved rung. Precedence (spec §DX

--- a/packages/vendo/src/dot-vendo.ts
+++ b/packages/vendo/src/dot-vendo.ts
@@ -7,6 +7,7 @@
 import type { ExtractedTool } from "@vendoai/actions";
 import { seedBaselineSchema, type SeedBaseline } from "@vendoai/apps";
 import {
+  log,
   type ToolDefinition,
 } from "@vendoai/core";
 import {
@@ -135,7 +136,11 @@ export function dotVendoSeedBaselines(root?: string): SeedBaseline[] {
     names = fs.readdirSync(directory).filter((name) => name.endsWith(".json")).sort();
   } catch (error) {
     if ((error as { code?: unknown }).code === "ENOENT") return [];
-    console.warn(`[vendo] could not read ${directory}; pin baselines were skipped`);
+    log({
+      code: "vendo.pin-baseline-dir-unreadable",
+      level: "warn",
+      message: `[vendo] could not read ${directory}; pin baselines were skipped`,
+    });
     return [];
   }
 
@@ -146,13 +151,21 @@ export function dotVendoSeedBaselines(root?: string): SeedBaseline[] {
     try {
       const parsed = seedBaselineSchema.parse(JSON.parse(fs.readFileSync(file, "utf8")));
       if (slots.has(parsed.slot)) {
-        console.warn(`[vendo] duplicate pin baseline slot ${parsed.slot} in ${file}; file was skipped`);
+        log({
+          code: "vendo.pin-baseline-duplicate-slot",
+          level: "warn",
+          message: `[vendo] duplicate pin baseline slot ${parsed.slot} in ${file}; file was skipped`,
+        });
         continue;
       }
       slots.add(parsed.slot);
       baselines.push(parsed);
     } catch {
-      console.warn(`[vendo] invalid pin baseline ${file}; file was skipped`);
+      log({
+        code: "vendo.pin-baseline-invalid",
+        level: "warn",
+        message: `[vendo] invalid pin baseline ${file}; file was skipped`,
+      });
     }
   }
   return baselines;

--- a/packages/vendo/src/screen-agent.ts
+++ b/packages/vendo/src/screen-agent.ts
@@ -33,6 +33,7 @@
  */
 import {
   VENDO_MAKE_TOOL,
+  log,
   mintTurnId,
   type AppId,
   type CommitResult,
@@ -659,9 +660,13 @@ export function screenAssembler(deps: ScreenAssemblerDeps): ScreenAssembler {
       if (result.kind !== "assembled") return result;
       if (result.decisions !== undefined) {
         await deps.remember?.(request.appId, result.decisions, ctx).catch((error: unknown) => {
-          console.warn(`[vendo] the screen agent's decisions were not recorded on ${request.appId} — ${
-            error instanceof Error ? error.message : String(error)
-          }`);
+          log({
+            code: "vendo.screen-agent-decisions-not-recorded",
+            level: "warn",
+            message: `[vendo] the screen agent's decisions were not recorded on ${request.appId} — ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          });
         });
       }
       return { kind: "assembled" };

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -8,7 +8,7 @@
  * is where a host names it.
  */
 import { provideCloudAdapters } from "@vendoai/agents";
-import { VendoError } from "@vendoai/core";
+import { log, VendoError } from "@vendoai/core";
 import { createComposition } from "./compose-context.js";
 import { vendoInstance, wireDepsFor } from "./compose-wire.js";
 import { setDelegateRunner } from "./delegate.js";
@@ -328,7 +328,11 @@ function createWireHandler(deps: WireDeps): (request: Request) => Promise<Respon
     // rejection, so a route that asked for the sweep still answers with it.
     let sweepPass = startSweep(false);
     await sweepPass?.catch((error: unknown) => {
-      console.warn(`[vendo] TTL sweep failed; will retry next interval: ${error instanceof Error ? error.message : String(error)}`);
+      log({
+        code: "vendo.ttl-sweep-retry",
+        level: "warn",
+        message: `[vendo] TTL sweep failed; will retry next interval: ${error instanceof Error ? error.message : String(error)}`,
+      });
     });
     // The one shared context-resolution pass (see wire/shared.ts).
     const context = createContextResolver(deps);
@@ -383,7 +387,12 @@ function createWireHandler(deps: WireDeps): (request: Request) => Promise<Respon
       if (error instanceof VendoError) return errorResponse(error);
       // The wire response stays generic (no internals leak to clients), but
       // the host operator gets the real failure on their own server log.
-      console.error("[vendo] unhandled wire error:", error);
+      log({
+        code: "vendo.unhandled-wire-error",
+        level: "error",
+        message: "[vendo] unhandled wire error:",
+        data: { error },
+      });
       return internalError();
     }
   };

--- a/packages/vendo/src/vendo-verbs.ts
+++ b/packages/vendo/src/vendo-verbs.ts
@@ -1,4 +1,4 @@
-import { VENDO_TOOL_TITLES, VendoError, type Json, type RunContext, type ToolDescriptor, type ToolRegistry } from "@vendoai/core";
+import { log, VENDO_TOOL_TITLES, VendoError, type Json, type RunContext, type ToolDescriptor, type ToolRegistry } from "@vendoai/core";
 
 /**
  * Design §4's vendo-verb family, projected as ordinary tools on the one
@@ -159,7 +159,12 @@ export function vendoVerbsRegistry(ports: VendoVerbPorts): ToolRegistry {
         // properties of undefined") teaches it nothing it can act on while
         // leaking our internals into the transcript. Log the detail for us; hand
         // the model a sentence about what to do.
-        console.error(`[vendo] ${call.tool} failed:`, error);
+        log({
+          code: "vendo.tool-call-failed",
+          level: "error",
+          message: `[vendo] ${call.tool} failed:`,
+          data: { error },
+        });
         return fail("error", `${call.tool} could not complete. Try again, or continue without it.`);
       }
     },


### PR DESCRIPTION
## Summary
- Mechanical migration of every `[vendo]`-prefixed `console.*` call to the new `log()` sink (`@vendoai/core`) added in the parent logger PR — no behavior change beyond routing.
- 77 sites migrated across 7 packages / 36 files (apps 18, harnesses 14, knowledge 1, mcp 5, store 1, ui 17, vendo 21).
- `message` stays byte-for-byte the original first argument (including the literal `[vendo] ` prefix); remaining arguments map 1:1 onto `data` keys in original argument order, preserving `consoleLogger`'s replay (`console[level](message, ...Object.values(data))`).
- A second-argument object literal (e.g. `console.error(msg, { tool, outcome, error })`) is wrapped as a single `data` key (`detail`) rather than flattened — flattening would change the replayed argument count/shape and break the byte-identical contract.

## Scope carve-outs (not touched, per brief)
- `packages/apps/src/server/generation/render-seam.ts` (5 sites) and `validate-gate.ts` (3 sites) — author-involved zone.
- `packages/harnesses/src/vendo/vendo.ts` (1 site) — author-involved zone.
- `packages/core/src/genui/**` — 0 sites found.
- `packages/mcp/src/shim/shim-html.gen.ts` — generated bundle (`Do not edit` header) containing a minified copy of `JailedComponent.tsx`'s `console.warn`; the real source site in `JailedComponent.tsx` is migrated, the generated artifact is not touched.
- The seven files owned by another lane (`core/sdk-events.ts`, `vendo/{batched-uploader,sdk-events,capability-misses,compose-tools,harness-turn,types}.ts`, `vendo/deployment-identity.ts`) — none contained a `[vendo]`-prefixed console site.

## Verification
- `pnpm turbo run build` and `typecheck` for all 7 touched packages: clean.
- `node scripts/dependency-guard.mjs`: OK (30 packages checked) — every touched package already declares `@vendoai/core`, no layering changes needed.
- Full scoped `vitest run` per package (capped `VITEST_MIN/MAX_FORKS/THREADS=1/2`):
  - knowledge 8/8 files, 102/102 tests
  - mcp 3/3 files, 143/143 tests
  - store 50/52 files (2 skipped, no local `POSTGRES_URL`), 502/507 tests
  - ui 113/113 files, 966/966 tests
  - harnesses 43/46 files (3 skipped), 536/543 tests
  - apps 113/117 files — one `engine.bundler-safety.e2e.test.ts` case timed out only under 5-package concurrent contention; passes cleanly (37.6s) run alone
  - vendo 192/202 files (10 skipped, live/CI-gated), 2217/2259 tests
- Console-spy tests (`mcp/tests/door.test.ts`, `store` tests, `vendo/tests/dev-creds/model.test.ts`, etc.) print output identical to the pre-migration bare `console.*` calls, confirming the byte-identical contract holds through the migration.

## Test plan
- [x] Build, typecheck, dependency-guard clean for all 7 touched packages
- [x] Full scoped test suite green (no regressions; one flake reproduced as machine contention, confirmed passing in isolation)
- [ ] CI's `ci` / `integration` / `conformance` / `audit` required checks on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finished migrating all remaining `[vendo]`-prefixed `console.*` calls to the centralized `log()` in `@vendoai/core` with no behavior change. Output stays byte-identical via the default console sink; structured error data is preserved.

- **Refactors**
  - Completed the sweep across `apps` (checking, doors, escalation, persistence, open), `harnesses` (claude-code, runtime), `mcp` (door, oauth), `ui` (chrome, hooks, jail), `store` (postgres), `knowledge`, and `vendo` (catalog, cloud tools, compose, sweep, connector discovery, dev-creds, screen, server, verbs).
  - Kept the original message (including the `[vendo] ` prefix); mapped remaining args into `data` and wrapped object-literal second args under a single `detail` key to keep replay parity.

- **Verification**
  - Build and typecheck clean; dependency guard unchanged.
  - Test suites green; console-spy tests confirm output identical to pre-migration `console.*` calls.

<sup>Written for commit cf6a0f27ac21afddf9743b6976cee327aec5674c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

