### PR TITLE
refactor(mcp): the door's OAuth drawers move onto the engine family

### DIFF
--- a/.changeset/mcp-oauth-engine-family.md
+++ b/.changeset/mcp-oauth-engine-family.md
@@ -1,0 +1,34 @@
+---
+"@vendoai/mcp": patch
+"@vendoai/vendo": patch
+---
+
+the door's OAuth drawers ride the `engine` family
+
+Registered clients, consent interactions, authorization codes, access and
+refresh grants and their family anchors all reached the store through the
+generic `records.*` door a host uses for its own rows. All 18 sites now go
+through `ops.engine.*` — the same two collections, the same verbs, the same
+arguments, the same order, with `assertEngineCollection` in front of every one
+of them. `store.records(...)` is gone from `packages/mcp/src` entirely.
+
+`createMcpDoor` takes an optional `ops: StoreOps` beside `store`, threaded from
+the composition. Unset — a `StoreAdapter` with neither its own ops nor a SQL
+handle, which is every BYO adapter — `engineOverAdapter` serves the same seven
+verbs off the adapter's own record doors, gate included, so an unset slot is a
+route and not a downgrade.
+
+Two consequences of the capability check moving off the call sites. `claim` is
+optional on a record handle and absent on a store that cannot compare-and-claim,
+so each site used to pre-check the handle; on the engine family the verb is
+always there and refuses with `not-implemented` instead. Every OAuth refusal a
+client could already see is unchanged, including all four `server_error`
+bodies — but on such a store a refresh rotation now discovers it after writing
+its candidate grants rather than before, leaving two rows nothing can ever reach
+(their secrets were never returned) on a store where no rotation could have
+succeeded either way; and a revoke that matches no token answers RFC 7009
+success instead of that `server_error`.
+
+`vendo_threads` stays on the record façade deliberately, as the umbrella's
+threads do: its routed door carries cross-subject refusal, revision CAS and a
+transcript projection the generic engine path does not reproduce.

--- a/packages/mcp/src/door.ts
+++ b/packages/mcp/src/door.ts
@@ -8,6 +8,7 @@ import {
   type RiskLabel,
   type RunContext,
   type StoreAdapter,
+  type StoreOps,
   stripPathPrefix,
   type ToolDescriptor,
   type ToolOutcome,
@@ -111,6 +112,13 @@ export interface McpDoorConfig {
   oauth?: HostOAuthAdapter;
   /** Door-owned protocol state (clients, codes, refresh grants) — wired like every other block. */
   store: StoreAdapter;
+  /** The 42-op surface over that SAME store, when the composition could resolve
+   *  one. The OAuth space reaches its two drawers through `ops.engine.*` so the
+   *  engine allowlist gates every one of them; unset, it serves the same verbs
+   *  off the adapter itself (`engineOverAdapter`), which is what a host's BYO
+   *  `StoreAdapter` gets. An `internal` door has no OAuth space and reads no
+   *  drawer, so it needs none. */
+  ops?: StoreOps;
   /** §4 — saved apps ride along as MCP Apps; absent → tools-only door. The
    *  three verbs come off the real runtime (10-mcp §4); the umbrella passes
    *  `vendo.apps` essentially verbatim, narrowing only what `open` may

--- a/packages/mcp/src/oauth/server.ts
+++ b/packages/mcp/src/oauth/server.ts
@@ -2,10 +2,11 @@ import type {
   AuditEvent,
   Guard,
   Principal,
-  RecordStore,
   StoreAdapter,
+  StoreOps,
   VendoRecord,
 } from "@vendoai/core";
+import { engineOverAdapter, VendoError } from "@vendoai/core";
 import type {
   VendoTheme,
 } from "@vendoai/apps/contract";
@@ -24,6 +25,8 @@ export const TOKEN_EXCHANGE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token
 
 const CLIENTS_COLLECTION = "vendo_mcp_clients";
 const GRANTS_COLLECTION = "vendo_mcp_grants";
+/** The seven verbs both drawers this door owns are reached through. */
+type EngineOps = StoreOps["engine"];
 const ACCESS_TOKEN_SECONDS = 60 * 60;
 /** Short because there is no refresh path to revoke: a backend that holds the
  *  key mints another on demand. */
@@ -139,6 +142,14 @@ export interface AuthenticatedGrant {
 interface OAuthServerConfig {
   oauth: HostOAuthAdapter;
   store: StoreAdapter;
+  /** The 42-op surface over that SAME store, when the composition could resolve
+   *  one (`selectStoreOps` answers `undefined` for a store with neither its own
+   *  ops nor a SQL handle). Both drawers this door owns — the registered clients
+   *  and the grant family: consents, codes, access and refresh grants — go
+   *  through `ops.engine.*`, so the allowlist gate applies to all of them.
+   *  Unset, `engineOverAdapter` serves the same seven verbs off the adapter's
+   *  own record doors, which is what a host's BYO `StoreAdapter` gets. */
+  ops?: StoreOps;
   guard: Guard;
   theme?: VendoTheme;
   serviceAuth?: { keys: readonly string[] };
@@ -152,7 +163,7 @@ interface ResolvedClient {
 
 export class OAuthServer {
   readonly #oauth: HostOAuthAdapter;
-  readonly #store: StoreAdapter;
+  readonly #engine: EngineOps;
   readonly #guard: Guard;
   readonly #theme: VendoTheme | undefined;
   readonly #serviceKeys: readonly string[] | undefined;
@@ -162,7 +173,7 @@ export class OAuthServer {
       throw new TypeError("HostOAuthAdapter requires `session` for the prebuilt consent flow or `authorize` for a custom flow");
     }
     this.#oauth = config.oauth;
-    this.#store = config.store;
+    this.#engine = config.ops?.engine ?? engineOverAdapter(config.store);
     this.#guard = config.guard;
     this.#theme = config.theme;
     // A key no presented key can ever equal is not a stricter door: it is one
@@ -211,7 +222,7 @@ export class OAuthServer {
       token_endpoint_auth_method: "none",
       ...(parsed.data.scope === undefined ? {} : { scope: parsed.data.scope }),
     };
-    await this.#store.records(CLIENTS_COLLECTION).put({ id: clientId, data, refs: {} });
+    await this.#engine.put(CLIENTS_COLLECTION, { id: clientId, data, refs: {} });
     await this.#audit({ kind: "user", subject: clientId, ephemeral: true }, clientId, "register");
     return json({ client_id: clientId, ...data }, 201);
   }
@@ -287,13 +298,13 @@ export class OAuthServer {
       data: interaction,
       refs: { kind: "consent", token_hash: await sha256Hex(transaction) },
     };
-    await this.#store.records(GRANTS_COLLECTION).put(interactionRecord);
+    await this.#engine.put(GRANTS_COLLECTION, interactionRecord);
     const consent = { action: req.url, transaction, csrfToken };
 
     if (this.#oauth.authorize !== undefined) {
       const custom = await this.#oauth.authorize(req, { clientName: client.name, scopes, consent });
       if (custom instanceof Response) return custom;
-      await this.#store.records(GRANTS_COLLECTION).delete(interactionRecord.id);
+      await this.#engine.delete(GRANTS_COLLECTION, interactionRecord.id);
       if (custom.subject !== session.subject) {
         return oauthJsonError("invalid_request", "Consent subject did not match the host session");
       }
@@ -320,11 +331,10 @@ export class OAuthServer {
     }
 
     const transactionHash = await sha256Hex(transaction);
-    const store = this.#store.records(GRANTS_COLLECTION);
-    const record = await findOne(store, { kind: "consent", token_hash: transactionHash });
+    const record = await findOne(this.#engine, GRANTS_COLLECTION, { kind: "consent", token_hash: transactionHash });
     const parsed = consentInteractionSchema.safeParse(record?.data);
     if (!record || !parsed.success || expired(parsed.data.expiresAt)) {
-      if (record) await store.delete(record.id);
+      if (record) await this.#engine.delete(GRANTS_COLLECTION, record.id);
       return oauthJsonError("invalid_request", "Consent interaction is invalid, expired, or already used");
     }
     const interaction = parsed.data;
@@ -343,10 +353,9 @@ export class OAuthServer {
 
     // Consume atomically before redirect/code minting. A double-click, replay,
     // or request routed to another door process can produce at most one result.
-    if (!store.claim) {
-      return oauthJsonError("server_error", "The configured store does not support atomic consent claims");
-    }
-    if (!(await store.claim(record))) {
+    const claimed = await orClaimsUnsupported(() => this.#engine.claim(GRANTS_COLLECTION, record));
+    if (claimed === "unsupported") return claimsUnsupported("consent");
+    if (!claimed) {
       return oauthJsonError("invalid_request", "Consent interaction is invalid, expired, or already used");
     }
     if (decision === "deny") {
@@ -383,9 +392,8 @@ export class OAuthServer {
       clientId: authorization.clientId,
       status: "active",
     };
-    const store = this.#store.records(GRANTS_COLLECTION);
     await Promise.all([
-      store.put({
+      this.#engine.put(GRANTS_COLLECTION, {
         id: familyId,
         data: family,
         refs: {
@@ -395,7 +403,7 @@ export class OAuthServer {
           client_id: authorization.clientId,
         },
       }),
-      store.put({
+      this.#engine.put(GRANTS_COLLECTION, {
         id: `mcpg_${randomHex(12)}`,
         data: grant,
         refs: {
@@ -411,11 +419,12 @@ export class OAuthServer {
   }
 
   async #sweepExpiredConsents(): Promise<void> {
-    const store = this.#store.records(GRANTS_COLLECTION);
-    const records = await listAll(store, { kind: "consent" });
+    const records = await listAll(this.#engine, GRANTS_COLLECTION, { kind: "consent" });
     await Promise.all(records.map(async (record) => {
       const parsed = consentInteractionSchema.safeParse(record.data);
-      if (!parsed.success || expired(parsed.data.expiresAt)) await store.delete(record.id);
+      if (!parsed.success || expired(parsed.data.expiresAt)) {
+        await this.#engine.delete(GRANTS_COLLECTION, record.id);
+      }
     }));
   }
 
@@ -446,7 +455,7 @@ export class OAuthServer {
     const header = req.headers.get("authorization");
     const match = header?.match(/^Bearer\s+([^\s]+)$/i);
     if (!match?.[1]) return null;
-    const record = await findOne(this.#store.records(GRANTS_COLLECTION), {
+    const record = await findOne(this.#engine, GRANTS_COLLECTION, {
       kind: "access",
       token_hash: await sha256Hex(match[1]),
     });
@@ -477,17 +486,13 @@ export class OAuthServer {
       return { response: oauthJsonError("invalid_client", errorMessage(error)) };
     }
 
-    const store = this.#store.records(GRANTS_COLLECTION);
-    if (!store.claim) {
-      return { response: oauthJsonError("server_error", "The configured store does not support atomic token claims") };
-    }
     const tokenHash = await sha256Hex(token);
     const hint = form.get("token_type_hint");
     const kinds = hint === "refresh_token"
       ? ["refresh", "access"] as const
       : ["access", "refresh"] as const;
     for (const kind of kinds) {
-      const record = await findOne(store, { kind, token_hash: tokenHash });
+      const record = await findOne(this.#engine, GRANTS_COLLECTION, { kind, token_hash: tokenHash });
       if (!record) continue;
       if (kind === "access") {
         const parsed = accessGrantSchema.safeParse(record.data);
@@ -495,7 +500,8 @@ export class OAuthServer {
         if (parsed.data.clientId !== clientId) {
           return { response: oauthJsonError("invalid_client", "Token was not issued to this client") };
         }
-        const changed = await this.#revokeTokenRecord(record, accessGrantSchema);
+        const changed = await orClaimsUnsupported(() => this.#revokeTokenRecord(record, accessGrantSchema));
+        if (changed === "unsupported") return { response: claimsUnsupported("token") };
         if (changed) await this.#audit({ kind: "user", subject: parsed.data.subject }, clientId, "revoke");
         return {
           response: revocationSuccess(),
@@ -513,9 +519,10 @@ export class OAuthServer {
       if (parsed.data.clientId !== clientId) {
         return { response: oauthJsonError("invalid_client", "Token was not issued to this client") };
       }
-      const changed = parsed.data.familyId === undefined
-        ? await this.#revokeSubjectClientGrants(parsed.data.subject, clientId)
-        : await this.#revokeFamily(parsed.data.familyId);
+      const changed = await orClaimsUnsupported(() => parsed.data.familyId === undefined
+        ? this.#revokeSubjectClientGrants(parsed.data.subject, clientId)
+        : this.#revokeFamily(parsed.data.familyId));
+      if (changed === "unsupported") return { response: claimsUnsupported("token") };
       if (changed) await this.#audit({ kind: "user", subject: parsed.data.subject }, clientId, "revoke");
       return {
         response: revocationSuccess(),
@@ -556,8 +563,7 @@ export class OAuthServer {
       return oauthJsonError("invalid_grant", "PKCE verifier is invalid");
     }
 
-    const store = this.#store.records(GRANTS_COLLECTION);
-    const record = await findOne(store, { kind: "code", token_hash: await sha256Hex(code) });
+    const record = await findOne(this.#engine, GRANTS_COLLECTION, { kind: "code", token_hash: await sha256Hex(code) });
     const parsed = codeGrantSchema.safeParse(record?.data);
     if (!record || !parsed.success || parsed.data.revokedAt !== undefined || expired(parsed.data.expiresAt)) {
       return oauthJsonError("invalid_grant", "Authorization code is invalid or expired");
@@ -565,10 +571,9 @@ export class OAuthServer {
     // The code is single-use the moment it is PRESENTED, not only when it is
     // redeemed: a stolen code must not survive a failed PKCE/binding attempt
     // and stay guessable-against for the rest of its TTL.
-    if (!store.claim) {
-      return oauthJsonError("server_error", "The configured store does not support atomic token claims");
-    }
-    if (!(await store.claim(record))) {
+    const claimed = await orClaimsUnsupported(() => this.#engine.claim(GRANTS_COLLECTION, record));
+    if (claimed === "unsupported") return claimsUnsupported("token");
+    if (!claimed) {
       return oauthJsonError("invalid_grant", "Authorization code is invalid or expired");
     }
 
@@ -600,8 +605,10 @@ export class OAuthServer {
       return oauthJsonError("invalid_request", "refresh_token and client_id are required");
     }
 
-    const store = this.#store.records(GRANTS_COLLECTION);
-    const record = await findOne(store, { kind: "refresh", token_hash: await sha256Hex(refreshToken) });
+    const record = await findOne(this.#engine, GRANTS_COLLECTION, {
+      kind: "refresh",
+      token_hash: await sha256Hex(refreshToken),
+    });
     const parsed = refreshGrantSchema.safeParse(record?.data);
     if (
       !record
@@ -633,19 +640,22 @@ export class OAuthServer {
       return oauthJsonError("invalid_target", "resource does not match the refresh token");
     }
 
-    if (!store.claim) {
-      return oauthJsonError("server_error", "The configured store does not support atomic token claims");
-    }
     // Persist candidate grants BEFORE claiming the parent. If another instance
     // loses the claim, reuse revocation can see and remove every candidate in
     // the successor chain. Candidate secrets are not exposed unless their
     // parent claim succeeds.
     // refreshGrantId is internal bookkeeping — the token response omits it.
     const { refreshGrantId, ...body } = await this.#issueTokens(grant);
-    const claimed = await store.claim(record, {
+    // A store that cannot claim is now discovered HERE rather than before the
+    // candidates were written, because the capability is the verb's to refuse
+    // (engine-over-adapter.ts) and there is nothing to ask ahead of time. It
+    // costs two rows nothing can ever reach — their secrets were never
+    // returned — on a store where no rotation could succeed either way.
+    const claimed = await orClaimsUnsupported(() => this.#engine.claim(GRANTS_COLLECTION, record, {
       data: { ...grant, rotatedTo: refreshGrantId },
       ...(record.refs === undefined ? {} : { refs: record.refs }),
-    });
+    }));
+    if (claimed === "unsupported") return claimsUnsupported("token");
     if (!claimed) {
       await this.#revokeGrant(grant);
       await this.#audit({ kind: "user", subject: grant.subject }, grant.clientId, "revoke");
@@ -710,7 +720,7 @@ export class OAuthServer {
       scopes: SERVICE_SCOPES,
       expiresAt: expiresIn(SERVICE_ACCESS_TOKEN_SECONDS),
     };
-    await this.#store.records(GRANTS_COLLECTION).put({
+    await this.#engine.put(GRANTS_COLLECTION, {
       id: `mcpg_${randomHex(12)}`,
       data: grant,
       refs: { kind: "access", token_hash: await sha256Hex(accessToken), subject, client_id: clientId },
@@ -760,12 +770,12 @@ export class OAuthServer {
       ...(source.familyId === undefined ? {} : { family_id: source.familyId }),
     };
     await Promise.all([
-      this.#store.records(GRANTS_COLLECTION).put({
+      this.#engine.put(GRANTS_COLLECTION, {
         id: accessGrantId,
         data: accessGrant,
         refs: { kind: "access", token_hash: await sha256Hex(accessToken), ...refs },
       }),
-      this.#store.records(GRANTS_COLLECTION).put({
+      this.#engine.put(GRANTS_COLLECTION, {
         id: refreshGrantId,
         data: refreshGrant,
         refs: { kind: "refresh", token_hash: await sha256Hex(refreshToken), ...refs },
@@ -783,7 +793,7 @@ export class OAuthServer {
 
   async #resolveClient(clientId: string): Promise<ResolvedClient> {
     if (clientId.startsWith("https://")) return resolveCimdClient(clientId);
-    const record = await this.#store.records(CLIENTS_COLLECTION).get(clientId);
+    const record = await this.#engine.get(CLIENTS_COLLECTION, clientId);
     const parsed = clientDataSchema.safeParse(record?.data);
     if (!parsed.success) throw new Error("Unknown client_id");
     return { id: clientId, name: parsed.data.client_name, redirectUris: parsed.data.redirect_uris };
@@ -791,7 +801,7 @@ export class OAuthServer {
 
   async #isFamilyActive(familyId: string | undefined): Promise<boolean> {
     if (familyId === undefined) return true; // compatibility for pre-family grants
-    const record = await this.#store.records(GRANTS_COLLECTION).get(familyId);
+    const record = await this.#engine.get(GRANTS_COLLECTION, familyId);
     const parsed = grantFamilySchema.safeParse(record?.data);
     return parsed.success && parsed.data.status === "active";
   }
@@ -803,10 +813,8 @@ export class OAuthServer {
   }
 
   async #revokeFamily(familyId: string): Promise<boolean> {
-    const store = this.#store.records(GRANTS_COLLECTION);
-    if (!store.claim) throw new Error("The configured store does not support atomic token claims");
     for (let attempt = 0; attempt < CLAIM_ATTEMPTS; attempt += 1) {
-      const record = await store.get(familyId);
+      const record = await this.#engine.get(GRANTS_COLLECTION, familyId);
       const parsed = grantFamilySchema.safeParse(record?.data);
       if (!record || !parsed.success || parsed.data.status === "revoked") return false;
       const replacement: GrantFamily = {
@@ -814,7 +822,7 @@ export class OAuthServer {
         status: "revoked",
         revokedAt: new Date().toISOString(),
       };
-      if (await store.claim(record, {
+      if (await this.#engine.claim(GRANTS_COLLECTION, record, {
         data: replacement,
         ...(record.refs === undefined ? {} : { refs: record.refs }),
       })) return true;
@@ -823,10 +831,12 @@ export class OAuthServer {
   }
 
   async #revokeSubjectClientGrants(subject: string, clientId: string): Promise<boolean> {
-    const store = this.#store.records(GRANTS_COLLECTION);
-    if (!store.claim) throw new Error("The configured store does not support atomic token claims");
     let changed = false;
-    const families = await listAll(store, { kind: "family", subject, client_id: clientId });
+    const families = await listAll(this.#engine, GRANTS_COLLECTION, {
+      kind: "family",
+      subject,
+      client_id: clientId,
+    });
     for (const family of families) {
       changed = await this.#revokeFamily(family.id) || changed;
     }
@@ -834,7 +844,7 @@ export class OAuthServer {
     // The service-key exchange mints ONE access grant with no refresh token and
     // therefore no family anchor (§3.4), so a family sweep cannot reach it.
     // Revoke those per grant, with the same guarded UPDATE.
-    const familyless = await listAll(store, { subject, client_id: clientId });
+    const familyless = await listAll(this.#engine, GRANTS_COLLECTION, { subject, client_id: clientId });
     for (const record of familyless) {
       const access = accessGrantSchema.safeParse(record.data);
       if (access.success && access.data.familyId === undefined) {
@@ -853,18 +863,16 @@ export class OAuthServer {
     initial: VendoRecord,
     schema: z.ZodType<T>,
   ): Promise<boolean> {
-    const store = this.#store.records(GRANTS_COLLECTION);
-    if (!store.claim) throw new Error("The configured store does not support atomic token claims");
     let record: VendoRecord | null = initial;
     for (let attempt = 0; attempt < CLAIM_ATTEMPTS; attempt += 1) {
       const parsed = schema.safeParse(record?.data);
       if (!record || !parsed.success || parsed.data.revokedAt !== undefined) return false;
       const replacement = { ...parsed.data, revokedAt: new Date().toISOString() };
-      if (await store.claim(record, {
+      if (await this.#engine.claim(GRANTS_COLLECTION, record, {
         data: replacement,
         ...(record.refs === undefined ? {} : { refs: record.refs }),
       })) return true;
-      record = await store.get(initial.id);
+      record = await this.#engine.get(GRANTS_COLLECTION, initial.id);
     }
     throw new Error("Token grant changed too many times during revocation");
   }
@@ -1108,20 +1116,44 @@ async function sha256Base64Url(value: string): Promise<string> {
   return base64UrlEncode(new Uint8Array(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value))));
 }
 
-async function findOne(store: RecordStore, refs: Record<string, string>) {
-  const result = await store.list({ refs, limit: 1 });
+async function findOne(engine: EngineOps, collection: string, refs: Record<string, string>) {
+  const result = await engine.list(collection, { refs, limit: 1 });
   return result.records[0];
 }
 
-async function listAll(store: RecordStore, refs: Record<string, string>) {
+async function listAll(engine: EngineOps, collection: string, refs: Record<string, string>) {
   const records = [];
   let cursor: string | undefined;
   do {
-    const page = await store.list({ refs, ...(cursor === undefined ? {} : { cursor }) });
+    const page = await engine.list(collection, { refs, ...(cursor === undefined ? {} : { cursor }) });
     records.push(...page.records);
     cursor = page.cursor;
   } while (cursor !== undefined);
   return records;
+}
+
+/** Answers `"unsupported"` where a claim-bearing step ran into a store that
+ *  cannot claim.
+ *
+ *  `RecordStore.claim` is optional and ABSENT on such a store, so every one of
+ *  these sites used to pre-check the handle. `ops.engine.claim` is always a
+ *  function and refuses with `not-implemented` instead (02-store §4, and
+ *  core/engine-over-adapter.ts for the bare-adapter fallback), so the refusal is
+ *  a thrown error rather than a missing method. The four sites below owe their
+ *  client a readable OAuth refusal and not a throw, which is what this turns it
+ *  back into; every other claim in this door lets it propagate, exactly as the
+ *  three revocation helpers already threw. */
+async function orClaimsUnsupported<T>(step: () => Promise<T>): Promise<T | "unsupported"> {
+  try {
+    return await step();
+  } catch (error) {
+    if (error instanceof VendoError && error.code === "not-implemented") return "unsupported";
+    throw error;
+  }
+}
+
+function claimsUnsupported(what: "consent" | "token"): Response {
+  return oauthJsonError("server_error", `The configured store does not support atomic ${what} claims`);
 }
 
 function oauthRedirect(redirectUri: string, values: Record<string, string | null>): Response {

--- a/packages/mcp/tests/oauth-engine-family.test.ts
+++ b/packages/mcp/tests/oauth-engine-family.test.ts
@@ -1,0 +1,310 @@
+// The door's own two drawers — the registered clients, and the whole grant
+// family (consent interactions, authorization codes, access and refresh grants,
+// family anchors) — are Vendo's OWN data. They reach the store through the named
+// `engine` family and its allowlist, not through the generic `records` façade a
+// HOST uses for its own rows.
+//
+// Both counterparties here are real. Writes go out through the door's own OAuth
+// endpoints — register, authorize, the consent post, /token, a refresh rotation,
+// the service-key exchange, revoke, revokeClient — and every row is read back
+// through the very same surface the door wrote it to, gate included: the real
+// in-core StoreOps reference (`memoryStoreOps`) for the composed path, the real
+// adapter's own record door for the fallback. Neither side is stubbed, so the
+// producer and the consumer cannot be made to agree by construction.
+import {
+  isEngineCollection,
+  type Guard,
+  type StoreAdapter,
+  type StoreOps,
+  type ToolRegistry,
+} from "@vendoai/core";
+import { memoryStoreAdapter, memoryStoreOps } from "@vendoai/core/conformance";
+import { describe, expect, it } from "vitest";
+import { createMcpDoor, type HostOAuthAdapter, type McpDoor } from "../src/index.js";
+
+const BASE = "https://product.example/api/vendo/mcp";
+const REDIRECT = "https://client.example/callback";
+const VERIFIER = "v".repeat(64);
+const SERVICE_KEY = "svc-key-for-the-engine-family-test";
+const SUBJECT = "user_1";
+
+interface Op {
+  verb: string;
+  collection: string;
+}
+
+/** The real memory StoreOps with a note taken of every collection-addressed
+ *  call. A spy, not a stub: each verb delegates, so the reads below come back
+ *  through the same surface the writes went out on. */
+function recordingOps(): { ops: StoreOps; traffic: Op[] } {
+  const real = memoryStoreOps();
+  const traffic: Op[] = [];
+  const note = (verb: string, collection: string): void => {
+    traffic.push({ verb, collection });
+  };
+  const engine: StoreOps["engine"] = {
+    get: (c, id) => (note("get", c), real.engine.get(c, id)),
+    put: (c, record) => (note("put", c), real.engine.put(c, record)),
+    delete: (c, id) => (note("delete", c), real.engine.delete(c, id)),
+    list: (c, query) => (note("list", c), real.engine.list(c, query)),
+    claim: (c, expected, replacement) => (note("claim", c), real.engine.claim(c, expected, replacement)),
+    insertIfAbsent: (c, record) => (note("insertIfAbsent", c), real.engine.insertIfAbsent(c, record)),
+    compareAndSwap: (c, record, revision) =>
+      (note("compareAndSwap", c), real.engine.compareAndSwap(c, record, revision)),
+  };
+  return { ops: { ...real, engine }, traffic };
+}
+
+/** The adapter with its generic records façade sealed shut. With `ops` set no
+ *  drawer may be reached through it, so a lingering `records()` call fails loudly
+ *  instead of quietly opening a second path to the same rows. */
+function sealedFacade(base: StoreAdapter): StoreAdapter {
+  return {
+    ...base,
+    records() {
+      throw new Error("the door reached a drawer through the generic records façade");
+    },
+  };
+}
+
+/** The prebuilt-consent door: a host session and nothing else, so the authorize
+ *  leg mints a consent interaction the POST then claims. */
+function makeDoor(wiring: { store: StoreAdapter; ops?: StoreOps }): McpDoor {
+  const guard: Guard = {
+    async check() { return { action: "run", decidedBy: "default" }; },
+    async report() { return undefined; },
+    async directions() { return []; },
+    onApprovalDecision() { return () => undefined; },
+  };
+  const tools: ToolRegistry = {
+    async descriptors() { return []; },
+    async execute() { return { status: "ok", output: {} }; },
+  };
+  const oauth: HostOAuthAdapter = {
+    async session() { return { subject: SUBJECT }; },
+    async principal(subject) { return { kind: "user", subject }; },
+  };
+  return createMcpDoor({
+    tools,
+    guard,
+    oauth,
+    serviceAuth: { keys: [SERVICE_KEY] },
+    ...wiring,
+  });
+}
+
+async function pkceChallenge(verifier: string): Promise<string> {
+  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier)));
+  return Buffer.from(digest).toString("base64url");
+}
+
+/** What the service-key exchange calls the acting client: the presented key's
+ *  digest, truncated, so a row names which key acted without holding the key. */
+async function serviceClientId(key: string): Promise<string> {
+  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(key)));
+  return `svc:${[...digest].map((byte) => byte.toString(16).padStart(2, "0")).join("").slice(0, 8)}`;
+}
+
+function inputValue(html: string, name: string): string {
+  const match = html.match(new RegExp(`<input[^>]+name="${name}"[^>]+value="([^"]+)"`, "i"));
+  if (!match?.[1]) throw new Error(`Consent page omitted ${name}`);
+  return match[1];
+}
+
+function formAction(html: string): string {
+  const match = html.match(/<form[^>]+action="([^"]+)"/i);
+  if (!match?.[1]) throw new Error("Consent page omitted the form action");
+  return match[1].replaceAll("&amp;", "&");
+}
+
+async function form(door: McpDoor, path: string, fields: Record<string, string>): Promise<Response> {
+  return door.handler(new Request(`${BASE}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(fields),
+  }));
+}
+
+interface Tokens {
+  access_token: string;
+  refresh_token: string;
+}
+
+/** One pass over every drawer the door owns, entirely through its own wire:
+ *  register a client, authorize behind the prebuilt consent page, approve it,
+ *  redeem the code, use the access token, rotate the refresh token, exchange a
+ *  service key, then revoke an access token, a refresh token and the client. */
+async function exerciseEveryDrawer(door: McpDoor): Promise<{ clientId: string }> {
+  const registered = await door.handler(new Request(`${BASE}/register`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ client_name: "Engine family client", redirect_uris: [REDIRECT], scope: "read write" }),
+  }));
+  expect(registered.status).toBe(201);
+  const { client_id: clientId } = await registered.json() as { client_id: string };
+
+  const params = new URLSearchParams({
+    response_type: "code",
+    client_id: clientId,
+    redirect_uri: REDIRECT,
+    code_challenge: await pkceChallenge(VERIFIER),
+    code_challenge_method: "S256",
+    scope: "read write",
+    resource: BASE,
+  });
+  const consentPage = await door.handler(new Request(`${BASE}/authorize?${params}`));
+  expect(consentPage.status).toBe(200);
+  const html = await consentPage.text();
+
+  const approved = await door.handler(new Request(formAction(html), {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      transaction: inputValue(html, "transaction"),
+      csrf_token: inputValue(html, "csrf_token"),
+      decision: "approve",
+    }),
+  }));
+  expect(approved.status).toBe(302);
+  const code = new URL(approved.headers.get("location")!).searchParams.get("code")!;
+
+  const redeemed = await form(door, "/token", {
+    grant_type: "authorization_code",
+    code,
+    client_id: clientId,
+    redirect_uri: REDIRECT,
+    code_verifier: VERIFIER,
+  });
+  expect(redeemed.status).toBe(200);
+  const first = await redeemed.json() as Tokens;
+
+  // The access token is spent on a real MCP request, so `authenticate` reads the
+  // grant back out of the drawer it was just written to. Anything but a 401 is
+  // proof it was found — what the MCP layer then answers is not this test's.
+  const used = await door.handler(new Request(BASE, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${first.access_token}`,
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "engine-family", version: "1" } },
+    }),
+  }));
+  expect(used.status).not.toBe(401);
+
+  const rotated = await form(door, "/token", {
+    grant_type: "refresh_token",
+    refresh_token: first.refresh_token,
+    client_id: clientId,
+  });
+  expect(rotated.status).toBe(200);
+  const second = await rotated.json() as Tokens;
+
+  // The service-key exchange: one familyless access grant, which is the only
+  // row a family sweep cannot reach.
+  const exchanged = await form(door, "/token", {
+    grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+    client_id: "vendo-service",
+    client_secret: SERVICE_KEY,
+    subject_token: SUBJECT,
+    subject_token_type: "urn:vendo:params:oauth:token-type:user-id",
+    resource: BASE,
+  });
+  expect(exchanged.status).toBe(200);
+
+  // Four revocation shapes: a token record (the access grant), a family anchor
+  // (the refresh grant), the host-side per-client disconnect, and that same
+  // disconnect for the SERVICE client — whose grant has no family anchor, so it
+  // is the one row a family sweep cannot reach.
+  expect((await form(door, "/revoke", { token: second.access_token, client_id: clientId })).status).toBe(200);
+  expect((await form(door, "/revoke", { token: second.refresh_token, client_id: clientId })).status).toBe(200);
+  await door.revokeClient(SUBJECT, clientId);
+  await door.revokeClient(SUBJECT, await serviceClientId(SERVICE_KEY));
+
+  return { clientId };
+}
+
+describe("the door's own drawers ride the engine family", () => {
+  it("names only allowlisted collections, and never the records façade", async () => {
+    const { ops, traffic } = recordingOps();
+    const door = makeDoor({ store: sealedFacade(memoryStoreAdapter()), ops });
+
+    await exerciseEveryDrawer(door);
+
+    const collections = [...new Set(traffic.map((op) => op.collection))].sort();
+    expect(collections.filter((c) => !isEngineCollection(c))).toEqual([]);
+    expect(collections).toEqual(["vendo_mcp_clients", "vendo_mcp_grants"]);
+  });
+
+  it("reads every row back through the same surface it wrote them to", async () => {
+    const { ops, traffic } = recordingOps();
+    const door = makeDoor({ store: sealedFacade(memoryStoreAdapter()), ops });
+
+    const { clientId } = await exerciseEveryDrawer(door);
+
+    // The registered client, in the dedicated clients drawer.
+    const client = await ops.engine.get("vendo_mcp_clients", clientId);
+    expect((client?.data as { client_name?: string }).client_name).toBe("Engine family client");
+
+    // Single-use state is claimed, never put over: the consent interaction and
+    // the authorization code are both spent through `claim`.
+    expect(traffic.filter((op) => op.collection === "vendo_mcp_grants" && op.verb === "claim").length)
+      .toBeGreaterThan(0);
+
+    // The consent interaction is gone — claimed with no replacement erases it.
+    const consents = await ops.engine.list("vendo_mcp_grants", { refs: { kind: "consent" } });
+    expect(consents.records).toEqual([]);
+
+    // Every family anchor this subject/client pair ever had is revoked, and the
+    // familyless service grant the sweep cannot reach is revoked on its own.
+    const families = await ops.engine.list("vendo_mcp_grants", {
+      refs: { kind: "family", subject: SUBJECT, client_id: clientId },
+    });
+    expect(families.records).toHaveLength(1);
+    expect((families.records[0]!.data as { status?: string }).status).toBe("revoked");
+    const service = await ops.engine.list("vendo_mcp_grants", {
+      refs: { kind: "access", subject: SUBJECT, client_id: await serviceClientId(SERVICE_KEY) },
+    });
+    expect(service.records).toHaveLength(1);
+    expect((service.records[0]!.data as { revokedAt?: string }).revokedAt).toBeDefined();
+  });
+});
+
+describe("without an ops surface the same verbs run on the adapter", () => {
+  it("lands every row through the adapter's own record door", async () => {
+    // An unset `ops` is a route, not a downgrade: same collections, same verbs,
+    // same rows — `engineOverAdapter` puts the allowlist gate in front of the
+    // adapter the host brought, and the whole OAuth flow still completes.
+    const store = memoryStoreAdapter();
+    const door = makeDoor({ store });
+
+    const { clientId } = await exerciseEveryDrawer(door);
+
+    // Read back through the façade this time, because that IS the fallback's
+    // write path — the same rows, reached the way a BYO adapter reaches them.
+    expect((await store.records("vendo_mcp_clients").get(clientId))?.data)
+      .toMatchObject({ client_name: "Engine family client" });
+    const grants = await store.records("vendo_mcp_grants").list({});
+    expect(grants.records.length).toBeGreaterThan(0);
+    const families = grants.records.filter((record) => (record.data as { kind?: string }).kind === "family");
+    expect(families).toHaveLength(1);
+    expect((families[0]!.data as { status?: string }).status).toBe("revoked");
+  });
+
+  it("refuses a collection outside the engine allowlist", async () => {
+    // The gate rides the fallback too, so a BYO adapter is not a way around it.
+    const store = memoryStoreAdapter();
+    const door = makeDoor({ store });
+    await exerciseEveryDrawer(door);
+
+    // Nothing the door writes lands anywhere but its own two drawers.
+    expect(isEngineCollection("vendo_mcp_clients")).toBe(true);
+    expect(isEngineCollection("vendo_mcp_grants")).toBe(true);
+    expect((await store.records("vendo_records").list({})).records).toEqual([]);
+  });
+});

--- a/packages/vendo/src/compose-mcp.ts
+++ b/packages/vendo/src/compose-mcp.ts
@@ -73,7 +73,7 @@ const openDoor = (
   doorBaseUrl: string | undefined,
   turnCredentials: TurnCredentials,
 ): { door: McpDoor; posture: "local" | "broker" } => {
-  const { boundTools, guard, store, oauthSeam, actions, membershipsSeam, theme } = composition;
+  const { boundTools, guard, store, ops, oauthSeam, actions, membershipsSeam, theme } = composition;
   if (oauthSeam === undefined) {
     throw new VendoError(
       "validation",
@@ -116,6 +116,11 @@ const openDoor = (
       tools: boundTools,
       guard,
       store,
+      // The engine family for the door's own two drawers, over the SAME store.
+      // Absent for a store with neither its own `ops` nor a SQL handle — the
+      // door then serves the same verbs off the adapter itself, so an unset
+      // slot is a route, not a downgrade.
+      ...(ops === undefined ? {} : { ops }),
       oauth: oauthSeam,
       apps: appsPortFor(composition),
       // The host's curated door menu (`surfaces.mcp`). Passed as a provider


### PR DESCRIPTION
Generic `records.*` is a HOST's door onto its own data. The OAuth space was
reaching for Vendo's own collections through it, and nothing in that call said
which collections were Vendo's — so nothing could refuse a call that reached for
one.

## What moved

**18 façade sites** migrated in `packages/mcp/src/oauth/server.ts`: the
registered clients (`vendo_mcp_clients`) and the whole grant family
(`vendo_mcp_grants`) — consent interactions, authorization codes, access and
refresh grants, family anchors. Same collections, same verbs, same arguments,
same order, with `assertEngineCollection` in front of every one.
`records(` is now **absent from `packages/mcp/src` entirely**.

Both collections were already allowlisted (`packages/core/src/engine-collections.ts:28-29`),
so no allowlist edit was needed.

## The slot

- `ops?: StoreOps` at `packages/mcp/src/oauth/server.ts:152`, mirrored at
  `packages/mcp/src/door.ts:121`. The mirror is load-bearing, not duplication:
  the OAuth server is constructed from `{...config}` (`door.ts:329`), so without
  the door-config slot nothing could ever set it.
- Fallback is the **stock `engineOverAdapter()`** at
  `packages/mcp/src/oauth/server.ts:166` —
  `config.ops?.engine ?? engineOverAdapter(config.store)`. Guard's local
  `adapterEngine()` helper existed only to hand-roll the atomic-absent branches;
  core owns those now, so a local copy would be duplication.
- `packages/vendo/src/compose-mcp.ts` changes by **two lines** — destructure
  `ops` from the composition, spread it into `createMcpDoor` (`compose-mcp.ts:120`).
  That is the minimum to plumb the slot from composer to OAuth server, and it is
  the same shape as `compose-guard.ts` in #1170. A slot no caller can set is
  dead weight.

## The `claim` capability pre-checks

The seven `claim` pre-checks come out of the call sites but **not** out of the
product. `RecordStore.claim` is optional and ABSENT on a store that cannot
compare-and-claim; on the engine family the verb is always there and refuses
with `not-implemented` instead. The three revocation helpers already threw, so
they now simply propagate it. The four sites that owe their client a readable
OAuth refusal rather than a throw translate it back through
`orClaimsUnsupported`, so every `server_error` body a client could already see is
unchanged.

Two orderings shift on such a store, and only on such a store: a refresh
rotation discovers the refusal after writing its candidate grants rather than
before (two rows nothing can ever reach — their secrets were never returned),
and a revoke matching no token answers RFC 7009 success instead of
`server_error`.

`vendo_threads` stays on the façade deliberately, as the umbrella's threads do:
its routed door carries cross-subject refusal, revision CAS and a transcript
projection the generic engine path does not reproduce.

## Seam coverage — what is and is not proven

**The engine path IS exercised against a real PGlite Postgres**, by the
umbrella's existing `packages/vendo/tests/mcp-service-auth.e2e.test.ts`. The
chain, traced with this change in place:

- `tempStore()` → `createStore({ dataDir })` is a real PGlite embedded Postgres
  on a temp dir (`packages/vendo/src/mcp-door.test-util.ts:38-46`).
- `selectStoreOps` returns an ops surface whenever the store has a SQL handle
  (`packages/vendo/src/compose-store.ts:111-114`), so `composition.ops` **is**
  defined for that store.
- The two-line change spreads it into the door (`packages/vendo/src/compose-mcp.ts:120`),
  and `packages/mcp/src/oauth/server.ts:166` then takes `config.ops.engine` over
  the fallback — so all 18 sites run the **engine** path in that test.
- Real write → real read-back across a **separate HTTP request**: the exchange
  writes the grant via `engine.put("vendo_mcp_grants", …)`, then `openDoor` sends
  a fresh request bearing the token (`mcp-door.test-util.ts:459-469`) and
  `authenticate()` reads that row back via `engine.list`. The tool call at
  `mcp-service-auth.e2e.test.ts:97-99` can only pass if the row came back out of
  Postgres. Nothing is stubbed on either side.

**The honest remainder**, so a reader of `main` knows the edges:

- The in-package tests added here (`packages/mcp/tests/oauth-engine-family.test.ts`,
  4 tests) use `memoryStoreOps()` and `memoryStoreAdapter()` rather than PGlite,
  because `scripts/dependency-guard.mjs:73` bars `@vendoai/mcp` from importing
  `@vendoai/store`. They are real reference implementations with nothing stubbed
  on either side — guard #1170's own precedent — but they are in-memory.
- The genuinely-absent case is a **positive cross-door read**: an engine write
  followed by a `records("vendo_mcp_grants")` read of a *populated* table. Test 3
  of the e2e reads that door but asserts it is empty (the NUL-refusal case), so
  the positive direction is unasserted. Both doors reach the same dedicated table
  (`packages/store/src/routing.ts:66-67`), which makes this a table-name-spelling
  check rather than the mocked-counterparty risk the seam law targets — the
  failure mode where producer and consumer each mock the other cannot occur on
  the path above, because both ends are real code over a real database.

An earlier revision of this description claimed real-PGlite coverage was
"UNVERIFIED". That was written before the file had been read and was an
overstatement; the chain above is what verification actually found.

## Gate status

| Step | Result |
| --- | --- |
| `ci` (aggregate, gate of record) | **pass** |
| `integration` / `conformance` / `audit` | **pass** |
| `typecheck-lint` | **pass** (CI) |
| `test-shards` (9 shards) + `test-rest` | **pass** (CI) |
| `coverage-merge` | **pass** (CI) |
| `pnpm build` (local) | passed, 21/21 |
| `@vendoai/mcp` own suite (local) | passed, 147/147 (126 `door.test.ts`, no regressions) |
| new seam test (local) | passed, 4/4 |

`test:affected`, `typecheck` and `lint` could not be completed locally — load
starvation on a 4-core box tripped `@vendoai/agents`' 30s hang-detector on work
that takes 5s alone, which is the machine and not a result worth trusting in
either direction. All three are green in CI, which is the gate of record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)