### PR TITLE
refactor(store): the app-access door rides the engine family

### DIFF
--- a/.changeset/store-app-access-engine-family.md
+++ b/.changeset/store-app-access-engine-family.md
@@ -1,0 +1,23 @@
+---
+"@vendoai/store": patch
+---
+
+the app-access door rides the `engine` family
+
+`appAccess` resolved and wrote app permissions through `store.records(collection)`
+— the generic door a HOST reaches its own rows through — so nothing in those
+calls said that `vendo_apps` and `vendo_app_grants` are Vendo's own drawers, and
+nothing could refuse a call that reached outside them. All four sites now name
+their collection to `ops.engine.*`: the app row every level resolves from, and
+the grant list, grant write and revoke behind it.
+
+Same collections, same verbs, same arguments, same order. `engine` reaches the
+very same routed doors `records` did, so the `ON CONFLICT (app_id, principal)`
+floor and the rest of the per-collection policy are untouched; the one statement
+added in front is the allowlist.
+
+No new parameter: this helper lives inside `@vendoai/store` and takes the store
+itself, so it uses the store's OWN `ops` when it carries one — the hosted store
+does, one hop shorter than its `records` façade, which is built on these very
+ops — and the family over the adapter's record doors (`engineOverAdapter`) when
+it does not, which is what a local store and every BYO adapter get.

--- a/packages/store/src/helpers/app-access.ts
+++ b/packages/store/src/helpers/app-access.ts
@@ -1,6 +1,7 @@
 import {
   VendoError,
   accessForPath,
+  engineOverAdapter,
   grantMatches,
   holdsLevel,
   parseGrantPrincipal,
@@ -40,16 +41,26 @@ const GRANT_PAGE_SIZE = 500;
  * from the ctx ONLY — the host asserted them this request and `can()` never
  * queries an org chart, because Vendo does not have one (§9.1).
  *
- * Everything goes through the ADAPTER interface (`store.records`), never raw
- * SQL: multi-party deployments are exactly the ones running on a hosted store,
- * which has no local db handle.
+ * Every row is read and written through the `engine` family, never raw SQL:
+ * multi-party deployments are exactly the ones running on a hosted store, which
+ * has no local db handle. `vendo_apps` and `vendo_app_grants` are Vendo's OWN
+ * drawers, so they are named to the family that knows that (the allowlist gate
+ * in front, the same routed doors behind) rather than to the generic
+ * `records.*` door a host reaches its own rows through.
+ *
+ * The store's own `ops` when it carries one — the hosted store does, and its
+ * client is one hop shorter than its `records` façade, which is built on these
+ * very ops. Otherwise the family over the adapter's record doors
+ * (`engineOverAdapter`), which is what a store this package minted and every
+ * host's BYO adapter gets. No `ops` parameter: unlike guard or mcp, this helper
+ * lives INSIDE @vendoai/store and takes the store itself, whose `ops` slot
+ * (store.ts:17-22) already IS the surface a composition would have threaded.
  */
 export function appAccess(store: VendoStore): AppAccess {
-  const grants = store.records("vendo_app_grants");
-  const apps = store.records("vendo_apps");
+  const engine = store.ops?.engine ?? engineOverAdapter(store);
 
   const rowSubject = async (appId: AppId): Promise<string | undefined> => {
-    const record = await apps.get(appId);
+    const record = await engine.get("vendo_apps", appId);
     return record === null ? undefined : record.refs?.["subject"];
   };
 
@@ -70,7 +81,7 @@ export function appAccess(store: VendoStore): AppAccess {
     const rows: AppGrantRecord[] = [];
     let cursor: string | undefined;
     do {
-      const page = await grants.list({
+      const page = await engine.list("vendo_app_grants", {
         refs: { app_id: appId },
         limit: GRANT_PAGE_SIZE,
         ...(cursor === undefined ? {} : { cursor }),
@@ -184,7 +195,7 @@ export function appAccess(store: VendoStore): AppAccess {
       }
       // ONE row per (app, principal), enforced HERE rather than by the local
       // engine's `ON CONFLICT (app_id, principal)` — a constraint no hosted or
-      // BYO records adapter has, and `records.put` is keyed by id alone. A
+      // BYO records adapter has, and `engine.put` is keyed by id alone. A
       // second row for one principal is an unrevokable grant: `levelFor` folds
       // every match with `strongerLevel`, so a downgrade does nothing, and
       // `revoke` would have to find them all.
@@ -204,7 +215,7 @@ export function appAccess(store: VendoStore): AppAccess {
       // its own id through `ON CONFLICT (app_id, principal) DO UPDATE`, which
       // never writes the id column, so nothing already stored is re-keyed.
       const existing = (await grantsFor(appId)).find((row) => row.principal === principal);
-      await grants.put({
+      await engine.put("vendo_app_grants", {
         id: existing?.id ?? `ag_${appId}_${principal}`,
         data: { appId, orgId, principal, level, createdBy: ctx.principal.subject },
         // The door writes the refs it queries by. The local engine derives them
@@ -223,7 +234,7 @@ export function appAccess(store: VendoStore): AppAccess {
       // before `grant` reused ids would otherwise keep the person granted, and
       // a revoke that leaves access standing is the worst possible outcome here.
       const matching = (await grantsFor(appId)).filter((row) => row.principal === principal);
-      for (const row of matching) await grants.delete(row.id);
+      for (const row of matching) await engine.delete("vendo_app_grants", row.id);
     },
 
     async list(ctx, appId) {

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -3,7 +3,7 @@
  *  keep the PGlite wasm engine out of the bundle graph. */
 export { createStore } from "./create-store.js";
 export { maybeDbFor, type VendoStore } from "./store.js";
-// The StoreOps local backend (02-store): the 42-op named-operation contract
+// The StoreOps local backend (02-store): the 35-op named-operation contract
 // served off this store's own Postgres, transactions at verb boundaries.
 export { createStoreOps } from "./ops.js";
 // The one composer of appData names and the owner stamp: everything that

--- a/packages/store/tests/app-access.ops.test.ts
+++ b/packages/store/tests/app-access.ops.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Build contract §9.2–§9.4 through the `engine` family, on a store that carries
+ * its OWN ops and no SQL handle — the hosted shape, which is the shape every
+ * multi-party deployment actually runs.
+ *
+ * `appAccess` reached its two drawers through `store.records(collection)`, the
+ * generic door a HOST reaches its own rows through; it names them to
+ * `ops.engine.*` now, so the allowlist stands in front of every read and write.
+ * That move is invisible from the outside, which is why this suite is shaped to
+ * be UNABLE to pass on the old road: `records()` throws here, and the ops behind
+ * it are the real local backend over a real database. Every grant below is
+ * written through the door's own write path and read back through its own read
+ * path — and then once more straight out of `vendo_app_grants`, so the row a
+ * caller resolves and the row on disk cannot disagree.
+ *
+ * The DENY half is the half that matters on permission code, so it is here in
+ * full: a stranger stays masked, an editor cannot re-share, and a revoke leaves
+ * nothing standing in either place.
+ */
+import type { Membership, RunContext, StoreOps } from "@vendoai/core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { appFixture } from "../src/fixtures.test-util.js";
+import { backends, type MadeBackend } from "../src/backends.test-util.js";
+import { appAccess } from "../src/helpers/app-access.js";
+import { appStore } from "../src/helpers/apps.js";
+import { createStoreOps } from "../src/ops.js";
+import type { VendoStore } from "../src/store.js";
+
+const ctxFor = (subject: string, memberships?: Membership[]): RunContext => ({
+  principal: { kind: "user", subject },
+  venue: "app",
+  presence: "present",
+  sessionId: `s_${subject}`,
+  ...(memberships === undefined ? {} : { memberships }),
+});
+
+/** Not a handle `@vendoai/store` minted — the shape a hosted store presents.
+ *  `records()` throws: the façade survives for hosts, but this door may not be
+ *  served by it any more, and a test that let it would prove nothing. */
+function opsOnlyStore(ops: StoreOps): VendoStore {
+  const unused = (what: string): never => {
+    throw new Error(`the app-access door must not reach ${what}`);
+  };
+  return {
+    ops,
+    records: () => unused("records()"),
+    blobs: () => unused("blobs()"),
+    async ensureSchema() {},
+    async close() {},
+    raw: () => unused("raw()"),
+  };
+}
+
+for (const backend of backends()) {
+  describe(`${backend.name} build contract §9 — app access over ops.engine`, () => {
+    let made: MadeBackend;
+    let hosted: VendoStore;
+
+    beforeAll(async () => {
+      made = await backend.make();
+      await made.store.ensureSchema();
+      // The SAME database, reached the way a store with no SQL handle reaches it.
+      hosted = opsOnlyStore(createStoreOps(made.store));
+    });
+    afterAll(async () => { if (made) await made.cleanup(); });
+
+    const access = (): ReturnType<typeof appAccess> => appAccess(hosted);
+    /** The row as `vendo_app_grants` holds it, not as the door reports it. */
+    const rowsFor = async (app: string): Promise<Record<string, unknown>[]> =>
+      await made.sql("SELECT principal, level FROM vendo_app_grants WHERE app_id = $1", [app]);
+
+    const admin = ctxFor("dana", [{ org: "acme", admin: true }]);
+
+    it("writes a grant and resolves it back, with the row on disk agreeing", async () => {
+      const app = "app_ops_grant";
+      await appStore(made.store).put({ kind: "user", subject: "acme" }, appFixture(app));
+
+      await access().grant(admin, app, "user:kim", "editor");
+
+      expect(await access().levelFor(ctxFor("kim"), app)).toBe("editor");
+      expect(await access().can(ctxFor("kim"), "editor", { app })).toBe(true);
+      expect(await access().list(admin, app)).toHaveLength(1);
+      expect(await rowsFor(app)).toEqual([{ principal: "user:kim", level: "editor" }]);
+    });
+
+    // The red half of the gate: these MUST fail, and §9.4's two postures must
+    // stay distinguishable — masked for someone who cannot see the app at all,
+    // `forbidden` for a proven viewer reaching past their level.
+    it("denies a stranger and an editor, and leaves nothing after a revoke", async () => {
+      const app = "app_ops_deny";
+      await appStore(made.store).put({ kind: "user", subject: "acme" }, appFixture(app));
+      await access().grant(admin, app, "user:kim", "editor");
+
+      // A stranger: no level, no view, and existence stays masked.
+      expect(await access().levelFor(ctxFor("mal"), app)).toBeNull();
+      expect(await access().can(ctxFor("mal"), "viewer", { app })).toBe(false);
+      await expect(access().list(ctxFor("mal"), app))
+        .rejects.toMatchObject({ code: "not-found" });
+      await expect(access().grant(ctxFor("mal"), app, "user:mal", "owner"))
+        .rejects.toMatchObject({ code: "not-found" });
+      // An editor sees the app, so re-sharing is refused as `forbidden`.
+      await expect(access().grant(ctxFor("kim"), app, "user:mal", "viewer"))
+        .rejects.toMatchObject({ code: "forbidden" });
+      await expect(access().revoke(ctxFor("kim"), app, "user:kim"))
+        .rejects.toMatchObject({ code: "forbidden" });
+      // Nothing the refusals touched was written.
+      expect(await rowsFor(app)).toEqual([{ principal: "user:kim", level: "editor" }]);
+
+      await access().revoke(admin, app, "user:kim");
+      expect(await access().levelFor(ctxFor("kim"), app)).toBeNull();
+      expect(await rowsFor(app)).toEqual([]);
+    });
+
+    it("refuses a collection outside the engine allowlist, which is what the family adds", async () => {
+      // The gate is the ONE statement this migration put in front of every verb.
+      // Named here so the door's drawers staying inside the allowlist is a fact
+      // this suite holds, not an accident of the two strings above.
+      await expect(hosted.ops!.engine.get("invoices", "any"))
+        .rejects.toMatchObject({ code: "blocked" });
+    });
+  });
+}

--- a/packages/store/tests/app-access.parity.test.ts
+++ b/packages/store/tests/app-access.parity.test.ts
@@ -1,0 +1,155 @@
+/**
+ * §9.2–§9.4 asserted on EVERY road `appAccess` can take, because the denial
+ * posture is the part that may not vary.
+ *
+ * `appAccess` resolves its engine family as
+ * `store.ops?.engine ?? engineOverAdapter(store)` (helpers/app-access.ts:63), so
+ * one permission check has three possible roads beneath it: a hosted store's own
+ * ops, the family over a store this package minted, and the family over a host's
+ * BYO adapter. That the three behave identically was, until this file, an
+ * INFERENCE from shared code — the door calls only get/list/put/delete, and
+ * `engineOverAdapter` degrades only the verbs it never calls (`claim`,
+ * `insertIfAbsent`, `compareAndSwap`). An inference is not an assertion, and the
+ * stake is the difference between `not-found` and `forbidden`: a masked app and a
+ * leaked one. Nobody may learn an app exists by changing which store is wired.
+ *
+ * So core's own `appAccessConformance` runs once per road. Reused rather than
+ * rewritten on purpose: it asserts the CODES rather than merely that something was
+ * refused (conformance/app-access.ts:139 — grant is owner-gated, a viewer
+ * `forbidden` and a stranger masked; :153 — list masked from a non-viewer; :165 —
+ * the grant → revoke round trip ending at no level), and it is the same table
+ * every other implementation of `AppAccess` is held to. A hand-copied deny table
+ * here would be a second spelling of one rule, free to drift from the first.
+ *
+ * Each road gets its OWN store. The suite mints app ids from a timestamp and a
+ * per-suite counter, so two suites constructed in the same millisecond hand the
+ * same id to two roads; sharing one database between them would let one road's
+ * rows answer another road's question.
+ */
+import type { AccessLevel, AppId, StoreOps } from "@vendoai/core";
+import { appAccessConformance, memoryStoreAdapter } from "@vendoai/core/conformance";
+import { afterAll, beforeAll, describe, it } from "vitest";
+import { appFixture } from "../src/fixtures.test-util.js";
+import { backends, type MadeBackend } from "../src/backends.test-util.js";
+import { appAccess } from "../src/helpers/app-access.js";
+import { appStore } from "../src/helpers/apps.js";
+import { createStoreOps } from "../src/ops.js";
+import type { VendoStore } from "../src/store.js";
+
+/** Not a handle `@vendoai/store` minted — the shape a hosted store presents.
+ *  `records()` throws, so the façade cannot serve this road by accident. */
+function opsOnlyStore(ops: StoreOps): VendoStore {
+  const unused = (what: string): never => {
+    throw new Error(`the app-access door must not reach ${what}`);
+  };
+  return {
+    ops,
+    records: () => unused("records()"),
+    blobs: () => unused("blobs()"),
+    async ensureSchema() {},
+    async close() {},
+    raw: () => unused("raw()"),
+  };
+}
+
+/** The org the conformance suite seeds its shared-app cases under. */
+const SEED_ORG = "conformance-org";
+
+/** A grant row put in place WITHOUT the owner gate — the suite's way of setting a
+ *  world up before asserting the gate itself through `access.grant`. */
+const grantRow = (appId: AppId, principal: string, level: AccessLevel) => ({
+  id: `ag_${appId}_${principal}`,
+  data: { appId, orgId: SEED_ORG, principal, level, createdBy: "seed" },
+});
+
+const ROADS = [
+  "hosted ops — store.ops.engine",
+  "local fallback — engineOverAdapter over a minted store",
+  "BYO fallback — engineOverAdapter over a generic adapter",
+] as const;
+
+/** The store under test, plus the SQL handle to seed it through when it has one.
+ *  A road with no handle seeds through its own generic record doors. */
+interface Road {
+  store: VendoStore;
+  sql?: MadeBackend;
+}
+
+for (const backend of backends()) {
+  describe(`${backend.name} build contract §9 — the same posture on every road`, () => {
+    let local: MadeBackend;
+    let hostedBacking: MadeBackend;
+    let hosted: VendoStore;
+    let byo: VendoStore;
+
+    beforeAll(async () => {
+      local = await backend.make();
+      await local.store.ensureSchema();
+      hostedBacking = await backend.make();
+      await hostedBacking.store.ensureSchema();
+      hosted = opsOnlyStore(createStoreOps(hostedBacking.store));
+      const adapter = memoryStoreAdapter();
+      await adapter.ensureSchema();
+      byo = adapter as unknown as VendoStore;
+    });
+    afterAll(async () => {
+      if (local) await local.cleanup();
+      if (hostedBacking) await hostedBacking.cleanup();
+    });
+
+    /** Resolved per call, never at collect time: the handles above exist only
+     *  once `beforeAll` has run. */
+    const roadFor = (name: typeof ROADS[number]): Road => {
+      switch (name) {
+        case "hosted ops — store.ops.engine":
+          return { store: hosted, sql: hostedBacking };
+        case "local fallback — engineOverAdapter over a minted store":
+          return { store: local.store, sql: local };
+        case "BYO fallback — engineOverAdapter over a generic adapter":
+          return { store: byo };
+      }
+    };
+
+    for (const name of ROADS) {
+      describe(name, () => {
+        const suite = appAccessConformance({
+          get access() { return appAccess(roadFor(name).store); },
+
+          /** Seeding rides each road's OWN doors — the façade survives for exactly
+           *  this kind of caller. */
+          async seedApp(appId, subject) {
+            const road = roadFor(name);
+            if (road.sql !== undefined) {
+              await appStore(road.sql.store).put({ kind: "user", subject }, appFixture(appId));
+              return;
+            }
+            await road.store.records("vendo_apps").put({
+              id: appId,
+              data: { subject, enabled: true, doc: appFixture(appId) },
+            });
+          },
+
+          /** On the SQL roads the routed door derives a grant's refs from its own
+           *  columns. A generic adapter cannot: it keeps only the refs it is
+           *  given, so this seeder passes the `app_id` the door lists by — the same
+           *  invariant `appAccess.grant` itself observes (app-access.ts:216). A
+           *  seeder that omitted it would write a grant nothing reads back, and the
+           *  road would then fail for the seeding's reason rather than the door's. */
+          async seedGrant(appId, principal, level) {
+            const road = roadFor(name);
+            const row = grantRow(appId, principal, level);
+            if (road.sql !== undefined) {
+              await road.sql.store.records("vendo_app_grants").put(row);
+              return;
+            }
+            await road.store.records("vendo_app_grants").put({
+              ...row,
+              refs: { app_id: appId, principal, level },
+            });
+          },
+        });
+        for (const conformanceCase of suite.cases) it(conformanceCase.name, conformanceCase.run);
+      });
+    }
+  });
+}


### PR DESCRIPTION
> **This changes APP-PERMISSION RESOLUTION.** `appAccess()` is the one function
> behind every share, every `can()` and every level check (build contract
> §9.2-§9.4). Every read and write it makes moved to a different door. Review it
> as permissions code.

Generic `records.*` is the door a HOST reaches its OWN rows through. `appAccess`
was reaching Vendo's own `vendo_apps` and `vendo_app_grants` through it, so
nothing in those calls said the drawers were Vendo's and nothing could refuse one
that reached outside them. Four sites now name their collection to
`ops.engine.*`: the app row every level resolves from (`rowSubject`), and the
grant list, the grant write and the revoke behind it.

Same collections, same verbs, same arguments, same order. `engine` reaches the
very same routed doors `records` did, so the `ON CONFLICT (app_id, principal)`
floor and the rest of the per-collection policy are untouched; the one statement
added in front is the allowlist.

## Mechanism, and why no `ops?` parameter

`store.ops?.engine ?? engineOverAdapter(store)` — `packages/store/src/helpers/app-access.ts:63`.

guard, mcp and knowledge took an `ops?: StoreOps` slot beside `store` because a
composition has to thread it in from outside. This helper does not: it lives
INSIDE `packages/store` and already receives the store, whose optional `ops` slot
at `packages/store/src/store.ts:17-22` IS the surface such a composition would
have threaded. A parameter here would duplicate a field the argument already
carries. So: the store's own ops when it has them — the hosted store does, and
that client is one hop shorter than its own `records` façade, which is built on
these very ops (`packages/vendo/src/hosted-store.ts:161-210`) — and otherwise the
family over the adapter's record doors, which is what a locally-minted store and
every host's BYO adapter get. Same shape as
`packages/automations/src/engine-context.ts:71`.

## Reserved/routed: capability, not access

`vendo_apps` and `vendo_app_grants` ARE allowlisted — `packages/core/src/engine-collections.ts:21,24`,
listed there as the reserved block mirroring `RESERVED_COLLECTIONS`
(`packages/store/src/routing.ts:53-63`) — so the gate admits them unchanged. What
"reserved/routed" costs is CAPABILITY, not access: the routed doors expose no
`claim`, and `atomic` only for `vendo_threads`, mirrored hosted-side at
`packages/vendo/src/hosted-store.ts:196-210`. `appAccess` uses only
get/list/put/delete, so it loses nothing.

`vendo_threads` is deliberately NOT touched here: its routed door
(`packages/store/src/routing.ts:403-481`) has cross-subject refusal, revision CAS
and transcript projection the generic engine path does not reproduce. The
`StoreAdapter.records(collection)` façade also survives on purpose — this moves
one caller off it, it is not a deletion.

## The 42→35 comment

`packages/store/src/index.ts:6` said "42-op". Counted from the `StoreOps`
interface at `packages/core/src/store.ts:132-207`: engine 7 + blobs 4 + appData 8
+ transcripts 6 + harness 3 + workspace 4 + lifecycle 2 + `status()` 1 = **35**.
Corroborated twice independently — core's own docstring at `store.ts:130` ("all 35
store operations across 8 families") and `packages/vendo/src/hosted-store.ts:278`
("The 35 named ops"). The comment now says 35.

## Test

`packages/store/tests/app-access.ops.test.ts` — new, on the HOSTED shape, which is
the shape every multi-party deployment actually runs: an ops-only store whose
`records()` THROWS, over `createStoreOps(store)` on a real PGlite database. No
mocked counterparty on either side: every grant is written through the door's own
write path and read back through the door's own read path AND straight out of
`vendo_app_grants`, so the row a caller resolves and the row on disk cannot
disagree.

- The DENY half — **`app-access.ops.test.ts:87`**, "denies a stranger and an
  editor, and leaves nothing after a revoke": a stranger gets `levelFor` null,
  `can` false, and `list`/`grant` refused `not-found` so existence stays masked
  (:95-100); an editor reaching past their level is refused `forbidden` on both
  re-share and revoke (:102-105); the refusals are then asserted to have written
  NOTHING, and after a real revoke the row is gone from both the door and the
  table (:107-113).
- Not vacuous: revert `app-access.ts` and two of the three tests fail with "the
  app-access door must not reach records()" — this suite cannot pass on the old
  road.
- `:114` pins the one thing the family adds, refusing a collection outside the
  allowlist with `blocked`.

## Parity: the denial posture on every road, asserted rather than inferred

`packages/store/tests/app-access.parity.test.ts` (new, no source change, no existing
test touched).

This door now has three roads under one permission check —
`store.ops?.engine ?? engineOverAdapter(store)` — and that they DENY identically
was only an inference from shared code: the door calls just get/list/put/delete,
and `engineOverAdapter` degrades only the verbs it never calls (`claim`,
`insertIfAbsent`, `compareAndSwap`). An inference is not an assertion, and the
stake is `not-found` versus `forbidden` — a masked app versus a leaked one. Nobody
may learn an app exists by changing which store is wired.

So core's own `appAccessConformance` runs once per road, **18 cases × 3 roads = 54,
all passing**:

| road | store under test |
| --- | --- |
| hosted ops | `opsOnlyStore(createStoreOps(...))` — carries `ops`, and `records()` THROWS |
| local fallback | a store this package minted — never sets `ops`, so `engineOverAdapter` |
| BYO fallback | `memoryStoreAdapter()` — neither `ops` nor a SQL handle |

Reused rather than hand-copied on purpose: `packages/core/src/conformance/app-access.ts`
asserts the CODES, not merely that something was refused — `:139` grant is
owner-gated with a viewer `forbidden` and a stranger masked, `:153` list masked
from a non-viewer, `:165` the grant → revoke round trip ending at no level — and it
is the same table every other `AppAccess` implementation is held to, so a private
deny table here would be free to drift from it.

Two details that make it honest: each road gets its OWN store, because the suite
mints ids from a timestamp plus a per-suite counter and two suites built in the
same millisecond would otherwise let one road's rows answer another road's
question; and the BYO seeder passes `refs: { app_id }` explicitly, because
`vendo_app_grants` falls to the generic branch of the reference adapter
(`packages/core/src/conformance/memory-store.ts:304`), which keeps only the refs it
is given, where the routed SQL door derives them from its columns.

## Gate

Run on a quiet box, foreground, all green:

| step | exit | result |
| --- | --- | --- |
| `pnpm build` | **0** | 21/21 tasks |
| `packages/store` suite | **0** | 53 files, **505 passed / 5 skipped**, run as CI's 3 shards |
| `pnpm typecheck` | **0** | 42/42 tasks |
| `pnpm lint` | **0** | 4/4 tasks; only output is 4 pre-existing `no-unused-vars` warnings in `demo-bank`, 0 errors, untouched here |
| the three app-access suites, re-run on the rebased base | **0** | **99 passed** (54 parity + 42 existing + 3 hosted-shape) |

`pnpm test:affected` was NOT used: `--affected` fans out to every dependent of
`store` — 11 packages including genbench, the e2e fixtures and `demo-bank` — which
is the full suite this repo reserves for CI, and it exceeded the local 600s call
budget twice. Narrowed to `packages/store`'s own suite instead, which is the
touched scope. **CI's `ci` check remains the gate of record.** No browser is
installed on this box, so the Playwright suites did not run here either; this diff
touches no UI.

An independent internal checker audited this change for permission semantics
(masked existence, the `ON CONFLICT (app_id, principal)` floor, gating, revoke,
hosted-vs-BYO equivalence) and cleared it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
