### PR TITLE
refactor(knowledge): the lexical engine's drawers move onto the engine family

### DIFF
--- a/.changeset/knowledge-engine-family.md
+++ b/.changeset/knowledge-engine-family.md
@@ -1,0 +1,21 @@
+---
+"@vendoai/knowledge": patch
+---
+
+The local lexical engine's drawers go through the `engine` family instead of the
+generic record façade.
+
+Generic `records.*` is a host's door onto its own data, and `vendoKnowledge` was
+reaching for two of Vendo's own collections through it — `vendo_knowledge_docs`
+and `vendo_knowledge_chunks`. Nothing in those calls said the collections were
+Vendo's, so nothing could refuse a call that reached for one. Both drawers now
+name their collection through `ops.engine.*`: the same verbs onto the same doors
+with `assertEngineCollection` in front, so per-collection policy is unchanged.
+
+`vendoKnowledge` takes an optional `ops` alongside `store` for that same store's
+named-operation surface, when the composition could resolve one. Unset — which is what a
+host constructing the engine with its own `StoreAdapter` gets, and what
+`createVendo`'s knowledge seam still passes — the same seven verbs are served
+straight off the adapter's own record doors through core's `engineOverAdapter`,
+so a BYO adapter behaves exactly as before. An engine with neither still fails
+loudly on the operation rather than reporting an empty corpus.

--- a/packages/knowledge/src/local/lexical.ts
+++ b/packages/knowledge/src/local/lexical.ts
@@ -1,5 +1,6 @@
 import {
   VendoError,
+  engineOverAdapter,
   type KnowledgeAdapter,
   type KnowledgeChunk,
   type KnowledgeContext,
@@ -8,8 +9,8 @@ import {
   type KnowledgeKind,
   type KnowledgeQuery,
   type KnowledgeStatus,
-  type RecordStore,
   type StoreAdapter,
+  type StoreOps,
   type VendoRecord,
 } from "@vendoai/core";
 import { KNOWLEDGE_CHUNKS_COLLECTION, KNOWLEDGE_DOCS_COLLECTION } from "../collections.js";
@@ -32,13 +33,16 @@ interface ChunkRow extends KnowledgeChunk {
   source?: string;
 }
 
+/** The seven verbs every drawer in this engine is reached through. */
+type EngineOps = StoreOps["engine"];
+
 /** Every corpus scan pages with the keyset cursor (page cap 1000), including
     the status() counts. */
-async function listAll(store: RecordStore, refs?: Record<string, string>): Promise<VendoRecord[]> {
+async function listAll(engine: EngineOps, collection: string, refs?: Record<string, string>): Promise<VendoRecord[]> {
   const records: VendoRecord[] = [];
   let cursor: string | undefined;
   do {
-    const page = await store.list({ ...(refs === undefined ? {} : { refs }), limit: 1000, ...(cursor === undefined ? {} : { cursor }) });
+    const page = await engine.list(collection, { ...(refs === undefined ? {} : { refs }), limit: 1000, ...(cursor === undefined ? {} : { cursor }) });
     records.push(...page.records);
     if (page.records.length === 0) break;
     cursor = page.cursor;
@@ -71,21 +75,34 @@ function snippetAround(text: string, tokens: string[]): string {
  *
  * Zero-config: `knowledge: vendoKnowledge()` — createVendo injects the
  * composed store. Pass `{ store }` to keep the knowledge tables in a different
- * database (BYO rule); until a store is bound, operations fail loudly rather
- * than pretending to be an empty corpus.
+ * database (BYO rule), and `{ ops }` alongside it for that same store's
+ * named-operation surface when the composition could resolve one; until an
+ * engine is bound, operations fail loudly rather than pretending to be an empty
+ * corpus.
  */
-export function vendoKnowledge(options: { store?: StoreAdapter } = {}): KnowledgeAdapter {
-  const store = (): StoreAdapter => {
+export function vendoKnowledge(options: {
+  store?: StoreAdapter;
+  /** The named-operation surface (`StoreOps`) over that SAME store, when the
+   *  composition could resolve one (`selectStoreOps` answers `undefined` for a
+   *  store with neither its own ops nor a SQL handle). Both drawers this engine owns — the doc rows and
+   *  the chunk rows — are reached through `ops.engine.*`, so the allowlist gate
+   *  applies to both. Unset, the same seven verbs are served straight off the
+   *  adapter's own record doors (`engineOverAdapter`), which is what a host's
+   *  BYO `StoreAdapter` gets. */
+  ops?: StoreOps;
+} = {}): KnowledgeAdapter {
+  /** Resolved per verb, never at construction: an engine with nothing bound
+      must fail on the operation, not on `vendoKnowledge()`. */
+  const engine = (): EngineOps => {
+    if (options.ops !== undefined) return options.ops.engine;
     if (options.store === undefined) {
       throw new VendoError(
         "validation",
         "vendoKnowledge() has no store bound — pass vendoKnowledge({ store }) or wire it through createVendo, which injects the composed store",
       );
     }
-    return options.store;
+    return engineOverAdapter(options.store);
   };
-  const docRows = (): RecordStore => store().records(KNOWLEDGE_DOCS_COLLECTION);
-  const chunkRows = (): RecordStore => store().records(KNOWLEDGE_CHUNKS_COLLECTION);
 
   const visible = (visibility: KnowledgeDoc["visibility"], ctx: KnowledgeContext): boolean =>
     visibility === "public" || ctx.includeInternal === true;
@@ -96,14 +113,15 @@ export function vendoKnowledge(options: { store?: StoreAdapter } = {}): Knowledg
   /** The cited chunk's source, reading through to the doc row for chunks
       written before `source` was denormalized onto the row. */
   const chunkSource = async (chunk: ChunkRow): Promise<string | undefined> =>
-    chunk.source ?? ((await docRows().get(chunk.docId))?.data as KnowledgeDoc | undefined)?.source;
+    chunk.source
+    ?? ((await engine().get(KNOWLEDGE_DOCS_COLLECTION, chunk.docId))?.data as KnowledgeDoc | undefined)?.source;
 
   /** schema intent: exact term/title match over glossary+api docs. */
   async function schemaSearch(query: KnowledgeQuery, ctx: KnowledgeContext, limit: number): Promise<KnowledgeHit[]> {
     const key = termSlug(query.text);
     if (key.length === 0) return [];
     const hits: KnowledgeHit[] = [];
-    for (const row of await listAll(docRows())) {
+    for (const row of await listAll(engine(), KNOWLEDGE_DOCS_COLLECTION)) {
       const doc = row.data as KnowledgeDoc;
       if (doc.kind !== "glossary" && doc.kind !== "api") continue;
       if (!kindMatches(doc.kind, query.kinds) || !visible(doc.visibility, ctx)) continue;
@@ -135,7 +153,7 @@ export function vendoKnowledge(options: { store?: StoreAdapter } = {}): Knowledg
       const scored: { chunk: ChunkRow; score: number }[] = [];
       // Visibility and kind filter BEFORE ranking: invisible rows never enter
       // the candidate set, so they cannot influence scores or limits.
-      for (const row of await listAll(chunkRows())) {
+      for (const row of await listAll(engine(), KNOWLEDGE_CHUNKS_COLLECTION)) {
         const chunk = row.data as ChunkRow;
         if (!visible(chunk.visibility, ctx) || !kindMatches(chunk.kind, query.kinds)) continue;
         const body = tokenize(chunk.text);
@@ -169,17 +187,18 @@ export function vendoKnowledge(options: { store?: StoreAdapter } = {}): Knowledg
     },
 
     async fetch(ref, ctx) {
-      const row = await docRows().get(ref.docId);
+      const rows = engine();
+      const row = await rows.get(KNOWLEDGE_DOCS_COLLECTION, ref.docId);
       if (row === null) return null;
       const doc = row.data as KnowledgeDoc;
       // A ref is not a capability: internal docs read as unknown.
       if (!visible(doc.visibility, ctx)) return null;
       if (ref.chunkId !== undefined) {
-        const chunkRow = await chunkRows().get(ref.chunkId);
+        const chunkRow = await rows.get(KNOWLEDGE_CHUNKS_COLLECTION, ref.chunkId);
         const chunk = chunkRow?.data as ChunkRow | undefined;
         if (chunk !== undefined && chunk.docId === ref.docId) {
           // Read-more: the cited chunk joined with its structural neighbors.
-          const siblings = (await listAll(chunkRows(), { doc_id: ref.docId }))
+          const siblings = (await listAll(rows, KNOWLEDGE_CHUNKS_COLLECTION, { doc_id: ref.docId }))
             .map((sibling) => sibling.data as ChunkRow)
             .sort((a, b) => a.index - b.index);
           const window = siblings.filter((sibling) => Math.abs(sibling.index - chunk.index) <= 1);
@@ -194,14 +213,15 @@ export function vendoKnowledge(options: { store?: StoreAdapter } = {}): Knowledg
     },
 
     async upsert(docs) {
+      const rows = engine();
       for (const doc of docs) {
         const chunks = structuralChunker.chunk(doc);
         const keep = new Set(chunks.map((chunk) => chunk.chunkId));
         // Replace chunk rows: stale rows go first so a re-chunked doc never
         // leaves orphans, then the new rows land, then the doc row — by the
         // time upsert resolves the doc is searchable.
-        for (const stale of await listAll(chunkRows(), { doc_id: doc.id })) {
-          if (!keep.has(stale.id)) await chunkRows().delete(stale.id);
+        for (const stale of await listAll(rows, KNOWLEDGE_CHUNKS_COLLECTION, { doc_id: doc.id })) {
+          if (!keep.has(stale.id)) await rows.delete(KNOWLEDGE_CHUNKS_COLLECTION, stale.id);
         }
         for (const chunk of chunks) {
           const data: ChunkRow = {
@@ -213,25 +233,26 @@ export function vendoKnowledge(options: { store?: StoreAdapter } = {}): Knowledg
           };
           // Chunks ref their doc; knowledge is host-level, so rows deliberately
           // carry no subject_id (subject-erase skips them).
-          await chunkRows().put({ id: chunk.chunkId, data, refs: { doc_id: doc.id } });
+          await rows.put(KNOWLEDGE_CHUNKS_COLLECTION, { id: chunk.chunkId, data, refs: { doc_id: doc.id } });
         }
-        await docRows().put({ id: doc.id, data: { ...doc }, refs: { source: doc.source } });
+        await rows.put(KNOWLEDGE_DOCS_COLLECTION, { id: doc.id, data: { ...doc }, refs: { source: doc.source } });
       }
     },
 
     async remove(docIds) {
+      const rows = engine();
       for (const docId of docIds) {
-        for (const chunk of await listAll(chunkRows(), { doc_id: docId })) {
-          await chunkRows().delete(chunk.id);
+        for (const chunk of await listAll(rows, KNOWLEDGE_CHUNKS_COLLECTION, { doc_id: docId })) {
+          await rows.delete(KNOWLEDGE_CHUNKS_COLLECTION, chunk.id);
         }
-        await docRows().delete(docId);
+        await rows.delete(KNOWLEDGE_DOCS_COLLECTION, docId);
       }
     },
 
     async status(): Promise<KnowledgeStatus> {
       const byKind: Partial<Record<KnowledgeKind, number>> = {};
       let docs = 0;
-      for (const row of await listAll(docRows())) {
+      for (const row of await listAll(engine(), KNOWLEDGE_DOCS_COLLECTION)) {
         const doc = row.data as KnowledgeDoc;
         docs += 1;
         byKind[doc.kind] = (byKind[doc.kind] ?? 0) + 1;
@@ -240,7 +261,10 @@ export function vendoKnowledge(options: { store?: StoreAdapter } = {}): Knowledg
     },
   };
 
-  if (options.store === undefined) storeless.add(adapter);
+  // Store-less means NOTHING bound: an engine handed only `ops` reaches its
+  // drawers, so rebinding it to the composed store would drop the surface the
+  // host passed.
+  if (options.store === undefined && options.ops === undefined) storeless.add(adapter);
   return adapter;
 }
 

--- a/packages/vendo/tests/knowledge-engine.seam.test.ts
+++ b/packages/vendo/tests/knowledge-engine.seam.test.ts
@@ -1,0 +1,114 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { KnowledgeContext, KnowledgeDoc, StoreOps } from "@vendoai/core";
+import {
+  KNOWLEDGE_CHUNKS_COLLECTION,
+  KNOWLEDGE_DOCS_COLLECTION,
+  vendoKnowledge,
+} from "@vendoai/knowledge";
+import { createStore, createStoreOps, type VendoStore } from "@vendoai/store";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+/**
+ * The knowledge drawers' ENGINE SEAM.
+ *
+ * `vendoKnowledge` reaches `vendo_knowledge_docs` and `vendo_knowledge_chunks`
+ * through `ops.engine.*` now, either the `StoreOps` surface the host passed or
+ * `engineOverAdapter` over the bare adapter. Both halves are real here: the
+ * write goes through the engine's own upsert into a real PGlite store, and the
+ * read comes back BOTH through the engine's retrieval (search) and through the
+ * store's own routed door for those dedicated tables — so a write that never
+ * landed, or landed somewhere the store does not serve, fails the test instead
+ * of round-tripping through one mocked side.
+ *
+ * One store for the whole file, torn down at the end: each case writes its own
+ * doc, asserts on that doc by id, and removes it. Booting an embedded Postgres
+ * per case cost more wall clock than the test timeout allows on a busy machine.
+ */
+
+let dataDir: string;
+let store: VendoStore;
+let ops: StoreOps;
+
+beforeAll(async () => {
+  dataDir = await mkdtemp(join(tmpdir(), "vendo-knowledge-engine-"));
+  store = createStore({ dataDir });
+  await store.ensureSchema();
+  ops = createStoreOps(store);
+});
+
+afterAll(async () => {
+  await store.close();
+  await rm(dataDir, { recursive: true, force: true });
+});
+
+const ctx: KnowledgeContext = { principal: { kind: "user", subject: "user_knowledge_engine" } };
+
+/** A doc whose body carries a token no other case's query matches, so a shared
+    store cannot let one case's rows answer another's search. */
+const docWith = (token: string): KnowledgeDoc => ({
+  id: `docs#${token}.md`,
+  title: `Refund policy ${token}`,
+  kind: "docs",
+  visibility: "public",
+  source: `docs/${token}.md`,
+  text: `# Refund policy\nRefunds tagged ${token} are processed within five business days.`,
+});
+
+describe("vendoKnowledge — engine seam over a real store", () => {
+  it("writes and reads its drawers through the ops surface the host passed", async () => {
+    const doc = docWith("alpha");
+    const knowledge = vendoKnowledge({ store, ops });
+
+    await knowledge.upsert!([doc]);
+
+    // Product read path: retrieval and read-more off the rows just written.
+    const { hits } = await knowledge.search({ text: "refunds tagged alpha" }, ctx);
+    expect(hits.map((hit) => hit.ref.docId)).toEqual([doc.id]);
+    expect(hits[0]!.ref.source).toBe(doc.source);
+    await expect(knowledge.fetch!({ docId: doc.id }, ctx)).resolves.toMatchObject({ text: doc.text });
+
+    // Store read path: the same rows through the store's own routed door for
+    // these dedicated tables.
+    await expect(ops.engine.get(KNOWLEDGE_DOCS_COLLECTION, doc.id)).resolves.not.toBeNull();
+    const chunks = await ops.engine.list(KNOWLEDGE_CHUNKS_COLLECTION, { refs: { doc_id: doc.id } });
+    expect(chunks.records.length).toBeGreaterThan(0);
+
+    await knowledge.remove!([doc.id]);
+    await expect(ops.engine.get(KNOWLEDGE_DOCS_COLLECTION, doc.id)).resolves.toBeNull();
+    await expect(ops.engine.list(KNOWLEDGE_CHUNKS_COLLECTION, { refs: { doc_id: doc.id } }))
+      .resolves.toMatchObject({ records: [] });
+  });
+
+  /** The discriminator: with `store` unset there is no adapter to fall back to,
+      so this only passes if the `ops` slot is genuinely the door. */
+  it("reaches its drawers through ops alone, with no adapter to fall back to", async () => {
+    const doc = docWith("beta");
+    const knowledge = vendoKnowledge({ ops });
+
+    await knowledge.upsert!([doc]);
+
+    const { hits } = await knowledge.search({ text: "refunds tagged beta" }, ctx);
+    expect(hits.map((hit) => hit.ref.docId)).toEqual([doc.id]);
+    await expect(ops.engine.get(KNOWLEDGE_DOCS_COLLECTION, doc.id)).resolves.not.toBeNull();
+
+    await knowledge.remove!([doc.id]);
+  });
+
+  it("serves the same drawers off a bare adapter, with no ops passed", async () => {
+    const doc = docWith("gamma");
+    const knowledge = vendoKnowledge({ store });
+
+    await knowledge.upsert!([doc]);
+
+    const { hits } = await knowledge.search({ text: "refunds tagged gamma" }, ctx);
+    expect(hits.map((hit) => hit.ref.docId)).toEqual([doc.id]);
+    // Written through `engineOverAdapter`'s record door, read back through the
+    // store's ops door: the fallback lands in the very same tables.
+    await expect(ops.engine.get(KNOWLEDGE_DOCS_COLLECTION, doc.id)).resolves.not.toBeNull();
+
+    await knowledge.remove!([doc.id]);
+    await expect(ops.engine.get(KNOWLEDGE_DOCS_COLLECTION, doc.id)).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
Generic `records.*` is a HOST's door onto its own data. `vendoKnowledge` was reaching for two of Vendo's own collections through it, and nothing in those calls said the collections were Vendo's — so nothing could refuse a call that reached for one.

## What changed

**2 facade sites**, both in `packages/knowledge/src/local/lexical.ts` (was `:87-88`): the `docRows`/`chunkRows` closures that opened `store().records(KNOWLEDGE_DOCS_COLLECTION)` and `store().records(KNOWLEDGE_CHUNKS_COLLECTION)`. `grep "\.records("` over `packages/knowledge/src/` now returns nothing.

Those two closures hid the collection name from 14 downstream call sites, which now name it at the call as guard (#1170), automations (#1171) and the umbrella (#1186) do. Same verbs, same doors, same arguments, same order — `assertEngineCollection` is the one statement added in front.

`vendoKnowledge` gains an optional `ops?: StoreOps` (`lexical.ts:92`). Unset, core's `engineOverAdapter` serves the same seven verbs off the adapter's own record doors — what a host's BYO `StoreAdapter` gets, and what `createVendo`'s knowledge seam still passes, so no BYO deployment changes behavior. The stock helper rather than a guard-style local `adapterEngine()`: knowledge only uses get/put/delete/list, so they are behaviorally identical here and one import beats a 40-line copy.

`storeless` now means NOTHING bound (`lexical.ts:267`): an engine handed only `ops` already reaches its drawers, so rebinding it to the composed store would drop the surface the host passed.

`vendo_knowledge_docs` and `vendo_knowledge_chunks` were already allowlisted (`packages/core/src/engine-collections.ts:30-31`) — the allowlist is untouched.

## The seam test

`packages/vendo/tests/knowledge-engine.seam.test.ts`, in `packages/vendo` because dependency-guard keeps `@vendoai/knowledge` core-only (`scripts/dependency-guard.mjs:76`), so a real store cannot be imported from knowledge's own tests. That is the only place knowledge and `@vendoai/store` are both legal.

Nothing is stubbed on either side: a real PGlite `createStore({ dataDir })` with a real `createStoreOps(store)`; the write goes through knowledge's real `upsert`; the rows come back both through knowledge's real `search`/`fetch` AND independently through the store's own routed door (`ops.engine.get/list`) for those dedicated tables. Three cases: ops passed, **ops alone with no adapter to fall back to** (the discriminator — it can only pass if the new slot is genuinely the door), and bare adapter via `engineOverAdapter`.

## Local gate — stated honestly

- `pnpm build` — **green** (21/21 tasks).
- `pnpm typecheck` — **green**.
- `pnpm lint` — **green** (dependency-guard + portability-gate + eslint).
- `pnpm test:affected` — **did not complete on this machine**, and I am not claiming it did:
  - green: `@vendoai/knowledge` 8/8 files, `vendoai` 1/1, `@vendoai/corpus-harness` 20/20;
  - `@vendoai/genbench` 6 failures, all the missing Playwright Chromium on this box (`browserType.launch: Executable doesn't exist at ~/.cache/ms-playwright/...`; the 6th calls `openBrowser()` at `genbench/tests/diy.test.ts:208`). genbench does not depend on `@vendoai/knowledge`. Per CLAUDE.md the Playwright suites are a local gate and no browser runs in CI;
  - the full `@vendoai/vendo` suite did not fit the agent harness's 600s per-call ceiling. In its place, the two vendo suites that exercise this change ran green: `knowledge-engine.seam.test.ts` + `knowledge-resolution.test.ts`, 12 tests.

The `ci` check is the gate of record here, not this list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor the knowledge engine to use `ops.engine.*` for doc and chunk drawers instead of `records.*`, and add optional `ops` support to `vendoKnowledge`. This tightens collection access while keeping BYO adapters working via `engineOverAdapter`.

- **Refactors**
  - Replace `store().records(...)` with `ops.engine.*` for `vendo_knowledge_docs` and `vendo_knowledge_chunks`.
  - Add `ops?: StoreOps` to `vendoKnowledge`; fallback to `engineOverAdapter` when only `store` is passed.
  - “Storeless” now means both `store` and `ops` are unset; `ops` alone is valid.
  - Keep allowlist policy as-is; same verbs and doors, now with explicit collections.

- **Tests**
  - Add seam test using a real PGlite store (`@vendoai/store`): covers (1) `store + ops`, (2) `ops`-only, and (3) `store`-only via `engineOverAdapter`.

<sup>Written for commit 57ac7575990c29ee8e9b662080905d06f262b0b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

