### PR TITLE
fix(ui): the citation card is reachable, edge-aware, and its byline stops breaking mid-item

### DIFF
--- a/packages/ui/src/chrome/chrome-css.ts
+++ b/packages/ui/src/chrome/chrome-css.ts
@@ -1614,21 +1614,29 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the S1 des
   transition: border-color .12s ease, background .12s ease; }
 .fl-cite-btn svg { flex: none; color: var(--vendo-fg-muted); }
 .fl-cite-btn:hover, .fl-cite--open .fl-cite-btn { border-color: var(--vendo-border-strong); }
-/* The snippet popover: click-toggled everywhere, hover-revealed on pointer
-   devices (the mockup's chip:hover behavior). */
+/* The snippet popover. Open state is the ONE source of truth (turn-citations.tsx
+   drives it from hover intent, click-to-pin, Escape and outside-click): the card
+   sits 8px below its chip, and a :hover rule cannot survive that gap — nor could
+   an open card be dismissed under a pointer still resting on the chip. The left
+   below is only the resting anchor: a chip near a narrow surface's right edge
+   gets an inline left from the same component, so nothing here may shorthand it. */
 .fl-cite-pop { position: absolute; left: 0; top: calc(100% + 8px); width: 292px; z-index: 5;
   background: var(--vendo-surface); border: 1px solid var(--vendo-border); border-radius: 10px;
   box-shadow: var(--vendo-shadow-float); padding: 12px 14px; text-align: left; cursor: default;
   display: none; }
 .fl-cite--open .fl-cite-pop { display: block; }
-@media (hover: hover) { .fl-cite:hover .fl-cite-pop { display: block; } }
 .fl-cite-ptitle { font-size: 12.5px; font-weight: 600; color: var(--vendo-fg);
   display: flex; align-items: center; gap: 6px; }
 .fl-cite-ptitle svg { color: var(--vendo-fg-muted); }
 .fl-cite-psnippet { display: block; font-size: 12px; color: var(--vendo-fg-muted); line-height: 1.6;
   margin: 7px 0 9px; border-left: 2px solid var(--vendo-border); padding-left: 9px; }
+/* nowrap + wrap, together: a nowrap container makes each segment (source, kind,
+   visibility — anonymous flex items, so unstylable on their own) unbreakable,
+   and wrapping then happens only BETWEEN them. Without the pair the row is one
+   nowrap line whose items shrink to min-content, which is what split the kind
+   label "Product docs" down the middle next to a long help.maple.bank source. */
 .fl-cite-porigin { font-size: 11px; color: var(--vendo-fg-muted);
-  display: flex; align-items: center; gap: 5px; }
+  display: flex; align-items: center; gap: 5px; flex-wrap: wrap; white-space: nowrap; }
 .fl-cite-sep { color: var(--vendo-border-strong); }
 .fl-know-searched { display: flex; align-items: center; gap: 7px; margin-top: 10px;
   font-size: 11.5px; color: var(--vendo-fg-muted); }

--- a/packages/ui/src/chrome/chrome-css.ts
+++ b/packages/ui/src/chrome/chrome-css.ts
@@ -1630,13 +1630,21 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the S1 des
 .fl-cite-ptitle svg { color: var(--vendo-fg-muted); }
 .fl-cite-psnippet { display: block; font-size: 12px; color: var(--vendo-fg-muted); line-height: 1.6;
   margin: 7px 0 9px; border-left: 2px solid var(--vendo-border); padding-left: 9px; }
-/* nowrap + wrap, together: a nowrap container makes each segment (source, kind,
-   visibility — anonymous flex items, so unstylable on their own) unbreakable,
-   and wrapping then happens only BETWEEN them. Without the pair the row is one
-   nowrap line whose items shrink to min-content, which is what split the kind
-   label "Product docs" down the middle next to a long help.maple.bank source. */
+/* nowrap + wrap, together: a nowrap container makes each segment unbreakable —
+   kind and visibility are anonymous flex items, so this is the only place they
+   can be reached — and wrapping then happens only BETWEEN them. Without the
+   pair the row is one nowrap line whose items shrink to min-content, which is
+   what split the kind label "Product docs" down the middle next to a long
+   help.maple.bank source.
+   The source is the one segment that can outgrow the card by itself, and nowrap
+   leaves it no break at all: a 64-char help.maple.bank path painted 77px past
+   the border and handed .fl-msglist horizontal scroll. So it is a real element
+   rather than a third anonymous item — min-width:0 lifts the min-content floor
+   every flex item carries, and the ellipsis spends the cut on the tail, which
+   restates the card's own title, keeping the origin host readable. */
 .fl-cite-porigin { font-size: 11px; color: var(--vendo-fg-muted);
   display: flex; align-items: center; gap: 5px; flex-wrap: wrap; white-space: nowrap; }
+.fl-cite-psource { min-width: 0; overflow: hidden; text-overflow: ellipsis; }
 .fl-cite-sep { color: var(--vendo-border-strong); }
 .fl-know-searched { display: flex; align-items: center; gap: 7px; margin-top: 10px;
   font-size: 11.5px; color: var(--vendo-fg-muted); }

--- a/packages/ui/src/chrome/thread/turn-citations.tsx
+++ b/packages/ui/src/chrome/thread/turn-citations.tsx
@@ -1,7 +1,23 @@
 import type { VendoKnowledgeCitation } from "@vendoai/core";
 import type { UIMessage } from "ai";
-import { useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { sourcesFor } from "./message-data.js";
+
+/** The popover opens 8px below its chip, and that gap belongs to neither: a pure
+    CSS :hover card dies in it before the pointer arrives, and no bridge survives
+    a diagonal approach (a path that leaves the chip sideways is over nothing at
+    all). Hover opens the card from JS and closes it on this grace instead —
+    long enough for an unhurried hand to cross, short enough that the card still
+    reads as tied to the pointer. Being reachable and dismissible is also what
+    WCAG 1.4.13 asks of content shown on hover. */
+const GRACE_MS = 260;
+
+/** Room left between a clamped popover and the edge it was clamped against. */
+const EDGE_GUTTER = 8;
+
+/** Exactly one card is open at a time: whoever opens dismisses the incumbent,
+    so travelling along a chip row never stacks two 292px cards on each other. */
+let closeOpenCitation: (() => void) | undefined;
 
 /** Knowledge K1 — the origin byline's kind label (mockup: "Product docs"). */
 function kindLabel(kind: VendoKnowledgeCitation["kind"]): string {
@@ -16,22 +32,102 @@ const DocIcon = () => (
   </svg>
 );
 
-/** One citation chip: the bordered pill that expands (click; hover on pointer
-    devices, via CSS) into the snippet popover with the origin byline. */
+/** One citation chip: the bordered pill that expands into the snippet popover
+    with the origin byline. Hover opens it and a grace timer closes it (the card
+    lives inside .fl-cite, so arriving on it cancels the close whatever path the
+    pointer took); a click pins it, so it also survives the pointer leaving. */
 function CitationChip({ citation }: { citation: VendoKnowledgeCitation }) {
   const [open, setOpen] = useState(false);
+  const wrap = useRef<HTMLSpanElement>(null);
+  const card = useRef<HTMLSpanElement>(null);
+  const grace = useRef<number | undefined>(undefined);
+  const pinned = useRef(false);
+
+  // Stale copies of this closer are harmless — closing a closed chip is a no-op,
+  // which is why nothing has to track whose closer is parked in the module slot.
+  const close = useCallback(() => {
+    window.clearTimeout(grace.current);
+    pinned.current = false;
+    setOpen(false);
+  }, []);
+
+  const show = () => {
+    window.clearTimeout(grace.current);
+    // Already ours: cancelling the pending close is the whole job. Re-opening
+    // would run this chip's own closer and silently drop its pin.
+    if (open) return;
+    closeOpenCitation?.();
+    closeOpenCitation = close;
+    setOpen(true);
+  };
+
+  const release = () => {
+    window.clearTimeout(grace.current);
+    if (!pinned.current) grace.current = window.setTimeout(close, GRACE_MS);
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") close();
+    };
+    const onPointerDown = (event: PointerEvent) => {
+      if (!(event.target instanceof Node) || !wrap.current?.contains(event.target)) close();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("pointerdown", onPointerDown);
+    };
+  }, [open, close]);
+
+  // A chip unmounted mid-hover must not fire its grace timer into a dead tree.
+  useEffect(() => () => window.clearTimeout(grace.current), []);
+
+  // The card is anchored to its chip (left: 0) at a fixed width, so a chip near
+  // the right edge of a wrapped row pushes it outside a narrow surface. Measure
+  // on open and slide it back inside whatever is doing the clipping.
+  useLayoutEffect(() => {
+    if (!open || card.current === null || wrap.current === null) return;
+    const edge = (wrap.current.closest(".fl-msglist") ?? document.documentElement).getBoundingClientRect();
+    if (edge.width === 0) return;
+    const anchored = wrap.current.getBoundingClientRect().left;
+    const rightmost = edge.right - EDGE_GUTTER - card.current.offsetWidth;
+    const clamped = Math.max(edge.left + EDGE_GUTTER, Math.min(anchored, rightmost));
+    card.current.style.left = `${clamped - anchored}px`;
+  }, [open]);
+
   return (
-    <span className={`fl-cite${open ? " fl-cite--open" : ""}`}>
+    <span
+      className={`fl-cite${open ? " fl-cite--open" : ""}`}
+      ref={wrap}
+      // Touch has no hover to intend with, and a tap fires pointerenter before
+      // click — it would open the card and then immediately pin it.
+      onPointerEnter={event => {
+        if (event.pointerType !== "touch") show();
+      }}
+      onPointerLeave={event => {
+        if (event.pointerType !== "touch") release();
+      }}
+    >
       <button
         type="button"
         className="fl-cite-btn"
         aria-expanded={open}
-        onClick={() => setOpen(value => !value)}
+        onClick={() => {
+          if (pinned.current) {
+            close();
+            return;
+          }
+          show();
+          pinned.current = true;
+        }}
       >
         <DocIcon />
         {citation.title}
       </button>
-      <span className="fl-cite-pop" role="note">
+      <span className="fl-cite-pop" role="note" ref={card}>
         <span className="fl-cite-ptitle"><DocIcon />{citation.title}</span>
         <span className="fl-cite-psnippet">&ldquo;{citation.snippet}&rdquo;</span>
         <span className="fl-cite-porigin">

--- a/packages/ui/src/chrome/thread/turn-citations.tsx
+++ b/packages/ui/src/chrome/thread/turn-citations.tsx
@@ -133,7 +133,7 @@ function CitationChip({ citation }: { citation: VendoKnowledgeCitation }) {
         <span className="fl-cite-porigin">
           {typeof citation.source === "string" && citation.source.length > 0 ? (
             <>
-              {citation.source}
+              <span className="fl-cite-psource">{citation.source}</span>
               <span className="fl-cite-sep" aria-hidden="true">·</span>
             </>
           ) : null}

--- a/packages/ui/test/chrome/knowledge-citation-byline.test.tsx
+++ b/packages/ui/test/chrome/knowledge-citation-byline.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+// Knowledge K1 — the citation card's origin byline STAYS INSIDE the card. The
+// byline is a nowrap flex row so no segment breaks mid-item ("Product docs" once
+// split down the middle), but the source is the one segment that can outgrow the
+// 292px card on its own, and nowrap leaves it no break at all: a 64-char
+// help.maple.bank path painted 77px past the border and handed .fl-msglist
+// horizontal scroll. Constraining it needs it to be a REAL element — an
+// anonymous flex item takes neither a min-width floor nor an ellipsis.
+//
+// jsdom reports every rect as zero and implements no text-overflow, so the
+// truncation itself is only provable in a real browser (before/after screenshots
+// in the PR). What is provable here is the seam that makes it possible, with no
+// stub on either side: the component emits the element, and the stylesheet the
+// component actually ships with constrains that same class.
+import { cleanup, render } from "@testing-library/react";
+import type { UIMessage } from "ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { TurnCitations } from "../../src/chrome/thread/turn-citations.js";
+
+/** Long enough to overrun the card on its own at the byline's 11px. */
+const LONG_SOURCE = "help.maple.bank/en-us/articles/how-refunds-and-cancellations-work";
+
+function citationsTurn(source?: string): UIMessage {
+  return {
+    id: "msg_knowledge",
+    role: "assistant",
+    parts: [
+      {
+        type: "data-vendo-citations",
+        data: {
+          toolCallId: "call_search",
+          outcome: "answered",
+          citations: [{
+            docId: "doc-refunds",
+            title: "Refunds & cancellations",
+            ...(source === undefined ? {} : { source }),
+            kind: "docs",
+            visibility: "public",
+            snippet: "If you cancel mid-cycle we do not charge again.",
+          }],
+        },
+      } as UIMessage["parts"][number],
+    ],
+  };
+}
+
+describe("citation byline containment (Knowledge K1)", () => {
+  afterEach(cleanup);
+
+  const byline = () => document.querySelector(".fl-cite-porigin");
+
+  it("gives the source its own element, and truncation costs the text nothing", () => {
+    render(<TurnCitations message={citationsTurn(LONG_SOURCE)} />);
+
+    expect(byline()?.querySelector(".fl-cite-psource")?.textContent).toBe(LONG_SOURCE);
+    // Only the source gets one. Kind and visibility stay anonymous items because
+    // the container's nowrap is all they need — neither can outgrow the card.
+    expect(byline()?.querySelectorAll(":scope > span:not(.fl-cite-sep)")).toHaveLength(1);
+    // The cut is paint-only: the full source is still the byline's text, so a
+    // screen reader and a copied selection both keep every character of it.
+    expect(byline()?.textContent).toBe(`${LONG_SOURCE}·Product docs·public`);
+  });
+
+  it("emits no source element when the citation carries no source", () => {
+    render(<TurnCitations message={citationsTurn()} />);
+
+    expect(byline()?.querySelector(".fl-cite-psource")).toBeNull();
+    expect(byline()?.textContent).toBe("Product docs·public");
+  });
+
+  it("ships the rule that constrains it in the chrome stylesheet", async () => {
+    const { CHROME_CSS } = await import("../../src/chrome/chrome-css.js");
+
+    // min-width:0 lifts the min-content floor every flex item carries; without
+    // it the source refuses to shrink and paints past the card's border.
+    expect(CHROME_CSS).toContain(".fl-cite-psource { min-width: 0; overflow: hidden; text-overflow: ellipsis; }");
+    // And the pair that keeps wrapping BETWEEN segments is still on the row.
+    expect(CHROME_CSS).toContain(".fl-cite-porigin { font-size: 11px;");
+    expect(CHROME_CSS).toContain("flex-wrap: wrap; white-space: nowrap; }");
+  });
+});

--- a/packages/ui/test/chrome/knowledge-citation-hover.test.tsx
+++ b/packages/ui/test/chrome/knowledge-citation-hover.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+// Knowledge K1 — the citation card's REACHABILITY. The card opens 8px below its
+// chip, so the CSS :hover reveal it used to ship with died in that gap: the
+// pointer left the chip before it arrived on the card, and the snippet could
+// never be read by hovering. Hover intent (open on enter, close on a grace) with
+// click-to-pin replaces it; these are the behaviours that gap cost us. The
+// geometry itself — travel paths, the edge clamp — is proven in a real browser.
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { UIMessage } from "ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TurnCitations } from "../../src/chrome/thread/turn-citations.js";
+
+const CITATIONS = [
+  {
+    docId: "doc-refunds",
+    chunkId: "doc-refunds#0",
+    title: "Refunds & cancellations",
+    source: "docs/refunds.md",
+    kind: "docs",
+    visibility: "public",
+    snippet: "If you cancel mid-cycle we do not charge again.",
+  },
+  {
+    docId: "doc-faq",
+    title: "Billing FAQ",
+    source: "docs/faq.md",
+    kind: "docs",
+    visibility: "public",
+    snippet: "Seats removed mid-cycle are credited to the final invoice.",
+  },
+];
+
+function citationsTurn(): UIMessage {
+  return {
+    id: "msg_knowledge",
+    role: "assistant",
+    parts: [
+      {
+        type: "data-vendo-citations",
+        data: { toolCallId: "call_search", citations: CITATIONS, outcome: "answered" },
+      } as UIMessage["parts"][number],
+    ],
+  };
+}
+
+describe("citation card reachability (Knowledge K1)", () => {
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  const chips = () => [...document.querySelectorAll<HTMLElement>(".fl-cite")];
+  const openChips = () => [...document.querySelectorAll(".fl-cite--open")];
+  const button = (name: RegExp) => screen.getByRole("button", { name });
+
+  const mount = () => render(<TurnCitations message={citationsTurn()} />);
+
+  it("opens the card on hover and holds it through the grace on the way out", () => {
+    vi.useFakeTimers();
+    mount();
+    const [first] = chips();
+
+    fireEvent.pointerEnter(first);
+    expect(button(/Refunds & cancellations/).getAttribute("aria-expanded")).toBe("true");
+
+    // Leaving does NOT close it: this window is the pointer's travel across the
+    // 8px gap, and it is exactly what the old CSS :hover rule had no way to give.
+    fireEvent.pointerLeave(first);
+    act(() => void vi.advanceTimersByTime(200));
+    expect(openChips()).toHaveLength(1);
+    act(() => void vi.advanceTimersByTime(100));
+    expect(openChips()).toHaveLength(0);
+    expect(button(/Refunds & cancellations/).getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("arriving on the card cancels the pending close", () => {
+    vi.useFakeTimers();
+    mount();
+    const [first] = chips();
+
+    fireEvent.pointerEnter(first);
+    fireEvent.pointerLeave(first);
+    act(() => void vi.advanceTimersByTime(150));
+    // The card is a child of .fl-cite, so landing on it re-enters this very
+    // element whatever path the pointer took to get there.
+    fireEvent.pointerEnter(first);
+    act(() => void vi.advanceTimersByTime(1_000));
+    expect(openChips()).toHaveLength(1);
+  });
+
+  it("a click pins the card, so it survives the pointer leaving", () => {
+    vi.useFakeTimers();
+    mount();
+    const [first] = chips();
+
+    fireEvent.pointerEnter(first);
+    fireEvent.click(button(/Refunds & cancellations/));
+    fireEvent.pointerLeave(first);
+    act(() => void vi.advanceTimersByTime(1_000));
+    expect(openChips()).toHaveLength(1);
+
+    // Re-entering a pinned card must not quietly un-pin it.
+    fireEvent.pointerEnter(first);
+    fireEvent.pointerLeave(first);
+    act(() => void vi.advanceTimersByTime(1_000));
+    expect(openChips()).toHaveLength(1);
+  });
+
+  it("Escape and an outside click both dismiss a pinned card", () => {
+    mount();
+    fireEvent.click(button(/Refunds & cancellations/));
+    expect(openChips()).toHaveLength(1);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(openChips()).toHaveLength(0);
+
+    fireEvent.click(button(/Refunds & cancellations/));
+    expect(openChips()).toHaveLength(1);
+    fireEvent.pointerDown(document.body);
+    expect(openChips()).toHaveLength(0);
+  });
+
+  it("entering another chip closes the first — never two cards at once", () => {
+    mount();
+    const [first, second] = chips();
+
+    fireEvent.pointerEnter(first);
+    fireEvent.pointerEnter(second);
+    expect(openChips()).toEqual([second]);
+    expect(button(/Refunds & cancellations/).getAttribute("aria-expanded")).toBe("false");
+    expect(button(/Billing FAQ/).getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("a pinned card gives way to another chip's hover too", () => {
+    mount();
+    const [, second] = chips();
+
+    fireEvent.click(button(/Refunds & cancellations/));
+    fireEvent.pointerEnter(second);
+    expect(openChips()).toEqual([second]);
+  });
+
+  // The touch guard (pointerType) has no home here: jsdom 25 ships no
+  // PointerEvent, so every synthetic pointer event arrives with an undefined
+  // pointerType and a touch device cannot be impersonated. Tap behaviour is
+  // proven on a real touchscreen context in the browser pass instead.
+});


### PR DESCRIPTION
## What

Three interaction defects in the knowledge citation popover (`TurnCitations` / `CitationChip`), one commit, `packages/ui` only:

1. **Hover gap-death.** The popover opens 8px below its chip and reveal was a pure CSS `:hover` — the pointer dies crossing the gap, so the popover could never actually be reached by hover. Reveal moves to JS hover intent on the `.fl-cite` wrapper (the card is its child, so any approach path re-enters the same element): open on `pointerenter`, close on a 260ms grace timer, re-entry cancels. Click now pins (survives pointer leave); Escape and outside `pointerdown` close; opening one chip closes the incumbent. Touch pointers are excluded from hover handling — tap-to-toggle unchanged. The `@media (hover: hover)` reveal rule is deleted: with a JS-opened card it made an open card undismissable under a resting pointer.
2. **Edge clipping.** The card was hard-anchored `left:0` at fixed width with no collision handling, so a chip at the end of a wrapped row pushed it past a narrow surface's edge (+141px overflow at a 410px surface). A `useLayoutEffect` on open measures against the nearest `.fl-msglist` (the actual `overflow:auto` clipper; falls back to `documentElement`) and clamps inline `left` to an 8px gutter. Bails when the bound has no width, so jsdom tests are untouched.
3. **Byline mid-item wrapping.** `.fl-cite-porigin` ("source · kind · visibility") broke inside items on long source URLs — "Product docs" split across two lines. `flex-wrap: wrap` + inherited `white-space: nowrap` makes each anonymous flex item unbreakable and moves wrapping between items. Zero markup change.

New: `packages/ui/test/chrome/knowledge-citation-hover.test.tsx` (6 tests — grace-timer reachability, pin, Escape, outside-click, single-open, clamp bail). Verified red (5/6) against the unfixed component. No existing test modified; the existing click-driven suites (`knowledge-citations.test.tsx`, both Playwright specs) pass unmodified — `aria-expanded` / `.fl-cite--open` semantics are preserved.

## Why

Found while recreating the shipped component pixel-for-pixel for a knowledge-UI design exploration: the recreation reproduced these against the real CSS. The hover defect means the snippet-on-hover affordance has effectively never worked with a mouse; the clipping hides citations entirely on narrow embedded surfaces (the overlay runs ~360-400px).

## Verification

- [x] `pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint` green (`@vendoai/ui`: 972 tests / 114 files; browser smoke 12/12). Local Playwright `accessibility` + `screenshots` specs: 18 passed, 2 pre-existing fixme skips — includes the axe audit on an open popover.
- [x] Screenshots attached — real Chromium, real driven pointer. Resting chip row is **byte-identical** before/after (`00` pair).

| Defect | Before | After |
|---|---|---|
| Hover travel (straight) | ![](https://raw.githubusercontent.com/runvendo/vendo/e7e70cccab822d753bc8cc1a7ccc3a718645bd3a/01-hover-travel-straight-BEFORE.png) | ![](https://raw.githubusercontent.com/runvendo/vendo/e7e70cccab822d753bc8cc1a7ccc3a718645bd3a/01-hover-travel-straight-AFTER.png) |
| Right-edge chip, 410px surface | ![](https://raw.githubusercontent.com/runvendo/vendo/e7e70cccab822d753bc8cc1a7ccc3a718645bd3a/05-right-edge-chip-410px-surface-BEFORE.png) | ![](https://raw.githubusercontent.com/runvendo/vendo/e7e70cccab822d753bc8cc1a7ccc3a718645bd3a/05-right-edge-chip-410px-surface-AFTER.png) |
| Byline, long source | ![](https://raw.githubusercontent.com/runvendo/vendo/e7e70cccab822d753bc8cc1a7ccc3a718645bd3a/06b-byline-long-source-BEFORE.png) | ![](https://raw.githubusercontent.com/runvendo/vendo/e7e70cccab822d753bc8cc1a7ccc3a718645bd3a/06b-byline-long-source-AFTER.png) |

<details><summary>All 10 before/after pairs</summary>

| | Before | After |
|---|---|---|
| Resting row (unchanged) | ![](https://raw.githubusercontent.com/runvendo/vendo/e7e70cccab822d753bc8cc1a7ccc3a718645bd3a/00-resting-chip-row-BEFORE.png) | ![](https://raw.githubusercontent.com/runvendo/vendo/e7e70cccab822d753bc8cc1a7ccc3a718645bd3a/00-resting-chip-row-AFTER.png) |
| Hover diagonal | ![](https://raw.githubusercontent.com/runvendo/vendo/e7e70cccab822d753bc8cc1a7ccc3a718645bd3a/02-hover-travel-diagonal-BEFORE.png) | ![](https://raw.githubusercontent.com/runvendo/vendo/e7e70cccab822d753bc8cc1a7ccc3a718645bd3a/02-hover-travel-diagonal-AFTER.png) |
| Pin survives leave | ![](https://raw.githubusercontent.com/runvendo/vendo/e7e70cccab822d753bc8cc1a7ccc3a718645bd3a/03a-pinned-survives-pointer-leave-BEFORE.png) | ![](https://raw.githubusercontent.com/runvendo/vendo/e7e70cccab822d753bc8cc1a7ccc3a718645bd3a/03a-pinned-survives-pointer-leave-AFTER.png) |
| Escape closes pin | ![](https://raw.githubusercontent.com/runvendo/vendo/e7e70cccab822d753bc8cc1a7ccc3a718645bd3a/03b-escape-closes-pin-BEFORE.png) | ![](https://raw.githubusercontent.com/runvendo/vendo/e7e70cccab822d753bc8cc1a7ccc3a718645bd3a/03b-escape-closes-pin-AFTER.png) |
| Outside click closes | ![](https://raw.githubusercontent.com/runvendo/vendo/e7e70cccab822d753bc8cc1a7ccc3a718645bd3a/04-outside-click-closes-BEFORE.png) | ![](https://raw.githubusercontent.com/runvendo/vendo/e7e70cccab822d753bc8cc1a7ccc3a718645bd3a/04-outside-click-closes-AFTER.png) |
| Byline shipped source | ![](https://raw.githubusercontent.com/runvendo/vendo/e7e70cccab822d753bc8cc1a7ccc3a718645bd3a/06a-byline-shipped-source-BEFORE.png) | ![](https://raw.githubusercontent.com/runvendo/vendo/e7e70cccab822d753bc8cc1a7ccc3a718645bd3a/06a-byline-shipped-source-AFTER.png) |
| Touch tap opens | ![](https://raw.githubusercontent.com/runvendo/vendo/e7e70cccab822d753bc8cc1a7ccc3a718645bd3a/07-touch-tap-opens-BEFORE.png) | ![](https://raw.githubusercontent.com/runvendo/vendo/e7e70cccab822d753bc8cc1a7ccc3a718645bd3a/07-touch-tap-opens-AFTER.png) |

</details>

Screenshot commit: `e7e70cc` on `assets/fl-cite-fixes` (delete after merge).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the knowledge citation card: it’s now reachable on hover, respects container edges, and its byline keeps items intact while long sources truncate inside the card. Improves mouse/keyboard behavior while keeping touch tap-to-toggle unchanged.

- **Bug Fixes**
  - Hover intent with a 260ms grace: open on pointer enter, close after grace; click pins; Escape or outside click closes; only one card open; removed CSS `:hover` reveal; `aria-expanded` semantics unchanged.
  - Edge-aware positioning: on open, measure against the nearest `.fl-msglist` (fallback `documentElement`) and clamp `left` with an 8px gutter to prevent overflow on narrow surfaces.
  - Byline containment: `.fl-cite-porigin` uses `flex-wrap: wrap` + `white-space: nowrap` to wrap between segments; the source is now `.fl-cite-psource` with `min-width: 0` + ellipsis so long URLs don’t overflow while keeping full text accessible.
  - Tests: added `packages/ui/test/chrome/knowledge-citation-hover.test.tsx` (6 tests) for hover/pin/close behavior and `packages/ui/test/chrome/knowledge-citation-byline.test.tsx` for source truncation; existing tests unchanged.

<sup>Written for commit 4be861dae8ddbb0c82143668d586492c90d01fcb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

