### PR TITLE
fix(sandbox): an unusable snapshot ref says WHICH way it is wrong

### DIFF
--- a/packages/apps/src/server/escalation/e2b/index.ts
+++ b/packages/apps/src/server/escalation/e2b/index.ts
@@ -75,30 +75,93 @@ const decodePayload = (payload: string): Record<string, unknown> => {
   return value as Record<string, unknown>;
 };
 
-const decodeSnapshotRef = (snapshotRef: string): Omit<E2BSnapshotState, "version"> => {
-  try {
-    if (snapshotRef.startsWith(SNAPSHOT_REF_PREFIX) && snapshotRef.length > SNAPSHOT_REF_PREFIX.length) {
-      const state = decodePayload(snapshotRef.slice(SNAPSHOT_REF_PREFIX.length));
-      if (state.version !== 2 || typeof state.snapshotId !== "string" || state.snapshotId.length === 0) {
-        throw new Error("invalid snapshot id");
-      }
-      if (!validPort(state.port)) throw new Error("invalid port");
-      if (!validDomains(state.allowedDomains)) throw new Error("invalid allowedDomains policy");
-      if (state.sourceSandboxId !== undefined
-        && (typeof state.sourceSandboxId !== "string" || state.sourceSandboxId.length === 0)) {
-        throw new Error("invalid source sandbox id");
-      }
-      return {
-        snapshotId: state.snapshotId,
-        ...(state.sourceSandboxId === undefined ? {} : { sourceSandboxId: state.sourceSandboxId }),
-        ...(state.allowedDomains === undefined ? {} : { allowedDomains: [...state.allowedDomains] }),
-        port: state.port,
-      };
-    }
-    throw new Error("unknown prefix");
-  } catch {
-    throw new VendoError("validation", "E2B snapshot references must start with e2b:v2: and carry a valid payload");
+/** The scheme a ref announces itself with — what a provider mismatch is read
+    from. */
+const REF_SCHEME_PATTERN = /^([a-z0-9][a-z0-9+.-]*):/;
+
+/** The other providers' schemes, with the adapter that resumes one, so a
+    cross-provider ref can name the fix instead of the failure. */
+const FOREIGN_PROVIDERS: Record<string, { name: string; adapter: string }> = {
+  vendo: { name: "Vendo Cloud", adapter: "cloudSandbox()" },
+};
+
+/** The offending value's SHAPE, never its content — a ref's payload is the
+    caller's data, and a message is a log line. */
+const shapeOf = (value: unknown): string => {
+  if (value === undefined) return "nothing";
+  if (value === null) return "null";
+  if (typeof value === "string") {
+    return value.length === 0 ? '""' : `a string of ${value.length} characters`;
   }
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (Array.isArray(value)) return `an array of ${value.length} entries`;
+  return "an object";
+};
+
+const invalidField = (field: string, expected: string, value: unknown): VendoError =>
+  new VendoError(
+    "validation",
+    `E2B snapshot reference has an invalid "${field}": expected ${expected}, got ${shapeOf(value)}. Rebuild the app to mint a current reference.`,
+  );
+
+/** A ref this adapter did not mint: say WHICH of the three ways it is wrong —
+    another provider's ref, a raw provider snapshot id, or not a reference at
+    all. One relabelling catch made all three read as the same sentence, which
+    sent every one of them down the same wrong fix. */
+const notMintedHere = (snapshotRef: string): VendoError => {
+  const scheme = REF_SCHEME_PATTERN.exec(snapshotRef)?.[1];
+  if (scheme === undefined) {
+    return new VendoError(
+      "validation",
+      `This is not a sandbox snapshot reference: E2B snapshot references start with "${SNAPSHOT_REF_PREFIX}". Rebuild the app to mint a current reference.`,
+    );
+  }
+  if (scheme === "e2b") {
+    return new VendoError(
+      "validation",
+      `This is a raw E2B snapshot id, not a sandbox snapshot reference. Snapshot references start with "${SNAPSHOT_REF_PREFIX}" and carry the source sandbox id alongside the snapshot. Rebuild the app to mint a current reference.`,
+    );
+  }
+  const provider = FOREIGN_PROVIDERS[scheme];
+  return new VendoError(
+    "validation",
+    `This snapshot was minted by ${provider?.name ?? `"${scheme}"`}, but the resuming sandbox is E2B. A snapshot cannot move between providers — resume it with the same sandbox that made it${provider === undefined ? "" : ` (pass sandbox: ${provider.adapter})`}, or rebuild the app on E2B.`,
+  );
+};
+
+const decodeSnapshotRef = (snapshotRef: string): Omit<E2BSnapshotState, "version"> => {
+  if (!snapshotRef.startsWith(SNAPSHOT_REF_PREFIX)) throw notMintedHere(snapshotRef);
+  const payload = snapshotRef.slice(SNAPSHOT_REF_PREFIX.length);
+  let state: Record<string, unknown>;
+  try {
+    state = decodePayload(payload);
+  } catch {
+    // The payload NEVER goes in the message — its length is what says "cut off".
+    throw new VendoError(
+      "validation",
+      `E2B snapshot reference is truncated or corrupt: ${payload.length} characters after the "${SNAPSHOT_REF_PREFIX}" prefix, expected 100-400. The stored reference was cut off — rebuild the app.`,
+    );
+  }
+  if (state.version !== 2) throw invalidField("version", "2", state.version);
+  if (typeof state.snapshotId !== "string" || state.snapshotId.length === 0) {
+    throw invalidField("snapshotId", "a non-empty string", state.snapshotId);
+  }
+  if (!validPort(state.port)) {
+    throw invalidField("port", "an integer between 1 and 65535", state.port);
+  }
+  if (!validDomains(state.allowedDomains)) {
+    throw invalidField("allowedDomains", "an array of hostname strings", state.allowedDomains);
+  }
+  if (state.sourceSandboxId !== undefined
+    && (typeof state.sourceSandboxId !== "string" || state.sourceSandboxId.length === 0)) {
+    throw invalidField("sourceSandboxId", "a non-empty string", state.sourceSandboxId);
+  }
+  return {
+    snapshotId: state.snapshotId,
+    ...(state.sourceSandboxId === undefined ? {} : { sourceSandboxId: state.sourceSandboxId as string }),
+    ...(state.allowedDomains === undefined ? {} : { allowedDomains: [...state.allowedDomains] }),
+    port: state.port,
+  };
 };
 
 const environment = (name: string): string | undefined => {

--- a/packages/apps/src/server/escalation/e2b/index.ts
+++ b/packages/apps/src/server/escalation/e2b/index.ts
@@ -76,8 +76,11 @@ const decodePayload = (payload: string): Record<string, unknown> => {
 };
 
 /** The scheme a ref announces itself with — what a provider mismatch is read
-    from. */
-const REF_SCHEME_PATTERN = /^([a-z0-9][a-z0-9+.-]*):/;
+    from. BOUNDED on purpose: the scheme is the only part of a caller's ref that
+    reaches a message, so an unbounded capture turns a stored ref into an error
+    as long as the ref itself. Nothing this long is a URI scheme, and a ref that
+    leads with one is not a reference at all. */
+const REF_SCHEME_PATTERN = /^([a-z0-9][a-z0-9+.-]{0,31}):/;
 
 /** The other providers' schemes, with the adapter that resumes one, so a
     cross-provider ref can name the fix instead of the failure. */

--- a/packages/apps/tests/snapshot-ref-seam.test.ts
+++ b/packages/apps/tests/snapshot-ref-seam.test.ts
@@ -1,0 +1,164 @@
+/**
+ * The snapshot-ref seam: an adapter MINTS a ref, the app document STORES it,
+ * and an adapter DECODES it back on the next wake. Three parties, and the only
+ * thing that keeps them agreeing is the ref's shape — so this suite drives the
+ * real e2b adapter into the real row writer and back out through the real row
+ * reader, with no stub anywhere on that path. The e2b SDK is mocked because it
+ * is the PROVIDER (the machine at the far end), not the counterparty of this
+ * seam: the producer of a ref and its consumer are both the real adapter here.
+ *
+ * The Cloud half of the same seam is tested against the real Cloud adapter in
+ * `packages/vendo/tests/sandbox.test.ts` — `@vendoai/apps` cannot import it
+ * (the umbrella sits above this block).
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { VENDO_APP_FORMAT, engineOverAdapter } from "@vendoai/core";
+import { e2bSandbox } from "../src/server/escalation/e2b/index.js";
+import type { EngineOps } from "../src/server/persistence/engine.js";
+import { APPS_COLLECTION, appRecordInput, rowFromRecord, updateAppRow } from "../src/server/persistence/persistence.js";
+import { memoryStore } from "../src/server/testing/memory-store.js";
+import type { AppDocument } from "../src/contract/index.js";
+
+const APP = "app_seam";
+const SUBJECT = "user_1";
+const PROVISIONED_AT = "2026-08-11T00:00:00.000Z";
+
+const sdk = vi.hoisted(() => {
+  const sandbox = {
+    sandboxId: "sandbox_seam_123",
+    getHost: vi.fn((port: number) => `${port}-sandbox_seam_123.e2b.app`),
+    createSnapshot: vi.fn(async () => ({ snapshotId: "snapshot_seam_789" })),
+    pause: vi.fn(async () => true),
+    kill: vi.fn(async () => true),
+    setTimeout: vi.fn(async () => undefined),
+    isRunning: vi.fn(async () => true),
+    commands: { run: vi.fn(async () => ({ exitCode: 0, stdout: "", stderr: "" })) },
+    files: {
+      read: vi.fn(async () => new Uint8Array()),
+      write: vi.fn(async () => undefined),
+      list: vi.fn(async () => []),
+    },
+  };
+  return {
+    sandbox,
+    create: vi.fn(async () => sandbox),
+    staticKill: vi.fn(async () => true),
+    deleteSnapshot: vi.fn(async () => true),
+  };
+});
+
+class FakeNotFoundError extends Error {}
+
+vi.mock("e2b", () => ({
+  ALL_TRAFFIC: "0.0.0.0/0",
+  NotFoundError: FakeNotFoundError,
+  Sandbox: {
+    create: sdk.create,
+    kill: sdk.staticKill,
+    deleteSnapshot: sdk.deleteSnapshot,
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const seeded = (): AppDocument => ({
+  format: VENDO_APP_FORMAT,
+  id: APP,
+  name: "Seam",
+  tree: {
+    formatVersion: "vendo-genui/v2",
+    root: "root",
+    nodes: [{ id: "root", component: "Text", props: { text: "Seam" } }],
+  },
+} as AppDocument);
+
+/** An engine with the app row already written through the real writer. */
+const seededApps = async (): Promise<EngineOps> => {
+  const engine = engineOverAdapter(memoryStore());
+  await engine.put(APPS_COLLECTION, appRecordInput(seeded(), SUBJECT, false, "box"));
+  return engine;
+};
+
+/** A Cloud composite ref of the real shape (`sandbox-wire.ts`): what the
+ *  console-backed adapter writes into a document. */
+const cloudRef = (): string => `vendo:v2:${Buffer.from(JSON.stringify({
+  version: 2,
+  machineId: "m_00000000000000000000cloud",
+  ref: `vendo:snap_${"a".repeat(40)}`,
+  port: 8080,
+})).toString("base64url")}`;
+
+describe("the snapshot-ref seam: mint → row → wake", () => {
+  it("carries a ref the real adapter minted through the real row writer and back into a real resume", async () => {
+    const engine = await seededApps();
+    const adapter = e2bSandbox({ apiKey: "key_test" });
+    const machine = await adapter.create({ env: { PORT: "8080" }, allowedDomains: ["api.example.com"] });
+    const minted = await machine.snapshot();
+
+    // Producer side: the real row writer (admission → validation → store), the
+    // same path machine-lifecycle's sleep and provision flows take.
+    const written = await updateAppRow(
+      engine,
+      APP,
+      (document) => ({ ...document, machine: { snapshotRef: minted, provisionedAt: PROVISIONED_AT } }),
+      "box",
+    );
+    expect(written.machine?.snapshotRef).toBe(minted);
+
+    // Consumer side: the real row reader, then the real adapter decoding what
+    // came back out of the store — not the string the producer kept in hand.
+    const stored = rowFromRecord((await engine.get(APPS_COLLECTION, APP))!).doc.machine!.snapshotRef;
+    expect(stored).toBe(minted);
+    await adapter.resume(stored);
+    expect(sdk.create).toHaveBeenLastCalledWith("snapshot_seam_789", expect.objectContaining({
+      network: { allowOut: ["api.example.com"], denyOut: ["0.0.0.0/0"] },
+    }));
+  });
+
+  it("refuses another provider's ref out of a legacy row, naming both providers, before any provider call", async () => {
+    const engine = await seededApps();
+    // The legacy row: a Cloud-minted ref sitting in an app the host now resumes
+    // with the e2b adapter. Written before validation could tell the difference,
+    // so it is forced in with the row shape the reader expects.
+    const document = { ...seeded(), machine: { snapshotRef: cloudRef(), provisionedAt: PROVISIONED_AT } };
+    await engine.put(APPS_COLLECTION, { id: APP, data: { subject: SUBJECT, enabled: false, doc: document }, refs: { subject: SUBJECT } });
+
+    const stored = rowFromRecord((await engine.get(APPS_COLLECTION, APP))!).doc.machine!.snapshotRef;
+    const adapter = e2bSandbox({ apiKey: "key_test" });
+    const foreign = {
+      code: "validation",
+      message: "This snapshot was minted by Vendo Cloud, but the resuming sandbox is E2B. A snapshot cannot move between providers — resume it with the same sandbox that made it (pass sandbox: cloudSandbox()), or rebuild the app on E2B.",
+    };
+    await expect(adapter.resume(stored)).rejects.toMatchObject(foreign);
+    await expect(adapter.destroy(stored)).rejects.toMatchObject(foreign);
+    // Nothing reached the provider: a ref this adapter cannot read never
+    // becomes a machine, a kill, or a snapshot deletion.
+    expect(sdk.create).not.toHaveBeenCalled();
+    expect(sdk.staticKill).not.toHaveBeenCalled();
+    expect(sdk.deleteSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("tells a raw provider snapshot id apart from a truncated one", async () => {
+    const adapter = e2bSandbox({ apiKey: "key_test" });
+
+    await expect(adapter.resume("e2b:snap_0000000000000000000000000000000000000000")).rejects.toMatchObject({
+      code: "validation",
+      message: 'This is a raw E2B snapshot id, not a sandbox snapshot reference. Snapshot references start with "e2b:v2:" and carry the source sandbox id alongside the snapshot. Rebuild the app to mint a current reference.',
+    });
+
+    const cut = Buffer.from(JSON.stringify({
+      version: 2,
+      snapshotId: "snapshot_seam_789",
+      sourceSandboxId: "sandbox_seam_123",
+      port: 8080,
+    })).toString("base64url").slice(0, 40);
+    await expect(adapter.resume(`e2b:v2:${cut}`)).rejects.toMatchObject({
+      code: "validation",
+      // The LENGTH is the evidence; the payload itself never reaches the message.
+      message: `E2B snapshot reference is truncated or corrupt: ${cut.length} characters after the "e2b:v2:" prefix, expected 100-400. The stored reference was cut off — rebuild the app.`,
+    });
+    expect(sdk.create).not.toHaveBeenCalled();
+  });
+});

--- a/packages/apps/tests/snapshot-ref-seam.test.ts
+++ b/packages/apps/tests/snapshot-ref-seam.test.ts
@@ -159,6 +159,14 @@ describe("the snapshot-ref seam: mint → row → wake", () => {
       // The LENGTH is the evidence; the payload itself never reaches the message.
       message: `E2B snapshot reference is truncated or corrupt: ${cut.length} characters after the "e2b:v2:" prefix, expected 100-400. The stored reference was cut off — rebuild the app.`,
     });
+
+    // The scheme is the ONE piece of a caller's ref that reaches a message, so
+    // it is bounded: an unbounded capture made a 200k-character lead a
+    // 200k-character error and a 200k-character log line. It is not a scheme.
+    await expect(adapter.resume(`${"a".repeat(200_000)}:x`)).rejects.toMatchObject({
+      code: "validation",
+      message: 'This is not a sandbox snapshot reference: E2B snapshot references start with "e2b:v2:". Rebuild the app to mint a current reference.',
+    });
     expect(sdk.create).not.toHaveBeenCalled();
   });
 });

--- a/packages/vendo/src/sandbox.ts
+++ b/packages/vendo/src/sandbox.ts
@@ -89,8 +89,11 @@ const encodeSnapshotRef = (state: CloudSnapshotState): string =>
   `${CLOUD_SNAPSHOT_REF_PREFIX}${toBase64Url(JSON.stringify(state))}`;
 
 /** The scheme a ref announces itself with — what a provider mismatch is read
- * from. */
-const REF_SCHEME_PATTERN = /^([a-z0-9][a-z0-9+.-]*):/;
+ * from. BOUNDED on purpose: the scheme is the only part of a caller's ref that
+ * reaches a message, so an unbounded capture turns a stored ref into an error
+ * as long as the ref itself. Nothing this long is a URI scheme, and a ref that
+ * leads with one is not a reference at all. */
+const REF_SCHEME_PATTERN = /^([a-z0-9][a-z0-9+.-]{0,31}):/;
 
 /** The other providers' schemes, with the adapter that resumes one, so a
  * cross-provider ref can name the fix instead of the failure. */

--- a/packages/vendo/src/sandbox.ts
+++ b/packages/vendo/src/sandbox.ts
@@ -88,43 +88,108 @@ const toBase64Url = (value: string): string =>
 const encodeSnapshotRef = (state: CloudSnapshotState): string =>
   `${CLOUD_SNAPSHOT_REF_PREFIX}${toBase64Url(JSON.stringify(state))}`;
 
-const decodeSnapshotRef = (snapshotRef: string): CloudSnapshotState => {
-  try {
-    if (!snapshotRef.startsWith(CLOUD_SNAPSHOT_REF_PREFIX)
-      || snapshotRef.length <= CLOUD_SNAPSHOT_REF_PREFIX.length) {
-      throw new Error("unknown prefix");
-    }
-    const payload = snapshotRef.slice(CLOUD_SNAPSHOT_REF_PREFIX.length)
-      .replaceAll("-", "+").replaceAll("_", "/");
-    const state = JSON.parse(decoder.decode(
-      Uint8Array.from(atob(payload), (character) => character.charCodeAt(0)),
-    )) as Record<string, unknown>;
-    if (state.version !== 2
-      || typeof state.machineId !== "string" || state.machineId.length === 0
-      || typeof state.ref !== "string" || !state.ref.startsWith(CONSOLE_SNAPSHOT_REF_PREFIX)) {
-      throw new Error("invalid payload");
-    }
-    if (state.allowedDomains !== undefined && !(Array.isArray(state.allowedDomains)
-      && state.allowedDomains.every((host) => typeof host === "string"))) {
-      throw new Error("invalid allowedDomains policy");
-    }
-    if (state.port !== undefined && !(Number.isInteger(state.port)
-      && (state.port as number) > 0 && (state.port as number) <= 65_535)) {
-      throw new Error("invalid port");
-    }
-    return {
-      version: 2,
-      machineId: state.machineId,
-      ref: state.ref,
-      ...(state.allowedDomains === undefined ? {} : { allowedDomains: [...state.allowedDomains as string[]] }),
-      ...(state.port === undefined ? {} : { port: state.port as number }),
-    };
-  } catch {
-    throw new VendoError(
+/** The scheme a ref announces itself with — what a provider mismatch is read
+ * from. */
+const REF_SCHEME_PATTERN = /^([a-z0-9][a-z0-9+.-]*):/;
+
+/** The other providers' schemes, with the adapter that resumes one, so a
+ * cross-provider ref can name the fix instead of the failure. */
+const FOREIGN_PROVIDERS: Record<string, { name: string; adapter: string }> = {
+  e2b: { name: "e2b", adapter: "e2bSandbox()" },
+};
+
+/** The console-minted artifact id a composite carries (sandbox-wire.ts). A
+ * SHAPE check, not a prefix check: CONSOLE_SNAPSHOT_REF_PREFIX ("vendo:") is a
+ * strict prefix of the composite prefix ("vendo:v2:"), so a prefix test would
+ * accept a composite nested inside a composite. */
+const CONSOLE_ARTIFACT_PATTERN = /^vendo:snap_[0-9a-f]{40}$/;
+
+/** The offending value's SHAPE, never its content — a ref's payload is the
+ * caller's data, and a message is a log line. */
+const shapeOf = (value: unknown): string => {
+  if (value === undefined) return "nothing";
+  if (value === null) return "null";
+  if (typeof value === "string") {
+    return value.length === 0 ? '""' : `a string of ${value.length} characters`;
+  }
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (Array.isArray(value)) return `an array of ${value.length} entries`;
+  return "an object";
+};
+
+const invalidField = (field: string, expected: string, value: unknown): VendoError =>
+  new VendoError(
+    "validation",
+    `Vendo Cloud snapshot reference has an invalid "${field}": expected ${expected}, got ${shapeOf(value)}. Rebuild the app to mint a current reference.`,
+  );
+
+/** A ref this adapter did not mint: say WHICH of the three ways it is wrong —
+ * another provider's ref, a bare console artifact id, or not a reference at
+ * all. One relabelling catch made all three read as the same sentence, which
+ * sent every one of them down the same wrong fix. */
+const notMintedHere = (snapshotRef: string): VendoError => {
+  const scheme = REF_SCHEME_PATTERN.exec(snapshotRef)?.[1];
+  if (scheme === undefined) {
+    return new VendoError(
       "validation",
-      `Vendo Cloud snapshot references must start with "${CLOUD_SNAPSHOT_REF_PREFIX}" and carry a valid payload`,
+      `This is not a sandbox snapshot reference: Vendo Cloud snapshot references start with "${CLOUD_SNAPSHOT_REF_PREFIX}". Rebuild the app to mint a current reference.`,
     );
   }
+  if (scheme === "vendo") {
+    return new VendoError(
+      "validation",
+      `This is a raw Vendo Cloud artifact id, not a sandbox snapshot reference. Snapshot references start with "${CLOUD_SNAPSHOT_REF_PREFIX}" and carry the machine id alongside the artifact. Rebuild the app to mint a current reference.`,
+    );
+  }
+  const provider = FOREIGN_PROVIDERS[scheme];
+  return new VendoError(
+    "validation",
+    `This snapshot was minted by ${provider?.name ?? `"${scheme}"`}, but the resuming sandbox is Vendo Cloud. A snapshot cannot move between providers — resume it with the same sandbox that made it${provider === undefined ? "" : ` (pass sandbox: ${provider.adapter})`}, or rebuild the app on Cloud.`,
+  );
+};
+
+const decodeSnapshotRef = (snapshotRef: string): CloudSnapshotState => {
+  if (!snapshotRef.startsWith(CLOUD_SNAPSHOT_REF_PREFIX)) throw notMintedHere(snapshotRef);
+  const payload = snapshotRef.slice(CLOUD_SNAPSHOT_REF_PREFIX.length);
+  let state: Record<string, unknown>;
+  try {
+    const parsed = JSON.parse(decoder.decode(Uint8Array.from(
+      atob(payload.replaceAll("-", "+").replaceAll("_", "/")),
+      (character) => character.charCodeAt(0),
+    ))) as unknown;
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      throw new Error("not an object");
+    }
+    state = parsed as Record<string, unknown>;
+  } catch {
+    // The payload NEVER goes in the message — its length is what says "cut off".
+    throw new VendoError(
+      "validation",
+      `Vendo Cloud snapshot reference is truncated or corrupt: ${payload.length} characters after the "${CLOUD_SNAPSHOT_REF_PREFIX}" prefix, expected 120-400. The stored reference was cut off — rebuild the app.`,
+    );
+  }
+  if (state.version !== 2) throw invalidField("version", "2", state.version);
+  if (typeof state.machineId !== "string" || state.machineId.length === 0) {
+    throw invalidField("machineId", "a non-empty string", state.machineId);
+  }
+  if (typeof state.ref !== "string" || !CONSOLE_ARTIFACT_PATTERN.test(state.ref)) {
+    throw invalidField("ref", 'a Vendo Cloud artifact id ("vendo:snap_<40 hex>")', state.ref);
+  }
+  if (state.allowedDomains !== undefined && !(Array.isArray(state.allowedDomains)
+    && state.allowedDomains.every((host) => typeof host === "string"))) {
+    throw invalidField("allowedDomains", "an array of hostname strings", state.allowedDomains);
+  }
+  if (state.port !== undefined && !(Number.isInteger(state.port)
+    && (state.port as number) > 0 && (state.port as number) <= 65_535)) {
+    throw invalidField("port", "an integer between 1 and 65535", state.port);
+  }
+  return {
+    version: 2,
+    machineId: state.machineId,
+    ref: state.ref,
+    ...(state.allowedDomains === undefined ? {} : { allowedDomains: [...state.allowedDomains as string[]] }),
+    ...(state.port === undefined ? {} : { port: state.port as number }),
+  };
 };
 
 /** True exactly for the "that state is already gone" answer that the seam's

--- a/packages/vendo/tests/sandbox.test.ts
+++ b/packages/vendo/tests/sandbox.test.ts
@@ -477,20 +477,38 @@ describe("cloudSandbox", () => {
     expect(console_.requests.at(-1)!.json).toMatchObject({ egress: ["example.com"] });
   });
 
-  it("rejects snapshot refs it did not mint before anything rides the wire", async () => {
+  it("rejects snapshot refs it did not mint before anything rides the wire, saying WHICH way each is wrong", async () => {
     const console_ = fakeConsole();
     const adapter = adapterFor(console_);
-    for (const foreign of [
-      "bogus:not-a-real-ref",
-      "e2b:v2:abc",
-      "snap_nocolon",
-      `vendo:snap_${"a".repeat(40)}`, // a bare console ref is not a seam ref
-      "vendo:v2:", // bare prefix
-      "vendo:v2:!!!not-base64url!!!", // garbage payload
-      `vendo:v2:${btoa(JSON.stringify({ version: 2, machineId: "", ref: "vendo:snap_x" }))}`, // empty machine id
-    ]) {
-      await expect(adapter.resume(foreign)).rejects.toMatchObject({ code: "validation" });
-      await expect(adapter.destroy(foreign)).rejects.toMatchObject({ code: "validation" });
+    const composite = (state: unknown): string =>
+      `${CLOUD_SNAPSHOT_REF_PREFIX}${btoa(JSON.stringify(state))}`;
+    const garbage = "!!!not-base64url!!!";
+    // A composite carried as another composite's inner artifact ref: the
+    // console prefix ("vendo:") is a strict prefix of the composite prefix, so
+    // a startsWith check on the inner ref accepted this.
+    const inner = composite({ version: 2, machineId: "m_1", ref: `vendo:snap_${"a".repeat(40)}` });
+
+    // Seven distinct failures, seven distinct sentences. One blind catch used
+    // to relabel all of them as "must start with vendo:v2: and carry a valid
+    // payload", which named the wrong fix for six of the seven.
+    for (const [ref, message] of [
+      // Another provider's ref — the scheme says who minted it.
+      ["bogus:not-a-real-ref", 'This snapshot was minted by "bogus", but the resuming sandbox is Vendo Cloud. A snapshot cannot move between providers — resume it with the same sandbox that made it, or rebuild the app on Cloud.'],
+      ["e2b:v2:abc", "This snapshot was minted by e2b, but the resuming sandbox is Vendo Cloud. A snapshot cannot move between providers — resume it with the same sandbox that made it (pass sandbox: e2bSandbox()), or rebuild the app on Cloud."],
+      // No scheme at all: not a snapshot reference of any provider.
+      ["snap_nocolon", 'This is not a sandbox snapshot reference: Vendo Cloud snapshot references start with "vendo:v2:". Rebuild the app to mint a current reference.'],
+      // A bare console artifact id — the shape a raw console read hands back.
+      [`vendo:snap_${"a".repeat(40)}`, 'This is a raw Vendo Cloud artifact id, not a sandbox snapshot reference. Snapshot references start with "vendo:v2:" and carry the machine id alongside the artifact. Rebuild the app to mint a current reference.'],
+      // Right prefix, unusable payload: the LENGTH is the evidence, and the
+      // payload itself never reaches the message.
+      ["vendo:v2:", 'Vendo Cloud snapshot reference is truncated or corrupt: 0 characters after the "vendo:v2:" prefix, expected 120-400. The stored reference was cut off — rebuild the app.'],
+      [`vendo:v2:${garbage}`, `Vendo Cloud snapshot reference is truncated or corrupt: ${garbage.length} characters after the "vendo:v2:" prefix, expected 120-400. The stored reference was cut off — rebuild the app.`],
+      // A decodable payload with one bad field names the field.
+      [composite({ version: 2, machineId: "", ref: "vendo:snap_x" }), 'Vendo Cloud snapshot reference has an invalid "machineId": expected a non-empty string, got "". Rebuild the app to mint a current reference.'],
+      [composite({ version: 2, machineId: "m_1", ref: inner }), `Vendo Cloud snapshot reference has an invalid "ref": expected a Vendo Cloud artifact id ("vendo:snap_<40 hex>"), got a string of ${inner.length} characters. Rebuild the app to mint a current reference.`],
+    ] as const) {
+      await expect(adapter.resume(ref)).rejects.toMatchObject({ code: "validation", message });
+      await expect(adapter.destroy(ref)).rejects.toMatchObject({ code: "validation", message });
     }
     expect(console_.requests).toEqual([]);
   });

--- a/packages/vendo/tests/sandbox.test.ts
+++ b/packages/vendo/tests/sandbox.test.ts
@@ -510,6 +510,14 @@ describe("cloudSandbox", () => {
       await expect(adapter.resume(ref)).rejects.toMatchObject({ code: "validation", message });
       await expect(adapter.destroy(ref)).rejects.toMatchObject({ code: "validation", message });
     }
+
+    // The scheme is the ONE piece of a caller's ref that reaches a message, so
+    // it is bounded: an unbounded capture made a 200k-character lead a
+    // 200k-character error and a 200k-character log line. It is not a scheme.
+    await expect(adapter.resume(`${"a".repeat(200_000)}:x`)).rejects.toMatchObject({
+      code: "validation",
+      message: 'This is not a sandbox snapshot reference: Vendo Cloud snapshot references start with "vendo:v2:". Rebuild the app to mint a current reference.',
+    });
     expect(console_.requests).toEqual([]);
   });
 


### PR DESCRIPTION
## What

`decodeSnapshotRef` wrapped its whole body in one `try`, so seven distinct failure modes all reported the same sentence. A customer hit this with an e2b-minted snapshot ref that a Vendo Cloud sandbox tried to resume, and the error said nothing about which way it was wrong.

Classification now happens outside the catch — each failure throws its own `VendoError("validation", …)`. The e2b adapter's identical blind catch gets the mirrored treatment. Payloads are never printed; only length, field name, and the offending value's shape.

Also fixes a real bug found in passing: `CONSOLE_SNAPSHOT_REF_PREFIX` (`"vendo:"`) is a strict prefix of the composite prefix, so the old inner-ref check **accepted a nested composite ref and rode the wire with it**. Now checks the artifact's real shape.

## Proof

Prove-it-fails recorded: with the decoder split reverted, all eight cases collapse back to the single old sentence and the nested-composite case fails differently (`Vendo Cloud sandbox returned no machine handle`) — the bug, live. Restored, each case reports its own message.

Adds `packages/apps/tests/snapshot-ref-seam.test.ts`: a ref minted by the **real** e2b adapter, written through the **real** `updateAppRow`/admission into a real record store, read back through the **real** `rowFromRecord`, decoded by the **real** adapter. No stub anywhere on the mint → row → wake path. The Cloud-consumer half lives in `packages/vendo/tests/sandbox.test.ts` because `packages/apps` cannot resolve `@vendoai/vendo` (layering) — it asserts all seven messages plus zero HTTP requests reaching the console.

## Deliberately NOT included

The spec's write-time `SERVER_REFERENCE_PATTERN` tightening is **not** in this PR, pending a founder decision. Independently verified reasons:

- The validator gates **reads** as well as writes (`persistence.ts:39-48` → `rowFromRecord`, 10 non-test call sites), so tightening it stops affected rows from **loading at all** — the app cannot be opened, listed, reviewed, or edited. The spec's "any failing row was already unresumable" is wrong in kind.
- It allowlists two providers, banning every BYO sandbox ref format — against the hard BYO rule — including the shipped testing kit's `fake:`, `fakebox:`, `fake-v2:`.
- Measured: **71 test failures across 13 files**.
- It would not have caught this incident anyway. The bad row held a *valid* `e2b:v2:` ref; the validator is a pure function of the document and cannot know which adapter is configured, so cross-provider mismatch is undetectable at write time by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved snapshot ref decoding for E2B and Vendo Cloud. Invalid refs now say exactly what’s wrong, are rejected before any provider/console calls, and scheme reads are bounded to avoid oversized error/log messages.

- **Bug Fixes**
  - Replaced blanket catches with targeted checks: distinguish cross‑provider refs (names both providers and suggests `e2bSandbox()`/`cloudSandbox()`), bare artifact/raw IDs, truncated/corrupt payloads (report length only), and non‑scheme/overlong prefixes (treated as “not a ref”). Messages report value shape, never payload contents.
  - Field validation with specific messages (both adapters): `version`, `snapshotId`/`machineId`, `ref` (`vendo:snap_<40 hex>`; blocks composite‑in‑composite), `port` (1–65535), `allowedDomains`, and optional `sourceSandboxId`. Added seam tests (real E2B mint → store → resume) and Cloud tests that assert seven distinct error cases plus the bounded‑scheme path; invalid refs trigger zero provider/console requests.

<sup>Written for commit 576c51b256c669bb9159b877914c2eee633657b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

