### PR TITLE
fix(apps): the create door stops reporting complete when server work failed

### DIFF
--- a/packages/apps/src/server/doors/build-surface.ts
+++ b/packages/apps/src/server/doors/build-surface.ts
@@ -346,6 +346,22 @@ const createCreateDoor = (
       return structuredClone(app);
     }
     await reportLifecycle("create", app.id, ctx);
+    // A create used to swallow this whole lane: `edit` read `served.failed` and
+    // refused, `create` read nothing at all and the catch below only warned, so
+    // an app whose server side never got built painted its skeleton and reported
+    // itself complete — a live empty app declared successful (2026-08-11). The
+    // app still RESOLVES, because it is real and on screen; what it no longer
+    // does is claim the server work landed.
+    let serverWorkFailed: string[] | undefined;
+    const failServerWork = (reasons: string[]): void => {
+      serverWorkFailed = reasons;
+      input.onServerWork?.({ ok: false, reasons });
+      log({
+        code: "apps.server-work-failed",
+        level: "error",
+        message: `[vendo] server work failed for ${appId} (the screen stands, its server side does not): ${reasons.join("; ")}`,
+      });
+    };
     try {
       const served = await runServerWork({
         plan: planned,
@@ -354,21 +370,18 @@ const createCreateDoor = (
         request: input.prompt,
       }, ctx, generationDeps);
       app = served.document;
+      if (served.failed !== undefined) failServerWork(served.failed);
       for (const finding of served.findings) {
         console.info(findingLine(finding));
       }
     } catch (error) {
-      log({
-        code: "apps.server-work-skipped",
-        level: "warn",
-        message: `[vendo] server work skipped for ${appId} (the app stands without it): ${safeErrorMessage(error)}`,
-      });
+      failServerWork([safeErrorMessage(error)]);
     }
     await paintSettledTree(caller, app, ctx, input.onView, appId);
     log({
       code: "apps.gen-create-complete",
       level: "info",
-      message: `[vendo] gen create complete app=${appId} total=${((Date.now() - createStartedAt) / 1000).toFixed(1)}s`,
+      message: `[vendo] gen create complete${serverWorkFailed === undefined ? "" : " (server work failed)"} app=${appId} total=${((Date.now() - createStartedAt) / 1000).toFixed(1)}s`,
     });
     return structuredClone(app);
   };

--- a/packages/apps/src/server/doors/build-surface.ts
+++ b/packages/apps/src/server/doors/build-surface.ts
@@ -353,15 +353,6 @@ const createCreateDoor = (
     // app still RESOLVES, because it is real and on screen; what it no longer
     // does is claim the server work landed.
     let serverWorkFailed: string[] | undefined;
-    const failServerWork = (reasons: string[]): void => {
-      serverWorkFailed = reasons;
-      input.onServerWork?.({ ok: false, reasons });
-      log({
-        code: "apps.server-work-failed",
-        level: "error",
-        message: `[vendo] server work failed for ${appId} (the screen stands, its server side does not): ${reasons.join("; ")}`,
-      });
-    };
     try {
       const served = await runServerWork({
         plan: planned,
@@ -370,12 +361,32 @@ const createCreateDoor = (
         request: input.prompt,
       }, ctx, generationDeps);
       app = served.document;
-      if (served.failed !== undefined) failServerWork(served.failed);
+      if (served.failed !== undefined) serverWorkFailed = served.failed;
+      // A plan that asked to be SERVED and did not get its surface is the same
+      // half-built app: the box ran, but the flip was refused (`issues`), so the
+      // person is looking at a skeleton with nothing behind it. `edit` hands
+      // these back to its caller as `issues`; a create returns a document, so
+      // this callback is its only channel for them. `served` is compiler-gated
+      // to kind="box" (plan/compile.ts), so no automation issue arrives here.
+      else if (planned.server?.served === true && served.issues !== undefined) {
+        serverWorkFailed = served.issues;
+      }
       for (const finding of served.findings) {
         console.info(findingLine(finding));
       }
     } catch (error) {
-      failServerWork([safeErrorMessage(error)]);
+      serverWorkFailed = [safeErrorMessage(error)];
+    }
+    // Reported OUTSIDE the try on purpose: reporting from inside it let a
+    // throwing consumer re-enter this very catch as a second "server work
+    // failed", call the callback twice, and take `paintSettledTree` with it.
+    if (serverWorkFailed !== undefined) {
+      input.onServerWork?.({ ok: false, reasons: serverWorkFailed });
+      log({
+        code: "apps.server-work-failed",
+        level: "error",
+        message: `[vendo] server work failed for ${appId} (the screen stands, its server side does not): ${serverWorkFailed.join("; ")}`,
+      });
     }
     await paintSettledTree(caller, app, ctx, input.onView, appId);
     log({

--- a/packages/apps/src/server/doors/make-tool.ts
+++ b/packages/apps/src/server/doors/make-tool.ts
@@ -206,6 +206,7 @@ const makeNewApp = async (
     );
   }
   let unsaved: string | undefined;
+  let serverWork: string | undefined;
   const created = await runtime.create({
     appId,
     prompt: ask,
@@ -213,6 +214,12 @@ const makeNewApp = async (
     // No `slot`: the claim went down at the mint above, which is the
     // same instant `create` would have made it for an id of its own.
     onUnsaved: (reason) => { unsaved = reason; },
+    // The screen landed but the server work its plan required did not, so
+    // the person is looking at an app whose sections have nothing behind
+    // them. Said plainly here for the same reason `onUnsaved` is: the door
+    // reports the app as ready either way, and an unqualified "it's on your
+    // screen" is how an empty app gets declared successful.
+    onServerWork: ({ reasons }) => { serverWork = reasons.join("; "); },
     ...(stream === undefined ? {} : {
       onView: (part) => stream({ id: vendoViewStreamId(part.appId), part }),
     }),
@@ -230,9 +237,11 @@ const makeNewApp = async (
     id: created.id,
     title: created.name,
     status: "ready",
-    say: unsaved === undefined
-      ? `${created.name} is on your screen.`
-      : `${created.name} is on your screen, though I couldn't save it to your apps.`,
+    say: serverWork !== undefined
+      ? `I built the screen, but the server-side part didn't get built: ${serverWork}. The app works for viewing — ask me to try the build again.`
+      : unsaved === undefined
+        ? `${created.name} is on your screen.`
+        : `${created.name} is on your screen, though I couldn't save it to your apps.`,
   });
 };
 

--- a/packages/apps/src/server/runtime/types.ts
+++ b/packages/apps/src/server/runtime/types.ts
@@ -416,6 +416,14 @@ export interface AppsRuntime {
      *  the agent bridge turns it into an honest sentence instead of an
      *  apology for something the user can see. */
     onUnsaved?: (reason: string) => void;
+    /** Called when the screen was built and saved but the SERVER work its plan
+     *  required was not: the sections that waited on it have nothing to show.
+     *  The create still resolves with the document — the app is real and on
+     *  screen — so this is the only signal that its server side is missing, and
+     *  without it a half-built app reports a plain success (a live empty app was
+     *  declared complete this way). The agent bridge turns it into an honest
+     *  sentence, exactly as it does for {@link onUnsaved}. */
+    onServerWork?: (result: { ok: false; reasons: string[] }) => void;
   }, ctx: RunContext): Promise<AppDocument>;
   /**
    * Build contract §1.6 / redesign D4 — the files-first counterpart of

--- a/packages/apps/tests/create-server-work-failed.test.ts
+++ b/packages/apps/tests/create-server-work-failed.test.ts
@@ -64,6 +64,13 @@ const setup = (agent: FakeBoxAgent) => createApps({
 
 const brokenBox: FakeBoxAgent = () => ({ ok: false, summary: BOX_GAVE_UP, filesChanged: [], testsRun: 0 });
 
+/** The box builds fine and CLAIMS it serves the app's whole surface, but never
+ *  installs a root page — so the host's own `GET /` check fails, the 2→3 flip is
+ *  refused, and the person is left on the skeleton. `runServerWork` reports that
+ *  as `issues`, not `failed`, because the box's work itself did land. */
+const unservedBox: FakeBoxAgent = () =>
+  ({ ok: true, summary: "wrote the drag-and-drop server", filesChanged: ["/app/server.js"], testsRun: 1, servesUi: true });
+
 const workingBox: FakeBoxAgent = ({ box }) => {
   box.pages.set("/", "<!doctype html><title>Invoice kanban</title><h1>Kanban</h1>");
   box.manifest = {};
@@ -146,6 +153,63 @@ describe("a create whose server work could not be built", () => {
       );
       // Contract §3.1 — four fields of words, and no document among them.
       expect(Object.keys(output).sort()).toEqual(["id", "say", "status", "title"]);
+    } finally {
+      errorSpy.mockRestore();
+      infoSpy.mockRestore();
+    }
+  });
+
+  it("reports a served plan whose surface flip was refused — the other half of the same silence", async () => {
+    // `failed` is not the only way a served plan comes back half-built: the box
+    // can succeed and still fail the host's own `GET /` verification, which
+    // `runServerWork` returns as `issues`. `edit` hands those to its caller; a
+    // create returns a document, so without this they went nowhere and the app
+    // reported complete on a skeleton — the same bug, one branch over.
+    const runtime = setup(unservedBox);
+    const failures: Array<{ ok: false; reasons: string[] }> = [];
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const infos: string[] = [];
+    const infoSpy = vi.spyOn(console, "log").mockImplementation((line: unknown) => {
+      infos.push(String(line));
+    });
+    try {
+      const app = await runtime.create({
+        prompt: "Make me a full kanban board for my invoices with drag-and-drop between columns",
+        onServerWork: (result) => failures.push(result),
+      }, ctx);
+
+      // The tree was never replaced, because the flip was refused.
+      expect(app.ui).toBe("tree");
+      expect(failures).toHaveLength(1);
+      expect(failures[0]?.reasons.join(" ")).toContain("did not produce a verified served web app");
+      const completion = infos.filter((line) => line.includes("gen create complete"));
+      expect(completion[0]).toContain("gen create complete (server work failed)");
+    } finally {
+      errorSpy.mockRestore();
+      infoSpy.mockRestore();
+    }
+  });
+
+  it("reports the failure exactly once, even when the consumer's own callback throws", async () => {
+    // The report used to run INSIDE the try that wraps the server lane, so a
+    // throwing consumer re-entered that catch as a second "server work failed":
+    // the callback fired twice and the second throw escaped. The host's
+    // exception is still the host's — it propagates, once — but it is never
+    // relabelled as another server-work failure.
+    const runtime = setup(brokenBox);
+    const seen: Array<{ ok: false; reasons: string[] }> = [];
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const infoSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    try {
+      await expect(runtime.create({
+        prompt: "Make me a full kanban board for my invoices with drag-and-drop between columns",
+        onServerWork: (result) => {
+          seen.push(result);
+          throw new Error("the host's own listener blew up");
+        },
+      }, ctx)).rejects.toThrow("the host's own listener blew up");
+      expect(seen).toHaveLength(1);
+      expect(seen[0]?.reasons.join(" ")).toContain(BOX_GAVE_UP);
     } finally {
       errorSpy.mockRestore();
       infoSpy.mockRestore();

--- a/packages/apps/tests/create-server-work-failed.test.ts
+++ b/packages/apps/tests/create-server-work-failed.test.ts
@@ -1,0 +1,176 @@
+import { type RunContext, type ToolRegistry } from "@vendoai/core";
+import { type ScreenAssembler } from "../src/contract/index.js";
+import { describe, expect, it, vi } from "vitest";
+import { createAgentTools } from "../src/server/doors/agent-tools.js";
+import { createApps } from "../src/server/index.js";
+import { fakeBoxSandbox, type FakeBoxAgent } from "../src/server/testing/fake-box.js";
+import { guardFixture } from "../src/server/testing/guard-fixture.js";
+import { memoryStore } from "../src/server/testing/memory-store.js";
+import { basicLanguageModel } from "../src/server/testing/scripted-model.js";
+
+/**
+ * The create door used to swallow the whole server lane. `edit` read
+ * `served.failed` and refused the edit; `create` read nothing at all and its
+ * catch only `console.warn`ed, so a build whose server side never landed
+ * painted its skeleton and logged "gen create complete" — an empty app declared
+ * successful on a live deployment (2026-08-11).
+ *
+ * The contract now, mirroring `onUnsaved`: the create STILL resolves with the
+ * document (the screen is real and on the person's page), and the failure gets
+ * an honest signal — `onServerWork`, an error-level `log()`, and a completion
+ * line that says the server work failed.
+ *
+ * The spies below follow the default log sink, not the level name: `log()` at
+ * `info` writes through `console.log` and at `error` through `console.error`
+ * (core's `METHODS` table), so this reads exactly the console an operator sees.
+ */
+
+const ctx: RunContext = {
+  principal: { kind: "user", subject: "user_ada" },
+  venue: "chat",
+  presence: "present",
+  sessionId: "session_ada",
+};
+
+const tools: ToolRegistry = {
+  async descriptors() { return []; },
+  async execute() { return { status: "error", error: { code: "not-found", message: "no tools" } }; },
+};
+
+/** A plan that REQUIRES a served surface — the one shape whose server work the
+ *  app cannot stand without, which is what `runServerWork` reports as `failed`. */
+const SERVED_PLAN = `<Plan name="Invoice board">
+  <Group tab="Board"><Leaf component="Text" purpose="the board"/></Group>
+  <Server kind="box" served why="Dragging cards between columns is an interaction no component can express."/>
+</Plan>`;
+
+const escalating: ScreenAssembler = {
+  assemble: async () => ({ kind: "escalate", why: "this needs real code, not an arrangement of components" }),
+};
+
+const BOX_GAVE_UP = "could not build the drag-and-drop server";
+
+const setup = (agent: FakeBoxAgent) => createApps({
+  store: memoryStore(),
+  guard: guardFixture(),
+  tools,
+  catalog: [],
+  model: basicLanguageModel(),
+  screen: escalating,
+  escalatedPlan: async () => SERVED_PLAN,
+  machine: { sandbox: fakeBoxSandbox({ agent }), buildEnv: () => ({ PORT: "8080" }), boxEditPollMs: 5 },
+  servedProxyPath: (appId) => `/api/vendo/apps/${appId}/serve/`,
+});
+
+const brokenBox: FakeBoxAgent = () => ({ ok: false, summary: BOX_GAVE_UP, filesChanged: [], testsRun: 0 });
+
+const workingBox: FakeBoxAgent = ({ box }) => {
+  box.pages.set("/", "<!doctype html><title>Invoice kanban</title><h1>Kanban</h1>");
+  box.manifest = {};
+  return { ok: true, summary: "serving the kanban web app", filesChanged: ["/app/server.js"], testsRun: 2, servesUi: true };
+};
+
+describe("a create whose server work could not be built", () => {
+  it("tells the caller, logs it, and does not report complete — while still resolving with the app", async () => {
+    const runtime = setup(brokenBox);
+    const failures: Array<{ ok: false; reasons: string[] }> = [];
+    const errors: string[] = [];
+    const infos: string[] = [];
+    const errorSpy = vi.spyOn(console, "error").mockImplementation((line: unknown) => {
+      errors.push(String(line));
+    });
+    const infoSpy = vi.spyOn(console, "log").mockImplementation((line: unknown) => {
+      infos.push(String(line));
+    });
+    try {
+      const app = await runtime.create({
+        prompt: "Make me a full kanban board for my invoices with drag-and-drop between columns",
+        onServerWork: (result) => failures.push(result),
+      }, ctx);
+
+      // The app is real and on screen, so the turn still hands it back.
+      expect(app.id).toMatch(/^app_/);
+
+      // The signal the door was missing, exactly once, carrying the box's own
+      // words rather than a generic apology.
+      expect(failures).toHaveLength(1);
+      expect(failures[0]?.ok).toBe(false);
+      expect(failures[0]?.reasons.join(" ")).toContain(BOX_GAVE_UP);
+
+      // Server-side it is an error, not a shrug.
+      expect(errors.some((line) => line.includes("server work failed") && line.includes(app.id))).toBe(true);
+
+      // And the completion line no longer claims a clean build. This is the
+      // assertion the original bug failed: it logged "gen create complete".
+      const completion = infos.filter((line) => line.includes("gen create complete"));
+      expect(completion).toHaveLength(1);
+      expect(completion[0]).toContain("gen create complete (server work failed)");
+    } finally {
+      errorSpy.mockRestore();
+      infoSpy.mockRestore();
+    }
+  });
+
+  it("reads to the person as an honest half-success through the agent bridge, not a plain 'it's on your screen'", async () => {
+    // The SEAM: the real front door (`vendo_make`) over the real create door,
+    // with nothing stubbed between them. This is what the person actually
+    // hears, and an unqualified "on your screen" here is the whole bug —
+    // the app is empty and the turn calls it done.
+    const runtime = setup(brokenBox);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const infoSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    try {
+      const agentTools = createAgentTools(runtime, {
+        data: {} as never,
+        requireOwned: async () => { throw new Error("unused"); },
+        claimSlot: async () => { throw new Error("unused"); },
+        markUnbuilt: async () => { throw new Error("unused"); },
+        screen: escalating,
+        escalatedPlan: async () => SERVED_PLAN,
+      });
+
+      const outcome = await agentTools.execute({
+        id: "call_1",
+        tool: "vendo_make",
+        args: { request: "Make me a full kanban board for my invoices with drag-and-drop between columns" },
+      }, ctx);
+
+      expect(outcome.status).toBe("ok");
+      const output = (outcome as { output: Record<string, unknown> }).output;
+      expect(output.say).toBe(
+        "I built the screen, but the server-side part didn't get built: "
+        + "the in-box agent could not build the server work: could not build the drag-and-drop server"
+        + " — the machine was discarded, the rest of the app stands, and the sections that waited on it"
+        + " have nothing to show."
+        + ". The app works for viewing — ask me to try the build again.",
+      );
+      // Contract §3.1 — four fields of words, and no document among them.
+      expect(Object.keys(output).sort()).toEqual(["id", "say", "status", "title"]);
+    } finally {
+      errorSpy.mockRestore();
+      infoSpy.mockRestore();
+    }
+  });
+
+  it("stays silent when the box builds what the plan asked for (the signal is failure-only)", async () => {
+    const runtime = setup(workingBox);
+    const failures: Array<{ ok: false; reasons: string[] }> = [];
+    const infos: string[] = [];
+    const infoSpy = vi.spyOn(console, "log").mockImplementation((line: unknown) => {
+      infos.push(String(line));
+    });
+    try {
+      const app = await runtime.create({
+        prompt: "Make me a full kanban board for my invoices with drag-and-drop between columns",
+        onServerWork: (result) => failures.push(result),
+      }, ctx);
+
+      expect(failures).toEqual([]);
+      const completion = infos.filter((line) => line.includes("gen create complete"));
+      expect(completion).toHaveLength(1);
+      expect(completion[0]).toContain(`gen create complete app=${app.id}`);
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## What

`runServerWork` returns `failed?: string[]`. The edit door checked it; the **create** door never did — it `console.warn`ed and continued on to paint the app and report completion. An app whose server side silently failed was reported to the user as done.

The app still resolves with its document (it is real and on screen), but the failure now gets an honest signal: a new `onServerWork` callback on the create input (mirroring the existing `onUnsaved` precedent), `console.error`, no completion report, and a user-facing sentence through the agent bridge.

## Proof

Prove-it-fails recorded against the final code. With the fix reverted, the test captures the original bug verbatim:

```
× reads to the person as an honest half-success through the agent bridge
  → expected 'Invoice board is on your screen.' to be 'I built the screen, but the server-si…'
```

`"Invoice board is on your screen."` — an app with no server side, reported as plainly done. Restored → 3 passed.

The bridge test is a real seam: real `createAgentTools` → real `vendo_make` → real `create` → real box sandbox whose in-box agent returns `ok:false`. Nothing stubbed between producer and consumer; it asserts the box's own words survive the whole trip.

Full `@vendoai/apps` suite: **1540 passed, 0 failed**.

## Note

The approved sentence appends `". The app works…"` to a reason that already ends in a period, so it renders a doubled `..`. Left as approved rather than silently altering founder-approved wording — one-line trim if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop the create door from reporting completion when server work fails. Adds `onServerWork`, treats refused surface flips as failures, logs an error, updates the agent message, and marks completion as "(server work failed)" while still returning the screen.

- **Bug Fixes**
  - `create` now checks `served.failed` and served-plan `issues`; fires `onServerWork`, logs `apps.server-work-failed` via `console.error`, and marks "gen create complete (server work failed)".
  - Reporting moved outside the try/catch to prevent double-calls when a consumer callback throws.
  - Agent bridge in `make-tool` says "I built the screen, but the server-side part didn't get built: … The app works for viewing — ask me to try the build again." on failure, and stays silent on success. Tests cover server-work failure, refused flips, single-report behavior, and the success path.

<sup>Written for commit 19203318646ba835b4e6235a0ca3d1347bcfbdce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

