### PR TITLE
feat(store): warn when the store is writing to disk the platform wipes

### DIFF
--- a/.changeset/ephemeral-store-warning.md
+++ b/.changeset/ephemeral-store-warning.md
@@ -1,0 +1,29 @@
+---
+"@vendoai/store": minor
+"@vendoai/vendo": minor
+---
+
+The store warns when it is writing to disk the platform wipes, and `vendo doctor`
+finds the same thing statically as `E-STORE-001`.
+
+Railway, Render, Fly.io and Heroku all run a long-lived process, so PGlite
+genuinely works there and refusing outright would be wrong — but they replace the
+container filesystem on every redeploy. The store kept working and quietly lost
+every app the host's users had built at the next deploy, with nothing said at any
+point. It now says so at construction, naming the directory it is about to write
+to and both ways out: mount a persistent volume and point `dataDir` at it, or
+pass a Postgres `url`.
+
+A platform marker is evidence on its own, so the warning does not wait for data
+to appear — warning before the first user writes is the whole point. A path under
+`/tmp` warns without a marker. `memory://` and a configured Postgres `url` say
+nothing, and the existing hard refusal on genuinely serverless environments
+(Vercel, Cloudflare Pages, Lambda) is untouched and still throws, because there
+PGlite cannot work at all.
+
+`vendo doctor` carries the static twin as `E-STORE-001`, so the wipe is findable
+before a deploy rather than after one. A project under `/tmp` additionally needs
+a real database sitting there: a scratch checkout under `/tmp` is what doctor
+sees on a laptop, and a false warning on every local run is worse than no
+warning. The check also stays quiet when `VENDO_API_KEY` composes the hosted
+store, since the local data directory is then one that nothing ever writes to.

--- a/docs-site/agents/verify.mdx
+++ b/docs-site/agents/verify.mdx
@@ -251,6 +251,41 @@ path prefix disagree — every page renders and every host tool call 404s.
 server mount (`https://site.com/maple`), or drop the relative server from the
 spec if the app is not mounted under a prefix.
 
+## Store persistence
+
+### E-STORE-001 {#E-STORE-001}
+
+**Symptom (warning):** The store's data directory is on ephemeral disk — the
+platform wipes it on every redeploy, and every app your users built plus all of
+their data goes with it.
+
+**Cause:** The store's default engine is PGlite, which writes to a directory on
+the local filesystem (`.vendo/data` unless you passed `dataDir`). That is the
+right default on a laptop and on a machine with a real disk. It is a data-loss
+bug on a platform whose container filesystem is recreated on each deploy —
+Railway, Render, Fly.io, and Heroku all are — and under `/tmp` anywhere.
+Doctor reports this when it finds one of those platform markers
+(`RAILWAY_ENVIRONMENT`, `RENDER`, `FLY_APP_NAME`, `DYNO`), or when the data
+directory sits under `/tmp` with a database already in it. The store prints the
+same warning at boot.
+
+**Fix:** Give the store storage that survives a deploy. Either mount a
+persistent volume and point `dataDir` at it:
+
+```ts
+createVendo({ store: createStore({ dataDir: "/data/vendo" }) });
+```
+
+or move to Postgres, which is the recommended production answer:
+
+```ts
+createVendo({ store: createStore({ url: process.env.DATABASE_URL }) });
+```
+
+Fully serverless platforms (Vercel, Cloudflare Pages, AWS Lambda) are a hard
+refusal rather than a warning: PGlite cannot run there at all, so the store
+throws at boot and Postgres is the only option.
+
 ## Host dependencies
 
 ### E-DEP-001 {#E-DEP-001}

--- a/packages/store/src/db.ts
+++ b/packages/store/src/db.ts
@@ -4,13 +4,42 @@
  *  PGlite wasm — in its bundle graph. */
 import { PGlite } from "@electric-sql/pglite";
 import fs from "node:fs";
-import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { join, resolve, sep } from "node:path";
 
 import { createPostgresDb, type Db, type Query, type StoreConfig } from "./db-postgres.js";
 
 export type { Db, Query, StoreConfig } from "./db-postgres.js";
 
 const SERVERLESS_ENVS = ["VERCEL", "CF_PAGES", "AWS_LAMBDA_FUNCTION_NAME"] as const;
+
+/** Platforms that DO run a long-lived process — so PGlite works, and refusing
+ *  outright (SERVERLESS_ENVS) would be wrong — but wipe the container
+ *  filesystem on every redeploy. The store keeps working; it just silently
+ *  loses every user's app at the next deploy, so this is a warning. */
+const EPHEMERAL_PLATFORM_ENVS = [
+  ["RAILWAY_ENVIRONMENT", "Railway"],
+  ["RENDER", "Render"],
+  ["FLY_APP_NAME", "Fly.io"],
+  ["DYNO", "Heroku"],
+] as const;
+
+const isUnder = (path: string, dir: string): boolean =>
+  path === dir || path.startsWith(dir.endsWith(sep) ? dir : dir + sep);
+
+function warnIfEphemeralDataDir(dataDir: string): void {
+  if (dataDir.startsWith("memory://")) return; // not a path on disk
+  const path = resolve(dataDir);
+  const platform = EPHEMERAL_PLATFORM_ENVS.find(([name]) => (process.env[name] ?? "").trim() !== "")?.[1];
+  if (platform === undefined && !(isUnder(path, tmpdir()) || isUnder(path, "/tmp"))) return;
+  const wipes = platform === undefined
+    ? "which this platform wipes on every redeploy"
+    : `and ${platform} wipes the container filesystem on every redeploy`;
+  console.warn(
+    `[vendo] warning: the store is writing to ${JSON.stringify(path)}, ${wipes} — your users' apps and data will be gone.`
+    + ` Mount a persistent volume and point dataDir at it, or pass url: "postgres://…" to createVendo.`,
+  );
+}
 
 function preparePgliteDir(dataDir: string): void {
   if (dataDir.startsWith("memory://")) return;
@@ -252,7 +281,9 @@ async function createPgliteHealingStaleLock(dataDir: string): Promise<PGlite> {
 /** 02-store §4 — url picks the pg engine; otherwise the PGlite dev default. */
 export function createDb(config: StoreConfig = {}): Db {
   if (config.url) return createPostgresDb(config.url);
-  return createPgliteDb(config.dataDir ?? ".vendo/data");
+  const dataDir = config.dataDir ?? ".vendo/data";
+  warnIfEphemeralDataDir(dataDir);
+  return createPgliteDb(dataDir);
 }
 
 function createPgliteDb(dataDir: string): Db {

--- a/packages/store/tests/db.ephemeral-warning.test.ts
+++ b/packages/store/tests/db.ephemeral-warning.test.ts
@@ -1,0 +1,70 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDb } from "../src/db.js";
+
+// A container platform runs a long-lived process, so PGlite WORKS there — right
+// up to the next deploy, which deletes the whole filesystem and with it every
+// app the product's users built. The store cannot refuse (unlike VERCEL and
+// friends, where PGlite cannot run at all), so boot warns instead.
+
+const TMP_DATA_DIR = join(tmpdir(), "vendo-ephemeral-warning", "data");
+// A path with a real disk under it: the laptop case that must stay silent.
+const LAPTOP_DATA_DIR = "/home/dev/maple/.vendo/data";
+
+describe("PGlite ephemeral-disk warning", () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+    vi.unstubAllEnvs();
+  });
+
+  const warning = (): string => String(warn.mock.calls[0]?.[0] ?? "");
+
+  it("warns when the data dir is under the OS temp dir", () => {
+    createDb({ dataDir: TMP_DATA_DIR });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warning()).toBe(
+      `[vendo] warning: the store is writing to ${JSON.stringify(TMP_DATA_DIR)}, which this platform wipes on every`
+      + " redeploy — your users' apps and data will be gone. Mount a persistent volume and point dataDir at it,"
+      + ' or pass url: "postgres://…" to createVendo.',
+    );
+  });
+
+  it.each([
+    ["RAILWAY_ENVIRONMENT", "production", "Railway"],
+    ["RENDER", "true", "Render"],
+    ["FLY_APP_NAME", "maple", "Fly.io"],
+    ["DYNO", "web.1", "Heroku"],
+  ])("warns on %s even with a normal-looking data dir", (marker, value, platform) => {
+    vi.stubEnv(marker, value);
+
+    createDb({ dataDir: LAPTOP_DATA_DIR });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warning()).toContain(`and ${platform} wipes the container filesystem on every redeploy`);
+    expect(warning()).toContain(JSON.stringify(LAPTOP_DATA_DIR));
+  });
+
+  it("stays silent for an ordinary laptop path", () => {
+    createDb({ dataDir: LAPTOP_DATA_DIR });
+    createDb({}); // the .vendo/data default, resolved against this repo's cwd
+    createDb({ dataDir: "memory://silent" });
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("still hard-refuses a serverless platform instead of warning", async () => {
+    vi.stubEnv("VERCEL", "1");
+
+    const db = createDb({ dataDir: TMP_DATA_DIR });
+    await expect(db.query("select 1")).rejects.toThrow(/PGlite cannot run on VERCEL/);
+    await db.close();
+  });
+});

--- a/packages/store/tests/db.stale-lock.test.ts
+++ b/packages/store/tests/db.stale-lock.test.ts
@@ -89,7 +89,9 @@ describe("PGlite stale-lock self-heal (ENG-350)", () => {
     await expect(db.query("select 1")).rejects.toThrow("Aborted()");
 
     expect(pgliteCreate).toHaveBeenCalledTimes(1);
-    expect(warn).not.toHaveBeenCalled();
+    // Scoped to THIS test's subject: the fixture dir lives under /tmp, so boot
+    // also (correctly) warns about ephemeral disk — see db.ephemeral-warning.test.ts.
+    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining("stale postmaster.pid"));
     await db.close();
   });
 });

--- a/packages/vendo/src/cli/doctor-codes.ts
+++ b/packages/vendo/src/cli/doctor-codes.ts
@@ -4,7 +4,7 @@ import { CLI_VERSION } from "./shared.js";
  * Agent-install DX (design 2026-07-19 §CLI-3) — the doctor error-code
  * registry. Every failure mode doctor can report (static and live) has one
  * stable, grep-able code here: E-<AREA>-<NNN>, where the area groups related
- * checks (WIRE wiring, CFG config files, DEP host dependency versions, UI
+ * checks (WIRE wiring, CFG config files, STORE store persistence, DEP host dependency versions, UI
  * eject drift, DEV probe server, LIVE composition/status, AUTH credentials,
  * MCP door, TURN model turn, CLOUD key). Codes are append-only: never renumber or reuse one — the
  * verify page anchors (`fix_ref`) and agents' remediation notes depend on
@@ -29,6 +29,7 @@ export const DOCTOR_ERROR_CODES = {
   "E-CFG-001": "a required .vendo/ config file is missing",
   "E-CFG-002": ".vendo/data/.gitignore is missing",
   "E-CFG-003": "the OpenAPI spec's relative server mount and VENDO_BASE_URL's path prefix disagree",
+  "E-STORE-001": "the store's data directory is on ephemeral disk (it will be wiped on redeploy)",
   "E-DEP-001": "the installed ai package is a major version @vendoai/vendo does not support",
   "E-DEP-002": "the running wire serves a different @vendoai/vendo version than this CLI (split-brain install)",
   "E-DEP-003": "the installed zod predates the zod/v3 + zod/v4 subpaths the AI SDK imports (zod < 3.25)",

--- a/packages/vendo/src/cli/doctor-config-checks.ts
+++ b/packages/vendo/src/cli/doctor-config-checks.ts
@@ -46,6 +46,15 @@ const isUnder = (path: string, dir: string): boolean =>
  *  /tmp is what doctor sees on a laptop and a false warning on every local run
  *  is worse than no warning. */
 export async function checkStorePersistence(run: DoctorRun): Promise<void> {
+  // …but only when the local PGlite default is the store at all. `selectStore`
+  // prefers hostedStore(VENDO_API_KEY) over createStore() (compose-store.ts), so
+  // on a Cloud deployment this path is a directory nothing ever writes and the
+  // warning would name it to every single Cloud user. A host that sets the key
+  // and STILL passes `store: createStore()` is not visible from here — no
+  // doctor check can see a programmatic override (doctor-report.ts's DoctorRun;
+  // same limit checkSurfaceOwnership states) — and that host still gets the
+  // store's own boot warning, which fires on the real dataDir at runtime.
+  if ((run.env.VENDO_API_KEY ?? "").trim() !== "") return;
   const dataDir = join(run.root, ".vendo", "data");
   const platform = EPHEMERAL_PLATFORM_ENVS.find(([name]) => (run.env[name] ?? "").trim() !== "")?.[1];
   const wiper = platform

--- a/packages/vendo/src/cli/doctor-config-checks.ts
+++ b/packages/vendo/src/cli/doctor-config-checks.ts
@@ -54,7 +54,13 @@ export async function checkStorePersistence(run: DoctorRun): Promise<void> {
   // doctor check can see a programmatic override (doctor-report.ts's DoctorRun;
   // same limit checkSurfaceOwnership states) — and that host still gets the
   // store's own boot warning, which fires on the real dataDir at runtime.
-  if ((run.env.VENDO_API_KEY ?? "").trim() !== "") return;
+  // Deliberately NOT trimmed — this has to be the SAME predicate composition
+  // uses or doctor and runtime disagree. Runtime reads the key through
+  // `environment()` (wire/shared.ts), which accepts any non-empty string, so a
+  // whitespace-only key still composes hostedStore (cloudKeyOptions →
+  // selectStore) and .vendo/data is never written. Trimming here named a
+  // directory nothing writes, blaming the disk for a bad key.
+  if ((run.env.VENDO_API_KEY ?? "") !== "") return;
   const dataDir = join(run.root, ".vendo", "data");
   const platform = EPHEMERAL_PLATFORM_ENVS.find(([name]) => (run.env[name] ?? "").trim() !== "")?.[1];
   const wiper = platform

--- a/packages/vendo/src/cli/doctor-config-checks.ts
+++ b/packages/vendo/src/cli/doctor-config-checks.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
-import { join, relative } from "node:path";
+import { tmpdir } from "node:os";
+import { join, relative, sep } from "node:path";
 import { applyJudgment, judgmentsFileSchema, overridesFileSchema, toolsFileSchema, type ExtractedTool, type ToolJudgment, type ToolsFile } from "@vendoai/actions";
 import { firstOpenApiSpec, openApiMountPath } from "@vendoai/actions/sync";
 import { publicBase, type RiskLabel } from "@vendoai/core";
@@ -20,6 +21,42 @@ export async function checkConfigFiles(run: DoctorRun): Promise<void> {
     else run.fail(`config/${file}`, "E-CFG-001", `missing .vendo/${file}`);
   }
   if (!await exists(join(root, ".vendo", "data", ".gitignore"))) run.warn("config/data-gitignore", "E-CFG-002", ".vendo/data/.gitignore is missing");
+}
+
+/** Platforms whose container filesystem is wiped on every redeploy — the same
+ *  list the store's own boot warning carries (@vendoai/store src/db.ts); the
+ *  two copies are deliberate, the CLI must not pull the store's engine module
+ *  into its bundle graph just to read four strings. */
+const EPHEMERAL_PLATFORM_ENVS = [
+  ["RAILWAY_ENVIRONMENT", "Railway"],
+  ["RENDER", "Render"],
+  ["FLY_APP_NAME", "Fly.io"],
+  ["DYNO", "Heroku"],
+] as const;
+
+const isUnder = (path: string, dir: string): boolean =>
+  path === dir || path.startsWith(dir.endsWith(sep) ? dir : dir + sep);
+
+/** The static twin of the store's boot warning: the PGlite default writes
+ *  under the project root, so a root on ephemeral disk means every user's app
+ *  and data is deleted by the next redeploy. A platform marker is evidence on
+ *  its own — the wipe is coming, and warning BEFORE the first user writes is
+ *  the whole point. A tmp path additionally needs a real database to be sitting
+ *  there (PG_VERSION, the file initdb writes), because a scratch checkout under
+ *  /tmp is what doctor sees on a laptop and a false warning on every local run
+ *  is worse than no warning. */
+export async function checkStorePersistence(run: DoctorRun): Promise<void> {
+  const dataDir = join(run.root, ".vendo", "data");
+  const platform = EPHEMERAL_PLATFORM_ENVS.find(([name]) => (run.env[name] ?? "").trim() !== "")?.[1];
+  const wiper = platform
+    ?? ((isUnder(dataDir, tmpdir()) || isUnder(dataDir, "/tmp")) && await exists(join(dataDir, "PG_VERSION"))
+      ? "this platform"
+      : undefined);
+  if (wiper === undefined) return;
+  run.warn("store/persistence", "E-STORE-001",
+    `the store's data directory ${JSON.stringify(dataDir)} is on ephemeral disk — ${wiper} wipes it on every redeploy `
+    + "and your users' apps and data go with it; mount a persistent volume and point the store's dataDir at it, "
+    + "or pass url: \"postgres://…\" to createVendo");
 }
 
 /** Spec 2026-08-06 §B1 — the deployment's path prefix has exactly one home:

--- a/packages/vendo/src/cli/doctor.ts
+++ b/packages/vendo/src/cli/doctor.ts
@@ -6,7 +6,7 @@ import {
   type CloudDoctorResult,
   type LiveTurnResult,
 } from "./doctor-live.js";
-import { checkConfigFiles, checkEjectDrift, checkModelResolution, checkMountAgreement, checkSurfaceOwnership, checkToolCatalog } from "./doctor-config-checks.js";
+import { checkConfigFiles, checkEjectDrift, checkModelResolution, checkMountAgreement, checkStorePersistence, checkSurfaceOwnership, checkToolCatalog } from "./doctor-config-checks.js";
 import { checkInstalledDeps } from "./doctor-deps-checks.js";
 import { checkMcpDiscovery } from "./doctor-mcp-checks.js";
 import { checkAuthProbes, checkLiveStatus, checkRootRender, reportMachines, startDevServerIfOffered } from "./doctor-probe-checks.js";
@@ -119,6 +119,7 @@ export async function runDoctor(options: DoctorOptions): Promise<number> {
   await checkWiring(run);
   await checkInstalledDeps(run, output, options.npmLatest);
   await checkConfigFiles(run);
+  await checkStorePersistence(run);
   await checkMountAgreement(run);
   await checkSurfaceOwnership(run);
   await checkModelResolution(run);

--- a/packages/vendo/tests/cli/doctor-codes.test.ts
+++ b/packages/vendo/tests/cli/doctor-codes.test.ts
@@ -54,6 +54,7 @@ describe("doctor error-code registry", () => {
         "E-MCP-008": "the live MCP registry auth challenge is malformed",
         "E-MCP-009": "the MCP door is wired but VENDO_BASE_URL is not set (discovery advertises the wrong origin)",
         "E-SCHED-001": "apps declare vendo.json schedules but no schedule caller is configured",
+        "E-STORE-001": "the store's data directory is on ephemeral disk (it will be wiped on redeploy)",
         "E-TOOLS-001": "every extracted host tool is disabled or excluded (zero live host tools)",
         "E-TOOLS-002": "the extracted tool surface is empty (zero host tools)",
         "E-TOOLS-003": "part of the tool catalog is ungraded (nobody has graded it, so it asks on every call)",

--- a/packages/vendo/tests/cli/doctor-store-persistence.test.ts
+++ b/packages/vendo/tests/cli/doctor-store-persistence.test.ts
@@ -92,8 +92,23 @@ describe("store/persistence (E-STORE-001)", () => {
     expect(doctor.warnings).toBe(0);
   });
 
-  it("still warns when VENDO_API_KEY is present but blank", async () => {
+  // `environment()` (wire/shared.ts) accepts ANY non-empty string, so a
+  // whitespace-only key still composes hostedStore and .vendo/data is never
+  // written. Doctor must read the key the same way it is read at runtime.
+  it("stays silent when VENDO_API_KEY is whitespace, because the hosted store still composes", async () => {
     const doctor = run("/srv/maple", { RAILWAY_ENVIRONMENT: "production", VENDO_API_KEY: "  " });
+
+    await checkStorePersistence(doctor);
+
+    expect(doctor.checks).toEqual([]);
+    expect(doctor.warnings).toBe(0);
+  });
+
+  // The other side of that boundary: an empty key is what `environment()`
+  // itself rejects, so the local PGlite store is what composes and the warning
+  // is the truth.
+  it("still warns when VENDO_API_KEY is set but empty", async () => {
+    const doctor = run("/srv/maple", { RAILWAY_ENVIRONMENT: "production", VENDO_API_KEY: "" });
 
     await checkStorePersistence(doctor);
 

--- a/packages/vendo/tests/cli/doctor-store-persistence.test.ts
+++ b/packages/vendo/tests/cli/doctor-store-persistence.test.ts
@@ -1,0 +1,86 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { checkStorePersistence } from "../../src/cli/doctor-config-checks.js";
+import { createDoctorRun, type DoctorRun } from "../../src/cli/doctor-report.js";
+
+// The static twin of the store's boot warning: the PGlite default writes under
+// the project root, so an ephemeral root loses every app the product's users
+// built on the next redeploy.
+
+const cleanup: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const dispose of cleanup.splice(0).reverse()) await dispose();
+});
+
+async function project(options: { booted: boolean }): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "vendo-store-persistence-"));
+  cleanup.push(() => rm(root, { recursive: true, force: true }));
+  await mkdir(join(root, ".vendo", "data"), { recursive: true });
+  await writeFile(join(root, ".vendo", "data", ".gitignore"), "*\n");
+  // PG_VERSION is what initdb writes: the evidence a real database lives here.
+  if (options.booted) await writeFile(join(root, ".vendo", "data", "PG_VERSION"), "15\n");
+  return root;
+}
+
+function run(root: string, env: Record<string, string | undefined> = {}): DoctorRun {
+  return createDoctorRun({
+    root,
+    env,
+    json: true, // no console lines from the reporters
+    statusUrl: "http://localhost:3000/api/vendo",
+    fetchImpl: fetch,
+    output: { log: () => {}, error: () => {} },
+  });
+}
+
+describe("store/persistence (E-STORE-001)", () => {
+  it("warns when a booted store's data dir sits under /tmp", async () => {
+    const root = await project({ booted: true });
+    const doctor = run(root);
+
+    await checkStorePersistence(doctor);
+
+    const check = doctor.checks.find((candidate) => candidate.id === "store/persistence");
+    expect(check?.status).toBe("warning");
+    expect(check?.error_code).toBe("E-STORE-001");
+    expect(check?.fix_ref).toContain("#E-STORE-001");
+    expect(check?.message).toContain(join(root, ".vendo", "data"));
+    expect(check?.message).toContain("wipes it on every redeploy");
+    expect(doctor.failures).toBe(0); // ephemeral disk is a warning, never a block
+  });
+
+  it.each([
+    ["RAILWAY_ENVIRONMENT", "production", "Railway"],
+    ["RENDER", "true", "Render"],
+    ["FLY_APP_NAME", "maple", "Fly.io"],
+    ["DYNO", "web.1", "Heroku"],
+  ])("warns on %s before any data exists", async (marker, value, platform) => {
+    const doctor = run("/srv/maple", { [marker]: value });
+
+    await checkStorePersistence(doctor);
+
+    const check = doctor.checks.find((candidate) => candidate.id === "store/persistence");
+    expect(check?.error_code).toBe("E-STORE-001");
+    expect(check?.message).toContain(`${platform} wipes it on every redeploy`);
+  });
+
+  it("stays silent on a persistent disk", async () => {
+    const doctor = run("/srv/maple");
+
+    await checkStorePersistence(doctor);
+
+    expect(doctor.checks).toEqual([]);
+    expect(doctor.warnings).toBe(0);
+  });
+
+  it("stays silent for a scratch project under /tmp with no database in it", async () => {
+    const root = await project({ booted: false });
+    const doctor = run(root);
+
+    await checkStorePersistence(doctor);
+
+    expect(doctor.checks).toEqual([]);
+  });
+});

--- a/packages/vendo/tests/cli/doctor-store-persistence.test.ts
+++ b/packages/vendo/tests/cli/doctor-store-persistence.test.ts
@@ -75,6 +75,32 @@ describe("store/persistence (E-STORE-001)", () => {
     expect(doctor.warnings).toBe(0);
   });
 
+  // The local PGlite default is only the store when no Cloud key fills the slot
+  // (selectStore, compose-store.ts). Warning on a Cloud deployment names a
+  // directory nothing writes — to every Cloud user, on every doctor run.
+  it.each([
+    ["RAILWAY_ENVIRONMENT", "production"],
+    ["RENDER", "true"],
+    ["FLY_APP_NAME", "maple"],
+    ["DYNO", "web.1"],
+  ])("stays silent on %s when VENDO_API_KEY composes the hosted store", async (marker, value) => {
+    const doctor = run("/srv/maple", { [marker]: value, VENDO_API_KEY: "vk_live_test" });
+
+    await checkStorePersistence(doctor);
+
+    expect(doctor.checks).toEqual([]);
+    expect(doctor.warnings).toBe(0);
+  });
+
+  it("still warns when VENDO_API_KEY is present but blank", async () => {
+    const doctor = run("/srv/maple", { RAILWAY_ENVIRONMENT: "production", VENDO_API_KEY: "  " });
+
+    await checkStorePersistence(doctor);
+
+    expect(doctor.checks.find((candidate) => candidate.id === "store/persistence")?.error_code)
+      .toBe("E-STORE-001");
+  });
+
   it("stays silent for a scratch project under /tmp with no database in it", async () => {
     const root = await project({ booted: false });
     const doctor = run(root);


### PR DESCRIPTION
## What

A store writing to disk the platform wipes on every redeploy loses every user's apps and data on the next deploy, silently. Two surfaces now say so: a warning at store boot, and a static `vendo doctor` check (**E-STORE-001**, a new STORE area).

Fires when the data dir resolves under `/tmp`, or when a container marker is present (`RAILWAY_ENVIRONMENT`, `RENDER`, `FLY_APP_NAME`, `DYNO`).

## Proof — real `vendo doctor` run

```
warning: the store's data directory "/tmp/s6-doctor-proof-project/.vendo/data" is on ephemeral disk — this platform wipes it on every redeploy and your users' apps and data go with it; mount a persistent volume and point the store's dataDir at it, or pass url: "postgres://…" to createVendo
```
```json
{"id":"store/persistence","status":"warning","error_code":"E-STORE-001","fix_ref":"https://vendo.run/agents/verify?v=0.14.0#E-STORE-001"}
```

The warning never blocks — it is a warning, not a failure.

## What did NOT change

`SERVERLESS_ENVS` and the existing hard refusal are untouched: **Vercel still throws**, confirmed by test. An ordinary laptop path, the default `.vendo/data`, and `memory://` all stay silent.

## Judgment calls worth reviewing

- **Doctor's bare-`/tmp` branch additionally requires a database to already exist there.** Every existing doctor fixture is `mkdtemp(tmpdir())`, so the literal rule warned on ~10 unrelated tests, and a scratch checkout under `/tmp` is exactly the false positive to avoid. Container markers fire unconditionally — on Railway/Render/Fly/Heroku doctor warns on first boot with no database written. Store boot keeps both conditions unconditionally.
- **Container wording adds one connector.** Substituting the platform into `…"X", which this platform wipes…` yields ungrammatical output, so it reads `…"X", and Railway wipes the container filesystem on every redeploy…`. The approved fragment appears verbatim; only `, which ` → `, and `.
- **Out-of-fence edits, all deliberate:** `doctor.ts` (one itinerary line — without it the check is dead code), `doctor-codes.test.ts` (the registry's inline snapshot, whose own comment says a new code extends it), `db.stale-lock.test.ts` (its blanket `not.toHaveBeenCalled()` used a `/tmp` fixture; now scoped to the stale-lock message, same intent).

Counts: ephemeral-warning 7 · store lock suites 10 · doctor+docs gate 12 · doctor regression 121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warn when the store writes to ephemeral disk that platforms wipe on redeploy, to prevent silent data loss. Adds a boot-time warning and a `vendo doctor` check (E-STORE-001), with docs and a changeset for minor releases in `@vendoai/store` and `@vendoai/vendo`; serverless refusals still throw.

- **New Features**
  - Store boot warns when `dataDir` is under `/tmp` or when `RAILWAY_ENVIRONMENT`, `RENDER`, `FLY_APP_NAME`, or `DYNO` are set.
  - `vendo doctor` adds `store/persistence` (E-STORE-001): fires on those markers, or when `.vendo/data` under `/tmp` contains a real DB (`PG_VERSION`). Docs include guidance and an E-STORE-001 fix section.

- **Bug Fixes**
  - `vendo doctor` reads `VENDO_API_KEY` exactly like runtime composition (any non-empty string, even whitespace) and skips E-STORE-001 when a hosted store composes; an empty key still triggers the warning.

<sup>Written for commit 72d39cea71198e751a67f8fd8779a609d7ee3ca7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

