### PR TITLE
feat(vendo): init writes the model line it detected

### DIFF
--- a/packages/vendo/src/cli/init-mcp.ts
+++ b/packages/vendo/src/cli/init-mcp.ts
@@ -19,7 +19,7 @@ import { randomBytes } from "node:crypto";
 import { join, relative, sep } from "node:path";
 import { MCP_MOUNT } from "../door-paths.js";
 import type { AuthMatch } from "./init-auth.js";
-import { compositionModuleSource, routeSource } from "./init-scaffolds.js";
+import { compositionModuleSource, routeSource, type ScaffoldModel } from "./init-scaffolds.js";
 
 /** Which authorization server fronts the door. DECLARED by the operator and
     nothing else (10-mcp §3.1) — init prints environment lines, it never
@@ -55,6 +55,10 @@ export interface McpPlanInput {
   /** The public origin captured earlier this run, or null when the user skipped
       the question. */
   baseUrl: string | null;
+  /** The provider key init found in the environment. This path's composition
+      module is the ONLY place it may land: the thin route composes nothing, so
+      writing it there too would be a second, dead selection. */
+  models?: ScaffoldModel | null;
 }
 
 /** A file the MCP path creates. Always new — `before` is null for every one of
@@ -91,6 +95,12 @@ export interface McpPlan {
   steps: string[];
   /** Environment lines the operator sets where they deploy (broker posture). */
   envLines: string[];
+  /** The provider and file of the `models` line this plan wrote — the
+      composition module, never the route it replaced. The caller's closing
+      summary names this file, so it can never point a reader at a route that
+      holds nothing. Null when no provider key resolved or the plan is
+      `blocked`. */
+  modelWritten: { provider: ScaffoldModel["provider"]; path: string } | null;
   /** Why nothing was written. Set means the other fields are empty. */
   blocked?: string;
 }
@@ -159,7 +169,8 @@ const KEYLESS_SIGN_IN =
 
 export function planMcp(input: McpPlanInput): McpPlan {
   const { root, appDir, framework, authWired, serverActions, cloudKey, posture, serviceKey, baseUrl } = input;
-  const refuse = (why: string): McpPlan => ({ changes: [], routeSource: null, steps: [], envLines: [], blocked: why });
+  const models = input.models ?? null;
+  const refuse = (why: string): McpPlan => ({ changes: [], routeSource: null, steps: [], envLines: [], modelWritten: null, blocked: why });
 
   if (framework !== "next") {
     return refuse(
@@ -188,8 +199,11 @@ export function planMcp(input: McpPlanInput): McpPlan {
 
   // `serviceAuth` is wired only under local posture: see McpPlan.serviceKeyValue.
   const serviceAuth = posture === "local" && serviceKey;
+  // The one file on this path that composes, so the one that may carry the
+  // models line — named here because the closing summary points at it.
+  const compositionChange = change(composition, compositionModuleSource({ serverActions, auth: authWired, serviceAuth, models }));
   const changes: McpChange[] = [
-    change(composition, compositionModuleSource({ serverActions, auth: authWired, serviceAuth })),
+    compositionChange,
     change(
       join(wellKnownDir, "route.ts"),
       wellKnownRouteSource(specifierBetween(wellKnownDir, join(wiringDir, "vendo"))),
@@ -218,8 +232,10 @@ export function planMcp(input: McpPlanInput): McpPlan {
 
   return {
     changes,
+    // No `models` on this arm, and never one: the thin route composes nothing.
     routeSource: routeSource({ serverActions, auth: authWired, mcp: { serviceAuth } }),
     ...(serviceAuth ? { serviceKeyValue: generateServiceKey() } : {}),
+    modelWritten: models === null ? null : { provider: models.provider, path: compositionChange.path },
     steps,
     envLines: posture === "broker"
       ? [

--- a/packages/vendo/src/cli/init-scaffolds.ts
+++ b/packages/vendo/src/cli/init-scaffolds.ts
@@ -5,6 +5,9 @@ import {
   serverActionRegistrations,
   type ServerActionRegistration,
 } from "@vendoai/actions/sync";
+// Relative (not the #dev-creds condition): the CLI is Node-only and the edge
+// condition would resolve the browser-safe half here.
+import type { EnvKeyProvider } from "../dev-creds/resolve.js";
 import { AUTH_FAMILY_INFO, AUTH_PRESET_SPECIFIER, type AuthMatch } from "./init-auth.js";
 import { readOptional } from "./shared.js";
 
@@ -48,9 +51,49 @@ function authImportLine(auth: AuthMatch | null): string {
   return auth === null ? "" : `import { ${auth.preset} } from ${JSON.stringify(AUTH_PRESET_SPECIFIER[auth.preset])};\n`;
 }
 
+/** What each env-key provider's `models.default` line names: the AI SDK's
+    DEFAULT provider instance — it reads the key straight out of the
+    environment, so the scaffold never touches key material — and the flagship
+    id that provider's ladder resolves (dev-creds/model.ts DEFAULT_MODELS). */
+const MODEL_PROVIDERS: Record<EnvKeyProvider, { specifier: string; model: string }> = {
+  anthropic: { specifier: "@ai-sdk/anthropic", model: "claude-sonnet-4-6" },
+  openai: { specifier: "@ai-sdk/openai", model: "gpt-5" },
+  google: { specifier: "@ai-sdk/google", model: "gemini-2.5-flash" },
+};
+
+/** The provider key init found in the host's environment at scaffold time.
+ *  Env keys are CREDENTIALS and composition SELECTS the model, so a stray
+ *  ANTHROPIC_API_KEY no longer picks one by itself — the explicit line has to
+ *  exist in the config. Init detected the key, so init writes that line; a
+ *  host that "just worked" off an ambient key keeps working. */
+export interface ScaffoldModel {
+  provider: EnvKeyProvider;
+  /** The variable the key came from — named in the line's comment so the
+      reader knows what still supplies it. */
+  envVar: string;
+}
+
+function modelImportLine(model: ScaffoldModel | null): string {
+  if (model === null) return "";
+  return `import { ${model.provider} } from ${JSON.stringify(MODEL_PROVIDERS[model.provider].specifier)};\n`;
+}
+
+/** The `models` line inside a `createVendo({ … })` call. Emitted by exactly
+    ONE scaffold per host: the MCP path's route composes nothing (it imports
+    `./vendo`), so its models line lives in the composition module and nowhere
+    else. */
+function modelConfigLine(model: ScaffoldModel | null): string {
+  if (model === null) return "";
+  const { model: id } = MODEL_PROVIDERS[model.provider];
+  return `  models: { default: ${model.provider}(${JSON.stringify(id)}) }, // ${model.envVar} supplies the key\n`;
+}
+
 export function routeSource(options: {
   serverActions: boolean;
   auth: AuthMatch | null;
+  /** The provider key init found, written as the explicit `models` selection.
+      Ignored on the MCP arm below — that route composes nothing. */
+  models?: ScaffoldModel | null;
   /** The MCP path (10-mcp): the composition moves to its own module and this
       file becomes the thin handler over it. A Next.js route module may not
       export anything but route handlers, and the origin-root discovery route
@@ -65,12 +108,15 @@ export function routeSource(options: {
       `import { vendo } from "./vendo";\n\n` +
       `export const { GET, POST, PUT, PATCH, DELETE } = nextVendoHandler(vendo);\n`;
   }
-  return authImportLine(options.auth) +
+  const model = options.models ?? null;
+  return modelImportLine(model) +
+    authImportLine(options.auth) +
     `import { createVendo, guard, nextVendoHandler } from "@vendoai/vendo/server";\n` +
     (options.serverActions ? `import { serverActions } from "./vendo-actions";\n` : "") +
     `\nconst vendo = createVendo({\n` +
     // The Next route is always TypeScript (app/api/vendo/[...vendo]/route.ts).
     (options.auth === null ? anonymousPrincipalLines(true) : authConfigLines(options.auth)) +
+    modelConfigLine(model) +
     (options.serverActions ? `  serverActions,\n` : "") +
     `  guard: guard({ policy: {} }), // .vendo/policy.json: destructive asks, reads run\n` +
     `});\n\n` +
@@ -91,8 +137,13 @@ export function compositionModuleSource(options: {
   auth: AuthMatch;
   /** Wire first-party service auth off the environment (local posture only). */
   serviceAuth: boolean;
+  /** The provider key init found. This module is the MCP path's ONLY
+      composition, so it is the only place the models line may appear there —
+      the thin route it feeds composes nothing. */
+  models?: ScaffoldModel | null;
 }): string {
-  return authImportLine(options.auth) +
+  return modelImportLine(options.models ?? null) +
+    authImportLine(options.auth) +
     `import { createVendo, guard } from "@vendoai/vendo/server";\n` +
     (options.serverActions ? `import { serverActions } from "./vendo-actions";\n` : "") +
     (options.serviceAuth
@@ -103,6 +154,7 @@ export function compositionModuleSource(options: {
       : "") +
     `\nexport const vendo = createVendo({\n` +
     authConfigLines(options.auth) +
+    modelConfigLine(options.models ?? null) +
     (options.serverActions ? `  serverActions,\n` : "") +
     `  guard: guard({ policy: {} }), // .vendo/policy.json: destructive asks, reads run\n` +
     `  // The door outside agents reach, through the SAME guard-bound path your own\n` +

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -836,6 +836,10 @@ async function planMcpScaffold(input: {
     cloudKey,
     posture,
     serviceKey,
+    // The composition moves into ./vendo on this path, so the models line the
+    // route scaffold planned moves with it — resolved the same way, written in
+    // exactly one of the two files.
+    models: await scaffoldModel(root, options),
     // Not optional: a null base URL is an ANSWER the plan reads, and it is
     // what makes steps[] lead with the recoverable version of E-MCP-009's
     // failure instead of assuming an origin.
@@ -1899,13 +1903,13 @@ export async function runInit(options: InitOptions): Promise<number> {
     // explicit config is already there to edit, and no first boot fails on the
     // removed ambient behaviour.
     //
-    // It only speaks for a file that actually holds the line. The MCP arm
-    // REPLACES the route this planned for with the thin handler over ./vendo
-    // (a route module may export only handlers), so the planned line went with
-    // it and `planMcp` composes its module without one — naming route.ts here
-    // would send the reader to a file that does not have it.
-    if (mcp === null && modelWritten !== null) {
-      output.log(`models: ${modelWritten.provider} — written into ${modelWritten.path}`);
+    // It only ever names the file that actually holds the line. The MCP arm
+    // REPLACES the route this planned for with the thin handler over ./vendo (a
+    // route module may export only handlers), so the line lives in that plan's
+    // composition module and `planMcp` reports which file that is.
+    const modelLanded = mcp === null ? modelWritten : mcp.modelWritten;
+    if (modelLanded !== null) {
+      output.log(`models: ${modelLanded.provider} — written into ${modelLanded.path}`);
     }
     // The one short Cloud reminder in the end-of-run summary — ONLY while no
     // key exists (the full emphasized block already ran up top; no repeat).

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -36,6 +36,7 @@ import {
   serverActionsModuleSource,
   serverActionsWiring,
   VENDO_ENV_EXAMPLE,
+  type ScaffoldModel,
 } from "./init-scaffolds.js";
 import { createPrettyOutput, plainSecret, plainSelect, plainText, usePrettyOutput, type PrettyOutput, type SelectOption } from "./pretty.js";
 import { contrastingText } from "./theme/color.js";
@@ -939,6 +940,11 @@ interface ScaffoldPlan {
   authWired: AuthMatch | null;
   compositionPath: string | null;
   layout: LayoutWiring;
+  /** The provider and file of the `models` line this run wrote — the migration
+      path off the removed ambient-key behaviour, and what the closing summary
+      reports. Null when no provider key resolved, or when the composition
+      already existed (init never edits a file it did not author). */
+  modelWritten: { provider: ScaffoldModel["provider"]; path: string } | null;
 }
 
 const emptyScaffold = (layout: LayoutWiring): ScaffoldPlan => ({
@@ -948,6 +954,7 @@ const emptyScaffold = (layout: LayoutWiring): ScaffoldPlan => ({
   authWired: null,
   compositionPath: null,
   layout,
+  modelWritten: null,
 });
 
 async function planCustomComposition(
@@ -1069,11 +1076,13 @@ async function planNextComposition(
     const path = relative(root, route);
     // Detect + confirm happens only on fresh composition creation.
     const auth = await resolveScaffoldAuth(root, path, options.auth, confirmAuth, selectAuth);
-    const routeAfter = routeSource({ serverActions: registrations.length > 0, auth: auth.wired });
+    const models = await scaffoldModel(root, options);
+    const routeAfter = routeSource({ serverActions: registrations.length > 0, auth: auth.wired, models });
     scaffold.changes.push({ absolute: route, path, before: routeBefore, after: routeAfter, diff: diff(path, routeBefore, routeAfter) });
     scaffold.authAdvice = auth.advice;
     scaffold.authWired = auth.wired;
     scaffold.compositionPath = path;
+    if (models !== null) scaffold.modelWritten = { provider: models.provider, path };
   } else if (registrations.length > 0) {
     // The route already exists but server actions appeared since it was
     // generated: name the wiring the existing createVendo is missing, so
@@ -1106,6 +1115,8 @@ async function buildPlan(options: InitOptions, confirmAuth?: ConfirmAuth, select
   compositionPath: string | null;
   /** How the visible surface reached (or didn't reach) the layout. */
   layout: LayoutWiring;
+  /** The `models` line this run wrote, and where (ScaffoldPlan.modelWritten). */
+  modelWritten: ScaffoldPlan["modelWritten"];
 }> {
   const root = resolve(options.targetDir);
   // The non-interactive guard still demands an explicit --framework, so
@@ -1116,7 +1127,7 @@ async function buildPlan(options: InitOptions, confirmAuth?: ConfirmAuth, select
     : framework === "express"
       ? await planExpressComposition(root, options, confirmAuth, selectAuth)
       : await planNextComposition(root, options, confirmAuth, selectAuth);
-  const { changes, edits, authAdvice, authWired, compositionPath, layout } = scaffold;
+  const { changes, edits, authAdvice, authWired, compositionPath, layout, modelWritten } = scaffold;
 
   const packageJson = join(root, "package.json");
   const packageBefore = await readOptional(packageJson);
@@ -1171,6 +1182,7 @@ async function buildPlan(options: InitOptions, confirmAuth?: ConfirmAuth, select
     authWired,
     compositionPath,
     layout,
+    modelWritten,
     plan: {
       framework,
       // Only when the run named one: an unattended plan stays byte-identical
@@ -1377,6 +1389,37 @@ async function guardUndetectedFramework(input: {
   return true;
 }
 
+/** The env every credential consumer reads. Dev keys may live in .env.local
+    rather than this process's env — a PRIOR run's minted starter key, or
+    hand-added provider keys — so they are merged in for the credential ladder,
+    the cloud step, the theme model pass and the AI polish. An explicit env
+    value always wins over .env.local. */
+function credentialEnv(root: string, env: Record<string, string | undefined>): Record<string, string | undefined> {
+  let effective = env;
+  for (const name of [...ENV_KEY_VARS.map((entry) => entry.envVar), "VENDO_API_KEY"]) {
+    if ((env[name] ?? "").trim() !== "") continue;
+    const stored = envFileValueSync(root, name);
+    if (stored !== null) effective = { ...effective, [name]: stored };
+  }
+  return effective;
+}
+
+/** The provider key a scaffold written THIS run should name in `models`, or
+ *  null when no provider key resolved. Only the env-key rungs qualify: they
+ *  are the rung whose meaning changed (a key in the environment no longer
+ *  picks a model on its own), and the Cloud rung resolves its model through
+ *  the gateway's own family names instead. Resolved here, at scaffold time,
+ *  because the file is authored before the interactive credential step runs —
+ *  detection is pure and read-only, so asking twice costs nothing. */
+async function scaffoldModel(root: string, options: InitOptions): Promise<ScaffoldModel | null> {
+  const credential = await (options.resolveCredential ?? resolveDevCredential)({
+    env: credentialEnv(root, options.env ?? process.env),
+  });
+  return credential.rung === "env-key"
+    ? { provider: credential.provider, envVar: credential.envVar }
+    : null;
+}
+
 /** Key first (product order fix): the model-credential story — env keys,
  *  else the Vendo Cloud offer — runs BEFORE the AI-assisted passes, so a
  *  starter key minted here powers the SAME run's theme model pass and AI
@@ -1390,17 +1433,7 @@ async function resolveModelCredential(input: {
   pretty: PrettyOutput | null;
 }): Promise<{ credential: DevCredential; cloud: Awaited<ReturnType<typeof runCloudStep>> }> {
   const { root, env, options, output, pretty } = input;
-  // Dev keys may live in .env.local rather than this process's env — a
-  // PRIOR run's minted starter key, or hand-added provider keys. Merge
-  // them into the env every credential consumer reads (credential ladder,
-  // cloud step, theme model pass, AI polish); an explicit env value
-  // always wins over .env.local.
-  let effectiveEnv = env;
-  for (const name of [...ENV_KEY_VARS.map((entry) => entry.envVar), "VENDO_API_KEY"]) {
-    if ((env[name] ?? "").trim() !== "") continue;
-    const stored = envFileValueSync(root, name);
-    if (stored !== null) effectiveEnv = { ...effectiveEnv, [name]: stored };
-  }
+  let effectiveEnv = credentialEnv(root, env);
   let credential = await (options.resolveCredential ?? resolveDevCredential)({ env: effectiveEnv });
   if (credential.rung === "env-key") {
     // Their key is a decision already made, so this stays a statement and
@@ -1750,7 +1783,7 @@ export async function runInit(options: InitOptions): Promise<number> {
     ? undefined
     : (options.selectAuth ?? (pretty === null ? plainSelect : pretty.select));
   const detectStarted = Date.now();
-  const { plan, changes, edits, manualSteps, mount, authAdvice, authWired, compositionPath, layout } = await buildPlan(options, confirmAuth, selectAuth);
+  const { plan, changes, edits, manualSteps, mount, authAdvice, authWired, compositionPath, layout, modelWritten } = await buildPlan(options, confirmAuth, selectAuth);
   const detectMs = Date.now() - detectStarted;
   let telemetry = telemetryFor(options, output, root);
   await telemetry.track("init_started", { framework: plan.framework });
@@ -1860,6 +1893,14 @@ export async function runInit(options: InitOptions): Promise<number> {
 
     await ensureHostDeps({ root, output, options, pretty, interactive, credential });
 
+    // The one line that closes the model story. A provider key is a credential
+    // now, not a selection: nothing picks a model off the environment any more,
+    // so the run says which model it SELECTED for them and in which file — the
+    // explicit config is already there to edit, and no first boot fails on the
+    // removed ambient behaviour.
+    if (modelWritten !== null) {
+      output.log(`models: ${modelWritten.provider} — written into ${modelWritten.path}`);
+    }
     // The one short Cloud reminder in the end-of-run summary — ONLY while no
     // key exists (the full emphasized block already ran up top; no repeat).
     if (credential.rung === "none") {

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -1898,7 +1898,13 @@ export async function runInit(options: InitOptions): Promise<number> {
     // so the run says which model it SELECTED for them and in which file — the
     // explicit config is already there to edit, and no first boot fails on the
     // removed ambient behaviour.
-    if (modelWritten !== null) {
+    //
+    // It only speaks for a file that actually holds the line. The MCP arm
+    // REPLACES the route this planned for with the thin handler over ./vendo
+    // (a route module may export only handlers), so the planned line went with
+    // it and `planMcp` composes its module without one — naming route.ts here
+    // would send the reader to a file that does not have it.
+    if (mcp === null && modelWritten !== null) {
       output.log(`models: ${modelWritten.provider} — written into ${modelWritten.path}`);
     }
     // The one short Cloud reminder in the end-of-run summary — ONLY while no

--- a/packages/vendo/tests/cli/init-scaffolds.test.ts
+++ b/packages/vendo/tests/cli/init-scaffolds.test.ts
@@ -106,3 +106,60 @@ describe("the MCP path's split composition", () => {
     expect(service).not.toContain("./vendo-actions");
   });
 });
+
+/** SPEC 4b: env keys are credentials and CONFIG selects the model, so a stray
+    ANTHROPIC_API_KEY no longer picks one. The scaffold is the migration path —
+    init writes the explicit selection into the composition it authors, ONCE. */
+describe("the models line a detected provider key writes", () => {
+  const clerk = { preset: "clerk", dependency: "@clerk/nextjs" } as const;
+  const anthropicKey = { provider: "anthropic", envVar: "ANTHROPIC_API_KEY" } as const;
+
+  it("writes the import and the config line exactly once into the Next route", () => {
+    const route = routeSource({ serverActions: false, auth: null, models: anthropicKey });
+    expect(route).toContain(`import { anthropic } from "@ai-sdk/anthropic";\n`);
+    expect(route).toContain(`  models: { default: anthropic("claude-sonnet-4-6") }, // ANTHROPIC_API_KEY supplies the key\n`);
+    expect(route.match(/@ai-sdk\/anthropic/g)).toHaveLength(1);
+    expect(route.match(/models:/g)).toHaveLength(1);
+    // The import leads the file — the same order the runtime-neutral scaffold
+    // already uses — and the line lands inside the createVendo call.
+    expect(route.indexOf("@ai-sdk/anthropic")).toBeLessThan(route.indexOf("@vendoai/vendo/server"));
+    expect(route.indexOf("createVendo({")).toBeLessThan(route.indexOf("models:"));
+  });
+
+  it("names each provider's own default instance and flagship id", () => {
+    expect(routeSource({ serverActions: false, auth: null, models: { provider: "openai", envVar: "OPENAI_API_KEY" } }))
+      .toContain(`  models: { default: openai("gpt-5") }, // OPENAI_API_KEY supplies the key\n`);
+    expect(routeSource({ serverActions: false, auth: null, models: { provider: "google", envVar: "GOOGLE_GENERATIVE_AI_API_KEY" } }))
+      .toContain(`  models: { default: google("gemini-2.5-flash") }, // GOOGLE_GENERATIVE_AI_API_KEY supplies the key\n`);
+  });
+
+  it("writes neither the import nor the line when no provider key resolved", () => {
+    for (const route of [
+      routeSource({ serverActions: false, auth: null }),
+      routeSource({ serverActions: false, auth: null, models: null }),
+    ]) {
+      expect(route).not.toContain("@ai-sdk/");
+      expect(route).not.toContain("models:");
+    }
+  });
+
+  it("keeps it out of the thin MCP route and in the composition module — one models line per host", () => {
+    // The MCP route composes nothing (it imports ./vendo), so a models line
+    // there would be a second, dead selection plus a dangling import.
+    const thin = routeSource({ serverActions: false, auth: clerk, models: anthropicKey, mcp: { serviceAuth: false } });
+    expect(thin).not.toContain("@ai-sdk/anthropic");
+    expect(thin).not.toContain("models:");
+
+    const composition = compositionModuleSource({ serverActions: false, auth: clerk, serviceAuth: false, models: anthropicKey });
+    expect(composition).toContain(`import { anthropic } from "@ai-sdk/anthropic";\n`);
+    expect(composition).toContain(`  models: { default: anthropic("claude-sonnet-4-6") }, // ANTHROPIC_API_KEY supplies the key\n`);
+    expect(composition.match(/@ai-sdk\/anthropic/g)).toHaveLength(1);
+    expect(composition.match(/models:/g)).toHaveLength(1);
+    // The pair init writes on that path carries exactly one of each.
+    expect(`${thin}${composition}`.match(/models:/g)).toHaveLength(1);
+
+    const keyless = compositionModuleSource({ serverActions: false, auth: clerk, serviceAuth: false });
+    expect(keyless).not.toContain("@ai-sdk/");
+    expect(keyless).not.toContain("models:");
+  });
+});

--- a/packages/vendo/tests/cli/init.test.ts
+++ b/packages/vendo/tests/cli/init.test.ts
@@ -905,10 +905,10 @@ describe("vendo init (zero-question)", () => {
   });
 
   /** The MCP arm replaces the route this planned for with the thin handler over
-      ./vendo, so the planned models line went with it. The summary may not name
-      a file that does not hold the line — sending the reader to route.ts to
-      find a `models:` that is not there is worse than saying nothing. */
-  it("names no file on the MCP path, where the thin route replaced the one it planned", async () => {
+      ./vendo, so the line moves into that path's composition module — and the
+      summary must name THAT file. Naming route.ts here would send the reader
+      to a file with no `models:` in it (the bug this pins). */
+  it("moves the models line into the MCP composition module, and names that file", async () => {
     const root = await mkdtemp(join(tmpdir(), "vendo-init-mcp-models-"));
     cleanup.push(root);
     await mkdir(join(root, "app"), { recursive: true });
@@ -934,11 +934,18 @@ describe("vendo init (zero-question)", () => {
     expect(route).toContain(`import { vendo } from "./vendo";`);
     expect(route).not.toContain("@ai-sdk/");
     expect(route).not.toContain("models:");
-    // Whatever the composition module holds, the pair never carries two.
+
     const composition = await readFile(join(wiringDir, "vendo.ts"), "utf8");
-    expect(`${route}${composition}`.match(/models:/g)?.length ?? 0).toBeLessThanOrEqual(1);
-    expect(`${route}${composition}`.match(/@ai-sdk\/anthropic/g)?.length ?? 0).toBeLessThanOrEqual(1);
-    expect(sink.logs.join("\n")).not.toContain("written into");
+    expect(composition).toContain(`import { anthropic } from "@ai-sdk/anthropic";`);
+    expect(composition).toContain(`  models: { default: anthropic("claude-sonnet-4-6") }, // ANTHROPIC_API_KEY supplies the key`);
+    // One selection per host, across BOTH files init wrote on this path.
+    expect(`${route}${composition}`.match(/models:/g)).toHaveLength(1);
+    expect(`${route}${composition}`.match(/@ai-sdk\/anthropic/g)).toHaveLength(1);
+
+    // The summary names the composition module, not the route it replaced.
+    expect(sink.logs.join("\n")).toContain(
+      `models: anthropic — written into ${join("app", "api", "vendo", "[...vendo]", "vendo.ts")}`,
+    );
   });
 
   /** A Cloud key is not a provider key: its models resolve through the

--- a/packages/vendo/tests/cli/init.test.ts
+++ b/packages/vendo/tests/cli/init.test.ts
@@ -904,6 +904,43 @@ describe("vendo init (zero-question)", () => {
     expect(logs).toContain("No model key yet");
   });
 
+  /** The MCP arm replaces the route this planned for with the thin handler over
+      ./vendo, so the planned models line went with it. The summary may not name
+      a file that does not hold the line — sending the reader to route.ts to
+      find a `models:` that is not there is worse than saying nothing. */
+  it("names no file on the MCP path, where the thin route replaced the one it planned", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vendo-init-mcp-models-"));
+    cleanup.push(root);
+    await mkdir(join(root, "app"), { recursive: true });
+    await writeFile(join(root, "package.json"), JSON.stringify({
+      name: "mcp-host",
+      dependencies: { next: "16.0.0", "@clerk/nextjs": "7.0.0" },
+    }));
+    await writeFile(join(root, "app", "layout.tsx"),
+      "export default function Layout({ children }) { return <html><body>{children}</body></html>; }\n");
+    const sink = output();
+    expect(await run(root, sink, {
+      useCase: "mcp",
+      yes: true,
+      auth: "clerk",
+      baseUrl: "https://app.acme.com",
+      env: { ANTHROPIC_API_KEY: "sk-a" },
+      installProvider: async () => 0,
+    })).toBe(0);
+
+    const wiringDir = join(root, "app", "api", "vendo", "[...vendo]");
+    const route = await readFile(join(wiringDir, "route.ts"), "utf8");
+    // The thin route carries neither half — it composes nothing at all.
+    expect(route).toContain(`import { vendo } from "./vendo";`);
+    expect(route).not.toContain("@ai-sdk/");
+    expect(route).not.toContain("models:");
+    // Whatever the composition module holds, the pair never carries two.
+    const composition = await readFile(join(wiringDir, "vendo.ts"), "utf8");
+    expect(`${route}${composition}`.match(/models:/g)?.length ?? 0).toBeLessThanOrEqual(1);
+    expect(`${route}${composition}`.match(/@ai-sdk\/anthropic/g)?.length ?? 0).toBeLessThanOrEqual(1);
+    expect(sink.logs.join("\n")).not.toContain("written into");
+  });
+
   /** A Cloud key is not a provider key: its models resolve through the
       gateway's own family names, so nothing is written for it. */
   it("writes nothing for a Vendo Cloud key", async () => {

--- a/packages/vendo/tests/cli/init.test.ts
+++ b/packages/vendo/tests/cli/init.test.ts
@@ -858,6 +858,67 @@ describe("vendo init (zero-question)", () => {
     expect(logs.indexOf("Model: explicit")).toBeLessThan(logs.indexOf("Wired ("));
   });
 
+  /** SPEC 4b: a provider key in the environment is a CREDENTIAL now — it no
+      longer selects a model by itself. Init detected the key, so init writes
+      the explicit selection into the composition it authors; without it a host
+      that "just worked" off an ambient key would fail on its first boot. */
+  it("writes the models line and its import once into the route it authors, and names the file", async () => {
+    const root = await fixture();
+    const sink = output();
+    expect(await run(root, sink, {
+      env: { ANTHROPIC_API_KEY: "sk-a" },
+      installProvider: async () => 0,
+    })).toBe(0);
+
+    const routePath = join("app", "api", "vendo", "[...vendo]", "route.ts");
+    const route = await readFile(join(root, routePath), "utf8");
+    expect(route).toContain(`import { anthropic } from "@ai-sdk/anthropic";`);
+    expect(route).toContain(`  models: { default: anthropic("claude-sonnet-4-6") }, // ANTHROPIC_API_KEY supplies the key`);
+    expect(route.match(/@ai-sdk\/anthropic/g)).toHaveLength(1);
+    expect(route.match(/models:/g)).toHaveLength(1);
+
+    expect(sink.logs.join("\n")).toContain(`models: anthropic — written into ${routePath}`);
+  });
+
+  /** A key that only ever lived in .env.local counts the same way — it is the
+      same key the runtime will read, and the ONLY reason the old ambient
+      behaviour looked like it worked. */
+  it("counts a provider key that lives only in .env.local", async () => {
+    const root = await fixture();
+    await writeFile(join(root, ".env.local"), 'ANTHROPIC_API_KEY="sk-ant-local"\n');
+    const sink = output();
+    expect(await run(root, sink, { installProvider: async () => 0 })).toBe(0);
+    const route = await readFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts"), "utf8");
+    expect(route).toContain(`models: { default: anthropic("claude-sonnet-4-6") }`);
+  });
+
+  it("leaves a keyless host's route model-free — no line, no dangling import", async () => {
+    const root = await fixture();
+    const sink = output();
+    expect(await run(root, sink)).toBe(0);
+    const route = await readFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts"), "utf8");
+    expect(route).not.toContain("@ai-sdk/");
+    expect(route).not.toContain("models:");
+    const logs = sink.logs.join("\n");
+    expect(logs).not.toContain("models: anthropic");
+    expect(logs).toContain("No model key yet");
+  });
+
+  /** A Cloud key is not a provider key: its models resolve through the
+      gateway's own family names, so nothing is written for it. */
+  it("writes nothing for a Vendo Cloud key", async () => {
+    const root = await fixture();
+    const sink = output();
+    expect(await run(root, sink, {
+      env: { VENDO_API_KEY: `vnd_${"c".repeat(40)}` },
+      installProvider: async () => 0,
+    })).toBe(0);
+    const route = await readFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts"), "utf8");
+    expect(route).not.toContain("@ai-sdk/");
+    expect(route).not.toContain("models:");
+    expect(sink.logs.join("\n")).not.toContain("written into");
+  });
+
   it("points a keyless host at .env.local and `vendo login`", async () => {
     const root = await fixture();
     const sink = output();


### PR DESCRIPTION
## What

The selection-law change (separate PR) stops a stray provider key in the environment from selecting a model. Without a migration path, a developer who previously "just worked" via an ambient `ANTHROPIC_API_KEY` would hit a boot error on upgrade. This makes `vendo init` write the explicit config line for them, so the explicit-config way out is already taken before they ever run the app.

## Proof — real `vendo init` on a clean host

Generated `app/api/vendo/[...vendo]/route.ts`:

```ts
import { anthropic } from "@ai-sdk/anthropic";
import { createVendo, guard, nextVendoHandler } from "@vendoai/vendo/server";

const vendo = createVendo({
  principal: async () => ({ kind: "user" as const, subject: "demo-user" }),
  models: { default: anthropic("claude-sonnet-4-6") }, // ANTHROPIC_API_KEY supplies the key
  guard: guard({ policy: {} }),
});
```

Closing summary, verbatim: `models: anthropic — written into app/api/vendo/[...vendo]/route.ts`

**Keyless counter-proof:** with no provider key, no `models:` line and no `@ai-sdk/` import are written, and the existing "No model key yet" line still fires.

## Corpus — green

```
Summary: 2/2 layers passing; 0 hard failures.
| taxonomy     | Layer 1 structural | PASS | 7/7 |
| express-host | Layer 1 structural | PASS | 7/7 |
```

Layer 1 is the clean room (no provider key), so the generated route is byte-identical to pre-change.

**Extra seam proof:** the generated route typechecks clean against the real `@vendoai/vendo/server` types and real `@ai-sdk/anthropic` in a scratch host — producer and consumer actually agree rather than each mocking the other.

## A real bug this surfaced

On the MCP path the summary printed `models: anthropic — written into …/route.ts` while the MCP arm had **already replaced that route** with a thin handler — pointing the reader at a file with no `models:` in it. Captured in the log before the fix. `e3d3d8277` makes the line speak only for the file it actually wrote.

## Scope notes

- **Generalised beyond anthropic.** The spec named only anthropic, but `resolveDevCredential` returns three providers — handling one would leave `OPENAI_API_KEY` / `GOOGLE_GENERATIVE_AI_API_KEY` hosts broken by the release with no migration line. Uses the model ids already in `dev-creds/model.ts`; nothing invented. The anthropic bytes are exactly as specified.
- **Written exactly once**, pinned by test at both levels and verified on a real MCP run.
- The Express/custom scaffolds still don't write the line — the spec scoped this to the route and MCP module.

Counts: 152 passed across 4 test files (9 new) · build 13/13 · typecheck clean · dependency-guard OK · portability-gate all legs green · corpus harness units 189/189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`vendo init` now writes an explicit `models.default` line when it detects a provider key, including on the MCP path (in `vendo.ts`), so apps keep working after ambient keys stop selecting a model. The run prints which provider it selected and which file it wrote, only when that file actually contains the line.

- **New Features**
  - Detects `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GOOGLE_GENERATIVE_AI_API_KEY` and writes the import and config using `@ai-sdk/anthropic` (`claude-sonnet-4-6`), `@ai-sdk/openai` (`gpt-5`), or `@ai-sdk/google` (`gemini-2.5-flash`).
  - Writes the line exactly once per host: in Next.js it lives in the route; on the MCP path it lives in the composition module (`app/api/vendo/[...vendo]/vendo.ts`) and the thin route stays clean.
  - Skips writing when no provider key is found or when only `VENDO_API_KEY` is present (Cloud keys resolve models via family names).
  - Reads from the environment and `.env.local`, and never embeds key material in code.

- **Bug Fixes**
  - The closing summary never names a file without the `models` line and points to the MCP composition module when applicable.

<sup>Written for commit 125c273a4c734981d1798dfcbcd8778ae6dc0ce2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

