### PR TITLE
feat(core)!: env keys are credentials, config selects

### DIFF
--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -200,7 +200,9 @@ const defaultStore = (): VendoStore => {
 /** The ladder itself lives in @vendoai/apps (`selectSandbox`) — ONE
  *  implementation, shared with the umbrella's composition seam. This function
  *  is only what an EMPTY ladder means here: a harness that needs a machine and
- *  has none is a boot error, not a turn that dies in front of a user. */
+ *  has none is a boot error, not a turn that dies in front of a user. Both
+ *  messages name the two ways out in the same order the law states them:
+ *  explicit config first, then VENDO_API_KEY. */
 const resolveSandbox = (explicit: SandboxAdapter | undefined): SandboxAdapter => {
   const { adapter } = selectSandbox(explicit, cloudAdapters.sandbox);
   if (adapter !== undefined) return adapter;
@@ -208,13 +210,15 @@ const resolveSandbox = (explicit: SandboxAdapter | undefined): SandboxAdapter =>
     throw new VendoError(
       "not-implemented",
       "A VENDO_API_KEY is set but this build has no Cloud sandbox rung wired. "
-      + "Pass `sandbox: e2b({ apiKey })` or set E2B_API_KEY.",
+      + "Pass a sandbox explicitly — `sandbox: e2b()`, which reads E2B_API_KEY as its credential "
+      + "— or use a build that ships the Cloud sandbox rung for VENDO_API_KEY to fill.",
     );
   }
   throw new VendoError(
     "validation",
-    "This harness runs on a sandbox and none resolved: pass `sandbox: e2b({ apiKey })`, "
-    + "set E2B_API_KEY, or set VENDO_API_KEY for the Cloud pool.",
+    "This harness runs on a sandbox and none resolved: pass one — `sandbox: e2b()`, which reads "
+    + "E2B_API_KEY as its credential — or set VENDO_API_KEY for the Vendo Cloud sandbox pool. "
+    + "An E2B_API_KEY alone no longer selects a sandbox.",
   );
 };
 

--- a/packages/agents/tests/agent.test.ts
+++ b/packages/agents/tests/agent.test.ts
@@ -106,12 +106,14 @@ describe("the sandbox ladder", () => {
     expect(harnessAdapters(harness).sandbox).toBeDefined();
   });
 
-  it("E2B_API_KEY fills the slot when nothing was passed", () => {
+  it("E2B_API_KEY does NOT fill the slot — a key is a credential, not a choice", () => {
+    // The breaking change (selection law): a key in the shell used to compose the
+    // e2b adapter for a harness nobody handed one to. Now it is a boot error that
+    // names the two ways out.
     vi.stubEnv("VENDO_API_KEY", "");
     vi.stubEnv("E2B_API_KEY", "e2b_test");
-    const harness = boxy();
-    agent({ name: "support", harness, store: memoryStore(), guard: fakeGuard() });
-    expect(harnessAdapters(harness).sandbox).toBeDefined();
+    expect(() => agent({ name: "support", harness: boxy(), store: memoryStore(), guard: fakeGuard() }))
+      .toThrow(/runs on a sandbox and none resolved/);
   });
 
   it("a VENDO_API_KEY reaches the Cloud rung — unwired, that is a clear error", () => {
@@ -131,11 +133,17 @@ describe("the sandbox ladder", () => {
     expect(harnessAdapters(harness).sandbox).toBeDefined();
   });
 
-  it("no rung answering is a boot error with every way out named", () => {
+  it("no rung answering is a boot error naming BOTH ways out, config first", () => {
     vi.stubEnv("E2B_API_KEY", "");
     vi.stubEnv("VENDO_API_KEY", "");
-    expect(() => agent({ name: "support", harness: boxy(), store: memoryStore(), guard: fakeGuard() }))
-      .toThrow(/e2b|E2B_API_KEY|VENDO_API_KEY/);
+    const boot = (): unknown =>
+      agent({ name: "support", harness: boxy(), store: memoryStore(), guard: fakeGuard() });
+    // (1) explicit config, (2) VENDO_API_KEY — the order the law states, because
+    // a loose alternation matched the old message that pointed at E2B_API_KEY as
+    // a way out and would have kept passing after the law changed.
+    expect(boot).toThrow(/pass one — `sandbox: e2b\(\)`, which reads E2B_API_KEY as its credential/);
+    expect(boot).toThrow(/or set VENDO_API_KEY for the Vendo Cloud sandbox pool/);
+    expect(boot).toThrow(/An E2B_API_KEY alone no longer selects a sandbox/);
   });
 
   it("a harness that thinks in-process never resolves a sandbox", () => {

--- a/packages/apps/src/server/doors/build-messages.ts
+++ b/packages/apps/src/server/doors/build-messages.ts
@@ -96,9 +96,16 @@ const MODEL_ERROR_PREFIX = /^model generation failed: /;
  *  same swallowing was measured again 2026-08-03 for the 401 lines, where the
  *  generic reason was ALSO wrongly retryable — a revoked key fails identically
  *  on every retry). Anchored to the exact shapes in vendo/dev-creds
- *  (`rejectedKey`, `noModelKey`) so a provider error that merely mentions a key
- *  can never leak through. */
-const MODEL_UNAVAILABLE_SIGNAL = /^(?:[A-Z][A-Z0-9_]* is set but @ai-sdk\/[\w-]+ is not installed in this app|Vendo found no model key|your [A-Za-z]+ API key was rejected \(401\)|VENDO_API_KEY was rejected by the Vendo Cloud model gateway \(401\))/;
+ *  (`rejectedKey`, `NO_CREDENTIAL_MESSAGE`) so a provider error that merely
+ *  mentions a key can never leak through.
+ *
+ *  BYTE-FOR-BYTE COUPLED to those sentences, in another package this one may not
+ *  import: reword a message without reworking this pattern and the actionable
+ *  line silently stops reaching users (it lands only in the operator terminal —
+ *  the 0.4.x defect, twice). The `Vendo has no model.` alternative below is
+ *  `NO_CREDENTIAL_MESSAGE` in `@vendoai/vendo` (dev-creds/model.ts); the seam is
+ *  tested against the real constant in that package's tests/dev-creds/model.test.ts. */
+const MODEL_UNAVAILABLE_SIGNAL = /^(?:[A-Z][A-Z0-9_]* is set but @ai-sdk\/[\w-]+ is not installed in this app|Vendo has no model\.|your [A-Za-z]+ API key was rejected \(401\)|VENDO_API_KEY was rejected by the Vendo Cloud model gateway \(401\))/;
 
 /**
  * Map a generation-turn throw to the short, honest, NON-LEAKY reason persisted

--- a/packages/apps/src/server/escalation/e2b/index.ts
+++ b/packages/apps/src/server/escalation/e2b/index.ts
@@ -10,8 +10,13 @@ const SNAPSHOT_REF_PREFIX = "e2b:v2:";
 export interface E2BSandboxOptions {
   /** E2B API key. When omitted, the SDK reads E2B_API_KEY. */
   apiKey?: string;
-  /** Provider machine lifetime and reconnect timeout, in milliseconds. */
+  /** Provider machine lifetime and reconnect timeout, in milliseconds. When
+   *  omitted, the operator knobs below decide, then DEFAULT_TIMEOUT_MS. */
   timeoutMs?: number;
+  /** @internal Which module the install probe asks about. Tests name a package
+   *  that genuinely is not installed, so the refusal below is exercised over the
+   *  real module resolver rather than by stubbing the probe. */
+  specifier?: string;
 }
 
 type E2BMachine = InstanceType<typeof import("e2b").Sandbox>;
@@ -94,6 +99,24 @@ const decodeSnapshotRef = (snapshotRef: string): Omit<E2BSnapshotState, "version
   } catch {
     throw new VendoError("validation", "E2B snapshot references must start with e2b:v2: and carry a valid payload");
   }
+};
+
+const environment = (name: string): string | undefined => {
+  if (typeof process === "undefined") return undefined;
+  const value = process.env[name]?.trim();
+  return value === undefined || value === "" ? undefined : value;
+};
+
+/** Operator knob for the provider machine lifetime: the default 5-minute TTL
+ *  kills a box mid-way through a long in-box agent build. Explicit
+ *  VENDO_E2B_TIMEOUT_MS wins; otherwise a raised box-edit budget implies a
+ *  matching machine lifetime (budget + 5-minute slack), so the two knobs cannot
+ *  silently disagree. An inline `timeoutMs` outranks both — it is config. */
+const envTimeoutMs = (): number | undefined => {
+  const configured = Number(environment("VENDO_E2B_TIMEOUT_MS"));
+  if (Number.isFinite(configured) && configured > 0) return configured;
+  const editBudget = Number(environment("VENDO_BOX_EDIT_TIMEOUT_MS"));
+  return Number.isFinite(editBudget) && editBudget > 0 ? editBudget + 5 * 60_000 : undefined;
 };
 
 const networkOptions = (allowedDomains: string[] | undefined, allTraffic: string) =>
@@ -195,7 +218,20 @@ const loadE2b = async (): Promise<E2BModule> => {
  * the box). The optional SDK is imported only when create/resume is called.
  */
 export const e2bSandbox = (options: E2BSandboxOptions = {}): SandboxAdapter => {
-  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  // Half a BYO sandbox is a MISCONFIG, not a fallback (0.4.4 defect C): an
+  // adapter whose first create() dies on a missing module hides the missing
+  // install until a box boot fails somewhere else entirely. Asking HERE — where
+  // the host explicitly chose e2b — is the only place the answer is unambiguous:
+  // selection is config now, so a bare E2B_API_KEY never reaches this code.
+  if (!e2bInstalled(options.specifier)) {
+    throw new VendoError(
+      "validation",
+      "e2bSandbox() needs the \"e2b\" package, which does not resolve from this project. "
+      + "Install it (npm install e2b), or remove sandbox: e2bSandbox() to use the Vendo Cloud "
+      + "sandbox with VENDO_API_KEY.",
+    );
+  }
+  const timeoutMs = options.timeoutMs ?? envTimeoutMs() ?? DEFAULT_TIMEOUT_MS;
 
   const wrap = (
     sandbox: E2BMachine,

--- a/packages/apps/src/server/escalation/sandbox-ladder.ts
+++ b/packages/apps/src/server/escalation/sandbox-ladder.ts
@@ -8,34 +8,36 @@
  * the lowest package BOTH consumers may depend on — nothing in `@vendoai/agents`
  * may import `@vendoai/vendo` (the agents-v0 dependency law).
  *
+ * SELECTION LAW: env keys are credentials, config selects. `VENDO_API_KEY` is
+ * the only blessed default-filler for a slot the host left unset — a
+ * third-party provider key lying around in the environment selects nothing.
+ *
  * Precedence, top to bottom:
  *   1. an explicitly passed adapter always wins (the hard BYO rule);
- *   2. E2B_API_KEY, the BYO sandbox env — but only when the optional `e2b` SDK
- *      is actually loadable. Half a BYO sandbox is a MISCONFIG, not a
- *      fallback: silently riding Cloud (or going dark) hides the missing
- *      install until the first box boot dies somewhere else entirely (0.4.4
- *      defect C). Trimmed, because a whitespace-only value is not a key —
- *      `vendo doctor`'s E-LIVE-007 check trims before deciding one is present,
- *      and disagreeing with doctor about whether the operator set a key means
- *      one of them is lying to the operator;
- *   3. VENDO_API_KEY defaults the Cloud managed pool, for a slot the caller
- *      left unset and with no BYO sandbox env present — so a Vendo key never
- *      shadows an existing provider account;
- *   4. nothing. What "nothing" MEANS belongs to the caller, and is the one
+ *   2. VENDO_API_KEY defaults the Cloud managed pool, for a slot the caller
+ *      left unset;
+ *   3. nothing. What "nothing" MEANS belongs to the caller, and is the one
  *      thing the two consumers legitimately disagree about: the umbrella's
  *      dark venue (server apps answer sandbox-unavailable, chat is unaffected)
- *      versus the agent runtime's boot error naming every way out.
+ *      versus the agent runtime's boot error naming both ways out.
+ *
+ * `E2B_API_KEY` is NOT a rung. It is a credential, consumed only by an explicit
+ * `e2bSandbox()` when no `apiKey` was passed inline — so a stray key in a shell
+ * can no longer flip a deployment's execution venue (0.4.4 defect C's real
+ * cause), and the "is the SDK installed?" refusal lives where the host actually
+ * chose e2b, in `e2bSandbox()` itself.
  *
  * The Cloud rung is a PARAMETER, not an env branch here, because its
  * implementation speaks the console wire and therefore ships in
- * `@vendoai/vendo`, which this package may not import. Unset, rung 3 simply
+ * `@vendoai/vendo`, which this package may not import. Unset, rung 2 simply
  * does not light — a build with no Cloud adapter has no Cloud sandbox.
  */
-import { VendoError } from "@vendoai/core";
-import { e2bInstalled, e2bSandbox } from "./e2b/index.js";
 import type { SandboxAdapter } from "./sandbox.js";
 
-/** Which rung answered — reported verbatim on the umbrella's /status. */
+/** Which rung answered — reported verbatim on the umbrella's /status. `"e2b"`
+ *  is no longer produced by this function (an explicit `e2bSandbox()` is
+ *  `"custom"` like any other host adapter); it stays in the union because
+ *  /status readers still meet it on older wires. */
 export type SandboxVenue = "e2b" | "cloud" | "custom" | false;
 
 export interface SandboxSelection {
@@ -53,43 +55,11 @@ const environment = (name: string): string | undefined => {
   return value === undefined || value === "" ? undefined : value;
 };
 
-/** Operator knob for the provider machine lifetime: the adapter's default
- *  5-minute TTL kills a box mid-way through a long in-box agent build.
- *  Explicit VENDO_E2B_TIMEOUT_MS wins; otherwise a raised box-edit budget
- *  implies a matching machine lifetime (budget + 5-minute slack), so the two
- *  knobs cannot silently disagree. */
-const e2bTimeoutMs = (): number | undefined => {
-  const configured = Number(environment("VENDO_E2B_TIMEOUT_MS"));
-  if (Number.isFinite(configured) && configured > 0) return configured;
-  const editBudget = Number(environment("VENDO_BOX_EDIT_TIMEOUT_MS"));
-  return Number.isFinite(editBudget) && editBudget > 0 ? editBudget + 5 * 60_000 : undefined;
-};
-
 export function selectSandbox(
   configured: SandboxAdapter | undefined,
   cloud?: CloudSandboxRung,
-  /** Which module the "is the BYO SDK usable?" probe asks about. Defaults to
-   *  `e2b`; this is the same specifier seam `e2bInstalled` already takes, so
-   *  rung 2's misconfig refusal can be exercised by naming a package that
-   *  genuinely is not installed rather than by stubbing the probe. */
-  e2bSpecifier?: string,
 ): SandboxSelection {
   if (configured !== undefined) return { adapter: configured, venue: "custom" };
-
-  const e2bApiKey = environment("E2B_API_KEY");
-  if (e2bApiKey !== undefined) {
-    if (!e2bInstalled(e2bSpecifier)) {
-      throw new VendoError(
-        "validation",
-        "E2B_API_KEY is set but the e2b package is not installed — install e2b, or unset E2B_API_KEY to use another sandbox",
-      );
-    }
-    const timeoutMs = e2bTimeoutMs();
-    return {
-      adapter: e2bSandbox({ apiKey: e2bApiKey, ...(timeoutMs === undefined ? {} : { timeoutMs }) }),
-      venue: "e2b",
-    };
-  }
 
   const apiKey = environment("VENDO_API_KEY");
   if (apiKey !== undefined && cloud !== undefined) {

--- a/packages/apps/tests/build-failure.test.ts
+++ b/packages/apps/tests/build-failure.test.ts
@@ -308,9 +308,18 @@ describe("buildFailureReason", () => {
     expect(buildFailureReason(new VendoError("validation", "model could not produce a valid app", [
       `model generation failed: ${installLine}`,
     ]))).toEqual({ reason: installLine, retryable: false });
-    const noKeyLine = "Vendo found no model key. Set ANTHROPIC_API_KEY / OPENAI_API_KEY / GOOGLE_GENERATIVE_AI_API_KEY "
-      + "in .env.local (with the matching @ai-sdk provider installed), or run `vendo login` for a "
-      + "free dev key. Production always needs a real server-side key.";
+    // THE COUPLING, from the consumer's side. This is NO_CREDENTIAL_MESSAGE in
+    // @vendoai/vendo (dev-creds/model.ts), which this package may not import, so
+    // the literal is pinned from both sides: here against the real
+    // MODEL_UNAVAILABLE_SIGNAL, and there against the real constant
+    // (tests/dev-creds/model.test.ts, "keeps the exact bytes @vendoai/apps'
+    // MODEL_UNAVAILABLE_SIGNAL anchors on"). Reword the message and that one
+    // fails; retune the pattern and this one does. Neither can drift quietly —
+    // which the old wording did, and the actionable line then reaches only the
+    // operator's terminal (0.4.x, measured twice).
+    const noKeyLine = "Vendo has no model. Pass one — models: { default: anthropic(\"claude-sonnet-4-6\") } in "
+      + "createVendo — or set VENDO_API_KEY for the Vendo Cloud gateway (`vendo login` mints a free "
+      + "dev key). A provider key alone no longer selects a model; Vendo never picks a provider for you.";
     expect(buildFailureReason(new Error(noKeyLine))).toEqual({ reason: noKeyLine, retryable: false });
   });
 

--- a/packages/apps/tests/e2b/e2b.test.ts
+++ b/packages/apps/tests/e2b/e2b.test.ts
@@ -1,3 +1,4 @@
+import { VendoError } from "@vendoai/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { e2bSandbox } from "../../src/server/escalation/e2b/index.js";
 
@@ -308,5 +309,75 @@ describe("e2bSandbox", () => {
     expect(sdk.sandbox.kill).not.toHaveBeenCalled();
     await created.destroy();
     expect(sdk.sandbox.kill).toHaveBeenCalledOnce();
+  });
+});
+
+/**
+ * What the sandbox ladder used to own, moved here by the SELECTION LAW: since
+ * E2B_API_KEY no longer selects a venue, the only place that knows a host chose
+ * e2b is `e2bSandbox()` itself — so the install refusal and the machine-lifetime
+ * knobs live where the choice was made.
+ */
+describe("e2bSandbox's install refusal (0.4.4 defect C, moved off the ladder)", () => {
+  it("refuses at construction when the e2b package does not resolve", () => {
+    // The probe is `e2bInstalled(specifier)` over the REAL module resolver, so an
+    // absent package is spelled the honest way — by naming one that genuinely is
+    // not installed — rather than by stubbing the probe.
+    const attempt = (): unknown => e2bSandbox({ apiKey: "key_test", specifier: "e2b-not-a-real-package" });
+
+    expect(attempt).toThrow(VendoError);
+    // Both ways out, in the order the law states them: make the explicit config
+    // work, then VENDO_API_KEY.
+    expect(attempt).toThrow(/e2bSandbox\(\) needs the "e2b" package, which does not resolve from this project/);
+    expect(attempt).toThrow(/Install it \(npm install e2b\)/);
+    expect(attempt).toThrow(/remove sandbox: e2bSandbox\(\) to use the Vendo Cloud sandbox with VENDO_API_KEY/);
+  });
+
+  it("does not refuse when the package is really there", () => {
+    expect(() => e2bSandbox({ apiKey: "key_test" })).not.toThrow();
+  });
+});
+
+describe("e2bSandbox's machine-lifetime knobs", () => {
+  /** The knobs are real env, and the assertion is the REAL timeout the provider
+   *  is handed — the old ladder tests could only assert "still lands on e2b". */
+  const timeoutFor = async (
+    env: Record<string, string>,
+    options: Parameters<typeof e2bSandbox>[0] = { apiKey: "key_test" },
+  ): Promise<unknown> => {
+    for (const name of ["VENDO_E2B_TIMEOUT_MS", "VENDO_BOX_EDIT_TIMEOUT_MS"]) vi.stubEnv(name, "");
+    for (const [name, value] of Object.entries(env)) vi.stubEnv(name, value);
+    try {
+      await e2bSandbox(options).create({ env: {} });
+      return (sdk.create.mock.calls.at(-1)?.[0] as { timeoutMs?: unknown }).timeoutMs;
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  };
+
+  it("takes an explicit VENDO_E2B_TIMEOUT_MS", async () => {
+    await expect(timeoutFor({ VENDO_E2B_TIMEOUT_MS: "900000" })).resolves.toBe(900_000);
+  });
+
+  it("derives a machine lifetime from a raised box-edit budget (budget + 5-minute slack)", async () => {
+    await expect(timeoutFor({ VENDO_BOX_EDIT_TIMEOUT_MS: "600000" })).resolves.toBe(900_000);
+  });
+
+  it("lets the explicit knob win over the derived one, so the two cannot disagree", async () => {
+    await expect(timeoutFor({ VENDO_E2B_TIMEOUT_MS: "120000", VENDO_BOX_EDIT_TIMEOUT_MS: "600000" }))
+      .resolves.toBe(120_000);
+  });
+
+  it("ignores a non-numeric or non-positive knob instead of throwing", async () => {
+    await expect(timeoutFor({ VENDO_E2B_TIMEOUT_MS: "not-a-number" })).resolves.toBe(300_000);
+    await expect(timeoutFor({ VENDO_E2B_TIMEOUT_MS: "0" })).resolves.toBe(300_000);
+    await expect(timeoutFor({ VENDO_BOX_EDIT_TIMEOUT_MS: "-1" })).resolves.toBe(300_000);
+  });
+
+  it("an inline timeoutMs outranks both knobs — it is config, they are environment", async () => {
+    await expect(timeoutFor(
+      { VENDO_E2B_TIMEOUT_MS: "900000" },
+      { apiKey: "key_test", timeoutMs: 42_000 },
+    )).resolves.toBe(42_000);
   });
 });

--- a/packages/apps/tests/sandbox-ladder.test.ts
+++ b/packages/apps/tests/sandbox-ladder.test.ts
@@ -4,16 +4,16 @@
  * (`agent({ sandbox })`).
  *
  * Every rung here is a promise the docs make to an operator, and each one is a
- * different way to get a deployment silently wrong: a Vendo key shadowing an
- * existing E2B account, a half-installed BYO sandbox riding Cloud instead of
- * saying so, a whitespace key that `vendo doctor` and this function disagree
- * about. So the ladder is tested as a ladder — precedence and all — rather than
- * one rung at a time.
+ * different way to get a deployment silently wrong. The biggest one is gone
+ * since the SELECTION LAW: E2B_API_KEY is a credential, not a rung, so a key
+ * lying in a shell can no longer choose a deployment's execution venue. What is
+ * left is short enough to state in one line — explicit adapter, VENDO_API_KEY,
+ * dark — and it is still tested as a ladder, precedence and all, because the
+ * precedence is the promise.
  *
- * The env is driven for real (`vi.stubEnv`) and `e2bInstalled()` really probes
- * the installed `e2b` package: nothing here stubs the thing it is asking about.
+ * The env is driven for real (`vi.stubEnv`); nothing here stubs the thing it is
+ * asking about.
  */
-import { VendoError } from "@vendoai/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SandboxAdapter } from "../src/server/escalation/sandbox.js";
 import { selectSandbox, type CloudSandboxRung } from "../src/server/escalation/sandbox-ladder.js";
@@ -22,7 +22,8 @@ afterEach(() => {
   vi.unstubAllEnvs();
 });
 
-/** The four env vars the ladder reads. Cleared per case so a developer's own
+/** Every env var this file speaks about — the two the ladder still reads, plus
+ *  the ones it deliberately no longer does. Cleared per case so a developer's own
  *  shell (a real E2B_API_KEY is common) cannot decide the answer. */
 const clearLadderEnv = (): void => {
   for (const name of ["E2B_API_KEY", "VENDO_API_KEY", "VENDO_CLOUD_URL", "VENDO_E2B_TIMEOUT_MS", "VENDO_BOX_EDIT_TIMEOUT_MS"]) {
@@ -68,72 +69,55 @@ describe("rung 1 — an explicitly passed adapter always wins (the hard BYO rule
   });
 });
 
-describe("rung 2 — E2B_API_KEY, the BYO sandbox env", () => {
-  it("composes the e2b adapter and reports the e2b venue", () => {
+describe("E2B_API_KEY is a CREDENTIAL, not a rung (the selection law)", () => {
+  // The breaking change, stated as tests. Before this, a key left in a shell —
+  // or inherited by a container — selected the e2b venue for the whole
+  // deployment, which is how 0.4.4 defect C shipped: nobody wrote it down, so
+  // nobody could see it was wrong.
+  it("a stray E2B_API_KEY selects nothing at all — the venue stays dark", () => {
     clearLadderEnv();
     vi.stubEnv("E2B_API_KEY", "e2b_key");
 
-    const selection = selectSandbox(undefined);
-
-    expect(selection.venue).toBe("e2b");
-    expect(selection.adapter).toBeDefined();
+    expect(selectSandbox(undefined)).toEqual({ adapter: undefined, venue: false });
   });
 
-  it("beats VENDO_API_KEY, so a Vendo key never shadows an existing provider account", () => {
+  it("a stray E2B_API_KEY does NOT outrank VENDO_API_KEY — Cloud fills the unset slot", () => {
     clearLadderEnv();
     vi.stubEnv("E2B_API_KEY", "e2b_key");
     vi.stubEnv("VENDO_API_KEY", "vendo_key");
     const cloud = cloudRung();
 
-    expect(selectSandbox(undefined, cloud).venue).toBe("e2b");
-    expect(cloud.calls).toEqual([]);
+    expect(selectSandbox(undefined, cloud).venue).toBe("cloud");
+    expect(cloud.calls).toEqual([{ apiKey: "vendo_key" }]);
   });
 
-  it("does NOT treat a whitespace-only key as a key — the same trim `vendo doctor` does", () => {
-    // Disagreeing with doctor's E-LIVE-007 about whether the operator set a key
-    // means one of the two is lying to the operator.
-    clearLadderEnv();
-    vi.stubEnv("E2B_API_KEY", "   ");
+  it("no shape of E2B_API_KEY changes the answer — set, whitespace, or empty", () => {
+    for (const value of ["e2b_key", "   ", "  \t ", ""]) {
+      clearLadderEnv();
+      vi.stubEnv("E2B_API_KEY", value);
+      expect(selectSandbox(undefined).venue, value).toBe(false);
 
-    expect(selectSandbox(undefined).venue).toBe(false);
+      clearLadderEnv();
+      vi.stubEnv("E2B_API_KEY", value);
+      vi.stubEnv("VENDO_API_KEY", "vendo_key");
+      expect(selectSandbox(undefined, cloudRung()).venue, value).toBe("cloud");
+    }
   });
 
-  it("falls to Cloud when the E2B key is whitespace, rather than refusing", () => {
-    clearLadderEnv();
-    vi.stubEnv("E2B_API_KEY", "  \t ");
-    vi.stubEnv("VENDO_API_KEY", "vendo_key");
-
-    expect(selectSandbox(undefined, cloudRung()).venue).toBe("cloud");
-  });
-});
-
-describe("rung 2's machine lifetime knobs", () => {
-  // Not observable on the selection object, so these assert the ladder ACCEPTS
-  // each spelling and still lands on e2b — the regression they guard is a throw
-  // or a dropped rung from a malformed value, not a specific timeout number.
-  const e2bWith = (env: Record<string, string>): ReturnType<typeof selectSandbox> => {
-    clearLadderEnv();
-    vi.stubEnv("E2B_API_KEY", "e2b_key");
-    for (const [name, value] of Object.entries(env)) vi.stubEnv(name, value);
-    return selectSandbox(undefined);
-  };
-
-  it("takes an explicit VENDO_E2B_TIMEOUT_MS", () => {
-    expect(e2bWith({ VENDO_E2B_TIMEOUT_MS: "900000" }).venue).toBe("e2b");
-  });
-
-  it("derives a machine lifetime from a raised box-edit budget", () => {
-    expect(e2bWith({ VENDO_BOX_EDIT_TIMEOUT_MS: "600000" }).venue).toBe("e2b");
-  });
-
-  it("ignores a non-numeric or non-positive knob instead of throwing", () => {
-    expect(e2bWith({ VENDO_E2B_TIMEOUT_MS: "not-a-number" }).venue).toBe("e2b");
-    expect(e2bWith({ VENDO_E2B_TIMEOUT_MS: "0" }).venue).toBe("e2b");
-    expect(e2bWith({ VENDO_BOX_EDIT_TIMEOUT_MS: "-1" }).venue).toBe("e2b");
+  it("neither do the e2b machine-lifetime knobs, which are the adapter's business now", () => {
+    // VENDO_E2B_TIMEOUT_MS / VENDO_BOX_EDIT_TIMEOUT_MS moved into e2bSandbox()
+    // with the credential (tests/e2b/e2b.test.ts asserts the real timeout they
+    // produce). Here they must not resurrect a rung.
+    for (const knob of ["VENDO_E2B_TIMEOUT_MS", "VENDO_BOX_EDIT_TIMEOUT_MS"]) {
+      clearLadderEnv();
+      vi.stubEnv("E2B_API_KEY", "e2b_key");
+      vi.stubEnv(knob, "900000");
+      expect(selectSandbox(undefined).venue, knob).toBe(false);
+    }
   });
 });
 
-describe("rung 3 — VENDO_API_KEY defaults the Cloud managed pool", () => {
+describe("rung 2 — VENDO_API_KEY defaults the Cloud managed pool", () => {
   it("builds the Cloud rung with the console credential", () => {
     clearLadderEnv();
     vi.stubEnv("VENDO_API_KEY", "vendo_key");
@@ -177,7 +161,7 @@ describe("rung 3 — VENDO_API_KEY defaults the Cloud managed pool", () => {
   });
 });
 
-describe("rung 4 — nothing", () => {
+describe("rung 3 — nothing", () => {
   it("answers with no adapter and no venue, leaving the meaning to the caller", () => {
     clearLadderEnv();
 
@@ -191,34 +175,16 @@ describe("rung 4 — nothing", () => {
     expect(selectSandbox(undefined, cloud)).toEqual({ adapter: undefined, venue: false });
     expect(cloud.calls).toEqual([]);
   });
-});
 
-describe("half a BYO sandbox is a MISCONFIG, not a fallback (0.4.4 defect C)", () => {
-  it("refuses at boot when E2B_API_KEY is set but the e2b package is absent", () => {
-    // The probe is `e2bInstalled(specifier)` over the real module resolver, so
-    // an absent package is spelled here the honest way — by asking about one
-    // that genuinely is not installed — rather than by stubbing the probe.
-    clearLadderEnv();
-    vi.stubEnv("E2B_API_KEY", "e2b_key");
-
-    const attempt = (): unknown => selectSandbox(undefined, cloudRung(), "e2b-not-a-real-package");
-
-    expect(attempt).toThrow(VendoError);
-    expect(attempt).toThrow(/E2B_API_KEY is set but the e2b package is not installed/);
-    // The remedy names BOTH ways out, because either is legitimate.
-    expect(attempt).toThrow(/install e2b/);
-    expect(attempt).toThrow(/unset E2B_API_KEY/);
-  });
-
-  it("does NOT quietly fall through to Cloud when the install is missing", () => {
+  it("never throws — the ladder has no misconfiguration left to refuse", () => {
+    // Half a BYO sandbox (0.4.4 defect C) used to be refused HERE, because the
+    // env chose the venue. It is refused in e2bSandbox() now, where the host
+    // actually asked for e2b (tests/e2b/e2b.test.ts). Selection itself is total.
     clearLadderEnv();
     vi.stubEnv("E2B_API_KEY", "e2b_key");
     vi.stubEnv("VENDO_API_KEY", "vendo_key");
-    const cloud = cloudRung();
 
-    expect(() => selectSandbox(undefined, cloud, "e2b-not-a-real-package")).toThrow(VendoError);
-    // Silently riding Cloud is exactly the defect: it hides the missing install
-    // until the first box boot dies somewhere else entirely.
-    expect(cloud.calls).toEqual([]);
+    expect(() => selectSandbox(undefined)).not.toThrow();
+    expect(() => selectSandbox(undefined, cloudRung())).not.toThrow();
   });
 });

--- a/packages/harnesses/src/claude-code/index.ts
+++ b/packages/harnesses/src/claude-code/index.ts
@@ -142,12 +142,27 @@ export interface ClaudeCodeDeps
   sandbox?: SandboxAdapterLike;
 }
 
-/** The recorded v0 inference exception (design §9): a boxed harness must reach a
- *  model to think, and that is the ONLY credential in the machine. */
+/**
+ * The recorded v0 inference exception (design §9): a boxed harness must reach a
+ * model to think, and that is the ONLY credential in the machine.
+ *
+ * SELECTION LAW, the same one `boxInference()` in the umbrella obeys: the
+ * explicit VENDO_INFERENCE_URL+KEY pair — which is what the box env door sets —
+ * wins; otherwise VENDO_API_KEY funds the box's model through the console's
+ * Anthropic-compatible gateway at `<console>/api/v1`; otherwise the box gets no
+ * inference credential at all.
+ *
+ * A stray ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL selects NOTHING. It used to
+ * outrank both rungs, so a provider key sitting in the deployment's environment
+ * silently decided which account every box billed. Naming an own endpoint is
+ * still fully supported — as the explicit pair, which is config.
+ */
 export function inferenceEnv(): Record<string, string> {
   const source = globalThis.process?.env ?? {};
-  let key = source["ANTHROPIC_API_KEY"] ?? source["VENDO_INFERENCE_KEY"];
-  let url = source["ANTHROPIC_BASE_URL"] ?? source["VENDO_INFERENCE_URL"];
+  const set = (name: string): string | undefined => {
+    const value = source[name];
+    return value === undefined || value === "" ? undefined : value;
+  };
   const env: Record<string, string> = {
     // Nothing the CLI reaches for on the side: its telemetry and update hosts are
     // not on the box's allowlist (`boxEgress` below), so those calls fail rather
@@ -155,28 +170,31 @@ export function inferenceEnv(): Record<string, string> {
     CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
     DISABLE_AUTOUPDATER: "1",
   };
-  // The third rung, mirroring server.ts's `boxInference()`: no Anthropic
-  // credential and no pre-resolved gateway means VENDO_API_KEY — the same key
-  // that provisions the Cloud machine — funds the box's model through the
-  // console's Anthropic-compatible gateway at `<console>/api/v1`. The gateway
-  // serves the vendo model family as literal ids, so the DEFAULT model is
-  // pinned to the family name — the SDK's own default is a raw claude-* id the
-  // gateway would grace-remap. Only the default: an explicit `options.model`
-  // rides the session-open payload, which beats ANTHROPIC_MODEL.
-  const cloudKey = source["VENDO_API_KEY"];
-  if ((key === undefined || key === "") && (url === undefined || url === "")
-    && cloudKey !== undefined && cloudKey !== "") {
-    const cloudUrl = source["VENDO_CLOUD_URL"];
-    const base = (cloudUrl === undefined || cloudUrl === "" ? "https://console.vendo.run" : cloudUrl)
-      .replace(/\/+$/, "");
+  // The PAIR, both halves or neither: half an endpoint is a misconfiguration, and
+  // quietly completing it from somewhere else is how a box ends up billing an
+  // account nobody chose.
+  const pairKey = set("VENDO_INFERENCE_KEY");
+  const pairUrl = set("VENDO_INFERENCE_URL");
+  const cloudKey = set("VENDO_API_KEY");
+  let key: string | undefined;
+  let url: string | undefined;
+  if (pairKey !== undefined && pairUrl !== undefined) {
+    key = pairKey;
+    url = pairUrl;
+  } else if (cloudKey !== undefined) {
+    const base = (set("VENDO_CLOUD_URL") ?? "https://console.vendo.run").replace(/\/+$/, "");
     key = cloudKey;
     url = base.endsWith("/api/v1") ? base : `${base}/api/v1`;
+    // The gateway serves the vendo model family as literal ids, so the DEFAULT
+    // model is pinned to the family name — the SDK's own default is a raw
+    // claude-* id the gateway would grace-remap. Only the default: an explicit
+    // `options.model` rides the session-open payload, which beats ANTHROPIC_MODEL.
     env["ANTHROPIC_MODEL"] = "vendo";
   }
-  if (key !== undefined && key !== "") env["ANTHROPIC_API_KEY"] = key;
-  if (url !== undefined && url !== "") {
-    env["ANTHROPIC_BASE_URL"] = url.replace(/\/+$/, "").replace(/\/v1$/, "");
-  }
+  if (key === undefined || url === undefined) return env;
+  env["ANTHROPIC_API_KEY"] = key;
+  // The bare origin: the SDK re-appends /v1 and wants no trailing slash.
+  env["ANTHROPIC_BASE_URL"] = url.replace(/\/+$/, "").replace(/\/v1$/, "");
   return env;
 }
 

--- a/packages/harnesses/tests/claude-code/claude-code.test.ts
+++ b/packages/harnesses/tests/claude-code/claude-code.test.ts
@@ -387,14 +387,16 @@ describe("options — declared, then overridable per turn", () => {
 describe("E7 · the credential law — build list item 8", () => {
   test("only the recorded v0 inference exception enters the machine", () => {
     const env = withEnv({
-      ANTHROPIC_API_KEY: "sk-test",
-      ANTHROPIC_BASE_URL: "https://gateway.example/v1/",
+      VENDO_INFERENCE_KEY: "gw-key",
+      VENDO_INFERENCE_URL: "https://gateway.example/v1/",
+      ANTHROPIC_API_KEY: "sk-should-never-travel",
+      ANTHROPIC_BASE_URL: "https://api.anthropic.com",
       E2B_API_KEY: "e2b-should-never-travel",
       DATABASE_URL: "postgres://should-never-travel",
       VENDO_API_KEY: "vnd-should-never-travel",
     }, inferenceEnv);
     expect(env).toEqual({
-      ANTHROPIC_API_KEY: "sk-test",
+      ANTHROPIC_API_KEY: "gw-key",
       // The bare origin: the SDK wants no /v1 and no trailing slash.
       ANTHROPIC_BASE_URL: "https://gateway.example",
       CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
@@ -428,6 +430,50 @@ describe("E7 · the credential law — build list item 8", () => {
     ]);
   });
 
+  // The SELECTION LAW's breaking change on this door. ANTHROPIC_* used to outrank
+  // BOTH rungs, so a provider key or endpoint sitting in the deployment's
+  // environment silently decided which account every box billed.
+  test("a stray ANTHROPIC_API_KEY selects nothing — it never reaches the box", () => {
+    const env = withEnv({
+      ANTHROPIC_API_KEY: "sk-test",
+      ANTHROPIC_BASE_URL: undefined,
+      VENDO_INFERENCE_KEY: undefined,
+      VENDO_INFERENCE_URL: undefined,
+      VENDO_API_KEY: undefined,
+    }, inferenceEnv);
+    expect(Object.keys(env).sort()).toEqual([
+      "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
+      "DISABLE_AUTOUPDATER",
+    ]);
+  });
+
+  test("a stray ANTHROPIC_BASE_URL selects nothing either", () => {
+    const env = withEnv({
+      ANTHROPIC_API_KEY: undefined,
+      ANTHROPIC_BASE_URL: "https://gateway.example",
+      VENDO_INFERENCE_KEY: undefined,
+      VENDO_INFERENCE_URL: undefined,
+      VENDO_API_KEY: undefined,
+    }, inferenceEnv);
+    expect(env["ANTHROPIC_BASE_URL"]).toBeUndefined();
+  });
+
+  test("half the pair selects nothing — an endpoint is both halves or neither", () => {
+    for (const half of [
+      { VENDO_INFERENCE_KEY: "gw-key", VENDO_INFERENCE_URL: undefined },
+      { VENDO_INFERENCE_KEY: undefined, VENDO_INFERENCE_URL: "https://gateway.example" },
+    ]) {
+      const env = withEnv({
+        ANTHROPIC_API_KEY: undefined,
+        ANTHROPIC_BASE_URL: undefined,
+        VENDO_API_KEY: undefined,
+        ...half,
+      }, inferenceEnv);
+      expect(env["ANTHROPIC_API_KEY"]).toBeUndefined();
+      expect(env["ANTHROPIC_BASE_URL"]).toBeUndefined();
+    }
+  });
+
   test("VENDO_API_KEY is the third rung — the box thinks through the Vendo Cloud gateway", () => {
     const env = withEnv({
       ANTHROPIC_API_KEY: undefined,
@@ -459,19 +505,9 @@ describe("E7 · the credential law — build list item 8", () => {
     expect(env["ANTHROPIC_BASE_URL"]).toBe("https://cloud.example/api");
   });
 
-  test("the Cloud rung yields to every higher rung — and an empty string counts as absent", () => {
-    // An explicit Anthropic key wins; no gateway pin rides along.
-    const anthropic = withEnv({
-      ANTHROPIC_API_KEY: "sk-test",
-      ANTHROPIC_BASE_URL: undefined,
-      VENDO_INFERENCE_KEY: undefined,
-      VENDO_INFERENCE_URL: undefined,
-      VENDO_API_KEY: "vnd-key",
-    }, inferenceEnv);
-    expect(anthropic["ANTHROPIC_API_KEY"]).toBe("sk-test");
-    expect(anthropic["ANTHROPIC_MODEL"]).toBeUndefined();
-
-    // So does a pre-resolved VENDO_INFERENCE_* gateway.
+  test("the Cloud rung yields only to the explicit pair — and an empty string counts as absent", () => {
+    // A pre-resolved VENDO_INFERENCE_* gateway is the one thing above it; no
+    // gateway model pin rides along, because the host chose the endpoint.
     const preResolved = withEnv({
       ANTHROPIC_API_KEY: undefined,
       ANTHROPIC_BASE_URL: undefined,
@@ -482,20 +518,26 @@ describe("E7 · the credential law — build list item 8", () => {
     expect(preResolved["ANTHROPIC_API_KEY"]).toBe("gw-key");
     expect(preResolved["ANTHROPIC_MODEL"]).toBeUndefined();
 
-    // A bare BYO endpoint (URL, no key — mTLS/proxy auth) is an own credential
-    // too: routing it through Vendo's gateway would silently rebill the org.
-    const byoEndpoint = withEnv({
-      ANTHROPIC_API_KEY: undefined,
-      ANTHROPIC_BASE_URL: "https://gateway.example",
-      VENDO_INFERENCE_KEY: undefined,
-      VENDO_INFERENCE_URL: undefined,
-      VENDO_API_KEY: "vnd-key",
-    }, inferenceEnv);
-    expect(byoEndpoint["ANTHROPIC_API_KEY"]).toBeUndefined();
-    expect(byoEndpoint["ANTHROPIC_MODEL"]).toBeUndefined();
-    expect(byoEndpoint["ANTHROPIC_BASE_URL"]).toBe("https://gateway.example");
+    // A stray provider key or endpoint does NOT yield to it — and does not win:
+    // the Cloud rung answers, because it is the only thing anyone configured.
+    // (Before the law, either ANTHROPIC_* var silently rebilled the org.)
+    for (const stray of [
+      { ANTHROPIC_API_KEY: "sk-test", ANTHROPIC_BASE_URL: undefined },
+      { ANTHROPIC_API_KEY: undefined, ANTHROPIC_BASE_URL: "https://gateway.example" },
+    ]) {
+      const env = withEnv({
+        VENDO_INFERENCE_KEY: undefined,
+        VENDO_INFERENCE_URL: undefined,
+        VENDO_API_KEY: "vnd-key",
+        VENDO_CLOUD_URL: undefined,
+        ...stray,
+      }, inferenceEnv);
+      expect(env["ANTHROPIC_API_KEY"]).toBe("vnd-key");
+      expect(env["ANTHROPIC_BASE_URL"]).toBe("https://console.vendo.run/api");
+      expect(env["ANTHROPIC_MODEL"]).toBe("vendo");
+    }
 
-    // "" is absent, exactly as the higher rungs already treat it.
+    // "" is absent, exactly as the pair already treats it.
     const blanks = withEnv({
       ANTHROPIC_API_KEY: "",
       ANTHROPIC_BASE_URL: "",

--- a/packages/vendo/src/cli/doctor-codes.ts
+++ b/packages/vendo/src/cli/doctor-codes.ts
@@ -8,7 +8,8 @@ import { CLI_VERSION } from "./shared.js";
  * eject drift, DEV probe server, LIVE composition/status, AUTH credentials,
  * MCP door, TURN model turn, CLOUD key). Codes are append-only: never renumber or reuse one — the
  * verify page anchors (`fix_ref`) and agents' remediation notes depend on
- * them staying put.
+ * them staying put. A check that goes away leaves its entry behind, marked
+ * RETIRED, for the same reason.
  *
  * This is the ONE module a CI check enumerates to assert every code has a
  * matching verify-page anchor (no registry rot).
@@ -39,7 +40,12 @@ export const DOCTOR_ERROR_CODES = {
   "E-LIVE-004": "no execution venue is configured",
   "E-LIVE-005": "the host /status does not report an execution venue (version skew)",
   "E-LIVE-006": "the app's root page returns a server error while the wire answers",
-  "E-LIVE-007": "the selected e2b execution venue is unusable (E2B_API_KEY or the e2b package is missing)",
+  // RETIRED 2026-08-11 (the selection law): E2B_API_KEY no longer selects a
+  // venue, so no host can be handed an e2b venue it did not ask for. An explicit
+  // `sandbox: e2bSandbox()` refuses at boot when the SDK does not resolve, which
+  // is earlier and louder than a probe. The ENTRY stays — the registry is
+  // append-only and the verify page anchors on it.
+  "E-LIVE-007": "RETIRED — doctor no longer emits this; E2B_API_KEY does not select an execution venue",
   "E-LIVE-008": "the host still calls store ops the wire has deprecated and will remove",
   "E-AUTH-001": "present credentials did not reach the host API",
   "E-AUTH-002": "the present credential probe is unreachable",

--- a/packages/vendo/src/cli/doctor-probe-checks.ts
+++ b/packages/vendo/src/cli/doctor-probe-checks.ts
@@ -1,24 +1,8 @@
-import { createRequire } from "node:module";
-import { join } from "node:path";
 import { stdin, stdout } from "node:process";
 import { startDevServerForProbe } from "./doctor-live.js";
 import { CLI_VERSION, askYesNo } from "./shared.js";
 import { probeBody, type DoctorRun } from "./doctor-report.js";
 import type { DoctorOptions } from "./doctor.js";
-
-/** Whether the optional `e2b` SDK resolves from the target project — the same
- *  node_modules walk the running wire's dynamic `import("e2b")` performs, so
- *  doctor certifies the venue against the resolution that will actually be
- *  asked to load it (0.4.4 defect C: /status said e2b on a host without the
- *  SDK, and the first build died in an unusable venue). */
-function e2bResolvableFrom(root: string): boolean {
-  try {
-    createRequire(join(root, "__vendo-doctor-probe__.js")).resolve("e2b");
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 /** NOTHING doctor can observe proves WHY the auth probes 404, so neither
     message below asserts a cause — they report what was seen, name the
@@ -86,34 +70,16 @@ export async function startDevServerIfOffered(run: DoctorRun, options: DoctorOpt
   return null;
 }
 
-/** 0.4.4 defect C — "ok: execution venue: e2b" on a host that cannot
- *  actually run e2b is a false blessing: the venue must be USABLE
- *  (key set and SDK resolvable from this project), or every server-app
- *  build dies in it instead of riding the Cloud sandbox. */
-function checkE2bVenue(run: DoctorRun, e2bResolvable: ((root: string) => boolean) | undefined): void {
-  const { env, root } = run;
-  const keyPresent = typeof env.E2B_API_KEY === "string" && env.E2B_API_KEY.trim() !== "";
-  const installed = (e2bResolvable ?? e2bResolvableFrom)(root);
-  if (keyPresent && installed) {
-    run.pass("live/venue", "execution venue: e2b");
-    return;
-  }
-  const missing = [
-    ...(keyPresent ? [] : ["E2B_API_KEY is not set"]),
-    ...(installed ? [] : ["the e2b package does not resolve from this project"]),
-  ].join(" and ");
-  // This reads doctor's OWN env and project root, not the server's, so
-  // a live e2b venue failing here means the two disagree.
-  run.fail("live/venue", "E-LIVE-007", `the running wire selected the e2b execution venue but ${missing}; server-app builds will fail in an unusable sandbox. Fix: install the e2b package and set E2B_API_KEY, or remove E2B_API_KEY from the server env (with VENDO_API_KEY set, the managed Cloud sandbox takes over), then restart the dev server and re-run doctor`);
-}
-
-function checkVenue(run: DoctorRun, sandboxVenue: unknown, e2bResolvable: ((root: string) => boolean) | undefined): void {
-  if (sandboxVenue === "e2b") {
-    checkE2bVenue(run, e2bResolvable);
-  } else if (sandboxVenue === "cloud" || sandboxVenue === "custom") {
+/** No E2B-specific usability check any more (E-LIVE-007, retired): E2B_API_KEY
+ *  no longer selects a venue, so there is no such thing as a venue the operator
+ *  did not ask for. An explicit `sandbox: e2bSandbox()` reports "custom" and
+ *  refuses at boot when the SDK does not resolve, which is both earlier and
+ *  louder than a doctor probe. `"e2b"` still arrives from older wires. */
+function checkVenue(run: DoctorRun, sandboxVenue: unknown): void {
+  if (sandboxVenue === "e2b" || sandboxVenue === "cloud" || sandboxVenue === "custom") {
     run.pass("live/venue", `execution venue: ${sandboxVenue}`);
   } else if (sandboxVenue === false) {
-    run.warn("live/venue", "E-LIVE-004", "install the e2b package and set E2B_API_KEY, or set VENDO_API_KEY for the managed Cloud sandbox, or pass sandbox: to createVendo; without one, server apps (rungs 2-4) return sandbox-unavailable");
+    run.warn("live/venue", "E-LIVE-004", "pass sandbox: to createVendo (e.g. sandbox: e2bSandbox(), which reads E2B_API_KEY as its credential), or set VENDO_API_KEY for the managed Cloud sandbox; without one, server apps (rungs 2-4) return sandbox-unavailable");
   } else if (sandboxVenue === undefined) {
     // Older hosts predate blocks.sandbox — version skew, not a broken install.
     run.warn("live/venue", "E-LIVE-005", "host /status does not report an execution venue; upgrade @vendoai/vendo to enable the venue check");
@@ -144,7 +110,7 @@ export interface LiveComposition {
   live: boolean;
 }
 
-export async function checkLiveStatus(run: DoctorRun, e2bResolvable: ((root: string) => boolean) | undefined): Promise<LiveComposition> {
+export async function checkLiveStatus(run: DoctorRun): Promise<LiveComposition> {
   const { statusUrl, fetchImpl } = run;
   try {
     const response = await fetchImpl(`${statusUrl}/status`, {
@@ -166,7 +132,7 @@ export async function checkLiveStatus(run: DoctorRun, e2bResolvable: ((root: str
     const mcpPosture = body.blocks.mcp === "broker" ? "broker"
       : body.blocks.mcp === true || body.blocks.mcp === "local" ? "local"
       : false;
-    checkVenue(run, body.blocks.sandbox, e2bResolvable);
+    checkVenue(run, body.blocks.sandbox);
     return { mcpPosture, live: true };
   } catch {
     run.fail("live/status", "E-LIVE-002", `/status is unreachable at ${statusUrl}/status — doctor expects the WIRE BASE (your app origin plus the mount path, e.g. http://localhost:3000/api/vendo); a bare site origin passed to --url is missing the /api/vendo part`);

--- a/packages/vendo/src/cli/doctor.ts
+++ b/packages/vendo/src/cli/doctor.ts
@@ -39,7 +39,6 @@ export interface DoctorOptions {
   liveTurn?: (base: string) => Promise<LiveTurnResult>;
   cloudProbe?: (options: { env?: Record<string, string | undefined> }) => Promise<CloudDoctorResult>;
   startDevServer?: (options: { root: string; statusUrl: string; env?: Record<string, string | undefined>; fetchImpl?: typeof fetch }) => Promise<{ ok: boolean; stop: () => void }>;
-  e2bResolvable?: (root: string) => boolean;
   /** The npm `latest` lookup behind the version-skew line — its own seam, not
       fetchImpl, so a scripted wire probe never doubles as a registry answer. */
   npmLatest?: () => Promise<string | null>;
@@ -127,7 +126,7 @@ export async function runDoctor(options: DoctorOptions): Promise<number> {
   await checkEjectDrift(run);
 
   const devServerStop = await startDevServerIfOffered(run, options);
-  const { mcpPosture, live } = await checkLiveStatus(run, options.e2bResolvable);
+  const { mcpPosture, live } = await checkLiveStatus(run);
   if (live) await checkRootRender(run);
   await checkAuthProbes(run, live);
   if (mcpPosture !== false) await checkMcpDiscovery(run, mcpPosture);

--- a/packages/vendo/src/compose-adapters.ts
+++ b/packages/vendo/src/compose-adapters.ts
@@ -20,13 +20,13 @@ import { cloudSandbox } from "./sandbox.js";
    (models-config.ts). Precedence per slot: an explicitly passed model object
    always wins (BYO-LLM) → env pin (VENDO_MODEL / VENDO_MODEL_<SLOT>) →
    `models` string → the per-rung default. Every string rides vendoModel()'s
-   env ladder, whose rungs live INSIDE it (resolveDevCredential): a provider
-   key (ANTHROPIC / OPENAI / GOOGLE) via the host-installed @ai-sdk provider,
-   then VENDO_API_KEY via @ai-sdk/anthropic pointed at the Cloud model gateway
-   (`<console>/api/v1` — Anthropic-compatible /messages), then the honest
-   keyless failure with exact instructions on first use. vendoModel is the one
-   seam-sanctioned lazy env resolver; every other adapter still never reads
-   the environment. */
+   env ladder, whose rungs live INSIDE it (resolveDevCredential): VENDO_API_KEY
+   via @ai-sdk/anthropic pointed at the Cloud model gateway (`<console>/api/v1`
+   — Anthropic-compatible /messages), then the honest keyless failure with exact
+   instructions on first use. A provider key (ANTHROPIC / OPENAI / GOOGLE) in
+   the environment selects NOTHING — the selection law: keys are credentials,
+   `models` selects. vendoModel is the one seam-sanctioned lazy env resolver;
+   every other adapter still never reads the environment. */
 
 /** 09-vendo §2 — the adapter rule, applied at the one seam that may read the
  *  environment. */
@@ -45,7 +45,8 @@ export const composeAdapters = (composition: VendoComposition): Pick<VendoCompos
     composed?.files ?? config.files,
   );
   // The sandbox seam, resolved by THE ladder — the one in @vendoai/apps that
-  // `agent()` calls too (explicit → E2B_API_KEY → the Cloud rung → nothing).
+  // `agent()` calls too (explicit → the Cloud rung → nothing; E2B_API_KEY is a
+  // credential for an explicit `e2bSandbox()`, never a rung).
   // "Nothing" is this deployment's dark venue: server apps answer
   // sandbox-unavailable and assertHarnessComposable below refuses a harness
   // that needed a machine.

--- a/packages/vendo/src/compose-apps.ts
+++ b/packages/vendo/src/compose-apps.ts
@@ -38,21 +38,23 @@ import { BASE_PATH, environment } from "./wire/shared.js";
 // key is just such a secret: declare it, grant it, and it rides the same
 // injection path as any other key.
 // execution-v2 Wave 3 — the box's inference door (the in-box coding agent's
-// model). Explicit VENDO_INFERENCE_URL/KEY win; otherwise the BYO Anthropic
-// key rides api.anthropic.com; otherwise VENDO_API_KEY rides the console's
-// Anthropic-compatible model gateway — the same key that provisions the
-// Cloud machine funds its model (chat inference already does, via vendoModel's
-// vendo-cloud rung; a machine without this rung fails every in-box task).
+// model). SELECTION LAW: the explicit VENDO_INFERENCE_URL+KEY pair wins;
+// otherwise VENDO_API_KEY rides the console's Anthropic-compatible model gateway
+// — the same key that provisions the Cloud machine funds its model (chat
+// inference already does, via vendoModel's vendo-cloud rung; a machine without
+// this rung fails every in-box task); otherwise the box gets no inference door
+// and says so.
+//
+// There is deliberately no ANTHROPIC_API_KEY rung: a provider key in the
+// deployment's environment used to point every box at api.anthropic.com and bill
+// that account, chosen by nothing anyone wrote down. A host who wants their own
+// endpoint names it — both halves of the pair, explicitly.
 const boxInference = (): { url: string; key: string; model?: string } | undefined => {
   const url = environment("VENDO_INFERENCE_URL");
   const key = environment("VENDO_INFERENCE_KEY");
   const model = environment("VENDO_INFERENCE_MODEL");
   if (url !== undefined && key !== undefined) {
     return { url, key, ...(model === undefined ? {} : { model }) };
-  }
-  const anthropic = environment("ANTHROPIC_API_KEY");
-  if (anthropic !== undefined) {
-    return { url: "https://api.anthropic.com", key: anthropic, ...(model === undefined ? {} : { model }) };
   }
   const cloud = cloudKeyOptions();
   if (cloud !== undefined) {

--- a/packages/vendo/src/dev-creds/model.ts
+++ b/packages/vendo/src/dev-creds/model.ts
@@ -20,7 +20,11 @@ import {
  * resolving the credential lazily on first use:
  *
  * - env-key rungs delegate to the host-installed @ai-sdk provider (^3, spec
- *   v3) with full native tool calling — works in production too.
+ *   v3) with full native tool calling — works in production too. Since the
+ *   selection law they are reachable only through the internal
+ *   VENDO_DEV_CREDENTIAL pin: a host's own provider key belongs in `models`,
+ *   where it is a CHOICE (`models: { default: anthropic(key) }`), not in an env
+ *   var Vendo sniffs.
  * - VENDO_API_KEY delegates to the Vendo Cloud model gateway: the
  *   host-installed @ai-sdk/anthropic pointed at `<console>/api/v1`, whose
  *   Anthropic-compatible /messages endpoint serves the metered allowance
@@ -146,10 +150,16 @@ export const SLOT_PIN_ENV: Record<VendoModelSlot, string> = {
   extract: "VENDO_MODEL_EXTRACT",
 };
 
+/** The keyless boot error. Both ways out, in order: explicit config first, then
+ *  VENDO_API_KEY. Byte-for-byte coupled to `MODEL_UNAVAILABLE_SIGNAL` in
+ *  `@vendoai/apps` (server/doors/build-messages.ts), which anchors on this
+ *  sentence's opening so the actionable line survives the build door's fold —
+ *  change one and the other stops matching. The seam is tested in
+ *  tests/dev-creds/model.test.ts, through the real regex. */
 export const NO_CREDENTIAL_MESSAGE =
-  "Vendo found no model key. Set ANTHROPIC_API_KEY / OPENAI_API_KEY / GOOGLE_GENERATIVE_AI_API_KEY "
-  + "in .env.local (with the matching @ai-sdk provider installed), or run `vendo login` for a "
-  + "free dev key. Production always needs a real server-side key.";
+  "Vendo has no model. Pass one — models: { default: anthropic(\"claude-sonnet-4-6\") } in "
+  + "createVendo — or set VENDO_API_KEY for the Vendo Cloud gateway (`vendo login` mints a free "
+  + "dev key). A provider key alone no longer selects a model; Vendo never picks a provider for you.";
 
 function nonBlank(value: string | undefined): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
@@ -226,8 +236,8 @@ async function dynamicImport(url: string): Promise<Record<string, unknown>> {
  *  provider in a repo that has it (the dual-package hazard). Only when the
  *  host root resolves nothing do we resolve from vendo's own module context
  *  (createRequire off import.meta.url): @ai-sdk/anthropic ships as a real
- *  dependency of @vendoai/vendo, so an ANTHROPIC_API_KEY — or VENDO_API_KEY
- *  via the Anthropic-compatible Cloud gateway — lights up live chat under
+ *  dependency of @vendoai/vendo, so a VENDO_API_KEY — via the
+ *  Anthropic-compatible Cloud gateway — lights up live chat under
  *  `npx vendo try` with nothing installed in the repo. Scoped to @ai-sdk/*
  *  provider modules; arbitrary specifiers keep strict host-root resolution.
  *  (Exported for the resolution tests; the injectable seam is `importModule`.) */
@@ -360,6 +370,8 @@ export class DevModelController {
     const options: ResolveDevCredentialOptions = { env: this.env };
     const credential = await resolveDevCredential(options);
 
+    // Reachable only through the internal VENDO_DEV_CREDENTIAL pin now (see
+    // resolve.ts): a bare provider key in the environment selects nothing.
     if (credential.rung === "env-key") {
       return this.delegate(
         credential,

--- a/packages/vendo/src/dev-creds/resolve.ts
+++ b/packages/vendo/src/dev-creds/resolve.ts
@@ -3,12 +3,19 @@
  * Runtime model credentials are REAL KEYS ONLY — CLI-session rungs were removed
  * (a coding-agent login helps at init time only, never serves product turns).
  * Detection is PURE and read-only — no network, no writes, no key material in
- * the result (consumers read the env variable themselves). Order (explicit
- * beats implicit):
+ * the result (consumers read the env variable themselves).
  *
- *   1. explicit env key (ANTHROPIC / OPENAI / GOOGLE)
- *   2. VENDO_API_KEY (Vendo Cloud starter allowance / gateway)
- *   3. none (honest failure with exact instructions)
+ * SELECTION LAW (2026-08-11): env keys are credentials, config selects. A
+ * provider key lying around in the environment no longer selects a model —
+ * `models: { default: … }` on createVendo does, and `VENDO_API_KEY` is the only
+ * blessed default-filler for the slot a host left unset. Order:
+ *
+ *   1. VENDO_API_KEY (Vendo Cloud starter allowance / gateway)
+ *   2. none (honest failure with exact instructions — NO_CREDENTIAL_MESSAGE)
+ *
+ * The `env-key` rung still EXISTS, and `ENV_KEY_VARS` is still its credential
+ * table, but nothing arrives at it by accident: only the internal
+ * `VENDO_DEV_CREDENTIAL` pin below can name it.
  */
 
 export type EnvKeyProvider = "anthropic" | "openai" | "google";
@@ -34,9 +41,11 @@ function present(env: Record<string, string | undefined>, name: string): boolean
 }
 
 /** Detect the best available model credential. `VENDO_DEV_CREDENTIAL`
- *  (env-key:anthropic | vendo-cloud | none) pins the rung explicitly — used by
- *  E2E rung matrices and escape hatches. Async for seam stability (callers and
- *  test seams predate the session-rung removal). */
+ *  (env-key:anthropic | vendo-cloud | none) pins the rung explicitly.
+ *  INTERNAL ONLY — it is Vendo's own E2E rung matrix and escape hatch, not a
+ *  documented host knob, and since the selection law it is the ONLY way to reach
+ *  the `env-key` rung at all. Async for seam stability (callers and test seams
+ *  predate the session-rung removal). */
 export async function resolveDevCredential(
   options: ResolveDevCredentialOptions = {},
 ): Promise<DevCredential> {
@@ -61,10 +70,10 @@ export async function resolveDevCredential(
     }
   }
 
-  for (const { envVar, provider } of ENV_KEY_VARS) {
-    if (present(env, envVar)) return { rung: "env-key", provider, envVar };
-  }
-
+  // No provider-key sweep here, deliberately: a stray ANTHROPIC_API_KEY (or an
+  // OPENAI / GOOGLE one) used to WIN this ladder, so a key left in a shell chose
+  // the model — and the provider — for the host. Keys are credentials; the
+  // `models` block on createVendo is what selects.
   if (present(env, "VENDO_API_KEY")) return { rung: "vendo-cloud" };
   return { rung: "none" };
 }

--- a/packages/vendo/tests/box-inference.test.ts
+++ b/packages/vendo/tests/box-inference.test.ts
@@ -13,9 +13,12 @@ import type { LanguageModel } from "ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createVendo } from "../src/server.js";
 
-// The box's inference-door ladder (release-gap fix, 2026-07-20): explicit
-// VENDO_INFERENCE_URL/KEY → BYO ANTHROPIC_API_KEY → VENDO_API_KEY via the
-// console's Anthropic-compatible model gateway. Before the Cloud rung landed,
+// The box's inference-door ladder (release-gap fix, 2026-07-20; narrowed by the
+// SELECTION LAW 2026-08-11): the explicit VENDO_INFERENCE_URL+KEY pair →
+// VENDO_API_KEY via the console's Anthropic-compatible model gateway → nothing.
+// A stray ANTHROPIC_API_KEY is no longer a rung: it used to point every box at
+// api.anthropic.com and bill that account, chosen by nothing anyone wrote down.
+// Before the Cloud rung landed,
 // a zero-key Cloud host provisioned billed machines whose in-box agent had no
 // model (the box harness refuses: "the box has no inference endpoint" —
 // The box's task door maps VENDO_INFERENCE_URL/KEY onto
@@ -190,15 +193,25 @@ describe("boxInference ladder (the in-box agent's model door)", () => {
     expect(env["VENDO_INFERENCE_KEY"]).toBe("own_key");
   });
 
-  it("a BYO ANTHROPIC_API_KEY beats the Cloud rung", async () => {
+  it("a stray ANTHROPIC_API_KEY does NOT beat the Cloud rung — it selects nothing", async () => {
     const env = await boxEnv({
       ANTHROPIC_API_KEY: "sk-ant-byo",
       VENDO_API_KEY: "vnd_cloud_key",
     });
-    expect(env["VENDO_INFERENCE_URL"]).toBe("https://api.anthropic.com");
-    expect(env["VENDO_INFERENCE_KEY"]).toBe("sk-ant-byo");
-    // BYO keeps the box harness's own real-model default — no alias pin.
-    expect(env["VENDO_INFERENCE_MODEL"]).toBeUndefined();
+    // The key that provisions the machine funds its model; the provider key in
+    // the deployment's environment is not consulted.
+    expect(env["VENDO_INFERENCE_URL"]).toBe("https://console.vendo.run/api/v1");
+    expect(env["VENDO_INFERENCE_KEY"]).toBe("vnd_cloud_key");
+    expect(env["VENDO_INFERENCE_MODEL"]).toBe("vendo");
+  });
+
+  it("a stray ANTHROPIC_API_KEY alone leaves the box without an inference door", async () => {
+    // There is deliberately NO middle rung: a host who wants their own endpoint
+    // names both halves of the pair. Silently routing every box to
+    // api.anthropic.com on a key nobody pointed at Vendo is the thing being removed.
+    const env = await boxEnv({ ANTHROPIC_API_KEY: "sk-ant-byo" });
+    expect(env["VENDO_INFERENCE_URL"]).toBeUndefined();
+    expect(env["VENDO_INFERENCE_KEY"]).toBeUndefined();
   });
 
   it("no key on any rung leaves the box without an inference door", async () => {

--- a/packages/vendo/tests/cli/doctor-codes.test.ts
+++ b/packages/vendo/tests/cli/doctor-codes.test.ts
@@ -16,6 +16,9 @@ describe("doctor error-code registry", () => {
   it("locks the registry append-only: renumbering, removing, or reusing a code fails here", () => {
     // A NEW code extends this snapshot; touching an existing entry rewrites
     // published fix_ref anchors and agents' remediation notes — never do it.
+    // A check that goes away leaves its KEY behind, marked RETIRED (E-LIVE-007,
+    // 2026-08-11): the verify page anchors on it, so deleting the entry breaks a
+    // published URL for the sake of tidiness.
     expect(DOCTOR_ERROR_CODES).toMatchInlineSnapshot(`
       {
         "E-AUTH-001": "present credentials did not reach the host API",
@@ -39,7 +42,7 @@ describe("doctor error-code registry", () => {
         "E-LIVE-004": "no execution venue is configured",
         "E-LIVE-005": "the host /status does not report an execution venue (version skew)",
         "E-LIVE-006": "the app's root page returns a server error while the wire answers",
-        "E-LIVE-007": "the selected e2b execution venue is unusable (E2B_API_KEY or the e2b package is missing)",
+        "E-LIVE-007": "RETIRED — doctor no longer emits this; E2B_API_KEY does not select an execution venue",
         "E-LIVE-008": "the host still calls store ops the wire has deprecated and will remove",
         "E-MCP-001": "MCP protected-resource metadata did not resolve",
         "E-MCP-002": "MCP authorization-server metadata did not resolve",

--- a/packages/vendo/tests/cli/doctor-live.test.ts
+++ b/packages/vendo/tests/cli/doctor-live.test.ts
@@ -13,7 +13,11 @@ function sseResponse(frames: string[]): Response {
 }
 
 describe("liveModelTurn", () => {
-  const env = { ANTHROPIC_API_KEY: "sk-test" };
+  // The rung doctor reports is the one the RUNTIME would ride, and since the
+  // selection law a bare provider key rides nothing — so a host whose credential
+  // is a real, selecting one sets VENDO_API_KEY (or pins the internal env-key
+  // rung, as this case does, to keep exercising that branch).
+  const env = { VENDO_DEV_CREDENTIAL: "env-key:anthropic", ANTHROPIC_API_KEY: "sk-test" };
 
   it("streams a UI-message SSE reply and reports ok with the rung", async () => {
     const deltas: string[] = [];

--- a/packages/vendo/tests/cli/doctor.test.ts
+++ b/packages/vendo/tests/cli/doctor.test.ts
@@ -549,51 +549,26 @@ describe("vendo doctor", () => {
     expect(messages.logs).toContain(`ok: execution venue: ${sandbox}`);
   });
 
-  // 0.4.4 defect C — an e2b venue is blessed only when it is USABLE: key set
-  // and SDK resolvable from the project. "ok: execution venue: e2b" on a
-  // keyless host certified a composition whose every server-app build died
-  // (the venue ladder had picked e2b over the Cloud sandbox).
-  it("reports a lit e2b execution venue when the key is set and the SDK resolves", async () => {
-    const messages = output();
-    expect(await doctor({
-      targetDir: await healthy(),
-      fetchImpl: successfulProbeFetch({ store: true, sandbox: "e2b" }),
-      env: { E2B_API_KEY: "e2b_key" },
-      e2bResolvable: () => true,
-      output: messages.sink,
-      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
-    })).toBe(0);
-    expect(messages.logs).toContain("ok: execution venue: e2b");
-  });
-
-  it("fails when the wire selected e2b but no E2B_API_KEY is set", async () => {
+  // 0.4.4 defect C used to be doctor's problem: E2B_API_KEY selected the venue,
+  // so a host could be handed an e2b venue it never asked for, and doctor had to
+  // second-guess it (E-LIVE-007, now RETIRED). The selection law removed the
+  // question — nothing but explicit config produces an e2b box, and an explicit
+  // `e2bSandbox()` refuses at BOOT when the SDK does not resolve, which is
+  // earlier and louder than any probe. So an "e2b" venue on the wire (only older
+  // wires still send one) is simply reported, with no usability verdict attached.
+  it("reports an e2b execution venue from an older wire without second-guessing it", async () => {
     const messages = output();
     expect(await doctor({
       targetDir: await healthy(),
       fetchImpl: successfulProbeFetch({ store: true, sandbox: "e2b" }),
       env: {},
-      e2bResolvable: () => true,
       output: messages.sink,
       telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
-    })).toBe(1);
-    expect(messages.errors).toContain(
-      "broken: the running wire selected the e2b execution venue but E2B_API_KEY is not set; server-app builds will fail in an unusable sandbox. Fix: install the e2b package and set E2B_API_KEY, or remove E2B_API_KEY from the server env (with VENDO_API_KEY set, the managed Cloud sandbox takes over), then restart the dev server and re-run doctor",
-    );
-  });
-
-  it("fails when the wire selected e2b but the SDK does not resolve from the project", async () => {
-    const messages = output();
-    expect(await doctor({
-      targetDir: await healthy(),
-      fetchImpl: successfulProbeFetch({ store: true, sandbox: "e2b" }),
-      env: { E2B_API_KEY: "e2b_key" },
-      e2bResolvable: () => false,
-      output: messages.sink,
-      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
-    })).toBe(1);
-    expect(messages.errors).toContain(
-      "broken: the running wire selected the e2b execution venue but the e2b package does not resolve from this project; server-app builds will fail in an unusable sandbox. Fix: install the e2b package and set E2B_API_KEY, or remove E2B_API_KEY from the server env (with VENDO_API_KEY set, the managed Cloud sandbox takes over), then restart the dev server and re-run doctor",
-    );
+    })).toBe(0);
+    expect(messages.logs).toContain("ok: execution venue: e2b");
+    // No E2B key, no e2b install check, no failure: the venue is not doctor's to
+    // re-derive any more.
+    expect(messages.errors.join("\n")).not.toContain("unusable sandbox");
   });
 
   it("warns with actionable guidance when the execution venue is dark", async () => {
@@ -604,8 +579,11 @@ describe("vendo doctor", () => {
       output: messages.sink,
       telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
     })).toBe(0);
+    // Both ways out, in the order the law states them: explicit config first,
+    // then VENDO_API_KEY. "set E2B_API_KEY" is deliberately NOT one of them any
+    // more — it selects nothing, so offering it would send the reader in circles.
     expect(messages.errors).toContain(
-      "warning: install the e2b package and set E2B_API_KEY, or set VENDO_API_KEY for the managed Cloud sandbox, or pass sandbox: to createVendo; without one, server apps (rungs 2-4) return sandbox-unavailable",
+      "warning: pass sandbox: to createVendo (e.g. sandbox: e2bSandbox(), which reads E2B_API_KEY as its credential), or set VENDO_API_KEY for the managed Cloud sandbox; without one, server apps (rungs 2-4) return sandbox-unavailable",
     );
     expect(messages.logs).toContain(
       "Ladder: execution venue is checked above; actAs for away host actions; connectors for external tools.",
@@ -814,6 +792,10 @@ describe("vendo doctor v2 (live turn + --json + cloud + dev-server probe)", () =
       targetDir: await healthy(),
       fetchImpl: probeFetchWithTurn(),
       env: {
+        // The rung doctor reports is the one the RUNTIME would ride. Since the
+        // selection law a bare provider key rides nothing (asserted below), so a
+        // host on the env-key rung got there through the internal pin.
+        VENDO_DEV_CREDENTIAL: "env-key:anthropic",
         ANTHROPIC_API_KEY: "sk-test",
         VENDO_MODEL: "claude-opus-4-8",
         VENDO_MODEL_PAINT: "claude-haiku-4-5",
@@ -833,7 +815,7 @@ describe("vendo doctor v2 (live turn + --json + cloud + dev-server probe)", () =
     expect(await runDoctor({
       targetDir: await healthy(),
       fetchImpl: probeFetchWithTurn(),
-      env: { ANTHROPIC_API_KEY: "sk-test" },
+      env: { VENDO_DEV_CREDENTIAL: "env-key:anthropic", ANTHROPIC_API_KEY: "sk-test" },
       interactive: false,
       cloudProbe: async () => ({ present: false, ok: false, unlocks: ["x"] }),
       npmLatest: async () => null,
@@ -842,6 +824,28 @@ describe("vendo doctor v2 (live turn + --json + cloud + dev-server probe)", () =
     })).toBe(0);
     expect(bare.logs.some((line) => line.includes("model pins:"))).toBe(false);
     expect(bare.logs).toContain("ok: model credential: explicit ANTHROPIC_API_KEY (anthropic)");
+  });
+
+  it("reports NO winning credential for a bare provider key — doctor tells the runtime's truth", async () => {
+    // The selection law's honesty requirement: doctor reads the same resolver the
+    // runtime rides, so a host whose only key is ANTHROPIC_API_KEY must be told it
+    // has no model — not blessed with "ok: model credential". Blessing it is how a
+    // certified-healthy composition failed its first turn.
+    const messages = output();
+    expect(await runDoctor({
+      targetDir: await healthy(),
+      fetchImpl: probeFetchWithTurn(),
+      env: { ANTHROPIC_API_KEY: "sk-test" },
+      interactive: false,
+      cloudProbe: async () => ({ present: false, ok: false, unlocks: ["x"] }),
+      npmLatest: async () => null,
+      output: messages.sink,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    })).toBe(0);
+    expect(messages.logs).toContain(
+      "model credential: none found — the live turn check below carries the honest failure",
+    );
+    expect(messages.logs.some((line) => line.startsWith("ok: model credential:"))).toBe(false);
   });
 
   it("runs one real model turn over the wired route and exits 0 when it answers", async () => {

--- a/packages/vendo/tests/cli/init.test.ts
+++ b/packages/vendo/tests/cli/init.test.ts
@@ -602,7 +602,10 @@ describe("vendo init (zero-question)", () => {
 
     const keyed = await fixture();
     const keyedSink = output();
-    expect(await run(keyed, keyedSink, { env: { ANTHROPIC_API_KEY: "sk-ant-test" } })).toBe(0);
+    expect(await run(keyed, keyedSink, {
+      // A resolving credential, which a bare provider key no longer is.
+      env: { VENDO_DEV_CREDENTIAL: "env-key:anthropic", ANTHROPIC_API_KEY: "sk-ant-test" },
+    })).toBe(0);
     const keyedTail = keyedSink.logs.join("\n").split("Agent tail:")[1]!;
     expect(keyedTail).not.toContain("cloud key: none");
   });
@@ -850,7 +853,12 @@ describe("vendo init (zero-question)", () => {
   it("states an env key in one line and skips the cloud offer", async () => {
     const root = await fixture();
     const sink = output();
-    expect(await run(root, sink, { env: { ANTHROPIC_API_KEY: "sk-a" } })).toBe(0);
+    // A bare provider key selects nothing since the selection law, so a host on
+    // the env-key rung got there through the internal VENDO_DEV_CREDENTIAL pin —
+    // which is what keeps this line (init's REPORT of the winning rung) covered.
+    expect(await run(root, sink, {
+      env: { VENDO_DEV_CREDENTIAL: "env-key:anthropic", ANTHROPIC_API_KEY: "sk-a" },
+    })).toBe(0);
     const logs = sink.logs.join("\n");
     expect(logs).toContain("Model: explicit ANTHROPIC_API_KEY (anthropic)");
     expect(logs).not.toContain("No model key yet");

--- a/packages/vendo/tests/cli/onboarding-safety.test.ts
+++ b/packages/vendo/tests/cli/onboarding-safety.test.ts
@@ -219,7 +219,11 @@ describe("the closing line tells the truth about the model key", () => {
 
   it("keyed: live in your app", async () => {
     const sink = output();
-    expect(await run(await mountedPagesHost(), sink, { env: { ANTHROPIC_API_KEY: "sk-a" } })).toBe(0);
+    // A RESOLVING credential — which a bare provider key stopped being under the
+    // selection law, so the env-key rung is named through the internal pin.
+    expect(await run(await mountedPagesHost(), sink, {
+      env: { VENDO_DEV_CREDENTIAL: "env-key:anthropic", ANTHROPIC_API_KEY: "sk-a" },
+    })).toBe(0);
     expect(sink.logs.join("\n")).toContain(LIVE);
   });
 

--- a/packages/vendo/tests/dev-creds/model.test.ts
+++ b/packages/vendo/tests/dev-creds/model.test.ts
@@ -38,6 +38,93 @@ async function resolvedId(model: LanguageModel): Promise<string> {
   return (await record.doGenerate({ prompt: [] })).modelId;
 }
 
+/**
+ * The env-key rungs, as they are reachable AFTER the selection law: a provider
+ * key in the environment selects nothing on its own, so every case that
+ * exercises one of those rungs names it through the internal
+ * `VENDO_DEV_CREDENTIAL` pin. The rung's own behaviour — per-slot precedence,
+ * per-provider defaults, sampling params, host-first module resolution — is
+ * unchanged and still fully covered; what changed is who may ask for it.
+ * The keyless cases below prove the bare-key path is genuinely dead.
+ */
+const BYO = {
+  anthropic: { VENDO_DEV_CREDENTIAL: "env-key:anthropic", ANTHROPIC_API_KEY: "sk-a" },
+  openai: { VENDO_DEV_CREDENTIAL: "env-key:openai", OPENAI_API_KEY: "sk-o" },
+  google: { VENDO_DEV_CREDENTIAL: "env-key:google", GOOGLE_GENERATIVE_AI_API_KEY: "g" },
+} as const;
+
+describe("THE SELECTION LAW — a provider key is a credential, not a choice", () => {
+  it("a stray ANTHROPIC_API_KEY with no models config gets the boot error, not a model", async () => {
+    // The breaking change. A key left in a shell (or inherited by a container)
+    // used to pick both the provider and the model for the whole deployment.
+    const controller = new DevModelController({
+      env: { ANTHROPIC_API_KEY: "sk-a" },
+      // Would answer happily if it were ever reached — and it must not be.
+      importModule: scriptedProvider("createAnthropic"),
+    });
+    await expect(controller.doGenerate({ prompt: [] })).rejects.toThrow(NO_CREDENTIAL_MESSAGE);
+    await expect(controller.doStream({ prompt: [] })).rejects.toThrow(NO_CREDENTIAL_MESSAGE);
+  });
+
+  it("says so for every provider key, and for all of them at once", async () => {
+    for (const env of [
+      { ANTHROPIC_API_KEY: "sk-a" },
+      { OPENAI_API_KEY: "sk-o" },
+      { GOOGLE_GENERATIVE_AI_API_KEY: "g" },
+      { ANTHROPIC_API_KEY: "sk-a", OPENAI_API_KEY: "sk-o", GOOGLE_GENERATIVE_AI_API_KEY: "g" },
+    ]) {
+      const model = vendoModel(undefined, { env, importModule: scriptedProvider("createAnthropic") });
+      await expect(resolvedId(model)).rejects.toThrow(NO_CREDENTIAL_MESSAGE);
+    }
+  });
+
+  it("teaches both ways out, in order: explicit config first, then VENDO_API_KEY", () => {
+    expect(NO_CREDENTIAL_MESSAGE).toContain("models: { default: anthropic(\"claude-sonnet-4-6\") }");
+    expect(NO_CREDENTIAL_MESSAGE).toContain("set VENDO_API_KEY for the Vendo Cloud gateway");
+    expect(NO_CREDENTIAL_MESSAGE).toContain("`vendo login` mints a free dev key");
+    expect(NO_CREDENTIAL_MESSAGE.indexOf("models: { default:"))
+      .toBeLessThan(NO_CREDENTIAL_MESSAGE.indexOf("VENDO_API_KEY"));
+  });
+
+  it("still serves VENDO_API_KEY when a provider key sits beside it", async () => {
+    // The Cloud key is the ONE blessed default-filler; a provider key next to it
+    // no longer shadows it (nor does it get used).
+    const seen: Array<{ apiKey: string; baseURL?: string }> = [];
+    expect(await resolvedId(vendoModel(undefined, {
+      env: { ANTHROPIC_API_KEY: "sk-a", VENDO_API_KEY: "vnd_x" },
+      importModule: scriptedProvider("createAnthropic", seen),
+    }))).toBe("vendo");
+    expect(seen).toEqual([{ apiKey: "vnd_x", baseURL: "https://console.vendo.run/api/v1" }]);
+  });
+
+  /**
+   * THE COUPLING, from the producer's side.
+   *
+   * `MODEL_UNAVAILABLE_SIGNAL` in `@vendoai/apps` (server/doors/build-messages.ts)
+   * is anchored BYTE-FOR-BYTE to this sentence's opening: it is what lets the
+   * app-build door surface the actionable line instead of collapsing it to
+   * "generation failed · retry", where it reaches only the operator's terminal
+   * (0.4.x, measured twice). apps may not import vendo and this test may not
+   * import apps' internals, so the coupling is pinned from BOTH sides against one
+   * literal — this assertion, and the same literal fed through the real
+   * `buildFailureReason` in packages/apps/tests/build-failure.test.ts ("passes the
+   * dev-model's own unavailable-credential lines through verbatim"). Reword the
+   * message and THIS fails; retune the pattern away from the literal and THAT
+   * fails. Neither can drift quietly.
+   */
+  it("keeps the exact bytes @vendoai/apps' MODEL_UNAVAILABLE_SIGNAL anchors on", () => {
+    // The anchored prefix — the pattern is ^-anchored, so this opening is the
+    // load-bearing part.
+    expect(NO_CREDENTIAL_MESSAGE.startsWith("Vendo has no model.")).toBe(true);
+    // And the whole line, which is what the door surfaces verbatim.
+    expect(NO_CREDENTIAL_MESSAGE).toBe(
+      "Vendo has no model. Pass one — models: { default: anthropic(\"claude-sonnet-4-6\") } in "
+      + "createVendo — or set VENDO_API_KEY for the Vendo Cloud gateway (`vendo login` mints a free "
+      + "dev key). A provider key alone no longer selects a model; Vendo never picks a provider for you.",
+    );
+  });
+});
+
 describe("devModel (env-resolving default model)", () => {
   it("is an ai-SDK LanguageModel", () => {
     const model = devModel({ env: {} });
@@ -141,7 +228,7 @@ describe("devModel (env-resolving default model)", () => {
 
   it("names the missing provider install for an env-key rung without the package", async () => {
     const controller = new DevModelController({
-      env: { OPENAI_API_KEY: "sk-o" },
+      env: { ...BYO.openai },
       importModule: async (_root, specifier) => {
         throw new Error(`Cannot find module '${specifier}'`);
       },
@@ -152,7 +239,7 @@ describe("devModel (env-resolving default model)", () => {
   it("delegates env-key calls to the host provider model with full fidelity", async () => {
     const seen: unknown[] = [];
     const controller = new DevModelController({
-      env: { ANTHROPIC_API_KEY: "sk-a" },
+      env: { ...BYO.anthropic },
       importModule: async () => ({
         createAnthropic: (config: { apiKey: string }) => {
           seen.push(config.apiKey);
@@ -175,7 +262,7 @@ describe("devModel (env-resolving default model)", () => {
 
   it("honors the model-override env var for the resolved provider", async () => {
     const controller = new DevModelController({
-      env: { ANTHROPIC_API_KEY: "sk-a", VENDO_DEV_ANTHROPIC_MODEL: "claude-opus-4-8" },
+      env: { ...BYO.anthropic, VENDO_DEV_ANTHROPIC_MODEL: "claude-opus-4-8" },
       importModule: async () => ({
         createAnthropic: () => (modelId: string) => ({
           specificationVersion: "v3",
@@ -212,7 +299,7 @@ describe("call-time sampling params on the resolved rung", () => {
 
   it("drops temperature/topP/topK and caps output for a ladder-resolved Claude 5 model", async () => {
     const controller = new DevModelController({
-      env: { ANTHROPIC_API_KEY: "sk-a", VENDO_MODEL: "claude-sonnet-5" },
+      env: { ...BYO.anthropic, VENDO_MODEL: "claude-sonnet-5" },
       importModule: optionsEcho("createAnthropic"),
     });
     expect(await controller.doGenerate({ prompt: [], temperature: 0, topP: 0.9, topK: 40 })).toEqual({
@@ -227,7 +314,7 @@ describe("call-time sampling params on the resolved rung", () => {
 
   it("keeps a caller's explicit output cap while dropping the sampling params", async () => {
     const controller = new DevModelController({
-      env: { ANTHROPIC_API_KEY: "sk-a", VENDO_MODEL: "claude-opus-5" },
+      env: { ...BYO.anthropic, VENDO_MODEL: "claude-opus-5" },
       importModule: optionsEcho("createAnthropic"),
     });
     expect(await controller.doGenerate({ prompt: [], temperature: 0, maxOutputTokens: 9_000 })).toEqual({
@@ -238,7 +325,7 @@ describe("call-time sampling params on the resolved rung", () => {
 
   it("leaves a non-Claude resolution untouched — temperature still flows", async () => {
     const controller = new DevModelController({
-      env: { OPENAI_API_KEY: "sk-o" },
+      env: { ...BYO.openai },
       importModule: optionsEcho("createOpenAI"),
     });
     expect(await controller.doGenerate({ prompt: [], temperature: 0 })).toEqual({
@@ -249,7 +336,7 @@ describe("call-time sampling params on the resolved rung", () => {
 
   it("leaves a sampling-era Claude resolution untouched", async () => {
     const controller = new DevModelController({
-      env: { ANTHROPIC_API_KEY: "sk-a", VENDO_MODEL: "claude-sonnet-4-6" },
+      env: { ...BYO.anthropic, VENDO_MODEL: "claude-sonnet-4-6" },
       importModule: optionsEcho("createAnthropic"),
     });
     expect(await controller.doGenerate({ prompt: [], temperature: 0 })).toEqual({
@@ -299,7 +386,7 @@ describe("provider module resolution (host first, vendo's copy as fallback)", ()
 
   it("falls back to vendo's own @ai-sdk/anthropic when the host has no provider install", async () => {
     const root = await fixtureRoot();
-    const controller = new DevModelController({ root, env: { ANTHROPIC_API_KEY: "sk-a" } });
+    const controller = new DevModelController({ root, env: { ...BYO.anthropic } });
     const resolution = await withoutGlobalPaths(() => controller.resolve());
     expect(resolution.mode).toBe("delegate");
     if (resolution.mode !== "delegate") return;
@@ -332,7 +419,7 @@ describe("provider module resolution (host first, vendo's copy as fallback)", ()
       }
       `,
     );
-    const controller = new DevModelController({ root, env: { ANTHROPIC_API_KEY: "sk-a" } });
+    const controller = new DevModelController({ root, env: { ...BYO.anthropic } });
     expect(await controller.doGenerate({ prompt: [] })).toEqual({ from: "host" });
   });
 
@@ -369,14 +456,14 @@ describe("vendoModel (the vendo model family entry)", () => {
 
   it("passes an explicit name VERBATIM to the provider rung — no client-side mapping", async () => {
     const model = vendoModel("claude-opus-4-8", {
-      env: { ANTHROPIC_API_KEY: "sk-a" },
+      env: { ...BYO.anthropic },
       importModule: scriptedProvider("createAnthropic"),
     });
     expect(await resolvedId(model)).toBe("claude-opus-4-8");
     // Even a vendo-* family name goes through untouched: the provider's own
     // error is the surface for unknown names, never a client-side remap.
     const family = vendoModel("vendo-paint", {
-      env: { ANTHROPIC_API_KEY: "sk-a" },
+      env: { ...BYO.anthropic },
       importModule: scriptedProvider("createAnthropic"),
     });
     expect(await resolvedId(family)).toBe("vendo-paint");
@@ -398,11 +485,11 @@ describe("vendoModel (the vendo model family entry)", () => {
       importModule: scriptedProvider("createAnthropic"),
     }))).toBe("vendo");
     expect(await resolvedId(vendoModel(undefined, {
-      env: { ANTHROPIC_API_KEY: "sk-a" },
+      env: { ...BYO.anthropic },
       importModule: scriptedProvider("createAnthropic"),
     }))).toBe("claude-sonnet-4-6");
     expect(await resolvedId(vendoModel(undefined, {
-      env: { OPENAI_API_KEY: "sk-o" },
+      env: { ...BYO.openai },
       importModule: scriptedProvider("createOpenAI"),
     }))).toBe("gpt-5");
   });
@@ -415,30 +502,30 @@ describe("vendoModel (the vendo model family entry)", () => {
     }))).toBe("vendo-paint");
     expect(await resolvedId(vendoModel(undefined, {
       slot: "paint",
-      env: { ANTHROPIC_API_KEY: "sk-a" },
+      env: { ...BYO.anthropic },
       importModule: scriptedProvider("createAnthropic"),
     }))).toBe("claude-haiku-4-5");
     expect(await resolvedId(vendoModel(undefined, {
       slot: "paint",
-      env: { OPENAI_API_KEY: "sk-o" },
+      env: { ...BYO.openai },
       importModule: scriptedProvider("createOpenAI"),
     }))).toBe("gpt-5-mini");
     expect(await resolvedId(vendoModel(undefined, {
       slot: "paint",
-      env: { GOOGLE_GENERATIVE_AI_API_KEY: "g" },
+      env: { ...BYO.google },
       importModule: scriptedProvider("createGoogleGenerativeAI"),
     }))).toBe("gemini-2.5-flash-lite");
   });
 
   it("VENDO_MODEL pins the agent slot above a configured name string", async () => {
     expect(await resolvedId(vendoModel("claude-opus-4-8", {
-      env: { ANTHROPIC_API_KEY: "sk-a", VENDO_MODEL: "claude-sonnet-4-6" },
+      env: { ...BYO.anthropic, VENDO_MODEL: "claude-sonnet-4-6" },
       importModule: scriptedProvider("createAnthropic"),
     }))).toBe("claude-sonnet-4-6");
     // The new pin outranks the deprecated per-provider var.
     expect(await resolvedId(vendoModel(undefined, {
       env: {
-        ANTHROPIC_API_KEY: "sk-a",
+        ...BYO.anthropic,
         VENDO_MODEL: "claude-sonnet-4-6",
         VENDO_DEV_ANTHROPIC_MODEL: "claude-opus-4-8",
       },
@@ -448,7 +535,7 @@ describe("vendoModel (the vendo model family entry)", () => {
 
   it("keeps the deprecated VENDO_DEV_*_MODEL / VENDO_CLOUD_MODEL pins working on the agent slot only", async () => {
     expect(await resolvedId(vendoModel(undefined, {
-      env: { ANTHROPIC_API_KEY: "sk-a", VENDO_DEV_ANTHROPIC_MODEL: "claude-opus-4-8" },
+      env: { ...BYO.anthropic, VENDO_DEV_ANTHROPIC_MODEL: "claude-opus-4-8" },
       importModule: scriptedProvider("createAnthropic"),
     }))).toBe("claude-opus-4-8");
     expect(await resolvedId(vendoModel(undefined, {
@@ -458,7 +545,7 @@ describe("vendoModel (the vendo model family entry)", () => {
     // The deprecated pins never leak onto the paint slot.
     expect(await resolvedId(vendoModel(undefined, {
       slot: "paint",
-      env: { ANTHROPIC_API_KEY: "sk-a", VENDO_DEV_ANTHROPIC_MODEL: "claude-opus-4-8" },
+      env: { ...BYO.anthropic, VENDO_DEV_ANTHROPIC_MODEL: "claude-opus-4-8" },
       importModule: scriptedProvider("createAnthropic"),
     }))).toBe("claude-haiku-4-5");
   });
@@ -466,12 +553,12 @@ describe("vendoModel (the vendo model family entry)", () => {
   it("VENDO_MODEL_PAINT pins the paint slot; VENDO_MODEL does not", async () => {
     expect(await resolvedId(vendoModel(undefined, {
       slot: "paint",
-      env: { ANTHROPIC_API_KEY: "sk-a", VENDO_MODEL: "claude-opus-4-8", VENDO_MODEL_PAINT: "claude-haiku-4-5" },
+      env: { ...BYO.anthropic, VENDO_MODEL: "claude-opus-4-8", VENDO_MODEL_PAINT: "claude-haiku-4-5" },
       importModule: scriptedProvider("createAnthropic"),
     }))).toBe("claude-haiku-4-5");
     expect(await resolvedId(vendoModel(undefined, {
       slot: "paint",
-      env: { ANTHROPIC_API_KEY: "sk-a", VENDO_MODEL: "claude-opus-4-8" },
+      env: { ...BYO.anthropic, VENDO_MODEL: "claude-opus-4-8" },
       importModule: scriptedProvider("createAnthropic"),
     }))).toBe("claude-haiku-4-5");
   });

--- a/packages/vendo/tests/dev-creds/resolve.test.ts
+++ b/packages/vendo/tests/dev-creds/resolve.test.ts
@@ -2,18 +2,25 @@ import { describe, expect, it } from "vitest";
 import { describeDevCredential, resolveDevCredential } from "../../src/dev-creds/resolve.js";
 
 describe("resolveDevCredential (real keys only)", () => {
-  it("prefers an explicit env key over VENDO_API_KEY, in provider order", async () => {
+  // THE SELECTION LAW (2026-08-11), and the one breaking change in it: a provider
+  // key lying in the environment used to WIN this ladder, so a key left in a shell
+  // chose the model — and the provider — for the host. Keys are credentials;
+  // `models` on createVendo is what selects.
+  it("does NOT select a provider from a bare env key, whichever provider it is", async () => {
+    for (const envVar of ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY"]) {
+      expect(await resolveDevCredential({ env: { [envVar]: "sk-1" } }), envVar)
+        .toEqual({ rung: "none" });
+    }
+    // All three at once is still nothing: there is no provider order left to have.
+    expect(await resolveDevCredential({
+      env: { ANTHROPIC_API_KEY: "sk-1", OPENAI_API_KEY: "sk-2", GOOGLE_GENERATIVE_AI_API_KEY: "sk-3" },
+    })).toEqual({ rung: "none" });
+  });
+
+  it("lets VENDO_API_KEY fill the slot even when provider keys are lying around", async () => {
     expect(await resolveDevCredential({
       env: { ANTHROPIC_API_KEY: "sk-1", OPENAI_API_KEY: "sk-2", VENDO_API_KEY: "vnd_x" },
-    })).toEqual({ rung: "env-key", provider: "anthropic", envVar: "ANTHROPIC_API_KEY" });
-
-    expect(await resolveDevCredential({
-      env: { OPENAI_API_KEY: "sk-2", GOOGLE_GENERATIVE_AI_API_KEY: "sk-3" },
-    })).toEqual({ rung: "env-key", provider: "openai", envVar: "OPENAI_API_KEY" });
-
-    expect(await resolveDevCredential({
-      env: { GOOGLE_GENERATIVE_AI_API_KEY: "sk-3" },
-    })).toEqual({ rung: "env-key", provider: "google", envVar: "GOOGLE_GENERATIVE_AI_API_KEY" });
+    })).toEqual({ rung: "vendo-cloud" });
   });
 
   it("falls to VENDO_API_KEY, then to an honest none", async () => {
@@ -23,11 +30,11 @@ describe("resolveDevCredential (real keys only)", () => {
   });
 
   it("ignores blank-valued keys", async () => {
-    expect(await resolveDevCredential({ env: { ANTHROPIC_API_KEY: "  ", VENDO_API_KEY: "" } }))
+    expect(await resolveDevCredential({ env: { VENDO_API_KEY: "  " } }))
       .toEqual({ rung: "none" });
   });
 
-  it("VENDO_DEV_CREDENTIAL pins a rung; a pin whose key is missing degrades to none", async () => {
+  it("VENDO_DEV_CREDENTIAL (internal only) pins a rung; a pin whose key is missing degrades to none", async () => {
     expect(await resolveDevCredential({
       env: { VENDO_DEV_CREDENTIAL: "vendo-cloud", VENDO_API_KEY: "vnd_x", ANTHROPIC_API_KEY: "sk-1" },
     })).toEqual({ rung: "vendo-cloud" });
@@ -40,9 +47,19 @@ describe("resolveDevCredential (real keys only)", () => {
       env: { VENDO_DEV_CREDENTIAL: "vendo-cloud", ANTHROPIC_API_KEY: "sk-1" },
     })).toEqual({ rung: "none" });
 
+    // The pin is the ONLY door to the env-key rung now — ENV_KEY_VARS stays as its
+    // credential table, but nothing arrives here by accident.
     expect(await resolveDevCredential({
       env: { VENDO_DEV_CREDENTIAL: "env-key:openai", OPENAI_API_KEY: "sk-2", ANTHROPIC_API_KEY: "sk-1" },
     })).toEqual({ rung: "env-key", provider: "openai", envVar: "OPENAI_API_KEY" });
+
+    expect(await resolveDevCredential({
+      env: { VENDO_DEV_CREDENTIAL: "env-key:anthropic", ANTHROPIC_API_KEY: "sk-1" },
+    })).toEqual({ rung: "env-key", provider: "anthropic", envVar: "ANTHROPIC_API_KEY" });
+
+    expect(await resolveDevCredential({
+      env: { VENDO_DEV_CREDENTIAL: "env-key:google", GOOGLE_GENERATIVE_AI_API_KEY: "sk-3" },
+    })).toEqual({ rung: "env-key", provider: "google", envVar: "GOOGLE_GENERATIVE_AI_API_KEY" });
 
     expect(await resolveDevCredential({
       env: { VENDO_DEV_CREDENTIAL: "env-key:openai", ANTHROPIC_API_KEY: "sk-1" },

--- a/packages/vendo/tests/onboarding-error-rails.test.ts
+++ b/packages/vendo/tests/onboarding-error-rails.test.ts
@@ -54,6 +54,16 @@ async function rejection(call: Promise<unknown>): Promise<VendoError> {
   return error as VendoError;
 }
 
+/** The env-key rungs, as they are reachable AFTER the selection law: a provider
+ *  key in the environment selects nothing on its own, so a case that exercises
+ *  one of those rungs names it through the internal VENDO_DEV_CREDENTIAL pin.
+ *  The rejected-key and missing-install rails below are unchanged; what changed
+ *  is who may ask for the rung. */
+const BYO = {
+  anthropic: { VENDO_DEV_CREDENTIAL: "env-key:anthropic", ANTHROPIC_API_KEY: "sk-a" },
+  openai: { VENDO_DEV_CREDENTIAL: "env-key:openai", OPENAI_API_KEY: "sk-o" },
+} as const;
+
 describe("the keyless model failure", () => {
   it("throws a VendoError so the safe-error gate carries the fix instead of genericizing it", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
@@ -68,7 +78,7 @@ describe("the keyless model failure", () => {
   it("throws a VendoError naming the missing provider install", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     const controller = new DevModelController({
-      env: { ANTHROPIC_API_KEY: "sk-a" },
+      env: { ...BYO.anthropic },
       importModule: async (_root, specifier) => { throw new Error(`Cannot find module '${specifier}'`); },
     });
     const error = await rejection(controller.doGenerate({ prompt: [] }));
@@ -97,7 +107,7 @@ describe("a rejected key names the rung it was rejected on", () => {
   it("sends an env-key rung to its own env var, never to `vendo login`", async () => {
     const refused = unauthorized();
     const controller = new DevModelController({
-      env: { OPENAI_API_KEY: "sk-o" },
+      env: { ...BYO.openai },
       importModule: failingProvider("createOpenAI", refused),
     });
     const error = await rejection(controller.doGenerate({ prompt: [] }));
@@ -127,7 +137,7 @@ describe("a rejected key names the rung it was rejected on", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     const patterns = { "image/*": [/^https:\/\/example\.test\/.*$/] };
     const controller = new DevModelController({
-      env: { OPENAI_API_KEY: "sk-o" },
+      env: { ...BYO.openai },
       importModule: failingProvider("createOpenAI", unauthorized(), patterns),
     });
     expect(await lazy(controller.model()).supportedUrls).toEqual(patterns);
@@ -144,7 +154,7 @@ describe("a rejected key names the rung it was rejected on", () => {
 
     const overloaded = Object.assign(new Error("Overloaded"), { statusCode: 529 });
     const transient = new DevModelController({
-      env: { ANTHROPIC_API_KEY: "sk-a" },
+      env: { ...BYO.anthropic },
       importModule: failingProvider("createAnthropic", overloaded),
     });
     await expect(transient.doGenerate({ prompt: [] })).rejects.toBe(overloaded);
@@ -177,7 +187,12 @@ describe("end to end: a keyless turn through the real composed door", () => {
     });
     expect(response.status).toBe(200);
     const stream = await response.text();
-    expect(stream).toContain(`Vendo: ${NO_CREDENTIAL_MESSAGE} (validation)`);
+    // The frame carries the sentence JSON-encoded, and the sentence quotes a code
+    // snippet — models: { default: anthropic("claude-sonnet-4-6") } — so the raw
+    // bytes contain the ESCAPED form. Compare against that, not the plain string,
+    // or this passes for the wrong reason the day the message loses its quotes.
+    const framed = JSON.stringify(`Vendo: ${NO_CREDENTIAL_MESSAGE} (validation)`).slice(1, -1);
+    expect(stream).toContain(framed);
     expect(stream).not.toContain("An error occurred while generating the response.");
 
     // The same frame, read by `vendo doctor`'s live-turn check.

--- a/packages/vendo/tests/server-venue.test.ts
+++ b/packages/vendo/tests/server-venue.test.ts
@@ -9,13 +9,15 @@ import { createStore, type VendoStore } from "@vendoai/store";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 // 0.4.4 defect C — the field host (Turbopack server bundle, no e2b install)
-// had e2bInstalled() blanket-passing, so a stray E2B_API_KEY outranked the
-// Cloud sandbox and the first build died in an unusable venue. This file pins
-// the ADAPTER RULE's ladder against exactly that: an e2b the runtime cannot
-// load is never selected. Cloud-audit fix 5 sharpened the answer — half a BYO
-// sandbox is now a LOUD compose-time misconfig instead of a silent demotion to
-// Cloud (or to the dark venue), so the operator learns at startup rather than
-// at the first server-app build.
+// had e2bInstalled() blanket-passing, so a stray E2B_API_KEY outranked the Cloud
+// sandbox and the first build died in an unusable venue. Two answers were tried:
+// blanket-pass, then a LOUD compose-time misconfig. The SELECTION LAW removes the
+// question instead — E2B_API_KEY is a credential, not a rung, so no stray key can
+// flip a deployment's venue in either direction.
+//
+// The unloadable-SDK mock stays as the TRIPWIRE for that: this is the field host's
+// exact shape, and nothing in the composition path may consult installability any
+// more. Re-introduce an env-driven e2b rung and every case below changes answer.
 vi.mock("@vendoai/apps/e2b", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@vendoai/apps/e2b")>()),
   e2bInstalled: () => false,
@@ -64,27 +66,28 @@ describe("venue ladder with an unloadable e2b SDK (0.4.4 defect C)", () => {
     })).toBe("cloud");
   });
 
-  it("refuses to compose: an E2B_API_KEY without a loadable SDK is a misconfig, not a demotion to Cloud", async () => {
-    await expect(venueFor({
+  it("resolves cloud with the SAME stray E2B_API_KEY added — the key does not select, so nothing changes", async () => {
+    expect(await venueFor({
       E2B_API_KEY: "e2b_leaked_from_shell",
       VENDO_API_KEY: "vnd_cloud_key",
       ANTHROPIC_API_KEY: "sk-ant-byo",
-    })).rejects.toThrow("E2B_API_KEY is set but the e2b package is not installed");
+    })).toBe("cloud");
   });
 
-  it("names the exact fix rather than going dark when the SDK is unloadable and no Vendo key is set", async () => {
-    await expect(venueFor({ E2B_API_KEY: "e2b_leaked_from_shell" }))
-      .rejects.toThrow("install e2b, or unset E2B_API_KEY to use another sandbox");
+  it("goes dark rather than refusing when a stray E2B_API_KEY is the only key set", async () => {
+    // The required breaking-change case: composing must SUCCEED and report the
+    // dark venue. A tree-only host is fine here; a server-work attempt is what
+    // reports sandbox-unavailable, one layer up.
+    expect(await venueFor({ E2B_API_KEY: "e2b_leaked_from_shell" })).toBe(false);
   });
 
-  it("treats a whitespace-only E2B_API_KEY as unset, the way doctor's check reads it", async () => {
-    // environment() only strips "", so a stray-space value used to reach the
-    // throw above while `vendo doctor` (which trims) reported no key set.
+  it("reads a whitespace-only E2B_API_KEY the same as any other value: not a selector", async () => {
     expect(await venueFor({
       E2B_API_KEY: "   ",
       VENDO_API_KEY: "vnd_cloud_key",
       ANTHROPIC_API_KEY: "sk-ant-byo",
     })).toBe("cloud");
+    expect(await venueFor({ E2B_API_KEY: "   " })).toBe(false);
   });
 
   it("still lets an explicit sandbox: adapter win before any env check", async () => {

--- a/packages/vendo/tests/server.test.ts
+++ b/packages/vendo/tests/server.test.ts
@@ -668,7 +668,7 @@ describe("09 §3 public wire", () => {
     });
   });
 
-  it("selects explicit, E2B, Cloud, and dark venues with the required precedence", async () => {
+  it("selects explicit, Cloud, and dark venues with the required precedence", async () => {
     const custom: SandboxAdapter = {
       create: vi.fn(async () => { throw new Error("not called"); }),
       resume: vi.fn(async () => { throw new Error("not called"); }),
@@ -690,16 +690,18 @@ describe("09 §3 public wire", () => {
       return (await status.json() as { blocks: { sandbox: unknown } }).blocks.sandbox;
     };
 
-    // Adapter rule (2026-07-17 cloud definition): the explicit adapter always
-    // wins; BYO sandbox env beats the Vendo key (the Cloud default fills ONLY
-    // the slot the host left unfilled); no key and no BYO env → dark.
+    // Adapter rule (2026-07-17 cloud definition) as the SELECTION LAW sharpened
+    // it: the explicit adapter always wins; VENDO_API_KEY fills ONLY the slot the
+    // host left unfilled; nothing else selects. A stray E2B_API_KEY is a
+    // credential now — present or absent, it changes no answer here.
     const allKeys = {
       E2B_API_KEY: "e2b-key",
       VENDO_API_KEY: "vnd_cloud_key",
     };
     expect(await statusFor(allKeys, custom)).toBe("custom");
-    expect(await statusFor(allKeys)).toBe("e2b");
+    expect(await statusFor(allKeys)).toBe("cloud");
     expect(await statusFor({ ...allKeys, E2B_API_KEY: "" })).toBe("cloud");
+    expect(await statusFor({ ...allKeys, VENDO_API_KEY: "" })).toBe(false);
     expect(await statusFor({ ...allKeys, E2B_API_KEY: "", VENDO_API_KEY: "" })).toBe(false);
     expect(custom.create).not.toHaveBeenCalled();
     expect(custom.resume).not.toHaveBeenCalled();


### PR DESCRIPTION
## What — the release's one breaking change

**Env keys are credentials. Config selects.** A third-party provider key sitting in the environment no longer selects any adapter or behavior. `VENDO_API_KEY` remains the only blessed default-filler for slots the host left unset.

Applied to all four doors:

- **Sandbox** — the `E2B_API_KEY` rung is gone. Ladder is now: explicit adapter → `VENDO_API_KEY` Cloud → none. `E2B_API_KEY` is read only by an explicit `e2bSandbox()`, as its credential.
- **Agent model** — the `ENV_KEY_VARS` loop is gone. Explicit `models` config → `VENDO_API_KEY` gateway → boot error.
- **Box inference** — the `ANTHROPIC_API_KEY` endpoint fallback is gone. Explicit `VENDO_INFERENCE_URL`+`KEY` pair → `VENDO_API_KEY` gateway → undefined.
- **Claude Code harness** — same law in `inferenceEnv`; a stray `ANTHROPIC_API_KEY` selects nothing.

Every boot error teaches both ways out — explicit config first, then `VENDO_API_KEY`.

## Migration

`vendo init` now writes the explicit `models:` line for you (#1208), so upgrading hosts have the explicit-config path already taken.

## The coupled edit that would have silently broken

`MODEL_UNAVAILABLE_SIGNAL` in `@vendoai/apps` was anchored byte-for-byte to the old `"Vendo found no model key"`. Rewording the message without retuning that regex would have stopped the actionable message reaching users, with nothing going red.

`apps` may not import `vendo`, and `buildFailureReason` is not on apps' public surface, so a single-process seam test wasn't possible without growing public API. Instead the literal is pinned from **both** sides against the real halves: the apps test feeds the literal through the real `buildFailureReason`; the vendo test asserts the real constant equals it byte-for-byte. Reword the message → the vendo test fails. Retune the pattern → the apps test fails. Each test names the other by title. **Stated honestly: this is a paired-literal tripwire, not one process reading through both halves.**

## Gate

`build` 0 · `typecheck` 0 · `lint` 0 · four owned packages green: **apps 1540** · **vendo 2223** · **harnesses 539** · **agents 84**. Green downstream: store 502, ui unit 966, corpus 189, mcp-e2e 19, automations-e2e 65, redteam 23, demo-bank 119.

`test:affected` exits 1 on two Playwright tasks (`ui#test:ui`, `genbench#test`) — **environmental, proven pre-existing**: no browser is installed on this machine, and stashing the entire diff reproduces the identical `browserType.launch: Executable doesn't exist`. Per CLAUDE.md those are a local browser gate CI never runs, and nothing here touches `ui` or `genbench`.

## Known blast radius NOT fixed here — outside this slice's fence

These are real user-visible consequences of the breaking change that the spec did not scope. Flagged rather than silently absorbed:

1. **`vendo sync --ai` regresses.** `resolveJudgmentEngine` gates on `resolveDevCredential`, widened only by `hasOwnAnthropicEnvOverride`, which does not cover `ANTHROPIC_API_KEY`. A dev whose only credential is that key now gets `engine: null` with the reason *"no model credential — set ANTHROPIC_API_KEY … or VENDO_API_KEY"* — telling them to set the key they already have. Its tests inject the resolver, so nothing went red.
2. **`vendo init --byo` writes a key that does nothing.** It prompts for a provider key into `.env.local`, and the closing advice still points at those vars. Both are now dead ends; the BYO path needs to write a `models:` block.
3. **Local-mode Claude Code hosts break.** `localMachine` replaces the subprocess env with `inferenceEnv()`, so `machine: "local"` with only `ANTHROPIC_API_KEY` yields a subprocess with no model — intended by door (d), but with no boot error in front of it.

## Two implicit decisions taken

- `VENDO_E2B_TIMEOUT_MS` / `VENDO_BOX_EDIT_TIMEOUT_MS` would have become dead code when the rung died. Rather than silently delete operator knobs, they moved into `e2bSandbox()` beside the credential, inline `timeoutMs` outranking both — and the knob tests now assert the real timeout handed to the provider, which the old ladder tests could not.
- `inferenceEnv` reads "explicit pair" strictly: both `VENDO_INFERENCE_URL` and `VENDO_INFERENCE_KEY`, or neither.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces the selection law: env keys are credentials, config selects. Third‑party provider env vars no longer choose adapters; only `VENDO_API_KEY` can fill unset slots. Boot errors now name both exits in order: explicit config first, then `VENDO_API_KEY`.

- **Refactors**
  - Sandbox: remove `E2B_API_KEY` rung. Precedence is explicit adapter → Cloud (`VENDO_API_KEY`) → none. Move SDK install check and timeouts into `e2bSandbox()`; a stray `E2B_API_KEY` selects nothing.
  - Agent model: drop the `ENV_KEY_VARS` sweep. Resolution is `models` config → `VENDO_API_KEY` gateway → boot error. Env‑key rung remains only via internal `VENDO_DEV_CREDENTIAL`.
  - Box inference: drop `ANTHROPIC_API_KEY` fallback. Use `VENDO_INFERENCE_URL`+`VENDO_INFERENCE_KEY` → `VENDO_API_KEY` gateway → none.
  - Claude Code: `inferenceEnv()` follows the same law; `ANTHROPIC_*` does not select; pair‑or‑none.
  - Doctor: remove the e2b usability check; `E-LIVE-007` marked retired. Dark‑venue guidance now points to `sandbox: e2bSandbox()` or `VENDO_API_KEY`.
  - Build messages: `@vendoai/apps` `MODEL_UNAVAILABLE_SIGNAL` now anchors on `@vendoai/vendo` `NO_CREDENTIAL_MESSAGE`; tests pin the exact bytes.

- **Migration**
  - Define `models` in `createVendo` (e.g. `models: { default: anthropic("claude-sonnet-4-6") }`) or set `VENDO_API_KEY`. `vendo init` now writes `models:` for you.
  - For BYO sandbox, pass `sandbox: e2bSandbox()` (install `e2b`; it still reads `E2B_API_KEY` as the credential) or rely on Cloud via `VENDO_API_KEY`.
  - For box/harness inference, set both `VENDO_INFERENCE_URL` and `VENDO_INFERENCE_KEY`, or rely on `VENDO_API_KEY`. Provider `ANTHROPIC_*` env alone no longer applies.

<sup>Written for commit c300c8c19975346bf701e7bbb202edd993b43be3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

