### PR TITLE
fix(harnesses): every onCall watcher runs, not just the last one written

### DIFF
--- a/packages/harnesses/src/runtime.ts
+++ b/packages/harnesses/src/runtime.ts
@@ -38,7 +38,7 @@ import {
   validateUpsert,
 } from "./transcript-rules.js";
 import { createCapabilityMissDetector, type CapabilityMissConfig } from "./capability-miss.js";
-import type { ToolBridgeOptions } from "./tool-bridge.js";
+import { mergeToolCallHooks, type ToolBridgeOptions } from "./tool-bridge.js";
 import {
   createUIMessageStream,
   createUIMessageStreamResponse,
@@ -394,7 +394,12 @@ export function createHarnessRuntime(deps: HarnessRuntimeDeps): HarnessRuntime {
             // in one turn reports itself, wherever the failure came from.
             bridge: {
               ...deps.bridge,
-              ...(capabilityMiss === undefined ? {} : { onCall: capabilityMiss.onCall }),
+              // MERGED, not assigned: the detector's hook used to be assigned into
+              // this slot, replacing whatever composition had already put there —
+              // the turn's own tool counting — so every composed deployment
+              // reported zero tool calls and an empty tool list. One
+              // unconditional merge, and a fourth watcher joins the argument list.
+              onCall: mergeToolCallHooks(deps.bridge?.onCall, capabilityMiss?.onCall),
               writer,
               connectCards: new Set<string>(),
             },

--- a/packages/harnesses/src/tool-bridge.ts
+++ b/packages/harnesses/src/tool-bridge.ts
@@ -10,6 +10,7 @@ import {
   vendoViewPart,
   vendoViewPartSchema,
   isVendoAppsTool,
+  log,
   type ApprovalId,
   type Guard,
   type RiskLabel,
@@ -32,6 +33,10 @@ import type { UIMessage, UIMessageStreamWriter } from "ai";
 
 type VendoPart = VendoApprovalPart | VendoAutomationPart | VendoBuildFailedPart | VendoCitationsPart | VendoConnectPart | VendoViewPart;
 
+/** An observer of one guarded call: invoked before the gate, returning the
+ *  finisher that receives the model-visible outcome. */
+export type ToolCallHook = (call: ToolCall) => (outcome: ToolOutcome) => void;
+
 /** 03-agent §2 */
 export interface ToolBridgeOptions {
   registry: ToolRegistry;
@@ -40,7 +45,15 @@ export interface ToolBridgeOptions {
   writer?: UIMessageStreamWriter<UIMessage>;
   toolOutputCap?: number;
   gate?: (call: ToolCall) => ToolOutcome | undefined;
-  onCall?: (call: ToolCall) => (outcome: ToolOutcome) => void;
+  /** Observes every guarded call. THREE independent call sites want this one slot
+   * — composition's turn shape (harness-turn.ts), the away run record
+   * (agents/away.ts), and the runtime's capability-miss detector — and a plain
+   * assignment silently drops whoever wrote it first, which is how every composed
+   * turn came to report zero tool calls. Fill it through
+   * {@link mergeToolCallHooks}; never assign over a value that may already be
+   * there. A hook that throws is logged and skipped: watching a call may never
+   * fail, delay or reorder it. */
+  onCall?: ToolCallHook;
   /** Discovery-discipline 2026-07-25: a pre-guard short-circuit (the connect
    * gate). A non-undefined outcome means the call cannot run — needsApproval
    * skips the guard entirely (no approval minted; the ask would be answered
@@ -52,6 +65,47 @@ export interface ToolBridgeOptions {
    * matter how many of its tools the model called. Omit to disable deduping
    * (the away runner has no card surface). */
   connectCards?: Set<string>;
+}
+
+/** Runs one hook, reporting a throw instead of propagating it. */
+function isolate<T>(run: () => T): T | undefined {
+  try {
+    return run();
+  } catch (error) {
+    log({
+      code: "harnesses.tool-call-hook-failed",
+      level: "error",
+      message: "[vendo] tool bridge: an onCall hook threw",
+      data: { detail: { error: error instanceof Error ? error.message : String(error) } },
+    });
+    return undefined;
+  }
+}
+
+/**
+ * The ONE hook that runs all of them, in argument order, on both halves of a
+ * call: every hook is opened before the gate, and every finisher it handed back
+ * runs on the outcome. `undefined` arguments drop out, so a caller passes an
+ * optional hook straight through.
+ *
+ * This exists so a caller that wants to observe calls ADDS itself to the
+ * `onCall` slot instead of assigning over it. Assignment is how the turn's tool
+ * counting disappeared: `{ ...bridge, onCall: mine }` type-checks, reads as
+ * additive, and silently throws away the hook the spread just copied in.
+ *
+ * A hook that throws — on the way in or on the outcome — is logged and skipped:
+ * it neither fails the tool call nor stops any other hook.
+ */
+export function mergeToolCallHooks(...hooks: Array<ToolCallHook | undefined>): ToolCallHook {
+  const present = hooks.filter((hook) => hook !== undefined);
+  return (call) => {
+    const finishers = present
+      .map((hook) => isolate(() => hook(call)))
+      .filter((finish) => finish !== undefined);
+    return (outcome) => {
+      for (const finish of finishers) isolate(() => finish(outcome));
+    };
+  };
 }
 
 function writePart(
@@ -183,7 +237,7 @@ export async function guardedCall(
       },
     });
   }
-  const finishCall = options.onCall?.(call);
+  const finishCall = mergeToolCallHooks(options.onCall)(call);
   let outcome = options.gate?.(call);
   if (outcome === undefined) {
     try {
@@ -271,7 +325,7 @@ export async function guardedCall(
   }
 
   const modelOutcome = capOutcome(outcome, options.toolOutputCap);
-  finishCall?.(modelOutcome);
+  finishCall(modelOutcome);
   return modelOutcome;
 }
 

--- a/packages/harnesses/tests/tool-call-hooks.test.ts
+++ b/packages/harnesses/tests/tool-call-hooks.test.ts
@@ -1,0 +1,156 @@
+/**
+ * The `onCall` slot's isolation contract.
+ *
+ * Several independent watchers share this one slot on a composed turn — the
+ * turn's tool counting (composition, harness-turn.ts), the away run record
+ * (agents/away.ts), the capability-miss detector (this runtime). That they all
+ * RUN is proven at the composition seam, in
+ * `packages/vendo/tests/tool-call-hooks.seam.test.ts`, where the real
+ * composition fills two of them.
+ *
+ * What is pinned here is the half no composed turn can stage: a watcher that
+ * THROWS. A watcher is an observer, so a throw is logged and skipped — it may
+ * not fail the tool call, change its outcome, or stop any other watcher, on the
+ * way in or on the way out.
+ */
+import { setLogger, type CapabilityMissEvent, type Harness, type ThreadId, type ToolOutcome, type VendoLogEvent } from "@vendoai/core";
+import { afterEach, describe, expect, it } from "vitest";
+import { defineHarness } from "../src/define.js";
+import { memoryHarnessStateStore } from "../src/harness-state.js";
+import { createHarnessRuntime } from "../src/runtime.js";
+import { mergeToolCallHooks, type ToolCallHook } from "../src/tool-bridge.js";
+import {
+  boundRegistry,
+  ctx,
+  readSse,
+  readTool,
+  testGuard,
+  testSkills,
+  testTranscript,
+  testWorkspace,
+  unusedModels,
+  userMessage,
+} from "../src/test-doubles.test-util.js";
+
+const THREAD = "thr_hooks" as ThreadId;
+
+afterEach(() => {
+  setLogger(undefined);
+});
+
+/**
+ * One turn on the real runtime with `watchers` filling composition's bridge slot
+ * — the shape the umbrella really passes — while the runtime adds the real
+ * capability-miss detector to the same slot on top.
+ */
+async function runTurn(watchers: ToolCallHook, harness: Harness): Promise<{
+  logs: VendoLogEvent[];
+  misses: CapabilityMissEvent[];
+}> {
+  const logs: VendoLogEvent[] = [];
+  const misses: CapabilityMissEvent[] = [];
+  setLogger((event) => { logs.push(event); });
+  const guard = testGuard();
+  const registry = boundRegistry({
+    maple_invoices_list: { descriptor: readTool("maple_invoices_list"), execute: () => ({ count: 2 }) },
+    maple_ledger_export: {
+      descriptor: readTool("maple_ledger_export"),
+      execute: () => { throw new Error("the ledger is offline"); },
+    },
+  }, guard);
+  const runtime = createHarnessRuntime({
+    tools: registry,
+    guard,
+    skills: testSkills(),
+    transcript: testTranscript(),
+    harnessState: memoryHarnessStateStore(),
+    bridge: { onCall: watchers },
+  });
+  // Drained, exactly as a host route does: the turn's own cleanup only runs on
+  // consumption.
+  await readSse(await runtime.run({
+    harness,
+    threadId: THREAD,
+    messages: [userMessage("m1", "export the ledger")],
+    ctx: ctx(),
+    workspace: testWorkspace(),
+    models: unusedModels(),
+    interactive: true,
+    capabilityMiss: {
+      config: {
+        hostId: "host_test",
+        surface: async () => ({ format: "vendo/tools@1", hash: `sha256:${"a".repeat(64)}` }),
+        emit: (event) => { misses.push(event); },
+      },
+      intent: "export the ledger",
+    },
+  }));
+  return { logs, misses };
+}
+
+/**
+ * The harness every case runs: one tool that answers, then the SAME broken tool
+ * twice — the capability-miss detector's `repeated-tool-failure` trigger, which
+ * it can only see through its `onCall` finisher. The reporter afterwards answers
+ * `{ reported: false }` only once the detector has ALREADY fired, so `latch` is
+ * that watcher saying, through its own product read path, that it survived.
+ */
+function caller(seen: { statuses: string[]; latch?: unknown }): Harness {
+  return defineHarness({
+    name: "caller",
+    async *run(turn) {
+      seen.statuses.push((await turn.tools.call("maple_invoices_list", {})).status);
+      seen.statuses.push((await turn.tools.call("maple_ledger_export", {})).status);
+      seen.statuses.push((await turn.tools.call("maple_ledger_export", {})).status);
+      const report = await turn.tools.call("vendo_report_capability_miss", {
+        kind: "no-matching-tool",
+        toolsConsidered: ["maple_ledger_export"],
+      });
+      seen.latch = report.status === "ok" ? report.output : report;
+      yield { type: "text", delta: "done" };
+    },
+  });
+}
+
+describe("a throwing onCall watcher", () => {
+  it("neither fails the call nor stops the other watchers when it throws on the way in", async () => {
+    const seen: { statuses: string[]; latch?: unknown } = { statuses: [] };
+    const counted: string[] = [];
+    const { logs } = await runTurn(
+      mergeToolCallHooks(
+        () => { throw new Error("watcher exploded"); },
+        (call) => { counted.push(call.tool); return () => {}; },
+      ),
+      caller(seen),
+    );
+
+    // The calls themselves are untouched: the good one still answered, the
+    // broken one still failed on its own merits.
+    expect(seen.statuses).toEqual(["ok", "error", "error"]);
+    // The watcher AFTER the thrower still saw every guarded call…
+    expect(counted).toEqual(["maple_invoices_list", "maple_ledger_export", "maple_ledger_export"]);
+    // …and so did the runtime's own, which reported on the second failure.
+    expect(seen.latch).toEqual({ reported: false });
+    // Skipped, never swallowed: an operator can grep for a broken watcher.
+    expect(logs.map((entry) => entry.code)).toContain("harnesses.tool-call-hook-failed");
+  });
+
+  it("neither changes the outcome nor stops the other watchers when its FINISHER throws", async () => {
+    const seen: { statuses: string[]; latch?: unknown } = { statuses: [] };
+    const finished: Array<ToolOutcome["status"]> = [];
+    const { logs } = await runTurn(
+      mergeToolCallHooks(
+        () => () => { throw new Error("finisher exploded"); },
+        () => (outcome) => { finished.push(outcome.status); },
+      ),
+      caller(seen),
+    );
+
+    expect(seen.statuses).toEqual(["ok", "error", "error"]);
+    // The finisher after the throwing one still received every outcome, and the
+    // outcome each watcher saw is the one the harness got.
+    expect(finished).toEqual(["ok", "error", "error"]);
+    expect(seen.latch).toEqual({ reported: false });
+    expect(logs.filter((entry) => entry.code === "harnesses.tool-call-hook-failed")).toHaveLength(3);
+  });
+});

--- a/packages/vendo/tests/tool-call-hooks.seam.test.ts
+++ b/packages/vendo/tests/tool-call-hooks.seam.test.ts
@@ -1,0 +1,159 @@
+/**
+ * The turn's TWO tool-call watchers, through the REAL composition.
+ *
+ * `agent_run`'s `toolCalls`/`tools` are counted by a hook composition puts on the
+ * bridge (harness-turn.ts); the capability-miss detector's hook is added by the
+ * harness runtime (harnesses/runtime.ts). They shared ONE `onCall` slot and the
+ * runtime's assignment won, so a composed turn that really executed host tools
+ * reported `{ toolCalls: 0, tools: [] }` — in every composed deployment, since
+ * composition always configures capability miss.
+ *
+ * Only a real turn can show that. A unit test that calls `onCall` itself never
+ * touches the assignment that discarded it, and a harness that mocks either
+ * watcher lets the two agree forever. So: one composed turn, real host tools that
+ * really run, both watchers read through their own production read path — the
+ * usage sink for the count, and the reporter tool's `reported` latch for the miss
+ * detector (it answers `false` only once the detector has already fired).
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Principal, ToolDescriptor, ToolRegistry, VendoUsageEvent } from "@vendoai/core";
+import { setUsageSink } from "@vendoai/core";
+import { defineHarness } from "@vendoai/harnesses";
+import { createStore, type VendoStore } from "@vendoai/store";
+import type { LanguageModel, UIMessage } from "ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createVendo, type Vendo } from "../src/server.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  // A leaked sink is another suite's failure, not this one's.
+  setUsageSink(undefined);
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+const principal: Principal = { kind: "user", subject: "user_hooks" };
+
+const request = (path: string, body: unknown): Request =>
+  new Request(`https://host.test/api/vendo${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+const userMessage = (id: string, text: string): UIMessage =>
+  ({ id, role: "user", parts: [{ type: "text", text }] }) as UIMessage;
+
+const descriptor = (name: string): ToolDescriptor => ({
+  name,
+  title: name,
+  description: `The host's ${name}`,
+  inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  // `read` throughout: the guard runs a read silently, so what this file measures
+  // is the watchers and never an approval card.
+  risk: "read",
+});
+
+/**
+ * Two REAL host tools with observable side effects: one that answers, and one
+ * that is broken the same way twice — which is exactly what the capability-miss
+ * detector watches `onCall` for.
+ */
+function hostTools(): { tools: ToolRegistry; executed: string[] } {
+  const executed: string[] = [];
+  return {
+    executed,
+    tools: {
+      async descriptors() {
+        return [descriptor("maple_invoices_list"), descriptor("maple_ledger_export")];
+      },
+      async execute(call) {
+        executed.push(call.tool);
+        if (call.tool === "maple_ledger_export") {
+          return { status: "error", error: { code: "upstream", message: "the ledger is offline" } };
+        }
+        return { status: "ok", output: { invoices: [{ id: "inv_1" }] } };
+      },
+    },
+  };
+}
+
+async function compose(harness: Parameters<typeof createVendo>[0]["harness"]): Promise<{
+  vendo: Vendo;
+  host: ReturnType<typeof hostTools>;
+  runs: VendoUsageEvent[];
+}> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-tool-hooks-"));
+  const store: VendoStore = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  const host = hostTools();
+  const vendo = createVendo({
+    // Never reached: the harness below is scripted, so no provider is involved.
+    model: {} as LanguageModel,
+    principal: async () => principal,
+    store,
+    harness,
+  });
+  vendo.actions.add(host.tools);
+  // AFTER createVendo: composition installs its own sink at boot (undefined
+  // without a Cloud key), so an earlier install would simply be replaced.
+  const runs: VendoUsageEvent[] = [];
+  setUsageSink((event) => { if (event.name === "agent_run") runs.push(event); });
+  return { vendo, host, runs };
+}
+
+describe("both tool-call watchers survive a composed turn", () => {
+  it("counts every executed call AND still reports the capability miss", async () => {
+    let latch: unknown;
+    const { vendo, host, runs } = await compose(defineHarness({
+      name: "scripted",
+      async *run(turn) {
+        await turn.tools.call("maple_invoices_list", {});
+        // Twice, and the same tool: two failures in one turn is the detector's
+        // `repeated-tool-failure` trigger, and it can only see them through the
+        // `onCall` finisher.
+        await turn.tools.call("maple_ledger_export", {});
+        await turn.tools.call("maple_ledger_export", {});
+        // The reporter answers `{ reported: false }` only when the detector has
+        // ALREADY reported — so this is the miss rail's own read path saying its
+        // hook ran, with nothing stubbed on either side.
+        const outcome = await turn.tools.call("vendo_report_capability_miss", {
+          kind: "no-matching-tool",
+          toolsConsidered: ["maple_ledger_export"],
+        });
+        latch = outcome.status === "ok" ? outcome.output : outcome;
+        yield { type: "text", delta: "done" };
+      },
+    }));
+
+    const turn = await vendo.handler(request("/threads", {
+      threadId: "thr_hooks", message: userMessage("m1", "export the ledger"),
+    }));
+    expect(await turn.text()).toContain("done");
+
+    // The host tools really ran — not a mirror, not a stub.
+    expect(host.executed).toEqual([
+      "maple_invoices_list",
+      "maple_ledger_export",
+      "maple_ledger_export",
+    ]);
+
+    // Watcher one, read off the shipped usage sink. The reporter tool is
+    // dispatched before the guarded-call path, so it is deliberately not counted.
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toMatchObject({
+      name: "agent_run",
+      toolCalls: 3,
+      tools: ["maple_invoices_list", "maple_ledger_export"],
+      outcome: "ok",
+    });
+
+    // Watcher two, unchanged: the detector fired on the second failure, so the
+    // reporter has nothing left to report.
+    expect(latch).toEqual({ reported: false });
+  });
+});


### PR DESCRIPTION
## The bug

`agent_run` reported `{"toolCalls":0,"tools":[]}` for **every composed turn**, however many host tools actually ran. Two fields of the SDK's usage event were dead in production.

The tool bridge's `onCall` is a single slot with three independent writers:

| writer | what it watches |
| --- | --- |
| `packages/vendo/src/harness-turn.ts:408` | the turn's tool count and tool names (`agent_run`) |
| `packages/agents/src/away.ts:283` | the away run record |
| `packages/harnesses/src/runtime.ts:397` | the capability-miss detector |

The runtime **assigned** the detector's hook into the slot, one line below the spread that had just copied composition's hook in:

```ts
bridge: {
  ...deps.bridge,
  ...(capabilityMiss === undefined ? {} : { onCall: capabilityMiss.onCall }),
```

`packages/harnesses/src/tool-bridge.ts:186` then invoked the single survivor. Composition always configures `capabilityMiss` (`compose-prompt.ts:59` → `compose-harness.ts:211`), so the counting hook was discarded in every composed deployment.

## The fix

`mergeToolCallHooks` (`packages/harnesses/src/tool-bridge.ts`) returns the one hook that runs all of them, in argument order, on both halves of a call — opened before the gate, finishers run on the outcome. The runtime now appends instead of replacing, in one unconditional merge, so a fourth watcher joins an argument list rather than racing for the slot.

Every hook is also isolated at the point of invocation, which covers the hooks `harness-turn.ts` and `away.ts` set directly too: one that throws — on the way in or on the outcome — is logged under `harnesses.tool-call-hook-failed` and skipped. An observer may not fail the tool call it is watching, change its outcome, or stop another observer.

**Why `tool-bridge.ts` and not only the call site:** the clobber is a property of the slot, not of one caller — three files write it. And isolation has to live where the hooks are invoked, or the two hooks set directly on the bridge stay unprotected.

**Ordering:** composition's hooks first, then the runtime's capability-miss hook; finishers in the same order, not reverse-unwind, because these are independent observers rather than nested resources. Nothing observable depends on the order — what does matter is preserved exactly: hooks open *before* the gate and `registry.execute`, finishers run *after* `capOutcome`.

## Proof at the seam

`packages/vendo/tests/tool-call-hooks.seam.test.ts` — a **real composed turn** through `createVendo` + `vendo.handler`, real store, real guard, real host tools that really execute. Nothing stubbed on either side:

- the count is read off the shipped usage sink (`setUsageSink` → `agent_run`);
- the miss detector is read through its own product read path — the reporter tool answers `{ reported: false }` only once the detector has already fired.

Both mutations go red:

| mutation | result |
| --- | --- |
| restore the replacing spread (the live bug) | `toolCalls: 0, tools: []` vs expected `3` / `["maple_invoices_list","maple_ledger_export"]` |
| merge composition's hook only, drop the detector's | `{ reported: true }` vs expected `{ reported: false }` |

`packages/harnesses/tests/tool-call-hooks.test.ts` pins the half no composed turn can stage — a watcher that throws, on entry and in its finisher.

## Gate

| command | result |
| --- | --- |
| `pnpm build` | 21/21 tasks |
| `packages/harnesses` `npx vitest run` | 538 passed, 7 skipped, 0 failed |
| `packages/vendo` `npx vitest run` (6 foreground shards) | 2236 passed, 42 skipped, 0 failed |
| `typecheck` (harnesses + vendo) | clean |
| `node scripts/dependency-guard.mjs` | OK (30 packages) |
| `node scripts/portability-gate.mjs` | all legs green |

No existing test file was modified. The capability-miss suites (`packages/vendo/tests/capability-misses.test.ts`, `packages/core/tests/capability-miss.test.ts`, `packages/harnesses/tests/turn-tools.test.ts`) are byte-unmodified and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where only the last `onCall` watcher ran. All watchers now run and are isolated, so composed turns correctly report tool usage (`agent_run.toolCalls` and `tools`).

- **Bug Fixes**
  - Added `mergeToolCallHooks` in `packages/harnesses/src/tool-bridge.ts` to combine hooks, invoke each before/after the call, and isolate throws (logs `harnesses.tool-call-hook-failed`).
  - Updated `createHarnessRuntime` to merge hooks instead of overwriting, so the capability-miss detector no longer clobbers composition’s counting hook.
  - Wired merged hook into `guardedCall` to ensure a single combined hook drives all watchers; preserves order (composition first, then runtime), with finishers in the same order.
  - Added tests: `packages/harnesses/tests/tool-call-hooks.test.ts` (throw isolation) and `packages/vendo/tests/tool-call-hooks.seam.test.ts` (real composed turn with 3 counted calls and capability-miss still firing).

<sup>Written for commit 0288fcc2bc368197be5b52bec39bde9d7c1cbd83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

