### PR TITLE
fix(vendo): deployment_boot reports the adapters it actually runs

### DIFF
--- a/packages/core/src/sdk-events.ts
+++ b/packages/core/src/sdk-events.ts
@@ -14,8 +14,10 @@
  */
 
 export type VendoUsageEvent =
-  /** One deployment came up: which adapter slots it filled, which blocks
-   *  mounted, and the host framework when its runtime announces itself. */
+  /** One deployment came up: which adapters it is RUNNING (after the adapter
+   *  rule has filled every slot the host left unset — not the slots themselves),
+   *  which blocks mounted, and the host framework when its runtime announces
+   *  itself. */
   | { name: "deployment_boot"; adapters: string[]; blocks: string[]; framework: string | null }
   /** One agent turn ended. `tools` are NAMES; `modelFamily` is the model id the
    *  thinking seat resolved to, never a key or a URL. */

--- a/packages/vendo/src/compose-context.ts
+++ b/packages/vendo/src/compose-context.ts
@@ -65,7 +65,7 @@ import { composeMcp } from "./compose-mcp.js";
 import { composePrompt } from "./compose-prompt.js";
 import { composeSurfaces } from "./compose-surfaces.js";
 import { composeSweep } from "./compose-sweep.js";
-import { composeTools } from "./compose-tools.js";
+import { composeTools, emitDeploymentBoot } from "./compose-tools.js";
 import type { ConfigSurfaceName } from "./config-surface.js";
 import type { ResolvedSweep } from "./compose-config.js";
 import type { ConnectionsService } from "./connections.js";
@@ -278,5 +278,9 @@ export const createComposition = (input: CreateVendoConfig): VendoComposition =>
   Object.assign(composition, composeAutomations(composition));
   Object.assign(composition, composeConnections(composition));
   Object.assign(composition, composeMcp(composition));
+  // LAST, and it has to be: `deployment_boot` names the adapters this
+  // deployment RUNS, and the connections adapter is not selected until
+  // compose-discovery.ts above.
+  emitDeploymentBoot(composition);
   return composition;
 };

--- a/packages/vendo/src/compose-tools.ts
+++ b/packages/vendo/src/compose-tools.ts
@@ -72,26 +72,39 @@ const connectorDiscoveryPorts = (
     },
 });
 
-/** `deployment_boot`'s three lists, from the names composition can already see
- *  at this phase: which adapter SLOTS the deployment filled, which optional
- *  BLOCKS mounted, and the host framework when its runtime announces itself.
- *  NAMES only — never a URL, a key, or a host identifier. */
+/** `deployment_boot`'s three lists: which adapters this deployment is RUNNING,
+ *  which optional BLOCKS mounted, and the host framework when its runtime
+ *  announces itself. NAMES only — never a URL, a key, or a host identifier.
+ *
+ *  Every name is read from what the adapter rule SELECTED, never from the slot
+ *  the host filled. The two disagree on every Cloud-defaulted seam: a
+ *  deployment that passes no `sandbox` and runs the Cloud sandbox is running a
+ *  sandbox, and a list built from `config` reports none — an undercount that
+ *  looks exactly like a deployment with no sandbox at all. */
 const bootShape = (
   composition: VendoComposition,
-  knowledge: boolean,
 ): { adapters: string[]; blocks: string[]; framework: string | null } => {
-  const { config, resolvedConnectors, appsMounted, automationsMounted } = composition;
-  const filled = (name: string, slot: unknown): string[] => (slot === undefined ? [] : [name]);
+  const {
+    config, sandbox, connections, resolvedConnectors, knowledgeIndex, appsMounted, automationsMounted,
+  } = composition;
+  // The knowledge adapter and its prompt index compose together or not at all
+  // (composeTools below), so the resolver's presence IS the adapter's.
+  const knowledge = knowledgeIndex !== undefined;
+  const running = (name: string, live: boolean): string[] => (live ? [name] : []);
   return {
     adapters: [
-      ...filled("store", config.store),
-      ...filled("files", config.files),
-      ...filled("sandbox", config.sandbox),
-      ...filled("secrets", config.secrets),
-      ...filled("harness", config.harness),
-      ...filled("connections", config.connections),
-      ...(knowledge ? ["knowledge"] : []),
-      ...(resolvedConnectors.length === 0 ? [] : ["connectors"]),
+      // Persistence, blob storage, secrets and the thinker always resolve to
+      // something — the local store, the store-backed files adapter, the env
+      // provider, the composed `vendo()` harness — so every deployment runs one
+      // of each, whether or not it passed one.
+      "store",
+      "files",
+      ...running("sandbox", sandbox.venue !== false),
+      "secrets",
+      "harness",
+      ...running("connections", connections.posture !== false),
+      ...running("knowledge", knowledge),
+      ...running("connectors", resolvedConnectors.length > 0),
     ],
     blocks: [
       ...(appsMounted ? ["apps"] : []),
@@ -104,6 +117,14 @@ const bootShape = (
     // else is honestly unknown rather than guessed.
     framework: environment("NEXT_RUNTIME") === undefined ? null : "next",
   };
+};
+
+/** One deployment came up. Emitted by `createComposition` once every phase has
+ *  run, because that is the first moment the answer exists: the connections
+ *  adapter is not chosen until compose-discovery.ts, so a boot event raised
+ *  mid-composition could only report the host's config. */
+export const emitDeploymentBoot = (composition: VendoComposition): void => {
+  emitUsage({ name: "deployment_boot", ...bootShape(composition) });
 };
 
 /** The discovery pair, the knowledge tool, and the capability-miss surface. */
@@ -195,6 +216,8 @@ export const composeTools = (composition: VendoComposition): Pick<VendoCompositi
     ...(missCloud === undefined ? {} : { cloud: missCloud }),
     runtime: sdkRuntime(),
   })?.record);
-  emitUsage({ name: "deployment_boot", ...bootShape(composition, knowledge !== undefined) });
+  // The boot event itself is raised by `createComposition`, after every phase
+  // has run — see emitDeploymentBoot above. The SINK still has to be installed
+  // here, before the phases below it can warn.
   return { toolOutputCap, catalogConnectors, serviceCatalog, knowledgeIndex, missSurface, missCapture };
 };

--- a/packages/vendo/tests/deployment-boot.test.ts
+++ b/packages/vendo/tests/deployment-boot.test.ts
@@ -95,3 +95,12 @@ describe("deployment_boot's adapter list", () => {
     expect(boot?.adapters).toContain("sandbox");
   });
 });
+
+describe("deployment_boot's arity", () => {
+  it("raises exactly one event per composition", async () => {
+    // One composition is one deployment coming up. Two events from one process
+    // therefore mean two compositions, and that is a fact about the host worth
+    // seeing — never something this event may hide by deduplicating itself.
+    expect(bootEventsOf(await uploadedEvents())).toHaveLength(1);
+  });
+});

--- a/packages/vendo/tests/deployment-boot.test.ts
+++ b/packages/vendo/tests/deployment-boot.test.ts
@@ -1,0 +1,97 @@
+/**
+ * `deployment_boot`'s `adapters` list, read where the console reads it: off the
+ * telemetry POST this deployment's own events pipeline sends. No stub stands
+ * between the composition and the assertion — the fetch seam is the far end of
+ * the real write path, so producer and consumer cannot agree on a shape neither
+ * of them ships.
+ *
+ * The list answers "which adapters is this deployment RUNNING", which is a
+ * different question from "which slots did its host fill": every Cloud-defaulted
+ * seam runs an adapter the host never passed. A suite that only ever set slots
+ * explicitly would agree with a list built from `config` and prove nothing, so
+ * the cases below leave the slots UNSET and let the adapter rule fill them.
+ */
+import { setLogger, setUsageSink, type VendoUsageEvent } from "@vendoai/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createVendo } from "../src/server.js";
+import type { CreateVendoConfig } from "../src/types.js";
+
+/** Never resolved: the events pipeline is the only thing this suite lets talk. */
+const CONSOLE_URL = "https://console.boot-test";
+
+const bootEventsOf = (events: VendoUsageEvent[]): Extract<VendoUsageEvent, { name: "deployment_boot" }>[] =>
+  events.filter((event) => event.name === "deployment_boot");
+
+/** The one slot a composition cannot default; never resolved in this suite. */
+const identity: Pick<CreateVendoConfig, "principal"> = {
+  principal: async () => ({ kind: "user", subject: "user_boot_test" }),
+};
+
+/** Compose ONCE and hand back every usage event the stream actually uploaded. */
+async function uploadedEvents(config: CreateVendoConfig = {}): Promise<VendoUsageEvent[]> {
+  const uploaded: VendoUsageEvent[] = [];
+  vi.stubGlobal("fetch", vi.fn(async (_input: unknown, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body)) as { events?: VendoUsageEvent[] };
+    uploaded.push(...(body.events ?? []));
+    return Response.json({ accepted: body.events?.length ?? 0 }, { status: 202 });
+  }));
+  createVendo({ ...identity, ...config });
+  // The uploader batches on a 250ms timer. The budget is far under this
+  // package's 30s test timeout, so the timeout stays the only hang-detector.
+  await vi.waitFor(() => expect(uploaded.length).toBeGreaterThan(0), { timeout: 5_000, interval: 25 });
+  return uploaded;
+}
+
+beforeEach(() => {
+  // The Cloud slot is what fills every unset seam AND what installs the events
+  // pipeline — one key, both halves, exactly as a deployed host has it.
+  vi.stubEnv("VENDO_API_KEY", "vnd_boot_test");
+  vi.stubEnv("VENDO_CLOUD_URL", CONSOLE_URL);
+  // The stream's kill switches: vitest.setup.ts disables telemetry for the
+  // whole package and a CI runner sets CI, and reading what the stream sends is
+  // this suite's entire job.
+  vi.stubEnv("VENDO_TELEMETRY_DISABLED", "");
+  vi.stubEnv("DO_NOT_TRACK", "");
+  vi.stubEnv("CI", "");
+});
+
+afterEach(() => {
+  // A leaked sink or logger is another suite's failure, not this one's.
+  setUsageSink(undefined);
+  setLogger(undefined);
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("deployment_boot's adapter list", () => {
+  it("names a seam the host left UNSET that the adapter rule filled anyway", async () => {
+    const [boot] = bootEventsOf(await uploadedEvents());
+    // The live miss: demo-bank passes no `sandbox`, runs the Cloud sandbox, and
+    // reported no sandbox at all — an invisible undercount of every deployment
+    // that takes a default.
+    expect(boot?.adapters).toContain("sandbox");
+  });
+
+  it("names every adapter a wholly unconfigured Cloud deployment runs", async () => {
+    const [boot] = bootEventsOf(await uploadedEvents());
+    expect(boot?.adapters).toEqual([
+      "store",
+      "files",
+      "sandbox",
+      "secrets",
+      "harness",
+      "connections",
+      "knowledge",
+      "connectors",
+    ]);
+  });
+
+  it("leaves out a seam nothing runs — an explicit empty connector list", async () => {
+    // "No connectors, ever" is a choice the seam honors, so no connector
+    // composes and the name must not appear. Presence means running, both ways.
+    const [boot] = bootEventsOf(await uploadedEvents({ connectors: [] }));
+    expect(boot?.adapters).not.toContain("connectors");
+    expect(boot?.adapters).toContain("sandbox");
+  });
+});


### PR DESCRIPTION
Two defects were reported against the shipped `deployment_boot` event. **One is fixed here. The other turned out not to be an SDK defect at all**, and this PR deliberately does not "fix" it — see below.

## 1. Fixed: `adapters` reported SLOTS, not running adapters

`bootShape` built `adapters` from the host's `config`, so every seam the adapter rule filled by DEFAULT reported nothing.

Observed live: `demo-bank` genuinely runs the Cloud sandbox — `/api/vendo/status` reports `"sandbox":"cloud"` — yet its boot event listed only `["knowledge","connectors"]`. No sandbox, no store, no connections, because that deployment leaves those slots unset. Anyone reading this event to answer *"how many deployments run a sandbox?"* got a systematic undercount, indistinguishable from deployments that genuinely have none.

Every name now comes from what composition **selected**, at `packages/vendo/src/compose-tools.ts:84-128`:

| name | read from |
|---|---|
| `sandbox` | `sandbox.venue !== false` (the `selectSandbox` ladder) |
| `connections` | `connections.posture !== false` (`selectConnections`) |
| `knowledge` | the composed knowledge index resolver |
| `connectors` | `resolvedConnectors` (`selectConnectors`) |
| `store` / `files` / `secrets` / `harness` | always resolve to something, so always named |

**The emit moved to the end of `createComposition`** (`packages/vendo/src/compose-context.ts:284`). That is not cosmetic: the connections adapter is not selected until `composeDiscovery`, *four phases after* the boot event used to fire, so mid-composition the honest answer literally did not exist yet. The event **sink** stays in `composeTools`, before the phases that may warn through it.

Field shape is unchanged and still frozen: `adapters: string[]`, names only — no config, no credentials, no URLs.

### Evidence

Red before the fix, on the unset-slot-but-running-adapter case — the exact live signature:

```
x names a seam the host left UNSET that the adapter rule filled anyway
  -> expected [ 'knowledge', 'connectors' ] to include 'sandbox'
x names every adapter a wholly unconfigured Cloud deployment runs
  -> expected [ 'knowledge', 'connectors' ] to deeply equal [ 'store', 'files', 'sandbox', ...(5) ]
```

Mutation-proven: reverting only the sandbox line to `config.sandbox !== undefined` turns 3 tests red again.

The test reads the **real** write path end to end — real composition, real batched uploader, the actual telemetry POST body. No stub between producer and assertion.

## 2. NOT fixed, on purpose: the double `deployment_boot`

**The event was reporting the truth. Two Vendo deployments really did boot in that process.**

`examples/demo-bank/src/instrumentation.ts:16` imports `@/demo-script/seed` which imports `@/vendo/server`, which calls `createVendo()`. Next/Turbopack compiles `instrumentation.ts` into a **separate module graph** from the route handlers, so `@/vendo/server` is evaluated twice and `createVendo()` runs twice — in one PID.

Probe evidence, same process (`pid 132797`):

```
o Compiling instrumentation Node.js ...
[BOOTPROBE] 1 pid 132797   at composeTools (.../chunks/packages_vendo_1lg5lxq._.js)
o Compiling /api/vendo/[...vendo] ...
[BOOTPROBE] 2 pid 132797   at composeTools (.../chunks/packages_vendo_1nqmzni._.js)
```

Two **distinct compiled copies** of the whole `@vendoai/vendo` graph. Causally confirmed: disabling that one instrumentation import collapses it to exactly one compose per process (`[BOOTPROBE] 1` only, in each PID).

**No dedup was added.** Deduplicating the event would have hidden two live compositions sharing one `.vendo/data` directory — separate stores, caches and registries, exactly the module-identity split `next.config.ts` already warns about. That is a real problem worth seeing, not one telemetry should paper over.

What this PR adds instead is a guard that pins the SDK's half of the contract — one compose, one event (mutation-proven: emitting twice turns it red). **The demo-bank module graph is a separate decision and is not owned by this PR.**

## Pre-existing failures, not from this branch

`packages/vendo/tests/cli/init.test.ts` has **3 failing tests** about `vendo init` writing the `anthropic(...)` models line. They are **not caused by this change** — all 3 reproduce identically at clean `HEAD` with this branch's source changes stashed:

```
x writes the models line and its import once into the route it authors, and names the file
x counts a provider key that lives only in .env.local
x moves the models line into the MCP composition module, and names that file
   Tests  3 failed | 98 passed (101)
```

Flagging so the next person does not repeat the investigation.

## Local gate (bounded; CI is the gate of record)

```
packages/vendo  npx vitest run (8 directly-affected files) -> Test Files 8 passed (8)
                                                              Tests 117 passed | 1 skipped (118)
packages/core   npx vitest run                             -> Test Files 43 passed (43)
                                                              Tests 618 passed (618)
typecheck       @vendoai/vendo, @vendoai/core              -> exit 0
dependency-guard                                           -> OK (30 packages checked)
```

No UI surface is touched, so there are no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `deployment_boot` to report the adapters a deployment actually runs, not the config slots, preventing undercounts when defaults apply. The event now emits after composition completes; tests pin exactly one event per composition without dedup hiding real double-composes.

- **Bug Fixes**
  - Build the adapters list from selected composition state: always name `store`, `files`, `secrets`, `harness`; include `sandbox`, `connections`, `knowledge`, `connectors` only when running.
  - Move emission to the end of `createComposition`; the usage sink stays in `compose-tools`.
  - Add end-to-end telemetry test: asserts exactly one `deployment_boot` per composition via the real upload path.
  - No schema changes; `adapters` remains a string list.

<sup>Written for commit 54a6e89164eaf660c19ae31abf6f00e2c69a7e32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

