### PR TITLE
fix(vendo): init detects provider keys again, restoring the migration path

### DIFF
--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -839,7 +839,7 @@ async function planMcpScaffold(input: {
     // The composition moves into ./vendo on this path, so the models line the
     // route scaffold planned moves with it — resolved the same way, written in
     // exactly one of the two files.
-    models: await scaffoldModel(root, options),
+    models: scaffoldModel(root, options),
     // Not optional: a null base URL is an ANSWER the plan reads, and it is
     // what makes steps[] lead with the recoverable version of E-MCP-009's
     // failure instead of assuming an origin.
@@ -1080,7 +1080,7 @@ async function planNextComposition(
     const path = relative(root, route);
     // Detect + confirm happens only on fresh composition creation.
     const auth = await resolveScaffoldAuth(root, path, options.auth, confirmAuth, selectAuth);
-    const models = await scaffoldModel(root, options);
+    const models = scaffoldModel(root, options);
     const routeAfter = routeSource({ serverActions: registrations.length > 0, auth: auth.wired, models });
     scaffold.changes.push({ absolute: route, path, before: routeBefore, after: routeAfter, diff: diff(path, routeBefore, routeAfter) });
     scaffold.authAdvice = auth.advice;
@@ -1409,19 +1409,27 @@ function credentialEnv(root: string, env: Record<string, string | undefined>): R
 }
 
 /** The provider key a scaffold written THIS run should name in `models`, or
- *  null when no provider key resolved. Only the env-key rungs qualify: they
- *  are the rung whose meaning changed (a key in the environment no longer
- *  picks a model on its own), and the Cloud rung resolves its model through
- *  the gateway's own family names instead. Resolved here, at scaffold time,
- *  because the file is authored before the interactive credential step runs —
- *  detection is pure and read-only, so asking twice costs nothing. */
-async function scaffoldModel(root: string, options: InitOptions): Promise<ScaffoldModel | null> {
-  const credential = await (options.resolveCredential ?? resolveDevCredential)({
-    env: credentialEnv(root, options.env ?? process.env),
-  });
-  return credential.rung === "env-key"
-    ? { provider: credential.provider, envVar: credential.envVar }
-    : null;
+ *  null when the host has no provider key at all. A Cloud key is not one: its
+ *  models resolve through the gateway's own family names, so nothing is written.
+ *
+ *  This sweeps ENV_KEY_VARS directly instead of asking `resolveDevCredential`.
+ *  "Which provider key is lying around for me to write an explicit selection
+ *  for?" is a DIFFERENT question from "what selects the model at runtime?", and
+ *  since the selection law a bare provider key answers the second one with
+ *  nothing — so routing this through the runtime ladder silently returned null
+ *  for every real host and wrote no line at all. That is backwards: the ambient
+ *  key is exactly the signal that this host needs the explicit selection, since
+ *  it is the host whose boot the law just broke. The ladder's own env-key rung
+ *  is reachable only through the internal VENDO_DEV_CREDENTIAL pin, which no
+ *  host running `vendo init` sets.
+ *
+ *  Resolved here, at scaffold time, because the file is authored before the
+ *  interactive credential step runs — detection is pure and read-only, so
+ *  asking twice costs nothing. */
+function scaffoldModel(root: string, options: InitOptions): ScaffoldModel | null {
+  const env = credentialEnv(root, options.env ?? process.env);
+  const found = ENV_KEY_VARS.find((entry) => (env[entry.envVar] ?? "").trim() !== "");
+  return found === undefined ? null : { provider: found.provider, envVar: found.envVar };
 }
 
 /** Key first (product order fix): the model-credential story — env keys,


### PR DESCRIPTION
## main is red — this fixes it

`main` is failing at `2d52adbd6` (`ci`, `coverage-merge`, `test-shards vendo-3`). Three tests in `packages/vendo/tests/cli/init.test.ts` fail. **Every open PR is blocked behind this**, none of them individually at fault.

## Root cause — two PRs that were each green alone

**#1208** made `vendo init` write an explicit `models:` line when it detects a provider key at scaffold time. `scaffoldModel` (`init.ts:1418`) gated on `credential.rung === "env-key"`.

**#1209** then deleted the `ENV_KEY_VARS` sweep from `resolveDevCredential` (`dev-creds/resolve.ts:74-79`, now a comment explaining the removal). The `env-key` rung survives only behind the internal `VENDO_DEV_CREDENTIAL` pin — which no real host sets — so `scaffoldModel` returned `null` for every real host.

Timing confirms it: run `31484246145` on identical branch content was **green at 10:54**; it went red at 11:55, after #1208 (11:36) and #1209 (11:44) landed.

## Why this is worse than a red shard

**#1208 is the migration path for #1209's breaking change.** As of `main` today, the breaking change has shipped *without* the thing that makes it survivable — `vendo init` silently stopped writing the model line, so an upgrading developer hits the boot error with no automatic way out.

## The fix

One function, `scaffoldModel`, now sweeps `ENV_KEY_VARS` directly. **#1209's runtime selection law is completely untouched** — `resolveDevCredential` is not modified. The distinction is deliberate: `resolveDevCredential` correctly no longer *selects* a model from an ambient key; init still needs to *detect* one to write explicit config. Detection is pure, so the function is no longer `async` (two call sites drop `await`).

23 insertions, 15 deletions, one file.

## No test was changed or weakened

The three failing tests were right; the source was wrong.

Worth noting: #1209 *did* edit `init.test.ts`, adding the `VENDO_DEV_CREDENTIAL` pin to the two tests that existed on its base. #1208's three newer tests never got it — correctly. **Adding the pin to them would have bought a green suite while leaving the feature dead for every real user.**

## Verification

- `tests/cli/init.test.ts`: **101/101 pass** (was 3 failed)
- CI shard 3/4 reproduced locally: **549 passed / 21 skipped** (was 3 failed / 546 passed)
- init + init-scaffolds + onboarding-safety: **133 passed**
- `tsc -p tsconfig.test.json --noEmit` clean · `pnpm lint` 0 errors

**Real `vendo init` runs on scratch hosts, not just the suite:**
- ambient `ANTHROPIC_API_KEY` → line written to the authored route, summary names `route.ts`
- key only in `.env.local` → line written (the case the old ambient behavior was really riding on)
- MCP path → line in `vendo.ts`, thin `route.ts` clean of both halves, summary names `vendo.ts`
- keyless → nothing written · Vendo Cloud key only → nothing written

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores provider key detection in `vendo init` so it writes an explicit `models:` line again, unblocking `main` and preserving the migration path after #1209. Runtime model selection remains unchanged.

- **Bug Fixes**
  - `scaffoldModel` now sweeps `ENV_KEY_VARS` directly to detect provider keys and write `models:` during `vendo init`.
  - Leaves `resolveDevCredential` untouched; detection-only change. Function is no longer async and call sites drop `await`.
  - Behavior: ambient or `.env.local` provider keys write the line; Vendo Cloud key or no key writes nothing. Tests pass without changes.

<sup>Written for commit 0ee9a850a291eff02aa805c19ea066638b21c68c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

