### PR TITLE
fix(vendo): sync footer reports judgment tallies (#1174)

### DIFF
--- a/.changeset/sync-footer-judgment-tallies.md
+++ b/.changeset/sync-footer-judgment-tallies.md
@@ -1,0 +1,9 @@
+---
+"@vendoai/vendo": patch
+---
+
+The sync footer's "what moved" line now reports judgment tallies (hardened
+fields, inferred schemas, applied and queued loosenings) instead of collapsing
+every judged run into a single opaque "judged" fragment. A judged run that
+found nothing to change now says `0 findings`, so it reads distinctly from a
+keyless, structural-only run — which still omits the fragment entirely.

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -2086,7 +2086,7 @@ export async function runInit(input: InitOptions): Promise<number> {
     await emitEnding({
       root, options, output, useCase, framework: plan.framework, keptUncertain,
       wrote: [...planned, ...changes.map((change) => change.path)],
-      pendingLoosenings: flow.judged.queued,
+      pendingLoosenings: flow.judged.looseningsQueued ?? 0,
       serviceAuthUnwired: mcp?.serviceAuthUnwired === true,
       signIn: mcp?.signIn ?? null,
       judged: flow.judged.ran,

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -2086,7 +2086,7 @@ export async function runInit(input: InitOptions): Promise<number> {
     await emitEnding({
       root, options, output, useCase, framework: plan.framework, keptUncertain,
       wrote: [...planned, ...changes.map((change) => change.path)],
-      pendingLoosenings: flow.judged.looseningsQueued ?? 0,
+      pendingLoosenings: flow.judged.queued,
       serviceAuthUnwired: mcp?.serviceAuthUnwired === true,
       signIn: mcp?.signIn ?? null,
       judged: flow.judged.ran,

--- a/packages/vendo/src/cli/sync-flow.ts
+++ b/packages/vendo/src/cli/sync-flow.ts
@@ -120,15 +120,22 @@ async function withSpin<T>(
   }
 }
 
+/** What the judgment pass handed back — `ran` means the pass was invoked;
+ *  the tallies are present only when it returned `status: "judged"`, so a
+ *  zero-finding judgment is distinguishable from a keyless structural-only
+ *  run in the sync footer (#1174). */
+export interface SyncFlowJudged {
+  ran: boolean;
+  engine?: "claude" | "codex" | "npx-engine";
+  hardened?: number;
+  schemasInferred?: number;
+  looseningsApproved?: number;
+  looseningsQueued?: number;
+}
+
 export interface SyncFlowResult {
   report: SyncReportWithWarnings;
-  judged: {
-    ran: boolean;
-    engine?: "claude" | "codex" | "npx-engine";
-    /** Loosening proposals held as PENDING — never applied, waiting for a human
-        (`vendo sync --review`). init reports the count in its closing facts. */
-    queued: number;
-  };
+  judged: SyncFlowJudged;
   /** The theme re-scan: which slots this run took from the host, and which the
    *  host disagrees with but a human owns. null = nothing to reconcile (the
    *  file was just created, or there is none). */
@@ -615,7 +622,7 @@ async function runGradingStages(input: {
 }): Promise<{ judged: SyncFlowResult["judged"]; themeDraft: SyncFlowResult["themeDraft"] }> {
   const { root, vendoDir, mode, env, options, output, themeSummary } = input;
   const { note, noteError } = input.notes;
-  const judged: SyncFlowResult["judged"] = { ran: false, queued: 0 };
+  const judged: SyncFlowResult["judged"] = { ran: false };
   let themeDraft: SyncFlowResult["themeDraft"] = null;
   const selection = await chooseEngine(options, env, note);
   if (selection.skip) return { judged, themeDraft };
@@ -662,12 +669,20 @@ async function runGradingStages(input: {
     // The pass already printed the count and `vendo sync --review`; say WHY
     // they were held, so an unattended caller doesn't read it as a refusal.
     if (loosenings === "queue" && pass.status === "judged" && pass.queued > 0) {
-      judged.queued = pass.queued;
       note("  (held, not applied: a loosening needs a human — review them with `vendo sync --review`)");
     }
     judged.ran = true;
     const engine = selection.engine === undefined ? undefined : ENGINE_BY_HARNESS_ID[selection.engine.harness.id];
     if (engine !== undefined) judged.engine = engine;
+    // Tallies ride on the result only for a real judgment — structural-only /
+    // up-to-date leave them unset so the footer can tell those apart from a
+    // judged run that found nothing to harden (#1174).
+    if (pass.status === "judged") {
+      judged.hardened = pass.hardened;
+      judged.schemasInferred = pass.schemasInferred;
+      judged.looseningsApproved = pass.approved;
+      judged.looseningsQueued = pass.queued;
+    }
   } catch (error) {
     note(`judgment failed soft: ${error instanceof Error ? error.message : "unknown error"}`);
     judged.ran = false;

--- a/packages/vendo/src/cli/sync-flow.ts
+++ b/packages/vendo/src/cli/sync-flow.ts
@@ -123,14 +123,17 @@ async function withSpin<T>(
 /** What the judgment pass handed back — `ran` means the pass was invoked;
  *  the tallies are present only when it returned `status: "judged"`, so a
  *  zero-finding judgment is distinguishable from a keyless structural-only
- *  run in the sync footer (#1174). */
+ *  run in the sync footer (#1174). `queued` is always a count (0 when none
+ *  are held) because init's closing facts read it. */
 export interface SyncFlowJudged {
   ran: boolean;
   engine?: "claude" | "codex" | "npx-engine";
+  /** Loosening proposals held as PENDING — never applied, waiting for a human
+      (`vendo sync --review`). init reports the count in its closing facts. */
+  queued: number;
   hardened?: number;
   schemasInferred?: number;
   looseningsApproved?: number;
-  looseningsQueued?: number;
 }
 
 export interface SyncFlowResult {
@@ -622,7 +625,7 @@ async function runGradingStages(input: {
 }): Promise<{ judged: SyncFlowResult["judged"]; themeDraft: SyncFlowResult["themeDraft"] }> {
   const { root, vendoDir, mode, env, options, output, themeSummary } = input;
   const { note, noteError } = input.notes;
-  const judged: SyncFlowResult["judged"] = { ran: false };
+  const judged: SyncFlowResult["judged"] = { ran: false, queued: 0 };
   let themeDraft: SyncFlowResult["themeDraft"] = null;
   const selection = await chooseEngine(options, env, note);
   if (selection.skip) return { judged, themeDraft };
@@ -681,7 +684,7 @@ async function runGradingStages(input: {
       judged.hardened = pass.hardened;
       judged.schemasInferred = pass.schemasInferred;
       judged.looseningsApproved = pass.approved;
-      judged.looseningsQueued = pass.queued;
+      judged.queued = pass.queued;
     }
   } catch (error) {
     note(`judgment failed soft: ${error instanceof Error ? error.message : "unknown error"}`);

--- a/packages/vendo/src/cli/sync.ts
+++ b/packages/vendo/src/cli/sync.ts
@@ -178,7 +178,7 @@ export function whatMoved(flow: SyncFlowResult): string | undefined {
   // Non-zero ones speak for themselves; a judged run with none still says
   // "0 findings" — count-style like its neighbors, not a bare adjective — so
   // it cannot read as a keyless structural-only footer (#1174).
-  const { hardened, schemasInferred, looseningsApproved, looseningsQueued } = flow.judged;
+  const { hardened, schemasInferred, looseningsApproved, queued } = flow.judged;
   const wasJudged = hardened !== undefined;
   let judgmentSaid = false;
   if (hardened !== undefined && hardened > 0) {
@@ -193,7 +193,7 @@ export function whatMoved(flow: SyncFlowResult): string | undefined {
     moved.push(`${looseningsApproved} loosening${looseningsApproved === 1 ? "" : "s"} applied`);
     judgmentSaid = true;
   }
-  if (wasJudged && !judgmentSaid && (looseningsQueued ?? 0) === 0) {
+  if (wasJudged && !judgmentSaid && queued === 0) {
     moved.push("0 findings");
   }
 
@@ -201,8 +201,8 @@ export function whatMoved(flow: SyncFlowResult): string | undefined {
     moved.push("pushed to Cloud");
   }
   // Queued loosenings need the user later — last fragment they read.
-  if (looseningsQueued !== undefined && looseningsQueued > 0) {
-    moved.push(`${looseningsQueued} loosening${looseningsQueued === 1 ? "" : "s"} queued`);
+  if (queued > 0) {
+    moved.push(`${queued} loosening${queued === 1 ? "" : "s"} queued`);
   }
   return moved.length === 0 ? undefined : moved.join(" · ");
 }

--- a/packages/vendo/src/cli/sync.ts
+++ b/packages/vendo/src/cli/sync.ts
@@ -164,16 +164,45 @@ async function writeThemeDraft(root: string, flow: SyncFlowResult, output: Outpu
   output.log(`theme: ${filled.length} slot${filled.length === 1 ? "" : "s"} filled by the AI pass (${filled.join(", ")}) → .vendo/theme.json`);
 }
 
-/** The footer's "what moved", read off the report this run just printed. The
- *  footer REPORTS the outcome; it never decides it. */
-function whatMoved(flow: SyncFlowResult): string | undefined {
+/** The footer's "what moved", read off the report and judgment tallies this
+ *  run just produced. The footer REPORTS the outcome; it never decides it.
+ *  Exported so the register stays covered without driving a full pretty TTY. */
+export function whatMoved(flow: SyncFlowResult): string | undefined {
   const moved: string[] = [];
   const { added, removed, changed } = flow.report.tools;
   if (added.length > 0) moved.push(`+${added.length} tool${added.length === 1 ? "" : "s"}`);
   if (removed.length > 0) moved.push(`-${removed.length} tool${removed.length === 1 ? "" : "s"}`);
   if (changed.length > 0) moved.push(`~${changed.length} changed`);
+
+  // Judgment tallies — only present when the pass returned `status: "judged"`.
+  // Non-zero ones speak for themselves; a judged run with none still says
+  // "0 findings" — count-style like its neighbors, not a bare adjective — so
+  // it cannot read as a keyless structural-only footer (#1174).
+  const { hardened, schemasInferred, looseningsApproved, looseningsQueued } = flow.judged;
+  const wasJudged = hardened !== undefined;
+  let judgmentSaid = false;
+  if (hardened !== undefined && hardened > 0) {
+    moved.push(`${hardened} field${hardened === 1 ? "" : "s"} hardened`);
+    judgmentSaid = true;
+  }
+  if (schemasInferred !== undefined && schemasInferred > 0) {
+    moved.push(`${schemasInferred} schema${schemasInferred === 1 ? "" : "s"} inferred`);
+    judgmentSaid = true;
+  }
+  if (looseningsApproved !== undefined && looseningsApproved > 0) {
+    moved.push(`${looseningsApproved} loosening${looseningsApproved === 1 ? "" : "s"} applied`);
+    judgmentSaid = true;
+  }
+  if (wasJudged && !judgmentSaid && (looseningsQueued ?? 0) === 0) {
+    moved.push("0 findings");
+  }
+
   if ((flow.baselines?.pushed.length ?? 0) + (flow.components?.pushed.length ?? 0) > 0) {
     moved.push("pushed to Cloud");
+  }
+  // Queued loosenings need the user later — last fragment they read.
+  if (looseningsQueued !== undefined && looseningsQueued > 0) {
+    moved.push(`${looseningsQueued} loosening${looseningsQueued === 1 ? "" : "s"} queued`);
   }
   return moved.length === 0 ? undefined : moved.join(" · ");
 }

--- a/packages/vendo/tests/cli/sync-flow.unattended.test.ts
+++ b/packages/vendo/tests/cli/sync-flow.unattended.test.ts
@@ -73,6 +73,8 @@ beforeEach(() => {
     evidenceless: 0,
     advisoriesClamped: 0,
     inconsistentRisk: 0,
+    schemasInferred: 0,
+    schemasRejected: 0,
   });
   runProseStages.mockResolvedValue({});
 });
@@ -105,6 +107,13 @@ describe("the loosening review never blocks an unattended run", () => {
     const result = await initFlow({ root, output, yes: true, interactive: true, confirm });
 
     expect(result.judged.ran).toBe(true);
+    // Tallies surface onto the flow so the sync footer can report them (#1174).
+    expect(result.judged).toMatchObject({
+      looseningsQueued: 2,
+      looseningsApproved: 0,
+      hardened: 0,
+      schemasInferred: 0,
+    });
     expect(runJudgmentPass).toHaveBeenCalledTimes(1);
     const passed = runJudgmentPass.mock.calls[0]![0] as { loosenings: string; confirm?: unknown };
     expect(passed.loosenings).toBe("queue");
@@ -125,6 +134,20 @@ describe("the loosening review never blocks an unattended run", () => {
     const passed = runJudgmentPass.mock.calls[0]![0] as { loosenings: string; confirm?: unknown };
     expect(passed.loosenings).toBe("queue");
     expect(passed.confirm).toBeUndefined();
+  });
+
+  it("leaves judgment tallies unset on a structural-only pass", async () => {
+    runJudgmentPass.mockResolvedValueOnce({ status: "structural-only", unjudged: 3 });
+    const root = await projectWithTools();
+    const result = await initFlow({
+      root,
+      output: silentOutput(),
+      yes: true,
+      interactive: true,
+    });
+    expect(result.judged.ran).toBe(true);
+    expect(result.judged.hardened).toBeUndefined();
+    expect(result.judged.looseningsQueued).toBeUndefined();
   });
 
   it("still reviews inline when a human is actually there", async () => {

--- a/packages/vendo/tests/cli/sync-flow.unattended.test.ts
+++ b/packages/vendo/tests/cli/sync-flow.unattended.test.ts
@@ -109,7 +109,7 @@ describe("the loosening review never blocks an unattended run", () => {
     expect(result.judged.ran).toBe(true);
     // Tallies surface onto the flow so the sync footer can report them (#1174).
     expect(result.judged).toMatchObject({
-      looseningsQueued: 2,
+      queued: 2,
       looseningsApproved: 0,
       hardened: 0,
       schemasInferred: 0,
@@ -147,7 +147,7 @@ describe("the loosening review never blocks an unattended run", () => {
     });
     expect(result.judged.ran).toBe(true);
     expect(result.judged.hardened).toBeUndefined();
-    expect(result.judged.looseningsQueued).toBeUndefined();
+    expect(result.judged.queued).toBe(0);
   });
 
   it("still reviews inline when a human is actually there", async () => {

--- a/packages/vendo/tests/cli/sync.test.ts
+++ b/packages/vendo/tests/cli/sync.test.ts
@@ -1019,7 +1019,7 @@ describe("sync --full writes the theme fill it paid for", () => {
 /** Minimal flow result for the footer formatter — only the fields `whatMoved` reads. */
 function flowForFooter(overrides: {
   tools?: Partial<SyncFlowResult["report"]["tools"]>;
-  judged?: SyncFlowResult["judged"];
+  judged?: Partial<SyncFlowResult["judged"]>;
   baselines?: SyncFlowResult["baselines"];
   components?: SyncFlowResult["components"];
 }): SyncFlowResult {
@@ -1034,7 +1034,7 @@ function flowForFooter(overrides: {
       components: { captured: [], drifted: [] },
       warnings: [],
     },
-    judged: overrides.judged ?? { ran: false },
+    judged: { ran: false, queued: 0, ...overrides.judged },
     theme: null,
     themeSummary: null,
     themeDraft: null,
@@ -1057,7 +1057,7 @@ describe("sync footer whatMoved (#1174)", () => {
         hardened: 8,
         schemasInferred: 0,
         looseningsApproved: 0,
-        looseningsQueued: 2,
+        queued: 2,
       },
       baselines: { pushed: ["a"], pruned: [] },
     }))).toBe("+1 tool · ~1 changed · 8 fields hardened · pushed to Cloud · 2 loosenings queued");
@@ -1071,7 +1071,7 @@ describe("sync footer whatMoved (#1174)", () => {
         hardened: 0,
         schemasInferred: 3,
         looseningsApproved: 2,
-        looseningsQueued: 0,
+        queued: 0,
       },
       components: { pushed: ["Button"], pruned: [], modules: { uploaded: 0, deleted: 0 } },
     }))).toBe("+2 tools · 3 schemas inferred · 2 loosenings applied · pushed to Cloud");
@@ -1085,7 +1085,7 @@ describe("sync footer whatMoved (#1174)", () => {
         hardened: 0,
         schemasInferred: 0,
         looseningsApproved: 0,
-        looseningsQueued: 0,
+        queued: 0,
       },
     }))).toBe("+1 tool · ~1 changed · 0 findings");
 

--- a/packages/vendo/tests/cli/sync.test.ts
+++ b/packages/vendo/tests/cli/sync.test.ts
@@ -4,7 +4,8 @@ import { join } from "node:path";
 import { createHash } from "node:crypto";
 import { PROJECT_ID_SALT } from "@vendoai/telemetry";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { runSync } from "../../src/cli/sync.js";
+import { runSync, whatMoved } from "../../src/cli/sync.js";
+import type { SyncFlowResult } from "../../src/cli/sync-flow.js";
 import { telemetryCapture } from "../../src/cli/telemetry.test-util.js";
 
 afterEach(() => {
@@ -1012,5 +1013,90 @@ describe("sync --full writes the theme fill it paid for", () => {
     expect(written.colors.accent).toBe("#112233");
     expect(written.typography.fontFamily).toBe("Inter, sans-serif");
     expect(messages.logs.join("\n")).toContain("filled by the AI pass (accent, fontFamily)");
+  });
+});
+
+/** Minimal flow result for the footer formatter — only the fields `whatMoved` reads. */
+function flowForFooter(overrides: {
+  tools?: Partial<SyncFlowResult["report"]["tools"]>;
+  judged?: SyncFlowResult["judged"];
+  baselines?: SyncFlowResult["baselines"];
+  components?: SyncFlowResult["components"];
+}): SyncFlowResult {
+  return {
+    report: {
+      tools: { added: [], removed: [], changed: [], ...overrides.tools },
+      breaking: [],
+      toolSchemas: { total: 0, inputs: { known: 0, unknown: [] }, outputs: { known: 0, unknown: [] } },
+      pins: { captured: [], drifted: [] },
+      remixableErrors: [],
+      catalog: { discovered: 0, registered: 0 },
+      components: { captured: [], drifted: [] },
+      warnings: [],
+    },
+    judged: overrides.judged ?? { ran: false },
+    theme: null,
+    themeSummary: null,
+    themeDraft: null,
+    catalog: [],
+    counts: { tools: 0, routes: 0 },
+    impact: null,
+    baselines: overrides.baselines ?? null,
+    components: overrides.components ?? null,
+    notes: [],
+    cloudKey: undefined,
+  };
+}
+
+describe("sync footer whatMoved (#1174)", () => {
+  it("reports hardened fields and keeps queued loosenings last", () => {
+    expect(whatMoved(flowForFooter({
+      tools: { added: ["host_new"], changed: ["host_a"] },
+      judged: {
+        ran: true,
+        hardened: 8,
+        schemasInferred: 0,
+        looseningsApproved: 0,
+        looseningsQueued: 2,
+      },
+      baselines: { pushed: ["a"], pruned: [] },
+    }))).toBe("+1 tool · ~1 changed · 8 fields hardened · pushed to Cloud · 2 loosenings queued");
+  });
+
+  it("uses the mock's register for approved loosenings and schemas", () => {
+    expect(whatMoved(flowForFooter({
+      tools: { added: ["a", "b"] },
+      judged: {
+        ran: true,
+        hardened: 0,
+        schemasInferred: 3,
+        looseningsApproved: 2,
+        looseningsQueued: 0,
+      },
+      components: { pushed: ["Button"], pruned: [], modules: { uploaded: 0, deleted: 0 } },
+    }))).toBe("+2 tools · 3 schemas inferred · 2 loosenings applied · pushed to Cloud");
+  });
+
+  it("says 0 findings when the pass ran with zero findings, unlike structural-only", () => {
+    expect(whatMoved(flowForFooter({
+      tools: { added: ["host_new"], changed: ["host_a"] },
+      judged: {
+        ran: true,
+        hardened: 0,
+        schemasInferred: 0,
+        looseningsApproved: 0,
+        looseningsQueued: 0,
+      },
+    }))).toBe("+1 tool · ~1 changed · 0 findings");
+
+    // Keyless / structural-only: tallies unset — no judgment fragment at all.
+    expect(whatMoved(flowForFooter({
+      tools: { added: ["host_new"], changed: ["host_a"] },
+      judged: { ran: true },
+    }))).toBe("+1 tool · ~1 changed");
+  });
+
+  it("returns undefined when nothing moved and judgment never ran", () => {
+    expect(whatMoved(flowForFooter({ judged: { ran: false } }))).toBeUndefined();
   });
 });


### PR DESCRIPTION
## What

Surfaces judgment-pass tallies on `SyncFlowResult.judged` and includes the non-zero ones in the sync footer's `whatMoved()` line — hardened fields, schemas inferred, loosenings applied/queued — so a long judged sync no longer ends as only `+1 tool · ~1 changed`.

A judged run with zero findings appends `judged`; structural-only leaves tallies unset so the footers stay distinct.

## Why

The footer's job is to say the run finished, how long it took, and what moved. Hardenings were computed and printed in the judgment narrative but never returned on the flow result, so the last line the user reads omitted the main outcome of a multi-minute pass (#1174).

## Verification

- [x] `pnpm --filter @vendoai/vendo... build` and targeted vitest (`sync.test.ts`, `sync-flow.unattended.test.ts`) green; `@vendoai/vendo` typecheck green
- [x] Live `vendo sync --ai --full` on `examples/demo-bank`: footer read `Done in 1428.1s — 8 fields hardened · 1 schema inferred` (matches judgment narrative)
- [x] Screenshots attached (if UI-affecting) — N/A (CLI footer only)
<img width="544" height="155" alt="image" src="https://github.com/user-attachments/assets/247d6aa7-bf36-4935-beba-e11ad3f6cbb7" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync footer now reports judgment tallies: hardened fields, inferred schemas, and loosenings applied/queued. This surfaces these counts on `SyncFlowResult.judged` and fixes misleading footers after judged runs (#1174).

- **Bug Fixes**
  - Added `SyncFlowJudged` and populate tallies only when `status: "judged"` to distinguish structural-only runs.
  - Updated `whatMoved()` to include non-zero tallies, say "judged" on zero findings, and place queued loosenings last.
  - Exported `whatMoved` and added focused tests for footer formatting and structural-only behavior.

<sup>Written for commit d6861e8483f52bc657a3265e923041f207e22e8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

