### PR TITLE
fix(vendo)!: a failed snapshot ref is classified, never echoed into telemetry

### DIFF
--- a/packages/vendo/src/sandbox.ts
+++ b/packages/vendo/src/sandbox.ts
@@ -213,14 +213,6 @@ const KNOWN_REF_SCHEMES = [
 
 const UNKNOWN_REF_SCHEME = "(no known scheme)";
 
-/** Twelve hex characters of SHA-256 — enough to tie two reports of the same
- * bad ref together, one-way so it carries none of it. */
-const refDigest = async (snapshotRef: string): Promise<string> => {
-  const hash = await crypto.subtle.digest("SHA-256", encoder.encode(snapshotRef));
-  return [...new Uint8Array(hash).subarray(0, 6)]
-    .map((byte) => byte.toString(16).padStart(2, "0")).join("");
-};
-
 /** Decode a ref, and report which ref failed when it will not decode.
  *
  * The decoder's message says which WAY a ref is wrong; it cannot say which
@@ -234,10 +226,15 @@ const refDigest = async (snapshotRef: string): Promise<string> => {
  * DEFINITION not one Vendo minted — it is arbitrary caller content, up to and
  * including a secret passed to the wrong function. A prefix of that content is
  * still that content, so the scheme is matched against the closed set above
- * and reported as the constant that matched; the rest travels only as a length
- * and a one-way digest. The error the caller sees is unchanged — this only
- * observes it on the way past. */
-const decodeOrReport = async (snapshotRef: string): Promise<CloudSnapshotState> => {
+ * and reported as the constant that matched; the rest travels only as a length.
+ *
+ * NOTHING here reads the whole value. There is deliberately no digest: an
+ * unkeyed hash of caller content is a confirmation oracle (hash your candidate
+ * secrets offline, compare), and hashing an unbounded argument on a public
+ * failure path is a free CPU sink. Cross-report correlation of the same bad ref
+ * is the accepted cost — do not re-add one. The error the caller sees is
+ * unchanged; this only observes it on the way past. */
+const decodeOrReport = (snapshotRef: string): CloudSnapshotState => {
   try {
     return decodeSnapshotRef(snapshotRef);
   } catch (error) {
@@ -249,7 +246,6 @@ const decodeOrReport = async (snapshotRef: string): Promise<CloudSnapshotState> 
         snapshotRefScheme: KNOWN_REF_SCHEMES.find((scheme) => snapshotRef.startsWith(scheme))
           ?? UNKNOWN_REF_SCHEME,
         snapshotRefLength: snapshotRef.length,
-        snapshotRefDigest: await refDigest(snapshotRef),
       },
     });
     throw error;
@@ -526,7 +522,7 @@ export function cloudSandbox(options: CloudSandboxOptions): SandboxAdapter {
       });
     },
     async resume(snapshotRef, policy?: SandboxResumePolicy) {
-      const state = await decodeOrReport(snapshotRef);
+      const state = decodeOrReport(snapshotRef);
       // The new machine inherits NO network config from the artifact
       // (sandbox-wire.ts), so every resume states the applicable allowlist:
       // Lane E's replace semantics when the caller re-polices the wake, the
@@ -542,7 +538,7 @@ export function cloudSandbox(options: CloudSandboxOptions): SandboxAdapter {
       });
     },
     async destroy(snapshotRef) {
-      const state = await decodeOrReport(snapshotRef);
+      const state = decodeOrReport(snapshotRef);
       // Best-effort reap of the recorded source machine (it is usually
       // already gone — the sleep flow destroyed it), then the artifact GC.
       // A 404 from either is the seam's idempotent no-op.

--- a/packages/vendo/src/sandbox.ts
+++ b/packages/vendo/src/sandbox.ts
@@ -1,5 +1,5 @@
 import type { SandboxAdapter, SandboxMachine, SandboxResumePolicy } from "@vendoai/apps";
-import { defaultFetch, log, safeErrorMessage, VendoError } from "@vendoai/core";
+import { defaultFetch, log, VendoError } from "@vendoai/core";
 import { deploymentIdentityHeaders } from "./deployment-identity.js";
 import { raiseCloudError } from "./cloud-console.js";
 import {
@@ -241,7 +241,12 @@ const decodeOrReport = (snapshotRef: string): CloudSnapshotState => {
     log({
       code: "vendo.snapshot-ref-undecodable",
       level: "error",
-      message: `[vendo] ${safeErrorMessage(error)}`,
+      // Vendo's OWN fixed sentence, not the decoder's. The decoder writes for
+      // the CALLER and names the unrecognised scheme it read out of the ref
+      // (`notMintedHere`), so relaying that sentence here would carry a
+      // caller-controlled slice into telemetry. The caller still gets the full
+      // sentence — it is on the error being rethrown, untouched.
+      message: "[vendo] a Vendo Cloud snapshot reference could not be decoded:",
       data: {
         snapshotRefScheme: KNOWN_REF_SCHEMES.find((scheme) => snapshotRef.startsWith(scheme))
           ?? UNKNOWN_REF_SCHEME,

--- a/packages/vendo/src/sandbox.ts
+++ b/packages/vendo/src/sandbox.ts
@@ -200,23 +200,57 @@ const decodeSnapshotRef = (snapshotRef: string): CloudSnapshotState => {
 const isGone = (error: unknown): boolean =>
   error instanceof VendoError && error.code === "not-found";
 
-/** Decode a ref, and report WHICH ref when it will not decode.
+/** Every snapshot-ref scheme this repo mints, longest match first — "vendo:"
+ * is a strict prefix of "vendo:v2:". Classification reports the MATCHED
+ * CONSTANT from this list, never a slice of the input. */
+const KNOWN_REF_SCHEMES = [
+  CLOUD_SNAPSHOT_REF_PREFIX,
+  "e2b:v2:",
+  "fake-v2:",
+  "fake:",
+  CONSOLE_SNAPSHOT_REF_PREFIX,
+] as const;
+
+const UNKNOWN_REF_SCHEME = "(no known scheme)";
+
+/** Twelve hex characters of SHA-256 — enough to tie two reports of the same
+ * bad ref together, one-way so it carries none of it. */
+const refDigest = async (snapshotRef: string): Promise<string> => {
+  const hash = await crypto.subtle.digest("SHA-256", encoder.encode(snapshotRef));
+  return [...new Uint8Array(hash).subarray(0, 6)]
+    .map((byte) => byte.toString(16).padStart(2, "0")).join("");
+};
+
+/** Decode a ref, and report which ref failed when it will not decode.
  *
  * The decoder's message says which WAY a ref is wrong; it cannot say which
- * ref, because it is one authored sentence and a ref does not belong inside
- * one. That left an operator reading "a ref was malformed" with no way to find
- * it. The ref reaches the `sdk_error` stream from here instead, under the
- * allowlisted `snapshotRef` key (sdk-events.ts). The error the caller sees is
- * unchanged — this only observes it on the way past. */
-const decodeOrReport = (snapshotRef: string): CloudSnapshotState => {
+ * one, because it is one authored sentence and a ref does not belong inside
+ * one. That left an operator reading "a ref was malformed" with no way to tell
+ * them apart. A CLASSIFICATION of the ref reaches the `sdk_error` stream from
+ * here instead (allowlisted in sdk-events.ts).
+ *
+ * Classification, never an echo: `resume` and `destroy` are public methods, so
+ * their argument is the caller's, and a ref that failed to decode is BY
+ * DEFINITION not one Vendo minted — it is arbitrary caller content, up to and
+ * including a secret passed to the wrong function. A prefix of that content is
+ * still that content, so the scheme is matched against the closed set above
+ * and reported as the constant that matched; the rest travels only as a length
+ * and a one-way digest. The error the caller sees is unchanged — this only
+ * observes it on the way past. */
+const decodeOrReport = async (snapshotRef: string): Promise<CloudSnapshotState> => {
   try {
     return decodeSnapshotRef(snapshotRef);
   } catch (error) {
     log({
       code: "vendo.snapshot-ref-undecodable",
       level: "error",
-      message: `[vendo] ${safeErrorMessage(error)} Reference:`,
-      data: { snapshotRef },
+      message: `[vendo] ${safeErrorMessage(error)}`,
+      data: {
+        snapshotRefScheme: KNOWN_REF_SCHEMES.find((scheme) => snapshotRef.startsWith(scheme))
+          ?? UNKNOWN_REF_SCHEME,
+        snapshotRefLength: snapshotRef.length,
+        snapshotRefDigest: await refDigest(snapshotRef),
+      },
     });
     throw error;
   }
@@ -492,7 +526,7 @@ export function cloudSandbox(options: CloudSandboxOptions): SandboxAdapter {
       });
     },
     async resume(snapshotRef, policy?: SandboxResumePolicy) {
-      const state = decodeOrReport(snapshotRef);
+      const state = await decodeOrReport(snapshotRef);
       // The new machine inherits NO network config from the artifact
       // (sandbox-wire.ts), so every resume states the applicable allowlist:
       // Lane E's replace semantics when the caller re-polices the wake, the
@@ -508,7 +542,7 @@ export function cloudSandbox(options: CloudSandboxOptions): SandboxAdapter {
       });
     },
     async destroy(snapshotRef) {
-      const state = decodeOrReport(snapshotRef);
+      const state = await decodeOrReport(snapshotRef);
       // Best-effort reap of the recorded source machine (it is usually
       // already gone — the sleep flow destroyed it), then the artifact GC.
       // A 404 from either is the seam's idempotent no-op.

--- a/packages/vendo/src/sdk-events.ts
+++ b/packages/vendo/src/sdk-events.ts
@@ -142,14 +142,14 @@ export function withSdkErrorReporting(logger: VendoLogger): VendoLogger {
  */
 const VENDO_IDENTIFIER_KEYS: ReadonlySet<string> = new Set([
   // A CLASSIFICATION of a snapshot ref, never the ref (sandbox.ts): a matched
-  // constant from Vendo's closed set of schemes, a length, and a one-way
-  // digest. A raw `snapshotRef` is deliberately NOT here — the only path that
-  // reports one is the path where it FAILED to decode, and a ref that failed
-  // to decode is by definition not Vendo-minted but whatever a caller handed a
-  // public method.
+  // constant from Vendo's closed set of schemes, and a length. A raw
+  // `snapshotRef` is deliberately NOT here — the only path that reports one is
+  // the path where it FAILED to decode, and a ref that failed to decode is by
+  // definition not Vendo-minted but whatever a caller handed a public method.
+  // Nor is a DIGEST of one: an unkeyed hash of caller content confirms guesses
+  // offline, which is a quieter version of the same leak.
   "snapshotRefScheme",
   "snapshotRefLength",
-  "snapshotRefDigest",
   // Vendo's `app_*` id namespace (core's `appIdSchema`) — the only thing that
   // says WHICH app failed.
   "appId",

--- a/packages/vendo/src/sdk-events.ts
+++ b/packages/vendo/src/sdk-events.ts
@@ -132,11 +132,24 @@ export function withSdkErrorReporting(logger: VendoLogger): VendoLogger {
  * WHICH ref), so a value Vendo itself minted travels verbatim — but anything
  * originating in the host's data, its end user's input, or the model's content
  * travels as its shape and nothing else.
+ *
+ * MINTED BY VENDO, not merely NAMED by Vendo. A key earns a place here only if
+ * every value that can reach it was produced by this SDK. The question to ask
+ * of a candidate is which code path logs it: a key logged on a FAILURE path
+ * often holds the input that failed, and an input is the caller's, not ours.
+ * Classify such a value against a closed set and report the classification;
+ * never echo it, and never a prefix of it either.
  */
 const VENDO_IDENTIFIER_KEYS: ReadonlySet<string> = new Set([
-  // A sandbox snapshot reference: every one is minted by a Vendo sandbox
-  // adapter and carries Vendo's own scheme prefix (sandbox.ts).
-  "snapshotRef",
+  // A CLASSIFICATION of a snapshot ref, never the ref (sandbox.ts): a matched
+  // constant from Vendo's closed set of schemes, a length, and a one-way
+  // digest. A raw `snapshotRef` is deliberately NOT here — the only path that
+  // reports one is the path where it FAILED to decode, and a ref that failed
+  // to decode is by definition not Vendo-minted but whatever a caller handed a
+  // public method.
+  "snapshotRefScheme",
+  "snapshotRefLength",
+  "snapshotRefDigest",
   // Vendo's `app_*` id namespace (core's `appIdSchema`) — the only thing that
   // says WHICH app failed.
   "appId",
@@ -148,21 +161,22 @@ const VENDO_IDENTIFIER_KEYS: ReadonlySet<string> = new Set([
   "errorCode",
 ]);
 
-/** No identifier Vendo mints comes near this: the longest, a composite
- *  snapshot ref, tops out around 410 characters. The cap is a VOLUME gate — an
+/** No identifier Vendo mints comes near this. The cap is a VOLUME gate — an
  *  allowlisted key that unexpectedly holds something unbounded reports its
  *  shape instead, so no key on the list can become a content channel. */
 const MAX_IDENTIFIER_CHARS = 512;
 
 /** A log event's `data` carries a call site's ACTUAL arguments. Vendo's own
- *  identifiers ({@link VENDO_IDENTIFIER_KEYS}) travel as themselves; every
- *  other key travels as its own name and the SHAPE of its value. */
+ *  identifiers ({@link VENDO_IDENTIFIER_KEYS}) travel as themselves — strings
+ *  within the cap, and finite numbers, which are bounded by their own type.
+ *  Every other key travels as its own name and the SHAPE of its value. */
 function dataByProvenance(data: Record<string, unknown> | undefined): Record<string, unknown> {
   const reported: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(data ?? {})) {
     const verbatim = VENDO_IDENTIFIER_KEYS.has(key)
-      && typeof value === "string"
-      && value.length <= MAX_IDENTIFIER_CHARS;
+      && (typeof value === "number"
+        ? Number.isFinite(value)
+        : typeof value === "string" && value.length <= MAX_IDENTIFIER_CHARS);
     reported[key] = verbatim ? value : shapeOf(value);
   }
   return reported;

--- a/packages/vendo/tests/sdk-error-provenance.test.ts
+++ b/packages/vendo/tests/sdk-error-provenance.test.ts
@@ -64,9 +64,19 @@ describe("a snapshot ref the Cloud adapter cannot decode", () => {
    *  failed to decode is by definition not one Vendo minted — it is whatever
    *  the caller passed to a public method. Echoing it back, even truncated,
    *  puts caller content on the wire. */
-  it.each(["resume", "destroy"] as const)(
-    "classifies the ref instead of echoing caller content, from %s()",
-    async (method) => {
+  const methods = ["resume", "destroy"] as const;
+  /** Two shapes of hostile input. The scheme-shaped one matters because the
+   *  decoder's own message names an unrecognised scheme, and that message is
+   *  what this log line carries — so a caller who spells their secret like a
+   *  URI scheme would ride the sentence into telemetry. */
+  const hostile = [
+    ["no recognised scheme", "SECRET=caller-controlled-telemetry-content", (m: string) => `oops ${m}`],
+    ["a scheme-shaped value", "zzsecretleakzz", (m: string) => `${m}:payload`],
+  ] as const;
+
+  it.each(methods.flatMap((method) => hostile.map((h) => [method, ...h] as const)))(
+    "keeps caller content out of telemetry from %s(), given %s",
+    async (method, _shape, marker, build) => {
       vi.spyOn(console, "error").mockImplementation(() => {});
       const seen = reported();
       setLogger(withSdkErrorReporting(consoleLogger));
@@ -77,17 +87,18 @@ describe("a snapshot ref the Cloud adapter cannot decode", () => {
         }) as unknown as typeof fetch,
       });
 
-      const marker = "SECRET=caller-controlled-telemetry-content";
-      await expect(adapter[method](`oops ${marker}`)).rejects.toMatchObject({ code: "validation" });
+      const ref = build(marker);
+      await expect(adapter[method](ref)).rejects.toMatchObject({ code: "validation" });
 
       const errors = seen.filter((usage) => usage.name === "sdk_error");
       expect(errors).toHaveLength(1);
+      // The WHOLE event — `message` included, not just `data`.
       expect(JSON.stringify(errors[0])).not.toContain(marker);
-      // Still says WHICH WAY it is wrong — from Vendo's own vocabulary, never
-      // a slice of the input. Scheme and length are the WHOLE projection.
+      // Scheme and length are the whole projection, from Vendo's own
+      // vocabulary, never a slice of the input.
       expect((errors[0] as { data: Record<string, unknown> }).data).toEqual({
         snapshotRefScheme: "(no known scheme)",
-        snapshotRefLength: `oops ${marker}`.length,
+        snapshotRefLength: ref.length,
       });
     },
   );

--- a/packages/vendo/tests/sdk-error-provenance.test.ts
+++ b/packages/vendo/tests/sdk-error-provenance.test.ts
@@ -83,17 +83,41 @@ describe("a snapshot ref the Cloud adapter cannot decode", () => {
       const errors = seen.filter((usage) => usage.name === "sdk_error");
       expect(errors).toHaveLength(1);
       expect(JSON.stringify(errors[0])).not.toContain(marker);
-      // Still says WHICH WAY it is wrong, and correlates repeats of the same
-      // bad ref — from Vendo's own vocabulary, never a slice of the input.
-      expect(errors[0]).toMatchObject({
-        data: {
-          snapshotRefScheme: "(no known scheme)",
-          snapshotRefLength: `oops ${marker}`.length,
-          snapshotRefDigest: expect.stringMatching(/^[0-9a-f]{12}$/) as unknown,
-        },
+      // Still says WHICH WAY it is wrong — from Vendo's own vocabulary, never
+      // a slice of the input. Scheme and length are the WHOLE projection.
+      expect((errors[0] as { data: Record<string, unknown> }).data).toEqual({
+        snapshotRefScheme: "(no known scheme)",
+        snapshotRefLength: `oops ${marker}`.length,
       });
     },
   );
+
+  /** No digest, ever. An unkeyed hash of caller content is a confirmation
+   *  oracle — hash your candidate secrets offline and compare — and hashing an
+   *  unbounded argument on a public failure path is a free CPU sink. Losing
+   *  cross-report correlation is the accepted trade; this pins it so a re-add
+   *  fails a test rather than a review. */
+  it("emits no digest of the ref under any key", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const seen = reported();
+    setLogger(withSdkErrorReporting(consoleLogger));
+    const adapter = cloudSandbox({ apiKey: "vnd_test", fetch: (() => {
+      throw new Error("unreachable");
+    }) as unknown as typeof fetch });
+
+    const secret = "vendo:v2:correct-horse-battery-staple";
+    await expect(adapter.resume(secret)).rejects.toMatchObject({ code: "validation" });
+
+    const { data } = seen.filter((usage) => usage.name === "sdk_error")[0] as {
+      data: Record<string, unknown>;
+    };
+    // The exact key set: a re-added digest fails here whatever it is called...
+    expect(Object.keys(data)).toEqual(["snapshotRefScheme", "snapshotRefLength"]);
+    // ...and nothing emitted may look like a hash, whatever key carries it.
+    for (const value of Object.values(data)) {
+      expect(String(value)).not.toMatch(/^[0-9a-f]{8,}$/);
+    }
+  });
 
   it("names the scheme a foreign ref announces, from Vendo's closed set", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});

--- a/packages/vendo/tests/sdk-error-provenance.test.ts
+++ b/packages/vendo/tests/sdk-error-provenance.test.ts
@@ -7,14 +7,17 @@ import { withSdkErrorReporting } from "../src/sdk-events.js";
 /**
  * The provenance split on `sdk_error.data`. Reporting every value as its type
  * name defeated the point of the stream: an operator learned that "a ref was
- * malformed" and could not tell WHICH ref. Vendo's own identifiers now travel
- * verbatim; anything from the host, its end user, or the model travels as its
- * shape — and so does every key nobody has allowlisted, which is the property
- * that keeps a log site added tomorrow from leaking by default.
+ * malformed" and could not tell WHICH ref. Values Vendo itself MINTED now
+ * travel verbatim; anything from the host, its end user, or the model travels
+ * as its shape — and so does every key nobody has allowlisted, which is the
+ * property that keeps a log site added tomorrow from leaking by default.
+ *
+ * A value that failed to decode is the caller's input, not Vendo's mint, so it
+ * is classified against a closed set and never echoed — not even a prefix of
+ * it. That distinction is what the marker cases below hold in place.
  */
 
-/** A composite Cloud snapshot ref, the incident's identifier (sandbox.ts). */
-const REF = "vendo:v2:eyJ2ZXJzaW9uIjoyLCJtYWNoaW5lSWQiOiJtXzEifQ";
+const APP_ID = "app_2f6b1c0e-4d3a-4f52-9a71-0c8e5b2d7a13";
 
 const reported = (): VendoUsageEvent[] => {
   const seen: VendoUsageEvent[] = [];
@@ -40,43 +43,71 @@ afterEach(() => {
 
 describe("sdk_error.data splits by provenance", () => {
   it("passes a Vendo identifier verbatim and shapes the host-derived key beside it", () => {
-    expect(dataOf({ snapshotRef: REF, path: "/home/someone/app/customers.ts" }))
-      .toEqual({ snapshotRef: REF, path: "string" });
+    expect(dataOf({ appId: APP_ID, path: "/home/someone/app/customers.ts" }))
+      .toEqual({ appId: APP_ID, path: "string" });
   });
 
   it("defaults an unknown key to shapes-only, so a new log site leaks nothing", () => {
-    expect(dataOf({ customerEmail: "ada@example.com", balanceCents: 4200, snapshotRef: REF }))
-      .toEqual({ customerEmail: "string", balanceCents: "number", snapshotRef: REF });
+    expect(dataOf({ customerEmail: "ada@example.com", balanceCents: 4200, appId: APP_ID }))
+      .toEqual({ customerEmail: "string", balanceCents: "number", appId: APP_ID });
   });
 
   it("falls back to the shape when an allowlisted value exceeds the length cap", () => {
-    const atCap = `vendo:v2:${"a".repeat(512 - "vendo:v2:".length)}`;
-    expect(dataOf({ snapshotRef: atCap })).toEqual({ snapshotRef: atCap });
-    expect(dataOf({ snapshotRef: `${atCap}a` })).toEqual({ snapshotRef: "string" });
+    const atCap = `app_${"a".repeat(512 - "app_".length)}`;
+    expect(dataOf({ appId: atCap })).toEqual({ appId: atCap });
+    expect(dataOf({ appId: `${atCap}a` })).toEqual({ appId: "string" });
   });
 });
 
 describe("a snapshot ref the Cloud adapter cannot decode", () => {
-  it("reports WHICH ref failed on the sdk_error stream", async () => {
+  /** The failure path is the ONLY path that reports a ref, and a ref that
+   *  failed to decode is by definition not one Vendo minted — it is whatever
+   *  the caller passed to a public method. Echoing it back, even truncated,
+   *  puts caller content on the wire. */
+  it.each(["resume", "destroy"] as const)(
+    "classifies the ref instead of echoing caller content, from %s()",
+    async (method) => {
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      const seen = reported();
+      setLogger(withSdkErrorReporting(consoleLogger));
+      const adapter = cloudSandbox({
+        apiKey: "vnd_test",
+        fetch: (() => {
+          throw new Error("an undecodable ref must never reach the console");
+        }) as unknown as typeof fetch,
+      });
+
+      const marker = "SECRET=caller-controlled-telemetry-content";
+      await expect(adapter[method](`oops ${marker}`)).rejects.toMatchObject({ code: "validation" });
+
+      const errors = seen.filter((usage) => usage.name === "sdk_error");
+      expect(errors).toHaveLength(1);
+      expect(JSON.stringify(errors[0])).not.toContain(marker);
+      // Still says WHICH WAY it is wrong, and correlates repeats of the same
+      // bad ref — from Vendo's own vocabulary, never a slice of the input.
+      expect(errors[0]).toMatchObject({
+        data: {
+          snapshotRefScheme: "(no known scheme)",
+          snapshotRefLength: `oops ${marker}`.length,
+          snapshotRefDigest: expect.stringMatching(/^[0-9a-f]{12}$/) as unknown,
+        },
+      });
+    },
+  );
+
+  it("names the scheme a foreign ref announces, from Vendo's closed set", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     const seen = reported();
     setLogger(withSdkErrorReporting(consoleLogger));
-    const fetchImpl = vi.fn(async () => {
-      throw new Error("an undecodable ref must never reach the console");
-    });
-    const adapter = cloudSandbox({
-      apiKey: "vnd_test",
-      fetch: fetchImpl as unknown as typeof fetch,
-    });
+    const adapter = cloudSandbox({ apiKey: "vnd_test", fetch: (() => {
+      throw new Error("unreachable");
+    }) as unknown as typeof fetch });
 
-    // An e2b-minted ref handed to the Cloud adapter — the shape of the live
-    // incident that started this.
-    const ref = "e2b:v2:eyJzbmFwc2hvdElkIjoic25hcF9lMmIifQ";
-    await expect(adapter.resume(ref)).rejects.toMatchObject({ code: "validation" });
+    // The live incident: an e2b-minted ref a Cloud sandbox tried to resume.
+    await expect(adapter.resume("e2b:v2:eyJzbmFwc2hvdElkIjoic25hcCJ9"))
+      .rejects.toMatchObject({ code: "validation" });
 
-    expect(fetchImpl).not.toHaveBeenCalled();
-    const errors = seen.filter((usage) => usage.name === "sdk_error");
-    expect(errors).toHaveLength(1);
-    expect(errors[0]).toMatchObject({ level: "error", data: { snapshotRef: ref } });
+    expect(seen.filter((usage) => usage.name === "sdk_error")[0])
+      .toMatchObject({ data: { snapshotRefScheme: "e2b:v2:" } });
   });
 });


### PR DESCRIPTION
## What

The `sdk_error` phone-home replaced **every** value in `data` with its type name, so the dashboard said `{ path: "string", err: "TypeError" }`. An operator learned that "a ref was malformed" and could not tell **which** ref — the entire incident the stream exists to answer.

The split is by **provenance** now, not blanket.

> **Follow-up to #1216**, which merged with a version that had a live leak. Three security findings have been fixed since: a verbatim `snapshotRef` on the failure path, a digest of it, and the decoder's sentence being relayed into `sdk_error.message`. `main` still carries the first of those until this lands.

### The privacy boundary

**The rule, in one sentence:** a `data` value travels verbatim only when its key is on the closed allowlist below of keys that hold identifiers **Vendo itself minted**; every other key — anything originating in the host's data, its end user's input, or the model's content, plus every key nobody has listed — travels as the shape of its value and nothing else.

**Minted by Vendo, not merely named by Vendo.** A key earns a place only if every value that can *reach* it was produced by this SDK. The question to ask of a candidate is *which code path logs it*: a key logged on a **failure** path usually holds the input that failed, and an input is the caller's, not ours. Classify such a value against a closed set and report the classification — never echo it, never a prefix of it, and never a hash of it either.

**The exact allowlist** (`packages/vendo/src/sdk-events.ts`, `VENDO_IDENTIFIER_KEYS`):

| key | why every value that can reach it is Vendo's own |
| --- | --- |
| `snapshotRefScheme` | A **classification** of a ref, not the ref: the matched constant from a closed set of schemes this repo mints (`vendo:v2:`, `vendo:`, `e2b:v2:`, `fake-v2:`, `fake:`), or `"(no known scheme)"`. Reported from our constant, never sliced out of the input. |
| `snapshotRefLength` | A number computed from the input; carries no content. |
| `appId` | Vendo's `app_*` id namespace (`appIdSchema`, `packages/core/src/ids.ts:39`). The only thing that says which app failed. |
| `turnId` | `trn_<32 hex>` — `turnIdSchema` (`packages/core/src/ids.ts:56`) pins the whole shape and `mintTurnId` is the single mint, so it can hold nothing but random hex. |
| `errorCode` | A `VendoErrorCode` — a closed eight-member union (`packages/core/src/errors.ts:5-16`), already travelling verbatim on the approved `tool_call` event. |

It is a **key** allowlist, not a value heuristic, and it is closed — the same discipline as the CLI lane's `CLOUD_PROP_KEYS`. A log site added tomorrow leaks nothing by default; opting a key in is a deliberate edit to that list.

**Deliberately left shapes-only**, each because the value can be named by the host, the model, or the end user:

- `snapshotRef` — the only path that reports one is the path where it **failed** to decode, and a ref that failed to decode is by definition not Vendo-minted but whatever a caller handed a public method. No site emits a verbatim ref on any path.
- `path` — a workspace path embeds host-chosen directory and file names.
- `code` — collides with the OAuth **authorization code** vocabulary in `packages/mcp/src/oauth/`; that is a live credential.
- `threadId` — `threadIdSchema` pins only the `thr_` prefix, so a host-supplied suffix could carry end-user identity.
- `tool` — generated tool names describe the **host's** API surface.
- `detail`, `error`, `err`, `reason` — the keys real log sites actually pass today; they carry error text and nested grab-bags (`subject`, `principal`, `clientId` live in there).

Values that pass through are capped at **512 characters** (finite numbers pass on their own bound), so an allowlisted key that unexpectedly holds something unbounded reports its shape instead of becoming a content channel by volume.

### No digest — an accepted trade, not an oversight

An earlier revision carried a 12-hex SHA-256 prefix for correlating repeat reports of the same bad ref. **It is deleted and must not come back.** An unkeyed hash over the complete caller value is a confirmation oracle — hash your enumerable candidate secrets offline and compare against captured telemetry — and computing it hashed an unbounded argument on two public failure paths, which is a free CPU sink.

A random per-event token would correlate nothing, and a keyed hash would buy key management for a nice-to-have. **Losing cross-report correlation is the deliberate cost.** A test pins the emitted key set exactly, so a re-add under any name fails CI.

The failure path now touches the value only via five `startsWith` probes against ≤9-character constants and `.length` — no hashing, no `TextEncoder`, no allocation proportional to the input.

## Getting the classification to the error path at all

`decodeSnapshotRef` throws one authored sentence with no interpolation, so nothing about the failing ref reached a log site. The two callers now decode through a wrapper that logs the classification and rethrows untouched. **The decoder itself is not touched**, and the log line carries Vendo's own fixed sentence rather than the decoder's — #1204's `notMintedHere` names the unrecognised scheme it read out of the ref, and relaying that would carry a caller-controlled slice into telemetry. The caller still receives the full sentence on the rethrown error.

## Proof

`packages/vendo/tests/sdk-error-provenance.test.ts` (9 cases) — no pre-existing test file was modified.

- **The split:** `appId` arrives verbatim while `path` beside it arrives as `"string"`.
- **The fail-safe default:** unknown `customerEmail` / `balanceCents` arrive as `"string"` / `"number"`. This is the property that protects customers when someone adds a log site later.
- **The cap:** 512 chars passes verbatim, 513 falls back to `"string"`.
- **No caller content, 2x2:** from **both** `resume()` and `destroy()`, given both a plain hostile value and a **scheme-shaped** one, the marker appears nowhere in the **whole** `sdk_error` event — `message` included, not just `data`. Each recorded red first.
- **No digest:** the emitted key set is exactly `["snapshotRefScheme", "snapshotRefLength"]` and no value matches `/^[0-9a-f]{8,}$/`. Verified red by re-adding a digest.
- **The incident is still legible:** an e2b-minted ref reports `snapshotRefScheme: "e2b:v2:"`, with zero requests reaching the console.

**Mutation proof of the allowlist:** with the key check deleted so everything passes, the host-derived and fail-safe tests both go red — and so does the pre-existing `sdk-events.test.ts` "carries data as SHAPES" case, which still guards `path` / `count` / `err` unchanged.

Rebased onto `main` (which now carries both #1216 and #1204). Local gate: build ✅, **66 passed + 1 skipped** across `sdk-error-provenance`, `sdk-events`, `sandbox`, `capability-misses` ✅, typecheck ✅, lint ✅ (0 errors).

### Known, not fixed here

`decodeSnapshotRef` is O(n) in the input for a `vendo:v2:`-prefixed value — it slices the payload, runs two `replaceAll`s, then `atob` and `JSON.parse` (`sandbox.ts:156-162`). That is the decode attempt itself, it predates this PR, and it is the function #1204 rewrote. Bounding it is a change to ref decoding, not to telemetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
