### PR TITLE
fix(vendo)!: only a classification leaves the customer's servers

### DIFF
--- a/packages/vendo/src/sdk-events.ts
+++ b/packages/vendo/src/sdk-events.ts
@@ -120,27 +120,38 @@ export function withSdkErrorReporting(logger: VendoLogger): VendoLogger {
 }
 
 /**
- * The `data` keys that hold one of VENDO'S OWN identifiers.
+ * The `data` keys that travel VERBATIM.
  *
  * A CLOSED set of KEY NAMES, the same discipline as the CLI lane's
  * `CLOUD_PROP_KEYS`: a key nobody listed here — including every key a log site
  * added tomorrow — is shapes-only, so the default leaks nothing and opting a
  * key in is a deliberate edit to this list.
  *
- * The split is by PROVENANCE, not by usefulness. Reporting an incident is
- * pointless without the failing identifier ("a ref was malformed" does not say
- * WHICH ref), so a value Vendo itself minted travels verbatim — but anything
- * originating in the host's data, its end user's input, or the model's content
- * travels as its shape and nothing else.
+ * CLASSIFICATION ONLY. The test for membership is ONE question — CAN A CALLER
+ * INFLUENCE THIS VALUE? — and it is not the question the key's NAME answers. A
+ * name in Vendo's own namespace proves nothing: what matters is whether every
+ * value that can reach the key was produced here, on every path, including the
+ * failure paths. If a caller can put arbitrary content there by any route, no
+ * caller-influenced value leaves the customer's servers: the verbatim value
+ * stays in their local logs and their hosted-DB lookup, and only a
+ * classification of it travels.
  *
- * MINTED BY VENDO, not merely NAMED by Vendo. A key earns a place here only if
- * every value that can reach it was produced by this SDK. The question to ask
- * of a candidate is which code path logs it: a key logged on a FAILURE path
- * often holds the input that failed, and an input is the caller's, not ours.
- * Classify such a value against a closed set and report the classification;
- * never echo it, and never a prefix of it either.
+ * So the set needs no per-key argument, and that is the property to preserve:
+ * every entry is a CLASSIFICATION against a Vendo-authored closed set, a
+ * NON-CONTENT SCALAR, or a CLOSED UNION. A candidate that is none of those
+ * three does not belong here, whatever it is called.
+ *
+ * REMOVED, and not to be re-added by reasoning that the namespaces are Vendo's
+ * — both are caller-suppliable on a live path:
+ *   - `appId`: `apps/src/server/doors/build-surface.ts:286` is
+ *     `input.appId ?? mint`, and `appIdSchema` pins only the `app_` prefix, so
+ *     a caller's app id is `app_` followed by anything at all.
+ *   - `turnId`: `screen-agent.ts:855` is `surface.turnId ?? mintTurnId()`.
+ *     `turnIdSchema` does pin the whole `trn_<32 hex>` shape, but nothing
+ *     parses that path through it — a `TurnId` is a bare `string`, and the
+ *     type's stated contract is that it is opaque and nobody parses it.
  */
-const VENDO_IDENTIFIER_KEYS: ReadonlySet<string> = new Set([
+const VERBATIM_DATA_KEYS: ReadonlySet<string> = new Set([
   // A CLASSIFICATION of a snapshot ref, never the ref (sandbox.ts): a matched
   // constant from Vendo's closed set of schemes, and a length. A raw
   // `snapshotRef` is deliberately NOT here — the only path that reports one is
@@ -150,30 +161,27 @@ const VENDO_IDENTIFIER_KEYS: ReadonlySet<string> = new Set([
   // offline, which is a quieter version of the same leak.
   "snapshotRefScheme",
   "snapshotRefLength",
-  // Vendo's `app_*` id namespace (core's `appIdSchema`) — the only thing that
-  // says WHICH app failed.
-  "appId",
-  // `trn_<32 hex>`: core's `turnIdSchema` pins the WHOLE shape and
-  // `mintTurnId` is the one mint, so it can hold nothing but random hex.
-  "turnId",
   // A `VendoErrorCode` — a closed eight-member union in core, already
-  // travelling verbatim on the `tool_call` event.
+  // travelling verbatim on the `tool_call` event. FORWARD-LOOKING on purpose:
+  // no log site puts one in `data` today (it rides `agent_run` instead), so
+  // this entry is deliberate rather than an oversight, and it is here so the
+  // first log site that does report one is not silently reduced to "string".
   "errorCode",
 ]);
 
-/** No identifier Vendo mints comes near this. The cap is a VOLUME gate — an
+/** No classification Vendo emits comes near this. The cap is a VOLUME gate — an
  *  allowlisted key that unexpectedly holds something unbounded reports its
  *  shape instead, so no key on the list can become a content channel. */
 const MAX_IDENTIFIER_CHARS = 512;
 
-/** A log event's `data` carries a call site's ACTUAL arguments. Vendo's own
- *  identifiers ({@link VENDO_IDENTIFIER_KEYS}) travel as themselves — strings
- *  within the cap, and finite numbers, which are bounded by their own type.
- *  Every other key travels as its own name and the SHAPE of its value. */
+/** A log event's `data` carries a call site's ACTUAL arguments. The allowlisted
+ *  keys ({@link VERBATIM_DATA_KEYS}) travel as themselves — strings within the
+ *  cap, and finite numbers, which are bounded by their own type. Every other
+ *  key travels as its own name and the SHAPE of its value. */
 function dataByProvenance(data: Record<string, unknown> | undefined): Record<string, unknown> {
   const reported: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(data ?? {})) {
-    const verbatim = VENDO_IDENTIFIER_KEYS.has(key)
+    const verbatim = VERBATIM_DATA_KEYS.has(key)
       && (typeof value === "number"
         ? Number.isFinite(value)
         : typeof value === "string" && value.length <= MAX_IDENTIFIER_CHARS);

--- a/packages/vendo/tests/sdk-error-provenance.test.ts
+++ b/packages/vendo/tests/sdk-error-provenance.test.ts
@@ -5,19 +5,28 @@ import { cloudSandbox } from "../src/sandbox.js";
 import { withSdkErrorReporting } from "../src/sdk-events.js";
 
 /**
- * The provenance split on `sdk_error.data`. Reporting every value as its type
- * name defeated the point of the stream: an operator learned that "a ref was
- * malformed" and could not tell WHICH ref. Values Vendo itself MINTED now
- * travel verbatim; anything from the host, its end user, or the model travels
- * as its shape — and so does every key nobody has allowlisted, which is the
- * property that keeps a log site added tomorrow from leaking by default.
+ * What `sdk_error.data` is allowed to say. CLASSIFICATION ONLY: no
+ * caller-influenced value leaves the customer's servers, so the one question a
+ * candidate key has to answer is whether a CALLER CAN INFLUENCE ITS VALUE — not
+ * whether its name sits in Vendo's namespace. A classification against a
+ * Vendo-authored closed set travels; every other value travels as its shape,
+ * and so does every key nobody has allowlisted, which is the property that
+ * keeps a log site added tomorrow from leaking by default.
  *
- * A value that failed to decode is the caller's input, not Vendo's mint, so it
- * is classified against a closed set and never echoed — not even a prefix of
- * it. That distinction is what the marker cases below hold in place.
+ * `appId` and `turnId` are the worked examples, and the reason the name is not
+ * the test: both are spelled in Vendo's own id namespace, and both are supplied
+ * by the caller on a live path, so both report their type and nothing else. A
+ * value that failed to decode is the caller's input for the same reason —
+ * classified against a closed set, never echoed, not even a prefix of it. That
+ * distinction is what the marker cases below hold in place.
  */
 
+/** Caller-suppliable on a live path, so neither may travel: `input.appId ??
+ *  mint` in apps' build-surface door, `surface.turnId ?? mintTurnId()` in the
+ *  screen agent. Both are spelled exactly as Vendo would mint them, which is
+ *  the point — a well-formed value proves nothing about where it came from. */
 const APP_ID = "app_2f6b1c0e-4d3a-4f52-9a71-0c8e5b2d7a13";
+const TURN_ID = "trn_0123456789abcdef0123456789abcdef";
 
 const reported = (): VendoUsageEvent[] => {
   const seen: VendoUsageEvent[] = [];
@@ -41,21 +50,40 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("sdk_error.data splits by provenance", () => {
-  it("passes a Vendo identifier verbatim and shapes the host-derived key beside it", () => {
-    expect(dataOf({ appId: APP_ID, path: "/home/someone/app/customers.ts" }))
-      .toEqual({ appId: APP_ID, path: "string" });
+describe("sdk_error.data reports classifications and shapes everything else", () => {
+  it("passes a classification verbatim and shapes the host-derived key beside it", () => {
+    expect(dataOf({ snapshotRefScheme: "e2b:v2:", path: "/home/someone/app/customers.ts" }))
+      .toEqual({ snapshotRefScheme: "e2b:v2:", path: "string" });
   });
 
   it("defaults an unknown key to shapes-only, so a new log site leaks nothing", () => {
-    expect(dataOf({ customerEmail: "ada@example.com", balanceCents: 4200, appId: APP_ID }))
-      .toEqual({ customerEmail: "string", balanceCents: "number", appId: APP_ID });
+    expect(dataOf({ customerEmail: "ada@example.com", balanceCents: 4200, snapshotRefScheme: "fake:" }))
+      .toEqual({ customerEmail: "string", balanceCents: "number", snapshotRefScheme: "fake:" });
   });
 
+  /** The apps create door mints an app id only when the caller passed none
+   *  (`input.appId ?? mint`), and `appIdSchema` pins the `app_` prefix and
+   *  NOTHING after it — so an `app_` value is `app_` plus arbitrary caller
+   *  content, and a well-formed one is indistinguishable from a minted one. */
+  it("reports a caller-suppliable appId as its type, never its value", () => {
+    expect(dataOf({ appId: APP_ID })).toEqual({ appId: "string" });
+  });
+
+  /** `turnIdSchema` pins the whole `trn_<32 hex>` shape, but no door parses the
+   *  screen agent's `surface.turnId` through it: a `TurnId` is a bare `string`
+   *  whose stated contract is that nobody parses it. A schema that is never
+   *  applied constrains nothing. */
+  it("reports a caller-suppliable turnId as its type, never its value", () => {
+    expect(dataOf({ turnId: TURN_ID })).toEqual({ turnId: "string" });
+  });
+
+  /** The cap is a VOLUME gate on the passthrough, independent of what the key
+   *  means: `data` is `Record<string, unknown>`, so an allowlisted key CAN be
+   *  handed something unbounded, and when it is, the shape travels instead. */
   it("falls back to the shape when an allowlisted value exceeds the length cap", () => {
-    const atCap = `app_${"a".repeat(512 - "app_".length)}`;
-    expect(dataOf({ appId: atCap })).toEqual({ appId: atCap });
-    expect(dataOf({ appId: `${atCap}a` })).toEqual({ appId: "string" });
+    const atCap = "a".repeat(512);
+    expect(dataOf({ errorCode: atCap })).toEqual({ errorCode: atCap });
+    expect(dataOf({ errorCode: `${atCap}a` })).toEqual({ errorCode: "string" });
   });
 });
 


### PR DESCRIPTION
## The ruling this applies

> "No caller-influenced value ever leaves the customer servers. #1217 is approved as built (classified ref type + length, verbatim value stays in the customer local logs and hosted-DB lookup). This supersedes the earlier verbatim-identifier wording."

CLASSIFICATION-ONLY. The earlier rule split `sdk_error.data` by provenance and let anything *Vendo minted* travel verbatim. That is superseded.

## The one-line test

**Can a caller influence this value?** If yes, it does not leave.

It is explicitly *not* "does the key name look internal". That was the old test, and it is how `appId` and `turnId` got onto the allowlist in the first place — both are spelled in Vendo's own id namespace, and both are supplied by the caller on a live path.

## What comes off

| key | why it fails the test |
|---|---|
| `appId` | `packages/apps/src/server/doors/build-surface.ts:286` is `input.appId ?? mint`, and `appIdSchema` pins only the `app_` prefix — so a caller's app id is `app_` followed by arbitrary content. |
| `turnId` | `packages/vendo/src/screen-agent.ts:855` is `surface.turnId ?? mintTurnId()`. `turnIdSchema` *does* pin the whole `trn_<32 hex>` shape, but nothing parses that path through it: a `TurnId` is a bare `string` whose stated contract is that it is opaque and nobody parses it. A schema that is never applied constrains nothing. |

`turnId` was found by re-deriving the allowlist from source rather than trusting the brief, which had it as safe. Neither key is reachable from a log site today, so removing them is free rather than a behavior change.

## What survives, and why it needs no per-key argument

`snapshotRefScheme`, `snapshotRefLength`, `errorCode`.

Every entry is one of three things — a **classification against a Vendo-authored closed set**, a **non-content scalar**, or a **closed union**:

- `snapshotRefScheme` — `sandbox.ts:250` reports `KNOWN_REF_SCHEMES.find(...) ?? "(no known scheme)"`: one of six Vendo-authored constants, never a slice of the input.
- `snapshotRefLength` — a number.
- `errorCode` — the closed eight-member `vendoErrorCodeSchema` (`core/src/errors.ts:19`). **Forward-looking on purpose:** no log site puts one in `data` today (it rides `agent_run`), and the comment says so, so the entry reads as deliberate rather than as an oversight. *(This claim was unenforced — see the update below.)*

That property is the thing to preserve: a candidate that is none of those three does not belong, whatever it is called. `VENDO_IDENTIFIER_KEYS` is renamed `VERBATIM_DATA_KEYS` for the same reason — the old name *was* the superseded test, and it invites the re-add this change removes.

## Evidence

- **RED against `main`:** both new cases fail with the value passing through verbatim — `appId` received `app_2f6b1c0e-...` where `"string"` was expected, same for `turnId`.
- **GREEN after:** 4 suites, 68 passed / 1 skipped (`sdk-error-provenance`, `sdk-events`, `sandbox`, `capability-misses`).
- **Mutation-proved per key:** re-adding `appId` reds exactly its own case (1 failed / 10 passed); re-adding `turnId` likewise.
- Marker, no-digest, fail-safe-default and length-cap cases all still green.

## The test file is a contract co-change (second commit)

`sdk-error-provenance.test.ts` asserted `appId` travels verbatim. That was not a test catching a regression — it *encoded the superseded rule*, and left alone it would have pinned the leak in place. It moves in its own commit so the boundary move is reviewable on its own: the verbatim and fail-safe cases retarget to `snapshotRefScheme`, the length-cap case re-expresses against `errorCode`, and `appId`/`turnId` gain cases asserting they arrive as their type name. The marker and no-digest cases are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tighten `sdk_error.data` to classification-only so no caller-influenced value leaves customer servers; removes `appId` and `turnId` from the verbatim allowlist and keeps only closed-set classifications and scalars. Aligns with Linear #1217.

- **Bug Fixes**
  - Verbatim allowlist limited to `snapshotRefScheme`, `snapshotRefLength`, and `errorCode`; everything else reports its type shape.
  - `appId` and `turnId` are now shaped as `"string"` (caller-suppliable on live paths).
  - Verbatim passthrough still capped; values over 512 chars fall back to shape.

- **Refactors**
  - Rename `VENDO_IDENTIFIER_KEYS` to `VERBATIM_DATA_KEYS`.
  - Update tests to the new contract, including cases for `appId`/`turnId`.

<sup>Written for commit 295daae3bd8dcd13b46fc508f53d43b5a402e1a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



---

## Update — Greptile found a real leak in the first version of this PR (fixed in `956f830a`)

The first version allowlisted **key names**. That let a name make a claim nothing checked: the key said `errorCode` and the comment said "closed eight-member union", but the only actual gate was a 512-character length cap — so any string a caller could reach that key with travelled verbatim. Greptile's 410-character case reproduces it exactly.

**The allowlist now validates the VALUE.** `VERBATIM_DATA_KEYS` (a `Set` of names) became `VERBATIM_DATA_VALUES`, a map from key to the closed set its value must belong to; anything non-conforming is reduced to its type name, exactly as an unlisted key already was.

| key | must be | source of truth |
|---|---|---|
| `snapshotRefScheme` | a `KNOWN_REF_SCHEMES` constant or the `"(no known scheme)"` sentinel | `sandbox-wire.ts` |
| `snapshotRefLength` | a finite number | — |
| `errorCode` | a member of `vendoErrorCodeSchema` | `core/src/errors.ts:19` |

Each check reads its vocabulary from that vocabulary's **owner** rather than re-listing it, so the two cannot drift. That moved `KNOWN_REF_SCHEMES`/`UNKNOWN_REF_SCHEME` from `sandbox.ts` into the zero-import `sandbox-wire.ts`, so the producer of a classification and its validator share one list without `sdk-events.ts` inheriting `sandbox.ts`'s graph. Portability gate green.

**The 512-char cap is deleted as dead code** — every conforming value is now one of six short constants, one of eight short codes, or a number, so no cap could fire. Keeping an unreachable one would keep implying volume is the risk; it is not, provenance is.

**The cap test is superseded, not adjusted** — a test asserting arbitrary content passes verbatim under any key *is* the bug. Three conforming/non-conforming pairs replace it, the `errorCode` pair using Greptile's 410-character shape. Each check is mutation-proved: dropping any one reds its own test and nothing else. Gate: 4 suites, 70 passed / 1 skipped.

**Surfaced, not papered over:** the only live producer of an `errorCode` value (`harness-turn.ts:460`) emits `"unknown"` for a non-`VendoError` failure, which is outside the union. It rides `agent_run.errorCode` — a declared field, not `sdk_error.data` — so it never passes through this allowlist. The union was left alone rather than widened to fit.
