### PR TITLE
fix(vendo)!: validate what an allowlisted key HOLDS, not just its name

### DIFF
--- a/packages/vendo/src/sandbox-wire.ts
+++ b/packages/vendo/src/sandbox-wire.ts
@@ -100,6 +100,27 @@ export const CLOUD_SNAPSHOT_REF_PREFIX = "vendo:v2:";
  * adapter's composite ref, never handed to the seam bare. */
 export const CONSOLE_SNAPSHOT_REF_PREFIX = "vendo:";
 
+/** Every snapshot-ref scheme this repo mints, longest match first — "vendo:"
+ * is a strict prefix of "vendo:v2:". Classification reports the MATCHED
+ * CONSTANT from this list, never a slice of the input.
+ *
+ * It lives HERE, in the module with no imports, because it has two readers that
+ * must never drift: `decodeOrReport` (sandbox.ts) PRODUCES a classification
+ * from it, and the telemetry boundary (sdk-events.ts) VALIDATES an emitted
+ * classification against it before letting one travel verbatim. A scheme added
+ * to the producer's copy alone would be silently shaped by the validator. */
+export const KNOWN_REF_SCHEMES = [
+  CLOUD_SNAPSHOT_REF_PREFIX,
+  "e2b:v2:",
+  "fake-v2:",
+  "fake:",
+  CONSOLE_SNAPSHOT_REF_PREFIX,
+] as const;
+
+/** The classification for a ref that matches no {@link KNOWN_REF_SCHEMES}
+ *  entry — a Vendo-authored sentence, never any part of the input. */
+export const UNKNOWN_REF_SCHEME = "(no known scheme)";
+
 /** The canonical box port the relay targets when no port rides the wire
  * (and the one the public ingress `https://<id-suffix>-m.vendo.run`
  * serves). */

--- a/packages/vendo/src/sandbox.ts
+++ b/packages/vendo/src/sandbox.ts
@@ -8,6 +8,8 @@ import {
   CLOUD_SNAPSHOT_REF_PREFIX,
   CLOUD_SNAPSHOTS_SUBPATH,
   CONSOLE_SNAPSHOT_REF_PREFIX,
+  KNOWN_REF_SCHEMES,
+  UNKNOWN_REF_SCHEME,
 } from "./sandbox-wire.js";
 
 /** Same default as the e2b adapter and the retired ENG-295 broker client:
@@ -199,19 +201,6 @@ const decodeSnapshotRef = (snapshotRef: string): CloudSnapshotState => {
  * idempotent transitions (destroy twice, stop of a dead machine) absorb. */
 const isGone = (error: unknown): boolean =>
   error instanceof VendoError && error.code === "not-found";
-
-/** Every snapshot-ref scheme this repo mints, longest match first — "vendo:"
- * is a strict prefix of "vendo:v2:". Classification reports the MATCHED
- * CONSTANT from this list, never a slice of the input. */
-const KNOWN_REF_SCHEMES = [
-  CLOUD_SNAPSHOT_REF_PREFIX,
-  "e2b:v2:",
-  "fake-v2:",
-  "fake:",
-  CONSOLE_SNAPSHOT_REF_PREFIX,
-] as const;
-
-const UNKNOWN_REF_SCHEME = "(no known scheme)";
 
 /** Decode a ref, and report which ref failed when it will not decode.
  *

--- a/packages/vendo/src/sdk-events.ts
+++ b/packages/vendo/src/sdk-events.ts
@@ -15,9 +15,10 @@
  *
  * Keep this module free of node builtins; the portability gate bundles it.
  */
-import { emitUsage, type VendoLogger, type VendoUsageEvent } from "@vendoai/core";
+import { emitUsage, vendoErrorCodeSchema, type VendoLogger, type VendoUsageEvent } from "@vendoai/core";
 import { envOptOut } from "@vendoai/telemetry";
 import { createBatchedUploader } from "./batched-uploader.js";
+import { KNOWN_REF_SCHEMES, UNKNOWN_REF_SCHEME } from "./sandbox-wire.js";
 import { VERSION } from "./wire/shared.js";
 
 /** The console door this stream POSTs to. ONE constant: the route is the
@@ -120,29 +121,36 @@ export function withSdkErrorReporting(logger: VendoLogger): VendoLogger {
 }
 
 /**
- * The `data` keys that travel VERBATIM.
+ * The `data` keys that may travel VERBATIM, each with the CLOSED SET its value
+ * has to belong to before it does.
  *
- * A CLOSED set of KEY NAMES, the same discipline as the CLI lane's
- * `CLOUD_PROP_KEYS`: a key nobody listed here — including every key a log site
- * added tomorrow — is shapes-only, so the default leaks nothing and opting a
- * key in is a deliberate edit to this list.
+ * A closed set of KEY NAMES was not enough, and this map is the correction: the
+ * name said `errorCode` while nothing checked the value WAS an error code, so
+ * any string a caller could reach that key with travelled unchanged, up to a
+ * length cap that was never the point. A key name is a CLAIM about a value.
+ * This checks the claim.
  *
- * CLASSIFICATION ONLY. The test for membership is ONE question — CAN A CALLER
- * INFLUENCE THIS VALUE? — and it is not the question the key's NAME answers. A
- * name in Vendo's own namespace proves nothing: what matters is whether every
- * value that can reach the key was produced here, on every path, including the
- * failure paths. If a caller can put arbitrary content there by any route, no
- * caller-influenced value leaves the customer's servers: the verbatim value
- * stays in their local logs and their hosted-DB lookup, and only a
- * classification of it travels.
+ * CLASSIFICATION ONLY. The rule: an allowlisted key's value is validated
+ * against a closed set or a scalar type, and anything that does not conform is
+ * reduced to its type name — exactly as a key nobody allowlisted already is.
+ * So no caller-influenced value leaves the customer's servers; the verbatim
+ * value stays in their local logs and their hosted-DB lookup, and only a
+ * classification of it travels. A key nobody listed here — including every key
+ * a log site adds tomorrow — is shapes-only, so the default still leaks
+ * nothing.
  *
- * So the set needs no per-key argument, and that is the property to preserve:
- * every entry is a CLASSIFICATION against a Vendo-authored closed set, a
- * NON-CONTENT SCALAR, or a CLOSED UNION. A candidate that is none of those
- * three does not belong here, whatever it is called.
+ * That makes the boundary safe BY CONSTRUCTION rather than by argument: what
+ * can travel is ENUMERABLE, and every one of those values is Vendo-authored. A
+ * candidate key with no closed set to check against does not belong here,
+ * whatever it is called.
+ *
+ * Each check reads its vocabulary from that vocabulary's OWNER — the schemes
+ * from `sandbox-wire.ts`, the codes from core's `vendoErrorCodeSchema` — never
+ * a local re-listing, so a check and the thing it checks cannot drift apart.
  *
  * REMOVED, and not to be re-added by reasoning that the namespaces are Vendo's
- * — both are caller-suppliable on a live path:
+ * — both are caller-suppliable on a live path, and neither has any closed set
+ * to be validated against:
  *   - `appId`: `apps/src/server/doors/build-surface.ts:286` is
  *     `input.appId ?? mint`, and `appIdSchema` pins only the `app_` prefix, so
  *     a caller's app id is `app_` followed by anything at all.
@@ -151,41 +159,42 @@ export function withSdkErrorReporting(logger: VendoLogger): VendoLogger {
  *     parses that path through it — a `TurnId` is a bare `string`, and the
  *     type's stated contract is that it is opaque and nobody parses it.
  */
-const VERBATIM_DATA_KEYS: ReadonlySet<string> = new Set([
-  // A CLASSIFICATION of a snapshot ref, never the ref (sandbox.ts): a matched
-  // constant from Vendo's closed set of schemes, and a length. A raw
-  // `snapshotRef` is deliberately NOT here — the only path that reports one is
-  // the path where it FAILED to decode, and a ref that failed to decode is by
-  // definition not Vendo-minted but whatever a caller handed a public method.
-  // Nor is a DIGEST of one: an unkeyed hash of caller content confirms guesses
-  // offline, which is a quieter version of the same leak.
-  "snapshotRefScheme",
-  "snapshotRefLength",
-  // A `VendoErrorCode` — a closed eight-member union in core, already
-  // travelling verbatim on the `tool_call` event. FORWARD-LOOKING on purpose:
-  // no log site puts one in `data` today (it rides `agent_run` instead), so
-  // this entry is deliberate rather than an oversight, and it is here so the
-  // first log site that does report one is not silently reduced to "string".
-  "errorCode",
+const VERBATIM_DATA_VALUES: ReadonlyMap<string, (value: unknown) => boolean> = new Map([
+  // A CLASSIFICATION of a snapshot ref, never the ref (sandbox.ts): the matched
+  // constant from Vendo's closed set of schemes, or the sentinel for no match.
+  // A raw `snapshotRef` is deliberately NOT a key here — the only path that
+  // reports one is the path where it FAILED to decode, and a ref that failed to
+  // decode is by definition not Vendo-minted but whatever a caller handed a
+  // public method. Nor is a DIGEST of one: an unkeyed hash of caller content
+  // confirms guesses offline, which is a quieter version of the same leak.
+  ["snapshotRefScheme", (value) => typeof value === "string"
+    && (value === UNKNOWN_REF_SCHEME || KNOWN_REF_SCHEMES.some((scheme) => scheme === value))],
+  // How long the ref was, which says nothing about what was in it.
+  ["snapshotRefLength", (value) => typeof value === "number" && Number.isFinite(value)],
+  // A `VendoErrorCode`, checked against core's schema rather than a re-listing
+  // of its members. FORWARD-LOOKING on purpose: no log site puts one in `data`
+  // today (it rides `agent_run` instead), so this entry is deliberate rather
+  // than an oversight, and it is here so the first log site that does report
+  // one is not silently reduced to "string".
+  ["errorCode", (value) => vendoErrorCodeSchema.safeParse(value).success],
 ]);
 
-/** No classification Vendo emits comes near this. The cap is a VOLUME gate — an
- *  allowlisted key that unexpectedly holds something unbounded reports its
- *  shape instead, so no key on the list can become a content channel. */
-const MAX_IDENTIFIER_CHARS = 512;
-
-/** A log event's `data` carries a call site's ACTUAL arguments. The allowlisted
- *  keys ({@link VERBATIM_DATA_KEYS}) travel as themselves — strings within the
- *  cap, and finite numbers, which are bounded by their own type. Every other
- *  key travels as its own name and the SHAPE of its value. */
+/** A log event's `data` carries a call site's ACTUAL arguments. A key travels
+ *  verbatim only when it is allowlisted AND its value passes that key's check
+ *  ({@link VERBATIM_DATA_VALUES}); everything else — an unlisted key, and a
+ *  listed key holding something it should never hold — travels as its own name
+ *  and the SHAPE of its value.
+ *
+ *  There is deliberately no length cap any more. One used to stand in for this
+ *  check, and it was the bug: it let 512 characters of anything through under a
+ *  name that promised a classification. Now that every conforming value is one
+ *  of a handful of Vendo-authored constants or a number, a cap could never
+ *  fire, and keeping an unreachable one would only re-suggest that volume is
+ *  the risk. It is not; provenance is. */
 function dataByProvenance(data: Record<string, unknown> | undefined): Record<string, unknown> {
   const reported: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(data ?? {})) {
-    const verbatim = VERBATIM_DATA_KEYS.has(key)
-      && (typeof value === "number"
-        ? Number.isFinite(value)
-        : typeof value === "string" && value.length <= MAX_IDENTIFIER_CHARS);
-    reported[key] = verbatim ? value : shapeOf(value);
+    reported[key] = VERBATIM_DATA_VALUES.get(key)?.(value) === true ? value : shapeOf(value);
   }
   return reported;
 }

--- a/packages/vendo/tests/sdk-error-provenance.test.ts
+++ b/packages/vendo/tests/sdk-error-provenance.test.ts
@@ -6,19 +6,23 @@ import { withSdkErrorReporting } from "../src/sdk-events.js";
 
 /**
  * What `sdk_error.data` is allowed to say. CLASSIFICATION ONLY: no
- * caller-influenced value leaves the customer's servers, so the one question a
- * candidate key has to answer is whether a CALLER CAN INFLUENCE ITS VALUE — not
- * whether its name sits in Vendo's namespace. A classification against a
- * Vendo-authored closed set travels; every other value travels as its shape,
- * and so does every key nobody has allowlisted, which is the property that
- * keeps a log site added tomorrow from leaking by default.
+ * caller-influenced value leaves the customer's servers.
  *
- * `appId` and `turnId` are the worked examples, and the reason the name is not
- * the test: both are spelled in Vendo's own id namespace, and both are supplied
- * by the caller on a live path, so both report their type and nothing else. A
- * value that failed to decode is the caller's input for the same reason —
+ * The rule is about VALUES, not key names. An allowlisted key's value is
+ * validated against a closed set or a scalar type, and anything that does not
+ * conform is reduced to its type name — exactly as a key nobody allowlisted
+ * already is. Allowlisting a NAME was the earlier, weaker version of this and
+ * it shipped a leak: `errorCode` promised a closed union while nothing checked
+ * for one, so caller content travelled verbatim under it.
+ *
+ * Two failure modes, and the cases below hold both:
+ *   - a key whose value a caller supplies (`appId`, `turnId` — both spelled in
+ *     Vendo's own id namespace, which is exactly why the NAME is not the test)
+ *   - an allowlisted key handed something outside its closed set
+ *
+ * A value that failed to decode is the caller's input for the same reason —
  * classified against a closed set, never echoed, not even a prefix of it. That
- * distinction is what the marker cases below hold in place.
+ * distinction is what the marker cases hold in place.
  */
 
 /** Caller-suppliable on a live path, so neither may travel: `input.appId ??
@@ -77,13 +81,33 @@ describe("sdk_error.data reports classifications and shapes everything else", ()
     expect(dataOf({ turnId: TURN_ID })).toEqual({ turnId: "string" });
   });
 
-  /** The cap is a VOLUME gate on the passthrough, independent of what the key
-   *  means: `data` is `Record<string, unknown>`, so an allowlisted key CAN be
-   *  handed something unbounded, and when it is, the shape travels instead. */
-  it("falls back to the shape when an allowlisted value exceeds the length cap", () => {
-    const atCap = "a".repeat(512);
-    expect(dataOf({ errorCode: atCap })).toEqual({ errorCode: atCap });
-    expect(dataOf({ errorCode: `${atCap}a` })).toEqual({ errorCode: "string" });
+  /** Being allowlisted buys the KEY nothing on its own — the value still has to
+   *  be one of the six constants `sandbox-wire.ts` names, or the sentinel. A
+   *  scheme-shaped string that is not on that list is caller content wearing a
+   *  classification's name. */
+  it("passes a snapshot scheme from the closed set, and shapes anything else under that key", () => {
+    expect(dataOf({ snapshotRefScheme: "(no known scheme)" }))
+      .toEqual({ snapshotRefScheme: "(no known scheme)" });
+    expect(dataOf({ snapshotRefScheme: "s3cret-leak:" })).toEqual({ snapshotRefScheme: "string" });
+  });
+
+  /** The length key means a LENGTH. A string under it is a whole ref smuggled
+   *  through a key whose name promised a scalar. */
+  it("passes a numeric snapshotRefLength, and shapes a non-number under that key", () => {
+    expect(dataOf({ snapshotRefLength: 42 })).toEqual({ snapshotRefLength: 42 });
+    expect(dataOf({ snapshotRefLength: "vendo:v2:eyJzZWNyZXQiOiJsZWFrIn0" }))
+      .toEqual({ snapshotRefLength: "string" });
+  });
+
+  /** Greptile's finding on #1222, pinned so it cannot come back. The key name
+   *  claimed the closed `VendoErrorCode` union while NOTHING checked for one,
+   *  and the old length cap approved any string under 512 characters — so a
+   *  410-character caller-controlled value travelled verbatim under a name that
+   *  promised a classification. The VALUE is checked now, against core's
+   *  `vendoErrorCodeSchema` rather than a re-listing that could drift from it. */
+  it("passes a real VendoErrorCode, and shapes a long non-union string under that key", () => {
+    expect(dataOf({ errorCode: "validation" })).toEqual({ errorCode: "validation" });
+    expect(dataOf({ errorCode: "x".repeat(410) })).toEqual({ errorCode: "string" });
   });
 });
 


### PR DESCRIPTION
**Security fix. Closes a proven latent leak that #1222 merged before this commit landed on the branch.**

## What is on `main` today

`VERBATIM_DATA_KEYS` is a set of key **names**. Any string under an allowlisted name is forwarded verbatim into `sdk_error.data`, up to a 512-character cap. `errorCode` is on that list, and its comment claims safety on the grounds that it is "a closed eight-member union" — but nothing checks that at the emit path.

Greptile proved it on #1222 with a runtime repro: a 410-character non-`VendoErrorCode` value is rejected by core's schema and retained verbatim in telemetry.

**Reachability:** latent, not live. No log site puts `errorCode` in `data` today — it rides `agent_run` instead, where the field is declared `string | null`. So nothing is leaking right now. The point is that the boundary should not depend on "no caller does that yet", which is the assumption that has now failed six times on this feature.

## The fix

The allowlist becomes a map of key → validator. A conforming value travels; a non-conforming value is reduced to its type name, exactly as an unlisted key already is.

| key | must be | source of truth |
|---|---|---|
| `snapshotRefScheme` | a `KNOWN_REF_SCHEMES` constant or the `"(no known scheme)"` sentinel | `sandbox-wire.ts` |
| `snapshotRefLength` | a finite number | — |
| `errorCode` | a member of `vendoErrorCodeSchema` | `core/src/errors.ts:19` |

Each validator reads its vocabulary from that vocabulary's **owner** rather than re-listing it, so a check and the thing it checks cannot drift.

**The 512-character cap is deleted as dead code.** Every conforming value is now one of six short constants, one of eight short codes, or a number — no cap could ever fire. Keeping an unreachable one would keep implying that volume is the risk. It isn't; provenance is.

## Also corrected

The comment on `errorCode` claimed it was "already travelling verbatim on the `tool_call` event". There is no `errorCode` on `tool_call`. The justification rested partly on a citation that did not exist.

## Proof

Three pairs — for each key, a conforming value travels and a non-conforming value of the same key arrives as its type name. The `errorCode` case uses Greptile's shape (a long non-union string) and asserts it is NOT retained; shown RED against the merged code, reproducing their result. Mutation-proven per key: dropping each validator reds its own test and nothing else.

Gate: 70 passed / 1 skipped across 4 suites, typecheck, lint, build, and the portability gate green on all seven legs — the last matters because sourcing the scheme constants required keeping `sdk-events.ts` out of `sandbox.ts`'s import graph.

## Non-conforming live producer, found and not papered over

`harness-turn.ts:460` emits `"unknown"` for a non-`VendoError` failure, which is outside the union. It rides `agent_run.errorCode`, a declared `string | null` field, so it never passes through this allowlist. The union was **not** widened to fit it. If a log site ever reports that value under `data.errorCode`, being shaped to `"string"` is the correct outcome.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Security fix: we now validate the values of allowlisted `sdk_error.data` keys, not just their names, closing a latent path where arbitrary strings under `errorCode` could pass through. This switches to key→validator checks and removes the unused 512‑char cap.

- **Bug Fixes**
  - Allowlist is now a key→validator map; only values that match a closed set or scalar type travel verbatim. Non‑conforming values (and all unlisted keys) are reduced to their type name.
  - Validations:
    - `snapshotRefScheme`: must be one of `KNOWN_REF_SCHEMES` or the `"(no known scheme)"` sentinel.
    - `snapshotRefLength`: must be a finite number.
    - `errorCode`: must pass `vendoErrorCodeSchema` from `@vendoai/core`.
  - Removed the 512‑char cap (dead code). Provenance, not length, gates what can travel.
  - Centralized scheme constants in `sandbox-wire.ts` so the producer and validator read the same list.
  - Fixed an outdated comment that incorrectly referenced `tool_call`.

<sup>Written for commit 6d1c8130b40d93d7564c291b81a47460b0e0a7ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

