### PR TITLE
test(apps): quarantine OOM-screen contract test blocking the v0.15.0 publish

### DIFF
--- a/packages/apps/tests/contract/genui/component/screen-errors.test.ts
+++ b/packages/apps/tests/contract/genui/component/screen-errors.test.ts
@@ -306,7 +306,12 @@ export default function S() { while (true) {} return <Text text="never" />; }`);
     expect(error.message).toContain("did not finish inside 2000ms");
   });
 
-  it("raises an out-of-memory screen as a catchable failure, and the engine survives it", () => {
+  // Quarantined 2026-08-11: deterministic-red on the release workflow's serial
+  // single-runner pass while green on sharded CI — on a loaded runner the 5M-row
+  // allocation can trip the 2000ms boot budget before the per-VM heap limit, so
+  // the error kind races between "budget" and "boot". Root-cause + un-skip
+  // tracked in the follow-up issue; do not delete: this guards engine survival.
+  it.skip("raises an out-of-memory screen as a catchable failure, and the engine survives it", () => {
     const error = failsBoot(`
 import { Text } from "@vendo/screen";
 export default function S() {


### PR DESCRIPTION
One-line test skip to unblock the release train, per Yousef's direct order (ship ASAP).

- Test: screen-errors.test.ts › "raises an out-of-memory screen as a catchable failure, and the engine survives it"
- Red twice, deterministically, on release.yml's serial publish pass (run 31522090201); green on sharded CI at the same commit 926c0bfa
- Root cause + un-skip tracked in #1224, owned by the BETTER lane

No product code touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Temporarily skip the out-of-memory screen contract test to unblock the v0.15.0 publish. The test fails on the release runner due to a budget-vs-OOM race; tracked in #1224; no product code changed.

<sup>Written for commit 5c823f8271b68c1f50f3ce1347e7e98d45fc3007. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

