### PR TITLE
fix(vendo): the store's ephemeral-disk warning lands IN the boot block, not beside it

### DIFF
--- a/packages/store/src/db-postgres.ts
+++ b/packages/store/src/db-postgres.ts
@@ -20,9 +20,24 @@ export interface StoreConfig {
 
 export type Query = Db["query"];
 
+/** A data directory the next redeploy deletes, and why: a container platform
+    that wipes its filesystem (named), or a path under the OS temp dir (no
+    platform). Composed state, not a message — whoever holds the store decides
+    how to say it; `createVendo` renders it as the boot block's ⚠ store row. */
+export interface EphemeralDataDir {
+  /** The directory as configured — what the operator wrote, or the default. */
+  readonly dataDir: string;
+  /** The platform whose filesystem is wiped, when a marker named one. */
+  readonly platform?: string;
+}
+
 /** 02-store §4 */
 export interface Db {
   kind: "pg" | "pglite";
+  /** Set only when this engine writes to storage a redeploy wipes — the PGlite
+      default on a container platform or under the OS temp dir. Absent for a
+      Postgres url, for `memory://`, and for a real disk. */
+  readonly ephemeral?: EphemeralDataDir;
   query(text: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[] }>;
   close(): Promise<void>;
   raw(): unknown;

--- a/packages/store/src/db.ts
+++ b/packages/store/src/db.ts
@@ -7,16 +7,23 @@ import fs from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve, sep } from "node:path";
 
-import { createPostgresDb, type Db, type Query, type StoreConfig } from "./db-postgres.js";
+import {
+  createPostgresDb,
+  type Db,
+  type EphemeralDataDir,
+  type Query,
+  type StoreConfig,
+} from "./db-postgres.js";
 
-export type { Db, Query, StoreConfig } from "./db-postgres.js";
+export type { Db, EphemeralDataDir, Query, StoreConfig } from "./db-postgres.js";
 
 const SERVERLESS_ENVS = ["VERCEL", "CF_PAGES", "AWS_LAMBDA_FUNCTION_NAME"] as const;
 
 /** Platforms that DO run a long-lived process — so PGlite works, and refusing
  *  outright (SERVERLESS_ENVS) would be wrong — but wipe the container
  *  filesystem on every redeploy. The store keeps working; it just silently
- *  loses every user's app at the next deploy, so this is a warning. */
+ *  loses every user's app at the next deploy, so the handle carries the fact
+ *  and the deployment says it once, at boot. */
 const EPHEMERAL_PLATFORM_ENVS = [
   ["RAILWAY_ENVIRONMENT", "Railway"],
   ["RENDER", "Render"],
@@ -27,18 +34,17 @@ const EPHEMERAL_PLATFORM_ENVS = [
 const isUnder = (path: string, dir: string): boolean =>
   path === dir || path.startsWith(dir.endsWith(sep) ? dir : dir + sep);
 
-function warnIfEphemeralDataDir(dataDir: string): void {
-  if (dataDir.startsWith("memory://")) return; // not a path on disk
-  const path = resolve(dataDir);
+/** The judgment, as DATA on the handle rather than a line on the console: the
+ *  deployment that composed this store is what tells its operator (the boot
+ *  block's ⚠ store row, boot-summary.ts), and it can only do that if the answer
+ *  is readable off the composition. Pure — a path resolve and env reads, no I/O
+ *  — so it is safe at compose time, where `createVendo` may not touch disk. */
+function ephemeralDataDirOf(dataDir: string): EphemeralDataDir | undefined {
+  if (dataDir.startsWith("memory://")) return undefined; // not a path on disk
   const platform = EPHEMERAL_PLATFORM_ENVS.find(([name]) => (process.env[name] ?? "").trim() !== "")?.[1];
-  if (platform === undefined && !(isUnder(path, tmpdir()) || isUnder(path, "/tmp"))) return;
-  const wipes = platform === undefined
-    ? "which this platform wipes on every redeploy"
-    : `and ${platform} wipes the container filesystem on every redeploy`;
-  console.warn(
-    `[vendo] warning: the store is writing to ${JSON.stringify(path)}, ${wipes} — your users' apps and data will be gone.`
-    + ` Mount a persistent volume and point dataDir at it, or pass url: "postgres://…" to createVendo.`,
-  );
+  if (platform !== undefined) return { dataDir, platform };
+  const path = resolve(dataDir);
+  return isUnder(path, tmpdir()) || isUnder(path, "/tmp") ? { dataDir } : undefined;
 }
 
 function preparePgliteDir(dataDir: string): void {
@@ -281,9 +287,7 @@ async function createPgliteHealingStaleLock(dataDir: string): Promise<PGlite> {
 /** 02-store §4 — url picks the pg engine; otherwise the PGlite dev default. */
 export function createDb(config: StoreConfig = {}): Db {
   if (config.url) return createPostgresDb(config.url);
-  const dataDir = config.dataDir ?? ".vendo/data";
-  warnIfEphemeralDataDir(dataDir);
-  return createPgliteDb(dataDir);
+  return createPgliteDb(config.dataDir ?? ".vendo/data");
 }
 
 function createPgliteDb(dataDir: string): Db {
@@ -330,8 +334,10 @@ function createPgliteDb(dataDir: string): Db {
     return opening;
   };
 
+  const ephemeral = ephemeralDataDirOf(dataDir);
   const db: Db = {
     kind: "pglite",
+    ...(ephemeral === undefined ? {} : { ephemeral }),
     async query(text, params = []) {
       const active = await open();
       const result = await active.query<Record<string, unknown>>(text, params);

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -3,6 +3,10 @@
  *  keep the PGlite wasm engine out of the bundle graph. */
 export { createStore } from "./create-store.js";
 export { maybeDbFor, type VendoStore } from "./store.js";
+// Composed state, read off the engine handle `maybeDbFor` returns: the data dir
+// this store writes to when a redeploy wipes it. The deployment that composed
+// the store is what tells its operator (createVendo's boot block).
+export type { EphemeralDataDir } from "./db-postgres.js";
 // The StoreOps local backend (02-store): the 35-op named-operation contract
 // served off this store's own Postgres, transactions at verb boundaries.
 export { createStoreOps } from "./ops.js";

--- a/packages/store/tests/db.ephemeral-warning.test.ts
+++ b/packages/store/tests/db.ephemeral-warning.test.ts
@@ -2,17 +2,21 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDb } from "../src/db.js";
+import { createStore } from "../src/create-store.js";
+import { maybeDbFor } from "../src/store.js";
 
 // A container platform runs a long-lived process, so PGlite WORKS there — right
 // up to the next deploy, which deletes the whole filesystem and with it every
 // app the product's users built. The store cannot refuse (unlike VERCEL and
-// friends, where PGlite cannot run at all), so boot warns instead.
+// friends, where PGlite cannot run at all), so it carries the judgment as a fact
+// on the handle and the deployment that composed it says it once, at boot
+// (createVendo's ⚠ store row — packages/vendo/src/boot-summary.ts).
 
 const TMP_DATA_DIR = join(tmpdir(), "vendo-ephemeral-warning", "data");
 // A path with a real disk under it: the laptop case that must stay silent.
 const LAPTOP_DATA_DIR = "/home/dev/maple/.vendo/data";
 
-describe("PGlite ephemeral-disk warning", () => {
+describe("PGlite ephemeral-disk judgment", () => {
   let warn: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
@@ -24,17 +28,8 @@ describe("PGlite ephemeral-disk warning", () => {
     vi.unstubAllEnvs();
   });
 
-  const warning = (): string => String(warn.mock.calls[0]?.[0] ?? "");
-
-  it("warns when the data dir is under the OS temp dir", () => {
-    createDb({ dataDir: TMP_DATA_DIR });
-
-    expect(warn).toHaveBeenCalledTimes(1);
-    expect(warning()).toBe(
-      `[vendo] warning: the store is writing to ${JSON.stringify(TMP_DATA_DIR)}, which this platform wipes on every`
-      + " redeploy — your users' apps and data will be gone. Mount a persistent volume and point dataDir at it,"
-      + ' or pass url: "postgres://…" to createVendo.',
-    );
+  it("flags a data dir under the OS temp dir, naming it as configured", () => {
+    expect(createDb({ dataDir: TMP_DATA_DIR }).ephemeral).toEqual({ dataDir: TMP_DATA_DIR });
   });
 
   it.each([
@@ -42,25 +37,38 @@ describe("PGlite ephemeral-disk warning", () => {
     ["RENDER", "true", "Render"],
     ["FLY_APP_NAME", "maple", "Fly.io"],
     ["DYNO", "web.1", "Heroku"],
-  ])("warns on %s even with a normal-looking data dir", (marker, value, platform) => {
+  ])("names %s's platform even with a normal-looking data dir", (marker, value, platform) => {
     vi.stubEnv(marker, value);
 
-    createDb({ dataDir: LAPTOP_DATA_DIR });
-
-    expect(warn).toHaveBeenCalledTimes(1);
-    expect(warning()).toContain(`and ${platform} wipes the container filesystem on every redeploy`);
-    expect(warning()).toContain(JSON.stringify(LAPTOP_DATA_DIR));
+    expect(createDb({ dataDir: LAPTOP_DATA_DIR }).ephemeral)
+      .toEqual({ dataDir: LAPTOP_DATA_DIR, platform });
   });
 
-  it("stays silent for an ordinary laptop path", () => {
-    createDb({ dataDir: LAPTOP_DATA_DIR });
-    createDb({}); // the .vendo/data default, resolved against this repo's cwd
-    createDb({ dataDir: "memory://silent" });
+  it("says nothing for an ordinary laptop path, the default, memory:// or a url", () => {
+    expect(createDb({ dataDir: LAPTOP_DATA_DIR }).ephemeral).toBeUndefined();
+    // The .vendo/data default, resolved against this repo's cwd.
+    expect(createDb({}).ephemeral).toBeUndefined();
+    expect(createDb({ dataDir: "memory://silent" }).ephemeral).toBeUndefined();
+    expect(createDb({ url: "postgres://user@host/db" }).ephemeral).toBeUndefined();
+  });
 
+  // The store is not the one that talks to the operator: printing here and
+  // rendering the same judgment in the boot block said it twice.
+  it("never prints it itself", () => {
+    vi.stubEnv("RAILWAY_ENVIRONMENT", "production");
+    createDb({ dataDir: TMP_DATA_DIR });
     expect(warn).not.toHaveBeenCalled();
   });
 
-  it("still hard-refuses a serverless platform instead of warning", async () => {
+  // The SEAM the boot block reads through: a real createStore handle in, the
+  // judgment out, with nothing stubbed on either side.
+  it("reaches a composed store handle through maybeDbFor", () => {
+    expect(maybeDbFor(createStore({ dataDir: TMP_DATA_DIR }))?.ephemeral)
+      .toEqual({ dataDir: TMP_DATA_DIR });
+    expect(maybeDbFor(createStore({ dataDir: LAPTOP_DATA_DIR }))?.ephemeral).toBeUndefined();
+  });
+
+  it("still hard-refuses a serverless platform instead of flagging it", async () => {
     vi.stubEnv("VERCEL", "1");
 
     const db = createDb({ dataDir: TMP_DATA_DIR });

--- a/packages/vendo/src/boot-summary.ts
+++ b/packages/vendo/src/boot-summary.ts
@@ -19,16 +19,18 @@
  *   1. COMPOSED FACTS ONLY. `createVendo` must stay I/O-free at module init for
  *      Workers portability (compose-store.ts's `selectFiles` note), so nothing
  *      here may stat a path, open a handle, or await anything. Every row is a
- *      property read off the finished composition or an env variable — and the
- *      one judgment that genuinely needs the filesystem (is the data dir
- *      ephemeral?) is made by its owner and arrives here as a WARNING, which is
- *      data in `BootSummary`, not a special case in the renderer.
+ *      property read off the finished composition or an env variable — including
+ *      the ephemeral-disk judgment, which its OWNER makes (the store, at
+ *      `createStore`) and hangs on the engine handle, so this block reads it
+ *      like any other composed fact and renders it as a WARNING, which is data
+ *      in `BootSummary`, not a special case in the renderer.
  *
  *   2. ONE BLOCK PER PROCESS. A dev server recomposes on nearly every request;
  *      this is a boot fact, not a per-request one (the same latch
  *      `reportHostedStoreOnce` uses).
  */
 import { log, vendoStyle, type VendoStyle } from "@vendoai/core";
+import { maybeDbFor, type VendoStore } from "@vendoai/store";
 import type { VendoComposition } from "./compose-context.js";
 import { ENV_KEY_VARS } from "./dev-creds/resolve.js";
 import { environment } from "./wire/shared.js";
@@ -62,9 +64,12 @@ export interface BootSummary {
 }
 
 /** "Did the operator set this?" — TRIMMED, because a whitespace-only value is
-    not a key, and the sandbox ladder and `vendo doctor` already agree on that.
-    Disagreeing with either about whether a key is present means one of the three
-    is lying to the operator. */
+    not a key, and `present` in dev-creds/resolve.ts — the ladder that actually
+    resolves the model credentials this asks about — makes the same call. It is
+    STRICTER than `environment()` (wire/shared.ts), which any non-empty string
+    satisfies, and `vendo doctor` matches that looser predicate deliberately
+    (doctor-config-checks.ts's checkStorePersistence), so the three do NOT all
+    agree for a whitespace-only value. */
 const keySet = (name: string): boolean => (environment(name)?.trim() ?? "") !== "";
 
 const MARKER = "◆";
@@ -166,6 +171,29 @@ const STRAY_E2B: BootWarning = {
   ],
 };
 
+/** The store's own ephemeral-disk judgment, said in the block instead of on its
+    own console line: made at `createStore` and carried on the engine handle
+    (`EphemeralDataDir`), so reading it here is a property read, not a stat. The
+    dir is named the way the store ROW above names it — `.vendo/data`, as
+    configured — and the second line is the operator's two ways out.
+
+    Silent for every store this cannot be true of: a Postgres url, `memory://`,
+    a real disk, the Cloud hosted store, and a host's own adapter. */
+function ephemeralStoreWarning(store: VendoStore): BootWarning | undefined {
+  const ephemeral = maybeDbFor(store)?.ephemeral;
+  if (ephemeral === undefined) return undefined;
+  const where = ephemeral.platform === undefined
+    ? "is under /tmp"
+    : `is on ${ephemeral.platform}'s container filesystem`;
+  return {
+    label: "store",
+    lines: [
+      `${ephemeral.dataDir} ${where} — data will not survive a redeploy.`,
+      'Mount a volume, or pass url: "postgres://…" to createVendo.',
+    ],
+  };
+}
+
 /** Which ladder rung the composed model slot rode — named from the environment,
     because the ladder itself resolves LAZILY and asking it would force a
     resolution at boot (the same reason /status reports only "ladder"). The rung
@@ -194,7 +222,8 @@ function modelRow(): BootRow | undefined {
  * block stays four lines for the deployment that filled four seams.
  */
 export function bootSummaryFor(composition: VendoComposition): BootSummary {
-  const { config, composed, sandbox, inference, connections, guard, hostedStoreComposed } = composition;
+  const { config, composed, sandbox, inference, connections, guard, hostedStoreComposed, store }
+    = composition;
   const rows: BootRow[] = [];
   const warnings: BootWarning[] = [];
 
@@ -226,6 +255,10 @@ export function bootSummaryFor(composition: VendoComposition): BootSummary {
   } else {
     rows.push({ label: "store", venue: "local", detail: ".vendo/data" });
   }
+  // Whatever store composed, on disk or not: only the store knows, and only the
+  // deployment can tell the operator.
+  const ephemeral = ephemeralStoreWarning(store);
+  if (ephemeral !== undefined) warnings.push(ephemeral);
 
   if (inference.agent.venue === "custom") {
     rows.push({ label: "models", venue: "custom", detail: "createVendo({ models })" });

--- a/packages/vendo/src/cli/doctor-config-checks.ts
+++ b/packages/vendo/src/cli/doctor-config-checks.ts
@@ -53,7 +53,8 @@ export async function checkStorePersistence(run: DoctorRun): Promise<void> {
   // and STILL passes `store: createStore()` is not visible from here — no
   // doctor check can see a programmatic override (doctor-report.ts's DoctorRun;
   // same limit checkSurfaceOwnership states) — and that host still gets the
-  // store's own boot warning, which fires on the real dataDir at runtime.
+  // boot block's ⚠ store row (boot-summary.ts), which names the real dataDir the
+  // store composed at runtime.
   // Deliberately NOT trimmed — this has to be the SAME predicate composition
   // uses or doctor and runtime disagree. Runtime reads the key through
   // `environment()` (wire/shared.ts), which accepts any non-empty string, so a

--- a/packages/vendo/tests/boot-summary.test.ts
+++ b/packages/vendo/tests/boot-summary.test.ts
@@ -7,8 +7,11 @@
  * itself about which fields exist.
  */
 import fs from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { Principal } from "@vendoai/core";
 import { setLogger, vendoStyle, type VendoLogEvent, type VendoStyle } from "@vendoai/core";
+import { createStore } from "@vendoai/store";
 import type { LanguageModel } from "ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { authJs } from "../src/auth-presets/auth-js.js";
@@ -354,6 +357,57 @@ describe("the composed facts", () => {
     const { rows, warnings } = summaryFor();
     expect(rows.map((row) => row.label)).not.toContain("sandbox");
     expect(warnings).toEqual([]);
+  });
+
+  // The store makes this judgment at `createStore` and hangs it on its engine
+  // handle; the block is the only thing that says it out loud. Composed for
+  // real, so a store that stopped carrying the fact — or a block that stopped
+  // reading it — is a red test, which is exactly how it shipped mute once.
+  describe("the store's ephemeral-disk warning", () => {
+    // A platform marker, not a path: it fires wherever the suite is checked out.
+    const ONTO_EPHEMERAL_DISK = { RAILWAY_ENVIRONMENT: "production" };
+
+    it("folds into the block as a ⚠ store row", () => {
+      const summary = summaryFor(base, ONTO_EPHEMERAL_DISK);
+      expect(summary.warnings).toEqual([{
+        label: "store",
+        lines: [
+          ".vendo/data is on Railway's container filesystem — data will not survive a redeploy.",
+          'Mount a volume, or pass url: "postgres://…" to createVendo.',
+        ],
+      }]);
+      expect(plainText(renderBootSummary(summary, pretty())).split("\n").slice(-2)).toEqual([
+        "│  ⚠ store     .vendo/data is on Railway's container filesystem"
+        + " — data will not survive a redeploy.",
+        '│              Mount a volume, or pass url: "postgres://…" to createVendo.',
+      ]);
+    });
+
+    it("becomes one plain warn line in a non-TTY run", () => {
+      expect(renderBootSummary(summaryFor(base, ONTO_EPHEMERAL_DISK), vendoStyle({}, {})).split("\n"))
+        .toEqual([
+          "[vendo] ready — store: local · auth: custom",
+          "[vendo] warning: store — .vendo/data is on Railway's container filesystem"
+          + ' — data will not survive a redeploy. Mount a volume, or pass url: "postgres://…" to createVendo.',
+        ]);
+    });
+
+    it("names the OS temp dir case the way the founder's example does", () => {
+      const summary = summaryFor({ ...base, store: createStore({ dataDir: join(tmpdir(), "maple/data") }) });
+      expect(summary.warnings[0]?.lines[0])
+        .toBe(`${join(tmpdir(), "maple/data")} is under /tmp — data will not survive a redeploy.`);
+    });
+
+    it("says nothing at all for a store on a real disk", () => {
+      const healthy = summaryFor({ ...base, store: createStore({ dataDir: "/home/dev/maple/.vendo/data" }) });
+      expect(healthy.warnings).toEqual([]);
+      expect(renderBootSummary(healthy, pretty())).not.toContain("⚠");
+      expect(renderBootSummary(healthy, vendoStyle({}, {}))).not.toContain("warning");
+    });
+
+    it("says nothing for the Cloud hosted store, which has no dir to lose", () => {
+      expect(summaryFor(base, { ...ONTO_EPHEMERAL_DISK, VENDO_API_KEY: "vk_test" }).warnings).toEqual([]);
+    });
   });
 
   it("never touches the filesystem", () => {


### PR DESCRIPTION
## Finding

`boot-summary.ts` documents an inline `⚠ store` row for the ephemeral-disk case in
its own header, and `boot-summary.test.ts` even carries the founder's wording as a
renderer fixture ("the warning S6 will feed in") — but nothing ever fed it in.
`bootSummaryFor` pushed exactly one warning, the stray `E2B_API_KEY` hint, so a
deployment writing to a disk the next redeploy wipes printed an **unqualified**
`vendo ready` block, with the real warning arriving separately from
`packages/store/src/db.ts`'s own `console.warn` — a different voice, a different
shape, and easy to lose above the block.

Two smaller things found in the same read:

- `boot-summary.ts:64-67` justified `keySet`'s trim with "the sandbox ladder and
  `vendo doctor` already agree on that". Neither claim holds: the sandbox ladder
  no longer judges key presence at all (`E2B_API_KEY` stopped being a rung), and
  `checkStorePersistence` deliberately does **not** trim
  (`doctor-config-checks.ts`) so it matches `environment()`. Comment rewritten to
  say what is true — the trim matches `present` in `dev-creds/resolve.ts`, the
  ladder that resolves the model credentials `keySet` is asked about, and is
  stricter than `environment()`.
- The header claimed the ephemeral judgment "genuinely needs the filesystem". It
  does not — it is a path resolve plus env reads. Header corrected.

## Fix

The judgment stays with its owner and becomes **composed state** instead of a
console line:

- `packages/store/src/db-postgres.ts` — new `EphemeralDataDir` (`dataDir` as
  configured, plus `platform` when a container marker named one) and an optional
  `ephemeral` field on `Db`, set only by the PGlite engine.
- `packages/store/src/db.ts` — `warnIfEphemeralDataDir` becomes the pure
  `ephemeralDataDirOf`, hung on the handle. The store no longer prints it: one
  printer, so the operator cannot see the same fact twice in two voices.
- `packages/vendo/src/boot-summary.ts` — reads it off the composed store through
  the store's existing public accessor (`maybeDbFor(store)?.ephemeral`) and
  renders the documented `⚠ store` row. A property read, so the Workers
  portability constraint holds (the "never touches the filesystem" test still
  passes untouched).

Because the flag rides the **handle**, it also covers the case no config-level
check could see: a host that passes its own `createStore({ dataDir })` into
`createVendo` (the limit `checkStorePersistence`'s comment calls out).

Silent for every store this cannot be true of: a Postgres url, `memory://`, a
real disk, the Cloud hosted store, and a host's own adapter.

## Proof

Rendered for real (`RAILWAY_ENVIRONMENT=production`, keyless local default), by
composing through `createComposition` — same path `createVendo` takes.

**Before** — the block says nothing is wrong, and the warning arrives on its own
line in the store's voice:

```
[vendo] warning: the store is writing to "/…/packages/vendo/.vendo/data", and Railway wipes the container filesystem on every redeploy — your users' apps and data will be gone. Mount a persistent volume and point dataDir at it, or pass url: "postgres://…" to createVendo.

◆  vendo ready
│  ✓ store     local    .vendo/data
│  ✓ auth      custom   createVendo({ principal })
```

**After** — one block, the warning folded in as the documented row (no other
console output during compose):

```
◆  vendo ready
│  ✓ store     local    .vendo/data
│  ✓ auth      custom   createVendo({ principal })
│  ⚠ store     .vendo/data is on Railway's container filesystem — data will not survive a redeploy.
│              Mount a volume, or pass url: "postgres://…" to createVendo.
```

**After, non-TTY** (pipe / CI / `NO_COLOR`) — one plain line per warning, as the
degraded form always did:

```
[vendo] ready — store: local · auth: custom
[vendo] warning: store — .vendo/data is on Railway's container filesystem — data will not survive a redeploy. Mount a volume, or pass url: "postgres://…" to createVendo.
```

The OS-temp-dir case keeps the founder's frozen wording byte for byte:
`<dataDir> is under /tmp — data will not survive a redeploy.`

### Tests

New regression tests compose for real — a real `createStore` handle on the
producer side, the real `bootSummaryFor` + `renderBootSummary` on the consumer
side, nothing stubbed between them:

- `packages/vendo/tests/boot-summary.test.ts` — the ⚠ row in pretty mode, the
  plain warn line in non-TTY mode, the `/tmp` wording, silence for a store on a
  real disk, and silence for the Cloud hosted store.
- `packages/store/tests/db.ephemeral-warning.test.ts` — now asserts the exposed
  fact (including through `createStore` → `maybeDbFor`, the seam the block reads)
  and that the store never prints it itself.

**Prove-it-fails**, both sides of the seam:

- neuter the consumer (drop the `warnings.push`) → 3 failed | 32 passed
- neuter the producer (stop hanging `ephemeral` on the handle) → store 6 failed |
  3 passed **and** vendo 3 failed | 32 passed, i.e. the consumer test really is
  reading the producer's output

### Gate (scoped, vitest capped `--maxWorkers=2 --minWorkers=1`)

`pnpm build` ✅ · `pnpm test:affected` ✅ (33/33 tasks; `@vendoai/store` 568
passed, `@vendoai/vendo` 2333 passed) · `pnpm typecheck` ✅ · `pnpm lint` ✅

## Note for review

Deliberate behavior change: a program that calls `createStore` on ephemeral disk
and never calls `createVendo` no longer gets a console warning — the fact is on
the handle for its holder to report. Every `createVendo` deployment reports it,
and `vendo doctor`'s static twin (`E-STORE-001`) is unchanged.

Out of scope, found while reading and NOT touched: `modelRow` still sweeps
`ENV_KEY_VARS` for a provider key, but `resolveDevCredential` deliberately
dropped that sweep under the selection law — so with `ANTHROPIC_API_KEY` set and
no `VENDO_DEV_CREDENTIAL` pin, the block's `models` row names a provider the
ladder would never pick. A test currently pins that behavior, so it is a product
call, not a refactor.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the store’s ephemeral-disk warning into the boot block as a ⚠ store row, instead of a separate console line. This keeps messaging in one place, stays Workers-safe, and covers hosts that pass their own `createStore({ dataDir })`.

- **Bug Fixes**
  - `@vendoai/vendo`: `boot-summary` now reads `maybeDbFor(store)?.ephemeral` and renders the documented ⚠ store row (TTY and non-TTY forms).
  - `@vendoai/store`: exposes `ephemeral?: { dataDir, platform? }` on the `Db` handle; PGlite sets it when running on container filesystems or under `/tmp`. Postgres URLs, `memory://`, real disks, and the Cloud hosted store do not set it.
  - Removed the store’s own console warning to avoid duplicate messages and ensure one source of truth.
  - Kept composition I/O-free: ephemeral check is a pure property read, not a stat.
  - Clarified comments around key trimming and doctor wording to reflect current behavior.

- **Refactors**
  - Introduced `ephemeralDataDirOf` to compute ephemeral state without side effects.
  - Updated tests to compose real stores and assert the warning appears only via the boot block; added cases for platform markers (e.g., Railway) and OS temp dirs.

<sup>Written for commit b8a1bb331eeeab25cd743408f3f2e53a9bb99e37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

