### PR TITLE
refactor(apps): put screen checking's three Node-only loads behind one ScreenToolchain slot (no behavior change)

### DIFF
--- a/packages/apps/src/server/checking/component-screen.ts
+++ b/packages/apps/src/server/checking/component-screen.ts
@@ -50,25 +50,27 @@ import {
 } from "../../contract/index.js";
 // The screen engine, by its own path: the contract door does not carry it yet.
 import {
-  bootScreen,
-  flattenTree,
   SCREEN_TEXT_NODE,
-  ScreenError,
-  warmScreenEngine,
   type FlatTree,
-  type ScreenInstance,
+  type ScreenErrorKind,
 } from "../../contract/genui/component/index.js";
 import { isMutatingTool, type HostToolInfo } from "./deps.js";
 import { catalogIssues, factIssueLine } from "./facts.js";
 import { sampleLines } from "./reviewer.js";
+import { list, QUERY_HOOK } from "./screen-typecheck.js";
 import {
   componentScreenTypings,
   screenCatalogNames,
   SCREEN_MODULE,
   type ScreenCatalogEntry,
 } from "./screen-typings.js";
-import { diagnosticLine, screenProgram, translateDiagnostic } from "./screen-tsc.js";
-import type TS from "typescript";
+import {
+  defaultToolchain,
+  ScreenToolchainUnavailable,
+  type ScreenPaintResult,
+  type ScreenToolchain,
+  type ScreenTransform,
+} from "./toolchain.js";
 
 // ---- the contract ---------------------------------------------------------
 
@@ -140,6 +142,10 @@ export interface ComponentScreenOptions {
   /** The trusted executor, injected by the caller: this check runs the screen's
    *  queries for real, and it is the caller who holds the guard-bound registry. */
   runQuery: (tool: string, input?: unknown) => Promise<unknown>;
+  /** What compiles, type-checks and paints the screen — the one thing in this
+   *  gauntlet that cannot run in every venue. Unset, this process's own
+   *  ({@link defaultToolchain}); the floor names it one layer up. */
+  toolchain?: ScreenToolchain;
 }
 
 const issue = (code: string, message: string): ComponentScreenIssue => ({ code, message });
@@ -150,44 +156,6 @@ const refuse = (
 ): ComponentScreenCheck => ({ ok: false, issues, ...rest });
 
 // ---- stage 1: compile -----------------------------------------------------
-
-/** esbuild, lazily and bundler-safely: routed through a mutable binding so NO
- *  bundler statically resolves the compiler (Wrangler ignores the webpack-dialect
- *  comments and would inline esbuild's Node-only main into a Worker bundle — the
- *  portability gate's field failure). Same pattern as smoke-render.ts.
- *
- *  Unlike the smoke gate, an unavailable compiler here is a FAILED check, not a
- *  skipped one: nothing downstream can run without the compiled screen, and a
- *  gate that read nothing must not answer "fine". */
-let ESBUILD_SPECIFIER = "esbuild";
-
-/**
- * The two forms of one screen file, and why they differ.
- *
- * - `engine` is what {@link bootScreen} evaluates: CommonJS, because the VM
- *   hosts a `require` and no module loader, and the AUTOMATIC jsx transform,
- *   because the VM publishes `react/jsx-runtime` and has no bare `React` global
- *   (contract/genui/component/vm-program.ts). Classic mode compiles to
- *   `React.createElement`, which is a ReferenceError in there.
- * - `scan` is what the scan reads: the module form, so the author's imports and
- *   default export are still visible (CJS renames every import into a namespace
- *   access), with the CLASSIC transform, so the compiler's own
- *   `react/jsx-runtime` import does not read as an import the author wrote.
- */
-type ScreenForm = "engine" | "scan";
-
-type Transform = (source: string, form: ScreenForm) => string;
-
-const esbuildTransform: Promise<Transform | undefined> = (async () => {
-  try {
-    const esbuild = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ ESBUILD_SPECIFIER) as typeof import("esbuild");
-    return (source, form) => esbuild.transformSync(source, form === "engine"
-      ? { loader: "tsx", format: "cjs", target: "es2020", jsx: "automatic" }
-      : { loader: "tsx", format: "esm", target: "es2020" }).code;
-  } catch {
-    return undefined;
-  }
-})();
 
 /** esbuild reports a location; a screen author's repair starts from the line. */
 const compileMessage = (error: unknown): string => {
@@ -291,8 +259,6 @@ const literalValue = (node: Node): { ok: true; value: unknown } | { ok: false } 
 
 const ALLOWED_IMPORTS: readonly string[] = ["react", SCREEN_MODULE];
 
-const QUERY_HOOK = "useQuery";
-
 /** The import block is not `tools` USAGE: `import { tools } from "@vendo/screen"`
  *  puts the name in expression position (a `{` to its left), which the shipped
  *  literal-access scan reads as aliasing. Blanked with offsets preserved, so that
@@ -371,8 +337,6 @@ interface ScanResult {
   issues: ComponentScreenIssue[];
   queryPlan: QueryPlanEntry[];
 }
-
-const list = (names: readonly string[]): string => (names.length === 0 ? "(none)" : names.join(", "));
 
 const scan = (moduleSource: string, tools: readonly HostToolInfo[]): ScanResult => {
   const issues: ComponentScreenIssue[] = [];
@@ -519,146 +483,15 @@ const announceUntyped = (notes: readonly string[]): void => {
   console.warn(`[vendo] component screen type check: ${fresh.length} schema construct(s) could not be typed, so they are UNCHECKED — ${fresh.join("; ")}`);
 };
 
-/** "Cannot find name X", in all its forms. 2304 is the plain one and 2552 the
- *  one with a spelling suggestion; the 258x family is the SAME error with a
- *  "change your target library" or "install @types/…" hint attached — advice a
- *  screen author cannot act on, since there is no tsconfig here and the missing
- *  lib (`dom`) is missing on purpose. */
-const UNKNOWN_NAME = new Set([2304, 2552, 2580, 2581, 2582, 2583, 2584, 2591, 2592, 2593]);
-const MISSING_PROPERTY = new Set([2339, 2551]);
-const NO_SUCH_EXPORT = new Set([2305, 2724]);
-const MISSING_MODULE = new Set([2307, 2792]);
-// 2353 is the excess-property error on its own, which is how a misspelled tool
-// payload key arrives.
-const BAD_CALL = new Set([2345, 2769, 2353]);
-
-const INTRINSIC_ELEMENT = /Property '([^']+)' does not exist on type 'JSX\.IntrinsicElements'/u;
-
-/** The deepest node covering a diagnostic — the same descent screen-tsc.ts uses
- *  to anchor its own findings. */
-const nodeAt = (ts: typeof TS, file: TS.SourceFile, diagnostic: TS.Diagnostic): TS.Node => {
-  const start = diagnostic.start ?? 0;
-  const end = start + (diagnostic.length ?? 0);
-  let best: TS.Node = file;
-  const descend = (node: TS.Node): void => {
-    if (node.getStart(file) > start || end > node.getEnd()) return;
-    best = node;
-    ts.forEachChild(node, descend);
-  };
-  ts.forEachChild(file, descend);
-  return best;
-};
-
-/** The nearest enclosing call whose ARGUMENT holds the diagnostic, with the
- *  keys that argument's type really accepts. */
-const badPayloadMessage = (
-  ts: typeof TS,
-  file: TS.SourceFile,
-  checker: TS.TypeChecker,
-  diagnostic: TS.Diagnostic,
-  sentence: string,
-): string | undefined => {
-  const start = diagnostic.start ?? 0;
-  const end = start + (diagnostic.length ?? 0);
-  const covers = (node: TS.Node): boolean => node.getStart(file) <= start && end <= node.getEnd();
-  for (let current: TS.Node | undefined = nodeAt(ts, file, diagnostic); current !== undefined; current = current.parent) {
-    if (!ts.isCallExpression(current)) continue;
-    const index = current.arguments.findIndex(covers);
-    if (index < 0) continue;
-    const callee = current.expression.getText(file);
-    if (!callee.startsWith("tools.") && callee !== QUERY_HOOK) return undefined;
-    const parameter = checker.getResolvedSignature(current)?.getParameters()[index];
-    const type = parameter === undefined ? undefined : checker.getTypeOfSymbolAtLocation(parameter, current);
-    const properties = type === undefined ? [] : checker.getPropertiesOfType(type);
-    const required = properties
-      .filter((symbol) => (symbol.flags & ts.SymbolFlags.Optional) === 0)
-      .map((symbol) => symbol.getName());
-    return `calls ${callee}(…) with an input its schema does not accept: ${sentence}`
-      + (properties.length === 0
-        ? ""
-        : ` Its input keys are: ${list(properties.map((symbol) => symbol.getName()))}${required.length === 0 ? "" : ` (required: ${required.join(", ")})`}.`);
-  }
-  return undefined;
-};
-
-/** One diagnostic as a repair instruction.
- *
- * Only the classes whose prose is specific to THIS dialect are written here —
- * the surface is two modules, there is no DOM, and a tool payload is a schema.
- * Everything else is handed to the wire screen's own translator, which already
- * says the right thing about props, arguments and missing fields. */
-const typeIssue = (
-  ts: typeof TS,
-  file: TS.SourceFile,
-  checker: TS.TypeChecker,
-  diagnostic: TS.Diagnostic,
-  surface: { components: readonly string[] },
-): ComponentScreenIssue | undefined => {
-  const line = diagnosticLine(file, diagnostic);
-  const sentence = ts.flattenDiagnosticMessageText(diagnostic.messageText, " ");
-  const at = (message: string): ComponentScreenIssue => issue("types", `line ${line}: ${message}`);
-  const node = nodeAt(ts, file, diagnostic);
-  // A bad tag is reported twice, on `<div>` and again on `</div>`. The closing
-  // one is the same break, and a repair list that says everything twice reads
-  // as two problems.
-  if (ts.isJsxClosingElement(node) || (node.parent !== undefined && ts.isJsxClosingElement(node.parent))) {
-    return undefined;
-  }
-
-  const intrinsic = INTRINSIC_ELEMENT.exec(sentence);
-  if (intrinsic !== null) {
-    return at(`writes the HTML element <${intrinsic[1]}> — a screen has no HTML elements. It renders only the components it imports from ${JSON.stringify(SCREEN_MODULE)}: ${list(surface.components)}. Lay out with <Stack>/<Row>/<Grid> and write text with <Text>.`);
-  }
-
-  if (UNKNOWN_NAME.has(diagnostic.code)) {
-    // The compiler anchors a tag error on the whole tag as often as on the name
-    // inside it, so the element is read from either.
-    const element = ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)
-      ? node
-      : (node.parent !== undefined && (ts.isJsxOpeningElement(node.parent) || ts.isJsxSelfClosingElement(node.parent))
-        ? node.parent
-        : undefined);
-    return at(element === undefined
-      ? `reads the name "${node.getText(file)}", which does not exist inside a screen — there is no DOM, no window/document, no fetch, no timers and no process here. Read data with ${QUERY_HOOK}("tool_name"), act with tools.tool_name(args), and import anything else from "react" or ${JSON.stringify(SCREEN_MODULE)}.`
-      : `renders <${element.tagName.getText(file)}>, which this screen never imported — import the component from ${JSON.stringify(SCREEN_MODULE)}. The components available are: ${list(surface.components)}.`);
-  }
-
-  if (NO_SUCH_EXPORT.has(diagnostic.code)) {
-    return at(`${sentence} The screen surface is ${QUERY_HOOK}, tools, and these components: ${list(surface.components)}.`);
-  }
-
-  if (MISSING_MODULE.has(diagnostic.code)) {
-    return at(`${sentence} A screen may import only "react" and ${JSON.stringify(SCREEN_MODULE)}.`);
-  }
-
-  if (BAD_CALL.has(diagnostic.code)) {
-    const payload = badPayloadMessage(ts, file, checker, diagnostic, sentence);
-    if (payload !== undefined) return at(payload);
-  }
-
-  if (MISSING_PROPERTY.has(diagnostic.code) || BAD_CALL.has(diagnostic.code) || diagnostic.code === 2322) {
-    const [reused] = translateDiagnostic(ts, file, checker, diagnostic);
-    // The wire translator's `where` is a locus its sentence sometimes states
-    // itself, and prefixing it anyway said `prop "variant" prop "variant" on
-    // <Text> takes …`. A sentence that names its own locus stands alone; the
-    // line number is already the prefix here either way.
-    if (reused !== undefined) {
-      return at(reused.message.startsWith("prop \"") ? reused.message : `${reused.where} ${reused.message}`);
-    }
-  }
-
-  return at(sentence);
-};
-
 // ---- stage 4: run once ----------------------------------------------------
 
 /** What went wrong inside the VM, said as a repair. A `render` or `budget`
  *  failure is RELAYED: the engine writes those messages to be read by whatever
  *  repairs the screen, and a second sentence of advice on top of them only says
  *  the same thing twice. A throw is the class that needs the advice. */
-const renderMessage = (error: unknown): string => {
-  const message = (error instanceof Error ? error.message : String(error)).split("\n")[0] ?? "";
-  if (error instanceof ScreenError && (error.kind === "render" || error.kind === "budget")) {
+const renderMessage = (kind: ScreenErrorKind, thrown: string): string => {
+  const message = thrown.split("\n")[0] ?? "";
+  if (kind === "render" || kind === "budget") {
     return `the screen would not paint: ${message}`;
   }
   return `the screen threw while rendering against the data its queries really returned: ${message}`
@@ -673,21 +506,22 @@ const renderMessage = (error: unknown): string => {
  * consequences of a break it has not fixed yet.
  */
 export async function checkComponentScreen(opts: ComponentScreenOptions): Promise<ComponentScreenCheck> {
-  const transform = await esbuildTransform;
-  if (transform === undefined) {
-    return refuse([issue("compile", "the screen could not be compiled: no esbuild is reachable from @vendoai/apps, so nothing about this screen was checked. This check refuses to pass a screen it never read.")]);
-  }
+  const toolchain = opts.toolchain ?? defaultToolchain();
 
-  let compiled: string;
-  let moduleForm: string;
+  let forms: ScreenTransform;
   try {
-    compiled = transform(opts.source, "engine");
-    moduleForm = transform(opts.source, "scan");
+    forms = await toolchain.transform(opts.source);
   } catch (error) {
-    return refuse([issue("compile", compileMessage(error))]);
+    // A toolchain that cannot compile is a FAILED check, not a skipped one:
+    // nothing downstream can run without the compiled screen, and a gate that
+    // read nothing must not answer "fine".
+    return refuse([issue("compile", error instanceof ScreenToolchainUnavailable
+      ? `the screen could not be compiled: ${error.message}, so nothing about this screen was checked. This check refuses to pass a screen it never read.`
+      : compileMessage(error))]);
   }
+  const compiled = forms.engine;
 
-  const scanned = scan(moduleForm, opts.hostTools);
+  const scanned = scan(forms.scan, opts.hostTools);
   if (scanned.issues.length > 0) return refuse(scanned.issues, { compiled });
   const queryPlan = scanned.queryPlan;
 
@@ -704,19 +538,16 @@ export async function checkComponentScreen(opts: ComponentScreenOptions): Promis
   });
   announceUntyped(notes);
 
-  const program = screenProgram({ screen: opts.source, typings, lib: COMPONENT_SCREEN_LIB });
-  if (!program.ok) {
-    return refuse([issue("typecheck-unavailable", `the screen could not be type-checked: ${program.why}. This check refuses to pass a screen it never read — make the TypeScript compiler reachable where the build runs.`)], { compiled, queryPlan });
+  const typed = await toolchain.typecheck({
+    source: opts.source,
+    typings,
+    lib: COMPONENT_SCREEN_LIB,
+    components: names,
+  });
+  if (!typed.ok) {
+    return refuse([issue("typecheck-unavailable", `the screen could not be type-checked: ${typed.why}. This check refuses to pass a screen it never read — make the TypeScript compiler reachable where the build runs.`)], { compiled, queryPlan });
   }
-  const surface = { components: [...new Set(names)] };
-  const typeIssues = [
-    ...program.syntactic.map((diagnostic) => issue("types", `line ${diagnosticLine(program.file, diagnostic)}: does not parse as a screen: ${program.ts.flattenDiagnosticMessageText(diagnostic.messageText, " ")}`)),
-    ...program.semantic.flatMap((diagnostic) => {
-      const found = typeIssue(program.ts, program.file, program.checker, diagnostic, surface);
-      return found === undefined ? [] : [found];
-    }),
-  ];
-  if (typeIssues.length > 0) return refuse(typeIssues, { compiled, queryPlan });
+  if (typed.issues.length > 0) return refuse([...typed.issues], { compiled, queryPlan });
 
   // The engine keys its results by TOOL, one entry each — which is why the scan
   // refuses a screen that reads one tool with two different inputs.
@@ -729,29 +560,21 @@ export async function checkComponentScreen(opts: ComponentScreenOptions): Promis
     }
   }
 
+  let painted: ScreenPaintResult;
   try {
-    await warmScreenEngine();
+    // A clock IS given: the surface renders with one, and a gate that is
+    // stricter than production blocks screens that work.
+    painted = await toolchain.paint({ compiledSource: compiled, queries, catalog: names, now: Date.now() });
   } catch (error) {
+    // A paint answers a screen that failed with a verdict, so a THROW is the
+    // engine itself never starting.
     return refuse([issue("run", `the screen was never executed: the screen engine would not start (${error instanceof Error ? error.message : String(error)}). This check refuses to pass a screen it could not render.`)], { compiled, queryPlan });
   }
+  if (!painted.ok) {
+    return refuse([issue("run", renderMessage(painted.kind, painted.message))], { compiled, queryPlan });
+  }
 
-  const rendered = ((): { ok: true; tree: FlatTree } | { ok: false; message: string } => {
-    let instance: ScreenInstance | undefined;
-    try {
-      // A clock IS given: the surface renders with one, and a gate that is
-      // stricter than production blocks screens that work.
-      instance = bootScreen({ compiledSource: compiled, queries, catalog: names, now: Date.now() });
-      return { ok: true, tree: flattenTree(instance.tree()) };
-    } catch (error) {
-      return { ok: false, message: renderMessage(error) };
-    } finally {
-      // A dispose that throws is not the screen's verdict.
-      try { instance?.dispose(); } catch { /* ignore */ }
-    }
-  })();
-  if (!rendered.ok) return refuse([issue("run", rendered.message)], { compiled, queryPlan });
-
-  const initialTree = rendered.tree;
+  const initialTree = painted.tree;
   const treeIssues = await treeCheckIssues(initialTree, names);
   if (treeIssues.length > 0) return refuse(treeIssues, { compiled, queryPlan, initialTree });
 

--- a/packages/apps/src/server/checking/floor.ts
+++ b/packages/apps/src/server/checking/floor.ts
@@ -44,7 +44,7 @@ import { screenTypesCheck } from "./facts.js";
 import { prepareIslands } from "./islands.js";
 import { createCheckingLayer, runChecks } from "./layer.js";
 import { smokeRenderIslands } from "./smoke-render.js";
-import { defaultToolchain, type ScreenToolchain } from "./toolchain.js";
+import type { ScreenToolchain } from "./toolchain.js";
 
 /** A compiled wire result as the document the checks read. The checks take a whole
  *  `AppDocument` (build contract §5) and the seam knows the id, so this is the
@@ -235,13 +235,14 @@ export interface AppFloorOptions {
    * The gauntlet's three stages that cannot run in every venue, behind one slot,
    * so a deployment whose checks happen somewhere without esbuild, the
    * `typescript` package and the QuickJS build can still run every other stage
-   * here. Unset → this process's own.
+   * here. Passed through unresolved: the gauntlet holds the one default, so a
+   * toolchain installed after a floor was built still reaches that floor.
    */
   toolchain?: ScreenToolchain;
 }
 
 export const createAppFloor = (
-  { deps, checks, runQuery, delivered, refused, toolchain = defaultToolchain() }: AppFloorOptions,
+  { deps, checks, runQuery, delivered, refused, toolchain }: AppFloorOptions,
 ): AppFloor => {
   let resolved: Promise<FloorDependencies> | undefined;
   const once = (): Promise<FloorDependencies> => resolved ??= deps();

--- a/packages/apps/src/server/checking/floor.ts
+++ b/packages/apps/src/server/checking/floor.ts
@@ -44,6 +44,7 @@ import { screenTypesCheck } from "./facts.js";
 import { prepareIslands } from "./islands.js";
 import { createCheckingLayer, runChecks } from "./layer.js";
 import { smokeRenderIslands } from "./smoke-render.js";
+import { defaultToolchain, type ScreenToolchain } from "./toolchain.js";
 
 /** A compiled wire result as the document the checks read. The checks take a whole
  *  `AppDocument` (build contract §5) and the seam knows the id, so this is the
@@ -228,9 +229,20 @@ export interface AppFloorOptions {
    * it here and nowhere else.
    */
   refused?: (input: { appId: AppId; blocking: readonly string[] }) => Promise<void>;
+  /**
+   * What compiles, type-checks and paints a component screen (`AppsConfig.toolchain`).
+   *
+   * The gauntlet's three stages that cannot run in every venue, behind one slot,
+   * so a deployment whose checks happen somewhere without esbuild, the
+   * `typescript` package and the QuickJS build can still run every other stage
+   * here. Unset → this process's own.
+   */
+  toolchain?: ScreenToolchain;
 }
 
-export const createAppFloor = ({ deps, checks, runQuery, delivered, refused }: AppFloorOptions): AppFloor => {
+export const createAppFloor = (
+  { deps, checks, runQuery, delivered, refused, toolchain = defaultToolchain() }: AppFloorOptions,
+): AppFloor => {
   let resolved: Promise<FloorDependencies> | undefined;
   const once = (): Promise<FloorDependencies> => resolved ??= deps();
   return {
@@ -288,6 +300,7 @@ export const createAppFloor = ({ deps, checks, runQuery, delivered, refused }: A
         hostTools: resolved.tools ?? [],
         catalog: screenCatalog(resolved.catalog),
         runQuery: (tool, input) => runQuery(appId, tool, input),
+        toolchain,
       });
       if (!checked.ok || checked.compiled === undefined || checked.initialTree === undefined) {
         return refuse(checked.issues.map(({ message }) => message));

--- a/packages/apps/src/server/checking/screen-tsc.ts
+++ b/packages/apps/src/server/checking/screen-tsc.ts
@@ -117,10 +117,20 @@ const compilerOptions = (ts: typeof TS, input: ScreenTscInput): TS.CompilerOptio
   skipDefaultLibCheck: true,
 });
 
-/** The text of one standard-library file, by the name the compiler asked for.
- *  `ts.sys` is Node's disk; a venue without one carries its libs some other way,
- *  which is the whole reason this is an argument. */
-export type LibTextProvider = (fileName: string) => string | undefined;
+/**
+ * The standard library, as the compiler host asks for it. `ts.sys` is Node's
+ * disk; a venue without one carries its libs some other way, which is the whole
+ * reason this is an argument.
+ *
+ * `exists` is separate from `read` because the compiler PROBES far more files
+ * than it reads, and a lib file is hundreds of kilobytes: answering existence by
+ * reading the body would pay for every probe, and would call a file that exists
+ * but cannot be read absent. An in-memory provider answers both with one lookup.
+ */
+export interface LibTextProvider {
+  read(fileName: string): string | undefined;
+  exists(fileName: string): boolean;
+}
 
 const buildProgram = (
   ts: typeof TS,
@@ -138,7 +148,7 @@ const buildProgram = (
       if (own !== undefined) return create(name, own, version);
       const cached = libCache.get(name);
       if (cached !== undefined) return cached;
-      const text = libs(name);
+      const text = libs.read(name);
       if (text === undefined) return undefined;
       const file = create(name, text, version);
       libCache.set(name, file);
@@ -150,8 +160,8 @@ const buildProgram = (
     getCanonicalFileName: (name) => name,
     useCaseSensitiveFileNames: () => true,
     getNewLine: () => "\n",
-    fileExists: (name) => files.has(name) || libs(name) !== undefined,
-    readFile: (name) => files.get(name) ?? libs(name),
+    fileExists: (name) => files.has(name) || libs.exists(name),
+    readFile: (name) => files.get(name) ?? libs.read(name),
   };
   return ts.createProgram({ rootNames: [SCREEN_FILE, SCREEN_TYPINGS_FILE], options, host });
 };
@@ -468,7 +478,12 @@ export function screenProgram(input: ScreenTscInput): ScreenProgram {
   if (ts === null) {
     return { ok: false, why: "no usable TypeScript compiler is reachable from @vendoai/apps" };
   }
-  return screenProgramWith(ts, input, (name) => ts.sys.readFile(name), (options) => ts.getDefaultLibFilePath(options));
+  return screenProgramWith(
+    ts,
+    input,
+    { read: (name) => ts.sys.readFile(name), exists: (name) => ts.sys.fileExists(name) },
+    (options) => ts.getDefaultLibFilePath(options),
+  );
 }
 
 /** One diagnostic as the floor's sentence. Exported for the component screen's

--- a/packages/apps/src/server/checking/screen-tsc.ts
+++ b/packages/apps/src/server/checking/screen-tsc.ts
@@ -117,7 +117,17 @@ const compilerOptions = (ts: typeof TS, input: ScreenTscInput): TS.CompilerOptio
   skipDefaultLibCheck: true,
 });
 
-const buildProgram = (ts: typeof TS, input: ScreenTscInput): TS.Program => {
+/** The text of one standard-library file, by the name the compiler asked for.
+ *  `ts.sys` is Node's disk; a venue without one carries its libs some other way,
+ *  which is the whole reason this is an argument. */
+export type LibTextProvider = (fileName: string) => string | undefined;
+
+const buildProgram = (
+  ts: typeof TS,
+  input: ScreenTscInput,
+  libs: LibTextProvider,
+  defaultLibFileName: (options: TS.CompilerOptions) => string,
+): TS.Program => {
   const options = compilerOptions(ts, input);
   const files = new Map([[SCREEN_FILE, input.screen], [SCREEN_TYPINGS_FILE, input.typings]]);
   const create = (name: string, text: string, version: TS.ScriptTarget | TS.CreateSourceFileOptions): TS.SourceFile =>
@@ -128,20 +138,20 @@ const buildProgram = (ts: typeof TS, input: ScreenTscInput): TS.Program => {
       if (own !== undefined) return create(name, own, version);
       const cached = libCache.get(name);
       if (cached !== undefined) return cached;
-      const text = ts.sys.readFile(name);
+      const text = libs(name);
       if (text === undefined) return undefined;
       const file = create(name, text, version);
       libCache.set(name, file);
       return file;
     },
-    getDefaultLibFileName: (compilerOptionsIn) => ts.getDefaultLibFilePath(compilerOptionsIn),
+    getDefaultLibFileName: defaultLibFileName,
     writeFile: () => {},
     getCurrentDirectory: () => "/",
     getCanonicalFileName: (name) => name,
     useCaseSensitiveFileNames: () => true,
     getNewLine: () => "\n",
-    fileExists: (name) => files.has(name) || ts.sys.fileExists(name),
-    readFile: (name) => files.get(name) ?? ts.sys.readFile(name),
+    fileExists: (name) => files.has(name) || libs(name) !== undefined,
+    readFile: (name) => files.get(name) ?? libs(name),
   };
   return ts.createProgram({ rootNames: [SCREEN_FILE, SCREEN_TYPINGS_FILE], options, host });
 };
@@ -424,14 +434,17 @@ export type ScreenProgram =
     }
   | { ok: false; why: string };
 
-/** Build the program and collect its diagnostics. Never throws. */
-export function screenProgram(input: ScreenTscInput): ScreenProgram {
-  const ts = loadCompiler();
-  if (ts === null) {
-    return { ok: false, why: "no usable TypeScript compiler is reachable from @vendoai/apps" };
-  }
+/** Build the program and collect its diagnostics, with the compiler and its
+ *  standard library HANDED OVER — for a caller that resolved both somewhere this
+ *  package cannot reach (`checking/toolchain.ts`). Never throws. */
+export function screenProgramWith(
+  ts: typeof TS,
+  input: ScreenTscInput,
+  libs: LibTextProvider,
+  defaultLibFileName: (options: TS.CompilerOptions) => string,
+): ScreenProgram {
   try {
-    const program = buildProgram(ts, input);
+    const program = buildProgram(ts, input, libs, defaultLibFileName);
     const file = program.getSourceFile(SCREEN_FILE);
     if (file === undefined) return { ok: false, why: "the compiler did not accept the screen file" };
     const syntactic = program.getSyntacticDiagnostics(file);
@@ -446,6 +459,16 @@ export function screenProgram(input: ScreenTscInput): ScreenProgram {
   } catch (error) {
     return { ok: false, why: `the TypeScript compiler threw: ${error instanceof Error ? error.message : String(error)}` };
   }
+}
+
+/** Build the program and collect its diagnostics, on this process's own
+ *  compiler and Node's own disk. Never throws. */
+export function screenProgram(input: ScreenTscInput): ScreenProgram {
+  const ts = loadCompiler();
+  if (ts === null) {
+    return { ok: false, why: "no usable TypeScript compiler is reachable from @vendoai/apps" };
+  }
+  return screenProgramWith(ts, input, (name) => ts.sys.readFile(name), (options) => ts.getDefaultLibFilePath(options));
 }
 
 /** One diagnostic as the floor's sentence. Exported for the component screen's

--- a/packages/apps/src/server/checking/screen-typecheck.ts
+++ b/packages/apps/src/server/checking/screen-typecheck.ts
@@ -1,0 +1,181 @@
+/**
+ * Stage 3's translation: one compiled screen's diagnostics as repair
+ * instructions.
+ *
+ * Split out of the gauntlet because it travels with the COMPILER, not with the
+ * gate. Every sentence here is written off the AST — the node under a
+ * diagnostic, the resolved signature of the call around it, the tag of the
+ * element it sits in — and an AST walk cannot cross a service binding. So a
+ * toolchain that type-checks somewhere else translates there too, and both run
+ * THIS translation: a screen author reads the same sentence whatever compiled
+ * the screen.
+ *
+ * Only the classes whose prose is specific to this dialect are written here —
+ * the surface is two modules, there is no DOM, and a tool payload is a schema.
+ * Everything else is handed to the wire screen's own translator (screen-tsc.ts),
+ * which already says the right thing about props, arguments and missing fields.
+ */
+import { diagnosticLine, translateDiagnostic, type ScreenProgram } from "./screen-tsc.js";
+import { SCREEN_MODULE } from "./screen-typings.js";
+import type { ComponentScreenIssue } from "./component-screen.js";
+import type TS from "typescript";
+
+/** The gauntlet's shared sentence vocabulary. It lives with the translation
+ *  below because that is the leaf of the checking graph — the scan imports from
+ *  here, and a second spelling of either would be two sentences for one rule. */
+export const QUERY_HOOK = "useQuery";
+
+export const list = (names: readonly string[]): string => (names.length === 0 ? "(none)" : names.join(", "));
+
+const issue = (code: string, message: string): ComponentScreenIssue => ({ code, message });
+
+/** "Cannot find name X", in all its forms. 2304 is the plain one and 2552 the
+ *  one with a spelling suggestion; the 258x family is the SAME error with a
+ *  "change your target library" or "install @types/…" hint attached — advice a
+ *  screen author cannot act on, since there is no tsconfig here and the missing
+ *  lib (`dom`) is missing on purpose. */
+const UNKNOWN_NAME = new Set([2304, 2552, 2580, 2581, 2582, 2583, 2584, 2591, 2592, 2593]);
+const MISSING_PROPERTY = new Set([2339, 2551]);
+const NO_SUCH_EXPORT = new Set([2305, 2724]);
+const MISSING_MODULE = new Set([2307, 2792]);
+// 2353 is the excess-property error on its own, which is how a misspelled tool
+// payload key arrives.
+const BAD_CALL = new Set([2345, 2769, 2353]);
+
+const INTRINSIC_ELEMENT = /Property '([^']+)' does not exist on type 'JSX\.IntrinsicElements'/u;
+
+/** The deepest node covering a diagnostic — the same descent screen-tsc.ts uses
+ *  to anchor its own findings. */
+const nodeAt = (ts: typeof TS, file: TS.SourceFile, diagnostic: TS.Diagnostic): TS.Node => {
+  const start = diagnostic.start ?? 0;
+  const end = start + (diagnostic.length ?? 0);
+  let best: TS.Node = file;
+  const descend = (node: TS.Node): void => {
+    if (node.getStart(file) > start || end > node.getEnd()) return;
+    best = node;
+    ts.forEachChild(node, descend);
+  };
+  ts.forEachChild(file, descend);
+  return best;
+};
+
+/** The nearest enclosing call whose ARGUMENT holds the diagnostic, with the
+ *  keys that argument's type really accepts. */
+const badPayloadMessage = (
+  ts: typeof TS,
+  file: TS.SourceFile,
+  checker: TS.TypeChecker,
+  diagnostic: TS.Diagnostic,
+  sentence: string,
+): string | undefined => {
+  const start = diagnostic.start ?? 0;
+  const end = start + (diagnostic.length ?? 0);
+  const covers = (node: TS.Node): boolean => node.getStart(file) <= start && end <= node.getEnd();
+  for (let current: TS.Node | undefined = nodeAt(ts, file, diagnostic); current !== undefined; current = current.parent) {
+    if (!ts.isCallExpression(current)) continue;
+    const index = current.arguments.findIndex(covers);
+    if (index < 0) continue;
+    const callee = current.expression.getText(file);
+    if (!callee.startsWith("tools.") && callee !== QUERY_HOOK) return undefined;
+    const parameter = checker.getResolvedSignature(current)?.getParameters()[index];
+    const type = parameter === undefined ? undefined : checker.getTypeOfSymbolAtLocation(parameter, current);
+    const properties = type === undefined ? [] : checker.getPropertiesOfType(type);
+    const required = properties
+      .filter((symbol) => (symbol.flags & ts.SymbolFlags.Optional) === 0)
+      .map((symbol) => symbol.getName());
+    return `calls ${callee}(…) with an input its schema does not accept: ${sentence}`
+      + (properties.length === 0
+        ? ""
+        : ` Its input keys are: ${list(properties.map((symbol) => symbol.getName()))}${required.length === 0 ? "" : ` (required: ${required.join(", ")})`}.`);
+  }
+  return undefined;
+};
+
+/** One diagnostic as a repair instruction. */
+const typeIssue = (
+  ts: typeof TS,
+  file: TS.SourceFile,
+  checker: TS.TypeChecker,
+  diagnostic: TS.Diagnostic,
+  surface: { components: readonly string[] },
+): ComponentScreenIssue | undefined => {
+  const line = diagnosticLine(file, diagnostic);
+  const sentence = ts.flattenDiagnosticMessageText(diagnostic.messageText, " ");
+  const at = (message: string): ComponentScreenIssue => issue("types", `line ${line}: ${message}`);
+  const node = nodeAt(ts, file, diagnostic);
+  // A bad tag is reported twice, on `<div>` and again on `</div>`. The closing
+  // one is the same break, and a repair list that says everything twice reads
+  // as two problems.
+  if (ts.isJsxClosingElement(node) || (node.parent !== undefined && ts.isJsxClosingElement(node.parent))) {
+    return undefined;
+  }
+
+  const intrinsic = INTRINSIC_ELEMENT.exec(sentence);
+  if (intrinsic !== null) {
+    return at(`writes the HTML element <${intrinsic[1]}> — a screen has no HTML elements. It renders only the components it imports from ${JSON.stringify(SCREEN_MODULE)}: ${list(surface.components)}. Lay out with <Stack>/<Row>/<Grid> and write text with <Text>.`);
+  }
+
+  if (UNKNOWN_NAME.has(diagnostic.code)) {
+    // The compiler anchors a tag error on the whole tag as often as on the name
+    // inside it, so the element is read from either.
+    const element = ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)
+      ? node
+      : (node.parent !== undefined && (ts.isJsxOpeningElement(node.parent) || ts.isJsxSelfClosingElement(node.parent))
+        ? node.parent
+        : undefined);
+    return at(element === undefined
+      ? `reads the name "${node.getText(file)}", which does not exist inside a screen — there is no DOM, no window/document, no fetch, no timers and no process here. Read data with ${QUERY_HOOK}("tool_name"), act with tools.tool_name(args), and import anything else from "react" or ${JSON.stringify(SCREEN_MODULE)}.`
+      : `renders <${element.tagName.getText(file)}>, which this screen never imported — import the component from ${JSON.stringify(SCREEN_MODULE)}. The components available are: ${list(surface.components)}.`);
+  }
+
+  if (NO_SUCH_EXPORT.has(diagnostic.code)) {
+    return at(`${sentence} The screen surface is ${QUERY_HOOK}, tools, and these components: ${list(surface.components)}.`);
+  }
+
+  if (MISSING_MODULE.has(diagnostic.code)) {
+    return at(`${sentence} A screen may import only "react" and ${JSON.stringify(SCREEN_MODULE)}.`);
+  }
+
+  if (BAD_CALL.has(diagnostic.code)) {
+    const payload = badPayloadMessage(ts, file, checker, diagnostic, sentence);
+    if (payload !== undefined) return at(payload);
+  }
+
+  if (MISSING_PROPERTY.has(diagnostic.code) || BAD_CALL.has(diagnostic.code) || diagnostic.code === 2322) {
+    const [reused] = translateDiagnostic(ts, file, checker, diagnostic);
+    // The wire translator's `where` is a locus its sentence sometimes states
+    // itself, and prefixing it anyway said `prop "variant" prop "variant" on
+    // <Text> takes …`. A sentence that names its own locus stands alone; the
+    // line number is already the prefix here either way.
+    if (reused !== undefined) {
+      return at(reused.message.startsWith("prop \"") ? reused.message : `${reused.where} ${reused.message}`);
+    }
+  }
+
+  return at(sentence);
+};
+
+/**
+ * Every issue one type-checked screen carries.
+ *
+ * Syntax errors alone when there are any: semantic diagnostics over a file that
+ * does not parse are a cascade of consequences of the same break, which
+ * {@link ScreenProgram} already encodes by leaving `semantic` empty.
+ *
+ * `components` are the names the refusal sentences list — the declared surface,
+ * deduplicated here so a catalog that names one component twice does not offer
+ * it twice.
+ */
+export function screenTypecheckIssues(
+  program: Extract<ScreenProgram, { ok: true }>,
+  components: readonly string[],
+): ComponentScreenIssue[] {
+  const surface = { components: [...new Set(components)] };
+  return [
+    ...program.syntactic.map((diagnostic) => issue("types", `line ${diagnosticLine(program.file, diagnostic)}: does not parse as a screen: ${program.ts.flattenDiagnosticMessageText(diagnostic.messageText, " ")}`)),
+    ...program.semantic.flatMap((diagnostic) => {
+      const found = typeIssue(program.ts, program.file, program.checker, diagnostic, surface);
+      return found === undefined ? [] : [found];
+    }),
+  ];
+}

--- a/packages/apps/src/server/checking/toolchain.ts
+++ b/packages/apps/src/server/checking/toolchain.ts
@@ -1,0 +1,183 @@
+/**
+ * The screen checking toolchain — the three machines the gauntlet needs, behind
+ * one adapter slot.
+ *
+ * Checking a component screen means compiling it, type-checking it, and RUNNING
+ * it. Today all three arrive by lazy load from this process: esbuild, the
+ * `typescript` package through `createRequire`, and the QuickJS single-file
+ * build. Each is reached the way it is for its own good reason, and together
+ * they are the reason screen checking cannot happen anywhere but Node.
+ *
+ * So they are one slot rather than three: the three fire in a fixed order over
+ * one screen, an implementation that has any of them has all of them, and a
+ * venue that has none of them needs to hand the whole job somewhere else in one
+ * call. ADAPTER RULE, as everywhere else in this repo — an explicitly passed
+ * toolchain always wins, the default is exactly what this package did before
+ * the slot existed, and nothing here reads the environment.
+ *
+ * What did NOT move is as deliberate as what did: the acorn scan, running the
+ * queries and validating the tree stay with the gauntlet. They are portable
+ * already, and a stage that can run anywhere should not pay to travel.
+ */
+import {
+  bootScreen,
+  flattenTree,
+  ScreenError,
+  warmScreenEngine,
+  type FlatTree,
+  type ScreenErrorKind,
+  type ScreenInstance,
+} from "../../contract/genui/component/index.js";
+import { screenTypecheckIssues } from "./screen-typecheck.js";
+import { screenProgram } from "./screen-tsc.js";
+import type { ComponentScreenIssue } from "./component-screen.js";
+
+/**
+ * The two forms of one screen file, and why they differ.
+ *
+ * - `engine` is what `bootScreen` evaluates: CommonJS, because the VM hosts a
+ *   `require` and no module loader, and the AUTOMATIC jsx transform, because the
+ *   VM publishes `react/jsx-runtime` and has no bare `React` global
+ *   (contract/genui/component/vm-program.ts). Classic mode compiles to
+ *   `React.createElement`, which is a ReferenceError in there.
+ * - `scan` is what the scan reads: the module form, so the author's imports and
+ *   default export are still visible (CJS renames every import into a namespace
+ *   access), with the CLASSIC transform, so the compiler's own
+ *   `react/jsx-runtime` import does not read as an import the author wrote.
+ */
+export interface ScreenTransform {
+  readonly engine: string;
+  readonly scan: string;
+}
+
+export interface ScreenTypecheckInput {
+  /** The author's TSX, verbatim — so a finding carries the author's line. */
+  readonly source: string;
+  /** The ambient declarations, generated caller-side from the same catalog and
+   *  tool schemas whatever venue checks the screen. */
+  readonly typings: string;
+  /** The standard library the screen is checked against. */
+  readonly lib: readonly string[];
+  /** The component names the refusal sentences list. */
+  readonly components: readonly string[];
+}
+
+/** `ok: false` NAMES why nothing was checked rather than returning silence a
+ *  caller cannot tell apart from a clean screen: it becomes the
+ *  "typecheck-unavailable" refusal, because a gate that could not read the
+ *  screen must not pass it. */
+export type ScreenTypecheckResult =
+  | { readonly ok: true; readonly issues: readonly ComponentScreenIssue[] }
+  | { readonly ok: false; readonly why: string };
+
+export interface ScreenPaintInput {
+  readonly compiledSource: string;
+  readonly queries: Record<string, unknown>;
+  readonly catalog: readonly string[];
+  readonly now?: number;
+}
+
+/** A failed paint is DATA, not a throw: `ScreenError`'s two fields are what the
+ *  gauntlet's sentence is chosen on, and an error object does not survive a
+ *  venue boundary. */
+export type ScreenPaintResult =
+  | { readonly ok: true; readonly tree: FlatTree }
+  | { readonly ok: false; readonly kind: ScreenErrorKind; readonly message: string };
+
+export interface ScreenToolchain {
+  /** Both forms of the screen. A throw is a screen that does not compile;
+   *  {@link ScreenToolchainUnavailable} is a toolchain that cannot compile. */
+  transform(source: string): Promise<ScreenTransform>;
+  typecheck(input: ScreenTypecheckInput): Promise<ScreenTypecheckResult>;
+  /** A throw here is the engine failing to START, which is a different refusal
+   *  from a screen that would not paint. */
+  paint(input: ScreenPaintInput): Promise<ScreenPaintResult>;
+}
+
+/**
+ * The toolchain itself could not run — as distinct from a screen that will not
+ * compile, which is the ordinary throw.
+ *
+ * The message is the WHY alone, never a whole sentence: the refusal belongs to
+ * the gate, which writes the same one for every toolchain, and a toolchain that
+ * wrote its own would be a second voice in the repair instructions.
+ */
+export class ScreenToolchainUnavailable extends Error {}
+
+/** esbuild, lazily and bundler-safely: routed through a mutable binding so NO
+ *  bundler statically resolves the compiler (Wrangler ignores the webpack-dialect
+ *  comments and would inline esbuild's Node-only main into a Worker bundle — the
+ *  portability gate's field failure). Same pattern as smoke-render.ts. */
+let ESBUILD_SPECIFIER = "esbuild";
+
+type ScreenForm = "engine" | "scan";
+
+type Transform = (source: string, form: ScreenForm) => string;
+
+/** Started at MODULE SCOPE, not on first use: the load is the slowest thing in
+ *  a first check, and it has nothing to wait for. */
+const esbuildTransform: Promise<Transform | undefined> = (async () => {
+  try {
+    const esbuild = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ ESBUILD_SPECIFIER) as typeof import("esbuild");
+    return (source, form) => esbuild.transformSync(source, form === "engine"
+      ? { loader: "tsx", format: "cjs", target: "es2020", jsx: "automatic" }
+      : { loader: "tsx", format: "esm", target: "es2020" }).code;
+  } catch {
+    return undefined;
+  }
+})();
+
+/** Everything this package can do in-process: esbuild, the `typescript` package,
+ *  and the QuickJS VM. */
+export const nodeToolchain = (): ScreenToolchain => ({
+  async transform(source) {
+    const transform = await esbuildTransform;
+    if (transform === undefined) {
+      throw new ScreenToolchainUnavailable("no esbuild is reachable from @vendoai/apps");
+    }
+    return { engine: transform(source, "engine"), scan: transform(source, "scan") };
+  },
+
+  async typecheck({ source, typings, lib, components }) {
+    const program = screenProgram({ screen: source, typings, lib });
+    if (!program.ok) return program;
+    return { ok: true, issues: screenTypecheckIssues(program, components) };
+  },
+
+  async paint(input) {
+    // Outside the try: the engine failing to start is not a verdict on the
+    // screen, and the gauntlet says so in its own sentence.
+    await warmScreenEngine();
+    let instance: ScreenInstance | undefined;
+    try {
+      instance = bootScreen(input);
+      return { ok: true, tree: flattenTree(instance.tree()) };
+    } catch (error) {
+      // A throw that is not a `ScreenError` has no kind of its own. `boot` is
+      // where it happened, and — like every kind but `render` and `budget` — it
+      // reads back as the screen having thrown.
+      return error instanceof ScreenError
+        ? { ok: false, kind: error.kind, message: error.message }
+        : { ok: false, kind: "boot", message: error instanceof Error ? error.message : String(error) };
+    } finally {
+      // A dispose that throws is not the screen's verdict.
+      try { instance?.dispose(); } catch { /* ignore */ }
+    }
+  },
+});
+
+let installed: ScreenToolchain | undefined;
+
+/** The toolchain a caller that named none gets. Memoized for the process, for
+ *  the reason the compiler resolution is: a deployment's toolchain does not
+ *  change mid-run. */
+export const defaultToolchain = (): ScreenToolchain => installed ??= nodeToolchain();
+
+/** Test seam, mirroring `__setCompilerForTests`: the default is memoized, so the
+ *  unavailable paths are unreachable from a test without one. `null` clears the
+ *  memo. Returns the restore. */
+export function __setToolchainForTests(candidate: ScreenToolchain | null): () => void {
+  const previous = installed;
+  installed = candidate ?? undefined;
+  return () => { installed = previous; };
+}

--- a/packages/apps/src/server/doors/build-surface.ts
+++ b/packages/apps/src/server/doors/build-surface.ts
@@ -540,6 +540,9 @@ const createValidateDoor = (
         hostTools: deps.tools ?? [],
         catalog: screenCatalog(deps.catalog),
         runQuery: (tool, queryInput) => runQuery(document.id, tool, queryInput),
+        // The same slot the floor honors: `validate` runs the identical gauntlet,
+        // so it must run it on the identical toolchain.
+        ...(config.toolchain === undefined ? {} : { toolchain: config.toolchain }),
       });
       if (!checked.ok) {
         // The gauntlet's own repair instructions, verbatim and with no locus: each
@@ -631,6 +634,7 @@ export const createBuildSurface = (
           ...await generationToolContext(ctx),
         }),
         ...(config.checks === undefined ? {} : { checks: config.checks }),
+        ...(config.toolchain === undefined ? {} : { toolchain: config.toolchain }),
         // The component gauntlet's outside reaches, which a checking module cannot
         // hold itself: the screen's queries, the row-and-source a passing screen
         // earns, and the reason a refused one earned none. All three are this

--- a/packages/apps/src/server/index.ts
+++ b/packages/apps/src/server/index.ts
@@ -173,6 +173,23 @@ export { stripServerAuthoritativeFields } from "../contract/index.js";
  * harness which mocks its counterparty proves nothing.
  */
 export { createAppFloor, type AppFloorOptions } from "./checking/floor.js";
+/**
+ * The screen toolchain (`AppsConfig.toolchain`) — the adapter slot the gauntlet
+ * compiles, type-checks and paints through. Public because the implementation is
+ * not always ours: a deployment whose checks run where esbuild, the `typescript`
+ * package and the QuickJS build are not reachable writes its own, and it cannot
+ * write one against an interface it cannot name.
+ */
+export {
+  ScreenToolchainUnavailable,
+  type ScreenPaintInput,
+  type ScreenPaintResult,
+  type ScreenToolchain,
+  type ScreenTransform,
+  type ScreenTypecheckInput,
+  type ScreenTypecheckResult,
+} from "./checking/toolchain.js";
+export type { ComponentScreenIssue } from "./checking/component-screen.js";
 // The component screen's own two facts every writer of one needs: which file it
 // is, and the title it gives itself. Public because the hand that SAVES a screen
 // is not in this package — the screen agent lives in the umbrella, and a harness

--- a/packages/apps/src/server/runtime/types.ts
+++ b/packages/apps/src/server/runtime/types.ts
@@ -42,6 +42,7 @@ import type {
   AppFloor,
 } from "../../contract/index.js";
 import type { LanguageModel } from "ai";
+import type { ScreenToolchain } from "../checking/toolchain.js";
 import type { Check, Finding } from "../checking/types.js";
 import type { CloudAppsClient, PublishRecord, ShareSnapshot } from "../persistence/cloud.js";
 import type { GenerationDependencies } from "../generation/engine.js";
@@ -235,6 +236,17 @@ export interface AppsConfig {
    * `vendo_make` in agent-tools.ts).
    */
   screen?: ScreenAssembler;
+  /**
+   * ADAPTER SLOT — what compiles, type-checks and paints a component screen.
+   *
+   * The screen gauntlet's three machines (esbuild, the `typescript` package, the
+   * QuickJS build) behind one interface, because they are the only part of
+   * checking a screen that cannot run in every venue: a deployment whose checks
+   * happen where none of the three is reachable fills this and every other stage
+   * runs unchanged. Explicitly passed always wins; unset is this process's own,
+   * which is exactly what checking did before the slot existed.
+   */
+  toolchain?: ScreenToolchain;
   /**
    * §4.5's other half — the plan an escalating screen agent left behind, read
    * back so the build ANCHORS on it instead of re-planning from the ask alone.

--- a/packages/apps/tests/checking/toolchain-conformance.test-util.ts
+++ b/packages/apps/tests/checking/toolchain-conformance.test-util.ts
@@ -1,0 +1,178 @@
+/**
+ * The screen toolchain's conformance table — one fixture set, driven once per
+ * implementation.
+ *
+ * A toolchain is an ADAPTER SLOT: the Node one compiles with esbuild, checks
+ * with the `typescript` package and paints in QuickJS, and a non-Node venue will
+ * do all three differently. What must NOT differ is what a screen author reads
+ * back, so the contract is asserted where the author meets it — through the
+ * whole gauntlet (`checkComponentScreen`), on the verdict and the issue codes
+ * and the sentence each class is written in.
+ *
+ * Driven through the gauntlet rather than against the three methods directly
+ * because two of these fixtures never reach the toolchain's second or third
+ * call: the import surface and the literal-query rule are the SCAN's, and a
+ * toolchain that compiled to a different module form would break them without
+ * ever answering a question wrong itself.
+ *
+ * A second driver calls this with its own factory and adds nothing else.
+ */
+import { expect, it } from "vitest";
+import {
+  checkComponentScreen,
+  type ComponentScreenCheck,
+} from "../../src/server/checking/component-screen.js";
+import type { HostToolInfo } from "../../src/server/checking/deps.js";
+import type { ScreenToolchain } from "../../src/server/checking/toolchain.js";
+
+const tools: readonly HostToolInfo[] = [
+  {
+    name: "list_rows",
+    description: "The rows this screen paints",
+    risk: "read",
+    inputSchema: { type: "object", properties: { status: { type: "string" } }, additionalProperties: false },
+    outputSchema: {
+      type: "object",
+      properties: {
+        rows: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: { id: { type: "string" }, label: { type: "string" } },
+            required: ["id", "label"],
+            additionalProperties: false,
+          },
+        },
+      },
+      required: ["rows"],
+      additionalProperties: false,
+    },
+  },
+];
+
+const catalog = ["Stack", "Text"];
+
+/** The rows `list_rows` really answers with, for every fixture but the one that
+ *  is about a tool answering with less than its shape promised. */
+const ROWS = { rows: [{ id: "r_1", label: "One" }, { id: "r_2", label: "Two" }] };
+
+const LISTING = `import { Stack, Text, useQuery } from "@vendo/screen";
+
+export default function Rows() {
+  const listed = useQuery("list_rows");
+
+  return (
+    <Stack gap={8}>
+      {listed.rows.map((row) => <Text key={row.id} text={row.label} />)}
+    </Stack>
+  );
+}
+`;
+
+interface Fixture {
+  readonly name: string;
+  readonly source: string;
+  /** What `list_rows` answers with here. */
+  readonly answer: unknown;
+  /** The refusal's codes, in order. Empty means the screen passes. */
+  readonly codes: readonly string[];
+  /** A fragment of the sentence the author reads — the part that must be
+   *  identical whatever compiled, checked and painted the screen. */
+  readonly says?: string;
+}
+
+const FIXTURES: readonly Fixture[] = [
+  {
+    name: "paints a screen that compiles, type-checks and renders",
+    source: LISTING,
+    answer: ROWS,
+    codes: [],
+  },
+  {
+    name: "refuses a screen that does not type-check",
+    source: `import { Text } from "@vendo/screen";
+
+export default function Rows() {
+  return <div><Text text="hi" /></div>;
+}
+`,
+    answer: ROWS,
+    codes: ["types"],
+    says: "writes the HTML element <div> — a screen has no HTML elements",
+  },
+  {
+    name: "refuses a screen that throws on the data its query really returned",
+    // The listing screen, against a tool that answered with less than its shape
+    // promised: nothing static can catch this, so only a real paint does.
+    source: LISTING,
+    answer: {},
+    codes: ["run"],
+    says: "the screen threw while rendering against the data its queries really returned",
+  },
+  {
+    name: "refuses a screen that imports a module it may not",
+    source: `import { Text } from "@vendo/screen";
+import { titleCase } from "change-case";
+
+export default function Rows() {
+  return <Text text={titleCase("hello")} />;
+}
+`,
+    answer: ROWS,
+    codes: ["import"],
+    says: 'imports "change-case" — a screen may import only "react"',
+  },
+  {
+    name: "refuses a screen whose query names its tool through a variable",
+    source: `import { Stack, Text, useQuery } from "@vendo/screen";
+
+const TOOL = "list_rows";
+
+export default function Rows() {
+  const listed = useQuery(TOOL);
+
+  return (
+    <Stack gap={8}>
+      {listed.rows.map((row) => <Text key={row.id} text={row.label} />)}
+    </Stack>
+  );
+}
+`,
+    answer: ROWS,
+    codes: ["query-name"],
+    says: "calls useQuery(…) with a computed tool name",
+  },
+];
+
+const check = (
+  toolchain: ScreenToolchain,
+  fixture: Fixture,
+): Promise<ComponentScreenCheck> => checkComponentScreen({
+  source: fixture.source,
+  hostTools: tools,
+  catalog,
+  runQuery: async () => fixture.answer,
+  toolchain,
+});
+
+/** Drive the table with one implementation. Call it inside a `describe`. */
+export function runToolchainConformance(makeToolchain: () => ScreenToolchain): void {
+  for (const fixture of FIXTURES) {
+    it(fixture.name, async () => {
+      const result = await check(makeToolchain(), fixture);
+
+      expect(result.issues.map(({ code }) => code)).toEqual(fixture.codes);
+      expect(result.ok).toBe(fixture.codes.length === 0);
+      if (fixture.says !== undefined) {
+        expect(result.issues.map(({ message }) => message).join("\n")).toContain(fixture.says);
+      }
+      if (fixture.codes.length > 0) return;
+      // A passing verdict is only worth what it hands back: the compiled screen
+      // the renderer re-boots, the answers it boots on, and the paint itself.
+      expect(result.compiled).toContain("react/jsx-runtime");
+      expect(result.queries).toEqual({ list_rows: fixture.answer });
+      expect(Object.values(result.initialTree?.nodes ?? {}).map(({ component }) => component))
+        .toContain("Text");
+    });
+  }
+}

--- a/packages/apps/tests/checking/toolchain-node.test.ts
+++ b/packages/apps/tests/checking/toolchain-node.test.ts
@@ -1,0 +1,51 @@
+/**
+ * The Node screen toolchain against the shared conformance table — the real
+ * esbuild, the real TypeScript compiler and the real VM, through the whole
+ * gauntlet.
+ *
+ * Plus the one thing no fixture can state: a toolchain that cannot do its job
+ * REFUSES. The three lazy loads behind this adapter are the reason the gauntlet
+ * exists at all, and a check that read nothing must never answer "fine".
+ */
+import { describe, expect, it } from "vitest";
+import { checkComponentScreen } from "../../src/server/checking/component-screen.js";
+import { nodeToolchain, __setToolchainForTests } from "../../src/server/checking/toolchain.js";
+import { runToolchainConformance } from "./toolchain-conformance.test-util.js";
+
+describe("the Node screen toolchain", () => {
+  runToolchainConformance(nodeToolchain);
+});
+
+const PLAIN = `import { Text } from "@vendo/screen";
+
+export default function Rows() {
+  return <Text text="hi" />;
+}
+`;
+
+describe("a toolchain that cannot type-check", () => {
+  it("refuses the screen and names why, instead of passing one it never read", async () => {
+    const restore = __setToolchainForTests({
+      ...nodeToolchain(),
+      typecheck: async () => ({ ok: false, why: "the compiler is not reachable here" }),
+    });
+    try {
+      const result = await checkComponentScreen({
+        source: PLAIN,
+        hostTools: [],
+        catalog: ["Text"],
+        runQuery: async () => ({}),
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.issues).toEqual([{
+        code: "typecheck-unavailable",
+        message: "the screen could not be type-checked: the compiler is not reachable here."
+          + " This check refuses to pass a screen it never read — make the TypeScript compiler"
+          + " reachable where the build runs.",
+      }]);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/packages/apps/tests/checking/toolchain-seam.test.ts
+++ b/packages/apps/tests/checking/toolchain-seam.test.ts
@@ -1,0 +1,128 @@
+/**
+ * `AppsConfig.toolchain`, end to end — the WIRING, not the interface.
+ *
+ * The slot is only a feature if the toolchain a host passes to `createApps` is
+ * the one that really compiles, type-checks and paints its screens. Everything
+ * between the two is composition — the config, the build surface, the floor the
+ * render seam is handed, the stored-app `validate` door — and none of it has a
+ * verdict of its own, so a broken thread there is invisible to every other test:
+ * the gauntlet passes on its own toolchain, the toolchain passes on its own
+ * fixtures, and each proves the other is fine. That is the shape of failure this
+ * repo has already shipped four times (host-component previews), so the two
+ * doors that reach the gauntlet are driven here through the REAL runtime, with
+ * nothing stubbed in between.
+ *
+ * The recorder DELEGATES to the Node toolchain rather than faking one: a
+ * recorder that answered for itself would prove the calls were made and not that
+ * their answers are what the door acts on.
+ */
+import { VENDO_APP_FORMAT, engineOverAdapter, sha256Hex, type RunContext, type ToolRegistry } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { SCREEN_FILE, type AppDocument, type NormalizedCatalog } from "../../src/contract/index.js";
+import { createApps } from "../../src/server/index.js";
+import { nodeToolchain, type ScreenToolchain } from "../../src/server/checking/toolchain.js";
+import { guardFixture } from "../../src/server/testing/guard-fixture.js";
+import { memoryStore } from "../../src/server/testing/memory-store.js";
+import { scriptedLanguageModel } from "../../src/server/testing/scripted-model.js";
+import { seedAppRow } from "../../src/server/testing/seed-app-row.js";
+
+/** One Kit component, no queries: this screen is about the wiring, and a tool
+ *  call would only add a second thing that could fail. */
+const SCREEN = `import { Text } from "@vendo/screen";
+
+export default function Hello() {
+  return <Text text="hi" />;
+}
+`;
+
+const catalog: NormalizedCatalog = [];
+
+const ctx: RunContext = {
+  principal: { kind: "user", subject: "user_ada" },
+  venue: "app",
+  presence: "present",
+  sessionId: "session_ada",
+};
+
+const tools: ToolRegistry = {
+  async descriptors() { return []; },
+  async execute() { return { status: "error", error: { code: "not-found", message: "no tools" } }; },
+};
+
+/** The reviewer is fail-open, and no door under test here reads a model
+ *  answer — the same posture one-floor.test.ts takes. */
+const model = () => scriptedLanguageModel(() => "no");
+
+interface Recorder {
+  toolchain: ScreenToolchain;
+  calls: string[];
+}
+
+const recording = (): Recorder => {
+  const real = nodeToolchain();
+  const calls: string[] = [];
+  return {
+    calls,
+    toolchain: {
+      transform: (source) => { calls.push("transform"); return real.transform(source); },
+      typecheck: (input) => { calls.push("typecheck"); return real.typecheck(input); },
+      paint: (input) => { calls.push("paint"); return real.paint(input); },
+    },
+  };
+};
+
+/** The stored form of a component screen: the `.tsx` IS the app, so the row
+ *  carries source and no tree — what `commitApp` lands. */
+const storedScreen = (id: string): AppDocument => ({
+  format: VENDO_APP_FORMAT,
+  id,
+  name: "Hello",
+  ui: "tree",
+  source: {
+    [SCREEN_FILE]: {
+      hash: `sha256:${sha256Hex(SCREEN)}`,
+      bytes: new TextEncoder().encode(SCREEN).byteLength,
+      text: SCREEN,
+    },
+  },
+} as AppDocument);
+
+describe("the toolchain a host passes to createApps is the one its screens face", () => {
+  it("at the paint seam's floor — AppsRuntime.floor(ctx).component", async () => {
+    const recorder = recording();
+    const apps = createApps({
+      store: memoryStore(),
+      guard: guardFixture(),
+      tools,
+      catalog,
+      model: model(),
+      toolchain: recorder.toolchain,
+    });
+
+    const painted = await apps.floor(ctx).component?.({ appId: "app_seam_floor", source: SCREEN });
+
+    // All three stages, in the gauntlet's own order, and the paint the door
+    // hands back is the one this toolchain produced.
+    expect(recorder.calls).toEqual(["transform", "typecheck", "paint"]);
+    expect(painted?.ok).toBe(true);
+  }, 60_000);
+
+  it("at the stored-app door — AppsRuntime.validate({ appId })", async () => {
+    const recorder = recording();
+    const store = memoryStore();
+    const apps = createApps({
+      store,
+      guard: guardFixture(),
+      tools,
+      catalog,
+      model: model(),
+      toolchain: recorder.toolchain,
+    });
+    await seedAppRow(engineOverAdapter(store), storedScreen("app_seam_validate"), ctx.principal.subject);
+
+    const verdict = await apps.validate({ appId: "app_seam_validate" }, ctx);
+
+    expect(recorder.calls).toEqual(["transform", "typecheck", "paint"]);
+    expect(verdict.ok).toBe(true);
+  }, 60_000);
+});


### PR DESCRIPTION
## What

Screen checking currently hard-requires Node: `checkComponentScreen` reaches for
esbuild, for `typescript` through `createRequire`, and for the QuickJS
single-file build, all from this process. That is the reason a screen cannot be
checked on Cloudflare Workers.

This PR makes those three an ADAPTER SLOT and nothing else. **No behavior
changes and no sentence changes** — the default is exactly what the package did
before, and the existing suites pass unmodified.

## The seam

```ts
interface ScreenToolchain {
  transform(source): Promise<ScreenTransform>;       // both forms of the screen
  typecheck(input): Promise<ScreenTypecheckResult>;  // fail-closed: ok:false names why
  paint(input): Promise<ScreenPaintResult>;          // ScreenError as data
}
```

- `AppsConfig.toolchain` threads it through `createApps` → `createAppFloor` →
  `checkComponentScreen`, and through `validate`, which runs the same gauntlet.
  Adapter rule as everywhere else: explicitly passed always wins, unset is
  today's behavior, nothing reads the environment, all OSS.
- Stage 3's diagnostic translation moves to `checking/screen-typecheck.ts`. It
  travels with the COMPILER because every sentence is written off the AST, and
  an AST walk cannot cross a service binding — so both toolchains run the one
  translation and an author reads the same sentence either way.
- `screen-tsc.ts` gains `screenProgramWith(ts, input, libs, defaultLibFileName)`;
  `screenProgram` delegates to it with this process's compiler and Node's disk.
  The wire path `screenTscFindings` is untouched.
- What did NOT move: the acorn scan, running the queries, and tree validation.
  They are portable already.
- esbuild keeps its module-scope eager start and its bundler-blind specifier
  (no literal `import("esbuild")` — the portability gate forbids it).

The edge implementation is a LATER PR. `tests/checking/toolchain-conformance.test-util.ts`
is the shared fixture table it will be driven through: one call with a different
factory and nothing else.

## Proof

- `packages/apps` suite green unmodified — 1646 passed, incl. all 49
  `component-screen` sentence assertions.
- Sentence parity checked mechanically: all 60 prose fragments the old file could
  emit are byte-identical in the new tree.
- Fail-closed proven both ways: a toolchain whose `typecheck` returns
  `{ok:false}` refuses with the same "typecheck-unavailable" sentence, and
  deleting that branch turns the test red.
- `pnpm build`, `pnpm typecheck`, `pnpm lint` green — dependency guard OK, all
  portability legs OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Puts component screen checking’s three Node-only loads behind a single `ScreenToolchain` adapter slot, enabling non-Node venues with no behavior change.

- Adds `ScreenToolchain` (`transform`, `typecheck`, `paint`) with `nodeToolchain` as the default; exports types and `ScreenToolchainUnavailable`.
- Threads the toolchain through `AppsConfig`, `createAppFloor`, and the stored-app validate door so both paths use the same implementation.
- Moves Stage 3 diagnostic translation to `screen-typecheck.ts`; extends `screen-tsc` with `screenProgramWith` and restores `fileExists` as a probe; `screenProgram` keeps the Node default.
- Starts `esbuild` at module scope with a bundler-blind specifier; keeps the portability guard.
- Adds a conformance table and Node toolchain tests; new end-to-end tests prove `AppsConfig.toolchain` reaches the paint seam floor and the validate door.
- Drops the floor’s duplicate default so an installed toolchain still reaches a floor built earlier.

**Rollout/Migration**
- No migration required.
- Optional: set `AppsConfig.toolchain` to run checks outside Node; pass the same toolchain to build-surface validation for parity.
- Checks remain fail-closed: if the toolchain cannot compile/type-check/paint, the gauntlet refuses with the same messages as before.

<sup>Written for commit 826ebc9bf7dce315b6ab9a29234bb29175a0cbac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

