### PR TITLE
feat(apps): budget a screen in interrupts, because workerd freezes the clock

### DIFF
--- a/packages/apps/src/contract/genui/component/boot.ts
+++ b/packages/apps/src/contract/genui/component/boot.ts
@@ -16,12 +16,11 @@
  * in-VM queue this file pumps (./vm-program.ts), so a `setState` inside a
  * handler has already landed by the time `fire` returns.
  *
- * THE BUDGET IS WALL-CLOCK, not instructions. QuickJS counts interrupts in
- * bytecode operations, which is the wrong unit for "this screen is stuck": the
- * same `while (true)` burns a wildly different number of them depending on what
- * is in the loop, so a tick budget is simultaneously too tight for a real
- * render over a page of rows and too loose for a spin. A deadline is the
- * question actually being asked.
+ * THE BUDGET IS THE VENUE'S TO CHOOSE. A deadline is the question actually
+ * being asked — until the venue is one that freezes the clock while a screen
+ * burns, where it is a question that can only be answered "not yet". So the
+ * limit arrives as a {@link ScreenBudget} (./budget.ts): wall-clock by default,
+ * interrupt counts where the clock does not move.
  *
  * A THROW LEAVES THE SCREEN STANDING. A handler that throws, or that never
  * finishes, raises a {@link ScreenError} out of `fire` — and the instance stays
@@ -33,11 +32,11 @@ import {
   isFail,
   newQuickJSWASMModuleFromVariant,
   Scope,
-  shouldInterruptAfterDeadline,
   type QuickJSDeferredPromise,
   type QuickJSHandle,
   type QuickJSWASMModule,
 } from "quickjs-emscripten-core";
+import { wallClockBudget, type ScreenTurn, type TurnLimit } from "./budget.js";
 import { SCREEN_RUNTIME, installSource, sealSource } from "./vm-program.js";
 import {
   ScreenError,
@@ -59,34 +58,40 @@ const MEMORY_LIMIT_BYTES = 32 * 1_024 * 1_024;
  *  the one failure that would tear through this module. */
 const MAX_STACK_BYTES = 512 * 1_024;
 
-/** Wall-clock a single event or paint may spend. A 60-row render measured 3.3ms
- *  in this VM, so this is ~60x headroom for real work and still a fifth of a
- *  second for a runaway. */
-const OP_BUDGET_MS = 200;
-
-/** Wall-clock the boot may spend. Longer because it parses Preact and this
- *  screen's own source before it paints for the first time. */
-const BOOT_BUDGET_MS = 2_000;
-
 /** Times the drain may find more work waiting. A paint that schedules an update
  *  that schedules an effect is ordinary; a hundred rounds of it is a loop. */
 const MAX_DRAIN_TURNS = 64;
 
-let booting: Promise<QuickJSWASMModule> | null = null;
+/** Which QuickJS build the engine runs on — the argument the module factory
+ *  takes, so a host may hand over a variant it loaded its own way. */
+export type ScreenEngineVariant = Parameters<typeof newQuickJSWASMModuleFromVariant>[0];
+
+const engines = new Map<ScreenEngineVariant, Promise<QuickJSWASMModule>>();
+let stock: ScreenEngineVariant | null = null;
 let wasm: QuickJSWASMModule | null = null;
 
 /**
  * Load the WebAssembly. Running a screen is synchronous — this one-time load is
  * not, so a caller awaits it once before the first {@link bootScreen}.
  *
- * The variant is the SINGLE-FILE BROWSER build, for `$expr`'s reason: the
- * WebAssembly rides inside the JavaScript, so no host bundler has to be taught
- * to emit a `.wasm`, and it reaches for no Node builtin — one variant for both
- * venues.
+ * The default variant is the SINGLE-FILE BROWSER build, for `$expr`'s reason:
+ * the WebAssembly rides inside the JavaScript, so no host bundler has to be
+ * taught to emit a `.wasm`, and it reaches for no Node builtin. The import stays
+ * a literal specifier because `@vendoai/ui` depends on a bundler inlining it.
+ *
+ * A venue that cannot run that build passes its own variant, and each variant
+ * gets its own engine: the memo is keyed on the variant itself, so a host that
+ * warms two never gets one of them handed the other's WebAssembly. `stock` is
+ * held for the same reason — the default needs one stable key, not a fresh
+ * import promise per call.
  */
-export async function warmScreenEngine(): Promise<void> {
-  booting ??= import("@jitl/quickjs-singlefile-browser-release-sync")
-    .then((module) => newQuickJSWASMModuleFromVariant(module.default));
+export async function warmScreenEngine(variant?: ScreenEngineVariant): Promise<void> {
+  const key = variant ?? (stock ??= import("@jitl/quickjs-singlefile-browser-release-sync"));
+  let booting = engines.get(key);
+  if (booting === undefined) {
+    booting = newQuickJSWASMModuleFromVariant(key);
+    engines.set(key, booting);
+  }
   wasm = await booting;
 }
 
@@ -110,12 +115,6 @@ const messageOf = (thrown: unknown): Thrown => {
 /** QuickJS reports a tripped interrupt handler as exactly this. */
 const isInterrupt = (thrown: Thrown): boolean => thrown.message === "InternalError: interrupted";
 
-/** Boot's budget is ten times an event's, so the number is the TURN'S, not one
- *  constant: a sentence that names the wrong limit sends a repair after the
- *  wrong problem. */
-const budgetMessage = (budgetMs: number): string =>
-  `this screen did not finish inside ${budgetMs}ms — a loop that never ends, or work too heavy for a paint`;
-
 /**
  * Boot one screen. Synchronous, and long-lived: the VM, the component and its
  * hook state stay alive until {@link ScreenInstance.dispose}, because a screen
@@ -129,6 +128,7 @@ export function bootScreen(options: BootScreenOptions): ScreenInstance {
     throw new ScreenError("boot", "the screen engine is not warm yet — await warmScreenEngine() once before booting a screen");
   }
 
+  const budget = options.budget ?? wallClockBudget();
   const runtime = module.newRuntime();
   runtime.setMemoryLimit(MEMORY_LIMIT_BYTES);
   runtime.setMaxStackSize(MAX_STACK_BYTES);
@@ -142,8 +142,9 @@ export function bootScreen(options: BootScreenOptions): ScreenInstance {
   let painted: string | null = null;
   let tree: NestedNode | null = null;
   let dead = false;
-  /** The budget of the turn in progress — what a budget failure names. */
-  let budgetMs = BOOT_BUDGET_MS;
+  /** The allowance of the turn in progress — what a budget failure names. Set
+   *  by `turn`, which is the only way any of this runs. */
+  let limit!: TurnLimit;
 
   const teardown = (): void => {
     if (dead) return;
@@ -166,7 +167,7 @@ export function bootScreen(options: BootScreenOptions): ScreenInstance {
 
   const failure = (kind: ScreenErrorKind, thrown: Thrown): ScreenError =>
     isInterrupt(thrown)
-      ? new ScreenError("budget", budgetMessage(budgetMs))
+      ? new ScreenError("budget", limit.message)
       : new ScreenError(kind, thrown.message, thrown.stack);
 
   /** Evaluate in the VM. The returned handle is the caller's to dispose; every
@@ -212,7 +213,7 @@ export function bootScreen(options: BootScreenOptions): ScreenInstance {
   /** Run everything the screen scheduled: awaited tool answers (the VM's own
    *  job queue) and Preact's updates and effects (the engine's queue), until
    *  both are quiet. */
-  const drain = (deadline: number): void => {
+  const drain = (): void => {
     for (let turn = 0; turn < MAX_DRAIN_TURNS; turn += 1) {
       const jobs = runtime.executePendingJobs();
       if (isFail(jobs)) {
@@ -222,7 +223,7 @@ export function bootScreen(options: BootScreenOptions): ScreenInstance {
       }
       const ran = evalNumber("__vendo.flush()", "handler");
       if (jobs.value === 0 && ran === 0) return;
-      if (Date.now() > deadline) throw new ScreenError("budget", budgetMessage(budgetMs));
+      if (limit.spent()) throw new ScreenError("budget", limit.message);
     }
     throw new ScreenError("budget", "this screen scheduled more work after every paint and never settled");
   };
@@ -244,13 +245,12 @@ export function bootScreen(options: BootScreenOptions): ScreenInstance {
     return true;
   };
 
-  const turn = <T>(budget: number, body: (deadline: number) => T): T => {
+  const turn = <T>(kind: ScreenTurn, body: () => T): T => {
     if (dead) throw new ScreenError("vm", "this screen was disposed");
-    budgetMs = budget;
-    const deadline = Date.now() + budget;
-    runtime.setInterruptHandler(shouldInterruptAfterDeadline(deadline));
+    limit = budget.limit(kind);
+    runtime.setInterruptHandler(limit.handler);
     try {
-      return body(deadline);
+      return body();
     } finally {
       if (!dead) runtime.removeInterruptHandler();
     }
@@ -279,7 +279,7 @@ export function bootScreen(options: BootScreenOptions): ScreenInstance {
   bridge.dispose();
 
   try {
-    turn(BOOT_BUDGET_MS, (deadline) => {
+    turn("boot", () => {
       evalVoid(sealSource(options.now), "boot");
       evalVoid(SCREEN_RUNTIME, "boot");
       evalVoid(installSource({
@@ -287,7 +287,7 @@ export function bootScreen(options: BootScreenOptions): ScreenInstance {
         queries: options.queries,
         catalog: options.catalog,
       }), "boot");
-      drain(deadline);
+      drain();
       checkFailure();
       repaint();
     });
@@ -300,11 +300,11 @@ export function bootScreen(options: BootScreenOptions): ScreenInstance {
     tree: currentTree,
 
     fire(handlerId: string, event?: unknown): FireResult {
-      return turn(OP_BUDGET_MS, (deadline) => {
+      return turn("op", () => {
         intents = [];
         try {
           evalVoid(`__vendo.fire(${JSON.stringify(handlerId)}, ${literal(event)})`, "handler");
-          drain(deadline);
+          drain();
           checkFailure();
           repaint();
         } catch (error) {
@@ -316,7 +316,7 @@ export function bootScreen(options: BootScreenOptions): ScreenInstance {
     },
 
     settle(intentId: string, result: unknown): FireResult | null {
-      return turn(OP_BUDGET_MS, (deadline) => {
+      return turn("op", () => {
         const deferred = awaiting.get(intentId);
         if (deferred === undefined) {
           throw new ScreenError("handler", `no tool call "${intentId}" is waiting on this screen — it was already settled, or it belongs to a screen that has since been disposed`);
@@ -344,7 +344,7 @@ export function bootScreen(options: BootScreenOptions): ScreenInstance {
           // The code resuming after the await is still the handler's, so its
           // tool calls are still an event's.
           evalVoid("__vendo.resume()", "handler");
-          drain(deadline);
+          drain();
           checkFailure();
         } catch (error) {
           discardIntents();

--- a/packages/apps/src/contract/genui/component/budget.ts
+++ b/packages/apps/src/contract/genui/component/budget.ts
@@ -1,0 +1,103 @@
+/**
+ * What stops a screen that will not stop — in the unit the venue can measure.
+ *
+ * A screen runs synchronously inside a QuickJS VM, so the only way out of a
+ * `while (true)` is the interrupt handler QuickJS polls while it burns. What that
+ * handler is allowed to ask is the whole question here, and the answer is not the
+ * same in both venues:
+ *
+ * - **Node reads the clock.** "Has this screen had its fifth of a second" is the
+ *   question actually being asked, and a deadline answers it whatever the loop
+ *   happens to contain. {@link wallClockBudget} is the default for that reason.
+ * - **workerd freezes the clock.** During a synchronous burn `Date.now()` and
+ *   `performance.now()` do not advance at all, so a deadline handler is asked a
+ *   million times and truthfully answers "not yet" every time: a measured runaway
+ *   screen spent 37 seconds of CPU and died on a platform error instead of a
+ *   refusal. {@link opsBudget} counts the polls instead, and a count rises
+ *   whether or not the clock does.
+ *
+ * An interrupt count is a coarser unit — the same `while (true)` costs a
+ * different number of them depending on what is in the loop — so the counts are
+ * calibrated with room to spare rather than cut fine. QuickJS comes up for air
+ * about every ten thousand bytecode operations, which puts real work and a
+ * runaway three orders apart: booting a 60-row screen spends ONE interrupt and
+ * re-painting it spends none, against budgets of 7000 and 650.
+ *
+ * This file lives under contract/, so it stays browser-safe: `InterruptHandler`
+ * is imported as a TYPE and nothing here runs anything from that package.
+ */
+import type { InterruptHandler } from "quickjs-emscripten-core";
+
+/** The two things a screen does, and the two limits they get. Boot is the longer
+ *  of the pair: it parses Preact and the screen's own source before it paints. */
+export type ScreenTurn = "boot" | "op";
+
+/** One turn's allowance, made the moment the turn starts. */
+export interface TurnLimit {
+  /** Installed on the runtime for the length of the turn. */
+  readonly handler: InterruptHandler;
+  /** Is the allowance gone? Asked between drain rounds, where no VM code is
+   *  running and so nothing would poll the handler. */
+  spent(): boolean;
+  /** The refusal, naming THIS turn's limit — a sentence that names the wrong one
+   *  sends a repair after the wrong problem. */
+  readonly message: string;
+}
+
+export interface ScreenBudget {
+  limit(turn: ScreenTurn): TurnLimit;
+}
+
+/** Wall-clock a single event or paint may spend. A 60-row render measured 3.3ms
+ *  in this VM, so this is ~60x headroom for real work and still a fifth of a
+ *  second for a runaway. */
+const OP_BUDGET_MS = 200;
+
+/** Wall-clock the boot may spend. Longer because it parses Preact and this
+ *  screen's own source before it paints for the first time. */
+const BOOT_BUDGET_MS = 2_000;
+
+/** Interrupts a single event or paint may spend. Calibrated against the 200ms
+ *  above: a VM burning a tight loop reaches this in 60-125ms. */
+export const OP_INTERRUPT_BUDGET = 650;
+
+/** Interrupts the boot may spend, calibrated the same way against the 2000ms:
+ *  a boot that loops while it renders reaches this in ~2.2s. */
+export const BOOT_INTERRUPT_BUDGET = 7_000;
+
+const finishMessage = (limit: string): string =>
+  `this screen did not finish inside ${limit} — a loop that never ends, or work too heavy for a paint`;
+
+/**
+ * The default, and the only one that is right in Node: a deadline per turn.
+ *
+ * The handler is `shouldInterruptAfterDeadline`'s own body, written out rather
+ * than imported — contract/ must bundle for a browser, and a type import is all
+ * this file may take from `quickjs-emscripten-core`.
+ */
+export const wallClockBudget = (options: { opMs?: number; bootMs?: number } = {}): ScreenBudget => ({
+  limit: (turn) => {
+    const budgetMs = turn === "boot" ? options.bootMs ?? BOOT_BUDGET_MS : options.opMs ?? OP_BUDGET_MS;
+    const deadline = Date.now() + budgetMs;
+    const over = (): boolean => Date.now() > deadline;
+    return { handler: over, spent: over, message: finishMessage(`${budgetMs}ms`) };
+  },
+});
+
+/** The edge's budget: how many times QuickJS came up for air, which no runtime
+ *  can freeze. Deterministic, so the same runaway is contained identically on
+ *  every machine — and unlike a deadline it cannot be defeated by a stopped
+ *  clock. */
+export const opsBudget = (options: { opInterrupts?: number; bootInterrupts?: number } = {}): ScreenBudget => ({
+  limit: (turn) => {
+    const allowed = turn === "boot"
+      ? options.bootInterrupts ?? BOOT_INTERRUPT_BUDGET
+      : options.opInterrupts ?? OP_INTERRUPT_BUDGET;
+    let polls = 0;
+    return {
+      handler: () => (polls += 1) > allowed,
+      spent: () => polls > allowed,
+      message: finishMessage(`${allowed} interrupts`),
+    };
+  },
+});

--- a/packages/apps/src/contract/genui/component/index.ts
+++ b/packages/apps/src/contract/genui/component/index.ts
@@ -17,10 +17,20 @@
  * and every catalog name.
  *
  * The pieces: ./boot.ts runs the VM, ./vm-program.ts is what the VM runs,
- * ./preact-source.ts is the pinned Preact it runs it with, ./flatten.ts turns a
- * paint into addressable nodes, ./types.ts is the vocabulary.
+ * ./preact-source.ts is the pinned Preact it runs it with, ./budget.ts is what
+ * stops a screen that will not stop, ./flatten.ts turns a paint into addressable
+ * nodes, ./types.ts is the vocabulary.
  */
-export { bootScreen, warmScreenEngine } from "./boot.js";
+export { bootScreen, warmScreenEngine, type ScreenEngineVariant } from "./boot.js";
+export {
+  BOOT_INTERRUPT_BUDGET,
+  OP_INTERRUPT_BUDGET,
+  opsBudget,
+  wallClockBudget,
+  type ScreenBudget,
+  type ScreenTurn,
+  type TurnLimit,
+} from "./budget.js";
 export { flattenTree } from "./flatten.js";
 export {
   isHandlerRef,

--- a/packages/apps/src/contract/genui/component/types.ts
+++ b/packages/apps/src/contract/genui/component/types.ts
@@ -21,6 +21,7 @@
  *    reports back through {@link ScreenInstance.settle}. The screen cannot
  *    reach the network, so this is the only way anything leaves it.
  */
+import type { ScreenBudget } from "./budget.js";
 
 /** A function-valued prop, as it crosses the VM boundary. */
 export interface HandlerRef {
@@ -101,6 +102,12 @@ export interface BootScreenOptions {
    * keeps, so one screen over one set of data paints the same twice.
    */
   now?: number;
+  /**
+   * What stops a screen that will not stop. Unset is `wallClockBudget()` — a
+   * fifth of a second an event, two seconds a boot. A venue whose clock does not
+   * advance during a synchronous burn (workerd) passes `opsBudget()` instead.
+   */
+  budget?: ScreenBudget;
 }
 
 /** The one node kind that is not a catalog component: a run of text. */

--- a/packages/apps/tests/contract/genui/component/budget.test.ts
+++ b/packages/apps/tests/contract/genui/component/budget.test.ts
@@ -1,0 +1,246 @@
+/**
+ * What contains a runaway screen — and why the clock is not always the answer.
+ *
+ * Wall-clock is the right question in Node and the WRONG one on Cloudflare
+ * Workers: workerd freezes `Date.now()` and `performance.now()` for the whole of
+ * a synchronous burn, so a deadline handler is asked "is it past 3pm" a million
+ * times and truthfully answers "no" every time. A measured runaway screen spent
+ * 37 seconds of CPU that way and died on a platform error instead of a refusal.
+ * An interrupt COUNT rises whether or not the clock does, so it is what holds on
+ * the edge.
+ *
+ * The two implementations are asserted against the same three questions: does a
+ * legitimate screen paint, does a runaway stop, and does the refusal name the
+ * limit the screen actually blew. Plus the one that only matters here: with an
+ * unset budget, every sentence is byte-for-byte the one `screen-errors` pins.
+ */
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  BOOT_INTERRUPT_BUDGET,
+  bootScreen,
+  OP_INTERRUPT_BUDGET,
+  opsBudget,
+  ScreenError,
+  wallClockBudget,
+  warmScreenEngine,
+  type ScreenBudget,
+  type ScreenInstance,
+  type ScreenTurn,
+} from "../../../../src/contract/genui/component/index.js";
+import { CATALOG, compileScreen, textsOf } from "./screen-fixture.test-util.js";
+
+beforeAll(async () => {
+  await warmScreenEngine();
+});
+
+const boot = (tsx: string, budget?: ScreenBudget): ScreenInstance => bootScreen({
+  compiledSource: compileScreen(tsx),
+  queries: {},
+  catalog: CATALOG,
+  ...(budget === undefined ? {} : { budget }),
+});
+
+const raised = (body: () => unknown): ScreenError => {
+  try {
+    body();
+  } catch (error) {
+    if (error instanceof ScreenError) return error;
+    throw new Error(`expected a ScreenError, got ${String(error)}`);
+  }
+  throw new Error("expected a ScreenError, got no throw at all");
+};
+
+/** Loops in the component body, so it never reaches a first paint. */
+const SPINS_ON_RENDER = `
+import { Text } from "@vendo/screen";
+export default function S() { while (true) {} return <Text text="never" />; }`;
+
+/** Boots fine, then loops inside the click — the OP turn's problem. */
+const SPINS_ON_CLICK = `
+import { Button, Stack, Text } from "@vendo/screen";
+export default function S() {
+  return (
+    <Stack>
+      <Text text="ready" />
+      <Button label="spin" onClick={() => { while (true) {} }} />
+    </Stack>
+  );
+}`;
+
+/** Real work: the table the op budget was calibrated against. */
+const SIXTY_ROWS = `
+import { useState } from "react";
+import { Button, DataTable, Stack, Text } from "@vendo/screen";
+export default function S() {
+  const [round, setRound] = useState(0);
+  const rows = [];
+  for (let index = 0; index < 60; index += 1) rows.push({ id: index, label: "row " + index + " of round " + round });
+  return (
+    <Stack>
+      <Text text={"round " + round} />
+      <DataTable rows={rows} />
+      <Button label="again" onClick={() => setRound((value) => value + 1)} />
+    </Stack>
+  );
+}`;
+
+/** A budget that reports what its turns actually spent — the calibration read. */
+const counting = (inner: ScreenBudget): { budget: ScreenBudget; spent: Record<ScreenTurn, number> } => {
+  const spent: Record<ScreenTurn, number> = { boot: 0, op: 0 };
+  return {
+    spent,
+    budget: {
+      limit: (turn) => {
+        const limit = inner.limit(turn);
+        return { ...limit, handler: (runtime) => { spent[turn] += 1; return limit.handler(runtime); } };
+      },
+    },
+  };
+};
+
+describe("no budget supplied", () => {
+  it("refuses in exactly the words it refused in before there was a budget interface", () => {
+    const booted = raised(() => boot(SPINS_ON_RENDER));
+    expect(booted.kind).toBe("budget");
+    expect(booted.message).toBe("this screen did not finish inside 2000ms — a loop that never ends, or work too heavy for a paint");
+
+    const screen = boot(SPINS_ON_CLICK);
+    try {
+      const clicked = raised(() => screen.fire("h1"));
+      expect(clicked.kind).toBe("budget");
+      expect(clicked.message).toBe("this screen did not finish inside 200ms — a loop that never ends, or work too heavy for a paint");
+    } finally {
+      screen.dispose();
+    }
+  });
+});
+
+describe("wallClockBudget", () => {
+  it("takes the boot's milliseconds and says the number it was given", () => {
+    const error = raised(() => boot(SPINS_ON_RENDER, wallClockBudget({ bootMs: 300 })));
+
+    expect(error.kind).toBe("budget");
+    expect(error.message).toBe("this screen did not finish inside 300ms — a loop that never ends, or work too heavy for a paint");
+  });
+
+  it("takes an event's milliseconds without touching the boot's", () => {
+    // Only `opMs` is set, so this screen boots on the stock 2000ms — a custom
+    // knob must not quietly re-budget the other turn.
+    const screen = boot(SPINS_ON_CLICK, wallClockBudget({ opMs: 50 }));
+    try {
+      expect(textsOf(screen.tree())).toEqual(["ready"]);
+
+      const error = raised(() => screen.fire("h1"));
+      expect(error.kind).toBe("budget");
+      expect(error.message).toBe("this screen did not finish inside 50ms — a loop that never ends, or work too heavy for a paint");
+    } finally {
+      screen.dispose();
+    }
+  });
+});
+
+describe("opsBudget", () => {
+  it("paints a 60-row screen and re-paints it, well inside the stock counts", () => {
+    const counted = counting(opsBudget());
+    const screen = boot(SIXTY_ROWS, counted.budget);
+    try {
+      expect(textsOf(screen.tree())).toContain("round 0");
+      screen.fire("h1");
+      expect(textsOf(screen.tree())).toContain("round 1");
+
+      // The calibration, asserted rather than commented. QuickJS comes up for
+      // air about every ten thousand bytecode operations, so real work is
+      // measured in single interrupts: this boot spends 1 and the re-paint 0,
+      // against budgets of 7000 and 650. These bounds are the ratchet — a
+      // legitimate render climbing into the hundreds means the counts want
+      // re-measuring, not raising.
+      expect(counted.spent.boot).toBeLessThan(100);
+      expect(counted.spent.op).toBeLessThan(10);
+    } finally {
+      screen.dispose();
+    }
+  });
+
+  it("stops a runaway on the STOCK counts, which is what the edge will run", () => {
+    // The other direction of the calibration: 650 has to be a real limit, not
+    // only headroom. Measured, this lands in ~60-125ms — under the 200ms the
+    // wall clock would have taken, and the boot's 7000 lands at ~2.2s.
+    const screen = boot(SPINS_ON_CLICK, opsBudget());
+    try {
+      const error = raised(() => screen.fire("h1"));
+
+      expect(error.kind).toBe("budget");
+      expect(error.message).toBe(`this screen did not finish inside ${OP_INTERRUPT_BUDGET} interrupts — a loop that never ends, or work too heavy for a paint`);
+    } finally {
+      screen.dispose();
+    }
+  });
+
+  it("stops a screen that loops while it renders, and names the count it blew", () => {
+    const error = raised(() => boot(SPINS_ON_RENDER, opsBudget({ bootInterrupts: 5 })));
+
+    expect(error.kind).toBe("budget");
+    expect(error.message).toContain("5 interrupts");
+  });
+
+  it("stops a runaway click, and names the event's count rather than the boot's", () => {
+    const screen = boot(SPINS_ON_CLICK, opsBudget({ opInterrupts: 5 }));
+    try {
+      const error = raised(() => screen.fire("h1"));
+
+      expect(error.kind).toBe("budget");
+      expect(error.message).toContain("5 interrupts");
+      expect(error.message).not.toContain(String(BOOT_INTERRUPT_BUDGET));
+    } finally {
+      screen.dispose();
+    }
+  });
+
+  it("still stops a runaway when the clock is frozen, which is workerd's whole problem", () => {
+    // The measured platform behaviour, reproduced: `Date.now()` never moves for
+    // the duration of the burn. A deadline handler would answer "not yet"
+    // forever and this test would hang; a counter cannot be frozen.
+    const clock = vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    try {
+      const error = raised(() => boot(SPINS_ON_RENDER, opsBudget({ bootInterrupts: 200 })));
+
+      expect(error.kind).toBe("budget");
+      expect(error.message).toContain("200 interrupts");
+    } finally {
+      clock.mockRestore();
+    }
+  });
+});
+
+describe("warmScreenEngine's variant", () => {
+  it("builds one engine per variant, and never hands one variant's engine to another", async () => {
+    const base = (await import("@jitl/quickjs-singlefile-browser-release-sync")).default;
+    // The engine builder calls `importFFI` exactly once per engine it builds, so
+    // counting that call is how many engines a variant got.
+    const counted = (): { variant: typeof base; builds: () => number } => {
+      let builds = 0;
+      return { variant: { ...base, importFFI: () => { builds += 1; return base.importFFI(); } }, builds: () => builds };
+    };
+    const first = counted();
+    const second = counted();
+
+    await warmScreenEngine(first.variant);
+    await warmScreenEngine(first.variant);
+    expect(first.builds()).toBe(1);
+
+    await warmScreenEngine(second.variant);
+    expect(second.builds()).toBe(1);
+    expect(first.builds()).toBe(1);
+
+    // …and the no-arg default is an entry of its own, still booting screens.
+    await warmScreenEngine();
+    const screen = boot(`
+import { Text } from "@vendo/screen";
+export default function S() { return <Text text="warm" />; }`);
+    try {
+      expect(textsOf(screen.tree())).toEqual(["warm"]);
+    } finally {
+      screen.dispose();
+    }
+  });
+});


### PR DESCRIPTION
Stacked on #1231 (`yousefh409/edge-toolchain-s1-seam`). Review that one first.

## Why this exists

Screen execution was bounded by WALL CLOCK — a 200ms per-op budget and a 2s boot budget. That is the right question in Node and an **unanswerable** one on Cloudflare Workers.

**workerd does not advance `Date.now()` or `performance.now()` during synchronous CPU work.** So the deadline interrupt handler gets polled a million times while a screen burns, and every single time it truthfully answers "not yet". A wall-clock budget therefore NEVER FIRES on the edge: a measured runaway screen burned **37 seconds of CPU** and died on a platform error instead of being contained by a refusal.

An interrupt count rises whether or not the clock does. That is the unit the edge can actually measure.

## What changed

The budget is now an interface with two implementations:

- `wallClockBudget({ opMs?, bootMs? })` — today's behaviour, 200/2000, **still the default**.
- `opsBudget({ opInterrupts?, bootInterrupts? })` — deterministic interrupt counts, for the edge.

`turn()` installs the limit's handler, `drain()` asks `limit.spent()` instead of reading a deadline, and a tripped handler is raised as `ScreenError("budget", limit.message)` so the sentence always names the limit that turn actually blew.

`warmScreenEngine` also gains an optional variant, memoized on **variant identity** so a host that warms two never gets one handed the other's WebAssembly.

## Node behaviour is unchanged

With no budget supplied, nothing moves. The new suite asserts both refusal sentences with full string equality:

- `this screen did not finish inside 2000ms — a loop that never ends, or work too heavy for a paint`
- `this screen did not finish inside 200ms — a loop that never ends, or work too heavy for a paint`

The existing `screen-errors` suite, which pins those sentences, is **untouched and passing**.

## Corrected calibration

The earlier spike claimed a legitimate render costs ~11 interrupts. Measured on this branch, that number is wrong:

| what | measured |
| --- | --- |
| 60-row screen, boot | **1 interrupt** |
| 60-row screen, re-paint | **0 interrupts** |
| tight loop reaching 650 | 60–125 ms |
| tight loop reaching 7,000 | ~2.2 s |

QuickJS comes up for air roughly every 10,000 bytecode operations, which is why real work is measured in single interrupts.

**The constants stand unchanged at 650 / 7,000**, because 650 lands where the 200 ms op budget landed and 7,000 lands where the 2,000 ms boot budget landed. The correction means the op budget has **far more headroom over a legitimate render than the spike assumed** — three orders of magnitude, not sixty-fold. The test asserts bounds of 100 and 10 as a ratchet: a legitimate render climbing into the hundreds means the counts want re-measuring, not raising.

## Proof it can fail

Two sabotages, both restored:

1. Removed `runtime.setInterruptHandler(limit.handler)` → the run wedged past 150s with zero test results. vitest's own timeout cannot interrupt a synchronous QuickJS burn, so the handler is the only thing containing it.
2. Swapped `opsBudget` for `wallClockBudget` inside the frozen-clock test → wedged past 120s. That is exactly the workerd failure reproduced locally.

The frozen-clock test is the one that encodes the finding: `Date.now` is pinned to a constant and `opsBudget` still contains the loop.

## Constraints honoured

- The singlefile import stays a **literal, statically analysable specifier**, in source and in `dist` — `packages/ui` depends on a bundler inlining it.
- `budget.ts` lives in `contract/` and imports only a TYPE from `quickjs-emscripten-core`. Portability gate **Leg D** is green: `portability-gate: ok — @vendoai/apps/contract bundles for a browser target (no node built-ins)`.
- No changeset here; the driving session adds one for the whole stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Budgets screen execution with a `ScreenBudget` that can count QuickJS interrupts when the venue freezes the clock; wall-clock remains the default. Previously we used 200ms/op and 2000ms/boot deadlines; on Cloudflare Workers `workerd` freezes the clock during synchronous work, so deadlines never fired.

- Introduces `ScreenBudget` with `wallClockBudget({ opMs?, bootMs? })` (default) and `opsBudget({ opInterrupts?, bootInterrupts? })`; calibrates and exports `OP_INTERRUPT_BUDGET = 650`, `BOOT_INTERRUPT_BUDGET = 7000`.
- `turn()` installs the limit’s handler; `drain()` checks `limit.spent()`; budget failures raise `ScreenError("budget", limit.message)`.
- Adds `warmScreenEngine(variant?)` and memoizes engines by variant identity; keeps a literal import of `@jitl/quickjs-singlefile-browser-release-sync` and exports `ScreenEngineVariant`.
- Accepts optional `budget` in `BootScreenOptions`, re-exports budget APIs from `index.ts`; contract stays browser-safe with only type imports from `quickjs-emscripten-core`.
- Tests assert Node refusal sentences are unchanged, reproduce the frozen-clock case, and pin calibration headroom.

**Rollout**
- No change for Node consumers; default `wallClockBudget` preserves behavior.
- Required on `workerd`: pass `opsBudget()` when booting screens.
- Bundling assumptions for `@vendoai/ui` remain intact.

<sup>Written for commit 22fd3d19fcc1bb9f682348cb3eeece239cadfbc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

