### PR TITLE
feat(apps)!: compile screens strict, and refuse the two constructs the toolchains disagree on

### DIFF
--- a/packages/apps/src/server/checking/component-screen.ts
+++ b/packages/apps/src/server/checking/component-screen.ts
@@ -259,6 +259,12 @@ const literalValue = (node: Node): { ok: true; value: unknown } | { ok: false } 
 
 const ALLOWED_IMPORTS: readonly string[] = ["react", SCREEN_MODULE];
 
+/** The two constructs the toolchains do not agree on. Read off the AUTHOR's
+ *  source rather than the module form, because that is the last place either one
+ *  is still visible: the transform is exactly what disagrees about them. */
+const NAMESPACE_BLOCK = /^[ \t]*(?:export[ \t]+)?(?:declare[ \t]+)?namespace[ \t]+([A-Za-z_$][\w$.]*)[ \t]*\{/mu;
+const STATIC_BLOCK = /(?:^|[;{}\s])static[ \t]*\{/mu;
+
 /** The import block is not `tools` USAGE: `import { tools } from "@vendo/screen"`
  *  puts the name in expression position (a `{` to its left), which the shipped
  *  literal-access scan reads as aliasing. Blanked with offsets preserved, so that
@@ -338,7 +344,7 @@ interface ScanResult {
   queryPlan: QueryPlanEntry[];
 }
 
-const scan = (moduleSource: string, tools: readonly HostToolInfo[]): ScanResult => {
+const scan = (moduleSource: string, source: string, tools: readonly HostToolInfo[]): ScanResult => {
   const issues: ComponentScreenIssue[] = [];
   const queryPlan: QueryPlanEntry[] = [];
   let program: Program;
@@ -355,7 +361,16 @@ const scan = (moduleSource: string, tools: readonly HostToolInfo[]): ScanResult 
   const readable = tools.filter((tool) => !isMutatingTool(tool)).map((tool) => tool.name);
   const byName = new Map(tools.map((tool) => [tool.name, tool]));
 
-  // (a) the import surface. An UNUSED disallowed import is elided by the
+  // (a) the two constructs whose compiled form depends on which toolchain ran.
+  const namespaced = NAMESPACE_BLOCK.exec(source);
+  if (namespaced !== null) {
+    issues.push(issue("namespace", `declares a namespace block (namespace ${namespaced[1]} { … }) — a screen is compiled by a types-only transform, which has no output form for one, so this file would compile in one venue and not in another. A screen is ONE file and needs no inner scope: write plain top-level consts, functions and types instead.`));
+  }
+  if (STATIC_BLOCK.test(source)) {
+    issues.push(issue("static-block", `writes a class static initializer block (static { … }) — a screen is compiled by a types-only transform, which emits the class as written, so this block reaches the screen VM unlowered and the same file does not run the same in every venue. Do that work in the component body, or in a plain top-level const.`));
+  }
+
+  // (b) the import surface. An UNUSED disallowed import is elided by the
   // transform before it reaches here — and it cannot affect the screen either,
   // since nothing requires it; the type check still sees it in the source.
   for (const statement of program.body) {
@@ -521,7 +536,7 @@ export async function checkComponentScreen(opts: ComponentScreenOptions): Promis
   }
   const compiled = forms.engine;
 
-  const scanned = scan(forms.scan, opts.hostTools);
+  const scanned = scan(forms.scan, opts.source, opts.hostTools);
   if (scanned.issues.length > 0) return refuse(scanned.issues, { compiled });
   const queryPlan = scanned.queryPlan;
 

--- a/packages/apps/src/server/checking/component-screen.ts
+++ b/packages/apps/src/server/checking/component-screen.ts
@@ -259,10 +259,25 @@ const literalValue = (node: Node): { ok: true; value: unknown } | { ok: false } 
 
 const ALLOWED_IMPORTS: readonly string[] = ["react", SCREEN_MODULE];
 
-/** The two constructs the toolchains do not agree on. Read off the AUTHOR's
- *  source rather than the module form, because that is the last place either one
- *  is still visible: the transform is exactly what disagrees about them. */
-const NAMESPACE_BLOCK = /^[ \t]*(?:export[ \t]+)?(?:declare[ \t]+)?namespace[ \t]+([A-Za-z_$][\w$.]*)[ \t]*\{/mu;
+/**
+ * A `namespace` block, off the AUTHOR's source — the module form cannot answer
+ * this. esbuild lowers a namespace to an IIFE and a types-only transform has no
+ * output form for one at all, so by the time there is a parsed module the
+ * construct is gone either way.
+ *
+ * Text matching is therefore the only reading available, and it is written to
+ * fail CLOSED: `\s` on both sides so a brace on the next line still counts, and
+ * a non-identifier lookbehind rather than a line anchor so `const x = 1;
+ * namespace Foo {` is seen — those were misses, and a guard that misses admits
+ * the very screen it exists to catch. The residual is the other direction: the
+ * literal text `namespace X {` inside a string or template literal reads as the
+ * real thing. That costs a repair round on a screen nobody writes; a miss costs
+ * a screen that paints differently in two venues.
+ */
+const NAMESPACE_BLOCK = /(?<![\w$])namespace\s+([A-Za-z_$][\w$.]*)\s*\{/u;
+
+/** A class `static {}` initializer block, off the author's source for the same
+ *  reason. */
 const STATIC_BLOCK = /(?:^|[;{}\s])static[ \t]*\{/mu;
 
 /** The import block is not `tools` USAGE: `import { tools } from "@vendo/screen"`

--- a/packages/apps/src/server/checking/component-screen.ts
+++ b/packages/apps/src/server/checking/component-screen.ts
@@ -186,6 +186,14 @@ const childNodes = (node: Node): Node[] => {
 
 const FUNCTION_TYPES = new Set(["FunctionDeclaration", "FunctionExpression", "ArrowFunctionExpression"]);
 
+/** A class `static {}` block anywhere in the module — an AST question, because
+ *  `static {` is also ordinary prose: it turns up in strings, in comments and in
+ *  JSX text, and a screen that merely SAYS it is not a screen that DOES it. The
+ *  scan form is compiled to es2022 precisely so the block survives as a node to
+ *  find; at es2020 esbuild lowers it away and there is nothing left to ask. */
+const hasStaticBlock = (node: Node): boolean =>
+  node.type === "StaticBlock" || childNodes(node).some(hasStaticBlock);
+
 interface CallNode extends Node {
   callee: Node;
   arguments: Node[];
@@ -276,10 +284,6 @@ const ALLOWED_IMPORTS: readonly string[] = ["react", SCREEN_MODULE];
  */
 const NAMESPACE_BLOCK = /(?<![\w$])namespace\s+([A-Za-z_$][\w$.]*)\s*\{/u;
 
-/** A class `static {}` initializer block, off the author's source for the same
- *  reason. */
-const STATIC_BLOCK = /(?:^|[;{}\s])static[ \t]*\{/mu;
-
 /** The import block is not `tools` USAGE: `import { tools } from "@vendo/screen"`
  *  puts the name in expression position (a `{` to its left), which the shipped
  *  literal-access scan reads as aliasing. Blanked with offsets preserved, so that
@@ -364,9 +368,12 @@ const scan = (moduleSource: string, source: string, tools: readonly HostToolInfo
   const queryPlan: QueryPlanEntry[] = [];
   let program: Program;
   try {
-    // The input is esbuild's own ES2020 output, so the edition is pinned rather
-    // than "latest": the grammar a screen is admitted under must not move when
-    // the parser is upgraded (genui/expr.ts pins it for the same reason).
+    // The input is esbuild's own ES2022 output, and the edition is pinned to
+    // match rather than "latest": the grammar a screen is admitted under must
+    // not move when the parser is upgraded (genui/expr.ts pins it for the same
+    // reason). 2022 is also the edition that HAS `StaticBlock` — pinned lower,
+    // the parser would reject the block outright and the guard below could
+    // never name it.
     program = parse(moduleSource, { ecmaVersion: 2022, sourceType: "module" });
   } catch (error) {
     return { issues: [issue("compile", `does not parse as a module: ${error instanceof Error ? error.message : String(error)}`)], queryPlan };
@@ -381,7 +388,7 @@ const scan = (moduleSource: string, source: string, tools: readonly HostToolInfo
   if (namespaced !== null) {
     issues.push(issue("namespace", `declares a namespace block (namespace ${namespaced[1]} { … }) — a screen is compiled by a types-only transform, which has no output form for one, so this file would compile in one venue and not in another. A screen is ONE file and needs no inner scope: write plain top-level consts, functions and types instead.`));
   }
-  if (STATIC_BLOCK.test(source)) {
+  if (hasStaticBlock(program)) {
     issues.push(issue("static-block", `writes a class static initializer block (static { … }) — a screen is compiled by a types-only transform, which emits the class as written, so this block reaches the screen VM unlowered and the same file does not run the same in every venue. Do that work in the component body, or in a plain top-level const.`));
   }
 

--- a/packages/apps/src/server/checking/component-screen.ts
+++ b/packages/apps/src/server/checking/component-screen.ts
@@ -186,6 +186,24 @@ const childNodes = (node: Node): Node[] => {
 
 const FUNCTION_TYPES = new Set(["FunctionDeclaration", "FunctionExpression", "ArrowFunctionExpression"]);
 
+/**
+ * What owns the code inside it, for the render-time question alone: every
+ * function, plus an INSTANCE field initializer.
+ *
+ * The distinction is when the body runs. An instance field runs on `new`, so
+ * its calls belong to whoever constructs the class — attributing them to the
+ * render that merely encloses the class declaration refuses a screen whose
+ * author did precisely what the refusal asks for. A STATIC field runs when the
+ * class definition itself is evaluated, which IS the render, so it stays
+ * attributed to the render and keeps earning `tool-at-render`.
+ *
+ * Kept apart from FUNCTION_TYPES on purpose: that set answers a different
+ * question — "could this node BE the component" — and must stay functions only.
+ */
+const ownsItsScope = (node: Node): boolean =>
+  FUNCTION_TYPES.has(node.type)
+  || (node.type === "PropertyDefinition" && (node as unknown as { static?: boolean }).static !== true);
+
 /** A class `static {}` block anywhere in the module — an AST question, because
  *  `static {` is also ordinary prose: it turns up in strings, in comments and in
  *  JSX text, and a screen that merely SAYS it is not a screen that DOES it. The
@@ -277,10 +295,19 @@ const ALLOWED_IMPORTS: readonly string[] = ["react", SCREEN_MODULE];
  * fail CLOSED: `\s` on both sides so a brace on the next line still counts, and
  * a non-identifier lookbehind rather than a line anchor so `const x = 1;
  * namespace Foo {` is seen — those were misses, and a guard that misses admits
- * the very screen it exists to catch. The residual is the other direction: the
- * literal text `namespace X {` inside a string or template literal reads as the
- * real thing. That costs a repair round on a screen nobody writes; a miss costs
- * a screen that paints differently in two venues.
+ * the very screen it exists to catch.
+ *
+ * The residual runs the other way, and it is the WHOLE of the author's file:
+ * this reads raw text, so the words `namespace X {` are refused wherever they
+ * appear — in a line comment, in a block comment, in a string, in a template
+ * literal, in JSX text. Nothing here strips any of those, and a screen that
+ * merely SAYS the construct is refused as if it declared one. That is the
+ * accepted price: unlike the `static {}` guard, no AST can answer this, because
+ * every toolchain erases the construct before there is a tree to read. A false
+ * refusal costs one repair round on a screen nobody writes; a miss ships a
+ * screen that paints differently in two venues. `scan-fidelity.test.ts` pins
+ * this behaviour deliberately, so that closing it cannot silently reopen the
+ * `namespace Foo\n{` miss.
  */
 const NAMESPACE_BLOCK = /(?<![\w$])namespace\s+([A-Za-z_$][\w$.]*)\s*\{/u;
 
@@ -428,7 +455,7 @@ const scan = (moduleSource: string, source: string, tools: readonly HostToolInfo
         }
       }
     }
-    const inner = FUNCTION_TYPES.has(node.type) ? node : nearestFunction;
+    const inner = ownsItsScope(node) ? node : nearestFunction;
     for (const child of childNodes(node)) visit(child, inner);
   };
   visit(program, undefined);

--- a/packages/apps/src/server/checking/toolchain.ts
+++ b/packages/apps/src/server/checking/toolchain.ts
@@ -110,6 +110,13 @@ export class ScreenToolchainUnavailable extends Error {}
  *  portability gate's field failure). Same pattern as smoke-render.ts. */
 let ESBUILD_SPECIFIER = "esbuild";
 
+/** Strict mode is SPECIFIED on the engine form, not inherited: CommonJS output
+ *  is sloppy by default, an ES module is strict already, and the two differ on
+ *  frozen writes, `this` in a plain call and undeclared assignment. Without the
+ *  banner a screen could pass here and throw wherever a types-only transform
+ *  runs it. The scan form is the module form and needs nothing. */
+const STRICT_BANNER = '"use strict";';
+
 type ScreenForm = "engine" | "scan";
 
 type Transform = (source: string, form: ScreenForm) => string;
@@ -120,7 +127,7 @@ const esbuildTransform: Promise<Transform | undefined> = (async () => {
   try {
     const esbuild = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ ESBUILD_SPECIFIER) as typeof import("esbuild");
     return (source, form) => esbuild.transformSync(source, form === "engine"
-      ? { loader: "tsx", format: "cjs", target: "es2020", jsx: "automatic" }
+      ? { loader: "tsx", format: "cjs", target: "es2020", jsx: "automatic", banner: STRICT_BANNER }
       : { loader: "tsx", format: "esm", target: "es2020" }).code;
   } catch {
     return undefined;

--- a/packages/apps/src/server/checking/toolchain.ts
+++ b/packages/apps/src/server/checking/toolchain.ts
@@ -44,6 +44,16 @@ import type { ComponentScreenIssue } from "./component-screen.js";
  *   default export are still visible (CJS renames every import into a namespace
  *   access), with the CLASSIC transform, so the compiler's own
  *   `react/jsx-runtime` import does not read as an import the author wrote.
+ *
+ * Their TARGETS are deliberately different, and the difference is the point.
+ * The engine form stays at es2020 because it is EXECUTED, inside QuickJS, and
+ * lowering is what keeps modern syntax from reaching a VM that may not
+ * implement it. The scan form is only ever READ, so it is raised to es2022 to
+ * lower as LITTLE as possible: a construct that was lowered away is a construct
+ * the scan cannot see, and a types-only transform — the Workers scan form —
+ * lowers nothing at all. The closer this form sits to that one, the closer the
+ * two venues agree about the same screen. The class `static {}` guard is simply
+ * the first check that noticed.
  */
 export interface ScreenTransform {
   readonly engine: string;
@@ -128,7 +138,7 @@ const esbuildTransform: Promise<Transform | undefined> = (async () => {
     const esbuild = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ ESBUILD_SPECIFIER) as typeof import("esbuild");
     return (source, form) => esbuild.transformSync(source, form === "engine"
       ? { loader: "tsx", format: "cjs", target: "es2020", jsx: "automatic", banner: STRICT_BANNER }
-      : { loader: "tsx", format: "esm", target: "es2020" }).code;
+      : { loader: "tsx", format: "esm", target: "es2022" }).code;
   } catch {
     return undefined;
   }

--- a/packages/apps/tests/checking/scan-fidelity.test.ts
+++ b/packages/apps/tests/checking/scan-fidelity.test.ts
@@ -20,9 +20,10 @@ import {
   checkComponentScreen,
   type ComponentScreenCheck,
 } from "../../src/server/checking/component-screen.js";
+import type { HostToolInfo } from "../../src/server/checking/deps.js";
 import { nodeToolchain } from "../../src/server/checking/toolchain.js";
 
-const catalog = ["Stack", "Text"];
+const catalog = ["Stack", "Text", "Button"];
 
 /** The refusal, to the byte — every namespace shape names the same construct, so
  *  every one of them earns the same sentence. */
@@ -31,8 +32,21 @@ const NAMESPACE_MESSAGE = "declares a namespace block (namespace Format { … })
   + " one venue and not in another. A screen is ONE file and needs no inner scope: write"
   + " plain top-level consts, functions and types instead.";
 
-const check = (source: string): Promise<ComponentScreenCheck> =>
-  checkComponentScreen({ source, hostTools: [], catalog, runQuery: async () => ({}) });
+const check = (source: string, hostTools: readonly HostToolInfo[] = []): Promise<ComponentScreenCheck> =>
+  checkComponentScreen({ source, hostTools, catalog, runQuery: async () => ({}) });
+
+/** One WRITE, for the question of when a tool call actually fires. */
+const writeTool: readonly HostToolInfo[] = [{
+  name: "archive_invoice",
+  description: "Archive one invoice",
+  risk: "destructive",
+  inputSchema: {
+    type: "object",
+    properties: { id: { type: "string" } },
+    required: ["id"],
+    additionalProperties: false,
+  },
+}];
 
 const NAMESPACE = `import { Text } from "@vendo/screen";
 
@@ -188,6 +202,84 @@ export default function Screen() {
 }
 `;
 
+/**
+ * WHEN a class field initializer runs, which is the thing raising the scan form
+ * to es2022 made visible. The body runs on `new`, so the tool call belongs to
+ * whoever constructs the class — here, the click handler. This screen does
+ * exactly what the tool-at-render refusal tells authors to do, so refusing it
+ * would be the gate contradicting its own instructions.
+ */
+const FIELD_CONSTRUCTED_IN_HANDLER = `import { Button, Stack, tools } from "@vendo/screen";
+
+class Archive {
+  result = tools.archive_invoice({ id: "inv_1" });
+}
+
+export default function Screen() {
+  return (
+    <Stack gap={4}>
+      <Button label="Archive" onClick={() => { const run = new Archive(); void run.result; }} />
+    </Stack>
+  );
+}
+`;
+
+/** A STATIC field is the other case, and it inverts: its initializer runs when
+ *  the class DEFINITION is evaluated, which is the render — nobody has to
+ *  construct anything. So this one really does fire with nobody clicking. */
+const STATIC_FIELD_CALLS_TOOL = `import { Button, Stack, tools } from "@vendo/screen";
+
+class Archive {
+  static result = tools.archive_invoice({ id: "inv_1" });
+}
+
+export default function Screen() {
+  return (
+    <Stack gap={4}>
+      <Button label="Archive" onClick={() => void Archive.result} />
+    </Stack>
+  );
+}
+`;
+
+/** The same class, constructed while the component renders — so the write DOES
+ *  fire with nobody clicking. The engine is what catches this, and its sentence
+ *  is the one this screen has always earned. */
+const FIELD_CONSTRUCTED_AT_RENDER = `import { Button, Stack, tools } from "@vendo/screen";
+
+class Archive {
+  result = tools.archive_invoice({ id: "inv_1" });
+}
+
+export default function Screen() {
+  const run = new Archive();
+  return (
+    <Stack gap={4}>
+      <Button label="Archive" onClick={() => void run.result} />
+    </Stack>
+  );
+}
+`;
+
+/** The namespace guard reads raw text, so it answers on prose too. Pinned on
+ *  purpose — see the note below the assertions. */
+const NAMESPACE_IN_COMMENT = `import { Text } from "@vendo/screen";
+
+// namespace Format { — how NOT to write a screen
+export default function Screen() {
+  return <Text text="hi" />;
+}
+`;
+
+const NAMESPACE_IN_STRING = `import { Text } from "@vendo/screen";
+
+const advice = "namespace Format { is not allowed here";
+
+export default function Screen() {
+  return <Text text={advice} />;
+}
+`;
+
 beforeAll(async () => {
   await warmScreenEngine();
 });
@@ -254,6 +346,62 @@ describe("a construct the two toolchains would not agree on", () => {
 
     expect(result.issues).toEqual([]);
     expect(result.ok).toBe(true);
+  });
+});
+
+/**
+ * Raising the scan form to es2022 stopped esbuild lowering class fields into the
+ * constructor, which made WHEN a field initializer runs a question this scan can
+ * see for the first time. It must answer it the way the engine always has.
+ */
+describe("a tool call in a class field initializer", () => {
+  it("is admitted when the class is constructed in a handler — the author did what the gate asks", async () => {
+    const result = await check(FIELD_CONSTRUCTED_IN_HANDLER, writeTool);
+
+    expect(result.issues).toEqual([]);
+    expect(result.ok).toBe(true);
+  });
+
+  it("still earns tool-at-render when the field is STATIC — that one runs at render", async () => {
+    const result = await check(STATIC_FIELD_CALLS_TOOL, writeTool);
+
+    expect(result.ok).toBe(false);
+    expect(result.issues.map(({ code }) => code)).toEqual(["tool-at-render"]);
+  });
+
+  it("is refused by the ENGINE when the class is constructed while rendering", async () => {
+    const result = await check(FIELD_CONSTRUCTED_AT_RENDER, writeTool);
+
+    expect(result.ok).toBe(false);
+    expect(result.issues.map(({ code }) => code)).toEqual(["run"]);
+    expect(result.issues[0]?.message).toContain("tools.archive_invoice() cannot run while the screen");
+  });
+});
+
+/**
+ * ACCEPTED RESIDUAL, pinned on purpose.
+ *
+ * The namespace guard matches raw text and strips nothing, so it refuses the
+ * words `namespace X {` in a comment or a string as if they declared one. Both
+ * assertions below are WRONG refusals, and they are correct to assert: the
+ * regex was deliberately widened to close a fail-open miss (`namespace Foo\n{`
+ * passed the entire gauntlet), and unlike `static {}` there is no AST route —
+ * every toolchain erases a namespace before there is a tree to read.
+ *
+ * So this is a ratchet. Anyone "fixing" these two tests reopens that miss, and
+ * these assertions are the tripwire that makes them notice.
+ */
+describe("the namespace guard's accepted false positives", () => {
+  it("refuses the construct written in a line comment", async () => {
+    const result = await check(NAMESPACE_IN_COMMENT);
+
+    expect(result.issues).toEqual([{ code: "namespace", message: NAMESPACE_MESSAGE }]);
+  });
+
+  it("refuses the construct written inside a string", async () => {
+    const result = await check(NAMESPACE_IN_STRING);
+
+    expect(result.issues).toEqual([{ code: "namespace", message: NAMESPACE_MESSAGE }]);
   });
 });
 

--- a/packages/apps/tests/checking/scan-fidelity.test.ts
+++ b/packages/apps/tests/checking/scan-fidelity.test.ts
@@ -24,6 +24,13 @@ import { nodeToolchain } from "../../src/server/checking/toolchain.js";
 
 const catalog = ["Stack", "Text"];
 
+/** The refusal, to the byte — every namespace shape names the same construct, so
+ *  every one of them earns the same sentence. */
+const NAMESPACE_MESSAGE = "declares a namespace block (namespace Format { … }) — a screen is compiled by a"
+  + " types-only transform, which has no output form for one, so this file would compile in"
+  + " one venue and not in another. A screen is ONE file and needs no inner scope: write"
+  + " plain top-level consts, functions and types instead.";
+
 const check = (source: string): Promise<ComponentScreenCheck> =>
   checkComponentScreen({ source, hostTools: [], catalog, runQuery: async () => ({}) });
 
@@ -65,6 +72,30 @@ export default function Screen() {
 }
 `;
 
+/** The brace on the next line, and the block not at the start of one: the two
+ *  shapes a line-anchored, space-only match let through. A guard that misses
+ *  admits exactly the screen it exists to catch. */
+const NAMESPACE_WRAPPED_BRACE = `import { Text } from "@vendo/screen";
+
+namespace Format
+{
+  export const dash = "—";
+}
+
+export default function Screen() {
+  return <Text text={Format.dash} />;
+}
+`;
+
+const NAMESPACE_MID_LINE = `import { Text } from "@vendo/screen";
+
+const gap = 4; namespace Format { export const dash = "—"; }
+
+export default function Screen() {
+  return <Text text={Format.dash} gap={gap} />;
+}
+`;
+
 /** `static` as a property and as a method — neither is an initializer block, and
  *  neither may be refused. */
 const STATIC_MEMBERS = `import { Text } from "@vendo/screen";
@@ -90,13 +121,21 @@ describe("a construct the two toolchains would not agree on", () => {
     const result = await check(NAMESPACE);
 
     expect(result.ok).toBe(false);
-    expect(result.issues).toEqual([{
-      code: "namespace",
-      message: "declares a namespace block (namespace Format { … }) — a screen is compiled by a"
-        + " types-only transform, which has no output form for one, so this file would compile in"
-        + " one venue and not in another. A screen is ONE file and needs no inner scope: write"
-        + " plain top-level consts, functions and types instead.",
-    }]);
+    expect(result.issues).toEqual([{ code: "namespace", message: NAMESPACE_MESSAGE }]);
+  });
+
+  it("sees a namespace whose brace is on the next line", async () => {
+    const result = await check(NAMESPACE_WRAPPED_BRACE);
+
+    expect(result.issues).toEqual([{ code: "namespace", message: NAMESPACE_MESSAGE }]);
+    expect(result.ok).toBe(false);
+  });
+
+  it("sees a namespace that does not start its line", async () => {
+    const result = await check(NAMESPACE_MID_LINE);
+
+    expect(result.issues).toEqual([{ code: "namespace", message: NAMESPACE_MESSAGE }]);
+    expect(result.ok).toBe(false);
   });
 
   it("refuses a class static initializer block, and says where that work goes", async () => {

--- a/packages/apps/tests/checking/scan-fidelity.test.ts
+++ b/packages/apps/tests/checking/scan-fidelity.test.ts
@@ -1,0 +1,138 @@
+/**
+ * The two fidelity guards — the screens this gauntlet refuses because the ANSWER
+ * would otherwise depend on which toolchain ran.
+ *
+ * A screen is compiled by one toolchain today and could be compiled by a
+ * types-only one tomorrow, so a construct the two translate differently is a
+ * screen that passes here and paints something else there. Two of them exist —
+ * a `namespace` block and a class `static {}` initializer — and the scan refuses
+ * both rather than admitting a venue-dependent screen.
+ *
+ * The third test is the other half of the same promise: the engine form is
+ * compiled with a `"use strict";` banner, so strict mode is SPECIFIED rather
+ * than inherited from whatever the compiler happened to emit. A screen that only
+ * works in sloppy mode is now refused instead of quietly working here and
+ * throwing somewhere else.
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+import { warmScreenEngine } from "../../src/contract/index.js";
+import {
+  checkComponentScreen,
+  type ComponentScreenCheck,
+} from "../../src/server/checking/component-screen.js";
+import { nodeToolchain } from "../../src/server/checking/toolchain.js";
+
+const catalog = ["Stack", "Text"];
+
+const check = (source: string): Promise<ComponentScreenCheck> =>
+  checkComponentScreen({ source, hostTools: [], catalog, runQuery: async () => ({}) });
+
+const NAMESPACE = `import { Text } from "@vendo/screen";
+
+namespace Format {
+  export const dash = "—";
+}
+
+export default function Screen() {
+  return <Text text={Format.dash} />;
+}
+`;
+
+const STATIC_BLOCK = `import { Text } from "@vendo/screen";
+
+class Labels {
+  static heading: string;
+  static {
+    Labels.heading = "Pending";
+  }
+}
+
+export default function Screen() {
+  return <Text text={Labels.heading} />;
+}
+`;
+
+/** A screen that only works in SLOPPY mode: the write to a frozen object is
+ *  silently dropped there and a TypeError here. */
+const SLOPPY = `import { Text } from "@vendo/screen";
+
+const settings: { label: string } = { label: "before" };
+Object.freeze(settings);
+
+export default function Screen() {
+  settings.label = "after";
+  return <Text text={settings.label} />;
+}
+`;
+
+/** `static` as a property and as a method — neither is an initializer block, and
+ *  neither may be refused. */
+const STATIC_MEMBERS = `import { Text } from "@vendo/screen";
+
+class Labels {
+  static heading = { title: "Pending" };
+  static caption() {
+    return "nothing is waiting";
+  }
+}
+
+export default function Screen() {
+  return <Text text={Labels.heading.title + Labels.caption()} />;
+}
+`;
+
+beforeAll(async () => {
+  await warmScreenEngine();
+});
+
+describe("a construct the two toolchains would not agree on", () => {
+  it("refuses a namespace block, and says what to write instead", async () => {
+    const result = await check(NAMESPACE);
+
+    expect(result.ok).toBe(false);
+    expect(result.issues).toEqual([{
+      code: "namespace",
+      message: "declares a namespace block (namespace Format { … }) — a screen is compiled by a"
+        + " types-only transform, which has no output form for one, so this file would compile in"
+        + " one venue and not in another. A screen is ONE file and needs no inner scope: write"
+        + " plain top-level consts, functions and types instead.",
+    }]);
+  });
+
+  it("refuses a class static initializer block, and says where that work goes", async () => {
+    const result = await check(STATIC_BLOCK);
+
+    expect(result.ok).toBe(false);
+    expect(result.issues).toEqual([{
+      code: "static-block",
+      message: "writes a class static initializer block (static { … }) — a screen is compiled by a"
+        + " types-only transform, which emits the class as written, so this block reaches the screen"
+        + " VM unlowered and the same file does not run the same in every venue. Do that work in the"
+        + " component body, or in a plain top-level const.",
+    }]);
+  });
+
+  it("admits a static property and a static method — only the BLOCK is the problem", async () => {
+    const result = await check(STATIC_MEMBERS);
+
+    expect(result.issues).toEqual([]);
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("the engine form", () => {
+  it("is compiled strict, so a screen that needs sloppy mode is refused rather than run", async () => {
+    const result = await check(SLOPPY);
+
+    expect(result.ok).toBe(false);
+    expect(result.issues.map(({ code }) => code)).toEqual(["run"]);
+    expect(result.issues[0]?.message).toContain("'label' is read-only");
+  });
+
+  it("carries the strict-mode banner; the scan form is a module and is strict already", async () => {
+    const forms = await nodeToolchain().transform(SLOPPY);
+
+    expect(forms.engine.startsWith('"use strict";')).toBe(true);
+    expect(forms.scan).not.toContain('"use strict";');
+  });
+});

--- a/packages/apps/tests/checking/scan-fidelity.test.ts
+++ b/packages/apps/tests/checking/scan-fidelity.test.ts
@@ -45,6 +45,13 @@ export default function Screen() {
 }
 `;
 
+/** The refusal, to the byte — every shape of the block names the same construct,
+ *  so every one of them earns the same sentence. */
+const STATIC_BLOCK_MESSAGE = "writes a class static initializer block (static { … }) — a screen is compiled by a"
+  + " types-only transform, which emits the class as written, so this block reaches the screen"
+  + " VM unlowered and the same file does not run the same in every venue. Do that work in the"
+  + " component body, or in a plain top-level const.";
+
 const STATIC_BLOCK = `import { Text } from "@vendo/screen";
 
 class Labels {
@@ -56,6 +63,91 @@ class Labels {
 
 export default function Screen() {
   return <Text text={Labels.heading} />;
+}
+`;
+
+/** An empty block is still a block, and the brace still counts on the next
+ *  line — the shape a `static[ \\t]*\\{` text match could not see. */
+const STATIC_BLOCK_EMPTY = `import { Text } from "@vendo/screen";
+
+class Labels {
+  static {}
+}
+
+export default function Screen() {
+  return <Text text={Labels.name} />;
+}
+`;
+
+const STATIC_BLOCK_SPACED = `import { Text } from "@vendo/screen";
+
+class Labels {
+  static { }
+}
+
+export default function Screen() {
+  return <Text text={Labels.name} />;
+}
+`;
+
+const STATIC_BLOCK_WRAPPED_BRACE = `import { Text } from "@vendo/screen";
+
+class Labels {
+  static heading: string;
+  static
+  {
+    Labels.heading = "Pending";
+  }
+}
+
+export default function Screen() {
+  return <Text text={Labels.heading} />;
+}
+`;
+
+/** Every shape of `static` MEMBER that is not an initializer block. A text match
+ *  had to guess at these; the AST does not. */
+const STATIC_MEMBERS = `import { Text } from "@vendo/screen";
+
+class Labels {
+  static heading = { title: "Pending" };
+  static caption() {
+    return "nothing is waiting";
+  }
+  static get subtitle() {
+    return "up next";
+  }
+  static async load() {
+    return "loaded";
+  }
+}
+
+export default function Screen() {
+  return <Text text={Labels.heading.title + Labels.caption() + Labels.subtitle} />;
+}
+`;
+
+/**
+ * The construct as PROSE, in the five places a raw-text match mistook for the
+ * real thing. The JSX one is the wrong refusal that mattered most: the screen
+ * says the word "static" to a person, and the old guard answered by telling the
+ * author to move a class initializer block their file does not contain.
+ */
+const STATIC_AS_PROSE = `import { Stack, Text } from "@vendo/screen";
+
+// keep it static { and simple
+/* a block comment mentioning static { too */
+const plain = "a string with static { inside";
+const templated = \`a template with static { inside\`;
+
+export default function Screen() {
+  const v = 12;
+  return (
+    <Stack gap={4}>
+      <Text text={plain + templated} />
+      <Stack>Balance is static {v}</Stack>
+    </Stack>
+  );
 }
 `;
 
@@ -96,22 +188,6 @@ export default function Screen() {
 }
 `;
 
-/** `static` as a property and as a method — neither is an initializer block, and
- *  neither may be refused. */
-const STATIC_MEMBERS = `import { Text } from "@vendo/screen";
-
-class Labels {
-  static heading = { title: "Pending" };
-  static caption() {
-    return "nothing is waiting";
-  }
-}
-
-export default function Screen() {
-  return <Text text={Labels.heading.title + Labels.caption()} />;
-}
-`;
-
 beforeAll(async () => {
   await warmScreenEngine();
 });
@@ -142,17 +218,39 @@ describe("a construct the two toolchains would not agree on", () => {
     const result = await check(STATIC_BLOCK);
 
     expect(result.ok).toBe(false);
-    expect(result.issues).toEqual([{
-      code: "static-block",
-      message: "writes a class static initializer block (static { … }) — a screen is compiled by a"
-        + " types-only transform, which emits the class as written, so this block reaches the screen"
-        + " VM unlowered and the same file does not run the same in every venue. Do that work in the"
-        + " component body, or in a plain top-level const.",
-    }]);
+    expect(result.issues).toEqual([{ code: "static-block", message: STATIC_BLOCK_MESSAGE }]);
   });
 
-  it("admits a static property and a static method — only the BLOCK is the problem", async () => {
+  it("sees an empty static block", async () => {
+    const result = await check(STATIC_BLOCK_EMPTY);
+
+    expect(result.issues).toEqual([{ code: "static-block", message: STATIC_BLOCK_MESSAGE }]);
+    expect(result.ok).toBe(false);
+  });
+
+  it("sees a static block that holds nothing but a space", async () => {
+    const result = await check(STATIC_BLOCK_SPACED);
+
+    expect(result.issues).toEqual([{ code: "static-block", message: STATIC_BLOCK_MESSAGE }]);
+    expect(result.ok).toBe(false);
+  });
+
+  it("sees a static block whose brace is on the next line", async () => {
+    const result = await check(STATIC_BLOCK_WRAPPED_BRACE);
+
+    expect(result.issues).toEqual([{ code: "static-block", message: STATIC_BLOCK_MESSAGE }]);
+    expect(result.ok).toBe(false);
+  });
+
+  it("admits every static MEMBER — property, method, getter, async method", async () => {
     const result = await check(STATIC_MEMBERS);
+
+    expect(result.issues).toEqual([]);
+    expect(result.ok).toBe(true);
+  });
+
+  it("admits `static {` written as PROSE — in a string, both comments, a template, and as JSX text", async () => {
+    const result = await check(STATIC_AS_PROSE);
 
     expect(result.issues).toEqual([]);
     expect(result.ok).toBe(true);

--- a/packages/apps/tests/contract/genui/component/screen-fixture.test-util.ts
+++ b/packages/apps/tests/contract/genui/component/screen-fixture.test-util.ts
@@ -2,10 +2,11 @@
  * One screen, compiled and booted the way the engine is fed in production.
  *
  * The compile flags are the gauntlet's own `engine` form
- * (server/checking/component-screen.ts): CommonJS, because the VM hosts a
- * `require` and no module loader, and the AUTOMATIC jsx transform, because the VM
- * publishes `react/jsx-runtime` and has no bare `React` global. A test that
- * hand-wrote the CJS would be asserting against a source shape nothing produces.
+ * (server/checking/toolchain.ts): CommonJS, because the VM hosts a `require` and
+ * no module loader, the AUTOMATIC jsx transform, because the VM publishes
+ * `react/jsx-runtime` and has no bare `React` global, and the `"use strict";`
+ * banner, because CommonJS output is otherwise sloppy. A test that hand-wrote the
+ * CJS would be asserting against a source shape nothing produces.
  */
 import { transformSync } from "esbuild";
 import {
@@ -15,7 +16,7 @@ import {
 } from "../../../../src/contract/genui/component/index.js";
 
 export const compileScreen = (tsx: string): string =>
-  transformSync(tsx, { loader: "tsx", format: "cjs", target: "es2020", jsx: "automatic" }).code;
+  transformSync(tsx, { loader: "tsx", format: "cjs", target: "es2020", jsx: "automatic", banner: '"use strict";' }).code;
 
 /** The Kit names a host surface holds, as the engine receives them. */
 export const CATALOG: readonly string[] = [


### PR DESCRIPTION
Stacked on #1231 (`yousefh409/edge-toolchain-s1-seam`).

Two fidelity guards, so the Node toolchain and a future edge toolchain cannot silently disagree about the same screen.

**Strict mode is now specified on both paths.** The engine form is compiled with a `"use strict";` banner. esbuild's CommonJS output is sloppy-mode; a types-only (sucrase) transform emits an ES module, which is strict. The two differ on frozen writes, `this` in a plain call and undeclared assignment — three ways the same screen could pass here and throw there. The scan form is the module form and needed nothing.

**Two constructs are refused.** A fidelity spike over 66 screens found sucrase silently mistranslates exactly two things today's gauntlet happily admits:

- `namespace X { … }` — a types-only transform has no output form for one, so the file compiles in one venue and not in another.
- a class `static { … }` initializer block — a types-only transform emits the class as written, so the block reaches the screen VM unlowered.

Rather than accept a venue-dependent screen, the scan refuses both, with a repair message that says what to write instead.

### The scan form was lowering the construct away

The static-block guard first shipped as a raw-text match, and it was wrong in both directions. It answered on prose — `static {` inside a string, either kind of comment, a template literal, or JSX text all read as the real construct, so `<p>Balance is static {v}</p>` was refused and then told the author to move a class initializer block their file does not contain. And it missed `static\n{`, which is the direction that actually costs something: that screen passed the entire gauntlet.

An AST answers both at once — but only if the node is still there to find, and it was not. The scan form was compiled at `target: "es2020"`, where esbuild lowers a static block to a `__publicField(...)` call plus a bare top-level assignment, indistinguishable from ordinary class-field lowering. Verified directly against `nodeToolchain().transform`: the es2020 scan form contained no `static {` text and its AST contained no `StaticBlock` node.

So the **scan form moves to `es2022`**, the block survives as a `StaticBlock` node, and the guard reads it off the AST. acorn's `ecmaVersion` was already pinned at `2022` — the edition that has `StaticBlock` — so no parser change was needed; the pin is now documented as load-bearing rather than incidental.

**The engine form deliberately stays at `es2020`.** It is the form that is EXECUTED, inside QuickJS, and lowering is exactly what keeps modern syntax away from a VM that may not implement it. The scan form is only ever READ, so it should lower as little as possible. The two targets are now different on purpose, and the reason is recorded in `ScreenTransform`'s doc comment.

This is not a static-block workaround — it narrows Node/Workers scan divergence generally. A types-only transform lowers *nothing*, so every construct the scan form stops erasing is one more place the two venues see the same screen. The static-block guard is simply the first check that noticed.

### Blast radius: measured, and now zero

Eight constructs stop being lowered between es2020 and es2022 (verified with esbuild, not assumed): logical assignment (`||= &&= ??=`), class public instance fields, class public static fields, class private fields, class private methods, class static blocks, brand checks (`#x in obj`), and the RegExp `/d` flag. Top-level await additionally goes from a hard compile error to legal in the scan form — but the engine form still rejects it at es2020, and that transform runs first, so the screen is refused exactly as before.

Raising the target initially changed one answer, and **it was a new WRONG refusal, not a hole closing**. A class whose instance field calls a tool (`result = tools.archive_invoice({…})`), constructed inside `onClick`, went from `ok:true` to `tool-at-render` — but an instance field initializer runs on `new`, and the `new` is in the handler, so the call already fires on click. The refusal was prescribing what the author had already done. The genuinely dangerous shape (same class, `new` in the render body) was never fail-open at es2020 either: the engine refuses it with `tools.archive_invoice() cannot run while the screen renders`.

So an instance field initializer is now its own scope in the render-time walk. A **static** field is deliberately not — its initializer runs when the class definition is evaluated, which IS the render, so it keeps earning `tool-at-render` exactly as before. That second half was caught by re-measuring, not by reasoning: the first version of the fix treated every field alike and silently moved the static case off `tool-at-render`.

Re-measured across all eight constructs, every check inside `scan()` — import surface, `import()`, `require()`, all four `useQuery` refusals, unknown tool names, tools-at-render, aliased tool access, default-export — and all three class-field shapes: **es2020 and es2022 now give the same answer on all 22 probes. Zero divergence.**

No pre-existing test changed outcome. The full `packages/apps` suite is green at 1664 tests.

### One accepted residual, pinned as tests

The namespace guard reads raw text and strips nothing, so `namespace X {` written in a comment or a string is refused as if it were declared. Both cases are asserted in `scan-fidelity.test.ts` as wrong-but-accepted. That is deliberate: the regex was widened to close a fail-open miss (`namespace Foo\n{` passed the entire gauntlet), and unlike `static {}` there is no AST route, because every toolchain erases a namespace before there is a tree to read. The tests are a ratchet — anyone "fixing" the false positive reopens the miss, and these assertions are the tripwire.

**Breaking:** a screen that only worked in sloppy mode, or that uses either construct, is now refused at save time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)