### PR TITLE
feat(ui,apps,vendo,core): a parked press gets its answer — approval modal, refresh on resolution, animated landing

### DIFF
--- a/.changeset/a-parked-press-gets-its-answer.md
+++ b/.changeset/a-parked-press-gets-its-answer.md
@@ -1,0 +1,35 @@
+---
+"@vendoai/core": minor
+"@vendoai/apps": minor
+"@vendoai/vendo": minor
+"@vendoai/ui": minor
+---
+
+A parked press gets its answer: the approval modal, the refresh on resolution, and the animated landing.
+
+A guarded action pressed on a generated screen parked for approval and then
+dead-ended twice over: the ask had no UI anywhere on the page (only a badge
+count), and once someone approved it — over the wire, from the chat card — the
+action ran server-side while the screen sat on "Sending…" and stale numbers
+forever. The resumed call's outcome was simply discarded.
+
+Now the whole loop closes. The apps runtime persists what became of a parked
+call (`PARKED_CALL_OUTCOME_COLLECTION`, shared with the BYO lane so both write
+the same rows), `GET /approvals/:id` serves it — answering `pending` while the
+resumed call is still running, so the decide window reads as what it is — and
+the screen watches its own parked presses: on `executed` it re-reads its query
+plan and repaints backend truth; on `declined`/`expired` it re-reads too, so a
+screen whose own state latched "sending" re-arms instead of locking forever.
+
+The ask itself is a centered modal, mounted wherever screens mount (slot, chat
+card, workspace stage, BYO embed, remix): the ask at hero size, Approve/Deny,
+a designed in-flight state for the seconds the decision takes to run, and a
+queue so burst presses ask one question at a time. Esc closes without deciding
+— the pending notice on the pressed control is now pressable and re-raises the
+ask. `ApprovalResolution`'s pending arm may now omit `request` (the decide
+window has no ask left to show); consumers skeleton or fall back.
+
+Refresh repaints animate: an arriving row opens under a fading highlight, a
+leaving row collapses and returns its gap, and numeric leaves roll to their new
+figure — repaints only, never first paint, never streams, and never under
+`prefers-reduced-motion`.

--- a/packages/apps/src/server/persistence/approval-flow.ts
+++ b/packages/apps/src/server/persistence/approval-flow.ts
@@ -198,8 +198,15 @@ const subscribeApprovalDecisions = (
       try {
         // Contained: a failed resume must never roll back the approval (the
         // guard already swallows subscriber throws, but be explicit here so
-        // the record is always cleared).
-        if (approved) await config.tools.execute(parkedAction.call, parkedAction.ctx);
+        // the record is always cleared). The resume's ANSWER is persisted
+        // beside the effect — the screen that pressed the button is not on this
+        // call stack and learns what happened only by reading it back.
+        if (approved) {
+          const outcome = await config.tools.execute(parkedAction.call, parkedAction.ctx);
+          await parkedActions.resolve(parkedAction, { state: "executed", outcome });
+        } else {
+          await parkedActions.resolve(parkedAction, { state: "declined" });
+        }
       } finally {
         await parkedActions.remove(id);
       }

--- a/packages/apps/src/server/persistence/parked-action.ts
+++ b/packages/apps/src/server/persistence/parked-action.ts
@@ -1,4 +1,5 @@
 import {
+  PARKED_ACTION_COLLECTION,
   PARKED_CALL_OUTCOME_COLLECTION,
   type AppId,
   type ApprovalId,
@@ -56,7 +57,7 @@ export interface ParkedAction {
   ctx: RunContext;
 }
 
-const COLLECTION = "vendo_parked_action";
+const COLLECTION = PARKED_ACTION_COLLECTION;
 
 const parkedData = (record: VendoRecord): ParkedAction => record.data as ParkedAction;
 

--- a/packages/apps/src/server/persistence/parked-action.ts
+++ b/packages/apps/src/server/persistence/parked-action.ts
@@ -1,8 +1,11 @@
 import {
+  PARKED_CALL_OUTCOME_COLLECTION,
   type AppId,
   type ApprovalId,
+  type ParkedCallOutcome,
   type RunContext,
   type ToolCall,
+  type ToolOutcome,
   type VendoRecord,
 } from "@vendoai/core";
 import type { EngineOps } from "./engine.js";
@@ -29,6 +32,12 @@ import { listAllEngineRecords } from "./persistence.js";
  * Hygiene mirrors the egress/exposure stores: records live in their own
  * collection keyed by app id (a copy's fresh id has none) and are cleared with
  * the app on delete.
+ *
+ * The resume ANSWER outlives the parked record: the surface that pressed the
+ * button has long since had its `pending-approval` back, so what happened is
+ * persisted as a {@link ParkedCallOutcome} — the same row (and drawer) the BYO
+ * lane writes — and `GET /approvals/:id` serves it to the waiting screen. Without
+ * it a gated press sat on "waiting for approval" forever even once it had run.
  */
 export interface ParkedAction {
   /** The guard approval that gates this call. */
@@ -59,6 +68,13 @@ export interface ParkedActions {
   put(action: ParkedAction): Promise<void>;
   /** The action riding a specific guard approval id, or null if none. */
   byApproval(approvalId: ApprovalId): Promise<ParkedAction | null>;
+  /** Record what the decision did with the action, for the surface that parked
+   *  it to read back. "expired" is not in this lane's vocabulary: a TTL sweep
+   *  reaches the guard's deny path, which reports itself as a plain denial. */
+  resolve(
+    action: ParkedAction,
+    result: { state: "executed"; outcome: ToolOutcome } | { state: "declined" },
+  ): Promise<void>;
   /** Clear the parked action for one approval (its approval was decided, either way). */
   remove(approvalId: ApprovalId): Promise<void>;
   /** Delete every parked action for one app (app deletion cleanup). */
@@ -77,6 +93,19 @@ export const createParkedActions = (engine: EngineOps): ParkedActions => {
     async byApproval(approvalId) {
       const record = await engine.get(COLLECTION, approvalId);
       return record === null ? null : parkedData(record);
+    },
+    async resolve(action, result) {
+      const outcome: ParkedCallOutcome = {
+        approvalId: action.approvalId,
+        owner: action.owner,
+        ...result,
+        at: new Date().toISOString(),
+      };
+      await engine.put(PARKED_CALL_OUTCOME_COLLECTION, {
+        id: outcome.approvalId,
+        data: outcome,
+        refs: { subject: outcome.owner, state: outcome.state },
+      });
     },
     async remove(approvalId) {
       await engine.delete(COLLECTION, approvalId);

--- a/packages/core/src/engine-collections.ts
+++ b/packages/core/src/engine-collections.ts
@@ -32,7 +32,9 @@ export const ENGINE_COLLECTIONS = [
 
   // Generic-table collections the blocks own.
   "vendo_parked_call", // PARKED_COLLECTION, packages/vendo/src/byo-approvals.ts:47
-  "vendo_parked_call_outcome", // OUTCOME_COLLECTION, packages/vendo/src/byo-approvals.ts:48
+  // PARKED_CALL_OUTCOME_COLLECTION, packages/core/src/parked-outcome.ts — written
+  // by BOTH parked-call lanes (byo-approvals.ts, parked-action.ts), read by one.
+  "vendo_parked_call_outcome",
   // The next two, and guard:controls below, write rows carrying NEITHER a
   // subject ref NOR an app ref, and that is deliberate: they are HOST-LEVEL
   // CONFIG — the host's component registry, the pinned-baseline seed, the

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,6 +26,7 @@ export * from "./log.js";
 export * from "./meter-exhausted.js";
 export * from "./model-seats.js";
 export * from "./capability.js";
+export * from "./parked-outcome.js";
 export * from "./principal.js";
 export * from "./reshape.js";
 export * from "./product-slug.js";

--- a/packages/core/src/parked-outcome.ts
+++ b/packages/core/src/parked-outcome.ts
@@ -1,0 +1,28 @@
+import type { ApprovalId, IsoDateTime } from "./ids.js";
+import type { ToolOutcome } from "./tools.js";
+
+/**
+ * What became of a guarded call the guard PARKED, once its approval is decided.
+ *
+ * Two lanes park calls and both resume them from the SAME
+ * `guard.onApprovalDecision` seam: the venue-neutral BYO one
+ * (`packages/vendo/src/byo-approvals.ts`) and the apps runtime's in-app actions
+ * (`packages/apps/src/server/persistence/parked-action.ts`). By the time either
+ * resumes, the surface that asked is long gone from the call stack — a foreign
+ * agent loop, or a generated screen sitting on "Sending…" — so the answer is
+ * PERSISTED here, keyed by the approval, and `GET /approvals/:id` serves it back.
+ *
+ * The shape and the collection live in core because both writers and the single
+ * reader must agree on them and none of them may import each other (layering).
+ */
+export const PARKED_CALL_OUTCOME_COLLECTION = "vendo_parked_call_outcome";
+
+export interface ParkedCallOutcome {
+  approvalId: ApprovalId;
+  /** The parking principal's subject — the only principal who may read it. */
+  owner: string;
+  state: "executed" | "declined" | "expired";
+  /** Present for "executed": the resumed call's outcome, errors included. */
+  outcome?: ToolOutcome;
+  at: IsoDateTime;
+}

--- a/packages/core/src/parked-outcome.ts
+++ b/packages/core/src/parked-outcome.ts
@@ -17,6 +17,17 @@ import type { ToolOutcome } from "./tools.js";
  */
 export const PARKED_CALL_OUTCOME_COLLECTION = "vendo_parked_call_outcome";
 
+/**
+ * The apps lane's PARKED record, keyed by approval — written when an in-app
+ * action parks, cleared only after the outcome row above is written. So "this
+ * record exists" is exactly the window where the decision has already left the
+ * guard's pending queue and the answer is not readable yet, and the read
+ * (`byo-approvals.ts`) answers "pending" through it instead of a terminal
+ * not-found the surface would render as expired. Here for the same reason the
+ * outcome shape is: one writer, one reader, no import between them.
+ */
+export const PARKED_ACTION_COLLECTION = "vendo_parked_action";
+
 export interface ParkedCallOutcome {
   approvalId: ApprovalId;
   /** The parking principal's subject — the only principal who may read it. */

--- a/packages/ui/src/chrome/approval-card.tsx
+++ b/packages/ui/src/chrome/approval-card.tsx
@@ -83,7 +83,7 @@ export interface ApprovalCardProps {
  *  developer sentence keeps its home in the server's own error; the person
  *  looking at the card is told what it means for them. `refusalCopy` in
  *  grant-set-card.tsx is the pattern. */
-function refusalCopy(reason: unknown): string {
+export function refusalCopy(reason: unknown): string {
   const code = (reason as { code?: unknown } | null)?.code;
   if (code === "not-found") return "This request isn’t waiting on you any more — it may have expired.";
   if (code === "conflict") return "This request was already answered.";

--- a/packages/ui/src/chrome/approval-modal.tsx
+++ b/packages/ui/src/chrome/approval-modal.tsx
@@ -188,6 +188,9 @@ export function ApprovalModal({ approvalId, onClose }: {
   const detail = useMemo(() => {
     if (resolution?.state !== "pending") return undefined;
     const { request } = resolution;
+    // Pending with no ask attached: the decision is already running server-side
+    // (byo-approvals.ts). The skeleton stands — there is nothing to decide here.
+    if (request === undefined) return undefined;
     const meta = tools[request.call.tool];
     const presentation = toolPresentation(
       request.call.tool,

--- a/packages/ui/src/chrome/approval-modal.tsx
+++ b/packages/ui/src/chrome/approval-modal.tsx
@@ -1,0 +1,343 @@
+/**
+ * The screen-initiated approval modal.
+ *
+ * THE DEFECT this exists for: a money-moving button on a generated screen that
+ * parked on the guard had no UI anywhere — only a badge count somewhere else on
+ * the page — so the person who pressed it waited forever for something that was
+ * never going to happen without them. This is that press's answer: the ask,
+ * centered over the page, decided or dismissed on the spot.
+ *
+ * Its own composition rather than `<ApprovalCard>` in a box. The card is a ROW
+ * — one item in a thread or a queue — and this is the confirmation moment a
+ * deliberate press earned, so it wears the ask at hero size. The WORDS still
+ * come from the one shared ladder (`toolPresentation` → `consentAsk`, ruling
+ * 14), so a modal and a thread card can never say different things about one
+ * ask, and the inputs still ride `CardFields` — the honesty law's one body.
+ *
+ * Three rules the surface is built around:
+ *  · Esc and the scrim CLOSE, they never decide. An approval is spent by
+ *    pressing Approve or Deny and by nothing else; dismissed, it stays pending
+ *    and comes back from the badge or the next press.
+ *  · While a decision is in flight there is no exit. `approvals.decide` does not
+ *    return until the approved action has actually RUN server-side (~25s in
+ *    production today), so the modal shows that plainly instead of freezing a
+ *    button or pretending it finished.
+ *  · Focus lands on the DIALOG, never on Approve — the keystroke that opened
+ *    this modal must not be able to spend the decision it came here to ask for.
+ */
+import type { ApprovalId } from "@vendoai/core";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import { APPROVALS_DECIDED_EVENT, type ApprovalsDecidedDetail } from "../client-impl.js";
+import { useVendoProvider, useVendoTheme, useVendoTools } from "../context.js";
+import { themeCssVariables } from "../theme.js";
+import type { ApprovalResolution } from "../wire-types.js";
+import { refusalCopy } from "./approval-card.js";
+import { consentAsk, toolPresentation } from "./build-beat.js";
+import { CARD_EYEBROWS, CardFields, SHIELD_GLYPH } from "./card-shell.js";
+import { ensureChromeStyles } from "./chrome-root.js";
+import { fieldRows } from "./field-rows.js";
+import { inertBehind } from "./inert-behind.js";
+
+/** Long enough for the exit to play, short enough that a decided modal is gone
+    before the eye looks for it. Kept in step with `fl-apmodal-out`. */
+const EXIT_MS = 170;
+
+const FOCUSABLE = "button:not([disabled]),input:not([disabled]),textarea:not([disabled]),select:not([disabled]),a[href],[tabindex]:not([tabindex='-1'])";
+
+/** The ask is no longer waiting on this person — every reason, in their words.
+    Never a silent close: they pressed a button and are owed the outcome. */
+const SETTLED: Record<string, string> = {
+  executed: "This already went through.",
+  declined: "This was already declined.",
+  expired: "This request expired — try the action again.",
+};
+
+/** A press inside a generated view that parked on the guard. */
+export interface ParkedApproval {
+  /** The pressed node in the view — the press's own origin. */
+  nodeId: string;
+  /** The approval the guard minted for it. */
+  approvalId: ApprovalId;
+}
+
+/**
+ * The mount seam: one call gives a surface the park handler and the modal to
+ * render. Deliberately not a provider or a registry — a slot owns the presses
+ * inside it, so it owns the questions they raise.
+ *
+ * A QUEUE, because presses arrive in bursts: pressing Send on two payee rows
+ * back to back parks two approvals, and two modals over one screen (let alone
+ * two stacked scrims) is not a question anybody can answer. Exactly one is on
+ * screen; the next presents itself once that one has left.
+ */
+export function useApprovalModal(): {
+  onParked(parked: ParkedApproval): void;
+  modal: ReactNode;
+} {
+  const [queue, setQueue] = useState<readonly ParkedApproval[]>([]);
+  // Keyed by approval, so re-pressing a button whose ask is already waiting
+  // joins nothing and asks nothing twice.
+  const onParked = useCallback((next: ParkedApproval) => setQueue(current =>
+    current.some(parked => parked.approvalId === next.approvalId) ? current : [...current, next]), []);
+  // ONE exit for both endings — decided, or dismissed with Esc — and it drops
+  // only the HEAD. Nothing is lost by dismissing: Esc never decides, so that
+  // approval is still pending on the server and comes back from the badge or
+  // the next press, while the asks queued behind it get their turn now.
+  // (Sending it to the BACK instead would make Esc unescapable whenever it is
+  // the only ask waiting — it would re-present itself forever.)
+  const close = useCallback(() => setQueue(current => current.slice(1)), []);
+  // An ask answered on another surface never gets a turn here. Without this,
+  // someone who presses twice and then approves both from the chat card is
+  // shown a modal per press, each only to say it was already handled. The HEAD
+  // is deliberately exempt: the mounted modal is listening to the same event
+  // and owns its own exit, and yanking it here would cut that exit short.
+  useEffect(() => {
+    const onDecided = (event: Event) => {
+      const ids = (event as CustomEvent<ApprovalsDecidedDetail>).detail?.ids;
+      if (ids === undefined) return;
+      setQueue(current => current.filter((parked, index) => index === 0 || !ids.includes(parked.approvalId)));
+    };
+    window.addEventListener(APPROVALS_DECIDED_EVENT, onDecided);
+    return () => window.removeEventListener(APPROVALS_DECIDED_EVENT, onDecided);
+  }, []);
+  const head = queue[0];
+  return {
+    onParked,
+    // Keyed by approval: the outgoing modal finishes its exit before the next
+    // ask mounts and plays its own entrance, so there is never a frame with
+    // two of them.
+    modal: head === undefined
+      ? null
+      : <ApprovalModal key={head.approvalId} approvalId={head.approvalId} onClose={close} />,
+  };
+}
+
+export function ApprovalModal({ approvalId, onClose }: {
+  approvalId: ApprovalId;
+  /** Fires once the exit has played — the caller unmounts here. */
+  onClose(): void;
+}) {
+  const { client } = useVendoProvider();
+  const theme = useVendoTheme();
+  const tools = useVendoTools();
+  const [resolution, setResolution] = useState<ApprovalResolution>();
+  const [loadFailed, setLoadFailed] = useState(false);
+  const [deciding, setDeciding] = useState<"approve" | "deny">();
+  const [error, setError] = useState<string>();
+  const [leaving, setLeaving] = useState(false);
+  const layerRef = useRef<HTMLDivElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(ensureChromeStyles, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    void client.approvals.get(approvalId).then(
+      answer => { if (!cancelled) setResolution(answer); },
+      () => { if (!cancelled) setLoadFailed(true); },
+    );
+    return () => { cancelled = true; };
+  }, [approvalId, client]);
+
+  // Answered on another surface sharing this page (the thread card, a host's
+  // own queue): the question is settled, so the modal leaves rather than
+  // asking it a second time. Our own decide announces through the same event.
+  useEffect(() => {
+    const onDecided = (event: Event) => {
+      const detail = (event as CustomEvent<ApprovalsDecidedDetail>).detail;
+      if (detail?.ids.includes(approvalId) === true) setLeaving(true);
+    };
+    window.addEventListener(APPROVALS_DECIDED_EVENT, onDecided);
+    return () => window.removeEventListener(APPROVALS_DECIDED_EVENT, onDecided);
+  }, [approvalId]);
+
+  useEffect(() => {
+    if (!leaving) return;
+    const timer = window.setTimeout(onClose, EXIT_MS);
+    return () => window.clearTimeout(timer);
+  }, [leaving, onClose]);
+
+  // Modal semantics. `position: fixed` and a scrim stop the mouse; only `inert`
+  // stops the keyboard and the screen reader from walking into the page
+  // underneath — which is also what keeps Tab inside the dialog.
+  useEffect(() => {
+    const { body } = document;
+    const previousOverflow = body.style.overflow;
+    body.style.overflow = "hidden";
+    const release = inertBehind(layerRef.current);
+    return () => {
+      release();
+      body.style.overflow = previousOverflow;
+    };
+  }, []);
+
+  // The dialog itself takes focus, and the opener gets it back on close.
+  useEffect(() => {
+    const previous = document.activeElement instanceof HTMLElement ? document.activeElement : undefined;
+    dialogRef.current?.focus();
+    return () => previous?.focus();
+  }, []);
+
+  const detail = useMemo(() => {
+    if (resolution?.state !== "pending") return undefined;
+    const { request } = resolution;
+    const meta = tools[request.call.tool];
+    const presentation = toolPresentation(
+      request.call.tool,
+      request.call.args,
+      meta,
+      request.descriptor.title,
+      request.descriptor.inputSchema,
+    );
+    const named = new Set(presentation.questionKeys ?? []);
+    return {
+      title: presentation.title,
+      // The real inputs ride their own table below, so the shared ladder is
+      // asked only for its SENTENCE half: the question, and what approving
+      // does. (Passing no rows is what leaves its row half empty.)
+      ask: consentAsk(request.descriptor.risk, presentation, [], meta),
+      // The honesty law: every input the question does not already name is on
+      // the surface, never behind a fold.
+      rows: fieldRows(request.call.args, request.descriptor.inputSchema, meta)
+        .filter(row => !named.has(row.key)),
+    };
+  }, [resolution, tools]);
+
+  const dismiss = () => {
+    // No exit mid-decision: the action is already running on the server, and
+    // hiding that is worse than waiting for it.
+    if (deciding === undefined) setLeaving(true);
+  };
+
+  const decide = async (approve: boolean) => {
+    setDeciding(approve ? "approve" : "deny");
+    setError(undefined);
+    try {
+      await client.approvals.decide([approvalId], { approve });
+      setLeaving(true);
+    } catch (reason) {
+      setError(refusalCopy(reason));
+      setDeciding(undefined);
+    }
+  };
+
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
+      dismiss();
+      return;
+    }
+    if (event.key !== "Tab") return;
+    const focusable = [...(dialogRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE) ?? [])];
+    if (focusable.length === 0) return;
+    const edge = event.shiftKey ? focusable[0]! : focusable.at(-1)!;
+    if (document.activeElement !== edge) return;
+    event.preventDefault();
+    (event.shiftKey ? focusable.at(-1)! : focusable[0]!).focus();
+  };
+
+  if (typeof document === "undefined") return null;
+
+  const settled = loadFailed
+    ? "We couldn’t load this request."
+    : resolution !== undefined && resolution.state !== "pending"
+      ? SETTLED[resolution.state]
+      : undefined;
+
+  return createPortal(
+    <div
+      ref={layerRef}
+      className="vendo-root fl-apmodal-layer"
+      data-vendo-ignore=""
+      data-vendo-motion={theme.motion}
+      data-vendo-density={theme.density}
+      {...(leaving ? { "data-leaving": "" } : {})}
+      style={{
+        ...themeCssVariables(theme),
+        fontFamily: "var(--vendo-font-family)",
+        fontSize: "var(--vendo-font-size)",
+      } as CSSProperties}
+    >
+      <div className="fl-apmodal-scrim" onClick={dismiss} />
+      <div
+        ref={dialogRef}
+        className="fl-apmodal"
+        role="dialog"
+        aria-modal="true"
+        aria-label={detail === undefined ? "Approval request" : `Approval for ${detail.title}`}
+        tabIndex={-1}
+        {...(deciding === undefined ? {} : { "data-deciding": deciding })}
+        onKeyDown={onKeyDown}
+      >
+        <span className="fl-apmodal-mark" aria-hidden="true">{SHIELD_GLYPH}</span>
+        {settled !== undefined ? (
+          <>
+            <p className="fl-apmodal-settled">{settled}</p>
+            <div className="fl-apmodal-acts">
+              <button type="button" className="fl-btn fl-apmodal-deny" onClick={dismiss}>Close</button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="fl-apmodal-eyebrow">{CARD_EYEBROWS.waiting}</div>
+            {detail === undefined ? (
+              // The press deserves an instant surface, so the modal arrives
+              // whole and the ask fills in — never a blank frame, never a
+              // spinner where the sentence is about to be.
+              <p className="fl-apmodal-ask" role="status" aria-label="Loading this request">
+                <span className="fl-apmodal-skel" style={{ width: "84%" }} />
+                <span className="fl-apmodal-skel" style={{ width: "52%", marginTop: "9px" }} />
+              </p>
+            ) : (
+              <>
+                <h2 className="fl-apmodal-ask">{detail.ask.question}</h2>
+                {/* One line to the eye, a LIST to a screen reader — the card's
+                    own treatment, so the " · " stays CSS punctuation. */}
+                <ul className="fl-approval-sub fl-apmodal-notes" aria-label="What approving does">
+                  {detail.ask.notes.map((note, index) => <li key={index}>{note}</li>)}
+                </ul>
+                <CardFields rows={detail.rows} />
+              </>
+            )}
+            {error ? <div role="alert" className="fl-error">{error}</div> : null}
+            <div className="fl-apmodal-acts">
+              <button
+                type="button"
+                className="fl-btn fl-btn-primary fl-apmodal-approve"
+                disabled={detail === undefined || deciding !== undefined}
+                onClick={() => void decide(true)}
+              >
+                {deciding === "approve" ? "Approving…" : "Approve"}
+                {deciding === "approve" ? <span className="fl-apmodal-rail" aria-hidden="true" /> : null}
+              </button>
+              <button
+                type="button"
+                className="fl-btn fl-apmodal-deny"
+                disabled={detail === undefined || deciding !== undefined}
+                onClick={() => void decide(false)}
+              >
+                {deciding === "deny" ? "Declining…" : "Deny"}
+              </button>
+            </div>
+            {deciding === "approve" ? (
+              // Honest, because the POST really is the action running.
+              <p className="fl-apmodal-wait" role="status">Running now — this can take a few seconds.</p>
+            ) : null}
+          </>
+        )}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/packages/ui/src/chrome/chrome-css.ts
+++ b/packages/ui/src/chrome/chrome-css.ts
@@ -1577,6 +1577,119 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the S1 des
   .fl-connect-act { width: 100%; margin-left: 0; }
 }
 
+/* ============ the screen-initiated approval modal ============
+   A press on a generated screen that parks on the guard used to have no UI
+   anywhere — only a badge count — so the person who pressed it waited forever.
+   This is that press's answer: the ask centered over the page, at hero size.
+   Composition and copy live in chrome/approval-modal.tsx.
+
+   Above the mobile approval sheet (…004): the two never co-exist, and a modal
+   raised by a deliberate press outranks anything already floating. */
+/* background:none is LOAD-BEARING. The layer carries .vendo-root for the token
+   bridge, and that rule paints --vendo-bg — which over a full-viewport fixed
+   layer is an opaque sheet hiding the very page the scrim exists to dim. (The
+   overlay dodges this by being display:contents; this layer has to position,
+   so it clears the paint instead.) */
+.fl-apmodal-layer { position: fixed; inset: 0; z-index: 2147483005; background: none;
+  display: grid; place-items: center; padding: 16px; }
+/* Dim to focus: the page goes BACK so the question is the only thing worth
+   reading. Heavier than the overlay's 22% on purpose — that scrim frames a
+   panel covering most of the screen, this one has to carry a 400px card
+   against a full page of live content, and at 22% the host's own headings
+   still competed with the ask. No blur: S1 retired frosted glass sheet-wide
+   (s1-recipe.test.ts), and reading as one material with every other Vendo
+   scrim is worth more than the blur was. */
+.fl-apmodal-scrim { position: absolute; inset: 0;
+  background: color-mix(in srgb, var(--vendo-fg) 42%, transparent); }
+.fl-apmodal { position: relative; width: min(400px, 100%); max-height: calc(100vh - 32px);
+  overflow-y: auto; overscroll-behavior: contain; outline: none;
+  padding: 26px 24px 20px; text-align: center;
+  border-radius: var(--vendo-radius-lg); background: var(--vendo-surface); color: var(--vendo-fg);
+  font: 400 var(--vendo-text-body)/1.5 var(--vendo-font);
+  /* The highest surface on the page, so the float shadow gains its ambient
+     half: a tight direct shadow under the card, a wide soft one around it. */
+  box-shadow: 0 2px 6px color-mix(in srgb, var(--vendo-fg) 6%, transparent),
+    0 28px 70px color-mix(in srgb, var(--vendo-fg) 20%, transparent); }
+/* The dialog takes focus on open, so the ask is the keyboard context — but it
+   is a CONTAINER, not a control, and the a11y block's ".vendo-root
+   :focus-visible" ring (specificity 0,2,0 — a plain outline:none above loses
+   to it) drew a 2px accent box around the whole card whenever it was opened by
+   anything but a mouse. The controls inside keep their rings. */
+.fl-apmodal:focus-visible { outline: none; }
+/* The consent register's mark at hero size. The 28px well is the CARD's law
+   (one item among many); this surface has ONE mark and it is the subject. */
+.fl-apmodal-mark { display: grid; place-items: center; width: 40px; height: 40px; margin: 0 auto 14px;
+  border-radius: 999px; color: var(--vendo-accent); background: var(--vendo-accent-soft); }
+.fl-apmodal-mark svg { width: 19px; height: 19px; }
+.fl-apmodal-eyebrow { font: 600 10.5px/1 var(--vendo-font); letter-spacing: .07em;
+  text-transform: uppercase; color: var(--vendo-fg-muted); }
+/* The ask, big and plain. Tracking goes NEGATIVE and leading tightens as type
+   grows — the same sentence the card sets at 14px, sized for a hero. */
+.fl-apmodal-ask { margin: 10px 0 0; font: 600 24px/1.22 var(--vendo-heading-font);
+  letter-spacing: -.021em; color: var(--vendo-fg); overflow-wrap: anywhere; text-wrap: balance; }
+.fl-apmodal-notes { margin-top: 9px; }
+/* Values read left-aligned in their table even though the ask is centered:
+   a column of inputs is scanned, not read. */
+.fl-apmodal .fl-card-fields { text-align: left; margin-top: 18px; }
+.fl-apmodal-acts { display: flex; flex-direction: column; gap: 6px; margin-top: 20px; }
+.fl-apmodal-approve { position: relative; overflow: hidden; width: 100%;
+  padding: 13px 16px; font-size: 14.5px; font-weight: 600; }
+.fl-apmodal-deny { width: 100%; padding: 11px 16px; border-color: transparent;
+  background: transparent; color: var(--vendo-fg-muted); }
+.fl-apmodal-deny:hover:not(:disabled) { background: var(--vendo-accent-soft);
+  border-color: transparent; color: var(--vendo-fg); }
+/* Press feedback on the whole button, instant and subtle — the interface
+   confirming it heard the press before anything else happens. */
+.fl-apmodal-acts .fl-btn { transition: transform .14s cubic-bezier(.23,1,.32,1),
+  opacity .2s ease, background .16s ease, color .16s ease; }
+.fl-apmodal-acts .fl-btn:active:not(:disabled) { transform: scale(.98); }
+/* .fl-btn has no disabled treatment of its own, so a locked Approve looked
+   exactly as pressable as a live one while the ask was still loading. Scoped
+   to this action row rather than fixed globally — every other card in the
+   product shares that base button, and that is not this lane's call. */
+.fl-apmodal-acts .fl-btn:disabled { opacity: .5; cursor: default; }
+/* Deciding: the competition steps back and the primary keeps every bit of its
+   presence — the decision is made, the system is working on it. */
+.fl-apmodal[data-deciding] .fl-apmodal-deny { opacity: .45; }
+.fl-apmodal[data-deciding] .fl-apmodal-approve:disabled { opacity: 1; }
+/* The in-flight rail: a sweep along the primary's bottom edge. Indeterminate
+   on purpose — the wire cannot say how far along a running action is, and a
+   percentage bar that invents one is a lie told 25 seconds long. */
+.fl-apmodal-rail { position: absolute; left: 0; right: 0; bottom: 0; height: 2px; overflow: hidden;
+  /* The track stays near-invisible so the MOVING segment is the signal — at a
+     readable weight it just underlines the button. */
+  background: color-mix(in srgb, var(--vendo-accent-fg) 15%, transparent); }
+.fl-apmodal-rail::after { content: ""; position: absolute; inset: 0; width: 38%;
+  border-radius: 999px; background: var(--vendo-accent-fg); }
+.fl-apmodal-wait { margin: 12px 0 0; font-size: 12px; color: var(--vendo-fg-muted); }
+.fl-apmodal-skel { display: block; height: 15px; margin: 0 auto; border-radius: 7px;
+  background: color-mix(in srgb, var(--vendo-fg) 9%, transparent); }
+.fl-apmodal-settled { margin: 12px 0 0; font: 500 15px/1.45 var(--vendo-font); }
+.fl-apmodal .fl-error { margin: 14px 0 0; text-align: left; }
+@media (prefers-reduced-motion: no-preference) {
+  /* The dim lands first and fast — the page must recede before the card
+     arrives, or the card reads as pasted onto a live page. */
+  .fl-apmodal-scrim { animation: fl-fade-in .22s ease-out both; }
+  /* transform-origin stays CENTER — a modal is not anchored to a trigger.
+     Critically damped (no overshoot): nothing threw this card onto the screen. */
+  .fl-apmodal { animation: fl-apmodal-in .3s var(--vendo-ease) both; }
+  /* Exit is faster than entry: the system responding, not the user deciding. */
+  .fl-apmodal-layer[data-leaving] .fl-apmodal { animation: fl-apmodal-out .17s ease both; }
+  .fl-apmodal-layer[data-leaving] .fl-apmodal-scrim { animation: fl-apmodal-fade-out .17s ease both; }
+  .fl-apmodal-rail::after { animation: fl-apmodal-sweep 1.5s cubic-bezier(.65,0,.35,1) infinite; }
+  .fl-apmodal-skel { animation: fl-apmodal-breathe 1.6s ease-in-out infinite; }
+}
+/* Reduced motion is gentler, not absent: the surface still cross-fades so it
+   never simply blinks into existence — it just never travels. */
+@media (prefers-reduced-motion: reduce) {
+  .fl-apmodal, .fl-apmodal-scrim { animation: fl-fade-in .16s ease both; }
+}
+@keyframes fl-apmodal-in { from { opacity: 0; transform: scale(.96) translateY(10px); } }
+@keyframes fl-apmodal-out { to { opacity: 0; transform: scale(.985); } }
+@keyframes fl-apmodal-fade-out { to { opacity: 0; } }
+@keyframes fl-apmodal-sweep { from { transform: translateX(-100%); } to { transform: translateX(363%); } }
+@keyframes fl-apmodal-breathe { 50% { opacity: .5; } }
+
 /* 3-A′ · real brand marks in the tray rows (monogram = fallback). */
 .fl-picker-ic img { width: 15px; height: 15px; object-fit: contain; display: block; }
 @media (prefers-reduced-motion: reduce) {

--- a/packages/ui/src/chrome/embeds.tsx
+++ b/packages/ui/src/chrome/embeds.tsx
@@ -20,6 +20,7 @@ import { AppFrame } from "../tree/frames.js";
 import type { ApprovalResolution, OpenSurface } from "../wire-types.js";
 import { AddToPicker } from "./add-to-picker.js";
 import { ApprovalCard } from "./approval-card.js";
+import { useApprovalModal } from "./approval-modal.js";
 import {
   CardActions,
   CardFields,
@@ -239,7 +240,11 @@ export function VendoApprovalEmbed({ refValue }: VendoApprovalEmbedProps) {
         )
       : <BeatLine state="working">{summary}</BeatLine>;
   } else if (data.state === "pending") {
-    body = <ApprovalCard approval={data.request} onDecide={decide} />;
+    // No ask to show means the decision is already running server-side — the
+    // same beat this embed opens with, and the poll is still armed.
+    body = data.request === undefined
+      ? <BeatLine state="working">{summary}</BeatLine>
+      : <ApprovalCard approval={data.request} onDecide={decide} />;
   } else if (data.state === "executed") {
     body = executedCard(summary, data.outcome);
   } else if (data.state === "declined") {
@@ -263,6 +268,10 @@ export function VendoApprovalEmbed({ refValue }: VendoApprovalEmbedProps) {
 export function VendoAppEmbed({ refValue }: VendoAppEmbedProps) {
   const { client, components } = useVendoProvider();
   const { appId, title } = refValue;
+  // A press inside the embedded app that parks on the guard asks its question
+  // HERE, over the surface the person pressed it on — the same seam VendoSlot
+  // mounts (one modal per mount; it portals to <body>).
+  const approval = useApprovalModal();
   // Retry (criterion 8, speed-core): a retryable terminal failure re-issues
   // the create; the fresh build gets its own id, so the poll loop keys on
   // activeAppId rather than the ref's original.
@@ -389,6 +398,7 @@ export function VendoAppEmbed({ refValue }: VendoAppEmbedProps) {
             <AppFrame
               surface={surface}
               components={components}
+              onParked={approval.onParked}
               // Actions bind to the app actually being SHOWN: after a retry
               // that is the replacement build's id, never the original failed
               // record (checker F5).
@@ -423,6 +433,7 @@ export function VendoAppEmbed({ refValue }: VendoAppEmbedProps) {
           )}
         </div>
       </div>
+      {approval.modal}
     </ChromeRoot>
   );
 }

--- a/packages/ui/src/chrome/index.ts
+++ b/packages/ui/src/chrome/index.ts
@@ -22,6 +22,9 @@ export { VendoTrigger, type VendoTriggerProps } from "./vendo-trigger.js";
 export { VendoPalette, type VendoCommand } from "./vendo-palette.js";
 export { type HotkeyChord, type PaletteHotkey } from "./palette-hotkey.js";
 export { VendoSlot } from "./vendo-slot.js";
+/** Re-exported beside VendoSlot: it is the shape of that component's
+    `onParked` prop, and defined with the tree that fires it. */
+export type { ParkedPress } from "../tree/renderer.js";
 export { VendoThread, type VendoThreadProps } from "./thread/index.js";
 export { VendoToasts, vendoToast, dismissAllVendoToasts, type VendoToastsProps, type VendoToastInput, type VendoToastAction } from "./vendo-toasts.js";
 

--- a/packages/ui/src/chrome/index.ts
+++ b/packages/ui/src/chrome/index.ts
@@ -25,6 +25,10 @@ export { VendoSlot } from "./vendo-slot.js";
 /** Re-exported beside VendoSlot: it is the shape of that component's
     `onParked` prop, and defined with the tree that fires it. */
 export type { ParkedPress } from "../tree/renderer.js";
+/** Public because the thread is an eject surface: `thread/parts.tsx` mounts the
+    approval modal per app card, so the hook is API by construction — and a host
+    building its own surface needs the same seam to give parked presses an ask. */
+export { useApprovalModal, type ParkedApproval } from "./approval-modal.js";
 export { VendoThread, type VendoThreadProps } from "./thread/index.js";
 export { VendoToasts, vendoToast, dismissAllVendoToasts, type VendoToastsProps, type VendoToastInput, type VendoToastAction } from "./vendo-toasts.js";
 

--- a/packages/ui/src/chrome/remixable.tsx
+++ b/packages/ui/src/chrome/remixable.tsx
@@ -6,6 +6,7 @@ import { useResource } from "../hooks/use-resource.js";
 import { FluidReveal } from "../tree/fluid-reveal.js";
 import { AppFrame, PinMount } from "../tree/frames.js";
 import type { InClientVenue, OpenSurface } from "../wire-types.js";
+import { useApprovalModal } from "./approval-modal.js";
 import { ChromeRoot } from "./chrome-root.js";
 import { developmentMode } from "./dev-mode.js";
 import { openVendoConversation } from "./overlay-registry.js";
@@ -157,6 +158,11 @@ function RemixedFork({ appId, slot, review, liveProps, menuOpen, onMenuToggle, o
   const { surface, error, isLoading } = useApp(appId);
   const menuRef = useRef<HTMLDivElement>(null);
   const [reverting, setReverting] = useState(false);
+  // A press inside the mounted fork that parks on the guard asks its question
+  // over this surface (the VendoSlot seam). The modal hangs off the ✦ chrome
+  // below rather than the fork's own boundary: it must outlive a fork that
+  // unmounts (a revert) while a decision is still in flight.
+  const approval = useApprovalModal();
 
   // The popover dismisses like any menu: Escape, or pointer-down outside it.
   useEffect(() => {
@@ -243,6 +249,7 @@ function RemixedFork({ appId, slot, review, liveProps, menuOpen, onMenuToggle, o
               <AppFrame
                 surface={staged}
                 components={components}
+                onParked={approval.onParked}
                 onAction={({ action, payload }) => client.apps.call(appId, action, payload ?? {})}
               />
             </PinMount>
@@ -298,6 +305,7 @@ function RemixedFork({ appId, slot, review, liveProps, menuOpen, onMenuToggle, o
             </div>
           ) : null}
         </div>
+        {approval.modal}
       </ChromeRoot>
     </>
   );

--- a/packages/ui/src/chrome/thread/parts.tsx
+++ b/packages/ui/src/chrome/thread/parts.tsx
@@ -8,6 +8,7 @@ import { PayloadView } from "../../tree/renderer.js";
 import { useSlots } from "../../hooks/use-slots.js";
 import { AddToPicker } from "../add-to-picker.js";
 import { ApprovalCard } from "../approval-card.js";
+import { useApprovalModal } from "../approval-modal.js";
 import { ApprovalSheet } from "../approval-sheet.js";
 import { AutomationCard } from "../automation-card.js";
 import { BuildBeat, toolPresentation } from "../build-beat.js";
@@ -539,6 +540,10 @@ function AppCardBody({ compact, shellRef, canvasRef, previewHeight, previewScale
 function ThreadAppCard({ appId, payload, restored, buildKey }: { appId: string; payload: UIPayload; restored: boolean; buildKey: string }) {
   const { client, components } = useVendoProvider();
   const pin = usePinAction();
+  // A press inside the card's view that parks on the guard asks its question
+  // over the conversation, where the person pressed it (the VendoSlot seam).
+  // One per card mount: the stage renders its own view, and its own modal.
+  const approval = useApprovalModal();
   // The destinations the registry knows — a mounted VendoSlot is the only thing
   // that can say a slot exists (hooks/use-slots.ts). More than one, and the
   // bar's placement affordance is a picker rather than a single fixed pin.
@@ -665,91 +670,98 @@ function ThreadAppCard({ appId, payload, restored, buildKey }: { appId: string; 
       }
     : undefined;
   return (
-    // The generated view lives inside a clear app boundary — a titled
-    // frame — so it reads as a distinct piece of software, not loose
-    // content bleeding into the surrounding chat text.
-    <div
-      ref={cardRef}
-      className="fl-uihost fl-appcard"
-      data-vendo-app-embed={appId}
-      {...(featured ? { "data-vendo-featured": "" } : {})}
-      {...(featureOnClick ? { onClick: featureOnClick, "data-vendo-featurable": "" } : {})}
-    >
-      {/* The bar narrates forming → live. The data-state contract
-          ("building" | "ready") is shared with the renderer; the label pair
-          stays mounted so the swap crossfades. */}
-      <div className="fl-appcard-bar" data-state={streaming ? "building" : "ready"}>
-        <span className="fl-appcard-dot" aria-hidden="true" />
-        <span className="fl-boot-labels fl-appcard-name">
-          {/* Both labels stay mounted for the renderer lane's crossfade;
-              aria-hidden tracks data-state so screen readers hear only the
-              ACTIVE one (AI-review catch — the CSS-faded label was still
-              announced, including a stale "Building…" after ready). */}
-          <span className="fl-boot-building" aria-hidden={!streaming}>Building your view…</span>
-          <span className="fl-boot-ready" aria-hidden={streaming}>{appTitle(payload) ?? "Your app"}</span>
-        </span>
-        {/* The workspace-feature affordance (keyboard path for "click the
-            embed to feature it"); only while the split view is expanded and
-            this card isn't already on the stage. */}
-        {split?.expanded === true && !streaming && !featured ? (
-          <button
-            type="button"
-            className="fl-barpin"
-            aria-label="Show this view in the workspace"
-            onClick={() => split.feature(appId)}
-          >
-            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-              <path d="M8 3H5a2 2 0 0 0-2 2v3M16 3h3a2 2 0 0 1 2 2v3M8 21H5a2 2 0 0 1-2-2v-3M16 21h3a2 2 0 0 0 2-2v-3" />
-            </svg>
-            Feature
-          </button>
-        ) : null}
-        {/* The placement affordance lives ON the bar (visible only once the
-            view is ready), replacing the old full-width footer row. The
-            data-state/label/hairline markup above is the shared contract and
-            stays untouched.
-
-            ONE destination is a verb ("Pin to dashboard") — naming the only
-            place it could go would be a menu of one. Several, and the same
-            affordance becomes the picker: this card is the surface a real user
-            actually reaches a generated view from, so it is where the choice
-            has to live (the embed-only picker was unreachable in every host
-            that renders its conversation through the overlay). */}
-        {!streaming && pin ? (
-          slots.length > 1 ? <AddToPicker appId={appId} /> : (
+    <>
+      {/* The generated view lives inside a clear app boundary — a titled
+          frame — so it reads as a distinct piece of software, not loose
+          content bleeding into the surrounding chat text. */}
+      <div
+        ref={cardRef}
+        className="fl-uihost fl-appcard"
+        data-vendo-app-embed={appId}
+        {...(featured ? { "data-vendo-featured": "" } : {})}
+        {...(featureOnClick ? { onClick: featureOnClick, "data-vendo-featurable": "" } : {})}
+      >
+        {/* The bar narrates forming → live. The data-state contract
+            ("building" | "ready") is shared with the renderer; the label pair
+            stays mounted so the swap crossfades. */}
+        <div className="fl-appcard-bar" data-state={streaming ? "building" : "ready"}>
+          <span className="fl-appcard-dot" aria-hidden="true" />
+          <span className="fl-boot-labels fl-appcard-name">
+            {/* Both labels stay mounted for the renderer lane's crossfade;
+                aria-hidden tracks data-state so screen readers hear only the
+                ACTIVE one (AI-review catch — the CSS-faded label was still
+                announced, including a stale "Building…" after ready). */}
+            <span className="fl-boot-building" aria-hidden={!streaming}>Building your view…</span>
+            <span className="fl-boot-ready" aria-hidden={streaming}>{appTitle(payload) ?? "Your app"}</span>
+          </span>
+          {/* The workspace-feature affordance (keyboard path for "click the
+              embed to feature it"); only while the split view is expanded and
+              this card isn't already on the stage. */}
+          {split?.expanded === true && !streaming && !featured ? (
             <button
               type="button"
               className="fl-barpin"
-              {...(nudge === undefined ? {} : { "data-vendo-pin": nudge })}
-              onClick={() => pin({ appId, payload })}
+              aria-label="Show this view in the workspace"
+              onClick={() => split.feature(appId)}
             >
               <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-                <path d="M12 17v5M9 3h6l-1 7 3 3H7l3-3-1-7Z" />
+                <path d="M8 3H5a2 2 0 0 0-2 2v3M16 3h3a2 2 0 0 1 2 2v3M8 21H5a2 2 0 0 1-2-2v-3M16 21h3a2 2 0 0 0 2-2v-3" />
               </svg>
-              Pin to dashboard
+              Feature
             </button>
-          )
-        ) : null}
-        <span className="fl-boot-hairline" aria-hidden="true" />
+          ) : null}
+          {/* The placement affordance lives ON the bar (visible only once the
+              view is ready), replacing the old full-width footer row. The
+              data-state/label/hairline markup above is the shared contract and
+              stays untouched.
+
+              ONE destination is a verb ("Pin to dashboard") — naming the only
+              place it could go would be a menu of one. Several, and the same
+              affordance becomes the picker: this card is the surface a real user
+              actually reaches a generated view from, so it is where the choice
+              has to live (the embed-only picker was unreachable in every host
+              that renders its conversation through the overlay). */}
+          {!streaming && pin ? (
+            slots.length > 1 ? <AddToPicker appId={appId} /> : (
+              <button
+                type="button"
+                className="fl-barpin"
+                {...(nudge === undefined ? {} : { "data-vendo-pin": nudge })}
+                onClick={() => pin({ appId, payload })}
+              >
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                  <path d="M12 17v5M9 3h6l-1 7 3 3H7l3-3-1-7Z" />
+                </svg>
+                Pin to dashboard
+              </button>
+            )
+          ) : null}
+          <span className="fl-boot-hairline" aria-hidden="true" />
+        </div>
+        <AppCardBody
+          compact={compact}
+          shellRef={shellRef}
+          canvasRef={canvasRef}
+          previewHeight={previewHeight}
+          previewScale={previewScale}
+          featured={featured}
+          activate={activate}
+          splitExpanded={split?.expanded === true}
+          view={
+            <PayloadView
+              payload={payload}
+              components={components}
+              onParked={approval.onParked}
+              onAction={({ action, payload: actionPayload }) => client.apps.call(appId, action, actionPayload ?? {})}
+            />
+          }
+        />
       </div>
-      <AppCardBody
-        compact={compact}
-        shellRef={shellRef}
-        canvasRef={canvasRef}
-        previewHeight={previewHeight}
-        previewScale={previewScale}
-        featured={featured}
-        activate={activate}
-        splitExpanded={split?.expanded === true}
-        view={
-          <PayloadView
-            payload={payload}
-            components={components}
-            onAction={({ action, payload: actionPayload }) => client.apps.call(appId, action, actionPayload ?? {})}
-          />
-        }
-      />
-    </div>
+      {/* OUTSIDE the card: a portal still bubbles its clicks up the REACT tree,
+          and the card's own click features the app on the stage — dismissing the
+          modal must not do that. */}
+      {approval.modal}
+    </>
   );
 }
 

--- a/packages/ui/src/chrome/vendo-overlay.tsx
+++ b/packages/ui/src/chrome/vendo-overlay.tsx
@@ -5,6 +5,7 @@ import { useVendoProvider, useVendoDiscoverability, useVendoTheme } from "../con
 import { useMobileTakeover } from "../hooks/use-mobile-takeover.js";
 import { themeCssVariables } from "../theme.js";
 import { PayloadView } from "../tree/renderer.js";
+import { useApprovalModal } from "./approval-modal.js";
 import { BeatRail } from "./build-beat.js";
 import { ChromeRoot } from "./chrome-root.js";
 import { hasSeen, markSeen, type VendoDiscoverability, type VendoGreeting } from "./discoverability.js";
@@ -272,6 +273,10 @@ function WorkspaceStage({ mounted, expanded, featured, beats, pinNudge, pin, onP
   onPinned: () => void;
 }) {
   const { client, components } = useVendoProvider();
+  // The stage is where a featured view is actually PRESSED, so a press that
+  // parks asks its question here — the rail card behind it owns its own copy of
+  // the view and its own modal (the VendoSlot seam, one per mount).
+  const approval = useApprovalModal();
   return (
     <div className="fl-split-stage" {...(expanded ? {} : { "aria-hidden": true })}>
       {!mounted ? null : (
@@ -306,6 +311,7 @@ function WorkspaceStage({ mounted, expanded, featured, beats, pinNudge, pin, onP
                   // (ThreadAppCard receives VendoViewPart payloads).
                   payload={featured.payload as UIPayload}
                   components={components}
+                  onParked={approval.onParked}
                   onAction={({ action, payload: actionPayload }) =>
                     client.apps.call(featured.appId, action, actionPayload ?? {})}
                 />
@@ -321,6 +327,7 @@ function WorkspaceStage({ mounted, expanded, featured, beats, pinNudge, pin, onP
               empty stage while the first view is still being made, the view
               itself once it lands. */}
           <BeatRail beats={beats} />
+          {approval.modal}
         </>
       )}
     </div>

--- a/packages/ui/src/chrome/vendo-slot.tsx
+++ b/packages/ui/src/chrome/vendo-slot.tsx
@@ -7,6 +7,7 @@ import { useReportSlot } from "../hooks/use-placements.js";
 import { useSlotApp } from "../hooks/use-slot-app.js";
 import { FluidReveal } from "../tree/fluid-reveal.js";
 import { AppFrame, PinMount } from "../tree/frames.js";
+import { useApprovalModal, type ParkedApproval } from "./approval-modal.js";
 import { ChromeRoot } from "./chrome-root.js";
 import { defaultSlotSuggestions } from "./discoverability.js";
 import { developmentMode } from "./dev-mode.js";
@@ -165,7 +166,24 @@ function SlotBuildFailed({ appId, slotId, onChanged }: {
   );
 }
 
-function MountedApp({ appId }: { appId: string }) {
+/** A guarded call PARKS instead of running (`pending-approval`) — and until
+ *  now that outcome had no UI anywhere on the page, so the person who pressed
+ *  the button waited forever. This is where the press hands its park to the
+ *  approval modal, around whichever action handler the slot is using. */
+function watchForPark(
+  run: (req: { nodeId: string; action: string; payload?: Json }) => Promise<ToolOutcome>,
+  onParked: (parked: ParkedApproval) => void,
+) {
+  return async (req: { nodeId: string; action: string; payload?: Json }): Promise<ToolOutcome> => {
+    const outcome = await run(req);
+    if (outcome.status === "pending-approval") {
+      onParked({ nodeId: req.nodeId, approvalId: outcome.approvalId });
+    }
+    return outcome;
+  };
+}
+
+function MountedApp({ appId, onParked }: { appId: string; onParked(parked: ParkedApproval): void }) {
   const { client, components } = useVendoProvider();
   const { surface, error, isLoading, refresh } = useApp(appId);
   // The served-surface keepalive: an on-screen embed pings the
@@ -174,11 +192,15 @@ function MountedApp({ appId }: { appId: string }) {
     () => ({ ping: () => client.apps.pingMachine(appId) }),
     [appId, client],
   );
+  const act = useMemo(
+    () => watchForPark(({ action, payload }) => client.apps.call(appId, action, payload ?? {}), onParked),
+    [appId, client, onParked],
+  );
   if (!surface) {
     if (error && !isLoading) return <SlotLoadFailed reason={error} onRetry={() => void refresh()} />;
     return <SlotGhost label="Loading app…" loading />;
   }
-  return <AppFrame key={appId} surface={surface} components={components} keepalive={keepalive} onAction={({ action, payload }) => client.apps.call(appId, action, payload ?? {})} />;
+  return <AppFrame key={appId} surface={surface} components={components} keepalive={keepalive} onAction={act} />;
 }
 
 /** A generated view pinned into a slot (08-ui §4 — "or a pinned component").
@@ -240,6 +262,18 @@ export function VendoSlot({ id, label, appId: appIdProp, pin, onAuthor, discover
   children?: ReactNode;
 }) {
   const { components } = useVendoProvider();
+  // Screen-initiated approvals: a press inside the mounted view that parks on
+  // the guard hands itself here, and the modal asks the question centered over
+  // the page. The slot owns the presses inside it, so it owns the question
+  // they raise — no provider, no registry.
+  const approval = useApprovalModal();
+  // Memoized so the wrapper preserves whatever identity stability the host's
+  // own handler had: the tree's runAction is keyed on this prop, and a fresh
+  // function every render would re-run the screen's setup on every render.
+  const pinAction = useMemo(
+    () => pin?.onAction === undefined ? undefined : watchForPark(pin.onAction, approval.onParked),
+    [pin?.onAction, approval.onParked],
+  );
   // Self-discovery (ui-usage-dx §2): with no explicit `appId`/`pin`, the slot
   // resolves its own pinned app — hosts never write the polling dance.
   const discovery = useSlotApp(id, { enabled: discover && appIdProp === undefined && pin === undefined });
@@ -356,8 +390,15 @@ export function VendoSlot({ id, label, appId: appIdProp, pin, onAuthor, discover
 
   const Fallback = () => <>{children}</>;
   const mounted = appId
-    ? <MountedApp appId={appId} />
-    : <AppFrame surface={{ kind: "tree", payload: pin!.payload }} components={components} data={pin!.data} onAction={pin!.onAction} />;
+    ? <MountedApp appId={appId} onParked={approval.onParked} />
+    : (
+      <AppFrame
+        surface={{ kind: "tree", payload: pin!.payload }}
+        components={components}
+        data={pin!.data}
+        {...(pinAction === undefined ? {} : { onAction: pinAction })}
+      />
+    );
   return (
     <ChromeRoot>
       <div className="fl-slot" data-vendo-slot={id}>
@@ -367,6 +408,9 @@ export function VendoSlot({ id, label, appId: appIdProp, pin, onAuthor, discover
           </FluidReveal>
         </div>
       </div>
+      {/* Portals to <body> with its own theme boundary, so it is never trapped
+          by the host's stacking context around this slot. */}
+      {approval.modal}
     </ChromeRoot>
   );
 }

--- a/packages/ui/src/chrome/vendo-slot.tsx
+++ b/packages/ui/src/chrome/vendo-slot.tsx
@@ -7,6 +7,7 @@ import { useReportSlot } from "../hooks/use-placements.js";
 import { useSlotApp } from "../hooks/use-slot-app.js";
 import { FluidReveal } from "../tree/fluid-reveal.js";
 import { AppFrame, PinMount } from "../tree/frames.js";
+import type { ParkedPress } from "../tree/renderer.js";
 import { ChromeRoot } from "./chrome-root.js";
 import { defaultSlotSuggestions } from "./discoverability.js";
 import { developmentMode } from "./dev-mode.js";
@@ -165,7 +166,7 @@ function SlotBuildFailed({ appId, slotId, onChanged }: {
   );
 }
 
-function MountedApp({ appId }: { appId: string }) {
+function MountedApp({ appId, onParked }: { appId: string; onParked?: (parked: ParkedPress) => void }) {
   const { client, components } = useVendoProvider();
   const { surface, error, isLoading, refresh } = useApp(appId);
   // The served-surface keepalive: an on-screen embed pings the
@@ -178,7 +179,7 @@ function MountedApp({ appId }: { appId: string }) {
     if (error && !isLoading) return <SlotLoadFailed reason={error} onRetry={() => void refresh()} />;
     return <SlotGhost label="Loading app…" loading />;
   }
-  return <AppFrame key={appId} surface={surface} components={components} keepalive={keepalive} onAction={({ action, payload }) => client.apps.call(appId, action, payload ?? {})} />;
+  return <AppFrame key={appId} surface={surface} components={components} keepalive={keepalive} onParked={onParked} onAction={({ action, payload }) => client.apps.call(appId, action, payload ?? {})} />;
 }
 
 /** A generated view pinned into a slot (08-ui §4 — "or a pinned component").
@@ -209,7 +210,7 @@ export interface VendoSlotPin {
  *  the original `children` as the visible recovery path (06-apps §8). Without any
  *  of the three, the children render UNTOUCHED (no wrapper — hosts may inline
  *  slots anywhere). */
-export function VendoSlot({ id, label, appId: appIdProp, pin, onAuthor, discover = true, emptyState, children }: {
+export function VendoSlot({ id, label, appId: appIdProp, pin, onAuthor, onParked, discover = true, emptyState, children }: {
   id: string;
   /** What a person choosing this slot in the "Add to…" picker reads. Defaults
    *  to the id read as words ("net-worth-card" → "Net worth card"). */
@@ -219,6 +220,10 @@ export function VendoSlot({ id, label, appId: appIdProp, pin, onAuthor, discover
   /** Invoked when the empty-state CTA is activated — the seam to open a thread
    *  or palette to author the view. Defaults to opening a mounted VendoPalette. */
   onAuthor?(slotId: string): void;
+  /** Invoked when a press inside the mounted view is parked on an approval. The
+   *  view settles itself when the decision lands (tree/parked-approvals.ts);
+   *  this is the seam for surfacing the decision where the person already is. */
+  onParked?: (parked: ParkedPress) => void;
   /** Pass `false` to stand pin self-discovery down even with no `appId`/`pin`
    *  prop — for hosts that resolve the pin themselves (e.g. via useSlotApp
    *  for a layout decision) and must not start a second poll. */
@@ -356,8 +361,8 @@ export function VendoSlot({ id, label, appId: appIdProp, pin, onAuthor, discover
 
   const Fallback = () => <>{children}</>;
   const mounted = appId
-    ? <MountedApp appId={appId} />
-    : <AppFrame surface={{ kind: "tree", payload: pin!.payload }} components={components} data={pin!.data} onAction={pin!.onAction} />;
+    ? <MountedApp appId={appId} onParked={onParked} />
+    : <AppFrame surface={{ kind: "tree", payload: pin!.payload }} components={components} data={pin!.data} onAction={pin!.onAction} onParked={onParked} />;
   return (
     <ChromeRoot>
       <div className="fl-slot" data-vendo-slot={id}>

--- a/packages/ui/src/context.tsx
+++ b/packages/ui/src/context.tsx
@@ -177,6 +177,13 @@ export function useVendoThemeOrDefault(): VendoTheme {
   return useContext(VendoContext)?.theme ?? defaultVendoTheme;
 }
 
+/** The wire, provider-optional. A tree inside a provider can ask what became of
+    an approval one of its presses parked; a standalone one has nobody to ask and
+    simply never resolves one. */
+export function useVendoClientOrNone(): VendoClient | undefined {
+  return useContext(VendoContext)?.client;
+}
+
 /** The discoverability dial, provider-optional (standalone surfaces default on). */
 export function useVendoDiscoverability(): VendoDiscoverability {
   return useContext(VendoContext)?.discoverability ?? "default";

--- a/packages/ui/src/tree/frames.tsx
+++ b/packages/ui/src/tree/frames.tsx
@@ -3,7 +3,7 @@ import type { Json, ToolOutcome, UIPayload } from "@vendoai/core";
 import type { OpenSurface } from "../wire-types.js";
 import { applyFrameResize, FRAME_MAX_HEIGHT_CSS } from "./frame-resize.js";
 import { ContainedNotice } from "./notice.js";
-import { PayloadView } from "./renderer.js";
+import { PayloadView, type ParkedPress } from "./renderer.js";
 import { Skeleton } from "./forming-skeleton.js";
 
 /**
@@ -33,6 +33,9 @@ export interface AppFrameProps {
   components?: Record<string, ComponentType>;
   data?: Record<string, Json>;
   onAction?(req: { nodeId: string; action: string; payload?: Json }): Promise<ToolOutcome>;
+  /** A press parked on an approval (tree surfaces only) — renderer.tsx's
+   *  TreeViewProps documents what a surface does with it. */
+  onParked?: (parked: ParkedPress) => void;
   onStateChange?(state: Record<string, Json>): void;
   /** Keepalive for an embedded served app (http surfaces only). */
   keepalive?: AppFrameKeepalive;
@@ -163,7 +166,7 @@ function HttpFrame({ url, keepalive }: { url: string; keepalive?: AppFrameKeepal
 }
 
 /** 08-ui §5; 06-apps §1 — render every app execution plane fail-soft. */
-export function AppFrame({ surface, appId, components = {}, data, onAction = unavailableAction, onStateChange, keepalive }: AppFrameProps) {
+export function AppFrame({ surface, appId, components = {}, data, onAction = unavailableAction, onParked, onStateChange, keepalive }: AppFrameProps) {
   if (surface.kind === "http") {
     return <HttpFrame url={surface.url} keepalive={keepalive} />;
   }
@@ -183,6 +186,7 @@ export function AppFrame({ surface, appId, components = {}, data, onAction = una
         components={components}
         data={data}
         onAction={onAction}
+        onParked={onParked}
         onStateChange={onStateChange}
       />
     );

--- a/packages/ui/src/tree/notice.tsx
+++ b/packages/ui/src/tree/notice.tsx
@@ -45,18 +45,32 @@ export function ContainedNotice(props: {
   detail?: string;
   code?: string;
   outcome?: string;
+  /** Makes the notice ITSELF the affordance — the same box, pressable. The
+   *  pending-approval notice is the way back to an ask the person dismissed,
+   *  and a second component beside it would be a second thing to explain. */
+  onPress?(): void;
 }) {
   const danger = props.outcome === "error" || props.outcome === "blocked";
   const detail = props.detail !== undefined && developmentMode() ? ` ${props.detail}` : "";
-  return (
-    <small
-      role="note"
-      aria-label={props.label}
-      data-error-code={props.code}
-      data-vendo-notice={props.outcome ?? "contained"}
-      style={noticeStyle(danger)}
-    >
-      {`${props.children}${detail}`}
-    </small>
-  );
+  const text = `${props.children}${detail}`;
+  const shell = {
+    "data-error-code": props.code,
+    "data-vendo-notice": props.outcome ?? "contained",
+  };
+  // A pressable notice takes its name from the sentence it shows (WCAG 2.5.3):
+  // "review" is the whole point, and a category label over it would hide that
+  // from exactly the people who cannot see the box.
+  if (props.onPress !== undefined) {
+    return (
+      <button
+        type="button"
+        {...shell}
+        style={{ ...noticeStyle(danger), cursor: "pointer", textAlign: "left" }}
+        onClick={props.onPress}
+      >
+        {text}
+      </button>
+    );
+  }
+  return <small role="note" aria-label={props.label} {...shell} style={noticeStyle(danger)}>{text}</small>;
 }

--- a/packages/ui/src/tree/parked-approvals.ts
+++ b/packages/ui/src/tree/parked-approvals.ts
@@ -1,0 +1,79 @@
+/**
+ * What happens to a press the guard parked.
+ *
+ * `pending-approval` is the honest answer at press time — nothing has changed
+ * yet — so the node paints "waiting for approval" and the screen stops there.
+ * Nothing ever cleared it. The decision lands on a different surface entirely
+ * (the approvals queue, another tab, the host's own card), the server resumes
+ * the exact parked call from `guard.onApprovalDecision`, and the screen that
+ * pressed the button was never told: it sat on "Sending…" forever, over data
+ * the backend had already changed.
+ *
+ * This watches every outstanding parked press for its terminal state. The
+ * same-tab `vendo:approvals-decided` announcement settles it the moment the
+ * decision lands; a slow poll covers every decision this page cannot hear.
+ */
+import { useEffect, useRef } from "react";
+import { APPROVALS_DECIDED_EVENT, type ApprovalsDecidedDetail } from "../client-impl.js";
+import { useVendoClientOrNone } from "../context.js";
+import type { ApprovalResolution } from "../wire-types.js";
+
+/** Slower than the approvals feed on purpose: this is the backstop for a
+ *  decision made where the page cannot hear it, not the primary signal. */
+const POLL_MS = 5_000;
+
+const hidden = (): boolean => typeof document !== "undefined" && document.visibilityState === "hidden";
+
+/**
+ * @param parked nodeId → the approval its press is waiting on.
+ * @param onResolved fires once per node with the approval's terminal state.
+ */
+export function useParkedApprovals(
+  parked: ReadonlyMap<string, string>,
+  onResolved: (nodeId: string, resolution: ApprovalResolution) => void,
+): void {
+  const client = useVendoClientOrNone();
+  // Read at fire time, always from the newest render — so the effect below
+  // re-arms only when the SET of outstanding approvals changes.
+  const latest = useRef({ parked, onResolved });
+  latest.current = { parked, onResolved };
+  const outstanding = [...parked].map(([nodeId, approvalId]) => `${nodeId}=${approvalId}`).join(",");
+
+  useEffect(() => {
+    if (client === undefined || outstanding === "") return undefined;
+    let live = true;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const settle = async (only?: ReadonlySet<string>): Promise<void> => {
+      for (const [nodeId, approvalId] of latest.current.parked) {
+        if (only !== undefined && !only.has(approvalId)) continue;
+        // A failed read is TRANSIENT, never a verdict: the server runs the
+        // resumed call INSIDE the decision, so a read landing in that window
+        // finds neither a pending ask nor an outcome yet. The next pass asks
+        // again and the pending notice stands meanwhile — today's behavior.
+        const resolution = await client.approvals.get(approvalId).catch(() => undefined);
+        if (!live) return;
+        if (resolution !== undefined && resolution.state !== "pending") {
+          latest.current.onResolved(nodeId, resolution);
+        }
+      }
+    };
+    const poll = async (): Promise<void> => {
+      // A background tab asks nothing (the approvals feed's rule); the first
+      // tick after the person comes back picks the answer up.
+      if (!hidden()) await settle();
+      if (live) timer = setTimeout(() => void poll(), POLL_MS);
+    };
+    const onDecided = (event: Event): void => {
+      const detail = (event as CustomEvent<ApprovalsDecidedDetail>).detail;
+      if (detail === undefined || !Array.isArray(detail.ids)) return;
+      void settle(new Set(detail.ids));
+    };
+    window.addEventListener(APPROVALS_DECIDED_EVENT, onDecided);
+    timer = setTimeout(() => void poll(), POLL_MS);
+    return () => {
+      live = false;
+      if (timer !== undefined) clearTimeout(timer);
+      window.removeEventListener(APPROVALS_DECIDED_EVENT, onDecided);
+    };
+  }, [client, outstanding]);
+}

--- a/packages/ui/src/tree/renderer.tsx
+++ b/packages/ui/src/tree/renderer.tsx
@@ -6,6 +6,7 @@ import {
   isPathBinding,
   isStateBinding,
   VENDO_TREE_FORMAT,
+  type ApprovalId,
   type Json,
   type PathBinding,
   type ToolOutcome,
@@ -41,8 +42,15 @@ import { ContainedNotice } from "./notice.js";
 import { KIT_COMPONENTS } from "../kit/registry.js";
 import { markHandlerCallback, screenEvent } from "../kit/handler.js";
 import { useKeyedState } from "../kit/state.js";
+import { useParkedApprovals } from "./parked-approvals.js";
 import type { ScreenInteractive, ScreenQuery } from "./screen-engine.js";
 import { useScreen, type ScreenBridge } from "./use-screen.js";
+
+/** A press the guard sent to approval, announced through `onParked`. */
+export interface ParkedPress {
+  nodeId: string;
+  approvalId: ApprovalId;
+}
 
 export interface TreeViewProps {
   tree: WalkTree;
@@ -55,6 +63,13 @@ export interface TreeViewProps {
   components: Record<string, ComponentType>;
   data?: Record<string, Json>;
   onAction(req: { nodeId: string; action: string; payload?: Json }): Promise<ToolOutcome>;
+  /**
+   * Fires the instant a press is PARKED on an approval. The tree resolves the
+   * approval on its own (parked-approvals.ts) and repaints when it lands; this
+   * is the seam for a surface that wants to put the decision in front of the
+   * person instead of leaving them to go find it.
+   */
+  onParked?: (parked: ParkedPress) => void;
   /**
    * 08-ui §5; 06-apps §6 — additive persistence hook for TreeView-local `$state`.
    * It fires with the complete state map after every jail `state-set` message.
@@ -77,6 +92,8 @@ export interface PayloadRendererProps {
   components: Record<string, ComponentType>;
   data?: Record<string, Json>;
   onAction(req: { nodeId: string; action: string; payload?: Json }): Promise<ToolOutcome>;
+  /** As {@link TreeViewProps.onParked}. */
+  onParked?: (parked: ParkedPress) => void;
   onStateChange?(state: Record<string, Json>): void;
 }
 
@@ -665,6 +682,7 @@ function StatefulTreeView({
   components,
   data,
   onAction,
+  onParked,
   onStateChange,
   interactive,
 }: TreeViewProps) {
@@ -690,8 +708,9 @@ function StatefulTreeView({
       };
     }
     setOutcomes((current) => ({ ...current, [nodeId]: outcome.status === "ok" ? undefined : outcome }));
+    if (outcome.status === "pending-approval") onParked?.({ nodeId, approvalId: outcome.approvalId });
     return outcome;
-  }, [onAction]);
+  }, [onAction, onParked]);
 
   // A screen's own failure (a VM that will not boot, a handler that threw) lands
   // in the same per-node slot a failed action does — one place a region reports
@@ -702,6 +721,27 @@ function StatefulTreeView({
   // What the screen may render: the Kit plus whatever this host registered.
   const catalog = useMemo(() => [...KIT_COMPONENT_NAMES, ...Object.keys(components)], [components]);
   const screen = useScreen({ interactive, base: painted, catalog, runAction, onFailure: failNode });
+  // Every press still waiting on an approval, read straight off the outcome
+  // slots that hold its notice — resolving one clears the slot, which is also
+  // what stops the watch.
+  const parked = useMemo(() => new Map(Object.entries(outcomes).flatMap(([nodeId, outcome]) =>
+    outcome?.status === "pending-approval" ? [[nodeId, outcome.approvalId] as [string, string]] : [])), [outcomes]);
+  // The approval's answer lands in the SAME per-node slot the press itself
+  // fills, so a resumed call that succeeded clears its own stale notice and
+  // re-reads the screen — the only thing that clears the "Sending…" a parked
+  // press left behind, since the screen re-boots on the fresh data. A tree with
+  // no query plan (a plain action tree) has nothing to re-read; its notice
+  // still settles.
+  useParkedApprovals(parked, (nodeId, resolution) => {
+    const settled: ToolOutcome = resolution.state === "executed" ? resolution.outcome : {
+      status: "blocked",
+      reason: resolution.state === "expired"
+        ? "This needed approval and nobody answered in time — nothing was sent."
+        : "This wasn’t approved — nothing was sent.",
+    };
+    setOutcomes((current) => ({ ...current, [nodeId]: settled.status === "ok" ? undefined : settled }));
+    if (settled.status === "ok") void screen.refresh(nodeId);
+  });
   // The served paint until a handler moves the screen, and the screen's own tree
   // after — one walk, so validation, bindings, `$state` and outcomes are the ones
   // already here rather than a second renderer for interactive trees.

--- a/packages/ui/src/tree/renderer.tsx
+++ b/packages/ui/src/tree/renderer.tsx
@@ -22,6 +22,7 @@ import {
 } from "@vendoai/apps/contract";
 import { convertPayload } from "./convert-payload.js";
 import {
+  Fragment,
   useCallback,
   useEffect,
   useMemo,
@@ -404,6 +405,36 @@ function outcomeNotice(
   return null;
 }
 
+/**
+ * An answer belongs to the node that fired the press — and a generated screen
+ * routinely closes the confirm panel that node lived in, which used to take the
+ * answer off the page with it (the button pressed, then nothing, forever). Node
+ * ids are structural paths (apps/contract/genui/component/flatten.ts), so the
+ * notice climbs instead: the longest dot-prefix that still names a live node
+ * carries it, worst case the root. Two orphans that reach the same ancestor
+ * both render, stacked in the order their slots were filled.
+ */
+function orphanedOutcomes(
+  outcomes: Record<string, ToolOutcome | undefined>,
+  nodes: ReadonlyMap<string, TreeNode>,
+): ReadonlyMap<string, Array<[string, ToolOutcome]>> {
+  const homed = new Map<string, Array<[string, ToolOutcome]>>();
+  for (const [nodeId, outcome] of Object.entries(outcomes)) {
+    if (outcome === undefined || nodes.has(nodeId)) continue;
+    let host = nodeId;
+    while (!nodes.has(host)) {
+      const cut = host.lastIndexOf(".");
+      if (cut < 0) break;
+      host = host.slice(0, cut);
+    }
+    if (!nodes.has(host)) continue;
+    const slot = homed.get(host);
+    if (slot === undefined) homed.set(host, [[nodeId, outcome]]);
+    else slot.push([nodeId, outcome]);
+  }
+  return homed;
+}
+
 interface NodeRendererProps {
   nodeId: string;
   ancestry: ReadonlySet<string>;
@@ -421,6 +452,9 @@ interface NodeRendererProps {
   state: Record<string, Json>;
   streaming: boolean;
   outcomes: Record<string, ToolOutcome | undefined>;
+  /** Outcomes whose own node left the tree, re-homed on the nearest surviving
+   *  ancestor by {@link orphanedOutcomes}: ancestor id → the fired ids it carries. */
+  orphans: ReadonlyMap<string, Array<[string, ToolOutcome]>>;
   runAction(nodeId: string, action: string, payload?: Json): Promise<ToolOutcome>;
   /** Re-raise a node's park, so a dismissed ask can be asked again. Absent when
    *  the caller passed no `onParked` — there would be nowhere to raise it. */
@@ -683,10 +717,17 @@ function NodeRenderer(props: NodeRendererProps) {
 
   const outcome = props.outcomes[node.id];
   const review = props.onReview;
+  // Re-raising a park names the node that FIRED it, never the one carrying the
+  // notice — an orphan's press is still that press.
+  const notice = (firedId: string, settled: ToolOutcome | undefined): ReactNode =>
+    outcomeNotice(settled, review === undefined ? undefined : (approvalId) => review(firedId, approvalId));
   return (
     <NodeShell nodeId={node.id} outcome={outcome} mark={props.marks.get(node.id)}>
       {content}
-      {outcomeNotice(outcome, review === undefined ? undefined : (approvalId) => review(node.id, approvalId))}
+      {notice(node.id, outcome)}
+      {props.orphans.get(node.id)?.map(([firedId, orphan]) => (
+        <Fragment key={firedId}>{notice(firedId, orphan)}</Fragment>
+      ))}
     </NodeShell>
   );
 }
@@ -850,6 +891,9 @@ function StatefulTreeView({
   // is the one paint that animates. A served first paint, every streaming chunk
   // and every non-interactive payload swap instantly, as they always have.
   const repaint = useRepaintMotion(nodes, interactive !== undefined && !streaming);
+  // Against the map that is actually WALKED, so a re-homed notice always lands
+  // on a node this render mounts.
+  const orphans = useMemo(() => orphanedOutcomes(outcomes, repaint.nodes), [outcomes, repaint.nodes]);
 
   // A review-kind version awaiting the host reviewer renders NOTHING but its
   // standing, checked BEFORE tree validation:
@@ -962,6 +1006,7 @@ function StatefulTreeView({
         state={viewState}
         streaming={streaming}
         outcomes={outcomes}
+        orphans={orphans}
         runAction={runAction}
         {...(onReview === undefined ? {} : { onReview })}
         setViewState={updateState}

--- a/packages/ui/src/tree/renderer.tsx
+++ b/packages/ui/src/tree/renderer.tsx
@@ -369,12 +369,25 @@ const dataShapeNotice = (mismatch: string, streaming: boolean, name: string): Re
     </ContainedNotice>
   );
 
-function outcomeNotice(outcome: ToolOutcome | undefined): ReactNode {
+function outcomeNotice(
+  outcome: ToolOutcome | undefined,
+  /** Re-raise this node's park. Absent when nobody is listening for one. */
+  onReview?: (approvalId: ApprovalId) => void,
+): ReactNode {
   if (!outcome || outcome.status === "ok") return null;
   if (outcome.status === "pending-approval") {
+    // The ask can be dismissed (Esc closes the modal without deciding), and
+    // this notice is the way back to it — the SAME box, now pressable, rather
+    // than a second affordance nobody would find. The id stays a dev-mode aid.
+    const approvalId = outcome.approvalId;
     return (
-      <ContainedNotice label="Action pending approval" outcome={outcome.status}>
-        {`Action is waiting for approval (${outcome.approvalId}).`}
+      <ContainedNotice
+        label="Action pending approval"
+        outcome={outcome.status}
+        detail={`(${approvalId})`}
+        {...(onReview === undefined ? {} : { onPress: () => onReview(approvalId) })}
+      >
+        {onReview === undefined ? "Waiting for your approval." : "Waiting for your approval — review"}
       </ContainedNotice>
     );
   }
@@ -409,6 +422,9 @@ interface NodeRendererProps {
   streaming: boolean;
   outcomes: Record<string, ToolOutcome | undefined>;
   runAction(nodeId: string, action: string, payload?: Json): Promise<ToolOutcome>;
+  /** Re-raise a node's park, so a dismissed ask can be asked again. Absent when
+   *  the caller passed no `onParked` — there would be nowhere to raise it. */
+  onReview?(nodeId: string, approvalId: ApprovalId): void;
   setViewState(key: string, value: Json): void;
   /** The live screen behind this tree, when there is one. */
   screen?: Pick<ScreenBridge, "fire" | "inFlight">;
@@ -666,10 +682,11 @@ function NodeRenderer(props: NodeRendererProps) {
   const content = node.source === "generated" ? generatedContent(context) : builtinContent(context);
 
   const outcome = props.outcomes[node.id];
+  const review = props.onReview;
   return (
     <NodeShell nodeId={node.id} outcome={outcome} mark={props.marks.get(node.id)}>
       {content}
-      {outcomeNotice(outcome)}
+      {outcomeNotice(outcome, review === undefined ? undefined : (approvalId) => review(node.id, approvalId))}
     </NodeShell>
   );
 }
@@ -743,6 +760,16 @@ function StatefulTreeView({
     return outcome;
   }, [onAction, onParked]);
 
+  // Pressing the pending notice raises the SAME park again, down the SAME
+  // channel — so whichever surface answered the first announcement (the modal)
+  // presents the ask again after an Esc. Nothing to raise it to, no affordance.
+  const onReview = useMemo(
+    () => onParked === undefined
+      ? undefined
+      : (nodeId: string, approvalId: ApprovalId) => onParked({ nodeId, approvalId }),
+    [onParked],
+  );
+
   // A screen's own failure (a VM that will not boot, a handler that threw) lands
   // in the same per-node slot a failed action does — one place a region reports
   // that something didn't work.
@@ -758,9 +785,11 @@ function StatefulTreeView({
   const parked = useMemo(() => new Map(Object.entries(outcomes).flatMap(([nodeId, outcome]) =>
     outcome?.status === "pending-approval" ? [[nodeId, outcome.approvalId] as [string, string]] : [])), [outcomes]);
   // The approval's answer lands in the SAME per-node slot the press itself
-  // fills, so a resumed call that succeeded clears its own stale notice and
-  // re-reads the screen — the only thing that clears the "Sending…" a parked
-  // press left behind, since the screen re-boots on the fresh data. A tree with
+  // fills, and EVERY terminal answer re-reads the screen. Not just the happy
+  // one: the re-read is also the only thing that RE-BOOTS the screen, and a
+  // screen's own `useState` (the "Sending…" flag a generated handler sets
+  // before it awaits) has no other way back — a declined press used to leave
+  // its own controls locked forever over data that never changed. A tree with
   // no query plan (a plain action tree) has nothing to re-read; its notice
   // still settles.
   useParkedApprovals(parked, (nodeId, resolution) => {
@@ -770,8 +799,13 @@ function StatefulTreeView({
         ? "This needed approval and nobody answered in time — nothing was sent."
         : "This wasn’t approved — nothing was sent.",
     };
-    setOutcomes((current) => ({ ...current, [nodeId]: settled.status === "ok" ? undefined : settled }));
-    if (settled.status === "ok") void screen.refresh(nodeId);
+    // The stale pending notice goes now; the refusal's own notice lands AFTER
+    // the repaint, because the re-read's reads run through `runAction` and an
+    // ok read clears this very slot.
+    setOutcomes((current) => ({ ...current, [nodeId]: undefined }));
+    void screen.refresh(nodeId).then(() => {
+      if (settled.status !== "ok") setOutcomes((current) => ({ ...current, [nodeId]: settled }));
+    });
   });
   // The served paint until a handler moves the screen, and the screen's own tree
   // after — one walk, so validation, bindings, `$state` and outcomes are the ones
@@ -929,6 +963,7 @@ function StatefulTreeView({
         streaming={streaming}
         outcomes={outcomes}
         runAction={runAction}
+        {...(onReview === undefined ? {} : { onReview })}
         setViewState={updateState}
         {...(interactive === undefined ? {} : { screen })}
       />

--- a/packages/ui/src/tree/renderer.tsx
+++ b/packages/ui/src/tree/renderer.tsx
@@ -24,6 +24,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ComponentType,
   type ReactNode,
@@ -38,6 +39,7 @@ import { deriveFormShape, FormingSkeleton, PendingLeaf } from "./forming-skeleto
 import { InClientMount } from "./host-mount.js";
 import { JailedComponent, type JailFurnishing } from "./jail/JailedComponent.js";
 import { ContainedNotice } from "./notice.js";
+import { playNodeMotion, useMotionLayoutEffect, useRepaintMotion, type NodeMark } from "./repaint-motion.js";
 import { KIT_COMPONENTS } from "../kit/registry.js";
 import { markHandlerCallback, screenEvent } from "../kit/handler.js";
 import { useKeyedState } from "../kit/state.js";
@@ -393,6 +395,8 @@ interface NodeRendererProps {
   setViewState(key: string, value: Json): void;
   /** The live screen behind this tree, when there is one. */
   screen?: Pick<ScreenBridge, "fire" | "inFlight">;
+  /** What this repaint moved, per node (repaint-motion.ts). Empty on a first paint. */
+  marks: ReadonlyMap<string, NodeMark>;
 }
 
 const EMPTY_LAYOUT_COMPONENTS = new Set(["Stack", "Row", "Grid"]);
@@ -646,9 +650,36 @@ function NodeRenderer(props: NodeRendererProps) {
 
   const outcome = props.outcomes[node.id];
   return (
-    <div data-vendo-node-id={node.id} data-vendo-outcome={outcome?.status === "ok" ? undefined : outcome?.status}>
+    <NodeShell nodeId={node.id} outcome={outcome} mark={props.marks.get(node.id)}>
       {content}
       {outcomeNotice(outcome)}
+    </NodeShell>
+  );
+}
+
+/**
+ * Every node's box, and the one thing a repaint can animate. A mark arrives on
+ * the render that carries the change and never on a first paint, so the effect
+ * plays exactly one beat per node per repaint (repaint-motion.ts).
+ */
+function NodeShell({ nodeId, outcome, mark, children }: {
+  nodeId: string;
+  outcome: ToolOutcome | undefined;
+  mark: NodeMark | undefined;
+  children: ReactNode;
+}) {
+  const box = useRef<HTMLDivElement>(null);
+  useMotionLayoutEffect(() => {
+    if (mark !== undefined && box.current !== null) playNodeMotion(box.current, mark);
+  }, [mark]);
+  return (
+    <div
+      ref={box}
+      data-vendo-node-id={nodeId}
+      data-vendo-outcome={outcome?.status === "ok" ? undefined : outcome?.status}
+      {...(mark?.kind === "exit" ? { "aria-hidden": true, "data-vendo-departing": "" } : {})}
+    >
+      {children}
     </div>
   );
 }
@@ -739,6 +770,12 @@ function StatefulTreeView({
     () => new Map(validation.ok ? validation.tree.nodes.map((node) => [node.id, node]) : []),
     [validation.ok ? validation.tree.nodes : validation.error.message],
   );
+
+  // A repaint of a screen that is already on the page — a handler moved it, or a
+  // successful tool made its data stale and the refresh brought new rows back —
+  // is the one paint that animates. A served first paint, every streaming chunk
+  // and every non-interactive payload swap instantly, as they always have.
+  const repaint = useRepaintMotion(nodes, interactive !== undefined && !streaming);
 
   // A review-kind version awaiting the host reviewer renders NOTHING but its
   // standing, checked BEFORE tree validation:
@@ -839,7 +876,8 @@ function StatefulTreeView({
       <NodeRenderer
         nodeId={validation.tree.root}
         ancestry={new Set()}
-        nodes={nodes}
+        nodes={repaint.nodes}
+        marks={repaint.marks}
         generated={streaming ? tree.components ?? {} : validation.tree.components ?? {}}
         {...(componentTools === undefined ? {} : { componentTools })}
         inClientGranted={inClientGranted}

--- a/packages/ui/src/tree/repaint-motion.ts
+++ b/packages/ui/src/tree/repaint-motion.ts
@@ -1,0 +1,362 @@
+/**
+ * The animated landing: when a handler's refresh repaints an already-painted
+ * screen, the CHANGE is shown rather than swapped.
+ *
+ * A repaint arrives as a whole new flat tree, but the node ids are structural
+ * paths (apps/contract/genui/component/flatten.ts) and they are already this
+ * renderer's React keys — so React has mounted, updated and unmounted the right
+ * elements before we get here. All that is missing is the beat that says which:
+ * a row that arrived slides open under a fading highlight, a row that left
+ * collapses out, and a value that moved pulses (and, for the Kit's numeric
+ * leaves, rolls to its new figure).
+ *
+ * Three rules the shape encodes:
+ *
+ *  1. Only repaints animate. The first paint, every streaming chunk and the
+ *     forming-skeleton reveal (fluid-reveal.tsx) are somebody else's beat — the
+ *     baseline resets whenever motion is off, so the first paint AFTER a stream
+ *     is still a first paint.
+ *  2. Nothing ambiguous animates. A keyless sibling's id is its POSITION, so
+ *     deleting the middle row of an unkeyed list renames every row below it and
+ *     the diff reads "the LAST row left". That would collapse the wrong row, so
+ *     when the ids of a changed list are positional AND its survivors' contents
+ *     shifted, the whole list swaps instantly instead. A missing animation reads
+ *     fine; a wrong one reads broken.
+ *  3. One beat, not fireworks. Past {@link MAX_MARKS} changed nodes the repaint
+ *     is a different view rather than a data refresh, and nothing animates.
+ */
+import { isHandlerRef, SCREEN_TEXT_NODE } from "@vendoai/apps/contract";
+import type { Json, TreeNode } from "@vendoai/core";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { applyFormat, formatMoney, formatNum, formatPercent, type ValueFormat } from "../kit/format.js";
+import { t } from "../kit/tokens.js";
+
+export type NodeMap = ReadonlyMap<string, TreeNode>;
+
+/** A value that rolls from one figure to the next rather than cutting to it. */
+export interface NumericTick {
+  from: number;
+  to: number;
+  /** The exact string the leaf renders for a value — the tick writes these. */
+  render(value: number): string | null;
+}
+
+export type NodeMark =
+  | { kind: "enter" }
+  | { kind: "exit" }
+  | { kind: "pulse"; tick: NumericTick | null };
+
+export interface PaintDiff {
+  marks: ReadonlyMap<string, NodeMark>;
+  /** Departed subtrees, with the surviving parent and slot they held. */
+  exits: ReadonlyArray<{ parent: string; index: number; id: string }>;
+}
+
+const EMPTY_DIFF: PaintDiff = { marks: new Map(), exits: [] };
+
+/** Past this many changed nodes a repaint is a new view, not a refresh. */
+const MAX_MARKS = 24;
+
+/**
+ * The Kit's numeric leaves: the prop holding the number, and how that leaf
+ * prints it. Everything else pulses without rolling — a date or a status has no
+ * in-between to show.
+ */
+const NUMERIC_LEAVES: Record<string, (props: Record<string, Json>) => NumericTick["render"] | null> = {
+  Money: (props) => (value) => formatMoney(value, {
+    ...(typeof props.currency === "string" ? { currency: props.currency } : {}),
+    ...(typeof props.locale === "string" ? { locale: props.locale } : {}),
+  }),
+  Num: (props) => (value) => formatNum(value, {
+    ...(typeof props.maximumFractionDigits === "number" ? { maximumFractionDigits: props.maximumFractionDigits } : {}),
+    ...(props.notation === "compact" || props.notation === "standard" ? { notation: props.notation } : {}),
+  }),
+  Percent: (props) => (value) => formatPercent(value, {
+    ...(typeof props.fractionDigits === "number" ? { fractionDigits: props.fractionDigits } : {}),
+    ...(props.whole === true ? { whole: true } : {}),
+  }),
+  Stat: (props) => (value) => applyFormat(value, (props.format ?? "text") as ValueFormat),
+};
+
+/** The numeric prop of a Kit numeric leaf, when it holds a finite number. */
+const numericValue = (node: TreeNode): number | undefined => {
+  if (!(node.component in NUMERIC_LEAVES)) return undefined;
+  const raw = node.component === "Money" ? node.props?.amount : node.props?.value;
+  return typeof raw === "number" && Number.isFinite(raw) ? raw : undefined;
+};
+
+const tickBetween = (before: TreeNode, after: TreeNode): NumericTick | null => {
+  const from = numericValue(before);
+  const to = numericValue(after);
+  if (from === undefined || to === undefined || from === to) return null;
+  const render = NUMERIC_LEAVES[after.component]?.(after.props ?? {});
+  // A leaf that cannot print its own value (a bad currency code) has nothing to
+  // roll THROUGH, so it takes the pulse alone.
+  return render && render(to) !== null ? { from, to, render } : null;
+};
+
+const parentsOf = (map: NodeMap): Map<string, string> => {
+  const parents = new Map<string, string>();
+  for (const node of map.values()) for (const child of node.children ?? []) parents.set(child, node.id);
+  return parents;
+};
+
+/**
+ * What a leaf SHOWS: its own props plus the text its text-children hold. Key
+ * order is the VM's own and stable across its paints.
+ *
+ * `{$handler}` props are machinery, not a value — and their ids are minted
+ * against the node's POSITION, so every row below a deleted one gets a new
+ * handler id and would pulse for a value that never moved.
+ */
+const contentOf = (node: TreeNode, map: NodeMap): string => JSON.stringify([
+  Object.entries(node.props ?? {}).filter(([, value]) => !isHandlerRef(value)),
+  (node.children ?? []).map((id) => map.get(id)?.props?.text ?? null),
+]);
+
+/** A node whose children are all runs of text — the deepest thing that owns a
+ *  displayed value. A container never pulses: its card is not what changed. */
+const isLeaf = (node: TreeNode, map: NodeMap): boolean =>
+  (node.children ?? []).every((id) => map.get(id)?.component === SCREEN_TEXT_NODE);
+
+/** Does an author key name this node, or only its position? */
+const isKeyed = (id: string): boolean => id.slice(id.lastIndexOf(".") + 1).includes(":");
+
+const descends = (id: string, ancestor: string, parents: Map<string, string>): boolean => {
+  let walk = parents.get(id);
+  while (walk !== undefined) {
+    if (walk === ancestor) return true;
+    walk = parents.get(walk);
+  }
+  return false;
+};
+
+/** What moved between two paints of the same screen. Pure. */
+export function diffPaints(before: NodeMap, after: NodeMap): PaintDiff {
+  const wasParent = parentsOf(before);
+  const isParent = parentsOf(after);
+
+  // Only the TOPMOST arrival/departure animates: a row that slid in does not
+  // also need each of its cells to slide in.
+  const entered = [...after.keys()]
+    .filter((id) => !before.has(id) && before.has(isParent.get(id) ?? ""));
+  const exited = [...before.keys()]
+    .filter((id) => !after.has(id) && after.has(wasParent.get(id) ?? ""));
+  const pulsed = [...after.keys()].filter((id) => {
+    const now = after.get(id)!;
+    const then = before.get(id);
+    return then !== undefined && isLeaf(now, after) && contentOf(then, before) !== contentOf(now, after);
+  });
+
+  // Rule 2 — a keyed id names a thing, so its arrival IS an arrival. A
+  // POSITIONAL one only names a slot: if a list's positional survivors are
+  // showing different contents, the ids renumbered and the diff is reading the
+  // wrong row. Drop that list's positional marks; its keyed siblings are
+  // unaffected, and so is the rest of the screen.
+  const suppressed = new Set<string>();
+  for (const parent of new Set([...entered.map((id) => isParent.get(id)!), ...exited.map((id) => wasParent.get(id)!)])) {
+    const slots = [...entered, ...exited]
+      .filter((id) => (isParent.get(id) ?? wasParent.get(id)) === parent && !isKeyed(id));
+    if (slots.length === 0) continue;
+    const held = (after.get(parent)?.children ?? []).filter((id) => before.has(id) && !isKeyed(id));
+    const shifted = pulsed.filter((leaf) => held.some((slot) => slot === leaf || descends(leaf, slot, isParent)));
+    if (shifted.length === 0) continue;
+    for (const id of [...slots, ...shifted]) suppressed.add(id);
+  }
+
+  const marks = new Map<string, NodeMark>();
+  for (const id of entered) if (!suppressed.has(id)) marks.set(id, { kind: "enter" });
+  for (const id of exited) if (!suppressed.has(id)) marks.set(id, { kind: "exit" });
+  for (const id of pulsed) {
+    if (!suppressed.has(id)) marks.set(id, { kind: "pulse", tick: tickBetween(before.get(id)!, after.get(id)!) });
+  }
+  if (marks.size === 0 || marks.size > MAX_MARKS) return EMPTY_DIFF;
+
+  const exits = exited
+    .filter((id) => marks.has(id))
+    .map((id) => {
+      const parent = wasParent.get(id)!;
+      return { parent, index: (before.get(parent)?.children ?? []).indexOf(id), id };
+    });
+  return { marks, exits };
+}
+
+/** Copy a departed subtree out of the paint it belonged to. */
+const carryOver = (from: NodeMap, id: string, into: Map<string, TreeNode>): void => {
+  const node = from.get(id);
+  if (node === undefined || into.has(id)) return;
+  into.set(id, node);
+  for (const child of node.children ?? []) carryOver(from, child, into);
+};
+
+/** Held one beat past the repaint, so departing rows have something to leave. */
+const EXIT_HOLD_MS = 360;
+
+/**
+ * Reduced motion means an INSTANT swap, not a slower one — and an environment
+ * with no Web Animations (SSR, jsdom) is in exactly the same position: holding a
+ * departed row for a beat it cannot animate out just leaves a corpse on screen.
+ * Either way the repaint lands the way it always did.
+ */
+const motionAllowed = (): boolean =>
+  typeof window !== "undefined"
+  && typeof Element.prototype.animate === "function"
+  && window.matchMedia?.("(prefers-reduced-motion: reduce)").matches !== true;
+
+/** The beat has to be set up BEFORE the browser paints the repaint, or an
+ *  entering row flashes at full height for a frame. On the server there is no
+ *  paint (and no marks), so the layout variant would only earn a warning. */
+export const useMotionLayoutEffect = typeof document === "undefined" ? useEffect : useLayoutEffect;
+
+/**
+ * The renderer's seam. Returns the node map to WALK — the repaint's own, plus
+ * any departing subtrees spliced back into the slots they held — and the mark
+ * each node's shell should play.
+ *
+ * `active` is the caller's "this is a repaint of a live screen" gate; while it
+ * is false the baseline resets, so the paint that turns it back on is treated
+ * as a first paint rather than a diff against a stream.
+ */
+export function useRepaintMotion(nodes: NodeMap, active: boolean): { nodes: NodeMap; marks: ReadonlyMap<string, NodeMark> } {
+  const previous = useRef<NodeMap | null>(null);
+  const [beat, setBeat] = useState<{ diff: PaintDiff; before: NodeMap } | null>(null);
+
+  // Render-phase capture, as FluidReveal does it: the paint has to be diffed on
+  // the render that carries it, or the tree it replaced is already gone.
+  if (!active || !motionAllowed()) previous.current = null;
+  else if (previous.current !== nodes) {
+    const before = previous.current;
+    previous.current = nodes;
+    if (before !== null) {
+      const diff = diffPaints(before, nodes);
+      if (diff.marks.size > 0) setBeat({ diff, before });
+    }
+  }
+
+  useEffect(() => {
+    if (beat === null) return undefined;
+    const timer = setTimeout(() => setBeat(null), EXIT_HOLD_MS);
+    return () => clearTimeout(timer);
+  }, [beat]);
+
+  const walked = useMemo(() => {
+    if (beat === null || beat.diff.exits.length === 0) return nodes;
+    const merged = new Map(nodes);
+    for (const exit of beat.diff.exits) carryOver(beat.before, exit.id, merged);
+    for (const parent of new Set(beat.diff.exits.map((exit) => exit.parent))) {
+      const node = merged.get(parent);
+      if (node === undefined) continue;
+      const children = [...(node.children ?? [])];
+      for (const exit of beat.diff.exits.filter((one) => one.parent === parent).sort((a, b) => a.index - b.index)) {
+        children.splice(Math.min(Math.max(exit.index, 0), children.length), 0, exit.id);
+      }
+      merged.set(parent, { ...node, children });
+    }
+    return merged;
+  }, [nodes, beat]);
+
+  return { nodes: walked, marks: beat?.diff.marks ?? EMPTY_DIFF.marks };
+}
+
+// ── The motion itself ───────────────────────────────────────────────────────
+// Transform/opacity carry the beat; the collapse animates height because that
+// is what closes the gap a departing row leaves — the rows below it ride the
+// same 280ms rather than needing a second animation of their own.
+
+const ENTER_MS = 340;
+const EXIT_MS = 280;
+const HIGHLIGHT_MS = 800;
+const PULSE_MS = 520;
+const TICK_MS = 600;
+/** Strong ease-out: entrances and exits both answer the user immediately. */
+const EASE = "cubic-bezier(0.23, 1, 0.32, 1)";
+
+const TINT = `color-mix(in srgb, ${t.accent} 9%, transparent)`;
+const RING = `color-mix(in srgb, ${t.accent} 26%, transparent)`;
+
+/**
+ * The highlight: a brand-tinted wash that holds a third of a beat, then fades.
+ *
+ * It borrows the radius of whatever it wraps so it hugs a card's corners
+ * instead of boxing them, and falls back to a soft 6px for a bare run of text —
+ * a square-cornered tint on a number reads as a text SELECTION, not a change.
+ * An arriving row earns a hairline ring to define it; a value that merely moved
+ * gets the wash alone, spread a few pixels past the glyphs.
+ */
+function highlight(el: HTMLElement, duration: number, ring: boolean): void {
+  const inner = el.firstElementChild;
+  const radius = inner === null ? "" : getComputedStyle(inner).borderRadius;
+  el.style.borderRadius = radius && radius !== "0px" ? radius : "6px";
+  const lit = {
+    backgroundColor: TINT,
+    boxShadow: ring ? `0 0 0 1px ${RING}, 0 10px 30px -12px ${RING}` : `0 0 0 4px ${TINT}`,
+  };
+  const dark = { backgroundColor: "transparent", boxShadow: ring ? "0 0 0 1px transparent, 0 10px 30px -12px transparent" : "0 0 0 4px transparent" };
+  const animation = el.animate(
+    [{ ...lit, offset: 0 }, { ...lit, offset: 0.3 }, { ...dark, offset: 1 }],
+    { duration, easing: "ease-out" },
+  );
+  void animation.finished.then(() => { el.style.borderRadius = ""; }, () => undefined);
+}
+
+/** The gap a stacking parent puts between its children. A row on its way out
+ *  has to give that back too, or the list closes 14px short and jumps when the
+ *  departing box finally unmounts. */
+const stackGap = (el: HTMLElement): string => {
+  const parent = el.parentElement;
+  const gap = parent === null ? Number.NaN : Number.parseFloat(getComputedStyle(parent).rowGap);
+  return Number.isFinite(gap) && gap > 0 ? `${-gap}px` : "0px";
+};
+
+/** Roll a leaf's rendered figure to its new value. The text node is found by the
+ *  string React just wrote, so a leaf we cannot identify is simply left alone. */
+function roll(el: HTMLElement, tick: NumericTick): void {
+  const settled = tick.render(tick.to);
+  const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+  let target: Text | null = null;
+  for (let node = walker.nextNode(); node !== null && target === null; node = walker.nextNode()) {
+    if (node.nodeValue === settled) target = node as Text;
+  }
+  if (target === null) return;
+  const started = performance.now();
+  const step = (now: number): void => {
+    // Clamped at BOTH ends: rAF reports the frame's START time, which can
+    // predate the layout effect that scheduled it — an unclamped negative
+    // progress makes the first figure overshoot past where it began.
+    const progress = Math.min(1, Math.max(0, (now - started) / TICK_MS));
+    const eased = 1 - (1 - progress) ** 3;
+    target.nodeValue = progress === 1 ? settled : tick.render(tick.from + (tick.to - tick.from) * eased) ?? settled;
+    if (progress < 1) requestAnimationFrame(step);
+  };
+  // The old figure goes back BEFORE the browser paints the repaint, or the
+  // value flashes its new number for one frame and then rewinds to roll.
+  step(started);
+  requestAnimationFrame(step);
+}
+
+/** Play a node's mark on its shell element. Safe to call with no Web Animations
+ *  support (jsdom, older engines): the beat is skipped, the paint still lands. */
+export function playNodeMotion(el: HTMLElement, mark: NodeMark): void {
+  if (typeof el.animate !== "function") return;
+  if (mark.kind === "pulse") {
+    highlight(el, PULSE_MS, false);
+    if (mark.tick !== null) roll(el, mark.tick);
+    return;
+  }
+  const height = `${el.getBoundingClientRect().height}px`;
+  const closed = { height: "0px", opacity: 0, marginBottom: stackGap(el) };
+  const open = { height, opacity: 1, marginBottom: "0px", transform: "none" };
+  el.style.overflow = "hidden";
+  if (mark.kind === "exit") {
+    // A row on its way out must not take a click with it.
+    el.style.pointerEvents = "none";
+    el.animate([{ ...open }, { ...closed, transform: "translateY(-4px)" }], { duration: EXIT_MS, easing: EASE, fill: "forwards" });
+    return;
+  }
+  const opening = el.animate(
+    [{ ...closed, transform: "translateY(-6px)" }, { ...open }],
+    { duration: ENTER_MS, easing: EASE },
+  );
+  void opening.finished.then(() => { el.style.overflow = ""; }, () => undefined);
+  highlight(el, HIGHLIGHT_MS, true);
+}

--- a/packages/ui/src/tree/use-screen.ts
+++ b/packages/ui/src/tree/use-screen.ts
@@ -57,6 +57,11 @@ export interface ScreenBridge {
   /** Handler ids with an intent in flight — their control renders disabled. */
   inFlight: ReadonlySet<string>;
   fire(nodeId: string, handlerId: string, event?: unknown): void;
+  /** Re-read the plan and re-boot on the answer — the same cycle a changed
+   *  action runs. Public for the one change that arrives from OUTSIDE a press:
+   *  an approval decided elsewhere, whose resumed call already moved the data
+   *  this screen is painted from (parked-approvals.ts). */
+  refresh(nodeId: string): Promise<void>;
 }
 
 export interface ScreenBridgeInput {
@@ -241,5 +246,5 @@ export function useScreen(input: ScreenBridgeInput): ScreenBridge {
   // reaches the newest one through here.
   latest.current = { interactive, base, catalog, onFailure, fire };
 
-  return { tree, inFlight, fire };
+  return { tree, inFlight, fire, refresh };
 }

--- a/packages/ui/src/wire-types.ts
+++ b/packages/ui/src/wire-types.ts
@@ -162,7 +162,10 @@ export interface EnableResult {
  *  renders them with the existing failed vocabulary, never a blank).
  *  Mirrors the umbrella's `ByoApprovalResolution`. */
 export type ApprovalResolution =
-  | { state: "pending"; request: ApprovalRequest }
+  // The request is absent only for an in-app parked press read during the
+  // resume window: still undecided, but the ask itself is gone (the umbrella's
+  // ByoApprovalResolution says why). Surfaces keep waiting on it.
+  | { state: "pending"; request?: ApprovalRequest }
   | { state: "executed"; outcome: ToolOutcome }
   | { state: "declined" }
   | { state: "expired" };

--- a/packages/ui/test/chrome/approval-modal.test.tsx
+++ b/packages/ui/test/chrome/approval-modal.test.tsx
@@ -10,11 +10,15 @@
  * honestly while the approved action actually runs, and it never spends a
  * decision the person did not make.
  */
-import type { ApprovalId, ApprovalRequest, JsonSchema } from "@vendoai/core";
+import type { AppDocument, ApprovalId, ApprovalRequest, JsonSchema, UIPayload } from "@vendoai/core";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useEffect } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { APPROVALS_DECIDED_EVENT, VendoProvider, createVendoClient, type VendoClient } from "../../src/index.js";
 import { ApprovalModal, useApprovalModal } from "../../src/chrome/approval-modal.js";
+import { Remixable, VendoAppEmbed, VendoOverlay, type VendoThreadProps } from "../../src/chrome/index.js";
+import { useSplitView } from "../../src/chrome/split-view.js";
+import { ThreadPart } from "../../src/chrome/thread/parts.js";
 import type { ApprovalResolution } from "../../src/wire-types.js";
 import { createWireServer } from "../wire-server.js";
 
@@ -61,9 +65,11 @@ function request(over: Partial<ApprovalRequest> = {}): ApprovalRequest {
 function clientWith(over: {
   get?(id: ApprovalId): Promise<ApprovalResolution>;
   decide?(...args: Parameters<VendoClient["approvals"]["decide"]>): Promise<void>;
+  apps?: Partial<VendoClient["apps"]>;
 }): VendoClient {
   return {
     ...base,
+    apps: { ...base.apps, ...over.apps },
     approvals: {
       ...base.approvals,
       ...(over.get === undefined ? {} : { get: over.get }),
@@ -338,6 +344,105 @@ describe("the screen-initiated approval modal", () => {
       // …and the second never gets a turn just to announce it was handled.
       await new Promise(resolve => setTimeout(resolve, 250));
       expect(screen.queryByRole("dialog")).toBeNull();
+    });
+  });
+
+  /**
+   * EVERY surface a generated screen can live on, not just the dashboard slot.
+   * The modal shipped wired into `VendoSlot` alone, so the same money-moving
+   * press made from the conversation — the surface people actually build views
+   * in — parked in silence: no ask anywhere, and the screen sat on "Sending…".
+   *
+   * Each case presses a real action-bound button inside the real surface, over
+   * a host pipe that parks it, and asks for the ask. Nothing about the modal
+   * itself is exercised here; that is every case above.
+   */
+  describe("the surfaces a parked press asks from", () => {
+    const PAYEES: UIPayload = {
+      formatVersion: "vendo-genui/v2",
+      root: "root",
+      nodes: [{
+        id: "root",
+        component: "Button",
+        props: { label: "Send $47.50", onClick: { $action: "host_transferMoney" } },
+      }],
+    } as unknown as UIPayload;
+
+    /** The host pipe parks the press, and the wire answers for the ask it
+     *  parked on — the two halves any surface needs to raise this modal. */
+    const parking = (over: Partial<VendoClient["apps"]> = {}) => clientWith({
+      get: pending(),
+      apps: { call: async () => ({ status: "pending-approval", approvalId: "apr_1" as ApprovalId }), ...over },
+    });
+
+    /** The overlay is itself a dialog, so the ask is named, never positional. */
+    const askedFor = async () => (await screen.findByRole("dialog", { name: /^Approval for/u }))
+      .querySelector(".fl-apmodal-ask")!.textContent;
+
+    const press = async () => fireEvent.click(await screen.findByRole("button", { name: "Send $47.50" }));
+
+    it("the conversation's in-thread card", async () => {
+      render(
+        <VendoProvider client={parking()}>
+          <ThreadPart
+            part={{ type: "data-vendo-view", data: { appId: "app_1", payload: PAYEES } } as unknown as Parameters<typeof ThreadPart>[0]["part"]}
+            partKey="p0"
+            role="assistant"
+            restored={false}
+            risks={new Map()}
+          />
+        </VendoProvider>,
+      );
+      await press();
+      expect(await askedFor()).toBe("Send $47.50 to Acme Utilities?");
+    });
+
+    it("the workspace stage the same card expands onto", async () => {
+      // The stage renders its OWN copy of the view (the rail card keeps its
+      // preview), so the press made there is answered there.
+      const Probe = () => {
+        const split = useSplitView();
+        useEffect(() => {
+          split?.registerEmbed("app_1", PAYEES);
+          split?.expandTo("app_1");
+        }, [split]);
+        return null;
+      };
+      render(
+        <VendoProvider client={parking()}>
+          <VendoOverlay defaultOpen thread={Probe as unknown as (props: VendoThreadProps) => React.JSX.Element} />
+        </VendoProvider>,
+      );
+      await press();
+      expect(await askedFor()).toBe("Send $47.50 to Acme Utilities?");
+    });
+
+    it("the BYO chat surface's app embed", async () => {
+      render(
+        <VendoProvider client={parking({ open: async () => ({ kind: "tree", payload: PAYEES }) })}>
+          <VendoAppEmbed refValue={{ kind: "vendo/app-ref@1", appId: "app_1", title: "Payees" }} />
+        </VendoProvider>,
+      );
+      await press();
+      expect(await askedFor()).toBe("Send $47.50 to Acme Utilities?");
+    });
+
+    it("the remixed host component", async () => {
+      function TopMerchants() {
+        return <table><tbody><tr><td>Blue Bottle</td></tr></tbody></table>;
+      }
+      const fork = { id: "app_fork", name: "Top merchants", seed: { component: "TopMerchants" } } as unknown as AppDocument;
+      render(
+        <VendoProvider client={parking({
+          list: async () => [fork],
+          get: async () => fork,
+          open: async () => ({ kind: "tree", payload: PAYEES }),
+        })}>
+          <Remixable><TopMerchants /></Remixable>
+        </VendoProvider>,
+      );
+      await press();
+      expect(await askedFor()).toBe("Send $47.50 to Acme Utilities?");
     });
   });
 });

--- a/packages/ui/test/chrome/approval-modal.test.tsx
+++ b/packages/ui/test/chrome/approval-modal.test.tsx
@@ -1,0 +1,343 @@
+// @vitest-environment jsdom
+/**
+ * The screen-initiated approval modal.
+ *
+ * THE DEFECT it exists for: a money-moving button on a generated screen that
+ * parked on the guard had no UI anywhere — only a badge count on another
+ * surface — so the person who pressed it waited forever. These cases pin the
+ * behaviors that make the modal an answer rather than a second dead end:
+ * it says the ask in the product's own words for ANY tool, it shows the wait
+ * honestly while the approved action actually runs, and it never spends a
+ * decision the person did not make.
+ */
+import type { ApprovalId, ApprovalRequest, JsonSchema } from "@vendoai/core";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { APPROVALS_DECIDED_EVENT, VendoProvider, createVendoClient, type VendoClient } from "../../src/index.js";
+import { ApprovalModal, useApprovalModal } from "../../src/chrome/approval-modal.js";
+import type { ApprovalResolution } from "../../src/wire-types.js";
+import { createWireServer } from "../wire-server.js";
+
+let wire: Awaited<ReturnType<typeof createWireServer>>;
+let base: VendoClient;
+
+beforeEach(async () => {
+  wire = await createWireServer();
+  base = createVendoClient({ baseUrl: wire.url });
+});
+
+afterEach(async () => {
+  cleanup();
+  await wire.close();
+});
+
+const CENTS_SCHEMA: JsonSchema = {
+  type: "object",
+  properties: {
+    amount: { type: "integer", description: "Amount in integer cents" },
+    recipient_name: { type: "string", description: "Who is being paid" },
+    memo: { type: "string" },
+  },
+};
+
+function request(over: Partial<ApprovalRequest> = {}): ApprovalRequest {
+  return {
+    id: "apr_1" as ApprovalId,
+    call: { id: "call_1", tool: "host_transferMoney", args: { amount: 4750, recipient_name: "Acme Utilities", memo: "July water bill" } },
+    descriptor: {
+      name: "host_transferMoney",
+      title: "Send money",
+      inputSchema: CENTS_SCHEMA,
+      risk: "destructive",
+    },
+    inputPreview: "host_transferMoney …",
+    ctx: { principal: { kind: "user", subject: "user_1" }, venue: "app", presence: "present" },
+    createdAt: "2026-08-12T12:00:00.000Z",
+    ...over,
+  } as ApprovalRequest;
+}
+
+/** A client whose approval routes this test drives directly. */
+function clientWith(over: {
+  get?(id: ApprovalId): Promise<ApprovalResolution>;
+  decide?(...args: Parameters<VendoClient["approvals"]["decide"]>): Promise<void>;
+}): VendoClient {
+  return {
+    ...base,
+    approvals: {
+      ...base.approvals,
+      ...(over.get === undefined ? {} : { get: over.get }),
+      ...(over.decide === undefined ? {} : { decide: over.decide }),
+    },
+  };
+}
+
+function mount(client: VendoClient, onClose = () => undefined) {
+  return render(
+    <VendoProvider client={client}>
+      <ApprovalModal approvalId={"apr_1" as ApprovalId} onClose={onClose} />
+    </VendoProvider>,
+  );
+}
+
+const pending = (over?: Partial<ApprovalRequest>) =>
+  async (): Promise<ApprovalResolution> => ({ state: "pending", request: request(over) });
+
+const ask = () => screen.getByRole("dialog").querySelector(".fl-apmodal-ask")!.textContent;
+const notes = () => Array.from(screen.getByRole("dialog").querySelectorAll(".fl-apmodal-notes li")).map(li => li.textContent);
+const rows = () => Array.from(screen.getByRole("dialog").querySelectorAll(".fl-card-field"))
+  .map(row => `${row.querySelector("dt")!.textContent}: ${row.querySelector("dd")!.textContent}`);
+
+describe("the screen-initiated approval modal", () => {
+  describe("the ask it renders", () => {
+    it("states the real money and counterparty as the hero, with the rest of the inputs under it", async () => {
+      mount(clientWith({ get: pending() }));
+      await waitFor(() => expect(ask()).toBe("Send $47.50 to Acme Utilities?"));
+      // The honesty law: what the question did not name is on the surface,
+      // never behind a fold — and the raw 4750 never reaches a person.
+      expect(rows()).toEqual(["Memo: July water bill"]);
+      expect(notes()).toEqual(["Sends now, as you", "Can’t be undone"]);
+      expect(screen.getByRole("dialog").textContent).not.toContain("4750");
+    });
+
+    it("asks for a tool that moves no money at all — nothing here is wired to transfers", async () => {
+      mount(clientWith({
+        get: pending({
+          call: { id: "call_2", tool: "host_archiveProject", args: { project: "Orion", notify_team: true } },
+          descriptor: { name: "host_archiveProject", title: "Archive project", inputSchema: {}, risk: "destructive" },
+        }),
+      }));
+      await waitFor(() => expect(ask()).toBe("Archive project?"));
+      expect(rows()).toEqual(["Project: Orion", "Notify team: Yes"]);
+      expect(notes()).toEqual(["This makes a change you can’t undo, as you."]);
+    });
+
+    it("lands focus on the dialog, never on Approve — the press that opened it must not spend the decision", async () => {
+      mount(clientWith({ get: pending() }));
+      await waitFor(() => expect(ask()).toBe("Send $47.50 to Acme Utilities?"));
+      expect(document.activeElement).toBe(screen.getByRole("dialog"));
+    });
+  });
+
+  describe("deciding", () => {
+    it("holds a designed in-flight state until the approved action has actually run", async () => {
+      let release = () => undefined as void;
+      const running = new Promise<void>(resolve => { release = () => resolve(); });
+      const onClose = vi.fn();
+      mount(clientWith({ get: pending(), decide: () => running }), onClose);
+      await waitFor(() => expect(ask()).toBe("Send $47.50 to Acme Utilities?"));
+
+      fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+
+      // The POST does not return until the action has run (~25s in production),
+      // so the modal says so: both buttons locked, the wait stated plainly.
+      const approve = await screen.findByRole("button", { name: "Approving…" });
+      expect(approve).toHaveProperty("disabled", true);
+      expect(screen.getByRole("button", { name: "Deny" })).toHaveProperty("disabled", true);
+      expect(screen.getByText("Running now — this can take a few seconds.")).toBeDefined();
+      expect(screen.getByRole("dialog").getAttribute("data-deciding")).toBe("approve");
+      expect(onClose).not.toHaveBeenCalled();
+
+      release();
+      await waitFor(() => expect(onClose).toHaveBeenCalled());
+    });
+
+    it("refuses to close mid-decision: the action is already running on the server", async () => {
+      const onClose = vi.fn();
+      mount(clientWith({ get: pending(), decide: () => new Promise<void>(() => undefined) }), onClose);
+      await waitFor(() => expect(ask()).toBe("Send $47.50 to Acme Utilities?"));
+      fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+      await screen.findByRole("button", { name: "Approving…" });
+
+      fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+      fireEvent.click(document.querySelector(".fl-apmodal-scrim")!);
+
+      await new Promise(resolve => setTimeout(resolve, 250));
+      expect(onClose).not.toHaveBeenCalled();
+      expect(screen.getByRole("dialog")).toBeDefined();
+    });
+
+    it("denies through the same wire call and closes", async () => {
+      const decide = vi.fn(async () => undefined);
+      const onClose = vi.fn();
+      mount(clientWith({ get: pending(), decide }), onClose);
+      await waitFor(() => expect(ask()).toBe("Send $47.50 to Acme Utilities?"));
+      fireEvent.click(screen.getByRole("button", { name: "Deny" }));
+      await waitFor(() => expect(onClose).toHaveBeenCalled());
+      expect(decide).toHaveBeenCalledWith(["apr_1"], { approve: false });
+    });
+
+    it("says what a refused decision means for the person, and re-arms the buttons", async () => {
+      const onClose = vi.fn();
+      mount(clientWith({
+        get: pending(),
+        decide: () => Promise.reject(Object.assign(new Error("approval apr_1 not found"), { code: "not-found" })),
+      }), onClose);
+      await waitFor(() => expect(ask()).toBe("Send $47.50 to Acme Utilities?"));
+      fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+
+      // The consumer's half of a refusal (§16 law 3) — never the wire's own
+      // sentence, which carries the approval id.
+      const alert = await screen.findByRole("alert");
+      expect(alert.textContent).toBe("This request isn’t waiting on you any more — it may have expired.");
+      expect(screen.getByRole("button", { name: "Approve" })).toHaveProperty("disabled", false);
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("dismissing", () => {
+    it("Escape CLOSES without deciding — the approval stays pending", async () => {
+      const decide = vi.fn(async () => undefined);
+      const onClose = vi.fn();
+      mount(clientWith({ get: pending(), decide }), onClose);
+      await waitFor(() => expect(ask()).toBe("Send $47.50 to Acme Utilities?"));
+      fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+      await waitFor(() => expect(onClose).toHaveBeenCalled());
+      // The one thing a consent surface may never do is spend a decision on a
+      // keystroke: nothing was approved and nothing was denied.
+      expect(decide).not.toHaveBeenCalled();
+    });
+
+    it("the scrim closes without deciding too", async () => {
+      const decide = vi.fn(async () => undefined);
+      const onClose = vi.fn();
+      mount(clientWith({ get: pending(), decide }), onClose);
+      await waitFor(() => expect(ask()).toBe("Send $47.50 to Acme Utilities?"));
+      fireEvent.click(document.querySelector(".fl-apmodal-scrim")!);
+      await waitFor(() => expect(onClose).toHaveBeenCalled());
+      expect(decide).not.toHaveBeenCalled();
+    });
+
+    it("leaves when the same approval is decided on another surface", async () => {
+      const onClose = vi.fn();
+      mount(clientWith({ get: pending() }), onClose);
+      await waitFor(() => expect(ask()).toBe("Send $47.50 to Acme Utilities?"));
+      window.dispatchEvent(new CustomEvent(APPROVALS_DECIDED_EVENT, { detail: { ids: ["apr_1"], approved: true } }));
+      await waitFor(() => expect(onClose).toHaveBeenCalled());
+    });
+
+    it("stays put when a DIFFERENT approval is decided elsewhere", async () => {
+      const onClose = vi.fn();
+      mount(clientWith({ get: pending() }), onClose);
+      await waitFor(() => expect(ask()).toBe("Send $47.50 to Acme Utilities?"));
+      window.dispatchEvent(new CustomEvent(APPROVALS_DECIDED_EVENT, { detail: { ids: ["apr_other"], approved: true } }));
+      await new Promise(resolve => setTimeout(resolve, 250));
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("an ask that is no longer waiting on this person", () => {
+    it.each([
+      ["expired", "This request expired — try the action again."],
+      ["declined", "This was already declined."],
+      ["executed", "This already went through."],
+    ])("says so rather than closing silently (%s)", async (state, copy) => {
+      mount(clientWith({ get: async () => ({ state }) as ApprovalResolution }));
+      expect(await screen.findByText(copy)).toBeDefined();
+      // Nothing left to decide — and no dead end either.
+      expect(screen.queryByRole("button", { name: "Approve" })).toBeNull();
+      expect(screen.getByRole("button", { name: "Close" })).toBeDefined();
+    });
+
+    it("says the request could not be loaded at all", async () => {
+      mount(clientWith({ get: () => Promise.reject(new Error("offline")) }));
+      expect(await screen.findByText("We couldn’t load this request.")).toBeDefined();
+    });
+  });
+
+  /**
+   * Presses arrive in BURSTS — Send on two payee rows, back to back. Two
+   * modals over one screen is not a question anybody can answer, so the asks
+   * queue: exactly one on screen, the next when that one leaves.
+   */
+  describe("useApprovalModal, queueing a burst of presses", () => {
+    /** Each ask is its own sentence, so "which one is on screen" is readable. */
+    const byId = async (id: ApprovalId): Promise<ApprovalResolution> => ({
+      state: "pending",
+      request: request({
+        id,
+        call: { id: `call_${id}`, tool: "host_transferMoney", args: { amount: 4750, recipient_name: id === "apr_1" ? "Acme Utilities" : "Northline Internet" } },
+      }),
+    });
+    const asks = { first: "Send $47.50 to Acme Utilities?", second: "Send $47.50 to Northline Internet?" };
+
+    function Harness({ client }: { client: VendoClient }) {
+      const approval = useApprovalModal();
+      return (
+        <VendoProvider client={client}>
+          <button type="button" onClick={() => approval.onParked({ nodeId: "pay-1", approvalId: "apr_1" as ApprovalId })}>park one</button>
+          <button type="button" onClick={() => approval.onParked({ nodeId: "pay-2", approvalId: "apr_2" as ApprovalId })}>park two</button>
+          {approval.modal}
+        </VendoProvider>
+      );
+    }
+
+    const burst = (client: VendoClient) => {
+      render(<Harness client={client} />);
+      fireEvent.click(screen.getByRole("button", { name: "park one" }));
+      fireEvent.click(screen.getByRole("button", { name: "park two" }));
+    };
+
+    it("shows exactly ONE modal for two parked presses — never a second scrim", async () => {
+      burst(clientWith({ get: byId }));
+      await waitFor(() => expect(ask()).toBe(asks.first));
+      expect(screen.getAllByRole("dialog")).toHaveLength(1);
+      expect(document.querySelectorAll(".fl-apmodal-scrim")).toHaveLength(1);
+    });
+
+    it("presents the next ask once the first is decided", async () => {
+      burst(clientWith({ get: byId, decide: async () => undefined }));
+      await waitFor(() => expect(ask()).toBe(asks.first));
+      fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+      await waitFor(() => expect(ask()).toBe(asks.second));
+      expect(screen.getAllByRole("dialog")).toHaveLength(1);
+    });
+
+    it("Escape moves on to the next ask WITHOUT deciding, and loses neither", async () => {
+      const decide = vi.fn(async () => undefined);
+      burst(clientWith({ get: byId, decide }));
+      await waitFor(() => expect(ask()).toBe(asks.first));
+
+      fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+
+      // The dismissed ask was never decided — it is still pending on the
+      // server, and reachable again by pressing that row. The one queued
+      // behind it gets its turn now rather than being dropped with it.
+      await waitFor(() => expect(ask()).toBe(asks.second));
+      expect(decide).not.toHaveBeenCalled();
+    });
+
+    it("empties out rather than re-presenting a dismissed ask forever", async () => {
+      burst(clientWith({ get: byId }));
+      await waitFor(() => expect(ask()).toBe(asks.first));
+      fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+      await waitFor(() => expect(ask()).toBe(asks.second));
+      fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+      await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+    });
+
+    it("never queues the same approval twice, however often its button is pressed", async () => {
+      const get = vi.fn(byId);
+      render(<Harness client={clientWith({ get })} />);
+      fireEvent.click(screen.getByRole("button", { name: "park one" }));
+      fireEvent.click(screen.getByRole("button", { name: "park one" }));
+      await waitFor(() => expect(ask()).toBe(asks.first));
+      fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+      await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+      expect(get).toHaveBeenCalledTimes(1);
+    });
+
+    it("drops a queued ask that was answered on another surface, instead of showing a modal to say so", async () => {
+      burst(clientWith({ get: byId, decide: async () => undefined }));
+      await waitFor(() => expect(ask()).toBe(asks.first));
+
+      // The chat card settles BOTH presses while the first modal is up.
+      window.dispatchEvent(new CustomEvent(APPROVALS_DECIDED_EVENT, { detail: { ids: ["apr_1", "apr_2"], approved: true } }));
+
+      await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+      // …and the second never gets a turn just to announce it was handled.
+      await new Promise(resolve => setTimeout(resolve, 250));
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+  });
+});

--- a/packages/ui/test/chrome/export-surface.test.ts
+++ b/packages/ui/test/chrome/export-surface.test.ts
@@ -54,6 +54,11 @@ const VALUE_EXPORTS = [
   // `thread/parts.tsx` is public API by construction. (Its destinations come
   // from `useSlots`, which the root surface exports.)
   "AddToPicker",
+  // ⚠️ TEST EDIT — `useApprovalModal` joins them DELIBERATELY, for the same
+  // reason as the two above: `thread/parts.tsx` now mounts the approval modal
+  // per app card (a parked press must be able to ask its question in the chat),
+  // and every import in that eject template is public API by construction.
+  "useApprovalModal",
   "VendoTrigger",
   // Keystone graduates B7 — the remixable-surface affordance.
   "Remixable",

--- a/packages/ui/test/tree/parked-approval-resolution.test.tsx
+++ b/packages/ui/test/tree/parked-approval-resolution.test.tsx
@@ -58,6 +58,27 @@ export default function PendingTransfers() {
 }
 `;
 
+/** The same screen, with the flag a real generated one latches before it awaits
+ *  — the "Sending…" nothing but a fresh boot can clear. */
+const SENDING = `
+import { useState } from "react";
+import { Button, Stack, Text, tools, useQuery } from "@vendo/screen";
+
+export default function PendingTransfers() {
+  const pending = useQuery("list_pending");
+  const [sending, setSending] = useState(false);
+  return (
+    <Stack gap={12}>
+      <Text text={"Pending: " + pending.data.length} />
+      <Button label={sending ? "Sending…" : "Cancel Ada"} disabled={sending} onClick={async () => {
+        setSending(true);
+        await tools.cancel_transfer({ id: "tr_1" });
+      }} />
+    </Stack>
+  );
+}
+`;
+
 const ROWS = [
   { id: "tr_1", recipient: "Ada", amount_cents: 4_200 },
   { id: "tr_2", recipient: "Bob", amount_cents: 900 },
@@ -94,7 +115,7 @@ const payloadFor = (compiledSource: string, queries: Record<string, unknown>): U
  * `approve()` is the server doing what it really does — resuming the parked
  * call (the row goes) and recording the outcome for the surface to find.
  */
-function world() {
+function world(source = TRANSFERS) {
   let rows = [...ROWS];
   let resolution: ApprovalResolution | undefined;
   const calls: Call[] = [];
@@ -129,7 +150,7 @@ function world() {
       return render(
         <VendoProvider client={client}>
           <PayloadView
-            payload={payloadFor(compile(TRANSFERS), { list_pending: { data: rows } })}
+            payload={payloadFor(compile(source), { list_pending: { data: rows } })}
             components={{}}
             onAction={onAction}
             onParked={(press) => parked.push(press)}
@@ -148,10 +169,14 @@ const announce = async (approved: boolean): Promise<void> => {
   });
 };
 
+/** The pending notice, which is also the affordance back to a dismissed ask —
+ *  and says so, in the name a screen reader hears. */
+const waitingNotice = () => screen.getByRole("button", { name: /Waiting for your approval — review/u });
+
 const parkAda = async (live: ReturnType<typeof world>): Promise<void> => {
   live.render();
   fireEvent.click(await screen.findByRole("button", { name: "Cancel Ada" }));
-  await waitFor(() => expect(screen.getByText(/waiting for approval/u)).toBeTruthy());
+  await waitFor(() => expect(screen.getByText(/Waiting for your approval/u)).toBeTruthy());
 };
 
 describe("a parked press learns its answer", () => {
@@ -171,12 +196,12 @@ describe("a parked press learns its answer", () => {
     // The stale notice is gone and the screen re-read the plan, so it paints
     // what the backend now holds rather than the list it was built from.
     await waitFor(() => expect(screen.getByText("Pending: 1")).toBeTruthy());
-    expect(screen.queryByText(/waiting for approval/u)).toBeNull();
+    expect(screen.queryByText(/Waiting for your approval/u)).toBeNull();
     expect(screen.queryByText("Ada")).toBeNull();
     expect(screen.getByText("Bob")).toBeTruthy();
   });
 
-  it("settles a refusal in place: the notice says so, and nothing is re-read", async () => {
+  it("settles a refusal in place: the notice says so, over the data that did not change", async () => {
     const live = world();
     await parkAda(live);
 
@@ -185,12 +210,57 @@ describe("a parked press learns its answer", () => {
 
     await waitFor(() => expect(screen.getByText(/nothing was sent/u)).toBeTruthy());
     // The pending sentence is replaced, not stacked on top of.
-    expect(screen.queryByText(/waiting for approval/u)).toBeNull();
-    // A refused call changed nothing, so the screen has nothing to re-read, and
-    // the control is live again for a second try.
-    expect(live.of("list_pending")).toEqual([]);
+    expect(screen.queryByText(/Waiting for your approval/u)).toBeNull();
+    // The refusal re-reads too (that is what re-boots the screen), and the
+    // re-read paints the truth it finds: nothing was sent, so nothing moved.
+    expect(live.of("list_pending")).toHaveLength(1);
     expect(screen.getByText("Pending: 2")).toBeTruthy();
+    expect(screen.getByText("Ada")).toBeTruthy();
     expect((screen.getByRole("button", { name: "Cancel Ada" }) as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  /**
+   * THE DEAD SCREEN. A generated screen latches its own "Sending…" before it
+   * awaits, and expects the row to be gone when it comes back. Deny — or Esc,
+   * then the TTL — and nothing came back: the flag was still set, the button
+   * still disabled, and the only way out was a page reload. Only a re-boot
+   * clears in-screen state, so every terminal answer re-reads, not just yes.
+   */
+  it.each([["declined"], ["expired"]] as const)("re-arms the screen's own controls after %s", async (state) => {
+    const live = world(SENDING);
+    live.render();
+    fireEvent.click(await screen.findByRole("button", { name: "Cancel Ada" }));
+    await waitFor(() => expect(screen.getByText(/Waiting for your approval/u)).toBeTruthy());
+    // The screen's own flag, latched: nothing in the tree can clear it.
+    expect(screen.getByRole("button", { name: "Sending…" })).toBeTruthy();
+
+    live.refuse(state);
+    await announce(false);
+
+    const rearmed = await screen.findByRole("button", { name: "Cancel Ada" });
+    expect((rearmed as HTMLButtonElement).disabled).toBe(false);
+    expect(screen.getByText(/nothing was sent/u)).toBeTruthy();
+  });
+
+  /**
+   * Esc closes the modal without deciding, so the ask is still pending on the
+   * server — and the queue drops it. The notice IS the way back: pressing it
+   * re-raises the same park down the same channel the first one took, so
+   * whichever surface answered that announcement asks again.
+   */
+  it("hands a dismissed ask back: pressing the pending notice re-raises the park", async () => {
+    const live = world();
+    await parkAda(live);
+    expect(live.parked).toEqual([{ nodeId: ADA_NODE, approvalId: APPROVAL }]);
+
+    fireEvent.click(waitingNotice());
+
+    expect(live.parked).toEqual([
+      { nodeId: ADA_NODE, approvalId: APPROVAL },
+      { nodeId: ADA_NODE, approvalId: APPROVAL },
+    ]);
+    // Re-asking is not re-pressing: no second call reached the host.
+    expect(live.of("cancel_transfer")).toHaveLength(1);
   });
 
   it("says an unanswered approval expired, in its own words", async () => {
@@ -213,6 +283,6 @@ describe("a parked press learns its answer", () => {
     live.approve();
 
     await waitFor(() => expect(screen.getByText("Pending: 1")).toBeTruthy(), { timeout: 20_000 });
-    expect(screen.queryByText(/waiting for approval/u)).toBeNull();
+    expect(screen.queryByText(/Waiting for your approval/u)).toBeNull();
   }, 30_000);
 });

--- a/packages/ui/test/tree/parked-approval-resolution.test.tsx
+++ b/packages/ui/test/tree/parked-approval-resolution.test.tsx
@@ -1,0 +1,218 @@
+// @vitest-environment jsdom
+/**
+ * A press the guard parked, from the stall to the repaint.
+ *
+ * The screen, the engine and the Kit controls are the real ones
+ * (screen-bridge.test.tsx documents why nothing here is stubbed on the render
+ * side). Two doubles, both of them the OTHER side of a seam by definition: the
+ * host's `onAction`, and the wire. What the server actually writes into an
+ * `ApprovalResolution` is held by
+ * `packages/vendo/tests/parked-action-resolution.e2e.test.ts`, where the apps
+ * runtime's write path and the umbrella's read path both run for real — so the
+ * shape below cannot quietly drift away from the one that ships.
+ *
+ * The stall this closes: `pending-approval` is the honest answer at press time,
+ * so the node painted "waiting for approval" and the screen sat on it forever —
+ * including long after the server had resumed the call and changed the data.
+ */
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { transform } from "sucrase";
+import { bootScreen, flattenTree, warmScreenEngine } from "@vendoai/apps/contract";
+import { VENDO_TREE_FORMAT, type Json, type ToolOutcome, type UIPayload } from "@vendoai/core";
+import type { VendoClient } from "../../src/client.js";
+import { APPROVALS_DECIDED_EVENT } from "../../src/client-impl.js";
+import { VendoProvider } from "../../src/context.js";
+import { PayloadView, type ParkedPress } from "../../src/tree/index.js";
+import type { ApprovalResolution } from "../../src/wire-types.js";
+
+afterEach(cleanup);
+
+beforeAll(async () => {
+  await warmScreenEngine();
+}, 30_000);
+
+const compile = (tsx: string): string =>
+  transform(tsx, { transforms: ["typescript", "jsx", "imports"], production: true, jsxRuntime: "automatic" }).code;
+
+const CATALOG = ["Stack", "Card", "Text", "Money", "Button"];
+
+const TRANSFERS = `
+import { Button, Card, Money, Stack, Text, tools, useQuery } from "@vendo/screen";
+
+export default function PendingTransfers() {
+  const pending = useQuery("list_pending");
+  return (
+    <Stack gap={12}>
+      <Text text={"Pending: " + pending.data.length} />
+      {pending.data.map((row) => (
+        <Card key={row.id} title={row.recipient}>
+          <Money amount={row.amount_cents / 100} />
+          <Button label={"Cancel " + row.recipient} onClick={async () => {
+            await tools.cancel_transfer({ id: row.id });
+          }} />
+        </Card>
+      ))}
+    </Stack>
+  );
+}
+`;
+
+const ROWS = [
+  { id: "tr_1", recipient: "Ada", amount_cents: 4_200 },
+  { id: "tr_2", recipient: "Bob", amount_cents: 900 },
+];
+
+/** The Button inside Ada's card — the node whose press parks. */
+const ADA_NODE = "root.Card:tr_1.1";
+const APPROVAL = "apr_cancel_ada";
+
+interface Call {
+  nodeId: string;
+  action: string;
+  payload?: Json;
+}
+
+const payloadFor = (compiledSource: string, queries: Record<string, unknown>): UIPayload => {
+  const first = bootScreen({ compiledSource, queries, catalog: CATALOG, now: Date.UTC(2026, 1, 1) });
+  try {
+    const flat = flattenTree(first.tree());
+    return {
+      formatVersion: VENDO_TREE_FORMAT,
+      root: flat.root,
+      nodes: Object.values(flat.nodes),
+      interactive: { compiledSource, queries, queryPlan: [{ tool: "list_pending" }] },
+    } as unknown as UIPayload;
+  } finally {
+    first.dispose();
+  }
+};
+
+/**
+ * The world behind one screen: rows the backend owns, a host pipe that parks
+ * the cancel behind an approval, and the wire's answer for that approval.
+ * `approve()` is the server doing what it really does — resuming the parked
+ * call (the row goes) and recording the outcome for the surface to find.
+ */
+function world() {
+  let rows = [...ROWS];
+  let resolution: ApprovalResolution | undefined;
+  const calls: Call[] = [];
+  const parked: ParkedPress[] = [];
+  return {
+    calls,
+    parked,
+    of: (action: string): Call[] => calls.filter((call) => call.action === action),
+    approve(): void {
+      rows = rows.filter((row) => row.id !== "tr_1");
+      resolution = { state: "executed", outcome: { status: "ok", output: { cancelled: true } } };
+    },
+    refuse(state: "declined" | "expired"): void {
+      resolution = { state };
+    },
+    render() {
+      const client = {
+        approvals: {
+          get: async (id: string): Promise<ApprovalResolution> => {
+            if (id !== APPROVAL || resolution === undefined) throw new Error(`Approval ${id} was not found`);
+            return resolution;
+          },
+        },
+      } as unknown as VendoClient;
+      const onAction = async (call: Call): Promise<ToolOutcome> => {
+        calls.push(call);
+        if (call.action === "list_pending") return { status: "ok", output: { data: rows } as Json };
+        // The guard sends the mutation to approval: nothing has changed yet, and
+        // that is exactly what the surface is told.
+        return { status: "pending-approval", approvalId: APPROVAL };
+      };
+      return render(
+        <VendoProvider client={client}>
+          <PayloadView
+            payload={payloadFor(compile(TRANSFERS), { list_pending: { data: rows } })}
+            components={{}}
+            onAction={onAction}
+            onParked={(press) => parked.push(press)}
+          />
+        </VendoProvider>,
+      );
+    },
+  };
+}
+
+/** Same-tab announcement: `client.approvals.decide` fires this the moment the
+ *  POST returns, which is AFTER the server resumed the call. */
+const announce = async (approved: boolean): Promise<void> => {
+  await act(async () => {
+    window.dispatchEvent(new CustomEvent(APPROVALS_DECIDED_EVENT, { detail: { ids: [APPROVAL], approved } }));
+  });
+};
+
+const parkAda = async (live: ReturnType<typeof world>): Promise<void> => {
+  live.render();
+  fireEvent.click(await screen.findByRole("button", { name: "Cancel Ada" }));
+  await waitFor(() => expect(screen.getByText(/waiting for approval/u)).toBeTruthy());
+};
+
+describe("a parked press learns its answer", () => {
+  it("announces the park, then clears the notice and re-reads once the call ran", async () => {
+    const live = world();
+    await parkAda(live);
+
+    // The contract a surface builds an approval prompt against.
+    expect(live.parked).toEqual([{ nodeId: ADA_NODE, approvalId: APPROVAL }]);
+    // Nothing changed yet, so nothing is re-read — the press is genuinely parked.
+    expect(live.of("list_pending")).toEqual([]);
+    expect(screen.getByText("Pending: 2")).toBeTruthy();
+
+    live.approve();
+    await announce(true);
+
+    // The stale notice is gone and the screen re-read the plan, so it paints
+    // what the backend now holds rather than the list it was built from.
+    await waitFor(() => expect(screen.getByText("Pending: 1")).toBeTruthy());
+    expect(screen.queryByText(/waiting for approval/u)).toBeNull();
+    expect(screen.queryByText("Ada")).toBeNull();
+    expect(screen.getByText("Bob")).toBeTruthy();
+  });
+
+  it("settles a refusal in place: the notice says so, and nothing is re-read", async () => {
+    const live = world();
+    await parkAda(live);
+
+    live.refuse("declined");
+    await announce(false);
+
+    await waitFor(() => expect(screen.getByText(/nothing was sent/u)).toBeTruthy());
+    // The pending sentence is replaced, not stacked on top of.
+    expect(screen.queryByText(/waiting for approval/u)).toBeNull();
+    // A refused call changed nothing, so the screen has nothing to re-read, and
+    // the control is live again for a second try.
+    expect(live.of("list_pending")).toEqual([]);
+    expect(screen.getByText("Pending: 2")).toBeTruthy();
+    expect((screen.getByRole("button", { name: "Cancel Ada" }) as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("says an unanswered approval expired, in its own words", async () => {
+    const live = world();
+    await parkAda(live);
+
+    live.refuse("expired");
+    await announce(false);
+
+    await waitFor(() => expect(screen.getByText(/nobody answered in time/u)).toBeTruthy());
+    expect(screen.getByText("Pending: 2")).toBeTruthy();
+  });
+
+  it("finds a decision made where this page could not hear it", async () => {
+    const live = world();
+    await parkAda(live);
+
+    // No announcement at all — the person approved in another tab, or the host's
+    // own queue did. The poll is the only way this screen ever finds out.
+    live.approve();
+
+    await waitFor(() => expect(screen.getByText("Pending: 1")).toBeTruthy(), { timeout: 20_000 });
+    expect(screen.queryByText(/waiting for approval/u)).toBeNull();
+  }, 30_000);
+});

--- a/packages/ui/test/tree/parked-approval-resolution.test.tsx
+++ b/packages/ui/test/tree/parked-approval-resolution.test.tsx
@@ -79,6 +79,37 @@ export default function PendingTransfers() {
 }
 `;
 
+/** The shape generated screens actually write: the button that fires the
+ *  mutation lives INSIDE a confirm panel, and pressing it closes the panel. So
+ *  the node that fired is gone before the guard's answer comes back. */
+const CONFIRMING = `
+import { useState } from "react";
+import { Button, Card, Stack, Text, tools, useQuery } from "@vendo/screen";
+
+export default function PayJordan() {
+  const pending = useQuery("list_pending");
+  const [confirming, setConfirming] = useState(false);
+  return (
+    <Stack gap={12}>
+      <Text text={"Pending: " + pending.data.length} />
+      <Card key="pay" title="Pay Jordan">
+        {confirming ? (
+          <Stack key="confirm" gap={8}>
+            <Text text="Send $42 to Jordan?" />
+            <Button label="Send now" onClick={async () => {
+              setConfirming(false);
+              await tools.pay_jordan({ amount_cents: 4200 });
+            }} />
+          </Stack>
+        ) : (
+          <Button label="Review" onClick={() => setConfirming(true)} />
+        )}
+      </Card>
+    </Stack>
+  );
+}
+`;
+
 const ROWS = [
   { id: "tr_1", recipient: "Ada", amount_cents: 4_200 },
   { id: "tr_2", recipient: "Bob", amount_cents: 900 },
@@ -86,6 +117,11 @@ const ROWS = [
 
 /** The Button inside Ada's card — the node whose press parks. */
 const ADA_NODE = "root.Card:tr_1.1";
+/** {@link CONFIRMING}'s three ids: the button that fires, the panel that closes
+ *  under it, and the card that outlives both. */
+const SEND_NODE = "root.Card:pay.Stack:confirm.1";
+const CONFIRM_PANEL = "root.Card:pay.Stack:confirm";
+const PAY_CARD = "root.Card:pay";
 const APPROVAL = "apr_cancel_ada";
 
 interface Call {
@@ -261,6 +297,50 @@ describe("a parked press learns its answer", () => {
     ]);
     // Re-asking is not re-pressing: no second call reached the host.
     expect(live.of("cancel_transfer")).toHaveLength(1);
+  });
+
+  /**
+   * THE ORPHANED ANSWER. A confirm panel closes the moment the button inside it
+   * is pressed, so by the time the guard answers there is no node left holding
+   * that press's slot — and the notice rendered nowhere at all: the button was
+   * pressed and the surface said nothing, forever. Node ids are structural
+   * paths, so the answer climbs to the nearest node still on screen.
+   */
+  it("keeps the answer on the nearest surviving ancestor when the fired node unmounts", async () => {
+    const live = world(CONFIRMING);
+    live.render();
+    fireEvent.click(await screen.findByRole("button", { name: "Review" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Send now" }));
+
+    // The panel that held the press is gone with it...
+    await screen.findByRole("button", { name: "Review" });
+    expect(document.querySelector(`[data-vendo-node-id="${CONFIRM_PANEL}"]`)).toBeNull();
+    // ...and the answer to that press is on the card the panel hung under.
+    const notice = await screen.findByRole("button", { name: /Waiting for your approval — review/u });
+    expect(document.querySelector(`[data-vendo-node-id="${PAY_CARD}"]`)?.contains(notice)).toBe(true);
+
+    // Re-raising it is still THAT press: the fired node's id, not the card's.
+    expect(live.parked).toEqual([{ nodeId: SEND_NODE, approvalId: APPROVAL }]);
+    fireEvent.click(notice);
+    expect(live.parked).toEqual([
+      { nodeId: SEND_NODE, approvalId: APPROVAL },
+      { nodeId: SEND_NODE, approvalId: APPROVAL },
+    ]);
+  });
+
+  it("lands the refusal for an unmounted press on that same ancestor", async () => {
+    const live = world(CONFIRMING);
+    live.render();
+    fireEvent.click(await screen.findByRole("button", { name: "Review" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Send now" }));
+    await screen.findByText(/Waiting for your approval/u);
+
+    live.refuse("declined");
+    await announce(false);
+
+    const refusal = await screen.findByText(/nothing was sent/u);
+    expect(document.querySelector(`[data-vendo-node-id="${PAY_CARD}"]`)?.contains(refusal)).toBe(true);
+    expect(screen.queryByText(/Waiting for your approval/u)).toBeNull();
   });
 
   it("says an unanswered approval expired, in its own words", async () => {

--- a/packages/ui/test/tree/repaint-motion.test.ts
+++ b/packages/ui/test/tree/repaint-motion.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import type { TreeNode } from "@vendoai/core";
+import { SCREEN_TEXT_NODE } from "@vendoai/apps/contract";
+import { diffPaints, type NodeMap } from "../../src/tree/repaint-motion.js";
+
+const paint = (...nodes: TreeNode[]): NodeMap => new Map(nodes.map((node) => [node.id, node]));
+
+const text = (id: string, value: string): TreeNode =>
+  ({ id, component: SCREEN_TEXT_NODE, props: { text: value }, children: [] });
+
+/** A keyed list of `<Row><text/></Row>` under `root.list`. */
+const rows = (...labels: string[]): TreeNode[] => [
+  { id: "root", component: "Stack", children: ["root.list"] },
+  { id: "root.list", component: "Stack", children: labels.map((label) => `root.list.Row:${label}`) },
+  ...labels.flatMap((label): TreeNode[] => [
+    { id: `root.list.Row:${label}`, component: "Row", children: [`root.list.Row:${label}.0`] },
+    text(`root.list.Row:${label}.0`, label),
+  ]),
+];
+
+/** The same list written WITHOUT keys — ids are positions, so a mid-list
+ *  removal renumbers everything below it. */
+const unkeyedRows = (...labels: string[]): TreeNode[] => [
+  { id: "root", component: "Stack", children: ["root.list"] },
+  { id: "root.list", component: "Stack", children: labels.map((_, index) => `root.list.${index}`) },
+  ...labels.flatMap((label, index): TreeNode[] => [
+    { id: `root.list.${index}`, component: "Row", children: [`root.list.${index}.0`] },
+    text(`root.list.${index}.0`, label),
+  ]),
+];
+
+describe("diffPaints", () => {
+  it("marks nothing when the repaint says the same thing", () => {
+    expect(diffPaints(paint(...rows("a", "b")), paint(...rows("a", "b"))).marks.size).toBe(0);
+  });
+
+  it("marks an arriving keyed row, and only the row — not its cells", () => {
+    const diff = diffPaints(paint(...rows("a", "b")), paint(...rows("a", "b", "c")));
+    expect([...diff.marks]).toEqual([["root.list.Row:c", { kind: "enter" }]]);
+  });
+
+  it("marks a departing keyed row and remembers the slot it held", () => {
+    const diff = diffPaints(paint(...rows("a", "b", "c")), paint(...rows("a", "c")));
+    expect(diff.marks.get("root.list.Row:b")).toEqual({ kind: "exit" });
+    expect(diff.exits).toEqual([{ parent: "root.list", index: 1, id: "root.list.Row:b" }]);
+  });
+
+  it("pulses the leaf that owns a changed value, never its container", () => {
+    const restated = rows("a", "b").map((node) =>
+      node.id === "root.list.Row:b.0" ? text(node.id, "b, restated") : node);
+    const diff = diffPaints(paint(...rows("a", "b")), paint(...restated));
+    // The row directly holds the run of text that changed, so the row is the
+    // leaf that pulses — its list and the screen root stay still.
+    expect(diff.marks.get("root.list.Row:b")).toEqual({ kind: "pulse", tick: null });
+    expect(diff.marks.has("root.list")).toBe(false);
+    expect(diff.marks.has("root")).toBe(false);
+  });
+
+  it("gives a Kit numeric leaf a tick that renders its own in-between figures", () => {
+    const before = paint(
+      { id: "root", component: "Stack", children: ["root.Money:total"] },
+      { id: "root.Money:total", component: "Money", props: { amount: 100, currency: "USD", locale: "en-US" } },
+    );
+    const after = paint(
+      { id: "root", component: "Stack", children: ["root.Money:total"] },
+      { id: "root.Money:total", component: "Money", props: { amount: 250, currency: "USD", locale: "en-US" } },
+    );
+    const mark = diffPaints(before, after).marks.get("root.Money:total");
+    expect(mark?.kind).toBe("pulse");
+    const tick = mark?.kind === "pulse" ? mark.tick : null;
+    expect(tick).toMatchObject({ from: 100, to: 250 });
+    expect(tick?.render(100)).toBe("$100.00");
+    expect(tick?.render(250)).toBe("$250.00");
+  });
+
+  it("pulses a non-numeric leaf without a tick", () => {
+    const before = paint(
+      { id: "root", component: "Stack", children: ["root.DateTime:due"] },
+      { id: "root.DateTime:due", component: "DateTime", props: { value: "2026-03-14" } },
+    );
+    const after = paint(
+      { id: "root", component: "Stack", children: ["root.DateTime:due"] },
+      { id: "root.DateTime:due", component: "DateTime", props: { value: "2026-04-01" } },
+    );
+    expect(diffPaints(before, after).marks.get("root.DateTime:due")).toEqual({ kind: "pulse", tick: null });
+  });
+
+  it("trusts an unkeyed list when the arrival is at the end — nothing below shifted", () => {
+    const diff = diffPaints(paint(...unkeyedRows("a", "b")), paint(...unkeyedRows("a", "b", "c")));
+    expect([...diff.marks]).toEqual([["root.list.2", { kind: "enter" }]]);
+  });
+
+  it("animates NOTHING when an unkeyed list loses a row from the middle", () => {
+    // Positional ids say "the last row left" while rows 1..n shifted up. The
+    // wrong row would collapse, so the list swaps instantly instead.
+    const diff = diffPaints(paint(...unkeyedRows("a", "b", "c")), paint(...unkeyedRows("a", "c")));
+    expect(diff.marks.size).toBe(0);
+    expect(diff.exits).toEqual([]);
+  });
+
+  it("keeps a keyed list animating next to a keyless header that also moved", () => {
+    // The screen's own shape: a positional summary row above a keyed list. The
+    // header's changing total must not cost the list its arrival.
+    const withHeader = (total: string, ...labels: string[]): TreeNode[] => {
+      const list = rows(...labels);
+      return [
+        { id: "root", component: "Stack", children: ["root.0", "root.list"] },
+        { id: "root.0", component: "Text", props: { text: total } },
+        ...list.filter((node) => node.id !== "root"),
+      ];
+    };
+    const diff = diffPaints(paint(...withHeader("$2", "a", "b")), paint(...withHeader("$3", "a", "b", "c")));
+    expect(diff.marks.get("root.list.Row:c")).toEqual({ kind: "enter" });
+    expect(diff.marks.get("root.0")).toEqual({ kind: "pulse", tick: null });
+  });
+
+  it("does not pulse a control whose handler id merely got renumbered", () => {
+    // Handler ids are minted against the node's POSITION, so every row below a
+    // deleted one gets a new one. That is machinery, not a value that moved.
+    const button = (handler: string): TreeNode[] => [
+      { id: "root", component: "Stack", children: ["root.Button:cancel"] },
+      { id: "root.Button:cancel", component: "Button", props: { label: "Cancel", onClick: { $handler: handler } } },
+    ];
+    expect(diffPaints(paint(...button("h3")), paint(...button("h7"))).marks.size).toBe(0);
+  });
+
+  it("stays quiet when a repaint replaces the view wholesale", () => {
+    const before = paint(...rows(...Array.from({ length: 20 }, (_, i) => `a${i}`)));
+    const after = paint(...rows(...Array.from({ length: 20 }, (_, i) => `b${i}`)));
+    expect(diffPaints(before, after).marks.size).toBe(0);
+  });
+
+  it("ignores a root that is not shared between the paints", () => {
+    const before = paint({ id: "root", component: "Stack", children: [] });
+    const after = paint({ id: "other", component: "Stack", children: [] });
+    expect(diffPaints(before, after).marks.size).toBe(0);
+  });
+});

--- a/packages/vendo/src/byo-approvals.ts
+++ b/packages/vendo/src/byo-approvals.ts
@@ -1,4 +1,5 @@
 import {
+  PARKED_ACTION_COLLECTION,
   PARKED_CALL_OUTCOME_COLLECTION,
   VendoError,
   type ApprovalId,
@@ -69,9 +70,14 @@ interface ParkedByoCall {
 /** The wire's answer to `GET /approvals/:id` — the frozen
  *  `VendoApprovalEmbedState` vocabulary, plus what each state needs to render:
  *  the full request while pending (the consent card shows real inputs), the
- *  executed outcome after resume. */
+ *  executed outcome after resume.
+ *
+ *  The request is absent in exactly one case: an IN-APP parked press read
+ *  during the resume window, where the answer is "not decided yet" and the ask
+ *  itself is no longer anywhere to be had (that lane persists the call, not the
+ *  request). Surfaces treat it as still-working and keep polling. */
 export type ByoApprovalResolution =
-  | { state: "pending"; request: ApprovalRequest }
+  | { state: "pending"; request?: ApprovalRequest }
   | { state: "executed"; outcome: ToolOutcome }
   | { state: "declined" }
   | { state: "expired" };
@@ -265,16 +271,18 @@ export function createByoApprovals({ guard, tools, ops }: ByoApprovalsConfig): B
       const request = pending.find((candidate) => candidate.id === approvalId);
       if (request !== undefined) return { state: "pending", request };
       // Mid-resume window: the decision already left the guard's pending queue
-      // but the subscriber has not written the outcome row yet. The parked
-      // record exists exactly until that write, so serve its request snapshot
-      // as still-pending rather than a terminal not-found (which the embed
-      // renders as expired and stops polling).
-      const stillParked = await engine().get(PARKED_COLLECTION, approvalId);
-      if (stillParked !== null) {
-        const data = stillParked.data as ParkedByoCall;
-        if (data.owner === principal.subject && data.request !== undefined) {
-          return { state: "pending", request: data.request };
-        }
+      // but the subscriber has not written the outcome row yet. EITHER lane's
+      // parked record exists exactly until that write, so serve its request
+      // snapshot as still-pending rather than a terminal not-found — which the
+      // embed renders as expired, and a screen's poll logs as a failed read
+      // once every few seconds for the length of the resumed call.
+      for (const collection of [PARKED_COLLECTION, PARKED_ACTION_COLLECTION]) {
+        const stillParked = await engine().get(collection, approvalId);
+        // The two lanes' records differ (the in-app one pins an app and keeps
+        // no request snapshot), but the owner is the same field in both.
+        const data = stillParked?.data as Pick<ParkedByoCall, "owner" | "request"> | undefined;
+        if (data?.owner !== principal.subject) continue;
+        return { state: "pending", ...(data.request === undefined ? {} : { request: data.request }) };
       }
       throw new VendoError("not-found", `Approval ${approvalId} was not found`);
     },

--- a/packages/vendo/src/byo-approvals.ts
+++ b/packages/vendo/src/byo-approvals.ts
@@ -1,8 +1,10 @@
 import {
+  PARKED_CALL_OUTCOME_COLLECTION,
   VendoError,
   type ApprovalId,
   type ApprovalRequest,
   type IsoDateTime,
+  type ParkedCallOutcome,
   type Principal,
   type RunContext,
   type StoreOps,
@@ -44,7 +46,6 @@ import type { VendoGuard } from "@vendoai/guard";
  */
 
 const PARKED_COLLECTION = "vendo_parked_call";
-const OUTCOME_COLLECTION = "vendo_parked_call_outcome";
 
 interface ParkedByoCall {
   /** The guard approval that gates this call. */
@@ -63,15 +64,6 @@ interface ParkedByoCall {
   /** Set by the sweep just before it denies, so the decision subscriber
    *  resolves the outcome to "expired" instead of "declined". */
   expiring?: boolean;
-}
-
-interface ParkedByoOutcome {
-  approvalId: ApprovalId;
-  owner: string;
-  state: "executed" | "declined" | "expired";
-  /** Present for "executed": the resumed call's outcome, errors included. */
-  outcome?: ToolOutcome;
-  at: IsoDateTime;
 }
 
 /** The wire's answer to `GET /approvals/:id` — the frozen
@@ -157,8 +149,8 @@ export function createByoApprovals({ guard, tools, ops }: ByoApprovalsConfig): B
     });
   };
 
-  const putOutcome = async (record: ParkedByoOutcome): Promise<void> => {
-    await engine().put(OUTCOME_COLLECTION, {
+  const putOutcome = async (record: ParkedCallOutcome): Promise<void> => {
+    await engine().put(PARKED_CALL_OUTCOME_COLLECTION, {
       id: record.approvalId,
       data: record,
       refs: { subject: record.owner, state: record.state },
@@ -255,9 +247,11 @@ export function createByoApprovals({ guard, tools, ops }: ByoApprovalsConfig): B
     },
 
     async read(approvalId, principal) {
-      const record = await engine().get(OUTCOME_COLLECTION, approvalId);
+      // BOTH lanes' terminal rows land here (parked-outcome.ts): a BYO call the
+      // subscriber below resolved, or an in-app action the apps runtime did.
+      const record = await engine().get(PARKED_CALL_OUTCOME_COLLECTION, approvalId);
       if (record !== null) {
-        const data = record.data as ParkedByoOutcome;
+        const data = record.data as ParkedCallOutcome;
         if (data.owner === principal.subject) {
           if (data.state === "executed" && data.outcome !== undefined) {
             return { state: "executed", outcome: data.outcome };

--- a/packages/vendo/tests/byo-approvals.e2e.test.ts
+++ b/packages/vendo/tests/byo-approvals.e2e.test.ts
@@ -130,7 +130,8 @@ describe.sequential("existing-agents — parked BYO guarded calls", () => {
     // The embed's first poll: pending, with the full request for the card.
     const pending = await byo.read(parked.approvalId, principal);
     expect(pending.state).toBe("pending");
-    if (pending.state !== "pending") throw new Error("expected pending");
+    // The BYO lane keeps the ask itself, so the card has real inputs to show.
+    if (pending.state !== "pending" || pending.request === undefined) throw new Error("expected a pending ask");
     expect(pending.request.call.tool).toBe("host_sendClientMessage");
     expect(pending.request.inputPreview).toContain("overdue");
 

--- a/packages/vendo/tests/parked-action-resolution.e2e.test.ts
+++ b/packages/vendo/tests/parked-action-resolution.e2e.test.ts
@@ -1,0 +1,185 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createApps } from "@vendoai/apps";
+import {
+  VENDO_APP_FORMAT,
+  type AppDocument,
+  type Principal,
+  type RunContext,
+  type ToolDescriptor,
+  type ToolRegistry,
+} from "@vendoai/core";
+import { createGuard } from "@vendoai/guard";
+import { createStore, createStoreOps } from "@vendoai/store";
+import { afterEach, describe, expect, it } from "vitest";
+import { createByoApprovals } from "../src/byo-approvals.js";
+
+// The parked in-app press, from park to answer. W0 made the approved call LAND
+// (approve-resume.e2e.test.ts); its answer was then thrown away, so the screen
+// that pressed the button sat on "waiting for approval" forever over data the
+// backend had already changed.
+//
+// Both halves are real and neither knows about the other: the apps runtime
+// writes the terminal row from its own `onApprovalDecision` subscriber, and the
+// umbrella's `byoApprovals.read` — what `GET /approvals/:id` serves — reads it
+// back. They agree only because they share one shape (core's ParkedCallOutcome)
+// and one drawer; that agreement is what this file holds.
+
+const principal: Principal = { kind: "user", subject: "user_parked" };
+const ctx: RunContext = {
+  principal,
+  venue: "app",
+  presence: "present",
+  sessionId: "session_parked",
+};
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+/** A host with ONE mutating tool: it records what it delivered, and refuses the
+ *  recipient nobody can reach — the two answers a resumed call can come back
+ *  with. */
+function messagingHost(): {
+  tools: ToolRegistry;
+  delivered: Array<{ clientId: string; body: string }>;
+} {
+  const delivered: Array<{ clientId: string; body: string }> = [];
+  const descriptor: ToolDescriptor = {
+    name: "host_sendClientMessage",
+    description: "Message a client about their account",
+    inputSchema: {
+      type: "object",
+      properties: { clientId: { type: "string" }, body: { type: "string" } },
+      required: ["clientId", "body"],
+    },
+    risk: "write",
+  };
+  return {
+    delivered,
+    tools: {
+      async descriptors() {
+        return [descriptor];
+      },
+      async execute(call) {
+        if (call.tool !== "host_sendClientMessage") {
+          return { status: "error", error: { code: "not-found", message: `no tool ${call.tool}` } };
+        }
+        const { clientId, body } = call.args as { clientId: string; body: string };
+        if (clientId === "cli_closed") {
+          return { status: "error", error: { code: "bank", message: "the account is closed" } };
+        }
+        delivered.push({ clientId, body });
+        return { status: "ok", output: { delivered: true } };
+      },
+    },
+  };
+}
+
+async function harness() {
+  const root = await mkdtemp(join(tmpdir(), "vendo-parked-resolution-"));
+  cleanups.push(async () => rm(root, { recursive: true, force: true }));
+  const store = createStore({ dataDir: join(root, ".data") });
+  cleanups.push(async () => store.close());
+  await store.ensureSchema();
+  // Every write-class call asks — the gate that parks the press in the first place.
+  const guard = createGuard({ store, policy: { rules: [{ match: { risk: "write" }, action: "ask" }] } });
+  const host = messagingHost();
+  const tools = guard.bind(host.tools);
+  // The SAME named-operation surface both sides get from the composition
+  // (compose-apps passes `composition.ops` to createApps; compose-actions passes
+  // it to createByoApprovals) — one deployment, one set of drawers.
+  const ops = createStoreOps(store);
+  const apps = createApps({ store, ops, guard, tools, catalog: [] });
+  const byo = createByoApprovals({ guard, tools, ops });
+  const app = await apps.importApp(
+    {
+      format: VENDO_APP_FORMAT,
+      id: "app_seed_id_is_replaced",
+      name: "Client messenger",
+      ui: "tree",
+      tree: {
+        formatVersion: "vendo-genui/v2",
+        root: "root",
+        nodes: [{ id: "root", component: "Stack", source: "prewired" }],
+      },
+    } as AppDocument,
+    ctx,
+  );
+  return { guard, apps, byo, host, appId: app.id };
+}
+
+const park = async (
+  apps: Awaited<ReturnType<typeof harness>>["apps"],
+  appId: string,
+  clientId: string,
+  body: string,
+) => {
+  const outcome = await apps.call(appId, "host_sendClientMessage", { clientId, body }, ctx);
+  if (outcome.status !== "pending-approval") throw new Error("expected the mutation to park");
+  return outcome.approvalId;
+};
+
+describe.sequential("a parked in-app press learns what happened to it", () => {
+  it("reads pending, then the executed outcome once the owner approves", async () => {
+    const { guard, apps, byo, host, appId } = await harness();
+
+    const approvalId = await park(apps, appId, "cli_1", "Your documents are overdue");
+    // The surface's first poll while the ask is still open: the full request, so
+    // a consent card can show what is actually waiting.
+    const pending = await byo.read(approvalId, principal);
+    expect(pending.state).toBe("pending");
+    if (pending.state !== "pending") throw new Error("expected pending");
+    expect(pending.request.call.tool).toBe("host_sendClientMessage");
+    expect(host.delivered).toHaveLength(0);
+
+    await guard.approvals.decide(approvalId, { approve: true }, principal);
+
+    // The effect landed (W0) AND the answer survived the call that ran it, which
+    // is the only way the screen can know to re-read.
+    expect(host.delivered).toEqual([{ clientId: "cli_1", body: "Your documents are overdue" }]);
+    await expect(byo.read(approvalId, principal)).resolves.toEqual({
+      state: "executed",
+      outcome: { status: "ok", output: { delivered: true } },
+    });
+  });
+
+  it("carries a resumed call's FAILURE back as the executed outcome", async () => {
+    const { guard, apps, byo, host, appId } = await harness();
+
+    const approvalId = await park(apps, appId, "cli_closed", "Never lands");
+    await guard.approvals.decide(approvalId, { approve: true }, principal);
+
+    // Approved and run, and it failed. "Executed" is about the decision, not the
+    // result — a blank here would tell the surface the press succeeded.
+    expect(host.delivered).toHaveLength(0);
+    await expect(byo.read(approvalId, principal)).resolves.toEqual({
+      state: "executed",
+      outcome: { status: "error", error: { code: "bank", message: "the account is closed" } },
+    });
+  });
+
+  it("reports declined for a refused press, and never lands the effect", async () => {
+    const { guard, apps, byo, host, appId } = await harness();
+
+    const approvalId = await park(apps, appId, "cli_2", "This should never send");
+    await guard.approvals.decide(approvalId, { approve: false }, principal);
+
+    expect(host.delivered).toHaveLength(0);
+    await expect(byo.read(approvalId, principal)).resolves.toEqual({ state: "declined" });
+  });
+
+  it("keeps the answer to the owner alone", async () => {
+    const { guard, apps, byo, appId } = await harness();
+
+    const approvalId = await park(apps, appId, "cli_3", "Private business");
+    await guard.approvals.decide(approvalId, { approve: true }, principal);
+    expect((await byo.read(approvalId, principal)).state).toBe("executed");
+
+    // Same treatment a foreign id gets: an outcome row nobody else may read is
+    // indistinguishable from one that never existed.
+    await expect(byo.read(approvalId, { kind: "user", subject: "user_other" })).rejects.toThrow(/not found/u);
+  });
+});

--- a/packages/vendo/tests/parked-action-resolution.e2e.test.ts
+++ b/packages/vendo/tests/parked-action-resolution.e2e.test.ts
@@ -194,6 +194,17 @@ describe.sequential("a parked in-app press learns what happened to it", () => {
     const { guard, apps, byo, host, appId } = await harness();
 
     const approvalId = await park(apps, appId, "cli_slow", "Takes a while to send");
+    // UNDECIDED is not the resume window. A parked record stands the whole time
+    // an approval is open, so serving its (request-less) snapshot here would
+    // leave a re-presented modal — Esc, then the pending notice — on an empty
+    // skeleton with nothing to decide, for as long as the ask stands. The guard
+    // still holds the ask, so the guard's answer is the one that ships.
+    const undecided = await byo.read(approvalId, principal);
+    if (undecided.state !== "pending" || undecided.request === undefined) {
+      throw new Error("an undecided approval must read back with its full request");
+    }
+    expect(undecided.request.call.args).toMatchObject({ clientId: "cli_slow" });
+
     const hold = host.holdNext();
     const decided = guard.approvals.decide(approvalId, { approve: true }, principal);
     await hold.running;

--- a/packages/vendo/tests/parked-action-resolution.e2e.test.ts
+++ b/packages/vendo/tests/parked-action-resolution.e2e.test.ts
@@ -45,8 +45,13 @@ afterEach(async () => {
 function messagingHost(): {
   tools: ToolRegistry;
   delivered: Array<{ clientId: string; body: string }>;
+  /** Hold the next delivery INSIDE the tool. `running` settles once the resumed
+   *  call is executing and `release` lets it finish — between the two is the
+   *  resume window: decided, but no answer written yet. */
+  holdNext(): { running: Promise<void>; release(): void };
 } {
   const delivered: Array<{ clientId: string; body: string }> = [];
+  let hold: { entered(): void; released: Promise<void> } | undefined;
   const descriptor: ToolDescriptor = {
     name: "host_sendClientMessage",
     description: "Message a client about their account",
@@ -59,6 +64,14 @@ function messagingHost(): {
   };
   return {
     delivered,
+    holdNext() {
+      let entered = (): void => undefined;
+      let release = (): void => undefined;
+      const running = new Promise<void>(resolve => { entered = resolve; });
+      const released = new Promise<void>(resolve => { release = resolve; });
+      hold = { entered: () => entered(), released };
+      return { running, release: () => release() };
+    },
     tools: {
       async descriptors() {
         return [descriptor];
@@ -70,6 +83,12 @@ function messagingHost(): {
         const { clientId, body } = call.args as { clientId: string; body: string };
         if (clientId === "cli_closed") {
           return { status: "error", error: { code: "bank", message: "the account is closed" } };
+        }
+        const held = hold;
+        if (held !== undefined) {
+          hold = undefined;
+          held.entered();
+          await held.released;
         }
         delivered.push({ clientId, body });
         return { status: "ok", output: { delivered: true } };
@@ -131,7 +150,7 @@ describe.sequential("a parked in-app press learns what happened to it", () => {
     // a consent card can show what is actually waiting.
     const pending = await byo.read(approvalId, principal);
     expect(pending.state).toBe("pending");
-    if (pending.state !== "pending") throw new Error("expected pending");
+    if (pending.state !== "pending" || pending.request === undefined) throw new Error("expected a pending ask");
     expect(pending.request.call.tool).toBe("host_sendClientMessage");
     expect(host.delivered).toHaveLength(0);
 
@@ -169,6 +188,35 @@ describe.sequential("a parked in-app press learns what happened to it", () => {
 
     expect(host.delivered).toHaveLength(0);
     await expect(byo.read(approvalId, principal)).resolves.toEqual({ state: "declined" });
+  });
+
+  it("answers PENDING through the resume window, instead of a not-found the surface polls into", async () => {
+    const { guard, apps, byo, host, appId } = await harness();
+
+    const approvalId = await park(apps, appId, "cli_slow", "Takes a while to send");
+    const hold = host.holdNext();
+    const decided = guard.approvals.decide(approvalId, { approve: true }, principal);
+    await hold.running;
+
+    // Mid-resume: the guard no longer lists the ask and the outcome row is not
+    // written yet. The screen that pressed the button polls straight through
+    // this window — every few seconds, for as long as the resumed call runs —
+    // so a not-found here is a console error per tick, and the BYO embed reads
+    // it as expired and stops asking. The parked record still exists, and that
+    // is exactly "decided, not answered yet".
+    await expect(byo.read(approvalId, principal)).resolves.toEqual({ state: "pending" });
+
+    hold.release();
+    await decided;
+    await expect(byo.read(approvalId, principal)).resolves.toEqual({
+      state: "executed",
+      outcome: { status: "ok", output: { delivered: true } },
+    });
+  });
+
+  it("still refuses an id nobody ever parked", async () => {
+    const { byo } = await harness();
+    await expect(byo.read("apr_never_existed", principal)).rejects.toThrow(/not found/u);
   });
 
   it("keeps the answer to the owner alone", async () => {


### PR DESCRIPTION
## What

A guarded action pressed on a generated screen used to dead-end twice: the approval had **no UI anywhere** (only a badge count), and after approving, the resumed call's outcome was **discarded** — the screen sat on \"Sending…\" and stale numbers forever while the money had already moved (proven live: 151s+ stall, ~110s after the backend mutated).

This PR closes the whole loop: **press → centered approval modal (every surface screens mount on) → designed in-flight state → the screen re-reads and repaints backend truth, with motion.**

## How

- **Loop** — the apps runtime persists what became of a parked call (`PARKED_CALL_OUTCOME_COLLECTION`, shared with the BYO lane so both write the same rows); `GET /approvals/:id` serves it, answering `pending` through the decide window (kills the transient 404 console noise). The tree watches its parked presses: `executed` → re-read + repaint; `declined`/`expired` → re-read too, so a screen whose own state latched \"sending\" re-arms instead of locking forever.
- **Modal** — `useApprovalModal` mounted on every screen surface (slot, thread app card, workspace stage, BYO embed, remix): ask at hero size, Approve/Deny, in-flight progress for the seconds a decision takes to run, queue for burst presses (one ask at a time). Esc closes without deciding; the pending notice on the pressed control is pressable and re-raises the ask — and when a screen collapses the panel it was pressed in, the notice climbs to the nearest surviving ancestor instead of orphaning. Public API by construction (thread is an eject template); export-surface pin updated deliberately.
- **Landing** — refresh repaints animate via the Web Animations API: arriving rows open under a fading highlight, leaving rows collapse and return their gap, numeric leaves roll to the new figure. Repaints only — never first paint, never streams, never under `prefers-reduced-motion`.

## Evidence (live, real browser, real Vendo Cloud, real money moved)

Three full live E2E rounds against the running Maple demo (screenshots below):
- Modal on park in **chat stage / dashboard slot / workspace stage**; press→modal < 3s.
- Approve → in-flight (\"Running now — this can take a few seconds\", progress rail) → **self-repaint**: balance rolled frame-by-frame ($9,412.20 → $9,411.20), ~10 concurrent element transitions, approve→repaint 7–23s (bounded by `POST /approvals/decide` itself).
- **Esc**: closes without deciding; pressable \"Waiting for your approval — review\" notice survives panel collapse (climb proven forced and spontaneous); re-presents the same `apr_` id.
- **Deny**: \"This wasn't approved — nothing was sent.\", balance unchanged, controls re-arm.
- Double-press → exactly one approval. Full-page reload → screen matches backend. **0 app console errors**; decide-window 404s gone (100+ polls, all 200).

Tests: 3 new suites (server seam e2e — real write path, real read path; client resolution; modal states + queue) — every one **revert-checked red** before landing. Repaint-motion diff logic: 12 headless cases.

## Out of scope (tracked separately)

Decide latency (~7–25s per decision), real-product generation time, theme fidelity on generated screens, genbench build lane.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the guarded action loop: adds a centered approval modal across surfaces, persists the resumed call’s outcome, and refreshes with animated landing when a decision lands. Previously a parked press had no UI, and approved calls left the screen stuck on “Sending…”.

- `@vendoai/core`: introduces `PARKED_CALL_OUTCOME_COLLECTION` and `parked-outcome` types shared by both parked-call lanes.
- `@vendoai/apps`: on approval decision, persists `executed/declined` and the resumed call’s outcome; clears parked records after outcome lands.
- `@vendoai/vendo`: `GET /approvals/:id` now serves in-app parked presses too; returns `pending` during the resume window instead of transient 404s.
- `@vendoai/ui`: adds `useApprovalModal` (modal with queueing) and mounts it on `VendoSlot`, thread app cards, workspace stage, BYO embed, and remix forks; the tree watches parked presses, re-reads on `executed/declined/expired`, and animates repaint-only arrivals/departures/changed values; pending notice becomes pressable and climbs to a surviving ancestor when the fired node unmounts; exports `refusalCopy`.
- Behavior notes: Esc/scrim dismiss, never decide; one ask on screen at a time; in-flight approve shows honest wait; animations only on repaints and respect `prefers-reduced-motion`.

**Migration**
- Handle `ApprovalResolution` pending answers without `request` (resume window) and keep polling; treat as “working” UI.
- If you build custom surfaces, mount `useApprovalModal` and pass `onParked` from the tree through `AppFrame`/`VendoSlot` using `ParkedPress`.
- Update imports to use `useApprovalModal` and `refusalCopy` from `@vendoai/ui`.

<sup>Written for commit 1a5d6505e1fcac1262a7ec76b8f38c7441e8bb75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

