### PR TITLE
feat(guard)!: an explicit host rule survives the unattended downgrade

### DIFF
--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -492,6 +492,11 @@ class GuardImplementation implements VendoGuard {
   readonly #config: CreateGuardConfig;
   readonly #policyConfig: PolicyConfigObject | undefined;
   readonly #policy: PolicyResolver;
+  /** A string policy IS a preset (`resolvePolicyConfig`), and a preset's rules
+   *  are never mixed with authored ones — `PolicyResolver.rules()` returns
+   *  either the inline/preset set or the file's, never both. So one boolean
+   *  says whether every rule this guard evaluates was authored by the host. */
+  readonly #presetPolicy: boolean;
   readonly #maxCallsPerMinute: number;
   readonly #maxWritesPerRun: number;
   readonly #callWindows = new Map<string, number[]>();
@@ -532,6 +537,7 @@ class GuardImplementation implements VendoGuard {
     // policy misconfiguration `resolvePolicyConfig` catches) must fail loud
     // from `createGuard` itself.
     this.#policyConfig = resolvePolicyConfig(config.policy);
+    this.#presetPolicy = typeof config.policy === "string";
     this.#policy = new PolicyResolver(this.#policyConfig, config.policyCloudFallback);
     this.#maxCallsPerMinute = resolveBreakerLimit(
       config.breakers?.maxCallsPerMinute, "maxCallsPerMinute", DEFAULT_MAX_CALLS_PER_MINUTE,
@@ -1067,9 +1073,17 @@ class GuardImplementation implements VendoGuard {
     // refusal in `bind().execute()` and the `projectableForRun` projection are
     // downstream of every decision here, so a rule can free a read or a write
     // and nothing more.
+    //
+    // And a person's NO outranks the rule. A host rule is standing authority
+    // written ahead of time; a standing denial is this user answering THIS
+    // question, and the later, more specific answer wins. Losing the exemption
+    // drops the call back into the park below, where the same denial turns it
+    // into the "you denied this" block — the rule cannot re-open a question the
+    // user already closed.
     if (
       ctx.presence === "away" && draft.action === "run" && draft.decidedBy !== "grant"
-      && metadata.hostRule !== true
+      && (metadata.hostRule !== true
+        || await this.#standingDenial(call, effectiveDescriptor, ctx))
     ) {
       draft = { action: "ask", decidedBy: "default" };
     }
@@ -1365,7 +1379,12 @@ class GuardImplementation implements VendoGuard {
           decision: { action: "block", reason: rule.note ?? "blocked by policy rule", decidedBy: "rule" },
         });
       }
-      return withInvalidated({ decision: { action: rule.action, decidedBy: "rule" }, hostRule: true });
+      return withInvalidated({
+        decision: { action: rule.action, decidedBy: "rule" },
+        // Only a rule the host WROTE. A preset is a shorthand they selected, not
+        // a rule they authored, so it does not carry the away exemption.
+        ...(this.#presetPolicy ? {} : { hostRule: true }),
+      });
     }
 
     const code = this.#policyConfig?.code;

--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -174,6 +174,12 @@ interface DecisionMetadata {
   decision: DraftDecision;
   rationale?: string;
   invalidatedGrants?: PermissionGrant[];
+  /** Set ONLY by the host-rules loop in `#pipeline`, and read only by the away
+   *  downgrade (05 §6), which exempts an explicit host rule. It cannot be
+   *  `decidedBy === "rule"`: `normalizeCodeDecision` deliberately labels
+   *  `policy.code` decisions "rule" too, and that deploy-time hatch must STAY
+   *  away-downgraded (P1-A). The flag is what tells the two apart. */
+  hostRule?: true;
 }
 
 interface CompletedDecision {
@@ -1039,16 +1045,32 @@ class GuardImplementation implements VendoGuard {
     const metadata = await this.#pipeline(call, effectiveDescriptor, ctx, commitRun);
     let draft = metadata.decision;
 
-    // 05 §6: away runs hold only grants captured while present and bound to the
-    // running app — a would-be "run" that is not grant-authorized (rule, code,
-    // judge, or the default posture) parks instead of running. This applies to
-    // READS too: away execution has no live session to act as the user through,
-    // so it needs captured authority (a grant) to call the host as them. The
-    // automation ENABLE flow captures grants for every tool it uses, reads
+    // 05 §6: an away "run" needs authority written down BEFORE the run started —
+    // a would-be run decided by the judge or the default posture parks instead.
+    // This applies to READS too: away execution has no live session to act as
+    // the user through, so it needs standing authority to call the host as them.
+    // The automation ENABLE flow captures grants for every tool it uses, reads
     // included, so an enabled automation runs its reads via `decidedBy: grant`;
     // an ungranted away read parks (approve → grant → future runs succeed)
     // rather than erroring at execution with no actAs authority.
-    if (ctx.presence === "away" && draft.action === "run" && draft.decidedBy !== "grant") {
+    //
+    // Exactly two provenances survive the downgrade: a real app-bound grant, and
+    // an EXPLICIT host policy rule (`metadata.hostRule`). A rule is the host
+    // writing down ahead of time that this tool, at this grade, in this venue
+    // runs — standing authority, authored by the host instead of captured from
+    // the user. Downgrading it made `{ presence: "away", action: "run" }` a rule
+    // nobody could write.
+    //
+    // `policy.code` is NOT exempt: `normalizeCodeDecision` labels it "rule" too,
+    // but never sets `hostRule`, so the deploy-time hatch still parks (P1-A).
+    // Nor is this a way past THE LAW — the unattended destructive/ungraded
+    // refusal in `bind().execute()` and the `projectableForRun` projection are
+    // downstream of every decision here, so a rule can free a read or a write
+    // and nothing more.
+    if (
+      ctx.presence === "away" && draft.action === "run" && draft.decidedBy !== "grant"
+      && metadata.hostRule !== true
+    ) {
       draft = { action: "ask", decidedBy: "default" };
     }
 
@@ -1343,7 +1365,7 @@ class GuardImplementation implements VendoGuard {
           decision: { action: "block", reason: rule.note ?? "blocked by policy rule", decidedBy: "rule" },
         });
       }
-      return withInvalidated({ decision: { action: rule.action, decidedBy: "rule" } });
+      return withInvalidated({ decision: { action: rule.action, decidedBy: "rule" }, hostRule: true });
     }
 
     const code = this.#policyConfig?.code;

--- a/packages/guard/test/pipeline-conformance.test.ts
+++ b/packages/guard/test/pipeline-conformance.test.ts
@@ -3,7 +3,7 @@ import type { GuardDecision, RiskLabel, RunContext } from "@vendoai/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createGuard } from "../src/index.js";
 import { createMemoryStore } from "./fixtures/memory-store.js";
-import { FixtureTools, call, context, descriptor, seedGrant } from "./fixtures/tools.js";
+import { FixtureTools, alice, call, context, descriptor, seedGrant } from "./fixtures/tools.js";
 
 afterEach(() => {
   vi.useRealTimers();
@@ -451,6 +451,41 @@ describe("away authority (05 §6)", () => {
       action: "ask",
       decidedBy: "default",
     });
+  });
+
+  it("lets an explicit user denial outrank a host rule that says run", async () => {
+    const store = createMemoryStore();
+    const d = descriptor("write");
+    const stable = () => call(d.name, { amount: 1 }, "call_stable_away");
+
+    // The user's no, given while the guard had no rule to lean on.
+    const before = createGuard({ store });
+    const parked = await before.bind(new FixtureTools([d])).execute(stable(), awayCtx());
+    if (parked.status !== "pending-approval") throw new Error("expected the away call to park");
+    await before.approvals.decide(parked.approvalId, { approve: false }, alice);
+
+    // The host writes a run rule afterwards: it does NOT reopen the closed question.
+    const after = createGuard({ store, policy: { rules: [{ match: { risk: "write" }, action: "run" }] } });
+    const tools = new FixtureTools([d]);
+    await expect(after.check(stable(), d, awayCtx())).resolves.toMatchObject({
+      action: "block",
+      decidedBy: "denied",
+    });
+    await expect(after.bind(tools).execute(stable(), awayCtx())).resolves.toMatchObject({
+      status: "blocked",
+    });
+    expect(tools.executions).toHaveLength(0);
+  });
+
+  it("still parks a preset-decided away call, with its approval row, since a preset is not authored", async () => {
+    const store = createMemoryStore();
+    const d = descriptor("read");
+    // `cautious` expands to a `read → run` rule, but the host selected a
+    // shorthand rather than writing that rule, so the exemption does not apply.
+    const guard = createGuard({ store, policy: "cautious" });
+    const decision = await guard.check(call(d.name, {}, "call_preset"), d, awayCtx());
+    expect(decision).toMatchObject({ action: "ask", decidedBy: "default" });
+    expect(await guard.approvals.pending(alice)).toHaveLength(1);
   });
 
   it("attaches the authorizing grant as ctx.grant for executors (04 §4 ActAs seam)", async () => {

--- a/packages/guard/test/pipeline-conformance.test.ts
+++ b/packages/guard/test/pipeline-conformance.test.ts
@@ -369,14 +369,88 @@ describe("away authority (05 §6)", () => {
     });
   });
 
-  it("parks an away call even when a rule says run", async () => {
+  it("runs an away call when an explicit host rule says run", async () => {
     const store = createMemoryStore();
     const d = descriptor("read");
     const guard = createGuard({
       store,
       policy: { rules: [{ match: { risk: "read" }, action: "run" }] },
     });
-    await expect(guard.check(call(d.name, {}), d, awayCtx())).resolves.toMatchObject({ action: "ask" });
+    await expect(guard.check(call(d.name, {}), d, awayCtx())).resolves.toMatchObject({
+      action: "run",
+      decidedBy: "rule",
+    });
+  });
+
+  it("executes rule-decided away reads and writes end to end", async () => {
+    const store = createMemoryStore();
+    const read = descriptor("read");
+    const write = descriptor("write");
+    const guard = createGuard({
+      store,
+      policy: { rules: [{ match: { risk: "read" }, action: "run" }, { match: { risk: "write" }, action: "run" }] },
+    });
+    const tools = new FixtureTools([read, write]);
+    const bound = guard.bind(tools);
+
+    await expect(bound.execute(call(read.name, {}, "call_read"), awayCtx())).resolves.toMatchObject({
+      status: "ok",
+    });
+    await expect(bound.execute(call(write.name, {}, "call_write"), awayCtx())).resolves.toMatchObject({
+      status: "ok",
+    });
+    expect(tools.executions).toHaveLength(2);
+  });
+
+  it("still refuses a rule-decided away destructive or ungraded call", async () => {
+    const store = createMemoryStore();
+    const destructive = descriptor("destructive");
+    const ungraded = descriptor("ungraded");
+    const guard = createGuard({ store, policy: { rules: [{ match: { tool: "host_*" }, action: "run" }] } });
+    const tools = new FixtureTools([destructive, ungraded]);
+    const bound = guard.bind(tools);
+
+    // THE LAW sits downstream of the decision: the rule frees the verdict, the
+    // unattended refusal still stops the call.
+    await expect(bound.execute(call(destructive.name, {}, "call_destroy"), awayCtx())).resolves.toMatchObject({
+      status: "blocked",
+    });
+    await expect(bound.execute(call(ungraded.name, {}, "call_ungraded"), awayCtx())).resolves.toMatchObject({
+      status: "blocked",
+    });
+    expect(tools.executions).toHaveLength(0);
+  });
+
+  it("still parks an away run decided by the judge or by the default posture", async () => {
+    const store = createMemoryStore();
+    const d = descriptor("read");
+    const judged = createGuard({
+      store,
+      judge: { decide: async () => ({ action: "run" as const, rationale: "judge allowed" }) },
+    });
+    await expect(judged.check(call(d.name, {}, "call_judge"), d, awayCtx())).resolves.toMatchObject({
+      action: "ask",
+      decidedBy: "default",
+    });
+
+    const bare = createGuard({ store: createMemoryStore() });
+    await expect(bare.check(call(d.name, {}, "call_default"), d, awayCtx())).resolves.toMatchObject({
+      action: "ask",
+      decidedBy: "default",
+    });
+  });
+
+  it("still parks an away run decided by policy.code, which is never an explicit rule", async () => {
+    const store = createMemoryStore();
+    const d = descriptor("read");
+    const guard = createGuard({
+      store,
+      policy: { code: (): GuardDecision => ({ action: "run", decidedBy: "rule" }) },
+    });
+    await expect(guard.check(call(d.name, {}, "call_code"), d, awayCtx())).resolves.toMatchObject({
+      action: "ask",
+      decidedBy: "default",
+    });
   });
 
   it("attaches the authorizing grant as ctx.grant for executors (04 §4 ActAs seam)", async () => {


### PR DESCRIPTION
## ⛔ STILL BLOCKED — do not merge, do not approve

Round 2 applied the coordinator's ruling. It **closed the second blocker**
(`mcp-door-parity.e2e.test.ts:249` is green, untouched). Two remain red:

1. `fixtures/integration/tests/away-park-revoke.e2e.test.ts:112` (J5) — the
   mechanism the ruling names does not reach it. Source proof in "Why the
   ruling does not reach J5" below.
2. `packages/vendo/tests/harness-system-prompt.test.ts` — "promises only the
   discovery rail this harness and this deployment actually have" now exceeds
   its 30s budget. NOT load flake: run alone on an idle box it is 15.9s green
   with `packages/guard/src` at `main` and 30.6s timed-out with this branch.
   The likely cause is the feature working as designed — away rule-decided
   calls now EXECUTE instead of parking instantly, so the unattended turn in
   that test does real tool work it never used to do. Whether that is
   acceptable (and the budget moves) or a signal the exemption is too broad is
   a call for the security round, not mine.

## The change

The away/unattended downgrade parked every would-be `run` that was not
grant-authorized, which made `{ presence: "away", action: "run" }` a policy
rule nobody could write. A `run` decided by an explicit host policy **rule**
now survives the downgrade — under two fail-closed limits.

**The exemption's one condition, set in exactly one place** — the host-rules
loop in `#pipeline`, `packages/guard/src/guard.ts:1382-1387`:

```ts
return withInvalidated({
  decision: { action: rule.action, decidedBy: "rule" },
  // Only a rule the host WROTE. A preset is a shorthand they selected, not
  // a rule they authored, so it does not carry the away exemption.
  ...(this.#presetPolicy ? {} : { hostRule: true }),
});
```

Declared at `guard.ts:182` (`hostRule?: true`), read at `guard.ts:1083-1087`.

**Not gated on `decidedBy === "rule"`.** `normalizeCodeDecision`
(`guard.ts:455-467`) deliberately labels `policy.code` decisions `"rule"` too,
so the deploy-time hatch stays away-downgraded. Gating on the string would have
exempted it. The flag is what tells the two apart.

## The resolution, in the ruling's terms

**An explicit user denial always outranks a host rule's run verdict —
fail-closed.** A host rule is standing authority written ahead of time; a
standing denial is this user answering *this* question, and the later, more
specific answer wins. Implemented on the existing `#standingDenial` seam at
`guard.ts:1083-1087`: losing the exemption drops the call back into the away
park, where the same denial turns it into the "you denied this" block, so a
rule cannot reopen a question the user already closed.

**Preset-expanded rules are excluded from the exemption, for the same
reason.** `resolvePolicyConfig` (`policy.ts:46-56`) is the only place a preset
becomes rules, and a string policy is always a preset, so `#presetPolicy`
(`guard.ts:495-499`, set at `guard.ts:540`) reads the provenance with no new
type, no per-rule tagging and no spoofable field. Preset rules are never mixed
with authored ones — `PolicyResolver.rules()` (`policy.ts:137-144`) returns
either the inline/preset set or the file's, never both — so one boolean is
exact rather than approximate.

**Both are deliberately conservative.** They remove capability, never add it,
and can be loosened later if a real use case appears.

## Deliberate contract change

`packages/guard/test/pipeline-conformance.test.ts:372` — "parks an away call
even when a rule says run" — asserted the exact behavior the spec removes. It
is **deliberately updated**, not repaired: it now reads "runs an away call when
an explicit host rule says run" and asserts
`{ action: "run", decidedBy: "rule" }`.

## Untouched and green

`packages/guard/test/security/away-code-hatch.test.ts` (P1-A) — not one
character changed. It is the positive proof the exemption did not leak to the
code hatch:

```
 ✓ test/security/away-code-hatch.test.ts (2 tests) 27ms
```

`packages/vendo/tests/mcp-door-parity.e2e.test.ts:249` — untouched, and fixed
by the preset exclusion:

```
 ✓ §12 — an UNATTENDED turn's door call carries `away`/`automation` into the AUDIT, identically to in process  8671ms
```

## The six proofs (`packages/guard/test/pipeline-conformance.test.ts`)

| # | Test | Proves |
|---|---|---|
| a | `executes rule-decided away reads and writes end to end` | rule-decided read/write tools EXECUTE unattended |
| b | `still refuses a rule-decided away destructive or ungraded call` | destructive and ungraded are STILL blocked unattended — THE LAW is downstream |
| c | `still parks an away run decided by the judge or by the default posture` | judge and default-posture runs STILL downgrade to ask |
| d | `still parks an away run decided by policy.code, which is never an explicit rule` | the code hatch STILL parks |
| e | `lets an explicit user denial outrank a host rule that says run` | a user's no beats a rule added afterwards |
| f | `still parks a preset-decided away call, with its approval row, since a preset is not authored` | a preset does not take the exemption |

## Why the ruling does not reach J5

`fixtures/integration/tests/away-park-revoke.e2e.test.ts:112` still fails:

```
- "code": "needs-permission",   - "tool": "host_invoices_update",
+ "code": "validation",
```

The ruling routes through "an explicit user denial". In J5 there is no denial
row that the guard can see for that call. Proof from source and from base
behavior, not inference:

- `#standingDenial` (`guard.ts:1779-1797`) matches only rows where
  `deniedBy === "human"` **and** `sameParkedCall(...)`, which requires
  `request.call.id === call.id` (`guard.ts:446`).
- The park path at `guard.ts:1158` runs that same check first, and turns a
  match into a **block**. On `main`, J5's sweep **parks** (`pending-approval`,
  `needs-permission`) rather than blocking. Therefore no matching denial row
  exists for that call.

J5's user denies the sweep at automation-**enable capture** time, which is a
different call id. Their "no" is expressed as the **absence of a grant**, not
as a denial row — and parking-on-absence-of-grant is exactly the behavior this
change removes for host-authored rules. The fixture's `.vendo/policy.json`
says `write → run` and is hand-authored, so the preset exclusion does not
reach it either.

The open question is therefore narrower than before, and unresolved: **does a
host-authored `run` rule authorize an away step whose capture-time consent the
user declined?** Today it does, and the step then dies downstream with no
actAs authority — a clean resumable `needs-permission` becomes an opaque
`validation` error. Options are to exclude away/automation venues from the
exemption, or to require capture consent regardless of rule; both are further
narrowings, and neither is mine to choose.

## Gate

```
build      exit=0   Tasks: 21 successful, 21 total
typecheck  exit=0   Tasks: 42 successful, 42 total
lint       exit=0   Tasks:  4 successful,  4 total
guard      exit=0   Test Files 27 passed | 1 skipped (28) · Tests 287 passed | 3 skipped (290)
```

`pnpm test:affected`: 31 of 34 tasks successful. Red: `@vendoai-fixtures/integration`
(J5, above), `@vendoai/vendo` (the discovery-rail budget, above), and
`@vendoai/genbench` (pre-existing on this box — missing `chrome-headless-shell`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
