### PR TITLE
fix(agents,harnesses): budget parked calls, surface the user, name import paths in errors

### DIFF
--- a/packages/agents/README.md
+++ b/packages/agents/README.md
@@ -39,6 +39,35 @@ const response = await session.stream("Refund invoice #7");
 // conversation on the next request.
 ```
 
+`respond()` is that pair — `session()` then `stream()` — in one call, for a
+route that only wants the Response back:
+
+```ts
+export async function POST(req: Request) {
+  const { message, threadId } = await req.json();
+  return support.respond("u_42", message, { threadId, headers: req.headers });
+}
+```
+
+`run()` answers CODE rather than a screen: one unattended turn, a report at the
+end. Nobody is there to tap, so a call the guard wants a person for parks as a
+card instead of running — `refs.approvals` is who to ask, and there is no
+resume: answer them and run again.
+
+```ts
+const running = support.run("Chase every invoice over 30 days.", {
+  as: "u_42",                               // whose run it is; omit to run as the agent
+  maxToolCalls: 20,                         // default 20; the call past it is refused
+  output: z.object({ chased: z.number() }), // optional typed answer, no second model call
+});
+console.log(running.threadId);              // readable before the run finishes
+for await (const event of running.events) console.log(event);   // text, status, calls
+
+const report = await running;
+// status "ok" | "stopped" | "error", summary, toolCalls, usage, output,
+// refs: { threadId, approvals }.
+```
+
 A session is a REQUEST-lifetime object — the conversation it is on outlives
 it, in your store. Build one per request and pass `threadId` back in, or the
 next request starts a blank conversation. Omitting `threadId` opens a new

--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -221,7 +221,8 @@ const defaultStore = (): VendoStore => {
       throw new VendoError(
         "not-implemented",
         "A VENDO_API_KEY is set but this build has no Cloud store rung wired (tenant-store access is "
-        + "under redesign). Pass `store: postgres(url)` explicitly, or unset the key for the embedded store.",
+        + "under redesign). Pass `store: postgres(url)` explicitly, importing `postgres` from "
+        + "`@vendoai/agents` — or unset the key for the embedded store.",
       );
     }
     return cloudAdapters.store(key);
@@ -243,13 +244,15 @@ const resolveSandbox = (explicit: SandboxAdapter | undefined): SandboxAdapter =>
       "not-implemented",
       "A VENDO_API_KEY is set but this build has no Cloud sandbox rung wired. "
       + "Pass a sandbox explicitly — `sandbox: e2b()`, which reads E2B_API_KEY as its credential "
-      + "— or use a build that ships the Cloud sandbox rung for VENDO_API_KEY to fill.",
+      + "(import `e2b` from `@vendoai/agents`) — or use a build that ships the Cloud sandbox rung "
+      + "for VENDO_API_KEY to fill.",
     );
   }
   throw new VendoError(
     "validation",
     "This harness runs on a sandbox and none resolved: pass one — `sandbox: e2b()`, which reads "
-    + "E2B_API_KEY as its credential — or set VENDO_API_KEY for the Vendo Cloud sandbox pool. "
+    + "E2B_API_KEY as its credential (import `e2b` from `@vendoai/agents`) — or set VENDO_API_KEY "
+    + "for the Vendo Cloud sandbox pool. "
     + "An E2B_API_KEY alone no longer selects a sandbox.",
   );
 };
@@ -279,8 +282,9 @@ export function agent(config: AgentConfig): VendoAgent {
     throw new VendoError(
       "validation",
       "agent({ model }) is required — vendo(), the default brain, thinks with it. Pass one — "
-      + "`model: anthropic(\"claude-sonnet-4-6\")` — or name a harness that brings its own, "
-      + "e.g. `harness: claudeCode()`.",
+      + "`model: anthropic(\"claude-sonnet-4-6\")`, importing `anthropic` from `@ai-sdk/anthropic` "
+      + "— or name a harness that brings its own, e.g. `harness: claudeCode()`, importing "
+      + "`claudeCode` from `@vendoai/harnesses/claude-code`.",
     );
   };
 

--- a/packages/agents/src/away.ts
+++ b/packages/agents/src/away.ts
@@ -57,6 +57,14 @@ import { openThread } from "./session.js";
  *  own (50), so this only bounds a host driving the seam directly. */
 const DEFAULT_MAX_TOOL_CALLS = 20;
 
+/** What a call past the run's budget gets. Two rails answer with it: `preflight`
+ *  rules the call out before the guard can park it, and `gate` — the rail whose
+ *  outcome reaches the model — repeats it for that same call. */
+const BUDGET_EXHAUSTED: ToolOutcome = {
+  status: "error",
+  error: { code: "budget-exhausted", message: "Tool-call budget exhausted" },
+};
+
 export interface AwayRunnerDeps {
   /** The brain, with its knobs already bound. */
   harness: Harness<unknown>;
@@ -348,6 +356,22 @@ async function runTurn(deps: AwayRunnerDeps, input: RunTurnInput): Promise<Agent
   if (!Number.isInteger(cap) || cap < 1) {
     throw new VendoError("validation", "maxToolCalls must be a positive integer");
   }
+  // Read through a call, never inline: `AbortSignal.aborted` is a readonly
+  // boolean, so a narrowing here would have the compiler believe the answer
+  // below cannot change — and the whole point of a signal is that it does.
+  const aborted = (): boolean => input.signal?.aborted === true;
+  // Cancelled before it began: no thread, no workspace, no harness. The signal
+  // is the only way to stop a run, and a run stopped before its first I/O has
+  // nothing to report but the stop.
+  if (aborted()) {
+    return {
+      status: "stopped",
+      summary: fallbackSummary("stopped", []),
+      toolCalls: [],
+      refs: { threadId: input.threadId, approvals: [] },
+      usage: { inputTokens: 0, outputTokens: 0 },
+    };
+  }
   // Everything the caller put on the ctx rides through untouched — the sponsor,
   // the venue, the appId, the firing trigger's id, the asserted memberships.
   // Only presence is asserted, for a caller that came in without it.
@@ -374,6 +398,10 @@ async function runTurn(deps: AwayRunnerDeps, input: RunTurnInput): Promise<Agent
   };
   let startedCalls = 0;
   let budgetRefused = false;
+  /** Calls the budget already refused, by id: the two rails below are two halves
+   *  of ONE decision, and the second must answer for exactly the call the first
+   *  ruled out — never for the call that spent the last of the budget. */
+  const overBudget = new Set<string>();
   let failed = false;
   let usage: UsageTotals | undefined;
   let output: unknown;
@@ -432,35 +460,38 @@ async function runTurn(deps: AwayRunnerDeps, input: RunTurnInput): Promise<Agent
       emit: opts.emit,
     }),
     bridge: {
-      // Every call the harness ATTEMPTS, before the guard sees it. It is only an
-      // observer (it never rules a call out), and it is here because a call the
-      // preview refuses — `interactive: false` and nobody there to approve — is
-      // denied without ever reaching `execute`, so `onCall` below never sees it.
-      // Leaving it out of the report would hide the very thing the run record is
-      // for: the automation asked, and it is waiting on a person.
+      // Every call the harness ATTEMPTS, before the guard sees it — and the one
+      // rail EVERY away call passes, which is why the budget is spent here. A
+      // call the preview parks (`interactive: false` and nobody there to
+      // approve) is denied without ever reaching `execute`, so `gate` and
+      // `onCall` below never see it: charged there alone, the budget bounded
+      // nothing away and a looping model minted one approval card per attempt.
+      // Recording the attempt here is what keeps the run record honest too —
+      // the automation asked, and it is waiting on a person.
       preflight: async (call) => {
-        attempted(call).outcome = "pending-approval";
+        attempted(call);
+        if (startedCalls >= cap) {
+          budgetRefused = true;
+          overBudget.add(call.id);
+          // Returned BEFORE the guard is consulted: nothing past the bound is
+          // worth a person's card, and `gate` speaks this to the model.
+          return BUDGET_EXHAUSTED;
+        }
+        startedCalls += 1;
         // The result channel takes the same pre-guard short-circuit an
         // unconnected service does. It reaches nothing — it validates its args
         // and hands them to a closure in this function: no network, no store,
-        // no host API, no file — and it still pays the call budget at `gate`
-        // below. It is here ONLY because an away run parks every call it cannot
-        // trace to a grant, READS INCLUDED (packages/guard/src/guard.ts:1051),
-        // which would strand every typed run on a card nobody can answer.
-        // DELETE THIS BRANCH once the pending guard change lands and a
-        // reaches-nothing read no longer parks unattended.
+        // no host API, no file — and it pays the call budget just above. It is
+        // here ONLY because an away run parks every call it cannot trace to a
+        // grant, READS INCLUDED (packages/guard/src/guard.ts:1051), which would
+        // strand every typed run on a card nobody can answer. DELETE THIS
+        // BRANCH once the pending guard change lands and a reaches-nothing read
+        // no longer parks unattended.
         return call.tool === RESULT_TOOL ? { status: "ok", output: {} } : undefined;
       },
-      // The budget, at the one place every guarded call passes. Spent, further
-      // calls are refused BEFORE the registry — nothing runs past the bound.
-      gate: () => {
-        if (startedCalls >= cap) {
-          budgetRefused = true;
-          return { status: "error", error: { code: "budget-exhausted", message: "Tool-call budget exhausted" } };
-        }
-        startedCalls += 1;
-        return undefined;
-      },
+      // The other half of the budget decision: the refusal, at the one place an
+      // outcome reaches the model — nothing runs past the bound.
+      gate: (call) => (overBudget.has(call.id) ? BUDGET_EXHAUSTED : undefined),
       onCall: (call) => {
         const entry = attempted(call);
         return (outcome) => {
@@ -475,6 +506,7 @@ async function runTurn(deps: AwayRunnerDeps, input: RunTurnInput): Promise<Agent
   const directions = await deps.guard.directions(awayCtx);
   const assembled = assemblePrompt({
     ...(deps.instructions === undefined ? {} : { instructions: deps.instructions }),
+    ...(awayCtx.user === undefined ? {} : { user: awayCtx.user }),
     ...(awayCtx.context === undefined ? {} : { situation: awayCtx.context }),
     directions,
   });
@@ -503,8 +535,18 @@ async function runTurn(deps: AwayRunnerDeps, input: RunTurnInput): Promise<Agent
   // its callbacks in a set forever, so a throw between the subscribe and the
   // teardown would leak one — and a foreign `threadId` is a rejection a caller
   // can repeat at will.
-  const unsubscribe = runKey === undefined ? undefined : deps.guard.onApprovalRequested?.((request) => {
-    if ((request.ctx.trigger?.runId ?? request.ctx.sessionId) === runKey) approvals.push(request.id);
+  const unsubscribe = deps.guard.onApprovalRequested?.((request) => {
+    if (runKey !== undefined && (request.ctx.trigger?.runId ?? request.ctx.sessionId) === runKey) {
+      approvals.push(request.id);
+    }
+    // A parked call never reaches `onCall`, so this is the only moment the run
+    // learns one parked — and it is the HONEST one: a guard that threw while
+    // parking mints no request, so its call keeps the opening `error` instead of
+    // telling the host to wait on a card nobody has. Matched on the tool call's
+    // own id (minted per call, uuid-backed), so a sibling run's card cannot mark
+    // this run's call whatever the run key says.
+    const parked = recorded.find((entry) => entry.call.id === request.call.id);
+    if (parked !== undefined) parked.outcome = "pending-approval";
   });
   try {
     const response = await runtime.run({
@@ -543,7 +585,7 @@ async function runTurn(deps: AwayRunnerDeps, input: RunTurnInput): Promise<Agent
   // agreeing with the report rather than silently short of it.
   for (const entry of recorded) if (!reported.has(entry.call.id)) emitResult(entry);
 
-  const stopped = input.signal?.aborted === true || budgetRefused;
+  const stopped = aborted() || budgetRefused;
   const status: AgentRunReport["status"] = stopped
     ? "stopped"
     : failed ? "error" : "ok";

--- a/packages/agents/src/prompt.ts
+++ b/packages/agents/src/prompt.ts
@@ -7,8 +7,12 @@
  */
 import { situationPromptBlock, userPromptBlock, type Json, type RunContext } from "@vendoai/core";
 
+/** Who the agent is acting for. An unattended run often has no user at all, and
+ *  "the user named below" with nobody below it is a dangling reference. */
+const role = (named: boolean): string =>
+  `You are an agent embedded in the host application${named ? ", acting for the user named below" : ""}.`;
+
 const BASE_RULES = [
-  "You are an agent embedded in the host application, acting for the user named below.",
   "Follow the host's instructions. Never reveal tool, function, or file identifiers in anything the user reads.",
   "When a tool call needs approval, say what you asked for and wait — never claim it ran.",
 ].join("\n");
@@ -33,14 +37,14 @@ export type SystemPromptHook = (
 ) => string | undefined | Promise<string | undefined>;
 
 export function assemblePrompt(input: PromptInput): string {
-  const sections: string[] = [BASE_RULES];
-  if (input.instructions !== undefined && input.instructions.trim() !== "") {
-    sections.push(input.instructions.trim());
-  }
   // Both blocks — the label, the observation note, and the section-forgery
   // indent that stops a client-supplied fact from forging a top-level
   // `Directions` — are core's, shared verbatim with the umbrella's assembler.
   const user = userPromptBlock(input.user);
+  const sections: string[] = [`${role(user !== undefined)}\n${BASE_RULES}`];
+  if (input.instructions !== undefined && input.instructions.trim() !== "") {
+    sections.push(input.instructions.trim());
+  }
   if (user !== undefined) sections.push(user);
   const situation = situationPromptBlock(input.situation);
   if (situation !== undefined) sections.push(situation);

--- a/packages/agents/tests/error-imports.test.ts
+++ b/packages/agents/tests/error-imports.test.ts
@@ -1,0 +1,79 @@
+/**
+ * A boot error that names a symbol has to name where the symbol COMES FROM.
+ *
+ * Every one of these sentences is copied verbatim by the person reading it, and
+ * `claudeCode` is not on the `@vendoai/harnesses` root barrel — so "pass
+ * `harness: claudeCode()`" sent a host straight into `TypeError: claudeCode is
+ * not a function`. The path is pinned here against the REAL module, so a moved
+ * export breaks this suite instead of the next host's first hour.
+ */
+import { defineHarness } from "@vendoai/harnesses";
+import { createStore } from "@vendoai/store";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { agent, e2b, postgres } from "../src/index.js";
+
+let stores = 0;
+const memoryStore = () => createStore({ dataDir: `memory://agents-error-imports-${stores++}` });
+
+/** The zero-key rung, pinned so the suite reads the same on a laptop that has
+ *  run `vendo login` and on one that has not. */
+const withoutRung = (): void => {
+  vi.stubEnv("VENDO_DEV_CREDENTIAL", "");
+  vi.stubEnv("VENDO_API_KEY", "");
+};
+
+/** A harness that thinks on a machine — the one that needs a sandbox slot. */
+const boxy = () => defineHarness({
+  name: "boxy",
+  requires: { sandbox: true, toolDoor: true },
+  async *run() {},
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("the symbols a boot error names", () => {
+  it("says where claudeCode and anthropic live — the two the no-model error hands out", async () => {
+    withoutRung();
+    const support = agent({ name: "support", store: memoryStore() });
+
+    await expect(support.run("do a thing")).rejects.toThrow(
+      /`harness: claudeCode\(\)`, importing `claudeCode` from `@vendoai\/harnesses\/claude-code`/,
+    );
+    await expect(support.run("do a thing")).rejects.toThrow(
+      /`model: anthropic\("claude-sonnet-4-6"\)`, importing `anthropic` from `@ai-sdk\/anthropic`/,
+    );
+  });
+
+  it("claudeCode really is at that path, and really is not on the root barrel", async () => {
+    // The verifier's exact failure: the suggestion, pasted verbatim, threw.
+    const subpath = await import("@vendoai/harnesses/claude-code");
+    const barrel = await import("@vendoai/harnesses");
+
+    expect(typeof subpath.claudeCode).toBe("function");
+    expect(barrel).not.toHaveProperty("claudeCode");
+  });
+
+  it("says where e2b lives, on both sandbox errors", () => {
+    withoutRung();
+    expect(() => agent({ name: "support", harness: boxy(), store: memoryStore() }))
+      .toThrow(/import `e2b` from `@vendoai\/agents`/);
+
+    vi.stubEnv("VENDO_API_KEY", "vk_test");
+    expect(() => agent({ name: "support", harness: boxy(), store: memoryStore() }))
+      .toThrow(/import `e2b` from `@vendoai\/agents`/);
+  });
+
+  it("says where postgres lives, on the store error", () => {
+    vi.stubEnv("VENDO_API_KEY", "vk_test");
+    expect(() => agent({ name: "support" }))
+      .toThrow(/importing `postgres` from `@vendoai\/agents`/);
+  });
+
+  // The paths above are only true because this package exports them.
+  it("exports the symbols it points at", () => {
+    expect(typeof e2b).toBe("function");
+    expect(typeof postgres).toBe("function");
+  });
+});

--- a/packages/agents/tests/unattended.test.ts
+++ b/packages/agents/tests/unattended.test.ts
@@ -1,0 +1,168 @@
+/**
+ * What an UNATTENDED run owes its caller, proved against merged main by an
+ * independent prove-walk: the budget bounds the run even when every call parks,
+ * the brief carries the user the caller named, an aborted run does nothing at
+ * all, and a guard that fails while parking is reported as a failure rather than
+ * as "waiting on a person". Real embedded store, real guard, real runtime; only
+ * the thinker is scripted (CLAUDE.md: test the SEAM).
+ */
+import type { Guard, ToolDescriptor, ToolRegistry } from "@vendoai/core";
+import { defineHarness } from "@vendoai/harnesses";
+import { createStore, threadStore } from "@vendoai/store";
+import { describe, expect, it } from "vitest";
+import { agent } from "../src/agent.js";
+import { startRun } from "../src/away.js";
+import { tool } from "../src/tools.js";
+
+let stores = 0;
+const memoryStore = () => createStore({ dataDir: `memory://agents-unattended-${stores++}` });
+
+const readTool = () => tool({
+  name: "invoices_list",
+  description: "List invoices",
+  risk: "read",
+  inputSchema: { type: "object" },
+  execute: () => ({ invoices: 2 }),
+});
+
+/** A harness that calls one tool `attempts` times and then speaks. */
+const looper = (attempts: number) => defineHarness({
+  name: "looper",
+  async *run(turn) {
+    for (let index = 0; index < attempts; index += 1) await turn.tools.call("invoices_list", {});
+    yield { type: "text" as const, delta: "done" };
+  },
+});
+
+describe("run() — the budget bounds a run whose calls PARK", () => {
+  // The shipped guard parks every away call it cannot trace to an app-bound
+  // grant, so in production every host tool call an unattended run makes is a
+  // parked one — and a parked call was denied before the budget rail, which
+  // meant the budget bounded nothing and a looping model minted one approval
+  // card per attempt (25 cards against a budget of 20, reported `ok`).
+  it("spends the budget on parked calls too, and stops rather than minting cards forever", async () => {
+    const store = memoryStore();
+    const support = agent({
+      name: "support",
+      harness: looper(5),
+      tools: [readTool()],
+      store,
+    });
+
+    const report = await support.run("Loop.", { as: "u_42", maxToolCalls: 2 });
+
+    // Two cards for two attempts the budget allowed — never one per attempt.
+    expect(report.refs.approvals).toHaveLength(2);
+    expect(report.toolCalls.map(({ outcome }) => outcome))
+      .toEqual(["pending-approval", "pending-approval", "error", "error", "error"]);
+    expect(report.status).toBe("stopped");
+  });
+});
+
+describe("run() — the brief", () => {
+  const briefFor = async (options: Parameters<ReturnType<typeof agent>["run"]>[1]): Promise<string> => {
+    let seen = "";
+    const support = agent({
+      name: "support",
+      harness: defineHarness({
+        name: "peek",
+        async *run(turn) {
+          seen = turn.system ?? "";
+          yield { type: "text" as const, delta: "ok" };
+        },
+      }),
+      store: memoryStore(),
+    });
+    await support.run("go", options);
+    return seen;
+  };
+
+  // Documented as model-visible (`RunOptions.user`) and assembled by `session`,
+  // but dropped on the way to the away assembler: the block never reached the
+  // model on an unattended run.
+  it("carries the user the caller named, as [User]", async () => {
+    const brief = await briefFor({ as: "u_42", user: { name: "Dana", plan: "pro" } });
+
+    expect(brief).toContain("[User]");
+    expect(brief).toContain("name: Dana");
+    expect(brief).toContain("acting for the user named below");
+  });
+
+  it("names no user when there is none — a dangling reference is a lie about the run", async () => {
+    const brief = await briefFor({ as: "u_42" });
+
+    expect(brief).toContain("You are an agent embedded in the host application.");
+    expect(brief).not.toContain("the user named below");
+  });
+});
+
+describe("run() — an already-aborted signal", () => {
+  it("does no work at all: no thread, no harness, just the stop", async () => {
+    const store = memoryStore();
+    let thought = false;
+    const support = agent({
+      name: "support",
+      harness: defineHarness({
+        name: "eager",
+        async *run() {
+          thought = true;
+          yield { type: "text" as const, delta: "should not arrive" };
+        },
+      }),
+      store,
+    });
+    // The run itself opens the schema; opened here so the read below can answer
+    // for a thread that was never written rather than for a store never touched.
+    await store.ensureSchema();
+    const controller = new AbortController();
+    controller.abort();
+
+    const running = support.run("Stop me.", { as: "u_42", signal: controller.signal });
+    const report = await running;
+
+    expect(report.status).toBe("stopped");
+    expect(thought).toBe(false);
+    expect(await threadStore(store).get({ kind: "user", subject: "u_42" }, running.threadId as never))
+      .toBeNull();
+  });
+});
+
+describe("run() — a guard that fails while parking", () => {
+  const descriptor: ToolDescriptor = {
+    name: "invoices_list",
+    description: "List invoices",
+    inputSchema: { type: "object" },
+    risk: "read",
+  };
+  const registry: ToolRegistry = {
+    descriptors: async () => [descriptor],
+    execute: async () => ({ status: "ok", output: { invoices: 2 } }),
+  };
+  /** Fails closed the way the shipped preview does: it wants a person, and it
+   *  minted nothing for anyone to answer. */
+  const brokenGuard = (): Guard => ({
+    check: async () => {
+      throw new Error("the guard is down");
+    },
+    report: async () => {},
+    directions: async () => [],
+    onApprovalDecision: () => () => {},
+    onApprovalRequested: () => () => {},
+  });
+
+  // "pending-approval" with `refs.approvals: []` tells the host to wait on a
+  // person who has nothing to answer — the run is stuck, silently, forever.
+  it("reports the failure, not a card nobody has", async () => {
+    const report = await startRun({
+      name: "support",
+      store: memoryStore(),
+      guard: brokenGuard(),
+      tools: registry,
+      harness: looper(1),
+    }, "read the invoices", { as: "u_42" });
+
+    expect(report.refs.approvals).toEqual([]);
+    expect(report.toolCalls.map(({ call, outcome }) => [call.tool, outcome]))
+      .toEqual([["invoices_list", "error"]]);
+  });
+});

--- a/packages/harnesses/src/vendo/model-windows.ts
+++ b/packages/harnesses/src/vendo/model-windows.ts
@@ -70,6 +70,13 @@ export function rememberResolvedModelId(model: LanguageModel, reported: string |
   resolvedIds.set(model, reported);
 }
 
+/** What the provider reported for `model`, if a call has reported yet. The
+ *  metering path reads it too: usage is priced on the model that served the
+ *  tokens, and a lazy seat's own id is a family name, not a model. */
+export function resolvedModelId(model: LanguageModel): string | undefined {
+  return typeof model === "string" ? model : resolvedIds.get(model);
+}
+
 /**
  * THE one new public knob of this shipment.
  *

--- a/packages/harnesses/src/vendo/vendo.ts
+++ b/packages/harnesses/src/vendo/vendo.ts
@@ -20,7 +20,7 @@ import { z } from "zod";
 import { modelToolDescription, type Harness, type Json, type Turn } from "@vendoai/core";
 import { readCompactionState, writeCompactionState, type CompactionState } from "./compaction.js";
 import { startTurn, type TurnCompaction, type TurnContext } from "./loop.js";
-import { contextWindowTokens, rememberResolvedModelId } from "./model-windows.js";
+import { contextWindowTokens, rememberResolvedModelId, resolvedModelId } from "./model-windows.js";
 import { isContextOverflow } from "./overflow.js";
 import {
   computeInitialLoadout,
@@ -291,10 +291,12 @@ interface SubagentReport {
   usage: UsageTotals;
 }
 
-/** The resolved id of the seat that spent the tokens: the union's string form IS
- *  the id, the object form names it. */
+/** The resolved id of the seat that spent the tokens: what the PROVIDER reported
+ *  for it (the same record the window table reads), else the seat's own id. A
+ *  lazy seat answers `vendo-env` for its own id — a family, not a model — and
+ *  usage is what hosts meter on. */
 const modelIdOf = (model: LanguageModel): string =>
-  typeof model === "string" ? model : model.modelId;
+  typeof model === "string" ? model : resolvedModelId(model) ?? model.modelId;
 
 /** One usage figure set from an `ai` totals block, in `UsageTotals` shape. */
 function usageOf(usage: LanguageModelUsage, model: LanguageModel): UsageTotals {

--- a/packages/harnesses/tests/vendo/usage-model.test.ts
+++ b/packages/harnesses/tests/vendo/usage-model.test.ts
@@ -1,0 +1,115 @@
+/**
+ * What the metering row says the tokens were spent ON.
+ *
+ * Vendo's own seat is LAZY: it answers `vendo-env` for its own id and picks the
+ * rung on the first call, so every usage event a deployment on it emitted named
+ * a FAMILY, not a model — and usage is what hosts meter and price on. The
+ * resolved id is not knowable before the call and IS reported on it, which the
+ * window table already reads; the same record answers here.
+ */
+import type { ToolRegistry, Turn } from "@vendoai/core";
+import type { LanguageModel } from "ai";
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+import { describe, expect, it } from "vitest";
+import { createTurnState } from "../../src/harness-state.js";
+import { createTurnTools } from "../../src/turn-tools.js";
+import { vendo, type VendoHarnessOptions } from "../../src/vendo/vendo.js";
+import {
+  ctx,
+  seats,
+  testGuard,
+  testSkills,
+  testWorkspace,
+  userMessage,
+} from "../../src/test-doubles.test-util.js";
+
+const NO_TOOLS: ToolRegistry = {
+  descriptors: async () => [],
+  execute: async () => ({ status: "error", error: { code: "not-found", message: "no tools" } }),
+};
+
+/** A seat that calls itself one thing and is SERVED by another — the shape of
+ *  every `vendoModel()` deployment. */
+const lazySeat = (modelId: string, respondsAs: string): LanguageModel =>
+  new MockLanguageModelV3({
+    modelId,
+    doStream: async () => ({
+      stream: simulateReadableStream({
+        chunks: [
+          { type: "response-metadata" as const, modelId: respondsAs },
+          { type: "text-start" as const, id: "t1" },
+          { type: "text-delta" as const, id: "t1", delta: "ok" },
+          { type: "text-end" as const, id: "t1" },
+          {
+            type: "finish" as const,
+            usage: {
+              inputTokens: { total: 11, noCache: 11, cacheRead: 0, cacheWrite: 0 },
+              outputTokens: { total: 7, text: 7, reasoning: 0 },
+            },
+            finishReason: { unified: "stop" as const, raw: undefined },
+          },
+        ],
+      }),
+    }),
+  }) as unknown as LanguageModel;
+
+async function usageModels(model: LanguageModel): Promise<Array<string | undefined>> {
+  const turnTools = createTurnTools({
+    registry: NO_TOOLS,
+    guard: testGuard(),
+    ctx: ctx(),
+    interactive: true,
+    mirror: () => {},
+  });
+  const turn: Turn<VendoHarnessOptions> = {
+    threadId: "thr_usage_model",
+    turnId: "trn_usage_model",
+    messages: [userMessage("m1", "hello")],
+    tools: turnTools,
+    skills: testSkills(),
+    workspace: testWorkspace(),
+    models: seats(model),
+    state: createTurnState(undefined),
+    options: {},
+    signal: new AbortController().signal,
+    interactive: true,
+  };
+  const models: Array<string | undefined> = [];
+  for await (const event of vendo().run(turn)) {
+    if (event.type === "usage") models.push(event.model);
+  }
+  turnTools.dispose();
+  return models;
+}
+
+describe("usage.model", () => {
+  it("is the model that SERVED the turn, not the lazy seat's family name", async () => {
+    expect(await usageModels(lazySeat("vendo-env", "claude-sonnet-4-6-20260101")))
+      .toEqual(["claude-sonnet-4-6-20260101"]);
+  });
+
+  it("is the seat's own id when the provider reported none", async () => {
+    const silent = new MockLanguageModelV3({
+      modelId: "claude-opus-4-1",
+      doStream: async () => ({
+        stream: simulateReadableStream({
+          chunks: [
+            { type: "text-start" as const, id: "t1" },
+            { type: "text-delta" as const, id: "t1", delta: "ok" },
+            { type: "text-end" as const, id: "t1" },
+            {
+              type: "finish" as const,
+              usage: {
+                inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+                outputTokens: { total: 1, text: 1, reasoning: 0 },
+              },
+              finishReason: { unified: "stop" as const, raw: undefined },
+            },
+          ],
+        }),
+      }),
+    }) as unknown as LanguageModel;
+
+    expect(await usageModels(silent)).toEqual(["claude-opus-4-1"]);
+  });
+});


### PR DESCRIPTION
Seven defects an independent prove-walk found by RUNNING merged `main` (`abbfe14f4`) against real services — none of them by CI. Each is verified from source and pinned by a new test that fails on `main` and passes here. No existing test file was edited.

1. **Parked calls bypassed `maxToolCalls` entirely.** `packages/agents/src/away.ts:471,494` — the budget lived only on `gate`, which `turn-tools.ts:324-332` never reaches for a parked call, and the shipped guard parks *every* host tool call in an unattended run. 25 calls against a budget of 20 wrote 25 approval rows and returned `ok`. The budget now spends at `preflight` — the one rail every away call passes *before* the guard can park it, so nothing past the bound is worth a person's card — and `gate` repeats the refusal for that same call, which is where an outcome reaches the model. `turn-tools.ts` (shared with the interactive lane) is untouched.
2. **`run({ user })` never reached the model.** `packages/agents/src/away.ts:509` now hands `ctx.user` to `assemblePrompt`, mirroring `session.ts:242`. `packages/agents/src/prompt.ts:12` no longer opens with "acting for the user named below" when no user was supplied.
3. **Error messages named symbols with no import path.** `packages/agents/src/agent.ts:224,247,254,285` — `claudeCode` is at `@vendoai/harnesses/claude-code` and is **not** on the root barrel (the verifier's `TypeError: claudeCode is not a function`); `anthropic` is `@ai-sdk/anthropic`; `e2b` and `postgres` are `@vendoai/agents`. Every path was resolved against the built packages, and the claude-code one is pinned by a real import in the new suite.
4. **An already-aborted `AbortSignal` still did work.** `packages/agents/src/away.ts:366` short-circuits before the thread, the workspace or the harness — a run cancelled before it began now writes nothing.
5. **`pending-approval` with no card to answer.** `packages/agents/src/away.ts:538` — the outcome is now stamped when the guard actually parks (its `onApprovalRequested` request, matched on the tool call's own id), so a guard that fails closed while parking reports `error` instead of telling the host to wait on a person with `refs.approvals: []`.
6. **`report.usage.model` was the family id.** `packages/harnesses/src/vendo/vendo.ts:298` now reads the provider-reported id the window table already records (`model-windows.ts:76`), so a metered run names `claude-sonnet-4-6-…` rather than `vendo-env`.
7. **`packages/agents/README.md` documented only `session()`.** `respond()` and `run()` added, in the file's existing style and length.

New tests: `packages/agents/tests/unattended.test.ts` (1, 2, 4, 5), `packages/agents/tests/error-imports.test.ts` (3), `packages/harnesses/tests/vendo/usage-model.test.ts` (6).

Out of scope by instruction: `packages/guard/**` is untouched, and unattended `run()` still parks host tool calls rather than executing them (`guard.ts:382-396`) — that deferral is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes seven defects in unattended runs and metering: budgets now apply to parked calls, user context reaches the model, aborts short‑circuit, and errors/usage report correct sources.

- Enforce `maxToolCalls` on parked calls by spending budget at `preflight` and repeating the refusal at `gate`. A looping model no longer mints unlimited approval cards; runs stop at the cap.
- Pass `user` to the prompt for unattended runs; the base prompt omits “acting for the user named below” when no user is provided.
- Name import paths in boot errors: suggest `claudeCode` from `@vendoai/harnesses/claude-code`, `anthropic` from `@ai-sdk/anthropic`, and `e2b`/`postgres` from `@vendoai/agents`.
- Short‑circuit already‑aborted runs before opening a thread/workspace or invoking the harness; report `stopped` and write nothing.
- Mark `pending-approval` only when the guard actually mints a request; if parking fails closed, report `error` and leave `refs.approvals` empty.
- Emit `report.usage.model` as the provider‑reported model id (e.g., `claude-sonnet-4-6-…`) instead of a lazy seat’s family id (e.g., `vendo-env`).
- Document `respond()` and `run()` in `packages/agents/README.md`.

**Rollout notes**
- Unattended runs may now stop earlier when exceeding `maxToolCalls`. Adjust `maxToolCalls` if you relied on extra parked attempts.
- If dashboards assumed `report.usage.model` was a family id, update them to expect the actual served model id.

<sup>Written for commit 99d3c28c5ef29e6d28b63fabf15ea3a35fbe3714. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

