### PR TITLE
refactor(agents): fold the duplicated turn setup into one path

### DIFF
--- a/packages/agents/src/away.ts
+++ b/packages/agents/src/away.ts
@@ -50,8 +50,8 @@ import { addUsage, createHarnessRuntime, type HarnessRuntimeDeps, type UsageTota
 import { storeFiles, threadMessageStore, workspaceStore, type VendoStore } from "@vendoai/store";
 import { asSchema, type FlexibleSchema, type LanguageModel, type Schema, type UIMessage } from "ai";
 import { randomUUID } from "node:crypto";
-import { assemblePrompt, type SystemPromptHook } from "./prompt.js";
-import { openThread } from "./session.js";
+import { resolveSystem, type SystemPromptHook } from "./prompt.js";
+import { asUserMessage, openThread } from "./session.js";
 
 /** What a caller with no budget gets. The automations engine always passes its
  *  own (50), so this only bounds a host driving the seam directly. */
@@ -503,29 +503,13 @@ async function runTurn(deps: AwayRunnerDeps, input: RunTurnInput): Promise<Agent
     ...(deps.liveTurn === undefined ? {} : { liveTurn: deps.liveTurn }),
   });
 
-  const directions = await deps.guard.directions(awayCtx);
-  const assembled = assemblePrompt({
-    ...(deps.instructions === undefined ? {} : { instructions: deps.instructions }),
-    ...(awayCtx.user === undefined ? {} : { user: awayCtx.user }),
-    ...(awayCtx.context === undefined ? {} : { situation: awayCtx.context }),
-    directions,
-  });
-  const system = deps.system === undefined
-    ? assembled
-    : (await deps.system(awayCtx, { assembled, directions })) ?? assembled;
-  const message: UIMessage = {
-    id: `msg_${randomUUID()}`,
-    role: "user",
-    parts: [{
-      type: "text",
-      // The result channel is NAMED in the ask, not merely listed among the
-      // tools: a model that never calls it returns prose where the caller asked
-      // for a shape, and there is no second model call here to recover one.
-      text: schema === undefined
-        ? input.prompt
-        : `${input.prompt}\n\nWhen you are done, call ${RESULT_TOOL} with the result.`,
-    }],
-  };
+  const system = await resolveSystem(deps, awayCtx);
+  // The result channel is NAMED in the ask, not merely listed among the tools: a
+  // model that never calls it returns prose where the caller asked for a shape,
+  // and there is no second model call here to recover one.
+  const message = asUserMessage(schema === undefined
+    ? input.prompt
+    : `${input.prompt}\n\nWhen you are done, call ${RESULT_TOOL} with the result.`);
 
   // Reopening means CONTINUING: the thread's own turns come back with it, read
   // through the same path a session's do. A fresh thread has none.

--- a/packages/agents/src/prompt.ts
+++ b/packages/agents/src/prompt.ts
@@ -5,7 +5,7 @@
  * and the guard's directions. Assembled per turn because it needs the ctx a
  * `Turn` deliberately does not carry; it rides `Turn.system`.
  */
-import { situationPromptBlock, userPromptBlock, type Json, type RunContext } from "@vendoai/core";
+import { situationPromptBlock, userPromptBlock, type Guard, type Json, type RunContext } from "@vendoai/core";
 
 /** Who the agent is acting for. An unattended run often has no user at all, and
  *  "the user named below" with nobody below it is a dangling reference. */
@@ -53,4 +53,22 @@ export function assemblePrompt(input: PromptInput): string {
     sections.push(["Directions", ...directions.map((d) => `- ${d}`)].join("\n"));
   }
   return sections.join("\n\n");
+}
+
+/** A turn's system prompt, in EITHER venue: this package's assembly, then the
+ *  host's last word on it. ONE resolution, because a chat turn and an away
+ *  firing that thought with different briefs would be two agents wearing one
+ *  name — the drift `AgentConfig.system` exists to prevent. */
+export async function resolveSystem(
+  deps: { guard: Guard; instructions?: string; system?: SystemPromptHook },
+  ctx: RunContext,
+): Promise<string> {
+  const directions = await deps.guard.directions(ctx);
+  const assembled = assemblePrompt({
+    ...(deps.instructions === undefined ? {} : { instructions: deps.instructions }),
+    ...(ctx.user === undefined ? {} : { user: ctx.user }),
+    ...(ctx.context === undefined ? {} : { situation: ctx.context }),
+    directions,
+  });
+  return deps.system === undefined ? assembled : (await deps.system(ctx, { assembled, directions })) ?? assembled;
 }

--- a/packages/agents/src/session.ts
+++ b/packages/agents/src/session.ts
@@ -34,7 +34,7 @@ import {
 } from "@vendoai/store";
 import type { LanguageModel, UIMessage } from "ai";
 import { randomUUID } from "node:crypto";
-import { assemblePrompt, type SystemPromptHook } from "./prompt.js";
+import { resolveSystem, type SystemPromptHook } from "./prompt.js";
 
 export interface SessionOptions {
   /** Server-trust identity facts, model-visible (`[User]`). */
@@ -139,7 +139,7 @@ const toHeaderRecord = (
   return headers;
 };
 
-const asUserMessage = (message: string | UIMessage): UIMessage =>
+export const asUserMessage = (message: string | UIMessage): UIMessage =>
   typeof message === "string"
     ? { id: `msg_${randomUUID()}`, role: "user", parts: [{ type: "text", text: message }] }
     : message;
@@ -235,16 +235,7 @@ export async function createSession(
       const ctx = contextFor(streamOptions.context);
 
       const workspace = await workspaces.open(principal, { host: hostSkillFiles(deps.skills) });
-      const directions = await deps.guard.directions(ctx);
-      const assembled = assemblePrompt({
-        ...(deps.instructions === undefined ? {} : { instructions: deps.instructions }),
-        ...(options.user === undefined ? {} : { user: options.user }),
-        ...(ctx.context === undefined ? {} : { situation: ctx.context }),
-        directions,
-      });
-      const system = deps.system === undefined
-        ? assembled
-        : (await deps.system(ctx, { assembled, directions })) ?? assembled;
+      const system = await resolveSystem(deps, ctx);
 
       const response = await runtime(workspace).run({
         harness: deps.harness,


### PR DESCRIPTION
A quality pass over tonight's agents/harnesses shipment. Reuse only — no behavior change, no test edits, net -7 lines.

## What folded

- **`packages/agents/src/prompt.ts`** — new `resolveSystem(deps, ctx)`. `session.stream()` and the away `runTurn()` each held their own copy of the same nine lines (`guard.directions` → `assemblePrompt` → the host's `system` hook, where `undefined` means "the default"). That duplicate is precisely the drift `AgentConfig.system` exists to prevent — a chat turn and an away firing thinking with different briefs — so it is one function now. Both callers already put the same `user` and `context` on the ctx they pass, so reading them off the ctx is the same values in the same order.
- **`packages/agents/src/away.ts`** — `run()` hand-built the user message that `asUserMessage` (session.ts) already mints, field for field; it calls it instead.

## What I looked at and left alone

- The `wrapWorkspace` render seam is duplicated verbatim in both files, but the two comments explain different venues and there is no natural shared home — folding it would trade four lines for a worse read.
- The runtime accumulates usage internally *and* `run()` re-folds it through the new `observe` tap. Unifying that is an API change, not a cleanup.

## Gate

    pnpm build       Tasks: 21 successful, 21 total
    pnpm test:affected  Tasks: 31 successful, 32 total  (only @vendoai/genbench, pre-existing: chrome-headless-shell not installed on this box)
    pnpm typecheck   Tasks: 42 successful, 42 total
    pnpm lint        Tasks:  4 successful,  4 total

No changeset: nothing here is visible to a consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates turn setup by introducing a single `resolveSystem(deps, ctx)` used by both chat sessions and away runs to prevent prompt drift. No behavior change; same calls, same order, same strings.

- Review notes:
  - `packages/agents/src/prompt.ts`: adds `resolveSystem(deps, ctx)` that runs `guard.directions` → `assemblePrompt` → optional host `system` hook, reading `user` and `context` from `ctx`.
  - `packages/agents/src/session.ts`: replaces inline system-prompt build with `resolveSystem`; exports `asUserMessage`.
  - `packages/agents/src/away.ts`: uses `resolveSystem`; replaces handwritten `UIMessage` with `asUserMessage` while preserving the result-tool hint.
  - No migrations; external behavior and test surface unchanged.

<sup>Written for commit 94b25db660f19226918203e1397ec098371df826. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

