### PR TITLE
chore(deps): bump nanoid past GHSA-2v37-7h3g-55p8

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ overrides:
   brace-expansion@>=4 <5.0.9: '>=5.0.9 <6'
   undici@>=7 <7.29.0: '>=7.29.0 <8'
   ip-address@>=10 <10.3.1: '>=10.3.1 <11'
-  nanoid@<3.3.17: '>=3.3.17 <4'
+  nanoid@<3.3.18: '>=3.3.18 <4'
 
 importers:
 
@@ -6641,8 +6641,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -8401,7 +8401,7 @@ snapshots:
   '@ai-sdk/provider-utils@2.2.8(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       secure-json-parse: 2.7.0
       zod: 3.25.76
 
@@ -14028,7 +14028,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   napi-build-utils@2.0.0:
     optional: true
@@ -14493,7 +14493,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -201,10 +201,17 @@ overrides:
   # "<=10.3.0", so a hypothetical 9.x consumer is not dragged across a major.
   "ip-address@>=10 <10.3.1": ">=10.3.1 <11"
   # 2026-08-07 advisory: nanoid custom generators loop indefinitely when size
-  # is zero, GHSA-2v37-7h3g-55p8 (<3.3.17). Arrives via
+  # is zero, GHSA-2v37-7h3g-55p8. Arrives via
   # examples/{ai-sdk-agent,demo-bank}>next>postcss>nanoid (16 paths) — postcss
   # declares `nanoid: ^3.3.16`, so the patch is already inside its declared
   # range and the lockfile was simply pinned to 3.3.16. Bounded to the 3.x
   # line that is actually installed; the advisory's other range (>=4.0.0
   # <5.1.6) has no consumer in this tree.
-  "nanoid@<3.3.17": ">=3.3.17 <4"
+  #
+  # Floor raised 3.3.17 -> 3.3.18 (2026-08-13): the advisory's 3.x range was
+  # widened to <3.3.18 — 3.3.17 carried a follow-up commit and the record now
+  # names 3.3.18 as the only patched 3.x — so the old floor resolved to exactly
+  # the version the advisory calls vulnerable, reddening the required `audit`
+  # check on main. Still inside both consumers' declared ranges (postcss
+  # ^3.3.16, @ai-sdk/provider-utils ^3.3.8).
+  "nanoid@<3.3.18": ">=3.3.18 <4"


### PR DESCRIPTION
GitHub advisory [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) (nanoid: custom generators loop indefinitely when size is zero) widened its 3.x vulnerable range from `<3.3.17` to `<3.3.18`, so the `nanoid@<3.3.17: >=3.3.17 <4` floor already in `pnpm-workspace.yaml` now resolves to exactly the version the advisory calls vulnerable. The required `audit` check is therefore red on main's own head (`f5dfb9e2d`) and is blocking every open PR, including docs-only ones. This raises that one floor to `nanoid@<3.3.18: >=3.3.18 <4`; the lockfile delta is six lines, all nanoid `3.3.17` -> `3.3.18`, nothing else moves. 3.3.18 is inside both consumers' declared ranges (`postcss` asks `^3.3.16`, `@ai-sdk/provider-utils` asks `^3.3.8`) and the floor stays bounded below the next major, per the convention in that file.

Verified locally on a clean `origin/main` worktree with the same pnpm (11.10.0) and Node (22) as CI: before the change `pnpm audit --prod --audit-level high` reproduced the CI failure exactly (4 vulnerabilities, `1 low | 3 high (2 ignored)`, exit 1); after it, `3 vulnerabilities found / 1 low | 2 high (2 ignored)`, exit 0 — the two remaining highs are the pre-existing unfixable `image-size` advisories already ignored by ID. `pnpm build` (21 tasks) and `pnpm typecheck` (42 tasks) both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the `nanoid` 3.x override floor from 3.3.17 to 3.3.18 to address GHSA-2v37-7h3g-55p8. The old floor resolved to vulnerable 3.3.17 and failed the required audit check; the new floor pins the patched 3.3.18 and unblocks CI.

- Scope: updates the override in pnpm-workspace and six lockfile lines (`3.3.17` -> `3.3.18`); no source code changes.
- Compatibility: stays within consumer ranges (`postcss` `^3.3.16`, `@ai-sdk/provider-utils` `^3.3.8`) and remains `<4`.
- CI expectations: build and typecheck pass; `pnpm audit --prod --audit-level high` exits 0 with only the pre-ignored `image-size` advisories remaining.

<sup>Written for commit 7aca8d575a44da824e4a047117917faca9d90705. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

