### PR TITLE
feat(ui): paced streamed-text reveal

### DIFF
--- a/packages/ui/e2e/smoke.spec.ts
+++ b/packages/ui/e2e/smoke.spec.ts
@@ -64,19 +64,44 @@ async function loopingThroughBuild(scope: Locator): Promise<{
   let samples = 0;
   const deadline = Date.now() + 25_000;
   while (Date.now() < deadline) {
-    const frame = await scope.evaluate(root => ({
-      building: root.querySelector('.fl-appcard-bar[data-state="building"]') !== null,
-      caret: root.querySelector(".fl-caret") !== null,
-      prose: root.querySelector(".fl-md--streaming") !== null,
-      table: root.querySelector(".fl-skeleton-bar") !== null,
-    }));
+    // ONE evaluate: the building check and the animation sweep must observe the
+    // SAME frame. As two round-trips, the build could finish between them and
+    // the sweep then caught the prose caret legitimately resuming after the
+    // window §8 makes a claim about — a race the paced text reveal
+    // (useSmoothText) turned from theoretical into reliable, since the reveal
+    // now renders continuously across the build's end instead of pausing on
+    // network lulls. Mirrors looping(); Playwright serializes the callback, so
+    // the logic cannot be shared by reference.
+    const frame = await scope.evaluate(root => {
+      const building = root.querySelector('.fl-appcard-bar[data-state="building"]') !== null;
+      const loops: string[] = [];
+      if (building) {
+        for (const node of Array.from(root.querySelectorAll("*"))) {
+          const name = node.className.toString().trim().split(/\s+/).at(-1) || node.tagName.toLowerCase();
+          for (const pseudo of ["", "::before", "::after"] as const) {
+            const style = getComputedStyle(node, pseudo === "" ? undefined : pseudo);
+            if (style.animationName !== "none"
+              && style.animationIterationCount.split(",").some(count => count.trim() === "infinite")) {
+              loops.push(`${name}${pseudo}`);
+            }
+          }
+        }
+      }
+      return {
+        building,
+        loops,
+        caret: root.querySelector(".fl-caret") !== null,
+        prose: root.querySelector(".fl-md--streaming") !== null,
+        table: root.querySelector(".fl-skeleton-bar") !== null,
+      };
+    });
     if (!frame.building && samples > 0) break;
     if (frame.building) {
       samples += 1;
       seen.caret ||= frame.caret;
       seen.prose ||= frame.prose;
       seen.table ||= frame.table;
-      for (const name of await looping(scope)) moved.add(name);
+      for (const name of frame.loops) moved.add(name);
     }
   }
   return {
@@ -171,7 +196,11 @@ test("a build animates exactly one thing, and the bar flips to the app's name", 
 
   await expect(page.getByText("Spending board").first()).toBeVisible({ timeout: 20_000 });
   await expect(page.getByRole("button", { name: /Did 3 things/ })).toBeVisible({ timeout: 20_000 });
-  // The settled turn is calm: nothing loops once the work is done.
+  // The settled turn is calm: nothing loops once the work is done. "Done" now
+  // includes the paced reveal's tail (useSmoothText): the caret deliberately
+  // rides the REVEAL's end, not the stream's, so let the last frames drain —
+  // the streaming class clearing IS the reveal finishing — before asserting.
+  await expect(list.locator(".fl-md--streaming")).toHaveCount(0);
   expect(await looping(list)).toEqual([]);
 });
 

--- a/packages/ui/src/chrome/markdown.tsx
+++ b/packages/ui/src/chrome/markdown.tsx
@@ -1,4 +1,4 @@
-import { isValidElement, memo, useRef, useState, type ComponentProps, type ReactNode } from "react";
+import { isValidElement, memo, useEffect, useRef, useState, type ComponentProps, type ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { useCopyFeedback } from "./clipboard.js";
@@ -165,6 +165,46 @@ function FoldSection({ title, level, open: initialOpen, children }: {
 }
 
 /**
+ * Streamed text arrives in network-sized bursts — whole sentences at once now
+ * that a warm prompt cache streams at full rate — and painting a burst in one
+ * frame reads as the UI stuttering. Pace the reveal instead: show more of
+ * `text` each animation frame, draining faster the further the reveal falls
+ * behind (backlog/8 per frame ≈ a ~150ms tail), so bursts read as steady
+ * typing and the reveal can never lag the wire by more than a beat. Pure
+ * pacing, no opacity and no transform: this plays on every single reply, and
+ * at that frequency the animation IS the absence of a jolt — nothing more.
+ *
+ * Three edges the rates encode: a text that stops extending the shown prefix
+ * (a regenerate rewrote it) SNAPS rather than types over the old words; a
+ * settled turn drains its remainder at 4x so the ending never dawdles behind
+ * a finished stream; and a body that mounts already complete (restored
+ * history) starts fully shown — the pacing is for arrival, never replay.
+ */
+function useSmoothText(text: string, streaming: boolean): string {
+  const [shown, setShown] = useState(() => (streaming ? "" : text));
+  const frame = useRef(0);
+  useEffect(() => {
+    if (!text.startsWith(shown)) {
+      setShown(text);
+      return;
+    }
+    if (shown.length >= text.length) return;
+    frame.current = requestAnimationFrame(() => {
+      setShown(current => {
+        const backlog = text.length - current.length;
+        if (backlog <= 0 || !text.startsWith(current)) return text;
+        const rate = streaming
+          ? Math.max(2, Math.ceil(backlog / 8))
+          : Math.max(8, Math.ceil(backlog / 4));
+        return text.slice(0, current.length + rate);
+      });
+    });
+    return () => cancelAnimationFrame(frame.current);
+  }, [text, shown, streaming]);
+  return shown;
+}
+
+/**
  * Assistant text as GitHub-flavored markdown (the `.fl-md` design). react-markdown
  * escapes raw HTML by default (no rehype-raw), so no markup is injected — safe for
  * model-authored text.
@@ -179,15 +219,21 @@ function FoldSection({ title, level, open: initialOpen, children }: {
  *    restored bodies collapse — a message the reader just watched stream in
  *    must not snap shut — and never while streaming.
  */
-function MarkdownImpl({ text, streaming, restored }: { text: string; streaming?: boolean; restored?: boolean }) {
+function MarkdownImpl({ text: liveText, streaming, restored }: { text: string; streaming?: boolean; restored?: boolean }) {
   const [expanded, setExpanded] = useState(false);
-  const collapsible = restored === true && !streaming && text.length > LONG_TEXT_CAP;
+  const text = useSmoothText(liveText, streaming === true);
+  // The caret and the reveal end together: a settled stream may still be
+  // draining its last paced characters, and a caret that vanished while words
+  // were visibly arriving would read as a glitch. The forming-table row keeps
+  // the REAL flag — it narrates the wire, not the reveal.
+  const revealing = streaming === true || text.length < liveText.length;
+  const collapsible = restored === true && !revealing && liveText.length > LONG_TEXT_CAP;
   const components = streaming ? MD_COMPONENTS_STREAMING : MD_COMPONENTS;
   // 8D — structured restored bodies fold by section instead of truncating.
   const sections = collapsible ? splitSections(text) : null;
   if (sections) {
     return (
-      <div className={`fl-md${streaming ? " fl-md--streaming" : ""}`}>
+      <div className={`fl-md${revealing ? " fl-md--streaming" : ""}`}>
         {sections.map((section, index) =>
           section.title.length === 0 ? (
             <ReactMarkdown key={index} remarkPlugins={REMARK_PLUGINS} components={components}>{section.body}</ReactMarkdown>
@@ -205,7 +251,7 @@ function MarkdownImpl({ text, streaming, restored }: { text: string; streaming?:
     <ReactMarkdown remarkPlugins={REMARK_PLUGINS} components={components}>{shown}</ReactMarkdown>
   );
   if (!collapsible) {
-    return <div className={`fl-md${streaming ? " fl-md--streaming" : ""}`}>{body}</div>;
+    return <div className={`fl-md${revealing ? " fl-md--streaming" : ""}`}>{body}</div>;
   }
   // The collapsed head sits under a gradient fade with a
   // centered pill instead of a hard cut + inline link.

--- a/packages/ui/test/chrome/composer.test.tsx
+++ b/packages/ui/test/chrome/composer.test.tsx
@@ -97,7 +97,11 @@ describe("composer: type-while-streaming, queued send, edit, regenerate (ENG-215
     expect(threadPosts(wire)).toHaveLength(1);
 
     await act(async () => release());
-    await screen.findByText("Turn complete");
+    // findAll, not find: the queued follow-up auto-sends the moment turn one
+    // settles, and with the paced text reveal (useSmoothText) both turns'
+    // replies can reach the DOM inside one polling window — two matches is
+    // the CORRECT end state here, not an ambiguity.
+    await screen.findAllByText("Turn complete");
 
     // Turn done → the queued message auto-sends as a real second turn, pill gone.
     await waitFor(() => expect(threadPosts(wire)).toHaveLength(2));

--- a/packages/ui/test/chrome/pill-states.test.tsx
+++ b/packages/ui/test/chrome/pill-states.test.tsx
@@ -311,8 +311,10 @@ describe("closing the panel mid-run (G1: closing is leaving)", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "View" }));
     // The thread IS the record: the finished turn sits where it was left.
+    // Awaited, not read synchronously: the reopened message finishes its paced
+    // reveal (useSmoothText) a frame or two after mount.
     expect(dialog()).toBeTruthy();
-    expect(screen.getByText("All done.")).toBeTruthy();
+    await screen.findByText("All done.");
     expect(screen.getByText("[tool-after-text] how did I spend?")).toBeTruthy();
   });
 });


### PR DESCRIPTION
The turn-start speedups (warm prompt cache) made streamed text arrive in sentence-sized bursts that painted in one frame — abrupt, reported by Yousef on the workbench. This paces the reveal per animation frame with backlog-proportional catch-up (never trails the wire by more than ~150ms; settles at 4x; snaps on regenerate; restored history renders instantly). Pure pacing — no opacity/transform, per the frequency rule: this plays on every reply, so the animation is the absence of a jolt.

Verified live by Yousef on the Maple workbench (motion doesn't screenshot; the two backlog-divisor rates are the only knobs). Four test-timing updates called out in the commit message; local Playwright suite 12/12.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Smooths streamed assistant text by pacing the reveal per animation frame. Previously sentence-sized bursts painted in one frame; now the reveal progresses steadily, never lags the wire by more than ~150ms, drains at 4x once settled, snaps on regenerate, and restored history renders instantly.

- In `packages/ui/src/chrome/markdown.tsx`, add `useSmoothText`; apply `fl-md--streaming` while revealing (not just while the network streams) and have the caret follow the reveal’s end.
- Tests align to the new timing: `packages/ui/e2e/smoke.spec.ts` consolidates its evaluate to avoid a new race and waits for `.fl-md--streaming` to clear; `packages/ui/test/chrome/composer.test.tsx` uses `findAllByText("Turn complete")` for overlapping completions; `packages/ui/test/chrome/pill-states.test.tsx` awaits the final text after mount.

- Required test updates: wait for the reveal tail before asserting calm states; update assertions that watch `.fl-md--streaming` or caret timing to follow the reveal, not the network stream; prefer `findAllByText` when queued sends can settle within one polling window.

<sup>Written for commit 70165add92fd715209a3fab807863e8b35b32f0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

