### PR TITLE
fix(apps): validate written .tsx screens through the screen door, not the wire door

### DIFF
--- a/packages/apps/src/server/generation/validate-gate.ts
+++ b/packages/apps/src/server/generation/validate-gate.ts
@@ -15,11 +15,15 @@
  * any other tool call. There is no privileged side door and no second
  * implementation of the floor.
  *
- * `{ document }`, not `{ appId }`, deliberately. A file that did not pass has no
- * store row — the seam refuses to author an app it would not paint — so `appId`
- * would answer not-found on exactly the case the gate exists for. The wire text is
- * what was written, and it is what `validate` was built to check "before committing
- * it".
+ * For WIRE text, `{ document }` rather than `{ appId }`, deliberately. A file that
+ * did not pass has no store row — the seam refuses to author an app it would not
+ * paint — so `appId` would answer not-found on exactly the case the gate exists
+ * for. The wire text is what was written, and it is what `validate` was built to
+ * check "before committing it".
+ *
+ * A COMPONENT screen is the other artifact and takes the other door, because
+ * `{ document }` is the wire door and would judge a TSX module as markup. See the
+ * routing in {@link validateWrittenApps}.
  *
  * FAIL-OPEN, everywhere. A validate that could not run is not a finding: treating
  * it as one would spend the builder's fix round repairing an app nobody said was
@@ -33,6 +37,7 @@ import {
   type WorkspaceFs,
 } from "@vendoai/core";
 import {
+  SCREEN_FILE,
   type Finding,
 } from "../../contract/index.js";
 import { hotPathAppId } from "./render-seam.js";
@@ -62,7 +67,12 @@ const isFinding = (value: unknown): value is Finding =>
  *  `plan.vendo` is a skeleton rather than an app document — there is nothing to
  *  validate yet. */
 const appDocumentAt = (path: string): AppId | undefined =>
-  path.endsWith("/app.vendo") || path.endsWith("/app.tsx") ? hotPathAppId(path) : undefined;
+  path.endsWith("/app.vendo") || path.endsWith(`/${SCREEN_FILE}`) ? hotPathAppId(path) : undefined;
+
+/** A COMPONENT screen rather than wire text, by the file's own name — the same
+ *  discrimination the render seam makes before it sends one to the floor's
+ *  gauntlet and the other to `compileWire` (`viewForWrite`). */
+const isComponentScreen = (path: string): boolean => path.endsWith(`/${SCREEN_FILE}`);
 
 /** One `validate` call, or undefined for every way it could not reach a verdict —
  *  each of which is reported to the OPERATOR and to nobody else. */
@@ -121,6 +131,10 @@ export async function validateWrittenApps(input: {
    * that does not pass the floor is not a finished screen, and a document that
    * never painted has no row for the row-scoped door to find. So the reviewer is
    * spent exactly once, on exactly the screens a person is about to keep.
+   *
+   * For a COMPONENT screen that door is the only one: it runs the gauntlet on the
+   * stored screen AND the reviewer in one call, so this flag is what gates a
+   * screen's whole trip through the verb.
    */
   review?: boolean;
 }): Promise<AppValidationFailure[]> {
@@ -129,12 +143,22 @@ export async function validateWrittenApps(input: {
     const appId = appDocumentAt(path);
     if (appId === undefined) continue;
     try {
-      const document = await input.workspace.readFile(path);
-      const mechanical = await askValidate(input.tools, appId, { document });
-      if (mechanical === undefined) continue;
-      if (mechanical.length > 0) {
-        failures.push({ path, appId, findings: mechanical });
-        continue;
+      // WIRE TEXT ONLY. `validate({document})` compiles what it is handed as wire
+      // (`createValidateDoor`), so a component screen — which is a TSX module, not
+      // markup — comes back "expected a single <App> element" however well it
+      // paints, and a builder that obeys that rewrites a working screen into wire.
+      // A screen's mechanical half is the component gauntlet, which already ran as
+      // its paint gate on the way in (`AppFloor.component`), so what is left for a
+      // screen here is the judging door below — the same reading the vendo() loop
+      // takes of the same artifact (`judgeScreen`, screen-agent.ts).
+      if (!isComponentScreen(path)) {
+        const document = await input.workspace.readFile(path);
+        const mechanical = await askValidate(input.tools, appId, { document });
+        if (mechanical === undefined) continue;
+        if (mechanical.length > 0) {
+          failures.push({ path, appId, findings: mechanical });
+          continue;
+        }
       }
       if (input.review !== true) continue;
       const judged = await askValidate(input.tools, appId, { appId });

--- a/packages/apps/tests/validate-gate.test.ts
+++ b/packages/apps/tests/validate-gate.test.ts
@@ -87,12 +87,24 @@ describe("validateWrittenApps", () => {
     expect(failures.map(({ appId }) => appId)).toEqual(["app_2"]);
   });
 
-  it("gates a component screen too — app.tsx is an app document", async () => {
+  it("gates a component screen through the door that reads a SCREEN, not the wire one", async () => {
+    // `validate({document})` compiles what it is handed as WIRE, so a `.tsx` screen
+    // that compiles, renders and paints was answered "expected a single <App>
+    // element" — and a builder that obeyed rewrote a working screen into markup.
     const SCREEN = "/user/apps/app_1/app.tsx";
-    const { tools, workspace } = answering({ [SCREEN]: { ok: false, findings: [LYING] } });
+    const calls: Array<{ name: string; args: Json }> = [];
+    const tools = {
+      call: async (name: string, args: Json): Promise<ToolResult> => {
+        calls.push({ name, args });
+        return { status: "ok", output: { ok: false, findings: [LYING] } as unknown as Json };
+      },
+    };
+    const workspace = { readFile: async () => "export default function Spending() { return null; }" };
 
-    const failures = await validateWrittenApps({ tools, workspace, paths: [SCREEN] });
+    const failures = await validateWrittenApps({ tools, workspace, paths: [SCREEN], review: true });
 
+    expect(calls).toEqual([{ name: "validate", args: { appId: "app_1" } }]);
+    // …and what that door says still comes back as this gate's own shape.
     expect(failures).toEqual([{ path: SCREEN, appId: "app_1", findings: [LYING] }]);
   });
 

--- a/packages/vendo/tests/validate-gate-screen.e2e.test.ts
+++ b/packages/vendo/tests/validate-gate-screen.e2e.test.ts
@@ -1,0 +1,147 @@
+/**
+ * THE BUILDER'S VALIDATE GATE, ON A SCREEN THAT PAINTS.
+ *
+ * `validateWrittenApps` is what a `claudeCode()` turn runs over the files the model
+ * wrote (`packages/harnesses/src/claude-code/index.ts`, the artifact path). It used
+ * to hand EVERY app document to `validate({document})` — the WIRE door, which
+ * compiles what it is given as markup — so an `app.tsx` that compiled,
+ * type-checked, ran in the sealed VM and PAINTED came back "expected a single
+ * <App> element", and a builder that obeyed the feedback rewrote a working screen
+ * into wire.
+ *
+ * So this walks a REAL composed deployment — real store, real guard, real apps
+ * pack, the real render seam, the real component gauntlet, the real `validate`
+ * verb — writes the screen with a harness's own hands exactly as the artifact path
+ * does, and asks the REAL gate what it makes of a screen the seam has just
+ * painted. Only the model is scripted, because what is measured is the doors.
+ *
+ * The one that must be able to fail: send the screen back through
+ * `validate({document})` in `packages/apps/src/server/generation/validate-gate.ts`
+ * and this goes red with the wire compiler's own sentence about `<App>`.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  paintedIn,
+  SCREEN_FILE,
+  validateWrittenApps,
+  type AppValidationFailure,
+} from "@vendoai/apps";
+import type { AppId, Principal } from "@vendoai/core";
+import { defineHarness } from "@vendoai/harnesses";
+import { createStore, type VendoStore } from "@vendoai/store";
+import type { LanguageModel } from "ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createVendo } from "../src/server.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+const principal: Principal = { kind: "user", subject: "user_validate_gate" };
+
+const APP_ID = "app_written_screen" as AppId;
+const SCREEN_PATH = `/user/apps/${APP_ID}/${SCREEN_FILE}`;
+
+/** The smallest screen the gauntlet passes and the seam paints. */
+const SPENDING = `import { Stack, Text } from "@vendo/screen";
+
+export default function Spending() {
+  return (
+    <Stack gap={12}>
+      <Text text="This month" variant="heading" />
+    </Stack>
+  );
+}
+`;
+
+async function tempStore(): Promise<VendoStore> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-validate-gate-"));
+  const store = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  return store;
+}
+
+describe("the validate gate judges a written app by what it IS", () => {
+  it("a component screen that paints passes the gate, through the door that reads a screen", async () => {
+    const store = await tempStore();
+    /** The reviewer is the only thing that thinks here — the harness below never
+     *  asks a model anything — so this counts the calls the ROW-SCOPED door makes.
+     *  It answers clean through its own strict tool call, which is what keeps the
+     *  gauntlet rather than a provider's mood the thing under test. */
+    let reviewerCalls = 0;
+    const model = {
+      specificationVersion: "v2",
+      provider: "vendo-validate-gate",
+      modelId: "vendo-validate-gate-v1",
+      supportedUrls: {},
+      async doGenerate() {
+        reviewerCalls += 1;
+        return {
+          content: [{
+            type: "tool-call" as const,
+            toolCallId: "call_report_findings",
+            toolName: "report_findings",
+            input: JSON.stringify({ findings: [] }),
+          }],
+          finishReason: "tool-calls" as const,
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        };
+      },
+    } as unknown as LanguageModel;
+
+    let painted: boolean | undefined;
+    let failures: readonly AppValidationFailure[] | undefined;
+    const harness = defineHarness({
+      name: "validate-gate-probe",
+      async *run(turn) {
+        // The artifact path's own two steps: land the file the model wrote, then
+        // gate what landed. The commit IS the paint (§1.6).
+        await turn.workspace.writeFile(SCREEN_PATH, SPENDING);
+        const committed = await turn.workspace.commit({ message: "the screen" });
+        painted = paintedIn(committed)?.includes(APP_ID) === true;
+        failures = await validateWrittenApps({
+          tools: turn.tools,
+          workspace: turn.workspace,
+          paths: [SCREEN_PATH],
+          // What `claudeCode()` passes at the turn boundary.
+          review: true,
+        });
+        yield { type: "text", delta: "ok" };
+      },
+    });
+    const vendo = createVendo({
+      model,
+      principal: async () => principal,
+      store,
+      harness: harness as never,
+    } as Parameters<typeof createVendo>[0]);
+
+    const response = await vendo.handler(new Request("https://host.test/api/vendo/threads", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        threadId: "thr_validate_gate",
+        message: { id: "m1", role: "user", parts: [{ type: "text", text: "show me my spending" }] },
+      }),
+    }));
+    await response.text();
+    expect(response.status).toBe(200);
+
+    // The real floor really painted it: the gauntlet's five stages passed and the
+    // seam put the screen on the wire. Anything the gate says now is about a screen
+    // the person can see.
+    expect(painted).toBe(true);
+    // THE BUG. The wire door answered this screen with "expected a single <App>
+    // element", and one round later the builder had replaced it with markup.
+    expect(failures).toEqual([]);
+    // …and it was not silence that passed it: the screen went to the door that
+    // reads a stored screen, which runs the gauntlet AND the one judging call.
+    expect(reviewerCalls).toBe(1);
+  }, 120_000);
+});


### PR DESCRIPTION
## The bug

The builder's validate gate handed every app document it found to `validate({document})`, which is the WIRE door — it compiles whatever it is given as markup. A component screen is a TSX module, so an `app.tsx` that compiled, type-checked, ran in the sealed VM and **painted** was answered `wire missing-app: expected a single <App ...>...</App> element`, and a builder that obeyed the feedback rewrote a working screen into wire.

It bites production on every `claudeCode()` turn that writes a screen: the artifact path syncs the model's files and gates them through this exact function (`packages/harnesses/src/claude-code/index.ts:726-740`).

## The failure

Found by a benchmark arm driving the `claudeCode()` harness. Reproduced here against a real composed deployment — real store, real guard, real apps pack, real render seam, real component gauntlet, real `validate` verb — in `packages/vendo/tests/validate-gate-screen.e2e.test.ts`. The seam **painted** the screen (`paintedIn` says so) and the gate condemned it anyway:

```
AssertionError: expected [ { …(3) } ] to deeply equal []
+   {
+     "appId": "app_written_screen",
+     "findings": [
+       { "message": "wire did not parse to a complete <App> document", "severity": "block" },
+       { "message": "wire missing-app: expected a single <App ...>...</App> element", "severity": "block" },
+       { "message": "App must carry a non-empty name=\"...\" attribute", "severity": "block" },
+     ],
+     "path": "/user/apps/app_written_screen/app.tsx",
+   },
```

## The fix

`packages/apps/src/server/generation/validate-gate.ts` — a written app now takes the door that matches what it IS:

- **wire text** (`app.vendo`) → `validate({document})`, unchanged.
- **component screen** (`app.tsx`) → `validate({appId})`, the door that reads a stored screen: it runs the component gauntlet on the screen and the one judging call with it (`createValidateDoor`, `build-surface.ts:558-593`).

The discrimination is the file's own name (`SCREEN_FILE`) — the same one the render seam makes before sending one artifact to the floor's gauntlet and the other to `compileWire` (`render-seam.ts:253`). Routing a screen to `{appId}` is the reading the `vendo()` loop already takes of the same artifact (`judgeScreen`, `screen-agent.ts:376-383`). Still no privileged side door: everything goes through the one registered verb via `turn.tools.call`.

## Red, then green

Fix stashed, tests kept, `@vendoai/apps` rebuilt:

```
 ❯ packages/apps  tests/validate-gate.test.ts
   × gates a component screen through the door that reads a SCREEN, not the wire one
     - Expected  "appId": "app_1"
     + Received  "document": "export default function Spending() { return null; }"
   Tests  1 failed | 11 passed (12)

 ❯ packages/vendo  tests/validate-gate-screen.e2e.test.ts
   × a component screen that paints passes the gate, through the door that reads a screen
     → expected [ { …(3) } ] to deeply equal []   ← the three wire findings above
   Tests  1 failed (1)
```

Fix restored, same tests:

```
 ❯ packages/apps  tests/validate-gate.test.ts        Tests  12 passed (12)
 ❯ packages/vendo tests/validate-gate-screen.e2e.test.ts   Tests  1 passed (1)
```

The e2e also asserts `reviewerCalls === 1`, so the screen is proven to have reached the row-scoped door rather than merely being skipped.

## Tests touched

- `packages/vendo/tests/validate-gate-screen.e2e.test.ts` — new; the real-seam regression above.
- `packages/apps/tests/validate-gate.test.ts` — the existing `gates a component screen too` case asserted the buggy routing through a double that answered by matching `args.document`, with `<App name="…"/>` standing in for a `.tsx` file. It is rewritten to pin the door instead of the bug. No other test touched.

## Gate

`pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint` green at the worktree root.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates written TSX screens through the screen door instead of the wire door to stop false “expected a single <App>…>” blocks and prevent builders from rewriting working screens to wire. Previously `validateWrittenApps` always called `validate({document})`; now `.vendo` stays on `{document}` and `.tsx` goes to `validate({appId})`, which reads the stored screen, runs the component gauntlet, and performs the reviewer call.

**Review notes**
- Routing uses `SCREEN_FILE` to detect screens; see `validate-gate.ts` (`appDocumentAt`, `isComponentScreen`, and the conditional call path).
- Wire path unchanged; screen path skips mechanical `{document}` validation and, when `review: true`, calls the row-scoped `{appId}` door once.
- Findings shape and fail-open behavior are unchanged.
- New e2e (`packages/vendo/tests/validate-gate-screen.e2e.test.ts`) proves a painted screen yields no wire errors and triggers exactly one reviewer call; unit test updated to assert `{appId}` routing. No migrations required.

<sup>Written for commit 23a96385b41f7825ca18bca29f20b00e4e5d1928. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

