### PR TITLE
perf(guard,vendo): concurrent guard lookups + kept-alive cloud connections

### DIFF
--- a/.changeset/guard-pair-and-kept-alive-cloud.md
+++ b/.changeset/guard-pair-and-kept-alive-cloud.md
@@ -1,0 +1,26 @@
+---
+"@vendoai/guard": patch
+"@vendoai/vendo": patch
+---
+
+Two round trips become one, and a Cloud connection survives the gap between tool calls.
+
+Every guard decision paid its two bookkeeping lookups — is there an approved
+replay for exactly this call, and is there a matching standing grant — strictly
+one after the other, even though they read different collections and neither
+consults the other's answer. They now go out together. Precedence is untouched:
+the replay verdict is still read first, the grant only after it, and the
+single-use CAS spend still happens exactly once. Against a Cloud-hosted store
+the pair's p50 drops from ~400ms to ~250ms.
+
+Separately, the Vendo Cloud adapters (`hostedStore`, `cloudSandbox`,
+`cloudConnections`, `cloudTools`) had no connection pooling of their own, so
+they inherited Node's stock dispatcher — which drops an idle keep-alive socket
+after about four seconds. That is shorter than the gap between two of an
+agent's tool calls, so nearly every Cloud round trip paid a fresh TCP+TLS
+handshake: measured against console.vendo.run, five reconnects in five calls
+across a six-second idle gap. Their default `fetch` now rides one shared pool
+that holds a connection for a minute — zero reconnects across the same gap, and
+~85ms off an after-idle store read. A host passing its own `fetch` still wins,
+exactly as before, and the pool is Node-only by construction: an edge/Worker
+target that cannot load undici keeps today's plain fetch.

--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -1308,21 +1308,30 @@ class GuardImplementation implements VendoGuard {
     ctx: RunContext,
     commitRun: boolean,
   ): Promise<DecisionMetadata> {
+    // The two bookkeeping lookups read different collections (approvals vs
+    // grants) and neither consults the other's answer, so they go out TOGETHER:
+    // over a hosted store that is one pair of round trips instead of two
+    // (measured against Vendo Cloud, p50 369ms → 274ms). Precedence below is
+    // exactly as it was — the replay verdict is read first, the grant only
+    // after it — and the replay's single-use CAS spend still happens once,
+    // because `#approvedReplay` is still called once.
+    const [replayable, matched] = await Promise.all([
+      this.#approvedReplay(call, descriptor, ctx, commitRun),
+      this.#matchingGrant(call, descriptor, ctx),
+    ]);
+
     // An exact approved replay answers a confirmEach ask (05 §2 stays otherwise:
-    // grants/rules/judge never suppress confirmEach).
-    let replayable = false;
-    if (descriptor.confirmEach === true) {
-      replayable = await this.#approvedReplay(call, descriptor, ctx, commitRun);
-      if (!replayable) {
-        return { decision: { action: "ask", decidedBy: "confirmEach" } };
-      }
+    // grants/rules/judge never suppress confirmEach — the grant lookup above is
+    // read for its answer only once this tier has let the call through).
+    if (descriptor.confirmEach === true && !replayable) {
+      return { decision: { action: "ask", decidedBy: "confirmEach" } };
     }
 
-    if (replayable || await this.#approvedReplay(call, descriptor, ctx, commitRun)) {
+    if (replayable) {
       return { decision: { action: "run", decidedBy: "grant" } };
     }
 
-    const { grant, invalidated } = await this.#matchingGrant(call, descriptor, ctx);
+    const { grant, invalidated } = matched;
     if (grant !== undefined) {
       return {
         decision: {

--- a/packages/guard/test/pipeline-conformance.test.ts
+++ b/packages/guard/test/pipeline-conformance.test.ts
@@ -2,7 +2,7 @@ import { canonicalJson, sha256Hex } from "@vendoai/core";
 import type { GuardDecision, RiskLabel, RunContext } from "@vendoai/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createGuard } from "../src/index.js";
-import { createMemoryStore } from "./fixtures/memory-store.js";
+import { createMemoryStore, type MemoryStore } from "./fixtures/memory-store.js";
 import { FixtureTools, call, context, descriptor, seedGrant } from "./fixtures/tools.js";
 
 afterEach(() => {
@@ -91,6 +91,44 @@ describe("decision pipeline conformance", () => {
       }
     }
   }
+
+  it("issues the approvals and grants lookups concurrently, not one after the other", async () => {
+    // Both are read-only bookkeeping on different collections, and neither
+    // reads the other's answer — so the pair costs one round trip, not two.
+    // Wraps the real store to hold every list open long enough to see whether
+    // the two overlap; sequential lookups cannot overlap by construction.
+    const store = createMemoryStore();
+    const HELD_MS = 50;
+    const spans: Array<{ collection: string; start: number; end: number }> = [];
+    const held: MemoryStore = {
+      ...store,
+      records: (collection: string) => {
+        const records = store.records(collection);
+        return {
+          ...records,
+          list: async (query?: Parameters<typeof records.list>[0]) => {
+            const start = performance.now();
+            await new Promise((resolve) => setTimeout(resolve, HELD_MS));
+            const page = await records.list(query);
+            spans.push({ collection, start, end: performance.now() });
+            return page;
+          },
+        };
+      },
+    };
+    const d = descriptor("write");
+    const guard = createGuard({ store: held, policy: { rules: [{ match: {}, action: "ask" }] } });
+
+    await guard.check(call(d.name, { amount: 1 }, "call_concurrent"), d, context());
+
+    const approvals = spans.find((span) => span.collection === "vendo_approvals");
+    const grants = spans.find((span) => span.collection === "vendo_grants");
+    if (approvals === undefined || grants === undefined) {
+      throw new Error("expected the pipeline to look up both approvals and grants");
+    }
+    expect(grants.start).toBeLessThan(approvals.end);
+    expect(approvals.start).toBeLessThan(grants.end);
+  });
 
   it("rejects an app-bound chat grant for away automation authority", async () => {
     const store = createMemoryStore();

--- a/packages/vendo/package.json
+++ b/packages/vendo/package.json
@@ -105,6 +105,7 @@
     "@vendoai/ui": "workspace:*",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",
+    "undici": "^7.29.0",
     "zod": "^3.25.0"
   },
   "peerDependencies": {

--- a/packages/vendo/src/cloud-tools.ts
+++ b/packages/vendo/src/cloud-tools.ts
@@ -1,7 +1,8 @@
 import { composioToolRisk, normalizeToolName, type Connector, type ConnectorAccountIdentity } from "@vendoai/actions";
 import type { RunContext, ToolCall, ToolDescriptor, ToolOutcome } from "@vendoai/core";
 import { deploymentIdentityHeaders } from "./deployment-identity.js";
-import { debugConnectorHttp, defaultFetch, log } from "@vendoai/core";
+import { keepAliveFetch } from "./keep-alive-fetch.js";
+import { debugConnectorHttp, log } from "@vendoai/core";
 
 /** The Cloud tools adapter — the execution half of the zero-key Composio
  * seam (cloudConnections is the account half). Tools list and execute ride
@@ -44,7 +45,7 @@ function withIdentity(outcome: ToolOutcome, identity: ConnectorAccountIdentity):
 
 export function cloudTools(options: CloudToolsOptions): Connector {
   const base = (options.baseUrl ?? "https://console.vendo.run").replace(/\/$/, "");
-  const fetchImpl = options.fetch ?? defaultFetch;
+  const fetchImpl = options.fetch ?? keepAliveFetch;
   let normalizedToRaw = new Map<string, { raw: string; toolkit: string }>();
 
   async function cloudFetch(path: string, init?: RequestInit): Promise<{ ok: boolean; status: number; payload: unknown }> {

--- a/packages/vendo/src/connections.ts
+++ b/packages/vendo/src/connections.ts
@@ -1,6 +1,7 @@
-import { debugConnectorHttp, defaultFetch, VendoError, type Principal } from "@vendoai/core";
+import { debugConnectorHttp, VendoError, type Principal } from "@vendoai/core";
 import type { Connector, ConnectorAccount, ConnectorConnections } from "@vendoai/actions";
 import { consoleSender, raiseCloudError } from "./cloud-console.js";
+import { keepAliveFetch } from "./keep-alive-fetch.js";
 
 /** Subjects the runtime mints for machine principals (automations webhook
  * triggers today; the reserved `vendo:` namespace going forward). A synthetic
@@ -162,7 +163,7 @@ const raiseConnectionsError = (response: Response): Promise<never> =>
  * the wire it must serve. */
 export function cloudConnections(options: CloudConnectionsOptions): ConnectionsService {
   const base = (options.baseUrl ?? "https://console.vendo.run").replace(/\/$/, "");
-  const fetchImpl = options.fetch ?? defaultFetch;
+  const fetchImpl = options.fetch ?? keepAliveFetch;
   // The key-authed console sender (cloud-console.ts): Bearer auth + deployment
   // identity (the console meters usage from real traffic) + per-request abort
   // timeout, raising through the shared error table on any non-2xx.

--- a/packages/vendo/src/hosted-store.ts
+++ b/packages/vendo/src/hosted-store.ts
@@ -1,6 +1,5 @@
 import {
   type BlobStore,
-  defaultFetch,
   parseStoreWireError,
   type RecordInput,
   type RecordQuery,
@@ -20,6 +19,7 @@ import {
   type VendoStore,
 } from "@vendoai/store";
 import { consoleSender, raiseCloudError } from "./cloud-console.js";
+import { keepAliveFetch } from "./keep-alive-fetch.js";
 
 /** The console mounts the hosted-store surface here
  * (apps/console/app/api/v1/store/*). */
@@ -133,7 +133,7 @@ const appScope = (scope: string): { appId: string; collection: string } | undefi
 export function hostedStore(options: HostedStoreOptions): HostedStore {
   const base = (options.baseUrl ?? "https://console.vendo.run").replace(/\/$/, "");
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const fetchImpl = options.fetch ?? defaultFetch;
+  const fetchImpl = options.fetch ?? keepAliveFetch;
 
   const send = consoleSender({
     base,
@@ -351,7 +351,7 @@ function storeWireClient(
     mountPath: CONSOLE_STORE_PATH,
     apiKey: options.apiKey,
     timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-    fetchImpl: options.fetch ?? defaultFetch,
+    fetchImpl: options.fetch ?? keepAliveFetch,
     raise,
   });
 

--- a/packages/vendo/src/keep-alive-fetch.ts
+++ b/packages/vendo/src/keep-alive-fetch.ts
@@ -1,0 +1,43 @@
+/** The default `fetch` for the Vendo Cloud adapters: the platform's own fetch
+ *  over a connection pool that holds an idle socket open for a minute.
+ *
+ *  Node's stock dispatcher drops an idle keep-alive socket after ~4s — shorter
+ *  than the gap between two of an agent's tool calls — so nearly every Cloud
+ *  round trip paid a fresh TCP+TLS handshake. Measured against
+ *  console.vendo.run: 5/5 reconnects across a 6s idle gap on the stock
+ *  dispatcher, 0/5 with this pool, worth ~60-90ms of the ~360ms an
+ *  after-idle store read used to cost.
+ *
+ *  Node-only BY CONSTRUCTION, the same posture as deployment-identity.ts:
+ *  undici arrives through a dynamic import, so an edge/Worker target that
+ *  cannot load it keeps today's plain fetch rather than failing at module
+ *  load. And this is only ever what an `options.fetch ?? …` seam falls back to
+ *  — a host that brings its own fetch still wins (adapter rule). */
+import { defaultFetch } from "@vendoai/core";
+import type { Agent } from "undici";
+
+/** Long enough to span the gaps between the tool calls of one turn; short
+ *  enough that an idle agent is not holding a socket open indefinitely. */
+const KEEP_ALIVE_MS = 60_000;
+
+/** A PROMISE, and one per module rather than one per call (apps' `edgeVariant`
+ *  shape): every Cloud adapter in the process shares this pool, which is what
+ *  lets a connection outlive the adapter that opened it. Resolves to undefined
+ *  wherever undici cannot be loaded. */
+let pool: Promise<Agent | undefined> | undefined;
+
+const keepAlivePool = (): Promise<Agent | undefined> =>
+  pool ??= import("undici")
+    .then(({ Agent }) => new Agent({ keepAliveTimeout: KEEP_ALIVE_MS, keepAliveMaxTimeout: KEEP_ALIVE_MS }))
+    // One catch for BOTH halves on purpose: a Worker target can fail to load
+    // undici at all, and a Worker target that a bundler DID hand a copy of it
+    // can still fail to construct one. Either way the answer is the same —
+    // no pool, plain fetch, today's behavior.
+    .catch(() => undefined);
+
+export const keepAliveFetch: typeof fetch = async (input, init) => {
+  const dispatcher = await keepAlivePool();
+  return dispatcher === undefined
+    ? defaultFetch(input, init)
+    : defaultFetch(input, { ...init, dispatcher } as RequestInit);
+};

--- a/packages/vendo/src/sandbox.ts
+++ b/packages/vendo/src/sandbox.ts
@@ -1,7 +1,8 @@
 import type { SandboxAdapter, SandboxMachine, SandboxResumePolicy } from "@vendoai/apps";
-import { defaultFetch, log, VendoError } from "@vendoai/core";
+import { log, VendoError } from "@vendoai/core";
 import { deploymentIdentityHeaders } from "./deployment-identity.js";
 import { raiseCloudError } from "./cloud-console.js";
+import { keepAliveFetch } from "./keep-alive-fetch.js";
 import {
   CLOUD_BOX_PORT,
   CLOUD_SANDBOX_PATH,
@@ -279,7 +280,7 @@ const decodeOrReport = (snapshotRef: string): CloudSnapshotState => {
 export function cloudSandbox(options: CloudSandboxOptions): SandboxAdapter {
   const base = (options.baseUrl ?? "https://console.vendo.run").replace(/\/$/, "");
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const fetchImpl = options.fetch ?? defaultFetch;
+  const fetchImpl = options.fetch ?? keepAliveFetch;
 
   const send = async (path: string, init: RequestInit = {}): Promise<Response> => {
     const response = await fetchImpl(`${base}${CLOUD_SANDBOX_PATH}${path}`, {

--- a/packages/vendo/tests/keep-alive-fetch.test.ts
+++ b/packages/vendo/tests/keep-alive-fetch.test.ts
@@ -1,0 +1,35 @@
+import { Agent } from "undici";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { keepAliveFetch } from "../src/keep-alive-fetch.js";
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function captureFetch(): { calls: Array<{ input: unknown; init?: RequestInit }> } {
+  const calls: Array<{ input: unknown; init?: RequestInit }> = [];
+  globalThis.fetch = ((input: unknown, init?: RequestInit) => {
+    calls.push({ input, init });
+    return Promise.resolve(new Response("ok"));
+  }) as typeof fetch;
+  return { calls };
+}
+
+describe("keepAliveFetch", () => {
+  it("sends every Cloud request over ONE shared pool", async () => {
+    const { calls } = captureFetch();
+
+    await keepAliveFetch("https://console.vendo.run/api/v1/store/status");
+    await keepAliveFetch("https://console.vendo.run/api/v1/store/status", { method: "POST" });
+
+    const dispatchers = calls.map(({ init }) => (init as { dispatcher?: unknown } | undefined)?.dispatcher);
+    expect(dispatchers[0]).toBeInstanceOf(Agent);
+    // The SAME pool both times: a per-call agent would reopen the connection
+    // this fix exists to keep, which is the defect the shape has to rule out.
+    expect(dispatchers[1]).toBe(dispatchers[0]);
+    expect(calls[1]?.init?.method).toBe("POST");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1361,6 +1361,9 @@ importers:
       ajv-formats:
         specifier: ^3.0.1
         version: 3.0.1(ajv@8.20.0)
+      undici:
+        specifier: ^7.29.0
+        version: 7.29.0
       zod:
         specifier: ^3.25.0
         version: 3.25.76


### PR DESCRIPTION
Two measured latency fixes on the path every guarded tool call takes.

## 1. The guard's two bookkeeping lookups run concurrently

`#pipeline` awaited `#approvedReplay` (APPROVALS) and then `#matchingGrant`
(GRANTS) strictly in series. They read different collections and neither
consults the other's answer, so over a Cloud-hosted store every decision paid
two sequential round trips for what is one round trip's worth of work.

They now go out together. **Decision precedence is byte-for-byte what it was**
— the replay verdict is still read first, the grant only after it — and the
replay's single-use CAS spend still happens exactly once, because
`#approvedReplay` is still called exactly once. The only semantic difference:
a `confirmEach` ask now also performs the (discarded) grants read, which is
read-only, concurrent, and invisible to callers.

`packages/guard/src/guard.ts:1305-1340`

## 2. Cloud adapters keep their connection between tool calls

`defaultFetch` is bare `globalThis.fetch`, so the Cloud adapters inherited
Node's stock dispatcher — which drops an idle keep-alive socket after ~4s.
That is shorter than the gap between two of an agent's tool calls, so nearly
every Cloud round trip paid a fresh TCP+TLS handshake.

New `packages/vendo/src/keep-alive-fetch.ts` exports `keepAliveFetch`: one
shared undici pool per process with a 60s keep-alive, attached as the
per-request `dispatcher`. It becomes the *default* of the existing
`options.fetch ?? …` seam in the four adapters that make repeated calls over a
long-lived client — `hostedStore`, `cloudSandbox`, `cloudConnections`,
`cloudTools` — so **a host passing its own `fetch` still wins**, exactly as
before (adapter rule).

Node-only by construction, the same posture as `deployment-identity.ts`:
undici arrives through a dynamic import and any failure to load *or*
construct falls back to today's plain fetch, so an edge/Worker target is
unchanged. The portability gate's workerd leg boots `createVendo` with
`store: cloud` at module scope and serves `/status` 200 with this in the
graph.

## Measured (read-only, live Vendo Cloud, this build)

Two independent runs of the same probe, interleaved so network drift hits both
arms:

| | before | after |
|---|---|---|
| guard's lookup pair, p50 | **399 ms** / 402 ms | **270 ms** / 254 ms |
| after a 6s idle gap, reconnects | **5 / 5** | **0 / 5** |
| after a 6s idle gap, p50 | **410 ms** / 272 ms | **283 ms** / 187 ms |

Together that is roughly **130 ms off a warm guard decision and another ~130 ms
off the first call after any idle gap** — and every gap between an agent's tool
calls is longer than 4s.

## Tests

- New: `pipeline-conformance.test.ts` holds every store `list` open for 50ms
  and asserts the approvals and grants lookups *overlap*. Verified it fails on
  the old sequential code (`expected 392.96 to be less than 392.89`) and passes
  on the new.
- New: `packages/vendo/tests/keep-alive-fetch.test.ts` pins that every Cloud
  request carries the *same* pool — a per-call agent would reopen the very
  connection this fix exists to keep.
- Replay-spend semantics re-run green unchanged: `approval-replay`,
  `approval-single-use-cas`, `confirm-each-unsuppressible`, `park-resume`.
- Full `@vendoai/guard` suite (284 passed), touched `@vendoai/vendo` adapter
  tests (120 passed), scoped typecheck, `pnpm lint` (dependency guard +
  portability gate, all legs green), `pnpm build`.

## Note for review

`undici` is a new runtime dependency of `@vendoai/vendo` (zero-dep, Node's own
HTTP client). Node exposes no builtin way to reach a dispatcher — `node:undici`
does not exist and the global dispatcher lives behind an undocumented symbol —
so the package is the only supported mechanism. Verified empirically that
Node 24's global `fetch` honours a userland undici `Agent` as `init.dispatcher`,
and that a 60s idle socket does **not** delay process exit (85ms, same as
baseline).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs the guard’s approval and grant lookups concurrently and keeps Cloud adapter HTTP connections alive, reducing hosted‑store decision latency and avoiding reconnects after idle gaps.

- Guard pipeline (`@vendoai/guard`): approvals and grants lookups now issue together instead of sequentially while still applying the replay verdict first; single‑use CAS spend is unchanged. Side effect: `confirmEach` calls also perform the grants read (discarded). Concurrency is verified by a new test.
- Cloud adapters (`@vendoai/vendo`): default `fetch` for `hostedStore`, `cloudSandbox`, `cloudConnections`, and `cloudTools` is now `keepAliveFetch` (shared `undici` pool, 60s keep‑alive). `options.fetch` continues to override. Node‑only via dynamic import; if `undici` cannot load, adapters fall back to plain fetch and edge targets are unchanged. Adds a runtime dependency on `undici`. Measured impact: lookup pair p50 ~400 ms → ~250 ms; 0 reconnects after a 6 s idle gap and ~85 ms faster first call.

<sup>Written for commit b1df7312130276cf1603711d59daf21a36db1ec7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

