### PR TITLE
feat(apps): a screen writes ONE element for an action, and the product does the asking

### DIFF
--- a/.changeset/one-element-for-a-money-action.md
+++ b/.changeset/one-element-for-a-money-action.md
@@ -1,0 +1,34 @@
+---
+"@vendoai/apps": minor
+---
+
+A screen writes ONE element for an action, and the product does the asking.
+
+A generated money screen used to hand-roll its own consent: a `confirming`
+piece of state, a Callout, a "Yes, cancel it" and a "Keep it" — fifteen to
+twenty-five lines per action, and often half the file. It was wasted twice
+over. The reviewer rejected the screen for confirm details it could not see,
+which cost a repair round on nearly every money screen; and the guard already
+asks properly at the system layer, so the person who got through the screen's
+panel was then asked a second time by the approval modal.
+
+`@vendo/screen` now exports `<ActionButton>`:
+
+```tsx
+<ActionButton tool="cancel_transfer" args={{ id: transfer.id }} label="Cancel" variant="danger" />
+```
+
+It renders the Kit's own `Button`, and the press files EXACTLY the call a
+handler files — the same `tools` proxy, the same intent — so the guard, the
+approval modal, the single-flight lock, the per-node outcome notice and the
+refresh on success are the ones already there. It adds nothing to trust.
+
+The compiler decides whether the press is real, on the same schemas that type
+`tools.<name>(args)`: `tool` is the written-out name of a tool this host has
+(with TypeScript's own "did you mean" on a typo) and `args` is that tool's own
+payload, required exactly when its schema requires one. A name computed from
+the data satisfies no tool, so it is refused before the screen ever runs.
+
+The screen manual now teaches it in place of the confirm panel it used to
+teach, and the reviewer is told that a screen using it is not missing a
+confirmation — asking twice is the bug, not asking once.

--- a/packages/apps/src/contract/genui/component/index.ts
+++ b/packages/apps/src/contract/genui/component/index.ts
@@ -34,6 +34,7 @@ export {
 export { flattenTree } from "./flatten.js";
 export {
   isHandlerRef,
+  SCREEN_ACTION_COMPONENT,
   SCREEN_FILE,
   SCREEN_TEXT_NODE,
   ScreenError,

--- a/packages/apps/src/contract/genui/component/types.ts
+++ b/packages/apps/src/contract/genui/component/types.ts
@@ -127,6 +127,24 @@ export const SCREEN_TEXT_NODE = "#text";
  */
 export const SCREEN_FILE = "app.tsx";
 
+/**
+ * The one component `@vendo/screen` exports that is not a catalog name:
+ * `<ActionButton tool="cancel_transfer" args={{ id }} label="Cancel"/>` — a
+ * write as ONE element.
+ *
+ * It renders the Kit's own `Button`, and its press files exactly the call a
+ * handler files: the same `tools` proxy, the same intent, and therefore the same
+ * guard, the same approval and the same refresh on the way back (./vm-program.ts).
+ * It carries no ceremony of its own — whether a press is asked about is the
+ * guard's policy, decided outside the screen — which is why a screen written with
+ * it writes no confirm panel.
+ *
+ * Held with the engine's vocabulary because the engine IMPLEMENTS it and the type
+ * declarations DECLARE it (`checking/screen-typings.ts`): a second spelling in
+ * either is a component a screen may import and cannot render.
+ */
+export const SCREEN_ACTION_COMPONENT = "ActionButton";
+
 /** A node of the flat tree {@link flattenTree} prints. */
 export interface FlatNode {
   id: string;

--- a/packages/apps/src/contract/genui/component/vm-program.ts
+++ b/packages/apps/src/contract/genui/component/vm-program.ts
@@ -32,6 +32,7 @@
  * same trick.
  */
 import { PREACT_HOOKS_SOURCE, PREACT_JSX_RUNTIME_SOURCE, PREACT_SOURCE } from "./preact-source.js";
+import { SCREEN_ACTION_COMPONENT } from "./types.js";
 
 /**
  * The names the VM must NOT carry.
@@ -269,19 +270,37 @@ const ENGINE = `(function () {
     return event;
   }
 
+  // ── the screen's own surface ──────────────────────────────────────────────
+  var tools = (function make(path) {
+    return new Proxy(function () {}, {
+      get: function (target, key) { return typeof key === "string" ? make(path.concat(key)) : undefined; },
+      apply: function (target, self, args) {
+        if (path.length === 0) throw new TypeError("tools is not itself a tool — call one on it, like tools.cancel_transfer({ id })");
+        if (!eventPhase) {
+          throw new Error("tools." + path.join(".") + "() cannot run while the screen renders — tools run inside event handlers, and a screen paints from its useQuery data");
+        }
+        return callTool(path, args[0]);
+      },
+    });
+  })([]);
+
+  // <${SCREEN_ACTION_COMPONENT}> (./types.ts): a write as one element. It is a
+  // Button whose press goes down the handler path unchanged — the same proxy,
+  // the same intent — so it adds nothing to trust and inherits the whole story
+  // the guard already tells about a press. Every other prop rides through to the
+  // Button, so the two agree with the declarations by construction
+  // (checking/screen-typings.ts prints Button's own props here, minus its
+  // handler slot); \`onClick\` is written LAST, so it is the component's alone.
+  function actionButton(props) {
+    var button = {};
+    for (var key in props) if (key !== "tool" && key !== "args") button[key] = props[key];
+    button.onClick = function () { return tools[props.tool](props.args); };
+    return preact.createElement("Button", button);
+  }
+
   globalThis.__vendo = {
-    tools: (function make(path) {
-      return new Proxy(function () {}, {
-        get: function (target, key) { return typeof key === "string" ? make(path.concat(key)) : undefined; },
-        apply: function (target, self, args) {
-          if (path.length === 0) throw new TypeError("tools is not itself a tool — call one on it, like tools.cancel_transfer({ id })");
-          if (!eventPhase) {
-            throw new Error("tools." + path.join(".") + "() cannot run while the screen renders — tools run inside event handlers, and a screen paints from its useQuery data");
-          }
-          return callTool(path, args[0]);
-        },
-      });
-    })([]),
+    tools: tools,
+    actionButton: actionButton,
 
     mount: function (loaded) {
       component = loaded;
@@ -431,6 +450,9 @@ export function installSource(input: InstallInput): string {
     tools: __vendo.tools,
   };
   for (var i = 0; i < names.length; i++) screen[names[i]] = names[i];
+  // After the catalog, so the one component with an implementation cannot be
+  // shadowed by a bare name.
+  screen[${JSON.stringify(SCREEN_ACTION_COMPONENT)}] = __vendo.actionButton;
   __vendo_modules["@vendo/screen"] = screen;
 
   var module = { exports: {} };

--- a/packages/apps/src/server/checking/component-screen.ts
+++ b/packages/apps/src/server/checking/component-screen.ts
@@ -50,6 +50,7 @@ import {
 } from "../../contract/index.js";
 // The screen engine, by its own path: the contract door does not carry it yet.
 import {
+  SCREEN_ACTION_COMPONENT,
   SCREEN_TEXT_NODE,
   type FlatTree,
   type ScreenErrorKind,
@@ -618,7 +619,10 @@ export async function checkComponentScreen(opts: ComponentScreenOptions): Promis
       source: opts.source,
       typings,
       lib: COMPONENT_SCREEN_LIB,
-      components: names,
+      // The names a refusal LISTS as available, which is the catalog plus the
+      // screen module's own action component: a sentence that tells a model what
+      // it may render must not omit something it may.
+      components: [...names, SCREEN_ACTION_COMPONENT],
     });
   } catch (error) {
     // A toolchain reached over a service binding reports failure by THROWING —

--- a/packages/apps/src/server/checking/reviewer-prompt.ts
+++ b/packages/apps/src/server/checking/reviewer-prompt.ts
@@ -21,6 +21,7 @@ Judge five things:
 2. DISHONEST TOOL USE. A tool may only be used for what its own description says it does. A payment tool is not a message channel. An invoice-creating tool is not a reminder. A search tool is not a delete. A control whose label promises something its tool does not do is dishonest even though it runs.
 
 3. DEAD OR UNGROUNDED CONTROLS. A button, form, or link that does nothing — or that acts without the data it needs, like a row action carrying no row id — is dead. Say what it promises and what it actually does.
+   \`<ActionButton tool="…" args={…}/>\` is a live control: it files that tool call itself, and this product asks the person to confirm it OUTSIDE the screen. So it is never dead for having no handler, and a screen that uses it is never wrong for having no confirmation step of its own — asking twice is the bug, not asking once.
 
 4. SECTIONS THAT DON'T ANSWER THE ASK. Part of the app the user never asked for and that answers nothing.
 

--- a/packages/apps/src/server/checking/screen-typings.ts
+++ b/packages/apps/src/server/checking/screen-typings.ts
@@ -32,6 +32,8 @@ import {
   type NormalizedCatalog,
   type PropSpec,
 } from "../../contract/index.js";
+// The screen engine, by its own path — the same door component-screen.ts takes.
+import { SCREEN_ACTION_COMPONENT } from "../../contract/genui/component/index.js";
 import { z, type ZodTypeAny } from "zod";
 import { isMutatingTool, type HostToolInfo } from "./deps.js";
 
@@ -396,10 +398,12 @@ const IDENTIFIER = /^[A-Za-z_$][\w$]*$/u;
  *  purpose — that is what makes `<div>` an error — and `IntrinsicAttributes`
  *  carries `key`, because a list rendered with `.map()` writes one and it is
  *  React's, not the component's. */
+const JSX_KEY_PROP = "key?: string | number";
+
 const JSX_FRAME = `declare namespace JSX {
   interface Element {}
   interface ElementChildrenAttribute { children: {} }
-  interface IntrinsicAttributes { key?: string | number }
+  interface IntrinsicAttributes { ${JSX_KEY_PROP} }
   interface IntrinsicElements {}
 }`;
 
@@ -440,6 +444,63 @@ const componentPropsText = (props: Record<string, PropSpec>, note?: TypeNote): s
  *  writes JSX, so nesting is allowed even where the host's schema closes. */
 const hostComponentPropsText = (schema: JsonSchema, note?: TypeNote): string =>
   `${objectTypeText(schema, "props", 0, note)} & { children?: any }`;
+
+/**
+ * `<ActionButton tool="…" args={…}/>` — the one component the catalog does not
+ * carry, because its props are the HOST's tools rather than a zod spec: `tool`
+ * is the literal name of one tool and `args` is THAT tool's own payload.
+ *
+ * So `tool` types as the names and `args` is looked up BY that name, which is
+ * what makes the compiler answer all three ways a screen can get this wrong,
+ * each on the attribute that is wrong: a tool the host does not have (with
+ * TypeScript's own "did you mean"), a name that is not written out (a `string`
+ * satisfies no name), and a payload that tool's schema does not accept. The same
+ * three answers `tools.<name>(args)` already gets in a handler — printed from
+ * the same schemas, by the same printer, under the same required rule, so one
+ * write cannot read two ways.
+ *
+ * The rest of the props are `Button`'s own, minus its handler slot: this
+ * component IS the handler, and the engine forwards everything else straight to
+ * the Button it renders (`contract/genui/component/vm-program.ts`). Derived
+ * rather than written out, so a prop added to the Kit's Button arrives here the
+ * day it is added. No `children`: the engine renders the `label`, and a nested
+ * child would be silently dropped.
+ */
+const ACTION_ARGS_TYPE = "VendoActionArgs";
+
+const actionComponentLines = (tools: readonly HostToolInfo[], note?: TypeNote): string[] => {
+  const shared = [
+    ...Object.entries(kitSpec("Button")?.props ?? {})
+      .filter(([, spec]) => spec.schema.description !== ACTION_PROP_DESCRIPTION)
+      .map(([name, spec]) => `${name}${spec.required === true ? "" : "?"}: ${zodTypeText(spec.schema, 0, at(note, `<${SCREEN_ACTION_COMPONENT}> prop "${name}"`))}`),
+    // `key` is React's, not the component's, and `JSX.IntrinsicAttributes`
+    // already carries it — but only into a props type that is ONE object, and
+    // this one is a lookup. Without it here, every mis-typed row control reports
+    // its `key` instead of the thing that is actually wrong. Written from the
+    // frame's own constant, so the two cannot say different things.
+    JSX_KEY_PROP,
+  ];
+  // One entry per tool, carrying `args` with its own required-ness — so the
+  // lookup below decides both the payload's TYPE and whether it may be omitted.
+  // No tools at all leaves it EMPTY, which types `tool` as `never`: there is
+  // nothing to call, rather than the component being gone.
+  const args = tools.map((tool) => {
+    const { text, required } = toolInputText(tool, at(note, `<${SCREEN_ACTION_COMPONENT} tool="${tool.name}"> args`));
+    return `    ${JSON.stringify(tool.name)}: { args${required ? "" : "?"}: ${text} };`;
+  });
+  // The constraint is the NAMES, not `keyof` the table: a refusal prints the
+  // constraint verbatim, and a screen author can act on "…takes
+  // "cancel_transfer" | "resend_receipts"" in a way they cannot act on the name
+  // of a type they will never see.
+  const names = tools.length === 0 ? "never" : tools.map((tool) => JSON.stringify(tool.name)).join(" | ");
+  return [
+    `  interface ${ACTION_ARGS_TYPE} {`,
+    ...args,
+    `  }`,
+    `  /** One press, one tool call. The product decides whether to ask first. */`,
+    `  export const ${SCREEN_ACTION_COMPONENT}: <T extends ${names}>(props: { tool: T; ${shared.join("; ")} } & ${ACTION_ARGS_TYPE}[T]) => JSX.Element;`,
+  ];
+};
 
 /** A tool payload reads CLOSED, whatever `additionalProperties` says: the whole
  *  point of typing it is that a misspelled key (`amountCents` for `amount`) is
@@ -495,6 +556,7 @@ export function componentScreenTypings(input: ComponentScreenTypingsInput): stri
         : hostComponentPropsText(schema, at(note, `<${name}>`));
     lines.push(`  export const ${name}: (props: ${propsText}) => JSX.Element;`);
   }
+  lines.push(...actionComponentLines(input.tools, note));
 
   const overloads = input.tools.filter((tool) => !isMutatingTool(tool)).map((tool) => {
     const { text, required } = toolInputText(tool, at(note, `useQuery("${tool.name}") input`));

--- a/packages/apps/src/server/skills/format-reference.ts
+++ b/packages/apps/src/server/skills/format-reference.ts
@@ -4,18 +4,18 @@
  * hands, never listed.
  *
  * A screen is a plain React component now, so this file teaches only the DELTAS
- * from React a model already knows: the two imports, catalog-only components, tool
- * calls in handlers, no clock and no network, keys, controlled inputs. Everything
- * that used to live here — a markup dialect, its attribute forms, its brace
- * grammar, its island envelope — is gone with the dialect, and teaching it would
- * send a model writing a file nothing compiles.
+ * from React a model already knows: the two imports, catalog-only components, a
+ * write as one element, tool calls in handlers, no clock and no network, keys,
+ * controlled inputs. Everything that used to live here — a markup dialect, its
+ * attribute forms, its brace grammar, its island envelope — is gone with the
+ * dialect, and teaching it would send a model writing a file nothing compiles.
  *
  * The component half is INTERPOLATED from the same generated schemas the engine's
  * workers read (`componentsPromptSection`), so it cannot drift from the code — and
  * it now teaches the same idiom this chapter does, so nothing here has to correct
  * it (`contract/kit/kit-prompt.ts`).
  */
-import { SCREEN_FILE } from "../../contract/genui/component/index.js";
+import { SCREEN_ACTION_COMPONENT, SCREEN_FILE } from "../../contract/genui/component/index.js";
 import { HOT_PATH_FILES } from "../generation/render-seam.js";
 import { componentsPromptSection } from "../generation/contracts/sections.js";
 
@@ -45,12 +45,16 @@ result exactly as the tool returns it, so read the field names off the tool's ow
 schema. Money arrives in whatever unit that schema says: divide a \`_cents\` field
 by 100 where you read it, because the components format and never convert.
 
-**Actions — \`tools.<tool_name>(args)\`, inside an event handler only.** Never
-during render. \`await\` it when you need the result; the host runs the tool and
-answers. When an awaited call succeeds, every \`useQuery\` on the screen re-runs and
-the screen re-renders with fresh data on its own — so never patch state to mirror
-what the refresh will bring back. The host may also put its own approval card in
-front of a destructive call; that is its business, and you still write the call.
+**A button that does one thing — \`<${SCREEN_ACTION_COMPONENT} tool="…" args={…} label="…"/>\`.**
+The press files that exact call. This product asks the person to confirm it where
+confirming belongs, outside your screen, so never build a confirm step of your
+own: no "are you sure" panel, no second button, no \`confirming\` state.
+
+**Anything more than one call — \`tools.<tool_name>(args)\`, inside an event
+handler only.** Never during render. \`await\` it when you need the result; the
+host runs the tool and answers. When an awaited call succeeds, every \`useQuery\`
+on the screen re-runs and the screen re-renders with fresh data on its own — so
+never patch state to mirror what the refresh will bring back.
 
 **Components — the catalog below, and nothing else.** No \`<div>\`, no
 \`className\`, no \`style\`, no CSS: each component already carries this product's
@@ -63,8 +67,7 @@ there is no network, no storage and no timers.
 **State — \`useState\`.** Inputs are controlled: \`value={x}\` with
 \`onChange={(e) => setX(e.target.value)}\`. A handler receives a plain
 \`{ target: { value } }\` — a checkbox, \`{ target: { checked } }\` — and there is no
-\`preventDefault\` to call: \`<Form>\` submits itself. Confirm a destructive action
-wherever the flow needs confirming.
+\`preventDefault\` to call: \`<Form>\` submits itself.
 
 Save errors tell you exactly what to fix. Fix and save again.
 
@@ -75,17 +78,10 @@ Save errors tell you exactly what to fix. Fix and save again.
 The ask: "let me cancel a transfer before it goes out."
 
 \`\`\`tsx
-import { useState } from "react";
-import { Button, Callout, Card, DateTime, Money, Row, Stack, Text, tools, useQuery } from "@vendo/screen";
+import { ${SCREEN_ACTION_COMPONENT}, Card, DateTime, Money, Row, Stack, Text, useQuery } from "@vendo/screen";
 
 export default function PendingTransfers() {
   const pending = useQuery("list_pending_transfers");
-  const [confirming, setConfirming] = useState<string | null>(null);
-
-  const cancel = async (id: string) => {
-    await tools.cancel_transfer({ id });
-    setConfirming(null);
-  };
 
   return (
     <Stack gap={12}>
@@ -101,17 +97,8 @@ export default function PendingTransfers() {
                 <Money amount={transfer.amount_cents / 100} />
                 <DateTime value={transfer.scheduled_for} mode="date" />
               </Stack>
-              <Button label="Cancel" variant="secondary" onClick={() => setConfirming(transfer.id)} />
+              <${SCREEN_ACTION_COMPONENT} tool="cancel_transfer" args={{ id: transfer.id }} label="Cancel" variant="danger" />
             </Row>
-
-            {confirming === transfer.id && (
-              <Callout tone="warning" title="Cancel this transfer?">
-                <Row gap={8}>
-                  <Button label="Yes, cancel it" variant="danger" onClick={() => cancel(transfer.id)} />
-                  <Button label="Keep it" variant="secondary" onClick={() => setConfirming(null)} />
-                </Row>
-              </Callout>
-            )}
           </Card>
         ))
       )}
@@ -122,8 +109,8 @@ export default function PendingTransfers() {
 
 Nothing on that screen is typed in: every value is read off the query, every
 number and date is formatted by the component showing it, the empty list says so
-in one honest line, and the one thing that changes the product goes through
-\`tools.cancel_transfer\` in a handler.
+in one honest line, and the one thing that changes the product is one element —
+the product does the asking.
 
 ---
 

--- a/packages/apps/tests/checking/action-button.test.ts
+++ b/packages/apps/tests/checking/action-button.test.ts
@@ -1,0 +1,220 @@
+/**
+ * `<ActionButton>` — a write as ONE element, through the real gauntlet and the
+ * real engine.
+ *
+ * Two claims, and they are the whole feature:
+ *
+ *  1. THE COMPILER DECIDES WHETHER THE PRESS IS REAL. `tool` is the written-out
+ *     name of a tool this host has and `args` is that tool's own payload, so a
+ *     name it does not have, a name that is not a literal, and a key the schema
+ *     does not take are each refused before the screen ever runs — the same
+ *     answers `tools.<name>(args)` already gets in a handler.
+ *  2. THE PRESS FILES WHAT A HANDLER FILES. Proven by booting the compiled
+ *     screen this check hands back, firing the handler the painted tree names,
+ *     and reading the intent out — nothing stubbed on either side, because a
+ *     button that paints and calls nothing is exactly the failure this replaces.
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+import type { JsonSchema } from "@vendoai/core";
+import { bootScreen, flattenTree, warmScreenEngine } from "../../src/contract/index.js";
+import {
+  checkComponentScreen,
+  screenCatalog,
+  type ComponentScreenCheck,
+} from "../../src/server/checking/component-screen.js";
+import type { HostToolInfo } from "../../src/server/checking/deps.js";
+
+const pendingSchema: JsonSchema = {
+  type: "object",
+  properties: {
+    data: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: { id: { type: "string" }, recipient: { type: "string" } },
+        required: ["id", "recipient"],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ["data"],
+  additionalProperties: false,
+};
+
+const tools: readonly HostToolInfo[] = [
+  {
+    name: "list_pending_transfers",
+    description: "Transfers waiting to go out",
+    risk: "read",
+    outputSchema: pendingSchema,
+  },
+  {
+    name: "cancel_transfer",
+    description: "Cancel one pending transfer",
+    risk: "destructive",
+    inputSchema: {
+      type: "object",
+      properties: { id: { type: "string" } },
+      required: ["id"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "resend_receipts",
+    description: "Send today's receipts again",
+    risk: "write",
+    inputSchema: { type: "object", properties: { since: { type: "string" } }, additionalProperties: false },
+  },
+];
+
+const ROWS = { data: [{ id: "tr_1", recipient: "Ada" }] };
+
+const catalog = screenCatalog([]);
+
+const check = async (source: string): Promise<ComponentScreenCheck> =>
+  checkComponentScreen({ source, hostTools: tools, catalog, runQuery: async () => ROWS });
+
+const refusal = async (source: string): Promise<string> => {
+  const result = await check(source);
+  if (result.ok) throw new Error("expected the gauntlet to refuse this screen");
+  return result.issues.map(({ message }) => message).join("\n");
+};
+
+/** One screen, both shapes of the component: a tool whose schema REQUIRES a
+ *  payload, and one whose schema does not. */
+const SCREEN = `import { ActionButton, Card, Stack, Text, useQuery } from "@vendo/screen";
+
+export default function PendingTransfers() {
+  const pending = useQuery("list_pending_transfers");
+
+  return (
+    <Stack gap={12}>
+      <Text text="Transfers waiting to go out" variant="heading" />
+      <ActionButton tool="resend_receipts" label="Resend receipts" variant="secondary" />
+      {pending.data.map((transfer) => (
+        <Card key={transfer.id} title={transfer.recipient}>
+          <ActionButton tool="cancel_transfer" args={{ id: transfer.id }} label="Cancel" variant="danger" />
+        </Card>
+      ))}
+    </Stack>
+  );
+}
+`;
+
+/** The painted Button nodes, in paint order, with the handler each one carries. */
+const buttons = (nodes: Record<string, { component: string; props: Record<string, unknown> }>) =>
+  Object.entries(nodes)
+    .filter(([, node]) => node.component === "Button")
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([id, node]) => ({ id, props: node.props }));
+
+beforeAll(async () => {
+  await warmScreenEngine();
+});
+
+describe("a screen that presses through <ActionButton>", () => {
+  it("passes, and paints the Kit's own Button with a handler — never the tool name as a prop", async () => {
+    const result = await check(SCREEN);
+
+    expect(result.issues).toEqual([]);
+    expect(result.ok).toBe(true);
+
+    const painted = buttons(result.initialTree?.nodes ?? {});
+    expect(painted).toHaveLength(2);
+    // The rendered control is a Button like any other: what it calls lives in the
+    // handler, so `tool` and `args` never reach the surface as props.
+    expect(painted[0]?.props).toEqual({
+      label: "Resend receipts",
+      variant: "secondary",
+      onClick: { $handler: expect.stringMatching(/^h\d+$/u) },
+    });
+    expect(painted[1]?.props).toEqual({
+      label: "Cancel",
+      variant: "danger",
+      onClick: { $handler: expect.stringMatching(/^h\d+$/u) },
+    });
+  });
+
+  it("files exactly the intent a handler files when the button is pressed", async () => {
+    const result = await check(SCREEN);
+    expect(result.ok).toBe(true);
+
+    // The seam: boot what the check handed back, the way the renderer does
+    // (`packages/ui` use-screen.ts), and press.
+    const screen = bootScreen({
+      compiledSource: result.compiled ?? "",
+      queries: result.queries ?? {},
+      catalog: [...catalog].map((entry) => (typeof entry === "string" ? entry : entry.name)),
+      now: Date.UTC(2026, 7, 13),
+    });
+    try {
+      const painted = buttons(flattenTree(screen.tree()).nodes);
+      const rowPress = painted[1]?.props.onClick as { $handler: string };
+      const fired = screen.fire(rowPress.$handler);
+
+      // The row's own id, off the row it was rendered from — and the SAME shape
+      // `tools.cancel_transfer({ id })` records, so everything downstream (the
+      // guard, the approval, the refresh) sees a press it already knows how to
+      // answer.
+      expect(fired.intents).toEqual([
+        { id: expect.stringMatching(/^i\d+$/u), tool: "cancel_transfer", args: { id: "tr_1" } },
+      ]);
+
+      // A tool whose schema requires nothing files with no payload at all.
+      const bare = painted[0]?.props.onClick as { $handler: string };
+      expect(screen.fire(bare.$handler).intents).toEqual([
+        { id: expect.stringMatching(/^i\d+$/u), tool: "resend_receipts", args: undefined },
+      ]);
+    } finally {
+      screen.dispose();
+    }
+  });
+});
+
+describe("what the compiler refuses", () => {
+  const screenAround = (element: string): string => `import { ActionButton, Stack, useQuery } from "@vendo/screen";
+
+export default function Screen() {
+  const pending = useQuery("list_pending_transfers");
+  return <Stack gap={8}>{pending.data.map((transfer) => (${element}))}</Stack>;
+}
+`;
+
+  it("refuses a tool this host does not have", async () => {
+    const text = await refusal(screenAround(
+      `<ActionButton key={transfer.id} tool="cancel_transfers" args={{ id: transfer.id }} label="Cancel" />`,
+    ));
+    expect(text).toContain("cancel_transfer");
+    expect(text).toMatch(/cancel_transfers/u);
+  });
+
+  it("refuses a tool name computed from the data", async () => {
+    const text = await refusal(screenAround(
+      `<ActionButton key={transfer.id} tool={transfer.recipient} args={{ id: transfer.id }} label="Cancel" />`,
+    ));
+    expect(text).toContain('prop "tool"');
+    // …and it says what it would have taken, so the repair is the name itself.
+    expect(text).toContain("cancel_transfer");
+  });
+
+  it("refuses a payload the tool's own schema does not accept", async () => {
+    const text = await refusal(screenAround(
+      `<ActionButton key={transfer.id} tool="cancel_transfer" args={{ transferId: transfer.id }} label="Cancel" />`,
+    ));
+    expect(text).toContain("transferId");
+  });
+
+  it("refuses a press with no payload where the tool's schema requires one", async () => {
+    const text = await refusal(screenAround(
+      `<ActionButton key={transfer.id} tool="cancel_transfer" label="Cancel" />`,
+    ));
+    expect(text).toContain("args");
+  });
+
+  it("refuses a prop the Button it renders does not have", async () => {
+    const text = await refusal(screenAround(
+      `<ActionButton key={transfer.id} tool="cancel_transfer" args={{ id: transfer.id }} label="Cancel" tone="danger" />`,
+    ));
+    expect(text).toContain("tone");
+  });
+});

--- a/packages/apps/tests/checking/component-screen.test.ts
+++ b/packages/apps/tests/checking/component-screen.test.ts
@@ -555,7 +555,9 @@ export default function S() { return <div><Text text="x" /></div>; }
 
     expect(codes).toEqual(["types"]);
     expect(text).toContain("line 2: writes the HTML element <div>");
-    expect(text).toContain("It renders only the components it imports from \"@vendo/screen\": Stack, Row, Card, Text, Money, DateTime, Button, Callout.");
+    // The catalog, and the one component the module carries that no catalog
+    // does — a list of what a screen may render must not omit something it may.
+    expect(text).toContain("It renders only the components it imports from \"@vendo/screen\": Stack, Row, Card, Text, Money, DateTime, Button, Callout, ActionButton.");
     expect(text).toContain("Lay out with <Stack>/<Row>/<Grid> and write text with <Text>.");
     // The closing tag is the same break; a repair list that says everything
     // twice reads as two problems.
@@ -580,7 +582,7 @@ export default function S() { return <Sidebar><Text text="x" /></Sidebar>; }
 `);
 
     expect(text).toContain("renders <Sidebar>, which this screen never imported");
-    expect(text).toContain("The components available are: Stack, Row, Card, Text, Money, DateTime, Button, Callout.");
+    expect(text).toContain("The components available are: Stack, Row, Card, Text, Money, DateTime, Button, Callout, ActionButton.");
   });
 
   it("refuses a member the screen module does not export", async () => {


### PR DESCRIPTION
## ⚠️ TWO TEXT CHANGES NEED YOUSEF'S SIGN-OFF BEFORE MERGE

Both are texts you iterate on personally. **Do not merge until you've okayed the exact wording.**

### 1. `packages/apps/src/server/checking/reviewer-prompt.ts` — one sentence added to finding 3

```diff
 3. DEAD OR UNGROUNDED CONTROLS. A button, form, or link that does nothing — or that acts without the data it needs, like a row action carrying no row id — is dead. Say what it promises and what it actually does.
+   `<ActionButton tool="…" args={…}/>` is a live control: it files that tool call itself, and this product asks the person to confirm it OUTSIDE the screen. So it is never dead for having no handler, and a screen that uses it is never wrong for having no confirmation step of its own — asking twice is the bug, not asking once.
```

### 2. `packages/apps/src/server/skills/format-reference.ts` — the screen manual

**(a) the Actions paragraph — split in two:**

```diff
-**Actions — `tools.<tool_name>(args)`, inside an event handler only.** Never
-during render. `await` it when you need the result; the host runs the tool and
-answers. When an awaited call succeeds, every `useQuery` on the screen re-runs and
-the screen re-renders with fresh data on its own — so never patch state to mirror
-what the refresh will bring back. The host may also put its own approval card in
-front of a destructive call; that is its business, and you still write the call.
+**A button that does one thing — `<ActionButton tool="…" args={…} label="…"/>`.**
+The press files that exact call. This product asks the person to confirm it where
+confirming belongs, outside your screen, so never build a confirm step of your
+own: no "are you sure" panel, no second button, no `confirming` state.
+
+**Anything more than one call — `tools.<tool_name>(args)`, inside an event
+handler only.** Never during render. `await` it when you need the result; the
+host runs the tool and answers. When an awaited call succeeds, every `useQuery`
+on the screen re-runs and the screen re-renders with fresh data on its own — so
+never patch state to mirror what the refresh will bring back.
```

**(b) one sentence deleted from the State paragraph** (it is what produced the panels):

```diff
-`preventDefault` to call: `<Form>` submits itself. Confirm a destructive action
-wherever the flow needs confirming.
+`preventDefault` to call: `<Form>` submits itself.
```

**(c) the worked example** — the confirm panel (and `useState`, and the `cancel` handler) come out; one element goes in:

```diff
-              <Button label="Cancel" variant="secondary" onClick={() => setConfirming(transfer.id)} />
-            </Row>
-
-            {confirming === transfer.id && (
-              <Callout tone="warning" title="Cancel this transfer?">
-                <Row gap={8}>
-                  <Button label="Yes, cancel it" variant="danger" onClick={() => cancel(transfer.id)} />
-                  <Button label="Keep it" variant="secondary" onClick={() => setConfirming(null)} />
-                </Row>
-              </Callout>
-            )}
+              <ActionButton tool="cancel_transfer" args={{ id: transfer.id }} label="Cancel" variant="danger" />
+            </Row>
```

…and its closing line: *"…and the one thing that changes the product* ~~goes through `tools.cancel_transfer` in a handler~~ *is one element — the product does the asking."*

---

## What this is

A generated money screen hand-rolled its own consent — a `confirming` state, a Callout, a "Yes" and a "Keep it" — 15-25 lines per action and often half the file. It was wasted twice: the reviewer rejected the screen for confirm details it could not see (a repair round on nearly every money screen), and the guard's approval modal then asked the person a **second** time.

Now the screen declares intent in one line and the system owns consent:

```tsx
<ActionButton tool="cancel_transfer" args={{ id: transfer.id }} label="Cancel" variant="danger" />
```

## How it works (no new trust surface)

`<ActionButton>` is implemented **inside the screen VM**: it renders the Kit's own `Button` with an `onClick` that calls the same `tools` proxy a handler calls. So the press is byte-for-byte the intent a handler files, and the guard, the approval modal, the parked-press resolution, the single-flight lock, the per-node outcome notice and the refresh-on-success are all the ones already shipped. **`packages/ui` is untouched** — no renderer change, no change to `use-screen.ts`.

It is deliberately **not** a Kit component: the Kit is the renderable vocabulary shared by wire trees and jailed islands, and this is a screen-dialect authoring form that resolves to a Button. It lives beside `useQuery` and `tools`, which is where the engine implements it and the type declarations declare it.

## What the compiler now answers

`tool`/`args` are typed off the **same schemas** that type `tools.<name>(args)`, so a screen loses nothing by switching:

| written | refusal |
| --- | --- |
| `tool="cancel_transfers"` | `Type '"cancel_transfers"' is not assignable to type '"list_transfers" \| "cancel_transfer" \| …'. Did you mean '"cancel_transfer"'?` |
| `tool={transfer.recipient}` | `prop "tool" on <ActionButton> takes "list_transfers" \| "cancel_transfer" \| …, but this value is string` |
| `args={{ transferId: … }}` | `prop "args" Object literal may only specify known properties, and 'transferId' does not exist in type '{ id: string; }'` |
| `tone="danger"` | `sets unknown prop "tone" on <ActionButton>. Allowed props: tool, label, variant, disabled, key, args` |

`args` is **not** required to be literal — it is evaluated at press time inside the VM, exactly like a handler's `tools.x({ id: row.id })`. Only the tool NAME must be static, and the type system is what enforces that, so the acorn scan needed no new rule.

## Proof

**Unit/seam** — `packages/apps/tests/checking/action-button.test.ts` (7 tests) runs the real gauntlet (esbuild + acorn + tsc + QuickJS), then boots the compiled screen the check hands back and **presses** it: the intent is `{ tool: "cancel_transfer", args: { id: "tr_1" } }`, the row's own id. Both new tests were proven to fail — a no-op `onClick` reddens the press test, dropping the declaration reddens the accept tests **and** the manual's worked example.

**The manual is tested like code** — `tests/skills/format-reference.test.ts` already runs every worked example through the real gauntlet, so the new example is proven, not asserted.

**Gate** — `pnpm build` ✅ · `pnpm typecheck` (42/42) ✅ · `pnpm lint` (0 errors) ✅ · full `packages/apps` suite 1705 passed ✅ · `packages/vendo` screen-agent + review fixture ✅.

**Genbench** (`vendo-sonnet`, `pending-transfers`, sonnet):

| | baseline `2026-08-12T20-37-08` | this branch `2026-08-14T04-45-29` |
| --- | --- | --- |
| floor | 5/5 | 5/5 |
| judged | 6/8 | 6/8 |
| settled | 18 092 ms | **13 663 ms** (−24%) |
| cost | $0.0592 | $0.0563 |
| press probe | `effect: "state"` — opened a panel, called nothing | `effect: "tool"` — `cancel_transfer{id:tr_1}` + the refresh read |

**The model reached for it on the first try**, unprompted, and the artifact is 25 lines with no confirm state:

```tsx
<ActionButton tool="cancel_transfer" args={{ id: transfer.id }} label="Cancel" variant="danger" />
```

## Findings for you (not changed here)

1. **The genbench style rubric now contradicts the product.** `genbench/worlds/maple/world.json` grades every screen on *"destructive actions ask for confirmation"* — the judge reads a screenshot and a trace, so it cannot see the guard's modal and marks this **fail** whatever the screen does. It failed on the baseline too (for the opposite reason), so nothing regressed — but the line is now wrong by design. Proposed replacement, for your call: *"a destructive control files its call directly — the product asks; the screen never builds its own confirm step"*. Not touched: changing the exam to pass it is grading our own homework.
2. **`docs-site/capabilities/generated-ui.mdx`** says *"What `@vendo/screen` exports is exactly the component Kit plus the components your host registered"*, which is now one export short, and its Actions bullet only names `tools.tool_name(args)`. Public docs are your voice — not touched.

## Deviations

- **No scan change.** The brief asked me to decide how `tool`/`args` literalness is enforced. The type check states it better (with did-you-mean), and it is a hard gate that runs before the screen is ever executed, so a second rule in the acorn scan would be a duplicate. Documented at `screen-typings.ts`.
- **Two existing assertions updated** in `tests/checking/component-screen.test.ts`: the refusal sentence that lists what a screen may render now truthfully includes `ActionButton`. Stated out loud because touching a test alongside code is not free.
- **`packages/apps/src/server/generation/**` and `packages/harnesses/**` untouched** (stop zones). Nothing there needed to change: the manual reaches the screen agent through `buildingAppsSkill.files`, which is outside them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Screens write one element per action with `<ActionButton>` from `@vendo/screen`; the product now handles confirmation. Before: screens built confirm panels and called tools in handlers. Now: the button renders a `Button` whose press files the same tool call via `tools`, removing duplicate asks.

- Engine: implements `<ActionButton>` in the screen VM; it renders `Button` and calls through the same `tools` proxy; `packages/ui` is unchanged.
- Typings: `tool` must be a literal host tool name; `args` is that tool’s payload (required when the schema requires it); carries `Button` props minus the handler; clearer refusal messages.
- Checks/docs/tests: refusals list `ActionButton`; reviewer prompt notes it is a live control and confirmation is outside the screen; manual teaches `<ActionButton>` and updates the worked example; new seam tests press the button and assert intent and compiler refusals.
- No new scan rule; validation is type-driven off existing schemas.
- Two copy edits (reviewer prompt and manual) require Yousef’s sign-off.

**Migration**
- Replace per-action confirm UIs and `confirming` state with `<ActionButton tool="…" args={…} label="…"/>`.
- Do not add confirm steps in screens; the product asks outside the screen.
- Make `tool` a literal host tool name; supply `args` only as the tool’s schema requires.
- Keep handler-based flows only when an interaction performs more than one tool call.
- Remove unknown props (for example, `tone`); use supported `Button` props like `label`, `variant`, and `disabled`.

<sup>Written for commit d7d75f63ff081e7844f5e1735d7af538eae76582. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

