### PR TITLE
feat(ui,apps,vendo): unseal kit slots + shared adjectives + loud nesting errors

### DIFF
--- a/packages/apps/src/contract/genui/component/vm-program.ts
+++ b/packages/apps/src/contract/genui/component/vm-program.ts
@@ -170,7 +170,11 @@ const ENGINE = `(function () {
   function emitValue(value, slot, depth) {
     if (typeof value === "function") { var id = handlerId(slot); drawer[id] = value; return { $handler: id }; }
     if (value === null || typeof value !== "object") return typeof value === "symbol" ? undefined : value;
-    if (preact.isValidElement(value)) return emitNode(value, slot, depth);
+    // An element in a PROP reads back as a plain object, indistinguishable from
+    // data — so it carries a sigil, as a function does. It is what the renderer
+    // builds a component back out of (ui/tree/renderer.tsx bindValue). A tree
+    // node is never stamped: it already arrives where a node belongs.
+    if (preact.isValidElement(value)) { var element = emitNode(value, slot, depth); element.$element = true; return element; }
     // A frozen-clock screen can hold a real Date. Left to the object walk below
     // it would emit as {} — a Date has no enumerable own properties.
     if (typeof Date !== "undefined" && value instanceof Date) return value.toISOString();

--- a/packages/apps/src/contract/kit/kit-prompt.ts
+++ b/packages/apps/src/contract/kit/kit-prompt.ts
@@ -3,7 +3,7 @@
  * Rendered entirely from `KIT_SPECS`; hand-written component lists are dead.
  * W3 wires this into the engine's wire contract (engine.ts).
  */
-import { KIT_SPECS } from "./specs.js";
+import { KIT_SHARED_PROP_NAMES, KIT_SPECS } from "./specs.js";
 import type { KitComponentSpec, PropClass } from "./schema.js";
 
 export interface KitPromptOptions {
@@ -32,6 +32,21 @@ const PREAMBLE = [
   "Money: formatters never convert units. `<Money>`, `format=\"money\"` and a",
   "`format:\"money\"` column all take an amount ALREADY in dollars, so divide a",
   "minor-unit field by 100 where you read it: `value={invoice.amount_cents / 100}`.",
+  "",
+  "Two adjectives, on every component: **tone** (neutral | accent | success |",
+  "warning | danger) paints from the HOST's theme — the figure that is bad news is",
+  "`danger`, the one worth looking at is `accent`, and nothing invents a color.",
+  "**density** (comfortable | compact) set on a container tightens everything",
+  "inside it; an operations screen is `compact`.",
+  "",
+  "Cells are not sealed. A DataTable column and a CardList field each take a",
+  "`cell` — Kit value components composed for ONE record — and a Stat takes them",
+  "as children. Inside a cell a component names its field instead of taking a",
+  'value: `cell:<EnumBadge field="status" tones={{overdue:"danger"}}/>`. A',
+  "status-like enum column is an EnumBadge, never a bare word; an id or code rides",
+  "under its name as a caption `Text` instead of costing a column. Only the value",
+  "tier and Stack/Row go in a cell, and only containers take children — a Button",
+  "in a cell, or anything nested in a chart, is REFUSED, not quietly dropped.",
 ].join("\n");
 
 /**
@@ -53,11 +68,11 @@ const PREAMBLE = [
 const PROMPT_EXAMPLES: Readonly<Record<string, readonly string[]>> = {
   // Data off a `useQuery` result, never an inline call.
   Money: ["<Money amount={invoice.amount_cents / 100}/>"],
-  Stat: ['<Stat label="Total overdue" value={overdue.total_cents / 100} format="money"/>'],
+  Stat: ['<Stat label="Total overdue" value={overdue.total_cents / 100} format="money" tone="danger"><Sparkline data={overdue.trend}/></Stat>'],
   DataTable: [
-    '<DataTable rows={invoices.data} sortBy="dueDate asc" columns={[{key:"client.name",label:"Client"},{key:"amount",format:"money",align:"end"},{key:"dueDate",format:"date"}]} emptyState="No overdue invoices"/>',
+    '<DataTable rows={invoices.data} sortBy="dueDate asc" columns={[{key:"client.name",label:"Client",cell:<Stack gap={2}><Text field="client.name"/><Text field="number" variant="caption"/></Stack>},{key:"amount",format:"money",align:"end"},{key:"dueDate",format:"date"},{key:"status",label:"Status",cell:<EnumBadge field="status" tones={{overdue:"danger",paid:"success"}}/>}]} emptyState="No overdue invoices"/>',
   ],
-  CardList: ['<CardList items={clients.data} titleField="name" badgeField="status" fields={[{key:"balance",label:"Balance",format:"money"}]}/>'],
+  CardList: ['<CardList items={clients.data} titleField="name" badgeField="status" fields={[{key:"balance",label:"Balance",format:"money"},{key:"plan",cell:<EnumBadge field="plan"/>}]}/>'],
   LineChart: ['<LineChart data={revenue.data} xKey="month" series={["amount"]} format="money"/>'],
   DonutChart: ['<DonutChart data={spend.data} categoryKey="category" valueKey="amount" format="money"/>'],
   // Handlers are functions; every field is controlled.
@@ -72,7 +87,7 @@ const PROMPT_EXAMPLES: Readonly<Record<string, readonly string[]>> = {
   Form: ['<Form onSubmit={() => tools.create_client({ name })} submitLabel="Add client"><Input .../></Form>'],
   // Containers: the child shape is the teaching, not the child's own props.
   Card: ['<Card title="Overdue" description="Worst first"><DataTable .../></Card>'],
-  Grid: ["<Grid columns={3}><Stat .../><Stat .../></Grid>"],
+  Grid: ["<Grid minChildWidth={160}><Stat .../><Stat .../><Stat .../><Stat .../></Grid>"],
   Tabs: ['<Tabs tabs={["Overview","Detail"]}><Stat .../><DataTable .../></Tabs>'],
 };
 
@@ -82,7 +97,10 @@ function classTag(cls: PropClass): string {
 
 function renderSpec(spec: KitComponentSpec): string {
   const lines: string[] = [`## <${spec.name}>`, spec.summary, ""];
-  const props = Object.entries(spec.props);
+  // The two adjectives are on every component's props so that validation and the
+  // screen typings admit them everywhere; the preamble teaches them once, and
+  // restating them 31 times would spend a fifth of the catalog on two words.
+  const props = Object.entries(spec.props).filter(([name]) => !KIT_SHARED_PROP_NAMES.includes(name));
   if (props.length > 0) {
     lines.push("Props:");
     for (const [name, prop] of props) {

--- a/packages/apps/src/contract/kit/kit-prompt.ts
+++ b/packages/apps/src/contract/kit/kit-prompt.ts
@@ -33,11 +33,11 @@ const PREAMBLE = [
   "`format:\"money\"` column all take an amount ALREADY in dollars, so divide a",
   "minor-unit field by 100 where you read it: `value={invoice.amount_cents / 100}`.",
   "",
-  "Two adjectives, on every component: **tone** (neutral | accent | success |",
-  "warning | danger) paints from the HOST's theme — the figure that is bad news is",
-  "`danger`, the one worth looking at is `accent`, and nothing invents a color.",
-  "**density** (comfortable | compact) set on a container tightens everything",
-  "inside it; an operations screen is `compact`.",
+  "Two adjectives. **tone** (neutral | accent | success | warning | danger) on",
+  "values, badges and surfaces paints from the HOST's theme — the figure that is",
+  "bad news is `danger`, the one worth looking at is `accent`, and nothing invents",
+  "a color. **density** (comfortable | compact) on containers and data blocks",
+  "tightens everything inside; an operations screen is `compact`.",
   "",
   "Cells are not sealed. A DataTable column and a CardList field each take a",
   "`cell` — Kit value components composed for ONE record — and a Stat takes them",
@@ -97,9 +97,9 @@ function classTag(cls: PropClass): string {
 
 function renderSpec(spec: KitComponentSpec): string {
   const lines: string[] = [`## <${spec.name}>`, spec.summary, ""];
-  // The two adjectives are on every component's props so that validation and the
-  // screen typings admit them everywhere; the preamble teaches them once, and
-  // restating them 31 times would spend a fifth of the catalog on two words.
+  // The shared adjectives sit in the props of every component that reads one, so
+  // validation and the screen typings admit them there; the preamble teaches them
+  // once, and restating them per component would spend a fifth of the catalog.
   const props = Object.entries(spec.props).filter(([name]) => !KIT_SHARED_PROP_NAMES.includes(name));
   if (props.length > 0) {
     lines.push("Props:");

--- a/packages/apps/src/contract/kit/schema.ts
+++ b/packages/apps/src/contract/kit/schema.ts
@@ -54,6 +54,9 @@ export interface KitComponentSpec {
   examples: string[];
   /** Optional group for prompt organization (layout, values, data, charts, forms). */
   group?: string;
+  /** Does this component RENDER what is nested inside it? Absent means no — most
+   *  of the Kit is a leaf, and the renderer hands children to leaves too. */
+  takesChildren?: boolean;
 }
 
 /** Build a `z.object` from a spec's props, applying `.optional()` to non-required ones. */

--- a/packages/apps/src/contract/kit/specs.ts
+++ b/packages/apps/src/contract/kit/specs.ts
@@ -54,19 +54,34 @@ const tone = z.enum(["neutral", "accent", "success", "warning", "danger"]).or(z.
 const density = z.enum(["comfortable", "compact"]);
 
 /**
- * THE ADJECTIVES — accepted by every component, taught once in the prompt's
- * preamble rather than restated 31 times. Both resolve to theme tokens only:
- * `tone` to the palette, `density` to the host's own spacing ladder.
+ * THE ADJECTIVES — the props many components share, taught once in the prompt's
+ * preamble rather than restated 31 times. Each carries the components that
+ * actually READ it: on any other, the prop would validate and then be dropped
+ * at render — the "valid component, nothing happens" class this floor refuses.
+ * They resolve to theme tokens (`tone` the palette, `density` the host's own
+ * spacing ladder) or, for `field`, to the row a cell slot is painted for.
  */
-const SHARED_PROPS: Readonly<Record<string, PropSpec>> = {
-  tone: config(tone, "emphasis — neutral | accent | success | warning | danger"),
-  density: config(density, "comfortable (default) or compact; set on a container it tightens everything inside"),
-  field: config(z.string(), "inside a cell slot: the row field this component reads"),
-};
+const SHARED_PROPS: ReadonlyArray<{ name: string; spec: PropSpec; on: readonly string[] }> = [
+  {
+    name: "tone",
+    spec: config(tone, "emphasis — neutral | accent | success | warning | danger"),
+    on: ["Text", "Money", "DateTime", "Percent", "Num", "EnumBadge", "Badge", "Sparkline", "Progress", "Stat", "Card", "Surface", "Callout"],
+  },
+  {
+    name: "density",
+    spec: config(density, "comfortable (default) or compact; set on a container it tightens everything inside"),
+    on: ["Stack", "Row", "Grid", "Surface", "Card", "DataTable", "CardList", "Stat"],
+  },
+  {
+    name: "field",
+    spec: config(z.string(), "inside a cell slot: the row field this component reads"),
+    on: ["Text", "Money", "DateTime", "Percent", "Num", "EnumBadge", "Badge", "Sparkline", "Progress"],
+  },
+];
 
 /** The shared adjectives' names, so `kitPrompt` can leave them out of every
  *  component's prop list and teach them once. */
-export const KIT_SHARED_PROP_NAMES: readonly string[] = Object.keys(SHARED_PROPS);
+export const KIT_SHARED_PROP_NAMES: readonly string[] = SHARED_PROPS.map(({ name }) => name);
 
 // ---- specs ---------------------------------------------------------------
 const BASE_SPECS: KitComponentSpec[] = [
@@ -476,12 +491,17 @@ const BASE_SPECS: KitComponentSpec[] = [
   },
 ];
 
-/** Every spec, with the shared adjectives folded in — so validation, the wire's
- *  allowed-prop set and the screen typings all admit `tone` and `density`
- *  without 31 components restating them. */
+/** Every spec, with each shared adjective folded into the components that read
+ *  it — so validation, the wire's allowed-prop set and the screen typings admit
+ *  it exactly where it lands, and refuse it where it would be dropped. */
 export const KIT_SPECS: KitComponentSpec[] = BASE_SPECS.map((spec) => ({
   ...spec,
-  props: { ...spec.props, ...SHARED_PROPS },
+  props: {
+    ...spec.props,
+    ...Object.fromEntries(SHARED_PROPS
+      .filter(({ on }) => on.includes(spec.name))
+      .map(({ name, spec: prop }) => [name, prop])),
+  },
 }));
 
 /**

--- a/packages/apps/src/contract/kit/specs.ts
+++ b/packages/apps/src/contract/kit/specs.ts
@@ -10,27 +10,70 @@
  * pins the two in step).
  */
 import { z } from "zod";
-import { config, copy, data, type KitComponentSpec, type PropClass } from "./schema.js";
+import { config, copy, data, type KitComponentSpec, type PropClass, type PropSpec } from "./schema.js";
 
 // ---- shared zod fragments -------------------------------------------------
 const rows = z.array(z.record(z.string(), z.unknown()));
 const valueFormat = z.enum(["money", "date", "datetime", "time", "percent", "number", "text"]);
 const align = z.enum(["start", "center", "end"]);
 const seriesInput = z.array(z.union([z.string(), z.object({ key: z.string(), label: z.string().optional() })]));
+
+/**
+ * A CELL SLOT — Kit value components composed for one record.
+ *
+ * `z.unknown()` for the same reason `Accordion.items[].content` is: a slot
+ * holds an ELEMENT, and no schema describes one. A slot is written in a screen's
+ * JSX and cannot be written in a wire attribute, so it is code-only, exactly
+ * like `Tabs.tabs[].content` — and, exactly like it, being optional is what
+ * keeps its component wire-usable at all (`KIT_WIRE_UNSAFE_NAMES`).
+ *
+ * NOT a function. `(row) => <EnumBadge/>` looks like the React answer and is the
+ * one thing that cannot work: the screen VM serializes a function prop as a
+ * `$handler` callback (`genui/component/vm-program.ts` `emitValue`), so the
+ * table would be handed an async door, not something it may call while it
+ * paints. An element serializes; a closure does not.
+ */
+const slot = z.unknown();
 const tableColumn = z.object({
   key: z.string(),
   label: z.string().optional(),
   format: valueFormat.optional(),
   align: align.optional(),
+  cell: slot.optional(),
 });
-const cardField = z.object({ key: z.string(), label: z.string().optional(), format: valueFormat.optional() });
+const cardField = z.object({
+  key: z.string(),
+  label: z.string().optional(),
+  format: valueFormat.optional(),
+  cell: slot.optional(),
+});
 const action = z.string().describe("names a host tool");
+/** The one tone vocabulary. The two older spellings still parse, because stored
+ *  apps carry them; only the five are taught. */
+const tone = z.enum(["neutral", "accent", "success", "warning", "danger"]).or(z.enum(["default", "info"]));
+const density = z.enum(["comfortable", "compact"]);
+
+/**
+ * THE ADJECTIVES — accepted by every component, taught once in the prompt's
+ * preamble rather than restated 31 times. Both resolve to theme tokens only:
+ * `tone` to the palette, `density` to the host's own spacing ladder.
+ */
+const SHARED_PROPS: Readonly<Record<string, PropSpec>> = {
+  tone: config(tone, "emphasis — neutral | accent | success | warning | danger"),
+  density: config(density, "comfortable (default) or compact; set on a container it tightens everything inside"),
+  field: config(z.string(), "inside a cell slot: the row field this component reads"),
+};
+
+/** The shared adjectives' names, so `kitPrompt` can leave them out of every
+ *  component's prop list and teach them once. */
+export const KIT_SHARED_PROP_NAMES: readonly string[] = Object.keys(SHARED_PROPS);
 
 // ---- specs ---------------------------------------------------------------
-export const KIT_SPECS: KitComponentSpec[] = [
+const BASE_SPECS: KitComponentSpec[] = [
   // Layout
   {
     name: "Stack",
+    takesChildren: true,
     group: "layout",
     summary: "Vertical flow of children. The default container for a section.",
     props: { gap: config(z.number(), "pixels between children") },
@@ -38,6 +81,7 @@ export const KIT_SPECS: KitComponentSpec[] = [
   },
   {
     name: "Row",
+    takesChildren: true,
     group: "layout",
     summary: "Horizontal flow; wraps by default. Use for a row of stats or buttons.",
     props: {
@@ -50,12 +94,18 @@ export const KIT_SPECS: KitComponentSpec[] = [
   {
     name: "Grid",
     group: "layout",
-    summary: "Equal-width columns. Use for a grid of cards or stats.",
-    props: { columns: config(z.number().int().positive(), "column count"), gap: config(z.number(), "pixels between cells") },
-    examples: ["<Grid columns={3}><Stat .../><Stat .../><Stat .../></Grid>"],
+    summary: "Equal-width columns. A fixed count CLIPS its cells on a narrow screen rather than shrinking them, so a grid of stats sets minChildWidth and wraps; name columns only for a fixed layout.",
+    takesChildren: true,
+    props: {
+      columns: config(z.number().int().positive(), "column count (fixed layouts only)"),
+      minChildWidth: config(z.number().int().positive(), "auto-fit: narrowest a cell may get in px; cells wrap instead of clipping. 160 suits Stat tiles. Wins over columns"),
+      gap: config(z.number(), "pixels between cells"),
+    },
+    examples: ["<Grid minChildWidth={160}><Stat .../><Stat .../><Stat .../><Stat .../></Grid>"],
   },
   {
     name: "Surface",
+    takesChildren: true,
     group: "layout",
     summary: "A bordered, elevated container with an optional title.",
     props: { title: copy(z.string(), "container heading") },
@@ -63,12 +113,12 @@ export const KIT_SPECS: KitComponentSpec[] = [
   },
   {
     name: "Card",
+    takesChildren: true,
     group: "layout",
     summary: "A titled content block with an optional one-line description. Use it to label a region; Surface is the plain bordered container.",
     props: {
       title: copy(z.string(), "card heading"),
       description: copy(z.string(), "one-line subheading under the title"),
-      tone: config(z.enum(["default", "accent", "danger"]), "border emphasis"),
     },
     examples: ['<Card title="Overdue" description="Worst first"><DataTable rows={invoices.data} columns={[{key:"client"}]}/></Card>'],
   },
@@ -91,7 +141,7 @@ export const KIT_SPECS: KitComponentSpec[] = [
       // bit anyone while the legacy prewired Text shadowed this one with a
       // permissive `any` prop — retiring it (V4) made the over-tight schema
       // load-bearing and blocked the very common `<Text text={count}/>`.
-      text: copy(z.union([z.string(), z.number()]), "the text to show", { required: true }),
+      text: copy(z.union([z.string(), z.number()]), "the text to show"),
       variant: config(z.enum(["body", "heading", "caption", "label"]), "text role"),
     },
     examples: ['<Text text="This month" variant="heading"/>'],
@@ -101,7 +151,7 @@ export const KIT_SPECS: KitComponentSpec[] = [
     group: "values",
     summary: "Currency from an amount ALREADY in dollars. Formatters never convert units: a minor-unit (cents) field is divided by 100 where you read it.",
     props: {
-      amount: data(z.number(), "the amount in dollars (major units)", { required: true }),
+      amount: data(z.number(), "the amount in dollars (major units)"),
       currency: config(z.string(), "ISO 4217 code, default USD"),
     },
     examples: ["<Money amount={invoices.total({}).amountCents / 100}/>"],
@@ -111,7 +161,7 @@ export const KIT_SPECS: KitComponentSpec[] = [
     group: "values",
     summary: "A date/time from an ISO string, epoch millis, or Date. Invalid input renders a dash, never 'Invalid Date'.",
     props: {
-      value: data(z.union([z.string(), z.number()]), "ISO string or epoch millis", { required: true }),
+      value: data(z.union([z.string(), z.number()]), "ISO string or epoch millis"),
       mode: config(z.enum(["date", "time", "datetime", "relative"]), "how to render"),
     },
     examples: ['<DateTime value={invoice.dueDate} mode="date"/>', '<DateTime value={event.at} mode="relative"/>'],
@@ -121,7 +171,7 @@ export const KIT_SPECS: KitComponentSpec[] = [
     group: "values",
     summary: "A percentage from a ratio (0.42 → 42%). Pass whole=true for an already-whole percent.",
     props: {
-      value: data(z.number(), "a ratio 0..1", { required: true }),
+      value: data(z.number(), "a ratio 0..1"),
       fractionDigits: config(z.number().int().nonnegative(), "decimal places"),
       whole: config(z.boolean(), "value is already a whole percent"),
     },
@@ -132,7 +182,7 @@ export const KIT_SPECS: KitComponentSpec[] = [
     group: "values",
     summary: "A grouped number. Use notation=compact for large counts (1.5M).",
     props: {
-      value: data(z.number(), "the number", { required: true }),
+      value: data(z.number(), "the number"),
       notation: config(z.enum(["standard", "compact"]), "grouping style"),
       maximumFractionDigits: config(z.number().int().nonnegative(), "decimal places"),
     },
@@ -143,7 +193,7 @@ export const KIT_SPECS: KitComponentSpec[] = [
     group: "values",
     summary: "A status pill for an enum field. Humanizes the raw value (past_due → Past due) and tone-maps it.",
     props: {
-      value: data(z.string().nullable(), "the raw enum value", { required: true }),
+      value: data(z.string().nullable(), "the raw enum value"),
       labels: config(z.record(z.string(), z.string()), "value → display label overrides"),
       tones: config(z.record(z.string(), z.enum(["neutral", "accent", "success", "warning", "danger"])), "value → tone overrides"),
     },
@@ -154,10 +204,10 @@ export const KIT_SPECS: KitComponentSpec[] = [
   {
     name: "DataTable",
     group: "data",
-    summary: "The smart table. Sorts, filters, searches, paginates, resolves dot-path column keys, and formats each cell — you only pass rows and columns.",
+    summary: "The smart table. Sorts, filters, searches, paginates, resolves dot-path column keys, and formats each cell — you only pass rows and columns. A column's `cell` slot renders Kit value components against that row instead of plain text. Dates in cells are compact (\"Aug 12\"), and columns past the width the screen has FOLD into the first cell rather than scrolling out of sight — prefer few, richer columns.",
     props: {
       rows: data(rows, "rows from a tool call", { required: true }),
-      columns: config(z.array(tableColumn), "column descriptions; key supports dot-paths like client.name; format is a value tier token"),
+      columns: config(z.array(tableColumn), "column descriptions; key supports dot-paths like client.name; format is a value tier token; cell is a slot"),
       sortBy: config(z.string(), 'initial sort, e.g. "dueDate asc"'),
       limit: config(z.number().int().positive(), "hard cap on rows shown"),
       filterableBy: config(z.array(z.string()), "column keys to expose as filter dropdowns"),
@@ -167,18 +217,18 @@ export const KIT_SPECS: KitComponentSpec[] = [
       caption: copy(z.string(), "table caption"),
     },
     examples: [
-      '<DataTable rows={invoices.list({status:"overdue"}).data} sortBy="dueDate asc" limit={20} filterableBy={["client.name"]} columns={[{key:"client.name",label:"Client"},{key:"amount",format:"money",align:"end"},{key:"dueDate",format:"date"}]} emptyState="No overdue invoices"/>',
+      '<DataTable rows={invoices.list({status:"overdue"}).data} sortBy="dueDate asc" limit={20} columns={[{key:"client.name",label:"Client",cell:<Stack gap={2}><Text field="client.name"/><Text field="number" variant="caption"/></Stack>},{key:"amount",format:"money",align:"end"},{key:"dueDate",format:"date"},{key:"status",label:"Status",cell:<EnumBadge field="status" tones={{overdue:"danger",paid:"success"}}/>}]} emptyState="No overdue invoices"/>',
     ],
   },
   {
     name: "CardList",
     group: "data",
-    summary: "One branded card per record. Use when rows read better as cards than a table.",
+    summary: "One branded card per record. Use when rows read better as cards than a table. A field takes a `cell` slot, as a table column does.",
     props: {
       items: data(rows, "items from a tool call", { required: true }),
       titleField: config(z.string(), "field for each card title"),
       badgeField: config(z.string(), "field rendered as a status pill"),
-      fields: config(z.array(cardField), "label/value rows shown on each card"),
+      fields: config(z.array(cardField), "label/value rows on each card; cell is a slot"),
       columns: config(z.number().int().positive(), "cards per row"),
       emptyState: copy(z.string(), "text when there are no items"),
     },
@@ -187,13 +237,13 @@ export const KIT_SPECS: KitComponentSpec[] = [
   {
     name: "Stat",
     group: "data",
-    summary: "A KPI/metric summary. Formats its value (money takes dollars — divide a cents field by 100 where you read it) and shows an optional trend.",
+    summary: "A KPI/metric summary. Formats its value (money takes dollars — divide a cents field by 100 where you read it) and shows an optional trend. Kit value components nested inside render under the number.",
+    takesChildren: true,
     props: {
       label: copy(z.string(), "metric name", { required: true }),
       value: data(z.union([z.number(), z.string()]), "raw value", { required: true }),
       format: config(valueFormat, "value tier format"),
       trend: copy(z.string(), "delta caption, e.g. +12% MoM"),
-      tone: config(z.enum(["default", "accent", "danger"]), "emphasis"),
     },
     examples: ['<Stat label="Total overdue" value={invoices.total({}).amountCents / 100} format="money" trend="+12% MoM"/>'],
   },
@@ -201,7 +251,7 @@ export const KIT_SPECS: KitComponentSpec[] = [
     name: "Badge",
     group: "data",
     summary: "A small literal status label the model writes. For enum data fields use EnumBadge instead.",
-    props: { label: copy(z.string(), "badge text", { required: true }), tone: config(z.enum(["neutral", "accent", "success", "warning", "danger"]), "color tone") },
+    props: { label: copy(z.string(), "badge text") },
     examples: ['<Badge label="Beta" tone="accent"/>'],
   },
 
@@ -239,13 +289,14 @@ export const KIT_SPECS: KitComponentSpec[] = [
   {
     name: "DonutChart",
     group: "charts",
-    summary: "A donut/pie of category shares. Zero and invalid slices are dropped.",
+    summary: "A donut/pie of category shares. Zero and invalid slices are dropped. Every slice is named and valued in a legend under the ring, so set `format`.",
     props: {
       data: data(rows, "rows to plot", { required: true }),
       categoryKey: config(z.string(), "slice-label field", { required: true }),
       valueKey: config(z.string(), "slice-value field", { required: true }),
-      format: config(valueFormat, "tooltip format"),
+      format: config(valueFormat, "legend + tooltip format"),
       donut: config(z.boolean(), "false renders a full pie"),
+      legend: config(z.boolean(), "on by default; turn it off only when labels already sit beside the chart"),
       height: config(z.number().int().positive(), "chart height in px"),
       emptyState: copy(z.string(), "text when there is nothing to plot"),
     },
@@ -256,7 +307,7 @@ export const KIT_SPECS: KitComponentSpec[] = [
     group: "charts",
     summary: "A compact inline trend. Pass a number list or rows with a valueKey.",
     props: {
-      data: data(z.array(z.union([z.number(), z.record(z.string(), z.unknown())])), "numbers or rows", { required: true }),
+      data: data(z.array(z.union([z.number(), z.record(z.string(), z.unknown())])), "numbers or rows"),
       valueKey: config(z.string(), "field to read when data holds objects"),
       height: config(z.number().int().positive(), "height in px"),
     },
@@ -267,11 +318,10 @@ export const KIT_SPECS: KitComponentSpec[] = [
     group: "charts",
     summary: "A progress bar from a ratio (0..1) or value/max. Clamps to 100%.",
     props: {
-      value: data(z.number(), "ratio 0..1, or a raw value with max", { required: true }),
+      value: data(z.number(), "ratio 0..1, or a raw value with max"),
       max: data(z.number(), "denominator when value is raw"),
       label: copy(z.string(), "caption"),
       showValue: config(z.boolean(), "show the percentage"),
-      tone: config(z.enum(["accent", "success", "danger"]), "fill color"),
     },
     examples: ["<Progress value={goal.saved} max={goal.target} label=\"Savings goal\" showValue/>"],
   },
@@ -356,6 +406,7 @@ export const KIT_SPECS: KitComponentSpec[] = [
   },
   {
     name: "Form",
+    takesChildren: true,
     group: "forms",
     summary: "Groups fields with a submit action. `onSubmit` takes a function.",
     props: {
@@ -378,6 +429,7 @@ export const KIT_SPECS: KitComponentSpec[] = [
   // Feedback / interactive
   {
     name: "Tabs",
+    takesChildren: true,
     group: "feedback",
     summary: "Self-managing tabs. Name the tabs, then nest ONE child per tab in tab order — switching panels needs no handler and never leaves the page.",
     props: {
@@ -404,14 +456,10 @@ export const KIT_SPECS: KitComponentSpec[] = [
   },
   {
     name: "Callout",
+    takesChildren: true,
     group: "feedback",
     summary: "A toned info/accent/success/warning/danger notice highlighting real information. For 'no tool' honesty use Disclaimer.",
     props: {
-      // "accent" is first-class (re-gate 2026-07-26): the sibling tone
-      // vocabularies (Badge/EnumBadge/Stat/Progress) teach it, so generated
-      // code writes it whether or not this enum admits it — the spec and the
-      // ui component (@vendoai/ui kit/feedback/callout.tsx) must agree.
-      tone: config(z.enum(["info", "accent", "success", "warning", "danger"]), "notice tone"),
       title: copy(z.string(), "notice heading"),
     },
     examples: ['<Callout tone="warning" title="Heads up">Three invoices are overdue.</Callout>'],
@@ -428,12 +476,41 @@ export const KIT_SPECS: KitComponentSpec[] = [
   },
 ];
 
+/** Every spec, with the shared adjectives folded in — so validation, the wire's
+ *  allowed-prop set and the screen typings all admit `tone` and `density`
+ *  without 31 components restating them. */
+export const KIT_SPECS: KitComponentSpec[] = BASE_SPECS.map((spec) => ({
+  ...spec,
+  props: { ...spec.props, ...SHARED_PROPS },
+}));
+
 /**
  * THE component vocabulary — one list, derived from the specs, and the single
  * definition every other name here is a view of (the ui renderer maps them to
  * `KIT_COMPONENTS`). Nothing recomputes `KIT_SPECS.map(name)` a second time.
  */
 export const KIT_COMPONENT_NAMES: readonly string[] = KIT_SPECS.map((spec) => spec.name);
+
+/**
+ * What may be nested where — the two rules the renderer cannot state.
+ *
+ * The tree renderer hands `children` to EVERY node it renders
+ * (`packages/ui/src/tree/renderer.tsx` `builtinContent`), so a chart handed a
+ * child, or a Button dropped into a cell, has always rendered as nothing at
+ * all: the model wrote a control, the person got a blank, and no stage said a
+ * word. These two lists are what the checks floor refuses on.
+ */
+export const KIT_CHILDLESS_NAMES: readonly string[] = KIT_SPECS
+  .filter((spec) => spec.takesChildren !== true)
+  .map((spec) => spec.name);
+
+/** What a `cell` slot may hold: the value tier, plus the two arrangers. A cell
+ *  is read, never operated — an interactive control in one has no row to act
+ *  on and no room to be pressed. */
+export const KIT_SLOT_CONTENT_NAMES: readonly string[] = [
+  "Text", "Money", "DateTime", "Percent", "Num", "EnumBadge", "Badge", "Sparkline", "Progress",
+  "Stack", "Row",
+];
 
 /** The same list, as the mutable array `@vendoai/ui`'s registry wants. */
 export function kitComponentNames(): string[] {

--- a/packages/apps/src/contract/kit/specs.ts
+++ b/packages/apps/src/contract/kit/specs.ts
@@ -458,7 +458,7 @@ const BASE_SPECS: KitComponentSpec[] = [
     name: "Callout",
     takesChildren: true,
     group: "feedback",
-    summary: "A toned info/accent/success/warning/danger notice highlighting real information. For 'no tool' honesty use Disclaimer.",
+    summary: "A toned notice highlighting real information. For 'no tool' honesty use Disclaimer.",
     props: {
       title: copy(z.string(), "notice heading"),
     },

--- a/packages/apps/src/contract/screen.ts
+++ b/packages/apps/src/contract/screen.ts
@@ -34,6 +34,10 @@ export interface ScreenRequest {
   appId: AppId;
   /** The person's ask, verbatim — never a paraphrase. */
   request: string;
+  /** The surface this screen renders into, in CSS pixels, when the front door
+   *  knows it. Only the host can know it, and the writer can learn it from
+   *  nothing else it is handed. Absent claims nothing. */
+  viewport?: { width: number; height: number };
   /** Where a painted view goes. The same additive per-call hook
    *  `AppsRuntime.create` takes, so a screen and a built app reach the surface on
    *  one channel. */

--- a/packages/apps/src/contract/theme.ts
+++ b/packages/apps/src/contract/theme.ts
@@ -72,6 +72,35 @@ function relativeLuminance(color: string): number | null {
   return 0.2126 * r! + 0.7152 * g! + 0.0722 * b!;
 }
 
+/**
+ * The spacing scale one density implies, on its own.
+ *
+ * Split out of `themeCssVariables` because density is no longer only a
+ * page-level setting: a Kit container takes a `density` adjective and re-emits
+ * this same scale on its own element, so the compact table inside a comfortable
+ * page is the SAME compact the host would have got. One ladder, two callers —
+ * a second copy in the Kit would be a scale that drifts.
+ */
+export function densityCssVariables(density: VendoTheme["density"]): Record<string, string> {
+  const compact = density === "compact";
+  return {
+    "--vendo-density": density,
+    "--vendo-density-control-height": compact ? "32px" : "38px",
+    "--vendo-density-control-padding": compact ? "6px 10px" : "9px 12px",
+    "--vendo-density-card-padding": compact ? "12px" : "16px",
+    "--vendo-density-content-gap": compact ? "7px" : "10px",
+    "--vendo-density-inline-gap": compact ? "5px" : "7px",
+    "--vendo-density-field-gap": compact ? "4px" : "6px",
+    "--vendo-density-table-padding": compact ? "7px 10px" : "10px 12px",
+    "--vendo-density-badge-height": compact ? "20px" : "24px",
+    "--vendo-density-badge-padding": compact ? "3px 7px" : "5px 9px",
+    "--vendo-density-stat-padding": compact ? "9px 11px" : "12px 14px",
+    "--vendo-density-tabs-padding": compact ? "3px" : "4px",
+    "--vendo-density-tab-height": compact ? "26px" : "30px",
+    "--vendo-density-tab-padding": compact ? "4px 8px" : "6px 10px",
+  };
+}
+
 /** Flatten a theme into `--vendo-*` CSS custom properties. */
 export function themeCssVariables(theme: VendoTheme): Record<string, string> {
   const vars: Record<string, string> = {};
@@ -85,22 +114,8 @@ export function themeCssVariables(theme: VendoTheme): Record<string, string> {
   // so a host's baseSize scales the whole surface instead of only the root font.
   vars["--vendo-base-size"] = theme.typography.baseSize;
   for (const [key, value] of Object.entries(theme.radius)) vars[`--vendo-radius-${kebab(key)}`] = value;
-  vars["--vendo-density"] = theme.density;
+  Object.assign(vars, densityCssVariables(theme.density));
   vars["--vendo-motion"] = theme.motion;
-  const compact = theme.density === "compact";
-  vars["--vendo-density-control-height"] = compact ? "32px" : "38px";
-  vars["--vendo-density-control-padding"] = compact ? "6px 10px" : "9px 12px";
-  vars["--vendo-density-card-padding"] = compact ? "12px" : "16px";
-  vars["--vendo-density-content-gap"] = compact ? "7px" : "10px";
-  vars["--vendo-density-inline-gap"] = compact ? "5px" : "7px";
-  vars["--vendo-density-field-gap"] = compact ? "4px" : "6px";
-  vars["--vendo-density-table-padding"] = compact ? "7px 10px" : "10px 12px";
-  vars["--vendo-density-badge-height"] = compact ? "20px" : "24px";
-  vars["--vendo-density-badge-padding"] = compact ? "3px 7px" : "5px 9px";
-  vars["--vendo-density-stat-padding"] = compact ? "9px 11px" : "12px 14px";
-  vars["--vendo-density-tabs-padding"] = compact ? "3px" : "4px";
-  vars["--vendo-density-tab-height"] = compact ? "26px" : "30px";
-  vars["--vendo-density-tab-padding"] = compact ? "4px 8px" : "6px 10px";
   vars["--vendo-motion-duration"] = theme.motion === "reduced" ? "0ms" : "160ms";
   vars["--vendo-motion-easing"] = "cubic-bezier(0.2, 0.8, 0.2, 1)";
   return vars;

--- a/packages/apps/src/server/checking/component-screen.ts
+++ b/packages/apps/src/server/checking/component-screen.ts
@@ -55,7 +55,7 @@ import {
   type ScreenErrorKind,
 } from "../../contract/genui/component/index.js";
 import { isMutatingTool, type HostToolInfo } from "./deps.js";
-import { catalogIssues, factIssueLine } from "./facts.js";
+import { catalogIssues, factIssueLine, kitNestingIssues } from "./facts.js";
 import { sampleLines } from "./reviewer.js";
 import { list, QUERY_HOOK } from "./screen-typecheck.js";
 import {
@@ -696,7 +696,9 @@ export function screenName(source: string): string {
  *  vocabulary and nothing else — its props were the type check's business.
  *
  *  A text run is the engine's own node kind, not a component anybody registered,
- *  so it is not measured against the catalog. */
+ *  so it is not measured against the catalog — but it IS a child, so the nesting
+ *  rule reads the tree whole: text nested in a component that renders no
+ *  children is the same blank as a node nested there. */
 const treeCheckIssues = async (
   flat: FlatTree,
   catalog: readonly string[],
@@ -713,7 +715,10 @@ const treeCheckIssues = async (
     undefined,
     normalized,
   );
-  return found.map((entry) => issue("tree", factIssueLine(entry)));
+  return [
+    ...kitNestingIssues(validation.tree).map((entry) => issue("nesting", factIssueLine(entry))),
+    ...found.map((entry) => issue("tree", factIssueLine(entry))),
+  ];
 };
 
 // ---- the reviewer's input -------------------------------------------------

--- a/packages/apps/src/server/checking/facts.ts
+++ b/packages/apps/src/server/checking/facts.ts
@@ -427,12 +427,13 @@ const CHILDLESS: ReadonlySet<string> = new Set(KIT_CHILDLESS_NAMES);
 const SLOT_CONTENT: ReadonlySet<string> = new Set(KIT_SLOT_CONTENT_NAMES);
 
 /** A Kit element sitting in a PROP — what a `cell` slot holds. The screen VM
- *  serializes one as the node shape it stamps `$element`
- *  (genui/component/vm-program.ts `emitValue`); either mark reads as an element,
- *  so a data row that merely carries a "component" column is not mistaken for
- *  one. */
-const asElement = (value: unknown): { component: string; children?: unknown } | undefined =>
-  isRecord(value) && typeof value.component === "string" && (value.$element === true || Array.isArray(value.children))
+ *  stamps the SLOT's own element `$element` and leaves the ones nested under it
+ *  bare (genui/component/vm-program.ts `emitValue`), and the renderer reifies on
+ *  exactly that (`packages/ui` renderer.tsx `reifyElement`) — so this reads the
+ *  sigil at the slot and a `component` name below it, and a data row that merely
+ *  carries a "component" field is never mistaken for an element. */
+const asElement = (value: unknown, sigil: boolean): { component: string; children?: unknown } | undefined =>
+  isRecord(value) && typeof value.component === "string" && (!sigil || value.$element === true)
     ? (value as { component: string; children?: unknown })
     : undefined;
 
@@ -456,14 +457,14 @@ export const kitNestingIssues = (tree: Tree): FactIssue[] => {
 
   /** One `cell` slot: the element it holds, and every element nested in that
    *  one. */
-  const checkSlot = (nodeId: string, path: string, value: unknown): void => {
-    const element = asElement(value);
+  const checkSlot = (nodeId: string, path: string, value: unknown, sigil = true): void => {
+    const element = asElement(value, sigil);
     if (element === undefined) return;
     if (!SLOT_CONTENT.has(element.component)) {
       issues.push(atProp(nodeId, path, `holds <${element.component}> in a cell slot — a cell is read, never operated: the slot is written ONCE and rendered for every row, so nothing in it has a row of its own to act on. A cell may hold: ${KIT_SLOT_CONTENT_NAMES.join(", ")} — each reading its row's value with field="…". Anything else belongs beside the table, not in it.`));
     }
     if (Array.isArray(element.children)) {
-      element.children.forEach((child, index) => checkSlot(nodeId, `${path}.children[${index}]`, child));
+      element.children.forEach((child, index) => checkSlot(nodeId, `${path}.children[${index}]`, child, false));
     }
   };
 

--- a/packages/apps/src/server/checking/facts.ts
+++ b/packages/apps/src/server/checking/facts.ts
@@ -22,6 +22,8 @@ import {
   type TreeNode,
 } from "@vendoai/core";
 import {
+  KIT_CHILDLESS_NAMES,
+  KIT_SLOT_CONTENT_NAMES,
   KIT_WIRE_COMPONENT_NAMES,
   WIRE_COMPONENT_NAMES,
   checkBindingShapes,
@@ -421,6 +423,77 @@ export const catalogIssues = async (
   return issues;
 };
 
+const CHILDLESS: ReadonlySet<string> = new Set(KIT_CHILDLESS_NAMES);
+const SLOT_CONTENT: ReadonlySet<string> = new Set(KIT_SLOT_CONTENT_NAMES);
+
+/** A Kit element sitting in a PROP — what a `cell` slot holds. The screen VM
+ *  serializes one as the node shape it stamps `$element`
+ *  (genui/component/vm-program.ts `emitValue`); either mark reads as an element,
+ *  so a data row that merely carries a "component" column is not mistaken for
+ *  one. */
+const asElement = (value: unknown): { component: string; children?: unknown } | undefined =>
+  isRecord(value) && typeof value.component === "string" && (value.$element === true || Array.isArray(value.children))
+    ? (value as { component: string; children?: unknown })
+    : undefined;
+
+/**
+ * What may be nested where — the rule the RENDERER cannot state. The tree
+ * renderer hands `children` to every node it renders (`packages/ui`
+ * renderer.tsx `builtinContent`), so a chart handed a child, or a Button
+ * dropped into a table cell, has always painted as nothing at all: the model
+ * wrote a control, the person got a blank, and no stage said a word.
+ *
+ * One function, both artifacts: a wire tree and the tree a `.tsx` screen paints
+ * are the same tree and reach the same renderer, so this is a check in the wire
+ * floor (`kit-nesting`) and a stage of the component-screen gauntlet
+ * (`nesting`), never two implementations that could disagree.
+ *
+ * A `host`/`generated` node is somebody else's implementation, which may nest
+ * whatever it likes — only a name the renderer resolves to the Kit is measured.
+ */
+export const kitNestingIssues = (tree: Tree): FactIssue[] => {
+  const issues: FactIssue[] = [];
+
+  /** One `cell` slot: the element it holds, and every element nested in that
+   *  one. */
+  const checkSlot = (nodeId: string, path: string, value: unknown): void => {
+    const element = asElement(value);
+    if (element === undefined) return;
+    if (!SLOT_CONTENT.has(element.component)) {
+      issues.push(atProp(nodeId, path, `holds <${element.component}> in a cell slot — a cell is read, never operated: the slot is written ONCE and rendered for every row, so nothing in it has a row of its own to act on. A cell may hold: ${KIT_SLOT_CONTENT_NAMES.join(", ")} — each reading its row's value with field="…". Anything else belongs beside the table, not in it.`));
+    }
+    if (Array.isArray(element.children)) {
+      element.children.forEach((child, index) => checkSlot(nodeId, `${path}.children[${index}]`, child));
+    }
+  };
+
+  /** The `cell` slots inside one prop — a column/field description carries one,
+   *  and the descriptions are an array. */
+  const findSlots = (nodeId: string, path: string, key: string, value: unknown): void => {
+    if (key === "cell") {
+      checkSlot(nodeId, path, value);
+      return;
+    }
+    if (Array.isArray(value)) {
+      value.forEach((item, index) => findSlots(nodeId, `${path}[${index}]`, "", item));
+      return;
+    }
+    if (isRecord(value)) {
+      for (const [name, item] of Object.entries(value)) findSlots(nodeId, `${path}.${name}`, name, item);
+    }
+  };
+
+  for (const node of tree.nodes) {
+    if (node.source === "host" || node.source === "generated") continue;
+    const nested = node.children?.length ?? 0;
+    if (nested > 0 && CHILDLESS.has(node.component)) {
+      issues.push(atNode(node.id, `nests ${nested === 1 ? "1 node" : `${nested} nodes`} inside <${node.component}>, which renders nothing nested inside it: that content never reaches the screen. Put it beside <${node.component}> in a <Stack>, or give <${node.component}> what it showed through its own props.`));
+    }
+    for (const [prop, value] of Object.entries(node.props ?? {})) findSlots(node.id, prop, prop, value);
+  }
+  return issues;
+};
+
 /** A query naming a tool the host does not have. The message lists the real
  *  ones — a model reading it can pick, and a human reading it learns the
  *  surface. `fn:` queries are the app's own server code, not host tools. */
@@ -568,6 +641,7 @@ export const factChecks = (deps: FloorDependencies): Check[] => [
     ...kitSlotIssues(tree, deps),
     ...hostReshapeIssues(tree, deps),
   ]),
+  treeCheck("kit-nesting", (tree) => kitNestingIssues(tree)),
   treeCheck("expressions-compute", (tree) => exprIssues(tree)),
   treeCheck("query-inputs-literal", (tree) => queryInputIssues(tree)),
   treeCheck("no-string-interpolation", (tree) => interpolationIssues(tree)),

--- a/packages/apps/tests/checking/component-screen.test.ts
+++ b/packages/apps/tests/checking/component-screen.test.ts
@@ -848,6 +848,113 @@ export default function Everything() {
     expect(text).toContain("the rendered screen is not a valid tree");
     expect(text).toContain("too many nodes (max 5000)");
   });
+
+  /** Wide enough to write a chart, a table and a slot. Its own list because the
+   *  shared catalog is pinned verbatim by the sentences that enumerate it. */
+  const kitCatalog = [...catalog, "Badge", "DataTable", "EnumBadge", "LineChart", "Sparkline", "Stat"];
+
+  const painted = async (source: string): Promise<ComponentScreenCheck> =>
+    checkComponentScreen({ source, hostTools: tools, catalog: kitCatalog, runQuery: async () => ROWS });
+
+  it("refuses a node nested inside a component that renders no children", async () => {
+    // The renderer hands `children` to every node it renders, so this caption
+    // has always painted as nothing: the model wrote it, the person got a blank.
+    const result = await painted(`import { LineChart, Stack, Text } from "@vendo/screen";
+
+export default function Trend() {
+  return (
+    <Stack>
+      <LineChart data={[{ month: "Jan", amount: 1 }]} xKey="month" series={["amount"]}>
+        <Text text="Scheduled outflow" />
+      </LineChart>
+    </Stack>
+  );
+}
+`);
+
+    expect(result.ok).toBe(false);
+    expect(result.issues.map(({ code }) => code)).toEqual(["nesting"]);
+    const message = result.issues[0]?.message ?? "";
+    expect(message).toContain("nests 1 node inside <LineChart>, which renders nothing nested inside it");
+    expect(message).toContain("that content never reaches the screen");
+    // …and it says where the caption goes instead.
+    expect(message).toContain("Put it beside <LineChart> in a <Stack>, or give <LineChart> what it showed through its own props.");
+  });
+
+  it("counts a run of text as nesting too — a blank is a blank", async () => {
+    const result = await painted(`import { Badge, Stack } from "@vendo/screen";
+
+export default function Label() {
+  return <Stack><Badge label="Beta">and a note</Badge></Stack>;
+}
+`);
+
+    expect(result.issues.map(({ code }) => code)).toEqual(["nesting"]);
+    expect(result.issues[0]?.message).toContain("nests 1 node inside <Badge>");
+  });
+
+  it("refuses a control in a cell slot, and names what a cell may hold", async () => {
+    const result = await painted(`import { Button, DataTable, tools } from "@vendo/screen";
+
+export default function Ledger() {
+  return (
+    <DataTable
+      rows={[{ id: "tr_1", status: "paid" }]}
+      columns={[{ key: "status", cell: <Button label="Cancel" onClick={() => tools.cancel_transfer({ id: "tr_1" })} /> }]}
+    />
+  );
+}
+`);
+
+    expect(result.ok).toBe(false);
+    expect(result.issues.map(({ code }) => code)).toEqual(["nesting"]);
+    const message = result.issues[0]?.message ?? "";
+    // The locus is the column the control sits in, not just the table.
+    expect(message).toContain('prop "columns[0].cell" holds <Button> in a cell slot');
+    expect(message).toContain("a cell is read, never operated");
+    expect(message).toContain("A cell may hold: Text, Money, DateTime, Percent, Num, EnumBadge, Badge, Sparkline, Progress, Stack, Row");
+  });
+
+  it("follows a control nested INSIDE a legal slot component", async () => {
+    const result = await painted(`import { Button, DataTable, Stack, Text, tools } from "@vendo/screen";
+
+export default function Ledger() {
+  return (
+    <DataTable
+      rows={[{ id: "tr_1", status: "paid" }]}
+      columns={[{ key: "status", cell: <Stack><Text field="status" /><Button label="Cancel" onClick={() => tools.cancel_transfer({ id: "tr_1" })} /></Stack> }]}
+    />
+  );
+}
+`);
+
+    expect(result.issues.map(({ code }) => code)).toEqual(["nesting"]);
+    expect(result.issues[0]?.message).toContain('prop "columns[0].cell.children[1]" holds <Button> in a cell slot');
+  });
+
+  it("passes a legal slot and a legal nest — the rule is not a blanket ban", async () => {
+    // The negative case is what proves it: a value component in a cell reads its
+    // row by name, and <Stat> is one of the components that DOES render children.
+    const result = await painted(`import { DataTable, EnumBadge, Sparkline, Stack, Stat } from "@vendo/screen";
+
+export default function Ledger() {
+  return (
+    <Stack>
+      <Stat label="Paid" value={12}>
+        <Sparkline data={[1, 2, 3]} />
+      </Stat>
+      <DataTable
+        rows={[{ id: "tr_1", status: "paid" }]}
+        columns={[{ key: "status", cell: <EnumBadge field="status" /> }]}
+      />
+    </Stack>
+  );
+}
+`);
+
+    expect(result.issues).toEqual([]);
+    expect(result.ok).toBe(true);
+  });
 });
 
 describe("screenCatalog", () => {

--- a/packages/apps/tests/checking/component-screen.test.ts
+++ b/packages/apps/tests/checking/component-screen.test.ts
@@ -932,6 +932,28 @@ export default function Ledger() {
     expect(result.issues[0]?.message).toContain('prop "columns[0].cell.children[1]" holds <Button> in a cell slot');
   });
 
+  it("reads the sigil, not the shape — row data that describes a component is data", async () => {
+    // A "cell" column whose value happens to name a component and carry a
+    // children list. The VM stamps `$element` on what a screen wrote as an
+    // ELEMENT and on nothing else, and the renderer reifies on exactly that
+    // sigil — so this paints as text, and refusing it as a mis-nested cell
+    // would block an app over data the rule never governs.
+    const result = await painted(`import { DataTable } from "@vendo/screen";
+
+export default function Inventory() {
+  return (
+    <DataTable
+      rows={[{ id: "r1", cell: { component: "Button", children: [] } }]}
+      columns={[{ key: "id" }]}
+    />
+  );
+}
+`);
+
+    expect(result.issues).toEqual([]);
+    expect(result.ok).toBe(true);
+  });
+
   it("passes a legal slot and a legal nest — the rule is not a blanket ban", async () => {
     // The negative case is what proves it: a value component in a cell reads its
     // row by name, and <Stat> is one of the components that DOES render children.

--- a/packages/apps/tests/checking/floor.test.ts
+++ b/packages/apps/tests/checking/floor.test.ts
@@ -65,6 +65,11 @@ const BAD = '<App name="Invoices"><Query id="invoices" tool="host_wireMoney"/><S
  *  the caption inside the chart paints as nothing at all. */
 const NESTED = '<App name="Invoices"><Query id="invoices" tool="host_listInvoices"/><Stack gap={12}><LineChart data={invoices.data} xKey="id" series={["amount"]}><Text text="Legend"/></LineChart></Stack></App>';
 
+/** A shared adjective on a component that does not read it. `tone` paints
+ *  nothing on a table: the prop validates, the renderer drops it, and the model
+ *  is told it succeeded — the silent drop the prop-name gate turns into a block. */
+const DEAF = '<App name="Invoices"><Query id="invoices" tool="host_listInvoices"/><Stack><DataTable rows={invoices.data} tone="danger"/></Stack></App>';
+
 const inputFor = (wire: string, request = "show me my invoices"): CheckInput =>
   ({ document: documentFrom(wire), request });
 
@@ -159,6 +164,17 @@ describe("the floor holds regardless of the builder", () => {
       where: 'node "linechart-1"',
       message: "nests 1 node inside <LineChart>, which renders nothing nested inside it: that content never reaches the screen. Put it beside <LineChart> in a <Stack>, or give <LineChart> what it showed through its own props.",
       check: "kit-nesting",
+    });
+  });
+
+  it("blocks a shared adjective on a component that does not read it", async () => {
+    const findings = await createCheckingLayer({ deps: deps() }).run(inputFor(DEAF));
+
+    expect(findings).toContainEqual({
+      severity: "block",
+      where: 'node "datatable-1"',
+      message: expect.stringContaining('sets unknown prop "tone" on prewired component "DataTable"'),
+      check: "components-exist",
     });
   });
 

--- a/packages/apps/tests/checking/floor.test.ts
+++ b/packages/apps/tests/checking/floor.test.ts
@@ -61,6 +61,10 @@ const GOOD = '<App name="Invoices"><Query id="invoices" tool="host_listInvoices"
 /** A deliberately bad app: it names a tool the host does not have. */
 const BAD = '<App name="Invoices"><Query id="invoices" tool="host_wireMoney"/><Stack><DataTable rows={invoices.data}/></Stack></App>';
 
+/** Nests a node under a chart. The renderer hands `children` to every node, so
+ *  the caption inside the chart paints as nothing at all. */
+const NESTED = '<App name="Invoices"><Query id="invoices" tool="host_listInvoices"/><Stack gap={12}><LineChart data={invoices.data} xKey="id" series={["amount"]}><Text text="Legend"/></LineChart></Stack></App>';
+
 const inputFor = (wire: string, request = "show me my invoices"): CheckInput =>
   ({ document: documentFrom(wire), request });
 
@@ -142,6 +146,19 @@ describe("the floor holds regardless of the builder", () => {
       where: 'query "invoices"',
       message: 'names unknown tool "host_wireMoney"; the host tools are: host_listInvoices',
       check: "tools-exist",
+    });
+  });
+
+  it("blocks a node nested inside a component that renders no children", async () => {
+    // The silent-breakage class this rule exists for: the model wrote a caption,
+    // the person got a blank, and nothing said a word.
+    const findings = await createCheckingLayer({ deps: deps() }).run(inputFor(NESTED));
+
+    expect(findings).toContainEqual({
+      severity: "block",
+      where: 'node "linechart-1"',
+      message: "nests 1 node inside <LineChart>, which renders nothing nested inside it: that content never reaches the screen. Put it beside <LineChart> in a <Stack>, or give <LineChart> what it showed through its own props.",
+      check: "kit-nesting",
     });
   });
 

--- a/packages/apps/tests/checking/screen-typings.test.ts
+++ b/packages/apps/tests/checking/screen-typings.test.ts
@@ -59,12 +59,21 @@ describe("screenTypings", () => {
 
   it("carries the Kit's zod prop types, not just its prop names", () => {
     const dts = screenTypings({ catalog: [], queries: [] });
-    // Money.amount is a REQUIRED number of DOLLARS (data class); currency an
-    // optional string. Every prop also admits VendoBinding — see the
-    // unresolvable-binding test below.
-    expect(dts).toContain("declare const Money: (props: { amount: number | VendoBinding; currency?: string | VendoBinding;");
+    // Money.amount is a number of DOLLARS (data class); currency an optional
+    // string. Every prop also admits VendoBinding — see the unresolvable-binding
+    // test below. `amount` is optional since the cell slots landed: a value
+    // component inside a cell takes its value from `field`, so a required
+    // `amount` would make the slot the catalog teaches unwritable.
+    expect(dts).toContain("declare const Money: (props: { amount?: number | VendoBinding; currency?: string | VendoBinding;");
+    // Required is still required where it is load-bearing — a table with no rows
+    // is nothing at all, and that is what pins the marker itself.
+    expect(dts).toContain("declare const DataTable: (props: { rows: Array<Record<string, any>> | VendoBinding;");
     // Stat.format is an enum — the literal union is what makes format=\"huge\" a type error.
     expect(dts).toContain('format?: "money" | "date" | "datetime" | "time" | "percent" | "number" | "text"');
+    // A cell slot holds an ELEMENT, which no schema describes — `any` is its
+    // faithful type, and without it the catalog's own DataTable example would
+    // not compile.
+    expect(dts).toContain("cell?: any }> | VendoBinding");
   });
 
   /**
@@ -82,10 +91,9 @@ describe("screenTypings", () => {
   it("admits an unresolvable binding literal in any typed prop slot", () => {
     const dts = screenTypings({ catalog, queries: [] });
     expect(dts).toContain("declare type VendoBinding = { $path: string } | { $state: string } | { $expr: string };");
-    // The exact slot the regression hit — Text.text, a REQUIRED string | number,
-    // which is where a missing-prop error anchors on the tag rather than the
-    // attribute (so no checker-side suppression could have caught every spelling).
-    expect(dts).toContain("text: string | number | VendoBinding");
+    // The exact slot the regression hit — Text.text, a string | number (optional
+    // since the cell slots landed, where `field` supplies it instead).
+    expect(dts).toContain("text?: string | number | VendoBinding");
     // An enum slot keeps its literal union — format="huge" is still a type error.
     expect(dts).toContain('format?: "money" | "date" | "datetime" | "time" | "percent" | "number" | "text" | VendoBinding');
   });

--- a/packages/apps/tests/contract/genui/component/screen-fixture.test-util.ts
+++ b/packages/apps/tests/contract/genui/component/screen-fixture.test-util.ts
@@ -21,6 +21,7 @@ export const compileScreen = (tsx: string): string =>
 /** The Kit names a host surface holds, as the engine receives them. */
 export const CATALOG: readonly string[] = [
   "Stack", "Row", "Card", "Text", "Money", "DateTime", "Button", "Input", "Checkbox", "Callout", "Accordion", "DataTable",
+  "EnumBadge",
 ];
 
 export const bootTsx = (

--- a/packages/apps/tests/contract/genui/component/screen.test.ts
+++ b/packages/apps/tests/contract/genui/component/screen.test.ts
@@ -122,8 +122,43 @@ export default function S() {
 }`);
     try {
       expect(screen.tree().props.items).toEqual([
-        { label: "Terms", content: { component: "Text", props: { text: "the terms" }, children: [] } },
+        { label: "Terms", content: { $element: true, component: "Text", props: { text: "the terms" }, children: [] } },
       ]);
+    } finally {
+      screen.dispose();
+    }
+  });
+
+  it("stamps $element on a prop's element, and on no other node", () => {
+    // The sigil is the WHOLE difference between a cell slot and a data object on
+    // the read side (ui/tree/renderer.tsx binds on it), so it belongs to a prop's
+    // element only — a painted node arrives where a node already belongs.
+    const screen = bootTsx(`
+import { DataTable, EnumBadge, Row, Text } from "@vendo/screen";
+export default function S() {
+  return (
+    <DataTable
+      rows={[{ id: "tr_1", status: "in_review" }]}
+      columns={[
+        { key: "status", cell: <Row gap={4}><EnumBadge field="status" />flagged</Row> },
+      ]}
+    />
+  );
+}`);
+    try {
+      const tree = screen.tree();
+      expect(tree.component).toBe("DataTable");
+      expect(tree).not.toHaveProperty("$element");
+      expect((tree.props.columns as Array<Record<string, unknown>>)[0]).toEqual({
+        key: "status",
+        cell: {
+          $element: true,
+          component: "Row",
+          props: { gap: 4 },
+          // Nested elements are the slot's own children, not further props.
+          children: [{ component: "EnumBadge", props: { field: "status" }, children: [] }, "flagged"],
+        },
+      });
     } finally {
       screen.dispose();
     }

--- a/packages/apps/tests/contract/kit/kit-prompt.test.ts
+++ b/packages/apps/tests/contract/kit/kit-prompt.test.ts
@@ -26,11 +26,14 @@ describe("kitPrompt() — the generated model-facing Kit section", () => {
     expect(prompt).toContain("- `sortBy` [config] — initial sort");
   });
 
-  // The two adjectives are on every component's props so validation and the
-  // screen typings admit them everywhere — and they are taught ONCE, in the
+  // Each adjective is on the props of the components that READ it, so validation
+  // and the screen typings admit it there — and it is taught ONCE, in the
   // preamble, because 31 restatements would cost a fifth of the catalog.
   it("teaches tone and density in the preamble and never in a component's prop list", () => {
-    expect(kitPrompt()).toContain("Two adjectives, on every component");
+    const preamble = kitPrompt();
+    expect(preamble).toContain("Two adjectives.");
+    // …and the preamble no longer claims them for components that drop them.
+    expect(preamble).not.toContain("on every component");
     for (const name of ["DataTable", "Stat", "Card", "Divider"]) {
       const scoped = kitPrompt({ only: [name], omitPreamble: true });
       expect(scoped).not.toContain("- `tone`");

--- a/packages/apps/tests/contract/kit/kit-prompt.test.ts
+++ b/packages/apps/tests/contract/kit/kit-prompt.test.ts
@@ -16,10 +16,26 @@ describe("kitPrompt() — the generated model-facing Kit section", () => {
     expect(kitPrompt({ omitPreamble: true })).not.toContain("# The Kit");
   });
 
+  // Money's `amount` used to be the required one here. It is optional now: a
+  // value component in a cell slot takes its value from `field`, so demanding
+  // `amount` would make the slot unwritable. DataTable's `rows` is the example
+  // instead — a table with no rows is nothing at all.
   it("renders a prop as `name` [class] (required) — doc, and omits the marker when optional", () => {
-    const prompt = kitPrompt({ only: ["Money"] });
-    expect(prompt).toContain("- `amount` [data] (required) — the amount in dollars (major units)");
-    expect(prompt).toContain("- `currency` [config] — ISO 4217 code, default USD");
+    const prompt = kitPrompt({ only: ["DataTable"] });
+    expect(prompt).toContain("- `rows` [data] (required) — rows from a tool call");
+    expect(prompt).toContain("- `sortBy` [config] — initial sort");
+  });
+
+  // The two adjectives are on every component's props so validation and the
+  // screen typings admit them everywhere — and they are taught ONCE, in the
+  // preamble, because 31 restatements would cost a fifth of the catalog.
+  it("teaches tone and density in the preamble and never in a component's prop list", () => {
+    expect(kitPrompt()).toContain("Two adjectives, on every component");
+    for (const name of ["DataTable", "Stat", "Card", "Divider"]) {
+      const scoped = kitPrompt({ only: [name], omitPreamble: true });
+      expect(scoped).not.toContain("- `tone`");
+      expect(scoped).not.toContain("- `density`");
+    }
   });
 
   it("labels the example block for its count", () => {

--- a/packages/apps/tests/contract/kit/specs.test.ts
+++ b/packages/apps/tests/contract/kit/specs.test.ts
@@ -16,14 +16,37 @@ import {
  * the screen typings all read the specs, so a prop that lives only in the
  * preamble prose is a prop the model cannot use.
  */
+/** Who READS each shared adjective — pinned here because the cost of getting it
+ *  wrong is invisible: attached to a component that ignores it, the prop
+ *  validates and the renderer drops it, which is the silent failure the whole
+ *  prop-name gate exists to turn into a blocking error. */
+const READERS: Record<string, readonly string[]> = {
+  tone: ["Text", "Money", "DateTime", "Percent", "Num", "EnumBadge", "Badge", "Sparkline", "Progress", "Stat", "Card", "Surface", "Callout"],
+  density: ["Stack", "Row", "Grid", "Surface", "Card", "DataTable", "CardList", "Stat"],
+  field: ["Text", "Money", "DateTime", "Percent", "Num", "EnumBadge", "Badge", "Sparkline", "Progress"],
+};
+
 describe("the Kit specs", () => {
-  it("carries the shared adjectives on every component, as config", () => {
+  it("carries each shared adjective on the components that read it, as config, and on no others", () => {
+    expect(Object.keys(READERS)).toEqual([...KIT_SHARED_PROP_NAMES]);
     for (const spec of KIT_SPECS) {
-      for (const name of KIT_SHARED_PROP_NAMES) {
-        expect(spec.props[name], `${spec.name}.${name}`).toBeDefined();
-        expect(kitPropClasses(spec.name)?.[name]).toBe("config");
+      for (const [name, readers] of Object.entries(READERS)) {
+        const reads = readers.includes(spec.name);
+        expect(spec.props[name] !== undefined, `${spec.name}.${name}`).toBe(reads);
+        if (reads) expect(kitPropClasses(spec.name)?.[name]).toBe("config");
       }
     }
+  });
+
+  it("leaves an adjective the component would only drop OUT of its allowed props", () => {
+    // The refusal is by NAME, not by value: zod strips an unknown key rather
+    // than failing it, so what turns `<DataTable tone="danger">` into a blocking
+    // error is its absence from the allowed-prop set the floor reads
+    // (`kitPropClasses` → wirePropNames → the `components-exist` check, pinned
+    // end to end in tests/checking/floor.test.ts).
+    expect(kitPropClasses("DataTable")?.tone).toBeUndefined();
+    expect(kitPropClasses("Divider")?.density).toBeUndefined();
+    expect(kitPropClasses("LineChart")?.field).toBeUndefined();
   });
 
   it("admits the whole tone vocabulary, and the two spellings stored apps carry", () => {

--- a/packages/apps/tests/contract/kit/specs.test.ts
+++ b/packages/apps/tests/contract/kit/specs.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { validateProps } from "../../../src/contract/kit/schema.js";
+import {
+  KIT_CHILDLESS_NAMES,
+  KIT_SHARED_PROP_NAMES,
+  KIT_SLOT_CONTENT_NAMES,
+  KIT_SPECS,
+  kitPropClasses,
+  kitSpec,
+} from "../../../src/contract/kit/specs.js";
+
+/**
+ * The Kit's own contract — the half `kitPrompt` does NOT render. The adjectives
+ * and the cell slot only work if every consumer sees them: the wire's
+ * allowed-prop set (`kitPropClasses`), runtime validation (`validateProps`) and
+ * the screen typings all read the specs, so a prop that lives only in the
+ * preamble prose is a prop the model cannot use.
+ */
+describe("the Kit specs", () => {
+  it("carries the shared adjectives on every component, as config", () => {
+    for (const spec of KIT_SPECS) {
+      for (const name of KIT_SHARED_PROP_NAMES) {
+        expect(spec.props[name], `${spec.name}.${name}`).toBeDefined();
+        expect(kitPropClasses(spec.name)?.[name]).toBe("config");
+      }
+    }
+  });
+
+  it("admits the whole tone vocabulary, and the two spellings stored apps carry", () => {
+    const stat = kitSpec("Stat")!;
+    for (const tone of ["neutral", "accent", "success", "warning", "danger", "default", "info"]) {
+      expect(validateProps(stat, { label: "Open", value: 1, tone }).success, tone).toBe(true);
+    }
+    expect(validateProps(stat, { label: "Open", value: 1, tone: "chartreuse" }).success).toBe(false);
+  });
+
+  it("admits a density only from the host theme's own vocabulary", () => {
+    const table = kitSpec("DataTable")!;
+    expect(validateProps(table, { rows: [], density: "compact" }).success).toBe(true);
+    expect(validateProps(table, { rows: [], density: "cramped" }).success).toBe(false);
+  });
+
+  // A slot holds an ELEMENT, so the schema cannot describe it — the same
+  // `z.unknown()` Accordion's `content` uses. What IS pinned is that a column
+  // may carry one at all, and that the rest of the column stays typed.
+  it("lets a table column and a card field carry a cell slot", () => {
+    const table = kitSpec("DataTable")!;
+    const cell = { $element: true, component: "EnumBadge", props: { field: "status" } };
+    expect(validateProps(table, { rows: [], columns: [{ key: "status", cell }] }).success).toBe(true);
+    expect(validateProps(table, { rows: [], columns: [{ key: 1 }] }).success).toBe(false);
+    const cards = kitSpec("CardList")!;
+    expect(validateProps(cards, { items: [], fields: [{ key: "plan", cell }] }).success).toBe(true);
+  });
+
+  it("names the childless components and what a cell may hold", () => {
+    // The renderer hands children to every node it renders, so "renders no
+    // children" is a fact only the spec can state.
+    expect(KIT_CHILDLESS_NAMES).toContain("LineChart");
+    expect(KIT_CHILDLESS_NAMES).toContain("DataTable");
+    for (const container of ["Stack", "Row", "Grid", "Surface", "Card", "Tabs", "Callout", "Form", "Stat"]) {
+      expect(KIT_CHILDLESS_NAMES, container).not.toContain(container);
+    }
+    // A cell is read, never operated.
+    expect(KIT_SLOT_CONTENT_NAMES).toContain("EnumBadge");
+    expect(KIT_SLOT_CONTENT_NAMES).not.toContain("Button");
+    expect(KIT_SLOT_CONTENT_NAMES).not.toContain("DataTable");
+  });
+});

--- a/packages/ui/src/kit/aggregates.ts
+++ b/packages/ui/src/kit/aggregates.ts
@@ -20,23 +20,13 @@ import {
   type Json,
   type NumericReduction,
 } from "@vendoai/core";
+import { readField } from "./row.js";
 
 const isRow = (value: unknown): value is Record<string, Json> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
 const rowsOf = (value: Json | undefined): Record<string, Json>[] | undefined =>
   Array.isArray(value) ? value.filter(isRow) : undefined;
-
-/** A dotted field path off one row. Mirrors the reference grammar a screen
- *  writes (`row.progress.total`), so a nested numeric field reduces too. */
-const at = (row: Record<string, Json>, field: string): Json | undefined => {
-  let current: Json | undefined = row;
-  for (const segment of field.split(".")) {
-    if (!isRow(current)) return undefined;
-    current = current[segment];
-  }
-  return current;
-};
 
 /** The column, as numbers. Rows carrying an explicit null are sparse data, not
  *  a mismatch, so they are skipped; a non-numeric value IS a mismatch, and the
@@ -46,7 +36,9 @@ const at = (row: Record<string, Json>, field: string): Json | undefined => {
 const column = (rows: readonly Record<string, Json>[], field: string): number[] | undefined => {
   const numbers: number[] = [];
   for (const row of rows) {
-    const value = at(row, field);
+    // The ONE resolver, the same one every `field` prop and every column key
+    // reads a dotted path with — a nested numeric field reduces too.
+    const value = readField(row, field);
     if (value === null) continue;
     if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
     numbers.push(value);
@@ -109,7 +101,7 @@ export interface GroupedPoint {
 /** The bucket key of one date value: ISO date strings only. An epoch-ms number
  *  read as a date is how a numeric field silently buckets into 1970 instead of
  *  saying it is not a date. */
-const bucketKey = (value: Json | undefined, bucket: GroupByBucket): string | null => {
+const bucketKey = (value: unknown, bucket: GroupByBucket): string | null => {
   if (typeof value !== "string") return null;
   const time = Date.parse(value);
   if (!Number.isFinite(time)) return null;
@@ -133,7 +125,7 @@ export const groupBy = (
   if (aggregate !== "count" && valueField === undefined) return undefined;
   const groups = new Map<string, Record<string, Json>[]>();
   for (const row of source) {
-    const key = bucketKey(at(row, keyField), bucket);
+    const key = bucketKey(readField(row, keyField), bucket);
     if (key === null) return undefined;
     const existing = groups.get(key);
     if (existing === undefined) groups.set(key, [row]);

--- a/packages/ui/src/kit/charts/donut.tsx
+++ b/packages/ui/src/kit/charts/donut.tsx
@@ -2,7 +2,6 @@
 import { Cell, Pie, PieChart as RPieChart, ResponsiveContainer, Tooltip } from "recharts";
 import { isRenderableNumber, applyFormat, type ValueFormat } from "../format.js";
 import { font, seriesColor, t } from "../tokens.js";
-import { humanizeEnum } from "../values.js";
 import { ChartEmpty, ChartFrame } from "./sanitize.js";
 
 export interface DonutChartProps {
@@ -90,7 +89,10 @@ export function DonutChart({
                 aria-hidden="true"
                 style={{ width: 9, height: 9, flexShrink: 0, borderRadius: 3, background: seriesColor(i) }}
               />
-              <span>{humanizeEnum(slice.name)}</span>
+              {/* The name as the DATA spells it, which is what the slice's own
+                  tooltip shows: humanizing lowercased proper nouns ("ACME Corp"
+                  → "Acme corp") and made the two disagree. */}
+              <span>{slice.name}</span>
               <span style={{ color: t.muted, fontVariantNumeric: "tabular-nums" }}>{fmt(slice.value)}</span>
             </li>
           ))}

--- a/packages/ui/src/kit/charts/donut.tsx
+++ b/packages/ui/src/kit/charts/donut.tsx
@@ -1,7 +1,8 @@
 /** DonutChart — recharts Pie internals, data props only (W2 §The Kit). */
 import { Cell, Pie, PieChart as RPieChart, ResponsiveContainer, Tooltip } from "recharts";
 import { isRenderableNumber, applyFormat, type ValueFormat } from "../format.js";
-import { seriesColor, t } from "../tokens.js";
+import { font, seriesColor, t } from "../tokens.js";
+import { humanizeEnum } from "../values.js";
 import { ChartEmpty, ChartFrame } from "./sanitize.js";
 
 export interface DonutChartProps {
@@ -14,6 +15,8 @@ export interface DonutChartProps {
   format?: ValueFormat;
   /** false renders a full pie. */
   donut?: boolean;
+  /** Name + value under the ring. On by default. */
+  legend?: boolean;
   height?: number;
   emptyState?: string;
 }
@@ -24,6 +27,7 @@ export function DonutChart({
   valueKey,
   format = "number",
   donut = true,
+  legend = true,
   height = 220,
   emptyState = "No data to chart",
 }: DonutChartProps) {
@@ -37,7 +41,10 @@ export function DonutChart({
   }
   const fmt = (v: unknown) => applyFormat(v, format) ?? "";
   return (
-    <div data-kit="DonutChart">
+    <div
+      data-kit="DonutChart"
+      style={{ display: "flex", flexDirection: "column", gap: "var(--vendo-density-inline-gap, 7px)" }}
+    >
       <ChartFrame height={height}>
         <ResponsiveContainer width="100%" height="100%">
           <RPieChart>
@@ -60,6 +67,35 @@ export function DonutChart({
           </RPieChart>
         </ResponsiveContainer>
       </ChartFrame>
+      {/* An unlabelled ring says NOTHING in a screenshot — a hover tooltip is
+          not a label (genbench spend-overview, 2026-08-11). Every slice is
+          named and valued on the page itself. */}
+      {legend ? (
+        <ul
+          data-kit="DonutLegend"
+          style={{
+            ...font,
+            display: "flex",
+            flexWrap: "wrap",
+            gap: "var(--vendo-density-inline-gap, 7px) var(--vendo-density-content-gap, 10px)",
+            listStyle: "none",
+            margin: 0,
+            padding: 0,
+            fontSize: "0.85em",
+          }}
+        >
+          {slices.map((slice, i) => (
+            <li key={i} style={{ display: "flex", alignItems: "center", gap: 6 }}>
+              <span
+                aria-hidden="true"
+                style={{ width: 9, height: 9, flexShrink: 0, borderRadius: 3, background: seriesColor(i) }}
+              />
+              <span>{humanizeEnum(slice.name)}</span>
+              <span style={{ color: t.muted, fontVariantNumeric: "tabular-nums" }}>{fmt(slice.value)}</span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
     </div>
   );
 }

--- a/packages/ui/src/kit/charts/progress.tsx
+++ b/packages/ui/src/kit/charts/progress.tsx
@@ -1,33 +1,31 @@
 /** Progress — a themed progress bar; ratio or value/max (W2 §The Kit). */
 import { isRenderableNumber } from "../format.js";
-import { font, t } from "../tokens.js";
+import { useFieldValue } from "../row.js";
+import { font, resolveTone, t, toneColor, type KitTone } from "../tokens.js";
 
 export interface ProgressProps {
   /** A ratio (0..1) unless `max` is given, then a raw value. */
-  value: number;
+  value?: number;
   /** When set, `value/max` is the ratio. */
   max?: number;
   label?: string;
   /** Show the percentage text. */
   showValue?: boolean;
-  tone?: "accent" | "success" | "danger";
+  tone?: KitTone;
+  /** Inside a cell slot: the row field this value comes from. */
+  field?: string;
 }
 
-const TONE_FILL: Record<NonNullable<ProgressProps["tone"]>, string> = {
-  accent: t.accent,
-  success: "#1e7f53",
-  danger: t.danger,
-};
-
-export function Progress({ value, max, label, showValue = false, tone = "accent" }: ProgressProps) {
-  if (!isRenderableNumber(value) || (max !== undefined && !isRenderableNumber(max))) {
+export function Progress({ value, max, label, showValue = false, tone, field }: ProgressProps) {
+  const own = useFieldValue(field, value);
+  if (!isRenderableNumber(own) || (max !== undefined && !isRenderableNumber(max))) {
     return (
       <div data-kit="Progress" style={{ ...font, color: t.muted }}>
         —
       </div>
     );
   }
-  const ratio = max !== undefined && max !== 0 ? value / max : value;
+  const ratio = max !== undefined && max !== 0 ? own / max : own;
   const clamped = Math.max(0, Math.min(1, ratio));
   const pct = `${Math.round(clamped * 100)}%`;
   return (
@@ -55,7 +53,7 @@ export function Progress({ value, max, label, showValue = false, tone = "accent"
             width: pct,
             height: "100%",
             borderRadius: 999,
-            background: TONE_FILL[tone],
+            background: toneColor(resolveTone(tone, "accent")),
             transition: `width ${t.motionDuration} ${t.motionEasing}`,
           }}
         />

--- a/packages/ui/src/kit/charts/sparkline.tsx
+++ b/packages/ui/src/kit/charts/sparkline.tsx
@@ -1,8 +1,7 @@
 /** Sparkline — a compact inline trend, recharts Area internals (W2 §The Kit). */
 import { Area, AreaChart, ResponsiveContainer } from "recharts";
 import { useFieldValue } from "../row.js";
-import { seriesColor } from "../tokens.js";
-import { font, t } from "../tokens.js";
+import { font, resolveTone, seriesColor, t, toneColor, type KitTone } from "../tokens.js";
 import { sanitizeNumbers } from "./sanitize.js";
 
 export interface SparklineProps {
@@ -13,11 +12,13 @@ export interface SparklineProps {
   height?: number;
   /** Placeholder shown when there is nothing renderable. */
   emptyState?: string;
+  /** Paints the line — a trend that is bad news is `danger`. */
+  tone?: KitTone;
   /** Inside a cell slot: the row field holding this trend's points. */
   field?: string;
 }
 
-export function Sparkline({ data, valueKey = "value", height = 40, emptyState = "—", field }: SparklineProps) {
+export function Sparkline({ data, valueKey = "value", height = 40, emptyState = "—", tone, field }: SparklineProps) {
   const input = useFieldValue(field, data);
   // W3 — fail SOFT on missing data (a failed query resolves to undefined).
   const raw = (Array.isArray(input) ? input : []).map((d) =>
@@ -32,6 +33,11 @@ export function Sparkline({ data, valueKey = "value", height = 40, emptyState = 
     );
   }
   const points = clean.map((v, i) => ({ i, v }));
+  const resolved = resolveTone(tone);
+  const line = resolved === "neutral" ? seriesColor(0) : toneColor(resolved);
+  // Per-tone gradient id: a document resolves `url(#id)` to the FIRST match, so
+  // one shared id would paint every sparkline on the page in the first one's fill.
+  const fillId = `vendo-spark-fill-${resolved}`;
   // The ratio is `ChartFrame`'s intrinsic-width trick (charts/sanitize.tsx) at
   // this form's own proportion: a parent that sizes to its content (the Kit's
   // `Row`) measures `width: 100%` as zero and recharts draws nothing, and a trend
@@ -42,17 +48,17 @@ export function Sparkline({ data, valueKey = "value", height = 40, emptyState = 
       <ResponsiveContainer width="100%" height="100%">
         <AreaChart data={points} margin={{ top: 2, right: 2, bottom: 2, left: 2 }}>
           <defs>
-            <linearGradient id="vendo-spark-fill" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="0%" stopColor={seriesColor(0)} stopOpacity={0.25} />
-              <stop offset="100%" stopColor={seriesColor(0)} stopOpacity={0} />
+            <linearGradient id={fillId} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor={line} stopOpacity={0.25} />
+              <stop offset="100%" stopColor={line} stopOpacity={0} />
             </linearGradient>
           </defs>
           <Area
             type="monotone"
             dataKey="v"
-            stroke={seriesColor(0)}
+            stroke={line}
             strokeWidth={1.6}
-            fill="url(#vendo-spark-fill)"
+            fill={`url(#${fillId})`}
             dot={false}
             isAnimationActive={false}
           />

--- a/packages/ui/src/kit/charts/sparkline.tsx
+++ b/packages/ui/src/kit/charts/sparkline.tsx
@@ -1,22 +1,28 @@
 /** Sparkline — a compact inline trend, recharts Area internals (W2 §The Kit). */
 import { Area, AreaChart, ResponsiveContainer } from "recharts";
+import { useFieldValue } from "../row.js";
 import { seriesColor } from "../tokens.js";
 import { font, t } from "../tokens.js";
 import { sanitizeNumbers } from "./sanitize.js";
 
 export interface SparklineProps {
   /** A list of numbers, or rows with a `valueKey`. */
-  data: Array<number | Record<string, unknown>>;
+  data?: Array<number | Record<string, unknown>>;
   /** Field to read when `data` holds objects. */
   valueKey?: string;
   height?: number;
   /** Placeholder shown when there is nothing renderable. */
   emptyState?: string;
+  /** Inside a cell slot: the row field holding this trend's points. */
+  field?: string;
 }
 
-export function Sparkline({ data, valueKey = "value", height = 40, emptyState = "—" }: SparklineProps) {
+export function Sparkline({ data, valueKey = "value", height = 40, emptyState = "—", field }: SparklineProps) {
+  const input = useFieldValue(field, data);
   // W3 — fail SOFT on missing data (a failed query resolves to undefined).
-  const raw = (Array.isArray(data) ? data : []).map((d) => (typeof d === "number" ? d : (d[valueKey] as number)));
+  const raw = (Array.isArray(input) ? input : []).map((d) =>
+    typeof d === "number" ? d : (d as Record<string, unknown> | null)?.[valueKey] as number,
+  );
   const clean = sanitizeNumbers(raw);
   if (clean.length < 2) {
     return (

--- a/packages/ui/src/kit/data/badge.tsx
+++ b/packages/ui/src/kit/data/badge.tsx
@@ -1,18 +1,25 @@
 /** Badge — small status label using theme tones (W2 §The Kit). */
 import type { PropsWithChildren } from "react";
+import { applyFormat } from "../format.js";
+import { useFieldValue } from "../row.js";
+import { resolveTone } from "../tokens.js";
 import { EnumBadge, type EnumTone } from "../values.js";
 
 export interface BadgeProps {
   label?: string;
   tone?: EnumTone;
+  /** Inside a cell slot: the row field this label comes from. */
+  field?: string;
 }
 
 /**
  * A literal status pill. For enum data fields prefer `EnumBadge` (it humanizes
  * and tone-maps the raw value); `Badge` is for a copy label the model writes.
  */
-export function Badge({ label, tone = "neutral", children }: PropsWithChildren<BadgeProps>) {
-  const text = label ?? (typeof children === "string" ? children : "");
+export function Badge({ label, tone, field, children }: PropsWithChildren<BadgeProps>) {
+  const own = label ?? (typeof children === "string" ? children : "");
+  // A row field holds anything; `applyFormat` is the tier's total coercion.
+  const text = applyFormat(useFieldValue(field, own), "text") ?? "";
   // Reuse EnumBadge's tone styling with an explicit label (no humanization).
-  return <EnumBadge value={text} labels={{ [text]: text }} tone={tone} />;
+  return <EnumBadge value={text} labels={{ [text]: text }} tone={resolveTone(tone)} />;
 }

--- a/packages/ui/src/kit/data/card-list.tsx
+++ b/packages/ui/src/kit/data/card-list.tsx
@@ -1,12 +1,17 @@
 /** CardList — one branded card per record, semantically formatted (W2 §The Kit). */
+import type { ReactNode } from "react";
 import { applyFormat, type ValueFormat } from "../format.js";
-import { font, t } from "../tokens.js";
+import { readField, RowContext } from "../row.js";
+import { densityVars, font, t, type KitDensity } from "../tokens.js";
 import { EnumBadge } from "../values.js";
 
 export interface CardField {
   key: string;
   label?: string;
   format?: ValueFormat;
+  /** Kit elements rendered as this field's VALUE for THIS item (the label
+   *  stays); the components inside name their field. */
+  cell?: ReactNode;
 }
 
 export interface CardListProps {
@@ -22,13 +27,11 @@ export interface CardListProps {
   columns?: number;
   /** Text shown when there are no items. */
   emptyState?: string;
+  /** Spacing scale for this list's subtree. */
+  density?: KitDensity;
 }
 
-function resolve(row: Record<string, unknown>, key: string): unknown {
-  return key.split(".").reduce<unknown>((acc, k) => (acc && typeof acc === "object" ? (acc as Record<string, unknown>)[k] : undefined), row);
-}
-
-export function CardList({ items: rawItems, titleField, badgeField, fields = [], columns, emptyState = "No items" }: CardListProps) {
+export function CardList({ items: rawItems, titleField, badgeField, fields = [], columns, emptyState = "No items", density }: CardListProps) {
   // W3 — fail SOFT on missing data (a failed query resolves to undefined).
   const items = Array.isArray(rawItems) ? rawItems : [];
   if (items.length === 0) {
@@ -54,47 +57,51 @@ export function CardList({ items: rawItems, titleField, badgeField, fields = [],
   return (
     <div
       data-kit="CardList"
-      style={{ display: "grid", gridTemplateColumns: gridTemplate, gap: "var(--vendo-density-content-gap, 10px)" }}
+      style={{ ...densityVars(density), display: "grid", gridTemplateColumns: gridTemplate, gap: "var(--vendo-density-content-gap, 10px)" }}
     >
       {items.map((item, index) => {
-        const badge = badgeField ? resolve(item, badgeField) : undefined;
+        const badge = badgeField ? readField(item, badgeField) : undefined;
         return (
-          <article
-            key={String(resolve(item, "id") ?? index)}
-            style={{
-              ...font,
-              display: "flex",
-              flexDirection: "column",
-              gap: "var(--vendo-density-field-gap, 6px)",
-              border: `1px solid ${t.border}`,
-              borderRadius: t.radiusLarge,
-              background: t.surface,
-              boxShadow: `0 4px 20px color-mix(in srgb, ${t.text} 5%, transparent)`,
-              padding: "var(--vendo-density-card-padding, 16px)",
-            }}
-          >
-            {(titleField || badge !== undefined) && (
-              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
-                {titleField ? (
-                  <span style={{ fontFamily: t.headingFamily, fontWeight: 650, letterSpacing: "-0.015em" }}>
-                    {String(resolve(item, titleField) ?? "—")}
-                  </span>
-                ) : <span />}
-                {badge !== undefined && badge !== null && badge !== "" ? (
-                  <EnumBadge value={String(badge)} />
-                ) : null}
-              </div>
-            )}
-            {fields.map((f) => {
-              const formatted = applyFormat(resolve(item, f.key), f.format ?? "text");
-              return (
+          // One provider per card — a field slot's components read their field
+          // off it, exactly as a table cell's do.
+          <RowContext.Provider key={String(readField(item, "id") ?? index)} value={item}>
+            <article
+              style={{
+                ...font,
+                display: "flex",
+                flexDirection: "column",
+                gap: "var(--vendo-density-field-gap, 6px)",
+                border: `1px solid ${t.border}`,
+                borderRadius: t.radiusLarge,
+                background: t.surface,
+                boxShadow: `0 4px 20px color-mix(in srgb, ${t.text} 5%, transparent)`,
+                padding: "var(--vendo-density-card-padding, 16px)",
+              }}
+            >
+              {(titleField || badge !== undefined) && (
+                <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
+                  {titleField ? (
+                    <span style={{ fontFamily: t.headingFamily, fontWeight: 650, letterSpacing: "-0.015em" }}>
+                      {String(readField(item, titleField) ?? "—")}
+                    </span>
+                  ) : <span />}
+                  {badge !== undefined && badge !== null && badge !== "" ? (
+                    <EnumBadge value={String(badge)} />
+                  ) : null}
+                </div>
+              )}
+              {fields.map((f) => (
                 <div key={f.key} style={{ display: "flex", justifyContent: "space-between", gap: 8, fontSize: "0.92em" }}>
                   <span style={{ color: t.muted }}>{f.label ?? f.key}</span>
-                  <span style={{ fontVariantNumeric: "tabular-nums" }}>{formatted ?? "—"}</span>
+                  {f.cell ?? (
+                    <span style={{ fontVariantNumeric: "tabular-nums" }}>
+                      {applyFormat(readField(item, f.key), f.format ?? "text") ?? "—"}
+                    </span>
+                  )}
                 </div>
-              );
-            })}
-          </article>
+              ))}
+            </article>
+          </RowContext.Provider>
         );
       })}
     </div>

--- a/packages/ui/src/kit/data/data-table.tsx
+++ b/packages/ui/src/kit/data/data-table.tsx
@@ -4,7 +4,7 @@
  * column keys, formats each cell by its `format` token, and shows a named-query
  * empty state — none of which the model has to author.
  */
-import { useMemo, useState, type CSSProperties } from "react";
+import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import {
   flexRender,
   getCoreRowModel,
@@ -15,8 +15,9 @@ import {
   type ColumnDef,
   type SortingState,
 } from "@tanstack/react-table";
-import { applyFormat, type ValueFormat } from "../format.js";
-import { font, t } from "../tokens.js";
+import { applyFormat, formatDateTime, type ValueFormat } from "../format.js";
+import { readField, RowContext } from "../row.js";
+import { densityVars, font, t, type KitDensity } from "../tokens.js";
 import { humanizeEnum } from "../values.js";
 
 export interface DataTableColumn {
@@ -27,6 +28,10 @@ export interface DataTableColumn {
   /** Value-tier format applied to every cell. */
   format?: ValueFormat;
   align?: "start" | "center" | "end";
+  /** Kit elements rendered instead of the formatted text — once per row, with
+   *  that row published on `RowContext` so the components inside can name their
+   *  field. `key` still drives sorting, filtering and searching. */
+  cell?: ReactNode;
 }
 
 export interface DataTableProps {
@@ -48,28 +53,45 @@ export interface DataTableProps {
   emptyState?: string;
   /** Optional table caption. */
   caption?: string;
-}
-
-/** Resolve a dot-path against a row. */
-function resolvePath(row: Record<string, unknown>, path: string): unknown {
-  return path.split(".").reduce<unknown>((acc, key) => {
-    if (acc && typeof acc === "object") return (acc as Record<string, unknown>)[key];
-    return undefined;
-  }, row);
+  /** Spacing scale for this table's subtree. */
+  density?: KitDensity;
 }
 
 const alignCss = (a: DataTableColumn["align"]): CSSProperties["textAlign"] =>
   a === "end" ? "right" : a === "center" ? "center" : "left";
 
+/** A cell's formatted text, or `null` when the value is unrenderable. `compact`
+ *  is the date default — see `compactDateKeys`. */
+function cellText(value: unknown, format: ValueFormat, compact: boolean): string | null {
+  if (compact && (format === "date" || format === "datetime")) {
+    return typeof value === "string" || typeof value === "number" || value instanceof Date
+      ? formatDateTime(value, { mode: format, compact: true })
+      : null;
+  }
+  return applyFormat(value, format);
+}
+
 /**
  * The text a cell actually SHOWS, which is the only thing a filter may compare
  * against: the person filters on what is in front of them. Filtering the raw
- * field instead meant "$2,500.00" and "Mar 14, 2026" were unsearchable, while
- * the dropdown offered "2026-03-14" as an option for a column reading
- * "Mar 14, 2026". Unrenderable cells (the "—" placeholder) filter as empty.
+ * field instead meant "$2,500.00" and "Mar 14" were unsearchable, while the
+ * dropdown offered "2026-03-14" as an option for a column reading "Mar 14".
+ * Unrenderable cells (the "—" placeholder) filter as empty.
  */
-function displayText(row: Record<string, unknown>, column: DataTableColumn): string {
-  return applyFormat(resolvePath(row, column.key), column.format ?? "text") ?? "";
+function displayText(row: Record<string, unknown>, column: DataTableColumn, compact = false): string {
+  return cellText(readField(row, column.key), column.format ?? "text", compact) ?? "";
+}
+
+/** The calendar year a date value lands in, read the way the cell shows it: a
+ *  date-only ISO string is formatted in UTC (so the day cannot slip a zone), so
+ *  its year is read in UTC too. */
+function dateYear(value: unknown): number | undefined {
+  if (typeof value !== "string" && typeof value !== "number" && !(value instanceof Date)) return undefined;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return undefined;
+  return typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value.trim())
+    ? date.getUTCFullYear()
+    : date.getFullYear();
 }
 
 const cellPad = "var(--vendo-density-table-padding, 10px 12px)";
@@ -84,6 +106,7 @@ export function DataTable(props: DataTableProps) {
     paginate,
     emptyState = "No data",
     caption,
+    density,
   } = props;
 
   // W3 — fail SOFT on missing data: a failed/pending query resolves its
@@ -111,24 +134,49 @@ export function DataTable(props: DataTableProps) {
     return [{ id, desc: (dir ?? "asc").toLowerCase() === "desc" }];
   }, [sortBy]);
 
+  /**
+   * The date columns that may drop the year — "Aug 12", not "Aug 12, 2026".
+   * In a column of this year's dates the year is the same four characters on
+   * every row, and judges read the repetition as clutter. It stops being noise
+   * the moment the column straddles years, and a column mixing the two forms
+   * reads as a data error, so the year returns for the WHOLE column. Judged off
+   * `data`, not the filtered rows, so filtering cannot change what a date means.
+   */
+  const compactDateKeys = useMemo(() => {
+    const thisYear = new Date().getFullYear();
+    return new Set(
+      columns
+        .filter(
+          (col) =>
+            (col.format === "date" || col.format === "datetime") &&
+            data.every((row) => (dateYear(readField(row, col.key)) ?? thisYear) === thisYear),
+        )
+        .map((col) => col.key),
+    );
+  }, [columns, data]);
+
   const tanstackColumns = useMemo<Array<ColumnDef<Record<string, unknown>>>>(
     () =>
       columns.map((col) => ({
         id: col.key,
-        accessorFn: (row) => resolvePath(row, col.key),
+        accessorFn: (row) => readField(row, col.key),
         header: col.label ?? humanizeEnum(col.key.split(".").pop() ?? col.key),
+        // A slot holds an ELEMENT, never a function (a function prop serializes
+        // as a `$handler` door). The row it belongs to arrives on RowContext,
+        // published once per row below.
         cell: (ctx) => {
-          const raw = ctx.getValue();
-          const formatted = applyFormat(raw, col.format ?? "text");
+          if (col.cell !== undefined) return col.cell;
+          const formatted = cellText(ctx.getValue(), col.format ?? "text", compactDateKeys.has(col.key));
           if (formatted === null) return <span style={{ color: t.muted }}>—</span>;
           return formatted;
         },
         // A dropdown lists the values that exist, so picking one means THIS
         // value — "includesString" here let a pick of "paid" list the "unpaid"
         // rows too.
-        filterFn: (row, _columnId, value) => displayText(row.original, col) === String(value),
+        filterFn: (row, _columnId, value) =>
+          displayText(row.original, col, compactDateKeys.has(col.key)) === String(value),
       })),
-    [columns],
+    [columns, compactDateKeys],
   );
 
   const [sorting, setSorting] = useState<SortingState>(initialSorting);
@@ -145,7 +193,9 @@ export function DataTable(props: DataTableProps) {
     globalFilterFn: (row, columnId, value) => {
       const col = columns.find((entry) => entry.key === columnId);
       if (!col) return false;
-      return displayText(row.original, col).toLowerCase().includes(String(value).toLowerCase());
+      return displayText(row.original, col, compactDateKeys.has(col.key))
+        .toLowerCase()
+        .includes(String(value).toLowerCase());
     },
     // Every column renders text, so every column is searchable on that text.
     // The default excludes any column whose raw value is not a string or number
@@ -165,21 +215,54 @@ export function DataTable(props: DataTableProps) {
       const col = columns.find((entry) => entry.key === key) ?? { key };
       const set = new Set<string>();
       for (const row of data) {
-        const text = displayText(row, col);
+        const text = displayText(row, col, compactDateKeys.has(key));
         if (text !== "") set.add(text);
       }
       map.set(key, [...set].sort());
     }
     return map;
-  }, [filterableBy, data, columns]);
+  }, [filterableBy, data, columns, compactDateKeys]);
 
   const columnLabel = (key: string) =>
     columns.find((c) => c.key === key)?.label ?? humanizeEnum(key.split(".").pop() ?? key);
 
   const bodyRows = table.getRowModel().rows;
 
+  /**
+   * Columns past the width the surface has FOLD into the first one. The wrapper
+   * scrolls horizontally, which on a narrow surface parks the right-hand columns
+   * off-screen with nothing to say they exist — five separate judge failures.
+   * The trigger is the measurement itself: no prop, no invented breakpoint.
+   */
+  const scroller = useRef<HTMLDivElement | null>(null);
+  const neededWidth = useRef(0);
+  const [folded, setFolded] = useState(false);
+  useEffect(() => {
+    const node = scroller.current;
+    // No ResizeObserver (SSR, jsdom): nothing is measured, so nothing folds and
+    // the wide table behaves exactly as it always did.
+    if (node === null || typeof ResizeObserver === "undefined") return;
+    const measure = () =>
+      setFolded((was) => {
+        // Folded, the table is one column and fits — measuring THAT would unfold
+        // it into an overflow again, forever. So the width the wide table needs
+        // is remembered while it is still wide.
+        if (!was) neededWidth.current = node.scrollWidth;
+        return node.clientWidth < neededWidth.current;
+      });
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+  /** Folded, only the first column has a header and a cell of its own. */
+  const shown = <T,>(all: T[]): T[] => (folded ? all.slice(0, 1) : all);
+
   return (
-    <div data-kit="DataTable" style={{ ...font, display: "flex", flexDirection: "column", gap: "var(--vendo-density-content-gap, 10px)" }}>
+    <div
+      data-kit="DataTable"
+      style={{ ...font, ...densityVars(density), display: "flex", flexDirection: "column", gap: "var(--vendo-density-content-gap, 10px)" }}
+    >
       {(searchable || (filterableBy && filterableBy.length > 0)) && (
         <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--vendo-density-inline-gap, 7px)", alignItems: "center" }}>
           {searchable && (
@@ -235,6 +318,7 @@ export function DataTable(props: DataTableProps) {
       )}
 
       <div
+        ref={scroller}
         style={{
           width: "100%",
           overflowX: "auto",
@@ -250,7 +334,7 @@ export function DataTable(props: DataTableProps) {
           <thead>
             {table.getHeaderGroups().map((hg) => (
               <tr key={hg.id} style={{ background: `color-mix(in srgb, ${t.background} 72%, ${t.surface})` }}>
-                {hg.headers.map((header) => {
+                {shown(hg.headers).map((header) => {
                   const col = columns.find((c) => c.key === header.column.id);
                   const sorted = header.column.getIsSorted();
                   return (
@@ -284,7 +368,7 @@ export function DataTable(props: DataTableProps) {
             {bodyRows.length === 0 ? (
               <tr>
                 <td
-                  colSpan={Math.max(1, columns.length)}
+                  colSpan={Math.max(1, shown(columns).length)}
                   style={{ color: t.muted, padding: "calc(var(--vendo-font-size, 15px) * 1.6) 12px", textAlign: "center" }}
                 >
                   {emptyState}
@@ -293,22 +377,54 @@ export function DataTable(props: DataTableProps) {
             ) : (
               bodyRows.map((row, rowIndex) => (
                 <tr key={row.id}>
-                  {row.getVisibleCells().map((cell) => {
-                    const col = columns.find((c) => c.key === cell.column.id);
-                    return (
-                      <td
-                        key={cell.id}
-                        style={{
-                          borderBottom: rowIndex === bodyRows.length - 1 ? 0 : `1px solid ${t.border}`,
-                          padding: cellPad,
-                          textAlign: alignCss(col?.align),
-                          fontVariantNumeric: col?.format && col.format !== "text" ? "tabular-nums" : undefined,
-                        }}
-                      >
-                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                      </td>
-                    );
-                  })}
+                  {/* One provider per row — a slot's components read their field
+                      off it. A provider paints no element, so this is still tr > td. */}
+                  <RowContext.Provider value={row.original}>
+                    {shown(row.getVisibleCells()).map((cell) => {
+                      const col = columns.find((c) => c.key === cell.column.id);
+                      // A slot is elements, not a figure: only formatted TEXT is
+                      // tabular, and only formatted text is one unbreakable atom
+                      // ("Mar 14" split across two lines reads as two values).
+                      const figure = col?.format !== undefined && col.format !== "text" && col.cell === undefined;
+                      return (
+                        <td
+                          key={cell.id}
+                          style={{
+                            borderBottom: rowIndex === bodyRows.length - 1 ? 0 : `1px solid ${t.border}`,
+                            padding: cellPad,
+                            textAlign: alignCss(col?.align),
+                            whiteSpace: figure ? "nowrap" : undefined,
+                            fontVariantNumeric: figure ? "tabular-nums" : undefined,
+                          }}
+                        >
+                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                          {folded ? (
+                            <div
+                              style={{
+                                display: "flex",
+                                flexDirection: "column",
+                                gap: 2,
+                                marginTop: 4,
+                                color: t.muted,
+                                fontSize: "0.85em",
+                              }}
+                            >
+                              {columns.slice(1).flatMap((other) => {
+                                const text = displayText(row.original, other, compactDateKeys.has(other.key));
+                                return text === ""
+                                  ? []
+                                  : [
+                                      <span key={other.key}>
+                                        {columnLabel(other.key)}: {text}
+                                      </span>,
+                                    ];
+                              })}
+                            </div>
+                          ) : null}
+                        </td>
+                      );
+                    })}
+                  </RowContext.Provider>
                 </tr>
               ))
             )}

--- a/packages/ui/src/kit/data/data-table.tsx
+++ b/packages/ui/src/kit/data/data-table.tsx
@@ -78,7 +78,7 @@ function cellText(value: unknown, format: ValueFormat, compact: boolean): string
  * dropdown offered "2026-03-14" as an option for a column reading "Mar 14".
  * Unrenderable cells (the "—" placeholder) filter as empty.
  */
-function displayText(row: Record<string, unknown>, column: DataTableColumn, compact = false): string {
+function displayText(row: Record<string, unknown>, column: DataTableColumn, compact: boolean): string {
   return cellText(readField(row, column.key), column.format ?? "text", compact) ?? "";
 }
 
@@ -235,28 +235,38 @@ export function DataTable(props: DataTableProps) {
    * The trigger is the measurement itself: no prop, no invented breakpoint.
    */
   const scroller = useRef<HTMLDivElement | null>(null);
-  const neededWidth = useRef(0);
-  const [folded, setFolded] = useState(false);
+  const headRow = useRef<HTMLTableRowElement | null>(null);
+  /** Each column's right edge at its NATURAL width, measured while every column
+   *  is still shown. Folding changes those widths, so a second measurement would
+   *  disagree with the first and the table would oscillate — the natural edges
+   *  are recorded once and every later decision is taken against them. */
+  const naturalEdges = useRef<number[]>([]);
+  const [visibleCount, setVisibleCount] = useState(columns.length);
   useEffect(() => {
     const node = scroller.current;
     // No ResizeObserver (SSR, jsdom): nothing is measured, so nothing folds and
-    // the wide table behaves exactly as it always did.
+    // the table behaves exactly as it always did.
     if (node === null || typeof ResizeObserver === "undefined") return;
-    const measure = () =>
-      setFolded((was) => {
-        // Folded, the table is one column and fits — measuring THAT would unfold
-        // it into an overflow again, forever. So the width the wide table needs
-        // is remembered while it is still wide.
-        if (!was) neededWidth.current = node.scrollWidth;
-        return node.clientWidth < neededWidth.current;
-      });
+    const measure = () => {
+      const headers = headRow.current?.children;
+      if (headers !== undefined && headers.length === columns.length) {
+        let edge = 0;
+        naturalEdges.current = [...headers].map((th) => (edge += (th as HTMLElement).offsetWidth));
+      }
+      const edges = naturalEdges.current;
+      if (edges.length === 0) return;
+      // Keep every column that has room, fold only the ones that do not. The
+      // first column always stays, however narrow the surface is.
+      setVisibleCount(Math.max(1, edges.filter((right) => right <= node.clientWidth).length));
+    };
     measure();
     const observer = new ResizeObserver(measure);
     observer.observe(node);
     return () => observer.disconnect();
-  }, []);
-  /** Folded, only the first column has a header and a cell of its own. */
-  const shown = <T,>(all: T[]): T[] => (folded ? all.slice(0, 1) : all);
+  }, [columns.length]);
+  const folded = visibleCount < columns.length;
+  /** Only the columns that fit keep a header and a cell of their own. */
+  const shown = <T,>(all: T[]): T[] => (folded ? all.slice(0, visibleCount) : all);
 
   return (
     <div
@@ -333,7 +343,7 @@ export function DataTable(props: DataTableProps) {
           ) : null}
           <thead>
             {table.getHeaderGroups().map((hg) => (
-              <tr key={hg.id} style={{ background: `color-mix(in srgb, ${t.background} 72%, ${t.surface})` }}>
+              <tr ref={headRow} key={hg.id} style={{ background: `color-mix(in srgb, ${t.background} 72%, ${t.surface})` }}>
                 {shown(hg.headers).map((header) => {
                   const col = columns.find((c) => c.key === header.column.id);
                   const sorted = header.column.getIsSorted();
@@ -380,7 +390,7 @@ export function DataTable(props: DataTableProps) {
                   {/* One provider per row — a slot's components read their field
                       off it. A provider paints no element, so this is still tr > td. */}
                   <RowContext.Provider value={row.original}>
-                    {shown(row.getVisibleCells()).map((cell) => {
+                    {shown(row.getVisibleCells()).map((cell, cellIndex) => {
                       const col = columns.find((c) => c.key === cell.column.id);
                       // A slot is elements, not a figure: only formatted TEXT is
                       // tabular, and only formatted text is one unbreakable atom
@@ -398,7 +408,7 @@ export function DataTable(props: DataTableProps) {
                           }}
                         >
                           {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                          {folded ? (
+                          {folded && cellIndex === 0 ? (
                             <div
                               style={{
                                 display: "flex",
@@ -407,15 +417,25 @@ export function DataTable(props: DataTableProps) {
                                 marginTop: 4,
                                 color: t.muted,
                                 fontSize: "0.85em",
+                                // The cell this rides in may be a FIGURE, whose
+                                // nowrap/tabular is inherited: a folded line is
+                                // prose, and an unbreakable one scrolls the
+                                // table sideways — the thing folding prevents.
+                                whiteSpace: "normal",
+                                fontVariantNumeric: "normal",
                               }}
                             >
-                              {columns.slice(1).flatMap((other) => {
-                                const text = displayText(row.original, other, compactDateKeys.has(other.key));
-                                return text === ""
+                              {columns.slice(visibleCount).flatMap((other) => {
+                                // A folded column keeps its SLOT — a status
+                                // column reads as its pill here too, not as the
+                                // bare word the slot exists to kill.
+                                const value =
+                                  other.cell ?? displayText(row.original, other, compactDateKeys.has(other.key));
+                                return value === ""
                                   ? []
                                   : [
                                       <span key={other.key}>
-                                        {columnLabel(other.key)}: {text}
+                                        {columnLabel(other.key)}: {value}
                                       </span>,
                                     ];
                               })}

--- a/packages/ui/src/kit/data/stat.tsx
+++ b/packages/ui/src/kit/data/stat.tsx
@@ -1,6 +1,7 @@
 /** Stat — a KPI/metric summary with semantic formatting (W2 §The Kit). */
+import type { ReactNode } from "react";
 import { applyFormat, type ValueFormat } from "../format.js";
-import { font, t } from "../tokens.js";
+import { densityVars, font, resolveTone, t, toneColor, type KitDensity, type KitTone } from "../tokens.js";
 
 export interface StatProps {
   /** Metric name. */
@@ -11,7 +12,12 @@ export interface StatProps {
   format?: ValueFormat;
   /** A trend / delta caption, e.g. "+12% MoM". */
   trend?: string;
-  tone?: "default" | "accent" | "danger";
+  /** Emphasis. "default" is the older spelling of "neutral". */
+  tone?: KitTone | "default";
+  /** Spacing scale for this tile. */
+  density?: KitDensity;
+  /** Kit value components rendered under the number — a Sparkline, an EnumBadge. */
+  children?: ReactNode;
 }
 
 /** A KPI value is a number or a short phrase, never prose: past this length
@@ -19,8 +25,9 @@ export interface StatProps {
  *  so longer text renders truncated with the full text in the tooltip. */
 const STAT_VALUE_MAX_CHARS = 40;
 
-export function Stat({ label, value, format = "text", trend, tone = "default" }: StatProps) {
-  const emphasis = tone === "accent" ? t.accent : tone === "danger" ? t.danger : t.text;
+export function Stat({ label, value, format = "text", trend, tone, density, children }: StatProps) {
+  const resolvedTone = resolveTone(tone, "neutral");
+  const emphasis = toneColor(resolvedTone);
   const formatted = applyFormat(value, format);
   const empty = formatted === null;
   const overflow = !empty && formatted.length > STAT_VALUE_MAX_CHARS;
@@ -32,10 +39,11 @@ export function Stat({ label, value, format = "text", trend, tone = "default" }:
   return (
     <article
       data-kit="Stat"
-      data-tone={tone}
+      data-tone={resolvedTone}
       aria-label={label}
       style={{
         ...font,
+        ...densityVars(density),
         display: "flex",
         flexDirection: "column",
         gap: "var(--vendo-density-field-gap, 6px)",
@@ -57,6 +65,9 @@ export function Stat({ label, value, format = "text", trend, tone = "default" }:
           letterSpacing: "-0.025em",
           lineHeight: 1.12,
           fontVariantNumeric: "tabular-nums",
+          // A money figure has no break opportunity of its own, so a tile
+          // narrower than its number cut it off mid-number ("$1,113.1").
+          overflowWrap: "anywhere",
         }}
       >
         {display}
@@ -64,6 +75,7 @@ export function Stat({ label, value, format = "text", trend, tone = "default" }:
       {trend ? (
         <span style={{ color: t.muted, fontSize: "0.8em", lineHeight: 1.35 }}>{trend}</span>
       ) : null}
+      {children}
     </article>
   );
 }

--- a/packages/ui/src/kit/feedback/callout.tsx
+++ b/packages/ui/src/kit/feedback/callout.tsx
@@ -4,19 +4,23 @@
  * the honesty arm for when no tool backs the ask.
  */
 import type { PropsWithChildren } from "react";
-import { font, t } from "../tokens.js";
+import { font, t, toneColor, type KitTone } from "../tokens.js";
 
-export type CalloutTone = "info" | "accent" | "success" | "warning" | "danger";
+/** The shared vocabulary plus "info", which a Callout keeps as its own spelling:
+ *  elsewhere it is the legacy name for neutral, but a notice has ALWAYS been
+ *  brand-accented with the ⓘ, and it is still the default. */
+export type CalloutTone = KitTone | "info";
 
 const TONE: Record<CalloutTone, { accent: string; icon: string }> = {
   info: { accent: t.accent, icon: "ⓘ" },
+  neutral: { accent: toneColor("neutral"), icon: "ⓘ" },
   // "accent" is the tone the sibling vocabularies teach (Badge/EnumBadge/
   // Stat/Progress), so generated code reaches for it constantly — re-gate
   // 2026-07-26 arm C crashed on it four times. First-class, brand-accented.
   accent: { accent: t.accent, icon: "●" },
-  success: { accent: "#1e7f53", icon: "✓" },
-  warning: { accent: "#b8860b", icon: "▲" },
-  danger: { accent: t.danger, icon: "✕" },
+  success: { accent: toneColor("success"), icon: "✓" },
+  warning: { accent: toneColor("warning"), icon: "▲" },
+  danger: { accent: toneColor("danger"), icon: "✕" },
 };
 
 export interface CalloutProps {

--- a/packages/ui/src/kit/feedback/callout.tsx
+++ b/packages/ui/src/kit/feedback/callout.tsx
@@ -4,7 +4,7 @@
  * the honesty arm for when no tool backs the ask.
  */
 import type { PropsWithChildren } from "react";
-import { font, t, toneColor, type KitTone } from "../tokens.js";
+import { font, resolveTone, t, toneColor, type KitTone } from "../tokens.js";
 
 /** The shared vocabulary plus "info", which a Callout keeps as its own spelling:
  *  elsewhere it is the legacy name for neutral, but a notice has ALWAYS been
@@ -29,17 +29,17 @@ export interface CalloutProps {
 }
 
 export function Callout({ tone = "info", title, children }: PropsWithChildren<CalloutProps>) {
-  // Unknown tone values fall back to info instead of crashing: generated
-  // island code passes arbitrary strings, and a themed notice with the wrong
-  // color always beats "Node could not render: Cannot destructure 'accent'".
-  // Object.hasOwn, not a bare index: an unvalidated tone like "constructor"
-  // or "toString" would otherwise pick up Object.prototype members instead
-  // of falling back (review 2026-07-26).
-  const { accent, icon } = Object.hasOwn(TONE, tone) ? TONE[tone] : TONE.info;
+  // "info" is read HERE, before the shared resolver would flatten it to neutral:
+  // it is this component's default and has always been the accented ⓘ. Every
+  // other word goes through the ONE resolver, so "default" lands on neutral like
+  // it does on a Card and an unvalidated string ("constructor") falls back
+  // instead of picking up an Object.prototype member (review 2026-07-26).
+  const resolved: CalloutTone = tone === "info" ? "info" : resolveTone(tone);
+  const { accent, icon } = TONE[resolved];
   return (
     <div
       data-kit="Callout"
-      data-tone={tone}
+      data-tone={resolved}
       role="status"
       style={{
         ...font,

--- a/packages/ui/src/kit/format.ts
+++ b/packages/ui/src/kit/format.ts
@@ -103,9 +103,9 @@ export function currencyMinorUnits(currency: string): number {
  * Formatters never convert units. Callers pass major units, so a host field in
  * minor units (cents) is divided by 100 where it is READ, never here. The ISO
  * minor unit still decides how many decimals SHOW — none for JPY, three for KWD.
- * Returns `null` for any non-finite input so `$NaN` can never ship.
+ * Returns `null` for any non-finite or absent input so `$NaN` can never ship.
  */
-export function formatMoney(amount: number, options: MoneyOptions = {}): string | null {
+export function formatMoney(amount: number | undefined, options: MoneyOptions = {}): string | null {
   if (!isRenderableNumber(amount)) return null;
   const currency = options.currency ?? ambientIntl.currency;
   const digits = currencyMinorUnits(currency);
@@ -141,7 +141,7 @@ export interface PercentOptions {
  * Format a ratio (`0.42` → `"42%"`). Pass `whole: true` when the value is already
  * a whole percentage. Returns `null` for non-finite input.
  */
-export function formatPercent(value: number, options: PercentOptions = {}): string | null {
+export function formatPercent(value: number | undefined, options: PercentOptions = {}): string | null {
   if (!isRenderableNumber(value)) return null;
   const ratio = options.whole ? value / 100 : value;
   return new Intl.NumberFormat(options.locale ?? ambientIntl.locale, {
@@ -159,7 +159,7 @@ export interface NumOptions {
 }
 
 /** Format a plain number with thousands grouping. Returns `null` if non-finite. */
-export function formatNum(value: number, options: NumOptions = {}): string | null {
+export function formatNum(value: number | undefined, options: NumOptions = {}): string | null {
   if (!isRenderableNumber(value)) return null;
   return new Intl.NumberFormat(options.locale ?? ambientIntl.locale, {
     notation: options.notation ?? "standard",
@@ -173,11 +173,13 @@ export type DateInput = string | number | Date;
 export interface DateTimeOptions {
   /** date = calendar day · time = clock · datetime = both · relative = "3 days ago". */
   mode?: "date" | "time" | "datetime" | "relative";
+  /** Drop the year ("Aug 12"), for somewhere narrow like a table cell. */
+  compact?: boolean;
   locale?: string;
   timeZone?: string;
 }
 
-function toDate(value: DateInput): Date | null {
+function toDate(value: DateInput | undefined): Date | null {
   if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
   if (typeof value === "number") return Number.isFinite(value) ? new Date(value) : null;
   if (typeof value === "string") {
@@ -200,7 +202,7 @@ const RELATIVE_STEPS: Array<[Intl.RelativeTimeFormatUnit, number]> = [
  * Format a date/time. Accepts ISO strings, epoch millis, or `Date`. Returns
  * `null` for anything unparseable so `Invalid Date` can never ship.
  */
-export function formatDateTime(value: DateInput, options: DateTimeOptions = {}): string | null {
+export function formatDateTime(value: DateInput | undefined, options: DateTimeOptions = {}): string | null {
   const date = toDate(value);
   if (!date) return null;
   const mode = options.mode ?? "date";
@@ -219,12 +221,19 @@ export function formatDateTime(value: DateInput, options: DateTimeOptions = {}):
     return rtf.format(Math.round(diff / 1000), "second");
   }
   const base: Intl.DateTimeFormatOptions = { timeZone };
+  const clock: Intl.DateTimeFormatOptions = { hour: "numeric", minute: "2-digit" };
   const parts: Intl.DateTimeFormatOptions =
     mode === "time"
-      ? { hour: "numeric", minute: "2-digit" }
-      : mode === "datetime"
-        ? { year: "numeric", month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }
-        : { year: "numeric", month: "short", day: "numeric" };
+      ? clock
+      : {
+          // The year is the part a narrow column can afford to lose: dates in a
+          // table are overwhelmingly this year, and it reads as noise repeated
+          // down every row.
+          ...(options.compact ? {} : { year: "numeric" }),
+          month: "short",
+          day: "numeric",
+          ...(mode === "datetime" ? clock : {}),
+        };
   return new Intl.DateTimeFormat(locale, { ...base, ...parts }).format(date);
 }
 

--- a/packages/ui/src/kit/index.ts
+++ b/packages/ui/src/kit/index.ts
@@ -14,6 +14,7 @@
 
 // Semantics
 export * from "./format.js";
+export * from "./row.js";
 export * from "./state.js";
 export * from "./tokens.js";
 

--- a/packages/ui/src/kit/layout.tsx
+++ b/packages/ui/src/kit/layout.tsx
@@ -1,20 +1,28 @@
 /** Layout tier — themed containers (W2 §The Kit). */
 import type { CSSProperties, PropsWithChildren } from "react";
-import { font, t } from "./tokens.js";
+import { densityVars, font, resolveTone, t, toneColor, type KitDensity, type KitTone } from "./tokens.js";
 
 const gapVar = (gap: number | undefined): string =>
   gap === undefined ? "var(--vendo-density-content-gap, 10px)" : `${gap}px`;
 
+/** A toned container's rule. Neutral keeps the plain border rather than the
+ *  tone's foreground: a card is a region, not a pill. */
+const borderColor = (tone: KitTone | undefined): string => {
+  const resolved = resolveTone(tone, "neutral");
+  return resolved === "neutral" ? t.border : toneColor(resolved);
+};
+
 export interface StackProps {
   gap?: number;
+  density?: KitDensity;
 }
 
 /** Vertical flow. */
-export function Stack({ gap, children }: PropsWithChildren<StackProps>) {
+export function Stack({ gap, density, children }: PropsWithChildren<StackProps>) {
   return (
     <div
       data-kit="Stack"
-      style={{ display: "flex", flexDirection: "column", alignItems: "stretch", gap: gapVar(gap) }}
+      style={{ ...densityVars(density), display: "flex", flexDirection: "column", alignItems: "stretch", gap: gapVar(gap) }}
     >
       {children}
     </div>
@@ -26,6 +34,7 @@ export interface RowProps {
   align?: "start" | "center" | "end" | "stretch";
   justify?: "start" | "center" | "end" | "between";
   wrap?: boolean;
+  density?: KitDensity;
 }
 
 const alignMap: Record<string, CSSProperties["alignItems"]> = {
@@ -42,11 +51,12 @@ const justifyMap: Record<string, CSSProperties["justifyContent"]> = {
 };
 
 /** Horizontal flow. */
-export function Row({ gap, align = "center", justify = "start", wrap = true, children }: PropsWithChildren<RowProps>) {
+export function Row({ gap, align = "center", justify = "start", wrap = true, density, children }: PropsWithChildren<RowProps>) {
   return (
     <div
       data-kit="Row"
       style={{
+        ...densityVars(density),
         display: "flex",
         flexDirection: "row",
         flexWrap: wrap ? "wrap" : "nowrap",
@@ -62,18 +72,29 @@ export function Row({ gap, align = "center", justify = "start", wrap = true, chi
 
 export interface GridProps {
   columns?: number;
+  /** Narrowest a cell may get, in px. Wins over `columns`. */
+  minChildWidth?: number;
   gap?: number;
+  density?: KitDensity;
 }
 
 /** Equal-width columns. */
-export function Grid({ columns = 2, gap, children }: PropsWithChildren<GridProps>) {
+export function Grid({ columns = 2, minChildWidth = 0, gap, density, children }: PropsWithChildren<GridProps>) {
   const safe = Number.isFinite(columns) ? Math.max(1, Math.floor(columns)) : 2;
+  // A fixed count CLIPS its cells once the screen is narrower than the count
+  // needs; auto-fit wraps them instead. The inner `min()` is what keeps the last
+  // single column from overflowing a surface narrower than the floor itself.
+  const template =
+    minChildWidth > 0
+      ? `repeat(auto-fit, minmax(min(${Math.floor(minChildWidth)}px, 100%), 1fr))`
+      : `repeat(${safe}, minmax(0, 1fr))`;
   return (
     <div
       data-kit="Grid"
       style={{
+        ...densityVars(density),
         display: "grid",
-        gridTemplateColumns: `repeat(${safe}, minmax(0, 1fr))`,
+        gridTemplateColumns: template,
         alignItems: "stretch",
         gap: gapVar(gap),
       }}
@@ -85,19 +106,23 @@ export function Grid({ columns = 2, gap, children }: PropsWithChildren<GridProps
 
 export interface SurfaceProps {
   title?: string;
+  tone?: KitTone;
+  density?: KitDensity;
 }
 
 /** A bordered, elevated container; optional title. */
-export function Surface({ title, children }: PropsWithChildren<SurfaceProps>) {
+export function Surface({ title, tone, density, children }: PropsWithChildren<SurfaceProps>) {
   return (
     <section
       data-kit="Surface"
+      data-tone={resolveTone(tone, "neutral")}
       style={{
         ...font,
+        ...densityVars(density),
         display: "flex",
         flexDirection: "column",
         gap: "var(--vendo-density-content-gap, 10px)",
-        border: `1px solid ${t.border}`,
+        border: `1px solid ${borderColor(tone)}`,
         borderRadius: t.radiusMedium,
         background: t.surface,
         boxShadow: `0 4px 24px color-mix(in srgb, ${t.text} 6%, transparent)`,
@@ -124,22 +149,23 @@ export function Surface({ title, children }: PropsWithChildren<SurfaceProps>) {
 export interface CardProps {
   title?: string;
   description?: string;
-  tone?: "default" | "accent" | "danger";
+  tone?: KitTone;
+  density?: KitDensity;
 }
 
 /** A titled content block; Surface is the untitled/plain container. */
-export function Card({ title, description, tone = "default", children }: PropsWithChildren<CardProps>) {
-  const toneColor = tone === "accent" ? t.accent : tone === "danger" ? t.danger : t.border;
+export function Card({ title, description, tone, density, children }: PropsWithChildren<CardProps>) {
   return (
     <article
       data-kit="Card"
-      data-tone={tone}
+      data-tone={resolveTone(tone, "neutral")}
       style={{
         ...font,
+        ...densityVars(density),
         display: "flex",
         flexDirection: "column",
         gap: "var(--vendo-density-content-gap, 10px)",
-        border: `1px solid ${toneColor}`,
+        border: `1px solid ${borderColor(tone)}`,
         borderRadius: t.radiusLarge,
         background: t.surface,
         boxShadow: `0 8px 24px color-mix(in srgb, ${t.text} 7%, transparent)`,

--- a/packages/ui/src/kit/row.ts
+++ b/packages/ui/src/kit/row.ts
@@ -1,0 +1,44 @@
+/**
+ * The row a value component is standing in (2026-08-13, the cell slots).
+ *
+ * A DataTable cell and a CardList row are rendered once PER RECORD, so a Kit
+ * component nested in one cannot be handed its value as a prop: the prop would
+ * have to hold a different value in every row, and neither transport this Kit
+ * renders through can express that. The wire tree is JSON, and the screen VM
+ * serializes a prop function as a `$handler` callback, not as something the
+ * table may call while it paints.
+ *
+ * So the slot binds by NAME instead: the container publishes the record it is
+ * rendering, and a value component inside it names the field it wants —
+ * `<Money field="amount"/>` — which is the same "a config prop holds a field
+ * key" the Kit already speaks in `titleField`, `valueField`, `xKey` and a
+ * column's own `key`. Both transports carry a string.
+ */
+import { createContext, useContext } from "react";
+
+export type KitRow = Record<string, unknown>;
+
+/** The record the nearest DataTable cell / CardList card is rendering. */
+export const RowContext = createContext<KitRow | undefined>(undefined);
+
+/** Resolve a dot-path against a record ("client.name"). The ONE resolver: the
+ *  table, the card list and every `field` prop read a path the same way. */
+export function readField(row: KitRow | undefined, path: string): unknown {
+  if (row === undefined) return undefined;
+  return path.split(".").reduce<unknown>(
+    (value, key) => (value !== null && typeof value === "object" ? (value as KitRow)[key] : undefined),
+    row,
+  );
+}
+
+/**
+ * A value component's own value: the row's field when `field` names one and a
+ * row is in scope, and the prop it was passed otherwise. Outside a slot `field`
+ * resolves to nothing and the explicit prop still wins, so the same component
+ * reads the same either way.
+ */
+export function useFieldValue<T>(field: string | undefined, fallback: T): T | unknown {
+  const row = useContext(RowContext);
+  if (field === undefined || row === undefined) return fallback;
+  return readField(row, field);
+}

--- a/packages/ui/src/kit/row.ts
+++ b/packages/ui/src/kit/row.ts
@@ -22,7 +22,8 @@ export type KitRow = Record<string, unknown>;
 export const RowContext = createContext<KitRow | undefined>(undefined);
 
 /** Resolve a dot-path against a record ("client.name"). The ONE resolver: the
- *  table, the card list and every `field` prop read a path the same way. */
+ *  table, the card list, the aggregates and every `field` prop read a path the
+ *  same way. */
 export function readField(row: KitRow | undefined, path: string): unknown {
   if (row === undefined) return undefined;
   return path.split(".").reduce<unknown>(

--- a/packages/ui/src/kit/tokens.ts
+++ b/packages/ui/src/kit/tokens.ts
@@ -5,6 +5,7 @@
  */
 import {
   defaultVendoTheme,
+  densityCssVariables,
 } from "@vendoai/apps/contract";
 import type { CSSProperties } from "react";
 
@@ -22,6 +23,12 @@ export const t = {
   accent: `var(--vendo-color-accent, ${d.colors.accent})`,
   accentText: `var(--vendo-color-accent-text, ${d.colors.accentText})`,
   danger: `var(--vendo-color-danger, ${d.colors.danger})`,
+  // Two tones the host contract does not carry a color for. They are still
+  // TOKENS — a host that wants its own green and amber sets these two variables
+  // — and the fallback is the green/amber the pill palette already used as a
+  // literal, so nothing changes for a host that sets nothing.
+  success: "var(--vendo-color-success, #1e7f53)",
+  warning: "var(--vendo-color-warning, #d4a017)",
   border: `var(--vendo-color-border, ${d.colors.border})`,
   radiusSmall: `var(--vendo-radius-small, ${d.radius.small})`,
   radiusMedium: `var(--vendo-radius-medium, ${d.radius.medium})`,
@@ -44,6 +51,11 @@ export const font: CSSProperties = {
 export const control: CSSProperties = {
   ...font,
   width: "100%",
+  // `width: 100%` with padding and a border overflows its column by 26px
+  // unless the border-box is the thing being sized. The Kit renders inside a
+  // host page it does not control, so it cannot assume a `* { box-sizing }`
+  // reset is in force — every full-width Kit surface states it itself.
+  boxSizing: "border-box",
   minWidth: 0,
   minHeight: "var(--vendo-density-control-height, 38px)",
   border: `1px solid ${t.border}`,
@@ -51,6 +63,75 @@ export const control: CSSProperties = {
   background: t.surface,
   padding: "var(--vendo-density-control-padding, 9px 12px)",
 };
+
+// ---------------------------------------------------------------------------
+// The two adjectives (2026-08-13). One `tone` vocabulary and one `density`
+// vocabulary, shared by every component that has an opinion about either, and
+// resolving to nothing but the tokens above — so an adjective can never invent
+// a color or a spacing step the host did not agree to.
+// ---------------------------------------------------------------------------
+
+/** The ONE tone vocabulary. Card/Stat's "default" and Callout's "info" are the
+ *  older spellings of `neutral`; both still parse. */
+export type KitTone = "neutral" | "accent" | "success" | "warning" | "danger";
+
+/** The ONE density vocabulary — the host theme's own (`VendoTheme.density`). */
+export type KitDensity = "comfortable" | "compact";
+
+/** A tone's foreground, surface and border. Every entry is a token or a
+ *  `color-mix` of tokens. */
+export const toneStyle: Record<KitTone, { color: string; background: string; border: string }> = {
+  neutral: {
+    color: t.text,
+    background: `color-mix(in srgb, ${t.muted} 10%, ${t.surface})`,
+    border: t.border,
+  },
+  accent: { color: t.accentText, background: t.accent, border: t.accent },
+  success: {
+    color: `color-mix(in srgb, ${t.success} 88%, #000)`,
+    background: `color-mix(in srgb, ${t.success} 12%, ${t.surface})`,
+    border: `color-mix(in srgb, ${t.success} 30%, ${t.border})`,
+  },
+  warning: {
+    color: `color-mix(in srgb, ${t.warning} 72%, #000)`,
+    background: `color-mix(in srgb, ${t.warning} 16%, ${t.surface})`,
+    border: `color-mix(in srgb, ${t.warning} 34%, ${t.border})`,
+  },
+  danger: {
+    color: t.danger,
+    background: `color-mix(in srgb, ${t.danger} 11%, ${t.surface})`,
+    border: `color-mix(in srgb, ${t.danger} 30%, ${t.border})`,
+  },
+};
+
+/** A tone's own color, for text and rules that carry a tone WITHOUT a pill —
+ *  an emphasised Stat, a Card's border, a toned figure in a cell. */
+export function toneColor(tone: KitTone): string {
+  return tone === "accent" ? t.accent : toneStyle[tone].color;
+}
+
+/**
+ * Read a tone off a prop. Generated code passes arbitrary strings, so an
+ * unknown word falls back rather than crashing (the Callout lesson,
+ * 2026-07-26), and the two legacy spellings resolve to what they always meant.
+ * `Object.hasOwn`, not a bare index: "constructor" is a string too.
+ */
+export function resolveTone(value: string | undefined, fallback: KitTone = "neutral"): KitTone {
+  if (value === undefined) return fallback;
+  if (value === "default" || value === "info") return "neutral";
+  return Object.hasOwn(toneStyle, value) ? (value as KitTone) : fallback;
+}
+
+/**
+ * The density scale as inline custom properties, so a container can re-declare
+ * it for its own subtree. Every Kit component already reads its padding and
+ * gaps from these variables, so setting them here is the WHOLE implementation
+ * of `density` — nothing measures, nothing branches, and a component the
+ * adjective was never taught about still gets denser.
+ */
+export function densityVars(density: KitDensity | undefined): CSSProperties {
+  return density === undefined ? {} : (densityCssVariables(density) as CSSProperties);
+}
 
 /**
  * Series lightness ladder, as `[lightness, chroma scale]` in OKLCH. Absolute

--- a/packages/ui/src/kit/tokens.ts
+++ b/packages/ui/src/kit/tokens.ts
@@ -87,13 +87,15 @@ export const toneStyle: Record<KitTone, { color: string; background: string; bor
     border: t.border,
   },
   accent: { color: t.accentText, background: t.accent, border: t.accent },
+  // Darkened against `text`, not against `#000`: a literal black is not a token,
+  // and on a dark host theme it drove both foregrounds INTO the background.
   success: {
-    color: `color-mix(in srgb, ${t.success} 88%, #000)`,
+    color: `color-mix(in srgb, ${t.success} 88%, ${t.text})`,
     background: `color-mix(in srgb, ${t.success} 12%, ${t.surface})`,
     border: `color-mix(in srgb, ${t.success} 30%, ${t.border})`,
   },
   warning: {
-    color: `color-mix(in srgb, ${t.warning} 72%, #000)`,
+    color: `color-mix(in srgb, ${t.warning} 72%, ${t.text})`,
     background: `color-mix(in srgb, ${t.warning} 16%, ${t.surface})`,
     border: `color-mix(in srgb, ${t.warning} 34%, ${t.border})`,
   },
@@ -105,9 +107,12 @@ export const toneStyle: Record<KitTone, { color: string; background: string; bor
 };
 
 /** A tone's own color, for text and rules that carry a tone WITHOUT a pill —
- *  an emphasised Stat, a Card's border, a toned figure in a cell. */
-export function toneColor(tone: KitTone): string {
-  return tone === "accent" ? t.accent : toneStyle[tone].color;
+ *  an emphasised Stat, a Card's border, a toned figure in a cell. Total like
+ *  {@link resolveTone}, because this one is exported into code-land too and an
+ *  unknown word must fall back rather than throw on `toneStyle[bogus].color`. */
+export function toneColor(tone: string | undefined): string {
+  const resolved = resolveTone(tone);
+  return resolved === "accent" ? t.accent : toneStyle[resolved].color;
 }
 
 /**

--- a/packages/ui/src/kit/values.tsx
+++ b/packages/ui/src/kit/values.tsx
@@ -39,20 +39,30 @@ function Placeholder(): ReactNode {
 
 const numeric: CSSProperties = { fontVariantNumeric: "tabular-nums" };
 
+/** A tone's paint, or nothing at all — an absent (or neutral) tone leaves the
+ *  component's own color exactly as it was. The catalog teaches "the figure that
+ *  is bad news is `danger`", so every figure has to answer to it. */
+function tonePaint(tone: KitTone | undefined): CSSProperties {
+  const resolved = resolveTone(tone);
+  return resolved === "neutral" ? {} : { color: toneColor(resolved) };
+}
+
 export interface MoneyProps extends MoneyOptions {
   /** The amount in MAJOR units (dollars) — formatters never convert, so a cents
    *  field is divided by 100 before it gets here. */
   amount?: number;
+  /** Paints the figure — an overdue amount is `danger`. */
+  tone?: KitTone;
   /** Inside a cell slot: the row field this amount comes from. */
   field?: string;
 }
 
 /** Currency from a major-unit amount. `<Money amount={1234.56}/>` → "$1,234.56". */
-export function Money({ amount, currency, locale, field }: MoneyProps) {
+export function Money({ amount, currency, locale, tone, field }: MoneyProps) {
   const formatted = formatMoney(useValue(field, amount), { currency, locale });
   if (formatted === null) return <Placeholder />;
   return (
-    <span data-kit="Money" style={{ ...font, ...numeric }}>
+    <span data-kit="Money" style={{ ...font, ...numeric, ...tonePaint(tone) }}>
       {formatted}
     </span>
   );
@@ -60,16 +70,18 @@ export function Money({ amount, currency, locale, field }: MoneyProps) {
 
 export interface DateTimeProps extends DateTimeOptions {
   value?: DateInput;
+  /** Paints the date — a date that is bad news is `danger`. */
+  tone?: KitTone;
   /** Inside a cell slot: the row field this date comes from. */
   field?: string;
 }
 
 /** A date/time. `<DateTime value="2026-03-14" mode="date"/>` → "Mar 14, 2026". */
-export function DateTime({ value, mode, locale, timeZone, compact, field }: DateTimeProps) {
+export function DateTime({ value, mode, locale, timeZone, compact, tone, field }: DateTimeProps) {
   const formatted = formatDateTime(useValue(field, value), { mode, locale, timeZone, compact });
   if (formatted === null) return <Placeholder />;
   return (
-    <span data-kit="DateTime" style={font}>
+    <span data-kit="DateTime" style={{ ...font, ...tonePaint(tone) }}>
       {formatted}
     </span>
   );
@@ -80,16 +92,18 @@ export interface PercentProps {
   value?: number;
   fractionDigits?: number;
   whole?: boolean;
+  /** Paints the figure — a `danger` share is how a breach reads red. */
+  tone?: KitTone;
   /** Inside a cell slot: the row field this ratio comes from. */
   field?: string;
 }
 
 /** A percentage from a ratio. `<Percent value={0.42}/>` → "42%". */
-export function Percent({ value, fractionDigits, whole, field }: PercentProps) {
+export function Percent({ value, fractionDigits, whole, tone, field }: PercentProps) {
   const formatted = formatPercent(useValue(field, value), { fractionDigits, whole });
   if (formatted === null) return <Placeholder />;
   return (
-    <span data-kit="Percent" style={{ ...font, ...numeric }}>
+    <span data-kit="Percent" style={{ ...font, ...numeric, ...tonePaint(tone) }}>
       {formatted}
     </span>
   );
@@ -99,16 +113,18 @@ export interface NumProps {
   value?: number;
   maximumFractionDigits?: number;
   notation?: "standard" | "compact";
+  /** Paints the figure — the count that is bad news is `danger`. */
+  tone?: KitTone;
   /** Inside a cell slot: the row field this number comes from. */
   field?: string;
 }
 
 /** A grouped number. `<Num value={1234567}/>` → "1,234,567". */
-export function Num({ value, maximumFractionDigits, notation, field }: NumProps) {
+export function Num({ value, maximumFractionDigits, notation, tone, field }: NumProps) {
   const formatted = formatNum(useValue(field, value), { maximumFractionDigits, notation });
   if (formatted === null) return <Placeholder />;
   return (
-    <span data-kit="Num" style={{ ...font, ...numeric }}>
+    <span data-kit="Num" style={{ ...font, ...numeric, ...tonePaint(tone) }}>
       {formatted}
     </span>
   );
@@ -141,13 +157,20 @@ export interface EnumBadgeProps {
   field?: string;
 }
 
+/** A record entry the model authored, or nothing. `Object.hasOwn`, not a bare
+ *  index: an enum value of "toString" would otherwise pick up
+ *  `Object.prototype`'s member — a function handed to React as a child. */
+function own<T>(record: Record<string, T> | undefined, key: string): T | undefined {
+  return record !== undefined && Object.hasOwn(record, key) ? record[key] : undefined;
+}
+
 /** A status pill for enum fields — humanized label, tone-mapped color. */
 export function EnumBadge({ value, labels, tones, tone, field }: EnumBadgeProps) {
   const key = applyFormat(useValue(field, value), "text");
   if (key === null) return null;
-  const resolvedTone = resolveTone(tones?.[key] ?? tone);
+  const resolvedTone = resolveTone(own(tones, key) ?? tone);
   const style = toneStyle[resolvedTone];
-  const label = labels?.[key] ?? humanizeEnum(key);
+  const label = own(labels, key) ?? humanizeEnum(key);
   return (
     <span
       data-kit="EnumBadge"
@@ -184,21 +207,33 @@ export interface TextProps {
 
 /** Themed text. Heading renders an <h3>; others render a <span>. */
 export function Text({ text, variant = "body", tone, field }: TextProps) {
-  // A row field holds ANYTHING, and a plain object as a React child throws
-  // ("Objects are not valid as a React child") — so a non-node collapses to the
-  // placeholder like every other unrenderable value in this tier.
+  // A row field holds ANYTHING: a plain object as a React child throws
+  // ("Objects are not valid as a React child") and a boolean renders as
+  // literally NOTHING, which is how `active: false` came out blank. An element
+  // passes through as itself; every other value goes through the tier's total
+  // coercion — an object never reaching the formatter, which would spell it
+  // "[object Object]".
+  //
+  // ABSENT is not the same as unrenderable, and only Text can tell them apart:
+  // a binding whose query has not answered yet resolves to undefined, and a
+  // placeholder dash there reads as "no data" for data that is still on its
+  // way. Nothing renders as nothing; the dash is for a value that arrived and
+  // could not be shown.
   const value = useValue<ReactNode>(field, text);
-  const content =
-    typeof value === "object" && value !== null && !isValidElement(value) ? <Placeholder /> : value;
-  const resolvedTone = resolveTone(tone);
+  const content = isValidElement(value)
+    ? value
+    : value === undefined || value === null || value === ""
+      ? null
+      : (applyFormat(typeof value === "object" ? null : value, "text") ?? <Placeholder />);
   const style: CSSProperties = {
-    color: resolvedTone !== "neutral" ? toneColor(resolvedTone) : variant === "caption" ? t.muted : t.text,
+    color: variant === "caption" ? t.muted : t.text,
     fontFamily: variant === "heading" ? t.headingFamily : t.fontFamily,
     fontSize: variant === "caption" ? "var(--vendo-font-size-caption, 12.5px)" : t.fontSize,
     fontWeight: variant === "heading" ? 650 : variant === "label" ? 600 : 400,
     letterSpacing: "-0.011em",
     lineHeight: variant === "heading" ? 1.3 : 1.5,
     margin: 0,
+    ...tonePaint(tone),
   };
   if (variant === "heading") {
     return (

--- a/packages/ui/src/kit/values.tsx
+++ b/packages/ui/src/kit/values.tsx
@@ -3,8 +3,9 @@
  * Money takes MAJOR units (dollars); dates take ISO/epoch/Date; percent takes a ratio.
  * Any unrenderable value collapses to a muted placeholder, never bad text.
  */
-import type { CSSProperties, ReactNode } from "react";
+import { isValidElement, type CSSProperties, type ReactNode } from "react";
 import {
+  applyFormat,
   formatDateTime,
   formatMoney,
   formatNum,
@@ -13,9 +14,20 @@ import {
   type DateTimeOptions,
   type MoneyOptions,
 } from "./format.js";
-import { font, t } from "./tokens.js";
+import { useFieldValue } from "./row.js";
+import { font, resolveTone, t, toneColor, toneStyle, type KitTone } from "./tokens.js";
 
 const PLACEHOLDER = "—";
+
+/**
+ * What this component renders: the row's field when it is standing in a cell
+ * slot and named one, its own prop otherwise. The cast is safe because every
+ * formatter below is TOTAL — a field holding the wrong type comes back `null`
+ * and renders the placeholder, exactly as NaN does.
+ */
+function useValue<T>(field: string | undefined, own: T): T {
+  return useFieldValue(field, own) as T;
+}
 
 function Placeholder(): ReactNode {
   return (
@@ -30,12 +42,14 @@ const numeric: CSSProperties = { fontVariantNumeric: "tabular-nums" };
 export interface MoneyProps extends MoneyOptions {
   /** The amount in MAJOR units (dollars) — formatters never convert, so a cents
    *  field is divided by 100 before it gets here. */
-  amount: number;
+  amount?: number;
+  /** Inside a cell slot: the row field this amount comes from. */
+  field?: string;
 }
 
 /** Currency from a major-unit amount. `<Money amount={1234.56}/>` → "$1,234.56". */
-export function Money({ amount, currency, locale }: MoneyProps) {
-  const formatted = formatMoney(amount, { currency, locale });
+export function Money({ amount, currency, locale, field }: MoneyProps) {
+  const formatted = formatMoney(useValue(field, amount), { currency, locale });
   if (formatted === null) return <Placeholder />;
   return (
     <span data-kit="Money" style={{ ...font, ...numeric }}>
@@ -45,12 +59,14 @@ export function Money({ amount, currency, locale }: MoneyProps) {
 }
 
 export interface DateTimeProps extends DateTimeOptions {
-  value: DateInput;
+  value?: DateInput;
+  /** Inside a cell slot: the row field this date comes from. */
+  field?: string;
 }
 
 /** A date/time. `<DateTime value="2026-03-14" mode="date"/>` → "Mar 14, 2026". */
-export function DateTime({ value, mode, locale, timeZone }: DateTimeProps) {
-  const formatted = formatDateTime(value, { mode, locale, timeZone });
+export function DateTime({ value, mode, locale, timeZone, compact, field }: DateTimeProps) {
+  const formatted = formatDateTime(useValue(field, value), { mode, locale, timeZone, compact });
   if (formatted === null) return <Placeholder />;
   return (
     <span data-kit="DateTime" style={font}>
@@ -61,14 +77,16 @@ export function DateTime({ value, mode, locale, timeZone }: DateTimeProps) {
 
 export interface PercentProps {
   /** A ratio (0.42 → "42%") unless `whole`. */
-  value: number;
+  value?: number;
   fractionDigits?: number;
   whole?: boolean;
+  /** Inside a cell slot: the row field this ratio comes from. */
+  field?: string;
 }
 
 /** A percentage from a ratio. `<Percent value={0.42}/>` → "42%". */
-export function Percent({ value, fractionDigits, whole }: PercentProps) {
-  const formatted = formatPercent(value, { fractionDigits, whole });
+export function Percent({ value, fractionDigits, whole, field }: PercentProps) {
+  const formatted = formatPercent(useValue(field, value), { fractionDigits, whole });
   if (formatted === null) return <Placeholder />;
   return (
     <span data-kit="Percent" style={{ ...font, ...numeric }}>
@@ -78,14 +96,16 @@ export function Percent({ value, fractionDigits, whole }: PercentProps) {
 }
 
 export interface NumProps {
-  value: number;
+  value?: number;
   maximumFractionDigits?: number;
   notation?: "standard" | "compact";
+  /** Inside a cell slot: the row field this number comes from. */
+  field?: string;
 }
 
 /** A grouped number. `<Num value={1234567}/>` → "1,234,567". */
-export function Num({ value, maximumFractionDigits, notation }: NumProps) {
-  const formatted = formatNum(value, { maximumFractionDigits, notation });
+export function Num({ value, maximumFractionDigits, notation, field }: NumProps) {
+  const formatted = formatNum(useValue(field, value), { maximumFractionDigits, notation });
   if (formatted === null) return <Placeholder />;
   return (
     <span data-kit="Num" style={{ ...font, ...numeric }}>
@@ -94,31 +114,9 @@ export function Num({ value, maximumFractionDigits, notation }: NumProps) {
   );
 }
 
-export type EnumTone = "neutral" | "accent" | "success" | "warning" | "danger";
-
-const TONE_STYLE: Record<EnumTone, { color: string; background: string; border: string }> = {
-  neutral: {
-    color: t.text,
-    background: `color-mix(in srgb, ${t.muted} 10%, ${t.surface})`,
-    border: t.border,
-  },
-  accent: { color: t.accentText, background: t.accent, border: t.accent },
-  success: {
-    color: "color-mix(in srgb, #1e7f53 88%, #000)",
-    background: "color-mix(in srgb, #1e7f53 12%, var(--vendo-color-surface, #ffffff))",
-    border: "color-mix(in srgb, #1e7f53 30%, var(--vendo-color-border, #e3e3e8))",
-  },
-  warning: {
-    color: "color-mix(in srgb, #9a6700 90%, #000)",
-    background: "color-mix(in srgb, #d4a017 16%, var(--vendo-color-surface, #ffffff))",
-    border: "color-mix(in srgb, #d4a017 34%, var(--vendo-color-border, #e3e3e8))",
-  },
-  danger: {
-    color: t.danger,
-    background: `color-mix(in srgb, ${t.danger} 11%, ${t.surface})`,
-    border: `color-mix(in srgb, ${t.danger} 30%, ${t.border})`,
-  },
-};
+/** The pill vocabulary is the ONE tone vocabulary; the name stays because
+ *  Badge and the specs already speak it. */
+export type EnumTone = KitTone;
 
 /** Turn "past_due" / "pastDue" into "Past due". */
 export function humanizeEnum(value: string): string {
@@ -132,21 +130,24 @@ export function humanizeEnum(value: string): string {
 
 export interface EnumBadgeProps {
   /** The raw enum value from data. */
-  value: string | null | undefined;
+  value?: string | null;
   /** Optional value → display label overrides. */
   labels?: Record<string, string>;
   /** Optional value → tone overrides. */
   tones?: Record<string, EnumTone>;
   /** Fallback tone when no override matches. */
   tone?: EnumTone;
+  /** Inside a cell slot: the row field this enum comes from. */
+  field?: string;
 }
 
 /** A status pill for enum fields — humanized label, tone-mapped color. */
-export function EnumBadge({ value, labels, tones, tone = "neutral" }: EnumBadgeProps) {
-  if (value === null || value === undefined || value === "") return null;
-  const resolvedTone = tones?.[value] ?? tone;
-  const style = TONE_STYLE[resolvedTone];
-  const label = labels?.[value] ?? humanizeEnum(value);
+export function EnumBadge({ value, labels, tones, tone, field }: EnumBadgeProps) {
+  const key = applyFormat(useValue(field, value), "text");
+  if (key === null) return null;
+  const resolvedTone = resolveTone(tones?.[key] ?? tone);
+  const style = toneStyle[resolvedTone];
+  const label = labels?.[key] ?? humanizeEnum(key);
   return (
     <span
       data-kit="EnumBadge"
@@ -173,14 +174,25 @@ export function EnumBadge({ value, labels, tones, tone = "neutral" }: EnumBadgeP
 }
 
 export interface TextProps {
-  text: ReactNode;
+  text?: ReactNode;
   variant?: "body" | "heading" | "caption" | "label";
+  /** Paints the text — a `danger` figure is how an overdue amount reads red. */
+  tone?: KitTone;
+  /** Inside a cell slot: the row field this text comes from. */
+  field?: string;
 }
 
 /** Themed text. Heading renders an <h3>; others render a <span>. */
-export function Text({ text, variant = "body" }: TextProps) {
+export function Text({ text, variant = "body", tone, field }: TextProps) {
+  // A row field holds ANYTHING, and a plain object as a React child throws
+  // ("Objects are not valid as a React child") — so a non-node collapses to the
+  // placeholder like every other unrenderable value in this tier.
+  const value = useValue<ReactNode>(field, text);
+  const content =
+    typeof value === "object" && value !== null && !isValidElement(value) ? <Placeholder /> : value;
+  const resolvedTone = resolveTone(tone);
   const style: CSSProperties = {
-    color: variant === "caption" ? t.muted : t.text,
+    color: resolvedTone !== "neutral" ? toneColor(resolvedTone) : variant === "caption" ? t.muted : t.text,
     fontFamily: variant === "heading" ? t.headingFamily : t.fontFamily,
     fontSize: variant === "caption" ? "var(--vendo-font-size-caption, 12.5px)" : t.fontSize,
     fontWeight: variant === "heading" ? 650 : variant === "label" ? 600 : 400,
@@ -191,13 +203,13 @@ export function Text({ text, variant = "body" }: TextProps) {
   if (variant === "heading") {
     return (
       <h3 data-kit="Text" data-variant={variant} style={style}>
-        {text}
+        {content}
       </h3>
     );
   }
   return (
     <span data-kit="Text" data-variant={variant} style={style}>
-      {text}
+      {content}
     </span>
   );
 }

--- a/packages/ui/src/tree/renderer.tsx
+++ b/packages/ui/src/tree/renderer.tsx
@@ -252,6 +252,38 @@ export function isHandlerBinding(value: unknown): value is HandlerBinding {
     && typeof (value as { $handler?: unknown }).$handler === "string";
 }
 
+/**
+ * A Kit element a screen wrote INTO a prop — a table column's `cell`, an
+ * accordion item's `content`. It crosses the VM as data, stamped `$element`
+ * (apps genui/component/vm-program.ts `emitValue`), and is reified here.
+ */
+interface ElementBinding {
+  component: string;
+  props?: Record<string, unknown>;
+  children?: readonly unknown[];
+}
+
+const isElementNode = (value: unknown): value is ElementBinding =>
+  isPlainRecord(value) && typeof value.component === "string";
+
+/** The sigil rides on the prop's own element and on nothing else: a data object
+ *  that happens to carry a `component` string is still data. */
+const isElementBinding = (value: unknown): value is ElementBinding =>
+  isElementNode(value) && (value as { $element?: unknown }).$element === true;
+
+/** That element, back as an element: the Kit component it names, its own props
+ *  bound the same way, its children in order. An unknown name renders nothing
+ *  rather than throwing — a slot fails soft, like every other node here. */
+function reifyElement(node: ElementBinding, bind: (value: unknown) => unknown): ReactNode {
+  const Implementation = KIT_COMPONENTS[node.component] as ComponentType<Record<string, unknown>> | undefined;
+  if (Implementation === undefined) return null;
+  // Only the prop's own element carries the sigil; the ones under it are nodes.
+  const children = node.children?.map((child, index) => typeof child === "string"
+    ? child
+    : <Fragment key={index}>{isElementNode(child) ? reifyElement(child, bind) : null}</Fragment>);
+  return <Implementation {...bind(node.props ?? {}) as Record<string, unknown>}>{children}</Implementation>;
+}
+
 /** The node's own handler dispatch, node-scoped by NodeRenderer. */
 type HandlerDispatch = (handlerId: string, event?: unknown) => void;
 
@@ -316,6 +348,12 @@ function bindValue(
     return handle === undefined
       ? () => undefined
       : markHandlerCallback((event?: unknown) => handle(value.$handler, screenEvent(event)));
+  }
+  // A slot's element becomes a real element only in the host page. In the jail
+  // it falls through as the data it is: props cross to that frame by
+  // postMessage, and no element survives a structured clone.
+  if (isElementBinding(value) && mode === "host") {
+    return reifyElement(value, (child) => bindValue(child, mode, data, state, action, handle, onMismatch));
   }
   if (Array.isArray(value)) return value.map((item) => bindValue(item, mode, data, state, action, handle, onMismatch));
   if (typeof value === "object" && value !== null) {

--- a/packages/ui/test/kit/adjectives.test.tsx
+++ b/packages/ui/test/kit/adjectives.test.tsx
@@ -13,7 +13,8 @@ import { Badge } from "../../src/kit/data/badge.js";
 import { Callout } from "../../src/kit/feedback/callout.js";
 import { Card, Grid, Row, Stack, Surface } from "../../src/kit/layout.js";
 import { RowContext } from "../../src/kit/row.js";
-import { EnumBadge, Text } from "../../src/kit/values.js";
+import { toneColor } from "../../src/kit/tokens.js";
+import { DateTime, EnumBadge, Money, Num, Percent, Text } from "../../src/kit/values.js";
 
 /** Every Kit component tags its own root, so that is the handle these use. */
 function kit(container: HTMLElement, name: string): HTMLElement {
@@ -73,6 +74,44 @@ describe("tone is a theme token, never a literal color", () => {
     expect(screen.getByText("Overdue").style.color).toContain("var(--vendo-color-danger");
     render(<Badge label="Beta" tone="success" />);
     expect(screen.getByText("Beta").style.color).toContain("var(--vendo-color-success");
+  });
+
+  // The catalog teaches "the figure that is bad news is `danger`", i.e. exactly
+  // `<Money field="amount" tone="danger"/>` — which painted nothing at all while
+  // only Text and the pills read the adjective.
+  it("every figure in the value tier paints from the palette", () => {
+    const figures: Array<[string, ReactElement]> = [
+      ["Money", <Money amount={2500} tone="danger" />],
+      ["DateTime", <DateTime value="2026-03-14" tone="danger" />],
+      ["Percent", <Percent value={0.42} tone="danger" />],
+      ["Num", <Num value={1234} tone="danger" />],
+    ];
+    for (const [name, node] of figures) {
+      expect(kit(render(node).container, name).style.color, name).toContain("var(--vendo-color-danger");
+    }
+  });
+
+  it("an untoned figure is untouched, and neutral is not a color of its own", () => {
+    const plain = kit(render(<Money amount={2500} />).container, "Money").style.color;
+    expect(plain).toContain("var(--vendo-color-text");
+    expect(kit(render(<Money amount={2500} tone="neutral" />).container, "Money").style.color).toBe(plain);
+  });
+
+  // The pill palette's own docblock promises every entry is a token or a mix of
+  // tokens. Mixing the foreground with a literal `#000` broke that, and drove
+  // both foregrounds into the background of a dark host theme.
+  it("darkens the success/warning foregrounds against the TEXT token, never a literal black", () => {
+    render(<EnumBadge value="paid" tones={{ paid: "success" }} />);
+    const color = screen.getByText("Paid").style.color;
+    expect(color).toContain("var(--vendo-color-success");
+    expect(color).toContain("var(--vendo-color-text");
+    expect(color).not.toContain("#000");
+  });
+
+  it("an unknown tone falls back rather than throwing — toneColor is code-land too", () => {
+    expect(() => toneColor("bogus")).not.toThrow();
+    expect(toneColor("bogus")).toBe(toneColor("neutral"));
+    expect(toneColor(undefined)).toBe(toneColor("neutral"));
   });
 });
 

--- a/packages/ui/test/kit/adjectives.test.tsx
+++ b/packages/ui/test/kit/adjectives.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment jsdom
+// The two adjectives (2026-08-13) — one `tone` vocabulary and one `density`
+// vocabulary shared by the whole Kit. What this suite pins is the property that
+// makes them safe to hand a model: both resolve to nothing but THEME TOKENS, so
+// an adjective can never invent a color or a spacing step the host did not agree
+// to. It also pins the spellings stored apps already carry ("default", "info"),
+// which is the only reason those words are still in the resolver.
+import { render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { describe, expect, it } from "vitest";
+import { Progress } from "../../src/kit/charts/progress.js";
+import { Badge } from "../../src/kit/data/badge.js";
+import { Callout } from "../../src/kit/feedback/callout.js";
+import { Card, Grid, Row, Stack, Surface } from "../../src/kit/layout.js";
+import { RowContext } from "../../src/kit/row.js";
+import { EnumBadge, Text } from "../../src/kit/values.js";
+
+/** Every Kit component tags its own root, so that is the handle these use. */
+function kit(container: HTMLElement, name: string): HTMLElement {
+  const el = container.querySelector<HTMLElement>(`[data-kit="${name}"]`);
+  expect(el, `no [data-kit="${name}"] rendered`).not.toBeNull();
+  return el!;
+}
+
+const cardBorder = (tone?: string): string =>
+  kit(render(<Card title="Balance" tone={tone as never} />).container, "Card").style.border;
+
+const progressFill = (tone?: string): string => {
+  const { container } = render(<Progress value={0.5} tone={tone as never} />);
+  return container.querySelector<HTMLElement>('[role="progressbar"] > div')!.style.background;
+};
+
+describe("tone is a theme token, never a literal color", () => {
+  it("a Card's rule carries the danger token, and neutral keeps the plain border", () => {
+    expect(cardBorder("danger")).toContain("var(--vendo-color-danger");
+    expect(cardBorder("neutral")).toContain("var(--vendo-color-border");
+    expect(cardBorder("danger")).not.toBe(cardBorder("neutral"));
+  });
+
+  it("success and warning are tokens too — the two tones the host contract has no color for", () => {
+    expect(cardBorder("success")).toContain("var(--vendo-color-success");
+    expect(cardBorder("warning")).toContain("var(--vendo-color-warning");
+  });
+
+  it("a Surface takes the same vocabulary as a Card", () => {
+    const { container } = render(<Surface title="Overdue" tone="danger" />);
+    const surface = kit(container, "Surface");
+    expect(surface.getAttribute("data-tone")).toBe("danger");
+    expect(surface.style.border).toContain("var(--vendo-color-danger");
+  });
+
+  it("a toned Text paints from the palette — the red overdue figure", () => {
+    const danger = kit(render(<Text text="9 days late" tone="danger" />).container, "Text").style.color;
+    const neutral = kit(render(<Text text="9 days late" tone="neutral" />).container, "Text").style.color;
+    expect(danger).toContain("var(--vendo-color-danger");
+    expect(danger).not.toBe(neutral);
+    // Neutral is not a color of its own: it leaves the variant's own color alone.
+    expect(neutral).toBe(kit(render(<Text text="9 days late" />).container, "Text").style.color);
+    expect(kit(render(<Text text="note" variant="caption" />).container, "Text").style.color).toContain(
+      "var(--vendo-color-muted",
+    );
+  });
+
+  it("a toned Progress fills from the palette, and still defaults to the accent", () => {
+    expect(progressFill("danger")).toContain("var(--vendo-color-danger");
+    expect(progressFill("success")).toContain("var(--vendo-color-success");
+    expect(progressFill("danger")).not.toBe(progressFill("neutral"));
+    expect(progressFill()).toContain("var(--vendo-color-accent");
+  });
+
+  it("the pills speak the same five words", () => {
+    render(<EnumBadge value="overdue" tones={{ overdue: "danger" }} />);
+    expect(screen.getByText("Overdue").style.color).toContain("var(--vendo-color-danger");
+    render(<Badge label="Beta" tone="success" />);
+    expect(screen.getByText("Beta").style.color).toContain("var(--vendo-color-success");
+  });
+});
+
+describe("the legacy spellings stored apps carry", () => {
+  it('Card tone="default" still renders, as neutral', () => {
+    const { container } = render(<Card title="Balance" tone={"default" as never} />);
+    const card = kit(container, "Card");
+    expect(card.getAttribute("data-tone")).toBe("neutral");
+    expect(card.style.border).toContain("var(--vendo-color-border");
+  });
+
+  it('an EnumBadge tone map may still say "default"', () => {
+    render(<EnumBadge value="draft" tones={{ draft: "default" as never }} />);
+    expect(screen.getByText("Draft").getAttribute("data-tone")).toBe("neutral");
+  });
+
+  it('Callout tone="info" stays the accented ⓘ notice, and stays the default', () => {
+    const info = kit(render(<Callout tone="info" title="FYI">Body.</Callout>).container, "Callout");
+    expect(info.style.borderLeft).toContain("var(--vendo-color-accent");
+    expect(info.textContent).toContain("ⓘ");
+    const noTone = kit(render(<Callout title="FYI">Body.</Callout>).container, "Callout");
+    expect(noTone.getAttribute("style")).toBe(info.getAttribute("style"));
+  });
+
+  it('Callout also answers to the shared "neutral"', () => {
+    const { container } = render(<Callout tone="neutral">Nothing urgent.</Callout>);
+    expect(kit(container, "Callout").style.borderLeft).toContain("var(--vendo-color-text");
+    expect(screen.getByText("Nothing urgent.")).toBeTruthy();
+  });
+});
+
+describe("density is declared once and inherited", () => {
+  it("a compact container re-declares the whole spacing ladder on its own element", () => {
+    const { container } = render(<Stack density="compact" />);
+    const stack = kit(container, "Stack");
+    expect(stack.style.getPropertyValue("--vendo-density")).toBe("compact");
+    expect(stack.style.getPropertyValue("--vendo-density-table-padding")).toBe("7px 10px");
+    expect(stack.style.getPropertyValue("--vendo-density-card-padding")).toBe("12px");
+    expect(stack.style.getPropertyValue("--vendo-density-badge-height")).toBe("20px");
+  });
+
+  it("comfortable declares the other end of the same ladder", () => {
+    const { container } = render(<Stack density="comfortable" />);
+    expect(kit(container, "Stack").style.getPropertyValue("--vendo-density-table-padding")).toBe("10px 12px");
+  });
+
+  it("no density declares nothing, so the host page's own scale still wins", () => {
+    const { container } = render(<Stack />);
+    expect(kit(container, "Stack").style.getPropertyValue("--vendo-density")).toBe("");
+    expect(kit(container, "Stack").style.getPropertyValue("--vendo-density-card-padding")).toBe("");
+  });
+
+  it("a child READS the variables the container declared — the whole implementation", () => {
+    const { container } = render(
+      <Stack density="compact">
+        <Surface title="Invoices" />
+      </Stack>,
+    );
+    const stack = kit(container, "Stack");
+    const surface = kit(container, "Surface");
+    // Name-matched rather than computed: jsdom does not resolve var(), so what
+    // is provable here is the seam itself — the child names the same custom
+    // property the parent set, which is why nothing had to branch on density.
+    expect(surface.style.padding).toContain("var(--vendo-density-card-padding");
+    expect(stack.style.getPropertyValue("--vendo-density-card-padding")).toBe("12px");
+    expect(surface.style.gap).toContain("var(--vendo-density-content-gap");
+    expect(stack.style.getPropertyValue("--vendo-density-content-gap")).toBe("7px");
+  });
+
+  it("every container takes the adjective", () => {
+    const containers: Array<[string, ReactElement]> = [
+      ["Stack", <Stack density="compact" />],
+      ["Row", <Row density="compact" />],
+      ["Grid", <Grid density="compact" />],
+      ["Surface", <Surface density="compact" />],
+      ["Card", <Card density="compact" />],
+    ];
+    for (const [name, node] of containers) {
+      const { container } = render(node);
+      expect(kit(container, name).style.getPropertyValue("--vendo-density"), name).toBe("compact");
+    }
+  });
+});
+
+describe("Grid minChildWidth", () => {
+  it("auto-fits so cells wrap instead of clipping, and wins over columns", () => {
+    const { container } = render(<Grid columns={4} minChildWidth={160} />);
+    expect(kit(container, "Grid").style.gridTemplateColumns).toBe(
+      "repeat(auto-fit, minmax(min(160px, 100%), 1fr))",
+    );
+  });
+
+  it("keeps the fixed count when no floor is given", () => {
+    const { container } = render(<Grid columns={3} />);
+    expect(kit(container, "Grid").style.gridTemplateColumns).toBe("repeat(3, minmax(0, 1fr))");
+  });
+});
+
+// Badge's own suite lives in another file; its two new adjectives are here.
+describe("Badge", () => {
+  it("reads the row's field in a cell slot, and its own label outside one", () => {
+    render(
+      <RowContext.Provider value={{ plan: "Pro" }}>
+        <Badge label="Beta" field="plan" />
+      </RowContext.Provider>,
+    );
+    expect(screen.getByText("Pro")).toBeTruthy();
+    render(<Badge label="Beta" field="plan" />);
+    expect(screen.getByText("Beta")).toBeTruthy();
+  });
+});

--- a/packages/ui/test/kit/charts.test.tsx
+++ b/packages/ui/test/kit/charts.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
 import { describe, expect, it } from "vitest";
 import { RowContext } from "../../src/kit/row.js";
 import { sanitizeSeries, sanitizeNumbers } from "../../src/kit/charts/sanitize.js";
@@ -106,15 +107,18 @@ describe("Progress", () => {
 describe("DonutChart legend", () => {
   const spend = [
     { label: "rent", value: 1200 },
-    { label: "food_and_drink", value: 340 },
+    { label: "ACME Corp", value: 340 },
   ];
 
-  it("names and values every slice by default", () => {
+  // The legend names a slice the way the DATA spells it, which is what the
+  // slice's own tooltip shows. Humanizing it lowercased proper nouns and made
+  // the two disagree on the same ring.
+  it("names and values every slice by default, in the data's own words", () => {
     // An unlabelled ring says nothing in a screenshot: a tooltip is not a label.
     render(<DonutChart data={spend} categoryKey="label" valueKey="value" format="money" />);
-    expect(screen.getByText("Rent")).toBeTruthy();
+    expect(screen.getByText("rent")).toBeTruthy();
     expect(screen.getByText("$1,200.00")).toBeTruthy();
-    expect(screen.getByText("Food and drink")).toBeTruthy();
+    expect(screen.getByText("ACME Corp")).toBeTruthy();
     expect(screen.getByText("$340.00")).toBeTruthy();
   });
 
@@ -123,7 +127,42 @@ describe("DonutChart legend", () => {
       <DonutChart data={spend} categoryKey="label" valueKey="value" format="money" legend={false} />,
     );
     expect(container.querySelector('[data-kit="DonutLegend"]')).toBeNull();
-    expect(container.textContent).not.toContain("Rent");
+    expect(container.textContent).not.toContain("rent");
+  });
+});
+
+/**
+ * jsdom lays nothing out, so recharts' ResponsiveContainer measures zero and
+ * draws no SVG at all. State the size its observer reports and the real chart
+ * renders — the component still picks its own colors.
+ */
+function stubChartSize(width: number, height: number): () => void {
+  const real = globalThis.ResizeObserver;
+  globalThis.ResizeObserver = class {
+    constructor(private readonly cb: ResizeObserverCallback) {}
+    observe(target: Element) {
+      this.cb([{ target, contentRect: { width, height } } as unknown as ResizeObserverEntry], this as never);
+    }
+    unobserve() {}
+    disconnect() {}
+  } as never;
+  return () => {
+    globalThis.ResizeObserver = real;
+  };
+}
+
+describe("Sparkline tone", () => {
+  const stroke = (node: ReactElement): string | null =>
+    render(node).container.querySelector(".recharts-area-curve")!.getAttribute("stroke");
+
+  it("paints the line from the palette, and keeps the series color without a tone", () => {
+    const restore = stubChartSize(200, 40);
+    try {
+      expect(stroke(<Sparkline data={[1, 5, 3]} tone="danger" />)).toContain("var(--vendo-color-danger");
+      expect(stroke(<Sparkline data={[1, 5, 3]} />)).toContain("var(--vendo-color-accent");
+    } finally {
+      restore();
+    }
   });
 });
 

--- a/packages/ui/test/kit/charts.test.tsx
+++ b/packages/ui/test/kit/charts.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import { RowContext } from "../../src/kit/row.js";
 import { sanitizeSeries, sanitizeNumbers } from "../../src/kit/charts/sanitize.js";
 import { BarChart } from "../../src/kit/charts/bar.js";
 import { LineChart } from "../../src/kit/charts/line.js";
@@ -99,5 +100,52 @@ describe("Progress", () => {
   it("renders a placeholder for a non-finite value", () => {
     const { container } = render(<Progress value={Number.NaN} />);
     expect(container.textContent).not.toContain("NaN");
+  });
+});
+
+describe("DonutChart legend", () => {
+  const spend = [
+    { label: "rent", value: 1200 },
+    { label: "food_and_drink", value: 340 },
+  ];
+
+  it("names and values every slice by default", () => {
+    // An unlabelled ring says nothing in a screenshot: a tooltip is not a label.
+    render(<DonutChart data={spend} categoryKey="label" valueKey="value" format="money" />);
+    expect(screen.getByText("Rent")).toBeTruthy();
+    expect(screen.getByText("$1,200.00")).toBeTruthy();
+    expect(screen.getByText("Food and drink")).toBeTruthy();
+    expect(screen.getByText("$340.00")).toBeTruthy();
+  });
+
+  it("legend={false} leaves the bare ring", () => {
+    const { container } = render(
+      <DonutChart data={spend} categoryKey="label" valueKey="value" format="money" legend={false} />,
+    );
+    expect(container.querySelector('[data-kit="DonutLegend"]')).toBeNull();
+    expect(container.textContent).not.toContain("Rent");
+  });
+});
+
+describe("charts in a cell slot", () => {
+  it("Sparkline plots the row's series instead of its own prop", () => {
+    const { container } = render(
+      <RowContext.Provider value={{ history: [1, 5, 3] }}>
+        <Sparkline data={[]} field="history" emptyState="nothing" />
+      </RowContext.Provider>,
+    );
+    expect(container.querySelector('div[data-kit="Sparkline"]')).not.toBeNull();
+    expect(container.textContent).not.toContain("nothing");
+  });
+
+  it("Progress reads the row's value, and its own outside a row", () => {
+    render(
+      <RowContext.Provider value={{ used: 0.25 }}>
+        <Progress value={0.9} field="used" showValue />
+      </RowContext.Provider>,
+    );
+    expect(screen.getByText("25%")).toBeTruthy();
+    render(<Progress value={0.9} field="used" showValue />);
+    expect(screen.getByText("90%")).toBeTruthy();
   });
 });

--- a/packages/ui/test/kit/data-display.test.tsx
+++ b/packages/ui/test/kit/data-display.test.tsx
@@ -39,6 +39,29 @@ describe("Stat", () => {
     const value = screen.getByText("Growth (annual)");
     expect(value.getAttribute("title")).toBeNull();
   });
+
+  it("speaks the shared tone vocabulary, and 'default' still means neutral", () => {
+    const { container } = render(
+      <>
+        <Stat label="Plain" value={1} />
+        <Stat label="Old" value={1} tone="default" />
+        <Stat label="New" value={1} tone="success" />
+      </>,
+    );
+    const tiles = [...container.querySelectorAll<HTMLElement>('[data-kit="Stat"]')];
+    expect(tiles.map((tile) => tile.dataset.tone)).toEqual(["neutral", "neutral", "success"]);
+    // Neutral is exactly today's look; a real tone is not.
+    const color = (tile: HTMLElement) => tile.querySelector("strong")!.style.color;
+    expect(color(tiles[1]!)).toBe(color(tiles[0]!));
+    expect(color(tiles[2]!)).not.toBe(color(tiles[0]!));
+  });
+
+  // A money figure has no break opportunity of its own, so a tile narrower than
+  // its number cut it off mid-number ("$1,113.1").
+  it("lets a value too wide for its tile break rather than clip", () => {
+    render(<Stat label="Balance" value={1113.1} format="money" />);
+    expect(screen.getByText("$1,113.10").style.overflowWrap).toBe("anywhere");
+  });
 });
 
 describe("Badge", () => {

--- a/packages/ui/test/kit/data-table.test.tsx
+++ b/packages/ui/test/kit/data-table.test.tsx
@@ -2,6 +2,7 @@
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { DataTable } from "../../src/kit/data/data-table.js";
+import { EnumBadge } from "../../src/kit/values.js";
 
 // Money in the rows is DOLLARS: a `format:"money"` column pretty-prints the
 // value as it stands, so a host's cents field is divided by 100 upstream.
@@ -20,19 +21,19 @@ const rows = [
  * measurement the component reads — the component still does its own measuring,
  * folding and header hiding.
  */
-function stubOverflow(scrollWidth: number, clientWidth: number): () => void {
+function stubLayout(columnWidth: number, clientWidth: number): () => void {
   const observers = globalThis.ResizeObserver;
   globalThis.ResizeObserver = class {
     observe() {}
     unobserve() {}
     disconnect() {}
   } as never;
-  for (const [prop, value] of [["scrollWidth", scrollWidth], ["clientWidth", clientWidth]] as const) {
+  for (const [prop, value] of [["offsetWidth", columnWidth], ["clientWidth", clientWidth]] as const) {
     Object.defineProperty(HTMLElement.prototype, prop, { configurable: true, get: () => value });
   }
   return () => {
     globalThis.ResizeObserver = observers;
-    delete (HTMLElement.prototype as Partial<HTMLElement>).scrollWidth;
+    delete (HTMLElement.prototype as Partial<HTMLElement>).offsetWidth;
     delete (HTMLElement.prototype as Partial<HTMLElement>).clientWidth;
   };
 }
@@ -163,19 +164,94 @@ describe("DataTable", () => {
   });
 
   // A narrow surface used to scroll the right-hand columns out of view with
-  // nothing to say they existed. They fold into the first cell instead.
-  it("folds the columns that do not fit into the first cell, headers and all", () => {
-    const restore = stubOverflow(700, 240);
+  // nothing to say they existed. Only the ones that do not FIT fold — a table
+  // that folded every column but the first is a stack of cards, which is not a
+  // table and reads as one field per line.
+  it("keeps the columns that fit and folds only the rest into the first cell", () => {
+    // Three 200px columns; 420px of room, so two fit and the third folds.
+    const restore = stubLayout(200, 420);
     try {
       render(<DataTable rows={rows} columns={columns} />);
-      const headers = screen.getAllByRole("columnheader");
-      expect(headers).toHaveLength(1);
-      expect(headers[0]!.textContent).toContain("Client");
+      const headers = screen.getAllByRole("columnheader").map((h) => h.textContent);
+      expect(headers).toHaveLength(2);
+      expect(headers[0]).toContain("Client");
+      expect(headers[1]).toContain("Amount");
+      expect(headers.join()).not.toContain("Due");
 
       const firstRow = screen.getAllByRole("row")[1]!;
-      expect(within(firstRow).getAllByRole("cell")).toHaveLength(1);
+      expect(within(firstRow).getAllByRole("cell")).toHaveLength(2);
+      // The folded column rides in the FIRST cell, labelled, not in every cell.
+      const cells = within(firstRow).getAllByRole("cell");
+      expect(cells[0]!.textContent).toContain("Due: Mar 14");
+      expect(cells[1]!.textContent).not.toContain("Due:");
+    } finally {
+      restore();
+    }
+  });
+
+  it("keeps the first column however narrow the surface is", () => {
+    const restore = stubLayout(200, 40);
+    try {
+      render(<DataTable rows={rows} columns={columns} />);
+      expect(screen.getAllByRole("columnheader")).toHaveLength(1);
+      const firstRow = screen.getAllByRole("row")[1]!;
       expect(firstRow.textContent).toContain("Amount: $2,500.00");
       expect(firstRow.textContent).toContain("Due: Mar 14");
+    } finally {
+      restore();
+    }
+  });
+
+  // Folding a column must not undo the slot that column carries: rendering the
+  // formatted text instead folded a status pill back into the bare word
+  // "overdue" — the precise thing the slots exist to kill.
+  it("a folded column keeps its cell slot", () => {
+    const restore = stubLayout(200, 420);
+    try {
+      render(
+        <DataTable
+          rows={rows}
+          columns={[
+            ...columns,
+            { key: "status", label: "Status", cell: <EnumBadge field="status" tones={{ overdue: "danger" }} /> },
+          ]}
+        />,
+      );
+      const firstRow = screen.getAllByRole("row")[1]!;
+      expect(firstRow.textContent).toContain("Status: ");
+      const badge = within(firstRow).getByText("Overdue");
+      expect(badge.getAttribute("data-kit")).toBe("EnumBadge");
+      expect(badge.getAttribute("data-tone")).toBe("danger");
+      expect(firstRow.textContent).not.toContain("Status: overdue");
+    } finally {
+      restore();
+    }
+  });
+
+  // The fold-out rides INSIDE the first cell, and that cell is often a figure —
+  // nowrap and tabular-nums, both inherited. An unbreakable folded line scrolls
+  // the table sideways, which is the failure folding exists to prevent.
+  it("wraps its folded lines even when the first column is a figure", () => {
+    const restore = stubLayout(200, 220);
+    try {
+      render(<DataTable rows={rows} columns={[columns[1]!, columns[0]!, columns[2]!]} />);
+      const cell = screen.getByText("$2,500.00").closest("td")!;
+      expect(cell.style.whiteSpace).toBe("nowrap");
+      const fold = cell.querySelector("div")!;
+      expect(fold.textContent).toContain("Client: Hartwell");
+      expect(fold.style.whiteSpace).toBe("normal");
+      expect(fold.style.fontVariantNumeric).toBe("normal");
+    } finally {
+      restore();
+    }
+  });
+
+  it("folds nothing when every column fits", () => {
+    const restore = stubLayout(100, 900);
+    try {
+      render(<DataTable rows={rows} columns={columns} />);
+      expect(screen.getAllByRole("columnheader")).toHaveLength(3);
+      expect(screen.getAllByRole("row")[1]!.textContent).not.toContain("Due:");
     } finally {
       restore();
     }

--- a/packages/ui/test/kit/data-table.test.tsx
+++ b/packages/ui/test/kit/data-table.test.tsx
@@ -5,11 +5,37 @@ import { DataTable } from "../../src/kit/data/data-table.js";
 
 // Money in the rows is DOLLARS: a `format:"money"` column pretty-prints the
 // value as it stands, so a host's cents field is divided by 100 upstream.
+// The dates are built off the CURRENT year because that is what decides whether
+// a date cell shows its year — a hardcoded year would flip every expectation
+// here the moment the calendar turned.
+const year = new Date().getFullYear();
 const rows = [
-  { id: 1, client: { name: "Hartwell" }, amount: 2500, dueDate: "2026-03-14", status: "overdue" },
-  { id: 2, client: { name: "Acme" }, amount: 900, dueDate: "2026-01-02", status: "paid" },
-  { id: 3, client: { name: "Borealis" }, amount: 1750, dueDate: "2026-02-20", status: "overdue" },
+  { id: 1, client: { name: "Hartwell" }, amount: 2500, dueDate: `${year}-03-14`, status: "overdue" },
+  { id: 2, client: { name: "Acme" }, amount: 900, dueDate: `${year}-01-02`, status: "paid" },
+  { id: 3, client: { name: "Borealis" }, amount: 1750, dueDate: `${year}-02-20`, status: "overdue" },
 ];
+
+/**
+ * jsdom lays nothing out, so a table can never overflow in a test. State the
+ * measurement the component reads — the component still does its own measuring,
+ * folding and header hiding.
+ */
+function stubOverflow(scrollWidth: number, clientWidth: number): () => void {
+  const observers = globalThis.ResizeObserver;
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as never;
+  for (const [prop, value] of [["scrollWidth", scrollWidth], ["clientWidth", clientWidth]] as const) {
+    Object.defineProperty(HTMLElement.prototype, prop, { configurable: true, get: () => value });
+  }
+  return () => {
+    globalThis.ResizeObserver = observers;
+    delete (HTMLElement.prototype as Partial<HTMLElement>).scrollWidth;
+    delete (HTMLElement.prototype as Partial<HTMLElement>).clientWidth;
+  };
+}
 
 const columns = [
   { key: "client.name", label: "Client" },
@@ -22,7 +48,7 @@ describe("DataTable", () => {
     render(<DataTable rows={rows} columns={columns} />);
     expect(screen.getByText("Hartwell")).toBeTruthy();
     expect(screen.getByText("$2,500.00")).toBeTruthy();
-    expect(screen.getByText("Mar 14, 2026")).toBeTruthy();
+    expect(screen.getByText("Mar 14")).toBeTruthy();
   });
 
   it("applies an initial sortBy", () => {
@@ -77,10 +103,10 @@ describe("DataTable", () => {
   });
 
   // Every filter compares against the text the cell SHOWS. The columns are
-  // formatted — "$2,500.00", "Mar 14, 2026" — while the filters read the raw
-  // field ("2500", "2026-03-14"), so a person searching for what is in front
-  // of them got the empty state, and one searching the raw form got rows whose
-  // text does not contain what they typed.
+  // formatted — "$2,500.00", "Mar 14" — while the filters read the raw field
+  // ("2500", "2026-03-14"), so a person searching for what is in front of them
+  // got the empty state, and one searching the raw form got rows whose text
+  // does not contain what they typed.
   it("searches the text the cells actually show", () => {
     render(<DataTable rows={rows} columns={columns} searchable />);
     const search = screen.getByRole("searchbox");
@@ -96,11 +122,67 @@ describe("DataTable", () => {
   it("offers filter options in the words the column displays", () => {
     render(<DataTable rows={rows} columns={columns} filterableBy={["dueDate"]} />);
     const filter = screen.getByRole("combobox", { name: "Filter by Due" });
-    expect(within(filter).getByRole("option", { name: "Mar 14, 2026" })).toBeTruthy();
-    expect(within(filter).queryByRole("option", { name: "2026-03-14" })).toBeNull();
+    expect(within(filter).getByRole("option", { name: "Mar 14" })).toBeTruthy();
+    expect(within(filter).queryByRole("option", { name: `${year}-03-14` })).toBeNull();
 
-    fireEvent.change(filter, { target: { value: "Mar 14, 2026" } });
+    fireEvent.change(filter, { target: { value: "Mar 14" } });
     expect(screen.getByText("Hartwell")).toBeTruthy();
     expect(screen.queryByText("Acme")).toBeNull();
+  });
+
+  // The year is the same four characters on every row of a this-year column, so
+  // it is clutter — until the column straddles years, when dropping it would
+  // make two different days read as the same one.
+  it("drops the year from a date column that is entirely this year", () => {
+    render(<DataTable rows={rows} columns={columns} />);
+    expect(screen.getByText("Mar 14")).toBeTruthy();
+    expect(screen.queryByText(`Mar 14, ${year}`)).toBeNull();
+  });
+
+  it("keeps the year for the WHOLE column once its rows straddle years", () => {
+    const straddling = [
+      { id: 1, client: { name: "Hartwell" }, amount: 2500, dueDate: `${year}-03-14` },
+      { id: 2, client: { name: "Acme" }, amount: 900, dueDate: `${year - 1}-12-30` },
+    ];
+    render(<DataTable rows={straddling} columns={columns} />);
+    expect(screen.getByText(`Mar 14, ${year}`)).toBeTruthy();
+    expect(screen.getByText(`Dec 30, ${year - 1}`)).toBeTruthy();
+    expect(screen.queryByText("Mar 14")).toBeNull();
+  });
+
+  it("never breaks a formatted figure across two lines", () => {
+    render(<DataTable rows={rows} columns={columns} />);
+    expect(screen.getByText("$2,500.00").closest("td")!.style.whiteSpace).toBe("nowrap");
+    expect(screen.getByText("Hartwell").closest("td")!.style.whiteSpace).toBe("");
+  });
+
+  it("re-declares the spacing scale on its own element for density=compact", () => {
+    const { container } = render(<DataTable rows={rows} columns={columns} density="compact" />);
+    const root = container.querySelector<HTMLElement>('[data-kit="DataTable"]')!;
+    expect(root.style.getPropertyValue("--vendo-density-table-padding")).toBe("7px 10px");
+  });
+
+  // A narrow surface used to scroll the right-hand columns out of view with
+  // nothing to say they existed. They fold into the first cell instead.
+  it("folds the columns that do not fit into the first cell, headers and all", () => {
+    const restore = stubOverflow(700, 240);
+    try {
+      render(<DataTable rows={rows} columns={columns} />);
+      const headers = screen.getAllByRole("columnheader");
+      expect(headers).toHaveLength(1);
+      expect(headers[0]!.textContent).toContain("Client");
+
+      const firstRow = screen.getAllByRole("row")[1]!;
+      expect(within(firstRow).getAllByRole("cell")).toHaveLength(1);
+      expect(firstRow.textContent).toContain("Amount: $2,500.00");
+      expect(firstRow.textContent).toContain("Due: Mar 14");
+    } finally {
+      restore();
+    }
+  });
+
+  it("leaves the table wide where nothing can be measured (SSR, jsdom)", () => {
+    render(<DataTable rows={rows} columns={columns} />);
+    expect(screen.getAllByRole("columnheader")).toHaveLength(3);
   });
 });

--- a/packages/ui/test/kit/feedback.test.tsx
+++ b/packages/ui/test/kit/feedback.test.tsx
@@ -40,9 +40,10 @@ describe("Callout", () => {
     expect(screen.getByText("Highlighted information.")).toBeTruthy();
   });
 
-  it("renders any unknown tone safely with the info fallback", () => {
+  it("renders any unknown tone safely, falling back like every other component", () => {
     render(<Callout tone={"garbage" as never} title="Odd">Still visible.</Callout>);
-    expect(screen.getByRole("status")).toBeTruthy();
+    const el = screen.getByRole("status");
+    expect(el.getAttribute("data-tone")).toBe("neutral");
     expect(screen.getByText("Still visible.")).toBeTruthy();
   });
 
@@ -50,8 +51,21 @@ describe("Callout", () => {
     render(<Callout tone={"constructor" as never} title="Proto">Prototype-safe.</Callout>);
     const el = screen.getByRole("status");
     expect(screen.getByText("Prototype-safe.")).toBeTruthy();
-    // The info fallback's accent color applied — not an undefined style.
+    expect(el.getAttribute("data-tone")).toBe("neutral");
+    // A real fallback color applied — not an undefined style.
     expect((el as HTMLElement).style.borderLeft).not.toContain("undefined");
+  });
+
+  // Callout kept its own tone map and never called the shared resolver, so the
+  // legacy spelling every other component reads as neutral landed on the
+  // accented ⓘ here, and `data-tone` published the raw unvalidated string while
+  // Card/Surface/Stat published the resolved one.
+  it('reads "default" as neutral, and reports the tone it resolved to', () => {
+    render(<Callout tone={"default" as never} title="Note">Nothing urgent.</Callout>);
+    const el = screen.getByRole("status");
+    expect(el.getAttribute("data-tone")).toBe("neutral");
+    expect(el.style.borderLeft).toContain("var(--vendo-color-text");
+    expect(el.style.borderLeft).not.toContain("var(--vendo-color-accent");
   });
 });
 

--- a/packages/ui/test/kit/slots.test.tsx
+++ b/packages/ui/test/kit/slots.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { CardList } from "../../src/kit/data/card-list.js";
+import { DataTable } from "../../src/kit/data/data-table.js";
+import { Stat } from "../../src/kit/data/stat.js";
+import { Stack } from "../../src/kit/layout.js";
+import { EnumBadge, Text } from "../../src/kit/values.js";
+
+// A slot holds an ELEMENT, not a function of the row: the screen VM would
+// serialize a function prop as a `$handler` door. So the container renders the
+// SAME element once per row and publishes the row it is painting, and the value
+// components inside name the field they read.
+const rows = [
+  { id: 1, client: { name: "Hartwell" }, number: "INV-1", status: "overdue" },
+  { id: 2, client: { name: "Acme" }, number: "INV-2", status: "paid" },
+];
+
+const columns = [
+  {
+    key: "client.name",
+    label: "Client",
+    cell: (
+      <Stack gap={2}>
+        <Text field="client.name" />
+        <Text field="number" variant="caption" />
+      </Stack>
+    ),
+  },
+  {
+    key: "status",
+    label: "Status",
+    cell: <EnumBadge field="status" tones={{ overdue: "danger", paid: "success" }} />,
+  },
+];
+
+describe("cell slots", () => {
+  it("renders a column's slot once per row, against THAT row's fields", () => {
+    render(<DataTable rows={rows} columns={columns} />);
+    const [first, second] = screen.getAllByRole("row").slice(1);
+    expect(within(first!).getByText("Hartwell")).toBeTruthy();
+    expect(within(first!).getByText("INV-1")).toBeTruthy();
+    expect(within(second!).getByText("Acme")).toBeTruthy();
+    // One element, two rows, two different values — and two different tones.
+    expect(within(first!).getByText("Overdue").getAttribute("data-tone")).toBe("danger");
+    expect(within(second!).getByText("Paid").getAttribute("data-tone")).toBe("success");
+  });
+
+  // The slot changes what a cell SHOWS, never what the column IS: sorting,
+  // filtering and search still run off `key` + `format`.
+  it("still filters a slotted column on its key", () => {
+    render(<DataTable rows={rows} columns={columns} filterableBy={["status"]} />);
+    const filter = screen.getByRole("combobox", { name: "Filter by Status" });
+    expect(within(filter).getByRole("option", { name: "overdue" })).toBeTruthy();
+
+    fireEvent.change(filter, { target: { value: "overdue" } });
+    expect(screen.getByText("Hartwell")).toBeTruthy();
+    expect(screen.queryByText("Acme")).toBeNull();
+    expect(screen.queryByText("Paid")).toBeNull();
+  });
+
+  it("searches a slotted column on the text its key produces", () => {
+    render(<DataTable rows={rows} columns={columns} searchable />);
+    fireEvent.change(screen.getByRole("searchbox"), { target: { value: "paid" } });
+    expect(screen.getByText("Acme")).toBeTruthy();
+    expect(screen.queryByText("Hartwell")).toBeNull();
+  });
+
+  it("renders a CardList field's slot per item, keeping the label", () => {
+    render(
+      <CardList
+        items={rows}
+        titleField="client.name"
+        fields={[{ key: "status", label: "Status", cell: <EnumBadge field="status" tones={{ overdue: "danger" }} /> }]}
+      />,
+    );
+    expect(screen.getAllByText("Status")).toHaveLength(2); // one label per card
+    expect(screen.getByText("Overdue").getAttribute("data-tone")).toBe("danger");
+    expect(screen.getByText("Paid").getAttribute("data-tone")).toBe("neutral");
+  });
+
+  it("renders Stat's children under the value", () => {
+    render(
+      <Stat label="Balance" value={2500} format="money" trend="+12% MoM">
+        <Text text="last 30 days" variant="caption" />
+      </Stat>,
+    );
+    const tile = screen.getByLabelText("Balance");
+    const value = within(tile).getByText("$2,500.00");
+    const child = within(tile).getByText("last 30 days");
+    // DOCUMENT_POSITION_FOLLOWING — "under" is document order, not just nesting.
+    expect(value.compareDocumentPosition(child) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+});

--- a/packages/ui/test/kit/values.test.tsx
+++ b/packages/ui/test/kit/values.test.tsx
@@ -74,6 +74,15 @@ describe("EnumBadge", () => {
     const { container } = render(<EnumBadge value={null} />);
     expect(container.textContent).toBe("");
   });
+
+  // `labels`/`tones` are model-authored records, so an enum value that happens to
+  // name an Object.prototype member must read as ABSENT — a bare index hands
+  // React `Object.prototype.toString`, a function, as the pill's label.
+  it("an enum value that names a prototype member reads as data, never a method", () => {
+    const { container } = render(<EnumBadge value="toString" labels={{}} tones={{}} />);
+    expect(container.textContent).toBe("To string");
+    expect(screen.getByText("To string").getAttribute("data-tone")).toBe("neutral");
+  });
 });
 
 describe("Text", () => {
@@ -105,6 +114,13 @@ describe("the cell slot — a value bound to the row it is standing in", () => {
   it("falls back to the explicit prop outside a row — the same component reads the same either way", () => {
     expect(render(<Money amount={7} field="amount" />).container.textContent).toBe("$7.00");
     expect(render(<Text text="Maple" field="client.name" />).container.textContent).toBe("Maple");
+  });
+
+  // `active`, `isPaid`, `archived` — a boolean is one of the commonest fields
+  // there is, and React renders one as literally nothing.
+  it("shows a boolean field instead of swallowing it", () => {
+    expect(inRow({ active: false }, <Text field="active" />).container.textContent).toBe("false");
+    expect(inRow({ active: true }, <Text field="active" />).container.textContent).toBe("true");
   });
 
   it("a field holding the wrong type lands on the placeholder, never a crash", () => {

--- a/packages/ui/test/kit/values.test.tsx
+++ b/packages/ui/test/kit/values.test.tsx
@@ -1,6 +1,9 @@
 // @vitest-environment jsdom
 import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { describe, expect, it } from "vitest";
+import { formatDateTime } from "../../src/kit/format.js";
+import { RowContext } from "../../src/kit/row.js";
 import { DateTime, EnumBadge, Money, Num, Percent, Text } from "../../src/kit/values.js";
 
 describe("Money", () => {
@@ -25,6 +28,21 @@ describe("DateTime", () => {
   it("renders a placeholder for an unparseable value", () => {
     const { container } = render(<DateTime value="nope" />);
     expect(container.textContent).toBe("—");
+  });
+
+  it("compact drops the YEAR and keeps the clock", () => {
+    expect(formatDateTime("2026-08-12", { mode: "date" })).toBe("Aug 12, 2026");
+    expect(formatDateTime("2026-08-12", { mode: "date", compact: true })).toBe("Aug 12");
+    const stamp = formatDateTime(Date.UTC(2026, 7, 12, 15, 30), {
+      mode: "datetime",
+      compact: true,
+      timeZone: "UTC",
+    });
+    expect(stamp).toContain("Aug 12");
+    expect(stamp).toMatch(/3:30/);
+    expect(stamp).not.toContain("2026");
+    const { container } = render(<DateTime value="2026-08-12" mode="date" compact />);
+    expect(container.textContent).toBe("Aug 12");
   });
 });
 
@@ -62,5 +80,38 @@ describe("Text", () => {
   it("renders a heading element for the heading variant", () => {
     render(<Text text="Overview" variant="heading" />);
     expect(screen.getByRole("heading", { name: "Overview" })).toBeTruthy();
+  });
+});
+
+describe("the cell slot — a value bound to the row it is standing in", () => {
+  const inRow = (row: Record<string, unknown>, node: ReactNode) =>
+    render(<RowContext.Provider value={row}>{node}</RowContext.Provider>);
+
+  it("takes its primary value from the row's field, not its own prop", () => {
+    expect(inRow({ amount: 12.5 }, <Money amount={0} field="amount" />).container.textContent).toBe("$12.50");
+    expect(inRow({ due: "2026-03-14" }, <DateTime value="" field="due" mode="date" />).container.textContent).toBe(
+      "Mar 14, 2026",
+    );
+    expect(inRow({ share: 0.42 }, <Percent value={0} field="share" />).container.textContent).toBe("42%");
+    expect(inRow({ n: 1234567 }, <Num value={0} field="n" />).container.textContent).toBe("1,234,567");
+    expect(inRow({ status: "past_due" }, <EnumBadge value={null} field="status" />).container.textContent).toBe(
+      "Past due",
+    );
+    expect(inRow({ client: { name: "Maple" } }, <Text text="" field="client.name" />).container.textContent).toBe(
+      "Maple",
+    );
+  });
+
+  it("falls back to the explicit prop outside a row — the same component reads the same either way", () => {
+    expect(render(<Money amount={7} field="amount" />).container.textContent).toBe("$7.00");
+    expect(render(<Text text="Maple" field="client.name" />).container.textContent).toBe("Maple");
+  });
+
+  it("a field holding the wrong type lands on the placeholder, never a crash", () => {
+    // Money needs a number and Text needs a node; a column bound to the wrong
+    // field must not take the screen down with it.
+    expect(inRow({ amount: "lots" }, <Money amount={1} field="amount" />).container.textContent).toBe("—");
+    expect(inRow({ client: { name: "Maple" } }, <Text text="" field="client" />).container.textContent).toBe("—");
+    expect(inRow({ status: "  " }, <EnumBadge value="paid" field="status" />).container.textContent).toBe("");
   });
 });

--- a/packages/ui/test/theme-tokens.test.tsx
+++ b/packages/ui/test/theme-tokens.test.tsx
@@ -145,6 +145,13 @@ describe("Kit token fallbacks — an unthemed Kit is the default theme, exactly"
     expect(t.border).toBe(`var(--vendo-color-border, ${d.border})`);
   });
 
+  it("success and warning are tokens, not the literals the pills used to paint", () => {
+    // These two have no `colors` entry to read a default off, which makes them
+    // the one place a Kit color can quietly regress to a hardcoded hex.
+    expect(t.success).toContain("var(--vendo-color-success,");
+    expect(t.warning).toContain("var(--vendo-color-warning,");
+  });
+
   it("the type and radius fallbacks carry the default theme's own values", () => {
     expect(t.fontFamily).toBe(`var(--vendo-font-family, ${defaultVendoTheme.typography.fontFamily})`);
     expect(t.fontFamily).toContain("Onest");

--- a/packages/ui/test/tree/screen-bridge.test.tsx
+++ b/packages/ui/test/tree/screen-bridge.test.tsx
@@ -42,7 +42,7 @@ beforeAll(async () => {
 const compile = (tsx: string): string =>
   transform(tsx, { transforms: ["typescript", "jsx", "imports"], production: true, jsxRuntime: "automatic" }).code;
 
-const CATALOG = ["Stack", "Row", "Card", "Text", "Money", "Button", "Input", "Callout"];
+const CATALOG = ["Stack", "Row", "Card", "Text", "Money", "Button", "Input", "Callout", "Accordion", "EnumBadge"];
 
 /** The payload the server serves: the screen's FIRST paint, flattened, plus the
  *  interactive half that can produce the next one — built by the engine itself,
@@ -474,6 +474,40 @@ export default function Notice() {
     expect(screen.getByText("Heads up")).toBeTruthy();
     expect(screen.getByText("Three invoices are overdue.")).toBeTruthy();
     expect(screen.queryByText(/Unknown component/u)).toBeNull();
+  });
+
+  it("renders a Kit element the screen put in a PROP, as that Kit component", async () => {
+    // The slot round trip, with nothing stubbed on either side: the VM serializes
+    // the element into `content` as `{$element}` data (vm-program.ts `emitValue`),
+    // the server's own flatten leaves it inside the prop, and the renderer builds
+    // the real EnumBadge back out of it (renderer.tsx `reifyElement`). An object
+    // handed to React as a child is the failure this closes.
+    const compiled = compile(`
+import { Accordion, EnumBadge, useQuery } from "@vendo/screen";
+
+export default function Invoice() {
+  const invoice = useQuery("get_invoice");
+  return (
+    <Accordion
+      defaultOpen={[0]}
+      items={[{ label: "Status", content: <EnumBadge value={invoice.data.status} tone="warning" /> }]}
+    />
+  );
+}`);
+    const host = hostPipe(() => ok(null));
+    render(
+      <PayloadView
+        payload={payloadFor(compiled, { get_invoice: { data: { status: "past_due" } } })}
+        components={{}}
+        onAction={host.onAction}
+      />,
+    );
+
+    const badge = screen.getByText("Past due");
+    expect(badge.getAttribute("data-kit")).toBe("EnumBadge");
+    expect(badge.getAttribute("data-tone")).toBe("warning");
+    // The sigil is the renderer's business and never the DOM's.
+    expect(document.body.innerHTML).not.toContain("$element");
   });
 
   it("leaves a payload with no interactive half exactly as static as it was", async () => {

--- a/packages/ui/test/tree/tree-view.test.tsx
+++ b/packages/ui/test/tree/tree-view.test.tsx
@@ -371,6 +371,69 @@ describe("TreeView bindings and outcomes", () => {
     expect(output.textContent).toContain('"user":{"name":"Ada"}');
   });
 
+  /** A cell slot's element arrives as `{$element}` data in a prop
+   *  (apps genui/component/vm-program.ts) — the props inside it are ordinary
+   *  bindings and have to resolve like any other. */
+  it("reifies a Kit element in a prop, with its own bindings and its children in order", () => {
+    render(
+      <TreeView
+        tree={tree([{
+          id: "root",
+          component: "Accordion",
+          props: {
+            defaultOpen: [0],
+            items: [{
+              label: "Status",
+              content: {
+                $element: true,
+                component: "Row",
+                props: { gap: 4 },
+                children: [
+                  { component: "EnumBadge", props: { value: { $path: "/invoice/status" } }, children: [] },
+                  "flagged",
+                ],
+              },
+            }],
+          },
+        }])}
+        data={{ invoice: { status: "past_due" } }}
+        components={{}}
+        onAction={ok}
+      />,
+    );
+
+    expect(screen.getByText("Past due").getAttribute("data-kit")).toBe("EnumBadge");
+    expect(document.querySelector('[data-kit="Row"]')?.textContent).toBe("Past dueflagged");
+    expect(document.body.innerHTML).not.toContain("$element");
+  });
+
+  it("renders nothing for an unknown component in a slot, and never throws", () => {
+    render(
+      <TreeView
+        tree={tree([{
+          id: "root",
+          component: "Accordion",
+          props: {
+            defaultOpen: [0, 1],
+            items: [
+              { label: "Ghost", content: { $element: true, component: "Hallucinated", props: { value: "x" }, children: [] } },
+              { label: "Real", content: { $element: true, component: "EnumBadge", props: { value: "past_due" }, children: [] } },
+            ],
+          },
+        }])}
+        components={{}}
+        onAction={ok}
+      />,
+    );
+
+    // Fail-soft, like every other node: the slot is empty, its row still opens,
+    // and the sibling slot still renders — no notice, no boundary, no throw.
+    expect(screen.getByText("Ghost")).toBeTruthy();
+    expect(screen.queryByText("x")).toBeNull();
+    expect(screen.queryByRole("note")).toBeNull();
+    expect(screen.getByText("Past due").getAttribute("data-kit")).toBe("EnumBadge");
+  });
+
   it("updates $state reads and reports jail state-set messages", async () => {
     const StateProbe: ComponentType<{ value?: unknown }> = ({ value }) => <output>{String(value)}</output>;
     const onStateChange = vi.fn();

--- a/packages/vendo/src/screen-agent.ts
+++ b/packages/vendo/src/screen-agent.ts
@@ -220,6 +220,13 @@ export interface ScreenInput {
   appId: AppId;
   /** The person's ask, verbatim. */
   request: string;
+  /** The surface this screen renders into, in CSS pixels, when the host knows it.
+   *  The one fact about the render target a writer cannot learn from anything
+   *  else it is given — which is how eight-column tables and four-across stat
+   *  rows keep landing on a narrow panel, where the person, not the loop,
+   *  discovers the clip. Absent claims NOTHING: no width is invented, and the
+   *  brief then says nothing about the surface at all. */
+  viewport?: { width: number; height: number };
   /** THE briefing pack, already rendered (`renderBriefingPack`) — the host's
    *  theme, design rules, product brief, component catalog and tool shape card,
    *  in the same bytes the box rung is handed. Knowledge, not instruction, so it
@@ -420,6 +427,17 @@ const judgeScreen = async (
   return repairInstruction([{ path, appId, findings }]);
 };
 
+/** How much room the screen has, when the host said. Said ONLY then: a screen
+ *  cannot measure its own surface, so a width this file guessed would read to the
+ *  writer exactly like one the host measured. Absent, the paragraph above it ends
+ *  where it always did. */
+const surfaceNote = (viewport: ScreenInput["viewport"]): string => {
+  if (viewport === undefined) return "";
+  return `\n\nYou are writing into \`${viewport.width}×${viewport.height}\` CSS pixels, and nothing wider than that is
+on the person's screen. Fewer, richer columns rather than a table that runs off
+the edge, and a stat grid that wraps rather than a fixed count that clips.`;
+};
+
 /**
  * The environment correction, and only that.
  *
@@ -429,17 +447,17 @@ const judgeScreen = async (
  * the skill says what the job is — which is the difference between deriving a
  * brief and forking one.
  */
-const environmentNote = (appId: AppId, wireable: readonly ToolListing[], steps: number): string => `# In this loop
+const environmentNote = (input: ScreenInput, wireable: readonly ToolListing[], steps: number): string => `# In this loop
 
 You have no machine: no shell, no \`Task\`, no files on disk. Everything the skill
 above tells you to read is already below, and everything it tells you to write goes
 through the tools below.
 
 Build from the components that already exist: this product's own catalog and the
-standard Kit the manual documents. There is nothing else to import.
+standard Kit the manual documents. There is nothing else to import.${surfaceNote(input.viewport)}
 
 - **\`${SAVE_APP_TOOL}\`** saves this app's whole file. The app is
-  \`${appId}\`; you never name a path. Every save that parses repaints the person's
+  \`${input.appId}\`; you never name a path. Every save that parses repaints the person's
   screen, so save as you go — a save is cheap and silence is not. There is no plan
   file to write here: write the screen itself, and every save is checked as it
   lands — if something is wrong with it, the save tells you exactly what to fix.
@@ -497,7 +515,7 @@ function screenBrief(input: ScreenInput, wireable: readonly ToolListing[], steps
     buildingAppsSkill.body,
     buildingAppsSkill.files?.[`references/${"format.md"}`],
     input.briefing,
-    environmentNote(input.appId, wireable, steps),
+    environmentNote(input, wireable, steps),
   ]
     .filter((section): section is string => section !== undefined && section.trim().length > 0)
     .join("\n\n---\n\n");
@@ -1077,6 +1095,7 @@ export function screenAssembler(deps: ScreenAssemblerDeps): ScreenAssembler {
         {
           appId: request.appId,
           request: request.request,
+          ...(request.viewport === undefined ? {} : { viewport: request.viewport }),
           ...(pack === undefined ? {} : { briefing: renderBriefingPack(pack) }),
         },
       );

--- a/packages/vendo/tests/screen-design-brief.test.ts
+++ b/packages/vendo/tests/screen-design-brief.test.ts
@@ -15,7 +15,7 @@
 import { type AppId, type Json, type ToolDescriptor } from "@vendoai/core";
 import { type BriefingPack } from "@vendoai/apps/contract";
 import { describe, expect, it } from "vitest";
-import { screenAssembler } from "../src/screen-agent.js";
+import { assembleScreen, screenAssembler, type ScreenInput } from "../src/screen-agent.js";
 import {
   boundRegistry,
   ctx,
@@ -125,5 +125,51 @@ describe("the writers' design brief", () => {
     expect(brief).toContain("must run while nobody is watching");
     expect(brief).toContain("a schedule, a product event");
     expect(brief).toContain("escalate the WHOLE ask");
+  });
+});
+
+/** Everything a measured surface adds to the brief, byte for byte. One constant,
+ *  because the two cases below are the same claim from either side: this text is
+ *  there when the host measured, and the brief is exactly this text away from the
+ *  one it has always assembled when nobody did. */
+const SURFACE_PARAGRAPH = "\n\nYou are writing into `420×880` CSS pixels, and nothing wider than that is\n"
+  + "on the person's screen. Fewer, richer columns rather than a table that runs off\n"
+  + "the edge, and a stat grid that wraps rather than a fixed count that clips.";
+
+/** One run through `assembleScreen`, which is where a `ScreenInput` — and the
+ *  host's viewport with it — enters. Not the `vendo_make` route above: a
+ *  `ScreenRequest` carries no dimensions, so this door is where a host opts in.
+ *  The model still speaks and never saves, so the brief is all this reads. */
+async function briefFor(viewport?: ScreenInput["viewport"]): Promise<string> {
+  const model = scriptedModel([textTurn("nothing to build")]);
+  await assembleScreen(
+    {
+      models: seats(model),
+      tools: { list: async () => [], call: async () => ({ status: "ok", output: {} }) },
+      workspace: testWorkspace(),
+      signal: new AbortController().signal,
+    },
+    { appId: APP, request: "show me my spending", ...(viewport === undefined ? {} : { viewport }) },
+  );
+  return model.systemPrompts[0] ?? "";
+}
+
+describe("the surface the screen is written for", () => {
+  it("names the room the screen has, and what to spend it on", async () => {
+    // Judged 2026-08-12: eight-column tables whose "Status column is cut off
+    // beyond the viewport" and a stat row clipped to "$1,113.1(" — every one of
+    // them written by a writer that was never told how wide it was writing.
+    const brief = await briefFor({ width: 420, height: 880 });
+    expect(brief).toContain("`420×880` CSS pixels");
+    expect(brief).toContain(SURFACE_PARAGRAPH);
+  });
+
+  it("says nothing about a surface nobody measured", async () => {
+    // The half-filled brief is what this stops: a line that announces a width and
+    // then has none is worse than the silence the writer has always had.
+    const bare = await briefFor();
+    expect(bare).not.toContain("CSS pixels");
+    // …and byte for byte, that silence is the whole difference.
+    expect((await briefFor({ width: 420, height: 880 })).replace(SURFACE_PARAGRAPH, "")).toBe(bare);
   });
 });


### PR DESCRIPTION
## What this changes

The Kit's data widgets were **sealed**. A table cell could only be the text a
formatter produced, so a status column rendered the bare word `overdue`, an id
or an invoice number cost a whole column, and nothing a generated screen wrote
ever reached for the host's accent color. The benchmark judge scored that at
**57% on style** across 12 worlds — the single largest quality loss in generated
screens.

This unseals it, in the general form rather than as per-widget flags.

### 1. Slots

A `DataTable` column and a `CardList` field each take a `cell`; a `Stat` takes
one as children.

```jsx
<DataTable rows={invoices.data} columns={[
  { key: "client.name", label: "Client",
    cell: <Stack gap={2}><Text field="client.name"/><Text field="number" variant="caption"/></Stack> },
  { key: "amount", format: "money", align: "end" },
  { key: "status", label: "Status",
    cell: <EnumBadge field="status" tones={{ overdue: "danger", paid: "success" }}/> },
]}/>
```

A slot holds an **element**, never a closure. `cell: (row) => <EnumBadge/>` is
the shape that looks like the React answer and is the one thing that cannot
work: a generated screen renders in a QuickJS VM that serializes its tree, and
`emitValue` turns a function prop into a `$handler` callback — an async door,
not something the table may call while it paints. An element serializes; a
closure does not.

Because the element is written once and rendered for every row, a component
inside a cell names its field instead of taking a value — `field="status"` —
which is the same "a config prop holds a field key" the Kit already speaks in
`titleField`, `valueField`, `xKey` and a column's own `key`. The VM now stamps
an element-in-a-prop `$element` and the tree renderer reifies it, closing a
round trip that was already half-built.

### 2. Two adjectives

One `tone` vocabulary (`neutral | accent | success | warning | danger`) and one
`density` (`comfortable | compact`), accepted by every component — replacing
four rival per-component tone enums (`default|accent|danger`,
`accent|success|danger`, `info|accent|success|warning|danger`, …). Both resolve
to theme tokens only, so an adjective can never invent a color or a spacing
step the host did not agree to. `density` re-emits the host's own spacing ladder
for its subtree, which is the whole implementation — nothing measures, nothing
branches, and a component the adjective was never taught about still gets
denser. Taught once in the catalog preamble, not restated 31 times.

### 3. Loud errors

The tree renderer hands `children` to every node it renders, so a chart handed
a child and a `Button` dropped into a cell rendered as **nothing at all**, with
no stage saying a word. Both now fail the checks floor:

> nests 1 node inside `<LineChart>`, which renders nothing nested inside it:
> that content never reaches the screen. Put it beside `<LineChart>` in a
> `<Stack>`, or give `<LineChart>` what it showed through its own props.

> holds `<Button>` in a cell slot — a cell is read, never operated: the slot is
> written ONCE and rendered for every row, so nothing in it has a row of its own
> to act on. A cell may hold: Text, Money, DateTime, Percent, Num, EnumBadge,
> Badge, Sparkline, Progress, Stack, Row …

One rule, wired into both the wire dialect (`kit-nesting`) and the component
screen (`nesting`).

### 4. Defaults

- Dates in table cells are compact and never wrap — `Aug 12`, not
  `Aug 12, 2026`. The year comes back for the whole column when its rows
  straddle years.
- `Grid` gains `minChildWidth` (auto-fit). A fixed column count does not shrink
  its cells on a narrow screen, it clips them.
- `DonutChart` carries a labelled legend, on by default. An unlabelled ring says
  nothing in a screenshot.
- A table too wide for its surface **folds** its extra columns into the first
  cell instead of scrolling them silently out of view. Five separate judge
  failures were a column that simply was not on screen.
- The screen brief carries the render surface's size when the host knows it —
  the one fact about the render target a writer could not learn from anything
  else it was handed.

### 5. Bug ride-along

The Kit's control style set `width: 100%` with padding and a border and no
`box-sizing`. The Kit renders inside a host page it does not control, so it
cannot assume a `* { box-sizing }` reset is in force — every full-width Kit
surface now states it itself.

## Benchmark

Same judge, same 12 baseline (world, case) pairs, same model, vendo contender.

| | style score |
|---|---|
| before | **57%** (30/53) |
| config-flag prototype (not shipped) | **72%** |
| **this PR** | **78%** (42/54) |

Per case (style lines passed):

| case | before | after |
|---|---|---|
| my-queue | 2/5 | **5/5** |
| tracking-plan-table | 3/6 | **4/6** |
| recent-orders | 3/5 | 3/5 |
| sprint-health | 4/5 | 3/5 |
| roster-table | 1/3 | **3/3** |
| billing-overview | 2/4 | **4/5** |
| dispatch-board | 0/5 | **3/5** |
| open-jobs | 2/4 | **4/4** |
| spend-overview | 2/2 | 2/2 |
| rent-roll | 5/6 | 5/6 |
| all-clear | 1/3 | 1/3 |
| patient-record | 5/5 | 5/5 |

`sprint-health` lost one line (points render as bare numbers without a `pts`
unit) — a unit the Kit has never carried, not a regression from this change.

## Before / after

Each pair is the same world, same case, same model — only the Kit differs.

### dispatch-board — statuses were bare words and a column was cut off the right edge
<img width="420" alt="dispatch-board before" src="https://raw.githubusercontent.com/runvendo/vendo/028a999e71d985ff1b8b801d59ff84aa731da6a6/dispatch-board-BEFORE.png"> <img width="420" alt="dispatch-board after" src="https://raw.githubusercontent.com/runvendo/vendo/028a999e71d985ff1b8b801d59ff84aa731da6a6/dispatch-board-AFTER.png">
### my-queue — the accent never appeared and status/priority read as plain text
<img width="420" alt="my-queue before" src="https://raw.githubusercontent.com/runvendo/vendo/028a999e71d985ff1b8b801d59ff84aa731da6a6/my-queue-BEFORE.png"> <img width="420" alt="my-queue after" src="https://raw.githubusercontent.com/runvendo/vendo/028a999e71d985ff1b8b801d59ff84aa731da6a6/my-queue-AFTER.png">
### open-jobs — money truncated at the clipped right edge (`$29,750.0`)
<img width="420" alt="open-jobs before" src="https://raw.githubusercontent.com/runvendo/vendo/028a999e71d985ff1b8b801d59ff84aa731da6a6/open-jobs-BEFORE.png"> <img width="420" alt="open-jobs after" src="https://raw.githubusercontent.com/runvendo/vendo/028a999e71d985ff1b8b801d59ff84aa731da6a6/open-jobs-AFTER.png">
### roster-table — the status column was cut off beyond the viewport
<img width="420" alt="roster-table before" src="https://raw.githubusercontent.com/runvendo/vendo/028a999e71d985ff1b8b801d59ff84aa731da6a6/roster-table-BEFORE.png"> <img width="420" alt="roster-table after" src="https://raw.githubusercontent.com/runvendo/vendo/028a999e71d985ff1b8b801d59ff84aa731da6a6/roster-table-AFTER.png">

## Notes for review

- Catalog growth is **+15.0%** (12,730 → 14,643 chars). The adjectives and the
  slot are taught once in the preamble precisely to pay for themselves.
- The value tier's primary prop (`Money.amount`, `Text.text`, …) is optional
  now: a component in a cell takes its value from `field`, so a required
  `amount` would make the slot the catalog teaches unwritable. `DataTable.rows`
  and friends are still required, and the typings test pins that.
- `KIT_SLOT_CONTENT_NAMES` is scoped to props keyed `cell`. `Tabs.tabs[].content`
  and `Accordion.items[].content` are element-valued too and legitimately hold
  anything, so a blanket walk would have blocked working screens.
