### PR TITLE
bench(genbench): drop the confirm-step rubric line — the product asks now

### DIFF
--- a/genbench/worlds/maple/world.json
+++ b/genbench/worlds/maple/world.json
@@ -19,7 +19,6 @@
   "style": [
     "uses the theme exactly: brand green, Onest, 8px corners — no invented colors or fonts",
     "money always shows 2 decimals with currency symbol",
-    "destructive actions ask for confirmation",
     "dates shown as 'Aug 1' style, never ISO"
   ],
   "tools": {


### PR DESCRIPTION
The maple world graded every screen on "destructive actions ask for confirmation". Since #1264, a screen files the call with one element and the PRODUCT asks — the guard's approval modal, outside the screen, invisible to the judge's screenshot. The line failed by construction (it already failed on the 2026-08-12 baseline), so per Yousef's call it is dropped rather than reworded: confirmation is no longer the screen's job, so it is no longer the screen's grade.

Genbench suite: 160 passed, 2 skipped (money-spending live tests, as always). Judge scores on affected maple cases stop being comparable with pre-drop runs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the “destructive actions ask for confirmation” rubric from the Maple world because confirmation now happens at the product level via an approval modal outside the screen, which the judge cannot see. Previously, screens were graded for in-screen confirmation; now that responsibility moved out of the screen, the rubric no longer applies and caused systematic false failures.

**Review notes**
- Change scope: deletes one style rule in `genbench/worlds/maple/world.json` only.
- Benchmark impact: Maple judge scores are not comparable with pre-change runs.
- Test status: genbench suite 160 passed; 2 live-spend tests skipped.
- No migration required.

<sup>Written for commit 882ecb777d83b1bd3872fb1c53660cecb6dc25d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

