### PR TITLE
fix(core,vendo): a revoked key and a dry meter say so from every Cloud client

### DIFF
--- a/packages/core/src/cloud-standing.ts
+++ b/packages/core/src/cloud-standing.ts
@@ -1,0 +1,26 @@
+import { VendoError } from "./errors.js";
+import { formatMeterExhausted, meterExhaustedDetail, parseMeterExhausted } from "./meter-exhausted.js";
+
+/**
+ * The two "fix your Cloud standing" refusals every Vendo Cloud door sends —
+ * 401 (missing/revoked key) and 402 (dry meter) — read ONE way by every Cloud
+ * client: `cloud-required`, carrying the CONSOLE's own message, and for a meter
+ * refusal the crafted sentence plus the structured fields on `detail`.
+ * `undefined` for any other status, so the caller keeps its own mapping.
+ *
+ * This is the CONSOLE's reading. `parseStoreWireError` is deliberately NOT
+ * routed through here: a BYO wire mount is not Vendo Cloud.
+ */
+export function cloudStandingError(
+  status: number,
+  payload: unknown,
+  fallbackMessage: string,
+): VendoError | undefined {
+  if (status !== 401 && status !== 402) return undefined;
+  const refusal = parseMeterExhausted(payload);
+  if (refusal !== undefined) {
+    return new VendoError("cloud-required", formatMeterExhausted(refusal), meterExhaustedDetail(refusal));
+  }
+  const message = (payload as { error?: { message?: unknown } } | null)?.error?.message;
+  return new VendoError("cloud-required", typeof message === "string" ? message : fallbackMessage);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@ export * from "./app-document.js";
 export * from "./app-surfaces.js";
 export * from "./audit.js";
 export * from "./capability-miss.js";
+export * from "./cloud-standing.js";
 export * from "./descriptor-hash.js";
 export * from "./errors.js";
 export * from "./formats.js";

--- a/packages/core/tests/cloud-standing.test.ts
+++ b/packages/core/tests/cloud-standing.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { cloudStandingError } from "../src/cloud-standing.js";
+
+// The console's own wire bodies for the two standing refusals.
+const UNAUTHORIZED = { error: { code: "unauthorized", message: "Valid API key required." } };
+const METER_EXHAUSTED = {
+  error: { code: "meter-exhausted", message: "meter exhausted" },
+  meter: "usage",
+  unit: "usd",
+  used: 6.2,
+  limit: 5,
+  resets_at: "2026-08-01T00:00:00.000Z",
+  reason: "allowance",
+  exits: { upgrade_url: "https://console.vendo.run/billing", byo_docs_url: "https://docs.vendo.run/byo" },
+};
+
+describe("cloudStandingError", () => {
+  it("reads a revoked key (401) as cloud-required carrying the console's message", () => {
+    const error = cloudStandingError(401, UNAUTHORIZED, "fallback");
+    expect(error).toMatchObject({ code: "cloud-required", message: "Valid API key required." });
+  });
+
+  it("falls back to the caller's message when the body carries none", () => {
+    expect(cloudStandingError(401, undefined, "fallback")).toMatchObject({
+      code: "cloud-required",
+      message: "fallback",
+    });
+    expect(cloudStandingError(402, "<html>nginx</html>", "fallback")).toMatchObject({
+      code: "cloud-required",
+      message: "fallback",
+    });
+  });
+
+  it("renders a dry meter (402) as the crafted sentence, structured fields on detail", () => {
+    expect(cloudStandingError(402, METER_EXHAUSTED, "fallback")).toMatchObject({
+      code: "cloud-required",
+      message: "Vendo Cloud paused usage — the $5.00 included this billing period is used up "
+        + "($6.20 of $5.00 used; resets 2026-08-01). "
+        + "Upgrade your plan (https://console.vendo.run/billing) "
+        + "or bring your own infrastructure (https://docs.vendo.run/byo).",
+      detail: {
+        meter: "usage",
+        unit: "usd",
+        used: 6.2,
+        limit: 5,
+        resetsAt: "2026-08-01T00:00:00.000Z",
+        reason: "allowance",
+        upgradeUrl: "https://console.vendo.run/billing",
+        byoDocsUrl: "https://docs.vendo.run/byo",
+      },
+    });
+  });
+
+  it("leaves every other status to the caller's own mapping", () => {
+    for (const status of [403, 404, 500]) {
+      expect(cloudStandingError(status, UNAUTHORIZED, "fallback"), String(status)).toBeUndefined();
+    }
+  });
+});

--- a/packages/vendo/src/cloud-console.ts
+++ b/packages/vendo/src/cloud-console.ts
@@ -1,10 +1,4 @@
-import {
-  VendoError,
-  formatMeterExhausted,
-  meterExhaustedDetail,
-  parseMeterExhausted,
-  type VendoErrorCode,
-} from "@vendoai/core";
+import { VendoError, cloudStandingError, type VendoErrorCode } from "@vendoai/core";
 import { deploymentIdentityHeaders } from "./deployment-identity.js";
 
 /** Console-client plumbing shared by the Cloud adapters (cloudSandbox,
@@ -54,20 +48,8 @@ export async function raiseCloudError(
   const message = typeof error?.message === "string"
     ? error.message
     : `Vendo Cloud ${service} request failed with ${response.status}`;
-  if (response.status === 402 || response.status === 401) {
-    // Pricing v3 (spec §5): a meter refusal carries the stable code
-    // `meter-exhausted` and the structured body — surface it as OUR crafted
-    // sentence (meter, figures, reset date, the two exits) so the safe
-    // stream-error rail and the CLI print something actionable, with the
-    // structured fields preserved on `detail`. The body is the only source
-    // of truth; no client-side entitlement checks exist. Anything else on
-    // 402/401 keeps the ENG-295 cloud-required mapping.
-    const refusal = parseMeterExhausted(payload);
-    if (refusal !== undefined) {
-      throw new VendoError("cloud-required", formatMeterExhausted(refusal), meterExhaustedDetail(refusal));
-    }
-    throw new VendoError("cloud-required", message);
-  }
+  const standing = cloudStandingError(response.status, payload, message);
+  if (standing !== undefined) throw standing;
   const code = typeof error?.code === "string" ? error.code : undefined;
   if (code !== undefined && CLOUD_ERROR_CODES.has(code)) {
     throw new VendoError(code as VendoErrorCode, message);

--- a/packages/vendo/src/hosted-store.ts
+++ b/packages/vendo/src/hosted-store.ts
@@ -1,11 +1,13 @@
 import {
   type BlobStore,
+  cloudStandingError,
   parseStoreWireError,
   type RecordInput,
   type RecordQuery,
   type RecordStore,
   STORE_WIRE_PATHS,
   type StoreOps,
+  storeWireErrorSchema,
   type StoreWireStatus,
   storeWireStatusSchema,
   VendoError,
@@ -326,7 +328,13 @@ const isTimeout = (error: unknown): boolean =>
 
 /** The protocol's own client half owns the mapping (parseStoreWireError): an
  * enveloped code wins, recognized statuses map, everything else degrades to
- * not-implemented rather than blaming the caller. */
+ * not-implemented rather than blaming the caller. The one exception is a BARE
+ * standing refusal (401/402 with no wire-legal envelope), which this client —
+ * a Vendo Cloud client, not a BYO mount's — reads as cloud-required with the
+ * console's own message, so a revoked key never masquerades as an unsupported
+ * op. The console's own refusals are always bare in that sense: `unauthorized`
+ * and `meter-exhausted` are not wire codes, so a 401/402 that DOES carry a
+ * recognized envelope came from the service's protocol half and keeps it. */
 const raiseWireError = async (response: Response): Promise<never> => {
   let payload: unknown;
   try {
@@ -334,7 +342,9 @@ const raiseWireError = async (response: Response): Promise<never> => {
   } catch {
     payload = undefined;
   }
-  throw parseStoreWireError(response.status, payload);
+  if (storeWireErrorSchema.safeParse(payload).success) throw parseStoreWireError(response.status, payload);
+  throw cloudStandingError(response.status, payload, `Vendo Cloud store request failed with ${response.status}`)
+    ?? parseStoreWireError(response.status, payload);
 };
 
 /**

--- a/packages/vendo/tests/hosted-store.test.ts
+++ b/packages/vendo/tests/hosted-store.test.ts
@@ -1124,6 +1124,46 @@ describe("hostedStoreOps — the 35-op wire client", () => {
     await expect(bare.engine.get(ENGINE_COLLECTION, "r")).rejects.toMatchObject({ code: "not-implemented" });
   });
 
+  it("reads a BARE 401/402 as cloud-required, never as an unsupported op — an envelope still wins", async () => {
+    const refusing = (body: unknown, status: number) => hostedStoreOps({
+      apiKey: "vnd_secret",
+      baseUrl: "https://cloud.test",
+      fetch: (async () => Response.json(body, { status })) as unknown as typeof fetch,
+    });
+    // A revoked key used to reach the caller as a not-implemented relabelled
+    // "Vendo Cloud store does not support the ... operation" (#1203) — the
+    // skew story told for a key problem. It says what the console said now,
+    // and the relabel below never fires for it.
+    const revoked = await refusing({ error: { code: "unauthorized", message: "Valid API key required." } }, 401)
+      .engine.get(ENGINE_COLLECTION, "r")
+      .then(() => undefined, (reason: unknown) => reason);
+    expect(revoked).toMatchObject({ code: "cloud-required", message: "Valid API key required." });
+    expect((revoked as VendoError).message).not.toContain("does not support the");
+    // A dry meter carries the crafted sentence plus its structured fields.
+    await expect(refusing({
+      error: { code: "meter-exhausted", message: "meter exhausted" },
+      meter: "usage",
+      unit: "usd",
+      used: 6.2,
+      limit: 5,
+    }, 402).engine.get(ENGINE_COLLECTION, "r")).rejects.toMatchObject({
+      code: "cloud-required",
+      message: expect.stringContaining("Vendo Cloud paused usage"),
+      detail: { meter: "usage", unit: "usd" },
+    });
+    // Neither refusal is wire-legal (`unauthorized` and `meter-exhausted` are
+    // not VendoError codes), which is exactly what makes them the console's.
+    // A 401/402 that DOES carry a recognized envelope is the service's own
+    // protocol answer and keeps it — reading it as a key or billing problem
+    // would tell the caller a story its mount never told.
+    await expect(refusing({ error: { code: "blocked", message: "vendo_audit is append-only" } }, 401)
+      .engine.delete("vendo_audit", "aud_1"))
+      .rejects.toMatchObject({ code: "blocked", message: "vendo_audit is append-only" });
+    await expect(refusing({ error: { code: "conflict", message: "revision moved on" } }, 402)
+      .engine.compareAndSwap(ENGINE_COLLECTION, { id: "r", data: {} }, "rev_1"))
+      .rejects.toMatchObject({ code: "conflict", message: "revision moved on" });
+  });
+
   it("surfaces an unsupported op cleanly, naming it — never a silent fallback", async () => {
     const notImplemented = (body: BodyInit | null) => hostedStoreOps({
       apiKey: "vnd_secret",


### PR DESCRIPTION
Closes #1203.

A revoked key and a dry meter now say so, in the console's own words, from every Vendo Cloud client.

## The bug

On the ops surface a 401 fell through `parseStoreWireError` (which has no 401 in its status table) to `not-implemented`, and the version-skew relabel then reported a revoked key as:

> Vendo Cloud store does not support the "engine.get" operation

That is a lie about the operation when the truth is a lie about the key.

## The change

One shared helper, `cloudStandingError(status, payload, fallbackMessage)` in `@vendoai/core` (26 lines), read by both Cloud client paths:

- **401** → `cloud-required` carrying the console's own message ("Valid API key required.")
- **402** → `cloud-required` carrying the crafted meter sentence plus the structured fields on `detail`, reusing the existing `parseMeterExhausted`/`formatMeterExhausted`/`meterExhaustedDetail`
- **anything else** → `undefined`, so each caller keeps its own mapping

**No new `VendoErrorCode`** — `cloud-required` is reused, by decision.

`parseStoreWireError` is deliberately NOT routed through this: a BYO wire mount is not Vendo Cloud.

## Deliberately untouched

The version-skew relabel in `hosted-store.ts` is not edited. Once 401 maps to `cloud-required` it can no longer be reached for a 401 — and that non-firing is exactly what one of the new tests asserts. `call()` is unchanged.

## Live proof (Proof 2)

Run against the built artifact on this branch:

| surface | result |
|---|---|
| `hostedStoreOps().transcripts.listThreads({})` vs **the real console.vendo.run** with a bogus `vnd_definitely_revoked_*` key | `cloud-required` — "Valid API key required." |
| `hostedStore().records("vendo_threads").list()` (facade, same real console) | `cloud-required` — "Valid API key required." |
| dry meter — the console's recorded 402 body replayed verbatim through the real client path | `cloud-required` — full crafted sentence + `detail` with meter/unit/used/limit/resetsAt/reason/upgradeUrl/byoDocsUrl |

None of the forbidden vocabulary (`not-implemented`, `does not support the`, `older than the console`) appears on any surface. The meter half used a local replay of the recorded console body rather than draining a live meter — there was no safely drainable metered service available.

## Revert-proof (every new test shown able to fail)

- `raiseWireError` reverted to `throw parseStoreWireError(...)` → red: `expected VendoError: Vendo Cloud store does not su… to match object { code: 'cloud-required' }`, received `not-implemented`. That is the shipped bug, caught.
- 402 branch removed → red. Status guard removed → the 403/404/500 case goes red. Guard narrowed to `status !== 402` → both 401 cases go red.

## Gates

`pnpm build` 0 · `typecheck` (core, vendo) 0 · `pnpm lint` 0 · core `cloud-standing` 4/4 · vendo `hosted-store` + `cloud-apps` + `cloud-secrets` + `connections` 103/103.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cloud client error mapping so revoked API keys (401) and dry meters (402) surface as cloud-required with the console’s message. Previously, 401 degraded to not-implemented and triggered the version-skew relabel (“does not support …”).

- Adds `cloudStandingError` in `@vendoai/core` and exports it; maps 401/402 to `cloud-required` (401 uses the console’s message or a caller fallback; 402 uses the crafted meter sentence with structured `detail`). Returns undefined for other statuses.
- Updates `vendo` clients:
  - `cloud-console` now delegates 401/402 to `cloudStandingError` and removes custom handling.
  - `hosted-store` wire client keeps a valid store-wire envelope as-is; otherwise, reads bare 401/402 via `cloudStandingError` so a revoked key never hits the skew relabel.
- Reuses the existing `cloud-required` code. Leaves `parseStoreWireError` unchanged; BYO wire mounts are unaffected. Adds tests in `@vendoai/core` and `vendo` (including envelope precedence).

<sup>Written for commit e87bc1e960f44b86e80bece4ff0a56d03b23ce76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

