### PR TITLE
fix(agents): run.events buffers only for a reader that is actually there

### DIFF
--- a/packages/agents/src/away.ts
+++ b/packages/agents/src/away.ts
@@ -127,6 +127,8 @@ export interface AgentRun<T = never> extends PromiseLike<AgentReport<T>> {
   /** Available before the run starts, so a caller can show it (or hand it back
    *  as `run({ threadId })`) without waiting for the report. */
   readonly threadId: string;
+  /** Read ONCE, while the run runs: nothing is kept for a reader that never
+   *  attaches, and a second reader alongside the first throws. */
   readonly events: AsyncIterable<RunEvent>;
 }
 
@@ -189,18 +191,20 @@ function withResultTool(
 }
 
 /** One buffer, one waiter — everything an `AsyncIterable` fed from callbacks
- *  needs. A caller that never reads `events` costs the run nothing but the
- *  buffer. */
+ *  needs. Nothing is buffered unless a reader is attached: a run whose events
+ *  nobody reads is the common case, and buffering for it grew without a bound. */
 function eventQueue<T>(): { push: (item: T) => void; close: () => void; iterable: AsyncIterable<T> } {
   const buffered: T[] = [];
   let wake: (() => void) | undefined;
   let closed = false;
+  let reading = false;
   const nudge = (): void => {
     wake?.();
     wake = undefined;
   };
   return {
     push: (item) => {
+      if (!reading) return;
       buffered.push(item);
       nudge();
     },
@@ -210,12 +214,27 @@ function eventQueue<T>(): { push: (item: T) => void; close: () => void; iterable
     },
     iterable: {
       async *[Symbol.asyncIterator]() {
-        while (true) {
-          while (buffered.length > 0) yield buffered.shift() as T;
-          if (closed) return;
-          await new Promise<void>((resolve) => {
-            wake = resolve;
-          });
+        if (reading) throw new VendoError("validation", "run.events is single-reader — it is already being read.");
+        reading = true;
+        try {
+          while (true) {
+            while (buffered.length > 0) yield buffered.shift() as T;
+            if (closed) return;
+            await new Promise<void>((resolve) => {
+              wake = resolve;
+            });
+          }
+        } finally {
+          // A reader that LEFT is no reader at all — `break` gets here through
+          // `.return()`. What it did not take is dropped and nothing more is
+          // kept, or a cancelled read leaves the buffer growing forever, which
+          // is the whole growth this queue exists to avoid. Its seat goes back
+          // only while the run is still going: single-reader is there so two
+          // consumers cannot split ONE live stream, and a finished run has
+          // nothing left to hand a replacement, so reading it again stays the
+          // named error rather than a silently empty stream.
+          buffered.length = 0;
+          if (!closed) reading = false;
         }
       },
     },

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -26,7 +26,7 @@ export {
   type RunOptions,
 } from "./away.js";
 export { DOOR_PATH, type DoorConfig } from "./door.js";
-export { assemblePrompt, type PromptInput } from "./prompt.js";
+export { assemblePrompt, type PromptInput, type SystemPromptHook } from "./prompt.js";
 export type { AgentSession, ApprovalEvent, RespondOptions, SessionOptions } from "./session.js";
 export {
   api,

--- a/packages/agents/tests/index.test.ts
+++ b/packages/agents/tests/index.test.ts
@@ -13,6 +13,13 @@ describe("the package surface", () => {
     expect(agents.postgres).toBeTypeOf("function");
     expect(agents.provideCloudAdapters).toBeTypeOf("function");
   });
+
+  it("exports the type a host writes its `system` hook against", () => {
+    // Typed from the ROOT: a host that has to reach into a deep path to name the
+    // hook it is already passing has no exported contract at all.
+    const system: agents.SystemPromptHook = (_ctx, prompt) => prompt.assembled;
+    expect(system).toBeTypeOf("function");
+  });
 });
 
 describe("mcp sources", () => {

--- a/packages/agents/tests/run.test.ts
+++ b/packages/agents/tests/run.test.ts
@@ -2,7 +2,7 @@
  * The code lane — `agent.run(task)`. Real embedded store, real guard, real
  * runtime; only the thinker is scripted (CLAUDE.md: test the SEAM).
  */
-import { agentRunReportSchema } from "@vendoai/core";
+import { VendoError, agentRunReportSchema } from "@vendoai/core";
 import type { VendoGuard } from "@vendoai/guard";
 import { defineHarness } from "@vendoai/harnesses";
 import { createStore, threadStore } from "@vendoai/store";
@@ -145,6 +145,96 @@ describe("run()", () => {
     expect(events).toContainEqual(
       expect.objectContaining({ type: "tool-result", tool: "invoices_list", outcome: "ok" }),
     );
+  });
+
+  it("keeps nothing for a consumer that never arrived", async () => {
+    const support = agent({
+      name: "support",
+      harness: defineHarness({
+        name: "noisy",
+        async *run() {
+          yield { type: "status" as const, label: "Reading the ledger" };
+          yield { type: "text" as const, delta: "Two invoices." };
+        },
+      }),
+      store: memoryStore(),
+    });
+
+    const running = support.run("Check the invoices.", { as: "u_42" });
+    await running;
+
+    // Nobody read while it ran, so the run buffered nothing on the way — a run
+    // whose events nobody watches must not grow with what it says.
+    expect(await collect(running.events)).toEqual([]);
+  });
+
+  it("gives a reader everything said after it attached, and refuses a second one", async () => {
+    const support = agent({
+      name: "support",
+      harness: defineHarness({
+        name: "noisy",
+        async *run() {
+          yield { type: "status" as const, label: "Reading the ledger" };
+          yield { type: "text" as const, delta: "Two invoices." };
+        },
+      }),
+      store: memoryStore(),
+    });
+
+    const running = support.run("Check the invoices.", { as: "u_42" });
+    expect(await collect(running.events)).toEqual([
+      { type: "status", label: "Reading the ledger" },
+      { type: "text", delta: "Two invoices." },
+    ]);
+    await running;
+
+    const second = await collect(running.events).catch((error: unknown) => error);
+    expect(second).toBeInstanceOf(VendoError);
+    expect((second as VendoError).code).toBe("validation");
+    expect((second as VendoError).message).toMatch(/run\.events is single-reader/);
+  });
+
+  it("keeps nothing for a reader that broke off, and lets a replacement take its seat", async () => {
+    let readerLeft!: () => void;
+    const afterBreak = new Promise<void>((resolve) => { readerLeft = resolve; });
+    let saidUnheard!: () => void;
+    const unheard = new Promise<void>((resolve) => { saidUnheard = resolve; });
+    let replacementReading!: () => void;
+    const afterReplacement = new Promise<void>((resolve) => { replacementReading = resolve; });
+    const support = agent({
+      name: "support",
+      harness: defineHarness({
+        name: "noisy",
+        async *run() {
+          yield { type: "status" as const, label: "Reading the ledger" };
+          await afterBreak;
+          yield { type: "text" as const, delta: "Nobody was listening for this." };
+          saidUnheard();
+          await afterReplacement;
+          yield { type: "text" as const, delta: "Two invoices." };
+        },
+      }),
+      store: memoryStore(),
+    });
+
+    const running = support.run("Check the invoices.", { as: "u_42" });
+    const seen: RunEvent[] = [];
+    for await (const event of running.events) {
+      seen.push(event);
+      break;
+    }
+    expect(seen).toEqual([{ type: "status", label: "Reading the ledger" }]);
+
+    readerLeft();
+    await unheard;
+    const replacement = collect(running.events);
+    replacementReading();
+    await running;
+
+    // The replacement gets what was said after IT attached and nothing else:
+    // what the run said with no reader there was dropped as it was said, never
+    // stacked up for whoever might come along.
+    expect(await replacement).toEqual([{ type: "text", delta: "Two invoices." }]);
   });
 
   it("a run nobody was there to approve finishes ok, with the cards a person has to answer", async () => {


### PR DESCRIPTION
Two small, independent fixes.

## 1. `run.events` buffers only once a consumer attaches

The queue buffered every pushed event from the start, so a run whose events nobody reads grew unboundedly. Now `push()` is a no-op until the first consumer attaches, and a **second** `for await` over `run.events` throws `VendoError("validation", …)` naming `run.events` as single-reader. The queue's signature is unchanged; the change is one `reading` flag.

A reader that does attach still receives everything pushed after it attached — no loss for a real consumer.

The only in-repo consumer of `run.events` is `run.test.ts`; no other package, example, or fixture reads it, so the single-reader rule breaks nothing today.

## 2. `SystemPromptHook` is exported

`export { assemblePrompt, type PromptInput, type SystemPromptHook } from "./prompt.js";` — the type was already the contract, it just wasn't reachable.

## Revert-proof (both shown able to fail)

- Buffering guard removed → red: `expected [ { type: 'status' }, …(1) ] to deeply equal []` — the two buffered events came back.
- Second-reader throw removed → red: `expected [] to be an instance of VendoError` — the second reader silently got an empty stream.
- `index.ts` export reverted → typecheck red: `TS2694: Namespace '…/agents/src/index' has no exported member 'SystemPromptHook'`.

## Gates

`pnpm build` 0 · `pnpm --filter @vendoai/agents typecheck` 0 · `pnpm lint` 0 · agents `run` + `index` + `away` + `unattended` 41/41.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents unbounded memory growth in `agent.run()` by delivering `run.events` only while a reader is attached and enforcing single-reader-at-a-time. Also exports `SystemPromptHook` from `@vendoai/agents` for hosts to type their `system` hook.

- Behavior change: Old buffered all events from start; New: `push()` is a no-op until the first reader attaches, a concurrent second reader throws `VendoError("validation", "run.events is single-reader …")`, a reader that leaves before close drops any buffered items and allows a replacement to attach, and reads after the run finishes still error.
- API surface: `AgentRun.events` signature is unchanged. `SystemPromptHook` is now exported from the root (`@vendoai/agents`), no runtime changes.
- Migration: If you relied on pre-attach buffering or multiple readers, attach a single reader before starting and ensure only one consumer at a time. To hand off mid-run, end the current reader and then attach the replacement; do not read `run.events` after completion.

<sup>Written for commit 3a5fa082f24d692d752c29257c661878f05934ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

