### PR TITLE
feat(agents,store,core): a VENDO_API_KEY alone boots and persists — hostedStore moves down the layer stack

### DIFF
--- a/docs-site/agent-sdk/index.mdx
+++ b/docs-site/agent-sdk/index.mdx
@@ -81,11 +81,9 @@ npx vendo login
 ```
 
 Mints a `VENDO_API_KEY` into `.env.local` — never printed. It fills the
-model seat (through the Cloud gateway) and the sandbox, and for `createVendo`
-the store too — the Cloud hosted store. Standalone `agent()` is the exception:
-its store rung is not wired yet
-([#1259](https://github.com/runvendo/vendo/issues/1259)), so until it lands you
-pass `store: postgres(url)` yourself — a key-only `agent()` refuses to boot.
+model seat (through the Cloud gateway), the sandbox, and the store — the Cloud
+hosted store — for standalone `agent()` and `createVendo` alike. Pass
+`store: postgres(url)` and yours wins instead.
 
 ### No Vendo key — bring your own {#bring-your-own}
 

--- a/docs-site/agent-sdk/reference.mdx
+++ b/docs-site/agent-sdk/reference.mdx
@@ -31,7 +31,7 @@ export function agent(config: AgentConfig): VendoAgent;
 | `guard` | `VendoGuard \| GuardRules` | a built guard wins verbatim; rules are completed with this composition's store. Unset → `createGuard({ store })` |
 | `skills` | `readonly string[]` | skill folders, boot-loaded and mounted read-only at `/host/skills` |
 | `egress` | `EgressConfig` | outbound allowlist for the box; unset = the harness's minimum |
-| `store` | `VendoStore` | unset alone → embedded. `createVendo` fills it from `VENDO_API_KEY` (the Cloud hosted store), but `agent()`'s own store rung is not wired yet ([#1259](https://github.com/runvendo/vendo/issues/1259)), so here unset + a key is a boot error naming `postgres(url)` |
+| `store` | `VendoStore` | unset alone → embedded. Unset + `VENDO_API_KEY` → the Cloud hosted store, for `agent()` as for `createVendo`. An explicit `store` always wins |
 | `sandbox` | `SandboxAdapter` | `e2b()`, or unset + `VENDO_API_KEY` → the Cloud pool. Required by a harness declaring `requires.sandbox` |
 | `door` | `DoorConfig` | where a thinker running outside this process dials back for tools; unset → `VENDO_BASE_URL` |
 | `instructions` | `string` | the host's prompt block |

--- a/packages/agents/README.md
+++ b/packages/agents/README.md
@@ -76,8 +76,8 @@ silent new conversation. `session.threadId` is the id to hand your client.
 
 Every tool call passes the guard (`run` / `ask` / `block`); the dev's risk
 label is final and an unlabeled tool asks. Unset slots resolve down the
-ladder: store → the embedded zero-config store (with `VENDO_API_KEY` set,
-pass `store` explicitly — Cloud tenant-store access is not wired yet);
+ladder: store → the embedded zero-config store, or the Cloud hosted store with
+`VENDO_API_KEY` set (an explicit `store` always wins);
 sandbox → the Cloud pool with `VENDO_API_KEY`, else a boot error naming both
 ways out. `E2B_API_KEY` is not a rung — it is the credential an explicit
 `sandbox: e2b()` reads, so a key in the shell can no longer flip which venue a

--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -25,7 +25,7 @@ import { createGuard, isGuardInstance, permissionsHandler, type GuardRules, type
 import { provideHarnessAdapters, vendo } from "@vendoai/harnesses";
 import { vendoModel } from "@vendoai/harnesses/inference";
 import { resolveDevCredential } from "@vendoai/harnesses/inference/credential";
-import { createStore, storeFiles, type VendoStore } from "@vendoai/store";
+import { createStore, hostedStore, storeFiles, type VendoStore } from "@vendoai/store";
 import type { LanguageModel, UIMessage } from "ai";
 import { randomUUID } from "node:crypto";
 import { startRun, type AgentRun, type RunOptions } from "./away.js";
@@ -159,11 +159,8 @@ export const agentComposition = (agent: VendoAgent): AgentComposition | undefine
  * The Cloud rungs. Their concrete shapes ship with the Cloud wiring, so this
  * package holds only the seam: an interface that returns a store/adapter.
  * `createVendo` (or the host) fills it; unfilled, the rung is a clear error.
- * The store rung waits on `threadStore`, which still opens with `dbFor` —
- * every session and away-run routes through it (#1259).
  */
 export interface CloudAdapters {
-  store?: (key: { apiKey: string; baseUrl?: string }) => VendoStore;
   sandbox?: (key: { apiKey: string; baseUrl?: string }) => SandboxAdapter;
 }
 let cloudAdapters: CloudAdapters = {};
@@ -228,18 +225,7 @@ export function e2b(options: E2bOptions = {}): SandboxAdapter {
 
 const defaultStore = (): VendoStore => {
   const key = cloudKey();
-  if (key !== undefined) {
-    if (cloudAdapters.store === undefined) {
-      throw new VendoError(
-        "not-implemented",
-        "A VENDO_API_KEY is set but this build has no Cloud store rung wired (tenant-store access is "
-        + "under redesign). Pass `store: postgres(url)` explicitly, importing `postgres` from "
-        + "`@vendoai/agents` — or unset the key for the embedded store.",
-      );
-    }
-    return cloudAdapters.store(key);
-  }
-  return createStore();
+  return key === undefined ? createStore() : hostedStore(key);
 };
 
 /** The ladder itself lives in @vendoai/apps (`selectSandbox`) — ONE

--- a/packages/agents/tests/agent.test.ts
+++ b/packages/agents/tests/agent.test.ts
@@ -1,14 +1,16 @@
 import type { SandboxAdapter, SandboxMachine } from "@vendoai/apps";
-import type { AuditEvent, ToolRegistry } from "@vendoai/core";
+import type { AuditEvent, Principal, ToolRegistry } from "@vendoai/core";
 import type { VendoGuard } from "@vendoai/guard";
 import { defineHarness, harnessAdapters } from "@vendoai/harnesses";
-import { createStore } from "@vendoai/store";
+import { createStore, threadStore } from "@vendoai/store";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { agent, e2b, postgres, provideCloudAdapters, withDefaultTemplate } from "../src/agent.js";
+import { agent, agentComposition, e2b, postgres, provideCloudAdapters, withDefaultTemplate } from "../src/agent.js";
 import { tool } from "../src/tools.js";
 
 let stores = 0;
 const memoryStore = () => createStore({ dataDir: `memory://agents-test-${stores++}` });
+
+const user: Principal = { kind: "user", subject: "user_1" };
 
 const inert = () =>
   defineHarness({
@@ -73,7 +75,8 @@ const fakeGuard = (): VendoGuard & { reports: AuditEvent[]; bound: ToolRegistry[
 
 afterEach(() => {
   vi.unstubAllEnvs();
-  provideCloudAdapters({ store: undefined, sandbox: undefined });
+  vi.unstubAllGlobals();
+  provideCloudAdapters({ sandbox: undefined });
 });
 
 describe("agent() boot", () => {
@@ -154,17 +157,25 @@ describe("the sandbox ladder", () => {
 });
 
 describe("the store ladder", () => {
-  it("a VENDO_API_KEY with no Cloud store rung wired is a clear error, not a silent fallback", () => {
+  it("a key alone composes a HostedStore, and its conversations really go to Cloud", async () => {
     vi.stubEnv("VENDO_API_KEY", "vk_test");
-    expect(() => agent({ name: "support", harness: inert(), guard: fakeGuard() }))
-      .toThrow(/Cloud store rung/);
+    vi.stubEnv("VENDO_CLOUD_URL", "https://console.test");
+    const fetchSpy = vi.fn(async () => Response.json({ record: null }));
+    vi.stubGlobal("fetch", fetchSpy);
+    const composed = agentComposition(agent({ name: "support", harness: inert(), guard: fakeGuard() }));
+
+    // Not "a slot is filled" — a real thread read, over the real wire client.
+    expect(await threadStore(composed!.store).get(user, "thr_cloud")).toBeNull();
+    const [url, init] = fetchSpy.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe("https://console.test/api/v1/store/transcripts/getThread");
+    expect((init.headers as Record<string, string>)["authorization"]).toBe("Bearer vk_test");
   });
 
-  it("the Cloud rung is an interface that returns a store", () => {
+  it("an explicitly passed store wins over the key", () => {
     vi.stubEnv("VENDO_API_KEY", "vk_test");
     const store = memoryStore();
-    provideCloudAdapters({ store: () => store });
-    expect(() => agent({ name: "support", harness: inert(), guard: fakeGuard() })).not.toThrow();
+    const composed = agentComposition(agent({ name: "support", harness: inert(), guard: fakeGuard(), store }));
+    expect(composed?.store).toBe(store);
   });
 });
 

--- a/packages/agents/tests/error-imports.test.ts
+++ b/packages/agents/tests/error-imports.test.ts
@@ -65,12 +65,6 @@ describe("the symbols a boot error names", () => {
       .toThrow(/import `e2b` from `@vendoai\/agents`/);
   });
 
-  it("says where postgres lives, on the store error", () => {
-    vi.stubEnv("VENDO_API_KEY", "vk_test");
-    expect(() => agent({ name: "support" }))
-      .toThrow(/importing `postgres` from `@vendoai\/agents`/);
-  });
-
   // The paths above are only true because this package exports them.
   it("exports the symbols it points at", () => {
     expect(typeof e2b).toBe("function");

--- a/packages/core/src/cloud-console.ts
+++ b/packages/core/src/cloud-console.ts
@@ -1,4 +1,5 @@
-import { VendoError, cloudStandingError, type VendoErrorCode } from "@vendoai/core";
+import { cloudStandingError } from "./cloud-standing.js";
+import { VendoError, type VendoErrorCode } from "./errors.js";
 import { deploymentIdentityHeaders } from "./deployment-identity.js";
 
 /** Console-client plumbing shared by the Cloud adapters (cloudSandbox,

--- a/packages/core/src/deployment-identity.ts
+++ b/packages/core/src/deployment-identity.ts
@@ -10,7 +10,7 @@
  * request down. The console truncates and fails open on its side
  * (parseDeploymentHeaders), so sending is always safe. */
 
-import { VERSION } from "./wire/shared.js";
+import { VERSION } from "./version.js";
 
 type RuntimeProcess = {
   getBuiltinModule?: (id: string) => unknown;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,7 +8,13 @@ export * from "./app-document.js";
 export * from "./app-surfaces.js";
 export * from "./audit.js";
 export * from "./capability-miss.js";
+// The key-authed console client plumbing every Cloud adapter shares — the
+// deployment-identity headers, the wire-legal error table, and the sender.
+// `keepAliveFetch` deliberately stays in @vendoai/vendo: it reaches undici, and
+// core is bundled for browser and edge targets (portability-gate.mjs).
+export * from "./cloud-console.js";
 export * from "./cloud-standing.js";
+export * from "./deployment-identity.js";
 export * from "./descriptor-hash.js";
 export * from "./errors.js";
 export * from "./formats.js";
@@ -49,6 +55,7 @@ export * from "./stream-parts.js";
 export * from "./tool-envelopes.js";
 export * from "./tools.js";
 export * from "./url.js";
+export * from "./version.js";
 export * from "./genui/tree-node.js";
 export * from "./filesystem.js";
 export * from "./triggers.js";

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,0 +1,5 @@
+/** The published version of every @vendoai/* package (one `fixed` changeset
+    group, so one literal serves all of them). It lives HERE because the Cloud
+    adapters that stamp it on the wire — the deployment-identity headers — sit
+    in core now. Rewritten by scripts/sync-version-constants.mjs on release. */
+export const VERSION = "0.18.0";

--- a/packages/core/tests/cloud-console.test.ts
+++ b/packages/core/tests/cloud-console.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { consoleSender, raiseCloudError } from "../src/cloud-console.js";
+import { deploymentIdentityHeaders } from "../src/deployment-identity.js";
+
+// Stand-in for an adapter's own tail: whatever the raise could not read reaches here.
+const tail = (code: string | undefined, message: string): never => {
+  throw Object.assign(new Error(message), { code });
+};
+
+const enveloped = (status: number, body: unknown) => new Response(JSON.stringify(body), { status });
+
+describe("raiseCloudError", () => {
+  it("forwards a wire-legal console code as a VendoError carrying the server's message", async () => {
+    await expect(
+      raiseCloudError(enveloped(409, { error: { code: "conflict", message: "Slug already taken." } }), "store", tail),
+    ).rejects.toMatchObject({ code: "conflict", message: "Slug already taken." });
+  });
+
+  it("reads both standing refusals (401, 402) as cloud-required", async () => {
+    for (const status of [401, 402]) {
+      await expect(
+        raiseCloudError(
+          enveloped(status, { error: { code: "unauthorized", message: "Valid API key required." } }),
+          "store",
+          tail,
+        ),
+        String(status),
+      ).rejects.toMatchObject({ code: "cloud-required", message: "Valid API key required." });
+    }
+  });
+
+  it("hands a code it does not know to the adapter's own tail", async () => {
+    await expect(
+      raiseCloudError(enveloped(503, { error: { code: "unavailable", message: "Sandbox pool is drained." } }), "sandbox", tail),
+    ).rejects.toMatchObject({ code: "unavailable", message: "Sandbox pool is drained." });
+  });
+
+  it("falls back to a service-and-status sentence with no code when the body is not JSON", async () => {
+    await expect(
+      raiseCloudError(new Response("<html>nginx</html>", { status: 502 }), "store", tail),
+    ).rejects.toMatchObject({ code: undefined, message: "Vendo Cloud store request failed with 502" });
+  });
+
+  it("uses the same fallback sentence when the envelope carries no message", async () => {
+    await expect(
+      raiseCloudError(enveloped(500, { error: { code: "boom" } }), "apps", tail),
+    ).rejects.toMatchObject({ code: "boom", message: "Vendo Cloud apps request failed with 500" });
+  });
+});
+
+describe("consoleSender", () => {
+  const send = (fetchImpl: typeof fetch, raise: (response: Response) => Promise<never>) =>
+    consoleSender({
+      base: "https://console.vendo.run",
+      mountPath: "/api/store",
+      apiKey: "vk_live_1",
+      timeoutMs: 5_000,
+      fetchImpl,
+      raise,
+    });
+
+  const ok = (): { calls: [string, RequestInit][]; fetchImpl: typeof fetch; response: Response } => {
+    const calls: [string, RequestInit][] = [];
+    const response = new Response("{}", { status: 200 });
+    const fetchImpl = ((url: string, init: RequestInit) => {
+      calls.push([url, init]);
+      return Promise.resolve(response);
+    }) as unknown as typeof fetch;
+    return { calls, fetchImpl, response };
+  };
+
+  const raises = async (): Promise<never> => {
+    throw new Error("unreachable");
+  };
+
+  it("calls base + mountPath + path with bearer auth, a JSON accept and the deployment identity", async () => {
+    const { calls, fetchImpl } = ok();
+    await send(fetchImpl, raises)("/collections");
+    expect(calls[0]![0]).toBe("https://console.vendo.run/api/store/collections");
+    expect(calls[0]![1].headers).toEqual({
+      authorization: "Bearer vk_live_1",
+      accept: "application/json",
+      ...(await deploymentIdentityHeaders()),
+    });
+  });
+
+  it("merges the caller's own headers in, and lets them win where they overlap", async () => {
+    const { calls, fetchImpl } = ok();
+    await send(fetchImpl, raises)("/collections", { method: "POST", headers: { accept: "text/plain", "x-trace": "t1" } });
+    expect(calls[0]![1]).toMatchObject({ method: "POST" });
+    expect(calls[0]![1].headers).toMatchObject({ accept: "text/plain", "x-trace": "t1" });
+  });
+
+  it("hands a 2xx back untouched and puts anything else through the adapter's raise", async () => {
+    const { fetchImpl, response } = ok();
+    expect(await send(fetchImpl, raises)("/collections")).toBe(response);
+
+    const refused = new Response("{}", { status: 409 });
+    const seen: Response[] = [];
+    const refusing = (() => Promise.resolve(refused)) as unknown as typeof fetch;
+    await expect(
+      send(refusing, async (r) => {
+        seen.push(r);
+        throw new Error("raised");
+      })("/collections"),
+    ).rejects.toThrow("raised");
+    expect(seen).toEqual([refused]);
+  });
+});

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -36,6 +36,10 @@
     "./postgres": {
       "types": "./dist/postgres.d.ts",
       "default": "./dist/postgres.js"
+    },
+    "./test-util": {
+      "types": "./dist/hosted-store.test-util.d.ts",
+      "default": "./dist/hosted-store.test-util.js"
     }
   },
   "files": [

--- a/packages/store/src/files-store.ts
+++ b/packages/store/src/files-store.ts
@@ -22,7 +22,18 @@ export const WORKSPACE_BLOB_NAMESPACE = "workspace";
  * the fix rather than silently succeeding until Postgres complains.
  */
 export function storeFiles(store: VendoStore): FilesAdapter {
-  return storeFilesForDb(dbFor(store));
+  // The Db handle is bound LAZILY, on the first call. Every composition builds
+  // this adapter for whatever store it composed — a hosted one included, where
+  // `dbFor` has no handle to give and throws. A hosted deployment's blobs ride
+  // the wire instead, so it never reaches these methods; binding eagerly turned
+  // that into a boot failure.
+  let bound: FilesAdapter | undefined;
+  const local = (): FilesAdapter => (bound ??= storeFilesForDb(dbFor(store)));
+  return {
+    put: (key, bytes, meta) => local().put(key, bytes, meta),
+    get: (key) => local().get(key),
+    delete: (key) => local().delete(key),
+  };
 }
 
 /** The same adapter bound to an explicit Db handle — ops.ts hands it the

--- a/packages/store/src/helpers/threads.ts
+++ b/packages/store/src/helpers/threads.ts
@@ -1,6 +1,8 @@
-import { VendoError, type Json, type Principal, type ThreadId } from "@vendoai/core";
+import { VendoError, type Json, type Principal, type StoreOps, type ThreadId, type VendoRecord } from "@vendoai/core";
+import type { Db } from "../db-postgres.js";
 import { harnessStateKey } from "../harness-state.js";
-import { dbFor, type VendoStore } from "../store.js";
+import type { VendoStore } from "../store.js";
+import { backendOf } from "./backend.js";
 import type { ThreadRow } from "./types.js";
 import { putThreadRow, THREAD_MESSAGES_AGGREGATE, threadFromRow } from "./rows.js";
 import { iso, text } from "./utils.js";
@@ -17,16 +19,113 @@ export interface AskUserAnswer {
   answer: Json;
 }
 
-/** 02-store §3 */
-export function threadStore(store: VendoStore): {
+/** 02-store §3 — the surface, whichever backend serves it. */
+export interface ThreadStore {
   put(principal: Principal, thread: { id: ThreadId; messages: Json[] }): Promise<ThreadRow>;
   get(principal: Principal, id: ThreadId): Promise<ThreadRow | null>;
   list(principal: Principal): Promise<Array<{ id: ThreadId; createdAt: string; updatedAt: string }>>;
   delete(principal: Principal, id: ThreadId): Promise<void>;
   /** Record an `ask_user` answer into the answerer's OWN thread. */
   recordAnswer(principal: Principal, answer: AskUserAnswer): Promise<void>;
-} {
-  const db = dbFor(store);
+}
+
+/** 02-store §3 */
+export function threadStore(store: VendoStore): ThreadStore {
+  const backend = backendOf(store, "conversations (02-store §3)");
+  return backend.kind === "ops" ? overOps(backend.ops) : overSql(backend.db);
+}
+
+/** The inverse of `threadRecord` (routing.ts): the wire's transcript record,
+ *  read back as the row every caller of this helper already speaks. */
+function threadFromRecord(record: VendoRecord): ThreadRow {
+  const data = record.data as { subject?: unknown; messages?: unknown; title?: unknown };
+  return {
+    id: record.id,
+    subject: text(data.subject),
+    messages: Array.isArray(data.messages) ? data.messages as Json[] : [],
+    ...(typeof data.title === "string" ? { title: data.title } : {}),
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+    ...(record.revision === undefined ? {} : { revision: record.revision }),
+  };
+}
+
+/**
+ * The hosted half: conversations ride `vendo/store-wire@1`'s transcripts
+ * family, verb for verb — which is what lets a key-only deployment hold one.
+ *
+ * Three honest differences from the SQL half:
+ * - **Ownership is read-then-write**, not one statement. The TOCTOU window that
+ *   opens is between two writes by the same subject to a thread whose owner
+ *   would have to change mid-call, which the store has no verb for. (`put` is
+ *   the exception: it sends the subject, and the service's own guarded upsert
+ *   refuses a cross-subject flip atomically, exactly as SQL does.)
+ * - **`list` is ordered by the wire's cursor column** rather than by
+ *   `updated_at DESC`. It is still every thread: the pages are walked to
+ *   exhaustion, because the returned array is the caller's only handle.
+ * - **An answer carries its question id in its payload.** The wire derives the
+ *   answer's row id from the answer itself, so `questionId` rides along as
+ *   `id` — which is what keeps `ans_<questionId>` the row id here too, and with
+ *   it the loud refusal of a reused question id.
+ */
+function overOps(ops: StoreOps): ThreadStore {
+  /** The thread record is the ownership record on the wire exactly as the
+   *  `vendo_threads` row is in SQL: `data.subject` is the same field the join
+   *  reads. A foreign or absent thread yields nothing, so reads answer empty
+   *  and writes refuse — mirroring the local empty-read. */
+  const owned = async (principal: Principal, id: ThreadId): Promise<VendoRecord | undefined> => {
+    const record = await ops.transcripts.getThread(id);
+    if (record === null) return undefined;
+    return (record.data as { subject?: unknown }).subject === principal.subject ? record : undefined;
+  };
+
+  return {
+    async put(principal, thread) {
+      const parsed = parseThreadData({ subject: principal.subject, messages: thread.messages }, thread.id);
+      return threadFromRecord(await ops.transcripts.putThread({ id: thread.id, ...parsed }));
+    },
+    async get(principal, id) {
+      const record = await owned(principal, id);
+      return record === undefined ? null : threadFromRecord(record);
+    },
+    async list(principal) {
+      // `ThreadStore.list` hands back a complete array — it has no cursor of its
+      // own — so the service's pages are followed here. A service that repeats a
+      // cursor ends the walk rather than spinning (byo-approvals' `listAll`).
+      const records: VendoRecord[] = [];
+      let cursor: string | undefined;
+      do {
+        const page = await ops.transcripts.listThreads({
+          subject: principal.subject,
+          ...(cursor === undefined ? {} : { cursor }),
+        });
+        records.push(...page.records);
+        if (page.cursor === undefined || page.cursor === cursor) break;
+        cursor = page.cursor;
+      } while (cursor !== undefined);
+      return records.map((record) => ({
+        id: record.id,
+        createdAt: record.createdAt,
+        updatedAt: record.updatedAt,
+      }));
+    },
+    async delete(principal, id) {
+      // The service cascades (thread + messages + harness state) exactly as the
+      // SQL transaction below does; a foreign principal sweeps nothing.
+      if (await owned(principal, id) === undefined) return;
+      await ops.transcripts.deleteThread(id);
+    },
+    async recordAnswer(principal, { threadId, questionId, answer }) {
+      if (await owned(principal, threadId) === undefined) {
+        throw new VendoError("conflict", `thread ${threadId} does not belong to this subject`);
+      }
+      await ops.transcripts.recordAnswer(threadId, { id: questionId, answer });
+    },
+  };
+}
+
+/** The SQL half: the statements are the enforcement. */
+function overSql(db: Db): ThreadStore {
   return {
     async put(principal, thread) {
       const parsed = parseThreadData({ subject: principal.subject, messages: thread.messages }, thread.id);

--- a/packages/store/src/hosted-store.test-util.ts
+++ b/packages/store/src/hosted-store.test-util.ts
@@ -322,7 +322,9 @@ export function fakeConsole() {
     return miss();
   };
 
-  const handler = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  // `fetch`'s own first parameter rather than DOM's `RequestInfo`: this package
+  // compiles against ES2022 + @types/node, with no DOM lib.
+  const handler = async (input: Parameters<typeof fetch>[0], init?: RequestInit): Promise<Response> => {
     const request = new Request(input, init);
     const url = new URL(request.url);
     const recorded = await record(request);

--- a/packages/store/src/hosted-store.ts
+++ b/packages/store/src/hosted-store.ts
@@ -1,7 +1,10 @@
 import {
   type BlobStore,
   cloudStandingError,
+  consoleSender,
+  defaultFetch,
   parseStoreWireError,
+  raiseCloudError,
   type RecordInput,
   type RecordQuery,
   type RecordStore,
@@ -14,15 +17,9 @@ import {
   type VendoRecord,
   vendoRecordSchema,
 } from "@vendoai/core";
-import {
-  DEDICATED_RECORD_COLLECTIONS,
-  RESERVED_COLLECTIONS,
-  type EraseReport,
-  type VendoStore,
-} from "@vendoai/store";
-import { consoleSender, raiseCloudError } from "./cloud-console.js";
-import { keepAliveFetch } from "./keep-alive-fetch.js";
-import { environment } from "./wire/shared.js";
+import type { EraseReport } from "./erase.js";
+import { DEDICATED_RECORD_COLLECTIONS, RESERVED_COLLECTIONS } from "./routing.js";
+import type { VendoStore } from "./store.js";
 
 /** The console mounts the hosted-store surface here
  * (apps/console/app/api/v1/store/*). */
@@ -136,7 +133,7 @@ const appScope = (scope: string): { appId: string; collection: string } | undefi
 export function hostedStore(options: HostedStoreOptions): HostedStore {
   const base = (options.baseUrl ?? "https://console.vendo.run").replace(/\/$/, "");
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const fetchImpl = options.fetch ?? keepAliveFetch;
+  const fetchImpl = options.fetch ?? defaultFetch;
 
   const send = consoleSender({
     base,
@@ -290,7 +287,8 @@ type StoreWireOp = keyof typeof STORE_WIRE_PATHS;
  * Read ONCE at import, like the skew latch below: a debug switch belongs to the
  * process, so the adapter itself still reads nothing at construction or on any
  * call, and unset there is no wrapper to pay for. */
-const TRACE = environment("VENDO_STORE_TRACE") !== undefined;
+const TRACE = (globalThis as { process?: { env?: Record<string, string | undefined> } })
+  .process?.env?.VENDO_STORE_TRACE !== undefined;
 
 /** The `outcome=` field of a FAILED call's trace line. Failures are the tail of
  * the latency distribution, not an afterthought: an exhausted 30s budget is the
@@ -385,7 +383,7 @@ function storeWireClient(
     mountPath: CONSOLE_STORE_PATH,
     apiKey: options.apiKey,
     timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-    fetchImpl: options.fetch ?? keepAliveFetch,
+    fetchImpl: options.fetch ?? defaultFetch,
     raise,
   });
 

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -30,7 +30,7 @@ export {
 export { backfillAppDataStamps, type AppDataBackfillReport } from "./backfill-app-data.js";
 export { backfillAppRefKey, type AppRefKeyBackfillReport } from "./backfill-app-data.js";
 // The reserved-collection map (02-store §2): exported so remote StoreAdapters
-// (the umbrella's hostedStore) can mirror this engine's per-collection
+// (`hostedStore` below) can mirror this engine's per-collection
 // capability shape — claim on non-routed collections, atomic on generic
 // collections and vendo_threads — without re-deriving the routing table.
 export {
@@ -71,3 +71,7 @@ export {
 } from "./workspace.js";
 export { storeFiles, FILES_STORE_MAX_BYTES } from "./files-store.js";
 export { harnessStateStore } from "./harness-state.js";
+// The Cloud store: the same StoreAdapter and the same 35 ops, over the console
+// wire instead of a local Postgres. It lives HERE so every helper above can be
+// served by it without the caller reaching for the umbrella.
+export { hostedStore, hostedStoreOps, type HostedStore, type HostedStoreOptions } from "./hosted-store.js";

--- a/packages/store/src/postgres.ts
+++ b/packages/store/src/postgres.ts
@@ -82,3 +82,6 @@ export {
 } from "./workspace.js";
 export { storeFiles, FILES_STORE_MAX_BYTES } from "./files-store.js";
 export { harnessStateStore } from "./harness-state.js";
+// The Cloud store belongs here too: it talks to the console over HTTP, so it
+// carries no engine at all.
+export { hostedStore, hostedStoreOps, type HostedStore, type HostedStoreOptions } from "./hosted-store.js";

--- a/packages/store/tests/helpers/threads.ops.test.ts
+++ b/packages/store/tests/helpers/threads.ops.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Conversations (02-store §3), proven against every backend they can sit on —
+ * the harness-state and transcript suites' sibling, same shape and same reason.
+ *
+ * `threadStore` demanded a SQL handle, which is why a key-only deployment could
+ * not hold a conversation at all: every session and every away-run opens one. It
+ * picks a backend now (`backendOf`), so this file is the proof that §3's rules —
+ * a thread reads back as it was written, threads NEVER cross subjects, a delete
+ * cascades, and an answer is never overwritten — read identically whichever
+ * backend answers.
+ */
+import { VendoError, type Principal, type StoreOps } from "@vendoai/core";
+import { memoryStoreOps } from "@vendoai/core/conformance";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { backends, type MadeBackend } from "../../src/backends.test-util.js";
+import { createStoreOps, threadStore, type VendoStore } from "../../src/index.js";
+
+const alice: Principal = { kind: "user", subject: "user_alice" };
+const bob: Principal = { kind: "user", subject: "user_bob" };
+
+/** Not a handle `@vendoai/store` minted — the shape a hosted store presents. */
+function opsOnlyStore(ops: StoreOps): VendoStore {
+  const unused = (what: string): never => {
+    throw new Error(`the thread helper must not reach ${what}`);
+  };
+  return {
+    ops,
+    records: () => unused("records()"),
+    blobs: () => unused("blobs()"),
+    async ensureSchema() {},
+    async close() {},
+    raw: () => unused("raw()"),
+  };
+}
+
+/** Ids are namespaced per mode because `local-ops` and `sql` share one database. */
+const modesFor = (made: MadeBackend): Array<{ name: string; store: VendoStore }> => [
+  { name: "sql", store: made.store },
+  { name: "memory-ops", store: opsOnlyStore(memoryStoreOps()) },
+  { name: "local-ops", store: opsOnlyStore(createStoreOps(made.store)) },
+];
+
+for (const backend of backends()) {
+  describe(`${backend.name} conversations across backends (02-store §3)`, () => {
+    let made: MadeBackend;
+    let modes: Array<{ name: string; store: VendoStore }>;
+    beforeAll(async () => {
+      made = await backend.make();
+      await made.store.ensureSchema();
+      modes = modesFor(made);
+    });
+    afterAll(async () => { if (made) await made.cleanup(); });
+
+    describe.each([{ mode: "sql" }, { mode: "memory-ops" }, { mode: "local-ops" }])("$mode", ({ mode }) => {
+      const pick = (): VendoStore => modes.find((candidate) => candidate.name === mode)!.store;
+      const id = (suffix: string): string => `thr_${mode.replace("-", "_")}_${suffix}`;
+
+      it("a thread reads back as it was written", async () => {
+        const threads = threadStore(pick());
+        const thread = id("round_trip");
+        await threads.put(alice, { id: thread, messages: [{ id: "m1", role: "user" }] });
+
+        const row = await threads.get(alice, thread);
+        expect(row?.subject).toBe(alice.subject);
+        expect(row?.messages).toEqual([{ id: "m1", role: "user" }]);
+      });
+
+      it("threads never cross subjects: a foreign thread reads as absent", async () => {
+        const threads = threadStore(pick());
+        const thread = id("foreign");
+        await threads.put(alice, { id: thread, messages: [] });
+
+        expect(await threads.get(bob, thread)).toBeNull();
+      });
+
+      it("list is scoped to the asking subject", async () => {
+        const threads = threadStore(pick());
+        await threads.put(alice, { id: id("mine"), messages: [] });
+        await threads.put(bob, { id: id("theirs"), messages: [] });
+
+        const ids = (await threads.list(alice)).map((entry) => entry.id);
+        expect(ids).toContain(id("mine"));
+        expect(ids).not.toContain(id("theirs"));
+      });
+
+      it("delete removes the thread, and a foreign delete sweeps nothing", async () => {
+        const threads = threadStore(pick());
+        const thread = id("gone");
+        await threads.put(alice, { id: thread, messages: [] });
+
+        await threads.delete(bob, thread);
+        expect(await threads.get(alice, thread)).not.toBeNull();
+        await threads.delete(alice, thread);
+        expect(await threads.get(alice, thread)).toBeNull();
+      });
+
+      it("an answer lands in its own thread, and a reused questionId is refused", async () => {
+        const threads = threadStore(pick());
+        const thread = id("answered");
+        await threads.put(alice, { id: thread, messages: [] });
+        await threads.recordAnswer(alice, { threadId: thread, questionId: "q_1", answer: { text: "yes" } });
+
+        expect((await threads.get(alice, thread))?.messages).toHaveLength(1);
+        // Two answers are never the same answer, so the second is refused rather
+        // than overwriting the first (or reporting a success that never happened).
+        await expect(
+          threads.recordAnswer(alice, { threadId: thread, questionId: "q_1", answer: { text: "no" } }),
+        ).rejects.toBeInstanceOf(VendoError);
+      });
+
+      it("an answer cannot be written into someone else's thread", async () => {
+        const threads = threadStore(pick());
+        const thread = id("not_yours");
+        await threads.put(alice, { id: thread, messages: [] });
+
+        await expect(
+          threads.recordAnswer(bob, { threadId: thread, questionId: "q_2", answer: { text: "hi" } }),
+        ).rejects.toThrow(/does not belong to this subject/);
+      });
+    });
+  });
+}
+
+/** The real memory ops, one thread per page: `threadStore.list` sends no limit,
+ *  so this is how a subject with more threads than fit in one service page is
+ *  reached without writing the default page size (100) of them. */
+function pagedOneAtATime(ops: StoreOps, onList?: () => void): StoreOps {
+  return {
+    ...ops,
+    transcripts: {
+      ...ops.transcripts,
+      async listThreads(query) {
+        onList?.();
+        return await ops.transcripts.listThreads({ ...query, limit: 1 });
+      },
+    },
+  };
+}
+
+describe("a hosted list whose service pages", () => {
+  it("returns every thread, not just the first page", async () => {
+    const threads = threadStore(opsOnlyStore(pagedOneAtATime(memoryStoreOps())));
+    for (const suffix of ["p1", "p2", "p3"]) {
+      await threads.put(alice, { id: `thr_paged_${suffix}`, messages: [] });
+    }
+    await threads.put(bob, { id: "thr_paged_theirs", messages: [] });
+
+    const ids = (await threads.list(alice)).map((entry) => entry.id).sort();
+    expect(ids).toEqual(["thr_paged_p1", "thr_paged_p2", "thr_paged_p3"]);
+  });
+
+  it("ends the walk when the service repeats a cursor, rather than paging forever", async () => {
+    let calls = 0;
+    const ops = memoryStoreOps();
+    const paged = pagedOneAtATime(ops, () => { calls += 1; });
+    const stuck: StoreOps = {
+      ...paged,
+      transcripts: {
+        ...paged.transcripts,
+        async listThreads(query) {
+          return { ...(await paged.transcripts.listThreads(query)), cursor: "stuck" };
+        },
+      },
+    };
+    const threads = threadStore(opsOnlyStore(stuck));
+    await threads.put(alice, { id: "thr_stuck_1", messages: [] });
+    await threads.put(alice, { id: "thr_stuck_2", messages: [] });
+
+    await threads.list(alice);
+    expect(calls).toBe(2);
+  });
+});
+
+describe("a store with neither a SQL handle nor a StoreOps surface", () => {
+  it("is refused by name, at construction", () => {
+    const bare = { ...opsOnlyStore(memoryStoreOps()), ops: undefined };
+    expect(() => threadStore(bare)).toThrow(/SQL handle or a StoreOps-capable store/);
+  });
+});

--- a/packages/store/tests/hosted-store.test.ts
+++ b/packages/store/tests/hosted-store.test.ts
@@ -29,7 +29,7 @@ import {
   type StoreAdapter,
 } from "@vendoai/core";
 import { storeAdapterConformance } from "@vendoai/core/conformance";
-import { createStore, secretStore, storeSecrets, type VendoStore } from "@vendoai/store";
+import { createStore, secretStore, storeSecrets, type VendoStore } from "../src/index.js";
 import { hostedStore, hostedStoreOps, type HostedStore } from "../src/hosted-store.js";
 import { fakeConsole } from "../src/hosted-store.test-util.js";
 
@@ -1165,7 +1165,9 @@ describe("hostedStoreOps — the 35-op wire client", () => {
   });
 
   it("surfaces an unsupported op cleanly, naming it — never a silent fallback", async () => {
-    const notImplemented = (body: BodyInit | null) => hostedStoreOps({
+    // `Response`'s own body parameter rather than DOM's `BodyInit`: this
+    // package compiles against ES2022 + @types/node, with no DOM lib.
+    const notImplemented = (body: ConstructorParameters<typeof Response>[0]) => hostedStoreOps({
       apiKey: "vnd_secret",
       baseUrl: "https://cloud.test",
       fetch: (async () => new Response(body, {

--- a/packages/store/tsconfig.json
+++ b/packages/store/tsconfig.json
@@ -11,5 +11,8 @@
     "sourceMap": true
   },
   "include": ["src"],
-  "exclude": ["src/**/*.test.ts", "src/**/*.test-util.ts"]
+  // hosted-store.test-util.ts is NOT excluded: it is the published `./test-util`
+  // subpath — the ONE fake console every consumer of the hosted store drives it
+  // through, so a second copy cannot drift from this one.
+  "exclude": ["src/**/*.test.ts", "src/fixtures.test-util.ts", "src/backends.test-util.ts"]
 }

--- a/packages/vendo/src/channels.ts
+++ b/packages/vendo/src/channels.ts
@@ -1,5 +1,4 @@
-import { VendoError, defaultFetch, type Principal } from "@vendoai/core";
-import { consoleSender, raiseCloudError } from "./cloud-console.js";
+import { consoleSender, defaultFetch, raiseCloudError, VendoError, type Principal } from "@vendoai/core";
 import { hex } from "./wire/shared.js";
 
 /** The TEXT CHANNEL seam: a deployment's users reach the agent over

--- a/packages/vendo/src/cli/cloud/client.ts
+++ b/packages/vendo/src/cli/cloud/client.ts
@@ -1,5 +1,6 @@
 import {
   METER_EXHAUSTED_CODE,
+  deploymentIdentityHeaders,
   formatMeterExhausted,
   parseMeterExhausted,
 } from "@vendoai/core";
@@ -9,7 +10,6 @@ import {
   writeCloudSession,
   type CloudSession,
 } from "./session.js";
-import { deploymentIdentityHeaders } from "../../deployment-identity.js";
 import { CLI_VERSION } from "../shared.js";
 
 export function isVendoKey(key: string): boolean {

--- a/packages/vendo/src/cli/cloud/host-components.ts
+++ b/packages/vendo/src/cli/cloud/host-components.ts
@@ -2,7 +2,7 @@ import { promises as fs } from "node:fs";
 import { join } from "node:path";
 import { capturedHostComponentSchema, capturedModuleSchema, type CapturedHostComponent } from "@vendoai/actions";
 import type { Json } from "@vendoai/core";
-import { hostedStore } from "../../hosted-store.js";
+import { hostedStore } from "@vendoai/store";
 
 /**
  * Push the registered-component corpus `vendo sync` captured to Vendo Cloud, so

--- a/packages/vendo/src/cli/cloud/seed-baselines.ts
+++ b/packages/vendo/src/cli/cloud/seed-baselines.ts
@@ -2,7 +2,7 @@ import { promises as fs } from "node:fs";
 import { join } from "node:path";
 import { seedBaselineSchema, type SeedBaseline } from "@vendoai/apps";
 import type { Json } from "@vendoai/core";
-import { hostedStore } from "../../hosted-store.js";
+import { hostedStore } from "@vendoai/store";
 
 /**
  * Push the pin baselines `vendo sync` captured to Vendo Cloud, so the console's

--- a/packages/vendo/src/cloud-apps.ts
+++ b/packages/vendo/src/cloud-apps.ts
@@ -1,14 +1,15 @@
 import {
   type AppDocument,
   type AppId,
+  consoleSender,
   defaultFetch,
+  raiseCloudError,
 } from "@vendoai/core";
 import {
   publishRecordSchema,
   shareSnapshotSchema,
   type CloudAppsClient,
 } from "@vendoai/apps";
-import { consoleSender, raiseCloudError } from "./cloud-console.js";
 
 /** The Cloud share/publish client — the implementation the composition seam
  * (createVendo) injects into the apps block's CloudAppsClient seam when

--- a/packages/vendo/src/cloud-config.ts
+++ b/packages/vendo/src/cloud-config.ts
@@ -1,8 +1,8 @@
 import {
   defaultFetch,
+  deploymentIdentityHeaders,
   VendoError,
 } from "@vendoai/core";
-import { deploymentIdentityHeaders } from "./deployment-identity.js";
 
 /** The Cloud hosted-config client — the read half of the config-resolution seam
  * (cse lane 3). The composition seam (selectConfigSurface in server.ts) consults

--- a/packages/vendo/src/cloud-key-fetch.ts
+++ b/packages/vendo/src/cloud-key-fetch.ts
@@ -3,9 +3,7 @@
  *  state on top — Node-only concerns that used to ride into Worker bundles
  *  whenever runtime code borrowed it. Keep this module free of node builtins
  *  and CLI imports; the portability gate bundles it. */
-import { defaultFetch } from "@vendoai/core";
-
-import { deploymentIdentityHeaders } from "./deployment-identity.js";
+import { defaultFetch, deploymentIdentityHeaders } from "@vendoai/core";
 import { VERSION } from "./wire/shared.js";
 
 const DEFAULT_CLOUD_URL = "https://console.vendo.run";

--- a/packages/vendo/src/cloud-secrets.ts
+++ b/packages/vendo/src/cloud-secrets.ts
@@ -1,5 +1,4 @@
-import { defaultFetch, type SecretsProvider } from "@vendoai/core";
-import { consoleSender, raiseCloudError } from "./cloud-console.js";
+import { consoleSender, defaultFetch, raiseCloudError, type SecretsProvider } from "@vendoai/core";
 
 /** The Cloud secrets provider — the implementation the composition seam
  * (selectSecrets in server.ts) chains BEHIND envSecrets when VENDO_API_KEY

--- a/packages/vendo/src/cloud-tools.ts
+++ b/packages/vendo/src/cloud-tools.ts
@@ -1,8 +1,7 @@
 import { composioToolRisk, normalizeToolName, type Connector, type ConnectorAccountIdentity } from "@vendoai/actions";
 import type { RunContext, ToolCall, ToolDescriptor, ToolOutcome } from "@vendoai/core";
-import { deploymentIdentityHeaders } from "./deployment-identity.js";
+import { debugConnectorHttp, deploymentIdentityHeaders, log } from "@vendoai/core";
 import { keepAliveFetch } from "./keep-alive-fetch.js";
-import { debugConnectorHttp, log } from "@vendoai/core";
 
 /** The Cloud tools adapter — the execution half of the zero-key Composio
  * seam (cloudConnections is the account half). Tools list and execute ride

--- a/packages/vendo/src/compose-store.ts
+++ b/packages/vendo/src/compose-store.ts
@@ -8,13 +8,15 @@ import type { FilesAdapter, StoreOps } from "@vendoai/core";
 import {
   createStore,
   createStoreOps,
+  hostedStore,
   maybeDbFor,
   storeFiles,
   threadMessageStore,
+  type HostedStore,
   type VendoStore,
 } from "@vendoai/store";
 import { cloudKeyOptions } from "./compose-selection.js";
-import { hostedStore, type HostedStore } from "./hosted-store.js";
+import { keepAliveFetch } from "./keep-alive-fetch.js";
 import { environment } from "./wire/shared.js";
 
 /** Per-process latch for the hosted-store automations notice below — a dev
@@ -127,7 +129,10 @@ export function selectStore(
   const selected = ((): VendoStore => {
     if (configured !== undefined) return configured;
     const cloud = cloudKeyOptions();
-    if (cloud !== undefined) return hostedStore(cloud);
+    // The kept-alive pool is the umbrella's to supply: it reaches undici, so it
+    // cannot live in @vendoai/store, which @vendoai/agents composes on an edge
+    // target too. A host passing its own `fetch` still wins (adapter rule).
+    if (cloud !== undefined) return hostedStore({ ...cloud, fetch: keepAliveFetch });
     const encryptionKey = environment("VENDO_STORE_ENCRYPTION_KEY");
     return createStore(encryptionKey === undefined
       ? { allowUnencryptedSecrets: environment("NODE_ENV") !== "production" }

--- a/packages/vendo/src/connections.ts
+++ b/packages/vendo/src/connections.ts
@@ -1,7 +1,6 @@
-import { debugConnectorHttp, VendoError, type Principal } from "@vendoai/core";
-import type { Connector, ConnectorAccount, ConnectorConnections } from "@vendoai/actions";
-import { consoleSender, raiseCloudError } from "./cloud-console.js";
+import { consoleSender, debugConnectorHttp, raiseCloudError, VendoError, type Principal } from "@vendoai/core";
 import { keepAliveFetch } from "./keep-alive-fetch.js";
+import type { Connector, ConnectorAccount, ConnectorConnections } from "@vendoai/actions";
 
 /** Subjects the runtime mints for machine principals (automations webhook
  * triggers today; the reserved `vendo:` namespace going forward). A synthetic

--- a/packages/vendo/src/sandbox.ts
+++ b/packages/vendo/src/sandbox.ts
@@ -1,7 +1,5 @@
 import type { SandboxAdapter, SandboxMachine, SandboxResumePolicy } from "@vendoai/apps";
-import { log, VendoError } from "@vendoai/core";
-import { deploymentIdentityHeaders } from "./deployment-identity.js";
-import { raiseCloudError } from "./cloud-console.js";
+import { deploymentIdentityHeaders, log, raiseCloudError, VendoError } from "@vendoai/core";
 import { keepAliveFetch } from "./keep-alive-fetch.js";
 import {
   CLOUD_BOX_PORT,

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -161,7 +161,7 @@ export {
 // The hosted-store adapter rides the server surface like the other Cloud
 // adapters: a host can pass it explicitly via createVendo({ store }) with its
 // own options instead of relying on the VENDO_API_KEY default.
-export { hostedStore, type HostedStore, type HostedStoreOptions } from "./hosted-store.js";
+export { hostedStore, hostedStoreOps, type HostedStore, type HostedStoreOptions } from "@vendoai/store";
 
 // The composition merge, for anyone re-expressing a `ToolRegistry` as the
 // `tools:` entries createVendo takes.
@@ -201,13 +201,6 @@ export { guard, createGuard, type GuardRules, type VendoGuard } from "@vendoai/g
 // IMPORT time, not at compose: `agent()` resolves its own slots at
 // CONSTRUCTION, which is before createVendo ever runs. Pure closure
 // assignment, no I/O — safe at module scope under workerd (portability gate).
-//
-// The store rung stays unfilled for one reason: `threadStore` still opens with
-// `dbFor`, which knows only handles @vendoai/store minted, and every session
-// and away-run routes through it — so filling this rung would move the failure
-// from boot to the developer's first turn. (createVendo is clear of it: its
-// own thread lifecycle rides `records`.) A VENDO_API_KEY-only `agent()`
-// therefore fails loudly, naming `store: postgres(url)`. Tracked in #1259.
 provideCloudAdapters({ sandbox: cloudSandbox });
 
 function isJsonRequest(request: Request): boolean {

--- a/packages/vendo/src/wire/shared.ts
+++ b/packages/vendo/src/wire/shared.ts
@@ -26,7 +26,9 @@ import type { ConnectionsService } from "../connections.js";
     shares. The per-request RunContext resolution lives in wire/context.ts;
     server.ts assembles the table from the per-area modules under src/wire/. */
 
-export const VERSION = "0.18.0";
+/** Re-exported, not redeclared: the one version literal lives in
+    @vendoai/core, beside the deployment-identity headers that stamp it. */
+export { VERSION } from "@vendoai/core";
 export const BASE_PATH = "/api/vendo";
 
 /** Re-exported, not redeclared: the venue tag is what the ONE sandbox ladder

--- a/packages/vendo/tests/app-access-door.test.ts
+++ b/packages/vendo/tests/app-access-door.test.ts
@@ -5,10 +5,9 @@ import {
   type AppId,
   type RunContext,
 } from "@vendoai/core";
-import { appAccess } from "@vendoai/store";
+import { appAccess, hostedStore } from "@vendoai/store";
 import { describe, expect, it } from "vitest";
-import { hostedStore } from "../src/hosted-store.js";
-import { fakeConsole } from "../src/hosted-store.test-util.js";
+import { fakeConsole } from "@vendoai/store/test-util";
 
 /**
  * Build contract §9.2 — the principal grammar belongs to the DOOR.

--- a/packages/vendo/tests/automations-defer.test.ts
+++ b/packages/vendo/tests/automations-defer.test.ts
@@ -10,12 +10,11 @@ import {
   type Principal,
 } from "@vendoai/core";
 import { triggerKey } from "@vendoai/automations";
-import { createStore, type VendoStore } from "@vendoai/store";
+import { createStore, hostedStore, type VendoStore } from "@vendoai/store";
 import type { LanguageModel } from "ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createVendo, type Vendo } from "../src/server.js";
-import { hostedStore } from "../src/hosted-store.js";
-import { fakeConsole } from "../src/hosted-store.test-util.js";
+import { fakeConsole } from "@vendoai/store/test-util";
 
 /**
  * wave 2 (Cloud auto): a keyed deployment runs schedule- and external-triggered

--- a/packages/vendo/tests/channel-hosted-store.test.ts
+++ b/packages/vendo/tests/channel-hosted-store.test.ts
@@ -1,8 +1,8 @@
 import type { ApprovalId } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
 import { ChannelAskRepository, ChannelEventLog, ChannelLinkRepository } from "../src/channel-links.js";
-import { hostedStore } from "../src/hosted-store.js";
-import { fakeConsole } from "../src/hosted-store.test-util.js";
+import { hostedStore } from "@vendoai/store";
+import { fakeConsole } from "@vendoai/store/test-util";
 
 /**
  * The channel's rows against the HOSTED door — the seam that actually ships.

--- a/packages/vendo/tests/hosted-store-notice.test.ts
+++ b/packages/vendo/tests/hosted-store-notice.test.ts
@@ -1,7 +1,7 @@
 import type { LanguageModel } from "ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createVendo } from "../src/server.js";
-import { fakeConsole } from "../src/hosted-store.test-util.js";
+import { fakeConsole } from "@vendoai/store/test-util";
 
 /**
  * Self-serve audit F7: the hosted-store automations notice is a boot fact, but

--- a/packages/vendo/tests/hosted-transcript.live.test.ts
+++ b/packages/vendo/tests/hosted-transcript.live.test.ts
@@ -15,10 +15,9 @@
  * the end, and every id is per-run unique so two runs never collide.
  */
 import { VendoError, type Principal } from "@vendoai/core";
-import { harnessStateStore, threadMessageStore } from "@vendoai/store";
+import { harnessStateStore, hostedStore, threadMessageStore, type HostedStore } from "@vendoai/store";
 import type { UIMessage } from "ai";
 import { afterAll, describe, expect, it } from "vitest";
-import { hostedStore, type HostedStore } from "../src/hosted-store.js";
 
 // A named secret can EXIST and be empty (`infisical secrets get` exits 0 either
 // way), so the gate checks for content rather than for presence.

--- a/packages/vendo/tests/hosted-workspace-cas.live.test.ts
+++ b/packages/vendo/tests/hosted-workspace-cas.live.test.ts
@@ -26,9 +26,8 @@
  * Gated on `VENDO_API_KEY` like every other `.live.test.ts`.
  */
 import type { Membership, Principal } from "@vendoai/core";
-import { workspaceStore } from "@vendoai/store";
+import { hostedStore, workspaceStore, type HostedStore } from "@vendoai/store";
 import { afterAll, describe, expect, it } from "vitest";
-import { hostedStore, type HostedStore } from "../src/hosted-store.js";
 
 const apiKey = process.env["VENDO_API_KEY"] ?? "";
 const live = apiKey === "" ? describe.skip : describe;

--- a/packages/vendo/tests/hosted-workspace.live.test.ts
+++ b/packages/vendo/tests/hosted-workspace.live.test.ts
@@ -16,9 +16,8 @@
  * runs never collide, and everything written is erased at the end.
  */
 import type { Principal } from "@vendoai/core";
-import { workspaceStore } from "@vendoai/store";
+import { hostedStore, workspaceStore, type HostedStore } from "@vendoai/store";
 import { afterAll, describe, expect, it } from "vitest";
-import { hostedStore, type HostedStore } from "../src/hosted-store.js";
 
 // A named secret can EXIST and be empty (`infisical secrets get` exits 0 either
 // way), so the gate checks for content rather than for presence.

--- a/packages/vendo/tests/server-agent-seam.test.ts
+++ b/packages/vendo/tests/server-agent-seam.test.ts
@@ -8,9 +8,10 @@
  */
 import type { SandboxAdapter, SandboxMachine } from "@vendoai/apps";
 import { inMemoryBoxFiles } from "@vendoai/apps/testing";
-import { agent } from "@vendoai/agents";
+import { agent, agentComposition } from "@vendoai/agents";
+import type { Principal } from "@vendoai/core";
 import { defineHarness, harnessAdapters } from "@vendoai/harnesses";
-import { createStore, type VendoStore } from "@vendoai/store";
+import { createStore, threadStore, type VendoStore } from "@vendoai/store";
 import type { LanguageModel, UIMessage } from "ai";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -45,6 +46,9 @@ const noKeys = (): void => {
 };
 
 const boxy = () => defineHarness({ name: "boxy", requires: { sandbox: true }, async *run() {} });
+const inert = () => defineHarness({ name: "inert", async *run() {} });
+
+const seamUser: Principal = { kind: "user", subject: "user_seam" };
 
 const fakeSandbox = (): SandboxAdapter & { created: unknown[] } => {
   const created: unknown[] = [];
@@ -209,13 +213,35 @@ describe("the umbrella fills the agent's unset Cloud slots, and only those", () 
     expect(sandbox.created).toHaveLength(1);
   });
 
-  it("leaves the store's Cloud rung unfilled — it fails loudly instead of composing a store its sessions cannot use", async () => {
+  it("composes the hosted store from a VENDO_API_KEY alone", async () => {
     vi.stubEnv("E2B_API_KEY", "");
     vi.stubEnv("VENDO_API_KEY", "vk_seam");
-    // The tenant-store shape is under redesign (2026-08-04 hold); until it
-    // lands, an unset `store:` with a key must say so, not silently pick the
-    // HTTP hosted store, which serves neither transcript nor workspace.
-    expect(() => agent({ name: "support", harness: defineHarness({ name: "inert", async *run() {} }) }))
-      .toThrow(/Cloud store rung/);
+    vi.stubEnv("VENDO_CLOUD_URL", "https://console.seam.test");
+    const fetchSpy = vi.fn(async () => Response.json({ record: null }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    // No `store:` anywhere, and the proof is a real conversation read going out
+    // over the console wire — not that a slot is non-empty.
+    const support = agent({ name: "support", harness: inert() });
+    const composed = agentComposition(support);
+    expect(await threadStore(composed!.store).get(seamUser, "thr_seam")).toBeNull();
+    const [url, init] = fetchSpy.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe("https://console.seam.test/api/v1/store/transcripts/getThread");
+    expect((init.headers as Record<string, string>)["authorization"]).toBe("Bearer vk_seam");
+  });
+
+  it("lets an explicitly passed store win over the key", async () => {
+    vi.stubEnv("E2B_API_KEY", "");
+    vi.stubEnv("VENDO_API_KEY", "vk_seam");
+    const fetchSpy = vi.fn(async () => Response.json({ record: null }));
+    vi.stubGlobal("fetch", fetchSpy);
+    const store = await tempStore();
+
+    const support = agent({ name: "support", harness: inert(), store });
+    // Written through the composition's store, read back through the host's own
+    // handle: the same rows, and the console never heard about it.
+    await threadStore(agentComposition(support)!.store).put(seamUser, { id: "thr_byo", messages: [] });
+    expect(await threadStore(store).get(seamUser, "thr_byo")).not.toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/vendo/tests/server.test.ts
+++ b/packages/vendo/tests/server.test.ts
@@ -19,7 +19,7 @@ import type { SandboxAdapter } from "@vendoai/apps";
 import type { Connector } from "@vendoai/actions";
 import type { ConnectionsService } from "../src/connections.js";
 import { VERSION as WIRE_VERSION } from "../src/wire/shared.js";
-import { appStore, createStore, secretStore, storeSecrets, type VendoStore } from "@vendoai/store";
+import { appStore, createStore, hostedStore, secretStore, storeSecrets, type VendoStore } from "@vendoai/store";
 import { createHmac, randomBytes } from "node:crypto";
 import { exportJWK, generateKeyPair, SignJWT } from "jose";
 import type { LanguageModel } from "ai";
@@ -27,8 +27,7 @@ import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
 // authJs now ships on its own subpath (@vendoai/vendo/auth/auth-js), not
 // "./server.js" — corpus-triage Task 9.
 import { authJs } from "../src/auth-presets/auth-js.js";
-import { hostedStore } from "../src/hosted-store.js";
-import { fakeConsole } from "../src/hosted-store.test-util.js";
+import { fakeConsole } from "@vendoai/store/test-util";
 import { createVendo, nextVendoHandler, wellKnownVendoHandler, type CreateVendoConfig, type Vendo } from "../src/server.js";
 
 const cleanups: Array<() => Promise<void>> = [];

--- a/scripts/sync-version-constants.mjs
+++ b/scripts/sync-version-constants.mjs
@@ -15,7 +15,7 @@ const version = JSON.parse(
 
 const targets = [
   { file: "packages/vendo/src/cli/shared.ts", pattern: /(export const CLI_VERSION = ")[^"]+(")/ },
-  { file: "packages/vendo/src/wire/shared.ts", pattern: /(export const VERSION = ")[^"]+(")/ },
+  { file: "packages/core/src/version.ts", pattern: /(export const VERSION = ")[^"]+(")/ },
 ];
 
 for (const { file, pattern } of targets) {


### PR DESCRIPTION
Closes #1259.

`agent({ name, tools })` with only a `VENDO_API_KEY` set now boots and persists — threads, transcripts, guard audit — through Vendo Cloud. An explicitly passed `store:` always wins.

## How

`hostedStore` and the console plumbing move **down** the layer stack, so `@vendoai/agents` can reach them without depending on the umbrella:

- `packages/vendo/src/hosted-store.ts` (+ its test-util and test) → `@vendoai/store`
- `packages/vendo/src/{cloud-console,deployment-identity}.ts` → `@vendoai/core`
- new `packages/core/src/version.ts` (`VERSION`), re-exported by `wire/shared.ts`; `scripts/sync-version-constants.mjs` retargeted to the new home and verified to still find every VERSION site
- `storeFiles` binds its Db handle **lazily** — it called `dbFor(store)` eagerly, which threw on a hosted store before `threadStore` was ever reached
- `threadStore` switches from `dbFor` to `backendOf` and gains its ops half
- `CloudAdapters.store` slot and the `defaultStore` not-implemented throw are **deleted**

`pnpm lint` (dependency-guard) is the layering proof. `HostedStoreOptions.owner` semantics are unchanged — owner stays unset.

## ⚠️ Frozen test inversion — stated out loud

`packages/vendo/tests/server-agent-seam.test.ts` — this case was **DELETED**:

> `it("leaves the store's Cloud rung unfilled — it fails loudly instead of composing a store its sessions cannot use")`

It asserted exactly the behavior this PR removes. Replaced by `it("composes the hosted store from a VENDO_API_KEY alone")` and `it("lets an explicitly passed store win over the key")`. The matching pair in `packages/agents/tests/agent.test.ts` was inverted the same way.

## Two forced divergences

1. `packages/store/tsconfig.json` had to stop excluding `src/**/*.test-util.ts` wholesale (it now excludes the two unpublished ones by name) — the new `./test-util` subpath resolves into `dist/`, so the file must be emitted.
2. Two DOM-lib types in the moved files (`RequestInfo`, `BodyInit`) don't exist under store's `lib: ["ES2022"]`; replaced with `Parameters<typeof fetch>[0]` and `ConstructorParameters<typeof Response>[0]`.

## Three honest SQL-vs-wire differences in the new ops half

Documented in-code: ownership is read-then-write (restating `thread-messages.ts`'s existing TOCTOU note rather than inventing a new one); `list` is one service page rather than `updated_at DESC`; an answer carries its `questionId` as the payload `id`, which is what keeps `ans_<questionId>` the row id on both backends and with it the loud refusal of a reused question id.

## Coverage note for reviewers

Moving `hosted-store.ts` shifts its coverage from `@vendoai/vendo` (floor 78) into `@vendoai/store` (floor 84). The merged coverage gate in CI is where that lands.

## Revert-proof

- `defaultStore` restored to the throwing "no Cloud store rung wired" → both key-only cases red (`→ no Cloud store rung wired`); the explicit-store cases stayed green.
- `const store = defaultStore()` (explicit store ignored) → both "explicit store wins" cases red; key-only cases stayed green.
- `helpers/threads.ts` reverted to `dbFor` → all 12 memory-ops/local-ops cases red (`Unknown VendoStore handle`), the 6 sql cases green.

## Gates

`pnpm build` 0 · typecheck (core, store, agents, vendo) 0 · `pnpm lint` 0 · `node scripts/sync-version-constants.mjs` 0 (both sites found) · store `hosted-store` + `threads.ops` 79/79 · store conformance ×4 91/91 · agents 44/44 · vendo seam/server/app-access-door/automations-defer/hosted-store-notice 153/153.

Proof 1 (live key-only boot + console readback) is being run separately against this branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
A VENDO_API_KEY alone now boots `agent()` and persists through the Cloud hosted store. Previously, key-only `agent()` threw; now it defaults to `hostedStore`, and an explicit `store` still wins. Addresses #1259.

- `hostedStore` (+ `hostedStoreOps` and `./test-util`) moves to `@vendoai/store`; `@vendoai/vendo` re-exports and injects its keep‑alive fetch on the key path.
- Console client plumbing (`cloud-console`, `deployment-identity`) moves to `@vendoai/core`; the single `VERSION` literal lives in `@vendoai/core` and `@vendoai/vendo/wire/shared` re-exports it; the sync script targets the new site.
- `threadStore` selects a backend (`ops` or SQL) and gains an ops-backed implementation; `storeFiles` binds its DB lazily to avoid hosted‑store boot failures.
- `@vendoai/agents`: removes `CloudAdapters.store`; `defaultStore()` chooses `createStore()` or `hostedStore(key)`. Tests invert key‑only failure to success and verify “explicit store wins.” Docs updated accordingly.

**Migration**
- Delete any use of `CloudAdapters.store`; keep `provideCloudAdapters({ sandbox })`.
- Import `hostedStore` from `@vendoai/store` (or keep using the `@vendoai/vendo` re-exports).
- If you imported console client pieces from `@vendoai/vendo`, use `@vendoai/core` for `consoleSender` and `deploymentIdentityHeaders`.

<sup>Written for commit a2e967217fd8de127b0d92759b93bd37fcc86366. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

