### PR TITLE
refactor(core,guard,automations,vendo,agents): one grant mint and one permission wire

### DIFF
--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -21,7 +21,7 @@ import {
   type Skill,
   type ToolRegistry,
 } from "@vendoai/core";
-import { createGuard, isGuardInstance, type GuardRules, type VendoGuard } from "@vendoai/guard";
+import { createGuard, isGuardInstance, permissionsHandler, type GuardRules, type VendoGuard } from "@vendoai/guard";
 import { provideHarnessAdapters, vendo } from "@vendoai/harnesses";
 import { vendoModel } from "@vendoai/harnesses/inference";
 import { resolveDevCredential } from "@vendoai/harnesses/inference/credential";
@@ -31,6 +31,7 @@ import { randomUUID } from "node:crypto";
 import { startRun, type AgentRun, type RunOptions } from "./away.js";
 import { resolveDoor, type DoorConfig } from "./door.js";
 import { withEgress, type EgressConfig } from "./egress.js";
+import { PERMISSIONS_PATH, schemaReadyPrincipal, type AgentPrincipal } from "./permissions.js";
 import type { SystemPromptHook } from "./prompt.js";
 import {
   createSession,
@@ -69,6 +70,9 @@ export interface AgentConfig {
    *  tools; unset → `VENDO_BASE_URL`. Required by any harness that declares
    *  `requires.toolDoor` — see {@link resolveDoor}. */
   door?: DoorConfig;
+  /** Who is asking, for {@link VendoAgent.permissions}. Unset → those routes
+   *  401: a person's own asks and grants need a person. */
+  principal?: AgentPrincipal;
   /** The host's prompt block. */
   instructions?: string;
   /**
@@ -111,6 +115,13 @@ export interface VendoAgent {
    * turn's own credential.
    */
   readonly door?: (request: Request) => Promise<Response>;
+  /**
+   * This agent's approvals and grants wire — what `@vendoai/ui`'s consent
+   * surfaces already post to. MOUNT THIS at `PERMISSIONS_PATH`
+   * (`/api/vendo`); `undefined` comes back for every path it does not own,
+   * `DOOR_PATH` included, so ONE catch-all route can serve both.
+   */
+  readonly permissions: (request: Request) => Promise<Response | undefined>;
 }
 
 /**
@@ -377,6 +388,13 @@ export function agent(config: AgentConfig): VendoAgent {
       await requireModel();
       return createSession(deps, subject, options);
     },
+    // No principal resolver is not "everyone": these routes hand a person their
+    // own pending asks and standing grants, so with nobody to identify they 401.
+    permissions: permissionsHandler({
+      guard,
+      principal: schemaReadyPrincipal(config.principal ?? (async () => null), store),
+      mount: PERMISSIONS_PATH,
+    }),
     ...(door === undefined ? {} : { door: door.handler }),
   };
   compositions.set(built, { ...deps, ...(sandbox === undefined ? {} : { sandbox }) });

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -26,6 +26,7 @@ export {
   type RunOptions,
 } from "./away.js";
 export { DOOR_PATH, type DoorConfig } from "./door.js";
+export { PERMISSIONS_PATH, type AgentPrincipal } from "./permissions.js";
 export { assemblePrompt, type PromptInput, type SystemPromptHook } from "./prompt.js";
 export type { AgentSession, ApprovalEvent, RespondOptions, SessionOptions } from "./session.js";
 export {

--- a/packages/agents/src/permissions.ts
+++ b/packages/agents/src/permissions.ts
@@ -1,0 +1,36 @@
+/**
+ * Where this package's permission wire mounts, and who it asks. A library
+ * cannot add a route to the host's server, so — exactly like {@link DOOR_PATH}
+ * — the handler comes back out of `agent()` for the host to mount. The routes
+ * themselves are @vendoai/guard's ONE implementation.
+ */
+import type { Principal, StoreAdapter } from "@vendoai/core";
+
+/** Where the host mounts {@link VendoAgent.permissions}. `DOOR_PATH` lives
+ *  under it, which is why the handler falls THROUGH (undefined) instead of
+ *  answering not-found: one catch-all route can serve both. */
+export const PERMISSIONS_PATH = "/api/vendo";
+
+/** Who is asking, from the host's own session — the same seam the umbrella's
+ *  wire takes. */
+export type AgentPrincipal = (request: Request) => Promise<Principal | null>;
+
+/** This mount is a THIRD entry door into the package, and a consent surface can
+ *  poll it before the agent's first turn — so it ensures the schema exactly as
+ *  `createSession` and the away runner do, or a virgin store answers the first
+ *  `GET /approvals` with `relation "vendo_approvals" does not exist`.
+ *  Hung on the principal resolver because the wire calls it ONLY for the paths
+ *  this mount owns, so a fall-through (the door, someone else's route) still
+ *  pays nothing; latched, because a polled surface must not run a migration
+ *  check per request. */
+export function schemaReadyPrincipal(
+  principal: AgentPrincipal,
+  store: Pick<StoreAdapter, "ensureSchema">,
+): AgentPrincipal {
+  let ready: Promise<void> | undefined;
+  return async (request) => {
+    ready ??= store.ensureSchema();
+    await ready;
+    return principal(request);
+  };
+}

--- a/packages/agents/tests/permissions-scoping.test.ts
+++ b/packages/agents/tests/permissions-scoping.test.ts
@@ -1,0 +1,127 @@
+/**
+ * ADVERSARIAL CHECK on the standalone agent's permission mount. Two questions:
+ * can one person reach another person's rows through it, and can a crafted path
+ * reach a route the mount does not own.
+ */
+import type { Principal } from "@vendoai/core";
+import { defineHarness } from "@vendoai/harnesses";
+import { createStore } from "@vendoai/store";
+import { describe, expect, it } from "vitest";
+import { agent, agentComposition } from "../src/agent.js";
+import { PERMISSIONS_PATH } from "../src/permissions.js";
+import { tool } from "../src/tools.js";
+
+let stores = 0;
+const memoryStore = () => createStore({ dataDir: `memory://agents-permissions-check-${stores++}` });
+const inert = () => defineHarness({ name: "inert", async *run() {} });
+
+const alice: Principal = { kind: "user", subject: "user_alice" };
+const bob: Principal = { kind: "user", subject: "user_bob" };
+
+const sendReport = tool({
+  name: "host_send_report",
+  description: "Send a report",
+  inputSchema: { type: "object", properties: { body: { type: "string" } } },
+  risk: "write",
+  async execute() {
+    return { status: "ok", output: {} };
+  },
+});
+
+/** One agent, two visitors: the `x-subject` header says which. */
+function built() {
+  return agent({
+    name: "reporter",
+    harness: inert(),
+    store: memoryStore(),
+    tools: [sendReport],
+    guard: { policy: { rules: [{ match: { risk: "write" }, action: "ask" }] } },
+    async principal(request) {
+      return request.headers.get("x-subject") === "bob" ? bob : alice;
+    },
+  });
+}
+
+const request = (method: string, path: string, as: "alice" | "bob" = "alice", body?: unknown): Request =>
+  new Request(`https://app.example.com${path}`, {
+    method,
+    headers: { "x-subject": as, ...(body === undefined ? {} : { "content-type": "application/json" }) },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+
+async function park(reporter: ReturnType<typeof agent>): Promise<string> {
+  const composition = agentComposition(reporter)!;
+  await composition.store.ensureSchema();
+  const outcome = await composition.tools.execute(
+    { id: "call_check_1", tool: "host_send_report", args: { body: "the report" } },
+    { principal: alice, venue: "chat", presence: "present", sessionId: "session_1" },
+  );
+  if (outcome.status !== "pending-approval") throw new Error(`expected a park, got ${outcome.status}`);
+  return outcome.approvalId;
+}
+
+describe("CHECK: the agent mount is owner-scoped on all five routes", () => {
+  it("shows Bob nothing of Alice's and lets him decide, revoke or delete none of it", async () => {
+    const reporter = built();
+    const approvalId = await park(reporter);
+
+    const bobsQueue = await reporter.permissions(request("GET", `${PERMISSIONS_PATH}/approvals`, "bob"));
+    expect(await bobsQueue?.json()).toEqual([]);
+
+    const stolen = await reporter.permissions(request("POST", `${PERMISSIONS_PATH}/approvals/decide`, "bob", {
+      ids: [approvalId],
+      decision: { approve: true, remember: { scope: { kind: "tool" }, duration: "standing" } },
+    }));
+    expect(stolen?.status).toBe(404);
+
+    const takenBack = await reporter.permissions(
+      request("DELETE", `${PERMISSIONS_PATH}/approvals/${approvalId}`, "bob"),
+    );
+    expect(takenBack?.status).toBe(404);
+
+    // Alice's ask is untouched, and Bob minted himself nothing.
+    const hers = await reporter.permissions(request("GET", `${PERMISSIONS_PATH}/approvals`, "alice"));
+    expect(await hers?.json()).toMatchObject([{ id: approvalId }]);
+    const hisGrants = await reporter.permissions(request("GET", `${PERMISSIONS_PATH}/grants`, "bob"));
+    expect(await hisGrants?.json()).toEqual([]);
+  });
+
+  it("will not let Bob revoke a grant of Alice's", async () => {
+    const reporter = built();
+    const approvalId = await park(reporter);
+    await reporter.permissions(request("POST", `${PERMISSIONS_PATH}/approvals/decide`, "alice", {
+      ids: [approvalId],
+      decision: { approve: true, remember: { scope: { kind: "tool" }, duration: "standing" } },
+    }));
+    const listed = await reporter.permissions(request("GET", `${PERMISSIONS_PATH}/grants`, "alice"));
+    const [grant] = await listed!.json() as Array<{ id: string }>;
+
+    const stolen = await reporter.permissions(request("DELETE", `${PERMISSIONS_PATH}/grants/${grant!.id}`, "bob"));
+
+    expect(stolen?.status).toBe(404);
+    const after = await reporter.permissions(request("GET", `${PERMISSIONS_PATH}/grants`, "alice"));
+    const [still] = await after!.json() as Array<{ id: string; revokedAt?: string }>;
+    expect(still!.id).toBe(grant!.id);
+    expect(still!.revokedAt).toBeUndefined();
+  });
+});
+
+describe("CHECK: the agent mount owns exactly its own paths", () => {
+  it("does not answer for a path that merely SHARES the mount's first characters", async () => {
+    const reporter = built();
+    await agentComposition(reporter)!.store.ensureSchema();
+
+    // `/api/vendo` is the mount; `/api/vendoapprovals` is a different path
+    // entirely. The host is told this handler answers `undefined` for everything
+    // it does not own, so a catch-all can chain it — that promise is what breaks.
+    expect(await reporter.permissions(request("GET", "/api/vendoapprovals"))).toBeUndefined();
+    expect(await reporter.permissions(request("GET", "/api/vendogrants"))).toBeUndefined();
+  });
+
+  it("still falls through for everything under the door", async () => {
+    const reporter = built();
+
+    expect(await reporter.permissions(request("POST", "/api/vendo/mcp"))).toBeUndefined();
+    expect(await reporter.permissions(request("POST", "/api/vendo/mcp/message"))).toBeUndefined();
+  });
+});

--- a/packages/agents/tests/permissions.test.ts
+++ b/packages/agents/tests/permissions.test.ts
@@ -1,0 +1,122 @@
+/**
+ * The agent's permission mount, over the REAL guard the agent composed — the
+ * same one its turns park approvals into. A host mounts ONE catch-all under
+ * `/api/vendo`, so the two things that matter are that these routes answer from
+ * live guard state and that everything else — the MCP door above all — comes
+ * back undefined for the host's next handler.
+ */
+import type { Principal } from "@vendoai/core";
+import { defineHarness } from "@vendoai/harnesses";
+import { createStore } from "@vendoai/store";
+import { describe, expect, it } from "vitest";
+import { agent, agentComposition } from "../src/agent.js";
+import { DOOR_PATH } from "../src/door.js";
+import { PERMISSIONS_PATH } from "../src/permissions.js";
+import { tool } from "../src/tools.js";
+
+let stores = 0;
+const memoryStore = () => createStore({ dataDir: `memory://agents-permissions-${stores++}` });
+
+const inert = () => defineHarness({ name: "inert", async *run() {} });
+
+const alice: Principal = { kind: "user", subject: "user_alice" };
+
+const sendReport = tool({
+  name: "host_send_report",
+  description: "Send a report",
+  inputSchema: { type: "object", properties: { body: { type: "string" } } },
+  risk: "write",
+  async execute() {
+    return { status: "ok", output: {} };
+  },
+});
+
+function built(principal?: (request: Request) => Promise<Principal | null>) {
+  return agent({
+    name: "reporter",
+    harness: inert(),
+    store: memoryStore(),
+    tools: [sendReport],
+    guard: { policy: { rules: [{ match: { risk: "write" }, action: "ask" }] } },
+    ...(principal === undefined ? {} : { principal }),
+  });
+}
+
+const request = (method: string, path: string, body?: unknown): Request =>
+  new Request(`https://app.example.com${path}`, {
+    method,
+    ...(body === undefined ? {} : { body: JSON.stringify(body), headers: { "content-type": "application/json" } }),
+  });
+
+/** One parked write, through the agent's OWN guard-bound registry. */
+async function park(reporter: ReturnType<typeof agent>): Promise<string> {
+  const composition = agentComposition(reporter)!;
+  // Nothing has touched the store yet — a turn would have; this park is direct.
+  await composition.store.ensureSchema();
+  const outcome = await composition.tools.execute(
+    { id: "call_permissions_1", tool: "host_send_report", args: { body: "the report" } },
+    { principal: alice, venue: "chat", presence: "present", sessionId: "session_1" },
+  );
+  if (outcome.status !== "pending-approval") throw new Error(`expected a park, got ${outcome.status}`);
+  return outcome.approvalId;
+}
+
+describe("the agent's permission mount", () => {
+  it("answers the approvals and grants routes from the agent's own guard", async () => {
+    const reporter = built(async () => alice);
+    const approvalId = await park(reporter);
+
+    const pending = await reporter.permissions(request("GET", `${PERMISSIONS_PATH}/approvals`));
+    expect(pending?.status).toBe(200);
+    expect(await pending?.json()).toMatchObject([{ id: approvalId }]);
+
+    const decided = await reporter.permissions(request("POST", `${PERMISSIONS_PATH}/approvals/decide`, {
+      ids: [approvalId],
+      decision: { approve: true, remember: { scope: { kind: "tool" }, duration: "standing" } },
+    }));
+    expect(decided?.status).toBe(200);
+
+    const grants = await reporter.permissions(request("GET", `${PERMISSIONS_PATH}/grants`));
+    expect(await grants?.json()).toMatchObject([{ tool: "host_send_report", duration: "standing" }]);
+  });
+
+  it("answers a VIRGIN store — a fresh agent polled before its first turn — with an empty queue", async () => {
+    const reporter = built(async () => alice);
+
+    const pending = await reporter.permissions(request("GET", `${PERMISSIONS_PATH}/approvals`));
+
+    expect(pending?.status).toBe(200);
+    expect(await pending?.json()).toEqual([]);
+  });
+
+  it("falls THROUGH on a virgin store too — a route it does not own owes it no schema", async () => {
+    const reporter = built(async () => alice);
+
+    expect(await reporter.permissions(request("POST", DOOR_PATH))).toBeUndefined();
+    expect(await reporter.permissions(request("GET", "/api/vendoapprovals"))).toBeUndefined();
+  });
+
+  it("falls THROUGH for the door and for everything else on the mount", async () => {
+    const reporter = built(async () => alice);
+
+    // The door lives under the same base — one catch-all route serves both, and
+    // only because this hands the path back instead of answering not-found.
+    expect(await reporter.permissions(request("POST", DOOR_PATH))).toBeUndefined();
+    expect(await reporter.permissions(request("GET", "/api/vendo/threads"))).toBeUndefined();
+    expect(await reporter.permissions(request("GET", "/"))).toBeUndefined();
+  });
+
+  it("401s when the host configured no principal resolver — and still falls through for the door", async () => {
+    const reporter = built();
+
+    expect((await reporter.permissions(request("GET", `${PERMISSIONS_PATH}/approvals`)))?.status).toBe(401);
+    expect((await reporter.permissions(request("GET", `${PERMISSIONS_PATH}/grants`)))?.status).toBe(401);
+    expect(await reporter.permissions(request("POST", DOOR_PATH))).toBeUndefined();
+  });
+
+  it("401s when the resolver says this visitor has no identity", async () => {
+    const reporter = built(async () => null);
+
+    expect((await reporter.permissions(request("GET", `${PERMISSIONS_PATH}/approvals`)))?.status).toBe(401);
+  });
+});

--- a/packages/automations/src/grants.ts
+++ b/packages/automations/src/grants.ts
@@ -6,12 +6,14 @@
  * Lifted out of `createAutomationsEngine` unchanged.
  */
 import {
+  buildGrant,
   DEFAULT_TRIGGER_ID,
   descriptorHash,
+  grantRefs,
   permissionGrantSchema,
-  serviceToolSlug,
   USE_SERVICE_TOOL,
   type ApprovalRequest,
+  type MintGrantInput,
   type PermissionGrant,
   type RunContext,
   type ToolDescriptor,
@@ -146,45 +148,27 @@ const createGrantReads = ({ base: { config, engine, now } }: GrantsDeps): GrantR
   return { descriptors, liveAutomationGrants, liveGrant, grantedServiceSlugs, anyLiveAutomationGrant };
 };
 
-/** The write: what a decided approval turns into. */
+/** The write: what a decided approval turns into — the guard's ONE mint when it
+ *  offers one, and the identical row written here when a host's custom guard
+ *  does not. Both arms build it with core's `buildGrant`, so the fallback can
+ *  never drift into meaning something else. */
 const createGrantMint = (
-  { base: { engine, iso } }: GrantsDeps,
+  { base: { config, engine, iso } }: GrantsDeps,
 ): Pick<GrantsAccess, "mintGrant"> => {
   const mintGrant = async (request: ApprovalRequest, triggerId: string | undefined): Promise<string> => {
-    // A connector dispatch is granted at the width of its SLUG, never its tool
-    // name: "allow use_service_tool" would be consent to the broker's whole
-    // catalog. Every other tool keeps the tool-wide grant an automation has
-    // always minted — the slug is the only thing that narrows here.
-    const slug = serviceToolSlug(request.call);
-    const grant: PermissionGrant = {
-      id: id("grt_"),
-      subject: request.ctx.principal.subject,
-      tool: request.call.tool,
-      descriptorHash: descriptorHash(request.descriptor),
-      scope: slug === undefined ? { kind: "tool" } : { kind: "service-tool", slug },
-      duration: "standing",
-      ...(request.ctx.appId === undefined ? {} : { appId: request.ctx.appId }),
+    const input: MintGrantInput = {
+      request,
+      remember: { duration: "standing" },
+      source: "automation",
       // The trigger the person was actually looking at. Without it the grant
       // would be app-wide, and arming one trigger would silently authorize every
       // other trigger of the same app.
       ...(triggerId === undefined ? {} : { triggerId }),
-      source: "automation",
-      grantedAt: iso(),
     };
-    await engine.put(GRANTS, {
-      id: grant.id,
-      data: grant,
-      refs: {
-        subject: grant.subject,
-        tool: grant.tool,
-        ...(grant.appId === undefined ? {} : { app_id: grant.appId }),
-        // The reserved grants table derives this ref from the row's own column,
-        // but a generic StoreAdapter honors what is passed here — and one that
-        // filtered on `app_id` alone would hand back a sibling trigger's grant,
-        // making the ref-trusting adapter WIDER than the JS filter above it.
-        ...(grant.triggerId === undefined ? {} : { trigger_id: grant.triggerId }),
-      },
-    });
+    const minted = await config.guard.mintGrant?.(input);
+    if (minted !== undefined) return minted;
+    const grant = buildGrant(input, id("grt_"), iso());
+    await engine.put(GRANTS, { id: grant.id, data: grant, refs: grantRefs(grant) });
     return grant.id;
   };
 

--- a/packages/automations/tests/engine.test.ts
+++ b/packages/automations/tests/engine.test.ts
@@ -7,8 +7,10 @@ import {
   type AppDocument,
   type ApprovalId,
   type AuditEvent,
+  type GrantId,
   type Guard,
   type Json,
+  type MintGrantInput,
   type RecordStore,
   type RunContext,
   type StoreAdapter,
@@ -91,6 +93,9 @@ class GuardDouble implements Guard {
   /** The optional spend seam (05 §2 amendment), scripted. Left unset by default
    *  so every existing case still exercises the pre-seam fallback path. */
   spendApproval?: (id: ApprovalId) => Promise<"spent" | "already-spent" | "taken-back">;
+  /** The optional mint seam, scripted. Left unset by default so every existing
+   *  case still exercises the local-write fallback a custom guard leaves us. */
+  mintGrant?: (input: MintGrantInput) => Promise<GrantId>;
   /** Ids passed to {@link abandonApprovals}, in order. */
   readonly abandoned: ApprovalId[] = [];
   /** The store this double writes abandonment through, so a test can read the
@@ -361,6 +366,39 @@ describe("automations enable and grant capture", () => {
       consumedAt: NOW.toISOString(),
     });
     expect((await store.records("automations:captures").list()).records).toHaveLength(0);
+  });
+
+  // The case above is the other half: a GuardDouble with no mint seam, whose
+  // grant this engine writes itself from the very same buildGrant.
+  it("mints THROUGH the guard when it offers the seam — one implementation, not two", async () => {
+    const minted: MintGrantInput[] = [];
+    guard.mintGrant = async (input) => {
+      minted.push(input);
+      return "grt_from_guard";
+    };
+    const doc = app("app_guard_mint", {
+      on: { kind: "host-event", event: "go" },
+      run: { kind: "agentic", prompt: "do work" },
+    });
+    await seedApp(store, doc);
+    const engine = createAutomations({
+      apps: appsDouble(), tools: registry([readTool]), guard, store, now: () => NOW,
+    });
+    const { missing } = await engine.enable(doc.id, "main", ctx());
+
+    guard.decide(missing[0]!.id, true);
+    await flush();
+
+    // Everything the grant means is told to the guard; nothing about it is
+    // decided twice.
+    expect(minted).toMatchObject([{
+      request: { id: missing[0]!.id, call: { tool: readTool.name } },
+      remember: { duration: "standing" },
+      source: "automation",
+      triggerId: "main",
+    }]);
+    // …and the engine wrote no second row of its own.
+    expect((await store.records("vendo_grants").list()).records).toHaveLength(0);
   });
 
   it("ignores app-bound chat grants and preserves schedule cursors, webhook secrets, and disable state", async () => {

--- a/packages/core/src/grants.ts
+++ b/packages/core/src/grants.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { descriptorHash } from "./descriptor-hash.js";
 import {
   appIdSchema,
   approvalIdSchema,
@@ -196,6 +197,71 @@ export function approvalRecordRefs(
     subject: request.ctx.principal.subject,
     status,
     call: request.call.id,
+  };
+}
+
+/**
+ * Everything a mint is told. The subject, the tool, the descriptor hash and the
+ * app are read off the approved REQUEST and never off the caller, so a grant is
+ * bound to exactly what the person was shown.
+ */
+export interface MintGrantInput {
+  request: ApprovalRequest;
+  /** An omitted `scope` is derived: a connector dispatch is granted at the width
+   *  of its SLUG — "allow use_service_tool" would be consent to the broker's
+   *  whole catalog — and every other tool tool-wide. */
+  remember: { duration: GrantDuration; scope?: GrantScope };
+  source: PermissionGrant["source"];
+  /** WHICH trigger of the app this is for; omitted ⇒ app-wide. */
+  triggerId?: string;
+  /** `session`/`task` durations only; omitted ⇒ the request's runId ?? sessionId. */
+  contextKey?: string;
+}
+
+/**
+ * The ONE grant row. The guard's decide path and the automations engine's
+ * consent moment both mint through here, so a grant cannot mean two things
+ * depending on which of them wrote it.
+ */
+export function buildGrant(
+  { request, remember, source, triggerId, contextKey }: MintGrantInput,
+  id: GrantId,
+  grantedAt: IsoDateTime,
+): PermissionGrant {
+  const slug = serviceToolSlug(request.call);
+  const sessionKey = contextKey ?? request.ctx.sessionId;
+  return {
+    id,
+    subject: request.ctx.principal.subject,
+    tool: request.call.tool,
+    descriptorHash: descriptorHash(request.descriptor),
+    scope: remember.scope ?? (slug === undefined ? { kind: "tool" } : { kind: "service-tool", slug }),
+    duration: remember.duration,
+    ...(remember.duration === "session"
+      ? { contextKey: sessionKey }
+      : remember.duration === "task"
+        ? { contextKey: request.ctx.trigger?.runId ?? sessionKey }
+        : {}),
+    ...(request.ctx.appId === undefined ? {} : { appId: request.ctx.appId }),
+    ...(triggerId === undefined ? {} : { triggerId }),
+    source,
+    grantedAt,
+  };
+}
+
+/**
+ * The refs projection every `vendo_grants` row carries. The same reason
+ * {@link approvalRecordRefs} exists: reserved store tables derive these from the
+ * row's own columns, but a generic adapter honors exactly what a writer passes
+ * — and one that filtered on `app_id` alone would hand back a SIBLING trigger's
+ * grant, making the ref-trusting adapter wider than the JS filter above it.
+ */
+export function grantRefs(grant: PermissionGrant): Record<string, string> {
+  return {
+    subject: grant.subject,
+    tool: grant.tool,
+    ...(grant.appId === undefined ? {} : { app_id: grant.appId }),
+    ...(grant.triggerId === undefined ? {} : { trigger_id: grant.triggerId }),
   };
 }
 

--- a/packages/core/src/guard.ts
+++ b/packages/core/src/guard.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { AuditEvent } from "./audit.js";
 import { grantIdSchema, type ApprovalId, type GrantId } from "./ids.js";
-import { approvalRequestSchema, type ApprovalRequest } from "./grants.js";
+import { approvalRequestSchema, type ApprovalRequest, type MintGrantInput } from "./grants.js";
 import type { Principal } from "./principal.js";
 import type { RunContext } from "./run-context.js";
 import type { ToolCall, ToolDescriptor } from "./tools.js";
@@ -75,6 +75,13 @@ export interface Guard extends GuardLike {
    *  `taken-back` (the person revoked it — grant nothing). Callers
    *  feature-detect; a guard that omits it is used exactly as before. */
   spendApproval?(id: ApprovalId, principal: Principal): Promise<"spent" | "already-spent" | "taken-back">;
+  /** Mint the grant a decided approval turns into (optional — same
+   *  feature-detected shape as `spendApproval`). The guard's own decide path
+   *  mints through this, and so does the automations engine's consent moment,
+   *  so there is ONE implementation of what a remembered yes becomes rather
+   *  than one per caller. A guard that omits it leaves the caller writing the
+   *  row itself, from the same `buildGrant`. */
+  mintGrant?(input: MintGrantInput): Promise<GrantId>;
   /** genqa defect 1 (double-count) — a preview of `check()`'s verdict for a
    *  caller that is about to make (or ask the AI SDK to make) the REAL,
    *  dispatching call itself moments later for the SAME logical call: a

--- a/packages/core/tests/grants.test.ts
+++ b/packages/core/tests/grants.test.ts
@@ -1,0 +1,164 @@
+/**
+ * The ONE mint (01-core §5). The guard's decide path and the automations
+ * engine's consent moment both build their grant here, so what a remembered yes
+ * BECOMES is decided in one place — the width it covers, the context it is good
+ * for, and the refs a listing finds it by.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  buildGrant,
+  descriptorHash,
+  grantRefs,
+  USE_SERVICE_TOOL,
+  type ApprovalRequest,
+  type ToolDescriptor,
+} from "../src/index.js";
+
+const descriptor: ToolDescriptor = {
+  name: "host_send_email",
+  description: "send an email",
+  inputSchema: { type: "object" },
+  risk: "write",
+};
+
+const request = (overrides: Partial<ApprovalRequest["ctx"]> = {}, tool = descriptor.name): ApprovalRequest => ({
+  id: "apr_1",
+  call: { id: "call_1", tool, args: { slug: "GMAIL_SEND_EMAIL" } },
+  descriptor: { ...descriptor, name: tool },
+  inputPreview: "send an email",
+  ctx: {
+    principal: { kind: "user", subject: "user_alice" },
+    venue: "chat",
+    presence: "present",
+    sessionId: "session_1",
+    ...overrides,
+  },
+  createdAt: "2026-08-14T00:00:00.000Z",
+});
+
+describe("buildGrant", () => {
+  it("reads the subject, tool, descriptor hash and app off the REQUEST, never the caller", () => {
+    const approved = request({ appId: "app_1" });
+    const grant = buildGrant(
+      { request: approved, remember: { duration: "standing" }, source: "automation" },
+      "grt_1",
+      "2026-08-14T00:00:01.000Z",
+    );
+    expect(grant).toMatchObject({
+      id: "grt_1",
+      subject: "user_alice",
+      tool: "host_send_email",
+      descriptorHash: descriptorHash(approved.descriptor),
+      appId: "app_1",
+      source: "automation",
+      grantedAt: "2026-08-14T00:00:01.000Z",
+    });
+    expect(grant.triggerId).toBeUndefined();
+    expect(grant.contextKey).toBeUndefined();
+  });
+
+  it("derives a connector dispatch's width from its SLUG and every other tool's from its name", () => {
+    // "allow use_service_tool" would be consent to the broker's whole catalog.
+    const dispatch = buildGrant(
+      { request: request({}, USE_SERVICE_TOOL), remember: { duration: "standing" }, source: "automation" },
+      "grt_2",
+      "2026-08-14T00:00:00.000Z",
+    );
+    expect(dispatch.scope).toEqual({ kind: "service-tool", slug: "GMAIL_SEND_EMAIL" });
+    const hostTool = buildGrant(
+      { request: request(), remember: { duration: "standing" }, source: "chat" },
+      "grt_3",
+      "2026-08-14T00:00:00.000Z",
+    );
+    expect(hostTool.scope).toEqual({ kind: "tool" });
+  });
+
+  it("an explicit scope wins over the derived one", () => {
+    const grant = buildGrant(
+      {
+        request: request({}, USE_SERVICE_TOOL),
+        remember: { duration: "standing", scope: { kind: "exact", inputHash: "h", inputPreview: "p" } },
+        source: "chat",
+      },
+      "grt_4",
+      "2026-08-14T00:00:00.000Z",
+    );
+    expect(grant.scope).toEqual({ kind: "exact", inputHash: "h", inputPreview: "p" });
+  });
+
+  it("binds a session grant to the conversation and a task grant to the RUN", () => {
+    const trigger = { id: "main", kind: "schedule" as const, runId: "run_9" };
+    const session = buildGrant(
+      { request: request({ trigger }), remember: { duration: "session" }, source: "chat" },
+      "grt_5",
+      "2026-08-14T00:00:00.000Z",
+    );
+    expect(session.contextKey).toBe("session_1");
+    const task = buildGrant(
+      { request: request({ trigger }), remember: { duration: "task" }, source: "chat" },
+      "grt_6",
+      "2026-08-14T00:00:00.000Z",
+    );
+    expect(task.contextKey).toBe("run_9");
+    // No run to speak of and the conversation is the task.
+    const chatTask = buildGrant(
+      { request: request(), remember: { duration: "task" }, source: "chat" },
+      "grt_7",
+      "2026-08-14T00:00:00.000Z",
+    );
+    expect(chatTask.contextKey).toBe("session_1");
+  });
+
+  it("an explicit contextKey overrides the request's session — the parked row's own key", () => {
+    const grant = buildGrant(
+      { request: request(), remember: { duration: "session" }, source: "chat", contextKey: "session_parked" },
+      "grt_8",
+      "2026-08-14T00:00:00.000Z",
+    );
+    expect(grant.contextKey).toBe("session_parked");
+  });
+
+  it("carries the trigger it was armed for, so a sibling trigger never rides its yes", () => {
+    const grant = buildGrant(
+      {
+        request: request({ appId: "app_1" }),
+        remember: { duration: "standing" },
+        source: "automation",
+        triggerId: "nightly",
+      },
+      "grt_9",
+      "2026-08-14T00:00:00.000Z",
+    );
+    expect(grant.triggerId).toBe("nightly");
+  });
+});
+
+describe("grantRefs", () => {
+  it("is the one spelling: subject, tool, and the app/trigger a ref-trusting adapter filters on", () => {
+    const grant = buildGrant(
+      {
+        request: request({ appId: "app_1" }),
+        remember: { duration: "standing" },
+        source: "automation",
+        triggerId: "nightly",
+      },
+      "grt_10",
+      "2026-08-14T00:00:00.000Z",
+    );
+    expect(grantRefs(grant)).toEqual({
+      subject: "user_alice",
+      tool: "host_send_email",
+      app_id: "app_1",
+      trigger_id: "nightly",
+    });
+  });
+
+  it("omits the app and trigger a chat grant does not have", () => {
+    const grant = buildGrant(
+      { request: request(), remember: { duration: "standing" }, source: "chat" },
+      "grt_11",
+      "2026-08-14T00:00:00.000Z",
+    );
+    expect(grantRefs(grant)).toEqual({ subject: "user_alice", tool: "host_send_email" });
+  });
+});

--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -7,17 +7,20 @@ import {
   type AtomicRecordStore,
   auditContext,
   type AuditEvent,
+  buildGrant,
   canonicalJson,
   DEFAULT_TRIGGER_ID,
   descriptorHash,
   emitUsage,
   type GrantId,
+  grantRefs,
   type GrantScope,
   type GuardDecision,
   type IsoDateTime,
   isUnattended,
   type Json,
   log,
+  type MintGrantInput,
   type PermissionGrant,
   presenceOnlyCall,
   type Principal,
@@ -657,6 +660,16 @@ class GuardImplementation implements VendoGuard {
     if (data.status !== "approved" || data.consumedAt !== undefined) return "already-spent";
     if (data.voidedAt !== undefined) return "taken-back";
     return await this.#spendConsumedTransition(id, principal.subject);
+  }
+
+  /** The ONE mint. Every remembered yes — this guard's own decide path below,
+   *  and the automations engine's consent moment through core's `Guard` seam —
+   *  becomes a row here, so the grant and its listing refs cannot be spelled
+   *  two ways by two writers. */
+  async mintGrant(input: MintGrantInput): Promise<GrantId> {
+    const grant = buildGrant(input, makeId("grt_"), now());
+    await this.#engine.put(GRANTS_COLLECTION, { id: grant.id, data: grant, refs: grantRefs(grant) });
+    return grant.id;
   }
 
   /** The TTL backstop over the general approvals
@@ -2105,36 +2118,18 @@ class GuardImplementation implements VendoGuard {
     applied.push(entry);
     if (!decision.approve && provenance === "human") await this.#supersedeApprovedSiblings(decided);
 
-    let grant: PermissionGrant | undefined;
+    let grantId: GrantId | undefined;
     if (decision.approve && decision.remember !== undefined) {
-      const duration = decision.remember.duration;
-      grant = {
-        id: makeId("grt_") as GrantId,
-        subject: principal.subject,
-        tool: data.request.call.tool,
-        descriptorHash: descriptorHash(data.request.descriptor),
-        scope: normalizeRememberedScope(decision.remember.scope, data.request),
-        duration,
-        ...(duration === "session"
-          ? { contextKey: data.sessionId }
-          : duration === "task"
-            ? { contextKey: data.request.ctx.trigger?.runId ?? data.sessionId }
-            : {}),
-        ...(data.request.ctx.appId === undefined ? {} : { appId: data.request.ctx.appId }),
+      grantId = await this.mintGrant({
+        request: data.request,
+        remember: {
+          duration: decision.remember.duration,
+          scope: normalizeRememberedScope(decision.remember.scope, data.request),
+        },
         source: batch ? "batch" : "chat",
-        grantedAt: decidedAt,
-      };
-      const refs: Record<string, string> = {
-        subject: grant.subject,
-        tool: grant.tool,
-      };
-      if (grant.appId !== undefined) refs.app_id = grant.appId;
-      await this.#engine.put(GRANTS_COLLECTION, {
-        id: grant.id,
-        data: grant,
-        refs,
+        contextKey: data.sessionId,
       });
-      entry.grantId = grant.id;
+      entry.grantId = grantId;
     }
 
     const requestCtx = data.request.ctx;
@@ -2151,7 +2146,7 @@ class GuardImplementation implements VendoGuard {
       inputPreview: data.request.inputPreview,
       detail: {
         approved: decision.approve,
-        ...(grant === undefined ? {} : { grantId: grant.id }),
+        ...(grantId === undefined ? {} : { grantId }),
       },
     });
   }

--- a/packages/guard/src/index.ts
+++ b/packages/guard/src/index.ts
@@ -15,6 +15,15 @@ export { resolvePolicyConfig } from "./policy.js";
 // (hosts validating a policy file before handing it to the guard); 0.4.x
 // dropped them from the barrel by accident, so restore them here.
 export { policyFileSchema, policyRuleSchema } from "./types.js";
+// The ONE permission wire: the five approval/grant routes every mount serves,
+// as a request→body function (the umbrella's routes delegate to it) and as a
+// ready fetch handler (what @vendoai/agents mounts).
+export {
+  handlePermissionRequest,
+  permissionsHandler,
+  type PermissionRequest,
+  type PermissionsHandlerDeps,
+} from "./permission-wire.js";
 // Build contract §9.10 — the org-admin policy document's parser, exported for
 // the composition seam that reads `/orgs/<orgId>/policy.json` out of the
 // workspace and unions the rules into the guard's `orgPolicy` resolver.

--- a/packages/guard/src/permission-wire.ts
+++ b/packages/guard/src/permission-wire.ts
@@ -1,0 +1,137 @@
+/**
+ * ONE permission wire. Five routes — the pending asks, the decision, the two
+ * take-backs, the standing grants — served identically by every surface that
+ * mounts them (the umbrella's `/api/vendo`, `@vendoai/agents`'s mount, a host
+ * wiring the guard itself), because `@vendoai/ui`'s consent surfaces post to
+ * ONE shape and a second hand-rolled copy is how they come to disagree.
+ *
+ * `undefined` means "not one of mine": the caller falls through to its own
+ * table rather than answering not-found on someone else's path.
+ */
+import {
+  approvalDecisionSchema,
+  VendoError,
+  type ApprovalDecision,
+  type ApprovalId,
+  type GrantId,
+  type Json,
+  type Principal,
+  type VendoErrorCode,
+} from "@vendoai/core";
+import type { VendoGuard } from "./types.js";
+
+export interface PermissionRequest {
+  method: "GET" | "POST" | "DELETE";
+  /** Mount-relative: `/approvals`, `/approvals/decide`, `/grants/grt_1`, … */
+  path: string;
+  body?: unknown;
+}
+
+export interface PermissionsHandlerDeps {
+  guard: VendoGuard;
+  principal: (request: Request) => Promise<Principal | null>;
+  /** Where these routes are mounted; unset → the umbrella's base path. */
+  mount?: string;
+}
+
+/** The umbrella's base path, and the mount `@vendoai/agents` documents. */
+const DEFAULT_MOUNT = "/api/vendo";
+
+const STATUS_BY_CODE: Partial<Record<VendoErrorCode, number>> = {
+  validation: 400,
+  "not-found": 404,
+  conflict: 409,
+  // A store missing the atomic operations a decision or a take-back needs is a
+  // fact about the DEPLOYMENT, not about this person's permissions — 501, the
+  // same as the umbrella's wire (packages/vendo/src/wire/shared.ts), because
+  // the 403 fallback tells a client to re-prompt a person who cannot help.
+  "not-implemented": 501,
+};
+
+function approvalIds(body: unknown): ApprovalId[] {
+  const ids = (body as { ids?: unknown } | undefined)?.ids;
+  const list = Array.isArray(ids) ? ids : [];
+  if (list.length === 0) throw new VendoError("validation", "ids must contain at least one approval id");
+  for (const id of list) {
+    if (typeof id !== "string" || id.length === 0) {
+      throw new VendoError("validation", "approval id must be a non-empty string");
+    }
+  }
+  return list as ApprovalId[];
+}
+
+function approvalDecision(body: unknown): ApprovalDecision {
+  const parsed = approvalDecisionSchema.safeParse((body as { decision?: unknown } | undefined)?.decision);
+  if (!parsed.success) throw new VendoError("validation", "decision is invalid");
+  return parsed.data as ApprovalDecision;
+}
+
+export async function handlePermissionRequest(
+  guard: VendoGuard,
+  principal: Principal,
+  request: PermissionRequest,
+): Promise<{ body: Json } | undefined> {
+  const [area, id, ...rest] = request.path.split("/").filter(Boolean);
+  if (rest.length > 0) return undefined;
+  if (area === "approvals") {
+    if (request.method === "GET" && id === undefined) {
+      return { body: await guard.approvals.pending(principal) as unknown as Json };
+    }
+    if (request.method === "POST" && id === "decide") {
+      await guard.approvals.decide(approvalIds(request.body), approvalDecision(request.body), principal);
+      return { body: {} };
+    }
+    if (request.method === "DELETE" && id !== undefined) {
+      await guard.approvals.revoke(id as ApprovalId, principal);
+      return { body: {} };
+    }
+  }
+  if (area === "grants") {
+    if (request.method === "GET" && id === undefined) {
+      return { body: await guard.grants.list(principal) as unknown as Json };
+    }
+    if (request.method === "DELETE" && id !== undefined) {
+      await guard.grants.revoke(id as GrantId, principal);
+      return { body: {} };
+    }
+  }
+  return undefined;
+}
+
+/** The same five routes as a fetch handler, for a host that mounts them itself.
+ *  Which AREA a path names is decided before the principal is resolved, so a
+ *  neighbour on the same mount (the MCP door) falls through instead of being
+ *  challenged for a credential it does not owe this handler. */
+export function permissionsHandler(
+  deps: PermissionsHandlerDeps,
+): (request: Request) => Promise<Response | undefined> {
+  // `mount` is free-form, so a host may spell it with a trailing slash. Strip it
+  // once here rather than doubling it into the boundary below, which would make
+  // every ordinary path fall through and leave the consent surface silently dead.
+  const mount = (deps.mount ?? DEFAULT_MOUNT).replace(/\/$/, "");
+  return async (request: Request): Promise<Response | undefined> => {
+    const { pathname } = new URL(request.url);
+    // The mount is a path BOUNDARY, not a string prefix: `/api/vendoapprovals`
+    // is somebody else's route, and this handler promised to fall through.
+    if (!pathname.startsWith(`${mount}/`)) return undefined;
+    const path = pathname.slice(mount.length);
+    const area = path.split("/").filter(Boolean)[0];
+    if (area !== "approvals" && area !== "grants") return undefined;
+    const principal = await deps.principal(request);
+    if (principal === null) return new Response(null, { status: 401 });
+    try {
+      const result = await handlePermissionRequest(deps.guard, principal, {
+        method: request.method as PermissionRequest["method"],
+        path,
+        ...(request.method === "POST" ? { body: await request.json().catch(() => undefined) } : {}),
+      });
+      return result === undefined ? undefined : Response.json(result.body);
+    } catch (error) {
+      if (!(error instanceof VendoError)) throw error;
+      return Response.json(
+        { error: { code: error.code, message: error.message } },
+        { status: STATUS_BY_CODE[error.code] ?? 403 },
+      );
+    }
+  };
+}

--- a/packages/guard/test/decide-mint-parity.test.ts
+++ b/packages/guard/test/decide-mint-parity.test.ts
@@ -1,0 +1,178 @@
+/**
+ * ADVERSARIAL CHECK on the mint that MOVED. The commit lifted the grant write
+ * out of the decide path into `mintGrant`/`buildGrant`; every field the old
+ * inline code produced is pinned here against the DECIDE path (not against
+ * `mintGrant` directly, which is the seam the change added, not the one it
+ * risked). Values below are what `git show origin/main:packages/guard/src/
+ * guard.ts` wrote at #commitDecidedMember.
+ */
+import { USE_SERVICE_TOOL, type ToolDescriptor } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { createGuard } from "../src/index.js";
+import { createMemoryStore, type MemoryStore } from "./fixtures/memory-store.js";
+import { alice, call, context, FixtureTools } from "./fixtures/tools.js";
+
+const askWrites = { rules: [{ match: { risk: "write" as const }, action: "ask" as const }] };
+
+const dispatcher: ToolDescriptor = {
+  name: USE_SERVICE_TOOL,
+  description: "dispatch a connector action",
+  inputSchema: { type: "object", additionalProperties: true },
+  risk: "write",
+};
+
+function guardOf(store: MemoryStore) {
+  return createGuard({ store, policy: askWrites });
+}
+
+async function park(
+  guard: ReturnType<typeof guardOf>,
+  tools: FixtureTools,
+  toolCall: ReturnType<typeof call>,
+  ctx = context(),
+): Promise<string> {
+  const outcome = await guard.bind(tools).execute(toolCall, ctx);
+  if (outcome.status !== "pending-approval") throw new Error(`expected a park, got ${outcome.status}`);
+  return outcome.approvalId;
+}
+
+describe("CHECK: the decide path's grant is field-for-field what the inline mint wrote", () => {
+  it("keeps an explicitly remembered tool-wide scope tool-wide on a CONNECTOR dispatch", async () => {
+    // The extraction added a scope DERIVATION (slug → service-tool) that the old
+    // decide path never had. The decide path always passes an explicit scope, so
+    // the derivation must never fire here: a decide that said "tool" must stay
+    // "tool", and a decide that said "service-tool" must stay that slug.
+    const store = createMemoryStore();
+    const guard = guardOf(store);
+    const tools = new FixtureTools([dispatcher]);
+    const approvalId = await park(
+      guard,
+      tools,
+      call(USE_SERVICE_TOOL, { slug: "GMAIL_SEND_EMAIL", input: {} }, "call_dispatch"),
+    );
+
+    await guard.approvals.decide(
+      approvalId,
+      { approve: true, remember: { scope: { kind: "tool" }, duration: "standing" } },
+      alice,
+    );
+
+    const [grant] = await guard.grants.list(alice);
+    expect(grant!.scope).toEqual({ kind: "tool" });
+    expect(grant!.tool).toBe(USE_SERVICE_TOOL);
+  });
+
+  it("re-derives an exact scope from the approved request, never from the caller", async () => {
+    const store = createMemoryStore();
+    const guard = guardOf(store);
+    const tools = new FixtureTools();
+    const approvalId = await park(guard, tools, call("host_write", { value: 7 }, "call_exact"));
+
+    await guard.approvals.decide(
+      approvalId,
+      {
+        approve: true,
+        remember: { scope: { kind: "exact", inputHash: "attacker", inputPreview: "a harmless read" }, duration: "standing" },
+      },
+      alice,
+    );
+
+    const [grant] = await guard.grants.list(alice);
+    expect(grant!.scope).toMatchObject({ kind: "exact" });
+    expect((grant!.scope as { inputHash: string }).inputHash).not.toBe("attacker");
+    expect((grant!.scope as { inputPreview: string }).inputPreview).not.toBe("a harmless read");
+  });
+
+  it("binds a session grant to the PARKING conversation", async () => {
+    const store = createMemoryStore();
+    const guard = guardOf(store);
+    const sessionAsk = await park(guard, new FixtureTools(), call("host_write", { value: 1 }, "call_session"));
+
+    await guard.approvals.decide(
+      sessionAsk,
+      { approve: true, remember: { scope: { kind: "tool" }, duration: "session" } },
+      alice,
+    );
+
+    expect((await guard.grants.list(alice))[0]!.contextKey).toBe("session_1");
+  });
+
+  it("binds a task grant to the RUN, falling back to the conversation when there is none", async () => {
+    const withRun = guardOf(createMemoryStore());
+    const runCtx = context({
+      sessionId: "session_2",
+      trigger: { id: "main", kind: "schedule", runId: "run_9" },
+    });
+    const taskAsk = await park(withRun, new FixtureTools(), call("host_write", { value: 2 }, "call_task"), runCtx);
+    await withRun.approvals.decide(
+      taskAsk,
+      { approve: true, remember: { scope: { kind: "tool" }, duration: "task" } },
+      alice,
+    );
+    expect((await withRun.grants.list(alice))[0]!.contextKey).toBe("run_9");
+
+    const noRun = guardOf(createMemoryStore());
+    const chatAsk = await park(noRun, new FixtureTools(), call("host_write", { value: 3 }, "call_task_chat"));
+    await noRun.approvals.decide(
+      chatAsk,
+      { approve: true, remember: { scope: { kind: "tool" }, duration: "task" } },
+      alice,
+    );
+    expect((await noRun.grants.list(alice))[0]!.contextKey).toBe("session_1");
+  });
+
+  it("stamps a single decide as chat, carries the appId and NO triggerId, and writes those refs", async () => {
+    const store = createMemoryStore();
+    const guard = guardOf(store);
+    const appCtx = context({ appId: "app_1" });
+    const single = await park(guard, new FixtureTools(), call("host_write", { value: 1 }, "call_single"), appCtx);
+
+    await guard.approvals.decide(
+      single,
+      { approve: true, remember: { scope: { kind: "tool" }, duration: "standing" } },
+      alice,
+    );
+
+    const chat = (await guard.grants.list(alice))[0]!;
+    expect(chat.source).toBe("chat");
+    expect(chat.appId).toBe("app_1");
+    expect(chat.triggerId).toBeUndefined();
+    // The refs a ref-trusting adapter filters on: exactly subject/tool/app_id,
+    // which is what the inline code wrote — a chat grant carries no trigger.
+    const record = await store.records("vendo_grants").get(chat.id);
+    expect(record!.refs).toEqual({ subject: alice.subject, tool: "host_write", app_id: "app_1" });
+  });
+
+  it("stamps a multi-id decide as batch", async () => {
+    const guard = guardOf(createMemoryStore());
+    const tools = new FixtureTools();
+    const appCtx = context({ appId: "app_1" });
+    const a = await park(guard, tools, call("host_write", { value: 2 }, "call_batch_a"), appCtx);
+    const b = await park(guard, tools, call("host_write", { value: 3 }, "call_batch_b"), appCtx);
+
+    await guard.approvals.decide(
+      [a, b],
+      { approve: true, remember: { scope: { kind: "tool" }, duration: "standing" } },
+      alice,
+    );
+
+    const grants = await guard.grants.list(alice);
+    expect(grants).toHaveLength(2);
+    expect(grants.map((grant) => grant.source)).toEqual(["batch", "batch"]);
+  });
+
+  it("stamps the grant with the SUBJECT the approval was parked for", async () => {
+    const store = createMemoryStore();
+    const guard = guardOf(store);
+    const tools = new FixtureTools();
+    const approvalId = await park(guard, tools, call("host_write", { value: 1 }, "call_subject"));
+
+    await guard.approvals.decide(
+      approvalId,
+      { approve: true, remember: { scope: { kind: "tool" }, duration: "standing" } },
+      alice,
+    );
+
+    expect((await guard.grants.list(alice)).at(-1)!.subject).toBe(alice.subject);
+  });
+});

--- a/packages/guard/test/mint-grant.test.ts
+++ b/packages/guard/test/mint-grant.test.ts
@@ -1,0 +1,201 @@
+/**
+ * The guard's ONE mint, driven through the REAL store on both ends: minted
+ * through `mintGrant`, read back through the very grant lookup `check()` asks
+ * its authority question from. Nothing stubbed between them — the mint and the
+ * lookup disagreeing is exactly the failure a shared implementation exists to
+ * make impossible.
+ */
+import {
+  DEFAULT_TRIGGER_ID,
+  type ApprovalRequest,
+  type GrantId,
+  type MintGrantInput,
+  type ToolDescriptor,
+} from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { createGuard } from "../src/index.js";
+import { createMemoryStore, type MemoryStore } from "./fixtures/memory-store.js";
+import { alice, call, context, descriptor, FixtureTools } from "./fixtures/tools.js";
+
+const askWrites = { rules: [{ match: { risk: "write" as const }, action: "ask" as const }] };
+
+function guardOf(store: MemoryStore) {
+  return createGuard({ store, policy: askWrites });
+}
+
+/** Optional on the interface (the `spendApproval` shape — hand-written guards
+ *  predate it); always present on the one this package builds. */
+const mint = (guard: ReturnType<typeof guardOf>, input: MintGrantInput): Promise<GrantId> =>
+  guard.mintGrant!(input);
+
+async function grantRow(store: MemoryStore, id: string) {
+  const record = await store.records("vendo_grants").get(id);
+  if (record === null) throw new Error(`grant ${id} was never written`);
+  return record;
+}
+
+function approval(overrides: Partial<ApprovalRequest["ctx"]> = {}, tool: ToolDescriptor = descriptor("write")): ApprovalRequest {
+  return {
+    id: "apr_mint",
+    call: call(tool.name, { value: 1 }, "call_mint"),
+    descriptor: tool,
+    inputPreview: "value: 1",
+    ctx: { principal: alice, venue: "chat", presence: "present", sessionId: "session_1", ...overrides },
+    createdAt: new Date().toISOString(),
+  };
+}
+
+describe("guard.mintGrant — the one grant write", () => {
+  it("writes the row AND the refs a ref-trusting adapter filters on", async () => {
+    const store = createMemoryStore();
+    const guard = guardOf(store);
+
+    const id = await mint(guard, {
+      request: approval({ appId: "app_1", presence: "away", venue: "automation" }),
+      remember: { duration: "standing" },
+      source: "automation",
+      triggerId: "nightly",
+    });
+
+    const record = await grantRow(store, id);
+    // A reserved grants table derives its own refs from the row's columns; what
+    // this pins is that the mint hands it a row those columns can be read off.
+    expect(record.refs).toMatchObject({ subject: alice.subject, tool: "host_write", app_id: "app_1" });
+    expect(record.data).toMatchObject({
+      scope: { kind: "tool" },
+      duration: "standing",
+      source: "automation",
+      appId: "app_1",
+      triggerId: "nightly",
+    });
+  });
+
+  it("a minted automation grant is the authority an AWAY run of that trigger runs on", async () => {
+    // The seam, not a shape assertion: the mint is only correct if the guard's
+    // own away check honors what it wrote — same app, same trigger, source
+    // "automation" (05 §6).
+    const store = createMemoryStore();
+    const guard = guardOf(store);
+    const write = descriptor("write");
+    const away = context({ presence: "away", venue: "automation", appId: "app_1", trigger: { id: "nightly", kind: "schedule", runId: "run_1" } });
+
+    await mint(guard, {
+      request: approval({ appId: "app_1", presence: "away", venue: "automation" }),
+      remember: { duration: "standing" },
+      source: "automation",
+      triggerId: "nightly",
+    });
+
+    await expect(guard.check(call("host_write", { value: 2 }, "call_away"), write, away))
+      .resolves.toMatchObject({ action: "run", decidedBy: "grant" });
+  });
+
+  it("a SIBLING trigger of the same app never rides that yes", async () => {
+    const store = createMemoryStore();
+    const guard = guardOf(store);
+    const write = descriptor("write");
+
+    await mint(guard, {
+      request: approval({ appId: "app_1", presence: "away", venue: "automation" }),
+      remember: { duration: "standing" },
+      source: "automation",
+      triggerId: "nightly",
+    });
+
+    const sibling = context({
+      presence: "away",
+      venue: "automation",
+      appId: "app_1",
+      trigger: { id: "hourly", kind: "schedule", runId: "run_2" },
+    });
+    await expect(guard.check(call("host_write", { value: 2 }, "call_sibling"), write, sibling))
+      .resolves.toMatchObject({ action: "ask" });
+    // …and an app-wide grant (no trigger) still answers for the default one.
+    await mint(guard, {
+      request: approval({ appId: "app_2", presence: "away", venue: "automation" }),
+      remember: { duration: "standing" },
+      source: "automation",
+    });
+    const legacy = context({
+      presence: "away",
+      venue: "automation",
+      appId: "app_2",
+      trigger: { id: DEFAULT_TRIGGER_ID, kind: "schedule", runId: "run_3" },
+    });
+    await expect(guard.check(call("host_write", { value: 2 }, "call_legacy"), write, legacy))
+      .resolves.toMatchObject({ action: "run", decidedBy: "grant" });
+  });
+});
+
+describe("the decide path mints through it", () => {
+  it("a remembered yes lands one grant with the parked conversation's key and the chat source", async () => {
+    const store = createMemoryStore();
+    const guard = guardOf(store);
+    const bound = guard.bind(new FixtureTools());
+    const parked = await bound.execute(call("host_write", { value: 1 }, "call_remember"), context());
+    if (parked.status !== "pending-approval") throw new Error("expected a parked write");
+
+    await guard.approvals.decide(
+      parked.approvalId,
+      { approve: true, remember: { scope: { kind: "tool" }, duration: "session" } },
+      alice,
+    );
+
+    const [grant, ...extra] = await guard.grants.list(alice);
+    expect(extra).toEqual([]);
+    expect(grant).toMatchObject({
+      subject: alice.subject,
+      tool: "host_write",
+      scope: { kind: "tool" },
+      duration: "session",
+      contextKey: "session_1",
+      source: "chat",
+    });
+    expect((await grantRow(store, grant!.id)).refs).toEqual({ subject: alice.subject, tool: "host_write" });
+  });
+
+  it("an `exact` remember is still re-derived from the approved request, never from the caller", async () => {
+    const store = createMemoryStore();
+    const guard = guardOf(store);
+    const bound = guard.bind(new FixtureTools());
+    const parked = await bound.execute(call("host_write", { value: 7 }, "call_exact"), context());
+    if (parked.status !== "pending-approval") throw new Error("expected a parked write");
+
+    await guard.approvals.decide(
+      parked.approvalId,
+      {
+        approve: true,
+        // A wire caller's lie about what it authorizes.
+        remember: { scope: { kind: "exact", inputHash: "attacker", inputPreview: "something harmless" }, duration: "standing" },
+      },
+      alice,
+    );
+
+    const [grant] = await guard.grants.list(alice);
+    expect(grant?.scope).toMatchObject({ kind: "exact" });
+    expect(grant?.scope).not.toMatchObject({ inputHash: "attacker" });
+    expect((grant?.scope as { inputPreview: string }).inputPreview).toContain("7");
+  });
+
+  it("a SET decision mints every member with the batch source", async () => {
+    const store = createMemoryStore();
+    const guard = guardOf(store);
+    const bound = guard.bind(new FixtureTools());
+    const ids: string[] = [];
+    for (const id of ["call_batch_a", "call_batch_b"]) {
+      const parked = await bound.execute(call("host_write", { value: 1 }, id), context());
+      if (parked.status !== "pending-approval") throw new Error("expected a parked write");
+      ids.push(parked.approvalId);
+    }
+
+    await guard.approvals.decide(
+      ids,
+      { approve: true, remember: { scope: { kind: "tool" }, duration: "standing" } },
+      alice,
+    );
+
+    const grants = await guard.grants.list(alice);
+    expect(grants).toHaveLength(2);
+    expect(grants.every((grant) => grant.source === "batch")).toBe(true);
+  });
+});

--- a/packages/guard/test/mount-boundary.test.ts
+++ b/packages/guard/test/mount-boundary.test.ts
@@ -1,0 +1,110 @@
+/**
+ * ADVERSARIAL RE-CHECK on the mount boundary FIX (`startsWith(`${mount}/`)`).
+ * A boundary fix has two ways to be wrong: it can still let a foreign path in,
+ * and it can shut out a path that used to work. Both halves are here, plus the
+ * shapes the fix's own reasoning turns on — the bare mount, a trailing slash,
+ * a query string, an empty mount, and a mount that already ends in a slash.
+ */
+import { describe, expect, it } from "vitest";
+import { createGuard, permissionsHandler } from "../src/index.js";
+import { createMemoryStore } from "./fixtures/memory-store.js";
+import { alice } from "./fixtures/tools.js";
+
+const askWrites = { rules: [{ match: { risk: "write" as const }, action: "ask" as const }] };
+const guardOf = () => createGuard({ store: createMemoryStore(), policy: askWrites });
+
+const handlerOn = (mount?: string) =>
+  permissionsHandler({
+    guard: guardOf(),
+    principal: async () => alice,
+    ...(mount === undefined ? {} : { mount }),
+  });
+
+const get = (path: string): Request => new Request(`https://app.example.com${path}`, { method: "GET" });
+
+describe("RE-CHECK: the foreign path stays out", () => {
+  it("a sibling that merely shares the mount's characters still falls through", async () => {
+    const handler = handlerOn();
+
+    expect(await handler(get("/api/vendoapprovals"))).toBeUndefined();
+    expect(await handler(get("/api/vendogrants"))).toBeUndefined();
+    expect(await handler(get("/api/vendo-legacy/approvals"))).toBeUndefined();
+  });
+});
+
+describe("RE-CHECK: the bare mount itself", () => {
+  it("answers nothing for the mount with no route on it, however it is spelled", async () => {
+    const handler = handlerOn();
+
+    // Not one of the five, so the host's own table gets its turn — never a 401
+    // for a credential this handler is not owed, and never a 404 on the mount.
+    expect(await handler(get("/api/vendo"))).toBeUndefined();
+    expect(await handler(get("/api/vendo/"))).toBeUndefined();
+    expect(await handler(get("/api/vendo?org=org_x"))).toBeUndefined();
+    expect(await handler(get("/api/vendo/?org=org_x"))).toBeUndefined();
+  });
+});
+
+describe("RE-CHECK: everything that worked before the fix still works", () => {
+  it("the five on the default mount, with a trailing slash and with a query", async () => {
+    const handler = handlerOn();
+
+    expect((await handler(get("/api/vendo/approvals")))?.status).toBe(200);
+    expect((await handler(get("/api/vendo/grants")))?.status).toBe(200);
+    // filter(Boolean) has always eaten a trailing empty segment; the boundary
+    // fix must not have taken that away.
+    expect((await handler(get("/api/vendo/approvals/")))?.status).toBe(200);
+    expect((await handler(get("/api/vendo/grants?limit=1")))?.status).toBe(200);
+  });
+
+  it("a custom mount without a trailing slash", async () => {
+    const handler = handlerOn("/permissions");
+
+    expect((await handler(get("/permissions/grants")))?.status).toBe(200);
+    expect(await handler(get("/permissionsgrants"))).toBeUndefined();
+    expect(await handler(get("/permissions"))).toBeUndefined();
+  });
+
+  it("a mount that already ends in a slash", async () => {
+    // `mount` is a free-form string with no normalization and no documented
+    // shape, so `/permissions/` is a spelling a host will write. It served the
+    // five before the boundary fix; a silently dead permission surface is worse
+    // than the hole the fix closed.
+    const handler = handlerOn("/permissions/");
+
+    expect((await handler(get("/permissions/grants")))?.status).toBe(200);
+    // Normalization strips the host's slash rather than doubling it into the
+    // boundary, and filter(Boolean) eats the empty segment, so the doubled
+    // spelling nothing would ever send still lands on the same route.
+    expect((await handler(get("/permissions//grants")))?.status).toBe(200);
+  });
+
+  it("an empty mount serves at the root", async () => {
+    const handler = handlerOn("");
+
+    expect((await handler(get("/grants")))?.status).toBe(200);
+    expect(await handler(get("/healthz"))).toBeUndefined();
+  });
+
+  it("a root mount is the empty mount, not a doubled slash", async () => {
+    // `/` is the OTHER spelling of the root, and the one a host actually writes.
+    // Normalization takes it down to the empty mount, so the boundary is a bare
+    // `/` that every path clears and the AREA check is what decides — not a
+    // `//` that shuts the whole surface out.
+    const handler = handlerOn("/");
+
+    expect((await handler(get("/approvals")))?.status).toBe(200);
+    expect((await handler(get("/grants")))?.status).toBe(200);
+    expect(await handler(get("/healthz"))).toBeUndefined();
+  });
+});
+
+describe("RE-CHECK: the door beside the five still falls through", () => {
+  it("every path under the MCP door comes back undefined", async () => {
+    const handler = handlerOn();
+
+    expect(await handler(get("/api/vendo/mcp"))).toBeUndefined();
+    expect(await handler(get("/api/vendo/mcp/message"))).toBeUndefined();
+    expect(await handler(get("/api/vendo/threads"))).toBeUndefined();
+  });
+});

--- a/packages/guard/test/permission-wire-scoping.test.ts
+++ b/packages/guard/test/permission-wire-scoping.test.ts
@@ -1,0 +1,119 @@
+/**
+ * ADVERSARIAL CHECK on the shared permission wire. Not written by the author of
+ * the change. Two questions only: can principal A touch principal B's rows on
+ * any of the five routes, and can a crafted path reach a route it should not.
+ */
+import { describe, expect, it } from "vitest";
+import { createGuard, handlePermissionRequest, permissionsHandler } from "../src/index.js";
+import { createMemoryStore, type MemoryStore } from "./fixtures/memory-store.js";
+import { alice, bob, call, context, FixtureTools } from "./fixtures/tools.js";
+
+const askWrites = { rules: [{ match: { risk: "write" as const }, action: "ask" as const }] };
+
+function guardOf(store: MemoryStore = createMemoryStore()) {
+  return createGuard({ store, policy: askWrites });
+}
+
+async function park(guard: ReturnType<typeof guardOf>, id = "call_check"): Promise<string> {
+  const outcome = await guard.bind(new FixtureTools()).execute(call("host_write", { value: 1 }, id), context());
+  if (outcome.status !== "pending-approval") throw new Error("expected a parked write");
+  return outcome.approvalId;
+}
+
+/** Alice parks, approves and remembers — one live grant of hers to attack. */
+async function aliceGrant(guard: ReturnType<typeof guardOf>): Promise<string> {
+  const approvalId = await park(guard, "call_check_grant");
+  await guard.approvals.decide(
+    approvalId,
+    { approve: true, remember: { scope: { kind: "tool" }, duration: "standing" } },
+    alice,
+  );
+  const [grant] = await guard.grants.list(alice);
+  return grant!.id;
+}
+
+describe("CHECK: cross-subject on every one of the five routes", () => {
+  it("POST /approvals/decide cannot decide someone else's ask", async () => {
+    const guard = guardOf();
+    const approvalId = await park(guard);
+
+    await expect(handlePermissionRequest(guard, bob, {
+      method: "POST",
+      path: "/approvals/decide",
+      body: { ids: [approvalId], decision: { approve: true, remember: { scope: { kind: "tool" }, duration: "standing" } } },
+    })).rejects.toMatchObject({ code: "not-found" });
+
+    expect(await guard.approvals.pending(alice)).toHaveLength(1);
+    expect(await guard.grants.list(bob)).toEqual([]);
+  });
+
+  it("DELETE /approvals/:id cannot take back someone else's decision", async () => {
+    const guard = guardOf();
+    const approvalId = await park(guard);
+    await guard.approvals.decide(approvalId, { approve: false }, alice);
+
+    await expect(handlePermissionRequest(guard, bob, {
+      method: "DELETE",
+      path: `/approvals/${approvalId}`,
+    })).rejects.toMatchObject({ code: "not-found" });
+  });
+
+  it("DELETE /grants/:id cannot revoke someone else's grant", async () => {
+    const guard = guardOf();
+    const grantId = await aliceGrant(guard);
+
+    await expect(handlePermissionRequest(guard, bob, {
+      method: "DELETE",
+      path: `/grants/${grantId}`,
+    })).rejects.toMatchObject({ code: "not-found" });
+
+    const [still] = await guard.grants.list(alice);
+    expect(still!.id).toBe(grantId);
+    expect(still!.revokedAt).toBeUndefined();
+  });
+
+  it("GET /grants shows a stranger nothing of hers", async () => {
+    const guard = guardOf();
+    await aliceGrant(guard);
+
+    const listed = await handlePermissionRequest(guard, bob, { method: "GET", path: "/grants" });
+
+    expect(listed?.body).toEqual([]);
+  });
+});
+
+describe("CHECK: a GET must never reach a DELETE", () => {
+  it("GET /grants/:id neither reads nor revokes", async () => {
+    const guard = guardOf();
+    const grantId = await aliceGrant(guard);
+
+    const result = await handlePermissionRequest(guard, alice, { method: "GET", path: `/grants/${grantId}` });
+
+    expect(result).toBeUndefined();
+    const [still] = await guard.grants.list(alice);
+    expect(still!.id).toBe(grantId);
+    expect(still!.revokedAt).toBeUndefined();
+  });
+});
+
+describe("CHECK: the mount prefix is a PATH boundary, not a string prefix", () => {
+  const request = (method: string, path: string): Request =>
+    new Request(`https://app.example.com${path}`, { method });
+
+  it("a sibling path that merely starts with the mount is NOT on the mount", async () => {
+    const guard = guardOf();
+    const handler = permissionsHandler({ guard, principal: async () => alice });
+
+    // `/api/vendo` is the mount. `/api/vendoapprovals` is a DIFFERENT path that
+    // happens to share its first ten characters — it is not one of the five.
+    expect(await handler(request("GET", "/api/vendoapprovals"))).toBeUndefined();
+    expect(await handler(request("GET", "/api/vendogrants"))).toBeUndefined();
+  });
+
+  it("the same hole on a custom mount", async () => {
+    const guard = guardOf();
+    const handler = permissionsHandler({ guard, principal: async () => alice, mount: "/permissions" });
+
+    expect(await handler(request("GET", "/permissionsgrants"))).toBeUndefined();
+  });
+});

--- a/packages/guard/test/permission-wire.test.ts
+++ b/packages/guard/test/permission-wire.test.ts
@@ -1,0 +1,213 @@
+/**
+ * The ONE permission wire, over a REAL guard and a real store on both sides: a
+ * route answers from the same approvals and grants the guard's own check path
+ * parked and minted. `@vendoai/ui` posts these five shapes; a mount that
+ * answers a sixth is the drift this module exists to end.
+ */
+import type { StoreAdapter } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { createGuard, handlePermissionRequest, permissionsHandler } from "../src/index.js";
+import { createMemoryStore } from "./fixtures/memory-store.js";
+import { alice, bob, call, context, FixtureTools } from "./fixtures/tools.js";
+
+const askWrites = { rules: [{ match: { risk: "write" as const }, action: "ask" as const }] };
+
+function guardOf(store: StoreAdapter = createMemoryStore()) {
+  return createGuard({ store, policy: askWrites });
+}
+
+/** A StoreAdapter whose record stores omit the optional atomic-revisions
+ *  capability (02-store §4) — the deployment whose decisions and take-backs
+ *  cannot be made single-use, so the guard fails them closed. */
+function withoutAtomic(base: StoreAdapter): StoreAdapter {
+  return {
+    ...base,
+    records(collection) {
+      const { atomic: _atomic, ...rest } = base.records(collection);
+      return rest;
+    },
+  };
+}
+
+/** Parks one guarded write — the pending ask every route below is about. */
+async function park(guard: ReturnType<typeof guardOf>, id = "call_wire"): Promise<string> {
+  const outcome = await guard.bind(new FixtureTools()).execute(call("host_write", { value: 1 }, id), context());
+  if (outcome.status !== "pending-approval") throw new Error("expected a parked write");
+  return outcome.approvalId;
+}
+
+describe("handlePermissionRequest", () => {
+  it("GET /approvals hands a person their own pending asks", async () => {
+    const guard = guardOf();
+    const approvalId = await park(guard);
+
+    const result = await handlePermissionRequest(guard, alice, { method: "GET", path: "/approvals" });
+
+    expect(result?.body).toMatchObject([{ id: approvalId }]);
+    // Owner-scoped: someone else's queue is not this person's business.
+    const other = await handlePermissionRequest(guard, bob, { method: "GET", path: "/approvals" });
+    expect(other?.body).toEqual([]);
+  });
+
+  it("POST /approvals/decide decides the set and remembers what it was told to", async () => {
+    const guard = guardOf();
+    const approvalId = await park(guard);
+
+    const result = await handlePermissionRequest(guard, alice, {
+      method: "POST",
+      path: "/approvals/decide",
+      body: { ids: [approvalId], decision: { approve: true, remember: { scope: { kind: "tool" }, duration: "standing" } } },
+    });
+
+    expect(result?.body).toEqual({});
+    expect(await guard.approvals.pending(alice)).toEqual([]);
+    expect(await guard.grants.list(alice)).toMatchObject([{ tool: "host_write", duration: "standing" }]);
+  });
+
+  it("refuses a decide with no ids and a decide whose decision is not one", async () => {
+    const guard = guardOf();
+    const decide = (body: unknown): Promise<unknown> =>
+      handlePermissionRequest(guard, alice, { method: "POST", path: "/approvals/decide", body });
+
+    await expect(decide({ decision: { approve: true } })).rejects.toMatchObject({ code: "validation" });
+    await expect(decide({ ids: [], decision: { approve: true } })).rejects.toMatchObject({ code: "validation" });
+    await expect(decide({ ids: [""], decision: { approve: true } })).rejects.toMatchObject({ code: "validation" });
+    await expect(decide({ ids: ["apr_1"] })).rejects.toMatchObject({ code: "validation" });
+    await expect(decide({ ids: ["apr_1"], decision: { approve: "yes" } })).rejects.toMatchObject({ code: "validation" });
+  });
+
+  it("DELETE /approvals/:id takes a decision back", async () => {
+    const guard = guardOf();
+    const approvalId = await park(guard);
+    await guard.approvals.decide(approvalId, { approve: false }, alice);
+
+    const result = await handlePermissionRequest(guard, alice, { method: "DELETE", path: `/approvals/${approvalId}` });
+
+    expect(result?.body).toEqual({});
+    // The no no longer stands, so the same call asks again.
+    await expect(park(guard)).resolves.toBeTypeOf("string");
+  });
+
+  it("GET /grants lists and DELETE /grants/:id revokes", async () => {
+    const guard = guardOf();
+    const approvalId = await park(guard);
+    await guard.approvals.decide(
+      approvalId,
+      { approve: true, remember: { scope: { kind: "tool" }, duration: "standing" } },
+      alice,
+    );
+    const listed = await handlePermissionRequest(guard, alice, { method: "GET", path: "/grants" });
+    const [grant] = listed?.body as Array<{ id: string }>;
+
+    const revoked = await handlePermissionRequest(guard, alice, { method: "DELETE", path: `/grants/${grant!.id}` });
+
+    expect(revoked?.body).toEqual({});
+    // Marked, not deleted — the trail keeps both answers, in order.
+    expect(await guard.grants.list(alice)).toMatchObject([{ id: grant!.id, revokedAt: expect.any(String) }]);
+  });
+
+  it("falls THROUGH on anything outside the five — the caller's table still gets its turn", async () => {
+    const guard = guardOf();
+    const miss = (method: "GET" | "POST" | "DELETE", path: string): Promise<unknown> =>
+      handlePermissionRequest(guard, alice, { method, path });
+
+    await expect(miss("GET", "/mcp")).resolves.toBeUndefined();
+    await expect(miss("GET", "/approvals/apr_1")).resolves.toBeUndefined();
+    await expect(miss("DELETE", "/approvals")).resolves.toBeUndefined();
+    await expect(miss("POST", "/approvals")).resolves.toBeUndefined();
+    await expect(miss("POST", "/grants")).resolves.toBeUndefined();
+    await expect(miss("DELETE", "/grants")).resolves.toBeUndefined();
+    await expect(miss("GET", "/approvals/apr_1/history")).resolves.toBeUndefined();
+  });
+});
+
+describe("permissionsHandler", () => {
+  const request = (method: string, path: string, body?: unknown): Request =>
+    new Request(`https://app.example.com${path}`, {
+      method,
+      ...(body === undefined ? {} : { body: JSON.stringify(body), headers: { "content-type": "application/json" } }),
+    });
+
+  it("serves the five under its mount and falls through for the door beside them", async () => {
+    const guard = guardOf();
+    const approvalId = await park(guard);
+    const handler = permissionsHandler({ guard, principal: async () => alice });
+
+    const listed = await handler(request("GET", "/api/vendo/approvals"));
+    expect(await listed?.json()).toMatchObject([{ id: approvalId }]);
+    // The MCP door lives under the SAME mount: one catch-all route serves both,
+    // which only works if this hands the path back instead of 404ing it.
+    expect(await handler(request("POST", "/api/vendo/mcp"))).toBeUndefined();
+    expect(await handler(request("GET", "/healthz"))).toBeUndefined();
+  });
+
+  it("401s when nobody could be identified — never an empty list that reads as 'you have none'", async () => {
+    const handler = permissionsHandler({ guard: guardOf(), principal: async () => null });
+
+    const response = await handler(request("GET", "/api/vendo/approvals"));
+
+    expect(response?.status).toBe(401);
+  });
+
+  it("answers a decide, and turns a bad one into a 400 rather than a crash", async () => {
+    const guard = guardOf();
+    const approvalId = await park(guard);
+    const handler = permissionsHandler({ guard, principal: async () => alice });
+
+    const decided = await handler(request("POST", "/api/vendo/approvals/decide", {
+      ids: [approvalId],
+      decision: { approve: true },
+    }));
+    expect(decided?.status).toBe(200);
+    expect(await guard.approvals.pending(alice)).toEqual([]);
+
+    const bad = await handler(request("POST", "/api/vendo/approvals/decide", { ids: [] }));
+    expect(bad?.status).toBe(400);
+    expect(await bad?.json()).toMatchObject({ error: { code: "validation" } });
+  });
+
+  it("maps the guard's own refusals onto their statuses", async () => {
+    const guard = guardOf();
+    const handler = permissionsHandler({ guard, principal: async () => alice });
+
+    const missing = await handler(request("DELETE", "/api/vendo/grants/grt_nope"));
+    expect(missing?.status).toBe(404);
+
+    const approvalId = await park(guard);
+    // Pending, so a take-back conflicts — deny it instead.
+    const pending = await handler(request("DELETE", `/api/vendo/approvals/${approvalId}`));
+    expect(pending?.status).toBe(409);
+  });
+
+  it("501s where the store cannot do it at all — never 403, which reads as 'you may not'", async () => {
+    // A decision and a take-back both need the store's atomic revisions to be
+    // single-use; an adapter that omits them fails them closed with
+    // `not-implemented`. That is a fact about the DEPLOYMENT, and a client that
+    // reads it as an authorization denial re-prompts a person who cannot help.
+    const base = createMemoryStore();
+    const full = guardOf(base);
+    const pendingId = await park(full, "call_wire_501_pending");
+    const decidedId = await park(full, "call_wire_501_decided");
+    await full.approvals.decide(decidedId, { approve: false }, alice);
+    const handler = permissionsHandler({ guard: guardOf(withoutAtomic(base)), principal: async () => alice });
+
+    const decided = await handler(request("POST", "/api/vendo/approvals/decide", {
+      ids: [pendingId],
+      decision: { approve: true },
+    }));
+    expect(decided?.status).toBe(501);
+    expect(await decided?.json()).toMatchObject({ error: { code: "not-implemented" } });
+
+    const revoked = await handler(request("DELETE", `/api/vendo/approvals/${decidedId}`));
+    expect(revoked?.status).toBe(501);
+    expect(await revoked?.json()).toMatchObject({ error: { code: "not-implemented" } });
+  });
+
+  it("honors a custom mount", async () => {
+    const guard = guardOf();
+    const handler = permissionsHandler({ guard, principal: async () => alice, mount: "/permissions" });
+
+    expect((await handler(request("GET", "/permissions/grants")))?.status).toBe(200);
+    expect(await handler(request("GET", "/api/vendo/grants"))).toBeUndefined();
+  });
+});

--- a/packages/vendo/src/wire/approvals.ts
+++ b/packages/vendo/src/wire/approvals.ts
@@ -1,5 +1,21 @@
-import { VendoError, approvalDecisionSchema, type ApprovalDecision } from "@vendoai/core";
+import { VendoError, type Principal } from "@vendoai/core";
+import { handlePermissionRequest, type PermissionRequest, type VendoGuard } from "@vendoai/guard";
 import { json, orgsCloudRequired, requestJson, route, string, type RouteEntry } from "./shared.js";
+
+/** The five routes themselves are @vendoai/guard's ONE permission wire. What
+    stays here is only what the UMBRELLA adds around them: the `?org=` clamp on
+    every one of them, and the BYO `GET /approvals/:id` below. */
+async function serve(
+  guard: VendoGuard,
+  principal: Principal,
+  method: PermissionRequest["method"],
+  path: string,
+  body?: unknown,
+): Promise<Response> {
+  const result = await handlePermissionRequest(guard, principal, { method, path, body });
+  if (result === undefined) throw new VendoError("not-found", `${method} ${path} is not a permission route`);
+  return json(result.body);
+}
 
 /** 05-guard / 09 §3 — the approvals wire area. Org-scoped approvals
     (`?org=<id>` / body `org`) were a Vendo Cloud capability (block-actions
@@ -10,15 +26,14 @@ export const approvalRoutes: RouteEntry[] = [
   route("GET", "/approvals", async ({ url, deps, context }) => {
     const ctx = await context("chat");
     if (url.searchParams.get("org") !== null) orgsCloudRequired();
-    return json(await deps.guard.approvals.pending(ctx.principal));
+    return serve(deps.guard, ctx.principal, "GET", "/approvals");
   }),
   // Existing-agents Lane B — the read `<VendoApprovalEmbed>` polls for a
   // parked BYO guarded call: the frozen VendoApprovalEmbedState vocabulary,
   // carrying the full request while pending (the consent card shows real
   // inputs) and the resumed call's outcome once executed. Owner-scoped;
-  // unknown and foreign ids both answer not-found. Registered before the
-  // decide route only textually — decide's exact-path POST never collides
-  // with this GET segment pattern.
+  // unknown and foreign ids both answer not-found. The umbrella's OWN route —
+  // the shared wire has no per-approval read.
   route("GET", "/approvals/:id", async ({ url, deps, context, params }) => {
     const ctx = await context("chat");
     if (url.searchParams.get("org") !== null) orgsCloudRequired();
@@ -31,19 +46,13 @@ export const approvalRoutes: RouteEntry[] = [
   route("DELETE", "/approvals/:id", async ({ url, deps, context, params }) => {
     const ctx = await context("chat");
     if (url.searchParams.get("org") !== null) orgsCloudRequired();
-    await deps.guard.approvals.revoke(string(params["id"], "approval id"), ctx.principal);
-    return json({});
+    return serve(deps.guard, ctx.principal, "DELETE", `/approvals/${string(params["id"], "approval id")}`);
   }),
   route("POST", "/approvals/decide", async ({ request, deps, context }) => {
     const body = await requestJson(request);
-    const ids = Array.isArray(body["ids"]) ? body["ids"].map((id) => string(id, "approval id")) : [];
-    if (ids.length === 0) throw new VendoError("validation", "ids must contain at least one approval id");
-    const decision = approvalDecisionSchema.safeParse(body["decision"]);
-    if (!decision.success) throw new VendoError("validation", "decision is invalid");
     const ctx = await context("chat");
     if (body["org"] !== undefined) orgsCloudRequired();
-    await deps.guard.approvals.decide(ids, decision.data as ApprovalDecision, ctx.principal);
-    return json({});
+    return serve(deps.guard, ctx.principal, "POST", "/approvals/decide", body);
   }),
 ];
 
@@ -53,12 +62,11 @@ export const grantRoutes: RouteEntry[] = [
   route("GET", "/grants", async ({ url, deps, context }) => {
     const ctx = await context("chat");
     if (url.searchParams.get("org") !== null) orgsCloudRequired();
-    return json(await deps.guard.grants.list(ctx.principal));
+    return serve(deps.guard, ctx.principal, "GET", "/grants");
   }),
   route("DELETE", "/grants/:id", async ({ url, deps, context, params }) => {
     const ctx = await context("chat");
     if (url.searchParams.get("org") !== null) orgsCloudRequired();
-    await deps.guard.grants.revoke(string(params["id"], "grant id"), ctx.principal);
-    return json({});
+    return serve(deps.guard, ctx.principal, "DELETE", `/grants/${string(params["id"], "grant id")}`);
   }),
 ];

--- a/packages/vendo/tests/automations-grant-seam.seam.test.ts
+++ b/packages/vendo/tests/automations-grant-seam.seam.test.ts
@@ -1,0 +1,120 @@
+/**
+ * ADVERSARIAL CHECK on the seam the change created: automations no longer
+ * WRITES the standing grant a consent moment mints — it hands the input to
+ * `guard.mintGrant` and the guard writes it. Producer and consumer are now two
+ * different blocks, so this drives the REAL guard and the REAL automations
+ * engine over ONE real store, and reads the grant back through the read path
+ * that actually gates a firing (`enable` reporting nothing missing). The
+ * package-level test for this uses a GuardDouble whose `mintGrant` writes
+ * nothing at all, so it cannot see a producer and consumer disagreeing.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  VENDO_APP_FORMAT,
+  type AppDocument,
+  type Principal,
+  type RunContext,
+  type ToolDescriptor,
+  type ToolRegistry,
+} from "@vendoai/core";
+import { createStore, type VendoStore } from "@vendoai/store";
+import type { LanguageModel } from "ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createVendo, type Vendo } from "../src/server.js";
+
+const principal: Principal = { kind: "user", subject: "user_seam" };
+const ctx: RunContext = { principal, venue: "chat", presence: "present", sessionId: "session_seam" };
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+const readAccounts: ToolDescriptor = {
+  name: "host_read_accounts",
+  description: "Read the accounts",
+  inputSchema: { type: "object" },
+  risk: "read",
+};
+
+const host: ToolRegistry = {
+  async descriptors() {
+    return [readAccounts];
+  },
+  async execute() {
+    return { status: "ok", output: {} };
+  },
+};
+
+const doc: AppDocument = {
+  format: VENDO_APP_FORMAT,
+  id: "app_seam",
+  name: "Nightly sweep",
+  triggers: [{
+    id: "main",
+    on: { kind: "host-event", event: "go" },
+    run: { kind: "steps", steps: [{ id: "read", tool: readAccounts.name }] },
+  }],
+};
+
+async function setup(): Promise<Vendo> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-grant-seam-"));
+  const store: VendoStore = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  const vendo = createVendo({
+    model: {} as LanguageModel,
+    principal: async () => principal,
+    store,
+    guard: { policy: { rules: [{ match: { risk: "read" }, action: "ask" }] } },
+  });
+  vendo.actions.add(host);
+  await store.ensureSchema();
+  await store.records("vendo_apps").put({
+    id: doc.id,
+    data: { subject: principal.subject, enabled: false, doc },
+    refs: { subject: principal.subject },
+  });
+  return vendo;
+}
+
+describe.sequential("CHECK: the grant automations asks the GUARD to mint is the grant automations reads back", () => {
+  it("arms the trigger — enable, decide through the real guard, enable again with nothing missing", async () => {
+    const vendo = await setup();
+
+    const first = await vendo.automations.enable(doc.id, "main", ctx);
+    expect(first.missing.length).toBeGreaterThan(0);
+
+    await vendo.guard.approvals.decide(first.missing.map((ask) => ask.id), { approve: true }, principal);
+
+    // The consumer side: the same live-grant read every firing asks its three
+    // authority questions from. A row the guard wrote somewhere automations
+    // cannot see would leave this asking for consent forever.
+    const again = await vendo.automations.enable(doc.id, "main", ctx);
+    expect(again.missing).toEqual([]);
+    expect(again.enabled).toBe(true);
+  });
+
+  it("writes ONE grant row, scoped to the subject, the app and the trigger the person armed", async () => {
+    const vendo = await setup();
+    const first = await vendo.automations.enable(doc.id, "main", ctx);
+    await vendo.guard.approvals.decide(first.missing.map((ask) => ask.id), { approve: true }, principal);
+
+    const grants = await vendo.guard.grants.list(principal);
+
+    expect(grants).toHaveLength(1);
+    expect(grants[0]).toMatchObject({
+      subject: principal.subject,
+      tool: readAccounts.name,
+      appId: doc.id,
+      triggerId: "main",
+      source: "automation",
+      duration: "standing",
+      scope: { kind: "tool" },
+    });
+  });
+});

--- a/packages/vendo/tests/wire-approvals-scoping.test.ts
+++ b/packages/vendo/tests/wire-approvals-scoping.test.ts
@@ -1,0 +1,118 @@
+/**
+ * ADVERSARIAL CHECK on the umbrella's delegated approvals/grants area: two real
+ * people over one real composition. The delegation moved the subject scoping out
+ * of this file, so the thing worth proving here is that it did not go missing on
+ * the way — on every one of the five, and on the umbrella's own BYO read.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Principal, RunContext, ToolDescriptor, ToolRegistry } from "@vendoai/core";
+import { createStore, type VendoStore } from "@vendoai/store";
+import type { LanguageModel } from "ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createVendo, type Vendo } from "../src/server.js";
+
+const alice: Principal = { kind: "user", subject: "user_alice_check" };
+const bob: Principal = { kind: "user", subject: "user_bob_check" };
+const ctx: RunContext = { principal: alice, venue: "chat", presence: "present", sessionId: "session_check" };
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+const descriptor: ToolDescriptor = {
+  name: "host_send_report",
+  description: "Send a report",
+  inputSchema: { type: "object", properties: { body: { type: "string" } } },
+  risk: "write",
+};
+
+const host: ToolRegistry = {
+  async descriptors() {
+    return [descriptor];
+  },
+  async execute(toolCall) {
+    return { status: "ok", output: { sent: toolCall.args } };
+  },
+};
+
+/** One deployment, two visitors: the `x-subject` header says which. */
+async function setup(): Promise<Vendo> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-approvals-check-"));
+  const store: VendoStore = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  const vendo = createVendo({
+    model: {} as LanguageModel,
+    async principal(request) {
+      return request.headers.get("x-subject") === "bob" ? bob : alice;
+    },
+    store,
+    guard: { policy: { rules: [{ match: { risk: "write" }, action: "ask" }] } },
+  });
+  vendo.actions.add(host);
+  await store.ensureSchema();
+  return vendo;
+}
+
+const request = (method: string, path: string, as: "alice" | "bob" = "alice", body?: unknown): Request =>
+  new Request(`https://host.test/api/vendo${path}`, {
+    method,
+    headers: {
+      "x-subject": as,
+      ...(["POST", "PUT", "PATCH", "DELETE"].includes(method) ? { "content-type": "application/json" } : {}),
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+
+async function park(vendo: Vendo, callId: string): Promise<string> {
+  const outcome = await vendo.guardedTools.execute(
+    { id: callId, tool: descriptor.name, args: { body: "the report" } },
+    ctx,
+  );
+  if (outcome.status !== "pending-approval") throw new Error(`expected a park, got ${outcome.status}`);
+  return outcome.approvalId;
+}
+
+describe.sequential("CHECK: the umbrella's five routes are still owner-scoped after delegating", () => {
+  it("hands Bob none of Alice's asks, and lets him decide or take back none of them", async () => {
+    const vendo = await setup();
+    const approvalId = await park(vendo, "call_check_1");
+
+    expect(await (await vendo.handler(request("GET", "/approvals", "bob"))).json()).toEqual([]);
+
+    const stolen = await vendo.handler(request("POST", "/approvals/decide", "bob", {
+      ids: [approvalId],
+      decision: { approve: true, remember: { scope: { kind: "tool" }, duration: "standing" } },
+    }));
+    expect(stolen.status).toBe(404);
+
+    expect((await vendo.handler(request("DELETE", `/approvals/${approvalId}`, "bob"))).status).toBe(404);
+    // The umbrella's OWN per-approval read, which the shared wire has not got.
+    expect((await vendo.handler(request("GET", `/approvals/${approvalId}`, "bob"))).status).toBe(404);
+
+    expect(await vendo.guard.approvals.pending(alice)).toHaveLength(1);
+    expect(await vendo.guard.grants.list(bob)).toEqual([]);
+  });
+
+  it("hands Bob none of Alice's grants, and lets him revoke none of them", async () => {
+    const vendo = await setup();
+    const approvalId = await park(vendo, "call_check_2");
+    await vendo.handler(request("POST", "/approvals/decide", "alice", {
+      ids: [approvalId],
+      decision: { approve: true, remember: { scope: { kind: "tool" }, duration: "standing" } },
+    }));
+    const [grant] = await vendo.guard.grants.list(alice);
+
+    expect(await (await vendo.handler(request("GET", "/grants", "bob"))).json()).toEqual([]);
+    expect((await vendo.handler(request("DELETE", `/grants/${grant!.id}`, "bob"))).status).toBe(404);
+
+    const [still] = await vendo.guard.grants.list(alice);
+    expect(still!.id).toBe(grant!.id);
+    expect(still!.revokedAt).toBeUndefined();
+  });
+});

--- a/packages/vendo/tests/wire-approvals.test.ts
+++ b/packages/vendo/tests/wire-approvals.test.ts
@@ -1,0 +1,151 @@
+/**
+ * The umbrella's approvals/grants area after it became a DELEGATE to
+ * @vendoai/guard's one permission wire. Driven whole — the real composition,
+ * the real guard, a real park through `vendo.guardedTools` — because what is at
+ * risk in a delegation is precisely that the umbrella's OWN extras get lost:
+ * the `?org=` cloud clamp on all five routes, and the BYO `GET /approvals/:id`
+ * the shared wire does not have.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Principal, RunContext, ToolDescriptor, ToolRegistry } from "@vendoai/core";
+import { createStore, type VendoStore } from "@vendoai/store";
+import type { LanguageModel } from "ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createVendo, type Vendo } from "../src/server.js";
+
+const principal: Principal = { kind: "user", subject: "user_approvals_wire" };
+const ctx: RunContext = { principal, venue: "chat", presence: "present", sessionId: "session_approvals_wire" };
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+async function tempStore(): Promise<VendoStore> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-approvals-wire-"));
+  const store = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  return store;
+}
+
+const descriptor: ToolDescriptor = {
+  name: "host_send_report",
+  description: "Send a report",
+  inputSchema: { type: "object", properties: { body: { type: "string" } } },
+  risk: "write",
+};
+
+const host: ToolRegistry = {
+  async descriptors() {
+    return [descriptor];
+  },
+  async execute(toolCall) {
+    return { status: "ok", output: { sent: toolCall.args } };
+  },
+};
+
+async function setup(): Promise<Vendo> {
+  const store = await tempStore();
+  const vendo = createVendo({
+    model: {} as LanguageModel,
+    principal: async () => principal,
+    store,
+    guard: { policy: { rules: [{ match: { risk: "write" }, action: "ask" }] } },
+  });
+  vendo.actions.add(host);
+  await store.ensureSchema();
+  return vendo;
+}
+
+/** The wire's CSRF gate wants `application/json` on every mutation, body or no. */
+const request = (method: string, path: string, body?: unknown): Request =>
+  new Request(`https://host.test/api/vendo${path}`, {
+    method,
+    ...(["POST", "PUT", "PATCH", "DELETE"].includes(method)
+      ? { headers: { "content-type": "application/json" } }
+      : {}),
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+
+async function park(vendo: Vendo, callId: string): Promise<string> {
+  const outcome = await vendo.guardedTools.execute(
+    { id: callId, tool: descriptor.name, args: { body: "the report" } },
+    ctx,
+  );
+  if (outcome.status !== "pending-approval") throw new Error(`expected a park, got ${outcome.status}`);
+  return outcome.approvalId;
+}
+
+describe.sequential("the umbrella's approvals and grants wire", () => {
+  it("serves the five shared routes off the real guard, park to grant to revoke", async () => {
+    const vendo = await setup();
+    const approvalId = await park(vendo, "call_five_1");
+
+    const pending = await vendo.handler(request("GET", "/approvals"));
+    expect(pending.status).toBe(200);
+    expect(await pending.json()).toMatchObject([{ id: approvalId }]);
+
+    const decided = await vendo.handler(request("POST", "/approvals/decide", {
+      ids: [approvalId],
+      decision: { approve: true, remember: { scope: { kind: "tool" }, duration: "standing" } },
+    }));
+    expect(decided.status).toBe(200);
+
+    const listed = await vendo.handler(request("GET", "/grants"));
+    expect(listed.status).toBe(200);
+    const grants = await listed.json() as Array<{ id: string; tool: string }>;
+    expect(grants).toMatchObject([{ tool: descriptor.name }]);
+
+    const revoked = await vendo.handler(request("DELETE", `/grants/${grants[0]!.id}`));
+    expect(revoked.status).toBe(200);
+    expect(await vendo.guard.grants.list(principal)).toMatchObject([{ revokedAt: expect.any(String) }]);
+
+    // "I take that back" on the decision itself — the other durable answer.
+    const denied = await park(vendo, "call_five_2");
+    await vendo.handler(request("POST", "/approvals/decide", { ids: [denied], decision: { approve: false } }));
+    const takenBack = await vendo.handler(request("DELETE", `/approvals/${denied}`));
+    expect(takenBack.status).toBe(200);
+  });
+
+  it("still refuses an org-scoped request on EVERY one of the five", async () => {
+    const vendo = await setup();
+    const approvalId = await park(vendo, "call_org_1");
+
+    const responses = await Promise.all([
+      vendo.handler(request("GET", "/approvals?org=org_x")),
+      vendo.handler(request("DELETE", `/approvals/${approvalId}?org=org_x`)),
+      vendo.handler(request("POST", "/approvals/decide", { ids: [approvalId], decision: { approve: true }, org: "org_x" })),
+      vendo.handler(request("GET", "/grants?org=org_x")),
+      vendo.handler(request("DELETE", "/grants/grt_x?org=org_x")),
+    ]);
+
+    expect(responses.map((response) => response.status)).toEqual([402, 402, 402, 402, 402]);
+    // Refused, not half-done: the ask is still pending.
+    expect(await vendo.guard.approvals.pending(principal)).toHaveLength(1);
+  });
+
+  it("still serves the umbrella's OWN per-approval read, which the shared wire has not got", async () => {
+    const vendo = await setup();
+    const approvalId = await park(vendo, "call_byo_1");
+
+    const read = await vendo.handler(request("GET", `/approvals/${approvalId}`));
+
+    expect(read.status).toBe(200);
+    expect(await read.json()).toMatchObject({ state: "pending", request: { call: { tool: descriptor.name } } });
+    // Owner-scoped, and an unknown id is indistinguishable from a foreign one.
+    expect((await vendo.handler(request("GET", "/approvals/apr_nope"))).status).toBe(404);
+  });
+
+  it("keeps refusing a decide with no ids and an unknown grant", async () => {
+    const vendo = await setup();
+
+    expect((await vendo.handler(request("POST", "/approvals/decide", { ids: [] }))).status).toBe(400);
+    expect((await vendo.handler(request("POST", "/approvals/decide", { ids: ["apr_x"] }))).status).toBe(400);
+    expect((await vendo.handler(request("DELETE", "/grants/grt_nope"))).status).toBe(404);
+  });
+});


### PR DESCRIPTION
Closes #1246.

Two duplicate permission mechanisms collapse into one each.

## 1. One guard-owned grant mint

The mint that lived inline in guard's decide path is extracted into `mintGrant`, backed by new `buildGrant` / `grantRefs` / `MintGrantInput` in `@vendoai/core`. `Guard` gains ONE optional member, `mintGrant?()`, following the existing `spendApproval` pattern (it stays optional on `VendoGuard` too, exactly like `spendApproval`, so hand-written guard doubles keep working).

`packages/automations/src/grants.ts` becomes a delegate — `guard.mintGrant?.(input) ?? localPut(buildGrant(...))` — net **−16 lines**. The fallback keeps a custom `Guard` working, and both paths go through the same `buildGrant`/`grantRefs`, so there is one spelling of the refs (`subject`, `tool`, `app_id`, `trigger_id`).

An adversarial check pinned the extracted mint **field by field** against main's original inline code — scope derivation, duration, `contextKey` defaulting (`runId ?? sessionId`), `source`, `appId`, `triggerId`, `descriptorHash` — and found no drift. That comparison ships as `packages/guard/test/decide-mint-parity.test.ts`.

## 2. One permission wire

New `packages/guard/src/permission-wire.ts` serves the five routes (`GET /approvals`, `POST /approvals/decide`, `DELETE /approvals/:id`, `GET /grants`, `DELETE /grants/:id`). `packages/vendo/src/wire/approvals.ts` delegates to it while keeping the umbrella's own extras — the `?org=` clamp on all five and the BYO `GET /approvals/:id`. `packages/agents/src/permissions.ts` + `PERMISSIONS_PATH` mount the same wire for a standalone agent; `@vendoai/ui` already posts there. `respond()` gets no new option and `RespondOptions` is untouched; resume is the existing shared waiter.

`permissions` returns `undefined` (fall through) for non-permission paths including `DOOR_PATH`, so one catch-all mount serves both. With no principal resolver configured it 401s — "no resolver" is not "everyone".

## Hard law

`presenceMatches` and the away downgrade in `packages/guard/src/guard.ts` are **byte-identical to main** (md5-compared, not eyeballed). `git diff --name-only` never lists that file for edit beyond the extraction hunk and three imports; neither protected region appears in any hunk.

## Adversarial check round

An independent checker attacked cross-subject leakage on all five routes across three surfaces (shared wire, standalone agent, umbrella) and could not break it — every attempt at another principal's data returns `not-found`/404, indistinguishable from an unknown id. It also attacked method confusion, crafted paths (`..`, encoded segments, case, trailing slash), and the delegate fallback. One real defect found and fixed:

**The mount was compared as a string prefix, not a path boundary** — `/api/vendoapprovals` passed `startsWith("/api/vendo")` and was served as `/approvals`, silently shadowing a host's legacy route chained behind the handler. Fixed by making the boundary the slash (`${mount}/`). Not privilege escalation — the principal was still resolved and the guard still owner-scoped — but a broken contract. Revert-to-red proven on both the guard surface and the shipped `VendoAgent.permissions` surface.

## A test double replaced with a real seam

The automations engine test drives a `GuardDouble` whose `mintGrant` returns a fake id and writes nothing — producer and consumer each mocking the other, the pattern CLAUDE.md's testing section warns about. This PR adds `packages/vendo/tests/automations-grant-seam.seam.test.ts`, which drives the **real** guard and the **real** automations engine over **one real store**, with no stub on either side: `enable` → decide → the grant lands where `liveAutomationGrants` reads it. Whether the older double should be deleted is worth deciding separately.

## Gates

`pnpm build` 0 · typecheck (core, guard, automations, agents, vendo) 0 · `pnpm lint` 0 (`dependency-guard: OK, 30 packages`) · guard 84 tests incl. all four security suites green **with zero test edits** · core `grants` 8/8 · automations `engine` 54/54 · agents 8/8 · vendo 8/8.

Coverage: guard **97.39%** (floor 96) · core **97.57%** (floor 97).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies permissioning behind one grant mint and one permission wire, removing duplicates and fixing a mount path-boundary bug. Previously automations minted grants and the umbrella served the five routes independently; now the guard owns `mintGrant` and all five routes go through one wire with correct path boundaries and error status mapping.

- Core (`@vendoai/core`): adds `buildGrant`/`grantRefs` and `MintGrantInput` — single spelling for grant rows and refs.
- Guard (`@vendoai/guard`): adds optional `mintGrant` and routes decide-path mint through it; introduces the shared wire as `handlePermissionRequest`/`permissionsHandler` with boundary `${mount}/`, falls through for non-permission paths, and maps errors to 400/404/409/501.
- Automations: delegates minting to `guard.mintGrant`, with a fallback that writes via `buildGrant`/`grantRefs` so custom guards still work and both paths mint identical grants.
- Umbrella (`@vendoai/vendo`): approvals/grants routes delegate to the shared wire; keeps umbrella-specific behavior (`?org=` clamp on all five and BYO `GET /approvals/:id`).
- Agents (`@vendoai/agents`): exposes `agent.permissions` mounted at `PERMISSIONS_PATH`; returns undefined for non-permission paths (so one catch-all can serve the door and permissions) and 401s when no principal is configured; adds `schemaReadyPrincipal` to ensure schema before serving permission routes.

**Rollout/Migration**
- No breaking changes; `Guard.mintGrant` is optional. Custom guards can omit it; callers fall back to `buildGrant`.
- If you use `@vendoai/agents`, mount `agent.permissions` at `PERMISSIONS_PATH` and provide a `principal` resolver; consider wrapping with `schemaReadyPrincipal(store)` if the mount can be polled before first turn.
- Verify any custom mounts rely on the new boundary check (`${mount}/`) if you previously matched by string prefix.

<sup>Written for commit 2211307dfefbb528082b568e35b49800188441cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

