### PR TITLE
feat(agents): arm() raises the away asks, and run({ identity }) runs on what they minted

### DIFF
--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -28,6 +28,7 @@ import { resolveDevCredential } from "@vendoai/harnesses/inference/credential";
 import { createStore, storeFiles, type VendoStore } from "@vendoai/store";
 import type { LanguageModel, UIMessage } from "ai";
 import { randomUUID } from "node:crypto";
+import { createArm, type ArmRequest, type ArmResult } from "./arming.js";
 import { startRun, type AgentRun, type RunOptions } from "./away.js";
 import { resolveDoor, type DoorConfig } from "./door.js";
 import { withEgress, type EgressConfig } from "./egress.js";
@@ -87,6 +88,9 @@ export interface AgentConfig {
    * forgery-safe `[User]`/`[Situation]` blocks to the host, to keep or to drop.
    */
   system?: SystemPromptHook;
+  /** Which automation this agent's runs ARE, when it only ever is one — the
+   *  default behind `run({ identity })`, which still wins per run. */
+  identity?: RunOptions["identity"];
 }
 
 export interface VendoAgent {
@@ -106,6 +110,15 @@ export interface VendoAgent {
    *  happened. Venue "automation", presence "away", non-interactive — so a tool
    *  the guard wants a person for parks, and `refs.approvals` is who to ask. */
   run<T = never>(task: string, options?: RunOptions<T>): AgentRun<T>;
+  /**
+   * Ask this person to let an unattended run act as them: one approval per tool
+   * the run could reach, raised on the permission wire for them to answer. A yes
+   * mints a STANDING grant bound to (subject, appId, triggerId) — which is
+   * exactly what `run({ identity })` runs on, so an armed run proceeds instead
+   * of parking. Tools no unattended run may reach at all come back as `held`,
+   * unasked.
+   */
+  arm(subject: string, request: ArmRequest): Promise<ArmResult>;
   session(subject: string, options?: SessionOptions): Promise<AgentSession>;
   /**
    * This agent's MCP door, present exactly when its harness thinks outside this
@@ -367,6 +380,7 @@ export function agent(config: AgentConfig): VendoAgent {
     assertModel: requireModel,
     ...(config.instructions === undefined ? {} : { instructions: config.instructions }),
     ...(config.system === undefined ? {} : { system: config.system }),
+    ...(config.identity === undefined ? {} : { identity: config.identity }),
     // The other half of the door: a credential the harness minted resolves to
     // NOTHING until the turn it points at is published, so without this line a
     // mounted door 401s every tool call the box makes.
@@ -384,6 +398,7 @@ export function agent(config: AgentConfig): VendoAgent {
       return session.stream(message, options.signal === undefined ? {} : { signal: options.signal });
     },
     run: (task, options) => startRun(deps, task, options),
+    arm: createArm({ guard, store, tools: bound }),
     async session(subject, options) {
       await requireModel();
       return createSession(deps, subject, options);

--- a/packages/agents/src/arming.ts
+++ b/packages/agents/src/arming.ts
@@ -1,0 +1,155 @@
+/**
+ * ARMING — the present-time ceremony that turns "let this run while I am away"
+ * into standing authority. The asks are raised through the guard's own away
+ * check, so the question the person answers is exactly the question that firing
+ * would have raised — and the grant a yes mints is the one that firing looks up.
+ *
+ * KNOWN LIMIT — the raised asks live in THIS process's memory until they are
+ * answered. A restart between raising an ask and deciding it loses the mint, and
+ * the person arms again. Persisting them would mean a reserved collection of
+ * this package's own, which arming does not have.
+ */
+import {
+  DEFAULT_TRIGGER_ID,
+  descriptorHash,
+  presenceOnlyCall,
+  withheldFromUnattended,
+  type AppId,
+  type ApprovalId,
+  type ApprovalRequest,
+  type RunContext,
+  type RunId,
+  type ToolRegistry,
+} from "@vendoai/core";
+import type { VendoGuard } from "@vendoai/guard";
+import type { VendoStore } from "@vendoai/store";
+import { randomUUID } from "node:crypto";
+
+export interface ArmRequest {
+  /** The automation this authority is for. */
+  appId: string;
+  /** WHICH trigger of it — each is consented to on its own. Unset → `main`. */
+  triggerId?: string;
+  /** Unset ⇒ every bound tool an unattended run may still reach. */
+  tools?: readonly string[];
+}
+
+export interface ArmResult {
+  /** One ask per wanted tool, for a person to answer on the permission wire. */
+  pending: ApprovalId[];
+  /** Tools no unattended run may reach whatever anyone allows — never asked. */
+  held: readonly string[];
+}
+
+export interface ArmDeps {
+  guard: VendoGuard;
+  store: VendoStore;
+  /** The agent's guard-bound registry — an unattended run's whole tool surface. */
+  tools: ToolRegistry;
+}
+
+/**
+ * The row a consent moment leaves for the ONE mint path, keyed by the approval
+ * it is the ask for (core's engine allowlist, `engine-collections.ts`).
+ *
+ * Whoever else subscribes to `onApprovalDecision` on this guard, the automations
+ * engine's subscriber reads THIS first, and only an approval with no such row
+ * falls through to its app-wide fallback — the branch that derives the trigger
+ * from the RUN ROW the approval was raised inside. A present-time ceremony has
+ * no run, so that fallback reads `undefined` and mints an APP-WIDE standing
+ * grant: the trigger the person armed holds nothing, and `main` — never shown to
+ * anyone — holds unattended authority. The row is what makes the ask
+ * unclaimable by that fallback, whichever subscriber the host registered first.
+ */
+const CAPTURES = "automations:captures";
+
+/** The ceremony, with its own memory of what it has asked. */
+export function createArm(deps: ArmDeps): (subject: string, request: ArmRequest) => Promise<ArmResult> {
+  /** The asks this process raised, by the approval they are waiting on. */
+  const raised = new Map<ApprovalId, { request: ApprovalRequest; triggerId: string }>();
+
+  deps.guard.onApprovalDecision(async (id, approved) => {
+    const armed = raised.get(id);
+    if (armed === undefined) return;
+    raised.delete(id);
+    // The ask is answered, so its marker is spent whichever subscriber acted on
+    // it — a row outliving its approval would keep counting as an open question.
+    await deps.store.records(CAPTURES).delete(id);
+    if (!approved) return;
+    // Spend BEFORE minting: a yes the person took back at this instant must arm
+    // nothing, and the take-back and the mint contend for the approval's one
+    // one-time transition, so only one of them can ever win it. Both seams are
+    // optional on the interface and both fail CLOSED — a guard that cannot spend
+    // cannot linearize a take-back against a mint, and one that cannot mint has
+    // nowhere to put the grant.
+    if (await deps.guard.spendApproval?.(id, armed.request.ctx.principal) !== "spent") return;
+    await deps.guard.mintGrant?.({
+      request: armed.request,
+      remember: { duration: "standing" },
+      source: "automation",
+      triggerId: armed.triggerId,
+    });
+  });
+
+  return async (subject, { appId, triggerId = DEFAULT_TRIGGER_ID, tools }) => {
+    await deps.store.ensureSchema();
+    // Listed PRESENT: §12's unattended projection hides the very tools this has
+    // to report as held.
+    const descriptors = await deps.tools.descriptors({ venue: "automation", presence: "present" });
+    // Asked as the AWAY call it is about — same appId, same trigger — because
+    // the ask is only worth answering if it is the firing's own ask.
+    const ctx: RunContext = {
+      principal: { kind: "user", subject },
+      venue: "automation",
+      presence: "away",
+      sessionId: `arm_${randomUUID()}`,
+      appId: appId as AppId,
+      trigger: { runId: `run_${randomUUID()}` as RunId, kind: "host-event", id: triggerId },
+    };
+    // `previewCheck`, not `check`: nothing dispatches here, so the ceremony must
+    // not spend a run's write budget or the subject's call-rate window. It parks
+    // an ask exactly as `check` does.
+    const ask = deps.guard.previewCheck?.bind(deps.guard) ?? deps.guard.check.bind(deps.guard);
+    const pending: ApprovalId[] = [];
+    const held: string[] = [];
+    for (const descriptor of descriptors) {
+      if (tools !== undefined && !tools.includes(descriptor.name)) continue;
+      const call = { id: `call_${randomUUID()}`, tool: descriptor.name, args: {} };
+      // THE LAW an away run runs under has two halves, and `bind().execute()`
+      // enforces both: the withheld GRADES, and the placement tools it refuses
+      // away BY NAME. A card for either is a card for a call that can never
+      // happen, and a yes on it mints standing authority for nothing.
+      if (withheldFromUnattended(descriptor) || presenceOnlyCall(call)) {
+        held.push(descriptor.name);
+        continue;
+      }
+      const decision = await ask(call, descriptor, ctx);
+      // Anything else is already answered: a live grant runs, a standing no blocks.
+      if (decision.action !== "ask") continue;
+      // The grade §12 is applied to is the RESOLVED one (the guard re-grades a
+      // call through `resolveRisk` before it rules on it), and the parked ask —
+      // which carries the descriptor the guard itself decided on — is the only
+      // place a ceremony can read it. A tool this deployment re-grades
+      // destructive is held, and the card it just raised is withdrawn.
+      if (withheldFromUnattended(decision.approval.descriptor)) {
+        held.push(descriptor.name);
+        await deps.guard.abandonApprovals?.([decision.approval.id], ctx);
+        continue;
+      }
+      await deps.store.records(CAPTURES).put({
+        id: decision.approval.id,
+        data: {
+          appId,
+          triggerId,
+          subject,
+          tool: descriptor.name,
+          descriptorHash: descriptorHash(decision.approval.descriptor),
+        },
+        refs: { subject, app_id: appId, trigger_id: triggerId },
+      });
+      raised.set(decision.approval.id, { request: decision.approval, triggerId });
+      pending.push(decision.approval.id);
+    }
+    return { pending, held };
+  };
+}

--- a/packages/agents/src/away.ts
+++ b/packages/agents/src/away.ts
@@ -25,11 +25,13 @@
  * the harness's own `error` event.
  */
 import {
+  DEFAULT_TRIGGER_ID,
   VendoError,
   createTurnSkills,
   hostSkillFiles,
   type AgentRunner,
   type AgentRunReport,
+  type AppId,
   type FilesAdapter,
   type Guard,
   type Harness,
@@ -38,6 +40,7 @@ import {
   type JsonSchema,
   type Skill,
   type RunContext,
+  type RunId,
   type SeatModels,
   type ThreadId,
   type ToolCall,
@@ -147,6 +150,12 @@ export interface RunOptions<T = never> {
   signal?: AbortSignal;
   /** Continue a conversation this subject already owns, instead of a fresh one. */
   threadId?: string;
+  /** WHICH automation this run is, so the standing grants `agent.arm()` minted
+   *  for it are the ones the guard matches — an armed run proceeds unattended
+   *  instead of parking. A lookup KEY, never a credential: it authenticates
+   *  nothing and authorizes nothing on its own; the grant is still the whole
+   *  authority. Unset → the agent's own `identity`, else no automation at all. */
+  identity?: { appId: string; triggerId?: string };
 }
 
 /** The run's return channel. Named, rather than parsed back out of prose,
@@ -608,6 +617,8 @@ export interface RunDeps extends AwayRunnerDeps {
    *  door's origin is still undefined, and the box dials a URL that is not
    *  there yet. */
   doorReady?: Promise<void>;
+  /** The agent's own {@link RunOptions.identity}, for a caller that names none. */
+  identity?: RunOptions["identity"];
 }
 
 /**
@@ -621,6 +632,7 @@ export interface RunDeps extends AwayRunnerDeps {
 export function startRun<T>(deps: RunDeps, task: string, options: RunOptions<T> = {}): AgentRun<T> {
   const threadId = (options.threadId ?? `thr_${randomUUID()}`) as ThreadId;
   const queue = eventQueue<RunEvent>();
+  const identity = options.identity ?? deps.identity;
   // Both gates a turn has to clear before it opens anything, in the one place a
   // run begins: the model check, and the door still binding its port —
   // `createSession` awaits the same two.
@@ -636,6 +648,17 @@ export function startRun<T>(deps: RunDeps, task: string, options: RunOptions<T> 
       sessionId: threadId,
       ...(options.user === undefined ? {} : { user: options.user }),
       ...(options.context === undefined ? {} : { context: options.context }),
+      // The named automation, on the two fields the guard's away-grant lookup
+      // already matches on. The run id is this run's own — the trigger REF says
+      // which automation is firing, not which firing it is.
+      ...(identity === undefined ? {} : {
+        appId: identity.appId as AppId,
+        trigger: {
+          runId: `run_${randomUUID()}` as RunId,
+          kind: "host-event" as const,
+          id: identity.triggerId ?? DEFAULT_TRIGGER_ID,
+        },
+      }),
     },
     threadId,
     reopen: options.threadId !== undefined,

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -17,6 +17,7 @@ export {
   type PostgresOptions,
   type VendoAgent,
 } from "./agent.js";
+export type { ArmRequest, ArmResult } from "./arming.js";
 export {
   awayRunner,
   type AgentReport,

--- a/packages/agents/tests/arming-held.test.ts
+++ b/packages/agents/tests/arming-held.test.ts
@@ -1,0 +1,143 @@
+/**
+ * ADVERSARIAL CHECK — is `held` honest?
+ *
+ * `arm()` promises: "Tools no unattended run may reach at all come back as
+ * `held`, unasked" (agents/src/agent.ts:113-119). THE LAW an unattended run
+ * actually runs under has three parts, all enforced in `guard.bind().execute()`
+ * (guard.ts:793-796), and `held` is a lie unless it covers all three:
+ *
+ *   1. `withheldFromUnattended` on the descriptor — the grades §12 withholds.
+ *   2. `presenceOnlyCall` — the pin/unpin tools are refused away by NAME, not by
+ *      grade. `projectableForRun` drops them from every unattended listing.
+ *   3. the EFFECTIVE risk — the guard re-grades a call through `resolveRisk`
+ *      before it applies §12 (`completed.descriptor`), so a tool the host
+ *      declared `write` and the deployment re-graded `destructive` is refused
+ *      away. The declared grade alone would miss it.
+ *
+ * Miss any of them and `arm()` raises a card for something that can never run,
+ * and a yes on that card mints STANDING authority for it.
+ *
+ * Real store, real guard, real ceremony — the guard IS the counterparty
+ * (CLAUDE.md: test the SEAM).
+ */
+import { VENDO_APPS_PIN_TOOL, type RunContext } from "@vendoai/core";
+import { createGuard, type VendoGuard } from "@vendoai/guard";
+import { createStore, type VendoStore } from "@vendoai/store";
+import { describe, expect, it } from "vitest";
+import { agent, agentComposition, type VendoAgent } from "../src/agent.js";
+import { tool } from "../src/tools.js";
+
+let stores = 0;
+const memoryStore = (): VendoStore => createStore({ dataDir: `memory://agents-held-${stores++}` });
+
+const principal = { kind: "user", subject: "u_owner" } as const;
+const APP = "app_digest";
+
+const awayCtx: RunContext = {
+  principal,
+  venue: "automation",
+  presence: "away",
+  sessionId: "sess_check",
+  appId: APP as RunContext["appId"],
+  trigger: { runId: "run_check" as never, kind: "host-event", id: "nightly" },
+};
+
+/** Honestly `write` — putting your own app on your own page is a small
+ *  reversible write with a person there. It is withheld away by NAME.
+ *  `onRun` fires only if the host's own implementation is actually reached. */
+const pinTool = (onRun: () => void = () => {}) => tool({
+  name: VENDO_APPS_PIN_TOOL,
+  description: "Pin this app to the page",
+  risk: "write",
+  inputSchema: { type: "object" },
+  execute: () => {
+    onRun();
+    return { pinned: true };
+  },
+});
+
+/** Declared `write`; this deployment re-grades it `destructive` at call time,
+ *  which is the grade §12 is applied to. */
+const emailTool = () => tool({
+  name: "invoices_email",
+  description: "Email invoices",
+  risk: "write",
+  inputSchema: { type: "object" },
+  execute: () => ({ sent: true }),
+});
+
+const armAndSayYes = async (guard: VendoGuard, support: VendoAgent, name: string): Promise<string[]> => {
+  const { pending, held } = await support.arm(principal.subject, {
+    appId: APP,
+    triggerId: "nightly",
+    tools: [name],
+  });
+  if (pending.length > 0) await guard.approvals.decide(pending, { approve: true }, principal);
+  return [...held];
+};
+
+describe("arm() — held is the whole law, or it is a lie", () => {
+  it("holds the presence-only tools instead of asking about them", async () => {
+    const store = memoryStore();
+    const guard = createGuard({ store });
+    const support = agent({ name: "support", tools: [pinTool()], store, guard });
+
+    const held = await armAndSayYes(guard, support, VENDO_APPS_PIN_TOOL);
+
+    expect(held).toEqual([VENDO_APPS_PIN_TOOL]);
+  });
+
+  it("mints no standing authority for a tool the away run is refused by name", async () => {
+    const store = memoryStore();
+    const guard = createGuard({ store });
+    let ran = false;
+    const support = agent({
+      name: "support",
+      tools: [pinTool(() => { ran = true; })],
+      store,
+      guard,
+    });
+
+    const { pending, held } = await support.arm(principal.subject, {
+      appId: APP,
+      triggerId: "nightly",
+      tools: [VENDO_APPS_PIN_TOOL],
+    });
+
+    // Held means UNASKED: no ask came back, and none is sitting on the wire for
+    // a person to answer. There is no card here for a yes to turn into standing
+    // authority — which is the only way `held` can be honest about a tool the
+    // away run is refused by name.
+    expect([...held]).toEqual([VENDO_APPS_PIN_TOOL]);
+    expect(pending).toEqual([]);
+    expect(await guard.approvals.pending(principal)).toEqual([]);
+
+    // And the away call itself still cannot happen. Holding the tool took the
+    // grant away, so the call has no authority at all: it parks as an
+    // unanswered question rather than reaching the host's implementation.
+    const outcome = await agentComposition(support)!.tools.execute(
+      { id: "call_pin", tool: VENDO_APPS_PIN_TOOL, args: {} },
+      awayCtx,
+    );
+    expect(outcome.status).toBe("pending-approval");
+    expect(ran).toBe(false);
+    expect((await guard.grants.list(principal)).map((grant) => grant.tool)).toEqual([]);
+  });
+
+  it("holds a tool this deployment re-grades destructive, not the grade it was authored with", async () => {
+    const store = memoryStore();
+    const guard = createGuard({
+      store,
+      // The same seam the umbrella wires (`compose-guard.ts`): the grade a call
+      // really runs under is resolved at call time, not read off the author's
+      // label.
+      resolveRisk: (call) => call.tool === "invoices_email" ? "destructive" : undefined,
+    });
+    const support = agent({ name: "support", tools: [emailTool()], store, guard });
+
+    const held = await armAndSayYes(guard, support, "invoices_email");
+
+    expect(held).toEqual(["invoices_email"]);
+    expect((await guard.grants.list(principal)).map((grant) => grant.tool)).toEqual([]);
+  });
+});

--- a/packages/agents/tests/arming.test.ts
+++ b/packages/agents/tests/arming.test.ts
@@ -1,0 +1,124 @@
+/**
+ * `agent.arm()` — the ceremony that turns "let this run while I am away" into
+ * standing authority: one ask per tool an unattended run could reach, and a yes
+ * that mints the (app, trigger)-bound grant the firing runs on.
+ *
+ * Real embedded store, real guard, real approval wire — the guard IS the
+ * counterparty here, so stubbing any of it would prove nothing (CLAUDE.md: test
+ * the SEAM).
+ */
+import { createGuard, type VendoGuard } from "@vendoai/guard";
+import { createStore, type VendoStore } from "@vendoai/store";
+import { describe, expect, it } from "vitest";
+import { agent, type VendoAgent } from "../src/agent.js";
+import { tool } from "../src/tools.js";
+
+let stores = 0;
+const memoryStore = (): VendoStore => createStore({ dataDir: `memory://agents-arming-${stores++}` });
+
+const principal = { kind: "user", subject: "u_owner" } as const;
+const APP = "app_digest";
+
+/** Two tools an away run may still reach, and two THE LAW withholds from every
+ *  unattended run whatever anyone allows. */
+const hostTools = () => [
+  tool({ name: "invoices_list", description: "List invoices", risk: "read", inputSchema: { type: "object" }, execute: () => ({ invoices: 2 }) }),
+  tool({ name: "invoices_email", description: "Email invoices", risk: "write", inputSchema: { type: "object" }, execute: () => ({ sent: true }) }),
+  tool({ name: "invoices_delete", description: "Delete invoices", risk: "destructive", inputSchema: { type: "object" }, execute: () => ({ gone: true }) }),
+  tool({ name: "invoices_guess", description: "Nobody graded this one", inputSchema: { type: "object" }, execute: () => ({}) }),
+];
+
+function compose(): { guard: VendoGuard; support: VendoAgent } {
+  const store = memoryStore();
+  const guard = createGuard({ store });
+  return { guard, support: agent({ name: "support", tools: hostTools(), store, guard }) };
+}
+
+describe("arm() — the asks", () => {
+  it("raises one ask per wanted tool, and reports the withheld ones instead of asking", async () => {
+    const { guard, support } = compose();
+
+    const result = await support.arm(principal.subject, { appId: APP, triggerId: "nightly" });
+
+    expect([...result.held].sort()).toEqual(["invoices_delete", "invoices_guess"]);
+    const pending = await guard.approvals.pending(principal);
+    expect(pending.map((request) => request.call.tool).sort()).toEqual(["invoices_email", "invoices_list"]);
+    expect(result.pending.sort()).toEqual(pending.map((request) => request.id).sort());
+    // The ask is the FIRING's own ask — same app, same trigger, away — which is
+    // what makes it worth answering.
+    expect(pending[0]?.ctx).toMatchObject({
+      venue: "automation",
+      presence: "away",
+      appId: APP,
+      trigger: { id: "nightly" },
+    });
+  });
+
+  it("asks only about the tools the caller named", async () => {
+    const { guard, support } = compose();
+
+    const result = await support.arm(principal.subject, { appId: APP, tools: ["invoices_list"] });
+
+    expect(result.pending).toHaveLength(1);
+    expect((await guard.approvals.pending(principal)).map((request) => request.call.tool))
+      .toEqual(["invoices_list"]);
+  });
+});
+
+describe("arm() — what a decision mints", () => {
+  const armOne = async (): Promise<{ guard: VendoGuard; pending: string[] }> => {
+    const { guard, support } = compose();
+    const { pending } = await support.arm(principal.subject, {
+      appId: APP,
+      triggerId: "nightly",
+      tools: ["invoices_list"],
+    });
+    return { guard, pending };
+  };
+
+  it("a yes mints a STANDING automation grant bound to (subject, appId, triggerId)", async () => {
+    const { guard, pending } = await armOne();
+
+    await guard.approvals.decide(pending, { approve: true }, principal);
+
+    expect(await guard.grants.list(principal)).toMatchObject([{
+      subject: "u_owner",
+      tool: "invoices_list",
+      appId: APP,
+      triggerId: "nightly",
+      source: "automation",
+      duration: "standing",
+      scope: { kind: "tool" },
+    }]);
+  });
+
+  it("a no mints nothing", async () => {
+    const { guard, pending } = await armOne();
+
+    await guard.approvals.decide(pending, { approve: false }, principal);
+
+    expect(await guard.grants.list(principal)).toEqual([]);
+  });
+
+  it("a take-back landing inside the decision arms nothing — the spend runs first", async () => {
+    const store = memoryStore();
+    const guard = createGuard({ store });
+    // A competitor that takes the yes back the instant it lands, subscribed
+    // BEFORE arming so it runs first: it claims the approval's one-time
+    // transition, and the mint — which spends before it grants — finds nothing
+    // left to spend. Mint-then-spend would have both winning.
+    guard.onApprovalDecision(async (id) => {
+      await guard.approvals.revoke(id, principal);
+    });
+    const support = agent({ name: "support", tools: hostTools(), store, guard });
+    const { pending } = await support.arm(principal.subject, {
+      appId: APP,
+      triggerId: "nightly",
+      tools: ["invoices_list"],
+    });
+
+    await guard.approvals.decide(pending, { approve: true }, principal);
+
+    expect(await guard.grants.list(principal)).toEqual([]);
+  });
+});

--- a/packages/agents/tests/away.identity.test.ts
+++ b/packages/agents/tests/away.identity.test.ts
@@ -1,0 +1,107 @@
+/**
+ * `run({ identity })` — WHICH automation an unattended run is, so the standing
+ * grants `arm()` minted for it are the ones the guard matches and the run
+ * proceeds instead of parking.
+ *
+ * It is a lookup KEY and nothing else: naming an app and a trigger nobody armed
+ * buys a run exactly nothing, which is what the first and third cases here say.
+ * Real store, real guard, real arming — only the thinker is scripted (CLAUDE.md:
+ * test the SEAM).
+ */
+import { defineHarness } from "@vendoai/harnesses";
+import { createGuard, type VendoGuard } from "@vendoai/guard";
+import { createStore, type VendoStore } from "@vendoai/store";
+import { describe, expect, it } from "vitest";
+import { agent, type AgentConfig, type VendoAgent } from "../src/agent.js";
+import { tool } from "../src/tools.js";
+
+let stores = 0;
+const memoryStore = (): VendoStore => createStore({ dataDir: `memory://agents-identity-${stores++}` });
+
+const principal = { kind: "user", subject: "u_owner" } as const;
+const APP = "app_digest";
+
+/** One tool, called once, then the model speaks. */
+const caller = defineHarness({
+  name: "caller",
+  async *run(turn) {
+    await turn.tools.call("invoices_list", {});
+    yield { type: "text" as const, delta: "done" };
+  },
+});
+
+function compose(over: Partial<AgentConfig> = {}): { guard: VendoGuard; support: VendoAgent } {
+  const store = memoryStore();
+  const guard = createGuard({ store });
+  const support = agent({
+    name: "support",
+    harness: caller,
+    tools: [tool({
+      name: "invoices_list",
+      description: "List invoices",
+      risk: "read",
+      inputSchema: { type: "object" },
+      execute: () => ({ invoices: 2 }),
+    })],
+    store,
+    guard,
+    ...over,
+  });
+  return { guard, support };
+}
+
+/** Arm the named trigger and answer yes, exactly as a person would. */
+const armAndAllow = async (guard: VendoGuard, support: VendoAgent, triggerId: string): Promise<void> => {
+  const { pending } = await support.arm(principal.subject, { appId: APP, triggerId });
+  await guard.approvals.decide(pending, { approve: true }, principal);
+};
+
+describe("run({ identity })", () => {
+  it("parks every call when nobody armed that identity", async () => {
+    const { support } = compose();
+
+    const report = await support.run("Send the digest.", {
+      as: principal.subject,
+      identity: { appId: APP, triggerId: "nightly" },
+    });
+
+    expect(report.toolCalls.map(({ outcome }) => outcome)).toEqual(["pending-approval"]);
+    expect(report.refs.approvals).toHaveLength(1);
+  });
+
+  it("runs unattended on the grant arm() minted, and the call is decided BY that grant", async () => {
+    const { guard, support } = compose();
+    await armAndAllow(guard, support, "nightly");
+
+    const report = await support.run("Send the digest.", {
+      as: principal.subject,
+      identity: { appId: APP, triggerId: "nightly" },
+    });
+
+    expect(report.toolCalls.map(({ outcome }) => outcome)).toEqual(["ok"]);
+    expect(report.refs.approvals).toEqual([]);
+    const { events } = await guard.audit.query({ principal });
+    expect(events.find((event) => event.kind === "tool-call")?.decidedBy).toBe("grant");
+  });
+
+  it("holds nothing for a SIBLING trigger of the same app", async () => {
+    const { guard, support } = compose();
+    await armAndAllow(guard, support, "nightly");
+
+    const report = await support.run("Send the digest.", {
+      as: principal.subject,
+      identity: { appId: APP, triggerId: "weekly" },
+    });
+
+    expect(report.toolCalls.map(({ outcome }) => outcome)).toEqual(["pending-approval"]);
+  });
+
+  it("falls back to the agent's own identity when a run names none", async () => {
+    const { guard, support } = compose({ identity: { appId: APP, triggerId: "nightly" } });
+    await armAndAllow(guard, support, "nightly");
+
+    const report = await support.run("Send the digest.", { as: principal.subject });
+
+    expect(report.toolCalls.map(({ outcome }) => outcome)).toEqual(["ok"]);
+  });
+});

--- a/packages/vendo/tests/arming-binding.test.ts
+++ b/packages/vendo/tests/arming-binding.test.ts
@@ -1,0 +1,133 @@
+/**
+ * ADVERSARIAL CHECK — `agent.arm()` against the OTHER subscriber on the same
+ * guard.
+ *
+ * `createAutomations()` subscribes its own `onApprovalDecision` handler
+ * (automations/src/engine.ts:24), and that handler claims ANY approved approval
+ * whose context is `venue: "automation"` with an `appId` — which is exactly the
+ * shape `arm()` raises (agents/src/arming.ts:82-89). Whichever subscriber
+ * registered FIRST wins the approval's one-time `consumed` transition, so an
+ * engine booted before the agent claims the ceremony's yes.
+ *
+ * The automations handler derives the trigger from the RUN ROW named by
+ * `ctx.trigger.runId` (automations/src/consent.ts:221-224). `arm()` invents that
+ * run id, so there is no row, so the trigger comes out `undefined` and the grant
+ * is minted with NO `triggerId`.
+ *
+ * Both halves of the ceremony's promise then break, and one of them breaks OPEN:
+ * the trigger the person armed holds nothing, and `main` — a trigger nobody was
+ * ever shown — holds standing unattended authority.
+ *
+ * Nothing is stubbed: one real store, one real guard, the real engine, the real
+ * ceremony (CLAUDE.md: test the SEAM).
+ */
+import { agent, tool, type VendoAgent } from "@vendoai/agents";
+import type { AppsRuntime } from "@vendoai/apps";
+import { createAutomations } from "@vendoai/automations";
+import {
+  DEFAULT_TRIGGER_ID,
+  type AppId,
+  type Principal,
+  type RunContext,
+  type RunId,
+  type ToolRegistry,
+} from "@vendoai/core";
+import { createGuard, type VendoGuard } from "@vendoai/guard";
+import { createStore } from "@vendoai/store";
+import { describe, expect, it } from "vitest";
+
+const principal: Principal = { kind: "user", subject: "u_owner" };
+const APP = "app_digest";
+const ARMED_TRIGGER = "nightly";
+
+let stores = 0;
+
+const invoicesList = tool({
+  name: "invoices_list",
+  description: "List invoices",
+  risk: "read",
+  inputSchema: { type: "object" },
+  execute: () => ({ invoices: 2 }),
+});
+
+/** The realistic boot order: a host stands its automations engine up, then its
+ *  agent, then a person arms a trigger. Nothing here is contrived — reverse the
+ *  two constructor lines and the ceremony behaves; that ordering dependence is
+ *  the defect. */
+const bootEngineThenAgent = (): { guard: VendoGuard; support: VendoAgent } => {
+  const store = createStore({ dataDir: `memory://vendo-arming-binding-${stores++}` });
+  const guard = createGuard({ store });
+  const registry: ToolRegistry = {
+    descriptors: async () => [invoicesList.descriptor],
+    execute: async (call, ctx) => ({ status: "ok", output: await invoicesList.execute(call.args, ctx, call) }),
+  };
+  createAutomations({
+    apps: {} as unknown as AppsRuntime,
+    guard,
+    store,
+    tools: guard.bind(registry),
+  });
+  const support = agent({ name: "support", store, guard, tools: [invoicesList] });
+  return { guard, support };
+};
+
+const armAndSayYes = async (guard: VendoGuard, support: VendoAgent): Promise<void> => {
+  const { pending } = await support.arm(principal.subject, {
+    appId: APP,
+    triggerId: ARMED_TRIGGER,
+    tools: ["invoices_list"],
+  });
+  expect(pending).toHaveLength(1);
+  await guard.approvals.decide(pending, { approve: true }, principal);
+};
+
+const awayCtx = (triggerId: string): RunContext => ({
+  principal,
+  venue: "automation",
+  presence: "away",
+  sessionId: "sess_check",
+  appId: APP as AppId,
+  trigger: { runId: `run_${triggerId}_check` as RunId, kind: "host-event", id: triggerId },
+});
+
+const call = { id: "call_check", tool: "invoices_list", args: {} };
+
+describe("arm() binding, with an automations engine on the same guard", () => {
+  it("mints a grant bound to the trigger the person armed", async () => {
+    const { guard, support } = bootEngineThenAgent();
+
+    await armAndSayYes(guard, support);
+
+    expect(await guard.grants.list(principal)).toMatchObject([{
+      subject: principal.subject,
+      tool: "invoices_list",
+      appId: APP,
+      triggerId: ARMED_TRIGGER,
+      source: "automation",
+      duration: "standing",
+    }]);
+  });
+
+  it("arms the trigger that was asked about", async () => {
+    const { guard, support } = bootEngineThenAgent();
+
+    await armAndSayYes(guard, support);
+
+    // The trigger the person was shown: armed, so it runs unattended.
+    const armed = await guard.previewCheck!(call, invoicesList.descriptor, awayCtx(ARMED_TRIGGER));
+    expect({ action: armed.action, decidedBy: armed.decidedBy })
+      .toEqual({ action: "run", decidedBy: "grant" });
+  });
+
+  it("arms NO OTHER trigger — `main` was never asked about", async () => {
+    const { guard, support } = bootEngineThenAgent();
+
+    await armAndSayYes(guard, support);
+
+    // Nobody was ever shown a card for `main`. It must hold NOTHING — a "run"
+    // here is standing unattended authority nobody consented to.
+    const never = await guard.previewCheck!(call, invoicesList.descriptor, awayCtx(DEFAULT_TRIGGER_ID));
+    expect({ action: never.action, decidedBy: never.decidedBy })
+      .toEqual({ action: "ask", decidedBy: "default" });
+  });
+});

--- a/packages/vendo/tests/arming-collision.test.ts
+++ b/packages/vendo/tests/arming-collision.test.ts
@@ -1,0 +1,204 @@
+/**
+ * ADVERSARIAL CHECK — two consent doors, two asks, ONE guard, and no
+ * registration order to lean on.
+ *
+ * `createAutomations()` and `agent.arm()` both subscribe `onApprovalDecision` on
+ * the same guard (automations/src/engine.ts:24, agents/src/arming.ts:71), and
+ * the guard calls its subscribers in registration order. The fix for that
+ * collision is a CAPTURE ROW: `arm()` writes one keyed by the approval it just
+ * raised, which is the first branch the automations subscriber reads
+ * (automations/src/consent.ts:168) — so whichever subscriber gets there first
+ * uses the trigger the person was actually shown, and the loser finds the
+ * approval's one-time transition already spent and mints nothing.
+ *
+ * That claim is only worth anything if it holds BOTH WAYS ROUND, so every case
+ * here runs twice: engine constructed before the agent, and agent before the
+ * engine. The two must be indistinguishable. And the two doors must not reach
+ * into each other: arming's ask settles as arming's, the automations ask settles
+ * as automations', whichever is answered first.
+ *
+ * Nothing is stubbed: one real store, one real guard, the real engine, the real
+ * ceremony (CLAUDE.md: test the SEAM).
+ */
+import { agent, tool, type VendoAgent } from "@vendoai/agents";
+import type { AppsRuntime } from "@vendoai/apps";
+import { createAutomations, type AutomationsEngine } from "@vendoai/automations";
+import {
+  VENDO_APP_FORMAT,
+  type AppDocument,
+  type Principal,
+  type RunContext,
+  type ToolRegistry,
+} from "@vendoai/core";
+import { createGuard, type VendoGuard } from "@vendoai/guard";
+import { createStore } from "@vendoai/store";
+import { describe, expect, it } from "vitest";
+
+const principal: Principal = { kind: "user", subject: "u_owner" };
+const APP = "app_digest";
+/** The trigger a person arms through `agent.arm()`. */
+const ARMED_TRIGGER = "nightly";
+/** A DIFFERENT trigger of the same app, armed through `automations.enable()` —
+ *  so the two grants are told apart by the one field the collision destroyed. */
+const AUTO_TRIGGER = "digest";
+
+const presentCtx: RunContext = {
+  principal,
+  venue: "chat",
+  presence: "present",
+  sessionId: "sess_enable",
+};
+
+let stores = 0;
+
+const invoicesList = tool({
+  name: "invoices_list",
+  description: "List invoices",
+  risk: "read",
+  inputSchema: { type: "object" },
+  execute: () => ({ invoices: 2 }),
+});
+
+const doc: AppDocument = {
+  format: VENDO_APP_FORMAT,
+  id: APP,
+  name: "Nightly digest",
+  triggers: [{
+    id: AUTO_TRIGGER,
+    on: { kind: "host-event", event: "go" },
+    run: { kind: "steps", steps: [{ id: "read", tool: invoicesList.descriptor.name }] },
+  }],
+};
+
+type Order = "engine-first" | "agent-first";
+
+interface Composition {
+  guard: VendoGuard;
+  support: VendoAgent;
+  automations: AutomationsEngine;
+}
+
+/** The whole experiment: the ONLY difference between the two arms is which of
+ *  the two constructors runs first, i.e. which subscriber the guard calls
+ *  first. */
+const boot = async (order: Order): Promise<Composition> => {
+  const store = createStore({ dataDir: `memory://vendo-arming-collision-${stores++}` });
+  const guard = createGuard({ store });
+  const registry: ToolRegistry = {
+    descriptors: async () => [invoicesList.descriptor],
+    execute: async (call, ctx) => ({ status: "ok", output: await invoicesList.execute(call.args, ctx, call) }),
+  };
+  const mountEngine = (): AutomationsEngine => createAutomations({
+    apps: {} as unknown as AppsRuntime,
+    guard,
+    store,
+    tools: guard.bind(registry),
+  });
+  const mountAgent = (): VendoAgent => agent({ name: "support", store, guard, tools: [invoicesList] });
+  let automations: AutomationsEngine;
+  let support: VendoAgent;
+  if (order === "engine-first") {
+    automations = mountEngine();
+    support = mountAgent();
+  } else {
+    support = mountAgent();
+    automations = mountEngine();
+  }
+  await store.ensureSchema();
+  await store.records("vendo_apps").put({
+    id: APP,
+    data: { subject: principal.subject, enabled: false, doc },
+    refs: { subject: principal.subject },
+  });
+  return { guard, support, automations };
+};
+
+/** The ask the present-time ceremony raises for ARMED_TRIGGER. */
+const armAsk = async (support: VendoAgent): Promise<string> => {
+  const { pending } = await support.arm(principal.subject, {
+    appId: APP,
+    triggerId: ARMED_TRIGGER,
+    tools: [invoicesList.descriptor.name],
+  });
+  expect(pending).toHaveLength(1);
+  return pending[0]!;
+};
+
+/** The ask `enable()` captures for AUTO_TRIGGER. */
+const enableAsk = async (automations: AutomationsEngine): Promise<string> => {
+  const { missing } = await automations.enable(APP, AUTO_TRIGGER, presentCtx);
+  expect(missing).toHaveLength(1);
+  return missing[0]!.id;
+};
+
+const grantsBound = async (guard: VendoGuard): Promise<unknown[]> =>
+  (await guard.grants.list(principal))
+    .map((grant) => ({
+      subject: grant.subject,
+      tool: grant.tool,
+      appId: grant.appId,
+      triggerId: grant.triggerId,
+      source: grant.source,
+      duration: grant.duration,
+    }))
+    .sort((left, right) => String(left.triggerId).localeCompare(String(right.triggerId)));
+
+const bound = (triggerId: string): unknown => ({
+  subject: principal.subject,
+  tool: invoicesList.descriptor.name,
+  appId: APP,
+  triggerId,
+  source: "automation",
+  duration: "standing",
+});
+
+const openAsks = async (guard: VendoGuard): Promise<string[]> =>
+  (await guard.approvals.pending(principal)).map((request) => request.id);
+
+for (const order of ["engine-first", "agent-first"] as const) {
+  describe(`arm() and enable() on one guard — subscribers registered ${order}`, () => {
+    it("arming's yes settles as ARMING's: bound to the trigger it asked about, nothing app-wide", async () => {
+      const { guard, support, automations } = await boot(order);
+      const arming = await armAsk(support);
+      const engineSide = await enableAsk(automations);
+
+      await guard.approvals.decide([arming], { approve: true }, principal);
+
+      // ONE grant, bound to the trigger the person was actually shown. A row
+      // with no triggerId is the defect this fix exists for: it is app-wide
+      // standing unattended authority for triggers nobody was ever asked about.
+      expect(await grantsBound(guard)).toEqual([bound(ARMED_TRIGGER)]);
+      // And it did not reach into the other door's ask: still an open question.
+      expect(await openAsks(guard)).toEqual([engineSide]);
+
+      await guard.approvals.decide([engineSide], { approve: true }, principal);
+
+      expect(await grantsBound(guard)).toEqual([bound(AUTO_TRIGGER), bound(ARMED_TRIGGER)]);
+      // Read back through the path that actually gates a firing — the automations
+      // half behaves exactly as it does today.
+      expect((await automations.enable(APP, AUTO_TRIGGER, presentCtx)).missing).toEqual([]);
+    });
+
+    it("the automations yes settles as AUTOMATIONS' — arming neither claims, consumes, nor mints for it", async () => {
+      const { guard, support, automations } = await boot(order);
+      const arming = await armAsk(support);
+      const engineSide = await enableAsk(automations);
+
+      await guard.approvals.decide([engineSide], { approve: true }, principal);
+
+      // Three failures are excluded at once. Had arming's listener MINTED for
+      // this ask the row would name ARMED_TRIGGER; had it merely CONSUMED the
+      // approval's one-time transition, automations would have found nothing
+      // left to spend and there would be no row at all; had it CLAIMED the ask
+      // without either, the read below would still be asking for consent.
+      expect(await grantsBound(guard)).toEqual([bound(AUTO_TRIGGER)]);
+      expect((await automations.enable(APP, AUTO_TRIGGER, presentCtx)).missing).toEqual([]);
+      // Arming's own ask is untouched: still open, still unspent.
+      expect(await openAsks(guard)).toEqual([arming]);
+
+      await guard.approvals.decide([arming], { approve: true }, principal);
+
+      expect(await grantsBound(guard)).toEqual([bound(AUTO_TRIGGER), bound(ARMED_TRIGGER)]);
+    });
+  });
+}

--- a/packages/vendo/tests/arming-one-scheme.test.ts
+++ b/packages/vendo/tests/arming-one-scheme.test.ts
@@ -1,0 +1,99 @@
+/**
+ * ONE SCHEME for a standing automation grant, proved across the two blocks that
+ * mint and read it.
+ *
+ * `agent.arm()` (agents) writes the grant through the guard's own mint; the
+ * automations engine reads it back through `liveAutomationGrants` — the read
+ * behind `dryRun`'s "does this trigger already hold what it needs". BOTH halves
+ * are real here, over one store: the grant is minted by a real ceremony and read
+ * by the real engine, with nothing stubbed on either side. Mock either one and
+ * they could never disagree — which is exactly how a dead feature ships green
+ * (CLAUDE.md: test the SEAM).
+ *
+ * The engine is stood up BEFORE the ceremony runs, which is the order a host
+ * boots in — and the order that matters, because both blocks subscribe to the
+ * same guard's decisions and the engine's subscriber is then the first to see
+ * the person's yes.
+ *
+ * The one thing that is not real is the `apps` runtime the engine takes: `dryRun`
+ * never reaches it, and it is no part of this seam.
+ */
+import { createAutomations } from "@vendoai/automations";
+import { agent, tool } from "@vendoai/agents";
+import type { AppsRuntime } from "@vendoai/apps";
+import {
+  VENDO_APP_FORMAT,
+  type AppDocument,
+  type Principal,
+  type RunContext,
+  type ToolRegistry,
+} from "@vendoai/core";
+import { createGuard } from "@vendoai/guard";
+import { createStore } from "@vendoai/store";
+import { describe, expect, it } from "vitest";
+
+const principal: Principal = { kind: "user", subject: "u_owner" };
+const ctx: RunContext = { principal, venue: "automation", presence: "present", sessionId: "sess_check" };
+const APP = "app_digest";
+
+/** Two triggers, one step each: the one the person arms, and a sibling nobody
+ *  armed — the control that keeps the assertion below from being vacuous. */
+const doc: AppDocument = {
+  format: VENDO_APP_FORMAT,
+  id: APP,
+  name: "Invoice digest",
+  triggers: ["nightly", "weekly"].map((id) => ({
+    id,
+    on: { kind: "host-event" as const, event: "go" },
+    run: { kind: "steps" as const, steps: [{ id: "read", tool: "invoices_list" }] },
+  })),
+};
+
+describe("a grant armed through agents is the grant automations reads", () => {
+  it("leaves the armed trigger nothing missing, and the sibling everything", async () => {
+    const store = createStore({ dataDir: "memory://vendo-arming-one-scheme" });
+    const guard = createGuard({ store });
+    const invoicesList = tool({
+      name: "invoices_list",
+      description: "List invoices",
+      risk: "read",
+      inputSchema: { type: "object" },
+      execute: () => ({ invoices: 2 }),
+    });
+    const registry: ToolRegistry = {
+      descriptors: async () => [invoicesList.descriptor],
+      execute: async (call, runCtx) =>
+        ({ status: "ok", output: await invoicesList.execute(call.args, runCtx, call) }),
+    };
+    // The host's own boot order: the engine first, then the agent — so the
+    // engine's decision subscriber is the one that sees the yes first.
+    const engine = createAutomations({
+      apps: {} as unknown as AppsRuntime,
+      guard,
+      store,
+      tools: guard.bind(registry),
+    });
+    const support = agent({ name: "support", store, guard, tools: [invoicesList] });
+
+    // THE WRITE PATH: the person arms one trigger and says yes.
+    const { pending } = await support.arm(principal.subject, { appId: APP, triggerId: "nightly" });
+    await guard.approvals.decide(pending, { approve: true }, principal);
+
+    // THE READ PATH: the engine's own preview, over the same store and the same
+    // guard binding over the same tool the ceremony asked about.
+    await store.records("vendo_apps").put({
+      id: APP,
+      data: { subject: principal.subject, enabled: true, doc },
+      refs: { subject: principal.subject },
+    });
+
+    expect(await engine.dryRun(APP, "nightly", ctx)).toEqual({
+      steps: [{ id: "read", tool: "invoices_list", wouldAsk: false }],
+      grantsMissing: [],
+    });
+    expect(await engine.dryRun(APP, "weekly", ctx)).toEqual({
+      steps: [{ id: "read", tool: "invoices_list", wouldAsk: true }],
+      grantsMissing: ["invoices_list"],
+    });
+  });
+});


### PR DESCRIPTION
Stacked on #1273.

`agent.arm(subject, { appId, triggerId?, tools? })` raises one approval per wanted tool. On approve, guard mints a standing `source:"automation"` grant bound to (subject, appId, triggerId). `run({ identity: { appId, triggerId? } })` carries that identity into the existing `RunContext` fields, so an armed run proceeds unattended instead of parking.

**Identity is a lookup key, not a credential.** It authenticates nothing. Subject binding is enforced by the guard, not assumed: `#matchingGrant` scopes the query by `ctx.principal.subject` and re-checks `grant.subject`, so a run for B cannot use A's grant (verified adversarially).

**Acceptance:** an agents-minted grant is returned unmodified by automations' `liveAutomationGrants(subject, appId, triggerId)` — one scheme. `packages/vendo/tests/arming-one-scheme.test.ts` proves it as a real seam: real write path, real read path, no stub on either side.

## Stated limit

The raised asks live in this process's memory until answered. A restart between raising an ask and deciding it loses the mint, and the person re-arms. Persisting it would mean a new reserved collection — out of scope.

## ⚠️ An adversarial check round found a critical defect. It is fixed. Read this part.

`createAutomations()` and `arm()` both subscribe `onApprovalDecision`, and both claimed any approved `venue:"automation"` approval carrying an `appId`. Whichever subscriber **registered first** won the approval's one-time `consumed` transition. In the ordinary boot order (engine before agent) automations won — and it derives the trigger from the run row named by `ctx.trigger.runId`, a row `arm()` never wrote. So `triggerId` came out `undefined` and the grant was minted **app-wide**:

- the armed trigger held **nothing** — every armed run parked forever while `arm()` reported success;
- unarmed trigger `main` held **standing unattended authority nobody consented to**.

**Fix:** `arm()` writes a capture row keyed by the approval id, which the existing automations subscriber already reads as its first branch, so the correct `triggerId` is used. Entirely inside `packages/agents/src/` — `consent.ts` and `engine.ts` are untouched.

**Ordering-independence is tested, not claimed.** `packages/vendo/tests/arming-collision.test.ts` runs an automations capture ask and an arming ask raised and decided in the same process, each asserted to be claimed only by its own listener, plus the reverse — under **both** subscriber registration orders. 4/4 green, identical in both.

Revert-to-red on that test reddens the engine-first ordering only. That is correct rather than weak: pre-fix, the agent-first ordering already produced the right grant, so there is no observable difference to assert there. That asymmetry *is* the ordering dependence the fix removes.

Two further findings from the same round, also fixed: `held` omitted the presence-only tools (`vendo_apps_pin`/`unpin`, which the guard refuses away by name), and `held` read the tool's *authored* risk rather than the grade this deployment's `resolveRisk` actually applies. Both meant carding a person for a tool that could never run and minting a grant dead on arrival.

Our own acceptance test was also rearranged: it had been constructing the automations engine *after* the decision — the single ordering that hides the collision. It now boots the engine first and still passes.

## Hard law

`presenceMatches` and the away downgrade in `packages/guard/src/guard.ts` are **byte-identical to main** (SHA-256 compared). This commit touches zero guard source and zero automations source — only `packages/agents/src/{agent,arming,away,index}.ts` and tests.

## Two things for the owner to decide separately (not addressed here)

1. **An armed grant also authorizes attended calls.** `presenceMatches`' present branch is `grant.appId === undefined || grant.appId === ctx.appId` — it ignores `source` and `triggerId`. Pre-existing and byte-identical to main, but arming is the first feature that lets a plain `agent()` mint such grants, so it widens the blast radius. Any fix is inside the frozen `presenceMatches`.
2. **A `no` on an arm() ask now also reaches automations' disarm-on-bare-no branch** for that (app, trigger) — a side effect of the capture row. Scoped to that trigger and guarded by "nothing else pending and no live grant", so it reads as correct (a no disarms what it said no to), but it is new behavior the arming door did not have before.

## Gates

`pnpm build` 0 · `pnpm --filter @vendoai/agents --filter @vendoai/vendo typecheck` 0 · `pnpm lint` 0 · agents 66/66 · vendo `arming-binding` + `arming-one-scheme` + `arming-collision` 8/8.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `agent.arm()` to raise away approvals and mint standing automation grants bound to (subject, appId, triggerId), and makes `run({ identity })` execute against those grants. Previously, unattended runs parked and a boot-order race could mint app‑wide grants; now armed runs proceed and minting is trigger‑correct and registration‑order independent.

- API:
  - `agent.arm(subject, { appId, triggerId?, tools? })` raises one approval per reachable tool; tools withheld from unattended or presence‑only are returned in `held` and never asked. On approve, the guard spends the approval and mints a standing `source:"automation"` grant scoped to the trigger. Asks are tracked in‑process memory; a restart loses them.
  - `run({ identity: { appId, triggerId? } })` carries identity into `RunContext` (or uses `agent({ identity })` as default). Identity is a lookup key only; it authenticates nothing.
  - A capture row (`automations:captures`) keyed by approval id ensures the automations subscriber uses the correct trigger; this removes the engine/agent ordering race.
- Safety and rollout:
  - Guard enforces subject binding; a run for B cannot use A’s grant. A “no” on an arming ask also reaches automations’ disarm‑on‑bare‑no for that trigger. Existing `presenceMatches` means armed grants also match attended calls.
  - Required action: callers that want unattended runs must pass `identity` to `run()` or configure `agent({ identity })`.
  - No schema migration. Depends on guard `spendApproval`/`mintGrant`; code feature‑detects and fails closed if absent. Only `@vendoai/agents` is changed.

<sup>Written for commit 85fb1b53f41ef6d9aeff1bf7e0a9bc60ec6747d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

