### PR TITLE
fix(core,vendo): the text channel's drawers are on the engine allowlist

### DIFF
--- a/.changeset/channel-collections-engine-allowlist.md
+++ b/.changeset/channel-collections-engine-allowlist.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/core": patch
+---
+
+The text channel's three collections join the engine allowlist. `vendo_channel_links`, `vendo_channel_asks` and `vendo_channel_events` were never added to `ENGINE_COLLECTIONS`, so a deployment on a Cloud-hosted store — the posture a Cloud host gets by leaving the store slot unset — had its first channel write refused with `collection "vendo_channel_links" is not an engine collection`, which left the link route, the status and unlink doors, and every inbound text answering 403 on a live deployment while the suite stayed green: every channel test composes a local store, and a local store has no allowlist in front of it. The names are added with the `file:line` comment each entry in that list carries, `ENGINE_ALLOWLIST_VERSION` moves to 2 as that constant's contract requires, and a new seam test drives the channel repositories through `hostedStore` and the fake console — which serves the same gate as the live door precisely so a fake cannot bless a collection production refuses.

--- a/packages/core/src/engine-collections.ts
+++ b/packages/core/src/engine-collections.ts
@@ -3,7 +3,7 @@ import { VendoError } from "./errors.js";
 /** Named in every refusal so a caller can tell "this name was never an engine
     collection" from "this build's list is older than yours". Bump it whenever
     ENGINE_COLLECTIONS or ENGINE_COLLECTION_PATTERNS changes. */
-export const ENGINE_ALLOWLIST_VERSION = 1;
+export const ENGINE_ALLOWLIST_VERSION = 2;
 
 /** The collections the `engine` op family may touch: Vendo's OWN internal
     drawers, nothing a host or a generated app owns. The list lives in core
@@ -60,6 +60,9 @@ export const ENGINE_COLLECTIONS = [
   "automations:sponsored", // SPONSORED, packages/automations/src/sponsorship.ts:29
   "guard:controls", // CONTROLS_COLLECTION, packages/guard/src/guard.ts:117 — host-level config, see above
   "guard:approval-claims", // APPROVAL_CLAIMS_COLLECTION, packages/guard/src/guard.ts:111
+  "vendo_channel_links", // LINK_COLLECTION, packages/vendo/src/channel-links.ts:22
+  "vendo_channel_events", // EVENT_COLLECTION, packages/vendo/src/channel-links.ts:25
+  "vendo_channel_asks", // ASK_COLLECTION, packages/vendo/src/channel-links.ts:33
 ] as const;
 
 export type EngineCollection = typeof ENGINE_COLLECTIONS[number];

--- a/packages/core/tests/engine-collections.test.ts
+++ b/packages/core/tests/engine-collections.test.ts
@@ -27,10 +27,10 @@ function messageOf(run: () => unknown): string {
 }
 
 describe("engine allowlist", () => {
-  it("holds 35 distinct static collections", () => {
-    expect(ENGINE_ALLOWLIST_VERSION).toBe(1);
-    expect(ENGINE_COLLECTIONS).toHaveLength(35);
-    expect(new Set(ENGINE_COLLECTIONS).size).toBe(35);
+  it("holds 38 distinct static collections", () => {
+    expect(ENGINE_ALLOWLIST_VERSION).toBe(2);
+    expect(ENGINE_COLLECTIONS).toHaveLength(38);
+    expect(new Set(ENGINE_COLLECTIONS).size).toBe(38);
   });
 
   it("admits one name from each group and refuses host/app data", () => {
@@ -69,7 +69,10 @@ describe("engine allowlist", () => {
   it("refuses an unknown name, naming the version and the right door", () => {
     expect(codeOf(() => assertEngineCollection("users"))).toBe("blocked");
     const message = messageOf(() => assertEngineCollection("users"));
-    expect(message).toContain("v1");
+    // Against the constant, like the conformance suite's own check
+    // (conformance/store-ops.ts:241): the point is that the refusal names THIS
+    // build's list, so a bump does not turn into a test edit every time.
+    expect(message).toContain(`v${ENGINE_ALLOWLIST_VERSION}`);
     expect(message).toContain("appData");
     // "users" is not a typo of anything here, so it collects no guess.
     expect(message).not.toContain("did you mean");

--- a/packages/vendo/tests/channel-hosted-store.test.ts
+++ b/packages/vendo/tests/channel-hosted-store.test.ts
@@ -1,0 +1,68 @@
+import type { ApprovalId } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { ChannelAskRepository, ChannelEventLog, ChannelLinkRepository } from "../src/channel-links.js";
+import { hostedStore } from "../src/hosted-store.js";
+import { fakeConsole } from "../src/hosted-store.test-util.js";
+
+/**
+ * The channel's rows against the HOSTED door — the seam that actually ships.
+ *
+ * WHY THIS FILE EXISTS: every other channel test composes a local store, and a
+ * local store has no engine allowlist in front of it. The hosted door does
+ * (`engine-collections.ts`), and a Cloud host leaves the store slot unset, so
+ * hosted is the posture the feature runs in. The channel shipped with its three
+ * collections missing from that list: the suite was green, and the first write on
+ * the live deployment answered
+ *   403 collection "vendo_channel_links" is not an engine collection
+ * which made link, status, unlink and every inbound text dead on arrival.
+ *
+ * So these cases exercise the repositories through `hostedStore`, whose fake
+ * console serves the same gate the live door serves — deliberately, per the note
+ * at `hosted-store.test-util.ts`: a fake that answers a collection the real door
+ * refuses lets a wrong call pass every test and fail in production. Add a
+ * collection to this feature and it must appear both in `channel-links.ts` and in
+ * `ENGINE_COLLECTIONS`, or this file goes red.
+ */
+
+const hosted = () => hostedStore({
+  apiKey: "vnd_secret",
+  baseUrl: "https://cloud.test",
+  fetch: fakeConsole().handler as unknown as typeof fetch,
+});
+
+const APPROVAL = "apr_33333333-3333-3333-3333-333333333333" as ApprovalId;
+
+describe("the text channel on a Cloud-hosted store", () => {
+  it("mints and claims a link through the engine door", async () => {
+    const links = new ChannelLinkRepository(hosted());
+
+    const minted = await links.mint("user_hosted");
+    expect(minted.code).toMatch(/^[23456789A-Z]{6}$/);
+
+    const claimed = await links.claim(minted.code!, "+15557770123");
+    expect(claimed?.subject).toBe("user_hosted");
+    // Read back through the door the inbound text uses.
+    expect((await links.byPhone("+15557770123"))?.subject).toBe("user_hosted");
+    expect((await links.bySubject("user_hosted"))?.phone).toBe("+15557770123");
+
+    await links.unlink("user_hosted");
+    expect(await links.byPhone("+15557770123")).toBeNull();
+  });
+
+  it("records and spends an answerable card through the engine door", async () => {
+    const asks = new ChannelAskRepository(hosted());
+
+    await asks.add("user_hosted", "conv_hosted", APPROVAL);
+    expect(await asks.ids("conv_hosted")).toEqual([APPROVAL]);
+
+    await asks.consume(APPROVAL);
+    expect(await asks.ids("conv_hosted")).toEqual([]);
+  });
+
+  it("claims a delivery through the engine door", async () => {
+    const log = new ChannelEventLog(hosted());
+
+    expect(await log.claim("evt_hosted", "conv_hosted")).toBe(true);
+    expect(await log.claim("evt_hosted", "conv_hosted")).toBe(false);
+  });
+});


### PR DESCRIPTION
The text channel merged in #1268 is **dead on any Cloud-hosted store**, which is the store a Cloud host gets by leaving the slot unset. Its three collections were never added to `ENGINE_COLLECTIONS`, so the first write is refused:

```
$ curl -i https://maple-bank-production.up.railway.app/maple/api/vendo/channels/text/link
HTTP/2 403
{"error":{"code":"blocked","message":"collection \"vendo_channel_links\" is not an engine
 collection (engine allowlist v1). App data belongs to the appData family (ops.appData.*)…"}}
```

Link, status, unlink and every inbound text answer 403 on the live deployment. Nobody can mint a link code, so nothing downstream of linking exists yet.

## Why 2427 tests and 20 green checks missed it

Every channel test composes a **local** store, and a local store has no allowlist in front of it (`packages/store/src/store.ts:65`). The hosted door does. This is the producer/consumer seam `CLAUDE.md` warns about: the feature was only ever exercised against the posture it does not ship in.

## The fix

- The three names join `ENGINE_COLLECTIONS` with the `file:line` comment every other entry carries (`packages/core/src/engine-collections.ts`), and `ENGINE_ALLOWLIST_VERSION` moves 1 → 2, which that constant’s own doc comment requires on any list change.
- **The test whose absence let this ship**: `packages/vendo/tests/channel-hosted-store.test.ts` drives `ChannelLinkRepository`, `ChannelAskRepository` and `ChannelEventLog` through `hostedStore` and the fake console — which serves the real gate deliberately, per the note in `hosted-store.test-util.ts`, because "a fake that answers a collection the live door refuses lets a wrong call pass every test and fail in production". That is exactly what happened.

Red-then-green: with the allowlist entries reverted, the new file fails with the production error verbatim (`… is not an engine collection (engine allowlist v1)`) on all three collections; with them, 3/3 green.

## Test edits, stated rather than smuggled

`packages/core/tests/engine-collections.test.ts` pins the count and the version on purpose: 35 → 38 and v1 → v2. Its refusal-message assertion now reads `ENGINE_ALLOWLIST_VERSION` instead of a literal `"v1"`, matching what `conformance/store-ops.ts:241` already does, so the next bump is not another test edit. Nothing else in any test was touched.

## What this does NOT reach

**Vendo Cloud.** The console enforces this list from its own published `@vendoai/core` (`apps/console/package.json` pins `0.16.0`) and holds no allowlist source of its own, so the Cloud side needs a release and a dep bump — not a pull request. Flagged for a decision; this PR is the deployment/OSS half.

Local gate green on the touched scope: `pnpm build` 33/33, `pnpm test:affected` 45/45 tasks (`@vendoai/store` 568 tests, `@vendoai/vendo` 2430), `pnpm typecheck` 42/42, `pnpm lint` 0 errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the text channel’s three drawers to the engine allowlist and bumps the allowlist version so Cloud‑hosted stores accept link, status, unlink, and inbound text writes. Previously these writes returned 403 because the collections were missing; with the updated `@vendoai/core`, they pass.

**What changed**
- Add `vendo_channel_links`, `vendo_channel_events`, and `vendo_channel_asks` to `ENGINE_COLLECTIONS`; bump `ENGINE_ALLOWLIST_VERSION` from 1 to 2.
- Add `packages/vendo/tests/channel-hosted-store.test.ts` to exercise the repositories via `hostedStore` and the real gate; it fails if the drawers aren’t allowlisted.
- Update `engine-collections` test to assert the new count (38) and to read the version from the constant in refusal messages.

**Rollout**
- Release a new `@vendoai/core` and bump `apps/console` to that version (currently pinned to `0.16.0`) to fix Vendo Cloud.
- No migrations or config changes required; the text channel works on Cloud after the dep bump.

<sup>Written for commit 781c604c31dc8e7949230892c14c5fb4808da7de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

