### PR TITLE
perf(store): indexable cursorMs + hot-list indexes + createStoreForDb seam

### DIFF
--- a/packages/store/src/helpers/utils.ts
+++ b/packages/store/src/helpers/utils.ts
@@ -27,7 +27,10 @@ export function text(value: unknown): string {
  *  its ORDER BY route BOTH the column and the cursor parameter through this
  *  same truncated expression. */
 export function cursorMs(expr: string): string {
-  return `date_trunc('milliseconds', ${expr})`;
+  // 3-arg form is IMMUTABLE and indexable; 2-arg reads the TimeZone GUC and Postgres rejects it in
+  // an index expression. Millisecond truncation is timezone-invariant — verified equal under
+  // Asia/Kolkata, America/St_Johns, Pacific/Chatham.
+  return `date_trunc('milliseconds', ${expr}, 'UTC')`;
 }
 
 export function encodeCursor(date: IsoDateTime, id: string): string {

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -3,6 +3,10 @@
  *  keep the PGlite wasm engine out of the bundle graph. */
 export { createStore } from "./create-store.js";
 export { maybeDbFor, type VendoStore } from "./store.js";
+// The Db seam: a host that already holds a connection (a pooler, an open
+// transaction) builds the store over it instead of handing us a url.
+export { createStoreForDb } from "./store.js";
+export type { Db, Query } from "./db-postgres.js";
 // Composed state, read off the engine handle `maybeDbFor` returns: the data dir
 // this store writes to when a redeploy wipes it. The deployment that composed
 // the store is what tells its operator (createVendo's boot block).

--- a/packages/store/src/postgres.ts
+++ b/packages/store/src/postgres.ts
@@ -35,6 +35,8 @@ export function createStore(config: PostgresStoreConfig): VendoStore {
 // main entry exports (keep this list in lockstep with index.ts).
 export { createStoreOps } from "./ops.js";
 export { maybeDbFor } from "./store.js";
+export { createStoreForDb } from "./store.js";
+export type { Db, Query } from "./db-postgres.js";
 export {
   appDataFiles,
   appDataRows,

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -293,6 +293,27 @@ const ADDITIVE_DDL = [
   // booted before its CREATE was removed. The version gate would never re-run the
   // DDL loop on those databases, so the drop lives here and runs every boot.
   "DROP TABLE IF EXISTS vendo_sessions",
+  // The routed lists sort by the truncated cursor expression (helpers/utils.ts cursorMs),
+  // so a plain (created_at, id) index cannot serve them — the sort key is an expression.
+  // These match it exactly, in both the unfiltered and the ref-filtered shape, which turns
+  // every hot list from a seq scan + sort into a top-N index scan. They live here rather
+  // than in DDL because ADDITIVE_DDL runs on every ensureSchema: behind a version bump
+  // they would never reach a database already at the current version.
+  // vendo_state's created_at and id are ALTERed in above, so these must stay after them.
+  "CREATE INDEX IF NOT EXISTS vendo_threads_created_idx    ON vendo_threads    (date_trunc('milliseconds', created_at, 'UTC') DESC, id DESC)",
+  "CREATE INDEX IF NOT EXISTS vendo_apps_created_idx       ON vendo_apps       (date_trunc('milliseconds', created_at, 'UTC') DESC, id DESC)",
+  "CREATE INDEX IF NOT EXISTS vendo_runs_started_idx       ON vendo_runs       (date_trunc('milliseconds', started_at, 'UTC') DESC, id DESC)",
+  "CREATE INDEX IF NOT EXISTS vendo_approvals_created_idx  ON vendo_approvals  (date_trunc('milliseconds', created_at, 'UTC') DESC, id DESC)",
+  "CREATE INDEX IF NOT EXISTS vendo_grants_granted_idx     ON vendo_grants     (date_trunc('milliseconds', granted_at, 'UTC') DESC, id DESC)",
+  "CREATE INDEX IF NOT EXISTS vendo_state_created_idx      ON vendo_state      (date_trunc('milliseconds', created_at, 'UTC') DESC, id DESC)",
+  "CREATE INDEX IF NOT EXISTS vendo_app_grants_created_idx ON vendo_app_grants (date_trunc('milliseconds', created_at, 'UTC') DESC, id DESC)",
+  "CREATE INDEX IF NOT EXISTS vendo_effects_at_idx         ON vendo_effects    (date_trunc('milliseconds', at, 'UTC') DESC, key DESC)",
+  "CREATE INDEX IF NOT EXISTS vendo_threads_subject_created_idx   ON vendo_threads   (subject, date_trunc('milliseconds', created_at, 'UTC') DESC, id DESC)",
+  "CREATE INDEX IF NOT EXISTS vendo_runs_status_started_idx       ON vendo_runs      (status,  date_trunc('milliseconds', started_at, 'UTC') DESC, id DESC)",
+  "CREATE INDEX IF NOT EXISTS vendo_approvals_status_created_idx  ON vendo_approvals (status,  date_trunc('milliseconds', created_at, 'UTC') DESC, id DESC)",
+  "CREATE INDEX IF NOT EXISTS vendo_state_subject_created_idx     ON vendo_state     (subject, date_trunc('milliseconds', created_at, 'UTC') DESC, id DESC)",
+  "CREATE INDEX IF NOT EXISTS vendo_audit_app_at_idx              ON vendo_audit     (app_id,  date_trunc('milliseconds', at, 'UTC') DESC, id DESC)",
+  "CREATE INDEX IF NOT EXISTS vendo_grants_app_granted_idx        ON vendo_grants    (app_id,  date_trunc('milliseconds', granted_at, 'UTC') DESC, id DESC)",
 ] as const;
 
 // v2 backfill (runs once, only when upgrading from a version < 2 — 02 §4 keys

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -53,9 +53,14 @@ export function secretsConfigFor(store: VendoStore): Pick<StoreInternals, "encry
   return internals.get(store) ?? { encryptionKey: undefined, allowPlaintextSecrets: false };
 }
 
-/** 02-store §1 — assemble a VendoStore over an already-picked Db engine.
- *  Package-internal: the public `createStore` fronts live in
- *  ./create-store.ts and ./postgres.ts. */
+/** 02-store §1 — assemble a VendoStore over an already-picked Db engine. The
+ *  composition rung under the zero-config `createStore` fronts (./create-store.ts,
+ *  ./postgres.ts), for hosts that own their connection: a pooler-backed handle, a
+ *  transaction-scoped one, a Db spread over another (`{ ...db, query }`).
+ *  Two things the caller now owns: `store.close()` closes the Db it was given, and
+ *  `withSchemaLock` is the caller's to implement — a handle that cannot hold a
+ *  session-scoped lock must THROW there rather than no-op, or two concurrent
+ *  migrators both run the schema's data-moving backfills. */
 export function createStoreForDb(
   db: Db,
   config: Pick<StoreConfig, "encryption" | "allowUnencryptedSecrets"> = {},

--- a/packages/store/tests/postgres-entry.surface.test.ts
+++ b/packages/store/tests/postgres-entry.surface.test.ts
@@ -1,6 +1,8 @@
 import { expect, it } from "vitest";
 import * as mainEntry from "../src/index.js";
 import * as postgresEntry from "../src/postgres.js";
+import type { Db as MainDb, Query as MainQuery } from "../src/index.js";
+import type { Db as PostgresDb, Query as PostgresQuery } from "../src/postgres.js";
 
 // Separate file from postgres-entry.test.ts on purpose: importing the main
 // entry legitimately loads PGlite, which that file's tripwire mock forbids.
@@ -9,3 +11,16 @@ it("./postgres mirrors the main entry's engine-agnostic surface", () => {
     expect(postgresEntry, `main-entry export "${name}" missing from ./postgres`).toHaveProperty(name);
   }
 });
+
+// The parity check above only reads the MAIN entry's keys, so a ./postgres-only
+// export slips past it. The Db seam is the console's whole entry point into this
+// package — pin it on both entries by name.
+it("exports the Db seam from both entries", () => {
+  expect(mainEntry.createStoreForDb).toBeTypeOf("function");
+  expect(postgresEntry.createStoreForDb).toBeTypeOf("function");
+});
+
+// Type-only exports never appear in Object.keys, so no runtime check can see them.
+// These aliases are the pin: dropping Db or Query from either entry fails typecheck.
+export type PinnedDb = [MainDb, PostgresDb];
+export type PinnedQuery = [MainQuery, PostgresQuery];

--- a/packages/store/tests/schema.indexes.test.ts
+++ b/packages/store/tests/schema.indexes.test.ts
@@ -1,0 +1,131 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createStore, createStoreForDb, maybeDbFor, threadStore, type Db, type VendoStore } from "../src/index.js";
+import { persistentPrincipal } from "../src/fixtures.test-util.js";
+import { cursorMs } from "../src/helpers/utils.js";
+
+// The hot lists order by `date_trunc('milliseconds', <col>, 'UTC') DESC, id DESC`
+// (helpers/utils.ts cursorMs). The 2-arg form of that call reads the TimeZone GUC,
+// so Postgres refuses it in an index expression and every routed list degrades to a
+// seq scan + sort; the 3-arg 'UTC' form is IMMUTABLE, which is what makes the
+// ADDITIVE_DDL indexes below creatable at all. This suite proves both halves on a
+// real engine: the DDL is accepted, and the planner actually picks the index for
+// the exact SQL the read path emits.
+//
+// HONESTY NOTES:
+// - 1000 rows is the smallest count at which the planner flips for ALL THREE shapes
+//   on PGlite (PostgreSQL 18.3). Measured: the unfiltered and cursor pages flip at
+//   ~100 rows, the subject-filtered composite is still seq-scanning at 500 and only
+//   settles onto the index from 600 up. The blueprint's 200k-row measurement is real
+//   Postgres; seeding that through the real put path here is not practical.
+// - `ANALYZE` is required and is not a thumb on the scale: without stats a fresh
+//   table reads as empty to the planner. Production gets the same stats from
+//   autovacuum. Nothing here disables seq scans.
+const ROWS = 1000;
+const SUBJECTS = 5;
+
+/** The scan node(s) the plan uses for the listed table, one line each. */
+function scanNodes(plan: string, table: string): string[] {
+  return plan.split("\n").filter((line) => new RegExp(`Scan.* on ${table}\\b`).test(line)).map((line) => line.trim());
+}
+
+describe("hot-list indexes ride the routed read path", () => {
+  let dataDir: string;
+  let base: VendoStore;
+  let db: Db;
+  let store: VendoStore;
+  let lastQuery: { text: string; params: unknown[] } | undefined;
+
+  beforeAll(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), "vendo-store-indexes-"));
+    base = createStore({ dataDir });
+    const engine = maybeDbFor(base);
+    if (engine === undefined) throw new Error("expected a PGlite-backed store");
+    db = engine;
+    // The seam this slice exports: a Db handed straight to createStoreForDb. Here it
+    // is the real engine wrapped to record the exact SQL the read path emits, so the
+    // EXPLAINs below run the query under test rather than a hand-written lookalike.
+    store = createStoreForDb({
+      ...db,
+      async query(text: string, params: unknown[] = []) {
+        lastQuery = { text, params };
+        return await db.query(text, params);
+      },
+    });
+    await store.ensureSchema();
+    const threads = threadStore(store);
+    for (let i = 0; i < ROWS; i += 1) {
+      await threads.put(
+        { ...persistentPrincipal, subject: `sub_${i % SUBJECTS}` },
+        { id: `thr_${String(i).padStart(5, "0")}`, messages: [] },
+      );
+    }
+    await db.query("ANALYZE vendo_threads");
+  });
+
+  afterAll(async () => {
+    await base.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+
+  /** EXPLAIN the SQL the read path just emitted, verbatim. */
+  async function planOfLastQuery(): Promise<string> {
+    if (lastQuery === undefined) throw new Error("no query recorded");
+    const result = await db.query(`EXPLAIN ${lastQuery.text}`, lastQuery.params);
+    return result.rows.map((row) => String(row["QUERY PLAN"])).join("\n");
+  }
+
+  it("accepts the expression cursorMs emits in an index — it is IMMUTABLE", async () => {
+    // The coupling the whole slice rests on: the indexes below are only reachable
+    // while the read path's own sort expression is indexable. Postgres refuses the
+    // 2-arg form here with "functions in index expression must be marked IMMUTABLE".
+    // On a scratch table, so the probe index can never enter a plan under test.
+    await db.query("CREATE TABLE cursorms_probe (id text PRIMARY KEY, created_at timestamptz NOT NULL)");
+    await expect(db.query(
+      `CREATE INDEX cursorms_probe_idx ON cursorms_probe (${cursorMs("created_at")} DESC, id DESC)`,
+    )).resolves.toBeDefined();
+  });
+
+  it("creates every hot-list index", async () => {
+    const result = await db.query(
+      "SELECT indexname FROM pg_indexes WHERE schemaname = current_schema() AND indexname = ANY($1::text[])",
+      [[
+        "vendo_threads_created_idx", "vendo_apps_created_idx", "vendo_runs_started_idx",
+        "vendo_approvals_created_idx", "vendo_grants_granted_idx", "vendo_state_created_idx",
+        "vendo_app_grants_created_idx", "vendo_effects_at_idx", "vendo_threads_subject_created_idx",
+        "vendo_runs_status_started_idx", "vendo_approvals_status_created_idx",
+        "vendo_state_subject_created_idx", "vendo_audit_app_at_idx", "vendo_grants_app_granted_idx",
+      ]],
+    );
+    expect(result.rows).toHaveLength(14);
+  });
+
+  it("serves the unfiltered first page from vendo_threads_created_idx", async () => {
+    const page = await store.records("vendo_threads").list({ limit: 100 });
+    expect(page.records).toHaveLength(100);
+    const plan = await planOfLastQuery();
+    expect(scanNodes(plan, "vendo_threads").join("\n")).toContain("Index Scan using vendo_threads_created_idx");
+    expect(plan).not.toContain("Seq Scan on vendo_threads");
+  });
+
+  it("serves a cursor page from vendo_threads_created_idx", async () => {
+    const first = await store.records("vendo_threads").list({ limit: 100 });
+    expect(first.cursor).toBeDefined();
+    const next = await store.records("vendo_threads").list({ limit: 100, cursor: first.cursor as string });
+    expect(next.records).toHaveLength(100);
+    expect(next.records[0]?.id).not.toEqual(first.records[0]?.id);
+    const plan = await planOfLastQuery();
+    expect(scanNodes(plan, "vendo_threads").join("\n")).toContain("Index Scan using vendo_threads_created_idx");
+    expect(plan).not.toContain("Seq Scan on vendo_threads");
+  });
+
+  it("serves a subject-filtered page from the composite vendo_threads_subject_created_idx", async () => {
+    const page = await store.records("vendo_threads").list({ limit: 100, refs: { subject: "sub_1" } });
+    expect(page.records).toHaveLength(100);
+    const plan = await planOfLastQuery();
+    expect(scanNodes(plan, "vendo_threads").join("\n")).toContain("Index Scan using vendo_threads_subject_created_idx");
+    expect(plan).not.toContain("Seq Scan on vendo_threads");
+  });
+});


### PR DESCRIPTION
## What changed

1. **`cursorMs` → 3-arg `date_trunc('milliseconds', X, 'UTC')`** (`packages/store/src/helpers/utils.ts`). The 2-arg form reads the TimeZone GUC, so it is not IMMUTABLE and Postgres **refuses it in an index expression**. Millisecond truncation is timezone-invariant, so the emitted values are unchanged.
2. **14 hot-list expression indexes** added to `ADDITIVE_DDL` (`packages/store/src/schema.ts`) — threads, apps, runs, approvals, grants, state, app_grants, effects, plus the ref-filtered composites. Indexes that already exist (`vendo_grants (subject, tool)`, `vendo_audit (subject, at)`/`(at)`, `vendo_runs (app_id, started_at)`, the vendo_apps trigger-kind pair) are **not** re-added.
3. **The Db seam is now public**: `createStoreForDb` + `Db` + `Query`, exported from **both** `@vendoai/store` and `@vendoai/store/postgres`.

## Why

Every routed list ordered by the truncated cursor expression. No index could match that expression, so every hot list was a **parallel seq scan + sort**. This is the read-side half of the datastore latency work.

`ADDITIVE_DDL` (not `DDL`) is load-bearing: it runs on **every** `ensureSchema` regardless of stored schema version. Behind a version bump these indexes would never reach a database already at the current version — every existing tenant would be stranded. **The schema version is deliberately not bumped.**

## Measured evidence

New seam test `packages/store/tests/schema.indexes.test.ts`: real PGlite (**PostgreSQL 18.3**), `ensureSchema`, 1000 threads seeded **through the real put path** (`threadStore.put` → `putThreadRow`), listed **through the real read path** (`store.records("vendo_threads").list`), then `EXPLAIN` on the **exact SQL the read path emitted** (captured by wrapping the Db — which is itself the newly exported seam).

`EXPLAIN (ANALYZE, BUFFERS)`, same 1000-row table:

| shape | before (2-arg) | after (3-arg + index) |
|---|---|---|
| index DDL | **rejected**: `functions in index expression must be marked IMMUTABLE` | accepted |
| unfiltered first page | `Seq Scan on vendo_threads` — **1000 rows** examined, 6.07 ms | `Index Scan using vendo_threads_created_idx` — **101 rows**, 2.99 ms |
| subject-filtered page | `Seq Scan on vendo_threads` — 200 rows, 3.69 ms | `Index Scan using vendo_threads_subject_created_idx` — **101 rows**, 2.56 ms |

**Honesty notes**, also recorded in the test file:
- 1000 rows is the smallest count at which the planner flips for all three shapes on PGlite. The unfiltered and cursor pages flip at ~100 rows; the subject-filtered composite is still seq-scanning at 500 and settles from ~600 up. The blueprint's 21 ms → 0.03 ms figure is real Postgres at 200k rows — not reachable here through the real put path, so the honest structural claim is **rows examined 1000 → 101**, which is what scales.
- The test calls `ANALYZE`. That is required, not a thumb on the scale: without stats a fresh table reads as empty to the planner, and production gets the same stats from autovacuum. **Nothing disables seq scans anywhere in this PR.**

**Prove-it-can-fail:** reverting `cursorMs` to the 2-arg form turns 4 of the 5 new tests red — the IMMUTABLE probe fails with Postgres's own `functions in index expression must be marked IMMUTABLE`, and all three plan assertions fall back to `Seq Scan` / `Bitmap Heap Scan`.

## The new public export

`createStoreForDb` was package-internal by design (its own doc comment said so), so this is **new public API, not a re-export**. It went through the **vendo-dx** skill, which changed three things:
- **Export from both entries**, not just `./postgres` as originally specced — `Db` is engine-agnostic and the type export is fully erased, so the main entry should not be missing a capability `./postgres` has. (The portability gate confirms `./postgres` stays PGlite-free.)
- **Rewrite the doc comment.** Leaving a "Package-internal" label on a public export is a lie the next reader has to discover. It now states the rung and the two things the caller owns: `store.close()` closes the Db *they* passed, and `withSchemaLock` is theirs to implement — a handle that cannot hold a session-scoped lock must **throw**, not no-op, or two concurrent migrators both run the schema's data-moving backfills.
- **Pin both sides deliberately.** `postgres-entry.surface.test.ts` asserts parity *one-directionally* (it iterates the main entry's keys), and `Object.keys` never sees type-only exports — so it could not have caught either half. Added a named runtime pin for `createStoreForDb` on both entries and type-level pins for `Db`/`Query`.

## Gate

| command | verdict |
|---|---|
| `npx vitest run` — schema.indexes, postgres-entry.surface, keyset-precision, schema, routing, conformance, ops.conformance | **7 files / 132 tests passed** |
| `pnpm build` | 21/21 successful |
| `pnpm typecheck` | 42/42 successful |
| `pnpm lint` | dependency-guard OK · portability-gate ok (incl. store postgres entry stays PGlite-free) · eslint 0 errors |
| `pnpm test:affected` | 32/33 tasks green — `@vendoai/store` 54 files / 574 tests, `@vendoai/vendo` 211 files / 2427 tests |

The one red task is `@vendoai/genbench`, and it is **environmental, not this diff**: every failure in it roots in `browserType.launch: Executable doesn't exist at ~/.cache/ms-playwright/...` — Playwright browsers are not installed on this machine. genbench does not touch `packages/store`. The PR's green `ci` check is the gate of record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Indexes routed lists and exposes a `Db` seam. The cursor expression now uses `date_trunc('milliseconds', expr, 'UTC')` so indexes can match it; hot lists move from seq scan + sort to top-N index scans without changing emitted values.

- Replaces the 2-arg `date_trunc` in `cursorMs` with the 3-arg UTC form (IMMUTABLE). Old: not indexable, planner scanned and sorted. New: indexable; values are identical because millisecond truncation is timezone-invariant.
- Adds 14 expression indexes in `ADDITIVE_DDL` for threads, apps, runs, approvals, grants, state, app_grants, effects, and ref-filtered composites. Skips indexes that already exist. No schema version bump; `ensureSchema` creates them everywhere.
- Exports the `Db` seam: `createStoreForDb` plus `Db`/`Query` types from both `@vendoai/store` and `@vendoai/store/postgres`. Hosts can build the store over an existing connection or transaction.

**Rollout/Migration**
- No action for existing callers; run `ensureSchema` to create indexes.
- If you adopt `createStoreForDb`:
  - `store.close()` will close the `Db` instance you pass.
  - You must implement `withSchemaLock`; throw if your handle cannot hold a session-scoped lock.

<sup>Written for commit 554ccd39d48152f620edd347b5172d40c97c8db4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

