### PR TITLE
perf(store,core,vendo): transcripts.appendMessages — append without downloading the thread

### DIFF
--- a/packages/core/src/conformance/store-ops.ts
+++ b/packages/core/src/conformance/store-ops.ts
@@ -1,7 +1,7 @@
 import { ENGINE_ALLOWLIST_VERSION, engineAppHistory } from "../engine-collections.js";
 import type { VendoErrorCode } from "../errors.js";
 import { isoDateTimeSchema } from "../ids.js";
-import { VENDO_STORE_WIRE_FORMAT } from "../store-wire.js";
+import { STORE_WIRE_APPEND_MESSAGES_OPS, VENDO_STORE_WIRE_FORMAT } from "../store-wire.js";
 import type { StoreOps } from "../store.js";
 import { assert, assertBytesEqual, assertDeepEqual } from "./assertions.js";
 import type { ConformanceCase, ConformanceSuite } from "./index.js";
@@ -1103,6 +1103,37 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         await assertThrowsCode(() => ops.lifecycle.promote("app_absent", "org_1"), "not-found", "promoting an unknown app");
       }),
 
+      /** The batch append: ownership is the caller's `subject`, so the mount
+          checks it in its own statement and the client never downloads the
+          thread to check it first. Optional — a mount that omits it is served
+          by putMessage, and this case says so instead of failing it. */
+      opsCase(opts, "transcripts.appendMessages lands a batch under the named subject", async (ops) => {
+        const append = ops.transcripts.appendMessages;
+        if (append === undefined) return;
+        await ops.transcripts.putThread({ id: "thr_am1", subject: "u", messages: [] });
+        const landed = await append("thr_am1", "u", [
+          { id: "msg_a", role: "user", text: "one" },
+          { id: "msg_b", role: "assistant", text: "two" },
+        ], { title: "one" });
+        assert(landed.count === 2, `appendMessages should report 2 rows, got ${landed.count}`);
+        assert(typeof landed.revision === "string", "appendMessages should report the thread's new revision");
+        // The answer is the revision and the count — NOT the thread. Echoing the
+        // transcript back is the payload this op exists to stop paying.
+        assertDeepEqual(Object.keys(landed).sort(), ["count", "revision"], "appendMessages answered with more than {revision, count}");
+
+        const got = await ops.transcripts.getThread("thr_am1");
+        const messages = (got!.data as Record<string, unknown>)["messages"] as unknown[];
+        assert(messages.length === 2, `appendMessages did not land both messages: got ${messages.length}`);
+
+        // A foreign subject is refused by the statement, not by a pre-check.
+        await ops.transcripts.putThread({ id: "thr_am2", subject: "owner", messages: [] });
+        await assertThrowsCode(
+          () => append("thr_am2", "someone_else", [{ id: "msg_x", role: "user", text: "not mine" }]),
+          "conflict",
+          "appending to another subject's thread",
+        );
+      }),
+
       // =====================================================================
       // status
       // =====================================================================
@@ -1111,7 +1142,14 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         const status = await ops.status();
         assert(status.format === VENDO_STORE_WIRE_FORMAT, `status.format should be ${VENDO_STORE_WIRE_FORMAT}`);
         assert(typeof status.ops === "number", "status.ops should be a number");
-        assert(status.ops === 35, `status.ops should be 35, got ${status.ops}`);
+        // The count is the handshake's ONLY capability signal, so it must track
+        // what the mount actually serves — a client feature-detects the batch
+        // append on exactly this number (STORE_WIRE_APPEND_MESSAGES_OPS). A
+        // mount that omits the optional op is the 35-op vintage and says so.
+        const expected = ops.transcripts.appendMessages === undefined
+          ? STORE_WIRE_APPEND_MESSAGES_OPS - 1
+          : STORE_WIRE_APPEND_MESSAGES_OPS;
+        assert(status.ops === expected, `status.ops should be ${expected}, got ${status.ops}`);
       }),
     ],
   };

--- a/packages/core/src/store-wire.ts
+++ b/packages/core/src/store-wire.ts
@@ -39,12 +39,13 @@ export const STORE_WIRE_PATHS = {
   "appData.getFile": "/app-data/getFile",
   "appData.listFiles": "/app-data/listFiles",
   "appData.deleteFile": "/app-data/deleteFile",
-  // transcripts (6)
+  // transcripts (7)
   "transcripts.putThread": "/transcripts/putThread",
   "transcripts.getThread": "/transcripts/getThread",
   "transcripts.listThreads": "/transcripts/listThreads",
   "transcripts.deleteThread": "/transcripts/deleteThread",
   "transcripts.putMessage": "/transcripts/putMessage",
+  "transcripts.appendMessages": "/transcripts/appendMessages",
   "transcripts.recordAnswer": "/transcripts/recordAnswer",
   // harness (3)
   "harness.get": "/harness/get",
@@ -243,6 +244,35 @@ export const storeWireTranscriptsPutMessageRequestSchema = z.object({
   threadId: z.string().min(1),
   message: z.unknown(),
 }).passthrough();
+
+/** Append a batch of messages to a thread the CALLER names the owner of, so the
+    service can enforce ownership in its own statement instead of handing the
+    client a whole thread to check first. The answer is `{revision, count}` and
+    deliberately NOT the thread: returning it would put the entire conversation
+    back on the wire on every turn, which is the cost this op exists to remove. */
+export const storeWireTranscriptsAppendMessagesRequestSchema = z.object({
+  threadId: z.string().min(1),
+  subject: z.string().min(1),
+  messages: z.array(z.unknown()).min(1),
+  title: z.string().optional(),
+}).passthrough();
+
+export interface StoreWireAppendMessagesResult {
+  revision: string;
+  count: number;
+}
+
+/** The op count a mount must report on `/status` before a client may send
+    `transcripts.appendMessages` — the 36th op, and the first one a shipped
+    client has to feature-detect. The wire has no capability list and needs
+    none: `/status` is already the discovery handshake, and the count only ever
+    grows. FROZEN at the count this op shipped with; never
+    `Object.keys(STORE_WIRE_PATHS).length`, which would start refusing the op
+    the day a 37th is added. Detect once, cache, and route to the older
+    getThread + putMessage path when the mount is behind — never send it blind
+    and read the 501 as a fallback signal (#1251: a failed mutation is not a
+    capability answer). */
+export const STORE_WIRE_APPEND_MESSAGES_OPS = 36;
 
 export const storeWireTranscriptsRecordAnswerRequestSchema = z.object({
   threadId: z.string().min(1),

--- a/packages/core/src/store-wire.ts
+++ b/packages/core/src/store-wire.ts
@@ -265,13 +265,25 @@ export interface StoreWireAppendMessagesResult {
 /** The op count a mount must report on `/status` before a client may send
     `transcripts.appendMessages` — the 36th op, and the first one a shipped
     client has to feature-detect. The wire has no capability list and needs
-    none: `/status` is already the discovery handshake, and the count only ever
-    grows. FROZEN at the count this op shipped with; never
-    `Object.keys(STORE_WIRE_PATHS).length`, which would start refusing the op
-    the day a 37th is added. Detect once, cache, and route to the older
-    getThread + putMessage path when the mount is behind — never send it blind
-    and read the 501 as a fallback signal (#1251: a failed mutation is not a
-    capability answer). */
+    none: `/status` is already the discovery handshake, and the count is its
+    only signal. Compared with `>=`, and FROZEN at the count this op shipped
+    with — `===` would refuse the op the day a 37th is added, pinning every
+    client on the slow path forever with nothing to see; and
+    `Object.keys(STORE_WIRE_PATHS).length` would do the same from the client's
+    side.
+
+    ⚠ ADDING OP 37? READ THIS. The count is a PROXY for capability, and it
+    holds only while ops are ONLY EVER ADDED. Remove one while adding another
+    and the count still reaches 36 on a mount that no longer serves this op —
+    the client then believes it is supported, sends it, and takes the loud 501
+    this whole mechanism exists to avoid. That is not hypothetical: console
+    #468 ("restore the `records.*` store wire deleted by #456") is a production
+    incident from exactly that shape. Deleting a wire op means retiring this
+    constant, not renumbering it.
+
+    Detect once, cache, and route to the older getThread + putMessage path when
+    the mount is behind — never send it blind and read the 501 as a fallback
+    signal (#1251: a failed mutation is not a capability answer). */
 export const STORE_WIRE_APPEND_MESSAGES_OPS = 36;
 
 export const storeWireTranscriptsRecordAnswerRequestSchema = z.object({

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -88,7 +88,7 @@ export interface StoreAdapter {
 }
 
 // ---------------------------------------------------------------------------
-// StoreOps — the named-operation contract for the 35-op / 8-family store.
+// StoreOps — the named-operation contract for the 36-op / 8-family store.
 // Both the local backend (store/ops.ts) and the cloud client
 // (hosted-store.ts) implement this interface.
 // ---------------------------------------------------------------------------
@@ -127,7 +127,7 @@ export type EraseTarget =
   | { subject: string; appId?: never }
   | { appId: string; subject?: never };
 
-/** The typed contract for all 35 store operations across 8 families.
+/** The typed contract for all 36 store operations across 8 families.
     Lean by design — this is the CONTRACT interface, not the implementation. */
 export interface StoreOps {
   /** Vendo's OWN engine data — grants, approvals, audit, threads, runs, apps,
@@ -169,6 +169,25 @@ export interface StoreOps {
     listThreads(query?: { subject?: string; cursor?: string; limit?: number }): Promise<{ records: VendoRecord[]; cursor?: string }>;
     deleteThread(id: string): Promise<void>;
     putMessage(threadId: string, message: unknown): Promise<VendoRecord>;
+    /** Land a batch of messages on a thread this subject owns, in one call.
+        `putMessage` cannot express ownership, so a client had to download the
+        WHOLE thread first just to read `data.subject` — a payload that grows
+        with the conversation, paid several times per turn. Naming the subject
+        here moves that check into the service's own statement, and the answer
+        is the thread's new revision and the number of rows written, never the
+        thread itself.
+
+        OPTIONAL for the same reason `RecordStore.claim` and `atomic` are:
+        an implementation that cannot serve it says so by omitting it, and a
+        caller that finds it absent takes the getThread + putMessage route. Over
+        the wire the equivalent question is the `/status` op count — see
+        STORE_WIRE_APPEND_MESSAGES_OPS. */
+    appendMessages?(
+      threadId: string,
+      subject: string,
+      messages: unknown[],
+      opts?: { title?: string },
+    ): Promise<{ revision: string; count: number }>;
     recordAnswer(threadId: string, answer: unknown): Promise<VendoRecord>;
   };
   harness: {

--- a/packages/core/tests/store-wire.test.ts
+++ b/packages/core/tests/store-wire.test.ts
@@ -32,6 +32,7 @@ import {
   storeWireTranscriptsListThreadsRequestSchema,
   storeWireTranscriptsDeleteThreadRequestSchema,
   storeWireTranscriptsPutMessageRequestSchema,
+  storeWireTranscriptsAppendMessagesRequestSchema,
   storeWireTranscriptsRecordAnswerRequestSchema,
   storeWireHarnessGetRequestSchema,
   storeWireHarnessSetRequestSchema,
@@ -47,10 +48,10 @@ import {
 } from "../src/index.js";
 
 describe("vendo/store-wire@1", () => {
-  it("exposes the format constant and 35 mount-relative paths", () => {
+  it("exposes the format constant and 36 mount-relative paths", () => {
     expect(VENDO_STORE_WIRE_FORMAT).toBe("vendo/store-wire@1");
-    // 8 families: engine(7) + blobs(4) + appData(8) + transcripts(6) + harness(3) + workspace(4) + lifecycle(2) + status(1) = 35
-    expect(Object.keys(STORE_WIRE_PATHS)).toHaveLength(35);
+    // 8 families: engine(7) + blobs(4) + appData(8) + transcripts(7) + harness(3) + workspace(4) + lifecycle(2) + status(1) = 36
+    expect(Object.keys(STORE_WIRE_PATHS)).toHaveLength(36);
     expect(STORE_WIRE_PATHS.status).toBe("/status");
     expect(STORE_WIRE_PATHS["engine.get"]).toBe("/engine/get");
     expect(STORE_WIRE_PATHS["engine.compareAndSwap"]).toBe("/engine/compareAndSwap");
@@ -204,6 +205,18 @@ describe("vendo/store-wire@1", () => {
     expect(storeWireTranscriptsDeleteThreadRequestSchema.parse({ id: "t1" }).id).toBe("t1");
     expect(storeWireTranscriptsPutMessageRequestSchema.parse({ threadId: "t1", message: { role: "user", content: "test" } }).threadId).toBe("t1");
     expect(storeWireTranscriptsRecordAnswerRequestSchema.parse({ threadId: "t1", answer: { text: "done" } }).threadId).toBe("t1");
+
+    expect(storeWireTranscriptsAppendMessagesRequestSchema.parse({
+      threadId: "t1", subject: "sub_user1", messages: [{ id: "m1" }], title: "Hi",
+    }).subject).toBe("sub_user1");
+    // The subject IS the ownership check on this op — a body without one would
+    // ask the service to append to whichever thread holds the id.
+    expect(storeWireTranscriptsAppendMessagesRequestSchema.safeParse({
+      threadId: "t1", messages: [{ id: "m1" }],
+    }).success).toBe(false);
+    expect(storeWireTranscriptsAppendMessagesRequestSchema.safeParse({
+      threadId: "t1", subject: "sub_user1", messages: [],
+    }).success).toBe(false);
   });
 
   it("parses harness request DTOs", () => {

--- a/packages/harnesses/src/runtime.ts
+++ b/packages/harnesses/src/runtime.ts
@@ -79,6 +79,14 @@ function deepFreeze<T>(value: T): T {
 export interface TranscriptStore {
   /** One row per message; per-row CAS on `revision` for edits. */
   upsert(principal: Principal, threadId: ThreadId, message: UIMessage, seq: number): Promise<void>;
+  /** The whole turn's changed messages in ONE call. Optional the way every
+   *  capability in this codebase is optional: a store that cannot batch omits
+   *  it and the per-message loop below still runs. */
+  upsertMany?(
+    principal: Principal,
+    threadId: ThreadId,
+    entries: ReadonlyArray<{ message: UIMessage; seq: number }>,
+  ): Promise<void>;
   /** Reassembled by seq, oldest → newest. */
   list(principal: Principal, threadId: ThreadId): Promise<UIMessage[]>;
 }
@@ -737,14 +745,21 @@ async function persistTurn(
   const unchanged = new Map(
     (before ?? []).map((message) => [message.id, JSON.stringify(message)]),
   );
-  // ENG-309: a store blip must not cost the turn. Each attempt re-walks the
-  // whole diff — `upsert` is per-row and idempotent for an unchanged row, so a
-  // partial first pass costs a repeat write, never a corrupted thread.
+  const changed = [...messages.entries()]
+    .filter(([, message]) => unchanged.get(message.id) !== JSON.stringify(message))
+    .map(([seq, message]) => ({ message, seq }));
+  if (changed.length === 0) return;
+  // ENG-309: a store blip must not cost the turn. Each attempt re-sends the
+  // whole diff — the write is idempotent for an unchanged row, so a partial
+  // first pass costs a repeat write, never a corrupted thread.
   for (let attempt = 0; ; attempt += 1) {
     try {
-      for (const [seq, message] of messages.entries()) {
-        if (unchanged.get(message.id) === JSON.stringify(message)) continue;
-        await transcript.upsert(input.ctx.principal, input.threadId, message, seq);
+      if (transcript.upsertMany !== undefined) {
+        await transcript.upsertMany(input.ctx.principal, input.threadId, changed);
+      } else {
+        for (const { message, seq } of changed) {
+          await transcript.upsert(input.ctx.principal, input.threadId, message, seq);
+        }
       }
       return;
     } catch (error) {

--- a/packages/harnesses/src/runtime.ts
+++ b/packages/harnesses/src/runtime.ts
@@ -79,13 +79,14 @@ function deepFreeze<T>(value: T): T {
 export interface TranscriptStore {
   /** One row per message; per-row CAS on `revision` for edits. */
   upsert(principal: Principal, threadId: ThreadId, message: UIMessage, seq: number): Promise<void>;
-  /** The whole turn's changed messages in ONE call. Optional the way every
+  /** The whole turn's changed messages in ONE call, in array order — the store
+   *  assigns positions itself, under the row it writes. Optional the way every
    *  capability in this codebase is optional: a store that cannot batch omits
    *  it and the per-message loop below still runs. */
   upsertMany?(
     principal: Principal,
     threadId: ThreadId,
-    entries: ReadonlyArray<{ message: UIMessage; seq: number }>,
+    messages: ReadonlyArray<UIMessage>,
   ): Promise<void>;
   /** Reassembled by seq, oldest → newest. */
   list(principal: Principal, threadId: ThreadId): Promise<UIMessage[]>;
@@ -755,7 +756,7 @@ async function persistTurn(
   for (let attempt = 0; ; attempt += 1) {
     try {
       if (transcript.upsertMany !== undefined) {
-        await transcript.upsertMany(input.ctx.principal, input.threadId, changed);
+        await transcript.upsertMany(input.ctx.principal, input.threadId, changed.map(({ message }) => message));
       } else {
         for (const { message, seq } of changed) {
           await transcript.upsert(input.ctx.principal, input.threadId, message, seq);

--- a/packages/store/src/helpers/rows.ts
+++ b/packages/store/src/helpers/rows.ts
@@ -140,6 +140,88 @@ export async function replaceThreadMessages(
   );
 }
 
+/** Append (or edit) a batch of messages on a thread this subject owns, without
+ *  reading the transcript first — the one-statement ownership the hosted path
+ *  never had (the read-then-write TOCTOU named at helpers/thread-messages.ts).
+ *
+ *  Two statements, both set-based, and the CALLER runs them in one transaction:
+ *  1. create-or-touch the thread row, guarded on the subject exactly as
+ *     putThreadRow's upsert is — an empty RETURNING means a foreign row holds
+ *     the id, and the whole append is refused before a message row exists;
+ *  2. one multi-row insert for the messages.
+ *  Statement 1 leaves the thread row write-locked for the rest of the
+ *  transaction, so statement 2 needs neither the ownership join nor the
+ *  `FOR KEY SHARE OF t` its single-row sibling carries: a concurrent
+ *  `deleteThread` cascade cannot slip between them and leave orphan rows.
+ *
+ *  `seq` is NOT updated on conflict. An append names where NEW messages go; a
+ *  message the thread already holds has a decided position, and moving it would
+ *  reorder the conversation the next turn reads. It is also the only rule the
+ *  wire half can honor — a wire body carries no seq — so both halves of
+ *  `upsertMany` share this statement's semantics exactly. */
+export async function appendThreadMessages(
+  db: Db,
+  input: {
+    threadId: string;
+    subject: string;
+    messages: ReadonlyArray<{ id: string; seq: number; message: unknown }>;
+    title?: string;
+  },
+  now = new Date().toISOString(),
+): Promise<{ revision: string; count: number }> {
+  // ON CONFLICT cannot be given the same key twice in one statement (a bare
+  // 21000 that loses the whole write), so the same guard putThreadRow applies
+  // to a transcript applies to a batch — with the offender named.
+  const seen = new Set<string>();
+  for (const { id } of input.messages) {
+    if (seen.has(id)) {
+      throw new VendoError(
+        "validation",
+        `thread ${input.threadId} carries two messages with the id ${JSON.stringify(id)}; message ids must be unique within a thread`,
+      );
+    }
+    seen.add(id);
+  }
+  // A title rides along when the caller derived one; it must never CLEAR the
+  // stored title, which is why this is a COALESCE and putThreadRow's is not
+  // (that call owns the whole row and always carries the title it wants).
+  const touched = await db.query(
+    `INSERT INTO vendo_threads (id, subject, title, created_at, updated_at, revision)
+     VALUES ($1, $2, $3, $4, $4, 1)
+     ON CONFLICT (id) DO UPDATE
+       SET title = COALESCE(EXCLUDED.title, vendo_threads.title),
+           updated_at = EXCLUDED.updated_at,
+           revision = vendo_threads.revision + 1
+       WHERE vendo_threads.subject = EXCLUDED.subject
+     RETURNING revision`,
+    [input.threadId, input.subject, input.title ?? null, now],
+  );
+  const row = touched.rows[0];
+  if (row === undefined) {
+    throw new VendoError("conflict", `thread ${input.threadId} belongs to another subject`);
+  }
+  if (input.messages.length === 0) return { revision: String(row["revision"]), count: 0 };
+  const landed = await db.query(
+    `INSERT INTO vendo_thread_messages (thread_id, id, seq, message, created_at, updated_at)
+     SELECT $1, m.id, m.seq, a.elem, $5, $5
+     FROM unnest($2::text[], $3::integer[]) WITH ORDINALITY AS m(id, seq, n)
+     JOIN jsonb_array_elements($4::jsonb) WITH ORDINALITY AS a(elem, ordinality)
+       ON a.ordinality = m.n
+     ON CONFLICT (thread_id, id) DO UPDATE
+       SET message = EXCLUDED.message, updated_at = EXCLUDED.updated_at,
+           revision = vendo_thread_messages.revision + 1
+     RETURNING id`,
+    [
+      input.threadId,
+      input.messages.map((entry) => entry.id),
+      input.messages.map((entry) => entry.seq),
+      JSON.stringify(input.messages.map((entry) => entry.message)),
+      now,
+    ],
+  );
+  return { revision: String(row["revision"]), count: landed.rows.length };
+}
+
 export function threadFromRow(row: Record<string, unknown>): ThreadRow {
   const title = row["title"];
   const revision = row["revision"];

--- a/packages/store/src/helpers/rows.ts
+++ b/packages/store/src/helpers/rows.ts
@@ -154,17 +154,28 @@ export async function replaceThreadMessages(
  *  `FOR KEY SHARE OF t` its single-row sibling carries: a concurrent
  *  `deleteThread` cascade cannot slip between them and leave orphan rows.
  *
+ *  `seq` is assigned HERE, by statement 2, and never by the caller — the fix
+ *  for a real race (proven on PostgreSQL 17: 40 concurrent appends, 21 distinct
+ *  seqs). `seq` carries conversation order and has no unique constraint, so two
+ *  turns landing on the same number make the transcript fall back to ordering
+ *  by message id, which is not turn order. Any `max(seq) + 1` read taken BEFORE
+ *  the thread row is held is read by both racers under READ COMMITTED and hands
+ *  them the same answer. Statement 1 above is what serialises them: the loser
+ *  blocks there (on the row lock, or on the primary key when both are creating
+ *  the thread) until the winner COMMITs, so statement 2's subquery — a new
+ *  snapshot in READ COMMITTED — already sees the winner's rows.
+ *
  *  `seq` is NOT updated on conflict. An append names where NEW messages go; a
  *  message the thread already holds has a decided position, and moving it would
- *  reorder the conversation the next turn reads. It is also the only rule the
- *  wire half can honor — a wire body carries no seq — so both halves of
- *  `upsertMany` share this statement's semantics exactly. */
+ *  reorder the conversation the next turn reads. New rows land after the tail in
+ *  batch order, which is the only rule the wire half can honor anyway — a wire
+ *  body carries no seq — so both halves of `upsertMany` share this exactly. */
 export async function appendThreadMessages(
   db: Db,
   input: {
     threadId: string;
     subject: string;
-    messages: ReadonlyArray<{ id: string; seq: number; message: unknown }>;
+    messages: ReadonlyArray<{ id: string; message: unknown }>;
     title?: string;
   },
   now = new Date().toISOString(),
@@ -203,10 +214,12 @@ export async function appendThreadMessages(
   if (input.messages.length === 0) return { revision: String(row["revision"]), count: 0 };
   const landed = await db.query(
     `INSERT INTO vendo_thread_messages (thread_id, id, seq, message, created_at, updated_at)
-     SELECT $1, m.id, m.seq, a.elem, $5, $5
-     FROM unnest($2::text[], $3::integer[]) WITH ORDINALITY AS m(id, seq, n)
-     JOIN jsonb_array_elements($4::jsonb) WITH ORDINALITY AS a(elem, ordinality)
+     SELECT $1, m.id, tail.next + m.n - 1, a.elem, $4, $4
+     FROM unnest($2::text[]) WITH ORDINALITY AS m(id, n)
+     JOIN jsonb_array_elements($3::jsonb) WITH ORDINALITY AS a(elem, ordinality)
        ON a.ordinality = m.n
+     CROSS JOIN (SELECT COALESCE(max(seq) + 1, 0) AS next
+                 FROM vendo_thread_messages WHERE thread_id = $1) tail
      ON CONFLICT (thread_id, id) DO UPDATE
        SET message = EXCLUDED.message, updated_at = EXCLUDED.updated_at,
            revision = vendo_thread_messages.revision + 1
@@ -214,7 +227,6 @@ export async function appendThreadMessages(
     [
       input.threadId,
       input.messages.map((entry) => entry.id),
-      input.messages.map((entry) => entry.seq),
       JSON.stringify(input.messages.map((entry) => entry.message)),
       now,
     ],

--- a/packages/store/src/helpers/thread-messages.ts
+++ b/packages/store/src/helpers/thread-messages.ts
@@ -1,7 +1,8 @@
-import { VendoError, type Principal, type StoreOps, type ThreadId } from "@vendoai/core";
+import { STORE_WIRE_APPEND_MESSAGES_OPS, VendoError, type Principal, type StoreOps, type ThreadId } from "@vendoai/core";
 import type { Db } from "../db-postgres.js";
 import type { VendoStore } from "../store.js";
 import { backendOf } from "./backend.js";
+import { appendThreadMessages } from "./rows.js";
 
 /** The least a transcript row must have for this store to key it: an id.
  *
@@ -30,8 +31,47 @@ export interface ThreadMessageStore<M extends ThreadMessageLike = ThreadMessageL
     seq: number,
     opts?: { expectedRevision?: number },
   ): Promise<void>;
+  /** A whole turn's new-or-edited messages in ONE round trip, with `title` the
+   *  listing title the caller derived. What `upsert` does per message — and,
+   *  over the wire, per message plus a full thread download — this does once.
+   *  A message the thread already holds is updated in place and keeps its
+   *  position; only genuinely new ones are appended. */
+  upsertMany(
+    principal: Principal,
+    threadId: ThreadId,
+    entries: ReadonlyArray<{ message: M; seq: number }>,
+    opts?: { title?: string },
+  ): Promise<void>;
   /** Reassembled by seq, oldest → newest. */
   list(principal: Principal, threadId: ThreadId): Promise<M[]>;
+}
+
+/** One answer per StoreOps handle — i.e. once per process for the one hosted
+ *  client a deployment builds — to "does this mount serve
+ *  `transcripts.appendMessages`?". Weakly held so a per-request store handle
+ *  cannot pin its client forever. */
+const appendSupport = new WeakMap<StoreOps, Promise<boolean>>();
+
+/**
+ * The capability question, asked EXPLICITLY and answered before any write.
+ *
+ * `/status` is the wire's own discovery handshake, and the op count is the only
+ * signal it carries; a mount reporting fewer than
+ * STORE_WIRE_APPEND_MESSAGES_OPS predates the op. The shape is the one
+ * `guard.previewCheck` uses (detect the capability, then choose a supported
+ * route), and deliberately NOT a `catch` around a failed mutation: reading a
+ * 501 as "fall back" is how a half-applied write gets retried down a second
+ * path (#1251). A handshake that fails is not an answer — it is not cached and
+ * it does not degrade; the write fails and the caller's retry asks again.
+ */
+async function servesAppendMessages(ops: StoreOps): Promise<boolean> {
+  let answer = appendSupport.get(ops);
+  if (answer === undefined) {
+    answer = ops.status().then((status) => status.ops >= STORE_WIRE_APPEND_MESSAGES_OPS);
+    answer.catch(() => appendSupport.delete(ops));
+    appendSupport.set(ops, answer);
+  }
+  return await answer;
 }
 
 function requireMessageId(message: ThreadMessageLike): string {
@@ -76,6 +116,9 @@ export function threadMessageStore<M extends ThreadMessageLike = ThreadMessageLi
  * - **Ownership is read-then-write**, not one statement. The TOCTOU window that
  *   opens is between two writes by the same subject to a thread whose owner
  *   would have to change mid-call, which the store has no verb for.
+ *   `upsertMany` DOES have that verb (`transcripts.appendMessages` names the
+ *   subject), so it closes both the window and the download — on a mount new
+ *   enough to serve it.
  */
 function overOps<M extends ThreadMessageLike>(ops: StoreOps): ThreadMessageStore<M> {
   /** The thread record is the ownership record on the wire exactly as the
@@ -110,6 +153,34 @@ function overOps<M extends ThreadMessageLike>(ops: StoreOps): ThreadMessageStore
         throw new VendoError("conflict", `thread ${threadId} does not belong to this subject`);
       }
       await ops.transcripts.putMessage(threadId, message);
+    },
+    async upsertMany(principal, threadId, entries, opts) {
+      if (entries.length === 0) return;
+      for (const entry of entries) requireMessageId(entry.message);
+      const append = ops.transcripts.appendMessages;
+      if (append !== undefined && await servesAppendMessages(ops)) {
+        await append(
+          threadId,
+          principal.subject,
+          entries.map((entry) => entry.message),
+          { ...(opts?.title === undefined ? {} : { title: opts.title }) },
+        );
+        return;
+      }
+      // The mount predates the op. This is the ROUTE the feature detect chose
+      // up front, not a rescue after a failed write: one ownership read, then
+      // the per-message writes this helper has always made. The title is the
+      // only thing it cannot carry (no wire verb sets it without rewriting the
+      // whole thread), and it is derived from the first user message, which the
+      // thread's creating write already stored. It also refuses a thread that
+      // does not exist yet, where the op would create it — the harness persists
+      // the row before any turn appends, so nothing rides on the difference.
+      if (await ownedThread(principal, threadId) === undefined) {
+        throw new VendoError("conflict", `thread ${threadId} does not belong to this subject`);
+      }
+      for (const entry of entries) {
+        await ops.transcripts.putMessage(threadId, entry.message);
+      }
     },
     async list(principal, threadId) {
       const data = await ownedThread(principal, threadId);
@@ -191,6 +262,24 @@ function overSql<M extends ThreadMessageLike>(db: Db): ThreadMessageStore<M> {
       // Owned, no expectation, still nothing written — the statement should have
       // landed, so surface it rather than pretending it did.
       throw new VendoError("conflict", `could not write message ${JSON.stringify(messageId)} to thread ${threadId}`);
+    },
+    async upsertMany(principal, threadId, entries, opts) {
+      if (entries.length === 0) return;
+      // The SAME statements the hosted half reaches through the wire op, on the
+      // same rows: ownership is the thread upsert's guard, and the batch lands
+      // in one transaction with it.
+      await db.transaction(async (query) => {
+        await appendThreadMessages({ ...db, query }, {
+          threadId,
+          subject: principal.subject,
+          messages: entries.map((entry) => ({
+            id: requireMessageId(entry.message),
+            seq: entry.seq,
+            message: entry.message,
+          })),
+          ...(opts?.title === undefined ? {} : { title: opts.title }),
+        });
+      });
     },
     async list(principal, threadId) {
       const result = await db.query(

--- a/packages/store/src/helpers/thread-messages.ts
+++ b/packages/store/src/helpers/thread-messages.ts
@@ -35,11 +35,17 @@ export interface ThreadMessageStore<M extends ThreadMessageLike = ThreadMessageL
    *  listing title the caller derived. What `upsert` does per message — and,
    *  over the wire, per message plus a full thread download — this does once.
    *  A message the thread already holds is updated in place and keeps its
-   *  position; only genuinely new ones are appended. */
+   *  position; genuinely new ones are appended after the tail, in the order
+   *  given.
+   *
+   *  Unlike `upsert`, this takes NO `seq`: a caller computing a position
+   *  outside the write cannot avoid racing another turn on the same thread for
+   *  it (proven on PostgreSQL 17), so the position is the statement's to assign
+   *  while it holds the thread row. */
   upsertMany(
     principal: Principal,
     threadId: ThreadId,
-    entries: ReadonlyArray<{ message: M; seq: number }>,
+    messages: ReadonlyArray<M>,
     opts?: { title?: string },
   ): Promise<void>;
   /** Reassembled by seq, oldest → newest. */
@@ -154,15 +160,15 @@ function overOps<M extends ThreadMessageLike>(ops: StoreOps): ThreadMessageStore
       }
       await ops.transcripts.putMessage(threadId, message);
     },
-    async upsertMany(principal, threadId, entries, opts) {
-      if (entries.length === 0) return;
-      for (const entry of entries) requireMessageId(entry.message);
+    async upsertMany(principal, threadId, messages, opts) {
+      if (messages.length === 0) return;
+      for (const message of messages) requireMessageId(message);
       const append = ops.transcripts.appendMessages;
       if (append !== undefined && await servesAppendMessages(ops)) {
         await append(
           threadId,
           principal.subject,
-          entries.map((entry) => entry.message),
+          [...messages],
           { ...(opts?.title === undefined ? {} : { title: opts.title }) },
         );
         return;
@@ -178,8 +184,8 @@ function overOps<M extends ThreadMessageLike>(ops: StoreOps): ThreadMessageStore
       if (await ownedThread(principal, threadId) === undefined) {
         throw new VendoError("conflict", `thread ${threadId} does not belong to this subject`);
       }
-      for (const entry of entries) {
-        await ops.transcripts.putMessage(threadId, entry.message);
+      for (const message of messages) {
+        await ops.transcripts.putMessage(threadId, message);
       }
     },
     async list(principal, threadId) {
@@ -263,8 +269,8 @@ function overSql<M extends ThreadMessageLike>(db: Db): ThreadMessageStore<M> {
       // landed, so surface it rather than pretending it did.
       throw new VendoError("conflict", `could not write message ${JSON.stringify(messageId)} to thread ${threadId}`);
     },
-    async upsertMany(principal, threadId, entries, opts) {
-      if (entries.length === 0) return;
+    async upsertMany(principal, threadId, messages, opts) {
+      if (messages.length === 0) return;
       // The SAME statements the hosted half reaches through the wire op, on the
       // same rows: ownership is the thread upsert's guard, and the batch lands
       // in one transaction with it.
@@ -272,11 +278,7 @@ function overSql<M extends ThreadMessageLike>(db: Db): ThreadMessageStore<M> {
         await appendThreadMessages({ ...db, query }, {
           threadId,
           subject: principal.subject,
-          messages: entries.map((entry) => ({
-            id: requireMessageId(entry.message),
-            seq: entry.seq,
-            message: entry.message,
-          })),
+          messages: messages.map((message) => ({ id: requireMessageId(message), message })),
           ...(opts?.title === undefined ? {} : { title: opts.title }),
         });
       });

--- a/packages/store/src/ops.ts
+++ b/packages/store/src/ops.ts
@@ -14,7 +14,7 @@ import type { Db, Query } from "./db.js";
 import { eraseStore } from "./erase.js";
 import { storeFiles, storeFilesForDb } from "./files-store.js";
 import { harnessStateKey } from "./harness-state.js";
-import { putStateRow, putThreadRow, THREAD_MESSAGES_AGGREGATE, threadFromRow } from "./helpers/rows.js";
+import { appendThreadMessages, putStateRow, putThreadRow, THREAD_MESSAGES_AGGREGATE, threadFromRow } from "./helpers/rows.js";
 import { iso, jsonParam, pageLimit, text } from "./helpers/utils.js";
 import { createRecordStore } from "./records.js";
 import { createReservedRecordStore, threadRecord } from "./routing.js";
@@ -102,7 +102,7 @@ const decoder = new TextDecoder();
 
 /**
  * 02-store — the LOCAL backend of the StoreOps named-operation contract
- * (core/store.ts): the 35 ops served straight off this store's own Postgres,
+ * (core/store.ts): the 36 ops served straight off this store's own Postgres,
  * through the EXISTING helpers — routing doors, thread rows, workspace rows, the
  * erase cascade. Logic unchanged; what this layer adds is the atomic scope:
  * every multi-statement verb runs inside ONE
@@ -355,6 +355,36 @@ export function createStoreOps(
           const record = await readThread(txDb(q), threadId);
           if (record === null) throw new VendoError("not-found", `thread ${threadId} not found`);
           return record;
+        });
+      },
+      /** The batch append (design 4a): ownership is the caller's `subject`, so
+       *  no thread download precedes the write, and the answer is the thread's
+       *  new revision plus the row count — never the transcript. */
+      async appendMessages(threadId, subject, messages, opts) {
+        const rowIdOf = (message: unknown): string => {
+          const given = (message as { id?: unknown } | null)?.id;
+          return typeof given === "string" && given !== "" ? given : `msg_${globalThis.crypto.randomUUID()}`;
+        };
+        return await db.transaction(async (q) => {
+          // The wire carries no seq (the same honest gap putMessage has), so
+          // new rows land after the thread's current tail. An id the thread
+          // already holds keeps its own seq — appendThreadMessages does not
+          // move it.
+          const tail = await q(
+            "SELECT COALESCE(max(seq) + 1, 0) AS next FROM vendo_thread_messages WHERE thread_id = $1",
+            [threadId],
+          );
+          const next = Number(tail.rows[0]?.["next"] ?? 0);
+          return await appendThreadMessages(txDb(q), {
+            threadId,
+            subject,
+            messages: messages.map((message, index) => ({
+              id: rowIdOf(message),
+              seq: next + index,
+              message,
+            })),
+            ...(opts?.title === undefined ? {} : { title: opts.title }),
+          });
         });
       },
       /** Deliberately non-idempotent: a duplicate answer id is refused loudly —
@@ -679,7 +709,7 @@ export function createStoreOps(
     },
 
     async status() {
-      return { format: VENDO_STORE_WIRE_FORMAT, ops: 35 };
+      return { format: VENDO_STORE_WIRE_FORMAT, ops: 36 };
     },
   };
 }

--- a/packages/store/src/ops.ts
+++ b/packages/store/src/ops.ts
@@ -180,7 +180,23 @@ export function createStoreOps(
     return result.rows[0] !== undefined;
   };
 
-  /** Every message write is a thread write (same token discipline as the doors). */
+  /** Every message write is a thread write (same token discipline as the doors)
+   *  — and it is also how every message write TAKES THE THREAD ROW.
+   *
+   *  Call it BEFORE allocating a position, never after. `seq` has no unique
+   *  constraint, so two writers landing on one number leave the transcript
+   *  ordering by message id instead of by turn (THREAD_MESSAGES_AGGREGATE says
+   *  so). Any `max(seq) + 1` computed while this row is unheld is computed by
+   *  every concurrent writer from its own READ COMMITTED snapshot, and they all
+   *  get the same answer: measured on PostgreSQL 17, a batch append racing
+   *  `putMessage` collided on 20 of 20 rounds. Holding the row first makes the
+   *  loser block here until the winner COMMITs, so its allocation runs on a
+   *  fresh snapshot that already contains the winner's rows.
+   *
+   *  Every transcript writer therefore takes the SAME two locks in the SAME
+   *  order — thread row, then message rows — which is also why none of them can
+   *  deadlock against another. `appendThreadMessages` (helpers/rows.ts) is the
+   *  batch path's copy of this rule; keep the two honest with each other. */
   const touchThread = async (q: Query, threadId: string, now: string): Promise<void> => {
     await q(
       "UPDATE vendo_threads SET updated_at = $2, revision = revision + 1 WHERE id = $1",
@@ -340,6 +356,10 @@ export function createStoreOps(
           : `msg_${globalThis.crypto.randomUUID()}`;
         return await db.transaction(async (q) => {
           const now = new Date().toISOString();
+          // The thread row FIRST: it is what serialises this write's position
+          // against every other transcript writer (see touchThread). An absent
+          // thread updates nothing here and is reported below, as it always was.
+          await touchThread(q, threadId, now);
           if (!(await appendMessage(q, threadId, rowId, message, now))) {
             // The id already holds a row (an edit), or the thread is absent.
             const updated = await q(
@@ -351,7 +371,6 @@ export function createStoreOps(
               throw new VendoError("not-found", `thread ${threadId} not found`);
             }
           }
-          await touchThread(q, threadId, now);
           const record = await readThread(txDb(q), threadId);
           if (record === null) throw new VendoError("not-found", `thread ${threadId} not found`);
           return record;
@@ -390,6 +409,9 @@ export function createStoreOps(
         };
         return await db.transaction(async (q) => {
           const now = new Date().toISOString();
+          // The thread row FIRST, for the same reason putMessage does it: the
+          // position this answer takes must be allocated under that lock.
+          await touchThread(q, threadId, now);
           if (!(await appendMessage(q, threadId, rowId, message, now))) {
             const owned = await q("SELECT 1 FROM vendo_threads WHERE id = $1", [threadId]);
             if (owned.rows[0] === undefined) {
@@ -401,7 +423,6 @@ export function createStoreOps(
               + "an answer is never overwritten, so mint a fresh id for a new answer",
             );
           }
-          await touchThread(q, threadId, now);
           const record = await readThread(txDb(q), threadId);
           if (record === null) throw new VendoError("not-found", `thread ${threadId} not found`);
           return record;

--- a/packages/store/src/ops.ts
+++ b/packages/store/src/ops.ts
@@ -365,27 +365,15 @@ export function createStoreOps(
           const given = (message as { id?: unknown } | null)?.id;
           return typeof given === "string" && given !== "" ? given : `msg_${globalThis.crypto.randomUUID()}`;
         };
-        return await db.transaction(async (q) => {
-          // The wire carries no seq (the same honest gap putMessage has), so
-          // new rows land after the thread's current tail. An id the thread
-          // already holds keeps its own seq — appendThreadMessages does not
-          // move it.
-          const tail = await q(
-            "SELECT COALESCE(max(seq) + 1, 0) AS next FROM vendo_thread_messages WHERE thread_id = $1",
-            [threadId],
-          );
-          const next = Number(tail.rows[0]?.["next"] ?? 0);
-          return await appendThreadMessages(txDb(q), {
-            threadId,
-            subject,
-            messages: messages.map((message, index) => ({
-              id: rowIdOf(message),
-              seq: next + index,
-              message,
-            })),
-            ...(opts?.title === undefined ? {} : { title: opts.title }),
-          });
-        });
+        // Positions are assigned by appendThreadMessages' own statement, under
+        // the thread row it has already taken — reading the tail out here,
+        // before that lock, is what let two concurrent turns claim one seq.
+        return await db.transaction((q) => appendThreadMessages(txDb(q), {
+          threadId,
+          subject,
+          messages: messages.map((message) => ({ id: rowIdOf(message), message })),
+          ...(opts?.title === undefined ? {} : { title: opts.title }),
+        }));
       },
       /** Deliberately non-idempotent: a duplicate answer id is refused loudly —
        *  two answers are never the same answer (helpers/threads.recordAnswer). */

--- a/packages/store/tests/ops.test.ts
+++ b/packages/store/tests/ops.test.ts
@@ -73,11 +73,11 @@ for (const backend of backends()) {
       }
     });
 
-    it("status() reports the 35 ops this wire serves", async () => {
+    it("status() reports the 36 ops this wire serves", async () => {
       const { made, ops } = await makeOps();
       try {
         const status = await ops.status();
-        expect(status.ops).toBe(35);
+        expect(status.ops).toBe(36);
         // Nothing left to announce: the handshake carries the format and the
         // count, and the retired generic family is not advertised as anything.
         expect(Object.keys(status).sort()).toEqual(["format", "ops"]);

--- a/packages/store/tests/thread-messages.batch.test.ts
+++ b/packages/store/tests/thread-messages.batch.test.ts
@@ -161,37 +161,74 @@ for (const backend of backends()) {
      * interleaves. This needs genuine concurrent backends, so it runs on the
      * postgres leg only (POSTGRES_URL).
      */
-    it.runIf(backend.name === "postgres")("concurrent appends to one thread never share a seq", async () => {
-      const ops = createStoreOps(made.store);
-      const thread = "thr_batch_race";
-      const ROUNDS = 20;
-      // Round 0 deliberately races on a thread that does NOT exist yet, so the
-      // create path (two writers conflicting on the primary key) is covered
-      // alongside the update path (two writers queuing on the row lock).
-      for (let round = 0; round < ROUNDS; round += 1) {
-        await Promise.all([
-          ops.transcripts.appendMessages!(thread, alice.subject, [message(`m_${round}_a`, `round ${round} a`)]),
-          ops.transcripts.appendMessages!(thread, alice.subject, [message(`m_${round}_b`, `round ${round} b`)]),
-        ]);
-      }
+    /**
+     * EVERY transcript writer that allocates a position, raced against the batch
+     * append — not just the batch path against itself. The first round of this
+     * test only paired `appendMessages` with `appendMessages`, and that is
+     * precisely why it missed the same bug living in `putMessage` and
+     * `recordAnswer`: a race test proves only the pairing it actually runs.
+     */
+    const rivals = [
+      {
+        name: "appendMessages",
+        // Not pre-created: round 0 then races on a thread that does NOT exist
+        // yet, covering the create path (two writers conflicting on the primary
+        // key) alongside the update path (two queuing on the row lock).
+        seeded: false,
+        write: (ops: StoreOps, thread: string, round: number) =>
+          ops.transcripts.appendMessages!(thread, alice.subject, [message(`m_${round}_b`, "rival")]),
+      },
+      {
+        name: "putMessage",
+        seeded: true,
+        write: (ops: StoreOps, thread: string, round: number) =>
+          ops.transcripts.putMessage(thread, message(`m_${round}_b`, "rival")),
+      },
+      {
+        name: "recordAnswer",
+        seeded: true,
+        write: (ops: StoreOps, thread: string, round: number) =>
+          ops.transcripts.recordAnswer(thread, { id: `m_${round}_b`, value: round }),
+      },
+    ];
 
-      const rows = await made.sql(
-        "SELECT id, seq FROM vendo_thread_messages WHERE thread_id = $1 ORDER BY seq ASC, id ASC",
-        [thread],
+    for (const rival of rivals) {
+      it.runIf(backend.name === "postgres")(
+        `appendMessages racing ${rival.name} never shares a seq`,
+        async () => {
+          const ops = createStoreOps(made.store);
+          const thread = `thr_race_${rival.name.toLowerCase()}`;
+          const ROUNDS = 20;
+          if (rival.seeded) {
+            await ops.transcripts.putThread({ id: thread, subject: alice.subject, messages: [] });
+          }
+          for (let round = 0; round < ROUNDS; round += 1) {
+            await Promise.all([
+              ops.transcripts.appendMessages!(thread, alice.subject, [message(`m_${round}_a`, "batch")]),
+              rival.write(ops, thread, round),
+            ]);
+          }
+
+          const rows = await made.sql(
+            "SELECT id, seq FROM vendo_thread_messages WHERE thread_id = $1 ORDER BY seq ASC, id ASC",
+            [thread],
+          );
+          expect(rows).toHaveLength(ROUNDS * 2);
+          const seqs = rows.map((row) => Number(row["seq"]));
+          // THE claim: a seq identifies one position in the conversation.
+          expect(new Set(seqs).size, `duplicate seqs: ${JSON.stringify(seqs)}`).toBe(seqs.length);
+
+          // And the read-back order is the true append order: the two racers
+          // within a round may land either way round, but round k must precede
+          // round k+1. (`recordAnswer` prefixes its row id, so the round is read
+          // off the first digits rather than a fixed segment.)
+          const listed = await threadMessageStore<UIMessage>(pick("sql")).list(alice, thread);
+          const rounds = listed.map((m) => Number(/(\d+)/.exec(m.id)![1]));
+          expect(rounds, `transcript out of turn order: ${listed.map((m) => m.id).join(",")}`)
+            .toEqual([...rounds].sort((left, right) => left - right));
+        },
       );
-      expect(rows).toHaveLength(ROUNDS * 2);
-      const seqs = rows.map((row) => Number(row["seq"]));
-      // THE claim: a seq identifies one position in the conversation.
-      expect(new Set(seqs).size, `duplicate seqs: ${JSON.stringify(seqs)}`).toBe(seqs.length);
-
-      // And the read-back order is the true append order: the two racers within
-      // a round may land either way round, but round k must precede round k+1.
-      const listed = await threadMessageStore<UIMessage>(pick("sql")).list(alice, thread);
-      const roundOf = (id: string): number => Number(id.split("_")[1]);
-      const rounds = listed.map((m) => roundOf(m.id));
-      expect(rounds, `transcript out of turn order: ${listed.map((m) => m.id).join(",")}`)
-        .toEqual([...rounds].sort((left, right) => left - right));
-    });
+    }
 
     it("answers with the revision and the row count, never the transcript", async () => {
       await own("thr_batch_payload", alice.subject);

--- a/packages/store/tests/thread-messages.batch.test.ts
+++ b/packages/store/tests/thread-messages.batch.test.ts
@@ -1,0 +1,171 @@
+/**
+ * `upsertMany` — a turn's messages in ONE write, proven at the SEAM.
+ *
+ * Both halves of the transcript helper sit on the SAME real database here: the
+ * SQL half through `made.store`, the ops half through `createStoreOps` over
+ * that same store. So a batch written by one is read back by the other through
+ * its own real read path, with nothing stubbed on either side — the only way
+ * this file can catch the two disagreeing.
+ *
+ * The third mode is the console the op predates. It is spelled the way an old
+ * console actually answers (a `/status` op count from before the op, and a
+ * `not-implemented` for the route itself), not as a stub of our own code, so
+ * the feature detect has a real skew to detect.
+ */
+import { VENDO_STORE_WIRE_FORMAT, VendoError, type Principal, type StoreOps } from "@vendoai/core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { backends, type MadeBackend } from "../src/backends.test-util.js";
+import {
+  createStoreOps,
+  threadMessageStore,
+  threadStore,
+  type ThreadMessageLike as UIMessage,
+  type VendoStore,
+} from "../src/index.js";
+
+const alice: Principal = { kind: "user", subject: "user_alice" };
+const bob: Principal = { kind: "user", subject: "user_bob" };
+
+const message = (id: string, text: string, role: "user" | "assistant" = "user"): UIMessage =>
+  ({ id, role, parts: [{ type: "text", text }] }) as UIMessage;
+
+/** A store the way a HOST supplies one: the public surface plus a StoreOps, and
+ *  no handle this package minted — the shape the Cloud hosted store presents. */
+function opsOnlyStore(ops: StoreOps): VendoStore {
+  const unused = (what: string): never => {
+    throw new Error(`the transcript helper must not reach ${what}`);
+  };
+  return {
+    ops,
+    records: () => unused("records()"),
+    blobs: () => unused("blobs()"),
+    async ensureSchema() {},
+    async close() {},
+    raw: () => unused("raw()"),
+  };
+}
+
+/** The console as it answers BEFORE `transcripts.appendMessages` shipped: the
+ *  handshake reports the older op count, and the route itself is an enveloped
+ *  `not-implemented`. Everything else is the real implementation. */
+function consoleBeforeAppendMessages(ops: StoreOps): StoreOps {
+  return {
+    ...ops,
+    transcripts: {
+      ...ops.transcripts,
+      appendMessages: () => Promise.reject(
+        new VendoError("not-implemented", "Unknown store operation: transcripts.appendMessages"),
+      ),
+    },
+    status: async () => ({ format: VENDO_STORE_WIRE_FORMAT, ops: 35 }),
+  };
+}
+
+for (const backend of backends()) {
+  describe(`${backend.name} transcript batch append (design 4a)`, () => {
+    let made: MadeBackend;
+    /** Every mode writes to and reads from the one database below. */
+    let modes: Array<{ name: string; store: VendoStore }>;
+    const own = async (id: string, subject: string): Promise<void> => {
+      await threadStore(made.store).put({ kind: "user", subject }, { id, messages: [] });
+    };
+    const pick = (name: string): VendoStore => modes.find((mode) => mode.name === name)!.store;
+
+    beforeAll(async () => {
+      made = await backend.make();
+      await made.store.ensureSchema();
+      const ops = createStoreOps(made.store);
+      modes = [
+        { name: "sql", store: made.store },
+        { name: "ops", store: opsOnlyStore(ops) },
+        { name: "old-console", store: opsOnlyStore(consoleBeforeAppendMessages(ops)) },
+      ];
+    });
+    afterAll(async () => { if (made) await made.cleanup(); });
+
+    /** The same turn shape every mode writes: three messages, then one edit
+     *  plus one new message — the approval flip and its follow-up. */
+    const writeTurns = async (store: VendoStore, thread: string): Promise<void> => {
+      const messages = threadMessageStore<UIMessage>(store);
+      await messages.upsertMany(alice, thread, [
+        { message: message("m_1", "book me a table"), seq: 0 },
+        { message: message("m_2", "which night?", "assistant"), seq: 1 },
+        { message: message("m_3", "friday"), seq: 2 },
+      ], { title: "book me a table" });
+      await messages.upsertMany(alice, thread, [
+        { message: message("m_2", "friday it is", "assistant"), seq: 1 },
+        { message: message("m_4", "booked", "assistant"), seq: 3 },
+      ]);
+    };
+
+    it("the ops path and the SQL path land byte-identical transcripts", async () => {
+      await own("thr_batch_sql", alice.subject);
+      await own("thr_batch_ops", alice.subject);
+      await writeTurns(pick("sql"), "thr_batch_sql");
+      await writeTurns(pick("ops"), "thr_batch_ops");
+
+      // Read BOTH threads back through BOTH read paths: same rows, same order,
+      // whichever half wrote them and whichever half reads them.
+      const read = async (store: VendoStore, thread: string): Promise<string> =>
+        JSON.stringify(await threadMessageStore<UIMessage>(store).list(alice, thread));
+      const viaSqlOfSql = await read(pick("sql"), "thr_batch_sql");
+      const viaSqlOfOps = await read(pick("sql"), "thr_batch_ops");
+      const viaOpsOfSql = await read(pick("ops"), "thr_batch_sql");
+      const viaOpsOfOps = await read(pick("ops"), "thr_batch_ops");
+
+      expect(JSON.parse(viaSqlOfSql).map((m: UIMessage) => m.id)).toEqual(["m_1", "m_2", "m_3", "m_4"]);
+      expect(viaSqlOfSql).toContain("friday it is");
+      expect(viaSqlOfOps).toBe(viaSqlOfSql);
+      expect(viaOpsOfSql).toBe(viaSqlOfSql);
+      expect(viaOpsOfOps).toBe(viaSqlOfSql);
+    });
+
+    it("both halves refuse a foreign subject and write nothing", async () => {
+      await own("thr_batch_foreign", alice.subject);
+      const alicesMessages = threadMessageStore<UIMessage>(pick("sql"));
+      await alicesMessages.upsertMany(alice, "thr_batch_foreign", [
+        { message: message("m_1", "mine"), seq: 0 },
+      ]);
+
+      for (const mode of ["sql", "ops"] as const) {
+        const messages = threadMessageStore<UIMessage>(pick(mode));
+        await expect(
+          messages.upsertMany(bob, "thr_batch_foreign", [{ message: message("m_bob", "yours"), seq: 1 }]),
+          mode,
+        ).rejects.toBeInstanceOf(VendoError);
+      }
+      expect(await alicesMessages.list(alice, "thr_batch_foreign")).toHaveLength(1);
+    });
+
+    it("a console that predates the op takes the older route to the same transcript", async () => {
+      await own("thr_batch_skew", alice.subject);
+      await writeTurns(pick("old-console"), "thr_batch_skew");
+
+      // The fallback wrote through getThread + putMessage; the read path is the
+      // real one either way, and the transcript has to match the native op's.
+      await own("thr_batch_native", alice.subject);
+      await writeTurns(pick("ops"), "thr_batch_native");
+      const read = async (thread: string): Promise<unknown[]> =>
+        await threadMessageStore<UIMessage>(pick("sql")).list(alice, thread);
+      expect(JSON.stringify(await read("thr_batch_skew"))).toBe(JSON.stringify(await read("thr_batch_native")));
+    });
+
+    it("answers with the revision and the row count, never the transcript", async () => {
+      await own("thr_batch_payload", alice.subject);
+      const ops = createStoreOps(made.store);
+      const answer = await ops.transcripts.appendMessages!("thr_batch_payload", alice.subject, [
+        message("m_1", "one"),
+        message("m_2", "two"),
+      ]);
+
+      // The whole point of the op: what comes back does not grow with the
+      // conversation, so the tenth turn costs exactly what the first did.
+      expect(Object.keys(answer).sort()).toEqual(["count", "revision"]);
+      expect(answer.count).toBe(2);
+      const again = await ops.transcripts.appendMessages!("thr_batch_payload", alice.subject, [
+        message("m_3", "three"),
+      ]);
+      expect(JSON.stringify(again).length).toBeLessThanOrEqual(JSON.stringify(answer).length + 2);
+    });
+  });
+}

--- a/packages/store/tests/thread-messages.batch.test.ts
+++ b/packages/store/tests/thread-messages.batch.test.ts
@@ -88,13 +88,13 @@ for (const backend of backends()) {
     const writeTurns = async (store: VendoStore, thread: string): Promise<void> => {
       const messages = threadMessageStore<UIMessage>(store);
       await messages.upsertMany(alice, thread, [
-        { message: message("m_1", "book me a table"), seq: 0 },
-        { message: message("m_2", "which night?", "assistant"), seq: 1 },
-        { message: message("m_3", "friday"), seq: 2 },
+        message("m_1", "book me a table"),
+        message("m_2", "which night?", "assistant"),
+        message("m_3", "friday"),
       ], { title: "book me a table" });
       await messages.upsertMany(alice, thread, [
-        { message: message("m_2", "friday it is", "assistant"), seq: 1 },
-        { message: message("m_4", "booked", "assistant"), seq: 3 },
+        message("m_2", "friday it is", "assistant"),
+        message("m_4", "booked", "assistant"),
       ]);
     };
 
@@ -123,14 +123,12 @@ for (const backend of backends()) {
     it("both halves refuse a foreign subject and write nothing", async () => {
       await own("thr_batch_foreign", alice.subject);
       const alicesMessages = threadMessageStore<UIMessage>(pick("sql"));
-      await alicesMessages.upsertMany(alice, "thr_batch_foreign", [
-        { message: message("m_1", "mine"), seq: 0 },
-      ]);
+      await alicesMessages.upsertMany(alice, "thr_batch_foreign", [message("m_1", "mine")]);
 
       for (const mode of ["sql", "ops"] as const) {
         const messages = threadMessageStore<UIMessage>(pick(mode));
         await expect(
-          messages.upsertMany(bob, "thr_batch_foreign", [{ message: message("m_bob", "yours"), seq: 1 }]),
+          messages.upsertMany(bob, "thr_batch_foreign", [message("m_bob", "yours")]),
           mode,
         ).rejects.toBeInstanceOf(VendoError);
       }
@@ -148,6 +146,51 @@ for (const backend of backends()) {
       const read = async (thread: string): Promise<unknown[]> =>
         await threadMessageStore<UIMessage>(pick("sql")).list(alice, thread);
       expect(JSON.stringify(await read("thr_batch_skew"))).toBe(JSON.stringify(await read("thr_batch_native")));
+    });
+
+    /**
+     * TWO TURNS, ONE CONVERSATION — the seam this whole op sits on.
+     *
+     * `seq` carries the conversation's order, and it has no unique constraint
+     * (THREAD_MESSAGES_AGGREGATE says so): equal seqs make the transcript fall
+     * back to ordering by message ID, which is not turn order. A conversation
+     * that reads back scrambled is a broken product, and it would be
+     * intermittent and near-undiagnosable in the field.
+     *
+     * PGlite cannot prove anything here — it is one connection, so nothing
+     * interleaves. This needs genuine concurrent backends, so it runs on the
+     * postgres leg only (POSTGRES_URL).
+     */
+    it.runIf(backend.name === "postgres")("concurrent appends to one thread never share a seq", async () => {
+      const ops = createStoreOps(made.store);
+      const thread = "thr_batch_race";
+      const ROUNDS = 20;
+      // Round 0 deliberately races on a thread that does NOT exist yet, so the
+      // create path (two writers conflicting on the primary key) is covered
+      // alongside the update path (two writers queuing on the row lock).
+      for (let round = 0; round < ROUNDS; round += 1) {
+        await Promise.all([
+          ops.transcripts.appendMessages!(thread, alice.subject, [message(`m_${round}_a`, `round ${round} a`)]),
+          ops.transcripts.appendMessages!(thread, alice.subject, [message(`m_${round}_b`, `round ${round} b`)]),
+        ]);
+      }
+
+      const rows = await made.sql(
+        "SELECT id, seq FROM vendo_thread_messages WHERE thread_id = $1 ORDER BY seq ASC, id ASC",
+        [thread],
+      );
+      expect(rows).toHaveLength(ROUNDS * 2);
+      const seqs = rows.map((row) => Number(row["seq"]));
+      // THE claim: a seq identifies one position in the conversation.
+      expect(new Set(seqs).size, `duplicate seqs: ${JSON.stringify(seqs)}`).toBe(seqs.length);
+
+      // And the read-back order is the true append order: the two racers within
+      // a round may land either way round, but round k must precede round k+1.
+      const listed = await threadMessageStore<UIMessage>(pick("sql")).list(alice, thread);
+      const roundOf = (id: string): number => Number(id.split("_")[1]);
+      const rounds = listed.map((m) => roundOf(m.id));
+      expect(rounds, `transcript out of turn order: ${listed.map((m) => m.id).join(",")}`)
+        .toEqual([...rounds].sort((left, right) => left - right));
     });
 
     it("answers with the revision and the row count, never the transcript", async () => {

--- a/packages/vendo/src/harness-turn.ts
+++ b/packages/vendo/src/harness-turn.ts
@@ -34,7 +34,7 @@ import {
   hostComponentFiles,
   type NormalizedCatalog,
 } from "@vendoai/apps/contract";
-import { ThreadRepository, type Thread, type ThreadSummary } from "./threads.js";
+import { deriveTitle, ThreadRepository, type Thread, type ThreadSummary } from "./threads.js";
 import {
   HOT_PATH_WATCH,
   hotPathAppId,
@@ -386,7 +386,24 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
         // title, exactly as a `createAgent` turn's persist does. The workspace
         // open beside it reads file rows only — nothing it serves depends on the
         // thread row landing, and the runtime that writes messages runs after both.
-        threads.persist(thread, [input.message], { fresh }),
+        //
+        // ONE persistence path per turn: `persist` writes the whole transcript
+        // under a compare-and-swap, which is what CREATING the row needs and
+        // what every later turn was paying for nothing. Once the row exists the
+        // same three effects — the user's message, a touched `updated_at` and a
+        // refreshed title — are one append, and two overlapping turns writing
+        // disjoint message ids can no longer collide at all.
+        fresh
+          ? threads.persist(thread, [input.message], { fresh })
+          : transcript.upsertMany(
+            input.ctx.principal,
+            thread.id,
+            // Its position in the canonical array, which `upsertMessage` just
+            // decided: appended for a new message, in place for an answer to a
+            // pending approval (where the stored row keeps the seq it has).
+            [{ message: input.message, seq: thread.messages.findIndex((message) => message.id === input.message.id) }],
+            { title: deriveTitle(thread.messages) },
+          ),
         // §9.7 — the turn's façade mounts every org the wire asserted for this
         // request, so an agent turn can read and write the team's files at all.
         workspaces.open(input.ctx.principal, {

--- a/packages/vendo/src/harness-turn.ts
+++ b/packages/vendo/src/harness-turn.ts
@@ -395,13 +395,14 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
         // disjoint message ids can no longer collide at all.
         fresh
           ? threads.persist(thread, [input.message], { fresh })
+          // No position is passed: the store assigns one while it holds the
+          // thread row, so two turns racing on this conversation cannot claim
+          // the same slot. An answer to a pending approval matches an existing
+          // id and keeps the position it already has.
           : transcript.upsertMany(
             input.ctx.principal,
             thread.id,
-            // Its position in the canonical array, which `upsertMessage` just
-            // decided: appended for a new message, in place for an answer to a
-            // pending approval (where the stored row keeps the seq it has).
-            [{ message: input.message, seq: thread.messages.findIndex((message) => message.id === input.message.id) }],
+            [input.message],
             { title: deriveTitle(thread.messages) },
           ),
         // §9.7 — the turn's façade mounts every org the wire asserted for this

--- a/packages/vendo/src/hosted-store.ts
+++ b/packages/vendo/src/hosted-store.ts
@@ -72,7 +72,7 @@ export interface HostedStore extends VendoStore {
     bySubject(subject: string): Promise<EraseReport>;
     byApp(appId: string): Promise<EraseReport>;
   };
-  /** The 35-op named-operation surface over the same mount and the same key —
+  /** The 36-op named-operation surface over the same mount and the same key —
    * `vendo/store-wire@1` (see {@link hostedStoreOps}). The StoreAdapter doors
    * above are built ON these ops: engine for Vendo's own collections, appData
    * for an app's own drawers. */
@@ -158,7 +158,7 @@ export function hostedStore(options: HostedStoreOptions): HostedStore {
   };
   const sendJson = postJson(send);
 
-  // The StoreAdapter façade rides the SAME 35 ops as `ops` below — it has no
+  // The StoreAdapter façade rides the SAME 36 ops as `ops` below — it has no
   // doors of its own since the generic records family left the wire. A
   // collection (or blob namespace) either names an app's own drawer, which the
   // appData family serves with the owner stamped on, or it names one of Vendo's
@@ -272,10 +272,10 @@ export function hostedStore(options: HostedStoreOptions): HostedStore {
 }
 
 // ---------------------------------------------------------------------------
-// The 35-op StoreOps client — store design v1, `vendo/store-wire@1`
+// The 36-op StoreOps client — store design v1, `vendo/store-wire@1`
 // ---------------------------------------------------------------------------
 
-/** The 35 named ops — STORE_WIRE_PATHS' keys ARE the op names, and stay the
+/** The 36 named ops — STORE_WIRE_PATHS' keys ARE the op names, and stay the
  * op names even where the console's door sits at a different path. */
 type StoreWireOp = keyof typeof STORE_WIRE_PATHS;
 
@@ -314,7 +314,7 @@ const raiseWireError = async (response: Response): Promise<never> => {
 };
 
 /**
- * The Cloud client for the whole 35-op store contract, speaking
+ * The Cloud client for the whole 36-op store contract, speaking
  * `vendo/store-wire@1` over the console's store mount: bearer key, deployment
  * identity and per-request abort budget shared with {@link hostedStore}, the
  * same adapter rule (behavior comes ONLY from the constructor arguments),
@@ -600,6 +600,23 @@ function storeWireClient(
       },
       async putMessage(threadId, message) {
         return recordOf(await mutate("transcripts.putMessage", P["transcripts.putMessage"], { threadId, message }));
+      },
+      /** The answer is `{revision, count}`, NOT the thread: a batch append that
+       *  echoed the transcript back would put the whole conversation on the
+       *  wire on every turn, which is the download this op exists to delete.
+       *  The subject in the body is what lets the service check ownership in
+       *  its own statement instead of the client reading the thread first. */
+      async appendMessages(threadId, subject, messages, opts) {
+        const payload = await mutate("transcripts.appendMessages", P["transcripts.appendMessages"], {
+          threadId,
+          subject,
+          messages,
+          ...(opts?.title === undefined ? {} : { title: opts.title }),
+        });
+        return {
+          revision: field<string>(payload, "revision", "invalid append", (value) => typeof value === "string"),
+          count: field<number>(payload, "count", "invalid append", (value) => typeof value === "number"),
+        };
       },
       async recordAnswer(threadId, answer) {
         return recordOf(await mutate("transcripts.recordAnswer", P["transcripts.recordAnswer"], { threadId, answer }));

--- a/packages/vendo/src/threads.ts
+++ b/packages/vendo/src/threads.ts
@@ -25,6 +25,11 @@ export interface Thread {
   /** Precomputed listing title. Persisted beside the thread so `list` need not load the
    *  full messages array to derive it; absent on legacy rows (derived from messages then). */
   title?: string;
+  /** The store's concurrency token for this row, as READ. Carried so the turn
+   *  that resolved the thread can compare-and-swap on it directly instead of
+   *  re-reading the whole row (and its transcript) for a token it already had.
+   *  Absent on a thread that has never been written. */
+  revision?: string;
   createdAt: IsoDateTime;
   updatedAt: IsoDateTime;
 }
@@ -56,6 +61,9 @@ function threadFromRecord(record: VendoRecord): Thread | null {
     subject: candidate.subject,
     messages: candidate.messages as UIMessage[],
     ...(typeof candidate.title === "string" ? { title: candidate.title } : {}),
+    // The token rides the envelope beside the timestamps, and dropping it here
+    // is what made every persist re-read the row it had just been handed.
+    ...(typeof record.revision === "string" ? { revision: record.revision } : {}),
     createdAt: record.createdAt,
     updatedAt: record.updatedAt,
   };
@@ -68,7 +76,11 @@ function titleFor(thread: Thread): string {
   return deriveTitle(thread.messages);
 }
 
-function deriveTitle(messages: UIMessage[]): string {
+/** The listing title for a transcript. Exported because a turn that APPENDS
+ *  (rather than rewriting the thread through `persist`) still has to carry a
+ *  freshly-derived title along with the write — deriving it stays client-side,
+ *  where the message shapes are understood. */
+export function deriveTitle(messages: UIMessage[]): string {
   // Messages come from a Json array (parseThreadData accepts any shape), so a
   // message may lack an iterable `parts` or carry non-text parts — tolerate both,
   // skipping rather than throwing.
@@ -215,8 +227,16 @@ export class ThreadRepository {
       );
     }
     for (let attempt = 0; attempt < MAX_PERSIST_ATTEMPTS; attempt += 1) {
-      const record = opts?.fresh === true && attempt === 0 ? null : await records.get(thread.id);
-      const current = record === null ? null : threadFromRecord(record);
+      // The first attempt writes on what the CALLER already read: `fresh` is a
+      // read absence (insert), and a carried `revision` is a read row whose
+      // messages and token are both in hand. Either way the row is not fetched
+      // twice for one turn. A later attempt lost a race, so it must re-read.
+      const carried = attempt === 0 && opts?.fresh !== true ? thread.revision : undefined;
+      const record = attempt === 0 && (opts?.fresh === true || carried !== undefined)
+        ? null
+        : await records.get(thread.id);
+      const current = carried !== undefined ? thread : record === null ? null : threadFromRecord(record);
+      const revision = carried ?? record?.revision;
       if (current !== null && current.subject !== thread.subject) {
         // Mirror the door's guarded upsert (03 §5): never take over a foreign row.
         throw new VendoError("conflict", "threadId is already in use");
@@ -226,9 +246,9 @@ export class ThreadRepository {
         current === null ? turnMessages : mergeMessages(current.messages, turnMessages),
       );
       const input = { id: updated.id, data: updated, refs: { subject: updated.subject } };
-      const written = record === null
+      const written = current === null
         ? await atomic.insertIfAbsent(input)
-        : await atomic.compareAndSwap(input, record.revision!);
+        : await atomic.compareAndSwap(input, revision!);
       if (written !== null) return;
     }
     throw new VendoError(
@@ -241,10 +261,15 @@ export class ThreadRepository {
    *  freshly-derived listing title (never a stale prior title — `list` reads it
    *  back without loading messages), and a new updatedAt. */
   private updatedThread(thread: Thread, messages: UIMessage[]): Thread {
+    // Spelled out rather than spread: `revision` is the ENVELOPE's token, and
+    // this value becomes the row's `data`. The write carries the token as the
+    // compare-and-swap argument, never as a field inside what it writes.
     return {
-      ...thread,
+      id: thread.id,
+      subject: thread.subject,
       messages,
       title: deriveTitle(messages),
+      createdAt: thread.createdAt,
       updatedAt: new Date().toISOString(),
     };
   }


### PR DESCRIPTION
## What

Appending one message to a hosted thread downloaded the **whole conversation
first**. The wire had no verb carrying an owner, so `threadMessageStore`'s hosted
half had to `getThread` just to read `data.subject` before it could `putMessage`
(`helpers/thread-messages.ts:76-78` names exactly this gap). One agent turn paid
it several times, and the payload grew with the conversation forever. The SQL
half has always done it in one statement.

This adds the missing verb.

- **`transcripts.appendMessages`** — the additive 36th wire op. Body
  `{threadId, subject, messages, title?}`; answer `{revision, count}`, and
  deliberately **not the thread** — echoing the transcript back would reintroduce
  the exact payload the op exists to delete. (Rejected: an optional `subject` on
  `putMessage`; the wire schemas are `.passthrough()`, so an older console would
  silently ignore it.)
- **Engine** — `appendThreadMessages` (`helpers/rows.ts`): a subject-guarded
  create-or-touch of the thread row plus one multi-row insert, in one
  transaction, and it never moves an existing message's `seq`. Both halves of the
  new `ThreadMessageStore.upsertMany` run those same semantics, so they cannot
  disagree.
- **One persistence path per turn** — `Thread.revision` is carried from the read
  that already happened, so `persist`'s first attempt compare-and-swaps on it
  instead of re-reading the row (and its transcript) for a token it was handed.
  `persist` now runs only when the row must be created; every later turn appends,
  title and all. `MAX_PERSIST_ATTEMPTS`, the CAS-miss path, new-thread
  `insertIfAbsent` and the per-row CAS door are untouched.
- **`runtime.ts`** sends a turn's changed messages as ONE `upsertMany`.

## Wire compatibility, both directions

**Old client → new console:** untouched. The op is purely additive; nothing an
0.16.x client sends changes shape.

**New client → old console:** an **explicit capability feature-detect**, not a
catch-and-degrade. `/status` is the wire's own discovery handshake and its op
count is the signal (`STORE_WIRE_APPEND_MESSAGES_OPS = 36`, frozen at the count
this op shipped with). `servesAppendMessages` asks once per `StoreOps` handle,
caches the answer in a `WeakMap`, and routes to the existing
`getThread` + `putMessage` loop when the mount is behind. The shape is the
in-repo precedent at `tool-bridge.ts:380` (`guard.previewCheck`).

This does **not** reintroduce the failure mode behind field incident #1251. That
incident was about reading a *failed mutation* as a signal; `hosted-store.ts`
still logs once and rethrows on an unsupported op, and nothing here catches it.
The fallback is a supported route chosen **before** anything is written, so there
is no half-applied write to retry down a second path. A failed handshake is not
an answer: it is not cached, it does not degrade, and the write fails.

`StoreOps.transcripts.appendMessages` is **optional**, the way `RecordStore.claim`
and `atomic` already are — an implementation that cannot serve it says so by
omitting it, and the conformance suite now asserts that a mount's `/status` count
tracks the capability it advertises.

## Proof

`packages/store/tests/thread-messages.batch.test.ts` — no stub on either side.
Both halves sit on ONE real database, so each writes and the other reads back
through its own real path:
1. the real ops path and the real SQL path land **byte-identical transcripts**,
   read back through both read paths (4 combinations, all equal);
2. a **foreign subject is refused by both** halves, and nothing is written;
3. the **feature-detect fallback** (a stand-in console that reports the 35-op
   count and 501s the route, exactly as a real old console does) lands the **same
   transcript** as the native op;
4. the answer is `{revision, count}` and does not grow with the conversation.

Prove-can-fail: reverting the statement to `SET seq = EXCLUDED.seq` on conflict
turns tests 1 and 3 red.

## Gate

`pnpm build` ✅ · `pnpm typecheck` ✅ (42/42) · `pnpm lint` ✅ (0 errors) ·
store suites 152 passed / 10 files ✅ (batch, message-loss, ask-user-answer,
ops.conformance, conformance, thread-messages, thread-messages.ops,
thread-message-cas, ops, thread-scoping) · vendo 89 passed ✅ (hosted-store,
hosted-store-notice, threads, harness-threads, harness-wire,
harness-refusal-atomicity) · harnesses 78 passed ✅. No UI surface touched.

## Two things the reviewer should know

1. **Op count 35 → 36 lands in more places than the plan named.** Besides
   `packages/core/tests/store-wire.test.ts` (3 coupled literals), the count is
   pinned in `packages/store/tests/ops.test.ts` (2 literals, updated) and
   asserted as `=== 35` in `packages/core/src/conformance/store-ops.ts`, which is
   shared by `createStoreOps` (36) and `memoryStoreOps` (35). That assertion now
   derives the expected count from whether the mount serves the op — which makes
   the handshake a checked capability contract rather than a frozen number.
2. **The conformance case is a gate on the console half.** The new
   `transcripts.appendMessages` case skips only when the op is absent. The hosted
   client always defines it, so vendo-web's `store-ops-conformance` will fail
   until the console's dispatch arm ships — deliberately, and the stacked console
   PR carries both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Append thread messages in one call and enforce turn order under concurrency. Old: clients fetched the whole thread and looped `putMessage`; writers computed `seq` before taking the thread row, causing large payloads and occasional duplicate `seq`. New: `transcripts.appendMessages` accepts `{threadId, subject, messages, title?}`, assigns `seq` in-transaction, returns `{revision, count}`, and all writers (`appendMessages`, `putMessage`, `recordAnswer`) take the thread row before allocating `seq`.

- Wire/API: adds `transcripts.appendMessages`; `/status.ops` is now 36 and clients feature-detect (`>= 36`), falling back to `getThread` + `putMessage`. No thread echo; no schema/UI changes.
- Engine/local backend: subject-guarded upsert + one multi-row insert; unique message-id validation; `title` via COALESCE; `seq` from `max(seq)+1` under the thread row lock; existing messages keep position. `putMessage` and `recordAnswer` now lock the thread row before `seq` allocation.
- Client/runtime: `ThreadMessageStore.upsertMany` batches a turn and uses `appendMessages` when served; otherwise falls back. Threads carry `revision`; `persist` CASes on the carried token; non-creation turns append with a derived title.
- Tests: conformance derives expected `/status.ops` from op presence; seam tests ensure identical transcripts across SQL/wire paths, reject foreign subjects, verify feature-detected fallback; PostgreSQL race tests prove no shared `seq` across `appendMessages` vs `putMessage`/`recordAnswer`. Answers are `{revision, count}`.

**Rollout**
- Servers: implement `transcripts.appendMessages`, report `/status.ops >= 36`, or omit the op and stay `< 36`.
- Clients: no migration required; they auto-fallback until servers update.
- Run the updated conformance suite.

<sup>Written for commit 472312e39e40042e9e22484924dfc0fea229bc64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

