### PR TITLE
perf(guard,store): client read diet

### DIFF
--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -125,6 +125,14 @@ const FREEZE_ROW = "freeze";
 /** The block a frozen guard returns — the same words at the check and at the
  *  execute re-read, so the two agree. */
 const FROZEN_REASON = "vendo is frozen — nothing runs until it is unfrozen";
+/** How long a CHECK-TIME freeze answer may be reused (the execute gate never
+ *  reuses one). A freeze flipped in another process therefore starts blocking
+ *  new checks within this window, and blocks every DISPATCH immediately. */
+const FROZEN_CACHE_MS = 10_000;
+/** How long a preview pass's grant read may be handed to the real pass that
+ *  follows it. The two run moments apart for one logical call; anything older
+ *  is a different moment and reads the store again. */
+const PREVIEW_SHARE_MS = 10_000;
 /** Build contract §7 — the effect ledger: one row per completed mutating call,
  *  keyed by (run, tool, exact input). It is what makes fail-and-re-run correct:
  *  a re-run of a run that already sent the payment must not send it again. */
@@ -175,6 +183,14 @@ interface DecisionMetadata {
   decision: DraftDecision;
   rationale?: string;
   invalidatedGrants?: PermissionGrant[];
+}
+
+/** What the subject's standing grants say about one call: the one that
+ *  authorizes it, and the same-tool grants a descriptor change has invalidated
+ *  (which the park offer names). */
+interface MatchedGrant {
+  grant?: PermissionGrant;
+  invalidated: PermissionGrant[];
 }
 
 interface CompletedDecision {
@@ -491,6 +507,12 @@ class GuardImplementation implements VendoGuard {
   readonly #callWindows = new Map<string, number[]>();
   readonly #writeCounts = new Map<string, { count: number; touchedAt: number }>();
   #lastSweepAt = 0;
+  /** The last freeze answer a fresh read produced (see {@link frozen}). */
+  #frozenCache: { at: number; value: boolean } | undefined;
+  /** The last preview pass's grant read, waiting for its real pass. One entry:
+   *  the caller that previews executes moments later, so a second preview means
+   *  the first one's call is gone. */
+  #previewedGrant: { key: string; at: number; matched: MatchedGrant } | undefined;
   readonly #approvalCallbacks = new Set<(id: ApprovalId, approved: boolean) => void>();
   readonly #approvalRequestedCallbacks = new Set<(request: ApprovalRequest) => void>();
 
@@ -874,7 +896,21 @@ class GuardImplementation implements VendoGuard {
     await this.#setFrozen(false, by);
   }
 
-  async frozen(): Promise<boolean> {
+  /** Reads the flag row every time, unless the caller says a slightly stale
+   *  answer will do (`cached`). Only the CHECK-TIME read does: it is one static
+   *  row, read on every tool call, and the gate immediately before dispatch
+   *  (`bind().execute`) is uncached — so the freeze a cached check missed still
+   *  cannot reach a tool. Every fresh read refreshes the cached value, this
+   *  guard's own freeze()/unfreeze() included, so an in-process flip is visible
+   *  at once and only another process's flip can be up to
+   *  {@link FROZEN_CACHE_MS} stale. */
+  async frozen(opts?: { cached?: boolean }): Promise<boolean> {
+    if (
+      opts?.cached === true && this.#frozenCache !== undefined
+      && Date.now() - this.#frozenCache.at < FROZEN_CACHE_MS
+    ) {
+      return this.#frozenCache.value;
+    }
     let record: VendoRecord | null;
     try {
       record = await this.#engine.get(CONTROLS_COLLECTION, FREEZE_ROW);
@@ -884,17 +920,24 @@ class GuardImplementation implements VendoGuard {
       // in the pipeline is contained — never let it escape check()/execute() as
       // an unhandled rejection while the guard silently stops gating.
       await this.#reportUnreadableControl(errorMessage(error));
-      return true;
+      return this.#rememberFrozen(true);
     }
     // Absent row: the switch was never pulled — normal, unfrozen.
-    if (record === null) return false;
+    if (record === null) return this.#rememberFrozen(false);
     const frozen = (record.data as { frozen?: unknown }).frozen;
-    if (typeof frozen === "boolean") return frozen;
+    if (typeof frozen === "boolean") return this.#rememberFrozen(frozen);
     // A control row that EXISTS but does not parse is a kill switch we can no
     // longer read. Fail CLOSED — treat it as frozen — rather than let a corrupt
     // switch read as "run everything".
     await this.#reportUnreadableControl();
-    return true;
+    return this.#rememberFrozen(true);
+  }
+
+  /** What the next check-time read may answer with. Fail-closed answers are
+   *  cached like any other: the safe direction stays safe for at most a TTL. */
+  #rememberFrozen(value: boolean): boolean {
+    this.#frozenCache = { at: Date.now(), value };
+    return value;
   }
 
   /** The kill switch could not be read as a boolean — the row is corrupt, or
@@ -960,6 +1003,7 @@ class GuardImplementation implements VendoGuard {
       id: FREEZE_ROW,
       data: { frozen, by, at: now() },
     });
+    this.#rememberFrozen(frozen);
     await this.report({
       id: makeId("aud_"),
       at: now(),
@@ -1023,7 +1067,7 @@ class GuardImplementation implements VendoGuard {
     // `risk` (01-core §7) does not promise: it is the EFFECTIVE grade. Rather
     // than chip a possibly-wrong label, the frozen row OMITS `risk` entirely
     // (the console feed degrades cleanly to venue-led when risk is absent).
-    if (await this.frozen()) {
+    if (await this.frozen({ cached: true })) {
       // The block is the truth; the audit is best-effort. A `vendo_audit` that
       // is momentarily unavailable must never turn a freeze into an error (or,
       // worse, an un-block) — swallow the write failure and still return the
@@ -1315,10 +1359,21 @@ class GuardImplementation implements VendoGuard {
     // exactly as it was — the replay verdict is read first, the grant only
     // after it — and the replay's single-use CAS spend still happens once,
     // because `#approvedReplay` is still called once.
+    //
+    // The grant read is also the PREVIEW pass's, handed forward: a caller that
+    // previews (the harness bridge, the SDK's needsApproval hook) makes the
+    // real, dispatching call for the same (call, descriptor, ctx) moments
+    // later, and standing grants cannot have moved in between in a way this
+    // pass would act on — the approval tap that CAN move them lands on the
+    // replay, which is deliberately not shared: it must be re-read to see the
+    // fresh yes, and its single-use CAS spend happens on the real pass only.
+    const key = this.#previewKey(call, descriptor, ctx);
+    const previewed = commitRun ? this.#takePreviewedGrant(key) : undefined;
     const [replayable, matched] = await Promise.all([
       this.#approvedReplay(call, descriptor, ctx, commitRun),
-      this.#matchingGrant(call, descriptor, ctx),
+      previewed ?? this.#matchingGrant(call, descriptor, ctx),
     ]);
+    if (!commitRun) this.#previewedGrant = { key, at: Date.now(), matched };
 
     // An exact approved replay answers a confirmEach ask (05 §2 stays otherwise:
     // grants/rules/judge never suppress confirmEach — the grant lookup above is
@@ -1815,13 +1870,46 @@ class GuardImplementation implements VendoGuard {
     return false;
   }
 
+  /** Everything `#matchingGrant` answers off: the call, the frozen descriptor,
+   *  and the context bits `durationMatches`/`presenceMatches`/`scopeMatches`
+   *  read. A preview whose key differs is not this call. */
+  #previewKey(call: ToolCall, descriptor: ToolDescriptor, ctx: RunContext): string {
+    return canonicalJson([
+      call.id,
+      call.tool,
+      exactInputHash(call.args),
+      descriptorHash(descriptor),
+      ctx.principal.subject,
+      ctx.venue,
+      ctx.presence,
+      ctx.sessionId,
+      ctx.appId ?? null,
+      ctx.trigger?.id ?? null,
+      ctx.trigger?.runId ?? null,
+    ]);
+  }
+
+  /** The preview's grant read, once — the real pass consumes it, and anything
+   *  that goes unconsumed expires rather than waiting for a caller that may
+   *  never come. */
+  #takePreviewedGrant(key: string): MatchedGrant | undefined {
+    const previewed = this.#previewedGrant;
+    this.#previewedGrant = undefined;
+    if (previewed === undefined || previewed.key !== key) return undefined;
+    return Date.now() - previewed.at < PREVIEW_SHARE_MS ? previewed.matched : undefined;
+  }
+
   async #matchingGrant(
     call: ToolCall,
     descriptor: ToolDescriptor,
     ctx: RunContext,
-  ): Promise<{ grant?: PermissionGrant; invalidated: PermissionGrant[] }> {
+  ): Promise<MatchedGrant> {
+    // `tool` is an indexed column on the routed grants door — (subject, tool) —
+    // so the predicate rides the query instead of paging every grant the
+    // subject ever held back to filter it here. The rest of the tests below
+    // read fields no door indexes, which is why they stay in JavaScript.
     const records = await listAll(this.#engine, GRANTS_COLLECTION, {
-      refs: { subject: ctx.principal.subject },
+      refs: { subject: ctx.principal.subject, tool: call.tool },
     });
     const fingerprint = descriptorHash(descriptor);
     const at = Date.now();
@@ -1831,7 +1919,6 @@ class GuardImplementation implements VendoGuard {
       const grant = grantData(record);
       const expiresAt = grant.expiresAt === undefined ? undefined : Date.parse(grant.expiresAt);
       if (grant.subject !== ctx.principal.subject) continue;
-      if (grant.tool !== call.tool) continue;
       if (grant.revokedAt !== undefined) continue;
       if (expiresAt !== undefined && (!Number.isFinite(expiresAt) || expiresAt <= at)) continue;
       if (!durationMatches(grant, ctx) || !presenceMatches(grant, ctx)) continue;

--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -129,10 +129,6 @@ const FROZEN_REASON = "vendo is frozen — nothing runs until it is unfrozen";
  *  reuses one). A freeze flipped in another process therefore starts blocking
  *  new checks within this window, and blocks every DISPATCH immediately. */
 const FROZEN_CACHE_MS = 10_000;
-/** How long a preview pass's grant read may be handed to the real pass that
- *  follows it. The two run moments apart for one logical call; anything older
- *  is a different moment and reads the store again. */
-const PREVIEW_SHARE_MS = 10_000;
 /** Build contract §7 — the effect ledger: one row per completed mutating call,
  *  keyed by (run, tool, exact input). It is what makes fail-and-re-run correct:
  *  a re-run of a run that already sent the payment must not send it again. */
@@ -183,14 +179,6 @@ interface DecisionMetadata {
   decision: DraftDecision;
   rationale?: string;
   invalidatedGrants?: PermissionGrant[];
-}
-
-/** What the subject's standing grants say about one call: the one that
- *  authorizes it, and the same-tool grants a descriptor change has invalidated
- *  (which the park offer names). */
-interface MatchedGrant {
-  grant?: PermissionGrant;
-  invalidated: PermissionGrant[];
 }
 
 interface CompletedDecision {
@@ -509,10 +497,6 @@ class GuardImplementation implements VendoGuard {
   #lastSweepAt = 0;
   /** The last freeze answer a fresh read produced (see {@link frozen}). */
   #frozenCache: { at: number; value: boolean } | undefined;
-  /** The last preview pass's grant read, waiting for its real pass. One entry:
-   *  the caller that previews executes moments later, so a second preview means
-   *  the first one's call is gone. */
-  #previewedGrant: { key: string; at: number; matched: MatchedGrant } | undefined;
   readonly #approvalCallbacks = new Set<(id: ApprovalId, approved: boolean) => void>();
   readonly #approvalRequestedCallbacks = new Set<(request: ApprovalRequest) => void>();
 
@@ -1360,20 +1344,18 @@ class GuardImplementation implements VendoGuard {
     // after it — and the replay's single-use CAS spend still happens once,
     // because `#approvedReplay` is still called once.
     //
-    // The grant read is also the PREVIEW pass's, handed forward: a caller that
-    // previews (the harness bridge, the SDK's needsApproval hook) makes the
-    // real, dispatching call for the same (call, descriptor, ctx) moments
-    // later, and standing grants cannot have moved in between in a way this
-    // pass would act on — the approval tap that CAN move them lands on the
-    // replay, which is deliberately not shared: it must be re-read to see the
-    // fresh yes, and its single-use CAS spend happens on the real pass only.
-    const key = this.#previewKey(call, descriptor, ctx);
-    const previewed = commitRun ? this.#takePreviewedGrant(key) : undefined;
+    // Neither read is shared with the PREVIEW pass that precedes the real one,
+    // and the grant read is the reason: a grant is not a decision input the way
+    // a rule is — it IS the authority the call executes on, so reusing the
+    // preview's answer would leave a window in which a permission the person
+    // just took back still runs the tool. That is the same window the freeze
+    // re-read below `bind().execute` exists to close, and it gets the same
+    // answer: read it again. (The replay is unshared for its own reason — the
+    // single-use CAS spend belongs to the real pass.)
     const [replayable, matched] = await Promise.all([
       this.#approvedReplay(call, descriptor, ctx, commitRun),
-      previewed ?? this.#matchingGrant(call, descriptor, ctx),
+      this.#matchingGrant(call, descriptor, ctx),
     ]);
-    if (!commitRun) this.#previewedGrant = { key, at: Date.now(), matched };
 
     // An exact approved replay answers a confirmEach ask (05 §2 stays otherwise:
     // grants/rules/judge never suppress confirmEach — the grant lookup above is
@@ -1870,40 +1852,11 @@ class GuardImplementation implements VendoGuard {
     return false;
   }
 
-  /** Everything `#matchingGrant` answers off: the call, the frozen descriptor,
-   *  and the context bits `durationMatches`/`presenceMatches`/`scopeMatches`
-   *  read. A preview whose key differs is not this call. */
-  #previewKey(call: ToolCall, descriptor: ToolDescriptor, ctx: RunContext): string {
-    return canonicalJson([
-      call.id,
-      call.tool,
-      exactInputHash(call.args),
-      descriptorHash(descriptor),
-      ctx.principal.subject,
-      ctx.venue,
-      ctx.presence,
-      ctx.sessionId,
-      ctx.appId ?? null,
-      ctx.trigger?.id ?? null,
-      ctx.trigger?.runId ?? null,
-    ]);
-  }
-
-  /** The preview's grant read, once — the real pass consumes it, and anything
-   *  that goes unconsumed expires rather than waiting for a caller that may
-   *  never come. */
-  #takePreviewedGrant(key: string): MatchedGrant | undefined {
-    const previewed = this.#previewedGrant;
-    this.#previewedGrant = undefined;
-    if (previewed === undefined || previewed.key !== key) return undefined;
-    return Date.now() - previewed.at < PREVIEW_SHARE_MS ? previewed.matched : undefined;
-  }
-
   async #matchingGrant(
     call: ToolCall,
     descriptor: ToolDescriptor,
     ctx: RunContext,
-  ): Promise<MatchedGrant> {
+  ): Promise<{ grant?: PermissionGrant; invalidated: PermissionGrant[] }> {
     // `tool` is an indexed column on the routed grants door — (subject, tool) —
     // so the predicate rides the query instead of paging every grant the
     // subject ever held back to filter it here. The rest of the tests below

--- a/packages/guard/test/freeze-cache.test.ts
+++ b/packages/guard/test/freeze-cache.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createGuard } from "../src/index.js";
+import { createPGliteStore, type PGliteStore } from "./fixtures/pglite-store.js";
+import { call, context, descriptor, FixtureTools } from "./fixtures/tools.js";
+
+/**
+ * The kill switch is one static row read three times per tool call. Check-time
+ * reads may serve a ~10s cached answer; the pre-execute gate never may — a
+ * freeze that lands while the judge is thinking still has to refuse the
+ * dispatch. Both halves are asserted here against the REAL store, with the flag
+ * flipped the way the console flips it (a write straight through the store,
+ * from another process — which is exactly the flip an in-process cache cannot
+ * hear about).
+ */
+
+const stores: PGliteStore[] = [];
+
+async function store(): Promise<PGliteStore> {
+  const value = await createPGliteStore();
+  stores.push(value);
+  return value;
+}
+
+afterEach(async () => {
+  await Promise.all(stores.splice(0).map((value) => value.close()));
+});
+
+/** The console's own write path for the flag. */
+function freezeRow(sqlStore: PGliteStore, frozen: boolean): Promise<unknown> {
+  return sqlStore.records("guard:controls").put({
+    id: "freeze",
+    data: { frozen, by: "console", at: new Date().toISOString() },
+  });
+}
+
+/** The same store, counting the reads of the freeze row. */
+function counting(sqlStore: PGliteStore): { store: PGliteStore; reads: () => number } {
+  let reads = 0;
+  const wrapped = new Proxy(sqlStore, {
+    get(target, prop, receiver) {
+      if (prop !== "records") {
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      }
+      return (collection: string) => {
+        const inner = target.records(collection);
+        if (collection !== "guard:controls") return inner;
+        return new Proxy(inner, {
+          get(innerTarget, innerProp, innerReceiver) {
+            const value = Reflect.get(innerTarget, innerProp, innerReceiver);
+            if (innerProp !== "get") return typeof value === "function" ? value.bind(innerTarget) : value;
+            return async (id: string) => {
+              reads += 1;
+              return await (value as (id: string) => Promise<unknown>).call(innerTarget, id);
+            };
+          },
+        });
+      };
+    },
+  });
+  return { store: wrapped, reads: () => reads };
+}
+
+describe("the freeze flag, cached at check time and fresh at the gate", () => {
+  it("serves a check-time read from the cache while the pre-execute gate still reads the store", async () => {
+    const sqlStore = await store();
+    const counted = counting(sqlStore);
+    const guard = createGuard({ store: counted.store });
+    const tools = new FixtureTools();
+    const bound = guard.bind(tools);
+    const read = call("host_read", { value: 1 }, "call_cached");
+
+    // One tool call: the check reads the row, the pre-execute gate reads it again.
+    await expect(bound.execute(read, context())).resolves.toMatchObject({ status: "ok" });
+    expect(counted.reads()).toBe(2);
+
+    // A second check within the TTL asks the store nothing — the answer it has
+    // is at most 10 seconds old, which is the accepted staleness for a
+    // DECISION (the gate below is what a freeze actually has to beat).
+    const cached = counted.reads();
+    await expect(guard.check(read, descriptor("read"), context())).resolves.toMatchObject({
+      action: "run",
+    });
+    expect(counted.reads()).toBe(cached);
+  });
+
+  it("refuses the dispatch when the freeze lands during the judge's window", async () => {
+    const sqlStore = await store();
+    const counted = counting(sqlStore);
+    // The judge is the check's long await (up to 15s in the field). Freezing
+    // from inside it is that window, deterministically: the check read the flag
+    // before this ran, so only the pre-execute re-read can see the freeze.
+    const guard = createGuard({
+      store: counted.store,
+      judge: {
+        decide: async () => {
+          await freezeRow(sqlStore, true);
+          return { action: "run", rationale: "cleared before the freeze landed" };
+        },
+      },
+    });
+    const tools = new FixtureTools();
+    const bound = guard.bind(tools);
+    const write = call("host_write", { invoiceId: "inv_1" }, "call_judged");
+
+    await expect(bound.execute(write, context())).resolves.toMatchObject({
+      status: "blocked",
+      reason: "vendo is frozen — nothing runs until it is unfrozen",
+    });
+    // The tool never ran, and the gate paid for a real read to find that out.
+    expect(tools.executions).toHaveLength(0);
+    expect(counted.reads()).toBe(2);
+  });
+});

--- a/packages/guard/test/grant-filter.test.ts
+++ b/packages/guard/test/grant-filter.test.ts
@@ -1,0 +1,130 @@
+import type { PermissionGrant, VendoRecord } from "@vendoai/core";
+import { descriptorHash } from "@vendoai/core";
+import { afterEach, describe, expect, it } from "vitest";
+import { createGuard } from "../src/index.js";
+import { createPGliteStore, type PGliteStore } from "./fixtures/pglite-store.js";
+import { alice, call, context, descriptor, FixtureTools, seedGrant } from "./fixtures/tools.js";
+
+/**
+ * A check used to list every grant the subject ever held and throw away the
+ * wrong tools in JavaScript — one page per 1000 grants, every tool call. The
+ * tool is an indexed column on the routed door, so the predicate belongs in the
+ * query. This pins BOTH halves: the emitted SQL carries the tool, and the grant
+ * the guard picks is the one the old JS filter would have picked.
+ */
+
+const stores: PGliteStore[] = [];
+
+async function store(): Promise<PGliteStore> {
+  const value = await createPGliteStore();
+  stores.push(value);
+  return value;
+}
+
+afterEach(async () => {
+  await Promise.all(stores.splice(0).map((value) => value.close()));
+});
+
+/** Every statement the store runs, in order. */
+function recordSql(sqlStore: PGliteStore): string[] {
+  const emitted: string[] = [];
+  const real = sqlStore.db.query.bind(sqlStore.db);
+  (sqlStore.db as unknown as { query: unknown }).query = (sql: string, params?: unknown[]) => {
+    emitted.push(sql);
+    return real(sql, params as never);
+  };
+  return emitted;
+}
+
+/** The filter that used to run in JavaScript over every one of the subject's
+ *  grants, kept here as the equivalence oracle: whatever the query now selects
+ *  must be what this would have selected off the unfiltered list. */
+function jsFiltered(records: VendoRecord[], tool: string, fingerprint: string): PermissionGrant | undefined {
+  const at = Date.now();
+  for (const record of records) {
+    const grant = record.data as PermissionGrant;
+    const expiresAt = grant.expiresAt === undefined ? undefined : Date.parse(grant.expiresAt);
+    if (grant.subject !== alice.subject) continue;
+    if (grant.tool !== tool) continue;
+    if (grant.revokedAt !== undefined) continue;
+    if (expiresAt !== undefined && (!Number.isFinite(expiresAt) || expiresAt <= at)) continue;
+    if (grant.descriptorHash !== fingerprint) continue;
+    return grant;
+  }
+  return undefined;
+}
+
+describe("grants are filtered by tool in the query, not in JavaScript", () => {
+  it("emits the tool predicate and picks exactly what the JS filter picked", async () => {
+    const sqlStore = await store();
+    // Several tools, and two same-tool grants that must lose on their own
+    // merits — the filter has to keep answering those in JS.
+    await seedGrant(sqlStore, { descriptor: descriptor("read") });
+    await seedGrant(sqlStore, { descriptor: descriptor("destructive") });
+    await seedGrant(sqlStore, {
+      descriptor: descriptor("write"),
+      id: "grt_revoked",
+      revokedAt: new Date(Date.now() - 60_000).toISOString(),
+    });
+    await seedGrant(sqlStore, {
+      descriptor: descriptor("write"),
+      id: "grt_expired",
+      expiresAt: new Date(Date.now() - 60_000).toISOString(),
+    });
+    const live = await seedGrant(sqlStore, { descriptor: descriptor("write"), id: "grt_live" });
+
+    const guard = createGuard({ store: sqlStore });
+    const bound = guard.bind(new FixtureTools());
+    const write = call("host_write", { invoiceId: "inv_1" }, "call_grant");
+    const emitted = recordSql(sqlStore);
+
+    await expect(bound.execute(write, context())).resolves.toMatchObject({ status: "ok" });
+
+    // The tool rode the query. Every grants list the check ran carries it — a
+    // single unfiltered one would be the whole drawer coming back.
+    const listed = emitted.filter((sql) => sql.includes("FROM vendo_grants") && sql.includes("subject ="));
+    expect(listed.length).toBeGreaterThan(0);
+    expect(listed.every((sql) => /tool = \$\d+/.test(sql))).toBe(true);
+
+    // …and the grant it decided by is the one the old JS filter would have
+    // chosen off the unfiltered list.
+    const all = await sqlStore.records("vendo_grants").list({ refs: { subject: alice.subject } });
+    const expected = jsFiltered(all.records, "host_write", descriptorHash(descriptor("write")));
+    expect(expected?.id).toBe(live.id);
+    await expect(guard.check(write, descriptor("write"), context())).resolves.toEqual({
+      action: "run",
+      decidedBy: "grant",
+      grantId: expected?.id,
+    });
+  });
+
+  it("reads the grants once for a preview and the real call it precedes", async () => {
+    const sqlStore = await store();
+    await seedGrant(sqlStore, { descriptor: descriptor("write") });
+    const guard = createGuard({ store: sqlStore });
+    const write = call("host_write", { invoiceId: "inv_2" }, "call_previewed");
+    const emitted = recordSql(sqlStore);
+    const grantLists = (): number =>
+      emitted.filter((sql) => sql.includes("FROM vendo_grants") && sql.includes("subject =")).length;
+
+    // The bridge previews, then makes the REAL dispatching call moments later
+    // for the same call id — one logical call, and the standing grants behind
+    // it are read for it once.
+    await expect(guard.previewCheck!(write, descriptor("write"), context())).resolves.toMatchObject({
+      action: "run",
+      decidedBy: "grant",
+    });
+    expect(grantLists()).toBe(1);
+    await expect(guard.check(write, descriptor("write"), context())).resolves.toMatchObject({
+      action: "run",
+      decidedBy: "grant",
+    });
+    expect(grantLists()).toBe(1);
+
+    // A DIFFERENT call is not that call: it reads for itself.
+    await expect(
+      guard.check(call("host_write", { invoiceId: "inv_3" }, "call_other"), descriptor("write"), context()),
+    ).resolves.toMatchObject({ action: "run", decidedBy: "grant" });
+    expect(grantLists()).toBe(2);
+  });
+});

--- a/packages/guard/test/grant-filter.test.ts
+++ b/packages/guard/test/grant-filter.test.ts
@@ -1,4 +1,4 @@
-import type { PermissionGrant, VendoRecord } from "@vendoai/core";
+import type { GrantId, PermissionGrant, VendoRecord } from "@vendoai/core";
 import { descriptorHash } from "@vendoai/core";
 import { afterEach, describe, expect, it } from "vitest";
 import { createGuard } from "../src/index.js";
@@ -98,33 +98,32 @@ describe("grants are filtered by tool in the query, not in JavaScript", () => {
     });
   });
 
-  it("reads the grants once for a preview and the real call it precedes", async () => {
+  /** The grant is not a decision input the way a rule is — it IS the authority
+   *  the call executes on, and the preview-to-dispatch gap is exactly the
+   *  window the kill switch's own re-read comment (guard.ts, `bind().execute`)
+   *  exists to close. A permission taken back inside that window must bite
+   *  there too, so the grants are read again for the real pass. */
+  it("refuses a call whose grant was revoked between the preview and the real call", async () => {
     const sqlStore = await store();
-    await seedGrant(sqlStore, { descriptor: descriptor("write") });
+    const grant = await seedGrant(sqlStore, { descriptor: descriptor("destructive") });
     const guard = createGuard({ store: sqlStore });
-    const write = call("host_write", { invoiceId: "inv_2" }, "call_previewed");
-    const emitted = recordSql(sqlStore);
-    const grantLists = (): number =>
-      emitted.filter((sql) => sql.includes("FROM vendo_grants") && sql.includes("subject =")).length;
+    const tools = new FixtureTools();
+    const bound = guard.bind(tools);
+    const destructive = call("host_destructive", { invoiceId: "inv_2" }, "call_revoked");
 
-    // The bridge previews, then makes the REAL dispatching call moments later
-    // for the same call id — one logical call, and the standing grants behind
-    // it are read for it once.
-    await expect(guard.previewCheck!(write, descriptor("write"), context())).resolves.toMatchObject({
-      action: "run",
-      decidedBy: "grant",
-    });
-    expect(grantLists()).toBe(1);
-    await expect(guard.check(write, descriptor("write"), context())).resolves.toMatchObject({
-      action: "run",
-      decidedBy: "grant",
-    });
-    expect(grantLists()).toBe(1);
-
-    // A DIFFERENT call is not that call: it reads for itself.
+    // The SDK previews first: the standing grant answers, so nothing pauses.
     await expect(
-      guard.check(call("host_write", { invoiceId: "inv_3" }, "call_other"), descriptor("write"), context()),
+      guard.previewCheck!(destructive, descriptor("destructive"), context()),
     ).resolves.toMatchObject({ action: "run", decidedBy: "grant" });
-    expect(grantLists()).toBe(2);
+
+    // …and the person takes the permission back before the dispatch.
+    await guard.grants.revoke(grant.id as GrantId, alice);
+
+    // The real pass has to see that. Without the grant, a destructive call
+    // needs a human — it parks, and the tool never runs.
+    await expect(bound.execute(destructive, context())).resolves.toMatchObject({
+      status: "pending-approval",
+    });
+    expect(tools.executions).toHaveLength(0);
   });
 });

--- a/packages/store/src/workspace-fs.ts
+++ b/packages/store/src/workspace-fs.ts
@@ -527,31 +527,35 @@ export class WorkspaceStoreFs implements WorkspaceFs {
    * Only paths whose bytes actually changed are written (§3.5), so `changed` is
    * the honest O(files changed) count. `/user/scratch/**` never lands.
    */
+  /**
+   * Build contract §8/§9.3 — the box is born filtered, so `can()` runs at
+   * exactly two moments; this is the second. Live rows, per changed path,
+   * BEFORE anything is placed: a mid-session revoke must bite here even though
+   * the reads it already served stand.
+   */
+  private async assertCommittable(): Promise<void> {
+    if (this.mounts.canCommit === undefined) return;
+    for (const path of [...this.staged.keys(), ...this.removed]) {
+      if (!this.persists(path)) continue;
+      if (await this.mounts.canCommit(path)) continue;
+      // §9.4 — `forbidden` says "you can see this, but not change it", and the
+      // fork offer renders off exactly that. A caller who cannot even view the
+      // path gets what a path that isn't there gets, or the code itself becomes
+      // an existence oracle for every org app id.
+      if (this.mounts.canView !== undefined && !(await this.mounts.canView(path))) {
+        throw pathNotFound(path);
+      }
+      throw pathForbidden(path);
+    }
+  }
+
   async commit(opts?: { message?: string }): Promise<CommitResult> {
     // The harness commits after EVERY tool call (harnesses/runtime.ts), and
     // almost none of them touched a file. Nothing staged and nothing removed is
     // nothing to place, nothing to land and nothing to say — answer without
     // touching the store at all.
     if (this.staged.size === 0 && this.removed.size === 0) return { status: "ok", changed: [] };
-    // Build contract §8/§9.3 — the box is born filtered, so `can()` runs at
-    // exactly two moments; this is the second. Live rows, per changed path,
-    // BEFORE anything is placed: a mid-session revoke must bite here even
-    // though the reads it already served stand.
-    if (this.mounts.canCommit !== undefined) {
-      for (const path of [...this.staged.keys(), ...this.removed]) {
-        if (!this.persists(path)) continue;
-        if (!(await this.mounts.canCommit(path))) {
-          // §9.4 — `forbidden` says "you can see this, but not change it", and
-          // the fork offer renders off exactly that. A caller who cannot even
-          // view the path gets what a path that isn't there gets, or the code
-          // itself becomes an existence oracle for every org app id.
-          if (this.mounts.canView !== undefined && !(await this.mounts.canView(path))) {
-            throw pathNotFound(path);
-          }
-          throw pathForbidden(path);
-        }
-      }
-    }
+    await this.assertCommittable();
     const landing: PreparedWrite[] = [];
     for (const [path, staged] of this.staged) {
       if (!this.persists(path)) continue;
@@ -600,7 +604,6 @@ export class WorkspaceStoreFs implements WorkspaceFs {
     for (const path of [...this.removed].filter((candidate) => this.persists(candidate))) {
       entriesFor(this.ownerOf(path)!).push({ path, delete: true });
     }
-    this.removed.clear();
     for (const prepared of landing) {
       // Build contract §9.7 — commit policy is PER MOUNT: `/user` keeps the
       // last-write-wins re-aim loop, `/orgs` is strict compare-and-swap, so a
@@ -623,6 +626,12 @@ export class WorkspaceStoreFs implements WorkspaceFs {
     for (const [owner, entries] of byOwner) {
       const result = await this.rows.commitAll(owner, entries, opts?.message);
       conflicts.push(...result.conflicts);
+      // A refused commit removed nothing, so the deletions stay STAGED: the
+      // caller re-reads and re-applies the same turn, and a delete it never
+      // landed must be part of what it re-applies.
+      if (result.conflicts.length === 0) {
+        for (const entry of entries) if ("delete" in entry) this.removed.delete(entry.path);
+      }
       for (const path of result.removed) {
         this.index.delete(path);
         changed.push(path);

--- a/packages/store/src/workspace-fs.ts
+++ b/packages/store/src/workspace-fs.ts
@@ -15,7 +15,12 @@ import {
   type WorkspaceFs,
   type WriteFileOptions,
 } from "@vendoai/core";
-import type { PreparedWrite, WorkspaceFileMeta, WorkspaceRows } from "./workspace-rows.js";
+import type {
+  PreparedWrite,
+  WorkspaceCommitEntry,
+  WorkspaceFileMeta,
+  WorkspaceRows,
+} from "./workspace-rows.js";
 
 /** Build contract §3.1 — the frozen layout. `/user` is the subject's, rw;
     `/orgs/<orgId>` is one mount per ASSERTED membership (§9.7), owned by the
@@ -523,6 +528,11 @@ export class WorkspaceStoreFs implements WorkspaceFs {
    * the honest O(files changed) count. `/user/scratch/**` never lands.
    */
   async commit(opts?: { message?: string }): Promise<CommitResult> {
+    // The harness commits after EVERY tool call (harnesses/runtime.ts), and
+    // almost none of them touched a file. Nothing staged and nothing removed is
+    // nothing to place, nothing to land and nothing to say — answer without
+    // touching the store at all.
+    if (this.staged.size === 0 && this.removed.size === 0) return { status: "ok", changed: [] };
     // Build contract §8/§9.3 — the box is born filtered, so `can()` runs at
     // exactly two moments; this is the second. Live rows, per changed path,
     // BEFORE anything is placed: a mid-session revoke must bite here even
@@ -574,13 +584,21 @@ export class WorkspaceStoreFs implements WorkspaceFs {
       if (prepared !== "unchanged") landing.push(prepared);
     }
 
-    const changed: string[] = [];
-    const conflicts: string[] = [];
-    for (const path of [...this.removed].filter((candidate) => this.persists(candidate))) {
-      if (await this.rows.remove(this.ownerOf(path)!, path, opts?.message)) {
-        this.index.delete(path);
-        changed.push(path);
+    // One batched commit per OWNER: the store's commit verb addresses one
+    // drawer, and a mount's owner is a pure function of its path — so a turn
+    // that touched `/user` and `/orgs` sends two, which is also what keeps an
+    // org conflict from taking the same turn's `/user` edit down with it.
+    const byOwner = new Map<string, WorkspaceCommitEntry[]>();
+    const entriesFor = (owner: string): WorkspaceCommitEntry[] => {
+      let entries = byOwner.get(owner);
+      if (entries === undefined) {
+        entries = [];
+        byOwner.set(owner, entries);
       }
+      return entries;
+    };
+    for (const path of [...this.removed].filter((candidate) => this.persists(candidate))) {
+      entriesFor(this.ownerOf(path)!).push({ path, delete: true });
     }
     this.removed.clear();
     for (const prepared of landing) {
@@ -588,29 +606,40 @@ export class WorkspaceStoreFs implements WorkspaceFs {
       // last-write-wins re-aim loop, `/orgs` is strict compare-and-swap, so a
       // lost swap comes back as `conflict` for the harness to re-read and
       // re-apply rather than silently overwriting a colleague.
-      const owner = this.ownerOf(prepared.path)!;
-      const strict = !under(prepared.path, USER_MOUNT);
-      const written = await this.rows.land(owner, prepared, opts?.message, {
-        strict,
+      entriesFor(this.ownerOf(prepared.path)!).push({
+        path: prepared.path,
+        write: prepared,
+        strict: !under(prepared.path, USER_MOUNT),
         // The revision this TURN opened with (§3.5's checkout base), not the
         // head at commit time — the whole point of CAS is to notice the edit
         // that landed in between.
         expectedRevision: this.index.get(prepared.path)?.revision ?? null,
       });
-      if (written.conflict === true) {
-        conflicts.push(prepared.path);
-        continue;
+    }
+
+    const changed: string[] = [];
+    const conflicts: string[] = [];
+    const placed = new Map(landing.map((prepared) => [prepared.path, prepared.bytes]));
+    for (const [owner, entries] of byOwner) {
+      const result = await this.rows.commitAll(owner, entries, opts?.message);
+      conflicts.push(...result.conflicts);
+      for (const path of result.removed) {
+        this.index.delete(path);
+        changed.push(path);
       }
-      this.index.set(prepared.path, {
-        path: prepared.path,
-        owner,
-        bytes: prepared.bytes,
-        revision: written.revision,
-        updatedAt: written.updatedAt,
-      });
-      // A concurrent commit may have already stored these exact bytes, in which
-      // case this commit wrote nothing and must not claim the file changed.
-      if (written.landed) changed.push(prepared.path);
+      for (const written of result.landed) {
+        this.index.set(written.path, {
+          path: written.path,
+          owner,
+          bytes: placed.get(written.path)!,
+          revision: written.revision,
+          updatedAt: written.updatedAt,
+        });
+        // A concurrent commit may have already stored these exact bytes, in
+        // which case this commit wrote nothing and must not claim the file
+        // changed.
+        if (written.changed) changed.push(written.path);
+      }
     }
     if (conflicts.length > 0) return { status: "conflict", paths: conflicts.sort() };
     // Committed files now read through the store like everything else.

--- a/packages/store/src/workspace-ops-rows.ts
+++ b/packages/store/src/workspace-ops-rows.ts
@@ -1,6 +1,7 @@
 import { VendoError, type StoreOps } from "@vendoai/core";
 import { iso } from "./helpers/utils.js";
 import type {
+  CommitAllResult,
   WorkspaceFileMeta,
   WorkspaceHistoryEntry,
   WorkspaceRows,
@@ -123,30 +124,35 @@ export function workspaceOpsRows(ops: StoreOps): WorkspaceRows {
     return commits;
   };
 
+  /** One owner's whole path index. */
+  const indexOf = async (owner: string): Promise<WorkspaceFileMeta[]> => {
+    const metas: WorkspaceFileMeta[] = [];
+    let cursor: string | undefined;
+    do {
+      const page = await ops.workspace.index({
+        owner,
+        ...(cursor === undefined ? {} : { cursor }),
+      });
+      for (const entry of page.entries) {
+        const row = entry as Record<string, unknown>;
+        if (typeof row["path"] !== "string") continue;
+        metas.push({
+          path: row["path"],
+          owner,
+          bytes: Number(row["bytes"] ?? 0),
+          revision: Number(row["revision"] ?? 0),
+          updatedAt: iso(row["updatedAt"] ?? new Date(0).toISOString()),
+        });
+      }
+      cursor = page.cursor;
+    } while (cursor !== undefined);
+    return metas;
+  };
+
   return {
     async index(owners) {
       const metas: WorkspaceFileMeta[] = [];
-      for (const owner of owners) {
-        let cursor: string | undefined;
-        do {
-          const page = await ops.workspace.index({
-            owner,
-            ...(cursor === undefined ? {} : { cursor }),
-          });
-          for (const entry of page.entries) {
-            const row = entry as Record<string, unknown>;
-            if (typeof row["path"] !== "string") continue;
-            metas.push({
-              path: row["path"],
-              owner,
-              bytes: Number(row["bytes"] ?? 0),
-              revision: Number(row["revision"] ?? 0),
-              updatedAt: iso(row["updatedAt"] ?? new Date(0).toISOString()),
-            });
-          }
-          cursor = page.cursor;
-        } while (cursor !== undefined);
-      }
+      for (const owner of owners) metas.push(...await indexOf(owner));
       return metas.sort((left, right) => (left.path < right.path ? -1 : 1));
     },
 
@@ -209,6 +215,63 @@ export function workspaceOpsRows(ops: StoreOps): WorkspaceRows {
         throw error;
       }
       return { landed: true, revision: checkedOut + 1, updatedAt: new Date().toISOString() };
+    },
+
+    /** The whole turn in ONE `workspace.commit` — the wire has been
+        array-shaped all along, and the per-path loop this replaces paid a round
+        trip per file. Per-entry `expectedRevision` rides along unchanged, so
+        the strict mounts keep their compare-and-swap and a stale one still
+        refuses the WHOLE commit. */
+    async commitAll(owner, entries, _intent) {
+      const wire: unknown[] = [];
+      const landed: CommitAllResult["landed"] = [];
+      const removed: string[] = [];
+      const guarded = new Map<string, number | null>();
+      for (const entry of entries) {
+        if ("delete" in entry) {
+          // The wire's tombstone never says whether a row was there, and the
+          // façade counts only real removals — so ask, exactly as the per-path
+          // remove did.
+          if ((await readOne(owner, entry.path)) === undefined) continue;
+          wire.push({ path: entry.path, delete: true });
+          removed.push(entry.path);
+          continue;
+        }
+        if (entry.strict) guarded.set(entry.path, entry.expectedRevision);
+        wire.push({
+          path: entry.path,
+          data: workspaceBytesToJson(entry.write.content),
+          ...(entry.strict ? { expectedRevision: entry.expectedRevision } : {}),
+        });
+        landed.push({
+          // The server assigns the real revision; this is the checked-out one
+          // plus one, exactly as the per-path `land` reported it.
+          path: entry.path,
+          revision: (entry.expectedRevision ?? 0) + 1,
+          updatedAt: new Date().toISOString(),
+          changed: true,
+        });
+      }
+      if (wire.length === 0) return { conflicts: [], landed: [], removed: [] };
+      try {
+        await ops.workspace.commit(wire, { owner });
+      } catch (error) {
+        if (!(error instanceof VendoError) || error.code !== "conflict") throw error;
+        // §9.7 — a lost swap is the frozen conflict branch, not a failure. The
+        // refusal names no path on the wire (the error envelope carries a code
+        // and a message, nothing else), so read the heads back and re-run the
+        // server's own comparison: nothing landed, so a guarded path whose head
+        // is not what this turn checked out is precisely one that moved.
+        const heads = new Map((await indexOf(owner)).map((meta) => [meta.path, meta.revision]));
+        const conflicts = [...guarded]
+          .filter(([path, at]) => (heads.get(path) ?? null) !== at)
+          .map(([path]) => path);
+        // A conflict under no moved path is not this branch — it is the
+        // idempotency ledger refusing a reused key, and it belongs to the caller.
+        if (conflicts.length === 0) throw error;
+        return { conflicts, landed: [], removed: [] };
+      }
+      return { conflicts: [], landed, removed };
     },
 
     async discard() {

--- a/packages/store/src/workspace-rows.ts
+++ b/packages/store/src/workspace-rows.ts
@@ -471,16 +471,20 @@ export function workspaceRows(db: Db, files: FilesAdapter): WorkspaceRows {
     /** The batch is a LOOP here, deliberately: these statements are already on
         the database's own connection, so there is no round trip to save, and
         each path keeps the per-path compare-and-swap (and the re-aim loop the
-        /user mounts depend on) exactly as `land` gives it. */
+        /user mounts depend on) exactly as `land` gives it.
+
+        The two passes are ordered, and that order is the safety property: the
+        writes go first, and a single lost swap cancels every TOMBSTONE in the
+        batch. A delete that landed ahead of the conflict would be silent data
+        loss — the caller is told `conflict`, re-reads, retries, and the file it
+        never got to keep is already gone (a delete has no CAS of its own to
+        refuse it, and history's copy is not what the caller asked for). */
     async commitAll(owner, entries, intent) {
       const conflicts: string[] = [];
       const landed: CommitAllResult["landed"] = [];
       const removed: string[] = [];
       for (const entry of entries) {
-        if ("delete" in entry) {
-          if (await removeRow(owner, entry.path, intent)) removed.push(entry.path);
-          continue;
-        }
+        if ("delete" in entry) continue;
         const written = await landRow(owner, entry.write, {
           ...(intent === undefined ? {} : { intent }),
           ...(entry.strict ? { strict: true } : {}),
@@ -496,6 +500,11 @@ export function workspaceRows(db: Db, files: FilesAdapter): WorkspaceRows {
           updatedAt: written.updatedAt,
           changed: written.landed,
         });
+      }
+      if (conflicts.length > 0) return { conflicts, landed, removed };
+      for (const entry of entries) {
+        if (!("delete" in entry)) continue;
+        if (await removeRow(owner, entry.path, intent)) removed.push(entry.path);
       }
       return { conflicts, landed, removed };
     },

--- a/packages/store/src/workspace-rows.ts
+++ b/packages/store/src/workspace-rows.ts
@@ -100,6 +100,23 @@ export interface PreparedWrite {
   prior: Current | undefined;
 }
 
+/** One path's mutation inside a batched commit: a prepared write to land, or a
+ *  tombstone. `expectedRevision` is the revision the turn checked out (`null` =
+ *  "did not exist then"), and `strict` is the mount's policy — the same pair
+ *  `land` takes, per entry. */
+export type WorkspaceCommitEntry =
+  | { path: string; write: PreparedWrite; strict: boolean; expectedRevision: number | null }
+  | { path: string; delete: true };
+
+/** What one batched commit did: the paths that lost their compare-and-swap, the
+ *  rows that now hold new content (`changed` false when the head already held
+ *  exactly these bytes), and the tombstones that actually removed a row. */
+export interface CommitAllResult {
+  conflicts: string[];
+  landed: Array<{ path: string; revision: number; updatedAt: IsoDateTime; changed: boolean }>;
+  removed: string[];
+}
+
 /** Row-level access to the workspace pair (build contract §3.3). Content lands
  *  inline or in the files adapter; every overwrite appends the superseded
  *  revision to history. */
@@ -134,6 +151,16 @@ export interface WorkspaceRows {
       expectedRevision?: number | null;
     },
   ): Promise<{ landed: boolean; revision: number; updatedAt: IsoDateTime; conflict?: true }>;
+  /** Land a whole commit's worth of entries — the turn's removals and its
+      prepared writes, in one pass. The SQL backend runs the same per-path
+      statements `land`/`remove` do; a backend over the 42-op wire sends ONE
+      `workspace.commit`, which is what takes a turn's commit from a round trip
+      per file to a round trip. */
+  commitAll(
+    owner: string,
+    entries: ReadonlyArray<WorkspaceCommitEntry>,
+    intent?: string,
+  ): Promise<CommitAllResult>;
   /** Drop a prepared write that will never land, so its blob is not orphaned. */
   discard(prepared: PreparedWrite): Promise<void>;
   /** Deleting records what it removed, because history is append-only (§3.3).
@@ -383,6 +410,17 @@ export function workspaceRows(db: Db, files: FilesAdapter): WorkspaceRows {
     );
   };
 
+  const removeRow = async (owner: string, path: string, intent?: string): Promise<boolean> => {
+    const current = await currentOf(owner, path);
+    if (current === undefined) return false;
+    // History is append-only (§3.3): the delete records what it removed, so
+    // the blob stays — the history row is its pointer now.
+    await appendHistory(owner, path, current, intent, new Date().toISOString());
+    await db.query("DELETE FROM vendo_workspace_files WHERE path = $1 AND owner = $2", [path, owner]);
+    await trim(owner, path);
+    return true;
+  };
+
   return {
     async index(owners) {
       const result = await db.query(
@@ -430,19 +468,44 @@ export function workspaceRows(db: Db, files: FilesAdapter): WorkspaceRows {
       });
     },
 
+    /** The batch is a LOOP here, deliberately: these statements are already on
+        the database's own connection, so there is no round trip to save, and
+        each path keeps the per-path compare-and-swap (and the re-aim loop the
+        /user mounts depend on) exactly as `land` gives it. */
+    async commitAll(owner, entries, intent) {
+      const conflicts: string[] = [];
+      const landed: CommitAllResult["landed"] = [];
+      const removed: string[] = [];
+      for (const entry of entries) {
+        if ("delete" in entry) {
+          if (await removeRow(owner, entry.path, intent)) removed.push(entry.path);
+          continue;
+        }
+        const written = await landRow(owner, entry.write, {
+          ...(intent === undefined ? {} : { intent }),
+          ...(entry.strict ? { strict: true } : {}),
+          expectedRevision: entry.expectedRevision,
+        });
+        if (written.conflict === true) {
+          conflicts.push(entry.path);
+          continue;
+        }
+        landed.push({
+          path: entry.path,
+          revision: written.revision,
+          updatedAt: written.updatedAt,
+          changed: written.landed,
+        });
+      }
+      return { conflicts, landed, removed };
+    },
+
     async discard(prepared) {
       await dropBlob(prepared.stored);
     },
 
     async remove(owner, path, intent) {
-      const current = await currentOf(owner, path);
-      if (current === undefined) return false;
-      // History is append-only (§3.3): the delete records what it removed, so
-      // the blob stays — the history row is its pointer now.
-      await appendHistory(owner, path, current, intent, new Date().toISOString());
-      await db.query("DELETE FROM vendo_workspace_files WHERE path = $1 AND owner = $2", [path, owner]);
-      await trim(owner, path);
-      return true;
+      return await removeRow(owner, path, intent);
     },
 
     async moveApp(appId, from, to) {

--- a/packages/store/tests/workspace.orgs.test.ts
+++ b/packages/store/tests/workspace.orgs.test.ts
@@ -258,6 +258,51 @@ for (const backend of backends()) {
         const settled = await workspace().open(dana, { memberships: acme });
         expect(await settled.readFile(userPath)).toBe("dana's own");
       });
+
+      /**
+       * A refused commit must not have applied a DELETION. This is the one
+       * failure in the conflict branch that cannot be recovered from: the
+       * caller is told `conflict`, re-reads, re-applies — and a file that is
+       * already gone is gone, because a delete has no compare-and-swap of its
+       * own to refuse it and history's copy is not what the caller asked for.
+       * So the ordering inside a batched commit is a safety property, not a
+       * detail: every write lands first, and one lost swap cancels every
+       * tombstone in the batch. Both halves are pinned here — the file survives
+       * AND the deletion is still staged, so the re-apply the conflict branch
+       * asks for carries it.
+       *
+       * This is why the ordering may not be "simplified" back: it was wrong for
+       * the whole life of the per-path loop that preceded `commitAll`, and the
+       * loss was silent both times.
+       */
+      it("a conflicted commit leaves the deletions in it unapplied and still staged", async () => {
+        const doomed = "/orgs/acme/files/doomed.md";
+        const contested = "/orgs/acme/files/contested.md";
+        const seed = await workspace().open(dana, { memberships: acme });
+        await seed.writeFile(doomed, "still needed");
+        await seed.writeFile(contested, "base");
+        expect((await seed.commit()).status).toBe("ok");
+
+        // A colleague moves the contested file's head, so this turn's commit
+        // has to lose it.
+        const mine = await workspace().open(dana, { memberships: acme });
+        const theirs = await workspace().open(kim, { memberships: acme });
+        await theirs.writeFile(contested, "kim wins");
+        expect((await theirs.commit()).status).toBe("ok");
+
+        // One turn, two mutations on the same mount: a delete and an overwrite.
+        await mine.rm(doomed);
+        await mine.writeFile(contested, "dana loses");
+        expect(await mine.commit()).toEqual({ status: "conflict", paths: [contested] });
+
+        const after = await workspace().open(dana, { memberships: acme });
+        expect(await after.exists(doomed)).toBe(true);
+        expect(await after.readFile(doomed)).toBe("still needed");
+
+        // …and the turn's own intent survives, so re-applying onto the new head
+        // still deletes the file the caller asked to delete.
+        expect(await mine.exists(doomed)).toBe(false);
+      });
     });
 
     describe("the sandbox checkout/commit helpers (wave-2 lane E consumes these)", () => {


### PR DESCRIPTION
Slice 6 of the fast-datastore project — the client stops re-reading, per tool call, what it already knows. Three of the five items landed, one stopped on a load-bearing comment, and one (C) was reverted in review because it opened a permissions window. Net: ~3 fewer datastore calls per tool call.

## A. Freeze flag: cached at check time, fresh at the gate
`packages/guard/src/guard.ts` — `frozen()` gains `{ cached?: boolean }`, and only `#checkWithMetadata`'s read passes it. The pre-execute gate at the dispatch site is byte-identical: it still reads the store, so the invariant its comment spells out ("a freeze that lands during the judge's 15s window must still block execution") is unchanged. Every fresh read — this guard's own `freeze()`/`unfreeze()` included — refreshes the cached value, so an in-process flip is visible at once and only another process's flip can be up to 10s stale, and only for a DECISION.

**Deviation from the blueprint**: the option is `{ cached: true }` opt-in, not `{ fresh: true }` opt-out. A default-cached `frozen()` breaks `freeze.test.ts` -> "obeys a flag row written straight through the store, as the console writes it", which flips the row out of process and expects the public `frozen()` to answer the store. Code wins.

**Calls per tool call: 3 freeze reads -> 1** (2 on the first call of a 10s window).

## B. Grants filtered server-side
`refs: { subject, tool: call.tool }`; the routed door maps the ref to the indexed `tool` column, and the JS `continue` is gone. `invalidated` is unaffected — it only ever collected same-tool grants. The response also shrinks from every grant the subject ever held to that tool's.

## C. The preview pass shares its grant read with the real pass — REMOVED in review
Shipped and then reverted, on the reviewer's finding: a grant revoked (or expired) between the preview and the real, dispatching pass was not seen, so the tool ran on a permission the person had already taken back. A grant is not a decision input the way a rule is — it IS the authority the call executes on, so the preview-to-dispatch gap is exactly the window the kill switch's re-read comment exists to close, and it gets the same answer: read it again. The pipeline reads the grants for the real pass, and `grant-filter.test.ts` now pins that a revoked grant parks instead of running. No revocation-aware cache was attempted: one wire call per tool call does not buy that window.

The replay read is unshared for its own reason — the single-use CAS spend belongs to the real pass.

## D. Workspace: true no-op commit + one batched commit
`commit()` returns early when nothing is staged and nothing is removed (the harness calls it after every tool call). The remove pass and the land pass collapse into a new `commitAll(owner, entries, message?)` on the rows adapter: the hosted backend sends ONE `workspace.commit`, the SQL backend keeps its per-path statements and just wraps them. Entries are grouped by OWNER, because the commit verb addresses one drawer — which is also what keeps an org conflict from taking the same turn's `/user` edit down with it.

Preserved exactly: per-entry `expectedRevision` including the null create-only guard, and a stale one still refusing the WHOLE commit with `conflict`. The wire error carries no path list, so the hosted backend re-reads the heads on the conflict branch and re-runs the server's own comparison to name the paths that moved.

**Calls per turn (hosted): one commit per removal + one per landed file -> 1 per owner touched.**

### What this does NOT do
The ordering fix is ORDERING, not atomicity, and the residual is real: a lost swap can still leave earlier `/user` writes from the same commit applied — that is last-write-wins, which those mounts already promise, and it is not data loss. Genuine atomicity would need the row statements inside one transaction, and the blocker is the blob deletes: `trim` and `remove` release objects through the files adapter inside that scope, so a rollback would leave a row pointing at an object that is already gone. That is a separate lane, deliberately not taken here. The hosted backend is already atomic — one wire commit, refused whole, server-side.

### Pre-existing, not a regression
The deletion loss is NOT introduced by this branch. The same reproduction fails on `origin/main`: the per-path loop that `commitAll` replaces also removed before it landed, and the loss was silent there too. This branch's batching neither caused it nor hid it — it is fixed here because it breaks this slice's own "a stale revision refuses the WHOLE commit" requirement, and because the reproduction was in hand. Attribute it to the old path, not to the batch.

## E. Amortized sweep — STOPPED, not done
`packages/vendo/src/server.ts` is untouched. The ordering comment there calls itself LOAD-BEARING and pins the awaited sweep as step 1 "before anything", and the sweep's own comment gives the reason: "Awaited BEFORE the request is handled, so a request arriving past a TTL sees the swept state rather than racing its own sweep." Detaching the amortized leg is exactly the race that comment closes — an expired parked approval could still be answerable by the request that triggered the sweep. `byo-approvals-wire.test.ts` -> "expires an orphaned parked call via the on-request sweep and serves expired" depends on it. Reporting rather than reordering a documented invariant.

## Tests
New seams (`packages/guard/test/`):
- `freeze-cache.test.ts` — the flag is flipped through the real store write path (the console's own path). A check-time read is served from the cache with the store untouched, AND a freeze landing inside a judge's await still refuses the dispatch. **Prove-it-can-fail**: pointing the pre-execute gate at the cache turns both cases red, the second on `{status:'ok'}` — the tool ran while frozen.
- `grant-filter.test.ts` — grants for several tools written through the real store; the emitted SQL carries `tool = $n`, the selected grant is identical to what the old JS filter would have chosen off the unfiltered list, and a grant revoked between the preview and the real call parks instead of running (finding 1's regression).

Regression test for the deletion loss, in the suite that owns the conflict branch:
- `packages/store/tests/workspace.orgs.test.ts` — "a conflicted commit leaves the deletions in it unapplied and still staged". **Prove-it-can-fail**: restoring the pre-fix ordering turns it red on the surviving file.

Green: whole `@vendoai/guard` suite (288), whole `@vendoai/store` suite (569 — workspace, workspace.erase, flip-guards.conformance included), whole `@vendoai/harnesses` suite (550), `packages/vendo` org-policy + byo-approvals-wire + sweep-failure-isolation (20). Root gate `pnpm build && pnpm typecheck && pnpm lint` — 21/21, 42/42, 4/4.

One unasked-for change, on the record: `commit()`'s permission gate moved verbatim into `assertCommittable()` because the new branch pushed the method past the repo's cognitive-complexity ceiling. Behaviour-preserving — a pure move of the `canCommit`/`canView` block with its comments, no condition altered — and covered by the full store suite re-run after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces client reads in guard checks and workspace commits while preserving gating and CAS semantics. Fixes two correctness gaps: a revoke between preview and execute now blocks, and a conflicted commit no longer removes files.

- Guard
  - `frozen({ cached: true })` adds a 10s cache for the check-time freeze read; the pre-execute gate still does a fresh read. In-process `freeze()/unfreeze()` refresh the cache. 3 reads → 1 (2 on the first call in a window).
  - Grants list filters server-side with `refs: { subject, tool }`; `invalidated` stays same-tool only.
  - Preview vs. execute: the real pass re-reads grants; replay is also unshared. A revoke/expiry between preview and execute now blocks as expected.
  - Tests: `freeze-cache.test.ts` and `grant-filter.test.ts` cover caching, server-side filtering, and preview-to-execute revocation.

- Store
  - `WorkspaceStoreFs.commit()` returns early when nothing is staged or removed.
  - Per-owner batching: `WorkspaceRows.commitAll(owner, entries, message?)` sends one `workspace.commit` on hosted backends; SQL keeps per-path statements. Per-entry `expectedRevision` is preserved.
  - Conflicts and deletions: writes land first; any CAS conflict returns `conflict` and skips deletions. The façade keeps deletions staged for retry. Changed files only include paths that wrote new bytes. One commit per removal/landed file → 1 per owner.
  - Test: `packages/store/tests/workspace.orgs.test.ts` pins that a conflicted commit leaves deletions unapplied and still staged.

<sup>Written for commit 63dd94caf7565027eda400dfeb47d2130f6530d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

