### PR TITLE
docs: Linkwarden official example — pointer + integration guide (ENG-381/382)

### DIFF
--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -67,7 +67,8 @@
         "tag": "Beta",
         "pages": [
           "vendo-agent/quickstart",
-          "vendo-agent/overview"
+          "vendo-agent/overview",
+          "vendo-agent/linkwarden"
         ]
       },
       {

--- a/docs-site/vendo-agent/linkwarden.mdx
+++ b/docs-site/vendo-agent/linkwarden.mdx
@@ -103,7 +103,24 @@ serverExternalPackages: ["esbuild", "@electric-sql/pglite"],
 Without it, Next tries to bundle the build engine and the dev store's native
 pieces into the server bundle.
 
-## 6. `VENDO_BASE_URL`, before you need it
+## 6. Older tsconfigs: `moduleResolution`
+
+Linkwarden's tsconfig carried the legacy `"moduleResolution": "node"`, which
+cannot resolve `@vendoai/*` subpath **types** (`@vendoai/vendo/server`,
+`@vendoai/ui/chrome`). Dev mode never type-checks, so everything *runs* — the
+first `next build` fails. The fix is one line:
+
+```json
+"moduleResolution": "bundler"
+```
+
+One knock-on to know about: bundler resolution makes every dependency's
+`exports` map authoritative. Linkwarden had a single bare
+`import { Provider } from "next-auth/providers"` that only legacy resolution
+tolerated — it becomes `next-auth/providers/index`. Run your app's production
+build once right after integrating; it catches this whole class.
+
+## 7. `VENDO_BASE_URL`, before you need it
 
 Set the deployment's full public URL (locally, `http://localhost:3000`):
 same-origin trust, the MCP door's base, and **the callback URLs handed to
@@ -111,7 +128,7 @@ sandbox machines** all hang off it — machine provisioning fails without it,
 and `vendo init` writes it into `.env.example`, not your live env file.
 See [Environment variables](/reference/environment-variables).
 
-## 7. What you get
+## 8. What you get
 
 Sign in, click the launcher: ask for things the product has no UI for ("show my
 dead links by collection", "tag everything from last week") and the agent

--- a/docs-site/vendo-agent/linkwarden.mdx
+++ b/docs-site/vendo-agent/linkwarden.mdx
@@ -60,6 +60,11 @@ const vendo = createVendo({
 });
 ```
 
+The cast works because Next's App Router hands the route a `NextRequest`,
+whose `cookies` is the shape v4's `getToken` reads natively — the wire passes
+that object through untouched. On a non-Next runtime, adapt the cookie header
+into your session library's expected shape instead.
+
 If your product uses Auth.js v5, Clerk, Supabase, or Auth0, this section
 doesn't apply — the zero-arg presets do it in one line. This recipe is for any
 session scheme the presets don't speak.

--- a/docs-site/vendo-agent/linkwarden.mdx
+++ b/docs-site/vendo-agent/linkwarden.mdx
@@ -1,0 +1,135 @@
+---
+title: "Worked example: a real product"
+sidebarTitle: "Worked example"
+description: "Vendo embedded in Linkwarden — a real open-source app with its own auth, its own workspace quirks, and every wall we hit on the way, with the fix for each."
+---
+
+The quickstart shows the happy path. This page shows a *real* install: Vendo
+embedded in [Linkwarden](https://github.com/linkwarden/linkwarden), an
+open-source bookmark manager we didn't write — Next.js Pages Router, next-auth
+v4, Prisma/Postgres, a yarn monorepo with its own opinions. Every section below
+is a wall we actually hit, and what fixed it.
+
+The finished result is a public fork you can run:
+[runvendo/linkwarden-vendo](https://github.com/runvendo/linkwarden-vendo)
+(AGPL-3.0, like upstream; the copyable snippets also live in the Apache-licensed
+[example pointer](https://github.com/runvendo/vendo/tree/main/examples/linkwarden)).
+
+## 1. It's a monorepo — target the app package
+
+Linkwarden's framework dependency lives in `apps/web`, not the repo root. Every
+`vendo` command operates on the directory it runs from, so install and run
+there:
+
+```bash
+yarn workspace @linkwarden/web add vendoai @vendoai/vendo @vendoai/ui
+cd apps/web
+npx vendo init
+npx vendo login   # writes the minted key to .env.local IN THIS DIRECTORY
+```
+
+Run init or login at the workspace root and detection finds no framework — or
+worse, the key lands in a `.env.local` the app never loads and everything
+silently behaves keyless. Details: [vendo init](/reference/vendo-init).
+
+## 2. The identity wall (next-auth v4)
+
+First sign-in, first chat message: **403, "no identity for this request."**
+
+Linkwarden speaks next-auth v4. Vendo's `authJs()` preset speaks Auth.js v5,
+whose cookie names and session derivation differ — v4 sessions are structurally
+unreadable, and Vendo [mints no anonymous identities](/deploy/auth), so an
+unreadable session is a refusal, not a downgrade.
+
+The fix is the documented BYO-identity path — the host resolves its own session
+and hands Vendo a principal. v4's own `getToken` already knows how to decode
+the session:
+
+```ts
+import { getToken } from "next-auth/jwt";
+
+const vendo = createVendo({
+  auth: {
+    principal: async (request: Request) => {
+      const token = await getToken({ req: request as never });
+      if (token?.sub === undefined || token.sub === null) return null;
+      return { kind: "user" as const, subject: `user_${token.sub}` };
+    },
+  },
+  // ...
+});
+```
+
+If your product uses Auth.js v5, Clerk, Supabase, or Auth0, this section
+doesn't apply — the zero-arg presets do it in one line. This recipe is for any
+session scheme the presets don't speak.
+
+## 3. Two copies of `ai`, one workspace
+
+Linkwarden's worker pins `ai@5` at the workspace root; `@vendoai/*` drives
+`ai@6`. Hoisting hands Vendo the v5 copy and every chat turn dies.
+`vendo doctor` names this ([E-DEP-001](/deploy/troubleshooting#E-DEP-001));
+in a yarn workspace the fix is a `packageExtensions` entry in `.yarnrc.yml`:
+
+```yaml
+packageExtensions:
+  "@vendoai/vendo@*":
+    dependencies:
+      ai: "^6.0.230"
+      "@auth/core": "^0.41.3"
+```
+
+## 4. One package specifier for the UI
+
+In this workspace the umbrella resolves its own nested `@vendoai/ui`, so a page
+importing the provider from `@vendoai/vendo/react` and a component from
+`@vendoai/ui` gets **two copies — two React contexts** that can't see each
+other. Import both from one specifier:
+
+```tsx
+import { VendoProvider } from "@vendoai/ui";
+import { VendoOverlay } from "@vendoai/ui/chrome";
+```
+
+Single-app repos never see this; `@vendoai/vendo/react` is the normal form.
+
+## 5. Next config
+
+```js
+// next.config.js
+serverExternalPackages: ["esbuild", "@electric-sql/pglite"],
+```
+
+Without it, Next tries to bundle the build engine and the dev store's native
+pieces into the server bundle.
+
+## 6. `VENDO_BASE_URL`, before you need it
+
+Set the deployment's full public URL (locally, `http://localhost:3000`):
+same-origin trust, the MCP door's base, and **the callback URLs handed to
+sandbox machines** all hang off it — machine provisioning fails without it,
+and `vendo init` writes it into `.env.example`, not your live env file.
+See [Environment variables](/reference/environment-variables).
+
+## 7. What you get
+
+Sign in, click the launcher: ask for things the product has no UI for ("show my
+dead links by collection", "tag everything from last week") and the agent
+answers through Linkwarden's own API, as the signed-in user, with generated
+screens. Conversations survive reloads, previous conversations sit behind the
+header's history button, and tool-step automations ("every morning, tag new
+links as seen") run on the host engine — locally, the dev server fires its own
+schedules.
+
+The fork adds one host page on top: an automations status page
+(`/vendo-automations`) listing status, granted permissions, and run history
+over the standard wire.
+
+## Run it
+
+```bash
+git clone https://github.com/runvendo/linkwarden-vendo.git
+```
+
+Quickstart, known issues, and the AGPL notice of changes live in the fork's
+[README-VENDO](https://github.com/runvendo/linkwarden-vendo/blob/vendo-integration/README-VENDO.md).

--- a/docs/superpowers/plans/2026-08-13-linkwarden-standalone-example.md
+++ b/docs/superpowers/plans/2026-08-13-linkwarden-standalone-example.md
@@ -1,0 +1,112 @@
+# Linkwarden Standalone Example Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the field-tested Linkwarden + Vendo integration as an official example: an AGPL fork under the `runvendo` org carrying our additive integration branch, plus an Apache-side pointer (`examples/linkwarden/` stub) and a docs-site guide in the vendo monorepo (ENG-381/382).
+
+**Architecture:** Two artifacts, two licenses, one rule. The fork (`runvendo/linkwarden-vendo`, AGPL-3.0 like upstream) carries the *applied* integration as a small additive commit series on a `vendo-integration` branch pinned to upstream `62f1b81`. The vendo monorepo (Apache-2.0) carries the *canonical teaching content* — every integration snippet an integrator would copy lives Apache-side (stub README + docs-site guide), and the fork merely applies it. The stub directory has **no `package.json`**, so it never joins the pnpm workspace, the audit gate, or the root overrides (which would break next-auth v4).
+
+**Tech Stack:** Linkwarden upstream (yarn 4.12 monorepo, Next 15 Pages Router, next-auth v4, Prisma/Postgres) + published `@vendoai/*` (pin 0.16.0 now; the post-merge release hasn't cut — see Global Constraints).
+
+## Global Constraints
+
+- **License wall:** zero Linkwarden (AGPL) code enters the vendo repo. Snippets flowing the other way (our route/registry into docs) are our own authorship — fine.
+- **Fork is additive:** upstream files modified only where the integration demands it (7 files); everything else is new files. Eases AGPL §5 change-marking and upstream syncs.
+- **Pin published versions:** `@vendoai/vendo` + `@vendoai/ui` at `0.16.0` (npm latest as of 2026-08-13). The `file:../vendo-branch-tarballs` resolutions in the local checkout must NOT ship. README notes what the next release adds (conversation history/resume, launcher offsets, automation-creation honesty).
+- **Secrets:** `.env` / `apps/web/.env.local` never leave the machine. `.vendo/data/` (PGlite) is gitignored; only the `.vendo` contract files (`tools.json`, `catalog.json`, `overrides.json`, `theme.json`, `theme.extracted.json`, + `policy.json` if present) are committed.
+- **Known issue disclosed:** machine-backed automations are down Cloud-side (ENG-413); the example's automation demo must use tool-step/host-event automations and say so.
+- **Vendo repo rules apply to Phase B:** branch off fresh `origin/main`, PR, six green checks, no direct pushes; docs-site ships from main on merge.
+- **Trademark courtesy:** README states "not affiliated with or endorsed by Linkwarden"; a courtesy note to upstream maintainers goes out around publish (Amr sends; draft in Task 9).
+
+## Decisions taken (flag to Amr, defaults below)
+
+1. Repo: **`runvendo/linkwarden-vendo`** (a true GitHub fork of `linkwarden/linkwarden`, renamed).
+2. Default branch of the fork: **`vendo-integration`** (visitors land on the example, `main` tracks upstream).
+3. Ship now pinned at 0.16.0 with a "next release adds…" note, rather than waiting for the release.
+
+---
+
+## Phase A — the fork
+
+### Task 1: Create the fork under runvendo
+
+**Files:** none (GitHub + git remotes).
+
+- [ ] **Step 1:** `gh repo fork linkwarden/linkwarden --org runvendo --fork-name linkwarden-vendo --clone=false`
+  - If org permissions refuse: Amr creates the fork in the GitHub UI (Fork → owner: runvendo → name: linkwarden-vendo), then continue.
+- [ ] **Step 2:** In `C:\Vendo\New_Vendo_Workspace\linkwarden`: `git remote add vendo-fork https://github.com/runvendo/linkwarden-vendo.git`
+- [ ] **Step 3:** `git checkout -b vendo-integration 62f1b81` (keeps the dirty integration files in the working tree — they are untracked/unstaged, so the branch switch carries them).
+
+### Task 2: Replace the tarball wiring with published pins
+
+**Files:** Modify `package.json` (root), `apps/web/package.json`, `.yarnrc.yml`; regenerate `yarn.lock`.
+
+- [ ] **Step 1:** Root `package.json`: delete every `resolutions` entry pointing at `file:../vendo-branch-tarballs/*`; if `@vendoai/*`/`vendoai` resolutions remain, pin them `0.16.0` (telemetry `0.5.0`).
+- [ ] **Step 2:** `apps/web/package.json`: dependencies `"@vendoai/vendo": "0.16.0"`, `"@vendoai/ui": "0.16.0"`; remove any `vendoai` alias entry left from experiments.
+- [ ] **Step 3:** `.yarnrc.yml`: keep the `packageExtensions` block (the ai@6-beside-ai@5 fix — load-bearing, documented in Task 5's README) but change the exact `ai: "6.0.230"` pin to `ai: "^6.0.28"`. Remove `YARN_CHECKSUM_BEHAVIOR`-era artifacts if any.
+- [ ] **Step 4:** `corepack yarn install` (regenerates `yarn.lock` against npm, not local tarballs).
+- [ ] **Step 5:** Verify resolution: `corepack yarn why @vendoai/vendo` → exactly one copy, `0.16.0`, under `apps/web`; `corepack yarn why ai` → v6 nested under `@vendoai/vendo`, v5 only under `@linkwarden/worker`.
+
+### Task 3: Verify the integration still runs on published 0.16.0
+
+The local field-testing ran on branch tarballs; the fork ships npm 0.16.0. Same minor, but verify, don't assume.
+
+- [ ] **Step 1:** Postgres up: `docker start linkwarden-postgres` (or the compose file if reset).
+- [ ] **Step 2:** `cmd /c "corepack yarn web:dev > <scratchpad>\linkwarden-fork-test.log 2>&1"` (background), wait for `Ready in`.
+- [ ] **Step 3:** Probe: `GET http://localhost:3000/api/vendo/status` answers the composition; log shows `[vendo] ready — … store: cloud`; sign-in probe (bad creds → 401, not 500).
+- [ ] **Step 4:** Amr does one visual pass: overlay opens, chat answers, automations page renders. (History picker/F10 is absent on 0.16.0 — expected; noted in README.)
+
+### Task 4: Commit series (additive, AGPL §5-clean)
+
+**Files:** the 7 modified + 4 new paths, split by concern. `.vendo/data/` excluded via `.gitignore` line inside `apps/web/.vendo/` (add `data/` gitignore if `vendo init` didn't).
+
+- [ ] **Step 1 — commit `feat: mount Vendo (server wire + provider + config)`:**
+  `apps/web/app/api/vendo/[...vendo]/route.ts` (host principal resolver for next-auth v4 — the #1256 recipe), `apps/web/vendo/registry.tsx`, `apps/web/pages/_app.tsx` (provider mount), `apps/web/next.config.js` (`serverExternalPackages`), `apps/web/tsconfig.json` (Next-generated churn; keep), root+web `package.json`, `.yarnrc.yml`, `yarn.lock`, `apps/web/.vendo/` contract files.
+- [ ] **Step 2 — commit `feat: automations status page`:** `apps/web/pages/vendo-automations.tsx`, `apps/web/components/Sidebar.tsx`.
+- [ ] **Step 3 — commit `docs: example README + env template`:** `apps/web/.env.example` (VENDO_API_KEY, VENDO_BASE_URL=http://localhost:3000, model-key note), `README-VENDO.md` (Task 5), `NOTICE-VENDO.md` (one paragraph: fork of linkwarden/linkwarden at 62f1b81; modifications listed; AGPL-3.0 unchanged; not affiliated with/endorsed by Linkwarden).
+- [ ] **Step 4:** Secrets sweep before any push: `git diff 62f1b81..HEAD | Select-String -Pattern 'vnd_|sk-|API_KEY=\w'` → must be empty (only `VENDO_API_KEY=` blanks in .env.example); confirm `.env*` untracked: `git status --short | Select-String '\.env'` shows only `.env.example`.
+- [ ] **Step 5:** Commits end with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+### Task 5: README-VENDO.md (the fork's front page)
+
+- [ ] **Step 1:** Write with sections: What this is (official Vendo example on a real OSS product; not affiliated with Linkwarden; AGPL-3.0); The whole diff (list the 7+4 paths with one-liners); Quickstart (docker Postgres cmd, `.env` from `.env.sample` + `apps/web/.env.example`, `corepack yarn install`, `yarn prisma:deploy`, `yarn web:dev`, sign up, click the launcher); Identity note (next-auth v4 → host-resolved principal, link to docs guide); The ai@6 packageExtension explained; Known issues (0.16.0 lacks conversation-resume — next release; machine-backed automations Cloud-side outage ENG-413 — demo tool-step automations); Where the canonical guide lives (docs.vendo.run link).
+- [ ] **Step 2:** Point GitHub's repo README rendering at it: fork Settings later, or simply have `README-VENDO.md` linked from a 3-line note appended nowhere — instead set the fork's default branch (Task 6) and rely on GitHub showing upstream `README.md`; add one line at the very top of the *new file only* — no upstream README edits.
+
+### Task 6: Push + repo settings + smoke-clone
+
+- [ ] **Step 1:** `git push vendo-fork vendo-integration`
+- [ ] **Step 2:** `gh repo edit runvendo/linkwarden-vendo --default-branch vendo-integration --description "Official Vendo example: a real OSS product (Linkwarden) with an embedded Vendo agent. AGPL-3.0 fork; not affiliated with Linkwarden."`
+- [ ] **Step 3:** Fresh-clone verification in scratchpad: clone, `corepack yarn install`, `corepack yarn workspace @linkwarden/web build` — build green is the gate (no DB needed for build; `prisma generate` runs offline).
+
+### Task 7: Minimal CI on the fork
+
+**Files:** Create `.github/workflows/build.yml` on `vendo-integration`.
+
+- [ ] **Step 1:** Workflow: on push/PR → checkout, corepack enable, `yarn install --immutable`, `yarn workspace @linkwarden/web build`. Purpose: catch `@vendoai/*` bump breakage and upstream-sync breakage cheaply. Commit `ci: build check`.
+- [ ] **Step 2:** Confirm the action run goes green on GitHub.
+
+---
+
+## Phase B — the Apache-side pointer + guide (vendo monorepo PR)
+
+### Task 8: Branch, stub, guide, PR
+
+**Files:** Create `examples/linkwarden/README.md` (NO package.json), `docs-site/vendo-agent/linkwarden.mdx`; modify `docs-site/docs.json` (nav entry in "Your product has no agent" group after `vendo-agent/overview`).
+
+- [ ] **Step 1:** `git fetch origin && git checkout -b feat/eng381-linkwarden-example origin/main` (in-place branch, no worktree — Amr's preference).
+- [ ] **Step 2:** `examples/linkwarden/README.md`: what it demonstrates; link to `runvendo/linkwarden-vendo`; the **canonical snippets inline** (route.ts with the v4 principal resolver, registry shape, `_app.tsx` mount, the packageExtension) — Apache-licensed here by living here.
+- [ ] **Step 3:** `docs-site/vendo-agent/linkwarden.mdx` — the ENG-381 guide: narrative walk of the whole integration (detect → install → init → identity wall → resolver recipe → env → automations), each step naming the trap it dodges (from the fixes changelog), ending at the fork link. Add to `docs.json` nav.
+- [ ] **Step 4:** Gates: `pnpm deps:guard` (stub has no package.json — nothing to guard, but run it), docs.json parse check, `pnpm test:affected` (docs-only → trivially green).
+- [ ] **Step 5:** PR titled `docs: Linkwarden official example — pointer + integration guide (ENG-381/382)`; body links the fork, ENG-381/382, notes the license rationale (why pointer-not-vendor). Watch checks; merge only on Amr's word. PR body ends with the standard generation footer.
+
+### Task 9: Close the loop
+
+- [ ] **Step 1:** Linear: comment on ENG-381 + ENG-382 (route chosen, fork URL, PR link); update changelog file at workspace root.
+- [ ] **Step 2:** Draft the upstream courtesy note for Amr to send (2 sentences: we published an integration-example fork under AGPL, happy to rename/adjust if you'd like).
+- [ ] **Step 3:** When the next `@vendoai` release cuts: bump the fork's pins, drop the "next release" README note, verify build CI green. (Standing follow-up; note in ENG-382.)
+
+## Self-review notes
+
+- Spec coverage: fork (T1–7), pointer (T8), guide (T8), maintenance + comms (T9) — all four deliverables of the agreed route covered.
+- The one irreversible-ish action is T1 (public repo creation) — Amr authorized runvendo placement explicitly on 2026-08-13.
+- T3 exists because tarball-tested ≠ npm-tested; do not skip it.

--- a/examples/linkwarden/README.md
+++ b/examples/linkwarden/README.md
@@ -1,0 +1,119 @@
+# Linkwarden — Vendo on a real open-source product
+
+The runnable example lives in its own repository:
+**[runvendo/linkwarden-vendo](https://github.com/runvendo/linkwarden-vendo)** —
+a fork of [Linkwarden](https://github.com/linkwarden/linkwarden) (a bookmark
+manager: Next.js Pages Router, next-auth v4, Prisma/Postgres, yarn workspaces)
+with a Vendo agent embedded the way you'd embed it in your own product.
+
+It lives outside this repo on purpose: Linkwarden is AGPL-3.0 and this repo is
+Apache-2.0, so the fork carries the *applied* integration under upstream's
+license, while this page carries the **canonical, copyable snippets** under
+this repo's. Walkthrough: the
+[integration guide](https://docs.vendo.run/vendo-agent/linkwarden) on the docs
+site.
+
+What it demonstrates that the in-repo demo hosts don't:
+
+- **A product Vendo didn't write.** Real routes, real auth, real workspace
+  quirks — every snippet below earned its place by fixing a wall we hit.
+- **The BYO-identity recipe** for a session scheme the presets don't speak
+  (next-auth v4).
+- **A workspace with a conflicting `ai` major** (worker on ai@5, Vendo needs
+  ai@6) and the resolution fix.
+
+## The whole integration
+
+Four touches on upstream files, plus new files (`vendo init` writes the
+`.vendo/` contract and route scaffold; the rest is shown here in full).
+
+### 1. The server wire, with a host-resolved principal
+
+`apps/web/app/api/vendo/[...vendo]/route.ts` — an App Router route beside the
+Pages Router app. Linkwarden speaks next-auth v4, which the stock `authJs()`
+preset (Auth.js v5) cannot read — and Vendo mints no anonymous identities, so
+an unreadable session is a hard 403. The host resolves its own session and
+hands Vendo a principal; v4's own `getToken` decodes the session JWE with
+`NEXTAUTH_SECRET`:
+
+```ts
+import { getToken } from "next-auth/jwt";
+import { createVendo, guard, nextVendoHandler } from "@vendoai/vendo/server";
+import { registry } from "../../../../vendo/registry";
+
+const vendo = createVendo({
+  auth: {
+    principal: async (request: Request) => {
+      const token = await getToken({ req: request as never });
+      if (token?.sub === undefined || token.sub === null) return null;
+      return { kind: "user" as const, subject: `user_${token.sub}` };
+    },
+  },
+  catalog: registry,
+  guard: guard({ policy: {} }), // .vendo/policy.json: destructive asks, reads run
+});
+
+export const { GET, POST, PUT, PATCH, DELETE } = nextVendoHandler(vendo);
+```
+
+On Auth.js v5, Clerk, Supabase, or Auth0 you skip all of this — `auth:
+authJs()` and friends are one line ([Auth](https://docs.vendo.run/deploy/auth)).
+
+### 2. The client mount
+
+`apps/web/pages/_app.tsx` — wrap the app, add the overlay. One subtlety this
+workspace surfaces: import provider and overlay from **one package specifier**.
+In a workspace where the umbrella resolves its own nested `@vendoai/ui` copy,
+mixing `@vendoai/vendo/react` imports with direct `@vendoai/ui` imports on the
+same page yields two React contexts that cannot see each other:
+
+```tsx
+import { VendoProvider } from "@vendoai/ui";
+import { VendoOverlay } from "@vendoai/ui/chrome";
+
+<VendoProvider baseUrl="/api/vendo">
+  {getLayout(<Component {...pageProps} />)}
+  <VendoOverlay />
+</VendoProvider>
+```
+
+(Single-app repos: `import { VendoOverlay, VendoProvider } from
+"@vendoai/vendo/react"` is the normal form.)
+
+### 3. Config
+
+`apps/web/next.config.js`:
+
+```js
+serverExternalPackages: ["esbuild", "@electric-sql/pglite"],
+```
+
+### 4. The conflicting-`ai`-major fix
+
+Root `.yarnrc.yml` — the worker holds `ai@5` at the workspace root; `@vendoai/*`
+needs `ai@6`. Give `@vendoai/vendo` its own nested copy (`vendo doctor` names
+this fix as E-DEP-001):
+
+```yaml
+packageExtensions:
+  "@vendoai/vendo@*":
+    dependencies:
+      ai: "^6.0.230"
+      "@auth/core": "^0.41.3"
+```
+
+### Env
+
+`VENDO_API_KEY` (run `npx vendo login` from `apps/web` — the key lands in that
+directory's `.env.local`) and `VENDO_BASE_URL` (the deployment's full public
+URL; machine provisioning fails without it).
+
+## Run it
+
+Quickstart, known issues, and the AGPL notice of changes:
+[runvendo/linkwarden-vendo](https://github.com/runvendo/linkwarden-vendo).
+
+<!-- No package.json here on purpose: this directory documents; the fork runs.
+     Adding a manifest would pull an AGPL yarn workspace into this pnpm
+     workspace, its dep tree into the audit gate, and next-auth v4 under the
+     root's v5 security floor. -->


### PR DESCRIPTION
## What

The Linkwarden official example (ENG-381 / ENG-382), split across the license boundary:

- **The runnable example** is a standalone AGPL fork: [runvendo/linkwarden-vendo](https://github.com/runvendo/linkwarden-vendo) — Linkwarden (Next.js Pages Router, next-auth v4, Prisma/Postgres, yarn workspaces) with a Vendo agent embedded, pinned at published `@vendoai/*` 0.18.0, field-tested, with its own build CI and an AGPL §5 notice of changes.
- **This PR** is the Apache-2.0 half: `examples/linkwarden/README.md` (the canonical, copyable snippets — the next-auth v4 host-resolved principal, the one-specifier UI mount, the ai@5/ai@6 `packageExtensions` fix, `serverExternalPackages`) and a docs-site worked-example page (`vendo-agent/linkwarden.mdx`, added to the "Your product has no agent" nav group) walking each wall a real product hit and the fix for each.

## Why a pointer and not a vendored app

Linkwarden is AGPL-3.0; this repo is Apache-2.0. Beyond the license itself, vendoring would pull a yarn-4 monorepo into the pnpm workspace, its dependency tree into the required `audit` gate, and its next-auth **v4** under the root's `next-auth >= 5.0.0-beta.32` security floor. The pointer directory therefore has **no `package.json`** — it documents; the fork runs. Teaching content stays Apache-side so integrators can copy it without AGPL obligations.

## Tests & review

- Docs-only in this repo: `docs.json` parses, dependency-guard green, no code paths touched.
- The fork itself: dev-server verification on published 0.18.0 (composition boots `sandbox: cloud · store: cloud · models: cloud`, auth path answers correctly) + a `vendo-build` CI workflow (immutable install + prisma generate + next build).

## Pending

- Fork CI's first run finishing green (in flight at PR time).
- Plan doc included: `docs/superpowers/plans/2026-08-13-linkwarden-standalone-example.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
