### PR TITLE
fix(vendo): guard upsertMany at every call site

### DIFF
--- a/packages/vendo/src/harness-turn.ts
+++ b/packages/vendo/src/harness-turn.ts
@@ -369,6 +369,14 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
       // refusal a half-write, leaving a `vendo_threads` row carrying the user's
       // message on a deployment that can never answer it.
       const { transcript, workspaces, harnessState } = sqlDoors();
+      // The batch verb, read as OPTIONAL on purpose — its type says it is always
+      // there, and a `@vendoai/store` older than it says otherwise at runtime.
+      // The group ships lockstep, so that takes pinning the packages
+      // individually (or a stale build), but an unguarded call turns it into a
+      // hard failure on turn TWO of a conversation, and `persistTurn` in
+      // `@vendoai/harnesses` already guards the same verb the same way. One
+      // policy for it, not two.
+      const batchAppend: typeof transcript.upsertMany | undefined = transcript.upsertMany;
 
       // The turn's store reads, IN FLIGHT TOGETHER (sub-1s shipment): the state
       // read needs nothing below, and `resolve()` already read the thread row —
@@ -393,7 +401,12 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
         // same three effects — the user's message, a touched `updated_at` and a
         // refreshed title — are one append, and two overlapping turns writing
         // disjoint message ids can no longer collide at all.
-        fresh
+        // `persist` also serves as the fallback when the store predates the
+        // batch verb: it is exactly what this call site did before the verb
+        // existed, and unlike a bare `upsert` it still refreshes the listing
+        // title and `updated_at`. So a turn on an older store is slower, not
+        // broken.
+        fresh || batchAppend === undefined
           ? threads.persist(thread, [input.message], { fresh })
           // No position is passed: the store assigns one while it holds the
           // thread row, so two turns racing on this conversation cannot claim

--- a/packages/vendo/tests/transcript-batch-fallback.test.ts
+++ b/packages/vendo/tests/transcript-batch-fallback.test.ts
@@ -1,0 +1,88 @@
+/**
+ * A `@vendoai/store` older than `upsertMany` must make a turn SLOWER, not
+ * broken.
+ *
+ * `harness-turn` calls the batch verb on every turn after the first, and it
+ * used to call it unconditionally while `persistTurn` in `@vendoai/harnesses`
+ * guarded the same verb — one call site protected, one not, which reads as
+ * protection that is not there. A store without the verb then failed on turn
+ * TWO of a conversation, after the first turn had already worked.
+ *
+ * The old store is spelled the way one actually behaves: the REAL transcript
+ * door with exactly that one method absent. Everything else — the composition,
+ * the model turn, the store the messages land in and are read back from — is
+ * real, so this cannot pass by agreeing with a stub.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Principal } from "@vendoai/core";
+import { createStore } from "@vendoai/store";
+import type { LanguageModel } from "ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { scriptedModel, textTurn } from "../src/agent-doubles.test-util.js";
+import { createVendo, type CreateVendoConfig } from "../src/server.js";
+
+/** The store as it shipped BEFORE the batch verb: every real door, minus the
+ *  one method. `importOriginal` keeps this a subtraction from the shipped
+ *  implementation rather than a re-implementation of it. */
+vi.mock("@vendoai/store", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@vendoai/store")>();
+  return {
+    ...actual,
+    threadMessageStore: (store: Parameters<typeof actual.threadMessageStore>[0]) => {
+      const { upsertMany: _absent, ...older } = actual.threadMessageStore(store);
+      return older;
+    },
+  };
+});
+
+const principal: Principal = { kind: "user", subject: "user_batch_fallback" };
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+describe("a store older than upsertMany", () => {
+  it("still lands turn two, through the path that predates the verb", async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), "vendo-batch-fallback-"));
+    const store = createStore({ dataDir });
+    cleanups.push(async () => { await store.close(); await rm(dataDir, { recursive: true, force: true }); });
+    await store.ensureSchema();
+    const vendo = createVendo({
+      models: { default: scriptedModel([textTurn("one"), textTurn("two")]) as unknown as LanguageModel },
+      principal: async () => principal,
+      store,
+    } as CreateVendoConfig);
+
+    const thread = "thr_batch_fallback";
+    const say = async (text: string): Promise<Response> => {
+      const response = await vendo.handler(new Request("https://host.test/api/vendo/threads", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          threadId: thread,
+          message: { id: `m_${text}`, role: "user", parts: [{ type: "text", text }] },
+        }),
+      }));
+      await response.text();
+      return response;
+    };
+
+    // Turn one creates the row and never reaches the batch verb; turn two is
+    // the call site that used to hard-fail.
+    expect((await say("first")).status).toBe(200);
+    expect((await say("second")).status).toBe(200);
+
+    // Read back through the REAL store: both turns are in the conversation, in
+    // the order they were said.
+    const listed = await vendo.harness.threads.get(thread, {
+      principal, venue: "chat", presence: "present", sessionId: "s_fallback",
+    });
+    const said = (listed?.messages ?? [])
+      .filter((message) => message.role === "user")
+      .map((message) => message.id);
+    expect(said).toEqual(["m_first", "m_second"]);
+  });
+});


### PR DESCRIPTION
## The defect

`packages/vendo/src/harness-turn.ts` called `transcript.upsertMany(...)` **unconditionally**, while `persistTurn` in `packages/harnesses/src/runtime.ts` guards the same verb. One protected call site and one unprotected one, for one verb, is worse than either policy applied consistently — because it reads as protected.

Against a `@vendoai/store` older than the verb (or a stale `dist`, which is how it surfaced):

```
[vendo] unhandled wire error: TypeError: transcript.upsertMany is not a function
AssertionError: expected 501 to be 200
```

A **501 on turn TWO** of a conversation, after turn one had already worked — the first turn takes the `persist` create path and never reaches the verb.

## Which call site was wrong, and why

`harness-turn` was. The two sites are not symmetric, and it is worth being explicit about it:

- `TranscriptStore` in `runtime.ts` is a **structural, host-supplied** interface. Its `upsertMany?` is genuinely optional because any object of that shape can be passed — by a host, or a test double written before the verb existed. That guard is permanent and correct regardless of package versions.
- `ThreadMessageStore` in `harness-turn` comes from `threadMessageStore(config.store)`, a **workspace peer that declares the method required**. The type says it is always there; only a version skew says otherwise.

So the justifications differ — but the conclusion does not. `@vendoai/*` ships as a fixed lockstep group, so a real mismatch needs someone to pin packages individually, and **the uncommon case is the entire point of a guard**. The costs are asymmetric: unguarded and wrong is a broken conversation mid-flight; guarded and unnecessary is one condition.

## The policy

Guard at both sites, following `runtime.ts`'s shape — check the verb, else take the path that predates it.

Here that path is `threads.persist`, which is **exactly what this call site did before the batch verb existed**. It is not a second pattern, and unlike a bare `upsert` it still refreshes the listing title and `updated_at`, so an older store makes a turn *slower*, not *wrong*:

```ts
fresh || batchAppend === undefined
  ? threads.persist(thread, [input.message], { fresh })
  : transcript.upsertMany(...)
```

`batchAppend` is the verb read into a deliberately-widened local (`typeof transcript.upsertMany | undefined`) — without it TypeScript rejects the comparison as impossible, which is precisely the assumption that turned out to be false at runtime.

## Regression test

`packages/vendo/tests/transcript-batch-fallback.test.ts` — a real composed `vendo()` over a real store, two real turns, transcript read back from that same store. The "older store" is spelled the way one actually behaves: `vi.mock` with `importOriginal`, handing back the **real** transcript door with exactly that one method removed — a subtraction from the shipped implementation, not a re-implementation of it, so it cannot pass by agreeing with a stub.

Prove-can-fail: with the fix stashed, the test reports the 501 quoted above.

## Gate

`pnpm build` 21/21 ✅ · `pnpm typecheck` 42/42 ✅ · `pnpm lint` 0 errors ✅ · `packages/vendo` 88 passed / 5 files ✅ (transcript-batch-fallback, harness-threads, harness-wire, threads, hosted-store). No UI surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guards `transcript.upsertMany` in `harness-turn` and falls back to `threads.persist` when absent, matching `persistTurn` behavior. Previously, `harness-turn` called `upsertMany` unconditionally, causing a 501 on turn two against an older `@vendoai/store` or a stale build; now older stores process turns correctly (slower, not broken).

- Update `packages/vendo/src/harness-turn.ts`: read `transcript.upsertMany` as optional and call `threads.persist` when `fresh` or the verb is missing, aligning both call sites under the same guard policy from `@vendoai/harnesses`’s `persistTurn`.
- Add `packages/vendo/tests/transcript-batch-fallback.test.ts`: removes `upsertMany` via `vi.mock` and verifies two turns succeed and messages persist in order.
- No migration required; pinned/mixed versions now degrade gracefully instead of failing mid-conversation.

<sup>Written for commit 244ba552e31fc6e707df939a17f811d5423cdfcf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

