### PR TITLE
fix(core): store-wire 429/5xx classify as unavailable, not not-implemented

### DIFF
--- a/.changeset/store-wire-unavailable-status-mapping.md
+++ b/.changeset/store-wire-unavailable-status-mapping.md
@@ -1,0 +1,13 @@
+---
+"@vendoai/core": patch
+---
+
+`parseStoreWireError` no longer degrades a 429/5xx store-wire failure to
+`not-implemented`. A dropped Postgres connection under load answered a bare
+503, and the client reported "Vendo Cloud store does not support the
+transcripts.appendMessages operation" — a transient dependency failure
+misread as a missing capability. 429/500/502/503/504 now classify as the new
+`unavailable` VendoErrorCode (retryable); 400/402/403/409 are unchanged. The
+console's own `unavailable` envelope (`lib/api/respond.ts`'s
+`apiServerError`) now parses as itself too, instead of failing schema
+validation for carrying a code the enum didn't recognize.

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -13,7 +13,13 @@ export type VendoErrorCode =
   /** Build contract §9.4 — the caller provably SEES the thing and is denied the
       action anyway (a viewer asked to edit). Thrown only to a proven viewer;
       anything they cannot see stays `not-found`. Wire-mapped to HTTP 403. */
-  | "forbidden";
+  | "forbidden"
+  /** A transient failure on the SERVER's own dependency (a dropped database
+      connection, an upstream 5xx/429) — retry the same call verbatim rather
+      than treating it as a business refusal. Wire-mapped to HTTP 503.
+      Distinct from `sandbox-unavailable`, which names one specific capability
+      rather than "something downstream broke". */
+  | "unavailable";
 
 /** 01-core §15 */
 export const vendoErrorCodeSchema = z.enum([
@@ -25,6 +31,7 @@ export const vendoErrorCodeSchema = z.enum([
   "not-found",
   "conflict",
   "forbidden",
+  "unavailable",
 ]) satisfies z.ZodType<VendoErrorCode>;
 
 /** 01-core §15 */

--- a/packages/core/src/knowledge-wire.ts
+++ b/packages/core/src/knowledge-wire.ts
@@ -143,6 +143,11 @@ export const KNOWLEDGE_WIRE_STATUS_BY_CODE: Record<VendoErrorCode, number> = {
   "cloud-required": 402,
   "sandbox-unavailable": 501,
   "not-implemented": 501,
+  // Table entry only: `unavailable` is a store-wire concern (a transient
+  // dependency failure server-side). This wire's own STATUS_TO_CODE is
+  // untouched — a bare 5xx/429 here still degrades to "not-implemented",
+  // unchanged by this slice.
+  unavailable: 503,
 };
 
 /** 404 is deliberately absent: only an ENVELOPED `not-found` may become the

--- a/packages/core/src/store-wire.ts
+++ b/packages/core/src/store-wire.ts
@@ -426,16 +426,29 @@ export const STORE_WIRE_STATUS_BY_CODE: Record<VendoErrorCode, number> = {
   "cloud-required": 402,
   "sandbox-unavailable": 501,
   "not-implemented": 501,
+  unavailable: 503,
 };
 
 /** 404 is deliberately absent: only an ENVELOPED `not-found` may become the
     record-absence code. A bare 404 is a mount/deployment failure and degrades
-    to "not-implemented" so it surfaces as an error. */
+    to "not-implemented" so it surfaces as an error.
+    429/500/502/503/504 map to `unavailable` — a transient failure on the
+    server's own dependency, never "this op does not exist". Field 2026-08-14:
+    a dropped Postgres connection under load answered 503, and BEFORE this
+    entry existed that fell all the way through to "not-implemented", which
+    told the operator the Cloud store did not support a batch-append op it
+    shipped with — sending the first look at the incident at the version-skew
+    path instead of the real one. */
 const STATUS_TO_CODE: Record<number, VendoErrorCode> = {
   400: "validation",
   402: "cloud-required",
   403: "blocked",
   409: "conflict",
+  429: "unavailable",
+  500: "unavailable",
+  502: "unavailable",
+  503: "unavailable",
+  504: "unavailable",
 };
 
 /** Server half: one VendoError → the enveloped body + HTTP status. */
@@ -448,7 +461,8 @@ export function storeWireErrorBody(error: VendoError): { status: number; body: S
 
 /** Client half: a non-2xx response → VendoError. An enveloped wire-legal
     code wins over the bare status; recognized statuses map through
-    STATUS_TO_CODE; anything else degrades to "not-implemented". */
+    STATUS_TO_CODE (429/5xx → "unavailable", retryable); anything else
+    degrades to "not-implemented". */
 export function parseStoreWireError(status: number, body: unknown): VendoError {
   const parsed = storeWireErrorSchema.safeParse(body);
   if (parsed.success) {

--- a/packages/core/tests/contract-coverage.e2e.test.ts
+++ b/packages/core/tests/contract-coverage.e2e.test.ts
@@ -401,10 +401,14 @@ describe("§12/§13/§14 — store, host-seam, and theme schemas", () => {
 });
 
 describe("§15 — VendoErrorCode taxonomy is a closed enum", () => {
-  it("vendoErrorCodeSchema accepts exactly the seven codes and rejects cut/unknown ones", () => {
+  it("vendoErrorCodeSchema accepts exactly the nine codes and rejects cut/unknown ones", () => {
     for (const code of [
       "validation", "blocked", "not-implemented", "sandbox-unavailable",
-      "cloud-required", "not-found", "conflict",
+      "cloud-required", "not-found", "conflict", "forbidden",
+      // 2026-08-14: the retryable/transient-failure code (a dropped store
+      // connection, an upstream 5xx/429) — see store-wire.test.ts for its
+      // STATUS_TO_CODE pin.
+      "unavailable",
     ]) {
       expect(vendoErrorCodeSchema.safeParse(code).success).toBe(true);
     }

--- a/packages/core/tests/store-wire.test.ts
+++ b/packages/core/tests/store-wire.test.ts
@@ -284,8 +284,38 @@ describe("vendo/store-wire@1", () => {
   it("parseStoreWireError: enveloped code wins, bare statuses map, junk degrades honestly", () => {
     expect(parseStoreWireError(400, { error: { code: "conflict", message: "id taken" } }).code).toBe("conflict");
     expect(parseStoreWireError(402, undefined).code).toBe("cloud-required");
-    expect(parseStoreWireError(500, { error: { code: "not-a-real-code", message: "?" } }).code).toBe("not-implemented");
-    expect(parseStoreWireError(503, null).code).toBe("not-implemented");
+    // A junk/unenveloped code at a mapped status now reads as the status's
+    // own classification (`unavailable` at 500/503), not "not-implemented" —
+    // see the next case for why that distinction is the whole point.
+    expect(parseStoreWireError(500, { error: { code: "not-a-real-code", message: "?" } }).code).toBe("unavailable");
+    expect(parseStoreWireError(503, null).code).toBe("unavailable");
+  });
+
+  it("parseStoreWireError: 429/5xx are unavailable (retryable), never not-implemented", () => {
+    // Field 2026-08-14: a dropped Postgres connection under load answered a
+    // bare 503, no envelope — and every one of these used to degrade to
+    // "not-implemented", which told the operator Cloud store did not support
+    // an op it shipped with. Each status here is independently pinned so a
+    // future edit cannot drop one silently.
+    for (const status of [429, 500, 502, 503, 504]) {
+      expect(parseStoreWireError(status, undefined).code).toBe("unavailable");
+      expect(parseStoreWireError(status, null).code).toBe("unavailable");
+    }
+    // 400/402/403/409 are untouched by this slice — still their own codes,
+    // never folded into "unavailable".
+    expect(parseStoreWireError(400, undefined).code).toBe("validation");
+    expect(parseStoreWireError(402, undefined).code).toBe("cloud-required");
+    expect(parseStoreWireError(403, undefined).code).toBe("blocked");
+    expect(parseStoreWireError(409, undefined).code).toBe("conflict");
+    // 501 keeps its own, older meaning (a real not-implemented/sandbox-unavailable
+    // status) — it is not folded into the new 5xx bucket.
+    expect(parseStoreWireError(501, undefined).code).toBe("not-implemented");
+    // The console's own envelope for this failure (lib/api/respond.ts's
+    // apiServerError) round-trips as itself now, rather than being discarded
+    // by schema validation for carrying a code the old enum didn't know.
+    expect(
+      parseStoreWireError(503, { error: { code: "unavailable", message: "Store request failed." } }).code,
+    ).toBe("unavailable");
   });
 
   it("only an enveloped not-found reads as record absence — a bare 404 surfaces as failure", () => {

--- a/packages/vendo/src/wire/shared.ts
+++ b/packages/vendo/src/wire/shared.ts
@@ -49,6 +49,11 @@ const STATUS_BY_CODE: Record<VendoErrorCode, number> = {
   "cloud-required": 402,
   "sandbox-unavailable": 501,
   "not-implemented": 501,
+  // Table entry only, for the same reason knowledge-wire.ts's copy carries
+  // one: this umbrella wire builds its OWN VendoError responses and never
+  // parses a status code back into one, so there is no STATUS_TO_CODE here
+  // to extend.
+  unavailable: 503,
 };
 
 export interface WireDeps {


### PR DESCRIPTION
## Summary
- A dropped Postgres connection under load answered a bare 503 in production tonight, and `parseStoreWireError` degraded it to `not-implemented` — the client reported "Vendo Cloud store does not support the transcripts.appendMessages operation", sending the first look at the incident down the version-skew path instead of the real one.
- Root cause was one layer deeper than just a missing status mapping: the console's own honest envelope for this failure already uses `unavailable` (`lib/api/respond.ts`'s `apiServerError`), but that code did not exist in the shared `VendoErrorCode` enum, so `storeWireErrorSchema` failed to parse it and discarded the real detail before the status-code fallback ever ran.
- Adds `unavailable` as a real, retryable `VendoErrorCode` (wire-mapped 503) and maps 429/500/502/503/504 → `unavailable` in store-wire's `STATUS_TO_CODE`. 400/402/403/409 are untouched. `knowledge-wire.ts` and the umbrella wire's status table pick up the mechanical table entry the shared enum forces; their own `STATUS_TO_CODE` mappings are unchanged — this is a store-wire-scoped behavior change.
- Not implicated: `TRANSCRIPT_MUTATIONS`/batching (already correctly on the 8MB write door), and today's Hyperdrive tenant path (off in production, no `VENDO_TENANT_HYPERDRIVE` var set).

## Test plan
- [x] `packages/core` — 44/44 test files, 632 tests, including new/updated pins in `store-wire.test.ts` and `contract-coverage.e2e.test.ts` for the 429/5xx → `unavailable` classification and the untouched 400/402/403/409 cases
- [x] `packages/knowledge` — 8/8 test files, 102 tests (shares the enum via the mechanical table entry)
- [x] `pnpm test:affected` — 44/45 passing; the one `@vendoai/ui` failure is a chrome tsc-subprocess test timing out under 45-package machine contention, confirmed unrelated by re-running alone (24s, under its 30s budget)
- [x] typecheck + lint clean on the touched scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies store-wire 429/5xx responses as the retryable code `unavailable` instead of `not-implemented`, preventing false “does not support operation” errors and aligning clients to retry transient failures.

- Adds `unavailable` to `VendoErrorCode` (wire-mapped 503) and updates store-wire `STATUS_TO_CODE` to map 429/500/502/503/504 → `unavailable`; 400/402/403/409 unchanged; 501 stays `not-implemented`.
- Accepts the console’s `unavailable` envelope (previously failed schema validation); envelopes still override bare status.
- Scope is limited to store-wire behavior; `knowledge-wire.ts` and the umbrella wire only gain a table entry due to the shared enum.
- Migration: handle `unavailable` as retryable; if you exhaustively match on `VendoErrorCode`, add a case for `unavailable`.

<sup>Written for commit 802c8d00d7334ed8488679b3649bbaf167a89ced. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

