### PR TITLE
fix(store): the hosted client mirrors the engine's atomic set, not just threads

### DIFF
--- a/.changeset/hosted-atomics-mirror.md
+++ b/.changeset/hosted-atomics-mirror.md
@@ -1,0 +1,7 @@
+---
+"@vendoai/store": patch
+---
+
+`hostedStore` advertises guarded writes on every collection the engine actually backs with one. `records(collection).atomic` is a feature-detection signal — callers branch on its presence — and the hosted client offered it for `vendo_threads` alone, while the local engine has backed `vendo_apps` and `vendo_effects` with a revision counter since Wave 7. The wire already served both (`ops.engine.insertIfAbsent`/`compareAndSwap` delegate straight to the routed door, behind the same allowlist), so nothing was broken on the service side: hosted callers simply feature-detected `undefined` and fell back to the check-then-put those branches exist to avoid, on the two collections the service arbitrates properly. App-row lifecycle writes and schedule-fire claims lost their compare-and-swap; effect receipts lost their insert-once.
+
+The mirrored set is now one named constant next to `RESERVED_COLLECTIONS`, and a parity test derives the truth from the local engine's real doors — it reads the mirror's list nowhere — so the next collection to gain or lose guarded writes fails the build rather than drifting the two sides apart again.

--- a/packages/store/src/hosted-store.ts
+++ b/packages/store/src/hosted-store.ts
@@ -18,7 +18,11 @@ import {
   vendoRecordSchema,
 } from "@vendoai/core";
 import type { EraseReport } from "./erase.js";
-import { DEDICATED_RECORD_COLLECTIONS, RESERVED_COLLECTIONS } from "./routing.js";
+import {
+  ATOMIC_RESERVED_COLLECTIONS,
+  DEDICATED_RECORD_COLLECTIONS,
+  RESERVED_COLLECTIONS,
+} from "./routing.js";
 import type { VendoStore } from "./store.js";
 
 /** The console mounts the hosted-store surface here
@@ -195,16 +199,19 @@ export function hostedStore(options: HostedStoreOptions): HostedStore {
 
     // Capability mirror of the store engine's routing (02-store §2): routed
     // reserved collections expose no claim; atomic rides generic collections
-    // and vendo_threads' revision counter only. Mirroring the shape here keeps
-    // feature detection (`records.atomic !== undefined`) identical on both
-    // sides of the wire.
+    // and the routed doors backed by a revision counter. Mirroring the shape
+    // here keeps feature detection (`records.atomic !== undefined`) identical
+    // on both sides of the wire.
     const reserved = (RESERVED_COLLECTIONS as readonly string[]).includes(collection);
     const dedicated = (DEDICATED_RECORD_COLLECTIONS as readonly string[]).includes(collection);
     if (!reserved) {
       store.claim = (expected: RecordInput, replacement?: Pick<VendoRecord, "data" | "refs">) =>
         facade.engine.claim(collection, expected, replacement);
     }
-    if ((!reserved && !dedicated) || collection === "vendo_threads") {
+    if (
+      (!reserved && !dedicated)
+      || (ATOMIC_RESERVED_COLLECTIONS as readonly string[]).includes(collection)
+    ) {
       store.atomic = {
         insertIfAbsent: (record) => facade.engine.insertIfAbsent(collection, record),
         compareAndSwap: (record, expectedRevision) => facade.engine.compareAndSwap(collection, record, expectedRevision),

--- a/packages/store/src/routing.ts
+++ b/packages/store/src/routing.ts
@@ -69,6 +69,17 @@ export const DEDICATED_RECORD_COLLECTIONS = [
   "vendo_knowledge_chunks",
 ] as const;
 
+/** The routed collections whose table carries a revision counter, so their door
+ *  offers guarded writes (01 §12). A LITERAL because `atomic` is defined inline
+ *  per case in `configFor` below and there is nothing to read it off of without
+ *  a Db; the hosted client mirrors it for feature detection, and
+ *  tests/hosted-store.atomic-parity.test.ts holds both to the real doors. */
+export const ATOMIC_RESERVED_COLLECTIONS = [
+  "vendo_threads",
+  "vendo_apps",
+  "vendo_effects",
+] as const;
+
 export type ReservedCollection = typeof RESERVED_COLLECTIONS[number];
 
 interface RoutedConfig {

--- a/packages/store/tests/hosted-store.atomic-parity.test.ts
+++ b/packages/store/tests/hosted-store.atomic-parity.test.ts
@@ -1,0 +1,40 @@
+import { ENGINE_COLLECTIONS, engineAppHistory } from "@vendoai/core";
+import { afterAll, describe, expect, it } from "vitest";
+import { hostedStore } from "../src/hosted-store.js";
+import { createStore } from "../src/index.js";
+
+// `records(collection).atomic` is a FEATURE-DETECTION signal (01-core §12):
+// callers branch on its presence, so the hosted client must answer for every
+// engine collection exactly what the local engine answers. hosted-store.ts
+// hand-maintains that mirror; this test is the thing that holds it to reality.
+// The ONE source of truth is the local engine's own door — nothing here reads
+// the mirror's list — so a collection that gains or loses guarded writes in
+// routing.ts fails here until the mirror follows.
+//
+// Neither door queries at construction, so this needs no schema and never
+// boots PGlite or opens a socket.
+const local = createStore({ dataDir: "memory://atomic-parity" });
+const hosted = hostedStore({ apiKey: "vnd_secret", baseUrl: "https://cloud.test" });
+
+afterAll(async () => {
+  await local.close();
+});
+
+// Every collection the engine door serves: the allowlist, plus the one dynamic
+// name its pattern admits.
+const collections = [...ENGINE_COLLECTIONS, engineAppHistory("app_1")];
+const localAtomic = (collection: string) => local.records(collection).atomic !== undefined;
+
+describe("hostedStore mirrors the local engine's atomic capability", () => {
+  it.each(collections)("%s", (collection) => {
+    expect(hosted.records(collection).atomic !== undefined).toBe(localAtomic(collection));
+  });
+
+  // Guards the comparison against going vacuous: if the engine ever answered
+  // the same for everything, every case above would pass while proving nothing.
+  it("compares a set the engine genuinely splits", () => {
+    const atomic = collections.filter(localAtomic);
+    expect(atomic.length).toBeGreaterThan(0);
+    expect(atomic.length).toBeLessThan(collections.length);
+  });
+});

--- a/packages/store/tests/hosted-store.test.ts
+++ b/packages/store/tests/hosted-store.test.ts
@@ -178,11 +178,13 @@ describe("hostedStore wire", () => {
 
     // The capability mirror is UNCHANGED by the move onto the engine door:
     // claim is absent on routed reserved collections, atomic rides generic
-    // collections and vendo_threads' revision counter only. mcp and knowledge
-    // feature-detect on exactly this shape.
+    // collections and the routed doors backed by a revision counter. mcp and
+    // knowledge feature-detect on exactly this shape. The whole mirror is held
+    // to the local engine's real doors in hosted-store.atomic-parity.test.ts.
     expect(store.records("vendo_apps").claim).toBeUndefined();
     expect(store.records("vendo_threads").atomic).toBeDefined();
-    expect(store.records("vendo_apps").atomic).toBeUndefined();
+    expect(store.records("vendo_apps").atomic).toBeDefined();
+    expect(store.records("vendo_effects").atomic).toBeDefined();
     expect(store.records("vendo_mcp_clients").atomic).toBeUndefined();
     expect(store.records("vendo_mcp_clients").claim).toBeDefined();
 


### PR DESCRIPTION
## The drift

`records(collection).atomic` is a **feature-detection signal** (01-core §12) — callers branch on its presence. The hosted client advertised it for `vendo_threads` alone:

```ts
// packages/store/src/hosted-store.ts (before)
if ((!reserved && !dedicated) || collection === "vendo_threads") {
```

The local engine has backed **three** routed doors with a revision counter: `vendo_threads` (`routing.ts:431`), `vendo_apps` (`routing.ts:520`, Wave 7) and `vendo_effects` (`routing.ts:581`). So the same collection answered differently on hosted vs local — the exact drift that block's own comment says it exists to prevent.

**This is not a server-side gap.** The wire genuinely serves both:

- `ENGINE_COLLECTIONS` (`packages/core/src/engine-collections.ts`) already allowlists `vendo_apps` and `vendo_effects`, and the console delegates to it.
- `ops.engine.insertIfAbsent` / `compareAndSwap` (`packages/store/src/ops.ts:241-259`) call `assertEngineCollection`, then delegate **straight to the routed door's `atomic`** — no second gate.

So nothing was broken on the service side. Hosted callers simply feature-detected `undefined` and fell back to the check-then-put those branches exist to avoid, on two collections the service arbitrates properly: app-row lifecycle writes and schedule-fire claims lost their compare-and-swap; effect receipts lost their insert-once.

The `!dedicated` half was checked and is **correct** — `createRecordStore` exposes `atomic` only when `usesCollection` (`records.ts:283`), so dedicated tables genuinely have none on either side.

## The parity test, and its red proof

`packages/store/tests/hosted-store.atomic-parity.test.ts` derives the atomic-capable set from **one source of truth — the local engine's real doors** — and asserts the hosted client mirrors it, over every collection the engine door serves (`ENGINE_COLLECTIONS` plus the one dynamic app-history name). It reads the mirror's own list nowhere, so it cannot agree with the bug. An anti-vacuity case asserts the engine genuinely splits the set, so the comparison can never pass by both sides answering the same for everything.

Written first and run against unfixed code — it fails on exactly the two collections, and nothing else:

```
 FAIL  tests/hosted-store.atomic-parity.test.ts > hostedStore mirrors the local engine's atomic capability > vendo_apps
 FAIL  tests/hosted-store.atomic-parity.test.ts > hostedStore mirrors the local engine's atomic capability > vendo_effects
AssertionError: expected false to be true // Object.is equality

- Expected
+ Received

- true
+ false

 ❯ tests/hosted-store.atomic-parity.test.ts:30:61

 Test Files  1 failed (1)
      Tests  2 failed | 38 passed (40)
```

After the fix: `40 passed (40)`.

## The fix

The mirrored set becomes one named constant next to `RESERVED_COLLECTIONS` (`ATOMIC_RESERVED_COLLECTIONS`) — a literal, because `atomic` is defined inline per case in `configFor` and there is nothing to read it off of without a `Db`, the same shape as `ENGINE_COLLECTIONS` in core. The parity test is what holds it to reality.

## Test change, stated out loud

`hosted-store.test.ts` asserted `records("vendo_apps").atomic` was **undefined**. That assertion encoded the bug rather than catching it, so it flips, and `vendo_effects` joins it.

## Gate

`pnpm build` · `pnpm test:affected` (33/33 tasks, `@vendoai/vendo` 2381 passed) · `pnpm typecheck` · `pnpm lint` — all green. No UI surface touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hosted client mirrors the engine’s atomic capability across collections. Previously only `vendo_threads` exposed `atomic`; now `vendo_apps` and `vendo_effects` do too, so callers that feature-detect `atomic` will use guarded writes instead of fallback read-then-put.

- Introduces `ATOMIC_RESERVED_COLLECTIONS` next to `RESERVED_COLLECTIONS` and uses it in the hosted client to expose `atomic` consistently.
- Adds a parity test that derives truth from the local engine’s real doors and fails on drift; updates `hosted-store.test.ts` to expect `atomic` on `vendo_apps` and `vendo_effects`.
- No server changes or migrations; dedicated tables remain unchanged, and the wire already supported guarded writes.

<sup>Written for commit a93d47338651f9ae5f33d0df892bd9c5d9231699. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

