### PR TITLE
fix(core,store): the erase manifest names the door that exists

### DIFF
--- a/.changeset/erase-manifest-matches-the-door.md
+++ b/.changeset/erase-manifest-matches-the-door.md
@@ -1,0 +1,8 @@
+---
+"@vendoai/core": patch
+"@vendoai/store": patch
+---
+
+`STORE_WIRE_PATHS` now declares the erase door that actually exists. The manifest listed `lifecycle.erase` at `/lifecycle/erase` with a body that wrapped the scope in `{target: {...}}`, while every mount — the console included — serves `/erase` with the scope FLAT, and the hosted client sent it there by hardcoding the path rather than reading the table. The published contract therefore described a route no client calls and no service answers: anyone building a Store Wire v1 mount faithfully from `STORE_WIRE_PATHS` would never receive an erase, and would have validated the wrong body if one arrived. The manifest is now `/erase` with a flat `{subject}` / `{appId}` request schema (still exactly one of the two — a destructive call with no scope is still refused), and both hosted erase surfaces, the `StoreOps` client and the `StoreAdapter` façade, take their route from the table like the other 35 ops, so the two can no longer drift.
+
+No behavior changes on the wire: the client sent `POST /erase` with a flat body before this change and sends the identical request after it. Only the contract the manifest publishes changed, to match what ships.

--- a/packages/core/src/store-wire.ts
+++ b/packages/core/src/store-wire.ts
@@ -57,7 +57,13 @@ export const STORE_WIRE_PATHS = {
   "workspace.commit": "/workspace/commit",
   "workspace.history": "/workspace/history",
   // lifecycle (2)
-  "lifecycle.erase": "/lifecycle/erase",
+  // ⚠ erase is the ONE door not under its family prefix, and that is the
+  // point: it shipped at `/erase` before the wire had families, and every
+  // mount — the console included — serves it there and nowhere else. This
+  // manifest records the door that EXISTS. Tidying it to `/lifecycle/erase`
+  // makes it a route no client calls and no service answers, so a third party
+  // that builds its mount from this table never receives an erase at all.
+  "lifecycle.erase": "/erase",
   "lifecycle.promote": "/lifecycle/promote",
   // status (1)
   status: "/status",
@@ -363,17 +369,17 @@ export const storeWireWorkspaceHistoryRequestSchema = cursorQuerySchema.extend({
 // lifecycle
 // ---------------------------------------------------------------------------
 
-/** Exactly ONE of subject/appId — an erase with no scope (or an ambiguous
-    both-set scope) is a destructive call with no target and must be rejected. */
+/** The scope rides the body FLAT, the way the shipped door reads it — no
+    `target` wrapper. Exactly ONE of subject/appId: an erase with no scope (or
+    an ambiguous both-set scope) is a destructive call with no target and must
+    be rejected. */
 export const storeWireLifecycleEraseRequestSchema = z.object({
-  target: z.object({
-    subject: z.string().min(1).optional(),
-    appId: z.string().min(1).optional(),
-  }).passthrough().refine(
-    (t) => (t.subject === undefined) !== (t.appId === undefined),
-    { message: "erase target must set exactly one of subject or appId" },
-  ),
-}).passthrough();
+  subject: z.string().min(1).optional(),
+  appId: z.string().min(1).optional(),
+}).passthrough().refine(
+  (target) => (target.subject === undefined) !== (target.appId === undefined),
+  { message: "erase target must set exactly one of subject or appId" },
+);
 
 export const storeWireLifecyclePromoteRequestSchema = z.object({
   appId: z.string().min(1),

--- a/packages/core/tests/store-wire.test.ts
+++ b/packages/core/tests/store-wire.test.ts
@@ -57,6 +57,11 @@ describe("vendo/store-wire@1", () => {
     expect(STORE_WIRE_PATHS["engine.compareAndSwap"]).toBe("/engine/compareAndSwap");
     expect(STORE_WIRE_PATHS["appData.put"]).toBe("/app-data/put");
     expect(STORE_WIRE_PATHS["lifecycle.promote"]).toBe("/lifecycle/promote");
+    // erase is the one door NOT under its family prefix: it shipped at /erase
+    // before the wire had families and every mount serves it there. The
+    // manifest records the door that EXISTS — a prettier path here would be a
+    // route no client calls and no service answers.
+    expect(STORE_WIRE_PATHS["lifecycle.erase"]).toBe("/erase");
   });
 
   it("every engine door is its own path, and no route is left on the retired generic family", () => {
@@ -235,15 +240,17 @@ describe("vendo/store-wire@1", () => {
   });
 
   it("parses lifecycle request DTOs", () => {
-    expect(storeWireLifecycleEraseRequestSchema.parse({ target: { subject: "sub_1" } }).target.subject).toBe("sub_1");
-    expect(storeWireLifecycleEraseRequestSchema.parse({ target: { appId: "app_1" } }).target.appId).toBe("app_1");
-    // A destructive erase must name exactly one scope: no empty target...
-    expect(storeWireLifecycleEraseRequestSchema.safeParse({ target: {} }).success).toBe(false);
-    // ...and no ambiguous both-set target.
-    expect(storeWireLifecycleEraseRequestSchema.safeParse({
-      target: { subject: "sub_1", appId: "app_1" },
-    }).success).toBe(false);
-    expect(storeWireLifecycleEraseRequestSchema.safeParse({ target: { subject: "" } }).success).toBe(false);
+    // The erase body is FLAT — the scope rides the body itself, not a `target`
+    // wrapper, which is what every shipped mount reads and every client sends.
+    expect(storeWireLifecycleEraseRequestSchema.parse({ subject: "sub_1" }).subject).toBe("sub_1");
+    expect(storeWireLifecycleEraseRequestSchema.parse({ appId: "app_1" }).appId).toBe("app_1");
+    // A destructive erase must name exactly one scope: no empty body...
+    expect(storeWireLifecycleEraseRequestSchema.safeParse({}).success).toBe(false);
+    // ...and no ambiguous both-set body.
+    expect(storeWireLifecycleEraseRequestSchema.safeParse({ subject: "sub_1", appId: "app_1" }).success).toBe(false);
+    expect(storeWireLifecycleEraseRequestSchema.safeParse({ subject: "" }).success).toBe(false);
+    // A wrapped target names no scope at all, so it is not an erase request.
+    expect(storeWireLifecycleEraseRequestSchema.safeParse({ target: { subject: "sub_1" } }).success).toBe(false);
     expect(storeWireLifecyclePromoteRequestSchema.parse({ appId: "app_1", orgId: "org_1" }).orgId).toBe("org_1");
   });
 

--- a/packages/store/src/hosted-store.ts
+++ b/packages/store/src/hosted-store.ts
@@ -253,10 +253,10 @@ export function hostedStore(options: HostedStoreOptions): HostedStore {
     // parity.
     erase: {
       async bySubject(subject) {
-        return parseReport(await sendJson("/erase", { subject }));
+        return parseReport(await sendJson(STORE_WIRE_PATHS["lifecycle.erase"], { subject }));
       },
       async byApp(appId) {
-        return parseReport(await sendJson("/erase", { appId }));
+        return parseReport(await sendJson(STORE_WIRE_PATHS["lifecycle.erase"], { appId }));
       },
     },
     // The service owns its migrations; there is nothing to migrate from here.
@@ -357,9 +357,10 @@ const raiseWireError = async (response: Response): Promise<never> => {
  * storeWire*RequestSchema bodies — collection/namespace/key ride the JSON body
  * and blob bytes are base64 on the wire — so any conforming Store Wire v1
  * service (the console's wire mount, a BYO httpStore) accepts them verbatim.
- * Transcripts, harness, workspace, `lifecycle.promote` and `/status` answer at
- * their STORE_WIRE_PATHS path too; erase keeps `/erase` — T5's own note: it
- * "keeps its existing door until the cloud client moves it".
+ * EVERY op takes its route from that table, erase included — its door really is
+ * `/erase` rather than `/lifecycle/erase`, and the table says so, because a
+ * client that spelled its own route was free to drift from the contract third
+ * parties build against (it did, for as long as erase was hardcoded here).
  */
 export function hostedStoreOps(options: HostedStoreOptions): StoreOps {
   return storeWireClient(options, raiseWireError);
@@ -743,7 +744,7 @@ function storeWireClient(
     lifecycle: {
       // The erase door takes the target FLAT (exactly one of subject/appId).
       async erase(target) {
-        return reportOf(await mutate("lifecycle.erase", "/erase", target));
+        return reportOf(await mutate("lifecycle.erase", P["lifecycle.erase"], target));
       },
       async promote(appId, orgId) {
         await mutate("lifecycle.promote", P["lifecycle.promote"], { appId, orgId });

--- a/packages/store/tests/hosted-store.test.ts
+++ b/packages/store/tests/hosted-store.test.ts
@@ -26,6 +26,7 @@ import {
   storeWireCollectionInsertIfAbsentRequestSchema,
   storeWireCollectionListRequestSchema,
   storeWireCollectionPutRequestSchema,
+  storeWireLifecycleEraseRequestSchema,
   type StoreAdapter,
 } from "@vendoai/core";
 import { storeAdapterConformance } from "@vendoai/core/conformance";
@@ -293,6 +294,10 @@ describe("hostedStore wire", () => {
     const byApp = await store.erase.byApp("app_gone");
     expect(byApp).toEqual({ vendo_apps: 1, vendo_threads: 2 });
     expect(console_.eraseCalls).toEqual([{ subject: "user_gone" }, { appId: "app_gone" }]);
+    // Written out, NOT read off STORE_WIRE_PATHS: this is the shipped console
+    // route, and it is what gives the manifest-derived assertions elsewhere
+    // their meaning. Two derived sides always agree with each other; only a
+    // literal here can catch the manifest declaring a door nobody serves.
     expect(console_.requests.map((request) => request.url)).toEqual([
       "https://cloud.test/api/v1/store/erase",
       "https://cloud.test/api/v1/store/erase",
@@ -623,12 +628,14 @@ const wireRecord = {
   revision: "1",
 };
 
-/** The door each named op knocks on. Records and blobs speak the EXPORTED
- * store-wire v1 contract (STORE_WIRE_PATHS, collection/namespace/key on the
- * body, blob bytes base64); transcripts, harness, workspace,
- * lifecycle.promote and /status answer at their STORE_WIRE_PATHS path too;
- * erase keeps the console's own route. `keyed` marks the mutations that carry
- * an Idempotency-Key. */
+/** The door each named op knocks on — EVERY one of them read off
+ * STORE_WIRE_PATHS, never spelled out here. Records and blobs speak the
+ * EXPORTED store-wire v1 contract (collection/namespace/key on the body, blob
+ * bytes base64); transcripts, harness, workspace, lifecycle and /status answer
+ * at their STORE_WIRE_PATHS path too. A path written out here instead would let
+ * the client and the manifest disagree forever, which is exactly how
+ * `lifecycle.erase` came to declare a route no mount has ever served. `keyed`
+ * marks the mutations that carry an Idempotency-Key. */
 const DOORS: Record<string, { method: string; path: string; keyed?: true }> = {
   "engine.get": { method: "POST", path: P["engine.get"] },
   "engine.put": { method: "POST", path: P["engine.put"], keyed: true },
@@ -662,7 +669,7 @@ const DOORS: Record<string, { method: string; path: string; keyed?: true }> = {
   "workspace.read": { method: "POST", path: P["workspace.read"] },
   "workspace.commit": { method: "POST", path: P["workspace.commit"], keyed: true },
   "workspace.history": { method: "POST", path: P["workspace.history"] },
-  "lifecycle.erase": { method: "POST", path: "/erase", keyed: true },
+  "lifecycle.erase": { method: "POST", path: P["lifecycle.erase"], keyed: true },
   "lifecycle.promote": { method: "POST", path: P["lifecycle.promote"], keyed: true },
   status: { method: "GET", path: P.status },
 };
@@ -1007,12 +1014,18 @@ describe("hostedStoreOps — the 35-op wire client", () => {
   it("lifecycle: erase and promote on their own doors", async () => {
     const { calls, ops } = wireFake(ALL_BODIES);
 
-    // The erase door takes the target FLAT (exactly one of subject/appId).
+    // The erase door takes the target FLAT (exactly one of subject/appId), on
+    // the path the MANIFEST declares — the client derives both, so a third
+    // party building its mount from STORE_WIRE_PATHS receives this call.
     expect(await ops.lifecycle.erase({ subject: "sub_1" })).toEqual({ vendo_apps: 1 });
-    expect(calls[0]).toMatchObject({ path: "/erase", body: { subject: "sub_1" } });
+    expect(calls[0]).toMatchObject({ path: P["lifecycle.erase"], body: { subject: "sub_1" } });
+    expect(storeWireLifecycleEraseRequestSchema.parse(calls[0]!.body).subject).toBe("sub_1");
+
+    await ops.lifecycle.erase({ appId: "app_1" });
+    expect(storeWireLifecycleEraseRequestSchema.parse(calls[1]!.body).appId).toBe("app_1");
 
     await ops.lifecycle.promote("app_1", "org_1");
-    expect(calls[1]).toMatchObject({ path: "/lifecycle/promote", body: { appId: "app_1", orgId: "org_1" } });
+    expect(calls[2]).toMatchObject({ path: P["lifecycle.promote"], body: { appId: "app_1", orgId: "org_1" } });
   });
 
   it("status: the GET handshake, parsed as vendo/store-wire@1", async () => {


### PR DESCRIPTION
## The defect (present on `origin/main`, verified at c21521c1)

`STORE_WIRE_PATHS` published an erase door that does not exist.

| | manifest before | what ships |
|---|---|---|
| path | `/lifecycle/erase` | `/erase` |
| body | `{target: {subject \| appId}}` | `{subject}` / `{appId}` — flat |

The hosted client reached the real door by **hardcoding** it — `mutate("lifecycle.erase", "/erase", target)` in the ops client and `sendJson("/erase", …)` in the `StoreAdapter` façade — so nothing in the repo ever read the manifest's erase entry, and nothing could notice it was wrong.

Shipped truth, from the console repo (not changed here):

- `apps/console/app/api/v1/store/erase/` — the real route.
- `apps/console/app/api/v1/store/lifecycle/[...op]/route.ts` serves **only** `promote`; anything else under `lifecycle/` answers the enveloped 501. Its own comment: *"erase keeps its existing door (/api/v1/store/erase) until the cloud client moves it."*
- `docs-site/deploy/persistence.mdx` and `vendo-cloud.mdx` already document `POST /api/v1/store/erase`.

So the manifest entry was dead in both halves: **any third party implementing Store Wire v1 faithfully from `STORE_WIRE_PATHS` would never receive an erase**, and would have validated the wrong body if one arrived. Shipped behavior is the truth, so the manifest moves to meet it.

## The fix

- `packages/core/src/store-wire.ts` — `lifecycle.erase` → `/erase`; `storeWireLifecycleEraseRequestSchema` flattened to `{subject?, appId?}` with the same exactly-one-of refinement (a scopeless or both-set erase is still refused).
- `packages/store/src/hosted-store.ts` — both erase surfaces derive their route from the table like the other 35 ops; the two hardcodes are gone.

**No change on the wire.** The identical `POST /erase` with the identical flat body goes out before and after. Only the published contract changed, to match what ships.

## Consumers check

Every reader of `STORE_WIRE_PATHS` in the monorepo, and what it reads:

| reader | keys read |
|---|---|
| `packages/store/src/hosted-store.ts` | all — now including `lifecycle.erase` |
| `packages/store/src/hosted-store.test-util.ts` (`routesOf`) | `engine.*`, `appData.*` only |
| `packages/store/tests/hosted-store.test.ts` | the `DOORS` table |
| `packages/vendo/tests/cli/sync-flow.test.ts` | `engine.list` |
| `packages/vendo/tests/cli/cloud/host-components.test.ts` | `engine.*`, `blobs.*` |
| `packages/core/tests/store-wire.test.ts` | the contract test |

**Nothing depended on the `/lifecycle/erase` value — it had zero readers.** Op count is unchanged at 36, so `STORE_WIRE_APPEND_MESSAGES_OPS` is untouched. No doc references the old path.

## Test-first, with the red run

Tests were written against the unfixed manifest and captured red before any `src/` change.

`packages/core` — 2 failed | 14 passed:

```
FAIL tests/store-wire.test.ts > exposes the format constant and 36 mount-relative paths
  expected '/lifecycle/erase' to be '/erase'
FAIL tests/store-wire.test.ts > parses lifecycle request DTOs
  ZodError: { "path": ["target"], "message": "Required" }
```

`packages/store` — the `DOORS` table now reads `P["lifecycle.erase"]` instead of a written-out `/erase`, so the manifest-keyed fake answers nowhere the client knocks:

```
FAIL > lifecycle: erase and promote on their own doors
FAIL > routes all 35 ops to the console's real door, with a key on exactly the mutations
  Error: Vendo Cloud store returned an invalid report response
   ❯ Object.erase src/hosted-store.ts:746:16
```

After the fix: core 16/16, store 60/60.

The store test also parses the client's actual outgoing body with `storeWireLifecycleEraseRequestSchema`, so a manifest schema that disagrees with what the client sends is now a failure rather than a silent divergence.

One literal is kept deliberately: `hostedStore wire > speaks the erase wire` still asserts `https://cloud.test/api/v1/store/erase` written out, and `fakeConsole` still matches `erase` in its own spelling. Two manifest-derived sides always agree with each other — only a literal can catch the manifest declaring a door nobody serves.

## Gate

`pnpm build` ✅ · `pnpm typecheck` ✅ (42 tasks) · `pnpm lint` ✅ (0 errors) · `pnpm test:affected` — every package green except `fixtures/integration`, which failed under the 10-minute parallel run and passes clean standalone (17 files / 47 tests); it references neither erase nor `STORE_WIRE_PATHS` nor `hostedStore`, so that was load contention. CI is the gate of record.

Changeset: patch on `@vendoai/core` + `@vendoai/store`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Store Wire manifest with the shipped erase door. `lifecycle.erase` now declares `/erase` with a flat `{subject}`/`{appId}` body, fixing a manifest that pointed to `/lifecycle/erase` with a wrapped `target`. No wire behavior changes; this prevents drift and lets third-party mounts built from the manifest receive erases.

- `@vendoai/core`: `STORE_WIRE_PATHS["lifecycle.erase"]` → `/erase`; `storeWireLifecycleEraseRequestSchema` is flat with the same exactly-one-of rule.
- `@vendoai/store`: both hosted erase surfaces (`StoreOps` and `StoreAdapter`) read the route from `STORE_WIRE_PATHS` instead of hardcoding `/erase`.
- Tests updated to assert the flat body and the manifest-derived route; one literal URL assertion remains to catch future drift.
- Migration: none for runtime. If you consume the manifest externally, serve `POST /erase` and validate a flat `{subject}` or `{appId}` body.

<sup>Written for commit a3a3dffa9c38ac5ecbe898df09da48d4692e0a49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

