### PR TITLE
feat(core,store): the six StoreOps capabilities the console reaches around

### DIFF
--- a/.changeset/storeops-six-capabilities.md
+++ b/.changeset/storeops-six-capabilities.md
@@ -1,0 +1,42 @@
+---
+"@vendoai/core": minor
+"@vendoai/store": minor
+---
+
+Six capabilities the StoreOps contract was missing, so nothing has to reach
+around it into raw SQL to get them.
+
+- `audit.list` — the audit drawer's own typed read, filtered by kind, venue,
+  outcome and decidedBy, on the same keyset cursor `engine.list("vendo_audit")`
+  already walks. `venue` is a column, `outcome` and `decidedBy` live inside the
+  event, and no `engine.list` ref key reaches any of them.
+- `secrets.{get,set,list,delete}` — the store's vault, on the wire. Values cross
+  in the clear under TLS and are encrypted at rest server-side, so no key ever
+  leaves the mount; the local engine keeps the `vendo_secrets` table and the
+  envelope cipher it already had.
+- `footprint()` — per-collection byte accounting, with each collection's kind
+  (`storage` or `knowledge`) alongside. `bytes` is row-content size, uniform
+  across collections and comparable with itself over time — deliberately not a
+  relation size, because most collections share one table and a per-collection
+  disk number does not exist to report.
+- `engine.list`'s `watermark` bound — the forward walk `cursor` cannot express:
+  everything after a mark, oldest first, so a job that has already counted rows
+  resumes where it stopped instead of re-reading from the newest. Valid only on
+  fields the collection registry declares indexed (`vendo_runs.started_at`
+  today), and the bound is opaque and full-precision on purpose: a mark
+  round-tripped through a JS `Date` truncates to milliseconds, moves BACKWARDS,
+  and re-counts a window. The answer echoes the next bound back, which is also
+  how a caller detects a mount too old to have honored it — a request field, unlike
+  a new op, has no 501 to protect it.
+- `retention.{quarantine,purge}` — aging rows out of a collection in two moves,
+  because the gap between them is the recovery window. OPTIONAL, and no
+  implementation ships one yet: the contract is frozen here and the engine that
+  owns the quarantine lands next.
+- `IdempotencyLedger` — server-side only, no wire op. `createStore()` provides
+  one, and implementations MUST colocate it with the mutations it gates: a
+  ledger that can commit while its mutation rolls back will confidently replay
+  an answer for work that never happened.
+
+`ENGINE_COLLECTIONS` is now derived from `ENGINE_COLLECTION_REGISTRY`, which
+carries each collection's kind and indexed fields. Same 38 names, same order; a
+second place naming them is how an allowlist rots.

--- a/packages/core/src/conformance/index.ts
+++ b/packages/core/src/conformance/index.ts
@@ -37,6 +37,23 @@ export { memoryAppAccess, type MemoryAppAccess } from "./memory-app-access.js";
  */
 export interface ConformanceCase {
   name: string;
+  /**
+   * Why this case does not run yet, and which lane lands it. Set it and the
+   * case is carried but never executed — by `runConformance`, and by every
+   * mount, which reports it as skipped WITH this reason in the test name.
+   *
+   * It exists so that an op the contract declares and nothing yet serves is
+   * VISIBLE. The alternative every time has been to leave the case out until
+   * its implementation arrives, and a case nobody can see is how a feature
+   * ships dead four times over: the suite is green, the op is in the types,
+   * and the first person to find out is a caller in production. A named
+   * pending case is a standing line in the test output that says the contract
+   * is ahead of the code and who owes the difference.
+   *
+   * The body is a real one, not a placeholder: landing the capability means
+   * deleting this one field.
+   */
+  pending?: string;
   run(): Promise<void>;
 }
 
@@ -46,10 +63,14 @@ export interface ConformanceSuite {
   cases: ConformanceCase[];
 }
 
-/** The serializable result of executing every case in a conformance suite. */
+/** The serializable result of executing every case in a conformance suite.
+    `pending` names the cases that were carried but not run; `ok` is keyed off
+    failures alone, because a pending case is a promise nobody has made yet, not
+    a broken one. */
 export interface ConformanceReport {
   seam: string;
   passed: number;
+  pending: string[];
   failures: Array<{ name: string; error: string }>;
   ok: boolean;
 }
@@ -57,8 +78,13 @@ export interface ConformanceReport {
 /** Executes all cases without stopping at the first failure. */
 export async function runConformance(suite: ConformanceSuite): Promise<ConformanceReport> {
   const failures: ConformanceReport["failures"] = [];
+  const pending: string[] = [];
   let passed = 0;
   for (const conformanceCase of suite.cases) {
+    if (conformanceCase.pending !== undefined) {
+      pending.push(conformanceCase.name);
+      continue;
+    }
     try {
       await conformanceCase.run();
       passed += 1;
@@ -69,7 +95,7 @@ export async function runConformance(suite: ConformanceSuite): Promise<Conforman
       });
     }
   }
-  return { seam: suite.seam, passed, failures, ok: failures.length === 0 };
+  return { seam: suite.seam, passed, pending, failures, ok: failures.length === 0 };
 }
 
 type AdapterFactoryResult = { adapter: StoreAdapter; close?(): Promise<void> };
@@ -290,6 +316,76 @@ export function storeAdapterConformance(opts: {
         await blobs.put("delete.bin", new Uint8Array([1]));
         await blobs.delete("delete.bin");
         assert(await blobs.get("delete.bin") === null, "deleted blob remained readable");
+      }),
+
+      /** 01-core §12: the replay ledger behind `Idempotency-Key`. A fresh key
+          tells the caller to go do the work; the same key with the same body
+          gets the recorded answer back instead of applying the mutation twice.
+          OPTIONAL, on `RecordStore.claim`'s rule — an adapter that cannot
+          colocate a ledger with its mutations omits it and passes here by not
+          claiming one. */
+      readyAdapterCase(opts, "01-core §12 — idempotency.check is null when fresh and replays what record wrote", async (adapter) => {
+        const ledger = adapter.idempotency;
+        if (ledger === undefined) return;
+        const scope = { tenant: "tenant_a", op: "workspace.commit", key: "idem_1" };
+        assert(await ledger.check(scope, "hash_a") === null, "a key nobody has recorded should check as null");
+        await ledger.record(scope, "hash_a", { status: 200, result: { committed: 1 } });
+        assertDeepEqual(
+          await ledger.check(scope, "hash_a"),
+          { status: 200, result: { committed: 1 } },
+          "the replay did not return the recorded status and result",
+        );
+      }),
+
+      /** 01-core §12: the same key with a DIFFERENT body is not a replay, it is
+          a client bug — and returning some other request's result for it is the
+          one failure this shape exists to make impossible. The hash is passed
+          IN so the comparison cannot be skipped at a call site. */
+      readyAdapterCase(opts, "01-core §12 — idempotency.check refuses a held key carrying a different request", async (adapter) => {
+        const ledger = adapter.idempotency;
+        if (ledger === undefined) return;
+        const scope = { tenant: "tenant_a", op: "workspace.commit", key: "idem_2" };
+        await ledger.record(scope, "hash_a", { status: 200, result: { committed: 1 } });
+        const refusal = await ledger.check(scope, "hash_b").then(() => null, (error: unknown) => error);
+        assert(
+          (refusal as { code?: unknown } | null)?.code === "conflict",
+          `a held key checked with a different request hash should throw conflict, got ${String(refusal)}`,
+        );
+      }),
+
+      /** 01-core §12: first writer wins. A replay that has already been handed
+          an answer must keep getting THAT answer — a second `record` landing
+          over it would change history under a caller who already read it. */
+      readyAdapterCase(opts, "01-core §12 — idempotency.record does not overwrite a key already held", async (adapter) => {
+        const ledger = adapter.idempotency;
+        if (ledger === undefined) return;
+        const scope = { tenant: "tenant_a", op: "workspace.commit", key: "idem_3" };
+        await ledger.record(scope, "hash_a", { status: 200, result: { attempt: 1 } });
+        await ledger.record(scope, "hash_a", { status: 500, result: { attempt: 2 } });
+        assertDeepEqual(
+          await ledger.check(scope, "hash_a"),
+          { status: 200, result: { attempt: 1 } },
+          "a second record replaced the answer a replay had already been given",
+        );
+      }),
+
+      /** 01-core §12: `tenant` and `op` are part of the key, not decoration. A
+          mount serving many tenants out of one schema would otherwise let one
+          tenant's "req_1" answer another's, and a key reused across two ops
+          would replay the wrong mutation's result. */
+      readyAdapterCase(opts, "01-core §12 — idempotency keys are isolated across tenant and op", async (adapter) => {
+        const ledger = adapter.idempotency;
+        if (ledger === undefined) return;
+        const held = { tenant: "tenant_a", op: "workspace.commit", key: "shared" };
+        await ledger.record(held, "hash_a", { status: 200, result: { whose: "tenant_a" } });
+        assert(
+          await ledger.check({ ...held, tenant: "tenant_b" }, "hash_a") === null,
+          "another tenant's key replayed this tenant's answer",
+        );
+        assert(
+          await ledger.check({ ...held, op: "lifecycle.erase" }, "hash_a") === null,
+          "the same key on another op replayed the first op's answer",
+        );
       }),
 
       /** 01-core §12: blob list filters keys by prefix. */

--- a/packages/core/src/conformance/memory-store-ops.ts
+++ b/packages/core/src/conformance/memory-store-ops.ts
@@ -26,6 +26,30 @@ const isoNow = (): IsoDateTime => {
   return new Date(monotonicMs).toISOString() as IsoDateTime;
 };
 
+/** The forward walk's echoed bound: a resume token naming the last row a page
+    ended on, its indexed VALUE and its ID together. The value alone cannot say
+    where inside a group of rows sharing it the page stopped, and those groups
+    are routine — `vendo_runs.started_at` is caller-supplied at millisecond
+    precision. Prefixed because a caller's first bound is a plain field value,
+    and anything that does not decode as a token is read as one. The encoding is
+    this reference's own: the token is opaque contract and only ever travels
+    back to the implementation that minted it. */
+const WATERMARK_TOKEN = "wm1_";
+
+const encodeWatermark = (value: string, id: string): string =>
+  `${WATERMARK_TOKEN}${JSON.stringify([value, id])}`;
+
+const decodeWatermark = (after: string): { value: string; id: string } | undefined => {
+  if (!after.startsWith(WATERMARK_TOKEN)) return undefined;
+  try {
+    const parsed = JSON.parse(after.slice(WATERMARK_TOKEN.length)) as unknown;
+    if (!Array.isArray(parsed) || typeof parsed[0] !== "string" || typeof parsed[1] !== "string") return undefined;
+    return { value: parsed[0], id: parsed[1] };
+  } catch {
+    return undefined;
+  }
+};
+
 /** The synthetic harness appId a thread's state rides under (the store's
     `harnessStateKey`), so deleting the thread can sweep it. */
 const harnessSlot = (threadId: string): string => `harness_state:${threadId}`;
@@ -229,19 +253,36 @@ export function memoryStoreOps(): StoreOps {
           "engine.list takes a watermark or a cursor, never both — they page in opposite directions",
         );
       }
-      // Every indexed field declared today is the row's own creation instant,
-      // which is exactly what this reference stores as `createdAt`
-      // (`vendo_runs.started_at` IS the run record's createdAt in the real
-      // backend). Ascending, because a forward walk resumes where it stopped.
+      // The bound is on the row's own INDEXED FIELD, which for the one
+      // collection that declares one is CALLER-SUPPLIED: a host writes
+      // `startedAt: new Date().toISOString()`, so a burst of runs shares one
+      // millisecond. This reference stamps its own arrival clock on `createdAt`
+      // and that clock is monotonic, so walking it could never tie — and the
+      // tie is the case the walk has to survive. Read what the caller wrote.
+      const valueOf = (r: VendoRecord): string => {
+        const supplied = (r.data as { startedAt?: unknown }).startedAt;
+        return collection === "vendo_runs" && typeof supplied === "string" ? supplied : r.createdAt;
+      };
+      // A bare bound keeps its strictly-after-the-instant meaning; a token
+      // resumes exactly after the row it names, on the same (value, id) key the
+      // page is ordered by. Ascending, because a forward walk resumes where it
+      // stopped, and tie-broken on the id the token carries — an order that
+      // disagreed with the bound would skip rows at every page boundary.
+      const resume = decodeWatermark(after);
       const forward = [...col(collection).values()]
-        .filter((r) => r.createdAt > after)
-        .sort((a, b) => (a.createdAt === b.createdAt ? a.seq - b.seq : (a.createdAt < b.createdAt ? -1 : 1)));
+        .filter((r) => (resume === undefined
+          ? valueOf(r) > after
+          : valueOf(r) > resume.value || (valueOf(r) === resume.value && r.id > resume.id)))
+        .sort((a, b) => (valueOf(a) === valueOf(b)
+          ? (a.id < b.id ? -1 : 1)
+          : (valueOf(a) < valueOf(b) ? -1 : 1)));
       const page = forward.slice(0, pageLimit(query.limit));
+      const last = page.at(-1);
       return {
         records: page.map(copyRecord),
-        // The bound to send next time: where this page ended, or the caller's
-        // own bound back unchanged when nothing was there to move it.
-        watermark: page.at(-1)?.createdAt ?? after,
+        // The bound to send next time: the row this page ended on, or the
+        // caller's own bound back unchanged when nothing was there to move it.
+        watermark: last === undefined ? after : encodeWatermark(valueOf(last), last.id),
       };
     },
     async claim(collection, expected, replacement) {

--- a/packages/core/src/conformance/memory-store-ops.ts
+++ b/packages/core/src/conformance/memory-store-ops.ts
@@ -1,4 +1,5 @@
-import { assertEngineCollection } from "../engine-collections.js";
+import type { AuditEvent } from "../audit.js";
+import { assertEngineCollection, assertIndexedField, collectionKind } from "../engine-collections.js";
 import { VendoError } from "../errors.js";
 import type { IsoDateTime } from "../ids.js";
 import { VENDO_STORE_WIRE_FORMAT, type StoreWireStatus } from "../store-wire.js";
@@ -6,6 +7,7 @@ import {
   APP_DATA_COLLECTION_PATTERN,
   APP_DATA_OWNER_PATTERN,
   type AppDataTarget,
+  type CollectionFootprint,
   type RecordInput,
   type RecordQuery,
   type StoreOps,
@@ -218,7 +220,29 @@ export function memoryStoreOps(): StoreOps {
     },
     async list(collection, query) {
       assertEngineCollection(collection);
-      return rows.list(collection, query);
+      if (query?.watermark === undefined) return await rows.list(collection, query);
+      const { field, after } = query.watermark;
+      assertIndexedField(collection, field);
+      if (query.cursor !== undefined) {
+        throw new VendoError(
+          "validation",
+          "engine.list takes a watermark or a cursor, never both — they page in opposite directions",
+        );
+      }
+      // Every indexed field declared today is the row's own creation instant,
+      // which is exactly what this reference stores as `createdAt`
+      // (`vendo_runs.started_at` IS the run record's createdAt in the real
+      // backend). Ascending, because a forward walk resumes where it stopped.
+      const forward = [...col(collection).values()]
+        .filter((r) => r.createdAt > after)
+        .sort((a, b) => (a.createdAt === b.createdAt ? a.seq - b.seq : (a.createdAt < b.createdAt ? -1 : 1)));
+      const page = forward.slice(0, pageLimit(query.limit));
+      return {
+        records: page.map(copyRecord),
+        // The bound to send next time: where this page ended, or the caller's
+        // own bound back unchanged when nothing was there to move it.
+        watermark: page.at(-1)?.createdAt ?? after,
+      };
     },
     async claim(collection, expected, replacement) {
       assertEngineCollection(collection);
@@ -604,6 +628,54 @@ export function memoryStoreOps(): StoreOps {
   };
 
   // ---------------------------------------------------------------------------
+  // audit — the typed read over the append-only drawer
+  // ---------------------------------------------------------------------------
+
+  const audit: StoreOps["audit"] = {
+    async list(query = {}) {
+      const page = await rows.list("vendo_audit", {
+        ...(query.cursor === undefined ? {} : { cursor: query.cursor }),
+        ...(query.limit === undefined ? {} : { limit: query.limit }),
+      });
+      // Filtering AFTER the page is a reference's licence, not the contract:
+      // a real backend narrows in its own statement. What the suite pins is
+      // WHICH rows come back, in what order, and that the cursor walks them
+      // all — none of which this shortcut changes.
+      const events = page.records
+        .map((record) => record.data as AuditEvent)
+        .filter((event) =>
+          (query.kind === undefined || event.kind === query.kind)
+          && (query.venue === undefined || event.venue === query.venue)
+          && (query.outcome === undefined || event.outcome === query.outcome)
+          && (query.decidedBy === undefined || event.decidedBy === query.decidedBy));
+      return { events, ...(page.cursor === undefined ? {} : { cursor: page.cursor }) };
+    },
+  };
+
+  // ---------------------------------------------------------------------------
+  // secrets — plaintext here BY DESIGN: a reference has nothing to protect and
+  // no key to hold, and a fake cipher would prove nothing the real one does.
+  // ---------------------------------------------------------------------------
+
+  const vault = new Map<string, string>();
+  const secrets: StoreOps["secrets"] = {
+    async get(name) {
+      return vault.get(name) ?? null;
+    },
+    async set(name, value) {
+      vault.set(name, value);
+    },
+    async list() {
+      // Sorted, because "the order the Map happened to be written in" is not an
+      // answer any two implementations would agree on.
+      return [...vault.keys()].sort();
+    },
+    async delete(name) {
+      vault.delete(name);
+    },
+  };
+
+  // ---------------------------------------------------------------------------
   // status
   // ---------------------------------------------------------------------------
 
@@ -614,8 +686,29 @@ export function memoryStoreOps(): StoreOps {
     transcripts,
     harness,
     workspace,
+    audit,
+    secrets,
     lifecycle,
+    /** Serialized JSON length, which is this reference's honest answer to "how
+        much is in here": it grows with every row and shrinks when rows leave,
+        which is the whole of what a footprint promises. */
+    async footprint() {
+      const measured: CollectionFootprint[] = [];
+      for (const [collection, records] of collections) {
+        let bytes = 0;
+        for (const record of records.values()) {
+          bytes += JSON.stringify({ id: record.id, data: record.data, refs: record.refs }).length;
+        }
+        if (bytes > 0) measured.push({ collection, kind: collectionKind(collection), bytes });
+      }
+      return measured.sort((a, b) => (a.collection < b.collection ? -1 : 1));
+    },
     async status(): Promise<StoreWireStatus> {
+      // Still 35: `ops` is a LEVEL over STORE_WIRE_PATHS' order, and this
+      // reference has no batch append (op 36), so it cannot claim anything past
+      // 35 — whatever it serves further down the list. That is the level's known
+      // coarseness, not a bug in it: the only thing any client reads it for is
+      // STORE_WIRE_APPEND_MESSAGES_OPS, and 35 is the right answer there.
       return { format: VENDO_STORE_WIRE_FORMAT, ops: 35 };
     },
   };

--- a/packages/core/src/conformance/memory-store.ts
+++ b/packages/core/src/conformance/memory-store.ts
@@ -11,6 +11,8 @@ import {
   threadIdSchema,
   TRIGGER_KIND_REF_KEYS,
   triggerKindRefs,
+  type IdempotencyRecord,
+  type IdempotencyScope,
   type Json,
   type RecordStore,
   type StoreAdapter,
@@ -349,6 +351,12 @@ export function memoryStoreAdapter(
     return records;
   };
 
+  /** The three fields together ARE the key — spelled through JSON so a tenant
+      or op containing the separator cannot forge another key's slot. */
+  const ledger = new Map<string, { requestHash: string; answer: IdempotencyRecord }>();
+  const ledgerKey = (scope: IdempotencyScope): string =>
+    JSON.stringify([scope.tenant, scope.op, scope.key]);
+
   const blobMap = (namespace: string): Map<string, { bytes: Uint8Array; contentType?: string }> => {
     let blobs = namespaces.get(namespace);
     if (blobs === undefined) {
@@ -487,6 +495,29 @@ export function memoryStoreAdapter(
           },
         },
       };
+    },
+    // Colocated with the rows above by construction — one process, one object,
+    // so the ledger cannot commit while the mutation it gates rolls back. A
+    // hosted mount earns the same guarantee by putting it in the same database.
+    idempotency: {
+      async check(scope, requestHash) {
+        const held = ledger.get(ledgerKey(scope));
+        if (held === undefined) return null;
+        if (held.requestHash !== requestHash) {
+          throw new VendoError(
+            "conflict",
+            `idempotency key ${scope.key} was already used with a different request body`,
+          );
+        }
+        return { status: held.answer.status, result: jsonCopy(held.answer.result) };
+      },
+      async record(scope, requestHash, answer) {
+        const key = ledgerKey(scope);
+        // First writer wins: the answer a replay has already been handed must
+        // not change under it.
+        if (ledger.has(key)) return;
+        ledger.set(key, { requestHash, answer: { status: answer.status, result: jsonCopy(answer.result) } });
+      },
     },
     blobs(namespace: string) {
       const blobs = blobMap(namespace);

--- a/packages/core/src/conformance/store-ops.ts
+++ b/packages/core/src/conformance/store-ops.ts
@@ -252,6 +252,42 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         assertDeepEqual(seen, ids, "the forward walk did not visit every row exactly once, oldest first");
       }),
 
+      /** The tie the walk has to survive. `vendo_runs.started_at` is
+          CALLER-SUPPLIED, and callers write `new Date().toISOString()` — one
+          millisecond of resolution — so a burst of runs routinely shares one
+          value. A bound that is nothing but that value cannot say where INSIDE
+          such a group a page stopped: the next call asks for everything
+          strictly after the instant, and whatever was left of the group is
+          skipped, silently and permanently. For the meter this walk exists for
+          that is usage nobody ever bills. The group is seeded larger than the
+          page deliberately, so a page boundary MUST land inside it. */
+      opsCase(opts, "engine.list's forward walk crosses a page boundary inside rows sharing one indexed value", async (ops) => {
+        const tied = "2026-03-04T05:06:07.000Z"; // one millisecond, five runs
+        const ids = ["run_t1", "run_t2", "run_t3", "run_t4", "run_t5"];
+        for (const id of ids) {
+          await ops.engine.put("vendo_runs", {
+            id,
+            data: { appId: "app_meter", trigger: { kind: "schedule" }, status: "ok", record: {}, startedAt: tied },
+          });
+        }
+        // A meter's FIRST bound is a plain field value it authored; every later
+        // one is the page's own echo, sent back verbatim and never read.
+        await assertPaginates("engine.list watermark", ids, async (after) => {
+          const page = await ops.engine.list("vendo_runs", {
+            limit: PAGE,
+            watermark: { field: "started_at", after: after ?? new Date(0).toISOString() },
+          });
+          assert(page.watermark !== undefined, "a page that was given a watermark bound must echo the next bound back");
+          // The echo never falls away — its absence means the mount ignored the
+          // bound — so it is the empty page, not a missing echo, that ends the
+          // walk.
+          return {
+            ids: page.records.map((record) => record.id),
+            ...(page.records.length === 0 ? {} : { cursor: page.watermark }),
+          };
+        });
+      }),
+
       /** Two refusals, both of them cliffs a caller would otherwise fall off
           quietly: an unindexed bound is a full table scan wearing a filter's
           clothes, and a cursor beside a watermark is two walks in opposite

--- a/packages/core/src/conformance/store-ops.ts
+++ b/packages/core/src/conformance/store-ops.ts
@@ -1,8 +1,9 @@
+import type { AuditEvent } from "../audit.js";
 import { ENGINE_ALLOWLIST_VERSION, engineAppHistory } from "../engine-collections.js";
 import type { VendoErrorCode } from "../errors.js";
-import { isoDateTimeSchema } from "../ids.js";
-import { STORE_WIRE_APPEND_MESSAGES_OPS, VENDO_STORE_WIRE_FORMAT } from "../store-wire.js";
-import type { StoreOps } from "../store.js";
+import { isoDateTimeSchema, type IsoDateTime } from "../ids.js";
+import { STORE_WIRE_APPEND_MESSAGES_OPS, STORE_WIRE_PATHS, VENDO_STORE_WIRE_FORMAT } from "../store-wire.js";
+import type { AuditQuery, CollectionFootprint, StoreOps } from "../store.js";
 import { assert, assertBytesEqual, assertDeepEqual } from "./assertions.js";
 import type { ConformanceCase, ConformanceSuite } from "./index.js";
 
@@ -76,6 +77,36 @@ const numberField = (entry: unknown, field: string, message: string): number => 
     (the store's `harnessStateKey`), which is what makes deleteThread's cascade
     onto harness state observable through the 35 ops. */
 const harnessSlot = (threadId: string): string => `harness_state:${threadId}`;
+
+/** A shape-valid AuditEvent. `vendo_audit` is a TYPED door — the real backend
+    parses every row with `auditEventSchema` and refuses what does not fit — so
+    the audit cases seed real events rather than convenient stubs. `minute` is
+    the event's own `at`, which is the column both doors over this drawer order
+    on. */
+const auditEvent = (id: string, minute: number, fields: Partial<AuditEvent>): AuditEvent => ({
+  id,
+  at: new Date(Date.UTC(2026, 0, 1, 0, minute)).toISOString() as IsoDateTime,
+  kind: "tool-call",
+  principal: { kind: "user", subject: "user_1" },
+  venue: "chat",
+  presence: "present",
+  ...fields,
+});
+
+/** Seeds the audit drawer through the engine door, in ascending `at` order —
+    which is what makes "newest first" one list rather than two. */
+const seedAudit = async (ops: StoreOps, events: AuditEvent[]): Promise<void> => {
+  for (const event of events) await ops.engine.put("vendo_audit", { id: event.id, data: event });
+};
+
+/** Carries a case without running it, and says why (see
+    `ConformanceCase.pending`). The body is the real one — landing the
+    capability is deleting this call, not writing the case. */
+const pending = (reason: string, conformanceCase: ConformanceCase): ConformanceCase =>
+  ({ ...conformanceCase, pending: reason });
+
+/** The one lane that owes every case tagged below. */
+const RETENTION_LANE = "the retention lane lands StoreOps.retention — the contract declares it, nothing serves it yet";
 
 /** appData rows live in the app's own drawer, and the local backend fails an
     app-scoped write closed when the app has no row — so every appData case
@@ -167,6 +198,77 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
           const page = await ops.engine.list(collection, { limit: PAGE, cursor });
           return { ids: page.records.map((r) => r.id), cursor: page.cursor };
         });
+      }),
+
+      /** The forward walk — the one read a newest-first page cannot serve. A
+          meter that has already counted runs up to some instant asks for
+          everything after it and advances its mark as it goes, so a bound that
+          loses precision on the round trip moves BACKWARDS and the meter
+          re-counts a window it has already billed; one that moves too far skips
+          rows nobody ever counts. Both are silent, which is why the walk is
+          asserted lossless rather than merely non-empty.
+          Nothing here reads the watermark STRING: it is contractually opaque,
+          and the two shipped engines spell it differently (a Postgres-native
+          text form, an ISO instant). */
+      opsCase(opts, "engine.list walks forward from a watermark, oldest first, visiting every row exactly once", async (ops) => {
+        // vendo_runs is a typed door — appId, trigger, status, record and
+        // startedAt, or the real backend refuses the row. `startedAt` ascends
+        // with write order, so "oldest first" is one answer for an engine that
+        // orders on the indexed column and one that orders on arrival.
+        const ids = ["run_w1", "run_w2", "run_w3", "run_w4", "run_w5"];
+        for (const [index, id] of ids.entries()) {
+          await ops.engine.put("vendo_runs", {
+            id,
+            data: {
+              appId: "app_meter",
+              trigger: { kind: "schedule" },
+              status: "ok",
+              record: { index },
+              startedAt: new Date(Date.UTC(2026, 0, 1, 0, index)).toISOString(),
+            },
+          });
+        }
+
+        let after = new Date(0).toISOString(); // the mark a meter that has counted nothing holds
+        const seen: string[] = [];
+        for (let page = 0; page < ids.length + 2; page += 1) {
+          const answer = await ops.engine.list("vendo_runs", { limit: PAGE, watermark: { field: "started_at", after } });
+          const echoed = answer.watermark;
+          assert(answer.records.length <= PAGE, `a watermark page held ${answer.records.length} rows past its limit of ${PAGE}`);
+          // The echo is the ONLY thing that tells a caller its bound was
+          // understood: a mount older than the bound parses the query, ignores
+          // it, and answers with an ordinary newest-first page instead.
+          assert(echoed !== undefined, "a page that was given a watermark bound must echo the next bound back");
+          for (const record of answer.records) {
+            assert(!seen.includes(record.id), `${record.id} was visited twice by the forward walk`);
+            seen.push(record.id);
+          }
+          if (answer.records.length === 0) {
+            assert(echoed === after, "an empty page must echo the requested bound back unchanged");
+            break;
+          }
+          after = echoed;
+        }
+        assertDeepEqual(seen, ids, "the forward walk did not visit every row exactly once, oldest first");
+      }),
+
+      /** Two refusals, both of them cliffs a caller would otherwise fall off
+          quietly: an unindexed bound is a full table scan wearing a filter's
+          clothes, and a cursor beside a watermark is two walks in opposite
+          directions with no single answer to give. Refused, rather than served
+          slowly or resolved by a precedence rule nobody could guess. */
+      opsCase(opts, "engine.list refuses a watermark on an unindexed field, and one sent beside a cursor", async (ops) => {
+        const after = new Date(0).toISOString();
+        await assertThrowsCode(
+          () => ops.engine.list("vendo_audit", { watermark: { field: "at", after } }),
+          "validation",
+          "a watermark on a field vendo_audit does not declare indexed",
+        );
+        await assertThrowsCode(
+          () => ops.engine.list("vendo_runs", { cursor: "0", watermark: { field: "started_at", after } }),
+          "validation",
+          "a call carrying both a cursor and a watermark",
+        );
       }),
 
       opsCase(opts, "engine round-trips a record on an engine collection", async (ops) => {
@@ -1135,6 +1237,224 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
       }),
 
       // =====================================================================
+      // audit
+      // =====================================================================
+
+      /** The reviewer's feed and the decision tally, which are the only two
+          reasons this door exists at all: three of its four filters are not
+          refs (`venue` is a column, `outcome` and `decidedBy` live inside the
+          event), so `engine.list`'s ref filter cannot express any of them. */
+      opsCase(opts, "audit.list narrows by each of its four filters and ANDs them together", async (ops) => {
+        await seedAudit(ops, [
+          auditEvent("aud_c1", 1, { kind: "tool-call", venue: "chat", outcome: "ok", decidedBy: "grant" }),
+          auditEvent("aud_c2", 2, { kind: "approval", venue: "app", outcome: "blocked", decidedBy: "denied" }),
+          auditEvent("aud_c3", 3, { kind: "tool-call", venue: "app", outcome: "ok", decidedBy: "rule" }),
+          auditEvent("aud_c4", 4, { kind: "policy-decision", venue: "chat", outcome: "error", decidedBy: "judge" }),
+          auditEvent("aud_c5", 5, { kind: "tool-call", venue: "chat", outcome: "blocked", decidedBy: "grant" }),
+        ]);
+        const idsOf = async (query?: AuditQuery): Promise<string[]> =>
+          (await ops.audit.list(query)).events.map((event) => event.id);
+
+        // No filter is the whole drawer, newest first — an empty query is the
+        // feed, not an empty answer.
+        assertDeepEqual(await idsOf(), ["aud_c5", "aud_c4", "aud_c3", "aud_c2", "aud_c1"], "an unfiltered audit.list is the whole drawer, newest first");
+        assertDeepEqual(await idsOf({ kind: "tool-call" }), ["aud_c5", "aud_c3", "aud_c1"], "the kind filter returned the wrong rows");
+        assertDeepEqual(await idsOf({ venue: "app" }), ["aud_c3", "aud_c2"], "the venue filter returned the wrong rows");
+        assertDeepEqual(await idsOf({ outcome: "blocked" }), ["aud_c5", "aud_c2"], "the outcome filter returned the wrong rows");
+        assertDeepEqual(await idsOf({ decidedBy: "grant" }), ["aud_c5", "aud_c1"], "the decidedBy filter returned the wrong rows");
+
+        // ANDed, never ORed: each of these pairs drops rows that either filter
+        // alone keeps, which an OR could not do.
+        assertDeepEqual(await idsOf({ kind: "tool-call", venue: "app" }), ["aud_c3"], "two filters did not AND");
+        assertDeepEqual(
+          await idsOf({ kind: "tool-call", venue: "chat", outcome: "blocked", decidedBy: "grant" }),
+          ["aud_c5"],
+          "all four filters did not AND",
+        );
+      }),
+
+      opsCase(opts, "audit.list walks its cursor without loss or duplicates", async (ops) => {
+        const ids = ["aud_p1", "aud_p2", "aud_p3", "aud_p4", "aud_p5"];
+        await seedAudit(ops, ids.map((id, index) => auditEvent(id, index + 1, {})));
+        await assertPaginates("audit.list", ids, async (cursor) => {
+          const page = await ops.audit.list({ limit: PAGE, cursor });
+          return { ids: page.events.map((event) => event.id), cursor: page.cursor };
+        });
+      }),
+
+      /** TWO DOORS, ONE DRAWER — the case that matters more than the filters.
+          `audit.list()` and `engine.list("vendo_audit")` read the same rows on
+          the same keyset order, and nothing in an implementation forces that: a
+          typed door sorting on the event's own `at` and a generic one sorting
+          on the row's arrival agree until the two differ, and then a reviewer's
+          feed and the drawer the erase cascade sweeps stop describing the same
+          history. Two doors that are allowed to disagree will. */
+      opsCase(opts, "audit.list and engine.list read one drawer in one order", async (ops) => {
+        await seedAudit(ops, [
+          auditEvent("aud_d1", 1, { kind: "tool-call", outcome: "ok", decidedBy: "grant" }),
+          auditEvent("aud_d2", 2, { kind: "approval", venue: "app", outcome: "pending-approval" }),
+          auditEvent("aud_d3", 3, { kind: "run", venue: "automation", outcome: "error" }),
+        ]);
+        const typed = (await ops.audit.list()).events;
+        const generic = (await ops.engine.list("vendo_audit")).records;
+        assertDeepEqual(
+          typed.map((event) => event.id),
+          generic.map((record) => record.id),
+          "the two doors over vendo_audit returned different rows or a different order",
+        );
+        assertDeepEqual(
+          typed,
+          generic.map((record) => record.data),
+          "the typed door returned events the drawer does not hold",
+        );
+      }),
+
+      // =====================================================================
+      // secrets
+      // =====================================================================
+
+      /** The vault a host's connectors authenticate out of. `get` answering
+          NULL for a name nobody set — not undefined, not a throw — is what lets
+          a boot path ask "is this connector configured yet" without wrapping
+          the call; a throw there turns an unconfigured connector into a crash. */
+      opsCase(opts, "secrets round-trip, overwrite in place, and answer null for a name nobody set", async (ops) => {
+        assert(await ops.secrets.get("conf_absent") === null, "a name nobody set must read as null");
+        await ops.secrets.set("conf_token", "value_1");
+        assert(await ops.secrets.get("conf_token") === "value_1", "the stored secret did not round-trip");
+        await ops.secrets.set("conf_token", "value_2");
+        assert(await ops.secrets.get("conf_token") === "value_2", "set on a name already held did not overwrite it");
+      }),
+
+      /** `list` is the vault's inventory, and it is SORTED: "the order they
+          happened to be written in" is not an answer two implementations would
+          ever give alike, and an operator reading a rotation list needs the
+          same order twice. */
+      opsCase(opts, "secrets.list holds exactly the live names, sorted, and delete removes one", async (ops) => {
+        for (const name of ["conf_b", "conf_a", "conf_c"]) await ops.secrets.set(name, `value_of_${name}`);
+        assertDeepEqual(await ops.secrets.list(), ["conf_a", "conf_b", "conf_c"], "list is not the live names in sorted order");
+        await ops.secrets.delete("conf_b");
+        assertDeepEqual(await ops.secrets.list(), ["conf_a", "conf_c"], "a deleted name stayed in the inventory");
+        assert(await ops.secrets.get("conf_b") === null, "a deleted secret remained readable");
+      }),
+
+      // =====================================================================
+      // footprint
+      // =====================================================================
+
+      /** What is in the drawers, per collection, with each collection's kind
+          alongside — and the kind is the reason the op is shaped this way: a
+          footprint that cannot tell a retrieval corpus from an ordinary drawer
+          cannot answer "what is the index costing me".
+          Nothing here asserts a byte COUNT. `bytes` is an estimate of row
+          content that each engine measures its own way, and a case pinning a
+          number would fail every honest implementation but the one it was
+          written against. */
+      opsCase(opts, "footprint reports a shape-valid entry per non-empty collection, with its kind", async (ops) => {
+        await ops.engine.put("vendo_workspace_commits", { id: "fp_1", data: { note: "x".repeat(64) } });
+        await ops.engine.put("vendo_knowledge_docs", { id: "fp_doc_1", data: { text: "y".repeat(64) } });
+        const footprint = await ops.footprint();
+        for (const entry of footprint) {
+          assert(typeof entry.collection === "string" && entry.collection.length > 0, `a footprint entry has no collection name: ${JSON.stringify(entry)}`);
+          assert(entry.kind === "storage" || entry.kind === "knowledge", `${entry.collection} reported the kind ${JSON.stringify(entry.kind)}`);
+          assert(
+            typeof entry.bytes === "number" && Number.isFinite(entry.bytes) && entry.bytes >= 0,
+            `${entry.collection} reported bytes ${String(entry.bytes)}`,
+          );
+        }
+        const entryFor = (collection: string): CollectionFootprint | undefined =>
+          footprint.find((entry) => entry.collection === collection);
+        assert(entryFor("vendo_workspace_commits")?.kind === "storage", "a storage collection holding rows is missing from the footprint");
+        assert(entryFor("vendo_knowledge_docs")?.kind === "knowledge", "the retrieval corpus was counted as ordinary storage");
+        assert(
+          footprint.length === new Set(footprint.map((entry) => entry.collection)).size,
+          "a collection was reported more than once",
+        );
+      }),
+
+      /** MONOTONIC, not exact: rows going in may only push the number up, which
+          is the whole of what makes two footprints comparable. `>=` and not `>`
+          on purpose — a byte accounting is allowed to be page-granular or
+          otherwise coarse, and pinning strict growth would fail an engine that
+          is telling the truth about a page it had already allocated. */
+      opsCase(opts, "footprint bytes never decrease as a collection grows", async (ops) => {
+        const collection = engineAppHistory("conf_fp");
+        const bytesOf = async (): Promise<number> =>
+          (await ops.footprint()).find((entry) => entry.collection === collection)?.bytes ?? -1;
+        await ops.engine.put(collection, { id: "fp_seed", data: { note: "a".repeat(64) } });
+        const before = await bytesOf();
+        assert(before >= 0, "a collection holding rows was left out of the footprint");
+        for (let index = 0; index < 10; index += 1) {
+          await ops.engine.put(collection, { id: `fp_more_${index}`, data: { note: "b".repeat(512) } });
+        }
+        const after = await bytesOf();
+        assert(after >= before, `the footprint shrank as rows were added: ${after} < ${before}`);
+      }),
+
+      // =====================================================================
+      // retention — PENDING, both of them. The contract declares the family and
+      // nothing serves it yet, so these carry it in the open: a skipped case
+      // with a named owner is a standing line in every mount's output, where
+      // leaving the cases out until the code arrives is how an op ships dead.
+      // =====================================================================
+
+      /** The sweep is a cron, so the two things that matter are the count it
+          reports and its behavior on the second pass. The window is expressed
+          by moving the CUTOFF rather than the rows' age, because a case can
+          only write rows now: a cutoff older than every row covers them all and
+          must move nothing. */
+      pending(RETENTION_LANE, opsCase(opts, "retention.quarantine lifts rows past the cutoff out of the live collection, and re-running it moves nothing", async (ops) => {
+        const retention = ops.retention;
+        if (retention === undefined) return;
+        const collection = engineAppHistory("conf_ret");
+        const ids = ["ret_1", "ret_2", "ret_3"];
+        for (const id of ids) await ops.engine.put(collection, { id, data: { id } });
+
+        const inWindow = await retention.quarantine(collection, new Date(0).toISOString() as IsoDateTime);
+        assert(inWindow.moved === 0, `a cutoff older than every row should move nothing, moved ${inWindow.moved}`);
+        assert(
+          (await ops.engine.list(collection)).records.length === ids.length,
+          "a quarantine that moved nothing still took rows out of the live collection",
+        );
+
+        const cutoff = new Date(Date.now() + 60_000).toISOString() as IsoDateTime;
+        const swept = await retention.quarantine(collection, cutoff);
+        assert(swept.moved === ids.length, `quarantine should report the ${ids.length} rows it moved, reported ${swept.moved}`);
+        assertDeepEqual(
+          (await ops.engine.list(collection)).records.map((record) => record.id),
+          [],
+          "quarantined rows stayed in the live collection",
+        );
+        assert(await ops.engine.get(collection, "ret_1") === null, "a quarantined row is still readable through the live door");
+
+        const again = await retention.quarantine(collection, cutoff);
+        assert(again.moved === 0, `a second quarantine at the same cutoff should move nothing, moved ${again.moved}`);
+      })),
+
+      /** The gap between the two verbs IS the feature, and the purge count is
+          the only place it is observable: the engine owns the quarantine and no
+          caller may name it, so "still recoverable" can only be read as a purge
+          that declines to destroy. The cutoff is on the QUARANTINE time, not
+          the row's age — the grace a purge honors runs from the lift. */
+      pending(RETENTION_LANE, opsCase(opts, "retention.purge destroys only quarantined rows lifted before its cutoff", async (ops) => {
+        const retention = ops.retention;
+        if (retention === undefined) return;
+        const collection = engineAppHistory("conf_purge");
+        const ids = ["purge_1", "purge_2"];
+        for (const id of ids) await ops.engine.put(collection, { id, data: { id } });
+        const lifted = await retention.quarantine(collection, new Date(Date.now() + 60_000).toISOString() as IsoDateTime);
+        assert(lifted.moved === ids.length, `the sweep should have lifted ${ids.length} rows, lifted ${lifted.moved}`);
+
+        const early = await retention.purge(collection, new Date(0).toISOString() as IsoDateTime);
+        assert(early.purged === 0, `a purge cutoff predating the sweep should destroy nothing, destroyed ${early.purged}`);
+
+        const past = new Date(Date.now() + 60_000).toISOString() as IsoDateTime;
+        const destroyed = await retention.purge(collection, past);
+        assert(destroyed.purged === ids.length, `the purge should report the ${ids.length} rows it destroyed, reported ${destroyed.purged}`);
+        const again = await retention.purge(collection, past);
+        assert(again.purged === 0, `a second purge reported ${again.purged} rows a first one had already destroyed`);
+      })),
+
+      // =====================================================================
       // status
       // =====================================================================
 
@@ -1142,14 +1462,26 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         const status = await ops.status();
         assert(status.format === VENDO_STORE_WIRE_FORMAT, `status.format should be ${VENDO_STORE_WIRE_FORMAT}`);
         assert(typeof status.ops === "number", "status.ops should be a number");
-        // The count is the handshake's ONLY capability signal, so it must track
-        // what the mount actually serves — a client feature-detects the batch
-        // append on exactly this number (STORE_WIRE_APPEND_MESSAGES_OPS). A
-        // mount that omits the optional op is the 35-op vintage and says so.
-        const expected = ops.transcripts.appendMessages === undefined
-          ? STORE_WIRE_APPEND_MESSAGES_OPS - 1
-          : STORE_WIRE_APPEND_MESSAGES_OPS;
-        assert(status.ops === expected, `status.ops should be ${expected}, got ${status.ops}`);
+        // `ops` is a LEVEL over STORE_WIRE_PATHS' declared order, not an
+        // inventory, so there is no single right number to assert: three honest
+        // implementations report three (the local engine stops short of the two
+        // retention ops, the memory reference has no batch append). This case
+        // used to pin the count exactly, which only held while every mount was
+        // the same vintage — it would now fail two implementations that are
+        // telling the truth. What IS contract is the ceiling and the one
+        // question a client asks the level.
+        const declared = Object.keys(STORE_WIRE_PATHS).length;
+        assert(status.ops <= declared, `a mount cannot serve more than the ${declared} declared ops, got ${status.ops}`);
+        // The level's ONE contract use, and the only way it breaks a client: a
+        // caller feature-detects the batch append on this number alone, so a
+        // mount claiming the level must serve the op, and one serving the op
+        // must claim the level.
+        assert(
+          (status.ops >= STORE_WIRE_APPEND_MESSAGES_OPS) === (ops.transcripts.appendMessages !== undefined),
+          `status.ops ${status.ops} disagrees with transcripts.appendMessages being `
+          + `${ops.transcripts.appendMessages === undefined ? "absent" : "served"} `
+          + `(the batch append is op ${STORE_WIRE_APPEND_MESSAGES_OPS})`,
+        );
       }),
     ],
   };

--- a/packages/core/src/engine-collections.ts
+++ b/packages/core/src/engine-collections.ts
@@ -5,67 +5,109 @@ import { VendoError } from "./errors.js";
     ENGINE_COLLECTIONS or ENGINE_COLLECTION_PATTERNS changes. */
 export const ENGINE_ALLOWLIST_VERSION = 2;
 
+/** What a collection HOLDS. `knowledge` is the retrieval corpus — documents and
+    the chunks an engine mints from them; everything else is `storage`.
+    Deliberately a property of the DATA, not of anyone's billing: Vendo Cloud
+    meters the two kinds apart, but a category like "unmetered" is a price list,
+    not a data kind, and does not belong in a contract every BYO mount reads. */
+export type CollectionKind = "storage" | "knowledge";
+
+/** What the registry declares about one engine collection. */
+export interface EngineCollectionSpec {
+  kind: CollectionKind;
+  /** The fields an `engine.list` watermark may bound, because THIS collection
+      keeps them indexed. Absent for the 37 collections with nothing to walk
+      forward through: an unindexed bound is a full table scan wearing a filter's
+      clothes, so it is refused rather than served slowly. */
+  indexed?: readonly string[];
+}
+
 /** The collections the `engine` op family may touch: Vendo's OWN internal
-    drawers, nothing a host or a generated app owns. The list lives in core
+    drawers, nothing a host or a generated app owns. The registry lives in core
     because guard, automations and apps all need it and none of them may import
     @vendoai/store (layering); core imports nothing, so it is a literal here and
-    a drift test in @vendoai/store holds it to the real constants. */
-export const ENGINE_COLLECTIONS = [
+    a drift test in @vendoai/store holds it to the real constants.
+
+    ONE registry, not a list plus a side-table of attributes: a second place
+    naming these collections is how the allowlist rots, and `kind` and `indexed`
+    are facts ABOUT an entry, so they live on the entry. */
+export const ENGINE_COLLECTION_REGISTRY = {
   // Reserved, routed through typed doors — mirrors RESERVED_COLLECTIONS,
   // packages/store/src/routing.ts:53-63.
-  "vendo_grants",
-  "vendo_approvals",
-  "vendo_audit",
-  "vendo_threads",
-  "vendo_runs",
-  "vendo_apps",
-  "vendo_state",
-  "vendo_effects",
-  "vendo_app_grants",
+  vendo_grants: { kind: "storage" },
+  vendo_approvals: { kind: "storage" },
+  vendo_audit: { kind: "storage" },
+  vendo_threads: { kind: "storage" },
+  // The ONE collection with a watermark field today: `vendo_runs.started_at` is
+  // a real column with its own index (packages/store/src/schema.ts:120), and a
+  // meter that reconciles runs it has already counted has to walk forward from
+  // where it stopped. Every other collection is read newest-first and needs no
+  // forward walk — which is why this list is per-collection and not a blanket
+  // "any timestamp column".
+  vendo_runs: { kind: "storage", indexed: ["started_at"] },
+  vendo_apps: { kind: "storage" },
+  vendo_state: { kind: "storage" },
+  vendo_effects: { kind: "storage" },
+  vendo_app_grants: { kind: "storage" },
 
   // Dedicated tables — mirrors DEDICATED_RECORD_COLLECTIONS,
   // packages/store/src/routing.ts:65-70.
-  "vendo_mcp_clients",
-  "vendo_mcp_grants",
-  "vendo_knowledge_docs",
-  "vendo_knowledge_chunks",
+  vendo_mcp_clients: { kind: "storage" },
+  vendo_mcp_grants: { kind: "storage" },
+  // The retrieval corpus: the document rows and the chunks an engine mints from
+  // them. The only two `knowledge` entries in the registry, and the reason the
+  // kind exists — a footprint that cannot tell a corpus from a drawer cannot
+  // answer "what is the index costing me".
+  vendo_knowledge_docs: { kind: "knowledge" },
+  vendo_knowledge_chunks: { kind: "knowledge" },
 
   // Generic-table collections the blocks own.
-  "vendo_parked_call", // PARKED_COLLECTION, packages/vendo/src/byo-approvals.ts:47
+  vendo_parked_call: { kind: "storage" }, // PARKED_COLLECTION, packages/vendo/src/byo-approvals.ts:47
   // PARKED_CALL_OUTCOME_COLLECTION, packages/core/src/parked-outcome.ts — written
   // by BOTH parked-call lanes (byo-approvals.ts, parked-action.ts), read by one.
-  "vendo_parked_call_outcome",
+  vendo_parked_call_outcome: { kind: "storage" },
   // The next two, and guard:controls below, write rows carrying NEITHER a
   // subject ref NOR an app ref, and that is deliberate: they are HOST-LEVEL
   // CONFIG — the host's component registry, the pinned-baseline seed, the
   // guard's freeze switch — not any user's or any app's data, so the erase
   // cascade correctly never sweeps them. Do not "fix" them by adding a ref.
-  "vendo_host_components", // HOST_COMPONENTS_COLLECTION, packages/vendo/src/cli/cloud/host-components.ts:34
-  "vendo_pin_baselines", // PIN_BASELINES_COLLECTION, packages/vendo/src/cli/cloud/seed-baselines.ts:26
-  "vendo_placements", // PLACEMENTS_COLLECTION, packages/apps/src/server/persistence/placements.ts:48
-  "vendo_placement_slots", // PLACEMENT_SLOTS_COLLECTION, packages/apps/src/server/persistence/placements.ts:54
-  "vendo_app_tokens", // APP_TOKEN_COLLECTION, packages/apps/src/server/persistence/app-token.ts:12
-  "vendo_parked_action", // COLLECTION, packages/apps/src/server/persistence/parked-action.ts:50
-  "vendo_egress_approval", // COLLECTION, packages/apps/src/server/escalation/egress-approval.ts:96
-  "vendo_inclient_approvals", // COLLECTION, packages/apps/src/server/remix/inclient.ts:76
-  "vendo_remix_rejections", // COLLECTION, packages/apps/src/server/remix/review.ts:65
-  "vendo_slots", // SLOTS_COLLECTION, packages/apps/src/server/persistence/slots.ts:24
-  "vendo_workspace_commits", // WORKSPACE_COMMITS, packages/store/src/ops.ts:27
-  "automations:captures", // CAPTURES, packages/automations/src/types.ts:29
-  "automations:armed", // ARMED, packages/automations/src/types.ts:43
-  "automations:schedule", // SCHEDULE, packages/automations/src/types.ts:30
-  "automations:webhook", // WEBHOOK, packages/automations/src/types.ts:31
-  "automations:deliveries", // DELIVERIES, packages/automations/src/types.ts:32
-  "automations:sponsorships", // SPONSORSHIPS, packages/automations/src/sponsorship.ts:17
-  "automations:sponsored", // SPONSORED, packages/automations/src/sponsorship.ts:29
-  "guard:controls", // CONTROLS_COLLECTION, packages/guard/src/guard.ts:117 — host-level config, see above
-  "guard:approval-claims", // APPROVAL_CLAIMS_COLLECTION, packages/guard/src/guard.ts:111
-  "vendo_channel_links", // LINK_COLLECTION, packages/vendo/src/channel-links.ts:22
-  "vendo_channel_events", // EVENT_COLLECTION, packages/vendo/src/channel-links.ts:25
-  "vendo_channel_asks", // ASK_COLLECTION, packages/vendo/src/channel-links.ts:33
-] as const;
+  vendo_host_components: { kind: "storage" }, // HOST_COMPONENTS_COLLECTION, packages/vendo/src/cli/cloud/host-components.ts:34
+  vendo_pin_baselines: { kind: "storage" }, // PIN_BASELINES_COLLECTION, packages/vendo/src/cli/cloud/seed-baselines.ts:26
+  vendo_placements: { kind: "storage" }, // PLACEMENTS_COLLECTION, packages/apps/src/server/persistence/placements.ts:48
+  vendo_placement_slots: { kind: "storage" }, // PLACEMENT_SLOTS_COLLECTION, packages/apps/src/server/persistence/placements.ts:54
+  vendo_app_tokens: { kind: "storage" }, // APP_TOKEN_COLLECTION, packages/apps/src/server/persistence/app-token.ts:12
+  vendo_parked_action: { kind: "storage" }, // COLLECTION, packages/apps/src/server/persistence/parked-action.ts:50
+  vendo_egress_approval: { kind: "storage" }, // COLLECTION, packages/apps/src/server/escalation/egress-approval.ts:96
+  vendo_inclient_approvals: { kind: "storage" }, // COLLECTION, packages/apps/src/server/remix/inclient.ts:76
+  vendo_remix_rejections: { kind: "storage" }, // COLLECTION, packages/apps/src/server/remix/review.ts:65
+  vendo_slots: { kind: "storage" }, // SLOTS_COLLECTION, packages/apps/src/server/persistence/slots.ts:24
+  vendo_workspace_commits: { kind: "storage" }, // WORKSPACE_COMMITS, packages/store/src/ops.ts:27
+  "automations:captures": { kind: "storage" }, // CAPTURES, packages/automations/src/types.ts:29
+  "automations:armed": { kind: "storage" }, // ARMED, packages/automations/src/types.ts:43
+  "automations:schedule": { kind: "storage" }, // SCHEDULE, packages/automations/src/types.ts:30
+  "automations:webhook": { kind: "storage" }, // WEBHOOK, packages/automations/src/types.ts:31
+  "automations:deliveries": { kind: "storage" }, // DELIVERIES, packages/automations/src/types.ts:32
+  "automations:sponsorships": { kind: "storage" }, // SPONSORSHIPS, packages/automations/src/sponsorship.ts:17
+  "automations:sponsored": { kind: "storage" }, // SPONSORED, packages/automations/src/sponsorship.ts:29
+  "guard:controls": { kind: "storage" }, // CONTROLS_COLLECTION, packages/guard/src/guard.ts:117 — host-level config, see above
+  "guard:approval-claims": { kind: "storage" }, // APPROVAL_CLAIMS_COLLECTION, packages/guard/src/guard.ts:111
+  vendo_channel_links: { kind: "storage" }, // LINK_COLLECTION, packages/vendo/src/channel-links.ts:22
+  vendo_channel_events: { kind: "storage" }, // EVENT_COLLECTION, packages/vendo/src/channel-links.ts:25
+  vendo_channel_asks: { kind: "storage" }, // ASK_COLLECTION, packages/vendo/src/channel-links.ts:33
+} as const satisfies Record<string, EngineCollectionSpec>;
 
-export type EngineCollection = typeof ENGINE_COLLECTIONS[number];
+export type EngineCollection = keyof typeof ENGINE_COLLECTION_REGISTRY;
+
+/** The registry's names, in registry order — the allowlist itself. Derived, so
+    adding a collection is one edit and the two can never disagree. */
+export const ENGINE_COLLECTIONS = Object.keys(ENGINE_COLLECTION_REGISTRY) as readonly EngineCollection[];
+
+/** One widened read of the registry. The `as const` literal types each entry
+    exactly — which is what makes `indexed` a compile-time fact where it exists
+    — but that same precision means the union has no `indexed` member at all on
+    the entries without one, so every lookup goes through here. */
+const specOf = (collection: string): EngineCollectionSpec | undefined =>
+  (ENGINE_COLLECTION_REGISTRY as Record<string, EngineCollectionSpec>)[collection];
 
 /** The id grammar the app-history pattern accepts. Shared by the builder so a
     name that cannot pass the gate is never composed in the first place. */
@@ -148,5 +190,34 @@ export function assertEngineCollection(collection: string): void {
     + (suggestion === undefined ? "." : ` — did you mean ${JSON.stringify(suggestion)}?`)
     + " App data belongs to the appData family (ops.appData.*), which takes an"
     + " { appId, collection, owner } target.",
+  );
+}
+
+/** What a collection holds, for the byte accounting `footprint()` reports.
+    A legal collection with no registry entry — today only the app-history
+    pattern — is `storage`: `knowledge` is the closed exception (the corpus and
+    its chunks), never the default, so a collection invented later is never
+    silently counted as index cost. */
+export function collectionKind(collection: string): CollectionKind {
+  return specOf(collection)?.kind ?? "storage";
+}
+
+/** The gate on an `engine.list` watermark bound. A field this collection does
+    not keep indexed is refused, not scanned: the whole point of the bound is a
+    cheap forward walk, and one that degrades into a full scan under load is a
+    performance cliff hidden behind a working API.
+
+    `validation`, not `blocked`: the collection is legal and the caller's right
+    to read it is not in question — the FIELD is wrong, and the message says
+    which fields are right. */
+export function assertIndexedField(collection: string, field: string): void {
+  const fields = specOf(collection)?.indexed ?? [];
+  if (fields.includes(field)) return;
+  throw new VendoError(
+    "validation",
+    `${JSON.stringify(field)} is not an indexed field of ${JSON.stringify(collection)}`
+    + (fields.length === 0
+      ? ` — that collection declares none, so it cannot be walked by watermark. List it newest-first with a cursor instead.`
+      : ` — it declares ${fields.map((name) => JSON.stringify(name)).join(", ")}.`),
   );
 }

--- a/packages/core/src/engine-over-adapter.ts
+++ b/packages/core/src/engine-over-adapter.ts
@@ -25,7 +25,22 @@ export function engineOverAdapter(store: StoreAdapter): StoreOps["engine"] {
     delete: async (collection, id) => {
       await door(collection).delete(id);
     },
-    list: async (collection, query) => await door(collection).list(query),
+    /** A watermark is REFUSED here rather than dropped. `RecordStore.list`
+     *  takes a `RecordQuery`, which has no watermark in it, so passing the query
+     *  straight through would hand the adapter a bound it cannot see and answer
+     *  with an ordinary newest-first page — the caller's forward walk would
+     *  silently become a re-read of the newest rows, forever. An adapter door is
+     *  not the engine and has no indexed-field declaration to honor; say so. */
+    list: async (collection, query) => {
+      if (query?.watermark !== undefined) {
+        throw new VendoError(
+          "not-implemented",
+          `${collection} is served by a bare StoreAdapter, which cannot honor an engine.list watermark`
+          + " — use a store with its own engine (createStore, or a Store Wire mount).",
+        );
+      }
+      return await door(collection).list(query);
+    },
     claim: async (collection, expected, replacement) => {
       const records = door(collection);
       if (records.claim === undefined) {

--- a/packages/core/src/store-wire.ts
+++ b/packages/core/src/store-wire.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { VendoError, safeErrorMessage, vendoErrorCodeSchema, type VendoErrorCode } from "./errors.js";
+import { isoDateTimeSchema } from "./ids.js";
 import {
   APP_DATA_COLLECTION_PATTERN,
   APP_DATA_OWNER_PATTERN,
@@ -65,6 +66,21 @@ export const STORE_WIRE_PATHS = {
   // that builds its mount from this table never receives an erase at all.
   "lifecycle.erase": "/erase",
   "lifecycle.promote": "/lifecycle/promote",
+  // audit (1)
+  "audit.list": "/audit/list",
+  // secrets (4)
+  "secrets.get": "/secrets/get",
+  "secrets.set": "/secrets/set",
+  "secrets.list": "/secrets/list",
+  "secrets.delete": "/secrets/delete",
+  // footprint (1)
+  footprint: "/footprint",
+  // retention (2) — LAST on purpose, and not because of the family's name.
+  // `ops` on /status is a monotone LEVEL over this list (see below), so the ops
+  // an engine may legitimately not serve yet have to be its tail, or a mount
+  // that stops short of them cannot report an honest number.
+  "retention.quarantine": "/retention/quarantine",
+  "retention.purge": "/retention/purge",
   // status (1)
   status: "/status",
 } as const;
@@ -108,9 +124,29 @@ export const storeWireCollectionDeleteRequestSchema = z.object({
   id: z.string().min(1),
 }).passthrough();
 
+/** The forward-walk bound. `after` is an opaque string, NOT a datetime: it is
+    echoed back verbatim from a previous page, and validating it as a datetime
+    here would quietly re-encode a value whose extra precision is the whole
+    point (see `Watermark` in store.ts). */
+export const storeWireWatermarkSchema = z.object({
+  field: z.string().min(1),
+  after: z.string().min(1),
+}).passthrough();
+
+/** `engine.list`'s query. A watermark pages oldest-first from its bound and a
+    cursor pages newest-first from its own; a body carrying both is asking for
+    two different walks at once and is refused here rather than resolved by a
+    precedence rule nobody could guess. */
+export const engineListQuerySchema = recordQuerySchema.extend({
+  watermark: storeWireWatermarkSchema.optional(),
+}).refine(
+  (query) => query.watermark === undefined || query.cursor === undefined,
+  { message: "engine.list takes a watermark or a cursor, never both — they page in opposite directions" },
+);
+
 export const storeWireCollectionListRequestSchema = z.object({
   collection: z.string().min(1),
-  query: recordQuerySchema.optional(),
+  query: engineListQuerySchema.optional(),
 }).passthrough();
 
 export const storeWireCollectionClaimRequestSchema = z.object({
@@ -289,7 +325,19 @@ export interface StoreWireAppendMessagesResult {
 
     Detect once, cache, and route to the older getThread + putMessage path when
     the mount is behind — never send it blind and read the 501 as a fallback
-    signal (#1251: a failed mutation is not a capability answer). */
+    signal (#1251: a failed mutation is not a capability answer).
+
+    ⚠ AND THIS IS THE LAST CONSTANT OF ITS KIND. Ops 37-44 (audit, secrets,
+    footprint, retention) added no twin, and a future op should not either. A
+    pre-send check earns its keep only when sending blind is unsafe, and that is
+    true of exactly one shape: a MUTATION with a cheaper fallback, where a 501
+    leaves the caller unable to tell "never ran" from "ran and failed". Every one
+    of 37-44 is a new PATH, so an older mount refuses it with the enveloped 501
+    this protocol already answers unknown ops with — loud, specific, and
+    impossible to mistake for data. The one genuinely invisible addition, the
+    watermark bound on `engine.list`, is a FIELD on an existing op that
+    `.passthrough()` would let an old mount ignore in silence; it is detected by
+    the echo on its own answer (`EngineListPage.watermark`), not from here. */
 export const STORE_WIRE_APPEND_MESSAGES_OPS = 36;
 
 export const storeWireTranscriptsRecordAnswerRequestSchema = z.object({
@@ -387,12 +435,86 @@ export const storeWireLifecyclePromoteRequestSchema = z.object({
 }).passthrough();
 
 // ---------------------------------------------------------------------------
+// audit
+// ---------------------------------------------------------------------------
+
+/** The four filters are ANDed and every one is optional, so an empty body is
+    the whole feed, newest first. The enums are spelled here rather than
+    imported from `auditEventSchema` because this is the REQUEST, and a request
+    that names a kind this build has not heard of should be refused by the
+    mount's own validation, not silently widened. */
+export const storeWireAuditListRequestSchema = cursorQuerySchema.extend({
+  kind: z.enum(["tool-call", "approval", "policy-decision", "run", "app-lifecycle", "share", "door-auth", "principal"]).optional(),
+  venue: z.enum(["chat", "app", "automation", "mcp"]).optional(),
+  outcome: z.enum(["ok", "error", "pending-approval", "blocked", "connect-required"]).optional(),
+  decidedBy: z.enum(["grant", "rule", "judge", "default", "confirmEach", "breaker", "denied", "org", "frozen"]).optional(),
+});
+
+// ---------------------------------------------------------------------------
+// secrets
+//
+// The value rides the body in the clear — TLS is the transport's job and the
+// mount encrypts at rest. `secrets.get` is the one read in this protocol that
+// answers with a credential; a mount authenticates it like a mutation.
+// ---------------------------------------------------------------------------
+
+export const storeWireSecretsGetRequestSchema = z.object({
+  name: z.string().min(1),
+}).passthrough();
+
+export const storeWireSecretsSetRequestSchema = z.object({
+  name: z.string().min(1),
+  value: z.string(),
+}).passthrough();
+
+/** No filter and no page: a vault small enough to need one is not a vault. */
+export const storeWireSecretsListRequestSchema = z.object({}).passthrough();
+
+export const storeWireSecretsDeleteRequestSchema = z.object({
+  name: z.string().min(1),
+}).passthrough();
+
+// ---------------------------------------------------------------------------
+// footprint
+// ---------------------------------------------------------------------------
+
+/** No arguments: the answer is the whole store, and a caller that wants one
+    collection reads one entry out of it. */
+export const storeWireFootprintRequestSchema = z.object({}).passthrough();
+
+// ---------------------------------------------------------------------------
+// retention
+// ---------------------------------------------------------------------------
+
+/** Rows older than the cutoff leave the live collection. The cutoff is a real
+    datetime here (unlike a watermark, which is an opaque echo): it is a policy
+    the caller authored, not a value it read back. */
+export const storeWireRetentionQuarantineRequestSchema = z.object({
+  collection: z.string().min(1),
+  olderThan: isoDateTimeSchema,
+}).passthrough();
+
+/** The cutoff is on the QUARANTINE time, not the row's age — this verb destroys
+    rows, and the recovery grace it honors is measured from when they were
+    lifted. */
+export const storeWireRetentionPurgeRequestSchema = z.object({
+  collection: z.string().min(1),
+  quarantinedBefore: isoDateTimeSchema,
+}).passthrough();
+
+// ---------------------------------------------------------------------------
 // status
 // ---------------------------------------------------------------------------
 
 /** GET /status — the discovery handshake. Clients learn the protocol version
     and the op count. The body passes unknown keys through, so a mount that
-    still sends fields this build dropped is read, not refused. */
+    still sends fields this build dropped is read, not refused.
+
+    `ops` is a LEVEL, not an inventory: how far down STORE_WIRE_PATHS' declared
+    order this mount serves. It answers "are you at least as new as X" and
+    nothing finer — there is no way to say "all but one in the middle", which is
+    why the ops an engine may not have yet are declared last. Read it with `>=`
+    against a frozen constant, and read a missing op's absence off its own 501. */
 export interface StoreWireStatus {
   format: typeof VENDO_STORE_WIRE_FORMAT;
   ops: number;

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -1,4 +1,6 @@
 import { z } from "zod";
+import type { AuditEvent } from "./audit.js";
+import type { CollectionKind } from "./engine-collections.js";
 import { isoDateTimeSchema, type IsoDateTime, type Json } from "./ids.js";
 
 const requiredJsonValueSchema = z.unknown().refine(
@@ -80,15 +82,81 @@ export interface BlobStore {
   list(prefix?: string): Promise<string[]>;
 }
 
+// ---------------------------------------------------------------------------
+// IdempotencyLedger — a SERVER-SIDE capability, not a wire op.
+// ---------------------------------------------------------------------------
+
+/** The one key a replayed request is recognised by. `tenant` is separate from
+    `key` because a mount that serves many tenants out of one schema would
+    otherwise let one tenant's key collide with another's — and a mount that
+    gives every tenant its own schema simply passes a constant. */
+export interface IdempotencyScope {
+  tenant: string;
+  op: string;
+  key: string;
+}
+
+/** What a recorded request answered, replayed verbatim to a repeat caller.
+    `status` is the HTTP status the mount sent; `result` its JSON body. */
+export interface IdempotencyRecord {
+  status: number;
+  result: Json;
+}
+
+/**
+ * The replay ledger behind an `Idempotency-Key`: it remembers what a keyed
+ * request answered so the same key answers the same thing instead of applying
+ * the mutation twice.
+ *
+ * SERVER-SIDE ONLY. No client calls this and no wire op exposes it — a client
+ * sends its key in a header (`STORE_WIRE_PATHS`' one mutation header) and the
+ * mount is what consults the ledger.
+ *
+ * CONTRACT: an implementation MUST colocate the ledger with the mutations it
+ * gates — the same database, reached through the same handle. A ledger that
+ * lives somewhere else can commit while its mutation rolls back (or the
+ * reverse), and a replay then confidently returns a result for work that never
+ * happened. This is why `createStore()` hands one out instead of the ledger
+ * being an adapter a host wires up separately.
+ *
+ * The guarantee is REPLAY protection, not mutual exclusion: two concurrent
+ * requests carrying one key can both find the key fresh and both execute. That
+ * is what a check-then-do ledger can promise, and saying so here is cheaper
+ * than a caller discovering it in production.
+ */
+export interface IdempotencyLedger {
+  /**
+   * What this key already answered, or null when it is fresh and the caller
+   * should go do the work.
+   *
+   * `requestHash` is the caller's own digest of the request body. Passing it in
+   * — rather than reading it back out and comparing at the call site — is what
+   * makes the one dangerous case impossible to skip: the SAME key with a
+   * DIFFERENT body is not a replay, it is a client bug, and it throws
+   * `conflict` here rather than quietly returning some other request's result.
+   */
+  check(scope: IdempotencyScope, requestHash: string): Promise<IdempotencyRecord | null>;
+  /** Record what this key answered. First writer wins; a later `record` for a
+      key already held is ignored, never an overwrite — the answer a replay
+      already received must not change under it. */
+  record(scope: IdempotencyScope, requestHash: string, answer: IdempotencyRecord): Promise<void>;
+}
+
 /** 01-core §12 */
 export interface StoreAdapter {
   records(collection: string): RecordStore;
   blobs(namespace: string): BlobStore;
   ensureSchema(): Promise<void>;
+  /** Present when this store can serve `Idempotency-Key` replay for the
+      mutations it also stores — `createStore()` provides one. OPTIONAL for the
+      same reason `RecordStore.atomic` is: an adapter that cannot colocate a
+      ledger says so by omitting it, and a mount that finds it absent must
+      refuse keyed mutations rather than pretend they are deduplicated. */
+  idempotency?: IdempotencyLedger;
 }
 
 // ---------------------------------------------------------------------------
-// StoreOps — the named-operation contract for the 36-op / 8-family store.
+// StoreOps — the named-operation contract for the 44-op / 12-family store.
 // Both the local backend (store/ops.ts) and the cloud client
 // (hosted-store.ts) implement this interface.
 // ---------------------------------------------------------------------------
@@ -120,6 +188,120 @@ export interface AppDataTarget {
   owner: string;
 }
 
+// ---------------------------------------------------------------------------
+// engine.list — the forward walk
+// ---------------------------------------------------------------------------
+
+/** A strict lower bound on an INDEXED field, for the one read `engine.list`'s
+    newest-first page cannot serve: walking FORWARD from where a previous walk
+    stopped. A meter that has already counted runs up to some instant needs
+    everything after it, oldest first, so it can advance its mark as it goes.
+
+    `field` must be one the collection registry declares indexed
+    (`assertIndexedField`) — `vendo_runs.started_at` is the only one today.
+    `after` is EXCLUSIVE, and it is an opaque string echoed back from a previous
+    page, never a timestamp to do arithmetic on: the stored value can carry more
+    precision than a JS `Date` keeps, and a bound that has been round-tripped
+    through one moves BACKWARDS, which re-reads a window that was already
+    counted. */
+export interface Watermark {
+  field: string;
+  after: string;
+}
+
+/** `engine.list`'s query: a {@link RecordQuery}, plus the one bound only the
+    engine can honor. A watermark and a `cursor` are mutually exclusive and a
+    call carrying both is refused — they page in opposite directions (a cursor
+    walks newest-first, a watermark oldest-first), so a call with both has no
+    single answer to give. */
+export interface EngineListQuery extends RecordQuery {
+  watermark?: Watermark;
+}
+
+/** `engine.list`'s page.
+
+    `watermark` is present EXACTLY when a watermark bound was applied, and its
+    value is the bound to send next time — the field's value on the last row of
+    this page, or the requested `after` unchanged when the page was empty.
+
+    That is deliberately doing two jobs at once, and the second one is why it
+    exists. Wire request bodies pass unknown keys through, so a mount older than
+    the bound parses the query, ignores it, and answers with an ordinary
+    newest-first page: a silently WRONG answer, not a refusal. Every other new
+    op is a new PATH, and an old mount answers those with an enveloped 501 that
+    says exactly what is missing — a field on an existing op has no such
+    protection, and this echo is it. A caller that sent a watermark and got no
+    echo back must treat the page as unserved, not as data.
+
+    (The `/status` op count would not do here. It is a whole-mount version level
+    and it can only be trusted to say a mount is BEHIND, never that it is
+    complete; and it is checked before sending, which a read never needs to do —
+    reads are safely retryable, which is why the batch APPEND, a mutation, is
+    the one op that must feature-detect up front instead.) */
+export interface EngineListPage {
+  records: VendoRecord[];
+  cursor?: string;
+  watermark?: string;
+}
+
+// ---------------------------------------------------------------------------
+// audit.list — the typed read over the audit drawer
+// ---------------------------------------------------------------------------
+
+/** Which audit rows to read. Four filters, ANDed, all optional — the ones a
+    reviewer's feed and a decision tally actually narrow on, and no more.
+
+    Narrowing by SUBJECT, app or tool is deliberately NOT here: those are
+    `vendo_audit` ref keys and `engine.list("vendo_audit", { refs })` already
+    serves them. This op exists for the three fields that are not refs
+    (`venue` is a column, `outcome` and `decidedBy` live inside the event) plus
+    `kind`, which every real feed pairs with them.
+
+    Values are the AuditEvent's own field types, so there is no second copy of
+    any of these enums to drift. */
+export interface AuditQuery {
+  kind?: AuditEvent["kind"];
+  venue?: AuditEvent["venue"];
+  outcome?: NonNullable<AuditEvent["outcome"]>;
+  decidedBy?: NonNullable<AuditEvent["decidedBy"]>;
+  cursor?: string;
+  limit?: number;
+}
+
+/** A page of audit rows, newest first, on the SAME keyset cursor
+    `engine.list("vendo_audit")` walks. Typed events rather than records: the
+    audit drawer's rows are `AuditEvent`s, every consumer casts them back to one,
+    and a door that returns the type it stores is a door nobody has to parse. */
+export interface AuditPage {
+  events: AuditEvent[];
+  cursor?: string;
+}
+
+// ---------------------------------------------------------------------------
+// footprint — what the store is holding
+// ---------------------------------------------------------------------------
+
+/** What one collection is holding.
+
+    `bytes` is the size of the collection's ROW CONTENT as the engine measures
+    it — not the size of a table on disk. Indexes, TOAST overhead and free pages
+    are excluded, and they have to be: most collections share one table, so a
+    per-collection relation size does not exist to report. The number is an
+    ESTIMATE that is comparable with itself over time — it grows as the
+    collection grows and never shrinks except when rows leave. Compare
+    footprints; never treat one as an exact byte count, and never mix it with a
+    number that came from the filesystem.
+
+    COLLECTIONS only. Blob namespaces and workspace file content are not
+    collections and are not counted here — a footprint answers "what is in the
+    drawers", and a store whose bytes are mostly uploads has to ask its blob
+    store, which knows. */
+export interface CollectionFootprint {
+  collection: string;
+  kind: CollectionKind;
+  bytes: number;
+}
+
 /** The scope of a destructive erase: exactly ONE of subject or appId.
     A union (not two optionals) so `erase({})` and a both-set target are
     compile errors — an erase can never run without a data scope. */
@@ -127,8 +309,13 @@ export type EraseTarget =
   | { subject: string; appId?: never }
   | { appId: string; subject?: never };
 
-/** The typed contract for all 36 store operations across 8 families.
-    Lean by design — this is the CONTRACT interface, not the implementation. */
+/** The typed contract for all 44 store operations across 12 families.
+    Lean by design — this is the CONTRACT interface, not the implementation.
+
+    Two members are OPTIONAL, and both mean the same thing: an implementation
+    that cannot serve the family says so by OMITTING it, never by accepting the
+    call and doing something else (`transcripts.appendMessages` and `retention`,
+    following `RecordStore.claim`/`atomic`). Everything else is required. */
 export interface StoreOps {
   /** Vendo's OWN engine data — grants, approvals, audit, threads, runs, apps,
       effects, and the automations and guard drawers — reached through seven
@@ -140,7 +327,7 @@ export interface StoreOps {
     get(collection: string, id: string): Promise<VendoRecord | null>;
     put(collection: string, record: RecordInput): Promise<VendoRecord>;
     delete(collection: string, id: string): Promise<void>;
-    list(collection: string, query?: RecordQuery): Promise<{ records: VendoRecord[]; cursor?: string }>;
+    list(collection: string, query?: EngineListQuery): Promise<EngineListPage>;
     claim(collection: string, expected: RecordInput, replacement?: Pick<VendoRecord, "data" | "refs">): Promise<boolean>;
     insertIfAbsent(collection: string, record: RecordInput): Promise<VendoRecord | null>;
     compareAndSwap(collection: string, record: RecordInput, expectedRevision: string): Promise<VendoRecord | null>;
@@ -216,9 +403,58 @@ export interface StoreOps {
         makes a create distinguishable from an overwrite in the trail. */
     history(query?: { cursor?: string; limit?: number; owner?: string; path?: string }): Promise<{ entries: unknown[]; cursor?: string }>;
   };
+  /** The audit drawer's own read. One verb, because reading is all anyone does
+      to it: `vendo_audit` is append-only, and rows leave it only through the
+      erase cascade and the retention window. */
+  audit: {
+    list(query?: AuditQuery): Promise<AuditPage>;
+  };
+  /** The store's secret vault — the values a host's connectors authenticate
+      with, kept where the rest of its data is kept.
+      Values cross the wire in the clear (under TLS) and are encrypted AT REST,
+      server-side: an encryption key never leaves the mount, so no client can
+      lose one, and a BYO store needs nothing beyond
+      `VENDO_STORE_ENCRYPTION_KEY` to hold real credentials.
+      `get` is the only read in the whole contract that answers with a
+      credential — a mount serves it under the same authentication as a
+      mutation, never as an open read. */
+  secrets: {
+    get(name: string): Promise<string | null>;
+    set(name: string, value: string): Promise<void>;
+    list(): Promise<string[]>;
+    delete(name: string): Promise<void>;
+  };
+  /** Aging data out of a collection, in the two moves a recoverable sweep takes:
+      `quarantine` lifts rows past the window OUT of the live collection, and
+      `purge` destroys quarantined rows once the recovery grace has run out.
+      Two verbs and not one because the gap between them IS the feature — a
+      window that turns out to be wrong is recoverable right up until the purge.
+
+      The engine OWNS the quarantine: where the lifted rows go, what that store
+      is called and how it is shaped are the engine's business, and no caller
+      ever names it. `purge` is the only way back out.
+
+      OPTIONAL (`RecordStore.atomic`'s rule): an engine with nowhere to quarantine
+      to says so by omitting the family, rather than by accepting the call and
+      destroying rows a `quarantine` was supposed to keep recoverable. */
+  retention?: {
+    /** Rows whose age field is strictly older than `olderThan` leave the live
+        collection for quarantine. Answers how many moved. Re-runnable: a second
+        call with the same cutoff moves nothing. */
+    quarantine(collection: string, olderThan: IsoDateTime): Promise<{ moved: number }>;
+    /** Quarantined rows lifted before `quarantinedBefore` are destroyed —
+        irrecoverably, which is why the cutoff is on the QUARANTINE time and not
+        on the row's own age. Answers how many were destroyed. */
+    purge(collection: string, quarantinedBefore: IsoDateTime): Promise<{ purged: number }>;
+  };
   lifecycle: {
     erase(target: EraseTarget): Promise<unknown>;
     promote(appId: string, orgId: string): Promise<void>;
   };
+  /** What this store is holding, per collection, with each collection's kind
+      alongside — see {@link CollectionFootprint} for what `bytes` is and is not.
+      Collections holding nothing are omitted, so an empty store answers with an
+      empty list. */
+  footprint(): Promise<CollectionFootprint[]>;
   status(): Promise<StoreWireStatus>;
 }

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -199,11 +199,15 @@ export interface AppDataTarget {
 
     `field` must be one the collection registry declares indexed
     (`assertIndexedField`) — `vendo_runs.started_at` is the only one today.
-    `after` is EXCLUSIVE, and it is an opaque string echoed back from a previous
-    page, never a timestamp to do arithmetic on: the stored value can carry more
-    precision than a JS `Date` keeps, and a bound that has been round-tripped
-    through one moves BACKWARDS, which re-reads a window that was already
-    counted. */
+
+    `after` is EXCLUSIVE and takes either of two forms. A caller's FIRST bound is
+    a plain field VALUE ("everything since 9am"), which means strictly after that
+    instant. Every bound after it is the previous page's echo
+    ({@link EngineListPage}), an opaque token naming the exact row that page
+    ended on: send it back VERBATIM, never parsed, never compared, never a
+    timestamp to do arithmetic on. The stored value can carry more precision than
+    a JS `Date` keeps, and a bound that has been round-tripped through one moves
+    BACKWARDS, which re-reads a window that was already counted. */
 export interface Watermark {
   field: string;
   after: string;
@@ -221,8 +225,19 @@ export interface EngineListQuery extends RecordQuery {
 /** `engine.list`'s page.
 
     `watermark` is present EXACTLY when a watermark bound was applied, and its
-    value is the bound to send next time — the field's value on the last row of
-    this page, or the requested `after` unchanged when the page was empty.
+    value is the bound to send next time — an opaque RESUME TOKEN naming the last
+    row of this page, or the requested `after` unchanged when the page was empty.
+    A walk driven by this echo visits every row EXACTLY ONCE and terminates,
+    INCLUDING rows that share the indexed field's value.
+
+    A token rather than that value, because the value alone cannot say WHERE
+    INSIDE a group of rows sharing it a page stopped, and those groups are
+    routine: `vendo_runs.started_at` is caller-supplied and callers write
+    `new Date().toISOString()`, so a burst of runs shares one millisecond. Asking
+    for "strictly after that instant" then drops whatever was left of the group,
+    silently and permanently — uncounted usage for the meter this walk exists
+    for. Each implementation spells its token its own way; hand it back as
+    {@link Watermark}.`after` unchanged and never parse or compare one.
 
     That is deliberately doing two jobs at once, and the second one is why it
     exists. Wire request bodies pass unknown keys through, so a mount older than

--- a/packages/core/tests/conformance/memory-store-ops.test.ts
+++ b/packages/core/tests/conformance/memory-store-ops.test.ts
@@ -30,14 +30,23 @@ describe("StoreOps conformance kit against the memory reference", () => {
     expect(suite.cases.length).toBeGreaterThanOrEqual(28);
   });
 
+  // A pending case is carried, not run — and it is SKIPPED WITH ITS REASON in
+  // the name, so an op the contract declares and nothing serves yet is a line
+  // in the test output rather than an absence nobody can see.
   for (const conformanceCase of suite.cases) {
-    it(conformanceCase.name, conformanceCase.run);
+    if (conformanceCase.pending === undefined) it(conformanceCase.name, conformanceCase.run);
+    else it.skip(`${conformanceCase.name} [pending: ${conformanceCase.pending}]`, conformanceCase.run);
   }
 
-  it("runConformance reports ok for the memory reference", async () => {
+  it("runConformance reports ok for the memory reference, and names what is pending", async () => {
     const report = await runConformance(suite);
     expect(report.failures).toEqual([]);
     expect(report.ok).toBe(true);
+    // The reference serves no retention family, so the two cases over it must
+    // be reported as pending rather than passed — a green report that counted
+    // them as passes is exactly the blindness the tag exists to remove.
+    expect(report.pending.length).toBe(suite.cases.filter((c) => c.pending !== undefined).length);
+    expect(report.passed + report.pending.length).toBe(suite.cases.length);
   });
 
   it("a deleteThread that leaves harness state behind fails conformance", async () => {

--- a/packages/core/tests/conformance/retention-pending.test.ts
+++ b/packages/core/tests/conformance/retention-pending.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { memoryStoreOps, storeOpsConformance } from "../../src/conformance/index.js";
+import type { ConformanceCase } from "../../src/conformance/index.js";
+import type { IsoDateTime } from "../../src/ids.js";
+import type { StoreOps, VendoRecord } from "../../src/store.js";
+
+/**
+ * The two `retention` cases are PENDING: the contract declares the family and
+ * nothing ships one yet, so every mount carries them skipped with the lane that
+ * owes them named in the output.
+ *
+ * A pending case nobody has ever executed is a paragraph of prose wearing a
+ * test's clothes. It can assert the wrong contract, or nothing at all, and the
+ * day the lane arrives the first thing it debugs is the case rather than the
+ * code. So this file runs both of them against a reference `retention` built
+ * here — proving they PASS against an implementation that honors the contract,
+ * and, one broken rule at a time, that they FAIL against one that does not.
+ *
+ * This is the only place in the suite that executes a pending case. It is a
+ * test OF the cases, not of any shipped implementation: `memoryStoreOps()`
+ * still omits `retention`, and both cases stay skipped everywhere they mount.
+ */
+
+/** The contract's own words, in the smallest thing that can obey them:
+ *  quarantine lifts rows out of the live collection and remembers WHEN it
+ *  lifted them; purge destroys the lifted rows whose lift predates its cutoff.
+ *  Built entirely on the public ops surface — the engine owns its quarantine,
+ *  so even a reference may not reach past the doors to fake one. */
+function withRetention(
+  ops: StoreOps,
+  broken: {
+    countsRowsItDidNotMove?: true;
+    leavesRowsLive?: true;
+    ignoresTheGrace?: true;
+  } = {},
+): StoreOps {
+  const quarantined = new Map<string, Array<{ record: VendoRecord; at: number }>>();
+  return {
+    ...ops,
+    retention: {
+      async quarantine(collection, olderThan) {
+        const cutoff = Date.parse(olderThan);
+        const live = await ops.engine.list(collection);
+        const due = live.records.filter((record) => Date.parse(record.createdAt) < cutoff);
+        const held = quarantined.get(collection) ?? [];
+        for (const record of due) {
+          if (broken.leavesRowsLive !== true) await ops.engine.delete(collection, record.id);
+          held.push({ record, at: Date.now() });
+        }
+        quarantined.set(collection, held);
+        // The honest count is what LEFT the live collection; a sweep that
+        // reports the window's whole population instead is the mistake a cron
+        // makes exactly once, on its second run.
+        return { moved: broken.countsRowsItDidNotMove === true ? live.records.length : due.length };
+      },
+      async purge(collection, quarantinedBefore) {
+        const cutoff = Date.parse(quarantinedBefore);
+        const held = quarantined.get(collection) ?? [];
+        const kept = broken.ignoresTheGrace === true ? [] : held.filter((row) => row.at >= cutoff);
+        quarantined.set(collection, kept);
+        return { purged: held.length - kept.length };
+      },
+    },
+  };
+}
+
+const retentionCases = (make: () => StoreOps): ConformanceCase[] =>
+  storeOpsConformance({ makeOps: async () => ({ ops: make() }) })
+    .cases.filter((conformanceCase) => conformanceCase.pending !== undefined);
+
+describe("the pending retention cases are executable contract", () => {
+  const reference = retentionCases(() => withRetention(memoryStoreOps()));
+
+  it("carries exactly the two retention cases, and carries them tagged", () => {
+    expect(reference).toHaveLength(2);
+    for (const conformanceCase of reference) {
+      expect(conformanceCase.pending).toContain("the retention lane");
+    }
+  });
+
+  for (const conformanceCase of reference) {
+    it(`passes against a retention that honors the contract: ${conformanceCase.name}`, async () => {
+      await conformanceCase.run();
+    });
+  }
+
+  // Each of these breaks ONE rule the cases exist to hold, so a green result
+  // here would mean the case is decorative. The message is asserted too: a case
+  // that fails for an unrelated reason is not the same as a case that caught
+  // the thing it was written for.
+  it("catches a sweep that counts rows it never moved", async () => {
+    const [quarantine] = retentionCases(() => withRetention(memoryStoreOps(), { countsRowsItDidNotMove: true }));
+    await expect(quarantine!.run()).rejects.toThrow(/cutoff older than every row should move nothing/);
+  });
+
+  it("catches a sweep that reports rows moved but leaves them live", async () => {
+    const [quarantine] = retentionCases(() => withRetention(memoryStoreOps(), { leavesRowsLive: true }));
+    await expect(quarantine!.run()).rejects.toThrow(/quarantined rows stayed in the live collection/);
+  });
+
+  it("catches a purge that destroys rows still inside their recovery grace", async () => {
+    const [, purge] = retentionCases(() => withRetention(memoryStoreOps(), { ignoresTheGrace: true }));
+    await expect(purge!.run()).rejects.toThrow(/purge cutoff predating the sweep should destroy nothing/);
+  });
+
+  it("leaves the shipped memory reference without a retention family, so both stay skipped", async () => {
+    expect(memoryStoreOps().retention).toBeUndefined();
+    // And the cases no-op rather than fail on a mount that omits it — which is
+    // what lets every mount carry them without going red.
+    for (const conformanceCase of retentionCases(() => memoryStoreOps())) {
+      await expect(conformanceCase.run()).resolves.toBeUndefined();
+    }
+  });
+});
+
+describe("a quarantine window is a cutoff, not a row rewrite", () => {
+  // The cases can only write rows NOW, so the window has to be expressed by
+  // moving the cutoff. This pins the reading both cases depend on: a row is
+  // due when its OWN timestamp predates the cutoff.
+  it("lifts only the rows whose createdAt predates the cutoff", async () => {
+    const ops = withRetention(memoryStoreOps());
+    const collection = "vendo_parked_call";
+    await ops.engine.put(collection, { id: "old_1", data: {} });
+    const between = new Date(Date.now() + 60_000).toISOString() as IsoDateTime;
+    await ops.engine.put(collection, { id: "new_1", data: {} });
+
+    const swept = await ops.retention!.quarantine(collection, between);
+    expect(swept.moved).toBe(2);
+    expect((await ops.engine.list(collection)).records).toHaveLength(0);
+  });
+});

--- a/packages/core/tests/engine-collections.test.ts
+++ b/packages/core/tests/engine-collections.test.ts
@@ -4,6 +4,8 @@ import {
   ENGINE_ALLOWLIST_VERSION,
   ENGINE_COLLECTIONS,
   assertEngineCollection,
+  assertIndexedField,
+  collectionKind,
   engineAppHistory,
   isEngineCollection,
 } from "../src/engine-collections.js";
@@ -91,5 +93,46 @@ describe("engine allowlist", () => {
   it("refuses app-history names the pattern does not accept", () => {
     expect(codeOf(() => assertEngineCollection("vendo:app-history:"))).toBe("blocked");
     expect(codeOf(() => assertEngineCollection("vendo:app-history:a/b"))).toBe("blocked");
+  });
+});
+
+describe("collection kind", () => {
+  it("calls the corpus knowledge and everything else storage", () => {
+    expect(collectionKind("vendo_knowledge_docs")).toBe("knowledge");
+    expect(collectionKind("vendo_knowledge_chunks")).toBe("knowledge");
+    expect(collectionKind("vendo_audit")).toBe("storage");
+    expect(collectionKind("guard:controls")).toBe("storage");
+  });
+
+  // `knowledge` is what Cloud meters as index cost, so a collection nobody
+  // registered must never fall into it by default — the app-history pattern and
+  // any appData collection a footprint runs across are storage.
+  it("defaults an unregistered collection to storage, never knowledge", () => {
+    expect(collectionKind(engineAppHistory("app_1"))).toBe("storage");
+    expect(collectionKind("app:app_1:notes")).toBe("storage");
+  });
+
+  it("registers exactly two knowledge collections", () => {
+    expect(ENGINE_COLLECTIONS.filter((name) => collectionKind(name) === "knowledge"))
+      .toEqual(["vendo_knowledge_docs", "vendo_knowledge_chunks"]);
+  });
+});
+
+describe("indexed fields", () => {
+  it("accepts the one field a collection declares", () => {
+    expect(() => assertIndexedField("vendo_runs", "started_at")).not.toThrow();
+  });
+
+  // A bound on an unindexed column is a full table scan wearing a filter's
+  // clothes — refused, and the refusal names what IS indexed so the caller is
+  // not left guessing.
+  it("refuses a field the collection does not index, and says what it does", () => {
+    expect(codeOf(() => assertIndexedField("vendo_runs", "finished_at"))).toBe("validation");
+    expect(messageOf(() => assertIndexedField("vendo_runs", "finished_at"))).toContain("started_at");
+  });
+
+  it("refuses every field of a collection that declares none, and says so", () => {
+    expect(codeOf(() => assertIndexedField("vendo_audit", "at"))).toBe("validation");
+    expect(messageOf(() => assertIndexedField("vendo_audit", "at"))).toContain("declares none");
   });
 });

--- a/packages/core/tests/store-wire.test.ts
+++ b/packages/core/tests/store-wire.test.ts
@@ -48,10 +48,12 @@ import {
 } from "../src/index.js";
 
 describe("vendo/store-wire@1", () => {
-  it("exposes the format constant and 36 mount-relative paths", () => {
+  it("exposes the format constant and 44 mount-relative paths", () => {
     expect(VENDO_STORE_WIRE_FORMAT).toBe("vendo/store-wire@1");
-    // 8 families: engine(7) + blobs(4) + appData(8) + transcripts(7) + harness(3) + workspace(4) + lifecycle(2) + status(1) = 36
-    expect(Object.keys(STORE_WIRE_PATHS)).toHaveLength(36);
+    // 12 families: engine(7) + blobs(4) + appData(8) + transcripts(7) + harness(3)
+    // + workspace(4) + lifecycle(2) + audit(1) + secrets(4) + footprint(1)
+    // + retention(2) + status(1) = 44
+    expect(Object.keys(STORE_WIRE_PATHS)).toHaveLength(44);
     expect(STORE_WIRE_PATHS.status).toBe("/status");
     expect(STORE_WIRE_PATHS["engine.get"]).toBe("/engine/get");
     expect(STORE_WIRE_PATHS["engine.compareAndSwap"]).toBe("/engine/compareAndSwap");
@@ -62,6 +64,42 @@ describe("vendo/store-wire@1", () => {
     // manifest records the door that EXISTS — a prettier path here would be a
     // route no client calls and no service answers.
     expect(STORE_WIRE_PATHS["lifecycle.erase"]).toBe("/erase");
+  });
+
+  // `ops` on /status is a LEVEL over this order, so an implementation that
+  // stops short of the newest ops can only report an honest number when those
+  // ops are the tail. retention is the one family nothing serves yet; if a
+  // later op is ever declared after it, the local engine's 42 starts claiming
+  // ops it does not have.
+  it("declares the ops nothing serves yet LAST, so the /status level can stay honest", () => {
+    const ops = Object.keys(STORE_WIRE_PATHS).filter((op) => op !== "status");
+    expect(ops.slice(-2)).toEqual(["retention.quarantine", "retention.purge"]);
+  });
+
+  describe("engine.list's watermark bound", () => {
+    const list = (query: unknown): boolean =>
+      storeWireCollectionListRequestSchema.safeParse({ collection: "vendo_runs", query }).success;
+
+    it("takes a watermark alongside the ordinary query fields", () => {
+      expect(list({ watermark: { field: "started_at", after: "2026-08-14T00:00:00.000Z" }, limit: 50 })).toBe(true);
+    });
+
+    // A cursor walks newest-first from its own position and a watermark walks
+    // oldest-first from its bound. A body carrying both is asking for two
+    // different pages at once, and any precedence rule the mount picked would be
+    // one the caller could not have guessed — so neither is honored.
+    it("refuses a body that carries a watermark AND a cursor", () => {
+      expect(list({ watermark: { field: "started_at", after: "2026-08-14T00:00:00.000Z" }, cursor: "cur_1" })).toBe(false);
+    });
+
+    // The bound is echoed back verbatim from a previous page and can carry more
+    // precision than an ISO-with-milliseconds string keeps. Validating it as a
+    // datetime would re-encode it, and a bound that loses precision moves
+    // BACKWARDS — which re-reads a window a caller had already counted.
+    it("takes the bound as an opaque string, not a datetime", () => {
+      expect(list({ watermark: { field: "started_at", after: "2026-08-14 00:00:00.123456+00" } })).toBe(true);
+      expect(list({ watermark: { field: "started_at", after: "" } })).toBe(false);
+    });
   });
 
   it("every engine door is its own path, and no route is left on the retired generic family", () => {

--- a/packages/store/src/backends.test-util.ts
+++ b/packages/store/src/backends.test-util.ts
@@ -19,6 +19,7 @@ export interface Backend {
 
 const TABLES = [
   "invoices",
+  "vendo_idempotency_ledger",
   "vendo_app_grants",
   "vendo_workspace_history",
   "vendo_workspace_files",

--- a/packages/store/src/erase.ts
+++ b/packages/store/src/erase.ts
@@ -13,7 +13,14 @@ import { invalid } from "./validate.js";
  *  `vendo_effects` used to be in that same never-matched class, because the
  *  frozen v1 shape had no subject column — its `outcome` holds real tool output
  *  and survived an erase forever. The 2026-07-30 contract amendment added
- *  `subject`, so the subject axis now reaches it like any other owned table. */
+ *  `subject`, so the subject axis now reaches it like any other owned table.
+ *
+ *  `vendo_idempotency_ledger` (v8) is in the never-matched class TODAY, and not
+ *  because it holds nothing: `result` is a recorded response body and can carry
+ *  the caller's own data. Its key is (tenant, op, key) and its shape is the
+ *  console's, so no subject or app selector can reach a row — the same gap
+ *  `vendo_effects` sat in until it was given a subject. Listed here so the gap
+ *  is visible in the report rather than forgotten in the schema. */
 export const ERASE_TABLES = [
   "vendo_meta",
   "vendo_apps",
@@ -35,6 +42,7 @@ export const ERASE_TABLES = [
   "vendo_workspace_files",
   "vendo_workspace_history",
   "vendo_app_grants",
+  "vendo_idempotency_ledger",
 ] as const;
 
 export type EraseTable = typeof ERASE_TABLES[number];

--- a/packages/store/src/footprint.ts
+++ b/packages/store/src/footprint.ts
@@ -1,0 +1,47 @@
+import { collectionKind, type CollectionFootprint } from "@vendoai/core";
+// Type-only — erased at compile time, so this module stays engine-free.
+import type { Db } from "./db-postgres.js";
+import { text } from "./helpers/utils.js";
+import { DEDICATED_RECORD_COLLECTIONS, RESERVED_COLLECTIONS } from "./routing.js";
+
+/** Every collection that owns a table of its own name, from the two frozen
+ *  routing constants — never from anything a caller said, because these names
+ *  are interpolated into SQL. */
+const PER_TABLE_COLLECTIONS = [...RESERVED_COLLECTIONS, ...DEDICATED_RECORD_COLLECTIONS];
+
+/** The tables one collection's row content actually lives in. `vendo_threads`
+ *  is two: the transcript moved to `vendo_thread_messages` in v6 (schema.ts), so
+ *  counting only the header row would report the fattest drawer in the store as
+ *  a few hundred bytes per conversation. */
+const tablesOf = (collection: string): readonly string[] =>
+  collection === "vendo_threads" ? ["vendo_threads", "vendo_thread_messages"] : [collection];
+
+/** `pg_column_size(row)` summed per collection — row CONTENT, the unit
+ *  `CollectionFootprint.bytes` promises, and the same unit on both sides so the
+ *  two halves of the answer are comparable with each other. Deliberately NOT
+ *  `pg_total_relation_size`: most collections share `vendo_records`, so a
+ *  per-collection relation size does not exist to report. */
+const PER_TABLE_SQL = PER_TABLE_COLLECTIONS.map((collection) =>
+  `SELECT '${collection}' AS collection, (${tablesOf(collection)
+    .map((table) => `coalesce((SELECT sum(pg_column_size(t.*)) FROM ${table} t), 0)`)
+    .join(" + ")})::bigint AS bytes`).join("\n UNION ALL ");
+
+/** What this store is holding, per collection (01 §12 `footprint`). Two reads:
+ *  the generic table, which groups itself (and so covers every appData
+ *  collection that exists without anyone enumerating them), and the collections
+ *  that own a table. Empty collections are omitted, and the answer is sorted, so
+ *  two footprints of the same store are diffable. */
+export async function collectionFootprints(db: Db): Promise<CollectionFootprint[]> {
+  const generic = await db.query(
+    "SELECT collection, sum(pg_column_size(r.*))::bigint AS bytes FROM vendo_records r GROUP BY collection",
+  );
+  const perTable = await db.query(PER_TABLE_SQL);
+  const measured: CollectionFootprint[] = [];
+  for (const row of [...generic.rows, ...perTable.rows]) {
+    const bytes = Number(row["bytes"]);
+    if (bytes === 0) continue;
+    const collection = text(row["collection"]);
+    measured.push({ collection, kind: collectionKind(collection), bytes });
+  }
+  return measured.sort((a, b) => (a.collection < b.collection ? -1 : 1));
+}

--- a/packages/store/src/hosted-store.test-util.ts
+++ b/packages/store/src/hosted-store.test-util.ts
@@ -126,16 +126,41 @@ async function recordsOp(records: RecordStore, op: string, body: Body, miss: Mis
   }
 }
 
+/** The bound this fake echoes: a resume token naming the row the page ended on,
+ *  value and id together, because rows sharing one `started_at` are routine (it
+ *  is caller-supplied at millisecond precision) and a bound that is only the
+ *  value cannot resume inside such a group — the rest of it is skipped forever.
+ *  Its own encoding, like every implementation's: the token is opaque and never
+ *  crosses into another one. */
+const WATERMARK_TOKEN = "wm1_";
+
+const encodeResume = (value: string, id: string): string =>
+  WATERMARK_TOKEN + Buffer.from(JSON.stringify([value, id]), "utf8").toString("base64url");
+
+const decodeResume = (after: string): { value: string; id: string } | undefined => {
+  if (!after.startsWith(WATERMARK_TOKEN)) return undefined;
+  try {
+    const parsed = JSON.parse(
+      Buffer.from(after.slice(WATERMARK_TOKEN.length), "base64url").toString("utf8"),
+    ) as unknown;
+    if (!Array.isArray(parsed) || typeof parsed[0] !== "string" || typeof parsed[1] !== "string") return undefined;
+    return { value: parsed[0], id: parsed[1] };
+  } catch {
+    return undefined;
+  }
+};
+
 /** `engine.list`'s forward walk: oldest-first from the bound, with the bound to
- *  send next time echoed back — the last row's value, or the caller's own bound
- *  unchanged when the page was empty. The echo is not decoration and this fake
- *  must not skip it: it is the only thing that tells a mount which APPLIED the
- *  bound from one that parsed the query and ignored it, which is the exact
+ *  send next time echoed back — the row this page ended on, or the caller's own
+ *  bound unchanged when the page was empty. The echo is not decoration and this
+ *  fake must not skip it: it is the only thing that tells a mount which APPLIED
+ *  the bound from one that parsed the query and ignored it, which is the exact
  *  answer the client refuses (EngineListPage, core/src/store.ts).
- *  `createdAt` stands in for the indexed field, as the reference engine does —
- *  and for `vendo_runs`, the one collection with an indexed field today, they
- *  are the same value: the reference adapter projects a run's `startedAt` onto
- *  `createdAt`, which is the `started_at` column. The field name still goes through
+ *  `createdAt` IS the indexed field here: for `vendo_runs`, the one collection
+ *  with an indexed field today, the reference adapter projects a run's
+ *  `startedAt` onto `createdAt`, which is the `started_at` column — ties
+ *  included, so a burst of runs collides here exactly as it does in Postgres.
+ *  The field name still goes through
  *  `assertIndexedField`, because a bound on an unindexed field is refused by
  *  the live door rather than served slowly. */
 async function forwardWalk(
@@ -146,10 +171,24 @@ async function forwardWalk(
 ): Promise<{ records: VendoRecord[]; watermark: string }> {
   assertIndexedField(collection, watermark.field);
   const held = await records.list(query.refs === undefined ? {} : { refs: query.refs });
-  // The adapter answers newest-first; a forward walk reads the other way.
-  const forward = held.records.filter((record) => record.createdAt > watermark.after).reverse();
+  // A bare bound is strictly after the instant; a token resumes after the row it
+  // names. The adapter answers newest-first, so a forward walk re-orders — on
+  // the same (value, id) key the bound resumes from, or a page boundary inside
+  // a group sharing one value would step over the rest of it.
+  const resume = decodeResume(watermark.after);
+  const forward = held.records
+    .filter((record) => (resume === undefined
+      ? record.createdAt > watermark.after
+      : record.createdAt > resume.value || (record.createdAt === resume.value && record.id > resume.id)))
+    .sort((a, b) => (a.createdAt === b.createdAt
+      ? (a.id < b.id ? -1 : 1)
+      : (a.createdAt < b.createdAt ? -1 : 1)));
   const page = forward.slice(0, query.limit ?? forward.length);
-  return { records: page, watermark: page.at(-1)?.createdAt ?? watermark.after };
+  const last = page.at(-1);
+  return {
+    records: page,
+    watermark: last === undefined ? watermark.after : encodeResume(last.createdAt, last.id),
+  };
 }
 
 /** The audit drawer's typed read, over the SAME rows `engine.list("vendo_audit")`

--- a/packages/store/src/hosted-store.test-util.ts
+++ b/packages/store/src/hosted-store.test-util.ts
@@ -2,11 +2,17 @@ import {
   STORE_WIRE_PATHS,
   VendoError,
   assertEngineCollection,
+  assertIndexedField,
   canonicalJson,
+  collectionKind,
   type AppDataTarget,
+  type AuditEvent,
   type BlobStore,
+  type CollectionFootprint,
+  type EngineListQuery,
   type RecordStore,
   type VendoRecord,
+  type Watermark,
 } from "@vendoai/core";
 import { memoryStoreAdapter } from "@vendoai/core/conformance";
 
@@ -72,6 +78,7 @@ const routesOf = (family: string): Map<string, string> => new Map(
 
 const ENGINE_ROUTES = routesOf("engine");
 const APP_DATA_ROUTES = routesOf("appData");
+const SECRETS_ROUTES = routesOf("secrets");
 
 /** The ref key the appData family stamps its owner on, and the one key a caller
  *  may never supply — packages/store's APP_DATA_OWNER_REF, mirrored. */
@@ -96,8 +103,11 @@ async function recordsOp(records: RecordStore, op: string, body: Body, miss: Mis
     case "delete":
       await records.delete(body.id as string);
       return json({ ok: true });
-    case "list":
-      return json(await records.list((body.query ?? {}) as never));
+    case "list": {
+      const query = (body.query ?? {}) as EngineListQuery;
+      if (query.watermark === undefined) return json(await records.list(query as never));
+      return json(await forwardWalk(records, body.collection as string, query.watermark, query));
+    }
     case "claim":
       return recordsClaim(records, body);
     case "insertIfAbsent":
@@ -113,6 +123,72 @@ async function recordsOp(records: RecordStore, op: string, body: Body, miss: Mis
       });
     default:
       return miss(`unknown records op: ${op}`);
+  }
+}
+
+/** `engine.list`'s forward walk: oldest-first from the bound, with the bound to
+ *  send next time echoed back — the last row's value, or the caller's own bound
+ *  unchanged when the page was empty. The echo is not decoration and this fake
+ *  must not skip it: it is the only thing that tells a mount which APPLIED the
+ *  bound from one that parsed the query and ignored it, which is the exact
+ *  answer the client refuses (EngineListPage, core/src/store.ts).
+ *  `createdAt` stands in for the indexed field, as the reference engine does —
+ *  and for `vendo_runs`, the one collection with an indexed field today, they
+ *  are the same value: the reference adapter projects a run's `startedAt` onto
+ *  `createdAt`, which is the `started_at` column. The field name still goes through
+ *  `assertIndexedField`, because a bound on an unindexed field is refused by
+ *  the live door rather than served slowly. */
+async function forwardWalk(
+  records: RecordStore,
+  collection: string,
+  watermark: Watermark,
+  query: EngineListQuery,
+): Promise<{ records: VendoRecord[]; watermark: string }> {
+  assertIndexedField(collection, watermark.field);
+  const held = await records.list(query.refs === undefined ? {} : { refs: query.refs });
+  // The adapter answers newest-first; a forward walk reads the other way.
+  const forward = held.records.filter((record) => record.createdAt > watermark.after).reverse();
+  const page = forward.slice(0, query.limit ?? forward.length);
+  return { records: page, watermark: page.at(-1)?.createdAt ?? watermark.after };
+}
+
+/** The audit drawer's typed read, over the SAME rows `engine.list("vendo_audit")`
+ *  walks: the row's data IS the event. The four filters are applied AFTER the
+ *  page here — a licence a fake may take and a real mount may not, since it
+ *  narrows in its own statement — because what a caller can observe through
+ *  this door is which events come back and in what order. */
+async function auditListOp(records: RecordStore, body: Body): Promise<Response> {
+  const page = await records.list({
+    ...(body.cursor === undefined ? {} : { cursor: body.cursor as string }),
+    ...(body.limit === undefined ? {} : { limit: body.limit as number }),
+  });
+  const events = page.records
+    .map((record) => record.data as AuditEvent)
+    .filter((event) => (["kind", "venue", "outcome", "decidedBy"] as const)
+      .every((filter) => body[filter] === undefined || event[filter] === body[filter]));
+  return json({ events, ...(page.cursor === undefined ? {} : { cursor: page.cursor }) });
+}
+
+/** The vault, in plaintext and saying so: the console encrypts at rest with a
+ *  key that never leaves it, so a fake cipher here would prove nothing about
+ *  the real one and would hide that the VALUE is what crosses this wire. */
+function secretsOp(vault: Map<string, string>, op: string, body: Body, miss: Miss): Response {
+  const name = body.name as string;
+  switch (op) {
+    case "get":
+      return json({ value: vault.get(name) ?? null });
+    case "set":
+      vault.set(name, body.value as string);
+      return json({ ok: true });
+    case "list":
+      // Sorted: "the order the Map happened to be written in" is not an answer
+      // two implementations would ever agree on.
+      return json({ names: [...vault.keys()].sort() });
+    case "delete":
+      vault.delete(name);
+      return json({ ok: true });
+    default:
+      return miss(`unknown secrets op: ${op}`);
   }
 }
 
@@ -268,6 +344,33 @@ export function fakeConsole() {
   const adapter = memoryStoreAdapter();
   const requests: RecordedRequest[] = [];
   const eraseCalls: unknown[] = [];
+  const vault = new Map<string, string>();
+  // The drawers this mount has opened. The reference adapter hands out a
+  // RecordStore per name and never lists the names back, so `footprint` measures
+  // the ones that came through these doors — which is every drawer this fake can
+  // possibly hold anything in.
+  const opened = new Set<string>();
+  const records = (collection: string): RecordStore => {
+    opened.add(collection);
+    return adapter.records(collection);
+  };
+
+  /** Serialized row length per drawer — the reference engine's own measure: it
+   *  grows as rows land and shrinks as they leave, which is the whole of what a
+   *  footprint promises. Empty drawers are omitted, so a fresh mount answers an
+   *  empty list. */
+  const footprint = async (): Promise<CollectionFootprint[]> => {
+    const measured: CollectionFootprint[] = [];
+    for (const collection of [...opened].sort()) {
+      const held = await records(collection).list();
+      const bytes = held.records.reduce(
+        (total, row) => total + JSON.stringify({ id: row.id, data: row.data, refs: row.refs }).length,
+        0,
+      );
+      if (bytes > 0) measured.push({ collection, kind: collectionKind(collection), bytes });
+    }
+    return measured;
+  };
 
   const route = async (
     request: Request,
@@ -281,6 +384,7 @@ export function fakeConsole() {
       miss("not the console's store mount");
     }
     const rest = segments.slice(3);
+    const path = `/${rest.join("/")}`;
     const body = (recorded.json ?? {}) as Body;
     const post = request.method === "POST";
 
@@ -302,16 +406,24 @@ export function fakeConsole() {
     // with the allowlist in front. The gate is served here rather than skipped
     // because a fake that answers a collection the live door refuses lets a
     // wrong call pass every test and fail in production.
-    const engineOp = post ? ENGINE_ROUTES.get(`/${rest.join("/")}`) : undefined;
+    const engineOp = post ? ENGINE_ROUTES.get(path) : undefined;
     if (engineOp !== undefined) {
       const collection = body.collection as string;
       assertEngineCollection(collection);
-      return recordsOp(adapter.records(collection), engineOp, body, miss);
+      return recordsOp(records(collection), engineOp, body, miss);
     }
-    const appDataOpName = post ? APP_DATA_ROUTES.get(`/${rest.join("/")}`) : undefined;
+    const appDataOpName = post ? APP_DATA_ROUTES.get(path) : undefined;
     if (appDataOpName !== undefined) {
-      return appDataOp((c) => adapter.records(c), (n) => adapter.blobs(n), appDataOpName, body, miss);
+      return appDataOp(records, (n) => adapter.blobs(n), appDataOpName, body, miss);
     }
+    // The audit drawer's own read, and the vault — both over the same backing
+    // the engine door writes to. `retention.*` is deliberately NOT here: it is
+    // the op no mount serves yet, and an unserved route is exactly what a mount
+    // without it looks like to this client.
+    if (post && path === STORE_WIRE_PATHS["audit.list"]) return auditListOp(records("vendo_audit"), body);
+    const secretsOpName = post ? SECRETS_ROUTES.get(path) : undefined;
+    if (secretsOpName !== undefined) return secretsOp(vault, secretsOpName, body, miss);
+    if (post && path === STORE_WIRE_PATHS.footprint) return json({ collections: await footprint() });
     if (rest[0] === "blobs" && rest.length === 2 && post) {
       return blobsWireOp(adapter.blobs(body.namespace as string), rest[1]!, body, miss);
     }

--- a/packages/store/src/hosted-store.ts
+++ b/packages/store/src/hosted-store.ts
@@ -1,6 +1,8 @@
 import {
+  type AuditEvent,
   type BlobStore,
   cloudStandingError,
+  type CollectionFootprint,
   consoleSender,
   defaultFetch,
   parseStoreWireError,
@@ -76,7 +78,7 @@ export interface HostedStore extends VendoStore {
     bySubject(subject: string): Promise<EraseReport>;
     byApp(appId: string): Promise<EraseReport>;
   };
-  /** The 36-op named-operation surface over the same mount and the same key —
+  /** The 44-op named-operation surface over the same mount and the same key —
    * `vendo/store-wire@1` (see {@link hostedStoreOps}). The StoreAdapter doors
    * above are built ON these ops: engine for Vendo's own collections, appData
    * for an app's own drawers. */
@@ -162,7 +164,7 @@ export function hostedStore(options: HostedStoreOptions): HostedStore {
   };
   const sendJson = postJson(send);
 
-  // The StoreAdapter façade rides the SAME 36 ops as `ops` below — it has no
+  // The StoreAdapter façade rides the SAME 44 ops as `ops` below — it has no
   // doors of its own since the generic records family left the wire. A
   // collection (or blob namespace) either names an app's own drawer, which the
   // appData family serves with the owner stamped on, or it names one of Vendo's
@@ -279,15 +281,15 @@ export function hostedStore(options: HostedStoreOptions): HostedStore {
 }
 
 // ---------------------------------------------------------------------------
-// The 36-op StoreOps client — store design v1, `vendo/store-wire@1`
+// The 44-op StoreOps client — store design v1, `vendo/store-wire@1`
 // ---------------------------------------------------------------------------
 
-/** The 36 named ops — STORE_WIRE_PATHS' keys ARE the op names, and stay the
+/** The 44 named ops — STORE_WIRE_PATHS' keys ARE the op names, and stay the
  * op names even where the console's door sits at a different path. */
 type StoreWireOp = keyof typeof STORE_WIRE_PATHS;
 
 /** Measurement instrument, not a feature: with VENDO_STORE_TRACE set, every
- * call through the store client below — the 35 ops AND the StoreAdapter façade,
+ * call through the store client below — the 44 ops AND the StoreAdapter façade,
  * which rides the same client — emits one greppable stderr line naming the op,
  * its path, the round trip in milliseconds (the body read included, since that
  * is what the caller waits for), the response size in bytes and the outcome.
@@ -353,7 +355,7 @@ const raiseWireError = async (response: Response): Promise<never> => {
 };
 
 /**
- * The Cloud client for the whole 36-op store contract, speaking
+ * The Cloud client for the whole 44-op store contract, speaking
  * `vendo/store-wire@1` over the console's store mount: bearer key, deployment
  * identity and per-request abort budget shared with {@link hostedStore}, the
  * same adapter rule (behavior comes ONLY from the constructor arguments),
@@ -580,7 +582,27 @@ function storeWireClient(
         await mutate("engine.delete", P["engine.delete"], { collection, id });
       },
       async list(collection, query) {
-        return listOf(await post("engine.list", P["engine.list"], { collection, query: query ?? {} }));
+        const payload = await post("engine.list", P["engine.list"], { collection, query: query ?? {} });
+        const watermark = (payload as { watermark?: unknown }).watermark;
+        // The echo is the ONLY evidence the bound was applied. Request bodies
+        // pass unknown keys through, so a mount older than the watermark parses
+        // this query, ignores it, and answers an ordinary newest-first page —
+        // data, not a refusal (EngineListPage, core/src/store.ts). Read as a
+        // forward walk, that page drags the caller's mark BACK onto the newest
+        // rows and re-reads them on every pass, forever. Refuse it here.
+        if (query?.watermark !== undefined && typeof watermark !== "string") {
+          throw new VendoError(
+            "not-implemented",
+            `the "engine.list" watermark bound was sent but the answer echoed no watermark back`
+            + " — this mount predates the bound, so it ignored the query and answered an ordinary"
+            + " newest-first page, which a forward walk would re-read forever."
+            + " Upgrade the mount, or page this collection with a cursor instead.",
+          );
+        }
+        return {
+          ...listOf(payload),
+          ...(typeof watermark === "string" ? { watermark } : {}),
+        };
       },
       async claim(collection, expected, replacement) {
         return claimedOf(await mutate("engine.claim", P["engine.claim"], {
@@ -755,6 +777,70 @@ function storeWireClient(
       },
       async promote(appId, orgId) {
         await mutate("lifecycle.promote", P["lifecycle.promote"], { appId, orgId });
+      },
+    },
+    // The audit drawer's one read, and the only door that answers with the type
+    // it stores: `vendo_audit`'s rows ARE AuditEvents, so handing back records
+    // would put a cast at every call site instead of one here.
+    audit: {
+      async list(query) {
+        const payload = await post("audit.list", P["audit.list"], { ...query });
+        return {
+          events: field<AuditEvent[]>(payload, "events", "invalid audit page", Array.isArray),
+          ...cursorOf(payload),
+        };
+      },
+    },
+    // `get` is the one read in this protocol that answers with a CREDENTIAL. The
+    // value rides the body in the clear (TLS is the transport's job) and the
+    // mount encrypts it at rest with a key that never leaves it — so this client
+    // holds no key and cannot lose one.
+    secrets: {
+      async get(name) {
+        return field<string | null>(
+          await post("secrets.get", P["secrets.get"], { name }),
+          "value",
+          "invalid secret",
+          (value) => value === null || typeof value === "string",
+        );
+      },
+      async set(name, value) {
+        await mutate("secrets.set", P["secrets.set"], { name, value });
+      },
+      async list() {
+        return field<string[]>(
+          await post("secrets.list", P["secrets.list"], {}),
+          "names",
+          "invalid secret list",
+          (value) => Array.isArray(value) && value.every((name) => typeof name === "string"),
+        );
+      },
+      async delete(name) {
+        await mutate("secrets.delete", P["secrets.delete"], { name });
+      },
+    },
+    async footprint() {
+      return field<CollectionFootprint[]>(
+        await post("footprint", P.footprint, {}),
+        "collections",
+        "invalid footprint",
+        Array.isArray,
+      );
+    },
+    // Served here even though the family is OPTIONAL on StoreOps and no mount
+    // answers it yet: this is the protocol's client, not a mount's mirror, and a
+    // path a mount does not have already answers the enveloped 501 that `wire`
+    // turns into a refusal naming the op. A capability check would be a second
+    // answer to a question the wire already answers exactly — and a worse one,
+    // since it can only be as fresh as the client that ships it.
+    retention: {
+      async quarantine(collection, olderThan) {
+        const payload = await mutate("retention.quarantine", P["retention.quarantine"], { collection, olderThan });
+        return { moved: field<number>(payload, "moved", "invalid quarantine", (value) => typeof value === "number") };
+      },
+      async purge(collection, quarantinedBefore) {
+        const payload = await mutate("retention.purge", P["retention.purge"], { collection, quarantinedBefore });
+        return { purged: field<number>(payload, "purged", "invalid purge", (value) => typeof value === "number") };
       },
     },
     async status(): Promise<StoreWireStatus> {

--- a/packages/store/src/idempotency.ts
+++ b/packages/store/src/idempotency.ts
@@ -1,0 +1,43 @@
+import { VendoError, type IdempotencyLedger, type Json } from "@vendoai/core";
+// Type-only — erased at compile time, so this module stays engine-free and can
+// be assembled into the store alongside the routing doors (see store.ts).
+import type { Db } from "./db-postgres.js";
+import { jsonParam, text } from "./helpers/utils.js";
+
+/** 01 §12 — the `Idempotency-Key` replay ledger over `vendo_idempotency_ledger`,
+ *  the table this same database carries (schema.ts v8). Colocated with the
+ *  mutations it gates by construction: it runs on the handle the mutation runs
+ *  on, so the two commit or roll back together. */
+export function createIdempotencyLedger(db: Db): IdempotencyLedger {
+  return {
+    async check(scope, requestHash) {
+      const result = await db.query(
+        `SELECT request_hash, status, result FROM vendo_idempotency_ledger
+         WHERE tenant = $1 AND op = $2 AND key = $3`,
+        [scope.tenant, scope.op, scope.key],
+      );
+      const row = result.rows[0];
+      if (row === undefined) return null;
+      if (text(row["request_hash"]) !== requestHash) {
+        throw new VendoError(
+          "conflict",
+          `idempotency key ${JSON.stringify(scope.key)} on ${scope.op} was already used for a `
+          + "different request body, so there is no recorded answer that belongs to this one — "
+          + "a key stands for ONE request. Mint a fresh key for a new request, and reuse a key "
+          + "only to retry the identical body.",
+        );
+      }
+      return { status: Number(row["status"]), result: row["result"] as Json };
+    },
+    async record(scope, requestHash, answer) {
+      // First writer wins: the answer a replay has already been handed must not
+      // change under it, so a later record for a held key is a no-op.
+      await db.query(
+        `INSERT INTO vendo_idempotency_ledger (tenant, op, key, request_hash, status, result)
+         VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+         ON CONFLICT (tenant, op, key) DO NOTHING`,
+        [scope.tenant, scope.op, scope.key, requestHash, answer.status, jsonParam(answer.result)],
+      );
+    },
+  };
+}

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -11,9 +11,14 @@ export type { Db, Query } from "./db-postgres.js";
 // this store writes to when a redeploy wipes it. The deployment that composed
 // the store is what tells its operator (createVendo's boot block).
 export type { EphemeralDataDir } from "./db-postgres.js";
-// The StoreOps local backend (02-store): the 35-op named-operation contract
+// The StoreOps local backend (02-store): the 42-op named-operation contract
 // served off this store's own Postgres, transactions at verb boundaries.
 export { createStoreOps } from "./ops.js";
+// The `Idempotency-Key` replay ledger (01 §12). `createStore()` already hands
+// one out on the store handle; this is the door for a host assembling its own
+// mount over a Db it owns — the ledger MUST be the one that shares a database
+// with the mutations it gates.
+export { createIdempotencyLedger } from "./idempotency.js";
 // The one composer of appData names and the owner stamp: everything that
 // serves the family (the local backend here, the surfaces above it) spells
 // `app:<appId>:<collection>` and `<owner>/<key>` through these and nowhere else.
@@ -71,7 +76,7 @@ export {
 } from "./workspace.js";
 export { storeFiles, FILES_STORE_MAX_BYTES } from "./files-store.js";
 export { harnessStateStore } from "./harness-state.js";
-// The Cloud store: the same StoreAdapter and the same 35 ops, over the console
+// The Cloud store: the same StoreAdapter and the same ops, over the console
 // wire instead of a local Postgres. It lives HERE so every helper above can be
 // served by it without the caller reaching for the umbrella.
 export { hostedStore, hostedStoreOps, type HostedStore, type HostedStoreOptions } from "./hosted-store.js";

--- a/packages/store/src/ops.ts
+++ b/packages/store/src/ops.ts
@@ -2,6 +2,9 @@ import {
   assertEngineCollection,
   VENDO_STORE_WIRE_FORMAT,
   VendoError,
+  type AuditEvent,
+  type AuditPage,
+  type AuditQuery,
   type FilesAdapter,
   type Json,
   type RecordStore,
@@ -13,11 +16,13 @@ import { backfillAppDataOnDb, reownAppData } from "./backfill-app-data.js";
 import type { Db, Query } from "./db.js";
 import { eraseStore } from "./erase.js";
 import { storeFiles, storeFilesForDb } from "./files-store.js";
+import { collectionFootprints } from "./footprint.js";
 import { harnessStateKey } from "./harness-state.js";
 import { appendThreadMessages, putStateRow, putThreadRow, THREAD_MESSAGES_AGGREGATE, threadFromRow } from "./helpers/rows.js";
-import { iso, jsonParam, pageLimit, text } from "./helpers/utils.js";
+import { cursorMs, decodeCursor, encodeCursor, iso, jsonParam, pageLimit, text } from "./helpers/utils.js";
 import { createRecordStore } from "./records.js";
-import { createReservedRecordStore, threadRecord } from "./routing.js";
+import { createReservedRecordStore, threadRecord, watermarkPage } from "./routing.js";
+import { secretStore, storeSecrets } from "./secrets.js";
 import { dbFor, type VendoStore } from "./store.js";
 import { invalid, parseThreadData, requireJson } from "./validate.js";
 import { workspaceRows, type PreparedWrite } from "./workspace-rows.js";
@@ -97,12 +102,56 @@ const commitEntries = (commit: VendoRecord): WorkspaceEntry[] =>
 const commitTouches = (commit: VendoRecord, path: string): boolean =>
   commitEntries(commit).some((entry) => entry.path === path);
 
+/** `audit.list`'s statement (01 §12 `AuditQuery`). `kind` and `venue` are real
+ *  columns; `outcome` and `decidedBy` are not — they live inside the stored
+ *  event, so they are read out of the jsonb. Every filter is optional and they
+ *  AND together, so an empty query is the whole feed.
+ *
+ *  The ordering and the cursor are the routed `vendo_audit` door's, verbatim
+ *  (cursorMs, ORDER BY the truncated instant then id, over-fetch by one): both
+ *  doors read the same rows, so a cursor minted by one has to keep meaning the
+ *  same place in the other. */
+async function auditPage(db: Db, query: AuditQuery): Promise<AuditPage> {
+  const limit = pageLimit(query.limit);
+  const params: unknown[] = [];
+  const clauses: string[] = [];
+  const add = (sql: string, value: unknown): void => {
+    params.push(value);
+    clauses.push(sql.replace("?", `$${params.length}`));
+  };
+  if (query.kind !== undefined) add("kind = ?", query.kind);
+  if (query.venue !== undefined) add("venue = ?", query.venue);
+  if (query.outcome !== undefined) add("event->>'outcome' = ?", query.outcome);
+  if (query.decidedBy !== undefined) add("event->>'decidedBy' = ?", query.decidedBy);
+  if (query.cursor !== undefined) {
+    const cursor = decodeCursor(query.cursor);
+    params.push(cursor.c, cursor.i);
+    clauses.push(`(${cursorMs("at")}, id) < (${cursorMs(`$${params.length - 1}::timestamptz`)}, $${params.length})`);
+  }
+  params.push(limit + 1);
+  const result = await db.query(
+    `SELECT id, at, event FROM vendo_audit${clauses.length ? ` WHERE ${clauses.join(" AND ")}` : ""}
+     ORDER BY ${cursorMs("at")} DESC, id DESC LIMIT $${params.length}`,
+    params,
+  );
+  const page = result.rows.slice(0, limit);
+  const last = page.at(-1);
+  return {
+    // The typed events, not records: the drawer stores AuditEvents and every
+    // consumer casts a record's data straight back to one.
+    events: page.map((row) => row["event"] as AuditEvent),
+    ...(result.rows.length > limit && last
+      ? { cursor: encodeCursor(iso(last["at"]), text(last["id"])) }
+      : {}),
+  };
+}
+
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
 /**
  * 02-store — the LOCAL backend of the StoreOps named-operation contract
- * (core/store.ts): the 36 ops served straight off this store's own Postgres,
+ * (core/store.ts): the 42 ops served straight off this store's own Postgres,
  * through the EXISTING helpers — routing doors, thread rows, workspace rows, the
  * erase cascade. Logic unchanged; what this layer adds is the atomic scope:
  * every multi-statement verb runs inside ONE
@@ -134,6 +183,12 @@ export function createStoreOps(
 
   const recordsDoor = (d: Db, collection: string): RecordStore =>
     createReservedRecordStore(d, collection) ?? createRecordStore(d, collection);
+
+  /** The secrets family IS the existing vault (secrets.ts): at-rest encryption,
+   *  the dev-mode plaintext envelope and the fail-closed refusal without a key
+   *  are all its, and nothing about them is re-decided here. */
+  const secretReader = storeSecrets(store);
+  const secretWriter = secretStore(store);
 
   /** commit id → the revision that commit superseded at `path`. Every write a
    *  commit lands stamps the commit id as its intent, so the workspace history
@@ -224,9 +279,14 @@ export function createStoreOps(
         assertEngineCollection(collection);
         await db.transaction((q) => recordsDoor(txDb(q), collection).delete(id));
       },
-      async list(collection, query) {
+      async list(collection, query = {}) {
         assertEngineCollection(collection);
-        return await recordsDoor(db, collection).list(query);
+        const { watermark } = query;
+        // No watermark, no change: the newest-first door as it always was. With
+        // one, the walk goes the other way and both of its gates (indexed field,
+        // no cursor alongside) live inside watermarkPage.
+        if (watermark === undefined) return await recordsDoor(db, collection).list(query);
+        return await watermarkPage(db, collection, { ...query, watermark });
       },
       async claim(collection, expected, replacement) {
         assertEngineCollection(collection);
@@ -652,6 +712,47 @@ export function createStoreOps(
     },
 
     // -----------------------------------------------------------------------
+    // audit — one verb, because reading is all anyone does to an append-only
+    // drawer. The filters that ARE refs (subject, app, tool) are already served
+    // by engine.list("vendo_audit", { refs }); this door exists for the ones
+    // that are not.
+    // -----------------------------------------------------------------------
+    audit: {
+      async list(query = {}) {
+        return await auditPage(db, query);
+      },
+    },
+
+    // -----------------------------------------------------------------------
+    // secrets — the vault door (secrets.ts) as-is. The one seam this layer
+    // owns: the provider answers `undefined` for a name it does not hold, and
+    // the op's contract is `null`.
+    // -----------------------------------------------------------------------
+    secrets: {
+      async get(name) {
+        return (await secretReader.get(name)) ?? null;
+      },
+      async set(name, value) {
+        await secretWriter.set(name, value);
+      },
+      async list() {
+        return await secretWriter.list();
+      },
+      async delete(name) {
+        await secretWriter.delete(name);
+      },
+    },
+
+    // -----------------------------------------------------------------------
+    // retention is deliberately ABSENT (01 §12: the family is optional). This
+    // engine has nowhere to quarantine rows TO, and the contract's own rule is
+    // that an engine says so by omitting the family rather than by accepting
+    // the call and destroying rows a quarantine was supposed to keep
+    // recoverable. OSS retention is still host SQL on the host's own cron —
+    // the table map is public precisely so that works (tests/retention.test.ts).
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
     // lifecycle
     // -----------------------------------------------------------------------
     lifecycle: {
@@ -717,8 +818,17 @@ export function createStoreOps(
       },
     },
 
+    async footprint() {
+      return await collectionFootprints(db);
+    },
+
     async status() {
-      return { format: VENDO_STORE_WIRE_FORMAT, ops: 36 };
+      // 42 of STORE_WIRE_PATHS' 44: `ops` is a LEVEL over that list's declared
+      // order, and the two this engine does not serve — retention.quarantine and
+      // retention.purge — are declared last for exactly this reason, so the
+      // level stops honestly at footprint instead of claiming a family that is
+      // absent from the object above.
+      return { format: VENDO_STORE_WIRE_FORMAT, ops: 42 };
     },
   };
 }

--- a/packages/store/src/postgres.ts
+++ b/packages/store/src/postgres.ts
@@ -34,6 +34,7 @@ export function createStore(config: PostgresStoreConfig): VendoStore {
 // The rest of the store surface is engine-agnostic — the same modules the
 // main entry exports (keep this list in lockstep with index.ts).
 export { createStoreOps } from "./ops.js";
+export { createIdempotencyLedger } from "./idempotency.js";
 export { maybeDbFor } from "./store.js";
 export { createStoreForDb } from "./store.js";
 export type { Db, Query } from "./db-postgres.js";

--- a/packages/store/src/routing.ts
+++ b/packages/store/src/routing.ts
@@ -1,14 +1,18 @@
 import {
+  assertIndexedField,
   TRIGGER_KIND_REF_KEYS,
   triggerKindRefs,
   VendoError,
   type AtomicRecordStore,
   type AuditEvent,
+  type EngineListPage,
+  type EngineListQuery,
   type Json,
   type PermissionGrant,
   type RecordQuery,
   type RecordStore,
   type VendoRecord,
+  type Watermark,
 } from "@vendoai/core";
 import type { Db } from "./db.js";
 import { createRecordStore, requireRevision, type DedicatedRecordTable } from "./records.js";
@@ -661,4 +665,60 @@ export function createReservedRecordStore(
   }
   if (!(RESERVED_COLLECTIONS as readonly string[]).includes(collection)) return undefined;
   return createTableRecordStore(db, configFor(db, collection as ReservedCollection));
+}
+
+/** The alias the walk's own bound comes back under. Never a table's column: the
+ *  page projects `page.*` and adds this beside it, and `fromDb` reads only the
+ *  columns it names, so the extra key rides along unread. */
+const WATERMARK_ECHO = "vendo_watermark_echo";
+
+/**
+ * `engine.list`'s FORWARD walk (01 §12 `Watermark`): oldest-first from a strict
+ * lower bound on an indexed field, for the meter that has to resume where its
+ * last pass stopped. The ordinary door pages newest-first and cannot express it.
+ *
+ * The gates live HERE, not at the call site, so no direct caller can bypass
+ * them, and `configFor`'s `select`/`fromDb` are what make a walked record
+ * indistinguishable from a listed one.
+ *
+ * PRECISION IS THE WHOLE POINT. The bound is compared at the column's FULL
+ * precision (never `cursorMs`, which truncates to milliseconds) and echoed back
+ * as Postgres' own text rendering, so it round-trips through `$1::timestamptz`
+ * unchanged. Do not route the echo through a JS `Date`: a microsecond timestamp
+ * truncated to ms moves the bound BACKWARDS, and the console lost a window of
+ * runs to exactly that — re-read and double-counted. `Watermark.after` is
+ * contractually opaque precisely so this can stay a database-native value.
+ */
+export async function watermarkPage(
+  db: Db,
+  collection: string,
+  query: EngineListQuery & { watermark: Watermark },
+): Promise<EngineListPage> {
+  const { field, after } = query.watermark;
+  // Refuses any field the registry does not declare indexed — which today is
+  // every field of every collection but `vendo_runs.started_at`. That is also
+  // what makes the reserved-table cast below honest: `indexed` is declared only
+  // on reserved collections, and engine-allowlist.test.ts holds it that way.
+  assertIndexedField(collection, field);
+  if (query.cursor !== undefined) {
+    throw new VendoError(
+      "validation",
+      "engine.list takes a watermark or a cursor, never both — they page in opposite directions",
+    );
+  }
+  const config = configFor(db, collection as ReservedCollection);
+  const result = await db.query(
+    `SELECT page.*, to_json(page.${field})#>>'{}' AS ${WATERMARK_ECHO} FROM (
+       ${config.select} WHERE ${field} > $1::timestamptz
+       ORDER BY ${field} ASC, id ASC LIMIT $2
+     ) page`,
+    [after, pageLimit(query.limit)],
+  );
+  const last = result.rows.at(-1);
+  return {
+    records: result.rows.map(config.fromDb),
+    // Present exactly because a bound was applied — the caller reads its absence
+    // as "this mount ignored my watermark", so it is never conditional on rows.
+    watermark: last === undefined ? after : text(last[WATERMARK_ECHO]),
+  };
 }

--- a/packages/store/src/routing.ts
+++ b/packages/store/src/routing.ts
@@ -672,6 +672,37 @@ export function createReservedRecordStore(
  *  columns it names, so the extra key rides along unread. */
 const WATERMARK_ECHO = "vendo_watermark_echo";
 
+/** The echoed bound is a RESUME TOKEN naming the last row of the page — the
+ *  indexed field's value AND the row's id — never the value on its own. The
+ *  value cannot say where inside a group of rows sharing it a page stopped, and
+ *  `started_at` is CALLER-SUPPLIED (`parseRunData`) from
+ *  `new Date().toISOString()`, so a burst of runs shares one millisecond
+ *  routinely: a bound of "strictly after that instant" would drop the rest of
+ *  that group, silently and forever, and a meter reconciling counted runs would
+ *  never bill it.
+ *
+ *  Prefixed so it can never be read as a caller-authored value: a FIRST bound is
+ *  a plain field value ("everything since 9am"), and anything that does not
+ *  decode as a token is treated as one. The encoding is this backend's own — the
+ *  token is contractually opaque and only ever comes back to the door that
+ *  minted it, so there is nothing here to standardise. */
+const WATERMARK_TOKEN = "wm1_";
+
+const encodeResume = (value: string, id: string): string =>
+  WATERMARK_TOKEN + Buffer.from(JSON.stringify([value, id]), "utf8").toString("base64url");
+
+const decodeResume = (after: string): { value: string; id: string } | undefined => {
+  if (!after.startsWith(WATERMARK_TOKEN)) return undefined;
+  try {
+    const decoded = Buffer.from(after.slice(WATERMARK_TOKEN.length), "base64url").toString("utf8");
+    const parsed = JSON.parse(decoded) as unknown;
+    if (!Array.isArray(parsed) || typeof parsed[0] !== "string" || typeof parsed[1] !== "string") return undefined;
+    return { value: parsed[0], id: parsed[1] };
+  } catch {
+    return undefined;
+  }
+};
+
 /**
  * `engine.list`'s FORWARD walk (01 §12 `Watermark`): oldest-first from a strict
  * lower bound on an indexed field, for the meter that has to resume where its
@@ -682,12 +713,13 @@ const WATERMARK_ECHO = "vendo_watermark_echo";
  * indistinguishable from a listed one.
  *
  * PRECISION IS THE WHOLE POINT. The bound is compared at the column's FULL
- * precision (never `cursorMs`, which truncates to milliseconds) and echoed back
- * as Postgres' own text rendering, so it round-trips through `$1::timestamptz`
- * unchanged. Do not route the echo through a JS `Date`: a microsecond timestamp
- * truncated to ms moves the bound BACKWARDS, and the console lost a window of
- * runs to exactly that — re-read and double-counted. `Watermark.after` is
- * contractually opaque precisely so this can stay a database-native value.
+ * precision (never `cursorMs`, which truncates to milliseconds) and the value
+ * inside the echoed token is Postgres' own text rendering, so it round-trips
+ * through `$1::timestamptz` unchanged. Do not route it through a JS `Date`: a
+ * microsecond timestamp truncated to ms moves the bound BACKWARDS, and the
+ * console lost a window of runs to exactly that — re-read and double-counted.
+ * `Watermark.after` is contractually opaque precisely so this can stay a
+ * database-native value.
  */
 export async function watermarkPage(
   db: Db,
@@ -707,18 +739,26 @@ export async function watermarkPage(
     );
   }
   const config = configFor(db, collection as ReservedCollection);
+  // A bare bound keeps its strictly-after-the-instant meaning; a token resumes
+  // exactly after the row it names, comparing the PAIR the page is already
+  // ordered by — which is the (field, id) prefix the index serves, so the
+  // tiebreaker costs no scan.
+  const resume = decodeResume(after);
+  const bound = resume === undefined
+    ? { where: `${field} > $1::timestamptz`, params: [after] }
+    : { where: `(${field}, id) > ($1::timestamptz, $2)`, params: [resume.value, resume.id] };
   const result = await db.query(
     `SELECT page.*, to_json(page.${field})#>>'{}' AS ${WATERMARK_ECHO} FROM (
-       ${config.select} WHERE ${field} > $1::timestamptz
-       ORDER BY ${field} ASC, id ASC LIMIT $2
+       ${config.select} WHERE ${bound.where}
+       ORDER BY ${field} ASC, id ASC LIMIT $${bound.params.length + 1}
      ) page`,
-    [after, pageLimit(query.limit)],
+    [...bound.params, pageLimit(query.limit)],
   );
   const last = result.rows.at(-1);
   return {
     records: result.rows.map(config.fromDb),
     // Present exactly because a bound was applied — the caller reads its absence
     // as "this mount ignored my watermark", so it is never conditional on rows.
-    watermark: last === undefined ? after : text(last[WATERMARK_ECHO]),
+    watermark: last === undefined ? after : encodeResume(text(last[WATERMARK_ECHO]), text(last["id"])),
   };
 }

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -41,8 +41,16 @@ import type { Db } from "./db-postgres.js";
     v7 (build contract §9.2, wave 3) adds `vendo_app_grants`: app → principal →
     level, the ONLY multi-party rows Vendo stores. Memberships are asserted per
     request by the host's own identity system and are never persisted (§9.1),
-    so this one table is the whole sharing model. Same load-bearing bump. */
-export const SCHEMA_VERSION = 7;
+    so this one table is the whole sharing model. Same load-bearing bump.
+
+    v8 adds `vendo_idempotency_ledger` (01 §12 `IdempotencyLedger`): what a keyed
+    request already answered, so a replayed `Idempotency-Key` gives that answer
+    back instead of applying the mutation a second time. It is a table in THIS
+    database rather than a store of its own because the ledger must commit with
+    the mutation it gates — one that lives elsewhere can commit while its
+    mutation rolls back, and the replay then confidently returns a result for
+    work that never happened. Same load-bearing bump. */
+export const SCHEMA_VERSION = 8;
 
 /** 02-store §2 */
 export const DDL = [
@@ -192,6 +200,18 @@ export const DDL = [
   // grant table on the hot list path — the same order-of-magnitude regression
   // the perf gate exists to catch.
   "CREATE INDEX IF NOT EXISTS vendo_app_grants_principal_idx ON vendo_app_grants (principal)",
+  // v8 (01 §12): the `Idempotency-Key` replay ledger, in the shape the Vendo
+  // Cloud console already runs. `status` + `result` are the answer a repeat
+  // caller is handed back verbatim; `request_hash` is what separates a replay
+  // from the same key carrying a DIFFERENT body, which is a client bug and not a
+  // replay at all. The PK is the whole scope, `tenant` first, so a mount serving
+  // many tenants out of one schema cannot let one tenant's key answer another's.
+  `CREATE TABLE IF NOT EXISTS vendo_idempotency_ledger (
+    tenant text NOT NULL, op text NOT NULL, key text NOT NULL,
+    request_hash text NOT NULL, status int NOT NULL, result jsonb NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (tenant, op, key)
+  )`,
 ] as const;
 
 // Additive columns stay compatible with same-version development databases (02 §2

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -6,6 +6,7 @@ import { validateEncryptionKey } from "#store/crypto";
 // ./create-store.ts (main entry, PGlite dev default via #store/db) and
 // ./postgres.ts (pg only), so no engine module may be imported here.
 import type { Db, StoreConfig } from "./db-postgres.js";
+import { createIdempotencyLedger } from "./idempotency.js";
 import { createRecordStore } from "./records.js";
 import { createReservedRecordStore } from "./routing.js";
 import { ensureSchema as migrateSchema } from "./schema.js";
@@ -73,6 +74,10 @@ export function createStoreForDb(
     blobs(namespace: string): BlobStore {
       return createBlobStore(db, namespace);
     },
+    // The ledger rides the SAME handle as the mutations it gates (01 §12): that
+    // colocation is the contract, and it is why `createStore()` hands one out
+    // instead of leaving it to a host to wire up somewhere else.
+    idempotency: createIdempotencyLedger(db),
     async ensureSchema() {
       await migrateSchema(db);
     },

--- a/packages/store/tests/engine-allowlist.test.ts
+++ b/packages/store/tests/engine-allowlist.test.ts
@@ -1,4 +1,9 @@
-import { ENGINE_COLLECTIONS, isEngineCollection } from "@vendoai/core";
+import {
+  ENGINE_COLLECTION_REGISTRY,
+  ENGINE_COLLECTIONS,
+  isEngineCollection,
+  type EngineCollectionSpec,
+} from "@vendoai/core";
 import { describe, expect, it } from "vitest";
 import { DEDICATED_RECORD_COLLECTIONS, RESERVED_COLLECTIONS } from "../src/index.js";
 
@@ -19,6 +24,19 @@ describe("engine allowlist mirrors the store's routing constants", () => {
   it.each(DEDICATED_RECORD_COLLECTIONS)("dedicated %s is an engine collection", (collection) => {
     expect(allowed.has(collection)).toBe(true);
     expect(isEngineCollection(collection)).toBe(true);
+  });
+
+  // A watermark walk reaches its rows through `configFor` (routing.ts
+  // watermarkPage), which knows only the RESERVED tables — so a collection that
+  // declared an indexed field WITHOUT owning one of those doors would pass
+  // `assertIndexedField` and then find nothing to read. This is what says so on
+  // the day a second indexed field is declared.
+  it("declares indexed fields only on collections that own a reserved door", () => {
+    const registry = ENGINE_COLLECTION_REGISTRY as Record<string, EngineCollectionSpec>;
+    for (const [collection, spec] of Object.entries(registry)) {
+      if (spec.indexed === undefined) continue;
+      expect((RESERVED_COLLECTIONS as readonly string[]).includes(collection), collection).toBe(true);
+    }
   });
 
   // vendo_secrets is deliberately absent: it has zero .records() call sites and

--- a/packages/store/tests/erase.conformance.test.ts
+++ b/packages/store/tests/erase.conformance.test.ts
@@ -135,6 +135,9 @@ for (const backend of backends()) {
         vendo_knowledge_docs: 1,
         vendo_knowledge_chunks: 1,
         vendo_app_grants: 0, // ...and holds no app-access grant (§9.2)
+        // No selector can reach the idempotency ledger either: its key is
+        // (tenant, op, key) and it carries no subject (see ERASE_TABLES).
+        vendo_idempotency_ledger: 0,
         vendo_workspace_files: 0, // this subject wrote no workspace files
         vendo_workspace_history: 0,
         workspace_content_objects: 0, // ...so no workspace content was deleted either

--- a/packages/store/tests/hosted-store.test.ts
+++ b/packages/store/tests/hosted-store.test.ts
@@ -15,6 +15,7 @@ import {
   storeWireAppDataListRequestSchema,
   storeWireAppDataPutFileRequestSchema,
   storeWireAppDataPutRequestSchema,
+  storeWireAuditListRequestSchema,
   storeWireBlobsDeleteRequestSchema,
   storeWireBlobsGetRequestSchema,
   storeWireBlobsListRequestSchema,
@@ -26,7 +27,14 @@ import {
   storeWireCollectionInsertIfAbsentRequestSchema,
   storeWireCollectionListRequestSchema,
   storeWireCollectionPutRequestSchema,
+  storeWireFootprintRequestSchema,
   storeWireLifecycleEraseRequestSchema,
+  storeWireRetentionPurgeRequestSchema,
+  storeWireRetentionQuarantineRequestSchema,
+  storeWireSecretsDeleteRequestSchema,
+  storeWireSecretsGetRequestSchema,
+  storeWireSecretsListRequestSchema,
+  storeWireSecretsSetRequestSchema,
   type StoreAdapter,
 } from "@vendoai/core";
 import { storeAdapterConformance } from "@vendoai/core/conformance";
@@ -608,7 +616,7 @@ describe("demo-host journey through the store seam", () => {
 });
 
 // ---------------------------------------------------------------------------
-// hostedStoreOps — the 35-op client over `vendo/store-wire@1`.
+// hostedStoreOps — the 44-op client over `vendo/store-wire@1`.
 //
 // Unit tests over an injected fake fetch: they pin the route, the request body
 // and the response decoding for every op — engine, appData and blobs against the
@@ -637,7 +645,12 @@ const wireRecord = {
  * at their STORE_WIRE_PATHS path too. A path written out here instead would let
  * the client and the manifest disagree forever, which is exactly how
  * `lifecycle.erase` came to declare a route no mount has ever served. `keyed`
- * marks the mutations that carry an Idempotency-Key. */
+ * marks the mutations that carry an Idempotency-Key.
+ *
+ * 43 of STORE_WIRE_PATHS' 44: `transcripts.appendMessages` is the one op a
+ * client feature-detects before sending (STORE_WIRE_APPEND_MESSAGES_OPS), so it
+ * is driven where that detection is — thread-messages.batch.test.ts — rather
+ * than blind through this walker. */
 const DOORS: Record<string, { method: string; path: string; keyed?: true }> = {
   "engine.get": { method: "POST", path: P["engine.get"] },
   "engine.put": { method: "POST", path: P["engine.put"], keyed: true },
@@ -673,6 +686,17 @@ const DOORS: Record<string, { method: string; path: string; keyed?: true }> = {
   "workspace.history": { method: "POST", path: P["workspace.history"] },
   "lifecycle.erase": { method: "POST", path: P["lifecycle.erase"], keyed: true },
   "lifecycle.promote": { method: "POST", path: P["lifecycle.promote"], keyed: true },
+  "audit.list": { method: "POST", path: P["audit.list"] },
+  // `secrets.get` is the one READ in this protocol that answers with a
+  // credential — a mount authenticates it like a mutation, but it carries no
+  // Idempotency-Key, because reading a value twice is reading it twice.
+  "secrets.get": { method: "POST", path: P["secrets.get"] },
+  "secrets.set": { method: "POST", path: P["secrets.set"], keyed: true },
+  "secrets.list": { method: "POST", path: P["secrets.list"] },
+  "secrets.delete": { method: "POST", path: P["secrets.delete"], keyed: true },
+  footprint: { method: "POST", path: P.footprint },
+  "retention.quarantine": { method: "POST", path: P["retention.quarantine"], keyed: true },
+  "retention.purge": { method: "POST", path: P["retention.purge"], keyed: true },
   status: { method: "GET", path: P.status },
 };
 
@@ -743,6 +767,14 @@ const ALL_BODIES: Record<string, unknown> = {
   [door("workspace.history")]: { entries: [{ commitId: "wsc_1" }] },
   [door("lifecycle.erase")]: { report: { vendo_apps: 1 } },
   [door("lifecycle.promote")]: { ok: true },
+  [door("audit.list")]: { events: [{ id: "aud_1", kind: "tool-call" }], cursor: "cur_audit" },
+  [door("secrets.get")]: { value: "shhh" },
+  [door("secrets.set")]: { ok: true },
+  [door("secrets.list")]: { names: ["stripe_key"] },
+  [door("secrets.delete")]: { ok: true },
+  [door("footprint")]: { collections: [{ collection: "vendo_runs", kind: "storage", bytes: 4096 }] },
+  [door("retention.quarantine")]: { moved: 3 },
+  [door("retention.purge")]: { purged: 2 },
   [door("status")]: { format: "vendo/store-wire@1", ops: 35 },
 };
 
@@ -789,27 +821,38 @@ const driveEveryOp = async (ops: ReturnType<typeof wireFake>["ops"]): Promise<vo
   await ops.workspace.history();
   await ops.lifecycle.erase({ subject: "sub_1" });
   await ops.lifecycle.promote("app_1", "org_1");
+  await ops.audit.list();
+  await ops.secrets.get("stripe_key");
+  await ops.secrets.set("stripe_key", "sk_live_1");
+  await ops.secrets.list();
+  await ops.secrets.delete("stripe_key");
+  await ops.footprint();
+  // The client IMPLEMENTS retention even though the family is optional on the
+  // contract: it is the protocol's client, and a mount without these paths
+  // answers the enveloped 501 the client turns into a named refusal.
+  await ops.retention!.quarantine("vendo_runs", "2026-01-01T00:00:00.000Z");
+  await ops.retention!.purge("vendo_runs", "2026-01-01T00:00:00.000Z");
   await ops.status();
 };
 
-describe("hostedStoreOps — the 35-op wire client", () => {
-  it("routes all 35 ops to the console's real door, with a key on exactly the mutations", async () => {
+describe("hostedStoreOps — the 44-op wire client", () => {
+  it("routes 43 of the 44 ops to the console's real door, with a key on exactly the mutations", async () => {
     const { calls, ops } = wireFake(ALL_BODIES);
     await driveEveryOp(ops);
 
     const expected = Object.values(DOORS);
-    expect(calls).toHaveLength(35);
+    expect(calls).toHaveLength(43);
     expect(calls.map((call) => `${call.method} ${call.path}`))
       .toEqual(expected.map((route) => `${route.method} ${route.path}`));
     expect(calls.map((call) => call.idempotencyKey === null ? "read" : "keyed"))
       .toEqual(expected.map((route) => route.keyed === true ? "keyed" : "read"));
-    // 20 mutations, 15 reads — and the /status handshake is the one GET with
+    // 24 mutations, 19 reads — and the /status handshake is the one GET with
     // no body at all.
-    expect(expected.filter((route) => route.keyed === true)).toHaveLength(20);
+    expect(expected.filter((route) => route.keyed === true)).toHaveLength(24);
     expect(calls.at(-1)).toMatchObject({ path: P.status, method: "GET", body: undefined });
     // Distinct keys across distinct operations (one per logical mutation).
     const keys = calls.map((call) => call.idempotencyKey).filter((key) => key !== null);
-    expect(new Set(keys).size).toBe(20);
+    expect(new Set(keys).size).toBe(24);
   });
 
   it("blobs: JSON POST on the wire door, bytes base64 on the body", async () => {
@@ -1030,6 +1073,119 @@ describe("hostedStoreOps — the 35-op wire client", () => {
     expect(calls[2]).toMatchObject({ path: P["lifecycle.promote"], body: { appId: "app_1", orgId: "org_1" } });
   });
 
+  it("audit, secrets, footprint and retention: bodies flat on the contract, answers read off their own field", async () => {
+    const { calls, ops } = wireFake(ALL_BODIES);
+
+    // The four audit filters ride the body FLAT, beside the page keys.
+    expect(await ops.audit.list({ kind: "tool-call", outcome: "blocked", limit: 25 })).toEqual({
+      events: [{ id: "aud_1", kind: "tool-call" }],
+      cursor: "cur_audit",
+    });
+    expect(calls[0]!.body).toEqual({ kind: "tool-call", outcome: "blocked", limit: 25 });
+
+    expect(await ops.secrets.get("stripe_key")).toBe("shhh");
+    expect(calls[1]!.body).toEqual({ name: "stripe_key" });
+    // The value crosses in the clear under TLS; the mount encrypts at rest.
+    await ops.secrets.set("stripe_key", "sk_live_1");
+    expect(calls[2]!.body).toEqual({ name: "stripe_key", value: "sk_live_1" });
+    expect(await ops.secrets.list()).toEqual(["stripe_key"]);
+    expect(calls[3]!.body).toEqual({});
+    await ops.secrets.delete("stripe_key");
+    expect(calls[4]!.body).toEqual({ name: "stripe_key" });
+
+    expect(await ops.footprint()).toEqual([{ collection: "vendo_runs", kind: "storage", bytes: 4096 }]);
+    expect(calls[5]!.body).toEqual({});
+
+    expect(await ops.retention!.quarantine("vendo_runs", "2026-01-01T00:00:00.000Z")).toEqual({ moved: 3 });
+    expect(calls[6]!.body).toEqual({ collection: "vendo_runs", olderThan: "2026-01-01T00:00:00.000Z" });
+    // The purge cutoff is on the QUARANTINE time, not on the row's own age.
+    expect(await ops.retention!.purge("vendo_runs", "2026-02-01T00:00:00.000Z")).toEqual({ purged: 2 });
+    expect(calls[7]!.body).toEqual({ collection: "vendo_runs", quarantinedBefore: "2026-02-01T00:00:00.000Z" });
+
+    const CONTRACT: [keyof typeof P, { safeParse(value: unknown): { success: boolean } }][] = [
+      ["audit.list", storeWireAuditListRequestSchema],
+      ["secrets.get", storeWireSecretsGetRequestSchema],
+      ["secrets.set", storeWireSecretsSetRequestSchema],
+      ["secrets.list", storeWireSecretsListRequestSchema],
+      ["secrets.delete", storeWireSecretsDeleteRequestSchema],
+      ["footprint", storeWireFootprintRequestSchema],
+      ["retention.quarantine", storeWireRetentionQuarantineRequestSchema],
+      ["retention.purge", storeWireRetentionPurgeRequestSchema],
+    ];
+    expect(calls).toHaveLength(CONTRACT.length);
+    for (const [index, [op, schema]] of CONTRACT.entries()) {
+      const call = calls[index]!;
+      expect(`${call.method} ${call.path}`).toBe(`POST ${P[op]}`);
+      expect(schema.safeParse(call.body).success, op).toBe(true);
+    }
+
+    // An absent secret is null at the seam, never an empty string.
+    const absent = wireFake({ ...ALL_BODIES, [door("secrets.get")]: { value: null } });
+    expect(await absent.ops.secrets.get("gone")).toBeNull();
+  });
+
+  it("engine.list: the watermark rides the query, and an answer that does not echo it is refused", async () => {
+    const watermark = { field: "started_at", after: "2026-01-01T00:00:00.000Z" };
+    const walked = wireFake({
+      [door("engine.list")]: { records: [wireRecord], watermark: "2026-01-02T00:00:00.000Z" },
+    });
+    expect(await walked.ops.engine.list("vendo_runs", { watermark, limit: 2 })).toEqual({
+      records: [expect.objectContaining({ id: "inv_1" })],
+      watermark: "2026-01-02T00:00:00.000Z",
+    });
+    expect(walked.calls[0]!.body).toEqual({ collection: "vendo_runs", query: { watermark, limit: 2 } });
+    expect(storeWireCollectionListRequestSchema.safeParse(walked.calls[0]!.body).success).toBe(true);
+
+    // The case the echo check exists for. A mount older than the bound passes
+    // the unknown key through, ignores it, and answers an ordinary
+    // newest-first page — records with no echo. Read as a forward walk that
+    // page drags the caller's mark back onto the NEWEST rows and re-reads them
+    // on every pass, forever, so it is refused rather than returned.
+    const older = wireFake({ [door("engine.list")]: { records: [wireRecord], cursor: "cur_engine" } });
+    const refused = await older.ops.engine.list("vendo_runs", { watermark })
+      .then(() => undefined, (reason: unknown) => reason);
+    expect(refused).toBeInstanceOf(VendoError);
+    expect(refused).toMatchObject({ code: "not-implemented" });
+    // What happened, why, and the way out — the page is never quietly unfiltered.
+    expect((refused as VendoError).message).toContain('"engine.list"');
+    expect((refused as VendoError).message).toContain("predates the bound");
+    expect((refused as VendoError).message).toContain("cursor");
+
+    // A caller that sent NO watermark asked for that page and gets it.
+    expect(await older.ops.engine.list("vendo_runs")).toEqual({
+      records: [expect.objectContaining({ id: "inv_1" })],
+      cursor: "cur_engine",
+    });
+  });
+
+  it("retention against a mount without it: the 501 becomes a refusal naming the op", async () => {
+    // Why the client implements retention with no capability check: every one
+    // of the new ops is a new PATH, and a mount that does not have it answers
+    // the enveloped 501 this protocol answers all unknown ops with — loud,
+    // specific, and impossible to read as data.
+    const refusing = (body: ConstructorParameters<typeof Response>[0]) => hostedStoreOps({
+      apiKey: "vnd_secret",
+      baseUrl: "https://cloud.test",
+      fetch: (async () => new Response(body, {
+        status: 501,
+        ...(body === null ? {} : { headers: { "content-type": "application/json" } }),
+      })) as unknown as typeof fetch,
+    });
+    const enveloped = refusing(JSON.stringify({
+      error: { code: "not-implemented", message: "this store does not serve retention.quarantine." },
+    }));
+    await expect(enveloped.retention!.quarantine("vendo_runs", "2026-01-01T00:00:00.000Z")).rejects.toMatchObject({
+      code: "not-implemented",
+      message: 'Vendo Cloud store does not support the "retention.quarantine" operation'
+        + " — this store does not serve retention.quarantine.",
+    });
+    // A bare 501 names the op just the same.
+    await expect(refusing(null).retention!.purge("vendo_runs", "2026-01-01T00:00:00.000Z")).rejects.toMatchObject({
+      code: "not-implemented",
+      message: expect.stringContaining('"retention.purge"'),
+    });
+  });
+
   it("status: the GET handshake, parsed as vendo/store-wire@1", async () => {
     const { calls, ops } = wireFake(ALL_BODIES);
     expect(await ops.status()).toMatchObject({ format: "vendo/store-wire@1", ops: 35 });
@@ -1245,9 +1401,13 @@ describe("hostedStore keeps its StoreAdapter surface and gains the op surface", 
     expect(typeof store.records).toBe("function");
     expect(typeof store.blobs).toBe("function");
     expect(typeof store.erase.bySubject).toBe("function");
-    // Eight families — the generic records family is gone from the op surface.
+    // Eleven families plus the two bare verbs (`footprint`, `status`) — the
+    // generic records family is gone from the op surface, and `retention` is
+    // present because the CLIENT serves the whole protocol, whatever a given
+    // mount has.
     expect(Object.keys(store.ops).sort()).toEqual([
-      "appData", "blobs", "engine", "harness", "lifecycle", "status", "transcripts", "workspace",
+      "appData", "audit", "blobs", "engine", "footprint", "harness", "lifecycle",
+      "retention", "secrets", "status", "transcripts", "workspace",
     ]);
 
     // The op surface rides the SAME mount, key and identity headers as the
@@ -1269,18 +1429,78 @@ describe("hostedStore keeps its StoreAdapter surface and gains the op surface", 
     expect(await store.ops.blobs.list("uploads", "images/")).toEqual(["images/a.png"]);
   });
 
-  // 16 of the 35 ops have no door in the fake: all 6 transcripts, all 3
-  // harness, all 4 workspace, lifecycle.promote and /status. It used to answer
-  // them with a `not-found` envelope — the SAME answer a live console sends
-  // when it refuses — so a test exercising one of those families read a
-  // plausible rejection and asserted nothing. The fake now throws out of
-  // `fetch`, which no console answer can be mistaken for.
+  it("serves the drawers the wire gained: the audit read, the vault, the forward walk and the footprint", async () => {
+    const ops = hosted(fakeConsole()).ops;
+    const ctx = { principal: { kind: "user" as const, subject: "user_1" }, venue: "chat" as const, presence: "present" as const };
+    await ops.engine.put("vendo_audit", {
+      id: "aud_1",
+      data: { id: "aud_1", at: "2026-01-01T00:00:00.000Z", kind: "tool-call", tool: "host_send", outcome: "ok", ...ctx },
+    });
+    await ops.engine.put("vendo_audit", {
+      id: "aud_2",
+      data: { id: "aud_2", at: "2026-01-02T00:00:00.000Z", kind: "policy-decision", outcome: "blocked", decidedBy: "rule", ...ctx },
+    });
+
+    // Newest first, over the same rows engine.list("vendo_audit") walks, and
+    // the four filters AND together.
+    expect((await ops.audit.list()).events.map((event) => event.id)).toEqual(["aud_2", "aud_1"]);
+    expect((await ops.audit.list({ kind: "tool-call" })).events.map((event) => event.id)).toEqual(["aud_1"]);
+    expect((await ops.audit.list({ outcome: "blocked", decidedBy: "rule" })).events.map((event) => event.id))
+      .toEqual(["aud_2"]);
+    expect((await ops.audit.list({ venue: "app" })).events).toEqual([]);
+
+    await ops.secrets.set("stripe_key", "sk_live_1");
+    expect(await ops.secrets.get("stripe_key")).toBe("sk_live_1");
+    expect(await ops.secrets.list()).toEqual(["stripe_key"]);
+    await ops.secrets.delete("stripe_key");
+    expect(await ops.secrets.get("stripe_key")).toBeNull();
+    expect(await ops.secrets.list()).toEqual([]);
+
+    const started = ["2026-02-01T00:00:00.000Z", "2026-02-02T00:00:00.000Z", "2026-02-03T00:00:00.000Z"];
+    for (const [index, startedAt] of started.entries()) {
+      await ops.engine.put("vendo_runs", {
+        id: `run_${index + 1}`,
+        data: { appId: "app_1", trigger: { kind: "schedule" }, status: "ok", record: {}, startedAt },
+      });
+    }
+    // The forward walk: oldest-first from the bound, with the bound to send
+    // next time on the page — a meter advances its mark by that echo alone.
+    const first = await ops.engine.list("vendo_runs", {
+      watermark: { field: "started_at", after: started[0]! },
+      limit: 1,
+    });
+    expect(first).toMatchObject({ watermark: started[1] });
+    expect(first.records.map((record) => record.id)).toEqual(["run_2"]);
+    const next = await ops.engine.list("vendo_runs", { watermark: { field: "started_at", after: first.watermark! } });
+    expect(next.records.map((record) => record.id)).toEqual(["run_3"]);
+    // Nothing new to read echoes the caller's own bound back, so the mark holds
+    // where it was instead of falling back to the newest row.
+    expect(await ops.engine.list("vendo_runs", { watermark: { field: "started_at", after: next.watermark! } }))
+      .toEqual({ records: [], watermark: started[2] });
+    // A field the collection does not keep indexed is refused, not scanned.
+    await expect(ops.engine.list("vendo_apps", { watermark: { field: "started_at", after: started[0]! } }))
+      .rejects.toMatchObject({ code: "validation" });
+
+    // The footprint counts the drawers holding rows, each with its kind; the
+    // ones holding nothing are absent.
+    const footprint = await ops.footprint();
+    expect(footprint.map((entry) => entry.collection)).toEqual(["vendo_audit", "vendo_runs"]);
+    expect(footprint.every((entry) => entry.kind === "storage" && entry.bytes > 0)).toBe(true);
+  });
+
+  // 17 of the 43 ops have no door in the fake: all 6 transcripts, all 3
+  // harness, all 4 workspace, both retention verbs, lifecycle.promote and
+  // /status. It used to answer them with a `not-found` envelope — the SAME
+  // answer a live console sends when it refuses — so a test exercising one of
+  // those families read a plausible rejection and asserted nothing. The fake now
+  // throws out of `fetch`, which no console answer can be mistaken for.
   it("never stands in for a door it does not serve", async () => {
     const store = hosted(fakeConsole());
     const unserved: Array<[string, () => Promise<unknown>]> = [
       ["transcripts", () => store.ops.transcripts.listThreads()],
       ["harness", () => store.ops.harness.get("app_1", "sub_1")],
       ["workspace", () => store.ops.workspace.index()],
+      ["retention", () => store.ops.retention!.quarantine("vendo_runs", "2026-01-01T00:00:00.000Z")],
       ["lifecycle.promote", () => store.ops.lifecycle.promote("app_1", "org_1")],
       ["status", () => store.ops.status()],
     ];

--- a/packages/store/tests/hosted-store.test.ts
+++ b/packages/store/tests/hosted-store.test.ts
@@ -1469,14 +1469,29 @@ describe("hostedStore keeps its StoreAdapter surface and gains the op surface", 
       watermark: { field: "started_at", after: started[0]! },
       limit: 1,
     });
-    expect(first).toMatchObject({ watermark: started[1] });
+    // The echo is a resume token, spelled however the mount likes — asserted
+    // present and sent back verbatim, never read.
+    expect(first.watermark).toEqual(expect.any(String));
     expect(first.records.map((record) => record.id)).toEqual(["run_2"]);
     const next = await ops.engine.list("vendo_runs", { watermark: { field: "started_at", after: first.watermark! } });
     expect(next.records.map((record) => record.id)).toEqual(["run_3"]);
     // Nothing new to read echoes the caller's own bound back, so the mark holds
     // where it was instead of falling back to the newest row.
     expect(await ops.engine.list("vendo_runs", { watermark: { field: "started_at", after: next.watermark! } }))
-      .toEqual({ records: [], watermark: started[2] });
+      .toEqual({ records: [], watermark: next.watermark });
+
+    // Runs that share one `startedAt` — the millisecond a burst of callers all
+    // stamp. The page boundary lands INSIDE the group, so a bound that were only
+    // the instant would step over run_5 and never count it.
+    for (const id of ["run_4", "run_5"]) {
+      await ops.engine.put("vendo_runs", {
+        id,
+        data: { appId: "app_1", trigger: { kind: "schedule" }, status: "ok", record: {}, startedAt: "2026-02-04T00:00:00.000Z" },
+      });
+    }
+    const tiedFirst = await ops.engine.list("vendo_runs", { watermark: { field: "started_at", after: started[2]! }, limit: 1 });
+    const tiedNext = await ops.engine.list("vendo_runs", { watermark: { field: "started_at", after: tiedFirst.watermark! }, limit: 1 });
+    expect([...tiedFirst.records, ...tiedNext.records].map((record) => record.id).sort()).toEqual(["run_4", "run_5"]);
     // A field the collection does not keep indexed is refused, not scanned.
     await expect(ops.engine.list("vendo_apps", { watermark: { field: "started_at", after: started[0]! } }))
       .rejects.toMatchObject({ code: "validation" });

--- a/packages/store/tests/idempotency.test.ts
+++ b/packages/store/tests/idempotency.test.ts
@@ -1,0 +1,46 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { backends, type MadeBackend } from "../src/backends.test-util.js";
+import type { IdempotencyLedger } from "@vendoai/core";
+
+// 01 §12 — the `Idempotency-Key` replay ledger, served off the same database as
+// the mutations it gates. `createStore()` hands one out, so a mount never has to
+// wire a second store up (and never can put the ledger somewhere that commits
+// independently of the work it is recording).
+const scope = { tenant: "tenant_a", op: "workspace.commit", key: "key_1" };
+
+for (const backend of backends()) {
+  describe(`${backend.name} idempotency ledger`, () => {
+    let made: MadeBackend;
+    let ledger: IdempotencyLedger;
+    beforeAll(async () => {
+      made = await backend.make();
+      await made.store.ensureSchema();
+      ledger = made.store.idempotency!;
+    });
+    afterAll(async () => { if (made) await made.cleanup(); });
+
+    it("createStore hands out a ledger", () => {
+      expect(made.store.idempotency).toBeDefined();
+    });
+
+    it("replays what a key already answered, and only for the same request body", async () => {
+      expect(await ledger.check(scope, "hash_1")).toBeNull();
+      await ledger.record(scope, "hash_1", { status: 201, result: { id: "wsc_1" } });
+      expect(await ledger.check(scope, "hash_1")).toEqual({ status: 201, result: { id: "wsc_1" } });
+      // The same key with a DIFFERENT body is a client bug, not a replay: there
+      // is no recorded answer that belongs to it, so it must never receive the
+      // other request's.
+      await expect(ledger.check(scope, "hash_2")).rejects.toMatchObject({ code: "conflict" });
+    });
+
+    it("is scoped by tenant and op, so one key cannot answer another's request", async () => {
+      expect(await ledger.check({ ...scope, tenant: "tenant_b" }, "hash_1")).toBeNull();
+      expect(await ledger.check({ ...scope, op: "engine.put" }, "hash_1")).toBeNull();
+    });
+
+    it("keeps the FIRST answer: a later record for a held key is a no-op", async () => {
+      await ledger.record(scope, "hash_1", { status: 500, result: { error: "late" } });
+      expect(await ledger.check(scope, "hash_1")).toEqual({ status: 201, result: { id: "wsc_1" } });
+    });
+  });
+}

--- a/packages/store/tests/ops.conformance.test.ts
+++ b/packages/store/tests/ops.conformance.test.ts
@@ -1,7 +1,8 @@
+import { randomBytes } from "node:crypto";
 import { storeOpsConformance } from "@vendoai/core/conformance";
 import { describe, it } from "vitest";
 import { backends } from "../src/backends.test-util.js";
-import { createStoreOps } from "../src/index.js";
+import { createStore, createStoreOps } from "../src/index.js";
 
 // The StoreOps contract, proven against the LOCAL backend (ops.ts) on both
 // engines — the same suite the memory reference and the cloud client run.
@@ -10,12 +11,28 @@ for (const backend of backends()) {
     const suite = storeOpsConformance({
       async makeOps() {
         const made = await backend.make();
+        // `secrets.*` is encrypted at rest and fails CLOSED with no key, so a
+        // store built without one cannot serve that family at all — and this
+        // suite asks for the whole contract. Re-made with a key, the same move
+        // the stored-SecretsProvider mount makes (tests/conformance.test.ts).
+        // Costs nothing: the handle is lazy, so the one it replaces never
+        // opened a database.
+        await made.store.close();
+        made.store = createStore({
+          url: made.url,
+          dataDir: made.dataDir,
+          encryption: { key: randomBytes(32).toString("base64") },
+        });
         await made.store.ensureSchema();
         return { ops: createStoreOps(made.store), close: made.cleanup };
       },
     });
+    // A pending case is carried but not run, and the reason rides in the test
+    // name — the ops the contract declares and this backend does not serve yet
+    // stay visible in the output instead of quietly not existing.
     for (const conformanceCase of suite.cases) {
-      it(conformanceCase.name, conformanceCase.run);
+      if (conformanceCase.pending === undefined) it(conformanceCase.name, conformanceCase.run);
+      else it.skip(`${conformanceCase.name} [pending: ${conformanceCase.pending}]`, conformanceCase.run);
     }
   });
 }

--- a/packages/store/tests/ops.test.ts
+++ b/packages/store/tests/ops.test.ts
@@ -1,8 +1,19 @@
+import { randomBytes } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import { backends, type MadeBackend } from "../src/backends.test-util.js";
-import { auditFixture } from "../src/fixtures.test-util.js";
-import { createStoreOps } from "../src/index.js";
+import { at, auditFixture } from "../src/fixtures.test-util.js";
+import { encodeCursor } from "../src/helpers/utils.js";
+import { createStore, createStoreOps } from "../src/index.js";
 import type { StoreOps } from "@vendoai/core";
+
+/** One run at an exact instant — the watermark walk's only subject, because
+ *  `vendo_runs.started_at` is the one indexed field the registry declares. */
+const putRun = async (ops: StoreOps, id: string, startedAt: string): Promise<void> => {
+  await ops.engine.put("vendo_runs", {
+    id,
+    data: { appId: "app_test", trigger: { kind: "schedule" }, status: "ok", record: {}, startedAt },
+  });
+};
 
 // The local backend's OWN laws, beyond the shared conformance suite: the F4
 // cascade proven at the rows, and the per-collection policies the routed
@@ -73,11 +84,14 @@ for (const backend of backends()) {
       }
     });
 
-    it("status() reports the 36 ops this wire serves", async () => {
+    it("status() reports the 42 ops this wire serves", async () => {
       const { made, ops } = await makeOps();
       try {
         const status = await ops.status();
-        expect(status.ops).toBe(36);
+        // 42 of 44: retention is declared last in STORE_WIRE_PATHS and this
+        // engine has nowhere to quarantine to, so the level stops at footprint.
+        expect(status.ops).toBe(42);
+        expect(ops.retention).toBeUndefined();
         // Nothing left to announce: the handshake carries the format and the
         // count, and the retired generic family is not advertised as anything.
         expect(Object.keys(status).sort()).toEqual(["format", "ops"]);
@@ -147,6 +161,166 @@ for (const backend of backends()) {
         expect((await made.sql("SELECT 1 FROM vendo_state WHERE app_id = $1", ["app_shared"])).length).toBe(2);
         await ops.harness.clear("app_shared", "alice");
         expect(await ops.harness.get("app_shared", "bob")).toEqual({ seen: 2 });
+      } finally {
+        await made.cleanup();
+      }
+    });
+
+    it("audit.list filters on the columns AND on the fields inside the event", async () => {
+      const { made, ops } = await makeOps();
+      try {
+        const events = [
+          auditFixture("aud_a", { at: at(1), kind: "tool-call", venue: "chat", outcome: "ok" }),
+          auditFixture("aud_b", { at: at(2), kind: "policy-decision", venue: "app", outcome: "blocked", decidedBy: "rule" }),
+          auditFixture("aud_c", { at: at(3), kind: "policy-decision", venue: "app", outcome: "blocked", decidedBy: "judge" }),
+        ];
+        for (const event of events) await ops.engine.put("vendo_audit", { id: event.id, data: event });
+
+        // Newest first, and the whole feed when nothing narrows it.
+        expect((await ops.audit.list()).events.map((event) => event.id)).toEqual(["aud_c", "aud_b", "aud_a"]);
+        // `kind`/`venue` are columns; `outcome`/`decidedBy` are only inside the
+        // event jsonb — the filters that made this op worth having.
+        expect((await ops.audit.list({ venue: "app" })).events.map((event) => event.id)).toEqual(["aud_c", "aud_b"]);
+        expect((await ops.audit.list({ outcome: "blocked", decidedBy: "judge" })).events.map((event) => event.id)).toEqual(["aud_c"]);
+        expect((await ops.audit.list({ kind: "tool-call", venue: "app" })).events).toEqual([]);
+        // Typed events, not records.
+        expect((await ops.audit.list({ kind: "tool-call" })).events[0]?.principal.subject).toBe("user_test");
+
+        // The cursor is the routed door's, so a page taken here can be finished
+        // there — the two must never disagree about where a page stopped.
+        const first = await ops.audit.list({ limit: 2 });
+        expect(first.events.map((event) => event.id)).toEqual(["aud_c", "aud_b"]);
+        const rest = await ops.engine.list("vendo_audit", { cursor: first.cursor });
+        expect(rest.records.map((record) => record.id)).toEqual(["aud_a"]);
+      } finally {
+        await made.cleanup();
+      }
+    });
+
+    it("engine.list walks forward from a watermark WITHOUT losing microseconds", async () => {
+      const { made, ops } = await makeOps();
+      try {
+        // Two runs inside ONE millisecond. A watermark truncated to ms would
+        // hand back .123000, and the next walk would re-read run_1 forever —
+        // the console incident this precision rule exists for.
+        await putRun(ops, "run_1", "2026-03-04T05:06:07.123456Z");
+        await putRun(ops, "run_2", "2026-03-04T05:06:07.123789Z");
+        await putRun(ops, "run_3", "2026-03-04T05:06:08.000000Z");
+
+        const first = await ops.engine.list("vendo_runs", {
+          watermark: { field: "started_at", after: "2026-03-04T05:06:07.000000Z" },
+          limit: 1,
+        });
+        expect(first.records.map((record) => record.id)).toEqual(["run_1"]);
+        expect(first.watermark).toBeDefined();
+
+        const second = await ops.engine.list("vendo_runs", {
+          watermark: { field: "started_at", after: first.watermark! },
+          limit: 1,
+        });
+        expect(second.records.map((record) => record.id)).toEqual(["run_2"]);
+
+        const third = await ops.engine.list("vendo_runs", {
+          watermark: { field: "started_at", after: second.watermark! },
+        });
+        expect(third.records.map((record) => record.id)).toEqual(["run_3"]);
+
+        // Nothing left: the echo comes back unchanged, so the next pass resumes
+        // from the same place rather than from the top.
+        const done = await ops.engine.list("vendo_runs", {
+          watermark: { field: "started_at", after: third.watermark! },
+        });
+        expect(done.records).toEqual([]);
+        expect(done.watermark).toBe(third.watermark);
+
+        // Same record shape as the ordinary newest-first list.
+        expect(first.records[0]).toEqual(
+          (await ops.engine.list("vendo_runs", { ids: ["run_1"] })).records[0],
+        );
+      } finally {
+        await made.cleanup();
+      }
+    });
+
+    it("a watermark is refused on an unindexed field, and never travels with a cursor", async () => {
+      const { made, ops } = await makeOps();
+      try {
+        await expect(ops.engine.list("vendo_runs", { watermark: { field: "finished_at", after: at(1) } }))
+          .rejects.toMatchObject({ code: "validation" });
+        await expect(ops.engine.list("vendo_audit", { watermark: { field: "at", after: at(1) } }))
+          .rejects.toMatchObject({ code: "validation" });
+        await expect(ops.engine.list("vendo_runs", {
+          watermark: { field: "started_at", after: at(1) },
+          cursor: encodeCursor(at(2), "run_x"),
+        })).rejects.toMatchObject({ code: "validation" });
+      } finally {
+        await made.cleanup();
+      }
+    });
+
+    it("footprint measures row content per collection, counts a thread's messages, and omits the empty", async () => {
+      const { made, ops } = await makeOps();
+      try {
+        // Incompressible on purpose: pg_column_size reports the size Postgres
+        // actually stores, and a repeated character would pglz down to nothing.
+        await ops.transcripts.putThread({
+          id: "thr_fp",
+          subject: "user_fp",
+          messages: [{ id: "m1", role: "user", text: randomBytes(2048).toString("hex") }],
+        });
+        await ops.engine.put("vendo_knowledge_docs", { id: "doc_fp", data: { body: randomBytes(1024).toString("hex") } });
+        await ops.engine.put("vendo_placements", { id: "plc_fp", data: { slot: "hero" } });
+
+        const footprint = await ops.footprint();
+        const bytesOf = (collection: string): number =>
+          footprint.find((entry) => entry.collection === collection)?.bytes ?? 0;
+        // Sorted by name, and every reported collection is holding something.
+        expect(footprint.map((entry) => entry.collection))
+          .toEqual([...footprint.map((entry) => entry.collection)].sort());
+        expect(footprint.every((entry) => entry.bytes > 0)).toBe(true);
+        // The transcript lives in vendo_thread_messages since v6; a thread
+        // footprint that counted only the header row would report ~200 bytes.
+        expect(bytesOf("vendo_threads")).toBeGreaterThan(4000);
+        // Generic-table collections come back too, and the corpus is the one
+        // kind that is not `storage`.
+        expect(bytesOf("vendo_placements")).toBeGreaterThan(0);
+        expect(footprint.find((entry) => entry.collection === "vendo_knowledge_docs")?.kind).toBe("knowledge");
+        expect(footprint.find((entry) => entry.collection === "vendo_placements")?.kind).toBe("storage");
+
+        // A collection holding nothing has no entry at all — which is what makes
+        // an empty store answer with an empty list.
+        await ops.engine.delete("vendo_placements", "plc_fp");
+        expect((await ops.footprint()).find((entry) => entry.collection === "vendo_placements"))
+          .toBeUndefined();
+      } finally {
+        await made.cleanup();
+      }
+    });
+
+    it("secrets delegate to the vault, and an absent name reads as null (not undefined)", async () => {
+      const made = await backend.make();
+      try {
+        // The vault fails closed without a key (secrets.ts), so a store that
+        // serves this family has one — the same requirement a BYO mount meets
+        // with VENDO_STORE_ENCRYPTION_KEY.
+        await made.store.close();
+        made.store = createStore({
+          url: made.url,
+          dataDir: made.dataDir,
+          encryption: { key: randomBytes(32).toString("base64") },
+        });
+        await made.store.ensureSchema();
+        const ops = createStoreOps(made.store);
+
+        expect(await ops.secrets.get("MISSING")).toBeNull();
+        await ops.secrets.set("API_TOKEN", "shhh");
+        expect(await ops.secrets.get("API_TOKEN")).toBe("shhh");
+        expect(await ops.secrets.list()).toEqual(["API_TOKEN"]);
+        // Encrypted at rest by the vault this op delegates to.
+        const row = (await made.sql("SELECT ciphertext FROM vendo_secrets WHERE name = 'API_TOKEN'"))[0];
+        expect(String(row?.ciphertext)).not.toContain("shhh");
+        await ops.secrets.delete("API_TOKEN");
+        expect(await ops.secrets.get("API_TOKEN")).toBeNull();
       } finally {
         await made.cleanup();
       }

--- a/packages/store/tests/schema.test.ts
+++ b/packages/store/tests/schema.test.ts
@@ -26,6 +26,7 @@ const CONTRACT_COLUMNS: Record<string, string[]> = {
   vendo_workspace_files: ["path", "owner", "content", "blob_ref", "bytes", "revision", "created_at", "updated_at"],
   vendo_workspace_history: ["id", "path", "owner", "revision", "content", "blob_ref", "intent", "at"],
   vendo_app_grants: ["id", "app_id", "org_id", "principal", "level", "created_by", "created_at"],
+  vendo_idempotency_ledger: ["tenant", "op", "key", "request_hash", "status", "result", "created_at"],
 };
 
 for (const backend of backends()) {
@@ -46,17 +47,17 @@ for (const backend of backends()) {
     it("stores schema_version and a boot_id in vendo_meta", async () => {
       const rows = await made.sql("SELECT key, value FROM vendo_meta ORDER BY key");
       expect(rows).toEqual(expect.arrayContaining([
-        expect.objectContaining({ key: "schema_version", value: 7 }),
+        expect.objectContaining({ key: "schema_version", value: 8 }),
         expect.objectContaining({ key: "boot_id" }),
       ]));
       expect(rows.find((row) => row.key === "boot_id")?.value).toEqual(expect.any(String));
     });
 
-    it("lands a fresh database directly on schema version 7", async () => {
+    it("lands a fresh database directly on schema version 8", async () => {
       // A brand-new DB never runs the v2 backfill's DELETE against real data; it
       // just records the current version. (beforeAll already ran ensureSchema.)
       const version = (await made.sql("SELECT value FROM vendo_meta WHERE key = 'schema_version'"))[0]?.value;
-      expect(version).toBe(7);
+      expect(version).toBe(8);
     });
 
     it("keeps boot_id stable across a close and reopen", async () => {
@@ -76,7 +77,7 @@ for (const backend of backends()) {
 
       await made.store.ensureSchema();
 
-      expect((await made.sql("SELECT value FROM vendo_meta WHERE key = 'schema_version'"))[0]?.value).toBe(7);
+      expect((await made.sql("SELECT value FROM vendo_meta WHERE key = 'schema_version'"))[0]?.value).toBe(8);
       const rows = await made.sql(
         `SELECT table_name FROM information_schema.tables
          WHERE table_schema = 'public' AND table_name IN ('vendo_mcp_clients', 'vendo_mcp_grants')
@@ -100,7 +101,7 @@ for (const backend of backends()) {
 
       await made.store.ensureSchema();
 
-      expect((await made.sql("SELECT value FROM vendo_meta WHERE key = 'schema_version'"))[0]?.value).toBe(7);
+      expect((await made.sql("SELECT value FROM vendo_meta WHERE key = 'schema_version'"))[0]?.value).toBe(8);
       const survivor = await made.sql(
         "SELECT id FROM vendo_records WHERE collection = 'vendo_state' AND id = 'app_live:subject_live'",
       );
@@ -108,7 +109,7 @@ for (const backend of backends()) {
       await made.sql("DELETE FROM vendo_records WHERE collection = 'vendo_state' AND id = 'app_live:subject_live'");
     });
 
-    it("creates all 20 contract tables with every contracted key column", async () => {
+    it("creates all 21 contract tables with every contracted key column", async () => {
       const rows = await made.sql(
         "SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name LIKE 'vendo_%'",
       );
@@ -124,8 +125,10 @@ for (const backend of backends()) {
       // vendo_workspace_history. Each lane asserted 18 counting only its own
       // pair; the merged v6 carries all four. v7 (wave 3, build contract §9.2)
       // adds vendo_app_grants — the only multi-party rows Vendo stores. Guest
-      // sessions were then deleted, taking vendo_sessions back out.
-      expect(actual.size).toBe(20);
+      // sessions were then deleted, taking vendo_sessions back out. v8 adds
+      // vendo_idempotency_ledger — the `Idempotency-Key` replay ledger, which
+      // has to live in the same database as the mutations it gates (01 §12).
+      expect(actual.size).toBe(21);
       for (const [table, columns] of Object.entries(CONTRACT_COLUMNS)) {
         expect(actual.has(table), table).toBe(true);
         for (const column of columns) expect(actual.get(table)?.has(column), `${table}.${column}`).toBe(true);

--- a/packages/store/tests/state-routing.test.ts
+++ b/packages/store/tests/state-routing.test.ts
@@ -3,6 +3,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { backends, type MadeBackend } from "../src/backends.test-util.js";
 import { appFixture, persistentPrincipal } from "../src/fixtures.test-util.js";
 import { appStore, createStore } from "../src/index.js";
+import { SCHEMA_VERSION } from "../src/schema.js";
 
 for (const backend of backends()) {
   describe(`${backend.name} vendo_state routing`, () => {
@@ -293,7 +294,12 @@ for (const backend of backends()) {
 
       // The v1 -> v3 upgrade performs the (v2) backfill on the way through.
       await made.store.ensureSchema();
-      expect((await made.sql("SELECT value FROM vendo_meta WHERE key = 'schema_version'"))[0]?.value).toBe(7);
+      // Against the CONSTANT, not a literal: what this case is about is that a
+      // v1 store is carried all the way to current and the v2 backfill runs once
+      // on the way through. A hardcoded number makes every later schema bump
+      // look like a migration regression (v8, the idempotency ledger, did).
+      expect((await made.sql("SELECT value FROM vendo_meta WHERE key = 'schema_version'"))[0]?.value)
+        .toBe(SCHEMA_VERSION);
 
       expect(await made.sql(
         "SELECT app_id, subject, data FROM vendo_state WHERE app_id = 'app_legacy'",


### PR DESCRIPTION
Stage 1 of "make the interface the law". Vendo Cloud's console currently reaches
around `StoreOps` into raw Postgres for six things the contract cannot express.
This PR defines all six in OSS core so every later lane builds against a frozen
signature instead of inventing one.

`STORE_WIRE_PATHS` goes 36 → 44 paths. Nothing is removed and nothing is
renamed, so the `STORE_WIRE_APPEND_MESSAGES_OPS` proxy still holds.

## Live vs pending

| # | Capability | Wire | Local engine | Memory reference | Cloud client | Conformance |
|---|---|---|---|---|---|---|
| B1 | `IdempotencyLedger` | none — server-side | **live** (`vendo_idempotency_ledger`, schema v8) | **live** (`memoryStoreAdapter`) | n/a | 4 real cases in `storeAdapterConformance` |
| B2 | `audit.list` | `/audit/list` | **live** | **live** | **live** | 3 real cases |
| B3 | `footprint()` | `/footprint` | **live** | **live** | **live** | 2 real cases |
| B4 | `engine.list` watermark | field on `/engine/list` | **live** | **live** | **live** | 3 real cases |
| B5 | `retention.{quarantine,purge}` | `/retention/*` | **pending** (member omitted) | **pending** | live (client half) | **2 tagged pending** |
| B6 | `secrets.{get,set,list,delete}` | `/secrets/*` | **live** | **live** | **live** | 2 real cases |

**B5 is the only pending op, and it is owned by the retention lane.** `StoreOps.retention`
is OPTIONAL, so an engine with nowhere to quarantine to says so by omitting the
family rather than by accepting the call and destroying rows a quarantine was
supposed to keep recoverable. The two conformance cases carry real bodies and a
`pending:` tag naming that lane; landing it means deleting one field. CI prints
a standing `↓ … [pending: the retention lane …]` line per mount, so the gap is
visible rather than absent — no silent skips.

`ops` on `/status` goes 36 → 42 for the local engine: it serves everything except
the two retention ops, which are declared LAST in `STORE_WIRE_PATHS` for exactly
that reason. `ops` is a monotone LEVEL over that order, not an inventory.

## Design decisions

- **`audit.list` returns typed `AuditEvent`s, not records.** The drawer's rows
  *are* AuditEvents and every consumer casts them back to one; a door that
  returns what it stores is a door nobody has to parse.
- **Four audit filters, not a query language.** `kind`/`venue`/`outcome`/`decidedBy`
  — the ones that are not ref keys. Subject, app and tool narrowing stays on
  `engine.list`'s existing refs rather than becoming a second way to do it.
- **`footprint().bytes` is row content, not relation size.** Most collections
  share `vendo_records`, so a per-collection disk number does not exist to report.
  One uniform unit that is comparable with itself over time; conformance checks
  shape and non-decreasing growth and never a byte count.
- **`kind` is `storage | knowledge` only.** What a collection HOLDS. The console's
  third bucket ("unmetered") is a price list, not a data kind, and does not belong
  in a contract every BYO mount reads.
- **The watermark bound is opaque and full-precision.** A mark round-tripped
  through a JS `Date` truncates to milliseconds, moves BACKWARDS, and re-counts a
  window — so the value is never parsed, and the echo comes straight out of
  Postgres.
- **The watermark echo is a resume token carrying the row id.** Found during
  review: with only the field's value and a strict `>`, a page ending inside a
  group of rows sharing one `started_at` skipped the rest of that group, silently
  and permanently. `started_at` is caller-supplied and callers write
  millisecond-precision ISO strings, so ties are routine and the consumer is a
  meter — a skipped row is uncounted usage. Comparison is now on `(field, id)`.
  Proven red first: five tied runs walked two at a time returned two.
- **That echo is also how the bound is feature-detected**, and it is why no new
  `STORE_WIRE_*_OPS` constant exists. Every other new op is a new PATH, which an
  older mount refuses with the enveloped 501 the protocol already answers unknown
  ops with. A FIELD on an existing op has no such protection — `.passthrough()`
  lets an old mount ignore it and answer an ordinary newest-first page. A
  pre-send check earns its keep only for a mutation with a cheaper fallback,
  which is why the batch append has one and reads do not.
- **`IdempotencyLedger.check` takes the request hash and throws `conflict` itself.**
  The console reads the stored hash out and compares at the call site; passing it
  in makes the one dangerous case — same key, different body, someone else's
  result replayed — impossible to skip.
- **`ENGINE_COLLECTIONS` is now derived from `ENGINE_COLLECTION_REGISTRY`**, which
  carries each collection's kind and indexed fields. Same 38 names, same order. A
  second place naming them is how an allowlist rots.

## Where the rules forced a different shape than the console's call sites

1. **`decidedBy`, not `decider`** — it is `AuditEvent`'s own field name, and a
   second spelling for one field is gratuitous.
2. **`audit.list` will not express the console's default activity feed.** That
   feed is a compound OR (`kind='tool-call' OR (kind='policy-decision' AND
   detail.reason IN ('frozen','unfrozen'))`). That is policy, not a store
   capability, and a generic query language was an explicit anti-goal.
3. **`audit.list` does not aggregate, so the console's decision *tally* is not
   freed by this PR.** The tally is a `GROUP BY` over hour/outcome/decidedBy.
   Serving it needs a named `audit.tally` op — a seventh capability nobody asked
   for, so I did not add it. Flagging it as the one B2 consumer still on raw SQL.
4. **Secrets are the console's CONTROL plane today** (`project_secrets`, keyed by
   project), not the tenant store. B6 gives the OSS/BYO path a real vault and
   Cloud a place to land, but it does not literally replace that code. `list()`
   also returns names only, matching the existing OSS vault; the console's UI
   shows dates.
5. **`footprint` bytes will not match Cloud's billing numbers**, which come from
   `pg_total_relation_size` per schema. Different unit, on purpose (see above).
6. **The erase report gained a key, which the brief told me to avoid.**
   `erase.conformance.test.ts` pins a code-to-code invariant that every DDL table
   is accounted for in `ERASE_TABLES`, so a new table cannot be added without it.
   The alternative was inventing an exclusion mechanism that would HIDE the gap.
   The addition is additive and permanently `0`: no selector reaches
   `(tenant, op, key)`, exactly the class `vendo_effects` sat in until it was
   given a subject. Documented in `ERASE_TABLES`; **nothing prunes the ledger
   today, and retention is its natural sweeper.**

## Gate

`pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint` — all green
(45/45 turbo tasks). No UI surface, so no screenshots.

Every new case was mutation-proved: reversed audit order, a dropped watermark
echo, a millisecond-truncated echo, `undefined` for an absent secret, a
mislabeled and a shrinking footprint, a lying `status.ops` in both directions, a
ledger ignoring the request hash, and the tie-skip above — each turned its
intended case red before being restored.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds six StoreOps capabilities the console previously reached around so all lanes build against a stable contract; no existing paths are removed or renamed.

- New ops: `audit.list`, `secrets.{get,set,list,delete}`, `footprint()`, `engine.list` watermark bound/echo, and retention `{quarantine,purge}` (contract only). Retention is optional and the only pending op in the local engine. `STORE_WIRE_PATHS` grows 36 → 44; `/status ops` reports 42 for the local engine (everything except the two retention ops, which are last by design).

**Behavior changes that matter**
- Forward-walk reliability: the `engine.list` bound switches from strict “> field” to an opaque resume token echoing `(field,id)` at full precision. This prevents skipping rows when timestamps tie. Bare adapters can’t honor this; `engineOverAdapter` now rejects a watermark on bare adapters to avoid silent fallbacks.
- Server-side idempotency: adds `IdempotencyLedger` over `vendo_idempotency_ledger` (schema v8). `check(scope, requestHash)` throws `conflict` on key reuse with a different body and returns the original result for exact replays.

**Review and rollout notes**
- Schema: bumps to v8 adding `vendo_idempotency_ledger`. `ensureSchema()` migrates. Erase reports list the ledger explicitly with a permanent 0; retention will own its sweep later.
- Footprint: returns per-collection row-content bytes plus `kind` (`storage | knowledge`). Numbers differ from Cloud’s relation-size billing by design.
- Secrets: values traverse TLS in clear and are encrypted at rest server-side; stores without an encryption key cannot serve `secrets.*`.
- Compatibility: new PATHs return the existing enveloped 501 on older mounts; the watermark bound is feature-detected via the echo field on `engine.list`. No `STORE_WIRE_*_OPS` constant changed.
- Registry: `ENGINE_COLLECTIONS` now derives from `ENGINE_COLLECTION_REGISTRY` (kind + indexed fields). Watermarks are only allowed on declared indexed fields.
- Conformance: retention cases are carried as pending and now executed against a reference implementation to prove the contract; mounts report them as skipped with the reason in test output.

<sup>Written for commit 7df554e1fa3d448913288305746472cafe366bf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

