### PR TITLE
docs: drop the PR-screenshot requirement — browser verification stands on its own

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,8 @@ generated UI in a sandboxed, brand-native surface.
 - Vendo-facing API/SDK/CLI design additionally routes through the
   **vendo-dx** skill (on top of api-design-dx).
 - Never commit to `main`; branch and open a PR.
-- UI-affecting changes are verified in a real browser with screenshots in the
-  PR. Tests and typecheck alone don't count.
+- UI-affecting changes are verified in a real browser. Tests and typecheck
+  alone don't count.
 - Local gate = `pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint`
   on the touched scope. The FULL suite runs only in CI — the PR's green `ci`
   check is the gate of record; never run the full suite locally.


### PR DESCRIPTION
Yousef's call (2026-08-14): UI-affecting changes are still verified in a real browser, but screenshots in the PR are no longer required — the evidence ceremony is gone, the verification law stays. One line in CLAUDE.md, no code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops the PR-screenshot requirement for UI-affecting changes while keeping real-browser verification mandatory. Previously: verify in a browser and attach screenshots; now: verify in a browser without screenshots. Tests and typecheck alone still don't count.

**Review notes**
- Docs-only update in `CLAUDE.md`; no code changes.
- No migration required: keep doing real-browser checks, but stop attaching screenshots to PRs.

<sup>Written for commit 4d0a230596e420737d8e054cb9aff0991d3f569d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

