### PR TITLE
feat(core,store): audit.tally — the grouped read the decision tally is

### DIFF
--- a/.changeset/audit-tally.md
+++ b/.changeset/audit-tally.md
@@ -1,0 +1,45 @@
+---
+"@vendoai/core": minor
+"@vendoai/store": minor
+---
+
+`audit.tally` — the 45th store op, and the grouped read a decision tally is.
+
+A reviewer's tally ("how many calls ran, were asked about, were blocked, and by
+which layer, hour by hour") is a `GROUP BY`, not a page. Reading it through
+`audit.list` means shipping every event in the window across the wire and
+counting it at the other end, which is why the console reached around StoreOps
+into raw SQL for it. Now it does not have to.
+
+```ts
+const rows = await store.ops.audit.tally({
+  from: startOfDay,            // inclusive, REQUIRED, and the whole window
+  kind: "tool-call",           // the same four filters audit.list narrows on
+});
+// [{ bucket: "2026-08-14T09:00:00.000Z", outcome: "ok", decidedBy: "grant", count: 12 }, …]
+```
+
+- **The same WHERE as the feed.** `kind`, `venue`, `outcome` and `decidedBy`,
+  ANDed, now named once as `AuditFilters` and shared by both audit reads on the
+  contract, on the wire and inside each backend. A tally that narrows
+  differently from the feed it sits next to is a number nobody can reconcile.
+- **`from` is required and there is no `to`.** A tally has no cursor, so the
+  floor is the only thing bounding the answer, and a caller who cannot leave it
+  out cannot ask a mount to group an append-only drawer's whole history. Every
+  tally is "since"; an upper bound is grammar no consumer has asked for and stays
+  addable later.
+- **Fixed UTC-hour buckets, no bucket grammar.** `bucket` is the instant the
+  hour starts rather than an hour-of-day number, because a number only
+  identifies a bucket inside one day and the window is whatever `from` makes it.
+  Hours holding nothing are omitted; rows sort by bucket, then outcome, then
+  decidedBy, with an absent dimension last.
+- **Rows are typed with `AuditEvent`'s own fields.** `outcome` and `decidedBy`
+  are the event's enums or `null` — a control event is not a call and has no
+  outcome, and null is a group of its own. No second copy of either enum.
+
+Served by the local engine (one `GROUP BY`), by the memory reference, and by the
+hosted client, with conformance cases both backends run. `/audit/tally` is
+declared LAST in `STORE_WIRE_PATHS`, after `/status`: `ops` is a monotone level
+over that order, and appending is the only edit to it that cannot re-date a
+number a shipped mount already reports. No pre-send capability constant — a new
+path answers its own enveloped 501.

--- a/packages/core/src/conformance/memory-store-ops.ts
+++ b/packages/core/src/conformance/memory-store-ops.ts
@@ -7,6 +7,8 @@ import {
   APP_DATA_COLLECTION_PATTERN,
   APP_DATA_OWNER_PATTERN,
   type AppDataTarget,
+  type AuditFilters,
+  type AuditTallyRow,
   type CollectionFootprint,
   type RecordInput,
   type RecordQuery,
@@ -53,6 +55,20 @@ const decodeWatermark = (after: string): { value: string; id: string } | undefin
 /** The synthetic harness appId a thread's state rides under (the store's
     `harnessStateKey`), so deleting the thread can sweep it. */
 const harnessSlot = (threadId: string): string => `harness_state:${threadId}`;
+
+/** The UTC hour an event falls in, as the instant that hour starts — the tally's
+    bucket key. */
+const hourBucket = (at: IsoDateTime): IsoDateTime => {
+  const hour = new Date(at);
+  hour.setUTCMinutes(0, 0, 0);
+  return hour.toISOString() as IsoDateTime;
+};
+
+/** Ascending, with an ABSENT dimension last: `null` is a group of its own (a
+    control event is not a call and carries no outcome), and where it sorts has
+    to be contract or two implementations answer the same window in two orders. */
+const byDimension = (a: string | null, b: string | null): number =>
+  a === b ? 0 : a === null ? 1 : b === null ? -1 : (a < b ? -1 : 1);
 
 /** Store wire v1: every list op pages at 100 by default and caps at 1000. */
 const DEFAULT_PAGE = 100;
@@ -669,8 +685,17 @@ export function memoryStoreOps(): StoreOps {
   };
 
   // ---------------------------------------------------------------------------
-  // audit — the typed read over the append-only drawer
+  // audit — the typed reads over the append-only drawer: the feed, and the
+  // same rows counted
   // ---------------------------------------------------------------------------
+
+  /** The four filters, ANDed — one copy, read by both doors, because a tally
+      that narrows differently from the feed counts rows the feed never shows. */
+  const matchesFilters = (event: AuditEvent, filters: AuditFilters): boolean =>
+    (filters.kind === undefined || event.kind === filters.kind)
+    && (filters.venue === undefined || event.venue === filters.venue)
+    && (filters.outcome === undefined || event.outcome === filters.outcome)
+    && (filters.decidedBy === undefined || event.decidedBy === filters.decidedBy);
 
   const audit: StoreOps["audit"] = {
     async list(query = {}) {
@@ -684,12 +709,35 @@ export function memoryStoreOps(): StoreOps {
       // all — none of which this shortcut changes.
       const events = page.records
         .map((record) => record.data as AuditEvent)
-        .filter((event) =>
-          (query.kind === undefined || event.kind === query.kind)
-          && (query.venue === undefined || event.venue === query.venue)
-          && (query.outcome === undefined || event.outcome === query.outcome)
-          && (query.decidedBy === undefined || event.decidedBy === query.decidedBy));
+        .filter((event) => matchesFilters(event, query));
       return { events, ...(page.cursor === undefined ? {} : { cursor: page.cursor }) };
+    },
+    // Counting, where the real backend groups in SQL. Over the WHOLE drawer and
+    // not through `list`: a page is capped at 1000 rows and a tally answers a
+    // window, so a reference that counted a page would quietly answer a
+    // different question as soon as the window outgrew one.
+    async tally(query) {
+      const from = Date.parse(query.from);
+      const groups = new Map<string, AuditTallyRow>();
+      for (const record of col("vendo_audit").values()) {
+        const event = record.data as AuditEvent;
+        // The floor is INCLUSIVE.
+        if (Date.parse(event.at) < from || !matchesFilters(event, query)) continue;
+        const row = {
+          bucket: hourBucket(event.at),
+          outcome: event.outcome ?? null,
+          decidedBy: event.decidedBy ?? null,
+          count: 1,
+        };
+        const key = `${row.bucket}|${row.outcome}|${row.decidedBy}`;
+        const group = groups.get(key);
+        if (group === undefined) groups.set(key, row);
+        else group.count += 1;
+      }
+      return [...groups.values()].sort((a, b) =>
+        (a.bucket < b.bucket ? -1 : a.bucket > b.bucket ? 1 : 0)
+        || byDimension(a.outcome, b.outcome)
+        || byDimension(a.decidedBy, b.decidedBy));
     },
   };
 

--- a/packages/core/src/conformance/store-ops.ts
+++ b/packages/core/src/conformance/store-ops.ts
@@ -1345,6 +1345,88 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         );
       }),
 
+      /** The decision tally: the same drawer, the same four filters, collapsed
+          to counts per UTC hour. Three assertions and not one deep-equal on
+          purpose — the three ways a group-by goes wrong (a bucket that never
+          arrives, a group labelled with the wrong dimension, a count that is
+          off) are three different bugs, and a case that reports them with one
+          message tells whoever it caught nothing about which. */
+      opsCase(opts, "audit.tally counts events per UTC hour, split by outcome and decidedBy", async (ops) => {
+        await seedAudit(ops, [
+          // Before the floor — and the floor is INCLUSIVE, so only this one is
+          // out of the window.
+          auditEvent("aud_t0", -30, { outcome: "ok", decidedBy: "grant" }),
+          auditEvent("aud_t1", 0, { outcome: "ok", decidedBy: "grant" }),
+          auditEvent("aud_t2", 20, { outcome: "ok", decidedBy: "grant" }),
+          auditEvent("aud_t3", 40, { outcome: "blocked", decidedBy: "denied" }),
+          auditEvent("aud_t4", 70, { outcome: "ok", decidedBy: "grant" }),
+          // A control event: not a call, so it carries neither dimension. Its
+          // group is `null`/`null` — never dropped, never merged into another.
+          auditEvent("aud_t5", 80, { kind: "policy-decision" }),
+        ]);
+        const from = new Date(Date.UTC(2026, 0, 1, 0, 0)).toISOString() as IsoDateTime;
+        const rows = await ops.audit.tally({ from });
+
+        // Ascending by bucket, one row per (hour, outcome, decidedBy) group that
+        // has events in it — and hours with none are omitted, not zero-filled.
+        assertDeepEqual(
+          rows.map((row) => row.bucket),
+          ["2026-01-01T00:00:00.000Z", "2026-01-01T00:00:00.000Z", "2026-01-01T01:00:00.000Z", "2026-01-01T01:00:00.000Z"],
+          "the tally's buckets are not the window's UTC hours, ascending",
+        );
+        // Sorted by outcome then decidedBy inside a bucket, with an absent
+        // dimension LAST.
+        assertDeepEqual(
+          rows.map((row) => `${row.outcome ?? "-"}/${row.decidedBy ?? "-"}`),
+          ["blocked/denied", "ok/grant", "ok/grant", "-/-"],
+          "the tally labelled a group with the wrong outcome or decidedBy, or ordered the groups differently",
+        );
+        assertDeepEqual(
+          rows.map((row) => row.count),
+          [1, 2, 1, 1],
+          "the tally counted the wrong number of events in a group",
+        );
+      }),
+
+      /** ONE WHERE, TWO DOORS — the case that matters more than the arithmetic.
+          A tally is only ever read next to the feed it summarises, so the two
+          have to narrow identically: nothing in an implementation forces a
+          grouped statement's filters to match a paged one's, and a tally that
+          counts rows the feed does not show (or misses rows it does) is a
+          number a reviewer cannot reconcile with what is on the screen. */
+      opsCase(opts, "audit.tally narrows on the same four filters as audit.list, ANDed", async (ops) => {
+        await seedAudit(ops, [
+          auditEvent("aud_f1", 1, { kind: "tool-call", venue: "chat", outcome: "ok", decidedBy: "grant" }),
+          auditEvent("aud_f2", 2, { kind: "approval", venue: "app", outcome: "blocked", decidedBy: "denied" }),
+          auditEvent("aud_f3", 3, { kind: "tool-call", venue: "app", outcome: "ok", decidedBy: "rule" }),
+          auditEvent("aud_f4", 4, { kind: "tool-call", venue: "chat", outcome: "blocked", decidedBy: "grant" }),
+        ]);
+        const from = new Date(Date.UTC(2026, 0, 1, 0, 0)).toISOString() as IsoDateTime;
+        const counted = async (filters: AuditQuery): Promise<number> =>
+          (await ops.audit.tally({ ...filters, from })).reduce((total, row) => total + row.count, 0);
+        const listed = async (filters: AuditQuery): Promise<number> =>
+          (await ops.audit.list(filters)).events.length;
+
+        for (const filters of [
+          {},
+          { kind: "tool-call" },
+          { venue: "app" },
+          { outcome: "ok" },
+          { decidedBy: "grant" },
+          // ANDed, never ORed: this pair drops rows either filter alone keeps.
+          { kind: "tool-call", venue: "chat" },
+          { kind: "tool-call", venue: "chat", outcome: "blocked", decidedBy: "grant" },
+        ] satisfies AuditQuery[]) {
+          const total = await counted(filters);
+          const shown = await listed(filters);
+          assert(
+            total === shown,
+            `the tally counted ${total} events where the feed shows ${shown} for ${JSON.stringify(filters)}`,
+          );
+          assert(total > 0, `the case's own fixture makes ${JSON.stringify(filters)} match nothing, so it proves nothing`);
+        }
+      }),
+
       // =====================================================================
       // secrets
       // =====================================================================

--- a/packages/core/src/store-wire.ts
+++ b/packages/core/src/store-wire.ts
@@ -66,7 +66,7 @@ export const STORE_WIRE_PATHS = {
   // that builds its mount from this table never receives an erase at all.
   "lifecycle.erase": "/erase",
   "lifecycle.promote": "/lifecycle/promote",
-  // audit (1)
+  // audit (1 of 2 — `audit.tally` is the newest op and rides the tail, below)
   "audit.list": "/audit/list",
   // secrets (4)
   "secrets.get": "/secrets/get",
@@ -83,6 +83,18 @@ export const STORE_WIRE_PATHS = {
   "retention.purge": "/retention/purge",
   // status (1)
   status: "/status",
+  // audit.tally (1) — declared AFTER `status`, which is not a filing mistake.
+  // `ops` is a monotone level over THIS order, so a number a shipped mount is
+  // already reporting must keep meaning what it meant: appending is the only
+  // edit that cannot re-date one. Slot this op anywhere earlier and every mount
+  // reporting 44 today ("everything through /status") starts claiming a tally
+  // it has never served — the renumbering hazard
+  // STORE_WIRE_APPEND_MESSAGES_OPS spells out below, arriving from the other
+  // direction. Its cost is the level's known coarseness: an engine that stops
+  // short of retention can serve this op and still not be able to say so, which
+  // is fine, because a missing op is read off its own 501 and never off the
+  // level.
+  "audit.tally": "/audit/tally",
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -327,17 +339,18 @@ export interface StoreWireAppendMessagesResult {
     the mount is behind — never send it blind and read the 501 as a fallback
     signal (#1251: a failed mutation is not a capability answer).
 
-    ⚠ AND THIS IS THE LAST CONSTANT OF ITS KIND. Ops 37-44 (audit, secrets,
-    footprint, retention) added no twin, and a future op should not either. A
-    pre-send check earns its keep only when sending blind is unsafe, and that is
-    true of exactly one shape: a MUTATION with a cheaper fallback, where a 501
-    leaves the caller unable to tell "never ran" from "ran and failed". Every one
-    of 37-44 is a new PATH, so an older mount refuses it with the enveloped 501
-    this protocol already answers unknown ops with — loud, specific, and
-    impossible to mistake for data. The one genuinely invisible addition, the
-    watermark bound on `engine.list`, is a FIELD on an existing op that
-    `.passthrough()` would let an old mount ignore in silence; it is detected by
-    the echo on its own answer (`EngineListPage.watermark`), not from here. */
+    ⚠ AND THIS IS THE LAST CONSTANT OF ITS KIND. Ops 37-45 (audit, secrets,
+    footprint, retention, the audit tally) added no twin, and a future op should
+    not either. A pre-send check earns its keep only when sending blind is
+    unsafe, and that is true of exactly one shape: a MUTATION with a cheaper
+    fallback, where a 501 leaves the caller unable to tell "never ran" from
+    "ran and failed". Every one of 37-45 is a new PATH, so an older mount
+    refuses it with the enveloped 501 this protocol already answers unknown ops
+    with — loud, specific, and impossible to mistake for data. The one
+    genuinely invisible addition, the watermark bound on `engine.list`, is a
+    FIELD on an existing op that `.passthrough()` would let an old mount ignore
+    in silence; it is detected by the echo on its own answer
+    (`EngineListPage.watermark`), not from here. */
 export const STORE_WIRE_APPEND_MESSAGES_OPS = 36;
 
 export const storeWireTranscriptsRecordAnswerRequestSchema = z.object({
@@ -438,17 +451,34 @@ export const storeWireLifecyclePromoteRequestSchema = z.object({
 // audit
 // ---------------------------------------------------------------------------
 
-/** The four filters are ANDed and every one is optional, so an empty body is
-    the whole feed, newest first. The enums are spelled here rather than
-    imported from `auditEventSchema` because this is the REQUEST, and a request
-    that names a kind this build has not heard of should be refused by the
-    mount's own validation, not silently widened. */
-export const storeWireAuditListRequestSchema = cursorQuerySchema.extend({
+/** The four filters, ANDed and every one optional — ONE copy, shared by the
+    feed and the tally the way `AuditFilters` is shared on the contract side: a
+    WHERE spelled twice is a WHERE that drifts, and a tally that counts a
+    different set of rows than the feed shows is the drift nobody can see.
+    The enums are spelled here rather than imported from `auditEventSchema`
+    because this is the REQUEST, and a request that names a kind this build has
+    not heard of should be refused by the mount's own validation, not silently
+    widened. */
+const auditFilterFields = {
   kind: z.enum(["tool-call", "approval", "policy-decision", "run", "app-lifecycle", "share", "door-auth", "principal"]).optional(),
   venue: z.enum(["chat", "app", "automation", "mcp"]).optional(),
   outcome: z.enum(["ok", "error", "pending-approval", "blocked", "connect-required"]).optional(),
   decidedBy: z.enum(["grant", "rule", "judge", "default", "confirmEach", "breaker", "denied", "org", "frozen"]).optional(),
-});
+};
+
+/** An empty body is the whole feed, newest first. */
+export const storeWireAuditListRequestSchema = cursorQuerySchema.extend(auditFilterFields);
+
+/** The tally's body: the same four filters, and `from` INSTEAD of a page.
+    A real datetime (like retention's cutoffs, unlike a watermark's opaque
+    echo): it is a window the caller authored, not a value it read back. Not
+    optional — a tally has no cursor, so this floor is the only thing bounding
+    the answer, and a body without one asks a mount to group an append-only
+    drawer's whole history. */
+export const storeWireAuditTallyRequestSchema = z.object({
+  ...auditFilterFields,
+  from: isoDateTimeSchema,
+}).passthrough();
 
 // ---------------------------------------------------------------------------
 // secrets

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -156,7 +156,7 @@ export interface StoreAdapter {
 }
 
 // ---------------------------------------------------------------------------
-// StoreOps — the named-operation contract for the 44-op / 12-family store.
+// StoreOps — the named-operation contract for the 45-op / 12-family store.
 // Both the local backend (store/ops.ts) and the cloud client
 // (hosted-store.ts) implement this interface.
 // ---------------------------------------------------------------------------
@@ -260,25 +260,31 @@ export interface EngineListPage {
 }
 
 // ---------------------------------------------------------------------------
-// audit.list — the typed read over the audit drawer
+// audit.list / audit.tally — the typed reads over the audit drawer
 // ---------------------------------------------------------------------------
 
-/** Which audit rows to read. Four filters, ANDed, all optional — the ones a
-    reviewer's feed and a decision tally actually narrow on, and no more.
+/** Which audit rows a read narrows to. Four filters, ANDed, all optional — the
+    ones a reviewer's feed and a decision tally actually narrow on, and no more.
 
     Narrowing by SUBJECT, app or tool is deliberately NOT here: those are
     `vendo_audit` ref keys and `engine.list("vendo_audit", { refs })` already
-    serves them. This op exists for the three fields that are not refs
+    serves them. These reads exist for the three fields that are not refs
     (`venue` is a column, `outcome` and `decidedBy` live inside the event) plus
     `kind`, which every real feed pairs with them.
 
     Values are the AuditEvent's own field types, so there is no second copy of
-    any of these enums to drift. */
-export interface AuditQuery {
+    any of these enums to drift. Shared by both audit reads for the same reason:
+    a WHERE the feed and the tally could spell differently is a WHERE that will,
+    and then the tally stops counting the rows the feed shows. */
+export interface AuditFilters {
   kind?: AuditEvent["kind"];
   venue?: AuditEvent["venue"];
   outcome?: NonNullable<AuditEvent["outcome"]>;
   decidedBy?: NonNullable<AuditEvent["decidedBy"]>;
+}
+
+/** {@link AuditFilters} plus the page — `audit.list`'s query. */
+export interface AuditQuery extends AuditFilters {
   cursor?: string;
   limit?: number;
 }
@@ -290,6 +296,50 @@ export interface AuditQuery {
 export interface AuditPage {
   events: AuditEvent[];
   cursor?: string;
+}
+
+/** What to count, and over what stretch of time. The same four filters the feed
+    narrows on ({@link AuditFilters}), plus the one thing a count needs that a
+    page does not: a floor.
+
+    `from` is INCLUSIVE and REQUIRED, and it is the whole of the window — there
+    is no `to`, because a tally is always "since": the rows a reviewer is
+    counting end at now, and an upper bound is grammar no consumer has asked
+    for (an optional one can be added later without breaking a caller).
+    Required rather than optional because it is this op's ONLY bound: there is
+    no cursor to page a tally, so an unbounded call scans a drawer that only
+    ever grows and answers with a row per hour it has ever held. A caller who
+    cannot leave the floor out cannot write that call by accident, and `from`
+    is also the caller's cost dial — the answer is at most one row per UTC hour
+    in the window per outcome/decidedBy pair actually seen. */
+export interface AuditTallyQuery extends AuditFilters {
+  from: IsoDateTime;
+}
+
+/** One counted group: a UTC hour, the two dimensions the count is split by, and
+    how many matching events landed in it.
+
+    `bucket` is the START of the hour as an instant, not an hour-of-day number:
+    a number only identifies a bucket inside a single day, and this window is
+    whatever the caller's `from` makes it. A consumer charting one day reads its
+    0-23 index straight off the instant.
+
+    `outcome` and `decidedBy` are NULL when the events in the group carry none —
+    a control event is not a call and has no outcome — and null is a group of
+    its own, never dropped and never merged into another. They are the
+    AuditEvent's own field types for the same reason the filters are: a second
+    copy of either enum is a second thing to drift.
+
+    Hours holding nothing are OMITTED: a group-by answers with the groups that
+    exist, and a consumer that wants a fixed 24-slot row starts with zeros and
+    fills. Rows are sorted by `bucket`, then `outcome`, then `decidedBy`,
+    ascending, with a null dimension last — "whatever order the engine grouped
+    in" is not an answer two implementations would ever give alike. */
+export interface AuditTallyRow {
+  bucket: IsoDateTime;
+  outcome: NonNullable<AuditEvent["outcome"]> | null;
+  decidedBy: NonNullable<AuditEvent["decidedBy"]> | null;
+  count: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -324,7 +374,7 @@ export type EraseTarget =
   | { subject: string; appId?: never }
   | { appId: string; subject?: never };
 
-/** The typed contract for all 44 store operations across 12 families.
+/** The typed contract for all 45 store operations across 12 families.
     Lean by design — this is the CONTRACT interface, not the implementation.
 
     Two members are OPTIONAL, and both mean the same thing: an implementation
@@ -418,11 +468,20 @@ export interface StoreOps {
         makes a create distinguishable from an overwrite in the trail. */
     history(query?: { cursor?: string; limit?: number; owner?: string; path?: string }): Promise<{ entries: unknown[]; cursor?: string }>;
   };
-  /** The audit drawer's own read. One verb, because reading is all anyone does
-      to it: `vendo_audit` is append-only, and rows leave it only through the
-      erase cascade and the retention window. */
+  /** The audit drawer's own reads — both of them reads, because reading is all
+      anyone does to it: `vendo_audit` is append-only, and rows leave it only
+      through the erase cascade and the retention window.
+
+      Two verbs and not one because a count is not a page. A reviewer's feed
+      wants the newest rows and pages through them; a decision tally wants a
+      whole window collapsed to numbers, and getting it out of `list` means
+      downloading every row in the window to count it client-side. Same drawer,
+      same four filters, two answers. */
   audit: {
     list(query?: AuditQuery): Promise<AuditPage>;
+    /** Matching events counted per UTC hour, split by outcome and decidedBy —
+        the grouped read a decision tally is, in one call. */
+    tally(query: AuditTallyQuery): Promise<AuditTallyRow[]>;
   };
   /** The store's secret vault — the values a host's connectors authenticate
       with, kept where the rest of its data is kept.

--- a/packages/core/tests/conformance/audit-tally-mutants.test.ts
+++ b/packages/core/tests/conformance/audit-tally-mutants.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { memoryStoreOps, storeOpsConformance } from "../../src/conformance/index.js";
+import type { ConformanceCase } from "../../src/conformance/index.js";
+import type { StoreOps } from "../../src/store.js";
+
+/**
+ * The two `audit.tally` cases, run against tallies that are WRONG — one broken
+ * rule at a time.
+ *
+ * A grouped read is the easiest thing in this contract to ship dead: every
+ * implementation of it returns rows that look exactly right, and the three ways
+ * it actually goes wrong (an hour that never arrives, a group filed under the
+ * wrong dimension, a count that is off) all still parse, still type-check, and
+ * still render a chart. So the cases are only worth what they CATCH, and this
+ * file is where that is proven: the shipped memory reference passes them, and
+ * each mutant below fails the one assertion written for it.
+ *
+ * A test OF the cases, not of any shipped implementation — the same job
+ * retention-pending.test.ts does for the two cases nothing serves yet.
+ */
+
+/** The reference tally, then one rule broken on the way out. Every mutant is
+ *  post-processing on the honest answer, so nothing else about the reference
+ *  changes and the case can only be failing for the reason named. */
+function withBrokenTally(
+  ops: StoreOps,
+  broken: {
+    /** The counts, mirrored across the answer: every row present, every label
+     *  right, and the arithmetic silently swapped between groups. */
+    reversesTheCounts?: true;
+    /** The last bucket never arrives — an off-by-one on a window boundary,
+     *  which is what a tally gets wrong when it gets anything wrong. */
+    dropsTheLastBucket?: true;
+    /** Every group filed under one decidedBy: the shape of a statement that
+     *  grouped on a column it did not also select. */
+    mislabelsDecidedBy?: true;
+  },
+): StoreOps {
+  return {
+    ...ops,
+    audit: {
+      ...ops.audit,
+      async tally(query) {
+        const rows = await ops.audit.tally(query);
+        if (broken.reversesTheCounts === true) {
+          const counts = rows.map((row) => row.count).reverse();
+          return rows.map((row, index) => ({ ...row, count: counts[index]! }));
+        }
+        if (broken.dropsTheLastBucket === true) {
+          const last = rows.at(-1)?.bucket;
+          return rows.filter((row) => row.bucket !== last);
+        }
+        if (broken.mislabelsDecidedBy === true) {
+          return rows.map((row) => ({ ...row, decidedBy: "rule" as const }));
+        }
+        return rows;
+      },
+    },
+  };
+}
+
+const tallyCases = (make: () => StoreOps): ConformanceCase[] =>
+  storeOpsConformance({ makeOps: async () => ({ ops: make() }) })
+    .cases.filter((conformanceCase) => conformanceCase.name.startsWith("audit.tally"));
+
+describe("the audit.tally cases catch a tally that is wrong", () => {
+  it("carries both tally cases, and neither is pending — the reference serves the op", () => {
+    const cases = tallyCases(() => memoryStoreOps());
+    expect(cases).toHaveLength(2);
+    expect(cases.every((conformanceCase) => conformanceCase.pending === undefined)).toBe(true);
+  });
+
+  for (const conformanceCase of tallyCases(() => memoryStoreOps())) {
+    it(`passes against the honest reference: ${conformanceCase.name}`, async () => {
+      await conformanceCase.run();
+    });
+  }
+
+  // The message is asserted, not just the failure: a case that goes red for an
+  // unrelated reason is not the same as a case that caught the thing it exists
+  // for, and the three assertions are split precisely so these three mutants
+  // land on three different ones.
+  it("catches a tally whose counts are right in total but wrong per group", async () => {
+    const [grouping] = tallyCases(() => withBrokenTally(memoryStoreOps(), { reversesTheCounts: true }));
+    await expect(grouping!.run()).rejects.toThrow(/counted the wrong number of events in a group/);
+  });
+
+  it("catches a tally that drops a bucket the window holds", async () => {
+    const [grouping] = tallyCases(() => withBrokenTally(memoryStoreOps(), { dropsTheLastBucket: true }));
+    await expect(grouping!.run()).rejects.toThrow(/buckets are not the window's UTC hours/);
+  });
+
+  it("catches a tally that files every group under the wrong dimension", async () => {
+    const [grouping] = tallyCases(() => withBrokenTally(memoryStoreOps(), { mislabelsDecidedBy: true }));
+    await expect(grouping!.run()).rejects.toThrow(/labelled a group with the wrong outcome or decidedBy/);
+  });
+
+  // And the filter case has its own mutant: a tally that ignores the filters it
+  // was given counts the whole drawer, which is a number that looks perfectly
+  // reasonable next to a feed nobody cross-checked.
+  it("catches a tally that ignores the filters the feed is narrowed by", async () => {
+    const unfiltered = (ops: StoreOps): StoreOps => ({
+      ...ops,
+      audit: { ...ops.audit, tally: async (query) => ops.audit.tally({ from: query.from }) },
+    });
+    const [, filters] = tallyCases(() => unfiltered(memoryStoreOps()));
+    await expect(filters!.run()).rejects.toThrow(/the tally counted \d+ events where the feed shows \d+/);
+  });
+});

--- a/packages/core/tests/store-wire.test.ts
+++ b/packages/core/tests/store-wire.test.ts
@@ -43,17 +43,18 @@ import {
   storeWireWorkspaceHistoryRequestSchema,
   storeWireLifecycleEraseRequestSchema,
   storeWireLifecyclePromoteRequestSchema,
+  storeWireAuditTallyRequestSchema,
   type EraseTarget,
   type StoreWireStatus,
 } from "../src/index.js";
 
 describe("vendo/store-wire@1", () => {
-  it("exposes the format constant and 44 mount-relative paths", () => {
+  it("exposes the format constant and 45 mount-relative paths", () => {
     expect(VENDO_STORE_WIRE_FORMAT).toBe("vendo/store-wire@1");
     // 12 families: engine(7) + blobs(4) + appData(8) + transcripts(7) + harness(3)
-    // + workspace(4) + lifecycle(2) + audit(1) + secrets(4) + footprint(1)
-    // + retention(2) + status(1) = 44
-    expect(Object.keys(STORE_WIRE_PATHS)).toHaveLength(44);
+    // + workspace(4) + lifecycle(2) + audit(2) + secrets(4) + footprint(1)
+    // + retention(2) + status(1) = 45
+    expect(Object.keys(STORE_WIRE_PATHS)).toHaveLength(45);
     expect(STORE_WIRE_PATHS.status).toBe("/status");
     expect(STORE_WIRE_PATHS["engine.get"]).toBe("/engine/get");
     expect(STORE_WIRE_PATHS["engine.compareAndSwap"]).toBe("/engine/compareAndSwap");
@@ -68,12 +69,41 @@ describe("vendo/store-wire@1", () => {
 
   // `ops` on /status is a LEVEL over this order, so an implementation that
   // stops short of the newest ops can only report an honest number when those
-  // ops are the tail. retention is the one family nothing serves yet; if a
-  // later op is ever declared after it, the local engine's 42 starts claiming
-  // ops it does not have.
+  // ops are the tail. retention is the family nothing serves yet, and the audit
+  // tally is the newest op no mount answers — both sit behind everything a
+  // shipped mount already serves.
   it("declares the ops nothing serves yet LAST, so the /status level can stay honest", () => {
     const ops = Object.keys(STORE_WIRE_PATHS).filter((op) => op !== "status");
-    expect(ops.slice(-2)).toEqual(["retention.quarantine", "retention.purge"]);
+    expect(ops.slice(-3)).toEqual(["retention.quarantine", "retention.purge", "audit.tally"]);
+  });
+
+  // The rule the tail exists for, stated as the thing that would break: a new op
+  // may only be APPENDED. Slot one in the middle and every number a mount is
+  // already reporting silently starts naming a different op — the renumbering
+  // hazard STORE_WIRE_APPEND_MESSAGES_OPS is pinned against, arriving from the
+  // other side. `status` was the 44th op when it was last the end of this list,
+  // and a mount reporting 44 means "everything through /status" forever.
+  it("keeps every already-reported level meaning what it meant, by only ever appending", () => {
+    const ops = Object.keys(STORE_WIRE_PATHS);
+    expect(ops.indexOf("status") + 1).toBe(44);
+    expect(ops.indexOf("audit.tally") + 1).toBe(45);
+  });
+
+  // The tally is the one read in this protocol with a REQUIRED argument, and
+  // the requirement is the whole design: there is no cursor to page a tally, so
+  // `from` is the only thing bounding what a mount groups. A body without one
+  // asks it to group an append-only drawer's entire history.
+  it("audit.tally's body carries the four filters and refuses to be sent without its floor", () => {
+    const tally = (body: unknown): boolean => storeWireAuditTallyRequestSchema.safeParse(body).success;
+    expect(tally({ from: "2026-08-14T00:00:00.000Z" })).toBe(true);
+    expect(tally({ from: "2026-08-14T00:00:00.000Z", kind: "tool-call", venue: "chat", outcome: "ok", decidedBy: "grant" })).toBe(true);
+    expect(tally({ kind: "tool-call" })).toBe(false);
+    // A real datetime, unlike a watermark's opaque echo: this is a window the
+    // caller authored, not a value it read back off a page.
+    expect(tally({ from: "yesterday" })).toBe(false);
+    // The same four enums as the feed, refused the same way — one copy of them
+    // on the wire, so the two doors cannot come to narrow differently.
+    expect(tally({ from: "2026-08-14T00:00:00.000Z", outcome: "allowed" })).toBe(false);
   });
 
   describe("engine.list's watermark bound", () => {

--- a/packages/store/src/hosted-store.ts
+++ b/packages/store/src/hosted-store.ts
@@ -1,5 +1,6 @@
 import {
   type AuditEvent,
+  type AuditTallyRow,
   type BlobStore,
   cloudStandingError,
   type CollectionFootprint,
@@ -78,7 +79,7 @@ export interface HostedStore extends VendoStore {
     bySubject(subject: string): Promise<EraseReport>;
     byApp(appId: string): Promise<EraseReport>;
   };
-  /** The 44-op named-operation surface over the same mount and the same key —
+  /** The 45-op named-operation surface over the same mount and the same key —
    * `vendo/store-wire@1` (see {@link hostedStoreOps}). The StoreAdapter doors
    * above are built ON these ops: engine for Vendo's own collections, appData
    * for an app's own drawers. */
@@ -164,7 +165,7 @@ export function hostedStore(options: HostedStoreOptions): HostedStore {
   };
   const sendJson = postJson(send);
 
-  // The StoreAdapter façade rides the SAME 44 ops as `ops` below — it has no
+  // The StoreAdapter façade rides the SAME 45 ops as `ops` below — it has no
   // doors of its own since the generic records family left the wire. A
   // collection (or blob namespace) either names an app's own drawer, which the
   // appData family serves with the owner stamped on, or it names one of Vendo's
@@ -281,15 +282,15 @@ export function hostedStore(options: HostedStoreOptions): HostedStore {
 }
 
 // ---------------------------------------------------------------------------
-// The 44-op StoreOps client — store design v1, `vendo/store-wire@1`
+// The 45-op StoreOps client — store design v1, `vendo/store-wire@1`
 // ---------------------------------------------------------------------------
 
-/** The 44 named ops — STORE_WIRE_PATHS' keys ARE the op names, and stay the
+/** The 45 named ops — STORE_WIRE_PATHS' keys ARE the op names, and stay the
  * op names even where the console's door sits at a different path. */
 type StoreWireOp = keyof typeof STORE_WIRE_PATHS;
 
 /** Measurement instrument, not a feature: with VENDO_STORE_TRACE set, every
- * call through the store client below — the 44 ops AND the StoreAdapter façade,
+ * call through the store client below — the 45 ops AND the StoreAdapter façade,
  * which rides the same client — emits one greppable stderr line naming the op,
  * its path, the round trip in milliseconds (the body read included, since that
  * is what the caller waits for), the response size in bytes and the outcome.
@@ -355,7 +356,7 @@ const raiseWireError = async (response: Response): Promise<never> => {
 };
 
 /**
- * The Cloud client for the whole 44-op store contract, speaking
+ * The Cloud client for the whole 45-op store contract, speaking
  * `vendo/store-wire@1` over the console's store mount: bearer key, deployment
  * identity and per-request abort budget shared with {@link hostedStore}, the
  * same adapter rule (behavior comes ONLY from the constructor arguments),
@@ -779,9 +780,11 @@ function storeWireClient(
         await mutate("lifecycle.promote", P["lifecycle.promote"], { appId, orgId });
       },
     },
-    // The audit drawer's one read, and the only door that answers with the type
-    // it stores: `vendo_audit`'s rows ARE AuditEvents, so handing back records
-    // would put a cast at every call site instead of one here.
+    // The audit drawer's reads. `list` is the only door that answers with the
+    // type it stores — `vendo_audit`'s rows ARE AuditEvents, so handing back
+    // records would put a cast at every call site instead of one here — and
+    // `tally` is the same drawer counted rather than paged, which is the one
+    // shape a client cannot assemble from `list` without downloading the window.
     audit: {
       async list(query) {
         const payload = await post("audit.list", P["audit.list"], { ...query });
@@ -789,6 +792,10 @@ function storeWireClient(
           events: field<AuditEvent[]>(payload, "events", "invalid audit page", Array.isArray),
           ...cursorOf(payload),
         };
+      },
+      async tally(query) {
+        const payload = await post("audit.tally", P["audit.tally"], { ...query });
+        return field<AuditTallyRow[]>(payload, "rows", "invalid audit tally", Array.isArray);
       },
     },
     // `get` is the one read in this protocol that answers with a CREDENTIAL. The

--- a/packages/store/src/ops.ts
+++ b/packages/store/src/ops.ts
@@ -3,8 +3,11 @@ import {
   VENDO_STORE_WIRE_FORMAT,
   VendoError,
   type AuditEvent,
+  type AuditFilters,
   type AuditPage,
   type AuditQuery,
+  type AuditTallyQuery,
+  type AuditTallyRow,
   type FilesAdapter,
   type Json,
   type RecordStore,
@@ -102,10 +105,32 @@ const commitEntries = (commit: VendoRecord): WorkspaceEntry[] =>
 const commitTouches = (commit: VendoRecord, path: string): boolean =>
   commitEntries(commit).some((entry) => entry.path === path);
 
-/** `audit.list`'s statement (01 §12 `AuditQuery`). `kind` and `venue` are real
- *  columns; `outcome` and `decidedBy` are not — they live inside the stored
- *  event, so they are read out of the jsonb. Every filter is optional and they
- *  AND together, so an empty query is the whole feed.
+/** The four filters both audit doors narrow on (01 §12 `AuditFilters`), as the
+ *  WHERE and its bind parameters. `kind` and `venue` are real columns;
+ *  `outcome` and `decidedBy` are not — they live inside the stored event, so
+ *  they are read out of the jsonb. Every filter is optional and they AND
+ *  together, so no filter at all is the whole drawer.
+ *
+ *  ONE copy, shared by the feed and the tally: a grouped statement that spells
+ *  this WHERE its own way counts rows the feed never shows, and a reviewer
+ *  reconciling the tally against the feed has no way to tell which one lied.
+ *  Each door appends its own remaining clause (a cursor, a floor) to what comes
+ *  back. */
+function auditWhere(filters: AuditFilters): { params: unknown[]; clauses: string[] } {
+  const params: unknown[] = [];
+  const clauses: string[] = [];
+  const add = (sql: string, value: unknown): void => {
+    params.push(value);
+    clauses.push(sql.replace("?", `$${params.length}`));
+  };
+  if (filters.kind !== undefined) add("kind = ?", filters.kind);
+  if (filters.venue !== undefined) add("venue = ?", filters.venue);
+  if (filters.outcome !== undefined) add("event->>'outcome' = ?", filters.outcome);
+  if (filters.decidedBy !== undefined) add("event->>'decidedBy' = ?", filters.decidedBy);
+  return { params, clauses };
+}
+
+/** `audit.list`'s statement (01 §12 `AuditQuery`).
  *
  *  The ordering and the cursor are the routed `vendo_audit` door's, verbatim
  *  (cursorMs, ORDER BY the truncated instant then id, over-fetch by one): both
@@ -113,16 +138,7 @@ const commitTouches = (commit: VendoRecord, path: string): boolean =>
  *  same place in the other. */
 async function auditPage(db: Db, query: AuditQuery): Promise<AuditPage> {
   const limit = pageLimit(query.limit);
-  const params: unknown[] = [];
-  const clauses: string[] = [];
-  const add = (sql: string, value: unknown): void => {
-    params.push(value);
-    clauses.push(sql.replace("?", `$${params.length}`));
-  };
-  if (query.kind !== undefined) add("kind = ?", query.kind);
-  if (query.venue !== undefined) add("venue = ?", query.venue);
-  if (query.outcome !== undefined) add("event->>'outcome' = ?", query.outcome);
-  if (query.decidedBy !== undefined) add("event->>'decidedBy' = ?", query.decidedBy);
+  const { params, clauses } = auditWhere(query);
   if (query.cursor !== undefined) {
     const cursor = decodeCursor(query.cursor);
     params.push(cursor.c, cursor.i);
@@ -144,6 +160,43 @@ async function auditPage(db: Db, query: AuditQuery): Promise<AuditPage> {
       ? { cursor: encodeCursor(iso(last["at"]), text(last["id"])) }
       : {}),
   };
+}
+
+/** `audit.tally`'s statement (01 §12 `AuditTallyQuery`): the feed's WHERE plus
+ *  an inclusive floor, grouped into UTC hours and split by the two dimensions a
+ *  decision tally reads.
+ *
+ *  `date_trunc`'s 3-ARG form, like `cursorMs` and for the same reason: the
+ *  2-arg form buckets in whatever the session's TimeZone happens to be, so the
+ *  same drawer would tally into different hours on two connections. The bucket
+ *  is named in UTC because the contract says UTC.
+ *
+ *  No LIMIT and no cursor: `from` is the bound, and the answer is one row per
+ *  hour actually holding events per pair actually seen. Empty hours never
+ *  become rows — a GROUP BY answers with the groups that exist. */
+async function auditTally(db: Db, query: AuditTallyQuery): Promise<AuditTallyRow[]> {
+  const { params, clauses } = auditWhere(query);
+  params.push(query.from);
+  clauses.push(`at >= $${params.length}`);
+  const result = await db.query(
+    `SELECT date_trunc('hour', at, 'UTC') AS bucket,
+            event->>'outcome' AS outcome,
+            event->>'decidedBy' AS decided_by,
+            count(*) AS count
+       FROM vendo_audit WHERE ${clauses.join(" AND ")}
+      GROUP BY 1, 2, 3
+      ORDER BY 1, 2, 3`,
+    params,
+  );
+  // ORDER BY puts NULLs last by default, which IS the contract's order (an
+  // absent dimension sorts after every present one) — not an accident to
+  // preserve by luck. `count(*)` is a bigint and arrives as a string.
+  return result.rows.map((row) => ({
+    bucket: iso(row["bucket"]),
+    outcome: (row["outcome"] ?? null) as AuditTallyRow["outcome"],
+    decidedBy: (row["decided_by"] ?? null) as AuditTallyRow["decidedBy"],
+    count: Number(row["count"]),
+  }));
 }
 
 const encoder = new TextEncoder();
@@ -712,14 +765,19 @@ export function createStoreOps(
     },
 
     // -----------------------------------------------------------------------
-    // audit — one verb, because reading is all anyone does to an append-only
-    // drawer. The filters that ARE refs (subject, app, tool) are already served
-    // by engine.list("vendo_audit", { refs }); this door exists for the ones
-    // that are not.
+    // audit — two verbs, both READS, because reading is all anyone does to an
+    // append-only drawer. The filters that ARE refs (subject, app, tool) are
+    // already served by engine.list("vendo_audit", { refs }); this door exists
+    // for the ones that are not. `tally` is the same WHERE grouped rather than
+    // paged: a decision tally read through `list` means shipping every row in
+    // the window across the wire to count it at the other end.
     // -----------------------------------------------------------------------
     audit: {
       async list(query = {}) {
         return await auditPage(db, query);
+      },
+      async tally(query) {
+        return await auditTally(db, query);
       },
     },
 
@@ -823,11 +881,17 @@ export function createStoreOps(
     },
 
     async status() {
-      // 42 of STORE_WIRE_PATHS' 44: `ops` is a LEVEL over that list's declared
+      // 42 of STORE_WIRE_PATHS' 45: `ops` is a LEVEL over that list's declared
       // order, and the two this engine does not serve — retention.quarantine and
       // retention.purge — are declared last for exactly this reason, so the
       // level stops honestly at footprint instead of claiming a family that is
       // absent from the object above.
+      //
+      // It stops there DESPITE serving audit.tally, the op declared past them:
+      // a level is a prefix and cannot say "all but the two in the middle". The
+      // number is unchanged rather than raised, because a raised one would
+      // claim the retention family this engine still has nowhere to quarantine
+      // to. A caller learns about a missing op from its own 501, never here.
       return { format: VENDO_STORE_WIRE_FORMAT, ops: 42 };
     },
   };

--- a/packages/store/tests/hosted-store.test.ts
+++ b/packages/store/tests/hosted-store.test.ts
@@ -16,6 +16,7 @@ import {
   storeWireAppDataPutFileRequestSchema,
   storeWireAppDataPutRequestSchema,
   storeWireAuditListRequestSchema,
+  storeWireAuditTallyRequestSchema,
   storeWireBlobsDeleteRequestSchema,
   storeWireBlobsGetRequestSchema,
   storeWireBlobsListRequestSchema,
@@ -616,7 +617,7 @@ describe("demo-host journey through the store seam", () => {
 });
 
 // ---------------------------------------------------------------------------
-// hostedStoreOps — the 44-op client over `vendo/store-wire@1`.
+// hostedStoreOps — the 45-op client over `vendo/store-wire@1`.
 //
 // Unit tests over an injected fake fetch: they pin the route, the request body
 // and the response decoding for every op — engine, appData and blobs against the
@@ -647,7 +648,7 @@ const wireRecord = {
  * `lifecycle.erase` came to declare a route no mount has ever served. `keyed`
  * marks the mutations that carry an Idempotency-Key.
  *
- * 43 of STORE_WIRE_PATHS' 44: `transcripts.appendMessages` is the one op a
+ * 44 of STORE_WIRE_PATHS' 45: `transcripts.appendMessages` is the one op a
  * client feature-detects before sending (STORE_WIRE_APPEND_MESSAGES_OPS), so it
  * is driven where that detection is — thread-messages.batch.test.ts — rather
  * than blind through this walker. */
@@ -698,6 +699,9 @@ const DOORS: Record<string, { method: string; path: string; keyed?: true }> = {
   "retention.quarantine": { method: "POST", path: P["retention.quarantine"], keyed: true },
   "retention.purge": { method: "POST", path: P["retention.purge"], keyed: true },
   status: { method: "GET", path: P.status },
+  // Last, because the manifest declares it last — appending is the only edit to
+  // that order which cannot re-date a level a mount already reports.
+  "audit.tally": { method: "POST", path: P["audit.tally"] },
 };
 
 const door = (op: string): string => `${DOORS[op]!.method} ${DOORS[op]!.path}`;
@@ -776,6 +780,9 @@ const ALL_BODIES: Record<string, unknown> = {
   [door("retention.quarantine")]: { moved: 3 },
   [door("retention.purge")]: { purged: 2 },
   [door("status")]: { format: "vendo/store-wire@1", ops: 35 },
+  [door("audit.tally")]: {
+    rows: [{ bucket: "2026-08-14T09:00:00.000Z", outcome: "ok", decidedBy: "grant", count: 4 }],
+  },
 };
 
 /** Where an appData op lands: the app, the collection it invented, and the
@@ -833,23 +840,26 @@ const driveEveryOp = async (ops: ReturnType<typeof wireFake>["ops"]): Promise<vo
   await ops.retention!.quarantine("vendo_runs", "2026-01-01T00:00:00.000Z");
   await ops.retention!.purge("vendo_runs", "2026-01-01T00:00:00.000Z");
   await ops.status();
+  await ops.audit.tally({ from: "2026-01-01T00:00:00.000Z" });
 };
 
-describe("hostedStoreOps — the 44-op wire client", () => {
-  it("routes 43 of the 44 ops to the console's real door, with a key on exactly the mutations", async () => {
+describe("hostedStoreOps — the 45-op wire client", () => {
+  it("routes 44 of the 45 ops to the console's real door, with a key on exactly the mutations", async () => {
     const { calls, ops } = wireFake(ALL_BODIES);
     await driveEveryOp(ops);
 
     const expected = Object.values(DOORS);
-    expect(calls).toHaveLength(43);
+    expect(calls).toHaveLength(44);
     expect(calls.map((call) => `${call.method} ${call.path}`))
       .toEqual(expected.map((route) => `${route.method} ${route.path}`));
     expect(calls.map((call) => call.idempotencyKey === null ? "read" : "keyed"))
       .toEqual(expected.map((route) => route.keyed === true ? "keyed" : "read"));
-    // 24 mutations, 19 reads — and the /status handshake is the one GET with
+    // 24 mutations, 20 reads — and the /status handshake is the one GET with
     // no body at all.
     expect(expected.filter((route) => route.keyed === true)).toHaveLength(24);
-    expect(calls.at(-1)).toMatchObject({ path: P.status, method: "GET", body: undefined });
+    expect(calls.filter((call) => call.method === "GET")).toEqual([
+      expect.objectContaining({ path: P.status, method: "GET", body: undefined }),
+    ]);
     // Distinct keys across distinct operations (one per logical mutation).
     const keys = calls.map((call) => call.idempotencyKey).filter((key) => key !== null);
     expect(new Set(keys).size).toBe(24);
@@ -1083,27 +1093,37 @@ describe("hostedStoreOps — the 44-op wire client", () => {
     });
     expect(calls[0]!.body).toEqual({ kind: "tool-call", outcome: "blocked", limit: 25 });
 
+    // The tally sends the same filters flat, with `from` where the page keys
+    // would be, and reads its answer off `rows` — a bare list, like footprint's:
+    // a tally answers a whole window, so there is no page to wrap it in.
+    expect(await ops.audit.tally({ from: "2026-08-14T00:00:00.000Z", kind: "tool-call" })).toEqual([
+      { bucket: "2026-08-14T09:00:00.000Z", outcome: "ok", decidedBy: "grant", count: 4 },
+    ]);
+    expect(calls[1]!.body).toEqual({ from: "2026-08-14T00:00:00.000Z", kind: "tool-call" });
+    expect(calls[1]!.idempotencyKey).toBeNull();
+
     expect(await ops.secrets.get("stripe_key")).toBe("shhh");
-    expect(calls[1]!.body).toEqual({ name: "stripe_key" });
+    expect(calls[2]!.body).toEqual({ name: "stripe_key" });
     // The value crosses in the clear under TLS; the mount encrypts at rest.
     await ops.secrets.set("stripe_key", "sk_live_1");
-    expect(calls[2]!.body).toEqual({ name: "stripe_key", value: "sk_live_1" });
+    expect(calls[3]!.body).toEqual({ name: "stripe_key", value: "sk_live_1" });
     expect(await ops.secrets.list()).toEqual(["stripe_key"]);
-    expect(calls[3]!.body).toEqual({});
+    expect(calls[4]!.body).toEqual({});
     await ops.secrets.delete("stripe_key");
-    expect(calls[4]!.body).toEqual({ name: "stripe_key" });
+    expect(calls[5]!.body).toEqual({ name: "stripe_key" });
 
     expect(await ops.footprint()).toEqual([{ collection: "vendo_runs", kind: "storage", bytes: 4096 }]);
-    expect(calls[5]!.body).toEqual({});
+    expect(calls[6]!.body).toEqual({});
 
     expect(await ops.retention!.quarantine("vendo_runs", "2026-01-01T00:00:00.000Z")).toEqual({ moved: 3 });
-    expect(calls[6]!.body).toEqual({ collection: "vendo_runs", olderThan: "2026-01-01T00:00:00.000Z" });
+    expect(calls[7]!.body).toEqual({ collection: "vendo_runs", olderThan: "2026-01-01T00:00:00.000Z" });
     // The purge cutoff is on the QUARANTINE time, not on the row's own age.
     expect(await ops.retention!.purge("vendo_runs", "2026-02-01T00:00:00.000Z")).toEqual({ purged: 2 });
-    expect(calls[7]!.body).toEqual({ collection: "vendo_runs", quarantinedBefore: "2026-02-01T00:00:00.000Z" });
+    expect(calls[8]!.body).toEqual({ collection: "vendo_runs", quarantinedBefore: "2026-02-01T00:00:00.000Z" });
 
     const CONTRACT: [keyof typeof P, { safeParse(value: unknown): { success: boolean } }][] = [
       ["audit.list", storeWireAuditListRequestSchema],
+      ["audit.tally", storeWireAuditTallyRequestSchema],
       ["secrets.get", storeWireSecretsGetRequestSchema],
       ["secrets.set", storeWireSecretsSetRequestSchema],
       ["secrets.list", storeWireSecretsListRequestSchema],


### PR DESCRIPTION
`audit.tally` — the 45th store op, and the grouped read the console's decision
tally already is.

## Why

The console's Guard page counts calls per hour, split by outcome and by the
layer that decided, over one UTC day. It cannot ask StoreOps for that today, so
`readTallyFromStore` reaches around the contract into raw SQL
(`apps/console/lib/guard/service.ts`: `GROUP BY date_part('hour', …), outcome,
decidedBy`). The op that would replace it did not exist, because a tally is not
a page: getting it out of `audit.list` means shipping every event in the window
across the wire and counting it at the other end. This is that op, so the fence
allowlist can lose the entry.

## The signature

```ts
audit: {
  list(query?: AuditQuery): Promise<AuditPage>;
  tally(query: AuditTallyQuery): Promise<AuditTallyRow[]>;
}

interface AuditFilters { kind?; venue?; outcome?; decidedBy? }   // shared
interface AuditQuery      extends AuditFilters { cursor?; limit? }
interface AuditTallyQuery extends AuditFilters { from: IsoDateTime }
interface AuditTallyRow {
  bucket: IsoDateTime;                                  // start of the UTC hour
  outcome: NonNullable<AuditEvent["outcome"]> | null;
  decidedBy: NonNullable<AuditEvent["decidedBy"]> | null;
  count: number;
}
```

Every choice, one line each:

- **Filters reused, not re-spelled.** The four are now `AuditFilters`, shared by
  both reads on the contract, on the wire (`auditFilterFields`) and inside each
  backend (`auditWhere` in the engine, `matchesFilters` in the reference) — a
  tally that narrows differently from the feed it sits beside is a number
  nobody can reconcile.
- **`from` required, inclusive, and no `to`.** The consumer bounds with
  `at >= dayStart` and nothing else, so that is the whole bound the contract
  expresses honestly; required because a tally has no cursor, so the floor is
  the *only* thing bounding the answer, and a caller who cannot omit it cannot
  ask a mount to group an append-only drawer's entire history by accident. An
  optional `to` stays addable later without breaking anyone.
- **Fixed UTC-hour buckets.** The consumer needs hours; nothing needs a bucket
  grammar, so there isn't one.
- **`bucket` is an instant, not an hour-of-day number.** A 0-23 number only
  identifies a bucket inside one day, and the window is whatever `from` makes
  it. A day-scoped consumer reads its index straight off the instant.
- **Grouped dimensions are fixed at outcome × decidedBy.** Exactly what the
  tally splits by; a `groupBy` argument would be grammar nobody asked for.
- **`null`, not absent, for a dimension the events lack.** A control event is
  not a call and carries no outcome; null is a group of its own, never dropped
  and never merged (the console already renders it as "unknown").
- **Empty hours omitted, rows sorted** by bucket, then outcome, then decidedBy,
  with a null dimension last — "whatever order the engine grouped in" is not an
  answer two implementations would give alike.
- **A bare array**, like `footprint()`: a tally answers a whole window, so there
  is no page to wrap it in. Over the wire the answer is `{ rows: [...] }`.

## Wire placement

`/audit/tally` is declared **last** in `STORE_WIRE_PATHS`, after `/status`.
`status().ops` is a monotone level over that declared order, so appending is the
only edit to it that cannot re-date a number a shipped mount already reports:
slot the op anywhere earlier and every mount reporting 44 today ("everything
through /status") starts claiming a tally it has never served — the same
renumbering hazard `STORE_WIRE_APPEND_MESSAGES_OPS` is pinned against, from the
other direction. The cost is the level's known coarseness: the local engine
serves the tally and still reports 42, because it stops short of retention and a
prefix cannot say "all but the two in the middle". That is fine — a missing op is
read off its own enveloped 501, never off the level. **No new pre-send
constant**, per the rule in that comment: this is a new PATH, not a field on an
existing op.

## Implementations

- **Local engine** (`packages/store/src/ops.ts`) — one `GROUP BY` with
  `date_trunc`'s 3-arg form, like `cursorMs` and for the same reason: the 2-arg
  form buckets in whatever the session's TimeZone happens to be.
- **Memory reference** (`packages/core/src/conformance/memory-store-ops.ts`) —
  counts over the whole drawer rather than through `list`, whose page caps at
  1000.
- **Hosted client** (`packages/store/src/hosted-store.ts`) — filters flat on the
  body beside `from`, answer read off `rows`. Shipped without a capability check
  for the reason retention was: a mount that lacks the path answers the
  enveloped 501 the client turns into a refusal naming the op.

## Tests

Two conformance cases both backends run, with **three separate assertions** so
the three ways a group-by goes wrong report as three different failures — and a
mutant suite (`packages/core/tests/conformance/audit-tally-mutants.test.ts`)
proving each one actually goes red: counts reversed between groups, a bucket
dropped, every group mislabelled, and filters ignored. The SQL was falsified the
same way — swapping `date_trunc('hour', …)` for `'day'` turns the local-engine
case red on the bucket assertion, and only that one.

Local gate green on the touched scope: `pnpm build && pnpm test:affected &&
pnpm typecheck && pnpm lint`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `audit.tally`, a grouped read that returns the decision tally as counts per UTC hour by outcome and decidedBy. This replaces the console’s raw SQL tally and moves the work behind StoreOps.

Old: the console grouped `audit` events via SQL; New: `ops.audit.tally` serves the tally with the same filters as `audit.list`; Side effects: the wire manifest grows to 45 ops with `/audit/tally` appended after `/status`.

- Contract: `audit.tally(query: AuditTallyQuery): Promise<AuditTallyRow[]>` with shared `AuditFilters`; `from` is required and inclusive; fixed UTC-hour buckets; `outcome`/`decidedBy` can be null; rows sort by bucket, then outcome, then decidedBy; returns a bare array.
- Wire: adds `"/audit/tally"` to `STORE_WIRE_PATHS` after `"/status"` to keep `status().ops` monotone; no new pre-send capability check; older mounts reply 501; total ops = 45.
- Backends: local engine uses a single `GROUP BY` with `date_trunc('hour', …, 'UTC')`; memory reference counts the whole drawer; hosted client posts filters plus `from` and reads `rows`.
- Tests: two conformance cases (grouping and filter parity) and a mutant suite that turns them red for miscounts, missing buckets, mislabelled groups, and ignored filters.

<sup>Written for commit db271505672502fc04d1a6609e6c94bd7072cc9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

