### PR TITLE
test(core,store): the conformance kit races, and six divergences close

### DIFF
--- a/.changeset/storeops-conformance-hardening.md
+++ b/.changeset/storeops-conformance-hardening.md
@@ -37,6 +37,15 @@ early on a mount that omitted them, which the report counted as a PASS — "this
 mount has no batch append" and "this mount's batch append is correct" were the
 same green line, and a whole family could be dropped invisibly.
 
+Two consequences of that landing alongside the retention engine: the memory
+reference now serves every op the manifest declares, so its `status()` reports
+`Object.keys(STORE_WIRE_PATHS).length` rather than a literal that goes stale the
+day an op is added; and its `lifecycle.erase` sweeps quarantined rows on BOTH
+legs, matching the subject and app id the local backend copies onto every lifted
+row. Without that second one a retention lift is a way for data to outlive an
+erasure — the reference would have disagreed with the only shipped engine on the
+one cascade nobody gets to re-run.
+
 **`transcripts.appendMessages`** gains cases for batch ordering after the tail,
 edit-by-id in place without moving the message, the refusals (an empty batch,
 two messages under one id), the thread it creates when the id is new, and a

--- a/.changeset/storeops-conformance-hardening.md
+++ b/.changeset/storeops-conformance-hardening.md
@@ -1,0 +1,93 @@
+---
+"@vendoai/core": minor
+"@vendoai/store": minor
+---
+
+The StoreOps conformance kit stops being a sequential kit, and six places where
+the three implementations disagreed are closed. A second implementation of the
+contract can no longer pass the suite while being wrong about concurrency,
+tenancy, or the batch append.
+
+**Races.** Every atomic op in the contract was proven by two calls in sequence,
+and a sequence cannot see the window a concurrent caller lands in: a
+read-then-write with no atomicity underneath passes every sequential case ever
+written and loses one of two simultaneous writers in production. `engine.claim`,
+`engine.insertIfAbsent`, `engine.compareAndSwap`, `workspace.commit`'s
+compare-and-swap and a double-fired idempotency key are now fired at one instant
+with `Promise.all`. Nothing asserts which caller won — either winning is
+correct — only that exactly one did and that the row the store kept is the row
+that winner was handed. The double-fire asserts what the contract actually
+promises and no more: `IdempotencyLedger` guarantees REPLAY protection, not
+mutual exclusion, so two concurrent requests carrying one key may both execute;
+what may not happen is a third request, after the key has an answer, applying
+anything.
+
+**Tenancy.** `StoreOpsConformanceOptions.makeNeighbour` is a second handle on
+the same physical store bound to a different tenant. Supply it and one case
+proves records, blobs, app rows, threads, secrets and workspace files stay
+apart in both directions, and that one tenant's `lifecycle.erase` cannot reach
+the other's. A single-tenant store leaves it off and the case reports as
+OMITTED, never as a pass.
+
+**Omissions are counted.** `ConformanceCase.run` may now resolve to
+`{ omitted: reason }`, and `ConformanceReport` gains an `omitted` bucket, so
+`passed + pending + omitted + failures === cases`. The cases over the two
+optional members (`transcripts.appendMessages`, `retention`) used to `return`
+early on a mount that omitted them, which the report counted as a PASS — "this
+mount has no batch append" and "this mount's batch append is correct" were the
+same green line, and a whole family could be dropped invisibly.
+
+**`transcripts.appendMessages`** gains cases for batch ordering after the tail,
+edit-by-id in place without moving the message, the refusals (an empty batch,
+two messages under one id), the thread it creates when the id is new, and a
+revision that moves on every batch including an edit. The memory reference now
+serves the op (and reports op level 36) so the kit has a complete reference to
+run them against.
+
+**Untested branches now covered:** `engine.claim`'s no-replacement delete form,
+`engine.list`'s ref filter (exact containment, ANDed), `appData.list`
+pagination with the owner scope re-applied on every page, `appData`'s
+per-appId isolation, blob namespace isolation on every verb,
+`lifecycle.erase({ appId })`, the `$vendoWorkspaceBytes` envelope round-tripping
+untouched, and the commit conflict's `detail.conflicts`.
+
+**Divergences closed**, each because two of three implementations already
+agreed and the third was the outlier:
+
+- `transcripts.getThread`'s `cursor`/`limit` are **removed** from the contract,
+  the wire schema and the cloud client. They arrived by pattern-cloning the list
+  ops, were implemented by nobody, and were marshalled blind by the client — a
+  caller that passed `{ limit: 50 }` got the whole transcript back and no way to
+  notice. They cannot be implemented as declared either: the answer is one
+  `VendoRecord`, which has nowhere to carry a next-page cursor, so a windowed
+  read could never say there is more. Paging a transcript needs an op whose
+  answer has room for one. `.passthrough()` means a client still sending them is
+  read, not refused.
+- **Zero-byte blobs** are content, not absence. The wire's `bytes` field
+  required a non-empty base64 string, so an empty file was refused by the client
+  while both local implementations stored it happily — and the caller's `get`
+  then answered null exactly as it would for a key nobody wrote.
+- **`workspace.read([])` answers `{}`** and **`workspace.commit([])` is refused
+  as `validation`**, everywhere. Reading nothing has exactly one answer; an
+  empty commit has none (a commit id and a trail entry for a change nobody
+  made, or silence), and the wire had always refused it while the local half
+  accepted it.
+- **`transcripts.appendMessages([])` is refused as `validation`**, matching the
+  wire. The SQL half accepted it and bumped the thread's revision — and would
+  CREATE a thread — on a call that landed no messages.
+- **`VendoError.detail` crosses the wire.** The error envelope carried a code
+  and a message, so every structured payload a refusal carried was readable
+  locally and lost to a hosted caller: `workspace.commit`'s conflict names the
+  paths that moved, and the hosted path had to re-read the whole index and
+  re-derive them by hand. `detail` is optional and passed through untouched.
+- **`workspace.commit`'s idempotency ledger is scoped to the owner.** The row id
+  was built from the key alone, so two owners picking the same key — which
+  clients do routinely — had one owner's commit answered out of the other's
+  ledger row, as a replay when the bodies matched and as a `conflict` when they
+  did not. This is the rule `IdempotencyScope`'s `tenant` field already states.
+
+The hosted workspace's owner-defaulting divergence is **pinned, not fixed**: the
+local implementations resolve an omitted `owner` to a bound constant and the
+cloud client defers it to the mount, whose default lives in the console where
+OSS cannot see it. A new case pins what every mount owes regardless — that the
+default drawer is ONE drawer on all four verbs.

--- a/packages/core/src/conformance/index.ts
+++ b/packages/core/src/conformance/index.ts
@@ -35,6 +35,24 @@ export { memoryAppAccess, type MemoryAppAccess } from "./memory-app-access.js";
  * One executable seam assertion. Cases throw on failure and can be mounted in any
  * test framework, for example: `for (const c of suite.cases) it(c.name, c.run)`.
  */
+/**
+ * What a case answers when the mount does not serve the OPTIONAL member the
+ * case covers (`transcripts.appendMessages`, `retention`, a second tenant).
+ *
+ * RETURNED, never thrown: omitting an optional member is legal, so it is not a
+ * failure. It is not a PASS either, and that is the whole point — a case that
+ * simply `return`ed on an absent member made "this mount does not serve the op"
+ * and "this mount serves the op correctly" the same green line, so an
+ * implementation could drop a whole family and never appear to. An omission is
+ * counted in its own bucket instead, named and reasoned, so it has to be read.
+ */
+export interface ConformanceOmission {
+  omitted: string;
+}
+
+/** Spells {@link ConformanceOmission} at a case's return site. */
+export const omitted = (reason: string): ConformanceOmission => ({ omitted: reason });
+
 export interface ConformanceCase {
   name: string;
   /**
@@ -54,7 +72,10 @@ export interface ConformanceCase {
    * deleting this one field.
    */
   pending?: string;
-  run(): Promise<void>;
+  /** Throws on failure. Resolves to a {@link ConformanceOmission} when the
+      mount does not serve the optional member this case covers, and to nothing
+      when it ran. */
+  run(): Promise<void | ConformanceOmission>;
 }
 
 /** A framework-agnostic collection of executable assertions for one core seam. */
@@ -64,13 +85,17 @@ export interface ConformanceSuite {
 }
 
 /** The serializable result of executing every case in a conformance suite.
-    `pending` names the cases that were carried but not run; `ok` is keyed off
-    failures alone, because a pending case is a promise nobody has made yet, not
-    a broken one. */
+    `pending` names the cases that were carried but not run; `omitted` names the
+    ones that ran and found the optional member they cover absent. `ok` is keyed
+    off failures alone, because neither a promise nobody has made yet nor a
+    legally unserved family is a broken one.
+    Every case lands in exactly one bucket: `passed + pending.length +
+    omitted.length + failures.length === cases.length`. */
 export interface ConformanceReport {
   seam: string;
   passed: number;
   pending: string[];
+  omitted: Array<{ name: string; reason: string }>;
   failures: Array<{ name: string; error: string }>;
   ok: boolean;
 }
@@ -78,6 +103,7 @@ export interface ConformanceReport {
 /** Executes all cases without stopping at the first failure. */
 export async function runConformance(suite: ConformanceSuite): Promise<ConformanceReport> {
   const failures: ConformanceReport["failures"] = [];
+  const omissions: ConformanceReport["omitted"] = [];
   const pending: string[] = [];
   let passed = 0;
   for (const conformanceCase of suite.cases) {
@@ -86,8 +112,9 @@ export async function runConformance(suite: ConformanceSuite): Promise<Conforman
       continue;
     }
     try {
-      await conformanceCase.run();
-      passed += 1;
+      const answer = await conformanceCase.run();
+      if (answer === undefined) passed += 1;
+      else omissions.push({ name: conformanceCase.name, reason: answer.omitted });
     } catch (error) {
       failures.push({
         name: conformanceCase.name,
@@ -95,7 +122,7 @@ export async function runConformance(suite: ConformanceSuite): Promise<Conforman
       });
     }
   }
-  return { seam: suite.seam, passed, pending, failures, ok: failures.length === 0 };
+  return { seam: suite.seam, passed, pending, omitted: omissions, failures, ok: failures.length === 0 };
 }
 
 type AdapterFactoryResult = { adapter: StoreAdapter; close?(): Promise<void> };

--- a/packages/core/src/conformance/memory-store-ops.ts
+++ b/packages/core/src/conformance/memory-store-ops.ts
@@ -621,12 +621,15 @@ export function memoryStoreOps(): StoreOps {
     },
     async commit(entries, opts) {
       const owner = opts?.owner ?? BOUND_OWNER;
-      // One commit, one mutation per path: two entries for the same path leave
-      // the commit with no single before-image, so the path's trail could not
-      // say which revision this commit replaced.
+      // An empty commit has no single right answer — a commit id and a trail
+      // entry for a change nobody made, or silence — and the wire has always
+      // refused it, so it is refused here too.
       if (entries.length === 0) {
         throw new VendoError("validation", "a workspace commit must carry at least one entry");
       }
+      // One commit, one mutation per path: two entries for the same path leave
+      // the commit with no single before-image, so the path's trail could not
+      // say which revision this commit replaced.
       const paths = new Set<string>();
       for (const entry of entries as WsEntry[]) {
         if (paths.has(entry.path)) {

--- a/packages/core/src/conformance/memory-store-ops.ts
+++ b/packages/core/src/conformance/memory-store-ops.ts
@@ -1,8 +1,8 @@
 import type { AuditEvent } from "../audit.js";
-import { assertEngineCollection, assertIndexedField, collectionKind } from "../engine-collections.js";
+import { assertEngineCollection, assertIndexedField, collectionKind, engineAppHistory } from "../engine-collections.js";
 import { VendoError } from "../errors.js";
 import type { IsoDateTime } from "../ids.js";
-import { VENDO_STORE_WIRE_FORMAT, type StoreWireStatus } from "../store-wire.js";
+import { STORE_WIRE_PATHS, VENDO_STORE_WIRE_FORMAT, type StoreWireStatus } from "../store-wire.js";
 import {
   APP_DATA_COLLECTION_PATTERN,
   APP_DATA_OWNER_PATTERN,
@@ -449,7 +449,7 @@ export function memoryStoreOps(): StoreOps {
       threads.set(thread.id, { record: rec, thread: t });
       return copyRecord(rec);
     },
-    async getThread(id, _opts) {
+    async getThread(id) {
       const entry = threads.get(id);
       return entry ? copyRecord(entry.record) : null;
     },
@@ -494,6 +494,62 @@ export function memoryStoreOps(): StoreOps {
       const rec = threadRecord(threadId, entry.thread, entry.record);
       threads.set(threadId, { record: rec, thread: entry.thread });
       return copyRecord(rec);
+    },
+    /** The batch append, and the three things that make it more than a loop
+        over putMessage: the SUBJECT is named by the caller (so ownership is
+        decided without downloading the thread), an id the thread already holds
+        is an EDIT that keeps its decided position (moving it would reorder the
+        conversation the next turn reads), and a thread that does not exist yet
+        is CREATED under the named subject — the local backend's upsert, which
+        is what lets a harness land turn one without a separate putThread. */
+    async appendMessages(threadId, subject, messages, opts) {
+      if (messages.length === 0) {
+        throw new VendoError(
+          "validation",
+          `transcripts.appendMessages needs at least one message; the batch for thread ${threadId} was empty`,
+        );
+      }
+      // Two messages under one id cannot BOTH land, and a backend that upserts
+      // them in one statement loses the whole write to a duplicate-key error —
+      // so the offender is named here instead.
+      const idOf = (message: unknown): string => {
+        const given = (message as { id?: unknown } | null)?.id;
+        return typeof given === "string" && given !== "" ? given : `msg_${String(sequence += 1)}`;
+      };
+      const ids = messages.map(idOf);
+      const seen = new Set<string>();
+      for (const id of ids) {
+        if (seen.has(id)) {
+          throw new VendoError(
+            "validation",
+            `thread ${threadId} carries two messages with the id ${JSON.stringify(id)}; message ids must be unique within a thread`,
+          );
+        }
+        seen.add(id);
+      }
+      const existing = threads.get(threadId);
+      if (existing !== undefined && existing.thread.subject !== subject) {
+        throw new VendoError("conflict", `thread ${threadId} belongs to another subject`);
+      }
+      const thread: Thread = existing?.thread ?? {
+        id: threadId,
+        subject,
+        messages: [],
+        answers: new Set(),
+      };
+      if (opts?.title !== undefined) thread.title = opts.title;
+      for (const [index, id] of ids.entries()) {
+        // The message is stored VERBATIM, exactly as putMessage stores it: the
+        // row id a backend invents for an id-less message is the row's, not the
+        // message's, so injecting it here would invent a field no other
+        // implementation has.
+        const at = thread.messages.findIndex((held) => (held as { id?: unknown } | null)?.id === id);
+        if (at === -1) thread.messages.push(jsonCopy(messages[index]));
+        else thread.messages[at] = jsonCopy(messages[index]);
+      }
+      const record = threadRecord(threadId, thread, existing?.record);
+      threads.set(threadId, { record, thread });
+      return { revision: record.revision!, count: messages.length };
     },
     async recordAnswer(threadId, answer) {
       const entry = threads.get(threadId);
@@ -568,6 +624,9 @@ export function memoryStoreOps(): StoreOps {
       // One commit, one mutation per path: two entries for the same path leave
       // the commit with no single before-image, so the path's trail could not
       // say which revision this commit replaced.
+      if (entries.length === 0) {
+        throw new VendoError("validation", "a workspace commit must carry at least one entry");
+      }
       const paths = new Set<string>();
       for (const entry of entries as WsEntry[]) {
         if (paths.has(entry.path)) {
@@ -578,12 +637,17 @@ export function memoryStoreOps(): StoreOps {
       const key = opts?.idempotencyKey;
       if (key !== undefined) {
         const body = JSON.stringify(entries);
-        const recorded = wsIdempotencyKeys.get(key);
+        // The OWNER is part of the ledger key, exactly as `IdempotencyScope`'s
+        // `tenant` is (store.ts): clients pick their own keys and two owners
+        // will pick the same one, and a ledger keyed on the key alone answers
+        // the second owner's commit out of the first owner's record.
+        const scope = JSON.stringify([owner, key]);
+        const recorded = wsIdempotencyKeys.get(scope);
         if (recorded === body) return; // a replay: hand back the recorded result
         if (recorded !== undefined) {
           throw new VendoError("conflict", `idempotency key ${key} was already used for different entries`);
         }
-        wsIdempotencyKeys.set(key, body);
+        wsIdempotencyKeys.set(scope, body);
       }
       const files = drawer(owner);
       // Strict compare-and-swap is checked for the WHOLE set first: a commit
@@ -595,9 +659,13 @@ export function memoryStoreOps(): StoreOps {
           && (files.get(e.path)?.revision ?? null) !== e.expectedRevision)
         .map((e) => e.path);
       if (conflicts.length > 0) {
+        // The paths ride the DETAIL as well as the message: a caller that has
+        // to re-read and retry needs the list, and parsing it back out of a
+        // sentence is not a contract anyone can hold.
         throw new VendoError(
           "conflict",
           `the workspace moved on under ${conflicts.sort().join(", ")}; nothing was committed`,
+          { conflicts: conflicts.sort() },
         );
       }
       wsCommitSeq += 1;
@@ -668,11 +736,38 @@ export function memoryStoreOps(): StoreOps {
         for (const k of harnessState.keys()) {
           if (k.endsWith(`:${target.subject}`)) harnessState.delete(k);
         }
+        // A quarantined row is STILL this person's data. Sweeping it here is
+        // what stops a retention lift from becoming a way to outlive an
+        // erasure — the same hole the local backend closes by matching the
+        // subject it copies onto every lifted row (store/src/erase.ts).
+        for (const [collection, held] of quarantined) {
+          quarantined.set(collection, held.filter((row) => row.record.refs?.["subject"] !== target.subject));
+        }
       }
       if (target.appId) {
+        // Everything the app owns, and nothing beside it: its own drawers
+        // (`app:<id>:<collection>`, rows and files alike), its version history,
+        // its harness state, and the app record itself. NOT the user's threads
+        // — uninstalling an app is not erasing the person who installed it.
+        const prefix = `app:${target.appId}:`;
+        for (const name of [...collections.keys()]) {
+          if (name.startsWith(prefix) || name === engineAppHistory(target.appId)) collections.delete(name);
+        }
+        for (const name of [...blobStore.keys()]) {
+          if (name.startsWith(prefix)) blobStore.delete(name);
+        }
         for (const k of harnessState.keys()) {
           if (k.startsWith(`${target.appId}:`)) harnessState.delete(k);
         }
+        // The app's lifted rows too, by the same rule as the subject leg — and
+        // on both selectors the live rows needed: the app's own drawers, and
+        // its version log, whose rows name their app only in the collection.
+        for (const [collection] of quarantined) {
+          if (collection.startsWith(prefix) || collection === engineAppHistory(target.appId)) {
+            quarantined.delete(collection);
+          }
+        }
+        col("vendo_apps").delete(target.appId);
       }
       return { erased: true };
     },
@@ -833,12 +928,16 @@ export function memoryStoreOps(): StoreOps {
       return measured.sort((a, b) => (a.collection < b.collection ? -1 : 1));
     },
     async status(): Promise<StoreWireStatus> {
-      // Still 35: `ops` is a LEVEL over STORE_WIRE_PATHS' order, and this
-      // reference has no batch append (op 36), so it cannot claim anything past
-      // 35 — whatever it serves further down the list. That is the level's known
-      // coarseness, not a bug in it: the only thing any client reads it for is
-      // STORE_WIRE_APPEND_MESSAGES_OPS, and 35 is the right answer there.
-      return { format: VENDO_STORE_WIRE_FORMAT, ops: 35 };
+      // The whole list. `ops` is a LEVEL over STORE_WIRE_PATHS' declared order,
+      // so it may only run as far as the unbroken PREFIX this reference serves
+      // — and the last two gaps in that prefix have now closed: the batch
+      // append (op 36) is served above, and so is the retention family the list
+      // used to end on. Derived from the manifest rather than typed as a
+      // literal, because the number that matters is "everything declared" and a
+      // hand-written one goes stale the day op 46 is added.
+      // A level this reference cannot back with an op is the one thing it must
+      // never report, so this moves WITH the object and never ahead of it.
+      return { format: VENDO_STORE_WIRE_FORMAT, ops: Object.keys(STORE_WIRE_PATHS).length };
     },
   };
 }

--- a/packages/core/src/conformance/store-ops.ts
+++ b/packages/core/src/conformance/store-ops.ts
@@ -5,7 +5,7 @@ import { isoDateTimeSchema, type IsoDateTime } from "../ids.js";
 import { STORE_WIRE_APPEND_MESSAGES_OPS, STORE_WIRE_PATHS, VENDO_STORE_WIRE_FORMAT } from "../store-wire.js";
 import type { AuditQuery, CollectionFootprint, StoreOps } from "../store.js";
 import { assert, assertBytesEqual, assertDeepEqual } from "./assertions.js";
-import type { ConformanceCase, ConformanceSuite } from "./index.js";
+import { omitted, type ConformanceCase, type ConformanceOmission, type ConformanceSuite } from "./index.js";
 
 /** Refusals are checked by VendoError CODE, not by message text: "threw" is not
     "refused for the right reason". Duck-typed rather than `instanceof`, because
@@ -99,6 +99,49 @@ const seedAudit = async (ops: StoreOps, events: AuditEvent[]): Promise<void> => 
   for (const event of events) await ops.engine.put("vendo_audit", { id: event.id, data: event });
 };
 
+// ---------------------------------------------------------------------------
+// racing
+//
+// Everything else in this file is a SEQUENCE, and a sequence cannot see the
+// window a concurrent caller lands in: a read-then-write with no atomicity
+// underneath passes every sequential case ever written and loses one of two
+// simultaneous writers in production. These helpers are how a case fires two
+// callers at ONE instant and then asserts what has to be true of BOTH orders —
+// never which one won, because either winning is correct and pinning one would
+// fail an honest implementation on scheduling alone.
+// ---------------------------------------------------------------------------
+
+/** Fires one call `count` times at once and hands back how each settled. */
+const race = async <T>(
+  count: number,
+  call: (attempt: number) => Promise<T>,
+): Promise<Array<PromiseSettledResult<T>>> =>
+  await Promise.allSettled(Array.from({ length: count }, (_, attempt) => call(attempt)));
+
+/** The VendoError code a settled call was refused with, or undefined when it
+    resolved. A raced loser is refused for a NAMED reason or not at all: a
+    TypeError or a driver's own deadlock message escaping as the answer is a
+    different bug wearing the right shape. */
+const refusalCode = (settled: PromiseSettledResult<unknown>): unknown =>
+  settled.status === "rejected" ? (settled.reason as { code?: unknown } | null)?.code : undefined;
+
+/** The values of the calls that resolved. */
+const won = <T>(settled: Array<PromiseSettledResult<T>>): T[] =>
+  settled.flatMap((one) => (one.status === "fulfilled" ? [one.value] : []));
+
+/** Why a case over an OPTIONAL member answered `omitted` instead of running.
+    `transcripts.appendMessages` is optional by the same rule `RecordStore.claim`
+    is (store.ts): an implementation that cannot serve it says so by leaving it
+    off. What it may NOT do is leave it off invisibly, which is what these cases
+    used to allow — an early `return` made "absent" and "correct" one green
+    line, so a mount could drop the whole batch-append family and every case
+    over it still passed. */
+const APPEND_ABSENT =
+  "this mount omits transcripts.appendMessages (optional — callers fall back to getThread + putMessage)";
+
+/** {@link APPEND_ABSENT}'s twin for the other optional family. */
+const RETENTION_ABSENT = "this mount omits the retention family (optional — an engine with nowhere to quarantine to leaves it off)";
+
 /** appData rows live in the app's own drawer, and the local backend fails an
     app-scoped write closed when the app has no row — so every appData case
     seeds one first, with the shape the typed `vendo_apps` door accepts. */
@@ -120,18 +163,32 @@ const seedApp = async (ops: StoreOps, appId: string): Promise<void> => {
 
 export interface StoreOpsConformanceOptions {
   makeOps(): Promise<{ ops: StoreOps; close?(): Promise<void> }>;
+  /**
+   * A SECOND handle on the same physical store, bound to a different tenant.
+   *
+   * Supply it and the kit proves the one thing a single handle cannot: that a
+   * mount serving many tenants out of one database keeps them apart. Leave it
+   * off — as a single-tenant store must, having no second tenant to hand out —
+   * and those cases report as OMITTED rather than passing, so "this store has
+   * no tenants" and "this store's tenants are isolated" never read alike.
+   *
+   * The two handles must share their backing store. Two independent stores
+   * are trivially isolated and prove nothing, which is why this is a separate
+   * option and not a second `makeOps()` call.
+   */
+  makeNeighbour?(ops: StoreOps): Promise<{ ops: StoreOps; close?(): Promise<void> }>;
 }
 
 const opsCase = (
   opts: StoreOpsConformanceOptions,
   name: string,
-  body: (ops: StoreOps) => Promise<void>,
+  body: (ops: StoreOps) => Promise<void | ConformanceOmission>,
 ): ConformanceCase => ({
   name,
   async run() {
     const made = await opts.makeOps();
     try {
-      await body(made.ops);
+      return await body(made.ops);
     } finally {
       await made.close?.();
     }
@@ -189,6 +246,28 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
           const page = await ops.engine.list(collection, { limit: PAGE, cursor });
           return { ids: page.records.map((r) => r.id), cursor: page.cursor };
         });
+      }),
+
+      /** The ref filter, which is how every caller that is not walking a whole
+          drawer finds its rows: exact key/value CONTAINMENT, ANDed, and blind
+          to refs the row carries beyond the ones asked for. A filter that
+          matched on the key alone, or that required the row's refs to equal the
+          query, reads as "no results" at one call site and "everybody's rows"
+          at another — and neither says which. */
+      opsCase(opts, "engine.list narrows by refs, exactly and ANDed", async (ops) => {
+        const collection = engineAppHistory("conf_refs");
+        await ops.engine.put(collection, { id: "both", data: {}, refs: { subject: "u1", kind: "invoice" } });
+        await ops.engine.put(collection, { id: "other_value", data: {}, refs: { subject: "u2", kind: "invoice" } });
+        await ops.engine.put(collection, { id: "one_key", data: {}, refs: { subject: "u1" } });
+        // A row carrying MORE refs than the filter names still matches: this is
+        // containment, not equality.
+        await ops.engine.put(collection, { id: "extra", data: {}, refs: { subject: "u1", kind: "invoice", box: "in" } });
+
+        const idsOf = async (refs: Record<string, string>): Promise<string[]> =>
+          (await ops.engine.list(collection, { refs })).records.map((record) => record.id).sort();
+        assertDeepEqual(await idsOf({ subject: "u1" }), ["both", "extra", "one_key"], "a one-key ref filter returned the wrong rows");
+        assertDeepEqual(await idsOf({ subject: "u1", kind: "invoice" }), ["both", "extra"], "two ref keys did not AND");
+        assertDeepEqual(await idsOf({ subject: "nobody" }), [], "a ref value nothing carries matched rows anyway");
       }),
 
       /** The forward walk — the one read a newest-first page cannot serve. A
@@ -323,6 +402,27 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         assertDeepEqual(got?.data, { n: 1 }, "engine.insertIfAbsent overwrote the recorded delivery");
       }),
 
+      /** The same insert, RACED — which is the shape a redelivered webhook
+          actually arrives in. Sequentially, a `has()`-then-`set()` written in
+          application code passes the case above and still admits every one of
+          four simultaneous callers, because the check and the write are two
+          statements with a window between them. The winner is whichever one the
+          scheduler picked, so nothing here names it: what is asserted is that
+          there is exactly ONE, and that the row the drawer kept is the row that
+          winner was handed — a backend that returns one delivery and stores
+          another has told two callers two different truths. */
+      opsCase(opts, "engine.insertIfAbsent admits exactly one of four simultaneous writers", async (ops) => {
+        const settled = await race(4, (attempt) =>
+          ops.engine.insertIfAbsent("automations:deliveries", { id: "dlv_race", data: { attempt } }));
+        for (const one of settled) {
+          assert(one.status === "fulfilled", `a raced insert failed instead of losing: ${String(refusalCode(one))}`);
+        }
+        const admitted = won(settled).filter((record) => record !== null);
+        assert(admitted.length === 1, `exactly one of four simultaneous inserts may be admitted, ${admitted.length} were`);
+        const held = await ops.engine.get("automations:deliveries", "dlv_race");
+        assertDeepEqual(held?.data, admitted[0]!.data, "the drawer kept a delivery no admitted insert wrote");
+      }),
+
       /** The schedule cursor claim: a runner holding a revision the schedule has
           moved past may not write its stale cursor back over the live one. */
       opsCase(opts, "engine.compareAndSwap succeeds on matching revision, null on stale", async (ops) => {
@@ -333,6 +433,27 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         assertDeepEqual(swapped!.data, { cursor: 2 }, "engine.compareAndSwap did not update data");
         const stale = await ops.engine.compareAndSwap("automations:schedule", { id: "sch_1", data: { cursor: 3 } }, created.revision!);
         assert(stale === null, "engine.compareAndSwap should return null on stale revision");
+      }),
+
+      /** The same swap, RACED — two runners that read the schedule at the same
+          instant and both try to advance it. Both hold a revision that WAS live
+          when they read it, so a backend that compares against what it read a
+          statement ago (rather than inside the write itself) lets both land and
+          the schedule skips a window. Exactly one may be told it swapped, and
+          the row must hold that one's cursor: a row holding the loser's value
+          means the loser's write landed after being told it had not. */
+      opsCase(opts, "engine.compareAndSwap lands exactly one of two swaps off one revision", async (ops) => {
+        const created = await ops.engine.put("automations:schedule", { id: "sch_race", data: { cursor: 0 } });
+        assert(created.revision !== undefined, "engine.put must return a revision for CAS");
+        const settled = await race(2, (attempt) =>
+          ops.engine.compareAndSwap("automations:schedule", { id: "sch_race", data: { cursor: attempt + 1 } }, created.revision!));
+        for (const one of settled) {
+          assert(one.status === "fulfilled", `a raced swap failed instead of losing: ${String(refusalCode(one))}`);
+        }
+        const landed = won(settled).filter((record) => record !== null);
+        assert(landed.length === 1, `exactly one swap off one revision may land, ${landed.length} did`);
+        const held = await ops.engine.get("automations:schedule", "sch_race");
+        assertDeepEqual(held?.data, landed[0]!.data, "the row holds a cursor the losing swap wrote");
       }),
 
       /** Sequential, not concurrent: two callers read the same slot and both try
@@ -347,6 +468,48 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         assert(second === false, "the second claim on the same stale expectation should lose");
         const after = await ops.engine.get("vendo_placement_slots", "slot_1");
         assertDeepEqual(after?.data, { holder: "run_1" }, "the winner's replacement did not land");
+      }),
+
+      /** `claim`'s OTHER form: no replacement is a compare-and-DELETE, and it is
+          how a holder releases a slot without a second caller's stale write
+          landing in the gap between a read and a delete. Untested until now,
+          which meant an implementation could serve the replace form perfectly
+          and treat the delete form as a no-op that answers `true` — a released
+          slot nobody can take again, with a success code on it. */
+      opsCase(opts, "engine.claim with no replacement deletes exactly the row it matched", async (ops) => {
+        const expected = { id: "slot_rel", data: { holder: "run_1" }, refs: { o: "a" } };
+        await ops.engine.put("vendo_placement_slots", expected);
+        await ops.engine.put("vendo_placement_slots", { id: "slot_other", data: { holder: "run_1" }, refs: { o: "a" } });
+
+        assert(await ops.engine.claim("vendo_placement_slots", expected) === true, "a compare-and-delete on a matching row should win");
+        assert(await ops.engine.get("vendo_placement_slots", "slot_rel") === null, "the claimed row was not deleted");
+        assert(await ops.engine.get("vendo_placement_slots", "slot_other") !== null, "the delete took a row it was not aimed at");
+        // The row is gone, so the same claim can no longer match — a `true` here
+        // is a delete that reports success without looking.
+        assert(await ops.engine.claim("vendo_placement_slots", expected) === false, "a compare-and-delete matched a row that no longer exists");
+      }),
+
+      /** The claim, RACED — the shape it exists for. Two runners read one free
+          slot at the same instant and both move to take it; the loser must be
+          told the row moved rather than stamping its own holder over the
+          winner's. Which one wins is the scheduler's business, so the assertion
+          is that exactly one is told it won AND that the holder the slot ended
+          up with is that same one — the failure this catches is a backend where
+          both writes land and the answer disagrees with the row. */
+      opsCase(opts, "engine.claim under a real race lets exactly one caller win", async (ops) => {
+        const expected = { id: "slot_race", data: { holder: null }, refs: { o: "a" } };
+        await ops.engine.put("vendo_placement_slots", expected);
+        const holders = ["run_a", "run_b"];
+        const settled = await race(holders.length, (attempt) =>
+          ops.engine.claim("vendo_placement_slots", expected, { data: { holder: holders[attempt] }, refs: { o: "a" } }));
+        for (const one of settled) {
+          assert(one.status === "fulfilled", `a raced claim failed instead of losing: ${String(refusalCode(one))}`);
+        }
+        const winners = settled.flatMap((one, attempt) =>
+          (one.status === "fulfilled" && one.value === true ? [holders[attempt]!] : []));
+        assert(winners.length === 1, `exactly one of two simultaneous claims may win, ${winners.length} did`);
+        const after = await ops.engine.get("vendo_placement_slots", "slot_race");
+        assertDeepEqual(after?.data, { holder: winners[0] }, "the slot is held by a caller that was told it lost");
       }),
 
       opsCase(opts, "engine refuses a collection outside the allowlist on every verb", async (ops) => {
@@ -476,6 +639,49 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         );
       }),
 
+      /** The namespace is the blob store's ONLY partition, and every appData
+          file, every workspace object and every host upload is separated by
+          nothing else. An implementation that composes its physical key by
+          joining the namespace and the key with a delimiter — the obvious way
+          to build one on a flat object store — aliases namespace `a` + key
+          `b/c` onto namespace `a/b` + key `c`, and the read that crosses is
+          silent. Every verb, because every verb composes the key. */
+      opsCase(opts, "blobs keep two namespaces apart on every verb", async (ops) => {
+        const key = "shared.bin";
+        await ops.blobs.put("conf_ns_a", key, new Uint8Array([1]));
+        await ops.blobs.put("conf_ns_b", key, new Uint8Array([2]));
+        // A key each namespace holds ALONE, so a listing that forgot its
+        // partition is caught here rather than three assertions later — with
+        // only the shared key, a namespace-blind list returns the right answer
+        // by coincidence.
+        await ops.blobs.put("conf_ns_a", "only_a.bin", new Uint8Array([3]));
+        await ops.blobs.put("conf_ns_b", "only_b.bin", new Uint8Array([4]));
+
+        assertBytesEqual((await ops.blobs.get("conf_ns_a", key))!.bytes, new Uint8Array([1]), "one namespace read another's bytes");
+        assertBytesEqual((await ops.blobs.get("conf_ns_b", key))!.bytes, new Uint8Array([2]), "one namespace read another's bytes");
+        assert(await ops.blobs.get("conf_ns_a", "only_b.bin") === null, "one namespace read a key only its neighbour holds");
+        assertDeepEqual((await ops.blobs.list("conf_ns_a")).sort(), ["only_a.bin", key], "a namespace listed a neighbour's keys");
+        assert(await ops.blobs.get("conf_ns_c", key) === null, "an empty namespace read a neighbour's blob");
+
+        await ops.blobs.delete("conf_ns_a", key);
+        assert(await ops.blobs.get("conf_ns_a", key) === null, "the delete left its own namespace's blob behind");
+        assert(await ops.blobs.get("conf_ns_b", key) !== null, "a delete in one namespace destroyed another's blob");
+        assertDeepEqual(await ops.blobs.list("conf_ns_a"), ["only_a.bin"], "a deleted key stayed in its namespace's listing");
+      }),
+
+      /** Zero bytes is CONTENT, not absence: an empty file a user uploaded, a
+          truncated log, a placeholder an app wrote. `get` answering null for it
+          would make an existing key indistinguishable from one nobody ever
+          wrote, and the caller's next move — write it again — is the one thing
+          that must not follow from a successful put. */
+      opsCase(opts, "blobs round-trip a zero-byte payload as content, not absence", async (ops) => {
+        await ops.blobs.put("conf_bempty", "empty.bin", new Uint8Array([]), { contentType: "text/plain" });
+        const got = await ops.blobs.get("conf_bempty", "empty.bin");
+        assert(got !== null, "a stored zero-byte blob read back as absent");
+        assertBytesEqual(got!.bytes, new Uint8Array([]), "a zero-byte blob did not round-trip");
+        assertDeepEqual(await ops.blobs.list("conf_bempty"), ["empty.bin"], "a zero-byte blob is missing from its namespace's listing");
+      }),
+
       // =====================================================================
       // appData
       // =====================================================================
@@ -580,6 +786,50 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         assert(still !== null, "the refused put destroyed the holder's row");
         assertDeepEqual(still!.data, { v: 1 }, "the refused put overwrote the holder's row");
         assert(await ops.appData.get(other, "taken") === null, "the refused put re-stamped the row");
+      }),
+
+      /** The owner scope has to survive the WALK, not just the first page. A
+          backend that stamps the scope onto the initial query and then follows
+          its own cursor without re-applying it hands page two of everybody's
+          rows to whoever paged first — and every case above passes, because
+          none of them asks for a second page. */
+      opsCase(opts, "appData.list paginates one owner's drawer without loss, duplicates, or a neighbour's rows", async (ops) => {
+        await seedApp(ops, "app_pager");
+        const owner = { appId: "app_pager", collection: "notes", owner: "own_a" };
+        const other = { appId: "app_pager", collection: "notes", owner: "own_b" };
+        const expected = ["ap_a", "ap_b", "ap_c", "ap_d", "ap_e"];
+        for (const id of expected) await ops.appData.put(owner, { id, data: { id } });
+        for (const id of ["their_1", "their_2", "their_3"]) await ops.appData.put(other, { id, data: { id } });
+        await assertPaginates("appData.list", expected, async (cursor) => {
+          const page = await ops.appData.list(owner, { limit: PAGE, cursor });
+          return { ids: page.records.map((record) => record.id), cursor: page.cursor };
+        });
+      }),
+
+      /** The appId is the second half of the scope, and it is the half nothing
+          proves: every isolation case above moves the OWNER. Two apps holding
+          one collection name is the ordinary case (every generated app invents
+          `notes`), and an implementation that scopes on the owner alone puts
+          both apps' rows in one drawer for the user who installed both. */
+      opsCase(opts, "appData keeps two apps' drawers apart", async (ops) => {
+        await seedApp(ops, "app_one");
+        await seedApp(ops, "app_two");
+        const one = { appId: "app_one", collection: "notes", owner: "own_a" };
+        const two = { appId: "app_two", collection: "notes", owner: "own_a" };
+        await ops.appData.put(one, { id: "same", data: { whose: "one" } });
+        await ops.appData.put(two, { id: "same", data: { whose: "two" } });
+
+        assertDeepEqual((await ops.appData.get(one, "same"))?.data, { whose: "one" }, "one app read another app's row");
+        assertDeepEqual((await ops.appData.get(two, "same"))?.data, { whose: "two" }, "one app read another app's row");
+        assertDeepEqual((await ops.appData.list(one)).records.map((record) => record.id), ["same"], "an app listed another app's rows");
+
+        await ops.appData.putFile(one, "f.bin", new Uint8Array([1]));
+        await ops.appData.putFile(two, "f.bin", new Uint8Array([2]));
+        assertBytesEqual((await ops.appData.getFile(one, "f.bin"))!.bytes, new Uint8Array([1]), "one app read another app's file");
+        await ops.appData.delete(one, "same");
+        await ops.appData.deleteFile(one, "f.bin");
+        assert(await ops.appData.get(two, "same") !== null, "deleting in one app destroyed another app's row");
+        assert(await ops.appData.getFile(two, "f.bin") !== null, "deleting in one app destroyed another app's file");
       }),
 
       opsCase(opts, "appData.list honors caller refs alongside the owner scope", async (ops) => {
@@ -847,6 +1097,45 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         assert(!("missing.json" in result), "workspace read returned a missing path");
       }),
 
+      /** Reading NO paths has exactly one possible answer, and every caller that
+          builds its path list from a filter eventually asks for it. A refusal
+          here forces a `paths.length === 0` guard at every call site, and the
+          one that forgets it turns an empty result set into a thrown error —
+          which is why the empty answer is contract rather than each caller's
+          problem. */
+      opsCase(opts, "workspace.read of no paths is an empty answer, not a refusal", async (ops) => {
+        await ops.workspace.commit([{ path: "present.json", data: { v: 1 } }]);
+        assertDeepEqual(await ops.workspace.read([]), {}, "reading no paths did not answer with an empty result");
+      }),
+
+      /** Binary content rides `{"$vendoWorkspaceBytes": base64, contentType}`
+          (store.ts) — an ENVELOPE, not a type the store knows: the workspace
+          rows adapter above these ops encodes and decodes it, and to the store
+          it is ordinary JSON that must come back exactly as it went in. An
+          implementation that recognises the sentinel and helpfully re-encodes
+          it, or that normalises the base64 padding, hands the adapter above
+          bytes that are not the bytes it stored — and the corruption is
+          invisible until someone opens the file. */
+      opsCase(opts, "workspace round-trips the $vendoWorkspaceBytes envelope untouched", async (ops) => {
+        // Deliberately padded, and deliberately not valid UTF-8 once decoded:
+        // the bytes are 0x00 0xFF 0x10, which is what a store that decodes and
+        // re-encodes through a string will mangle.
+        const envelope = { $vendoWorkspaceBytes: "AP8Q", contentType: "application/octet-stream" };
+        await ops.workspace.commit([{ path: "binary.bin", data: envelope }]);
+        assertDeepEqual(
+          (await ops.workspace.read(["binary.bin"]))["binary.bin"],
+          envelope,
+          "the binary envelope did not round-trip byte-for-byte",
+        );
+        // And it is an ordinary entry in the index: the envelope is content, not
+        // a second kind of file.
+        assertDeepEqual(
+          (await ops.workspace.index()).entries.map((entry) => stringField(entry, "path", "workspace.index")),
+          ["binary.bin"],
+          "the binary entry is missing from the index",
+        );
+      }),
+
       opsCase(opts, "workspace.index paginates without loss or duplicates", async (ops) => {
         const expected = ["xa.json", "xb.json", "xc.json", "xd.json", "xe.json"];
         await ops.workspace.commit(expected.map((path) => ({ path, data: { path } })));
@@ -889,6 +1178,79 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         );
         const after = (await ops.workspace.history()).entries.length;
         assert(after === before, `the replay added ${after - before} history entries`);
+      }),
+
+      /** The key DOUBLE-FIRED: one logical commit, two requests in flight,
+          which is what a client retry on a timeout actually looks like.
+          The contract promises REPLAY protection, not mutual exclusion
+          (IdempotencyLedger, store.ts) — two concurrent requests carrying one
+          key MAY both find it fresh and both execute — so nothing here asserts
+          that one of them lost. What it asserts is the promise that IS made:
+          once the key has an answer, a later request carrying it applies
+          NOTHING further. An implementation whose ledger is written after the
+          mutation, or in a different transaction from it, fails here and passes
+          the sequential replay case above. */
+      opsCase(opts, "workspace.commit replays a double-fired idempotency key once it has an answer", async (ops) => {
+        const entries = [{ path: "idem_race.json", data: { v: 1 } }];
+        const settled = await race(2, () => ops.workspace.commit(entries, { idempotencyKey: "idem_race" }));
+        // A raced request either executes or is told it lost the key. Anything
+        // else — a TypeError, a driver's deadlock, a bare 500 — is not an answer.
+        for (const one of settled) {
+          const code = refusalCode(one);
+          assert(
+            one.status === "fulfilled" || code === "conflict",
+            `a raced keyed commit failed for a reason other than losing its key: ${String(code ?? one)}`,
+          );
+        }
+        assert(won(settled).length >= 1, "both raced requests carrying one key failed");
+
+        const history = (await ops.workspace.history()).entries.length;
+        const content = (await ops.workspace.read(["idem_race.json"]))["idem_race.json"];
+        assertDeepEqual(content, { v: 1 }, "the raced commit did not land its entries");
+
+        // The replay, sequentially, after the race has settled — the moment the
+        // contract does make a promise about.
+        await ops.workspace.commit(entries, { idempotencyKey: "idem_race" });
+        assert(
+          (await ops.workspace.history()).entries.length === history,
+          "a replay after the key already had an answer committed again",
+        );
+        assertDeepEqual(
+          (await ops.workspace.read(["idem_race.json"]))["idem_race.json"],
+          content,
+          "a replay after the key already had an answer changed the file",
+        );
+      }),
+
+      /** An idempotency key belongs to the OWNER that sent it. Clients pick
+          their own keys and two of them will pick the same one — `IdempotencyScope`
+          says so in as many words (store.ts: the tenant is part of the key
+          "because a mount that serves many tenants out of one schema would
+          otherwise let one tenant's key collide with another's"). A ledger keyed
+          on the key alone answers the second owner's commit with the first
+          owner's result, or refuses it as a body mismatch: either way one
+          tenant's write is decided by another tenant's traffic. */
+      opsCase(opts, "workspace.commit's idempotency key is scoped to its owner", async (ops) => {
+        const key = "shared_key";
+        await ops.workspace.commit([{ path: "keyed.json", data: { whose: "a" } }], { idempotencyKey: key, owner: "kown_a" });
+        await ops.workspace.commit([{ path: "keyed.json", data: { whose: "b" } }], { idempotencyKey: key, owner: "kown_b" });
+        assertDeepEqual(
+          (await ops.workspace.read(["keyed.json"], { owner: "kown_b" }))["keyed.json"],
+          { whose: "b" },
+          "one owner's commit was answered out of another owner's idempotency ledger",
+        );
+        assertDeepEqual(
+          (await ops.workspace.read(["keyed.json"], { owner: "kown_a" }))["keyed.json"],
+          { whose: "a" },
+          "the second owner's commit landed in the first owner's drawer",
+        );
+        // And within one owner the key still replays, rather than the scope
+        // simply having been widened until nothing collides.
+        await ops.workspace.commit([{ path: "keyed.json", data: { whose: "a" } }], { idempotencyKey: key, owner: "kown_a" });
+        assert(
+          (await ops.workspace.history({ owner: "kown_a" })).entries.length === 1,
+          "the key stopped replaying for the owner that first used it",
+        );
       }),
 
       opsCase(opts, "workspace.commit refuses a replayed idempotency key with a different body", async (ops) => {
@@ -1084,6 +1446,108 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         );
       }),
 
+      /** The commit-conflict's DETAIL. The message names the paths in prose,
+          which is enough for a human and useless to the caller that has to act:
+          `workspaceOpsRows.commitAll` re-reads the index and re-derives the
+          conflicting paths by hand precisely because it cannot get them out of
+          the refusal. `detail.conflicts` is that list, structured — and it is
+          named here rather than left to each implementation because a refusal
+          whose payload has no shape is a refusal nobody can program against. */
+      opsCase(opts, "workspace.commit's conflict names the paths it refused on", async (ops) => {
+        await ops.workspace.commit([{ path: "d-one.json", data: { v: 1 } }, { path: "d-two.json", data: { v: 1 } }]);
+        const revisionOf = async (path: string): Promise<number> => numberField(
+          (await ops.workspace.index()).entries.find((entry) => (entry as { path?: unknown }).path === path),
+          "revision",
+          "workspace.index",
+        );
+        const stale = { one: await revisionOf("d-one.json"), two: await revisionOf("d-two.json") };
+        // Both heads move under the caller, so BOTH guarded entries conflict.
+        await ops.workspace.commit([{ path: "d-one.json", data: { v: 2 } }, { path: "d-two.json", data: { v: 2 } }]);
+
+        const refusal = await ops.workspace.commit([
+          { path: "d-one.json", data: { v: 3 }, expectedRevision: stale.one },
+          { path: "d-two.json", data: { v: 3 }, expectedRevision: stale.two },
+        ]).then(() => null, (error: unknown) => error);
+        assert((refusal as { code?: unknown } | null)?.code === "conflict", `a stale commit should refuse with conflict, got ${String(refusal)}`);
+        const detail = (refusal as { detail?: unknown } | null)?.detail as { conflicts?: unknown } | undefined;
+        assert(detail !== undefined, "the refusal carried no detail, so the caller cannot learn which paths moved");
+        assert(Array.isArray(detail.conflicts), `the refusal's detail.conflicts is not an array: ${JSON.stringify(detail)}`);
+        assertDeepEqual(
+          [...detail.conflicts as string[]].sort(),
+          ["d-one.json", "d-two.json"],
+          "detail.conflicts did not name exactly the paths that moved",
+        );
+      }),
+
+      /** The commit CAS, raced — two colleagues who read one org file at the
+          same instant and both write it back. Sequentially the loser holds a
+          revision that has visibly moved; here NEITHER has, at the moment they
+          check, and only an atomic compare inside the write itself can tell
+          them apart. A backend that reads the head, compares in application
+          code, and then writes lets both land, and the first colleague's edit
+          is gone with no error anywhere. Either may win; exactly one must. */
+      opsCase(opts, "workspace.commit lands exactly one of two simultaneous compare-and-swaps", async (ops) => {
+        await ops.workspace.commit([{ path: "cas-race.json", data: { by: "seed" } }]);
+        const revision = numberField(
+          (await ops.workspace.index()).entries.find((entry) => (entry as { path?: unknown }).path === "cas-race.json"),
+          "revision",
+          "workspace.index",
+        );
+        const before = (await ops.workspace.history()).entries.length;
+
+        const writers = ["colleague_a", "colleague_b"];
+        const settled = await race(writers.length, (attempt) =>
+          ops.workspace.commit([{ path: "cas-race.json", data: { by: writers[attempt] }, expectedRevision: revision }]));
+        const landed = settled.filter((one) => one.status === "fulfilled");
+        assert(landed.length === 1, `exactly one commit off one revision may land, ${landed.length} did`);
+        for (const one of settled) {
+          if (one.status === "fulfilled") continue;
+          assert(refusalCode(one) === "conflict", `the losing commit was refused as ${String(refusalCode(one))}, not conflict`);
+        }
+        const held = (await ops.workspace.read(["cas-race.json"]))["cas-race.json"] as { by?: string };
+        assert(writers.includes(held.by ?? ""), `the file holds ${JSON.stringify(held)}, which neither writer wrote`);
+        assert(
+          (await ops.workspace.history()).entries.length === before + 1,
+          "the refused commit left a commit in the trail",
+        );
+      }),
+
+      /** The owner a workspace verb falls back to when the caller names none is
+          the mount's own (store.ts): the local backend and the memory reference
+          resolve it to a bound single-player constant, and a hosted mount
+          resolves it server-side, where OSS cannot see the value. What every
+          mount owes regardless is COHERENCE — the same default drawer on all
+          four verbs. Two of the hosted client's four verbs spread the query
+          straight onto the body rather than going through its owner helper, so
+          a mount whose index and history default differently from its read and
+          commit is the shape this pins, not a hypothetical.
+          It cannot pin that the hosted default EQUALS the local one; nothing in
+          OSS can, and this comment is where that ends. */
+      opsCase(opts, "the workspace's default owner is one drawer on every verb", async (ops) => {
+        await ops.workspace.commit([{ path: "default.json", data: { v: 1 } }]);
+        assertDeepEqual(
+          (await ops.workspace.read(["default.json"]))["default.json"],
+          { v: 1 },
+          "a read with no owner missed a commit with no owner",
+        );
+        assertDeepEqual(
+          (await ops.workspace.index()).entries.map((entry) => stringField(entry, "path", "workspace.index")),
+          ["default.json"],
+          "an index with no owner did not see a commit with no owner",
+        );
+        assert(
+          (await ops.workspace.history({ path: "default.json" })).entries.length === 1,
+          "a history with no owner did not see a commit with no owner",
+        );
+        // And the default drawer is A drawer, not everyone's: an explicitly
+        // named owner that has committed nothing sees nothing.
+        assertDeepEqual(
+          await ops.workspace.read(["default.json"], { owner: "own_elsewhere" }),
+          {},
+          "a named owner read the default drawer's file",
+        );
+      }),
+
       /** A DELETE is a commit against a revision too. Without this, a turn that
           checked out an org file, lost the head to a colleague, and then removed
           the path erased content it had never seen — the one mutation strict
@@ -1135,7 +1599,7 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
           so the path's trail would name two superseded revisions under one
           commit id and neither would be THE one it replaced. Refused at the
           door instead. */
-      opsCase(opts, "workspace.commit refuses the same path twice in one commit", async (ops) => {
+      opsCase(opts, "workspace.commit refuses the same path twice in one commit, and an empty commit", async (ops) => {
         await assertThrowsCode(
           () => ops.workspace.commit([
             { path: "dup.json", data: { v: 1 } },
@@ -1143,6 +1607,15 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
           ]),
           "validation",
           "committing one path twice",
+        );
+        // An empty commit has no single right answer — a commit id and a trail
+        // entry for a change nobody made, or silence — so it is refused rather
+        // than each implementation picking one. (`read([])` is the opposite
+        // case, and answers `{}`: reading nothing has exactly one answer.)
+        await assertThrowsCode(
+          () => ops.workspace.commit([]),
+          "validation",
+          "committing no entries at all",
         );
         assertDeepEqual(
           await ops.workspace.read(["dup.json"]),
@@ -1208,6 +1681,44 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         assert(await ops.harness.get("app_erase", "erase_me") === null, "erase left the subject's harness state behind");
       }),
 
+      /** The erase target's OTHER half. `EraseTarget` is a union of exactly two
+          scopes (store.ts) and only the subject one was ever proven, so an
+          implementation could serve `{subject}` faithfully and treat `{appId}`
+          as a no-op that answers with a report — an uninstalled app whose data
+          is all still there, and a deletion request answered with a receipt.
+          Scoped to the app and nothing else: the user who installed it keeps
+          their conversations, and the app NEXT to it keeps everything. */
+      opsCase(opts, "lifecycle.erase removes one app's data, and only that app's", async (ops) => {
+        await seedApp(ops, "app_gone");
+        await seedApp(ops, "app_stays");
+        const gone = { appId: "app_gone", collection: "notes", owner: "user_1" };
+        const stays = { appId: "app_stays", collection: "notes", owner: "user_1" };
+        await ops.appData.put(gone, { id: "row", data: { v: 1 } });
+        await ops.appData.put(stays, { id: "row", data: { v: 1 } });
+        await ops.appData.putFile(gone, "f.bin", new Uint8Array([1]));
+        await ops.appData.putFile(stays, "f.bin", new Uint8Array([1]));
+        await ops.engine.put(engineAppHistory("app_gone"), { id: "ver_1", data: { version: 1 } });
+        await ops.harness.set("app_gone", "user_1", { v: 1 });
+        await ops.harness.set("app_stays", "user_1", { v: 1 });
+        await ops.transcripts.putThread({ id: "thr_app_erase", subject: "user_1", messages: [] });
+
+        const report = await ops.lifecycle.erase({ appId: "app_gone" });
+        assert(report !== null && report !== undefined, "erase must return a report");
+
+        assert(await ops.appData.get(gone, "row") === null, "erase left the app's rows behind");
+        assert(await ops.appData.getFile(gone, "f.bin") === null, "erase left the app's files behind");
+        assert(await ops.harness.get("app_gone", "user_1") === null, "erase left the app's harness state behind");
+        assert(await ops.engine.get(engineAppHistory("app_gone"), "ver_1") === null, "erase left the app's history behind");
+        assert(await ops.engine.get("vendo_apps", "app_gone") === null, "erase left the app record itself behind");
+
+        assert(await ops.appData.get(stays, "row") !== null, "erase took the neighbouring app's rows");
+        assert(await ops.appData.getFile(stays, "f.bin") !== null, "erase took the neighbouring app's files");
+        assert(await ops.harness.get("app_stays", "user_1") !== null, "erase took the neighbouring app's harness state");
+        assert(await ops.engine.get("vendo_apps", "app_stays") !== null, "erase took the neighbouring app record");
+        // The person is not the app: uninstalling one keeps their conversations.
+        assert(await ops.transcripts.getThread("thr_app_erase") !== null, "an app-scoped erase took the user's threads");
+      }),
+
       /** Promote hands the app to an org: the app record's owning subject
           BECOMES the org id (02-store §9.5), which is the move's only
           observable through the ops surface. */
@@ -1234,11 +1745,12 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
 
       /** The batch append: ownership is the caller's `subject`, so the mount
           checks it in its own statement and the client never downloads the
-          thread to check it first. Optional — a mount that omits it is served
-          by putMessage, and this case says so instead of failing it. */
+          thread to check it first. OPTIONAL — a mount that omits it is served
+          by putMessage — so this case reports the omission rather than failing
+          it, and rather than passing, which is what an early `return` did. */
       opsCase(opts, "transcripts.appendMessages lands a batch under the named subject", async (ops) => {
         const append = ops.transcripts.appendMessages;
-        if (append === undefined) return;
+        if (append === undefined) return omitted(APPEND_ABSENT);
         await ops.transcripts.putThread({ id: "thr_am1", subject: "u", messages: [] });
         const landed = await append("thr_am1", "u", [
           { id: "msg_a", role: "user", text: "one" },
@@ -1261,6 +1773,132 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
           "conflict",
           "appending to another subject's thread",
         );
+      }),
+
+      /** ORDER is the whole of what a transcript is: the same messages in a
+          different order are a different conversation, and the next turn reads
+          them back as its own context. A batch lands AFTER what the thread
+          already holds, in the order the caller wrote it — not sorted by id,
+          not by arrival, and not interleaved with the tail. */
+      opsCase(opts, "transcripts.appendMessages lands a batch after the tail, in the caller's order", async (ops) => {
+        const append = ops.transcripts.appendMessages;
+        if (append === undefined) return omitted(APPEND_ABSENT);
+        await ops.transcripts.putThread({ id: "thr_order", subject: "u", messages: [] });
+        // Ids that sort the OPPOSITE way to the order they are written in, so an
+        // implementation ordering by id cannot pass by coincidence.
+        await append("thr_order", "u", [{ id: "m_9", role: "user", text: "one" }, { id: "m_7", role: "assistant", text: "two" }]);
+        await append("thr_order", "u", [{ id: "m_5", role: "user", text: "three" }, { id: "m_3", role: "assistant", text: "four" }]);
+        const got = await ops.transcripts.getThread("thr_order");
+        assertDeepEqual(
+          ((got!.data as Record<string, unknown>)["messages"] as Array<Record<string, unknown>>).map((message) => message["text"]),
+          ["one", "two", "three", "four"],
+          "the batches did not land after the tail in the order they were written",
+        );
+      }),
+
+      /** An id the thread already holds is an EDIT, in place — the same rule
+          putMessage follows, and for the same reason: an approval flips from
+          pending to answered by re-sending its own message, and a thread
+          carrying two messages under one id is a thread no engine will store.
+          The edited message keeps its DECIDED position: moving it to the tail
+          would reorder the conversation every time a turn re-sent anything. */
+      opsCase(opts, "transcripts.appendMessages edits an id the thread already holds, without moving it", async (ops) => {
+        const append = ops.transcripts.appendMessages;
+        if (append === undefined) return omitted(APPEND_ABSENT);
+        await ops.transcripts.putThread({ id: "thr_dedupe", subject: "u", messages: [] });
+        await append("thr_dedupe", "u", [
+          { id: "m_a", role: "user", text: "ask" },
+          { id: "m_b", role: "assistant", text: "answer" },
+        ]);
+        await append("thr_dedupe", "u", [
+          { id: "m_a", role: "user", text: "ask (edited)" },
+          { id: "m_c", role: "user", text: "next" },
+        ]);
+        const got = await ops.transcripts.getThread("thr_dedupe");
+        assertDeepEqual(
+          ((got!.data as Record<string, unknown>)["messages"] as Array<Record<string, unknown>>)
+            .map((message) => [message["id"], message["text"]]),
+          [["m_a", "ask (edited)"], ["m_b", "answer"], ["m_c", "next"]],
+          "the re-sent message was appended again, or moved, instead of edited in place",
+        );
+      }),
+
+      /** Two refusals the batch shape makes possible and the single-message verb
+          never could. Both are `validation` because both are the CALLER's
+          mistake, caught before a row is written: an empty batch has nothing to
+          land (and must not touch the thread on its way to doing nothing), and
+          two messages sharing one id cannot both be stored — an implementation
+          that upserts a batch in one statement loses the WHOLE write to a
+          duplicate-key error, so the offender is named instead. */
+      opsCase(opts, "transcripts.appendMessages refuses an empty batch and two messages under one id", async (ops) => {
+        const append = ops.transcripts.appendMessages;
+        if (append === undefined) return omitted(APPEND_ABSENT);
+        await ops.transcripts.putThread({ id: "thr_refuse", subject: "u", messages: [] });
+        const before = await ops.transcripts.getThread("thr_refuse");
+
+        await assertThrowsCode(() => append("thr_refuse", "u", []), "validation", "an empty batch");
+        await assertThrowsCode(
+          () => append("thr_refuse", "u", [{ id: "m_dup", role: "user", text: "one" }, { id: "m_dup", role: "user", text: "two" }]),
+          "validation",
+          "two messages sharing one id",
+        );
+        const after = await ops.transcripts.getThread("thr_refuse");
+        assertDeepEqual(
+          (after!.data as Record<string, unknown>)["messages"],
+          (before!.data as Record<string, unknown>)["messages"],
+          "a refused batch changed the thread anyway",
+        );
+      }),
+
+      /** A thread the store has never seen is CREATED, under the subject the
+          batch names — the upsert that lets a harness land turn one without a
+          separate putThread, and the reason the op takes a subject rather than
+          reading one. It is also the branch where getting ownership wrong costs
+          the most: a create that ignored the named subject would hand the new
+          thread to nobody, and every later append to it would then conflict. */
+      opsCase(opts, "transcripts.appendMessages creates a thread that does not exist yet, under the named subject", async (ops) => {
+        const append = ops.transcripts.appendMessages;
+        if (append === undefined) return omitted(APPEND_ABSENT);
+        const landed = await append("thr_new", "owner_1", [{ id: "m_1", role: "user", text: "first" }], { title: "First" });
+        assert(landed.count === 1, `the creating append should report 1 row, got ${landed.count}`);
+
+        const created = await ops.transcripts.getThread("thr_new");
+        assert(created !== null, "the append did not create the thread it named");
+        assert((created!.data as Record<string, unknown>)["subject"] === "owner_1", "the created thread was not handed to the named subject");
+        assertDeepEqual(
+          (await ops.transcripts.listThreads({ subject: "owner_1" })).records.map((record) => record.id),
+          ["thr_new"],
+          "the created thread is missing from its subject's listing",
+        );
+        // And the ownership it was created with holds against everyone else.
+        await assertThrowsCode(
+          () => append("thr_new", "someone_else", [{ id: "m_2", role: "user", text: "mine now" }]),
+          "conflict",
+          "appending to a thread another subject created",
+        );
+      }),
+
+      /** The revision is the ONLY thing a batch append hands back about the
+          thread, and a client caches it to decide whether its copy is stale. A
+          constant — or a value that repeats across two appends — tells every
+          holder of the old one that nothing changed, so the transcript they
+          keep serving is the one from before the turn. Nothing here reads the
+          revision's SPELLING: it is contractually an opaque string, and the two
+          shipped engines number and stamp theirs differently. */
+      opsCase(opts, "transcripts.appendMessages reports a revision that moves with every batch", async (ops) => {
+        const append = ops.transcripts.appendMessages;
+        if (append === undefined) return omitted(APPEND_ABSENT);
+        await ops.transcripts.putThread({ id: "thr_rev", subject: "u", messages: [] });
+        const seen: string[] = [];
+        for (const index of [0, 1, 2]) {
+          const landed = await append("thr_rev", "u", [{ id: `m_${index}`, role: "user", text: String(index) }]);
+          assert(typeof landed.revision === "string" && landed.revision.length > 0, "an append reported no revision");
+          assert(!seen.includes(landed.revision), `append ${index} reported a revision an earlier one already used: ${landed.revision}`);
+          seen.push(landed.revision);
+        }
+        // An EDIT is a change too — the thread a client holds is stale after it.
+        const edited = await append("thr_rev", "u", [{ id: "m_0", role: "user", text: "edited" }]);
+        assert(!seen.includes(edited.revision), `an edit reported a revision an earlier append already used: ${edited.revision}`);
       }),
 
       // =====================================================================
@@ -1500,10 +2138,12 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
       }),
 
       // =====================================================================
-      // retention — OPTIONAL (01 §12), so both cases return early on a mount
-      // that omits the family rather than failing it. That is what lets every
-      // mount carry them; an implementation that HAS the family is held to all
-      // of it.
+      // retention — OPTIONAL (01 §12), so both cases report the OMISSION on a
+      // mount that leaves the family off rather than failing it. That is what
+      // lets every mount carry them; an implementation that HAS the family is
+      // held to all of it. Reported rather than returned silently, because an
+      // early `return` counted as a pass — and "this engine has nowhere to
+      // quarantine to" then read exactly like "this engine's sweep is correct".
       // =====================================================================
 
       /** The sweep is a cron, so the two things that matter are the count it
@@ -1513,7 +2153,7 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
           must move nothing. */
       opsCase(opts, "retention.quarantine lifts rows past the cutoff out of the live collection, and re-running it moves nothing", async (ops) => {
         const retention = ops.retention;
-        if (retention === undefined) return;
+        if (retention === undefined) return omitted(RETENTION_ABSENT);
         const collection = engineAppHistory("conf_ret");
         const ids = ["ret_1", "ret_2", "ret_3"];
         for (const id of ids) await ops.engine.put(collection, { id, data: { id } });
@@ -1546,7 +2186,7 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
           the row's age — the grace a purge honors runs from the lift. */
       opsCase(opts, "retention.purge destroys only quarantined rows lifted before its cutoff", async (ops) => {
         const retention = ops.retention;
-        if (retention === undefined) return;
+        if (retention === undefined) return omitted(RETENTION_ABSENT);
         const collection = engineAppHistory("conf_purge");
         const ids = ["purge_1", "purge_2"];
         for (const id of ids) await ops.engine.put(collection, { id, data: { id } });
@@ -1564,6 +2204,89 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
       }),
 
       // =====================================================================
+      // tenancy — OMITTED unless the mount hands out a second tenant, because
+      // a single-tenant store has no second tenant to hand out. Everything
+      // above proves one store keeps its OWNERS, apps and namespaces apart;
+      // this is the line above those, and it is the only one a store serving
+      // many customers out of one database can get catastrophically wrong.
+      // =====================================================================
+
+      /** Every drawer at once, in both directions. One case rather than six,
+          because the failure is never "threads leak but blobs do not" — it is
+          one missing predicate on a shared query path, and it shows up in
+          whichever drawer is asked first. The reverse direction is asserted
+          too: a leak that only runs one way is still a leak, and a store that
+          scopes its reads but not its writes lands one tenant's row in
+          another's drawer where the first tenant will never see it again. */
+      {
+        name: "a neighbouring tenant shares no drawer with this one",
+        async run(): Promise<void | ConformanceOmission> {
+          const makeNeighbour = opts.makeNeighbour;
+          if (makeNeighbour === undefined) {
+            return omitted("this mount serves one tenant, so it hands out no neighbour to be isolated from");
+          }
+          const made = await opts.makeOps();
+          const neighbour = await makeNeighbour(made.ops);
+          const [mine, theirs] = [made.ops, neighbour.ops];
+          try {
+            const target = { appId: "app_tenant", collection: "notes", owner: "user_1" };
+            await seedApp(mine, "app_tenant");
+            await seedApp(theirs, "app_tenant");
+            for (const [ops, whose] of [[mine, "mine"], [theirs, "theirs"]] as const) {
+              await ops.engine.put("vendo_placement_slots", { id: "slot_1", data: { whose } });
+              await ops.blobs.put("conf_tenant", "file.bin", new TextEncoder().encode(whose));
+              await ops.appData.put(target, { id: "row_1", data: { whose } });
+              await ops.transcripts.putThread({ id: "thr_1", subject: "user_1", messages: [{ whose }] });
+              await ops.secrets.set("conf_token", whose);
+              await ops.workspace.commit([{ path: "w.json", data: { whose } }], { owner: "user_1" });
+            }
+
+            for (const [ops, whose] of [[mine, "mine"], [theirs, "theirs"]] as const) {
+              assertDeepEqual((await ops.engine.get("vendo_placement_slots", "slot_1"))?.data, { whose }, "a record crossed the tenant line");
+              assertDeepEqual(
+                (await ops.engine.list("vendo_placement_slots")).records.map((record) => record.data),
+                [{ whose }],
+                "a record listing crossed the tenant line",
+              );
+              assertBytesEqual(
+                (await ops.blobs.get("conf_tenant", "file.bin"))!.bytes,
+                new TextEncoder().encode(whose),
+                "a blob crossed the tenant line",
+              );
+              assertDeepEqual((await ops.appData.get(target, "row_1"))?.data, { whose }, "an app row crossed the tenant line");
+              assertDeepEqual(
+                ((await ops.transcripts.getThread("thr_1"))!.data as Record<string, unknown>)["messages"],
+                [{ whose }],
+                "a thread crossed the tenant line",
+              );
+              assertDeepEqual(
+                (await ops.transcripts.listThreads({ subject: "user_1" })).records.map((record) => record.id),
+                ["thr_1"],
+                "a thread listing crossed the tenant line",
+              );
+              assert(await ops.secrets.get("conf_token") === whose, "a secret crossed the tenant line");
+              assertDeepEqual(await ops.secrets.list(), ["conf_token"], "the vault inventory crossed the tenant line");
+              assertDeepEqual(
+                (await ops.workspace.read(["w.json"], { owner: "user_1" }))["w.json"],
+                { whose },
+                "a workspace file crossed the tenant line",
+              );
+            }
+
+            // A destructive verb is the loudest way to cross: an erase that
+            // reaches the neighbour is unrecoverable, and it is the one call
+            // where a missing tenant predicate is worst.
+            await mine.lifecycle.erase({ subject: "user_1" });
+            assert(await theirs.transcripts.getThread("thr_1") !== null, "one tenant's erase took the neighbour's thread");
+            assert(await theirs.appData.get(target, "row_1") !== null, "one tenant's erase took the neighbour's app row");
+          } finally {
+            await neighbour.close?.();
+            await made.close?.();
+          }
+        },
+      },
+
+      // =====================================================================
       // status
       // =====================================================================
 
@@ -1572,13 +2295,12 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         assert(status.format === VENDO_STORE_WIRE_FORMAT, `status.format should be ${VENDO_STORE_WIRE_FORMAT}`);
         assert(typeof status.ops === "number", "status.ops should be a number");
         // `ops` is a LEVEL over STORE_WIRE_PATHS' declared order, not an
-        // inventory, so there is no single right number to assert: three honest
-        // implementations report three (the local engine stops short of the two
-        // retention ops, the memory reference has no batch append). This case
-        // used to pin the count exactly, which only held while every mount was
-        // the same vintage — it would now fail two implementations that are
-        // telling the truth. What IS contract is the ceiling and the one
-        // question a client asks the level.
+        // inventory, so there is no single right number to assert: two mounts
+        // of different vintages both tell the truth with different numbers, and
+        // a mount that legitimately omits an optional family reports the prefix
+        // BEFORE it. This case used to pin the count exactly, which only held
+        // while every mount was the same vintage. What IS contract is the
+        // ceiling and the one question a client asks the level.
         const declared = Object.keys(STORE_WIRE_PATHS).length;
         assert(status.ops <= declared, `a mount cannot serve more than the ${declared} declared ops, got ${status.ops}`);
         // The level's ONE contract use, and the only way it breaks a client: a

--- a/packages/core/src/store-wire.ts
+++ b/packages/core/src/store-wire.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { VendoError, safeErrorMessage, vendoErrorCodeSchema, type VendoErrorCode } from "./errors.js";
-import { isoDateTimeSchema } from "./ids.js";
+import { isoDateTimeSchema, type Json } from "./ids.js";
 import {
   APP_DATA_COLLECTION_PATTERN,
   APP_DATA_OWNER_PATTERN,
@@ -185,11 +185,18 @@ export const storeWireCollectionCompareAndSwapRequestSchema = z.object({
 // blobs
 // ---------------------------------------------------------------------------
 
-/** Blob bytes are base64-encoded on the wire. */
+/** Blob bytes are base64-encoded on the wire. `bytes` carries no `.min(1)`:
+    base64 of a ZERO-BYTE payload is the empty string, and an empty file is
+    content — an empty upload, a truncated log, a placeholder an app wrote.
+    Refusing it here made the one thing a store must never do (lose a
+    successful write) into the client's default: the put failed, and the
+    caller's `get` then answered null exactly as it would for a key nobody had
+    ever written. Both local implementations always accepted it; this line is
+    where the wire stopped disagreeing with them. */
 export const storeWireBlobsPutRequestSchema = z.object({
   namespace: z.string().min(1),
   key: z.string().min(1),
-  bytes: z.string().min(1), // base64
+  bytes: z.string(), // base64
   contentType: z.string().optional(),
 }).passthrough();
 
@@ -278,10 +285,16 @@ export const storeWireTranscriptsPutThreadRequestSchema = z.object({
   }).passthrough(),
 }).passthrough();
 
+/** An id, and nothing else. `getThread` answers with ONE record and the wire's
+    read answer has no field a next-page cursor could ride, so the `cursor` and
+    `limit` this schema used to declare were a windowing request no mount could
+    complete — the client sent them, every implementation ignored them, and the
+    caller got the whole transcript back with no way to tell. Retired rather
+    than implemented: paging a transcript needs an answer shaped to say "there
+    is more", which is a different op. `.passthrough()` means a client that
+    still sends them is read, not refused. */
 export const storeWireTranscriptsGetThreadRequestSchema = z.object({
   id: z.string().min(1),
-  cursor: z.string().optional(),
-  limit: z.number().int().min(1).max(1000).optional(),
 }).passthrough();
 
 export const storeWireTranscriptsListThreadsRequestSchema = z.object({
@@ -559,10 +572,18 @@ export const storeWireStatusSchema = z.object({
 // Error envelope (identical shape to knowledge-wire / umbrella wire)
 // ---------------------------------------------------------------------------
 
+/** `detail` is `VendoError.detail`, and it crosses. Without it a refusal
+    arrived over the wire as a code and a sentence, so every structured payload
+    a refusal carried was readable by a local caller and lost to a hosted one:
+    `workspace.commit`'s conflict names the paths that moved in `detail.conflicts`,
+    and the hosted path had to re-read the whole index and re-derive them by
+    hand (`workspace-ops-rows.ts`). Optional, and passed through untouched — a
+    mount that sends none and a client that ignores one both stay legal. */
 export interface StoreWireError {
   error: {
     code: VendoErrorCode;
     message: string;
+    detail?: unknown;
   };
 }
 
@@ -570,6 +591,7 @@ export const storeWireErrorSchema = z.object({
   error: z.object({
     code: vendoErrorCodeSchema,
     message: z.string(),
+    detail: z.unknown().optional(),
   }).passthrough(),
 }).passthrough() satisfies z.ZodType<StoreWireError>;
 
@@ -613,7 +635,13 @@ const STATUS_TO_CODE: Record<number, VendoErrorCode> = {
 export function storeWireErrorBody(error: VendoError): { status: number; body: StoreWireError } {
   return {
     status: STORE_WIRE_STATUS_BY_CODE[error.code],
-    body: { error: { code: error.code, message: safeErrorMessage(error) } },
+    body: {
+      error: {
+        code: error.code,
+        message: safeErrorMessage(error),
+        ...(error.detail === undefined ? {} : { detail: error.detail }),
+      },
+    },
   };
 }
 
@@ -624,7 +652,7 @@ export function storeWireErrorBody(error: VendoError): { status: number; body: S
 export function parseStoreWireError(status: number, body: unknown): VendoError {
   const parsed = storeWireErrorSchema.safeParse(body);
   if (parsed.success) {
-    return new VendoError(parsed.data.error.code, parsed.data.error.message);
+    return new VendoError(parsed.data.error.code, parsed.data.error.message, parsed.data.error.detail as Json);
   }
   const code = STATUS_TO_CODE[status];
   if (code !== undefined) {

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -417,7 +417,16 @@ export interface StoreOps {
   };
   transcripts: {
     putThread(thread: { id: string; subject: string; messages: unknown[]; title?: string }): Promise<VendoRecord>;
-    getThread(id: string, opts?: { cursor?: string; limit?: number }): Promise<VendoRecord | null>;
+    /** The WHOLE thread. There is deliberately no `cursor`/`limit` here: the
+        answer is a single `VendoRecord`, which has nowhere to carry a next-page
+        cursor, so a windowed read could never tell a caller there is more. The
+        pair shipped on this signature by pattern-cloning the list ops (#784),
+        was implemented by nobody, and was marshalled blind by the cloud client
+        — a caller that passed `{ limit: 50 }` got the entire transcript and no
+        way to notice. Windowing a transcript is the reader's job (the harness
+        slices its own context window); paging one needs an op whose answer has
+        room for a cursor. */
+    getThread(id: string): Promise<VendoRecord | null>;
     listThreads(query?: { subject?: string; cursor?: string; limit?: number }): Promise<{ records: VendoRecord[]; cursor?: string }>;
     deleteThread(id: string): Promise<void>;
     putMessage(threadId: string, message: unknown): Promise<VendoRecord>;

--- a/packages/core/tests/conformance/memory-store-ops.test.ts
+++ b/packages/core/tests/conformance/memory-store-ops.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { StoreOps } from "../../src/index.js";
+import { STORE_WIRE_APPEND_MESSAGES_OPS, type StoreOps } from "../../src/index.js";
 import { memoryStoreOps, runConformance, storeOpsConformance } from "../../src/conformance/index.js";
 
 /** A backend whose thread delete drops the thread row and puts the thread's
@@ -42,13 +42,66 @@ describe("StoreOps conformance kit against the memory reference", () => {
     const report = await runConformance(suite);
     expect(report.failures).toEqual([]);
     expect(report.ok).toBe(true);
-    // The reference now serves every family the suite covers — retention
-    // included — so nothing is carried unrun. The accounting is asserted
-    // rather than the number: a case that is neither passed nor named pending
-    // is a case the report lost, which is exactly the blindness the tag exists
-    // to remove.
+    // The reference now serves every family the suite covers — retention and
+    // the batch append included — so nothing is carried unrun. The accounting
+    // is asserted rather than the number: a case that is in none of the three
+    // buckets is a case the report lost, which is exactly the blindness the
+    // buckets exist to remove.
     expect(report.pending).toEqual(suite.cases.filter((c) => c.pending !== undefined).map((c) => c.name));
-    expect(report.passed + report.pending.length).toBe(suite.cases.length);
+    // The reference serves ONE tenant, so the tenancy case is the only
+    // omission. Pinned as a set rather than a count: an early `return` in any
+    // other case would land here silently otherwise, which is the whole failure
+    // the bucket exists to expose.
+    expect(report.omitted.map((one) => one.name)).toEqual(["a neighbouring tenant shares no drawer with this one"]);
+    expect(report.omitted[0]!.reason).toContain("one tenant");
+    expect(report.passed + report.pending.length + report.omitted.length).toBe(suite.cases.length);
+  });
+
+  /** The omission bucket earning its keep: a mount that drops the OPTIONAL
+      batch-append family is still `ok` — the contract allows the omission — but
+      every case over it is counted as omitted rather than passed, so "this
+      mount has no batch append" can never again read as "this mount's batch
+      append is correct". Before the bucket existed those cases returned early
+      and the report called them passes. */
+  it("a mount that omits the batch append is counted, not quietly passed", async () => {
+    const report = await runConformance(storeOpsConformance({
+      async makeOps() {
+        const ops = memoryStoreOps();
+        return {
+          ops: {
+            ...ops,
+            transcripts: { ...ops.transcripts, appendMessages: undefined },
+            // A mount that omits op 36 may not claim to have reached it — the
+            // status case pins that biconditional, and this mount is honest.
+            async status() {
+              return { ...(await ops.status()), ops: STORE_WIRE_APPEND_MESSAGES_OPS - 1 };
+            },
+          },
+        };
+      },
+    }));
+    expect(report.ok).toBe(true);
+    const omittedNames = report.omitted.map((one) => one.name);
+    expect(omittedNames.filter((name) => name.includes("appendMessages")).length).toBeGreaterThanOrEqual(6);
+    for (const one of report.omitted) {
+      if (one.name.includes("appendMessages")) expect(one.reason).toContain("omits transcripts.appendMessages");
+    }
+  });
+
+  /** The same guarantee for the OTHER optional family, which the retention lane
+      just landed an engine for: a BYO adapter with nowhere to quarantine to
+      still leaves `retention` off, and both cases over it must then be counted
+      rather than pass on an empty body. */
+  it("a mount that omits the retention family is counted, not quietly passed", async () => {
+    const report = await runConformance(storeOpsConformance({
+      async makeOps() {
+        return { ops: { ...memoryStoreOps(), retention: undefined } };
+      },
+    }));
+    expect(report.ok).toBe(true);
+    const retention = report.omitted.filter((one) => one.name.startsWith("retention."));
+    expect(retention).toHaveLength(2);
+    for (const one of retention) expect(one.reason).toContain("omits the retention family");
   });
 
   it("a deleteThread that leaves harness state behind fails conformance", async () => {

--- a/packages/core/tests/conformance/retention-cases.test.ts
+++ b/packages/core/tests/conformance/retention-cases.test.ts
@@ -90,12 +90,16 @@ describe("the retention cases catch what they were written for", () => {
     await expect(purge!.run()).rejects.toThrow(/purge cutoff predating the sweep should destroy nothing/);
   });
 
-  // The family is OPTIONAL (01 §12), and this is what that costs the suite:
-  // both cases no-op on a mount that omits it, which is what lets every mount
-  // carry them without going red.
-  it("passes both cases on a mount that omits the family entirely", async () => {
+  // The family is OPTIONAL (01 §12), so neither case may fail a mount that
+  // omits it — but neither may PASS one either, which is what a bare `return`
+  // used to do. Both report the omission instead, and `runConformance` counts
+  // it in its own bucket, so "this engine has nowhere to quarantine to" can
+  // never read as "this engine's sweep is correct".
+  it("reports an omission, not a pass, on a mount that omits the family entirely", async () => {
     for (const conformanceCase of retentionCases(() => ({ ...memoryStoreOps(), retention: undefined }))) {
-      await expect(conformanceCase.run()).resolves.toBeUndefined();
+      await expect(conformanceCase.run()).resolves.toEqual({
+        omitted: expect.stringContaining("omits the retention family"),
+      });
     }
   });
 });

--- a/packages/core/tests/conformance/store-ops-mutations.test.ts
+++ b/packages/core/tests/conformance/store-ops-mutations.test.ts
@@ -1,0 +1,358 @@
+import { describe, expect, it } from "vitest";
+import { memoryStoreOps, storeOpsConformance } from "../../src/conformance/index.js";
+import { VendoError } from "../../src/errors.js";
+import type { StoreOps, VendoRecord } from "../../src/store.js";
+
+/**
+ * Every case in the StoreOps kit is a claim that some specific mistake would be
+ * caught. A case that has only ever been run against implementations that
+ * happen to be correct proves nothing about that claim — it may assert the
+ * wrong thing, or nothing at all, and the day a second implementation arrives
+ * the suite's silence is indistinguishable from its approval.
+ *
+ * So each case added by the conformance-hardening lane is run here against a
+ * memory reference with exactly ONE rule broken, and asserted to go red for the
+ * reason it was written for. The message is asserted too: a case that fails for
+ * an unrelated reason is not the same as a case that caught its own bug.
+ *
+ * The CONCURRENCY flaws deserve a note. `memoryStoreOps` does its work without
+ * a single `await` inside any verb, so two calls fired at one instant run to
+ * completion one after the other and no race is observable — which is why the
+ * raced cases pass against it, and against PGlite's single connection, without
+ * proving anything there. The flaws below put the `await` back exactly where a
+ * real implementation has one: between the read and the write that depends on
+ * it. That window is the whole bug, on every engine that has more than one
+ * connection, and these are the only runs in the repo that open it on purpose.
+ */
+
+type Flaw =
+  | "claimReadsThenWrites"
+  | "claimDeleteDoesNothing"
+  | "insertReadsThenWrites"
+  | "swapReadsThenWrites"
+  | "refsMatchOnKeyAlone"
+  | "listingForgetsItsNamespace"
+  | "emptyBytesAreAbsence"
+  | "appsShareOneDrawer"
+  | "pageTwoForgetsTheOwner"
+  | "eraseByAppIsAReceipt"
+  | "appendSortsTheBatch"
+  | "appendNeverEdits"
+  | "appendAcceptsAnEmptyBatch"
+  | "appendRefusesAThreadItShouldCreate"
+  | "appendRevisionNeverMoves"
+  | "commitIgnoresItsGuard"
+  | "commitForgetsTheKey"
+  | "keyIgnoresItsOwner"
+  | "conflictCarriesNoDetail"
+  | "workspaceNormalisesContent"
+  | "readOfNoPathsRefuses"
+  | "emptyCommitIsAccepted"
+  | "indexDefaultsElsewhere";
+
+/** A message id nobody would collide with, so `appendNeverEdits` really appends. */
+let nonce = 0;
+
+/** One flat table of one-rule breakages. Deliberately not split into per-family
+    factories: the point is that each arm is small enough to read as "this and
+    only this is wrong", and an indirection between the flaw and its name would
+    cost exactly that. */
+function broken(flaw: Flaw): StoreOps {
+  const ops = memoryStoreOps();
+  const append = ops.transcripts.appendMessages!;
+  const yieldToTheOther = async (): Promise<void> => { await Promise.resolve(); };
+
+  switch (flaw) {
+    // ---- engine ---------------------------------------------------------
+    case "claimReadsThenWrites":
+      return { ...ops, engine: { ...ops.engine, async claim(collection, expected, replacement) {
+        const current = await ops.engine.get(collection, expected.id);
+        const matches = current !== null && JSON.stringify(current.data) === JSON.stringify(expected.data);
+        await yieldToTheOther(); // the window a second caller lands in
+        if (!matches) return false;
+        if (replacement === undefined) await ops.engine.delete(collection, expected.id);
+        else await ops.engine.put(collection, { id: expected.id, data: replacement.data, refs: replacement.refs });
+        return true;
+      } } };
+    case "claimDeleteDoesNothing":
+      return { ...ops, engine: { ...ops.engine, async claim(collection, expected, replacement) {
+        if (replacement === undefined) return true; // a release that reports success and releases nothing
+        return await ops.engine.claim(collection, expected, replacement);
+      } } };
+    case "insertReadsThenWrites":
+      return { ...ops, engine: { ...ops.engine, async insertIfAbsent(collection, record) {
+        const held = await ops.engine.get(collection, record.id);
+        await yieldToTheOther();
+        return held === null ? await ops.engine.put(collection, record) : null;
+      } } };
+    case "swapReadsThenWrites":
+      return { ...ops, engine: { ...ops.engine, async compareAndSwap(collection, record, expectedRevision) {
+        const held = await ops.engine.get(collection, record.id);
+        await yieldToTheOther();
+        return held?.revision === expectedRevision ? await ops.engine.put(collection, record) : null;
+      } } };
+    case "refsMatchOnKeyAlone":
+      return { ...ops, engine: { ...ops.engine, async list(collection, query) {
+        if (query?.refs === undefined) return await ops.engine.list(collection, query);
+        const { refs, ...rest } = query;
+        const page = await ops.engine.list(collection, rest);
+        return { ...page, records: page.records.filter((r) => Object.keys(refs).every((k) => r.refs?.[k] !== undefined)) };
+      } } };
+
+    // ---- blobs ----------------------------------------------------------
+    case "listingForgetsItsNamespace":
+      return { ...ops, blobs: { ...ops.blobs, async list(_namespace, prefix) {
+        const namespaces = ["conf_ns_a", "conf_ns_b", "conf_ns_c"];
+        const all = await Promise.all(namespaces.map((n) => ops.blobs.list(n, prefix)));
+        return [...new Set(all.flat())];
+      } } };
+    case "emptyBytesAreAbsence":
+      return { ...ops, blobs: { ...ops.blobs, async put(namespace, key, bytes, meta) {
+        if (bytes.length === 0) return; // a successful put that stored nothing
+        await ops.blobs.put(namespace, key, bytes, meta);
+      } } };
+
+    // ---- appData --------------------------------------------------------
+    case "appsShareOneDrawer": {
+      const flatten = <T>(target: { appId: string }, run: (t: never) => Promise<T>): Promise<T> =>
+        run({ ...target, appId: "one_drawer" } as never);
+      return { ...ops, appData: {
+        ...ops.appData,
+        put: (target, record) => flatten(target, (t) => ops.appData.put(t, record)),
+        get: (target, id) => flatten(target, (t) => ops.appData.get(t, id)),
+        list: (target, query) => flatten(target, (t) => ops.appData.list(t, query)),
+        delete: (target, id) => flatten(target, (t) => ops.appData.delete(t, id)),
+        putFile: (target, key, bytes, meta) => flatten(target, (t) => ops.appData.putFile(t, key, bytes, meta)),
+        getFile: (target, key) => flatten(target, (t) => ops.appData.getFile(t, key)),
+        deleteFile: (target, key) => flatten(target, (t) => ops.appData.deleteFile(t, key)),
+      } } as StoreOps;
+    }
+    case "pageTwoForgetsTheOwner":
+      return { ...ops, appData: { ...ops.appData, async list(target, query) {
+        if (query?.cursor === undefined) return await ops.appData.list(target, query);
+        return await ops.appData.list({ ...target, owner: "own_b" }, query);
+      } } };
+
+    // ---- lifecycle ------------------------------------------------------
+    case "eraseByAppIsAReceipt":
+      return { ...ops, lifecycle: { ...ops.lifecycle, async erase(target) {
+        if (target.appId !== undefined) return { erased: true }; // a receipt for work never done
+        return await ops.lifecycle.erase(target);
+      } } };
+
+    // ---- transcripts ----------------------------------------------------
+    case "appendSortsTheBatch":
+      return { ...ops, transcripts: { ...ops.transcripts, appendMessages: (threadId, subject, messages, opts) =>
+        append(threadId, subject, [...messages].sort((a, b) =>
+          String((a as { id?: unknown }).id) < String((b as { id?: unknown }).id) ? -1 : 1), opts) } };
+    case "appendNeverEdits":
+      return { ...ops, transcripts: { ...ops.transcripts, appendMessages: (threadId, subject, messages, opts) =>
+        append(threadId, subject, messages.map((message) => {
+          nonce += 1;
+          return { ...(message as object), id: `${String((message as { id?: unknown }).id)}#${nonce}` };
+        }), opts) } };
+    case "appendAcceptsAnEmptyBatch":
+      return { ...ops, transcripts: { ...ops.transcripts, appendMessages: async (threadId, subject, messages, opts) =>
+        messages.length === 0 ? { revision: "0", count: 0 } : await append(threadId, subject, messages, opts) } };
+    case "appendRefusesAThreadItShouldCreate":
+      return { ...ops, transcripts: { ...ops.transcripts, appendMessages: async (threadId, subject, messages, opts) => {
+        if (await ops.transcripts.getThread(threadId) === null) {
+          throw new VendoError("not-found", `thread ${threadId} not found`);
+        }
+        return await append(threadId, subject, messages, opts);
+      } } };
+    case "appendRevisionNeverMoves":
+      return { ...ops, transcripts: { ...ops.transcripts, appendMessages: async (threadId, subject, messages, opts) =>
+        ({ ...(await append(threadId, subject, messages, opts)), revision: "1" }) } };
+
+    // ---- workspace ------------------------------------------------------
+    case "commitIgnoresItsGuard":
+      return { ...ops, workspace: { ...ops.workspace, commit: (entries, opts) =>
+        ops.workspace.commit(entries.map((entry) => {
+          const { expectedRevision: _dropped, ...rest } = entry as Record<string, unknown>;
+          return rest;
+        }), opts) } };
+    case "commitForgetsTheKey":
+      return { ...ops, workspace: { ...ops.workspace, commit: (entries, opts) =>
+        ops.workspace.commit(entries, opts?.owner === undefined ? {} : { owner: opts.owner }) } };
+    case "keyIgnoresItsOwner": {
+      // One ledger for every owner, keyed on the key alone — the shape
+      // `IdempotencyScope`'s `tenant` field exists to forbid.
+      const ledger = new Map<string, string>();
+      return { ...ops, workspace: { ...ops.workspace, async commit(entries, opts) {
+        const key = opts?.idempotencyKey;
+        if (key === undefined) return await ops.workspace.commit(entries, opts);
+        const body = JSON.stringify(entries);
+        const held = ledger.get(key);
+        if (held === body) return;
+        if (held !== undefined) throw new VendoError("conflict", `idempotency key ${key} was already used for different entries`);
+        ledger.set(key, body);
+        return await ops.workspace.commit(entries, opts?.owner === undefined ? {} : { owner: opts.owner });
+      } } };
+    }
+    case "conflictCarriesNoDetail":
+      return { ...ops, workspace: { ...ops.workspace, async commit(entries, opts) {
+        try {
+          return await ops.workspace.commit(entries, opts);
+        } catch (error) {
+          throw new VendoError((error as VendoError).code, (error as Error).message);
+        }
+      } } };
+    case "workspaceNormalisesContent":
+      return { ...ops, workspace: { ...ops.workspace, commit: (entries, opts) =>
+        ops.workspace.commit(entries.map((entry) => {
+          const data = (entry as { data?: unknown }).data as { $vendoWorkspaceBytes?: unknown } | undefined;
+          if (data?.$vendoWorkspaceBytes === undefined) return entry;
+          // A store that models content as a struct it knows, and loses the rest.
+          return { ...(entry as object), data: { $vendoWorkspaceBytes: data.$vendoWorkspaceBytes } };
+        }), opts) } };
+    case "readOfNoPathsRefuses":
+      return { ...ops, workspace: { ...ops.workspace, async read(paths, opts) {
+        if (paths.length === 0) throw new VendoError("validation", "workspace.read needs at least one path");
+        return await ops.workspace.read(paths, opts);
+      } } };
+    case "emptyCommitIsAccepted":
+      return { ...ops, workspace: { ...ops.workspace, async commit(entries, opts) {
+        if (entries.length === 0) return;
+        await ops.workspace.commit(entries, opts);
+      } } };
+    case "indexDefaultsElsewhere":
+      return { ...ops, workspace: { ...ops.workspace, index: (query) =>
+        ops.workspace.index({ ...query, owner: query?.owner ?? "some_other_default" }) } };
+  }
+}
+
+/** The one case a flaw is supposed to break, and the assertion that must fire. */
+const proofs: Array<{ flaw: Flaw; case: string; red: RegExp }> = [
+  { flaw: "claimReadsThenWrites", case: "engine.claim under a real race lets exactly one caller win", red: /exactly one of two simultaneous claims may win, 2 did/ },
+  { flaw: "claimDeleteDoesNothing", case: "engine.claim with no replacement deletes exactly the row it matched", red: /the claimed row was not deleted/ },
+  { flaw: "insertReadsThenWrites", case: "engine.insertIfAbsent admits exactly one of four simultaneous writers", red: /exactly one of four simultaneous inserts may be admitted, 4 were/ },
+  { flaw: "swapReadsThenWrites", case: "engine.compareAndSwap lands exactly one of two swaps off one revision", red: /exactly one swap off one revision may land, 2 did/ },
+  { flaw: "refsMatchOnKeyAlone", case: "engine.list narrows by refs, exactly and ANDed", red: /a one-key ref filter returned the wrong rows/ },
+  { flaw: "listingForgetsItsNamespace", case: "blobs keep two namespaces apart on every verb", red: /a namespace listed a neighbour's keys/ },
+  { flaw: "emptyBytesAreAbsence", case: "blobs round-trip a zero-byte payload as content, not absence", red: /a stored zero-byte blob read back as absent/ },
+  { flaw: "appsShareOneDrawer", case: "appData keeps two apps' drawers apart", red: /one app read another app's row/ },
+  { flaw: "pageTwoForgetsTheOwner", case: "appData.list paginates one owner's drawer without loss, duplicates, or a neighbour's rows", red: /appData\.list: pagination (omitted or added entries|.* appeared on more than one page)/ },
+  { flaw: "eraseByAppIsAReceipt", case: "lifecycle.erase removes one app's data, and only that app's", red: /erase left the app's rows behind/ },
+  { flaw: "appendSortsTheBatch", case: "transcripts.appendMessages lands a batch after the tail, in the caller's order", red: /did not land after the tail in the order they were written/ },
+  { flaw: "appendNeverEdits", case: "transcripts.appendMessages edits an id the thread already holds, without moving it", red: /appended again, or moved, instead of edited in place/ },
+  { flaw: "appendAcceptsAnEmptyBatch", case: "transcripts.appendMessages refuses an empty batch and two messages under one id", red: /an empty batch did not throw/ },
+  { flaw: "appendRefusesAThreadItShouldCreate", case: "transcripts.appendMessages creates a thread that does not exist yet, under the named subject", red: /thread thr_new not found/ },
+  { flaw: "appendRevisionNeverMoves", case: "transcripts.appendMessages reports a revision that moves with every batch", red: /reported a revision an earlier one already used/ },
+  { flaw: "commitIgnoresItsGuard", case: "workspace.commit lands exactly one of two simultaneous compare-and-swaps", red: /exactly one commit off one revision may land, 2 did/ },
+  { flaw: "commitForgetsTheKey", case: "workspace.commit replays a double-fired idempotency key once it has an answer", red: /a replay after the key already had an answer committed again/ },
+  { flaw: "keyIgnoresItsOwner", case: "workspace.commit's idempotency key is scoped to its owner", red: /idempotency key shared_key was already used for different entries/ },
+  { flaw: "conflictCarriesNoDetail", case: "workspace.commit's conflict names the paths it refused on", red: /carried no detail/ },
+  { flaw: "workspaceNormalisesContent", case: "workspace round-trips the $vendoWorkspaceBytes envelope untouched", red: /binary envelope did not round-trip/ },
+  { flaw: "readOfNoPathsRefuses", case: "workspace.read of no paths is an empty answer, not a refusal", red: /workspace\.read needs at least one path/ },
+  { flaw: "emptyCommitIsAccepted", case: "workspace.commit refuses the same path twice in one commit, and an empty commit", red: /committing no entries at all did not throw/ },
+  { flaw: "indexDefaultsElsewhere", case: "the workspace's default owner is one drawer on every verb", red: /an index with no owner did not see a commit with no owner/ },
+];
+
+const caseNamed = (name: string, options: Parameters<typeof storeOpsConformance>[0]) => {
+  const found = storeOpsConformance(options).cases.find((one) => one.name === name);
+  if (found === undefined) throw new Error(`no conformance case named ${JSON.stringify(name)}`);
+  return found;
+};
+
+describe("every hardened StoreOps case fails against the mistake it names", () => {
+  it("covers one flaw per new case, with no case named twice", () => {
+    expect(new Set(proofs.map((proof) => proof.case)).size).toBe(proofs.length);
+    expect(new Set(proofs.map((proof) => proof.flaw)).size).toBe(proofs.length);
+  });
+
+  for (const proof of proofs) {
+    it(`catches ${proof.flaw}`, async () => {
+      const one = caseNamed(proof.case, { makeOps: async () => ({ ops: broken(proof.flaw) }) });
+      await expect(one.run()).rejects.toThrow(proof.red);
+    });
+  }
+});
+
+describe("the tenancy case", () => {
+  const NAME = "a neighbouring tenant shares no drawer with this one";
+
+  it("passes for two tenants that share nothing", async () => {
+    const one = caseNamed(NAME, {
+      makeOps: async () => ({ ops: memoryStoreOps() }),
+      makeNeighbour: async () => ({ ops: memoryStoreOps() }),
+    });
+    await expect(one.run()).resolves.toBeUndefined();
+  });
+
+  it("catches a neighbour that is really the same drawer", async () => {
+    const one = caseNamed(NAME, {
+      makeOps: async () => ({ ops: memoryStoreOps() }),
+      // The "neighbour" is this tenant's own handle — the shape a mount that
+      // forgot its tenant predicate presents.
+      makeNeighbour: async (ops) => ({ ops }),
+    });
+    await expect(one.run()).rejects.toThrow(/crossed the tenant line/);
+  });
+
+  it("reports an omission, not a pass, when the mount hands out no neighbour", async () => {
+    const one = caseNamed(NAME, { makeOps: async () => ({ ops: memoryStoreOps() }) });
+    await expect(one.run()).resolves.toEqual({ omitted: expect.stringContaining("one tenant") });
+  });
+
+  it("catches a neighbour whose erase reaches across", async () => {
+    // Separate drawers for everything the reads touch, ONE shared thread store:
+    // a leak that only the destructive verb opens, which the read assertions
+    // above would never see.
+    const mine = memoryStoreOps();
+    const theirs = memoryStoreOps();
+    const shared: StoreOps = {
+      ...theirs,
+      transcripts: mine.transcripts,
+      appData: mine.appData as StoreOps["appData"],
+    };
+    const one = caseNamed(NAME, {
+      makeOps: async () => ({ ops: mine }),
+      makeNeighbour: async () => ({ ops: shared }),
+    });
+    await expect(one.run()).rejects.toThrow(/tenant line|neighbour's/);
+  });
+});
+
+describe("the omission bucket is a bucket, not a pass", () => {
+  it("a case over an absent optional family answers omitted", async () => {
+    const ops = memoryStoreOps();
+    const one = caseNamed("transcripts.appendMessages lands a batch under the named subject", {
+      makeOps: async () => ({ ops: { ...ops, transcripts: { ...ops.transcripts, appendMessages: undefined } } }),
+    });
+    await expect(one.run()).resolves.toEqual({ omitted: expect.stringContaining("omits transcripts.appendMessages") });
+  });
+
+  it("and answers nothing at all when the family is served", async () => {
+    const one = caseNamed("transcripts.appendMessages lands a batch under the named subject", {
+      makeOps: async () => ({ ops: memoryStoreOps() }),
+    });
+    await expect(one.run()).resolves.toBeUndefined();
+  });
+});
+
+/** Not a mutation proof — a guard on the reference itself. `memoryStoreOps` is
+    what every one of the proofs above starts from, so a reference that quietly
+    stopped serving something would make a whole column of them vacuous. */
+describe("the memory reference serves what the proofs assume", () => {
+  it("serves the batch append and reports the level that says so", async () => {
+    const ops = memoryStoreOps();
+    expect(ops.transcripts.appendMessages).toBeTypeOf("function");
+    expect((await ops.status()).ops).toBeGreaterThanOrEqual(36);
+  });
+
+  it("cascades an app-scoped erase past harness state", async () => {
+    const ops = memoryStoreOps();
+    await ops.engine.put("vendo_apps", {
+      id: "app_x",
+      data: { subject: "u", enabled: true, doc: { format: "vendo/app@1", id: "app_x", name: "x" } },
+      refs: { subject: "u" },
+    });
+    const target = { appId: "app_x", collection: "notes", owner: "u" };
+    const row: VendoRecord = await ops.appData.put(target, { id: "r", data: {} });
+    expect(row.id).toBe("r");
+    await ops.lifecycle.erase({ appId: "app_x" });
+    expect(await ops.appData.get(target, "r")).toBeNull();
+    expect(await ops.engine.get("vendo_apps", "app_x")).toBeNull();
+  });
+});

--- a/packages/core/tests/conformance/store-ops-mutations.test.ts
+++ b/packages/core/tests/conformance/store-ops-mutations.test.ts
@@ -39,6 +39,7 @@ type Flaw =
   | "appendSortsTheBatch"
   | "appendNeverEdits"
   | "appendAcceptsAnEmptyBatch"
+  | "appendQuietlyDropsADuplicateId"
   | "appendRefusesAThreadItShouldCreate"
   | "appendRevisionNeverMoves"
   | "commitIgnoresItsGuard"
@@ -154,6 +155,17 @@ function broken(flaw: Flaw): StoreOps {
     case "appendAcceptsAnEmptyBatch":
       return { ...ops, transcripts: { ...ops.transcripts, appendMessages: async (threadId, subject, messages, opts) =>
         messages.length === 0 ? { revision: "0", count: 0 } : await append(threadId, subject, messages, opts) } };
+    case "appendQuietlyDropsADuplicateId":
+      return { ...ops, transcripts: { ...ops.transcripts, appendMessages: (threadId, subject, messages, opts) => {
+        // De-duplicating instead of refusing: the caller believes both landed.
+        const seen = new Set<string>();
+        return append(threadId, subject, messages.filter((message) => {
+          const id = String((message as { id?: unknown }).id);
+          if (seen.has(id)) return false;
+          seen.add(id);
+          return true;
+        }), opts);
+      } } };
     case "appendRefusesAThreadItShouldCreate":
       return { ...ops, transcripts: { ...ops.transcripts, appendMessages: async (threadId, subject, messages, opts) => {
         if (await ops.transcripts.getThread(threadId) === null) {
@@ -237,6 +249,7 @@ const proofs: Array<{ flaw: Flaw; case: string; red: RegExp }> = [
   { flaw: "appendSortsTheBatch", case: "transcripts.appendMessages lands a batch after the tail, in the caller's order", red: /did not land after the tail in the order they were written/ },
   { flaw: "appendNeverEdits", case: "transcripts.appendMessages edits an id the thread already holds, without moving it", red: /appended again, or moved, instead of edited in place/ },
   { flaw: "appendAcceptsAnEmptyBatch", case: "transcripts.appendMessages refuses an empty batch and two messages under one id", red: /an empty batch did not throw/ },
+  { flaw: "appendQuietlyDropsADuplicateId", case: "transcripts.appendMessages refuses an empty batch and two messages under one id", red: /two messages sharing one id did not throw/ },
   { flaw: "appendRefusesAThreadItShouldCreate", case: "transcripts.appendMessages creates a thread that does not exist yet, under the named subject", red: /thread thr_new not found/ },
   { flaw: "appendRevisionNeverMoves", case: "transcripts.appendMessages reports a revision that moves with every batch", red: /reported a revision an earlier one already used/ },
   { flaw: "commitIgnoresItsGuard", case: "workspace.commit lands exactly one of two simultaneous compare-and-swaps", red: /exactly one commit off one revision may land, 2 did/ },
@@ -256,9 +269,13 @@ const caseNamed = (name: string, options: Parameters<typeof storeOpsConformance>
 };
 
 describe("every hardened StoreOps case fails against the mistake it names", () => {
-  it("covers one flaw per new case, with no case named twice", () => {
-    expect(new Set(proofs.map((proof) => proof.case)).size).toBe(proofs.length);
+  it("names a distinct flaw per proof, and a case that exists for each", () => {
     expect(new Set(proofs.map((proof) => proof.flaw)).size).toBe(proofs.length);
+    // A case may be guarded by more than one flaw (the refusals case carries
+    // two independent refusals), but every named case has to exist.
+    const suite = storeOpsConformance({ makeOps: async () => ({ ops: memoryStoreOps() }) });
+    const names = new Set(suite.cases.map((one) => one.name));
+    for (const proof of proofs) expect(names).toContain(proof.case);
   });
 
   for (const proof of proofs) {

--- a/packages/core/tests/conformance/store-ops-mutations.test.ts
+++ b/packages/core/tests/conformance/store-ops-mutations.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { memoryStoreOps, storeOpsConformance } from "../../src/conformance/index.js";
+import { engineAppHistory } from "../../src/engine-collections.js";
 import { VendoError } from "../../src/errors.js";
+import type { IsoDateTime } from "../../src/ids.js";
 import type { StoreOps, VendoRecord } from "../../src/store.js";
 
 /**
@@ -356,6 +358,37 @@ describe("the memory reference serves what the proofs assume", () => {
     const ops = memoryStoreOps();
     expect(ops.transcripts.appendMessages).toBeTypeOf("function");
     expect((await ops.status()).ops).toBeGreaterThanOrEqual(36);
+  });
+
+  /** A quarantined row is still its owner's data. The local backend matches the
+      subject and app id it copies onto every lifted row (`store/src/erase.ts`),
+      so the reference has to as well — otherwise a retention lift is a way for
+      data to outlive an erasure, and the reference would disagree with the one
+      shipped engine on the one cascade nobody gets to re-run.
+      Read through `purge`, because that is the only door onto the quarantine:
+      a purge that finds nothing left to destroy is the erase having reached it. */
+  it("sweeps quarantined rows on both legs of the erase cascade", async () => {
+    const far = () => new Date(Date.now() + 86_400_000).toISOString() as IsoDateTime;
+    const lift = async (ops: StoreOps, collection: string): Promise<void> => {
+      const swept = await ops.retention!.quarantine(collection, far());
+      expect(swept.moved).toBe(1);
+    };
+
+    const bySubject = memoryStoreOps();
+    await bySubject.engine.put("vendo_parked_call", { id: "p1", data: {}, refs: { subject: "erase_me" } });
+    await bySubject.engine.put("vendo_parked_call", { id: "p2", data: {}, refs: { subject: "other" } });
+    expect((await bySubject.retention!.quarantine("vendo_parked_call", far())).moved).toBe(2);
+    await bySubject.lifecycle.erase({ subject: "erase_me" });
+    // One of the two lifted rows was this subject's, so only the neighbour's is
+    // left for the purge to destroy.
+    expect((await bySubject.retention!.purge("vendo_parked_call", far())).purged).toBe(1);
+
+    const byApp = memoryStoreOps();
+    const history = engineAppHistory("app_lifted");
+    await byApp.engine.put(history, { id: "v1", data: { version: 1 } });
+    await lift(byApp, history);
+    await byApp.lifecycle.erase({ appId: "app_lifted" });
+    expect((await byApp.retention!.purge(history, far())).purged).toBe(0);
   });
 
   it("cascades an app-scoped erase past harness state", async () => {

--- a/packages/core/tests/contract-coverage.e2e.test.ts
+++ b/packages/core/tests/contract-coverage.e2e.test.ts
@@ -493,6 +493,9 @@ describe("amended public export surface — root utilities and /conformance inve
       "memoryKnowledgeAdapter",
       "memoryStoreAdapter",
       "memoryStoreOps",
+      // How a case says the OPTIONAL member it covers is absent, so the report
+      // counts the omission instead of the case passing on an empty body.
+      "omitted",
       "runConformance",
       "secretsProviderConformance",
       "storeAdapterConformance",

--- a/packages/core/tests/store-wire.test.ts
+++ b/packages/core/tests/store-wire.test.ts
@@ -273,7 +273,13 @@ describe("vendo/store-wire@1", () => {
       thread: { id: "", subject: "s", messages: [] },
     }).success).toBe(false);
 
-    expect(storeWireTranscriptsGetThreadRequestSchema.parse({ id: "t1", limit: 50 }).limit).toBe(50);
+    // An id and nothing else. The `cursor`/`limit` this schema used to declare
+    // were a windowing request the answer has no room to page with, so no mount
+    // ever honored them; an older client still sending them is READ, not
+    // refused, which is what `.passthrough()` buys.
+    expect(storeWireTranscriptsGetThreadRequestSchema.parse({ id: "t1" }).id).toBe("t1");
+    expect("limit" in storeWireTranscriptsGetThreadRequestSchema.shape).toBe(false);
+    expect(storeWireTranscriptsGetThreadRequestSchema.safeParse({ id: "t1", limit: 50 }).success).toBe(true);
     expect(storeWireTranscriptsListThreadsRequestSchema.parse({ subject: "sub_user1" }).subject).toBe("sub_user1");
     expect(storeWireTranscriptsDeleteThreadRequestSchema.parse({ id: "t1" }).id).toBe("t1");
     expect(storeWireTranscriptsPutMessageRequestSchema.parse({ threadId: "t1", message: { role: "user", content: "test" } }).threadId).toBe("t1");
@@ -354,6 +360,22 @@ describe("vendo/store-wire@1", () => {
     expect(roundTripped.message).toBe("unknown record");
     expect(STORE_WIRE_STATUS_BY_CODE["cloud-required"]).toBe(402);
     expect(STORE_WIRE_STATUS_BY_CODE["validation"]).toBe(400);
+  });
+
+  /** `VendoError.detail` crosses. `workspace.commit`'s conflict names the paths
+      that moved in `detail.conflicts`, and before this the envelope carried a
+      code and a sentence, so a hosted caller had to re-read the whole index and
+      re-derive them by hand. A refusal with no detail still sends no key. */
+  it("the error envelope carries VendoError.detail, and omits it when there is none", () => {
+    const conflict = new VendoError("conflict", "the workspace moved on", { conflicts: ["a.json", "b.json"] });
+    const { status, body } = storeWireErrorBody(conflict);
+    expect(status).toBe(409);
+    expect(body.error.detail).toEqual({ conflicts: ["a.json", "b.json"] });
+    expect(parseStoreWireError(status, body).detail).toEqual({ conflicts: ["a.json", "b.json"] });
+
+    const plain = storeWireErrorBody(new VendoError("not-found", "unknown record"));
+    expect("detail" in plain.body.error).toBe(false);
+    expect(parseStoreWireError(plain.status, plain.body).detail).toBeUndefined();
   });
 
   it("parseStoreWireError: enveloped code wins, bare statuses map, junk degrades honestly", () => {

--- a/packages/store/src/helpers/rows.ts
+++ b/packages/store/src/helpers/rows.ts
@@ -180,6 +180,19 @@ export async function appendThreadMessages(
   },
   now = new Date().toISOString(),
 ): Promise<{ revision: string; count: number }> {
+  // An empty batch has nothing to land, and it must not touch the thread on its
+  // way to doing nothing: statement 1 below is an UPSERT, so an empty append
+  // would bump the revision of a thread it changed nothing in — and CREATE one
+  // that did not exist. The wire has always refused it
+  // (`storeWireTranscriptsAppendMessagesRequestSchema`, `messages.min(1)`), so
+  // this is the SQL half catching up rather than a new rule; the one caller,
+  // `upsertMany`, already returns early on an empty list.
+  if (input.messages.length === 0) {
+    throw new VendoError(
+      "validation",
+      `transcripts.appendMessages needs at least one message; the batch for thread ${input.threadId} was empty`,
+    );
+  }
   // ON CONFLICT cannot be given the same key twice in one statement (a bare
   // 21000 that loses the whole write), so the same guard putThreadRow applies
   // to a transcript applies to a batch — with the offender named.
@@ -211,7 +224,6 @@ export async function appendThreadMessages(
   if (row === undefined) {
     throw new VendoError("conflict", `thread ${input.threadId} belongs to another subject`);
   }
-  if (input.messages.length === 0) return { revision: String(row["revision"]), count: 0 };
   const landed = await db.query(
     `INSERT INTO vendo_thread_messages (thread_id, id, seq, message, created_at, updated_at)
      SELECT $1, m.id, tail.next + m.n - 1, a.elem, $4, $4

--- a/packages/store/src/hosted-store.ts
+++ b/packages/store/src/hosted-store.ts
@@ -522,8 +522,6 @@ function storeWireClient(
   const reportOf = (payload: unknown): unknown =>
     field(payload, "report", "invalid report", (value) => value !== undefined);
 
-  const cursorQuery = (query?: { cursor?: string; limit?: number }): Record<string, unknown> => ({ ...query });
-
   /** The one file-read posture, shared by `blobs.get` and `appData.getFile` so
       the two can never drift: a missing file is null at the seam (01-core §12),
       whether the service answers `{blob: null}` or an ENVELOPED not-found. A
@@ -691,8 +689,12 @@ function storeWireClient(
       async putThread(thread) {
         return recordOf(await mutate("transcripts.putThread", P["transcripts.putThread"], { thread }));
       },
-      async getThread(id, opts) {
-        return nullableRecordOf(await post("transcripts.getThread", P["transcripts.getThread"], { id, ...cursorQuery(opts) }));
+      /** The id and nothing else. This used to marshal a `{cursor, limit}` pair
+          the answer had no room to page with — see `getThread` in core's
+          store.ts — so the client was the only one of the three implementations
+          that sent them, and no mount ever honored them. */
+      async getThread(id) {
+        return nullableRecordOf(await post("transcripts.getThread", P["transcripts.getThread"], { id }));
       },
       async listThreads(query) {
         return listOf(await post("transcripts.listThreads", P["transcripts.listThreads"], { ...query }));

--- a/packages/store/src/ops.ts
+++ b/packages/store/src/ops.ts
@@ -60,6 +60,12 @@ interface WorkspaceEntry {
 }
 
 function parseWorkspaceEntries(entries: unknown[]): WorkspaceEntry[] {
+  // An empty commit is caller nonsense with no single right answer — a commit
+  // id and a history entry for a change nobody made, or silence — and the wire
+  // has always refused it (`storeWireWorkspaceCommitRequestSchema`,
+  // `entries.min(1)`), so the local half was answering a question the hosted
+  // half rejected.
+  if (entries.length === 0) invalid("a workspace commit must carry at least one entry");
   const seen = new Set<string>();
   return entries.map((entry) => {
     const path = (entry as { path?: unknown } | null)?.path;
@@ -622,10 +628,17 @@ export function createStoreOps(
         const parsed = parseWorkspaceEntries(entries);
         const body = JSON.stringify(parsed);
         const key = opts?.idempotencyKey;
-        // The ledger row id derives from the key, so the key IS the claim.
+        // The ledger row id derives from the key, so the key IS the claim — and
+        // the OWNER is part of it for the reason `IdempotencyScope`'s `tenant`
+        // is (core's store.ts): clients pick their own keys, two owners will
+        // pick the same one, and an id built from the key alone answers the
+        // second owner's commit out of the first owner's ledger row (as a
+        // replay when the bodies match, as a `conflict` when they do not).
+        // JSON, because an owner is the host's own user id in the host's own
+        // spelling and any delimiter is a character some host uses.
         const commitId = key === undefined
           ? `wsc_${globalThis.crypto.randomUUID()}`
-          : `wsc_key_${key}`;
+          : `wsc_key_${JSON.stringify([owner, key])}`;
         const rows = workspaceRows(db, files);
         // Stage: place every entry's content (inline decided, blob uploaded)
         // before any row is touched — the saga's only non-transactional leg.

--- a/packages/store/tests/hosted-store.test.ts
+++ b/packages/store/tests/hosted-store.test.ts
@@ -1002,8 +1002,11 @@ describe("hostedStoreOps — the 45-op wire client", () => {
     expect(await ops.transcripts.putThread(thread)).toMatchObject({ id: "inv_1" });
     expect(calls[0]!.body).toEqual({ thread });
 
-    expect(await ops.transcripts.getThread("thr_1", { cursor: "cur_1", limit: 50 })).toMatchObject({ id: "inv_1" });
-    expect(calls[1]!.body).toEqual({ id: "thr_1", cursor: "cur_1", limit: 50 });
+    // An id and nothing else: the `{cursor, limit}` this used to send was a
+    // windowing request the answer has no room to page with, so no mount ever
+    // honored it (core's store.ts, `getThread`).
+    expect(await ops.transcripts.getThread("thr_1")).toMatchObject({ id: "inv_1" });
+    expect(calls[1]!.body).toEqual({ id: "thr_1" });
 
     expect(await ops.transcripts.listThreads({ subject: "sub_1", limit: 25 })).toEqual({
       records: [expect.objectContaining({ id: "inv_1" })],

--- a/packages/store/tests/ops.test.ts
+++ b/packages/store/tests/ops.test.ts
@@ -138,7 +138,10 @@ for (const backend of backends()) {
         // body — the loser's mutation never touched the workspace.
         const rows = await made.sql(
           "SELECT data FROM vendo_records WHERE collection = $1 AND id = $2",
-          ["vendo_workspace_commits", "wsc_key_idem_race"],
+          // The ledger id carries the OWNER as well as the key — two owners
+          // pick the same key routinely, and a key-only id answers one owner's
+          // commit out of the other's row (see `commitId` in ops.ts).
+          ["vendo_workspace_commits", `wsc_key_${JSON.stringify(["user_local", "idem_race"])}`],
         );
         expect(rows.length).toBe(1);
         const winner = results[0]!.status === "fulfilled" ? { v: "first" } : { v: "second" };


### PR DESCRIPTION
A second implementation of `StoreOps` — a native multi-tenant Cloud store — is
being built against this kit. The kit as it stood could be passed by an
implementation that is wrong about concurrency, wrong about tenancy, and
silently missing a whole optional family. This closes those blind spots and the
six places where the three shipped implementations disagreed with each other.

**23 new conformance cases, every one mutation-proved.** The diff is mostly the
kit and its proofs; the production surface it touches is 5 files in
`packages/core/src` and 3 in `packages/store/src`.

---

## Gap-by-gap

| # | Gap | What was there | What is there now |
|---|-----|----------------|-------------------|
| 1 | **Concurrency** | Every atomic op proven by two calls in SEQUENCE. `engine.claim`'s case even said so: *"Sequential, not concurrent"* | 5 raced cases over `Promise.all`: `engine.claim`, `insertIfAbsent`, `compareAndSwap`, `workspace.commit`'s CAS, and a double-fired idempotency key. Assertions name invariants, never a winner |
| 2 | **Tenancy** | Nothing in the kit. Isolation rested on one console-side test | `makeNeighbour` — a second handle on the same store, another tenant. One case over records, blobs, app rows, threads, secrets and workspace files, in **both directions**, plus one tenant's `erase` not reaching the other. Also two in-contract axes nothing covered: per-appId isolation, and blob namespace isolation on every verb |
| 3 | **`transcripts.appendMessages`** | One case, opening `if (append === undefined) return;` — a mount omitting the op passed 6 assertions by running none | 6 cases (batch order after the tail, edit-by-id in place without moving it, the two refusals, the thread it creates, a revision that moves every batch), and the silent skip is gone — see below |
| 4 | **Idempotency across gated families** | `workspace.commit` only | Still `workspace.commit` only, and that is correct: it is the **one** op in the contract whose signature carries a key (`store.ts` `workspace.commit(entries, opts?: { idempotencyKey })`); every other mutation's key is generated by the client per request (`hosted-store.ts` `mutate`). What was missing was depth, not breadth — the double-fire race and the key's **owner scope** are new |
| 5 | **Untested branches** | — | `engine.claim`'s delete form, `lifecycle.erase({ appId })`, `appData.list` pagination, `engine.list`'s refs filter, blob namespace isolation, `$vendoWorkspaceBytes`, commit-conflict `detail` — all now cases |
| 6 | **Divergences** | 6 places where the memory reference, the local backend and the cloud client disagreed | Closed, each justified below |

## The six divergence closures

Each was closed toward whichever answer **two of three** implementations already
gave, or toward the one that has no second sensible answer.

1. **Zero-byte blobs.** The wire required `bytes: z.string().min(1)`; base64 of
   an empty payload is `""`, so the client refused an empty file that both local
   implementations stored happily — and the caller's `get` then answered null,
   indistinguishable from a key nobody wrote. `.min(1)` removed.
2. **`workspace.read([])`** answers `{}`, everywhere. Reading nothing has exactly
   one possible answer, and forcing a `paths.length === 0` guard on every caller
   means the one that forgets turns an empty filter into a thrown error.
3. **`workspace.commit([])`** is refused as `validation`, everywhere. An empty
   commit has *no* single right answer (a commit id and a trail entry for a
   change nobody made — or silence), and the wire already refused it while the
   local half accepted it and wrote a history entry.
4. **`transcripts.appendMessages([])`** is refused as `validation`, matching the
   wire's `messages.min(1)`. The SQL half accepted it, bumped the thread's
   revision on a call that landed nothing, and would **create** a thread that did
   not exist. The one caller (`upsertMany`) already returns early on an empty
   list, so nothing relied on it.
5. **`VendoError.detail` crosses the wire.** The envelope carried a code and a
   sentence, so every structured payload a refusal carried was readable locally
   and lost to a hosted caller — `workspace.commit`'s conflict names the paths
   that moved, and the hosted path re-read the whole index to re-derive them by
   hand (`workspace-ops-rows.ts` says so in a comment). `detail` is optional and
   passed through untouched, so an old mount and an old client both stay legal.
6. **`workspace.commit`'s idempotency ledger is scoped to its owner.** The ledger
   row id was `wsc_key_<key>` — no owner. Clients pick their own keys and two
   owners will pick the same one, so one owner's commit was decided by another
   owner's traffic: replayed when the bodies matched, refused as `conflict` when
   they did not. This is the rule `IdempotencyScope`'s own doc already states
   ("a mount that serves many tenants out of one schema would otherwise let one
   tenant's key collide with another's"). Found by writing the tenancy case.

## Decision: `getThread`'s `cursor`/`limit` — **removed**

Removed from `StoreOps`, from `storeWireTranscriptsGetThreadRequestSchema`, and
from the cloud client.

- **It cannot be implemented as declared.** `getThread` answers with one
  `VendoRecord`. There is nowhere in that answer for a next-page cursor, so a
  windowed read could never tell a caller there is more. Implementing it means
  changing the return type — a much larger break than removing two options.
- **Nobody implements it.** The local backend does not even accept the parameter
  (`ops.ts` `async getThread(id)`); the memory reference took `_opts` and ignored
  it. The cloud client was the only one of three that marshalled the fields, and
  it sent them blind.
- **Nobody calls it.** Every call site in the repo passes one argument. The sole
  exception was a body-shape assertion in `hosted-store.test.ts`.
- **It is the exact failure `EngineListPage.watermark` exists to prevent.** A
  caller that passed `{ limit: 50 }` got the entire transcript and no signal —
  silently wrong, not refused. A field on an existing op has no 501 to protect it.
- **Provenance.** It arrived in #784 by pattern-cloning the list ops (that
  commit's own message says so), and the backend that landed the next day
  already omitted it. Never a regression; never a feature.
- `.passthrough()` means a client still sending the fields is read, not refused.

## Decision: hosted workspace owner-defaulting — **pinned, not fixed**

Not provably behavior-safe, so it stays. The local backend and the memory
reference resolve an omitted `owner` to a bound constant (`"user_local"`); the
cloud client omits the field and lets the mount resolve it. **Whether those two
drawers are the same drawer is decided in the console, which OSS cannot see** —
and the suite has never been run against the cloud client, so nothing in this
repo could assert it either way. Changing the client to always send an owner
would mean inventing a bound workspace owner in `HostedStoreOptions`, whose
existing `owner` field is documented and used exclusively for appData scoping;
overloading one field across two scoping domains to fix an unobservable is the
wrong trade at this size.

What every mount owes regardless is **coherence**, and that is now a case: the
default drawer must be ONE drawer on all four verbs, and it must not be
everyone's. This is not hypothetical — two of the cloud client's four workspace
verbs (`index`, `history`) spread the query straight onto the body instead of
going through its `owned()` helper, and are correct today only because
`JSON.stringify` drops `undefined`. **Flagged, not changed.**

## Silent skips are gone

`ConformanceCase.run` may now resolve to `{ omitted: reason }`, and
`ConformanceReport` gains an `omitted` bucket:
`passed + pending + omitted + failures === cases`. Before this, a case over an
absent optional family `return`ed early and the report counted it as a **pass** —
"this mount has no batch append" and "this mount's batch append is correct" were
the same green line. The memory reference now serves `appendMessages` (op level
36) so the kit has a complete reference; a test strips it back off and asserts
the omissions are counted.

## Mutations (each new case broken, watched go red, restored)

Every one lives in `packages/core/tests/conformance/store-ops-mutations.test.ts`
as a one-rule breakage of the memory reference, asserted to fail with **its own**
message — a case that fails for an unrelated reason has not caught anything.

The concurrency ones matter most: `memoryStoreOps` has no `await` inside any
verb and PGlite is single-connection, so a raced case passes against both
without proving anything. Four flaws put the `await` back exactly where a real
implementation has one — between the read and the write that depends on it.

| Flaw | Case it must break |
|---|---|
| `claimReadsThenWrites` | `engine.claim` under a real race |
| `claimDeleteDoesNothing` | `engine.claim` with no replacement |
| `insertReadsThenWrites` | `insertIfAbsent` admits one of four |
| `swapReadsThenWrites` | `compareAndSwap` lands one of two |
| `commitIgnoresItsGuard` | `workspace.commit`'s raced CAS |
| `commitForgetsTheKey` | double-fired idempotency key |
| `keyIgnoresItsOwner` | the key's owner scope |
| `refsMatchOnKeyAlone` | `engine.list` refs |
| `listingForgetsItsNamespace` | blob namespace isolation |
| `emptyBytesAreAbsence` | zero-byte blob |
| `appsShareOneDrawer` | two apps' drawers |
| `pageTwoForgetsTheOwner` | `appData.list` paging |
| `eraseByAppIsAReceipt` | `erase({ appId })` |
| `appendSortsTheBatch` | batch order |
| `appendNeverEdits` | edit-by-id in place |
| `appendAcceptsAnEmptyBatch` / `appendQuietlyDropsADuplicateId` | the two refusals |
| `appendRefusesAThreadItShouldCreate` | the thread it creates |
| `appendRevisionNeverMoves` | revision monotonicity |
| `conflictCarriesNoDetail` | commit-conflict `detail` |
| `workspaceNormalisesContent` | `$vendoWorkspaceBytes` |
| `readOfNoPathsRefuses` | `read([])` |
| `emptyCommitIsAccepted` | `commit([])` |
| `indexDefaultsElsewhere` | the default owner's coherence |

Plus three for the tenancy case (a neighbour that is really the same handle; a
neighbour reachable only by `erase`; the omission answer) and two for the
omission bucket itself.

## Gate

```
pnpm build         21/21 ✔
pnpm typecheck     42/42 ✔
pnpm lint           4/4  ✔
pnpm test:affected 45/45 ✔   (first run exit 0)
  @vendoai/core      738 passed | 2 skipped (49 files)
  @vendoai/store     all 61 files ✔ — ops.conformance 88 passed | 2 skipped
  @vendoai/vendo     215 passed | 11 skipped     @vendoai/apps  130 | 3
  @vendoai/ui        126 ✔     harnesses 48 | 3  guard 34 | 1   actions 51 | 1
core coverage      97.93% lines (floor 97) · conformance/ 99.61% · store-ops.ts 99.86%
```

A second, overlapping `test:affected` run (started by mistake while the first
was still finishing) reported `demo-bank` and `fixtures/integration` red with
`EADDRINUSE: :::51267` — two suite runs fighting over one fixture port. Both are
green in isolation on this branch (`integration` 47 passed, `demo-bank` 119
passed), and `demo-bank`'s away-drill also passes unchanged on `origin/main`,
so it is the collision and not this diff. Sequential re-run: 17/17 tasks ✔.

Races only genuinely race on the **Postgres** leg — PGlite serializes on one
connection and the memory reference never yields — which is why the mutation
proofs, not the green run, are the evidence here. CI runs the Postgres leg.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the `StoreOps` conformance kit to prove concurrency and tenancy, and closes six cross-implementation divergences. Behavior changes: removed `transcripts.getThread` pagination args; zero-byte blobs are valid; `workspace.read([])` returns `{}`; `workspace.commit([])` and `transcripts.appendMessages([])` are refused (`validation`); `workspace.commit` idempotency ledger is scoped by owner; `VendoError.detail` passes over the wire. The kit now races atomic ops, counts omitted optional families via `omitted`, and covers previously untested branches.

- The old `getThread(id, { cursor, limit })` shape is removed from `@vendoai/core` types and the `@vendoai/store` hosted client; the wire schema reads extra fields from older clients via `.passthrough()`.
- Concurrency cases race `engine.claim`, `insertIfAbsent`, `compareAndSwap`, `workspace.commit`'s CAS, and a double-fired idempotency key; assertions name invariants, not winners.
- Tenancy cases add `makeNeighbour` to prove cross-tenant isolation across records, blobs, app rows, threads, secrets, and workspace files; plus appId and blob-namespace isolation.
- `appendMessages` behavior is specified (batch order, edit-by-id in place, refusals, thread creation, revision movement); untested branches now covered (claim delete, `erase({ appId })`, `appData.list` paging, `engine.list` refs filter, blob namespace isolation, `$vendoWorkspaceBytes`, commit-conflict `detail`).
- Hosted owner-defaulting remains pinned (unchanged).

**Review/Migration**
- Update callers of `transcripts.getThread(id, opts?)` to `getThread(id)`; remove pagination args.
- Ensure no code emits empty `workspace.commit` or `transcripts.appendMessages`; short-circuit empty batches.
- If anything inspects the commit ledger row id directly, update to `wsc_key_${JSON.stringify([owner, key])}`.
- No other migrations; older clients sending `cursor/limit` still succeed due to wire `.passthrough()`.

<sup>Written for commit 51a5b6536a9bce8d6d6b7e61693e2690c477220c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

