### PR TITLE
feat(genbench): a case declares the UI shape it asks for

### DIFF
--- a/genbench/src/report.ts
+++ b/genbench/src/report.ts
@@ -278,6 +278,44 @@ const spendLine = (
     `<span>not counted in any contender's cost</span></p>`;
 };
 
+/**
+ * The run's floor score by shape — the only place on this page a contender's
+ * screens are added up at all. Every column below is a single screen, so a
+ * contender that holds the floor everywhere except charts says so here and
+ * nowhere else.
+ *
+ * The cells are the columns' OWN checks, summed: `checks` is the same function
+ * `column` scores with, so a cell can never disagree with the columns beneath it
+ * except by being their total. A shape nobody ran a case for is muted rather
+ * than scored, for the reason a vacuous `honestData` pass is — 0/0 painted green
+ * is a claim about a contender that was never put to the test.
+ */
+const shapeTable = (results: readonly CaseResult[]): string => {
+  if (results.length === 0) return "";
+  const shapes = [...new Set(results.map((result) => result.shape))].sort();
+  // First-seen, so the cells read left to right in the column order below.
+  const contenders = [...new Set(results.map((result) => result.contender))];
+  const cell = (rows: readonly CaseResult[]): string => {
+    const scored = rows.flatMap((row) => checks(row.floor));
+    if (scored.length === 0) return `<td class="muted">—</td>`;
+    const passed = scored.filter((check) => check.pass).length;
+    return `<td class="${passed === scored.length ? "ok" : "no"}">${passed}/${scored.length}</td>`;
+  };
+  return `<table class="shapes">
+  <thead><tr><th>shape</th><th>cases</th>${contenders
+    .map((contender) => `<th>${escape(contender)}</th>`)
+    .join("")}</tr></thead>
+  <tbody>${shapes
+    .map((shape) => {
+      const rows = results.filter((result) => result.shape === shape);
+      return `<tr><th>${escape(shape)}</th><td>${new Set(rows.map((row) => row.case)).size}</td>${contenders
+        .map((contender) => cell(rows.filter((row) => row.contender === contender)))
+        .join("")}</tr>`;
+    })
+    .join("")}</tbody>
+</table>`;
+};
+
 const spent = <T,>(results: readonly CaseResult[], of: (result: CaseResult) => T | undefined): T[] =>
   results.flatMap((result) => {
     const cost = of(result);
@@ -331,6 +369,16 @@ h1{margin:0;font-size:28px;font-weight:600;letter-spacing:-.02em}
 /* The run's own overhead, tucked under the run line it belongs to rather than
    given a panel: it is a fact about the benchmark, not a result. */
 .meta.spend{margin-top:6px}
+/* ---- the run's scoreboard by shape: the columns' own checks, added up ---- */
+.shapes{width:100%;margin:20px 0 0;border-collapse:collapse;overflow:hidden;background:var(--card);
+  border-radius:10px;box-shadow:0 1px 2px rgba(0,0,0,.04),0 8px 24px rgba(0,0,0,.05)}
+.shapes th,.shapes td{padding:9px 16px;text-align:right;border-bottom:1px solid var(--line);
+  font:450 13px/1 ui-monospace,SFMono-Regular,Menlo,monospace;font-variant-numeric:tabular-nums}
+.shapes th:first-child{text-align:left}
+.shapes thead th{font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:var(--ter)}
+.shapes tbody th{font-weight:600;color:var(--ink)}
+.shapes tbody tr:last-child th,.shapes tbody tr:last-child td{border-bottom:0}
+.shapes .muted{color:var(--ter)}
 /* The prompt is the heading a person reads; the case id is a filename. */
 .case{margin-top:48px}
 .case-id{margin:0;font:450 11px/1 ui-monospace,SFMono-Regular,Menlo,monospace;
@@ -539,6 +587,7 @@ export async function writePreview(input: {
 <p class="meta"><span>${escape(input.runId)}</span><span>world ${escape(first?.world ?? "")}</span><span>${escape(first?.lane ?? "screen")} lane</span></p>
 ${spendLine("judge", "graded", spent(input.results, (result) => result.judged.cost))}
 ${spendLine("honesty check", "sorted and audited", spent(input.results, (result) => result.floor.honestData.cost))}
+${shapeTable(input.results)}
 ${sections.join("")}
 </div>
 <aside class="feed"><p class="feed-label">tool calls</p><ol id="feed"></ol></aside>

--- a/genbench/src/run.ts
+++ b/genbench/src/run.ts
@@ -15,7 +15,7 @@ import { authoredPage, bundleMount, openBrowser, pageHtml, type Shot } from "./r
 import { tally, writePreview } from "./report.js";
 import { TriageContract } from "./triage.js";
 import { vendoDriver } from "./vendo.js";
-import { caseHash, loadCases, loadWorld, worldForCase, type Case, type Lane, type World } from "./world.js";
+import { caseHash, loadCases, loadWorld, worldForCase, type Case, type CaseShape, type Lane, type World } from "./world.js";
 
 export type HarnessId = "vendo" | "diy" | "claude-code";
 
@@ -72,6 +72,7 @@ export interface CaseResult {
   readonly case: string;
   readonly prompt: string;
   readonly lane: Lane;
+  readonly shape: CaseShape;
   readonly floor: FloorResult;
   readonly timing: { firstRenderMs?: number; settledMs: number };
   readonly cost: { usage: UsageTotals; usd: number };
@@ -374,6 +375,7 @@ async function main(argv: readonly string[]): Promise<number> {
       case: testCase.id,
       prompt: testCase.prompt,
       lane: testCase.lane,
+      shape: testCase.shape,
       floor,
       timing: {
         ...(outcome?.firstRenderMs === undefined ? {} : { firstRenderMs: outcome.firstRenderMs }),

--- a/genbench/src/world.ts
+++ b/genbench/src/world.ts
@@ -59,6 +59,32 @@ export type Lane = "screen" | "build";
  *  (`display`), or one that also has to act through a write tool (`action`). */
 export type CaseTag = "display" | "action";
 
+/** The UI shapes the real-software sweep found, as ONE list: trimming the
+ *  taxonomy is a one-line edit here, and the lint reads the same list. */
+export const CASE_SHAPES = [
+  "table",
+  "chart",
+  "form",
+  "detail",
+  "dashboard",
+  "board",
+  "calendar",
+  "wizard",
+  "settings",
+  "filter-builder",
+  "permissions",
+  "list-feed",
+  "timeline",
+  "map",
+  "split-inbox",
+  "comparison",
+  "empty-state",
+  "tree",
+  "gallery",
+] as const;
+
+export type CaseShape = (typeof CASE_SHAPES)[number];
+
 export interface Case {
   readonly id: string;
   readonly lane: Lane;
@@ -67,6 +93,14 @@ export interface Case {
   /** Absent from `caseHash` on purpose: tagging a case does not change the
    *  question it asks, so it must not declare every recorded run incomparable. */
   readonly tags?: readonly CaseTag[];
+  /** Absent from `caseHash` for the reason `tags` is: filing a case under the
+   *  shape it asks for does not change the question it asks, so it must not
+   *  declare every recorded run incomparable. */
+  readonly shape: CaseShape;
+  /** The real screen this case was mined from — product and screen, with the URL
+   *  when one exists. Out of `caseHash` too: where a question was found is not
+   *  the question. */
+  readonly source?: string;
   /** Per-case tool-data override, e.g. an empty state. Replaces `data` for the
    *  named tools only; every other tool keeps the world's data. */
   readonly data?: Readonly<Record<string, unknown>>;

--- a/genbench/src/world.ts
+++ b/genbench/src/world.ts
@@ -81,6 +81,7 @@ export const CASE_SHAPES = [
   "empty-state",
   "tree",
   "gallery",
+  "feed-composer",
 ] as const;
 
 export type CaseShape = (typeof CASE_SHAPES)[number];

--- a/genbench/tests/claude-code.test.ts
+++ b/genbench/tests/claude-code.test.ts
@@ -23,7 +23,7 @@ beforeAll(async () => {
   world = await loadWorld(join(root, "worlds", "maple"));
 });
 
-const caseFor = (id: string): Case => ({ id, lane: "screen", prompt: "Show my pending transfers", pass: [] });
+const caseFor = (id: string): Case => ({ id, lane: "screen", prompt: "Show my pending transfers", pass: [], shape: "table" });
 
 /** The run's clock, and nothing else the driver may lean on: this contender is
  *  billed by the SDK's own session, so a meter it actually used would be a lie. */

--- a/genbench/tests/report.test.ts
+++ b/genbench/tests/report.test.ts
@@ -53,6 +53,7 @@ const resultFor = (contender: string, testCase: string, prompt: string, judged: 
   case: testCase,
   prompt,
   lane: "screen",
+  shape: "table",
   floor: PASSING,
   timing: { firstRenderMs: 1_000, settledMs: 2_000 },
   cost: { usage: { inputTokens: 1, outputTokens: 1, cacheReadTokens: 0, cacheWriteTokens: 0, calls: 1 }, usd: 0.01 },

--- a/genbench/tests/report.test.ts
+++ b/genbench/tests/report.test.ts
@@ -212,6 +212,34 @@ describe("the preview page", () => {
     expect(html).not.toContain("judge ·");
   });
 
+  /**
+   * The one place on this page a contender's screens are added up, so the sum
+   * is what has to be checked — and a shape a contender never ran must not be
+   * scored: 0/0 painted green is a claim about a contender nobody put to the test.
+   */
+  it("adds a contender's checks up by shape, and leaves a shape it never ran unscored", async () => {
+    const html = await preview(
+      [
+        resultFor("vendo-sonnet", "pending-transfers", "Show my pending transfers."),
+        resultFor("diy-sonnet", "pending-transfers", "Show my pending transfers."),
+        {
+          ...resultFor("vendo-sonnet", "spend-overview", "Show me where my money went."),
+          floor: { ...PASSING, renders: false, valid: false, pass: false },
+        },
+        { ...resultFor("vendo-sonnet", "spend-chart", "Chart my spending by category."), shape: "chart" },
+      ],
+      { "pending-transfers": world, "spend-overview": world, "spend-chart": world },
+    );
+
+    // Two table cases at five checks each: vendo ran both and lost two checks on
+    // one, diy ran one of the two and held everything on it.
+    expect(html).toContain(`<tr><th>table</th><td>2</td><td class="no">8/10</td><td class="ok">5/5</td></tr>`);
+    // Only vendo ran the chart case, so diy's cell says so rather than scoring it.
+    expect(html).toContain(`<tr><th>chart</th><td>1</td><td class="ok">5/5</td><td class="muted">—</td></tr>`);
+    // Shapes nobody ran are not rows at all.
+    expect(html).not.toContain(`<th>form</th>`);
+  });
+
   it("carries the listener that turns a press in an embedded page into a feed row", async () => {
     const html = await preview([resultFor("vendo-sonnet", "spend-overview", "Show me where my money went.")], {
       "spend-overview": world,

--- a/genbench/tests/run-folder.test.ts
+++ b/genbench/tests/run-folder.test.ts
@@ -70,6 +70,7 @@ const RESULT: CaseResult = {
   case: "pending-transfers",
   prompt: "Show my pending transfers.",
   lane: "screen",
+  shape: "table",
   floor: PASSING,
   timing: { firstRenderMs: 1_000, settledMs: 2_000 },
   cost: { usage: { inputTokens: 1, outputTokens: 1, cacheReadTokens: 0, cacheWriteTokens: 0, calls: 1 }, usd: 0.01 },

--- a/genbench/tests/run.test.ts
+++ b/genbench/tests/run.test.ts
@@ -128,6 +128,7 @@ const scored = (floor: FloorResult, judged: JudgeResult): CaseResult => ({
   case: "pending-transfers",
   prompt: "Show my pending transfers.",
   lane: "screen",
+  shape: "table",
   floor,
   timing: { settledMs: 1 },
   cost: { usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, calls: 0 }, usd: 0 },

--- a/genbench/tests/seam.test.ts
+++ b/genbench/tests/seam.test.ts
@@ -194,6 +194,7 @@ const resultFor = (contender: string): CaseResult => ({
   case: "pending-transfers",
   prompt: "Show my pending transfers.",
   lane: "screen",
+  shape: "table",
   floor: PASSING,
   timing: { settledMs: 1 },
   cost: { usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, calls: 0 }, usd: 0 },

--- a/genbench/tests/vendo.test.ts
+++ b/genbench/tests/vendo.test.ts
@@ -80,7 +80,7 @@ beforeAll(async () => {
   world = await loadWorld(join(root, "worlds", "maple"));
 });
 
-const caseFor = (id: string): Case => ({ id, lane: "screen", prompt: "Show this month's spending", pass: [] });
+const caseFor = (id: string): Case => ({ id, lane: "screen", prompt: "Show this month's spending", pass: [], shape: "table" });
 
 describe("the vendo driver reports one revision", () => {
   it("does not report an earlier revision's view beside a final save that never painted", async () => {

--- a/genbench/tests/worlds.test.ts
+++ b/genbench/tests/worlds.test.ts
@@ -15,7 +15,7 @@ import { fileURLToPath } from "node:url";
 import { vendoThemeSchema } from "@vendoai/apps/contract";
 import { TOOL_NAME_PATTERN } from "@vendoai/core";
 import { beforeAll, describe, expect, it } from "vitest";
-import { loadCases, loadWorld, type Case, type CaseTag, type World } from "../src/world.js";
+import { CASE_SHAPES, loadCases, loadWorld, type Case, type CaseTag, type World } from "../src/world.js";
 
 const worldsDir = join(dirname(dirname(fileURLToPath(import.meta.url))), "worlds");
 
@@ -219,6 +219,17 @@ for (const name of folders) {
 
       const actions = cases.filter((entry) => (entry.tags ?? []).includes("action"));
       expect(actions.length, "a world whose cases never act grades no write tool").toBeGreaterThanOrEqual(3);
+    });
+
+    it("gives every case one shape, and any source it names a real one", () => {
+      const shapeless = cases.filter((entry) => !CASE_SHAPES.includes(entry.shape)).map((entry) => entry.id);
+      expect(shapeless, `each case carries one shape of ${CASE_SHAPES.join(" | ")}`).toEqual([]);
+
+      // `source` stays optional — a case authored before the sweep names no screen.
+      const blank = cases
+        .filter((entry) => entry.source !== undefined && (typeof entry.source !== "string" || entry.source.trim() === ""))
+        .map((entry) => entry.id);
+      expect(blank, "a case that declares a source names one").toEqual([]);
     });
 
     it("carries at least ten cases", () => {

--- a/genbench/worlds/clinic-scheduling/cases.json
+++ b/genbench/worlds/clinic-scheduling/cases.json
@@ -10,7 +10,8 @@
       "pressing check-in calls the check-in tool with that row's own appointment",
       "marking a no-show asks for confirmation before it goes through"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "table"
   },
   {
     "id": "day-by-provider",
@@ -22,7 +23,8 @@
       "shows the open slots the tool returned as open time, in the right provider's lane",
       "invents no appointment and no opening the tools did not return"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "calendar"
   },
   {
     "id": "patient-record",
@@ -34,7 +36,8 @@
       "shows today's appointment for her: the time, the provider and the visit type",
       "shows no other patient's details on the screen"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "detail"
   },
   {
     "id": "book-visit",
@@ -46,7 +49,8 @@
       "the slot choices are the open slots the tool returned, shown as times",
       "submitting calls the booking tool with all four values filled in"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "form"
   },
   {
     "id": "front-desk-now",
@@ -58,7 +62,8 @@
       "shows every room the tool returned with its status, so a person can see which are free",
       "every count on the screen matches the rows the tools returned"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "dashboard"
   },
   {
     "id": "no-show-trend",
@@ -70,7 +75,8 @@
       "labels each week so a person can tell which one it is",
       "the week of Jul 27 reads as the worst week for no-shows"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "chart"
   },
   {
     "id": "fill-cancellation",
@@ -82,7 +88,8 @@
       "shows how long each of those patients has been waiting",
       "offering the slot calls the waitlist tool with that patient's waitlist entry and that slot"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "list-feed"
   },
   {
     "id": "lobby-board",
@@ -94,7 +101,8 @@
       "nothing on the screen says why anyone is here: no visit type, no reason, no insurer",
       "each person reads as waiting or in a room, matching the tool's rows"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "list-feed"
   },
   {
     "id": "confirm-sweep",
@@ -106,7 +114,8 @@
       "asks for confirmation before anything sends, saying how many people will be texted",
       "confirming calls the reminder tool once for each of those appointments"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "list-feed"
   },
   {
     "id": "empty-waitlist",
@@ -118,6 +127,7 @@
       "offers no control that would act on a patient who is not there"
     ],
     "tags": ["display"],
+    "shape": "empty-state",
     "data": { "list_waitlist": { "data": [] } }
   }
 ]

--- a/genbench/worlds/logistics/cases.json
+++ b/genbench/worlds/logistics/cases.json
@@ -9,7 +9,8 @@
       "the four late shipments — PO-88377, SO-3352, PO-88402 and SO-3318 — are marked late and sit above the on-time rows",
       "PO-88540 and PO-88566 are the only two rows with no driver on them"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "table"
   },
   {
     "id": "shipment-detail",
@@ -22,7 +23,8 @@
       "lists the four scans newest first with the time and terminal of each",
       "shows the destination as 2701 E Shaw Ave, Fresno, CA and the three charges as $487.50 freight, $75.00 liftgate and $42.50 residential"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "detail"
   },
   {
     "id": "driver-route",
@@ -34,7 +36,8 @@
       "says how much of the route is finished — 2 of 5 stops",
       "shows Kestrel Coffee Roasters delivered at 9:12 AM, Bloom & Vine Nursery at 10:41 AM, and Ridgeline Hardware due at 1:35 PM"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "timeline"
   },
   {
     "id": "exception-queue",
@@ -46,7 +49,8 @@
       "each row shows its shipment, customer, the kind of exception and the day it opened",
       "each row's close control calls resolve_exception with that row's exception id, passing whatever note the field holds"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "list-feed"
   },
   {
     "id": "no-open-exceptions",
@@ -58,6 +62,7 @@
       "offers no close control"
     ],
     "tags": ["display"],
+    "shape": "empty-state",
     "data": { "list_exceptions": { "data": [] } }
   },
   {
@@ -70,7 +75,8 @@
       "shows each candidate driver's terminal and hours left so I can tell them apart",
       "submitting calls assign_driver with the chosen shipment id and driver id"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "form"
   },
   {
     "id": "on-time-week",
@@ -82,7 +88,8 @@
       "Aug 7 reads as the worst day of the week, with 14 late of 138 delivered",
       "states the week's on-time rate from the tool's own counts — 914 of 970 deliveries, 94.2%"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "chart"
   },
   {
     "id": "late-notify-all",
@@ -94,7 +101,8 @@
       "asks me to confirm before sending",
       "confirming calls notify_customer with a shipment id and a message once per row that is selected when I confirm"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "list-feed"
   },
   {
     "id": "hours-vs-route",
@@ -106,7 +114,8 @@
       "does not put Priya Raman in the at-risk group — her 190-minute route is inside the 200 minutes she has left",
       "keeps the available and off-duty drivers out of the at-risk group"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "table"
   },
   {
     "id": "refused-redelivery",
@@ -118,6 +127,7 @@
       "a row's button calls reschedule_delivery with that shipment's id, the chosen date and the chosen window",
       "the same row also calls notify_customer for that shipment, and nothing fires until I confirm"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "form"
   }
 ]

--- a/genbench/worlds/maple/cases.json
+++ b/genbench/worlds/maple/cases.json
@@ -9,7 +9,8 @@
       "shows groceries $612.45, dining $438.20, subscriptions $184.41 and transport $96.75",
       "shows a total for the month of $4,243.11"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "table"
   },
   {
     "id": "spend-chart",
@@ -21,7 +22,8 @@
       "orders them largest first, housing down to coffee",
       "shows housing's amount as $2,850.00 and the chart's largest category"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "chart"
   },
   {
     "id": "pending-transfers",
@@ -33,7 +35,8 @@
       "offers a cancel control on each pending transfer",
       "the cancel control targets the transfer it sits on"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "table"
   },
   {
     "id": "account-balances",
@@ -44,7 +47,8 @@
       "shows the credit account's balance as negative",
       "shows a total equal to the sum of the three balances"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "table"
   },
   {
     "id": "no-pending-transfers",
@@ -56,6 +60,7 @@
       "offers no cancel control"
     ],
     "tags": ["display"],
+    "shape": "empty-state",
     "data": { "list_transfers": { "data": [] } }
   },
   {
@@ -68,7 +73,8 @@
       "offers exactly one cancel control on the screen",
       "pressing cancel fires cancel_transfer with id tr_1"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "detail"
   },
   {
     "id": "cancel-both-pending",
@@ -80,7 +86,8 @@
       "asks for confirmation before cancelling and says it will cancel 2 transfers",
       "confirming fires cancel_transfer twice, once with id tr_1 and once with id tr_2"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "list-feed"
   },
   {
     "id": "transfer-activity-feed",
@@ -93,6 +100,7 @@
       "marks the two pending entries as pending and the other seven as completed"
     ],
     "tags": ["display"],
+    "shape": "timeline",
     "data": {
       "list_transfers": {
         "data": [
@@ -119,7 +127,8 @@
       "shows $9,102.20 as what checking holds once they clear",
       "answers plainly that there is room for the $125.50"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "detail"
   },
   {
     "id": "rent-check",
@@ -131,6 +140,7 @@
       "presents the two as one comparison block and says the amounts match",
       "stays on that comparison rather than becoming a full spending breakdown or a full transfer list"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "comparison"
   }
 ]

--- a/genbench/worlds/observability/cases.json
+++ b/genbench/worlds/observability/cases.json
@@ -3,6 +3,7 @@
     "id": "alert-triage-queue",
     "lane": "screen",
     "tags": ["action"],
+    "shape": "table",
     "prompt": "Give me a triage queue of everything firing right now, worst severity first, with an acknowledge button on every row.",
     "pass": [
       "shows all five firing alerts and neither acknowledged one",
@@ -15,6 +16,7 @@
     "id": "all-clear",
     "lane": "screen",
     "tags": ["display"],
+    "shape": "empty-state",
     "prompt": "Show me what's firing right now, worst first, with a way to acknowledge anything that is.",
     "pass": [
       "says nothing is firing rather than showing an empty table",
@@ -27,6 +29,7 @@
     "id": "service-catalog",
     "lane": "screen",
     "tags": ["display"],
+    "shape": "table",
     "prompt": "Table of every service we monitor with its owning team, tier and tail latency. Put the unhealthy ones at the top.",
     "pass": [
       "lists all eight services with owning team, tier and tail latency",
@@ -39,6 +42,7 @@
     "id": "deploy-blast-radius",
     "lane": "screen",
     "tags": ["action"],
+    "shape": "comparison",
     "prompt": "Checkout started failing this afternoon and I think the last checkout-api deploy did it. Put the open incident and that deploy side by side — when each one started, who shipped it, who's running the incident, how many customers are hit — and give me a rollback button for that build.",
     "pass": [
       "names the open checkout incident and the checkout-api deploy that landed before it",
@@ -52,6 +56,7 @@
     "id": "oncall-week",
     "lane": "screen",
     "tags": ["display"],
+    "shape": "calendar",
     "prompt": "Who's on call this week? Lay out every team's shifts with primary and secondary, and make it obvious who is holding the pager right now.",
     "pass": [
       "shows every team's shifts from the tool with each engineer's role",
@@ -64,6 +69,7 @@
     "id": "error-budget-board",
     "lane": "screen",
     "tags": ["display"],
+    "shape": "table",
     "prompt": "Build me an SLO board: for every service with a budget, its target, how much error budget it has burned and how much is left, worst first.",
     "pass": [
       "shows all five services that have an SLO, each with its target percentage",
@@ -76,6 +82,7 @@
     "id": "ingest-spend-chart",
     "lane": "screen",
     "tags": ["display"],
+    "shape": "chart",
     "prompt": "Chart what each service cost us in ingest this month, biggest spender first, and give me the total bill.",
     "pass": [
       "draws a chart of the services' ingest cost rather than only listing them",
@@ -88,6 +95,7 @@
     "id": "last-day-timeline",
     "lane": "screen",
     "tags": ["display"],
+    "shape": "timeline",
     "prompt": "Walk me through the last 24 hours as a timeline — deploys, alerts, pages, who did what — oldest first.",
     "pass": [
       "shows the activity entries from the tool in time order, oldest first",
@@ -100,6 +108,7 @@
     "id": "alert-fatigue-audit",
     "lane": "screen",
     "tags": ["action"],
+    "shape": "table",
     "prompt": "My phone will not stop. Rank the alerts by how often they fired this week against how often anyone actually acked them, call out the ones nobody ever acts on, and let me pick several and silence them for the rest of the day in one action.",
     "pass": [
       "ranks the alerts by how often they fired, most-fired first, using the tool's counts",
@@ -113,6 +122,7 @@
     "id": "page-the-oncall",
     "lane": "screen",
     "tags": ["action"],
+    "shape": "form",
     "prompt": "Checkout is on fire and I need a human. Give me a form that shows who is on call for checkout-api right now and sends them a page with a message I type.",
     "pass": [
       "names the Payments primary and secondary who are on call now, because Payments owns checkout-api",

--- a/genbench/worlds/people-ops/cases.json
+++ b/genbench/worlds/people-ops/cases.json
@@ -4,6 +4,7 @@
     "lane": "screen",
     "prompt": "Give me a table of everyone on the roster with their title, department, manager, start date and whether they're active, onboarding or out on leave.",
     "tags": ["display"],
+    "shape": "table",
     "pass": [
       "lists all twelve employees the roster tool returned and invents nobody",
       "shows each person's title, department, manager and start date",
@@ -16,6 +17,7 @@
     "lane": "screen",
     "prompt": "Walk me through the time-off requests waiting on my approval: who's asking, what dates, how many hours, and an approve and a deny on each row. Deny should ask me to confirm before the denial goes out.",
     "tags": ["action"],
+    "shape": "list-feed",
     "pass": [
       "shows the four pending requests and none of the approved or denied ones",
       "shows each pending request's employee, dates and hours",
@@ -28,6 +30,7 @@
     "lane": "screen",
     "prompt": "Walk me through the time-off requests waiting on my approval, with an approve and a deny on each row.",
     "tags": ["action"],
+    "shape": "empty-state",
     "pass": [
       "says nothing is waiting rather than drawing an empty table",
       "invents no requests",
@@ -40,6 +43,7 @@
     "lane": "screen",
     "prompt": "Open Priya Raghunathan's profile: title, department, manager, start date, how much PTO she has left, and where she is in the review cycle.",
     "tags": ["display"],
+    "shape": "detail",
     "pass": [
       "shows Priya Raghunathan as a Staff Engineer in Engineering reporting to Nadia Kwan, with her start date",
       "shows her remaining PTO exactly as the roster reports it, in hours",
@@ -52,6 +56,7 @@
     "lane": "screen",
     "prompt": "Give me a headcount overview: how many people in each department, what each department costs a year, what they're hiring, and the company totals.",
     "tags": ["display"],
+    "shape": "dashboard",
     "pass": [
       "shows all four departments with headcount, annual payroll and open roles",
       "each department's payroll matches the tool's number exactly",
@@ -64,6 +69,7 @@
     "lane": "screen",
     "prompt": "Chart what we spend on payroll by department, biggest first.",
     "tags": ["display"],
+    "shape": "chart",
     "pass": [
       "draws a chart of the departments rather than only listing them",
       "every department the tool returned is on the chart",
@@ -76,6 +82,7 @@
     "lane": "screen",
     "prompt": "Theo Brandt starts Monday. Show me his onboarding checklist grouped by who owns each item, and put a mark-done button on each item still open so I can clear them as they land.",
     "tags": ["action"],
+    "shape": "list-feed",
     "pass": [
       "shows only Theo Brandt's seven items and none of Luz Arriaga's",
       "groups the items by owner and shows each item's due date",
@@ -88,6 +95,7 @@
     "lane": "screen",
     "prompt": "Who's late on their review step? List them worst first with how many days late and what stage they're stuck at, then give me one button that nudges all of them — make me confirm before it emails anyone.",
     "tags": ["action"],
+    "shape": "list-feed",
     "pass": [
       "lists the four people whose review step is late and nobody who is on time",
       "orders them most days late first, so Marcus Odell and Tomas Bello come before Daniel Okafor and Sena Nakamura",
@@ -100,6 +108,7 @@
     "lane": "screen",
     "prompt": "Before I approve anything, show me the next two weeks as a calendar of who's already out and which pending requests land in that window — and flag any request that breaks our notice rule.",
     "tags": ["display"],
+    "shape": "calendar",
     "pass": [
       "lays the absences out on a two-week calendar or timeline whose every day is labelled with its month and day, like 'Aug 17', rather than a plain list",
       "shows Yara Haddad out across the whole window on parental leave, and blocks Rosa Delgado across Aug 19 to Aug 21",
@@ -113,6 +122,7 @@
     "lane": "screen",
     "prompt": "Nobody should quietly lose PTO at year end. Show me anyone carrying more hours than our carryover cap who has used a work day or less of time off this year, with how much each is carrying and how much they've used, so I can push them to book something.",
     "tags": ["display"],
+    "shape": "table",
     "pass": [
       "lists exactly Nadia Kwan, Priya Raghunathan and Wren Chen, most hours carried first",
       "leaves out Yara Haddad, who is over the cap but has used more than a work day",

--- a/genbench/worlds/product-analytics/cases.json
+++ b/genbench/worlds/product-analytics/cases.json
@@ -10,7 +10,8 @@
       "flags the three events with zero fires in the last 7 days: csv_import_finished, old_pricing_toggle and legacy_signup_v1",
       "app_opened is presented as the busiest event"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "table"
   },
   {
     "id": "event-detail",
@@ -22,7 +23,8 @@
       "shows a deprecate control and a field for the reason on the same screen",
       "pressing deprecate calls the write tool with name \"checkout_started\" and the reason that was typed"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "detail"
   },
   {
     "id": "onboarding-funnel",
@@ -34,7 +36,8 @@
       "names 'Created a workspace' as the step with the biggest drop-off",
       "shows the funnel's end-to-end conversion as 7.4%"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "chart"
   },
   {
     "id": "retention-grid",
@@ -46,7 +49,8 @@
       "cells the tool returned as null are blank rather than 0%",
       "the Jul 27 cohort's 52.6% week-1 retention reads as the strongest of the six cohorts"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "table"
   },
   {
     "id": "activity-with-alert-marks",
@@ -58,7 +62,8 @@
       "the four weekend days (Aug 1, Aug 2, Aug 8, Aug 9) read as the lowest points",
       "names the busiest day, Aug 10, in the screen's own copy rather than only on an axis"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "chart"
   },
   {
     "id": "morning-dashboard",
@@ -71,7 +76,8 @@
       "the firing-alert count is 3, not 5",
       "names Paid teams as the biggest segment by revenue at $63,180.00"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "dashboard"
   },
   {
     "id": "alert-triage",
@@ -83,7 +89,8 @@
       "the two high-severity alerts sit above the medium one",
       "an acknowledge control takes a note and calls the write tool with the id of the alert it sits on"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "list-feed"
   },
   {
     "id": "quiet-alert-board",
@@ -95,6 +102,7 @@
       "offers no acknowledge control"
     ],
     "tags": ["display"],
+    "shape": "empty-state",
     "data": { "list_alerts": { "data": [] } }
   },
   {
@@ -107,7 +115,8 @@
       "submitting calls the create tool with exactly the name and definition that were typed",
       "invents no segment that the tool did not return"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "form"
   },
   {
     "id": "retire-unused-events",
@@ -120,6 +129,7 @@
       "one control deprecates all three, and it asks for confirmation before any call fires",
       "confirming fires one deprecate call per listed event"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "list-feed"
   }
 ]

--- a/genbench/worlds/project-tracker/cases.json
+++ b/genbench/worlds/project-tracker/cases.json
@@ -9,7 +9,8 @@
       "shows exactly the nine Sprint 20 issues as cards — CAI-156, CAI-157 and CAI-158 of Sprint 21 and the backlog's CAI-159, CAI-160 and CAI-161 are nowhere on the board",
       "each card offers a control that moves that issue, and pressing it calls move_issue for the issue on that card"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "board"
   },
   {
     "id": "sprint-health",
@@ -21,7 +22,8 @@
       "shows the work left as 24 points, the difference between those two",
       "breaks the sprint's issues down by status, including the one blocked issue"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "dashboard"
   },
   {
     "id": "burndown-chart",
@@ -33,7 +35,8 @@
       "the remaining series starts at 42 and ends at 24",
       "the remaining series sits above the ideal line at the end, so the sprint reads as behind plan"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "chart"
   },
   {
     "id": "open-issues",
@@ -46,7 +49,8 @@
       "the four issues with nobody on them read as unassigned rather than borrowing a teammate's name",
       "rows run newest first by the update date each row shows — the three Aug 12 issues at the top, CAI-161 of Aug 3 last"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "table"
   },
   {
     "id": "estimate-backlog",
@@ -58,7 +62,8 @@
       "offers each of them the scale 2, 3, 5, 8 and 13 as one-click choices",
       "picking a value calls set_estimate with that row's issue and the number of points that was picked"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "list-feed"
   },
   {
     "id": "release-readiness",
@@ -71,7 +76,8 @@
       "surfaces that CAI-147's checks are failing and its review has been waiting four days",
       "invents no issue and no release the tools did not return"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "detail"
   },
   {
     "id": "cut-release",
@@ -83,7 +89,8 @@
       "asks for confirmation before the cut fires, rather than firing on the first press",
       "confirming is what calls cut_release, and it calls it for 2026.8"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "detail"
   },
   {
     "id": "capacity-rebalance",
@@ -96,7 +103,8 @@
       "names CAI-151, Theo's unfinished issue, and offers a control that hands it to another teammate",
       "handing one over calls assign_issue with one of Theo's issues and the teammate that was picked"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "dashboard"
   },
   {
     "id": "review-queue",
@@ -108,7 +116,8 @@
       "the review whose checks are failing is visibly marked as failing",
       "each row offers a control that sends the issue back, and pressing it calls move_issue for that row's issue"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "list-feed"
   },
   {
     "id": "quiet-review-queue",
@@ -120,6 +129,7 @@
       "offers no control that acts on a review"
     ],
     "tags": ["display"],
+    "shape": "empty-state",
     "data": { "list_reviews": { "data": [] } }
   }
 ]

--- a/genbench/worlds/property-management/cases.json
+++ b/genbench/worlds/property-management/cases.json
@@ -9,7 +9,8 @@
       "shows a portfolio total still outstanding of $6,970.00",
       "marks each row as paid in full, partly paid, or unpaid"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "table"
   },
   {
     "id": "collections-chart",
@@ -21,7 +22,8 @@
       "the months run oldest to newest, March 2026 through August 2026",
       "August's collected figure of $12,075.00 reads far below its billed figure of $19,045.00"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "chart"
   },
   {
     "id": "maintenance-board",
@@ -33,7 +35,8 @@
       "each request shows its unit and title, and the two urgent ones are visibly flagged",
       "no request appears in more than one column"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "board"
   },
   {
     "id": "no-maintenance-requests",
@@ -45,6 +48,7 @@
       "still names what the screen is for, so the empty state is not a blank page"
     ],
     "tags": ["display"],
+    "shape": "empty-state",
     "data": { "list_maintenance_requests": { "data": [] } }
   },
   {
@@ -57,7 +61,8 @@
       "offers a vendor choice on each row drawn from the five vendors the tool returned",
       "assigning fires assign_vendor with that row's request id and the chosen vendor's id"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "table"
   },
   {
     "id": "record-payment",
@@ -69,7 +74,8 @@
       "asks for a payment method as well as an amount",
       "submitting fires record_payment with that charge's id, the amount in cents (120000, not 1200), and a method"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "form"
   },
   {
     "id": "late-notice-blast",
@@ -81,7 +87,8 @@
       "several can be ticked at once and sent with one control",
       "asks for confirmation first, then fires one send_late_notice per ticked tenant"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "list-feed"
   },
   {
     "id": "showings-week",
@@ -93,7 +100,8 @@
       "the two requested showings read as not yet confirmed",
       "no day is filled with appointments the tool did not return"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "calendar"
   },
   {
     "id": "moveout-closeout",
@@ -105,7 +113,8 @@
       "lists both open work orders on that unit, at $185.00 and $225.00, and no work order from another unit",
       "ends on $685.00 left of the deposit — the deposit less the rent owed and both estimates"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "detail"
   },
   {
     "id": "lease-renewals",
@@ -117,6 +126,7 @@
       "the tenant who has already given notice is not offered a renewal",
       "renewing fires renew_lease with that lease's id, a new end date, and the new rent in cents"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "table"
   }
 ]

--- a/genbench/worlds/store-admin/cases.json
+++ b/genbench/worlds/store-admin/cases.json
@@ -4,6 +4,7 @@
     "lane": "screen",
     "prompt": "Show me my ten most recent orders in one table: order number, customer, when it was placed, whether it's paid, whether it's shipped, and the total.",
     "tags": ["display"],
+    "shape": "table",
     "pass": [
       "shows all ten orders the tool returned, newest first",
       "each row shows the order number, customer name, date placed and total",
@@ -16,6 +17,7 @@
     "lane": "screen",
     "prompt": "I work refunds every morning. Show me the refund requests that are still open — order, customer, reason and amount — and let me approve or deny each one right there.",
     "tags": ["action"],
+    "shape": "list-feed",
     "pass": [
       "lists the three open requests and neither approved nor denied one",
       "each request shows its order number, customer, reason and amount",
@@ -28,6 +30,7 @@
     "lane": "screen",
     "prompt": "Pull up order PDL-1042: every line item with quantity and price, the subtotal, shipping, tax and total, where it shipped, its timeline, and who the customer is — how many orders they've placed and what they've spent with us all time.",
     "tags": ["display"],
+    "shape": "detail",
     "pass": [
       "shows all four line items with quantity and unit price",
       "shows subtotal, shipping, tax and a total of $156.30",
@@ -40,6 +43,7 @@
     "lane": "screen",
     "prompt": "Give me this week at a glance: orders taken, gross sales, refunds paid out and average order value across the last seven days.",
     "tags": ["display"],
+    "shape": "dashboard",
     "pass": [
       "shows 9 orders for the seven days",
       "shows gross sales of $927.00",
@@ -52,6 +56,7 @@
     "lane": "screen",
     "prompt": "Chart gross sales day by day for the last seven days, with refunds plotted against them.",
     "tags": ["display"],
+    "shape": "chart",
     "pass": [
       "draws a chart with a bar or point per day rather than only a table",
       "all seven days are on the chart",
@@ -64,6 +69,7 @@
     "lane": "screen",
     "prompt": "SUMMERPOT ends at the end of the month and I want to run the same deal into autumn under a new code. Show me my discount codes with how far each is through its usage limit, then give me a form to create AUTUMNPOT — prefilled with SUMMERPOT's kind, value and usage limit — that creates the code when I submit it.",
     "tags": ["action"],
+    "shape": "form",
     "pass": [
       "lists every code with its uses against that code's usage limit",
       "shows each code's status, so the paused, scheduled and expired ones read differently from the active ones",
@@ -76,6 +82,7 @@
     "lane": "screen",
     "prompt": "Everything waiting to ship goes out this afternoon. Show me the orders that haven't shipped yet and let me mark them all fulfilled in one press, with a confirmation before it fires.",
     "tags": ["action"],
+    "shape": "list-feed",
     "pass": [
       "lists the four unfulfilled orders and neither the shipped, delivered nor cancelled ones",
       "flags PDL-1044 as still awaiting payment",
@@ -88,6 +95,7 @@
     "lane": "screen",
     "prompt": "Print me a packing slip for PDL-1042 that I can drop in the box: the ship-to address, the shipping method, and every line item with its SKU and quantity. No prices anywhere — whoever packs it doesn't need to see what the customer paid.",
     "tags": ["display"],
+    "shape": "detail",
     "pass": [
       "shows the ship-to address exactly as the tool returned it, plus the shipping method",
       "lists all four line items with SKU and quantity",
@@ -100,6 +108,7 @@
     "lane": "screen",
     "prompt": "Friday restock run. Build me the list I send to suppliers: every SKU at or below its reorder point, grouped by supplier, how many units to order to get each back to its target level from the units it has on hand, what that costs at unit cost, and a button on each line that places the order.",
     "tags": ["action"],
+    "shape": "table",
     "pass": [
       "lists exactly the five SKUs at or below their reorder point and no well-stocked one",
       "groups the lines by supplier",
@@ -113,6 +122,7 @@
     "lane": "screen",
     "prompt": "I work refunds every morning. Show me the refund requests that are still open — order, customer, reason and amount — and let me approve or deny each one right there.",
     "tags": ["display"],
+    "shape": "empty-state",
     "pass": [
       "says the refund queue is empty rather than showing an empty table",
       "invents no refund requests",

--- a/genbench/worlds/subscription-billing/cases.json
+++ b/genbench/worlds/subscription-billing/cases.json
@@ -9,7 +9,8 @@
       "shows the amount still outstanding and the MRR at risk from past-due subscriptions",
       "presents MRR as the headline figure rather than burying it in a table"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "dashboard"
   },
   {
     "id": "dunning-queue",
@@ -21,7 +22,8 @@
       "offers a retry control on each row",
       "pressing a row's retry control calls retry_payment for that row's invoice"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "table"
   },
   {
     "id": "plan-mix-chart",
@@ -33,7 +35,8 @@
       "the subscriber counts read 3 Starter, 3 Growth, 2 Scale, 1 Scale (annual) and 1 Pro (legacy)",
       "the plans read biggest first"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "chart"
   },
   {
     "id": "account-detail-ovid",
@@ -45,7 +48,8 @@
       "shows the unpaid invoice INV-2050 with its amount",
       "shows the account's event history, newest event first"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "detail"
   },
   {
     "id": "renewal-schedule",
@@ -57,7 +61,8 @@
       "does not present the canceled subscription as an upcoming renewal",
       "shows an amount beside each renewal, $89.10 beside Halden Freight and $29.00 beside Quarry Road Coffee"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "timeline"
   },
   {
     "id": "coupon-apply-form",
@@ -69,7 +74,8 @@
       "does not offer the expired LAUNCH50 coupon as a usable choice",
       "submitting calls apply_coupon with Steepgrove Bakery's subscription id and the chosen coupon code"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "form"
   },
   {
     "id": "write-off-unpayable",
@@ -81,7 +87,8 @@
       "asks for confirmation and takes a reason before anything is voided",
       "confirming calls void_invoice with a ticked invoice's id and a reason"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "table"
   },
   {
     "id": "dunning-queue-empty",
@@ -93,6 +100,7 @@
       "offers no retry control"
     ],
     "tags": ["display"],
+    "shape": "empty-state",
     "data": { "list_dunning_queue": { "data": [] } }
   },
   {
@@ -105,7 +113,8 @@
       "shows Halden Freight as nearly at its allowance with no overage owed",
       "says which overage has already been invoiced and which has not"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "table"
   },
   {
     "id": "dunning-last-stand",
@@ -117,6 +126,7 @@
       "each choice calls its own tool for Tessellate Studio — retry_payment and void_invoice on the invoice, cancel_subscription on the subscription with period_end",
       "the void and the cancel ask for confirmation before they run"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "detail"
   }
 ]

--- a/genbench/worlds/support-desk/cases.json
+++ b/genbench/worlds/support-desk/cases.json
@@ -9,7 +9,8 @@
       "TK-1040 and TK-1047 read as overdue and sit above the two that still have time",
       "the four rows name their customers — Dominic Reyes, Alina Petrova, Rosa Delgado and Sam Okonkwo"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "table"
   },
   {
     "id": "inbox-zero",
@@ -21,6 +22,7 @@
       "offers no per-ticket controls, since there are no tickets"
     ],
     "tags": ["display"],
+    "shape": "empty-state",
     "data": {
       "list_tickets": { "data": [] },
       "get_ticket": { "data": [] },
@@ -64,7 +66,8 @@
       "lists the canned replies the tool returned, by title",
       "picking a canned reply fires send_canned_reply with TK-1040 and that reply's id"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "detail"
   },
   {
     "id": "assign-backlog",
@@ -76,7 +79,8 @@
       "the only agents offered are the three the tool reports online: Nadia Okafor, Theo Lindqvist, June Hollis",
       "assigning fires assign_ticket with that row's ticket id and the chosen agent's id"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "table"
   },
   {
     "id": "refund-approvals",
@@ -89,7 +93,8 @@
       "the amount can be changed before approving",
       "approving fires approve_refund with that request's id and an amount in cents"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "table"
   },
   {
     "id": "bulk-close",
@@ -101,7 +106,8 @@
       "asks for confirmation before closing anything",
       "confirming fires close_tickets once, with the selected ticket ids"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "table"
   },
   {
     "id": "team-pulse",
@@ -114,7 +120,8 @@
       "shows that 4 tickets are overdue right now",
       "Nadia Okafor's CSAT reads 92% and Marco Duarte's 71%"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "dashboard"
   },
   {
     "id": "volume-trend",
@@ -126,7 +133,8 @@
       "all 14 days the tool returned are plotted, and no invented day",
       "the newest day's backlog reads 13"
     ],
-    "tags": ["display"]
+    "tags": ["display"],
+    "shape": "chart"
   },
   {
     "id": "holiday-handoff",
@@ -138,7 +146,8 @@
       "shows who is on shift Thursday with their hours — Theo, Priya, June, Marco — and Nadia is not among them",
       "each ticket has a handover control, and it fires assign_ticket with that ticket's id and an agent who is on shift Thursday"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "table"
   },
   {
     "id": "duplicate-merge",
@@ -150,6 +159,7 @@
       "no customer who only wrote once is presented as a duplicate",
       "merging fires merge_tickets with the newer ticket's id and the older ticket it merges into"
     ],
-    "tags": ["action"]
+    "tags": ["action"],
+    "shape": "table"
   }
 ]

--- a/genbench/worlds/trades-accounting/cases.json
+++ b/genbench/worlds/trades-accounting/cases.json
@@ -4,6 +4,7 @@
     "lane": "screen",
     "prompt": "Show me every job we still have open in one table: job number and customer, who's running it, what we quoted, the hours we quoted against the hours we've actually burned, what it's cost us so far, and what's left to invoice.",
     "tags": ["display"],
+    "shape": "table",
     "pass": [
       "shows the six open jobs and leaves the closed job J-2377 out",
       "each job's quoted amount, cost to date and remaining-to-invoice match the tool's numbers exactly",
@@ -17,6 +18,7 @@
     "lane": "screen",
     "prompt": "Open job J-2418, the Harbor Point Dental rooftop swap. I want every cost line posted against it with its date and amount, the labor/material/subcontractor split, where the margin sits against the quote, and the invoice we've sent them.",
     "tags": ["display"],
+    "shape": "detail",
     "pass": [
       "shows all eight cost lines with date, description and amount",
       "the cost lines add up to the job's cost to date of $37,576.00",
@@ -30,6 +32,7 @@
     "lane": "screen",
     "prompt": "Chart profit margin by job, worst first, so I can see at a glance which jobs are bleeding.",
     "tags": ["display"],
+    "shape": "chart",
     "pass": [
       "draws a chart of the jobs' margins rather than only listing them",
       "all six jobs the tool returned are on the chart",
@@ -42,6 +45,7 @@
     "lane": "screen",
     "prompt": "Who owes us money and how late are they? Put the aging summary up top, the past-due invoices underneath with the days late on each, and give me a button on each one to email that customer a payment reminder.",
     "tags": ["action"],
+    "shape": "list-feed",
     "pass": [
       "shows the aging buckets with $100,375.00 outstanding of which $35,275.00 is past due",
       "lists the four past-due invoices with the days late the tool reports",
@@ -54,6 +58,7 @@
     "lane": "screen",
     "prompt": "Lay this week's schedule out day by day: which job each visit is for, who's on it, whether it's a morning, afternoon or all-day window, and the crew hours planned.",
     "tags": ["display"],
+    "shape": "calendar",
     "pass": [
       "lays the week out day by day rather than as one flat list",
       "shows all thirteen visits, each on its own day",
@@ -66,6 +71,7 @@
     "lane": "screen",
     "prompt": "I keep eating labor overruns. Put quoted hours next to actual hours for every job, show me how many hours over or under each one came in, mark the ones that blew past the quote, and show the labor dollars posted against each — worst overrun first.",
     "tags": ["display"],
+    "shape": "table",
     "pass": [
       "shows quoted hours and actual hours side by side for all seven jobs",
       "shows the hour difference per job, with J-2377 at 61 hours over and J-2418 at 34 hours over as the two worst",
@@ -78,6 +84,7 @@
     "lane": "screen",
     "prompt": "My bookkeeper wants the write-offs. Total the coded charges in the expense inbox by tax category, largest first, and give me the coded total. Then put the charges nobody has coded yet up top with what they add up to and a way to set each one's category right there, and list every charge that's missing a receipt so I can go hunt them down.",
     "tags": ["action"],
+    "shape": "dashboard",
     "pass": [
       "totals the coded charges by tax category, largest first, with Materials & supplies at $3,452.40",
       "shows a coded total of $8,762.25",
@@ -91,6 +98,7 @@
     "lane": "screen",
     "prompt": "Payroll closes tonight. Show me every crew hour still waiting on my approval, grouped by job, with the hours and the dollars, and let me approve the whole lot in one press — make me confirm before it goes through.",
     "tags": ["action"],
+    "shape": "list-feed",
     "pass": [
       "groups the nine pending entries under the four jobs they were logged against",
       "shows the totals as 75.0 hours and $4,634.00",
@@ -104,6 +112,7 @@
     "lane": "screen",
     "prompt": "Talon Crane came back to Harbor Point for a second half day and their invoice is the same as the first one. Give me a form to log it against J-2418 — job, vendor, amount, tax category and receipt date — filled in from the half day we already posted, dated Aug 12, then save it.",
     "tags": ["action"],
+    "shape": "form",
     "pass": [
       "offers a form with fields for job, vendor, amount, tax category and receipt date",
       "the form comes filled in from the crane half day already posted: J-2418 · Harbor Point Dental, Talon Crane Service, $3,200.00, Subcontractors, Aug 12",
@@ -117,6 +126,7 @@
     "lane": "screen",
     "prompt": "Show me every charge that still needs a tax category so I can code them.",
     "tags": ["display"],
+    "shape": "empty-state",
     "pass": [
       "says nothing is waiting to be coded rather than showing an empty table",
       "invents no charges",


### PR DESCRIPTION
genbench could tell you a contender scored 41/60. It could not tell you *what kind of screen* it lost on. This branch gives every case a shape and a provenance, and prints the scoreboard that falls out.

## The Case type gains two fields

`CASE_SHAPES` in `genbench/src/world.ts` is one list of 20 UI shapes the real-software sweep found — `table`, `chart`, `form`, `detail`, `dashboard`, `board`, `calendar`, `wizard`, `settings`, `filter-builder`, `permissions`, `list-feed`, `timeline`, `map`, `split-inbox`, `comparison`, `empty-state`, `tree`, `gallery`, `feed-composer`. Trimming the taxonomy is a one-line edit there; the lint reads the same list.

- `shape: CaseShape` — required. The one shape the case asks for.
- `source?: string` — optional. The real screen the case was mined from. A case authored before the sweep names none.

**Both stay out of `caseHash`**, for the reason `tags` already does: filing a case under a shape, or noting where the question was found, does not change the question. Putting either in the hash would declare every recorded run incomparable and reset the run history for a bookkeeping change.

## The lint

`worlds.test.ts` gains one per-world assertion: every case carries a shape that is a member of `CASE_SHAPES`, and any case that declares a `source` names a real one (no empty strings). `source` stays optional on purpose.

## All 120 existing cases tagged

Every case in all twelve worlds now declares its shape. No prompt, tool, or data changed — the tag is the whole edit.

## The per-shape report table

`shapeTable` in `genbench/src/report.ts` is the only place on the preview page a contender's screens are added up at all. Rows are shapes, columns are contenders, cells are the floor checks summed. It calls the same `checks` function the per-case columns score with, so a cell can never disagree with the columns beneath it except by being their total. A shape nobody ran a case for is muted, not scored — 0/0 painted green is a claim about a contender that was never put to the test.

`CaseResult` carries `shape` so the table has something to group by.

Its test reads the scoreboard off the page it prints, not off the data that fed it.

## Six one-field test-fixture updates

`shape` is required, so four hand-built `CaseResult` fixtures and two hand-built `Case` fixtures each gain one field. Nothing else in those tests moved.

## Gate

`pnpm build`, genbench `typecheck`, the whole genbench vitest package, and `pnpm lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cases declare a required UI `shape` and optional `source`, and the preview now groups floor checks by shape. Previously the preview only showed per-case columns; now it adds a per-shape scoreboard that sums the same checks, and shapes with no cases are muted, not scored. Shape and source stay out of `caseHash`, so historical runs remain comparable.

- Adds `shape` to `Case` and carries it into `CaseResult`; `shapeTable` renders a per-shape scoreboard using the existing `checks` function.
- Defines the single taxonomy in `CASE_SHAPES` (adds `feed-composer`) and lints that every case has a valid shape; non-empty `source` is validated when present.
- Tags all existing cases with a shape; no prompts, tools, or data changed.

**Required actions**
- When authoring a new `Case`, set `shape` to one of `CASE_SHAPES`; if you provide `source`, make it a non-empty string.
- Update any out-of-tree test fixtures to include `shape` on both `Case` and `CaseResult`.

<sup>Written for commit 6196339f0e36bdfa0ef5d6f879896bea30adacb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

