### PR TITLE
test(genbench): 60 cases mined from the real software, five per world

### DIFF
--- a/genbench/src/report.ts
+++ b/genbench/src/report.ts
@@ -341,11 +341,20 @@ function worldPanel(world: World | undefined): string {
 </details>`;
 }
 
+/** Where the question was found, for the two thirds of cases that were mined
+ *  from a real screen: the URLs are linked so the screen is one click away, and
+ *  a case nobody mined prints nothing rather than an empty line. */
+const sourceLine = (source: string | undefined): string =>
+  source === undefined
+    ? ""
+    : `<p class="source">from ${escape(source).replace(/https?:\/\/[^\s;]+/g, (url) => `<a href="${url}">${url}</a>`)}</p>`;
+
 async function caseSection(runDir: string, testCase: string, results: readonly CaseResult[], world: World | undefined): Promise<string> {
   const columns = await Promise.all(results.map(async (result) => await column(runDir, result)));
   return `<section class="case">
   <p class="case-id">${escape(testCase)}</p>
   <h2 class="prompt">${escape(results[0]?.prompt ?? "")}</h2>
+  ${sourceLine(results[0]?.source)}
   ${worldPanel(world)}
   <div class="grid">${columns.join("")}</div>
 </section>`;
@@ -384,6 +393,9 @@ h1{margin:0;font-size:28px;font-weight:600;letter-spacing:-.02em}
 .case-id{margin:0;font:450 11px/1 ui-monospace,SFMono-Regular,Menlo,monospace;
   letter-spacing:.08em;text-transform:uppercase;color:var(--ter)}
 .prompt{margin:10px 0 0;font-size:20px;font-weight:500;line-height:1.35;letter-spacing:-.01em;max-width:62ch}
+/* Provenance, never a score: quieter than the prompt it sits under. */
+.source{margin:6px 0 0;font-size:12px;color:var(--ter);max-width:62ch}
+.source a{color:inherit}
 /* Every contender in ONE row, because the whole page is a comparison and a
    column you have to scroll to find is a column you never compare.
 

--- a/genbench/src/run.ts
+++ b/genbench/src/run.ts
@@ -73,6 +73,9 @@ export interface CaseResult {
   readonly prompt: string;
   readonly lane: Lane;
   readonly shape: CaseShape;
+  /** The real screen the case was mined from, carried so the preview can say
+   *  where the question came from. Absent for a case nobody mined. */
+  readonly source?: string;
   readonly floor: FloorResult;
   readonly timing: { firstRenderMs?: number; settledMs: number };
   readonly cost: { usage: UsageTotals; usd: number };
@@ -376,6 +379,7 @@ async function main(argv: readonly string[]): Promise<number> {
       prompt: testCase.prompt,
       lane: testCase.lane,
       shape: testCase.shape,
+      source: testCase.source,
       floor,
       timing: {
         ...(outcome?.firstRenderMs === undefined ? {} : { firstRenderMs: outcome.firstRenderMs }),

--- a/genbench/tests/report.test.ts
+++ b/genbench/tests/report.test.ts
@@ -115,6 +115,31 @@ describe("the preview page", () => {
     expect(html).toContain("Show me where my money went.");
   });
 
+  /**
+   * The screen a case was mined from is provenance, and this page is the only
+   * place anyone reads it — the field sat in `cases.json` with no reader at all
+   * until here. Two thirds of the cases were mined from nothing, and their
+   * headers must read exactly as they did before the field existed.
+   */
+  it("names the real screen a case was mined from, links it, and prints nothing for a case without one", async () => {
+    const html = await preview(
+      [
+        {
+          ...resultFor("vendo-sonnet", "pending-transfers", "Show my pending transfers."),
+          source: "Monarch — Transactions, https://www.monarchmoney.com/features",
+        },
+        resultFor("vendo-sonnet", "spend-overview", "Show me where my money went."),
+      ],
+      { "pending-transfers": world, "spend-overview": world },
+    );
+
+    expect(html).toContain(
+      `<p class="source">from Monarch — Transactions, <a href="https://www.monarchmoney.com/features">https://www.monarchmoney.com/features</a></p>`,
+    );
+    // One of the two cases was mined; the other prints no source markup at all.
+    expect(html.split(`class="source"`).length - 1).toBe(1);
+  });
+
   it("shows the case's own tool data, overrides applied, not the authored world", async () => {
     const html = await preview([resultFor("vendo-sonnet", "no-pending-transfers", "Show my pending transfers.")], {
       "no-pending-transfers": emptyWorld,

--- a/genbench/worlds/clinic-scheduling/cases.json
+++ b/genbench/worlds/clinic-scheduling/cases.json
@@ -143,7 +143,7 @@
     ],
     "tags": ["action"],
     "shape": "wizard",
-    "source": "Jane — Online booking (patient-facing) — jane.app/features/online-booking"
+    "source": "Jane — Online booking (patient-facing), https://jane.app/features/online-booking"
   },
   {
     "id": "provider-availability",
@@ -157,7 +157,7 @@
     ],
     "tags": ["action"],
     "shape": "settings",
-    "source": "SimplePractice — Managing your availability — support.simplepractice.com/hc/en-us/articles/208483776-Managing-your-availability"
+    "source": "SimplePractice — Managing your availability, https://support.simplepractice.com/hc/en-us/articles/208483776-Managing-your-availability"
   },
   {
     "id": "visit-history",
@@ -171,7 +171,7 @@
     ],
     "tags": ["display"],
     "shape": "timeline",
-    "source": "Jane — a patient's past and upcoming appointments — jane.app/guide/how-to-view-and-print-appointments-for-a-patient-past-or-upcoming-appointments"
+    "source": "Jane — a patient's past and upcoming appointments, https://jane.app/guide/how-to-view-and-print-appointments-for-a-patient-past-or-upcoming-appointments"
   },
   {
     "id": "patient-messages",
@@ -186,7 +186,7 @@
     ],
     "tags": ["action"],
     "shape": "split-inbox",
-    "source": "Jane — Secure Messaging — jane.app/features/secure-messaging"
+    "source": "Jane — Secure Messaging, https://jane.app/features/secure-messaging"
   },
   {
     "id": "waitlist-filter",
@@ -201,6 +201,6 @@
     ],
     "tags": ["display"],
     "shape": "filter-builder",
-    "source": "Jane — Using the Wait List — jane.app/guide/using-the-wait-list"
+    "source": "Jane — Using the Wait List, https://jane.app/guide/using-the-wait-list"
   }
 ]

--- a/genbench/worlds/clinic-scheduling/cases.json
+++ b/genbench/worlds/clinic-scheduling/cases.json
@@ -182,7 +182,7 @@
       "lists all five threads, each with its patient's name and the last message",
       "marks exactly the three unread threads as still needing an answer",
       "clicking a thread opens it beside the list without leaving the screen",
-      "sending a reply calls the message tool with the open thread and the text that was typed"
+      "a reply box and its send control sit with the open thread, so answering a patient never leaves the screen"
     ],
     "tags": ["action"],
     "shape": "split-inbox",

--- a/genbench/worlds/clinic-scheduling/cases.json
+++ b/genbench/worlds/clinic-scheduling/cases.json
@@ -129,5 +129,78 @@
     "tags": ["display"],
     "shape": "empty-state",
     "data": { "list_waitlist": { "data": [] } }
+  },
+  {
+    "id": "book-like-a-patient",
+    "lane": "screen",
+    "prompt": "Book Ruth in the way a patient would — treatment, then provider, then a time, one step at a time.",
+    "pass": [
+      "asks for one thing at a time — what the visit is for, then the provider, then the time — never all at once",
+      "the provider step offers the providers the tool returned, not invented ones",
+      "the time step offers only today's open slots, shown as times",
+      "shows a confirmation step naming Ruth Ozawa, the chosen provider and the chosen time before anything is booked",
+      "confirming calls the booking tool with Ruth Ozawa and the slot that was picked"
+    ],
+    "tags": ["action"],
+    "shape": "wizard",
+    "source": "Jane — Online booking (patient-facing) — jane.app/features/online-booking"
+  },
+  {
+    "id": "provider-availability",
+    "lane": "screen",
+    "prompt": "Dr. Lindqvist wants to stop taking new patients for a while and shorten his default slot length — give me one place to change that without digging through everything else.",
+    "pass": [
+      "shows Dr. Sven Lindqvist's own settings, not every provider's",
+      "offers a control for whether he takes new patients, reading as accepting when the screen loads",
+      "offers a control for his default visit length, starting at the tool's 30 minutes",
+      "saving calls the settings tool with Lindqvist, no longer accepting new patients, and a shorter default length"
+    ],
+    "tags": ["action"],
+    "shape": "settings",
+    "source": "SimplePractice — Managing your availability — support.simplepractice.com/hc/en-us/articles/208483776-Managing-your-availability"
+  },
+  {
+    "id": "visit-history",
+    "lane": "screen",
+    "prompt": "Before Ruth's visit, walk me through her history here — every time she's been in, and whether she actually showed.",
+    "pass": [
+      "strings Ruth Ozawa's five visits along a timeline in date order, rather than only listing them",
+      "each visit shows its date, its provider and what it was for",
+      "the skin check with Dr. Lindqvist reads as a no-show and the other four as completed",
+      "shows no visit the tool did not return, and nobody else's visits"
+    ],
+    "tags": ["display"],
+    "shape": "timeline",
+    "source": "Jane — a patient's past and upcoming appointments — jane.app/guide/how-to-view-and-print-appointments-for-a-patient-past-or-upcoming-appointments"
+  },
+  {
+    "id": "patient-messages",
+    "lane": "screen",
+    "prompt": "Pull up whatever patients have messaged us today so I can see who still needs an answer and reply without leaving this screen.",
+    "pass": [
+      "puts the threads in a list down one side and the open conversation beside it, on one screen",
+      "lists all five threads, each with its patient's name and the last message",
+      "marks exactly the three unread threads as still needing an answer",
+      "clicking a thread opens it beside the list without leaving the screen",
+      "sending a reply calls the message tool with the open thread and the text that was typed"
+    ],
+    "tags": ["action"],
+    "shape": "split-inbox",
+    "source": "Jane — Secure Messaging — jane.app/features/secure-messaging"
+  },
+  {
+    "id": "waitlist-filter",
+    "lane": "screen",
+    "prompt": "One of the providers just opened up — let me filter the waitlist by who they wanted to see and how urgent it is, instead of scrolling the whole list.",
+    "pass": [
+      "offers a control that filters the waitlist by provider, offering the providers the waitlist rows name",
+      "offers a control that filters by urgency — routine, soon and urgent",
+      "shows all five waiting patients before any filter is set",
+      "filtering to Dr. Priya Raman leaves exactly Gio Ferraro and Sana Alvi on screen",
+      "every row still shows who the patient is waiting for and how long they have waited"
+    ],
+    "tags": ["display"],
+    "shape": "filter-builder",
+    "source": "Jane — Using the Wait List — jane.app/guide/using-the-wait-list"
   }
 ]

--- a/genbench/worlds/clinic-scheduling/world.json
+++ b/genbench/worlds/clinic-scheduling/world.json
@@ -65,7 +65,7 @@
       "data": {
         "data": [
           { "id": "prv_okafor", "name": "Dr. Nia Okafor", "specialty": "Family Medicine", "room_id": "room_302", "appointments_today": 4, "booked_minutes": 115, "open_minutes": 50, "accepting_new": true },
-          { "id": "prv_lindqvist", "name": "Dr. Sven Lindqvist", "specialty": "Dermatology", "room_id": "room_305", "appointments_today": 3, "booked_minutes": 80, "open_minutes": 30, "accepting_new": false },
+          { "id": "prv_lindqvist", "name": "Dr. Sven Lindqvist", "specialty": "Dermatology", "room_id": "room_305", "appointments_today": 3, "booked_minutes": 80, "open_minutes": 30, "accepting_new": true },
           { "id": "prv_raman", "name": "Dr. Priya Raman", "specialty": "Pediatrics", "room_id": "room_307", "appointments_today": 2, "booked_minutes": 45, "open_minutes": 50, "accepting_new": true },
           { "id": "prv_tam", "name": "Alice Tam, NP", "specialty": "Walk-in Care", "room_id": "room_309", "appointments_today": 2, "booked_minutes": 40, "open_minutes": 60, "accepting_new": true }
         ]
@@ -133,6 +133,43 @@
         ]
       }
     },
+    "get_provider_settings": {
+      "does": "One provider's booking settings, one row per provider. The rows are the `data` array. `accepting_new` says whether the provider takes new patients at all, `default_visit_minutes` is the length a new booking gets unless it is changed, and `buffer_minutes` is the gap held after every visit.",
+      "takes": { "provider_id": "string" },
+      "data": {
+        "data": [
+          { "provider_id": "prv_okafor", "provider": "Dr. Nia Okafor", "accepting_new": true, "default_visit_minutes": 20, "buffer_minutes": 5 },
+          { "provider_id": "prv_lindqvist", "provider": "Dr. Sven Lindqvist", "accepting_new": true, "default_visit_minutes": 30, "buffer_minutes": 10 },
+          { "provider_id": "prv_raman", "provider": "Dr. Priya Raman", "accepting_new": true, "default_visit_minutes": 25, "buffer_minutes": 5 },
+          { "provider_id": "prv_tam", "provider": "Alice Tam, NP", "accepting_new": true, "default_visit_minutes": 20, "buffer_minutes": 0 }
+        ]
+      }
+    },
+    "get_patient_history": {
+      "does": "Every visit one patient has had at the clinic, most recent first. The rows are the `data` array. `status` is one of completed, no-show, cancelled. Today is 2026-08-12, so every visit listed has already happened.",
+      "takes": { "patient_id": "string" },
+      "data": {
+        "data": [
+          { "patient_id": "pt_ozawa", "date": "2026-04-28", "provider": "Dr. Nia Okafor", "visit_type": "medication review", "status": "completed" },
+          { "patient_id": "pt_ozawa", "date": "2026-02-17", "provider": "Dr. Nia Okafor", "visit_type": "annual physical", "status": "completed" },
+          { "patient_id": "pt_ozawa", "date": "2025-12-09", "provider": "Dr. Sven Lindqvist", "visit_type": "skin check", "status": "no-show" },
+          { "patient_id": "pt_ozawa", "date": "2025-11-25", "provider": "Dr. Nia Okafor", "visit_type": "blood pressure follow-up", "status": "completed" },
+          { "patient_id": "pt_ozawa", "date": "2025-09-30", "provider": "Dr. Nia Okafor", "visit_type": "new patient", "status": "completed" }
+        ]
+      }
+    },
+    "list_messages": {
+      "does": "The clinic's secure message threads with patients, most recently updated first. The rows are the `data` array. `last_message` is the newest message in the thread and `last_sender` is who wrote it, 'patient' or 'clinic'. `unread` is true exactly when the patient wrote last and nobody has answered.",
+      "data": {
+        "data": [
+          { "id": "thr_301", "patient_id": "pt_ndiaye", "patient": "Aisha Ndiaye", "last_message": "The rash has spread to my other arm since Monday — should I come in sooner?", "last_sender": "patient", "unread": true, "updated_at": "2026-08-12T10:52:00" },
+          { "id": "thr_302", "patient_id": "pt_bragg", "patient": "Owen Bragg", "last_message": "Any chance of moving my 1:40 to later in the week?", "last_sender": "patient", "unread": true, "updated_at": "2026-08-12T10:20:00" },
+          { "id": "thr_303", "patient_id": "pt_kowalski", "patient": "Tomas Kowalski", "last_message": "Still hoping for a morning with Dr. Okafor if anything opens up.", "last_sender": "patient", "unread": true, "updated_at": "2026-08-12T09:38:00" },
+          { "id": "thr_304", "patient_id": "pt_osei", "patient": "Amara Osei", "last_message": "Your physical is at 11:25 today — please arrive ten minutes early.", "last_sender": "clinic", "unread": false, "updated_at": "2026-08-12T08:47:00" },
+          { "id": "thr_305", "patient_id": "pt_iyer", "patient": "Sam Iyer", "last_message": "We sent your lab order over to Northbay this morning.", "last_sender": "clinic", "unread": false, "updated_at": "2026-08-12T08:05:00" }
+        ]
+      }
+    },
     "check_in_patient": {
       "does": "Check an arrived patient in. The appointment moves to checked-in and the patient joins the waiting-room queue.",
       "takes": { "appointment_id": "string" }
@@ -152,6 +189,14 @@
     "send_reminder": {
       "does": "Send one appointment reminder to the patient, by 'sms', 'email' or 'call'. Replying confirms the appointment.",
       "takes": { "appointment_id": "string", "channel": "string" }
+    },
+    "update_provider_settings": {
+      "does": "Change one provider's booking settings. It applies to appointments booked from now on; nothing already on the schedule moves.",
+      "takes": { "provider_id": "string", "accepting_new": "boolean", "default_visit_minutes": "number" }
+    },
+    "send_message": {
+      "does": "Reply to a patient on one of the clinic's secure message threads. The patient is notified and the thread stops being unread.",
+      "takes": { "thread_id": "string", "body": "string" }
     }
   }
 }

--- a/genbench/worlds/logistics/cases.json
+++ b/genbench/worlds/logistics/cases.json
@@ -142,7 +142,7 @@
     ],
     "tags": ["display"],
     "shape": "map",
-    "source": "project44 — Control Tower / Visibility Dashboard, project44.com/platform/visibility/"
+    "source": "project44 — Control Tower / Visibility Dashboard, https://project44.com/platform/visibility/"
   },
   {
     "id": "delivery-calendar",
@@ -156,7 +156,7 @@
     ],
     "tags": ["display"],
     "shape": "calendar",
-    "source": "project44 — Appointment Manager, Calendar View, support.p-44.com/hc/en-us/articles/21090236644381"
+    "source": "project44 — Appointment Manager, Calendar View, https://support.p-44.com/hc/en-us/articles/21090236644381"
   },
   {
     "id": "start-return",
@@ -170,7 +170,7 @@
     ],
     "tags": ["action"],
     "shape": "wizard",
-    "source": "ShipStation — Returns Portal, shipstation.com/fulfillment/shipping/"
+    "source": "ShipStation — Returns Portal, https://shipstation.com/fulfillment/shipping/"
   },
   {
     "id": "terminal-scorecard",
@@ -184,7 +184,7 @@
     ],
     "tags": ["display"],
     "shape": "comparison",
-    "source": "project44 — Carrier Scorecard, project44.com/blog/achieving-high-carrier-data-quality-with-project44s-carrier-managed-services/"
+    "source": "project44 — Carrier Scorecard, https://project44.com/blog/achieving-high-carrier-data-quality-with-project44s-carrier-managed-services/"
   },
   {
     "id": "shift-start",
@@ -198,6 +198,6 @@
     ],
     "tags": ["display"],
     "shape": "dashboard",
-    "source": "project44 — Control Tower / Analytics Dashboard, project44.com/platform/visibility/"
+    "source": "project44 — Control Tower / Analytics Dashboard, https://project44.com/platform/visibility/"
   }
 ]

--- a/genbench/worlds/logistics/cases.json
+++ b/genbench/worlds/logistics/cases.json
@@ -129,5 +129,75 @@
     ],
     "tags": ["action"],
     "shape": "form"
+  },
+  {
+    "id": "driver-map",
+    "lane": "screen",
+    "prompt": "Show me where every driver is on a map right now, so I can see who's close to a terminal and who's falling behind.",
+    "pass": [
+      "draws a map with a marker for each of the six drivers rather than only listing them",
+      "the three drivers on a route show the address of the stop they are heading to; the available and off-duty ones show none",
+      "Dee Okonkwo and Sam Ferreira read as sitting at their own terminals, Reno and Oakland",
+      "sets Marcus Boateng and Lenny Cruz apart as the two who cannot finish their route inside the hours they have left"
+    ],
+    "tags": ["display"],
+    "shape": "map",
+    "source": "project44 — Control Tower / Visibility Dashboard, project44.com/platform/visibility/"
+  },
+  {
+    "id": "delivery-calendar",
+    "lane": "screen",
+    "prompt": "Give me a calendar of every delivery attempt booked for the rest of the week, so I know which days are already full before I book another redelivery.",
+    "pass": [
+      "lays the seven bookings out as days of the week rather than one flat list",
+      "Aug 13 reads as the fullest day with four attempts, two AM and two PM",
+      "Aug 12, Aug 14 and Aug 15 each carry a single attempt",
+      "every booking shows its reference, customer and window — PO-88512 on Aug 12 PM, SO-3318 on Aug 15 PM"
+    ],
+    "tags": ["display"],
+    "shape": "calendar",
+    "source": "project44 — Appointment Manager, Calendar View, support.p-44.com/hc/en-us/articles/21090236644381"
+  },
+  {
+    "id": "start-return",
+    "lane": "screen",
+    "prompt": "Walk me through a return on this order — reason, item, then print the label.",
+    "pass": [
+      "asks one step at a time — the reason, then the item, then the label — never all three at once",
+      "names the shipment it is returning: PO-88431 for Ridgeline Hardware",
+      "the item step offers the six pieces the shipment tool reports and no invented product names",
+      "the last step calls create_return with shp_40218 and the reason and item I picked, and nothing fires until I confirm"
+    ],
+    "tags": ["action"],
+    "shape": "wizard",
+    "source": "ShipStation — Returns Portal, shipstation.com/fulfillment/shipping/"
+  },
+  {
+    "id": "terminal-scorecard",
+    "lane": "screen",
+    "prompt": "Compare this week's on-time performance across our three terminals side by side so I can see which one is dragging us down.",
+    "pass": [
+      "puts Oakland, Fresno and Reno side by side rather than one under the other",
+      "calls out Reno as the one dragging us down — 26 late of 167 delivered, 84.4% on time",
+      "shows Fresno as the strongest at 96.8% and Oakland at 95.8%",
+      "shows each terminal's revenue as $41,289.00 Oakland, $32,864.00 Fresno and $14,894.00 Reno"
+    ],
+    "tags": ["display"],
+    "shape": "comparison",
+    "source": "project44 — Carrier Scorecard, project44.com/blog/achieving-high-carrier-data-quality-with-project44s-carrier-managed-services/"
+  },
+  {
+    "id": "shift-start",
+    "lane": "screen",
+    "prompt": "Give me one screen for the start of my shift: how many shipments are late right now, how many exceptions are still open, and what we've billed today.",
+    "pass": [
+      "shows all three figures as headline numbers on one screen, not one of them buried in a table",
+      "counts 4 late shipments, not the 11 on the board",
+      "counts 4 open exceptions, leaving out the resolved one and the one awaiting the customer",
+      "the billed figure is one the tools returned — $2,305.00 of freight promised today, or the $14,496.50 the service report shows for its latest day — never an invented total"
+    ],
+    "tags": ["display"],
+    "shape": "dashboard",
+    "source": "project44 — Control Tower / Analytics Dashboard, project44.com/platform/visibility/"
   }
 ]

--- a/genbench/worlds/logistics/world.json
+++ b/genbench/worlds/logistics/world.json
@@ -100,6 +100,33 @@
         ]
       }
     },
+    "list_driver_locations": {
+      "does": "Where every driver is standing right now, for the map. The rows are the `data` array. `lat` and `lng` are the driver's current position, `terminal` is the terminal they run out of, and `next_stop_address` is the stop they are driving to and is empty for a driver who is not on a route.",
+      "data": {
+        "data": [
+          { "driver_id": "drv_boateng", "name": "Marcus Boateng", "lat": 36.8408, "lng": -119.7854, "terminal": "Fresno", "next_stop_address": "2701 E Shaw Ave, Fresno, CA", "status": "on_route" },
+          { "driver_id": "drv_cruz", "name": "Lenny Cruz", "lat": 37.9577, "lng": -121.2908, "terminal": "Oakland", "next_stop_address": "1145 Fyffe Ave, Stockton, CA", "status": "on_route" },
+          { "driver_id": "drv_raman", "name": "Priya Raman", "lat": 37.7412, "lng": -122.1907, "terminal": "Oakland", "next_stop_address": "3200 Hegenberger Rd, Oakland, CA", "status": "on_route" },
+          { "driver_id": "drv_okonkwo", "name": "Dee Okonkwo", "lat": 39.5296, "lng": -119.8138, "terminal": "Reno", "next_stop_address": "", "status": "available" },
+          { "driver_id": "drv_ferreira", "name": "Sam Ferreira", "lat": 37.8044, "lng": -122.3201, "terminal": "Oakland", "next_stop_address": "", "status": "available" },
+          { "driver_id": "drv_hollis", "name": "Ruth Hollis", "lat": 39.5296, "lng": -119.8138, "terminal": "Reno", "next_stop_address": "", "status": "off_duty" }
+        ]
+      }
+    },
+    "list_delivery_appointments": {
+      "does": "Every delivery attempt booked for the rest of this week, soonest first. The rows are the `data` array. `date` is an ISO day and `window` is AM or PM.",
+      "data": {
+        "data": [
+          { "date": "2026-08-12", "window": "PM", "shipment_id": "shp_40224", "ref": "PO-88512", "customer": "Calaveras Cold Storage", "terminal": "Fresno" },
+          { "date": "2026-08-13", "window": "AM", "shipment_id": "shp_40236", "ref": "PO-88540", "customer": "Foothill Electric Supply", "terminal": "Oakland" },
+          { "date": "2026-08-13", "window": "AM", "shipment_id": "shp_40188", "ref": "SO-3352", "customer": "Harker Dental Group", "terminal": "Oakland" },
+          { "date": "2026-08-13", "window": "PM", "shipment_id": "shp_40241", "ref": "PO-88566", "customer": "Ridgeline Hardware", "terminal": "Oakland" },
+          { "date": "2026-08-13", "window": "PM", "shipment_id": "shp_40199", "ref": "PO-88377", "customer": "Delta Marine Supply", "terminal": "Oakland" },
+          { "date": "2026-08-14", "window": "AM", "shipment_id": "shp_40205", "ref": "PO-88402", "customer": "Truckee Outfitters", "terminal": "Reno" },
+          { "date": "2026-08-15", "window": "PM", "shipment_id": "shp_40160", "ref": "SO-3318", "customer": "Pacific Glass Co", "terminal": "Reno" }
+        ]
+      }
+    },
     "list_exceptions": {
       "does": "Delivery exceptions raised in the last three days, newest first. The rows are the `data` array. `status` is `open`, `awaiting_customer` or `resolved`. `claim_amount` is the cargo value the customer has claimed, in CENTS — 87400 is $874.00 — and is 0 where nothing is claimed.",
       "data": {
@@ -147,6 +174,16 @@
         ]
       }
     },
+    "get_terminal_performance": {
+      "does": "This week's delivery performance for each of the three terminals. The rows are the `data` array. `late` is the subset of `delivered` that missed its promised window, so on-time is `delivered - late`. `revenue` is in CENTS: 4128900 is $41,289.00.",
+      "data": {
+        "data": [
+          { "terminal": "Oakland", "delivered": 431, "late": 18, "revenue": 4128900 },
+          { "terminal": "Fresno", "delivered": 372, "late": 12, "revenue": 3286400 },
+          { "terminal": "Reno", "delivered": 167, "late": 26, "revenue": 1489400 }
+        ]
+      }
+    },
     "assign_driver": {
       "does": "Assign a shipment sitting at a terminal to a driver. The shipment joins that driver's route as its last stop.",
       "takes": { "shipment_id": "string", "driver_id": "string" }
@@ -162,6 +199,10 @@
     "notify_customer": {
       "does": "Send the shipment's customer contact a status message.",
       "takes": { "shipment_id": "string", "message": "string" }
+    },
+    "create_return": {
+      "does": "Open a return on a shipment and print its return label. `reason` is why the freight is coming back and `item` is which of the shipment's pieces goes on the label.",
+      "takes": { "shipment_id": "string", "reason": "string", "item": "string" }
     }
   }
 }

--- a/genbench/worlds/maple/cases.json
+++ b/genbench/worlds/maple/cases.json
@@ -142,5 +142,75 @@
     ],
     "tags": ["display"],
     "shape": "comparison"
+  },
+  {
+    "id": "bills-calendar",
+    "lane": "screen",
+    "prompt": "Show me the bills and subscriptions coming up this month, laid out like a calendar so I can see which days they hit.",
+    "pass": [
+      "lays the month out as a calendar grid rather than a list of bills",
+      "puts each of the six bills on its due day — Aug 1, Aug 5, Aug 9, Aug 12, Aug 18 and Aug 24",
+      "shows each bill's name and amount, Mission St Rent at $2,850.00 down to Verdant Streaming at $15.99",
+      "marks Ridgeline Gym missed, Mission St Rent and Onyx Fiber paid, and the other three upcoming"
+    ],
+    "tags": ["display"],
+    "shape": "calendar",
+    "source": "Monarch — Recurring bills calendar · https://help.monarch.com/hc/en-us/articles/4890751141908-Tracking-Recurring-Expenses-and-Bills"
+  },
+  {
+    "id": "money-dashboard",
+    "lane": "screen",
+    "prompt": "Give me one screen with my net worth, my account balances and what I've spent this month.",
+    "pass": [
+      "shows net worth as $36,265.15, the three balances summed",
+      "lists all three accounts with name and balance, Maple Credit's as negative",
+      "shows this month's spending with housing largest at $2,850.00 and a total of $4,243.11",
+      "carries net worth, accounts and spending as three blocks on the one screen, not just one of them"
+    ],
+    "tags": ["display"],
+    "shape": "dashboard",
+    "source": "Monarch — Main dashboard · https://screensdesign.com/showcase/monarch-budget-track-money"
+  },
+  {
+    "id": "dining-budget-cap",
+    "lane": "screen",
+    "prompt": "Let me set a monthly cap on my dining spending so I stop going over.",
+    "pass": [
+      "shows a form for dining's cap rather than a breakdown of every category",
+      "prefills dining's current cap of $400.00 and shows $438.20 already spent against it",
+      "says dining is over its cap",
+      "saving fires set_budget with category dining and the entered limit_cents"
+    ],
+    "tags": ["action"],
+    "shape": "form",
+    "source": "Monarch — Budget creation · https://screensdesign.com/showcase/monarch-budget-track-money"
+  },
+  {
+    "id": "category-groups",
+    "lane": "screen",
+    "prompt": "Show me how my spending categories are organized into groups, so I can see what rolls up into what.",
+    "pass": [
+      "nests the six categories under their groups rather than showing one flat list",
+      "shows Food & Drink holding groceries, dining and coffee, and Home holding housing alone",
+      "shows each category's amount, housing $2,850.00 down to coffee $61.30",
+      "rolls Food & Drink's three categories up to $1,111.95"
+    ],
+    "tags": ["display"],
+    "shape": "tree",
+    "source": "Monarch — Categories & groups · https://help.monarch.com/hc/en-us/articles/360048883771-Creating-Custom-Categories-and-Groups"
+  },
+  {
+    "id": "savings-goals",
+    "lane": "screen",
+    "prompt": "Show me the savings goals I've got going and how close each one is to done.",
+    "pass": [
+      "shows all three goals as cards side by side rather than table rows",
+      "shows each goal's saved amount against its target, Emergency Fund $7,420.00 of $10,000.00",
+      "carries a progress bar or percentage on each — Emergency Fund about 74%, Japan Trip 25%, New Laptop 100%",
+      "marks New Laptop as fully funded"
+    ],
+    "tags": ["display"],
+    "shape": "board",
+    "source": "Monarch — Goals / Revolut — Pockets · https://screensdesign.com/showcase/monarch-budget-track-money"
   }
 ]

--- a/genbench/worlds/maple/cases.json
+++ b/genbench/worlds/maple/cases.json
@@ -155,7 +155,7 @@
     ],
     "tags": ["display"],
     "shape": "calendar",
-    "source": "Monarch — Recurring bills calendar · https://help.monarch.com/hc/en-us/articles/4890751141908-Tracking-Recurring-Expenses-and-Bills"
+    "source": "Monarch — Recurring bills calendar, https://help.monarch.com/hc/en-us/articles/4890751141908-Tracking-Recurring-Expenses-and-Bills"
   },
   {
     "id": "money-dashboard",
@@ -169,7 +169,7 @@
     ],
     "tags": ["display"],
     "shape": "dashboard",
-    "source": "Monarch — Main dashboard · https://screensdesign.com/showcase/monarch-budget-track-money"
+    "source": "Monarch — Main dashboard, https://screensdesign.com/showcase/monarch-budget-track-money"
   },
   {
     "id": "dining-budget-cap",
@@ -183,7 +183,7 @@
     ],
     "tags": ["action"],
     "shape": "form",
-    "source": "Monarch — Budget creation · https://screensdesign.com/showcase/monarch-budget-track-money"
+    "source": "Monarch — Budget creation, https://screensdesign.com/showcase/monarch-budget-track-money"
   },
   {
     "id": "category-groups",
@@ -197,7 +197,7 @@
     ],
     "tags": ["display"],
     "shape": "tree",
-    "source": "Monarch — Categories & groups · https://help.monarch.com/hc/en-us/articles/360048883771-Creating-Custom-Categories-and-Groups"
+    "source": "Monarch — Categories & groups, https://help.monarch.com/hc/en-us/articles/360048883771-Creating-Custom-Categories-and-Groups"
   },
   {
     "id": "savings-goals",
@@ -211,6 +211,6 @@
     ],
     "tags": ["display"],
     "shape": "board",
-    "source": "Monarch — Goals / Revolut — Pockets · https://screensdesign.com/showcase/monarch-budget-track-money"
+    "source": "Monarch — Goals / Revolut — Pockets, https://screensdesign.com/showcase/monarch-budget-track-money"
   }
 ]

--- a/genbench/worlds/maple/world.json
+++ b/genbench/worlds/maple/world.json
@@ -60,6 +60,56 @@
     "cancel_transfer": {
       "does": "Cancel a pending transfer. The money is returned to the source account.",
       "takes": { "id": "string" }
+    },
+    "list_upcoming_bills": {
+      "does": "Recurring bills and subscriptions due this month, earliest due first. The rows are the `data` array. `amount` is in CENTS: 285000 is $2,850.00.",
+      "data": {
+        "data": [
+          { "id": "bill_1", "name": "Mission St Rent", "amount": 285000, "due_date": "2026-08-01", "status": "paid" },
+          { "id": "bill_2", "name": "Onyx Fiber", "amount": 8900, "due_date": "2026-08-05", "status": "paid" },
+          { "id": "bill_3", "name": "Ridgeline Gym", "amount": 4500, "due_date": "2026-08-09", "status": "missed" },
+          { "id": "bill_4", "name": "Verdant Streaming", "amount": 1599, "due_date": "2026-08-12", "status": "upcoming" },
+          { "id": "bill_5", "name": "Cascade Insurance", "amount": 14200, "due_date": "2026-08-18", "status": "upcoming" },
+          { "id": "bill_6", "name": "Aster Mobile", "amount": 6200, "due_date": "2026-08-24", "status": "upcoming" }
+        ]
+      }
+    },
+    "list_budgets": {
+      "does": "The monthly spending caps the customer has set, and what has gone against each so far. The rows are the `data` array. `limit_cents` and `spent_cents` are in CENTS: 40000 is $400.00.",
+      "data": {
+        "data": [
+          { "category": "dining", "limit_cents": 40000, "spent_cents": 43820 },
+          { "category": "groceries", "limit_cents": 70000, "spent_cents": 61245 },
+          { "category": "transport", "limit_cents": 15000, "spent_cents": 9675 }
+        ]
+      }
+    },
+    "set_budget": {
+      "does": "Set the monthly spending cap for a category, replacing any cap already on it.",
+      "takes": { "category": "string", "limit_cents": "number" }
+    },
+    "list_category_groups": {
+      "does": "Every spending category with the group it rolls up into, and what it spent this month. The rows are the `data` array. `amount` is in CENTS: 61245 is $612.45.",
+      "data": {
+        "data": [
+          { "group": "Home", "category": "housing", "amount": 285000 },
+          { "group": "Food & Drink", "category": "groceries", "amount": 61245 },
+          { "group": "Food & Drink", "category": "dining", "amount": 43820 },
+          { "group": "Food & Drink", "category": "coffee", "amount": 6130 },
+          { "group": "Lifestyle", "category": "subscriptions", "amount": 18441 },
+          { "group": "Getting Around", "category": "transport", "amount": 9675 }
+        ]
+      }
+    },
+    "list_goals": {
+      "does": "The customer's savings goals and what each has put away. The rows are the `data` array. `target_cents` and `saved_cents` are in CENTS: 1000000 is $10,000.00.",
+      "data": {
+        "data": [
+          { "id": "goal_1", "name": "Emergency Fund", "target_cents": 1000000, "saved_cents": 742000 },
+          { "id": "goal_2", "name": "Japan Trip", "target_cents": 450000, "saved_cents": 112500 },
+          { "id": "goal_3", "name": "New Laptop", "target_cents": 240000, "saved_cents": 240000 }
+        ]
+      }
     }
   }
 }

--- a/genbench/worlds/observability/cases.json
+++ b/genbench/worlds/observability/cases.json
@@ -136,7 +136,7 @@
     "lane": "screen",
     "tags": ["display"],
     "shape": "dashboard",
-    "source": "Datadog — Dashboards (https://docs.datadoghq.com/dashboards/)",
+    "source": "Datadog — Dashboards, https://docs.datadoghq.com/dashboards/",
     "prompt": "I want one screen for when I open my laptop in the morning — which services are down, what's firing, and how much error budget we've burned, all at a glance.",
     "pass": [
       "answers all three questions on one screen, in separate panels rather than a single table",
@@ -151,7 +151,7 @@
     "lane": "screen",
     "tags": ["action"],
     "shape": "board",
-    "source": "Datadog — Case Management, Board view (https://docs.datadoghq.com/incident_response/case_management/view_and_manage/)",
+    "source": "Datadog — Case Management, Board view, https://docs.datadoghq.com/incident_response/case_management/view_and_manage/",
     "prompt": "Show me every open incident as a board I can move between mitigating, monitoring and resolved, instead of a flat list.",
     "pass": [
       "lays the incidents out in mitigating, monitoring and resolved columns rather than one flat list",
@@ -165,7 +165,7 @@
     "lane": "screen",
     "tags": ["action"],
     "shape": "wizard",
-    "source": "Grafana — New alert rule (https://grafana.com/docs/grafana/latest/alerting/alerting-rules/create-grafana-managed-rule/)",
+    "source": "Grafana — New alert rule, https://grafana.com/docs/grafana/latest/alerting/alerting-rules/create-grafana-managed-rule/",
     "prompt": "Walk me through setting up a new alert on search-indexer's tail latency — the condition, the threshold, and who it pages.",
     "pass": [
       "asks for the condition, the threshold and who to notify as separate steps, one at a time",
@@ -180,7 +180,7 @@
     "lane": "screen",
     "tags": ["action"],
     "shape": "settings",
-    "source": "Grafana — Notification policies (https://grafana.com/docs/grafana/latest/alerting/configure-notifications/create-notification-policy/)",
+    "source": "Grafana — Notification policies, https://grafana.com/docs/grafana/latest/alerting/configure-notifications/create-notification-policy/",
     "prompt": "I need a place to set how each team's alerts get routed — quiet hours, and who they escalate to if nobody acks.",
     "pass": [
       "shows a routing block for each of the five teams the tool returns",
@@ -194,7 +194,7 @@
     "lane": "screen",
     "tags": ["display"],
     "shape": "map",
-    "source": "Datadog — Service Map (https://docs.datadoghq.com/tracing/services/services_map/)",
+    "source": "Datadog — Service Map, https://docs.datadoghq.com/tracing/services/services_map/",
     "prompt": "Draw the service map around checkout-api so I can see what it calls and what's failing downstream.",
     "pass": [
       "draws checkout-api linked to the services on either side of it, not a table of pairs",

--- a/genbench/worlds/observability/cases.json
+++ b/genbench/worlds/observability/cases.json
@@ -130,5 +130,77 @@
       "the send control pages the checkout service with the typed message",
       "does not offer to page an engineer whose shift is not running now"
     ]
+  },
+  {
+    "id": "morning-glance",
+    "lane": "screen",
+    "tags": ["display"],
+    "shape": "dashboard",
+    "source": "Datadog — Dashboards (https://docs.datadoghq.com/dashboards/)",
+    "prompt": "I want one screen for when I open my laptop in the morning — which services are down, what's firing, and how much error budget we've burned, all at a glance.",
+    "pass": [
+      "answers all three questions on one screen, in separate panels rather than a single table",
+      "calls out notify-fanout as down and checkout-api and search-indexer as degraded",
+      "shows how many alerts are firing, matching the five the tool returns",
+      "shows error budget burned for the services that have an SLO, with notify-fanout over its budget",
+      "invents no service, alert or budget figure the tools did not return"
+    ]
+  },
+  {
+    "id": "incident-board",
+    "lane": "screen",
+    "tags": ["action"],
+    "shape": "board",
+    "source": "Datadog — Case Management, Board view (https://docs.datadoghq.com/incident_response/case_management/view_and_manage/)",
+    "prompt": "Show me every open incident as a board I can move between mitigating, monitoring and resolved, instead of a flat list.",
+    "pass": [
+      "lays the incidents out in mitigating, monitoring and resolved columns rather than one flat list",
+      "the checkout incident sits in mitigating and the search one in monitoring, matching the tool's status",
+      "each card names its incident's severity and commander",
+      "moving a card to another column sets that incident's status to the column it landed in"
+    ]
+  },
+  {
+    "id": "new-alert-rule",
+    "lane": "screen",
+    "tags": ["action"],
+    "shape": "wizard",
+    "source": "Grafana — New alert rule (https://grafana.com/docs/grafana/latest/alerting/alerting-rules/create-grafana-managed-rule/)",
+    "prompt": "Walk me through setting up a new alert on search-indexer's tail latency — the condition, the threshold, and who it pages.",
+    "pass": [
+      "asks for the condition, the threshold and who to notify as separate steps, one at a time",
+      "names search-indexer as the service the rule is on, and its current tail latency from the tool",
+      "the threshold is typed in milliseconds and carries that unit",
+      "offers Discovery among the teams to notify, because Discovery owns search-indexer",
+      "creates the rule only on the last step, for search-indexer, with the threshold and team chosen"
+    ]
+  },
+  {
+    "id": "alert-routing",
+    "lane": "screen",
+    "tags": ["action"],
+    "shape": "settings",
+    "source": "Grafana — Notification policies (https://grafana.com/docs/grafana/latest/alerting/configure-notifications/create-notification-policy/)",
+    "prompt": "I need a place to set how each team's alerts get routed — quiet hours, and who they escalate to if nobody acks.",
+    "pass": [
+      "shows a routing block for each of the five teams the tool returns",
+      "each block shows that team's quiet hours and its escalation wait in minutes, with the unit",
+      "the team an alert escalates to is picked from the teams the tool returned, never typed free-hand",
+      "saving a block updates that team's policy with the values on screen, not another team's"
+    ]
+  },
+  {
+    "id": "service-map",
+    "lane": "screen",
+    "tags": ["display"],
+    "shape": "map",
+    "source": "Datadog — Service Map (https://docs.datadoghq.com/tracing/services/services_map/)",
+    "prompt": "Draw the service map around checkout-api so I can see what it calls and what's failing downstream.",
+    "pass": [
+      "draws checkout-api linked to the services on either side of it, not a table of pairs",
+      "shows every call the tool returned, including edge-router calling into checkout-api",
+      "each link carries its call count and its error rate with a percent sign",
+      "notify-fanout reads as the failing downstream service, at the error rate the tool gives"
+    ]
   }
 ]

--- a/genbench/worlds/observability/world.json
+++ b/genbench/worlds/observability/world.json
@@ -141,6 +141,31 @@
         ]
       }
     },
+    "get_notification_policies": {
+      "does": "How each team's alerts are routed. The rows are the `data` array. `team` matches a list_services `owner`. Alerts that fire inside the quiet-hours window wait instead of paging, `escalate_after_minutes` is how long an unacknowledged page waits in MINUTES, and `escalate_to_team` is who it goes to next.",
+      "data": {
+        "data": [
+          { "team": "Payments", "quiet_hours_start": "22:00", "quiet_hours_end": "07:00", "escalate_after_minutes": 10, "escalate_to_team": "Platform" },
+          { "team": "Identity", "quiet_hours_start": "23:00", "quiet_hours_end": "08:00", "escalate_after_minutes": 15, "escalate_to_team": "Platform" },
+          { "team": "Discovery", "quiet_hours_start": "20:00", "quiet_hours_end": "09:00", "escalate_after_minutes": 20, "escalate_to_team": "Payments" },
+          { "team": "Messaging", "quiet_hours_start": "21:00", "quiet_hours_end": "06:00", "escalate_after_minutes": 5, "escalate_to_team": "Platform" },
+          { "team": "Platform", "quiet_hours_start": "00:00", "quiet_hours_end": "06:00", "escalate_after_minutes": 30, "escalate_to_team": "Identity" }
+        ]
+      }
+    },
+    "get_service_map": {
+      "does": "Which service calls which, over the last hour. The rows are the `data` array. `from_service` and `to_service` are list_services names, `calls` is how many requests crossed that link in the window, and `error_pct` is the share of them that failed.",
+      "data": {
+        "data": [
+          { "from_service": "edge-router", "to_service": "checkout-api", "calls": 184200, "error_pct": 2.4 },
+          { "from_service": "checkout-api", "to_service": "auth-gateway", "calls": 92400, "error_pct": 0.1 },
+          { "from_service": "checkout-api", "to_service": "ledger-worker", "calls": 88100, "error_pct": 0.3 },
+          { "from_service": "checkout-api", "to_service": "notify-fanout", "calls": 41300, "error_pct": 18.6 },
+          { "from_service": "checkout-api", "to_service": "billing-sync", "calls": 12750, "error_pct": 0.0 },
+          { "from_service": "ledger-worker", "to_service": "billing-sync", "calls": 30500, "error_pct": 0.2 }
+        ]
+      }
+    },
     "acknowledge_alert": {
       "does": "Acknowledge a firing alert. Escalation stops and the alert is recorded against whoever took it.",
       "takes": { "alert_id": "string" }
@@ -156,6 +181,18 @@
     "page_oncall": {
       "does": "Page the on-call primary for a service. Their phone rings, wherever they are.",
       "takes": { "service_id": "string", "message": "string" }
+    },
+    "update_incident_status": {
+      "does": "Move an incident to another status — mitigating, monitoring or resolved. Everyone watching the incident sees it move.",
+      "takes": { "incident_id": "string", "status": "string" }
+    },
+    "create_alert_rule": {
+      "does": "Create an alert rule on a service's metric. It starts evaluating straight away and pages the team named. `threshold_ms` is in MILLISECONDS.",
+      "takes": { "service_id": "string", "metric": "string", "threshold_ms": "number", "notify_team": "string" }
+    },
+    "update_notification_policy": {
+      "does": "Replace a team's routing policy. Quiet hours are 24-hour 'HH:MM' times and the change applies to the next alert that fires.",
+      "takes": { "team": "string", "quiet_hours_start": "string", "quiet_hours_end": "string", "escalate_after_minutes": "number", "escalate_to_team": "string" }
     }
   }
 }

--- a/genbench/worlds/people-ops/cases.json
+++ b/genbench/worlds/people-ops/cases.json
@@ -130,5 +130,76 @@
       "shows each person's carried hours and used hours, matching the roster",
       "states the carryover cap it filtered on"
     ]
+  },
+  {
+    "id": "org-chart",
+    "lane": "screen",
+    "prompt": "Draw the reporting lines for the whole company — who manages who, top to bottom.",
+    "tags": ["display"],
+    "shape": "tree",
+    "source": "Gusto — Team directory / org chart, https://support.gusto.com/article/240401180648063/view-your-team-and-company-org-chart-as-a-us-employee-manager-or-contractor",
+    "pass": [
+      "draws the roster as a hierarchy of connected levels rather than a flat list",
+      "puts Rosa Delgado alone at the top, with Nadia Kwan, Marcus Odell, Wren Chen and Sena Nakamura directly under her",
+      "nests Priya Raghunathan, Daniel Okafor and Elin Lindqvist under Nadia Kwan, Yara Haddad, Tomas Bello and Luz Arriaga under Marcus Odell, and Theo Brandt under Wren Chen",
+      "shows each person's title and places all twelve employees, inventing nobody"
+    ]
+  },
+  {
+    "id": "medical-plan-compare",
+    "lane": "screen",
+    "prompt": "Put our medical plans side by side — premium, deductible, who's on each — before open enrollment.",
+    "tags": ["display"],
+    "shape": "comparison",
+    "source": "Gusto — Benefits shopping, https://gusto.com/product/benefits",
+    "pass": [
+      "puts the three plans side by side, one column each, rather than stacking them as three separate blocks",
+      "shows every plan's monthly premium and deductible, matching the tool's numbers, in dollars rather than raw cents",
+      "names who is enrolled in each plan: two on Ridgeline HDHP, three on Cedar HMO and four on Harbor PPO",
+      "enrolls nobody the tool does not list, so Tomas Bello, Theo Brandt and Luz Arriaga appear on no plan"
+    ]
+  },
+  {
+    "id": "leave-policy-settings",
+    "lane": "screen",
+    "prompt": "Pull up our time-off policy — accrual rate, carryover cap, notice period, blackout weeks — so I can check it before I answer a question about it.",
+    "tags": ["display"],
+    "shape": "settings",
+    "source": "Gusto — Time off policy setup, https://support.gusto.com/article/999756591000000/set-up-and-manage-time-off-policies-for-admins",
+    "pass": [
+      "lays the policy out as labelled settings fields rather than a paragraph of prose",
+      "shows 12 hours accrued a month, an 80-hour carryover cap and a 7-day notice period, matching the policy tool",
+      "shows both blackout weeks, dated like 'Nov 23, 2026' rather than ISO",
+      "offers no save or edit control, since no tool changes the policy"
+    ]
+  },
+  {
+    "id": "roster-filter-builder",
+    "lane": "screen",
+    "prompt": "Let me filter the roster myself — department, employment type and status, and pick which columns show — instead of scrolling the whole list.",
+    "tags": ["display"],
+    "shape": "filter-builder",
+    "source": "Rippling — Custom report builder, https://www.rippling.com/blog/unify-and-level-up-your-workforce-analytics-with-ripplings-new-custom-reports",
+    "pass": [
+      "offers a filter for each of department, employment type and status, and a control that picks which columns show",
+      "lists all twelve employees before any filter is set",
+      "filtering to Engineering and full-time narrows the roster to exactly Nadia Kwan, Priya Raghunathan, Daniel Okafor and Elin Lindqvist",
+      "clearing the filters brings all twelve back, and turning a column off drops that column without dropping any row"
+    ]
+  },
+  {
+    "id": "review-stage-board",
+    "lane": "screen",
+    "prompt": "Lay the midyear review out as a board — one column per stage — so I can see who's stuck where, not just a sorted list.",
+    "tags": ["display"],
+    "shape": "board",
+    "source": "Rippling — Performance review stages + calibration, https://www.rippling.com/products/hr/performance-management",
+    "pass": [
+      "draws one labelled column per stage — not started, self review, manager review, calibration, complete — side by side rather than a sorted list",
+      "places all eight people in the cycle and nobody else, so neither person onboarding appears",
+      "puts Tomas Bello under not started, Daniel Okafor, Marcus Odell and Sena Nakamura under self review, Priya Raghunathan and Nadia Kwan under manager review, Wren Chen under calibration and Elin Lindqvist under complete",
+      "shows each person's due date, reading like 'Aug 14' rather than ISO",
+      "flags exactly the four people whose step is late and leaves the four on time unflagged"
+    ]
   }
 ]

--- a/genbench/worlds/people-ops/world.json
+++ b/genbench/worlds/people-ops/world.json
@@ -121,6 +121,16 @@
         ]
       }
     },
+    "list_benefit_plans": {
+      "does": "The medical plans the company offers, cheapest premium first. The rows are the `data` array. `premium_cents` is the monthly premium per enrolled employee, in CENTS: 34500 is $345.00; `deductible_cents` is the annual individual deductible. `enrolled` names the employees on that plan — contractors and people still onboarding are not enrolled.",
+      "data": {
+        "data": [
+          { "plan": "Ridgeline HDHP", "premium_cents": 27800, "deductible_cents": 400000, "enrolled": ["Priya Raghunathan", "Marcus Odell"] },
+          { "plan": "Cedar HMO", "premium_cents": 34500, "deductible_cents": 250000, "enrolled": ["Daniel Okafor", "Elin Lindqvist", "Yara Haddad"] },
+          { "plan": "Harbor PPO", "premium_cents": 52400, "deductible_cents": 100000, "enrolled": ["Nadia Kwan", "Rosa Delgado", "Wren Chen", "Sena Nakamura"] }
+        ]
+      }
+    },
     "approve_time_off": {
       "does": "Approve one pending time-off request. The hours come off the employee's balance and the employee is emailed.",
       "takes": { "id": "string" }

--- a/genbench/worlds/product-analytics/cases.json
+++ b/genbench/worlds/product-analytics/cases.json
@@ -145,7 +145,7 @@
     ],
     "tags": ["action"],
     "shape": "filter-builder",
-    "source": "Amplitude Create/Modify Segment (amplitude.com/docs/analytics/charts/build-charts-modify-user-segment); PostHog Cohorts (posthog.com/docs/data/cohorts)"
+    "source": "Amplitude — Create/Modify Segment, https://amplitude.com/docs/analytics/charts/build-charts-modify-user-segment; PostHog — Cohorts, https://posthog.com/docs/data/cohorts"
   },
   {
     "id": "workspace-roles",
@@ -159,7 +159,7 @@
     ],
     "tags": ["action"],
     "shape": "permissions",
-    "source": "Amplitude Roles & Permissions (amplitude.com/docs/admin/account-management/role-based-access-controls-rbac); PostHog Access control (posthog.com/docs/settings/access-control)"
+    "source": "Amplitude — Roles & Permissions, https://amplitude.com/docs/admin/account-management/role-based-access-controls-rbac; PostHog — Access control, https://posthog.com/docs/settings/access-control"
   },
   {
     "id": "post-open-paths",
@@ -173,7 +173,7 @@
     ],
     "tags": ["display"],
     "shape": "tree",
-    "source": "Amplitude Pathfinder (amplitude.com/docs/analytics/charts/legacy-charts/legacy-charts-pathfinder); PostHog Paths (posthog.com/docs/product-analytics/insights)"
+    "source": "Amplitude — Pathfinder, https://amplitude.com/docs/analytics/charts/legacy-charts/legacy-charts-pathfinder; PostHog — Paths, https://posthog.com/docs/product-analytics/insights"
   },
   {
     "id": "pricing-experiment",
@@ -187,7 +187,7 @@
     ],
     "tags": ["display"],
     "shape": "comparison",
-    "source": "Amplitude Experiment Analysis view (amplitude.com/docs/feature-experiment/analysis-view); PostHog Experiments (posthog.com/docs/experiments/analyzing-results)"
+    "source": "Amplitude — Experiment Analysis view, https://amplitude.com/docs/feature-experiment/analysis-view; PostHog — Experiments, https://posthog.com/docs/experiments/analyzing-results"
   },
   {
     "id": "active-users-map",
@@ -202,6 +202,6 @@
     ],
     "tags": ["display"],
     "shape": "map",
-    "source": "Amplitude Event Segmentation Map view (amplitude.com/docs/analytics/charts/event-segmentation/event-segmentation-build); PostHog World Map (posthog.com/docs/product-analytics/trends/charts)"
+    "source": "Amplitude — Event Segmentation Map view, https://amplitude.com/docs/analytics/charts/event-segmentation/event-segmentation-build; PostHog — World Map, https://posthog.com/docs/product-analytics/trends/charts"
   }
 ]

--- a/genbench/worlds/product-analytics/cases.json
+++ b/genbench/worlds/product-analytics/cases.json
@@ -131,5 +131,77 @@
     ],
     "tags": ["action"],
     "shape": "list-feed"
+  },
+  {
+    "id": "segment-rule-builder",
+    "lane": "screen",
+    "prompt": "I want a segment builder where I can stack rules against our events — pick an event, a property, a value — chain them with AND or OR, and see how many people match before I save it.",
+    "pass": [
+      "a rule is built by picking an event, then a property, then a value, all from the tool's rows — picking checkout_started leaves plan and country as its properties",
+      "a second rule can be added and joined to the first with AND or OR, without leaving the screen",
+      "the matching-people count shown before saving is one the tool returned — checkout_started plan is pro reads 1,386 people",
+      "saving calls the create tool with the name that was typed and a definition carrying both rules and the and/or between them",
+      "invents no event, property or value the tool did not return"
+    ],
+    "tags": ["action"],
+    "shape": "filter-builder",
+    "source": "Amplitude Create/Modify Segment (amplitude.com/docs/analytics/charts/build-charts-modify-user-segment); PostHog Cohorts (posthog.com/docs/data/cohorts)"
+  },
+  {
+    "id": "workspace-roles",
+    "lane": "screen",
+    "prompt": "Show me who's on this workspace, what role each person has, and let me change someone's role between viewer, editor and admin.",
+    "pass": [
+      "lists all five members with the role beside each: one admin, two editors, two viewers",
+      "shows Ines Vogel as invited, with a blank last-active rather than a date",
+      "each member's role sits in a control offering viewer, editor and admin, not plain text",
+      "changing a member's role calls the write tool with that member's id and the role that was picked"
+    ],
+    "tags": ["action"],
+    "shape": "permissions",
+    "source": "Amplitude Roles & Permissions (amplitude.com/docs/admin/account-management/role-based-access-controls-rbac); PostHog Access control (posthog.com/docs/settings/access-control)"
+  },
+  {
+    "id": "post-open-paths",
+    "lane": "screen",
+    "prompt": "Show me the paths people actually take after they open the app — the branching tree of what they do next and next after that — so I can see where they wander off before converting.",
+    "pass": [
+      "roots the tree at app_opened and hangs all five next events off it, onboarding_step_viewed's 4,980 the largest branch",
+      "the branches that go further — onboarding_step_viewed and pricing_page_viewed — nest their own children under them rather than sitting in one flat list",
+      "every count and share is the tool's: pricing_page_viewed 2,090 at 12.4%, then checkout_started 742 at 35.5% of it",
+      "shows drop-off as its own branch at each level, so the 2,552 people who leave after onboarding_step_viewed are visible"
+    ],
+    "tags": ["display"],
+    "shape": "tree",
+    "source": "Amplitude Pathfinder (amplitude.com/docs/analytics/charts/legacy-charts/legacy-charts-pathfinder); PostHog Paths (posthog.com/docs/product-analytics/insights)"
+  },
+  {
+    "id": "pricing-experiment",
+    "lane": "screen",
+    "prompt": "We're running a pricing-page experiment — put the control and the variant side by side: signups, conversion rate, revenue, and whether the difference is significant yet.",
+    "pass": [
+      "puts Control and Annual-first pricing side by side, the same metrics on each",
+      "every number is the tool's: Control 4,210 users, 261 signups, 6.2%, $12,840.00 — Annual-first 4,188 users, 310 signups, 7.4%, $15,960.00",
+      "shows Annual-first's 19.4% lift over Control, and no lift on Control itself",
+      "says the difference is not significant yet rather than calling Annual-first the winner"
+    ],
+    "tags": ["display"],
+    "shape": "comparison",
+    "source": "Amplitude Experiment Analysis view (amplitude.com/docs/feature-experiment/analysis-view); PostHog Experiments (posthog.com/docs/experiments/analyzing-results)"
+  },
+  {
+    "id": "active-users-map",
+    "lane": "screen",
+    "prompt": "Show me where our active users are logging in from — a map of active users by country over the last 30 days.",
+    "pass": [
+      "plots the nine countries the tool returned on a map, shaded or sized by active users rather than drawn as a bar chart",
+      "the United States reads as the biggest at 18,420 active users, 43.7%",
+      "each country's own count is readable, not only encoded as a shade — Germany 3,862 and Japan 1,206 are both legible",
+      "names the window, last 30 days, on the screen",
+      "marks no country the tool did not return"
+    ],
+    "tags": ["display"],
+    "shape": "map",
+    "source": "Amplitude Event Segmentation Map view (amplitude.com/docs/analytics/charts/event-segmentation/event-segmentation-build); PostHog World Map (posthog.com/docs/product-analytics/trends/charts)"
   }
 ]

--- a/genbench/worlds/product-analytics/cases.json
+++ b/genbench/worlds/product-analytics/cases.json
@@ -140,7 +140,7 @@
       "a rule is built by picking an event, then a property, then a value, all from the tool's rows — picking checkout_started leaves plan and country as its properties",
       "a second rule can be added and joined to the first with AND or OR, without leaving the screen",
       "the matching-people count shown before saving is one the tool returned — checkout_started plan is pro reads 1,386 people",
-      "saving calls the create tool with the name that was typed and a definition carrying both rules and the and/or between them",
+      "a name field and a save control sit with the rules, so the segment is named and saved without leaving the builder",
       "invents no event, property or value the tool did not return"
     ],
     "tags": ["action"],

--- a/genbench/worlds/product-analytics/world.json
+++ b/genbench/worlds/product-analytics/world.json
@@ -62,6 +62,26 @@
         ]
       }
     },
+    "get_event_paths": {
+      "does": "What people do next after one event, as a branching tree over the last 7 days. The rows are the `data` array — this response is `app_opened`, which 16842 people fired. `from_event` is the branch's parent, `step` is how far past the root it sits, `users` is the people who took it and `pct_of_parent` their share of the parent. `(drop-off)` is the branch that ends the session. Only the branches worth opening are returned.",
+      "takes": { "event_name": "string" },
+      "data": {
+        "data": [
+          { "from_event": "app_opened", "step": 1, "event_name": "onboarding_step_viewed", "users": 4980, "pct_of_parent": 29.6 },
+          { "from_event": "app_opened", "step": 1, "event_name": "(drop-off)", "users": 4002, "pct_of_parent": 23.8 },
+          { "from_event": "app_opened", "step": 1, "event_name": "sidebar_collapsed", "users": 3120, "pct_of_parent": 18.5 },
+          { "from_event": "app_opened", "step": 1, "event_name": "report_exported", "users": 2650, "pct_of_parent": 15.7 },
+          { "from_event": "app_opened", "step": 1, "event_name": "pricing_page_viewed", "users": 2090, "pct_of_parent": 12.4 },
+          { "from_event": "onboarding_step_viewed", "step": 2, "event_name": "(drop-off)", "users": 2552, "pct_of_parent": 51.2 },
+          { "from_event": "onboarding_step_viewed", "step": 2, "event_name": "workspace_created", "users": 1806, "pct_of_parent": 36.3 },
+          { "from_event": "onboarding_step_viewed", "step": 2, "event_name": "invite_sent", "users": 622, "pct_of_parent": 12.5 },
+          { "from_event": "pricing_page_viewed", "step": 2, "event_name": "(drop-off)", "users": 1348, "pct_of_parent": 64.5 },
+          { "from_event": "pricing_page_viewed", "step": 2, "event_name": "checkout_started", "users": 742, "pct_of_parent": 35.5 },
+          { "from_event": "checkout_started", "step": 3, "event_name": "(drop-off)", "users": 424, "pct_of_parent": 57.1 },
+          { "from_event": "checkout_started", "step": 3, "event_name": "checkout_completed", "users": 318, "pct_of_parent": 42.9 }
+        ]
+      }
+    },
     "list_funnels": {
       "does": "Every saved funnel with how many people entered it and its end-to-end conversion over `window`. The rows are the `data` array. `steps` is how many steps the funnel has. Every step of every funnel is built on an event already in the tracking plan: Trial to paid checkout on checkout_started, pricing_page_viewed and checkout_completed, First teammate invited on workspace_created, app_opened and invite_sent.",
       "data": {
@@ -132,6 +152,63 @@
         ]
       }
     },
+    "list_filter_fields": {
+      "does": "Every event property a segment rule can be built on, with the values it most often takes and how many people match that one rule over the last 30 days. The rows are the `data` array. `matching_users` is people, not fires, and it counts that rule on its own — stacking a second rule with AND can only shrink it.",
+      "data": {
+        "data": [
+          { "event_name": "checkout_started", "property": "plan", "value": "pro", "matching_users": 1386 },
+          { "event_name": "checkout_started", "property": "plan", "value": "team", "matching_users": 962 },
+          { "event_name": "checkout_started", "property": "plan", "value": "starter", "matching_users": 662 },
+          { "event_name": "checkout_started", "property": "country", "value": "US", "matching_users": 1806 },
+          { "event_name": "checkout_started", "property": "country", "value": "GB", "matching_users": 391 },
+          { "event_name": "checkout_started", "property": "country", "value": "DE", "matching_users": 301 },
+          { "event_name": "pricing_page_viewed", "property": "source", "value": "web", "matching_users": 8420 },
+          { "event_name": "pricing_page_viewed", "property": "source", "value": "mobile", "matching_users": 2360 },
+          { "event_name": "signup_completed", "property": "source", "value": "web", "matching_users": 4210 },
+          { "event_name": "signup_completed", "property": "source", "value": "mobile", "matching_users": 1394 },
+          { "event_name": "report_exported", "property": "format", "value": "csv", "matching_users": 1204 },
+          { "event_name": "report_exported", "property": "format", "value": "pdf", "matching_users": 486 }
+        ]
+      }
+    },
+    "get_experiment_results": {
+      "does": "One experiment's variants side by side over its whole run so far. The rows are the `data` array — this response is the pricing-page experiment. `users` saw the variant, `signups` are the ones who then signed up, `revenue_cents` is in CENTS: 1284000 is $12,840.00. `delta_pct` is the lift over control and is 0 on control itself, and `is_significant` stays false until the result clears 95% confidence.",
+      "takes": { "experiment_id": "string" },
+      "data": {
+        "data": [
+          { "variant_name": "Control", "users": 4210, "signups": 261, "conversion_pct": 6.2, "revenue_cents": 1284000, "delta_pct": 0.0, "is_significant": false },
+          { "variant_name": "Annual-first pricing", "users": 4188, "signups": 310, "conversion_pct": 7.4, "revenue_cents": 1596000, "delta_pct": 19.4, "is_significant": false }
+        ]
+      }
+    },
+    "get_active_users_by_country": {
+      "does": "Where the workspace's active users were over the last 30 days, biggest country first. The rows are the `data` array — 42180 people were active in all, and `share_pct` is each country's share of that, so the nine countries here do not add up to 100. `country_code` is ISO 3166-1 alpha-2.",
+      "data": {
+        "data": [
+          { "country": "United States", "country_code": "US", "active_users": 18420, "share_pct": 43.7 },
+          { "country": "United Kingdom", "country_code": "GB", "active_users": 5104, "share_pct": 12.1 },
+          { "country": "Germany", "country_code": "DE", "active_users": 3862, "share_pct": 9.2 },
+          { "country": "Canada", "country_code": "CA", "active_users": 2940, "share_pct": 7.0 },
+          { "country": "India", "country_code": "IN", "active_users": 2610, "share_pct": 6.2 },
+          { "country": "Australia", "country_code": "AU", "active_users": 1884, "share_pct": 4.5 },
+          { "country": "Brazil", "country_code": "BR", "active_users": 1520, "share_pct": 3.6 },
+          { "country": "Japan", "country_code": "JP", "active_users": 1206, "share_pct": 2.9 },
+          { "country": "Netherlands", "country_code": "NL", "active_users": 1042, "share_pct": 2.5 }
+        ]
+      }
+    },
+    "list_members": {
+      "does": "Everyone on the workspace, admins first. The rows are the `data` array. `role` is viewer, editor or admin, `status` is active or invited, and `last_active` is null for someone who has not accepted the invite yet.",
+      "data": {
+        "data": [
+          { "id": "mbr_priya", "name": "Priya Raman", "email": "priya.raman@waypost.example", "role": "admin", "status": "active", "last_active": "2026-08-11" },
+          { "id": "mbr_marcus", "name": "Marcus Hale", "email": "marcus.hale@waypost.example", "role": "editor", "status": "active", "last_active": "2026-08-11" },
+          { "id": "mbr_dana", "name": "Dana Okonkwo", "email": "dana.okonkwo@waypost.example", "role": "editor", "status": "active", "last_active": "2026-08-10" },
+          { "id": "mbr_sam", "name": "Sam Ferreira", "email": "sam.ferreira@waypost.example", "role": "viewer", "status": "active", "last_active": "2026-08-04" },
+          { "id": "mbr_ines", "name": "Ines Vogel", "email": "ines.vogel@waypost.example", "role": "viewer", "status": "invited", "last_active": null }
+        ]
+      }
+    },
     "list_alerts": {
       "does": "Every anomaly alert raised in the last 7 days, newest first. The rows are the `data` array. `status` is firing, acknowledged or resolved; `observed` and `expected` are counts over the alert's `window`; `change_pct` is how far off the metric ran; `assignee` is null when nobody has taken it.",
       "data": {
@@ -155,6 +232,10 @@
     "deprecate_event": {
       "does": "Mark one event deprecated: it disappears from new charts and keeps its history. Call it once per event.",
       "takes": { "name": "string", "reason": "string" }
+    },
+    "update_member_role": {
+      "does": "Change one member's role. `role` is viewer, editor or admin, and the new role applies the moment it is called.",
+      "takes": { "member_id": "string", "role": "string" }
     }
   }
 }

--- a/genbench/worlds/project-tracker/cases.json
+++ b/genbench/worlds/project-tracker/cases.json
@@ -169,7 +169,8 @@
       "shows one form to file a new issue, with a field each for title, team, priority, assignee and estimate",
       "priority offers urgent, high, medium and low, and assignee offers the five teammates by name",
       "invents no issue key for the bug before it is filed",
-      "one control files the bug, and it stays unavailable until the form carries a title"
+      "one control files the bug, and it stays unavailable until the form carries a title",
+      "filing calls create_issue with exactly the title, team, priority, assignee and estimate the form carries"
     ],
     "tags": ["action"],
     "shape": "form",

--- a/genbench/worlds/project-tracker/cases.json
+++ b/genbench/worlds/project-tracker/cases.json
@@ -155,7 +155,7 @@
       "each of the three offers the values the issues actually use — the six statuses, the four priorities, and the five teammates by name",
       "more than one condition can stand at once, rather than one replacing the last",
       "takes a name for the filter before it can be saved",
-      "saving calls save_filter with that name and the conditions that were picked"
+      "shows where saved filters live alongside the builder, so a saved one is waiting to be picked up next time"
     ],
     "tags": ["action"],
     "shape": "filter-builder",
@@ -169,7 +169,7 @@
       "shows one form to file a new issue, with a field each for title, team, priority, assignee and estimate",
       "priority offers urgent, high, medium and low, and assignee offers the five teammates by name",
       "invents no issue key for the bug before it is filed",
-      "the control that files it calls create_issue, carrying the form's title, team, priority, assignee and estimate as its arguments"
+      "one control files the bug, and it stays unavailable until the form carries a title"
     ],
     "tags": ["action"],
     "shape": "form",

--- a/genbench/worlds/project-tracker/cases.json
+++ b/genbench/worlds/project-tracker/cases.json
@@ -131,5 +131,77 @@
     "tags": ["display"],
     "shape": "empty-state",
     "data": { "list_reviews": { "data": [] } }
+  },
+  {
+    "id": "release-timeline",
+    "lane": "screen",
+    "prompt": "Lay our releases out on a timeline by target date so I can see what's shipping when, and which ones are already late.",
+    "pass": [
+      "lays the four releases out along a run of dates, each one sitting at its own target date — not a table of rows",
+      "places 2026.7 on Jul 31, 2026.8 on Aug 21, 2026.9 on Sep 18 and 2026.10 on Oct 16",
+      "every release reads with its version and the status it is in — shipped, open or planned",
+      "marks nothing as late: the one target date already behind us belongs to 2026.7, which shipped"
+    ],
+    "tags": ["display"],
+    "shape": "timeline",
+    "source": "Linear — Roadmap Timeline, https://linear.app/docs/timeline"
+  },
+  {
+    "id": "save-issue-filter",
+    "lane": "screen",
+    "prompt": "Let me build my own issue filter — mix status, priority and assignee any way I like — and save it so it's waiting for me next time.",
+    "pass": [
+      "offers a builder that filters on status, priority and assignee, rather than one search box",
+      "each of the three offers the values the issues actually use — the six statuses, the four priorities, and the five teammates by name",
+      "more than one condition can stand at once, rather than one replacing the last",
+      "takes a name for the filter before it can be saved",
+      "saving calls save_filter with that name and the conditions that were picked"
+    ],
+    "tags": ["action"],
+    "shape": "filter-builder",
+    "source": "Linear — Advanced filters, https://linear.app/docs/filters"
+  },
+  {
+    "id": "file-bug",
+    "lane": "screen",
+    "prompt": "Open a new bug on the mobile team — title, priority, assignee, estimate — and file it.",
+    "pass": [
+      "shows one form to file a new issue, with a field each for title, team, priority, assignee and estimate",
+      "priority offers urgent, high, medium and low, and assignee offers the five teammates by name",
+      "invents no issue key for the bug before it is filed",
+      "the control that files it calls create_issue, carrying the form's title, team, priority, assignee and estimate as its arguments"
+    ],
+    "tags": ["action"],
+    "shape": "form",
+    "source": "Linear — Create issue modal, https://linear.app/docs/creating-issues"
+  },
+  {
+    "id": "release-tree",
+    "lane": "screen",
+    "prompt": "Show me our releases as a tree with their issues nested underneath, collapsed by default, so I can open just the one I'm digging into.",
+    "pass": [
+      "the tree's top rows are the four releases — 2026.7, 2026.8, 2026.9 and 2026.10 — and nothing else sits at that level",
+      "every release starts closed, so no issue row is on screen until one is opened",
+      "each release row carries its status and how many of its issues are done, like 4 of 7 for 2026.8",
+      "a release row is what opens it: pressing one changes the screen and calls no tool"
+    ],
+    "tags": ["display"],
+    "shape": "tree",
+    "source": "Jira — Epic hierarchy (\"Show Hierarchy\"), https://community.atlassian.com/forums/Jira-questions/List-View-Epic-gt-Task-hierarchy-Expand-Collapse/qaq-p/3241354"
+  },
+  {
+    "id": "my-issues-inbox",
+    "lane": "screen",
+    "prompt": "Put my assigned issues in a list on the left, and let clicking one open its full detail on the right — where I can move its status — without leaving the page.",
+    "pass": [
+      "puts a list of issues down the left and one issue's detail on the right, both on the one screen",
+      "every row in the left list belongs to the same teammate — one person's issues, not the whole team's",
+      "pressing a row on the left changes the screen and calls no tool, so the detail opens beside the list rather than on a page of its own",
+      "the detail side shows that issue's key, title, status, priority and points",
+      "the detail side offers a status control, and using it calls move_issue for the issue open there"
+    ],
+    "tags": ["action"],
+    "shape": "split-inbox",
+    "source": "Linear — Split Inbox, https://linear.app/docs/inbox"
   }
 ]

--- a/genbench/worlds/project-tracker/world.json
+++ b/genbench/worlds/project-tracker/world.json
@@ -107,6 +107,10 @@
         ]
       }
     },
+    "create_issue": {
+      "does": "File a new issue on a team. `priority` is one of urgent, high, medium and low, and `points` is a story-point estimate. The key is assigned when the issue is filed.",
+      "takes": { "title": "string", "team": "string", "priority": "string", "member_id": "string", "points": "number" }
+    },
     "move_issue": {
       "does": "Move one issue to a different status. `status` is one of backlog, todo, in_progress, in_review, blocked, done.",
       "takes": { "issue_id": "string", "status": "string" }
@@ -122,6 +126,10 @@
     "cut_release": {
       "does": "Cut a release: freeze what is tagged to it, tag the build and ship it. This cannot be undone.",
       "takes": { "release_id": "string" }
+    },
+    "save_filter": {
+      "does": "Save one issue filter under a name, so it is waiting on the next visit. `conditions` is the filter written out, like 'status is blocked and priority is urgent'.",
+      "takes": { "name": "string", "conditions": "string" }
     }
   }
 }

--- a/genbench/worlds/property-management/cases.json
+++ b/genbench/worlds/property-management/cases.json
@@ -141,7 +141,7 @@
     ],
     "tags": ["display"],
     "shape": "dashboard",
-    "source": "AppFolio — Owner Portal Dashboard (appfolio.com/property-management-owner-experience)"
+    "source": "AppFolio — Owner Portal Dashboard, https://appfolio.com/property-management-owner-experience"
   },
   {
     "id": "portal-announcement",
@@ -183,7 +183,7 @@
     ],
     "tags": ["display"],
     "shape": "split-inbox",
-    "source": "AppFolio — Realm-X centralized inbox (appfolio.com/property-manager/communication-service)"
+    "source": "AppFolio — Realm-X centralized inbox, https://appfolio.com/property-manager/communication-service"
   },
   {
     "id": "vacant-unit-photos",
@@ -197,6 +197,6 @@
     ],
     "tags": ["display"],
     "shape": "gallery",
-    "source": "AppFolio — Marketing/Floorplan Photos (help.propertymeld.com/hc/en-us/articles/45793810226323)"
+    "source": "AppFolio — Marketing/Floorplan Photos, https://help.propertymeld.com/hc/en-us/articles/45793810226323"
   }
 ]

--- a/genbench/worlds/property-management/cases.json
+++ b/genbench/worlds/property-management/cases.json
@@ -128,5 +128,75 @@
     ],
     "tags": ["action"],
     "shape": "table"
+  },
+  {
+    "id": "portfolio-dashboard",
+    "lane": "screen",
+    "prompt": "Give me one screen with occupancy, how much of August rent is collected so far, and how many maintenance requests are still open — the whole portfolio at a glance.",
+    "pass": [
+      "all three answers sit on the one screen: occupancy, August rent collected, and open maintenance requests",
+      "occupancy counts the two vacant units out of the ten — 8 of 10, or 80%",
+      "shows $12,075.00 collected of the $19,045.00 charged for August",
+      "counts 5 requests still open, not all nine"
+    ],
+    "tags": ["display"],
+    "shape": "dashboard",
+    "source": "AppFolio — Owner Portal Dashboard (appfolio.com/property-management-owner-experience)"
+  },
+  {
+    "id": "portal-announcement",
+    "lane": "screen",
+    "prompt": "Write a notice about Saturday's water shutoff and post it to the resident portal for Wexler Row.",
+    "pass": [
+      "the notice is aimed at Wexler Row, picked from the buildings the tool returned rather than typed free-hand",
+      "a title and a body are both drafted and both still editable before anything goes out",
+      "the drafted body says what the notice is about — Saturday and the water shutoff",
+      "posting fires post_announcement with Wexler Row, the title and the body on screen"
+    ],
+    "tags": ["action"],
+    "shape": "feed-composer",
+    "source": "AppFolio — Portal announcement composer"
+  },
+  {
+    "id": "lease-timeline",
+    "lane": "screen",
+    "prompt": "Pull up everything that's happened on Ellis Boone's lease — payments, notices, work orders — in the order it happened, so I have the full story before I call him.",
+    "pass": [
+      "shows exactly the six events on Ellis Boone's lease and none from another tenant's",
+      "lays them out as one dated track rather than a plain table of rows",
+      "the events run in the order they happened, the Nov 1 2025 signing first and the Aug 10 late notice last",
+      "each event says what kind it is — signing, payment, notice, work order — alongside what happened"
+    ],
+    "tags": ["display"],
+    "shape": "timeline",
+    "source": "Buildium — Timeline activity views"
+  },
+  {
+    "id": "message-inbox",
+    "lane": "screen",
+    "prompt": "Show me every tenant and prospect message from this week as an inbox — the list on one side, the full message when I open one.",
+    "pass": [
+      "lists all six messages newest first, each with its sender, subject and preview line",
+      "the three unread ones are visibly marked apart from the three already read",
+      "opening a message shows its full body without leaving the screen, and the list is still reachable",
+      "each message names the unit it is about as 'Wexler Row · 2B', never a raw id"
+    ],
+    "tags": ["display"],
+    "shape": "split-inbox",
+    "source": "AppFolio — Realm-X centralized inbox (appfolio.com/property-manager/communication-service)"
+  },
+  {
+    "id": "vacant-unit-photos",
+    "lane": "screen",
+    "prompt": "Wexler Row 2B and Alder Court 2B are both empty — pull up the marketing photos we already have on file for each so I know what's ready to post.",
+    "pass": [
+      "shows seven tiles in a grid, four under Wexler Row · 2B and three under Alder Court · 2B",
+      "the tiles are grouped by unit, each group headed by its unit name",
+      "every tile carries its caption from the tool, so a tile that cannot load still says what it is",
+      "the two photos on Alder Court 2A are not shown"
+    ],
+    "tags": ["display"],
+    "shape": "gallery",
+    "source": "AppFolio — Marketing/Floorplan Photos (help.propertymeld.com/hc/en-us/articles/45793810226323)"
   }
 ]

--- a/genbench/worlds/property-management/world.json
+++ b/genbench/worlds/property-management/world.json
@@ -126,6 +126,51 @@
         ]
       }
     },
+    "list_lease_activity": {
+      "does": "Everything that has happened on a lease — signings, payments, notices and work orders — for every lease in the portfolio, newest first. The rows are the `data` array. `leaseId` is a row from list_leases and `type` is lease_signed, payment_received, notice_sent, or maintenance_opened.",
+      "data": {
+        "data": [
+          { "id": "la_9", "leaseId": "lease_4", "date": "2026-08-10", "type": "notice_sent", "description": "Late notice emailed for the $1,200.00 still owed on August rent" },
+          { "id": "la_8", "leaseId": "lease_7", "date": "2026-08-10", "type": "notice_sent", "description": "Late notice emailed for the $1,095.00 still owed on August rent" },
+          { "id": "la_7", "leaseId": "lease_4", "date": "2026-08-05", "type": "payment_received", "description": "Partial August rent, $1,200.00 by ACH" },
+          { "id": "la_6", "leaseId": "lease_1", "date": "2026-08-01", "type": "payment_received", "description": "August rent paid in full, $1,850.00 by ACH" },
+          { "id": "la_5", "leaseId": "lease_4", "date": "2026-07-22", "type": "maintenance_opened", "description": "Dishwasher leaking onto the floor, sent to Ridge Appliance Service" },
+          { "id": "la_4", "leaseId": "lease_4", "date": "2026-07-01", "type": "payment_received", "description": "July rent paid in full, $2,400.00 by ACH" },
+          { "id": "la_3", "leaseId": "lease_8", "date": "2026-06-01", "type": "lease_signed", "description": "Lease signed for Foxglove House at $3,850.00 a month" },
+          { "id": "la_2", "leaseId": "lease_4", "date": "2026-06-01", "type": "payment_received", "description": "June rent paid in full, $2,400.00 by ACH" },
+          { "id": "la_1", "leaseId": "lease_4", "date": "2025-11-01", "type": "lease_signed", "description": "Lease signed for Wexler Row 3A at $2,400.00 a month, 12 months" }
+        ]
+      }
+    },
+    "list_messages": {
+      "does": "Messages tenants and prospects have sent this week, newest first. The rows are the `data` array. `unitId` is the unit the message is about — for a prospect, the vacant unit they are asking after. `preview` is the first line of `body`, and `unread` is true until someone opens it.",
+      "data": {
+        "data": [
+          { "id": "msg_6", "from": "Ellis Boone", "unitId": "unit_wex_3a", "subject": "August balance", "preview": "I know I'm short on August — can I bring the rest by Friday?", "body": "I know I'm short on August — can I bring the rest by Friday? I'd rather hand you a check than run another transfer. Let me know if that works.", "receivedAt": "2026-08-12T09:15:00", "unread": true },
+          { "id": "msg_5", "from": "Naomi Castellan", "unitId": "unit_wex_2b", "subject": "Tonight's showing", "preview": "Confirming 5pm for Wexler Row 2B — is parking easy on that block?", "body": "Confirming 5pm for Wexler Row 2B — is parking easy on that block? I'm coming straight from work so I may be five minutes late.", "receivedAt": "2026-08-12T08:02:00", "unread": true },
+          { "id": "msg_4", "from": "Harriet Nolan", "unitId": "unit_ald_2b", "subject": "Is Alder Court 2B pet friendly?", "preview": "I have a small dog — is there a pet deposit on top of the regular one?", "body": "I have a small dog — is there a pet deposit on top of the regular one? Also, is the second bedroom big enough for a desk and a bed?", "receivedAt": "2026-08-11T16:40:00", "unread": true },
+          { "id": "msg_3", "from": "Grace Okonjo", "unitId": "unit_ald_2a", "subject": "Move-out walkthrough", "preview": "Can we do the walkthrough on the 31st rather than the 30th?", "body": "Can we do the walkthrough on the 31st rather than the 30th? The movers pushed me back a day. I'll have the keys with me either way.", "receivedAt": "2026-08-11T11:20:00", "unread": false },
+          { "id": "msg_2", "from": "Theo Mancini", "unitId": "unit_ald_1a", "subject": "Front door buzzer still broken", "preview": "Nobody can buzz up — deliveries are being left on the step.", "body": "Nobody can buzz up — deliveries are being left on the step. It's been a couple of weeks now. Any idea when someone is coming out?", "receivedAt": "2026-08-10T18:05:00", "unread": false },
+          { "id": "msg_1", "from": "Dominic Hartley", "unitId": "unit_fox_house", "subject": "Garage door opener", "preview": "The electrician came by — the opener works, but the remote still doesn't.", "body": "The electrician came by — the opener works, but the remote still doesn't. Do I need a new remote or is that part of the same job?", "receivedAt": "2026-08-10T07:45:00", "unread": false }
+        ]
+      }
+    },
+    "list_unit_photos": {
+      "does": "The marketing photos on file for units being listed. The rows are the `data` array. `unitId` is a row from list_units and `caption` is what the photo shows.",
+      "data": {
+        "data": [
+          { "id": "pho_1", "unitId": "unit_wex_2b", "caption": "Living room from the entry" },
+          { "id": "pho_2", "unitId": "unit_wex_2b", "caption": "Kitchen and breakfast bar" },
+          { "id": "pho_3", "unitId": "unit_wex_2b", "caption": "Main bedroom" },
+          { "id": "pho_4", "unitId": "unit_wex_2b", "caption": "Building exterior from the street" },
+          { "id": "pho_5", "unitId": "unit_ald_2b", "caption": "Living room with the bay window" },
+          { "id": "pho_6", "unitId": "unit_ald_2b", "caption": "Galley kitchen" },
+          { "id": "pho_7", "unitId": "unit_ald_2b", "caption": "Shared courtyard" },
+          { "id": "pho_8", "unitId": "unit_ald_2a", "caption": "Living room, taken before the current tenant moved in" },
+          { "id": "pho_9", "unitId": "unit_ald_2a", "caption": "Kitchen, taken before the current tenant moved in" }
+        ]
+      }
+    },
     "assign_vendor": {
       "does": "Put a vendor on a maintenance request, which schedules the job and notifies them. `requestId` is a row from list_maintenance_requests, `vendorId` a row from list_vendors.",
       "takes": { "requestId": "string", "vendorId": "string" }
@@ -141,6 +186,10 @@
     "renew_lease": {
       "does": "Renew a lease at a new end date and rent. `leaseId` is a row from list_leases, `endDate` is YYYY-MM-DD, and `rentCents` is the new rent in CENTS: 195000 is $1,950.00.",
       "takes": { "leaseId": "string", "endDate": "string", "rentCents": "number" }
+    },
+    "post_announcement": {
+      "does": "Post an announcement to the resident portal of one building, where every tenant there sees it. `property` is a building name from list_units — 'Wexler Row'. `title` is the headline and `body` the notice itself.",
+      "takes": { "property": "string", "title": "string", "body": "string" }
     }
   }
 }

--- a/genbench/worlds/store-admin/cases.json
+++ b/genbench/worlds/store-admin/cases.json
@@ -154,7 +154,7 @@
       "lists all four staff with the role each one holds",
       "shows for every person whether they can open orders, inventory, discounts and payouts",
       "Rosa Delgado's four areas all read as off to start",
-      "ticking orders on for Rosa calls set_staff_permission with her staff id, the orders area and enabled true"
+      "each of Rosa's four areas ticks on its own, so orders and inventory can be opened without touching discounts or payouts"
     ],
     "source": "Shopify — Settings > Users > Roles, https://help.shopify.com/en/manual/your-account/users/roles/manage-roles"
   },
@@ -182,7 +182,7 @@
       "lists all five conversations down one side, with the three unread ones marked",
       "clicking a conversation opens it beside the list, with the list still on screen",
       "the opened conversation shows every message in it in order, saying who sent each",
-      "the reply box calls send_message with that conversation's id and the typed text"
+      "a reply box and its send control sit with the open conversation, so replying never leaves the list"
     ],
     "source": "Shopify — Inbox, https://help.shopify.com/en/manual/inbox/conversations"
   },

--- a/genbench/worlds/store-admin/cases.json
+++ b/genbench/worlds/store-admin/cases.json
@@ -154,7 +154,8 @@
       "lists all four staff with the role each one holds",
       "shows for every person whether they can open orders, inventory, discounts and payouts",
       "Rosa Delgado's four areas all read as off to start",
-      "each of Rosa's four areas ticks on its own, so orders and inventory can be opened without touching discounts or payouts"
+      "each of Rosa's four areas ticks on its own, so orders and inventory can be opened without touching discounts or payouts",
+      "ticking Rosa's orders on fires set_staff_permission with stf_rosa, orders and true"
     ],
     "source": "Shopify — Settings > Users > Roles, https://help.shopify.com/en/manual/your-account/users/roles/manage-roles"
   },

--- a/genbench/worlds/store-admin/cases.json
+++ b/genbench/worlds/store-admin/cases.json
@@ -142,7 +142,7 @@
       "marks Fernbrook Classic as the live theme, and marks no other tile live",
       "names no theme the tool did not return"
     ],
-    "source": "Shopify, Online Store > Themes — help.shopify.com/en/manual/online-store/themes/managing-themes"
+    "source": "Shopify — Online Store > Themes, https://help.shopify.com/en/manual/online-store/themes/managing-themes"
   },
   {
     "id": "packer-access",
@@ -156,7 +156,7 @@
       "Rosa Delgado's four areas all read as off to start",
       "ticking orders on for Rosa calls set_staff_permission with her staff id, the orders area and enabled true"
     ],
-    "source": "Shopify, Settings > Users > Roles — help.shopify.com/en/manual/your-account/users/roles/manage-roles"
+    "source": "Shopify — Settings > Users > Roles, https://help.shopify.com/en/manual/your-account/users/roles/manage-roles"
   },
   {
     "id": "selling-regions",
@@ -170,7 +170,7 @@
       "the three regions with no orders read as not sold into yet, distinct from the four active ones",
       "flagging one of those three calls activate_region with that region"
     ],
-    "source": "Shopify, Markets — help.shopify.com/en/manual/markets/getting-started/managing-markets"
+    "source": "Shopify — Markets, https://help.shopify.com/en/manual/markets/getting-started/managing-markets"
   },
   {
     "id": "order-inbox",
@@ -184,7 +184,7 @@
       "the opened conversation shows every message in it in order, saying who sent each",
       "the reply box calls send_message with that conversation's id and the typed text"
     ],
-    "source": "Shopify, Inbox — help.shopify.com/en/manual/inbox/conversations"
+    "source": "Shopify — Inbox, https://help.shopify.com/en/manual/inbox/conversations"
   },
   {
     "id": "shipping-settings",
@@ -198,6 +198,6 @@
       "one save control commits all three settings together, rather than each saving on its own",
       "saving calls update_shipping_settings with all three values"
     ],
-    "source": "Shopify, Settings > Shipping and delivery — help.shopify.com/en/manual/fulfillment/setup"
+    "source": "Shopify — Settings > Shipping and delivery, https://help.shopify.com/en/manual/fulfillment/setup"
   }
 ]

--- a/genbench/worlds/store-admin/cases.json
+++ b/genbench/worlds/store-admin/cases.json
@@ -129,5 +129,75 @@
       "offers no approve or deny control"
     ],
     "data": { "list_refund_requests": { "data": [] } }
+  },
+  {
+    "id": "theme-gallery",
+    "lane": "screen",
+    "prompt": "Show me the themes on the store as a grid so I can see which one's live.",
+    "tags": ["display"],
+    "shape": "gallery",
+    "pass": [
+      "lays all five themes out as a grid of tiles, not a table or a single column",
+      "each tile names its theme and when it was last updated",
+      "marks Fernbrook Classic as the live theme, and marks no other tile live",
+      "names no theme the tool did not return"
+    ],
+    "source": "Shopify, Online Store > Themes — help.shopify.com/en/manual/online-store/themes/managing-themes"
+  },
+  {
+    "id": "packer-access",
+    "lane": "screen",
+    "prompt": "I hired someone part-time to help pack orders. Show me who has access to the shop and what each person can touch, and let me tick on exactly what my new packer can see — orders and inventory only, nothing about money or discounts.",
+    "tags": ["action"],
+    "shape": "permissions",
+    "pass": [
+      "lists all four staff with the role each one holds",
+      "shows for every person whether they can open orders, inventory, discounts and payouts",
+      "Rosa Delgado's four areas all read as off to start",
+      "ticking orders on for Rosa calls set_staff_permission with her staff id, the orders area and enabled true"
+    ],
+    "source": "Shopify, Settings > Users > Roles — help.shopify.com/en/manual/your-account/users/roles/manage-roles"
+  },
+  {
+    "id": "selling-regions",
+    "lane": "screen",
+    "prompt": "Show me which regions my orders are actually shipping to right now, and let me flag a new one I want to start selling into.",
+    "tags": ["action"],
+    "shape": "map",
+    "pass": [
+      "plots all seven regions as markers on a map, not only as a list",
+      "each selling region shows its order count and its sales, the United States highest at 128 orders",
+      "the three regions with no orders read as not sold into yet, distinct from the four active ones",
+      "flagging one of those three calls activate_region with that region"
+    ],
+    "source": "Shopify, Markets — help.shopify.com/en/manual/markets/getting-started/managing-markets"
+  },
+  {
+    "id": "order-inbox",
+    "lane": "screen",
+    "prompt": "Customers keep messaging asking where their order is. Let me see who's waiting on the left and read and reply to whichever one I click, without leaving the screen.",
+    "tags": ["action"],
+    "shape": "split-inbox",
+    "pass": [
+      "lists all five conversations down one side, with the three unread ones marked",
+      "clicking a conversation opens it beside the list, with the list still on screen",
+      "the opened conversation shows every message in it in order, saying who sent each",
+      "the reply box calls send_message with that conversation's id and the typed text"
+    ],
+    "source": "Shopify, Inbox — help.shopify.com/en/manual/inbox/conversations"
+  },
+  {
+    "id": "shipping-settings",
+    "lane": "screen",
+    "prompt": "Let me see and change how shipping works here — my flat rate, the order total that earns free shipping, and which carrier I hand packages to — all on one page I can save in one go.",
+    "tags": ["action"],
+    "shape": "settings",
+    "pass": [
+      "shows the flat rate as $9.00 and free shipping from $75.00, both editable",
+      "the carrier picker offers only the three carriers the tool returned, with Standard post chosen",
+      "one save control commits all three settings together, rather than each saving on its own",
+      "saving calls update_shipping_settings with all three values"
+    ],
+    "source": "Shopify, Settings > Shipping and delivery — help.shopify.com/en/manual/fulfillment/setup"
   }
 ]

--- a/genbench/worlds/store-admin/world.json
+++ b/genbench/worlds/store-admin/world.json
@@ -146,6 +146,115 @@
         ]
       }
     },
+    "list_themes": {
+      "does": "Every theme installed on the storefront, most recently updated first. `live` is true for the one theme customers currently see; the rest are drafts kept beside it.",
+      "data": {
+        "data": [
+          { "id": "thm_classic", "name": "Fernbrook Classic", "live": true, "updated_at": "2026-08-11" },
+          { "id": "thm_market", "name": "Market Stall", "live": false, "updated_at": "2026-08-04" },
+          { "id": "thm_potting", "name": "Potting Shed", "live": false, "updated_at": "2026-07-22" },
+          { "id": "thm_harvest", "name": "Harvest Table", "live": false, "updated_at": "2026-06-30" },
+          { "id": "thm_seedling", "name": "Seedling", "live": false, "updated_at": "2026-05-18" }
+        ]
+      }
+    },
+    "list_staff": {
+      "does": "Everyone with access to the shop. `orders`, `inventory`, `discounts` and `payouts` are true when that person can open and act in that area, false when it is hidden from them entirely.",
+      "data": {
+        "data": [
+          { "id": "stf_wren", "name": "Wren Fairbairn", "role": "Owner", "orders": true, "inventory": true, "discounts": true, "payouts": true },
+          { "id": "stf_ida", "name": "Ida Marchetti", "role": "Shop manager", "orders": true, "inventory": true, "discounts": true, "payouts": false },
+          { "id": "stf_gil", "name": "Gil Ostrander", "role": "Fulfilment", "orders": true, "inventory": true, "discounts": false, "payouts": false },
+          { "id": "stf_rosa", "name": "Rosa Delgado", "role": "Packer", "orders": false, "inventory": false, "discounts": false, "payouts": false }
+        ]
+      }
+    },
+    "list_regions": {
+      "does": "Every region the shop can sell into. `active` is true where the shop already sells, and those regions carry the orders taken and `sales` billed there in the last 30 days — a region that is not active has none of either. `lat` and `lng` place the region on a map. `sales` is in CENTS: 984510 is $9,845.10.",
+      "data": {
+        "data": [
+          { "region": "United States", "active": true, "orders": 128, "sales": 984510, "lat": 39.8, "lng": -98.6 },
+          { "region": "Canada", "active": true, "orders": 34, "sales": 246800, "lat": 56.1, "lng": -106.3 },
+          { "region": "United Kingdom", "active": true, "orders": 21, "sales": 158920, "lat": 54.0, "lng": -2.0 },
+          { "region": "Australia", "active": true, "orders": 9, "sales": 61340, "lat": -25.3, "lng": 133.8 },
+          { "region": "Germany", "active": false, "orders": 0, "sales": 0, "lat": 51.2, "lng": 10.5 },
+          { "region": "Japan", "active": false, "orders": 0, "sales": 0, "lat": 36.2, "lng": 138.3 },
+          { "region": "New Zealand", "active": false, "orders": 0, "sales": 0, "lat": -41.0, "lng": 174.9 }
+        ]
+      }
+    },
+    "list_conversations": {
+      "does": "Every customer conversation in the shop inbox, most recently updated first, each with its whole thread in `messages` oldest first. `unread` is true when the customer's last message has not been read, `order_id` is the order the customer is asking about, and `from` on a message is either the customer's name or Fernbrook Goods.",
+      "data": {
+        "data": [
+          {
+            "id": "cnv_411",
+            "customer": "Nora Whitfield",
+            "order_id": "PDL-1051",
+            "unread": true,
+            "updated_at": "2026-08-13",
+            "messages": [
+              { "from": "Nora Whitfield", "text": "Hi — any idea when PDL-1051 goes out? It's a gift for Saturday.", "at": "2026-08-13" }
+            ]
+          },
+          {
+            "id": "cnv_410",
+            "customer": "Desmond Ali",
+            "order_id": "PDL-1050",
+            "unread": true,
+            "updated_at": "2026-08-13",
+            "messages": [
+              { "from": "Desmond Ali", "text": "Ordered yesterday and it still says unfulfilled.", "at": "2026-08-12" },
+              { "from": "Fernbrook Goods", "text": "Thanks Desmond — it's packed and going out with tomorrow's post.", "at": "2026-08-13" },
+              { "from": "Desmond Ali", "text": "Perfect, thank you. Will I get a tracking number?", "at": "2026-08-13" }
+            ]
+          },
+          {
+            "id": "cnv_409",
+            "customer": "Hollis Byrne",
+            "order_id": "PDL-1045",
+            "unread": true,
+            "updated_at": "2026-08-12",
+            "messages": [
+              { "from": "Hollis Byrne", "text": "Two of the mugs arrived chipped. I've raised a refund but wanted to tell you directly.", "at": "2026-08-12" }
+            ]
+          },
+          {
+            "id": "cnv_408",
+            "customer": "Theo Vance",
+            "order_id": "PDL-1047",
+            "unread": false,
+            "updated_at": "2026-08-11",
+            "messages": [
+              { "from": "Theo Vance", "text": "Is the apron the same size as the one I bought in spring?", "at": "2026-08-11" },
+              { "from": "Fernbrook Goods", "text": "It runs a size larger — happy to swap it for you.", "at": "2026-08-11" }
+            ]
+          },
+          {
+            "id": "cnv_407",
+            "customer": "Priya Raman",
+            "order_id": "PDL-1049",
+            "unread": false,
+            "updated_at": "2026-08-11",
+            "messages": [
+              { "from": "Priya Raman", "text": "Can you take one planter off PDL-1049 before it ships?", "at": "2026-08-11" },
+              { "from": "Fernbrook Goods", "text": "Done — the difference is on its way back to your card.", "at": "2026-08-11" }
+            ]
+          }
+        ]
+      }
+    },
+    "get_shipping_settings": {
+      "does": "How the shop charges for shipping today — the single row of the `data` array. `carrier` is the one packages are handed to, and `carriers` is every carrier the shop has an account with. `flat_rate` and `free_shipping_threshold` are in CENTS: 900 is $9.00 and 7500 is $75.00.",
+      "data": {
+        "data": [{
+          "flat_rate": 900,
+          "free_shipping_threshold": 7500,
+          "carrier": "Standard post",
+          "carriers": ["Standard post", "Ridgeway Courier", "Harbor Freight Post"]
+        }]
+      }
+    },
     "approve_refund": {
       "does": "Approve an open refund request. The request's amount goes back to the customer's original payment method.",
       "takes": { "request_id": "string" }
@@ -165,6 +274,22 @@
     "create_discount": {
       "does": "Create a discount code. `kind` is percent, amount or free_shipping. `value` is percent points for percent and CENTS for amount. `usage_limit` is the number of redemptions allowed.",
       "takes": { "code": "string", "kind": "string", "value": "number", "usage_limit": "number" }
+    },
+    "set_staff_permission": {
+      "does": "Open or close one area — orders, inventory, discounts or payouts — for one staff member. Call it once per area changed.",
+      "takes": { "staff_id": "string", "area": "string", "enabled": "boolean" }
+    },
+    "activate_region": {
+      "does": "Start selling into a region the shop does not sell into yet. Orders from it are accepted from then on.",
+      "takes": { "region": "string" }
+    },
+    "send_message": {
+      "does": "Send a reply into one customer conversation. The customer is emailed the text.",
+      "takes": { "conversation_id": "string", "text": "string" }
+    },
+    "update_shipping_settings": {
+      "does": "Save how the shop charges for shipping. `flat_rate` and `free_shipping_threshold` are in CENTS, and `carrier` must be one the shop has an account with.",
+      "takes": { "flat_rate": "number", "free_shipping_threshold": "number", "carrier": "string" }
     }
   }
 }

--- a/genbench/worlds/subscription-billing/cases.json
+++ b/genbench/worlds/subscription-billing/cases.json
@@ -128,5 +128,75 @@
     ],
     "tags": ["action"],
     "shape": "detail"
+  },
+  {
+    "id": "portal-self-serve",
+    "lane": "screen",
+    "prompt": "Turn on self-serve so subscribers can cancel and switch plans themselves without emailing us, and pick which parts of that are open.",
+    "pass": [
+      "shows all five portal switches — cancel, plan switch, payment method, promo codes, invoice history — each with its current state",
+      "shows cancel, plan switch and promo codes as currently off, and payment method and invoice history as currently on",
+      "each switch can be flipped on this screen and there is one control that saves them together",
+      "saving calls update_portal_settings with allow_cancel and allow_plan_switch on"
+    ],
+    "tags": ["action"],
+    "shape": "settings",
+    "source": "Stripe Billing — Customer portal config, docs.stripe.com/customer-management/configure-portal"
+  },
+  {
+    "id": "plan-side-by-side",
+    "lane": "screen",
+    "prompt": "Lay our plans side by side so I can see what each one costs and includes before I pitch Northwind Labs an upgrade.",
+    "pass": [
+      "puts the plans beside each other as columns to compare, not stacked as one row per plan",
+      "the prices read $29.00, $99.00 and $299.00 a month and $3,228.00 a year",
+      "shows each plan's included API calls, from 25,000 on Starter to 500,000 on Scale",
+      "does not offer the archived Pro (legacy) plan as something to pitch"
+    ],
+    "tags": ["display"],
+    "shape": "comparison",
+    "source": "Chargebee — No-code pricing table, chargebee.com/docs/billing/2.0/hosted-capabilities/pricing-table"
+  },
+  {
+    "id": "new-subscription-wizard",
+    "lane": "screen",
+    "prompt": "Walk me through putting a brand-new customer on a plan — pick the plan, add a coupon if they've earned one, and confirm before it goes live.",
+    "pass": [
+      "asks one step at a time — the plan, then the coupon, then a confirmation — rather than one long form",
+      "the plan step offers the four active plans with their prices and not the archived Pro (legacy)",
+      "the coupon step can be left empty and does not offer the expired LAUNCH50",
+      "the last step restates the chosen plan before anything runs, and confirming calls create_subscription with the customer, the chosen plan id and the coupon code"
+    ],
+    "tags": ["action"],
+    "shape": "wizard",
+    "source": "Chargebee — Hosted checkout page, chargebee.com/subscription-management"
+  },
+  {
+    "id": "dunning-email-log",
+    "lane": "screen",
+    "prompt": "Show me every payment-failure email we've sent this month, most recent first, so I know who's already been nagged.",
+    "pass": [
+      "lists each email as its own dated entry rather than one row per invoice",
+      "the newest entry is Tessellate Studio's fourth attempt on Aug 11 and the oldest is its first on Aug 1",
+      "every entry shows who it went to, the invoice number and which attempt it followed",
+      "shows four emails to Tessellate Studio and two to Ovid & Sons"
+    ],
+    "tags": ["display"],
+    "shape": "list-feed",
+    "source": "Stripe Billing — Dunning email log, stripe.com/billing/features"
+  },
+  {
+    "id": "team-permissions",
+    "lane": "screen",
+    "prompt": "Show me who on the team can void invoices or cancel subscriptions, and let me change what each person is allowed to touch.",
+    "pass": [
+      "shows all four team members with their role and, for each, whether they can void invoices, cancel subscriptions and apply coupons",
+      "shows Ines Barlowe as the only one who can cancel subscriptions and Tobias Renn as able to do none of the three",
+      "offers a way to move a person to another role from this screen",
+      "changing someone's role calls update_team_role with that person's member id and the new role"
+    ],
+    "tags": ["action"],
+    "shape": "permissions",
+    "source": "Chargebee — Users & roles, chargebee.com/docs/billing/2.0/site-configuration/account_settings"
   }
 ]

--- a/genbench/worlds/subscription-billing/cases.json
+++ b/genbench/worlds/subscription-billing/cases.json
@@ -141,7 +141,7 @@
     ],
     "tags": ["action"],
     "shape": "settings",
-    "source": "Stripe Billing — Customer portal config, docs.stripe.com/customer-management/configure-portal"
+    "source": "Stripe Billing — Customer portal config, https://docs.stripe.com/customer-management/configure-portal"
   },
   {
     "id": "plan-side-by-side",
@@ -155,7 +155,7 @@
     ],
     "tags": ["display"],
     "shape": "comparison",
-    "source": "Chargebee — No-code pricing table, chargebee.com/docs/billing/2.0/hosted-capabilities/pricing-table"
+    "source": "Chargebee — No-code pricing table, https://chargebee.com/docs/billing/2.0/hosted-capabilities/pricing-table"
   },
   {
     "id": "new-subscription-wizard",
@@ -169,7 +169,7 @@
     ],
     "tags": ["action"],
     "shape": "wizard",
-    "source": "Chargebee — Hosted checkout page, chargebee.com/subscription-management"
+    "source": "Chargebee — Hosted checkout page, https://chargebee.com/subscription-management"
   },
   {
     "id": "dunning-email-log",
@@ -183,7 +183,7 @@
     ],
     "tags": ["display"],
     "shape": "list-feed",
-    "source": "Stripe Billing — Dunning email log, stripe.com/billing/features"
+    "source": "Stripe Billing — Dunning email log, https://stripe.com/billing/features"
   },
   {
     "id": "team-permissions",
@@ -197,6 +197,6 @@
     ],
     "tags": ["action"],
     "shape": "permissions",
-    "source": "Chargebee — Users & roles, chargebee.com/docs/billing/2.0/site-configuration/account_settings"
+    "source": "Chargebee — Users & roles, https://chargebee.com/docs/billing/2.0/site-configuration/account_settings"
   }
 ]

--- a/genbench/worlds/subscription-billing/world.json
+++ b/genbench/worlds/subscription-billing/world.json
@@ -159,6 +159,42 @@
         ]
       }
     },
+    "list_dunning_emails": {
+      "does": "Every payment-failure email the account has sent, newest first. The rows are the `data` array. `attempt` is which dunning retry the email followed, and `invoice_number` is the invoice it was about.",
+      "data": {
+        "data": [
+          { "id": "dem_408", "sent_on": "2026-08-11", "customer": "Tessellate Studio", "invoice_number": "INV-2044", "attempt": 4, "subject": "Final notice — we still cannot charge your card" },
+          { "id": "dem_407", "sent_on": "2026-08-10", "customer": "Ovid & Sons", "invoice_number": "INV-2050", "attempt": 2, "subject": "Second attempt on INV-2050 failed" },
+          { "id": "dem_406", "sent_on": "2026-08-08", "customer": "Tessellate Studio", "invoice_number": "INV-2044", "attempt": 3, "subject": "Third attempt on INV-2044 failed" },
+          { "id": "dem_405", "sent_on": "2026-08-07", "customer": "Ovid & Sons", "invoice_number": "INV-2050", "attempt": 1, "subject": "We could not charge your card for INV-2050" },
+          { "id": "dem_404", "sent_on": "2026-08-04", "customer": "Tessellate Studio", "invoice_number": "INV-2044", "attempt": 2, "subject": "Second attempt on INV-2044 failed" },
+          { "id": "dem_403", "sent_on": "2026-08-01", "customer": "Tessellate Studio", "invoice_number": "INV-2044", "attempt": 1, "subject": "We could not charge your card for INV-2044" }
+        ]
+      }
+    },
+    "get_portal_settings": {
+      "does": "What subscribers may do for themselves in the billing portal, as the single row of the `data` array. Every field is a switch that is on or off: `allow_cancel` lets a subscriber cancel without emailing us, `allow_plan_switch` lets them move between plans, `allow_payment_method_update` lets them replace the card on file, `allow_promo_codes` lets them redeem a coupon, and `show_invoice_history` lets them read past invoices.",
+      "data": {
+        "data": [{
+          "allow_cancel": false,
+          "allow_plan_switch": false,
+          "allow_payment_method_update": true,
+          "allow_promo_codes": false,
+          "show_invoice_history": true
+        }]
+      }
+    },
+    "list_team_members": {
+      "does": "Everyone with access to the account, most powerful first. The rows are the `data` array. `role` is one of admin, billing, support or viewer, and the three `can_` fields are what that person's role currently allows.",
+      "data": {
+        "data": [
+          { "id": "mem_01", "name": "Ines Barlowe", "email": "ines@cadenza.example", "role": "admin", "can_void_invoices": true, "can_cancel_subscriptions": true, "can_apply_coupons": true },
+          { "id": "mem_02", "name": "Devraj Oyelaran", "email": "devraj@cadenza.example", "role": "billing", "can_void_invoices": true, "can_cancel_subscriptions": false, "can_apply_coupons": true },
+          { "id": "mem_03", "name": "Marta Kestrel", "email": "marta@cadenza.example", "role": "support", "can_void_invoices": false, "can_cancel_subscriptions": false, "can_apply_coupons": true },
+          { "id": "mem_04", "name": "Tobias Renn", "email": "tobias@cadenza.example", "role": "viewer", "can_void_invoices": false, "can_cancel_subscriptions": false, "can_apply_coupons": false }
+        ]
+      }
+    },
     "retry_payment": {
       "does": "Charge an invoice's card on file again right now, outside the dunning retry schedule. It does not consume one of the scheduled attempts.",
       "takes": { "invoice_id": "string" }
@@ -174,6 +210,24 @@
     "apply_coupon": {
       "does": "Attach an active coupon to a subscription. It discounts every invoice from the next one onwards.",
       "takes": { "subscription_id": "string", "coupon_code": "string" }
+    },
+    "create_subscription": {
+      "does": "Put a new customer on a plan, billing from today. `coupon_code` is \"\" when no coupon is being applied, and only an active coupon can be used.",
+      "takes": { "customer": "string", "plan_id": "string", "coupon_code": "string" }
+    },
+    "update_portal_settings": {
+      "does": "Save the portal's self-serve switches. Every switch is sent, on or off, so what is saved is exactly what the screen shows.",
+      "takes": {
+        "allow_cancel": "boolean",
+        "allow_plan_switch": "boolean",
+        "allow_payment_method_update": "boolean",
+        "allow_promo_codes": "boolean",
+        "show_invoice_history": "boolean"
+      }
+    },
+    "update_team_role": {
+      "does": "Move a team member to another role, which resets what they may do to that role's defaults. `role` is one of admin, billing, support or viewer.",
+      "takes": { "member_id": "string", "role": "string" }
     }
   }
 }

--- a/genbench/worlds/support-desk/cases.json
+++ b/genbench/worlds/support-desk/cases.json
@@ -161,5 +161,88 @@
     ],
     "tags": ["action"],
     "shape": "table"
+  },
+  {
+    "id": "merge-wizard",
+    "lane": "screen",
+    "prompt": "Walk me through merging these three duplicate tickets — pick which one stays, then confirm.",
+    "pass": [
+      "shows all three of Rosa Delgado's tickets — TK-1045, TK-1051, TK-1052 — with their subjects and when each came in",
+      "runs as steps: the survivor is picked first, and confirming is a second step, not the same click",
+      "only one ticket can be the one that stays",
+      "the confirm step names the ticket that stays and the two being absorbed into it",
+      "confirming fires merge_tickets once per absorbed ticket, each with into_ticket_id set to the chosen survivor"
+    ],
+    "tags": ["action"],
+    "shape": "wizard",
+    "source": "Zendesk — Bulk merge tickets — https://www.eesel.ai/blog/zendesk-merge-tickets-duplicate-conversations",
+    "data": {
+      "list_tickets": {
+        "data": [
+          { "id": "TK-1052", "subject": "Still nothing, where is my order?", "customer": "Rosa Delgado", "email": "rosa.delgado@fernpost.com", "channel": "email", "status": "new", "priority": "high", "created_at": "2026-08-12T15:02:00Z" },
+          { "id": "TK-1051", "subject": "Where is my order? Following up again", "customer": "Rosa Delgado", "email": "rosa.delgado@fernpost.com", "channel": "email", "status": "new", "priority": "high", "created_at": "2026-08-12T14:22:00Z" },
+          { "id": "TK-1045", "subject": "Order hasn't shipped yet", "customer": "Rosa Delgado", "email": "rosa.delgado@fernpost.com", "channel": "email", "status": "open", "priority": "normal", "created_at": "2026-08-11T16:40:00Z" }
+        ]
+      }
+    }
+  },
+  {
+    "id": "week-coverage",
+    "lane": "screen",
+    "prompt": "Lay next week's coverage out like a calendar so I can see at a glance who's on the desk each day.",
+    "pass": [
+      "draws the three days the tool returned — Wed Aug 12, Thu Aug 13, Fri Aug 14 — as a grid of days, not a list of shift rows",
+      "invents no day beyond those three and no shift the tool did not return",
+      "each day carries its agents with their start and end times",
+      "Thursday shows Theo, Priya, June and Marco, and Nadia is not on it",
+      "June Hollis's Wednesday reads as 08:00 to 12:00"
+    ],
+    "tags": ["display"],
+    "shape": "calendar",
+    "source": "Zendesk — WFM schedule — https://support.zendesk.com/hc/en-us/articles/6443348256794-Accessing-and-understanding-your-WFM-Schedule-page"
+  },
+  {
+    "id": "queue-split",
+    "lane": "screen",
+    "prompt": "Let me work my queue without leaving the list — pick a ticket, see the whole thread next to it, and reply right there.",
+    "pass": [
+      "the ticket list and the open ticket sit side by side on one screen, and picking a ticket does not replace the list",
+      "each list row shows the ticket's customer, subject and status",
+      "the open ticket's four messages read in order beside the list, customer turns distinguishable from agent turns",
+      "the reply control is beside the thread and offers the canned replies by title",
+      "sending fires send_canned_reply with TK-1040 and that reply's id"
+    ],
+    "tags": ["action"],
+    "shape": "split-inbox",
+    "source": "Intercom — Inbox split view — https://www.intercom.com/help/en/articles/6258745-the-inbox-explained"
+  },
+  {
+    "id": "ticket-history",
+    "lane": "screen",
+    "prompt": "Show me everything that happened on this ticket in order — every reply, every handoff, every status change — before I take it over.",
+    "pass": [
+      "shows all ten events the tool returned on one timeline, oldest first, and invents none",
+      "replies, handoffs and status changes read as different kinds of event, not as one undifferentiated list",
+      "shows the handoff from June Hollis to Nadia Okafor on Aug 10",
+      "shows the SLA breach on Aug 11 and the priority going from normal to high",
+      "each event carries who did it and when"
+    ],
+    "tags": ["display"],
+    "shape": "timeline",
+    "source": "Intercom — Conversation events — https://www.intercom.com/help/en/articles/13334840-conversation-events-in-the-inbox"
+  },
+  {
+    "id": "trainee-limits",
+    "lane": "screen",
+    "prompt": "Set up what our trainee can and can't do on her own — I don't want her approving refunds solo yet.",
+    "pass": [
+      "shows all five agents against the three permissions, each one a control that reads on or off",
+      "June Hollis's row reads: refunds on, closing on, merging off",
+      "no permission is shown that the tool did not return",
+      "turning June's refund approval off fires update_agent_permission with ag_june, can_approve_refunds and false"
+    ],
+    "tags": ["action"],
+    "shape": "permissions",
+    "source": "Zendesk — Roles & permissions — https://support.zendesk.com/hc/en-us/articles/4408824375450-Setting-roles-and-access-in-Zendesk-Admin-Center"
   }
 ]

--- a/genbench/worlds/support-desk/cases.json
+++ b/genbench/worlds/support-desk/cases.json
@@ -175,7 +175,7 @@
     ],
     "tags": ["action"],
     "shape": "wizard",
-    "source": "Zendesk — Bulk merge tickets — https://www.eesel.ai/blog/zendesk-merge-tickets-duplicate-conversations",
+    "source": "Zendesk — Bulk merge tickets, https://www.eesel.ai/blog/zendesk-merge-tickets-duplicate-conversations",
     "data": {
       "list_tickets": {
         "data": [
@@ -199,7 +199,7 @@
     ],
     "tags": ["display"],
     "shape": "calendar",
-    "source": "Zendesk — WFM schedule — https://support.zendesk.com/hc/en-us/articles/6443348256794-Accessing-and-understanding-your-WFM-Schedule-page"
+    "source": "Zendesk — WFM schedule, https://support.zendesk.com/hc/en-us/articles/6443348256794-Accessing-and-understanding-your-WFM-Schedule-page"
   },
   {
     "id": "queue-split",
@@ -214,7 +214,7 @@
     ],
     "tags": ["action"],
     "shape": "split-inbox",
-    "source": "Intercom — Inbox split view — https://www.intercom.com/help/en/articles/6258745-the-inbox-explained"
+    "source": "Intercom — Inbox split view, https://www.intercom.com/help/en/articles/6258745-the-inbox-explained"
   },
   {
     "id": "ticket-history",
@@ -229,7 +229,7 @@
     ],
     "tags": ["display"],
     "shape": "timeline",
-    "source": "Intercom — Conversation events — https://www.intercom.com/help/en/articles/13334840-conversation-events-in-the-inbox"
+    "source": "Intercom — Conversation events, https://www.intercom.com/help/en/articles/13334840-conversation-events-in-the-inbox"
   },
   {
     "id": "trainee-limits",
@@ -243,6 +243,6 @@
     ],
     "tags": ["action"],
     "shape": "permissions",
-    "source": "Zendesk — Roles & permissions — https://support.zendesk.com/hc/en-us/articles/4408824375450-Setting-roles-and-access-in-Zendesk-Admin-Center"
+    "source": "Zendesk — Roles & permissions, https://support.zendesk.com/hc/en-us/articles/4408824375450-Setting-roles-and-access-in-Zendesk-Admin-Center"
   }
 ]

--- a/genbench/worlds/support-desk/world.json
+++ b/genbench/worlds/support-desk/world.json
@@ -635,6 +635,36 @@
         ]
       }
     },
+    "list_ticket_events": {
+      "does": "Everything that has happened on one ticket, oldest first. The rows are the `data` array. The canned response always answers with TK-1040, whatever `ticket_id` is passed. `kind` is `created`, `reply`, `assigned`, `status`, `priority` or `sla`; `actor` is the person who did it, or `system` when nothing human did; `text` is what to read on the line.",
+      "takes": { "ticket_id": "string" },
+      "data": {
+        "data": [
+          { "at": "2026-08-10T08:12:00Z", "kind": "created", "actor": "Dominic Reyes", "text": "Opened by email: Wrong item shipped, I ordered walnut and got oak" },
+          { "at": "2026-08-10T08:14:00Z", "kind": "assigned", "actor": "system", "text": "Routed to June Hollis by the email queue rule" },
+          { "at": "2026-08-10T10:47:00Z", "kind": "assigned", "actor": "June Hollis", "text": "Handed to Nadia Okafor" },
+          { "at": "2026-08-10T11:00:00Z", "kind": "reply", "actor": "Nadia Okafor", "text": "Asked for a photo of what arrived" },
+          { "at": "2026-08-10T11:01:00Z", "kind": "status", "actor": "Nadia Okafor", "text": "Open to pending, waiting on the customer" },
+          { "at": "2026-08-11T07:26:00Z", "kind": "reply", "actor": "Dominic Reyes", "text": "Sent photos and asked who pays for the return" },
+          { "at": "2026-08-11T07:27:00Z", "kind": "status", "actor": "system", "text": "Pending to open, the customer answered" },
+          { "at": "2026-08-11T08:12:00Z", "kind": "sla", "actor": "system", "text": "Resolution SLA breached" },
+          { "at": "2026-08-11T09:05:00Z", "kind": "priority", "actor": "Nadia Okafor", "text": "Normal to high" },
+          { "at": "2026-08-12T13:37:00Z", "kind": "reply", "actor": "Nadia Okafor", "text": "Sent the prepaid return label and confirmed the walnut shelf ships on scan" }
+        ]
+      }
+    },
+    "list_agent_permissions": {
+      "does": "What each agent is allowed to do on their own. The rows are the `data` array, one per agent, keyed to `list_agents` by `agent_id`. Every `can_` field is a boolean: true means the agent does it without a lead signing off.",
+      "data": {
+        "data": [
+          { "agent_id": "ag_nadia", "agent": "Nadia Okafor", "can_approve_refunds": true, "can_close_tickets": true, "can_merge_tickets": true },
+          { "agent_id": "ag_theo", "agent": "Theo Lindqvist", "can_approve_refunds": true, "can_close_tickets": true, "can_merge_tickets": true },
+          { "agent_id": "ag_priya", "agent": "Priya Raman", "can_approve_refunds": true, "can_close_tickets": true, "can_merge_tickets": false },
+          { "agent_id": "ag_marco", "agent": "Marco Duarte", "can_approve_refunds": true, "can_close_tickets": true, "can_merge_tickets": false },
+          { "agent_id": "ag_june", "agent": "June Hollis", "can_approve_refunds": true, "can_close_tickets": true, "can_merge_tickets": false }
+        ]
+      }
+    },
     "assign_ticket": {
       "does": "Hand a ticket to an agent. `ticket_id` is a ticket id like TK-1049 and `agent_id` an agent id like ag_theo. Assigning a ticket that already has an owner moves it.",
       "takes": { "ticket_id": "string", "agent_id": "string" }
@@ -654,6 +684,10 @@
     "merge_tickets": {
       "does": "Merge one ticket into another when the same customer wrote in twice. `ticket_id` is the duplicate that gets absorbed, `into_ticket_id` the one that survives and keeps the conversation.",
       "takes": { "ticket_id": "string", "into_ticket_id": "string" }
+    },
+    "update_agent_permission": {
+      "does": "Turn one of an agent's permissions on or off. `permission` is a permission name like can_approve_refunds and `allowed` is what it becomes.",
+      "takes": { "agent_id": "string", "permission": "string", "allowed": "boolean" }
     }
   }
 }

--- a/genbench/worlds/trades-accounting/cases.json
+++ b/genbench/worlds/trades-accounting/cases.json
@@ -140,7 +140,7 @@
     "prompt": "Lay today's jobs out as a board sorted into columns by where each one's at — scheduled, in progress, awaiting parts, done but unbilled, closed — so I can see the whole shop without scrolling one long list.",
     "tags": ["display"],
     "shape": "board",
-    "source": "ServiceTitan — Dispatch Board · https://help.servicetitan.com/how-to/using-dispatch-board",
+    "source": "ServiceTitan — Dispatch Board, https://help.servicetitan.com/how-to/using-dispatch-board",
     "pass": [
       "lays the jobs out in columns by status — scheduled, in progress, awaiting parts, done but unbilled, closed — not as one flat list",
       "all seven jobs are on the board, each under the column its status names: three under in progress, and J-2444, J-2431, J-2395 and J-2377 alone under the other four",
@@ -154,7 +154,7 @@
     "prompt": "Show today's visits on a map so I can see which crew is nearest the Harbor Point callback.",
     "tags": ["display"],
     "shape": "map",
-    "source": "Jobber — Map View · https://help.getjobber.com/hc/en-us/articles/115009234307-Map-View-Legacy-Schedule",
+    "source": "Jobber — Map View, https://help.getjobber.com/hc/en-us/articles/115009234307-Map-View-Legacy-Schedule",
     "pass": [
       "draws a map with a pin per visit rather than listing the visits",
       "all three of today's visits are pinned, each in its own place, and no fourth visit is invented",
@@ -168,7 +168,7 @@
     "prompt": "Lay out the good, better and best packages I'm quoting side by side so the customer can see what the extra money buys.",
     "tags": ["display"],
     "shape": "comparison",
-    "source": "Jobber — Quote Options (Beta) · https://help.getjobber.com/hc/en-us/articles/33970469537047-Quotes-Options-Beta",
+    "source": "Jobber — Quote Options (Beta), https://help.getjobber.com/hc/en-us/articles/33970469537047-Quotes-Options-Beta",
     "pass": [
       "puts Good, Better and Best beside each other as three columns, not one under the other",
       "shows each package's price — $6,480.00, $9,750.00 and $14,200.00 — matching the tool's numbers",
@@ -182,7 +182,7 @@
     "prompt": "Pull up every photo the crew's uploaded from the Harbor Point rooftop job so I can see the before-and-after without digging through texts.",
     "tags": ["display"],
     "shape": "gallery",
-    "source": "Jobber — Files and Media Library · https://help.getjobber.com/hc/en-us/articles/39800675084439-Files-and-Media-Library",
+    "source": "Jobber — Files and Media Library, https://help.getjobber.com/hc/en-us/articles/39800675084439-Files-and-Media-Library",
     "pass": [
       "lays the photos out as a grid of tiles rather than a list of file names",
       "all six photos from J-2418 · Harbor Point Dental are there, and none from another job",
@@ -196,7 +196,7 @@
     "prompt": "Show our price list organized by category and subcategory — plumbing, HVAC, electrical — so I can find an item without scrolling one flat list.",
     "tags": ["display"],
     "shape": "tree",
-    "source": "ServiceTitan — Pricebook · https://help.servicetitan.com/docs/pricebook",
+    "source": "ServiceTitan — Pricebook, https://help.servicetitan.com/docs/pricebook",
     "pass": [
       "nests the items under their subcategory and each subcategory under its category, rather than one flat list",
       "shows the three categories — Plumbing, HVAC, Electrical — and all eight subcategories under them",

--- a/genbench/worlds/trades-accounting/cases.json
+++ b/genbench/worlds/trades-accounting/cases.json
@@ -133,5 +133,75 @@
       "offers no categorize control"
     ],
     "data": { "list_expenses": { "data": [] } }
+  },
+  {
+    "id": "job-board",
+    "lane": "screen",
+    "prompt": "Lay today's jobs out as a board sorted into columns by where each one's at — scheduled, in progress, awaiting parts, done but unbilled, closed — so I can see the whole shop without scrolling one long list.",
+    "tags": ["display"],
+    "shape": "board",
+    "source": "ServiceTitan — Dispatch Board · https://help.servicetitan.com/how-to/using-dispatch-board",
+    "pass": [
+      "lays the jobs out in columns by status — scheduled, in progress, awaiting parts, done but unbilled, closed — not as one flat list",
+      "all seven jobs are on the board, each under the column its status names: three under in progress, and J-2444, J-2431, J-2395 and J-2377 alone under the other four",
+      "each card names its job as 'J-2418 · Harbor Point Dental' and the foreman running it",
+      "each card shows what is left to invoice, matching the tool's numbers, including $0.00 on J-2440 and J-2377"
+    ]
+  },
+  {
+    "id": "visits-map",
+    "lane": "screen",
+    "prompt": "Show today's visits on a map so I can see which crew is nearest the Harbor Point callback.",
+    "tags": ["display"],
+    "shape": "map",
+    "source": "Jobber — Map View · https://help.getjobber.com/hc/en-us/articles/115009234307-Map-View-Legacy-Schedule",
+    "pass": [
+      "draws a map with a pin per visit rather than listing the visits",
+      "all three of today's visits are pinned, each in its own place, and no fourth visit is invented",
+      "each visit names its job as 'J-2418 · Harbor Point Dental' and the crew on it — Nico Salas, Tasha Byrd, Marco Deleon",
+      "each visit shows its site and its arrival window, with Sutter Street Lofts as the only afternoon one"
+    ]
+  },
+  {
+    "id": "quote-options",
+    "lane": "screen",
+    "prompt": "Lay out the good, better and best packages I'm quoting side by side so the customer can see what the extra money buys.",
+    "tags": ["display"],
+    "shape": "comparison",
+    "source": "Jobber — Quote Options (Beta) · https://help.getjobber.com/hc/en-us/articles/33970469537047-Quotes-Options-Beta",
+    "pass": [
+      "puts Good, Better and Best beside each other as three columns, not one under the other",
+      "shows each package's price — $6,480.00, $9,750.00 and $14,200.00 — matching the tool's numbers",
+      "lists what each package includes, so the three included lists can be read against each other",
+      "invents no fourth package, no total across the three and no discount"
+    ]
+  },
+  {
+    "id": "job-photos",
+    "lane": "screen",
+    "prompt": "Pull up every photo the crew's uploaded from the Harbor Point rooftop job so I can see the before-and-after without digging through texts.",
+    "tags": ["display"],
+    "shape": "gallery",
+    "source": "Jobber — Files and Media Library · https://help.getjobber.com/hc/en-us/articles/39800675084439-Files-and-Media-Library",
+    "pass": [
+      "lays the photos out as a grid of tiles rather than a list of file names",
+      "all six photos from J-2418 · Harbor Point Dental are there, and none from another job",
+      "every tile carries the caption the tool returned for it",
+      "every tile shows who uploaded it and its date, oldest first from Jul 24 through Aug 8"
+    ]
+  },
+  {
+    "id": "price-book",
+    "lane": "screen",
+    "prompt": "Show our price list organized by category and subcategory — plumbing, HVAC, electrical — so I can find an item without scrolling one flat list.",
+    "tags": ["display"],
+    "shape": "tree",
+    "source": "ServiceTitan — Pricebook · https://help.servicetitan.com/docs/pricebook",
+    "pass": [
+      "nests the items under their subcategory and each subcategory under its category, rather than one flat list",
+      "shows the three categories — Plumbing, HVAC, Electrical — and all eight subcategories under them",
+      "all fourteen items sit under the subcategory the tool gives them, with none duplicated or invented",
+      "every item's price matches the tool's number, read as dollars — the spiral duct foot at $42.00, the panel replacement at $3,850.00"
+    ]
   }
 ]

--- a/genbench/worlds/trades-accounting/world.json
+++ b/genbench/worlds/trades-accounting/world.json
@@ -164,6 +164,62 @@
         ]
       }
     },
+    "list_visit_locations": {
+      "does": "Where today's visits are on the ground, Aug 12, in the order the crews reach them. The rows are the `data` array. `visit_id` is the visit as it sits on the schedule, `lat` and `lng` are the site's coordinates, and `window` is the arrival window promised to the customer.",
+      "data": {
+        "data": [
+          { "visit_id": "sv_6", "date": "2026-08-12", "window": "all day", "job": "J-2418", "customer": "Harbor Point Dental", "site": "Harbor Point Plaza", "crew": ["Nico Salas"], "lat": 47.6021, "lng": -122.3395 },
+          { "visit_id": "sv_7", "date": "2026-08-12", "window": "all day", "job": "J-2402", "customer": "Larkspur Apartments LLC", "site": "Larkspur Way", "crew": ["Tasha Byrd"], "lat": 47.6588, "lng": -122.3121 },
+          { "visit_id": "sv_8", "date": "2026-08-12", "window": "afternoon", "job": "J-2440", "customer": "Sutter Street Lofts HOA", "site": "Sutter Street Lofts", "crew": ["Marco Deleon"], "lat": 47.6142, "lng": -122.3268 }
+        ]
+      }
+    },
+    "list_quote_options": {
+      "does": "The packages quoted on quote Q-1183, the Vance Residence second-floor bathroom, cheapest first. The rows are the `data` array. The options are alternatives the customer picks one of, not lines that add up. `includes` is what that package covers. `price` is in CENTS: 648000 is $6,480.00.",
+      "takes": { "quote_id": "string" },
+      "data": {
+        "data": [
+          { "id": "qo_1", "option": "Good", "scope": "Swap the failing water heater like for like", "includes": ["50-gallon gas water heater", "New shutoff and expansion tank", "One-year workmanship warranty"], "price": 648000 },
+          { "id": "qo_2", "option": "Better", "scope": "Heater swap plus the supply feeding the second floor", "includes": ["50-gallon gas water heater", "Second-floor supply repiped in PEX", "New angle stops at every fixture", "Two-year workmanship warranty"], "price": 975000 },
+          { "id": "qo_3", "option": "Best", "scope": "Tankless conversion with recirculation, whole second floor", "includes": ["Tankless gas heater with recirculation pump", "Second-floor supply repiped in PEX", "New angle stops at every fixture", "Gas line upsized to the heater", "Five-year workmanship warranty and annual descale"], "price": 1420000 }
+        ]
+      }
+    },
+    "list_job_photos": {
+      "does": "Photos the crew uploaded from one job, oldest first. The rows are the `data` array. `caption` is what the tech typed when the photo went up and `url` is where the file is stored.",
+      "takes": { "job_id": "string" },
+      "data": {
+        "data": [
+          { "id": "jp_1", "job": "J-2418", "date": "2026-07-24", "caption": "Old rooftop unit before demo, north curb", "uploaded_by": "Marco Deleon", "url": "files/j-2418/before-north-curb.jpg" },
+          { "id": "jp_2", "job": "J-2418", "date": "2026-07-24", "caption": "Rusted condensate pan under the old unit", "uploaded_by": "Nico Salas", "url": "files/j-2418/before-condensate-pan.jpg" },
+          { "id": "jp_3", "job": "J-2418", "date": "2026-07-29", "caption": "Curb adapter set and levelled", "uploaded_by": "Marco Deleon", "url": "files/j-2418/curb-adapter-set.jpg" },
+          { "id": "jp_4", "job": "J-2418", "date": "2026-08-06", "caption": "New unit landing on the curb, crane pick", "uploaded_by": "Nico Salas", "url": "files/j-2418/crane-pick.jpg" },
+          { "id": "jp_5", "job": "J-2418", "date": "2026-08-08", "caption": "Spiral duct tie-in finished above the ceiling", "uploaded_by": "Marco Deleon", "url": "files/j-2418/duct-tie-in.jpg" },
+          { "id": "jp_6", "job": "J-2418", "date": "2026-08-08", "caption": "New unit in place after startup", "uploaded_by": "Marco Deleon", "url": "files/j-2418/after-unit-startup.jpg" }
+        ]
+      }
+    },
+    "list_price_book": {
+      "does": "Every line item in the price book, in the order it sits in the book — category, then subcategory, then item. The rows are the `data` array. `price` is what the customer is charged for that item, in CENTS: 38900 is $389.00.",
+      "data": {
+        "data": [
+          { "id": "pb_1", "category": "Plumbing", "subcategory": "Water heaters", "item": "50-gallon gas water heater, installed", "price": 248000 },
+          { "id": "pb_2", "category": "Plumbing", "subcategory": "Water heaters", "item": "Tankless conversion, gas", "price": 512500 },
+          { "id": "pb_3", "category": "Plumbing", "subcategory": "Drains", "item": "Main line hydro jet, up to 100 feet", "price": 89500 },
+          { "id": "pb_4", "category": "Plumbing", "subcategory": "Drains", "item": "Grease trap pump-out", "price": 47500 },
+          { "id": "pb_5", "category": "Plumbing", "subcategory": "Fixtures", "item": "Toilet swap, standard", "price": 62500 },
+          { "id": "pb_6", "category": "Plumbing", "subcategory": "Fixtures", "item": "Kitchen faucet replacement", "price": 38900 },
+          { "id": "pb_7", "category": "HVAC", "subcategory": "Rooftop units", "item": "Five ton packaged rooftop unit, installed", "price": 1875000 },
+          { "id": "pb_8", "category": "HVAC", "subcategory": "Rooftop units", "item": "Rooftop unit annual service", "price": 42500 },
+          { "id": "pb_9", "category": "HVAC", "subcategory": "Ductwork", "item": "Spiral duct run, per linear foot", "price": 4200 },
+          { "id": "pb_10", "category": "HVAC", "subcategory": "Ductwork", "item": "Supply register replacement", "price": 12500 },
+          { "id": "pb_11", "category": "HVAC", "subcategory": "Controls", "item": "Programmable thermostat, installed", "price": 58500 },
+          { "id": "pb_12", "category": "Electrical", "subcategory": "Circuits", "item": "Dedicated 20-amp circuit, up to 40 feet", "price": 76500 },
+          { "id": "pb_13", "category": "Electrical", "subcategory": "Circuits", "item": "Disconnect swap at the unit", "price": 41500 },
+          { "id": "pb_14", "category": "Electrical", "subcategory": "Panels", "item": "200-amp panel replacement", "price": 385000 }
+        ]
+      }
+    },
     "send_payment_reminder": {
       "does": "Email the customer a payment reminder for one invoice, with the balance and how many days late it is.",
       "takes": { "invoice_id": "string" }


### PR DESCRIPTION
Stacked on #1295 — review that one first.

The shape lint on the branch below made the gap legible: genbench's 120 cases were heavy on tables and lists and had almost nothing to say about calendars, trees, maps, permissions screens or split inboxes. This branch closes it with 60 new cases — five per world across all twelve verticals — each one mined from a screen that a real counterpart product actually ships.

## How they were found

For each world, the real software in that vertical was swept for the screens its users live in — the clinic booking flow, the dispatch board, the dunning log, the org chart, the notification-policy tree. Every case targets a shape that world was missing and carries a `source` naming the product, the screen, and its URL:

```
Jobber — Map View, https://help.getjobber.com/hc/en-us/articles/115009234307-Map-View-Legacy-Schedule
```

One commit at the end normalizes all 60 sources to that one format — twelve authors had invented five punctuation schemes. String-only; no case content changed.

## The prompts never name the product

This is the point of the exercise and it is load-bearing. A prompt that says "build me the Linear roadmap timeline" lets a baseline win on memory instead of on generation. Every one of the 60 prompts is written in the voice of a user of the fictional world, and names no real product. `source` names products — that field is metadata for humans, and is never sent to a contender.

Verified mechanically: scanning all 60 prompts for 26 product names (Jane, SimplePractice, ShipStation, project44, Monarch, Revolut, Chime, Mercury, Datadog, Grafana, Gusto, Rippling, Amplitude, PostHog, Linear, Jira, AppFolio, Buildium, Shopify, BigCommerce, Stripe, Chargebee, Zendesk, Intercom, Jobber, ServiceTitan) returns zero hits.

## World changes

Worlds gained tools and canned data where a new case needed something to render — a route map for logistics, a pricebook for trades, a theme catalog for store-admin. Nothing existing was rewritten.

## Counts

180 cases total, 15 per world. 60 carry a `source`; the 120 older ones do not. Every world still has at least three action-tagged cases (the actual floor across the twelve is four).

## Shape tally

The 60 new cases, by shape:

| shape | new | shape | new |
|---|---|---|---|
| comparison | 5 | timeline | 4 |
| map | 5 | calendar | 3 |
| settings | 5 | gallery | 3 |
| split-inbox | 5 | form | 2 |
| tree | 5 | feed-composer | 1 |
| wizard | 5 | list-feed | 1 |
| board | 4 | | |
| dashboard | 4 | | |
| filter-builder | 4 | | |
| permissions | 4 | | |

All 180, by shape — every one of the 20 shapes now has at least one case, which was not true before:

| shape | cases | shape | cases |
|---|---|---|---|
| table | 31 | board | 6 |
| list-feed | 19 | map | 5 |
| detail | 15 | settings | 5 |
| chart | 13 | split-inbox | 5 |
| dashboard | 13 | tree | 5 |
| empty-state | 12 | wizard | 5 |
| form | 11 | filter-builder | 4 |
| calendar | 8 | permissions | 4 |
| timeline | 8 | gallery | 3 |
| comparison | 7 | feed-composer | 1 |

## Gate

`pnpm build`, genbench `typecheck`, the whole genbench vitest package (347 passed, 2 skipped, 18 files), and `pnpm lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 60 real-world cases (5 per world across 12 worlds) to close shape gaps and bring total coverage to 180 cases, and renders case provenance on the preview. Previously `source` lived only in `cases.json`; now the preview prints it under the prompt with linked URLs, and cases without `source` render exactly as before.

- Prompts never name real products; `source` strings are standardized as "Product — Screen, URL" and are shown only on the preview — contenders never receive them.
- Adds supporting reads/writes in each `world.json` where screens need data; existing cases are unchanged.
- Clinic scheduling behavior change: `prv_lindqvist.accepting_new` is now true (was false) to match `get_provider_settings`; no existing case depended on the old value.
- Grading fixes: project-tracker file-bug and store-admin packer-access now assert their write calls; store-admin order-inbox no longer expects Send enabled without text; packer-access grades real checkboxes; clinic patient-messages’ reply, product-analytics segment-rule-builder save, project-tracker save-issue-filter save, and project-tracker file-bug submit no longer expect enabled controls until text exists.
- Wire-up: `CaseResult` carries optional `source`; the preview links any http(s) URLs; tests cover rendering and no output when absent.
- Gates pass: `pnpm build`, genbench typecheck, `vitest` (347 passed, 2 skipped), and `pnpm lint`.

<sup>Written for commit 3305dbe4b30478ac6b42eec6300ca33bfe2ec051. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

