### PR TITLE
fix(apps): a screen cannot forge the tree it hands back [stack 1/5]

### DIFF
--- a/packages/apps/src/contract/genui/component/boot.ts
+++ b/packages/apps/src/contract/genui/component/boot.ts
@@ -119,6 +119,12 @@ const messageOf = (thrown: unknown): Thrown => {
   };
 };
 
+/** A paint carries data, so a key that would touch this realm's prototypes is
+ *  dropped rather than parsed — the emitter refuses to write one, and this is
+ *  the second lock on the same door. */
+const dropPrototypeKeys = (key: string, value: unknown): unknown =>
+  key === "__proto__" || key === "prototype" || key === "constructor" ? undefined : value;
+
 /** QuickJS reports a tripped interrupt handler as exactly this. */
 const isInterrupt = (thrown: Thrown): boolean => thrown.message === "InternalError: interrupted";
 
@@ -248,7 +254,7 @@ export function bootScreen(options: BootScreenOptions): ScreenInstance {
     const json = evalString("__vendo.serialize()", "render");
     if (json === painted) return false;
     painted = json;
-    tree = JSON.parse(json) as NestedNode;
+    tree = JSON.parse(json, dropPrototypeKeys) as NestedNode;
     return true;
   };
 

--- a/packages/apps/src/contract/genui/component/vm-program.ts
+++ b/packages/apps/src/contract/genui/component/vm-program.ts
@@ -31,6 +31,7 @@
  * `setTimeout` in the VM at all. `act()` in Preact's own test utilities is the
  * same trick.
  */
+import { TREE_MAX_NODES } from "@vendoai/core";
 import { PREACT_HOOKS_SOURCE, PREACT_JSX_RUNTIME_SOURCE, PREACT_SOURCE } from "./preact-source.js";
 
 /**
@@ -79,6 +80,14 @@ const MAX_PROP_DEPTH = 8;
  *  the wall-clock budget would otherwise have to catch. */
 const MAX_FLUSH_TURNS = 64;
 
+/** How deep the emitted tree may nest. A screen paints sections, not a chain,
+ *  and the host walks this tree recursively on the other side. */
+const MAX_TREE_DEPTH = 128;
+
+/** How large one paint may be, measured on the JSON string in code units —
+ *  which for a tree of component names and props is its byte count. */
+const MAX_TREE_BYTES = 512 * 1_024;
+
 /** The engine, in the VM. Depends on the three Preact globals above it and on
  *  `__vendo_tool`, the host's tool bridge, both of which it captures and then
  *  deletes off the global object so the screen's own code cannot reach them. */
@@ -86,6 +95,10 @@ const ENGINE = `(function () {
   var preact = globalThis.preact, hooks = globalThis.preactHooks, jsx = globalThis.jsxRuntime;
   var options = preact.options;
   var callTool = globalThis.__vendo_tool;
+  // The intrinsics the engine still needs AFTER the screen's own code has run,
+  // held where the screen cannot reach them: a screen that assigned
+  // JSON.stringify would otherwise hand the host a tree it never painted.
+  var stringify = JSON.stringify, keys = Object.keys, isArray = Array.isArray, create = Object.create;
 
   // ── the fake host ─────────────────────────────────────────────────────────
   // Everything Preact 10 touches on a node, and nothing else. Props are read
@@ -161,6 +174,10 @@ const ENGINE = `(function () {
   // and a keyed row keeps its handlers even when a row is inserted over it.
   var slots = {}, minted = 0, drawer = {};
 
+  // A key that would mean the prototype chain rather than data once the host
+  // parses this tree back. Never emitted, whatever the screen calls it.
+  function unsafe(key) { return key === "__proto__" || key === "prototype" || key === "constructor"; }
+
   function handlerId(slot) {
     var id = slots[slot];
     if (id === undefined) { id = "h" + ++minted; slots[slot] = id; }
@@ -179,21 +196,29 @@ const ENGINE = `(function () {
     // it would emit as {} — a Date has no enumerable own properties.
     if (typeof Date !== "undefined" && value instanceof Date) return value.toISOString();
     if (depth >= ${MAX_PROP_DEPTH}) return undefined;
-    if (Array.isArray(value)) {
+    if (isArray(value)) {
       var list = [];
       for (var i = 0; i < value.length; i++) list.push(emitValue(value[i], slot + "." + i, depth + 1));
       return list;
     }
-    var out = {};
-    for (var key in value) out[key] = emitValue(value[key], slot + "." + key, depth + 1);
+    // Own keys onto a bare object: what the screen wrote, and nothing its
+    // prototype carries or the host's Object.prototype would answer for.
+    var out = create(null), names = keys(value);
+    for (var at = 0; at < names.length; at++) {
+      var key = names[at];
+      if (unsafe(key)) continue;
+      out[key] = emitValue(value[key], slot + "." + key, depth + 1);
+    }
     return out;
   }
 
   function emitProps(props, slot, depth) {
-    var out = {};
+    var out = create(null);
     if (props === null || typeof props !== "object") return out;
-    for (var key in props) {
-      if (key === "children" || key === "key" || key === "ref") continue;
+    var names = keys(props);
+    for (var at = 0; at < names.length; at++) {
+      var key = names[at];
+      if (key === "children" || key === "key" || key === "ref" || unsafe(key)) continue;
       var value = emitValue(props[key], slot + "#" + key, depth);
       if (value !== undefined) out[key] = value;
     }
@@ -240,6 +265,23 @@ const ENGINE = `(function () {
     }
   }
 
+  // What the host is about to parse, counted BEFORE it is JSON — the parse on
+  // the other side is one parse too late. The node cap is core's TREE_MAX_NODES
+  // so the cap in here and the gate out there are one number, and a text child
+  // counts as a node because that is what it becomes when the tree is flattened.
+  var counted = 0;
+
+  function measure(node, depth) {
+    if ((counted += 1) > ${TREE_MAX_NODES}) {
+      throw new Error("this screen painted more than ${TREE_MAX_NODES} nodes — paint a page of rows and let an event ask for the next");
+    }
+    if (depth > ${MAX_TREE_DEPTH}) {
+      throw new Error("this screen nested components more than ${MAX_TREE_DEPTH} deep — a screen paints a list of sections, not a chain");
+    }
+    if (typeof node === "string") return;
+    for (var i = 0; i < node.children.length; i++) measure(node.children[i], depth + 1);
+  }
+
   // ── the driver ────────────────────────────────────────────────────────────
   var root = null, component = null, eventPhase = false, failure = null;
 
@@ -273,7 +315,7 @@ const ENGINE = `(function () {
     return event;
   }
 
-  globalThis.__vendo = {
+  var api = {
     tools: (function make(path) {
       return new Proxy(function () {}, {
         get: function (target, key) { return typeof key === "string" ? make(path.concat(key)) : undefined; },
@@ -298,7 +340,7 @@ const ENGINE = `(function () {
       var handler = drawer[id];
       eventPhase = true;
       if (typeof handler !== "function") {
-        throw new Error('no handler "' + id + '" is on this screen — it named ' + Object.keys(drawer).length + " handler(s) at its last paint; deliver an event from the tree you are showing");
+        throw new Error('no handler "' + id + '" is on this screen — it named ' + keys(drawer).length + " handler(s) at its last paint; deliver an event from the tree you are showing");
       }
       var returned = handler(makeEvent(event));
       // An async handler's throw lands here, long after the call returned. The
@@ -332,7 +374,7 @@ const ENGINE = `(function () {
     takeFailure: function () {
       var taken = failure;
       failure = null;
-      return taken === null ? "null" : JSON.stringify(taken);
+      return taken === null ? "null" : stringify(taken);
     },
 
     /** The paint, as JSON. Handlers stay in here; the tree carries their ids. */
@@ -346,7 +388,13 @@ const ENGINE = `(function () {
       if (nodes.length !== 1 || typeof nodes[0] !== "object") {
         throw new Error("a screen must paint exactly one root element, and this one painted " + nodes.length + " — wrap what it returns in a single container component");
       }
-      return JSON.stringify(nodes[0]);
+      counted = 0;
+      measure(nodes[0], 1);
+      var json = stringify(nodes[0]);
+      if (json.length > ${MAX_TREE_BYTES}) {
+        throw new Error("this paint is too large to hand over at " + json.length + " bytes (max ${MAX_TREE_BYTES}) — paint a page of rows and let an event ask for the next");
+      }
+      return json;
     },
   };
 
@@ -379,18 +427,24 @@ const ENGINE = `(function () {
 
   var jsxModule = copy(jsx, ["jsx", "jsxs", "jsxDEV", "jsxTemplate", "Fragment"], {});
 
-  globalThis.__vendo_modules = {
+  // The module space is the engine's, not a global the screen can extend or
+  // swap: ./installSource takes it from here, adds its one module and freezes it.
+  api.modules = {
     react: react,
     "react/jsx-runtime": jsxModule,
     "react/jsx-dev-runtime": jsxModule,
   };
-  globalThis.__vendo_require = function (id) {
-    var found = __vendo_modules[id];
+  api.require = function (id) {
+    var found = api.modules[id];
     if (found === undefined) {
-      throw new Error('a screen cannot import "' + id + '" — the only modules it has are ' + Object.keys(__vendo_modules).join(", "));
+      throw new Error('a screen cannot import "' + id + '" — the only modules it has are ' + keys(api.modules).join(", "));
     }
     return found;
   };
+
+  // Not writable, not configurable, and nothing on it can be replaced — the
+  // host calls these by name after the screen's code has run.
+  Object.defineProperty(globalThis, "__vendo", { value: Object.freeze(api) });
 
   // The globals the engine captured are now unreachable from the screen.
   delete globalThis.preact;
@@ -435,12 +489,16 @@ export function installSource(input: InstallInput): string {
     tools: __vendo.tools,
   };
   for (var i = 0; i < names.length; i++) screen[names[i]] = names[i];
-  __vendo_modules["@vendo/screen"] = screen;
+  // The last module the space will ever hold. Frozen, and named nowhere the
+  // screen's own code can reach, before that code runs.
+  var modules = __vendo.modules;
+  modules["@vendo/screen"] = screen;
+  Object.freeze(modules);
 
   var module = { exports: {} };
   (function (require, module, exports) {
 ${input.compiledSource}
-  })(__vendo_require, module, module.exports);
+  })(__vendo.require, module, module.exports);
 
   var loaded = module.exports.default === undefined ? module.exports : module.exports.default;
   if (typeof loaded !== "function") {

--- a/packages/apps/src/contract/genui/component/vm-program.ts
+++ b/packages/apps/src/contract/genui/component/vm-program.ts
@@ -392,7 +392,7 @@ const ENGINE = `(function () {
       measure(nodes[0], 1);
       var json = stringify(nodes[0]);
       if (json.length > ${MAX_TREE_BYTES}) {
-        throw new Error("this paint is too large to hand over at " + json.length + " bytes (max ${MAX_TREE_BYTES}) — paint a page of rows and let an event ask for the next");
+        throw new Error("this paint is too large to hand over at " + json.length + " code units (max ${MAX_TREE_BYTES}) — paint a page of rows and let an event ask for the next");
       }
       return json;
     },

--- a/packages/apps/tests/checking/component-screen.test.ts
+++ b/packages/apps/tests/checking/component-screen.test.ts
@@ -841,12 +841,12 @@ export default function Everything() {
 }
 `);
 
-    // The screen ran fine — it is the TREE that is not one a surface can hold, and
-    // the check measures it with the format's own validator rather than a second
-    // implementation.
-    expect(codes).toEqual(["tree"]);
-    expect(text).toContain("the rendered screen is not a valid tree");
-    expect(text).toContain("too many nodes (max 5000)");
+    // The cap is the format's own number (core's TREE_MAX_NODES), counted INSIDE
+    // the VM before the JSON crosses — so the refusal now arrives from the run,
+    // one stage before the tree check that used to catch it.
+    expect(codes).toEqual(["run"]);
+    expect(text).toContain("the screen would not paint");
+    expect(text).toContain("more than 5000 nodes");
   });
 
   /** Wide enough to write a chart, a table and a slot. Its own list because the

--- a/packages/apps/tests/contract/genui/component/serialize-limits.test.ts
+++ b/packages/apps/tests/contract/genui/component/serialize-limits.test.ts
@@ -1,0 +1,90 @@
+/**
+ * How big a paint may be — asked INSIDE the VM, before the JSON crosses.
+ *
+ * The host's own gate on a tree (contract/genui/tree.ts) runs after
+ * `JSON.parse`, which is one parse too late: the string has already been built
+ * and read out of the VM. So the engine measures what it is about to hand over
+ * and refuses it with a sentence the screen's author can act on. The node cap is
+ * core's `TREE_MAX_NODES` — the same number on both sides of the crossing.
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+import { TREE_MAX_NODES } from "@vendoai/core";
+import {
+  bootScreen,
+  ScreenError,
+  wallClockBudget,
+  warmScreenEngine,
+  type ScreenInstance,
+} from "../../../../src/contract/genui/component/index.js";
+import { CATALOG, compileScreen } from "./screen-fixture.test-util.js";
+
+beforeAll(async () => {
+  await warmScreenEngine();
+});
+
+/** A screen that paints thousands of nodes is slow, not runaway — the budget
+ *  here is the test's own timeout, so a cap is what refuses it, never a clock. */
+const boot = (tsx: string): ScreenInstance => bootScreen({
+  compiledSource: compileScreen(tsx),
+  queries: {},
+  catalog: CATALOG,
+  budget: wallClockBudget({ bootMs: 30_000 }),
+});
+
+const refusal = (tsx: string): ScreenError => {
+  try {
+    boot(tsx).dispose();
+  } catch (error) {
+    if (error instanceof ScreenError) return error;
+    throw error;
+  }
+  throw new Error("expected the screen to be refused");
+};
+
+/** `count` rows under one Stack — count + 1 nodes. */
+const rows = (count: number): string => `
+import { Stack, Text } from "@vendo/screen";
+export default function S() {
+  return <Stack>{Array.from({ length: ${count} }, (_, i) => <Text key={i} text="r" />)}</Stack>;
+}`;
+
+const nested = (levels: number): string => `
+import { Stack, Text } from "@vendo/screen";
+export default function S() {
+  let node = <Text text="deep" />;
+  for (let i = 0; i < ${levels}; i++) node = <Stack>{node}</Stack>;
+  return node;
+}`;
+
+describe("the caps a paint has to fit", () => {
+  it("paints TREE_MAX_NODES and refuses one more", () => {
+    const screen = boot(rows(TREE_MAX_NODES - 1));
+    try {
+      expect(screen.tree().children).toHaveLength(TREE_MAX_NODES - 1);
+    } finally {
+      screen.dispose();
+    }
+
+    const error = refusal(rows(TREE_MAX_NODES));
+    expect(error.kind).toBe("render");
+    expect(error.message).toContain(`more than ${TREE_MAX_NODES} nodes`);
+    expect(error.message).toContain("paint a page of rows");
+  }, 60_000);
+
+  it("refuses a tree nested deeper than it caps", () => {
+    boot(nested(60)).dispose();
+
+    const error = refusal(nested(400));
+    expect(error.kind).toBe("render");
+    expect(error.message).toContain("deep");
+  });
+
+  it("refuses a paint too large to hand over, whatever its shape", () => {
+    const error = refusal(`
+import { Text } from "@vendo/screen";
+export default function S() { return <Text text={"x".repeat(600_000)} />; }`);
+
+    expect(error.kind).toBe("render");
+    expect(error.message).toContain("too large");
+  });
+});

--- a/packages/apps/tests/contract/genui/component/vm-forgery.test.ts
+++ b/packages/apps/tests/contract/genui/component/vm-forgery.test.ts
@@ -1,0 +1,91 @@
+/**
+ * The tree the host reads is the tree the screen PAINTED.
+ *
+ * The screen's own code evaluates inside the VM the engine already set up, so
+ * every name the engine still reaches for AFTERWARDS is a name the screen can
+ * redefine underneath it. A screen that assigned `JSON.stringify` used to hand
+ * the host a whole tree it never rendered, and the host validated it and said
+ * yes. So the engine holds its intrinsics in closure variables taken before the
+ * screen's first line, `__vendo` is not a name the screen can reach, and the
+ * emitter reads OWN keys onto a bare object. These are the attempts.
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+import { ScreenError, warmScreenEngine, type NestedNode } from "../../../../src/contract/genui/component/index.js";
+import { bootTsx, nodeOf, textsOf } from "./screen-fixture.test-util.js";
+
+beforeAll(async () => {
+  await warmScreenEngine();
+});
+
+/** One screen: something the model wrote at module scope, then a paint. */
+const paints = (prelude: string, body = `<Text text="real" />`): NestedNode => {
+  const screen = bootTsx(`
+import { Card, Stack, Text } from "@vendo/screen";
+${prelude}
+export default function S() { return <Stack>${body}</Stack>; }`);
+  try {
+    return screen.tree();
+  } finally {
+    screen.dispose();
+  }
+};
+
+const FORGED = '{"component":"Card","props":{"title":"forged"},"children":[]}';
+
+describe("a screen cannot forge its own paint", () => {
+  it("hands back what it rendered even when it rewrote JSON.stringify", () => {
+    const tree = paints(`JSON.stringify = () => ${JSON.stringify(FORGED)};`);
+
+    expect(tree.component).toBe("Stack");
+    expect(textsOf(tree)).toEqual(["real"]);
+  });
+
+  it("cannot replace the engine's handle, or any function on it", () => {
+    const fake = `{
+      mount: () => {}, flush: () => 0, resume: () => {}, fire: () => {},
+      takeFailure: () => "null", serialize: () => ${JSON.stringify(FORGED)}, tools: {},
+    }`;
+
+    expect(() => paints(`globalThis.__vendo = ${fake};`)).toThrow(ScreenError);
+    expect(() => paints(`__vendo.serialize = () => ${JSON.stringify(FORGED)};`)).toThrow(ScreenError);
+    expect(() => paints(`delete globalThis.__vendo;`)).toThrow(ScreenError);
+  });
+
+  it("cannot make an array read back as something else", () => {
+    const tree = paints(`Array.isArray = () => false;`, `<Card rows={[1, 2]} />`);
+
+    expect(nodeOf(tree, "Card")?.props.rows).toEqual([1, 2]);
+  });
+
+  it("cannot reach the module space the engine loaded it from", () => {
+    const tree = paints(`
+const reachable = [typeof globalThis.__vendo_modules, typeof globalThis.__vendo_require].join(",");`,
+      `<Text text={reachable} />`);
+
+    expect(textsOf(tree)).toEqual(["undefined,undefined"]);
+  });
+});
+
+describe("what crosses as props", () => {
+  it("is the object's own keys, never its prototype's", () => {
+    const tree = paints(`
+function Bag() {}
+Bag.prototype.inherited = "leaked";
+const instance = new Bag();
+instance.own = "kept";`, `<Card meta={instance} />`);
+
+    expect(nodeOf(tree, "Card")?.props.meta).toEqual({ own: "kept" });
+  });
+
+  it("drops the keys that mean the prototype chain on the host's side", () => {
+    const tree = paints(`
+const bag = { safe: 1 };
+Object.defineProperty(bag, "__proto__", { value: { role: "admin" }, enumerable: true });
+Object.defineProperty(bag, "constructor", { value: "forged", enumerable: true });
+Object.defineProperty(bag, "prototype", { value: "forged", enumerable: true });`,
+      `<Card meta={bag} />`);
+
+    expect(Object.keys(nodeOf(tree, "Card")?.props.meta as object)).toEqual(["safe"]);
+    expect(({} as { role?: string }).role).toBeUndefined();
+  });
+});


### PR DESCRIPTION
**Review window — do not merge individually. This stack merges once at the tip (PR⑤).**

Stack: `main` → **①** → ② → ③ → ④ → ⑤

## What it does

Closes a sandbox escape in the screen VM: the screen's own code evaluates inside the VM the engine set up, so every global the engine still reached for *after* that point was the screen's to redefine underneath it.

- The engine takes `JSON.stringify`, `Object.keys`, `Array.isArray` and `Object.create` into closure variables **before** the screen's first line.
- `__vendo` is installed non-writable and frozen; the module space moved onto it, so `__vendo_modules` and `__vendo_require` are no longer globals, and `installSource` freezes the space before the screen runs.
- The tree emitter reads own keys onto a bare object and never emits `__proto__`, `prototype` or `constructor`; the host's `JSON.parse` drops the same three as a second lock.
- `serialize` measures what it is about to hand over — core's `TREE_MAX_NODES`, a depth cap and a size cap — because the host's gate on the far side of `JSON.parse` is one parse too late.

## Why

A screen that assigned `JSON.stringify` handed the host a whole tree it never rendered, and the gauntlet passed it. The trust boundary was one line of the VM's own setup wide.

## What breaks

Nothing public. No exported type or function changes.

## Evidence

- 27 files changed, +343/−347.
- Gate run on the assembled tip (⑤), not per-slice: `pnpm build` ✅, `pnpm typecheck` ✅, `pnpm lint` ✅. Test result and the one open failure are recorded on PR③.
- No UI surface touched, so no browser proof applies to this slice.

---

## Assembled-tip gate (run once, on PR⑤'s tip `2e24e699`)

- `pnpm build` — 21/21 tasks ✅
- `pnpm typecheck` — 42/42 tasks ✅
- `pnpm lint` — ✅
- `pnpm test:affected` — 43 of 47 turbo tasks green. **4 red test files**, listed below. Everything else passed: apps 115/119 files, ui 118/118, store 60/62 (2 skipped), vendo 214/226, core 49/50, guard 34/35, actions 51/52, harnesses 48/51, agents 15/15, mcp 4/4, genbench 18/18, integration 17/18, automations-e2e 16/17, mcp-e2e 7/9, demo-bank 25/25, corpus 20/20 + express-host 6/6, ai-sdk-agent 2/3, mastra-agent 2/2.
- `packages/ui` Playwright e2e — **12/12 passed in a real Chromium**. That is the only browser evidence this assembly produced; the ✦/remix and display-brick surfaces still want their own browser pass before merge.
- **No contention flakes.** Every suite the loaded-laptop watchlist names passed on the first run: apps `engine.bundler-safety` (39.9 s), ui `export-surface`, store `split-brain.drill`, vendo `mcp-door-internal` + `server`, redteam smoke. All four failures below are real and reproducible.

### The four red files — all cross-slice, all test-only, one line each

No product code fails. Each of these is a test fixture or assertion that was correct on its own branch and is wrong once the slices are stacked. They are left UNTOUCHED: a test change is its own change, stated out loud, and needs a word before it lands.

| # | File:line | Cause | Owner |
|---|---|---|---|
| 1 | `packages/core/tests/contract-coverage.e2e.test.ts:327` | asserts `appSeedSchema.safeParse({component, baseline})` succeeds; PR③ made `instruction` required. This assertion landed on `main` in #1293, *after* the branches forked, so no builder could see it. | PR③ |
| 2 | `fixtures/redteam/tests/artifact-authority.e2e.test.ts:97` | builds a tampered `.vendoapp` whose `seed` has no `instruction`; import now refuses it. | PR③ |
| 3 | `packages/apps/tests/seed-survives-edit.test.ts:54` | the fixture screen is `<b>a sparkline</b>`; `b` is not one of PR②'s 21 display bricks, so PR②'s `JSX.IntrinsicElements` refuses it. `strong` is the brick that means this. | PR③ fixture × PR② gate |
| 4 | `packages/vendo/tests/screen-design-brief.test.ts:92` | asserts the design brief still says ``` `className`, no `style`, no CSS ```. PR② deleted that law from `format-reference.ts` on purpose — a screen now takes inline `style`. | PR② |

Items 1–3 are exactly what PR③'s own commit message promises ("the fixtures that hand-build a `seed` gain the instruction the schema now requires") and item 4 is exactly what PR②'s promises ("three suites pinned 'a screen has NO HTML' and this change makes that false") — each just reaches one file its builder could not see.
