### PR TITLE
feat(apps,ui): display bricks — the HTML a screen may write, contained by its box [stack 2/5]

### DIFF
--- a/packages/apps/src/contract/kit/display.ts
+++ b/packages/apps/src/contract/kit/display.ts
@@ -1,0 +1,49 @@
+/**
+ * The DISPLAY BRICKS — the display-only HTML a screen may write, beside the Kit.
+ *
+ * The Kit is the vocabulary of BEHAVIOR: it sorts, formats, validates and calls
+ * tools. These are the vocabulary of ARRANGEMENT, and they carry no behavior at
+ * all: children and an inline `style`, nothing else. No `className`, no `id`, no
+ * events, no `data-*`, no `aria-*`, no `dangerouslySetInnerHTML` — the React
+ * implementations (`packages/ui/src/tree/display-bricks.tsx`) take exactly two
+ * props per tag, so a prop that is not one of the two cannot arrive by spreading.
+ *
+ * Free CSS is safe because containment is CAPABILITY-shaped, never
+ * content-shaped: the surface root paints inside its own box
+ * (`SURFACE_CONTAINMENT`) so no declaration can reach host chrome, and the one
+ * trusted-side filter drops the style values that would FETCH (`url()`, `src()`,
+ * `image-set()`). Nothing reads a style for meaning; the LLM judge owns quality.
+ */
+
+/** One display tag. The name IS the tag — there are no props to describe. */
+export interface DisplayTagSpec {
+  readonly name: string;
+  readonly summary: string;
+}
+
+export const DISPLAY_SPECS: readonly DisplayTagSpec[] = [
+  { name: "div", summary: "A generic box. The default when nothing more specific fits." },
+  { name: "span", summary: "A generic inline run, inside a line of text." },
+  { name: "section", summary: "A themed region of the screen." },
+  { name: "header", summary: "The top band of a screen or section." },
+  { name: "footer", summary: "The bottom band of a screen or section." },
+  { name: "aside", summary: "Content beside the main flow — a sidebar or a note." },
+  { name: "h1", summary: "The screen's title." },
+  { name: "h2", summary: "A section heading." },
+  { name: "h3", summary: "A sub-section heading." },
+  { name: "h4", summary: "A fourth-level heading." },
+  { name: "h5", summary: "A fifth-level heading." },
+  { name: "h6", summary: "A sixth-level heading." },
+  { name: "p", summary: "A paragraph of prose." },
+  { name: "strong", summary: "Text that matters more than what surrounds it." },
+  { name: "em", summary: "Emphasized text." },
+  { name: "small", summary: "Fine print." },
+  { name: "code", summary: "An identifier or literal, in the mono face." },
+  { name: "blockquote", summary: "A quotation." },
+  { name: "ul", summary: "An unordered list." },
+  { name: "ol", summary: "An ordered list." },
+  { name: "li", summary: "One item in a list." },
+];
+
+/** The tags, as the renderer, the typings and the checks read them. */
+export const DISPLAY_TAG_NAMES: readonly string[] = DISPLAY_SPECS.map((spec) => spec.name);

--- a/packages/apps/src/contract/kit/index.ts
+++ b/packages/apps/src/contract/kit/index.ts
@@ -4,6 +4,7 @@
  * implementations stay in `@vendoai/ui` (`KIT_COMPONENTS`), keyed by these
  * names — a ui drift test pins the two in step.
  */
+export * from "./display.js";
 export * from "./schema.js";
 export * from "./specs.js";
 export { kitPrompt, type KitPromptOptions } from "./kit-prompt.js";

--- a/packages/apps/src/contract/kit/kit-prompt.ts
+++ b/packages/apps/src/contract/kit/kit-prompt.ts
@@ -3,6 +3,7 @@
  * Rendered entirely from `KIT_SPECS`; hand-written component lists are dead.
  * W3 wires this into the engine's wire contract (engine.ts).
  */
+import { DISPLAY_TAG_NAMES } from "./display.js";
 import { KIT_SHARED_PROP_NAMES, KIT_SPECS } from "./specs.js";
 import type { KitComponentSpec, PropClass } from "./schema.js";
 
@@ -47,6 +48,14 @@ const PREAMBLE = [
   "under its name as a caption `Text` instead of costing a column. Only the value",
   "tier and Stack/Row go in a cell, and only containers take children — a Button",
   "in a cell, or anything nested in a chart, is REFUSED, not quietly dropped.",
+  "",
+  `Beside the Kit you have display-only HTML — \`${DISPLAY_TAG_NAMES.join("`, `")}\` —`,
+  "taking children and an inline `style` and nothing else (no className, no id, no",
+  "handlers). Arrange and typeset freely with them, off the host's own CSS",
+  "variables (`var(--vendo-color-accent)`, `var(--vendo-density-content-gap)`) so",
+  "the screen stays branded; a hard-coded color is yours, not the product's. There",
+  "is no network here, so a style that fetches (`url(…)`) is dropped. Anything with",
+  "BEHAVIOR — a table, a number, a date, a control — is still a Kit component.",
 ].join("\n");
 
 /**

--- a/packages/apps/src/server/checking/component-screen.ts
+++ b/packages/apps/src/server/checking/component-screen.ts
@@ -41,6 +41,7 @@ import { parse } from "acorn";
 import type { Node, Program } from "acorn";
 import { VENDO_TREE_FORMAT, type JsonSchema, type TreeNode } from "@vendoai/core";
 import {
+  DISPLAY_TAG_NAMES,
   KIT_COMPONENT_NAMES,
   resolveIslandToolName,
   scanIslandTools,
@@ -698,7 +699,11 @@ export function screenName(source: string): string {
  *  A text run is the engine's own node kind, not a component anybody registered,
  *  so it is not measured against the catalog — but it IS a child, so the nesting
  *  rule reads the tree whole: text nested in a component that renders no
- *  children is the same blank as a node nested there. */
+ *  children is the same blank as a node nested there. A display brick is the
+ *  same case: the renderer resolves it beside the Kit, nothing registered it,
+ *  and the type check already refused every tag that is not one. */
+const DISPLAY_TAGS: ReadonlySet<string> = new Set(DISPLAY_TAG_NAMES);
+
 const treeCheckIssues = async (
   flat: FlatTree,
   catalog: readonly string[],
@@ -711,7 +716,7 @@ const treeCheckIssues = async (
   }
   const normalized: NormalizedCatalog = [...new Set(catalog)].map((name) => ({ name, description: "" }));
   const found = await catalogIssues(
-    { ...validation.tree, nodes: nodes.filter((node) => node.component !== SCREEN_TEXT_NODE) },
+    { ...validation.tree, nodes: nodes.filter((node) => node.component !== SCREEN_TEXT_NODE && !DISPLAY_TAGS.has(node.component)) },
     undefined,
     normalized,
   );

--- a/packages/apps/src/server/checking/screen-typecheck.ts
+++ b/packages/apps/src/server/checking/screen-typecheck.ts
@@ -15,6 +15,7 @@
  * Everything else is handed to the wire screen's own translator (screen-tsc.ts),
  * which already says the right thing about props, arguments and missing fields.
  */
+import { DISPLAY_TAG_NAMES } from "../../contract/index.js";
 import { diagnosticLine, translateDiagnostic, type ScreenProgram } from "./screen-program.js";
 import { SCREEN_MODULE } from "./screen-typings.js";
 import type { ComponentScreenIssue } from "./component-screen.js";
@@ -112,7 +113,7 @@ const typeIssue = (
 
   const intrinsic = INTRINSIC_ELEMENT.exec(sentence);
   if (intrinsic !== null) {
-    return at(`writes the HTML element <${intrinsic[1]}> — a screen has no HTML elements. It renders only the components it imports from ${JSON.stringify(SCREEN_MODULE)}: ${list(surface.components)}. Lay out with <Stack>/<Row>/<Grid> and write text with <Text>.`);
+    return at(`writes the HTML element <${intrinsic[1]}>, which a screen does not have. The HTML a screen has is display-only: ${list(DISPLAY_TAG_NAMES)} — each taking children and an inline style and nothing else. Anything with behavior comes from ${JSON.stringify(SCREEN_MODULE)}: ${list(surface.components)}.`);
   }
 
   if (UNKNOWN_NAME.has(diagnostic.code)) {

--- a/packages/apps/src/server/checking/screen-typings.ts
+++ b/packages/apps/src/server/checking/screen-typings.ts
@@ -27,6 +27,7 @@ import {
   type JsonSchema,
 } from "@vendoai/core";
 import {
+  DISPLAY_TAG_NAMES,
   KIT_WIRE_COMPONENT_NAMES,
   kitSpec,
   type NormalizedCatalog,
@@ -392,15 +393,19 @@ const HANDLER_TYPE = "(event?: { target: { value?: string; checked?: boolean } }
  *  one cannot be imported by a screen either. */
 const IDENTIFIER = /^[A-Za-z_$][\w$]*$/u;
 
-/** Everything the frame needs and nothing more. `IntrinsicElements` is EMPTY on
- *  purpose — that is what makes `<div>` an error — and `IntrinsicAttributes`
- *  carries `key`, because a list rendered with `.map()` writes one and it is
- *  React's, not the component's. */
+/** Everything the frame needs and nothing more. `IntrinsicElements` lists the
+ *  display bricks and NOTHING else — that is what keeps `<img>` and `<script>`
+ *  errors while `<div>` compiles — and each one takes only children and an
+ *  inline style, so `className`, `onClick` and `dangerouslySetInnerHTML` are
+ *  type errors on the tag itself. `IntrinsicAttributes` carries `key`, because a
+ *  list rendered with `.map()` writes one and it is React's, not the tag's. */
 const JSX_FRAME = `declare namespace JSX {
   interface Element {}
   interface ElementChildrenAttribute { children: {} }
   interface IntrinsicAttributes { key?: string | number }
-  interface IntrinsicElements {}
+  interface IntrinsicElements {
+${DISPLAY_TAG_NAMES.map((tag) => `    ${tag}: { children?: any; style?: Record<string, string | number> };`).join("\n")}
+  }
 }`;
 
 /** React as a screen may use it: the hooks, the two frame values, and the
@@ -414,6 +419,8 @@ const REACT_MODULE = `declare module "react" {
   export function useRef<T>(initial: T): { current: T };
   export function createElement(...args: any[]): JSX.Element;
   export const Fragment: (props: { children?: any }) => JSX.Element;
+  /** So a screen can name the type of a style it hoists out of the JSX. */
+  export interface CSSProperties { [property: string]: string | number }
   const React: {
     useState: typeof useState; useMemo: typeof useMemo; useCallback: typeof useCallback;
     useEffect: typeof useEffect; useRef: typeof useRef;

--- a/packages/apps/src/server/skills/format-reference.ts
+++ b/packages/apps/src/server/skills/format-reference.ts
@@ -15,6 +15,7 @@
  * it now teaches the same idiom this chapter does, so nothing here has to correct
  * it (`contract/kit/kit-prompt.ts`).
  */
+import { DISPLAY_TAG_NAMES } from "../../contract/kit/index.js";
 import { SCREEN_FILE } from "../../contract/genui/component/index.js";
 import { HOT_PATH_FILES } from "../generation/render-seam.js";
 import { componentsPromptSection } from "../generation/contracts/sections.js";
@@ -54,10 +55,18 @@ confirmed by the product OUTSIDE your screen — the guard asks the person befor
 the call runs — so never build a confirm step of your own: no "are you sure"
 panel, no second button, no \`confirming\` state.
 
-**Components — the catalog below, and nothing else.** No \`<div>\`, no
-\`className\`, no \`style\`, no CSS: each component already carries this product's
-own theme, so a screen built out of them is branded and a screen you style
-yourself is wrong. \`key={…}\` on every row you \`.map\`. Dates go to the date
+**Components — the catalog below, and nothing else.** Every component already
+carries this product's own theme, so anything with behavior — a table, a number,
+a date, a control — is a component, never HTML you assemble yourself.
+
+**Layout — the display tags, plus \`style\`.** \`${DISPLAY_TAG_NAMES.join("`, `")}\`
+are yours to arrange with, and they take children and an inline \`style\` and
+nothing else: no \`className\`, no \`id\`, no handlers. Style them off the host's own
+CSS variables (\`var(--vendo-color-accent)\`, \`var(--vendo-density-content-gap)\`)
+so the screen stays branded — a hard-coded color is your color, not the
+product's. There is no network in here, so a style that fetches (\`url(…)\`) is
+dropped.
+\`key={…}\` on every row you \`.map\`. Dates go to the date
 component as the ISO string you were given — there is no clock in here, so no
 \`new Date()\`; and no \`fetch\`, \`localStorage\` or \`setTimeout\` either, because
 there is no network, no storage and no timers.

--- a/packages/apps/tests/checking/component-screen.test.ts
+++ b/packages/apps/tests/checking/component-screen.test.ts
@@ -539,7 +539,7 @@ export default function S() {
     // fixed yet, so only the scan's finding is reported.
     const { codes, text } = await refusal(`import { z } from "zod";
 import { Text } from "@vendo/screen";
-export default function S() { return <div><Text text={String(z)} /></div>; }
+export default function S() { return <img><Text text={String(z)} /></img>; }
 `);
 
     expect(codes).toEqual(["import"]);
@@ -548,15 +548,15 @@ export default function S() { return <div><Text text={String(z)} /></div>; }
 });
 
 describe("stage 3 — the real compiler, with no DOM", () => {
-  it("refuses an HTML element, and says what to lay out with instead", async () => {
+  it("refuses an HTML element that is not a display brick, and names the ones that are", async () => {
     const { codes, text } = await refusal(`import { Text } from "@vendo/screen";
-export default function S() { return <div><Text text="x" /></div>; }
+export default function S() { return <img><Text text="x" /></img>; }
 `);
 
     expect(codes).toEqual(["types"]);
-    expect(text).toContain("line 2: writes the HTML element <div>");
-    expect(text).toContain("It renders only the components it imports from \"@vendo/screen\": Stack, Row, Card, Text, Money, DateTime, Button, Callout.");
-    expect(text).toContain("Lay out with <Stack>/<Row>/<Grid> and write text with <Text>.");
+    expect(text).toContain("line 2: writes the HTML element <img>");
+    expect(text).toContain("The HTML a screen has is display-only: div, span, section");
+    expect(text).toContain("Anything with behavior comes from \"@vendo/screen\": Stack, Row, Card, Text, Money, DateTime, Button, Callout.");
     // The closing tag is the same break; a repair list that says everything
     // twice reads as two problems.
     expect(text.match(/writes the HTML element/gu)).toHaveLength(1);

--- a/packages/apps/tests/checking/toolchain-conformance.test-util.ts
+++ b/packages/apps/tests/checking/toolchain-conformance.test-util.ts
@@ -93,12 +93,12 @@ const FIXTURES: readonly Fixture[] = [
     source: `import { Text } from "@vendo/screen";
 
 export default function Rows() {
-  return <div><Text text="hi" /></div>;
+  return <img><Text text="hi" /></img>;
 }
 `,
     answer: ROWS,
     codes: ["types"],
-    says: "writes the HTML element <div> — a screen has no HTML elements",
+    says: "writes the HTML element <img>, which a screen does not have",
   },
   {
     name: "refuses a screen that throws on the data its query really returned",

--- a/packages/apps/tests/skills/format-reference.test.ts
+++ b/packages/apps/tests/skills/format-reference.test.ts
@@ -118,11 +118,11 @@ describe("the reference only teaches what a screen really has", () => {
   });
 
   it("forbids the HTML and CSS a screen genuinely does not have", () => {
-    // No DOM lib is loaded into the check's program, so `<div>` and `className`
-    // are type errors; the theme lives in the components. A reference that let a
-    // model style a screen itself teaches an app that fails the checks AND
-    // arrives unbranded.
-    expect(VENDO_FORMAT_REFERENCE).toMatch(/No `<div>`, no\s+`className`, no `style`, no CSS/);
+    // The display bricks are the ONLY HTML in the check's program, and they take
+    // children and a style and nothing else — so `className` is still a type
+    // error, and a color the model invents is still unbranded.
+    expect(VENDO_FORMAT_REFERENCE).toMatch(/nothing else: no `className`, no `id`, no handlers/);
+    expect(VENDO_FORMAT_REFERENCE).toMatch(/var\(--vendo-color-accent\)/);
     expect(VENDO_FORMAT_REFERENCE).toMatch(/no `fetch`, `localStorage` or `setTimeout`/);
     expect(VENDO_FORMAT_REFERENCE).toMatch(/there is no clock in here, so no\s+`new Date\(\)`/);
   });

--- a/packages/ui/src/tree/display-bricks.tsx
+++ b/packages/ui/src/tree/display-bricks.tsx
@@ -1,0 +1,72 @@
+/**
+ * The display bricks' React half — the tags `DISPLAY_SPECS` names
+ * (`packages/apps/src/contract/kit/display.ts`), keyed by tag. A drift test pins
+ * the two in step, exactly as `KIT_COMPONENTS` is pinned to `KIT_SPECS`.
+ *
+ * Each brick is written out by hand and destructures exactly `style` and
+ * `children`. That is the whole containment of the prop surface: there is no
+ * spread, so `className`, `id`, `onClick`, `data-*`, `aria-*` and
+ * `dangerouslySetInnerHTML` cannot arrive — not because a list refuses them, but
+ * because nothing carries them through.
+ */
+import type { CSSProperties, ReactNode } from "react";
+
+export interface DisplayBrickProps {
+  style?: CSSProperties;
+  children?: ReactNode;
+}
+
+/**
+ * A style value that would make the browser FETCH. The only content the trusted
+ * side looks at, and it looks for a capability (a request leaves the page), not
+ * for meaning: `background: url(https://evil/x)` is a beacon whatever the URL
+ * says, and a screen has no network. `\b` catches the vendor spellings
+ * (`-webkit-image-set(`) and spares the functions that merely end in the same
+ * letters (`blur(`).
+ */
+const FETCHES = /\b(?:url|src|image-set)\s*\(/iu;
+
+/** The style a brick actually paints with: the model's, minus any declaration
+ *  that would fetch. Dropping the DECLARATION (not rewriting the value) keeps
+ *  this a filter with no parser in it. */
+export function withoutFetchableUrls(style: CSSProperties | undefined): CSSProperties | undefined {
+  if (style === undefined) return undefined;
+  return Object.fromEntries(Object.entries(style).filter(([, value]) => !FETCHES.test(String(value))));
+}
+
+export const DISPLAY_BRICKS: Record<string, (props: DisplayBrickProps) => ReactNode> = {
+  div: ({ style, children }) => <div style={withoutFetchableUrls(style)}>{children}</div>,
+  span: ({ style, children }) => <span style={withoutFetchableUrls(style)}>{children}</span>,
+  section: ({ style, children }) => <section style={withoutFetchableUrls(style)}>{children}</section>,
+  header: ({ style, children }) => <header style={withoutFetchableUrls(style)}>{children}</header>,
+  footer: ({ style, children }) => <footer style={withoutFetchableUrls(style)}>{children}</footer>,
+  aside: ({ style, children }) => <aside style={withoutFetchableUrls(style)}>{children}</aside>,
+  h1: ({ style, children }) => <h1 style={withoutFetchableUrls(style)}>{children}</h1>,
+  h2: ({ style, children }) => <h2 style={withoutFetchableUrls(style)}>{children}</h2>,
+  h3: ({ style, children }) => <h3 style={withoutFetchableUrls(style)}>{children}</h3>,
+  h4: ({ style, children }) => <h4 style={withoutFetchableUrls(style)}>{children}</h4>,
+  h5: ({ style, children }) => <h5 style={withoutFetchableUrls(style)}>{children}</h5>,
+  h6: ({ style, children }) => <h6 style={withoutFetchableUrls(style)}>{children}</h6>,
+  p: ({ style, children }) => <p style={withoutFetchableUrls(style)}>{children}</p>,
+  strong: ({ style, children }) => <strong style={withoutFetchableUrls(style)}>{children}</strong>,
+  em: ({ style, children }) => <em style={withoutFetchableUrls(style)}>{children}</em>,
+  small: ({ style, children }) => <small style={withoutFetchableUrls(style)}>{children}</small>,
+  code: ({ style, children }) => <code style={withoutFetchableUrls(style)}>{children}</code>,
+  blockquote: ({ style, children }) => <blockquote style={withoutFetchableUrls(style)}>{children}</blockquote>,
+  ul: ({ style, children }) => <ul style={withoutFetchableUrls(style)}>{children}</ul>,
+  ol: ({ style, children }) => <ol style={withoutFetchableUrls(style)}>{children}</ol>,
+  li: ({ style, children }) => <li style={withoutFetchableUrls(style)}>{children}</li>,
+};
+
+/**
+ * A screen paints inside its own box and nowhere else. Capability-shaped, like
+ * the fetch filter: `contain: paint` makes this element the containing block for
+ * every fixed and absolutely positioned descendant, so `position: fixed;
+ * width: 200vw` is held by the BOX — nothing had to read the word "fixed".
+ */
+export const SURFACE_CONTAINMENT: CSSProperties = {
+  contain: "layout paint",
+  overflow: "clip",
+  position: "relative",
+  isolation: "isolate",
+};

--- a/packages/ui/src/tree/display-bricks.tsx
+++ b/packages/ui/src/tree/display-bricks.tsx
@@ -35,6 +35,16 @@ const FETCHES = /\b(?:url|src|image-set)\s*\(/iu;
  */
 const ESCAPE = /\\(?:([0-9a-f]{1,6})[ \t\r\n\f]?|(.))/giu;
 
+/**
+ * CSS input preprocessing (Syntax §3.3), the stage that runs BEFORE any escape
+ * is read: CRLF, a lone CR and a form feed each collapse to ONE newline, and
+ * NUL and lone surrogates become the replacement character. That first stage is
+ * why `\75` + CRLF is `u` + a single newline by the time the escape claims its
+ * one trailing whitespace — leaving `url(`.
+ */
+const preprocessed = (value: string): string =>
+  value.replace(/\r\n?|\f/gu, "\n").replace(/[\0\ud800-\udfff]/gu, "�");
+
 /** The escapes resolved, for the DECISION only — the brick still paints the
  *  original value. Code points past the Unicode range are the tokenizer's
  *  replacement character, not a throw. */
@@ -50,7 +60,9 @@ const unescaped = (value: string): string =>
  *  no parser in it. */
 export function withoutFetchableUrls(style: CSSProperties | undefined): CSSProperties | undefined {
   if (style === undefined) return undefined;
-  return Object.fromEntries(Object.entries(style).filter(([, value]) => !FETCHES.test(unescaped(String(value)))));
+  return Object.fromEntries(
+    Object.entries(style).filter(([, value]) => !FETCHES.test(unescaped(preprocessed(String(value))))),
+  );
 }
 
 export const DISPLAY_BRICKS: Record<string, (props: DisplayBrickProps) => ReactNode> = {

--- a/packages/ui/src/tree/display-bricks.tsx
+++ b/packages/ui/src/tree/display-bricks.tsx
@@ -26,12 +26,31 @@ export interface DisplayBrickProps {
  */
 const FETCHES = /\b(?:url|src|image-set)\s*\(/iu;
 
+/**
+ * A CSS escape: `\` then 1–6 hex digits with one trailing whitespace consumed,
+ * or `\` then a literal character. The tokenizer unescapes BEFORE it decides
+ * what a token is, so `\75 rl(` is the function `url(` however the raw string
+ * reads — and `var()` substitutes whole tokens, so a custom property carries the
+ * spelling through intact.
+ */
+const ESCAPE = /\\(?:([0-9a-f]{1,6})[ \t\r\n\f]?|(.))/giu;
+
+/** The escapes resolved, for the DECISION only — the brick still paints the
+ *  original value. Code points past the Unicode range are the tokenizer's
+ *  replacement character, not a throw. */
+const unescaped = (value: string): string =>
+  value.replace(ESCAPE, (_, hex: string | undefined, literal: string) =>
+    hex === undefined ? literal
+      : Number.parseInt(hex, 16) > 0x10ffff ? "�"
+        : String.fromCodePoint(Number.parseInt(hex, 16)));
+
 /** The style a brick actually paints with: the model's, minus any declaration
- *  that would fetch. Dropping the DECLARATION (not rewriting the value) keeps
- *  this a filter with no parser in it. */
+ *  that would fetch once its escapes read the way the browser reads them.
+ *  Dropping the DECLARATION (not rewriting the value) keeps this a filter with
+ *  no parser in it. */
 export function withoutFetchableUrls(style: CSSProperties | undefined): CSSProperties | undefined {
   if (style === undefined) return undefined;
-  return Object.fromEntries(Object.entries(style).filter(([, value]) => !FETCHES.test(String(value))));
+  return Object.fromEntries(Object.entries(style).filter(([, value]) => !FETCHES.test(unescaped(String(value)))));
 }
 
 export const DISPLAY_BRICKS: Record<string, (props: DisplayBrickProps) => ReactNode> = {

--- a/packages/ui/src/tree/renderer.tsx
+++ b/packages/ui/src/tree/renderer.tsx
@@ -35,6 +35,7 @@ import { useVendoThemeOrDefault } from "../context.js";
 import { themeCssVariables } from "../theme.js";
 import type { InClientVenue, SeedDrift } from "../wire-types.js";
 import { resolvePointer } from "./bindings.js";
+import { DISPLAY_BRICKS, SURFACE_CONTAINMENT } from "./display-bricks.js";
 import { NodeErrorBoundary } from "./error-boundary.js";
 import { FluidReveal } from "./fluid-reveal.js";
 import { deriveFormShape, FormingSkeleton, PendingLeaf } from "./forming-skeleton.js";
@@ -663,9 +664,11 @@ function generatedContent(context: NodeContent): ReactNode {
   );
 }
 
-/** V4 — one component family: the Kit is the only built-in set. */
+/** V4 — one component family: the Kit is the only built-in set, plus the display
+ *  bricks, which resolve exactly like one. A brick's tag is lowercase and a Kit
+ *  or catalog name is an identifier, so the two can never collide. */
 function builtinContent({ props, node, children, invoke, handle }: NodeContent): ReactNode {
-  const kit = KIT_COMPONENTS[node.component] as ComponentType<Record<string, unknown>> | undefined;
+  const kit = (KIT_COMPONENTS[node.component] ?? DISPLAY_BRICKS[node.component]) as ComponentType<Record<string, unknown>> | undefined;
   const host = props.components[node.component] as ComponentType<Record<string, unknown>> | undefined;
   // An explicit `source: "host"` means the host brand won the name. An
   // undefined (or "prewired") source keeps the built-in first, so a stored
@@ -1025,32 +1028,34 @@ function StatefulTreeView({
     : null;
 
   return (
-    <NodeErrorBoundary nodeId={validation.tree.root} retryKey={data ?? validation.tree.data} streaming={streaming}>
-      {dataNotice}
-      {dropBackNotice}
-      {driftNotice}
-      <NodeRenderer
-        nodeId={validation.tree.root}
-        ancestry={new Set()}
-        nodes={repaint.nodes}
-        marks={repaint.marks}
-        generated={streaming ? tree.components ?? {} : validation.tree.components ?? {}}
-        {...(componentTools === undefined ? {} : { componentTools })}
-        inClientGranted={inClientGranted}
-        furnishings={furnishings}
-        themeVars={themeVars}
-        components={components}
-        data={data ?? validation.tree.data ?? {}}
-        state={viewState}
-        streaming={streaming}
-        outcomes={outcomes}
-        orphans={orphans}
-        runAction={runAction}
-        {...(onReview === undefined ? {} : { onReview })}
-        setViewState={updateState}
-        {...(interactive === undefined ? {} : { screen })}
-      />
-    </NodeErrorBoundary>
+    <div data-vendo-surface="" style={SURFACE_CONTAINMENT}>
+      <NodeErrorBoundary nodeId={validation.tree.root} retryKey={data ?? validation.tree.data} streaming={streaming}>
+        {dataNotice}
+        {dropBackNotice}
+        {driftNotice}
+        <NodeRenderer
+          nodeId={validation.tree.root}
+          ancestry={new Set()}
+          nodes={repaint.nodes}
+          marks={repaint.marks}
+          generated={streaming ? tree.components ?? {} : validation.tree.components ?? {}}
+          {...(componentTools === undefined ? {} : { componentTools })}
+          inClientGranted={inClientGranted}
+          furnishings={furnishings}
+          themeVars={themeVars}
+          components={components}
+          data={data ?? validation.tree.data ?? {}}
+          state={viewState}
+          streaming={streaming}
+          outcomes={outcomes}
+          orphans={orphans}
+          runAction={runAction}
+          {...(onReview === undefined ? {} : { onReview })}
+          setViewState={updateState}
+          {...(interactive === undefined ? {} : { screen })}
+        />
+      </NodeErrorBoundary>
+    </div>
   );
 }
 

--- a/packages/ui/test/tree/display-bricks.test.tsx
+++ b/packages/ui/test/tree/display-bricks.test.tsx
@@ -72,6 +72,19 @@ describe("display bricks", () => {
     // escape through intact — it is the declaration that has to go.
     expect(withoutFetchableUrls({ "--x": "u\\72 l(/pixel)", background: "var(--x)" } as CSSProperties))
       .toEqual({ background: "var(--x)" });
+
+    // Input preprocessing runs BEFORE escapes are read and collapses CRLF to one
+    // newline, so the escape's single trailing whitespace swallows the whole
+    // break and these spell `url(` too.
+    expect(withoutFetchableUrls({
+      background: "\\75\r\nrl(https://evil/x)",
+      maskImage: "\\75\r\nrl(https://evil/z)",
+      cursor: "\\75\r\nrl(https://evil/c), auto",
+      content: "\\75\r\nrl(https://evil/t)",
+      WebkitMaskBoxImage: "u\\72\r\nl(https://evil/b)",
+    })).toEqual({});
+    expect(withoutFetchableUrls({ "--y": "\\75\r\nrl(/pixel)", background: "var(--y)" } as CSSProperties))
+      .toEqual({ background: "var(--y)" });
   });
 
   it("keeps the values that only look like a fetch", () => {
@@ -86,6 +99,19 @@ describe("display bricks", () => {
     // filter's `\s*` takes it. Dropping a value that paints nothing is safe;
     // buying it back would cost a second mechanism.
     expect(withoutFetchableUrls({ background: "url\\9 (https://evil/x)" })).toEqual({});
+
+    // One decode pass is the RIGHT number: the browser decodes once too, so
+    // `\\75 rl(` is a literal backslash followed by text and paints nothing.
+    expect(withoutFetchableUrls({ background: "\\\\75 rl(https://evil/x)" }))
+      .toEqual({ background: "\\\\75 rl(https://evil/x)" });
+
+    // The legitimate CSS the filter must never eat, whatever the property.
+    for (const value of [
+      "blur(4px)", "linear-gradient(red, blue)", "radial-gradient(circle, #123, #456)",
+      "color-mix(in srgb, red 50%, blue)", '"url is a word"', "translateX(4px) blur(0)",
+      "Blurb, Source Sans, sans-serif", "pointer", "none", "linear-gradient(red, blue) 30",
+      '"a \\\\ b"', '"\\201C"', "repeat(auto-fill, minmax(120px, 1fr))",
+    ]) expect(withoutFetchableUrls({ background: value })).toEqual({ background: value });
   });
 
   it("paints the surface inside its own box", () => {

--- a/packages/ui/test/tree/display-bricks.test.tsx
+++ b/packages/ui/test/tree/display-bricks.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import type { CSSProperties } from "react";
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import { DISPLAY_TAG_NAMES, VENDO_TREE_FORMAT } from "@vendoai/apps/contract";
@@ -49,6 +50,42 @@ describe("display bricks", () => {
       filter: "blur(4px)",
     })).toEqual({ color: "var(--vendo-color-accent)", filter: "blur(4px)" });
     expect(withoutFetchableUrls(undefined)).toBeUndefined();
+  });
+
+  it("drops them however the escapes spell the function", () => {
+    // The CSS tokenizer unescapes before it decides what a token is, so every
+    // one of these IS `url(` to the browser, whatever the raw string reads.
+    expect(withoutFetchableUrls({
+      background: "\\75 rl(https://evil/x)",
+      borderImage: "\\000075rl(https://evil/y)",
+      maskImage: "u\\72 l(https://evil/z)",
+      WebkitMaskImage: "\\75 \\72 \\6c(https://evil/w)",
+      clipPath: "u\\72 l(#c)",
+      filter: "\\75 rl(#f)",
+      cursor: "u\\72 l(https://evil/c), auto",
+      content: "\\000075rl(https://evil/t)",
+      listStyleImage: "u\\72 l(https://evil/l)",
+      shapeOutside: "\\75 rl(https://evil/s)",
+    })).toEqual({});
+
+    // `var()` substitutes whole tokens, so the custom property carries the
+    // escape through intact — it is the declaration that has to go.
+    expect(withoutFetchableUrls({ "--x": "u\\72 l(/pixel)", background: "var(--x)" } as CSSProperties))
+      .toEqual({ background: "var(--x)" });
+  });
+
+  it("keeps the values that only look like a fetch", () => {
+    expect(withoutFetchableUrls({
+      filter: "blur(4px)",
+      // A comment splits the ident, so this computes to nothing and fetches nothing.
+      background: "ur/**/l(https://evil/x)",
+    })).toEqual({ filter: "blur(4px)", background: "ur/**/l(https://evil/x)" });
+
+    // `url\9 (` is inert too — whitespace between the ident and `(` is no
+    // function token — but normalizing puts a tab where the escape was and the
+    // filter's `\s*` takes it. Dropping a value that paints nothing is safe;
+    // buying it back would cost a second mechanism.
+    expect(withoutFetchableUrls({ background: "url\\9 (https://evil/x)" })).toEqual({});
   });
 
   it("paints the surface inside its own box", () => {

--- a/packages/ui/test/tree/display-bricks.test.tsx
+++ b/packages/ui/test/tree/display-bricks.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { DISPLAY_TAG_NAMES, VENDO_TREE_FORMAT } from "@vendoai/apps/contract";
+import type { ToolOutcome } from "@vendoai/core";
+import { TreeView, type WalkTree } from "../../src/tree/index.js";
+import { DISPLAY_BRICKS, SURFACE_CONTAINMENT, withoutFetchableUrls } from "../../src/tree/display-bricks.js";
+
+afterEach(cleanup);
+
+const ok = async (): Promise<ToolOutcome> => ({ status: "ok", output: null });
+
+const tree = (nodes: WalkTree["nodes"]): WalkTree =>
+  ({ formatVersion: VENDO_TREE_FORMAT, root: nodes[0]!.id, nodes });
+
+describe("display bricks", () => {
+  it("implements exactly the tags the specs name (the drift test)", () => {
+    expect(Object.keys(DISPLAY_BRICKS).sort()).toEqual([...DISPLAY_TAG_NAMES].sort());
+  });
+
+  it("renders a brick with its style, and nothing else it was handed", () => {
+    render(
+      <TreeView
+        tree={tree([
+          { id: "root", component: "section", props: { style: { padding: "8px" }, className: "host-chrome", onClick: "x" }, children: ["h"] },
+          { id: "h", component: "h2", props: { style: { color: "var(--vendo-color-accent)" } }, children: ["t"] },
+          { id: "t", component: "#text", props: { text: "Overdue" } },
+        ])}
+        components={{}}
+        onAction={ok}
+      />,
+    );
+
+    const heading = screen.getByText("Overdue");
+    expect(heading.tagName).toBe("H2");
+    expect(heading.getAttribute("style")).toBe("color: var(--vendo-color-accent);");
+    const box = heading.closest("section")!;
+    expect(box.getAttribute("style")).toBe("padding: 8px;");
+    expect(box.getAttribute("class")).toBeNull();
+  });
+
+  it("drops the style values that would make the browser fetch", () => {
+    expect(withoutFetchableUrls({
+      background: "url(https://evil/x)",
+      borderImage: "image-set('https://evil/y' 1x)",
+      cursor: "-webkit-image-set(url(https://evil/z) 1x)",
+      maskImage: "src(https://evil/w)",
+      color: "var(--vendo-color-accent)",
+      filter: "blur(4px)",
+    })).toEqual({ color: "var(--vendo-color-accent)", filter: "blur(4px)" });
+    expect(withoutFetchableUrls(undefined)).toBeUndefined();
+  });
+
+  it("paints the surface inside its own box", () => {
+    render(
+      <TreeView
+        tree={tree([{ id: "root", component: "div", props: { style: { position: "fixed", width: "200vw" } } }])}
+        components={{}}
+        onAction={ok}
+      />,
+    );
+
+    // Not a rule about the word "fixed": `contain: paint` makes the wrapper the
+    // containing block for every fixed descendant, so the escape has nowhere to go.
+    expect(document.querySelector("[data-vendo-surface]")?.getAttribute("style"))
+      .toBe("contain: layout paint; overflow: clip; position: relative; isolation: isolate;");
+    expect(SURFACE_CONTAINMENT.contain).toBe("layout paint");
+  });
+});

--- a/packages/vendo/tests/screen-design-brief.test.ts
+++ b/packages/vendo/tests/screen-design-brief.test.ts
@@ -82,9 +82,9 @@ describe("the writers' design brief", () => {
     await screen.assemble();
     const brief = screen.model.systemPrompts[0] ?? "";
 
-    // The law, in COMPONENT terms rather than CSS: hierarchy, density, chart
-    // choice by data shape, the honest hole, and the one styling rule — a screen
-    // picks parts, it never styles them.
+    // The law: hierarchy, density, chart choice by data shape, the honest hole,
+    // and the one styling rule — a screen styles freely, but off the host's own
+    // CSS variables, because a hard-coded color is not the product's.
     expect(brief).toContain("What a good screen looks like");
     expect(brief).toContain("Lead with the answer.");
     expect(brief).toContain("Never chart two data points");

--- a/packages/vendo/tests/screen-design-brief.test.ts
+++ b/packages/vendo/tests/screen-design-brief.test.ts
@@ -89,7 +89,7 @@ describe("the writers' design brief", () => {
     expect(brief).toContain("Lead with the answer.");
     expect(brief).toContain("Never chart two data points");
     expect(brief).toContain("A hole is a `<Disclaimer>`.");
-    expect(brief).toContain("`className`, no `style`, no CSS");
+    expect(brief).toContain("`var(--vendo-color-accent)`");
   });
 
   it("carries the WHOLE briefing pack when composition has one", async () => {


### PR DESCRIPTION
**Review window — do not merge individually. This stack merges once at the tip (PR⑤).**

Stack: main → ① → **②** → ③ → ④ → ⑤ · base: `kit/pr1-vm-hardening`

## What it does

Gives a screen ~21 display-only HTML tags beside the Kit — `div`, `span`, `section`, `header`, `footer`, `aside`, `h1`–`h6`, `p`, `strong`, `em`, `small`, `code`, `blockquote`, `ul`, `ol`, `li` — each taking children and an inline `style`, and nothing else.

`DISPLAY_SPECS` is the single source: the renderer resolves bricks beside `KIT_COMPONENTS`, the screen typings print them as the only `JSX.IntrinsicElements`, the type-check refusal names the legal tags, the tree's catalog check skips them like a text run, and the prompt teaches them off the host's own CSS variables.

## Why

A screen had exactly one vocabulary. Every arrangement the Kit could not express had to be faked with a container that was never meant for it, and `<div>` was a type error.

## What breaks

Nothing public — this is additive. Three suites that pinned "a screen has NO HTML" now pin it with `<img>`, an element that really is absent. That test change is part of the slice and is stated in the commit. A fourth, `packages/vendo/tests/screen-design-brief.test.ts:92`, was not in this slice's view and is still red on the assembled tip — see the gate section below.

## Security posture

Capability-shaped, never content-inspected. There is no style validator and no provenance scanner:

- Each brick is hand-written and destructures exactly `style` and `children`. No spread, so `className`, `id`, `on*`, `data-*`, `aria-*` and `dangerouslySetInnerHTML` cannot arrive — not because a list refuses them, but because nothing carries them.
- One trusted-side filter drops declarations that would FETCH (`url()`, `src()`, `image-set()`). A screen has no network; a beacon is a beacon whatever the URL says.
- The surface root paints inside its own box: `contain: layout paint; overflow: clip; position: relative; isolation: isolate`. `contain: paint` makes it the containing block for fixed descendants, so `position: fixed; width: 200vw` is held by geometry — nothing read the word "fixed".

## Evidence

- 13 files changed, +280/−53.
- Gate run on the assembled tip (⑤): `pnpm build` ✅, `pnpm typecheck` ✅, `pnpm lint` ✅.
- **Browser proof: partial.** `packages/ui`'s Playwright suite passed 12/12 in a real Chromium on the assembled tip, but it covers the thread surface, not the bricks; the brick DOM is asserted in `packages/ui/test/tree/display-bricks.test.tsx` (jsdom) only. Whoever lands this stack should take a browser pass on a brick-using screen.
- Cross-slice check performed on the tip: PR⑤ deletes the renderer's `themeVars` plumbing. That prop fed `JailedComponent` only — the iframe's separate document. Display bricks paint in the host document under `ChromeRoot`, which sets `themeCssVariables(theme)` at `packages/ui/src/chrome/chrome-root.tsx:64`, so `var(--vendo-*)` in a brick's inline style still resolves. No break.

---

## Assembled-tip gate (run once, on PR⑤'s tip `2e24e699`)

- `pnpm build` — 21/21 tasks ✅
- `pnpm typecheck` — 42/42 tasks ✅
- `pnpm lint` — ✅
- `pnpm test:affected` — 43 of 47 turbo tasks green. **4 red test files**, listed below. Everything else passed: apps 115/119 files, ui 118/118, store 60/62 (2 skipped), vendo 214/226, core 49/50, guard 34/35, actions 51/52, harnesses 48/51, agents 15/15, mcp 4/4, genbench 18/18, integration 17/18, automations-e2e 16/17, mcp-e2e 7/9, demo-bank 25/25, corpus 20/20 + express-host 6/6, ai-sdk-agent 2/3, mastra-agent 2/2.
- `packages/ui` Playwright e2e — **12/12 passed in a real Chromium**. That is the only browser evidence this assembly produced; the ✦/remix and display-brick surfaces still want their own browser pass before merge.
- **No contention flakes.** Every suite the loaded-laptop watchlist names passed on the first run: apps `engine.bundler-safety` (39.9 s), ui `export-surface`, store `split-brain.drill`, vendo `mcp-door-internal` + `server`, redteam smoke. All four failures below are real and reproducible.

### The four red files — all cross-slice, all test-only, one line each

No product code fails. Each of these is a test fixture or assertion that was correct on its own branch and is wrong once the slices are stacked. They are left UNTOUCHED: a test change is its own change, stated out loud, and needs a word before it lands.

| # | File:line | Cause | Owner |
|---|---|---|---|
| 1 | `packages/core/tests/contract-coverage.e2e.test.ts:327` | asserts `appSeedSchema.safeParse({component, baseline})` succeeds; PR③ made `instruction` required. This assertion landed on `main` in #1293, *after* the branches forked, so no builder could see it. | PR③ |
| 2 | `fixtures/redteam/tests/artifact-authority.e2e.test.ts:97` | builds a tampered `.vendoapp` whose `seed` has no `instruction`; import now refuses it. | PR③ |
| 3 | `packages/apps/tests/seed-survives-edit.test.ts:54` | the fixture screen is `<b>a sparkline</b>`; `b` is not one of PR②'s 21 display bricks, so PR②'s `JSX.IntrinsicElements` refuses it. `strong` is the brick that means this. | PR③ fixture × PR② gate |
| 4 | `packages/vendo/tests/screen-design-brief.test.ts:92` | asserts the design brief still says ``` `className`, no `style`, no CSS ```. PR② deleted that law from `format-reference.ts` on purpose — a screen now takes inline `style`. | PR② |

Items 1–3 are exactly what PR③'s own commit message promises ("the fixtures that hand-build a `seed` gain the instruction the schema now requires") and item 4 is exactly what PR②'s promises ("three suites pinned 'a screen has NO HTML' and this change makes that false") — each just reaches one file its builder could not see.
