### PR TITLE
feat(apps,ui): theme v2 — nineteen more brand tokens, every one optional

### DIFF
--- a/.changeset/theme-v2-contract.md
+++ b/.changeset/theme-v2-contract.md
@@ -1,0 +1,52 @@
+---
+"@vendoai/apps": minor
+"@vendoai/ui": minor
+---
+
+Theme v2 — nineteen more brand tokens, every one optional.
+
+`VendoTheme` carried eight colors, two type fields, three radii and two enums.
+Everything the Kit and the chrome needed beyond that was a literal somewhere in
+our source: the green and amber the pills paint, the mono stack, the three
+shadows, the chart ramp, the border width, the chrome's own motion pair. A host
+could not reach any of them. Now it can.
+
+```ts
+theme: {
+  colors: { …, success: "#0a7d55", warning: "#c98a00", surfaceRaised: "#fafafa" },
+  typography: { …, monoFamily: "Berkeley Mono, monospace", weightEmphasis: "650", lineHeightBody: "1.6" },
+  shadow: { small: "…", medium: "…", large: "…" },
+  borderWidth: "1px",
+  chartPalette: ["#1d4ed8", "#0891b2", "#7c3aed"],
+  motionDuration: "120ms",
+  motionEasing: "cubic-bezier(.2,.8,.2,1)",
+}
+```
+
+- **Every addition is OPTIONAL.** A theme file that fails to parse is discarded
+  whole, so one required field would have blanked the brand of every host whose
+  theme predates it. A pre-v2 theme parses and renders exactly as before.
+- **The variable NAMES stay one fixed set — 52 of them.** Three transports
+  (the chrome's style object, the MCP door's `style` attribute, the MCP Apps
+  shim's `:root{}`) serialize the same mapping and compare their output against
+  each other, and the shim's reverse read throws on a name outside the published
+  list. So `themeCssVariables` resolves each optional field against a default
+  and emits every name for every theme, rather than emitting a name only for
+  hosts that set it.
+- **The Kit reads them.** `success`/`warning` stop being Kit-only literals, a
+  control's edge is `var(--vendo-border-width)`, and `chartSeries` reads
+  `--vendo-chart-1..6` with the accent-derived OKLCH ramp — unchanged — as the
+  per-entry fallback. One definition of that ramp now, shared by the emitter and
+  the Kit.
+- **Three chrome tokens re-anchor onto the contract.** `--vendo-border` keeps
+  the derived ~8% hairline as its DEFAULT but a host that states `colors.border`
+  finally wins instead of being ignored; the `--vendo-ok`/`--vendo-warn` family
+  reads `colors.success`/`colors.warning`; and `--vendo-duration`/`--vendo-ease`
+  derive from the theme's motion pair (the chrome keeps its slower feel through
+  a multiplier), so one host knob moves the chrome and generated views together.
+
+`defaultVendoTheme` is deliberately unchanged: it is the shape the MCP Apps shim
+reconstructs a theme back INTO, and a field the reader cannot recover would make
+a theme round-trip into a different theme. The fill-in values live beside it as
+`themeDefaults`, which the Kit reads for its unthemed fallbacks — so each value
+still has exactly one definition.

--- a/packages/apps/src/contract/catalog.ts
+++ b/packages/apps/src/contract/catalog.ts
@@ -62,14 +62,36 @@ export interface VendoTheme {
     accentText: string;
     danger: string;
     border: string;
+    success?: string;
+    warning?: string;
+    surfaceRaised?: string;
   };
-  typography: { fontFamily: string; headingFamily?: string; baseSize: string };
+  typography: {
+    fontFamily: string;
+    headingFamily?: string;
+    monoFamily?: string;
+    baseSize: string;
+    weightNormal?: string;
+    weightEmphasis?: string;
+    letterSpacing?: string;
+    lineHeightBody?: string;
+    lineHeightHeading?: string;
+  };
   radius: { small: string; medium: string; large: string };
+  shadow?: { small: string; medium: string; large: string };
   density: "compact" | "comfortable";
   motion: "full" | "reduced";
+  borderWidth?: string;
+  /** Categorical chart series, in order; beyond six a chart reads the ramp
+   * `chartPaletteFor` derives from the accent. */
+  chartPalette?: string[];
+  motionDuration?: string;
+  motionEasing?: string;
 }
 
-/** 01-core §14 */
+/** 01-core §14. Every field added after the original eight-color shape is
+ * OPTIONAL: a failed parse discards the WHOLE theme file, so a required addition
+ * would blank the brand of every host whose theme predates it. */
 export const vendoThemeSchema = z.object({
   colors: z.object({
     background: z.string(),
@@ -80,19 +102,37 @@ export const vendoThemeSchema = z.object({
     accentText: z.string(),
     danger: z.string(),
     border: z.string(),
+    success: z.string().optional(),
+    warning: z.string().optional(),
+    surfaceRaised: z.string().optional(),
   }).passthrough(),
   typography: z.object({
     fontFamily: z.string(),
     headingFamily: z.string().optional(),
+    monoFamily: z.string().optional(),
     baseSize: z.string(),
+    weightNormal: z.string().optional(),
+    weightEmphasis: z.string().optional(),
+    letterSpacing: z.string().optional(),
+    lineHeightBody: z.string().optional(),
+    lineHeightHeading: z.string().optional(),
   }).passthrough(),
   radius: z.object({
     small: z.string(),
     medium: z.string(),
     large: z.string(),
   }).passthrough(),
+  shadow: z.object({
+    small: z.string(),
+    medium: z.string(),
+    large: z.string(),
+  }).passthrough().optional(),
   density: z.enum(["compact", "comfortable"]),
   motion: z.enum(["full", "reduced"]),
+  borderWidth: z.string().optional(),
+  chartPalette: z.array(z.string()).max(6).optional(),
+  motionDuration: z.string().optional(),
+  motionEasing: z.string().optional(),
 }).passthrough() satisfies z.ZodType<VendoTheme>;
 
 /** AGENT-1 — 03 §3 item (4): the model-facing summary of the host components a

--- a/packages/apps/src/contract/catalog.ts
+++ b/packages/apps/src/contract/catalog.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { JsonSchema } from "@vendoai/core";
+import { log, type JsonSchema } from "@vendoai/core";
 
 /** 01-core §14 */
 export interface StandardSchema {
@@ -130,7 +130,18 @@ export const vendoThemeSchema = z.object({
   density: z.enum(["compact", "comfortable"]),
   motion: z.enum(["full", "reduced"]),
   borderWidth: z.string().optional(),
-  chartPalette: z.array(z.string()).max(6).optional(),
+  // Truncate rather than reject: a failed parse discards the WHOLE theme file,
+  // so a seventh color would cost the host its fonts, colors and radius too.
+  chartPalette: z.array(z.string()).transform((palette) => {
+    if (palette.length > 6) {
+      log({
+        code: "apps.theme-palette-truncated",
+        level: "warn",
+        message: `[vendo] theme chartPalette has ${palette.length} colors; only the first 6 are used`,
+      });
+    }
+    return palette.slice(0, 6);
+  }).optional(),
   motionDuration: z.string().optional(),
   motionEasing: z.string().optional(),
 }).passthrough() satisfies z.ZodType<VendoTheme>;

--- a/packages/apps/src/contract/theme.ts
+++ b/packages/apps/src/contract/theme.ts
@@ -35,6 +35,76 @@ export const defaultVendoTheme: VendoTheme = {
   motion: "full",
 };
 
+/**
+ * The value the mapping fills in for each field the contract marks OPTIONAL, so
+ * one fixed set of variable names is emitted whatever vintage a host's theme
+ * file is — the door, the shim and the chrome compare that set against each
+ * other, and the shim's reverse read throws on a name outside it.
+ *
+ * Deliberately NOT folded into `defaultVendoTheme`: that object is the shape the
+ * MCP Apps shim reconstructs a theme back INTO, and a field the reader cannot
+ * recover would make a theme round-trip into a different theme. The Kit reads
+ * its own unthemed fallbacks off here, so there is still one copy of each value.
+ */
+export const themeDefaults = {
+  colors: {
+    success: "#1e7f53",
+    warning: "#d4a017",
+    // One step off the host's OWN surface rather than a literal, so a raised
+    // card sits the same distance from the page in any brand and either scheme.
+    surfaceRaised: "color-mix(in srgb, var(--vendo-color-surface) 92%, var(--vendo-color-text))",
+  },
+  typography: {
+    // System mono stack — no brand mono font ships.
+    monoFamily: "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace",
+    weightNormal: "400",
+    weightEmphasis: "600",
+    letterSpacing: "-0.011em",
+    lineHeightBody: "1.5",
+    lineHeightHeading: "1.3",
+  },
+  // The chrome sheet's three elevations, lifted verbatim — its `--vendo-fg` is
+  // `var(--vendo-color-text, #14151a)`: the hover lift, the float every element
+  // resting above a surface paints, and the overlay panel.
+  shadow: {
+    small: "0 2px 10px color-mix(in srgb, var(--vendo-color-text, #14151a) 8%, transparent)",
+    medium: "0 1px 2px color-mix(in srgb, var(--vendo-color-text, #14151a) 5%, transparent), "
+      + "0 10px 28px color-mix(in srgb, var(--vendo-color-text, #14151a) 8%, transparent)",
+    large: "0 30px 80px color-mix(in srgb, var(--vendo-color-text, #14151a) 24%, transparent)",
+  },
+  borderWidth: "1px",
+  motionDuration: "160ms",
+  motionEasing: "cubic-bezier(0.2, 0.8, 0.2, 1)",
+};
+
+/**
+ * Series lightness ladder, as `[lightness, chroma scale]` in OKLCH. Absolute
+ * lightness rather than `calc(l ± n)` because relative steps collapse for a
+ * near-black or near-white accent (the default accent is #111111), and chroma
+ * eases off as lightness rises so the pale steps stay in sRGB gamut. Ordered so
+ * neighbouring series sit far apart on the ladder.
+ */
+const chartRamp: ReadonlyArray<readonly [number, number]> = [
+  [0.7, 0.9],
+  [0.46, 1],
+  [0.86, 0.5],
+  [0.54, 1],
+  [0.78, 0.65],
+  [0.38, 1],
+  [0.62, 0.95],
+];
+
+/**
+ * The categorical chart palette an accent implies: the accent itself, then
+ * shades and tints that keep its hue (`h`) exactly — so a chart is brand-native
+ * on any host and never invents a color. `chartPalette` replaces the first six
+ * entry by entry (`--vendo-chart-1..6`); the Kit derives its own fallbacks from
+ * this same function, so the two sides cannot drift.
+ */
+export function chartPaletteFor(accent: string): string[] {
+  return [accent, ...chartRamp.map(([l, c]) => `oklch(from ${accent} ${l} calc(c * ${c}) h)`)];
+}
+
 /** Deep-merge a partial theme over a base (one level per contract group). */
 export function resolveTheme(base: VendoTheme, override?: Partial<VendoTheme>): VendoTheme {
   if (!override) return base;
@@ -42,8 +112,13 @@ export function resolveTheme(base: VendoTheme, override?: Partial<VendoTheme>): 
     colors: { ...base.colors, ...override.colors },
     typography: { ...base.typography, ...override.typography },
     radius: { ...base.radius, ...override.radius },
+    shadow: override.shadow ?? base.shadow,
     density: override.density ?? base.density,
     motion: override.motion ?? base.motion,
+    borderWidth: override.borderWidth ?? base.borderWidth,
+    chartPalette: override.chartPalette ?? base.chartPalette,
+    motionDuration: override.motionDuration ?? base.motionDuration,
+    motionEasing: override.motionEasing ?? base.motionEasing,
   };
 }
 
@@ -101,29 +176,51 @@ export function densityCssVariables(density: VendoTheme["density"]): Record<stri
   };
 }
 
-/** Flatten a theme into `--vendo-*` CSS custom properties. */
+/** Flatten a theme into `--vendo-*` CSS custom properties. Each optional field
+ * resolves against `themeDefaults`, so the NAMES emitted are one fixed set whatever
+ * vintage the host's theme file is — the door, the shim and the chrome compare
+ * that set, and the shim's reverse read rejects a name outside it. */
 export function themeCssVariables(theme: VendoTheme): Record<string, string> {
   const vars: Record<string, string> = {};
-  for (const [key, value] of Object.entries(theme.colors)) vars[`--vendo-color-${kebab(key)}`] = value;
+  const type = { ...themeDefaults.typography, ...theme.typography };
+  for (const [key, value] of Object.entries({ ...themeDefaults.colors, ...theme.colors })) {
+    vars[`--vendo-color-${kebab(key)}`] = value;
+  }
   vars["--vendo-color-scheme"] = colorSchemeForBackground(theme.colors.background);
-  vars["--vendo-font-family"] = theme.typography.fontFamily;
-  if (theme.typography.headingFamily) vars["--vendo-heading-family"] = theme.typography.headingFamily;
-  vars["--vendo-font-size"] = theme.typography.baseSize;
+  vars["--vendo-font-family"] = type.fontFamily;
+  if (type.headingFamily) vars["--vendo-heading-family"] = type.headingFamily;
+  vars["--vendo-mono-family"] = type.monoFamily;
+  vars["--vendo-font-size"] = type.baseSize;
   // baseSize is the anchor of the chrome type scale: the sheet derives every
   // text size (and a couple of spacing steps) from --vendo-base-size via calc,
   // so a host's baseSize scales the whole surface instead of only the root font.
-  vars["--vendo-base-size"] = theme.typography.baseSize;
+  vars["--vendo-base-size"] = type.baseSize;
+  vars["--vendo-font-weight-normal"] = type.weightNormal;
+  vars["--vendo-font-weight-emphasis"] = type.weightEmphasis;
+  vars["--vendo-letter-spacing"] = type.letterSpacing;
+  vars["--vendo-line-height"] = type.lineHeightBody;
+  vars["--vendo-line-height-heading"] = type.lineHeightHeading;
   for (const [key, value] of Object.entries(theme.radius)) vars[`--vendo-radius-${kebab(key)}`] = value;
+  for (const [key, value] of Object.entries(theme.shadow ?? themeDefaults.shadow)) {
+    vars[`--vendo-shadow-${kebab(key)}`] = value;
+  }
+  vars["--vendo-border-width"] = theme.borderWidth ?? themeDefaults.borderWidth;
+  for (const [i, color] of chartPaletteFor(theme.colors.accent).slice(0, 6).entries()) {
+    vars[`--vendo-chart-${i + 1}`] = theme.chartPalette?.[i] ?? color;
+  }
   Object.assign(vars, densityCssVariables(theme.density));
   vars["--vendo-motion"] = theme.motion;
-  vars["--vendo-motion-duration"] = theme.motion === "reduced" ? "0ms" : "160ms";
-  vars["--vendo-motion-easing"] = "cubic-bezier(0.2, 0.8, 0.2, 1)";
+  vars["--vendo-motion-duration"] = theme.motion === "reduced"
+    ? "0ms"
+    : theme.motionDuration ?? themeDefaults.motionDuration;
+  vars["--vendo-motion-easing"] = theme.motionEasing ?? themeDefaults.motionEasing;
   return vars;
 }
 
 /**
  * Every variable name the mapping can emit — READ OFF the mapping (a probe
- * theme that sets the one optional field), never hand-listed, so a consumer
+ * theme that sets headingFamily, the one field emitted only when a host declares
+ * it; the rest resolve against the defaults), never hand-listed, so a consumer
  * that teaches or reads these names cannot fall behind a rename. Two do:
  * the generation prompt's brand-token line and the MCP Apps shim's reverse
  * read.

--- a/packages/apps/tests/contract/theme-vars.test.ts
+++ b/packages/apps/tests/contract/theme-vars.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Theme v2 — the fields added after the original eight-color shape.
+ *
+ * Two properties hold the whole thing up. (1) Every addition is OPTIONAL: the
+ * parser discards the WHOLE theme file on one bad field, so a required addition
+ * would blank the brand of every host whose theme predates it. (2) The mapping
+ * emits ONE fixed set of variable NAMES regardless — the door, the MCP Apps shim
+ * and the chrome compare that set against each other, and the shim's reverse
+ * read throws on a name outside it, so a name that appears only for some themes
+ * is a live bug on three surfaces.
+ */
+import { describe, expect, it } from "vitest";
+import { vendoThemeSchema } from "../../src/contract/catalog.js";
+import {
+  VENDO_THEME_VARIABLE_NAMES,
+  chartPaletteFor,
+  themeCssVariables,
+  themeDefaults,
+} from "../../src/contract/theme.js";
+
+/** A theme written before any of the v2 fields existed. */
+const preV2 = {
+  colors: {
+    background: "#ffffff",
+    surface: "#f7f7f7",
+    text: "#111111",
+    muted: "#666666",
+    accent: "#0055ff",
+    accentText: "#ffffff",
+    danger: "#cc0000",
+    border: "#dddddd",
+  },
+  typography: { fontFamily: "Inter", baseSize: "16px" },
+  radius: { small: "4px", medium: "8px", large: "16px" },
+  density: "comfortable" as const,
+  motion: "full" as const,
+};
+
+describe("theme v2 — the additions never break an older theme", () => {
+  it("a theme carrying none of the new fields still parses", () => {
+    expect(vendoThemeSchema.safeParse(preV2).success).toBe(true);
+  });
+
+  it("…and a theme carrying all of them parses too", () => {
+    expect(vendoThemeSchema.safeParse({
+      ...preV2,
+      colors: { ...preV2.colors, success: "#0a0", warning: "#fa0", surfaceRaised: "#eee" },
+      typography: {
+        ...preV2.typography,
+        monoFamily: "Berkeley Mono, monospace",
+        weightNormal: "350",
+        weightEmphasis: "650",
+        letterSpacing: "0.01em",
+        lineHeightBody: "1.6",
+        lineHeightHeading: "1.2",
+      },
+      shadow: { small: "0 1px 2px #0001", medium: "0 4px 8px #0002", large: "0 20px 40px #0003" },
+      borderWidth: "2px",
+      chartPalette: ["#111", "#222"],
+      motionDuration: "90ms",
+      motionEasing: "linear",
+    }).success).toBe(true);
+  });
+
+  it("rejects a chartPalette longer than the six variables the mapping emits", () => {
+    const seven = ["#1", "#2", "#3", "#4", "#5", "#6", "#7"];
+    expect(vendoThemeSchema.safeParse({ ...preV2, chartPalette: seven }).success).toBe(false);
+    expect(vendoThemeSchema.safeParse({ ...preV2, chartPalette: seven.slice(0, 6) }).success).toBe(true);
+  });
+
+  it("emits the same variable NAMES for a pre-v2 theme as for a full one", () => {
+    const full = { ...preV2, borderWidth: "2px", chartPalette: ["#111"], motionEasing: "linear" };
+    expect(Object.keys(themeCssVariables(preV2))).toEqual(Object.keys(themeCssVariables(full)));
+    // …and that set is the published list, minus the one name a host either
+    // declares or does not.
+    expect(Object.keys(themeCssVariables(preV2)))
+      .toEqual(VENDO_THEME_VARIABLE_NAMES.filter((name) => name !== "--vendo-heading-family"));
+  });
+});
+
+describe("theme v2 — the new variables carry the new fields", () => {
+  it("a pre-v2 theme still gets every new variable, at its default", () => {
+    const vars = themeCssVariables(preV2);
+    expect(vars["--vendo-color-success"]).toBe(themeDefaults.colors.success);
+    expect(vars["--vendo-color-warning"]).toBe(themeDefaults.colors.warning);
+    expect(vars["--vendo-color-surface-raised"]).toContain("color-mix(");
+    expect(vars["--vendo-mono-family"]).toBe(themeDefaults.typography.monoFamily);
+    expect(vars["--vendo-font-weight-normal"]).toBe("400");
+    expect(vars["--vendo-font-weight-emphasis"]).toBe("600");
+    expect(vars["--vendo-letter-spacing"]).toBe("-0.011em");
+    expect(vars["--vendo-line-height"]).toBe("1.5");
+    expect(vars["--vendo-line-height-heading"]).toBe("1.3");
+    expect(vars["--vendo-shadow-medium"]).toBe(themeDefaults.shadow.medium);
+    expect(vars["--vendo-border-width"]).toBe("1px");
+    expect(vars["--vendo-motion-easing"]).toBe("cubic-bezier(0.2, 0.8, 0.2, 1)");
+  });
+
+  it("a host's own values win, field by field", () => {
+    const vars = themeCssVariables({
+      ...preV2,
+      colors: { ...preV2.colors, success: "#00aa55" },
+      typography: { ...preV2.typography, weightEmphasis: "800", lineHeightBody: "1.7" },
+      shadow: { small: "none", medium: "0 4px 8px #0002", large: "0 20px 40px #0003" },
+      borderWidth: "2px",
+      motionDuration: "90ms",
+      motionEasing: "linear",
+    });
+    expect(vars["--vendo-color-success"]).toBe("#00aa55");
+    expect(vars["--vendo-font-weight-emphasis"]).toBe("800");
+    expect(vars["--vendo-line-height"]).toBe("1.7");
+    expect(vars["--vendo-shadow-small"]).toBe("none");
+    expect(vars["--vendo-border-width"]).toBe("2px");
+    expect(vars["--vendo-motion-duration"]).toBe("90ms");
+    expect(vars["--vendo-motion-easing"]).toBe("linear");
+  });
+
+  it("motion: reduced still zeroes the duration a host asked for", () => {
+    const vars = themeCssVariables({ ...preV2, motion: "reduced", motionDuration: "90ms" });
+    expect(vars["--vendo-motion-duration"]).toBe("0ms");
+  });
+});
+
+describe("chartPalette — the host's series, else the accent ramp", () => {
+  it("a host palette lands on --vendo-chart-1..n and the ramp fills the rest", () => {
+    const vars = themeCssVariables({ ...preV2, chartPalette: ["#e11", "#1e1", "#11e"] });
+    expect(vars["--vendo-chart-1"]).toBe("#e11");
+    expect(vars["--vendo-chart-2"]).toBe("#1e1");
+    expect(vars["--vendo-chart-3"]).toBe("#11e");
+    expect(vars["--vendo-chart-4"]).toBe(chartPaletteFor(preV2.colors.accent)[3]);
+  });
+
+  it("no palette is the accent ramp, unchanged", () => {
+    const vars = themeCssVariables(preV2);
+    const ramp = chartPaletteFor(preV2.colors.accent);
+    expect([1, 2, 3, 4, 5, 6].map((n) => vars[`--vendo-chart-${n}`])).toEqual(ramp.slice(0, 6));
+    // The ramp itself: the accent, then hue-locked OKLCH steps off it.
+    expect(ramp[0]).toBe("#0055ff");
+    expect(ramp[1]).toBe("oklch(from #0055ff 0.7 calc(c * 0.9) h)");
+  });
+});

--- a/packages/apps/tests/contract/theme-vars.test.ts
+++ b/packages/apps/tests/contract/theme-vars.test.ts
@@ -62,12 +62,6 @@ describe("theme v2 — the additions never break an older theme", () => {
     }).success).toBe(true);
   });
 
-  it("rejects a chartPalette longer than the six variables the mapping emits", () => {
-    const seven = ["#1", "#2", "#3", "#4", "#5", "#6", "#7"];
-    expect(vendoThemeSchema.safeParse({ ...preV2, chartPalette: seven }).success).toBe(false);
-    expect(vendoThemeSchema.safeParse({ ...preV2, chartPalette: seven.slice(0, 6) }).success).toBe(true);
-  });
-
   it("emits the same variable NAMES for a pre-v2 theme as for a full one", () => {
     const full = { ...preV2, borderWidth: "2px", chartPalette: ["#111"], motionEasing: "linear" };
     expect(Object.keys(themeCssVariables(preV2))).toEqual(Object.keys(themeCssVariables(full)));
@@ -127,6 +121,22 @@ describe("chartPalette — the host's series, else the accent ramp", () => {
     expect(vars["--vendo-chart-2"]).toBe("#1e1");
     expect(vars["--vendo-chart-3"]).toBe("#11e");
     expect(vars["--vendo-chart-4"]).toBe(chartPaletteFor(preV2.colors.accent)[3]);
+  });
+
+  it("a palette longer than six truncates, and the rest of the theme survives", () => {
+    const parsed = vendoThemeSchema.safeParse({
+      ...preV2,
+      chartPalette: ["#1", "#2", "#3", "#4", "#5", "#6", "#7"],
+    });
+    expect(parsed.success && parsed.data.chartPalette).toEqual(["#1", "#2", "#3", "#4", "#5", "#6"]);
+    expect(parsed.success && parsed.data.typography.fontFamily).toBe("Inter");
+    expect(parsed.success && parsed.data.colors).toEqual(preV2.colors);
+  });
+
+  it("a palette of six or fewer is passed through untouched", () => {
+    const six = ["#1", "#2", "#3", "#4", "#5", "#6"];
+    const parsed = vendoThemeSchema.safeParse({ ...preV2, chartPalette: six });
+    expect(parsed.success && parsed.data.chartPalette).toEqual(six);
   });
 
   it("no palette is the accent ramp, unchanged", () => {

--- a/packages/ui/src/chrome/chrome-css.ts
+++ b/packages/ui/src/chrome/chrome-css.ts
@@ -28,11 +28,11 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the S1 des
   --vendo-surface: var(--vendo-color-surface, #fffdf9);
   --vendo-accent: var(--vendo-color-accent, #1b1c22);
   --vendo-accent-fg: var(--vendo-color-accent-text, #ffffff);
-  /* S1 hairline: felt, not seen. Derived as ~8% of the foreground rather than
-     read from colors.border, so the edge always sits the same distance from the
-     text in ANY brand and in both schemes (a host's literal border color could
-     not do that). colors.border is consequently unread by the chrome. */
-  --vendo-border: color-mix(in srgb, var(--vendo-color-text, #14151a) 8%, transparent);
+  /* S1 hairline: felt, not seen. The DEFAULT is ~8% of the foreground rather
+     than a fixed value, so an unstated edge sits the same distance from the
+     text in ANY brand and in both schemes — but a host that states
+     colors.border now wins, instead of having it silently ignored. */
+  --vendo-border: var(--vendo-color-border, color-mix(in srgb, var(--vendo-color-text, #14151a) 8%, transparent));
   --vendo-radius: var(--vendo-radius-medium, 12px);
   /* radius.small / radius.large were emitted by the theme but never read — only
      medium drove the whole sheet. Bridge them so small chrome (chips, badges,
@@ -72,30 +72,34 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the S1 des
      launcher pill and the overlay panel. Every resting surface is flat. */
   --vendo-shadow-float: 0 1px 2px color-mix(in srgb, var(--vendo-fg) 5%, transparent),
     0 10px 28px color-mix(in srgb, var(--vendo-fg) 8%, transparent);
-  /* M2 motion (spec §6): one unhurried duration + one iOS-sheet easing. Named
-     apart from the theme's --vendo-motion-* pair, which themeCssVariables emits
-     INLINE on the root (an inline custom property beats this rule) and which
-     drives the generated-view layer's 160ms hover transitions. */
-  --vendo-duration: 380ms;
-  --vendo-ease: cubic-bezier(0.32, 0.72, 0, 1);
-  --vendo-ok: #2e9e6b;
+  /* M2 motion (spec §6): one unhurried duration + one iOS-sheet easing, both
+     DERIVED from the theme's --vendo-motion-* pair so a host turns one knob and
+     the chrome and the generated-view layer move together. The chrome keeps its
+     slower feel through the multiplier (380ms at the default 160ms), and
+     motion: "reduced" — which emits 0ms — collapses it to nothing. */
+  --vendo-duration: calc(var(--vendo-motion-duration, 160ms) * 2.375);
+  --vendo-ease: var(--vendo-motion-easing, cubic-bezier(0.32, 0.72, 0, 1));
+  --vendo-ok: var(--vendo-color-success, #2e9e6b);
   --vendo-danger: var(--vendo-color-danger, #b0392b);
   --vendo-danger-bg: color-mix(in srgb, var(--vendo-danger) 8%, var(--vendo-surface));
   --vendo-danger-border: color-mix(in srgb, var(--vendo-danger) 32%, var(--vendo-border));
-  /* Warn / ceremony amber family — single source. The amber was scattered as
-     raw literals across ceremony buttons, voice consent and the a11y hardening
-     block; collapsed here so it is themeable from one place. Every dark-side
-     value and the AA-safe on-fill text (ENG-226) are preserved exactly. */
-  --vendo-warn: light-dark(#7a5000, #d9a94e);
-  --vendo-warn-text: light-dark(#8a6a2e, #d9a94e);
-  --vendo-warn-edge: #b3822f;
+  /* Warn / ceremony amber family — single source, now anchored on the contract's
+     colors.warning: every member that IS the tone reads it, and the two
+     contrast-tuned pairs below (on-fill, fill-critical) stay put. The amber was
+     scattered as raw literals across ceremony buttons, voice consent and the
+     a11y hardening block; collapsed here so it is themeable from one place.
+     Every dark-side value and the AA-safe on-fill text (ENG-226) are preserved
+     exactly as the fallbacks. */
+  --vendo-warn: var(--vendo-color-warning, light-dark(#7a5000, #d9a94e));
+  --vendo-warn-text: var(--vendo-color-warning, light-dark(#8a6a2e, #d9a94e));
+  --vendo-warn-edge: var(--vendo-color-warning, #b3822f);
   /* DEAD: the .fl-btn-critical alias it existed for is gone
      (critical IS ceremony now) and nothing reads this token. It survives only
      because test/theme-tokens.test.tsx pins its amber literal to exactly one
      definition — retire that pin and this token together. */
   --vendo-warn-fill-critical: light-dark(#a97e2f, #b3822f);
   --vendo-warn-on-fill: light-dark(#fff, #14151a);
-  --vendo-warn-tint: #f0b429;
+  --vendo-warn-tint: var(--vendo-color-warning, #f0b429);
   --vendo-warn-bg: color-mix(in srgb, var(--vendo-warn-tint) 12%, var(--vendo-surface));
   --vendo-warn-border: color-mix(in srgb, var(--vendo-warn-tint) 32%, var(--vendo-border));
   /* Neutral user bubble (ENG-227): raw accent painting the whole user turn read

--- a/packages/ui/src/chrome/chrome-css.ts
+++ b/packages/ui/src/chrome/chrome-css.ts
@@ -53,9 +53,9 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the S1 des
      font-size. The .933 ratio preserves the historical 14px-on-15px-base size. */
   --vendo-base-size: var(--vendo-font-size, 15px);
   --vendo-text-body: calc(var(--vendo-base-size) * 0.933);
-  /* System mono stack (no unshipped brand font): the chrome has no contract
-     mono token, so this is the single themeable source referenced everywhere. */
-  --vendo-font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  /* The host's mono face when its theme declares one, else the system stack:
+     this is the single source every mono rule in the sheet references. */
+  --vendo-font-mono: var(--vendo-mono-family, ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace);
   /* derived aesthetics */
   --vendo-accent-soft: color-mix(in srgb, var(--vendo-accent) 8%, transparent);
   --vendo-border-strong: color-mix(in srgb, var(--vendo-fg) 14%, transparent);

--- a/packages/ui/src/kit/tokens.ts
+++ b/packages/ui/src/kit/tokens.ts
@@ -4,8 +4,10 @@
  * on any host and never hardcodes Vendo's own brand (W2 §The Kit, axis 1).
  */
 import {
+  chartPaletteFor,
   defaultVendoTheme,
   densityCssVariables,
+  themeDefaults,
 } from "@vendoai/apps/contract";
 import type { CSSProperties } from "react";
 
@@ -23,12 +25,8 @@ export const t = {
   accent: `var(--vendo-color-accent, ${d.colors.accent})`,
   accentText: `var(--vendo-color-accent-text, ${d.colors.accentText})`,
   danger: `var(--vendo-color-danger, ${d.colors.danger})`,
-  // Two tones the host contract does not carry a color for. They are still
-  // TOKENS — a host that wants its own green and amber sets these two variables
-  // — and the fallback is the green/amber the pill palette already used as a
-  // literal, so nothing changes for a host that sets nothing.
-  success: "var(--vendo-color-success, #1e7f53)",
-  warning: "var(--vendo-color-warning, #d4a017)",
+  success: `var(--vendo-color-success, ${themeDefaults.colors.success})`,
+  warning: `var(--vendo-color-warning, ${themeDefaults.colors.warning})`,
   border: `var(--vendo-color-border, ${d.colors.border})`,
   radiusSmall: `var(--vendo-radius-small, ${d.radius.small})`,
   radiusMedium: `var(--vendo-radius-medium, ${d.radius.medium})`,
@@ -58,7 +56,7 @@ export const control: CSSProperties = {
   boxSizing: "border-box",
   minWidth: 0,
   minHeight: "var(--vendo-density-control-height, 38px)",
-  border: `1px solid ${t.border}`,
+  border: `var(--vendo-border-width, ${themeDefaults.borderWidth}) solid ${t.border}`,
   borderRadius: t.radiusSmall,
   background: t.surface,
   padding: "var(--vendo-density-control-padding, 9px 12px)",
@@ -139,33 +137,15 @@ export function densityVars(density: KitDensity | undefined): CSSProperties {
 }
 
 /**
- * Series lightness ladder, as `[lightness, chroma scale]` in OKLCH. Absolute
- * lightness rather than `calc(l ± n)` because relative steps collapse for a
- * near-black or near-white accent (the default accent is #111111), and chroma
- * eases off as lightness rises so the pale steps stay in sRGB gamut. Ordered so
- * neighbouring series sit far apart on the ladder.
- */
-const seriesRamp: ReadonlyArray<readonly [number, number]> = [
-  [0.7, 0.9],
-  [0.46, 1],
-  [0.86, 0.5],
-  [0.54, 1],
-  [0.78, 0.65],
-  [0.38, 1],
-  [0.62, 0.95],
-];
-
-/**
- * Recharts-friendly categorical palette: the host accent, then shades and tints
- * of it that keep its hue (`h`) exactly — so a chart is brand-native on any host
- * and never invents a color. The old cycle reached for `muted` and a
+ * Recharts-friendly categorical palette: the host's own `chartPalette`, which
+ * the theme emits as `--vendo-chart-1..6`, falling back entry by entry to the
+ * accent-derived ramp `chartPaletteFor` builds — so a chart is brand-native on
+ * any host and never invents a color. The old cycle reached for `muted` and a
  * danger×accent mix, which read as slate-purple and rust wedges on a green
  * brand.
  */
-export const chartSeries = [
-  t.accent,
-  ...seriesRamp.map(([l, c]) => `oklch(from ${t.accent} ${l} calc(c * ${c}) h)`),
-] as const;
+export const chartSeries: readonly string[] = chartPaletteFor(t.accent)
+  .map((color, i) => (i < 6 ? `var(--vendo-chart-${i + 1}, ${color})` : color));
 
 /** Nth series color, wrapping. */
 export function seriesColor(index: number): string {

--- a/packages/ui/src/tree/mcp-shim/theme.ts
+++ b/packages/ui/src/tree/mcp-shim/theme.ts
@@ -1,6 +1,8 @@
 import {
   VENDO_THEME_VARIABLE_NAMES,
+  chartPaletteFor,
   defaultVendoTheme,
+  themeDefaults,
   type VendoTheme,
 } from "@vendoai/apps/contract";
 
@@ -21,16 +23,34 @@ function emitted(name: string): string {
  * shim on variables (rather than embedded JSON) leaves the generated source
  * generic and gives its own chrome and the inner jail one canonical namespace.
  * Only the variables a `VendoTheme` field maps back from are read; the derived
- * ones (color-scheme, the density sizing scale, motion timings) are the
+ * ones (color-scheme, the density sizing scale, the duplicate base size) are the
  * mapping's output, not its input. */
 export function readThemeCssVariables(style: CssVariables): VendoTheme {
   const value = (name: string, fallback: string): string =>
     style.getPropertyValue(emitted(name)).trim() || fallback;
   const optional = (name: string): string | undefined =>
     style.getPropertyValue(emitted(name)).trim() || undefined;
+  /** A field the contract marks optional. The mapping emits its variable whatever
+   * vintage the host's theme file is, filling in `themeDefaults`, so recovering
+   * one whose value still IS that fill-in would turn a theme that declared none
+   * of them into a theme that declares them all. Recovered only when it differs. */
+  const override = <K extends string>(field: K, name: string, fallback: string): { [P in K]?: string } => {
+    const read = value(name, fallback);
+    return read === fallback ? {} : { [field]: read } as { [P in K]?: string };
+  };
   const density = optional("--vendo-density");
   const motion = optional("--vendo-motion");
   const headingFamily = optional("--vendo-heading-family") ?? defaultVendoTheme.typography.headingFamily;
+  const accent = value("--vendo-color-accent", defaultVendoTheme.colors.accent);
+  const shadow = {
+    small: value("--vendo-shadow-small", themeDefaults.shadow.small),
+    medium: value("--vendo-shadow-medium", themeDefaults.shadow.medium),
+    large: value("--vendo-shadow-large", themeDefaults.shadow.large),
+  };
+  // The mapping fills the six series from the accent's ramp, so a palette equal
+  // to that ramp is one the host never declared.
+  const chartRamp = chartPaletteFor(accent).slice(0, 6);
+  const chartPalette = chartRamp.map((fallback, i) => value(`--vendo-chart-${i + 1}`, fallback));
 
   return {
     colors: {
@@ -38,22 +58,39 @@ export function readThemeCssVariables(style: CssVariables): VendoTheme {
       surface: value("--vendo-color-surface", defaultVendoTheme.colors.surface),
       text: value("--vendo-color-text", defaultVendoTheme.colors.text),
       muted: value("--vendo-color-muted", defaultVendoTheme.colors.muted),
-      accent: value("--vendo-color-accent", defaultVendoTheme.colors.accent),
+      accent,
       accentText: value("--vendo-color-accent-text", defaultVendoTheme.colors.accentText),
       danger: value("--vendo-color-danger", defaultVendoTheme.colors.danger),
       border: value("--vendo-color-border", defaultVendoTheme.colors.border),
+      ...override("success", "--vendo-color-success", themeDefaults.colors.success),
+      ...override("warning", "--vendo-color-warning", themeDefaults.colors.warning),
+      ...override("surfaceRaised", "--vendo-color-surface-raised", themeDefaults.colors.surfaceRaised),
     },
     typography: {
       fontFamily: value("--vendo-font-family", defaultVendoTheme.typography.fontFamily),
       ...(headingFamily === undefined ? {} : { headingFamily }),
+      ...override("monoFamily", "--vendo-mono-family", themeDefaults.typography.monoFamily),
       baseSize: value("--vendo-font-size", defaultVendoTheme.typography.baseSize),
+      ...override("weightNormal", "--vendo-font-weight-normal", themeDefaults.typography.weightNormal),
+      ...override("weightEmphasis", "--vendo-font-weight-emphasis", themeDefaults.typography.weightEmphasis),
+      ...override("letterSpacing", "--vendo-letter-spacing", themeDefaults.typography.letterSpacing),
+      ...override("lineHeightBody", "--vendo-line-height", themeDefaults.typography.lineHeightBody),
+      ...override("lineHeightHeading", "--vendo-line-height-heading", themeDefaults.typography.lineHeightHeading),
     },
     radius: {
       small: value("--vendo-radius-small", defaultVendoTheme.radius.small),
       medium: value("--vendo-radius-medium", defaultVendoTheme.radius.medium),
       large: value("--vendo-radius-large", defaultVendoTheme.radius.large),
     },
+    ...(JSON.stringify(shadow) === JSON.stringify(themeDefaults.shadow) ? {} : { shadow }),
     density: density === "compact" || density === "comfortable" ? density : defaultVendoTheme.density,
     motion: motion === "full" || motion === "reduced" ? motion : defaultVendoTheme.motion,
+    ...override("borderWidth", "--vendo-border-width", themeDefaults.borderWidth),
+    ...(chartPalette.join() === chartRamp.join() ? {} : { chartPalette }),
+    // A reduced-motion theme is emitted with its duration zeroed, so 0ms there is
+    // the mapping's own output, not a host's declaration.
+    ...override("motionDuration", "--vendo-motion-duration",
+      motion === "reduced" ? "0ms" : themeDefaults.motionDuration),
+    ...override("motionEasing", "--vendo-motion-easing", themeDefaults.motionEasing),
   };
 }

--- a/packages/ui/test/chrome/s1-recipe.test.ts
+++ b/packages/ui/test/chrome/s1-recipe.test.ts
@@ -9,9 +9,9 @@ describe("S1 recipe", () => {
     expect(CHROME_CSS).not.toMatch(/--vendo-glass/);
   });
 
-  it("derives the hairline border from the host's text color", () => {
+  it("takes the host's border color, defaulting to a mix of its text color", () => {
     expect(CHROME_CSS).toContain(
-      "--vendo-border: color-mix(in srgb, var(--vendo-color-text, #14151a) 8%, transparent)",
+      "--vendo-border: var(--vendo-color-border, color-mix(in srgb, var(--vendo-color-text, #14151a) 8%, transparent))",
     );
   });
 
@@ -64,9 +64,10 @@ describe("S1 recipe", () => {
     expect(CHROME_CSS).not.toMatch(/var\(--vendo-shadow\)/);
   });
 
-  it("uses the M2 duration and easing", () => {
-    expect(CHROME_CSS).toContain("--vendo-duration: 380ms");
-    expect(CHROME_CSS).toContain("--vendo-ease: cubic-bezier(0.32, 0.72, 0, 1)");
+  it("derives the M2 duration and easing from the theme's motion knobs", () => {
+    // The multiplier keeps the chrome's slower feel: 160ms * 2.375 is the M2 380ms.
+    expect(CHROME_CSS).toContain("--vendo-duration: calc(var(--vendo-motion-duration, 160ms) * 2.375)");
+    expect(CHROME_CSS).toContain("--vendo-ease: var(--vendo-motion-easing, cubic-bezier(0.32, 0.72, 0, 1))");
   });
 
   it("every moving thing the chrome added respects prefers-reduced-motion (M29)", () => {

--- a/packages/ui/test/theme-tokens.test.tsx
+++ b/packages/ui/test/theme-tokens.test.tsx
@@ -12,8 +12,9 @@ import { describe, expect, it } from "vitest";
 import type {
   VendoTheme,
 } from "@vendoai/apps/contract";
+import { chartPaletteFor, themeDefaults } from "@vendoai/apps/contract";
 import { defaultVendoTheme, themeCssVariables } from "../src/theme.js";
-import { t } from "../src/kit/tokens.js";
+import { chartSeries, control, t } from "../src/kit/tokens.js";
 import { VendoProvider, createVendoClient } from "../src/index.js";
 import { ChromeRoot } from "../src/chrome/chrome-root.js";
 import { CHROME_CSS } from "../src/chrome/chrome-css.js";
@@ -159,6 +160,51 @@ describe("Kit token fallbacks — an unthemed Kit is the default theme, exactly"
     expect(t.radiusSmall).toBe(`var(--vendo-radius-small, ${defaultVendoTheme.radius.small})`);
     expect(t.radiusMedium).toBe(`var(--vendo-radius-medium, ${defaultVendoTheme.radius.medium})`);
     expect(t.radiusLarge).toBe(`var(--vendo-radius-large, ${defaultVendoTheme.radius.large})`);
+  });
+});
+
+describe("theme v2 — the Kit and the chrome read the new contract tokens", () => {
+  // success/warning were Kit-only literals: the contract now carries them, so
+  // the fallback is read off the default theme like every other color.
+  it("success and warning fall back to the contract's own defaults", () => {
+    expect(t.success).toBe(`var(--vendo-color-success, ${themeDefaults.colors.success})`);
+    expect(t.warning).toBe(`var(--vendo-color-warning, ${themeDefaults.colors.warning})`);
+  });
+
+  it("a Kit control's edge is one host-set border width", () => {
+    expect(control.border).toBe(`var(--vendo-border-width, 1px) solid ${t.border}`);
+  });
+
+  it("chartSeries reads the host's --vendo-chart-N, falling back to the ramp unchanged", () => {
+    const ramp = chartPaletteFor(t.accent);
+    // The six a host's chartPalette can replace…
+    expect(chartSeries.slice(0, 6)).toEqual(
+      ramp.slice(0, 6).map((color, i) => `var(--vendo-chart-${i + 1}, ${color})`),
+    );
+    // …and the tail, which is the ramp and nothing else.
+    expect(chartSeries.slice(6)).toEqual(ramp.slice(6));
+    // The ramp is the one it always was: the accent token, then hue-locked steps.
+    expect(ramp[0]).toBe(t.accent);
+    expect(ramp[1]).toBe(`oklch(from ${t.accent} 0.7 calc(c * 0.9) h)`);
+    expect(chartSeries).toHaveLength(8);
+  });
+
+  it("an explicit host border color now beats the derived hairline", () => {
+    expect(CHROME_CSS).toContain("--vendo-border: var(--vendo-color-border, color-mix(");
+  });
+
+  it("the ok/warn family is anchored on the contract's success/warning", () => {
+    expect(CHROME_CSS).toContain("--vendo-ok: var(--vendo-color-success,");
+    for (const token of ["--vendo-warn", "--vendo-warn-text", "--vendo-warn-edge", "--vendo-warn-tint"]) {
+      expect(CHROME_CSS).toContain(`${token}: var(--vendo-color-warning,`);
+    }
+  });
+
+  it("the chrome's motion derives from the theme's motion pair, one knob for both", () => {
+    expect(CHROME_CSS).toContain("--vendo-duration: calc(var(--vendo-motion-duration, 160ms) *");
+    expect(CHROME_CSS).toContain("--vendo-ease: var(--vendo-motion-easing,");
+    // reduced motion emits 0ms, so the chrome's own timings collapse with it.
+    expect(themeCssVariables({ ...defaultVendoTheme, motion: "reduced" })["--vendo-motion-duration"]).toBe("0ms");
   });
 });
 


### PR DESCRIPTION
## What

A host's theme could set eight colors, a font, a base size, three corner radii, a density and a motion mode. Everything else the product paints — the green and amber on status pills, the monospace stack, the three drop shadows, the chart colors, the border thickness, how fast the chrome animates — was a hardcoded value inside our own source. This PR turns those into theme settings a host can set.

New optional fields on `VendoTheme`:

- `colors.success`, `colors.warning`, `colors.surfaceRaised`
- `typography.monoFamily`, `.weightNormal`, `.weightEmphasis`, `.letterSpacing`, `.lineHeightBody`, `.lineHeightHeading`
- `shadow.small` / `.medium` / `.large` (shaped like the existing `radius` group)
- `borderWidth`, `chartPalette` (up to six series colors), `motionDuration`, `motionEasing`

## Why it is built this way

**Every field is optional.** A theme file that fails to validate is thrown away whole, not partially — so a single required addition would have wiped the brand off every host whose theme file was written before today. A theme with none of these fields parses and renders exactly as it did.

**The CSS variable names are one fixed set (52).** Three different surfaces render the same theme through three different transports — the React chrome, the MCP door's HTML pages, and the MCP Apps shim — and they check each other's output name-for-name. A variable that appears only for hosts who set it would break that check, and the shim's reader rejects any name outside the published list. So each optional field falls back to a default and every name is emitted for every theme.

**`defaultVendoTheme` is deliberately left alone.** It is the shape the MCP Apps shim rebuilds a theme back into; a field the reader cannot recover would make a theme round-trip into a *different* theme. The fill-in values sit beside it as `themeDefaults`, which the Kit also reads for its unthemed fallbacks — so every value still has exactly one definition in the codebase.

## User-visible changes for hosts that already set a theme

Three chrome tokens now read the contract, which changes what a themed host sees:

1. `--vendo-border` — the chrome derived its hairline as ~8% of the text color and *ignored* `colors.border` outright. The derived mix is still the default, but a host that states `colors.border` now wins. Themed hosts will see their own border color on chrome surfaces.
2. `--vendo-ok` / `--vendo-warn` — re-anchored on `colors.success` / `colors.warning`. Because those two are always emitted, a host that sets neither picks up the contract defaults (`#1e7f53` / `#d4a017`) rather than the chrome's previous literals, and the amber's light/dark pair collapses to one value.
3. `--vendo-duration` / `--vendo-ease` — derived from the theme's motion pair, so one host knob moves both the chrome and generated views. The chrome keeps its slower feel through a multiplier (380ms at the default 160ms), and `motion: "reduced"` now collapses chrome timings too.

## Tests

Variable emission is proven beside the contract in `@vendoai/apps`; the Kit and chrome side in `@vendoai/ui`. Covered: a pre-v2 theme still parses; a pre-v2 theme and a fully-loaded one emit identical variable *names*; a host `chartPalette` lands on `--vendo-chart-1..6` and the unset case is the existing OKLCH accent ramp, byte for byte; each new field's default and each host override. The existing three-transport seam test in `@vendoai/vendo` was run untouched and stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds theme v2: 19 optional brand tokens across `@vendoai/apps` and `@vendoai/ui`, plus MCP Apps shim and chrome updates so hosts can set success/warning, mono, shadows, border width, chart palette, and motion without breaking older themes.

- Contract: Extends `VendoTheme` with optional `colors.success`/`warning`/`surfaceRaised`, `typography.monoFamily`/`weightNormal`/`weightEmphasis`/`letterSpacing`/`lineHeightBody`/`lineHeightHeading`, `shadow`, `borderWidth`, `chartPalette`, `motionDuration`, `motionEasing`. Truncates `chartPalette` >6 with a warning. Emits a fixed variable set by resolving optionals via `themeDefaults`; `defaultVendoTheme` stays unchanged.
- Chrome: `--vendo-border` now uses `var(--vendo-color-border, <derived mix>)`; ok/warn anchor on `colors.success`/`colors.warning`; `--vendo-duration`/`--vendo-ease` derive from `--vendo-motion-*` with a multiplier and collapse to 0ms in reduced motion; mono reads `--vendo-mono-family` with the system stack as fallback.
- Kit: Reads contract success/warning, uses `--vendo-border-width` for control edges, and sources charts from `--vendo-chart-1..6` with the accent OKLCH ramp as fallback.
- Shim: Recovers all v2 fields from CSS variables and writes them back only when they differ from `themeDefaults` (including treating reduced motion’s zeroed duration as mapping output), preserving byte-identical round-trips for legacy themes.

**Rollout**
- No migration required; pre-v2 themes parse and render unchanged and variable names stay stable.
- Hosts can opt into any subset; palettes longer than 6 are truncated with a warning.
- Setting motion to "reduced" forces 0ms regardless of the requested duration.

<sup>Written for commit aceeb945c75ba77d74205e0fe46fcdc515c482c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

