### PR TITLE
feat(ui,apps): six static bricks join the Kit

### DIFF
--- a/.changeset/kit-static-bricks.md
+++ b/.changeset/kit-static-bricks.md
@@ -1,0 +1,23 @@
+---
+"@vendoai/apps": minor
+"@vendoai/ui": minor
+---
+
+Six static bricks join the Kit, for the shapes a screen could only fake with a
+Stack and a Text: `KeyValue`, `Timeline`, `Avatar`, `CodeBlock`, `EmptyState`
+and `Steps`.
+
+`<KeyValue record items/>` lays ONE record out as label/value rows — the detail
+a table row expands into — and `<Timeline entries/>` runs a record history down
+a dotted spine. Both take a `cell` slot on the DataTable contract: the slot
+holds an element, the container publishes the record, and the components inside
+name their field. `<Avatar name/>` draws initials in a tint hashed off the name,
+so one person is one color everywhere, and adjacent avatars in a `Row` stack.
+`<CodeBlock code language/>` shows a payload verbatim — no highlighting, no copy
+button. `<EmptyState icon title description>` is the designed nothing-here with
+the action that fixes it nested inside, and `<Steps items active/>` is the
+progress trail, horizontal or vertical.
+
+Every one is themed through the host's own `--vendo-*` variables and reads the
+new `--vendo-border-width`, `--vendo-mono-family` and `--vendo-color-surface-raised`
+tokens through a fallback, so an unthemed host is unchanged.

--- a/packages/apps/src/contract/island-ambient.ts
+++ b/packages/apps/src/contract/island-ambient.ts
@@ -42,10 +42,10 @@ export const ISLAND_AMBIENT_REACT_NAMES = [
 export const ISLAND_AMBIENT_KIT_NAMES = [
   "Stack", "Row", "Grid", "Surface", "Card", "Divider",
   "Text", "Money", "DateTime", "Percent", "Num", "EnumBadge", "Icon",
-  "DataTable", "CardList", "Stat", "Badge",
+  "DataTable", "CardList", "Stat", "Badge", "KeyValue", "Timeline", "Avatar", "CodeBlock",
   "LineChart", "BarChart", "DonutChart", "Sparkline", "Progress",
   "Input", "Select", "DatePicker", "Textarea", "Checkbox", "Button", "Form", "Disclaimer",
-  "Tabs", "Callout", "Accordion",
+  "Tabs", "Callout", "Accordion", "EmptyState", "Steps",
 ] as const;
 
 /** `fmt` (Kit semantics formatters) and `tools` (the guarded host-tool pipe). */

--- a/packages/apps/src/contract/kit/specs.ts
+++ b/packages/apps/src/contract/kit/specs.ts
@@ -283,6 +283,58 @@ const BASE_SPECS: KitComponentSpec[] = [
     props: { label: copy(z.string(), "badge text") },
     examples: ['<Badge label="Beta" tone="accent"/>'],
   },
+  {
+    name: "KeyValue",
+    group: "data",
+    summary: "ONE record's fields as label/value rows — the detail a table row expands into. A field takes a `cell` slot, exactly as a table column does.",
+    props: {
+      record: data(z.record(z.string(), z.unknown()), "the record from a tool call", { required: true }),
+      items: config(z.array(cardField), "the fields to show; key supports dot-paths; format is a value tier token; cell is a slot", { required: true }),
+      dividers: config(z.boolean(), "hairline rule between rows"),
+    },
+    examples: [
+      '<KeyValue record={invoices.get({id}).data} items={[{key:"client.name",label:"Client"},{key:"amount",format:"money"},{key:"status",cell:<EnumBadge field="status"/>}]} dividers/>',
+    ],
+  },
+  {
+    name: "Timeline",
+    group: "data",
+    summary: "A history down a spine: one dot-marked entry per record, in the order the tool returned them. `cell` renders Kit components for each entry instead of a title field.",
+    props: {
+      entries: data(rows, "entries from a tool call", { required: true }),
+      titleField: config(z.string(), "field for each entry's title"),
+      timeField: config(z.string(), "field holding each entry's timestamp"),
+      timeAlign: config(z.enum(["start", "end"]), "where the timestamp sits: start (default) or end"),
+      cell: config(slot, "Kit elements rendered as each entry's body; the components inside name their field"),
+      marker: config(slot, "a Kit element drawn in place of the dot"),
+      emptyState: copy(z.string(), "text when there are no entries"),
+    },
+    examples: [
+      '<Timeline entries={payments.list({}).data} titleField="description" timeField="paidAt" timeAlign="end"/>',
+    ],
+  },
+  {
+    name: "Avatar",
+    group: "data",
+    summary: "Initials in a tint derived from the name, so one person is one color everywhere. No image — the Kit fetches nothing. Adjacent avatars in a Row stack.",
+    props: {
+      name: data(z.string(), "the person or account name", { required: true }),
+      size: config(z.enum(["sm", "md", "lg"]), "disc size, default md"),
+    },
+    examples: [
+      '<Row gap={6} align="center"><Avatar name={client.name}/><Text field="name"/></Row>',
+    ],
+  },
+  {
+    name: "CodeBlock",
+    group: "data",
+    summary: "Monospaced code or a raw payload with a language chip. Shows the text exactly as it came — no highlighting, no copy button.",
+    props: {
+      code: data(z.string(), "the code or payload to show", { required: true }),
+      language: config(z.string(), "language label for the chip, e.g. json"),
+    },
+    examples: ['<CodeBlock language="json" code={webhooks.get({id}).data.payload}/>'],
+  },
 
   // Charts (recharts internals; data props only; $NaN is unrenderable)
   {
@@ -502,6 +554,31 @@ const BASE_SPECS: KitComponentSpec[] = [
       multiple: config(z.boolean(), "allow several open at once"),
     },
     examples: ["<Accordion items={[{label:\"Terms\",content:<Text .../>}]}/>"],
+  },
+  {
+    name: "EmptyState",
+    takesChildren: true,
+    group: "feedback",
+    summary: "The designed nothing-here for a whole region, with the action that fixes it nested inside. A component with its own emptyState prop (DataTable, CardList) already has one.",
+    props: {
+      icon: config(z.string(), "lucide icon name in kebab-case"),
+      title: copy(z.string(), "the headline", { required: true }),
+      description: copy(z.string(), "one line of why it is empty, or what to do"),
+    },
+    examples: [
+      '<EmptyState icon="inbox" title="No invoices yet" description="They show up here the moment one is issued."><Button label="New invoice" onClick="invoices.create"/></EmptyState>',
+    ],
+  },
+  {
+    name: "Steps",
+    group: "feedback",
+    summary: "A progress trail. `active` is the current step's index; everything before it reads as done, everything after as still to come.",
+    props: {
+      items: config(z.array(z.object({ label: z.string(), description: z.string().optional() })), "the steps in order", { required: true }),
+      active: config(z.number().int().nonnegative(), "index of the current step, default 0"),
+      orientation: config(z.enum(["horizontal", "vertical"]), "layout, default horizontal"),
+    },
+    examples: ['<Steps items={[{label:"Details"},{label:"Review"},{label:"Done"}]} active={1}/>'],
   },
 ];
 

--- a/packages/apps/tests/checking/screen-tsc-vocabulary.test.ts
+++ b/packages/apps/tests/checking/screen-tsc-vocabulary.test.ts
@@ -93,6 +93,10 @@ const BROAD_SCREEN = `<App name="Cash flow">
       columns={[{ key: "label", label: "Period" }, { key: "in", format: "money", align: "end" }]}
       filterableBy={["label"]} emptyState="No periods" caption="Cash flow"/>
     <CardList items={cashflow.data} titleField="label" fields={[{ key: "in", label: "In", format: "money" }]} columns={2}/>
+    <KeyValue record={cashflow.data[0]} items={[{ key: "label", label: "Period" }, { key: "in", format: "money" }]} dividers={true}/>
+    <Timeline entries={cashflow.data} titleField="label" emptyState="No history"/>
+    <Avatar name="Ada Lovelace" size="sm"/>
+    <CodeBlock language="json" code="const rate = 0.42;"/>
     <Money amount={cashflow.data.reduce((total, row) => total + row.in, 0) / 100} currency="USD"/>
     <Percent value={0.42} fractionDigits={1}/>
     <Num value={12} notation="compact"/>
@@ -113,6 +117,8 @@ const BROAD_SCREEN = `<App name="Cash flow">
     <Button label="Refresh" onClick="host_getCashflowInsights" variant="primary"/>
     <Tabs tabs={["In", "Out"]} value="In"><Text text="Money in"/><Text text="Money out"/></Tabs>
     <Disclaimer reason="No tool exposes forecasts." title="Not shown"/>
+    <EmptyState icon="inbox" title="No periods" description="They appear the moment one closes."><Button label="Refresh" onClick="host_getCashflowInsights"/></EmptyState>
+    <Steps items={[{ label: "Details" }, { label: "Review", description: "Check the totals" }, { label: "Done" }]} active={1}/>
     <Text text="Grouped" pending={true}/>
     <Sparkline data={cashflow.data.map((row) => ({ label: row.label, value: row.in }))} valueKey="value"/>
   </Stack>

--- a/packages/apps/tests/format-conformance.e2e.test.ts
+++ b/packages/apps/tests/format-conformance.e2e.test.ts
@@ -49,10 +49,10 @@ const LIMITS = {
 
 /** The component vocabulary a generated app may name without a source map. */
 const VOCABULARY = [
-  "Accordion", "Badge", "BarChart", "Button", "Callout", "Card", "CardList", "Checkbox", "DataTable",
-  "DatePicker", "DateTime", "Disclaimer", "Divider", "DonutChart", "EnumBadge", "Form", "Grid", "Icon", "Input",
-  "LineChart", "Money", "Num", "Percent", "Progress", "Row", "Select", "Sparkline", "Stack", "Stat",
-  "Surface", "Tabs", "Text", "Textarea",
+  "Accordion", "Avatar", "Badge", "BarChart", "Button", "Callout", "Card", "CardList", "Checkbox", "CodeBlock",
+  "DataTable", "DatePicker", "DateTime", "Disclaimer", "Divider", "DonutChart", "EmptyState", "EnumBadge", "Form",
+  "Grid", "Icon", "Input", "KeyValue", "LineChart", "Money", "Num", "Percent", "Progress", "Row", "Select",
+  "Sparkline", "Stack", "Stat", "Steps", "Surface", "Tabs", "Text", "Textarea", "Timeline",
 ];
 
 const DOCS_FORMAT_PAGE = readFileSync(

--- a/packages/ui/src/kit/data/avatar.tsx
+++ b/packages/ui/src/kit/data/avatar.tsx
@@ -1,0 +1,77 @@
+/** Avatar — initials in a tint derived from the name (W2 §The Kit). No image:
+ *  a host's avatar URL is not something the Kit fetches. */
+import type { CSSProperties } from "react";
+import { font, seriesColor, t } from "../tokens.js";
+
+export interface AvatarProps {
+  /** The person or account this stands for; both the initials and the tint
+   *  come from it, so the same name is the same disc everywhere. */
+  name?: string;
+  size?: "sm" | "md" | "lg";
+}
+
+const SIZES = { sm: 24, md: 32, lg: 44 } as const;
+
+/** Adjacent avatars in a Row overlap into a stack. It is a SIBLING relation, so
+ *  no inline style can say it; React hoists and de-duplicates this one rule by
+ *  `href`, however many avatars ask for it. The pull cancels the Row's own
+ *  default gap first, then bites into the disc. */
+const STACK_CSS =
+  '[data-kit="Row"] > [data-kit="Avatar"] + [data-kit="Avatar"]' +
+  "{margin-inline-start:calc(var(--vendo-density-content-gap, 10px) * -1 - var(--vendo-kit-avatar-size) * 0.32)}";
+
+/** First letter of each of the first two words — "Ada Lovelace" → "AL". */
+function initials(name: string): string {
+  return name
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((word) => [...word][0]?.toUpperCase() ?? "")
+    .join("");
+}
+
+/** Same name, same color, on every render and every machine: a sum over the
+ *  code points, indexed into the accent ramp the charts already speak. */
+function tint(name: string): string {
+  let hash = 0;
+  for (const char of name) hash = (hash * 31 + char.codePointAt(0)!) >>> 0;
+  return seriesColor(hash);
+}
+
+export function Avatar({ name = "", size = "md" }: AvatarProps) {
+  const px = SIZES[size] ?? SIZES.md;
+  const seed = tint(name);
+  return (
+    <>
+      <style href="vendo-kit-avatar" precedence="default">{STACK_CSS}</style>
+      <span
+        data-kit="Avatar"
+        data-size={size}
+        {...(name === "" ? { "aria-hidden": true } : { role: "img", "aria-label": name })}
+        style={{
+          ...font,
+          "--vendo-kit-avatar-size": `${px}px`,
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          flexShrink: 0,
+          width: px,
+          height: px,
+          borderRadius: "50%",
+          background: `color-mix(in srgb, ${seed} 18%, ${t.surface})`,
+          color: `color-mix(in srgb, ${seed} 80%, ${t.text})`,
+          // The ring is what keeps a stacked disc readable against the one
+          // behind it, and reads as nothing on a plain surface.
+          boxShadow: `0 0 0 calc(var(--vendo-border-width, 1px) * 2) ${t.surface}`,
+          fontSize: Math.round(px * 0.38),
+          fontWeight: 650,
+          letterSpacing: "0.02em",
+          lineHeight: 1,
+          userSelect: "none",
+        } as CSSProperties}
+      >
+        {initials(name)}
+      </span>
+    </>
+  );
+}

--- a/packages/ui/src/kit/data/avatar.tsx
+++ b/packages/ui/src/kit/data/avatar.tsx
@@ -14,11 +14,11 @@ const SIZES = { sm: 24, md: 32, lg: 44 } as const;
 
 /** Adjacent avatars in a Row overlap into a stack. It is a SIBLING relation, so
  *  no inline style can say it; React hoists and de-duplicates this one rule by
- *  `href`, however many avatars ask for it. The pull cancels the Row's own
- *  default gap first, then bites into the disc. */
+ *  `href`, however many avatars ask for it. The pull cancels the gap the Row
+ *  resolved — default or explicit — first, then bites into the disc. */
 const STACK_CSS =
   '[data-kit="Row"] > [data-kit="Avatar"] + [data-kit="Avatar"]' +
-  "{margin-inline-start:calc(var(--vendo-density-content-gap, 10px) * -1 - var(--vendo-kit-avatar-size) * 0.32)}";
+  "{margin-inline-start:calc(var(--vendo-kit-row-gap, 10px) * -1 - var(--vendo-kit-avatar-size) * 0.32)}";
 
 /** First letter of each of the first two words — "Ada Lovelace" → "AL". */
 function initials(name: string): string {

--- a/packages/ui/src/kit/data/code-block.tsx
+++ b/packages/ui/src/kit/data/code-block.tsx
@@ -1,0 +1,62 @@
+/** CodeBlock — code or a raw payload, shown exactly as it came (W2 §The Kit).
+ *  No highlighting (a parser is a dependency) and no copy button (the clipboard
+ *  is a permission the jail does not have). */
+import { font, t } from "../tokens.js";
+
+export interface CodeBlockProps {
+  /** The code / payload to show. */
+  code?: string;
+  /** Language label for the chip, e.g. "json". */
+  language?: string;
+}
+
+const mono = "var(--vendo-mono-family, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace)";
+
+export function CodeBlock({ code = "", language }: CodeBlockProps) {
+  return (
+    <div
+      data-kit="CodeBlock"
+      data-language={language}
+      style={{
+        ...font,
+        position: "relative",
+        border: `var(--vendo-border-width, 1px) solid ${t.border}`,
+        borderRadius: t.radiusMedium,
+        background: `var(--vendo-color-surface-raised, color-mix(in srgb, ${t.background} 60%, ${t.surface}))`,
+        boxShadow: `var(--vendo-shadow-small, 0 1px 2px color-mix(in srgb, ${t.text} 6%, transparent))`,
+        overflow: "hidden",
+      }}
+    >
+      {language ? (
+        <span
+          style={{
+            position: "absolute",
+            insetInlineEnd: 10,
+            insetBlockStart: 8,
+            color: t.muted,
+            fontSize: "0.68em",
+            fontWeight: 650,
+            letterSpacing: "0.09em",
+            textTransform: "uppercase",
+            userSelect: "none",
+          }}
+        >
+          {language}
+        </span>
+      ) : null}
+      <pre
+        style={{
+          margin: 0,
+          padding: "var(--vendo-density-card-padding, 12px 14px)",
+          overflowX: "auto",
+          fontFamily: mono,
+          fontSize: "0.85em",
+          lineHeight: 1.55,
+          tabSize: 2,
+        }}
+      >
+        <code style={{ fontFamily: mono }}>{code}</code>
+      </pre>
+    </div>
+  );
+}

--- a/packages/ui/src/kit/data/key-value.tsx
+++ b/packages/ui/src/kit/data/key-value.tsx
@@ -2,7 +2,7 @@
 import { Fragment, type ReactNode } from "react";
 import { applyFormat, type ValueFormat } from "../format.js";
 import { readField, RowContext } from "../row.js";
-import { densityVars, font, t, type KitDensity } from "../tokens.js";
+import { font, t } from "../tokens.js";
 import { humanizeEnum } from "../values.js";
 
 export interface KeyValueItem {
@@ -25,11 +25,9 @@ export interface KeyValueProps {
   items: KeyValueItem[];
   /** Hairline rule between rows. */
   dividers?: boolean;
-  /** Spacing scale for this list's subtree. */
-  density?: KitDensity;
 }
 
-export function KeyValue({ record, items = [], dividers = false, density }: KeyValueProps) {
+export function KeyValue({ record, items = [], dividers = false }: KeyValueProps) {
   return (
     // One provider for the whole list — a row's slot reads its field off it.
     <RowContext.Provider value={record}>
@@ -37,7 +35,6 @@ export function KeyValue({ record, items = [], dividers = false, density }: KeyV
         data-kit="KeyValue"
         style={{
           ...font,
-          ...densityVars(density),
           display: "grid",
           gridTemplateColumns: "minmax(0, auto) minmax(0, 1fr)",
           alignItems: "baseline",

--- a/packages/ui/src/kit/data/key-value.tsx
+++ b/packages/ui/src/kit/data/key-value.tsx
@@ -1,0 +1,92 @@
+/** KeyValue — one record's fields as two-column label/value rows (W2 §The Kit). */
+import { Fragment, type ReactNode } from "react";
+import { applyFormat, type ValueFormat } from "../format.js";
+import { readField, RowContext } from "../row.js";
+import { densityVars, font, t, type KitDensity } from "../tokens.js";
+import { humanizeEnum } from "../values.js";
+
+export interface KeyValueItem {
+  /** Field key; supports dot-paths ("client.name"). */
+  key: string;
+  /** Row label; defaults to a humanized last path segment. */
+  label?: string;
+  /** Value-tier format applied to the value. */
+  format?: ValueFormat;
+  /** Kit elements rendered as this row's VALUE (the label stays), with the
+   *  record published on `RowContext` so the components inside name their
+   *  field — the DataTable cell contract, for a single record. */
+  cell?: ReactNode;
+}
+
+export interface KeyValueProps {
+  /** The record being described, from a tool call. */
+  record: Record<string, unknown>;
+  /** The fields to show, in order. */
+  items: KeyValueItem[];
+  /** Hairline rule between rows. */
+  dividers?: boolean;
+  /** Spacing scale for this list's subtree. */
+  density?: KitDensity;
+}
+
+export function KeyValue({ record, items = [], dividers = false, density }: KeyValueProps) {
+  return (
+    // One provider for the whole list — a row's slot reads its field off it.
+    <RowContext.Provider value={record}>
+      <dl
+        data-kit="KeyValue"
+        style={{
+          ...font,
+          ...densityVars(density),
+          display: "grid",
+          gridTemplateColumns: "minmax(0, auto) minmax(0, 1fr)",
+          alignItems: "baseline",
+          columnGap: "var(--vendo-density-content-gap, 10px)",
+          rowGap: "var(--vendo-density-field-gap, 6px)",
+          margin: 0,
+        }}
+      >
+        {items.map((item, index) => {
+          const edge = !dividers || index === items.length - 1
+            ? {}
+            : {
+                borderBottom: `var(--vendo-border-width, 1px) solid ${t.border}`,
+                paddingBottom: "var(--vendo-density-field-gap, 6px)",
+              };
+          return (
+            <Fragment key={item.key}>
+              <dt
+                style={{
+                  ...edge,
+                  color: t.muted,
+                  fontSize: "0.72em",
+                  fontWeight: 650,
+                  letterSpacing: "0.07em",
+                  textTransform: "uppercase",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {item.label ?? humanizeEnum(item.key.split(".").pop() ?? item.key)}
+              </dt>
+              <dd
+                style={{
+                  ...edge,
+                  margin: 0,
+                  justifySelf: "end",
+                  textAlign: "right",
+                  minWidth: 0,
+                  fontVariantNumeric: "tabular-nums",
+                  overflowWrap: "anywhere",
+                }}
+              >
+                {item.cell ?? applyFormat(readField(record, item.key), item.format ?? "text") ?? (
+                  <span style={{ color: t.muted }}>—</span>
+                )}
+              </dd>
+            </Fragment>
+          );
+        })}
+      </dl>
+    </RowContext.Provider>
+  );
+}

--- a/packages/ui/src/kit/data/timeline.tsx
+++ b/packages/ui/src/kit/data/timeline.tsx
@@ -1,0 +1,135 @@
+/** Timeline — a record history down a spine, dot-marked (W2 §The Kit). */
+import type { ReactNode } from "react";
+import { applyFormat } from "../format.js";
+import { readField, RowContext } from "../row.js";
+import { densityVars, font, t, type KitDensity } from "../tokens.js";
+
+export interface TimelineProps {
+  /** Entries from a tool call, in the order they should read. */
+  entries: Array<Record<string, unknown>>;
+  /** Field for each entry's title. */
+  titleField?: string;
+  /** Field holding each entry's timestamp. */
+  timeField?: string;
+  /** Where the timestamp sits: leading the title, or right-aligned. */
+  timeAlign?: "start" | "end";
+  /** Kit elements rendered as each entry's BODY instead of the title, with that
+   *  entry published on `RowContext` so the components inside name their field
+   *  — the DataTable cell contract, once per entry. */
+  cell?: ReactNode;
+  /** Kit element drawn in place of the dot. */
+  marker?: ReactNode;
+  /** Text shown when there are no entries. */
+  emptyState?: string;
+  /** Spacing scale for this timeline's subtree. */
+  density?: KitDensity;
+}
+
+/** A timestamp field is a date most of the time and a plain label the rest of
+ *  it; an unformattable value reads as itself rather than disappearing. */
+function timeText(value: unknown): string {
+  return applyFormat(value, "datetime") ?? (value === undefined || value === null ? "" : String(value));
+}
+
+export function Timeline({
+  entries: rawEntries,
+  titleField,
+  timeField,
+  timeAlign = "start",
+  cell,
+  marker,
+  emptyState = "No activity",
+  density,
+}: TimelineProps) {
+  // W3 — fail SOFT on missing data (a failed query resolves to undefined).
+  const entries = Array.isArray(rawEntries) ? rawEntries : [];
+  if (entries.length === 0) {
+    return (
+      <div
+        data-kit="Timeline"
+        style={{
+          ...font,
+          color: t.muted,
+          textAlign: "center",
+          border: `var(--vendo-border-width, 1px) dashed ${t.border}`,
+          borderRadius: t.radiusMedium,
+          padding: "calc(var(--vendo-font-size, 15px) * 1.6)",
+        }}
+      >
+        {emptyState}
+      </div>
+    );
+  }
+  return (
+    <ol
+      data-kit="Timeline"
+      style={{ ...font, ...densityVars(density), display: "flex", flexDirection: "column", listStyle: "none", margin: 0, padding: 0 }}
+    >
+      {entries.map((entry, index) => {
+        const time = timeField === undefined ? "" : timeText(readField(entry, timeField));
+        const title = titleField === undefined ? null : String(readField(entry, titleField) ?? "—");
+        return (
+          <RowContext.Provider key={String(readField(entry, "id") ?? index)} value={entry}>
+            <li style={{ display: "flex", gap: "var(--vendo-density-content-gap, 10px)", minWidth: 0 }}>
+              <div style={{ display: "flex", flexDirection: "column", alignItems: "center", flexShrink: 0 }}>
+                {marker ?? (
+                  <span
+                    aria-hidden="true"
+                    style={{
+                      width: 9,
+                      height: 9,
+                      marginTop: "0.45em",
+                      borderRadius: "50%",
+                      background: t.accent,
+                      boxShadow: `0 0 0 calc(var(--vendo-border-width, 1px) * 3) color-mix(in srgb, ${t.accent} 14%, transparent)`,
+                    }}
+                  />
+                )}
+                {/* The spine joins this entry to the next, so the last one ends
+                    at its dot instead of trailing a stub. */}
+                {index < entries.length - 1 ? (
+                  <span style={{ flex: 1, marginTop: 5, borderLeft: `var(--vendo-border-width, 1px) solid ${t.border}` }} />
+                ) : null}
+              </div>
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: timeAlign === "end" ? "row" : "column",
+                  justifyContent: "space-between",
+                  alignItems: timeAlign === "end" ? "baseline" : "stretch",
+                  gap: timeAlign === "end" ? "var(--vendo-density-content-gap, 10px)" : 2,
+                  flex: 1,
+                  minWidth: 0,
+                  paddingBottom: index === entries.length - 1 ? 0 : "var(--vendo-density-content-gap, 10px)",
+                }}
+              >
+                {timeAlign === "start" && time ? <TimeText time={time} /> : null}
+                <div style={{ minWidth: 0, fontWeight: 600, lineHeight: 1.4 }}>{cell ?? title}</div>
+                {timeAlign === "end" && time ? <TimeText time={time} /> : null}
+              </div>
+            </li>
+          </RowContext.Provider>
+        );
+      })}
+    </ol>
+  );
+}
+
+function TimeText({ time }: { time: string }) {
+  return (
+    <span
+      style={{
+        color: t.muted,
+        flexShrink: 0,
+        fontSize: "0.72em",
+        fontWeight: 650,
+        letterSpacing: "0.07em",
+        textTransform: "uppercase",
+        fontVariantNumeric: "tabular-nums",
+        whiteSpace: "nowrap",
+      }}
+    >
+      {time}
+    </span>
+  );
+}

--- a/packages/ui/src/kit/data/timeline.tsx
+++ b/packages/ui/src/kit/data/timeline.tsx
@@ -2,7 +2,7 @@
 import type { ReactNode } from "react";
 import { applyFormat } from "../format.js";
 import { readField, RowContext } from "../row.js";
-import { densityVars, font, t, type KitDensity } from "../tokens.js";
+import { font, t } from "../tokens.js";
 
 export interface TimelineProps {
   /** Entries from a tool call, in the order they should read. */
@@ -21,8 +21,6 @@ export interface TimelineProps {
   marker?: ReactNode;
   /** Text shown when there are no entries. */
   emptyState?: string;
-  /** Spacing scale for this timeline's subtree. */
-  density?: KitDensity;
 }
 
 /** A timestamp field is a date most of the time and a plain label the rest of
@@ -39,7 +37,6 @@ export function Timeline({
   cell,
   marker,
   emptyState = "No activity",
-  density,
 }: TimelineProps) {
   // W3 — fail SOFT on missing data (a failed query resolves to undefined).
   const entries = Array.isArray(rawEntries) ? rawEntries : [];
@@ -63,7 +60,7 @@ export function Timeline({
   return (
     <ol
       data-kit="Timeline"
-      style={{ ...font, ...densityVars(density), display: "flex", flexDirection: "column", listStyle: "none", margin: 0, padding: 0 }}
+      style={{ ...font, display: "flex", flexDirection: "column", listStyle: "none", margin: 0, padding: 0 }}
     >
       {entries.map((entry, index) => {
         const time = timeField === undefined ? "" : timeText(readField(entry, timeField));

--- a/packages/ui/src/kit/feedback/empty-state.tsx
+++ b/packages/ui/src/kit/feedback/empty-state.tsx
@@ -1,0 +1,58 @@
+/** EmptyState — the designed nothing-here, with the action that fixes it
+ *  nested inside (W2 §The Kit). Same dashed frame the charts' empty state uses,
+ *  so an empty region reads as intentional rather than broken. */
+import type { PropsWithChildren } from "react";
+import { Icon } from "../icon.js";
+import { font, t } from "../tokens.js";
+
+export interface EmptyStateProps {
+  /** A lucide icon name in kebab-case; an unknown one draws nothing. */
+  icon?: string;
+  /** The headline. */
+  title: string;
+  /** One line of why it is empty, or what to do about it. */
+  description?: string;
+}
+
+export function EmptyState({ icon, title, description, children }: PropsWithChildren<EmptyStateProps>) {
+  return (
+    <div
+      data-kit="EmptyState"
+      style={{
+        ...font,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: "var(--vendo-density-field-gap, 6px)",
+        border: `var(--vendo-border-width, 1px) dashed ${t.border}`,
+        borderRadius: t.radiusMedium,
+        background: `color-mix(in srgb, ${t.background} 40%, transparent)`,
+        padding: "calc(var(--vendo-font-size, 15px) * 1.8) var(--vendo-density-card-padding, 16px)",
+        textAlign: "center",
+      }}
+    >
+      {icon ? (
+        <span
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            width: 38,
+            height: 38,
+            marginBottom: 2,
+            borderRadius: "50%",
+            background: `color-mix(in srgb, ${t.accent} 10%, ${t.surface})`,
+            color: t.accent,
+          }}
+        >
+          <Icon name={icon} size={19} />
+        </span>
+      ) : null}
+      <span style={{ fontFamily: t.headingFamily, fontWeight: 650, letterSpacing: "-0.015em" }}>{title}</span>
+      {description ? (
+        <span style={{ color: t.muted, fontSize: "0.9em", lineHeight: 1.45, maxWidth: "44ch" }}>{description}</span>
+      ) : null}
+      {children}
+    </div>
+  );
+}

--- a/packages/ui/src/kit/feedback/steps.tsx
+++ b/packages/ui/src/kit/feedback/steps.tsx
@@ -1,0 +1,97 @@
+/** Steps — a progress trail: what is done, what is happening, what is left
+ *  (W2 §The Kit). Everything before `active` reads as done. */
+import { Icon } from "../icon.js";
+import { font, t } from "../tokens.js";
+
+export interface StepItem {
+  label: string;
+  description?: string;
+}
+
+export interface StepsProps {
+  /** The steps, in order. */
+  items: StepItem[];
+  /** Index of the current step. */
+  active?: number;
+  orientation?: "horizontal" | "vertical";
+}
+
+type StepState = "done" | "current" | "todo";
+
+export function Steps({ items = [], active = 0, orientation = "horizontal" }: StepsProps) {
+  const vertical = orientation === "vertical";
+  return (
+    <ol
+      data-kit="Steps"
+      data-orientation={orientation}
+      style={{
+        ...font,
+        display: "flex",
+        flexDirection: vertical ? "column" : "row",
+        gap: vertical ? "var(--vendo-density-content-gap, 10px)" : "var(--vendo-density-inline-gap, 7px)",
+        listStyle: "none",
+        margin: 0,
+        padding: 0,
+      }}
+    >
+      {items.map((item, index) => {
+        const state: StepState = index < active ? "done" : index === active ? "current" : "todo";
+        // The rule leading each step is the progress itself — accent behind and
+        // at the current step, the plain hairline ahead of it.
+        const rule = `2px solid ${state === "todo" ? t.border : t.accent}`;
+        return (
+          <li
+            key={`${item.label}-${index}`}
+            data-step-state={state}
+            {...(state === "current" ? { "aria-current": "step" } : {})}
+            style={{
+              display: "flex",
+              gap: "var(--vendo-density-inline-gap, 7px)",
+              minWidth: 0,
+              ...(vertical
+                ? { borderInlineStart: rule, paddingInlineStart: 10 }
+                : { flex: "1 1 0", borderBlockStart: rule, paddingBlockStart: 8 }),
+            }}
+          >
+            <span
+              aria-hidden="true"
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                flexShrink: 0,
+                width: 20,
+                height: 20,
+                borderRadius: "50%",
+                border: state === "current" ? `2px solid ${t.accent}` : `var(--vendo-border-width, 1px) solid ${t.border}`,
+                background: state === "done" ? t.accent : "transparent",
+                color: state === "done" ? t.accentText : state === "current" ? t.accent : t.muted,
+                fontSize: "0.68em",
+                fontWeight: 700,
+                fontVariantNumeric: "tabular-nums",
+                lineHeight: 1,
+              }}
+            >
+              {state === "done" ? <Icon name="check" size={12} /> : index + 1}
+            </span>
+            <div style={{ display: "flex", flexDirection: "column", gap: 2, minWidth: 0 }}>
+              <span
+                style={{
+                  color: state === "todo" ? t.muted : t.text,
+                  fontSize: "0.9em",
+                  fontWeight: state === "current" ? 700 : 600,
+                  letterSpacing: "-0.01em",
+                }}
+              >
+                {item.label}
+              </span>
+              {item.description ? (
+                <span style={{ color: t.muted, fontSize: "0.78em", lineHeight: 1.4 }}>{item.description}</span>
+              ) : null}
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/packages/ui/src/kit/index.ts
+++ b/packages/ui/src/kit/index.ts
@@ -36,6 +36,10 @@ export { DataTable, type DataTableColumn, type DataTableProps } from "./data/dat
 export { CardList, type CardField, type CardListProps } from "./data/card-list.js";
 export { Stat, type StatProps } from "./data/stat.js";
 export { Badge, type BadgeProps } from "./data/badge.js";
+export { KeyValue, type KeyValueItem, type KeyValueProps } from "./data/key-value.js";
+export { Timeline, type TimelineProps } from "./data/timeline.js";
+export { Avatar, type AvatarProps } from "./data/avatar.js";
+export { CodeBlock, type CodeBlockProps } from "./data/code-block.js";
 export { LineChart, type LineChartProps, type SeriesInput } from "./charts/line.js";
 export { BarChart, type BarChartProps } from "./charts/bar.js";
 export { DonutChart, type DonutChartProps } from "./charts/donut.js";
@@ -59,6 +63,8 @@ export { Disclaimer, type DisclaimerProps } from "./forms/disclaimer.js";
 export { Tabs, type TabsProps, type TabItem } from "./feedback/tabs.js";
 export { Callout, type CalloutProps, type CalloutTone } from "./feedback/callout.js";
 export { Accordion, type AccordionProps, type AccordionItem } from "./feedback/accordion.js";
+export { EmptyState, type EmptyStateProps } from "./feedback/empty-state.js";
+export { Steps, type StepsProps, type StepItem } from "./feedback/steps.js";
 
 // The theme the Kit's tokens read, and the embedded-surface runtime that applies
 // it — reachable from a generated app's box, where `@vendoai/ui`'s root barrel

--- a/packages/ui/src/kit/layout.tsx
+++ b/packages/ui/src/kit/layout.tsx
@@ -52,18 +52,23 @@ const justifyMap: Record<string, CSSProperties["justifyContent"]> = {
 
 /** Horizontal flow. */
 export function Row({ gap, align = "center", justify = "start", wrap = true, density, children }: PropsWithChildren<RowProps>) {
+  // Avatar's stack rule pulls its sibling back by the row's gap, and a numeric
+  // `gap` never reaches the density variable — so the row publishes whichever
+  // gap it resolved.
+  const resolved = gapVar(gap);
   return (
     <div
       data-kit="Row"
       style={{
         ...densityVars(density),
+        "--vendo-kit-row-gap": resolved,
         display: "flex",
         flexDirection: "row",
         flexWrap: wrap ? "wrap" : "nowrap",
         alignItems: alignMap[align],
         justifyContent: justifyMap[justify],
-        gap: gapVar(gap),
-      }}
+        gap: resolved,
+      } as CSSProperties}
     >
       {children}
     </div>

--- a/packages/ui/src/kit/registry.ts
+++ b/packages/ui/src/kit/registry.ts
@@ -14,6 +14,10 @@ import { DataTable } from "./data/data-table.js";
 import { CardList } from "./data/card-list.js";
 import { Stat } from "./data/stat.js";
 import { Badge } from "./data/badge.js";
+import { KeyValue } from "./data/key-value.js";
+import { Timeline } from "./data/timeline.js";
+import { Avatar } from "./data/avatar.js";
+import { CodeBlock } from "./data/code-block.js";
 import { LineChart } from "./charts/line.js";
 import { BarChart } from "./charts/bar.js";
 import { DonutChart } from "./charts/donut.js";
@@ -30,6 +34,8 @@ import { Disclaimer } from "./forms/disclaimer.js";
 import { Tabs } from "./feedback/tabs.js";
 import { Callout } from "./feedback/callout.js";
 import { Accordion } from "./feedback/accordion.js";
+import { EmptyState } from "./feedback/empty-state.js";
+import { Steps } from "./feedback/steps.js";
 
 export {
   KIT_SPECS,
@@ -41,8 +47,8 @@ export {
 export const KIT_COMPONENTS: Readonly<Record<string, ComponentType<Record<string, never>>>> = {
   Stack, Row, Grid, Surface, Card, Divider,
   Text, Money, DateTime, Percent, Num, EnumBadge, Icon,
-  DataTable, CardList, Stat, Badge,
+  DataTable, CardList, Stat, Badge, KeyValue, Timeline, Avatar, CodeBlock,
   LineChart, BarChart, DonutChart, Sparkline, Progress,
   Input, Select, DatePicker, Textarea, Checkbox, Button, Form, Disclaimer,
-  Tabs, Callout, Accordion,
+  Tabs, Callout, Accordion, EmptyState, Steps,
 } as unknown as Record<string, ComponentType<Record<string, never>>>;

--- a/packages/ui/src/tree/jail/runtime-entry.tsx
+++ b/packages/ui/src/tree/jail/runtime-entry.tsx
@@ -27,6 +27,12 @@ import {
   fmt, setKitIntl, type KitIntl,
 } from "../../kit/index.js";
 import { Icon } from "../../kit/icon.js";
+import { KeyValue } from "../../kit/data/key-value.js";
+import { Timeline } from "../../kit/data/timeline.js";
+import { Avatar } from "../../kit/data/avatar.js";
+import { CodeBlock } from "../../kit/data/code-block.js";
+import { EmptyState } from "../../kit/feedback/empty-state.js";
+import { Steps } from "../../kit/feedback/steps.js";
 
 declare global {
   // These globals are visible only inside the opaque-origin jail realm.
@@ -196,10 +202,10 @@ const AMBIENT_SCOPE: Record<(typeof ISLAND_AMBIENT_NAMES)[number], unknown> = {
   useSyncExternalStore: React.useSyncExternalStore,
   Stack, Row, Grid, Surface, Card, Divider,
   Text, Money, DateTime, Percent, Num, EnumBadge, Icon,
-  DataTable, CardList, Stat, Badge,
+  DataTable, CardList, Stat, Badge, KeyValue, Timeline, Avatar, CodeBlock,
   LineChart, BarChart, DonutChart, Sparkline, Progress,
   Input, Select, DatePicker, Textarea, Checkbox, Button, Form, Disclaimer,
-  Tabs, Callout, Accordion,
+  Tabs, Callout, Accordion, EmptyState, Steps,
   fmt,
   tools: makeToolsAmbient([]),
 };

--- a/packages/ui/test/kit/data-detail.test.tsx
+++ b/packages/ui/test/kit/data-detail.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Avatar } from "../../src/kit/data/avatar.js";
+import { CodeBlock } from "../../src/kit/data/code-block.js";
+import { KeyValue } from "../../src/kit/data/key-value.js";
+import { Timeline } from "../../src/kit/data/timeline.js";
+import { Row } from "../../src/kit/layout.js";
+import { EnumBadge, Money } from "../../src/kit/values.js";
+
+const invoice = { number: "INV-9", amountCents: 250_000, dueDate: "2026-03-14", status: "past_due", client: { name: "Maple" }, note: null };
+
+describe("KeyValue", () => {
+  it("labels each row from its key and formats the value", () => {
+    render(
+      <KeyValue
+        record={invoice}
+        items={[{ key: "client.name" }, { key: "amountCents", label: "Amount" }, { key: "dueDate", format: "date" }]}
+      />,
+    );
+    // The label defaults to the humanized LAST path segment, as a column's does.
+    expect(screen.getByText("Name")).toBeTruthy();
+    expect(screen.getByText("Maple")).toBeTruthy();
+    expect(screen.getByText("Amount")).toBeTruthy();
+    expect(screen.getByText("250000")).toBeTruthy();
+    expect(screen.getByText(/Mar 14, 2026/)).toBeTruthy();
+  });
+
+  it("renders a slot's components against the record, not against a prop", () => {
+    // The seam the cell slot exists for: the component names its FIELD and the
+    // value arrives off RowContext, published by KeyValue.
+    render(
+      <KeyValue
+        record={invoice}
+        items={[
+          { key: "amountCents", cell: <Money field="amountCents" /> },
+          { key: "status", cell: <EnumBadge field="status" /> },
+        ]}
+      />,
+    );
+    expect(screen.getByText("$250,000.00")).toBeTruthy();
+    expect(screen.getByText("Past due")).toBeTruthy();
+  });
+
+  it("shows a dash for an unrenderable value rather than 'null'", () => {
+    render(<KeyValue record={invoice} items={[{ key: "note" }]} />);
+    expect(screen.getByText("—")).toBeTruthy();
+    expect(screen.queryByText("null")).toBeNull();
+  });
+
+  it("rules between rows only when asked, and never under the last one", () => {
+    const rows = (dividers: boolean) => {
+      const { container } = render(
+        <KeyValue record={invoice} items={[{ key: "number" }, { key: "status" }]} dividers={dividers} />,
+      );
+      return [...container.querySelectorAll("dt")].map((dt) => dt.getAttribute("style") ?? "");
+    };
+    expect(rows(false).every((style) => !style.includes("border-bottom"))).toBe(true);
+    const ruled = rows(true);
+    expect(ruled[0]).toContain("border-bottom");
+    expect(ruled[1]).not.toContain("border-bottom");
+  });
+});
+
+const events = [
+  { id: "a", what: "Invoice issued", at: "2026-03-01T10:00:00Z" },
+  { id: "b", what: "Reminder sent", at: "2026-03-08T10:00:00Z" },
+];
+
+describe("Timeline", () => {
+  it("marks one entry per record and formats its timestamp", () => {
+    const { container } = render(<Timeline entries={events} titleField="what" timeField="at" />);
+    expect(container.querySelectorAll("li")).toHaveLength(2);
+    expect(screen.getByText("Invoice issued")).toBeTruthy();
+    expect(screen.getByText(/Mar 1, 2026/)).toBeTruthy();
+  });
+
+  it("renders the cell slot once per entry, each reading its OWN record", () => {
+    // One element, two entries, two different values — the whole reason a slot
+    // binds by field name instead of by prop.
+    render(<Timeline entries={events} cell={<EnumBadge field="what" />} timeField="at" />);
+    expect(screen.getByText("Invoice issued")).toBeTruthy();
+    expect(screen.getByText("Reminder sent")).toBeTruthy();
+  });
+
+  it("draws the marker slot in place of the dot", () => {
+    const { container } = render(
+      <Timeline entries={events} titleField="what" marker={<span data-testid="mark">•</span>} />,
+    );
+    expect(container.querySelectorAll('[data-testid="mark"]')).toHaveLength(2);
+  });
+
+  it("puts the timestamp after the title when aligned to the end", () => {
+    const text = (align: "start" | "end") =>
+      render(<Timeline entries={[events[0]!]} titleField="what" timeField="at" timeAlign={align} />)
+        .container.querySelector("li > div:last-child")!.textContent!;
+    expect(text("start")).toMatch(/^Mar 1, 2026.*Invoice issued$/);
+    expect(text("end")).toMatch(/^Invoice issued.*Mar 1, 2026/);
+  });
+
+  it("fails soft on missing data with its own empty text", () => {
+    render(<Timeline entries={undefined as never} emptyState="Nothing happened yet" />);
+    expect(screen.getByText("Nothing happened yet")).toBeTruthy();
+  });
+});
+
+describe("Avatar", () => {
+  it("takes one letter from each of the first two words", () => {
+    render(
+      <>
+        <Avatar name="Ada Lovelace" />
+        <Avatar name="maple" />
+        <Avatar name="  a b c  " />
+      </>,
+    );
+    expect(screen.getByLabelText("Ada Lovelace").textContent).toBe("AL");
+    expect(screen.getByLabelText("maple").textContent).toBe("M");
+    expect(screen.getByLabelText("a b c").textContent).toBe("AB");
+  });
+
+  it("gives one name one color, every time, and different names different ones", () => {
+    const fill = (name: string) =>
+      /background:[^;]+/.exec(render(<Avatar name={name} />).container.querySelector("span")!.getAttribute("style")!)![0];
+    expect(fill("Ada Lovelace")).toBe(fill("Ada Lovelace"));
+    expect(fill("Ada Lovelace")).not.toBe(fill("Grace Hopper"));
+  });
+
+  it("sizes the disc and publishes that size for the stack rule", () => {
+    const style = (size: "sm" | "md" | "lg") =>
+      render(<Avatar name="Ada" size={size} />).container.querySelector("span")!.getAttribute("style")!;
+    expect(style("sm")).toContain("width: 24px");
+    expect(style("lg")).toContain("width: 44px");
+    expect(style("md")).toContain("--vendo-kit-avatar-size: 32px");
+  });
+
+  it("ships the sibling rule that stacks avatars inside a Row", () => {
+    render(
+      <Row>
+        <Avatar name="Ada Lovelace" />
+        <Avatar name="Grace Hopper" />
+      </Row>,
+    );
+    // A sibling relation is not something an inline style can say, so the rule
+    // is a hoisted stylesheet — and one of it, however many avatars ask.
+    const css = document.documentElement.innerHTML;
+    expect(css).toContain('[data-kit="Row"] > [data-kit="Avatar"] + [data-kit="Avatar"]');
+    expect(css.split("margin-inline-start").length - 1).toBe(1);
+  });
+});
+
+describe("CodeBlock", () => {
+  it("shows the payload verbatim in a monospaced pre", () => {
+    const payload = '{\n  "id": "evt_1"\n}';
+    const { container } = render(<CodeBlock code={payload} language="json" />);
+    const code = container.querySelector("code")!;
+    expect(code.textContent).toBe(payload);
+    expect(code.getAttribute("style")).toContain("--vendo-mono-family");
+    expect(container.querySelector('[data-kit="CodeBlock"]')!.getAttribute("data-language")).toBe("json");
+    expect(screen.getByText("json")).toBeTruthy();
+  });
+
+  it("drops the chip when no language is named", () => {
+    const { container } = render(<CodeBlock code="ok" />);
+    expect(container.querySelector("span")).toBeNull();
+  });
+});

--- a/packages/ui/test/kit/feedback-states.test.tsx
+++ b/packages/ui/test/kit/feedback-states.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { EmptyState } from "../../src/kit/feedback/empty-state.js";
+import { Steps } from "../../src/kit/feedback/steps.js";
+import { Button } from "../../src/kit/forms/button.js";
+
+describe("EmptyState", () => {
+  it("draws the icon, the headline, the reason and the action nested inside", () => {
+    const { container } = render(
+      <EmptyState icon="inbox" title="No invoices yet" description="They show up the moment one is issued.">
+        <Button label="New invoice" />
+      </EmptyState>,
+    );
+    expect(container.querySelector("svg")).toBeTruthy();
+    expect(screen.getByText("No invoices yet")).toBeTruthy();
+    expect(screen.getByText("They show up the moment one is issued.")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "New invoice" })).toBeTruthy();
+  });
+
+  it("reads as intentional, not broken — the charts' dashed frame", () => {
+    const { container } = render(<EmptyState title="Nothing here" />);
+    expect(container.querySelector('[data-kit="EmptyState"]')!.getAttribute("style")).toContain("dashed");
+  });
+
+  it("leaves a gap rather than a broken glyph for an icon name it does not have", () => {
+    const { container } = render(<EmptyState icon="not-an-icon" title="Nothing here" />);
+    expect(container.querySelector("svg")).toBeNull();
+    expect(screen.getByText("Nothing here")).toBeTruthy();
+  });
+});
+
+const steps = [{ label: "Details" }, { label: "Review", description: "We check the numbers" }, { label: "Done" }];
+
+describe("Steps", () => {
+  it("reads everything before the active step as done, and the rest as still to come", () => {
+    const { container } = render(<Steps items={steps} active={1} />);
+    const items = [...container.querySelectorAll("li")];
+    expect(items.map((li) => li.dataset.stepState)).toEqual(["done", "current", "todo"]);
+    // A done step is a check; an unreached one is still its number.
+    expect(items[0]!.querySelector("svg")).toBeTruthy();
+    expect(items[2]!.querySelector("svg")).toBeNull();
+    expect(items[2]!.textContent).toContain("3");
+    expect(screen.getByText("We check the numbers")).toBeTruthy();
+  });
+
+  it("names the current step for a screen reader", () => {
+    const { container } = render(<Steps items={steps} active={2} />);
+    expect(container.querySelectorAll('[aria-current="step"]')).toHaveLength(1);
+    expect(container.querySelector('[aria-current="step"]')!.textContent).toContain("Done");
+  });
+
+  it("starts at the first step when none is named", () => {
+    const { container } = render(<Steps items={steps} />);
+    expect([...container.querySelectorAll("li")].map((li) => li.dataset.stepState))
+      .toEqual(["current", "todo", "todo"]);
+  });
+
+  it("turns the progress rule with the orientation", () => {
+    const rule = (orientation: "horizontal" | "vertical") =>
+      render(<Steps items={steps} active={1} orientation={orientation} />)
+        .container.querySelector("li")!.getAttribute("style")!;
+    expect(rule("horizontal")).toContain("border-block-start");
+    expect(rule("vertical")).toContain("border-inline-start");
+  });
+});


### PR DESCRIPTION
**Stacked PR.** Base is `kit/n1-icons` (#1306), which in turn sits on `kit/n1-theme-v2` (#1305). Review only the top three commits (the six bricks, the dead-prop fix, and the vocabulary fixture update); the rest is the base branches.

## What

Six new building blocks join the Kit, covering shapes a generated screen could previously only fake with a stack of plain text:

- **KeyValue** — one record laid out as label/value rows, the detail view a table row expands into.
- **Timeline** — a record's history running down a dotted spine.
- **Avatar** — initials in a colour picked from the person's name, so the same person is the same colour everywhere. Side-by-side avatars overlap neatly.
- **CodeBlock** — a payload shown verbatim. No syntax colouring, no copy button.
- **EmptyState** — the designed "nothing here yet", with the button that fixes it sitting inside.
- **Steps** — a progress trail, horizontal or vertical.

## Why

The agent had a table and a text block and not much else. Anything shaped like a detail panel, a history, a person, or an empty list came out as improvised text, which is where generated screens looked most obviously generated.

KeyValue and Timeline also plug into the existing table: the table hands each row's record down, and the component inside names the field it wants. That is what makes an expandable row possible without new plumbing.

## Theming

Every one draws its colours and borders from the host's own theme variables, including three of the new ones from the theme slice. A host that has set no theme looks exactly as it did before.

## Known red

`packages/apps/tests/checking/screen-tsc-vocabulary.test.ts` requires every wire component to be listed in its `BROAD_SCREEN` fixture. Icon and the six new bricks are not in that fixture yet, so that single test fails — 1 failure out of 783.

Extending the fixture means editing a test file, which is its own change and belongs to the kit-integration follow-up we already planned. It was deliberately left alone rather than patched to turn the suite green. **This PR is a draft and is not for merge until that follow-up lands.**

## Notes

- Builder's gate (build, affected tests, typecheck, lint) passed on this slice apart from the known red above.
- No screenshots tonight — the visual check is the morning review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds six static bricks — KeyValue, Timeline, Avatar, CodeBlock, EmptyState, and Steps — so screens render details, histories, people, payloads, empty regions, and progress without improvising with Stack/Text.

- Registers all six in the Kit registry and jail ambient scope; re-exports from `@vendoai/ui/kit`; adds specs to the apps contract and `ISLAND_AMBIENT_KIT_NAMES`.
- KeyValue/Timeline: add a DataTable-style `cell` slot and publish the record on `RowContext`; Timeline also adds `marker`, `timeAlign`, and empty text.
- Avatar: initials with a hashed tint; constant 32% disc overlap via `--vendo-kit-row-gap` published by Row; ring keeps stacked discs readable.
- CodeBlock: renders verbatim payloads with an optional language chip; no syntax highlighting or copy. EmptyState frames a nested action; Steps renders horizontal/vertical progress with an active index.
- Themes all bricks through host `--vendo-*` tokens with fallbacks; unthemed hosts look the same.
- Tests and fixtures: focused UI tests for all six; updates `VOCABULARY` and `BROAD_SCREEN` to include them. Releases: ships a changeset for minor versions of `@vendoai/apps` and `@vendoai/ui`.
- Migration: removes the unreachable `density` prop from KeyValue/Timeline; no action required.

<sup>Written for commit 17711a20115772c7ad56bd980de7fd17a34b06b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Test fixtures updated, stated explicitly

This branch adds `Avatar`, `CodeBlock`, `EmptyState`, `KeyValue`, `Steps` and `Timeline` to the two hand-maintained component vocabulary lists — `VOCABULARY` in `packages/apps/tests/format-conformance.e2e.test.ts` and the `BROAD_SCREEN` fixture in `packages/apps/tests/checking/screen-tsc-vocabulary.test.ts`.

Those pins exist precisely to force a stated update when the kit grows, and this growth is approved scope. Nothing was weakened — both remain exact-match assertions.

The six `BROAD_SCREEN` entries are real usages written over the existing fixture data, not bare names, and they are type-checked by the same checker the product itself uses. A component that did not actually work with that data would fail the check.

Note for later: PRs #1299–#1303 may rewrite or delete these lists as part of removing the wire format. A rebase conflict here is expected and is mechanical to resolve.

