### PR TITLE
feat(store): add claim verb to IdempotencyLedger to resolve same-key write races (#1297)

### DIFF
--- a/packages/core/src/conformance/index.ts
+++ b/packages/core/src/conformance/index.ts
@@ -415,6 +415,33 @@ export function storeAdapterConformance(opts: {
         );
       }),
 
+      /** 01-core §12: idempotency.claim reserves a fresh key and replays a recorded answer. */
+      readyAdapterCase(opts, "01-core §12 — idempotency.claim returns 'claimed' when fresh, and replays what record wrote", async (adapter) => {
+        const ledger = adapter.idempotency;
+        if (ledger === undefined || ledger.claim === undefined) return;
+        const scope = { tenant: "tenant_a", op: "workspace.commit", key: "idem_claim_1" };
+        assert(await ledger.claim(scope, "hash_a") === "claimed", "a fresh key should claim as 'claimed'");
+        await ledger.record(scope, "hash_a", { status: 200, result: { committed: 1 } });
+        assertDeepEqual(
+          await ledger.claim(scope, "hash_a"),
+          { status: 200, result: { committed: 1 } },
+          "the claim replay did not return the recorded status and result",
+        );
+      }),
+
+      /** 01-core §12: idempotency.claim refuses a reserved key carrying a different request. */
+      readyAdapterCase(opts, "01-core §12 — idempotency.claim refuses a held key carrying a different request", async (adapter) => {
+        const ledger = adapter.idempotency;
+        if (ledger === undefined || ledger.claim === undefined) return;
+        const scope = { tenant: "tenant_a", op: "workspace.commit", key: "idem_claim_2" };
+        assert(await ledger.claim(scope, "hash_a") === "claimed", "a fresh key should claim as 'claimed'");
+        const refusal = await ledger.claim(scope, "hash_b").then(() => null, (error: unknown) => error);
+        assert(
+          (refusal as { code?: unknown } | null)?.code === "conflict",
+          `a held key claimed with a different request hash should throw conflict, got ${String(refusal)}`,
+        );
+      }),
+
       /** 01-core §12: blob list filters keys by prefix. */
       readyAdapterCase(opts, "01-core §12 — blobs.list filters by prefix", async (adapter) => {
         const blobs = adapter.blobs("conformance_blob_list");

--- a/packages/core/src/conformance/memory-store.ts
+++ b/packages/core/src/conformance/memory-store.ts
@@ -500,6 +500,22 @@ export function memoryStoreAdapter(
     // so the ledger cannot commit while the mutation it gates rolls back. A
     // hosted mount earns the same guarantee by putting it in the same database.
     idempotency: {
+      async claim(scope, requestHash) {
+        const key = ledgerKey(scope);
+        const held = ledger.get(key);
+        if (held === undefined) {
+          ledger.set(key, { requestHash, answer: { status: 0, result: {} } });
+          return "claimed";
+        }
+        if (held.requestHash !== requestHash) {
+          throw new VendoError(
+            "conflict",
+            `idempotency key ${scope.key} was already used with a different request body`,
+          );
+        }
+        if (held.answer.status === 0) return null;
+        return { status: held.answer.status, result: jsonCopy(held.answer.result) };
+      },
       async check(scope, requestHash) {
         const held = ledger.get(ledgerKey(scope));
         if (held === undefined) return null;
@@ -509,13 +525,13 @@ export function memoryStoreAdapter(
             `idempotency key ${scope.key} was already used with a different request body`,
           );
         }
+        if (held.answer.status === 0) return null;
         return { status: held.answer.status, result: jsonCopy(held.answer.result) };
       },
       async record(scope, requestHash, answer) {
         const key = ledgerKey(scope);
-        // First writer wins: the answer a replay has already been handed must
-        // not change under it.
-        if (ledger.has(key)) return;
+        const held = ledger.get(key);
+        if (held !== undefined && held.answer.status !== 0 && held.requestHash === requestHash) return;
         ledger.set(key, { requestHash, answer: { status: answer.status, result: jsonCopy(answer.result) } });
       },
     },

--- a/packages/core/src/conformance/memory-store.ts
+++ b/packages/core/src/conformance/memory-store.ts
@@ -531,7 +531,7 @@ export function memoryStoreAdapter(
       async record(scope, requestHash, answer) {
         const key = ledgerKey(scope);
         const held = ledger.get(key);
-        if (held !== undefined && held.answer.status !== 0 && held.requestHash === requestHash) return;
+        if (held !== undefined && (held.answer.status !== 0 || held.requestHash !== requestHash)) return;
         ledger.set(key, { requestHash, answer: { status: answer.status, result: jsonCopy(answer.result) } });
       },
     },

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -140,6 +140,20 @@ export interface IdempotencyLedger {
       key already held is ignored, never an overwrite — the answer a replay
       already received must not change under it. */
   record(scope: IdempotencyScope, requestHash: string, answer: IdempotencyRecord): Promise<void>;
+  /**
+   * Reserve (tenant, op, key) for this request hash BEFORE the mutation runs.
+   * Answers the reservation's owner: `"claimed"` when this caller won the key,
+   * or the {@link IdempotencyRecord} a prior owner already published. A differing
+   * request hash throws `conflict` HERE, so a refused request never reaches
+   * the mutation.
+   *
+   * Returns `null` when a prior caller claimed the key with the SAME hash but
+   * has not published an answer yet.
+   *
+   * OPTIONAL: an adapter that cannot reserve up front omits `claim` and callers
+   * fall back to `check` then `record`.
+   */
+  claim?(scope: IdempotencyScope, requestHash: string): Promise<IdempotencyRecord | null | "claimed">;
 }
 
 /** 01-core §12 */

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -141,7 +141,7 @@ export interface IdempotencyLedger {
       already received must not change under it. */
   record(scope: IdempotencyScope, requestHash: string, answer: IdempotencyRecord): Promise<void>;
   /**
-   * Reserve (tenant, op, key) for this request hash BEFORE the mutation runs.
+   * Atomically reserve (tenant, op, key) for this request hash BEFORE the mutation runs.
    * Answers the reservation's owner: `"claimed"` when this caller won the key,
    * or the {@link IdempotencyRecord} a prior owner already published. A differing
    * request hash throws `conflict` HERE, so a refused request never reaches

--- a/packages/store/src/idempotency.ts
+++ b/packages/store/src/idempotency.ts
@@ -10,6 +10,37 @@ import { jsonParam, text } from "./helpers/utils.js";
  *  on, so the two commit or roll back together. */
 export function createIdempotencyLedger(db: Db): IdempotencyLedger {
   return {
+    async claim(scope, requestHash) {
+      const inserted = await db.query(
+        `INSERT INTO vendo_idempotency_ledger (tenant, op, key, request_hash, status, result)
+         VALUES ($1, $2, $3, $4, 0, '{}'::jsonb)
+         ON CONFLICT (tenant, op, key) DO NOTHING
+         RETURNING request_hash, status, result`,
+        [scope.tenant, scope.op, scope.key, requestHash],
+      );
+      if (inserted.rows.length > 0) {
+        return "claimed";
+      }
+      const existing = await db.query(
+        `SELECT request_hash, status, result FROM vendo_idempotency_ledger
+         WHERE tenant = $1 AND op = $2 AND key = $3`,
+        [scope.tenant, scope.op, scope.key],
+      );
+      const row = existing.rows[0];
+      if (row === undefined) return "claimed";
+      if (text(row["request_hash"]) !== requestHash) {
+        throw new VendoError(
+          "conflict",
+          `idempotency key ${JSON.stringify(scope.key)} on ${scope.op} was already used for a `
+          + "different request body, so there is no recorded answer that belongs to this one — "
+          + "a key stands for ONE request. Mint a fresh key for a new request, and reuse a key "
+          + "only to retry the identical body.",
+        );
+      }
+      const status = Number(row["status"]);
+      if (status === 0) return null;
+      return { status, result: row["result"] as Json };
+    },
     async check(scope, requestHash) {
       const result = await db.query(
         `SELECT request_hash, status, result FROM vendo_idempotency_ledger
@@ -27,7 +58,9 @@ export function createIdempotencyLedger(db: Db): IdempotencyLedger {
           + "only to retry the identical body.",
         );
       }
-      return { status: Number(row["status"]), result: row["result"] as Json };
+      const status = Number(row["status"]);
+      if (status === 0) return null;
+      return { status, result: row["result"] as Json };
     },
     async record(scope, requestHash, answer) {
       // First writer wins: the answer a replay has already been handed must not
@@ -35,7 +68,9 @@ export function createIdempotencyLedger(db: Db): IdempotencyLedger {
       await db.query(
         `INSERT INTO vendo_idempotency_ledger (tenant, op, key, request_hash, status, result)
          VALUES ($1, $2, $3, $4, $5, $6::jsonb)
-         ON CONFLICT (tenant, op, key) DO NOTHING`,
+         ON CONFLICT (tenant, op, key) DO UPDATE
+         SET status = EXCLUDED.status, result = EXCLUDED.result
+         WHERE vendo_idempotency_ledger.status = 0 AND vendo_idempotency_ledger.request_hash = EXCLUDED.request_hash`,
         [scope.tenant, scope.op, scope.key, requestHash, answer.status, jsonParam(answer.result)],
       );
     },

--- a/packages/store/tests/idempotency.test.ts
+++ b/packages/store/tests/idempotency.test.ts
@@ -42,5 +42,18 @@ for (const backend of backends()) {
       await ledger.record(scope, "hash_1", { status: 500, result: { error: "late" } });
       expect(await ledger.check(scope, "hash_1")).toEqual({ status: 201, result: { id: "wsc_1" } });
     });
+
+    it("claims fresh keys, throws conflict on differing hash, and returns null while unrecorded", async () => {
+      const claimScope = { tenant: "tenant_a", op: "workspace.commit", key: "key_claim_test" };
+      expect(await ledger.claim!(claimScope, "hash_c1")).toBe("claimed");
+      // Claiming again with same hash before record returns null
+      expect(await ledger.claim!(claimScope, "hash_c1")).toBeNull();
+      // Claiming with different hash throws conflict before mutation
+      await expect(ledger.claim!(claimScope, "hash_c2")).rejects.toMatchObject({ code: "conflict" });
+      // Record answer
+      await ledger.record(claimScope, "hash_c1", { status: 200, result: { claimed: true } });
+      // Claiming after record returns the recorded answer
+      expect(await ledger.claim!(claimScope, "hash_c1")).toEqual({ status: 200, result: { claimed: true } });
+    });
   });
 }

--- a/scripts/dependency-guard.mjs
+++ b/scripts/dependency-guard.mjs
@@ -294,8 +294,8 @@ function workspacePackageDirs() {
   const list = /^packages:[^\S\n]*\n((?:[^\S\n]+-[^\n]*\n)+)/m.exec(yaml)?.[1];
   if (!list) throw new Error("dependency-guard: no `packages:` list in pnpm-workspace.yaml");
   const dirs = [];
-  for (const line of list.trimEnd().split("\n")) {
-    const pattern = /^\s*-\s*["']?([^"'\s]+)["']?$/.exec(line)?.[1];
+  for (const line of list.trimEnd().split(/\r?\n/)) {
+    const pattern = /^\s*-\s*["']?([^"'\r\n\s]+)["']?$/.exec(line)?.[1];
     if (!pattern) throw new Error(`dependency-guard: unreadable workspace entry: ${line.trim()}`);
     if (!pattern.includes("*")) {
       dirs.push(pattern);


### PR DESCRIPTION
# feat(store): add claim verb to IdempotencyLedger to resolve same-key write races (#1297)

### What

- Added an optional `claim` verb to `IdempotencyLedger` to enable atomic, pre-mutation key reservations:
`claim?(scope: IdempotencyScope, requestHash: string): Promise<IdempotencyRecord | null | "claimed">;`
- Returns `"claimed"` when this caller atomically inserted the reservation `(status = 0)` via `INSERT ... ON CONFLICT (tenant, op, key) DO NOTHING RETURNING ....`
- Returns `IdempotencyRecord` `({ status, result })` if a prior caller already completed and recorded an answer for the same request hash.
- Returns null if another caller claimed the key with the same request hash, but has not published an answer yet .
- Throws a `conflict` `VendoError` immediately if the key was claimed or recorded with a differing request hash, refusing the request before the mutation executes.
----

## File Changed:-

- `packages/core/src/store.ts`: Added `claim`? to `IdempotencyLedger` interface.
- `packages/store/src/idempotency.ts`: Implemented claim for Postgres/PGlite backend using atomic `INSERT ... ON CONFLICT DO NOTHING RETURNING.`
- `packages/core/src/conformance/memory-store.ts`: Implemented `claim` in memory store adapter.
- `packages/core/src/conformance/index.ts`: Added conformance suite cases for `idempotency.claim`.
- `packages/store/tests/idempotency.test.ts`: Added unit tests covering all claim return states and conflict handling.
- `scripts/dependency-guard.mjs`: Fixed CRLF line ending handling in `pnpm-workspace.yaml` parsing on Windows.

### Why
`IdempotencyLedger` previously operated on a check-then-do model (`check then record`). When two concurrent requests carried the same idempotency key with different request bodies, both passed `check `as fresh and executed their mutations in parallel. The loser was subsequently refused with conflict during `record/check`, but after its mutation had already committed to the store .

`claim` allows mounts and stores to reserve the key atomically before invoking the mutation, so conflicting request bodies are rejected upfront without touching underlying data.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional claim() to IdempotencyLedger to atomically reserve idempotency keys and prevent same‑key write races. Previously two requests could both mutate; now differing bodies are refused before mutation, while identical retries replay or wait.

- API: `IdempotencyLedger.claim(scope, requestHash)` returns `"claimed"` when this caller reserved the key, `null` while a same‑hash reservation is held and unrecorded, or the recorded `IdempotencyRecord`. Throws `conflict` when the key was used with a different hash.
- Behavior changes: `check` returns `null` while a placeholder reservation (`status = 0`) exists. `record` only updates a placeholder for the same hash (`status = 0`), otherwise it is a no‑op.
- Store/Adapters: Implemented `claim` and conditional `record` in the Postgres/PGlite ledger and in‑memory adapter; aligned `check`/`record` semantics. `claim` is optional; callers can fall back to `check` → `record` when an adapter omits it.
- Tests/Tooling: Added conformance and unit tests for claim states and conflicts. Improved CRLF handling in `scripts/dependency-guard.mjs`.

<sup>Written for commit a23f1224be12bb437717112662b5e4f33a885f62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

