### PR TITLE
fix(ui): back off the connect dock's failed status polls

### DIFF
--- a/.changeset/connect-poll-backoff.md
+++ b/.changeset/connect-poll-backoff.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/ui": patch
+---
+
+The connect dock's status poll now backs off exponentially on failures (1.5s floor, 15s cap, with jitter) instead of retrying on the healthy cadence until the 120s deadline, and a rate-limited answer (the wire `unavailable` code) jumps straight to the cap. A failing poll no longer sustains the very rate limit that is failing it. Before giving up at the deadline, the dock checks status one last time, so a connection that went active during the final backoff wait is reported as connected instead of timed out.

--- a/packages/ui/src/chrome/connect-dock.tsx
+++ b/packages/ui/src/chrome/connect-dock.tsx
@@ -17,6 +17,8 @@ import { toolkitDisplayName } from "./humanize.js";
 
 const POLL_INTERVAL_MS = 1_500;
 const POLL_DEADLINE_MS = 120_000;
+const POLL_BACKOFF_BASE_MS = 1_000;
+const POLL_BACKOFF_CAP_MS = 15_000;
 const POPUP_WIDTH = 520;
 const POPUP_HEIGHT = 680;
 
@@ -85,10 +87,17 @@ export async function completeConnection(
   if (popup === undefined) window.open(initiated.redirectUrl, "_blank", "noopener");
   else if (popup !== null) popup.location.replace(initiated.redirectUrl);
   const deadline = Date.now() + POLL_DEADLINE_MS;
+  let failures = 0;
   while (!isCancelled() && Date.now() < deadline) {
-    const account = await client.connections
-      .status(initiated.id, initiated.connector)
-      .catch(() => undefined);
+    let account: ConnectionAccount | undefined;
+    let failure: unknown;
+    try {
+      account = await client.connections.status(initiated.id, initiated.connector);
+      failures = 0;
+    } catch (reason) {
+      failure = reason;
+      failures += 1;
+    }
     // Closed from the OPENER: the consent page is the broker's, so there is
     // nothing of ours running inside it to postMessage back.
     if (account?.status === "active") {
@@ -99,13 +108,54 @@ export async function completeConnection(
       popup?.close();
       throw new Error(`The ${input.toolkit} connection ${account.status} — try again.`);
     }
-    await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
+    // Each poll is itself a broker call, so retrying failures on the healthy
+    // cadence sustained the very rate limit that was failing it in the field.
+    // Ordinary failures back off exponentially with jitter (so parked tabs
+    // drift apart), floored at the healthy cadence so one hiccup never polls
+    // faster than success does; a rate-limited answer goes straight to the
+    // full cap, unjittered — the server said stop, nothing shorter will do.
+    let delay = POLL_INTERVAL_MS;
+    if (failures > 0) {
+      if (isRateLimited(failure)) {
+        delay = POLL_BACKOFF_CAP_MS;
+      } else {
+        const backoff = Math.min(POLL_BACKOFF_CAP_MS, POLL_BACKOFF_BASE_MS * 2 ** (failures - 1));
+        delay = Math.max(POLL_INTERVAL_MS, backoff / 2 + Math.random() * (backoff / 2));
+      }
+    }
+    await waitUnlessCancelled(Math.min(delay, deadline - Date.now()), isCancelled);
   }
   if (isCancelled()) return;
+  // One last look before giving up: a capped backoff wait can blind the loop
+  // for up to 15s, and a connection that went active inside that window would
+  // otherwise be reported as "nothing changed".
+  const last = await client.connections
+    .status(initiated.id, initiated.connector)
+    .catch(() => undefined);
+  if (last?.status === "active") {
+    popup?.close();
+    return;
+  }
   popup?.close();
   // Coded, because a deadline is not a refusal: the surface says "nothing
   // changed" and re-offers, where a failure says the connect went wrong.
   throw Object.assign(new Error(`Timed out waiting for the ${input.toolkit} connection — try again.`), { code: "timeout" });
+}
+
+/** A rate-limited answer is a signal to back off hardest, not retry sooner.
+    The wire speaks it as the `unavailable` code. */
+function isRateLimited(reason: unknown): boolean {
+  if (typeof reason !== "object" || reason === null) return false;
+  return (reason as { code?: unknown }).code === "unavailable";
+}
+
+/** Sleep `ms`, in short slices so a cancel (an unmount, a superseding connect)
+    is honoured mid-backoff instead of after a full capped wait. */
+async function waitUnlessCancelled(ms: number, isCancelled: () => boolean): Promise<void> {
+  const until = Date.now() + ms;
+  while (!isCancelled() && Date.now() < until) {
+    await new Promise(resolve => setTimeout(resolve, Math.min(250, until - Date.now())));
+  }
 }
 
 /**

--- a/packages/ui/test/chrome/connect-backoff.test.ts
+++ b/packages/ui/test/chrome/connect-backoff.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { completeConnection } from "../../src/chrome/connect-dock.js";
+import type { VendoClient } from "../../src/index.js";
+
+/** A minimal client whose `status` behavior is scripted per call — the loop
+    under test only touches `connections.initiate` and `connections.status`. */
+function clientWhoseStatus(status: () => Promise<unknown>): { client: VendoClient; status: ReturnType<typeof vi.fn> } {
+  const statusMock = vi.fn(status);
+  const client = {
+    connections: {
+      initiate: vi.fn(async () => ({ id: "con_1", connector: undefined, redirectUrl: "https://broker.example/consent" })),
+      status: statusMock,
+    },
+  } as unknown as VendoClient;
+  return { client, status: statusMock };
+}
+
+const pending = () => Promise.resolve({ status: "pending" });
+const failing = () => Promise.reject(new Error("boom"));
+const rateLimited = () => Promise.reject(Object.assign(new Error("try later"), { code: "unavailable" }));
+
+describe("completeConnection failure backoff", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Pin the jitter to its upper bound so every asserted delay is exact.
+    vi.spyOn(Math, "random").mockReturnValue(1);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the healthy 1.5s cadence while the connection is pending", async () => {
+    const { client, status } = clientWhoseStatus(pending);
+    const run = completeConnection(client, { toolkit: "github" }, () => false, null);
+    run.catch(() => {});
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(status).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1_499);
+    expect(status).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(status).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1_500);
+    expect(status).toHaveBeenCalledTimes(3);
+  });
+
+  it("backs off exponentially on failures, floored at the healthy cadence", async () => {
+    const { client, status } = clientWhoseStatus(failing);
+    const run = completeConnection(client, { toolkit: "github" }, () => false, null);
+    run.catch(() => {});
+
+    // Delays after each failure: max(1500, 1000)=1500, 2000, 4000, 8000, 15000.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(status).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1_500);
+    expect(status).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1_999);
+    expect(status).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(status).toHaveBeenCalledTimes(3);
+    await vi.advanceTimersByTimeAsync(4_000);
+    expect(status).toHaveBeenCalledTimes(4);
+    await vi.advanceTimersByTimeAsync(8_000);
+    expect(status).toHaveBeenCalledTimes(5);
+    await vi.advanceTimersByTimeAsync(14_999);
+    expect(status).toHaveBeenCalledTimes(5);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(status).toHaveBeenCalledTimes(6);
+  });
+
+  it("jumps straight to the unjittered 15s cap when the wire says `unavailable`", async () => {
+    // Pin the jitter to its LOWER bound: a jittered rate-limited delay would
+    // fire at 7.5s and this test would catch it.
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const { client, status } = clientWhoseStatus(rateLimited);
+    const run = completeConnection(client, { toolkit: "github" }, () => false, null);
+    run.catch(() => {});
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(status).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(14_999);
+    expect(status).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(status).toHaveBeenCalledTimes(2);
+  });
+
+  it("actually jitters ordinary failures: the low-bound delay is half the backoff", async () => {
+    // With the jitter pinned LOW, the third failure waits backoff/2 = 2s
+    // instead of the full 4s. Deleting the jitter term makes this fire at 4s
+    // and fail, so the thundering-herd defense is covered, not just tolerated.
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const { client, status } = clientWhoseStatus(failing);
+    const run = completeConnection(client, { toolkit: "github" }, () => false, null);
+    run.catch(() => {});
+
+    // Delays at the low bound: max(1500, 500)=1500, max(1500, 1000)=1500, 2000.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(status).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1_500);
+    expect(status).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1_500);
+    expect(status).toHaveBeenCalledTimes(3);
+    await vi.advanceTimersByTimeAsync(1_999);
+    expect(status).toHaveBeenCalledTimes(3);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(status).toHaveBeenCalledTimes(4);
+  });
+
+  it("resets to the healthy cadence after a successful answer", async () => {
+    let call = 0;
+    const { client, status } = clientWhoseStatus(() => {
+      call += 1;
+      // fail, fail, pending, then fail again: the last failure is a FIRST
+      // failure again, so its delay is back at the floor.
+      if (call === 3) return pending();
+      return failing();
+    });
+    const run = completeConnection(client, { toolkit: "github" }, () => false, null);
+    run.catch(() => {});
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(status).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1_500);
+    expect(status).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(status).toHaveBeenCalledTimes(3);
+    await vi.advanceTimersByTimeAsync(1_500);
+    expect(status).toHaveBeenCalledTimes(4);
+    await vi.advanceTimersByTimeAsync(1_500);
+    expect(status).toHaveBeenCalledTimes(5);
+  });
+
+  it("still gives up at the 120s deadline with the coded timeout", async () => {
+    const { client } = clientWhoseStatus(failing);
+    const run = completeConnection(client, { toolkit: "github" }, () => false, null);
+    const settled = run.catch((reason: unknown) => reason);
+
+    await vi.advanceTimersByTimeAsync(121_000);
+    const reason = await settled;
+    expect(reason).toMatchObject({ code: "timeout" });
+  });
+
+  it("rescues a connection that went active inside the last backoff window", async () => {
+    // Every in-loop poll fails; the final pre-timeout check answers active.
+    // Without that last look, a connect that succeeded during the capped wait
+    // is reported as "nothing changed".
+    let last = false;
+    const { client } = clientWhoseStatus(() => (last ? Promise.resolve({ status: "active" }) : failing()));
+    const run = completeConnection(client, { toolkit: "github" }, () => false, null);
+    const settled = run.then(() => "resolved", () => "rejected");
+
+    await vi.advanceTimersByTimeAsync(119_000);
+    last = true;
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(await settled).toBe("resolved");
+  });
+
+  it("honours a cancel raised during a capped backoff wait", async () => {
+    let cancelled = false;
+    const { client, status } = clientWhoseStatus(rateLimited);
+    const run = completeConnection(client, { toolkit: "github" }, () => cancelled, null);
+    run.catch(() => {});
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(status).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1_000);
+    cancelled = true;
+    await vi.advanceTimersByTimeAsync(250);
+    await expect(run).resolves.toBeUndefined();
+    expect(status).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## What

`completeConnection`'s status poll backs off exponentially on failures: 1s, 2s, 4s, capped at 15s, with jitter, and floored at the healthy 1.5s cadence so a failing poll never fires faster than a succeeding one. A rate-limited answer (the wire `unavailable` code) jumps straight to the cap instead of climbing to it. A successful answer resets the backoff, every wait clamps to the existing 120s deadline, and waits run in short slices so a cancel is honoured mid-backoff rather than after a full 15s sleep.

Since a capped wait can blind the loop for up to 15s, the dock now checks status one final time before throwing the coded timeout: a connection that went active inside the last backoff window is reported as connected instead of "nothing changed".

## Why

As measured in #1252, a rate-limited org saw one open tab poll at about 2 requests per second for the full 120s deadline. Each poll is itself a Cloud broker call, so the failing poll sustained the very rate limit that was failing it, and the outage outlived its cause.

Refs #1252 (kept open: the issue's numbers were measured on `GET /connections`, which this PR does not touch; this fixes the per-connection status poll half)

## Verification

- [x] `pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint` green
- [ ] Screenshots attached (if UI-affecting) — timing behavior only, nothing rendered changes

New tests in `connect-backoff.test.ts` drive the poll with fake timers and assert the exact upper-bound delay ladder (1.5s, 2s, 4s, 8s, 15s, 15s), the straight-to-cap unjittered jump for an `unavailable` code, the reset to the healthy cadence after a successful answer, the intact coded 120s timeout, the final pre-timeout rescue, and a cancel honoured mid-backoff. The jitter itself is covered at both bounds: with `Math.random` pinned low, the third failure must fire at backoff/2 (2s, not 4s), so deleting the jitter term fails the suite rather than being silently tolerated. The healthy pending cadence is asserted unchanged at 1.5s. Mutating the source (deleting the jitter, or the final check) makes exactly the corresponding test fail while the adjacent connect suites stay green (35 tests across connect, connect-in-thread and client).

Note on `test:affected` locally: `demo-bank#test` fails on any non US Pacific machine independently of this change (the planted charge is seeded at 01:14 machine-local time, so on UTC+2 it lands on the previous UTC day and leaves the pinned same-day window), and `@vendoai/ui#test:ui` needs the Playwright browsers installed. The first is unreachable from this diff (which touches only `packages/ui` and a changeset); the second is a missing local browser install, and the touched suites above run green.
