### PR TITLE
fix(store): reserve idempotency keys before mutations

### DIFF
--- a/.changeset/idempotency-ledger-claim.md
+++ b/.changeset/idempotency-ledger-claim.md
@@ -1,0 +1,6 @@
+---
+"@vendoai/core": patch
+"@vendoai/store": patch
+---
+
+IdempotencyLedger.claim reserves a key before the mutation runs. A different body is refused before it writes, while same-body contenders wait for and replay the owner's answer.

--- a/packages/core/src/conformance/index.ts
+++ b/packages/core/src/conformance/index.ts
@@ -18,6 +18,7 @@ import {
   type RunContext,
   type SecretsProvider,
   type StoreAdapter,
+  type IdempotencyRecord,
   type ToolCall,
   type ToolDescriptor,
   type ToolRegistry,
@@ -130,13 +131,13 @@ type AdapterFactoryResult = { adapter: StoreAdapter; close?(): Promise<void> };
 const adapterCase = (
   opts: { makeAdapter(): Promise<AdapterFactoryResult> },
   name: string,
-  body: (adapter: StoreAdapter) => Promise<void>,
+  body: (adapter: StoreAdapter) => Promise<void | ConformanceOmission>,
 ): ConformanceCase => ({
   name,
-  async run(): Promise<void> {
+  async run(): Promise<void | ConformanceOmission> {
     const made = await opts.makeAdapter();
     try {
-      await body(made.adapter);
+      return await body(made.adapter);
     } finally {
       await made.close?.();
     }
@@ -146,10 +147,10 @@ const adapterCase = (
 const readyAdapterCase = (
   opts: { makeAdapter(): Promise<AdapterFactoryResult> },
   name: string,
-  body: (adapter: StoreAdapter) => Promise<void>,
+  body: (adapter: StoreAdapter) => Promise<void | ConformanceOmission>,
 ): ConformanceCase => adapterCase(opts, name, async (adapter) => {
   await adapter.ensureSchema();
-  await body(adapter);
+  return await body(adapter);
 });
 
 /** Executable StoreAdapter checks from 02-store §4 and 01-core §12. */
@@ -389,10 +390,11 @@ export function storeAdapterConformance(opts: {
         const scope = { tenant: "tenant_a", op: "workspace.commit", key: "idem_3" };
         await ledger.record(scope, "hash_a", { status: 200, result: { attempt: 1 } });
         await ledger.record(scope, "hash_a", { status: 500, result: { attempt: 2 } });
+        await ledger.record(scope, "hash_b", { status: 409, result: { attempt: 3 } });
         assertDeepEqual(
           await ledger.check(scope, "hash_a"),
           { status: 200, result: { attempt: 1 } },
-          "a second record replaced the answer a replay had already been given",
+          "a later same-hash or different-hash record replaced the first answer",
         );
       }),
 
@@ -412,6 +414,80 @@ export function storeAdapterConformance(opts: {
         assert(
           await ledger.check({ ...held, op: "lifecycle.erase" }, "hash_a") === null,
           "the same key on another op replayed the first op's answer",
+        );
+      }),
+
+      /** 01-core §12: `claim` reserves the key before the mutation. A second
+          caller with a different body is refused HERE, while the owner has not
+          yet published, so the refused request never executes. Optional: an
+          adapter that cannot reserve omits it. */
+      readyAdapterCase(opts, "01-core §12 — idempotency.claim refuses a different body before the owner publishes", async (adapter) => {
+        const ledger = adapter.idempotency;
+        if (ledger === undefined) return omitted("adapter has no idempotency ledger");
+        if (ledger.claim === undefined) return omitted("adapter has no idempotency.claim");
+        const scope = { tenant: "tenant_a", op: "workspace.commit", key: "idem_claim_1" };
+        const writes: string[] = [];
+        assert(await ledger.claim(scope, "hash_a") === "claimed", "a fresh key should claim");
+        writes.push("a");
+        const refusal = await ledger.claim(scope, "hash_b").then(() => null, (error: unknown) => error);
+        assert(
+          (refusal as { code?: unknown } | null)?.code === "conflict",
+          `claim with a different hash while the key is reserved should throw conflict, got ${String(refusal)}`,
+        );
+        await ledger.record(scope, "hash_a", { status: 200, result: { committed: 1 } });
+        assert(writes.length === 1 && writes[0] === "a", "the refused caller executed anyway");
+        assertDeepEqual(
+          await ledger.check(scope, "hash_a"),
+          { status: 200, result: { committed: 1 } },
+          "the owner could not publish after claiming",
+        );
+      }),
+
+      /** 01-core §12: a pending claim is held, not fresh. A mount still using
+          `check` must wait for the answer instead of running a second mutation. */
+      readyAdapterCase(opts, "01-core §12 — idempotency.check waits for a pending same-hash claim", async (adapter) => {
+        const ledger = adapter.idempotency;
+        if (ledger === undefined) return omitted("adapter has no idempotency ledger");
+        if (ledger.claim === undefined) return omitted("adapter has no idempotency.claim");
+        const scope = { tenant: "tenant_a", op: "workspace.commit", key: "idem_claim_check" };
+        assert(await ledger.claim(scope, "hash_a") === "claimed", "a fresh key should claim");
+        const replay = ledger.check(scope, "hash_a");
+        await ledger.record(scope, "hash_a", { status: 200, result: { committed: 1 } });
+        assertDeepEqual(
+          await replay,
+          { status: 200, result: { committed: 1 } },
+          "check treated a pending same-hash reservation as fresh",
+        );
+      }),
+
+      /** 01-core §12: two concurrent `claim`s with the same hash: one owner,
+          the loser waits and replays. The mutation runs once. */
+      readyAdapterCase(opts, "01-core §12 — idempotency.claim lets one same-hash owner run, the other replays", async (adapter) => {
+        const ledger = adapter.idempotency;
+        if (ledger === undefined) return omitted("adapter has no idempotency ledger");
+        if (ledger.claim === undefined) return omitted("adapter has no idempotency.claim");
+        const scope = { tenant: "tenant_a", op: "workspace.commit", key: "idem_claim_2" };
+        const claim = ledger.claim;
+        const writes: number[] = [];
+        const run = async (): Promise<IdempotencyRecord | "claimed"> => {
+          const got = await claim(scope, "hash_a");
+          if (got !== "claimed") return got;
+          writes.push(1);
+          const answer = { status: 200, result: { committed: writes.length } };
+          await ledger.record(scope, "hash_a", answer);
+          return "claimed";
+        };
+        const settled = await Promise.all([run(), run()]);
+        assert(writes.length === 1, `same-hash claim ran the mutation ${writes.length} times`);
+        assert(
+          settled.filter((one) => one === "claimed").length === 1,
+          "exactly one same-hash caller should own the reservation",
+        );
+        const replay = settled.find((one) => one !== "claimed");
+        assertDeepEqual(
+          replay,
+          { status: 200, result: { committed: 1 } },
+          "the loser did not receive the owner's published answer",
         );
       }),
 

--- a/packages/core/src/conformance/memory-store.ts
+++ b/packages/core/src/conformance/memory-store.ts
@@ -326,12 +326,18 @@ const projectMemoryRecord = (
 export interface MemoryStoreAdapterOptions {
   /** Deterministic clock for test assertions. */
   timestamp?: () => string;
+  /** Bound for a pending idempotency claim before waiters fail closed. */
+  idempotencyWaitTimeoutMs?: number;
 }
 
 export function memoryStoreAdapter(
   options: MemoryStoreAdapterOptions = {},
 ): StoreAdapter & { ensureSchema(): Promise<void> } {
   const collections = new Map<string, Map<string, VendoRecord & { seq: number }>>();
+  const idempotencyWaitTimeoutMs = options.idempotencyWaitTimeoutMs ?? 30_000;
+  if (!Number.isFinite(idempotencyWaitTimeoutMs) || idempotencyWaitTimeoutMs <= 0) {
+    throw new VendoError("validation", "idempotencyWaitTimeoutMs must be positive");
+  }
   let sequence = 0;
   let lastTimestamp = 0;
   const namespaces = new Map<string, Map<string, { bytes: Uint8Array; contentType?: string }>>();
@@ -382,7 +388,7 @@ export function memoryStoreAdapter(
         "unavailable",
         `idempotency key ${scope.key} is still being processed; retry later`,
       ));
-    }, 30_000);
+    }, idempotencyWaitTimeoutMs);
     held.waiters.push(wake);
   });
 

--- a/packages/core/src/conformance/memory-store.ts
+++ b/packages/core/src/conformance/memory-store.ts
@@ -353,9 +353,38 @@ export function memoryStoreAdapter(
 
   /** The three fields together ARE the key — spelled through JSON so a tenant
       or op containing the separator cannot forge another key's slot. */
-  const ledger = new Map<string, { requestHash: string; answer: IdempotencyRecord }>();
+  type LedgerHeld = {
+    requestHash: string;
+    answer?: IdempotencyRecord;
+    waiters: Array<(answer: IdempotencyRecord | null) => void>;
+  };
+  const ledger = new Map<string, LedgerHeld>();
   const ledgerKey = (scope: IdempotencyScope): string =>
     JSON.stringify([scope.tenant, scope.op, scope.key]);
+  const hashConflict = (scope: IdempotencyScope): VendoError => new VendoError(
+    "conflict",
+    `idempotency key ${scope.key} was already used with a different request body`,
+  );
+  const waitForAnswer = (scope: IdempotencyScope, held: LedgerHeld): Promise<IdempotencyRecord | null> => new Promise((resolve, reject) => {
+    if (held.answer !== undefined) {
+      resolve({ status: held.answer.status, result: jsonCopy(held.answer.result) });
+      return;
+    }
+    let timeout: ReturnType<typeof setTimeout>;
+    const wake = (answer: IdempotencyRecord | null): void => {
+      clearTimeout(timeout);
+      resolve(answer === null ? null : { status: answer.status, result: jsonCopy(answer.result) });
+    };
+    timeout = setTimeout(() => {
+      const index = held.waiters.indexOf(wake);
+      if (index !== -1) held.waiters.splice(index, 1);
+      reject(new VendoError(
+        "unavailable",
+        `idempotency key ${scope.key} is still being processed; retry later`,
+      ));
+    }, 30_000);
+    held.waiters.push(wake);
+  });
 
   const blobMap = (namespace: string): Map<string, { bytes: Uint8Array; contentType?: string }> => {
     let blobs = namespaces.get(namespace);
@@ -503,20 +532,43 @@ export function memoryStoreAdapter(
       async check(scope, requestHash) {
         const held = ledger.get(ledgerKey(scope));
         if (held === undefined) return null;
-        if (held.requestHash !== requestHash) {
-          throw new VendoError(
-            "conflict",
-            `idempotency key ${scope.key} was already used with a different request body`,
-          );
-        }
+        if (held.requestHash !== requestHash) throw hashConflict(scope);
+        if (held.answer === undefined) return waitForAnswer(scope, held);
         return { status: held.answer.status, result: jsonCopy(held.answer.result) };
       },
       async record(scope, requestHash, answer) {
         const key = ledgerKey(scope);
-        // First writer wins: the answer a replay has already been handed must
-        // not change under it.
-        if (ledger.has(key)) return;
-        ledger.set(key, { requestHash, answer: { status: answer.status, result: jsonCopy(answer.result) } });
+        const held = ledger.get(key);
+        if (held === undefined) {
+          ledger.set(key, {
+            requestHash,
+            answer: { status: answer.status, result: jsonCopy(answer.result) },
+            waiters: [],
+          });
+          return;
+        }
+        // First writer wins: a published answer must not change under a replay.
+        // A reservation (`claim`) is not yet an answer, so the owner may fill it.
+        if (held.answer !== undefined || held.requestHash !== requestHash) return;
+        held.answer = { status: answer.status, result: jsonCopy(answer.result) };
+        const waiters = held.waiters.splice(0);
+        for (const wake of waiters) wake(held.answer);
+      },
+      async claim(scope, requestHash) {
+        const key = ledgerKey(scope);
+        for (;;) {
+          const held = ledger.get(key);
+          if (held === undefined) {
+            ledger.set(key, { requestHash, waiters: [] });
+            return "claimed";
+          }
+          if (held.requestHash !== requestHash) throw hashConflict(scope);
+          if (held.answer !== undefined) {
+            return { status: held.answer.status, result: jsonCopy(held.answer.result) };
+          }
+          const answer = await waitForAnswer(scope, held);
+          if (answer !== null) return answer;
+        }
       },
     },
     blobs(namespace: string) {

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -156,6 +156,10 @@ export interface IdempotencyLedger {
    * contenders wait for the owner's answer rather than executing. Waiting is
    * bounded: if an owner disappears without publishing, callers
    * fail closed with `unavailable` instead of executing or polling forever.
+   * A pending claim is never expired automatically because its mutation may
+   * have committed before the owner disappeared. Transactional callers keep
+   * `claim`, the mutation, and {@link record} on one transaction-scoped store
+   * handle so rollback removes an unpublished reservation.
    */
   claim?(scope: IdempotencyScope, requestHash: string): Promise<IdempotencyRecord | "claimed">;
 }

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -119,15 +119,15 @@ export interface IdempotencyRecord {
  * happened. This is why `createStore()` hands one out instead of the ledger
  * being an adapter a host wires up separately.
  *
- * The guarantee is REPLAY protection, not mutual exclusion: two concurrent
- * requests carrying one key can both find the key fresh and both execute. That
- * is what a check-then-do ledger can promise, and saying so here is cheaper
- * than a caller discovering it in production.
+ * `check` then `record` is REPLAY protection, not mutual exclusion: two
+ * concurrent requests can both find the key fresh and both execute. A mount
+ * that needs the refused body never to reach the mutation uses {@link claim}.
  */
 export interface IdempotencyLedger {
   /**
    * What this key already answered, or null when it is fresh and the caller
-   * should go do the work.
+   * should go do the work. If the same hash has a pending {@link claim}, wait
+   * for its answer instead of reporting the key as fresh.
    *
    * `requestHash` is the caller's own digest of the request body. Passing it in
    * — rather than reading it back out and comparing at the call site — is what
@@ -138,8 +138,26 @@ export interface IdempotencyLedger {
   check(scope: IdempotencyScope, requestHash: string): Promise<IdempotencyRecord | null>;
   /** Record what this key answered. First writer wins; a later `record` for a
       key already held is ignored, never an overwrite — the answer a replay
-      already received must not change under it. */
+      already received must not change under it. After {@link claim} this
+      publishes onto the reservation rather than inserting a second row. A
+      claim owner records a terminal answer for both success and a caught
+      mutation failure. */
   record(scope: IdempotencyScope, requestHash: string, answer: IdempotencyRecord): Promise<void>;
+  /**
+   * Atomically reserve `(tenant, op, key)` for this request hash BEFORE the
+   * mutation runs.
+   * Optional on {@link RecordStore.claim}'s rule: an adapter that cannot
+   * reserve omits it, and a mount falls back to today's check-then-do.
+   *
+   * `"claimed"` means this caller owns the reservation and may run the
+   * mutation, then {@link record}. An `IdempotencyRecord` is a prior owner's
+   * published answer — replay it, do not mutate. A differing hash throws
+   * `conflict` here so a refused request never reaches the mutation. Equal-hash
+   * contenders wait for the owner's answer rather than executing. Waiting is
+   * bounded: if an owner disappears without publishing, callers
+   * fail closed with `unavailable` instead of executing or polling forever.
+   */
+  claim?(scope: IdempotencyScope, requestHash: string): Promise<IdempotencyRecord | "claimed">;
 }
 
 /** 01-core §12 */

--- a/packages/core/tests/conformance/index.test.ts
+++ b/packages/core/tests/conformance/index.test.ts
@@ -121,6 +121,14 @@ describe("StoreAdapter conformance", () => {
     expect(report.passed).toBeGreaterThan(0);
   });
 
+  it("memoryStoreAdapter honors the configured idempotency wait timeout", async () => {
+    const adapter = memoryStoreAdapter({ idempotencyWaitTimeoutMs: 5 });
+    const ledger = adapter.idempotency!;
+    const scope = { tenant: "tenant_a", op: "workspace.commit", key: "memory_timeout" };
+    expect(await ledger.claim!(scope, "hash_a")).toBe("claimed");
+    await expect(ledger.check(scope, "hash_a")).rejects.toMatchObject({ code: "unavailable" });
+  });
+
   it("rejects a broken store and reports failing case names", async () => {
     const report = await runConformance(storeAdapterConformance({
       async makeAdapter() {

--- a/packages/store/src/idempotency.ts
+++ b/packages/store/src/idempotency.ts
@@ -1,43 +1,194 @@
-import { VendoError, type IdempotencyLedger, type Json } from "@vendoai/core";
+import { VendoError, type IdempotencyLedger, type IdempotencyRecord, type IdempotencyScope, type Json } from "@vendoai/core";
 // Type-only — erased at compile time, so this module stays engine-free and can
 // be assembled into the store alongside the routing doors (see store.ts).
 import type { Db } from "./db-postgres.js";
 import { jsonParam, text } from "./helpers/utils.js";
 
+const PENDING_RESULT = {} as const;
+const WAIT_INTERVAL_MS = 50;
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => {
+  setTimeout(resolve, ms);
+});
+
+const hashConflict = (scope: IdempotencyScope): VendoError => new VendoError(
+  "conflict",
+  `idempotency key ${JSON.stringify(scope.key)} on ${scope.op} was already used for a `
+  + "different request body, so there is no recorded answer that belongs to this one — "
+  + "a key stands for ONE request. Mint a fresh key for a new request, and reuse a key "
+  + "only to retry the identical body.",
+);
+
+const pendingTimeout = (scope: IdempotencyScope): VendoError => new VendoError(
+  "unavailable",
+  `idempotency key ${JSON.stringify(scope.key)} on ${scope.op} is still being processed; retry later`,
+);
+
+const published = (row: Record<string, unknown>): IdempotencyRecord | undefined => {
+  if (row["claim_token"] !== null && row["claim_token"] !== undefined) return undefined;
+  return { status: Number(row["status"]), result: row["result"] as Json };
+};
+
 /** 01 §12 — the `Idempotency-Key` replay ledger over `vendo_idempotency_ledger`,
  *  the table this same database carries (schema.ts v8). Colocated with the
  *  mutations it gates by construction: it runs on the handle the mutation runs
  *  on, so the two commit or roll back together. */
-export function createIdempotencyLedger(db: Db): IdempotencyLedger {
+export function createIdempotencyLedger(
+  db: Db,
+  options: { waitTimeoutMs?: number } = {},
+): IdempotencyLedger {
+  const waitTimeoutMs = options.waitTimeoutMs ?? 30_000;
+  if (!Number.isFinite(waitTimeoutMs) || waitTimeoutMs <= 0) {
+    throw new VendoError("validation", "idempotency waitTimeoutMs must be positive");
+  }
+
+  const raceDeadline = async <T>(promise: Promise<T>, deadline: number): Promise<T | "expired"> => {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return "expired";
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        promise,
+        new Promise<"expired">((resolve) => {
+          timeout = setTimeout(() => resolve("expired"), remaining);
+        }),
+      ]);
+    } finally {
+      if (timeout !== undefined) clearTimeout(timeout);
+    }
+  };
+
+  const load = async (
+    scope: IdempotencyScope,
+    deadline: number,
+  ): Promise<Record<string, unknown> | undefined> => {
+    const query = db.query(
+      `SELECT request_hash, status, result, claim_token FROM vendo_idempotency_ledger
+       WHERE tenant = $1 AND op = $2 AND key = $3`,
+      [scope.tenant, scope.op, scope.key],
+    );
+    const result = await raceDeadline(query, deadline);
+    if (result === "expired") throw pendingTimeout(scope);
+    return result.rows[0];
+  };
+
+  const assertHash = (row: Record<string, unknown>, scope: IdempotencyScope, requestHash: string): void => {
+    if (text(row["request_hash"]) !== requestHash) throw hashConflict(scope);
+  };
+
+  const waitForAnswer = async (
+    scope: IdempotencyScope,
+    requestHash: string,
+    first: Record<string, unknown>,
+    deadline: number,
+  ): Promise<IdempotencyRecord | null> => {
+    let row = first;
+    for (;;) {
+      assertHash(row, scope, requestHash);
+      const answer = published(row);
+      if (answer !== undefined) return answer;
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) throw pendingTimeout(scope);
+      await delay(Math.min(WAIT_INTERVAL_MS, remaining));
+      const loaded = await load(scope, deadline);
+      if (loaded === undefined) return null;
+      row = loaded;
+    }
+  };
+
+  const cleanupTimedOutInsert = async (
+    scope: IdempotencyScope,
+    requestHash: string,
+    claimToken: string,
+  ): Promise<void> => {
+    await db.query(
+      `DELETE FROM vendo_idempotency_ledger
+       WHERE tenant = $1 AND op = $2 AND key = $3
+         AND request_hash = $4 AND claim_token = $5`,
+      [scope.tenant, scope.op, scope.key, requestHash, claimToken],
+    );
+  };
+
+  const boundedInsert = async (
+    scope: IdempotencyScope,
+    requestHash: string,
+    claimToken: string,
+    deadline: number,
+  ): Promise<{ rows: Record<string, unknown>[] }> => {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) throw pendingTimeout(scope);
+    const query = db.query(
+      `WITH previous AS MATERIALIZED (
+         SELECT current_setting('lock_timeout') AS lock_timeout
+       ), configure AS MATERIALIZED (
+         SELECT lock_timeout, set_config('lock_timeout', $7, true) FROM previous
+       ), inserted AS (
+         INSERT INTO vendo_idempotency_ledger
+           (tenant, op, key, request_hash, status, result, claim_token)
+         SELECT $1, $2, $3, $4, 503, $5::jsonb, $6 FROM configure
+         ON CONFLICT (tenant, op, key) DO NOTHING
+         RETURNING claim_token
+       ), restore AS MATERIALIZED (
+         SELECT set_config('lock_timeout', configure.lock_timeout, true)
+         FROM configure LEFT JOIN inserted ON true
+       )
+       SELECT inserted.claim_token
+       FROM restore LEFT JOIN inserted ON true`,
+      [scope.tenant, scope.op, scope.key, requestHash, jsonParam(PENDING_RESULT), claimToken, String(remaining)],
+    );
+    const result = await raceDeadline(query, deadline);
+    if (result !== "expired") return result;
+
+    // PGlite queues behind an open transaction before the SQL statement can
+    // install lock_timeout. If the queued INSERT eventually wins, remove its
+    // reservation because this caller has already failed closed.
+    void query.then(async (late) => {
+      if (late.rows[0]?.["claim_token"] === claimToken) {
+        await cleanupTimedOutInsert(scope, requestHash, claimToken);
+      }
+    }).catch(() => undefined);
+    throw pendingTimeout(scope);
+  };
+
   return {
     async check(scope, requestHash) {
-      const result = await db.query(
-        `SELECT request_hash, status, result FROM vendo_idempotency_ledger
-         WHERE tenant = $1 AND op = $2 AND key = $3`,
-        [scope.tenant, scope.op, scope.key],
-      );
-      const row = result.rows[0];
+      const deadline = Date.now() + waitTimeoutMs;
+      const row = await load(scope, deadline);
       if (row === undefined) return null;
-      if (text(row["request_hash"]) !== requestHash) {
-        throw new VendoError(
-          "conflict",
-          `idempotency key ${JSON.stringify(scope.key)} on ${scope.op} was already used for a `
-          + "different request body, so there is no recorded answer that belongs to this one — "
-          + "a key stands for ONE request. Mint a fresh key for a new request, and reuse a key "
-          + "only to retry the identical body.",
-        );
-      }
-      return { status: Number(row["status"]), result: row["result"] as Json };
+      return waitForAnswer(scope, requestHash, row, deadline);
     },
     async record(scope, requestHash, answer) {
-      // First writer wins: the answer a replay has already been handed must not
-      // change under it, so a later record for a held key is a no-op.
+      // First writer wins. ON CONFLICT DO UPDATE fills a reservation `claim`
+      // left with a claim token; a later record against a published row is a
+      // no-op. The request_hash predicate keeps a different body from
+      // publishing over someone else's reservation.
       await db.query(
         `INSERT INTO vendo_idempotency_ledger (tenant, op, key, request_hash, status, result)
          VALUES ($1, $2, $3, $4, $5, $6::jsonb)
-         ON CONFLICT (tenant, op, key) DO NOTHING`,
+         ON CONFLICT (tenant, op, key) DO UPDATE
+         SET status = EXCLUDED.status, result = EXCLUDED.result, claim_token = NULL
+         WHERE vendo_idempotency_ledger.claim_token IS NOT NULL
+           AND vendo_idempotency_ledger.request_hash = EXCLUDED.request_hash`,
         [scope.tenant, scope.op, scope.key, requestHash, answer.status, jsonParam(answer.result)],
       );
+    },
+    async claim(scope, requestHash) {
+      const deadline = Date.now() + waitTimeoutMs;
+      for (;;) {
+        let inserted: { rows: Record<string, unknown>[] };
+        const claimToken = globalThis.crypto.randomUUID();
+        try {
+          inserted = await boundedInsert(scope, requestHash, claimToken, deadline);
+        } catch (error) {
+          if ((error as { code?: unknown }).code === "55P03") throw pendingTimeout(scope);
+          throw error;
+        }
+        if (inserted.rows[0]?.["claim_token"] === claimToken) return "claimed";
+        const row = await load(scope, deadline);
+        if (row === undefined) continue;
+        const answer = await waitForAnswer(scope, requestHash, row, deadline);
+        if (answer !== null) return answer;
+      }
     },
   };
 }

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -212,13 +212,17 @@ export const DDL = [
   "CREATE INDEX IF NOT EXISTS vendo_app_grants_principal_idx ON vendo_app_grants (principal)",
   // v8 (01 §12): the `Idempotency-Key` replay ledger, in the shape the Vendo
   // Cloud console already runs. `status` + `result` are the answer a repeat
-  // caller is handed back verbatim; `request_hash` is what separates a replay
-  // from the same key carrying a DIFFERENT body, which is a client bug and not a
-  // replay at all. The PK is the whole scope, `tenant` first, so a mount serving
-  // many tenants out of one schema cannot let one tenant's key answer another's.
+  // caller is handed back verbatim. A non-NULL `claim_token` marks a pending
+  // reservation and fences cleanup of a timed-out insert to that exact claim
+  // generation. Older readers ignore the additive column and fail closed on
+  // the stored 503 answer. `request_hash` separates a replay from the
+  // same key carrying a DIFFERENT body, which is a client bug and not a replay
+  // at all. The PK is the whole scope, `tenant` first, so a mount serving many
+  // tenants out of one schema cannot let one tenant's key answer another's.
   `CREATE TABLE IF NOT EXISTS vendo_idempotency_ledger (
     tenant text NOT NULL, op text NOT NULL, key text NOT NULL,
     request_hash text NOT NULL, status int NOT NULL, result jsonb NOT NULL,
+    claim_token text,
     created_at timestamptz NOT NULL DEFAULT now(),
     PRIMARY KEY (tenant, op, key)
   )`,
@@ -344,6 +348,10 @@ const ADDITIVE_DDL = [
   // receipt written before the column existed genuinely has no known owner, and
   // every write path has supplied one since.
   "ALTER TABLE vendo_effects ADD COLUMN IF NOT EXISTS subject text NOT NULL DEFAULT ''",
+  // A non-NULL token is the pending discriminator for IdempotencyLedger.claim.
+  // Existing published rows stay NULL, so every previously valid status/result
+  // pair remains an ordinary replay answer after this additive upgrade.
+  "ALTER TABLE vendo_idempotency_ledger ADD COLUMN IF NOT EXISTS claim_token text",
   // Guest sessions are gone, so the v4 registry is an orphan on any database that
   // booted before its CREATE was removed. The version gate would never re-run the
   // DDL loop on those databases, so the drop lives here and runs every boot.

--- a/packages/store/tests/conformance.test.ts
+++ b/packages/store/tests/conformance.test.ts
@@ -21,7 +21,12 @@ for (const backend of backends()) {
           return { adapter: made.store, close: made.cleanup };
         },
       });
-      for (const c of suite.cases) it(c.name, c.run);
+      for (const c of suite.cases) {
+        it(c.name, async () => {
+          const result = await c.run();
+          expect(result, result === undefined ? undefined : result.omitted).toBeUndefined();
+        });
+      }
     });
 
     describe("environment SecretsProvider conformance", () => {

--- a/packages/store/tests/idempotency.test.ts
+++ b/packages/store/tests/idempotency.test.ts
@@ -1,6 +1,8 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { backends, type MadeBackend } from "../src/backends.test-util.js";
 import type { IdempotencyLedger } from "@vendoai/core";
+import type { Db } from "../src/db-postgres.js";
+import { createIdempotencyLedger, maybeDbFor } from "../src/index.js";
 
 // 01 §12 — the `Idempotency-Key` replay ledger, served off the same database as
 // the mutations it gates. `createStore()` hands one out, so a mount never has to
@@ -42,5 +44,177 @@ for (const backend of backends()) {
       await ledger.record(scope, "hash_1", { status: 500, result: { error: "late" } });
       expect(await ledger.check(scope, "hash_1")).toEqual({ status: 201, result: { id: "wsc_1" } });
     });
+
+    it("claim refuses a different-body racer before it writes", async () => {
+      const raced = { tenant: "tenant_a", op: "workspace.commit", key: "key_claim_diff" };
+      const claim = ledger.claim;
+      if (claim === undefined) throw new Error("createStore ledger must serve claim");
+      const writes: string[] = [];
+      const run = async (hash: string, body: string): Promise<unknown> => {
+        const got = await claim(raced, hash);
+        if (got !== "claimed") return got;
+        writes.push(body);
+        await ledger.record(raced, hash, { status: 200, result: { body } });
+        return "claimed";
+      };
+      const settled = await Promise.allSettled([run("hash_a", "a"), run("hash_b", "b")]);
+      expect(writes).toHaveLength(1);
+      expect(settled.filter((one) => one.status === "fulfilled")).toHaveLength(1);
+      const loser = settled.find((one) => one.status === "rejected") as PromiseRejectedResult;
+      expect(loser.reason).toMatchObject({ code: "conflict" });
+      const winner = writes[0]!;
+      expect(await ledger.check(raced, winner === "a" ? "hash_a" : "hash_b"))
+        .toEqual({ status: 200, result: { body: winner } });
+    });
+
+    it("claim: same-hash racers run the mutation once and the loser replays", async () => {
+      const raced = { tenant: "tenant_a", op: "workspace.commit", key: "key_claim_same" };
+      const claim = ledger.claim;
+      if (claim === undefined) throw new Error("createStore ledger must serve claim");
+      const writes: string[] = [];
+      const run = async (): Promise<unknown> => {
+        const got = await claim(raced, "hash_a");
+        if (got !== "claimed") return got;
+        writes.push("a");
+        await ledger.record(raced, "hash_a", { status: 201, result: { id: "once" } });
+        return "claimed";
+      };
+      const settled = await Promise.all([run(), run()]);
+      expect(writes).toEqual(["a"]);
+      expect(settled.filter((one) => one === "claimed")).toHaveLength(1);
+      expect(settled.find((one) => one !== "claimed")).toEqual({ status: 201, result: { id: "once" } });
+    });
+
+    it("keeps every previously valid 503 answer replayable", async () => {
+      const raced = { tenant: "tenant_a", op: "workspace.commit", key: "key_claim_status" };
+      await ledger.record(raced, "hash_a", {
+        status: 503,
+        result: { __vendo_idempotency_pending_v1: true },
+      });
+      expect(await ledger.check(raced, "hash_a"))
+        .toEqual({ status: 503, result: { __vendo_idempotency_pending_v1: true } });
+    });
+
+    it("restores the transaction's lock timeout after claiming", async () => {
+      const db = maybeDbFor(made.store);
+      if (db === undefined) throw new Error("createStore must expose its database handle");
+      const raced = { tenant: "tenant_a", op: "workspace.commit", key: "key_claim_timeout_restore" };
+      await db.transaction(async (query) => {
+        const before = (await query("SHOW lock_timeout")).rows[0]?.["lock_timeout"];
+        const txLedger = createIdempotencyLedger({ ...db, query }, { waitTimeoutMs: 25 });
+        expect(await txLedger.claim!(raced, "hash_a")).toBe("claimed");
+        expect((await query("SHOW lock_timeout")).rows[0]?.["lock_timeout"]).toBe(before);
+        await txLedger.record(raced, "hash_a", { status: 200, result: { committed: true } });
+      });
+    });
+
+    it("bounds claim acquisition behind an uncommitted owner", async () => {
+      const db = maybeDbFor(made.store);
+      if (db === undefined) throw new Error("createStore must expose its database handle");
+      const raced = { tenant: "tenant_a", op: "workspace.commit", key: "key_claim_blocked" };
+      let releaseOwner!: () => void;
+      let ownerReady!: () => void;
+      const held = new Promise<void>((resolve) => { releaseOwner = resolve; });
+      const ready = new Promise<void>((resolve) => { ownerReady = resolve; });
+      const owner = db.transaction(async (query) => {
+        const txLedger = createIdempotencyLedger({ ...db, query }, { waitTimeoutMs: 25 });
+        expect(await txLedger.claim!(raced, "hash_a")).toBe("claimed");
+        ownerReady();
+        await held;
+        await txLedger.record(raced, "hash_a", { status: 200, result: { committed: true } });
+      });
+      await ready;
+      try {
+        const contender = createIdempotencyLedger(db, { waitTimeoutMs: 25 });
+        await expect(contender.claim!(raced, "hash_a"))
+          .rejects.toMatchObject({ code: "unavailable" });
+      } finally {
+        releaseOwner();
+        await owner;
+      }
+    });
   });
 }
+
+const queryOnlyDb = (query: Db["query"]): Db => ({
+  kind: "pglite",
+  query,
+  async close() {},
+  raw: () => undefined,
+  withSchemaLock: async (work) => work(query),
+  transaction: async (work) => work(query),
+});
+
+describe("idempotency query deadlines", () => {
+  it.each(["check", "claim"] as const)("bounds a queued SELECT during %s", async (operation) => {
+    const queued = new Promise<{ rows: Record<string, unknown>[] }>((resolve) => {
+      setTimeout(() => resolve({ rows: [] }), 200);
+    });
+    const db = queryOnlyDb(async (sql) => (
+      sql.includes("INSERT INTO vendo_idempotency_ledger") ? { rows: [] } : queued
+    ));
+    const ledger = createIdempotencyLedger(db, { waitTimeoutMs: 25 });
+    const started = Date.now();
+
+    const call = operation === "check"
+      ? ledger.check(scope, "hash_queued")
+      : ledger.claim!(scope, "hash_queued");
+    await expect(call).rejects.toMatchObject({ code: "unavailable" });
+    expect(Date.now() - started).toBeLessThan(150);
+  });
+
+  it("clears its deadline timer when the claim INSERT rejects", async () => {
+    vi.useFakeTimers();
+    try {
+      const db = queryOnlyDb(async () => { throw new Error("query failed"); });
+      const ledger = createIdempotencyLedger(db, { waitTimeoutMs: 2_000 });
+      await expect(ledger.claim!(scope, "hash_failed")).rejects.toThrow("query failed");
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("maps PostgreSQL lock timeouts to unavailable without leaving a timer", async () => {
+    vi.useFakeTimers();
+    try {
+      const db = queryOnlyDb(async () => { throw Object.assign(new Error("lock timeout"), { code: "55P03" }); });
+      const ledger = createIdempotencyLedger(db, { waitTimeoutMs: 2_000 });
+      await expect(ledger.claim!(scope, "hash_locked")).rejects.toMatchObject({ code: "unavailable" });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("fences late INSERT cleanup to the timed-out claim generation", async () => {
+    let finishInsert!: (result: { rows: Record<string, unknown>[] }) => void;
+    const insert = new Promise<{ rows: Record<string, unknown>[] }>((resolve) => {
+      finishInsert = resolve;
+    });
+    let insertedToken: unknown;
+    let replacementToken: unknown;
+    let cleanupToken: unknown;
+    const db = queryOnlyDb(async (sql, params = []) => {
+      if (sql.includes("INSERT INTO vendo_idempotency_ledger")) {
+        insertedToken = params[5];
+        return insert;
+      }
+      if (sql.includes("DELETE FROM vendo_idempotency_ledger")) {
+        cleanupToken = params[4];
+        if (cleanupToken === replacementToken) replacementToken = undefined;
+        return { rows: [] };
+      }
+      return { rows: [] };
+    });
+    const ledger = createIdempotencyLedger(db, { waitTimeoutMs: 25 });
+
+    await expect(ledger.claim!(scope, "hash_late")).rejects.toMatchObject({ code: "unavailable" });
+    replacementToken = "replacement-claim-token";
+    finishInsert({ rows: [{ claim_token: insertedToken }] });
+    await new Promise((resolve) => { setTimeout(resolve, 0); });
+
+    expect(cleanupToken).toBe(insertedToken);
+    expect(replacementToken).toBe("replacement-claim-token");
+  });
+});

--- a/packages/store/tests/idempotency.test.ts
+++ b/packages/store/tests/idempotency.test.ts
@@ -108,6 +108,20 @@ for (const backend of backends()) {
       });
     });
 
+    it("lets a retry claim after the owner's transaction rolls back", async () => {
+      const db = maybeDbFor(made.store);
+      if (db === undefined) throw new Error("createStore must expose its database handle");
+      const raced = { tenant: "tenant_a", op: "workspace.commit", key: "key_claim_rollback" };
+      await expect(db.transaction(async (query) => {
+        const txLedger = createIdempotencyLedger({ ...db, query });
+        expect(await txLedger.claim!(raced, "hash_a")).toBe("claimed");
+        throw new Error("roll back the owner");
+      })).rejects.toThrow("roll back the owner");
+
+      expect(await ledger.claim!(raced, "hash_a")).toBe("claimed");
+      await ledger.record(raced, "hash_a", { status: 200, result: { committed: true } });
+    });
+
     it("bounds claim acquisition behind an uncommitted owner", async () => {
       const db = maybeDbFor(made.store);
       if (db === undefined) throw new Error("createStore must expose its database handle");

--- a/packages/store/tests/schema.test.ts
+++ b/packages/store/tests/schema.test.ts
@@ -26,7 +26,7 @@ const CONTRACT_COLUMNS: Record<string, string[]> = {
   vendo_workspace_files: ["path", "owner", "content", "blob_ref", "bytes", "revision", "created_at", "updated_at"],
   vendo_workspace_history: ["id", "path", "owner", "revision", "content", "blob_ref", "intent", "at"],
   vendo_app_grants: ["id", "app_id", "org_id", "principal", "level", "created_by", "created_at"],
-  vendo_idempotency_ledger: ["tenant", "op", "key", "request_hash", "status", "result", "created_at"],
+  vendo_idempotency_ledger: ["tenant", "op", "key", "request_hash", "status", "result", "claim_token", "created_at"],
   vendo_quarantine: ["collection", "id", "data", "subject", "app_id", "quarantined_at"],
 };
 
@@ -136,6 +136,19 @@ for (const backend of backends()) {
         expect(actual.has(table), table).toBe(true);
         for (const column of columns) expect(actual.get(table)?.has(column), `${table}.${column}`).toBe(true);
       }
+    });
+
+    it("adds claim_token to an existing current-version idempotency ledger", async () => {
+      await made.sql("ALTER TABLE vendo_idempotency_ledger DROP COLUMN claim_token");
+
+      await made.store.ensureSchema();
+
+      const rows = await made.sql(
+        `SELECT column_name FROM information_schema.columns
+         WHERE table_schema = 'public' AND table_name = 'vendo_idempotency_ledger'
+           AND column_name = 'claim_token'`,
+      );
+      expect(rows).toEqual([{ column_name: "claim_token" }]);
     });
 
     it("stores every contracted JSON column as jsonb", async () => {


### PR DESCRIPTION
## What

Add an optional atomic `claim` operation to `IdempotencyLedger`.

The Postgres/PGlite and memory implementations now:

- Reserve `(tenant, op, key)` before the mutation begins.
- Reject a different request hash with `conflict` before it can write.
- Make same-hash contenders wait for and replay the owner's answer.
- Make `check` wait when it encounters a pending claim.
- Publish the final answer through `record` without overwriting an existing answer.
- Bound claim acquisition and pending reads, failing closed with `unavailable`.
- Use an additive claim-token column to distinguish pending rows without reinterpreting existing responses.

The claim token also fences cleanup of a timed-out PGlite insert to that exact claim generation.

## Why

The existing check-then-record flow allows two requests using the same idempotency key with different bodies to both pass `check` and execute. The losing request discovers the conflict only after its mutation may have committed.

Atomic reservation moves that conflict check ahead of the mutation. A refused request never writes, while an identical retry receives the first caller's recorded answer.

Fixes #1297.

## Verification

- [x] `pnpm build` passed
- [x] Idempotency tests passed on PGlite
- [x] Schema and adapter conformance tests passed
- [x] Core and store typechecks passed
- [x] Blocking package lint passed
- [x] Playwright Chromium smoke tests passed
- [x] Changeset added
- [x] Screenshots not applicable; no UI changes

`pnpm test:affected` was also run. It reached an unrelated 30-second timeout in an `@vendoai/agents` away-runner test; the idempotency, schema, conformance, memory-adapter, and Playwright tests were green. `POSTGRES_URL` was not available locally, so repository CI will run the PostgreSQL leg.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reserves idempotency keys before mutations so different-body racers are refused early and identical retries replay the owner’s answer. Previously, two same-key different-body requests could both pass check and execute; now `claim` fences the mutation, `check` waits on a pending same-hash claim, and `record` publishes without overwriting an existing answer.

- Review and rollout
  - `@vendoai/core`: `IdempotencyLedger` adds optional `claim(scope, hash)`. `check(scope, hash)` now waits when the same key is reserved with the same hash. `record(scope, hash, answer)` fills a reservation; first writer still wins.
  - `@vendoai/store` (Postgres/PGlite): adds `claim_token` column; bounds waits for both `SELECT` and `INSERT` with per-INSERT `lock_timeout`; maps PG lock timeouts to `unavailable`; cleans up late inserts for the exact claim generation; default wait timeout is 30s and configurable. Transactional callers should keep `claim`, the mutation, and `record` on one transaction-scoped handle so rollback removes an unpublished reservation.
  - Memory adapter: mirrors `claim`/wait semantics with bounded waiters; adds configurable `idempotencyWaitTimeoutMs` (must be positive).
  - Migration actions: run `store.ensureSchema()` to add `claim_token`. If a mount needs the refused body never to write, call `ledger.claim` before the mutation; otherwise the existing check-then-record flow continues to work.
  - Side effects: same-hash contenders wait and replay; different-hash throws `conflict` before work; pending waits fail closed with `unavailable`. Backward compatible: previously recorded answers (including 503) remain replayable; older readers ignore `claim_token`.

<sup>Written for commit d3097ce98c8d98bcc53cc0de2550b3896773be9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

