### PR TITLE
feat(core,store): IdempotencyLedger.claim reserves before the mutation

### DIFF
--- a/.changeset/idempotency-claim.md
+++ b/.changeset/idempotency-claim.md
@@ -1,0 +1,61 @@
+---
+"@vendoai/core": minor
+"@vendoai/store": minor
+---
+
+`IdempotencyLedger.claim` — the refusal moves in front of the mutation.
+
+The ledger was check-then-do, so two concurrent requests carrying one key both
+found it fresh and both executed. For an EQUAL body that is benign and always
+was: one key, one body, one effect, and whichever request answers first is the
+answer every later replay gets. For a DIFFERENT body it was not. Both mutations
+committed, and the loser was then refused `conflict` by a verb that ran AFTER
+its write — an error naming the key while the write it refuses sits in the
+store, which is the one thing an idempotency ledger exists to prevent.
+
+`claim` reserves `(tenant, op, key)` for a request hash BEFORE the mutation
+runs, in one statement against the scope's own primary key, so the key itself is
+the serialization point:
+
+```ts
+const held = await store.idempotency?.claim?.(scope, requestHash);
+if (held === "claimed") {
+  // the reservation is ours: do the work, then record the answer
+} else if (held !== null && held !== undefined) {
+  // a prior owner already published: replay it, apply nothing
+}
+// null: same body, not yet answered — proceed, exactly as check's null says to
+```
+
+- **`null` means PROCEED, not wait.** A contender carrying the same hash is the
+  benign case the ledger has always permitted to execute twice, so it is told to
+  go — never to block. A contender that waited would hang behind an owner that
+  died between `claim` and `record`, which is the ordinary client-timeout retry
+  (`hostedStoreOps` replays the same key on exactly that path).
+- **No lease, and none would help.** An expiry cannot tell a dead owner from a
+  slow one, so it buys back the double-execution it was added to prevent while
+  adding a way to steal a live owner's key. A dropped request costs one
+  execution, which is what it cost before; it never costs the key.
+- **A reservation is not an answer.** `check` and `claim` share one reader, so
+  the two cannot drift on what a held row means — a divergence there reopens the
+  race, since a `check` caller told "fresh" mutates straight past a reservation.
+- **`record` settles the reservation it owns, and only that one.** First ANSWER
+  still wins: an answered key is never overwritten, and a request that never held
+  the key cannot stamp its own answer onto one, which is reachable on the `check`
+  fallback where a key can be taken between the check and the record.
+- **No migration.** `status = 0` is the reservation. It rides the existing column
+  because 0 is not a status a mount can send, so no reader — including a console
+  copy of the table that predates this verb — can mistake a reservation for a
+  replayable result, and no row of that shape exists until something calls
+  `claim`.
+- **OPTIONAL, on `RecordStore.atomic`'s rule.** An adapter that cannot reserve
+  omits `claim`; a caller that finds it absent falls back to `check` then
+  `record` with the race that implies. Nothing in the repo is required to adopt
+  it, and `workspace.commit` does not — it already claims its own ledger row
+  inside the mutation's transaction, which is the stronger guarantee `claim`
+  approximates for callers that cannot enclose their mutation.
+
+Served by the Postgres ledger and the in-memory reference, with conformance
+cases both run — including concurrent claims fired at one instant, because a
+read-then-insert implementation passes every sequential case and still lets both
+racers reserve.

--- a/packages/core/src/conformance/index.ts
+++ b/packages/core/src/conformance/index.ts
@@ -415,6 +415,74 @@ export function storeAdapterConformance(opts: {
         );
       }),
 
+      /** 01-core §12: `claim`'s whole reason to exist. The same key carrying a
+          DIFFERENT body is refused AT THE RESERVATION, so the caller never gets
+          as far as its mutation — where `check` refuses the identical request
+          only after it has already committed one. The reservation the winner
+          holds survives the refusal: a losing body must not be able to knock the
+          owner off its own key. */
+      readyAdapterCase(opts, "01-core §12 — idempotency.claim refuses a differing request before the mutation", async (adapter) => {
+        const ledger = adapter.idempotency;
+        if (ledger?.claim === undefined) return;
+        const scope = { tenant: "tenant_a", op: "workspace.commit", key: "idem_claim_1" };
+        assert(await ledger.claim(scope, "hash_a") === "claimed", "a fresh key did not reserve");
+        const refusal = await ledger.claim(scope, "hash_b").then(() => null, (error: unknown) => error);
+        assert(
+          (refusal as { code?: unknown } | null)?.code === "conflict",
+          `a reserved key claimed with a different request hash should throw conflict, got ${String(refusal)}`,
+        );
+        await ledger.record(scope, "hash_a", { status: 200, result: { committed: 1 } });
+        assertDeepEqual(
+          await ledger.check(scope, "hash_a"),
+          { status: 200, result: { committed: 1 } },
+          "the refused claim took the reservation away from the request that held it",
+        );
+      }),
+
+      /** 01-core §12: the reservation's whole lifecycle. A contender carrying the
+          SAME hash is told to PROCEED (null), not to wait — one key and one body
+          is one effect, and a contender that blocked would hang behind an owner
+          that died before `record`. Until it is settled a reservation is not an
+          answer, so neither verb may hand it back as one: `status` 0 replayed as
+          a result is a mount answering 0 to a live request. */
+      readyAdapterCase(opts, "01-core §12 — idempotency.claim reserves, never replays a reservation, and record settles it", async (adapter) => {
+        const ledger = adapter.idempotency;
+        if (ledger?.claim === undefined) return;
+        const scope = { tenant: "tenant_a", op: "workspace.commit", key: "idem_claim_2" };
+        assert(await ledger.claim(scope, "hash_a") === "claimed", "a fresh key did not reserve");
+        assert(await ledger.claim(scope, "hash_a") === null, "a same-body contender was not told to proceed");
+        assert(await ledger.check(scope, "hash_a") === null, "an unsettled reservation was replayed as an answer");
+        await ledger.record(scope, "hash_a", { status: 201, result: { id: "wsc_1" } });
+        assertDeepEqual(
+          await ledger.claim(scope, "hash_a"),
+          { status: 201, result: { id: "wsc_1" } },
+          "a claim after the key was settled did not replay the recorded answer",
+        );
+        assertDeepEqual(
+          await ledger.check(scope, "hash_a"),
+          { status: 201, result: { id: "wsc_1" } },
+          "check did not replay the answer that settled the reservation",
+        );
+      }),
+
+      /** 01-core §12: the reservation is ATOMIC or it is nothing. Fired together
+          rather than in sequence, because a read-then-insert implementation
+          passes every sequential case above and still lets both racers reserve —
+          which is the check-then-do shape `claim` exists to replace. */
+      readyAdapterCase(opts, "01-core §12 — concurrent idempotency.claim calls reserve exactly once", async (adapter) => {
+        const ledger = adapter.idempotency;
+        if (ledger?.claim === undefined) return;
+        const claim = ledger.claim.bind(ledger);
+        const scope = { tenant: "tenant_a", op: "workspace.commit", key: "idem_claim_3" };
+        const settled = await Promise.all([claim(scope, "hash_a"), claim(scope, "hash_a"), claim(scope, "hash_a")]);
+        const won = settled.filter((one) => one === "claimed");
+        assert(won.length === 1, `${won.length} of 3 concurrent claims reserved one key; exactly 1 may`);
+        assert(
+          settled.filter((one) => one === null).length === 2,
+          "a contender that lost the reservation was not told to proceed",
+        );
+      }),
+
       /** 01-core §12: blob list filters keys by prefix. */
       readyAdapterCase(opts, "01-core §12 — blobs.list filters by prefix", async (adapter) => {
         const blobs = adapter.blobs("conformance_blob_list");

--- a/packages/core/src/conformance/memory-store.ts
+++ b/packages/core/src/conformance/memory-store.ts
@@ -356,6 +356,27 @@ export function memoryStoreAdapter(
   const ledger = new Map<string, { requestHash: string; answer: IdempotencyRecord }>();
   const ledgerKey = (scope: IdempotencyScope): string =>
     JSON.stringify([scope.tenant, scope.op, scope.key]);
+  /** A reservation `claim` took that nobody has answered yet. Mirrors the
+      Postgres ledger's sentinel (`store/src/idempotency.ts`): 0 is not a status
+      a mount can send, so a reservation can never be read back as an answer. */
+  const RESERVED = 0;
+  /** What a held entry answers THIS request — shared by `check` and `claim` so
+      the two cannot drift on what a reservation means, which is the divergence
+      that reopens the race `claim` closes. */
+  const ledgerAnswer = (
+    held: { requestHash: string; answer: IdempotencyRecord },
+    scope: IdempotencyScope,
+    requestHash: string,
+  ): IdempotencyRecord | null => {
+    if (held.requestHash !== requestHash) {
+      throw new VendoError(
+        "conflict",
+        `idempotency key ${scope.key} was already used with a different request body`,
+      );
+    }
+    if (held.answer.status === RESERVED) return null;
+    return { status: held.answer.status, result: jsonCopy(held.answer.result) };
+  };
 
   const blobMap = (namespace: string): Map<string, { bytes: Uint8Array; contentType?: string }> => {
     let blobs = namespaces.get(namespace);
@@ -500,22 +521,34 @@ export function memoryStoreAdapter(
     // so the ledger cannot commit while the mutation it gates rolls back. A
     // hosted mount earns the same guarantee by putting it in the same database.
     idempotency: {
+      async claim(scope, requestHash) {
+        const key = ledgerKey(scope);
+        const held = ledger.get(key);
+        // One process and no await between the read and the write, so this map
+        // IS the indivisible step the contract asks `claim` for — the Postgres
+        // ledger earns the same thing from the key's unique index.
+        if (held === undefined) {
+          ledger.set(key, { requestHash, answer: { status: RESERVED, result: null } });
+          return "claimed";
+        }
+        return ledgerAnswer(held, scope, requestHash);
+      },
       async check(scope, requestHash) {
         const held = ledger.get(ledgerKey(scope));
         if (held === undefined) return null;
-        if (held.requestHash !== requestHash) {
-          throw new VendoError(
-            "conflict",
-            `idempotency key ${scope.key} was already used with a different request body`,
-          );
-        }
-        return { status: held.answer.status, result: jsonCopy(held.answer.result) };
+        return ledgerAnswer(held, scope, requestHash);
       },
       async record(scope, requestHash, answer) {
         const key = ledgerKey(scope);
-        // First writer wins: the answer a replay has already been handed must
-        // not change under it.
-        if (ledger.has(key)) return;
+        const held = ledger.get(key);
+        // First ANSWER wins: the answer a replay has already been handed must
+        // not change under it. A reservation is not an answer, so its own owner
+        // settles it — and only its owner, so another request's reservation
+        // stands rather than taking this answer's stamp.
+        const settling = held !== undefined
+          && held.answer.status === RESERVED
+          && held.requestHash === requestHash;
+        if (held !== undefined && !settling) return;
         ledger.set(key, { requestHash, answer: { status: answer.status, result: jsonCopy(answer.result) } });
       },
     },

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -119,10 +119,14 @@ export interface IdempotencyRecord {
  * happened. This is why `createStore()` hands one out instead of the ledger
  * being an adapter a host wires up separately.
  *
- * The guarantee is REPLAY protection, not mutual exclusion: two concurrent
- * requests carrying one key can both find the key fresh and both execute. That
- * is what a check-then-do ledger can promise, and saying so here is cheaper
- * than a caller discovering it in production.
+ * The guarantee `check` alone can make is REPLAY protection, not mutual
+ * exclusion: two concurrent requests carrying one key can both find the key
+ * fresh and both execute. For an EQUAL body that is benign — one key, one body,
+ * one effect, and the caller is told the truth. For a DIFFERENT body it is not:
+ * both mutations commit, and the loser is then refused `conflict` by a verb that
+ * ran AFTER its write, so the error it receives and the state of the store
+ * disagree. {@link IdempotencyLedger.claim} is what closes that case, by putting
+ * the refusal in front of the mutation instead of behind it.
  */
 export interface IdempotencyLedger {
   /**
@@ -136,10 +140,43 @@ export interface IdempotencyLedger {
    * `conflict` here rather than quietly returning some other request's result.
    */
   check(scope: IdempotencyScope, requestHash: string): Promise<IdempotencyRecord | null>;
-  /** Record what this key answered. First writer wins; a later `record` for a
-      key already held is ignored, never an overwrite — the answer a replay
-      already received must not change under it. */
+  /** Record what this key answered. First ANSWER wins: a later `record` for a
+      key that already holds one is ignored, never an overwrite — the answer a
+      replay already received must not change under it. A reservation taken by
+      {@link IdempotencyLedger.claim} is not an answer; `record` is how that
+      reservation's OWNER settles it, and another request's reservation stands
+      untouched. */
   record(scope: IdempotencyScope, requestHash: string, answer: IdempotencyRecord): Promise<void>;
+  /**
+   * ATOMICALLY reserve (tenant, op, key) for this request hash BEFORE the
+   * mutation runs, so a request that is going to be refused never reaches it.
+   *
+   * The reservation and the test for an existing one MUST be one indivisible
+   * step — `INSERT ... ON CONFLICT DO NOTHING RETURNING` against the scope's own
+   * unique index, which is what makes the key itself the serialization point. An
+   * implementation that reads first and inserts second IS the check-then-do
+   * shape this verb exists to replace and races in exactly the same way.
+   *
+   * - `"claimed"` — the reservation is this caller's. Do the work, then `record`.
+   * - {@link IdempotencyRecord} — a prior owner already published its answer;
+   *   replay it rather than applying anything.
+   * - `null` — a prior owner holds the key for the SAME request hash and has not
+   *   answered yet. PROCEED, exactly as `check` returning null says to. One key
+   *   and one body means one effect, so a second execution is the benign case
+   *   the ledger has always permitted, and whichever request answers first is
+   *   the answer every later replay gets. Deliberately NOT a wait: a contender
+   *   that blocked here would hang behind an owner that died between `claim` and
+   *   `record` — the ordinary client-timeout retry — and no expiry can tell a
+   *   dead owner from a slow one without stealing a live one's key.
+   * - throws `conflict` — the key is held for a DIFFERENT request hash. This is
+   *   the case the verb exists for, and it throws HERE, before the mutation, so
+   *   a refused request leaves nothing behind.
+   *
+   * OPTIONAL, on `RecordStore.atomic`'s rule: an adapter that cannot reserve
+   * says so by omitting `claim`, and a caller that finds it absent falls back to
+   * `check` then `record` with the race that implies.
+   */
+  claim?(scope: IdempotencyScope, requestHash: string): Promise<IdempotencyRecord | null | "claimed">;
 }
 
 /** 01-core §12 */

--- a/packages/store/src/idempotency.ts
+++ b/packages/store/src/idempotency.ts
@@ -1,41 +1,107 @@
-import { VendoError, type IdempotencyLedger, type Json } from "@vendoai/core";
+import { VendoError, type IdempotencyLedger, type IdempotencyScope, type Json } from "@vendoai/core";
 // Type-only — erased at compile time, so this module stays engine-free and can
 // be assembled into the store alongside the routing doors (see store.ts).
 import type { Db } from "./db-postgres.js";
 import { jsonParam, text } from "./helpers/utils.js";
+
+/** A reservation `claim` took but nobody has answered yet, spelled in the
+ *  `status` column the table already carries (schema.ts v8) so reserving costs
+ *  no migration and no nullable answer. 0 is not a status any mount can send —
+ *  `IdempotencyRecord.status` is "the HTTP status the mount sent" — so a
+ *  reservation can never be mistaken for an answer, and an older reader that
+ *  predates `claim` cannot mistake one for a replayable result either. */
+const RESERVED = 0;
+
+const conflictFor = (scope: IdempotencyScope): VendoError =>
+  new VendoError(
+    "conflict",
+    `idempotency key ${JSON.stringify(scope.key)} on ${scope.op} was already used for a `
+    + "different request body, so there is no recorded answer that belongs to this one — "
+    + "a key stands for ONE request. Mint a fresh key for a new request, and reuse a key "
+    + "only to retry the identical body.",
+  );
 
 /** 01 §12 — the `Idempotency-Key` replay ledger over `vendo_idempotency_ledger`,
  *  the table this same database carries (schema.ts v8). Colocated with the
  *  mutations it gates by construction: it runs on the handle the mutation runs
  *  on, so the two commit or roll back together. */
 export function createIdempotencyLedger(db: Db): IdempotencyLedger {
+  const readRow = async (scope: IdempotencyScope): Promise<Record<string, unknown> | undefined> => {
+    const result = await db.query(
+      `SELECT request_hash, status, result FROM vendo_idempotency_ledger
+       WHERE tenant = $1 AND op = $2 AND key = $3`,
+      [scope.tenant, scope.op, scope.key],
+    );
+    return result.rows[0];
+  };
+
+  /** What a held row answers THIS request: its recorded answer, or null when the
+      row is only a reservation. A differing hash is not an answer at all — it is
+      another request's row — so it refuses rather than replaying someone else's
+      result. Shared by `check` and `claim` so the two can never drift on what a
+      reservation means, which is the divergence that reopens the race. */
+  const answerFor = (
+    row: Record<string, unknown>,
+    scope: IdempotencyScope,
+    requestHash: string,
+  ): { status: number; result: Json } | null => {
+    if (text(row["request_hash"]) !== requestHash) throw conflictFor(scope);
+    const status = Number(row["status"]);
+    if (status === RESERVED) return null;
+    return { status, result: row["result"] as Json };
+  };
+
   return {
-    async check(scope, requestHash) {
-      const result = await db.query(
-        `SELECT request_hash, status, result FROM vendo_idempotency_ledger
-         WHERE tenant = $1 AND op = $2 AND key = $3`,
-        [scope.tenant, scope.op, scope.key],
-      );
-      const row = result.rows[0];
-      if (row === undefined) return null;
-      if (text(row["request_hash"]) !== requestHash) {
-        throw new VendoError(
-          "conflict",
-          `idempotency key ${JSON.stringify(scope.key)} on ${scope.op} was already used for a `
-          + "different request body, so there is no recorded answer that belongs to this one — "
-          + "a key stands for ONE request. Mint a fresh key for a new request, and reuse a key "
-          + "only to retry the identical body.",
+    async claim(scope, requestHash) {
+      // The reservation IS the test: one statement against the (tenant, op, key)
+      // primary key, so of two racers exactly one gets a row back and the loser
+      // reads what the winner reserved. A SELECT-then-INSERT here would be the
+      // very check-then-do shape `claim` exists to replace.
+      //
+      // Bounded loop for the one gap a single statement leaves: the row can be
+      // gone by the read-back, and the retry re-reserves the now-free key rather
+      // than degrading that key to check-then-do for good. Nothing in this repo
+      // produces that today — no erase selector reaches this table, which is the
+      // never-matched class erase.ts calls out — so two passes is the whole
+      // budget; a key being deleted in a loop is not worth spinning on.
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const reserved = await db.query(
+          `INSERT INTO vendo_idempotency_ledger (tenant, op, key, request_hash, status, result)
+           VALUES ($1, $2, $3, $4, ${RESERVED}, 'null'::jsonb)
+           ON CONFLICT (tenant, op, key) DO NOTHING
+           RETURNING key`,
+          [scope.tenant, scope.op, scope.key, requestHash],
         );
+        if (reserved.rows.length > 0) return "claimed";
+        const row = await readRow(scope);
+        if (row === undefined) continue;
+        return answerFor(row, scope, requestHash);
       }
-      return { status: Number(row["status"]), result: row["result"] as Json };
+      // Never "claimed": telling a caller it owns a key it holds no row for is
+      // the one answer that licenses the mutation this verb is meant to gate.
+      // null degrades to exactly what `check` would have said — go do the work.
+      return null;
+    },
+    async check(scope, requestHash) {
+      const row = await readRow(scope);
+      if (row === undefined) return null;
+      return answerFor(row, scope, requestHash);
     },
     async record(scope, requestHash, answer) {
-      // First writer wins: the answer a replay has already been handed must not
-      // change under it, so a later record for a held key is a no-op.
+      // First ANSWER wins: the answer a replay has already been handed must not
+      // change under it, so the UPDATE is gated on the row still being a
+      // reservation. `request_hash` is gated too, so a reservation is settled
+      // only by the request that took it. A different body reaches here on the
+      // `check` fallback — where the key can be taken between the check and the
+      // record — and it leaves the owner's reservation standing rather than
+      // stamping its own answer onto a key it never held.
       await db.query(
         `INSERT INTO vendo_idempotency_ledger (tenant, op, key, request_hash, status, result)
          VALUES ($1, $2, $3, $4, $5, $6::jsonb)
-         ON CONFLICT (tenant, op, key) DO NOTHING`,
+         ON CONFLICT (tenant, op, key) DO UPDATE
+           SET status = EXCLUDED.status, result = EXCLUDED.result
+           WHERE vendo_idempotency_ledger.status = ${RESERVED}
+             AND vendo_idempotency_ledger.request_hash = EXCLUDED.request_hash`,
         [scope.tenant, scope.op, scope.key, requestHash, answer.status, jsonParam(answer.result)],
       );
     },

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -216,6 +216,13 @@ export const DDL = [
   // from the same key carrying a DIFFERENT body, which is a client bug and not a
   // replay at all. The PK is the whole scope, `tenant` first, so a mount serving
   // many tenants out of one schema cannot let one tenant's key answer another's.
+  // `status = 0` is the one value that is NOT an answer: it is the reservation
+  // `IdempotencyLedger.claim` takes before a mutation runs, settled to the real
+  // status by `record`. It rides the existing column rather than a nullable
+  // answer because 0 is not a status a mount can send, so no reader — including
+  // the console's copy of this table, which predates `claim` — can mistake a
+  // reservation for a replayable result. That is what keeps `claim` additive:
+  // no migration, and no row of this shape exists until something calls it.
   `CREATE TABLE IF NOT EXISTS vendo_idempotency_ledger (
     tenant text NOT NULL, op text NOT NULL, key text NOT NULL,
     request_hash text NOT NULL, status int NOT NULL, result jsonb NOT NULL,

--- a/packages/store/tests/idempotency.test.ts
+++ b/packages/store/tests/idempotency.test.ts
@@ -42,5 +42,68 @@ for (const backend of backends()) {
       await ledger.record(scope, "hash_1", { status: 500, result: { error: "late" } });
       expect(await ledger.check(scope, "hash_1")).toEqual({ status: 201, result: { id: "wsc_1" } });
     });
+
+    // The filed race (#1297), fired at one instant against a real database
+    // rather than asserted in sequence: sequential cases pass just as happily on
+    // the check-then-do shape this verb replaces.
+    it("two concurrent claims on one key with DIFFERENT bodies: one reserves, the other is refused before it mutates", async () => {
+      const raced = { tenant: "tenant_a", op: "workspace.commit", key: "key_race_bodies" };
+      const settled = await Promise.allSettled([
+        ledger.claim!(raced, "hash_first"),
+        ledger.claim!(raced, "hash_second"),
+      ]);
+      const won = settled.filter((one) => one.status === "fulfilled");
+      expect(won).toHaveLength(1);
+      expect((won[0] as PromiseFulfilledResult<unknown>).value).toBe("claimed");
+      // The refusal is the whole point, and it arrives INSTEAD of the mutation
+      // rather than after it — the caller has not been told to go do any work.
+      const refused = settled.find((one) => one.status === "rejected") as PromiseRejectedResult;
+      expect(refused.reason).toMatchObject({ code: "conflict" });
+      // One row, holding the winner's hash and still unanswered: the loser
+      // neither reserved the key nor stamped its body onto the winner's row.
+      const rows = await made.sql(
+        "SELECT request_hash, status FROM vendo_idempotency_ledger WHERE tenant = $1 AND op = $2 AND key = $3",
+        [raced.tenant, raced.op, raced.key],
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!["request_hash"]).toBe(settled[0]!.status === "fulfilled" ? "hash_first" : "hash_second");
+      expect(Number(rows[0]!["status"])).toBe(0);
+    });
+
+    // The benign half: one key, one body, one effect. A contender is told to
+    // PROCEED, not to wait — a contender that waited would hang behind an owner
+    // that died before `record`, which is the ordinary client-timeout retry.
+    it("two concurrent claims on one key with the SAME body: one reserves, the other is told to proceed", async () => {
+      const raced = { tenant: "tenant_a", op: "workspace.commit", key: "key_race_same" };
+      const settled = await Promise.all([ledger.claim!(raced, "hash_same"), ledger.claim!(raced, "hash_same")]);
+      expect(settled.filter((one) => one === "claimed")).toHaveLength(1);
+      expect(settled.filter((one) => one === null)).toHaveLength(1);
+    });
+
+    // An owner that never returns leaves a reservation behind. Nothing may be
+    // stuck on it: the retry carrying the same key is told to proceed and its
+    // `record` settles the key, so a dropped request costs an execution, never
+    // the key itself.
+    it("a reservation whose owner never answered does not strand the key", async () => {
+      const dropped = { tenant: "tenant_a", op: "workspace.commit", key: "key_dropped" };
+      expect(await ledger.claim!(dropped, "hash_d")).toBe("claimed");
+      expect(await ledger.check(dropped, "hash_d")).toBeNull();
+      expect(await ledger.claim!(dropped, "hash_d")).toBeNull();
+      await ledger.record(dropped, "hash_d", { status: 200, result: { retried: true } });
+      expect(await ledger.check(dropped, "hash_d")).toEqual({ status: 200, result: { retried: true } });
+    });
+
+    // `record` settles the reservation it owns and nothing else. Reachable only
+    // through the `check` fallback — `claim` refuses a differing hash outright —
+    // which is exactly why it must hold there too.
+    it("record does not settle another request's reservation, and does not overwrite a settled one", async () => {
+      const held = { tenant: "tenant_a", op: "workspace.commit", key: "key_settle" };
+      expect(await ledger.claim!(held, "hash_owner")).toBe("claimed");
+      await ledger.record(held, "hash_other", { status: 200, result: { whose: "other" } });
+      expect(await ledger.check(held, "hash_owner")).toBeNull();
+      await ledger.record(held, "hash_owner", { status: 201, result: { whose: "owner" } });
+      await ledger.record(held, "hash_owner", { status: 500, result: { whose: "late" } });
+      expect(await ledger.check(held, "hash_owner")).toEqual({ status: 201, result: { whose: "owner" } });
+    });
   });
 }


### PR DESCRIPTION
…of the mutation

The ledger was check-then-do, so two concurrent requests carrying one key both found it fresh and both executed. An equal body makes that benign — one key, one body, one effect, and whichever answers first is the answer every replay gets. A DIFFERENT body did not: both mutations committed, and the loser was then refused `conflict` by a verb that ran AFTER its write, so the error it received and the state of the store disagreed.

`claim` reserves (tenant, op, key) for a request hash before the mutation runs, in one statement against the scope's own primary key, so the key itself is the serialization point and a request that is going to be refused never reaches the work.

`null` means PROCEED, not wait. A same-hash contender is the benign case the ledger has always permitted to execute twice; one that blocked would hang behind an owner that died between `claim` and `record`, which is the ordinary client-timeout retry. That is also why there is no lease — an expiry cannot tell a dead owner from a slow one, so it buys back the double execution it was added to prevent and adds a way to steal a live owner's key. A dropped request costs an execution, never the key.

`status = 0` is the reservation, on the column the table already carries: 0 is not a status a mount can send, so no reader can take one for an answer and there is no migration. `check` and `claim` share one reader so the two cannot drift on what a held row means — a divergence there reopens the race, because a `check` caller told "fresh" walks straight past a reservation. `record` settles only the reservation it owns and still never overwrites an answer.

OPTIONAL, on `RecordStore.atomic`'s rule: an adapter that cannot reserve omits `claim` and callers fall back to check-then-record. `workspace.commit` does not use it — it already claims its own ledger row inside the mutation's transaction, which is the stronger guarantee `claim` approximates for a caller that cannot enclose the work it gates.

Closes #1297.

What

IdempotencyLedger gains an optional third verb that reserves a key before the mutation runs:

claim?(scope: IdempotencyScope, requestHash: string): Promise<IdempotencyRecord | null | "claimed">;

┌───────────────────┬─────────────────────────────────────────────────────────────────────┐
│      returns      │                               meaning                               │
├───────────────────┼─────────────────────────────────────────────────────────────────────┤
│ "claimed"         │ the reservation is this caller's — do the work, then record         │
├───────────────────┼─────────────────────────────────────────────────────────────────────┤
│ IdempotencyRecord │ a prior owner already published — replay it, apply nothing          │
├───────────────────┼─────────────────────────────────────────────────────────────────────┤
│ null              │ same hash, not yet answered — proceed, exactly as check's null says │
├───────────────────┼─────────────────────────────────────────────────────────────────────┤
│ throws conflict   │ the key is held for a DIFFERENT hash — refused before the mutation  │
└───────────────────┴─────────────────────────────────────────────────────────────────────┘

Served by the Postgres ledger and the in-memory reference, with conformance cases both run. Optional on RecordStore.atomic's rule: an adapter that cannot reserve omits it and callers fall back to check-then-record. Nothing in the repo is required to adopt it, and no caller here does — the consumer is the console's store mount.

Why

The ledger is check-then-do, so two concurrent requests carrying one key both find it fresh and both execute. With an EQUAL body that is benign and always was: one key, one body, one effect, and whichever answers first is the answer every replay gets. With a DIFFERENT body it is not — both mutations commit, and the loser is then refused conflict by a verb that ran AFTER its write. The caller receives an error naming its key while the write that error refuses sits in the store.

claim makes the reservation the serialization point: one statement against the scope's own primary key, before the mutation, so a request that is going to be refused never reaches the work.

The decision worth reviewing: null means PROCEED, not wait. Everything else follows from it. Same key + same hash is the same request — the benign case the contract already permits to execute twice — so only the differing-hash case is the bug, and same-hash contenders are told to carry on.

That is what makes a lease unnecessary, and a lease is not merely unnecessary here but harmful:

- an expiry cannot tell a dead owner from a slow one, so it buys back the double execution it was added to prevent and adds a way to steal a live owner's key;
- and without "proceed", an owner that dies between claim and record would strand its key permanently — which is the ordinary client-timeout retry, the path hostedStoreOps replays the same key on.

Under "proceed", a dropped request costs one execution, exactly as it does today. It never costs the key. There is a test for that case by name.

It also keeps the two verbs in agreement. check and claim share one reader, so neither can eans. If claim said "wait" while check said "fresh", any mount mixing the verbs would walk acheck caller straight past a live reservation and the race would be back.

No migration. status = 0 is the reservation, on the column the table already carries. 0 is not a status a mount can send — IdempotencyRecord.status is "the HTTP status the mount sent" — so no reader can take a
reservation for a replayable answer, including a console copy of the table that predates thape exists until something calls claim, so this is inert for existing readers rather than acoordination item.

record is gated to settle only the reservation it owns, and still never overwrites an answer: first ANSWER wins, and a reservation is not an answer.

workspace.commit is untouched and does not adopt this. It already claims its own ledger row inside the mutation's transaction (ops.ts:662-673), which is the stronger guarantee — a losing claim's throw takes the
whole transaction with it. claim is the approximation available to a caller that cannot encich is every mount, since StoreAdapter exposes no transaction handle. store-ops.ts'sdouble-fired case is therefore left as it is; adding claim assertions there would test a path that was never affected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reserves idempotency keys before mutations to refuse differing-body contenders up front. Previously, two concurrent requests with the same key could both write and the loser was rejected after its write; now a differing hash is rejected at reservation time and never reaches the mutation.

- Adds `IdempotencyLedger.claim(scope, requestHash)` in `@vendoai/core` and `@vendoai/store`.
  - Returns "claimed" to do the work and then `record`.
  - Returns an `IdempotencyRecord` to replay.
  - Returns null to proceed for the same hash (no waiting).
  - Throws `conflict` for a different hash (rejected before the mutation).
- Uses `status = 0` as a reservation sentinel; `check` and `claim` share one reader; `record` settles only its own reservation and never overwrites an existing answer. No schema migration.
- Postgres and in-memory ledgers implement `claim` atomically via the scope primary key; adds conformance and concurrent claim tests. `workspace.commit` is unchanged (it already claims inside the transaction).

- Adoption is optional: adapters that cannot reserve omit `claim`, and callers fall back to `check` then `record`. Callers wanting pre-mutation refusal should call `claim` when available and handle the above return cases.

<sup>Written for commit 4a42a6172e7ea5a5497068c1d662a6ae06825063. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

