### PR TITLE
feat(ui): Tabs runs on Base UI

### DIFF
--- a/.changeset/kit-tabs-on-base-ui.md
+++ b/.changeset/kit-tabs-on-base-ui.md
@@ -1,0 +1,24 @@
+---
+"@vendoai/ui": minor
+---
+
+Tabs runs on Base UI.
+
+`@base-ui/react` (pinned `1.7.0`) is now a dependency of the Kit, and `Tabs` is
+the first brick built on it: `Tabs.Root` / `List` / `Tab` / `Panel` replace the
+hand-rolled tablist, so the roving tab order, the arrow/Home/End walk and the
+tab↔panel `aria-controls` / `aria-labelledby` wiring come from the library
+instead of from ~40 lines of this repo's own keyboard code.
+
+`TabsProps` is unchanged to the byte, and so is the rendering: the Quiet
+Precision inline styles moved onto Base UI's parts through its `style`-as-state
+callback, which is how the selected tab's accent, fill and rule survive with no
+stylesheet. Before/after screenshots of the bar in a real Chromium are
+pixel-identical.
+
+One behavior moved. A disabled tab is now reachable with the arrow keys (Base
+UI marks it `aria-disabled` and leaves it in the roving order, for
+discoverability) where the old bar skipped over it. It still cannot be
+selected, by click or by Enter.
+
+`Checkbox` and `Select` stay on their native elements — see the PR for why.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -68,6 +68,7 @@
   },
   "dependencies": {
     "@ai-sdk/react": "3.0.30",
+    "@base-ui/react": "1.7.0",
     "@tanstack/react-table": "^8.20.0",
     "@vendoai/apps": "workspace:*",
     "@vendoai/core": "workspace:*",

--- a/packages/ui/src/kit/feedback/tabs.tsx
+++ b/packages/ui/src/kit/feedback/tabs.tsx
@@ -8,7 +8,8 @@
  *  The code-only `{label, content}` item still works; children win when both
  *  are present.
  */
-import { Children, useId, useState, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react";
+import { Tabs as Base } from "@base-ui/react/tabs";
+import { Children, type ReactNode } from "react";
 import { font, hairline, t, transitionFor } from "../tokens.js";
 
 export type TabItem = string | number | {
@@ -54,38 +55,24 @@ const normalize = (item: TabItem): NormalTab => {
 export function Tabs({ tabs, value, defaultIndex = 0, children }: TabsProps) {
   const panels = Children.toArray(children);
   const items = (tabs ?? []).map(normalize);
-  const panelIdBase = useId().replace(/:/g, "");
+  // Tabs are addressed by INDEX, because two items may carry the same `value`
+  // (or none at all) and Base UI keys its panels off the tab's value.
   // `value` names a tab; otherwise fall back to defaultIndex. Either way a
   // disabled starting tab hands off to the first enabled one.
   const named = value === undefined ? -1 : items.findIndex((item) => item.value === text(value));
   const requested = named === -1 ? defaultIndex : named;
   const firstEnabled = items.findIndex((item) => !item.disabled);
-  const [active, setActive] = useState(
-    items[requested] !== undefined && !items[requested].disabled ? requested : Math.max(0, firstEnabled),
-  );
-
-  const focusTab = (event: ReactKeyboardEvent<HTMLButtonElement>) => {
-    const offsets: Partial<Record<string, number>> = { ArrowLeft: -1, ArrowUp: -1, ArrowRight: 1, ArrowDown: 1 };
-    const offset = offsets[event.key];
-    if (offset === undefined && event.key !== "Home" && event.key !== "End") return;
-    const buttons = Array.from(
-      event.currentTarget.parentElement?.querySelectorAll<HTMLButtonElement>('[role="tab"]:not(:disabled)') ?? [],
-    );
-    if (buttons.length === 0) return;
-    event.preventDefault();
-    const current = Math.max(0, buttons.indexOf(event.currentTarget));
-    const target = event.key === "Home"
-      ? 0
-      : event.key === "End"
-        ? buttons.length - 1
-        : (current + (offset ?? 0) + buttons.length) % buttons.length;
-    buttons[target]?.focus();
-  };
+  const start = items[requested] !== undefined && !items[requested].disabled
+    ? requested
+    : Math.max(0, firstEnabled);
 
   return (
-    <div data-kit="Tabs" style={{ ...font, display: "flex", flexDirection: "column", gap: "var(--vendo-density-content-gap, 10px)" }}>
-      <div
-        role="tablist"
+    <Base.Root
+      data-kit="Tabs"
+      defaultValue={start}
+      style={{ ...font, display: "flex", flexDirection: "column", gap: "var(--vendo-density-content-gap, 10px)" }}
+    >
+      <Base.List
         style={{
           display: "flex",
           gap: "var(--vendo-density-inline-gap, 7px)",
@@ -98,51 +85,41 @@ export function Tabs({ tabs, value, defaultIndex = 0, children }: TabsProps) {
           padding: "var(--vendo-density-tabs-padding, 4px)",
         }}
       >
-        {items.map((tab, i) => {
-          const selected = i === active;
-          return (
-            <button
-              key={`${tab.value}-${i}`}
-              id={`${panelIdBase}-tab-${i}`}
-              type="button"
-              role="tab"
-              aria-selected={selected}
-              aria-controls={`${panelIdBase}-panel-${i}`}
-              tabIndex={selected ? 0 : -1}
-              disabled={tab.disabled}
-              onClick={() => setActive(i)}
-              onKeyDown={focusTab}
-              style={{
-                ...font,
-                minHeight: "var(--vendo-density-tab-height, 30px)",
-                border: selected ? hairline : `${t.borderWidth} solid transparent`,
-                borderRadius: t.radiusSmall,
-                // Accent marks the ACTIVE state — the tablist's one brand pixel.
-                color: selected ? t.accent : t.muted,
-                background: selected ? t.surface : "transparent",
-                cursor: tab.disabled ? "not-allowed" : "pointer",
-                fontSize: "0.88em",
-                fontWeight: selected ? t.weightEmphasis : t.weightNormal,
-                opacity: tab.disabled ? 0.5 : 1,
-                padding: "var(--vendo-density-tab-padding, 6px 10px)",
-                whiteSpace: "nowrap",
-                // The indicator glide: the fill and the rule travel to the tab
-                // that was pressed instead of jumping.
-                transition: transitionFor("background-color", "border-color", "color"),
-              }}
-            >
-              {tab.label}
-            </button>
-          );
-        })}
-      </div>
-      <div
-        role="tabpanel"
-        id={`${panelIdBase}-panel-${active}`}
-        aria-labelledby={`${panelIdBase}-tab-${active}`}
-      >
-        {panels.length > 0 ? panels[active] : items[active]?.content}
-      </div>
-    </div>
+        {items.map((tab, i) => (
+          <Base.Tab
+            key={`${tab.value}-${i}`}
+            value={i}
+            disabled={tab.disabled}
+            // Base UI hands the state to `style`, so the selected look is
+            // painted with no stylesheet to select `[data-active]` on.
+            style={({ active }) => ({
+              ...font,
+              minHeight: "var(--vendo-density-tab-height, 30px)",
+              border: active ? hairline : `${t.borderWidth} solid transparent`,
+              borderRadius: t.radiusSmall,
+              // Accent marks the ACTIVE state — the tablist's one brand pixel.
+              color: active ? t.accent : t.muted,
+              background: active ? t.surface : "transparent",
+              cursor: tab.disabled ? "not-allowed" : "pointer",
+              fontSize: "0.88em",
+              fontWeight: active ? t.weightEmphasis : t.weightNormal,
+              opacity: tab.disabled ? 0.5 : 1,
+              padding: "var(--vendo-density-tab-padding, 6px 10px)",
+              whiteSpace: "nowrap",
+              // The indicator glide: the fill and the rule travel to the tab
+              // that was pressed instead of jumping.
+              transition: transitionFor("background-color", "border-color", "color"),
+            })}
+          >
+            {tab.label}
+          </Base.Tab>
+        ))}
+      </Base.List>
+      {items.map((tab, i) => (
+        <Base.Panel key={`${tab.value}-${i}`} value={i}>
+          {panels.length > 0 ? panels[i] : tab.content}
+        </Base.Panel>
+      ))}
+    </Base.Root>
   );
 }

--- a/packages/ui/test/kit/base-ui-migration.test.tsx
+++ b/packages/ui/test/kit/base-ui-migration.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+/**
+ * The Base UI migration's gate. Tabs now renders on `@base-ui/react`'s Tabs
+ * parts instead of hand-rolled buttons, so the two things a swapped internal
+ * can silently take away are asserted here against the REAL controls:
+ *
+ *  1. The `{$handler}` bridge (kit/handler.ts). Its known failure mode is a
+ *     migrated control that freezes mid-interaction — controlled by the screen,
+ *     but the screen never hears the change, so the box never moves again.
+ *     Every case below drives a LIVE screen: the handler writes state, the
+ *     re-render comes back through the control, and the assertion is made on
+ *     the second and third interaction, which is where a freeze shows.
+ *  2. The a11y contract Base UI is supposed to keep: the roles the renderer's
+ *     consumers query by, and the roving tab order a tablist owes a keyboard.
+ */
+import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { markHandlerCallback } from "../../src/kit/handler.js";
+import { Checkbox } from "../../src/kit/forms/checkbox.js";
+import { Input } from "../../src/kit/forms/input.js";
+import { Select } from "../../src/kit/forms/select.js";
+import { Tabs } from "../../src/kit/feedback/tabs.js";
+
+/** A live screen: the `{$handler}` callback owns the value and re-renders it. */
+function Screen<T>({ initial, render: renderControl }: {
+  initial: T;
+  render: (value: T, fire: (event?: unknown) => void) => React.ReactNode;
+}) {
+  const [value, setValue] = useState(initial);
+  const [fire] = useState(() =>
+    markHandlerCallback((event?: unknown) => {
+      const target = (event as { target?: { value?: T; checked?: T } }).target ?? {};
+      setValue((target.checked ?? target.value) as T);
+    }));
+  return <>{renderControl(value, fire)}</>;
+}
+
+describe("a screen-bound control keeps moving", () => {
+  it("types through an Input keystroke after keystroke", () => {
+    render(<Screen initial="" render={(value, fire) => <Input label="Find" value={value} onChange={fire} />} />);
+    const box = screen.getByLabelText("Find") as HTMLInputElement;
+
+    // Three keystrokes, each asserted: a control that freezes passes the first
+    // one and then stops, so only the later characters catch it.
+    for (const typed of ["h", "ha", "har"]) {
+      fireEvent.change(box, { target: { value: typed } });
+      expect(box.value).toBe(typed);
+    }
+  });
+
+  it("toggles a Checkbox back and forth", () => {
+    render(
+      <Screen initial={false} render={(value, fire) => <Checkbox label="Paid" checked={value} onChange={fire} />} />,
+    );
+    const box = () => screen.getByRole("checkbox", { name: "Paid" }) as HTMLInputElement;
+
+    fireEvent.click(box());
+    expect(box().checked).toBe(true);
+    // The toggle BACK is the freeze detector: a stuck control reports the first
+    // change and then holds whatever the screen last said.
+    fireEvent.click(box());
+    expect(box().checked).toBe(false);
+  });
+
+  it("changes a Select twice", () => {
+    render(
+      <Screen
+        initial="open"
+        render={(value, fire) => <Select label="Status" value={value} options={["open", "paid", "void"]} onChange={fire} />}
+      />,
+    );
+    const box = () => screen.getByLabelText("Status") as HTMLSelectElement;
+
+    fireEvent.change(box(), { target: { value: "paid" } });
+    expect(box().value).toBe("paid");
+    fireEvent.change(box(), { target: { value: "void" } });
+    expect(box().value).toBe("void");
+  });
+
+  it("switches Tabs and switches back", () => {
+    render(
+      <Tabs tabs={["Overview", "Overdue"]}>
+        <p>overview body</p>
+        <p>overdue body</p>
+      </Tabs>,
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: "Overdue" }));
+    expect(screen.getByRole("tabpanel").textContent).toBe("overdue body");
+    fireEvent.click(screen.getByRole("tab", { name: "Overview" }));
+    expect(screen.getByRole("tabpanel").textContent).toBe("overview body");
+  });
+});
+
+describe("the migrated Tabs keeps its a11y contract", () => {
+  const view = () => render(
+    <Tabs tabs={["Overview", "Overdue", { label: "Void", disabled: true }]}>
+      <p>overview body</p>
+      <p>overdue body</p>
+      <p>void body</p>
+    </Tabs>,
+  );
+
+  it("names the roles a consumer queries by, and points each at the other", () => {
+    view();
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs.map((tab) => tab.textContent)).toEqual(["Overview", "Overdue", "Void"]);
+    expect(screen.getByRole("tablist")).toBeTruthy();
+
+    const panel = screen.getByRole("tabpanel");
+    expect(panel.getAttribute("aria-labelledby")).toBe(tabs[0]?.id);
+    expect(tabs[0]?.getAttribute("aria-controls")).toBe(panel.id);
+    expect(tabs[0]?.getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("holds ONE tab stop, so the bar is one stop in the page's tab order", () => {
+    view();
+    // Roving tabindex. Where the arrow keys then take that stop is a REAL
+    // browser's question: Base UI drives its roving focus off trusted focus
+    // events, which jsdom's synthetic ones cannot stand in for, so the arrow
+    // walk is proven in the headed run rather than faked here.
+    expect(screen.getAllByRole("tab").map((tab) => tab.getAttribute("tabindex"))).toEqual(["0", "-1", "-1"]);
+  });
+
+  it("marks a disabled tab and refuses to select it", () => {
+    view();
+    const third = screen.getAllByRole("tab")[2] as HTMLElement;
+    expect(third.getAttribute("aria-disabled")).toBe("true");
+
+    fireEvent.click(third);
+    expect(screen.getByRole("tabpanel").textContent).toBe("overview body");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1231,6 +1231,9 @@ importers:
       '@ai-sdk/react':
         specifier: 3.0.30
         version: 3.0.30(react@19.2.7)(zod@3.25.76)
+      '@base-ui/react':
+        specifier: 1.7.0
+        version: 1.7.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-table':
         specifier: ^8.20.0
         version: 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -1828,6 +1831,33 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@base-ui/react@1.7.0':
+    resolution: {integrity: sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@date-fns/tz': ^1.2.0
+      '@types/react': ^19.2.0
+      date-fns: ^4.0.0
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
+      '@types/react':
+        optional: true
+      date-fns:
+        optional: true
+
+  '@base-ui/utils@0.3.2':
+    resolution: {integrity: sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
@@ -8804,6 +8834,29 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
+  '@base-ui/react@1.7.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@base-ui/utils': 0.3.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@floating-ui/utils': 0.2.12
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@base-ui/utils@0.3.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@floating-ui/utils': 0.2.12
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      reselect: 5.2.0
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   '@bcoe/v8-coverage@1.0.2': {}
 
   '@borewit/text-codec@0.2.2': {}
@@ -9369,6 +9422,12 @@ snapshots:
       '@floating-ui/dom': 1.8.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
+
+  '@floating-ui/react-dom@2.1.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   '@floating-ui/utils@0.2.12': {}
 


### PR DESCRIPTION
## What

Adds `@base-ui/react`, pinned exactly at **`1.7.0`**, and rebuilds the Kit's
`Tabs` brick on it. `TabsProps` is unchanged to the byte — this is a
contract-frozen swap of internals.

About the package name: the original plan named `@base-ui-components/react`.
That package is **deprecated** on npm ("Package was renamed to `@base-ui/react`")
and frozen at `1.0.0-rc.0`. The live package is `@base-ui/react`, current
`1.7.0`, which is what is pinned here. Its `react`/`react-dom` peers are
`^17 || ^18 || ^19`, so nothing conflicts; `date-fns` and `@date-fns/tz` are
optional peers and are not installed.

## Why

Roving tab order, the arrow/Home/End walk, and the tab↔panel `aria-controls` /
`aria-labelledby` wiring were ~40 lines of this repo's own keyboard code. They
are now the library's problem. Net: **-72 lines, +49** in `tabs.tsx`.

Nothing about the look changed. Base UI ships unstyled, so the Quiet Precision
inline styles moved onto its parts through Base UI's `style`-as-state callback
(`style={({ active }) => …}`) — which is how the selected tab's accent, fill,
rule and weight survive **without a stylesheet**. No document-level kit
stylesheet is introduced here; that is Track B.

## Checkbox and Select did NOT migrate

Both break the frozen kit suites, which the brief defines as the contract. The
failures are structural, not fixable from the source side, and the rule was to
stop rather than adapt a test:

- **Select** — Base UI's Select is a portal-mounted listbox. There is no
  `<option>` element (so `getByRole("option").value` has nothing to read), the
  options are not in the DOM at all until the popup opens, and it emits
  `onValueChange`, not a `change` event. `test/kit/forms.test.tsx:36-50` asserts
  all three. Base UI 1.7.0 has no native-`<select>` mode.
- **Checkbox** — Base UI renders a `<span role="checkbox">` plus a hidden
  `<input>`. Two frozen assertions break: `fireEvent.click` on the span does not
  toggle (verified — Base UI toggles through the hidden input, so only a real or
  `userEvent` click reaches it), and `getByLabelText("…")` becomes ambiguous
  because both the hidden input (`label[for]`) and the span (`aria-labelledby`)
  match.

Migrating either needs a decision to change those tests, which is a contract
change, not a refactor.

## One behavior moved

A disabled tab is now reachable with the arrow keys — Base UI marks it
`aria-disabled` and keeps it in the roving order for discoverability, where the
old bar queried `[role="tab"]:not(:disabled)` and skipped it. It still cannot be
selected, by click or by Enter. Confirmed in a real browser.

## Proof

- `pnpm build` · `turbo typecheck` · `pnpm lint` — green.
- The kit + tree + ssr suites: **49 files / 441 tests, all passing**, with every
  pre-existing test file untouched.
- New `test/kit/base-ui-migration.test.tsx` drives a LIVE `{$handler}` screen
  and asserts the **second and third** interaction, which is where the known
  freeze-mid-typing failure shows: three keystrokes through an Input, a Checkbox
  toggled and untoggled, a Select changed twice, Tabs switched and switched back.
- Real headed Chromium, `@vendoai/ui` built from `main` vs from this branch:
  the screenshots are **hash-identical** in both the default and second-tab
  state.

## This PR must not merge on green

Green is necessary and explicitly **not sufficient** here. This is a visual
migration and it is gated on Yousef's feel-check of the migrated bar. Please
leave it in draft until he has clicked it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilds Kit Tabs on `@base-ui/react` 1.7.0 with no API or visual changes. Previously, arrow keys skipped disabled tabs; now disabled tabs stay in the roving order (`aria-disabled`) but cannot be selected.

- Adds `@base-ui/react` pinned to `1.7.0`; replaces custom roving focus and tab↔panel ARIA with `Tabs.Root`/`List`/`Tab`/`Panel`.
- Keeps `TabsProps` identical; addresses panels by index to match Base UI; paints active state via the `style` state callback.
- Adds `test/kit/base-ui-migration.test.tsx` to assert handler round-trips and a11y; existing suites pass.
- Leaves `Checkbox` and `Select` on native elements to keep frozen tests green.
- Do not merge until keyboard/feel is approved in real browsers; review `tabs.tsx` focus behavior and a11y.

<sup>Written for commit c47c921472c0eb6442704627f0e27ed9391b7b68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

