### PR TITLE
feat(apps,ui): a Kit component declares the slots it takes

### DIFF
--- a/.changeset/kit-slots-generalize.md
+++ b/.changeset/kit-slots-generalize.md
@@ -22,3 +22,8 @@ element under a key no slot declares is refused by name instead of reaching a
 renderer that would drop it. Tabs' and Accordion's element-valued `content`,
 unchecked until now, goes through the same gate. `kitPrompt` prints the slots
 from the same declaration, so the model is taught the table the floor enforces.
+
+The renderer closes the matching gap: an element in a slot resolved only the
+Kit, while the CHILDREN path resolved the Kit and the display bricks, so a brick
+tag written into a slot painted nothing at all. `reifyElement` now reads the
+same two registries `builtinContent` does.

--- a/.changeset/kit-slots-generalize.md
+++ b/.changeset/kit-slots-generalize.md
@@ -9,11 +9,17 @@ checks floor reads that declaration instead of one hard-coded prop name.
 `KitComponentSpec` gains `slots?: Record<string, KitSlotSpec>` — a doc, an
 optional `content` vocabulary and a `perRow` flag per slot — and one table in
 `specs.ts` states every place the Kit takes an element instead of a value:
-`header`/`footer` on Surface, Card and Form, `rowActions`/`toolbar`/`empty` on
-DataTable, `cell` where it already lived, `icon`, `marker`, `hint`, `prefix`,
-`suffix`, `label`, `tooltip`, `legend`, and the `content` on a Tabs panel and an
-Accordion section. Money, DateTime, Percent, Num, EnumBadge, Sparkline, Icon and
-CodeBlock declare none, and take no element at all.
+`cell` where it already lived (a DataTable column, a CardList field, a KeyValue
+field), `cell` and `marker` on Timeline, and the `content` on a Tabs panel and an
+Accordion section. Every other component declares none, and takes no element at
+all.
+
+The table states only what the React Kit RENDERS. A slot the components do not
+implement is worse than no slot: the prompt teaches the model to write it, every
+check passes it, and the renderer drops it in silence — the same breakage the
+table exists to refuse, arriving through the table. `@vendoai/ui`'s `test/kit/slot-drift.test.tsx` puts a probe in every
+declared slot and fails unless it finds it in the DOM, so the declaration and
+the implementation move together.
 
 The `kit-nesting` check reads that table: an element in a declared slot is
 measured against the slot's own vocabulary — the read-only value tier by

--- a/.changeset/kit-slots-generalize.md
+++ b/.changeset/kit-slots-generalize.md
@@ -29,6 +29,17 @@ renderer that would drop it. Tabs' and Accordion's element-valued `content`,
 unchecked until now, goes through the same gate. `kitPrompt` prints the slots
 from the same declaration, so the model is taught the table the floor enforces.
 
+A slot is read at its DECLARED path and nowhere else. Each entry says where it
+sits (`at: "columns"` → `columns[].cell`), and both the prompt and the check use
+that one string — so a `cell` field on a ROW, which a DataTable never looks at,
+is refused by name instead of being admitted as if it were the column's.
+
+A component sitting in a slot is measured against its OWN spec, not just the
+outer slot's vocabulary. It is a component in its own right: an element in a
+prop it has no slot for, and children under a component that renders none, are
+now refused inside a slot exactly as they are at the top of the tree. Both had
+passed clean while the renderer dropped the descendant.
+
 The renderer closes the matching gap: an element in a slot resolved only the
 Kit, while the CHILDREN path resolved the Kit and the display bricks, so a brick
 tag written into a slot painted nothing at all. `reifyElement` now reads the

--- a/.changeset/kit-slots-generalize.md
+++ b/.changeset/kit-slots-generalize.md
@@ -1,0 +1,24 @@
+---
+"@vendoai/apps": minor
+"@vendoai/ui": minor
+---
+
+The Kit's `cell` slot generalizes: a component now DECLARES its slots, and the
+checks floor reads that declaration instead of one hard-coded prop name.
+
+`KitComponentSpec` gains `slots?: Record<string, KitSlotSpec>` — a doc, an
+optional `content` vocabulary and a `perRow` flag per slot — and one table in
+`specs.ts` states every place the Kit takes an element instead of a value:
+`header`/`footer` on Surface, Card and Form, `rowActions`/`toolbar`/`empty` on
+DataTable, `cell` where it already lived, `icon`, `marker`, `hint`, `prefix`,
+`suffix`, `label`, `tooltip`, `legend`, and the `content` on a Tabs panel and an
+Accordion section. Money, DateTime, Percent, Num, EnumBadge, Sparkline, Icon and
+CodeBlock declare none, and take no element at all.
+
+The `kit-nesting` check reads that table: an element in a declared slot is
+measured against the slot's own vocabulary — the read-only value tier by
+default, so a Button in a per-row `cell` is refused exactly as before — and an
+element under a key no slot declares is refused by name instead of reaching a
+renderer that would drop it. Tabs' and Accordion's element-valued `content`,
+unchecked until now, goes through the same gate. `kitPrompt` prints the slots
+from the same declaration, so the model is taught the table the floor enforces.

--- a/packages/apps/src/contract/kit/kit-prompt.ts
+++ b/packages/apps/src/contract/kit/kit-prompt.ts
@@ -4,7 +4,7 @@
  * W3 wires this into the engine's wire contract (engine.ts).
  */
 import { DISPLAY_TAG_NAMES } from "./display.js";
-import { KIT_SHARED_PROP_NAMES, KIT_SPECS } from "./specs.js";
+import { KIT_SHARED_PROP_NAMES, KIT_SPECS, kitSlotPath } from "./specs.js";
 import type { KitComponentSpec, PropClass } from "./schema.js";
 
 export interface KitPromptOptions {
@@ -125,7 +125,10 @@ function renderSpec(spec: KitComponentSpec): string {
   if (slots.length > 0) {
     lines.push("Slots:");
     for (const [name, slot] of slots) {
-      lines.push(`- \`${name}\` [slot]${slot.perRow === true ? " (per row)" : ""} — ${slot.doc}`);
+      // The PATH, not the bare name: a component reads its slot at exactly one
+      // place, so teaching `cell` where the table reads `columns[].cell` is
+      // teaching a value the renderer drops.
+      lines.push(`- \`${kitSlotPath(name, slot)}\` [slot]${slot.perRow === true ? " (per row)" : ""} — ${slot.doc}`);
     }
     lines.push("");
   }

--- a/packages/apps/src/contract/kit/kit-prompt.ts
+++ b/packages/apps/src/contract/kit/kit-prompt.ts
@@ -118,6 +118,17 @@ function renderSpec(spec: KitComponentSpec): string {
     }
     lines.push("");
   }
+  // The slots, from the same declaration the nesting check enforces: a place
+  // that takes an ELEMENT is unguessable from a prop list, and one written where
+  // no slot was declared is refused.
+  const slots = Object.entries(spec.slots ?? {});
+  if (slots.length > 0) {
+    lines.push("Slots:");
+    for (const [name, slot] of slots) {
+      lines.push(`- \`${name}\` [slot]${slot.perRow === true ? " (per row)" : ""} — ${slot.doc}`);
+    }
+    lines.push("");
+  }
   const examples = PROMPT_EXAMPLES[spec.name] ?? spec.examples;
   lines.push(examples.length > 1 ? "Examples:" : "Example:");
   for (const ex of examples) lines.push("  " + ex);

--- a/packages/apps/src/contract/kit/schema.ts
+++ b/packages/apps/src/contract/kit/schema.ts
@@ -45,9 +45,9 @@ export function data(schema: ZodTypeAny, doc: string, options?: PropOptions): Pr
 
 /**
  * A SLOT — a named place inside a component that holds an ELEMENT instead of a
- * value (a table column's `cell`, a Card's `header`). The key is the prop the
- * element sits under, or the field inside the description object a prop holds:
- * `columns[].cell` and `header` are both the slot named by their last segment.
+ * value (a table column's `cell`, a Timeline's `marker`). It is a prop of its
+ * own, or a field of the description objects one prop holds; `at` says which,
+ * and `kitSlotPath` writes the two as one comparable string.
  */
 export interface KitSlotSpec {
   /** 1-line "what goes here". */
@@ -58,6 +58,15 @@ export interface KitSlotSpec {
   /** Painted once per row/entry rather than once for the component — so what
    *  is written in it has no row of its own to act on. */
   perRow?: boolean;
+  /** The PROP whose description objects carry this slot as a field, so the slot
+   *  lives at `<at>[].<name>` (`columns[].cell`). Absent means the slot is a
+   *  prop of its own (`marker`).
+   *
+   *  Load-bearing, not documentation: a component reads its slot at exactly one
+   *  place, so a same-named field anywhere else (`rows[].cell` on a DataTable
+   *  that only renders `columns[].cell`) is a value nothing paints. The nesting
+   *  check matches on this path and refuses the rest. */
+  at?: string;
 }
 
 export interface KitComponentSpec {

--- a/packages/apps/src/contract/kit/schema.ts
+++ b/packages/apps/src/contract/kit/schema.ts
@@ -43,6 +43,23 @@ export function data(schema: ZodTypeAny, doc: string, options?: PropOptions): Pr
   return make("data", schema, doc, options);
 }
 
+/**
+ * A SLOT — a named place inside a component that holds an ELEMENT instead of a
+ * value (a table column's `cell`, a Card's `header`). The key is the prop the
+ * element sits under, or the field inside the description object a prop holds:
+ * `columns[].cell` and `header` are both the slot named by their last segment.
+ */
+export interface KitSlotSpec {
+  /** 1-line "what goes here". */
+  doc: string;
+  /** Component names the slot may hold; absent means the read-only value tier
+   *  (`KIT_SLOT_CONTENT_NAMES`). */
+  content?: readonly string[];
+  /** Painted once per row/entry rather than once for the component — so what
+   *  is written in it has no row of its own to act on. */
+  perRow?: boolean;
+}
+
 export interface KitComponentSpec {
   /** JSX tag name the model emits. */
   name: string;
@@ -57,6 +74,9 @@ export interface KitComponentSpec {
   /** Does this component RENDER what is nested inside it? Absent means no — most
    *  of the Kit is a leaf, and the renderer hands children to leaves too. */
   takesChildren?: boolean;
+  /** Slot name → spec. Absent means the component takes no elements in its
+   *  props at all, and one written there is refused rather than dropped. */
+  slots?: Record<string, KitSlotSpec>;
 }
 
 /** Build a `z.object` from a spec's props, applying `.optional()` to non-required ones. */

--- a/packages/apps/src/contract/kit/specs.ts
+++ b/packages/apps/src/contract/kit/specs.ts
@@ -709,7 +709,16 @@ const BASE_SPECS: KitComponentSpec[] = [
  * it: an element under a key that is NOT declared here is refused rather than
  * dropped at render, which is the silent-breakage class this floor exists for.
  * A slot's key is the last segment of where the element sits, so `columns[].cell`
- * and `header` are the slots `cell` and `header`.
+ * and `marker` are the slots `cell` and `marker`.
+ *
+ * THE LAW: a slot is declared here only when the React component RENDERS it —
+ * a `ReactNode` prop it actually paints (`@vendoai/ui`). Teaching a slot the Kit
+ * does not implement is worse than teaching none: the prompt tells the model to
+ * write it, every check passes it, and the renderer drops it in silence. That is
+ * the same silent-breakage this table exists to refuse, arriving through the
+ * table itself. `@vendoai/ui`'s `test/kit/slot-drift.test.tsx` puts a probe in
+ * every slot declared here and fails unless it finds it in the DOM, so the two
+ * move together at every merge.
  *
  * Vocabulary: no `content` means the read-only value tier
  * (`KIT_SLOT_CONTENT_NAMES`) — right for a slot painted per row, which is
@@ -720,68 +729,20 @@ const BASE_SPECS: KitComponentSpec[] = [
 const region: readonly string[] = BASE_SPECS.map((spec) => spec.name);
 const mark: readonly string[] = ["Icon", "Avatar", "Badge", "EnumBadge", "Text"];
 
-/** The three charts draw the same furniture, so they take the same three. */
-const CHART_SLOTS: Record<string, KitSlotSpec> = {
-  empty: { doc: "what the chart shows when there is nothing to plot", content: region },
-  tooltip: { doc: "the hover card for ONE point", perRow: true },
-  legend: { doc: "the series key, in place of the drawn one", content: region },
-};
-
 const SLOTS: Readonly<Record<string, Record<string, KitSlotSpec>>> = {
-  Surface: {
-    header: { doc: "elements along the top edge, beside the title", content: region },
-    footer: { doc: "elements under the content", content: region },
-  },
-  Card: {
-    header: { doc: "elements along the top edge, beside the title", content: region },
-    footer: { doc: "elements under the content", content: region },
-  },
-  Divider: { label: { doc: "a word or pill sitting in the rule" } },
   DataTable: {
     cell: { doc: "Kit value components composed for ONE row, in place of the column's plain text", perRow: true },
-    rowActions: { doc: "the controls for ONE row, at the end of it", content: ["Button", "Icon", "Row"], perRow: true },
-    toolbar: { doc: "controls above the table, beside its search and filters", content: region },
-    empty: { doc: "what the table shows in place of rows when the query returns none", content: region },
   },
   CardList: {
     cell: { doc: "Kit value components composed for ONE item, in place of the field's plain text", perRow: true },
-    actions: { doc: "controls above the list", content: region },
-    empty: { doc: "what the list shows when there are no items", content: region },
   },
-  Stat: { icon: { doc: "a glyph beside the metric's label", content: mark } },
   KeyValue: { cell: { doc: "Kit value components composed for the record, in place of the field's plain text", perRow: true } },
   Timeline: {
     cell: { doc: "Kit components rendered as ONE entry's body", perRow: true },
     marker: { doc: "a glyph drawn in place of the entry's dot", content: mark },
-    empty: { doc: "what the timeline shows when there are no entries", content: region },
   },
-  LineChart: CHART_SLOTS,
-  BarChart: CHART_SLOTS,
-  DonutChart: CHART_SLOTS,
-  Progress: { label: { doc: "a caption written as elements instead of a string" } },
-  Input: {
-    hint: { doc: "the help or error line under the field" },
-    prefix: { doc: "a glyph or unit inside the field's leading edge", content: mark },
-    suffix: { doc: "a glyph or unit inside the field's trailing edge", content: mark },
-  },
-  Select: { hint: { doc: "the help or error line under the field" } },
-  DatePicker: { hint: { doc: "the help or error line under the field" } },
-  Textarea: {
-    hint: { doc: "the help or error line under the field" },
-    footer: { doc: "a counter or controls under the field", content: region },
-  },
-  Form: {
-    header: { doc: "elements above the fields", content: region },
-    footer: { doc: "elements under the fields", content: region },
-    actions: { doc: "the buttons beside submit", content: region },
-  },
-  Tabs: {
-    actions: { doc: "controls on the tab bar's trailing edge", content: region },
-    content: { doc: "ONE tab's panel, written inline instead of as a child", content: region },
-  },
+  Tabs: { content: { doc: "ONE tab's panel, written inline instead of as a child", content: region } },
   Accordion: { content: { doc: "ONE section's body", content: region } },
-  EmptyState: { icon: { doc: "a glyph above the headline, in place of the icon name", content: mark } },
-  Steps: { marker: { doc: "a glyph drawn in place of a step's dot", content: mark } },
 };
 
 /** Every spec, with each shared adjective folded into the components that read

--- a/packages/apps/src/contract/kit/specs.ts
+++ b/packages/apps/src/contract/kit/specs.ts
@@ -10,7 +10,7 @@
  * pins the two in step).
  */
 import { z } from "zod";
-import { config, copy, data, type KitComponentSpec, type PropClass, type PropSpec } from "./schema.js";
+import { config, copy, data, type KitComponentSpec, type KitSlotSpec, type PropClass, type PropSpec } from "./schema.js";
 
 // ---- shared zod fragments -------------------------------------------------
 const rows = z.array(z.record(z.string(), z.unknown()));
@@ -703,11 +703,94 @@ const BASE_SPECS: KitComponentSpec[] = [
   },
 ];
 
+/**
+ * THE SLOTS — every place the Kit takes an ELEMENT instead of a value, in one
+ * table. The generated prompt teaches from it and the nesting check enforces
+ * it: an element under a key that is NOT declared here is refused rather than
+ * dropped at render, which is the silent-breakage class this floor exists for.
+ * A slot's key is the last segment of where the element sits, so `columns[].cell`
+ * and `header` are the slots `cell` and `header`.
+ *
+ * Vocabulary: no `content` means the read-only value tier
+ * (`KIT_SLOT_CONTENT_NAMES`) — right for a slot painted per row, which is
+ * written ONCE for every row and so has no row of its own to act on. A REGION
+ * is a place, and holds whatever the Kit holds; a MARK is one glyph, pill or
+ * word beside something else.
+ */
+const region: readonly string[] = BASE_SPECS.map((spec) => spec.name);
+const mark: readonly string[] = ["Icon", "Avatar", "Badge", "EnumBadge", "Text"];
+
+/** The three charts draw the same furniture, so they take the same three. */
+const CHART_SLOTS: Record<string, KitSlotSpec> = {
+  empty: { doc: "what the chart shows when there is nothing to plot", content: region },
+  tooltip: { doc: "the hover card for ONE point", perRow: true },
+  legend: { doc: "the series key, in place of the drawn one", content: region },
+};
+
+const SLOTS: Readonly<Record<string, Record<string, KitSlotSpec>>> = {
+  Surface: {
+    header: { doc: "elements along the top edge, beside the title", content: region },
+    footer: { doc: "elements under the content", content: region },
+  },
+  Card: {
+    header: { doc: "elements along the top edge, beside the title", content: region },
+    footer: { doc: "elements under the content", content: region },
+  },
+  Divider: { label: { doc: "a word or pill sitting in the rule" } },
+  DataTable: {
+    cell: { doc: "Kit value components composed for ONE row, in place of the column's plain text", perRow: true },
+    rowActions: { doc: "the controls for ONE row, at the end of it", content: ["Button", "Icon", "Row"], perRow: true },
+    toolbar: { doc: "controls above the table, beside its search and filters", content: region },
+    empty: { doc: "what the table shows in place of rows when the query returns none", content: region },
+  },
+  CardList: {
+    cell: { doc: "Kit value components composed for ONE item, in place of the field's plain text", perRow: true },
+    actions: { doc: "controls above the list", content: region },
+    empty: { doc: "what the list shows when there are no items", content: region },
+  },
+  Stat: { icon: { doc: "a glyph beside the metric's label", content: mark } },
+  KeyValue: { cell: { doc: "Kit value components composed for the record, in place of the field's plain text", perRow: true } },
+  Timeline: {
+    cell: { doc: "Kit components rendered as ONE entry's body", perRow: true },
+    marker: { doc: "a glyph drawn in place of the entry's dot", content: mark },
+    empty: { doc: "what the timeline shows when there are no entries", content: region },
+  },
+  LineChart: CHART_SLOTS,
+  BarChart: CHART_SLOTS,
+  DonutChart: CHART_SLOTS,
+  Progress: { label: { doc: "a caption written as elements instead of a string" } },
+  Input: {
+    hint: { doc: "the help or error line under the field" },
+    prefix: { doc: "a glyph or unit inside the field's leading edge", content: mark },
+    suffix: { doc: "a glyph or unit inside the field's trailing edge", content: mark },
+  },
+  Select: { hint: { doc: "the help or error line under the field" } },
+  DatePicker: { hint: { doc: "the help or error line under the field" } },
+  Textarea: {
+    hint: { doc: "the help or error line under the field" },
+    footer: { doc: "a counter or controls under the field", content: region },
+  },
+  Form: {
+    header: { doc: "elements above the fields", content: region },
+    footer: { doc: "elements under the fields", content: region },
+    actions: { doc: "the buttons beside submit", content: region },
+  },
+  Tabs: {
+    actions: { doc: "controls on the tab bar's trailing edge", content: region },
+    content: { doc: "ONE tab's panel, written inline instead of as a child", content: region },
+  },
+  Accordion: { content: { doc: "ONE section's body", content: region } },
+  EmptyState: { icon: { doc: "a glyph above the headline, in place of the icon name", content: mark } },
+  Steps: { marker: { doc: "a glyph drawn in place of a step's dot", content: mark } },
+};
+
 /** Every spec, with each shared adjective folded into the components that read
  *  it — so validation, the wire's allowed-prop set and the screen typings admit
- *  it exactly where it lands, and refuse it where it would be dropped. */
+ *  it exactly where it lands, and refuse it where it would be dropped — and its
+ *  slots, which the same consumers read. */
 export const KIT_SPECS: KitComponentSpec[] = BASE_SPECS.map((spec) => ({
   ...spec,
+  slots: SLOTS[spec.name],
   props: {
     ...spec.props,
     ...Object.fromEntries(SHARED_PROPS
@@ -736,9 +819,10 @@ export const KIT_CHILDLESS_NAMES: readonly string[] = KIT_SPECS
   .filter((spec) => spec.takesChildren !== true)
   .map((spec) => spec.name);
 
-/** What a `cell` slot may hold: the value tier, plus the two arrangers. A cell
- *  is read, never operated — an interactive control in one has no row to act
- *  on and no room to be pressed. */
+/** What a slot that declares no vocabulary of its own may hold: the value tier,
+ *  plus the two arrangers. It is the tier every PER-ROW slot keeps — a cell is
+ *  read, never operated, and an interactive control in one has no row to act on
+ *  and no room to be pressed. */
 export const KIT_SLOT_CONTENT_NAMES: readonly string[] = [
   "Text", "Money", "DateTime", "Percent", "Num", "EnumBadge", "Badge", "Sparkline", "Progress",
   "Stack", "Row",

--- a/packages/apps/src/contract/kit/specs.ts
+++ b/packages/apps/src/contract/kit/specs.ts
@@ -731,19 +731,26 @@ const mark: readonly string[] = ["Icon", "Avatar", "Badge", "EnumBadge", "Text"]
 
 const SLOTS: Readonly<Record<string, Record<string, KitSlotSpec>>> = {
   DataTable: {
-    cell: { doc: "Kit value components composed for ONE row, in place of the column's plain text", perRow: true },
+    cell: { doc: "Kit value components composed for ONE row, in place of the column's plain text", perRow: true, at: "columns" },
   },
   CardList: {
-    cell: { doc: "Kit value components composed for ONE item, in place of the field's plain text", perRow: true },
+    cell: { doc: "Kit value components composed for ONE item, in place of the field's plain text", perRow: true, at: "fields" },
   },
-  KeyValue: { cell: { doc: "Kit value components composed for the record, in place of the field's plain text", perRow: true } },
+  KeyValue: { cell: { doc: "Kit value components composed for the record, in place of the field's plain text", perRow: true, at: "items" } },
   Timeline: {
     cell: { doc: "Kit components rendered as ONE entry's body", perRow: true },
     marker: { doc: "a glyph drawn in place of the entry's dot", content: mark },
   },
-  Tabs: { content: { doc: "ONE tab's panel, written inline instead of as a child", content: region } },
-  Accordion: { content: { doc: "ONE section's body", content: region } },
+  Tabs: { content: { doc: "ONE tab's panel, written inline instead of as a child", content: region, at: "tabs" } },
+  Accordion: { content: { doc: "ONE section's body", content: region, at: "items" } },
 };
+
+/** Where a slot's element sits, as ONE comparable string: `columns[].cell` for a
+ *  field of a description object, `marker` for a slot that is a prop of its own.
+ *  The prompt teaches this string and the nesting check matches on it, so the
+ *  place a component READS and the place the floor admits are the same place. */
+export const kitSlotPath = (name: string, slot: KitSlotSpec): string =>
+  slot.at === undefined ? name : `${slot.at}[].${name}`;
 
 /** Every spec, with each shared adjective folded into the components that read
  *  it — so validation, the wire's allowed-prop set and the screen typings admit

--- a/packages/apps/src/server/checking/facts.ts
+++ b/packages/apps/src/server/checking/facts.ts
@@ -25,6 +25,7 @@ import {
   KIT_SCREEN_COMPONENT_NAMES,
   checkBindingShapes,
   checkExpr,
+  kitSlotPath,
   kitSpec,
   isExprBinding,
   validateAppDocument,
@@ -428,9 +429,9 @@ const CHILDLESS: ReadonlySet<string> = new Set(KIT_CHILDLESS_NAMES);
  *  exactly that (`packages/ui` renderer.tsx `reifyElement`) — so this reads the
  *  sigil at the slot and a `component` name below it, and a data row that merely
  *  carries a "component" field is never mistaken for an element. */
-const asElement = (value: unknown, sigil: boolean): { component: string; children?: unknown } | undefined =>
+const asElement = (value: unknown, sigil: boolean): { component: string; props?: unknown; children?: unknown } | undefined =>
   isRecord(value) && typeof value.component === "string" && (!sigil || value.$element === true)
-    ? (value as { component: string; children?: unknown })
+    ? (value as { component: string; props?: unknown; children?: unknown })
     : undefined;
 
 /**
@@ -461,7 +462,7 @@ export const kitNestingIssues = (tree: Tree): FactIssue[] => {
    *  arrangement and typography, `style` and children and nothing else
    *  (`contract/kit/display.ts`), so it can no more break the per-row rule than a
    *  word can. */
-  const checkSlot = (nodeId: string, path: string, key: string, slot: KitSlotSpec, value: unknown, sigil = true): void => {
+  const checkSlot = (nodeId: string, path: string, name: string, slot: KitSlotSpec, value: unknown, sigil = true): void => {
     const element = asElement(value, sigil);
     if (element === undefined) return;
     const allowed = slot.content ?? KIT_SLOT_CONTENT_NAMES;
@@ -469,52 +470,87 @@ export const kitNestingIssues = (tree: Tree): FactIssue[] => {
       const why = slot.perRow === true && slot.content === undefined
         ? `a cell is read, never operated: the slot is written ONCE and rendered for every row, so nothing in it has a row of its own to act on. A cell may hold: ${allowed.join(", ")} — each reading its row's value with field="…". Anything else belongs beside the table, not in it.`
         : `this slot may hold: ${allowed.join(", ")}.`;
-      issues.push(atProp(nodeId, path, `holds <${element.component}> in a ${key} slot — ${why}`));
+      issues.push(atProp(nodeId, path, `holds <${element.component}> in a ${name} slot — ${why}`));
     }
+    // What sits in a slot is a component in its own right, with its own slots
+    // and its own childless contract. Measuring it only against the OUTER
+    // slot's vocabulary passes `<Stack header={<Text/>}/>` and a `<DataTable>`
+    // handed children — both dropped by the renderer, which is the whole class
+    // this check exists to refuse.
+    checkKitElement(nodeId, path, element.component, element.props, element.children);
     if (Array.isArray(element.children)) {
-      element.children.forEach((child, index) => checkSlot(nodeId, `${path}.children[${index}]`, key, slot, child, false));
+      element.children.forEach((child, index) => checkSlot(nodeId, `${path}.children[${index}]`, name, slot, child, false));
     }
   };
 
-  /** The slots inside one prop — a slot is the prop itself (`marker`) or a field
-   *  of the description objects a prop holds (`columns[].cell`), so the walk
-   *  matches on the KEY at any depth. An element anywhere else is a place the
-   *  renderer paints nothing. */
-  const findSlots = (node: TreeNode, slots: ReadonlyMap<string, KitSlotSpec>, path: string, key: string, value: unknown): void => {
-    const slot = slots.get(key);
+  /** The slots inside one prop. The walk carries the SHAPE of where it stands —
+   *  `columns[].cell`, `rows[].cell` — and a slot matches only its own declared
+   *  path (`kitSlotPath`). Matching a bare key at any depth admitted
+   *  `rows[].cell` on a DataTable that reads `columns[].cell` and nothing else:
+   *  legal to the floor, dropped by the component. An element off the declared
+   *  paths is a place the renderer paints nothing. */
+  const findSlots = (
+    nodeId: string,
+    component: string,
+    slots: ReadonlyMap<string, readonly [string, KitSlotSpec]>,
+    path: string,
+    shape: string,
+    value: unknown,
+  ): void => {
+    const slot = slots.get(shape);
     if (slot !== undefined) {
-      checkSlot(node.id, path, key, slot, value);
+      checkSlot(nodeId, path, slot[0], slot[1], value);
       return;
     }
     const stray = asElement(value, true);
     if (stray !== undefined) {
       const has = slots.size === 0
-        ? `<${node.component}> takes no element in its props`
-        : `the slots on <${node.component}> are: ${[...slots.keys()].join(", ")}`;
-      issues.push(atProp(node.id, path, `holds <${stray.component}>, but "${key}" is not a slot — ${has}. An element written anywhere else is dropped at render.`));
+        ? `<${component}> takes no element in its props`
+        : `the slots on <${component}> are: ${[...slots.keys()].join(", ")}`;
+      issues.push(atProp(nodeId, path, `holds <${stray.component}>, but "${shape}" is not a slot — ${has}. An element written anywhere else is dropped at render.`));
       return;
     }
     if (Array.isArray(value)) {
-      value.forEach((item, index) => findSlots(node, slots, `${path}[${index}]`, "", item));
+      value.forEach((item, index) => findSlots(nodeId, component, slots, `${path}[${index}]`, `${shape}[]`, item));
       return;
     }
     if (isRecord(value)) {
-      for (const [name, item] of Object.entries(value)) findSlots(node, slots, `${path}.${name}`, name, item);
+      for (const [name, item] of Object.entries(value)) {
+        findSlots(nodeId, component, slots, `${path}.${name}`, `${shape}.${name}`, item);
+      }
+    }
+  };
+
+  /** One Kit element measured against ITS OWN spec — a tree node, or an element
+   *  written into a slot, which is the same thing in a different place. `at` is
+   *  where it sits ("" for a node), so a nested component's findings are
+   *  anchored at the prop path that leads to it. */
+  const checkKitElement = (
+    nodeId: string,
+    at: string,
+    component: string,
+    props: unknown,
+    children: unknown,
+  ): void => {
+    const nested = Array.isArray(children) ? children.length : 0;
+    if (nested > 0 && CHILDLESS.has(component)) {
+      const message = `nests ${nested === 1 ? "1 node" : `${nested} nodes`} inside <${component}>, which renders nothing nested inside it: that content never reaches the screen. Put it beside <${component}> in a <Stack>, or give <${component}> what it showed through its own props.`;
+      issues.push(at === "" ? atNode(nodeId, message) : atProp(nodeId, at, message));
+    }
+    const spec = kitSpec(component);
+    if (spec === undefined || !isRecord(props)) return;
+    // A Map, not the record: a prop key is model-written, and `slots["toString"]`
+    // on a plain object answers with Object's own.
+    const slots = new Map(Object.entries(spec.slots ?? {})
+      .map(([name, slot]) => [kitSlotPath(name, slot), [name, slot] as const]));
+    for (const [prop, value] of Object.entries(props)) {
+      findSlots(nodeId, component, slots, at === "" ? prop : `${at}.${prop}`, prop, value);
     }
   };
 
   for (const node of tree.nodes) {
     if (node.source === "host" || node.source === "generated") continue;
-    const nested = node.children?.length ?? 0;
-    if (nested > 0 && CHILDLESS.has(node.component)) {
-      issues.push(atNode(node.id, `nests ${nested === 1 ? "1 node" : `${nested} nodes`} inside <${node.component}>, which renders nothing nested inside it: that content never reaches the screen. Put it beside <${node.component}> in a <Stack>, or give <${node.component}> what it showed through its own props.`));
-    }
-    const spec = kitSpec(node.component);
-    if (spec === undefined) continue;
-    // A Map, not the record: a prop key is model-written, and `slots["toString"]`
-    // on a plain object answers with Object's own.
-    const slots = new Map(Object.entries(spec.slots ?? {}));
-    for (const [prop, value] of Object.entries(node.props ?? {})) findSlots(node, slots, prop, prop, value);
+    checkKitElement(node.id, "", node.component, node.props ?? {}, node.children);
   }
   return issues;
 };

--- a/packages/apps/src/server/checking/facts.ts
+++ b/packages/apps/src/server/checking/facts.ts
@@ -28,6 +28,7 @@ import {
   isExprBinding,
   validateAppDocument,
   validateTree,
+  type KitSlotSpec,
   type NormalizedCatalog,
   type Tree,
 } from "../../contract/index.js";
@@ -419,9 +420,8 @@ export const catalogIssues = async (
 };
 
 const CHILDLESS: ReadonlySet<string> = new Set(KIT_CHILDLESS_NAMES);
-const SLOT_CONTENT: ReadonlySet<string> = new Set(KIT_SLOT_CONTENT_NAMES);
 
-/** A Kit element sitting in a PROP — what a `cell` slot holds. The screen VM
+/** A Kit element sitting in a PROP — what a slot holds. The screen VM
  *  stamps the SLOT's own element `$element` and leaves the ones nested under it
  *  bare (genui/component/vm-program.ts `emitValue`), and the renderer reifies on
  *  exactly that (`packages/ui` renderer.tsx `reifyElement`) — so this reads the
@@ -450,32 +450,48 @@ const asElement = (value: unknown, sigil: boolean): { component: string; childre
 export const kitNestingIssues = (tree: Tree): FactIssue[] => {
   const issues: FactIssue[] = [];
 
-  /** One `cell` slot: the element it holds, and every element nested in that
-   *  one. */
-  const checkSlot = (nodeId: string, path: string, value: unknown, sigil = true): void => {
+  /** One slot: the element it holds, and every element nested in that one. A
+   *  slot with no declared vocabulary takes the read-only value tier, and a
+   *  per-row one says WHY that tier is the one it takes. */
+  const checkSlot = (nodeId: string, path: string, key: string, slot: KitSlotSpec, value: unknown, sigil = true): void => {
     const element = asElement(value, sigil);
     if (element === undefined) return;
-    if (!SLOT_CONTENT.has(element.component)) {
-      issues.push(atProp(nodeId, path, `holds <${element.component}> in a cell slot — a cell is read, never operated: the slot is written ONCE and rendered for every row, so nothing in it has a row of its own to act on. A cell may hold: ${KIT_SLOT_CONTENT_NAMES.join(", ")} — each reading its row's value with field="…". Anything else belongs beside the table, not in it.`));
+    const allowed = slot.content ?? KIT_SLOT_CONTENT_NAMES;
+    if (!allowed.includes(element.component)) {
+      const why = slot.perRow === true && slot.content === undefined
+        ? `a cell is read, never operated: the slot is written ONCE and rendered for every row, so nothing in it has a row of its own to act on. A cell may hold: ${allowed.join(", ")} — each reading its row's value with field="…". Anything else belongs beside the table, not in it.`
+        : `this slot may hold: ${allowed.join(", ")}.`;
+      issues.push(atProp(nodeId, path, `holds <${element.component}> in a ${key} slot — ${why}`));
     }
     if (Array.isArray(element.children)) {
-      element.children.forEach((child, index) => checkSlot(nodeId, `${path}.children[${index}]`, child, false));
+      element.children.forEach((child, index) => checkSlot(nodeId, `${path}.children[${index}]`, key, slot, child, false));
     }
   };
 
-  /** The `cell` slots inside one prop — a column/field description carries one,
-   *  and the descriptions are an array. */
-  const findSlots = (nodeId: string, path: string, key: string, value: unknown): void => {
-    if (key === "cell") {
-      checkSlot(nodeId, path, value);
+  /** The slots inside one prop — a slot is the prop itself (`marker`) or a field
+   *  of the description objects a prop holds (`columns[].cell`), so the walk
+   *  matches on the KEY at any depth. An element anywhere else is a place the
+   *  renderer paints nothing. */
+  const findSlots = (node: TreeNode, slots: ReadonlyMap<string, KitSlotSpec>, path: string, key: string, value: unknown): void => {
+    const slot = slots.get(key);
+    if (slot !== undefined) {
+      checkSlot(node.id, path, key, slot, value);
+      return;
+    }
+    const stray = asElement(value, true);
+    if (stray !== undefined) {
+      const has = slots.size === 0
+        ? `<${node.component}> takes no element in its props`
+        : `the slots on <${node.component}> are: ${[...slots.keys()].join(", ")}`;
+      issues.push(atProp(node.id, path, `holds <${stray.component}>, but "${key}" is not a slot — ${has}. An element written anywhere else is dropped at render.`));
       return;
     }
     if (Array.isArray(value)) {
-      value.forEach((item, index) => findSlots(nodeId, `${path}[${index}]`, "", item));
+      value.forEach((item, index) => findSlots(node, slots, `${path}[${index}]`, "", item));
       return;
     }
     if (isRecord(value)) {
-      for (const [name, item] of Object.entries(value)) findSlots(nodeId, `${path}.${name}`, name, item);
+      for (const [name, item] of Object.entries(value)) findSlots(node, slots, `${path}.${name}`, name, item);
     }
   };
 
@@ -485,7 +501,12 @@ export const kitNestingIssues = (tree: Tree): FactIssue[] => {
     if (nested > 0 && CHILDLESS.has(node.component)) {
       issues.push(atNode(node.id, `nests ${nested === 1 ? "1 node" : `${nested} nodes`} inside <${node.component}>, which renders nothing nested inside it: that content never reaches the screen. Put it beside <${node.component}> in a <Stack>, or give <${node.component}> what it showed through its own props.`));
     }
-    for (const [prop, value] of Object.entries(node.props ?? {})) findSlots(node.id, prop, prop, value);
+    const spec = kitSpec(node.component);
+    if (spec === undefined) continue;
+    // A Map, not the record: a prop key is model-written, and `slots["toString"]`
+    // on a plain object answers with Object's own.
+    const slots = new Map(Object.entries(spec.slots ?? {}));
+    for (const [prop, value] of Object.entries(node.props ?? {})) findSlots(node, slots, prop, prop, value);
   }
   return issues;
 };

--- a/packages/apps/src/server/checking/facts.ts
+++ b/packages/apps/src/server/checking/facts.ts
@@ -19,6 +19,7 @@ import {
   type TreeNode,
 } from "@vendoai/core";
 import {
+  DISPLAY_TAG_NAMES,
   KIT_CHILDLESS_NAMES,
   KIT_SLOT_CONTENT_NAMES,
   KIT_SCREEN_COMPONENT_NAMES,
@@ -452,12 +453,19 @@ export const kitNestingIssues = (tree: Tree): FactIssue[] => {
 
   /** One slot: the element it holds, and every element nested in that one. A
    *  slot with no declared vocabulary takes the read-only value tier, and a
-   *  per-row one says WHY that tier is the one it takes. */
+   *  per-row one says WHY that tier is the one it takes.
+   *
+   *  A DISPLAY BRICK passes every slot, and is stated here rather than added to
+   *  each vocabulary: these lists gate BEHAVIOR — what may sort, submit or call a
+   *  tool where there is no row to act on — and a brick has none to gate. It is
+   *  arrangement and typography, `style` and children and nothing else
+   *  (`contract/kit/display.ts`), so it can no more break the per-row rule than a
+   *  word can. */
   const checkSlot = (nodeId: string, path: string, key: string, slot: KitSlotSpec, value: unknown, sigil = true): void => {
     const element = asElement(value, sigil);
     if (element === undefined) return;
     const allowed = slot.content ?? KIT_SLOT_CONTENT_NAMES;
-    if (!allowed.includes(element.component)) {
+    if (!allowed.includes(element.component) && !DISPLAY_TAG_NAMES.includes(element.component)) {
       const why = slot.perRow === true && slot.content === undefined
         ? `a cell is read, never operated: the slot is written ONCE and rendered for every row, so nothing in it has a row of its own to act on. A cell may hold: ${allowed.join(", ")} — each reading its row's value with field="…". Anything else belongs beside the table, not in it.`
         : `this slot may hold: ${allowed.join(", ")}.`;

--- a/packages/apps/tests/checking/component-screen.test.ts
+++ b/packages/apps/tests/checking/component-screen.test.ts
@@ -954,6 +954,52 @@ export default function Invoices() {
     expect(result.ok).toBe(true);
   });
 
+  it("refuses a cell written on a ROW — the table reads columns[].cell and nothing else", async () => {
+    // Whole gauntlet, real compiler. The VM stamps this element exactly as it
+    // stamps a column's, so matching the bare key admitted a `cell` the table
+    // never looks at: green all the way through, blank on the screen.
+    const result = await painted(`import { Badge, DataTable } from "@vendo/screen";
+
+export default function Invoices() {
+  return (
+    <DataTable
+      rows={[{ id: "r1", cell: <Badge label="late" /> }]}
+      columns={[{ key: "id" }]}
+    />
+  );
+}
+`);
+
+    expect(result.issues.map(({ code }) => code)).toEqual(["nesting"]);
+    const message = result.issues[0]?.message ?? "";
+    expect(message).toContain('prop "rows[0].cell" holds <Badge>');
+    expect(message).toContain('"rows[].cell" is not a slot');
+    expect(message).toContain("the slots on <DataTable> are: columns[].cell");
+  });
+
+  it("follows a slot's component into its OWN contract — a slot is not a blind spot", async () => {
+    // A Sparkline is legal in a cell, so the outer check passed and stopped
+    // there. It renders nothing nested inside it, and the compiler cannot say
+    // so — every Kit component's typings carry `children?: any` — so this note
+    // reached the renderer and vanished. The nesting check is its only reader.
+    const result = await painted(`import { DataTable, Sparkline } from "@vendo/screen";
+
+export default function Invoices() {
+  return (
+    <DataTable
+      rows={[{ id: "r1" }]}
+      columns={[{ key: "id", cell: <Sparkline data={[1, 2, 3]}>trend</Sparkline> }]}
+    />
+  );
+}
+`);
+
+    expect(result.issues.map(({ code }) => code)).toEqual(["nesting"]);
+    const message = result.issues[0]?.message ?? "";
+    expect(message).toContain('prop "columns[0].cell" nests 1 node inside <Sparkline>');
+    expect(message).toContain("renders nothing nested inside it");
+  });
+
   it("reads the sigil, not the shape — row data that describes a component is data", async () => {
     // A "cell" column whose value happens to name a component and carry a
     // children list. The VM stamps `$element` on what a screen wrote as an

--- a/packages/apps/tests/checking/component-screen.test.ts
+++ b/packages/apps/tests/checking/component-screen.test.ts
@@ -932,6 +932,28 @@ export default function Ledger() {
     expect(result.issues[0]?.message).toContain('prop "columns[0].cell.children[1]" holds <Button> in a cell slot');
   });
 
+  /** A slot's vocabulary gates BEHAVIOR — what may sort, submit or call a tool
+   *  where there is no row to act on. A display brick has none to gate: it is
+   *  `style` and children and nothing else, so it passes the same per-row cell
+   *  that refuses a Button, and the renderer builds it back
+   *  (`packages/ui` renderer.tsx `reifyElement`). Whole gauntlet, real compiler. */
+  it("passes a display brick in a per-row cell — arrangement is not behavior", async () => {
+    const result = await painted(`import { DataTable, Text } from "@vendo/screen";
+
+export default function Invoices() {
+  return (
+    <DataTable
+      rows={[{ id: "r1", status: "past_due" }]}
+      columns={[{ key: "status", cell: <div style={{ display: "flex" }}><Text field="status" /></div> }]}
+    />
+  );
+}
+`);
+
+    expect(result.issues).toEqual([]);
+    expect(result.ok).toBe(true);
+  });
+
   it("reads the sigil, not the shape — row data that describes a component is data", async () => {
     // A "cell" column whose value happens to name a component and carry a
     // children list. The VM stamps `$element` on what a screen wrote as an

--- a/packages/apps/tests/checking/kit-slots.test.ts
+++ b/packages/apps/tests/checking/kit-slots.test.ts
@@ -46,13 +46,14 @@ describe("the Kit's slots", () => {
   });
 
   it("refuses an element where no slot was declared, naming the component and the key", () => {
-    // Surface takes a header; a DataTable does not, and an element written
-    // there reaches nothing at all.
+    // A DataTable column takes a cell; the table itself takes no `header`, and
+    // an element written there reaches nothing at all.
     const [message] = issuesFor("DataTable", { header: element("Text") });
 
     expect(message).toContain('node "n1" prop "header" holds <Text>, but "header" is not a slot');
-    expect(message).toContain("the slots on <DataTable> are: cell, rowActions, toolbar, empty");
-    expect(issuesFor("Surface", { header: element("Text") })).toEqual([]);
+    expect(message).toContain("the slots on <DataTable> are: cell");
+    // …while a slot the Kit really renders admits its own vocabulary.
+    expect(issuesFor("Timeline", { marker: element("Icon") })).toEqual([]);
   });
 
   it("says so when the component takes no element at all", () => {
@@ -68,10 +69,12 @@ describe("the Kit's slots", () => {
     expect(cell).toContain('prop "columns[0].cell" holds <Button> in a cell slot');
     expect(cell).toContain("a cell is read, never operated");
     expect(cell).toContain(`A cell may hold: ${KIT_SLOT_CONTENT_NAMES.join(", ")}`);
-    expect(issuesFor("DataTable", { rowActions: element("Button") })).toEqual([]);
-    // …and the tooltip a chart paints per point takes the same read-only tier.
-    expect(issuesFor("LineChart", { tooltip: element("Button") })[0])
+    // …the entry body a Timeline paints per entry takes that same tier…
+    expect(issuesFor("Timeline", { cell: element("Button") })[0])
       .toContain("a cell is read, never operated");
+    // …and the marker beside it takes the narrower one it declares.
+    expect(issuesFor("Timeline", { marker: element("Button") })[0])
+      .toContain("this slot may hold: Icon, Avatar, Badge, EnumBadge, Text");
   });
 
   it("lets an Accordion section hold a whole screen, and refuses a name the Kit has not got", () => {

--- a/packages/apps/tests/checking/kit-slots.test.ts
+++ b/packages/apps/tests/checking/kit-slots.test.ts
@@ -15,13 +15,22 @@ import {
   KIT_COMPONENT_NAMES,
   KIT_SLOT_CONTENT_NAMES,
   KIT_SPECS,
+  kitSlotPath,
+  type KitSlotSpec,
   type Tree,
 } from "../../src/contract/index.js";
 import { kitNestingIssues } from "../../src/server/checking/facts.js";
 
 /** An element as the screen VM stamps one into a prop (vm-program.ts). */
-const element = (component: string): Record<string, unknown> =>
-  ({ $element: true, component, props: {}, children: [] });
+const element = (component: string, over: Record<string, unknown> = {}): Record<string, unknown> =>
+  ({ $element: true, component, props: {}, children: [], ...over });
+
+/** The props that put a value at a slot's DECLARED path, built from the
+ *  declaration itself: a nested slot sits in its prop's description objects, a
+ *  top-level one is the prop. Placement is what these tests are about, so it is
+ *  derived rather than written out per component. */
+const propsAt = (name: string, slot: KitSlotSpec, value: unknown): Record<string, unknown> =>
+  slot.at === undefined ? { [name]: value } : { [slot.at]: [{ [name]: value }] };
 
 /** One Kit node's props, measured by the check the floor runs. */
 const issuesFor = (component: string, props: Record<string, unknown>): string[] =>
@@ -36,11 +45,30 @@ describe("the Kit's slots", () => {
     for (const spec of KIT_SPECS) {
       for (const [name, slot] of Object.entries(spec.slots ?? {})) {
         const allowed = slot.content ?? KIT_SLOT_CONTENT_NAMES;
-        const at = `${spec.name}.${name}`;
+        const at = `${spec.name}.${kitSlotPath(name, slot)}`;
         // A vocabulary naming something the Kit does not have is a slot nothing
         // can legally fill.
         expect(allowed.filter((held) => !KIT_COMPONENT_NAMES.includes(held)), at).toEqual([]);
-        expect(issuesFor(spec.name, { [name]: element(allowed[0]!) }), at).toEqual([]);
+        expect(issuesFor(spec.name, propsAt(name, slot, element(allowed[0]!))), at).toEqual([]);
+      }
+    }
+  });
+
+  /** THE CLASS, swept from the table: a component reads its slot at exactly one
+   *  place, so the floor must admit it there and refuse it everywhere else. A
+   *  checker that takes an element the component never looks at is the same
+   *  silent drop as a catalog that teaches a slot the Kit does not paint. */
+  it("reads every slot at its declared path, and refuses the same name off it", () => {
+    for (const spec of KIT_SPECS) {
+      for (const [name, slot] of Object.entries(spec.slots ?? {})) {
+        const at = `${spec.name}.${kitSlotPath(name, slot)}`;
+        const held = element((slot.content ?? KIT_SLOT_CONTENT_NAMES)[0]!);
+        expect(issuesFor(spec.name, propsAt(name, slot, held)), at).toEqual([]);
+        // The generic wrong place, derived from the declaration: a slot read out
+        // of its prop's items is not read as a bare prop of the same name.
+        if (slot.at !== undefined) {
+          expect(issuesFor(spec.name, { [name]: held })[0], at).toContain(`"${name}" is not a slot`);
+        }
       }
     }
   });
@@ -51,9 +79,51 @@ describe("the Kit's slots", () => {
     const [message] = issuesFor("DataTable", { header: element("Text") });
 
     expect(message).toContain('node "n1" prop "header" holds <Text>, but "header" is not a slot');
-    expect(message).toContain("the slots on <DataTable> are: cell");
+    // The message names WHERE the real slot is read, not just its bare name —
+    // a model told "cell" would write it on a row.
+    expect(message).toContain("the slots on <DataTable> are: columns[].cell");
     // …while a slot the Kit really renders admits its own vocabulary.
     expect(issuesFor("Timeline", { marker: element("Icon") })).toEqual([]);
+  });
+
+  it("refuses a slot's own name at a path the component never reads", () => {
+    // DataTable renders `columns[].cell` and nothing else. A `cell` field on a
+    // ROW is a value it never looks at — and matching the bare key at any depth
+    // admitted it as if it were the column's, so the floor passed an element
+    // the table drops.
+    const [message] = issuesFor("DataTable", {
+      rows: [{ id: "r1", cell: element("Badge") }],
+      columns: [{ key: "id" }],
+    });
+
+    expect(message).toContain('prop "rows[0].cell" holds <Badge>');
+    expect(message).toContain('"rows[].cell" is not a slot');
+    expect(message).toContain("the slots on <DataTable> are: columns[].cell");
+    // The declared path still passes, so this narrows placement and nothing else.
+    expect(issuesFor("DataTable", { rows: [], columns: [{ key: "id", cell: element("Badge") }] })).toEqual([]);
+  });
+
+  it("measures a component in a slot against its OWN contract, not just the slot's", () => {
+    // What sits in a slot is a component in its own right. Checked only against
+    // the outer slot's vocabulary, both of these passed clean while the renderer
+    // dropped the descendant: an element in a prop <Stack> has no slot for, and
+    // children under a component that renders none.
+    const [header] = issuesFor("Accordion", {
+      items: [{ label: "Status", content: element("Stack", { props: { header: element("Text") } }) }],
+    });
+    expect(header).toContain('prop "items[0].content.header" holds <Text>');
+    expect(header).toContain("<Stack> takes no element in its props");
+
+    const [childless] = issuesFor("Accordion", {
+      items: [{ label: "Rows", content: element("DataTable", { children: [element("Text")] }) }],
+    });
+    expect(childless).toContain('prop "items[0].content" nests 1 node inside <DataTable>');
+    expect(childless).toContain("renders nothing nested inside it");
+
+    // …and a legal component in the same slot still passes, contract and all.
+    expect(issuesFor("Accordion", {
+      items: [{ label: "Rows", content: element("Timeline", { props: { marker: element("Icon") } }) }],
+    })).toEqual([]);
   });
 
   it("says so when the component takes no element at all", () => {

--- a/packages/apps/tests/checking/kit-slots.test.ts
+++ b/packages/apps/tests/checking/kit-slots.test.ts
@@ -1,0 +1,89 @@
+/**
+ * The SLOTS — the places a Kit component takes an ELEMENT instead of a value.
+ * One table declares them (`KitComponentSpec.slots`) and the nesting check
+ * enforces it, so the two are pinned here TOGETHER: every slot the specs
+ * declare is a slot the checker admits, and a key it does not declare is an
+ * element the renderer would drop, refused by name.
+ *
+ * The `cell` slot is the one that already existed; the rest arrive with the
+ * declaration, so this file measures the CHECK against the declaration rather
+ * than restating a list the checker would then have to agree with.
+ */
+import { describe, expect, it } from "vitest";
+import { VENDO_TREE_FORMAT } from "@vendoai/core";
+import {
+  KIT_COMPONENT_NAMES,
+  KIT_SLOT_CONTENT_NAMES,
+  KIT_SPECS,
+  type Tree,
+} from "../../src/contract/index.js";
+import { kitNestingIssues } from "../../src/server/checking/facts.js";
+
+/** An element as the screen VM stamps one into a prop (vm-program.ts). */
+const element = (component: string): Record<string, unknown> =>
+  ({ $element: true, component, props: {}, children: [] });
+
+/** One Kit node's props, measured by the check the floor runs. */
+const issuesFor = (component: string, props: Record<string, unknown>): string[] =>
+  kitNestingIssues({
+    formatVersion: VENDO_TREE_FORMAT,
+    root: "n1",
+    nodes: [{ id: "n1", component, source: "prewired", props: props as Tree["nodes"][0]["props"] }],
+  }).map(({ where, message }) => `${where} ${message}`);
+
+describe("the Kit's slots", () => {
+  it("admits, for every declared slot, what that slot declares", () => {
+    for (const spec of KIT_SPECS) {
+      for (const [name, slot] of Object.entries(spec.slots ?? {})) {
+        const allowed = slot.content ?? KIT_SLOT_CONTENT_NAMES;
+        const at = `${spec.name}.${name}`;
+        // A vocabulary naming something the Kit does not have is a slot nothing
+        // can legally fill.
+        expect(allowed.filter((held) => !KIT_COMPONENT_NAMES.includes(held)), at).toEqual([]);
+        expect(issuesFor(spec.name, { [name]: element(allowed[0]!) }), at).toEqual([]);
+      }
+    }
+  });
+
+  it("refuses an element where no slot was declared, naming the component and the key", () => {
+    // Surface takes a header; a DataTable does not, and an element written
+    // there reaches nothing at all.
+    const [message] = issuesFor("DataTable", { header: element("Text") });
+
+    expect(message).toContain('node "n1" prop "header" holds <Text>, but "header" is not a slot');
+    expect(message).toContain("the slots on <DataTable> are: cell, rowActions, toolbar, empty");
+    expect(issuesFor("Surface", { header: element("Text") })).toEqual([]);
+  });
+
+  it("says so when the component takes no element at all", () => {
+    expect(issuesFor("Money", { amount: element("Text") })[0])
+      .toContain("<Money> takes no element in its props");
+  });
+
+  it("keeps the read-only tier on a per-row slot, and takes the declared one beside it", () => {
+    // The same table, the same row: what is painted for every row may not be
+    // operated, and the actions written FOR the row may.
+    const [cell] = issuesFor("DataTable", { columns: [{ key: "status", cell: element("Button") }] });
+
+    expect(cell).toContain('prop "columns[0].cell" holds <Button> in a cell slot');
+    expect(cell).toContain("a cell is read, never operated");
+    expect(cell).toContain(`A cell may hold: ${KIT_SLOT_CONTENT_NAMES.join(", ")}`);
+    expect(issuesFor("DataTable", { rowActions: element("Button") })).toEqual([]);
+    // …and the tooltip a chart paints per point takes the same read-only tier.
+    expect(issuesFor("LineChart", { tooltip: element("Button") })[0])
+      .toContain("a cell is read, never operated");
+  });
+
+  it("lets an Accordion section hold a whole screen, and refuses a name the Kit has not got", () => {
+    // `items[].content` is element-valued and was checked by nothing until the
+    // slots landed. A section is a REGION, so what goes in it is the Kit.
+    expect(issuesFor("Accordion", {
+      items: [{ label: "Overdue", content: element("DataTable") }],
+    })).toEqual([]);
+
+    const [message] = issuesFor("Accordion", {
+      items: [{ label: "Ghost", content: element("Hallucinated") }],
+    });
+    expect(message).toContain('prop "items[0].content" holds <Hallucinated> in a content slot');
+  });
+});

--- a/packages/ui/src/kit/schema.ts
+++ b/packages/ui/src/kit/schema.ts
@@ -12,6 +12,7 @@ export {
   propsSchema,
   validateProps,
   type KitComponentSpec,
+  type KitSlotSpec,
   type PropClass,
   type PropSpec,
 } from "@vendoai/apps/contract";

--- a/packages/ui/src/tree/renderer.tsx
+++ b/packages/ui/src/tree/renderer.tsx
@@ -272,11 +272,13 @@ const isElementNode = (value: unknown): value is ElementBinding =>
 const isElementBinding = (value: unknown): value is ElementBinding =>
   isElementNode(value) && (value as { $element?: unknown }).$element === true;
 
-/** That element, back as an element: the Kit component it names, its own props
- *  bound the same way, its children in order. An unknown name renders nothing
- *  rather than throwing — a slot fails soft, like every other node here. */
+/** That element, back as an element: the Kit component or display brick it
+ *  names — resolved exactly as `builtinContent` resolves a node, so a slot and a
+ *  child admit the same vocabulary — its own props bound the same way, its
+ *  children in order. An unknown name renders nothing rather than throwing —
+ *  a slot fails soft, like every other node here. */
 function reifyElement(node: ElementBinding, bind: (value: unknown) => unknown): ReactNode {
-  const Implementation = KIT_COMPONENTS[node.component] as ComponentType<Record<string, unknown>> | undefined;
+  const Implementation = (KIT_COMPONENTS[node.component] ?? DISPLAY_BRICKS[node.component]) as ComponentType<Record<string, unknown>> | undefined;
   if (Implementation === undefined) return null;
   // Only the prop's own element carries the sigil; the ones under it are nodes.
   const children = node.children?.map((child, index) => typeof child === "string"

--- a/packages/ui/test/kit/slot-drift.test.tsx
+++ b/packages/ui/test/kit/slot-drift.test.tsx
@@ -20,35 +20,50 @@ import type { ComponentType, ReactNode } from "react";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { KIT_COMPONENTS, KIT_SPECS } from "../../src/kit/registry.js";
+import type { KitSlotSpec } from "../../src/kit/schema.js";
 
 afterEach(cleanup);
 
-/** Where each declared slot sits in its component's props, with the minimum
- *  other props that component needs to paint at all. Keyed `Component.slot`. */
-const PROBES: Record<string, (probe: ReactNode) => Record<string, unknown>> = {
-  "DataTable.cell": (probe) => ({ rows: [{ k: "v" }], columns: [{ key: "k", cell: probe }] }),
-  "CardList.cell": (probe) => ({ items: [{ k: "v" }], fields: [{ key: "k", cell: probe }] }),
-  "KeyValue.cell": (probe) => ({ record: { k: "v" }, items: [{ key: "k", cell: probe }] }),
-  "Timeline.cell": (probe) => ({ entries: [{ id: "1" }], cell: probe }),
-  "Timeline.marker": (probe) => ({ entries: [{ id: "1" }], marker: probe }),
-  "Tabs.content": (probe) => ({ tabs: [{ label: "One", content: probe }] }),
-  "Accordion.content": (probe) => ({ items: [{ label: "One", content: probe }], defaultOpen: [0] }),
+/** The minimum a component needs to paint at all, BESIDE its slot: `props` for
+ *  the component, `item` to seed the description object a nested slot rides in.
+ *  The slot's PLACEMENT is deliberately not written here — it comes from the
+ *  `at` declaration, so the path this renders through is the same path
+ *  `kit-nesting` admits. Point `at` somewhere the component does not read and
+ *  this test goes red. */
+const CONTEXT: Record<string, { props: Record<string, unknown>; item?: Record<string, unknown> }> = {
+  DataTable: { props: { rows: [{ k: "v" }] }, item: { key: "k" } },
+  CardList: { props: { items: [{ k: "v" }] }, item: { key: "k" } },
+  KeyValue: { props: { record: { k: "v" } }, item: { key: "k" } },
+  Timeline: { props: { entries: [{ id: "1" }] } },
+  Tabs: { props: {}, item: { label: "One" } },
+  Accordion: { props: { defaultOpen: [0] }, item: { label: "One" } },
 };
 
+/** The probe at the slot's DECLARED path: a nested slot sits in its prop's
+ *  description objects, a top-level one is the prop itself. */
+const propsFor = (
+  context: { props: Record<string, unknown>; item?: Record<string, unknown> },
+  name: string,
+  slot: KitSlotSpec,
+  probe: ReactNode,
+): Record<string, unknown> => slot.at === undefined
+  ? { ...context.props, [name]: probe }
+  : { ...context.props, [slot.at]: [{ ...context.item, [name]: probe }] };
+
 describe("every declared slot renders what it promises", () => {
-  it("paints a probe put in each slot the catalog teaches", () => {
+  it("paints a probe put at each slot's declared path", () => {
     const declared = KIT_SPECS.flatMap((spec) =>
-      Object.keys(spec.slots ?? {}).map((slot) => [spec.name, slot] as const));
+      Object.entries(spec.slots ?? {}).map(([name, slot]) => [spec.name, name, slot] as const));
     // The table is the subject: an empty sweep would pass this test in silence.
     expect(declared.length).toBeGreaterThan(0);
 
-    for (const [component, slot] of declared) {
-      const key = `${component}.${slot}`;
-      const probe = PROBES[key];
-      expect(probe, `${key} is declared in SLOTS with no probe here — implement the slot in @vendoai/ui and probe it, or drop it from the table`).toBeTypeOf("function");
+    for (const [component, name, slot] of declared) {
+      const at = `${component}.${slot.at === undefined ? name : `${slot.at}[].${name}`}`;
+      const context = CONTEXT[component];
+      expect(context, `${at} is declared in SLOTS with no context here — implement the slot in @vendoai/ui and add one, or drop it from the table`).toBeTypeOf("object");
       const Implementation = KIT_COMPONENTS[component] as ComponentType<Record<string, unknown>>;
-      render(<Implementation {...probe(<span data-testid="probe">probe</span>)} />);
-      expect(screen.queryByTestId("probe"), `<${component}> declares a "${slot}" slot and does not render it — the prompt would teach a place the renderer drops`).toBeTruthy();
+      render(<Implementation {...propsFor(context!, name, slot, <span data-testid="probe">probe</span>)} />);
+      expect(screen.queryByTestId("probe"), `<${component}> declares its "${name}" slot at ${at} and does not render what is put there`).toBeTruthy();
       cleanup();
     }
   });

--- a/packages/ui/test/kit/slot-drift.test.tsx
+++ b/packages/ui/test/kit/slot-drift.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+/**
+ * THE LAW: the catalog may not teach a slot the Kit does not render.
+ *
+ * `SLOTS` (apps contract/kit/specs.ts) feeds three consumers — `kitPrompt`
+ * teaches it, `kit-nesting` enforces it, and the renderer reifies it — but none
+ * of them can see whether the React component on the other end actually PAINTS
+ * what is put there. When it does not, every stage passes and the person gets a
+ * blank: the model is told to write `header`, the checks admit it, and the
+ * component drops it. That is the silent-breakage class the table exists to
+ * refuse, arriving through the table itself. It shipped once, at a scale of ~22
+ * slots across 19 components, which is why this guard exists.
+ *
+ * So: every declared slot must have a probe here, and that probe must find its
+ * marker in the DOM. A slot added to the table without an implementation fails
+ * on the missing probe; one wired to a prop the component ignores fails on the
+ * render. Neither can reach a user.
+ */
+import type { ComponentType, ReactNode } from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { KIT_COMPONENTS, KIT_SPECS } from "../../src/kit/registry.js";
+
+afterEach(cleanup);
+
+/** Where each declared slot sits in its component's props, with the minimum
+ *  other props that component needs to paint at all. Keyed `Component.slot`. */
+const PROBES: Record<string, (probe: ReactNode) => Record<string, unknown>> = {
+  "DataTable.cell": (probe) => ({ rows: [{ k: "v" }], columns: [{ key: "k", cell: probe }] }),
+  "CardList.cell": (probe) => ({ items: [{ k: "v" }], fields: [{ key: "k", cell: probe }] }),
+  "KeyValue.cell": (probe) => ({ record: { k: "v" }, items: [{ key: "k", cell: probe }] }),
+  "Timeline.cell": (probe) => ({ entries: [{ id: "1" }], cell: probe }),
+  "Timeline.marker": (probe) => ({ entries: [{ id: "1" }], marker: probe }),
+  "Tabs.content": (probe) => ({ tabs: [{ label: "One", content: probe }] }),
+  "Accordion.content": (probe) => ({ items: [{ label: "One", content: probe }], defaultOpen: [0] }),
+};
+
+describe("every declared slot renders what it promises", () => {
+  it("paints a probe put in each slot the catalog teaches", () => {
+    const declared = KIT_SPECS.flatMap((spec) =>
+      Object.keys(spec.slots ?? {}).map((slot) => [spec.name, slot] as const));
+    // The table is the subject: an empty sweep would pass this test in silence.
+    expect(declared.length).toBeGreaterThan(0);
+
+    for (const [component, slot] of declared) {
+      const key = `${component}.${slot}`;
+      const probe = PROBES[key];
+      expect(probe, `${key} is declared in SLOTS with no probe here — implement the slot in @vendoai/ui and probe it, or drop it from the table`).toBeTypeOf("function");
+      const Implementation = KIT_COMPONENTS[component] as ComponentType<Record<string, unknown>>;
+      render(<Implementation {...probe(<span data-testid="probe">probe</span>)} />);
+      expect(screen.queryByTestId("probe"), `<${component}> declares a "${slot}" slot and does not render it — the prompt would teach a place the renderer drops`).toBeTruthy();
+      cleanup();
+    }
+  });
+});

--- a/packages/ui/test/tree/screen-bridge.test.tsx
+++ b/packages/ui/test/tree/screen-bridge.test.tsx
@@ -510,6 +510,43 @@ export default function Invoice() {
     expect(document.body.innerHTML).not.toContain("$element");
   });
 
+  it("renders a display brick the screen put in a PROP, as that tag", async () => {
+    // The other half of the slot round trip, end to end and unstubbed: the VM
+    // emits `<blockquote>` into `content` as `{$element}` data exactly as it
+    // emits a Kit element, the checks floor admits it (a brick carries no
+    // behavior for a slot to gate), and `reifyElement` resolves it through
+    // DISPLAY_BRICKS. Resolving only the Kit painted this as nothing at all.
+    const compiled = compile(`
+import { Accordion, EnumBadge, useQuery } from "@vendo/screen";
+
+export default function Invoice() {
+  const invoice = useQuery("get_invoice");
+  return (
+    <Accordion
+      defaultOpen={[0]}
+      items={[{ label: "Status", content: (
+        <blockquote style={{ paddingLeft: "8px" }}>
+          <EnumBadge value={invoice.data.status} tone="warning" />
+        </blockquote>
+      ) }]}
+    />
+  );
+}`);
+    const host = hostPipe(() => ok(null));
+    render(
+      <PayloadView
+        payload={payloadFor(compiled, { get_invoice: { data: { status: "past_due" } } })}
+        components={{}}
+        onAction={host.onAction}
+      />,
+    );
+
+    const brick = document.querySelector("blockquote");
+    expect(brick?.style.paddingLeft).toBe("8px");
+    expect(brick?.querySelector('[data-kit="EnumBadge"]')?.textContent).toBe("Past due");
+    expect(document.body.innerHTML).not.toContain("$element");
+  });
+
   it("leaves a payload with no interactive half exactly as static as it was", async () => {
     const { interactive: _none, ...served } = payloadFor(compile(TRANSFERS), { list_pending: { data: ROWS } }) as unknown as Record<string, unknown>;
     const host = hostPipe(() => ok(null));

--- a/packages/ui/test/tree/tree-view.test.tsx
+++ b/packages/ui/test/tree/tree-view.test.tsx
@@ -423,6 +423,43 @@ describe("TreeView bindings and outcomes", () => {
     expect(document.body.innerHTML).not.toContain("$element");
   });
 
+  /** A slot resolved only the Kit, while the CHILDREN path resolved the Kit and
+   *  the display bricks (`builtinContent`) — so a brick tag written into a slot
+   *  painted nothing at all. Both paths read the same two registries now. */
+  it("reifies a display brick in a prop, with its style and its Kit children", () => {
+    render(
+      <TreeView
+        tree={tree([{
+          id: "root",
+          component: "Accordion",
+          props: {
+            defaultOpen: [0],
+            items: [{
+              label: "Status",
+              content: {
+                $element: true,
+                component: "blockquote",
+                props: { style: { paddingLeft: "8px" } },
+                children: [
+                  { component: "EnumBadge", props: { value: { $path: "/invoice/status" } }, children: [] },
+                  "flagged",
+                ],
+              },
+            }],
+          },
+        }])}
+        data={{ invoice: { status: "past_due" } }}
+        components={{}}
+        onAction={ok}
+      />,
+    );
+
+    const brick = document.querySelector("blockquote");
+    expect(brick?.style.paddingLeft).toBe("8px");
+    expect(brick?.textContent).toBe("Past dueflagged");
+    expect(screen.getByText("Past due").getAttribute("data-kit")).toBe("EnumBadge");
+  });
+
   it("renders nothing for an unknown component in a slot, and never throws", () => {
     render(
       <TreeView


### PR DESCRIPTION
## What this is

Until now the Kit had exactly one place where a model could write an *element*
instead of a value: a table column's `cell`. The checks floor found it by
matching the literal prop name `"cell"`, so every other element-valued place —
a Tabs panel, an Accordion section — was governed by nothing at all.

This makes the slot a declared thing. `KitComponentSpec` gains
`slots?: Record<string, KitSlotSpec>` — a one-line doc, an optional `content`
vocabulary, and a `perRow` flag — and one table in `specs.ts` states every slot
the Kit has. Three consumers read that one table: the generated prompt, the
`kit-nesting` check, and the renderer.

## The slots

The table states **only what the React Kit actually renders** — every entry is a
`ReactNode` prop the component paints.

| Component | Slot | Where it sits |
| --- | --- | --- |
| DataTable | `cell` (per row) | `columns[].cell` |
| CardList | `cell` (per row) | `fields[].cell` |
| KeyValue | `cell` (per row) | `items[].cell` |
| Timeline | `cell` (per row), `marker` | top-level props |
| Tabs | `content` | `tabs[].content` |
| Accordion | `content` | `items[].content` |

Every other component declares no slots, and an element written in one of its
props is refused by name.

## Why the table is this short — and what is deferred

The first cut of this table declared **37** top-level slots. The React Kit
implements **two** of them (`Timeline.cell`, `Timeline.marker`).

That is not a cosmetic gap. A slot that is declared but not implemented is
*worse* than no slot: `kitPrompt` teaches the model to write it, `kit-nesting`
admits it, and the component drops it in silence, because the prop is not in
scope — `Surface({ title, tone, density, children })` has no `header`. Every
stage goes green and the person gets a blank. Only `components-exist` (which
refuses unknown prop names) stood between those 35 slots and a shipped app with
an invisible header, and the original plan for this PR was to *remove* that
backstop so the prompt and the checker would agree.

So the table now ships at what is real. **The 35 are deferred implementation,
not descoped** — the worklist below is the spec for the follow-up lane.

### Follow-up worklist — slots to implement in `@vendoai/ui`

No prop of that name exists on the component today (28):

| Component | Slots |
| --- | --- |
| Surface | `header`, `footer` |
| Card | `header`, `footer` |
| Form | `header`, `footer`, `actions` |
| DataTable | `rowActions` (per row — Button, Icon, Row), `toolbar`, `empty` |
| CardList | `actions`, `empty` |
| Timeline | `empty` |
| LineChart | `empty`, `tooltip` (per row), `legend` |
| BarChart | `empty`, `tooltip` (per row), `legend` |
| DonutChart | `empty`, `tooltip` (per row) |
| Stat | `icon` |
| Steps | `marker` |
| Tabs | `actions` |
| Input | `prefix`, `suffix` |
| Textarea | `footer` |
| Divider | `label` (Divider takes no props at all today) |

A prop of that name exists but is a **scalar**, so it must be widened to accept
an element as well as the value it takes now (7):

| Component | Slot | Today |
| --- | --- | --- |
| Input, Select, DatePicker, Textarea | `hint` | `hint?: string` |
| Progress | `label` | `label?: string` |
| EmptyState | `icon` | `icon?: string` (lucide name) |
| DonutChart | `legend` | `legend?: boolean` (on/off) |

Each one needs: the `ReactNode` prop on the React component, the entry back in
`SLOTS`, and a probe in `test/kit/slot-drift.test.tsx` — the guard fails the
build until all three exist.

## The law, made mechanical

`packages/ui/test/kit/slot-drift.test.tsx` sweeps the `SLOTS` table, renders
each component with a probe element in every declared slot, and fails unless it
finds that probe in the DOM.

- A slot declared with no implementation fails on the **missing probe**.
- A slot wired to a prop the component ignores fails on the **render**.

Both halves are negative-controlled against the drift that actually shipped
(re-adding `Surface.header` fails the first; giving it a probe fails the
second). The table and the components cannot drift apart at a merge again.

## What the check does

- An element in a declared slot is measured against **that slot's** vocabulary.
  No `content` means the read-only value tier (`KIT_SLOT_CONTENT_NAMES`), which
  every per-row slot keeps — so a `<Button>` in a `cell` is refused with the
  same message it always had, word for word.
- An element under a key **no slot declares** is refused by name: the message
  says which component, which key, and which slots that component does have.
- `Tabs.tabs[].content` and `Accordion.items[].content` are element-valued and
  were checked by nothing. They go through the same gate now, as regions.
- **A display brick passes every slot.** The vocabularies gate *behavior* — what
  may sort, submit or call a tool where there is no row to act on — and a brick
  has none to gate: it is `style` and children and nothing else. Stated once at
  the gate rather than added to each of the three vocabulary lists.

## The renderer

`reifyElement` resolved only `KIT_COMPONENTS`, so a display-brick tag in a slot
resolved to `undefined` and painted nothing, while the *children* path
(`builtinContent`) has always resolved `KIT_COMPONENTS[n] ?? DISPLAY_BRICKS[n]`.
The same tag rendered as a child and vanished as a slot value. Both paths read
the same two registries now.

Only the display-brick half of that asymmetry is closed. `builtinContent` also
falls back to the host catalog and shows an "Unknown component" notice; neither
belongs in a slot — no slot vocabulary admits a host name, and an unknown name
in a slot is already refused by `kit-nesting`, so a notice would be a second
verdict for something the floor blocks. A slot fails soft, as its comment says.

## Proof

Seams, not units — the producer and the consumer are both real:

- The **composed gauntlet** (catalog + nesting + the real TypeScript compiler)
  admits a display brick in a `columns[].cell`.
- The **screen VM → renderer** round trip paints a `<blockquote>` written into
  an Accordion `content` slot, with its style and its `EnumBadge` inside, with
  nothing stubbed on either side.
- Both are negative-controlled: revert the checker condition and the gauntlet
  refuses the brick; revert `reifyElement` and the seam renders nothing.

## Accordion — the one instruction not carried out

The brief said to remove `Accordion` from `KIT_WIRE_UNSAFE_NAMES` "because it
becomes screen-teachable". The premise does not hold: Accordion is *already*
screen-teachable (the screen catalog is the whole Kit), while
`KIT_WIRE_UNSAFE_NAMES` governs only the **wire** prompt — and the wire
genuinely cannot spell an element inside an attribute, which is the entire
reason Accordion is on the list. Removing it would teach the wire a component
whose required prop it cannot write, and turn a pinned test red.

## Gate

`turbo build` (21/21), `packages/apps` contract + checking suites (470 passed),
`packages/ui` kit + tree + ssr suites (423 passed), `turbo typecheck` (42/42),
repo `pnpm lint` (0 errors) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
