### PR TITLE
feat(ui,apps): Modal, Sheet and Toast — and the renderer seam that routes them [track B, B1]

### DIFF
--- a/.changeset/kit-overlay-bricks.md
+++ b/.changeset/kit-overlay-bricks.md
@@ -1,0 +1,18 @@
+---
+"@vendoai/apps": minor
+"@vendoai/ui": minor
+---
+
+Overlay bricks — Modal, Sheet and Toast — plus the Kit's first stylesheet.
+
+The three bricks paint outside the screen's own box, on Base UI's Dialog and
+Toast, so the focus trap, Esc and the page's scroll lock come from the library
+rather than from hand-rolled listeners. `KitOverlaySpec` names the open/close
+pair that makes an overlay an overlay, and `KIT_OVERLAY_SPECS` is how a consumer
+routes one without matching on a component name.
+
+`KIT_CSS` is the Kit's first document-level stylesheet, and it carries nothing
+but pseudo-class state — hover, focus-visible and the press, keyed on `data-kit`.
+Everything themable stays inline, because inline is what survives the jail; the
+sheet is injected into both documents that paint the Kit, the host page's and
+the island's own.

--- a/.changeset/kit-overlay-bricks.md
+++ b/.changeset/kit-overlay-bricks.md
@@ -11,8 +11,12 @@ rather than from hand-rolled listeners. `KitOverlaySpec` names the open/close
 pair that makes an overlay an overlay, and `KIT_OVERLAY_SPECS` is how a consumer
 routes one without matching on a component name.
 
+The renderer reads that map: an overlay node paints on the body-level host, so
+its box in the tree generates nothing, and the Stack it was written in no longer
+carries an empty gap where the overlay used to sit.
+
 `KIT_CSS` is the Kit's first document-level stylesheet, and it carries nothing
 but pseudo-class state — hover, focus-visible and the press, keyed on `data-kit`.
-Everything themable stays inline, because inline is what survives the jail; the
-sheet is injected into both documents that paint the Kit, the host page's and
-the island's own.
+Everything themable stays inline on the brick. The sheet is injected from the
+tree surface itself, so every generated screen has hover and focus states —
+not only the ones that happen to raise an overlay.

--- a/packages/apps/src/contract/kit/index.ts
+++ b/packages/apps/src/contract/kit/index.ts
@@ -7,4 +7,5 @@
 export * from "./display.js";
 export * from "./schema.js";
 export * from "./specs.js";
+export * from "./overlay.js";
 export { kitPrompt, type KitPromptOptions } from "./kit-prompt.js";

--- a/packages/apps/src/contract/kit/kit-prompt.ts
+++ b/packages/apps/src/contract/kit/kit-prompt.ts
@@ -138,7 +138,7 @@ function renderSpec(spec: KitComponentSpec): string {
   return lines.join("\n");
 }
 
-const GROUP_ORDER = ["layout", "values", "data", "charts", "forms", "feedback"];
+const GROUP_ORDER = ["layout", "values", "data", "charts", "forms", "feedback", "overlays"];
 const GROUP_TITLE: Record<string, string> = {
   layout: "Layout",
   values: "Values (semantic — formatted for you)",
@@ -146,6 +146,7 @@ const GROUP_TITLE: Record<string, string> = {
   charts: "Charts",
   forms: "Forms & actions",
   feedback: "Feedback & interactive",
+  overlays: "Overlays",
 };
 
 /** Render the generation prompt section from the schemas. */

--- a/packages/apps/src/contract/kit/overlay.ts
+++ b/packages/apps/src/contract/kit/overlay.ts
@@ -1,0 +1,36 @@
+/**
+ * The overlay bricks — the three Kit components that paint OUTSIDE the screen's
+ * own box (Modal, Sheet, Toast).
+ *
+ * What separates them from every other brick is the pair of props that drives
+ * them: one boolean the screen raises them with, one handler they close through.
+ * A consumer that must treat an overlay differently — the renderer routing the
+ * node to the chrome overlay host instead of painting it in place — reads that
+ * pair from here rather than matching on the component's name.
+ */
+import { KIT_SPECS } from "./specs.js";
+
+export interface KitOverlaySpec {
+  kind: "modal" | "sheet" | "toast";
+  /** The boolean prop that decides whether the overlay is on screen. */
+  openProp: string;
+  /** The handler the overlay calls when it wants to be taken down. */
+  closeProp: string;
+  /** Whether a press outside or an Esc takes it down. A toast has neither — it
+   *  leaves on its own timer, so nothing outside it can be a dismissal. */
+  dismissable: boolean;
+}
+
+const OVERLAYS: Readonly<Record<string, KitOverlaySpec>> = {
+  Modal: { kind: "modal", openProp: "open", closeProp: "onClose", dismissable: true },
+  Sheet: { kind: "sheet", openProp: "open", closeProp: "onClose", dismissable: true },
+  Toast: { kind: "toast", openProp: "open", closeProp: "onClose", dismissable: false },
+};
+
+/** Every overlay brick, keyed by component name. Filtered THROUGH `KIT_SPECS`,
+ *  so a name that is not a real Kit component cannot survive here. */
+export const KIT_OVERLAY_SPECS: Readonly<Record<string, KitOverlaySpec>> = Object.fromEntries(
+  KIT_SPECS
+    .filter((spec) => OVERLAYS[spec.name] !== undefined)
+    .map((spec) => [spec.name, OVERLAYS[spec.name]!]),
+);

--- a/packages/apps/src/contract/kit/specs.ts
+++ b/packages/apps/src/contract/kit/specs.ts
@@ -722,7 +722,10 @@ const BASE_SPECS: KitComponentSpec[] = [
     summary: "A dialog over the screen for a decision that must be answered before anything else. `open` raises it, `onClose` names the tool that takes it down; focus, Esc and the page's scroll lock are handled for you.",
     props: {
       open: config(z.boolean(), "whether the dialog is up", { required: true }),
-      onClose: config(action, "called when it asks to close — Esc, the backdrop, or the X"),
+      // REQUIRED, because every way out of a controlled dialog runs through it:
+      // the X, Esc and the backdrop all do nothing but call this. Without it a
+      // generated screen can raise a modal that nothing can take down.
+      onClose: config(action, "called when it asks to close — Esc, the backdrop, or the X", { required: true }),
       title: copy(z.string(), "the dialog's heading"),
       description: copy(z.string(), "one line under the heading"),
       size: config(z.enum(["small", "medium", "large"]), "width, default medium"),
@@ -736,7 +739,8 @@ const BASE_SPECS: KitComponentSpec[] = [
     summary: "A dialog that slides in from an edge, for detail beside the screen rather than on top of it. Same open/close pair as Modal; `side` picks the edge.",
     props: {
       open: config(z.boolean(), "whether the sheet is out", { required: true }),
-      onClose: config(action, "called when it asks to close — Esc, the backdrop, or the X"),
+      // REQUIRED for the same reason Modal's is — see there.
+      onClose: config(action, "called when it asks to close — Esc, the backdrop, or the X", { required: true }),
       title: copy(z.string(), "the sheet's heading"),
       description: copy(z.string(), "one line under the heading"),
       size: config(z.enum(["small", "medium", "large"]), "how far it comes out, default medium"),

--- a/packages/apps/src/contract/kit/specs.ts
+++ b/packages/apps/src/contract/kit/specs.ts
@@ -65,7 +65,7 @@ const SHARED_PROPS: ReadonlyArray<{ name: string; spec: PropSpec; on: readonly s
   {
     name: "tone",
     spec: config(tone, "emphasis — neutral | accent | success | warning | danger"),
-    on: ["Text", "Money", "DateTime", "Percent", "Num", "EnumBadge", "Badge", "Sparkline", "Progress", "Stat", "Card", "Surface", "Callout"],
+    on: ["Text", "Money", "DateTime", "Percent", "Num", "EnumBadge", "Badge", "Sparkline", "Progress", "Stat", "Card", "Surface", "Callout", "Toast"],
   },
   {
     name: "density",
@@ -713,6 +713,49 @@ const BASE_SPECS: KitComponentSpec[] = [
     },
     examples: ['<Steps items={[{label:"Details"},{label:"Review"},{label:"Done"}]} active={1}/>'],
   },
+
+  // Overlays — the bricks that paint outside the screen's own box.
+  {
+    name: "Modal",
+    takesChildren: true,
+    group: "overlays",
+    summary: "A dialog over the screen for a decision that must be answered before anything else. `open` raises it, `onClose` names the tool that takes it down; focus, Esc and the page's scroll lock are handled for you.",
+    props: {
+      open: config(z.boolean(), "whether the dialog is up", { required: true }),
+      onClose: config(action, "called when it asks to close — Esc, the backdrop, or the X"),
+      title: copy(z.string(), "the dialog's heading"),
+      description: copy(z.string(), "one line under the heading"),
+      size: config(z.enum(["small", "medium", "large"]), "width, default medium"),
+    },
+    examples: ['<Modal open={$state.confirming} onClose="ui.cancel" title="Send reminders?" description="Three clients will be emailed."><Button label="Send" onClick="invoices.sendReminders"/></Modal>'],
+  },
+  {
+    name: "Sheet",
+    takesChildren: true,
+    group: "overlays",
+    summary: "A dialog that slides in from an edge, for detail beside the screen rather than on top of it. Same open/close pair as Modal; `side` picks the edge.",
+    props: {
+      open: config(z.boolean(), "whether the sheet is out", { required: true }),
+      onClose: config(action, "called when it asks to close — Esc, the backdrop, or the X"),
+      title: copy(z.string(), "the sheet's heading"),
+      description: copy(z.string(), "one line under the heading"),
+      size: config(z.enum(["small", "medium", "large"]), "how far it comes out, default medium"),
+      side: config(z.enum(["left", "right", "top", "bottom"]), "the edge it slides from, default right"),
+    },
+    examples: ['<Sheet open={$state.viewing} onClose="ui.closeDetail" title="Invoice INV-204" side="right"><KeyValue pairs={invoices.get({id:$state.viewing}).data}/></Sheet>'],
+  },
+  {
+    name: "Toast",
+    group: "overlays",
+    summary: "A transient notice in the corner, for something that already happened. It takes itself down after `duration`; `onClose` is how the screen learns it went.",
+    props: {
+      open: config(z.boolean(), "whether the notice is up", { required: true }),
+      onClose: config(action, "called when it dismisses itself"),
+      message: copy(z.string(), "the one line to show", { required: true }),
+      duration: config(z.number().int().positive(), "ms on screen before it leaves, default 5000"),
+    },
+    examples: ['<Toast open={$state.sent} onClose="ui.clearSent" message="Reminders sent." tone="success"/>'],
+  },
 ];
 
 /**
@@ -755,6 +798,16 @@ const SLOTS: Readonly<Record<string, Record<string, KitSlotSpec>>> = {
   },
   Tabs: { content: { doc: "ONE tab's panel, written inline instead of as a child", content: region, at: "tabs" } },
   Accordion: { content: { doc: "ONE section's body", content: region, at: "items" } },
+  // No `at` on either pair: a dialog reads its header and footer as props of
+  // its own, the way Timeline reads `marker`.
+  Modal: {
+    header: { doc: "elements along the top edge, beside the title", content: region },
+    footer: { doc: "the buttons under the content", content: region },
+  },
+  Sheet: {
+    header: { doc: "elements along the top edge, beside the title", content: region },
+    footer: { doc: "the buttons under the content", content: region },
+  },
 };
 
 /** Where a slot's element sits, as ONE comparable string: `columns[].cell` for a

--- a/packages/apps/tests/checking/screen-tsc-vocabulary.test.ts
+++ b/packages/apps/tests/checking/screen-tsc-vocabulary.test.ts
@@ -126,6 +126,9 @@ const BROAD_SCREEN = `<App name="Cash flow">
     <Disclaimer reason="No tool exposes forecasts." title="Not shown"/>
     <EmptyState icon="inbox" title="No periods" description="They appear the moment one closes."><Button label="Refresh" onClick="host_getCashflowInsights"/></EmptyState>
     <Steps items={[{ label: "Details" }, { label: "Review", description: "Check the totals" }, { label: "Done" }]} active={1}/>
+    <Modal open={false} onClose="host_search" title="Confirm" description="Send reminders?" size="medium"><Text text="Body"/></Modal>
+    <Sheet open={false} onClose="host_search" title="Detail" side="right" size="medium"><Text text="Body"/></Sheet>
+    <Toast open={false} onClose="host_search" message="Saved." tone="success" duration={4000}/>
     <Text text="Grouped" pending={true}/>
     <Sparkline data={cashflow.data.map((row) => ({ label: row.label, value: row.in }))} valueKey="value"/>
   </Stack>

--- a/packages/apps/tests/contract/kit/overlay.test.ts
+++ b/packages/apps/tests/contract/kit/overlay.test.ts
@@ -40,17 +40,33 @@ describe("the overlay specs", () => {
 
   it("validates the props each overlay was given", () => {
     const modal = kitSpec("Modal")!;
-    expect(validateProps(modal, { open: true, title: "Send reminders?", size: "large" }).success).toBe(true);
+    expect(validateProps(modal, { open: true, onClose: "ui.cancel", title: "Send reminders?", size: "large" }).success).toBe(true);
     expect(validateProps(modal, { title: "no open prop" }).success).toBe(false);
-    expect(validateProps(modal, { open: true, size: "enormous" }).success).toBe(false);
+    expect(validateProps(modal, { open: true, onClose: "ui.cancel", size: "enormous" }).success).toBe(false);
 
     const sheet = kitSpec("Sheet")!;
-    expect(validateProps(sheet, { open: true, side: "left" }).success).toBe(true);
-    expect(validateProps(sheet, { open: true, side: "diagonal" }).success).toBe(false);
+    expect(validateProps(sheet, { open: true, onClose: "ui.close", side: "left" }).success).toBe(true);
+    expect(validateProps(sheet, { open: true, onClose: "ui.close", side: "diagonal" }).success).toBe(false);
 
     const toast = kitSpec("Toast")!;
     expect(validateProps(toast, { open: true, message: "Sent.", tone: "success", duration: 4000 }).success).toBe(true);
     expect(validateProps(toast, { open: true }).success).toBe(false);
+  });
+
+  it("refuses a controlled overlay with no way out", () => {
+    // Every dismissal affordance a dialog has — the X, Esc, the backdrop — does
+    // nothing but call `onClose`. Optional, it let a generated screen raise a
+    // modal that NOTHING could take down, with the person shut behind it.
+    for (const name of ["Modal", "Sheet"]) {
+      const spec = kitSpec(name)!;
+      expect(spec.props.onClose!.required, `${name}.onClose`).toBe(true);
+      expect(validateProps(spec, { open: true, title: "Trapped" }).success, name).toBe(false);
+      expect(validateProps(spec, { open: true, onClose: "ui.cancel", title: "Fine" }).success, name).toBe(true);
+    }
+    // A Toast is NOT in that class: it takes itself down on its own timer, so
+    // `onClose` stays optional — it is how the screen learns, not the way out.
+    expect(kitSpec("Toast")!.props.onClose!.required ?? false).toBe(false);
+    expect(validateProps(kitSpec("Toast")!, { open: true, message: "Sent." }).success).toBe(true);
   });
 
   it("gives Modal and Sheet the header and footer slots, and Toast none", () => {

--- a/packages/apps/tests/contract/kit/overlay.test.ts
+++ b/packages/apps/tests/contract/kit/overlay.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { KIT_OVERLAY_SPECS } from "../../../src/contract/kit/overlay.js";
+import { validateProps } from "../../../src/contract/kit/schema.js";
+import { KIT_SPECS, kitSpec } from "../../../src/contract/kit/specs.js";
+
+/**
+ * The overlay bricks' own contract. What separates them from every other brick
+ * is the open/close pair, so the pair is what this pins: a consumer that routes
+ * an overlay to the chrome host reads it from the map, and a map that named a
+ * prop the spec does not declare would route a node it cannot then open.
+ */
+describe("the overlay specs", () => {
+  it("covers exactly the three overlay bricks", () => {
+    expect(Object.keys(KIT_OVERLAY_SPECS).sort()).toEqual(["Modal", "Sheet", "Toast"]);
+  });
+
+  it("names, on every overlay, props its Kit spec actually declares", () => {
+    for (const [name, overlay] of Object.entries(KIT_OVERLAY_SPECS)) {
+      const spec = kitSpec(name);
+      expect(spec, name).toBeDefined();
+      expect(spec!.props[overlay.openProp], `${name}.${overlay.openProp}`).toBeDefined();
+      expect(spec!.props[overlay.closeProp], `${name}.${overlay.closeProp}`).toBeDefined();
+      // The open prop is the one a screen cannot leave out: without it the
+      // overlay has no truth to follow and would sit there permanently down.
+      expect(spec!.props[overlay.openProp]!.required, `${name}.${overlay.openProp} required`).toBe(true);
+    }
+  });
+
+  it("says a toast is not dismissable — it leaves on its own timer", () => {
+    expect(KIT_OVERLAY_SPECS.Modal!.dismissable).toBe(true);
+    expect(KIT_OVERLAY_SPECS.Sheet!.dismissable).toBe(true);
+    expect(KIT_OVERLAY_SPECS.Toast!.dismissable).toBe(false);
+  });
+
+  it("is derived from the specs — a name that is not a Kit component cannot survive", () => {
+    for (const name of Object.keys(KIT_OVERLAY_SPECS)) {
+      expect(KIT_SPECS.some((spec) => spec.name === name), name).toBe(true);
+    }
+  });
+
+  it("validates the props each overlay was given", () => {
+    const modal = kitSpec("Modal")!;
+    expect(validateProps(modal, { open: true, title: "Send reminders?", size: "large" }).success).toBe(true);
+    expect(validateProps(modal, { title: "no open prop" }).success).toBe(false);
+    expect(validateProps(modal, { open: true, size: "enormous" }).success).toBe(false);
+
+    const sheet = kitSpec("Sheet")!;
+    expect(validateProps(sheet, { open: true, side: "left" }).success).toBe(true);
+    expect(validateProps(sheet, { open: true, side: "diagonal" }).success).toBe(false);
+
+    const toast = kitSpec("Toast")!;
+    expect(validateProps(toast, { open: true, message: "Sent.", tone: "success", duration: 4000 }).success).toBe(true);
+    expect(validateProps(toast, { open: true }).success).toBe(false);
+  });
+
+  it("gives Modal and Sheet the header and footer slots, and Toast none", () => {
+    expect(Object.keys(kitSpec("Modal")!.slots ?? {}).sort()).toEqual(["footer", "header"]);
+    expect(Object.keys(kitSpec("Sheet")!.slots ?? {}).sort()).toEqual(["footer", "header"]);
+    expect(kitSpec("Toast")!.slots).toBeUndefined();
+  });
+});

--- a/packages/apps/tests/contract/kit/specs.test.ts
+++ b/packages/apps/tests/contract/kit/specs.test.ts
@@ -21,7 +21,7 @@ import {
  *  validates and the renderer drops it, which is the silent failure the whole
  *  prop-name gate exists to turn into a blocking error. */
 const READERS: Record<string, readonly string[]> = {
-  tone: ["Text", "Money", "DateTime", "Percent", "Num", "EnumBadge", "Badge", "Sparkline", "Progress", "Stat", "Card", "Surface", "Callout"],
+  tone: ["Text", "Money", "DateTime", "Percent", "Num", "EnumBadge", "Badge", "Sparkline", "Progress", "Stat", "Card", "Surface", "Callout", "Toast"],
   density: ["Stack", "Row", "Grid", "Surface", "Card", "DataTable", "CardList", "Stat"],
   field: ["Text", "Money", "DateTime", "Percent", "Num", "EnumBadge", "Badge", "Sparkline", "Progress"],
 };

--- a/packages/apps/tests/format-conformance.e2e.test.ts
+++ b/packages/apps/tests/format-conformance.e2e.test.ts
@@ -51,9 +51,10 @@ const LIMITS = {
 const VOCABULARY = [
   "Accordion", "Avatar", "Badge", "BarChart", "Button", "Callout", "Card", "CardList", "Checkbox", "CodeBlock",
   "Combobox", "DataTable", "DatePicker", "DateRange", "DateTime", "Disclaimer", "Divider", "DonutChart",
-  "EmptyState", "EnumBadge", "Form", "Grid", "Icon", "Input", "KeyValue", "LineChart", "Link", "Menu", "Money", "Num",
-  "Percent", "Progress", "Radio", "Row", "SegmentedControl", "Select", "Slider", "Sparkline", "Stack", "Stat",
-  "Steps", "Surface", "Switch", "Tabs", "Text", "Textarea", "Timeline", "Tooltip",
+  "EmptyState", "EnumBadge", "Form", "Grid", "Icon", "Input", "KeyValue", "LineChart", "Link", "Menu", "Modal",
+  "Money", "Num", "Percent", "Progress", "Radio", "Row", "SegmentedControl", "Select", "Sheet", "Slider",
+  "Sparkline", "Stack", "Stat", "Steps", "Surface", "Switch", "Tabs", "Text", "Textarea", "Timeline", "Toast",
+  "Tooltip",
 ];
 
 const DOCS_FORMAT_PAGE = readFileSync(

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -56,7 +56,7 @@
     "pretest": "pnpm run check:icons",
     "test": "vitest run",
     "pretypecheck": "pnpm run check:icons",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit",
     "test:browser": "playwright test",
     "test:ui": "playwright test e2e/smoke.spec.ts",
     "test:mcp-shim": "playwright test --config e2e/mcp-shim.config.ts",

--- a/packages/ui/src/kit/index.ts
+++ b/packages/ui/src/kit/index.ts
@@ -75,6 +75,10 @@ export { EmptyState, type EmptyStateProps } from "./feedback/empty-state.js";
 export { Steps, type StepsProps, type StepItem } from "./feedback/steps.js";
 export { Menu, type MenuProps, type MenuItem } from "./feedback/menu.js";
 export { Tooltip, type TooltipProps } from "./feedback/tooltip.js";
+export { Modal, type ModalProps } from "./overlay/modal.js";
+export { Sheet, type SheetProps, type SheetSide } from "./overlay/sheet.js";
+export { Toast, type ToastProps } from "./overlay/toast.js";
+export { KIT_CSS, ensureKitStyles } from "./kit-css.js";
 
 // The theme the Kit's tokens read, and the embedded-surface runtime that applies
 // it — reachable from a generated app's box, where `@vendoai/ui`'s root barrel

--- a/packages/ui/src/kit/kit-css.ts
+++ b/packages/ui/src/kit/kit-css.ts
@@ -1,0 +1,46 @@
+/**
+ * The Kit's ONE stylesheet, and it carries nothing but pseudo-class state.
+ *
+ * Every themable pixel stays in each brick's inline `style`, because inline is
+ * what survives the jail: an island paints inside a sandboxed `srcdoc` iframe
+ * whose only inherited styling is the `--vendo-*` custom properties the host
+ * posts in (`embedded-runtime.ts` `applyThemeVars`). That is also why `:hover`,
+ * `:focus-visible` and `:active` were unreachable until this file — a style
+ * attribute cannot express a pseudo-class, and there was no sheet to put one in.
+ *
+ * So the rule for what belongs here is exact: a STATE the inline style cannot
+ * spell. Anything a theme owns — a color, a radius, a spacing step — stays
+ * inline, and every value below still resolves to a `--vendo-*` token, so a
+ * hover state can no more invent a color than a resting one can.
+ */
+import { t } from "./tokens.js";
+
+/** The controls whose edge answers the pointer. */
+const FIELDS = ['[data-kit="Input"]', '[data-kit="Textarea"]', '[data-kit="Select"]', '[data-kit="DatePicker"]'];
+
+const hover = FIELDS.map((f) => `${f}:hover:not(:disabled)`).join(", ");
+const focus = FIELDS.map((f) => `${f}:focus-visible`).join(", ");
+
+export const KIT_CSS = `
+[data-kit="Button"][data-variant="primary"]:not([disabled]):hover { background: color-mix(in srgb, ${t.accent} 88%, ${t.text}); }
+[data-kit="Button"][data-variant="danger"]:not([disabled]):hover { background: color-mix(in srgb, ${t.danger} 88%, ${t.text}); }
+[data-kit="Button"][data-variant="secondary"]:not([disabled]):hover { background: ${t.surfaceRaised}; border-color: color-mix(in srgb, ${t.accent} 35%, ${t.border}); }
+[data-kit="Button"]:not([disabled]):active { transform: translateY(0.5px); }
+${hover} { border-color: color-mix(in srgb, ${t.accent} 35%, ${t.border}); }
+[data-kit-close]:hover { background: ${t.surfaceRaised}; color: ${t.text}; }
+[data-kit]:focus-visible, [data-kit-close]:focus-visible { outline: 2px solid ${t.accent}; outline-offset: 2px; }
+${focus} { border-color: ${t.accent}; outline-offset: 0; }
+[data-vendo-motion="reduced"] [data-kit="Button"]:active { transform: none; }
+`.trim();
+
+/** Inject the Kit stylesheet once, guarded exactly like `ensureChromeStyles`.
+ *  Called on both surfaces the Kit paints on, and `document` means a different
+ *  document on each: the host page's, and — from the jail runtime, which runs
+ *  inside the frame — the island's own. */
+export function ensureKitStyles(): void {
+  if (typeof document === "undefined" || document.querySelector("style[data-vendo-kit]")) return;
+  const style = document.createElement("style");
+  style.dataset.vendoKit = "";
+  style.textContent = KIT_CSS;
+  document.head.append(style);
+}

--- a/packages/ui/src/kit/kit-css.ts
+++ b/packages/ui/src/kit/kit-css.ts
@@ -1,11 +1,10 @@
 /**
  * The Kit's ONE stylesheet, and it carries nothing but pseudo-class state.
  *
- * Every themable pixel stays in each brick's inline `style`, because inline is
- * what survives the jail: an island paints inside a sandboxed `srcdoc` iframe
- * whose only inherited styling is the `--vendo-*` custom properties the host
- * posts in (`embedded-runtime.ts` `applyThemeVars`). That is also why `:hover`,
- * `:focus-visible` and `:active` were unreachable until this file — a style
+ * Every themable pixel stays in each brick's inline `style` — that is how the
+ * Kit is written (tokens.ts), so a brick carries its whole resting look with it
+ * and needs no sheet to be complete. Which is exactly why `:hover`,
+ * `:focus-visible` and `:active` were unreachable until this file: a style
  * attribute cannot express a pseudo-class, and there was no sheet to put one in.
  *
  * So the rule for what belongs here is exact: a STATE the inline style cannot
@@ -31,7 +30,7 @@ const focus = FIELDS.map((f) => `${f}:focus-visible`).join(", ");
  * the first cut of this file changed nothing at all on hover while the focus
  * ring worked, because `outline` is the one property no brick sets inline.
  * Marking only the STATE declarations is what lets the resting style stay where
- * it has to be — inline, where the jail can see it.
+ * it belongs — inline, on the brick, where the theme owns it.
  */
 export const KIT_CSS = `
 [data-kit="Button"][data-variant="primary"]:not([disabled]):hover { background: color-mix(in srgb, ${t.accent} 88%, ${t.text}) !important; }
@@ -46,9 +45,9 @@ ${focus} { border-color: ${t.accent} !important; outline-offset: 0; }
 `.trim();
 
 /** Inject the Kit stylesheet once, guarded exactly like `ensureChromeStyles`.
- *  Called on both surfaces the Kit paints on, and `document` means a different
- *  document on each: the host page's, and — from the jail runtime, which runs
- *  inside the frame — the island's own. */
+ *  There is ONE document now — a generated screen renders in the host page, in
+ *  the tree surface (renderer.tsx) — so both callers, that surface and the
+ *  body-level overlay host, land in the same `<head>` and the guard settles it. */
 export function ensureKitStyles(): void {
   if (typeof document === "undefined" || document.querySelector("style[data-vendo-kit]")) return;
   const style = document.createElement("style");

--- a/packages/ui/src/kit/kit-css.ts
+++ b/packages/ui/src/kit/kit-css.ts
@@ -21,15 +21,27 @@ const FIELDS = ['[data-kit="Input"]', '[data-kit="Textarea"]', '[data-kit="Selec
 const hover = FIELDS.map((f) => `${f}:hover:not(:disabled)`).join(", ");
 const focus = FIELDS.map((f) => `${f}:focus-visible`).join(", ");
 
+/**
+ * `!important` is not a shortcut here, it is the only thing that works.
+ *
+ * A brick paints its resting look in a `style` attribute, and an inline
+ * declaration outranks every rule in every stylesheet for that same property —
+ * specificity never enters into it. So a hover rule that sets `background` the
+ * normal way loses to the inline `background` 100% of the time; browser-checked,
+ * the first cut of this file changed nothing at all on hover while the focus
+ * ring worked, because `outline` is the one property no brick sets inline.
+ * Marking only the STATE declarations is what lets the resting style stay where
+ * it has to be — inline, where the jail can see it.
+ */
 export const KIT_CSS = `
-[data-kit="Button"][data-variant="primary"]:not([disabled]):hover { background: color-mix(in srgb, ${t.accent} 88%, ${t.text}); }
-[data-kit="Button"][data-variant="danger"]:not([disabled]):hover { background: color-mix(in srgb, ${t.danger} 88%, ${t.text}); }
-[data-kit="Button"][data-variant="secondary"]:not([disabled]):hover { background: ${t.surfaceRaised}; border-color: color-mix(in srgb, ${t.accent} 35%, ${t.border}); }
+[data-kit="Button"][data-variant="primary"]:not([disabled]):hover { background: color-mix(in srgb, ${t.accent} 88%, ${t.text}) !important; }
+[data-kit="Button"][data-variant="danger"]:not([disabled]):hover { background: color-mix(in srgb, ${t.danger} 88%, ${t.text}) !important; }
+[data-kit="Button"][data-variant="secondary"]:not([disabled]):hover { background: ${t.surfaceRaised} !important; border-color: color-mix(in srgb, ${t.accent} 35%, ${t.border}) !important; }
 [data-kit="Button"]:not([disabled]):active { transform: translateY(0.5px); }
-${hover} { border-color: color-mix(in srgb, ${t.accent} 35%, ${t.border}); }
-[data-kit-close]:hover { background: ${t.surfaceRaised}; color: ${t.text}; }
+${hover} { border-color: color-mix(in srgb, ${t.accent} 35%, ${t.border}) !important; }
+[data-kit-close]:hover { background: ${t.surfaceRaised} !important; color: ${t.text} !important; }
 [data-kit]:focus-visible, [data-kit-close]:focus-visible { outline: 2px solid ${t.accent}; outline-offset: 2px; }
-${focus} { border-color: ${t.accent}; outline-offset: 0; }
+${focus} { border-color: ${t.accent} !important; outline-offset: 0; }
 [data-vendo-motion="reduced"] [data-kit="Button"]:active { transform: none; }
 `.trim();
 

--- a/packages/ui/src/kit/overlay/dialog.tsx
+++ b/packages/ui/src/kit/overlay/dialog.tsx
@@ -14,10 +14,23 @@ import { font, hairline, t, transitionFor } from "../tokens.js";
 
 export type OverlaySize = "small" | "medium" | "large";
 
-/** Shared by both geometries — Sheet adds `side` on top. */
+/**
+ * Shared by both geometries — Sheet adds `side` on top.
+ *
+ * `open` and `onClose` are BOTH required, and that is the type doing the same
+ * job the spec does for generated screens: every way out of a dialog — the X,
+ * Esc, the backdrop — does nothing but call `onClose`, so `<Modal open />`
+ * without one is a person shut behind a dialog that cannot be dismissed. It
+ * must not compile.
+ *
+ * Not a discriminated union, because there is no uncontrolled dialog to be the
+ * union's other arm: `Dialog.Root` is always handed `open`, and this takes no
+ * trigger and no `defaultOpen`. A union would model a mode that does not exist
+ * — requiring both is the smaller shape that makes the same call unrepresentable.
+ */
 export interface DialogProps {
-  open?: boolean;
-  onClose?: () => void;
+  open: boolean;
+  onClose: () => void;
   title?: string;
   description?: string;
   size?: OverlaySize;
@@ -53,7 +66,7 @@ export const closeStyle: CSSProperties = {
 export function DialogShell({
   kind,
   popupStyle,
-  open = false,
+  open,
   onClose,
   title,
   description,
@@ -63,37 +76,37 @@ export function DialogShell({
 }: DialogProps & { kind: "Modal" | "Sheet"; popupStyle: CSSProperties }) {
   const body = (
     <>
-      {(title !== undefined || header !== undefined || onClose !== undefined) ? (
-        <div style={{ display: "flex", alignItems: "flex-start", gap: "var(--vendo-density-inline-gap, 7px)" }}>
-          <div style={{ display: "flex", flexDirection: "column", gap: 2, flex: 1, minWidth: 0 }}>
-            {title === undefined ? null : (
-              <Dialog.Title
-                style={{
-                  margin: 0,
-                  color: t.text,
-                  fontFamily: t.headingFamily,
-                  fontSize: "1.05em",
-                  fontWeight: t.weightEmphasis,
-                  lineHeight: t.lineHeightHeading,
-                }}
-              >
-                {title}
-              </Dialog.Title>
-            )}
-            {description === undefined ? null : (
-              <Dialog.Description style={{ margin: 0, color: t.muted, fontSize: "0.9em" }}>
-                {description}
-              </Dialog.Description>
-            )}
-          </div>
-          {header}
-          {/* Rendered INSIDE the popup on purpose: with the focus trap on, a
-              touch screen reader has no other way out. */}
-          <Dialog.Close data-kit-close="" aria-label="Close" style={closeStyle}>
-            ✕
-          </Dialog.Close>
+      {/* Always drawn: `onClose` is required, so there is always a way out to
+          draw, even on a dialog with no title and no header. */}
+      <div style={{ display: "flex", alignItems: "flex-start", gap: "var(--vendo-density-inline-gap, 7px)" }}>
+        <div style={{ display: "flex", flexDirection: "column", gap: 2, flex: 1, minWidth: 0 }}>
+          {title === undefined ? null : (
+            <Dialog.Title
+              style={{
+                margin: 0,
+                color: t.text,
+                fontFamily: t.headingFamily,
+                fontSize: "1.05em",
+                fontWeight: t.weightEmphasis,
+                lineHeight: t.lineHeightHeading,
+              }}
+            >
+              {title}
+            </Dialog.Title>
+          )}
+          {description === undefined ? null : (
+            <Dialog.Description style={{ margin: 0, color: t.muted, fontSize: "0.9em" }}>
+              {description}
+            </Dialog.Description>
+          )}
         </div>
-      ) : null}
+        {header}
+        {/* Rendered INSIDE the popup on purpose: with the focus trap on, a
+            touch screen reader has no other way out. */}
+        <Dialog.Close data-kit-close="" aria-label="Close" style={closeStyle}>
+          ✕
+        </Dialog.Close>
+      </div>
       <div style={{ flex: 1, minHeight: 0, overflowY: "auto" }}>{children}</div>
       {footer === undefined ? null : (
         <div style={{ display: "flex", justifyContent: "flex-end", gap: "var(--vendo-density-inline-gap, 7px)" }}>
@@ -107,7 +120,7 @@ export function DialogShell({
     <Dialog.Root
       open={open}
       onOpenChange={(next) => {
-        if (!next) onClose?.();
+        if (!next) onClose();
       }}
     >
       <OverlayPortal>

--- a/packages/ui/src/kit/overlay/dialog.tsx
+++ b/packages/ui/src/kit/overlay/dialog.tsx
@@ -1,0 +1,148 @@
+/**
+ * The shell Modal and Sheet share. They are one component with two geometries —
+ * a centered card and an edge that slides — so the chrome (title, description,
+ * the close affordance, the header/footer slots) is written once and the only
+ * thing either passes down is where its popup sits.
+ *
+ * Base UI's Dialog supplies the three behaviors that are miserable by hand and
+ * invisible when wrong: the focus trap, Esc, and the page's scroll lock.
+ */
+import { Dialog } from "@base-ui/react/dialog";
+import type { CSSProperties, ReactNode } from "react";
+import { OverlayPortal } from "../../tree/overlay-portal.js";
+import { font, hairline, t, transitionFor } from "../tokens.js";
+
+export type OverlaySize = "small" | "medium" | "large";
+
+/** Shared by both geometries — Sheet adds `side` on top. */
+export interface DialogProps {
+  open?: boolean;
+  onClose?: () => void;
+  title?: string;
+  description?: string;
+  size?: OverlaySize;
+  /** Elements along the top edge, beside the title. */
+  header?: ReactNode;
+  /** The buttons under the content. */
+  footer?: ReactNode;
+  children?: ReactNode;
+}
+
+/** The one measure both geometries read: a Modal's width, a Sheet's depth. */
+export const EXTENT: Record<OverlaySize, number> = { small: 360, medium: 480, large: 720 };
+
+/** The dismiss affordance every overlay carries, dialog and toast alike. */
+export const closeStyle: CSSProperties = {
+  ...font,
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: 28,
+  height: 28,
+  flexShrink: 0,
+  border: `${t.borderWidth} solid transparent`,
+  borderRadius: t.radiusSmall,
+  color: t.muted,
+  background: "transparent",
+  cursor: "pointer",
+  fontSize: "1.1em",
+  lineHeight: 1,
+  transition: transitionFor("background-color", "color"),
+};
+
+export function DialogShell({
+  kind,
+  popupStyle,
+  open = false,
+  onClose,
+  title,
+  description,
+  header,
+  footer,
+  children,
+}: DialogProps & { kind: "Modal" | "Sheet"; popupStyle: CSSProperties }) {
+  const body = (
+    <>
+      {(title !== undefined || header !== undefined || onClose !== undefined) ? (
+        <div style={{ display: "flex", alignItems: "flex-start", gap: "var(--vendo-density-inline-gap, 7px)" }}>
+          <div style={{ display: "flex", flexDirection: "column", gap: 2, flex: 1, minWidth: 0 }}>
+            {title === undefined ? null : (
+              <Dialog.Title
+                style={{
+                  margin: 0,
+                  color: t.text,
+                  fontFamily: t.headingFamily,
+                  fontSize: "1.05em",
+                  fontWeight: t.weightEmphasis,
+                  lineHeight: t.lineHeightHeading,
+                }}
+              >
+                {title}
+              </Dialog.Title>
+            )}
+            {description === undefined ? null : (
+              <Dialog.Description style={{ margin: 0, color: t.muted, fontSize: "0.9em" }}>
+                {description}
+              </Dialog.Description>
+            )}
+          </div>
+          {header}
+          {/* Rendered INSIDE the popup on purpose: with the focus trap on, a
+              touch screen reader has no other way out. */}
+          <Dialog.Close data-kit-close="" aria-label="Close" style={closeStyle}>
+            ✕
+          </Dialog.Close>
+        </div>
+      ) : null}
+      <div style={{ flex: 1, minHeight: 0, overflowY: "auto" }}>{children}</div>
+      {footer === undefined ? null : (
+        <div style={{ display: "flex", justifyContent: "flex-end", gap: "var(--vendo-density-inline-gap, 7px)" }}>
+          {footer}
+        </div>
+      )}
+    </>
+  );
+
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose?.();
+      }}
+    >
+      <OverlayPortal>
+        {(host) => host === null ? null : (
+          <Dialog.Portal container={host}>
+            <Dialog.Backdrop
+              style={{
+                position: "fixed",
+                inset: 0,
+                // Dimmed against `text`, never a literal black: on a dark host
+                // theme a black scrim is invisible and the page never recedes.
+                background: `color-mix(in srgb, ${t.text} 32%, transparent)`,
+              }}
+            />
+            <Dialog.Popup
+              data-kit={kind}
+              style={{
+                ...font,
+                position: "fixed",
+                display: "flex",
+                flexDirection: "column",
+                gap: "var(--vendo-density-content-gap, 10px)",
+                boxSizing: "border-box",
+                border: hairline,
+                background: t.surface,
+                boxShadow: t.shadowSmall,
+                padding: "var(--vendo-density-card-padding, 16px)",
+                ...popupStyle,
+              }}
+            >
+              {body}
+            </Dialog.Popup>
+          </Dialog.Portal>
+        )}
+      </OverlayPortal>
+    </Dialog.Root>
+  );
+}

--- a/packages/ui/src/kit/overlay/modal.tsx
+++ b/packages/ui/src/kit/overlay/modal.tsx
@@ -1,0 +1,23 @@
+/** Modal — a dialog centered over the screen, for a decision that has to be
+ *  answered before anything else. */
+import { DialogShell, EXTENT, type DialogProps } from "./dialog.js";
+import { t } from "../tokens.js";
+
+export type ModalProps = DialogProps;
+
+export function Modal({ size = "medium", ...rest }: ModalProps) {
+  return (
+    <DialogShell
+      kind="Modal"
+      popupStyle={{
+        top: "50%",
+        left: "50%",
+        transform: "translate(-50%, -50%)",
+        width: `min(${EXTENT[size] ?? EXTENT.medium}px, calc(100vw - 32px))`,
+        maxHeight: "calc(100vh - 64px)",
+        borderRadius: t.radiusLarge,
+      }}
+      {...rest}
+    />
+  );
+}

--- a/packages/ui/src/kit/overlay/sheet.tsx
+++ b/packages/ui/src/kit/overlay/sheet.tsx
@@ -1,0 +1,30 @@
+/** Sheet — the same dialog pinned to an edge, for detail that sits beside the
+ *  screen rather than on top of it. */
+import type { CSSProperties } from "react";
+import { DialogShell, EXTENT, type DialogProps, type OverlaySize } from "./dialog.js";
+
+export type SheetSide = "left" | "right" | "top" | "bottom";
+
+export interface SheetProps extends DialogProps {
+  side?: SheetSide;
+}
+
+/** Where the panel sits, and which way `size` measures it: an edge sheet fills
+ *  the two sides it is pinned to and takes its extent from the third. */
+const geometry = (side: SheetSide, extent: number): CSSProperties => {
+  const depth = `min(${extent}px, calc(100% - 32px))`;
+  if (side === "left" || side === "right") {
+    return { top: 0, bottom: 0, [side]: 0, width: depth };
+  }
+  return { left: 0, right: 0, [side]: 0, height: depth };
+};
+
+export function Sheet({ side = "right", size = "medium", ...rest }: SheetProps) {
+  return (
+    <DialogShell
+      kind="Sheet"
+      popupStyle={{ ...geometry(side, EXTENT[size as OverlaySize] ?? EXTENT.medium), borderRadius: 0 }}
+      {...rest}
+    />
+  );
+}

--- a/packages/ui/src/kit/overlay/toast.tsx
+++ b/packages/ui/src/kit/overlay/toast.tsx
@@ -36,10 +36,18 @@ function Notice({ open = false, onClose, message, tone, duration }: ToastProps) 
   closing.current = onClose;
 
   useEffect(() => {
-    if (open && !raised.current) {
+    if (open) {
+      // Unconditionally, NOT only on the way up: `add` with a known id updates
+      // that toast in place and refreshes its timer, which is the whole way a
+      // declarative notice re-states itself. Gating this on "not already
+      // raised" pinned the FIRST message and the FIRST duration for as long as
+      // `open` stayed true — a second, different notice silently showed the
+      // first one's text. The deps are what keep the timer honest: `add` and
+      // `close` are stable (read off the provider's store), so this runs when
+      // the notice actually changes and not once per render.
       raised.current = true;
       add({ id: TOAST_ID, description: message, timeout: duration ?? 5000, onClose: () => closing.current?.() });
-    } else if (!open && raised.current) {
+    } else if (raised.current) {
       raised.current = false;
       close(TOAST_ID);
     }

--- a/packages/ui/src/kit/overlay/toast.tsx
+++ b/packages/ui/src/kit/overlay/toast.tsx
@@ -1,0 +1,102 @@
+/**
+ * Toast — a transient notice in the corner, for something that already
+ * happened. Base UI's toast manager owns the part that is easy to get wrong:
+ * the auto-dismiss timer pauses while the notice is hovered or focused (WCAG
+ * 2.2.1) and resumes with the remainder, and the stack announces politely.
+ *
+ * The brick's contract is declarative — `open` is the truth and the manager is
+ * driven to match it — because a generated screen holds its state in `$state`
+ * and has nowhere to keep an imperative handle.
+ */
+import { Toast as Base } from "@base-ui/react/toast";
+import { useEffect, useRef } from "react";
+import { OverlayPortal } from "../../tree/overlay-portal.js";
+import { font, resolveTone, t, toneStyle } from "../tokens.js";
+import { closeStyle } from "./dialog.js";
+
+export interface ToastProps {
+  open?: boolean;
+  onClose?: () => void;
+  message?: string;
+  tone?: string;
+  duration?: number;
+}
+
+/** One notice per brick, so re-raising the same one refreshes it in place
+ *  rather than stacking a duplicate. */
+const TOAST_ID = "vendo-kit-toast";
+
+function Notice({ open = false, onClose, message, tone, duration }: ToastProps) {
+  const { add, close, toasts } = Base.useToastManager();
+  const raised = useRef(false);
+  // Held in a ref, NOT in the effect's deps: `add` with a known id refreshes the
+  // auto-dismiss timer, so an inline `onClose` in the deps would restart the
+  // countdown on every render and the notice would never leave.
+  const closing = useRef(onClose);
+  closing.current = onClose;
+
+  useEffect(() => {
+    if (open && !raised.current) {
+      raised.current = true;
+      add({ id: TOAST_ID, description: message, timeout: duration ?? 5000, onClose: () => closing.current?.() });
+    } else if (!open && raised.current) {
+      raised.current = false;
+      close(TOAST_ID);
+    }
+  }, [open, message, duration, add, close]);
+
+  const paint = toneStyle[resolveTone(tone)];
+  return (
+    <OverlayPortal>
+      {(host) => host === null ? null : (
+        <Base.Portal container={host}>
+          <Base.Viewport
+            style={{
+              position: "fixed",
+              right: 16,
+              bottom: 16,
+              display: "flex",
+              flexDirection: "column",
+              gap: "var(--vendo-density-inline-gap, 7px)",
+              width: "min(360px, calc(100vw - 32px))",
+            }}
+          >
+            {toasts.map((toast) => (
+              <Base.Root
+                key={toast.id}
+                toast={toast}
+                data-kit="Toast"
+                style={{
+                  ...font,
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "var(--vendo-density-inline-gap, 7px)",
+                  boxSizing: "border-box",
+                  border: `${t.borderWidth} solid ${paint.border}`,
+                  borderRadius: t.radiusMedium,
+                  color: paint.color,
+                  background: paint.background,
+                  boxShadow: t.shadowSmall,
+                  padding: "var(--vendo-density-card-padding, 16px)",
+                }}
+              >
+                <Base.Description style={{ margin: 0, flex: 1, minWidth: 0 }}>{toast.description}</Base.Description>
+                <Base.Close data-kit-close="" aria-label="Close" style={{ ...closeStyle, color: "inherit" }}>
+                  ✕
+                </Base.Close>
+              </Base.Root>
+            ))}
+          </Base.Viewport>
+        </Base.Portal>
+      )}
+    </OverlayPortal>
+  );
+}
+
+export function Toast(props: ToastProps) {
+  return (
+    <Base.Provider>
+      <Notice {...props} />
+    </Base.Provider>
+  );
+}

--- a/packages/ui/src/kit/registry.ts
+++ b/packages/ui/src/kit/registry.ts
@@ -45,6 +45,9 @@ import { EmptyState } from "./feedback/empty-state.js";
 import { Steps } from "./feedback/steps.js";
 import { Menu } from "./feedback/menu.js";
 import { Tooltip } from "./feedback/tooltip.js";
+import { Modal } from "./overlay/modal.js";
+import { Sheet } from "./overlay/sheet.js";
+import { Toast } from "./overlay/toast.js";
 
 export {
   KIT_SPECS,
@@ -61,4 +64,5 @@ export const KIT_COMPONENTS: Readonly<Record<string, ComponentType<Record<string
   Input, Select, DatePicker, Textarea, Checkbox, Button, Link, Form, Disclaimer,
   Switch, Radio, Slider, SegmentedControl, Combobox, DateRange,
   Tabs, Callout, Accordion, EmptyState, Steps, Menu, Tooltip,
+  Modal, Sheet, Toast,
 } as unknown as Record<string, ComponentType<Record<string, never>>>;

--- a/packages/ui/src/tree/overlay-portal.tsx
+++ b/packages/ui/src/tree/overlay-portal.tsx
@@ -1,0 +1,52 @@
+/**
+ * The chrome overlay host — the one body-level surface a Kit overlay paints on.
+ *
+ * A Modal drawn in place is trapped by whatever the screen is sitting in: a
+ * containment box, a transformed ancestor, an `overflow: hidden` column. So it
+ * portals to `document.body` inside its own `.vendo-root`, which is the same
+ * move `VendoToasts` makes and for the same reason — the boundary carries the
+ * theme, so a surface that escaped every themed ancestor is still brand-native.
+ *
+ * `createPortal` and not a second React root: the tree stays UNBROKEN, so the
+ * app context, the keyed `$state` store and a handler bound by the renderer all
+ * reach an overlay exactly as they reach a brick painted in place.
+ */
+import { useEffect, useState, type CSSProperties, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { ensureChromeStyles } from "../chrome/chrome-root.js";
+import { useVendoThemeOrDefault } from "../context.js";
+import { ensureKitStyles } from "../kit/kit-css.js";
+import { themeCssVariables } from "../theme.js";
+
+/**
+ * `children` is a function of the host element, because Base UI refuses to
+ * render a popup outside its own `<Dialog.Portal>` and that portal has to be
+ * pointed AT this boundary — otherwise it hops to `<body>` on its own and the
+ * popup lands outside the theme scope this element exists to draw.
+ */
+export function OverlayPortal({ children }: { children: (host: HTMLElement | null) => ReactNode }): ReactNode {
+  const theme = useVendoThemeOrDefault();
+  const [host, setHost] = useState<HTMLElement | null>(null);
+  useEffect(() => {
+    ensureChromeStyles();
+    ensureKitStyles();
+  }, []);
+  if (typeof document === "undefined") return null;
+  return createPortal(
+    <div
+      ref={setHost}
+      className="vendo-root"
+      data-vendo-ignore=""
+      // Marks it as a Vendo surface that is never behind: `inertBehind` exempts
+      // `[data-vendo-portal]`, so an overlay raised while the agent panel is
+      // open stays clickable instead of being inerted with the host's page.
+      data-vendo-portal="kit-overlay"
+      data-vendo-motion={theme.motion}
+      data-vendo-density={theme.density}
+      style={themeCssVariables(theme) as CSSProperties}
+    >
+      {children(host)}
+    </div>,
+    document.body,
+  );
+}

--- a/packages/ui/src/tree/renderer.tsx
+++ b/packages/ui/src/tree/renderer.tsx
@@ -616,17 +616,35 @@ function generatedContent(context: NodeContent): ReactNode {
   );
 }
 
+/** Which implementation wins for a built-in node. An explicit `source: "host"`
+ *  means the host brand won the name. An undefined (or "prewired") source keeps
+ *  the built-in first, so a stored app whose node collides with a host catalog
+ *  name still renders the built-in it was written against. */
+function resolveBuiltin(node: TreeNode, components: NodeRendererProps["components"]): ComponentType<Record<string, unknown>> | undefined {
+  const kit = (KIT_COMPONENTS[node.component] ?? DISPLAY_BRICKS[node.component]) as ComponentType<Record<string, unknown>> | undefined;
+  const host = components[node.component] as ComponentType<Record<string, unknown>> | undefined;
+  return node.source === "host" ? host ?? kit : kit ?? host;
+}
+
+/**
+ * Whether this node renders one of OUR overlay bricks — decided by the SAME
+ * resolution that picks the implementation, never by the component's name.
+ *
+ * Hosts name their own components, and a host `Modal` is an ordinary in-flow
+ * component: classifying it by name alone handed it a shell that generates no
+ * box, and it lost its layout box. (A GENERATED `Modal` needs no clause here —
+ * `validateWalkTree` refuses a generated name that shadows a Kit one.)
+ */
+function rendersKitOverlay(node: TreeNode, components: NodeRendererProps["components"]): boolean {
+  if (KIT_OVERLAY_SPECS[node.component] === undefined) return false;
+  return resolveBuiltin(node, components) === KIT_COMPONENTS[node.component];
+}
+
 /** V4 — one component family: the Kit is the only built-in set, plus the display
  *  bricks, which resolve exactly like one. A brick's tag is lowercase and a Kit
  *  or catalog name is an identifier, so the two can never collide. */
 function builtinContent({ props, node, children, invoke, handle }: NodeContent): ReactNode {
-  const kit = (KIT_COMPONENTS[node.component] ?? DISPLAY_BRICKS[node.component]) as ComponentType<Record<string, unknown>> | undefined;
-  const host = props.components[node.component] as ComponentType<Record<string, unknown>> | undefined;
-  // An explicit `source: "host"` means the host brand won the name. An
-  // undefined (or "prewired") source keeps the built-in first, so a stored
-  // app whose node collides with a host catalog name still renders the
-  // built-in it was written against.
-  const Implementation = node.source === "host" ? host ?? kit : kit ?? host;
+  const Implementation = resolveBuiltin(node, props.components);
   if (!Implementation) {
     // Mid-stream, an unresolved name is a transient (the defining island or
     // a corrected reference may still arrive) — hold the silhouette; the
@@ -719,7 +737,7 @@ function NodeRenderer(props: NodeRendererProps) {
       nodeId={node.id}
       outcome={outcome}
       mark={props.marks.get(node.id)}
-      overlay={KIT_OVERLAY_SPECS[node.component] !== undefined}
+      overlay={rendersKitOverlay(node, props.components)}
     >
       {content}
       {notice(node.id, outcome)}

--- a/packages/ui/src/tree/renderer.tsx
+++ b/packages/ui/src/tree/renderer.tsx
@@ -15,6 +15,7 @@ import {
 } from "@vendoai/core";
 import {
   KIT_COMPONENT_NAMES,
+  KIT_OVERLAY_SPECS,
   SCREEN_TEXT_NODE,
   evaluateExpr,
   isExprBinding,
@@ -44,6 +45,7 @@ import { InClientMount, type InClientFurnishing } from "./host-mount.js";
 import { ContainedNotice } from "./notice.js";
 import { playNodeMotion, useMotionLayoutEffect, useRepaintMotion, type NodeMark } from "./repaint-motion.js";
 import { KIT_COMPONENTS } from "../kit/registry.js";
+import { ensureKitStyles } from "../kit/kit-css.js";
 import { markHandlerCallback, screenEvent } from "../kit/handler.js";
 import { useKeyedState } from "../kit/state.js";
 import { useParkedApprovals } from "./parked-approvals.js";
@@ -713,7 +715,12 @@ function NodeRenderer(props: NodeRendererProps) {
   const notice = (firedId: string, settled: ToolOutcome | undefined): ReactNode =>
     outcomeNotice(settled, review === undefined ? undefined : (approvalId) => review(firedId, approvalId));
   return (
-    <NodeShell nodeId={node.id} outcome={outcome} mark={props.marks.get(node.id)}>
+    <NodeShell
+      nodeId={node.id}
+      outcome={outcome}
+      mark={props.marks.get(node.id)}
+      overlay={KIT_OVERLAY_SPECS[node.component] !== undefined}
+    >
       {content}
       {notice(node.id, outcome)}
       {props.orphans.get(node.id)?.map(([firedId, orphan]) => (
@@ -728,10 +735,14 @@ function NodeRenderer(props: NodeRendererProps) {
  * the render that carries the change and never on a first paint, so the effect
  * plays exactly one beat per node per repaint (repaint-motion.ts).
  */
-function NodeShell({ nodeId, outcome, mark, children }: {
+function NodeShell({ nodeId, outcome, mark, overlay, children }: {
   nodeId: string;
   outcome: ToolOutcome | undefined;
   mark: NodeMark | undefined;
+  /** An overlay brick paints on the body-level host (overlay-portal.tsx), so its
+   *  shell must generate NO box: an empty div left where the overlay was written
+   *  is still a flex item, and takes a whole gap out of the Stack around it. */
+  overlay: boolean;
   children: ReactNode;
 }) {
   const box = useRef<HTMLDivElement>(null);
@@ -742,6 +753,7 @@ function NodeShell({ nodeId, outcome, mark, children }: {
     <div
       ref={box}
       data-vendo-node-id={nodeId}
+      {...(overlay ? { style: { display: "contents" } } : {})}
       data-vendo-outcome={outcome?.status === "ok" ? undefined : outcome?.status}
       {...(mark?.kind === "exit" ? { "aria-hidden": true, "data-vendo-departing": "" } : {})}
     >
@@ -774,6 +786,10 @@ function StatefulTreeView({
   // surface nested in chrome restates identical values and cannot disagree.
   const theme = useVendoThemeOrDefault();
   useExprRuntime();
+  // The surface is also the only place every Kit brick passes through, so the
+  // Kit's pseudo-class sheet is injected here rather than from the overlay host
+  // alone — a screen with a Button and no Modal has hover and focus states too.
+  useEffect(ensureKitStyles, []);
   // The keyed `$state` store lives in the Kit bundle, shared with code-land's
   // `useVendoState` (kit/state.ts) — one implementation, two venues.
   const [viewState, updateState] = useKeyedState(onStateChange);

--- a/packages/ui/test/kit/overlay-types.test-d.tsx
+++ b/packages/ui/test/kit/overlay-types.test-d.tsx
@@ -1,0 +1,35 @@
+/**
+ * TYPE-LEVEL assertions for the overlay props. `tsc` is the entire test: every
+ * `@ts-expect-error` below must be USED, and TypeScript reports an unused one
+ * as an error of its own — so this file goes red the moment one of these bad
+ * calls starts compiling again.
+ *
+ * Named `.test-d.tsx` on purpose: vitest's `include` matches `*.test.ts?(x)`,
+ * so nothing here ever runs as a runtime test.
+ *
+ * WHY IT EXISTS. The spec (`specs.ts`) requires `onClose` on Modal and Sheet,
+ * which governs GENERATED screens. A host developer importing from
+ * `@vendoai/ui/kit` writes the props by hand and never passes through it, so
+ * `<Modal open />` compiled into a dialog nothing could dismiss. Two doors, one
+ * rule; this is the second door.
+ */
+import { Modal, Sheet, Toast } from "../../src/kit/index.js";
+
+const noop = (): void => {};
+
+// @ts-expect-error `onClose` is required — every way out of a dialog calls it.
+export const trappedModal = <Modal open title="No way out" />;
+
+// @ts-expect-error Sheet is the same dialog with a different geometry.
+export const trappedSheet = <Sheet open title="No way out" />;
+
+// @ts-expect-error `open` is required too — the spec has said so all along.
+export const bareModal = <Modal onClose={noop} title="Never opens" />;
+
+/** Controlled and dismissable is the only shape that compiles. */
+export const goodModal = <Modal open onClose={noop} title="Send reminders?" />;
+export const goodSheet = <Sheet open onClose={noop} side="left" title="Detail" />;
+
+/** A Toast takes itself down on its own timer, so `onClose` stays OPTIONAL —
+ *  it is how the screen learns the notice went, not the way out of it. */
+export const bareToast = <Toast open message="Reminders sent." />;

--- a/packages/ui/test/kit/overlay.test.tsx
+++ b/packages/ui/test/kit/overlay.test.tsx
@@ -78,6 +78,18 @@ describe("the Kit stylesheet", () => {
     for (const declaration of declarations) expect(declaration, declaration).toContain("var(--vendo-");
   });
 
+  it("marks every state declaration that has to beat an inline style", () => {
+    // A brick paints its resting look in a `style` attribute, and an inline
+    // declaration outranks every stylesheet rule for that property no matter
+    // its specificity. Browser-checked: the first cut of this sheet changed
+    // NOTHING on hover, and only the focus ring worked, because `outline` is
+    // the one property no brick sets inline. jsdom resolves no cascade, so
+    // this is the closest a unit test gets to that lesson.
+    for (const declaration of KIT_CSS.match(/(background|border-color|color):[^;}]+/gu) ?? []) {
+      expect(declaration, declaration).toContain("!important");
+    }
+  });
+
   it("stands down the press movement under reduced motion", () => {
     expect(KIT_CSS).toContain('[data-vendo-motion="reduced"] [data-kit="Button"]:active { transform: none; }');
   });

--- a/packages/ui/test/kit/overlay.test.tsx
+++ b/packages/ui/test/kit/overlay.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Modal } from "../../src/kit/overlay/modal.js";
+import { Sheet } from "../../src/kit/overlay/sheet.js";
+import { KIT_CSS, ensureKitStyles } from "../../src/kit/kit-css.js";
+
+describe("the overlay host", () => {
+  it("paints OUTSIDE the containment box it was written in", () => {
+    // The whole point of the portal: written inside a clipped, transformed
+    // column, the dialog still lands on <body> where nothing can crop it.
+    const { container } = render(
+      <div style={{ overflow: "hidden", transform: "translateZ(0)", height: 20 }}>
+        <Modal open title="Send reminders?">
+          <p>three clients</p>
+        </Modal>
+      </div>,
+    );
+    const popup = screen.getByText("three clients");
+    expect(container.contains(popup)).toBe(false);
+    expect(document.body.contains(popup)).toBe(true);
+    expect(popup.closest(".vendo-root")).toBeTruthy();
+    expect(popup.closest("[data-vendo-portal='kit-overlay']")).toBeTruthy();
+  });
+
+  it("carries onClose THROUGH the portal — the React tree is unbroken", () => {
+    const onClose = vi.fn();
+    render(<Modal open onClose={onClose} title="Send reminders?" />);
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders nothing while closed", () => {
+    render(<Modal title="Send reminders?"><p>three clients</p></Modal>);
+    expect(screen.queryByText("three clients")).toBeNull();
+  });
+
+  it("puts a Sheet on the edge it was asked for, and a Modal in the middle", () => {
+    render(<Sheet open side="left" title="Detail" />);
+    const sheet = document.querySelector("[data-kit='Sheet']") as HTMLElement;
+    expect(sheet.style.left).toBe("0px");
+    expect(sheet.style.transform).toBe("");
+    render(<Modal open title="Detail" />);
+    const modal = document.querySelector("[data-kit='Modal']") as HTMLElement;
+    expect(modal.style.transform).toBe("translate(-50%, -50%)");
+  });
+
+  it("renders the title and description as the dialog's own labels", () => {
+    render(<Modal open title="Send reminders?" description="Three clients will be emailed." />);
+    expect(screen.getByText("Send reminders?")).toBeTruthy();
+    expect(screen.getByText("Three clients will be emailed.")).toBeTruthy();
+  });
+
+  it("takes header and footer slots", () => {
+    render(<Modal open title="T" header={<span>badge</span>} footer={<button>Send</button>} />);
+    expect(screen.getByText("badge")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Send" })).toBeTruthy();
+  });
+});
+
+describe("the Kit stylesheet", () => {
+  it("injects once and is idempotent", () => {
+    ensureKitStyles();
+    ensureKitStyles();
+    ensureKitStyles();
+    expect(document.querySelectorAll("style[data-vendo-kit]").length).toBe(1);
+    expect(document.querySelector("style[data-vendo-kit]")?.textContent).toBe(KIT_CSS);
+  });
+
+  it("carries pseudo-class STATE only, and no color it did not read off a token", () => {
+    for (const rule of KIT_CSS.split("\n")) {
+      const selector = rule.slice(0, rule.indexOf("{"));
+      expect(selector, rule).toMatch(/:(hover|focus-visible|active)\b/);
+    }
+    // Every color resolves to a --vendo-* variable; a literal is a brand leak.
+    const declarations = KIT_CSS.match(/(background|color|border-color|outline):[^;]+/gu) ?? [];
+    expect(declarations.length).toBeGreaterThan(0);
+    for (const declaration of declarations) expect(declaration, declaration).toContain("var(--vendo-");
+  });
+
+  it("stands down the press movement under reduced motion", () => {
+    expect(KIT_CSS).toContain('[data-vendo-motion="reduced"] [data-kit="Button"]:active { transform: none; }');
+  });
+});

--- a/packages/ui/test/kit/overlay.test.tsx
+++ b/packages/ui/test/kit/overlay.test.tsx
@@ -6,13 +6,15 @@ import { Sheet } from "../../src/kit/overlay/sheet.js";
 import { Toast } from "../../src/kit/overlay/toast.js";
 import { KIT_CSS, ensureKitStyles } from "../../src/kit/kit-css.js";
 
+const noop = (): void => {};
+
 describe("the overlay host", () => {
   it("paints OUTSIDE the containment box it was written in", () => {
     // The whole point of the portal: written inside a clipped, transformed
     // column, the dialog still lands on <body> where nothing can crop it.
     const { container } = render(
       <div style={{ overflow: "hidden", transform: "translateZ(0)", height: 20 }}>
-        <Modal open title="Send reminders?">
+        <Modal open onClose={noop} title="Send reminders?">
           <p>three clients</p>
         </Modal>
       </div>,
@@ -32,28 +34,28 @@ describe("the overlay host", () => {
   });
 
   it("renders nothing while closed", () => {
-    render(<Modal title="Send reminders?"><p>three clients</p></Modal>);
+    render(<Modal open={false} onClose={noop} title="Send reminders?"><p>three clients</p></Modal>);
     expect(screen.queryByText("three clients")).toBeNull();
   });
 
   it("puts a Sheet on the edge it was asked for, and a Modal in the middle", () => {
-    render(<Sheet open side="left" title="Detail" />);
+    render(<Sheet open onClose={noop} side="left" title="Detail" />);
     const sheet = document.querySelector("[data-kit='Sheet']") as HTMLElement;
     expect(sheet.style.left).toBe("0px");
     expect(sheet.style.transform).toBe("");
-    render(<Modal open title="Detail" />);
+    render(<Modal open onClose={noop} title="Detail" />);
     const modal = document.querySelector("[data-kit='Modal']") as HTMLElement;
     expect(modal.style.transform).toBe("translate(-50%, -50%)");
   });
 
   it("renders the title and description as the dialog's own labels", () => {
-    render(<Modal open title="Send reminders?" description="Three clients will be emailed." />);
+    render(<Modal open onClose={noop} title="Send reminders?" description="Three clients will be emailed." />);
     expect(screen.getByText("Send reminders?")).toBeTruthy();
     expect(screen.getByText("Three clients will be emailed.")).toBeTruthy();
   });
 
   it("takes header and footer slots", () => {
-    render(<Modal open title="T" header={<span>badge</span>} footer={<button>Send</button>} />);
+    render(<Modal open onClose={noop} title="T" header={<span>badge</span>} footer={<button>Send</button>} />);
     expect(screen.getByText("badge")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Send" })).toBeTruthy();
   });

--- a/packages/ui/test/kit/overlay.test.tsx
+++ b/packages/ui/test/kit/overlay.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { Modal } from "../../src/kit/overlay/modal.js";
 import { Sheet } from "../../src/kit/overlay/sheet.js";
+import { Toast } from "../../src/kit/overlay/toast.js";
 import { KIT_CSS, ensureKitStyles } from "../../src/kit/kit-css.js";
 
 describe("the overlay host", () => {
@@ -55,6 +56,21 @@ describe("the overlay host", () => {
     render(<Modal open title="T" header={<span>badge</span>} footer={<button>Send</button>} />);
     expect(screen.getByText("badge")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Send" })).toBeTruthy();
+  });
+});
+
+describe("an open Toast", () => {
+  it("re-states itself when the message changes underneath it", async () => {
+    // `open` is the truth and the notice follows it. Raising a SECOND notice
+    // without lowering the first one in between showed the first one's text:
+    // `add` ran once on the way up and never again, so the description and the
+    // timeout were pinned to whatever the first render happened to carry.
+    const { rerender } = render(<Toast open message="First." duration={60_000} />);
+    expect(await screen.findByText("First.")).toBeTruthy();
+
+    rerender(<Toast open message="Second." duration={60_000} />);
+    expect(await screen.findByText("Second.")).toBeTruthy();
+    expect(screen.queryByText("First.")).toBeNull();
   });
 });
 

--- a/packages/ui/test/kit/slot-drift.test.tsx
+++ b/packages/ui/test/kit/slot-drift.test.tsx
@@ -41,8 +41,8 @@ const CONTEXT: Record<string, { props: Record<string, unknown>; item?: Record<st
   // land no matter how faithfully the slot is wired. `open` is the truth these
   // two follow; raise them and the slots are on the same footing as everyone
   // else's here.
-  Modal: { props: { open: true } },
-  Sheet: { props: { open: true } },
+  Modal: { props: { open: true, onClose: () => {} } },
+  Sheet: { props: { open: true, onClose: () => {} } },
 };
 
 /** The probe at the slot's DECLARED path: a nested slot sits in its prop's

--- a/packages/ui/test/kit/slot-drift.test.tsx
+++ b/packages/ui/test/kit/slot-drift.test.tsx
@@ -37,6 +37,12 @@ const CONTEXT: Record<string, { props: Record<string, unknown>; item?: Record<st
   Timeline: { props: { entries: [{ id: "1" }] } },
   Tabs: { props: {}, item: { label: "One" } },
   Accordion: { props: { defaultOpen: [0] }, item: { label: "One" } },
+  // A dialog paints nothing at all while it is down, so the probe would never
+  // land no matter how faithfully the slot is wired. `open` is the truth these
+  // two follow; raise them and the slots are on the same footing as everyone
+  // else's here.
+  Modal: { props: { open: true } },
+  Sheet: { props: { open: true } },
 };
 
 /** The probe at the slot's DECLARED path: a nested slot sits in its prop's

--- a/packages/ui/test/tree/overlay-host-collision.test.tsx
+++ b/packages/ui/test/tree/overlay-host-collision.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { VENDO_TREE_FORMAT, type ToolOutcome } from "@vendoai/core";
+import { TreeView, type WalkTree } from "../../src/tree/index.js";
+
+afterEach(cleanup);
+
+const ok = async (): Promise<ToolOutcome> => ({ status: "ok", output: null });
+
+const tree = (nodes: WalkTree["nodes"]): WalkTree =>
+  ({ formatVersion: VENDO_TREE_FORMAT, root: nodes[0]!.id, nodes } as WalkTree);
+
+const shellOf = (nodeId: string): HTMLElement =>
+  document.querySelector(`[data-vendo-node-id="${nodeId}"]`) as HTMLElement;
+
+function HostModal({ children }: { children?: ReactNode }) {
+  return <div data-testid="host-modal">{children}</div>;
+}
+
+/**
+ * An overlay brick paints on the body-level host, so its shell generates no box.
+ * That is right for OUR Modal and wrong for everyone else's: hosts name their
+ * own components, and a host `Modal` is an ordinary in-flow component. Deciding
+ * it by name alone cost the host's component its layout box.
+ */
+describe("a host component colliding with an overlay name", () => {
+  it("keeps its layout box when the host owns the name", () => {
+    render(
+      <TreeView
+        tree={tree([
+          { id: "root", component: "Stack", children: ["m"] },
+          { id: "m", component: "Modal", source: "host" },
+        ])}
+        components={{ Modal: HostModal }}
+        onAction={ok}
+      />,
+    );
+    expect(screen.getByTestId("host-modal")).toBeTruthy();
+    expect(shellOf("m").style.display).toBe("");
+  });
+
+  it("still gives OUR Modal the boxless shell", () => {
+    render(
+      <TreeView
+        tree={tree([
+          { id: "root", component: "Stack", children: ["m"] },
+          { id: "m", component: "Modal", props: { open: false } },
+        ])}
+        components={{}}
+        onAction={ok}
+      />,
+    );
+    expect(shellOf("m").style.display).toBe("contents");
+  });
+
+  it("falls back to OUR Modal when the node claims host but the host supplies none", () => {
+    render(
+      <TreeView
+        tree={tree([
+          { id: "root", component: "Stack", children: ["m"] },
+          { id: "m", component: "Modal", source: "host", props: { open: false } },
+        ])}
+        components={{}}
+        onAction={ok}
+      />,
+    );
+    expect(shellOf("m").style.display).toBe("contents");
+  });
+});

--- a/packages/ui/tsconfig.test.json
+++ b/packages/ui/tsconfig.test.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false
+  },
+  "//": "Scoped to the type-level suites. The runtime tests carry ~148 pre-existing type errors and bringing them under tsc is its own lane, not this file's job.",
+  "include": ["src", "test/**/*.test-d.tsx"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11200,14 +11200,6 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.7(vite@6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 3.2.7
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
-
   '@vitest/mocker@3.2.7(vite@6.4.3(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.7
@@ -15957,7 +15949,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.7
-      '@vitest/mocker': 3.2.7(vite@6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@vitest/mocker': 3.2.7(vite@6.4.3(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.7
       '@vitest/runner': 3.2.7
       '@vitest/snapshot': 3.2.7


### PR DESCRIPTION
Track B, slice B1. Now rebased onto post-stack `main` (`6856b4fe4`), and the banked renderer seam is in. **Draft on purpose** — Track B PRs are review windows, not merge units. Do not merge.

## What shipped

**The overlay bricks** — `Modal`, `Sheet`, `Toast`, on Base UI's Dialog and Toast (`@base-ui/react` pinned `1.7.0`). The focus trap, Esc, the page's scroll lock and the toast's hover-paused timer come from the library instead of from listeners we would own and get subtly wrong. Quiet Precision, tokens only.

**`KitOverlaySpec` + `KIT_OVERLAY_SPECS`** (`packages/apps/src/contract/kit/overlay.ts`) — names the pair that makes an overlay an overlay: the boolean a screen raises it with, the handler it closes through. Derived through `KIT_SPECS`, so a name that is not a real Kit component cannot survive.

**The overlay host** (`packages/ui/src/tree/overlay-portal.tsx`) — `document.body`, inside a `.vendo-root` carrying the theme, following the `VendoToasts` precedent. `createPortal` and not a second root, so the React tree stays **unbroken** and context, `$state` and renderer-bound handlers all reach an overlay exactly as they reach a brick painted in place. Base UI refuses to render a popup outside its own `<Dialog.Portal>`, so the boundary hands its element down as that portal's `container`.

**The renderer seam** (`packages/ui/src/tree/renderer.tsx`, +12 lines) — `KIT_OVERLAY_SPECS` existed so a consumer could route an overlay without matching on a component name; `NodeRenderer` is that consumer. The brick already portals itself, so what was left in the tree was the *box it was written in* — an empty div, still a flex item, still taking a whole gap out of the Stack around it. Its shell now generates no box at all (`display: contents`), which keeps the node's id, its repaint mark and its outcome notice while contributing nothing to the flow.

**The Kit stylesheet** (`packages/ui/src/kit/kit-css.ts`) — `KIT_CSS`, injected through the same guarded `<style data-vendo-kit>` pattern as the chrome styles. It carries only pseudo-class state — hover, focus-visible, the press — keyed on `data-kit`. Bricks keep their inline styles for everything themable.

## Which surface the stylesheet reaches — corrected

The earlier version of this section described two documents (host page + jail iframe). **The jail is deleted (#1303), so there is no second document.** Post-stack, a generated screen renders in the **host page**, in the tree surface: `PayloadView` → `TreeView` → `<div data-vendo-surface>` (`renderer.tsx`). `AppFrame`'s iframe is only the `kind: "http"` served-app case, which is a host-served app and not a Kit surface at all.

That correction exposed a real gap, not just stale prose. `ensureKitStyles()` had exactly **one** caller left — the overlay host. So a generated screen with a Button and an Input and no Modal got **no sheet at all**: no hover, no focus ring, on the exact surface the sheet exists for. Browser-measured on this branch: with the sheet removed, primary button hover stays `rgb(17,17,17)` — nothing happens.

The fix is plumbing. The tree surface injects it now (`useEffect(ensureKitStyles, [])` in `StatefulTreeView`) — the one place every Kit brick passes through. The overlay host keeps its own call for a brick used standalone, and the injection guard means both callers landing in the same `<head>` still yields exactly one sheet.

| Surface | Reached | How |
|---|---|---|
| Generated screen (the tree surface, host page) | yes | `ensureKitStyles()` from `StatefulTreeView` |
| The body-level overlay host | yes | same document; `ensureKitStyles()` from `OverlayPortal` |
| A Kit brick imported and mounted standalone | overlays yes, others no | only `OverlayPortal` injects |

## The `!important` finding — still load-bearing

Unchanged by the stack, and it survives in the code and its comment. An inline declaration outranks every stylesheet rule for that property; specificity never enters into it. The first cut of `KIT_CSS` changed **nothing** on hover and only the focus ring worked, because `outline` is the one property no Kit brick sets inline. So only the *state* declarations are marked `!important`, which lets the resting style stay inline on the brick where the theme owns it. The kit-css comments that explained this in terms of "surviving the jail" now say the actual reason: the Kit paints inline by construction, so a pseudo-class has nowhere else to live.

## Verified in a real headed browser

Real headed Chromium against the real `PayloadView` render path — a `vendo-genui/v2` payload, not a static gallery of bricks. Measured, not eyeballed:

- **Stylesheet reaches a no-overlay generated screen** — `style[data-vendo-kit]` count `1` with `[data-vendo-portal='kit-overlay']` count `0`. Button hover `rgb(17,17,17)` → `srgb(0.0709 0.0709 0.0728)`. Input `:focus-visible` matches, border → `rgb(17,17,17)`, outline `2px`. Remove the sheet from the document — the pre-fix world for this screen — and hover goes back to `rgb(17,17,17)`: no change at all.
- **The overlay leaves no residue** — the overlay node's shell computes `display: contents`, `0×0`. Its Stack has **4 child shells but 3 flex items**, and its height is `154px`, identical to the same screen written without the overlay node. Pre-seam that Stack would have carried a fourth flex item and its gap.
- **The overlay escapes** — the Modal lands on `<body>`, outside `[data-vendo-surface]`, inside `.vendo-root[data-vendo-portal='kit-overlay']`. Its close affordance hovers correctly through the same sheet (`transparent` → `srgb(0.899 0.899 0.904)`), so the sheet reaches the portaled host too.

## Gate

`turbo build` 21/21 · ui kit+tree+ssr suites 423 passed (46 files) · apps contract+checking 475 passed, 6 skipped · `turbo build typecheck` 49/49 · `pnpm lint` clean (4 pre-existing demo-bank warnings).

## Three forced test-file edits — flagging for review

Adding Kit vocabulary is a lockstep edit by design: three hand-kept lists pin it from outside the specs. Each **refuses** a name it has not been told about, so this branch could not be green without extending them. **Kept as its own commit (`595fc1de9`) so it can be reviewed or dropped apart from the feature.** No assertion is weakened — these are registry mirrors extended by exactly the three names added here.

- `format-conformance.e2e.test.ts` `VOCABULARY` — the pinned alphabetical list
- `specs.test.ts` `READERS` — Toast reads the shared `tone` adjective
- `screen-tsc-vocabulary.test.ts` `BROAD_SCREEN` — the fixture must NAME every wire component; the three are written in and type-checked for real

## A new import direction, flagged

`kit/overlay/*.tsx` imports `tree/overlay-portal.tsx`. That is a kit→tree direction that did not exist before, and nothing currently enforces against it. Worth a deliberate call now rather than letting it set a precedent by default.

## Collision warning for whoever stacks these

`packages/apps/src/contract/kit/specs.ts` is being added to by four slices in parallel (b1, b2, b3, a4). Each merges cleanly against `main` alone; they will collide when the branches stack. B1's edits are deliberately minimal and contiguous — one `tone` line and one block appended to `BASE_SPECS` — so the merge should be mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
