### PR TITLE
feat(core,store): the meter — storage behind per-user usage limits

### DIFF
--- a/packages/core/src/conformance/memory-store-ops.ts
+++ b/packages/core/src/conformance/memory-store-ops.ts
@@ -13,6 +13,8 @@ import {
   type RecordInput,
   type RecordQuery,
   type StoreOps,
+  type UsageEvent,
+  type UsageTallyRow,
   type VendoRecord,
 } from "../store.js";
 
@@ -902,6 +904,46 @@ export function memoryStoreOps(): StoreOps {
   };
 
   // ---------------------------------------------------------------------------
+  // usage — a LIST of events and not a per-window counter, for the reason the
+  // real table is one: a policy authors its own window, down to the minute, and
+  // a pre-bucketed count can only answer the periods whoever bucketed it picked.
+  // ---------------------------------------------------------------------------
+
+  const metered: UsageEvent[] = [];
+  const inWindow = (event: UsageEvent, window: { since: Date; until?: Date }): boolean =>
+    event.at >= window.since && (window.until === undefined || event.at < window.until);
+
+  const usage: NonNullable<StoreOps["usage"]> = {
+    async record(event) {
+      metered.push({ ...event, poolKeys: [...event.poolKeys ?? []] });
+    },
+    async count(query) {
+      return metered.filter((event) =>
+        event.action === query.action
+        && inWindow(event, query)
+        && (query.subject === undefined
+          ? (event.poolKeys ?? []).includes(query.poolKey)
+          : event.subject === query.subject)).length;
+    },
+    async tally(query) {
+      const groups = new Map<string, UsageTallyRow>();
+      for (const event of metered) {
+        if (!inWindow(event, query)) continue;
+        if (query.action !== undefined && event.action !== query.action) continue;
+        if (query.subject !== undefined && event.subject !== query.subject) continue;
+        const key = `${event.subject} ${event.action}`;
+        const row = groups.get(key) ?? { subject: event.subject, action: event.action, count: 0 };
+        row.count += 1;
+        groups.set(key, row);
+      }
+      // Sorted, because "the order the events happened to arrive in" is not an
+      // answer any two implementations would agree on.
+      return [...groups.values()].sort((a, b) =>
+        a.subject === b.subject ? a.action.localeCompare(b.action) : a.subject.localeCompare(b.subject));
+    },
+  };
+
+  // ---------------------------------------------------------------------------
   // status
   // ---------------------------------------------------------------------------
 
@@ -913,6 +955,7 @@ export function memoryStoreOps(): StoreOps {
     harness,
     workspace,
     audit,
+    usage,
     secrets,
     retention,
     lifecycle,

--- a/packages/core/src/conformance/store-ops.ts
+++ b/packages/core/src/conformance/store-ops.ts
@@ -3,7 +3,7 @@ import { ENGINE_ALLOWLIST_VERSION, engineAppHistory } from "../engine-collection
 import type { VendoErrorCode } from "../errors.js";
 import { isoDateTimeSchema, type IsoDateTime } from "../ids.js";
 import { STORE_WIRE_APPEND_MESSAGES_OPS, STORE_WIRE_PATHS, VENDO_STORE_WIRE_FORMAT } from "../store-wire.js";
-import type { AuditQuery, CollectionFootprint, StoreOps } from "../store.js";
+import type { AuditQuery, CollectionFootprint, StoreOps, UsageCountQuery } from "../store.js";
 import { assert, assertBytesEqual, assertDeepEqual } from "./assertions.js";
 import { omitted, type ConformanceCase, type ConformanceOmission, type ConformanceSuite } from "./index.js";
 
@@ -141,6 +141,9 @@ const APPEND_ABSENT =
 
 /** {@link APPEND_ABSENT}'s twin for the other optional family. */
 const RETENTION_ABSENT = "this mount omits the retention family (optional — an engine with nowhere to quarantine to leaves it off)";
+
+/** ...and for the meter, optional on the same rule. */
+const USAGE_ABSENT = "this mount omits the usage family (optional — a store with nowhere to meter leaves it off, and a limits policy is refused at composition rather than enforced against a meter that reads zero)";
 
 /** appData rows live in the app's own drawer, and the local backend fails an
     app-scoped write closed when the app has no row — so every appData case
@@ -2201,6 +2204,108 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         assert(destroyed.purged === ids.length, `the purge should report the ${ids.length} rows it destroyed, reported ${destroyed.purged}`);
         const again = await retention.purge(collection, past);
         assert(again.purged === 0, `a second purge reported ${again.purged} rows a first one had already destroyed`);
+      }),
+
+      // =====================================================================
+      // usage — OPTIONAL (01 §12) on `retention`'s rule, and reported the same
+      // way: a store with nowhere to meter says so by omitting the family, and
+      // a case that returned early instead would make "this mount has no meter"
+      // and "this mount's meter is correct" one green line.
+      // =====================================================================
+
+      /** The meter's whole job: what went in comes back as a number, for the
+          window the caller drew and no other. The EDGES are the load-bearing
+          half — `since` inclusive and `until` exclusive is what lets two
+          adjacent periods tile a timeline without counting the instant they
+          share twice or dropping it. */
+      opsCase(opts, "usage.count answers one subject's window, taking since inclusively and until exclusively", async (ops) => {
+        const usage = ops.usage;
+        if (usage === undefined) return omitted(USAGE_ABSENT);
+        const at = (minute: number): Date => new Date(Date.UTC(2026, 0, 1, 12, minute));
+        const counts = async (query: UsageCountQuery, expected: number, why: string): Promise<void> => {
+          const actual = await usage.count(query);
+          assert(actual === expected, `${why}: expected ${expected}, counted ${actual}`);
+        };
+        for (const minute of [0, 1, 2]) await usage.record({ subject: "conf_meter", action: "message", at: at(minute) });
+        await usage.record({ subject: "conf_meter", action: "generation", at: at(1) });
+        await usage.record({ subject: "conf_meter_neighbour", action: "message", at: at(1) });
+
+        const mine = { subject: "conf_meter", action: "message" } as const;
+        await counts({ ...mine, since: at(0) }, 3, "a window over every recorded action should count them all");
+        await counts({ ...mine, since: at(1) }, 2, "`since` is inclusive, so an action AT the floor is inside the window");
+        await counts({ ...mine, since: at(0), until: at(2) }, 2, "`until` is exclusive, so an action AT the ceiling is outside the window");
+        await counts({ ...mine, since: at(1), until: at(1) }, 0, "an empty window counts nothing");
+        await counts({ ...mine, since: at(3) }, 0, "a window past every action counts nothing");
+        // Both narrowings hold: neither another action nor another person's
+        // usage may land in a number a policy is about to decide on.
+        await counts({ subject: "conf_meter", action: "generation", since: at(0) }, 1, "the count is one action's, not the subject's whole meter");
+        await counts({ subject: "conf_meter_absent", action: "message", since: at(0) }, 0, "a subject who has done nothing counts zero");
+      }),
+
+      /** A pool count is the shared bucket's, and it is answered off the keys
+          the ROW carries — copied off the user when the action happened. That
+          is what keeps a departed member's usage counted against the team it
+          was spent in, and what stops a new member's history from arriving with
+          them. */
+      opsCase(opts, "usage.count answers a pool by the keys its rows were written with, never the member's own", async (ops) => {
+        const usage = ops.usage;
+        if (usage === undefined) return omitted(USAGE_ABSENT);
+        const since = new Date(Date.UTC(2026, 0, 1));
+        const at = new Date(Date.UTC(2026, 0, 2));
+        await usage.record({ subject: "conf_pool_a", action: "message", at, poolKeys: ["conf_team", "conf_org"] });
+        await usage.record({ subject: "conf_pool_b", action: "message", at, poolKeys: ["conf_org"] });
+        await usage.record({ subject: "conf_pool_c", action: "message", at });
+        const counted = async (poolKey: string): Promise<number> => await usage.count({ poolKey, action: "message", since });
+
+        assert(await counted("conf_org") === 2, `the org pool holds two members' actions, counted ${await counted("conf_org")}`);
+        assert(await counted("conf_team") === 1, `a row draws down EVERY key it carries, and only those it carries: counted ${await counted("conf_team")}`);
+        assert(await counted("conf_pool_a") === 0, "a subject is not a pool — a pool count matched a subject id");
+        assert(
+          await usage.count({ subject: "conf_pool_a", action: "message", since }) === 1,
+          "a subject's own count must not swell to the pool's",
+        );
+      }),
+
+      /** The operator's read: every subject's number over one window, in one
+          call rather than a count per user. Subjects with nothing in the window
+          are OMITTED, because a group-by answers with the groups that exist,
+          and the rows are sorted so two implementations answer alike. */
+      opsCase(opts, "usage.tally groups a window by subject and action, sorted, omitting what the window does not hold", async (ops) => {
+        const usage = ops.usage;
+        if (usage === undefined) return omitted(USAGE_ABSENT);
+        const at = (day: number): Date => new Date(Date.UTC(2026, 0, day));
+        await usage.record({ subject: "conf_tally_b", action: "message", at: at(2) });
+        await usage.record({ subject: "conf_tally_a", action: "message", at: at(2) });
+        await usage.record({ subject: "conf_tally_a", action: "message", at: at(3) });
+        await usage.record({ subject: "conf_tally_a", action: "generation", at: at(3) });
+
+        assertDeepEqual(
+          await usage.tally({ since: at(1) }),
+          [
+            { subject: "conf_tally_a", action: "generation", count: 1 },
+            { subject: "conf_tally_a", action: "message", count: 2 },
+            { subject: "conf_tally_b", action: "message", count: 1 },
+          ],
+          "the tally is one row per (subject, action) actually in the window, sorted by subject then action",
+        );
+        assertDeepEqual(
+          await usage.tally({ since: at(3) }),
+          [
+            { subject: "conf_tally_a", action: "generation", count: 1 },
+            { subject: "conf_tally_a", action: "message", count: 1 },
+          ],
+          "a narrower window still counted actions outside it, or kept a subject it no longer holds",
+        );
+        assertDeepEqual(
+          await usage.tally({ since: at(1), action: "generation" }),
+          [{ subject: "conf_tally_a", action: "generation", count: 1 }],
+          "narrowing to one action did not narrow the tally",
+        );
+        assertDeepEqual(
+          await usage.tally({ since: at(1), subject: "conf_tally_b" }),
+          [{ subject: "conf_tally_b", action: "message", count: 1 }],
+          "narrowing to one subject did not narrow the tally",
+        );
       }),
 
       // =====================================================================

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,7 @@ export * from "./ids.js";
 export * from "./jcs.js";
 export * from "./knowledge.js";
 export * from "./knowledge-wire.js";
+export * from "./limits.js";
 export * from "./log.js";
 export * from "./meter-exhausted.js";
 export * from "./model-seats.js";

--- a/packages/core/src/limits.ts
+++ b/packages/core/src/limits.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+import { principalSchema, type Principal } from "./principal.js";
+import type { Json } from "./ids.js";
+
+/** What the meter counts. `message` is one user turn; `generation` is one app
+    the agent built. Both are things a person does, never tokens or calls — a
+    host writes its policy in the units it sells in. */
+export type LimitAction = "message" | "generation";
+
+export const limitActionSchema = z.enum(["message", "generation"]) satisfies z.ZodType<LimitAction>;
+
+/** The stretch of usage one `count` covers. The three durations are ANDed into
+    a single lookback and `since` names an instant floor instead; omit all four
+    and the count is all-time.
+
+    `pool` counts the whole shared bucket rather than the one user — a seat pool,
+    a team, an org — and is only answerable for a pool the user is actually in
+    ({@link LimitUser.pools}). */
+export interface LimitWindow {
+  days?: number;
+  hours?: number;
+  minutes?: number;
+  since?: Date;
+  pool?: string;
+}
+
+export const limitWindowSchema = z.object({
+  days: z.number().optional(),
+  hours: z.number().optional(),
+  minutes: z.number().optional(),
+  since: z.date().optional(),
+  pool: z.string().optional(),
+}).passthrough() satisfies z.ZodType<LimitWindow>;
+
+/** What a policy answers with. `true`/`false` is the whole grammar; the object
+    form exists only to carry the sentence the user reads when denied, so there
+    is deliberately no `{ allow: true }` — allowing has nothing to say. */
+export type LimitDecision = boolean | { allow: false; message?: string };
+
+export const limitDecisionSchema = z.union([
+  z.boolean(),
+  z.object({ allow: z.literal(false), message: z.string().optional() }).passthrough(),
+]) satisfies z.ZodType<LimitDecision>;
+
+/** Who the policy is deciding about — the {@link Principal} the request
+    resolved to, plus the host-asserted profile the same resolve produced.
+
+    `facts` is the host's own bag (plan, role, tenure, …) and is what a tiered
+    policy branches on; `pools` are the shared buckets this user draws from,
+    and naming one in a {@link LimitWindow} is how a policy counts a team's
+    usage rather than a person's. */
+export interface LimitUser extends Principal {
+  email?: string;
+  facts?: Record<string, Json>;
+  pools?: string[];
+}
+
+export const limitUserSchema = principalSchema.extend({
+  email: z.string().optional(),
+  facts: z.record(z.unknown()).optional(),
+  pools: z.array(z.string()).optional(),
+}) satisfies z.ZodType<LimitUser>;
+
+/** The host's policy, asked once before each metered action. Vendo counts;
+    this decides.
+
+    `count` is a meter reader already bound to THIS user, so a policy never
+    names a subject and can never read another person's usage by accident. It
+    is a callback and not a number because most policies read the meter once,
+    for one window, and pre-computing every window a policy might ask about
+    would be a query per action per call. */
+export type LimitsCallback = (input: {
+  user: LimitUser;
+  action: LimitAction;
+  count: (action: LimitAction, window?: LimitWindow) => Promise<number>;
+}) => Promise<LimitDecision> | LimitDecision;

--- a/packages/core/src/store-wire.ts
+++ b/packages/core/src/store-wire.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { VendoError, safeErrorMessage, vendoErrorCodeSchema, type VendoErrorCode } from "./errors.js";
 import { isoDateTimeSchema, type Json } from "./ids.js";
+import { limitActionSchema } from "./limits.js";
 import {
   APP_DATA_COLLECTION_PATTERN,
   APP_DATA_OWNER_PATTERN,
@@ -95,6 +96,13 @@ export const STORE_WIRE_PATHS = {
   // is fine, because a missing op is read off its own 501 and never off the
   // level.
   "audit.tally": "/audit/tally",
+  // usage (3) — the meter behind per-user limits, appended for the same reason
+  // `audit.tally` was: the level may only ever grow, so a new family goes on
+  // the end and a mount that stops short of it keeps reporting the number it
+  // always did.
+  "usage.record": "/usage/record",
+  "usage.count": "/usage/count",
+  "usage.tally": "/usage/tally",
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -491,6 +499,45 @@ export const storeWireAuditListRequestSchema = cursorQuerySchema.extend(auditFil
 export const storeWireAuditTallyRequestSchema = z.object({
   ...auditFilterFields,
   from: isoDateTimeSchema,
+}).passthrough();
+
+// ---------------------------------------------------------------------------
+// usage
+// ---------------------------------------------------------------------------
+
+/** One metered action, as it happened. `at` is a real datetime the caller
+    authored, and `poolKeys` are the shared buckets this action ALSO drew down,
+    sent WITH the write rather than looked up at read time: a member who leaves
+    a team must not retroactively drain its quota. */
+export const storeWireUsageRecordRequestSchema = z.object({
+  subject: z.string().min(1),
+  action: limitActionSchema,
+  at: isoDateTimeSchema,
+  poolKeys: z.array(z.string().min(1)).optional(),
+}).passthrough();
+
+/** Exactly ONE of subject/poolKey (`lifecycle.erase`'s rule): a count is either
+    a person's or a pool's, and a body carrying both — or neither — asks for two
+    numbers under one name. `since` is required and inclusive for
+    `audit.tally`'s reason: it is the only bound on a drawer that only grows. */
+export const storeWireUsageCountRequestSchema = z.object({
+  action: limitActionSchema,
+  since: isoDateTimeSchema,
+  until: isoDateTimeSchema.optional(),
+  subject: z.string().min(1).optional(),
+  poolKey: z.string().min(1).optional(),
+}).passthrough().refine(
+  (query) => (query.subject === undefined) !== (query.poolKey === undefined),
+  { message: "usage count must set exactly one of subject or poolKey" },
+);
+
+/** The same window counted per subject instead of for one. Both narrowings are
+    optional here precisely because the answer names both. */
+export const storeWireUsageTallyRequestSchema = z.object({
+  since: isoDateTimeSchema,
+  until: isoDateTimeSchema.optional(),
+  action: limitActionSchema.optional(),
+  subject: z.string().min(1).optional(),
 }).passthrough();
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { AuditEvent } from "./audit.js";
 import type { CollectionKind } from "./engine-collections.js";
 import { isoDateTimeSchema, type IsoDateTime, type Json } from "./ids.js";
+import type { LimitAction } from "./limits.js";
 
 const requiredJsonValueSchema = z.unknown().refine(
   (value) => value !== undefined,
@@ -343,6 +344,59 @@ export interface AuditTallyRow {
 }
 
 // ---------------------------------------------------------------------------
+// usage.record / usage.count / usage.tally — the meter per-user limits read
+// ---------------------------------------------------------------------------
+
+/** One metered action, as it happened. `at` is the instant, not an
+    {@link IsoDateTime}: nothing about this row is ever rendered or compared as
+    text — it is written, bucketed by time, and counted.
+
+    `poolKeys` are the shared buckets this one action ALSO draws down, copied
+    off the user's pools at write time rather than looked up at read time: a
+    user who leaves a team must not retroactively drain its quota, and the row
+    is the only place that membership was ever true. */
+export interface UsageEvent {
+  subject: string;
+  action: LimitAction;
+  at: Date;
+  poolKeys?: string[];
+}
+
+/** What to count, over what stretch. Exactly ONE of `subject` or `poolKey`
+    ({@link EraseTarget}'s rule): a count is either a person's or a pool's, and
+    a query carrying both is two different numbers with one name.
+
+    `since` is INCLUSIVE and REQUIRED for {@link AuditTallyQuery}'s reason — it
+    is the only bound that keeps a call off a drawer that only ever grows.
+    `until` is optional and exclusive, for a policy counting a closed period
+    (last calendar month) rather than a lookback. */
+export type UsageCountQuery = {
+  action: LimitAction;
+  since: Date;
+  until?: Date;
+} & ({ subject: string; poolKey?: never } | { poolKey: string; subject?: never });
+
+/** The same window, counted per subject instead of for one — the read behind an
+    operator's "who is using this" table, in one call rather than a count per
+    user. Narrowing to a `subject` or an `action` is optional here precisely
+    because the answer names both. */
+export interface UsageTallyQuery {
+  since: Date;
+  until?: Date;
+  action?: LimitAction;
+  subject?: string;
+}
+
+/** One counted group. Subjects with nothing in the window are OMITTED (a
+    group-by answers with the groups that exist), and rows are sorted by
+    `subject` then `action`, ascending. */
+export interface UsageTallyRow {
+  subject: string;
+  action: LimitAction;
+  count: number;
+}
+
+// ---------------------------------------------------------------------------
 // footprint — what the store is holding
 // ---------------------------------------------------------------------------
 
@@ -491,6 +545,23 @@ export interface StoreOps {
     /** Matching events counted per UTC hour, split by outcome and decidedBy —
         the grouped read a decision tally is, in one call. */
     tally(query: AuditTallyQuery): Promise<AuditTallyRow[]>;
+  };
+  /** The usage meter behind per-user limits (a host's `LimitsCallback`) — a
+      write and the two reads it exists to serve.
+
+      Three verbs and not two for `audit`'s reason plus one: a policy's question
+      is a single number for one user, an operator's is every user's number over
+      a window, and neither is the other's answer sliced. The write is here and
+      not on `engine` because a meter row is only ever counted, never listed.
+
+      OPTIONAL (`retention`'s rule): a store with nowhere to meter says so by
+      omitting the family. A configured `LimitsCallback` then has no
+      counts to decide on, so it is refused at composition — never enforced
+      against a meter that reads zero. */
+  usage?: {
+    record(event: UsageEvent): Promise<void>;
+    count(query: UsageCountQuery): Promise<number>;
+    tally(query: UsageTallyQuery): Promise<UsageTallyRow[]>;
   };
   /** The store's secret vault — the values a host's connectors authenticate
       with, kept where the rest of its data is kept.

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -428,13 +428,14 @@ export type EraseTarget =
   | { subject: string; appId?: never }
   | { appId: string; subject?: never };
 
-/** The typed contract for all 45 store operations across 12 families.
+/** The typed contract for all 48 store operations across 13 families.
     Lean by design — this is the CONTRACT interface, not the implementation.
 
-    Two members are OPTIONAL, and both mean the same thing: an implementation
-    that cannot serve the family says so by OMITTING it, never by accepting the
-    call and doing something else (`transcripts.appendMessages` and `retention`,
-    following `RecordStore.claim`/`atomic`). Everything else is required. */
+    Three members are OPTIONAL, and all three mean the same thing: an
+    implementation that cannot serve the family says so by OMITTING it, never by
+    accepting the call and doing something else (`transcripts.appendMessages`,
+    `retention` and `usage`, following `RecordStore.claim`/`atomic`). Everything
+    else is required. */
 export interface StoreOps {
   /** Vendo's OWN engine data — grants, approvals, audit, threads, runs, apps,
       effects, and the automations and guard drawers — reached through seven

--- a/packages/core/tests/limits.test.ts
+++ b/packages/core/tests/limits.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  limitActionSchema,
+  limitDecisionSchema,
+  limitWindowSchema,
+  type LimitUser,
+  type LimitsCallback,
+} from "../src/limits.js";
+import type { StoreOps, UsageEvent } from "../src/store.js";
+
+const user: LimitUser = {
+  kind: "user",
+  subject: "user_ada",
+  display: "Ada",
+  email: "ada@example.com",
+  facts: { plan: "free" },
+  pools: ["org_acme"],
+};
+
+/** The two things a per-user limit is counted in. */
+describe("limitActionSchema", () => {
+  it("accepts the two metered actions and rejects anything else", () => {
+    expect(limitActionSchema.parse("message")).toBe("message");
+    expect(limitActionSchema.parse("generation")).toBe("generation");
+    expect(limitActionSchema.safeParse("tool-call").success).toBe(false);
+  });
+});
+
+/** The stretch of usage a meter read covers. */
+describe("limitWindowSchema", () => {
+  it("accepts an empty window, each duration field, an instant floor, and a pool", () => {
+    expect(limitWindowSchema.safeParse({}).success).toBe(true);
+    expect(limitWindowSchema.parse({ days: 30, hours: 1, minutes: 5 })).toMatchObject({ days: 30 });
+    expect(limitWindowSchema.parse({ since: new Date("2026-08-01T00:00:00.000Z"), pool: "org_acme" }))
+      .toMatchObject({ pool: "org_acme" });
+  });
+
+  it("rejects a non-numeric duration and an ISO string where an instant belongs", () => {
+    expect(limitWindowSchema.safeParse({ days: "30" }).success).toBe(false);
+    expect(limitWindowSchema.safeParse({ since: "2026-08-01T00:00:00.000Z" }).success).toBe(false);
+  });
+});
+
+/** What a host's policy answers with. */
+describe("limitDecisionSchema", () => {
+  it("accepts both booleans and a denial with and without a message", () => {
+    expect(limitDecisionSchema.parse(true)).toBe(true);
+    expect(limitDecisionSchema.parse(false)).toBe(false);
+    expect(limitDecisionSchema.parse({ allow: false })).toMatchObject({ allow: false });
+    expect(limitDecisionSchema.parse({ allow: false, message: "Daily limit reached" }))
+      .toMatchObject({ message: "Daily limit reached" });
+  });
+
+  it("rejects an allowing object — allowing is spelled `true`, never `{ allow: true }`", () => {
+    expect(limitDecisionSchema.safeParse({ allow: true }).success).toBe(false);
+    expect(limitDecisionSchema.safeParse({ message: "nope" }).success).toBe(false);
+  });
+});
+
+/** The host-supplied policy: the resolved user, the action, and a meter reader
+    already bound to that user. */
+describe("LimitsCallback", () => {
+  it("reads the meter for the current user and denies with a message", async () => {
+    const policy: LimitsCallback = async ({ user: who, action, count }) =>
+      who.facts?.plan === "free" && (await count(action, { days: 1 })) >= 20
+        ? { allow: false, message: "Daily limit reached" }
+        : true;
+
+    const count = async (): Promise<number> => 20;
+    expect(await policy({ user, action: "message", count })).toMatchObject({ allow: false });
+    expect(await policy({ user: { ...user, facts: { plan: "pro" } }, action: "message", count })).toBe(true);
+  });
+});
+
+/** The meter behind the policy: the three ops a limit is counted with. */
+describe("StoreOps.usage", () => {
+  it("records an event, counts by subject or by pool, and tallies a window", async () => {
+    const events: UsageEvent[] = [];
+    const usage: NonNullable<StoreOps["usage"]> = {
+      record: async (event) => void events.push(event),
+      count: async (query) => events.filter((e) => e.subject === query.subject && e.action === query.action).length,
+      tally: async () => events.map((e) => ({ subject: e.subject, action: e.action, count: 1 })),
+    };
+
+    await usage.record({ subject: "user_ada", action: "message", at: new Date(), poolKeys: ["org_acme"] });
+    expect(await usage.count({ subject: "user_ada", action: "message", since: new Date(0) })).toBe(1);
+    expect(await usage.count({ poolKey: "org_acme", action: "message", since: new Date(0) })).toBe(0);
+    expect(await usage.tally({ since: new Date(0) })).toMatchObject([{ subject: "user_ada", count: 1 }]);
+  });
+});

--- a/packages/core/tests/store-wire.test.ts
+++ b/packages/core/tests/store-wire.test.ts
@@ -44,17 +44,18 @@ import {
   storeWireLifecycleEraseRequestSchema,
   storeWireLifecyclePromoteRequestSchema,
   storeWireAuditTallyRequestSchema,
+  storeWireUsageCountRequestSchema,
   type EraseTarget,
   type StoreWireStatus,
 } from "../src/index.js";
 
 describe("vendo/store-wire@1", () => {
-  it("exposes the format constant and 45 mount-relative paths", () => {
+  it("exposes the format constant and 48 mount-relative paths", () => {
     expect(VENDO_STORE_WIRE_FORMAT).toBe("vendo/store-wire@1");
-    // 12 families: engine(7) + blobs(4) + appData(8) + transcripts(7) + harness(3)
+    // 13 families: engine(7) + blobs(4) + appData(8) + transcripts(7) + harness(3)
     // + workspace(4) + lifecycle(2) + audit(2) + secrets(4) + footprint(1)
-    // + retention(2) + status(1) = 45
-    expect(Object.keys(STORE_WIRE_PATHS)).toHaveLength(45);
+    // + retention(2) + status(1) + usage(3) = 48
+    expect(Object.keys(STORE_WIRE_PATHS)).toHaveLength(48);
     expect(STORE_WIRE_PATHS.status).toBe("/status");
     expect(STORE_WIRE_PATHS["engine.get"]).toBe("/engine/get");
     expect(STORE_WIRE_PATHS["engine.compareAndSwap"]).toBe("/engine/compareAndSwap");
@@ -69,12 +70,19 @@ describe("vendo/store-wire@1", () => {
 
   // `ops` on /status is a LEVEL over this order, so an implementation that
   // stops short of the newest ops can only report an honest number when those
-  // ops are the tail. retention is the family nothing serves yet, and the audit
-  // tally is the newest op no mount answers — both sit behind everything a
-  // shipped mount already serves.
+  // ops are the tail. The usage family is the newest one no mount answers yet,
+  // and it sits behind everything a shipped mount already serves — as retention
+  // and the audit tally did before it.
   it("declares the ops nothing serves yet LAST, so the /status level can stay honest", () => {
     const ops = Object.keys(STORE_WIRE_PATHS).filter((op) => op !== "status");
-    expect(ops.slice(-3)).toEqual(["retention.quarantine", "retention.purge", "audit.tally"]);
+    expect(ops.slice(-6)).toEqual([
+      "retention.quarantine",
+      "retention.purge",
+      "audit.tally",
+      "usage.record",
+      "usage.count",
+      "usage.tally",
+    ]);
   });
 
   // The rule the tail exists for, stated as the thing that would break: a new op
@@ -104,6 +112,25 @@ describe("vendo/store-wire@1", () => {
     // The same four enums as the feed, refused the same way — one copy of them
     // on the wire, so the two doors cannot come to narrow differently.
     expect(tally({ from: "2026-08-14T00:00:00.000Z", outcome: "allowed" })).toBe(false);
+  });
+
+  // The meter's count is either a person's or a pool's, and a body carrying
+  // both is two different numbers under one name — the same rule `lifecycle.erase`
+  // is refused by, and for the same reason: there is no sensible precedence a
+  // caller could have guessed.
+  it("usage.count's body names exactly one of subject or poolKey, over a required floor", () => {
+    const count = (body: unknown): boolean => storeWireUsageCountRequestSchema.safeParse(body).success;
+    const window = { action: "message", since: "2026-08-14T00:00:00.000Z" };
+    expect(count({ ...window, subject: "user_1" })).toBe(true);
+    expect(count({ ...window, poolKey: "team_1", until: "2026-08-15T00:00:00.000Z" })).toBe(true);
+    expect(count({ ...window, subject: "user_1", poolKey: "team_1" })).toBe(false);
+    expect(count(window)).toBe(false);
+    // `since` is the only bound on a drawer that only ever grows, so a body
+    // without one is refused rather than answered from the beginning of time.
+    expect(count({ action: "message", subject: "user_1" })).toBe(false);
+    // The action is the unit a host sells in, and an unknown one is a caller
+    // bug this build cannot silently widen to.
+    expect(count({ ...window, action: "tokens", subject: "user_1" })).toBe(false);
   });
 
   describe("engine.list's watermark bound", () => {

--- a/packages/store/src/backends.test-util.ts
+++ b/packages/store/src/backends.test-util.ts
@@ -19,6 +19,7 @@ export interface Backend {
 
 const TABLES = [
   "invoices",
+  "vendo_usage",
   "vendo_quarantine",
   "vendo_idempotency_ledger",
   "vendo_app_grants",

--- a/packages/store/src/erase.ts
+++ b/packages/store/src/erase.ts
@@ -51,6 +51,7 @@ export const ERASE_TABLES = [
   "vendo_app_grants",
   "vendo_idempotency_ledger",
   "vendo_quarantine",
+  "vendo_usage",
 ] as const;
 
 export type EraseTable = typeof ERASE_TABLES[number];
@@ -219,6 +220,10 @@ export function eraseStore(store: VendoStore, options: { files: FilesAdapter }):
       // the sweep copied their subject into a column of its own precisely so
       // this selector reaches them (01 §12, retention.ts).
       await del(report, "vendo_quarantine", "subject = $1", [subject]);
+      // The meter counts a PERSON, so its rows are that person's data. They go
+      // with them, and the limit they were counted against resets — which is
+      // the honest outcome: there is no one left to hold to it.
+      await del(report, "vendo_usage", "subject = $1", [subject]);
       // An appData file twin carries no refs: its owner is the leading key leg
       // (`<owner>/<key>`) inside the app's own namespace. For the subject's own
       // apps the cascade above already took them with the namespace, but a

--- a/packages/store/src/hosted-store.ts
+++ b/packages/store/src/hosted-store.ts
@@ -16,6 +16,7 @@ import {
   storeWireErrorSchema,
   type StoreWireStatus,
   storeWireStatusSchema,
+  type UsageTallyRow,
   VendoError,
   type VendoRecord,
   vendoRecordSchema,
@@ -79,7 +80,7 @@ export interface HostedStore extends VendoStore {
     bySubject(subject: string): Promise<EraseReport>;
     byApp(appId: string): Promise<EraseReport>;
   };
-  /** The 45-op named-operation surface over the same mount and the same key —
+  /** The 48-op named-operation surface over the same mount and the same key —
    * `vendo/store-wire@1` (see {@link hostedStoreOps}). The StoreAdapter doors
    * above are built ON these ops: engine for Vendo's own collections, appData
    * for an app's own drawers. */
@@ -165,7 +166,7 @@ export function hostedStore(options: HostedStoreOptions): HostedStore {
   };
   const sendJson = postJson(send);
 
-  // The StoreAdapter façade rides the SAME 45 ops as `ops` below — it has no
+  // The StoreAdapter façade rides the SAME 48 ops as `ops` below — it has no
   // doors of its own since the generic records family left the wire. A
   // collection (or blob namespace) either names an app's own drawer, which the
   // appData family serves with the owner stamped on, or it names one of Vendo's
@@ -282,15 +283,15 @@ export function hostedStore(options: HostedStoreOptions): HostedStore {
 }
 
 // ---------------------------------------------------------------------------
-// The 45-op StoreOps client — store design v1, `vendo/store-wire@1`
+// The 48-op StoreOps client — store design v1, `vendo/store-wire@1`
 // ---------------------------------------------------------------------------
 
-/** The 45 named ops — STORE_WIRE_PATHS' keys ARE the op names, and stay the
+/** The 48 named ops — STORE_WIRE_PATHS' keys ARE the op names, and stay the
  * op names even where the console's door sits at a different path. */
 type StoreWireOp = keyof typeof STORE_WIRE_PATHS;
 
 /** Measurement instrument, not a feature: with VENDO_STORE_TRACE set, every
- * call through the store client below — the 45 ops AND the StoreAdapter façade,
+ * call through the store client below — the 48 ops AND the StoreAdapter façade,
  * which rides the same client — emits one greppable stderr line naming the op,
  * its path, the round trip in milliseconds (the body read included, since that
  * is what the caller waits for), the response size in bytes and the outcome.
@@ -317,6 +318,13 @@ const traceOutcome = (error: unknown): string => {
  * replay is the only reason the server can tell "do it again" from "you
  * already did it"; a fresh key per attempt would double-apply the write. */
 const newIdempotencyKey = (): string => `idm_${globalThis.crypto.randomUUID()}`;
+
+/** Both meter reads bound their window the same way, and a Date is not a wire
+ * type: the instants cross as the ISO datetimes the request schemas validate. */
+const bounds = (query: { since: Date; until?: Date }): { since: string; until?: string } => ({
+  since: query.since.toISOString(),
+  ...(query.until === undefined ? {} : { until: query.until.toISOString() }),
+});
 
 /** Blob bytes are base64 on the wire (storeWireBlobsPutRequestSchema) —
  * Buffer-free so the client stays runnable on edge runtimes. */
@@ -356,7 +364,7 @@ const raiseWireError = async (response: Response): Promise<never> => {
 };
 
 /**
- * The Cloud client for the whole 45-op store contract, speaking
+ * The Cloud client for the whole 48-op store contract, speaking
  * `vendo/store-wire@1` over the console's store mount: bearer key, deployment
  * identity and per-request abort budget shared with {@link hostedStore}, the
  * same adapter rule (behavior comes ONLY from the constructor arguments),
@@ -798,6 +806,29 @@ function storeWireClient(
       async tally(query) {
         const payload = await post("audit.tally", P["audit.tally"], { ...query });
         return field<AuditTallyRow[]>(payload, "rows", "invalid audit tally", Array.isArray);
+      },
+    },
+    // The meter behind per-user limits. Served here even though the family is
+    // OPTIONAL on StoreOps, for `retention`'s reason: this is the protocol's
+    // client, not a mount's mirror. The write is KEYED — a retried record that
+    // counted twice is a limit the user hits early — and both reads send their
+    // instants as the ISO datetimes the wire schemas validate.
+    usage: {
+      async record(event) {
+        await mutate("usage.record", P["usage.record"], {
+          subject: event.subject,
+          action: event.action,
+          at: event.at.toISOString(),
+          ...(event.poolKeys === undefined ? {} : { poolKeys: event.poolKeys }),
+        });
+      },
+      async count(query) {
+        const payload = await post("usage.count", P["usage.count"], { ...query, ...bounds(query) });
+        return field<number>(payload, "count", "invalid usage count", (value) => typeof value === "number");
+      },
+      async tally(query) {
+        const payload = await post("usage.tally", P["usage.tally"], { ...query, ...bounds(query) });
+        return field<UsageTallyRow[]>(payload, "rows", "invalid usage tally", Array.isArray);
       },
     },
     // `get` is the one read in this protocol that answers with a CREDENTIAL. The

--- a/packages/store/src/ops.ts
+++ b/packages/store/src/ops.ts
@@ -12,6 +12,9 @@ import {
   type Json,
   type RecordStore,
   type StoreOps,
+  type UsageCountQuery,
+  type UsageTallyQuery,
+  type UsageTallyRow,
   type VendoRecord,
 } from "@vendoai/core";
 import { appDataFiles, appDataRows } from "./app-data-rows.js";
@@ -206,12 +209,67 @@ async function auditTally(db: Db, query: AuditTallyQuery): Promise<AuditTallyRow
   }));
 }
 
+/** The meter's window, shared by both reads (`auditWhere`'s rule): `since` is
+ *  the inclusive floor `audit.tally` already reads its own by, and `until` is
+ *  the exclusive ceiling a closed period needs. Two doors onto one drawer that
+ *  spell an edge differently disagree about a limit, and the person on the
+ *  wrong side of it cannot tell why. */
+function usageWindow(query: { since: Date; until?: Date }): { params: unknown[]; clauses: string[] } {
+  const params: unknown[] = [query.since.toISOString()];
+  const clauses = ["at >= $1::timestamptz"];
+  if (query.until !== undefined) {
+    params.push(query.until.toISOString());
+    clauses.push(`at < $${params.length}::timestamptz`);
+  }
+  return { params, clauses };
+}
+
+/** `usage.count`'s statement (01 §12 `UsageCountQuery`): the window, the action,
+ *  and EITHER the one person or the one pool — never both, because a count
+ *  carrying both is two different numbers with one name. The pool leg is a
+ *  containment test against the keys the row was written with, which is what
+ *  makes a departed member's usage stay counted against the team it was spent
+ *  in. */
+async function usageCount(db: Db, query: UsageCountQuery): Promise<number> {
+  const { params, clauses } = usageWindow(query);
+  params.push(query.action);
+  clauses.push(`action = $${params.length}`);
+  params.push(query.subject ?? query.poolKey);
+  clauses.push(query.subject === undefined ? `$${params.length} = ANY(pool_keys)` : `subject = $${params.length}`);
+  const result = await db.query(`SELECT count(*) AS count FROM vendo_usage WHERE ${clauses.join(" AND ")}`, params);
+  return Number(result.rows[0]?.["count"]);
+}
+
+/** `usage.tally`'s statement (01 §12 `UsageTallyQuery`) — `auditTally`'s shape
+ *  over the meter: the same window grouped instead of counted once, so an
+ *  operator's "who is using this" table is one call and not a count per user.
+ *  Subjects with nothing in the window are never rows, because a GROUP BY
+ *  answers with the groups that exist. */
+async function usageTally(db: Db, query: UsageTallyQuery): Promise<UsageTallyRow[]> {
+  const { params, clauses } = usageWindow(query);
+  for (const [column, value] of [["action", query.action], ["subject", query.subject]] as const) {
+    if (value === undefined) continue;
+    params.push(value);
+    clauses.push(`${column} = $${params.length}`);
+  }
+  const result = await db.query(
+    `SELECT subject, action, count(*) AS count FROM vendo_usage
+      WHERE ${clauses.join(" AND ")} GROUP BY 1, 2 ORDER BY 1, 2`,
+    params,
+  );
+  return result.rows.map((row) => ({
+    subject: text(row["subject"]),
+    action: row["action"] as UsageTallyRow["action"],
+    count: Number(row["count"]),
+  }));
+}
+
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
 /**
  * 02-store — the LOCAL backend of the StoreOps named-operation contract
- * (core/store.ts): the 44 ops served straight off this store's own Postgres,
+ * (core/store.ts): the 48 ops served straight off this store's own Postgres,
  * through the EXISTING helpers — routing doors, thread rows, workspace rows, the
  * erase cascade. Logic unchanged; what this layer adds is the atomic scope:
  * every multi-statement verb runs inside ONE
@@ -796,6 +854,29 @@ export function createStoreOps(
     },
 
     // -----------------------------------------------------------------------
+    // usage — the meter a host's LimitsCallback decides on. A write and the two
+    // reads it exists to serve, over `vendo_usage` (schema.ts v10). The write is
+    // here and not on `engine` because the drawer has no door: a meter row is
+    // only ever counted, so nothing lists it and nothing may name the table as a
+    // collection. Ids are minted here — the contract's event is what HAPPENED,
+    // and nothing outside this row ever refers to it.
+    // -----------------------------------------------------------------------
+    usage: {
+      async record(event) {
+        await db.query(
+          "INSERT INTO vendo_usage (id, subject, action, at, pool_keys) VALUES ($1, $2, $3, $4::timestamptz, $5)",
+          [`usg_${globalThis.crypto.randomUUID()}`, event.subject, event.action, event.at.toISOString(), event.poolKeys ?? null],
+        );
+      },
+      async count(query) {
+        return await usageCount(db, query);
+      },
+      async tally(query) {
+        return await usageTally(db, query);
+      },
+    },
+
+    // -----------------------------------------------------------------------
     // secrets — the vault door (secrets.ts) as-is. The one seam this layer
     // owns: the provider answers `undefined` for a name it does not hold, and
     // the op's contract is `null`.
@@ -895,14 +976,12 @@ export function createStoreOps(
     },
 
     async status() {
-      // All 45 of STORE_WIRE_PATHS: `ops` is a LEVEL over that list's declared
-      // order, and the two that used to stop it short — retention.quarantine
-      // and retention.purge — are served above, so the prefix now runs to the
-      // end of the list and audit.tally, declared past `status`, is inside it
-      // for the first time. A number this engine cannot back with an op is the
-      // one thing the level must never report, so it moves WITH the object and
-      // never ahead of it.
-      return { format: VENDO_STORE_WIRE_FORMAT, ops: 45 };
+      // All 48 of STORE_WIRE_PATHS: `ops` is a LEVEL over that list's declared
+      // order, and this engine serves the whole of it — retention, the audit
+      // tally, and now the usage family that rides the tail behind them. A
+      // number this engine cannot back with an op is the one thing the level
+      // must never report, so it moves WITH the object and never ahead of it.
+      return { format: VENDO_STORE_WIRE_FORMAT, ops: 48 };
     },
   };
 }

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -59,8 +59,16 @@ import type { Db } from "./db-postgres.js";
     than a column on every collection because the rows come from thirty-odd
     tables with nothing in common but their id, and a `quarantined_at` column
     apiece would mean every read in the store growing a `WHERE quarantined_at IS
-    NULL` it can never be trusted to remember. Same load-bearing bump. */
-export const SCHEMA_VERSION = 9;
+    NULL` it can never be trusted to remember. Same load-bearing bump.
+
+    v10 adds `vendo_usage` (01 §12 `StoreOps.usage`): the meter a host's
+    `LimitsCallback` decides on. One row per metered action, keeping its own
+    instant — never a pre-bucketed count, because a policy authors its own
+    window ("20 messages an hour", "3 generations today") and a bucket can only
+    answer the periods whoever chose it happened to pick. It is engine-owned
+    like `vendo_quarantine`: no collection maps to it and no door lists it, so a
+    meter row is only ever counted. Same load-bearing bump. */
+export const SCHEMA_VERSION = 10;
 
 /** 02-store §2 */
 export const DDL = [
@@ -247,6 +255,19 @@ export const DDL = [
   // The erase cascade's two selectors (§5).
   "CREATE INDEX IF NOT EXISTS vendo_quarantine_subject_idx ON vendo_quarantine (subject)",
   "CREATE INDEX IF NOT EXISTS vendo_quarantine_app_idx ON vendo_quarantine (app_id)",
+  // v10 (01 §12 `StoreOps.usage`): the meter. One row per metered action, and
+  // `pool_keys` is the shared buckets that action ALSO drew down, copied off
+  // the user at write time — a member who leaves a team must not retroactively
+  // drain its quota, and the row is the only place that membership was true.
+  `CREATE TABLE IF NOT EXISTS vendo_usage (
+    id text PRIMARY KEY, subject text NOT NULL, action text NOT NULL,
+    at timestamptz NOT NULL, pool_keys text[]
+  )`,
+  // The count's two shapes, one index each: a person's window is an equality on
+  // (subject, action) with a range on `at`, and a pool's is a containment test
+  // the btree cannot serve at all.
+  "CREATE INDEX IF NOT EXISTS vendo_usage_subject_action_at_idx ON vendo_usage (subject, action, at)",
+  "CREATE INDEX IF NOT EXISTS vendo_usage_pool_keys_idx ON vendo_usage USING GIN (pool_keys)",
 ] as const;
 
 // Additive columns stay compatible with same-version development databases (02 §2

--- a/packages/store/tests/erase.conformance.test.ts
+++ b/packages/store/tests/erase.conformance.test.ts
@@ -142,6 +142,10 @@ for (const backend of backends()) {
         // reaches what a sweep DID lift is proven on real quarantined rows in
         // retention.ops.test.ts, where the sweep exists to make them.
         vendo_quarantine: 0,
+        // This subject never spent a metered action either; that the cascade
+        // takes the ones they did spend is proven on real meter rows in
+        // usage.ops.test.ts.
+        vendo_usage: 0,
         vendo_workspace_files: 0, // this subject wrote no workspace files
         vendo_workspace_history: 0,
         workspace_content_objects: 0, // ...so no workspace content was deleted either

--- a/packages/store/tests/hosted-store.test.ts
+++ b/packages/store/tests/hosted-store.test.ts
@@ -36,6 +36,9 @@ import {
   storeWireSecretsGetRequestSchema,
   storeWireSecretsListRequestSchema,
   storeWireSecretsSetRequestSchema,
+  storeWireUsageCountRequestSchema,
+  storeWireUsageRecordRequestSchema,
+  storeWireUsageTallyRequestSchema,
   type StoreAdapter,
 } from "@vendoai/core";
 import { storeAdapterConformance } from "@vendoai/core/conformance";
@@ -702,6 +705,11 @@ const DOORS: Record<string, { method: string; path: string; keyed?: true }> = {
   // Last, because the manifest declares it last — appending is the only edit to
   // that order which cannot re-date a level a mount already reports.
   "audit.tally": { method: "POST", path: P["audit.tally"] },
+  // ...and the meter behind it, appended on the same rule. The write carries a
+  // key: a retried record that counted twice is a limit the user hits early.
+  "usage.record": { method: "POST", path: P["usage.record"], keyed: true },
+  "usage.count": { method: "POST", path: P["usage.count"] },
+  "usage.tally": { method: "POST", path: P["usage.tally"] },
 };
 
 const door = (op: string): string => `${DOORS[op]!.method} ${DOORS[op]!.path}`;
@@ -783,6 +791,9 @@ const ALL_BODIES: Record<string, unknown> = {
   [door("audit.tally")]: {
     rows: [{ bucket: "2026-08-14T09:00:00.000Z", outcome: "ok", decidedBy: "grant", count: 4 }],
   },
+  [door("usage.record")]: { ok: true },
+  [door("usage.count")]: { count: 7 },
+  [door("usage.tally")]: { rows: [{ subject: "sub_1", action: "message", count: 7 }] },
 };
 
 /** Where an appData op lands: the app, the collection it invented, and the
@@ -841,28 +852,34 @@ const driveEveryOp = async (ops: ReturnType<typeof wireFake>["ops"]): Promise<vo
   await ops.retention!.purge("vendo_runs", "2026-01-01T00:00:00.000Z");
   await ops.status();
   await ops.audit.tally({ from: "2026-01-01T00:00:00.000Z" });
+  // The meter, implemented here for retention's reason: this is the protocol's
+  // client, and a mount without these paths answers the enveloped 501.
+  const metered = { subject: "sub_1", action: "message", since: new Date(0), at: new Date(0) } as const;
+  await ops.usage!.record({ subject: metered.subject, action: metered.action, at: metered.at });
+  await ops.usage!.count({ subject: metered.subject, action: metered.action, since: metered.since });
+  await ops.usage!.tally({ since: metered.since });
 };
 
-describe("hostedStoreOps — the 45-op wire client", () => {
-  it("routes 44 of the 45 ops to the console's real door, with a key on exactly the mutations", async () => {
+describe("hostedStoreOps — the 48-op wire client", () => {
+  it("routes 47 of the 48 ops to the console's real door, with a key on exactly the mutations", async () => {
     const { calls, ops } = wireFake(ALL_BODIES);
     await driveEveryOp(ops);
 
     const expected = Object.values(DOORS);
-    expect(calls).toHaveLength(44);
+    expect(calls).toHaveLength(47);
     expect(calls.map((call) => `${call.method} ${call.path}`))
       .toEqual(expected.map((route) => `${route.method} ${route.path}`));
     expect(calls.map((call) => call.idempotencyKey === null ? "read" : "keyed"))
       .toEqual(expected.map((route) => route.keyed === true ? "keyed" : "read"));
-    // 24 mutations, 20 reads — and the /status handshake is the one GET with
+    // 25 mutations, 22 reads — and the /status handshake is the one GET with
     // no body at all.
-    expect(expected.filter((route) => route.keyed === true)).toHaveLength(24);
+    expect(expected.filter((route) => route.keyed === true)).toHaveLength(25);
     expect(calls.filter((call) => call.method === "GET")).toEqual([
       expect.objectContaining({ path: P.status, method: "GET", body: undefined }),
     ]);
     // Distinct keys across distinct operations (one per logical mutation).
     const keys = calls.map((call) => call.idempotencyKey).filter((key) => key !== null);
-    expect(new Set(keys).size).toBe(24);
+    expect(new Set(keys).size).toBe(25);
   });
 
   it("blobs: JSON POST on the wire door, bytes base64 on the body", async () => {
@@ -1084,6 +1101,43 @@ describe("hostedStoreOps — the 45-op wire client", () => {
 
     await ops.lifecycle.promote("app_1", "org_1");
     expect(calls[2]).toMatchObject({ path: P["lifecycle.promote"], body: { appId: "app_1", orgId: "org_1" } });
+  });
+
+  it("usage: instants cross as ISO datetimes, and each read comes back on its own field", async () => {
+    const { calls, ops } = wireFake(ALL_BODIES);
+    const at = new Date("2026-08-14T09:30:00.000Z");
+
+    await ops.usage!.record({ subject: "sub_1", action: "message", at, poolKeys: ["team_1"] });
+    // A Date is not a wire type: every instant crosses as the ISO string the
+    // request schema validates, which is what a mount can actually parse.
+    expect(calls[0]!.body).toEqual({
+      subject: "sub_1",
+      action: "message",
+      at: "2026-08-14T09:30:00.000Z",
+      poolKeys: ["team_1"],
+    });
+    // Keyed: a retried write that counted twice is a limit the user hits early.
+    expect(calls[0]!.idempotencyKey).not.toBeNull();
+
+    expect(await ops.usage!.count({ poolKey: "team_1", action: "message", since: at })).toBe(7);
+    expect(calls[1]!.body).toEqual({ poolKey: "team_1", action: "message", since: "2026-08-14T09:30:00.000Z" });
+    expect(calls[1]!.idempotencyKey).toBeNull();
+
+    expect(await ops.usage!.tally({ since: at, action: "message" }))
+      .toEqual([{ subject: "sub_1", action: "message", count: 7 }]);
+    expect(calls[2]!.body).toEqual({ since: "2026-08-14T09:30:00.000Z", action: "message" });
+
+    const CONTRACT: [keyof typeof P, { safeParse(value: unknown): { success: boolean } }][] = [
+      ["usage.record", storeWireUsageRecordRequestSchema],
+      ["usage.count", storeWireUsageCountRequestSchema],
+      ["usage.tally", storeWireUsageTallyRequestSchema],
+    ];
+    expect(calls).toHaveLength(CONTRACT.length);
+    for (const [index, [op, schema]] of CONTRACT.entries()) {
+      const call = calls[index]!;
+      expect(`${call.method} ${call.path}`).toBe(`POST ${P[op]}`);
+      expect(schema.safeParse(call.body).success, op).toBe(true);
+    }
   });
 
   it("audit, secrets, footprint and retention: bodies flat on the contract, answers read off their own field", async () => {
@@ -1430,7 +1484,7 @@ describe("hostedStore keeps its StoreAdapter surface and gains the op surface", 
     // mount has.
     expect(Object.keys(store.ops).sort()).toEqual([
       "appData", "audit", "blobs", "engine", "footprint", "harness", "lifecycle",
-      "retention", "secrets", "status", "transcripts", "workspace",
+      "retention", "secrets", "status", "transcripts", "usage", "workspace",
     ]);
 
     // The op surface rides the SAME mount, key and identity headers as the

--- a/packages/store/tests/ops.test.ts
+++ b/packages/store/tests/ops.test.ts
@@ -84,18 +84,19 @@ for (const backend of backends()) {
       }
     });
 
-    it("status() reports the 45 ops this wire serves", async () => {
+    it("status() reports the 48 ops this wire serves", async () => {
       const { made, ops } = await makeOps();
       try {
         const status = await ops.status();
-        // All 45, against the manifest rather than a literal: `ops` is a LEVEL
+        // All 48, against the manifest rather than a literal: `ops` is a LEVEL
         // over STORE_WIRE_PATHS' declared order, and this engine now serves
         // every op on it — including audit.tally, declared past `status`, which
         // no level could reach while retention was missing from the middle.
         expect(status.ops).toBe(Object.keys(STORE_WIRE_PATHS).length);
-        // The family is what the level is claiming, so assert both together or
-        // the number can drift ahead of the object it describes.
+        // The families are what the level is claiming, so assert them together
+        // or the number can drift ahead of the objects it describes.
         expect(ops.retention).toBeDefined();
+        expect(ops.usage).toBeDefined();
         // Nothing left to announce: the handshake carries the format and the
         // count, and the retired generic family is not advertised as anything.
         expect(Object.keys(status).sort()).toEqual(["format", "ops"]);

--- a/packages/store/tests/schema.test.ts
+++ b/packages/store/tests/schema.test.ts
@@ -28,6 +28,7 @@ const CONTRACT_COLUMNS: Record<string, string[]> = {
   vendo_app_grants: ["id", "app_id", "org_id", "principal", "level", "created_by", "created_at"],
   vendo_idempotency_ledger: ["tenant", "op", "key", "request_hash", "status", "result", "created_at"],
   vendo_quarantine: ["collection", "id", "data", "subject", "app_id", "quarantined_at"],
+  vendo_usage: ["id", "subject", "action", "at", "pool_keys"],
 };
 
 for (const backend of backends()) {
@@ -48,17 +49,17 @@ for (const backend of backends()) {
     it("stores schema_version and a boot_id in vendo_meta", async () => {
       const rows = await made.sql("SELECT key, value FROM vendo_meta ORDER BY key");
       expect(rows).toEqual(expect.arrayContaining([
-        expect.objectContaining({ key: "schema_version", value: 9 }),
+        expect.objectContaining({ key: "schema_version", value: 10 }),
         expect.objectContaining({ key: "boot_id" }),
       ]));
       expect(rows.find((row) => row.key === "boot_id")?.value).toEqual(expect.any(String));
     });
 
-    it("lands a fresh database directly on schema version 9", async () => {
+    it("lands a fresh database directly on schema version 10", async () => {
       // A brand-new DB never runs the v2 backfill's DELETE against real data; it
       // just records the current version. (beforeAll already ran ensureSchema.)
       const version = (await made.sql("SELECT value FROM vendo_meta WHERE key = 'schema_version'"))[0]?.value;
-      expect(version).toBe(9);
+      expect(version).toBe(10);
     });
 
     it("keeps boot_id stable across a close and reopen", async () => {
@@ -78,7 +79,7 @@ for (const backend of backends()) {
 
       await made.store.ensureSchema();
 
-      expect((await made.sql("SELECT value FROM vendo_meta WHERE key = 'schema_version'"))[0]?.value).toBe(9);
+      expect((await made.sql("SELECT value FROM vendo_meta WHERE key = 'schema_version'"))[0]?.value).toBe(10);
       const rows = await made.sql(
         `SELECT table_name FROM information_schema.tables
          WHERE table_schema = 'public' AND table_name IN ('vendo_mcp_clients', 'vendo_mcp_grants')
@@ -102,7 +103,7 @@ for (const backend of backends()) {
 
       await made.store.ensureSchema();
 
-      expect((await made.sql("SELECT value FROM vendo_meta WHERE key = 'schema_version'"))[0]?.value).toBe(9);
+      expect((await made.sql("SELECT value FROM vendo_meta WHERE key = 'schema_version'"))[0]?.value).toBe(10);
       const survivor = await made.sql(
         "SELECT id FROM vendo_records WHERE collection = 'vendo_state' AND id = 'app_live:subject_live'",
       );
@@ -110,7 +111,7 @@ for (const backend of backends()) {
       await made.sql("DELETE FROM vendo_records WHERE collection = 'vendo_state' AND id = 'app_live:subject_live'");
     });
 
-    it("creates all 22 contract tables with every contracted key column", async () => {
+    it("creates all 23 contract tables with every contracted key column", async () => {
       const rows = await made.sql(
         "SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name LIKE 'vendo_%'",
       );
@@ -130,8 +131,10 @@ for (const backend of backends()) {
       // vendo_idempotency_ledger — the `Idempotency-Key` replay ledger, which
       // has to live in the same database as the mutations it gates (01 §12).
       // v9 adds vendo_quarantine — where a retention sweep parks the rows it
-      // lifts until a purge destroys them (01 §12 StoreOps.retention).
-      expect(actual.size).toBe(22);
+      // lifts until a purge destroys them (01 §12 StoreOps.retention). v10 adds
+      // vendo_usage — the meter a host's limits policy decides on, one row per
+      // metered action (01 §12 StoreOps.usage).
+      expect(actual.size).toBe(23);
       for (const [table, columns] of Object.entries(CONTRACT_COLUMNS)) {
         expect(actual.has(table), table).toBe(true);
         for (const column of columns) expect(actual.get(table)?.has(column), `${table}.${column}`).toBe(true);

--- a/packages/store/tests/usage.ops.test.ts
+++ b/packages/store/tests/usage.ops.test.ts
@@ -1,0 +1,109 @@
+import type { IsoDateTime, StoreOps } from "@vendoai/core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { backends, type MadeBackend } from "../src/backends.test-util.js";
+import { createStoreOps, eraseStore, storeFiles } from "../src/index.js";
+
+/** One instant inside a fixed hour, so a window can be drawn around it to the
+ *  minute — which is the whole reason the meter stores events and not buckets. */
+const at = (minute: number): Date => new Date(Date.UTC(2026, 7, 15, 10, minute));
+
+// 01 §12 `StoreOps.usage` against the LOCAL engine. The shared conformance suite
+// holds the roundtrip, the window edges and the grouping (core's
+// storeOpsConformance); what lives here is what only this backend can be asked:
+// that a recorded action really lands as a `vendo_usage` row, that the erase
+// cascade takes those rows with their subject, and that a retention sweep
+// cannot reach the drawer a limit is counted from.
+for (const backend of backends()) {
+  describe(`${backend.name} StoreOps usage`, () => {
+    let made: MadeBackend;
+    let ops: StoreOps;
+    beforeAll(async () => {
+      made = await backend.make();
+      await made.store.ensureSchema();
+      ops = createStoreOps(made.store);
+    });
+    afterAll(async () => { if (made) await made.cleanup(); });
+
+    it("records one row per metered action and counts them back", async () => {
+      const subject = "user_meter_count";
+      await ops.usage!.record({ subject, action: "message", at: at(0) });
+      await ops.usage!.record({ subject, action: "message", at: at(1) });
+      await ops.usage!.record({ subject, action: "generation", at: at(2) });
+
+      // Events, not a counter: three rows, each keeping its own instant.
+      const rows = await made.sql("SELECT action, at FROM vendo_usage WHERE subject = $1 ORDER BY at", [subject]);
+      expect(rows).toHaveLength(3);
+
+      expect(await ops.usage!.count({ subject, action: "message", since: at(0) })).toBe(2);
+      expect(await ops.usage!.count({ subject, action: "generation", since: at(0) })).toBe(1);
+      // Another person's meter is not this one's.
+      expect(await ops.usage!.count({ subject: "user_meter_other", action: "message", since: at(0) })).toBe(0);
+    });
+
+    it("takes `since` inclusively and `until` exclusively", async () => {
+      // audit.tally's floor is `at >= from`, and this window's floor is the same
+      // one: two reads of the same drawer that disagree about an edge disagree
+      // about a limit, and the person on the wrong side of it cannot tell why.
+      const subject = "user_meter_window";
+      for (const minute of [10, 11, 12]) {
+        await ops.usage!.record({ subject, action: "message", at: at(minute) });
+      }
+      const window = { subject, action: "message" } as const;
+      expect(await ops.usage!.count({ ...window, since: at(11) })).toBe(2);
+      expect(await ops.usage!.count({ ...window, since: at(10), until: at(12) })).toBe(2);
+      expect(await ops.usage!.count({ ...window, since: at(11), until: at(11) })).toBe(0);
+      expect(await ops.usage!.count({ ...window, since: at(13) })).toBe(0);
+    });
+
+    it("counts a pool by matching any one of the keys the row was written with", async () => {
+      // The keys are copied off the user at write time, so a member who leaves
+      // never retroactively drains the team's quota — the row is the only place
+      // that membership was ever true.
+      await ops.usage!.record({ subject: "user_pool_a", action: "message", at: at(20), poolKeys: ["team_ops", "org_acme"] });
+      await ops.usage!.record({ subject: "user_pool_b", action: "message", at: at(21), poolKeys: ["org_acme"] });
+      await ops.usage!.record({ subject: "user_pool_c", action: "message", at: at(22) });
+
+      expect(await ops.usage!.count({ poolKey: "org_acme", action: "message", since: at(20) })).toBe(2);
+      expect(await ops.usage!.count({ poolKey: "team_ops", action: "message", since: at(20) })).toBe(1);
+      expect(await ops.usage!.count({ poolKey: "team_absent", action: "message", since: at(20) })).toBe(0);
+      // A pool count is the bucket's, never the members' own rows.
+      expect(await ops.usage!.count({ subject: "user_pool_a", action: "message", since: at(20) })).toBe(1);
+    });
+
+    it("tallies a window per subject and action", async () => {
+      const since = at(30);
+      await ops.usage!.record({ subject: "user_tally_b", action: "message", at: at(30) });
+      await ops.usage!.record({ subject: "user_tally_b", action: "message", at: at(31) });
+      await ops.usage!.record({ subject: "user_tally_a", action: "generation", at: at(32) });
+
+      const rows = (await ops.usage!.tally({ since })).filter((row) => row.subject.startsWith("user_tally_"));
+      expect(rows).toEqual([
+        { subject: "user_tally_a", action: "generation", count: 1 },
+        { subject: "user_tally_b", action: "message", count: 2 },
+      ]);
+      expect(await ops.usage!.tally({ since, subject: "user_tally_a" }))
+        .toEqual([{ subject: "user_tally_a", action: "generation", count: 1 }]);
+      expect(await ops.usage!.tally({ since, action: "generation" }))
+        .toEqual([{ subject: "user_tally_a", action: "generation", count: 1 }]);
+    });
+
+    it("erases a person's meter rows with the rest of their data", async () => {
+      const leaver = "user_meter_erased";
+      await ops.usage!.record({ subject: leaver, action: "message", at: at(40) });
+      expect(await made.sql("SELECT 1 FROM vendo_usage WHERE subject = $1", [leaver])).toHaveLength(1);
+
+      const report = await eraseStore(made.store, { files: storeFiles(made.store) }).bySubject(leaver);
+      expect(report.vendo_usage).toBe(1);
+      expect(await made.sql("SELECT 1 FROM vendo_usage WHERE subject = $1", [leaver])).toHaveLength(0);
+    });
+
+    it("refuses a retention sweep of the meter", async () => {
+      // The meter is not a collection anyone may name: it has no door, so the
+      // engine gate that fences every collection-addressed verb refuses it, and
+      // a limit can never be reset by ageing its evidence out.
+      const soon = new Date(Date.now() + 60_000).toISOString() as IsoDateTime;
+      await expect(ops.retention!.quarantine("vendo_usage", soon)).rejects.toMatchObject({ code: "blocked" });
+      await expect(ops.retention!.purge("vendo_usage", soon)).rejects.toMatchObject({ code: "blocked" });
+    });
+  });
+}


### PR DESCRIPTION
PR1 of a stack. Base: `main`. **This is a review window — the stack merges once, at the tip of PR2 (`yousefh409/limits-feature`), which is based on this branch.**

## What this adds

The counting layer for per-user usage limits: `LimitAction`/`LimitWindow`/`LimitDecision`/`LimitsCallback` in `packages/core/src/limits.ts`, and `StoreOps.usage` — `record`/`count`/`tally` — over a new `vendo_usage` table, local ops, conformance cases, and the hosted-client wire.

This PR is **storage only**. A host will supply a `LimitsCallback`; Vendo will count usage and enforce the host's decision. No policy, no enforcement, no config surface yet — that's PR2.

## Events, not buckets

`vendo_usage` is a table of timestamped events — one row per metered action — never pre-bucketed. A policy authors its own window ("20 messages an hour", "3 generations today", down to the minute), and a pre-aggregated count can only answer the periods whoever bucketed it happened to pick.

## Three deliberate design calls

1. **`vendo_usage` is NOT in `RESERVED_COLLECTIONS`.** That list opens a public records door (list/get by collection name), and a meter row is only ever counted, never listed. Follows the `vendo_quarantine` precedent — also absent from that list for the same reason.
2. **No retention list entry, on purpose.** Retention already refuses to sweep the meter structurally: `assertSweepable` calls `assertEngineCollection` first, which throws before a quarantine/purge on a collection with no door — `vendo_usage` has none. Adding a list entry would be unreachable code. `packages/store/tests/usage.ops.test.ts` has a test proving the refusal (`retention.quarantine`/`retention.purge` both reject with `code: "blocked"`).
3. **`StoreOps.usage` is OPTIONAL**, matching the `retention` precedent in the same interface — making it required would break BYO `StoreOps` implementers. The follow-up PR refuses a configured limits callback against a meterless store rather than failing open.

## Gate

Test evidence is **inherited from the builder's own gate on these four commits, not re-run by me**: `packages/core` 219/219, `packages/store` 280/280, plus `pnpm build`, `pnpm typecheck`, `pnpm lint` all exit 0. I did not re-run the suites myself — the repo's own rule makes the PR's green `ci` check the gate of record, and CI will run the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an events-based meter for per-user usage limits and serves it via `StoreOps.usage` over a new `vendo_usage` table. This enables counting usage windows without changing runtime behavior yet; policy and enforcement come next.

- Schema v10 adds `vendo_usage` with indexes; run your schema migration or `ensureSchema` before deploying.
- The wire protocol appends `usage.record`/`usage.count`/`usage.tally` (status level is now 48). Mounts that don’t implement these return 501; this PR treats `StoreOps.usage` as optional.
- `usage.record` is idempotent-keyed; `count` reads one of subject or pool, with since-inclusive/until-exclusive bounds; `tally` groups by subject and action.
- `vendo_usage` is engine-owned and not listable: retention quarantine/purge refuse it; erase-by-subject deletes a user’s meter rows.
- The hosted client implements the new ops, sending instants as ISO datetimes and preserving idempotency on writes.

<sup>Written for commit ffd507fb8045c7e71a457f7b45d85188283e0357. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

