### PR TITLE
refactor(ui): safeStyle is a pure property allowlist (no value inspection)

### DIFF
--- a/packages/ui/src/tree/display-bricks.tsx
+++ b/packages/ui/src/tree/display-bricks.tsx
@@ -62,16 +62,22 @@ const POSITION_KEEP: ReadonlySet<string> = new Set(["static", "relative", "absol
  * and a fetching one (`url()`, `image-set()`). Kept, but only when every CSS
  * function its value calls is on the property's list — `cursor` calls none
  * (keyword cursors only), so a `url()` cursor is dropped like any other fetch.
+ * `var()` is on the list so the standard theme value survives (`background:
+ * var(--vendo-color-background, #fff)`); it is safe because the scan sees every
+ * function anywhere in the value, so a `url()` smuggled into a `var()` fallback
+ * (`var(--x, url(evil))`) still puts `url` on the list and drops the whole
+ * declaration — and a custom-property DEFINITION is never allowlisted, so the
+ * model cannot mint its own token for `var()` to resolve to.
  */
 const GRADIENTS = ["linear-gradient", "radial-gradient", "conic-gradient",
   "repeating-linear-gradient", "repeating-radial-gradient", "repeating-conic-gradient"];
 const FILTERS = ["blur", "brightness", "contrast", "grayscale", "hue-rotate",
   "invert", "opacity", "saturate", "sepia", "drop-shadow"];
 const VALUE_RESTRICTED: Record<string, ReadonlySet<string>> = {
-  background: new Set(GRADIENTS),
-  backgroundImage: new Set(GRADIENTS),
-  filter: new Set(FILTERS),
-  backdropFilter: new Set(FILTERS),
+  background: new Set([...GRADIENTS, "var"]),
+  backgroundImage: new Set([...GRADIENTS, "var"]),
+  filter: new Set([...FILTERS, "var"]),
+  backdropFilter: new Set([...FILTERS, "var"]),
   cursor: new Set(),
 };
 

--- a/packages/ui/src/tree/display-bricks.tsx
+++ b/packages/ui/src/tree/display-bricks.tsx
@@ -62,12 +62,12 @@ const POSITION_KEEP: ReadonlySet<string> = new Set(["static", "relative", "absol
  * and a fetching one (`url()`, `image-set()`). Kept, but only when every CSS
  * function its value calls is on the property's list — `cursor` calls none
  * (keyword cursors only), so a `url()` cursor is dropped like any other fetch.
- * `var()` is on the list so the standard theme value survives (`background:
- * var(--vendo-color-background, #fff)`); it is safe because the scan sees every
- * function anywhere in the value, so a `url()` smuggled into a `var()` fallback
- * (`var(--x, url(evil))`) still puts `url` on the list and drops the whole
- * declaration — and a custom-property DEFINITION is never allowlisted, so the
- * model cannot mint its own token for `var()` to resolve to.
+ * `var()` is on the list, but only a reference to the approved `--vendo-*` theme
+ * surface the host controls survives (`background: var(--vendo-color-background,
+ * #fff)`): a `var()` onto any other token could resolve to a host- or
+ * ancestor-defined `url()` the browser then fetches, so it drops. A `url()`
+ * smuggled into a `var()` fallback (`var(--vendo-x, url(evil))`) drops the same
+ * way — the scan sees every function anywhere in the value.
  */
 const GRADIENTS = ["linear-gradient", "radial-gradient", "conic-gradient",
   "repeating-linear-gradient", "repeating-radial-gradient", "repeating-conic-gradient"];
@@ -117,10 +117,20 @@ const FUNCTION = /([-\w]+)\s*\(/gu;
 const functionsCalled = (value: string): string[] =>
   [...unescaped(preprocessed(value)).matchAll(FUNCTION)].map(([, name]) => name!.toLowerCase());
 
+/** The custom property each `var()` reads (its first argument), escapes resolved
+ *  the same way. A `var()` may resolve to whatever that token holds, so only the
+ *  approved `--vendo-*` theme surface is ours to trust; one reference outside it
+ *  (a host could point it at a `url()`) drops the whole declaration. */
+const VAR_REF = /(?<![-\w])var\s*\(\s*(--[^\s,)]*)/giu;
+const varsInThemeNamespace = (value: string): boolean =>
+  [...unescaped(preprocessed(value)).matchAll(VAR_REF)].every(([, name]) => name!.startsWith("--vendo-"));
+
 const keep = (property: string, value: unknown): boolean => {
   if (property === "position") return POSITION_KEEP.has(String(value).trim().toLowerCase());
   const allowed = VALUE_RESTRICTED[property];
-  if (allowed !== undefined) return functionsCalled(String(value)).every((name) => allowed.has(name));
+  if (allowed !== undefined)
+    return functionsCalled(String(value)).every((name) => allowed.has(name))
+      && varsInThemeNamespace(String(value));
   return ALLOWED_STYLE.has(property);
 };
 

--- a/packages/ui/src/tree/display-bricks.tsx
+++ b/packages/ui/src/tree/display-bricks.tsx
@@ -17,18 +17,24 @@ export interface DisplayBrickProps {
 }
 
 /**
- * What a screen may paint with is a DEFAULT-DENY property allowlist, not a
- * value denylist: a property not named here is dropped whatever its value, so a
- * fetching property nobody predicted (`maskImage`, `borderImage`, `content`) is
- * gone by default. Every name here is inert — none can carry a URL — so it
- * passes with any value; the properties that CAN fetch are handled below.
+ * What a screen may paint with is a DEFAULT-DENY property allowlist and NOTHING
+ * ELSE: `safeStyle` keeps a declaration iff its property is named here, whatever
+ * its value. No value is ever inspected — so there is no CSS spelling for a model
+ * to bypass. The list holds only properties that cannot fetch: a `color` takes a
+ * URL nowhere, but `background`, `backgroundImage`, `filter`, `backdropFilter`
+ * and `cursor` all can (`url()`, `image-set()`), so they are simply absent and
+ * drop by default alongside `maskImage`, `borderImage` and `content`. Themed fills
+ * use `backgroundColor`; gradients/blur are not available to a raw brick (a
+ * host-controlled kit token could reintroduce them later, out of scope here).
+ * `position` is allowed: `SURFACE_CONTAINMENT` clips even `fixed`/`sticky` to the
+ * box, so no value check is needed to hold a screen inside its surface.
  */
 const ALLOWED_STYLE: ReadonlySet<string> = new Set([
   // layout
   "display", "flexDirection", "flexWrap", "flex", "flexGrow", "flexShrink", "flexBasis",
   "alignItems", "alignSelf", "justifyContent", "justifyItems", "justifySelf",
   "gap", "rowGap", "columnGap", "gridTemplateColumns", "gridTemplateRows",
-  "gridColumn", "gridRow", "gridAutoFlow", "inset", "top", "right", "bottom", "left",
+  "gridColumn", "gridRow", "gridAutoFlow", "position", "inset", "top", "right", "bottom", "left",
   "width", "height", "minWidth", "minHeight", "maxWidth", "maxHeight",
   "overflow", "overflowX", "overflowY", "boxSizing",
   // spacing
@@ -53,94 +59,13 @@ const ALLOWED_STYLE: ReadonlySet<string> = new Set([
   "transition", "transitionProperty", "transitionDuration", "transitionTimingFunction",
 ]);
 
-/** `position` can fold a screen out of its box, so only the in-flow values
- *  survive — `fixed`/`sticky` would escape `SURFACE_CONTAINMENT` and are dropped. */
-const POSITION_KEEP: ReadonlySet<string> = new Set(["static", "relative", "absolute"]);
-
-/**
- * The dual-use properties: each holds both an inert value (a gradient, a blur)
- * and a fetching one (`url()`, `image-set()`). Kept, but only when every CSS
- * function its value calls is on the property's list — `cursor` calls none
- * (keyword cursors only), so a `url()` cursor is dropped like any other fetch.
- * `var()` is on the list, but only a reference to the approved `--vendo-*` theme
- * surface the host controls survives (`background: var(--vendo-color-background,
- * #fff)`): a `var()` onto any other token could resolve to a host- or
- * ancestor-defined `url()` the browser then fetches, so it drops. A `url()`
- * smuggled into a `var()` fallback (`var(--vendo-x, url(evil))`) drops the same
- * way — the scan sees every function anywhere in the value.
- */
-const GRADIENTS = ["linear-gradient", "radial-gradient", "conic-gradient",
-  "repeating-linear-gradient", "repeating-radial-gradient", "repeating-conic-gradient"];
-const FILTERS = ["blur", "brightness", "contrast", "grayscale", "hue-rotate",
-  "invert", "opacity", "saturate", "sepia", "drop-shadow"];
-const VALUE_RESTRICTED: Record<string, ReadonlySet<string>> = {
-  background: new Set([...GRADIENTS, "var"]),
-  backgroundImage: new Set([...GRADIENTS, "var"]),
-  filter: new Set([...FILTERS, "var"]),
-  backdropFilter: new Set([...FILTERS, "var"]),
-  cursor: new Set(),
-};
-
-/**
- * A CSS escape: `\` then 1–6 hex digits with one trailing whitespace consumed,
- * or `\` then a literal character. The tokenizer unescapes BEFORE it decides
- * what a token is, so `\75 rl(` is the function `url(` however the raw string
- * reads — and `var()` substitutes whole tokens, so a custom property carries the
- * spelling through intact.
- */
-const ESCAPE = /\\(?:([0-9a-f]{1,6})[ \t\r\n\f]?|(.))/giu;
-
-/**
- * CSS input preprocessing (Syntax §3.3), the stage that runs BEFORE any escape
- * is read: CRLF, a lone CR and a form feed each collapse to ONE newline, and
- * NUL and lone surrogates become the replacement character. That first stage is
- * why `\75` + CRLF is `u` + a single newline by the time the escape claims its
- * one trailing whitespace — leaving `url(`.
- */
-const preprocessed = (value: string): string =>
-  value.replace(/\r\n?|\f/gu, "\n").replace(/[\0\ud800-\udfff]/gu, "�");
-
-/** The escapes resolved, for the DECISION only — the brick still paints the
- *  original value. Code points past the Unicode range are the tokenizer's
- *  replacement character, not a throw. */
-const unescaped = (value: string): string =>
-  value.replace(ESCAPE, (_, hex: string | undefined, literal: string) =>
-    hex === undefined ? literal
-      : Number.parseInt(hex, 16) > 0x10ffff ? "�"
-        : String.fromCodePoint(Number.parseInt(hex, 16)));
-
-/** Every CSS function a value calls, escapes resolved the way the browser
- *  resolves them so `\75 rl(` reads as `url(`. Vendor spellings ride the hyphen
- *  (`-webkit-image-set`); one name off the property's list drops the whole
- *  declaration. */
-const FUNCTION = /([-\w]+)\s*\(/gu;
-const functionsCalled = (value: string): string[] =>
-  [...unescaped(preprocessed(value)).matchAll(FUNCTION)].map(([, name]) => name!.toLowerCase());
-
-/** The custom property each `var()` reads (its first argument), escapes resolved
- *  the same way. A `var()` may resolve to whatever that token holds, so only the
- *  approved `--vendo-*` theme surface is ours to trust; one reference outside it
- *  (a host could point it at a `url()`) drops the whole declaration. */
-const VAR_REF = /(?<![-\w])var\s*\(\s*(--[^\s,)]*)/giu;
-const varsInThemeNamespace = (value: string): boolean =>
-  [...unescaped(preprocessed(value)).matchAll(VAR_REF)].every(([, name]) => name!.startsWith("--vendo-"));
-
-const keep = (property: string, value: unknown): boolean => {
-  if (property === "position") return POSITION_KEEP.has(String(value).trim().toLowerCase());
-  const allowed = VALUE_RESTRICTED[property];
-  if (allowed !== undefined)
-    return functionsCalled(String(value)).every((name) => allowed.has(name))
-      && varsInThemeNamespace(String(value));
-  return ALLOWED_STYLE.has(property);
-};
-
 /** The style a brick actually paints with: the model's, minus every declaration
- *  the allowlist does not admit. Dropping the DECLARATION (never rewriting the
- *  value) keeps this a filter with no CSS parser in it. */
+ *  whose property is not on the allowlist. A pure key filter — no value is read,
+ *  so there is no CSS parser and nothing to bypass. */
 export function safeStyle(style: CSSProperties | undefined): CSSProperties | undefined {
   if (style === undefined) return undefined;
   return Object.fromEntries(
-    Object.entries(style).filter(([property, value]) => keep(property, value)),
+    Object.entries(style).filter(([property]) => ALLOWED_STYLE.has(property)),
   );
 }
 
@@ -170,9 +95,9 @@ export const DISPLAY_BRICKS: Record<string, (props: DisplayBrickProps) => ReactN
 
 /**
  * A screen paints inside its own box and nowhere else. Capability-shaped, like
- * the fetch filter: `contain: paint` makes this element the containing block for
- * every fixed and absolutely positioned descendant, so `position: fixed;
- * width: 200vw` is held by the BOX — nothing had to read the word "fixed".
+ * the property allowlist: `contain: paint` makes this element the containing
+ * block for every fixed and absolutely positioned descendant, so `position:
+ * fixed; width: 200vw` is held by the BOX — nothing had to read the word "fixed".
  */
 export const SURFACE_CONTAINMENT: CSSProperties = {
   contain: "layout paint",

--- a/packages/ui/test/tree/display-bricks.test.tsx
+++ b/packages/ui/test/tree/display-bricks.test.tsx
@@ -40,69 +40,49 @@ describe("display bricks", () => {
     expect(box.getAttribute("class")).toBeNull();
   });
 
-  it("keeps the allowlisted properties, whatever inert value they hold", () => {
+  it("keeps an allowlisted property whatever its value — no value is inspected", () => {
+    // A themed fill rides `backgroundColor` (a color cannot fetch); the value is
+    // passed straight through, never parsed.
     expect(safeStyle({
       padding: "8px",
       color: "var(--vendo-color-accent)",
-      background: "linear-gradient(90deg, red, blue)",
+      backgroundColor: "var(--vendo-surface)",
       transform: "translateX(4px)",
     })).toEqual({
       padding: "8px",
       color: "var(--vendo-color-accent)",
-      background: "linear-gradient(90deg, red, blue)",
+      backgroundColor: "var(--vendo-surface)",
       transform: "translateX(4px)",
     });
     expect(safeStyle(undefined)).toBeUndefined();
+  });
+
+  it("drops the fetch-capable properties whatever their value", () => {
+    // These carry `url()`/`image-set()`, so they are off the allowlist and drop
+    // wholesale — even a plain gradient or blur, which are no longer available to
+    // a raw brick. Nothing reads the value; there is no spelling to bypass.
+    expect(safeStyle({ background: "linear-gradient(red, blue)" })).toEqual({});
+    expect(safeStyle({ background: "url(https://evil/x)" })).toEqual({});
+    expect(safeStyle({ backgroundImage: "linear-gradient(red, blue)" })).toEqual({});
+    expect(safeStyle({ filter: "blur(4px)" })).toEqual({});
+    expect(safeStyle({ backdropFilter: "blur(4px)" })).toEqual({});
+    expect(safeStyle({ cursor: "pointer" })).toEqual({});
   });
 
   it("drops every property the allowlist does not name", () => {
     expect(safeStyle({
       WebkitMaskImage: "url(https://evil/x)",
       content: "url(https://evil/y)",
-      position: "fixed",
       color: "red",
     } as CSSProperties)).toEqual({ color: "red" });
-    // `position` keeps only its in-flow values.
+  });
+
+  it("allows position and leans on the surface box to contain it", () => {
+    // Option (b): no value check on `position`. `SURFACE_CONTAINMENT` clips even
+    // fixed/sticky to the box (see "paints the surface inside its own box"), so
+    // the value passes through and the box, not a string scan, holds it in.
+    expect(safeStyle({ position: "fixed" })).toEqual({ position: "fixed" });
     expect(safeStyle({ position: "relative" })).toEqual({ position: "relative" });
-  });
-
-  it("keeps a dual-use property's inert value and drops its fetching one", () => {
-    expect(safeStyle({ background: "url(https://evil/x)" })).toEqual({});
-    expect(safeStyle({ background: "linear-gradient(red, blue)" }))
-      .toEqual({ background: "linear-gradient(red, blue)" });
-    expect(safeStyle({ filter: "blur(4px)" })).toEqual({ filter: "blur(4px)" });
-    expect(safeStyle({ filter: "url(#x)" })).toEqual({});
-    // `image-set()` and a `url()` cursor go the same way — a fetch is a fetch.
-    expect(safeStyle({ backgroundImage: "image-set('https://evil/y' 1x)" })).toEqual({});
-    expect(safeStyle({ cursor: "url(https://evil/z), auto" })).toEqual({});
-    expect(safeStyle({ cursor: "pointer" })).toEqual({ cursor: "pointer" });
-  });
-
-  it("drops a fetch however its escapes spell the function", () => {
-    // The CSS tokenizer unescapes before it decides what a token is, so each of
-    // these IS `url(` to the browser whatever the raw string reads.
-    expect(safeStyle({ background: "\\75 rl(https://evil/x)" })).toEqual({});
-    expect(safeStyle({ background: "u\\72 l(https://evil/y)" })).toEqual({});
-    // A custom-property DEFINITION is never allowlisted, and a `var()` onto a
-    // non-`--vendo-` token is dropped for being outside the theme namespace — so
-    // this smuggle loses on both counts, both declarations go.
-    expect(safeStyle({ "--x": "url(/pixel)", background: "var(--x)" } as CSSProperties)).toEqual({});
-  });
-
-  it("keeps only --vendo- theme var() tokens, dropping foreign refs and url fetches", () => {
-    // Survives: the standard theme pattern — regression #1325 dropped it entirely.
-    expect(safeStyle({ background: "var(--vendo-color-background, #ffffff)" }))
-      .toEqual({ background: "var(--vendo-color-background, #ffffff)" });
-    expect(safeStyle({ filter: "var(--vendo-x)" })).toEqual({ filter: "var(--vendo-x)" });
-    // Survives nested in a gradient — both functions are on the list, ref is --vendo-.
-    expect(safeStyle({ background: "linear-gradient(var(--vendo-accent), #fff)" }))
-      .toEqual({ background: "linear-gradient(var(--vendo-accent), #fff)" });
-    // Dropped: a var() onto a non-`--vendo-` token — a host could point it at a url.
-    expect(safeStyle({ background: "var(--unapproved-host-token)" })).toEqual({});
-    expect(safeStyle({ background: "linear-gradient(var(--evil), #fff)" })).toEqual({});
-    // Dropped: a bare url(), and a url() smuggled into a var() fallback (url anywhere).
-    expect(safeStyle({ background: "url(https://evil/x)" })).toEqual({});
-    expect(safeStyle({ background: "var(--vendo-x, url(https://evil/x))" })).toEqual({});
   });
 
   it("paints the surface inside its own box", () => {

--- a/packages/ui/test/tree/display-bricks.test.tsx
+++ b/packages/ui/test/tree/display-bricks.test.tsx
@@ -83,27 +83,26 @@ describe("display bricks", () => {
     // these IS `url(` to the browser whatever the raw string reads.
     expect(safeStyle({ background: "\\75 rl(https://evil/x)" })).toEqual({});
     expect(safeStyle({ background: "u\\72 l(https://evil/y)" })).toEqual({});
-    // A custom-property DEFINITION is never on the allowlist, so the model cannot
-    // mint its own token: `--x` is dropped and `var(--x)` resolves to nothing. The
-    // reference itself survives now — themed `var(--vendo-*)` is the whole point.
-    expect(safeStyle({ "--x": "url(/pixel)", background: "var(--x)" } as CSSProperties))
-      .toEqual({ background: "var(--x)" });
+    // A custom-property DEFINITION is never allowlisted, and a `var()` onto a
+    // non-`--vendo-` token is dropped for being outside the theme namespace — so
+    // this smuggle loses on both counts, both declarations go.
+    expect(safeStyle({ "--x": "url(/pixel)", background: "var(--x)" } as CSSProperties)).toEqual({});
   });
 
-  it("keeps themed var() theme tokens and still drops a url smuggled in a fallback", () => {
-    // (a) The standard theme pattern survives — the regression #1325 dropped it.
+  it("keeps only --vendo- theme var() tokens, dropping foreign refs and url fetches", () => {
+    // Survives: the standard theme pattern — regression #1325 dropped it entirely.
     expect(safeStyle({ background: "var(--vendo-color-background, #ffffff)" }))
       .toEqual({ background: "var(--vendo-color-background, #ffffff)" });
-    // (b) A themed filter survives the same way.
     expect(safeStyle({ filter: "var(--vendo-x)" })).toEqual({ filter: "var(--vendo-x)" });
-    // (c) A gradient mixing a var() token survives — both functions are on the list.
+    // Survives nested in a gradient — both functions are on the list, ref is --vendo-.
     expect(safeStyle({ background: "linear-gradient(var(--vendo-accent), #fff)" }))
       .toEqual({ background: "linear-gradient(var(--vendo-accent), #fff)" });
-    // (d) A bare url() still drops.
+    // Dropped: a var() onto a non-`--vendo-` token — a host could point it at a url.
+    expect(safeStyle({ background: "var(--unapproved-host-token)" })).toEqual({});
+    expect(safeStyle({ background: "linear-gradient(var(--evil), #fff)" })).toEqual({});
+    // Dropped: a bare url(), and a url() smuggled into a var() fallback (url anywhere).
     expect(safeStyle({ background: "url(https://evil/x)" })).toEqual({});
-    // (e) A url() smuggled into a var() fallback still drops — the scan sees `url(`
-    // anywhere in the value, so `var` on the list does not let it through.
-    expect(safeStyle({ background: "var(--x, url(https://evil/x))" })).toEqual({});
+    expect(safeStyle({ background: "var(--vendo-x, url(https://evil/x))" })).toEqual({});
   });
 
   it("paints the surface inside its own box", () => {

--- a/packages/ui/test/tree/display-bricks.test.tsx
+++ b/packages/ui/test/tree/display-bricks.test.tsx
@@ -83,9 +83,27 @@ describe("display bricks", () => {
     // these IS `url(` to the browser whatever the raw string reads.
     expect(safeStyle({ background: "\\75 rl(https://evil/x)" })).toEqual({});
     expect(safeStyle({ background: "u\\72 l(https://evil/y)" })).toEqual({});
-    // A custom property is not on the allowlist, so a `var()` that would smuggle
-    // one in has nothing to resolve to — both declarations go.
-    expect(safeStyle({ "--x": "url(/pixel)", background: "var(--x)" } as CSSProperties)).toEqual({});
+    // A custom-property DEFINITION is never on the allowlist, so the model cannot
+    // mint its own token: `--x` is dropped and `var(--x)` resolves to nothing. The
+    // reference itself survives now — themed `var(--vendo-*)` is the whole point.
+    expect(safeStyle({ "--x": "url(/pixel)", background: "var(--x)" } as CSSProperties))
+      .toEqual({ background: "var(--x)" });
+  });
+
+  it("keeps themed var() theme tokens and still drops a url smuggled in a fallback", () => {
+    // (a) The standard theme pattern survives — the regression #1325 dropped it.
+    expect(safeStyle({ background: "var(--vendo-color-background, #ffffff)" }))
+      .toEqual({ background: "var(--vendo-color-background, #ffffff)" });
+    // (b) A themed filter survives the same way.
+    expect(safeStyle({ filter: "var(--vendo-x)" })).toEqual({ filter: "var(--vendo-x)" });
+    // (c) A gradient mixing a var() token survives — both functions are on the list.
+    expect(safeStyle({ background: "linear-gradient(var(--vendo-accent), #fff)" }))
+      .toEqual({ background: "linear-gradient(var(--vendo-accent), #fff)" });
+    // (d) A bare url() still drops.
+    expect(safeStyle({ background: "url(https://evil/x)" })).toEqual({});
+    // (e) A url() smuggled into a var() fallback still drops — the scan sees `url(`
+    // anywhere in the value, so `var` on the list does not let it through.
+    expect(safeStyle({ background: "var(--x, url(https://evil/x))" })).toEqual({});
   });
 
   it("paints the surface inside its own box", () => {


### PR DESCRIPTION
## What this is now

`safeStyle` is a **pure property allowlist with zero value inspection**: it keeps a declaration iff its property is named in `ALLOWED_STYLE`, whatever the value. Nothing reads a value — no url scan, no gradient/filter function lists, no `var()`-namespace check, no escape-decode.

## Why

The original #1325 change kept the four fetch-capable properties on a value-restricted path that peeked at each value to decide. That is a blacklist in disguise, and it kept leaking new CSS-spelling bypasses:
1. `var()` dropped the standard theme pattern (the P1 that opened this PR),
2. `var(--host-token)` could resolve to a host-defined `url()`,
3. `var/*comment*/(--evil)` slipped past the function scanner.

Every fix was another round of the arms race. The fix is to stop inspecting values.

## The change

- **Dropped** `background`, `backgroundImage`, `filter`, `backdropFilter`, and `cursor` from every allow path — they can fetch (`url()`, `image-set()`), so they are simply not on the allowlist and drop by default, alongside `maskImage`/`borderImage`/`content`.
- **Background COLOR stays**: `backgroundColor`, `color`, `borderColor`, `outlineColor` — a color cannot fetch, needs no inspection. Themed fills use `backgroundColor: var(--vendo-surface)`, which now passes through untouched.
- **Deleted** all value-inspection machinery: `GRADIENTS`, `FILTERS`, `VALUE_RESTRICTED`, `VAR_REF`, `functionsCalled`, `varsInThemeNamespace`, `ESCAPE`, `preprocessed`, `unescaped`, `FUNCTION`, `POSITION_KEEP`, and the `keep` helper. The source file drops from 166 to 107 lines (-95 / +36 in the diff).
- **`position`**: chose the smaller of the two options — `position` is now on the allowlist and relies on `SURFACE_CONTAINMENT` (`contain: layout paint` + `overflow: clip`) to hold even `fixed`/`sticky` inside the box. No value check; `POSITION_KEEP` deleted (it was itself value inspection).
- Kept `ALLOWED_STYLE` (minus the 4 fetch props), `SURFACE_CONTAINMENT`, `DisplayBrickProps`, and all 20 brick call sites.

This structurally ends the CSS-spelling arms race: nothing inspects values, so there is nothing to bypass.

### Tradeoff (in scope note)

Gradients and blur are no longer available to a raw generated brick. Themed solid fills still work via `backgroundColor`. Gradients could return later through a host-controlled kit token (a fixed, host-authored value the model selects but cannot author) — out of scope here.

## Tests

`packages/ui/test/tree/display-bricks.test.tsx` rewritten to the new reality: an allowed prop survives whatever its value (incl. `backgroundColor: var(--vendo-surface)`); each of `background`/`backgroundImage`/`filter`/`backdropFilter`/`cursor` drops regardless of value (incl. a plain gradient — gradients are gone); a non-allowlisted prop (`content`, `maskImage`) drops; `position` passes through and is contained. The old url/var/gradient/escape value-check tests were removed — **that behavior no longer exists**. Kept the drift test, "renders a brick", and the containment test. Prove-can-fail confirmed: adding `background` back to the allowlist reds the fetch-property drop test.

Gate: `pnpm build` + `pnpm typecheck` + `pnpm lint` green; targeted `display-bricks.test.tsx` 7/7. `safeStyle` has no importer outside this module, so the change is contained.