### PR TITLE
chore: hold the release to 0.x

### DIFF
--- a/.changeset/one-catalog-no-search.md
+++ b/.changeset/one-catalog-no-search.md
@@ -1,7 +1,7 @@
 ---
-"@vendoai/apps": major
-"@vendoai/core": major
-"@vendoai/vendo": major
+"@vendoai/apps": minor
+"@vendoai/core": minor
+"@vendoai/vendo": minor
 ---
 
 The whole catalog is in the prompt, so `search_components` is deleted.

--- a/.changeset/one-jail-wire-plan-deletion.md
+++ b/.changeset/one-jail-wire-plan-deletion.md
@@ -1,7 +1,7 @@
 ---
-"@vendoai/apps": major
-"@vendoai/harnesses": major
-"@vendoai/vendo": major
+"@vendoai/apps": minor
+"@vendoai/harnesses": minor
+"@vendoai/vendo": minor
 ---
 
 The wire format (`app.vendo`) and the plan dialect (`plan.vendo`) are gone. One

--- a/.changeset/one-venue-the-jail-is-deleted.md
+++ b/.changeset/one-venue-the-jail-is-deleted.md
@@ -1,6 +1,6 @@
 ---
-"@vendoai/apps": major
-"@vendoai/ui": major
+"@vendoai/apps": minor
+"@vendoai/ui": minor
 "@vendoai/actions": patch
 "@vendoai/mcp": patch
 ---

--- a/.changeset/remix-collects-an-instruction.md
+++ b/.changeset/remix-collects-an-instruction.md
@@ -1,8 +1,8 @@
 ---
-"@vendoai/core": major
-"@vendoai/apps": major
-"@vendoai/ui": major
-"@vendoai/vendo": major
+"@vendoai/core": minor
+"@vendoai/apps": minor
+"@vendoai/ui": minor
+"@vendoai/vendo": minor
 ---
 
 The ✦ gesture collects an instruction, and mints a screen. There are no bare forks: ✦ asks what the person wants BEFORE it fires, and the fork plus that first edit are ONE operation whose output is an ordinary screen app (`app.tsx`, through the ordinary edit door) carrying the remix's provenance — component, baseline, and the instruction, verbatim.


### PR DESCRIPTION
Four pending changesets declared `major`:

- `one-catalog-no-search.md`
- `one-jail-wire-plan-deletion.md`
- `one-venue-the-jail-is-deleted.md`
- `remix-collects-an-instruction.md`

On a 0.x package changesets reads `major` as `0.20.0 -> 1.0.0`, and since all
thirteen packages are one `fixed` group in `.changeset/config.json`, the whole
set went to 1.0.0. PR #1315 was proposing exactly that.

Held to 0.x per Yousef. Frontmatter only — 12 lines, `major` -> `minor`, no
changelog prose touched. Verified with a local `pnpm changeset:version`: the
group lands on 0.21.0 and nothing proposes 1.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Holds the release at 0.x by changing four pending changesets from major to minor across the fixed group to avoid an unintended 1.0.0 bump. Previously, `major` on 0.x would move 0.20.0 → 1.0.0; now the next publish resolves to 0.21.0.

- Edited only `.changeset/one-catalog-no-search.md`, `.changeset/one-jail-wire-plan-deletion.md`, `.changeset/one-venue-the-jail-is-deleted.md`, `.changeset/remix-collects-an-instruction.md` frontmatter (`major` → `minor`); no changelog prose or code changed.
- Affects the fixed group including `@vendoai/apps`, `@vendoai/core`, `@vendoai/vendo`, `@vendoai/ui`, `@vendoai/harnesses`; no package proposes 1.0.0.
- No runtime or API changes; no migration required.

<sup>Written for commit 49b463e79281239baa909873f3711b1986ff9f23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

