### PR TITLE
feat(ui): Checkbox on Base UI internals — BLOCKED on a real DOM contract change

### DIFF
--- a/.changeset/kit-checkbox-on-base-ui.md
+++ b/.changeset/kit-checkbox-on-base-ui.md
@@ -1,0 +1,26 @@
+---
+"@vendoai/ui": minor
+---
+
+Checkbox runs on Base UI.
+
+`Checkbox.Root` / `Checkbox.Indicator` replace the native `<input
+type="checkbox">`, so the checked state, the label association and the keyboard
+come from `@base-ui/react` (pinned `1.7.0`) rather than from the browser's own
+control — the same swap `Tabs`, `Switch` and `Radio` already made.
+
+This is an internals swap, not an API change: `CheckboxProps` is unchanged to
+the byte, and every prop a host or a generated screen passes behaves exactly as
+before. The Quiet Precision look moved onto Base UI's parts through its
+`style`-as-state callback, so the 16px box, the accent fill, the hairline edge
+and the `[data-kit]:focus-visible` ring survive with no new stylesheet;
+verified click-, keyboard- and focus-ring-wise in a real Chromium against
+before/after screenshots.
+
+One thing a consumer can see. Base UI renders the accessible control as a
+`<span role="checkbox">` with a visually hidden `<input type="checkbox">`
+beside it, so code that reached for the rendered node's `.checked` property
+must now read `aria-checked`, and a query by label text matches both elements
+rather than one. Nothing in the published API exposes either node.
+
+`Select` stays on its native element.

--- a/packages/ui/src/kit/forms/checkbox.tsx
+++ b/packages/ui/src/kit/forms/checkbox.tsx
@@ -1,6 +1,8 @@
 /** Checkbox — boolean input; onChange reports checked (W2 §The Kit). */
-import { t } from "../tokens.js";
+import { Checkbox as Base } from "@base-ui/react/checkbox";
+import { hairline, t, transitionFor } from "../tokens.js";
 import { controlledHandler } from "../handler.js";
+import { Icon } from "../icon.js";
 import { FieldShell, useFieldIds } from "./field.js";
 
 export interface CheckboxProps {
@@ -16,18 +18,37 @@ export function Checkbox({ label, checked, hint, disabled, onChange }: CheckboxP
   const screen = controlledHandler(checked !== undefined, onChange);
   return (
     <FieldShell fieldId={fieldId} helpId={helpId} label={label} hint={hint} inline>
-      <input
+      <Base.Root
         id={fieldId}
         data-kit="Checkbox"
-        type="checkbox"
         {...(screen === null ? { defaultChecked: checked } : { checked: checked ?? false })}
         disabled={disabled}
         aria-describedby={hint ? helpId : undefined}
-        onChange={(e) => screen === null
-          ? onChange?.(e.target.checked)
-          : screen({ target: { checked: e.target.checked } })}
-        style={{ width: 16, height: 16, accentColor: t.accent, cursor: disabled ? "not-allowed" : "pointer" }}
-      />
+        onCheckedChange={(next) => screen === null
+          ? onChange?.(next)
+          : screen({ target: { checked: next } })}
+        style={({ checked: on }) => ({
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          // The border is part of the 16px footprint the native box had, not on
+          // top of it — the Kit cannot assume a `box-sizing` reset in a host page.
+          boxSizing: "border-box",
+          width: 16,
+          height: 16,
+          border: on ? `${t.borderWidth} solid ${t.accent}` : hairline,
+          borderRadius: t.radiusSmall,
+          background: on ? t.accent : t.surface,
+          color: t.accentText,
+          cursor: disabled ? "not-allowed" : "pointer",
+          opacity: disabled ? 0.55 : 1,
+          transition: transitionFor("background-color", "border-color"),
+        })}
+      >
+        <Base.Indicator style={{ display: "inline-flex" }}>
+          <Icon name="check" size={12} />
+        </Base.Indicator>
+      </Base.Root>
     </FieldShell>
   );
 }

--- a/packages/ui/test/kit/base-ui-bricks.test.tsx
+++ b/packages/ui/test/kit/base-ui-bricks.test.tsx
@@ -18,6 +18,7 @@ import { markHandlerCallback } from "../../src/kit/handler.js";
 import { Accordion } from "../../src/kit/feedback/accordion.js";
 import { Menu } from "../../src/kit/feedback/menu.js";
 import { Tooltip } from "../../src/kit/feedback/tooltip.js";
+import { Checkbox } from "../../src/kit/forms/checkbox.js";
 import { Combobox } from "../../src/kit/forms/combobox.js";
 import { DateRange } from "../../src/kit/forms/date-range.js";
 import { Radio } from "../../src/kit/forms/radio.js";
@@ -56,6 +57,19 @@ function Screen<T>({ initial, render: renderControl }: {
     }));
   return <>{renderControl(value, fire)}</>;
 }
+
+describe("Checkbox", () => {
+  it("is a checkbox by role, and a screen-bound one keeps toggling", () => {
+    render(<Screen initial={false} render={(on, fire) => <Checkbox label="Paid" checked={on} onChange={fire} />} />);
+    const box = () => screen.getByRole("checkbox", { name: "Paid" });
+
+    fireEvent.click(box());
+    expect(box().getAttribute("aria-checked")).toBe("true");
+    // The toggle BACK is the freeze detector.
+    fireEvent.click(box());
+    expect(box().getAttribute("aria-checked")).toBe("false");
+  });
+});
 
 describe("Switch", () => {
   it("is a switch by role, and a screen-bound one keeps flipping", () => {

--- a/packages/ui/test/setup.ts
+++ b/packages/ui/test/setup.ts
@@ -69,6 +69,17 @@ globalThis.getComputedStyle = ((element: Element, pseudoElement?: string | null)
     : ({ content: "none", display: "inline", visibility: "visible" } as unknown as CSSStyleDeclaration)
 ) as typeof globalThis.getComputedStyle;
 
+/**
+ * jsdom ships no `PointerEvent`, and Base UI's Checkbox, Switch and Radio
+ * forward a click to their hidden input by CONSTRUCTING one — without the
+ * constructor the root throws and the control never moves. A real browser has
+ * it, so this is an environment gap, not a component one. (`MouseEvent` is the
+ * jsdom-only guard: the node-environment files have neither.)
+ */
+if (typeof MouseEvent === "function" && typeof PointerEvent !== "function") {
+  globalThis.PointerEvent = class extends MouseEvent {} as unknown as typeof PointerEvent;
+}
+
 const nativeFetch = globalThis.fetch;
 
 globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {


### PR DESCRIPTION
## ⛔ BLOCKED — do not merge as-is

The lane was scoped on the premise that Checkbox's Base UI failures were a jsdom
`PointerEvent` artifact. **Half of that is true and now proven; half of it is not.**

The polyfill is real and lands (commit 1). The migration (commit 2) is pushed as
**evidence**, not as a merge candidate: three pre-existing kit assertions fail for a
structural reason no polyfill can reach.

## What actually happens

Base UI's `Checkbox.Root` renders the accessible control as a
`<span role="checkbox">` with a visually hidden, `aria-hidden` `<input type="checkbox">`
beside it (`@base-ui/react@1.7.0`, `checkbox/root/CheckboxRoot.mjs:194–197, 256–265`).

| frozen assertion | fails because |
| --- | --- |
| `base-ui-migration.test.tsx:59,63` — `box().checked` | `.checked` lives on the hidden input; off the span it reads `undefined` |
| `handler.test.tsx:94,145` — `getByLabelText("Include paid")` | the label matches the input (`for=`) **and** the span (`aria-labelledby=`) → "Found multiple elements" |

Neither is reachable by any prop on `Checkbox.Root`. `nativeButton` was tried and made
it worse (log below). This is the same class of DOM-contract decision Select is
being held for.

Per the brief I stopped rather than adapt a frozen test. **No existing assertion was
edited.**

## What is proven

**The polyfill works.** `forms.test.tsx`'s "Checkbox toggles and reports its checked
state" — the case that convinced everyone Base UI's checkbox was broken — now passes
against the migrated component.

*Negative control*: with the polyfill removed, that same case fails with `expected
"spy" to be called with arguments: [ true ]` — the spy is never called at all, i.e.
the control does not move.

**The migrated component is correct.** Headed Chromium, real X display:

| | before (native input) | after (Base UI) |
| --- | --- | --- |
| click | `true → false` | `true → false` |
| Space | `false → true` | `false → true` |
| focus ring | `2px solid rgb(17,17,17)` | `2px solid rgb(17,17,17)` |
| footprint | 16×16 | 16×16 |
| element | `INPUT` | `SPAN` |

Screenshots: `/tmp/checkbox-{before,after}-{resting,after-click,focus-ring}.png`.
The only visible delta is the corner radius — the migrated box uses the Kit's own
`--vendo-radius-small` (6px) where the native box used Chrome's UA ~3px. The 18px→16px
footprint drift the browser caught is fixed with `boxSizing: "border-box"`; a green
unit suite would never have seen it.

**New test, with its negative control.** One added to `base-ui-bricks.test.tsx`
alongside Switch and Radio: the `aria-checked` freeze detector. Against the
*unmigrated* native input it fails `expected null to be 'true'`; against the migrated
component it passes.

## Gate

| step | result |
| --- | --- |
| `turbo build --concurrency=2` | 21/21 |
| `packages/ui` kit + tree + ssr | **3 failed / 466 passed** — the three above, nothing else |
| `packages/apps` contract | 271 passed, 1 skipped |
| `turbo typecheck` | 42/42 |
| `pnpm lint` | 0 errors (4 pre-existing demo-bank warnings) |

## The decision

The frozen assertions test the *rendered node's DOM shape*, not the component's
behavior — `.checked` on the element the query returned, and a label that matches
exactly one node. Both are implementation details of "it is a native input".

1. **Update those three assertions** to `aria-checked` / `getAllByLabelText`, and land
   the migration. (What Switch and Radio already did when they migrated.)
2. **Hold Checkbox** with Select and revisit both DOM contract changes together.
3. Keep Checkbox native forever.

Not my call — flagging it rather than picking.

## Untouched

Select, the demo document, genbench, `vendo-web`, the preview servers, and the local
`PointerEvent` shim already in `base-ui-bricks.test.tsx` (now redundant with the setup
copy; left alone deliberately — a test-file cleanup is its own change).

Changeset: `.changeset/kit-checkbox-on-base-ui.md`, `@vendoai/ui: minor`, worded as an
internals swap because `CheckboxProps` is unchanged to the byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates `Checkbox` to `@base-ui/react` and adds a jsdom `PointerEvent` polyfill so clicks forward in tests. Users keep the same API and behavior; the rendered control changes from a native `<input>` to a `<span role="checkbox">` with a hidden `<input>`, which impacts DOM-shape tests.

- Swaps to `@base-ui/react` (`Base.Root`/`Base.Indicator`, pinned `1.7.0`); `CheckboxProps` and `onChange` semantics are unchanged. The 16px footprint and focus ring are preserved via the style-as-state callback.
- Adds a `PointerEvent` polyfill in `packages/ui/test/setup.ts` to match real browsers; without it, jsdom prevents state changes.
- Adds an `aria-checked` toggle test in `base-ui-bricks.test.tsx`.
- Three existing tests fail due to the DOM contract: reading `.checked` off the role element now returns `undefined`, and `getByLabelText` is ambiguous because the label associates to both the span and the hidden input.

**Required actions to unblock**
- Update the failing assertions to read `aria-checked` (or query by role) and use `getAllByLabelText` or `getByRole('checkbox', { name })`.
- Decide whether to land with updated tests or hold this with `Select` for a combined DOM-contract change.

<sup>Written for commit 4a846b6bb9ea603a57409b718bef2499e6b381d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



---

**Held, not rejected — closed unmerged by decision.**

Migrating Checkbox to Base UI changes its rendered DOM: `<span role="checkbox">` plus a visually hidden input, so `.checked` no longer reads off the queried node and `getByLabelText` matches two elements. That is a contract break for any host testing against Checkbox's DOM today. Switch and Radio changed the same way when they migrated, but they were new bricks with no prior contract to break; Checkbox has one.

Select is held for exactly the same reason, so the two are bundled as one future announced change rather than shipped piecemeal.

**Worth keeping from this work:** the blocker was *partly* environmental and that part is now understood. jsdom ships no `PointerEvent`, and Base UI's Checkbox/Switch/Radio construct one to forward the click — so the control never moves under test. A three-line polyfill in the test setup fixes it, negative-controlled here. Whoever picks up the Checkbox/Select migration should start from this branch rather than rediscovering that.

Also verified along the way: the migrated component itself is correct in a real browser — click and Space both toggle, focus ring identical, and an 18px→16px footprint drift was found and fixed with `box-sizing`. The only remaining visual delta was corner radius (the Kit's 6px vs Chrome's UA ~3px).
