### PR TITLE
test(ui): the ui tests come under the typechecker

### DIFF
--- a/.changeset/the-ui-tests-come-under-the-typechecker.md
+++ b/.changeset/the-ui-tests-come-under-the-typechecker.md
@@ -1,0 +1,11 @@
+---
+"@vendoai/ui": minor
+---
+
+The ui test suite comes under the typechecker.
+
+`packages/ui` was the only package of fourteen whose tests never typechecked. `tsconfig.test.json` existed but its `include` was scoped to the `*.test-d.tsx` type-level suites, because the runtime tests under `test/` carried 135 pre-existing errors. The include now covers all of `test/`, and `pnpm typecheck` is clean over it — so a ui test can no longer be quietly wrong about the API it exercises.
+
+The errors were fixed, not silenced: no `any`, no `@ts-ignore`, no `@ts-expect-error`. Six kinds of debt came out of it — fixtures that never learned about a field the type gained (`risks`, `triggerId`, `Trigger.id`, `ToolDescriptor.description`, `VendoAppRef.status`), fixtures still naming a field the type had dropped or renamed (`GrantSetPermission.description`, `ToolDescriptor.critical` → `confirmEach`), imports pointing at the wrong module (`Thread`, `VENDO_TREE_FORMAT`, `InClientVenue`), tree fixtures declaring themselves `UIPayload` while being handed to `TreeView`'s `WalkTree` prop, DOM reads that ignored `noUncheckedIndexedAccess`, and helpers whose parameter types had been inferred from one call site. No assertion changed meaning and no test was added or removed; all 1206 still pass.
+
+One type widened as a result. `HostComponentsInput` was `Record<string, ComponentType> | ComponentRegistry`, which rejected every host component that declares required props — `ComponentType` defaults its props to `{}` — and could not express a map mixing a plain component with a registry entry, which is exactly what `hostComponentMap` has always read per entry. It is now `Record<string, ComponentType<never> | ComponentRegistryEntry>`. Purely a widening: everything that typechecked before still does, and nothing at runtime changed.

--- a/packages/ui/src/context.tsx
+++ b/packages/ui/src/context.tsx
@@ -1,6 +1,5 @@
 /** VendoProvider + the internal context every hook and surface reads (08 §2). */
 import type {
-  ComponentRegistry,
   ComponentRegistryEntry,
   VendoNavigation,
   VendoRouteMap,
@@ -85,14 +84,17 @@ export const VendoContext = createContext<VendoContextValue | null>(null);
 
 /** 08 §2 (amended 2026-07-18): the components input — the plain name→component
  * map, or the 01 §14 name-keyed ComponentRegistry (the same object the server
- * takes as `catalog`). */
-export type HostComponentsInput = Record<string, ComponentType> | ComponentRegistry;
+ * takes as `catalog`). The choice is per ENTRY, which is how hostComponentMap
+ * has always read it; a union of the two whole-map forms could not express a
+ * mixed one. `ComponentType<never>` because a host component declares its own
+ * required props and `ComponentType`'s default `{}` rejects every one of them. */
+export type HostComponentsInput = Record<string, ComponentType<never> | ComponentRegistryEntry>;
 
 /** Safe narrow: a plain-map value is a function/class component or an exotic
  * React component object ($$typeof/render/type — never a `component` field),
  * while a registry entry always carries `component` plus its REQUIRED string
  * `description` (01 §14). Both checks together rule out misdetection. */
-function isRegistryEntry(value: ComponentType | ComponentRegistryEntry): value is ComponentRegistryEntry {
+function isRegistryEntry(value: ComponentType<never> | ComponentRegistryEntry): value is ComponentRegistryEntry {
   return typeof value === "object" && value !== null
     && "component" in value
     && typeof (value as ComponentRegistryEntry).description === "string";
@@ -105,7 +107,7 @@ export function hostComponentMap(components: HostComponentsInput | undefined): R
   if (components === undefined) return {};
   const map: Record<string, ComponentType> = {};
   for (const [name, value] of Object.entries(components)) {
-    map[name] = isRegistryEntry(value) ? (value.component as ComponentType) : value;
+    map[name] = (isRegistryEntry(value) ? value.component : value) as ComponentType;
   }
   return map;
 }

--- a/packages/ui/test/chrome/add-to-picker.test.tsx
+++ b/packages/ui/test/chrome/add-to-picker.test.tsx
@@ -173,7 +173,7 @@ describe("placing a generated view from the conversation the user is actually in
     await waitFor(() => expect(wire.state.slots).toHaveLength(slots.length));
     render(
       <VendoProvider client={client} pinSlot="home-hero">
-        <ThreadPart part={view(appId)} partKey="p0" role="assistant" restored={false} />
+        <ThreadPart part={view(appId)} partKey="p0" role="assistant" restored={false} risks={new Map()} />
       </VendoProvider>,
     );
   }

--- a/packages/ui/test/chrome/affordances-eng225.test.tsx
+++ b/packages/ui/test/chrome/affordances-eng225.test.tsx
@@ -372,7 +372,7 @@ describe("connect dock + tray (ENG-225)", () => {
     // broker), then navigated to the real OAuth URL once initiate resolves. The
     // stand-in is what a browser that ALLOWS the popup hands back.
     const popup = { location: { replace: vi.fn() }, close: vi.fn() };
-    const open = vi.fn(() => popup);
+    const open = vi.fn((_url: string, _target: string, _features: string) => popup);
     vi.stubGlobal("open", open);
     render(
       <VendoProvider client={client} connectors={CONNECTORS}><VendoThread threadId="thr_1" /></VendoProvider>,
@@ -525,7 +525,7 @@ describe("connect dock + tray (ENG-225)", () => {
   // the other. Pre-existing in the panel post-#1051; the tray's old
   // surface-wide `disabled` was hiding it here.
   it("gives each concurrent connect its own sign-in window", async () => {
-    const open = vi.fn(() => ({ location: { replace: vi.fn() }, close: vi.fn() }));
+    const open = vi.fn((_url: string, _target: string, _features: string) => ({ location: { replace: vi.fn() }, close: vi.fn() }));
     vi.stubGlobal("open", open);
     holdThePoll();
     const tray = await openTray();

--- a/packages/ui/test/chrome/approval-and-notice.test.tsx
+++ b/packages/ui/test/chrome/approval-and-notice.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import type { VendoTheme } from "@vendoai/apps/contract";
 import type { ApprovalRequest } from "@vendoai/core";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -120,8 +121,10 @@ describe("ApprovalCard and NoPolicyNotice exports", () => {
   });
 
   it("injects the chrome stylesheet once and applies resolved theme variables", () => {
+    // `theme` is a SHALLOW `Partial<VendoTheme>`, so overriding ONE color needs a
+    // cast; resolveTheme spreads `colors` over the defaults at runtime.
     render(
-      <VendoProvider client={client} theme={{ colors: { accent: "rgb(1, 2, 3)" } }}>
+      <VendoProvider client={client} theme={{ colors: { accent: "rgb(1, 2, 3)" } as VendoTheme["colors"] }}>
         <ApprovalCard approval={approval} onDecide={() => undefined} />
         <ApprovalCard approval={{ ...approval, id: "apr_2" }} onDecide={() => undefined} />
       </VendoProvider>,

--- a/packages/ui/test/chrome/approval-degraded.test.tsx
+++ b/packages/ui/test/chrome/approval-degraded.test.tsx
@@ -123,7 +123,7 @@ describe("degraded data never changes the card", () => {
       <VendoProvider client={client}>
         <GrantSetCard
           name="Renewal digest"
-          permissions={[{ approvalId: "apr_1", tool: "slack_SLACK_SEND_MESSAGE", description: "Post digests.", risk: "write" }]}
+          permissions={[{ approvalId: "apr_1", tool: "slack_SLACK_SEND_MESSAGE", risk: "write" }]}
           state="parked"
         />
       </VendoProvider>,
@@ -492,7 +492,7 @@ describe("the plain-words line says what happens, not which tool", () => {
       args: { amount_cents: 4750, recipient_name: "Acme Utilities" },
       risk: "write",
     }, {});
-    expect(graded.descriptor.critical).toBeUndefined();
+    expect(graded.descriptor.confirmEach).toBeUndefined();
     const notes = notesOf(show(graded));
     expect(notes).not.toContain("Nobody has checked what this changes");
     expect(notes).not.toContain("Can’t be undone");

--- a/packages/ui/test/chrome/approval-modal.test.tsx
+++ b/packages/ui/test/chrome/approval-modal.test.tsx
@@ -110,7 +110,7 @@ describe("the screen-initiated approval modal", () => {
       mount(clientWith({
         get: pending({
           call: { id: "call_2", tool: "host_archiveProject", args: { project: "Orion", notify_team: true } },
-          descriptor: { name: "host_archiveProject", title: "Archive project", inputSchema: {}, risk: "destructive" },
+          descriptor: { name: "host_archiveProject", title: "Archive project", description: "", inputSchema: {}, risk: "destructive" },
         }),
       }));
       await waitFor(() => expect(ask()).toBe("Archive project?"));
@@ -420,7 +420,7 @@ describe("the screen-initiated approval modal", () => {
     it("the BYO chat surface's app embed", async () => {
       render(
         <VendoProvider client={parking({ open: async () => ({ kind: "tree", payload: PAYEES }) })}>
-          <VendoAppEmbed refValue={{ kind: "vendo/app-ref@1", appId: "app_1", title: "Payees" }} />
+          <VendoAppEmbed refValue={{ kind: "vendo/app-ref@1", appId: "app_1", title: "Payees", status: "building" }} />
         </VendoProvider>,
       );
       await press();

--- a/packages/ui/test/chrome/automation-card.test.tsx
+++ b/packages/ui/test/chrome/automation-card.test.tsx
@@ -79,6 +79,7 @@ describe("AutomationCard", () => {
           description="Emails you when checking dips below $2,000."
           sponsor={{ subject: "user_1", display: "Dana" }}
           trigger={{
+            id: "main",
             on: { kind: "schedule", cron: "0 8 * * *" },
             run: { kind: "steps", steps: [{ id: "balance", tool: "host_listAccounts" }] },
           }}
@@ -115,6 +116,7 @@ describe("AutomationCard", () => {
             enabled
             description={description}
             trigger={{
+              id: "main",
               on: { kind: "schedule", cron: "0 8 * * *" },
               run: { kind: "steps", steps: [{ id: "balance", tool: "host_listAccounts" }] },
             }}
@@ -165,6 +167,7 @@ describe("AutomationCard", () => {
           name="Low balance alert"
           enabled={false}
           trigger={{
+            id: "main",
             on: { kind: "schedule", cron: "0 8 * * *" },
             run: { kind: "steps", steps: [{ id: "balance", tool: "host_listAccounts" }] },
           }}

--- a/packages/ui/test/chrome/card-shell.test.tsx
+++ b/packages/ui/test/chrome/card-shell.test.tsx
@@ -66,7 +66,7 @@ const KINDS: Array<[string, React.ReactNode]> = [
     "standing access",
     <GrantSetCard
       name="Invoice watcher"
-      permissions={[{ approvalId: "apr_1", tool: "host_email_send", description: "Send digests.", risk: "read" }]}
+      permissions={[{ approvalId: "apr_1", tool: "host_email_send", risk: "read" }]}
       state="parked"
     />,
   ],

--- a/packages/ui/test/chrome/connect.test.tsx
+++ b/packages/ui/test/chrome/connect.test.tsx
@@ -17,7 +17,7 @@ function fakePopup() {
 /** Stub `window.open` with what a browser that ALLOWS the popup returns. */
 function allowPopups() {
   const popup = fakePopup();
-  const open = vi.fn(() => popup);
+  const open = vi.fn<typeof window.open>(() => popup);
   vi.stubGlobal("open", open);
   return { popup, open };
 }
@@ -78,7 +78,7 @@ describe("ConnectCard", () => {
     expect(wire.requests.some(request => request.path === "/connections/initiate")).toBe(false);
     // …and centered on the screen, at the designed size, rather than dropped
     // in a corner. (jsdom reports a 0x0 screen, so the test states one.)
-    const features = open.mock.calls[0]![2] as string;
+    const features = open.mock.calls[0]![2];
     expect(features).toBe("popup=yes,width=520,height=680,left=540,top=200");
 
     await waitFor(() => expect(onConnected).toHaveBeenCalledTimes(1));

--- a/packages/ui/test/chrome/extreme-content.test.tsx
+++ b/packages/ui/test/chrome/extreme-content.test.tsx
@@ -5,9 +5,8 @@
 // transcript can be mounted deterministically.
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
-import type { Thread } from "@vendoai/core";
 import type { UIMessage } from "ai";
-import { VendoProvider, createVendoClient, type VendoClient } from "../../src/index.js";
+import { VendoProvider, createVendoClient, type Thread, type VendoClient } from "../../src/index.js";
 import { VendoThread } from "../../src/chrome/index.js";
 import { LONG_TEXT_CAP, truncateHead } from "../../src/chrome/truncate.js";
 

--- a/packages/ui/test/chrome/knowledge-citation-hover.test.tsx
+++ b/packages/ui/test/chrome/knowledge-citation-hover.test.tsx
@@ -50,6 +50,8 @@ describe("citation card reachability (Knowledge K1)", () => {
   });
 
   const chips = () => [...document.querySelectorAll<HTMLElement>(".fl-cite")];
+  // One chip per citation, so an index this fixture names is always rendered.
+  const chip = (index: number) => chips()[index]!;
   const openChips = () => [...document.querySelectorAll(".fl-cite--open")];
   const button = (name: RegExp) => screen.getByRole("button", { name });
 
@@ -58,7 +60,7 @@ describe("citation card reachability (Knowledge K1)", () => {
   it("opens the card on hover and holds it through the grace on the way out", () => {
     vi.useFakeTimers();
     mount();
-    const [first] = chips();
+    const first = chip(0);
 
     fireEvent.pointerEnter(first);
     expect(button(/Refunds & cancellations/).getAttribute("aria-expanded")).toBe("true");
@@ -76,7 +78,7 @@ describe("citation card reachability (Knowledge K1)", () => {
   it("arriving on the card cancels the pending close", () => {
     vi.useFakeTimers();
     mount();
-    const [first] = chips();
+    const first = chip(0);
 
     fireEvent.pointerEnter(first);
     fireEvent.pointerLeave(first);
@@ -91,7 +93,7 @@ describe("citation card reachability (Knowledge K1)", () => {
   it("a click pins the card, so it survives the pointer leaving", () => {
     vi.useFakeTimers();
     mount();
-    const [first] = chips();
+    const first = chip(0);
 
     fireEvent.pointerEnter(first);
     fireEvent.click(button(/Refunds & cancellations/));
@@ -121,7 +123,8 @@ describe("citation card reachability (Knowledge K1)", () => {
 
   it("entering another chip closes the first — never two cards at once", () => {
     mount();
-    const [first, second] = chips();
+    const first = chip(0);
+    const second = chip(1);
 
     fireEvent.pointerEnter(first);
     fireEvent.pointerEnter(second);
@@ -132,7 +135,7 @@ describe("citation card reachability (Knowledge K1)", () => {
 
   it("a pinned card gives way to another chip's hover too", () => {
     mount();
-    const [, second] = chips();
+    const second = chip(1);
 
     fireEvent.click(button(/Refunds & cancellations/));
     fireEvent.pointerEnter(second);

--- a/packages/ui/test/chrome/lane-thread-picks.test.tsx
+++ b/packages/ui/test/chrome/lane-thread-picks.test.tsx
@@ -75,7 +75,7 @@ describe("lane pick 4B — landing starter cards", () => {
         <VendoThread
           discoverability="quiet"
           suggestions={[
-            { title: "Build a view", prompt: "Build me a renewals view" },
+            { title: "Build a view", description: "Renewals sorted by risk", prompt: "Build me a renewals view" },
             "Build me a subscriptions tracker",
             "Where did my dining budget go?",
           ]}
@@ -94,7 +94,7 @@ describe("lane pick 4B — landing starter cards", () => {
   it("cards without strings render no chip row and no micro-label", async () => {
     render(
       <VendoProvider client={client}>
-        <VendoThread discoverability="quiet" suggestions={[{ title: "Build a view", prompt: "p" }]} />
+        <VendoThread discoverability="quiet" suggestions={[{ title: "Build a view", description: "Renewals sorted by risk", prompt: "p" }]} />
       </VendoProvider>,
     );
     await screen.findByRole("button", { name: /Build a view/ });

--- a/packages/ui/test/chrome/mobile-takeover.test.tsx
+++ b/packages/ui/test/chrome/mobile-takeover.test.tsx
@@ -127,7 +127,7 @@ describe("mobile takeover (ENG-228)", () => {
     const { container } = render(
       <VendoProvider client={client}><VendoPalette /><VendoOverlay launcher="none" /></VendoProvider>,
     );
-    fireEvent.keyDown(globalThis, { key: "k", ctrlKey: true });
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true });
     const dialog = await screen.findByRole("dialog", { name: "Vendo assistant" });
     expect(dialog.classList.contains("fl-takeover")).toBe(true);
     expect(container.contains(dialog)).toBe(false);
@@ -139,7 +139,7 @@ describe("mobile takeover (ENG-228)", () => {
     render(
       <VendoProvider client={client}><VendoPalette /><VendoOverlay launcher="none" /></VendoProvider>,
     );
-    fireEvent.keyDown(globalThis, { key: "k", ctrlKey: true });
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true });
     const dialog = await screen.findByRole("dialog", { name: "Vendo assistant" });
     expect(dialog.classList.contains("fl-takeover")).toBe(false);
   });
@@ -182,11 +182,11 @@ describe("mobile takeover (ENG-228)", () => {
       </VendoProvider>,
     );
     expect(panel()).toBeTruthy();
-    fireEvent.keyDown(globalThis, { key: "k", ctrlKey: true });
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true });
     await waitFor(() => expect(screen.queryByRole("dialog", { name: "Vendo assistant" })).toBeNull());
     // No palette dialog ever mounts — the keybinding owns ONE surface.
     expect(screen.queryByRole("dialog", { name: "Vendo command palette" })).toBeNull();
-    fireEvent.keyDown(globalThis, { key: "k", ctrlKey: true });
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true });
     expect(await screen.findByRole("dialog", { name: "Vendo assistant" })).toBeTruthy();
   });
 

--- a/packages/ui/test/chrome/palette-singleton.test.tsx
+++ b/packages/ui/test/chrome/palette-singleton.test.tsx
@@ -34,7 +34,7 @@ describe("VendoPalette singleton, host-collision-safe keybinding", () => {
       </VendoProvider>,
     );
     screen.getByRole("button", { name: "Opener" }).focus();
-    fireEvent.keyDown(globalThis, { key: "k", metaKey: true });
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
     // The keybinding TOGGLES the one-surface overlay: double delivery (the
     // pre-ENG-222 bug) would toggle twice and leave it closed. Exactly one
     // delivery leaves exactly one open dialog.
@@ -67,10 +67,10 @@ describe("VendoPalette singleton, host-collision-safe keybinding", () => {
     );
     screen.getByRole("button", { name: "Opener" }).focus();
     // The default ⌘K no longer opens a surface bound to ⌘J.
-    fireEvent.keyDown(globalThis, { key: "k", metaKey: true });
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
     expect(screen.queryByRole("dialog", { name: "Vendo assistant" })).toBeNull();
     // The configured chord opens it.
-    fireEvent.keyDown(globalThis, { key: "j", metaKey: true });
+    fireEvent.keyDown(window, { key: "j", metaKey: true });
     const dialog = await screen.findByRole("dialog", { name: "Vendo assistant" });
     expect(dialog).toBeTruthy();
     // Close it before disabling (disabling stops the keybinding, it doesn't
@@ -87,8 +87,8 @@ describe("VendoPalette singleton, host-collision-safe keybinding", () => {
       </VendoProvider>,
     );
     await waitFor(() => expect(screen.queryByRole("dialog", { name: "Vendo assistant" })).toBeNull());
-    fireEvent.keyDown(globalThis, { key: "k", metaKey: true });
-    fireEvent.keyDown(globalThis, { key: "j", metaKey: true });
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    fireEvent.keyDown(window, { key: "j", metaKey: true });
     expect(screen.queryByRole("dialog", { name: "Vendo assistant" })).toBeNull();
   });
 });

--- a/packages/ui/test/chrome/pin-nudge.test.tsx
+++ b/packages/ui/test/chrome/pin-nudge.test.tsx
@@ -8,10 +8,9 @@
 // The state rides ONE attribute on the EXISTING button (`data-vendo-pin`), the
 // same shape `data-vendo-suggest` uses on the expand affordance: no new button,
 // no new component, no toast.
-import type { Thread } from "@vendoai/core";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { VendoProvider, createVendoClient, type VendoClient } from "../../src/index.js";
+import { VendoProvider, createVendoClient, type Thread, type VendoClient } from "../../src/index.js";
 import { VendoOverlay, VendoThread, type VendoThreadProps } from "../../src/chrome/index.js";
 import { ThreadPart } from "../../src/chrome/thread/parts.js";
 import { createWireServer } from "../wire-server.js";
@@ -56,7 +55,7 @@ describe("the pin nudge on the in-thread card", () => {
   function card(appId: string, restored: boolean, streaming = false) {
     render(
       <VendoProvider client={client} onPin={() => {}}>
-        <ThreadPart part={view(appId, "Spending board", streaming)} partKey="p0" role="assistant" restored={restored} />
+        <ThreadPart part={view(appId, "Spending board", streaming)} partKey="p0" role="assistant" restored={restored} risks={new Map()} />
       </VendoProvider>,
     );
   }

--- a/packages/ui/test/chrome/slot-discovery.test.tsx
+++ b/packages/ui/test/chrome/slot-discovery.test.tsx
@@ -4,15 +4,15 @@
 // poller per client — every mounted slot rides the same GET /apps/placements.
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { VendoProvider, createVendoClient, useSlotApp, type VendoClient } from "../../src/index.js";
+import { VendoProvider, createVendoClient, useSlotApp, type PlacementEntry, type VendoClient } from "../../src/index.js";
 import { VendoSlot } from "../../src/chrome/index.js";
 import { createWireServer } from "../wire-server.js";
 
-const entry = (overrides: Partial<{ slot: string; app: string; title: string; status: string }> = {}) => ({
+const entry = (overrides: Partial<PlacementEntry> = {}): PlacementEntry => ({
   slot: "hero",
   app: "app_1",
   title: "Invoices",
-  status: "ready" as const,
+  status: "ready",
   ...overrides,
 });
 

--- a/packages/ui/test/chrome/split-view.test.tsx
+++ b/packages/ui/test/chrome/split-view.test.tsx
@@ -4,11 +4,10 @@
 // tests then pin the overlay behaviors: expand/collapse without a thread
 // remount, feature selection from the rail, the Escape order (collapse first,
 // close second), and the subtle expand suggestion when an embed lands.
-import type { Thread } from "@vendoai/core";
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { useEffect, useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { VendoProvider, createVendoClient, type VendoClient } from "../../src/index.js";
+import { VendoProvider, createVendoClient, type Thread, type VendoClient } from "../../src/index.js";
 import { VendoOverlay, VendoThread, type VendoThreadProps } from "../../src/chrome/index.js";
 import {
   escapeIntent,
@@ -430,7 +429,8 @@ describe("VendoOverlay split view", () => {
     }, [appIds]);
     useEffect(() => {
       if (split === null) return;
-      for (const appId of appIds.slice(0, arrived)) split.autoStage(appId);
+      // Build keys as parts.tsx forms them: `${message.id}-${index}-${appId}`.
+      for (const [index, appId] of appIds.slice(0, arrived).entries()) split.autoStage(appId, `msg_1-${index}-${appId}`);
     }, [split, appIds, arrived]);
     return null;
   }

--- a/packages/ui/test/chrome/status-beats.test.tsx
+++ b/packages/ui/test/chrome/status-beats.test.tsx
@@ -28,7 +28,7 @@ import { createWireServer } from "../wire-server.js";
 describe("the status channel reaches the screen", () => {
   let wire: Awaited<ReturnType<typeof createWireServer>>;
   let client: VendoClient;
-  let release = () => undefined;
+  let release: () => void = () => undefined;
 
   beforeEach(async () => {
     wire = await createWireServer();

--- a/packages/ui/test/chrome/stopped-build-card.test.tsx
+++ b/packages/ui/test/chrome/stopped-build-card.test.tsx
@@ -41,6 +41,8 @@ function renderTurn(busy: boolean, restored = false) {
         busy={busy}
         activeAssistantId={busy ? message.id : undefined}
         lastAssistantId={message.id}
+        onEditLast={() => undefined}
+        onRegenerateLast={() => undefined}
       />
     </VendoProvider>,
   );

--- a/packages/ui/test/chrome/theme-fonts.test.tsx
+++ b/packages/ui/test/chrome/theme-fonts.test.tsx
@@ -1,10 +1,10 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, render, waitFor } from "@testing-library/react";
-import { VENDO_TREE_FORMAT, type ToolOutcome, type UIPayload } from "@vendoai/core";
+import { VENDO_TREE_FORMAT, type ToolOutcome } from "@vendoai/core";
 import { ChromeRoot } from "../../src/chrome/index.js";
 import { VendoProvider } from "../../src/context.js";
-import { TreeView } from "../../src/tree/index.js";
+import { TreeView, type WalkTree } from "../../src/tree/index.js";
 
 /**
  * Generated code mounts natively in the host page now (`InClientMount`), so the
@@ -24,7 +24,7 @@ afterEach(() => {
     .forEach((style) => style.remove());
 });
 
-const generatedTree: UIPayload = {
+const generatedTree: WalkTree & { formatVersion: typeof VENDO_TREE_FORMAT } = {
   formatVersion: VENDO_TREE_FORMAT,
   root: "root",
   nodes: [

--- a/packages/ui/test/chrome/thread-and-overlay.test.tsx
+++ b/packages/ui/test/chrome/thread-and-overlay.test.tsx
@@ -23,7 +23,7 @@ describe("VendoThread and VendoOverlay exports", () => {
   // whole workspace's suites in parallel, so this heavy integration test can
   // starve past the 5s default under load (275ms locally, ~7s on a loaded runner).
   it("runs a complete wire turn, renders receipts and approvals, and honors composer keys", { timeout: 20_000 }, async () => {
-    let release = () => undefined;
+    let release: () => void = () => undefined;
     wire.state.threadReplyGate = new Promise<void>(resolve => { release = resolve; });
     render(<VendoProvider client={client}><VendoThread threadId="thr_1" /></VendoProvider>);
     expect(await screen.findByText("Existing thread")).toBeTruthy();
@@ -122,7 +122,7 @@ describe("VendoThread and VendoOverlay exports", () => {
   // must keep a live row whatever text precedes it — since spec §1 that row is
   // the transcript's own beat, not the ribbon.
   it("keeps a live beat on a running tool call after text has streamed", { timeout: 20_000 }, async () => {
-    let release = () => undefined;
+    let release: () => void = () => undefined;
     wire.state.threadReplyGate = new Promise<void>(resolve => { release = resolve; });
     render(<VendoProvider client={client}><VendoThread threadId="thr_1" /></VendoProvider>);
     expect(await screen.findByText("Existing thread")).toBeTruthy();
@@ -158,7 +158,7 @@ describe("VendoThread and VendoOverlay exports", () => {
   // the list TAIL (was a WorkingRibbon pill above the composer), and it waits
   // out an 800ms debounce so the end-of-stream teardown never flashes it.
   it("shows the working beat in the settled-tools busy gap and drops it when the turn closes", { timeout: 20_000 }, async () => {
-    let release = () => undefined;
+    let release: () => void = () => undefined;
     wire.state.threadReplyGate = new Promise<void>(resolve => { release = resolve; });
     render(<VendoProvider client={client}><VendoThread threadId="thr_1" /></VendoProvider>);
     expect(await screen.findByText("Existing thread")).toBeTruthy();
@@ -197,7 +197,7 @@ describe("VendoThread and VendoOverlay exports", () => {
   // M22 — a REFUSED ask is terminal. It used to count as a live step forever, so
   // the between-steps indicator never returned for the rest of the turn.
   it("brings the working beat back after a denial — a refused ask is not live", { timeout: 20_000 }, async () => {
-    let release = () => undefined;
+    let release: () => void = () => undefined;
     wire.state.threadReplyGate = new Promise<void>(resolve => { release = resolve; });
     render(<VendoProvider client={client}><VendoThread threadId="thr_1" /></VendoProvider>);
     expect(await screen.findByText("Existing thread")).toBeTruthy();

--- a/packages/ui/test/chrome/tool-humanization.test.tsx
+++ b/packages/ui/test/chrome/tool-humanization.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
-import type { ApprovalRequest, Thread } from "@vendoai/core";
+import type { ApprovalRequest } from "@vendoai/core";
 import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { VendoProvider, createVendoClient, type ToolMetaMap, type VendoClient } from "../../src/index.js";
+import { VendoProvider, createVendoClient, type Thread, type ToolMetaMap, type VendoClient } from "../../src/index.js";
 import { ApprovalCard, BuildBeat, VendoThread } from "../../src/chrome/index.js";
 import { createWireServer } from "../wire-server.js";
 

--- a/packages/ui/test/chrome/transcript-beats.test.tsx
+++ b/packages/ui/test/chrome/transcript-beats.test.tsx
@@ -7,11 +7,10 @@
  *  no beat because its card IS that step, and a FAILED turn grows no failure
  *  furniture at all — the ✕ stays in the record and the agent's prose carries
  *  the recovery. */
-import type { Thread } from "@vendoai/core";
 import type { UIMessage } from "ai";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { VendoProvider, createVendoClient, type VendoClient } from "../../src/index.js";
+import { VendoProvider, createVendoClient, type Thread, type VendoClient } from "../../src/index.js";
 import { VendoThread } from "../../src/chrome/index.js";
 import { toolResultSummary } from "../../src/chrome/build-beat.js";
 import { SplitViewContext, type SplitViewContextValue } from "../../src/chrome/split-view.js";
@@ -116,7 +115,7 @@ describe("the transcript's beats", () => {
   // position while the call runs, ticks when it settles, and the closed turn
   // folds it into one row that reopens on click.
   it("beats a running call in-transcript, then folds the settled turn into one reopenable row", { timeout: 20_000 }, async () => {
-    let release = () => undefined;
+    let release: () => void = () => undefined;
     wire.state.threadReplyGate = new Promise<void>(resolve => { release = resolve; });
     render(<VendoProvider client={client}><VendoThread threadId="thr_1" /></VendoProvider>);
     expect(await screen.findByText("Existing thread")).toBeTruthy();

--- a/packages/ui/test/chrome/user-bubble.test.tsx
+++ b/packages/ui/test/chrome/user-bubble.test.tsx
@@ -9,10 +9,9 @@
 //     sent text paints as a blank line (host sendMessage / prefill bridges
 //     can carry one even though the composer trims its own drafts).
 // These tests pin both fixes.
-import type { Thread } from "@vendoai/core";
 import { cleanup, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { VendoProvider, createVendoClient, type VendoClient } from "../../src/index.js";
+import { VendoProvider, createVendoClient, type Thread, type VendoClient } from "../../src/index.js";
 import { VendoThread } from "../../src/chrome/index.js";
 import { CHROME_CSS } from "../../src/chrome/chrome-css.js";
 import { createWireServer } from "../wire-server.js";

--- a/packages/ui/test/chrome/workbench-store.test.ts
+++ b/packages/ui/test/chrome/workbench-store.test.ts
@@ -10,7 +10,7 @@ import {
 
 afterEach(() => resetWorkbench());
 
-function chunk(part: Partial<WorkbenchPart> & { event?: unknown }, type = "data-vendo-debug") {
+function chunk(part: Omit<Partial<WorkbenchPart>, "event"> & { event?: unknown }, type = "data-vendo-debug") {
   return { type, data: { turnId: "thr_a", seq: 1, at: 1_000, agent: "resident", ...part } };
 }
 

--- a/packages/ui/test/chrome/workspace-palette-slot.test.tsx
+++ b/packages/ui/test/chrome/workspace-palette-slot.test.tsx
@@ -34,7 +34,7 @@ describe("VendoPalette and VendoSlot exports", () => {
     await waitFor(() => expect(wire.requests.some(request => request.path === "/apps")).toBe(true));
     const opener = screen.getByRole("button", { name: "Palette opener" });
     opener.focus();
-    fireEvent.keyDown(globalThis, { key: "k", ctrlKey: true });
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true });
     // One surface: the conversation overlay, composer focused, no combobox.
     expect(await screen.findByRole("dialog", { name: "Vendo assistant" })).toBeTruthy();
     expect(screen.queryByRole("combobox")).toBeNull();
@@ -61,7 +61,7 @@ describe("VendoPalette and VendoSlot exports", () => {
     // the Escape/focus assertions below.
     await waitFor(() => expect(screen.queryByRole("dialog", { name: "Vendo assistant" })).toBeNull());
     opener.focus();
-    fireEvent.keyDown(globalThis, { key: "k", ctrlKey: true });
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true });
     await screen.findByRole("dialog", { name: "Vendo assistant" });
     // Escape closes the surface and restores focus to the invoker.
     fireEvent.keyDown(screen.getByRole("dialog", { name: "Vendo assistant" }), { key: "Escape" });
@@ -69,7 +69,7 @@ describe("VendoPalette and VendoSlot exports", () => {
     await waitFor(() => expect(document.activeElement).toBe(opener));
 
     // ⌘K toggles: open, then a second press (even from the composer) closes.
-    fireEvent.keyDown(globalThis, { key: "k", metaKey: true });
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
     await screen.findByRole("dialog", { name: "Vendo assistant" });
     const reopenedComposer = await screen.findByRole("textbox", { name: "Message" });
     await waitFor(() => expect(document.activeElement).toBe(reopenedComposer));
@@ -95,7 +95,7 @@ describe("VendoPalette and VendoSlot exports", () => {
   function Racer({ open }: { open: boolean }) {
     const previous = useRef(open);
     useLayoutEffect(() => {
-      if (previous.current && !open) fireEvent.keyDown(globalThis, { key: "k", metaKey: true });
+      if (previous.current && !open) fireEvent.keyDown(window, { key: "k", metaKey: true });
       previous.current = open;
     }, [open]);
     return null;
@@ -117,7 +117,7 @@ describe("VendoPalette and VendoSlot exports", () => {
     await waitFor(() => expect(wire.requests.some(request => request.path === "/apps")).toBe(true));
     const opener = screen.getByRole("button", { name: "Palette opener" });
     opener.focus();
-    fireEvent.keyDown(globalThis, { key: "k", metaKey: true });
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
     await screen.findByRole("dialog", { name: "Vendo assistant" });
 
     // Close from a host affordance; the Racer's layout effect fires the racing

--- a/packages/ui/test/eject-templates.test.ts
+++ b/packages/ui/test/eject-templates.test.ts
@@ -28,7 +28,11 @@ afterAll(() => {
 describe("eject template assembly", () => {
   it("assembles the thread surface into dist with a generated header and manifest", async () => {
     const { assembleEjectTemplates } = await lib();
-    const manifest = await assembleEjectTemplates(PACKAGE_DIR);
+    // The lib seeds `surfaces` as `{}`, so inference loses the manifest's shape.
+    const manifest = (await assembleEjectTemplates(PACKAGE_DIR)) as {
+      version: string;
+      surfaces: Record<"thread", { component: string; sourceBase: string; sourceDir: string; files: string[] }>;
+    };
 
     const version = (JSON.parse(readFileSync(join(PACKAGE_DIR, "package.json"), "utf8")) as {
       version: string;

--- a/packages/ui/test/embeds.test.tsx
+++ b/packages/ui/test/embeds.test.tsx
@@ -9,6 +9,8 @@ import {
   VendoProvider,
   VendoToolResult,
   createVendoClient,
+  type OpenSurface,
+  type PendingSurface,
   type VendoClient,
 } from "../src/index.js";
 import { createWireServer } from "./wire-server.js";
@@ -372,7 +374,8 @@ describe("existing-agents embeds", () => {
           ...client,
           apps: {
             ...client.apps,
-            open: (() => Promise.resolve({ kind: "pending" })) as VendoClient["apps"]["open"],
+            open: ((): Promise<OpenSurface | PendingSurface> =>
+              Promise.resolve({ kind: "pending" })) as VendoClient["apps"]["open"],
           },
         };
         render(

--- a/packages/ui/test/hooks.test.tsx
+++ b/packages/ui/test/hooks.test.tsx
@@ -410,10 +410,13 @@ describe("headless hooks", () => {
     const nativeApproval = result.current.approvals.find(part => part.type === "dynamic-tool");
     expect(nativeApproval).toMatchObject({ state: "approval-requested" });
 
-    await act(() => result.current.addToolApprovalResponse({
-      id: (nativeApproval as { approval: { id: string } }).approval.id,
-      approved: true,
-    }));
+    // The SDK types this `void | PromiseLike<void>`, which fits neither act() overload.
+    await act(async () => {
+      await result.current.addToolApprovalResponse({
+        id: (nativeApproval as { approval: { id: string } }).approval.id,
+        approved: true,
+      });
+    });
     await waitFor(() => {
       expect(wire.requests.filter(request => request.method === "POST" && request.path === "/threads"))
         .toHaveLength(2);

--- a/packages/ui/test/kit/data-table.test.tsx
+++ b/packages/ui/test/kit/data-table.test.tsx
@@ -33,8 +33,10 @@ function stubLayout(columnWidth: number, clientWidth: number): () => void {
   }
   return () => {
     globalThis.ResizeObserver = observers;
-    delete (HTMLElement.prototype as Partial<HTMLElement>).offsetWidth;
-    delete (HTMLElement.prototype as Partial<HTMLElement>).clientWidth;
+    // `delete` needs a writable view — both props are readonly on HTMLElement.
+    const proto = HTMLElement.prototype as Partial<Record<"offsetWidth" | "clientWidth", number>>;
+    delete proto.offsetWidth;
+    delete proto.clientWidth;
   };
 }
 

--- a/packages/ui/test/ssr.test.tsx
+++ b/packages/ui/test/ssr.test.tsx
@@ -78,7 +78,7 @@ describe("every chrome surface server-renders without a DOM", () => {
     createdAt: "2026-07-11T12:00:00.000Z",
   };
   const noop = async () => ({ status: "ok", output: null } as const);
-  const tree = { formatVersion: "vendo-genui/v2", root: "root", nodes: [{ id: "root", component: "Text", props: { text: "SSR tree" } }] } as const;
+  const tree = { formatVersion: "vendo-genui/v2", root: "root", nodes: [{ id: "root", component: "Text", props: { text: "SSR tree" } }] };
   // A NAMED component child: the wrapper derives its slot from the child's
   // identifier (2026-08-02 final shape — the `name` prop is gone).
   const SsrCard = () => <span>original</span>;

--- a/packages/ui/test/tree/convert-payload.test.tsx
+++ b/packages/ui/test/tree/convert-payload.test.tsx
@@ -240,13 +240,14 @@ describe("vendo-genui/v2 component source resolution", () => {
 describe("v1 walk regression", () => {
   it("keeps preferring the built-in for undefined-source v1 nodes that collide with host names", () => {
     const Card: ComponentType<{ title?: string }> = ({ title }) => <article>Host card: {title}</article>;
+    const v1Tree = {
+      formatVersion: "vendo-genui/v2",
+      root: "root",
+      nodes: [{ id: "root", component: "Card", props: { title: "still built-in" } }],
+    };
     render(
       <TreeView
-        tree={{
-          formatVersion: "vendo-genui/v2",
-          root: "root",
-          nodes: [{ id: "root", component: "Card", props: { title: "still built-in" } }],
-        }}
+        tree={v1Tree}
         components={{ Card }}
         onAction={ok}
       />,

--- a/packages/ui/test/tree/data-unavailable-notice.test.tsx
+++ b/packages/ui/test/tree/data-unavailable-notice.test.tsx
@@ -1,12 +1,15 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
-import { VENDO_TREE_FORMAT, type ToolOutcome, type UIPayload } from "@vendoai/core";
-import { TreeView } from "../../src/tree/index.js";
+import { VENDO_TREE_FORMAT, type ToolOutcome } from "@vendoai/core";
+import { TreeView, type WalkTree } from "../../src/tree/index.js";
 
 afterEach(() => {
   cleanup();
 });
+
+/** A v2 payload rendered straight by TreeView: the walk shape plus the format tag. */
+type Payload = WalkTree & { formatVersion: typeof VENDO_TREE_FORMAT };
 
 const ok = async (): Promise<ToolOutcome> => ({ status: "ok", output: null });
 
@@ -18,7 +21,7 @@ const NOTICE = "Data didn't load";
  * ("No data"), which is exactly why the failure has to be said out loud —
  * otherwise the user cannot tell "this couldn't load" from "you have nothing".
  */
-function spendingTree(extras: Record<string, unknown> = {}): UIPayload {
+function spendingTree(extras: Record<string, unknown> = {}): Payload {
   return {
     formatVersion: VENDO_TREE_FORMAT,
     root: "root",
@@ -31,12 +34,12 @@ function spendingTree(extras: Record<string, unknown> = {}): UIPayload {
       },
     ],
     ...extras,
-  } as UIPayload;
+  } as Payload;
 }
 
 /** The same app with a second, independent value in it — the shape a PARTIAL
  *  failure takes on screen: one binding resolved, one still blank. */
-function mixedTree(extras: Record<string, unknown> = {}): UIPayload {
+function mixedTree(extras: Record<string, unknown> = {}): Payload {
   return {
     formatVersion: VENDO_TREE_FORMAT,
     root: "root",
@@ -50,7 +53,7 @@ function mixedTree(extras: Record<string, unknown> = {}): UIPayload {
       },
     ],
     ...extras,
-  } as UIPayload;
+  } as Payload;
 }
 
 describe("the data-unavailable notice (render-seam F6)", () => {

--- a/packages/ui/test/tree/display-bricks.test.tsx
+++ b/packages/ui/test/tree/display-bricks.test.tsx
@@ -2,8 +2,8 @@
 import type { CSSProperties } from "react";
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
-import { DISPLAY_TAG_NAMES, VENDO_TREE_FORMAT } from "@vendoai/apps/contract";
-import type { ToolOutcome } from "@vendoai/core";
+import { DISPLAY_TAG_NAMES } from "@vendoai/apps/contract";
+import { VENDO_TREE_FORMAT, type ToolOutcome } from "@vendoai/core";
 import { TreeView, type WalkTree } from "../../src/tree/index.js";
 import { DISPLAY_BRICKS, SURFACE_CONTAINMENT, safeStyle } from "../../src/tree/display-bricks.js";
 
@@ -11,7 +11,7 @@ afterEach(cleanup);
 
 const ok = async (): Promise<ToolOutcome> => ({ status: "ok", output: null });
 
-const tree = (nodes: WalkTree["nodes"]): WalkTree =>
+const tree = (nodes: WalkTree["nodes"]): WalkTree & { formatVersion: typeof VENDO_TREE_FORMAT } =>
   ({ formatVersion: VENDO_TREE_FORMAT, root: nodes[0]!.id, nodes });
 
 describe("display bricks", () => {

--- a/packages/ui/test/tree/inclient-mount.test.tsx
+++ b/packages/ui/test/tree/inclient-mount.test.tsx
@@ -1,14 +1,17 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { VENDO_TREE_FORMAT, type ToolOutcome, type UIPayload } from "@vendoai/core";
-import { TreeView, evaluateApprovedComponent } from "../../src/tree/index.js";
-import type { InClientVenue } from "../../src/tree/renderer.js";
+import { VENDO_TREE_FORMAT, type ToolOutcome } from "@vendoai/core";
+import { TreeView, evaluateApprovedComponent, type WalkTree } from "../../src/tree/index.js";
+import type { InClientVenue } from "../../src/wire-types.js";
 
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
 });
+
+/** A v2 payload rendered straight by TreeView: the walk shape plus the format tag. */
+type Payload = WalkTree & { formatVersion: typeof VENDO_TREE_FORMAT };
 
 const ok = async (): Promise<ToolOutcome> => ({ status: "ok", output: null });
 
@@ -25,8 +28,8 @@ const GRANTED: InClientVenue = {
   at: "2026-07-15T09:00:00.000Z",
 };
 
-function venueTree(inClient?: InClientVenue, source = WIDGET_SOURCE): UIPayload {
-  const tree: UIPayload & { inClient?: InClientVenue } = {
+function venueTree(inClient?: InClientVenue, source = WIDGET_SOURCE): Payload {
+  const tree: Payload & { inClient?: InClientVenue } = {
     formatVersion: VENDO_TREE_FORMAT,
     root: "root",
     nodes: [
@@ -69,10 +72,10 @@ describe("in-client venue enforcement (06-apps §9)", () => {
     // A forked pin commonly has no live tree props. Promotion is hash-pinned,
     // so the approved mount must see the baseline's sampleProps instead of
     // crashing on undefined.
-    const tree = venueTree(GRANTED, "export default function Widget({ label }) { return <p>Sampled {label}</p>; }") as UIPayload & {
+    const tree = venueTree(GRANTED, "export default function Widget({ label }) { return <p>Sampled {label}</p>; }") as Payload & {
       furnishings?: Record<string, { sampleProps?: Record<string, unknown> }>;
     };
-    delete (tree.nodes[1] as { props?: unknown }).props;
+    delete (tree.nodes[1]! as { props?: unknown }).props;
     tree.furnishings = { Widget: { sampleProps: { label: "rehearsal" } } };
     render(<TreeView tree={tree} components={{}} onAction={ok} />);
 

--- a/packages/ui/test/tree/inclient-zod-shim.test.ts
+++ b/packages/ui/test/tree/inclient-zod-shim.test.ts
@@ -2,8 +2,19 @@ import { describe, expect, it } from "vitest";
 import { IN_CLIENT_BUNDLED_PACKAGES } from "@vendoai/apps/contract";
 import { zodShim } from "../../src/tree/inclient-zod-shim.js";
 
+/** The shim's node: a Proxy, so every one of these names answers with another
+ *  callable node — nothing here is ever missing. */
+interface ShimNode extends Record<
+  "object" | "string" | "number" | "boolean" | "enum" | "array"
+  | "discriminatedUnion" | "optional" | "describe" | "min" | "brand" | "readonly" | "catch",
+  ShimNode
+> {
+  (...args: unknown[]): ShimNode;
+  [name: string]: ShimNode;
+}
+
 /** The `z` namespace as an in-client component receives it. */
-const z = (zodShim as { z: Record<string, (...args: unknown[]) => Record<string, unknown>> }).z;
+const z = (zodShim as { z: ShimNode }).z;
 
 describe("the in-client zod shim", () => {
   it("resolves the declaration surface real host registries use", () => {

--- a/packages/ui/test/tree/review-standing.test.tsx
+++ b/packages/ui/test/tree/review-standing.test.tsx
@@ -1,18 +1,21 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
-import { VENDO_TREE_FORMAT, type ToolOutcome, type UIPayload } from "@vendoai/core";
-import { TreeView } from "../../src/tree/index.js";
-import type { InClientVenue } from "../../src/tree/renderer.js";
+import { VENDO_TREE_FORMAT, type ToolOutcome } from "@vendoai/core";
+import { TreeView, type WalkTree } from "../../src/tree/index.js";
+import type { InClientVenue } from "../../src/wire-types.js";
 
 afterEach(() => cleanup());
+
+/** A v2 payload rendered straight by TreeView: the walk shape plus the format tag. */
+type Payload = WalkTree & { formatVersion: typeof VENDO_TREE_FORMAT };
 
 const ok = async (): Promise<ToolOutcome> => ({ status: "ok", output: null });
 
 /** A review-kind payload as the server ships it while unapproved: the venue
  *  says pending-review and NO fork source travels (open() strips it). */
-function pendingTree(inClient: InClientVenue): UIPayload {
-  const tree: UIPayload & { inClient?: InClientVenue } = {
+function pendingTree(inClient: InClientVenue): Payload {
+  const tree: Payload & { inClient?: InClientVenue } = {
     formatVersion: VENDO_TREE_FORMAT,
     root: "root",
     nodes: [

--- a/packages/ui/test/tree/seed-drift-notice.test.tsx
+++ b/packages/ui/test/tree/seed-drift-notice.test.tsx
@@ -1,13 +1,16 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
-import { VENDO_TREE_FORMAT, type ToolOutcome, type UIPayload } from "@vendoai/core";
-import { TreeView } from "../../src/tree/index.js";
+import { VENDO_TREE_FORMAT, type ToolOutcome } from "@vendoai/core";
+import { TreeView, type WalkTree } from "../../src/tree/index.js";
 import type { SeedDrift } from "../../src/wire-types.js";
 
 afterEach(() => {
   cleanup();
 });
+
+/** A v2 payload rendered straight by TreeView: the walk shape plus the format tag. */
+type Payload = WalkTree & { formatVersion: typeof VENDO_TREE_FORMAT };
 
 const ok = async (): Promise<ToolOutcome> => ({ status: "ok", output: null });
 
@@ -27,8 +30,8 @@ const DRIFT: SeedDrift = {
 
 const NOTICE = "Newer version available";
 
-function driftedTree(seedDrift?: SeedDrift): UIPayload {
-  const tree: UIPayload & { seedDrift?: SeedDrift; inClient?: unknown } = {
+function driftedTree(seedDrift?: SeedDrift): Payload {
+  const tree: Payload & { seedDrift?: SeedDrift; inClient?: unknown } = {
     formatVersion: VENDO_TREE_FORMAT,
     root: "root",
     nodes: [

--- a/packages/ui/test/tree/surface-theme.test.tsx
+++ b/packages/ui/test/tree/surface-theme.test.tsx
@@ -7,8 +7,8 @@
 // `var(…, fallback)` carries, which is why a screenshot could not see it.
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
-import { VENDO_TREE_FORMAT } from "@vendoai/apps/contract";
-import type { ToolOutcome } from "@vendoai/core";
+import type { VendoTheme } from "@vendoai/apps/contract";
+import { VENDO_TREE_FORMAT, type ToolOutcome } from "@vendoai/core";
 import { TreeView, type WalkTree } from "../../src/tree/index.js";
 import { VendoProvider, createVendoClient } from "../../src/index.js";
 import { ChromeRoot } from "../../src/chrome/chrome-root.js";
@@ -20,7 +20,7 @@ const ok = async (): Promise<ToolOutcome> => ({ status: "ok", output: null });
 /** Nothing in the default theme and no brick fallback is this color. */
 const HOST_ACCENT = "#ff00aa";
 
-const tree: WalkTree = {
+const tree: WalkTree & { formatVersion: typeof VENDO_TREE_FORMAT } = {
   formatVersion: VENDO_TREE_FORMAT,
   root: "root",
   nodes: [
@@ -41,10 +41,12 @@ function resolvedAccent(from: HTMLElement): string {
   return "";
 }
 
+// `theme` is a SHALLOW `Partial<VendoTheme>`, so overriding ONE color needs a
+// cast; resolveTheme spreads `colors` over the defaults at runtime.
 describe("surface theming does not depend on DOM ancestry", () => {
   it("resolves the host theme on a surface mounted OUTSIDE ChromeRoot", () => {
     render(
-      <VendoProvider client={createVendoClient({ baseUrl: "http://vendo.test/api/vendo" })} theme={{ colors: { accent: HOST_ACCENT } }}>
+      <VendoProvider client={createVendoClient({ baseUrl: "http://vendo.test/api/vendo" })} theme={{ colors: { accent: HOST_ACCENT } as VendoTheme["colors"] }}>
         <TreeView tree={tree} components={{}} onAction={ok} />
       </VendoProvider>,
     );
@@ -55,7 +57,7 @@ describe("surface theming does not depend on DOM ancestry", () => {
 
   it("resolves the same value inside ChromeRoot — one mapping, nothing to disagree about", () => {
     render(
-      <VendoProvider client={createVendoClient({ baseUrl: "http://vendo.test/api/vendo" })} theme={{ colors: { accent: HOST_ACCENT } }}>
+      <VendoProvider client={createVendoClient({ baseUrl: "http://vendo.test/api/vendo" })} theme={{ colors: { accent: HOST_ACCENT } as VendoTheme["colors"] }}>
         <ChromeRoot>
           <TreeView tree={tree} components={{}} onAction={ok} />
         </ChromeRoot>

--- a/packages/ui/test/tree/tree-view.test.tsx
+++ b/packages/ui/test/tree/tree-view.test.tsx
@@ -12,7 +12,11 @@ afterEach(() => {
 
 const ok = async (): Promise<ToolOutcome> => ({ status: "ok", output: null });
 
-function tree(nodes: WalkTree["nodes"], root = nodes[0]?.id ?? "root", components?: Record<string, string>): WalkTree {
+function tree(
+  nodes: WalkTree["nodes"],
+  root = nodes[0]?.id ?? "root",
+  components?: Record<string, string>,
+): WalkTree & { formatVersion: typeof VENDO_TREE_FORMAT } {
   return { formatVersion: VENDO_TREE_FORMAT, root, nodes, components };
 }
 
@@ -490,20 +494,21 @@ describe("TreeView bindings and outcomes", () => {
   it("updates $state reads and reports an approved component's state writes", async () => {
     const StateProbe: ComponentType<{ value?: unknown }> = ({ value }) => <output>{String(value)}</output>;
     const onStateChange = vi.fn();
+    const granted = {
+      ...tree(
+        [
+          { id: "root", component: "Row", children: ["generated", "probe"] },
+          { id: "generated", component: "Editor", source: "generated" },
+          { id: "probe", component: "StateProbe", source: "host", props: { value: { $state: "draft" } } },
+        ],
+        "root",
+        { Editor: setStateSource("Editor", "saved locally") },
+      ),
+      inClient: GRANTED,
+    };
     render(
       <TreeView
-        tree={{
-          ...tree(
-            [
-              { id: "root", component: "Row", children: ["generated", "probe"] },
-              { id: "generated", component: "Editor", source: "generated" },
-              { id: "probe", component: "StateProbe", source: "host", props: { value: { $state: "draft" } } },
-            ],
-            "root",
-            { Editor: setStateSource("Editor", "saved locally") },
-          ),
-          inClient: GRANTED,
-        }}
+        tree={granted}
         components={{ StateProbe }}
         onAction={ok}
         onStateChange={onStateChange}

--- a/packages/ui/test/wire-server.ts
+++ b/packages/ui/test/wire-server.ts
@@ -243,6 +243,7 @@ function run(): RunRecord {
   return {
     id: "run_1",
     appId: "app_auto",
+    triggerId: DEFAULT_TRIGGER_ID,
     trigger: { kind: "host-event", event: "invoice.created" },
     status: "running",
     startedAt: NOW,
@@ -265,7 +266,7 @@ function wireError(response: ServerResponse, code: string, message: string, stat
   json(response, { error: { code, message } }, status);
 }
 
-async function bodyBytes(request: IncomingMessage): Promise<Uint8Array> {
+async function bodyBytes(request: IncomingMessage): Promise<Uint8Array<ArrayBuffer>> {
   const chunks: Buffer[] = [];
   for await (const chunk of request) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
   return new Uint8Array(Buffer.concat(chunks));
@@ -301,6 +302,12 @@ export async function createWireServer(options: WireServerOptions = {}) {
     role: "assistant",
     parts: [{ type: "text", text: "Existing thread" }],
   };
+  // Annotated, not `satisfies`: the routes below arm a trigger and push a rung-2
+  // version, and a `satisfies` literal keeps `false`/`1` as its own type.
+  const automations: AutomationEntry[] = [
+    { app: automationApp, triggers: [{ trigger: automationApp.triggers![0]!, enabled: false }] },
+  ];
+  const history: VersionEntry[] = [{ at: NOW, intent: "create", rung: 1 }];
   const state = {
     apps: [baseApp, automationApp, ...(options.islandApp === true ? [islandApp()] : [])],
     /** Placement rows (2026-08-05): the fixture keeps the SHAPE the wire keeps
@@ -342,9 +349,7 @@ export async function createWireServer(options: WireServerOptions = {}) {
      *  URL. A knob because the URL is the one field of that response the
      *  BROKER controls, and the surfaces navigate a window to it. */
     redirectUrl: "https://connect.test/oauth/1",
-    automations: [
-      { app: automationApp, triggers: [{ trigger: automationApp.triggers![0]!, enabled: false }] },
-    ] satisfies AutomationEntry[],
+    automations,
     runs: [run()],
     events: [audit("aud_1"), audit("aud_2"), audit("aud_3"), appEditAudit()],
     threads: new Map<string, Thread>([
@@ -353,7 +358,7 @@ export async function createWireServer(options: WireServerOptions = {}) {
         { id: "thr_1", subject: "user_1", messages: [existingMessage], createdAt: NOW, updatedAt: NOW },
       ],
     ]),
-    history: [{ at: NOW, intent: "create", rung: 1 }] satisfies VersionEntry[],
+    history,
     importBytes: new Uint8Array(),
     // Existing-agents polish — how many open polls `app_building_lands`
     // misses before its build "lands" (the browser harness's build window).

--- a/packages/ui/tsconfig.test.json
+++ b/packages/ui/tsconfig.test.json
@@ -5,8 +5,12 @@
     "rootDir": ".",
     "declaration": false,
     "declarationMap": false,
-    "sourceMap": false
+    "sourceMap": false,
+    // eject-templates.test.ts imports this package's own
+    // `scripts/eject-templates-lib.mjs`, which has no `.d.ts` — same reason
+    // `apps`, `vendo` and `harnesses` set this. There is no `.js` under `src`
+    // or `test`, so it widens nothing else.
+    "allowJs": true
   },
-  "//": "Scoped to the type-level suites. The runtime tests carry ~148 pre-existing type errors and bringing them under tsc is its own lane, not this file's job.",
-  "include": ["src", "test/**/*.test-d.tsx"]
+  "include": ["src", "test"]
 }


### PR DESCRIPTION
`packages/ui` was the only package of fourteen whose tests never typechecked. `tsconfig.test.json` existed and carried the same `&& tsc -p tsconfig.test.json` script its siblings do, but its `include` was scoped to the `*.test-d.tsx` type-level suites, because the runtime tests under `test/` carried a pile of errors nobody had read. **The include now covers all of `test/` and `tsc` is clean over it.**

The real count was **135 errors across 41 files** (the standing estimate was ~148).

---

# ⚠️ Read these three first

This lane is advertised as types-only. Two things in it are not, and a reviewer must not have to discover either from the diff.

## 1. One `src/` change: `HostComponentsInput` widened — a genuine defect, not a typing inconvenience

`packages/ui/src/context.tsx`. It was:

```ts
export type HostComponentsInput = Record<string, ComponentType> | ComponentRegistry;
```

`ComponentType` defaults its props to `{}`, so the **documented plain `name → component` back-compat form rejected every host component that declares required props** — that is, every real one. A type that rejects the exact usage it documents is broken. Separately, a union of two whole-map forms cannot express a map mixing a plain component with a registry entry, which is exactly what `hostComponentMap` has always read *per entry*.

It is now:

```ts
export type HostComponentsInput = Record<string, ComponentType<never> | ComponentRegistryEntry>;
```

Four things a reviewer should weigh:

- **It is the only `src/` change in the lane**, and it touches a **public exported type** (`@vendoai/ui`).
- **It is strictly a widening** — it accepts everything the old type did, plus the mixed form. Nothing that compiled before stops compiling.
- **Nothing at runtime changed.** `isRegistryEntry`'s body is untouched; `hostComponentMap`'s ternary is identical, with its existing cast moved outside the branch.
- **It is reversible in one line** if you would rather split it into its own lane.

What settles it: this was **the only error in the whole set with no truthful test-side fix**. The alternatives were `as unknown as` or weakening the fixture, and both would have hidden the defect rather than fixed it. Pinned by `test/registry-components.test.tsx`, which now typechecks unchanged.

## 2. One behaviour change in a test: `split-view.test.tsx` has been half-inert since `489a204c4`

`autoStage(appId, buildKey)` gained its second parameter in **`489a204c4`** ("RULING 23 — the autoStage ledger is per BUILD"), whose message lists this file among those updated. **This one call site was missed.** It has been running with `buildKey === undefined` for *both* staged apps ever since, so the second card's shot was a silent no-op — directly contradicting the test's own comment three lines below it:

> the SECOND staged view spends its shot a commit later against the already-open workspace

So the test has been quietly proving half of what it claims. TypeScript cannot be satisfied without passing *something*, and the two candidates were not equivalent: a shared constant would have preserved today's behaviour byte-for-byte and therefore preserved the bug. **This lane passes the key `parts.tsx:483` actually forms**, so the test now does what it says. Every assertion holds and the test passes.

```diff
-      for (const appId of appIds.slice(0, arrived)) split.autoStage(appId);
+      // Build keys as parts.tsx forms them: `${message.id}-${index}-${appId}`.
+      for (const [index, appId] of appIds.slice(0, arrived).entries()) split.autoStage(appId, `msg_1-${index}-${appId}`);
```

## 3. Banked follow-up: `VendoProvider`'s `theme` prop cannot express a one-colour override

Out of scope here, deliberately — noting it so it is not lost. `theme?: Partial<VendoTheme>` is **shallow**, but `resolveTheme` (`packages/apps/src/contract/theme.ts:111-122`) **deep-merges `colors`** over the defaults. So overriding a single accent — the exact thing two tests in this repo prove works at runtime — is unsayable in types.

Two commented casts to the real `VendoTheme["colors"]` stand in for now (`test/chrome/approval-and-notice.test.tsx`, `test/tree/surface-theme.test.tsx`). **The product fix is a nested partial on the `theme` prop, and it belongs in its own lane.**

---

## What the 135 actually were

| # | Category | What it means |
|---|---|---|
| 32 | Tree fixture typed `UIPayload`, handed to `TreeView` | `TreeViewProps.tree` is `WalkTree` (`root`/`nodes`), `UIPayload` is `{ formatVersion, [k: string]: unknown }`. The fixtures are both — the walk shape plus the format tag — and now say so. |
| 31 | DOM reads under `noUncheckedIndexedAccess` | `querySelectorAll(...)[0]` is `\| undefined`; `globalThis` is not a `Window`; a `vi.fn()` with no declared signature has an empty arg tuple, so `.mock.calls[0][2]` is out of range. |
| 28 | The zod shim typed as `Record<string, …>` | One line. The shim is a Proxy where every name resolves, so `\| undefined` on every member was simply false — and the `Record<string, unknown>` return made every chained call `unknown`. |
| 20 | Fixture never learned about a field the type gained | `risks`, `triggerId`, `Trigger.id`, `ToolDescriptor.description`, `VendoAppRef.status`, `onEditLast`/`onRegenerateLast`. |
| 8 | Import pointing at the wrong module | `Thread` is ui's own (`src/wire-types.ts`), not core's. `VENDO_TREE_FORMAT` is core's, not `@vendoai/apps/contract`'s. `InClientVenue` is imported by the renderer, not exported from it. |
| 8 | Helper's parameter type inferred from one call site | So a second call site could not disagree with the first — `status: string` vs the real union, `rung: 2` vs a frozen `1`, `true` vs a frozen `false`. |
| 5 | Fixture naming a field the type had dropped or renamed | `GrantSetPermission.description` (the sentence moved to `ToolMeta`), `ToolDescriptor.critical` → `confirmEach`. |
| 3 | `let release = () => undefined` handed a promise `resolve` | Return type only; one annotation each. |

## What is NOT in here

**No `any`, no `@ts-ignore`, no `@ts-expect-error`** — verified by grepping the diff. No assertion changed meaning, no test was added or removed, and no test's runtime behaviour changed apart from §2 above. **All 138 files / 1206 tests pass.**

The single assertion line that moved is `expect(graded.descriptor.critical)` → `expect(graded.descriptor.confirmEach)` — a documented rename (`packages/core/src/tools.ts:222` still records `critical` as "its pre-rename name"). Same value, same proof.

Four suppressions were added, all casts to real types, all commented: the two `VendoTheme["colors"]` casts from §3, one manifest-shape cast in `eject-templates.test.ts` (the lib seeds `surfaces` as `{}`, so inference loses the shape — matching the idiom already at line 168 of that file), and one `!` behind a `chip(index)` helper on a fixed-length citation fixture.

## Gate

| Step | Result |
|---|---|
| `turbo build --concurrency=2` | 21/21 successful |
| `packages/ui` full suite (`VITEST_MIN/MAX_FORKS=1/2`, `MIN/MAX_THREADS=1/2`) | **138 files, 1206 tests, all passed** (356s) |
| `tsc -p tsconfig.json` + `tsc -p tsconfig.test.json` | clean — `test/` now included |
| `pnpm lint` (repo) | 0 errors (4 pre-existing `demo-bank` warnings, untouched) |

Draft, and **not to be merged** — this lane restacks onto the tip and merges with the others after the release is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
