### PR TITLE
feat(agents,actions): a tool may declare its result shape

### DIFF
--- a/.changeset/a-tool-declares-its-result-shape.md
+++ b/.changeset/a-tool-declares-its-result-shape.md
@@ -1,0 +1,28 @@
+---
+"@vendoai/agents": minor
+"@vendoai/actions": minor
+---
+
+A hand-authored tool may declare its result shape, and an MCP server's is no
+longer dropped on the way in.
+
+`ToolDescriptor.outputSchema` has been read on three prompt surfaces for a while
+— the apps shape brief, the automation planner, the screen agent's tool brief —
+and every one of them prints "result shape unknown — pass the whole output
+through; do not bind to guessed field names" when it is absent. Two producers
+never supplied it, so for their tools that sentence was always the answer:
+`tool()`, where the host knows the shape exactly and had nowhere to say it, and
+the inbound MCP connector, which parsed a server's `tools/list` entry and threw
+the advertised `outputSchema` away. A generated screen over either could not bind
+to a field until something had called the tool once and read the rows back.
+
+- **`tool({ …, outputSchema })`** (`@vendoai/agents`) takes the shape as JSON
+  Schema and puts it on the descriptor. Omitted, the key is absent rather than
+  `undefined`, so the unknown-shape sentence still prints.
+- **`mcpConnector`** (`@vendoai/actions`) keeps whatever the server advertised,
+  by the same rule its `inputSchema` already follows: an object survives,
+  anything else is not a schema and is ignored.
+
+Advisory in both cases. Nothing validates a result against the declared shape —
+a schema that has drifted from the code makes the model's expectations wrong,
+which is recoverable, where a checked one would fail a tool that works.

--- a/docs-site/agent-sdk/converse.mdx
+++ b/docs-site/agent-sdk/converse.mdx
@@ -31,6 +31,10 @@ export const support = agent({
         properties: { orderId: { type: "string" } },
         required: ["orderId"],
       },
+      outputSchema: {
+        type: "object",
+        properties: { refunded: { type: "string" } },
+      },
       execute: async (input, ctx) => {
         const { orderId } = input as { orderId: string };
         await refundOrder(orderId, { owner: ctx.principal.subject });

--- a/docs-site/agent-sdk/reference.mdx
+++ b/docs-site/agent-sdk/reference.mdx
@@ -206,10 +206,18 @@ export function tool(config: ToolConfig): HostTool;
 forwarding behind the origin gate, and `actAs` for away runs
 (`{ dir?, actAs?, baseUrl?, untrustedOriginPolicy?, fetch? }`).
 
-`tool()` takes `{ name, description?, risk?, inputSchema, execute }`.
+`tool()` takes `{ name, description?, risk?, inputSchema, outputSchema?, execute }`.
 **`risk` is your call and it is final** — `read`, `write`, or `destructive`.
 Omit it and the tool is `ungraded`, which the guard treats like `destructive`
 and asks about, which unattended means denied.
+
+`outputSchema` is the tool's **declared result shape**, in JSON Schema. Surfaces
+print it beside the tool, so the model — and a generated screen binding to
+fields — knows what comes back before any call. Omit it and those surfaces say
+*"result shape unknown — pass the whole output through; do not bind to guessed
+field names"*, which costs a throwaway call to learn the fields. It is advisory
+only: nothing checks a result against it, so a schema that drifts from the code
+never fails a working tool.
 
 ## Adapters
 

--- a/packages/actions/src/connectors/mcp.ts
+++ b/packages/actions/src/connectors/mcp.ts
@@ -13,6 +13,7 @@ interface McpTool {
   name?: unknown;
   description?: unknown;
   inputSchema?: unknown;
+  outputSchema?: unknown;
   annotations?: { readOnlyHint?: unknown; destructiveHint?: unknown };
 }
 
@@ -51,6 +52,12 @@ function joinedText(content: unknown): string {
     .filter((item) => item.type === "text" && typeof item.text === "string")
     .map((item) => item.text as string)
     .join("\n");
+}
+
+/** A schema the wire advertised, or nothing: arrays and scalars are not schemas. */
+function objectSchema(value: unknown): Record<string, unknown> | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
+  return value as Record<string, unknown>;
 }
 
 function parseSseEvent(event: string, id: number): JsonRpcResponse | undefined {
@@ -256,13 +263,15 @@ export function mcpConnector(config: {
           nextNormalizedToRaw.set(name, item.name);
           const destructive = item.annotations?.destructiveHint === true;
           const readOnly = item.annotations?.readOnlyHint === true;
+          // The server's own declared result shape, when it advertises one — the
+          // model reads field names off the listing instead of calling once to
+          // learn them. Advisory: results are never checked against it.
+          const outputSchema = objectSchema(item.outputSchema);
           descriptors.push({
             name,
             description: typeof item.description === "string" ? item.description : item.name,
-            inputSchema:
-              item.inputSchema && typeof item.inputSchema === "object" && !Array.isArray(item.inputSchema)
-                ? (item.inputSchema as Record<string, unknown>)
-                : {},
+            inputSchema: objectSchema(item.inputSchema) ?? {},
+            ...(outputSchema === undefined ? {} : { outputSchema }),
             risk: destructive ? "destructive" : readOnly ? "read" : "write",
           });
         }

--- a/packages/actions/tests/connectors/connectors.test.ts
+++ b/packages/actions/tests/connectors/connectors.test.ts
@@ -187,6 +187,7 @@ describe("mcpConnector", () => {
   it("initializes a session, paginates tools, parses SSE, and maps call results", async () => {
     const methods: string[] = [];
     const sessionHeaders: Array<string | undefined> = [];
+    const lookupOutput = { type: "object", properties: { found: { type: "boolean" } } };
     const server = await startServer(async (req, res) => {
       const body = await jsonBody(req);
       const method = body.method as string;
@@ -216,7 +217,13 @@ describe("mcpConnector", () => {
             id,
             result: {
               tools: [
-                { name: "lookup", description: "Lookup", inputSchema: { type: "object" }, annotations: { readOnlyHint: true } },
+                {
+                  name: "lookup",
+                  description: "Lookup",
+                  inputSchema: { type: "object" },
+                  outputSchema: lookupOutput,
+                  annotations: { readOnlyHint: true },
+                },
                 { name: "explode", description: "Explode", inputSchema: {}, annotations: { destructiveHint: true } },
               ],
               nextCursor: "next",
@@ -256,7 +263,12 @@ describe("mcpConnector", () => {
     const connector = mcpConnector({ url: server.url, name: "warehouse", headers: { authorization: "Bearer test" } });
     const descriptors = await connector.descriptors();
     expect(descriptors[0]).toMatchObject({ name: "mcp_warehouse_lookup", risk: "read" });
+    // The server's advertised result shape survives the listing; a tool that
+    // declares none carries no key, so surfaces print "shape unknown" instead of
+    // an empty schema that reads as "returns nothing".
+    expect(descriptors[0]?.outputSchema).toEqual(lookupOutput);
     expect(descriptors[1]).toMatchObject({ name: "mcp_warehouse_explode", risk: "destructive" });
+    expect(descriptors[1] && "outputSchema" in descriptors[1]).toBe(false);
     expect(descriptors[2]?.name).toHaveLength(64);
     expect(descriptors[2]?.risk).toBe("write");
 

--- a/packages/agents/README.md
+++ b/packages/agents/README.md
@@ -12,7 +12,8 @@ import { claudeCode } from "@vendoai/harnesses/claude-code";
 const support = agent({
   name: "support",
   harness: claudeCode({ model: "claude-sonnet-5" }),
-  tools: [api(), tool({ name: "refund", risk: "write", inputSchema, execute })],
+  // `outputSchema` is optional: the result shape the model is told to expect.
+  tools: [api(), tool({ name: "refund", risk: "write", inputSchema, outputSchema, execute })],
   mcp: [{ url: "https://mcp.example.com", headers: { authorization: "…" } }],
   skills: ["./skills/product-docs"],
   egress: ["api.stripe.com"],

--- a/packages/agents/src/tools.ts
+++ b/packages/agents/src/tools.ts
@@ -26,6 +26,10 @@ export interface ToolConfig {
   /** The dev's label is FINAL; unlabeled = ungraded = asks at call time. */
   risk?: RiskLabel;
   inputSchema: JsonSchema;
+  /** The tool's DECLARED result shape. Surfaces print it, so generated UI can
+   *  bind to fields before any call; nothing validates a result against it, so a
+   *  stale schema never fails a working tool. */
+  outputSchema?: JsonSchema;
   execute(input: Json, ctx: RunContext, call: ToolCall): Promise<Json> | Json;
 }
 
@@ -49,6 +53,7 @@ export function tool(config: ToolConfig): HostTool {
       name: config.name,
       description: config.description ?? "",
       inputSchema: config.inputSchema,
+      ...(config.outputSchema === undefined ? {} : { outputSchema: config.outputSchema }),
       risk: config.risk ?? "ungraded",
     },
     execute: config.execute,

--- a/packages/agents/tests/tools.test.ts
+++ b/packages/agents/tests/tools.test.ts
@@ -34,6 +34,14 @@ describe("tool()", () => {
     expect(t.descriptor.risk).toBe("destructive");
   });
 
+  it("carries the declared result shape, and has no key at all without one", () => {
+    const outputSchema = { type: "object" as const, properties: { balance: { type: "number" } } };
+    const declared = tool({ name: "balance", inputSchema: { type: "object" }, outputSchema, execute: () => ({}) });
+    expect(declared.descriptor.outputSchema).toEqual(outputSchema);
+    const silent = tool({ name: "ping", inputSchema: { type: "object" }, execute: () => ({}) });
+    expect("outputSchema" in silent.descriptor).toBe(false);
+  });
+
   it("rejects a name the registry could never carry", () => {
     expect(() => tool({ name: "not a name!", inputSchema: { type: "object" }, execute: () => ({}) }))
       .toThrow(/must match/);


### PR DESCRIPTION
## What

`ToolDescriptor.outputSchema` gains its two missing producers.

- **`tool({ …, outputSchema })`** (`@vendoai/agents`) — the host-facing tool API
  takes the declared result shape as JSON Schema and puts it on the descriptor.
  Omitted, the key is absent rather than `undefined`.
- **`mcpConnector`** (`@vendoai/actions`) — the inbound connector keeps whatever
  the external server advertised on its `tools/list` entry, by the same rule its
  `inputSchema` already follows: an object survives, anything else is not a
  schema and is ignored.

Docs: the field on `packages/agents/README.md`, the `agent-sdk/reference.mdx`
`ToolConfig` entry, and the `converse.mdx` `tool()` example. Changeset: minor on
both packages.

## Why

The agent was blind to hand-authored tools' result shapes. Every consumer
already reads `outputSchema` — the apps shape brief, the automation planner, the
screen agent's tool brief, `wireOutputSchema` on the MCP door — and each of them
prints *"result shape unknown — pass the whole output through; do not bind to
guessed field names"* when it is absent. For a `tool()` the host wrote by hand,
and for every tool behind an external MCP server, that sentence was always the
answer: the host knew the shape exactly, or the server had already stated it,
and there was nowhere for it to land. A generated screen over either could not
bind to a field until something called the tool once and read the rows back.

It is **advisory only**. Nothing checks a result against the declared shape — a
schema that drifts from the code makes the model's expectations wrong, which is
recoverable, where a checked one would fail a tool that works.

## Notes

**Seam test, not a mock.** The MCP change is proved through
`packages/actions/tests/connectors/connectors.test.ts`, which stands up a real
in-process HTTP MCP server. The fixture server now advertises an `outputSchema`
on one tool and none on another; the assertion reads the descriptor that comes
back out of the connector's own `descriptors()`, over the real JSON-RPC
handshake and pagination. Nothing on either side is stubbed. Both new tests were
proved to fail: with the pass-throughs reverted they go red, and green again
once restored.

**Framework passthrough (Change 3) skipped, deliberately.** Checked against the
installed types, not the docs:

- **AI SDK 6.0.28** — `dynamicTool()` (what `packages/vendo/src/ai-sdk.ts` uses)
  has no `outputSchema` parameter at all. `Tool.outputSchema` does exist, but
  `prepareToolsAndToolChoice` forwards only `inputSchema` to the provider, so it
  never reaches the model; its one runtime reader is `validateUIMessages`, which
  *validates outputs against it*. Passing it would buy no model-facing hint and
  add a failure mode.
- **Mastra `@mastra/core` 1.51.0** — `createTool({ outputSchema })` accepts a
  JSON Schema (no zod conversion needed), but the tool wrapper calls
  `validateToolOutput` on every result and returns
  `"Tool output validation failed for <id>"` on a mismatch. That is exactly the
  stale-schema-fails-a-working-tool case this field must never cause.
- **`packages/harnesses/src/vendo/vendo.ts`** — not touched. That directory
  carries an author-involved-zone `CLAUDE.md` requiring the author's sign-off
  before any edit; the AI SDK finding above means there was nothing to gain
  there anyway.

`VendoPackTool` was left alone for the same reason: with neither shim able to
consume the field, it would be a schema with no reader.

## Verification

- [x] `pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint` — build,
      typecheck and lint green; `test:affected` green except a **pre-existing**
      `@vendoai/genbench` `tests/font.test.ts` failure, confirmed failing on a
      clean tree at this branch point.
- [ ] Screenshots attached (if UI-affecting) — n/a, no UI surface changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose and preserve tool result shapes so UIs and planners can bind fields before the first call. Previously `tool()` could not supply `outputSchema` and `mcpConnector` dropped servers’ advertised shapes; surfaces showed “result shape unknown.”

- `tool({ …, outputSchema })` in `@vendoai/agents` accepts a JSON Schema; if omitted, the descriptor has no `outputSchema` key (not `undefined`).
- `mcpConnector` in `@vendoai/actions` now keeps `outputSchema` when it is an object; non-objects are ignored. `inputSchema` handling is unchanged in effect.
- Advisory only: results are not validated against `outputSchema`.
- Tests cover passthrough with a real in-process MCP server and assert key presence/absence; docs updated (`converse.mdx`, reference). Minor version bumps on both packages.
- No framework passthrough added: current AI SDK and Mastra paths would validate outputs and introduce failures on schema drift. Hosts may start setting `outputSchema` to improve generated surfaces; no migration required.

<sup>Written for commit 1f6e0f2bb2801b8a09f68f7fd119faba0f9847fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

