### PR TITLE
ci(release): merging the version PR publishes, and 1.0.0 stays impossible

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,17 @@ on:
   # Real release: pushing a v* tag publishes the fixed lockstep group to npm.
   push:
     tags: ["v*"]
-  # Dry run: manually dispatch to prove the publish end-to-end WITHOUT publishing
-  # or tagging. Runs the exact gate stack + `pnpm -r publish --dry-run`.
+  # Dry run by default: manually dispatch to prove the publish end-to-end WITHOUT
+  # publishing. Runs the exact gate stack + `pnpm -r publish --dry-run`.
   workflow_dispatch:
+    inputs:
+      publish:
+        # version-packages.yml sets this, dispatching at the tag it just pushed:
+        # a GITHUB_TOKEN tag push can never fire the `push: tags` trigger above,
+        # and a dispatch can. Leave it off for a hand-run dry run.
+        description: Publish for real
+        type: boolean
+        default: false
 
 # id-token: write powers npm trusted publishing (OIDC) AND provenance: the
 # workflow's OIDC token is exchanged for a short-lived npm credential, so
@@ -71,15 +79,16 @@ jobs:
       # touching the registry. --provenance is dropped here (no tag/release to
       # attest to, and dry runs mint no attestation).
       - name: Publish (dry run)
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && !inputs.publish
         run: pnpm -r --filter './packages/*' publish --dry-run --no-git-checks --access public
 
-      # Real publish (v* tag): pack every public workspace with pnpm (rewrites
-      # workspace:*), then publish each tarball with npm's OIDC trusted
-      # publishing + provenance. Versions already on the registry are skipped,
-      # so re-runs are safe. No token env by design.
+      # Real publish (v* tag, or a dispatch with publish=true): pack every
+      # public workspace with pnpm (rewrites workspace:*), then publish each
+      # tarball with npm's OIDC trusted publishing + provenance. Versions
+      # already on the registry are skipped, so re-runs are safe. No token env
+      # by design.
       - name: Publish to npm
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || inputs.publish
         run: |
           set -euo pipefail
           npm install -g npm@11
@@ -109,3 +118,51 @@ jobs:
           # (libnpmpublish/lib/publish.js), and under `set -e` that aborts the
           # release partway through, after earlier packages are already live.
           done < <(pnpm -r --filter './packages/*' exec node -e "const p=require('./package.json'); if (!p.private) process.stdout.write(p.name+'\n')")
+
+      # Last: open the @vendoai bump PR on vendo-web, so the console never sits
+      # on a stale release. GITHUB_TOKEN is scoped to this repo alone, so this
+      # needs its own cross-repo credential; without it the step says so and
+      # stops, and it never reddens a release that already published.
+      - name: Open the vendo-web dep bump PR
+        if: github.event_name == 'push' || inputs.publish
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.VENDO_WEB_PAT }}
+        run: |
+          set -euo pipefail
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::notice::VENDO_WEB_PAT is not set — skipping the vendo-web bump PR"
+            exit 0
+          fi
+          version=$(node -p "require('./packages/vendo/package.json').version")
+          branch="chore/bump-vendoai-$version"
+          git clone --depth=1 "https://x-access-token:$GH_TOKEN@github.com/runvendo/vendo-web.git" /tmp/vendo-web
+          cd /tmp/vendo-web
+          # Rewritten in place so the file's own formatting survives; catches
+          # both `dependencies` and `pnpm.overrides`. @vendoai/telemetry is
+          # deliberately excluded: it is outside this repo's changesets `fixed`
+          # group and versions on its own, so it must never ride the lockstep
+          # bump. (It is a `file:` reference today, which the semver pattern
+          # skips anyway — the name is excluded so that holds if it is ever
+          # published as a version.)
+          node -e '
+            const fs = require("fs");
+            fs.writeFileSync("package.json", fs.readFileSync("package.json", "utf8")
+              .replace(/"@vendoai\/(?!telemetry")[a-z-]+": "\d+\.\d+\.\d+"/g,
+                (dep) => dep.replace(/\d+\.\d+\.\d+/, process.argv[1])));
+          ' "$version"
+          if git diff --quiet; then
+            echo "vendo-web is already on $version"
+            exit 0
+          fi
+          # pnpm 9 is what vendo-web's own CI installs with, and it runs
+          # --frozen-lockfile: a lockfile written by this repo's pnpm 11 would
+          # fail there. Without this refresh the PR is red on arrival.
+          npx --yes pnpm@9 install --lockfile-only --ignore-scripts
+          git -c user.name='github-actions[bot]' \
+              -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+              commit -am "chore: bump @vendoai/* to $version"
+          git push origin "HEAD:refs/heads/$branch"
+          gh pr create --head "$branch" \
+            --title "chore: bump @vendoai/* to $version" \
+            --body "Automated by runvendo/vendo's release workflow for v$version. \`@vendoai/telemetry\` is outside the release group and is left alone."

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -2,18 +2,22 @@ name: Version Packages
 
 # Keeps a "chore: version packages" PR open on main whenever there are
 # pending changesets. Releasing = merge that PR; the post-merge run of this
-# workflow pushes the `v<version>` tag, and release.yml (tag-triggered) does
-# the publish. No `publish` input on purpose — publishing stays on the tag so a
-# release is always a deliberate act.
+# workflow pushes the `v<version>` tag and then dispatches release.yml at that
+# tag, which does the publish. Merging the version PR is the deliberate act.
 #
-# RELEASE_PAT (optional repo secret, and what makes the automation real):
-# GitHub deliberately never triggers workflows from anything pushed with the
-# default GITHUB_TOKEN — not the version PR's commits, not the tag. Without the
-# secret this workflow behaves exactly as it did before: the version PR gets no
-# checks until you close and reopen it, and the tag lands but release.yml has to
-# be run by hand. With it, the version PR gets CI on open and the tag push fires
-# release.yml. Fine-grained PAT scoped to this repo only — Contents:
-# read+write, Pull requests: read+write — stored as the secret RELEASE_PAT.
+# The dispatch is the whole automation. GitHub never triggers a workflow from
+# anything pushed with the default GITHUB_TOKEN, so the tag push alone publishes
+# nothing — v0.23.0 is tagged and published nothing. `workflow_dispatch` is the
+# documented exception GITHUB_TOKEN may trigger, and dispatching release.yml
+# keeps it the top-level workflow of its run, which is what npm's trusted
+# publisher config names for every @vendoai package (npm validates the calling
+# workflow's filename, so `workflow_call` would break OIDC publishing).
+#
+# RELEASE_PAT (optional repo secret): GitHub also never triggers workflows from
+# the version PR's own commits, so without this secret the version PR gets no
+# checks until someone closes and reopens it. Publishing no longer depends on
+# it. Fine-grained PAT scoped to this repo only — Contents: read+write, Pull
+# requests: read+write — stored as the secret RELEASE_PAT.
 
 on:
   push:
@@ -22,6 +26,8 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # Dispatching release.yml is an Actions write.
+  actions: write
 
 jobs:
   version:
@@ -33,7 +39,7 @@ jobs:
           fetch-depth: 0
           # The PAT has to be here too, not just on the action: changesets/action
           # pushes the version branch with a plain `git push`, so it uses the
-          # credentials checkout persists. The tag push below does the same.
+          # credentials checkout persists.
           token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -50,6 +56,36 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
 
+      # THE 0.x CEILING — deliberate, not a bug. Vendo does not ship 1.0.0 until
+      # Yousef says so, and lifting this ceiling is his call alone: delete this
+      # step (and the `v0.` check in the tag step below) only on his word.
+      #
+      # A major is not a one-package event here. All 13 packages are a single
+      # changesets `fixed` group, so ONE `major` changeset drags every one of
+      # them to 1.0.0 — that is exactly what happened on 2026-08-15, when four
+      # majors put 1.0.0 on all 13 in the version PR and the numbers had to be
+      # walked back by hand. So this does not look for a literal "1.0.0" in a
+      # changeset; it reads the versions the bot actually wrote on its branch —
+      # the same numbers a human reads off the version PR — and fails if any of
+      # them left 0.x. Downgrade the changeset to `minor` and this goes green.
+      - name: Guard the 0.x ceiling
+        if: steps.changesets.outputs.hasChangesets == 'true'
+        run: |
+          set -euo pipefail
+          git fetch origin changeset-release/main
+          crossed=""
+          for f in $(git ls-tree -r --name-only FETCH_HEAD | grep -E '^packages/[^/]+/package\.json$'); do
+            read -r name version <<<"$(git show "FETCH_HEAD:$f" | jq -r '.name + " " + .version')"
+            case "$version" in
+              0.*) ;;
+              *) crossed="$crossed $name@$version" ;;
+            esac
+          done
+          if [ -n "$crossed" ]; then
+            echo "::error::proposed versions left 0.x —$crossed. Vendo stays below 1.0.0 until Yousef lifts the ceiling; use a minor changeset."
+            exit 1
+          fi
+
       # No changesets left = this push is the version PR landing (or an ordinary
       # commit after a release, where the tag already exists and this no-ops), so
       # package.json already holds the released version. `changeset tag` is
@@ -58,10 +94,17 @@ jobs:
       # the single lockstep `v<version>`. packages/vendo is the version of record
       # (scripts/sync-version-constants.mjs reads the same file).
       - name: Push the release tag
+        id: tag
         if: steps.changesets.outputs.hasChangesets == 'false'
         run: |
           set -euo pipefail
           tag="v$(node -p "require('./packages/vendo/package.json').version")"
+          # Second half of the 0.x ceiling above: that guard fails the version
+          # PR, this one refuses to tag or publish a 1.0.0 that got past it.
+          case "$tag" in
+            v0.*) ;;
+            *) echo "::error::$tag left 0.x — Yousef lifts the ceiling, not a release run."; exit 1 ;;
+          esac
           if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
             echo "$tag already exists — nothing to release"
             exit 0
@@ -69,3 +112,15 @@ jobs:
           git tag "$tag"
           git push origin "refs/tags/$tag"
           echo "pushed $tag -> $(git rev-parse HEAD)"
+          echo "tag=$tag" >>"$GITHUB_OUTPUT"
+
+      # The tag push above used GITHUB_TOKEN, so release.yml's `push: tags`
+      # trigger did NOT fire (by GitHub's design) — dispatching it here is what
+      # turns a merged version PR into a published release. `--ref "$tag"` pins
+      # the publish to the exact commit that was tagged, not to whatever main
+      # has drifted to.
+      - name: Publish the tag
+        if: steps.tag.outputs.tag != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run release.yml --ref "${{ steps.tag.outputs.tag }}" -f publish=true


### PR DESCRIPTION
Tonight's release was cut by hand. The cause is one gap: **nothing in this repo can push a tag that GitHub will let trigger another workflow.** `RELEASE_PAT` does not exist, so `version-packages.yml` tags with `GITHUB_TOKEN`, and GitHub by design never fires a workflow from it — `v0.23.0` is tagged and published nothing. `release.yml`'s `workflow_dispatch` was dry-run only, so it was not a fallback either.

## What changes

**Merging the version PR now publishes.** The version workflow pushes the tag as before, then *dispatches* `release.yml` at that tag. `workflow_dispatch` is the one event `GITHUB_TOKEN` is documented to trigger, so this needs no new credential at all.

Dispatch rather than `workflow_call`, deliberately: npm validates the **calling** workflow's filename against each package's trusted publisher config, so making `release.yml` a reusable workflow would break OIDC publishing for all 13 packages until each one is reconfigured on npmjs.com. Same reason the publish loop was not moved into the version workflow.

**The 0.x ceiling.** A new step fails the version workflow if any proposed version left `0.x`. It does not look for a literal `1.0.0` in a changeset — all 13 packages are one changesets `fixed` group, so a single `major` drags every one of them over (that is what happened, and the numbers were walked back by hand). It reads the versions the bot actually wrote on `changeset-release/main`, i.e. the numbers a human reads off the version PR. A second one-line check refuses to tag a non-`v0.` release. **This is a deliberate ceiling, not a bug — lifting it is Yousef's call**, and the workflow comment says so.

**vendo-web bump PR.** Last step of a real publish rewrites the pinned `@vendoai/*` versions in `vendo-web`'s `package.json` (deps + `pnpm.overrides`), refreshes its lockfile with pnpm 9 (what that repo's CI installs with, and it runs `--frozen-lockfile`), and opens the PR. `@vendoai/telemetry` is excluded — it is outside the fixed group.

## Blocked on two secrets that do not exist

Neither is improvised in this PR; both degrade visibly.

| Secret | What to create | Without it |
| --- | --- | --- |
| `RELEASE_PAT` | Fine-grained PAT on `runvendo/vendo` — Contents R/W, Pull requests R/W. Repo secret. | Version PR still gets no CI until closed/reopened. Publishing no longer depends on it. |
| `VENDO_WEB_PAT` | Fine-grained PAT on `runvendo/vendo-web` — Contents R/W, Pull requests R/W. Repo secret **on this repo**. | Last step logs a notice and skips; release is unaffected. |

## Verified

- Both workflows parse; every embedded script passes `bash -n`.
- The 0.x guard was run against a simulated fixed-group major (all 13 at `1.0.0`) — it lists all 13 and fails; against current `main` it passes.
- The `vendo-web` rewrite was run against that repo's real `package.json`: 11 pins bumped, `@vendoai/telemetry` and `@vendoai/agent` untouched, formatting preserved, still valid JSON.

Not touched: `CONTRIBUTING.md` still says releases are tag-driven only (outside this lane's scope), and `ci.yml` is untouched — no overlap with the CI lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Merging the version PR now publishes a release. The version workflow tags as before and then dispatches `release.yml` at that tag, bypassing GitHub’s rule that `GITHUB_TOKEN` tag pushes don’t trigger workflows. A guard prevents any package from leaving `0.x`, and a successful publish opens a `runvendo/vendo-web` PR to bump pinned `@vendoai/*` versions (excluding `@vendoai/telemetry`).

**Rollout notes**
- Publishing runs via a `workflow_dispatch` from `version-packages.yml`; manual runs of `release.yml` are dry-run unless `publish=true`. OIDC trusted publishing in `release.yml` is unchanged.
- Enforced 0.x ceiling: the version job fails if any package on `changeset-release/main` leaves `0.x`; tagging/publishing also refuse non-`v0.*` tags.
- Create `RELEASE_PAT` (repo secret on `runvendo/vendo`, Contents: R/W, Pull requests: R/W) to restore CI on the version PR. Without it, publishing still works.
- Create `VENDO_WEB_PAT` (repo secret on `runvendo/vendo`, token scoped to `runvendo/vendo-web` with Contents: R/W, Pull requests: R/W) to open the bump PR. Without it, the step logs a notice and skips; the release is unaffected.

<sup>Written for commit 3895cd805cb4d28ce42d2ea79402da201a627512. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

