### PR TITLE
feat(core,store,vendo): usage.claim admits a quota and spends it in one step

### DIFF
--- a/.changeset/usage-claim.md
+++ b/.changeset/usage-claim.md
@@ -1,0 +1,64 @@
+---
+"@vendoai/core": minor
+"@vendoai/store": minor
+"@vendoai/vendo": minor
+---
+
+`usage.claim` — a quota is admitted and spent in one step.
+
+`Limiter.gate` was check-then-record. It handed the host's policy a `count`
+closure, awaited the verdict, and only then wrote the usage event — with nothing
+holding the subject in between. Two overlapping requests could both count under
+the cap, both be allowed, and both record, landing one more action than the cap
+permits for however many were genuinely in flight.
+
+The reservation the idempotency ledger takes has no equivalent here, and that is
+what made this awkward rather than obvious: a quota has no unique key to insert
+against, and **the cap belongs to the host, not to Vendo**. `gate` never learns
+the number the policy compared to, cannot know whether the policy will call
+`count` at all, and cannot know how many times. So the reservation is a
+compare-and-swap on the numbers the policy actually read:
+
+```ts
+// gate remembers every count the policy read, then admits only while they hold
+const admitted = await store.ops.usage?.claim?.(event, [{ query, count: 3 }]);
+// true  — the meter has not moved; the event is RECORDED in the same step
+// false — a count moved; nothing was written, so ask the policy again
+```
+
+- **No host API change.** `LimitsCallback` is untouched. A policy still reads
+  `count` and compares it to a cap this side never sees.
+- **An empty stake is an unconditional write.** A policy that never read the
+  meter has no race to lose, so it is admitted on the first pass.
+- **A lost reservation re-asks the policy, it does not deny outright.** Losing
+  means the verdict was reached against numbers that no longer exist, not that
+  the user hit their cap — so the policy decides again on fresh ones. After
+  three passes `gate` DENIES, on the same rule a throwing policy denies under: a
+  cap that is real is not worth admitting over because the meter is busy. This
+  is why `LimitsCallback` is documented as asked "before each" action rather
+  than exactly once, and why a policy should stay a decision with no side
+  effects of its own.
+- **The lock covers what the write touches, not just what was read.** The
+  Postgres implementation takes a transaction-scoped advisory lock over every
+  observed subject/pool AND the event's own `subject`/`poolKeys`, sorted so no
+  two callers can deadlock. Locking only the observed targets leaves the hole
+  intact: a contender who never counts a pool still draws it down, and would
+  slip past an observer of that pool.
+- **A conditional INSERT would not have worked.** `INSERT ... WHERE (SELECT
+  count(*) ...) = n` reads its own snapshot under READ COMMITTED, so both racers
+  count the old number and both insert — the same defect wearing the right
+  shape. The lock is what orders them, and the window it covers is a count and
+  an insert; the host's policy has already returned by then.
+- **OPTIONAL, on `RecordStore.claim`/`atomic`'s rule.** An adapter that cannot
+  reserve omits it and the limiter falls back to count-then-record. The hosted
+  client omits it deliberately: atomicity would have to live in the mount,
+  behind a wire path that does not exist yet, and a client that posted to one
+  anyway would be claiming a guarantee nothing on the other end makes. **Vendo
+  Cloud therefore keeps the bounded overrun until the mount serves the verb.**
+
+Served by the Postgres meter and the in-memory reference, with conformance cases
+run on both — including two claims fired at one instant under a cap of one. The
+kit's mutation suite carries three new proofs, one of them the read-then-write
+implementation that passes every sequential case and still admits both racers.
+
+Closes #1328.

--- a/packages/core/src/conformance/memory-store-ops.ts
+++ b/packages/core/src/conformance/memory-store-ops.ts
@@ -13,6 +13,7 @@ import {
   type RecordInput,
   type RecordQuery,
   type StoreOps,
+  type UsageCountQuery,
   type UsageEvent,
   type UsageTallyRow,
   type VendoRecord,
@@ -913,17 +914,35 @@ export function memoryStoreOps(): StoreOps {
   const inWindow = (event: UsageEvent, window: { since: Date; until?: Date }): boolean =>
     event.at >= window.since && (window.until === undefined || event.at < window.until);
 
+  /** Shared by `count` and `claim` and SYNCHRONOUS on purpose: the claim's
+      check and its write have to be one step, and on one thread that means one
+      turn — an `await` between them is this backend's whole race window. */
+  const countIn = (query: UsageCountQuery): number =>
+    metered.filter((event) =>
+      event.action === query.action
+      && inWindow(event, query)
+      && (query.subject === undefined
+        ? (event.poolKeys ?? []).includes(query.poolKey)
+        : event.subject === query.subject)).length;
+  const store = (event: UsageEvent): void => {
+    metered.push({ ...event, poolKeys: [...event.poolKeys ?? []] });
+  };
+
   const usage: NonNullable<StoreOps["usage"]> = {
     async record(event) {
-      metered.push({ ...event, poolKeys: [...event.poolKeys ?? []] });
+      store(event);
     },
     async count(query) {
-      return metered.filter((event) =>
-        event.action === query.action
-        && inWindow(event, query)
-        && (query.subject === undefined
-          ? (event.poolKeys ?? []).includes(query.poolKey)
-          : event.subject === query.subject)).length;
+      return countIn(query);
+    },
+    async claim(event, observed) {
+      // No await from here to the push: nothing else runs in between, so the
+      // re-check and the write are indivisible without a lock to say so. The
+      // SQL backend has to buy the same thing with one, because it has readers
+      // that genuinely run at once.
+      if (observed.some(({ query, count }) => countIn(query) !== count)) return false;
+      store(event);
+      return true;
     },
     async tally(query) {
       const groups = new Map<string, UsageTallyRow>();

--- a/packages/core/src/conformance/store-ops.ts
+++ b/packages/core/src/conformance/store-ops.ts
@@ -145,6 +145,11 @@ const RETENTION_ABSENT = "this mount omits the retention family (optional — an
 /** ...and for the meter, optional on the same rule. */
 const USAGE_ABSENT = "this mount omits the usage family (optional — a store with nowhere to meter leaves it off, and a limits policy is refused at composition rather than enforced against a meter that reads zero)";
 
+/** ...and for the one verb INSIDE the meter that is optional on its own, the
+    same way `RecordStore.claim` is: an adapter that cannot reserve says so by
+    omitting it, and the limiter falls back to count-then-record. */
+const USAGE_CLAIM_ABSENT = "this mount omits usage.claim (optional — an adapter that cannot reserve leaves it off, and the limiter falls back to count-then-record)";
+
 /** appData rows live in the app's own drawer, and the local backend fails an
     app-scoped write closed when the app has no row — so every appData case
     seeds one first, with the shape the typed `vendo_apps` door accepts. */
@@ -2306,6 +2311,102 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
           [{ subject: "conf_tally_b", action: "message", count: 1 }],
           "narrowing to one subject did not narrow the tally",
         );
+      }),
+
+      /** `claim`'s sequential half — what it admits and what it refuses when
+          nothing is racing. The refusal is the whole verb: a verdict reached
+          against a count that has since moved was decided against a meter that
+          no longer exists, and admitting it anyway is the overrun. */
+      opsCase(opts, "usage.claim records only while the counts the policy read still hold", async (ops) => {
+        const usage = ops.usage;
+        if (usage === undefined) return omitted(USAGE_ABSENT);
+        const claim = usage.claim;
+        if (claim === undefined) return omitted(USAGE_CLAIM_ABSENT);
+        const since = new Date(Date.UTC(2026, 0, 1));
+        const at = new Date(Date.UTC(2026, 0, 2));
+        const query: UsageCountQuery = { subject: "conf_claim", action: "message", since };
+        const counted = async (): Promise<number> => await usage.count(query);
+
+        // A policy that never read the meter has no race to lose, so an empty
+        // observation set is an unconditional write and never a refusal.
+        assert(await claim({ subject: "conf_claim", action: "message", at }, []) === true,
+          "a claim observing nothing was refused, though it staked nothing to be wrong about");
+        assert(await counted() === 1, `an admitted claim must land its event: counted ${await counted()}`);
+
+        // The honest case: the policy read 1, the meter still reads 1.
+        assert(await claim({ subject: "conf_claim", action: "message", at }, [{ query, count: 1 }]) === true,
+          "a claim whose observed count still holds was refused");
+        assert(await counted() === 2, `an admitted claim must land its event: counted ${await counted()}`);
+
+        // The stale case: the policy read 1, the meter has since moved to 2.
+        assert(await claim({ subject: "conf_claim", action: "message", at }, [{ query, count: 1 }]) === false,
+          "a claim against a count that had moved was ADMITTED — this is the overrun the verb exists to stop");
+        assert(await counted() === 2, `a refused claim must write NOTHING: counted ${await counted()}`);
+
+        // Every observation has to hold, not just the first: a policy that read
+        // two windows was judged on both.
+        const other: UsageCountQuery = { subject: "conf_claim", action: "generation", since };
+        assert(
+          await claim({ subject: "conf_claim", action: "message", at }, [{ query, count: 2 }, { query: other, count: 9 }]) === false,
+          "a claim was admitted on its FIRST observation alone, ignoring a second that no longer held",
+        );
+        assert(await counted() === 2, `a refused claim must write NOTHING: counted ${await counted()}`);
+      }),
+
+      /** The claim, RACED — the shape it exists for, and the one `count` +
+          `record` can never pass. Two requests for one subject read an empty
+          meter at the same instant, a cap of one admits both, and the meter
+          must still end at ONE. Which caller wins is the scheduler's business;
+          that exactly one does is the contract.
+
+          The pool leg rides along because it is the hole a check over the
+          OBSERVED targets alone leaves open: the second caller is a different
+          person who never counts the pool at all, so an implementation that
+          serializes on what it read — rather than on what it also WRITES —
+          lets its row into the bucket the first caller was judged against. */
+      opsCase(opts, "usage.claim under a real race admits exactly one of two callers reading one meter", async (ops) => {
+        const usage = ops.usage;
+        if (usage === undefined) return omitted(USAGE_ABSENT);
+        const claim = usage.claim;
+        if (claim === undefined) return omitted(USAGE_CLAIM_ABSENT);
+        const since = new Date(Date.UTC(2026, 0, 1));
+        const at = new Date(Date.UTC(2026, 0, 2));
+
+        // One subject, cap of one: both callers observed the empty meter.
+        const mine: UsageCountQuery = { subject: "conf_claim_race", action: "message", since };
+        const settled = await race(2, () =>
+          claim({ subject: "conf_claim_race", action: "message", at }, [{ query: mine, count: 0 }]));
+        for (const one of settled) {
+          assert(one.status === "fulfilled", `a raced claim failed instead of losing: ${String(refusalCode(one))}`);
+        }
+        const admitted = won(settled).filter((one) => one).length;
+        assert(admitted === 1, `exactly one of two simultaneous claims on a cap of one may be admitted, ${admitted} were`);
+        const held = await usage.count(mine);
+        assert(held === 1, `the meter must hold exactly the one admitted action, it holds ${held}`);
+
+        // The write-target leg, SEQUENCED rather than raced: which caller wins a
+        // race is the scheduler's business, so a race cannot say whether the
+        // loser was re-checked or merely late. A sequence can. The contender is
+        // a DIFFERENT person who never counts the pool — it only draws the
+        // bucket down — so an implementation that re-checks the observed
+        // targets and nothing else never notices its row, and admits an
+        // observer that was judged on a bucket the contender has since filled.
+        const pool: UsageCountQuery = { poolKey: "conf_claim_pool", action: "generation", since };
+        assert(
+          await claim(
+            { subject: "conf_claim_pool_other", action: "generation", at, poolKeys: ["conf_claim_pool"] },
+            [{ query: { subject: "conf_claim_pool_other", action: "generation", since }, count: 0 }],
+          ) === true,
+          "the contender staked only its own empty count and was refused anyway",
+        );
+        assert(
+          await claim(
+            { subject: "conf_claim_pool_mine", action: "generation", at, poolKeys: ["conf_claim_pool"] },
+            [{ query: pool, count: 0 }],
+          ) === false,
+          "a claim was admitted on a pool count of zero that ANOTHER subject's action had already moved to one",
+        );
+        assert(await usage.count(pool) === 1, "the refused pool claim wrote its event anyway");
       }),
 
       // =====================================================================

--- a/packages/core/src/conformance/store-ops.ts
+++ b/packages/core/src/conformance/store-ops.ts
@@ -2384,13 +2384,24 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         const held = await usage.count(mine);
         assert(held === 1, `the meter must hold exactly the one admitted action, it holds ${held}`);
 
-        // The write-target leg, SEQUENCED rather than raced: which caller wins a
-        // race is the scheduler's business, so a race cannot say whether the
-        // loser was re-checked or merely late. A sequence can. The contender is
-        // a DIFFERENT person who never counts the pool — it only draws the
-        // bucket down — so an implementation that re-checks the observed
-        // targets and nothing else never notices its row, and admits an
-        // observer that was judged on a bucket the contender has since filled.
+        // The write-target leg, SEQUENCED rather than raced. The contender is a
+        // DIFFERENT person who never counts the pool — it only draws the bucket
+        // down — so an implementation that re-checks the OBSERVED targets and
+        // nothing else never notices its row, and admits an observer that was
+        // judged on a bucket the contender has since filled.
+        //
+        // Sequenced because the raced form of this has no sound assertion.
+        // Fire the two at once and BOTH orders are legal: contender-first
+        // refuses the observer (pool 1, one admission), observer-first admits
+        // both (pool 2, two admissions) — and the second is also what an
+        // implementation with no lock at all produces, so no post-hoc count
+        // tells the two apart. That is the boundary of this case, and it is a
+        // real one: it pins that the re-check SPANS the pool, and it cannot pin
+        // that the implementation also serializes on what it WRITES. The lock
+        // covering the event's own targets is asserted by construction in the
+        // backend and by nothing here — PGlite has one connection and the
+        // memory reference one thread, so neither can exhibit the interleaving
+        // that would catch its absence.
         const pool: UsageCountQuery = { poolKey: "conf_claim_pool", action: "generation", since };
         assert(
           await claim(

--- a/packages/core/src/limits.ts
+++ b/packages/core/src/limits.ts
@@ -59,8 +59,14 @@ export const limitUserSchema = principalSchema.extend({
   pools: z.array(z.string()).optional(),
 }) satisfies z.ZodType<LimitUser>;
 
-/** The host's policy, asked once before each metered action. Vendo counts;
-    this decides.
+/** The host's policy, asked before each metered action. Vendo counts; this
+    decides.
+
+    Asked "before each" and not "exactly once per": when the meter moves between
+    the `count` this policy read and the write that admits the action, the
+    verdict was reached against numbers that no longer exist, and the policy is
+    asked AGAIN on fresh ones rather than honored over a cap. A policy is a
+    DECISION and should carry no side effects of its own, for that reason.
 
     `count` is a meter reader already bound to THIS user, so a policy never
     names a subject and can never read another person's usage by accident. It

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -396,6 +396,20 @@ export interface UsageTallyRow {
   count: number;
 }
 
+/** One number a policy already decided on, paired with the question that
+    produced it — what {@link StoreOps.usage}'s `claim` re-checks before it
+    admits the action.
+
+    The QUERY travels, not just the number, because the window a policy chose is
+    the only thing that makes the count meaningful: re-counting "messages in the
+    last hour" against a different hour proves nothing about the verdict that was
+    reached. Carrying the query verbatim means the re-check asks the identical
+    question, so a mismatch can only mean the meter moved. */
+export interface UsageObservation {
+  query: UsageCountQuery;
+  count: number;
+}
+
 // ---------------------------------------------------------------------------
 // footprint — what the store is holding
 // ---------------------------------------------------------------------------
@@ -428,14 +442,22 @@ export type EraseTarget =
   | { subject: string; appId?: never }
   | { appId: string; subject?: never };
 
-/** The typed contract for all 48 store operations across 13 families.
-    Lean by design — this is the CONTRACT interface, not the implementation.
+/** The typed contract for all 48 wire-served store operations across 13
+    families, plus `usage.claim`. Lean by design — this is the CONTRACT
+    interface, not the implementation.
 
-    Three members are OPTIONAL, and all three mean the same thing: an
-    implementation that cannot serve the family says so by OMITTING it, never by
+    `usage.claim` is counted apart because it is the one op with no path in
+    `STORE_WIRE_PATHS`, and `status()`'s `ops` level is a count of THAT list: a
+    reservation is one indivisible check and write, which is a thing an
+    implementation either holds a handle to make or does not, never a round trip
+    a client can compose. `IdempotencyLedger` sits outside the interface for the
+    same reason.
+
+    FOUR members are OPTIONAL, and all four mean the same thing: an
+    implementation that cannot serve it says so by OMITTING it, never by
     accepting the call and doing something else (`transcripts.appendMessages`,
-    `retention` and `usage`, following `RecordStore.claim`/`atomic`). Everything
-    else is required. */
+    `retention`, `usage` and `usage.claim`, following
+    `RecordStore.claim`/`atomic`). Everything else is required. */
 export interface StoreOps {
   /** Vendo's OWN engine data — grants, approvals, audit, threads, runs, apps,
       effects, and the automations and guard drawers — reached through seven
@@ -563,6 +585,41 @@ export interface StoreOps {
     record(event: UsageEvent): Promise<void>;
     count(query: UsageCountQuery): Promise<number>;
     tally(query: UsageTallyQuery): Promise<UsageTallyRow[]>;
+    /**
+     * ATOMICALLY record `event`, but ONLY while every number in `observed` is
+     * still what it was — the meter's answer to `IdempotencyLedger.claim`, and
+     * the same move: put the refusal in front of the write instead of behind
+     * it.
+     *
+     * A quota has no unique key to reserve, and the cap is the HOST's, never
+     * Vendo's — a policy is handed a `count` and compares it to a number this
+     * side never sees. So the reservation is a compare-and-swap on the counts
+     * the policy actually read: admit this action only while the meter it was
+     * judged against has not moved. That needs no cap and no host API.
+     *
+     * - `true` — every observed count still holds and the event is RECORDED.
+     * - `false` — a count moved, so the verdict was decided against a meter
+     *   that no longer exists. NOTHING is written; the caller re-asks its
+     *   policy on fresh numbers or denies.
+     *
+     * An EMPTY `observed` records unconditionally and answers `true`: a policy
+     * that never read the meter has no race to lose.
+     *
+     * CONTRACT: the check and the write MUST be one indivisible step against
+     * every target either of them touches — the observed subjects and pools AND
+     * the event's own `subject`/`poolKeys`. Checking only what was observed
+     * leaves the hole this verb exists to close: a writer draining a pool it
+     * never counted invalidates an observer of that pool without ever meeting
+     * it. A plain `INSERT ... WHERE (SELECT count(*) ...) = n` is NOT that step
+     * under READ COMMITTED, where each statement counts its own snapshot and
+     * neither racer sees the other's uncommitted row.
+     *
+     * OPTIONAL, on `RecordStore.claim`/`atomic`'s rule: an adapter that cannot
+     * reserve omits it, and callers fall back to `count`-then-`record` — which
+     * races, bounded by however many requests for one subject are genuinely in
+     * flight at once.
+     */
+    claim?(event: UsageEvent, observed: readonly UsageObservation[]): Promise<boolean>;
   };
   /** The store's secret vault — the values a host's connectors authenticate
       with, kept where the rest of its data is kept.

--- a/packages/core/tests/conformance/store-ops-mutations.test.ts
+++ b/packages/core/tests/conformance/store-ops-mutations.test.ts
@@ -51,7 +51,10 @@ type Flaw =
   | "workspaceNormalisesContent"
   | "readOfNoPathsRefuses"
   | "emptyCommitIsAccepted"
-  | "indexDefaultsElsewhere";
+  | "indexDefaultsElsewhere"
+  | "usageClaimIgnoresItsStake"
+  | "usageClaimReadsThenWrites"
+  | "usageClaimChecksOnlyWhatItRead";
 
 /** A message id nobody would collide with, so `appendNeverEdits` really appends. */
 let nonce = 0;
@@ -63,6 +66,7 @@ let nonce = 0;
 function broken(flaw: Flaw): StoreOps {
   const ops = memoryStoreOps();
   const append = ops.transcripts.appendMessages!;
+  const usage = ops.usage!;
   const yieldToTheOther = async (): Promise<void> => { await Promise.resolve(); };
 
   switch (flaw) {
@@ -233,6 +237,32 @@ function broken(flaw: Flaw): StoreOps {
     case "indexDefaultsElsewhere":
       return { ...ops, workspace: { ...ops.workspace, index: (query) =>
         ops.workspace.index({ ...query, owner: query?.owner ?? "some_other_default" }) } };
+
+    // ---- usage ----------------------------------------------------------
+    case "usageClaimIgnoresItsStake":
+      // A reservation that reserves nothing: it takes the stake, writes anyway,
+      // and reports the admission the caller was hoping for.
+      return { ...ops, usage: { ...usage, async claim(event) {
+        await usage.record(event);
+        return true;
+      } } };
+    case "usageClaimReadsThenWrites":
+      // The defect the verb exists to close, moved inside the verb: the counts
+      // are read, the window opens, and the write lands on a meter that has
+      // moved since. Passes every sequential case ever written.
+      return { ...ops, usage: { ...usage, async claim(event, observed) {
+        const counted = await Promise.all(observed.map(({ query }) => usage.count(query)));
+        await yieldToTheOther(); // the window a second caller lands in
+        if (counted.some((count, index) => count !== observed[index]!.count)) return false;
+        await usage.record(event);
+        return true;
+      } } };
+    case "usageClaimChecksOnlyWhatItRead":
+      // Re-checks the subject stakes and drops the pool ones — the plausible
+      // half-fix, and the one that lets a contender who never counted a bucket
+      // fill it under an observer who did.
+      return { ...ops, usage: { ...usage, claim: (event, observed) =>
+        usage.claim!(event, observed.filter(({ query }) => query.subject !== undefined)) } };
   }
 }
 
@@ -262,6 +292,9 @@ const proofs: Array<{ flaw: Flaw; case: string; red: RegExp }> = [
   { flaw: "readOfNoPathsRefuses", case: "workspace.read of no paths is an empty answer, not a refusal", red: /workspace\.read needs at least one path/ },
   { flaw: "emptyCommitIsAccepted", case: "workspace.commit refuses the same path twice in one commit, and an empty commit", red: /committing no entries at all did not throw/ },
   { flaw: "indexDefaultsElsewhere", case: "the workspace's default owner is one drawer on every verb", red: /an index with no owner did not see a commit with no owner/ },
+  { flaw: "usageClaimIgnoresItsStake", case: "usage.claim records only while the counts the policy read still hold", red: /was ADMITTED — this is the overrun the verb exists to stop/ },
+  { flaw: "usageClaimReadsThenWrites", case: "usage.claim under a real race admits exactly one of two callers reading one meter", red: /exactly one of two simultaneous claims on a cap of one may be admitted, 2 were/ },
+  { flaw: "usageClaimChecksOnlyWhatItRead", case: "usage.claim under a real race admits exactly one of two callers reading one meter", red: /admitted on a pool count of zero that ANOTHER subject's action had already moved/ },
 ];
 
 const caseNamed = (name: string, options: Parameters<typeof storeOpsConformance>[0]) => {

--- a/packages/store/src/hosted-store.ts
+++ b/packages/store/src/hosted-store.ts
@@ -830,6 +830,15 @@ function storeWireClient(
         const payload = await post("usage.tally", P["usage.tally"], { ...query, ...bounds(query) });
         return field<UsageTallyRow[]>(payload, "rows", "invalid usage tally", Array.isArray);
       },
+      // `claim` is DELIBERATELY absent, on the rule that says an adapter which
+      // cannot reserve omits it: the reservation is one indivisible check and
+      // write, and this client holds no handle it could make one on — the
+      // atomicity would have to live in the mount, behind a wire path that does
+      // not exist yet. A client that posted to it anyway would be claiming a
+      // guarantee nothing on the other end makes, which is worse than the
+      // bounded overrun the fallback keeps. Cloud stays on check-then-record
+      // until the mount serves the verb; the limiter reads its absence and says
+      // so in one branch.
     },
     // `get` is the one read in this protocol that answers with a CREDENTIAL. The
     // value rides the body in the clear (TLS is the transport's job) and the

--- a/packages/store/src/ops.ts
+++ b/packages/store/src/ops.ts
@@ -13,6 +13,7 @@ import {
   type RecordStore,
   type StoreOps,
   type UsageCountQuery,
+  type UsageEvent,
   type UsageTallyQuery,
   type UsageTallyRow,
   type VendoRecord,
@@ -238,6 +239,34 @@ async function usageCount(db: Db, query: UsageCountQuery): Promise<number> {
   clauses.push(query.subject === undefined ? `$${params.length} = ANY(pool_keys)` : `subject = $${params.length}`);
   const result = await db.query(`SELECT count(*) AS count FROM vendo_usage WHERE ${clauses.join(" AND ")}`, params);
   return Number(result.rows[0]?.["count"]);
+}
+
+/** The one statement a metered action is written with, on whatever handle the
+ *  caller is holding — the pool for `record`, a transaction's for `claim`. Ids
+ *  are minted here because the contract's event is what HAPPENED, and nothing
+ *  outside this row ever refers to it. */
+async function usageInsert(db: Db, event: UsageEvent): Promise<void> {
+  await db.query(
+    "INSERT INTO vendo_usage (id, subject, action, at, pool_keys) VALUES ($1, $2, $3, $4::timestamptz, $5)",
+    [`usg_${globalThis.crypto.randomUUID()}`, event.subject, event.action, event.at.toISOString(), event.poolKeys ?? null],
+  );
+}
+
+/** The classid every meter lock is taken under. Postgres keeps the two-argument
+ *  advisory key space separate from the one-argument (bigint) space, so nothing
+ *  here can alias the schema lock, which takes the latter. */
+const USAGE_LOCK_CLASS = 7_461_002;
+
+/** A lock key for one meter target, as a signed 32-bit int (FNV-1a). Hashed
+ *  rather than interned because the space is every subject and pool a
+ *  deployment has ever had, and a collision costs two unrelated targets one
+ *  shared lock — extra serialization, never a wrong answer. */
+function usageLockKey(target: string): number {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < target.length; index += 1) {
+    hash = Math.imul(hash ^ target.charCodeAt(index), 0x01000193);
+  }
+  return hash | 0;
 }
 
 /** `usage.tally`'s statement (01 §12 `UsageTallyQuery`) — `auditTally`'s shape
@@ -863,16 +892,50 @@ export function createStoreOps(
     // -----------------------------------------------------------------------
     usage: {
       async record(event) {
-        await db.query(
-          "INSERT INTO vendo_usage (id, subject, action, at, pool_keys) VALUES ($1, $2, $3, $4::timestamptz, $5)",
-          [`usg_${globalThis.crypto.randomUUID()}`, event.subject, event.action, event.at.toISOString(), event.poolKeys ?? null],
-        );
+        await usageInsert(db, event);
       },
       async count(query) {
         return await usageCount(db, query);
       },
       async tally(query) {
         return await usageTally(db, query);
+      },
+      async claim(event, observed) {
+        // The lock, and not a conditional INSERT, is what makes this atomic.
+        // `INSERT ... WHERE (SELECT count(*) ...) = n` reads its own snapshot
+        // under READ COMMITTED, so two racers both count the old number and
+        // both insert — the very defect this verb closes, wearing the right
+        // shape. Holding a lock from BEGIN to COMMIT is what actually orders
+        // them, and the window it covers is a count and an insert, never the
+        // host's policy: that already returned before `claim` was called.
+        //
+        // Every target EITHER half touches, sorted so all callers take them in
+        // one order and no two can deadlock holding each other's. The event's
+        // own targets are in the set because a contender that never counts a
+        // pool still draws it down, and locking only what was observed would
+        // let that row past an observer of that pool.
+        const targets = [...new Set([
+          event.subject,
+          ...event.poolKeys ?? [],
+          ...observed.map(({ query }) => query.subject ?? query.poolKey),
+        ])].sort();
+        return await db.transaction(
+          async (run) => {
+            const tx = txDb(run);
+            for (const { query, count } of observed) {
+              if (await usageCount(tx, query) !== count) return false;
+            }
+            await usageInsert(tx, event);
+            return true;
+          },
+          {
+            beforeWork: async (run) => {
+              for (const target of targets) {
+                await run("SELECT pg_advisory_xact_lock($1, $2)", [USAGE_LOCK_CLASS, usageLockKey(target)]);
+              }
+            },
+          },
+        );
       },
     },
 

--- a/packages/vendo/src/limits.ts
+++ b/packages/vendo/src/limits.ts
@@ -1,7 +1,7 @@
 /**
  * Per-user limits: Vendo counts, the host decides.
  *
- * The host's `limits` callback is asked once before each metered action and its
+ * The host's `limits` callback is asked before each metered action and its
  * verdict is honored. Everything else about a limit lives HERE — reading the
  * meter, invoking the policy, recording what an allow spent, and the fail mode —
  * so a choke point is one `gate` call and can never grow its own half of the
@@ -11,6 +11,16 @@
  * limits system that fails open stops limiting silently, so the host keeps
  * believing they have a cap while every user is unlimited — strictly worse than
  * a turn that was refused and said so.
+ *
+ * ADMISSION is the other half, and it is why the policy is asked "before each"
+ * action rather than exactly once. The meter is read INSIDE the host's callback
+ * and the allow is written after it returns, so on its own that is check-then-do
+ * and concurrent actions for one subject can each pass a cap only one of them
+ * fits under. `usage.claim` closes it by writing only while every number the
+ * policy read still holds; when it does not, the policy is asked AGAIN on fresh
+ * numbers rather than admitted on stale ones. An adapter with no `claim` keeps
+ * the old check-then-record behavior, which is the bounded overrun and not a
+ * silent one.
  */
 import {
   VENDO_MAKE_TOOL,
@@ -24,6 +34,8 @@ import {
   type RunContext,
   type StoreOps,
   type ToolRegistry,
+  type UsageCountQuery,
+  type UsageObservation,
   type VendoViewStreamingToolCall,
 } from "@vendoai/core";
 import type { VendoComposition } from "./compose-context.js";
@@ -41,6 +53,13 @@ const HOUR = 60 * MINUTE;
 const DAY = 24 * HOUR;
 /** `UsageCountQuery.since` is required, so "all time" is the epoch. */
 const ALL_TIME = new Date(0);
+
+/** How many times a contended admission re-asks the policy before denying.
+ *  Small on purpose: losing the reservation means another action for this same
+ *  subject landed in the window between the policy's read and this write, which
+ *  is bounded by how many are genuinely in flight — a number that does not
+ *  reward spinning. Three passes and then the fail-closed answer. */
+const ADMISSION_ATTEMPTS = 3;
 
 /** The host's policy, bound to the meter it decides on.
  *
@@ -60,45 +79,91 @@ export function createLimiter({ callback, ops }: {
         ...(ctx.user === undefined ? {} : { facts: ctx.user }),
         ...(ctx.pools === undefined ? {} : { pools: Object.keys(pools) }),
       };
-      // Pre-bound to THIS subject: a policy never names one, so it can never
-      // read another person's usage by accident.
-      const count = (counted: LimitAction, window?: LimitWindow): Promise<number> => {
-        const lookback = (window?.days ?? 0) * DAY + (window?.hours ?? 0) * HOUR
-          + (window?.minutes ?? 0) * MINUTE;
-        const since = lookback > 0 ? new Date(Date.now() - lookback) : window?.since ?? ALL_TIME;
-        if (window?.pool === undefined) return ops.count({ action: counted, since, subject });
-        const poolKey = pools[window.pool];
-        // A pool this user is not in is an ERROR, never a zero: answering 0 for
-        // a meter that was never resolved silently under-counts every limit
-        // written against it, and the deny below is the only safe answer.
-        if (poolKey === undefined) {
-          throw new VendoError(
-            "validation",
-            `The limits policy counted the \`${window.pool}\` pool, which this user is not in `
-            + `(their pools: ${Object.keys(pools).map((name) => `\`${name}\``).join(", ") || "none"}). `
-            + "Pools come from the auth preset's `pools` seam — assert the pool there, or count a pool the user is in.",
-          );
+      /** One pass at the policy: its verdict, and every number it reached that
+          verdict on. A pass owns its own observations because a re-ask is
+          judged on FRESH numbers — replaying the stale ones that just lost a
+          race would re-stake the losing bet. */
+      const ask = async (): Promise<{ verdict: LimitVerdict; observed: UsageObservation[] }> => {
+        // Kept as the QUERY that produced it, not the number alone: `claim`
+        // re-asks the identical question, so a mismatch can only mean the meter
+        // moved. Keyed so a policy that asks the same thing twice stakes it once.
+        const seen = new Map<string, UsageObservation>();
+        const observe = async (query: UsageCountQuery): Promise<number> => {
+          const counted = await ops.count(query);
+          const key = JSON.stringify([query.action, query.subject, query.poolKey, query.since.valueOf(), query.until?.valueOf()]);
+          seen.set(key, { query, count: counted });
+          return counted;
+        };
+        // Pre-bound to THIS subject: a policy never names one, so it can never
+        // read another person's usage by accident.
+        const count = (counted: LimitAction, window?: LimitWindow): Promise<number> => {
+          const lookback = (window?.days ?? 0) * DAY + (window?.hours ?? 0) * HOUR
+            + (window?.minutes ?? 0) * MINUTE;
+          const since = lookback > 0 ? new Date(Date.now() - lookback) : window?.since ?? ALL_TIME;
+          if (window?.pool === undefined) return observe({ action: counted, since, subject });
+          const poolKey = pools[window.pool];
+          // A pool this user is not in is an ERROR, never a zero: answering 0 for
+          // a meter that was never resolved silently under-counts every limit
+          // written against it, and the deny below is the only safe answer.
+          if (poolKey === undefined) {
+            throw new VendoError(
+              "validation",
+              `The limits policy counted the \`${window.pool}\` pool, which this user is not in `
+              + `(their pools: ${Object.keys(pools).map((name) => `\`${name}\``).join(", ") || "none"}). `
+              + "Pools come from the auth preset's `pools` seam — assert the pool there, or count a pool the user is in.",
+            );
+          }
+          return observe({ action: counted, since, poolKey });
+        };
+
+        let decision;
+        try {
+          decision = await callback({ user, action, count });
+        } catch (error) {
+          log({
+            code: "limits.callback_error",
+            level: "error",
+            message: `[vendo] the limits policy failed for ${subject}; DENYING the ${action} (a limits policy that fails open stops limiting):`,
+            data: { error },
+          });
+          return { verdict: { allow: false }, observed: [] };
         }
-        return ops.count({ action: counted, since, poolKey });
+        const verdict: LimitVerdict = decision === true
+          ? { allow: true }
+          : decision === false ? { allow: false } : decision;
+        return { verdict, observed: [...seen.values()] };
       };
 
-      let decision;
-      try {
-        decision = await callback({ user, action, count });
-      } catch (error) {
-        log({
-          code: "limits.callback_error",
-          level: "error",
-          message: `[vendo] the limits policy failed for ${subject}; DENYING the ${action} (a limits policy that fails open stops limiting):`,
-          data: { error },
-        });
-        return { allow: false };
+      for (let attempt = 1; attempt <= ADMISSION_ATTEMPTS; attempt += 1) {
+        const { verdict, observed } = await ask();
+        if (!verdict.allow) return verdict;
+        // Awaited, not fire-and-forget: the next action's count has to see this
+        // one, and a dropped write is a limit that never arrives.
+        const event = { subject, action, at: new Date(), poolKeys: Object.values(pools) };
+        if (ops.claim === undefined) {
+          // The adapter cannot reserve, so this is the check-then-record the
+          // meter has always been: concurrent actions for one subject can each
+          // pass a cap only one of them fits under, bounded by how many are
+          // genuinely in flight.
+          await ops.record(event);
+          return { allow: true };
+        }
+        // The verdict was reached against numbers that must still be true when
+        // the action lands. If they are, this admits and writes in one step; if
+        // they are not, nothing was written and the policy decides again.
+        if (await ops.claim(event, observed)) return { allow: true };
       }
-      if (decision !== true) return decision === false ? { allow: false } : decision;
-      // Awaited, not fire-and-forget: the next action's count has to see this
-      // one, and a dropped write is a limit that never arrives.
-      await ops.record({ subject, action, at: new Date(), poolKeys: Object.values(pools) });
-      return { allow: true };
+      // Every pass was outrun. DENY, on the same rule a throwing policy denies
+      // under: the cap this action would land over is real, and admitting it
+      // because the meter is busy is the overrun with extra steps.
+      log({
+        code: "limits.admission_contended",
+        level: "warn",
+        message: `[vendo] the meter moved under the limits policy ${ADMISSION_ATTEMPTS} times running for ${subject}; `
+          + `DENYING the ${action} rather than admitting it over a cap`,
+        data: { subject, action },
+      });
+      return { allow: false };
     },
   };
 }

--- a/packages/vendo/src/limits.ts
+++ b/packages/vendo/src/limits.ts
@@ -86,12 +86,18 @@ export function createLimiter({ callback, ops }: {
       const ask = async (): Promise<{ verdict: LimitVerdict; observed: UsageObservation[] }> => {
         // Kept as the QUERY that produced it, not the number alone: `claim`
         // re-asks the identical question, so a mismatch can only mean the meter
-        // moved. Keyed so a policy that asks the same thing twice stakes it once.
+        // moved.
         const seen = new Map<string, UsageObservation>();
         const observe = async (query: UsageCountQuery): Promise<number> => {
           const counted = await ops.count(query);
           const key = JSON.stringify([query.action, query.subject, query.poolKey, query.since.valueOf(), query.until?.valueOf()]);
-          seen.set(key, { query, count: counted });
+          // A repeated question stakes its FIRST answer, never its latest. The
+          // policy's decision rests on everything it read, so the stake has to
+          // span from the earliest read to the write — keeping the latest would
+          // narrow the window to the last `await` and quietly accept a meter
+          // that moved while the policy was still deciding on it. Same-window
+          // counts only grow, so the first answer is also the strictest.
+          if (!seen.has(key)) seen.set(key, { query, count: counted });
           return counted;
         };
         // Pre-bound to THIS subject: a policy never names one, so it can never

--- a/packages/vendo/tests/limits.test.ts
+++ b/packages/vendo/tests/limits.test.ts
@@ -185,6 +185,133 @@ describe("the meter reader the policy is handed", () => {
   });
 });
 
+describe("admission — the verdict and the write are one step", () => {
+  const logged = (): VendoLogEvent[] => {
+    const events: VendoLogEvent[] = [];
+    setLogger((event) => events.push(event));
+    return events;
+  };
+
+  /** The reference meter with its reservation forced to lose `failures` times,
+      standing in for another request landing in the window the policy's read
+      opened. Everything else is the real drawer. */
+  const outrun = (usage: Meter, failures: number): Meter => {
+    let left = failures;
+    return {
+      ...usage,
+      claim: async (event, observed) => {
+        if (left > 0) { left -= 1; return false; }
+        return await usage.claim!(event, observed);
+      },
+    };
+  };
+
+  /** The same ops with the OPTIONAL verb genuinely absent — an adapter that
+      cannot reserve, which is every hosted client today. */
+  const unreserving = (usage: Meter): Meter => {
+    const { claim: _absent, ...rest } = usage;
+    return rest as Meter;
+  };
+
+  it("admits ONE of two concurrent actions under a cap of one", async () => {
+    const usage = meter();
+    const limiter = createLimiter({
+      callback: async ({ count }) => (await count("message")) < 1,
+      ops: usage,
+    });
+
+    const verdicts = await Promise.all([limiter.gate("message", ctxFor()), limiter.gate("message", ctxFor())]);
+
+    expect(verdicts.filter((verdict) => verdict.allow)).toHaveLength(1);
+    expect(await usage.count({ action: "message", subject: "mia", since: ALL_TIME })).toBe(1);
+  });
+
+  it("keeps a pool's cap when the two actions are DIFFERENT people", async () => {
+    const usage = meter();
+    const limiter = createLimiter({
+      callback: async ({ count }) => (await count("generation", { pool: "workspace" })) < 1,
+      ops: usage,
+    });
+    const inWorkspace = (subject: string): RunContext =>
+      ctxFor({ principal: { kind: "user", subject }, pools: { workspace: "ws_maple" } });
+
+    const verdicts = await Promise.all([
+      limiter.gate("generation", inWorkspace("mia")),
+      limiter.gate("generation", inWorkspace("raj")),
+    ]);
+
+    expect(verdicts.filter((verdict) => verdict.allow)).toHaveLength(1);
+    expect(await usage.count({ action: "generation", poolKey: "ws_maple", since: ALL_TIME })).toBe(1);
+  });
+
+  it("asks the policy AGAIN on fresh numbers when the meter moved under it", async () => {
+    const usage = meter();
+    const seen: number[] = [];
+    const limiter = createLimiter({
+      callback: async ({ count }) => { seen.push(await count("message")); return true; },
+      ops: outrun(usage, 1),
+    });
+
+    await expect(limiter.gate("message", ctxFor())).resolves.toEqual({ allow: true });
+    // Twice, and the second pass read the meter for itself rather than
+    // re-staking the number the first pass lost with.
+    expect(seen).toHaveLength(2);
+    expect(await usage.count({ action: "message", subject: "mia", since: ALL_TIME })).toBe(1);
+  });
+
+  it("DENIES rather than admit over a cap when every pass is outrun", async () => {
+    const events = logged();
+    const usage = meter();
+    const limiter = createLimiter({ callback: () => true, ops: outrun(usage, Number.MAX_SAFE_INTEGER) });
+
+    await expect(limiter.gate("message", ctxFor())).resolves.toEqual({ allow: false });
+    expect(events.filter((event) => event.code === "limits.admission_contended")).toHaveLength(1);
+    expect(await usage.count({ action: "message", subject: "mia", since: ALL_TIME })).toBe(0);
+  });
+
+  it("stakes NOTHING for a policy that never read the meter", async () => {
+    const usage = meter();
+    // A reservation that refuses every non-empty stake: a policy that counted
+    // nothing has none, so this must still be admitted on the first pass.
+    let staked: number | undefined;
+    const limiter = createLimiter({
+      callback: () => true,
+      ops: { ...usage, claim: async (event, observed) => { staked = observed.length; return await usage.claim!(event, observed); } },
+    });
+
+    await expect(limiter.gate("message", ctxFor())).resolves.toEqual({ allow: true });
+    expect(staked).toBe(0);
+    expect(await usage.count({ action: "message", subject: "mia", since: ALL_TIME })).toBe(1);
+  });
+
+  it("falls back to count-then-record against an adapter that cannot reserve", async () => {
+    const usage = meter();
+    const limiter = createLimiter({ callback: () => true, ops: unreserving(usage) });
+
+    await expect(limiter.gate("message", ctxFor())).resolves.toEqual({ allow: true });
+    expect(await usage.count({ action: "message", subject: "mia", since: ALL_TIME })).toBe(1);
+  });
+
+  /** The defect itself, pinned against the fallback — and the reason the case
+      above it is worth anything. The SAME race, the SAME cap, the only
+      difference being an adapter that cannot reserve: both actions are admitted
+      and the meter ends at two. This is the bounded overrun Cloud still carries
+      until the mount serves the verb, and it fails the day the fallback stops
+      being the fallback — which is exactly when it should. */
+  it("over-admits WITHOUT a reservation — the bounded overrun the fallback keeps", async () => {
+    const usage = meter();
+    const limiter = createLimiter({
+      callback: async ({ count }) => (await count("message")) < 1,
+      ops: unreserving(usage),
+    });
+
+    const verdicts = await Promise.all([limiter.gate("message", ctxFor()), limiter.gate("message", ctxFor())]);
+
+    expect(verdicts.filter((verdict) => verdict.allow)).toHaveLength(2);
+    expect(await usage.count({ action: "message", subject: "mia", since: ALL_TIME })).toBe(2);
+  });
+});
+
 describe("the user the policy decides about", () => {
   it("is the resolved principal, the host's facts, and the pool NAMES", async () => {
     let seen: LimitUser | undefined;

--- a/packages/vendo/tests/limits.test.ts
+++ b/packages/vendo/tests/limits.test.ts
@@ -10,7 +10,7 @@
  * OPEN stops limiting silently, which is strictly worse than refusing a turn:
  * the host believes they have a cap, and every user is unlimited.
  */
-import { setLogger, type LimitUser, type RunContext, type StoreOps, type VendoLogEvent } from "@vendoai/core";
+import { setLogger, type LimitUser, type RunContext, type StoreOps, type UsageObservation, type VendoLogEvent } from "@vendoai/core";
 import { memoryStoreOps } from "@vendoai/core/conformance";
 import { createStore, type VendoStore } from "@vendoai/store";
 import { afterEach, describe, expect, it } from "vitest";
@@ -267,6 +267,37 @@ describe("admission — the verdict and the write are one step", () => {
     await expect(limiter.gate("message", ctxFor())).resolves.toEqual({ allow: false });
     expect(events.filter((event) => event.code === "limits.admission_contended")).toHaveLength(1);
     expect(await usage.count({ action: "message", subject: "mia", since: ALL_TIME })).toBe(0);
+  });
+
+  /** A policy that reads one window twice stakes the FIRST answer. Keeping the
+      latest would narrow the stake to the last `await` and admit on a meter
+      that moved while the policy was still deciding on it — the decision rests
+      on everything it read, so the stake has to span from the earliest read. */
+  it("stakes a repeated question's FIRST answer, not its latest", async () => {
+    const usage = meter();
+    const staked: UsageObservation[][] = [];
+    let intrudes = true;
+    const limiter = createLimiter({
+      callback: async ({ count }) => {
+        await count("message");
+        if (intrudes) {
+          // Another request lands mid-decision, exactly where the policy's own
+          // awaits leave room for one. Once only, so the second pass can settle.
+          intrudes = false;
+          await usage.record({ subject: "mia", action: "message", at: new Date() });
+        }
+        await count("message");
+        return true;
+      },
+      ops: { ...usage, claim: async (event, observed) => { staked.push([...observed]); return await usage.claim!(event, observed); } },
+    });
+
+    await expect(limiter.gate("message", ctxFor())).resolves.toEqual({ allow: true });
+
+    // The first pass read 0 and then 1. Staking the LATEST would have staked 1
+    // and been admitted on a count the decision never rested on; staking the
+    // first loses, and the policy is asked again on numbers that hold.
+    expect(staked.map((one) => one.map((obs) => obs.count))).toEqual([[0], [1]]);
   });
 
   it("stakes NOTHING for a policy that never read the meter", async () => {


### PR DESCRIPTION
Closes #1328.

## The problem

`Limiter.gate` was check-then-record. It handed the host's policy a `count` closure, awaited the verdict, and only then wrote the usage event — with nothing holding the subject in between. Two overlapping requests could both count under the cap, both be allowed, and both record.

## Why the idempotency `claim` trick doesn't transfer

A quota has no unique key to insert against, and **the cap belongs to the host, not to Vendo**. `gate` never learns the number the policy compared to, cannot know whether the policy will call `count` at all, and cannot know how many times. So there is nothing to reserve.

The reservation is instead a **compare-and-swap on the numbers the policy actually read** — admit the action only while the meter it was judged against has not moved:

```ts
const admitted = await store.ops.usage?.claim?.(event, [{ query, count: 3 }]);
// true  — the meter has not moved; the event is RECORDED in the same step
// false — a count moved; nothing was written, so ask the policy again
```

No `LimitsCallback` change. An empty stake (a policy that never read the meter) is an unconditional write.

## Two things worth reviewing closely

**The lock covers what the write TOUCHES, not just what was read.** Postgres takes a transaction-scoped advisory lock over every observed subject/pool *and* the event's own `subject`/`poolKeys`, sorted so no two callers deadlock. Locking only the observed targets leaves the hole intact: a contender who never counts a pool still draws it down, and would slip past an observer of that pool. There is a conformance case for exactly this.

**A conditional INSERT would not have worked.** `INSERT ... WHERE (SELECT count(*) ...) = n` reads its own snapshot under READ COMMITTED, so both racers count the old number and both insert — the same defect wearing the right shape. The lock is what orders them, and the window it covers is a count and an insert; the host's policy has already returned by then.

## Behavior change worth flagging

A lost reservation **re-asks the policy** rather than denying outright — losing means the verdict was reached against numbers that no longer exist, not that the user hit their cap. After three passes `gate` DENIES, on the same rule a throwing policy denies under. `LimitsCallback` is now documented as asked "before each" action rather than exactly once, and as a decision that should carry no side effects of its own.

## Scope note: Cloud still carries the overrun

`claim` is OPTIONAL on `RecordStore.claim`/`atomic`'s rule. **The hosted client omits it deliberately** — atomicity would have to live in the mount, behind a wire path that does not exist yet, and a client posting to one anyway would be claiming a guarantee nothing on the other end makes. Cloud stays on check-then-record until `vendo-web` serves the verb. That is the one part of #1328's stated scope this PR does not close, and it needs a follow-up in the console.

`usage.claim` has no `STORE_WIRE_PATHS` entry, so `status()`'s `ops: 48` is unchanged.

## Test plan

- [x] Two conformance cases, run against **both** the Postgres meter and the in-memory reference: the sequential re-check, and two claims fired at one instant under a cap of one.
- [x] Three new mutation proofs in the kit's mutation suite — `usageClaimIgnoresItsStake`, `usageClaimReadsThenWrites` (the read-then-write implementation that passes every sequential case and still admits both racers), and `usageClaimChecksOnlyWhatItRead` (the plausible half-fix that drops pool stakes).
- [x] Limiter tests: concurrent admission under a cap of one, the pool cap across two different people, re-ask on a moved meter, fail-closed after three contended passes, empty stake, and the fallback path.
- [x] A test pinning the fallback's **known** over-admission (2 admitted under a cap of 1), so the race cases above are proven to discriminate rather than pass vacuously.
- [x] Local gate: `pnpm build && pnpm typecheck && pnpm lint` green; `core` 770, `store` 778, `vendo` 2400 tests pass.
- [ ] CI `ci` / `integration` / `conformance` / `audit`.

Pre-existing and unrelated on this checkout: 45 `@vendoai/ui` test failures (identical on clean `main`) and `genbench`'s missing Playwright browser binaries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds atomic `usage.claim` and makes the limiter admit and spend quota in one step. Previously `Limiter.gate` was check‑then‑record; now admission compares the counts the policy read and writes only while they still hold. Repeated counts stake the first answer to cover the full decision window. Closes #1328.

- Store (`@vendoai/core`, `@vendoai/store`): adds optional `StoreOps.usage.claim(event, observed: UsageObservation[])`. Postgres takes transaction‑scoped advisory locks over all observed subjects/pools and the event’s `subject`/`poolKeys` (sorted to avoid deadlocks) and writes; memory backend re‑checks and writes in one synchronous turn. `usage.claim` has no `STORE_WIRE_PATHS` entry, so `status().ops` is unchanged.
- Limiter (`@vendoai/vendo`): records every `count` the policy calls, keyed by query, and stakes the FIRST answer for any repeated count; then attempts `claim`. If the meter moved, it re‑asks the policy on fresh numbers; after three contended passes, it denies and logs a warning. An empty observation set admits unconditionally. `LimitsCallback` is asked “before each” action; its signature is unchanged.
- Rollout: no required host changes. Adapters can implement `usage.claim` to get atomic admission; if omitted, the limiter falls back to count‑then‑record (bounded overrun remains). The hosted client in `@vendoai/store` omits `claim` until the mount serves the verb, so Cloud behavior is unchanged.

<sup>Written for commit f77546d5831864e760db7c0a7e8b5ee6d780cbe1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

