### PR TITLE
test(ui): the kit fixtures catch up to the types tsc now checks them against

### DIFF
--- a/packages/ui/test/kit/data-table.test.tsx
+++ b/packages/ui/test/kit/data-table.test.tsx
@@ -300,8 +300,8 @@ describe("DataTable", () => {
       settle: () => act(() => resize()),
       restore: () => {
         globalThis.ResizeObserver = observers;
-        delete (HTMLElement.prototype as Partial<HTMLElement>).offsetWidth;
-        delete (HTMLElement.prototype as Partial<HTMLElement>).clientWidth;
+        Reflect.deleteProperty(HTMLElement.prototype, "offsetWidth");
+        Reflect.deleteProperty(HTMLElement.prototype, "clientWidth");
       },
     };
   }

--- a/packages/ui/test/kit/slots.test.tsx
+++ b/packages/ui/test/kit/slots.test.tsx
@@ -128,7 +128,7 @@ describe("what a slot promises beyond landing", () => {
     // recharts hands its `content` the payload of whatever is under the pointer;
     // the slot reads it through `field`, exactly as a table cell reads its row.
     const Hover = slotTooltip(<Money field="amount" />);
-    render(<Hover payload={[{ payload: { month: "Mar", amount: 1250 } }]} />);
+    render(<Hover payload={[{ graphicalItemId: "amount", payload: { month: "Mar", amount: 1250 } }]} />);
     expect(screen.getByText("$1,250.00")).toBeTruthy();
   });
 


### PR DESCRIPTION
`main` is red. #1335 landed with a failing `typecheck-lint` job, which cascades into `vendoai:typecheck`. `pnpm build` passes — only typecheck is broken. This is a test-file-only fix; no product code and no published surface moves, so no changeset.

## What broke

#1332 brought the ui test files under `tsc`. #1335's new kit fixtures were written against the looser rules that came before it, so they went in unchecked.

**`test/kit/data-table.test.tsx:303,304` — TS2704, `delete` on a read-only property.** The restore path casts to `Partial<HTMLElement>` to make the stubbed `offsetWidth`/`clientWidth` deletable. That cast never worked: `Partial` is homomorphic, so it preserves `readonly`, and both props are readonly on `HTMLElement`. Fixed with `Reflect.deleteProperty`, which removes the stub without needing a writable view at all — the pattern `test/chrome/mobile-takeover.test.tsx` already uses. The cast goes away rather than getting widened.

**`test/kit/slots.test.tsx:131` — TS2741, missing `graphicalItemId`.** recharts' `Payload<ValueType, NameType>` requires `graphicalItemId: string`; it is the only required field on the interface. The hovered-point literal named only `payload`. Fixed by constructing the point with the field it needs (`graphicalItemId: "amount"`, the series the point belongs to).

## Is the product wrong?

No — both sites are stale fixtures. `slotTooltip` (`packages/ui/src/kit/charts/sanitize.tsx:105`) types its props as `Pick<TooltipContentProps<number, string>, "payload">`, which mirrors what recharts actually hands `content`. The product type is correct and the test literal was the incomplete half. No `as any`, no `@ts-expect-error`, no `@ts-ignore` anywhere in this change.

## Gate

Run on the branch, full logs read back:

| | |
|---|---|
| `pnpm build` | pass |
| `pnpm typecheck` | pass (42/42 tasks) |
| `pnpm lint` | pass (4 pre-existing demo-bank warnings, 0 errors) |
| `pnpm --filter @vendoai/ui test` | pass — 138 files, 1213 tests |

3 lines changed across 2 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TypeScript typecheck failures on `main` by updating UI test fixtures to match current rules. Previously tests deleted readonly `HTMLElement` properties and omitted a required `recharts` tooltip field; now they use `Reflect.deleteProperty` and include `graphicalItemId`, restoring passing CI without product changes.

- Tests-only change in `packages/ui/test`; no product code, no published surface, no changeset.
- `data-table.test.tsx`: replace `delete` on `HTMLElement.prototype` via `Partial<HTMLElement>` with `Reflect.deleteProperty` for `offsetWidth` and `clientWidth`.
- `slots.test.tsx`: add `graphicalItemId: "amount"` to the hovered point payload to satisfy `recharts` `Payload` requirements.
- Validation: `pnpm build`, `pnpm typecheck`, `pnpm lint`, and `pnpm --filter @vendoai/ui test` all pass.

<sup>Written for commit 2d97e1e8543b9c90236bcbb8d546a6185dfdaff0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

