### PR TITLE
fix(genbench): corpus repairs — every pass line the probe can actually grade

### DIFF
--- a/genbench/tests/worlds.test.ts
+++ b/genbench/tests/worlds.test.ts
@@ -211,14 +211,21 @@ for (const name of folders) {
       expect(offenders, "a case with no pass lines is graded on nothing").toEqual([]);
     });
 
-    it("tags every case display or action, at least three of them actions", () => {
+    it("tags every case display or action, at least two of them actions", () => {
       const mistagged = cases
         .filter((entry) => (entry.tags ?? []).filter((tag) => CASE_TAGS.includes(tag)).length !== 1)
         .map((entry) => entry.id);
       expect(mistagged, "each case carries exactly one of display | action").toEqual([]);
 
+      // Two, not three: `action` is what makes the floor demand an OBSERVED tool
+      // call, and the probe only reaches a control that fires from the default
+      // state in one click, optionally through one confirmation dialog. A wizard
+      // whose write sits on step three is graded on its shape, so it is tagged
+      // `display` however much it is "about" a write — which leaves a world with
+      // a single write tool (fieldops, `dispatch_job`) two honest action cases,
+      // and a third could only be invented.
       const actions = cases.filter((entry) => (entry.tags ?? []).includes("action"));
-      expect(actions.length, "a world whose cases never act grades no write tool").toBeGreaterThanOrEqual(3);
+      expect(actions.length, "a world whose cases never act grades no write tool").toBeGreaterThanOrEqual(2);
     });
 
     it("gives every case one shape, and any source it names a real one", () => {

--- a/genbench/worlds/buildlog/cases.json
+++ b/genbench/worlds/buildlog/cases.json
@@ -119,12 +119,12 @@
   {
     "id": "rerun-by-number",
     "lane": "screen",
-    "prompt": "Give me a small form where I pick a run and re-trigger it.",
+    "prompt": "Give me a small form where I pick a run and re-trigger it, starting on the newest run.",
     "pass": [
       "offers one field to choose the run, listing the six by number and commit message",
-      "shows the chosen run's branch and status before anything fires",
-      "has exactly one submit control, which is disabled or refuses until a run is chosen",
-      "submitting fires retry_build once, with the chosen run's id"
+      "the field starts on 4192, the newest run, and the screen shows that run's branch and status before anything fires",
+      "has exactly one submit control",
+      "submitting fires retry_build once, with bld_4192 — the run the form is showing"
     ],
     "tags": ["action"],
     "shape": "form"

--- a/genbench/worlds/buildlog/world.json
+++ b/genbench/worlds/buildlog/world.json
@@ -32,13 +32,13 @@
     "dark console: near-black #0A0C10 page, #12161D panels, hairline #1E2530 borders — never a light background",
     "uses the theme exactly: the blue accent, Inter for prose and the theme's mono family for shas, branches and log output — no invented colors or fonts",
     "build status reads as a labelled word or pill — passed, failed, running, cancelled — never color alone",
-    "durations read as '4m 28s', never a raw count of seconds",
+    "durations read as '3m 12s', never a raw count of seconds",
     "money shows a $ symbol and 2 decimals, converted from the tools' cents",
     "a commit shows as its 7-character short sha beside the message, never as a bare id"
   ],
   "tools": {
     "list_builds": {
-      "does": "The most recent pipeline runs, newest first. The rows are the `data` array. `duration_seconds` is how long the run took, and is how far a running build has got so far. `compute_cost` is in CENTS: 1870 is $18.70.",
+      "does": "The most recent pipeline runs, newest first. The rows are the `data` array. `duration_seconds` is how long the run took, and is how far a running build has got so far. `compute_cost` is in CENTS: 1870 is $18.70. Today is 2026-08-15 and it is about 10:00 AM.",
       "data": {
         "data": [
           { "id": "bld_4192", "number": 4192, "branch": "feat/timeline-brick", "commit": "5ba9e70", "message": "ui: the Timeline brick", "author": "Theo Lindqvist", "status": "running", "started": "2026-08-15 09:58", "duration_seconds": 133, "compute_cost": 620 },

--- a/genbench/worlds/clinic-scheduling/cases.json
+++ b/genbench/worlds/clinic-scheduling/cases.json
@@ -140,7 +140,7 @@
       "names Ruth Ozawa as the patient being booked, so no step has to ask who it is for",
       "nothing on the first step books anything — no press before the last step calls the booking tool"
     ],
-    "tags": ["action"],
+    "tags": ["display"],
     "shape": "wizard",
     "source": "Jane — Online booking (patient-facing), https://jane.app/features/online-booking"
   },

--- a/genbench/worlds/clinic-scheduling/cases.json
+++ b/genbench/worlds/clinic-scheduling/cases.json
@@ -111,7 +111,7 @@
     "pass": [
       "lists the appointments still to come that the patient has not confirmed, and no others",
       "offers one control that texts all of them at once",
-      "asks for confirmation before anything sends, saying how many people will be texted",
+      "that control says how many people it will text, and pressing it asks for confirmation before anything sends",
       "confirming calls the reminder tool once for each of those appointments"
     ],
     "tags": ["action"],
@@ -135,11 +135,10 @@
     "lane": "screen",
     "prompt": "Book Ruth in the way a patient would — treatment, then provider, then a time, one step at a time.",
     "pass": [
-      "asks for one thing at a time — what the visit is for, then the provider, then the time — never all at once",
-      "the provider step offers the providers the tool returned, not invented ones",
-      "the time step offers only today's open slots, shown as times",
-      "shows a confirmation step naming Ruth Ozawa, the chosen provider and the chosen time before anything is booked",
-      "confirming calls the booking tool with Ruth Ozawa and the slot that was picked"
+      "shows only the first step when it loads — what the visit is for — with the provider step and the time step named as what comes next, never all three at once",
+      "the first step's choices are visit types, not providers and not slot times",
+      "names Ruth Ozawa as the patient being booked, so no step has to ask who it is for",
+      "nothing on the first step books anything — no press before the last step calls the booking tool"
     ],
     "tags": ["action"],
     "shape": "wizard",
@@ -153,7 +152,7 @@
       "shows Dr. Sven Lindqvist's own settings, not every provider's",
       "offers a control for whether he takes new patients, reading as accepting when the screen loads",
       "offers a control for his default visit length, starting at the tool's 30 minutes",
-      "saving calls the settings tool with Lindqvist, no longer accepting new patients, and a shorter default length"
+      "saving calls the settings tool with Lindqvist and the values on screen, never another provider's"
     ],
     "tags": ["action"],
     "shape": "settings",
@@ -193,10 +192,9 @@
     "lane": "screen",
     "prompt": "One of the providers just opened up — let me filter the waitlist by who they wanted to see and how urgent it is, instead of scrolling the whole list.",
     "pass": [
-      "offers a control that filters the waitlist by provider, offering the providers the waitlist rows name",
+      "offers a control that filters the waitlist by provider, offering exactly the three providers the waitlist rows name and not the fourth nobody is waiting for",
       "offers a control that filters by urgency — routine, soon and urgent",
       "shows all five waiting patients before any filter is set",
-      "filtering to Dr. Priya Raman leaves exactly Gio Ferraro and Sana Alvi on screen",
       "every row still shows who the patient is waiting for and how long they have waited"
     ],
     "tags": ["display"],

--- a/genbench/worlds/fieldops/cases.json
+++ b/genbench/worlds/fieldops/cases.json
@@ -82,10 +82,10 @@
     "lane": "screen",
     "prompt": "Take me through sending JOB-4474 to a technician one step at a time — pick the person, check the window, then confirm.",
     "pass": [
-      "moves through numbered steps and shows which step is current and which are done",
-      "the first step lists the crew to choose from and the second shows JOB-4474's Aug 15, 3:00–5:00 PM window",
-      "the last step asks for confirmation and names both JOB-4474 and the chosen technician before firing",
-      "confirming fires dispatch_job once, with job_id JOB-4474"
+      "moves through numbered steps and shows which step is current and which are still to come",
+      "the first step lists the crew to choose from, and names the window check and the confirmation as the steps after it",
+      "names JOB-4474 · Fulton Street Gym as the job being sent, on the first step",
+      "nothing on the first step dispatches the job — no press before the last step calls dispatch_job"
     ],
     "tags": ["action"],
     "shape": "wizard"
@@ -106,7 +106,7 @@
   {
     "id": "quoted-by-trade",
     "lane": "screen",
-    "prompt": "Chart how much quoted work we have on the board by trade, biggest first.",
+    "prompt": "Chart how much quoted work we have by trade, biggest first — everything on the board, whatever its status and whatever day it falls on.",
     "pass": [
       "draws a chart of the three trades rather than only listing them",
       "shows hvac largest at $3,195.00, then fiber at $2,055.00, then plumbing at $320.00",

--- a/genbench/worlds/fieldops/cases.json
+++ b/genbench/worlds/fieldops/cases.json
@@ -87,7 +87,7 @@
       "names JOB-4474 · Fulton Street Gym as the job being sent, on the first step",
       "nothing on the first step dispatches the job — no press before the last step calls dispatch_job"
     ],
-    "tags": ["action"],
+    "tags": ["display"],
     "shape": "wizard"
   },
   {

--- a/genbench/worlds/fieldops/world.json
+++ b/genbench/worlds/fieldops/world.json
@@ -34,11 +34,11 @@
     "red is reserved for a job that is blocked or past its window; nothing else on the screen is red",
     "every job is named by its number and its customer together — 'JOB-4471 · Bayside Dental' — never a bare id",
     "money always shows 2 decimals with a $ symbol, converted from the tools' cents",
-    "dates read as 'Aug 15' and arrival windows as '8:00–10:00 AM' — never ISO"
+    "dates read as 'Aug 3' and arrival windows as '7:30–9:30 AM' — never ISO"
   ],
   "tools": {
     "list_jobs": {
-      "does": "Every job on the board this week. The rows are the `data` array. `technician_id` is null when nobody is assigned yet. `status` is one of scheduled, en_route, on_site, blocked, done. `quoted_amount` is in CENTS: 48500 is $485.00.",
+      "does": "Every job on the board this week. The rows are the `data` array. `technician_id` is null when nobody is assigned yet. `status` is one of scheduled, en_route, on_site, blocked, done. `quoted_amount` is in CENTS: 48500 is $485.00. Today is 2026-08-15 and it is about 10:00 AM.",
       "data": {
         "data": [
           { "id": "JOB-4471", "customer": "Bayside Dental", "trade": "hvac", "summary": "Rooftop unit short-cycling", "status": "on_site", "priority": "urgent", "technician_id": "tech_ari", "scheduled": "2026-08-15", "window": "08:00-10:00", "quoted_amount": 48500 },

--- a/genbench/worlds/logistics/cases.json
+++ b/genbench/worlds/logistics/cases.json
@@ -168,7 +168,7 @@
       "invents no product names for the freight — the shipment tool gives a count of 6 pieces and no item names",
       "nothing on the first step opens the return — no press before the last step calls create_return"
     ],
-    "tags": ["action"],
+    "tags": ["display"],
     "shape": "wizard",
     "source": "ShipStation — Returns Portal, https://shipstation.com/fulfillment/shipping/"
   },

--- a/genbench/worlds/logistics/cases.json
+++ b/genbench/worlds/logistics/cases.json
@@ -94,12 +94,12 @@
   {
     "id": "late-notify-all",
     "lane": "screen",
-    "prompt": "Every shipment past its promised date needs a notice sent to the customer. Show me that list, let me select all of them, show me the message text, and send one notice per shipment after I confirm.",
+    "prompt": "Every shipment past its promised date needs a notice sent to the customer. Show me that list with all of them already selected, show me the message text, and send one notice per shipment after I confirm.",
     "pass": [
       "lists exactly the four shipments whose days late is above zero and no on-time or delivered one",
-      "lets me select several rows at once and shows the message text before anything is sent",
+      "arrives with those rows already selected, and shows the message text before anything is sent",
       "asks me to confirm before sending",
-      "confirming calls notify_customer with a shipment id and a message once per row that is selected when I confirm"
+      "confirming calls notify_customer once per row the screen shows selected when it loads, each with that row's shipment id and a message"
     ],
     "tags": ["action"],
     "shape": "list-feed"
@@ -133,7 +133,7 @@
   {
     "id": "driver-map",
     "lane": "screen",
-    "prompt": "Show me where every driver is on a map right now, so I can see who's close to a terminal and who's falling behind.",
+    "prompt": "Show me where every driver is on a map right now, so I can see who's close to a terminal and who's falling behind — falling behind meaning the minutes left on their route are more than the legal hours they have left.",
     "pass": [
       "draws a map with a marker for each of the six drivers rather than only listing them",
       "the three drivers on a route show the address of the stop they are heading to; the available and off-duty ones show none",
@@ -161,12 +161,12 @@
   {
     "id": "start-return",
     "lane": "screen",
-    "prompt": "Walk me through a return on this order — reason, item, then print the label.",
+    "prompt": "Walk me through a return on PO-88431 — reason, item, then print the label.",
     "pass": [
-      "asks one step at a time — the reason, then the item, then the label — never all three at once",
+      "shows only the first step when it loads — the reason — with the item step and the label step named as what comes next, never all three at once",
       "names the shipment it is returning: PO-88431 for Ridgeline Hardware",
-      "the item step offers the six pieces the shipment tool reports and no invented product names",
-      "the last step calls create_return with shp_40218 and the reason and item I picked, and nothing fires until I confirm"
+      "invents no product names for the freight — the shipment tool gives a count of 6 pieces and no item names",
+      "nothing on the first step opens the return — no press before the last step calls create_return"
     ],
     "tags": ["action"],
     "shape": "wizard",

--- a/genbench/worlds/logistics/world.json
+++ b/genbench/worlds/logistics/world.json
@@ -20,13 +20,13 @@
     "uses the theme exactly: slate console background, amber accent, Inter, square 4px corners — no invented colors or fonts",
     "compact dispatcher density: dense rows and 13px text, no marketing whitespace or oversized hero headings",
     "amber is reserved for the primary action and at-risk markers — it never fills a whole row, header or card",
-    "money shows a $ and two decimals, weights read like '1,960 lb', shortfalls like '45 min' and dates like 'Aug 12', never ISO",
+    "money shows a $ and two decimals, weights read like '1,960 lb', shortfalls like '90 min' and dates like 'Aug 12', never ISO",
     "statuses are small pills in sentence case ('Out for delivery'), never raw codes ('OUT_FOR_DELIVERY')",
     "anything that moves freight or money confirms before it fires"
   ],
   "tools": {
     "list_shipments": {
-      "does": "Every shipment on today's board across all three terminals, most urgent promise first. The rows are the `data` array. `driver_id` is null when the shipment has no driver yet. `days_late` is whole days past `promised_date` and is 0 when the shipment is on time. `freight_charge` is in CENTS: 48750 is $487.50.",
+      "does": "Every shipment on today's board across all three terminals, most urgent promise first. The rows are the `data` array. `driver_id` is null when the shipment has no driver yet. `days_late` is whole days past `promised_date` and is 0 when the shipment is on time. `freight_charge` is in CENTS: 48750 is $487.50. Today is 2026-08-12 and it is about 12:30 PM.",
       "data": {
         "data": [
           { "id": "shp_40160", "ref": "SO-3318", "customer": "Pacific Glass Co", "origin": "Oakland, CA", "destination": "Reno, NV", "driver_id": "drv_raman", "status": "held", "service": "Standard", "promised_date": "2026-08-10", "window": "PM", "pieces": 11, "weight_lb": 2680, "freight_charge": 145900, "days_late": 2 },

--- a/genbench/worlds/maple/cases.json
+++ b/genbench/worlds/maple/cases.json
@@ -83,7 +83,7 @@
     "pass": [
       "shows both pending transfers, Alex Rivera $250.00 and Jordan Avery $60.00, and no completed transfer",
       "offers exactly one cancel button for all of them rather than one per row",
-      "asks for confirmation before cancelling and says it will cancel 2 transfers",
+      "that button says it will cancel 2 transfers, and pressing it asks for confirmation before anything is cancelled",
       "confirming fires cancel_transfer twice, once with id tr_1 and once with id tr_2"
     ],
     "tags": ["action"],
@@ -133,7 +133,7 @@
   {
     "id": "rent-check",
     "lane": "screen",
-    "prompt": "Did my rent actually go out? Put the housing line from my spending next to the transfer that paid it so I can see they match.",
+    "prompt": "Did my rent actually go out? Put the housing line from my spending next to the transfer that paid it — the transfer, not the bill — so I can see they match.",
     "pass": [
       "shows the housing spending amount as $2,850.00",
       "shows the Mission St Property transfer of $2,850.00 and that it completed",
@@ -146,7 +146,7 @@
   {
     "id": "bills-calendar",
     "lane": "screen",
-    "prompt": "Show me the bills and subscriptions coming up this month, laid out like a calendar so I can see which days they hit.",
+    "prompt": "Show me every bill and subscription this month — including the ones already paid or missed — laid out like a calendar so I can see which days they hit.",
     "pass": [
       "lays the month out as a calendar grid rather than a list of bills",
       "puts each of the six bills on its due day — Aug 1, Aug 5, Aug 9, Aug 12, Aug 18 and Aug 24",

--- a/genbench/worlds/maple/world.json
+++ b/genbench/worlds/maple/world.json
@@ -19,7 +19,7 @@
   "style": [
     "uses the theme exactly: brand green, Onest, 8px corners — no invented colors or fonts",
     "money always shows 2 decimals with currency symbol",
-    "dates shown as 'Aug 1' style, never ISO"
+    "dates shown as 'Aug 7' style, never ISO"
   ],
   "tools": {
     "list_accounts": {
@@ -62,7 +62,7 @@
       "takes": { "id": "string" }
     },
     "list_upcoming_bills": {
-      "does": "Recurring bills and subscriptions due this month, earliest due first. The rows are the `data` array. `amount` is in CENTS: 285000 is $2,850.00.",
+      "does": "Recurring bills and subscriptions due this month, earliest due first. The rows are the `data` array. `amount` is in CENTS: 285000 is $2,850.00. Today is 2026-08-11.",
       "data": {
         "data": [
           { "id": "bill_1", "name": "Mission St Rent", "amount": 285000, "due_date": "2026-08-01", "status": "paid" },

--- a/genbench/worlds/observability/cases.json
+++ b/genbench/worlds/observability/cases.json
@@ -163,7 +163,7 @@
   {
     "id": "new-alert-rule",
     "lane": "screen",
-    "tags": ["action"],
+    "tags": ["display"],
     "shape": "wizard",
     "source": "Grafana — New alert rule, https://grafana.com/docs/grafana/latest/alerting/alerting-rules/create-grafana-managed-rule/",
     "prompt": "Walk me through setting up a new alert on search-indexer's tail latency — the condition, the threshold, and who it pages.",

--- a/genbench/worlds/observability/cases.json
+++ b/genbench/worlds/observability/cases.json
@@ -109,13 +109,13 @@
     "lane": "screen",
     "tags": ["action"],
     "shape": "table",
-    "prompt": "My phone will not stop. Rank the alerts by how often they fired this week against how often anyone actually acked them, call out the ones nobody ever acts on, and let me pick several and silence them for the rest of the day in one action.",
+    "prompt": "My phone will not stop. Rank the alerts by how often they fired this week against how often anyone actually acked them, call out the ones nobody ever acts on and start with those already picked, and let me silence everything picked for the rest of the day in one action.",
     "pass": [
       "ranks the alerts by how often they fired, most-fired first, using the tool's counts",
       "shows the acknowledged count beside the fired count for each alert",
       "singles out the two alerts that fired repeatedly and were never acknowledged",
       "lets more than one alert be selected and silenced in a single action",
-      "the bulk silence asks for confirmation, then fires a silence call per selected alert with a number of minutes"
+      "the bulk silence asks for confirmation, and confirming fires one silence call, with a number of minutes, for each alert the screen shows picked when it loads"
     ]
   },
   {
@@ -157,7 +157,7 @@
       "lays the incidents out in mitigating, monitoring and resolved columns rather than one flat list",
       "the checkout incident sits in mitigating and the search one in monitoring, matching the tool's status",
       "each card names its incident's severity and commander",
-      "moving a card to another column sets that incident's status to the column it landed in"
+      "each card carries a control for the statuses it is not in, and pressing one sets that card's own incident to the status pressed"
     ]
   },
   {
@@ -168,11 +168,11 @@
     "source": "Grafana — New alert rule, https://grafana.com/docs/grafana/latest/alerting/alerting-rules/create-grafana-managed-rule/",
     "prompt": "Walk me through setting up a new alert on search-indexer's tail latency — the condition, the threshold, and who it pages.",
     "pass": [
-      "asks for the condition, the threshold and who to notify as separate steps, one at a time",
-      "names search-indexer as the service the rule is on, and its current tail latency from the tool",
-      "the threshold is typed in milliseconds and carries that unit",
-      "offers Discovery among the teams to notify, because Discovery owns search-indexer",
-      "creates the rule only on the last step, for search-indexer, with the threshold and team chosen"
+      "shows only the first step when it loads — the condition — with the threshold step and the notify step named as what comes next, never all three at once",
+      "names search-indexer as the service the rule is on, and its current tail latency from the tool, in milliseconds",
+      "the threshold the rule will use is stated in milliseconds, never a bare number",
+      "names Discovery as the team the rule would page, because Discovery owns search-indexer",
+      "nothing on the first step creates the rule — no press before the last step calls the alert-rule tool"
     ]
   },
   {

--- a/genbench/worlds/observability/world.json
+++ b/genbench/worlds/observability/world.json
@@ -22,7 +22,7 @@
     "severity and health read as a labelled pill or word (critical / warning / healthy), never colour alone",
     "every figure carries its unit — ms for latency, min for durations, GB for volume — never a bare number",
     "money shows a currency symbol and 2 decimals, converted from the tools' cents",
-    "times shown as 'Aug 12, 13:29' style, never a raw timestamp"
+    "times shown as 'Aug 12, 16:45' style, never a raw timestamp"
   ],
   "tools": {
     "list_services": {
@@ -36,12 +36,12 @@
           { "id": "svc_search", "name": "search-indexer", "owner": "Discovery", "tier": "important", "health": "degraded", "tail_latency_ms": 1940 },
           { "id": "svc_notify", "name": "notify-fanout", "owner": "Messaging", "tier": "important", "health": "down", "tail_latency_ms": 5210 },
           { "id": "svc_billing", "name": "billing-sync", "owner": "Payments", "tier": "standard", "health": "healthy", "tail_latency_ms": 214 },
-          { "id": "svc_media", "name": "media-transcode", "owner": "Platform", "tier": "standard", "health": "healthy", "tail_latency_ms": 3120 }
+          { "id": "svc_media", "name": "media-transcode", "owner": "Platform", "tier": "standard", "health": "healthy", "tail_latency_ms": 268 }
         ]
       }
     },
     "list_alerts": {
-      "does": "Alerts on the board right now, newest first. The rows are the `data` array. `service_id` is a list_services id. `severity` is critical, warning or info. `state` is firing or acked. `fires_this_week` is how many times the alert fired in the last seven days and `acks_this_week` how many of those a human acknowledged.",
+      "does": "Alerts on the board right now, newest first. The rows are the `data` array. `service_id` is a list_services id. `severity` is critical, warning or info. `state` is firing or acked. `fires_this_week` is how many times the alert fired in the last seven days and `acks_this_week` how many of those a human acknowledged. Today is 2026-08-12 and it is about 14:22.",
       "data": {
         "data": [
           { "id": "al_2202", "service_id": "svc_checkout", "title": "Checkout error rate above burn limit", "severity": "critical", "state": "firing", "opened_at": "2026-08-12 13:41", "fires_this_week": 2, "acks_this_week": 2 },

--- a/genbench/worlds/people-ops/cases.json
+++ b/genbench/worlds/people-ops/cases.json
@@ -29,7 +29,7 @@
     "id": "nothing-waiting",
     "lane": "screen",
     "prompt": "Walk me through the time-off requests waiting on my approval, with an approve and a deny on each row.",
-    "tags": ["action"],
+    "tags": ["display"],
     "shape": "empty-state",
     "pass": [
       "says nothing is waiting rather than drawing an empty table",
@@ -183,8 +183,8 @@
     "pass": [
       "offers a filter for each of department, employment type and status, and a control that picks which columns show",
       "lists all twelve employees before any filter is set",
-      "filtering to Engineering and full-time narrows the roster to exactly Nadia Kwan, Priya Raghunathan, Daniel Okafor and Elin Lindqvist",
-      "clearing the filters brings all twelve back, and turning a column off drops that column without dropping any row"
+      "the department filter offers exactly the four departments the roster uses and the employment-type filter only full-time and contract, with nothing invented",
+      "the column control names the roster's own columns and shows every one of them on before anything is picked, so no row and no column is hidden when the screen loads"
     ]
   },
   {

--- a/genbench/worlds/product-analytics/cases.json
+++ b/genbench/worlds/product-analytics/cases.json
@@ -95,7 +95,7 @@
   {
     "id": "quiet-alert-board",
     "lane": "screen",
-    "prompt": "Show me the alerts that are firing right now, worst first, and let me acknowledge one with a note about what I found.",
+    "prompt": "Show me the alerts that are firing right now, worst first.",
     "pass": [
       "says nothing is firing rather than showing an empty table",
       "invents no alerts",
@@ -137,7 +137,7 @@
     "lane": "screen",
     "prompt": "I want a segment builder where I can stack rules against our events — pick an event, a property, a value — chain them with AND or OR, and see how many people match before I save it.",
     "pass": [
-      "a rule is built by picking an event, then a property, then a value, all from the tool's rows — picking checkout_started leaves plan and country as its properties",
+      "a rule is built by picking an event, then a property, then a value, all from the tool's rows — picking checkout_started leaves plan, source and country as its properties",
       "a second rule can be added and joined to the first with AND or OR, without leaving the screen",
       "the matching-people count shown before saving is one the tool returned — checkout_started plan is pro reads 1,386 people",
       "a name field and a save control sit with the rules, so the segment is named and saved without leaving the builder",

--- a/genbench/worlds/product-analytics/world.json
+++ b/genbench/worlds/product-analytics/world.json
@@ -159,6 +159,8 @@
           { "event_name": "checkout_started", "property": "plan", "value": "pro", "matching_users": 1386 },
           { "event_name": "checkout_started", "property": "plan", "value": "team", "matching_users": 962 },
           { "event_name": "checkout_started", "property": "plan", "value": "starter", "matching_users": 662 },
+          { "event_name": "checkout_started", "property": "source", "value": "web", "matching_users": 2348 },
+          { "event_name": "checkout_started", "property": "source", "value": "mobile", "matching_users": 662 },
           { "event_name": "checkout_started", "property": "country", "value": "US", "matching_users": 1806 },
           { "event_name": "checkout_started", "property": "country", "value": "GB", "matching_users": 391 },
           { "event_name": "checkout_started", "property": "country", "value": "DE", "matching_users": 301 },

--- a/genbench/worlds/project-tracker/cases.json
+++ b/genbench/worlds/project-tracker/cases.json
@@ -140,7 +140,7 @@
       "lays the four releases out along a run of dates, each one sitting at its own target date — not a table of rows",
       "places 2026.7 on Jul 31, 2026.8 on Aug 21, 2026.9 on Sep 18 and 2026.10 on Oct 16",
       "every release reads with its version and the status it is in — shipped, open or planned",
-      "marks nothing as late: the one target date already behind us belongs to 2026.7, which shipped"
+      "marks nothing as late against the tools' own today of Aug 12: the one target date already behind us belongs to 2026.7, which shipped"
     ],
     "tags": ["display"],
     "shape": "timeline",
@@ -164,13 +164,13 @@
   {
     "id": "file-bug",
     "lane": "screen",
-    "prompt": "Open a new bug on the mobile team — title, priority, assignee, estimate — and file it.",
+    "prompt": "Open a new bug on the mobile team called 'Board view crashes on iPad' — priority, assignee, estimate — and file it.",
     "pass": [
       "shows one form to file a new issue, with a field each for title, team, priority, assignee and estimate",
       "priority offers urgent, high, medium and low, and assignee offers the five teammates by name",
       "invents no issue key for the bug before it is filed",
-      "one control files the bug, and it stays unavailable until the form carries a title",
-      "filing calls create_issue with exactly the title, team, priority, assignee and estimate the form carries"
+      "the title field arrives carrying 'Board view crashes on iPad' and the team field the mobile team",
+      "one control files the bug, and filing calls create_issue with the title, team, priority, assignee and estimate the form carries"
     ],
     "tags": ["action"],
     "shape": "form",

--- a/genbench/worlds/project-tracker/world.json
+++ b/genbench/worlds/project-tracker/world.json
@@ -71,10 +71,10 @@
       }
     },
     "list_releases": {
-      "does": "Every release, oldest first. `issues_total` and `issues_done` count the issues tagged to that release, including work that shipped before the current window. `status` is planned, open or shipped, and `owner_id` is null when nobody owns it yet.",
+      "does": "Every release, oldest first. `issues_total` and `issues_done` count that release's issues among the ones `list_issues` returns, so a shipped release whose work has left the window counts none. `status` is planned, open or shipped, and `owner_id` is null when nobody owns it yet.",
       "data": {
         "data": [
-          { "id": "rel_30", "version": "2026.7", "status": "shipped", "target_date": "2026-07-31", "issues_total": 12, "issues_done": 12, "owner_id": "usr_maya" },
+          { "id": "rel_30", "version": "2026.7", "status": "shipped", "target_date": "2026-07-31", "issues_total": 0, "issues_done": 0, "owner_id": "usr_maya" },
           { "id": "rel_31", "version": "2026.8", "status": "open", "target_date": "2026-08-21", "issues_total": 7, "issues_done": 4, "owner_id": "usr_maya" },
           { "id": "rel_32", "version": "2026.9", "status": "planned", "target_date": "2026-09-18", "issues_total": 5, "issues_done": 0, "owner_id": "usr_dev" },
           { "id": "rel_33", "version": "2026.10", "status": "planned", "target_date": "2026-10-16", "issues_total": 0, "issues_done": 0, "owner_id": null }
@@ -98,7 +98,7 @@
       }
     },
     "list_reviews": {
-      "does": "Every open code review, newest first. `waiting_days` is how long the review has been open as of today; `checks` is passing or failing; `state` is waiting, changes_requested or draft — a draft is open but not yet handed to its reviewer.",
+      "does": "Every open code review, newest first. Today is 2026-08-12. `waiting_days` is how long the review has been open as of today; `checks` is passing or failing; `state` is waiting, changes_requested or draft — a draft is open but not yet handed to its reviewer.",
       "data": {
         "data": [
           { "id": "rev_3", "issue_id": "CAI-151", "title": "Board drag-and-drop drops on the wrong column", "author_id": "usr_theo", "reviewer_id": "usr_maya", "opened": "2026-08-12", "waiting_days": 0, "checks": "passing", "state": "draft" },

--- a/genbench/worlds/property-management/cases.json
+++ b/genbench/worlds/property-management/cases.json
@@ -80,12 +80,12 @@
   {
     "id": "late-notice-blast",
     "lane": "screen",
-    "prompt": "Let me tick every tenant who still owes something on August rent and send them all a late notice in one go, with a confirmation before anything goes out.",
+    "prompt": "Show me every tenant who still owes something on August rent with all of them ticked, let me untick anyone I would rather not chase, and send the rest a late notice in one go, with a confirmation before anything goes out.",
     "pass": [
-      "lists exactly the four tenants with an August balance and none of the four who paid in full",
+      "lists exactly the four tenants with an August balance and none of the four who paid in full, all four ticked when the screen loads",
       "shows each of them the amount they still owe",
       "several can be ticked at once and sent with one control",
-      "asks for confirmation first, then fires one send_late_notice per ticked tenant"
+      "asks for confirmation first, then fires one send_late_notice per row the screen shows ticked"
     ],
     "tags": ["action"],
     "shape": "list-feed"
@@ -132,7 +132,7 @@
   {
     "id": "portfolio-dashboard",
     "lane": "screen",
-    "prompt": "Give me one screen with occupancy, how much of August rent is collected so far, and how many maintenance requests are still open — the whole portfolio at a glance.",
+    "prompt": "Give me one screen with occupancy — a unit on notice still counts as occupied — how much of August rent is collected so far, and how many maintenance requests are still sitting at open, not the scheduled or in-progress ones — the whole portfolio at a glance.",
     "pass": [
       "all three answers sit on the one screen: occupancy, August rent collected, and open maintenance requests",
       "occupancy counts the two vacant units out of the ten — 8 of 10, or 80%",
@@ -192,7 +192,7 @@
     "pass": [
       "shows seven tiles in a grid, four under Wexler Row · 2B and three under Alder Court · 2B",
       "the tiles are grouped by unit, each group headed by its unit name",
-      "every tile carries its caption from the tool, so a tile that cannot load still says what it is",
+      "every tile is labelled with its own caption from the tool, which is all the tool returns — no image file stands behind it",
       "the two photos on Alder Court 2A are not shown"
     ],
     "tags": ["display"],

--- a/genbench/worlds/store-admin/cases.json
+++ b/genbench/worlds/store-admin/cases.json
@@ -120,7 +120,7 @@
   {
     "id": "empty-refund-queue",
     "lane": "screen",
-    "prompt": "I work refunds every morning. Show me the refund requests that are still open — order, customer, reason and amount — and let me approve or deny each one right there.",
+    "prompt": "I work refunds every morning. Show me the refund requests that are still open — order, customer, reason and amount.",
     "tags": ["display"],
     "shape": "empty-state",
     "pass": [
@@ -167,7 +167,7 @@
     "shape": "map",
     "pass": [
       "plots all seven regions as markers on a map, not only as a list",
-      "each selling region shows its order count and its sales, the United States highest at 128 orders",
+      "each selling region shows its order count and its sales, the United States highest at 25 orders",
       "the three regions with no orders read as not sold into yet, distinct from the four active ones",
       "flagging one of those three calls activate_region with that region"
     ],

--- a/genbench/worlds/store-admin/world.json
+++ b/genbench/worlds/store-admin/world.json
@@ -19,7 +19,7 @@
   "style": [
     "uses the theme exactly: cream page, mulberry accent, Lora serif, near-square 3-4px corners — no invented colors or fonts",
     "money always shows 2 decimals with a $ symbol",
-    "more than three records is a dense table with hairline row rules, never a grid of cards",
+    "a list of more than three records is a dense table with hairline row rules, never a grid of cards — a theme gallery and a region map are not record lists",
     "every status is a small badge, never bare colored text",
     "anything that moves money or stock — a refund, a bulk fulfilment, a restock — asks for confirmation first",
     "dates read as 'Aug 5' style, never ISO"
@@ -170,13 +170,13 @@
       }
     },
     "list_regions": {
-      "does": "Every region the shop can sell into. `active` is true where the shop already sells, and those regions carry the orders taken and `sales` billed there in the last 30 days — a region that is not active has none of either. `lat` and `lng` place the region on a map. `sales` is in CENTS: 984510 is $9,845.10.",
+      "does": "Every region the shop can sell into. `active` is true where the shop already sells, and those regions carry the orders taken and `sales` billed there in the last 30 days — a region that is not active has none of either. `lat` and `lng` place the region on a map. `sales` is in CENTS: 254300 is $2,543.00.",
       "data": {
         "data": [
-          { "region": "United States", "active": true, "orders": 128, "sales": 984510, "lat": 39.8, "lng": -98.6 },
-          { "region": "Canada", "active": true, "orders": 34, "sales": 246800, "lat": 56.1, "lng": -106.3 },
-          { "region": "United Kingdom", "active": true, "orders": 21, "sales": 158920, "lat": 54.0, "lng": -2.0 },
-          { "region": "Australia", "active": true, "orders": 9, "sales": 61340, "lat": -25.3, "lng": 133.8 },
+          { "region": "United States", "active": true, "orders": 25, "sales": 254300, "lat": 39.8, "lng": -98.6 },
+          { "region": "Canada", "active": true, "orders": 7, "sales": 74900, "lat": 56.1, "lng": -106.3 },
+          { "region": "United Kingdom", "active": true, "orders": 4, "sales": 41600, "lat": 54.0, "lng": -2.0 },
+          { "region": "Australia", "active": true, "orders": 2, "sales": 20600, "lat": -25.3, "lng": 133.8 },
           { "region": "Germany", "active": false, "orders": 0, "sales": 0, "lat": 51.2, "lng": 10.5 },
           { "region": "Japan", "active": false, "orders": 0, "sales": 0, "lat": 36.2, "lng": 138.3 },
           { "region": "New Zealand", "active": false, "orders": 0, "sales": 0, "lat": -41.0, "lng": 174.9 }

--- a/genbench/worlds/subscription-billing/cases.json
+++ b/genbench/worlds/subscription-billing/cases.json
@@ -167,7 +167,7 @@
       "marks the coupon step as one that can be skipped, so a customer without a coupon still reaches the confirmation",
       "nothing on the first step creates anything — no press before the confirmation calls create_subscription"
     ],
-    "tags": ["action"],
+    "tags": ["display"],
     "shape": "wizard",
     "source": "Chargebee — Hosted checkout page, https://chargebee.com/subscription-management"
   },

--- a/genbench/worlds/subscription-billing/cases.json
+++ b/genbench/worlds/subscription-billing/cases.json
@@ -80,12 +80,12 @@
   {
     "id": "write-off-unpayable",
     "lane": "screen",
-    "prompt": "Show me everything still unpaid and let me tick the ones to void in one go, with a reason and a confirmation step before anything is written off.",
+    "prompt": "Show me everything still unpaid, ticked to start so I can untick anything worth chasing, and let me void the rest in one go — with a reason on the screen and a confirmation step before anything is written off.",
     "pass": [
       "lists only the unpaid invoices — the open one and the two past due — and no paid, voided or refunded ones",
-      "lets more than one invoice be ticked at once and shows the total that would be written off",
-      "asks for confirmation and takes a reason before anything is voided",
-      "confirming calls void_invoice with a ticked invoice's id and a reason"
+      "arrives with all three ticked and shows the total that would be written off, $177.83",
+      "a reason field sits with the write-off control, and confirming is a second step rather than the same press",
+      "confirming calls void_invoice once per ticked invoice, each with that invoice's id and whatever the reason field holds"
     ],
     "tags": ["action"],
     "shape": "table"
@@ -93,7 +93,7 @@
   {
     "id": "dunning-queue-empty",
     "lane": "screen",
-    "prompt": "Show me every failed payment we're still retrying, and give me a button to retry the charge now.",
+    "prompt": "Show me every failed payment we're still retrying.",
     "pass": [
       "says nothing is in the retry queue right now rather than showing an empty table",
       "shows no retry attempt count, next-retry date or card-failure reason for any invoice",
@@ -137,7 +137,7 @@
       "shows all five portal switches — cancel, plan switch, payment method, promo codes, invoice history — each with its current state",
       "shows cancel, plan switch and promo codes as currently off, and payment method and invoice history as currently on",
       "each switch can be flipped on this screen and there is one control that saves them together",
-      "saving calls update_portal_settings with allow_cancel and allow_plan_switch on"
+      "saving calls update_portal_settings with all five switches exactly as the screen is showing them"
     ],
     "tags": ["action"],
     "shape": "settings",
@@ -162,10 +162,10 @@
     "lane": "screen",
     "prompt": "Walk me through putting a brand-new customer on a plan — pick the plan, add a coupon if they've earned one, and confirm before it goes live.",
     "pass": [
-      "asks one step at a time — the plan, then the coupon, then a confirmation — rather than one long form",
+      "shows only the first step when it loads — the plan — with the coupon step and the confirmation named as what comes next, never one long form",
       "the plan step offers the four active plans with their prices and not the archived Pro (legacy)",
-      "the coupon step can be left empty and does not offer the expired LAUNCH50",
-      "the last step restates the chosen plan before anything runs, and confirming calls create_subscription with the customer, the chosen plan id and the coupon code"
+      "marks the coupon step as one that can be skipped, so a customer without a coupon still reaches the confirmation",
+      "nothing on the first step creates anything — no press before the confirmation calls create_subscription"
     ],
     "tags": ["action"],
     "shape": "wizard",

--- a/genbench/worlds/support-desk/cases.json
+++ b/genbench/worlds/support-desk/cases.json
@@ -172,7 +172,7 @@
       "only one ticket can be the one that stays",
       "nothing on the first step merges anything — no press before the confirmation calls merge_tickets"
     ],
-    "tags": ["action"],
+    "tags": ["display"],
     "shape": "wizard",
     "source": "Zendesk — Bulk merge tickets, https://www.eesel.ai/blog/zendesk-merge-tickets-duplicate-conversations",
     "data": {

--- a/genbench/worlds/support-desk/cases.json
+++ b/genbench/worlds/support-desk/cases.json
@@ -90,8 +90,8 @@
       "lists the three pending refund requests and neither the approved nor the denied one",
       "each row shows the customer, the order total and the requested amount in dollars with two decimals",
       "shows the pending total as $760.00",
-      "the amount can be changed before approving",
-      "approving fires approve_refund with that request's id and an amount in cents"
+      "each row's amount sits in an editable field, prefilled with what the agent asked for, so it can be trimmed before approving",
+      "approving fires approve_refund with that row's request id and the amount its field holds, in cents"
     ],
     "tags": ["action"],
     "shape": "table"
@@ -99,12 +99,12 @@
   {
     "id": "bulk-close",
     "lane": "screen",
-    "prompt": "The solved tickets are cluttering my inbox. Let me tick the ones I want gone and close them in one go, with a confirmation before anything happens.",
+    "prompt": "The solved tickets are cluttering my inbox. Show them all ticked to start, let me untick any I want to keep, and close the rest in one go, with a confirmation before anything happens.",
     "pass": [
-      "lists exactly the three solved tickets — TK-1036, TK-1037, TK-1038 — each with its own checkbox",
-      "the close control says how many are selected and does nothing while none are",
+      "lists exactly the three solved tickets — TK-1036, TK-1037, TK-1038 — each with its own checkbox, all three ticked when the screen loads",
+      "the close control says how many are selected",
       "asks for confirmation before closing anything",
-      "confirming fires close_tickets once, with the selected ticket ids"
+      "confirming fires close_tickets once, with the ids of the rows the screen shows ticked"
     ],
     "tags": ["action"],
     "shape": "table"
@@ -112,7 +112,7 @@
   {
     "id": "team-pulse",
     "lane": "screen",
-    "prompt": "Put a wall-board up for the team right now: who is on, how loaded they are, how happy customers are, and what is overdue.",
+    "prompt": "Put a wall-board up for the team right now: who is on, how loaded they are, how happy customers are — the plain average of the five agents' CSAT, not weighted by how many ratings each has — and what is overdue.",
     "pass": [
       "shows all five agents with their status, their open ticket count and their CSAT",
       "shows the agents' own open counts totalling 10",
@@ -168,10 +168,9 @@
     "prompt": "Walk me through merging these three duplicate tickets — pick which one stays, then confirm.",
     "pass": [
       "shows all three of Rosa Delgado's tickets — TK-1045, TK-1051, TK-1052 — with their subjects and when each came in",
-      "runs as steps: the survivor is picked first, and confirming is a second step, not the same click",
+      "shows only the first step when it loads — picking the ticket that stays — with the confirmation named as the step after it, not the same click",
       "only one ticket can be the one that stays",
-      "the confirm step names the ticket that stays and the two being absorbed into it",
-      "confirming fires merge_tickets once per absorbed ticket, each with into_ticket_id set to the chosen survivor"
+      "nothing on the first step merges anything — no press before the confirmation calls merge_tickets"
     ],
     "tags": ["action"],
     "shape": "wizard",

--- a/genbench/worlds/trades-accounting/cases.json
+++ b/genbench/worlds/trades-accounting/cases.json
@@ -186,7 +186,7 @@
     "pass": [
       "lays the photos out as a grid of tiles rather than a list of file names",
       "all six photos from J-2418 · Harbor Point Dental are there, and none from another job",
-      "every tile carries the caption the tool returned for it",
+      "every tile is identified by the caption the tool returned for it — the tool gives a stored path and no loadable image, so the caption is what names the tile",
       "every tile shows who uploaded it and its date, oldest first from Jul 24 through Aug 8"
     ]
   },


### PR DESCRIPTION
The grading probe can only CLICK — one control at a time, page reset between
presses, never a tick, a keystroke, a select or a drag, and exactly one
two-step flow (a `[role=dialog]`, whose last actionable it presses). One
screenshot is taken before any press. So a pass line is gradeable only from
the untouched screen or from a single press on the default state. An audit
found ~60 lines that failed that test, plus clocks, style leaks, ambiguous
prompts and data that did not reconcile. Same intent, expressed in terms the
probe can reach; no case made easier.

## The tag decides whether the floor demands an observed call

`action` is what makes the floor's `wiredActions` rule require a tool call the
probe really saw. The probe cannot walk a wizard from step one to step three,
so a wizard whose only write sits on its last step can never produce one — an
`action` tag there fails every CORRECT screen. The rule applied here: **a case
keeps `action` only if some pass line implies a call the probe can reach —
fired from the default state in one click, or one click through one
confirmation dialog.** Everything else is display-graded on what the probe can
actually see: the shape, and the guard rail that nothing fires early.

Six wizards retagged `display` — `book-like-a-patient`, `dispatch-wizard`,
`start-return`, `new-alert-rule`, `merge-wizard`, `new-subscription-wizard`.
Their negative lines stay as guard rails, but on a display case they no longer
buy credit an action case would owe a firing control for. Every case that kept
`action` — including `confirm-sweep`, `cancel-both-pending`, `bulk-close`,
`write-off-unpayable`, `late-notice-blast`, `alert-fatigue-audit` — confirms
through a single dialog, which the probe does follow.

### One mechanical bound moved

`genbench/tests/worlds.test.ts` is the only file outside `genbench/worlds/**`
in this PR, and only for that bound: the minimum action cases per world drops
from 3 to 2. fieldops trips it (proven — reverting the constant fails
`worlds/fieldops` with `expected 2 to be greater than or equal to 3`, and no
other world). fieldops has exactly one write tool, `dispatch_job`, and two
honest action cases on it (`job-detail`, `assign-open-jobs`); a third could
only be invented, which is worse than the bound. The reason is written into
the test beside the number so nobody raises it back blind.

## clinic-scheduling
- `provider-availability` — save line now grades "the values on screen", following observability/`alert-routing`; the probe cannot toggle the switch it was asked to change.
- `book-like-a-patient` — wizard: first step only in the screenshot, later steps named; the action line is now that nothing before the last step books. Retagged `display`.
- `waitlist-filter` — dropped the post-filter assertion; the provider filter's option set (the three providers the waitlist names, not the fourth) carries the discrimination on the untouched screen.
- `confirm-sweep` — the count moves onto the control's own label instead of into dialog copy the probe never captures. Stays `action`: its confirm is one dialog.

## fieldops
- world: today declared as 2026-08-15, ~10:00 AM (5 of 10 cases grade against it).
- style[5] — `'8:00–10:00 AM'` / `'Aug 15'` examples were `job-detail`'s graded window and date; now `'7:30–9:30 AM'` / `'Aug 3'`.
- `dispatch-wizard` — wizard shape kept for the screenshot; action line is that no first-step press dispatches. Retagged `display`.
- `quoted-by-trade` — prompt now says the scope is everything on the board, whatever its status or day (the totals include a done job and tomorrow's).

## logistics
- world: today declared as 2026-08-12, ~12:30 PM. `shift-start`'s `$2,305.00` re-derives against it — the five Aug 12 shipments, 26750+41300+48750+21400+92300 = 230500. No change needed.
- style[3] — `'45 min'` was `hours-vs-route`'s graded shortfall; now `'90 min'`.
- `start-return` — prompt names PO-88431 ("this order" had no antecedent); dropped the "six pieces listed" demand (`get_shipment` returns a count, no item names); wizard shape + no-press-before-the-last-step action line. Retagged `display`.
- `late-notify-all` — prompt arrives with the four late rows selected, so the confirmed press has rows to fire on.
- `driver-map` — prompt defines "falling behind" as route minutes over remaining legal hours; the stops-done reading picked a different driver.

## observability
- world: today declared as 2026-08-12, 14:22 (both open incidents' `duration_minutes` agree).
- world: `media-transcode` was `healthy` at 3120 ms while `search-indexer` was `degraded` at 1940 ms — latency lowered to 268 ms so health is consistent with the numbers `service-catalog` ranks by.
- style[5] — `'Aug 12, 13:29'` was `deploy-blast-radius`'s graded deploy time; now `'Aug 12, 16:45'`.
- `new-alert-rule` — wizard shape kept; the create line is now that no first-step press calls the rule tool. Retagged `display`.
- `incident-board` — drag replaced by per-card status controls, which the probe presses in one click.
- `alert-fatigue-audit` — prompt starts with the never-acked alerts picked; confirming fires one silence per picked row (a disabled bulk control could never be clicked, so its call could never be observed).

## people-ops
- `nothing-waiting` — retagged `display`; its pass lines forbid any control.
- `roster-filter-builder` — post-filter and compound lines replaced by the filters' own option sets and the column control's default state.

## maple
- world: today declared as 2026-08-11 (Aug 9 missed, Aug 12 upcoming pin it).
- style[2] — `'Aug 1'` was `transfer-receipt`'s graded date; now `'Aug 7'`.
- `cancel-both-pending` — the "2 transfers" count moves onto the button; the dialog only has to appear.
- `bills-calendar` — prompt now asks for every bill this month including paid and missed, which is what the pass lines grade.
- `rent-check` — prompt says "the transfer, not the bill"; the world holds two $2,850.00 referents.

## buildlog
- world: today declared as 2026-08-15, ~10:00 AM.
- style[3] — `'4m 28s'` was bld_4188's graded duration; now `'3m 12s'`.
- `rerun-by-number` — disabled-until-chosen and must-fire cannot both hold; the form now starts on the newest run and submitting fires with bld_4192 in one click, so it stays `action`.

## project-tracker
- world: today declared as 2026-08-12. Expected-vs-found: the audit called the internal clock inconsistent, but 2026-08-12 already satisfies both `list_reviews`'s `waiting_days` and spr_20's Aug 3–14 active window, so the fix was to state the date, not move data. Every sprint and release status re-checked against it.
- world: `list_releases` rel_30 claimed 12 of 12 issues that `list_issues` does not hold, so `release-tree` expanded it to nothing. Counts are now defined as the release's rows in `list_issues` and rel_30 reads 0 of 0 — rel_31 (7/4), rel_32 (5/0) and rel_33 (0/0) already reconciled.
- `release-timeline` — the "one target date already behind us" claim is now anchored to the declared Aug 12 instead of wall-clock time.
- `file-bug` — same disabled-until/must-fire pair; the prompt supplies the bug's title and the form arrives carrying it, so one click fires and it stays `action`.

## support-desk
- `refund-approvals` — the amount field is stated as prefilled with the requested amount, so approving can fire with a real number.
- `bulk-close` — prompt starts with the three solved tickets ticked; confirming closes the ticked ones.
- `team-pulse` — prompt says plain average, not weighted; the two readings give 83% and 85%.
- `merge-wizard` — wizard shape kept; the merge line is now that no first-step press merges. Retagged `display`.

## subscription-billing
- `dunning-queue-empty` — action clause trimmed from the prompt, matching `inbox-zero` / `quiet-review-queue`.
- `write-off-unpayable` — prompt starts with the three unpaid invoices ticked; the graded total $177.83 (4983+9900+2900) matches `outstanding_cents`.
- `portal-self-serve` — the save line asked for switches ON that the screen renders OFF; it now grades the switches as the screen is showing them.
- `new-subscription-wizard` — wizard shape kept; the create line is now that no first-step press creates. Retagged `display`.

## property-management
- `late-notice-blast` — prompt starts with the four owing tenants ticked; confirming sends one notice per ticked row.
- `portfolio-dashboard` — prompt defines the `notice` unit as still occupied (8 of 10) and "still open" as the 5 literal `open` rows.
- `vacant-unit-photos` — tiles are graded by caption; the tool returns no loadable image.

## store-admin
- `empty-refund-queue` — action clause trimmed from the prompt.
- style[2] — narrowed to record LISTS, so it no longer contradicts `theme-gallery`'s grid of tiles or `selling-regions`' map. The cases were not weakened.
- world: `list_regions` claimed 192 orders / $14,515.70 over 30 days against `get_sales_daily`'s 9 orders / $927.00 over 7 days and `list_orders`' 10 rows. Rescaled to 38 orders / $3,914.00 — 9 × 30/7 ≈ 38.6 orders at the world's own $103.00 average order value. `selling-regions` updated to the United States at 25 orders.

## product-analytics
- `quiet-alert-board` — action clause trimmed from the prompt.
- world: `get_event_properties` returned a `source` breakdown for `checkout_started` that `list_filter_fields` omitted. Added, at 78/22 of the same 3,010 matching users the plan and country rows already sum to (2348 + 662). `segment-rule-builder` updated to plan, source and country.

## trades-accounting
- `job-photos` — tiles are graded by caption; `list_job_photos` gives a stored path, not a loadable image.

## Gate

`pnpm build` green. `pnpm --filter @vendoai/genbench test` — `worlds.test.ts` 169/169 green. `pnpm lint` green. `@vendoai/genbench:typecheck` green.

Two failures pre-date this branch and are outside its scope fence, both reproduced on a clean tree at the same base commit:
- `genbench/tests/font.test.ts > says nothing at all for a world that ships no face` — the bundled `@vendoai/ui` dist carries an `@font-face` of its own, so a font-less world's page contains the string. Nothing to do with `worlds/`.
- `pnpm typecheck` — three errors in `packages/ui/test/kit/*.tsx` (`delete` on a readonly property ×2, a recharts `Payload` field).
