### PR TITLE
docs: whitespace canary for cone-only CI

### DIFF
--- a/docs-site/index.mdx
+++ b/docs-site/index.mdx
@@ -111,3 +111,4 @@ container to run.
 
 An adapter you pass yourself always beats a Cloud default, and nothing in
 these docs requires a key.
+


### PR DESCRIPTION
Canary 1 for the CI overhaul (#1341, #1344). A single trailing newline in `docs-site/index.mdx`.

Verifying: (a) only cone jobs run, (b) the aggregate `ci` is green **with the shards skipped**, (c) it merges **through the merge queue**, (d) main's post-merge full suite fires.

`docs-site/` is not a workspace package, so the cone is empty — every shard should skip and report green, and `coverage-merge` should not run at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a trailing newline to `docs-site/index.mdx` as a canary to validate cone-only CI routing. For a change in `docs-site/` (not a workspace package), all shards should skip while the aggregate `ci` stays green, and `coverage-merge` should not run.

- Verify only cone jobs run and each shard reports skipped/green.
- Confirm the aggregate `ci` check is green with skipped shards.
- Merge via the merge queue.
- After merge to `main`, confirm the full post-merge suite runs.

<sup>Written for commit bab9b7305f8bda3ec5b79828f1a25f5189aa77fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

