### PR TITLE
test(ui): canary proving the ui shards enter the cone

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -28,3 +28,5 @@ export {
 export { announcePin, onPinAnnounced } from "./pin-events.js";
 export { defaultVendoTheme, resolveTheme, themeCssVariables } from "./theme.js";
 export * from "./wire-types.js";
+
+/* cone canary 2 — proves the ui shards run */


### PR DESCRIPTION
Canary 2 for the CI overhaul (#1341, #1344). A comment in `packages/ui/src/index.ts`.

Verifying the ui shards **do** run when packages/ui is in the cone (canary 1 proved they skip when it is not).

Expected to go RED on `typecheck-lint` for a **pre-existing** reason unrelated to this lane: `@vendoai/ui`'s `test/kit/data-table.test.tsx` and `test/kit/slots.test.tsx` have been failing tsc on main since #1332 + #1335 landed together. Not to be merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a no-op comment in packages/ui/src/index.ts as a CI canary to confirm UI shards run when `packages/ui` is inside the cone. Validates shard routing in the CI overhaul without changing runtime behavior.

- `typecheck-lint` should fail due to existing TS errors in `@vendoai/ui` tests (`test/kit/data-table.test.tsx`, `test/kit/slots.test.tsx`), not due to this change.
- Confirm UI shard jobs execute in this lane when `packages/ui` is in the cone; prior canary showed they skipped when it was out.
- No code paths or exports changed; only a comment was added.
- Do not merge; close after observing the expected red on `typecheck-lint`.

<sup>Written for commit b5549744f616a8d128a1eec14c33722a22ce247e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

