### PR TITLE
chore: version packages

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vendoai/core",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "The shapes everything speaks: Vendo v0 contracts — types, zod schemas, format constants, pure validators, descriptor hashing, and seam conformance kits.",
   "keywords": [
     "ai",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vendoai/store",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Persistence under everything: core's StoreAdapter on Postgres — PGlite zero-config default, real Postgres in prod, one schema.",
   "keywords": [
     "ai",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vendoai/ui",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Headless hooks + optional chrome for Vendo: the client, every surface, and the vendo-genui/v2 tree renderer.",
   "keywords": [
     "ai",


### PR DESCRIPTION
**Throwaway canary — do not merge, will be closed.**

Simulates the changesets version PR to prove the heavy-job skip from #1344 does NOT strip its required checks. Branch matches `changeset-release/*` AND the title matches `chore: version packages`, so it exercises both detection paths. Bumps three package.json versions, so the cone is genuinely non-empty — the point is that the heavy jobs skip anyway while all four required checks still report green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Canary PR that bumps `@vendoai/core`, `@vendoai/store`, and `@vendoai/ui` from 0.23.0 to 0.23.1 to validate CI heavy-job skip for changesets version PRs while preserving required checks.

- Matches `changeset-release/*` and the title "chore: version packages" to exercise both detection paths.
- Only updates package.json versions; no runtime or build changes.
- CI should skip heavy jobs while all required checks remain and report green. Do not merge; will be closed after validation.

<sup>Written for commit e4e9dbf38427cdce6ee5670b5508a6a7802a9cdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

