### PR TITLE
fix(genbench): the judge reads the rendered DOM, not the page file

### DIFF
--- a/genbench/README.md
+++ b/genbench/README.md
@@ -330,9 +330,12 @@ like the product it claims to be) — from a pinned `claude-opus-5` that is show
 the screenshot, the click trace and the source.
 
 It grades **blind**. Nothing it is sent names the contender, its model or its
-run folder; the SOURCE channel is `page.html` for every column, because vendo's
-artifact is TSX and both baselines' is HTML and that is a perfect classifier for
-which column is the vendor's. The lines arrive shuffled and are mapped back
+run folder; the SOURCE channel is the DOM the browser holds once the screen has
+settled, script bodies dropped, captured when the shot is taken and the same for
+every column — vendo's artifact is TSX and both baselines' is HTML and that is a
+perfect classifier for which column is the vendor's, and the `page.html` that
+first fixed that carries vendo's whole inlined runtime, which is more than a
+judge's context can hold. The lines arrive shuffled and are mapped back
 after, and the shuffle is **seeded from the case's own stamp**, so one case is
 asked in one order — the same for every column of it and the same on every rerun.
 

--- a/genbench/src/render.ts
+++ b/genbench/src/render.ts
@@ -200,6 +200,14 @@ export interface Shot {
    *  every contender, which is what makes the fabrication check comparable
    *  across artifact formats. */
   readonly visibleText: string;
+  /** The document as the browser holds it once the screen has settled, minus
+   *  the script bodies — the judge's SOURCE evidence, in one format whoever
+   *  wrote the page. The saved FILE cannot be that channel: the page the
+   *  product renders inlines its whole runtime, so every one of that column's
+   *  cases reached the judge as `prompt is too long: 1791560 tokens > 1000000
+   *  maximum` and was failed for it, while the baselines' authored pages graded
+   *  fine. What painted is smaller than what was saved, and better evidence. */
+  readonly dom: string;
   /** Something took up space AND the browser reported no errors doing it. */
   readonly renders: boolean;
   readonly consoleErrors: readonly string[];
@@ -252,7 +260,7 @@ export async function openBrowser(): Promise<Shooter> {
       return {
         page,
         async shot() {
-          const { visibleText, mounted } = await page.evaluate((selector: string) => {
+          const { visibleText, dom, mounted } = await page.evaluate((selector: string) => {
             // `visibility`, not `display`: Chrome's `innerText` reports SVG text
             // in a `display:none` subtree, and reports it correctly hidden here.
             const scaffolding = [...document.querySelectorAll<SVGElement | HTMLElement>(selector)];
@@ -293,8 +301,15 @@ export async function openBrowser(): Promise<Shooter> {
             }
             const visibleText = parts.join("");
             scaffolding.forEach((element, index) => (element.style.visibility = was[index]!));
+            // A clone, because the page is probed after this and must keep
+            // everything it has. The scripts go because they have already run:
+            // what they built is the markup around them, and the bytes are the
+            // one part of a page that can be megabytes long.
+            const shell = document.documentElement.cloneNode(true) as HTMLElement;
+            for (const script of shell.querySelectorAll("script")) script.remove();
             return {
               visibleText,
+              dom: shell.outerHTML,
               // Anywhere in the body, not just under `#root`: a contender that
               // wrote its own document has no root to mount into, and grading it
               // as blank for that would be measuring the harness.
@@ -310,6 +325,7 @@ export async function openBrowser(): Promise<Shooter> {
             // handed the judge a screen no person was ever shown.
             png: await page.screenshot(),
             visibleText,
+            dom,
             renders: mounted && consoleErrors.length === 0,
             consoleErrors: [...consoleErrors],
           };

--- a/genbench/src/run.ts
+++ b/genbench/src/run.ts
@@ -442,11 +442,15 @@ async function main(argv: readonly string[]): Promise<number> {
         ? ungraded(testCase.pass, scoped.style)
         : await judge({
             screenshot: shot.png,
-            // The PAGE, for every column. Vendo's artifact is a TSX document and
-            // both baselines' is HTML, so sending each column its own artifact
-            // handed the judge a perfect classifier for which one was the
-            // vendor's — under a prompt that says the format is not evidence.
-            artifact: page ?? "",
+            // The RENDERED DOM, for every column. Vendo's artifact is a TSX
+            // document and both baselines' is HTML, so sending each column its
+            // own artifact handed the judge a perfect classifier for which one
+            // was the vendor's — under a prompt that says the format is not
+            // evidence. Sending the page FILE instead fixed that and lost the
+            // column anyway: vendo's inlines the whole runtime, so its every
+            // case died at `prompt is too long`. What the browser holds once
+            // the screen settled is one format for everyone and small with it.
+            artifact: shot.dom,
             trace,
             caseLines: testCase.pass,
             styleLines: scoped.style,

--- a/genbench/tests/audit.test.ts
+++ b/genbench/tests/audit.test.ts
@@ -175,7 +175,7 @@ describe("a legitimate operation no closed allowlist can express", () => {
    * before this contract; nothing about the check is stubbed but the model.
    */
   it("passes the floor's honesty check, so the floor itself passes", async () => {
-    const shot = { png: Buffer.alloc(0), visibleText: SCREEN, renders: true, consoleErrors: [] };
+    const shot = { png: Buffer.alloc(0), visibleText: SCREEN, dom: "", renders: true, consoleErrors: [] };
     const floor = runFloor({ world, artifact: "<Stack/>", blocking: [], trace: [], shot });
     expect(floor.honestData.pass).toBe(false);
 
@@ -389,7 +389,7 @@ describe("what the anti-cheat must not convict", () => {
       ],
     };
     const SCREEN = "Job J-2444 · quoted $24.44";
-    const shot = { png: Buffer.alloc(0), visibleText: SCREEN, renders: true, consoleErrors: [] };
+    const shot = { png: Buffer.alloc(0), visibleText: SCREEN, dom: "", renders: true, consoleErrors: [] };
 
     const settled = await auditFloor(
       runFloor({ world: jobs, artifact: "<Stack/>", blocking: [], trace: [], shot }),
@@ -826,7 +826,7 @@ describe("what it costs", () => {
  * a waiver nobody can read is a waiver nobody can overturn.
  */
 describe("the honesty check, end to end", () => {
-  const shotOf = (visibleText: string) => ({ png: Buffer.alloc(0), visibleText, renders: true, consoleErrors: [] });
+  const shotOf = (visibleText: string) => ({ png: Buffer.alloc(0), visibleText, dom: "", renders: true, consoleErrors: [] });
   const floorFor = (visibleText: string) =>
     runFloor({ world, artifact: "<Stack/>", blocking: [], trace: [], shot: shotOf(visibleText) });
 

--- a/genbench/tests/render.test.ts
+++ b/genbench/tests/render.test.ts
@@ -1,6 +1,6 @@
 /**
- * The two promises the contract makes about the page, held against what the
- * shooter actually does.
+ * What the shooter really does with a page: the two promises the contract makes
+ * about it, and the DOM it hands the judge.
  *
  * `HARNESS_CONTRACT` is the one text every page-writing contender is graded
  * against, so a sentence in it that the harness does not enforce is a rule
@@ -12,8 +12,13 @@
  *
  * A real browser, because both claims are about what Chromium did.
  */
+import { MockLanguageModelV3 } from "ai/test";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { HARNESS_CONTRACT, openBrowser, type Shooter } from "../src/render.js";
+import { judge } from "../src/judge.js";
+import { authoredPage, HARNESS_CONTRACT, openBrowser, type Shooter } from "../src/render.js";
+import { loadWorld } from "../src/world.js";
 
 let shooter: Shooter;
 beforeAll(async () => {
@@ -86,4 +91,84 @@ describe("the shot is the frame the contract names", () => {
     expect(HARNESS_CONTRACT).toContain("settled two frames after the page loads");
     expect(HARNESS_CONTRACT).not.toContain("window.__settled = true");
   });
+});
+
+// --------------------------------------------- what the judge is given to read
+
+/**
+ * A page that carries a runtime inside it, which is what the product's own page
+ * IS: a root, the case's data, and the whole renderer bundled in beside them.
+ */
+const INLINES_A_RUNTIME = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>spending</title>
+<style>h1{font-size:20px}</style></head>
+<body><h1>Spending this month</h1>
+<button onclick="window.vendo.callTool('cancel_transfer', { id: 'tr_1' })">Cancel transfer</button>
+<script>window.__runtime = ${JSON.stringify("compiled".repeat(125_000))};</script>
+</body></html>`;
+
+/** A judge that answers the one line it is asked. Nothing reaches a provider:
+ *  the claim is about what the judge is SENT, not about what it says back. */
+const answering = (): MockLanguageModelV3 =>
+  new MockLanguageModelV3({
+    doGenerate: async () => ({
+      content: [{ type: "text" as const, text: JSON.stringify({ verdicts: [{ verdict: "pass", note: "a header" }] }) }],
+      finishReason: { unified: "stop" as const, raw: undefined },
+      usage: {
+        inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+        outputTokens: { total: 0, text: 0, reasoning: 0 },
+      },
+      warnings: [],
+    }),
+  });
+
+/**
+ * The SOURCE the judge grades on is the settled DOM, and never the page file.
+ *
+ * Every column is sent the same channel so the artifact's format cannot classify
+ * it — but the FILE could not be that channel, because the page the product
+ * renders inlines its whole runtime. The live run said so: `prompt is too long:
+ * 1791560 tokens > 1000000 maximum`, on every one of that column's cases, while
+ * the baselines' hand-written pages were graded normally. What the browser holds
+ * once the screen has settled is the same format for everyone, is small because
+ * the script bodies have already run, and is better evidence besides — it is
+ * what painted, not what was meant.
+ */
+describe("the source the judge is given", () => {
+  it("is the settled DOM, so a page that inlines a runtime is still small and script-free", async () => {
+    const world = await loadWorld(join(dirname(dirname(fileURLToPath(import.meta.url))), "worlds", "maple"));
+    const html = authoredPage(INLINES_A_RUNTIME, world, "vendo-sonnet");
+    const visit = await shooter.visit(html);
+    try {
+      const { dom, png } = await visit.shot();
+
+      expect(dom).toContain("Spending this month");
+      expect(dom).not.toContain("<script");
+      expect(dom.length).toBeLessThan(html.length / 10);
+
+      // Through the real judge, because the whole failure was in the prompt it
+      // assembles rather than in anything it answered.
+      const model = answering();
+      await judge(
+        {
+          screenshot: png,
+          artifact: dom,
+          trace: [],
+          caseLines: ["shows the month's spending"],
+          styleLines: [],
+          caseHash: "settled-dom",
+        },
+        { model },
+      );
+      const sent = JSON.stringify(model.doGenerateCalls[0]!.prompt);
+
+      expect(sent).toContain("Spending this month");
+      expect(sent).not.toContain("window.__runtime");
+      // And the name is still struck out of it: the DOM says who wrote the page
+      // in every handler on it, which is the tell blinding exists to take.
+      expect(sent).toContain("host.callTool");
+    } finally {
+      await visit.close();
+    }
+  }, 60_000);
 });

--- a/genbench/tests/run-folder.test.ts
+++ b/genbench/tests/run-folder.test.ts
@@ -44,7 +44,7 @@ const PNG = Buffer.from(
  *  back, and what the browser shot of it. */
 const OUTCOME: RunOutcome = { artifact: `<screen id="transfers"/>`, blocking: [], snapshots: [], settledMs: 2_000 };
 
-const SHOT: Shot = { png: PNG, visibleText: "3 pending transfers", renders: true, consoleErrors: [] };
+const SHOT: Shot = { png: PNG, visibleText: "3 pending transfers", dom: "", renders: true, consoleErrors: [] };
 
 const PASSING: FloorResult = {
   delivered: true,

--- a/genbench/tests/seam.test.ts
+++ b/genbench/tests/seam.test.ts
@@ -212,7 +212,7 @@ const resultFor = (contender: string): CaseResult => ({
   agentSdkVersion: "0.0.0",
 });
 
-const SHOT: Shot = { png: PNG, visibleText: "", renders: true, consoleErrors: [] };
+const SHOT: Shot = { png: PNG, visibleText: "", dom: "", renders: true, consoleErrors: [] };
 
 /** Every identity the feed is showing, top row first. */
 type Rows = Array<{ who: string; tool: string }>;


### PR DESCRIPTION
## The failure

A live run today, on every vendo case:

```
prompt is too long: 1791560 tokens > 1000000 maximum
```

Each one landed `JUDGE DEGRADED` — every rubric line failed for the column, while
the baselines graded normally.

#1351 made the judge's SOURCE channel `page.html` for every contender, so the
artifact's format could no longer classify which column was the vendor's. But
vendo's `page.html` inlines the mount bundle: **2.84 MB** of compiled runtime,
measured on the real page, against ~40 KB for a baseline's hand-written document.
The format tell was gone and the column was lost anyway.

## The fix

The SOURCE evidence becomes the **rendered DOM**, captured at screenshot time,
for every column: `document.documentElement.outerHTML` after settle with the
`<script>` elements dropped, on `Shot.dom` (`genbench/src/render.ts:308`), handed
to the judge where `run.ts` passed the page file (`genbench/src/run.ts:453`).

Same format for every contender, so the classifier stays gone. Small, because the
script bodies have already run and what they built is the markup around them: the
same real product page measures **2,844,073 → 50,335 bytes**, 43 KB of which is
the harness's own font data URL. And better evidence than the file — it is what
actually painted, not what was meant. `blind()` name-stripping still applies to
it; a page's handlers name the product in the DOM too.

No size caps, no options, no fallbacks.

## The test

`genbench/tests/render.test.ts` — "the source the judge is given" shoots a page
that inlines a megabyte of script through the real shooter, then assembles a real
`judge()` call over the captured DOM with a mock model, and asserts the prompt is
script-free, carries the screen, and is an order of magnitude smaller than the
file. Proven to fail on the old behaviour (capture without the script strip):
`expected '<html lang="en">…' not to contain '<script'`.

`genbench/tests/font.test.ts` is red on this branch and on main alike — the mount
bundle now contains the literal `@font-face`, unrelated to this change.

`genbench/README.md`'s judge section now names the same channel: the settled,
script-stripped DOM captured when the shot is taken.
