### PR TITLE
fix(vendo): the config report ships the policy file, not the pointer to it

### DIFF
--- a/.changeset/report-the-policy-file-not-the-pointer.md
+++ b/.changeset/report-the-policy-file-not-the-pointer.md
@@ -1,0 +1,7 @@
+---
+"@vendoai/vendo": patch
+---
+
+The config report ships the policy document, not the pointer to it.
+
+`guard({ policy: { file: ".vendo/policy.json" } })` names a policy document; it is not one. The report sent the knob verbatim, so the console's Policy card showed `{"file":".vendo/policy.json"}` labelled "set in code" and then failed it against the policy schema, which wants a real `vendo/policy@1` document. The pointer is now followed at report time — the path taken exactly as the guard takes it — and the file's own bytes are reported as a file surface. Inline rules, preset names and `profile.policy` are values rather than pointers and still report as code.

--- a/packages/vendo/src/compose-adapters.ts
+++ b/packages/vendo/src/compose-adapters.ts
@@ -11,7 +11,7 @@ import type { VendoComposition } from "./compose-context.js";
 import { selectStore } from "./compose-store.js";
 import { createConfigReporter } from "./config-report.js";
 import type { ConfigSurfaceName } from "./config-surface.js";
-import { dotVendoFile, dotVendoRoot } from "./dot-vendo.js";
+import { dotVendoFile, dotVendoRoot, readFileSyncOrUndefined } from "./dot-vendo.js";
 import { resolveModels } from "./models-config.js";
 import { cloudSandbox } from "./sandbox.js";
 
@@ -91,11 +91,26 @@ export const composeAdapters = (composition: VendoComposition): Pick<VendoCompos
   // DEFINED `profile.brief` is authoritative even when blank and never touches
   // disk (compose-prompt.ts:40-42). `undefined` here — and only `undefined` —
   // means "code said nothing, go look at the file".
+  //
+  // `guard({ policy: { file } })` NAMES a policy document, it is not one:
+  // reported as a code value it shipped `{"file":".vendo/policy.json"}` as this
+  // deployment's policy, which no policy document schema accepts. A pointer is
+  // followed below instead and reported as the file it is — the path taken
+  // exactly as the guard takes it (guard/src/policy.ts:88-115), so the mirror
+  // can never name a different document than the one being enforced. Inline
+  // rules, a preset name and `profile.policy` are values, not pointers, and
+  // stay code.
+  const policySurface = isGuardInstance(config.guard)
+    ? undefined
+    : config.guard?.policy ?? config.profile?.policy;
+  const policyPointer = typeof policySurface === "object" && "file" in policySurface
+    ? policySurface.file
+    : undefined;
   const codeSurface: Record<ConfigSurfaceName, unknown> = {
     "design-rules.md": config.apps?.designRules?.trim() || config.profile?.designRules?.trim() || undefined,
     "brief.md": (config.instructions ?? composed?.instructions)?.trim() || config.profile?.brief?.trim(),
     "theme.json": config.theme ?? config.profile?.theme,
-    "policy.json": isGuardInstance(config.guard) ? undefined : config.guard?.policy ?? config.profile?.policy,
+    "policy.json": policyPointer === undefined ? policySurface : undefined,
     "overrides.json": config.profile?.overrides,
   };
   // The one-way config report, selected at THIS composition seam from
@@ -103,7 +118,9 @@ export const composeAdapters = (composition: VendoComposition): Pick<VendoCompos
   // cloudKeyOptions lives only here). Keyless, `reportConfig` is a no-op.
   const reportConfig = createConfigReporter({
     cloud: cloudKeyOptions(),
-    readFile: readSurfaceFile,
+    readFile: (name) => (name === "policy.json" && policyPointer !== undefined
+      ? readFileSyncOrUndefined(policyPointer)
+      : readSurfaceFile(name)),
     codeValue: (name) => {
       const value = codeSurface[name];
       if (value === undefined) return undefined;

--- a/packages/vendo/tests/config-report-producer.seam.test.ts
+++ b/packages/vendo/tests/config-report-producer.seam.test.ts
@@ -11,6 +11,7 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { guard } from "@vendoai/guard";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createVendo } from "../src/server.js";
 import type { CreateVendoConfig } from "../src/types.js";
@@ -20,6 +21,18 @@ const REPORT_URL = "https://console.producer-test/api/v1/config/report";
 const identity: Pick<CreateVendoConfig, "principal"> = {
   principal: async () => ({ kind: "user", subject: "user_producer_test" }),
 };
+
+/** A real `vendo/policy@1` document — what the console validates a reported
+ *  policy surface against. */
+const POLICY_DOC = `${JSON.stringify(
+  {
+    format: "vendo/policy@1",
+    directions: ["Ask before moving money."],
+    rules: [{ match: { risk: "destructive" }, action: "ask" }],
+  },
+  null,
+  2,
+)}\n`;
 
 type Surfaces = Record<string, { source: string; content: string | null }>;
 
@@ -104,6 +117,42 @@ describe("the report has to name the surface the runtime actually resolved", () 
     await waitForReport();
 
     expect(sent[0]?.surfaces["brief.md"]).toEqual({ source: "code", content: "" });
+  });
+
+  // `guard({ policy: { file } })` is the demo host's own wiring
+  // (examples/demo-bank/src/vendo/server.ts). The knob is a POINTER, and a
+  // pointer reported as the policy shipped `{"file":".vendo/policy.json"}` to
+  // the console as this deployment's policy document — labelled "set in code",
+  // and failed against the policy schema, which wants `vendo/policy@1`. The
+  // report has to carry the document the guard reads from that path.
+  it("reports policy.json as the FILE a `policy: { file }` pointer names, not the pointer", async () => {
+    await project({ "policy.json": POLICY_DOC });
+    createVendo({
+      ...identity,
+      guard: guard({ policy: { file: ".vendo/policy.json" } }),
+      connectors: [],
+    });
+    await waitForReport();
+
+    expect(sent[0]?.surfaces["policy.json"]).toEqual({ source: "file", content: POLICY_DOC });
+  });
+
+  // The other half of the pointer rule: a policy the host wrote IN CODE is the
+  // document, so it keeps reporting as code even with a file on disk beside it
+  // (inline wins with no merge — the guard never reads that file either).
+  it("reports policy.json as CODE when the rules are inline", async () => {
+    await project({ "policy.json": POLICY_DOC });
+    createVendo({
+      ...identity,
+      guard: guard({ policy: { rules: [{ match: { risk: "read" }, action: "run" }] } }),
+      connectors: [],
+    });
+    await waitForReport();
+
+    expect(sent[0]?.surfaces["policy.json"]?.source).toBe("code");
+    expect(JSON.parse(String(sent[0]?.surfaces["policy.json"]?.content))).toEqual({
+      rules: [{ match: { risk: "read" }, action: "run" }],
+    });
   });
 
   it("reports design-rules.md as the FILE when a blank `apps.designRules` falls through", async () => {


### PR DESCRIPTION
## Symptom

A host that configures its guard as `guard({ policy: { file: ".vendo/policy.json" } })` — the demo bank's own wiring (`examples/demo-bank/src/vendo/server.ts:150-151`) — sees the console's Policy card render the literal string:

```json
{
  "file": ".vendo/policy.json"
}
```

labelled **"set in code"**, and the console's schema validation of it then fails with *"does not match the policy schema"* — because a policy document needs `format: "vendo/policy@1"` and a pointer has no format at all. Both the card and the error are false: the deployment is running a perfectly valid policy, the report just never looked at it.

## Cause

The guard runtime resolves the pointer correctly at decision time (`packages/guard/src/policy.ts:88-115`). The config REPORTER did not: `compose-adapters.ts`'s `codeSurface` table put `config.guard?.policy` — the raw `{file: ...}` knob — into the `policy.json` slot, `codeValue` JSON-stringified it, and `config-report.ts` shipped it verbatim with `source: "code"`. The knob was reported unresolved.

## Fix

At report time, a policy config carrying a `file` is treated as what it is — a pointer — and the file's own bytes are reported, as a **file** source (the console renders "from .vendo/…" for those). The path is taken exactly as the guard takes it: the string as given, against the same process, so the mirror can never name a different document than the one being enforced. No path logic is duplicated; the read goes through the module's existing `readFileSyncOrUndefined`.

Nothing else changes shape:

- inline `rules` / `directions` and preset-name strings are **values**, not pointers, and still report as `code`;
- `profile.policy` is typed `PolicyFile` (the parsed document — it cannot carry a `file` key), so it is untouched;
- a built `VendoGuard` instance still reports nothing, as before;
- a missing or unreadable file at report time falls through to the module's existing convention for an absent surface (`unset`) — no new error plumbing.

The change lives entirely in the reporting path; the shared `readSurfaceFile` other blocks consume is unchanged.

## Test — the seam

Extended `packages/vendo/tests/config-report-producer.seam.test.ts`, the producer-half seam suite, in its own style: a real temp project dir with a real `.vendo/policy.json` holding a valid `vendo/policy@1` document → the real `createVendo` composition → the real reporter → the real batched uploader → the captured PUT body. No stub between the file and the wire.

- **the pointer case:** the reported `policy.json` surface is `{ source: "file", content: <the file's bytes> }`.
- **the non-regression half:** an inline-`rules` policy, with a `policy.json` sitting on disk beside it, still reports `source: "code"` with the rules the host wrote — the guard does not read that file either (inline wins with no merge).

**Revert-proof:** with the fix stashed and the tests untouched, the pointer test goes red with exactly the reported bug —

```
expected { source: 'code', …(1) } to deeply equal { source: 'file', …(1) }
- "content": "{ \"format\": \"vendo/policy@1\", … }"   (expected)
+ "content": "{ \"file\": \".vendo/policy.json\" }"     (received)
+ "source": "code"
```

The fix was then restored and the file went green again (7/7).

## Gate

`pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint`, scoped, all green — `@vendoai/vendo` at 2395 passed / 45 skipped. One unrelated, pre-existing failure in `genbench/tests/font.test.ts` (a TanStack license-banner assertion in generated page HTML); verified it fails identically with this branch's changes stashed, so it is main's, not this PR's.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sends the policy document in the config report when hosts use `guard({ policy: { file: ".vendo/policy.json" } })`, instead of sending the pointer object. Previously the report sent `{"file":".vendo/policy.json"}` as a code value, which the Console rendered as “set in code” and rejected against the policy schema; now it reads that path with the same logic the guard uses and reports the file as a file source.

- Inline `rules` and preset-name policies still report as `code`; `profile.policy` stays unchanged; built guard instances still report nothing; unreadable/missing files fall back to `unset`.
- Change is confined to `packages/vendo/src/compose-adapters.ts`: detect a `policy: { file }`, omit it from `codeSurface`, and override the reporter’s `readFile` to use `readFileSyncOrUndefined` for `policy.json`. Added seam tests for pointer and inline cases in `packages/vendo/tests/config-report-producer.seam.test.ts`.

<sup>Written for commit 99ce59d439a0c5a719d7eedb133775a1053430d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

