### PR TITLE
feat(core): turn envelope wire ops

### DIFF
--- a/.changeset/turn-envelope-wire-ops.md
+++ b/.changeset/turn-envelope-wire-ops.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/core": minor
+---
+
+Two batched store-wire ops so one agent turn costs one call at each end instead of many. `turn.load` bundles a turn's opening reads — `transcripts.getThread`, `workspace.index`, `workspace.read`, and optionally `harness.get` and the `usage.count` a limits policy needs — and `turn.commit` bundles its closing writes: `transcripts.appendMessages`, optionally `harness.set`, and optionally the run's audit `engine.put`. Both bodies are pure composition of the per-op schemas that already existed, and every answer is exactly what the individual op returns, so nothing here is new semantics; the only thing that changes is the number of round trips. The family is OPTIONAL on `StoreOps` (`usage`'s rule) and rides the tail of `STORE_WIRE_PATHS`, so a mount that omits it reports the level it always did and a caller that finds it absent makes the calls it always made. Clients feature-detect on `/status` with the frozen `STORE_WIRE_TURN_OPS = 50`, read with `>=`, exactly as the batch append is detected.

--- a/packages/core/src/conformance/memory-store-ops.ts
+++ b/packages/core/src/conformance/memory-store-ops.ts
@@ -944,6 +944,32 @@ export function memoryStoreOps(): StoreOps {
   };
 
   // ---------------------------------------------------------------------------
+  // turn — a fan-out over the ops it bundles and nothing more. Written as calls
+  // through the members above so the envelope cannot drift from the individual
+  // ops: a rule added to one is a rule the envelope already obeys.
+  // ---------------------------------------------------------------------------
+
+  const turn: NonNullable<StoreOps["turn"]> = {
+    async load(request) {
+      return {
+        thread: await transcripts.getThread(request.thread.id),
+        index: await workspace.index(request.index),
+        read: await workspace.read(request.read.paths, request.read),
+        ...(request.harness ? { harness: await harness.get(request.harness.appId, request.harness.subject) } : {}),
+        ...(request.usage ? { usage: await usage.count(request.usage) } : {}),
+      };
+    },
+    async commit(request) {
+      const { threadId, subject, messages, title } = request.messages;
+      if (request.harness) await harness.set(request.harness.appId, request.harness.subject, request.harness.state);
+      return {
+        messages: await transcripts.appendMessages!(threadId, subject, messages, { title }),
+        ...(request.audit ? { audit: await engine.put(request.audit.collection, request.audit.record) } : {}),
+      };
+    },
+  };
+
+  // ---------------------------------------------------------------------------
   // status
   // ---------------------------------------------------------------------------
 
@@ -959,6 +985,7 @@ export function memoryStoreOps(): StoreOps {
     secrets,
     retention,
     lifecycle,
+    turn,
     /** Serialized JSON length, which is this reference's honest answer to "how
         much is in here": it grows with every row and shrinks when rows leave,
         which is the whole of what a footprint promises. */

--- a/packages/core/src/conformance/memory-store-ops.ts
+++ b/packages/core/src/conformance/memory-store-ops.ts
@@ -954,7 +954,8 @@ export function memoryStoreOps(): StoreOps {
       return {
         thread: await transcripts.getThread(request.thread.id),
         index: await workspace.index(request.index),
-        read: await workspace.read(request.read.paths, request.read),
+        // Asked for or absent, the same rule the two below follow.
+        ...(request.read ? { read: await workspace.read(request.read.paths, request.read) } : {}),
         ...(request.harness ? { harness: await harness.get(request.harness.appId, request.harness.subject) } : {}),
         ...(request.usage ? { usage: await usage.count(request.usage) } : {}),
       };

--- a/packages/core/src/conformance/store-ops.ts
+++ b/packages/core/src/conformance/store-ops.ts
@@ -2424,6 +2424,14 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         // Asking for less costs less: a part the request left out is absent from
         // the answer, never a zero standing in for one.
         assert(!("usage" in loaded), "turn.load answered a usage count nobody asked for");
+
+        // The shape EVERY `vendo()` turn sends: the thread and the index, no
+        // file bytes. A turn reads a file when a tool asks for one, so a
+        // required `read` would have it name a path it does not want.
+        const quiet = await turn.load({ thread: { id: "thr_turn" }, index: { owner: "user_1" } });
+        assertDeepEqual(quiet.index, loaded.index, "turn.load's index changed when the request dropped `read`");
+        assert(!("read" in quiet), "turn.load answered a workspace read nobody asked for");
+        assert(!("harness" in quiet), "turn.load answered harness state nobody asked for");
       }),
 
       /** The closing half, held to the same rule from the other side: every part

--- a/packages/core/src/conformance/store-ops.ts
+++ b/packages/core/src/conformance/store-ops.ts
@@ -2,7 +2,7 @@ import type { AuditEvent } from "../audit.js";
 import { ENGINE_ALLOWLIST_VERSION, engineAppHistory } from "../engine-collections.js";
 import type { VendoErrorCode } from "../errors.js";
 import { isoDateTimeSchema, type IsoDateTime } from "../ids.js";
-import { STORE_WIRE_APPEND_MESSAGES_OPS, STORE_WIRE_PATHS, VENDO_STORE_WIRE_FORMAT } from "../store-wire.js";
+import { STORE_WIRE_APPEND_MESSAGES_OPS, STORE_WIRE_PATHS, STORE_WIRE_TURN_OPS, VENDO_STORE_WIRE_FORMAT } from "../store-wire.js";
 import type { AuditQuery, CollectionFootprint, StoreOps, UsageCountQuery } from "../store.js";
 import { assert, assertBytesEqual, assertDeepEqual } from "./assertions.js";
 import { omitted, type ConformanceCase, type ConformanceOmission, type ConformanceSuite } from "./index.js";
@@ -144,6 +144,9 @@ const RETENTION_ABSENT = "this mount omits the retention family (optional — an
 
 /** ...and for the meter, optional on the same rule. */
 const USAGE_ABSENT = "this mount omits the usage family (optional — a store with nowhere to meter leaves it off, and a limits policy is refused at composition rather than enforced against a meter that reads zero)";
+
+/** ...and for the turn envelopes, optional on the same rule. */
+const TURN_ABSENT = "this mount omits the turn family (optional — a caller that finds it absent makes the individual calls it always did)";
 
 /** appData rows live in the app's own drawer, and the local backend fails an
     app-scoped write closed when the app has no row — so every appData case
@@ -2392,6 +2395,61 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
       },
 
       // =====================================================================
+      // turn
+      // =====================================================================
+
+      /** The envelope's WHOLE contract: each part is exactly what its own op
+          answers, so a turn that batches its opening reads reads the same store
+          it would have read one call at a time. OPTIONAL — a mount that omits
+          the family is served by those calls — so this reports the omission
+          rather than passing on absence. */
+      opsCase(opts, "turn.load answers exactly what the ops it bundles answer", async (ops) => {
+        const turn = ops.turn;
+        if (turn === undefined) return omitted(TURN_ABSENT);
+        await seedApp(ops, "app_turn");
+        await ops.transcripts.putThread({ id: "thr_turn", subject: "user_1", messages: [{ id: "m_1", text: "one" }] });
+        await ops.harness.set("app_turn", "user_1", { step: 3 });
+        await ops.workspace.commit([{ path: "page.tsx", data: { code: "x" } }], { owner: "user_1" });
+
+        const loaded = await turn.load({
+          thread: { id: "thr_turn" },
+          index: { owner: "user_1" },
+          read: { paths: ["page.tsx"], owner: "user_1" },
+          harness: { appId: "app_turn", subject: "user_1" },
+        });
+        assertDeepEqual(loaded.thread, await ops.transcripts.getThread("thr_turn"), "turn.load's thread is not getThread's answer");
+        assertDeepEqual(loaded.index, await ops.workspace.index({ owner: "user_1" }), "turn.load's index is not workspace.index's answer");
+        assertDeepEqual(loaded.read, await ops.workspace.read(["page.tsx"], { owner: "user_1" }), "turn.load's read is not workspace.read's answer");
+        assertDeepEqual(loaded.harness, await ops.harness.get("app_turn", "user_1"), "turn.load's harness is not harness.get's answer");
+        // Asking for less costs less: a part the request left out is absent from
+        // the answer, never a zero standing in for one.
+        assert(!("usage" in loaded), "turn.load answered a usage count nobody asked for");
+      }),
+
+      /** The closing half, held to the same rule from the other side: every part
+          lands exactly where its own op would have landed it, and the answer is
+          the batch append's `{revision, count}` — never the thread. */
+      opsCase(opts, "turn.commit lands exactly what the ops it bundles land", async (ops) => {
+        const turn = ops.turn;
+        if (turn === undefined) return omitted(TURN_ABSENT);
+        await seedApp(ops, "app_commit");
+        const event = auditEvent("aud_turn", 0, {});
+        const landed = await turn.commit({
+          messages: { threadId: "thr_commit", subject: "user_1", messages: [{ id: "m_1", text: "one" }], title: "a turn" },
+          harness: { appId: "app_commit", subject: "user_1", state: { step: 4 } },
+          audit: { collection: "vendo_audit", record: { id: event.id, data: event } },
+        });
+        assert(landed.messages.count === 1, `turn.commit should report 1 message landed, got ${landed.messages.count}`);
+        const thread = await ops.transcripts.getThread("thr_commit");
+        assert(
+          thread?.revision === landed.messages.revision,
+          `turn.commit reported revision ${String(landed.messages.revision)}, the thread holds ${String(thread?.revision)}`,
+        );
+        assertDeepEqual(await ops.harness.get("app_commit", "user_1"), { step: 4 }, "turn.commit did not land the harness state");
+        assertDeepEqual((await ops.engine.get("vendo_audit", "aud_turn"))?.data, event, "turn.commit did not land the audit row");
+      }),
+
+      // =====================================================================
       // status
       // =====================================================================
 
@@ -2417,6 +2475,12 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
           `status.ops ${status.ops} disagrees with transcripts.appendMessages being `
           + `${ops.transcripts.appendMessages === undefined ? "absent" : "served"} `
           + `(the batch append is op ${STORE_WIRE_APPEND_MESSAGES_OPS})`,
+        );
+        assert(
+          (status.ops >= STORE_WIRE_TURN_OPS) === (ops.turn !== undefined),
+          `status.ops ${status.ops} disagrees with the turn family being `
+          + `${ops.turn === undefined ? "absent" : "served"} `
+          + `(the envelopes are ops ${STORE_WIRE_TURN_OPS - 1} and ${STORE_WIRE_TURN_OPS})`,
         );
       }),
     ],

--- a/packages/core/src/store-wire.ts
+++ b/packages/core/src/store-wire.ts
@@ -6,6 +6,9 @@ import {
   APP_DATA_COLLECTION_PATTERN,
   APP_DATA_OWNER_PATTERN,
   recordQuerySchema,
+  vendoRecordSchema,
+  type TurnCommit,
+  type TurnLoad,
 } from "./store.js";
 
 /** Store design v1 — the wire protocol version tag. The HTTP profile of the
@@ -103,6 +106,10 @@ export const STORE_WIRE_PATHS = {
   "usage.record": "/usage/record",
   "usage.count": "/usage/count",
   "usage.tally": "/usage/tally",
+  // turn (2) — the two cross-family envelopes, appended for the reason every
+  // family since `audit.tally` was: the level may only ever grow.
+  "turn.load": "/turn/load",
+  "turn.commit": "/turn/commit",
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -360,9 +367,10 @@ export interface StoreWireAppendMessagesResult {
     the mount is behind — never send it blind and read the 501 as a fallback
     signal (#1251: a failed mutation is not a capability answer).
 
-    ⚠ AND THIS IS THE LAST CONSTANT OF ITS KIND. Ops 37-45 (audit, secrets,
-    footprint, retention, the audit tally) added no twin, and a future op should
-    not either. A pre-send check earns its keep only when sending blind is
+    ⚠ AND A SECOND CONSTANT OF THIS KIND MUST CLEAR THE BAR BELOW — only
+    STORE_WIRE_TURN_OPS ever has. Ops 37-48 (audit, secrets, footprint,
+    retention, the audit tally, usage) added no twin, and most ops should not.
+    A pre-send check earns its keep only when sending blind is
     unsafe, and that is true of exactly one shape: a MUTATION with a cheaper
     fallback, where a 501 leaves the caller unable to tell "never ran" from
     "ran and failed". Every one of 37-45 is a new PATH, so an older mount
@@ -591,6 +599,59 @@ export const storeWireRetentionPurgeRequestSchema = z.object({
   collection: z.string().min(1),
   quarantinedBefore: isoDateTimeSchema,
 }).passthrough();
+
+// ---------------------------------------------------------------------------
+// turn — one call at the start of an agent turn, one at the end
+//
+// Both bodies are COMPOSITION: every part is the very schema its own op takes,
+// and every answer is the very shape its own op returns. A part a caller does
+// not need is omitted from the request and then absent from the answer, so
+// asking for less costs less. Nothing here is new semantics — an envelope that
+// invented a shape would be a second contract to keep in step with the first.
+// ---------------------------------------------------------------------------
+
+export const storeWireTurnLoadRequestSchema = z.object({
+  thread: storeWireTranscriptsGetThreadRequestSchema,
+  index: storeWireWorkspaceIndexRequestSchema,
+  read: storeWireWorkspaceReadRequestSchema,
+  harness: storeWireHarnessGetRequestSchema.optional(),
+  usage: storeWireUsageCountRequestSchema.optional(),
+}).passthrough();
+
+export const storeWireTurnLoadResponseSchema = z.object({
+  thread: vendoRecordSchema.nullable(),
+  index: z.object({
+    entries: z.array(z.unknown()),
+    cursor: z.string().optional(),
+  }).passthrough(),
+  read: z.record(z.unknown()),
+  harness: z.unknown().optional(),
+  usage: z.number().optional(),
+}).passthrough() satisfies z.ZodType<TurnLoad>;
+
+export const storeWireTurnCommitRequestSchema = z.object({
+  messages: storeWireTranscriptsAppendMessagesRequestSchema,
+  harness: storeWireHarnessSetRequestSchema.optional(),
+  audit: storeWireCollectionPutRequestSchema.optional(),
+}).passthrough();
+
+/** `harness.set` answers nothing, so the envelope answers nothing for it. */
+export const storeWireTurnCommitResponseSchema = z.object({
+  messages: z.object({
+    revision: z.string(),
+    count: z.number().int(),
+  }).passthrough(),
+  audit: vendoRecordSchema.optional(),
+}).passthrough() satisfies z.ZodType<TurnCommit>;
+
+/** The op count a mount must report on `/status` before a client may send the
+    turn envelopes — read with `>=` and FROZEN, exactly as
+    {@link STORE_WIRE_APPEND_MESSAGES_OPS} is, and for its reasons.
+    `turn.commit` is the shape that warrants a pre-send check: a MUTATION with a
+    cheaper fallback (the individual ops), where a 501 leaves the caller unable
+    to tell "never ran" from "ran and failed". `turn.load` is a read that could
+    be sent blind, but the two ship as one family on one level. */
+export const STORE_WIRE_TURN_OPS = 50;
 
 // ---------------------------------------------------------------------------
 // status

--- a/packages/core/src/store-wire.ts
+++ b/packages/core/src/store-wire.ts
@@ -613,7 +613,7 @@ export const storeWireRetentionPurgeRequestSchema = z.object({
 export const storeWireTurnLoadRequestSchema = z.object({
   thread: storeWireTranscriptsGetThreadRequestSchema,
   index: storeWireWorkspaceIndexRequestSchema,
-  read: storeWireWorkspaceReadRequestSchema,
+  read: storeWireWorkspaceReadRequestSchema.optional(),
   harness: storeWireHarnessGetRequestSchema.optional(),
   usage: storeWireUsageCountRequestSchema.optional(),
 }).passthrough();
@@ -624,7 +624,7 @@ export const storeWireTurnLoadResponseSchema = z.object({
     entries: z.array(z.unknown()),
     cursor: z.string().optional(),
   }).passthrough(),
-  read: z.record(z.unknown()),
+  read: z.record(z.unknown()).optional(),
   harness: z.unknown().optional(),
   usage: z.number().optional(),
 }).passthrough() satisfies z.ZodType<TurnLoad>;

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -428,14 +428,51 @@ export type EraseTarget =
   | { subject: string; appId?: never }
   | { appId: string; subject?: never };
 
-/** The typed contract for all 48 store operations across 13 families.
+/** The reads one agent turn OPENS with, in one call: the thread it continues,
+    the workspace it works in, and — only when the caller needs them — the
+    harness state it resumes and the meter reading its limits are decided on.
+    Every part is exactly its own op's argument, and {@link TurnLoad}'s parts are
+    exactly those ops' answers. The saving is round trips and nothing else. */
+export interface TurnLoadRequest {
+  thread: { id: string };
+  index: { cursor?: string; limit?: number; owner?: string };
+  read: { paths: string[]; owner?: string };
+  harness?: { appId: string; subject: string };
+  usage?: UsageCountQuery;
+}
+
+export interface TurnLoad {
+  thread: VendoRecord | null;
+  index: { entries: unknown[]; cursor?: string };
+  read: Record<string, unknown>;
+  /** Present exactly when the request asked for it — the harness state, or
+      `null` where `harness.get` would have answered null. */
+  harness?: unknown;
+  usage?: number;
+}
+
+/** The writes one agent turn CLOSES with, in one call: the messages it produced,
+    and — when the caller has them — the harness state to carry into the next
+    turn and the run's audit row. */
+export interface TurnCommitRequest {
+  messages: { threadId: string; subject: string; messages: unknown[]; title?: string };
+  harness?: { appId: string; subject: string; state: unknown };
+  audit?: { collection: string; record: RecordInput };
+}
+
+export interface TurnCommit {
+  messages: { revision: string; count: number };
+  audit?: VendoRecord;
+}
+
+/** The typed contract for all 50 store operations across 14 families.
     Lean by design — this is the CONTRACT interface, not the implementation.
 
-    Three members are OPTIONAL, and all three mean the same thing: an
+    Four members are OPTIONAL, and all four mean the same thing: an
     implementation that cannot serve the family says so by OMITTING it, never by
     accepting the call and doing something else (`transcripts.appendMessages`,
-    `retention` and `usage`, following `RecordStore.claim`/`atomic`). Everything
-    else is required. */
+    `retention`, `usage` and `turn`, following `RecordStore.claim`/`atomic`).
+    Everything else is required. */
 export interface StoreOps {
   /** Vendo's OWN engine data — grants, approvals, audit, threads, runs, apps,
       effects, and the automations and guard drawers — reached through seven
@@ -605,6 +642,17 @@ export interface StoreOps {
   lifecycle: {
     erase(target: EraseTarget): Promise<unknown>;
     promote(appId: string, orgId: string): Promise<void>;
+  };
+  /** One agent turn's opening reads and its closing writes, each as ONE call
+      over the families they already cross — no new semantics, no new data, just
+      the round trips a hosted turn was paying for them.
+
+      OPTIONAL (`usage`'s rule): a mount that omits the family is served by the
+      individual ops, which is where every caller started. Over the wire the
+      equivalent question is the `/status` op count — see STORE_WIRE_TURN_OPS. */
+  turn?: {
+    load(request: TurnLoadRequest): Promise<TurnLoad>;
+    commit(request: TurnCommitRequest): Promise<TurnCommit>;
   };
   /** What this store is holding, per collection, with each collection's kind
       alongside — see {@link CollectionFootprint} for what `bytes` is and is not.

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -436,7 +436,11 @@ export type EraseTarget =
 export interface TurnLoadRequest {
   thread: { id: string };
   index: { cursor?: string; limit?: number; owner?: string };
-  read: { paths: string[]; owner?: string };
+  /** Only for a turn that opens with file BYTES in hand. A turn that opens with
+      the index alone — every `vendo()` turn does; the workspace reads a file
+      when a tool asks for it — omits this rather than naming a path it does not
+      want, which is what a required `paths` would force it to do. */
+  read?: { paths: string[]; owner?: string };
   harness?: { appId: string; subject: string };
   usage?: UsageCountQuery;
 }
@@ -444,7 +448,9 @@ export interface TurnLoadRequest {
 export interface TurnLoad {
   thread: VendoRecord | null;
   index: { entries: unknown[]; cursor?: string };
-  read: Record<string, unknown>;
+  /** Present exactly when the request asked for it — the same rule as
+      `harness` and `usage` below. */
+  read?: Record<string, unknown>;
   /** Present exactly when the request asked for it — the harness state, or
       `null` where `harness.get` would have answered null. */
   harness?: unknown;

--- a/packages/core/tests/conformance/memory-store-ops.test.ts
+++ b/packages/core/tests/conformance/memory-store-ops.test.ts
@@ -71,6 +71,10 @@ describe("StoreOps conformance kit against the memory reference", () => {
           ops: {
             ...ops,
             transcripts: { ...ops.transcripts, appendMessages: undefined },
+            // The turn envelopes ride BEHIND the batch append on the same level
+            // and `turn.commit` IS one, so a mount stopping short of op 36
+            // serves neither.
+            turn: undefined,
             // A mount that omits op 36 may not claim to have reached it — the
             // status case pins that biconditional, and this mount is honest.
             async status() {

--- a/packages/core/tests/store-wire.test.ts
+++ b/packages/core/tests/store-wire.test.ts
@@ -50,12 +50,12 @@ import {
 } from "../src/index.js";
 
 describe("vendo/store-wire@1", () => {
-  it("exposes the format constant and 48 mount-relative paths", () => {
+  it("exposes the format constant and 50 mount-relative paths", () => {
     expect(VENDO_STORE_WIRE_FORMAT).toBe("vendo/store-wire@1");
-    // 13 families: engine(7) + blobs(4) + appData(8) + transcripts(7) + harness(3)
+    // 14 families: engine(7) + blobs(4) + appData(8) + transcripts(7) + harness(3)
     // + workspace(4) + lifecycle(2) + audit(2) + secrets(4) + footprint(1)
-    // + retention(2) + status(1) + usage(3) = 48
-    expect(Object.keys(STORE_WIRE_PATHS)).toHaveLength(48);
+    // + retention(2) + status(1) + usage(3) + turn(2) = 50
+    expect(Object.keys(STORE_WIRE_PATHS)).toHaveLength(50);
     expect(STORE_WIRE_PATHS.status).toBe("/status");
     expect(STORE_WIRE_PATHS["engine.get"]).toBe("/engine/get");
     expect(STORE_WIRE_PATHS["engine.compareAndSwap"]).toBe("/engine/compareAndSwap");
@@ -70,18 +70,20 @@ describe("vendo/store-wire@1", () => {
 
   // `ops` on /status is a LEVEL over this order, so an implementation that
   // stops short of the newest ops can only report an honest number when those
-  // ops are the tail. The usage family is the newest one no mount answers yet,
-  // and it sits behind everything a shipped mount already serves — as retention
-  // and the audit tally did before it.
+  // ops are the tail. The turn family is the newest one no mount answers yet,
+  // and it sits behind everything a shipped mount already serves — as usage,
+  // retention and the audit tally did before it.
   it("declares the ops nothing serves yet LAST, so the /status level can stay honest", () => {
     const ops = Object.keys(STORE_WIRE_PATHS).filter((op) => op !== "status");
-    expect(ops.slice(-6)).toEqual([
+    expect(ops.slice(-8)).toEqual([
       "retention.quarantine",
       "retention.purge",
       "audit.tally",
       "usage.record",
       "usage.count",
       "usage.tally",
+      "turn.load",
+      "turn.commit",
     ]);
   });
 


### PR DESCRIPTION
A hosted agent turn currently pays a round trip per store op at each end of the turn. This PR adds the core-package contract for two batched cross-family wire ops that collapse those into one call each: `turn.load` bundles a turn's opening reads (`transcripts.getThread` + `workspace.index` + `workspace.read`, plus the optional `harness.get` and the `usage.count` a limits policy needs), and `turn.commit` bundles its closing writes (`transcripts.appendMessages`, plus the optional `harness.set` and the run's audit `engine.put`). Both bodies are composition of the per-op schemas that already existed, and every answer is exactly what the individual op returns — a part the caller does not ask for is absent from the request and absent from the answer, so asking for less costs less. The family is OPTIONAL on `StoreOps` (`usage`'s rule) and its two paths are APPENDED to the tail of `STORE_WIRE_PATHS`, so `/status`'s monotone level keeps meaning what it meant; clients feature-detect with `>=` against the frozen `STORE_WIRE_TURN_OPS = 50`, the way the batch append is detected. The in-memory conformance double implements both as a fan-out over the ops they bundle, and the new conformance cases pin the one contract that matters: each part equals what its own op answers, and each part lands where its own op lands it.

Two existing test files move with the manifest, stated rather than smuggled: the wire inventory count and tail assertions (48 -> 50 paths), and the conformance kit's level-35 mutant mount, which now omits the turn family too — `turn.commit` IS a batch append, so a mount stopping short of op 36 serves neither.

**Known red, and owned by PR 2:** `packages/store/tests/ops.test.ts` ("status() reports the 48 ops this wire serves") fails on this branch alone, because the local backend hardcodes `ops: 48` in `packages/store/src/ops.ts` while that test compares the reported level against `STORE_WIRE_PATHS.length`. The level must not run ahead of the ops, so that number rises only when the local backend actually serves the envelopes — which is PR 2.

This is PR 1 of a 3-PR stack (core contract -> store implementation -> adoption) and merges only at the tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batches an agent turn’s store calls into two optional wire ops to cut round trips: previously each turn opened and closed with multiple calls; now `turn.load` and `turn.commit` make one call each without changing semantics. `turn.load.read` is optional so a turn can open with just the thread and index.

- Adds optional `turn` family to `StoreOps`; appends `turn.load`/`turn.commit` to the tail of `STORE_WIRE_PATHS` and freezes `STORE_WIRE_TURN_OPS = 50` for `/status.ops >= 50` feature detection.
- `turn.load` composes `transcripts.getThread` + `workspace.index`, and optionally `workspace.read`, `harness.get`, `usage.count`. Omitted request parts are absent from the response.
- `turn.commit` composes `transcripts.appendMessages`, optionally `harness.set`, and optionally audit `engine.put`. Answers `{messages: {revision, count}}` plus optional `audit`.
- In-memory conformance implements both as fan-outs; new cases pin part-for-part parity and assert `/status.ops >= STORE_WIRE_TURN_OPS` iff `ops.turn` is served.
- Updates wire path inventory and tail assertions from 48 to 50 and keeps the level‑35 mutant mount honest by omitting `turn` alongside the batch append.

- No breaking changes. Clients may batch turns when `/status.ops >= 50`; otherwise call individual ops. Mounts must only bump `/status.ops` to 50 when they actually serve `/turn/*`.

<sup>Written for commit cb0f86e5d35ec5af79c0d14f02fb046a78817a85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

