### PR TITLE
fix(genbench): the vendo page wears the world's theme

### DIFF
--- a/genbench/src/mount.tsx
+++ b/genbench/src/mount.tsx
@@ -14,6 +14,7 @@ import {
   themeCssVariables,
   type VendoTheme,
 } from "@vendoai/apps/contract";
+import { VendoProvider } from "@vendoai/ui";
 import { applyThemeVars } from "@vendoai/ui/kit";
 import { PayloadView } from "@vendoai/ui/tree";
 import { useEffect, type JSX } from "react";
@@ -35,7 +36,8 @@ declare global {
 
 const read = <T,>(id: string): T => JSON.parse(document.getElementById(id)!.textContent!) as T;
 
-applyThemeVars(themeCssVariables(resolveTheme(defaultVendoTheme, read<VendoTheme>("theme"))));
+const theme = read<VendoTheme>("theme");
+applyThemeVars(themeCssVariables(resolveTheme(defaultVendoTheme, theme)));
 const payload = read<UIPayload>("payload");
 
 /**
@@ -76,13 +78,21 @@ function Screen(): JSX.Element {
       });
     });
   }, []);
+  // The provider is where a host declares its brand, and the renderer's surface
+  // re-emits every `--vendo-*` from the theme it reads there — defaulting to the
+  // product's own neutral one when nobody provided it (renderer.tsx:805, 1016).
+  // So the root variables `applyThemeVars` set above are shadowed inside the
+  // screen: without this, every vendo-column page painted accent #111111 on a
+  // world that declares brand green, and was graded down for it.
   return (
-    <PayloadView
-      payload={payload}
-      components={{}}
-      data={(payload as { data?: Record<string, Json> }).data}
-      onAction={async ({ action, payload: args }) => window.vendo.callTool(action, args ?? {})}
-    />
+    <VendoProvider theme={theme}>
+      <PayloadView
+        payload={payload}
+        components={{}}
+        data={(payload as { data?: Record<string, Json> }).data}
+        onAction={async ({ action, payload: args }) => window.vendo.callTool(action, args ?? {})}
+      />
+    </VendoProvider>
   );
 }
 

--- a/genbench/tests/mount.test.ts
+++ b/genbench/tests/mount.test.ts
@@ -1,5 +1,8 @@
 /**
- * The settle signal, which is what decides when a screen is looked at.
+ * What `mount.tsx` does to a page in a real browser: when it says the screen is
+ * ready, and whose brand the screen is wearing when it says so.
+ *
+ * THE SETTLE SIGNAL, which is what decides when a screen is looked at.
  *
  * Everything downstream hangs off it: the screenshot the judge grades, the text
  * the auditor answers for, and the page the probe starts pressing. A signal that
@@ -16,6 +19,16 @@
  * When `PayloadView` boots the VM and can say when it has painted, that signal
  * replaces the wait and the grace becomes its ceiling — and this file is where
  * that change is proven.
+ *
+ * THE THEME is the other half, and it is graded: every judge note on a live
+ * maple run said the vendo column's surface was accent #111111 with 6/10/16px
+ * corners — the product's DEFAULT theme — while the baselines, handed the same
+ * theme as prompt text, painted the world's green. So the one column running
+ * the real renderer was the only one not wearing the brand, and was marked down
+ * for the harness's mount. Asserted on the element that PAINTS with the token,
+ * not on the variable the page sets: the renderer's surface re-emits every
+ * `--vendo-*` from its own theme, so a root variable can be right and the screen
+ * still default.
  */
 import type { UIPayload } from "@vendoai/core";
 import type { ScreenInteractive } from "@vendoai/ui/tree";
@@ -101,5 +114,31 @@ describe("the settle signal", () => {
     // interactive screen would be shot and pressed on whatever the VM had
     // managed to paint by the second frame — which is nothing.
     expect(waitedMs).toBeGreaterThanOrEqual(VM_BOOT_MS);
+  }, 120_000);
+});
+
+/** A screen whose whole surface is one brand-filled control: the Kit's primary
+ *  Button fills with `var(--vendo-color-accent)` (kit/forms/button.tsx:22). */
+const BRANDED: UIPayload = {
+  formatVersion: "vendo-genui/v2",
+  root: "root",
+  nodes: [{ id: "root", component: "Button", props: { label: "Send payment" } }],
+} as UIPayload;
+
+/** A hex the world authored, as the browser reports it back. */
+const rgb = (hex: string): string =>
+  `rgb(${[1, 3, 5].map((at) => parseInt(hex.slice(at, at + 2), 16)).join(", ")})`;
+
+describe("the theme the screen wears", () => {
+  it("is the world's brand, not the product's default", async () => {
+    const visit = await shooter.visit(pageHtml(BRANDED, world, bundle, "vendo-sonnet"));
+    try {
+      const filled = await visit.page.evaluate(() =>
+        getComputedStyle(document.querySelector('[data-kit="Button"]')!).backgroundColor);
+
+      expect(filled).toBe(rgb(world.theme.colors.accent));
+    } finally {
+      await visit.close();
+    }
   }, 120_000);
 });


### PR DESCRIPTION
## The evidence

Live run `genbench/runs/2026-08-16T08-54-08`, main @ `8e74cde6d`. The judge notes on all 15 maple cases said the vendo column's surface used accent `#111111` and radii `6/10/16px` — that is `defaultVendoTheme` verbatim. The world declares accent `#0F6B4E` (brand green) and `8px` corners in `genbench/worlds/maple/world.json`.

The baselines are handed the same theme as prompt text and render it correctly, so the vendo column was the only one not wearing the world's brand — the harness was grading the product down for its own mount.

## Root cause — genbench, not product code

`packages/ui/src/tree/renderer.tsx:805` reads the theme off the provider, provider-optional:

```ts
const theme = useVendoThemeOrDefault();   // context.tsx:202 → defaultVendoTheme when unprovided
```

and `renderer.tsx:1016` re-emits **every** `--vendo-*` variable from it onto the surface element:

```tsx
<div data-vendo-surface="" style={{ ...themeCssVariables(theme), ...SURFACE_CONTAINMENT }}>
```

That is deliberate and documented at `renderer.tsx:798` — "the surface is its own theme boundary", so a bare `AppFrame` on a host page still resolves its brand tokens.

`genbench/src/mount.tsx:38` set the world's tokens on the **document root** via `applyThemeVars` — the protocol for an iframe-embedded surface — and then mounted `PayloadView` with **no `VendoProvider`**. The surface's own inline `--vendo-*` values therefore shadowed the root ones for everything inside it, and the screen painted the default theme. The theme reached the page fine; it was overwritten one element in.

Nothing in `packages/**` is wrong. genbench was using the embedded-surface seam where the in-page mount seam was required.

## The fix

`genbench/src/mount.tsx` — wrap `PayloadView` in `VendoProvider theme={theme}`, which is how a host declares its brand. `applyThemeVars` stays: the page's own `<style>` reads `--vendo-color-background` off the root.

Verified end to end in a real browser: the surface now carries `--vendo-radius-small: 8px` (no `6px` anywhere), the judge's DOM evidence carries `#0F6B4E`, `renders: true`, no console errors. Bundle cost is +7.4 KB on 2.8 MB — the chrome exports on `@vendoai/ui`'s root tree-shake away.

## The test

`genbench/tests/mount.test.ts` — "the theme the screen wears". Mounts a payload whose root is a Kit primary `Button` (fills with `var(--vendo-color-accent)`, `kit/forms/button.tsx:22`) through the real `pageHtml` + `bundleMount` + Chromium path, and asserts the button's **computed** `background-color` equals the world's authored accent. Asserted at the element that paints, not at the variable the page sets — a root variable can be right while the screen is still default, which is exactly the bug.

Proven to fail on the old behaviour:

```
× the theme the screen wears > is the world's brand, not the product's default
  → expected 'rgb(17, 17, 17)' to be 'rgb(15, 107, 78)'
```

`rgb(17, 17, 17)` is `#111111` — the same value the judge reported on every live case.

## Gate

`pnpm build` ✅ · `pnpm --filter @vendoai/genbench test` — 419 passed, 1 failed · `pnpm typecheck` ✅ · `pnpm lint` ✅ (0 errors).

The single failure is `genbench/tests/font.test.ts` > "says nothing at all for a world that ships no face", which is **pre-existing**: it fails identically on `HEAD` with this branch's `mount.tsx` reverted (the minified bundle contains the string `@font-face` regardless). Not touched here.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the genbench vendo page use the world’s theme. Previously the surface re-emitted the default theme and shadowed root vars, so pages painted the product default; now it reads the world theme via `VendoProvider` and renders brand tokens correctly.

- Wraps `PayloadView` in `VendoProvider theme={theme}` in `genbench/src/mount.tsx`; keeps `applyThemeVars` for page CSS. No changes in `packages/**`.
- Adds an integration test asserting the computed background color matches the world’s accent; the test fails on old behavior and passes with this change.
- Observed bundle delta: +7.4 KB in the genbench page; no product impact.
- One unrelated, pre-existing test remains failing (`font.test.ts`); unchanged by this PR.

<sup>Written for commit b7a6be3a634303f9d01b9750e0c6bdd2226531e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

