### PR TITLE
fix(core): pre-0.22 app seeds load again — instruction defaults on read

### DIFF
--- a/.changeset/seed-instruction-default.md
+++ b/.changeset/seed-instruction-default.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/core": patch
+---
+
+Apps seeded before a remix carried its instruction load again. `appSeedSchema` made `instruction` required, so every stored `seed` written without one failed the read-side integrity check (`validateDocument`) and its app refused to open — a document that had been valid when it was written became unreadable. `instruction` now defaults to the empty string on read, so an old seed parses as the seed it always was while the field stays required for everything that writes one.

--- a/packages/apps/tests/contract/app-document.test.ts
+++ b/packages/apps/tests/contract/app-document.test.ts
@@ -117,6 +117,16 @@ describe("appDocumentSchema and validateAppDocument", () => {
     expect(validateAppDocument(legacy)).toEqual({ ok: true, app: expected });
   });
 
+  it("loads a pre-instruction seeded document, defaulting the instruction to empty", () => {
+    // Apps seeded before the ✦ gesture collected an instruction verbatim stored
+    // a seed without one. They must still load, or every app remixed before the
+    // field existed fails the read-side integrity check and never opens again.
+    const legacy = { ...minimal(), seed: { component: "invoice-card", baseline: "sha256:abc123" } };
+    const expected = { ...legacy, seed: { ...legacy.seed, instruction: "" } };
+    expect(appDocumentSchema.parse(legacy)).toEqual(expected);
+    expect(validateAppDocument(legacy)).toEqual({ ok: true, app: expected });
+  });
+
   it("rejects two triggers sharing one id", () => {
     // The id is the key for this trigger's grants, sponsorship, schedule cursor
     // and runs, so a duplicate would silently share all of them.

--- a/packages/core/src/app-document.ts
+++ b/packages/core/src/app-document.ts
@@ -207,10 +207,15 @@ export interface AppSeed {
 export const appSeedSchema = z.object({
   component: z.string(),
   baseline: z.string(),
-  instruction: z.string(),
+  // Seeds stored before the ✦ gesture collected an instruction have none, and a
+  // required field would make every one of those apps unreadable. Defaulted on
+  // READ so the field stays required for everything that writes a seed.
+  instruction: z.string().default(""),
   slot: z.string().optional(),
   review: z.boolean().optional(),
-}).passthrough() satisfies z.ZodType<AppSeed>;
+  // The parsed shape is still an AppSeed; only the INPUT is looser than one,
+  // which is what a default means.
+}).passthrough() satisfies z.ZodType<AppSeed, z.ZodTypeDef, unknown>;
 
 /**
  * The stable generated-component name a seeded app's copy of the host component
@@ -365,7 +370,9 @@ const appDocumentShapeSchema = z.object({
   buildFailed: appBuildFailureSchema.optional(),
   building: isoDateTimeSchema.optional(),
   memory: appMemorySchema.optional(),
-}).passthrough() satisfies z.ZodType<AppDocument>;
+  // Input widened for the same reason as {@link appSeedSchema}'s: a defaulted
+  // field inside `seed` makes this schema's input looser than an AppDocument.
+}).passthrough() satisfies z.ZodType<AppDocument, z.ZodTypeDef, unknown>;
 
 /**
  * READ-TIME normalization of the pre-list document shape: a stored `trigger`


### PR DESCRIPTION
## What broke

`#1303` added `instruction` to `AppSeed` as a **required** field (`packages/core/src/app-document.ts:210`). Every app document whose `seed` was written before that commit has no `instruction`, so it now fails `appSeedSchema` — and that schema is on the READ path: `rowFromRecord` → `validateDocument` → `validateAppDocument` (`packages/apps/src/server/persistence/persistence.ts:115`). A document that was valid when it was written became unreadable, and the app never opens:

```
ZodError: [{ "code": "invalid_type", "expected": "string", "received": "undefined",
             "path": ["seed", "instruction"], "message": "Required" }]
```

## The fix

One line — `packages/core/src/app-document.ts:213`:

```ts
instruction: z.string().default(""),
```

Defaulted on READ, so an old seed parses as the seed it always was while the field stays required for everything that writes one. The two `satisfies z.ZodType<…>` clauses on `appSeedSchema` and `appDocumentShapeSchema` take an explicit `unknown` input, because a defaulted field is by definition looser on input than the interface — the OUTPUT check against `AppSeed` / `AppDocument` is unchanged.

No compat layer, no migration, no new option.

## Regression test

`packages/apps/tests/contract/app-document.test.ts:120`, beside the existing pre-list `trigger` normalization test, and driven through the same real gate the read path uses (`appDocumentSchema` + `validateAppDocument`).

**Against the unfixed code — FAILS:**

```
 FAIL  tests/contract/app-document.test.ts > appDocumentSchema and validateAppDocument >
       loads a pre-instruction seeded document, defaulting the instruction to empty
ZodError: [{ "code": "invalid_type", "expected": "string", "received": "undefined",
             "path": ["seed","instruction"], "message": "Required" }]
 Test Files  1 failed (1)
      Tests  1 failed | 29 skipped (30)
```

**With the fix — PASSES:**

```
 ✓ tests/contract/app-document.test.ts (30 tests) 45ms
 Test Files  1 passed (1)
      Tests  30 passed (30)
```

## Changeset

`.changeset/seed-instruction-default.md` — `@vendoai/core: patch`. Patch changeset, held to 0.x.

## Local gate

`pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint`

- build: 21/21
- test:affected: **44/45**. The one failure is `@vendoai/genbench tests/font.test.ts > says nothing at all for a world that ships no face` — **pre-existing on `main`**, reproduced on a stashed (clean) tree in this same worktree. Unrelated to this change; `@vendoai/apps` is 1334 passed / 19 skipped and `@vendoai/core` 51/51.
- typecheck: 42/42 · lint: 4/4 (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores loading of pre-0.22 app seeds by defaulting `instruction` to an empty string on read. Previously, `instruction` was required in `appSeedSchema`, so older documents failed validation and their apps would not open.

- In `packages/core/src/app-document.ts`, set `instruction: z.string().default("")` and widen the input type for `appSeedSchema` and `appDocumentShapeSchema` to accept `unknown` while still outputting `AppSeed`/`AppDocument`.
- Keeps the write contract strict: writers must still provide `instruction`; only read-time parsing changes.
- No migration required. Existing stored seeds without `instruction` will load.
- Adds a regression test in `packages/apps/tests/contract/app-document.test.ts` to verify read-time defaulting.

<sup>Written for commit 06eb144dd0e03c80cc61e189b91b5e6802199ff0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

