### PR TITLE
feat(ui,apps,core,vendo): a slot says what it is for, and the agent can ask

### DIFF
--- a/packages/apps/src/server/doors/agent-tools.ts
+++ b/packages/apps/src/server/doors/agent-tools.ts
@@ -2,6 +2,7 @@ import {
   VENDO_APPS_PIN_TOOL,
   VENDO_APPS_UNPIN_TOOL,
   VENDO_MAKE_TOOL,
+  VENDO_SLOTS_LIST_TOOL,
   VENDO_TOOL_TITLES,
   VendoError,
   type AppId,
@@ -90,6 +91,21 @@ const descriptors = [
         },
       },
       required: ["appId"],
+      additionalProperties: false,
+    },
+    risk: "read",
+  },
+  {
+    name: VENDO_SLOTS_LIST_TOOL,
+    // The answer to the one question the two `slot` arguments below cannot ask
+    // for themselves. A model with no way to see the real slot ids guesses one,
+    // and a guessed id is a placement aimed at a spot no page renders: the row
+    // is written, nothing ever shows it, and the user is told their view landed.
+    description: "List the places on the user's page where a generated view can go. Each entry has an `id`, a `label` the user would recognize, and a `description` of what that place is for. Pass an `id` from this list to `vendo_make`'s `slot` or to `vendo_apps_pin`'s `slot`, and never invent one: an id that is not here belongs to no page, so nothing would ever appear there. An empty list means the page the user is on offers no place to put a view, so make the view without a slot.",
+    inputSchema: {
+      $schema: DRAFT_2020_12,
+      type: "object",
+      properties: {},
       additionalProperties: false,
     },
     risk: "read",
@@ -286,6 +302,14 @@ export const createAgentTools = (
         // "no such app" while that app sat in the caller's own list.
         const appId = await resolveAppRef(runtime, args.appId as string, ctx);
         return { status: "ok", output: await runtime.open(appId, ctx) as unknown as Json };
+      }
+      if (call.tool === VENDO_SLOTS_LIST_TOOL) {
+        const slots = await runtime.slots.list(ctx);
+        return {
+          status: "ok",
+          output: slots.map(({ id, label, description }) =>
+            ({ id, label, ...(description === undefined ? {} : { description }) })),
+        };
       }
       if (call.tool === VENDO_APPS_PIN_TOOL) {
         const args = input(call.args, ["app", "slot"]);

--- a/packages/apps/src/server/persistence/slots.ts
+++ b/packages/apps/src/server/persistence/slots.ts
@@ -32,6 +32,9 @@ export { SLOT_DECAY_MS };
 export interface SlotDescriptor {
   id: string;
   label: string;
+  /** What the spot is FOR, in the host developer's own words — the sentence an
+   *  agent reads to pick between two slots a label alone cannot separate. */
+  description?: string;
 }
 
 /** A registered slot, as the registry answers it. */
@@ -54,11 +57,11 @@ const rowId = (subject: string, slotId: string): string =>
 const slotOf = (record: VendoRecord): SlotRecord | undefined => {
   const data = record.data as Partial<SlotRecord> | null;
   if (data === null || typeof data !== "object") return undefined;
-  const { id, label, lastSeen } = data;
+  const { id, label, description, lastSeen } = data;
   if (typeof id !== "string" || typeof label !== "string" || typeof lastSeen !== "string") {
     return undefined;
   }
-  return { id, label, lastSeen };
+  return { id, label, lastSeen, ...(typeof description === "string" ? { description } : {}) };
 };
 
 export const createSlotRegistry = (engine: EngineOps): SlotRegistry => {
@@ -70,9 +73,9 @@ export const createSlotRegistry = (engine: EngineOps): SlotRegistry => {
       // Plain put, last write wins, no compare-and-swap: two tabs reporting the
       // same slot are reporting the SAME fact, so there is nothing to
       // arbitrate — and a renamed label is meant to overwrite the old one.
-      await Promise.all(slots.map(({ id, label }) => engine.put(SLOTS_COLLECTION, {
+      await Promise.all(slots.map(({ id, label, description }) => engine.put(SLOTS_COLLECTION, {
         id: rowId(subject, id),
-        data: { id, label, lastSeen },
+        data: { id, label, lastSeen, ...(description === undefined ? {} : { description }) },
         refs: { subject },
       })));
     },

--- a/packages/apps/tests/agent-tools.test.ts
+++ b/packages/apps/tests/agent-tools.test.ts
@@ -62,6 +62,7 @@ describe("apps agent tools", () => {
       "vendo_make",
       "vendo_apps_reseed",
       "vendo_apps_open",
+      "vendo_slots_list",
       "vendo_apps_pin",
       "vendo_apps_unpin",
       "vendo_apps_data_list",
@@ -84,7 +85,7 @@ describe("apps agent tools", () => {
     // rearranging your own view is not an act on the world, and the history is
     // the safety net.
     expect(descriptors.map((descriptor) => descriptor.risk)).toEqual([
-      "read", "write", "read", "write", "write", "read", "write", "write",
+      "read", "write", "read", "read", "write", "write", "read", "write", "write",
     ]);
     // The one-narrower-retry instruction survived the merge onto `vendo_make`:
     // without it the model's answer to a rejected change was to rebuild the app

--- a/packages/core/src/slot-limits.ts
+++ b/packages/core/src/slot-limits.ts
@@ -10,6 +10,11 @@ export const SLOT_ID_MAX_CHARS = 256;
 /** Longest slot label a report may carry. */
 export const SLOT_LABEL_MAX_CHARS = 256;
 
+/** Longest slot description a report may carry. Roomier than a label because it
+ *  is a sentence of intent for the MODEL to read ("main dashboard area, where
+ *  users keep KPI views"), not a word a person picks from a menu. */
+export const SLOT_DESCRIPTION_MAX_CHARS = 1024;
+
 /** Most slots one report may carry — no page mounts more than this. */
 export const SLOTS_REPORT_MAX = 200;
 

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -44,6 +44,12 @@ export const VENDO_MAKE_TOOL = "vendo_make";
 export const VENDO_APPS_PIN_TOOL = "vendo_apps_pin";
 export const VENDO_APPS_UNPIN_TOOL = "vendo_apps_unpin";
 
+/** The read that makes those two callable: the slot ids the host's own pages
+ *  have reported. Named here beside them because a model that invents a slot id
+ *  aims a placement at a spot no page renders, and this is the only answer to
+ *  "which ones are real". */
+export const VENDO_SLOTS_LIST_TOOL = "vendo_slots_list";
+
 /**
  * Tools whose whole effect is on a PERSON'S SCREEN.
  *
@@ -101,6 +107,7 @@ export const VENDO_TOOL_TITLES: Readonly<Record<string, string>> = {
   vendo_apps_reseed: "Refresh a remixed piece",
   vendo_apps_pin: "Pin the app to your page",
   vendo_apps_unpin: "Take the app off your page",
+  vendo_slots_list: "Find the spots on your page",
   vendo_apps_data_list: "Read the app's saved items",
   vendo_apps_data_put: "Save an item in the app",
   vendo_apps_data_delete: "Remove an item from the app",

--- a/packages/ui/e2e/harness/main.tsx
+++ b/packages/ui/e2e/harness/main.tsx
@@ -1849,6 +1849,19 @@ function SlotPickerScenario() {
   );
 }
 
+/** The empty-press fallback with NO conversation overlay and NO palette on the
+ *  page: the first slot's press has nowhere to go, the second has onAuthor. */
+function SlotHintScenario() {
+  const [authored, setAuthored] = useState<string>();
+  return (
+    <div style={{ display: "grid", gap: 24 }}>
+      <VendoSlot id="net-worth-card" description="the money summary at the top of the dashboard" />
+      <VendoSlot id="spending-card" label="Spending" onAuthor={setAuthored} />
+      <output data-testid="authored">{authored ?? "nothing authored"}</output>
+    </div>
+  );
+}
+
 function scenario(pathname: string): { title: string; theme?: Partial<VendoTheme>; content: ReactNode; ownProvider?: boolean } {
   switch (pathname) {
     case "/thread": return { title: "Thread — dark theme", theme: darkTheme, content: <VendoThread threadId="thr_1" /> };
@@ -1888,6 +1901,7 @@ function scenario(pathname: string): { title: string; theme?: Partial<VendoTheme
     case "/consent-marks": return { title: "Consent surfaces — no shield", content: <ConsentMarksScenario />, ownProvider: true };
     case "/slot": return { title: "Inline app slot", content: <VendoSlot id="hero" appId="app_1"><section aria-label="Original host component"><h2>Original host hero</h2></section></VendoSlot> };
     case "/slot-empty": return { title: "Inline slot — empty CTA (Maple)", theme: mapleTheme, content: <><VendoSlot id="hero" /><VendoPalette /><VendoOverlay launcher="none" /></> };
+    case "/slot-hint": return { title: "Inline slot — no chat surface", theme: mapleTheme, content: <SlotHintScenario /> };
     case "/slot-empty-dark": return { title: "Inline slot — empty CTA (dark)", theme: darkTheme, content: <><VendoSlot id="hero" /><VendoPalette /><VendoOverlay launcher="none" /></> };
     case "/slot-pinned": return { title: "Inline slot — pinned component", theme: mapleTheme, content: <VendoSlot id="hero" pin={{ payload: pinnedViewTree }}><section aria-label="Original host component"><h2>Original host hero</h2></section></VendoSlot> };
     case "/slot-fallback": return { title: "Slot pin fallback", content: <SlotFallbackScenario />, ownProvider: true };

--- a/packages/ui/e2e/slot-hint.spec.ts
+++ b/packages/ui/e2e/slot-hint.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "@playwright/test";
+import { openScenario } from "./helpers.js";
+
+const SHOTS = "/tmp/b1-shots";
+
+test("the empty-press fallback, in a real browser", async ({ page }) => {
+  await openScenario(page, "slot-hint");
+
+  // 1 — an empty slot renders.
+  const slot = page.locator('[data-vendo-slot="net-worth-card"]');
+  await expect(slot.getByRole("button", { name: "Design a view" })).toBeVisible();
+  await page.screenshot({ path: `${SHOTS}/1-empty-slot.png`, fullPage: true, animations: "disabled" });
+
+  // 2 — the hint, because this page mounts no overlay and no palette.
+  await slot.getByRole("button", { name: "Design a view" }).click();
+  await expect(slot.getByRole("status"))
+    .toHaveText("Ask your assistant to build something for this spot. Net worth card");
+  await expect(slot.getByRole("button", { name: "Design a view" })).toHaveCount(0);
+  await page.screenshot({ path: `${SHOTS}/2-hint.png`, fullPage: true, animations: "disabled" });
+
+  // 3 — onAuthor wins over both, on the slot beside it.
+  await page.locator('[data-vendo-slot="spending-card"]').getByRole("button", { name: "Design a view" }).click();
+  await expect(page.getByTestId("authored")).toHaveText("spending-card");
+  await page.screenshot({ path: `${SHOTS}/3-onauthor.png`, fullPage: true, animations: "disabled" });
+});

--- a/packages/ui/src/chrome/vendo-slot.tsx
+++ b/packages/ui/src/chrome/vendo-slot.tsx
@@ -202,7 +202,8 @@ export interface VendoSlotPin {
  *  A slot's one job is mounting brand-new generated apps (2026-08-02 final
  *  shape — remix lives entirely on `<Remixable>` now). Three states:
  *  - empty: no `appId`, no `pin`, no `children` → the ghost with a REAL CTA button
- *    that opens the authoring surface (`onAuthor`, else the mounted ⌘K palette);
+ *    that opens the authoring surface (`onAuthor`, else the mounted conversation
+ *    or ⌘K palette, else a line saying to ask the assistant);
  *  - app: `appId` → the whole app document mounts (via the single-app transport);
  *  - pinned component: `pin` → the authored `vendo-genui/v2` view mounts in place.
  *
@@ -211,11 +212,15 @@ export interface VendoSlotPin {
  *  the original `children` as the visible recovery path (06-apps §8). Without any
  *  of the three, the children render UNTOUCHED (no wrapper — hosts may inline
  *  slots anywhere). */
-export function VendoSlot({ id, label, appId: appIdProp, pin, onAuthor, onParked, discover = true, emptyState, children }: {
+export function VendoSlot({ id, label, description, appId: appIdProp, pin, onAuthor, onParked, discover = true, emptyState, children }: {
   id: string;
   /** What a person choosing this slot in the "Add to…" picker reads. Defaults
    *  to the id read as words ("net-worth-card" → "Net worth card"). */
   label?: string;
+  /** What this spot is FOR, in your own words ("main dashboard area, where
+   *  users keep KPI views"). It reaches the agent through the slot registry, so
+   *  it can tell two slots apart that a label alone cannot. Nobody sees it. */
+  description?: string;
   appId?: string;
   pin?: VendoSlotPin;
   /** Invoked when the empty-state CTA is activated — the seam to open a thread
@@ -280,8 +285,14 @@ export function VendoSlot({ id, label, appId: appIdProp, pin, onAuthor, onParked
   // exists from here. Every state of a self-resolving slot reports it, including
   // the untouched-children one; a host-asserted one stays out of the picker
   // rather than promising a landing the person would never see.
-  useReportSlot(id, label ?? slotLabel(id), resolvesItself);
+  const name = label ?? slotLabel(id);
+  useReportSlot(id, name, resolvesItself, description);
 
+  // The third arm of the press, reached only when there is nowhere for it to
+  // go. Runtime-detected, never a prop: a host that mounts an overlay LATER
+  // gets the overlay, and one that never does gets a sentence instead of a
+  // button that quietly does nothing (the old behavior).
+  const [hint, setHint] = useState(false);
   const author = () => {
     if (onAuthor) {
       onAuthor(id);
@@ -290,7 +301,7 @@ export function VendoSlot({ id, label, appId: appIdProp, pin, onAuthor, onParked
     // One-surface model (pick P-C): authoring opens the conversation overlay
     // with the composer focused. The palette-opener fallback keeps hosts that
     // mounted only a VendoPalette (custom onCommand routing) working.
-    if (!openVendoConversation()) openVendoPalette();
+    if (!openVendoConversation() && !openVendoPalette()) setHint(true);
   };
 
   // Suggestion chips prefill the composer — never send (safe on any prompt).
@@ -366,7 +377,13 @@ export function VendoSlot({ id, label, appId: appIdProp, pin, onAuthor, onParked
                   </div>
                 </>
               ) : null}
-              <button type="button" className="fl-invite-btn" onClick={author}>{invite.ctaLabel}</button>
+              {hint ? (
+                <small className="fl-invite-sub" role="status">
+                  Ask your assistant to build something for this spot. <strong>{name}</strong>
+                </small>
+              ) : (
+                <button type="button" className="fl-invite-btn" onClick={author}>{invite.ctaLabel}</button>
+              )}
             </div>
           </div>
         </div>

--- a/packages/ui/src/client.ts
+++ b/packages/ui/src/client.ts
@@ -180,7 +180,7 @@ export interface VendoClient {
     /** GET /slots — every reported destination, newest first. */
     list(): Promise<SlotEntry[]>;
     /** POST /slots — mounted slots saying they exist; batched, idempotent. */
-    report(slots: readonly { id: string; label: string }[]): Promise<void>;
+    report(slots: readonly { id: string; label: string; description?: string }[]): Promise<void>;
   };
 
   status(): Promise<VendoStatus>;

--- a/packages/ui/src/hooks/use-placements.ts
+++ b/packages/ui/src/hooks/use-placements.ts
@@ -218,7 +218,12 @@ function createPoller(client: VendoClient): Poller {
       const entry: Reported = {
         id: slot,
         label: label.slice(0, SLOT_LABEL_MAX_CHARS),
-        ...(description === undefined ? {} : { description: description.slice(0, SLOT_DESCRIPTION_MAX_CHARS) }),
+        // An empty string is left off entirely: the route reads a description
+        // as a NON-EMPTY string and refuses the whole batch over one, so a
+        // `description=""` on one slot would unregister the entire page.
+        ...(description === undefined || description.length === 0
+          ? {}
+          : { description: description.slice(0, SLOT_DESCRIPTION_MAX_CHARS) }),
       };
       // JSON, not a separator join: a space (or any other delimiter) is legal
       // in every half, so `${slot} ${label}` merges ("sales report", "Q3")

--- a/packages/ui/src/hooks/use-placements.ts
+++ b/packages/ui/src/hooks/use-placements.ts
@@ -18,6 +18,7 @@
 import {
   log,
   SLOTS_REPORT_MAX,
+  SLOT_DESCRIPTION_MAX_CHARS,
   SLOT_ID_MAX_CHARS,
   SLOT_LABEL_MAX_CHARS,
   SLOT_REPORT_REFRESH_MS,
@@ -53,7 +54,14 @@ interface Poller {
   error(): Error | undefined;
   loading(): boolean;
   refresh(): Promise<void>;
-  report(slot: string, label: string): void;
+  report(slot: string, label: string, description?: string): void;
+}
+
+/** One slot, as a page reports it. */
+interface Reported {
+  id: string;
+  label: string;
+  description?: string;
 }
 
 const pollers = new WeakMap<VendoClient, Poller>();
@@ -78,16 +86,19 @@ function createPoller(client: VendoClient): Poller {
    *  back-navigation re-reports a slot; the write is idempotent, so that costs
    *  one request and changes nothing. */
   const reported = new Map<string, number>();
-  let queued: Array<{ id: string; label: string }> = [];
+  let queued: Reported[] = [];
   let flushing = false;
 
-  const keyOf = (id: string, label: string): string => JSON.stringify([id, label]);
+  // The whole entry, not a tuple: `JSON.stringify` writes an absent array slot
+  // as `null`, so a tuple key parses back with `description: null` and the
+  // renewal below re-reports garbage. An omitted object key just stays omitted.
+  const keyOf = (entry: Reported): string => JSON.stringify(entry);
   /** Un-remember entries that never reached the registry. `reported` is keyed by
    *  the CLIENT and outlives the React tree, so a key left behind here silences
    *  that slot until the refresh window — which is what the source used to promise
    *  it did not do ("another chance from the next page that mounts it"). */
-  const forget = (entries: readonly { id: string; label: string }[]): void => {
-    for (const { id, label } of entries) reported.delete(keyOf(id, label));
+  const forget = (entries: readonly Reported[]): void => {
+    for (const entry of entries) reported.delete(keyOf(entry));
   };
 
   const announce = (): void => {
@@ -122,8 +133,8 @@ function createPoller(client: VendoClient): Poller {
     const stale = Date.now() - SLOT_REPORT_REFRESH_MS;
     for (const [key, at] of [...reported]) {
       if (at > stale) continue;
-      const [id, label] = JSON.parse(key) as [string, string];
-      if (listeners.has(id)) poller.report(id, label);
+      const { id, label, description } = JSON.parse(key) as Reported;
+      if (listeners.has(id)) poller.report(id, label, description);
     }
   };
 
@@ -187,7 +198,7 @@ function createPoller(client: VendoClient): Poller {
     error: () => error,
     loading: () => !loaded,
     refresh: read,
-    report(slot, label) {
+    report(slot, label, description) {
       // The route validates the batch ALL-OR-NOTHING, and a page reports every
       // slot it mounts in one batch, so a single over-long host prop would take
       // the whole page out of the "Add to…" picker. The client cleans its own
@@ -202,17 +213,22 @@ function createPoller(client: VendoClient): Poller {
         }
         return;
       }
-      // Clamped, not skipped: a verbose label is still a real destination.
-      const trimmed = label.slice(0, SLOT_LABEL_MAX_CHARS);
+      // Clamped, not skipped: a verbose label is still a real destination, and
+      // so is a slot whose developer wrote a paragraph of intent.
+      const entry: Reported = {
+        id: slot,
+        label: label.slice(0, SLOT_LABEL_MAX_CHARS),
+        ...(description === undefined ? {} : { description: description.slice(0, SLOT_DESCRIPTION_MAX_CHARS) }),
+      };
       // JSON, not a separator join: a space (or any other delimiter) is legal
-      // in both halves, so `${slot} ${label}` merges ("sales report", "Q3")
+      // in every half, so `${slot} ${label}` merges ("sales report", "Q3")
       // with ("sales", "report Q3") and the second slot never reaches the
       // registry — it is a destination the picker can never offer.
-      const key = keyOf(slot, trimmed);
+      const key = keyOf(entry);
       const at = reported.get(key);
       if (at !== undefined && Date.now() - at < SLOT_REPORT_REFRESH_MS) return;
       reported.set(key, Date.now());
-      queued.push({ id: slot, label: trimmed });
+      queued.push(entry);
       if (flushing) return;
       flushing = true;
       // The same deferral the first placements read uses: every slot mounting in
@@ -276,10 +292,10 @@ export function usePlacements(slotId: string, enabled = true): SlotPlacement {
 /** Tell the registry this slot exists, so a surface that is NOT on this page
  *  (the "Add to…" picker) can offer it as a destination. Effect-time only, so
  *  an SSR render reports nothing; deduped and batched by the shared poller. */
-export function useReportSlot(slotId: string, label: string, enabled: boolean): void {
+export function useReportSlot(slotId: string, label: string, enabled: boolean, description?: string): void {
   const { client } = useVendoProvider();
   useEffect(() => {
     if (!enabled) return;
-    pollerFor(client).report(slotId, label);
-  }, [client, enabled, label, slotId]);
+    pollerFor(client).report(slotId, label, description);
+  }, [client, description, enabled, label, slotId]);
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -14,6 +14,11 @@ export type { VendoAppEmbedProps, VendoApprovalEmbedProps, VendoApprovalEmbedSta
 // The components behind the frozen prop contracts, exported from the root so
 // a BYO chat page needs only `@vendoai/ui`.
 export { VendoAppEmbed, VendoApprovalEmbed, VendoToolResult } from "./chrome/embeds.js";
+// The slot itself, from the ROOT: a host mounting one only has @vendoai/vendo
+// as a direct dependency, and the "@vendoai/ui/chrome" subpath does not resolve
+// under pnpm strict linking (the same TS2307 story as VendoOverlay's).
+export { VendoSlot } from "./chrome/vendo-slot.js";
+export type { ParkedPress } from "./tree/renderer.js";
 export * from "./hooks/index.js";
 // Dev-only rails: the `data-vendo-debug` feed a host's workbench pane reads,
 // and the check that decides whether such a surface renders at all.

--- a/packages/ui/src/wire-types.ts
+++ b/packages/ui/src/wire-types.ts
@@ -41,6 +41,9 @@ export interface SlotEntry {
   id: string;
   /** What a person choosing a destination reads. */
   label: string;
+  /** What the spot is for, as the host developer described it. Only an agent
+   *  reads this; the picker shows the label. */
+  description?: string;
   /** When a mounted slot last reported itself. */
   lastSeen: string;
 }

--- a/packages/ui/test/chrome/slot-cta-pin.test.tsx
+++ b/packages/ui/test/chrome/slot-cta-pin.test.tsx
@@ -88,6 +88,23 @@ describe("VendoSlot empty-state CTA + pinned-component path (ENG-223)", () => {
     expect(screen.queryByRole("dialog", { name: "Vendo assistant" })).toBeNull();
   });
 
+  it("says how to reach the assistant when the press has nowhere to go", () => {
+    // The third arm of the press, and the only runtime-detected one: no
+    // onAuthor, no overlay, no palette. The button used to swallow the press.
+    render(<VendoProvider client={client}><VendoSlot id="net-worth-card" /></VendoProvider>);
+    fireEvent.click(screen.getByRole("button", { name: /design a view/i }));
+    expect(screen.getByRole("status").textContent)
+      .toBe("Ask your assistant to build something for this spot. Net worth card");
+    // The button that had nowhere to go goes with it — nothing left that lies.
+    expect(screen.queryByRole("button", { name: /design a view/i })).toBeNull();
+  });
+
+  it("keeps the hint away when the press had somewhere to go", () => {
+    render(<VendoProvider client={client}><VendoSlot id="hero" onAuthor={vi.fn()} /></VendoProvider>);
+    fireEvent.click(screen.getByRole("button", { name: /design a view/i }));
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
   it("mounts a pinned component in the slot, in place of the host children", async () => {
     render(
       <VendoProvider client={client}>

--- a/packages/ui/test/chrome/slot-report.test.tsx
+++ b/packages/ui/test/chrome/slot-report.test.tsx
@@ -92,6 +92,29 @@ describe("a mounted VendoSlot reports itself to the registry", () => {
     });
   });
 
+  it("leaves an EMPTY description off the wire, so the page it is on still registers", async () => {
+    // The route refuses a zero-length string and refuses the WHOLE batch with
+    // it, so one `description=""` on one slot would take every slot on the page
+    // out of the registry — no pin destinations at all.
+    render(
+      <VendoProvider client={client}>
+        <VendoSlot id="hero" description="" />
+        <VendoSlot id="sidebar" description="the right rail" />
+      </VendoProvider>,
+    );
+    await waitFor(() => expect(reports()).toHaveLength(1));
+    expect(reports()[0]?.body).toEqual({
+      slots: [
+        { id: "hero", label: "Hero" },
+        { id: "sidebar", label: "Sidebar", description: "the right rail" },
+      ],
+    });
+    expect(wire.state.slots).toEqual([
+      { id: "sidebar", label: "Sidebar", description: "the right rail", lastSeen: expect.any(String) },
+      { id: "hero", label: "Hero", lastSeen: expect.any(String) },
+    ]);
+  });
+
   it("re-reports the same slot under a NEW description", async () => {
     const page = (description: string) => (
       <VendoProvider client={client}><VendoSlot id="hero" description={description} /></VendoProvider>

--- a/packages/ui/test/chrome/slot-report.test.tsx
+++ b/packages/ui/test/chrome/slot-report.test.tsx
@@ -4,7 +4,7 @@
 // the host's own markup untouched. Nothing below stubs the report path: the
 // slots write through the real client to the real wire fixture, and the
 // assertions read that server's own state back.
-import { SLOT_REPORT_REFRESH_MS } from "@vendoai/core";
+import { SLOT_DESCRIPTION_MAX_CHARS, SLOT_REPORT_REFRESH_MS } from "@vendoai/core";
 import { cleanup, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { VendoProvider, createVendoClient, type VendoClient } from "../../src/index.js";
@@ -71,6 +71,37 @@ describe("a mounted VendoSlot reports itself to the registry", () => {
         { id: "sidebar_feed", label: "Sidebar feed" },
         { id: "net-worth-card", label: "Net worth card" },
       ],
+    });
+  });
+
+  it("carries the host's description, clamped rather than dropped when it runs long", async () => {
+    render(
+      <VendoProvider client={client}>
+        <VendoSlot id="dashboard.main" label="Dashboard" description="main dashboard area, where users keep KPI views" />
+        <VendoSlot id="verbose" description={"x".repeat(SLOT_DESCRIPTION_MAX_CHARS + 50)} />
+      </VendoProvider>,
+    );
+    await waitFor(() => expect(reports()).toHaveLength(1));
+    expect(reports()[0]?.body).toEqual({
+      slots: [
+        { id: "dashboard.main", label: "Dashboard", description: "main dashboard area, where users keep KPI views" },
+        // Clamped, like the label beside it: a wordy slot is still a real
+        // destination, and the whole page's report is all-or-nothing at the route.
+        { id: "verbose", label: "Verbose", description: "x".repeat(SLOT_DESCRIPTION_MAX_CHARS) },
+      ],
+    });
+  });
+
+  it("re-reports the same slot under a NEW description", async () => {
+    const page = (description: string) => (
+      <VendoProvider client={client}><VendoSlot id="hero" description={description} /></VendoProvider>
+    );
+    const { rerender } = render(page("the top of the page"));
+    await waitFor(() => expect(reports()).toHaveLength(1));
+    rerender(page("the top of the page, above the fold"));
+    await waitFor(() => expect(reports()).toHaveLength(2));
+    expect(reports()[1]?.body).toMatchObject({
+      slots: [{ description: "the top of the page, above the fold" }],
     });
   });
 

--- a/packages/ui/test/wire-server.ts
+++ b/packages/ui/test/wire-server.ts
@@ -317,7 +317,7 @@ export async function createWireServer(options: WireServerOptions = {}) {
     /** The slot registry: what mounted `VendoSlot`s have reported. Kept
      *  newest-first the way the real route answers, and re-reporting a slot
      *  moves it back to the head rather than adding a second row. */
-    slots: [] as Array<{ id: string; label: string; lastSeen: string }>,
+    slots: [] as Array<{ id: string; label: string; description?: string; lastSeen: string }>,
     /** PR3 — apps whose build "lands" on the `after`-th placements read, so a
      *  test can watch a slot go building → ready over the real wire instead of
      *  asserting two static pages. Placing one again rewinds it (see the place
@@ -1360,7 +1360,7 @@ export async function createWireServer(options: WireServerOptions = {}) {
       }
       if (url.pathname === "/slots") {
         if (method === "POST") {
-          const reported = (parsedBody as { slots: Array<{ id: string; label: string }> }).slots;
+          const reported = (parsedBody as { slots: Array<{ id: string; label: string; description?: string }> }).slots;
           // Mirrors the real route's caps (packages/vendo/src/wire/slots.ts):
           // at most 200 entries, each id and label 1-256 characters, refused as
           // `validation` before ANY row is written — the whole batch, because
@@ -1374,7 +1374,9 @@ export async function createWireServer(options: WireServerOptions = {}) {
           }
           for (const slot of reported) {
             state.slots = [
-              { id: slot.id, label: slot.label, lastSeen: NOW },
+              // Kept, not dropped: a fixture that quietly discards a field lets
+              // a test pass while the real registry loses the sentence.
+              { id: slot.id, label: slot.label, ...(slot.description === undefined ? {} : { description: slot.description }), lastSeen: NOW },
               ...state.slots.filter(row => row.id !== slot.id),
             ];
           }

--- a/packages/vendo/src/react.tsx
+++ b/packages/vendo/src/react.tsx
@@ -38,6 +38,10 @@ export {
   VendoAppEmbed,
   VendoApprovalEmbed,
   VendoToolResult,
+  // chrome/vendo-slot.tsx — the mount point a host puts in its own markup, and
+  // the shape of its `onParked` prop.
+  VendoSlot,
+  type ParkedPress,
   // hooks/*
   useActivity,
   useApp,

--- a/packages/vendo/src/wire/slots.ts
+++ b/packages/vendo/src/wire/slots.ts
@@ -1,5 +1,6 @@
 import {
   SLOTS_REPORT_MAX,
+  SLOT_DESCRIPTION_MAX_CHARS,
   SLOT_ID_MAX_CHARS,
   SLOT_LABEL_MAX_CHARS,
   VendoError,
@@ -32,14 +33,20 @@ const bounded = (value: unknown, label: string, max: number): string => {
 
 /** ONE slot from the report body. Validated here — the one place a
     host-authored descriptor crosses into the runtime. */
-const descriptor = (value: unknown): { id: string; label: string } => {
+const descriptor = (value: unknown): { id: string; label: string; description?: string } => {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new VendoError("validation", "each slot must be an object");
   }
   const entry = value as Record<string, unknown>;
+  const description = entry["description"];
   return {
     id: bounded(entry["id"], "slot id", SLOT_ID_MAX_CHARS),
     label: bounded(entry["label"], "slot label", SLOT_LABEL_MAX_CHARS),
+    // Optional, because it is: a slot with no description is still a real
+    // destination, and only the model reads the sentence.
+    ...(description === undefined
+      ? {}
+      : { description: bounded(description, "slot description", SLOT_DESCRIPTION_MAX_CHARS) }),
   };
 };
 

--- a/packages/vendo/tests/default-composition.test.ts
+++ b/packages/vendo/tests/default-composition.test.ts
@@ -35,6 +35,7 @@ const DEFAULT_TOOL_NAMES = [
   "vendo_apps_reseed",
   "vendo_apps_unpin",
   "vendo_make",
+  "vendo_slots_list",
 ] as const;
 
 /** Every skill a default `createVendo()` mounts at /host/skills. */

--- a/packages/vendo/tests/mcp-door-outside-agent.e2e.test.ts
+++ b/packages/vendo/tests/mcp-door-outside-agent.e2e.test.ts
@@ -87,6 +87,9 @@ describe("the MCP door, as an OUTSIDE agent sees it — pinned before door-ctx",
       // screen through `vendo_make` and never has to decide "new or change?"
       // first. Losing it from this list is losing the front door.
       "vendo_make",
+      // The read that keeps a `slot` argument honest: without it an outside
+      // agent can only guess a slot id, and a guess lands nowhere.
+      "vendo_slots_list",
     ]);
   });
 

--- a/packages/vendo/tests/placement-tools.e2e.test.ts
+++ b/packages/vendo/tests/placement-tools.e2e.test.ts
@@ -26,6 +26,7 @@ import {
   VENDO_APPS_PIN_TOOL,
   VENDO_APPS_UNPIN_TOOL,
   VENDO_MAKE_TOOL,
+  VENDO_SLOTS_LIST_TOOL,
   type ToolListing,
   type ToolResult,
 } from "@vendoai/core";
@@ -212,6 +213,43 @@ describe("a slot-targeted make, over the MCP door", () => {
 });
 
 describe("pin and unpin, over the MCP door", () => {
+  it("pins to a slot the list tool handed back, so the id is never invented", async () => {
+    const { vendo, store } = await host();
+    // The host's page reports its slot the way a browser does — the real route,
+    // no fixture. Nothing else in this test tells the server the slot exists.
+    await vendo.handler(new Request("https://host.test/api/vendo/slots", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        slots: [{
+          id: "dashboard.main",
+          label: "Dashboard",
+          description: "main dashboard area, where users keep KPI views",
+        }],
+      }),
+    }));
+
+    const door = await openDoor(vendo, await bearer(vendo));
+    const listed = JSON.parse((await door.callTool(VENDO_SLOTS_LIST_TOOL, {})).text) as
+      { id: string; label: string; description?: string }[];
+    expect(listed).toEqual([{
+      id: "dashboard.main",
+      label: "Dashboard",
+      description: "main dashboard area, where users keep KPI views",
+    }]);
+
+    const made = await door.callTool(VENDO_MAKE_TOOL, { request: "my spending this month" });
+    const { id } = makeReceiptSchema.parse(JSON.parse(made.text));
+    // The id the caller pins with is the one the LIST answered with, never a
+    // literal typed into this test — which is the whole point of the tool.
+    const pinned = await door.callTool(VENDO_APPS_PIN_TOOL, { app: id, slot: listed[0]!.id });
+
+    expect(pinned.isError).toBeFalsy();
+    expect(await placementRows(store)).toEqual([
+      expect.objectContaining({ slot: "dashboard.main", appId: id }),
+    ]);
+  });
+
   it("writes the row on pin and removes it on unpin", async () => {
     const { vendo, store } = await host();
     const door = await openDoor(vendo, await bearer(vendo));

--- a/packages/vendo/tests/slot-registry.seam.test.ts
+++ b/packages/vendo/tests/slot-registry.seam.test.ts
@@ -16,11 +16,18 @@
  * real PGlite store; the destination is then read back through a SECOND client
  * instance — a fresh session for the same person, the "other device" — and
  * painted by the real picker.
+ *
+ * The AGENT is the registry's other consumer, and the same law applies to it:
+ * `vendo_slots_list` is called on a real turn through the composed, guard-bound
+ * registry, so the sentence a host wrote on a `<VendoSlot description>` prop has
+ * to survive every layer between that prop and the model's context or the
+ * assertion fails.
  */
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { Principal } from "@vendoai/core";
+import { VENDO_SLOTS_LIST_TOOL, type Principal, type ToolResult } from "@vendoai/core";
+import { defineHarness } from "@vendoai/harnesses";
 import { createStore, type VendoStore } from "@vendoai/store";
 import { VendoProvider, createVendoClient, type VendoClient } from "@vendoai/ui";
 import { AddToPicker, VendoSlot } from "@vendoai/ui/chrome";
@@ -48,13 +55,44 @@ async function tempStore(): Promise<VendoStore> {
   return store;
 }
 
+/** What `vendo_slots_list` hands the model for one slot. */
+interface ListedSlot { id: string; label: string; description?: string }
+
 /** The deployment, with the client's `fetch` routed straight into its door.
  *  Hands back how many reports have crossed it — the only thing the test needs
- *  the wire itself for. */
-async function compose(): Promise<{ reports: () => number }> {
+ *  the wire itself for — and the agent's own read of the registry. */
+async function compose(): Promise<{ reports: () => number; askTheAgent: () => Promise<ListedSlot[]> }> {
   const store = await tempStore();
   await store.ensureSchema();
-  const vendo = createVendo({ principal: async () => ADA, store });
+  // The consumer's real path: a turn, the composed guard-bound registry, and
+  // the tool a model would call. Nothing here reaches the store directly.
+  const answers: ToolResult[] = [];
+  const harness = defineHarness({
+    name: "slot-listing-probe",
+    async *run(turn) {
+      answers.push(await turn.tools.call(VENDO_SLOTS_LIST_TOOL, {}));
+      yield { type: "text", delta: "listed" };
+    },
+  });
+  const vendo = createVendo({ principal: async () => ADA, store, harness: harness as never });
+
+  let turns = 0;
+  const askTheAgent = async (): Promise<ListedSlot[]> => {
+    const threadId = `thr_slots_${(turns += 1)}`;
+    const answered = await vendo.handler(new Request(`${BASE}/threads`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        threadId,
+        message: { id: `m_${threadId}`, role: "user", parts: [{ type: "text", text: "where can this go?" }] },
+      }),
+    }));
+    // The turn only completes as its stream is drained.
+    await answered.text();
+    const outcome = answers.at(-1);
+    expect(outcome?.status).toBe("ok");
+    return (outcome as { output: ListedSlot[] }).output;
+  };
 
   let reports = 0;
   const realFetch = globalThis.fetch;
@@ -69,7 +107,7 @@ async function compose(): Promise<{ reports: () => number }> {
   }) as typeof fetch;
   cleanups.push(() => { globalThis.fetch = realFetch; });
 
-  return { reports: () => reports };
+  return { reports: () => reports, askTheAgent };
 }
 
 // --- rendering, without a component-test harness in this package -------------
@@ -145,5 +183,25 @@ describe("the slot registry, from a mounted slot to another device's picker", ()
     ));
     await until(() => (reports() >= 2 ? reports() : undefined));
     expect(await other.slots.list()).toHaveLength(1);
+  });
+
+  it("hands the agent the description the host wrote on the slot, and nothing it made up", async () => {
+    const { askTheAgent } = await compose();
+    const description = "main dashboard area, where users keep KPI views";
+
+    // The producer, again: the ONLY thing in this test that tells the server
+    // this slot exists is a host component rendering.
+    await mount(under(
+      createVendoClient({ baseUrl: BASE }),
+      createElement(VendoSlot, { id: "dashboard.main", label: "Dashboard", description }),
+    ));
+
+    // The consumer: the tool a model calls to find out where a view may land.
+    // No inner budget — the test's own timeout is the hang detector.
+    const listed = await until(async () => {
+      const slots = await askTheAgent();
+      return slots.length > 0 ? slots : undefined;
+    });
+    expect(listed).toEqual([{ id: "dashboard.main", label: "Dashboard", description }]);
   });
 });

--- a/packages/vendo/tests/slots-wire.test.ts
+++ b/packages/vendo/tests/slots-wire.test.ts
@@ -4,7 +4,7 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { Principal } from "@vendoai/core";
+import { SLOT_DESCRIPTION_MAX_CHARS, type Principal } from "@vendoai/core";
 import { createStore, type VendoStore } from "@vendoai/store";
 import { afterEach, describe, expect, it } from "vitest";
 import { createVendo } from "../src/server.js";
@@ -59,6 +59,34 @@ describe("POST /slots · GET /slots", () => {
     // Two rows still, the newly seen one first.
     expect(again.map(({ id }) => id)).toEqual(["hero", "sidebar"]);
     expect(again[0]).toMatchObject({ label: "Hero banner" });
+  });
+
+  it("round-trips the description a host wrote, and refuses one past the cap", async () => {
+    const store = await tempStore();
+    const vendo = createVendo({ principal: async () => principal, store });
+    const description = "main dashboard area, where users keep KPI views";
+
+    const reported = await vendo.handler(request("POST", "/slots", {
+      slots: [{ id: "dashboard.main", label: "Dashboard", description }],
+    }));
+    expect(reported.status).toBe(200);
+
+    const listed = await (await vendo.handler(request("GET", "/slots"))).json();
+    expect(listed).toEqual([
+      { id: "dashboard.main", label: "Dashboard", description, lastSeen: expect.any(String) },
+    ]);
+
+    // The cap is the route's, not the client's: this is the backstop every
+    // caller that is not our own UI hits.
+    const overlong = await vendo.handler(request("POST", "/slots", {
+      slots: [{ id: "dashboard.main", label: "Dashboard", description: "x".repeat(SLOT_DESCRIPTION_MAX_CHARS + 1) }],
+    }));
+    expect(overlong.status).toBe(400);
+    expect(await overlong.json()).toMatchObject({
+      error: { code: "validation", message: `slot description must be 1-${SLOT_DESCRIPTION_MAX_CHARS} characters` },
+    });
+    // …and the row it refused is untouched, not half-written.
+    expect(await (await vendo.handler(request("GET", "/slots"))).json()).toMatchObject([{ description }]);
   });
 
   it("refuses a body that is not a list of {id, label}", async () => {


### PR DESCRIPTION
A slot is a spot on the host's own page where a generated view can land. Until now a slot carried an `id` and a `label`, the agent had no way to see the list, and pressing an empty one on a page with no chat surface did nothing at all. This PR closes all three.

## A slot says what it is for

`VendoSlot` takes a new optional `description` (`packages/ui/src/chrome/vendo-slot.tsx:220-223`) — a sentence of intent written by the host developer, for the model, that nobody sees. The picker still renders `label`.

It survives every layer between the prop and the model's context: `useReportSlot` (`packages/ui/src/hooks/use-placements.ts:295`, with `description` in the effect deps at `:300` so an edited sentence re-reports) → the poller's `Reported` entry (`:218-222`) → `VendoClient.slots.report` (`packages/ui/src/client.ts:183`) → the wire `descriptor` (`packages/vendo/src/wire/slots.ts:36-51`) → the registry row (`packages/apps/src/server/persistence/slots.ts:76-79`). The write is a plain last-write-wins put, so an edited description overwrites in place rather than growing a second row.

## The 1024 cap, and why it behaves differently at the two ends

`SLOT_DESCRIPTION_MAX_CHARS = 1024` (`packages/core/src/slot-limits.ts:16`) — characters, not bytes. Roomier than the 256 of `id` and `label` because it is a sentence for a model to read, not a word a person picks from a menu.

Two enforcement sites, deliberately not symmetric:

- **The host's own UI truncates.** `packages/ui/src/hooks/use-placements.ts:216-222` slices to fit. The `/slots` route validates a batch all-or-nothing and a page reports every slot it mounts in one batch, so one over-long host prop would otherwise take that whole page out of the "Add to…" picker. Clamped, not skipped.
- **Every other caller gets a 400.** `bounded()` at `packages/vendo/src/wire/slots.ts:47-49` throws `slot description must be 1-1024 characters`. Rejection is per-batch and atomic — `descriptor` is mapped across the array before any write, so nothing lands half-written.

## The agent can ask

`vendo_slots_list` (`packages/core/src/tools.ts:51`, registered at `packages/apps/src/server/doors/agent-tools.ts:98-112`, `risk: "read"`). No inputs: the schema is `properties: {}` with `additionalProperties: false`. It returns `Array<{ id, label, description? }>` (`agent-tools.ts:306-313`) over the existing subject-scoped, decay-filtered `runtime.slots.list(ctx)` — no new read path, and `lastSeen` is stripped so the model never sees it.

The reason it has to exist is in the source at `:100-103`: a model with no way to see the real slot ids guesses one, and a guessed id is a placement aimed at a spot no page renders — the row is written, nothing ever shows it, and the user is told their view landed.

## The empty press has somewhere to go

`packages/ui/src/chrome/vendo-slot.tsx:296-305`. Pressing an empty slot's CTA now resolves in three arms, checked at press time rather than read off a prop, so a host that mounts an overlay later still gets the overlay:

1. **`onAuthor`**, if the host passed it. The host takes over; nothing else runs.
2. **`openVendoConversation()`, else `openVendoPalette()`** (`:304`). Short-circuit `&&` — the palette only runs when no overlay is mounted, which is the compatibility path for hosts that mounted a bare `VendoPalette` with their own `onCommand` routing.
3. **The hint**, reached only when both openers returned `false`: `Ask your assistant to build something for this spot.` plus the slot's name (`:380-386`).

The one changed line is `:304`; it used to read `if (!openVendoConversation()) openVendoPalette();`. Arm 3 is a ternary, not an addition — the dead button is **replaced**, not accompanied. A press that finds nothing no longer gets swallowed by a button that does nothing.

## The export fix

`VendoSlot` was reachable only through the `@vendoai/ui/chrome` subpath. A host that depends on the umbrella `@vendoai/vendo` has no `@vendoai/ui` in its own `node_modules` under pnpm's strict linking, so that import fails to resolve with TS2307 — the flagship host-facing component was not importable by the people it is for. Same story as `VendoOverlay`'s.

It now exports from the package root (`packages/ui/src/index.ts:17-21`, with `type ParkedPress`) and is re-exported on the path a host actually uses, `@vendoai/vendo/react` (`packages/vendo/src/react.tsx:41-44`). The named-export style is required there because `react.tsx` is a `"use client"` boundary and Next's flight loader cannot enumerate `export *`. `packages/vendo/tests/react-export-parity.test.ts` enumerates the ui root's runtime exports and would have gone red on the root export alone.

## Test — the seam

`packages/vendo/tests/slot-registry.seam.test.ts:188-206`, "hands the agent the description the host wrote on the slot, and nothing it made up".

Producer and consumer are both real, with **no stub on either side** — the file imports `afterEach, describe, expect, it` and not `vi`; there is no `vi.mock` and no `vi.fn` anywhere in it.

- **Write path:** a real `VendoSlot` from `@vendoai/ui/chrome`, mounted with `createRoot` under a real `VendoProvider` and a real `createVendoClient`. The only thing in the test that tells the server this slot exists is a host component rendering.
- **Read path:** a real agent turn — `POST /threads` through `vendo.handler`, stream drained, and inside it a probe calls `turn.tools.call(VENDO_SLOTS_LIST_TOOL, {})` through the composed, guard-bound tool surface. Everything under that call is production code.
- **Server:** real `createVendo` over a real PGlite store on a real temp dir.
- **Assertion:** `toEqual([{ id: "dashboard.main", label: "Dashboard", description }])` — exact, so a leaked `lastSeen` and a dropped description both fail.

`globalThis.fetch` is swapped, and only toward reality: it hands the request straight to `vendo.handler`. Its other job is counting POSTs to `/slots` so re-reporting can be shown not to grow the table.

The test was written against the unfixed tree first and observed red before the wiring existed — the description could not survive a seam that did not carry it. The `until()` poller has no inner wall-clock budget, per the repo rule.

Companion at `packages/vendo/tests/placement-tools.e2e.test.ts:216-252` pins with `listed[0]!.id` rather than a literal, so the id the tool handed back is the id that gets pinned.

## Browser proof

Playwright is a local pre-PR gate, not a CI job, so the evidence is a local run plus screenshots. `packages/ui/e2e/slot-hint.spec.ts` drives `/slot-hint` (`packages/ui/e2e/harness/main.tsx:1852-1863`), a scenario built with **no overlay and no palette on the page** — the only way to reach arm 3. It asserts, in a real browser:

1. the empty slot renders a visible `Design a view` button;
2. after the press, `role="status"` reads exactly `Ask your assistant to build something for this spot. Net worth card` — confirming the id-to-words derivation — **and** the button is at `toHaveCount(0)`, gone rather than merely inert;
3. the neighbouring slot's `onAuthor` still wins on the same page where arm 3 just fired.

Three full-page screenshots with animations disabled: `1-empty-slot.png`, `2-hint.png`, `3-onauthor.png`.

## Gate

Run on the tip of the three-PR stack this branch is the base of, so all three lanes are under it: `pnpm install` ✅ · `pnpm build` ✅ · `pnpm typecheck` ✅ · `pnpm lint` ✅. `pnpm test:affected` is 44 of 45 turbo tasks green — `@vendoai/ui` 1217 passed, `@vendoai/apps` 1333 passed, `@vendoai/vendo` 2410 passed / 45 skipped, `@vendoai/core` 765 passed.

### The one pre-existing failure this PR does not touch

`@vendoai/genbench` `tests/font.test.ts > the world's font > says nothing at all for a world that ships no face` — `expected '<!doctype html>…' not to contain '@font-face'`.

It is **main's, not this stack's**, and this was checked rather than assumed: `genbench/` has no file in any of the three lanes, but `pageHtml` is fed by `bundleMount()`, which bundles `@vendoai/ui` — a package this PR does change — so the test was run against a clean `origin/main` (`6c26bfdc3`) with a full rebuild and no ven8 commits present. It fails there identically, 1 failed / 5 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `description` to slots and a `vendo_slots_list` tool so agents use real slot ids instead of guessing. Also fixes empty-slot presses to always resolve and exports `VendoSlot` from paths hosts use. New: the UI now omits empty descriptions so a blank `description` no longer unregisters a page; the route still rejects overlong or empty descriptions from non-UI callers.

- `VendoSlot` accepts `description` and reports it end to end; the UI clamps to 1024 chars and drops empty strings, while the wire enforces 1–1024 and returns 400 to other callers.
- Adds `vendo_slots_list` (`risk: "read"`) returning `[{ id, label, description? }]` from the registry; it strips `lastSeen`.
- Changes the empty-slot CTA: try conversation overlay, else palette, else show a hint and remove the button (old behavior swallowed the press on pages with no chat surface).
- Exports `VendoSlot` from `@vendoai/ui` root and re-exports it from `@vendoai/vendo/react`.
- Tests cover registry propagation, tool output, UI hint, wire validation, and the empty-description backstop.

**Rollout**
- Hosts may add `description` to `VendoSlot` to guide the agent; no required changes.
- Agents and tools should call `vendo_slots_list` and pass returned ids to `vendo_make.slot` or `vendo_apps_pin.slot`; do not invent ids.
- Expect a visible hint on pages without a chat surface when users press an empty slot.

<sup>Written for commit cf3306b26606c84ac851bb9cfd8dc1657c0e32c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

