### PR TITLE
feat(vendo): init --agent asks first, then writes

### DIFF
--- a/.changeset/init-agent-asks-first.md
+++ b/.changeset/init-agent-asks-first.md
@@ -1,0 +1,17 @@
+---
+"@vendoai/vendo": minor
+---
+
+`vendo init --agent` asks first and then writes, instead of printing a plan nobody could act on.
+
+Init has one personality in every mode now: it detects, asks, logs in, and writes. Agent mode only changes how the questions TRAVEL. Init emits them as JSON, the coding agent relays them in chat, the answers come back as flags on a re-run, and that run writes.
+
+The first `--agent` call runs detection and, if anything a person must decide is still open, prints ONE object and touches nothing: `{"status": "questions", "detected": {…}, "questions": [{id, prompt, options}]}`. Each prompt is chat copy an agent relays verbatim, and each option carries the literal thing the agent does to pick it, a `flag` for the re-run or a `command` to run before it. There is no select-vs-confirm machinery: yes/no is two options. The set is use-case, auth and models, plus the sign-in posture and the service key once the use case is MCP. A call that already carries every answer skips the question pass and writes in one go.
+
+Both passes exit 0. `status` is what a caller branches on, the same idea as `doctor --json`. The write pass ends in a receipt: `{"status": "written", root, useCase, wrote, pasteEdits, tools, riskRecommendations, judgment}`. `judgment` is always `{"status": "delegated"}` with the checklist of what the catalog still needs, because the caller IS a coding agent and agent mode may not spawn another one underneath it.
+
+**The read-only plan dump is retired.** There is no mode that prints code diffs and stops, and there is no `--plan` flag. No new flags were added for any of this either: `--use-case`, `--auth`, `--cloud-key`, `--byo`, `--posture` and `--service-key` all already existed and already validated.
+
+Nothing mechanical is ever relayed. The deploy URL, the zod floor, the theme slots and the live check take the same defaults `--yes` gives them and show up in the diff. The interactive terminal flow is unchanged.
+
+Two wording fixes ride along: `--byo` now states what your own key needs instead of pointing back at `vendo login`, which made the opt-out read as a detour rather than a first-class path; and the packaged `vendo-setup` skill teaches the new flow.

--- a/packages/vendo/skills/vendo-setup/SKILL.md
+++ b/packages/vendo/skills/vendo-setup/SKILL.md
@@ -20,31 +20,45 @@ fetch it when you need more detail than this skill carries.
    npm install @vendoai/vendo
    ```
 
-2. Run init. As an agent, plan first, then apply:
+2. Run init. It asks first, then writes:
 
    ```bash
-   npx vendo init --agent   # read-only JSON plan: framework, code diffs, the `mount` paste, extracted tools, risk recommendations
-   npx vendo init --yes
+   npx vendo init --agent
    ```
 
-   `--agent` writes nothing. Init applies its bounded change set and lists
-   it; the only questions are an auth confirm when detection is uncertain, a
-   review of uncertain theme slots, and the end-of-init cloud-login offer
-   (`--yes` skips it). Each question has a non-interactive answer flag:
-   `--auth <preset>`, `--framework <name>`, `--theme <slot=value>`
-   (repeatable), `--cloud-key <key>` or `--byo`, and `--ai` / `--no-ai` to
-   force the AI judgment pass on or off. Prefer the interactive run when a
-   human is present.
+   Init detects the stack and prints ONE JSON object. `{"status":
+   "questions", …}` means it wrote nothing: relay every `prompt` to the user
+   VERBATIM in chat, with its options. Each option carries the literal thing
+   you do to pick it, a `flag` for the re-run or a `command` to run first.
+   Then re-run with every answer:
+
+   ```bash
+   npx vendo login --wait 90                          # only if they picked the free Cloud key
+   npx vendo init --agent --use-case embedded --auth clerk --byo
+   ```
+
+   That run writes, narrates itself, and ends on the receipt, the LAST JSON
+   object it prints: `{"status": "written", …}` with `wrote` (the files
+   it created), `pasteEdits` (the changes only you can make), `tools`,
+   `riskRecommendations`, and `judgment`, which is always `delegated` with a
+   checklist that is yours to work through. Both runs exit 0, so branch on
+   `status`, never on the exit code. All answers on the first call and it
+   writes in one pass.
+
+   Never relay a mechanical question. The deploy URL, the zod floor, the
+   theme slots and the live check are never asked: they take their defaults
+   and show up in the diff.
 
    **Init never edits a file a human wrote.** Every file it writes is new and
    Vendo-owned, plus its own `package.json` hooks. Mounting the visible
-   surface is a paste YOU must apply — the plan carries it as
-   `mount: { file, lines, why }` and the run prints it in a framed
-   "ONE STEP LEFT" block. Apply it before calling the install done; `vendo
-   doctor` fails with `E-WIRE-004` until it lands.
+   surface is a paste YOU must apply: the receipt carries it in `pasteEdits`
+   as `{ file, lines, why }` and the run prints it in a framed "ONE STEP
+   LEFT" block. Apply it before calling the install done; `vendo doctor`
+   fails with `E-WIRE-004` until it lands.
 
 3. What init does (framework detected from `package.json`, `next` beats
-   `express`; anything else is treated as Next):
+   `express`; with neither present it refuses to guess and asks for
+   `--framework next|express|custom`):
    - Writes `.vendo/` — `tools.json` (extracted tools), `overrides.json`
      (your risk/confirmEach edits, respected forever), `policy.json`,
      `brief.md`, `theme.json` (brand extracted from the host CSS), and a

--- a/packages/vendo/src/cli.ts
+++ b/packages/vendo/src/cli.ts
@@ -30,7 +30,7 @@ Advanced:
   config <command> Show which layer owns each .vendo config surface
 
 Options:
-  --agent                    Init only: print a read-only JSON plan — code changes, extracted tools, risk recommendations
+  --agent                    Init only: ask first. Prints the open questions as JSON and writes nothing; re-run with the answers as flags and it writes, ending in a JSON receipt
   --yes                      Init: accept the detected auth preset, skip the cloud offer + AI polish + theme review, end with the agent tail; doctor: auto-start the dev server
   --force                    Init/server-json: overwrite owned or generated files; eject: overwrite an ejected dir
   --auth <preset>            Init only: wire this auth preset without asking (authJs, clerk, supabase, auth0, jwt, none)
@@ -181,6 +181,12 @@ async function initCommand(args: string[]): Promise<number> {
   const initAi = args.includes("--ai") || args.includes("--ai-polish");
   if (initAi && args.includes("--no-ai")) {
     problems.push("--ai and --no-ai answer the same question — pass one or the other");
+  }
+  // Agent mode delegates judgment to the caller, so an engine can never run on
+  // it. Saying so beats dropping the flag: silently ignoring one is exactly how
+  // the "--agent writes nothing" promise broke in the field.
+  if (args.includes("--agent") && (initAi || engine !== undefined)) {
+    problems.push(`${initAi ? "--ai" : "--engine"} has no effect with --agent: judgment is delegated to you and the receipt names what it left. Drop it, or drop --agent to let init judge`);
   }
   const themePairs = options(args, "--theme");
   const badTheme = themePairs.find((pair) => !/^[A-Za-z]+=./.test(pair));

--- a/packages/vendo/src/cli/cloud-init.ts
+++ b/packages/vendo/src/cli/cloud-init.ts
@@ -303,7 +303,10 @@ async function cloudStep(options: CloudStepOptions, failure: { failedStep?: stri
   if (options.yes || options.byo === true || !laddersWantKey) {
     if (laddersWantKey) {
       if (options.byo === true) {
-        output.log("Run `vendo login` to claim a free API key; it lands in .env.local.");
+        // --byo is the ANSWER, so this states what their own key needs and
+        // stops. Nudging back to `vendo login` here is what made the opt-out
+        // read as a detour rather than a first-class path.
+        output.log("Your own key: set ANTHROPIC_API_KEY (or OPENAI_API_KEY / GOOGLE_GENERATIVE_AI_API_KEY) in .env.local, then select it in your composition's `models`.");
       } else {
         // --yes / agent-driven runs get the full auth.md pointer: the agent
         // can complete the whole key story in-band from these lines.

--- a/packages/vendo/src/cli/init-questions.ts
+++ b/packages/vendo/src/cli/init-questions.ts
@@ -1,0 +1,169 @@
+/**
+ * The questions `vendo init --agent` hands back, as data.
+ *
+ * One personality for init in every mode: it detects, asks, logs in and writes.
+ * Agent mode only changes how the questions TRAVEL — init emits them as JSON,
+ * the coding agent relays the prompts VERBATIM in chat, the answers come back
+ * as flags on a re-run, and that run writes. No new flags exist for any of it:
+ * every option below names one of the six init already validates.
+ *
+ * Only what a PERSON must decide appears here. The base URL, the zod floor, the
+ * theme slots and the live check are mechanical, so they default exactly as
+ * `--yes` leaves them and show up in the diff instead of in someone's chat.
+ *
+ * PURE apart from reading the host's dependencies for auth: every prompt is
+ * decided from the answers already on the command line, so the whole set is
+ * assertable without a run.
+ */
+import { AUTH_FAMILY_INFO, detectAuthPreset, type AuthPresetName } from "./init-auth.js";
+import type { InitOptions } from "./init.js";
+
+/** One answer, carrying the literal thing the agent does to pick it: a flag on
+    the re-run, or a command to run before it. No select-vs-confirm machinery —
+    yes/no is simply two options. */
+export interface InitQuestionOption {
+  label: string;
+  flag?: string;
+  command?: string;
+  note?: string;
+  recommended?: boolean;
+}
+
+export interface InitQuestion {
+  id: string;
+  /** Chat-ready: agents relay it verbatim. */
+  prompt: string;
+  options: InitQuestionOption[];
+}
+
+export interface InitQuestions {
+  status: "questions";
+  detected: { framework: string; auth?: AuthPresetName };
+  questions: InitQuestion[];
+}
+
+const USE_CASE: InitQuestion = {
+  id: "use-case",
+  prompt: "How will people use your agent? Most apps embed it: your users chat with your product and it builds them real working screens from your data, dashboards, forms, views, right inside your app (recommended). Or: through your own agent loop. Or: from outside AI apps over MCP.",
+  options: [
+    { label: "Embedded: chat + generated screens in your app", flag: "--use-case embedded", recommended: true },
+    { label: "Through your own agent loop (AI SDK / Mastra)", flag: "--use-case agent-loop" },
+    { label: "From outside AI apps over MCP", flag: "--use-case mcp" },
+  ],
+};
+
+const MODELS: InitQuestion = {
+  id: "models",
+  prompt: "Vendo needs a model. Easiest is a free Vendo Cloud key, one browser click, no provider account. Set that up? Or use your own Anthropic or OpenAI key.",
+  options: [
+    { label: "Vendo Cloud, free key", command: "npx vendo login --wait 90", recommended: true },
+    { label: "Own key", flag: "--byo", note: "put the key in .env.local first, it never enters the chat" },
+  ],
+};
+
+const SERVICE_KEY_PROMPT = "Will your own backend call these tools machine to machine, like a nightly job? If yes I'll set up a service key.";
+
+const POSTURE: InitQuestion = {
+  id: "posture",
+  prompt: "When an outside agent connects, its user always signs in with your app's own login. Who should run the OAuth plumbing around that? Vendo can host it at yourcompany.mcp.vendo.run so none of it lives on your domain (recommended, uses your new cloud account). Or your app serves it itself, also fine, zero config.",
+  options: [
+    { label: "Vendo hosts the OAuth plumbing", flag: "--posture broker", recommended: true },
+    { label: "Your app serves it itself", flag: "--posture local" },
+  ],
+};
+
+/** MCP's extras. They are relayed together and answered together — see the
+ *  single gate in `initQuestions`.
+ *
+ *  Without a Cloud key there is no posture QUESTION: a keyless run cannot reach
+ *  a broker, so local is simply the default (the same rule the terminal flow
+ *  follows — init.ts's posture select only appears with a key in hand). Offering
+ *  the broker anyway would write a tenant URL that does not exist and silently
+ *  drop the service key with it, so the one remaining question carries the
+ *  settled `--posture local` on both of its answers instead. */
+function mcpQuestions(cloudKey: boolean): InitQuestion[] {
+  if (!cloudKey) {
+    return [{
+      id: "service-key",
+      prompt: SERVICE_KEY_PROMPT,
+      options: [
+        { label: "Yes", flag: "--posture local --service-key" },
+        { label: "No", flag: "--posture local" },
+      ],
+    }];
+  }
+  return [
+    POSTURE,
+    {
+      id: "service-key",
+      prompt: SERVICE_KEY_PROMPT,
+      options: [
+        { label: "Yes", flag: "--service-key" },
+        { label: "No", note: "send the other answers without --service-key" },
+      ],
+    },
+  ];
+}
+
+const PRESETS = Object.keys(AUTH_FAMILY_INFO) as AuthPresetName[];
+
+function authQuestion(detected: AuthPresetName | undefined): InitQuestion {
+  if (detected === undefined) {
+    return {
+      id: "auth",
+      prompt: "Which auth should Vendo wire?",
+      options: [
+        ...PRESETS.map((preset) => ({ label: AUTH_FAMILY_INFO[preset].name, flag: `--auth ${preset}` })),
+        { label: "Your own JWT scheme", flag: "--auth jwt" },
+        { label: "No signed-in user", flag: "--auth none" },
+      ],
+    };
+  }
+  const name = AUTH_FAMILY_INFO[detected].name;
+  const others = [...PRESETS.filter((preset) => preset !== detected), "jwt"].join("|");
+  return {
+    id: "auth",
+    prompt: `It detected ${name}. Should the assistant act as your signed-in ${name} user?`,
+    options: [
+      { label: "Yes", flag: `--auth ${detected}`, recommended: true },
+      { label: "A different auth", flag: `--auth <${others}>`, note: "replace the placeholder with one of those four names" },
+      { label: "No signed-in user", flag: "--auth none" },
+    ],
+  };
+}
+
+/** What is still unanswered on this command line, or null when nothing is —
+    which is the signal to go ahead and write. */
+export async function initQuestions(input: {
+  root: string;
+  options: InitOptions;
+  framework: string;
+  /** A model key is already in hand (env or .env.local), so the models
+      question is settled and disappears on the re-run. */
+  modelKey: boolean;
+  /** A Vendo Cloud key specifically — the only thing a broker posture can run
+      on, so it decides whether the MCP sign-in question exists at all. */
+  cloudKey: boolean;
+}): Promise<InitQuestions | null> {
+  const { options } = input;
+  // `wired`, never `matches[0]`: two families matching is AMBIGUOUS, and
+  // claiming the first one would name a provider the host may not use and hide
+  // the other. Ambiguity falls through to the full-list question.
+  const detected = (await detectAuthPreset(input.root)).wired?.preset;
+  const questions: InitQuestion[] = [];
+  if (options.useCase === undefined) questions.push(USE_CASE);
+  if (options.auth === undefined) questions.push(authQuestion(detected));
+  if (!input.modelKey && options.byo !== true && options.cloudKey === undefined) questions.push(MODELS);
+  // ONE gate for the MCP extras: they travel in the same relay, so `--posture`
+  // on the way back is what says they were answered. A bare `--service-key` has
+  // no "no" spelling, so gating on it would ask forever.
+  if (options.useCase === "mcp" && options.posture === undefined) {
+    questions.push(...mcpQuestions(input.cloudKey));
+  }
+  if (questions.length === 0) return null;
+  return {
+    status: "questions",
+    detected: { framework: input.framework, ...(detected === undefined ? {} : { auth: detected }) },
+    questions,
+  };
+}

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -1,8 +1,6 @@
-import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { mkdir, readFile } from "node:fs/promises";
 import { dirname, join, relative, resolve, sep } from "node:path";
-import type { ExtractedTool, OverridesFile } from "@vendoai/actions";
-import { mergeOverrides, vendoSync } from "@vendoai/actions/sync";
+import type { ExtractedTool } from "@vendoai/actions";
 import { VendoError } from "@vendoai/core";
 import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
@@ -12,6 +10,7 @@ import { AUTH_MD_URL, ensureEnvLocalIgnored, runCloudStep, upsertEnvLocal, type 
 import { runDoctor } from "./doctor.js";
 import type { InitPolishSeam } from "./init-judgment.js";
 import { mcpStepLines, planMcp, type McpPosture } from "./init-mcp.js";
+import { initQuestions } from "./init-questions.js";
 import { rendererFlowOptions, runSyncFlow, writeFonts, type SyncFlowResult } from "./sync-flow.js";
 import { BRIEF_TEMPLATE } from "./extract/stages.js";
 import { ENV_KEY_VARS, resolveDevCredential, describeDevCredential, type DevCredential } from "../dev-creds/resolve.js";
@@ -108,8 +107,8 @@ export interface RiskRecommendation {
 /** A step init cannot take for you. Init only ever CREATES files in your source
     tree, so every change to a file that already exists — the visible-surface
     mount, the server-action wiring — is the developer's paste, structured so
-    the terminal block, the `manualSteps` lines, and the `--agent` plan all
-    carry the SAME file and lines. */
+    the terminal block, the `manualSteps` lines and the receipt's `pasteEdits`
+    all carry the SAME file and lines. */
 export interface ManualEdit {
   /** The file the paste goes in, relative to the init root. */
   file: string;
@@ -126,31 +125,42 @@ export type InitUseCase = "embedded" | "agent-loop" | "mcp";
 
 export const INIT_USE_CASES: readonly InitUseCase[] = ["embedded", "agent-loop", "mcp"];
 
-export interface InitPlan {
+/** What the run settled before it writes anything. Everything else buildPlan
+    resolves — the changes, the pastes, the auth facts — rides beside it on that
+    function's return, where each has exactly one reader. */
+interface InitPlan {
   framework: Exclude<HostFramework, "unknown"> | "custom";
-  /** --use-case only: absent on a run that never named one, so an unattended
-      plan stays byte-identical to the one agents parse today. */
-  useCase?: InitUseCase;
-  root: string;
+  /** The `.vendo` artifacts every path lays down. */
   writes: string[];
-  codeChanges: Array<{ path: string; diff: string }>;
-  /** Whatever wiring the run could not do safely itself: the paste lines for
-      the user. Always carries the mount when one is outstanding. */
-  manualSteps: string[];
-  /** The mount paste as data (absent when a surface is already mounted, and
-      on Express/custom hosts, whose two wiring lines have no single file to
-      name — they ride `manualSteps`). */
-  mount?: ManualEdit;
-  /** Changes init found for files that already exist and it therefore will not
-      write: an existing route.ts missing its `serverActions` wiring, a
-      registration map that has fallen behind the host's `"use server"`
-      surface. Absent when there are none. */
-  edits?: ManualEdit[];
-  /** --agent only: deterministic extraction results, so an agent can act on
-      real tool names instead of re-deriving them. */
-  extraction?: { tools: ExtractedTool[]; warnings: string[] };
-  riskRecommendations?: RiskRecommendation[];
 }
+
+/** How an agent-mode run ENDS: the same facts the prose tail carries, as data.
+    Its twin is `InitQuestions` — one status field tells them apart, and both
+    exit 0, so the coding agent branches on the shape and never on a code. */
+export interface InitReceipt {
+  status: "written";
+  root: string;
+  useCase: InitUseCase;
+  /** The install's files, root-relative: what init wrote, plus what an earlier
+      init already put there (it is idempotent, so a re-run leaves the same set
+      in place). Every entry exists on disk. */
+  wrote: string[];
+  /** What init could not write for you: the mount, the wiring it found stale,
+      the loop snippet. Verbatim `ManualEdit`s (see `handSteps`). */
+  pasteEdits: ManualEdit[];
+  tools: number;
+  riskRecommendations: RiskRecommendation[];
+  /** Agent mode never spends a model on judgment: the caller IS the model, so
+      the work is named rather than done. */
+  judgment: { status: "delegated"; checklist: string[] };
+}
+
+const JUDGMENT_CHECKLIST = [
+  "task-quality descriptions per tool",
+  "risk grades into .vendo/overrides.json",
+  "replace the .vendo/brief.md placeholder",
+  "fill unresolved slots in .vendo/theme.json",
+];
 
 export interface InitOptions {
   targetDir: string;
@@ -504,32 +514,6 @@ interface PlannedChange {
   before: string | null;
   after: string;
   diff: string;
-}
-
-/** Read-only extraction for the agent plan. vendoSync writes its artifacts, so
-    it runs against a throwaway out dir — the host tree stays untouched (the
-    --agent contract). Existing overrides ride along so the plan reflects prior
-    human risk decisions, mirroring vendoSync's own merge semantics. */
-async function extractForPlan(root: string): Promise<{ tools: ExtractedTool[]; warnings: string[] }> {
-  const out = await mkdtemp(join(tmpdir(), "vendo-agent-plan-"));
-  try {
-    const overridesRaw = await readOptional(join(root, ".vendo", "overrides.json"));
-    if (overridesRaw !== null) await writeText(join(out, "overrides.json"), overridesRaw);
-    const report = await vendoSync({ root, out });
-    const file = JSON.parse(await readFile(join(out, "tools.json"), "utf8")) as { tools?: ExtractedTool[] };
-    let overrides: OverridesFile | null = null;
-    try {
-      overrides = overridesRaw === null ? null : JSON.parse(overridesRaw) as OverridesFile;
-    } catch {
-      // vendoSync already validated the copy; an unreadable original merges as absent.
-    }
-    return { tools: mergeOverrides(file.tools ?? [], overrides), warnings: report.warnings };
-  } catch (error) {
-    // The plan must always emit — extraction failures degrade to a warning.
-    return { tools: [], warnings: [`extraction failed: ${error instanceof Error ? error.message : "unknown error"}`] };
-  } finally {
-    await rm(out, { recursive: true, force: true });
-  }
 }
 
 /** 04-actions §1 risk ladder projected as advice: destructive asks first,
@@ -1224,18 +1208,7 @@ async function buildPlan(options: InitOptions, confirmAuth?: ConfirmAuth, select
     layout,
     modelWritten,
     rewriteModels,
-    plan: {
-      framework,
-      // Only when the run named one: an unattended plan stays byte-identical
-      // to the one agents parse today.
-      ...(options.useCase === undefined ? {} : { useCase: options.useCase }),
-      root,
-      writes,
-      codeChanges: changes.map(({ path, diff: rendered }) => ({ path, diff: rendered })),
-      manualSteps,
-      ...(mount === null ? {} : { mount }),
-      ...(edits.length === 0 ? {} : { edits }),
-    },
+    plan: { framework, writes },
   };
 }
 
@@ -1429,7 +1402,7 @@ async function guardUndetectedFramework(input: {
   if (options.yes === true || !interactive) {
     output.error(
       "Framework not detected (no next or express dependency in package.json) and this run cannot ask. " +
-      "Pass --framework. Examples: vendo init --yes --framework next · --framework custom (any Web-standard runtime: Cloudflare Workers, Bun, Hono, ...)",
+      "Pass --framework. Examples: vendo init --framework next · --framework custom (any Web-standard runtime: Cloudflare Workers, Bun, Hono, ...)",
     );
     return false;
   }
@@ -1640,6 +1613,9 @@ async function runInstallSyncFlow(input: {
     interactive: extract.interactive
       ?? (!invokedByPackageScript() && Boolean(stdin.isTTY) && Boolean(stdout.isTTY)),
     yes: options.yes === true,
+    // Agent mode never spends a model here and never asks to: the caller IS
+    // the model, and the receipt hands it the checklist instead.
+    ...(options.agent === true ? { delegated: true } : {}),
     // --ai IS the consent (no prompt, non-interactive runs stop skipping);
     // --no-ai is the refusal. No flag = ask, every interactive run.
     ...(ai === undefined ? {} : { ai }),
@@ -1736,10 +1712,15 @@ async function finishRun(input: {
   layout: LayoutWiring;
   toolCount: number;
   brandCaptured: boolean;
+  /** Receipt-only (--agent): the install's files, and the risk ladder read off
+      the catalog this run synced. Empty on every other run. */
+  wrote: string[];
+  risks: RiskRecommendation[];
 }): Promise<string> {
   const {
     root, options, output, pretty, interactive, useCase, mcp, mount, edits, manualSteps,
     credential, cloud, compositionPath, framework, authWired, layout, toolCount, brandCaptured,
+    wrote, risks,
   } = input;
 
   // Where will this deploy? — every path but MCP, which needed the answer
@@ -1768,10 +1749,26 @@ async function finishRun(input: {
   const checkPassed = handSteps.length === 0
     && await offerLiveCheck({ root, options, output, pretty, interactive });
 
+  // The receipt: agent mode's LAST line, and the whole of its ending. Same
+  // facts as the prose tail below, shaped so the caller can act on them without
+  // parsing sentences.
+  if (options.agent === true) {
+    output.log(JSON.stringify({
+      status: "written",
+      root,
+      useCase,
+      wrote,
+      pasteEdits: handSteps,
+      tools: toolCount,
+      riskRecommendations: risks,
+      judgment: { status: "delegated", checklist: JUDGMENT_CHECKLIST },
+    } satisfies InitReceipt, null, 2));
+    return runStats({ toolCount, brandCaptured, handSteps: handSteps.length, checkPassed });
+  }
+
   // Agent tail (agent-install-dx): the --yes-or-non-TTY path is agent-driven
   // — the run's FINAL block is the repo-specific pointers an agent parses.
-  // Interactive human runs keep the clack-style output untouched; --agent
-  // never reaches here (its read-only JSON plan returned above).
+  // Interactive human runs keep the clack-style output untouched.
   if (options.yes === true || !interactive) {
     output.log("\nAgent tail:");
     const tail = await agentTailLines({ root, framework, compositionPath, authWired, layout, edits, cloudKeyMissing: credential.rung === "none" });
@@ -1791,7 +1788,12 @@ async function finishRun(input: {
   return runStats({ toolCount, brandCaptured, handSteps: handSteps.length, checkPassed });
 }
 
-export async function runInit(options: InitOptions): Promise<number> {
+export async function runInit(input: InitOptions): Promise<number> {
+  // Agent mode answers every MECHANICAL question the way `--yes` does — the
+  // base URL, the zod floor, the theme slots, the live check — so they land in
+  // the diff instead of in someone's chat. Only what a person must decide is
+  // relayed, and that happens before anything here writes.
+  const options: InitOptions = input.agent === true ? { ...input, yes: true } : input;
   // The clack-style renderer rides the SAME Output seam: it restyles the
   // exact plain messages below, and is selected only for a human terminal
   // (TTY, no NO_COLOR/CI, never --agent, never an injected output). Every
@@ -1843,27 +1845,38 @@ const explainedPlanFailure = (error: unknown): boolean => {
     }
   };
 
-  if (options.agent === true) {
-    // Extraction runs before the plan is emitted so the plan carries real tool
-    // names and risk advice; the throwaway out dir keeps --agent read-only.
-    const planned = await buildPlanOrExplained(options);
-    if (planned === null) return 1;
-    const { plan } = planned;
-    const extraction = await extractForPlan(root);
-    output.log(JSON.stringify({
-      ...plan,
-      extraction,
-      riskRecommendations: riskRecommendations(extraction.tools),
-    } satisfies InitPlan, null, 2));
-    return 0;
-  }
-
   // Detect + confirm (interactive runs only): --yes and non-interactive runs
   // accept the detected default silently — the same interactivity posture as
-  // the AI-polish consent.
-  const interactive = options.interactive
-    ?? (!invokedByPackageScript() && Boolean(stdin.isTTY) && Boolean(stdout.isTTY));
-  if (!await guardUndetectedFramework({ root, options, output, interactive })) return 1;
+  // the AI-polish consent. Agent mode is never interactive: its questions
+  // travel as JSON, so nothing on that run may prompt.
+  const interactive = options.agent !== true
+    && (options.interactive
+      ?? (!invokedByPackageScript() && Boolean(stdin.isTTY) && Boolean(stdout.isTTY)));
+  // The guard belongs to the runs that would otherwise GUESS. Agent mode keeps
+  // the fall-through to the runtime-neutral custom scaffold it has always had:
+  // resolveFramework answers "custom" for an undetectable host, which is the
+  // safe default rather than a guess, and detection behaves the same in every
+  // mode.
+  if (options.agent !== true && !await guardUndetectedFramework({ root, options, output, interactive })) return 1;
+
+  // Ask first (agent mode): detection has run, so whatever a PERSON still owes
+  // an answer to leaves as ONE JSON object and this run writes nothing. The
+  // answers come back as flags and the re-run writes; a call that already
+  // carries them all falls through and writes in this one pass.
+  if (options.agent === true) {
+    const cloudKey = (credentialEnv(root, env)["VENDO_API_KEY"] ?? "").trim() !== "";
+    const questions = await initQuestions({
+      root,
+      options,
+      framework: await resolveFramework(root, options),
+      modelKey: cloudKey || scaffoldModel(root, options) !== null,
+      cloudKey,
+    });
+    if (questions !== null) {
+      output.log(JSON.stringify(questions, null, 2));
+      return 0;
+    }
+  }
 
   // The read-back first: every fact below is already detected for other
   // reasons, and showing it is the moment the tool proves it looked.
@@ -2053,6 +2066,14 @@ const explainedPlanFailure = (error: unknown): boolean => {
 
     await warnOffContractAi(root, output);
 
+    // `wrote` names files the caller may open, so the plan's static list is
+    // filtered to what is actually on disk: fonts.css exists only when a font
+    // was embedded, and naming it would send an agent to a file that is not
+    // there.
+    const planned = options.agent !== true ? [] : (await Promise.all(
+      plan.writes.map(async (path) => await exists(join(root, path)) ? path : null),
+    )).filter((path): path is string => path !== null);
+
     // Called on its OWN line, never inside `pretty?.done(…)`: optional
     // chaining short-circuits its arguments, so a null `pretty` — every
     // non-TTY run — would skip the entire ending without a trace.
@@ -2060,6 +2081,10 @@ const explainedPlanFailure = (error: unknown): boolean => {
       root, options, output, pretty, interactive, useCase, mcp, mount, edits, manualSteps,
       credential, cloud, compositionPath, framework: plan.framework, authWired, layout,
       toolCount, brandCaptured: themeSummary !== null,
+      wrote: [...planned, ...changes.map((change) => change.path)],
+      // The SAME projection the plan used to make from a throwaway extraction,
+      // over the catalog the flow already read this run.
+      risks: riskRecommendations(flow.catalog),
     });
     pretty?.done(Date.now() - started, true, stats);
     return 0;

--- a/packages/vendo/src/cli/pretty.ts
+++ b/packages/vendo/src/cli/pretty.ts
@@ -21,7 +21,7 @@ import type { Output } from "./shared.js";
  * below are pure string rules over those exact plain strings; the renderer
  * restyles and groups. The copy it owns is the block TITLES and the one docs
  * pointer (MOUNT_DOCS) that cannot live in the caller without changing the
- * --agent plan's pinned JSON; every fact on screen is still the caller's.
+ * receipt's pinned `pasteEdits`; every fact on screen is still the caller's.
  */
 
 const ESC = "\u001b";
@@ -178,9 +178,10 @@ const PASTE_FILE = /^ {2}File: (.+)$/;
     literal in the terminal would be wrong for half of hosts and the docs
     pointer below carries the exact per-router wording instead. */
 const MOUNT_WRAP = /^… then wrap: (<VendoProvider\b[^>]*>).*<\/VendoProvider>$/;
-/** This pointer is the renderer's and not the caller's: init's `mount.lines` is
-    pinned byte-for-byte by the --agent plan, and a line added there would
-    change that JSON. Emitted here, the --agent path never sees it. */
+/** This pointer is the renderer's and not the caller's: the mount's `lines` are
+    pinned byte-for-byte by the receipt's `pasteEdits`, and a line added there
+    would change that JSON. Emitted here, the --agent path never sees it (the
+    rail is off in agent mode). */
 const MOUNT_DOCS = "docs.vendo.run/quickstart#the-client-mount — exact wording for layout.tsx and _app.tsx";
 const WIRED = /^(Wired \(\d+ files?\)):$/;
 const DIFF_MARKER = /^ {2}([+~]) (.+)$/;

--- a/packages/vendo/src/cli/sync-flow.ts
+++ b/packages/vendo/src/cli/sync-flow.ts
@@ -1,6 +1,7 @@
 import { readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import type { z } from "zod";
+import type { ExtractedTool } from "@vendoai/actions";
 import { vendoSync, type SyncReportWithWarnings } from "@vendoai/actions/sync";
 import type { VendoThemeFont } from "@vendoai/apps/contract";
 import type { ToolImpact } from "../sync-impact.js";
@@ -61,6 +62,10 @@ export interface SyncFlowOptions {
   interactive: boolean;
   yes: boolean;
   ai?: boolean;
+  /** `vendo init --agent`: the caller is itself a coding agent, so judgment is
+      its work, not ours. Beats every other answer — even `--ai` — because
+      spawning an engine underneath one is the one thing agent mode may not do. */
+  delegated?: boolean;
   engine?: string;
   force?: boolean;
   themeRefresh?: boolean;
@@ -127,7 +132,10 @@ export interface SyncFlowResult {
   themeDraft: z.infer<typeof modelThemeSchema> | null;
   /** How long the deterministic theme scan took, when this run made one. */
   themeMs?: number;
-  /** The catalog on disk after this run — what telemetry counts. */
+  /** The catalog on disk after this run: the tools themselves, and what
+   *  telemetry counts. Unreadable degrades to empty, so every consumer sees
+   *  the same answer instead of one of them failing the run. */
+  catalog: ExtractedTool[];
   counts: { tools: number; routes: number };
   /** [] = nothing referenced the changed tools; null = impact unknown. */
   impact: ToolImpact[] | null;
@@ -290,19 +298,16 @@ function themeStageInput(summary: ThemeSummary): Pick<ThemeStageInput, "needed" 
   };
 }
 
-/** The catalog as it stands on disk, for telemetry. Unreadable degrades to
- *  zero — sync already reported any extraction warning. */
-async function countCatalog(vendoDir: string): Promise<SyncFlowResult["counts"]> {
+/** The catalog as it stands on disk: read and parsed ONCE for everyone who
+ *  needs it (telemetry's counts, init's risk advice). Unreadable degrades to
+ *  empty — sync already reported any extraction warning, and a second reader
+ *  that threw instead would fail a run this one calls fine. */
+async function readCatalog(vendoDir: string): Promise<ExtractedTool[]> {
   try {
-    const tools = JSON.parse(await readFile(join(vendoDir, "tools.json"), "utf8")) as {
-      tools?: Array<{ binding?: { kind?: string } }>;
-    };
-    return {
-      tools: tools.tools?.length ?? 0,
-      routes: tools.tools?.filter((tool) => tool.binding?.kind === "route").length ?? 0,
-    };
+    const file = JSON.parse(await readFile(join(vendoDir, "tools.json"), "utf8")) as { tools?: ExtractedTool[] };
+    return file.tools ?? [];
   } catch {
-    return { tools: 0, routes: 0 };
+    return [];
   }
 }
 
@@ -357,6 +362,10 @@ async function chooseEngine(
   note: (message: string) => void,
 ): Promise<{ skip: true } | { skip: false; engine?: AvailableEngine }> {
   const { output } = options;
+  if (options.delegated === true) {
+    output.log("Judgment: delegated to you. The receipt lists what the catalog still needs.");
+    return { skip: true };
+  }
   if (options.ai === false) {
     output.log("AI polish (descriptions, risk review, brief, theme): off (--no-ai) — extractor defaults stand.");
     return { skip: true };
@@ -762,6 +771,7 @@ export async function runSyncFlow(options: SyncFlowOptions): Promise<SyncFlowRes
   const keyed = cloudKey !== undefined && cloudKey.trim() !== "";
   const baselines = await pushBaselinesToCloud({ vendoDir, cloudKey, keyed, options, notes: notes_ });
   const components = await pushComponentsToCloud({ vendoDir, cloudKey, keyed, options, notes: notes_ });
+  const catalog = await readCatalog(vendoDir);
 
   return {
     report,
@@ -770,7 +780,11 @@ export async function runSyncFlow(options: SyncFlowOptions): Promise<SyncFlowRes
     themeSummary,
     themeDraft,
     ...(themeMs === undefined ? {} : { themeMs }),
-    counts: await countCatalog(vendoDir),
+    catalog,
+    counts: {
+      tools: catalog.length,
+      routes: catalog.filter((tool) => tool.binding?.kind === "route").length,
+    },
     impact,
     baselines,
     components,

--- a/packages/vendo/tests/cli.test.ts
+++ b/packages/vendo/tests/cli.test.ts
@@ -95,21 +95,27 @@ describe("vendo CLI commands", () => {
     const root = await mkdtemp(join(tmpdir(), "vendo-cli-init-known-"));
     cleanup.push(root);
 
-    expect(await main(["init", root, "--agent", "--yes", "--force", "--byo", "--ai",
+    // Every option but the models answer, so this stays init's ask pass: it
+    // writes nothing and hands back the one question still open. (`--ai` is
+    // absent because --agent refuses it by name — the AI-flag test owns that.)
+    expect(await main(["init", root, "--agent", "--yes", "--force",
       "--auth", "clerk", "--framework", "next", "--theme", "accent=#7c3bed",
       "--use-case", "mcp", "--base-url", "https://app.acme.com", "--posture", "broker",
       "--service-key", "--no-check"])).toBe(0);
 
-    expect(await readdir(root)).toEqual([]); // --agent stayed read-only
-    // Value-flag values are never mistaken for the target dir, and the
-    // --framework and --use-case answers reach the plan.
-    const plan = JSON.parse(log.mock.calls.flat().join("\n")) as { root: string; framework: string; useCase: string };
-    expect(plan.root).toBe(root);
-    expect(plan.framework).toBe("next");
-    expect(plan.useCase).toBe("mcp");
+    expect(await readdir(root)).toEqual([]); // the ask pass wrote nothing
+    // Value-flag values are never mistaken for the target dir: --framework
+    // reached the run, so `next` was read as an answer and not as the target.
+    const asked = JSON.parse(log.mock.calls.flat().join("\n")) as {
+      detected: { framework: string };
+      questions: Array<{ id: string }>;
+    };
+    expect(asked.detected.framework).toBe("next");
+    expect(asked.questions.map((question) => question.id)).toEqual(["models"]);
 
-    // --cloud-key parses too — and --agent STILL writes nothing (the
-    // read-only promise beats the key-landing side effect).
+    // --byo and --cloud-key parse too, and neither writes while a question is
+    // still open.
+    expect(await main(["init", root, "--agent", "--byo"])).toBe(0);
     expect(await main(["init", root, "--agent", "--cloud-key", `vnd_${"b".repeat(40)}`])).toBe(0);
     expect(await readdir(root)).toEqual([]);
     log.mockRestore();
@@ -244,10 +250,14 @@ describe("vendo CLI commands", () => {
     const root = await mkdtemp(join(tmpdir(), "vendo-cli-ai-flags-"));
     cleanup.push(root);
 
-    // Parsed, not rejected (--agent keeps init read-only).
-    for (const flag of ["--ai", "--no-ai", "--ai-polish"]) {
-      expect(await main(["init", root, "--agent", flag])).toBe(0);
+    // Parsed, not rejected. Under --agent an `--ai` that can never run is
+    // refused BY NAME rather than dropped, since judgment is delegated to the
+    // caller; --no-ai agrees with what happens and passes.
+    for (const flag of ["--ai", "--ai-polish"]) {
+      expect(await main(["init", root, "--agent", flag])).toBe(1);
+      expect(error.mock.calls.flat().join("\n")).toContain("has no effect with --agent");
     }
+    expect(await main(["init", root, "--agent", "--no-ai"])).toBe(0);
     expect(await readdir(root)).toEqual([]);
 
     for (const flag of ["--ai", "--no-ai", "--no-watermark", "--yes", "--theme-refresh"]) {

--- a/packages/vendo/tests/cli/cloud-init.test.ts
+++ b/packages/vendo/tests/cli/cloud-init.test.ts
@@ -76,7 +76,11 @@ describe("runCloudStep", () => {
     expect(result.wroteEnvLocal).toBe(false);
     const joined = messages.logs.join("\n");
     expect(joined).not.toContain(AUTH_MD_URL);
-    expect(joined).toContain("vendo login"); // the calm human pointer stays
+    // --byo is the ANSWER: the step says what their own key needs and stops.
+    // It never points back at `vendo login`, which read as a detour past the
+    // path they just chose.
+    expect(joined).toContain("set ANTHROPIC_API_KEY");
+    expect(joined).not.toContain("vendo login");
   });
 
   it("an unshown (non-TTY) decline emits the agent pointer; a real TTY decline stays calm", async () => {

--- a/packages/vendo/tests/cli/init.test.ts
+++ b/packages/vendo/tests/cli/init.test.ts
@@ -7,7 +7,8 @@ import { createGuard } from "@vendoai/guard";
 import { createStore } from "@vendoai/store";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ExtractionHarness } from "../../src/cli/extract/harness.js";
-import { firstSentence, prettyThemeReview, runInit } from "../../src/cli/init.js";
+import { firstSentence, prettyThemeReview, runInit, type InitReceipt } from "../../src/cli/init.js";
+import type { InitQuestions } from "../../src/cli/init-questions.js";
 import { CLI_VERSION, type Output } from "../../src/cli/shared.js";
 
 const cleanup: string[] = [];
@@ -117,6 +118,20 @@ function run(root: string, sink: { output: Output }, extra: Partial<Parameters<t
   });
 }
 
+/** An --agent run with every question already answered: the WRITE pass, whose
+    last line is the receipt. Leaving any one of them off makes it the ask
+    pass instead. */
+function agentRun(
+  root: string,
+  sink: { output: Output },
+  extra: Partial<Parameters<typeof runInit>[0]> = {},
+): Promise<number> {
+  return run(root, sink, { agent: true, useCase: "embedded", auth: "none", byo: true, ...extra });
+}
+
+const receiptOf = (logs: string[]): InitReceipt => JSON.parse(logs.at(-1)!) as InitReceipt;
+const questionsOf = (logs: string[]): InitQuestions => JSON.parse(logs.join("\n")) as InitQuestions;
+
 describe("vendo init (zero-question)", () => {
   it.each([
     [{ dependencies: { express: "5.0.0" } }, "express"],
@@ -130,7 +145,7 @@ describe("vendo init (zero-question)", () => {
     await writeFile(join(root, "package.json"), JSON.stringify(manifest));
     const sink = output();
     expect(await run(root, sink, { agent: true })).toBe(0);
-    expect(JSON.parse(sink.logs.join("\n"))).toMatchObject({ framework: expected });
+    expect(questionsOf(sink.logs).detected).toMatchObject({ framework: expected });
   });
 
   it("wires a fresh Next host with no prompts: route + hooks + .vendo, and one paste", async () => {
@@ -666,7 +681,7 @@ describe("vendo init (zero-question)", () => {
     expect(await run(root, sink, { yes: true })).toBe(1);
     const errors = sink.errors.join("\n");
     expect(errors).toContain("--framework");
-    expect(errors).toContain("vendo init --yes --framework next"); // one example invocation
+    expect(errors).toContain("vendo init --framework next"); // one example invocation
     expect(await readdir(root)).toEqual(["package.json"]); // nothing was written
 
     // The flag answers it: the same host scaffolds as the named framework.
@@ -1254,7 +1269,7 @@ describe("vendo init (zero-question)", () => {
     expect(logs).not.toContain("internal");
   });
 
-  it("carries the pastes it will not write into the --agent plan", async () => {
+  it("carries the pastes it will not write into the receipt", async () => {
     const routeDir = join("app", "api", "vendo", "[...vendo]");
     const root = await fixture();
     expect(await run(root, output())).toBe(0);
@@ -1262,16 +1277,11 @@ describe("vendo init (zero-question)", () => {
     await writeFile(join(root, "app", "actions", "later.ts"),
       '"use server";\n\nexport async function later() {\n  return 1;\n}\n');
     const sink = output();
-    expect(await runInit({ targetDir: root, agent: true, output: sink.output })).toBe(0);
-    const plan = JSON.parse(sink.logs.join("\n")) as {
-      edits?: Array<{ file: string; lines: string[]; why: string }>;
-      manualSteps: string[];
-    };
-    expect(plan.edits).toHaveLength(1);
-    expect(plan.edits?.[0]?.file).toBe(join(routeDir, "route.ts"));
-    expect(plan.edits?.[0]?.lines).toContain('import { serverActions } from "./vendo-actions";');
-    expect(plan.edits?.[0]?.why).toContain("fails closed");
-    expect(plan.manualSteps.join("\n")).toContain(`In ${join(routeDir, "route.ts")}:`);
+    expect(await agentRun(root, sink)).toBe(0);
+    const edit = receiptOf(sink.logs).pasteEdits.find((paste) => paste.file === join(routeDir, "route.ts"));
+    expect(edit?.lines).toContain('import { serverActions } from "./vendo-actions";');
+    expect(edit?.why).toContain("fails closed");
+    expect(sink.logs.join("\n")).toContain(`File: ${join(routeDir, "route.ts")}`);
   });
 
   it("leaves a hand-customized route that passes its own serverActions untouched (no conflicting import)", async () => {
@@ -1737,38 +1747,203 @@ describe("vendo init (zero-question)", () => {
     expect(await readFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts"), "utf8"))
       .toContain(`from "@vendoai/vendo/server"`);
   });
+});
 
-  it("emits a read-only agent plan with code changes, extraction, and the layout mount", async () => {
+/** One personality for init in every mode: detect, ask, log in, write. Agent
+    mode only changes how the questions TRAVEL — out as JSON, back as flags on
+    a re-run. The read-only plan dump it replaces is gone: there is no mode that
+    prints code diffs and stops. */
+describe("vendo init --agent (ask first, then write)", () => {
+  it("asks and writes NOTHING, then writes on the re-run that carries the answers", async () => {
     const root = await fixture();
     const before = await tree(root);
     const sink = output();
+
     expect(await run(root, sink, { agent: true })).toBe(0);
-    const plan = JSON.parse(sink.logs.join("\n")) as {
-      framework: string;
-      writes: string[];
-      codeChanges: Array<{ path: string; diff: string }>;
-      manualSteps: string[];
-      extraction: { tools: unknown[]; warnings: string[] };
-      riskRecommendations: unknown[];
-      aiPolish?: unknown;
-    };
-    expect(plan.framework).toBe("next");
-    expect(plan.writes).toContain(".vendo/tools.json");
-    expect(plan.writes).not.toContain(".env");
-    expect(plan.codeChanges.map((change) => change.path)).toContain(join("app", "api", "vendo", "[...vendo]", "route.ts"));
-    // Init writes no client file at all, and the host's layout never is a
-    // planned change: the paste rides manualSteps + `mount`.
-    expect(plan.codeChanges.map((change) => change.path)).not.toContain(join("vendo", "vendo-root.tsx"));
-    expect(plan.codeChanges.map((change) => change.path)).not.toContain(join("app", "layout.tsx"));
-    expect(plan.manualSteps[0]).toBe(`In ${join("app", "layout.tsx")}:`);
-    expect(Array.isArray(plan.extraction.tools)).toBe(true);
-    expect(Array.isArray(plan.riskRecommendations)).toBe(true);
-    // The delegated AI-polish contract is GONE with the draft channel it fed:
-    // there is no `vendo extract --apply` for an external agent to land a draft
-    // through, and judgment now needs quoted evidence a delegated draft cannot
-    // carry. The plan stays deterministic facts only.
-    expect(plan.aiPolish).toBeUndefined();
-    expect(await tree(root)).toEqual(before); // --agent wrote nothing
+    const asked = questionsOf(sink.logs);
+    expect(asked.status).toBe("questions");
+    expect(asked.detected.framework).toBe("next");
+    expect(asked.questions.map((question) => question.id)).toEqual(["use-case", "auth", "models"]);
+    // The prompts are chat copy, relayed verbatim: each option carries the
+    // literal thing the agent does to pick it.
+    expect(asked.questions[0]?.prompt).toContain("real working screens from your data");
+    expect(asked.questions[0]?.options[0]).toMatchObject({ flag: "--use-case embedded", recommended: true });
+    expect(asked.questions[2]?.options[0]?.command).toBe("npx vendo login --wait 90");
+    expect(asked.questions[2]?.options[1]?.flag).toBe("--byo");
+    // The mechanical answers never surface: they default like --yes and show
+    // up in the diff.
+    const ids = asked.questions.map((question) => question.id).join(" ");
+    expect(ids).not.toContain("base-url");
+    expect(ids).not.toContain("theme");
+    expect(ids).not.toContain("check");
+    expect(await tree(root)).toEqual(before); // the ask pass wrote nothing
+
+    const wrote = output();
+    expect(await agentRun(root, wrote)).toBe(0);
+    expect(await readFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts"), "utf8"))
+      .toContain(`from "@vendoai/vendo/server"`);
+  });
+
+  it("writes in ONE pass when the first call already carries every answer", async () => {
+    const root = await fixture();
+    const sink = output();
+    expect(await agentRun(root, sink)).toBe(0);
+    const receipt = receiptOf(sink.logs);
+    expect(receipt).toMatchObject({
+      status: "written",
+      root,
+      useCase: "embedded",
+      tools: expect.any(Number),
+      judgment: {
+        status: "delegated",
+        checklist: [
+          "task-quality descriptions per tool",
+          "risk grades into .vendo/overrides.json",
+          "replace the .vendo/brief.md placeholder",
+          "fill unresolved slots in .vendo/theme.json",
+        ],
+      },
+    });
+    expect(receipt.wrote).toContain(".vendo/tools.json");
+    expect(receipt.wrote).toContain(join("app", "api", "vendo", "[...vendo]", "route.ts"));
+    // Every named path is one the caller can open: this rejects the plan's
+    // static list, which promises a fonts.css only an embedded font creates.
+    await Promise.all(receipt.wrote.map((path) => readFile(join(root, path), "utf8")));
+    // Init writes no client file, so the layout is a paste and never a write.
+    expect(receipt.wrote).not.toContain(join("app", "layout.tsx"));
+    expect(receipt.pasteEdits[0]?.file).toBe(join("app", "layout.tsx"));
+    expect(Array.isArray(receipt.riskRecommendations)).toBe(true);
+    // The retired plan dump's fields are gone with it.
+    expect(sink.logs.join("\n")).not.toContain("codeChanges");
+    // Agent mode never spawns a judgment engine and never asks to.
+    expect(sink.logs.join("\n")).toContain("Judgment: delegated to you");
+  });
+
+  it("asks MCP's two extra questions on the re-run that picked mcp", async () => {
+    const root = await fixture();
+    await writeFile(join(root, ".env.local"), `VENDO_API_KEY=vnd_${"c".repeat(40)}\n`);
+    const sink = output();
+    expect(await run(root, sink, { agent: true, useCase: "mcp", auth: "clerk" })).toBe(0);
+    const asked = questionsOf(sink.logs);
+    expect(asked.questions.map((question) => question.id)).toEqual(["posture", "service-key"]);
+    expect(asked.questions[0]?.prompt).toContain("yourcompany.mcp.vendo.run");
+    expect(asked.questions[0]?.options[0]?.flag).toBe("--posture broker");
+    expect(asked.questions[1]?.prompt).toContain("machine to machine");
+    expect(asked.questions[1]?.options[0]?.flag).toBe("--service-key");
+  });
+
+  /** A keyless run cannot reach a broker, so posture is not a decision — the
+      terminal flow never shows that select either. Offering it here would write
+      a tenant URL that does not exist and drop the service key with it. */
+  it("never offers the broker to a host with no Cloud key: the one MCP question settles posture", async () => {
+    const root = await fixture();
+    const sink = output();
+    expect(await run(root, sink, { agent: true, useCase: "mcp", auth: "clerk", byo: true })).toBe(0);
+    const asked = questionsOf(sink.logs);
+    expect(asked.questions.map((question) => question.id)).toEqual(["service-key"]);
+    expect(JSON.stringify(asked)).not.toContain("broker");
+    // Both answers carry the settled posture, so the SAME gate closes.
+    expect(asked.questions[0]?.options.map((option) => option.flag))
+      .toEqual(["--posture local --service-key", "--posture local"]);
+  });
+
+  /** detectAuthPreset reports `wired: null` when two families match, precisely
+      because that case is ambiguous. Naming the first would assert a provider
+      the host may not use and hide the other one entirely. */
+  it("falls through to the full list when two auth families match", async () => {
+    const root = await fixture();
+    await writeFile(join(root, "package.json"), JSON.stringify({
+      name: "host",
+      dependencies: { next: "16.0.0", "next-auth": "5.0.0", "@clerk/nextjs": "6.0.0" },
+    }));
+    const sink = output();
+    expect(await run(root, sink, { agent: true })).toBe(0);
+    const asked = questionsOf(sink.logs);
+    expect(asked.detected.auth).toBeUndefined();
+    const auth = asked.questions.find((question) => question.id === "auth");
+    expect(auth?.prompt).toBe("Which auth should Vendo wire?");
+    expect(auth?.options.map((option) => option.flag)).toContain("--auth clerk");
+    expect(auth?.options.map((option) => option.flag)).toContain("--auth authJs");
+  });
+
+  /** The login loop's REAL seam: `vendo login` lands VENDO_API_KEY in
+      .env.local, and the next `--agent` call must stop asking. A provider key
+      in the environment is a different branch entirely. */
+  it("drops the models question once vendo login has left a key in .env.local", async () => {
+    const root = await fixture();
+    const sink = output();
+    expect(await run(root, sink, { agent: true })).toBe(0);
+    expect(questionsOf(sink.logs).questions.map((question) => question.id)).toContain("models");
+    await writeFile(join(root, ".env.local"), `VENDO_API_KEY=vnd_${"a".repeat(40)}\n`);
+    const after = output();
+    expect(await run(root, after, { agent: true })).toBe(0);
+    expect(questionsOf(after.logs).questions.map((question) => question.id)).toEqual(["use-case", "auth"]);
+  });
+
+  /** `--ai` cannot buy an engine here: the caller IS one. The harness below
+      throws the moment the ladder probes it, so reaching it fails the test. */
+  it("stays delegated under --ai and never probes an engine", async () => {
+    const root = await fixture();
+    const sink = output();
+    expect(await agentRun(root, sink, {
+      ai: true,
+      extract: {
+        harnesses: [{
+          id: "never",
+          availability: async () => { throw new Error("probed an engine"); },
+          run: async () => { throw new Error("ran an engine"); },
+        }],
+        confirm: async () => { throw new Error("asked for AI consent"); },
+      },
+    })).toBe(0);
+    expect(sink.logs.join("\n")).toContain("Judgment: delegated to you");
+    expect(receiptOf(sink.logs).judgment.status).toBe("delegated");
+  });
+
+  it("writes and receipts the agent-loop and mcp arms too", async () => {
+    const loop = await fixture();
+    await writeFile(join(loop, "package.json"), JSON.stringify({
+      name: "host",
+      dependencies: { next: "16.0.0", ai: "6.0.0" },
+    }));
+    const loopSink = output();
+    expect(await agentRun(loop, loopSink, { useCase: "agent-loop" })).toBe(0);
+    const loopReceipt = receiptOf(loopSink.logs);
+    expect(loopReceipt.useCase).toBe("agent-loop");
+    expect(loopReceipt.pasteEdits.map((paste) => paste.lines.join("\n")).join("\n"))
+      .toContain('import { vendoTools } from "@vendoai/vendo/ai-sdk";');
+
+    const mcp = await fixture();
+    const mcpSink = output();
+    expect(await agentRun(mcp, mcpSink, { useCase: "mcp", auth: "clerk", posture: "local" })).toBe(0);
+    const mcpReceipt = receiptOf(mcpSink.logs);
+    expect(mcpReceipt.useCase).toBe("mcp");
+    expect(mcpReceipt.wrote).toContain("app/.well-known/[...vendo]/route.ts");
+  });
+
+
+  it("names the detected auth in the question, and drops the models one once a key exists", async () => {
+    const root = await fixture();
+    await writeFile(join(root, "package.json"), JSON.stringify({
+      name: "host",
+      dependencies: { next: "16.0.0", "@clerk/nextjs": "6.0.0" },
+    }));
+    const sink = output();
+    expect(await run(root, sink, { agent: true, env: { ANTHROPIC_API_KEY: "sk-ant-test" } })).toBe(0);
+    const asked = questionsOf(sink.logs);
+    expect(asked.detected.auth).toBe("clerk");
+    expect(asked.questions.map((question) => question.id)).toEqual(["use-case", "auth"]);
+    expect(asked.questions[1]?.prompt)
+      .toBe("It detected Clerk. Should the assistant act as your signed-in Clerk user?");
+    expect(asked.questions[1]?.options).toEqual([
+      { label: "Yes", flag: "--auth clerk", recommended: true },
+      {
+        label: "A different auth",
+        flag: "--auth <authJs|supabase|auth0|jwt>",
+        note: "replace the placeholder with one of those four names",
+      },
+      { label: "No signed-in user", flag: "--auth none" },
+    ]);
   });
 });
 
@@ -1913,26 +2088,22 @@ describe("the mount paste (init never edits user-authored source)", () => {
     expect(logs).toContain("<VendoProvider baseUrl=");
   });
 
-  it("carries the same file and lines in the --agent plan's `mount`", async () => {
+  it("carries the same file and lines in the receipt's `pasteEdits`", async () => {
     const root = await fixture();
     const sink = output();
-    expect(await run(root, sink, { agent: true })).toBe(0);
-    const plan = JSON.parse(sink.logs.join("\n")) as {
-      mount?: { file: string; lines: string[]; why: string };
-      manualSteps: string[];
-      codeChanges: Array<{ path: string }>;
-    };
-    expect(plan.mount?.file).toBe(join("app", "layout.tsx"));
-    expect(plan.mount?.lines).toEqual([
+    expect(await agentRun(root, sink)).toBe(0);
+    const receipt = receiptOf(sink.logs);
+    expect(receipt.pasteEdits[0]?.file).toBe(join("app", "layout.tsx"));
+    expect(receipt.pasteEdits[0]?.lines).toEqual([
       'import { VendoProvider } from "@vendoai/vendo/react";',
       'import theme from "../.vendo/theme.json";',
       'import type { VendoTheme } from "@vendoai/vendo";',
       '… then wrap: <VendoProvider baseUrl="/api/vendo" theme={theme as VendoTheme}>{children}</VendoProvider>',
     ]);
-    expect(plan.mount?.why).toContain("nothing on the page can reach it");
-    // The same lines still ride manualSteps, and no layout diff is planned.
-    expect(plan.manualSteps.join("\n")).toContain('<VendoProvider baseUrl="/api/vendo"');
-    expect(plan.codeChanges.map((change) => change.path)).not.toContain(join("app", "layout.tsx"));
+    expect(receipt.pasteEdits[0]?.why).toContain("nothing on the page can reach it");
+    // The same lines are printed, and the layout itself is never written.
+    expect(sink.logs.join("\n")).toContain('<VendoProvider baseUrl="/api/vendo"');
+    expect(receipt.wrote).not.toContain(join("app", "layout.tsx"));
   });
 
   /** A host that already mounts the provider IS mounted — init has nothing
@@ -1974,13 +2145,13 @@ describe("the mount paste (init never edits user-authored source)", () => {
     await writeFile(join(root, "app", "[locale]", "(auth)", "layout.tsx"),
       "export default function AuthLayout({ children }) { return <main>{children}</main>; }\n");
     const sink = output();
-    expect(await run(root, sink, { agent: true })).toBe(0);
-    const plan = JSON.parse(sink.logs.join("\n")) as { mount?: { file: string; lines: string[] } };
-    expect(plan.mount?.file).toBe(join("app", "[locale]", "layout.tsx"));
+    expect(await agentRun(root, sink)).toBe(0);
+    const mount = receiptOf(sink.logs).pasteEdits[0];
+    expect(mount?.file).toBe(join("app", "[locale]", "layout.tsx"));
     // The paste still wraps {children}, and the theme import walks out of the
     // deeper directory.
-    expect(plan.mount?.lines.at(-1)).toContain("{children}</VendoProvider>");
-    expect(plan.mount?.lines).toContain('import theme from "../../.vendo/theme.json";');
+    expect(mount?.lines.at(-1)).toContain("{children}</VendoProvider>");
+    expect(mount?.lines).toContain('import theme from "../../.vendo/theme.json";');
   });
 
   it("keeps naming app/layout.tsx when a root layout sits beside nested ones", async () => {
@@ -1989,9 +2160,8 @@ describe("the mount paste (init never edits user-authored source)", () => {
     await writeFile(join(root, "app", "(shop)", "layout.tsx"),
       "export default function ShopLayout({ children }) { return <main>{children}</main>; }\n");
     const sink = output();
-    expect(await run(root, sink, { agent: true })).toBe(0);
-    expect((JSON.parse(sink.logs.join("\n")) as { mount?: { file: string } }).mount?.file)
-      .toBe(join("app", "layout.tsx"));
+    expect(await agentRun(root, sink)).toBe(0);
+    expect(receiptOf(sink.logs).pasteEdits[0]?.file).toBe(join("app", "layout.tsx"));
   });
 
   it("still names pages/_app.tsx on a Pages-Router host with no layouts at all", async () => {
@@ -2000,10 +2170,10 @@ describe("the mount paste (init never edits user-authored source)", () => {
     await mkdir(join(root, "pages"), { recursive: true });
     await writeFile(join(root, "pages", "index.tsx"), "export default () => <main />;\n");
     const sink = output();
-    expect(await run(root, sink, { agent: true })).toBe(0);
-    const plan = JSON.parse(sink.logs.join("\n")) as { mount?: { file: string; lines: string[] } };
-    expect(plan.mount?.file).toBe(join("pages", "_app.tsx"));
-    expect(plan.mount?.lines.at(-1)).toContain("<Component {...pageProps} /></VendoProvider>");
+    expect(await agentRun(root, sink)).toBe(0);
+    const mount = receiptOf(sink.logs).pasteEdits[0];
+    expect(mount?.file).toBe(join("pages", "_app.tsx"));
+    expect(mount?.lines.at(-1)).toContain("<Component {...pageProps} /></VendoProvider>");
   });
 
   /** No layout and no pages/ means the host has no client root yet — the
@@ -2012,9 +2182,8 @@ describe("the mount paste (init never edits user-authored source)", () => {
     const root = await fixture();
     await rm(join(root, "app", "layout.tsx"));
     const sink = output();
-    expect(await run(root, sink, { agent: true })).toBe(0);
-    expect((JSON.parse(sink.logs.join("\n")) as { mount?: { file: string } }).mount?.file)
-      .toBe(join("app", "layout.tsx"));
+    expect(await agentRun(root, sink)).toBe(0);
+    expect(receiptOf(sink.logs).pasteEdits[0]?.file).toBe(join("app", "layout.tsx"));
   });
 });
 
@@ -2160,9 +2329,11 @@ describe("vendo init (custom runtime)", () => {
     const root = await customFixture();
     const sink = output();
     expect(await run(root, sink, { agent: true })).toBe(0);
-    const plan = JSON.parse(sink.logs.join("\n")) as { framework: string; writes: string[] };
-    expect(plan.framework).toBe("custom");
-    expect(plan.writes.join("\n")).not.toContain("app/api/vendo");
+    expect(questionsOf(sink.logs).detected.framework).toBe("custom");
+    // …and the fall-through survives into the write: still no Next layout.
+    const wrote = output();
+    expect(await agentRun(root, wrote)).toBe(0);
+    expect(receiptOf(wrote.logs).wrote.join("\n")).not.toContain("app/api/vendo");
   });
 });
 


### PR DESCRIPTION
Stacked on #1361. Review the top commit only.

`vendo init --agent` used to print a read-only plan: the files init would write, the code diffs, the extracted tools. A coding agent read that plan and then decided, on its human's behalf, what the install should be. Init asks now, and the coding agent carries the questions.

## The contract

Two passes, discriminated by a `status` field, **both exit 0** — the agent branches on the shape and never on a code (`packages/vendo/src/cli/init.ts:135-136`).

**Pass 1 — ask.** Agent mode is coerced to `--yes` semantics (`init.ts:1796`) so every mechanical answer defaults instead of being asked, then the ask branch runs at `init.ts:1866-1879`: it prints one JSON object of the questions still open and returns 0 **having written nothing**.

**Pass 2 — write.** When `initQuestions` returns `null` — every answer already on the command line — the run falls through into the normal write path and ends on a receipt (`init.ts:2090`).

Nothing new carries the answers back. They ride the flags that already existed: `--use-case`, `--auth`, `--byo` / `--cloud-key`, `--posture`, `--service-key`, plus one option that is a `command` (`npx vendo login --wait 90`) to run before the re-run. Which questions are still open is decided purely from the command line (`packages/vendo/src/cli/init-questions.ts:150-162`).

## The two shapes

**Ask — `InitQuestions`** (`init-questions.ts:22-43`):

```ts
export interface InitQuestions {
  status: "questions";
  detected: { framework: string; auth?: AuthPresetName };
  questions: InitQuestion[];   // { id, prompt, options: { label, flag?, command?, note?, recommended? }[] }
}
```

`prompt` is chat-ready — agents relay it verbatim. Question ids: `use-case`, `auth`, `models`, `posture`, `service-key`. `detected.auth` is omitted when detection is ambiguous.

**Write — `InitReceipt`** (`init.ts:137-156`):

```ts
export interface InitReceipt {
  status: "written";
  root: string;
  useCase: InitUseCase;
  wrote: string[];
  pasteEdits: ManualEdit[];
  tools: number;
  riskRecommendations: RiskRecommendation[];
  judgment: { status: "delegated"; checklist: string[] };
}
```

`wrote` is `exists()`-checked against the filesystem before it goes out (`init.ts:2073-2075`), so it never names a `fonts.css` that no embedded font created. Both shapes are plain TS interfaces — no zod, nothing to version.

Two behavioral rules carried over from the terminal flow: `mcpQuestions` offers `posture` only when a Cloud key exists (`init-questions.ts:84-106`), and a keyless host gets a single `service-key` question whose options both settle `--posture local`; and auth detection reads `wired?.preset`, so two matching families stay ambiguous and fall through to the full list rather than being flattened to the first.

`--agent` with `--ai`/`--engine` is now rejected by name, exit 1 (`packages/vendo/src/cli.ts:189`): judgment is delegated to the agent, and the receipt's `checklist` names the four things it left.

## The plan dump is retired — and no test went with it

Said out loud, because it is the thing worth checking in this diff.

`InitPlan` was an exported interface carrying `writes`, `codeChanges`, `manualSteps`, `mount`, `edits`, `extraction`, `riskRecommendations`. It is gone as a public shape: it is now an internal, un-exported two-field struct (`init.ts:131-135`). Its helper `extractForPlan` is deleted outright — it used to run a whole `vendoSync` into an `mkdtemp` throwaway directory just to keep `--agent` read-only. Risk projection now runs over the catalog the real sync already read (`init.ts:2079`), which is why `runSyncFlow` gained `SyncFlowResult.catalog` (`packages/vendo/src/cli/sync-flow.ts:138`).

**Test accounting, exactly:**

- **Zero tests deleted.** The plan-dump test was **rewritten in place**, not dropped: `"emits a read-only agent plan with code changes, extraction, and the layout mount"` → `"asks and writes NOTHING, then writes on the re-run that carries the answers"` (`packages/vendo/tests/cli/init.test.ts:1757`). Its first four lines survive as unchanged context.
- **Three `it(` titles retired, all three with replacements** — the other two are `"carries the pastes it will not write into the --agent plan"` → `"…into the receipt"` (`init.test.ts:1272`) and `` "carries the same file and lines in the --agent plan's `mount`" `` → `` "…in the receipt's `pasteEdits`" `` (`init.test.ts:2091`).
- **Eleven `it(` added; net +8** on `cli/init.test.ts` (100 → 108). `cli.test.ts` (13) and `cli/cloud-init.test.ts` (16) are unchanged in count, changed in body.

So the retired surface cost the suite nothing. Coverage moved from asserting a plan's fields to asserting the two-pass contract: that the ask pass writes nothing, that the re-run writes, and that both return 0 (`init.test.ts:1757-1786`).

The eight new tests cover the one-pass write, MCP's two extra questions, the keyless host never being offered the broker, two auth families staying ambiguous, the models question dropping once `vendo login` left a key in `.env.local`, `--ai` staying delegated without probing an engine, the agent-loop and mcp arms, and the detected auth appearing in the question text.

## The regression this caught

Moving the ask branch to sit **after** framework detection put it downstream of `guardUndetectedFramework`, which errors and returns 1 on any non-interactive run — and agent mode is non-interactive by construction (`init.ts:1852`). Every `--agent` run against a Worker, Bun, or Hono host would have exited 1 instead of asking.

Restored at `init.ts:1855-1860`: the guard belongs to the runs that would otherwise **guess**. Agent mode keeps the fall-through to the runtime-neutral `custom` scaffold it has always had, because `resolveFramework` answers `"custom"` for an undetectable host — a safe default, not a guess.

Covered both ways: `init.test.ts:136-149` asserts `detected.framework === "custom"` on the ask pass for a bare-React host, and `init.test.ts:2328-2337` now carries the guarantee through the **write** pass too — the receipt's `wrote` still contains no `app/api/vendo`, so the fall-through does not quietly become a Next install.

## Changeset

`.changeset/init-agent-asks-first.md` — this moves a published CLI surface.

## Gate

Run on the tip of the stack this branch sits in: `pnpm install` ✅ · `pnpm build` ✅ · `pnpm typecheck` ✅ · `pnpm lint` ✅. `pnpm test:affected` is 44 of 45 turbo tasks green — `@vendoai/vendo`, which owns every file in this PR, is 2410 passed / 45 skipped across 224 files.

The single red is `@vendoai/genbench` `tests/font.test.ts`, which is main's: it fails identically on a clean `origin/main` (`6c26bfdc3`) with a full rebuild and no ven8 commits present. See the base PR for the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Init `--agent` now asks first, then writes. Old behavior printed a read‑only plan; new behavior emits one JSON object of questions and writes nothing, then writes on a re‑run with those answers. Both passes exit 0; callers branch on the `status` field.

- Emits a single `InitQuestions` object; mechanical choices default to `--yes`. Questions: `use-case`, `auth`, `models`, and for MCP runs: `posture` only when a Cloud key exists (keyless hosts get one `service-key` question whose options both settle `--posture local`). Ambiguous auth detection shows the full list.
- The write pass returns an `InitReceipt` with `wrote` (exist‑checked), `pasteEdits`, `tools`, `riskRecommendations` (from the synced catalog), and `judgment: { status: "delegated", checklist: [...] }`.
- Rejects `--ai`/`--engine` with `--agent` (exit 1). Agent mode never spawns an engine.
- Fixes framework guard: `--agent` never guesses; it falls back to `custom` when hosts are undetected.
- Retires the public plan dump and removes `extractForPlan`. Updates `--byo` help; the `vendo-setup` skill teaches the new flow. Tests cover the two‑pass contract (net +8 on init).

**Migration**
- Stop reading the plan. Call `vendo init --agent`; if `status: "questions"`, relay prompts verbatim, run any `command` (e.g., `npx vendo login --wait 90`), then re‑run with the chosen `flag`s.
- Branch only on `status`. On the write pass expect `status: "written"` and read `wrote` and `pasteEdits`.
- Do not pass `--ai` or `--engine` with `--agent`; judgment is delegated and the receipt lists the checklist.

<sup>Written for commit 6a53451185b9ddad0d8514cc2ee4b55c0f6fe430. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

