### PR TITLE
test(ui): the compiler-spawning export-surface tests get a compiler-sized timeout

### DIFF
--- a/packages/apps/tests/engine.bundler-safety.e2e.test.ts
+++ b/packages/apps/tests/engine.bundler-safety.e2e.test.ts
@@ -66,4 +66,4 @@ describe("toolchain.ts esbuild import — bundler-style reachability (built dist
     const compiled = buildDistToolchainSource();
     expect(GUARDED_ESBUILD_IMPORT.test(compiled)).toBe(true);
   });
-}, 30_000);
+}, 120_000);

--- a/packages/ui/test/chrome/export-surface.test.ts
+++ b/packages/ui/test/chrome/export-surface.test.ts
@@ -183,11 +183,11 @@ describe("@vendoai/ui/chrome export surface", () => {
   it("re-exports every chrome type from the source entry", () => {
     const failure = typecheckImports(TYPE_EXPORTS);
     expect(failure, failure ?? "").toBeNull();
-  });
+  }, 120_000);
 
   it("has teeth: a missing type re-export fails the tsc gate with TS2305", () => {
     const failure = typecheckImports(["__DefinitelyNotAChromeExport"]);
     expect(failure).not.toBeNull();
     expect(failure).toContain("TS2305");
-  });
+  }, 120_000);
 });


### PR DESCRIPTION
## Summary
- The two `export-surface.test.ts` tests that shell out to a cold `tsc --noEmit` get an explicit 120s per-test timeout (third arg to `it`). The package's 30s default is a hang-detector sized for jsdom settles; these two spawn a full compiler (~40-60s on a loaded 4-vCPU release runner) and flaked the v0.26.0 release run ([31951222264](https://github.com/runvendo/vendo/actions/runs/31951222264)) and an earlier pre-merge run ([31937733503](https://github.com/runvendo/vendo/actions/runs/31937733503)) identically.
- Same rationale for `packages/apps/tests/engine.bundler-safety.e2e.test.ts:69` — the suite-level timeout goes from `}, 30_000);` to `}, 120_000);`. Its two tests each run a full `npx tsc -p tsconfig.json`, measured 27.4-28.5s on the slow release runners (91-95% of budget) vs ~2s healthy — the same ~14x contention scaling. Evidence from the second red release run: [31952854208](https://github.com/runvendo/vendo/actions/runs/31952854208).
- Precedent: `packages/ui/test/eject-templates.test.ts:184` carries `}, 60_000);` for its pnpm-pack shellout. 120s still catches a genuinely hung tsc.
- Test-only, no changeset — nothing published changes.

## Test plan
- [x] `cd packages/ui && npx vitest run test/chrome/export-surface.test.ts --maxWorkers=2 --minWorkers=1` — all 4 tests pass
- [x] `cd packages/apps && npx vitest run tests/engine.bundler-safety.e2e.test.ts --maxWorkers=2 --minWorkers=1` — all 2 tests pass