### PR TITLE
fix(ui,apps): a date-only value has no clock, and a confirm the person asked for is theirs

### DIFF
--- a/packages/apps/src/server/skills/format-reference.ts
+++ b/packages/apps/src/server/skills/format-reference.ts
@@ -53,11 +53,19 @@ and the screen re-renders with fresh data on its own — so never patch state to
 mirror what the refresh will bring back. Destructive and money-moving calls are
 confirmed by the product OUTSIDE your screen — the guard asks the person before
 the call runs — so never build a confirm step of your own: no "are you sure"
-panel, no second button, no \`confirming\` state.
+panel, no second button, no \`confirming\` state. The exception is a confirmation
+the person ASKED for, or one press that fires a whole batch of calls: that one is
+part of their app, and it is a \`<Modal>\` saying how many, with the button that
+runs the loop LAST in its \`footer\` — that footer is a right-aligned row, so the
+last button is the one a person reaches for. A guarded host still asks once per
+call on top of it, and that is the trade: only your Modal can say how many, and
+being asked twice beats a batch that goes out silently.
 
 **Components — the catalog below, and nothing else.** Every component already
 carries this product's own theme, so anything with behavior — a table, a number,
-a date, a control — is a component, never HTML you assemble yourself.
+a date, a control — is a component, never HTML you assemble yourself. That holds
+inside a sentence too: an amount in prose is an inline \`<Money>\`, never a \`$\`
+and a \`toFixed\` you typed, which lose the grouping and the host's own currency.
 
 **Layout — the display tags, plus \`style\`.** \`${DISPLAY_TAG_NAMES.join("`, `")}\`
 are yours to arrange with, and they take children and an inline \`style\` and

--- a/packages/ui/src/kit/format.ts
+++ b/packages/ui/src/kit/format.ts
@@ -232,7 +232,10 @@ export function formatDateTime(value: DateInput | undefined, options: DateTimeOp
           ...(options.compact ? {} : { year: "numeric" }),
           month: "short",
           day: "numeric",
-          ...(mode === "datetime" ? clock : {}),
+          // A date-only value carries no clock, so `datetime` shows the day
+          // alone: the alternative is stamping "12:00 AM" on every row, which
+          // is a time the host never said.
+          ...(mode === "datetime" && !dateOnly ? clock : {}),
         };
   return new Intl.DateTimeFormat(locale, { ...base, ...parts }).format(date);
 }

--- a/packages/ui/test/kit/data-detail.test.tsx
+++ b/packages/ui/test/kit/data-detail.test.tsx
@@ -75,6 +75,11 @@ describe("Timeline", () => {
     expect(screen.getByText(/Mar 1, 2026/)).toBeTruthy();
   });
 
+  it("labels a date-only entry with the day alone, no midnight stamp", () => {
+    render(<Timeline entries={[{ id: "c", what: "Rent due", due_date: "2026-08-01" }]} titleField="what" timeField="due_date" />);
+    expect(screen.getByText("Aug 1, 2026")).toBeTruthy();
+  });
+
   it("renders the cell slot once per entry, each reading its OWN record", () => {
     // One element, two entries, two different values — the whole reason a slot
     // binds by field name instead of by prop.

--- a/packages/ui/test/kit/format.test.ts
+++ b/packages/ui/test/kit/format.test.ts
@@ -91,6 +91,13 @@ describe("formatDateTime", () => {
     expect(formatDateTime(d, { mode: "date", timeZone: "UTC" })).toBe("Jan 2, 2026");
   });
 
+  it("shows no clock for a date-only value asked for as a datetime", () => {
+    // A `due_date` used to render "Aug 1, 2026, 12:00 AM" — a time nobody stored.
+    expect(formatDateTime("2026-08-01", { mode: "datetime" })).toBe("Aug 1, 2026");
+    // A value that HAS a clock still keeps it.
+    expect(formatDateTime("2026-08-01T15:30:00Z", { mode: "datetime", timeZone: "UTC" })).toMatch(/3:30/);
+  });
+
   it("returns null for unparseable input (never Invalid Date)", () => {
     expect(formatDateTime("not-a-date")).toBeNull();
     expect(formatDateTime(Number.NaN)).toBeNull();


### PR DESCRIPTION
Three defects from the maple bench run `genbench/runs/2026-08-16T09-39-56`, each traced to its own line and fixed with the smallest lever that is honestly the product's.

## 1. A date-only value printed a midnight it never had

**Root cause — `packages/ui/src/kit/format.ts:235`.** `formatDateTime` appended a clock to every `datetime`, whatever the value was. `Timeline` labels its spine with `applyFormat(value, "datetime")` (`packages/ui/src/kit/data/timeline.tsx:31`), so a screen that passed a date-only `due_date` — `"2026-08-01"` — got `AUG 1, 2026, 12:00 AM`. Judged: *"timeline labels read 'AUG 1, 2026, 12:00 AM' etc., appending year and a 12:00 AM time rather than the 'Aug 7' style"*.

**Fix.** One condition, on a boolean the function had already computed to pin date-only strings to UTC:

```ts
...(mode === "datetime" && !dateOnly ? clock : {}),
```

The clock is not a formatting preference here, it is data the host never stored, so this is a wrong default rather than a taste call. It lands everywhere a `datetime` is formatted — Timeline's label, a DataTable column, `<DateTime>`, the islands' bare `fmt` — and a value that really carries a time still shows it.

**Tests, proven red on the old default:**
- `packages/ui/test/kit/format.test.ts` — `expected 'Aug 1, 2026, 12:00 AM' to be 'Aug 1, 2026'`, the reported string exactly.
- `packages/ui/test/kit/data-detail.test.tsx` — the Timeline seam: `Unable to find an element with the text: Aug 1, 2026`.

## 2. Money hand-formatted inside prose

**Root cause — `packages/apps/src/server/skills/format-reference.ts:60`.** The manual said *"anything with behavior — a table, a number, a date, a control — is a component, **never HTML you assemble yourself**"*, and the trailing clause let a model read the rule as being about HTML. It wrote `<Money>` in the cards and `$${(housing.amount / 100).toFixed(2)}` in the `<Callout>` sentence beside them — while inlining `<DateTime>` in that same sentence — so the page read `$2850.00` next to `$2,850.00`. Judged: *"the callout text reads '$2850.00' without a thousands-formatted match to the cards"*.

**Fix — one sentence, no checker rule.** A rule that rejects `toFixed` would fail legitimate screens; the honest gap was the manual's silence about prose:

> That holds inside a sentence too: an amount in prose is an inline `<Money>`, never a `$` and a `toFixed` you typed, which lose the grouping and the host's own currency.

**Honesty note:** this defect is intermittent. It reproduces in `2026-08-16T08-54-08`; in the named run `rent-check` passed every line. No proof run can flip a line that is already green — this is prevention, and it is the reason it costs one sentence and nothing else.

## 3. A bulk cancel fired twice with no confirmation

**Root cause — `packages/apps/src/server/skills/format-reference.ts:53-56`.** The manual **forbade** the confirmation the person had asked for in their own words (*"…asking me to confirm first and telling me how many it will cancel"*):

> Destructive and money-moving calls are confirmed by the product OUTSIDE your screen — the guard asks the person before the call runs — so never build a confirm step of your own: no "are you sure" panel, no second button, no `confirming` state.

The model obeyed it exactly, and the Kit's `<Modal>` — which the catalog carries and whose own spec example is a confirmation — was never reachable. The rule is right for the ordinary destructive press and wrong twice over here: the person asked, and the guard asks once per **call**, so a bulk loop asks N times and can never say how many. 21 cases across 14 worlds and 7 of the worlds' style rubrics expect an in-screen confirmation; the manual forbade all of them.

**Fix — one sentence, appended, original untouched:**

> The exception is a confirmation the person ASKED for, or one press that fires a whole batch of calls: that one is part of their app, and it is a `<Modal>` saying how many, with the button that runs the loop LAST in its `footer` — that footer is a right-aligned row, so the last button is the one a person reaches for.

The `LAST` clause is the Kit's own geometry, not benchmark coaching: `DialogShell` draws the footer as `display:flex; justify-content:flex-end` (`packages/ui/src/kit/overlay/dialog.tsx:112`), so the last child is the rightmost, which is where a confirming action belongs. Without it the model wrapped both buttons in a vertical `Stack` with the danger button on top — see the proof runs below.

## Proof runs (from this branch, real benchmark)

`GENBENCH_NO_OPEN=1 pnpm genbench run --prompt <case>`

**`bills-calendar`** (`runs/2026-08-16T13-42-26`) — vendo judged **6/7**, up from 3/7. `dates shown as 'Aug 7' style, never ISO` → **pass** (*"dates read 'Aug 1, 2026', 'Aug 12, 2026' etc."*). Fair reading: this roll wrote `<Card header={<DateTime mode="date"/>}>` rather than a Timeline, so the bench shows no regression while the two tests above carry the actual before/after for the defective idiom. The one line still failing is `lays the month out as a calendar grid` — the Kit has no calendar grid, which is a different question.

**`cancel-both-pending`** (three rolls, `13-44-22`, `13-46-58`, `13-49-46`) — every one of them painted a `<Modal>`, and the target line flipped in all three:

> `that button says it will cancel 2 transfers, and pressing it asks for confirmation before anything is cancelled` — **fail → pass** (*"the trace shows a confirmation step appeared before anything proceeded"*).

The first two rolls put the danger button first in a vertical `Stack` footer, and the probe presses a dialog's **last** control (`genbench/src/probe.ts:119-121`), so it took the way out: `confirmed: true, calls: []`, and the next line — `confirming fires cancel_transfer twice` — failed on the harness rather than the screen. The third roll, after the `LAST` clause, wrote `<Row justify="end">` with the danger button last and went clean: **floor 5/5**, trace `cancel_transfer({id:tr_1})`, `cancel_transfer({id:tr_2})`, and both lines pass.

## Two things for the owner, deliberately not done here

1. **The bench's floor penalises confirming.** `wiredActions` fails a press whose confirmation was followed through and called nothing (`genbench/src/floor.ts:340-360`), and the probe assumes the primary action is a dialog's last control. `diy` and `claude-code` have failed this floor on `cancel-both-pending` in **every** historical run — precisely because they confirm — and the vendo column only ever passed it by not confirming. Pressing the dialog's primary/danger action instead of its last one would make the floor agree with the rubric. That is `genbench/**`, outside this PR's scope, and it changes numbers for all three columns, so it is a call to make deliberately.
2. **No changeset.** This changes shipped behaviour in `@vendoai/ui` and `@vendoai/apps`; the scope for this PR was `packages/ui/**` + `packages/apps/**` only, so `.changeset/` was left alone. It needs one before release.

**Observed in passing, not fixed:** `Timeline` renders `cell ?? title`, so a screen that passes both `titleField` and `cell` loses its titles — the documented behaviour of the slot, and why the `bills-calendar` roll in the named run showed amounts with no bill names. And one roll wrote `cell: (row) => <Money .../>` — a render function where the Kit's cell slot wants an element — and the checks let it through to empty cells.

Local gate green on the touched scope: `pnpm build`, `pnpm typecheck`, `pnpm lint` all clean; `packages/ui` kit 305/305, `packages/apps` 1333/1333. Six failures elsewhere in `test:affected` (`store` pglite SIGKILL drills, `vendo` docs/mcp path tests, `genbench` font) reproduce identically on a clean checkout of this worktree — the worktree path contains a space, which those tests do not survive.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop adding “12:00 AM” to date-only values and clarify confirmation and money formatting rules. Previously `datetime` always showed a clock; now date-only inputs render just the day, and the manual allows requested/batch confirms and requires inline money in prose.

- `@vendoai/ui`: `formatDateTime` omits the clock for date-only inputs; values with a real time are unchanged. This affects Timeline labels, `<DateTime>`, DataTable columns, and `fmt`. Tests cover date-only and time-preserving cases.
- `@vendoai/apps`: In `format-reference`, allow a `<Modal>` confirm when the person asked for it or when one press runs a batch; the action that runs the loop must be the last footer button, and the host will still ask once per call. Amounts in prose must use inline `<Money>`, not `$` + `toFixed`.

- Rollout: add a changeset before publishing `@vendoai/ui` and `@vendoai/apps`.

<sup>Written for commit cdfb9d0c989a0657c090901cf4084dec77a27322. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



---

**Review round (Greptile P1, `format-reference.ts`).** The exception now states its own why, after a P1 arguing that one Modal cannot authorize per-call guards. Half right: in a host whose policy asks, every call in the loop is still graded on its own, so a batch draws the Modal *plus* N approval cards — the guidance did not say that, and now does:

> A guarded host still asks once per call on top of it, and that is the trade: only your Modal can say how many, and being asked twice beats a batch that goes out silently.

Half wrong: the review claimed approving the first item leaves the rest of the batch pending. Nothing serialises on the decision — a parked call answers the press immediately with `{ status: "pending-approval", approvalId }` (`packages/core/src/tools.ts:342`, `packages/ui/src/tree/parked-approvals.ts:4-10`), so the loop runs to the end, all N park together, and each is resumed by its own decision. Full reasoning in the thread.

**Proof after that edit** (`runs/2026-08-16T19-20-43`, vendo column): confirmation still paints and **both** target lines pass — `pressing it asks for confirmation before anything is cancelled` and `confirming fires cancel_transfer twice, once with id tr_1 and once with id tr_2` — with `wiredActions` green. Across four rolls of this case every one painted a `<Modal>` and passed the confirmation line; two of the four (after the `LAST` clause) also completed the follow-through under the probe. The one line failing in the latest roll is an unrelated cents/dollars slip ($25,000.00 for $250.00), which the floor's own honest-data check caught. Gate re-run clean: build, typecheck, lint; apps 1333/1333, ui kit 305/305.
