### PR TITLE
fix(genbench): the contract says what the probe presses — the confirm sits last

### DIFF
--- a/genbench/src/render.ts
+++ b/genbench/src/render.ts
@@ -37,7 +37,7 @@ export const HARNESS_CONTRACT = `THE PAGE — the seam every screen is scored th
 
 - SELF-CONTAINED. Inline every style and every script. The page is opened with NO network at all, so a CDN link, a webfont URL or an import of anything paints a blank screen.
 - WIRED. Every control a person can press must call \`window.vendo.callTool("<tool name>", { ...arguments })\`, with arguments that tool's input schema accepts. \`window.vendo\` is already on the page before anything you write runs — use it, do not define it.
-- CONFIRMED. A step that confirms before acting must carry \`role="dialog"\`, or the call behind it is never seen.
+- CONFIRMED. A step that confirms before acting must carry \`role="dialog"\`, or the call behind it is never seen. The control that confirms goes LAST inside it — that is the one the press follows through on, and everything before it is read as a way out.
 - FINISHED. The screen is considered settled two frames after the page loads, and it is shot then. Draw synchronously: anything painted later may not be in the picture anyone grades.
 - HONEST. Every number and every date on the screen must come from the tool data above — shown as it is, or computed from it. Anything else is graded as invented.
 - SIZED. It is shot at ${VIEWPORT.width}x${VIEWPORT.height}, and what a person sees there is all anyone sees.`;

--- a/genbench/tests/probe.test.ts
+++ b/genbench/tests/probe.test.ts
@@ -14,7 +14,7 @@ import { fileURLToPath } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { wiredActions } from "../src/floor.js";
 import { probe } from "../src/probe.js";
-import { openBrowser, type Shooter } from "../src/render.js";
+import { HARNESS_CONTRACT, openBrowser, type Shooter } from "../src/render.js";
 import { loadWorld, type World } from "../src/world.js";
 
 /** The recorder every real benchmark page carries, in its smallest honest form.
@@ -250,6 +250,11 @@ describe("the click probe grades what a browser actually does", () => {
     const result = wiredActions(trace, world);
     expect(result.pass).toBe(true);
     expect(result.bindings[0]).toMatchObject({ effect: "tool", tool: "cancel_transfer" });
+
+    // The order this press relies on is one every contender is TOLD, in the same
+    // text: a page that puts the way out last has its way out pressed, records a
+    // confirmation that called nothing, and fails a screen that was wired.
+    expect(HARNESS_CONTRACT).toContain("goes LAST inside it");
   });
 
   it("fails a confirmation that was followed through and still called nothing", async () => {


### PR DESCRIPTION
## The hole

The click probe, when a press opens a `[role=dialog]`, follows through by clicking the dialog's **last** actionable control (`genbench/src/probe.ts:119-121` — "The primary action sits last in a confirmation; everything before it is a way out").

The shared `HARNESS_CONTRACT` — the one text both baselines are handed — said only that a confirm step must carry `role="dialog"`. It never said the confirming action has to sit last. So a baseline that rendered `[Confirm][Cancel]` had its **Cancel** pressed, recorded "a confirmation was followed through and it still called nothing", and failed the `wiredActions` floor on a perfectly good screen.

~21 corpus cases expect a confirm, and two of the three columns were exposed to it. Vendo's own authoring manual was just taught the confirm-last rule (#1376), so the product column complies; the baselines were still never told. That is the same class of unfairness the contract was created to end: a rule the harness KEEPS but does not STATE.

## The fix

One sentence, in the contract's own voice, on the bullet that already covers confirmations:

> - CONFIRMED. A step that confirms before acting must carry `role="dialog"`, or the call behind it is never seen. **The control that confirms goes LAST inside it — that is the one the press follows through on, and everything before it is read as a way out.**

Probe behavior is unchanged. The contract is a single shared string, so both baselines get the identical bytes and `diy.test.ts`'s byte-level fairness assertions cover it automatically.

## The pin

`probe.test.ts` now asserts the contract carries the convention, inside the test that proves the probe presses last (`passes a confirmation whose primary action calls a real tool`). Delete the sentence and that test goes red — the same guard `render.test.ts` puts on "shot at 480x900".

No change was needed in `diy.test.ts`: the fence strips `HARNESS_CONTRACT` before checking a baseline's own words, and `/\bdialog\b/i` already catches any column that starts coaching confirmations on its own.

## Gate

`pnpm install && pnpm build && pnpm --filter @vendoai/genbench test && pnpm typecheck && pnpm lint` — build 21/21, typecheck 42/42, lint 0 errors. genbench: every suite green except the pre-existing `tests/font.test.ts` failure (`says nothing at all for a world that ships no face`), verified failing identically on the base commit with these changes stashed. Not this PR's.

No live model calls; `GENBENCH_LIVE` was never set.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the shared contract with the probe: the probe follows a `[role=dialog]` by pressing its last actionable control, so the confirming action must be last. Previously the contract only required `role="dialog"`, which let [Confirm][Cancel] dialogs have Cancel pressed and falsely fail `wiredActions`.

**Changes**
- Append to `HARNESS_CONTRACT` that the confirming control goes last in a confirmation dialog.
- Pin this convention in `probe.test.ts` by asserting the contract contains the “goes LAST inside it” sentence.
- No probe behavior change; both baselines receive the same updated contract text.

**Migration**
- Place the confirming/primary control last in any confirmation `[role="dialog"]`; otherwise the probe will press a way out and the screen will fail `wiredActions`.

<sup>Written for commit 18116b743276529a3dea706c75b63a1e93006c21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

