### PR TITLE
fix(genbench): confirm-gated pass lines grade the confirmation, not the press-through

### DIFF
--- a/genbench/worlds/clinic-scheduling/cases.json
+++ b/genbench/worlds/clinic-scheduling/cases.json
@@ -112,7 +112,7 @@
       "lists the appointments still to come that the patient has not confirmed, and no others",
       "offers one control that texts all of them at once",
       "that control says how many people it will text, and pressing it asks for confirmation before anything sends",
-      "confirming calls the reminder tool once for each of those appointments"
+      "the confirmation names the three patients it is about to text — Amara Osei, Owen Bragg and Sam Iyer"
     ],
     "tags": ["action"],
     "shape": "list-feed"

--- a/genbench/worlds/logistics/cases.json
+++ b/genbench/worlds/logistics/cases.json
@@ -99,7 +99,7 @@
       "lists exactly the four shipments whose days late is above zero and no on-time or delivered one",
       "arrives with those rows already selected, and shows the message text before anything is sent",
       "asks me to confirm before sending",
-      "confirming calls notify_customer once per row the screen shows selected when it loads, each with that row's shipment id and a message"
+      "the confirmation names the four shipments it would notify — SO-3318, SO-3352, PO-88377 and PO-88402"
     ],
     "tags": ["action"],
     "shape": "list-feed"
@@ -125,7 +125,7 @@
       "shows both refused shipments — SO-3352 and PO-88402 — with the refusal reason the exception tool returned for each",
       "each shipment has its own date and delivery window input rather than one setting for both",
       "a row's button calls reschedule_delivery with that shipment's id, the chosen date and the chosen window",
-      "the same row also calls notify_customer for that shipment, and nothing fires until I confirm"
+      "the same row also calls notify_customer for that shipment, so one press both books it and tells the customer"
     ],
     "tags": ["action"],
     "shape": "form"

--- a/genbench/worlds/maple/cases.json
+++ b/genbench/worlds/maple/cases.json
@@ -84,7 +84,7 @@
       "shows both pending transfers, Alex Rivera $250.00 and Jordan Avery $60.00, and no completed transfer",
       "offers exactly one cancel button for all of them rather than one per row",
       "that button says it will cancel 2 transfers, and pressing it asks for confirmation before anything is cancelled",
-      "confirming fires cancel_transfer twice, once with id tr_1 and once with id tr_2"
+      "the confirmation names what it would cancel — Alex Rivera's $250.00 and Jordan Avery's $60.00 — rather than asking a bare 'are you sure'"
     ],
     "tags": ["action"],
     "shape": "list-feed"

--- a/genbench/worlds/observability/cases.json
+++ b/genbench/worlds/observability/cases.json
@@ -49,7 +49,7 @@
       "shows both times, with the deploy landing before the incident started",
       "shows the incident's commander and its customers-affected count from the tool",
       "shows who shipped the deploy and which build number it was",
-      "the rollback control asks for confirmation and then rolls back that deploy, not another one"
+      "the rollback control asks for confirmation, and the confirmation names the checkout-api build it would roll back — 4192 — not another deploy"
     ]
   },
   {
@@ -115,7 +115,7 @@
       "shows the acknowledged count beside the fired count for each alert",
       "singles out the two alerts that fired repeatedly and were never acknowledged",
       "lets more than one alert be selected and silenced in a single action",
-      "the bulk silence asks for confirmation, and confirming fires one silence call, with a number of minutes, for each alert the screen shows picked when it loads"
+      "the bulk silence asks for confirmation, and the confirmation says how many alerts it would silence — the two picked when the screen loads — and for how long"
     ]
   },
   {

--- a/genbench/worlds/people-ops/cases.json
+++ b/genbench/worlds/people-ops/cases.json
@@ -22,7 +22,7 @@
       "shows the four pending requests and none of the approved or denied ones",
       "shows each pending request's employee, dates and hours",
       "approve fires approve_time_off with the id of the request it sits on",
-      "deny asks for confirmation first, and confirming fires deny_time_off with that request's id"
+      "deny asks for confirmation first, and the confirmation names whose request it is about to deny"
     ]
   },
   {
@@ -100,7 +100,7 @@
       "lists the four people whose review step is late and nobody who is on time",
       "orders them most days late first, so Marcus Odell and Tomas Bello come before Daniel Okafor and Sena Nakamura",
       "shows each person's days late and the stage they are stuck at",
-      "the nudge-everyone control asks for confirmation and then fires send_review_reminder for each late person"
+      "the nudge-everyone control asks for confirmation, and the confirmation says it is about to email all four of them"
     ]
   },
   {

--- a/genbench/worlds/product-analytics/cases.json
+++ b/genbench/worlds/product-analytics/cases.json
@@ -127,7 +127,7 @@
       "does not list csv_import_finished, which the Import-first accounts segment is built on",
       "shows each listed event's 7-day fire count, so sidebar_collapsed's 9,402 is visible",
       "one control deprecates all three, and it asks for confirmation before any call fires",
-      "confirming fires one deprecate call per listed event"
+      "the confirmation names all three events it would deprecate — sidebar_collapsed, old_pricing_toggle and legacy_signup_v1"
     ],
     "tags": ["action"],
     "shape": "list-feed"

--- a/genbench/worlds/project-tracker/cases.json
+++ b/genbench/worlds/project-tracker/cases.json
@@ -87,7 +87,7 @@
       "shows what 2026.8 holds before it offers to cut anything — its 7 issues, 4 of them done",
       "offers a cut control for 2026.8 only, not for the planned releases",
       "asks for confirmation before the cut fires, rather than firing on the first press",
-      "confirming is what calls cut_release, and it calls it for 2026.8"
+      "the confirmation names 2026.8 as the release it would cut, and says the cut cannot be undone"
     ],
     "tags": ["action"],
     "shape": "detail"

--- a/genbench/worlds/property-management/cases.json
+++ b/genbench/worlds/property-management/cases.json
@@ -85,7 +85,7 @@
       "lists exactly the four tenants with an August balance and none of the four who paid in full, all four ticked when the screen loads",
       "shows each of them the amount they still owe",
       "several can be ticked at once and sent with one control",
-      "asks for confirmation first, then fires one send_late_notice per row the screen shows ticked"
+      "asks for confirmation first, and the confirmation says how many notices it is about to send — the four rows ticked when the screen loads"
     ],
     "tags": ["action"],
     "shape": "list-feed"

--- a/genbench/worlds/store-admin/cases.json
+++ b/genbench/worlds/store-admin/cases.json
@@ -87,7 +87,7 @@
       "lists the four unfulfilled orders and neither the shipped, delivered nor cancelled ones",
       "flags PDL-1044 as still awaiting payment",
       "one control marks the whole batch fulfilled, and asks for confirmation before it does",
-      "confirming calls mark_fulfilled once per order listed"
+      "the confirmation says how many orders it is about to fulfil — all four"
     ]
   },
   {

--- a/genbench/worlds/subscription-billing/cases.json
+++ b/genbench/worlds/subscription-billing/cases.json
@@ -85,7 +85,7 @@
       "lists only the unpaid invoices — the open one and the two past due — and no paid, voided or refunded ones",
       "arrives with all three ticked and shows the total that would be written off, $177.83",
       "a reason field sits with the write-off control, and confirming is a second step rather than the same press",
-      "confirming calls void_invoice once per ticked invoice, each with that invoice's id and whatever the reason field holds"
+      "the confirmation names what it would write off — three invoices, $177.83 — and carries the reason the field holds"
     ],
     "tags": ["action"],
     "shape": "table"
@@ -123,8 +123,8 @@
     "pass": [
       "shows Tessellate Studio's failed invoice with its amount, the card-expired reason and that all four attempts are spent",
       "offers exactly the three choices asked for and nothing else",
-      "each choice calls its own tool for Tessellate Studio — retry_payment and void_invoice on the invoice, cancel_subscription on the subscription with period_end",
-      "the void and the cancel ask for confirmation before they run"
+      "the retry choice calls retry_payment for INV-2044, the invoice on the screen",
+      "the void and the cancel each ask for confirmation first, and each confirmation says what it would do — void INV-2044, or cancel Tessellate Studio at the end of the period"
     ],
     "tags": ["action"],
     "shape": "detail"

--- a/genbench/worlds/support-desk/cases.json
+++ b/genbench/worlds/support-desk/cases.json
@@ -104,7 +104,7 @@
       "lists exactly the three solved tickets — TK-1036, TK-1037, TK-1038 — each with its own checkbox, all three ticked when the screen loads",
       "the close control says how many are selected",
       "asks for confirmation before closing anything",
-      "confirming fires close_tickets once, with the ids of the rows the screen shows ticked"
+      "the confirmation names the three tickets it is about to close — TK-1036, TK-1037 and TK-1038"
     ],
     "tags": ["action"],
     "shape": "table"

--- a/genbench/worlds/trades-accounting/cases.json
+++ b/genbench/worlds/trades-accounting/cases.json
@@ -104,7 +104,7 @@
       "shows the totals as 75.0 hours and $4,634.00",
       "shows each entry's tech, date, hours and amount",
       "one control approves every pending entry and asks for confirmation before it fires",
-      "confirming calls approve_time_entry once per pending entry — nine calls"
+      "the confirmation says what it is about to approve — nine entries, 75.0 hours, $4,634.00"
     ]
   },
   {


### PR DESCRIPTION
The probe no longer presses any button inside a `[role=dialog]` confirmation — a deterministic robot cannot know which button confirms. It records instead that a dialog opened and the dialog's visible text, which the judge reads as:

```
pressed "Cancel all" — opened a confirmation: "Cancel 2 transfers? Alex Rivera $250.00 and Jordan Avery $60.00."
```

That makes any pass line grading what happens AFTER a confirmation ("confirming fires close_tickets once with the selected ids") unobservable by every contender. Seventeen such lines across twelve worlds are rewritten to what the new trace line does show: the confirmation's own text, naming the aggregate, the named target, or the consequence.

**Post-confirm tool-call correctness is out of scope for confirm-gated actions until a judgment-based prober exists.** What a confirm-gated case now grades is: the initial screen offers the action control (screenshot), pressing it opens a confirmation rather than firing (trace), and the confirmation names what it is about to do (trace). What it no longer grades is which tool the confirm fires and with what arguments.

Lines about an action that fires WITHOUT a dialog are untouched — those are still fully observable and were not weakened. `tags: ["action"]` stays on every rewritten case: the new floor rule counts a dialog-opening press as the action control.

Every number a rewritten line grades was re-verified against the world's raw rows.

### What changed, per world

| World · case | Was | Now |
| --- | --- | --- |
| maple · cancel-both-pending | confirming fires cancel_transfer twice, tr_1 and tr_2 | the confirmation names what it would cancel — Alex Rivera's $250.00 and Jordan Avery's $60.00 |
| clinic-scheduling · confirm-sweep | confirming calls the reminder tool once per appointment | the confirmation names the three patients it is about to text |
| logistics · late-notify-all | confirming calls notify_customer once per selected row | the confirmation names the four shipments it would notify |
| logistics · refused-redelivery | …and nothing fires until I confirm | …so one press both books it and tells the customer (confirm clause dropped — it was poisoning the two fully observable tool-call lines in the same case, and the prompt never asked for a confirmation) |
| observability · deploy-blast-radius | asks for confirmation and then rolls back that deploy | the confirmation names the checkout-api build it would roll back — 4192 |
| observability · alert-fatigue-audit | confirming fires one silence call per picked alert | the confirmation says how many alerts it would silence — the two picked — and for how long |
| people-ops · time-off-queue | confirming fires deny_time_off with that request's id | the confirmation names whose request it is about to deny |
| people-ops · late-reviews-nudge | then fires send_review_reminder for each late person | the confirmation says it is about to email all four of them |
| product-analytics · retire-unused-events | confirming fires one deprecate call per listed event | the confirmation names all three events it would deprecate |
| project-tracker · cut-release | confirming is what calls cut_release, for 2026.8 | the confirmation names 2026.8 as the release it would cut, and says the cut cannot be undone |
| property-management · late-notice-blast | then fires one send_late_notice per ticked row | the confirmation says how many notices it is about to send — the four rows ticked on load |
| store-admin · bulk-fulfil | confirming calls mark_fulfilled once per order | the confirmation says how many orders it is about to fulfil — all four |
| subscription-billing · write-off-unpayable | confirming calls void_invoice once per ticked invoice with the reason | the confirmation names what it would write off — three invoices, $177.83 — and carries the reason |
| subscription-billing · dunning-last-stand | each choice calls its own tool (retry, void, cancel with period_end) + the void and the cancel ask for confirmation | the retry choice calls retry_payment for INV-2044 (still fully observable); the void and the cancel each ask first, and each confirmation says what it would do |
| support-desk · bulk-close | confirming fires close_tickets once with the ticked ids | the confirmation names the three tickets it is about to close |
| trades-accounting · approve-week-time | confirming calls approve_time_entry nine times | the confirmation says what it is about to approve — nine entries, 75.0 hours, $4,634.00 |

### Left alone deliberately

- `"asks for confirmation before X"` lines — a dialog opening is exactly what the new trace records.
- Wizard cases (`fieldops/dispatch-wizard`, `clinic-scheduling/book-like-a-patient`, `logistics/start-return`, `observability/new-alert-rule`, `subscription-billing/new-subscription-wizard`, `support-desk/merge-wizard`) — their lines are negative claims about the FIRST step's presses, which the probe still observes.
- Every direct tool-call line with no dialog in front of it.

### Scope and gate

`genbench/worlds/**` only. `genbench/tests/worlds.test.ts` needed no change — no case lost a pass line, an `action` tag, or dropped below any mechanical bound.

```
pnpm build                          21 successful, 21 total
pnpm --filter @vendoai/genbench test  Test Files 1 failed | 18 passed (19)
                                      Tests 1 failed | 419 passed | 2 skipped (422)
                                      tests/worlds.test.ts ✓ (169 tests)
pnpm lint                           4 successful, 4 total (0 errors)
```

The single red is the pre-existing `tests/font.test.ts`, verified identical on the clean tree at the same base commit (same 1 failed / 419 passed).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrites confirm-gated pass lines to grade the confirmation dialog text instead of post-confirmation tool calls, because the probe no longer clicks inside a `[role=dialog]`. Previously these lines asserted what fired after confirming; now they assert that pressing the control opens a confirmation that names the target, aggregate, or consequence.

- Scope: 17 pass lines across 12 worlds; changes are confined to `genbench/worlds/**` case text. Direct-action lines without dialogs are unchanged; wizard flows and “asks for confirmation” claims are unchanged; `tags: ["action"]` are retained. One exception: in logistics/refused-redelivery the confirm clause is dropped to avoid poisoning two observable tool-call lines.
- Review: Check that each updated line mirrors the dialog’s visible text and preserves counts/names/amounts. No test or harness changes were needed; worlds tests stay green, and no case lost a pass line or fell below bounds.

<sup>Written for commit deff6d1de8c188c9e53ebd612d5d45404b4487dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

