### PR TITLE
feat(genbench)!: the probe records a confirmation, it never presses inside one

### DIFF
--- a/genbench/src/floor.ts
+++ b/genbench/src/floor.ts
@@ -136,8 +136,12 @@ export interface WiredActionsResult {
    *  one control that was pressed. */
   readonly pressed: number;
   readonly bindings: readonly Binding[];
+  /** What cleared an `action` case's bar, and which of the two did it: a press
+   *  that asked the host for something, or one that opened a confirmation the
+   *  probe never presses inside. Absent when neither happened. */
+  readonly acted?: "tool" | "confirmation";
   /** Why the check failed for a reason no single binding carries — an `action`
-   *  case none of whose presses ever asked the host for anything. */
+   *  case none of whose presses did either. */
   readonly why?: string;
 }
 
@@ -329,7 +333,8 @@ export const holds = (binding: Binding): boolean =>
  *  catch: a screen can name a tool in its document and still be dead in a
  *  browser. A DISPLAY screen with nothing to press passes vacuously; an `action`
  *  case does not, because a case that asked the screen to do something is proven
- *  by a tool call and by nothing else. */
+ *  by a tool call — or by a confirmation, since the probe stops at the dialog
+ *  and the call behind it can never reach this trace. */
 export function wiredActions(
   trace: readonly Probed[],
   world: World,
@@ -337,30 +342,12 @@ export function wiredActions(
 ): WiredActionsResult {
   const bindings = trace.flatMap((candidate): Binding[] => {
     if (candidate.calls.length === 0) {
-      // A confirmation exists to authorize an action, and the probe only ever
-      // follows through on its PRIMARY action (`probe.ts` clicks the dialog's last
-      // control; a way out sits before it and is never taken). So a chain that was
-      // followed through and still asked for nothing is dead by construction —
-      // however much opening the dialog moved the screen. This is the "looks
-      // wired, is dead" case the probe exists to catch, and letting the dialog's
-      // own repaint stand in for an effect would hide exactly it.
-      //
-      // A dismiss button is not caught by this: closing a dialog leaves none
-      // visible, so its own press records `confirmed: false` and is graded on
-      // whether the screen moved, like any other local control.
-      if (candidate.confirmed) {
-        return [
-          {
-            where: candidate.label,
-            effect: "none",
-            why: "a confirmation was followed through and it still called nothing",
-          },
-        ];
-      }
       return [
-        candidate.changed
-          ? { where: candidate.label, effect: "state", why: "changed the screen without calling a tool" }
-          : { where: candidate.label, effect: "none", why: "pressing it called nothing and changed nothing" },
+        candidate.dialog !== undefined
+          ? { where: candidate.label, effect: "state", why: "opened a confirmation — not followed; the judge reads it" }
+          : candidate.changed
+            ? { where: candidate.label, effect: "state", why: "changed the screen without calling a tool" }
+            : { where: candidate.label, effect: "none", why: "pressing it called nothing and changed nothing" },
       ];
     }
     return candidate.calls.map((call): Binding => {
@@ -379,15 +366,20 @@ export function wiredActions(
       };
     });
   });
-  const acted = bindings.some((binding) => binding.effect === "tool" && holds(binding));
+  const acted = bindings.some((binding) => binding.effect === "tool" && holds(binding))
+    ? "tool"
+    : trace.some((candidate) => candidate.dialog !== undefined)
+      ? "confirmation"
+      : undefined;
   const why =
-    tags.includes("action") && !acted
-      ? "this case asks the screen to DO something, and no press ever asked the host for anything"
+    tags.includes("action") && acted === undefined
+      ? "this case asks the screen to DO something, and no press ever asked the host for anything or opened a confirmation"
       : undefined;
   return {
     pass: why === undefined && bindings.every(holds),
     pressed: trace.length,
     bindings,
+    ...(acted === undefined ? {} : { acted }),
     ...(why === undefined ? {} : { why }),
   };
 }

--- a/genbench/src/judge.ts
+++ b/genbench/src/judge.ts
@@ -163,18 +163,21 @@ function traceText(trace: readonly Probed[]): string {
   return trace
     .map((probed) => {
       const asked = probed.calls.map((call) => `${call.name}(${JSON.stringify(call.args)})`).join(", ");
-      // A confirmation is where the probe STOPS, so its words are the whole of
-      // that press's evidence: quoted verbatim, because "asks before it cancels
-      // two transfers" is graded off what the dialog said and nothing else.
+      // A confirmation is where the probe STOPS, so its words are that press's
+      // evidence: quoted verbatim, because "asks before it cancels two transfers"
+      // is graded off what the dialog said and nothing else. A press that does
+      // both says both — hiding the call would fail a "pressing it calls X" line
+      // on a screen that really does call X and then asks.
       //
       // A control that only changes local state asked the host for nothing and is
       // still a working control; "called nothing" alone would read to the judge as
       // a dead button and cost the screen a correctness line it earned.
+      const opened = probed.dialog === undefined ? "" : `opened a confirmation: ${JSON.stringify(probed.dialog)}`;
       const did =
-        probed.dialog !== undefined
-          ? `opened a confirmation: ${JSON.stringify(probed.dialog)}`
-          : asked !== ""
-            ? `called ${asked}`
+        asked !== ""
+          ? `called ${asked}${opened === "" ? "" : ` and ${opened}`}`
+          : opened !== ""
+            ? opened
             : probed.changed
               ? "called nothing, and changed the screen"
               : "called nothing, and changed nothing";

--- a/genbench/src/judge.ts
+++ b/genbench/src/judge.ts
@@ -163,17 +163,22 @@ function traceText(trace: readonly Probed[]): string {
   return trace
     .map((probed) => {
       const asked = probed.calls.map((call) => `${call.name}(${JSON.stringify(call.args)})`).join(", ");
-      const step = probed.confirmed ? " (a confirmation step appeared, and was confirmed)" : "";
+      // A confirmation is where the probe STOPS, so its words are the whole of
+      // that press's evidence: quoted verbatim, because "asks before it cancels
+      // two transfers" is graded off what the dialog said and nothing else.
+      //
       // A control that only changes local state asked the host for nothing and is
       // still a working control; "called nothing" alone would read to the judge as
       // a dead button and cost the screen a correctness line it earned.
       const did =
-        asked !== ""
-          ? `called ${asked}`
-          : probed.changed
-            ? "called nothing, and changed the screen"
-            : "called nothing, and changed nothing";
-      return `pressed "${probed.label}"${step} — ${did}`;
+        probed.dialog !== undefined
+          ? `opened a confirmation: ${JSON.stringify(probed.dialog)}`
+          : asked !== ""
+            ? `called ${asked}`
+            : probed.changed
+              ? "called nothing, and changed the screen"
+              : "called nothing, and changed nothing";
+      return `pressed "${probed.label}" — ${did}`;
     })
     .join("\n");
 }

--- a/genbench/src/probe.ts
+++ b/genbench/src/probe.ts
@@ -32,6 +32,10 @@ const CLICK_MS = 5_000;
  */
 const EFFECT_MS = 2_000;
 
+/** Enough of a confirmation for a judge to grade what it says, and not so much
+ *  that a dialog of fine print becomes the whole trace. */
+const DIALOG_CHARS = 500;
+
 export interface Fired {
   readonly name: string;
   readonly args: unknown;
@@ -39,8 +43,11 @@ export interface Fired {
 
 export interface Probed {
   readonly label: string;
-  /** A `[role=dialog]` stood between the press and the call, and was confirmed. */
-  readonly confirmed: boolean;
+  /** The visible text of a `[role=dialog]` the press opened. Nothing inside it
+   *  is pressed: which control confirms is a judgement, not a lookup, and a robot
+   *  that guesses at it grades its own guess. What the dialog SAYS is the
+   *  evidence, and the judge is who reads it. Absent when none opened. */
+  readonly dialog?: string;
   /** The press visibly moved the screen — a dialog opened, a tab switched, a row
    *  was dismissed. What tells a control that only changes local state apart from
    *  one that is dead, since neither asks the host for anything. */
@@ -109,18 +116,12 @@ export async function probe(visit: Visit): Promise<Probed[]> {
 
     // Read after the press has landed, so a confirmation the runtime paints a
     // frame late is still a confirmation and not a control that did nothing.
+    // `isVisible` first because it answers on a missing element instead of
+    // waiting for one, which every press that opens no dialog is.
     const dialog = visit.page.locator("[role=dialog]").first();
-    const confirmed = await dialog.isVisible().catch(() => false);
-    if (confirmed) {
-      // Measured from the screen WITH the dialog on it, not from before the
-      // press: the dialog opening already moved the page, so a wait against the
-      // earlier state would be satisfied before the confirm had done anything.
-      const opened = await look(visit.page);
-      // The primary action sits last in a confirmation; everything before it is a
-      // way out, and taking one of those would record the press as firing nothing.
-      await dialog.locator(ACTIONABLE).last().click({ timeout: CLICK_MS }).catch(() => undefined);
-      await settle(visit.page, opened);
-    }
+    const said = (await dialog.isVisible().catch(() => false))
+      ? (await dialog.innerText().catch(() => "")).trim().slice(0, DIALOG_CHARS)
+      : undefined;
 
     // A press that navigated away — a link with an href — leaves no screen to
     // read: it went somewhere, which is the change, and it asked the host for
@@ -130,7 +131,7 @@ export async function probe(visit: Visit): Promise<Probed[]> {
     if (after === undefined) await visit.reset();
     trace.push({
       label: (text || aria || "").trim() || `control ${index + 1}`,
-      confirmed,
+      ...(said === undefined ? {} : { dialog: said }),
       changed: after === undefined || after.text !== before.text || after.elements !== before.elements,
       // Only what THIS press asked for. The recorder is the page's, not the
       // press's, so handing over the whole array credited one load-time call to

--- a/genbench/src/render.ts
+++ b/genbench/src/render.ts
@@ -37,7 +37,7 @@ export const HARNESS_CONTRACT = `THE PAGE — the seam every screen is scored th
 
 - SELF-CONTAINED. Inline every style and every script. The page is opened with NO network at all, so a CDN link, a webfont URL or an import of anything paints a blank screen.
 - WIRED. Every control a person can press must call \`window.vendo.callTool("<tool name>", { ...arguments })\`, with arguments that tool's input schema accepts. \`window.vendo\` is already on the page before anything you write runs — use it, do not define it.
-- CONFIRMED. A step that confirms before acting must carry \`role="dialog"\`, or the call behind it is never seen.
+- CONFIRMED. A step that confirms before acting must carry \`role="dialog"\`. The harness records that it opened and the text it shows, and presses nothing inside it — what the dialog SAYS is what is graded.
 - FINISHED. The screen is considered settled two frames after the page loads, and it is shot then. Draw synchronously: anything painted later may not be in the picture anyone grades.
 - HONEST. Every number and every date on the screen must come from the tool data above — shown as it is, or computed from it. Anything else is graded as invented.
 - SIZED. It is shot at ${VIEWPORT.width}x${VIEWPORT.height}, and what a person sees there is all anyone sees.`;

--- a/genbench/tests/floor.test.ts
+++ b/genbench/tests/floor.test.ts
@@ -243,7 +243,7 @@ describe("checks", () => {
 
 describe("wiredActions", () => {
   const pressed = (name: string, args: unknown): Probed[] => [
-    { label: "Cancel", confirmed: false, changed: false, calls: [{ name, args }] },
+    { label: "Cancel", changed: false, calls: [{ name, args }] },
   ];
 
   it("passes a real tool called with the arguments it declares", () => {
@@ -259,7 +259,7 @@ describe("wiredActions", () => {
    * moved, and that is the only thing these two cases differ by.
    */
   it("passes a control that called nothing but visibly changed the screen", () => {
-    const result = wiredActions([{ label: "Details", confirmed: false, changed: true, calls: [] }], world);
+    const result = wiredActions([{ label: "Details", changed: true, calls: [] }], world);
     expect(result.pass).toBe(true);
     expect(result.bindings[0]).toEqual({
       where: "Details",
@@ -269,7 +269,7 @@ describe("wiredActions", () => {
   });
 
   it("fails a control that called nothing and changed nothing", () => {
-    const result = wiredActions([{ label: "Cancel", confirmed: false, changed: false, calls: [] }], world);
+    const result = wiredActions([{ label: "Cancel", changed: false, calls: [] }], world);
     expect(result.pass).toBe(false);
     expect(result.bindings[0]).toEqual({
       where: "Cancel",
@@ -278,25 +278,25 @@ describe("wiredActions", () => {
     });
   });
 
-  /** The one press that changed the screen and is dead anyway. A confirmation
-   *  authorizes an action, and the probe only follows through on the primary one,
-   *  so being told yes and asking for nothing is not local state — it is a screen
-   *  that asks "are you sure?" and means nothing by it. */
-  it("fails a confirmation that was followed through and still called nothing", () => {
-    const result = wiredActions([{ label: "Cancel transfer", confirmed: true, changed: true, calls: [] }], world);
-    expect(result.pass).toBe(false);
+  /** A press that opened a confirmation. The probe stops at the dialog — which
+   *  control inside it confirms is a judgement, not a lookup — so the call behind
+   *  it can never appear here, and "it confirmed and called nothing" is a verdict
+   *  nobody is entitled to. The dialog's words go to the judge instead. */
+  it("passes a press that opened a confirmation, and says nobody followed it through", () => {
+    const result = wiredActions([{ label: "Cancel transfer", dialog: "Cancel this transfer?", changed: true, calls: [] }], world);
+    expect(result.pass).toBe(true);
     expect(result.bindings[0]).toEqual({
       where: "Cancel transfer",
-      effect: "none",
-      why: "a confirmation was followed through and it still called nothing",
+      effect: "state",
+      why: "opened a confirmation — not followed; the judge reads it",
     });
   });
 
   /** …and the control that closes one. Nothing is left visible for the probe to
-   *  confirm, so a dismiss records `confirmed: false` and is graded like any other
-   *  local control — the rule above cannot reach it. */
+   *  read, so a dismiss records no dialog and is graded like any other local
+   *  control. */
   it("passes a dismiss that closes a dialog and calls nothing", () => {
-    const result = wiredActions([{ label: "Keep it", confirmed: false, changed: true, calls: [] }], world);
+    const result = wiredActions([{ label: "Keep it", changed: true, calls: [] }], world);
     expect(result.pass).toBe(true);
     expect(result.bindings[0]).toMatchObject({ effect: "state" });
   });
@@ -335,18 +335,21 @@ describe("wiredActions", () => {
   });
 
   /**
-   * An `action` case asks the screen to DO something, and the only evidence that
-   * it did is a tool call. A screen that opens a confirmation, moves a toggle and
-   * never asks the host for anything passed this check — every press held, and
-   * the case it was answering was never done.
+   * An `action` case asks the screen to DO something, and a toggle moving is not
+   * evidence that it did. Two things are: a tool call, and a confirmation — the
+   * probe presses nothing inside a dialog, so a confirm-gated action's call can
+   * never reach this trace, and the tool-call-only bar failed every screen that
+   * asks before it acts. Which of the two cleared it is on the result, because a
+   * confirmation that was never followed through is a weaker proof than a call.
    */
   describe("an action case", () => {
-    const DETAILS: Probed[] = [{ label: "Details", confirmed: false, changed: true, calls: [] }];
+    const DETAILS: Probed[] = [{ label: "Details", changed: true, calls: [] }];
 
     it("is not proven by controls that only moved the screen", () => {
       const result = wiredActions(DETAILS, world, ["action"]);
       expect(result.pass).toBe(false);
       expect(result.why).toContain("no press ever asked the host for anything");
+      expect(result.acted).toBeUndefined();
       // Every binding still holds on its own — the failure is the case's, and it
       // has to say so somewhere a reader can find it.
       expect(result.bindings[0]).toMatchObject({ effect: "state" });
@@ -356,6 +359,14 @@ describe("wiredActions", () => {
       const result = wiredActions(pressed("cancel_transfer", { id: "tr_1" }), world, ["action"]);
       expect(result.pass).toBe(true);
       expect(result.why).toBeUndefined();
+      expect(result.acted).toBe("tool");
+    });
+
+    it("is proven by a press that opened a confirmation, and says that is what proved it", () => {
+      const result = wiredActions([{ label: "Cancel all", dialog: "Cancel 2 transfers?", changed: true, calls: [] }], world, ["action"]);
+      expect(result.pass).toBe(true);
+      expect(result.why).toBeUndefined();
+      expect(result.acted).toBe("confirmation");
     });
 
     it("is not proven by a tool call that does not hold", () => {
@@ -372,8 +383,8 @@ describe("wiredActions", () => {
     // One press that fires two tools is two bindings and one control; a press
     // that fires nothing is still a control that was pressed.
     const trace: Probed[] = [
-      { label: "Refresh", confirmed: false, changed: true, calls: [{ name: "list_transfers", args: { limit: 5 } }, { name: "get_spending", args: {} }] },
-      { label: "Details", confirmed: false, changed: true, calls: [] },
+      { label: "Refresh", changed: true, calls: [{ name: "list_transfers", args: { limit: 5 } }, { name: "get_spending", args: {} }] },
+      { label: "Details", changed: true, calls: [] },
     ];
 
     expect(wiredActions(trace, world).pressed).toBe(2);

--- a/genbench/tests/judge.test.ts
+++ b/genbench/tests/judge.test.ts
@@ -164,17 +164,32 @@ describe("blindness", () => {
   });
 
   /** The probe presses nothing inside a confirmation, so the dialog's own words
-   *  are the only evidence that press left. They are quoted verbatim, because a
-   *  line like "asks before it cancels two transfers" is graded off them. */
+   *  are the evidence that press left. They are quoted verbatim, because a line
+   *  like "asks before it cancels two transfers" is graded off them. */
+  const DIALOG = "Cancel 2 transfers? This cannot be undone.";
+
   it("renders a confirmation as the text it showed, quoted", async () => {
     const model = answering();
+    const trace: Probed[] = [{ label: "Cancel all", dialog: DIALOG, changed: true, calls: [] }];
+    await judge(input({ trace }), { model });
+
+    expect(traceSent(model.doGenerateCalls[0]!)).toContain(
+      `pressed "Cancel all" — opened a confirmation: "${DIALOG}"`,
+    );
+  });
+
+  /** A press can do both, and then the judge is owed both: dropping the call
+   *  would fail a "pressing it calls X" line on a screen that really does call X
+   *  and then ask. */
+  it("renders a press that called AND confirmed as both, in one line", async () => {
+    const model = answering();
     const trace: Probed[] = [
-      { label: "Cancel all", dialog: "Cancel 2 transfers? This cannot be undone.", changed: true, calls: [] },
+      { label: "Cancel all", dialog: DIALOG, changed: true, calls: [{ name: "cancel_transfer", args: { id: "tr_1" } }] },
     ];
     await judge(input({ trace }), { model });
 
     expect(traceSent(model.doGenerateCalls[0]!)).toContain(
-      `pressed "Cancel all" — opened a confirmation: "Cancel 2 transfers? This cannot be undone."`,
+      `pressed "Cancel all" — called cancel_transfer({"id":"tr_1"}) and opened a confirmation: "${DIALOG}"`,
     );
   });
 

--- a/genbench/tests/judge.test.ts
+++ b/genbench/tests/judge.test.ts
@@ -19,8 +19,8 @@ const PNG = Buffer.from(
 );
 
 const TRACE: Probed[] = [
-  { label: "Cancel", confirmed: true, changed: false, calls: [{ name: "cancel_transfer", args: { id: "tr_1" } }] },
-  { label: "Refresh", confirmed: false, changed: false, calls: [] },
+  { label: "Cancel", changed: false, calls: [{ name: "cancel_transfer", args: { id: "tr_1" } }] },
+  { label: "Refresh", changed: false, calls: [] },
 ];
 
 const CASE_LINES = ["alpha shows every row", "bravo totals the rows", "charlie confirms deletions"];
@@ -62,6 +62,16 @@ const asked = (call: { prompt: unknown }): string[] => {
   );
   const checklist = parts.filter((part) => part.type === "text").at(-1)?.text ?? "";
   return [...checklist.matchAll(/^\s*\d+\.\s+\[\w+\]\s+(.+)$/gm)].map((match) => match[1]!);
+};
+
+/** The interaction trace exactly as it went over the wire. Its wording is a
+ *  contract, not a detail: the corpus grades confirmation lines off these words. */
+const traceSent = (call: { prompt: unknown }): string => {
+  const parsed = JSON.parse(JSON.stringify(call.prompt)) as Array<{ content: unknown }>;
+  const parts = parsed.flatMap((message) =>
+    Array.isArray(message.content) ? (message.content as Array<{ type: string; text?: string }>) : [],
+  );
+  return parts.find((part) => part.text?.startsWith("INTERACTION TRACE") === true)?.text ?? "";
 };
 
 /** The verdict this line is worth, decided by its own first word — so a remap
@@ -122,7 +132,7 @@ describe("blindness", () => {
 <script type="module">import { PayloadView } from "@vendoai/ui/tree";</script>
 <button onclick="window.vendo.callTool('cancel_transfer', { id: 'tr_1' })">Cancel</button>`,
         // A control's label is page text, and page text can sign its own work.
-        trace: [{ label: "Built with Vendo", confirmed: false, changed: false, calls: [{ name: "cancel_transfer", args: {} }] }],
+        trace: [{ label: "Built with Vendo", changed: false, calls: [{ name: "cancel_transfer", args: {} }] }],
       }),
       contender: "vendo-sonnet",
       harness: "claude-code",
@@ -151,6 +161,21 @@ describe("blindness", () => {
     expect(sent).toContain("cancel_transfer");
     expect(sent).toContain("Cancel");
     for (const line of [...CASE_LINES, ...STYLE_LINES]) expect(sent).toContain(line);
+  });
+
+  /** The probe presses nothing inside a confirmation, so the dialog's own words
+   *  are the only evidence that press left. They are quoted verbatim, because a
+   *  line like "asks before it cancels two transfers" is graded off them. */
+  it("renders a confirmation as the text it showed, quoted", async () => {
+    const model = answering();
+    const trace: Probed[] = [
+      { label: "Cancel all", dialog: "Cancel 2 transfers? This cannot be undone.", changed: true, calls: [] },
+    ];
+    await judge(input({ trace }), { model });
+
+    expect(traceSent(model.doGenerateCalls[0]!)).toContain(
+      `pressed "Cancel all" — opened a confirmation: "Cancel 2 transfers? This cannot be undone."`,
+    );
   });
 
   it("keeps the artifact's format while taking its name — a tree still reads as a tree", async () => {

--- a/genbench/tests/probe.test.ts
+++ b/genbench/tests/probe.test.ts
@@ -106,36 +106,45 @@ const STATE_ONLY = fixture(`document.getElementById("go").addEventListener("clic
   }, 50));`);
 
 /**
- * The whole confirmation chain: the press opens a `[role=dialog]` with a way out
- * and a primary action, in that order, a beat after the click.
+ * The whole confirmation chain: the press opens a `[role=dialog]` with a message,
+ * a way out and a primary action, a beat after the click.
  *
  * The dialog is BUILT on the press rather than sitting hidden in the markup, the
  * way a real screen mounts one — so the page the probe counts its candidates on
  * has exactly the one button, and the dialog's own controls are never graded as
  * screens of their own.
  */
-const chain = (attachPrimary: string): string =>
+const MESSAGE = "Cancel this transfer? It cannot be undone.";
+const chain = (attachPrimary: string, said = MESSAGE): string =>
   fixture(`document.getElementById("go").addEventListener("click", () =>
   setTimeout(() => {
     var dialog = document.createElement("div");
     dialog.setAttribute("role", "dialog");
+    var message = document.createElement("p");
+    message.textContent = ${JSON.stringify(said)};
     var keep = document.createElement("button");
     keep.textContent = "Keep it";
     keep.addEventListener("click", () => dialog.remove());
     var primary = document.createElement("button");
     primary.textContent = "Yes, cancel it";
     ${attachPrimary}
-    dialog.append(keep, primary);
+    dialog.append(message, keep, primary);
     document.getElementById("root").append(dialog);
   }, 50));`);
 
 const CONFIRMED = chain(`primary.addEventListener("click", () =>
       window.vendo.callTool("cancel_transfer", { id: "tr_1" }));`);
 
-/** The same chain with the primary's handler never attached — a screen that asks
- *  "are you sure?", is told yes, and does nothing. Indistinguishable from the one
- *  above in a screenshot, and the exact thing a dialog's repaint could hide. */
+/** The same chain with the primary's handler never attached. The two are one
+ *  page to this probe, on purpose: which control confirms is a judgement, and a
+ *  robot pressing the one it guessed at would be grading its own guess. */
 const CONFIRMED_DEAD = chain("");
+
+/** The whole record either chain leaves. `innerText` is the screen as rendered,
+ *  so the exact spacing between the message and the buttons is the browser's to
+ *  decide; what is pinned is that the words a person reads are captured, and
+ *  that `calls` is empty because nothing inside the dialog was pressed. */
+const OPENED = [{ label: "Cancel transfer", dialog: expect.stringContaining(MESSAGE), changed: true, calls: [] }];
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 let world: World;
@@ -159,7 +168,7 @@ describe("the click probe grades what a browser actually does", () => {
   it("passes a button whose handler calls a real tool with valid arguments", async () => {
     const trace = await traceOf(WIRED);
     expect(trace).toEqual([
-      { label: "Cancel transfer", confirmed: false, changed: false, calls: [{ name: "cancel_transfer", args: { id: "tr_1" } }] },
+      { label: "Cancel transfer", changed: false, calls: [{ name: "cancel_transfer", args: { id: "tr_1" } }] },
     ]);
     expect(wiredActions(trace, world).pass).toBe(true);
   });
@@ -171,14 +180,14 @@ describe("the click probe grades what a browser actually does", () => {
     // still empty here and a wired control is graded dead. Every interactive
     // screen presses through a runtime, so every one of them looked like this.
     expect(trace).toEqual([
-      { label: "Cancel transfer", confirmed: false, changed: false, calls: [{ name: "cancel_transfer", args: { id: "tr_1" } }] },
+      { label: "Cancel transfer", changed: false, calls: [{ name: "cancel_transfer", args: { id: "tr_1" } }] },
     ]);
     expect(wiredActions(trace, world).pass).toBe(true);
   });
 
   it("passes a button that only changes the screen, and says that is what it did", async () => {
     const trace = await traceOf(STATE_ONLY);
-    expect(trace).toEqual([{ label: "Cancel transfer", confirmed: false, changed: true, calls: [] }]);
+    expect(trace).toEqual([{ label: "Cancel transfer", changed: true, calls: [] }]);
 
     const result = wiredActions(trace, world);
     expect(result.pass).toBe(true);
@@ -187,7 +196,7 @@ describe("the click probe grades what a browser actually does", () => {
 
   it("fails the same button with no handler attached", async () => {
     const trace = await traceOf(DEAD);
-    expect(trace).toEqual([{ label: "Cancel transfer", confirmed: false, changed: false, calls: [] }]);
+    expect(trace).toEqual([{ label: "Cancel transfer", changed: false, calls: [] }]);
 
     const result = wiredActions(trace, world);
     expect(result.pass).toBe(false);
@@ -199,7 +208,7 @@ describe("the click probe grades what a browser actually does", () => {
 
     // One control, one press, and it did nothing: the load-time fetch was on the
     // recorder before the button was ever touched.
-    expect(trace).toEqual([{ label: "Cancel transfer", confirmed: false, changed: false, calls: [] }]);
+    expect(trace).toEqual([{ label: "Cancel transfer", changed: false, calls: [] }]);
     expect(wiredActions(trace, world).pass).toBe(false);
     expect(wiredActions(trace, world).bindings[0]).toMatchObject({ effect: "none" });
   });
@@ -227,46 +236,44 @@ describe("the click probe grades what a browser actually does", () => {
   });
 
   /**
-   * The confirmation chain, both ways, and the one case where a screen that moved
-   * is still dead.
+   * The confirmation chain, both ways, and they are the SAME record.
    *
-   * A dialog opening is a visible change, so the state-only rule on its own would
-   * pass a screen that asks "are you sure?", is told yes, and calls nothing — the
-   * precise failure the probe replaced a static scan to catch. Being followed
-   * through is what separates the two: the pair below differs only by whether the
-   * primary action has a handler.
+   * The probe used to press the dialog's last control and grade what followed. It
+   * cannot: which control confirms is a judgement — "Cancel" in a dialog about
+   * cancelling means the opposite of "Cancel" beside it — so a robot pressing the
+   * one it guessed at was grading its own guess, and the two pages below are
+   * exactly where that showed. Now it records the dialog and its words, presses
+   * nothing inside, and the judge reads what the screen actually asked.
    */
-  it("passes a confirmation whose primary action calls a real tool", async () => {
+  it("records the dialog a press opened, and presses nothing inside it", async () => {
     const trace = await traceOf(CONFIRMED);
-    expect(trace).toEqual([
-      {
-        label: "Cancel transfer",
-        confirmed: true,
-        changed: true,
-        calls: [{ name: "cancel_transfer", args: { id: "tr_1" } }],
-      },
-    ]);
+
+    // The primary action IS wired here — so a call in `calls` would be the probe
+    // having pressed it. There is none.
+    expect(trace).toEqual(OPENED);
 
     const result = wiredActions(trace, world);
     expect(result.pass).toBe(true);
-    expect(result.bindings[0]).toMatchObject({ effect: "tool", tool: "cancel_transfer" });
+    expect(result.bindings[0]).toMatchObject({ effect: "state" });
   });
 
-  it("fails a confirmation that was followed through and still called nothing", async () => {
+  it("no longer convicts a confirmation nobody followed through", async () => {
     const trace = await traceOf(CONFIRMED_DEAD);
 
-    // The screen DID move — the dialog is on it — so this is the one press that
-    // changed something and is dead anyway.
-    expect(trace).toEqual([{ label: "Cancel transfer", confirmed: true, changed: true, calls: [] }]);
-
-    const result = wiredActions(trace, world);
-    expect(result.pass).toBe(false);
-    expect(result.bindings[0]).toMatchObject({ effect: "none" });
+    // The wired chain's record exactly: the harness cannot tell the two apart
+    // and does not pretend to.
+    expect(trace).toEqual(OPENED);
+    expect(wiredActions(trace, world).pass).toBe(true);
 
     // The dialog's own buttons were never graded as controls of their own: the
     // candidates are counted on the untouched page, where the dialog does not
-    // exist yet. That is why a "Keep it" dismiss cannot be caught by the rule
-    // above — the probe only ever presses a dialog's LAST control.
+    // exist yet.
     expect(trace).toHaveLength(1);
+  });
+
+  it("caps a dialog of fine print instead of letting it become the trace", async () => {
+    const trace = await traceOf(chain("", "x".repeat(900)));
+
+    expect(trace[0]!.dialog).toBe("x".repeat(500));
   });
 });

--- a/genbench/tests/report.test.ts
+++ b/genbench/tests/report.test.ts
@@ -358,8 +358,8 @@ describe("the preview page", () => {
   it("marks a state-only control as a pass, with the reason it passed, and a dead one as a fail", async () => {
     const graded = wiredActions(
       [
-        { label: "Details", confirmed: false, changed: true, calls: [] },
-        { label: "Refresh", confirmed: false, changed: false, calls: [] },
+        { label: "Details", changed: true, calls: [] },
+        { label: "Refresh", changed: false, calls: [] },
       ],
       world,
     );
@@ -403,7 +403,7 @@ describe("the preview page", () => {
    *  the check's own reason has to be readable beside them or the column shows a
    *  red mark over a row of green ticks. */
   it("prints why an action case failed when no single press did", async () => {
-    const unproven = wiredActions([{ label: "Details", confirmed: false, changed: true, calls: [] }], world, ["action"]);
+    const unproven = wiredActions([{ label: "Details", changed: true, calls: [] }], world, ["action"]);
     const html = await preview(
       [
         {
@@ -435,8 +435,8 @@ describe("the preview page", () => {
   it("tells a screen whose controls all held apart from one with nothing to press", async () => {
     const live = wiredActions(
       [
-        { label: "Cancel", confirmed: false, changed: false, calls: [{ name: "cancel_transfer", args: { id: "tr_1" } }] },
-        { label: "Details", confirmed: false, changed: true, calls: [] },
+        { label: "Cancel", changed: false, calls: [{ name: "cancel_transfer", args: { id: "tr_1" } }] },
+        { label: "Details", changed: true, calls: [] },
       ],
       world,
     );


### PR DESCRIPTION
A robot will never know which button in a confirmation dialog is the one that
means yes. `probe.ts` pressed the dialog's LAST actionable and called it the
primary action; `floor.ts` then graded "confirmed and still called nothing" as a
dead control. Both assumed a judgement the harness cannot make.

## What changes

- **`probe.ts`** — a press that opens a `[role=dialog]` records the dialog's
  visible text (trimmed, capped at 500 chars) and presses **nothing** inside it.
  `Probed.confirmed: boolean` → `Probed.dialog?: string`.
- **`floor.ts`** — the "a confirmation was followed through and it still called
  nothing → dead" rule is deleted; there is no follow-through any more. A press
  that opened a dialog is a live control (`opened a confirmation — not followed;
  the judge reads it`). The `tags:["action"]` bar is now cleared by a holding
  tool binding **or** by a press that opened a confirmation — without that,
  every confirm-gated action case fails for all three contenders, because the
  call behind the dialog can no longer reach the trace. `WiredActionsResult.acted`
  records which of the two cleared it.
- **`judge.ts`** — the trace line for such a press is
  `pressed "Cancel all" — opened a confirmation: "<the dialog text>"`, so lines
  like "asks for confirmation and says it will cancel 2 transfers" are graded off
  what the screen actually said. `SYSTEM_PROMPT` is untouched, so `rubricVersion`
  stays 3 and the pinned `promptHash` still holds.
- **`render.ts`** — the CONFIRMED bullet now says what the harness really does:
  the step must carry `role="dialog"`, the harness records it and its text and
  presses nothing inside, and what the dialog SAYS is what is judged.

Supersedes #1377 (a contract sentence about the confirm sitting last), closed as
obsolete. The corpus's "confirming fires X" pass lines are being rewritten in a
parallel PR to grade the dialog's text through this trace format.

## Proof

The five new assertions were run against the old behaviour (probe presses the
dialog's last control, floor convicts a dead confirm, judge drops the dialog
clause) and all five go red; restored, all pass.

Local gate on the touched scope: `pnpm build` ✅ · `pnpm --filter @vendoai/genbench test`
422 passed, 1 failed · `pnpm typecheck` ✅ · `pnpm lint` ✅. The one failure is
`tests/font.test.ts > says nothing at all for a world that ships no face`, which
fails identically on `origin/main` (verified by stashing this diff) and is
untouched by this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops pressing inside confirmation dialogs and records their visible text instead. Previously the probe clicked the dialog’s last control and treated it as the primary action; now it never follows through, so calls gated by confirmations no longer appear in traces, and when a press both calls a tool and opens a dialog the judge shows both.

- In `probe.ts`, `Probed.confirmed` → `Probed.dialog?: string` (trimmed to 500 chars). A press that opens a `[role=dialog]` records its text; nothing inside is pressed.
- In `floor.ts`, the “dead confirm” rule is removed. A press that opened a confirmation is a live control with `effect: "state"` (“opened a confirmation — not followed; the judge reads it”). `action` cases clear if either a holding tool binding exists or a confirmation was opened. `WiredActionsResult.acted?: "tool" | "confirmation"` indicates which cleared it.
- In `judge.ts`, trace lines render confirmations as: pressed "Cancel all" — opened a confirmation: "<text>". If the press also called a tool, it renders both: pressed "Cancel all" — called cancel_transfer({...}) and opened a confirmation: "<text>". Rubric and prompt remain unchanged.
- In `render.ts`, the CONFIRMED contract bullet states that the harness records the dialog and presses nothing inside it.

**Migration**
- Replace all uses of `Probed.confirmed` with checks for `Probed.dialog` and update tests/snapshots accordingly.
- Do not expect tool calls in `calls` after confirm-gated presses; read the dialog text from `dialog` instead.
- For `action` cases, accept `result.acted === "confirmation"` in addition to `"tool"`.

<sup>Written for commit 5a29638228da4df0ab4b43421fe6af1fb5616cab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

