### PR TITLE
feat(genbench): wafer contenders (glm-fast, deepseek-flash) + --contenders/--jobs

### DIFF
--- a/genbench/package.json
+++ b/genbench/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@ai-sdk/anthropic": "3.0.12",
+    "@ai-sdk/openai-compatible": "2.0.9",
     "@ai-sdk/provider": "3.0.2",
     "@anthropic-ai/claude-agent-sdk": ">=0.3.0 <1",
     "@playwright/test": "^1.49.0",

--- a/genbench/src/meter.ts
+++ b/genbench/src/meter.ts
@@ -1,13 +1,23 @@
 import type { LanguageModelV3, LanguageModelV3Middleware, LanguageModelV3Usage } from "@ai-sdk/provider";
 import { wrapLanguageModel, type LanguageModel } from "ai";
 
-export type ModelAlias = "opus" | "sonnet" | "haiku";
+/** The open-source contenders, served through one OpenAI-compatible endpoint at
+ *  Wafer. Membership here is what says an alias is NOT an Anthropic model — the
+ *  provider a run builds for it, and the key it demands, both read this. */
+export const WAFER_MODEL_IDS = {
+  "glm-fast": "glm5.2-fast",
+  "deepseek-flash": "DeepSeek-V4-Flash-0731-Fast",
+} as const;
+
+export const WAFER_BASE_URL = "https://pass.wafer.ai/v1";
+
+export type ModelAlias = "opus" | "sonnet" | "haiku" | keyof typeof WAFER_MODEL_IDS;
 
 /**
  * Pinned ids. Each one was checked against the live API through
  * `@ai-sdk/anthropic` before being written here.
  *
- * Two of the three are floating aliases, and not for want of trying: as of
+ * Two of the three Anthropic ids are floating aliases, and not for want of trying: as of
  * 2026-08-15 `GET /v1/models` lists `claude-opus-5` and `claude-sonnet-5` with
  * no dated snapshot beside them, so there is nothing to pin them to. Haiku has
  * one and carries it. Until the other two do, `Meter.answeredBy` is what says
@@ -18,6 +28,7 @@ export const MODEL_IDS: Readonly<Record<ModelAlias, string>> = {
   opus: "claude-opus-5",
   sonnet: "claude-sonnet-5",
   haiku: "claude-haiku-4-5-20251001",
+  ...WAFER_MODEL_IDS,
 };
 
 interface ModelPrice {
@@ -34,6 +45,12 @@ const PRICING: Readonly<Record<string, ModelPrice>> = {
   "claude-opus-5": { inputPerMTok: 5, outputPerMTok: 25 },
   "claude-sonnet-5": { inputPerMTok: 2, outputPerMTok: 10 },
   "claude-haiku-4-5-20251001": { inputPerMTok: 1, outputPerMTok: 5 },
+  // Wafer's own quote, read off `GET /v1/models` on 2026-08-16 — its `pricing`
+  // block is in cents per million. Its cache reads are a tenth of input for GLM
+  // and a QUARTER for DeepSeek, so DeepSeek's cache-read dollars read low
+  // against the one multiplier below; its token counts are exact either way.
+  "glm5.2-fast": { inputPerMTok: 2.1, outputPerMTok: 6.6 },
+  "DeepSeek-V4-Flash-0731-Fast": { inputPerMTok: 0.28, outputPerMTok: 0.56 },
 };
 
 /** Cache reads bill at a tenth of the input rate; 5-minute cache writes at 1.25x. */

--- a/genbench/src/run.ts
+++ b/genbench/src/run.ts
@@ -1,4 +1,5 @@
 import { createAnthropic } from "@ai-sdk/anthropic";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import type { UIPayload } from "@vendoai/core";
 import { execFileSync, spawn } from "node:child_process";
 import { readdir, readFile, mkdir, writeFile } from "node:fs/promises";
@@ -10,7 +11,15 @@ import { claudeCodeDriver, WALL_CLOCK_MS, type SessionRecord } from "./claude-co
 import { diyDriver } from "./diy.js";
 import { checks, runFloor, type FloorResult } from "./floor.js";
 import { judge, JudgeContract, rubricLines, type JudgeResult } from "./judge.js";
-import { meteredModel, MODEL_IDS, type Meter, type ModelAlias, type UsageTotals } from "./meter.js";
+import {
+  meteredModel,
+  MODEL_IDS,
+  WAFER_BASE_URL,
+  WAFER_MODEL_IDS,
+  type Meter,
+  type ModelAlias,
+  type UsageTotals,
+} from "./meter.js";
 import { probe, type Probed } from "./probe.js";
 import { authoredPage, bundleMount, openBrowser, pageHtml, type Shot } from "./render.js";
 import { tally, writePreview, writeSummary } from "./report.js";
@@ -136,6 +145,8 @@ const DRIVERS: Record<HarnessId, (model: ModelAlias) => Contender> = {
   "claude-code": (model) => claudeCodeDriver({ model }),
 };
 
+const HARNESS_IDS = Object.keys(DRIVERS) as readonly HarnessId[];
+
 /** The world a run uses when `--world` names none — one of the fourteen folders
  *  under `worlds/`. */
 const DEFAULT_WORLD = "maple";
@@ -151,6 +162,10 @@ export interface Args {
   /** A folder under `worlds/`, holding `world.json`, `cases.json` and any face —
    *  or `all`, which is every folder there. */
   readonly world: string;
+  /** The harnesses that race each case. Every driver, unless narrowed. */
+  readonly contenders: readonly HarnessId[];
+  /** How many cases are in flight at once. */
+  readonly jobs: number;
 }
 
 export function parseArgs(argv: readonly string[]): Args {
@@ -158,6 +173,8 @@ export function parseArgs(argv: readonly string[]): Args {
   let only: string | undefined;
   let models: readonly ModelAlias[] = ["sonnet"];
   let world = DEFAULT_WORLD;
+  let harnesses = HARNESS_IDS;
+  let jobs = 1;
   let index = 0;
   while (index < rest.length) {
     const flag = rest[index];
@@ -166,10 +183,12 @@ export function parseArgs(argv: readonly string[]): Args {
     if (flag === "--prompt") only = value;
     else if (flag === "--models") models = value.split(",").map(asAlias);
     else if (flag === "--world") world = value;
+    else if (flag === "--contenders") harnesses = value.split(",").map(asHarness);
+    else if (flag === "--jobs") jobs = asJobs(value);
     else throw new Error(`genbench: unexpected argument "${flag}"`);
     index += 2;
   }
-  return { ...(only === undefined ? {} : { only }), models, world };
+  return { ...(only === undefined ? {} : { only }), models, world, contenders: harnesses, jobs };
 }
 
 function asAlias(value: string): ModelAlias {
@@ -177,11 +196,45 @@ function asAlias(value: string): ModelAlias {
   return value as ModelAlias;
 }
 
+function asHarness(value: string): HarnessId {
+  if (!Object.hasOwn(DRIVERS, value)) throw new Error(`genbench: unknown contender "${value}"`);
+  return value as HarnessId;
+}
+
+function asJobs(value: string): number {
+  const jobs = Number(value);
+  if (!Number.isInteger(jobs) || jobs < 1) throw new Error(`genbench: --jobs takes whole cases, not "${value}"`);
+  return jobs;
+}
+
 /** Every contender that has a driver today, in every requested model. */
-export function contenders(models: readonly ModelAlias[]): readonly ContenderId[] {
-  return Object.keys(DRIVERS).flatMap((harness) =>
-    models.map((model) => ({ harness: harness as HarnessId, model, slug: `${harness}-${model}` })),
-  );
+export function contenders(
+  models: readonly ModelAlias[],
+  harnesses: readonly HarnessId[] = HARNESS_IDS,
+): readonly ContenderId[] {
+  return harnesses.flatMap((harness) => models.map((model) => ({ harness, model, slug: `${harness}-${model}` })));
+}
+
+/**
+ * Up to `limit` jobs in flight, answering in the jobs' own order.
+ *
+ * Within a case the contenders already race each other; this is the bound
+ * ACROSS cases, and it is a bound rather than `Promise.all` because every case
+ * in flight holds a browser page, a model's rate limit and a share of the
+ * laptop. The order is the order the cases were authored in, never the order
+ * they finished, for the same reason the columns never shuffle.
+ */
+export async function pool<T>(jobs: readonly (() => Promise<T>)[], limit: number): Promise<T[]> {
+  const done: T[] = [];
+  let next = 0;
+  const worker = async (): Promise<void> => {
+    while (next < jobs.length) {
+      const index = next++;
+      done[index] = await jobs[index]!();
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(limit, jobs.length) }, worker));
+  return done;
 }
 
 /** The recharts-backed Kit components (packages/ui/src/kit/charts/). */
@@ -343,6 +396,15 @@ async function main(argv: readonly string[]): Promise<number> {
     console.error("genbench: ANTHROPIC_API_KEY is not set");
     return 1;
   }
+  // Demanded up front rather than at the first call, which is a case and a
+  // browser later. The Anthropic key is still required whatever was asked for:
+  // the judge and the honesty check run on it, whoever built the screen.
+  const waferKey = process.env.WAFER_API_KEY;
+  const wanted = args.models.filter((alias) => Object.hasOwn(WAFER_MODEL_IDS, alias));
+  if (wanted.length > 0 && (waferKey === undefined || waferKey === "")) {
+    console.error(`genbench: WAFER_API_KEY is not set, and it is what serves ${wanted.join(", ")}`);
+    return 1;
+  }
 
   const root = dirname(dirname(fileURLToPath(import.meta.url)));
   const worldsDir = join(root, "worlds");
@@ -351,6 +413,7 @@ async function main(argv: readonly string[]): Promise<number> {
   const runId = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
   const runDir = join(root, "runs", runId);
   const anthropic = createAnthropic({ apiKey });
+  const wafer = createOpenAICompatible({ name: "wafer", baseURL: WAFER_BASE_URL, apiKey: waferKey });
   const bundle = await bundleMount();
   const shooter = await openBrowser();
   const results: CaseResult[] = [];
@@ -367,7 +430,8 @@ async function main(argv: readonly string[]): Promise<number> {
     const modelId = MODEL_IDS[contender.model];
     // Its own meter, so a sibling's tokens and a sibling's clock are never
     // charged to this column.
-    const meter = meteredModel(anthropic(modelId), modelId);
+    const provider = Object.hasOwn(WAFER_MODEL_IDS, contender.model) ? wafer : anthropic;
+    const meter = meteredModel(provider(modelId), modelId);
 
     /** Evidence as it is produced, not as it is returned. Losing the outer race
      *  used to discard a screenshot that had already been taken and a trace that
@@ -514,6 +578,10 @@ async function main(argv: readonly string[]): Promise<number> {
   };
 
   try {
+    // Every case as a job first, then up to `--jobs` of them at once. The worlds
+    // are read here, in one pass and in order, so nothing a case is graded
+    // against depends on which cases happened to be in flight beside it.
+    const cases: (() => Promise<CaseResult[]>)[] = [];
     for (const name of names) {
       const worldDir = join(worldsDir, name);
       const world = await loadWorld(worldDir);
@@ -524,12 +592,17 @@ async function main(argv: readonly string[]): Promise<number> {
         worlds[key] = scoped;
         // The whole row at once: they share only the browser, a page each, and the
         // order of `results` is the order of `contenders` whoever finishes first.
-        const row = await Promise.all(
-          contenders(args.models).map(async (contender) => await runOne(contender, testCase, scoped, key)),
+        cases.push(
+          async () =>
+            await Promise.all(
+              contenders(args.models, args.contenders).map(
+                async (contender) => await runOne(contender, testCase, scoped, key),
+              ),
+            ),
         );
-        results.push(...row);
       }
     }
+    results.push(...(await pool(cases, args.jobs)).flat());
   } finally {
     await shooter.close();
   }

--- a/genbench/src/run.ts
+++ b/genbench/src/run.ts
@@ -207,12 +207,19 @@ function asJobs(value: string): number {
   return jobs;
 }
 
-/** Every contender that has a driver today, in every requested model. */
+/** Every contender that has a driver today, in every model that driver can
+ *  think with. Claude Code spawns its own Anthropic engine and never reads
+ *  `meter.model`, so a Wafer alias would reach its Agent SDK as an Anthropic id
+ *  and the column would report the harness's mistake as the model's score. */
 export function contenders(
   models: readonly ModelAlias[],
   harnesses: readonly HarnessId[] = HARNESS_IDS,
 ): readonly ContenderId[] {
-  return harnesses.flatMap((harness) => models.map((model) => ({ harness, model, slug: `${harness}-${model}` })));
+  return harnesses.flatMap((harness) =>
+    models
+      .filter((model) => harness !== "claude-code" || !Object.hasOwn(WAFER_MODEL_IDS, model))
+      .map((model) => ({ harness, model, slug: `${harness}-${model}` })),
+  );
 }
 
 /**

--- a/genbench/tests/meter.test.ts
+++ b/genbench/tests/meter.test.ts
@@ -1,0 +1,33 @@
+/**
+ * An open-source contender has to be nameable in `--models` AND billable in the
+ * same table as the rest. `usdFor` throws for a model it holds no price for, so
+ * an alias shipped without its pricing row would end its own run at the first
+ * result rather than at a missing row somebody could see and fix.
+ */
+import { describe, expect, it } from "vitest";
+import { MODEL_IDS, usdFor, WAFER_MODEL_IDS, type UsageTotals } from "../src/meter.js";
+
+const perMTok: UsageTotals = {
+  inputTokens: 1_000_000,
+  outputTokens: 1_000_000,
+  cacheReadTokens: 0,
+  cacheWriteTokens: 0,
+  calls: 1,
+};
+
+describe("the Wafer contenders", () => {
+  it("names each alias by the id Wafer serves it under", () => {
+    expect(MODEL_IDS["glm-fast"]).toBe("glm5.2-fast");
+    expect(MODEL_IDS["deepseek-flash"]).toBe("DeepSeek-V4-Flash-0731-Fast");
+  });
+
+  it("prices every one of them, so no Wafer run is ended by a missing row", () => {
+    for (const id of Object.values(WAFER_MODEL_IDS)) expect(usdFor(perMTok, id)).toBeGreaterThan(0);
+  });
+
+  /** Wafer's own `GET /v1/models` quote, in dollars per million tokens. */
+  it("charges what Wafer quotes", () => {
+    expect(usdFor(perMTok, "glm5.2-fast")).toBeCloseTo(2.1 + 6.6, 6);
+    expect(usdFor(perMTok, "DeepSeek-V4-Flash-0731-Fast")).toBeCloseTo(0.28 + 0.56, 6);
+  });
+});

--- a/genbench/tests/run.test.ts
+++ b/genbench/tests/run.test.ts
@@ -309,6 +309,14 @@ describe("--contenders", () => {
   it("refuses a contender that has no driver", () => {
     expect(() => parseArgs(["run", "--contenders", "vendo,langchain"])).toThrow(/unknown contender "langchain"/);
   });
+
+  /** Claude Code is Anthropic's own engine and never reads the meter's model, so
+   *  a Wafer alias would reach its Agent SDK as an Anthropic id — a column that
+   *  scores zero for a mistake the harness made. It has no such column. */
+  it("leaves Claude Code out of a Wafer model's row, and keeps the rest of it", () => {
+    expect(contenders(["glm-fast"]).map((contender) => contender.slug)).toEqual(["vendo-glm-fast", "diy-glm-fast"]);
+    expect(contenders(["sonnet", "glm-fast"]).map((contender) => contender.slug)).toContain("claude-code-sonnet");
+  });
 });
 
 /** Within a case the contenders already race each other. `--jobs` is the bound

--- a/genbench/tests/run.test.ts
+++ b/genbench/tests/run.test.ts
@@ -19,6 +19,7 @@ import {
   exitCode,
   harnessStamp,
   parseArgs,
+  pool,
   shouldOpen,
   ungraded,
   worldsFor,
@@ -208,6 +209,8 @@ describe("opening the preview", () => {
     ...(only === undefined ? {} : { only }),
     models: ["sonnet"],
     world: "maple",
+    contenders: ["vendo", "diy", "claude-code"],
+    jobs: 1,
   });
 
   it("opens for the single case a person is sitting and watching", () => {
@@ -272,5 +275,88 @@ describe("harnessStamp", () => {
 
     expect(stamp.gitSha).toMatch(/^[0-9a-f]{40}$/);
     expect(stamp.agentSdkVersion).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});
+
+/** `--models` is the only door into a run, so an alias nothing serves is refused
+ *  at the flag rather than at the first model call, a case and a browser later. */
+describe("--models", () => {
+  it("takes the Wafer-served open-source contenders", () => {
+    expect(parseArgs(["run", "--models", "glm-fast,deepseek-flash"]).models).toEqual(["glm-fast", "deepseek-flash"]);
+  });
+
+  it("refuses a model no provider here serves", () => {
+    expect(() => parseArgs(["run", "--models", "gpt-9"])).toThrow(/unknown model "gpt-9"/);
+  });
+});
+
+/** A row is every driver, and the reason to narrow it is money: measuring one
+ *  harness should not spend the other two's tokens on the same case. */
+describe("--contenders", () => {
+  it("races every driver when nobody narrows the row", () => {
+    expect(parseArgs(["run"]).contenders).toEqual(["vendo", "diy", "claude-code"]);
+  });
+
+  it("narrows the row to the drivers named", () => {
+    const only = parseArgs(["run", "--contenders", "vendo,claude-code"]).contenders;
+
+    expect(contenders(["sonnet"], only).map((contender) => contender.slug)).toEqual([
+      "vendo-sonnet",
+      "claude-code-sonnet",
+    ]);
+  });
+
+  it("refuses a contender that has no driver", () => {
+    expect(() => parseArgs(["run", "--contenders", "vendo,langchain"])).toThrow(/unknown contender "langchain"/);
+  });
+});
+
+/** Within a case the contenders already race each other. `--jobs` is the bound
+ *  ACROSS cases — the only thing between a 200-case corpus and one case at a
+ *  time — and a bound that is not a whole number of cases is not a bound. */
+describe("--jobs", () => {
+  it("runs one case at a time unless asked otherwise", () => {
+    expect(parseArgs(["run"]).jobs).toBe(1);
+  });
+
+  it("takes the number of cases to keep in flight", () => {
+    expect(parseArgs(["run", "--jobs", "4"]).jobs).toBe(4);
+  });
+
+  it("refuses anything that is not a whole number of cases", () => {
+    for (const value of ["0", "-1", "2.5", "lots"]) {
+      expect(() => parseArgs(["run", "--jobs", value])).toThrow(/--jobs/);
+    }
+  });
+});
+
+describe("pool", () => {
+  it("keeps results in the jobs' own order, not the order they finished", async () => {
+    const jobs = [30, 1, 15].map((ms, index) => async () => {
+      await new Promise((settle) => setTimeout(settle, ms));
+      return index;
+    });
+
+    expect(await pool(jobs, 3)).toEqual([0, 1, 2]);
+  });
+
+  it("never has more than the bound in flight", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const jobs = Array.from({ length: 7 }, () => async () => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await new Promise((settle) => setTimeout(settle, 5));
+      inFlight -= 1;
+    });
+
+    await pool(jobs, 2);
+
+    expect(peak).toBe(2);
+  });
+
+  it("runs every job when the bound is wider than the queue, and none when there are none", async () => {
+    expect(await pool([async () => "the only case"], 8)).toEqual(["the only case"]);
+    expect(await pool([], 8)).toEqual([]);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -788,6 +788,9 @@ importers:
       '@ai-sdk/anthropic':
         specifier: 3.0.12
         version: 3.0.12(zod@4.4.3)
+      '@ai-sdk/openai-compatible':
+        specifier: 2.0.9
+        version: 2.0.9(zod@4.4.3)
       '@ai-sdk/provider':
         specifier: 3.0.2
         version: 3.0.2
@@ -8385,6 +8388,12 @@ snapshots:
       '@ai-sdk/provider': 3.0.2
       '@ai-sdk/provider-utils': 4.0.5(zod@3.25.76)
       zod: 3.25.76
+
+  '@ai-sdk/openai-compatible@2.0.9(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.2
+      '@ai-sdk/provider-utils': 4.0.5(zod@4.4.3)
+      zod: 4.4.3
 
   '@ai-sdk/openai@3.0.9(zod@3.25.76)':
     dependencies:


### PR DESCRIPTION
## What

genbench can now run Wafer-served open-source models as contenders, plus two run controls.

- **Two new `--models` aliases** — `glm-fast` → `glm5.2-fast` and `deepseek-flash` → `DeepSeek-V4-Flash-0731-Fast`, through the stock `@ai-sdk/openai-compatible` provider against `https://pass.wafer.ai/v1`. Membership in `WAFER_MODEL_IDS` is what says an alias is not an Anthropic model, so the provider a column is built from and the key the run demands both read one map. `WAFER_API_KEY` is checked up front — a missing key ends the run before a browser opens, not at the first model call. `ANTHROPIC_API_KEY` stays required either way: the judge and the honesty check run on it whoever built the screen.
- **`--contenders`** — comma list validated against the `DRIVERS` keys (`vendo`, `diy`, `claude-code`), defaulting to all three. Measuring one harness no longer spends the other two's tokens on the same case.
- **`--jobs N`** (default 1) — a bound on how many CASES are in flight. Within a case the contenders already race via `Promise.all`; this is the bound across cases. Every case becomes a job first, so worlds are still read in one ordered pass and results keep the authored case order, never the finish order.
- **Pricing** — both models get rows in the meter's table, taken from Wafer's own `GET /v1/models` quote read 2026-08-16 (`$2.10/$6.60` and `$0.28/$0.56` per MTok). `usdFor` throws for a model it holds no price for, so a shipped alias without its row would end its own run at the first result.

## Why

The buy-vs-build question is not only "Vendo vs raw Claude" — it is also what the pipeline does on a cheap open-weights model. `--jobs` is what makes a 200-case corpus finishable, and `--contenders` is what keeps a one-harness measurement from costing three.

## Verification

Live one-case smoke, real Wafer inference, vendo contender only:

```
· vendo-glm-fast / spend-overview · floor 5/5 · judged 4/6 · 28841ms · $0.0555 · values 5/5
floor failures: 0 (exit 0)
```

`result.json` carries `modelVersion: glm5.2-fast` — the provider itself confirming which model answered — with 13,368 input / 3,461 output / 21,824 cache-read tokens over 4 calls, and a delivered `artifact.tsx` that rendered a real screen with two Kit charts. GLM-fast drove the whole tool loop with no compaction warnings, so the unknown-model context-window fallback needed no escape hatch.

The missing-key path was exercised too: `genbench: WAFER_API_KEY is not set, and it is what serves glm-fast`, exit 1, nothing spent.

Gates: `pnpm build`, `pnpm typecheck`, `pnpm lint` all green. `pnpm test:affected` is green apart from one pre-existing failure — `font.test.ts > says nothing at all for a world that ships no face` — which fails identically on unmodified `5baa81f14`.

`genbench/runs/` is gitignored, so the smoke artifacts stay local.

## Notes

- The `pool` bound was proven to fail: removing `Math.min(limit, jobs.length)` turns the in-flight peak from 2 into 7 and the test goes red.
- Shared state under `--jobs > 1` was checked rather than assumed: `visit()` opens its own page per case (`render.ts:237`), `writeCase` writes per-case directories, meters are per contender, the `claude-code` driver takes a fresh `mkdtemp`, and the vendo driver's store is keyed by case id. `worlds` and `results` are both populated outside the concurrent section.
- `--jobs > 1` is proven at the pool level and by inspection, but has not been exercised in a live multi-case run — the smallest world is 10 cases, and each case also spends judge and audit calls, which puts it past this change's approved spend.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs Wafer-served open-weight contenders (glm-fast, deepseek-flash) and adds `--contenders` and `--jobs` to control spend and runtime. Claude Code no longer runs on Wafer models; it only benchmarks Anthropic models to avoid misreported columns.

- Adds model aliases `glm-fast` → `glm5.2-fast` and `deepseek-flash` → `DeepSeek-V4-Flash-0731-Fast` via `@ai-sdk/openai-compatible` against https://pass.wafer.ai/v1; a single alias map selects the provider. Requires `ANTHROPIC_API_KEY` for judge/audit and checks `WAFER_API_KEY` up front when Wafer models are requested.
- Extends pricing with Wafer quotes; `usdFor` throws on unknown models to fail early if an alias lacks a price row.
- Introduces `--contenders vendo,diy,claude-code` (defaults to all) to choose which harnesses race each case, and `--jobs N` (default 1) to bound cases in flight while preserving case order. Automatically omits `claude-code` for Wafer aliases because that harness runs Anthropic’s engine and would misattribute results.
- Adds dependency `@ai-sdk/openai-compatible`.

**Rollout**
- Set `WAFER_API_KEY` to run `glm-fast` or `deepseek-flash`; without it, runs exit before opening a browser.
- Use `--contenders` to avoid spending on unused harnesses and `--jobs N` to tune throughput on large worlds.

<sup>Written for commit 5eca312c41af69bc5a1c6b65028ef4bfc4e1b3e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

