### PR TITLE
fix(vendo): wiring detection reads the unscoped vendoai alias (#1382)

### DIFF
--- a/.changeset/alias-wired-hosts-read-as-wired.md
+++ b/.changeset/alias-wired-hosts-read-as-wired.md
@@ -1,0 +1,10 @@
+---
+"@vendoai/vendo": patch
+---
+
+An alias-wired host reads as wired. The wiring scan's server marker knew only
+the scoped `@vendoai/vendo/server` spelling, so a host importing `createVendo`
+through the unscoped `vendoai` alias was diagnosed "not wired" (E-WIRE-001 /
+E-WIRE-007) by doctor and init alike — and a `VendoRoot` import from the alias
+dodged the E-WIRE-010 legacy warning the same way. Both markers now read both
+supported spellings, like the supabase preset marker before them.

--- a/packages/vendo/src/cli/framework.ts
+++ b/packages/vendo/src/cli/framework.ts
@@ -39,10 +39,12 @@ export const SURFACE_MARKERS: readonly string[] = [
 ];
 
 /** A `VendoRoot` named in an import from a Vendo package — the removed export
-    taken from the package, the one spelling that can no longer resolve. (The
-    specifier is not spelled out in prose here: the dependency guard reads a
-    literal one as a real cross-package import.) */
-const LEGACY_ROOT_IMPORT = /import\s*\{[^}]*\bVendoRoot\b[^}]*\}\s*from\s*["']@vendoai\//;
+    taken from the package, the one spelling that can no longer resolve. Both
+    the scoped packages and the unscoped `vendoai` alias count: the alias
+    re-exported VendoRoot too while it existed. (Specifiers are not spelled out
+    in prose here: the dependency guard reads a literal one as a real
+    cross-package import.) */
+const LEGACY_ROOT_IMPORT = /import\s*\{[^}]*\bVendoRoot\b[^}]*\}\s*from\s*["'](?:@vendoai\/|vendoai["'/])/;
 
 const SOURCE_FILE = /\.(?:[cm]?[jt]sx?)$/;
 const SOURCE_SCAN_MAX_FILES = 2_000;
@@ -88,6 +90,11 @@ export async function workspaceHostCandidates(root: string): Promise<string[]> {
     LEGACY_ROOT_IMPORT above). */
 export const SUPABASE_PRESET_IMPORT = /["'](?:@vendoai\/vendo|vendoai)\/auth\/supabase["']/;
 
+/** Both supported spellings of the server entry, for the same reason: an
+    alias-wired host (`createVendo` imported from the unscoped package's
+    /server) is WIRED, and reading it as bare misdiagnosed it E-WIRE-001/007. */
+const SERVER_ENTRY_IMPORT = /["'](?:@vendoai\/vendo|vendoai)\/server["']/;
+
 /** Whether any host source imports the Supabase auth preset. Import marker
     only, comments stripped: outside a known Vendo composition file a bare
     `supabase(` call is the host's OWN Supabase client, not the preset
@@ -115,7 +122,7 @@ export async function detectVendoWiring(root: string): Promise<VendoWiring> {
   for (const file of files) {
     const source = await readFile(file, "utf8").catch(() => "");
     const code = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
-    if (code.includes("@vendoai/vendo/server") && /\bcreateVendo\s*\(/.test(code)) server = true;
+    if (SERVER_ENTRY_IMPORT.test(code) && /\bcreateVendo\s*\(/.test(code)) server = true;
     if (code.includes("<VendoProvider")) provider = true;
     if (code.includes("<VendoRoot")) legacyTag = true;
     if (LEGACY_ROOT_IMPORT.test(code)) legacyImport = true;

--- a/packages/vendo/tests/cli/doctor.test.ts
+++ b/packages/vendo/tests/cli/doctor.test.ts
@@ -1849,6 +1849,47 @@ describe("vendo doctor error codes + fix_refs", () => {
     expect(report.checks.find((check) => check.id === "wiring/supabase-env")).toBeUndefined();
   });
 
+  // The unscoped vendoai alias ships the same wire, so wiring detection must
+  // read both spellings — #1374 fixed the supabase preset marker; these pin
+  // the server and legacy-root markers, which had the same blindness (an
+  // alias-wired host read as not wired at all). Alias specifiers assembled at
+  // runtime: an import-shaped literal here would read as a real cross-package
+  // import to the dependency guard.
+  it("reads an alias-wired Express server as wired, never E-WIRE-001", async () => {
+    const root = await expressHost(true);
+    const aliasServer = ["vendoai", "server"].join("/");
+    await writeFile(join(root, "src", "server.ts"),
+      `import { createVendo } from "${aliasServer}";\n` +
+      "createVendo({ models: { default: model }, principal });\n");
+    const { report } = await jsonChecks({ targetDir: root, fetchImpl: successfulProbeFetch(), env: {} });
+    expect(report.checks.find((check) => check.id === "wiring/express-server")).toMatchObject({ status: "ok" });
+  });
+
+  it("reads an alias-wired custom-runtime server as wired, never E-WIRE-007", async () => {
+    const root = await customHost(true);
+    const aliasServer = ["vendoai", "server"].join("/");
+    await writeFile(join(root, "src", "worker.ts"),
+      `import { createVendo } from "${aliasServer}";\n` +
+      "export const vendo = createVendo({ models: { default: model }, principal });\n");
+    const { report } = await jsonChecks({ targetDir: root, fetchImpl: successfulProbeFetch(), env: {} });
+    expect(report.checks.find((check) => check.id === "wiring/server")).toMatchObject({ status: "ok" });
+  });
+
+  it("flags a VendoRoot import from the alias as legacy, E-WIRE-010", async () => {
+    const root = await expressHost(true);
+    const aliasReact = ["vendoai", "react"].join("/");
+    // A provider is also mounted, so the tag-only fallback (legacyTag with no
+    // provider) cannot mask a miss in the import marker.
+    await writeFile(join(root, "src", "client.tsx"),
+      `import { VendoRoot } from "${aliasReact}";\n` +
+      "export const App = () => <VendoProvider><VendoRoot /><main /><VendoOverlay /></VendoProvider>;\n");
+    const { report } = await jsonChecks({ targetDir: root, fetchImpl: successfulProbeFetch(), env: {} });
+    expect(report.checks.find((check) => check.id === "wiring/vendo-root")).toMatchObject({
+      status: "warning",
+      error_code: "E-WIRE-010",
+    });
+  });
+
   // Visible-surface gate (0.4.1 E2E cert B3): green must mean a user can SEE
   // the agent — <VendoProvider> alone is a provider that renders nothing.
   it("fails E-WIRE-006 when nothing visible is mounted, and exits 1", async () => {


### PR DESCRIPTION
## What

Fixes #1382: `detectVendoWiring`'s two import-shaped markers only knew the scoped `@vendoai/vendo` spellings, so a host wired entirely through the unscoped `vendoai` alias (a fully supported spelling - the alias exports `./server`, and E-WIRE-011's own message says "both names ship the same wire") was misdiagnosed:

- **Server marker**: alias-wired Express hosts failed `E-WIRE-001`, custom-runtime hosts failed `E-WIRE-007` - both false. Init shares the scan, so its wiring verdicts were wrong for the same hosts.
- **Legacy-root marker**: a `VendoRoot` imported from the alias dodged the `E-WIRE-010` swap guidance whenever a `<VendoProvider>` was also mounted (the tag-only fallback requires the provider absent).

Both markers now read both supported spellings, completing the class that #1374 opened with `SUPABASE_PRESET_IMPORT` (greptile surfaced the alias spelling there; this is the same blindness one layer down). The client/surface markers are tag- and hook-based and were already alias-neutral - verified, not changed.

## How

One new `SERVER_ENTRY_IMPORT` regex beside `SUPABASE_PRESET_IMPORT`, and `LEGACY_ROOT_IMPORT` widened to the alias. Regexes rather than string literals, so the dependency guard never reads an import-shaped alias specifier out of `packages/vendo`; the new test fixtures assemble alias specifiers at runtime for the same reason.

## Tests

Three new doctor pins (alias-wired Express server passes, alias-wired custom-runtime server passes, alias `VendoRoot` import warns E-WIRE-010 with a provider present) - all failed before the fix, all pass after. Affected scopes green locally: doctor 119/120, init 114/115, onboarding-safety 17/19, typecheck clean - every red is the known pre-existing Windows env class (split-composition, symlink, monorepo-root interactive, models-line), each previously verified identical on pristine main; CI is the gate of record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)