### PR TITLE
feat(vendo): `vendo login` names the code it just replaced

### DIFF
--- a/.changeset/login-names-the-code-it-replaced.md
+++ b/.changeset/login-names-the-code-it-replaced.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/vendo": minor
+---
+
+`vendo login` names the dead code before it prints the new one, so a human holding a relayed code learns it stopped working instead of typing it into an error.

--- a/packages/vendo/src/cli/cloud/device-login.ts
+++ b/packages/vendo/src/cli/cloud/device-login.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { option } from "./args.js";
 import { isVendoKey, resolveCloudBaseUrl } from "./client.js";
 import { errorMessage, printJson } from "./output.js";
-import { deletePendingClaim, readPendingClaim, writePendingClaim } from "./pending-claim.js";
+import { deletePendingClaim, readPendingClaim, writePendingClaim, type PendingClaim } from "./pending-claim.js";
 import { writeCloudSession, type CloudSession } from "./session.js";
 import { ensureEnvLocalIgnored, upsertEnvLocal } from "../cloud-init.js";
 import { browserOpenCommand, CLI_VERSION, consoleOutput, withCommandRun, type Output, type TelemetryOptions } from "../shared.js";
@@ -92,6 +92,18 @@ export async function preflightEnvLocalWrite(root: string): Promise<string | nul
   } catch (error) {
     return error instanceof Error ? error.message : String(error);
   }
+}
+
+/**
+ * A dead claim was still on disk when a fresh ceremony opened, so whoever the
+ * last code was relayed to may still be holding it. Say the old code is gone
+ * before the new one prints: the published flow has the agent hand its code to
+ * a human through a chat relay, and a silently replaced code reaches that human
+ * as a bare "no open request matches that code" on the approval page.
+ */
+function noteStaleCode(pending: PendingClaim | null, now: number, output: Output): void {
+  if (pending === null || pending.expires_at > now) return;
+  output.log(`The earlier code ${pending.user_code} has expired and no longer works. Here is a new one.`);
 }
 
 interface Ceremony {
@@ -276,6 +288,7 @@ export async function runDeviceLogin(
 
       const approvalUrl = ceremony.verification_uri_complete ?? ceremony.verification_uri;
       const tty = options.isTty ?? (process.stdout.isTTY === true);
+      noteStaleCode(pending, now(), output);
       if (options.pretty === true) {
         if (tty) {
           // One line. The browser is already opening, so the code IS the whole

--- a/packages/vendo/tests/cli/cloud/device-login.test.ts
+++ b/packages/vendo/tests/cli/cloud/device-login.test.ts
@@ -645,6 +645,48 @@ describe("pending claim persistence", () => {
     expect(new URLSearchParams(requests[1]!.body).get("claim_token")).toBe(CEREMONY.claim_token);
   });
 
+  it("says the expired code is dead before printing its replacement", async () => {
+    const home = await tempRoot();
+    const root = await tempRoot();
+    await writePending(home, root, { expires_at: Date.now() - 1_000 });
+    const { fetchImpl } = scriptedFetch([
+      { status: 200, body: { access_token: KEY, token_type: "Bearer" } },
+    ]);
+    const messages = output();
+    const exit = await runDeviceLogin(["--api-url", "https://console.test"], {
+      output: messages.sink,
+      fetchImpl,
+      root,
+      home,
+      sleep: async () => {},
+      env: {},
+      isTty: false,
+    });
+    expect(exit).toBe(0);
+    const logs = messages.logs.join("\n");
+    // The relay human may still be holding WXYZ-PQRS: naming it as dead is the
+    // whole point, and it has to land before the new code is printed.
+    expect(logs).toContain("The earlier code WXYZ-PQRS has expired and no longer works. Here is a new one.");
+    expect(logs.indexOf("WXYZ-PQRS")).toBeLessThan(logs.indexOf(CEREMONY.user_code));
+  });
+
+  it("says nothing about an earlier code when there was none", async () => {
+    const { fetchImpl } = scriptedFetch([
+      { status: 200, body: { access_token: KEY, token_type: "Bearer" } },
+    ]);
+    const messages = output();
+    await runDeviceLogin(["--api-url", "https://console.test"], {
+      output: messages.sink,
+      fetchImpl,
+      root: await tempRoot(),
+      home: await tempRoot(),
+      sleep: async () => {},
+      env: {},
+      isTty: false,
+    });
+    expect(messages.logs.join("\n")).not.toContain("The earlier code");
+  });
+
   it("removes the pending claim when the human denies the request", async () => {
     const home = await tempRoot();
     const root = await tempRoot();


### PR DESCRIPTION
## The failure that motivated this

A worker walked the real Vendo install as a coding agent would, following the published playbook. That playbook's whole design is that the agent relays Vendo's device-login code to a human in chat. Four codes were minted; **three expired unapproved** before the human could act.

Worse, when a claim lapsed, the next `vendo login` minted a brand new code and said nothing about the old one. In a relay chain that means a human types a code that died minutes ago and gets a bare "no open request matches that code" on the approval page, with no explanation. Only the worker's own bookkeeping caught it.

## The change

One line, printed only when a claim was on disk for this project and is too old to resume, and only when a fresh code is actually minted:

```
The earlier code WXYZ-PQRS has expired and no longer works. Here is a new one.
```

It reads the pending-claim file that is already there (#479). No flag, no config, no new bookkeeping, no change to the login flow.

`noteStaleCode` is its own function rather than an inline branch because `runDeviceLogin` sits exactly at the repo's cognitive-complexity ceiling: every inline shape I tried (an `if`, a hoisted ternary, both at two nesting depths) pushed it to 52 or 53 against the 50 allowed. An unconditional call adds nothing to the caller's score, and module-level helpers are already this file's shape.

## Test

`tests/cli/cloud/device-login.test.ts` gains two cases: the notice lands and lands *before* the replacement code prints, and no such line appears when there was no earlier claim. Proven red before the source change: `expected 'Vendo Cloud device login — ask your h…' to contain 'The earlier code WXYZ-PQRS has expire…'`.

## Gates

- `packages/vendo` `tests/cli/` — 56 files, 1020 tests, all pass (4 files failed on a first run against an unbuilt `@vendoai/vendo`; green in isolation after `pnpm --filter @vendoai/vendo build`, and green in the full re-run)
- `pnpm --filter @vendoai/vendo typecheck` — clean
- `dependency-guard`, `portability-gate`, and the blocking eslint config over `src/cli/cloud` and `tests/cli/cloud` — clean

## The case this does not cover

When the CLI polls *through* the expiry itself, the `expired_token` branch deletes the pending-claim file (`packages/vendo/src/cli/cloud/device-login.ts:430`), so the next run has no on-disk state to warn from. That is the exact 8-to-9 transition in the captured evidence. Covering it means keeping a dead claim token on disk, and the `expired_token` delete also guards a real resume trap under clock skew, so it is left alone here and flagged rather than resolved quietly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Names the expired device-login code that `vendo login` just replaced so a human relaying the code knows it no longer works. Previously, expired claims were replaced silently; now the CLI logs that the prior code expired before printing the new code.

**Review notes**
- Logs the notice only when an on-disk pending claim exists and is past its expiry; no flags, config, or flow changes. The message prints before the new code.
- Adds tests to assert the notice order and absence when no prior claim.
- Introduces a small `noteStaleCode` helper to keep `runDeviceLogin` within the complexity gate; functional behavior lives at the call site.
- Known gap: when the CLI polls through expiry and deletes the pending claim, no notice can be emitted; left unchanged.
- Publishes a minor for `@vendoai/vendo`.

<sup>Written for commit 52a3a33df726786d3dbb832131af9f7c07d01575. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

