### PR TITLE
feat(actions,vendo,apps): a tool that goes off says who took it

### DIFF
--- a/.changeset/a-tool-that-goes-off-says-who-took-it.md
+++ b/.changeset/a-tool-that-goes-off-says-who-took-it.md
@@ -1,0 +1,13 @@
+---
+"@vendoai/actions": minor
+"@vendoai/apps": minor
+"@vendoai/vendo": minor
+---
+
+A host tool that is off says so, and a screen with nothing to read says that instead of inventing a tool.
+
+An extracted tool can be turned off by three different layers, and until now only the all-or-nothing case was ever announced: `warnZeroLiveTools` fired when EVERY tool was dead, doctor passed on any `live > 0`, and the init receipt never mentioned it. So a catalog that shipped 5 tools and served 2 read healthy from every angle, and the missing three were discovered by watching the assistant fail to answer.
+
+Now the count and the reason travel together. Boot warns once naming each tool that is off and the layer that took it (an override, a judgment, or a non-end-user audience grade). `vendo doctor` warns `E-TOOLS-005` with the same list when live is short of the extracted count — a warning, not a failure, because which exclusions are right is the host's call. The `vendo init` agent tail carries a `tools off:` line with the same names and the one edit that turns a tool back on.
+
+The generator stops filling that silence with fiction. When no tool on the list can be READ, the briefing says so outright, and a screen that queries an unknown tool with nothing readable behind it is told there is no data for the ask, to use `<Disclaimer>`, and specifically not to claim data is missing or empty when it cannot know. The failure this closes: a model invented a tool name, failed five times, then rendered "No revenue data connected" above a table of that exact data.

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -188,7 +188,8 @@
                   "production/troubleshooting/e-tools-001",
                   "production/troubleshooting/e-tools-002",
                   "production/troubleshooting/e-tools-003",
-                  "production/troubleshooting/e-tools-004"
+                  "production/troubleshooting/e-tools-004",
+                  "production/troubleshooting/e-tools-005"
                 ]
               }
             ]

--- a/docs-site/production/troubleshooting/e-tools-005.mdx
+++ b/docs-site/production/troubleshooting/e-tools-005.mdx
@@ -1,0 +1,80 @@
+---
+title: "E-TOOLS-005"
+sidebarTitle: "E-TOOLS-005"
+description: "Some extracted host tools are off, so the agent will never offer them."
+---
+
+# E-TOOLS-005
+
+<Warning>
+**what doctor prints** (warning)
+
+2 of 5 extracted host tools are live; the agent will never offer the other 3:
+host_customers_list (graded audience "operator", and only end-user tools are on
+by default), host_admin_purge (turned off in .vendo/overrides.json); To turn one
+back on, set its "disabled": false in .vendo/overrides.json
+</Warning>
+
+Your catalog extracted more tools than the agent can actually use. Nothing is
+broken. This names the gap so you decide, instead of finding out later when the
+assistant cannot answer a question and will not say why.
+
+`check tools/live-surface` · `error_code E-TOOLS-005` · `doctor exits 0` (warning only)
+
+## What you're seeing
+
+A host tool's final state is three layers stacked in order: the extracted
+skeleton in `.vendo/tools.json`, then the AI judge's call in
+`.vendo/judgments.json`, then your own `.vendo/overrides.json`, which wins last.
+
+Doctor compares the number of tools that survive that stack against the number
+in `tools.json`. When they differ, it names each missing tool and the layer that
+turned it off.
+
+## Why a tool is off
+
+**Graded for operators or staff.** The judge decides who a tool is for. A tool
+graded `operator` or `internal` is switched off for the embedded agent by
+default. This is deliberate and fail-closed. An endpoint that returns your whole
+customer book with revenue is not something an end user's assistant should read,
+so Vendo hides it unless you say otherwise.
+
+**Turned off in `judgments.json`.** The judge read the handler and disabled the
+tool outright.
+
+**Turned off in `overrides.json`.** You did this. Nothing to explain.
+
+## The fix
+
+Usually there is nothing to fix. A staff tool staying hidden is the system
+working.
+
+If you have looked at a tool and you want the agent to have it, say so
+explicitly in `.vendo/overrides.json`. Your file is the last word, so this beats
+both the grade and the judge:
+
+```json
+{
+  "format": "vendo/overrides@3",
+  "tools": {
+    "host_customers_list": { "disabled": false }
+  }
+}
+```
+
+Enablement resolves once at boot, so restart the app after the edit.
+
+Before you turn one on, check what it actually returns. The reason most staff
+tools are graded that way is that they return every record rather than the
+signed-in user's own. If that is the case here, scope the endpoint per user
+first and re-run `vendo sync`. Then the judge can grade it for end users
+honestly, and you will not need an override at all.
+
+## Related errors
+
+<CardGroup cols={2}>
+  <Card title="E-TOOLS-001" href="/production/troubleshooting/e-tools-001">every tool disabled</Card>
+  <Card title="E-TOOLS-002" href="/production/troubleshooting/e-tools-002">tool surface is empty</Card>
+  <Card title="E-TOOLS-003" href="/production/troubleshooting/e-tools-003">tools ungraded</Card>
+  <Card title="E-TOOLS-004" href="/production/troubleshooting/e-tools-004">tools declare no shape</Card>
+</CardGroup>

--- a/packages/actions/src/judgments.ts
+++ b/packages/actions/src/judgments.ts
@@ -142,6 +142,28 @@ export function applyJudgment(tool: ExtractedTool, judgment: ToolJudgment | unde
 }
 
 /**
+ * Why one host tool is off, named for the layer that turned it off, or
+ * undefined when it is live. The human's override wins the merge, so it is
+ * checked first; an audience grade is the fail-closed exclusion `applyJudgment`
+ * adds above, and it is the only reason no file states outright — which is
+ * exactly how a graded tool used to vanish in silence.
+ */
+export function disabledReason(
+  tool: ExtractedTool,
+  judgment: ToolJudgment | undefined,
+  override: { disabled?: boolean } | undefined,
+): string | undefined {
+  const judged = applyJudgment(tool, judgment);
+  if ((override?.disabled ?? judged.disabled ?? false) !== true) return undefined;
+  if (override?.disabled === true) return "turned off in .vendo/overrides.json";
+  if (judgment?.fields.disabled === true) return "turned off in .vendo/judgments.json";
+  if (judged.audience !== undefined && judged.audience !== "end-user") {
+    return `graded audience "${judged.audience}", and only end-user tools are on by default`;
+  }
+  return "turned off in .vendo/tools.json";
+}
+
+/**
  * Drop judgments that no longer describe anything: a name the current catalog
  * does not carry, or one whose binding moved. Keeps the file honest instead of
  * accumulating inert entries a human would have to read past.

--- a/packages/actions/src/judgments.ts
+++ b/packages/actions/src/judgments.ts
@@ -156,7 +156,12 @@ export function disabledReason(
   const judged = applyJudgment(tool, judgment);
   if ((override?.disabled ?? judged.disabled ?? false) !== true) return undefined;
   if (override?.disabled === true) return "turned off in .vendo/overrides.json";
-  if (judgment?.fields.disabled === true) return "turned off in .vendo/judgments.json";
+  // Binding-checked exactly as `applyJudgment` checks it: a judgment of a
+  // handler that moved is inert, so naming it would send the developer to edit
+  // the one file that did not turn this tool off.
+  if (judgment?.fields.disabled === true && judgment.binding === bindingIdentity(tool.binding)) {
+    return "turned off in .vendo/judgments.json";
+  }
   if (judged.audience !== undefined && judged.audience !== "end-user") {
     return `graded audience "${judged.audience}", and only end-user tools are on by default`;
   }

--- a/packages/actions/src/runtime/registry.ts
+++ b/packages/actions/src/runtime/registry.ts
@@ -34,7 +34,7 @@ import {
   type ToolOverride,
   type TrpcBinding,
 } from "../formats.js";
-import { applyJudgment } from "../judgments.js";
+import { applyJudgment, disabledReason } from "../judgments.js";
 import { createCompoundExecutor, validateCapabilities, type PrimitiveStepTarget } from "./compound.js";
 import { error, isArgsObject } from "./outcome.js";
 import { searchToolDescriptors, type ToolSearchMatch, type ToolSearchOptions } from "./search.js";
@@ -764,19 +764,30 @@ export function createActions(config: RegistryConfig): ActionsRegistry {
   // The product's core promise, warned at the seam that knows: an agent with
   // zero live host tools serves users it cannot help (field case: an
   // extraction stripped to tools: [] shipped a silently useless agent).
+  // PARTIAL loss is the same failure at a quieter volume — a catalog that keeps
+  // 2 of 5 reads healthy everywhere else, so the tools it lost are named here
+  // with the layer that took them (field case: an `operator` grade took 3).
   /** One warning per surface per boot, however often the menu is resolved. */
   const surfaceMenuWarned = new Set<string>();
-  let zeroLiveWarned = false;
-  const warnZeroLiveTools = (host: LoadedHost): LoadedHost => {
-    if (zeroLiveWarned) return host;
-    const live = host.tools.filter((tool) => effectiveHostTool(host, tool).disabled !== true);
-    if (live.length === 0) {
-      zeroLiveWarned = true;
+  let hostToolsWarned = false;
+  const warnHostToolSurface = (host: LoadedHost): LoadedHost => {
+    if (hostToolsWarned) return host;
+    hostToolsWarned = true;
+    const off = host.tools.flatMap((tool) => {
+      const reason = disabledReason(tool, host.judgments?.tools[tool.name], host.overrides.tools[tool.name]);
+      return reason === undefined ? [] : [`${tool.name} (${reason})`];
+    });
+    if (off.length === host.tools.length) {
       console.warn(
         "[vendo] zero live host tools — every extracted tool is absent, disabled, or excluded, so the agent cannot "
         + "act on this product's API. Review .vendo/tools.json, the judgments in .vendo/judgments.json, and the "
         + "audience exclusions in .vendo/overrides.json, or re-run `vendo init` extraction. (Connector-only "
         + "deployments can ignore this.)",
+      );
+    } else if (off.length > 0) {
+      console.warn(
+        `[vendo] ${off.length} of ${host.tools.length} extracted host tools are off, so the agent will never offer `
+        + `them: ${off.join(", ")}. To turn one back on, set its "disabled": false in .vendo/overrides.json.`,
       );
     }
     return host;
@@ -844,7 +855,7 @@ export function createActions(config: RegistryConfig): ActionsRegistry {
         briefs: overrides.briefs ?? [],
       };
     })();
-    return hostPromise.then(warnZeroLiveTools);
+    return hostPromise.then(warnHostToolSurface);
   }
 
   /** Memoized per source. A REJECTION is never memoized: a transient schema

--- a/packages/actions/tests/judgments.test.ts
+++ b/packages/actions/tests/judgments.test.ts
@@ -6,6 +6,7 @@ import {
   RISK_RANK,
   applyJudgment,
   classifyField,
+  disabledReason,
   pruneJudgments,
   splitProposal,
   type JudgmentProposal,
@@ -187,6 +188,19 @@ describe("applyJudgment", () => {
   it("does not re-compose disabled when it is already true", () => {
     const applied = applyJudgment(tool({ disabled: true }), judgment({ fields: { audience: "operator" } }));
     expect(applied.disabled).toBe(true);
+  });
+});
+
+describe("disabledReason", () => {
+  // A judgment of a handler that moved is INERT in the merge, so crediting it
+  // sends the developer to edit the one file that did NOT turn the tool off.
+  it("never credits a stale judgment — the binding is checked as applyJudgment checks it", () => {
+    const moved = tool({
+      binding: { kind: "route", method: "POST", path: "/api/invoices", argsIn: "body" },
+      disabled: true,
+    });
+    expect(disabledReason(moved, judgment({ fields: { disabled: true } }), undefined))
+      .toBe("turned off in .vendo/tools.json");
   });
 });
 

--- a/packages/actions/tests/runtime/registry-judgments.test.ts
+++ b/packages/actions/tests/runtime/registry-judgments.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { bindingIdentity } from "../../src/binding-identity.js";
+import { disabledReason } from "../../src/judgments.js";
 import {
   VENDO_JUDGMENTS_FORMAT,
   VENDO_OVERRIDES_FORMAT,
@@ -194,6 +195,61 @@ describe("judgments.json load posture", () => {
     await expect(actionsFor(root).descriptors()).rejects.toMatchObject({
       message: expect.stringContaining("judgments.json"),
     });
+  });
+});
+
+/**
+ * The seam the zero-live warning does not cover: a catalog that loses SOME of
+ * its tools. Every other vantage point reads healthy (doctor passes on any
+ * live > 0, the agent simply never offers the tool), so the count and the
+ * reason have to come out of the same merge the runtime actually performs.
+ * Field case: an `operator` grade took 3 of 5 host tools in silence.
+ */
+describe("partial host-tool loss is named at boot", () => {
+  const tool = (name: string, path: string): ExtractedTool =>
+    routeTool({ name, binding: { kind: "route", method: "GET", path, argsIn: "query" } });
+
+  it("offers exactly what the merge left live, and names every tool it did not", async () => {
+    const plain = tool(HOST, "/api/invoices");
+    const graded = tool("host_customers_list", "/api/customers");
+    const explicit = tool("host_admin_purge", "/api/admin/purge");
+    const written = [plain, graded, explicit];
+    const judgments = {
+      [graded.name]: judgment({ binding: bindingIdentity(graded.binding), fields: { audience: "operator" } }),
+    };
+    const overrides: Record<string, { disabled: boolean }> = { [explicit.name]: { disabled: true } };
+    const root = await tempVendo({
+      tools: toolsFile(written),
+      judgments: judgmentsFile(judgments),
+      overrides: overridesFile(overrides),
+    });
+
+    const warned: string[] = [];
+    const spy = vi.spyOn(console, "warn").mockImplementation((message: unknown) => { warned.push(String(message)); });
+    let live: string[];
+    try {
+      const actions = actionsFor(root);
+      live = (await actions.descriptors()).map((descriptor) => descriptor.name);
+      await actions.descriptors();
+    } finally {
+      spy.mockRestore();
+    }
+
+    // The oracle is the merge itself, never a hard-coded list: whatever
+    // `applyJudgment` decides about a grade, the registry has to agree with it
+    // and the boot line has to say it. The two sides cannot drift apart here.
+    const reasons = new Map(written.map((tool) =>
+      [tool.name, disabledReason(tool, judgments[tool.name], overrides[tool.name])]));
+    const lines = warned.filter((message) => message.includes("host tools are off"));
+    expect(lines).toHaveLength(1);
+    // Nothing vanishes quietly: what is live plus what was named IS the file.
+    expect(live).toEqual(written.map((tool) => tool.name).filter((name) => reasons.get(name) === undefined));
+    for (const [name, reason] of reasons) {
+      if (reason !== undefined) expect(lines[0]).toContain(`${name} (${reason})`);
+    }
+    // An explicit disable is off under every reading of the catalog.
+    expect(live).not.toContain(explicit.name);
+    expect(live).toContain(plain.name);
   });
 });
 

--- a/packages/apps/src/server/checking/component-screen.ts
+++ b/packages/apps/src/server/checking/component-screen.ts
@@ -481,7 +481,12 @@ const scanQuery = (
   }
   const tool = context.byName.get(literal);
   if (tool === undefined) {
-    context.issues.push(issue("query-tool", `${QUERY_HOOK}("${literal}") names unknown tool "${literal}"; the host tools are: ${list(context.known)}`));
+    // The no-readable-tool case has to be said outright. A model refused with a
+    // list it cannot use invents a near-miss name, and after enough refusals it
+    // ships a screen that ASSERTS the data is missing above data it made up.
+    context.issues.push(issue("query-tool", context.readable.length === 0
+      ? `${QUERY_HOOK}("${literal}") names unknown tool "${literal}", and this product has NO tool a screen can read. There is no data behind this ask. Do not invent a tool name, and do not claim the data is missing or empty, which you cannot know: drop the query and use <Disclaimer> to say plainly that no tool provides this data.`
+      : `${QUERY_HOOK}("${literal}") names unknown tool "${literal}"; the host tools are: ${list(context.known)}`));
     return;
   }
   if (isMutatingTool(tool)) {

--- a/packages/apps/src/server/doors/build-surface.ts
+++ b/packages/apps/src/server/doors/build-surface.ts
@@ -563,6 +563,14 @@ export const createBuildSurface = (
           ? `- ${name} — ${UNKNOWN_OUTPUT_SHAPE_NOTE}`
           : `- ${name} — shape: ${describeShapeWithSemantics(shape, semantics[name] ?? {})}`;
       });
+      // A product with tools but no READ tool has no data a screen can show,
+      // and nothing else in the prompt says so. That silence is where a model
+      // invents a tool name instead of admitting there is none for the ask.
+      if (!tools.some(({ risk }) => risk !== "write" && risk !== "destructive")) {
+        cards.push("- Nothing on this list can be READ, so a screen has no data to show from this product."
+          + " If the person asks for data, use <Disclaimer> to say no tool provides it."
+          + " Never name a tool that is not on this list, and never claim the data is empty or missing, which you cannot know.");
+      }
       return `${header}\n${cards.join("\n")}`;
     },
 

--- a/packages/apps/tests/checking/component-screen.test.ts
+++ b/packages/apps/tests/checking/component-screen.test.ts
@@ -400,6 +400,27 @@ export default function S() { return <Text text={String(useQuery("ghost_list"))}
     expect(text).toContain("the host tools are: list_pending_transfers, list_accounts, search_transfers, cancel_transfer");
   });
 
+  it("tells a screen with NO readable tool to say so, instead of listing tools it cannot read", async () => {
+    // The field failure this closes: refused with a list of write-only tools,
+    // the model invented a plausible read tool, failed five times, then shipped
+    // a screen asserting there was no data above a table of that same data.
+    const result = await checkComponentScreen({
+      source: `import { Text, useQuery } from "@vendo/screen";
+export default function S() { return <Text text={String(useQuery("invoices_list"))} />; }
+`,
+      hostTools: tools.filter(({ risk }) => risk !== "read"),
+      catalog,
+      runQuery: async () => ROWS,
+    });
+    if (result.ok) throw new Error("expected the gauntlet to refuse this screen");
+    const text = result.issues.map(({ message }) => message).join("\n");
+    expect(text).toContain("this product has NO tool a screen can read");
+    expect(text).toContain("do not claim the data is missing or empty, which you cannot know");
+    expect(text).toContain("<Disclaimer>");
+    // The tools it CANNOT read are not offered as if they were an answer.
+    expect(text).not.toContain("cancel_transfer");
+  });
+
   it("refuses a query that WRITES, because a query runs on every render", async () => {
     const { codes, text } = await refusal(`import { Text, useQuery } from "@vendo/screen";
 export default function S() { return <Text text={String(useQuery("cancel_transfer"))} />; }

--- a/packages/apps/tests/tool-shapes.test.ts
+++ b/packages/apps/tests/tool-shapes.test.ts
@@ -107,6 +107,32 @@ describe("declared output schemas produce the shape cards", () => {
     expect(brief).toContain(UNKNOWN_OUTPUT_SHAPE_NOTE);
   });
 
+  it("says outright when nothing on the list can be READ, so a screen has no data to show", async () => {
+    // Tools exist, but none of them reads. Nothing else in the prompt says so,
+    // and that silence is where a model invents a tool name for the ask.
+    const tools = new FixtureTools([{
+      name: "host_voice_create",
+      description: "POST /api/voice",
+      risk: "write",
+      inputSchema: { type: "object", properties: {}, additionalProperties: true },
+    }]);
+    const brief = await runtimeWith(tools).toolShapeBrief(ctx);
+
+    expect(brief).toContain("Nothing on this list can be READ");
+    expect(brief).toContain("<Disclaimer>");
+    expect(brief).toContain("never claim the data is empty or missing, which you cannot know");
+  });
+
+  it("stays quiet about the read case when a read tool is on the list", async () => {
+    const tools = new FixtureTools([{
+      name: "host_listItems",
+      description: "List items",
+      risk: "read",
+      inputSchema: { type: "object", properties: {} },
+    }]);
+    expect(await runtimeWith(tools).toolShapeBrief(ctx)).not.toContain("Nothing on this list can be READ");
+  });
+
   it("returns a section even when the product has no tools at all", async () => {
     const brief = await runtimeWith(new FixtureTools([])).toolShapeBrief(ctx);
     expect(typeof brief).toBe("string");

--- a/packages/vendo/src/cli/doctor-codes.ts
+++ b/packages/vendo/src/cli/doctor-codes.ts
@@ -76,6 +76,7 @@ export const DOCTOR_ERROR_CODES = {
   "E-TOOLS-002": "the extracted tool surface is empty (zero host tools)",
   "E-TOOLS-003": "part of the tool catalog is ungraded (nobody has graded it, so it asks on every call)",
   "E-TOOLS-004": "part of the tool catalog declares no request/response shape (the agent must pass whole outputs through / cannot know the arguments)",
+  "E-TOOLS-005": "some extracted host tools are off, so the agent will never offer them (an audience grade or an explicit disable took them)",
 } as const;
 
 export type DoctorErrorCode = keyof typeof DOCTOR_ERROR_CODES;

--- a/packages/vendo/src/cli/doctor-config-checks.ts
+++ b/packages/vendo/src/cli/doctor-config-checks.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, relative, sep } from "node:path";
-import { applyJudgment, judgmentsFileSchema, overridesFileSchema, toolsFileSchema, type ExtractedTool, type ToolJudgment, type ToolsFile } from "@vendoai/actions";
+import { applyJudgment, disabledReason, judgmentsFileSchema, overridesFileSchema, toolsFileSchema, type ExtractedTool, type ToolJudgment, type ToolsFile } from "@vendoai/actions";
 import { firstOpenApiSpec, openApiMountPath } from "@vendoai/actions/sync";
 import { publicBase, type RiskLabel } from "@vendoai/core";
 import { CONFIG_SURFACES, OVERRIDES_ENABLEMENT_NOTE } from "../config-surface.js";
@@ -156,10 +156,12 @@ function effectiveGrades(
   toolsFile: ToolsFile,
   judgments: Record<string, ToolJudgment>,
   overridesTools: Record<string, { disabled?: boolean; risk?: RiskLabel }>,
-): { live: number; ungraded: number } {
-  const live = toolsFile.tools.filter((tool) => {
-    const effective = applyJudgment(tool, judgments[tool.name]);
-    return (overridesTools[tool.name]?.disabled ?? effective.disabled ?? false) !== true;
+): { live: number; ungraded: number; off: string[] } {
+  // Named, not just counted: `live > 0` passed while three of five tools were
+  // gone, and nothing anywhere said which three or who took them.
+  const off = toolsFile.tools.flatMap((tool) => {
+    const reason = disabledReason(tool, judgments[tool.name], overridesTools[tool.name]);
+    return reason === undefined ? [] : [`${tool.name} (${reason})`];
   });
   // Risk-grading redesign D4 — not-knowing must be FELT. Extraction only
   // asserts protocol facts, so a catalog nobody has judged is mostly
@@ -170,7 +172,7 @@ function effectiveGrades(
     const effective = applyJudgment(tool, judgments[tool.name]);
     return (overridesTools[tool.name]?.risk ?? effective.risk) === "ungraded";
   });
-  return { live: live.length, ungraded: ungraded.length };
+  return { live: toolsFile.tools.length - off.length, ungraded: ungraded.length, off };
 }
 
 /** Malformed overrides are their own (pre-existing) failure surface, and
@@ -230,11 +232,13 @@ export async function checkToolCatalog(run: DoctorRun): Promise<void> {
       overridesRaw, (value) => overridesFileSchema.parse(value).tools, {});
     const judgments = parseSidecar<Record<string, ToolJudgment>>(
       judgmentsRaw, (value) => judgmentsFileSchema.parse(value).tools, {});
-    const { live, ungraded } = effectiveGrades(toolsFile, judgments, overridesTools);
+    const { live, ungraded, off } = effectiveGrades(toolsFile, judgments, overridesTools);
     if (toolsFile.tools.length === 0) {
       run.warn("tools/live-surface", "E-TOOLS-002", "the extracted tool surface is empty — the agent cannot act on this product's API; re-run `vendo init` extraction (or ignore if this deployment is connector-only)");
     } else if (live === 0) {
       run.fail("tools/live-surface", "E-TOOLS-001", `zero live host tools — all ${toolsFile.tools.length} extracted tools are disabled or excluded; review the audience exclusions in .vendo/overrides.json and re-enable the end-user surface (disabled: false)`);
+    } else if (off.length > 0) {
+      run.warn("tools/live-surface", "E-TOOLS-005", `${live} of ${toolsFile.tools.length} extracted host tools are live; the agent will never offer the other ${off.length}: ${off.join(", ")}. To turn one back on, set its "disabled": false in .vendo/overrides.json`);
     } else {
       run.pass("tools/live-surface", `${live} live host tool${live === 1 ? "" : "s"}`);
     }

--- a/packages/vendo/src/cli/init-scaffolds.ts
+++ b/packages/vendo/src/cli/init-scaffolds.ts
@@ -1,5 +1,5 @@
 import { join, relative, sep } from "node:path";
-import { applyJudgment, judgmentsFileSchema, overridesFileSchema } from "@vendoai/actions";
+import { applyJudgment, disabledReason, judgmentsFileSchema, overridesFileSchema, toolsFileSchema } from "@vendoai/actions";
 import {
   extractServerActions,
   serverActionRegistrations,
@@ -189,6 +189,28 @@ export async function requiredServerActions(root: string): Promise<ServerActionR
   } catch {
     return [];
   }
+}
+
+/**
+ * Host tools this run extracted and then left off WITHOUT being asked to, each
+ * with the layer that turned it off. The run that wrote them has to name them,
+ * or the developer meets the hole later, as an assistant that cannot answer and
+ * will not say why. Whatever the merge decided is what this reports.
+ *
+ * A tool the human disabled in overrides.json is left out: that decision is
+ * theirs and already written down, so repeating it back on every run is the nag
+ * the receipt has always refused to be.
+ */
+export async function disabledTools(root: string): Promise<string[]> {
+  const vendoDir = join(root, ".vendo");
+  const tools = await readVendoFile(join(vendoDir, "tools.json"), (value) => toolsFileSchema.parse(value).tools);
+  const overrides = await readVendoFile(join(vendoDir, "overrides.json"), (value) => overridesFileSchema.parse(value).tools);
+  const judgments = await readVendoFile(join(vendoDir, "judgments.json"), (value) => judgmentsFileSchema.parse(value).tools);
+  return (tools ?? []).flatMap((tool) => {
+    if (overrides?.[tool.name]?.disabled === true) return [];
+    const reason = disabledReason(tool, judgments?.[tool.name], overrides?.[tool.name]);
+    return reason === undefined ? [] : [`${tool.name} (${reason})`];
+  });
 }
 
 /** A `.vendo/` file, or null when absent or malformed — both mean "no recorded

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -27,6 +27,7 @@ import {
 import { aiBelowPeerFloor, ensureProviderDeps, ensureVendoPackage, ensureZodFloor, type InstallRunner } from "./provider-deps.js";
 import {
   customServerSource,
+  disabledTools,
   expressServerSource,
   importsGeneratedMap,
   missingRegistrationLines,
@@ -654,6 +655,10 @@ async function agentTailLines(args: {
   }
   for (const edit of args.edits) {
     lines.push(`edit ${edit.file} — apply the change printed above yourself (it already exists, so init did not write it)`);
+  }
+  const off = await disabledTools(args.root);
+  if (off.length > 0) {
+    lines.push(`tools off: ${off.join(", ")}. The assistant will never offer these. To turn one on, set "disabled": false under its name in ${join(".vendo", "overrides.json")}`);
   }
   if (await readOptional(join(args.root, ".vendo", "brief.md")) === BRIEF_PLACEHOLDER) {
     lines.push(`edit ${join(".vendo", "brief.md")} — replace the placeholder with what this product does and for whom`);

--- a/packages/vendo/tests/cli/doctor-codes.test.ts
+++ b/packages/vendo/tests/cli/doctor-codes.test.ts
@@ -61,6 +61,7 @@ describe("doctor error-code registry", () => {
         "E-TOOLS-002": "the extracted tool surface is empty (zero host tools)",
         "E-TOOLS-003": "part of the tool catalog is ungraded (nobody has graded it, so it asks on every call)",
         "E-TOOLS-004": "part of the tool catalog declares no request/response shape (the agent must pass whole outputs through / cannot know the arguments)",
+        "E-TOOLS-005": "some extracted host tools are off, so the agent will never offer them (an audience grade or an explicit disable took them)",
         "E-TURN-001": "RETIRED — doctor no longer runs a model turn",
         "E-TURN-002": "RETIRED — doctor no longer runs a model turn",
         "E-UI-001": "an ejected surface predates the installed @vendoai/ui",

--- a/packages/vendo/tests/cli/doctor.test.ts
+++ b/packages/vendo/tests/cli/doctor.test.ts
@@ -659,6 +659,32 @@ describe("vendo doctor error codes + fix_refs", () => {
       .toMatchObject({ status: "ok", message: "catalog: inputs 1/1 · outputs 1/1" });
   });
 
+  it("warns E-TOOLS-005 naming each tool the merge left off, and keeps the exit green", async () => {
+    // `live > 0` passed while 3 of 5 tools were gone: the count was the whole
+    // report, so a catalog that lost most of itself read as healthy.
+    const root = await healthy();
+    const tool = (name: string, path: string) => ({
+      name, description: "d", inputSchema: { type: "object" }, risk: "read" as const,
+      inputSchemaSource: "declared", outputSchemaSource: "declared",
+      binding: { kind: "route" as const, method: "GET" as const, path, argsIn: "query" as const },
+    });
+    await writeFile(join(root, ".vendo", "tools.json"), JSON.stringify({
+      format: "vendo/tools@3",
+      tools: [tool("host_invoices_list", "/api/invoices"), tool("host_customers_list", "/api/customers")],
+    }));
+    await writeFile(join(root, ".vendo", "overrides.json"), JSON.stringify({
+      format: "vendo/overrides@3",
+      tools: { host_customers_list: { disabled: true } },
+    }));
+    const { exit, report } = await jsonChecks({ targetDir: root });
+    const check = report.checks.find((entry) => entry.id === "tools/live-surface");
+    expect(check).toMatchObject({ status: "warning", error_code: "E-TOOLS-005" });
+    expect(check?.message).toContain("1 of 2 extracted host tools are live");
+    expect(check?.message).toContain("host_customers_list (turned off in .vendo/overrides.json)");
+    // Awareness, not breakage: which exclusions are acceptable is the host's call.
+    expect(exit).toBe(0);
+  });
+
   it("check ids are unique across a full run, healthy and broken alike", async () => {
     // Duplicate ids would make fix_ref anchors and agents' remediation notes
     // ambiguous — every check in one run must be individually addressable.

--- a/packages/vendo/tests/cli/init.test.ts
+++ b/packages/vendo/tests/cli/init.test.ts
@@ -608,6 +608,33 @@ describe("vendo init (zero-question)", () => {
     expect(sink.logs[sink.logs.length - 1]).toBe(`\n→ Don't forget the paste in ${join("app", "layout.tsx")} (frame above)`);
   });
 
+  // A tool the run extracted and then left off WITHOUT being asked to is the one
+  // fact the tail used to drop: the developer met it later, as an assistant that
+  // could not answer and would not say why. The human's own overrides.json
+  // disable stays unmentioned — that is the nag the test above forbids.
+  it("the tail names a tool the machine turned off, with the layer that did it and the way back on", async () => {
+    const root = await fixture();
+    await mkdir(join(root, "app", "api", "customers"), { recursive: true });
+    await writeFile(join(root, "app", "api", "customers", "route.ts"),
+      "export async function GET() { return Response.json({ customers: [] }); }\n");
+    await mkdir(join(root, ".vendo"), { recursive: true });
+    await writeFile(join(root, ".vendo", "judgments.json"), JSON.stringify({
+      format: "vendo/judgments@1",
+      tools: {
+        host_customers_list: {
+          binding: "GET /api/customers",
+          fields: { disabled: true },
+          evidence: "the handler returns the whole customer book",
+        },
+      },
+    }));
+    const sink = output();
+    expect(await run(root, sink)).toBe(0);
+    const tail = sink.logs.join("\n").split("Agent tail:")[1]!;
+    expect(tail).toContain("tools off: host_customers_list (turned off in .vendo/judgments.json)");
+    expect(tail).toContain('set "disabled": false');
+  });
+
   // Agent-install-dx Layer 2 (key-mint integration): a keyless run's tail
   // carries the complete in-band key story — the auth.md discovery URL, the
   // `vendo login` ceremony, and both flag fallbacks — so the agent never


### PR DESCRIPTION
## The policy is settled and this PR does not touch it

Yousef's decision stands: a host tool the judge stamps for operators or staff stays hidden from the embedded agent. **This PR changes no policy.** It does not decouple `audience` from `disabled`, does not retune the judge, and adds no opt-in flag or install question. The refusal is correct and it stays.

What was wrong was the SILENCE around it. This PR is the visibility half only.

A tool can be switched off by three layers, and only the all-or-nothing case was ever announced: the boot warning fired when EVERY tool was dead, doctor passed on any `live > 0`, and the init receipt never mentioned it. A catalog that shipped 5 tools and served 2 read healthy from every angle, and the three missing ones were discovered by watching the assistant fail to answer.

## What changed

**1. Loud at boot.** `warnZeroLiveTools` became `warnHostToolSurface` (`packages/actions/src/runtime/registry.ts:767-793`). The all-dead sentence is unchanged; the partial case now names each tool that is off and the layer that took it.

**2. Doctor counts the delta.** `checkToolCatalog` warns `E-TOOLS-005` when live is short of the extracted count (`packages/vendo/src/cli/doctor-config-checks.ts:240`). A **warning with exit 0**, never a failure: which exclusions are right is the host's call. Troubleshooting page added at `docs-site/production/troubleshooting/e-tools-005.mdx`.

**3. Init's receipt names them.** The agent tail carries a `tools off:` line (`packages/vendo/src/cli/init.ts:670`, helper at `packages/vendo/src/cli/init-scaffolds.ts:194`).

**4. The generator stops inventing.** When nothing on the list can be READ, the briefing says so (`packages/apps/src/server/doors/build-surface.ts:566`), and a screen querying an unknown tool with nothing readable behind it is told there is no data for the ask, to use `<Disclaimer>`, and not to claim data is missing or empty when it cannot know (`packages/apps/src/server/checking/component-screen.ts:483`).

One shared `disabledReason` (`packages/actions/src/judgments.ts:144`) backs all three reporting surfaces, so boot, doctor and the receipt physically cannot drift apart. That drift is what let this live.

### The no-nag fix

The first version of the receipt reported EVERY off tool, including ones the developer themselves disabled in `overrides.json`. That tripped init's documented no-nag contract (`packages/vendo/tests/cli/init.test.ts:1269-1274`), which forbids reporting back a decision the human already wrote down. **The code was fixed, not the test.** The receipt now names only what the machine turned off, which is the entire point of the ticket.

## Tests: five, each proven red first

| Test | Red proof before the fix |
|---|---|
| `actions` seam: live set equals what the merge decided, every exclusion named | `expected [] to have a length of 1` |
| `vendo` doctor `E-TOOLS-005` names each excluded tool, exit stays 0 | `expected { id: 'tools/live-surface' } to match { status: 'warning' }` |
| `vendo` init tail names a machine-disabled tool | `expected '\n  auth: none wired…' to contain 'tools off: host_customers_list…'` |
| `apps` screen refusal when nothing is readable | `expected 'useQuery("invoices_list") names unkno…' to contain 'this product has NO tool a screen can…'` |
| `apps` briefing says nothing can be read | `expected 'TOOL RESPONSE SHAPES…' to contain 'Nothing on this list can be READ'` |

The seam test writes a real `tools.json` + `judgments.json` + `overrides.json`, puts them through the REAL merge, and reads back through the REAL `createActions().descriptors()`. No stub on either side. Its oracle is the merge itself rather than a hard-coded list, so it holds whatever is decided about the audience rule later.

## Browser proof on the live Ledgerline app

**Half A, the refusal is honest.** With `/api/customers` graded `operator`, the generated screen says *"No customer revenue data available. This app has no connected data source for customers or invoices … so a bar chart here would have to show made-up numbers, which this build won't do."* No invented tool, no fabricated data.

Boot printed, on the real app:
```
[vendo] 3 of 5 extracted host tools are off, so the agent will never offer them:
host_customers_list (graded audience "operator", and only end-user tools are on by
default), host_submit (turned off in .vendo/tools.json), host_transactions_list
(graded audience "operator", ...). To turn one back on, set its "disabled": false
in .vendo/overrides.json.
```

**Half B, the opt-in path works.** An explicit developer edit to the scratch app's `overrides.json` (`"host_customers_list": { "disabled": false }`) brings the tool back and the revenue screen renders CORRECT data: Lakeside Robotics $209,600, Northwind Traders $184,200, Halcyon Health $141,900, down to Pinegrove Studios $0, all matching Ledgerline's own table. Doctor moved from "2 of 5 live … the other 3" to "4 of 5 live … the other 1", and the boot warning fell silent.

Verified from source first: `effectiveHostTool` runs `applyJudgment` (which applies the fail-closed rule) and then `mergeOverride` LAST, so an explicit `disabled: false` wins. The escape hatch Yousef's decision relies on exists and works end to end.

## Gates

`pnpm build`, `@vendoai/actions` (624), `@vendoai/apps` (1353), `@vendoai/vendo` (2418), `pnpm typecheck` (42 tasks), `pnpm lint` (0 errors) all green, re-run after rebasing onto current `main`.

MINOR changeset. No majors in `.changeset/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes host tool exclusions visible across boot, `vendo doctor`, and `vendo init`, without changing policy. Previously partial losses were silent; now each off tool states who turned it off and why.

- Adds shared `disabledReason` in `@vendoai/actions` to unify per-tool reasons and credit only judgments whose binding actually applied; avoids misattributing a `tools.json` disable to a stale `judgments.json` entry.
- Replaces `warnZeroLiveTools` with `warnHostToolSurface` to emit counts and per-tool reasons when some tools are off; the zero-live warning text is unchanged.
- Adds doctor warning `E-TOOLS-005` in `@vendoai/vendo` that names each off tool and layer; exit stays 0.
- `vendo init` tail prints `tools off:` for machine-disabled tools only and shows the override path (`"disabled": false` in `.vendo/overrides.json`).
- `@vendoai/apps` briefing and screen checks state when no READ tools exist and instruct using `<Disclaimer>` instead of inventing tools or asserting missing data.
- Docs: adds `production/troubleshooting/e-tools-005.mdx`; minor bumps for `@vendoai/actions`, `@vendoai/apps`, `@vendoai/vendo`. No migration; restart the app after editing overrides.

<sup>Written for commit 5d41df019953ac513bdedcebd5985c11193791d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

