### PR TITLE
fix(store): heal a transiently truncated PGlite FS bundle read with one retry

### DIFF
--- a/.changeset/a-truncated-bundle-read-heals.md
+++ b/.changeset/a-truncated-bundle-read-heals.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/store": patch
+---
+
+store: heal a transiently truncated PGlite FS bundle read with one retry

--- a/packages/store/src/db.ts
+++ b/packages/store/src/db.ts
@@ -258,10 +258,33 @@ async function releaseSharedPglite(dataDir: string, entry: SharedPglite): Promis
   }
 }
 
+/** A PGlite boot re-reads its ~6MB wasm FS bundle from node_modules every time,
+    and pnpm links that file to its shared store — so an external rewrite of the
+    store's copy is visible here as a transiently truncated read, which pglite
+    surfaces as `Invalid FS bundle size` (seen on CI 2026-08-16, healed by the
+    next read). One delayed retry is the fix; a second identical failure means
+    the installed package really is truncated. */
+async function createPgliteRetryingTruncatedBundle(dataDir: string): Promise<PGlite> {
+  try {
+    return await PGlite.create(dataDir);
+  } catch (error) {
+    if (!/Invalid FS bundle size/.test(errorMessage(error))) throw error;
+    await wait(500);
+    try {
+      return await PGlite.create(dataDir);
+    } catch (retryError) {
+      if (!/Invalid FS bundle size/.test(errorMessage(retryError))) throw retryError;
+      throw new Error(
+        `[vendo] PGlite's wasm bundle read back truncated twice — the installed @electric-sql/pglite files are likely corrupt. Reinstall dependencies (pnpm install --force). Cause: ${errorMessage(retryError)}`,
+      );
+    }
+  }
+}
+
 /** ENG-350 — self-heal a stale lock instead of hard-aborting boot. */
 async function createPgliteHealingStaleLock(dataDir: string): Promise<PGlite> {
   try {
-    return await PGlite.create(dataDir);
+    return await createPgliteRetryingTruncatedBundle(dataDir);
   } catch (error) {
     const lock = readPgliteLock(dataDir);
     if (!lock) throw error;
@@ -275,7 +298,7 @@ async function createPgliteHealingStaleLock(dataDir: string): Promise<PGlite> {
     );
     fs.rmSync(lock.path, { force: true });
     try {
-      return await PGlite.create(dataDir);
+      return await createPgliteRetryingTruncatedBundle(dataDir);
     } catch (retryError) {
       throw new Error(
         `[vendo] PGlite data directory "${dataDir}" failed to open even after clearing its stale lock — the store is likely corrupt. Back up and delete the directory to start fresh, or set a Postgres url. Cause: ${errorMessage(retryError)}`,

--- a/packages/store/tests/db.fs-bundle-retry.test.ts
+++ b/packages/store/tests/db.fs-bundle-retry.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// A PGlite boot re-reads its ~6MB wasm FS bundle out of node_modules every
+// time, and pnpm links that file to its shared store — so an external rewrite
+// of the store's copy shows up here as a transiently truncated read, which
+// pglite reports as `Invalid FS bundle size` (seen on CI 2026-08-16: 12 of 13
+// boots in one file succeeded). The engine is mocked so the truncated read is
+// deterministic; the retry logic is the subject.
+const pgliteCreate = vi.fn();
+vi.mock("@electric-sql/pglite", () => ({
+  PGlite: { create: (...args: unknown[]) => pgliteCreate(...args) },
+}));
+
+const { createDb } = await import("../src/db.js");
+
+const truncatedBundle = () => new Error("Invalid FS bundle size: 3030528 !== 6293225");
+const fakePglite = () => ({
+  query: vi.fn(async () => ({ rows: [{ ok: 1 }] })),
+  close: vi.fn(async () => {}),
+});
+
+// memory:// keeps the subject alone: no data dir, so neither the writer lock
+// nor the stale-postmaster.pid heal has anything to say about these failures.
+describe("PGlite truncated FS bundle retry", () => {
+  beforeEach(() => {
+    pgliteCreate.mockReset();
+  });
+
+  it("heals a transiently truncated bundle read with one retry", async () => {
+    pgliteCreate.mockRejectedValueOnce(truncatedBundle()).mockResolvedValueOnce(fakePglite());
+
+    const db = createDb({ dataDir: "memory://fs-bundle-heals" });
+    await expect(db.query("select 1")).resolves.toEqual({ rows: [{ ok: 1 }] });
+
+    expect(pgliteCreate).toHaveBeenCalledTimes(2);
+    await db.close();
+  });
+
+  it("tells the operator to reinstall when the bundle reads short twice", async () => {
+    pgliteCreate.mockRejectedValue(truncatedBundle());
+
+    const db = createDb({ dataDir: "memory://fs-bundle-truly-truncated" });
+    const error = await db.query("select 1").catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("[vendo]");
+    expect((error as Error).message).toContain("Reinstall dependencies");
+    expect((error as Error).message).toContain("Invalid FS bundle size: 3030528 !== 6293225");
+    expect(pgliteCreate).toHaveBeenCalledTimes(2);
+    await db.close();
+  });
+
+  it("propagates an unrelated boot failure unchanged, without retrying", async () => {
+    pgliteCreate.mockRejectedValue(new Error("boot blip"));
+
+    const db = createDb({ dataDir: "memory://fs-bundle-unrelated" });
+    await expect(db.query("select 1")).rejects.toThrow("boot blip");
+
+    expect(pgliteCreate).toHaveBeenCalledTimes(1);
+    await db.close();
+  });
+});


### PR DESCRIPTION
## What

`PGlite.create` now retries exactly once (500ms later) when it fails with `Invalid FS bundle size` — the error pglite throws when its ~6MB wasm FS bundle reads back short. A second identical failure surfaces as a `[vendo]` error telling the operator to reinstall, instead of raw Emscripten text. Any other boot error propagates unchanged, never retried.

## Why

This is the flake that keeps bouncing PRs out of the merge queue (e.g. run 31976289691 on #1384, and a red `main` push earlier the same day): `test-rest` dies in a random PGlite-booting test with `Invalid FS bundle size: <random short size> !== 6293225`.

Root cause, established empirically:
- Node's `fs.promises.readFile` **cannot** return a short buffer from a complete file — `.buffer.byteLength` is identically the fstat size (`allocUnsafeSlow`, subarray is a view). So the file on disk was genuinely short at read time.
- 963 stress boots + 789k concurrent reads of the static file: zero repros. A reader racing a writer that truncates+refills: reproduces the exact CI signature (short, varying, 512-aligned sizes).
- In the failing run, 12 of 13 boots in the same vitest file succeeded — the file was whole again moments later. pnpm hard-links `node_modules` files to its shared store, so an external rewrite of the store's copy is what the reader sees as a transient truncation.
- Nothing in this repo writes that path (all turbo output globs audited; no `next output: standalone`; turbo cache restore truncates in place but no cached output overlaps `node_modules`). The writer is outside the repo, and pglite re-reads the bundle on every single boot, so every boot is a window.

One delayed retry heals the observed failure mode; the poisoned-copy case (file permanently short) now fails with an actionable message instead of a mystery.

## Tests

New `packages/store/tests/db.fs-bundle-retry.test.ts` (engine mocked so the truncated read is deterministic): heals on one retry; reports reinstall guidance after two; unrelated errors propagate unretried. Proven red before the fix (2 failed | 1 passed) and green after.

Gate: build ✓, test:affected ✓ (sole red is the pre-existing genbench font test, which fails on a clean `origin/main` checkout too), typecheck ✓, lint ✓. Store suite ×2: 786 passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries a truncated PGlite wasm FS bundle read once to heal transient boot failures and surfaces a clear reinstall error if the bundle is truly corrupt. Previously, `PGlite.create` failed with raw “Invalid FS bundle size” text and aborted; now it retries once after 500ms on that signature, and throws a `[vendo]` error with reinstall guidance on a second identical failure. Other boot errors remain unchanged and are never retried.

**Review notes**
- Routes both `PGlite.create` call sites through a wrapper that only retries on “Invalid FS bundle size”; introduces at most a 500ms delay in that failure mode.
- Adds `packages/store/tests/db.fs-bundle-retry.test.ts` covering heal-once, double-failure reinstall guidance, and no-retry on unrelated errors.
- No API changes; affects `@vendoai/store` boot only. If you see the `[vendo]` error, reinstall dependencies with `pnpm install --force`.
- Rationale: `@electric-sql/pglite` re-reads its ~6MB bundle on each boot, and `pnpm` hard-links files; transient external rewrites can produce short reads observed in CI.

<sup>Written for commit bf15ac0cb5e8811a8c7176df040770a2834f561b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

