### PR TITLE
test(ui): iterating browser specs reuse the warm dev server; the proof of record still builds fresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,14 @@ generated UI in a sandboxed, brand-native surface.
   names breaks merges. No browser runs in CI (2026-08-06) — headless
   mis-resolves `:focus-visible` and `light-dark()`, so the Playwright suites
   stay a LOCAL pre-PR gate.
+- Iterating on a browser spec is two-speed. While you are editing, start ONE
+  warm hot-reloading harness (`VENDO_HARNESS_DEV=1` plus a pinned
+  `VENDO_HARNESS_PORT`) and rerun specs against it with the same two variables —
+  reuse is dev-mode-only, so every rerun skips the build and starts in seconds.
+  Then one run WITHOUT the flag — a fresh production build — is the proof of
+  record, and the only result worth reporting. A production run never reuses a
+  server: `vite preview` serves whatever was built last, so a reused one greens
+  the previous build.
 - `--continue` and a turbo concurrency bound are the standing rule wherever the
   suite runs: `--continue` so one red package never hides every other package's
   result; the bound (2 in CI's `test-rest`, 4 in the root `test` /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,13 @@ generated UI in a sandboxed, brand-native surface.
   record, and the only result worth reporting. A production run never reuses a
   server: `vite preview` serves whatever was built last, so a reused one greens
   the previous build.
+- An agent proves a browser flow by SCRIPTING it, never by stepping through it
+  click-by-click: write one throwaway Playwright script for the whole flow, run
+  it once, judge the screenshot/video artifacts — one model turn instead of
+  fifteen, seconds instead of minutes. Interactive stepping is for two cases
+  only: exploring UI the agent didn't write, and diagnosing a scripted run that
+  failed for unclear reasons — and whatever stepping teaches gets banked as a
+  script so the flow is never stepped twice.
 - `--continue` and a turbo concurrency bound are the standing rule wherever the
   suite runs: `--continue` so one red package never hides every other package's
   result; the bound (2 in CI's `test-rest`, 4 in the root `test` /

--- a/packages/ui/playwright.config.ts
+++ b/packages/ui/playwright.config.ts
@@ -76,7 +76,9 @@ export default defineConfig({
     command: harnessCommand(port),
     cwd: packageRoot,
     url: `${baseURL}/thread`,
-    reuseExistingServer: false,
+    // Reuse only the dev server: it hot-reloads, while a reused `vite preview`
+    // would serve the previous build.
+    reuseExistingServer: process.env.VENDO_HARNESS_DEV === "1",
     timeout: 180_000,
     stdout: "pipe",
     stderr: "pipe",


### PR DESCRIPTION
## What

`packages/ui/playwright.config.ts` now sets `reuseExistingServer: process.env.VENDO_HARNESS_DEV === "1"` instead of a flat `false`.

That is the whole change, plus one bullet in the root `CLAUDE.md` writing down the loop it enables.

## Why

The ui browser harness has two modes. By default the webServer command is `vite build && vite preview` — the production proof, and the reason a browser gate exists at all (a dev-only run once asserted `developmentMode()` copy that ships to nobody). `VENDO_HARNESS_DEV=1` swaps in a plain `vite` dev server for interactive debugging.

Reusing a **preview** server is the classic false green: it serves whatever was built last, so your edit is invisible and the suite greens the previous build. Reusing a **dev** server is safe — it hot-reloads the source it serves. So reuse is now allowed in exactly the mode where it cannot lie, and production runs still boot a fresh build every time. Nothing about the proof of record changes.

The loop: start one warm dev harness (`VENDO_HARNESS_DEV=1` + a pinned `VENDO_HARNESS_PORT`), rerun specs against it while you edit, then one run **without** the flag — a fresh production build — is the result worth reporting.

## Measured

`packages/ui`, `e2e/palette-keybinding.spec.ts` (2 tests), three laps each, same machine:

| lap | 1 | 2 | 3 |
| --- | --- | --- | --- |
| production (`npx playwright test …`, builds + previews each run) | 6.8s | 5.2s | 5.2s |
| dev warm (`VENDO_HARNESS_DEV=1 VENDO_HARNESS_PORT=…`, reuses the running server) | 1.5s | 1.5s | 1.5s |

One-time dev-server boot: **0.5s** (warm vite dep cache; the first boot in a fresh checkout also optimizes deps).

So a spec rerun goes from ~5.2s to ~1.5s — about 3.5x, and the gap grows with the size of the harness build. Reuse was confirmed, not assumed: the dev laps print no `[WebServer]` lines at all (Playwright started nothing), while the production laps print the full vite build; only one vite process was alive throughout.

## Fixtures configs left alone

Both other Playwright configs keep `reuseExistingServer: false`, on purpose:

- `fixtures/integration-browser` — its vite dev server boots the REAL composed umbrella and the fixture host app **in the vite node process** (`e2e/harness/backends.ts`, called from the config factory). Vite hot-reloads the browser module graph, not that. A reused server would test yesterday's server-side umbrella, which is precisely the thing this fixture exists to prove.
- `fixtures/context-e2e` — the command is `pnpm --filter demo-bank dev`, and demo-bank's `predev` runs `vendo sync . --no-ai`, which regenerates `.vendo/`. A reused server skips that extraction and reads a stale `.vendo/` — same stale-producer hazard in a different coat.

## Gate

`pnpm build`, `pnpm typecheck`, `pnpm lint` green. `pnpm test:affected` (root `CLAUDE.md` touched, so it fans out wide) is green except one pre-existing failure, `genbench tests/font.test.ts > says nothing at all for a world that ships no face`, which fails identically on a clean tree with these changes stashed. Unrelated to this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up iterating `packages/ui` Playwright specs by reusing a warm dev server, while production proofs still build fresh each run. Previously reuse was always off; now only the dev server can be reused to avoid false greens from `vite preview`.

- `packages/ui/playwright.config.ts`: sets `reuseExistingServer: process.env.VENDO_HARNESS_DEV === "1"`; production (`vite build && vite preview`) still starts a new server every run.
- `CLAUDE.md`: documents the two-speed loop (`VENDO_HARNESS_DEV=1` + pinned `VENDO_HARNESS_PORT` for iteration; run once without the flag for the proof) and adds guidance to script browser flows instead of stepping interactively.
- Other Playwright configs stay `reuseExistingServer: false`. No migration required.

<sup>Written for commit e86ff9eee6135530a3ec8fcb9c2271ca51cf2f78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

