### PR TITLE
chore(deps): the image parser that never stopped looping leaves the tree

### DIFF
--- a/examples/mastra-agent/package.json
+++ b/examples/mastra-agent/package.json
@@ -19,7 +19,7 @@
     "@mastra/duckdb": "^1.5.1",
     "@mastra/libsql": "^1.15.1",
     "@mastra/loggers": "^1.2.0",
-    "@mastra/memory": "^1.22.2",
+    "@mastra/memory": "^1.26.1",
     "@mastra/observability": "^1.16.0",
     "@vendoai/core": "workspace:*",
     "@vendoai/store": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -384,8 +384,8 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0(@mastra/core@1.51.0(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.230(zod@3.25.76))(express@5.2.1)(rxjs@7.8.1)(zod@3.25.76))
       '@mastra/memory':
-        specifier: ^1.22.2
-        version: 1.23.0(@mastra/core@1.51.0(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.230(zod@3.25.76))(express@5.2.1)(rxjs@7.8.1)(zod@3.25.76))
+        specifier: ^1.26.1
+        version: 1.26.2(@mastra/core@1.51.0(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.230(zod@3.25.76))(express@5.2.1)(rxjs@7.8.1)(zod@3.25.76))
       '@mastra/observability':
         specifier: ^1.16.0
         version: 1.16.1(@mastra/core@1.51.0(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.230(zod@3.25.76))(express@5.2.1)(rxjs@7.8.1)(zod@3.25.76))(zod@3.25.76)
@@ -2893,8 +2893,8 @@ packages:
     peerDependencies:
       '@mastra/core': '>=1.0.0-0 <2.0.0-0'
 
-  '@mastra/memory@1.23.0':
-    resolution: {integrity: sha512-UkJcuZ5S/SDfnrXMmigjZxUUQr42zdcIvW7JVmeN5CIt/lOkfJ6Km89nf6IDXpI8nAcvPiU96WcK4WIPHXTjqw==}
+  '@mastra/memory@1.26.2':
+    resolution: {integrity: sha512-9eFJg/9TXEUJmWdJbAJkt4FCa8cNdK1lFEUgXwqpjijnsMLtaLUAeqHz86pI5E34hpJYlPhMwLKiRzM1e4iAsg==}
     engines: {node: '>=22.13.0'}
     peerDependencies:
       '@mastra/core': '>=1.4.1-0 <2.0.0-0'
@@ -2908,6 +2908,12 @@ packages:
 
   '@mastra/schema-compat@1.3.4':
     resolution: {integrity: sha512-2ObUsd21KIVelQy+eKPxJvnMxtmKnWacsIkZovhEYjVcQX9OYTDQ+u4E4RboIJZvurJnFx++/ujQLFznUaEYMg==}
+    engines: {node: '>=22.13.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+
+  '@mastra/schema-compat@1.3.7':
+    resolution: {integrity: sha512-06WfY+j9rulYnDp8CM7pL7JIyrntkMolqmyyb1VJNEzlYTQCIcJcY0SwQiubZv2tztmoYGikszDiRVyXp0E9gA==}
     engines: {node: '>=22.13.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -5823,11 +5829,6 @@ packages:
     resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
     engines: {node: '>= 4'}
 
-  image-size@1.2.1:
-    resolution: {integrity: sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==}
-    engines: {node: '>=16.x'}
-    hasBin: true
-
   immer@11.1.11:
     resolution: {integrity: sha512-qzXuyXAkPySAGYkfsAwodDPWT8Zm7/Uo5BNt4BjhMhG5WlWyZZ4wQqnWwdS8kjlQ1Cwu6gjw3A6+0gTQwlyYtw==}
 
@@ -7137,9 +7138,6 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-
-  queue@6.0.2:
-    resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
@@ -9888,13 +9886,12 @@ snapshots:
       pino: 10.3.1
       pino-pretty: 13.1.3
 
-  '@mastra/memory@1.23.0(@mastra/core@1.51.0(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.230(zod@3.25.76))(express@5.2.1)(rxjs@7.8.1)(zod@3.25.76))':
+  '@mastra/memory@1.26.2(@mastra/core@1.51.0(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.230(zod@3.25.76))(express@5.2.1)(rxjs@7.8.1)(zod@3.25.76))':
     dependencies:
       '@mastra/core': 1.51.0(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.230(zod@3.25.76))(express@5.2.1)(rxjs@7.8.1)(zod@3.25.76)
-      '@mastra/schema-compat': 1.3.4(zod@4.4.3)
+      '@mastra/schema-compat': 1.3.7(zod@4.4.3)
       async-mutex: 0.5.0
       diff: 8.0.4
-      image-size: 1.2.1
       json-schema: 0.4.0
       lru-cache: 11.5.1
       probe-image-size: 7.3.0
@@ -9917,13 +9914,11 @@ snapshots:
       zod-from-json-schema-v3: zod-from-json-schema@0.0.5
       zod-to-json-schema: 3.25.2(zod@3.25.76)
 
-  '@mastra/schema-compat@1.3.4(zod@4.4.3)':
+  '@mastra/schema-compat@1.3.7(zod@4.4.3)':
     dependencies:
       json-schema-to-zod: 2.8.1
       zod: 4.4.3
       zod-from-json-schema: 0.5.6
-      zod-from-json-schema-v3: zod-from-json-schema@0.0.5
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
 
   '@mastra/server@1.51.0(@mastra/core@1.51.0(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(ai@6.0.230(zod@3.25.76))(express@5.2.1)(rxjs@7.8.1)(zod@3.25.76))(zod@3.25.76)':
     dependencies:
@@ -12984,10 +12979,6 @@ snapshots:
 
   ignore@7.0.6: {}
 
-  image-size@1.2.1:
-    dependencies:
-      queue: 6.0.2
-
   immer@11.1.11: {}
 
   import-fresh@3.3.1:
@@ -14600,10 +14591,6 @@ snapshots:
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
-
-  queue@6.0.2:
-    dependencies:
-      inherits: 2.0.4
 
   quick-format-unescaped@4.0.4: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,24 +28,15 @@ allowBuilds:
   unrs-resolver: true
   workerd: true
 
-# 2026-08-07 advisories: image-size GHSA-w3rx-r6r6-pgpr (ICNS parser infinite
-# loop) and GHSA-5p2g-fcmc-qvqq (JXL/HEIF parsers infinite loop), both HIGH,
-# via examples/mastra-agent > @mastra/memory > image-size. Not a
-# stale-lockfile case like every floor in `overrides` below: GitHub's own
-# advisory records report first_patched_version: null for both, and
-# image-size's last release anywhere (npm or GitHub) is 2.0.2 from April
-# 2025 — the "patched >=2.0.3" pnpm audit prints does not exist. Checked
-# upstream too: @mastra/memory 1.26.0 (2026-08-05, its current latest) still
-# pins image-size exactly at 1.2.1, so no version bump anywhere in the chain
-# reaches a fix. Ignored by advisory ID (pnpm's own mechanism for this,
-# `pnpm audit --ignore <GHSA-ID>`, which persists here) rather than an
-# `overrides` floor that can't resolve to a real package version. Re-check
-# both IDs whenever image-size cuts a new release; drop the ignores once one
-# ships >=2.0.3.
-auditConfig:
-  ignoreGhsas:
-    - GHSA-w3rx-r6r6-pgpr
-    - GHSA-5p2g-fcmc-qvqq
+# The 2026-08-07 image-size ignores (GHSA-w3rx-r6r6-pgpr ICNS infinite loop,
+# GHSA-5p2g-fcmc-qvqq JXL/HEIF infinite loop, both HIGH) are GONE
+# (2026-08-16). They were never going to be fixed by a floor — image-size's
+# last release anywhere is still 2.0.2 from April 2025 and both advisories
+# still report first_patched_version: null — so the exit was upstream dropping
+# the package, not patching it: @mastra/memory 1.26.1 (2026-08-12) swapped
+# image-size for probe-image-size, and the example's floor moved to ^1.26.1.
+# image-size is now absent from the tree entirely; `pnpm why image-size -r`
+# finds nothing, which is why the ignores can go rather than be re-justified.
 
 minimumReleaseAgeExclude:
   - '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.214'


### PR DESCRIPTION
Triage of the three open Dependabot alerts on `main` (2 high, 1 low). Two fixed by dropping the vulnerable package out of the tree; one deferred with a reason.

| Alert | Package | Sev | Where it lives | Fix |
|---|---|---|---|---|
| [GHSA-w3rx-r6r6-pgpr](https://github.com/advisories/GHSA-w3rx-r6r6-pgpr) (CVE-2025-71330) | `image-size` ≤2.0.2 | HIGH | example-only — `examples/mastra-agent` > `@mastra/memory` | **Fixed.** `@mastra/memory` floor `^1.22.2` → `^1.26.1`; image-size is gone from the tree |
| [GHSA-5p2g-fcmc-qvqq](https://github.com/advisories/GHSA-5p2g-fcmc-qvqq) (CVE-2025-71329) | `image-size` ≤2.0.2 | HIGH | same path | **Fixed.** same bump |
| [GHSA-866g-f22w-33x8](https://github.com/advisories/GHSA-866g-f22w-33x8) (CVE-2026-8769) | `@ai-sdk/provider-utils` ≤3.0.97 | LOW | example-only (`examples/mastra-agent`) + dev-only in `@vendoai/vendo` | **Deferred** — no in-range patch exists; escaping the range means a cross-major override on mastra's exact-pinned compat aliases |

### Exploitability, honestly

**image-size (both highs, HIGH but not reachable here).** A crafted ICNS / JXL / HEIF buffer with a zero-valued length field never advances the parser's offset, so the `while` loop spins the Node event loop forever — an unauthenticated remote DoS *if* attacker-controlled image bytes reach the parser. In our tree the only consumer was `@mastra/memory`'s image handling inside the private `examples/mastra-agent` demo; nothing in a published `@vendoai/*` tarball ever touched it. Real severity for our users: none. Real severity for anyone running the example against untrusted image input: the advisory's.

**@ai-sdk/provider-utils (low, not reachable on any path we ship).** `createJsonResponseHandler` / `createJsonErrorResponseHandler` read the provider's response body without a bound, so a hostile or compromised *model endpoint* can pin memory/CPU. The attacker has to be the model provider you configured, which is already inside the trust boundary. The two vulnerable copies (`2.2.8`, `3.0.28`) arrive only through `@mastra/core`, and `pnpm why --prod` puts both behind `examples/mastra-agent`; in `@vendoai/vendo` the mastra chain is a devDependency. Every published `@vendoai/*` package resolves `@ai-sdk/provider-utils` 4.x, which is outside the vulnerable range.

### Why the image-size fix is a floor bump and not an override

2026-08-07 parked both GHSAs in `auditConfig.ignoreGhsas` because there was genuinely nothing to bump to — image-size's last release anywhere is 2.0.2 (April 2025) and both advisories still report `first_patched_version: null`. That is still true. What changed is upstream: `@mastra/memory` 1.26.1 (2026-08-12) swapped image-size for `probe-image-size`, which the tree already carried. The example declared `^1.22.2` but the lockfile sat on 1.23.0, so the floor moves to `^1.26.1` to make the security reason explicit and stop a silent regression.

`pnpm why image-size -r` now returns nothing, so both ignores are deleted rather than re-justified — the workspace comment records why they existed and why they're gone. Net −2 packages (`image-size`, `queue`); `@mastra/core` stays pinned at 1.51.0 and memory 1.26.2's peer range (`>=1.4.1-0 <2.0.0-0`) covers it.

### Why the low one is deferred

Vulnerable range is `<= 3.0.97`; the 3.x line tops out at 3.0.32, so no in-range patch exists and the only escape is 4.x. Both copies are `@mastra/core`'s AI-SDK-v5 compatibility aliases — `@ai-sdk/provider-utils-v5` is pinned *exactly* at `3.0.28`, and `@ai-sdk/ui-utils@1.2.11` wants its own `^2.x`. A `pnpm.overrides` floor would drag a v5-era compat layer across one or two majors of a package whose API changed, breaking the example at runtime to close a low-severity advisory on a path we don't ship. mastra 1.59.0 still pins the alias at 3.0.30, so this closes when upstream moves. The `audit` gate runs `--audit-level high`, so this does not redden CI.

### Gate

`pnpm build` · `pnpm test:affected` (mastra-agent, 11/11) · `pnpm typecheck` (42 tasks) · `pnpm lint` — all green. `pnpm audit --prod --audit-level high` green *without* the ignores (1 low remaining = the deferred alert above).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes `image-size` by raising the example app’s `@mastra/memory` floor to `^1.26.1`, which uses `probe-image-size`. Deletes the two HIGH Dependabot ignores; audit stays green and no published `@vendoai/*` package is affected.

- Old: `image-size` reachable via `examples/mastra-agent` > `@mastra/memory`; New: absent. Side effects: net −2 packages (`image-size`, `queue`); lockfile updates only.
- Keeps `@mastra/core` at `1.51.0`; `@mastra/memory@1.26.2` peer range covers it.
- Removes `auditConfig.ignoreGhsas` for `GHSA-w3rx-r6r6-pgpr` and `GHSA-5p2g-fcmc-qvqq`.
- Defers LOW `@ai-sdk/provider-utils` (`GHSA-866g-f22w-33x8`) due to no in-range patch; copies exist only behind the example and dev deps; CI runs `--audit-level high` and remains green.

<sup>Written for commit c6f0cc35c61dd1c74f2d27fb6955a1ce700cb6e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

