### PR TITLE
test(genbench): the fontless-world control measures the harness, not the bundle's built-in face

### DIFF
--- a/genbench/tests/font.test.ts
+++ b/genbench/tests/font.test.ts
@@ -86,7 +86,10 @@ describe("the world's font", () => {
     const { font: _font, ...bare } = world;
 
     expect(fontFace(bare)).toBe("");
-    expect(pageHtml(TEXT, bare, bundle, "vendo-sonnet")).not.toContain("@font-face");
+    // The bundle carries the product's own built-in Onest face, so the page is
+    // never font-free; the control is that the harness added none of its own.
+    const page = pageHtml(TEXT, bare, bundle, "vendo-sonnet");
+    expect(page.split("@font-face").length).toBe(bundle.split("@font-face").length);
   });
 });
 


### PR DESCRIPTION
The control test "says nothing at all for a world that ships no face" asserted the whole rendered page contains no `@font-face`. Since dd0197c52 the `@vendoai/ui` bundle legitimately carries the product's own built-in Onest face, so every page inlining the bundle trips the assertion — the suite has been red on a stale assumption, not a product bug.

The control's intent survives: the harness must inject no face for a fontless world. The assertion now compares the page's `@font-face` count to the bundle's own, so the harness contribution is what's measured. `fontFace(bare) === ""` stays asserted separately.

Gate: build, test:affected (genbench 6/6, was 5/6), typecheck, lint — all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adjusts the genbench control to measure harness-added fonts instead of the bundle’s built-in face. Previously the test asserted the page contained no `@font-face`; with `@vendoai/ui` embedding Onest, the test now compares the page’s `@font-face` count to the bundle’s and still asserts `fontFace(bare) === ""`.

- Review: The assertion is `page.split("@font-face").length === bundle.split("@font-face").length`, ensuring the harness adds none.
- Impact: Test-only change; no product behavior change. No migration required.

<sup>Written for commit 3ab0dd0c4c234844d8afed4b030e13ac6be8fa91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

