### PR TITLE
feat(agents)!: `agent.on()` declares an automation, boot reconciles it

### DIFF
--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -20,6 +20,7 @@ import {
   type SeatModels,
   type Skill,
   type ToolRegistry,
+  type When,
 } from "@vendoai/core";
 import { createGuard, isGuardInstance, permissionsHandler, type GuardRules, type VendoGuard } from "@vendoai/guard";
 import { provideHarnessAdapters, vendo } from "@vendoai/harnesses";
@@ -28,6 +29,7 @@ import { resolveDevCredential } from "@vendoai/harnesses/inference/credential";
 import { createStore, hostedStore, storeFiles, type VendoStore } from "@vendoai/store";
 import type { LanguageModel, UIMessage } from "ai";
 import { randomUUID } from "node:crypto";
+import { declareAutomation, type OnOptions } from "./automations.js";
 import { startRun, type AgentRun, type RunOptions } from "./away.js";
 import { resolveDoor, type DoorConfig } from "./door.js";
 import { withEgress, type EgressConfig } from "./egress.js";
@@ -106,6 +108,23 @@ export interface VendoAgent {
    *  happened. Venue "automation", presence "away", non-interactive — so a tool
    *  the guard wants a person for parks, and `refs.approvals` is who to ask. */
   run<T = never>(task: string, options?: RunOptions<T>): AgentRun<T>;
+  /**
+   * Declare an automation this agent runs unattended. A bare string is a cron
+   * expression; the other four shapes are `{ every }`, `{ at }`, `{ event }` and
+   * `{ webhook }`.
+   *
+   *     support.on("0 9 * * 1", "summarize the week and email ops");
+   *     support.on({ every: "1d" }, "refresh credit scores");
+   *     support.on({ event: "payment.failed" }, "triage and notify the user");
+   *     support.on("0 2 * * *", "rebuild the digest", { id: "nightly-digest" });
+   *
+   * Returns void because it is a DECLARATION: it is validated here and now — a
+   * bad cron throws at module load, with what, why, a did-you-mean and the docs
+   * — and reconciled against the store when `createVendo` boots. The code is the
+   * consent, so deleting the call disarms the automation on the next deploy;
+   * `disable()` by a person outlives every redeploy.
+   */
+  on(when: When, task: string, options?: OnOptions): void;
   session(subject: string, options?: SessionOptions): Promise<AgentSession>;
   /**
    * This agent's MCP door, present exactly when its harness thinks outside this
@@ -370,6 +389,7 @@ export function agent(config: AgentConfig): VendoAgent {
       return session.stream(message, options.signal === undefined ? {} : { signal: options.signal });
     },
     run: (task, options) => startRun(deps, task, options),
+    on: (when, task, options) => declareAutomation(built, when, task, options),
     async session(subject, options) {
       await requireModel();
       return createSession(deps, subject, options);

--- a/packages/agents/src/automations.ts
+++ b/packages/agents/src/automations.ts
@@ -1,0 +1,91 @@
+/**
+ * `agent.on(...)` — automations authored in code.
+ *
+ * A DECLARATION, never a write: the call validates and stashes, and the
+ * umbrella's boot reconcile is what reaches the store. That split is the layer
+ * map, not a preference — this package may not import `@vendoai/automations`
+ * (`scripts/dependency-guard.mjs`), so the declaration stops here and
+ * `createVendo` carries it the rest of the way.
+ *
+ * Consent for a code-authored automation IS the code, so a redeploy reconciles:
+ * new → created, edited → a new identity with the old one disarmed, deleted from
+ * the source → disarmed (never deleted, so its run history survives).
+ */
+import {
+  AUTOMATIONS_DOCS_URL,
+  reconcileAutomations,
+  toTriggerSource,
+  VendoError,
+  type AutomationRecord,
+  type Budget,
+  type DeclaredAutomation,
+  type Principal,
+  type ReconcilePlan,
+  type When,
+} from "@vendoai/core";
+import type { VendoAgent } from "./agent.js";
+
+export interface OnOptions {
+  /** Stable identity. Unset → hash(when + task + agent), so editing the cron or
+   *  the words MINTS A NEW automation and disarms the old one at the next boot.
+   *  Name one to keep an automation's identity across an edit. */
+  id?: string;
+  /** The zone `when` is read in; unset → UTC. */
+  timezone?: string;
+  budget?: Budget;
+}
+
+const declarations = new WeakMap<VendoAgent, DeclaredAutomation[]>();
+
+/** What `.on()` collected, read the way {@link agentComposition} is — through a
+ *  WeakMap, so the public agent object stays exactly what it was. */
+export const agentAutomations = (agent: VendoAgent): readonly DeclaredAutomation[] =>
+  declarations.get(agent) ?? [];
+
+/** The body of {@link VendoAgent.on}, bound to the agent whose `name` every
+ *  declaration carries — that name is the runner-map key the firing looks up. */
+export function declareAutomation(
+  agent: VendoAgent,
+  when: When,
+  task: string,
+  options: OnOptions = {},
+): void {
+  // Synchronously, at declaration — a bad cron is a boot error with a way out,
+  // never a firing that quietly never happens. `toTriggerSource` is core's one
+  // converter, shared by all four authoring doors, so they cannot drift.
+  toTriggerSource(when);
+  if (task.trim() === "") {
+    throw new VendoError(
+      "validation",
+      `${agent.name}.on() was given an empty task — an automation runs on the words you write there, e.g. `
+      + `${agent.name}.on("0 9 * * 1", "summarize the week and email ops"). See ${AUTOMATIONS_DOCS_URL}`,
+    );
+  }
+  declarations.set(agent, [...agentAutomations(agent), {
+    ...(options.id === undefined ? {} : { id: options.id }),
+    when,
+    task: {
+      kind: "goal",
+      prompt: task,
+      ...(options.budget === undefined ? {} : { budget: options.budget }),
+    },
+    agent: agent.name,
+    ...(options.timezone === undefined ? {} : { timezone: options.timezone }),
+  }]);
+}
+
+/**
+ * What the umbrella applies at boot: every declared automation across the
+ * agents it composed, diffed against what is stored, through core's one
+ * reconcile.
+ *
+ * Names ride through VERBATIM. Two agents called "support" produce two sets of
+ * declarations both claiming that runner name; collapsing them here would hide
+ * a collision the runner map has to throw on.
+ */
+export const agentAutomationPlan = (
+  agents: readonly VendoAgent[],
+  stored: readonly AutomationRecord[],
+  owner: Principal,
+): ReconcilePlan =>
+  reconcileAutomations(agents.flatMap((agent) => agentAutomations(agent)), stored, owner, "code");

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -18,6 +18,11 @@ export {
   type VendoAgent,
 } from "./agent.js";
 export {
+  agentAutomationPlan,
+  agentAutomations,
+  type OnOptions,
+} from "./automations.js";
+export {
   awayRunner,
   type AgentReport,
   type AgentRun,

--- a/packages/agents/tests/automations.test.ts
+++ b/packages/agents/tests/automations.test.ts
@@ -1,0 +1,200 @@
+import {
+  toTriggerSource,
+  type AutomationRecord,
+  type CreateAutomationInput,
+  type Principal,
+  type VendoError,
+} from "@vendoai/core";
+import { createStore } from "@vendoai/store";
+import { defineHarness } from "@vendoai/harnesses";
+import { describe, expect, it } from "vitest";
+import { agent } from "../src/agent.js";
+import { agentAutomationPlan, agentAutomations } from "../src/automations.js";
+
+let stores = 0;
+const memoryStore = () => createStore({ dataDir: `memory://agents-automations-${stores++}` });
+
+const inert = () => defineHarness({ name: "inert", async *run() {} });
+
+const host: Principal = { kind: "org", subject: "host" };
+const NOW = "2026-08-17T00:00:00.000Z";
+
+const support = (name = "support") => agent({ name, harness: inert(), store: memoryStore() });
+
+/** A stored record as the engine would have written the plan's create input —
+ *  the second half of the loop a redeploy closes. */
+const asStored = (input: CreateAutomationInput, extra: Partial<AutomationRecord> = {}): AutomationRecord => ({
+  id: input.id ?? "atm_unminted",
+  owner: input.owner,
+  when: toTriggerSource(input.when),
+  task: input.task,
+  ...(input.agent === undefined ? {} : { agent: input.agent }),
+  ...(input.timezone === undefined ? {} : { timezone: input.timezone }),
+  armed: true,
+  authoredBy: input.authoredBy,
+  createdAt: NOW,
+  updatedAt: NOW,
+  ...extra,
+});
+
+describe("agent.on() — declaration", () => {
+  it("takes all five shapes and returns void", () => {
+    const a = support();
+    expect(a.on("0 9 * * 1", "summarize the week and email ops")).toBeUndefined();
+    a.on({ every: "1d" }, "refresh credit scores");
+    a.on({ at: "2099-09-01T09:00:00.000Z" }, "send the launch recap");
+    a.on({ event: "payment.failed" }, "triage and notify the user");
+    a.on({ webhook: "stripe" }, "reconcile the invoice");
+    expect(agentAutomations(a)).toHaveLength(5);
+  });
+
+  it("carries the agent's own name — that is the runner-map key the fire looks up", () => {
+    const a = support("billing");
+    a.on("0 2 * * *", "rebuild the digest");
+    expect(agentAutomations(a)[0]).toMatchObject({
+      agent: "billing",
+      task: { kind: "goal", prompt: "rebuild the digest" },
+    });
+  });
+
+  it("carries the options bag: id, timezone and budget", () => {
+    const a = support();
+    a.on("0 2 * * *", "rebuild the digest", {
+      id: "nightly-digest",
+      timezone: "Europe/London",
+      budget: { maxToolCalls: 20 },
+    });
+    expect(agentAutomations(a)[0]).toEqual({
+      id: "nightly-digest",
+      when: "0 2 * * *",
+      task: { kind: "goal", prompt: "rebuild the digest", budget: { maxToolCalls: 20 } },
+      agent: "support",
+      timezone: "Europe/London",
+    });
+  });
+
+  it("an agent that declared nothing has nothing", () => {
+    expect(agentAutomations(support())).toEqual([]);
+  });
+
+  it("english in the cron slot fails HERE, with what, why, a did-you-mean and the docs", () => {
+    const a = support();
+    let thrown: VendoError | undefined;
+    try {
+      a.on("every monday", "summarize the week");
+    } catch (error) {
+      thrown = error as VendoError;
+    }
+    expect(thrown?.code).toBe("validation");
+    const message = thrown?.message ?? "";
+    // All FOUR parts, named one at a time — a three-part error reads fine and
+    // still leaves the author without the thing they can paste.
+    expect(message).toContain('"every monday" is not a cron expression'); // what
+    expect(message).toContain("a cron expression has exactly 5 fields"); // why
+    expect(message).toContain('Did you mean "0 9 * * 1"?'); // did-you-mean, and it IS Monday
+    expect(message).toContain("https://vendo.run/docs/capabilities/automations"); // docs
+    // Declaration-time means nothing was collected: the process fails at module
+    // load, not at 2am on a Monday that never comes.
+    expect(agentAutomations(a)).toEqual([]);
+  });
+
+  it("an empty task fails at declaration too, naming the agent and a shape that works", () => {
+    const a = support();
+    expect(() => a.on("0 9 * * 1", "   ")).toThrow(/support\.on\(\) was given an empty task/);
+    expect(agentAutomations(a)).toEqual([]);
+  });
+});
+
+describe("boot reconcile", () => {
+  it("a new declaration is created, owned by the host and authored by the code", () => {
+    const a = support();
+    a.on("0 9 * * 1", "summarize the week and email ops");
+    const plan = agentAutomationPlan([a], [], host);
+    expect(plan.disarm).toEqual([]);
+    expect(plan.create).toHaveLength(1);
+    expect(plan.create[0]).toMatchObject({
+      owner: host,
+      when: "0 9 * * 1",
+      agent: "support",
+      authoredBy: "code",
+      task: { kind: "goal", prompt: "summarize the week and email ops" },
+    });
+  });
+
+  it("a redeploy of unchanged code is a no-op — identity is hash(when + task)", () => {
+    const a = support();
+    a.on("0 9 * * 1", "summarize the week and email ops");
+    const first = agentAutomationPlan([a], [], host);
+    const again = agentAutomationPlan([a], [asStored(first.create[0]!)], host);
+    expect(again).toEqual({ create: [], disarm: [] });
+  });
+
+  it("editing the words mints a NEW identity and disarms the old one", () => {
+    const before = support();
+    before.on("0 9 * * 1", "summarize the week and email ops");
+    const stored = asStored(agentAutomationPlan([before], [], host).create[0]!);
+
+    const after = support();
+    after.on("0 9 * * 1", "summarize the week and post it to Slack");
+    const plan = agentAutomationPlan([after], [stored], host);
+
+    expect(plan.disarm).toEqual([stored.id]);
+    expect(plan.create).toHaveLength(1);
+    expect(plan.create[0]?.id).not.toBe(stored.id);
+  });
+
+  it("a stable id opts out: the same automation survives an edit", () => {
+    const before = support();
+    before.on("0 9 * * 1", "summarize the week", { id: "weekly" });
+    const stored = asStored(agentAutomationPlan([before], [], host).create[0]!);
+
+    const after = support();
+    after.on("0 9 * * 1", "summarize the week and post it to Slack", { id: "weekly" });
+    const plan = agentAutomationPlan([after], [stored], host);
+
+    expect(plan.disarm).toEqual([]);
+    expect(plan.create.map((input) => input.id)).toEqual([stored.id]);
+  });
+
+  it("deleting the call disarms the automation — the code was the consent", () => {
+    const a = support();
+    a.on("0 9 * * 1", "summarize the week");
+    const stored = asStored(agentAutomationPlan([a], [], host).create[0]!);
+
+    expect(agentAutomationPlan([support()], [stored], host)).toEqual({ create: [], disarm: [stored.id] });
+  });
+
+  it("a manual kill switch survives every redeploy", () => {
+    const a = support();
+    a.on("0 9 * * 1", "summarize the week");
+    const killed = asStored(agentAutomationPlan([a], [], host).create[0]!, {
+      armed: false,
+      disarmedBy: "user",
+    });
+    // Neither re-armed by the declaration that still names it, nor disarmed
+    // again: a person's decision is not the code's to revisit.
+    expect(agentAutomationPlan([a], [killed], host)).toEqual({ create: [], disarm: [] });
+    expect(agentAutomationPlan([support()], [killed], host)).toEqual({ create: [], disarm: [] });
+  });
+
+  it("chat-authored records are none of the code's business", () => {
+    // Same owner as the code reconcile, so it is AUTHORSHIP doing the filtering.
+    const chat = asStored({
+      id: "atm_chat",
+      owner: host,
+      when: "0 9 * * 1",
+      task: { kind: "goal", prompt: "pay my rent" },
+      authoredBy: "chat",
+    });
+    expect(agentAutomationPlan([support()], [chat], host)).toEqual({ create: [], disarm: [] });
+  });
+
+  it("two agents claiming one name are NOT collapsed — the runner map owns that throw", () => {
+    const first = support();
+    const second = support();
+    first.on("0 9 * * 1", "summarize the week");
+    second.on("0 9 * * 1", "chase the overdue invoices");
+    expect(agentAutomationPlan([first, second], [], host).create.map((input) => input.agent))
+      .toEqual(["support", "support"]);
+  });
+});

--- a/packages/agents/tests/away.test.ts
+++ b/packages/agents/tests/away.test.ts
@@ -29,14 +29,14 @@ const readDescriptor: ToolDescriptor = {
 };
 
 /** The engine's fire-time ctx: the sponsor, venue "automation", presence "away",
- *  and the firing trigger's own id. */
+ *  and the firing automation's own id. */
 const fireCtx = (): RunContext => ({
   principal: { kind: "user", subject: "u_owner" },
   venue: "automation",
   presence: "away",
   sessionId: "sess_run_1",
   appId: "app_digest",
-  trigger: { runId: "run_1", kind: "host-event", id: "nightly" },
+  trigger: { runId: "run_1", kind: "host-event", automationId: "atm_nightly" },
 });
 
 /** A registry the runner is HANDED (the engine passes the task's guard-bound one),
@@ -80,14 +80,14 @@ async function armTrigger(store: VendoStore): Promise<void> {
     scope: { kind: "tool" as const },
     duration: "standing" as const,
     appId: "app_digest",
-    triggerId: "nightly",
+    automationId: "atm_nightly",
     source: "automation" as const,
     grantedAt: new Date().toISOString(),
   };
   await store.records("vendo_grants").put({
     id: grant.id,
     data: grant,
-    refs: { subject: grant.subject, tool: grant.tool, app_id: grant.appId, trigger_id: grant.triggerId },
+    refs: { subject: grant.subject, tool: grant.tool, app_id: grant.appId, automation_id: grant.automationId },
   });
 }
 
@@ -221,13 +221,13 @@ describe("awayRunner", () => {
 
     expect(seen?.interactive).toBe(false);
     // The registry is asked for descriptors with the FIRING ctx — venue, presence
-    // and the trigger id intact, because the guard's away-grant lookup matches on it.
+    // and the automation id intact, because the guard's away-grant lookup matches on it.
     const asked = registry.ctxs.find((ctx) => ctx !== undefined);
     expect(asked).toMatchObject({
       venue: "automation",
       presence: "away",
       appId: "app_digest",
-      trigger: { id: "nightly", runId: "run_1" },
+      trigger: { automationId: "atm_nightly", runId: "run_1" },
     });
   });
 


### PR DESCRIPTION
> Base is `automations/s1-engine` (#1394), so this diff is lane S2a alone: 5 files, all under `packages/agents`.

## The shape

A developer authors an automation in code, and **the code IS the consent**:

```ts
support.on("0 9 * * 1", "summarize the week and email ops");  // bare string = cron
support.on({ every: "1d" }, "refresh credit scores");
support.on({ at: "2026-09-01T09:00Z" }, "send the launch recap");
support.on({ event: "payment.failed" }, "triage and notify the user");
support.on({ webhook: "stripe" }, "reconcile the invoice");
support.on("0 2 * * *", "rebuild the digest", {
  id: "nightly-digest",      // stable identity; default = hash(when + task + agent)
  timezone: "Europe/London",
  budget: { maxToolCalls: 20 },
});
```

`.on()` returns `void` because it is a DECLARATION, not a write. It validates where it is written and stashes into a WeakMap; `createVendo` boots and reconciles. That split is the layer map rather than a preference — `@vendoai/agents` may not import `@vendoai/automations` (`scripts/dependency-guard.mjs:124`), so the declaration has to stop here.

## A bad cron fails at module load, not at 2am

`.on()` calls core's one `toTriggerSource`, the same converter the other three authoring doors use, so English in the cron slot gets the same four-part sentence everywhere — what, why, a did-you-mean the author can paste, and the docs:

```
"every monday" is not a cron expression — a cron expression has exactly 5 fields.
Did you mean "0 9 * * 1"? See https://vendo.run/docs/capabilities/automations
```

Nothing is collected when it throws, so a cron nobody can run cannot reach a store.

## One plan builder, one plan applier

`agentAutomationPlan` folds every composed agent's declarations through core's `reconcileAutomations` and returns a `ReconcilePlan`. It BUILDS a plan and does nothing else — the engine's `automationsInternals(engine).reconcile` is the only thing that applies one, so there is no second write path to disagree with the first.

Agent names ride through **verbatim**. Two agents claiming one name produce two declarations both claiming that runner name, because collapsing them here would hide a collision the runner map has to throw on at startup (`packages/automations/src/runner-map.ts:19`).

## Tests

The tests in this lane's original commit had **never been executed** — the commit was written against a contracts sheet and never gated. Passing on a first run proves nothing, so every load-bearing behavior had its implementation broken and the test watched fail.

Mutating `packages/agents/src/automations.ts`, one at a time, restoring after each:

| Mutation | Test that went red |
|---|---|
| drop the declaration-time `toTriggerSource()` call | `english in the cron slot fails HERE` — `expected undefined to be 'validation'` |
| reconcile as `manifest` instead of `code` | `a new declaration is created, owned by the host and authored by the code` |
| collapse two agents sharing a name | `two agents claiming one name are NOT collapsed` — `expected [ 'support' ] to deeply equal [ 'support', 'support' ]` |
| declaration stops carrying `agent.name` | 4 tests red, including the plan's `agent` values |
| empty task accepted | `an empty task fails at declaration too` — `expected [Function] to throw an error` |

**The kill switch — the invariant that matters most — needed a second pass.** Breaking it in `packages/core/src/automation.ts` changed nothing: 14/14 still passed. The reason is worth writing down, because it weakens any lane that gates a downstream package without rebuilding core — `packages/agents/vitest.config.ts` sets no alias to core's `src`, and core's `package.json` exports resolve to `./dist`, so a core **source** edit is invisible to this suite. Mutating the same two lines in `packages/core/dist/automation.js` turned the test red both times:

```
F: dist stops skipping a user-disarmed record on the create side
   × a manual kill switch survives every redeploy
     expected { create: [ { …(6) } ], disarm: [] } to deeply equal { create: [], disarm: [] }

G: dist stops excluding a user-disarmed record from the disarm list
   × a manual kill switch survives every redeploy
     expected { create: [], …(1) } to deeply equal { create: [], disarm: [] }
```

So the test bites on **both** halves: a killed record the code still declares is not re-created, and a killed record the code no longer declares is not disarmed again. Core's `dist` is current with its source — built 00:41, after the foundation commit that introduced `automation.ts` (00:37), and S1's only later edit to that file was type-only (`ctx: { principal: Principal }` → `ctx: RunContext`), which erases at runtime.

`away.test.ts` follows core's `TriggerRef.id` → `automationId` rename. That is required at the base regardless of this lane: with the base copy of the file checked in, `@vendoai/agents` does not typecheck.

```
$ git checkout origin/automations/s1-engine -- packages/agents/tests/away.test.ts
$ tsc -p tsconfig.test.json --noEmit
tests/away.test.ts(39,50): error TS2353: Object literal may only specify known
  properties, and 'id' does not exist in type 'TriggerRef'.
```

## Gates

Run twice, identical both times:

```
$ pnpm --filter @vendoai/agents test
 Test Files  16 passed (16)
      Tests  148 passed (148)
```

```
$ pnpm --filter @vendoai/agents typecheck    # src + tests
$ tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit
TYPECHECK_EXIT=0

$ node scripts/dependency-guard.mjs
dependency-guard: OK (30 packages checked)

$ npx eslint --config eslint.blocking.config.mjs --no-config-lookup packages/agents
ESLINT_EXIT=0
```

`pnpm build` and `portability-gate` are red at the base and not from this lane — `packages/apps/src/server/automation/plan.ts:83` calls `triggerSchema.omit()` and core has no `triggerSchema`. That is lane S2b's fix, dispatched separately; flagged, not worked around. CI's `ci` check remains the gate of record.

## What this does not cover

**The duplicate-agent-name throw is not tested from this package, and cannot be.** The throw lives in `@vendoai/automations`, which `@vendoai/agents` may not import — in src *or* in tests, since `dependency-guard` scans test files too (`scripts/dependency-guard.mjs:26-29`). It is already proven against the real map in the S1 lane (`packages/automations/tests/engine.test.ts:382`), and the boot loop that calls `register` is lane S2c's — `packages/vendo/src/compose-automations.ts:98` still passes a single `runner:` today. What this lane proves is its own half: names reach the map uncollapsed, so the collision is not silently merged before it gets there.

No changeset, matching the two lanes below this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces `agent.on()` in `@vendoai/agents` to declare automations in code and reconcile them at boot. Invalid crons now fail at module load (old: could slip to runtime), and reconciliation uses core’s single path, making code the consent.

- **Review notes**
  - `.on()` validates via `@vendoai/core` `toTriggerSource`; bad cron and empty tasks throw immediately with actionable messages.
  - Declarations are stashed in a WeakMap (`agentAutomations`); no store writes in `@vendoai/agents`. Boot builds a plan with `agentAutomationPlan` using `@vendoai/core` `reconcileAutomations` and authoredBy `code`.
  - Identity defaults to a hash of when+task+agent; editing mints a new id and disarms the old. Set `options.id` to keep identity across edits. Deleting the call disarms on next deploy. Manual user disarm is preserved.
  - Agent names pass through verbatim; do not collapse duplicate names. Collisions are surfaced by `@vendoai/automations` at startup.
  - Tests added for declaration, plan building, and kill-switch behavior. `away.test.ts` follows the core rename to `TriggerRef.automationId`.

- **Migration**
  - Replace uses of `trigger.id` with `trigger.automationId` in run context and store refs.
  - Ensure cron strings are valid and tasks are non-empty when adopting `agent.on()`.

<sup>Written for commit c6f08d92835cc67579f68299f50240cbc6cbd598. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

