### PR TITLE
fix(core,automations,ui): six defects the e2e paths found — two 500s on public doors, a dead authoring door, and a raw id in a consent prompt

### DIFF
--- a/examples/demo-bank/src/demo-script/engine.ts
+++ b/examples/demo-bank/src/demo-script/engine.ts
@@ -451,7 +451,6 @@ async function surfaceGrantSet(
     type: "data-vendo-grant-set",
     toolCallId,
     grantSetId,
-    appId: demoAppId(key, ctx.principal.subject),
     name,
     permissions: asks.map((ask) => ({
       approvalId: ask.id,

--- a/packages/automations/src/arming-surface.ts
+++ b/packages/automations/src/arming-surface.ts
@@ -46,7 +46,15 @@ const createArmDoors = (deps: ArmingSurfaceDeps): Pick<AutomationsEngine, "enabl
     // the same authority that turned it off, and a record that stayed flagged
     // would be skipped by every reconcile forever.
     const { disarmedBy: _cleared, ...rest } = found.row;
-    await automations.write({ ...rest, armed: true, updatedAt: iso() });
+    // The set is stamped on the RECORD because that is where a consent surface
+    // holding only the automation id reads it from — chrome resolves the record
+    // through `list()` and settles the whole set with the id it finds there.
+    await automations.write({
+      ...rest,
+      armed: true,
+      ...(missing.length === 0 ? {} : { grantSetId }),
+      updatedAt: iso(),
+    });
     return { enabled: true, missing, ...(missing.length === 0 ? {} : { grantSetId }) };
   };
 

--- a/packages/automations/src/arming-surface.ts
+++ b/packages/automations/src/arming-surface.ts
@@ -9,7 +9,7 @@ import type { ConsentAccess } from "./consent.js";
 import type { EngineBase } from "./engine-context.js";
 import type { GrantsAccess } from "./grants.js";
 import type { AutomationsEngine, RunPlan } from "./index.js";
-import { currentIntentHash, markSponsored, writeSponsorship } from "./sponsorship.js";
+import { currentIntentHash, declaredSurface, markSponsored, writeSponsorship } from "./sponsorship.js";
 import { evaluate, stepArgs, validateForEachItems } from "./steps.js";
 
 export type ArmingSurfaceDeps = {
@@ -78,7 +78,17 @@ const createDryRunDoor = (
     const found = await automations.owned(automationId, ctx);
     const byName = await grants.descriptors(ctx);
     const plan: RunPlan = { steps: [], grantsMissing: [] };
+    // The record's HOST tools, from the one place that rule lives: `declaredSurface`
+    // is every step tool EXCEPT the `fn:` refs, so a steps record naming a tool
+    // absent from it is naming the app's own server code. Listed — a preview says
+    // what would run — but never resolved against the host registry and never a
+    // missing grant. An unknown HOST tool IS in that set, so it still fails loudly.
+    const hostTools = new Set(declaredSurface(found.row));
     const add = async (stepId: string, tool: string): Promise<void> => {
+      if (found.row.task.kind === "steps" && !hostTools.has(tool)) {
+        plan.steps.push({ id: stepId, tool, wouldAsk: false });
+        return;
+      }
       const descriptor = byName.get(tool);
       if (descriptor === undefined) throw new VendoError("validation", `unknown tool in automation: ${tool}`);
       const granted = await grants.liveGrant(found.row.owner.subject, automationId, descriptor);

--- a/packages/automations/src/messages.ts
+++ b/packages/automations/src/messages.ts
@@ -2,16 +2,20 @@
  * §9.9's stop sentences, in one place — the list, the fire-time gate and the
  * stopped run row all print them and have to match byte for byte.
  */
-import type { AutomationRecord } from "@vendoai/core";
+import { humanizeToolName, type AutomationRecord } from "@vendoai/core";
 import type { Sponsorship } from "./sponsorship.js";
 
 /** What to CALL an automation in a sentence a person reads. A record has no
  *  name field — it is a task, so the task is the name. Capped, because this
- *  goes inside a sentence and a goal prompt can be a paragraph. */
+ *  goes inside a sentence and a goal prompt can be a paragraph.
+ *
+ *  A goal's prompt is already a person's words; a step's tool is an IDENTIFIER,
+ *  and design §3's voice law is that no surface prints one at someone — so it
+ *  arrives through the same prettifier chrome titles a tool chip with. */
 export const automationName = (record: AutomationRecord): string => {
   const text = record.task.kind === "goal"
     ? record.task.prompt.trim()
-    : record.task.steps[0]?.tool ?? "";
+    : humanizeToolName(record.task.steps[0]?.tool ?? "");
   return text.length <= 60 ? text || record.id : `${text.slice(0, 59)}…`;
 };
 

--- a/packages/automations/src/run-rows.ts
+++ b/packages/automations/src/run-rows.ts
@@ -4,8 +4,10 @@
  * in-flight run interleaves with.
  *
  * ONE ledger. The owner / agent / automation / console views are FILTERS over
- * it, which is why the refs carry all three keys rather than just the one the
- * first caller happened to need.
+ * it — but only the two keys `vendo_runs` DECLARES are refs (routing.ts), and a
+ * run names no subject of its own. Owner and agent are read off the row by
+ * `runs.list`; writing them here as refs no store would answer is what made
+ * `runs.list({ owner })` throw.
  */
 import {
   auditContext,
@@ -80,9 +82,7 @@ export const createRunRows = ({ base: { config, engine, iso, stopped } }: RunRow
       },
       refs: {
         automation_id: record.automationId,
-        subject: record.owner.subject,
         status: record.status,
-        ...(record.agent === undefined ? {} : { agent: record.agent }),
       },
     });
     return true;

--- a/packages/automations/src/runs-surface.ts
+++ b/packages/automations/src/runs-surface.ts
@@ -44,10 +44,14 @@ const createRunReadDoors = (
     ) {
       return { runs: [] };
     }
+    // Only what the ledger is KEYED by goes to the store: `vendo_runs` carries an
+    // automation id and a status and nothing else — a run names no subject of its
+    // own, which is also why the erase cascade reaches a person's runs through
+    // their automations (packages/store/src/erase.ts). Owner and agent are read
+    // off the row in the walk below, exactly as `list` reads an automation's
+    // `agent` off its row.
     const refs = {
       ...(filter.automationId === undefined ? {} : { automation_id: filter.automationId }),
-      ...(filter.owner === undefined ? {} : { subject: filter.owner }),
-      ...(filter.agent === undefined ? {} : { agent: filter.agent }),
       ...(filter.status === undefined ? {} : { status: filter.status }),
     };
     const runs: RunRecord[] = [];
@@ -65,6 +69,8 @@ const createRunReadDoors = (
       });
       for (const stored of page.records) {
         const run = parseRunRecord(stored);
+        if (filter.owner !== undefined && run.owner.subject !== filter.owner) continue;
+        if (filter.agent !== undefined && run.agent !== filter.agent) continue;
         if (automations.speaksFor(ctx, run.owner.subject)) runs.push(publicRun(run));
       }
       cursor = page.cursor;

--- a/packages/automations/src/sponsorship.ts
+++ b/packages/automations/src/sponsorship.ts
@@ -49,11 +49,17 @@ export const sponsorshipSchema = z.object({
 
 /** The tools an automation DECLARES it will use: its steps' host tools, deduped.
  *  A goal declares nothing — its toolset is whatever the registry binds at fire
- *  time, which is not a declaration. */
+ *  time, which is not a declaration.
+ *
+ *  An `fn:` step is dropped because it is not a host tool: it is the app's own
+ *  server code, run inside the app's own box, which never sees host credentials
+ *  (`packages/apps/src/server/escalation/fn.ts`) — so the host has no descriptor
+ *  to grade, no hash to bind, and nothing to consent to. Its authority is the
+ *  app's boundary, and the automation's own kill switch is what revokes it. */
 export const declaredSurface = (record: AutomationRecord): string[] =>
   record.task.kind !== "steps"
     ? []
-    : [...new Set(record.task.steps.map((step) => step.tool))];
+    : [...new Set(record.task.steps.map((step) => step.tool).filter((tool) => !tool.startsWith("fn:")))];
 
 /** The intent this record's consent is bound to — core's own content hash, the
  *  SAME one that mints a declaration's default id. One hash, so "this changed"

--- a/packages/automations/tests/engine.test.ts
+++ b/packages/automations/tests/engine.test.ts
@@ -1631,6 +1631,48 @@ describe("dry runs, run visibility, goal execution, and stopping", () => {
     expect((await engine.runs.list({ automationId: record.id, status: "ok" }, ctx())).runs).toHaveLength(1);
   });
 
+  /** 07 §5 — the owner and agent views are FILTERS over the one ledger. Both are
+   *  declared on the public surface and both are mapped from a query param on the
+   *  public `/runs` route, so a filter the store cannot answer is a 500 on a
+   *  documented door rather than a result. */
+  it("filters the one ledger by owner and by agent", async () => {
+    const store = memoryStoreAdapter();
+    const engine = createAutomations({
+      tools: registry([readTool]),
+      guard: new GuardDouble(),
+      store,
+      now: () => NOW,
+      memberships: async () => [{ org: "org_acme" }],
+    });
+    register(engine, async () => ({ status: "ok", summary: "mine", toolCalls: [] }));
+    register(engine, async () => ({ status: "ok", summary: "theirs", toolCalls: [] }), "nightly");
+    // §9.1 — the org is ASSERTED for this caller, so it speaks for both subjects
+    // and both records' runs are its to read.
+    const member: RunContext = { ...ctx(), memberships: [{ org: "org_acme" }] };
+    const mine = await create(engine, {
+      id: "atm_ledger_mine",
+      when: { event: "go" },
+      task: { kind: "goal", prompt: "mine" },
+    }, member);
+    const theirs = await create(engine, {
+      id: "atm_ledger_org",
+      owner: { kind: "user", subject: "org_acme" },
+      when: { event: "go" },
+      task: { kind: "goal", prompt: "theirs" },
+      agent: "nightly",
+    }, member);
+
+    await engine.emit("go", {}, member.principal);
+
+    expect((await engine.runs.list({}, member)).runs).toHaveLength(2);
+    expect((await engine.runs.list({ owner: "org_acme" }, member)).runs)
+      .toMatchObject([{ automationId: theirs.id }]);
+    expect((await engine.runs.list({ owner: "user_a" }, member)).runs)
+      .toMatchObject([{ automationId: mine.id }]);
+    expect((await engine.runs.list({ agent: "nightly" }, member)).runs)
+      .toMatchObject([{ automationId: theirs.id }]);
+  });
+
   it("marks an in-flight goal run stopped, discards the late result, and rejects terminal stops", async () => {
     const store = memoryStoreAdapter();
     const guard = new GuardDouble();

--- a/packages/automations/tests/engine.test.ts
+++ b/packages/automations/tests/engine.test.ts
@@ -672,6 +672,28 @@ describe("automations enable and grant capture", () => {
       consumedAt: NOW.toISOString(),
     });
   });
+
+  /** Design §3's voice law — a consent sentence may never print an identifier at
+   *  someone. A steps record has no name field, so its first step is what names
+   *  it, and it has to arrive in words. */
+  it("names a steps automation in the consent sentence in words, not in its step's identifier", async () => {
+    const invoicesTool: ToolDescriptor = {
+      name: "host_invoices_list",
+      description: "List invoices.",
+      inputSchema: { type: "object" },
+      risk: "read",
+    };
+    const engine = createAutomations({ tools: registry([invoicesTool]), guard, store, now: () => NOW });
+    const record = await create(engine, {
+      id: "atm_named_steps",
+      when: { event: "go" },
+      task: { kind: "steps", steps: [{ id: "list", tool: invoicesTool.name }] },
+    });
+
+    const { missing } = await engine.enable(record.id, ctx());
+
+    expect(missing[0]?.inputPreview).toContain('Allow "Invoices list" to');
+  });
 });
 
 describe("grant sets: one set per enable, dedupe against pending", () => {

--- a/packages/automations/tests/engine.test.ts
+++ b/packages/automations/tests/engine.test.ts
@@ -1614,6 +1614,51 @@ describe("dry runs, run visibility, goal execution, and stopping", () => {
     expect((await store.records("automations:captures").list()).records).toHaveLength(0);
   });
 
+  /** `dryRun` is public surface, and a manifest automation's only step is an app
+   *  function — so a preview of one has to ANSWER. An `fn:` ref is the app's own
+   *  server code, so it is listed (a preview says what would run) but never
+   *  resolved against the host registry and never a missing grant. */
+  it("previews an app-function step instead of resolving it against the host registry", async () => {
+    const store = memoryStoreAdapter();
+    const engine = createAutomations({
+      tools: registry([readTool]), guard: new GuardDouble(), store, now: () => NOW,
+    });
+    const record = await create(engine, {
+      id: "atm_dryrun_fn",
+      authoredBy: "manifest",
+      when: "0 8 * * *",
+      task: { kind: "steps", steps: [
+        { id: "fire", tool: "fn:chaseInvoices" },
+        { id: "read", tool: readTool.name },
+      ] },
+    });
+
+    const plan = await engine.dryRun(record.id, ctx());
+
+    expect(plan.steps).toEqual([
+      { id: "fire", tool: "fn:chaseInvoices", wouldAsk: false },
+      { id: "read", tool: readTool.name, wouldAsk: true },
+    ]);
+    expect(plan.grantsMissing).toEqual([readTool.name]);
+  });
+
+  /** The loud path the case above must not soften: a step naming a HOST tool this
+   *  deployment does not offer is a broken automation, and the preview says so
+   *  rather than quietly dropping the step. */
+  it("still refuses a preview whose step names a host tool the registry has never heard of", async () => {
+    const store = memoryStoreAdapter();
+    const engine = createAutomations({
+      tools: registry([readTool]), guard: new GuardDouble(), store, now: () => NOW,
+    });
+    const record = await create(engine, {
+      id: "atm_dryrun_typo",
+      when: "0 8 * * *",
+      task: { kind: "steps", steps: [{ id: "read", tool: "host_invoices_lst" }] },
+    });
+
+    await expect(engine.dryRun(record.id, ctx())).rejects.toThrow(/unknown tool in automation: host_invoices_lst/);
+  });
+
   it("surfaces a scheduler-refused run (pricing v3 §5) as a failed run carrying the blocked reason", async () => {
     // Under a hosted store, Cloud's scheduler is the firing authority for
     // schedule/external automations and writes run rows with the same shape

--- a/packages/automations/tests/engine.test.ts
+++ b/packages/automations/tests/engine.test.ts
@@ -516,6 +516,39 @@ describe("automations enable and grant capture", () => {
     });
   });
 
+  /** The `vendo.json` fold-in's step list verbatim — `manifest-triggers.ts` writes
+   *  `[{ id: "fire", tool: `fn:${fn}` }]` and then arms it, so this is the whole
+   *  of what one of the four authoring doors asks the engine to consent to. */
+  it("arms an automation whose only step is an app function, with nothing to capture", async () => {
+    const engine = createAutomations({ tools: registry([readTool]), guard, store, now: () => NOW });
+    const record = await create(engine, {
+      id: "atm_manifest_fn",
+      authoredBy: "manifest",
+      when: "0 8 * * *",
+      task: { kind: "steps", steps: [{ id: "fire", tool: "fn:chaseInvoices" }] },
+    });
+
+    expect(await engine.enable(record.id, ctx())).toMatchObject({ enabled: true, missing: [] });
+    expect((await store.records("vendo_approvals").list()).records).toEqual([]);
+  });
+
+  /** The other half of the rule: dropping `fn:` may not widen what runs without
+   *  consent. A host tool named beside an app function is still asked for. */
+  it("still captures the host tool a step list names beside its app function", async () => {
+    const engine = createAutomations({ tools: registry([readTool]), guard, store, now: () => NOW });
+    const record = await create(engine, {
+      id: "atm_mixed_fn",
+      when: "0 8 * * *",
+      task: { kind: "steps", steps: [
+        { id: "fire", tool: "fn:chaseInvoices" },
+        { id: "read", tool: readTool.name },
+      ] },
+    });
+
+    expect((await engine.enable(record.id, ctx())).missing.map(({ call }) => call.tool))
+      .toEqual([readTool.name]);
+  });
+
   it("captures every descriptor for goal runs and mints or discards on decisions", async () => {
     const engine = createAutomations({ tools: registry([readTool, writeTool]), guard, store, now: () => NOW });
     const record = await create(engine, {

--- a/packages/automations/tests/engine.test.ts
+++ b/packages/automations/tests/engine.test.ts
@@ -724,6 +724,16 @@ describe("grant sets: one set per enable, dedupe against pending", () => {
     }
   });
 
+  /** The RECORD has to name its set, because that is where the consent surface
+   *  reads it from: chrome resolves the automation through `automations.list()`
+   *  and settles the whole set with the id it finds there
+   *  (`packages/ui/src/chrome/thread/automation-consent.tsx`). */
+  it("stamps the set on the record, so a surface holding only the id can settle it", async () => {
+    const result = await engine.enable(WEEKLY, ctx());
+
+    expect((await engine.get(WEEKLY, ctx()))?.grantSetId).toBe(result.grantSetId);
+  });
+
   it("re-running enable() reuses the pending ask — no duplicate ApprovalRequest per (automation, tool)", async () => {
     const first = await engine.enable(WEEKLY, ctx());
     guard.decide(first.missing[0]!.id, true);

--- a/packages/core/src/automation.ts
+++ b/packages/core/src/automation.ts
@@ -134,8 +134,10 @@ export interface CreateAutomationInput {
   armed?: boolean;
 }
 
-/** Where a rejected declaration sends its author. */
-export const AUTOMATIONS_DOCS_URL = "https://vendo.run/docs/capabilities/automations";
+/** Where a rejected declaration sends its author. The docs are their own host —
+ *  `vendo.run/docs/**` is a 404, so a refusal built on it sends the developer to
+ *  a dead page. */
+export const AUTOMATIONS_DOCS_URL = "https://docs.vendo.run/capabilities/automations";
 
 /** `<n><s|m|h|d>`, or null. The tick reads it too, so it is stated once here
  *  rather than once per package. */

--- a/packages/core/src/stream-parts.ts
+++ b/packages/core/src/stream-parts.ts
@@ -306,8 +306,7 @@ export interface VendoGrantSetPart {
   /** The set every permission below belongs to — one decision settles all
    *  (mirrors the automations engine's enable() grantSetId). */
   grantSetId: string;
-  appId: AppId;
-  /** The automation document's display name. */
+  /** The automation's display name. */
   name: string;
   /** Every requested permission: its pending guard approval, the tool, the
    *  descriptor's one-line description, and its risk. */
@@ -323,7 +322,6 @@ export const vendoGrantSetPartSchema = z.object({
   type: z.literal("data-vendo-grant-set"),
   toolCallId: z.string(),
   grantSetId: z.string().min(1),
-  appId: appIdSchema,
   name: z.string().min(1),
   permissions: z.array(z.object({
     approvalId: approvalIdSchema,

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -142,6 +142,33 @@ export const VENDO_TOOL_TITLES: Readonly<Record<string, string>> = {
   vendo_report_capability_miss: "Note what I can't do",
 };
 
+/** Prettify a raw tool id / slug into a human label:
+    `host_email_send` → "Email send", `fn:listInvoices` → "List invoices",
+    `gmail_GMAIL_CREATE_EMAIL_DRAFT` → "Gmail create email draft".
+
+    Beside {@link VENDO_TOOL_TITLES} rather than in the render layer for the same
+    reason that table is: §3's voice law binds every surface, and the engine writes
+    consent sentences with no UI on hand (`serviceToolPhrase` is its sibling for
+    service slugs). Chrome's `toolTitle` falls back to it; so does an automation's
+    display name, which is its first step. */
+export function humanizeToolName(raw: string): string {
+  const stripped = raw.replace(/^fn:/i, "").replace(/^host[_:.\- ]?/i, "");
+  const words = stripped
+    // camelCase / PascalCase boundaries
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    // any run of separators
+    .replace(/[._:\-\s]+/g, " ")
+    .trim()
+    .split(" ")
+    .filter(Boolean)
+    .map(word => word.toLowerCase());
+  // Collapse consecutive duplicate tokens ("gmail GMAIL …" → "gmail …").
+  const deduped = words.filter((word, index) => word !== words[index - 1]);
+  if (deduped.length === 0) return raw;
+  const sentence = deduped.join(" ");
+  return sentence.charAt(0).toUpperCase() + sentence.slice(1);
+}
+
 /**
  * The description a MODEL is given for one tool: its human title first, then the
  * operational text.

--- a/packages/core/tests/automation.test.ts
+++ b/packages/core/tests/automation.test.ts
@@ -46,6 +46,10 @@ describe("toTriggerSource", () => {
     expect(error.code).toBe("validation");
     expect(error.message).toContain('"0 9 * * 1"');
     expect(error.message).toContain(AUTOMATIONS_DOCS_URL);
+    // …on the host the docs actually answer on. Every other in-repo docs link is
+    // built on this origin; `vendo.run/docs/**` returns 404, so the link a
+    // refusal hands its author has to be checked, not just present.
+    expect(AUTOMATIONS_DOCS_URL.startsWith("https://docs.vendo.run/")).toBe(true);
   });
 
   it("refuses a cron that is short a field or out of range", () => {

--- a/packages/ui/src/chrome/humanize.ts
+++ b/packages/ui/src/chrome/humanize.ts
@@ -6,7 +6,7 @@
     site: a host-supplied `ToolMeta` (VendoProvider `tools` prop) wins, and when
     it is absent these pure fallbacks prettify the raw id and args so end users
     never read a raw slug, a lifecycle string, or raw JSON. */
-import { declaredMoneyUnit, VENDO_TOOL_TITLES, type Json, type JsonSchema } from "@vendoai/core";
+import { declaredMoneyUnit, humanizeToolName, VENDO_TOOL_TITLES, type Json, type JsonSchema } from "@vendoai/core";
 import { currencyMinorUnits, formatMoney, getKitIntl } from "../kit/format.js";
 
 /** Optional host-supplied friendly metadata for one tool (08-ui provider seam).
@@ -28,26 +28,10 @@ export interface ToolMeta {
 
 export type ToolMetaMap = Record<string, ToolMeta>;
 
-/** Prettify a raw tool id / slug into a human label:
-    `host_email_send` → "Email send", `fn:listInvoices` → "List invoices",
-    `gmail_GMAIL_CREATE_EMAIL_DRAFT` → "Gmail create email draft". */
-export function humanizeToolName(raw: string): string {
-  const stripped = raw.replace(/^fn:/i, "").replace(/^host[_:.\- ]?/i, "");
-  const words = stripped
-    // camelCase / PascalCase boundaries
-    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
-    // any run of separators
-    .replace(/[._:\-\s]+/g, " ")
-    .trim()
-    .split(" ")
-    .filter(Boolean)
-    .map(word => word.toLowerCase());
-  // Collapse consecutive duplicate tokens ("gmail GMAIL …" → "gmail …").
-  const deduped = words.filter((word, index) => word !== words[index - 1]);
-  if (deduped.length === 0) return raw;
-  const sentence = deduped.join(" ");
-  return sentence.charAt(0).toUpperCase() + sentence.slice(1);
-}
+/** Beside {@link VENDO_TOOL_TITLES} in core since the engine writes consent
+    sentences with the same prettifier; re-exported so every chrome caller keeps
+    its one import site. */
+export { humanizeToolName };
 
 /**
  * The display title for a tool, most local authority first: the host's


### PR DESCRIPTION
Six defects found by driving the real end-to-end paths — five by the e2e lane,
the sixth while writing those up. All of them sat in code no open lane owned.

Every one has a named test that was **watched fail first**: the fixes were built,
then the source the tests read was reverse-applied inside a single gate hold so the
red is attributable, then restored. Two of the six are 500s on documented public
doors and share a root cause; one is the string a real user is asked to approve.

## 1 — `runs.list({ owner })` and `({ agent })` were a 500 on a documented public filter

`runs-surface.ts` pushed `owner` and `agent` down to the store as `vendo_runs`
refs, and `vendo_runs` declares neither:

```
$ grep -n 'case "vendo_runs"' -A5 packages/store/src/routing.ts
583:        refs: { automation_id: "automation_id", status: "status" },
```

Both filters are declared public surface (`packages/automations/src/index.ts:157-164`)
and both are mapped from a query param on the public `/runs` route, so every
`?owner=` / `?agent=` request threw `Unknown vendo_runs ref key: subject`.

**I fixed the SURFACE, not the store.** The store is right, and says so in the one
place that had to think about it — the erase cascade reaches a person's runs
through their automations *because a run has no subject of its own*:

```
$ sed -n '213,221p' packages/store/src/erase.ts
      // deleted FIRST, while the join that identifies them still exists (the
      // vendo_thread_messages lesson); a run names no subject of its own.
      await del(report, "vendo_runs",
        "automation_id IN (SELECT id FROM vendo_automations WHERE subject = $1)", [subject]);
```

Making them real refs would mean two new generated columns and indexes on
`vendo_runs`, a guard-fixture mirror edit and a memory-store projection — i.e.
re-keying the runs table on an owner axis, straight against S1's decision to key
it on the automation id. So `owner`/`agent` are now read off the row inside the
page walk, which is **exactly** how `list` already filters an automation's own
`agent` (`list-surface.ts:41`), for the same reason: `vendo_automations` doesn't
declare that ref either.

The producer's half went with it: `run-rows.ts` was *writing* `subject` and
`agent` refs that no store declares and nothing queries (grep proof — the only
two `RUNS` call sites in `src` are this put and that list), so the write and the
read now agree on the same two keys.

**Red:** `VendoError: Unknown vendo_runs ref key: subject` — `filters the one
ledger by owner and by agent`.

## 2 — a `vendo.json` manifest schedule could never be armed, so one of the four authoring doors was dead

`consentSurface` passed `fn:` steps through as host tools, and `captureGrants`
then refused the app's own function, which the fold-in swallowed into a warning —
so **no record was created at all**: no panel row, no kill switch, no run ledger.

```
[vendo] vendo.json schedules for app_manifest_cron were not folded into
automations: unknown tool in automation: fn:chase
```

An `fn:` ref is not a host tool and cannot be one, which is why a grant for it
could never have existed:

```
$ sed -n '19,20p' packages/apps/src/server/escalation/fn.ts
 * The host ToolRegistry never sees an fn: ref; the box never sees host
 * credentials — only content-type crosses the skin, exactly like the wire proxy.
```

`captureGrants` mints from `descriptorHash(descriptor)`; with no descriptor there
is no hash, no risk grade and no sentence to show a person. So `declaredSurface`
— whose own docstring already said "its steps' **host** tools" — now drops them.

**Consent is not widened.** An `fn:` call's authority is the app's boundary (a
machine plus a declared egress list, consented separately) and the automation's
kill switch is what revokes it — a switch that did not exist before this fix. A
second test holds the line: a step list naming a host tool **beside** its `fn:`
step still asks for the host tool.

**Red:** `VendoError: unknown tool in automation: fn:chaseInvoices` — on both
`arms an automation whose only step is an app function, with nothing to capture`
and `still captures the host tool a step list names beside its app function`.

## 3 — the consent prompt asked a real person to approve an identifier

```
before: Allow "host_invoices_list" to use host_invoices_list while you're away (standing, this automation only)
after:  Allow "Invoices list" to use host_invoices_list while you're away (standing, this automation only)
```

A steps record has no name field, so its first step names it — and
`messages.ts:14` handed over the raw tool id. No new mechanism: `humanizeToolName`
already existed and already produced exactly this (`host_email_send` → "Email
send"), it just lived in the render layer where the engine cannot reach it. It
moves next to `VENDO_TOOL_TITLES` and `serviceToolPhrase` in `packages/core`, for
the reason `tools.ts` already gives for that table — "ONE table, because two
sides must say the same words and neither can read the other's copy" — and
chrome's `humanize.ts` re-exports it so every existing caller keeps its import
site. `packages/ui/test/chrome/humanize.test.ts` is untouched and still passes
against the moved implementation, which is the no-behaviour-change proof.

The `use ${tool}` half of that sentence is the same voice-law violation and is
**not** touched here: it was not in this lane's scope, and humanizing it verbatim
reads `Allow "Invoices list" to use Invoices list …` for a single-step
automation, so the action half wants a lowercase verb phrase like
`serviceToolPhrase`'s — copy design, not a defect fix.

**Red:** `expected 'Allow "host_invoices_list" to use hos…' to contain 'Allow
"Invoices list" to'`.

## 4 — every declaration-time refusal linked a 404

`AUTOMATIONS_DOCS_URL` was `https://vendo.run/docs/capabilities/automations`.
The docs are their own host; every other in-repo docs link is built on
`docs.vendo.run` with no `/docs` segment. Checked live rather than assumed:

```
$ curl -sL -o /dev/null -w '%{http_code}\n' https://vendo.run/docs/capabilities/automations
404
$ curl -sL -o /dev/null -w '%{http_code}\n' https://docs.vendo.run/capabilities/automations
200
```

The existing test asserted the message *contains* the constant, which is
tautological and stayed green through the whole bug; it now also asserts the
origin.

**Red:** `expected false to be true` on
`AUTOMATIONS_DOCS_URL.startsWith("https://docs.vendo.run/")`.

## 5 — one declared field deleted, one made true

**`VendoGrantSetPart.appId` — deleted.** Zero readers: nothing anywhere reads
`appId` off a grant-set part. `parts.tsx:418` duck-types the part and requires
`toolCallId`, `grantSetId`, `name` and `permissions` only; `message-data.ts:151`
reads `toolCallId`, `grantSetId` and the approval ids. The only writers were
demo-bank and two test fixtures. It was also unsatisfiable by design — the field
is a required `AppId` (`/^app_.+$/`), a grant set now belongs to a RECORD, and an
app-less automation is first-class, so demo-bank was putting an `atm_…` id in an
app-id slot and anything that ever validated the part with
`vendoGrantSetPartSchema` would have dropped the card. Deleted from the interface,
the schema and demo-bank's producer. The schemas are `.passthrough()`, so no test
fixture needed editing.

**`AutomationRecord.grantSetId` — made true.** It has a real reader, and that
reader states the bug in its own comment:

```
$ sed -n '58,66p' packages/ui/src/chrome/thread/automation-consent.tsx
    // The set id makes the decision atomic across the batch and lets a denial
    // disarm inside the same decision. Read at decide time from the
    // automations projection — the wire PART predates the set id (the record
    // carries it, the part does not) …
    const grantSetId = await client.automations.list()
      .then(entries => entries.find(entry => entry.id === props.automationId)?.grantSetId)
```

The record never carried it: `enable` returned the set id but `arming-surface.ts:49`
rewrote the record without it, so `automations.get(id).grantSetId` was always
undefined and every consent card fell to the plain-ids path — which settles the
asks but does **not** disarm the automation on a full-set denial. `enable` now
stamps the set on the record, exactly when it returns one. Safe against §9.9:
`automationHash` covers `{when, task, agent, timezone}` only, so the stamp cannot
invalidate the sponsorship the same `enable` just wrote.

**Red:** `expected undefined to be 'gset_…'` — `stamps the set on the record, so
a surface holding only the id can settle it`.

## 6 — `dryRun` on an app-function step was the same 500, one door over

Found while writing up defect 2 and handed back to this lane by the conductor.
`arming-surface.ts` kept its OWN copy of "resolve the step tool against the host
registry, throw if absent", so the rule fixed for the consent surface never
reached the preview door:

```
$ grep -n 'unknown tool in automation' packages/automations/src/*.ts
arming-surface.ts:75:      if (descriptor === undefined) throw new VendoError(...
consent.ts:307:      if (authored === undefined) throw new VendoError(...
```

`dryRun` is public surface, so a preview of a manifest automation was a 500. The
preview now reads the rule from the ONE place it lives: `declaredSurface` is every
step tool EXCEPT the `fn:` refs, so a steps record naming a tool absent from it is
naming the app's own server code.

An `fn:` step is **listed** — a preview says what would run, and answering with an
empty plan for an automation that plainly does something would be a second bug —
but it is never resolved against the host registry and never lands in
`grantsMissing`.

**Red:** `VendoError: unknown tool in automation: fn:chaseInvoices` at
`arming-surface.ts:83` — `previews an app-function step instead of resolving it
against the host registry`.

**And the loud path is pinned, not softened.** A second test holds that a step
naming a HOST tool the registry never heard of still refuses — it passes before
the fix (it is pre-existing behaviour this change must not weaken), so it was
proven non-vacuous by mutation: turning that throw into a silent `return` turns it
red with `promise resolved "{ steps: [], grantsMissing: [] }" instead of
rejecting`, which is exactly the silent-drop failure mode it guards.

## Gate

`packages/automations` · `packages/core` · `packages/ui` — the three packages
touched — each run twice, plus `dependency-guard` and scoped eslint
(`gate-s2e-run1.log`, `gate-s2e-run2.log`).

Defect 6 touches `packages/automations` only, so it was re-gated there twice
(104/104 both passes, up from 102 with the two new tests), with typecheck 5/5 over
all three packages, `dependency-guard` OK and eslint clean (`gate-s2e-run6.log`).
`git diff` over `packages/core` and `packages/ui` for that commit is empty, so
their twice-green results stand unchanged.

`pnpm test:affected` was NOT run: this change touches `packages/core`, so its
affected cone is the whole monorepo, i.e. the full suite `CLAUDE.md` forbids
locally. The three packages were gated individually instead.

`packages/vendo` does not build on this base — a pre-existing S2C
work-in-progress break in files this branch never touches
(`compose-apps.ts` wanting `AutomationsEngine.onDocumentEdit` and an
`armAutomation` config key, `wire/automations.ts` wanting `DEFAULT_TRIGGER_ID`).
`examples/*` and `fixtures/automations-e2e` fail downstream of it for the same
reason and still speak the pre-S1 surface. That is why the regression tests live
in `packages/automations/tests` and `packages/core/tests` rather than in the e2e
fixture: the fixture cannot run on this base at all.

Three adjacent defects of the same class were found and deliberately left alone
(reported, not attempted): `dryRun` still throws on an `fn:` step through its own
copy of the check (`arming-surface.ts:75`); a manifest automation now arms but its
fire still cannot resolve `fn:` until the in-runtime fn path lands, so it lands
as a fail-loud `error` row, which is the documented behaviour; and
`packages/vendo/tests/org-automation-sponsorship.test.ts:249` still queries the
`app_id` ref S1 deleted from `vendo_runs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
