### PR TITLE
test(vendo): the mid-firing tap that authorizes a re-run, over the real guard

### DIFF
--- a/packages/vendo/tests/automations-consent-chain.seam.test.ts
+++ b/packages/vendo/tests/automations-consent-chain.seam.test.ts
@@ -1,0 +1,126 @@
+/**
+ * THE WHOLE mid-run consent chain, over one real composition: a firing meets a
+ * permission nobody granted and FAILS, one real tap on the real guard mints the
+ * away authority, and `runs.rerun` spends it — proved by the HOST's own function
+ * running, not by a status.
+ *
+ * Both halves of this were already proved, and neither could catch the other:
+ * `packages/automations/tests/engine.test.ts` re-runs against a `GuardDouble`
+ * whose `check()` always answers "run", so its `status: "ok"` says nothing about
+ * authority, and `packages/guard/test/security/chat-grant-not-away.test.ts`
+ * hand-seeds the grant shape it accepts. Here the guard that refuses the first
+ * call is the guard that authorizes the second, and nothing between them is
+ * stubbed: real `createVendo`, real guard, real automations engine, one real
+ * store, and the host registry's own side effect as the evidence.
+ *
+ * There is no auto-resume, deliberately (`run-execution.ts`, `consent.ts` — the
+ * run ends at the miss); `runs.rerun` is the whole remedy.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { automationsInternals } from "@vendoai/automations";
+import type { Principal, RunContext, ToolRegistry } from "@vendoai/core";
+import { createStore } from "@vendoai/store";
+import { afterEach, describe, expect, it } from "vitest";
+import { createVendo, type Vendo } from "../src/server.js";
+
+const READ_TOOL = "host_readInvoices";
+const owner: Principal = { kind: "user", subject: "nadia" };
+const ctx: RunContext = {
+  principal: owner,
+  venue: "automation",
+  presence: "away",
+  sessionId: "sess_nadia",
+};
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+/** The composed host, and the ledger of what its OWN function was asked to do —
+ *  the only witness that says a run really ran rather than merely said "ok". */
+async function boot(): Promise<{ vendo: Vendo; calls: string[] }> {
+  const root = await mkdtemp(join(tmpdir(), "vendo-consent-chain-"));
+  const store = createStore({ dataDir: join(root, "data") });
+  cleanups.push(async () => {
+    await store.close().catch(() => undefined);
+    await rm(root, { recursive: true, force: true });
+  });
+  const vendo = createVendo({ store, auth: { principal: async () => owner } });
+  const calls: string[] = [];
+  const tools: ToolRegistry = {
+    async descriptors() {
+      return [{ name: READ_TOOL, description: "Read the invoices", inputSchema: { type: "object" }, risk: "read" }];
+    },
+    async execute(call) {
+      calls.push(call.tool);
+      return { status: "ok", output: { invoices: [] } };
+    },
+  };
+  vendo.actions.add(tools);
+  await store.ensureSchema();
+  return { vendo, calls };
+}
+
+describe.sequential("CHECK: a mid-firing tap is the away authority the re-run spends", () => {
+  it("parks and fails, mints one automation grant from the real decision, then really calls the host", async () => {
+    const { vendo, calls } = await boot();
+    const record = await automationsInternals(vendo.automations).create({
+      owner,
+      when: { event: "invoice.paid" },
+      task: { kind: "steps", steps: [{ id: "read", tool: READ_TOOL }] },
+      authoredBy: "chat",
+    }, ctx);
+
+    // Armed, and holding nothing: the away downgrade forces an ask, the run
+    // parks its capture and ends LOUDLY.
+    const [runId] = await vendo.emit("invoice.paid", {}, owner);
+    expect(await vendo.automations.runs.get(runId!, ctx)).toMatchObject({
+      automationId: record.id,
+      status: "error",
+      error: { code: "needs-permission", tool: READ_TOOL },
+    });
+    // The refusal was real: the host's own function was never reached.
+    expect(calls).toEqual([]);
+
+    // The ask the FIRING raised, read back off the guard's own pending feed.
+    const pending = await vendo.guard.approvals.pending(owner);
+    expect(pending.map((ask) => ask.ctx.trigger?.automationId)).toEqual([record.id]);
+
+    // One tap. `{ approve: true }` and nothing else — exactly what the consent
+    // card sends, so the guard's own remembered-grant arm never runs and the
+    // automations engine's decision subscriber is the only minter.
+    await vendo.guard.approvals.decide([pending[0]!.id], { approve: true }, owner);
+
+    const grants = await vendo.guard.grants.list(owner);
+    expect(grants).toHaveLength(1);
+    expect(grants[0]).toMatchObject({
+      subject: owner.subject,
+      tool: READ_TOOL,
+      automationId: record.id,
+      source: "automation",
+      duration: "standing",
+      scope: { kind: "tool" },
+    });
+    // The record's own id is the WHOLE away match (`presenceMatches` in
+    // `packages/guard/src/guard.ts`): an automation carries no app reference at
+    // all, so the rerun below is authorized with NO `appId` on the grant. Pinned
+    // so this stays specifically the automations rule and can never quietly
+    // absorb the boxed-app case, which is a different question with its own fix.
+    expect(grants[0]!.appId).toBeUndefined();
+
+    // A FRESH run of the same firing, and the same guard now says run.
+    const rerunId = await vendo.automations.runs.rerun(runId!, ctx);
+    expect(await vendo.automations.runs.get(rerunId, ctx)).toMatchObject({
+      automationId: record.id,
+      status: "ok",
+    });
+    // THE point: a status of "ok" with the tool never called would be the same
+    // lie in a new costume.
+    expect(calls).toEqual([READ_TOOL]);
+    // The failed run is left as the record of what happened.
+    expect(await vendo.automations.runs.get(runId!, ctx)).toMatchObject({ status: "error" });
+  });
+});


### PR DESCRIPTION
## What

The mid-run consent flow works. Until now it was proved only by two halves that
mock each other — the exact failure mode `CLAUDE.md` warns about, and the one
that let the host-component previews ship dead four times.

- `packages/automations/tests/engine.test.ts:1143` asserts the exact shape of the
  grant a decided approval mints, then re-runs the automation to `ok` — but its
  `GuardDouble.check()` always answers `run` (`:112`), so the re-run succeeding
  says nothing at all about authority.
- `packages/guard/test/security/chat-grant-not-away.test.ts:51` proves the guard
  accepts that grant shape — but hand-seeds the row.
- `automations-grant-seam.seam.test.ts` crosses the real seam for the **arming**
  path only, never the fire-time miss.
- `org-automation-emit.test.ts:90` drives the real guard to `needs-permission`
  and stops there.

So nothing ran the whole chain, and a refactor could have killed a consent flow
in silence.

One new file — `packages/vendo/tests/automations-consent-chain.seam.test.ts` —
runs it, with no double on either side:

1. an armed automation holding no grant fires (`vendo.emit`); the away downgrade
   forces an ask, the run parks its capture and ends `needs-permission`, and the
   HOST's own function is never reached;
2. one `{ approve: true }` tap on `vendo.guard.approvals.decide` — exactly what
   the automation consent card sends, so the guard's own remembered-grant arm
   never runs and the engine's decision subscriber is the only minter;
3. `vendo.guard.grants.list` holds **one** grant: `source: "automation"`, the
   record's own id, `duration: "standing"`, `scope: { kind: "tool" }`, and **no
   `appId`** — an automation carries no app reference, so that id is the whole
   away match (`presenceMatches`). Pinned so this stays specifically the
   automations rule and can never quietly absorb the boxed-app case;
4. `runs.rerun` starts a fresh run the same guard now authorizes — and the proof
   is the host function **actually executing**, not the status. A run that says
   `ok` with the tool never called would be the same lie in a new costume.

Real `createVendo`, real guard, real automations engine, one real store. No
`GuardDouble`, no seeded grant row, no fake store. There is no auto-resume and
the test does not expect one: the failed run stays failed and `runs.rerun` is the
whole remedy.

## Watched red first, three ways

Each mutation was applied to `dist`, because a package's tests resolve sibling
`@vendoai/*` from `dist` and a source edit is invisible to them:

| mutation | red at |
| --- | --- |
| away downgrade disabled in `guard/dist/guard.js` | first firing RUNS — `status: "ok"` where `error` was expected |
| `automationId` dropped from `automations/dist/grants.js` mint | the grant assertion (`automationId` absent) |
| `presenceMatches`' away branch neutered | the re-run stays `status: "error"` |

Both files were then rebuilt from source with `tsc` and verified byte-identical
to their pre-mutation copies.

## Gate

- `pnpm --filter @vendoai/vendo typecheck` — clean
- the new suite, twice: `1 passed` both times
- alongside its neighbours (`org-automation-emit`, `automations-grant-seam`,
  `compose-automations`): `4 files / 11 tests passed`
- `eslint --config eslint.blocking.config.mjs` on the new file — clean

Test-only change; no production code touched.

Note for the reviewer: `pnpm build` does not complete on this base branch —
`examples/demo-bank/src/demo-script/console-seed.ts:38` still imports
`DEFAULT_TRIGGER_ID`, which `af8f2d020` removed from `@vendoai/core`. Every
`@vendoai/*` package builds; only the two Next.js examples fail. Not touched
here (`examples/` is another lane's, and this lane changes no production code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an end-to-end test that proves the mid-run consent flow using the real guard and automations engine. Previous tests mocked either side, so they could not catch regressions across the seam.

- New `packages/vendo/tests/automations-consent-chain.seam.test.ts` boots real `createVendo`, real guard, automations engine, and one store; no doubles or seeded grants.
- First run of an armed automation in away presence ends `needs-permission` and does not call the host tool.
- A single `{ approve: true }` via `vendo.guard.approvals.decide` mints one standing grant with `source: "automation"`, `automationId` set, and no `appId`.
- `runs.rerun` executes the host tool, proving authorization by side effect.
- Test-only change; no production code; no migration. Packages under `@vendoai/*` build and tests pass; examples are unchanged.

<sup>Written for commit 4048530298262c481717a9ff7c26827c2a5a8b1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

