### PR TITLE
chore: changesets for the automations centralization, at 0.27.0

### DIFF
--- a/.changeset/agent-on-declares-an-automation.md
+++ b/.changeset/agent-on-declares-an-automation.md
@@ -1,0 +1,27 @@
+---
+"@vendoai/agents": minor
+"@vendoai/apps": minor
+---
+
+Two doors author an automation now: `agent.on(...)` in your own code, and `vendo_automate` when a person asks in chat.
+
+`support.on(when, task, options?)` is a DECLARATION, never a store write — it validates where you wrote it and `createVendo` reconciles it at boot. All five `When` shapes:
+
+```ts
+support.on("0 9 * * 1", "summarize the week and email ops");
+support.on({ every: "1d" }, "refresh credit scores");
+support.on({ at: "2026-09-01T09:00:00Z" }, "send the launch note");
+support.on({ event: "payment.failed" }, "triage and notify the user");
+support.on({ webhook: "stripe" }, "reconcile the payout");
+support.on("0 2 * * *", "rebuild the digest", { id: "nightly-digest" });
+```
+
+A bad cron throws at module load, not at 2am, with what, why, a did-you-mean you can paste and the docs link. The code is the consent, so a redeploy reconciles: new → created, edited → a new identity with the old one disarmed, deleted from your source → disarmed (never deleted, so its run history survives). Identity defaults to `hash(when + task + agent)`, so editing the cron or the words MINTS a new automation — pass `id` to keep one across an edit. A `disable()` a person did stamps `disarmedBy: "user"`, and that kill switch survives every redeploy.
+
+`@vendoai/agents` newly exports `agentAutomations`, `agentAutomationPlan` and `OnOptions`. The plan is built here and applied only by the engine's own internal reconcile: this package may not import `@vendoai/automations`, so there is no second write path to disagree with the first. Agent names ride through verbatim — two agents claiming one name produce two declarations both claiming that runner name, because collapsing them here would hide a collision the runner map has to throw on at startup.
+
+`vendo_automate` is the chat door — a schedule with nothing to build. It takes `{ task, when?, agent?, timezone? }` and carries **no app argument of any kind**, because a record has no app slot to fill. `vendo_make` still arms the schedule half of a compound ask ("build me the board and refresh it every Monday") and does it by calling the same one create operation, so the two cannot drift into arming differently. The `vendo.json` manifest fold-in is a reconcile through the same core helper: a changed cron replaces its own record under the same identity, a schedule dropped from the manifest disarms its own, an unchanged manifest touches nothing, and two schedules that collapse to one identity are refused out loud rather than last-wins.
+
+**Breaking, and the reason your app writes may start failing:** every triggers-in-documents path is gone rather than shimmed — `app-validation`, the edit journal, interchange, persistence, the runtime types and the write surface all lost their trigger halves. An app document that still carries `triggers` no longer arms anything. What an app may hold instead is an optional `automations: string[]`, maintained by this layer alone (the compound flow and the manifest fold-in, nowhere else) and resolved on read. Deleting the app does NOT stop its automation: the automation fires, reaches for the tool its task named, and fails loudly with a `not-found` that becomes a terminal error run row.
+
+One misuse hole closed on the way past. `vendo_automate`'s `when` now requires exactly one of `every` / `at` / `event` / `webhook` (or a bare cron string) and refuses the rest, naming what it got and where the shapes are written down. An object naming none of them used to become `{ kind: "external", connector: undefined }` — an automation nothing could ever trigger, reported to its owner as armed.

--- a/.changeset/an-automation-is-a-record.md
+++ b/.changeset/an-automation-is-a-record.md
@@ -1,0 +1,27 @@
+---
+"@vendoai/core": minor
+"@vendoai/store": minor
+"@vendoai/automations": minor
+"@vendoai/apps": minor
+"@vendoai/ui": minor
+---
+
+**Breaking.** An automation is a first-class principal-owned RECORD, not an app with a list of triggers. `AppDocument.triggers` is deleted, every automation verb keys off one automation id, and stored automations are NOT migrated — they stop firing at the upgrade and have to be authored again.
+
+**Tell your users before you deploy this.** Their existing automations lived inside `AppDocument.triggers`; nothing reads that field any more, and nothing converts one into a record. They re-create them (`agent.on(...)` in your code, or by asking in chat). Their run history goes too: `vendo_runs` is emptied once, because an app-keyed run row has no read path and no erase selector left to reach it.
+
+## What breaks in your code
+
+**`@vendoai/core`.** `AppDocument.triggers` is gone, and these exports with it: `Trigger`, `triggerSchema`, `RunModel`, `runModelSchema`, `DEFAULT_TRIGGER_ID`, `TRIGGER_ID_PATTERN`, `triggerKindRefKey`, `TRIGGER_KIND_REF_KEYS`, `TRIGGER_KIND_REF_PRESENT` and `triggerKindRefs`. An app now holds at most `automations?: AutomationId[]` — a list of NAMES the apps layer maintains and resolves on read, not a foreign key, so dead ids simply drop out and there is no cascade to run. Writing `triggers` into an app document arms nothing. New in `automation.ts`: `AutomationRecord`, `When` and the one `toTriggerSource` converter, `AutomationTask`, `Budget`, `automationHash` and `reconcileAutomations`. `TriggerRef.id` is `TriggerRef.automationId`, and `PermissionGrant.triggerId` / `MintGrantInput.triggerId` are `automationId` — a record has no app id for the old pair's other half to name.
+
+**`vendo.automations`.** `enable` / `disable` / `dryRun` take ONE id instead of `(appId, triggerId)`. `list({ owner?, agent? }, ctx)` returns plain redacted `AutomationRecord[]`, deployment-wide. There is **no `app` filter** and there will not be one: a record carries no app reference at all, so an app page filters by resolving its own `automations` list and dropping the dead ids. `runs.list` filters on `{ automationId, owner, agent, status, cursor }`, and `RunRecord.appId`/`.triggerId` become `.automationId` plus `.owner` and an optional `.agent` — one ledger, with the owner, agent and console views as filters over it rather than tables of their own.
+
+**`createAutomations` config.** `apps`, `runner`, `appAccess` (and the `AppAccessSeam` type), `localTriggerKinds` and `AutomationsEngine.onDocumentEdit` are gone; so is the `triggerKey` export. `@vendoai/automations` depends on `@vendoai/core` alone now — a goal run reaches a brain through the named runner map the umbrella registers, and a task reaches an app only by naming one of that app's functions as an ordinary granted tool, which resolves through the bound registry like anything else. Delete an app and its automation still fires, then fails loudly at tool resolution with a `not-found` in the run ledger. The engine no longer watches app-document edits either: sponsorship is bound to the record's own content hash (`automationHash`), so a record whose content changed under a live sponsorship stops on its own. `@vendoai/automations` newly exports `verifySignature`, `signedWebhookBytes` and `base64url` — the one implementation of the standard-webhooks scheme, so the tick door and the per-record webhook path cannot drift.
+
+**`@vendoai/ui`.** `AutomationEntry` IS `AutomationRecord` (`AutomationTriggerEntry` is gone). `client.automations.{enable,disable,dryRun}` take one id; `client.runs.list` takes the new filter. `<AutomationCard>` takes `when` (a `TriggerSource`) plus an already-humanized `action` string instead of `trigger`, and `automationRule(when, action)` takes both halves — a record's task is the producer's to read, and a card that guessed at the words would put them in an automation's mouth.
+
+## What breaks in your store
+
+Schema **v11**. `vendo_automations` is the new table: `subject` is the erase-cascade selector, because a row carries a live webhook signing key and a record that outlived its owner's erasure would be a hole rather than an untidiness; `revision` is the compare-and-swap counter every write bumps. `vendo_runs` re-keys `app_id` to `automation_id` and is **emptied once**, guarded on the old column. `vendo_grants` re-keys `trigger_id` to `automation_id`. The `trigger_kind_*` generated columns on `vendo_apps` are dropped by pattern, so the names leave the codebase entirely. The erase cascade deletes runs BEFORE automations, while the join that identifies them still exists.
+
+`ENGINE_ALLOWLIST_VERSION` goes 2 → 4. `vendo_automations` joins the engine allowlist; `automations:armed` and `automations:webhook` leave it — armed is a FIELD on the record, so a disarm is one write with no second row to keep in step, and the webhook secret lives on the record. If your BYO store pins the allowlist version, bump it.

--- a/.changeset/one-engine-per-deployment-and-one-door-that-wakes-it.md
+++ b/.changeset/one-engine-per-deployment-and-one-door-that-wakes-it.md
@@ -1,0 +1,37 @@
+---
+"@vendoai/vendo": minor
+"@vendoai/core": minor
+---
+
+One automations engine per deployment, the brains a firing can reach named at composition, and `POST /api/vendo/tick` the only door that wakes it.
+
+The whole public surface:
+
+```ts
+vendo.agent                                   // the agent this deployment adopted, read back
+createVendo({ agents: [support, billing] })   // MORE brains, resolvable by name
+vendo.automations.list / get / enable / disable
+vendo.automations.runs.list / get / stop / rerun
+vendo.automations.dryRun
+```
+
+`createVendo({ agents })` is registration only — nothing in that list serves chat turns. It makes a name resolvable, so a firing declared by `support.on(...)` lands on `support`. (`agent:` is the different, existing key: that one this deployment ADOPTS, taking its harness, store and instructions.) A firing's brain is looked up BY NAME at fire time and registered at BOOT, so two agents wearing one name throw during `createVendo` rather than at 2am, when the lookup would already have reached the wrong brain. A name nobody registered is a loud FAILED row in the run ledger and never a fallback brain: the wrong agent acting with the owner's grants is worse than nothing running, because nobody would ever find out.
+
+**There is deliberately no public `create`.** The one create operation is internal, so a host that can observe automations and switch them off still cannot mint one; `vendo_automate`, `vendo_make`'s sugar, the `vendo.json` fold-in and `agent.on` are the four doors in.
+
+## The firing door
+
+`POST /api/vendo/tick` takes two credentials side by side, both verified against `VENDO_TICK_SECRET`:
+
+- `Authorization: Bearer $VENDO_TICK_SECRET` — your own cron (a Vercel cron, a GitHub Action, crontab).
+- A standard-webhooks signature (`webhook-id`, `webhook-timestamp`, `webhook-signature`) over the EMPTY body — Vendo Cloud's heartbeat. This leg is new.
+
+You configure one thing and either waker works. **With `VENDO_TICK_SECRET` unset, both are refused**, Cloud's heartbeat included, so a deployment with no secret fires nothing — if you read that env var as the BYO-cron credential only, set it now. The door answers `202 {"fired":n}`, and its idempotency is the engine's own atomic cursor claim rather than anything the door asserts, so a duplicate knock claims nothing and honestly says `{"fired":0}`.
+
+The signed leg keys the HMAC on the DECODED secret. A standard-webhooks secret is random bytes carried as base64url text, and a door that hashed the text's own characters would have answered 401 to every signed knock forever. This one calls the engine's `verifySignature` — the same function the per-record webhook path uses — so there is one implementation of the scheme and a test cannot agree with a wrong door. A host who chose a passphrase rather than base64url still gets a working bearer and simply never matches on this leg.
+
+`localFiringKinds` is gone from the repo entirely: the engine decides what is due, and the tick is the only thing that asks. The boot reconcile reads the store on the `ready()` latch even with zero `.on()` declarations, because a deployment that just deleted its last one still has stragglers to disarm.
+
+## core
+
+`toTriggerSource` tested `webhook === ""` when the hazard is the key being ABSENT. The webhook arm is the fall-through, so an object naming none of the five `When` shapes — which is what an untyped wire body is, and the admin routes are exactly that caller — walked in and left with `{ kind: "external", connector: undefined }`: an automation nothing can ever trigger, reported to its owner as armed. It is refused now, naming the shapes.


### PR DESCRIPTION
## What

The six-commit automations stack had **no changesets at all**. Three, one per
story a host meets:

| file | packages | what breaks |
| --- | --- | --- |
| `an-automation-is-a-record.md` | core, store, automations, apps, ui | the model: `AppDocument.triggers` deleted, every verb keyed on one automation id, store **v11**, stored automations not migrated |
| `agent-on-declares-an-automation.md` | agents, apps | the authoring doors: `agent.on(...)` in code, `vendo_automate` in chat, every triggers-in-documents path gone |
| `one-engine-per-deployment-and-one-door-that-wakes-it.md` | vendo, core | the composition: `vendo.agent`, `createVendo({ agents })`, no public `create`, and the tick door's two credentials |

All three are **`minor`**. Pre-1.0 semver permits a breaking change in a minor,
and 1.0.0 stays gated on Yousef's own standalone yes. The repo already enforces
that mechanically (`.github/workflows/version-packages.yml:71`).

## The version, from tooling rather than reasoning

`changeset status --verbose` on this branch, and again a real `changeset version`
in a throwaway detached worktree — all 13 fixed-group packages land on
**0.27.0** from 0.26.0, and `Running release would release NO packages as a major`.
`@vendoai/telemetry` (0.5.0) sits outside the fixed group and is untouched.

## There was nothing to re-mark

The decision was to re-mark pending `major` changesets as `minor`. There are
none — not on this stack, not on `main`. `git grep -E ':\s*major\s*$'` over
`.changeset/` on `origin/main` and on every `origin/automations/*` branch comes
back empty. The four majors that once existed were already walked back in
96dc6b47 (2026-08-15), and the CI ceiling has refused one since.

## What I deliberately left out

**Boot self-enrolment with Cloud** gets no changeset here. It is not on this
branch (`grep -rn 'enrol' packages/vendo/src` is empty) — it is S2f's, on an
unpushed branch, so I could not verify a single claim about it. That lane writes
its own note.

**#1400's six defect fixes** get none either: every one of them fixes code that
only exists inside this same unreleased stack, so from a customer's side they
never shipped.

## `automations.list` and the `app` filter

Per the amended API sheet, `owner` + `agent` are the whole surface. Nothing in
the repo advertises an `app` filter and nothing accepts-and-ignores one — the
engine reads exactly two keys (`packages/automations/src/list-surface.ts:31,41`),
the wire parses exactly two query params (`packages/vendo/src/wire/automations.ts:14-17`),
the typed client takes no filter at all (`packages/ui/src/client.ts:149`), and
`docs-site/capabilities/automations.mdx:194` already says there is no `app`
filter and why. **No code change was needed, so none was made.**

## Gate

Markdown only, so the gate is the release tooling and nothing bigger:

- `changeset status --verbose` before and after — read, both times.
- `changeset version` in a throwaway detached worktree: 13 package.json files at
  `0.27.0`, and the generated `CHANGELOG.md` entries render (fenced blocks
  intact, indentation correct).
- `git diff --stat` against the base: three added files under `.changeset/`,
  nothing else.

No test suite was run and no typecheck: this commit contains no code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes three `changeset` notes to ship automations centralization at 0.27.0. Old: app-embedded triggers and `(appId, triggerId)` APIs. New: principal-owned records keyed by `automationId`, authoring via `agent.on(...)`/`vendo_automate`, one engine per deployment with `POST /api/vendo/tick`. Side effects: schema v11, one-time `vendo_runs` emptying, engine allowlist 4, `automations.list` has no `app` filter.

**Review focus**
- Only `.changeset/*` files are added; no code changes.
- All fixed-group packages version to 0.27.0 (minor); `@vendoai/telemetry` unchanged.
- Notes flag breaks: delete `AppDocument.triggers`, unify on `automationId`, remove public create, tick door requires `VENDO_TICK_SECRET` (bearer and standard-webhooks).

**Rollout/Migration**
- Tell users: automations in `AppDocument.triggers` stop; re-create via `agent.on(...)` or `vendo_automate`. Historical runs are dropped once.
- Apply store schema v11; bump engine allowlist to 4 if pinned.
- Update callers in `@vendoai/core`, `@vendoai/automations`, and `@vendoai/ui` to `automationId` APIs; stop writing `triggers` to app documents.
- Set `VENDO_TICK_SECRET`; leaving it unset disables all firing.

<sup>Written for commit 2334f108e341c1fee22283a3ea30e697e96a223f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

