### PR TITLE
fix(genbench): the vendo column reads the world's tools and nothing else

### DIFF
--- a/genbench/src/vendo.ts
+++ b/genbench/src/vendo.ts
@@ -176,7 +176,18 @@ async function run(request: RunRequest): Promise<RunOutcome> {
   const runtimeTools = apps.agentTools();
   appsTools = {
     async descriptors(listCtx) {
-      return [...(await runtimeTools.descriptors(listCtx)), ...(await verbs.descriptors(listCtx))];
+      // Read-risk only, and that is a FAIRNESS filter, not a permission one. The
+      // screen agent equips the read verbs it needs and offers everything else
+      // it was listed as a tool a button may wire (`screen-agent.ts`'s
+      // `callable`), so serving the runtime's write verbs put `vendo_apps_pin`,
+      // `vendo_apps_unpin`, `vendo_apps_reseed`, `vendo_apps_data_put` and
+      // `vendo_apps_data_delete` in this column's brief with full schemas — ~3KB
+      // of platform surface no bench case can use, and no baseline is handed
+      // (`diy.test.ts`). The world's tools are the only tools any contender may
+      // wire. `validate` still routes: `execute` below is untouched, and the
+      // loop calls it by name rather than off this list.
+      const runtime = await runtimeTools.descriptors(listCtx);
+      return [...runtime.filter((descriptor) => descriptor.risk === "read"), ...(await verbs.descriptors(listCtx))];
     },
     async execute(call, callCtx) {
       const fromVerbs = await verbs.descriptors(callCtx);

--- a/genbench/tests/vendo.test.ts
+++ b/genbench/tests/vendo.test.ts
@@ -36,18 +36,26 @@ const stopTurn = (): StreamPart[] => [
 ];
 
 /** A meter over a model that replays the given turns, so the loop — not a real
- *  model — decides what lands. */
-function scripted(turns: StreamPart[][]): Meter {
+ *  model — decides what lands. It keeps the brief it was sent, because the only
+ *  honest reading of what the vendo column was handed is the prompt that really
+ *  went on the wire. */
+function scripted(turns: StreamPart[][]): Meter & { system: () => string } {
   const remaining = turns.map((turn) => [...turn]);
   let tick = 0;
+  let system = "";
   const model = new MockLanguageModelV3({
-    doStream: async () => {
+    doStream: async ({ prompt }) => {
+      system = prompt
+        .filter((message) => message.role === "system")
+        .map((message) => message.content as string)
+        .join("\n");
       const chunks = remaining.shift();
       if (chunks === undefined) throw new Error("scripted model exhausted");
       return { stream: simulateReadableStream({ chunks }) };
     },
   });
   return {
+    system: () => system,
     model,
     elapsedMs: () => (tick += 1),
     totals: () => ({ inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, calls: 0 }),
@@ -82,6 +90,39 @@ beforeAll(async () => {
 });
 
 const caseFor = (id: string): Case => ({ id, lane: "screen", prompt: "Show this month's spending", pass: [], shape: "table" });
+
+/**
+ * The fairness assertion for the column every other column is measured against.
+ *
+ * `diy.test.ts` proves each baseline is handed the world block and nothing more.
+ * This is the same claim on the vendo side: the screen agent's brief ends with
+ * the tools it may hand the person a button for, and that list is the registry's
+ * write half — so every write verb the apps runtime happens to serve landed in
+ * it with its full JSON Schema. `vendo_apps_pin`, `vendo_apps_unpin`,
+ * `vendo_apps_reseed`, `vendo_apps_data_put` and `vendo_apps_data_delete` are
+ * not this world's tools, no case can use one, and no baseline is told they
+ * exist — they were kilobytes of prompt only this column paid for.
+ */
+describe("the vendo column is offered the world's tools and nothing else", () => {
+  const CALL_HEADING = "## This product's tools your screen can CALL";
+
+  /** The names the brief offers as buttons, read off the prompt the model was
+   *  really sent — `toolBrief` prints one `- name — description` line each. */
+  const offeredNames = (system: string): readonly string[] =>
+    [...(system.split(CALL_HEADING)[1] ?? "").matchAll(/^- (\w+) — /gm)].map((match) => match[1]!);
+
+  it("names exactly the world's own write tools, and no platform verb", async () => {
+    const meter = scripted([stopTurn()]);
+    await vendoDriver().run({ world, testCase: caseFor("wireable"), meter });
+
+    // The read half is equipped as real tools with their own schemas, so the
+    // brief's list is the world's writes — the tools a screen can only reach
+    // from a button.
+    expect(offeredNames(meter.system())).toEqual(
+      world.tools.filter((tool) => tool.descriptor.risk === "write").map((tool) => tool.name),
+    );
+  });
+});
 
 describe("the vendo driver reports one revision", () => {
   it("does not report an earlier revision's view beside a final save that never painted", async () => {


### PR DESCRIPTION
Every number this benchmark reports rests on one claim: each contender was handed exactly what the product's own pipeline was handed. The vendo column was handed more.

The screen agent offers every listed tool it cannot call itself as one a button may wire (`screen-agent.ts`'s `callable` / `wireable` split), so the apps runtime's own write verbs came through the genbench driver's registry and landed in the vendo column's brief with full JSON Schemas:

- `vendo_apps_pin`
- `vendo_apps_unpin`
- `vendo_apps_reseed`
- `vendo_apps_data_put`
- `vendo_apps_data_delete`

Roughly 3KB of platform surface under "This product's tools your screen can CALL" — cost and distraction no bench case can use, and that neither `diy` nor `claude-code` is told exists (they get the byte-identical `worldBlock` and nothing else).

## The fix

`genbench/src/vendo.ts` serves the runtime's **read** verbs and stops. Those are exactly the ones the assembly loop equips (`vendo_apps_data_list`, `vendo_apps_open`, `vendo_slots_list`); the write half was never callable there, only describable. `execute` is untouched, so `validate` still routes — the loop calls it by name rather than off this list. No change under `packages/**`.

## The proof

`genbench/tests/vendo.test.ts` reads the brief off the prompt the model was really sent — the real store, guard, apps runtime and render seam, with only the model doubled — and asserts the wireable list names this world's write tools and nothing else. Red on the old behaviour with exactly the five names above; green with the filter.

## Gate

`pnpm build && pnpm --filter @vendoai/genbench test && pnpm typecheck && pnpm lint` — green. genbench: 440 passed, 2 skipped, 20 files.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts the vendo column to read-only runtime tools in its prompt brief to restore benchmark fairness. Previously, the brief exposed apps‑runtime write verbs (`vendo_apps_pin`, `vendo_apps_unpin`, `vendo_apps_reseed`, `vendo_apps_data_put`, `vendo_apps_data_delete`), inflating the prompt with unused surface that baselines never saw.

- In genbench/src/vendo.ts, `appsTools.descriptors` filters runtime tool descriptors to `risk === "read"` before appending `verbs.descriptors`; `execute` is unchanged and `validate` still routes by name.
- genbench/tests/vendo.test.ts reads the actual system prompt and asserts the wireable list names only the world's write tools and no platform verbs.

- Rollout: No migrations. Verify with `pnpm build && pnpm --filter @vendoai/genbench test && pnpm typecheck && pnpm lint`.

<sup>Written for commit 30c0099de5bb9edfa2273d36be2a87a1b728da83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

