### PR TITLE
feat(apps): the manual names every variable it tells you to style with

### DIFF
--- a/.changeset/the-manual-names-the-variables-it-tells-you-to-use.md
+++ b/.changeset/the-manual-names-the-variables-it-tells-you-to-use.md
@@ -1,0 +1,9 @@
+---
+"@vendoai/apps": minor
+---
+
+The screen manual names every CSS variable it tells a screen to style with, generated from the emitter that sets them.
+
+The manual has always said to style the display tags off the host's own CSS variables, and it named exactly two as examples — `--vendo-color-accent` and `--vendo-density-content-gap`. `themeCssVariables` sets 52. A model reaching for the surface color, a radius, a chart series or any of the thirteen density steps had to guess the name, and a wrong guess is silent: CSS resolves an unknown variable to nothing and the declaration falls back, with no error on any surface.
+
+`references/format.md` now ends with the whole list — each name and a few words of what it is for — walked off `VENDO_THEME_VARIABLE_NAMES`, which is itself read off `themeCssVariables`. The names cannot fall behind a rename or an addition, exactly as the component catalog cannot; only the meanings are written by hand, and a meaning left behind fails a drift test instead of teaching a dead name. Values stay out — they are the host's and per-theme, and the briefing pack already carries them.

--- a/packages/apps/src/server/skills/format-reference.ts
+++ b/packages/apps/src/server/skills/format-reference.ts
@@ -17,6 +17,7 @@
  */
 import { DISPLAY_TAG_NAMES } from "../../contract/kit/index.js";
 import { SCREEN_FILE } from "../../contract/genui/component/index.js";
+import { VENDO_THEME_VARIABLE_NAMES } from "../../contract/theme.js";
 import { HOT_PATH_FILES } from "../generation/render-seam.js";
 import { componentsPromptSection } from "../generation/contracts/sections.js";
 
@@ -72,7 +73,8 @@ are yours to arrange with, and they take children and an inline \`style\` and
 nothing else: no \`className\`, no \`id\`, no handlers. Style them off the host's own
 CSS variables (\`var(--vendo-color-accent)\`, \`var(--vendo-density-content-gap)\`)
 so the screen stays branded — a hard-coded color is your color, not the
-product's. There is no network in here, so a style that fetches (\`url(…)\`) is
+product's; every variable there is, and what each one means, is listed at the end
+of this file. There is no network in here, so a style that fetches (\`url(…)\`) is
 dropped.
 \`key={…}\` on every row you \`.map\`. Dates go to the date
 component as the ISO string you were given — there is no clock in here, so no
@@ -141,5 +143,82 @@ names and types are exact — an unknown prop fails the checks.
 
 `;
 
+/**
+ * What each variable is FOR, one short line each — never what it is SET to: the
+ * values are this host's and per-theme, and the briefing pack carries them.
+ *
+ * Only the MEANINGS live here. The names the section prints are walked off
+ * `VENDO_THEME_VARIABLE_NAMES`, which is read off `themeCssVariables` itself, so
+ * a variable added or renamed reaches the manual the day it is emitted and a
+ * meaning left behind fails the drift test instead of teaching a dead name.
+ */
+const VARIABLE_MEANINGS: Record<string, string> = {
+  "--vendo-color-success": "a completed or positive state",
+  "--vendo-color-warning": "something that needs attention, not yet wrong",
+  "--vendo-color-surface-raised": "a panel resting on a surface",
+  "--vendo-color-background": "the page behind everything",
+  "--vendo-color-surface": "a panel resting on the page",
+  "--vendo-color-text": "body text",
+  "--vendo-color-muted": "secondary text and labels",
+  "--vendo-color-accent": "the brand color — the primary action",
+  "--vendo-color-accent-text": "text and icons sitting on the accent",
+  "--vendo-color-danger": "destructive and error",
+  "--vendo-color-border": "hairlines, outlines and dividers",
+  "--vendo-color-scheme": "`light` or `dark`, derived from the background",
+  "--vendo-font-family": "the body text face",
+  "--vendo-heading-family": "the heading face — set only when this host has one",
+  "--vendo-mono-family": "the monospace face, for code and figures",
+  "--vendo-font-size": "the body text size",
+  "--vendo-base-size": "that same size, as the anchor the type scale derives from",
+  "--vendo-font-weight-normal": "the body weight",
+  "--vendo-font-weight-emphasis": "the weight for emphasis and headings",
+  "--vendo-letter-spacing": "the body tracking",
+  "--vendo-line-height": "the body leading",
+  "--vendo-line-height-heading": "the tighter leading a heading takes",
+  "--vendo-radius-small": "the corner radius of a control or badge",
+  "--vendo-radius-medium": "the corner radius of a card or input",
+  "--vendo-radius-large": "the corner radius of a panel or sheet",
+  "--vendo-shadow-small": "the hover lift",
+  "--vendo-shadow-medium": "anything resting above a surface",
+  "--vendo-shadow-large": "an overlay floating over the page",
+  "--vendo-border-width": "the hairline thickness",
+  "--vendo-chart-1": "the first chart series color — the accent itself",
+  "--vendo-chart-2": "the second chart series color",
+  "--vendo-chart-3": "the third chart series color",
+  "--vendo-chart-4": "the fourth chart series color",
+  "--vendo-chart-5": "the fifth chart series color",
+  "--vendo-chart-6": "the sixth chart series color",
+  "--vendo-density": "`comfortable` or `compact` — which spacing scale is in force",
+  "--vendo-density-control-height": "the height of a button or input",
+  "--vendo-density-control-padding": "the padding inside a button or input",
+  "--vendo-density-card-padding": "the padding inside a card",
+  "--vendo-density-content-gap": "the gap between blocks stacked in a column",
+  "--vendo-density-inline-gap": "the gap between items sitting in a row",
+  "--vendo-density-field-gap": "the gap between a label and its field",
+  "--vendo-density-table-padding": "the padding inside a table cell",
+  "--vendo-density-badge-height": "the height of a badge",
+  "--vendo-density-badge-padding": "the padding inside a badge",
+  "--vendo-density-stat-padding": "the padding inside a stat",
+  "--vendo-density-tabs-padding": "the padding around a tab strip",
+  "--vendo-density-tab-height": "the height of one tab",
+  "--vendo-density-tab-padding": "the padding inside one tab",
+  "--vendo-motion": "`full` or `reduced`",
+  "--vendo-motion-duration": "one transition's duration — `0ms` when motion is reduced",
+  "--vendo-motion-easing": "the easing curve a transition uses",
+};
+
+/** The VARIABLES section, generated the way the catalog is. */
+const variablesPromptSection = (): string => `---
+
+# The host's CSS variables
+
+Every one of these is already set on your screen, at this product's own values.
+Use the NAME — the values are in the brief, and a copied value stops being the
+product's the moment its theme changes. A name outside this list resolves to
+nothing and the declaration it was in silently falls back.
+
+${VENDO_THEME_VARIABLE_NAMES.map((name) => `\`${name}\` — ${VARIABLE_MEANINGS[name]}`).join("\n")}
+`;
+
 /** The reference as it lands on disk. */
-export const VENDO_FORMAT_REFERENCE = `${CHAPTER}${componentsPromptSection()}\n`;
+export const VENDO_FORMAT_REFERENCE = `${CHAPTER}${componentsPromptSection()}\n\n${variablesPromptSection()}`;

--- a/packages/apps/src/server/skills/format-reference.ts
+++ b/packages/apps/src/server/skills/format-reference.ts
@@ -166,7 +166,10 @@ const VARIABLE_MEANINGS: Record<string, string> = {
   "--vendo-color-border": "hairlines, outlines and dividers",
   "--vendo-color-scheme": "`light` or `dark`, derived from the background",
   "--vendo-font-family": "the body text face",
-  "--vendo-heading-family": "the heading face — set only when this host has one",
+  // The ONE name the emitter may not set (`if (type.headingFamily)`), so the one
+  // meaning that has to carry its own absence and the fallback to write instead.
+  "--vendo-heading-family": "the heading face, set only when this host names one — write it as "
+    + "`var(--vendo-heading-family, var(--vendo-font-family))`",
   "--vendo-mono-family": "the monospace face, for code and figures",
   "--vendo-font-size": "the body text size",
   "--vendo-base-size": "that same size, as the anchor the type scale derives from",
@@ -212,10 +215,11 @@ const variablesPromptSection = (): string => `---
 
 # The host's CSS variables
 
-Every one of these is already set on your screen, at this product's own values.
-Use the NAME — the values are in the brief, and a copied value stops being the
-product's the moment its theme changes. A name outside this list resolves to
-nothing and the declaration it was in silently falls back.
+Every one of these is already set on your screen, at this product's own values,
+unless its own line says otherwise. Use the NAME — the values are in the brief,
+and a copied value stops being the product's the moment its theme changes. A name
+outside this list resolves to nothing and the declaration it was in silently
+falls back.
 
 ${VENDO_THEME_VARIABLE_NAMES.map((name) => `\`${name}\` — ${VARIABLE_MEANINGS[name]}`).join("\n")}
 `;

--- a/packages/apps/tests/skills/format-reference.test.ts
+++ b/packages/apps/tests/skills/format-reference.test.ts
@@ -15,7 +15,12 @@
  * reshape pipe left in the reference to check.
  */
 import type { HostToolInfo } from "../../src/server/checking/deps.js";
-import { KIT_COMPONENT_NAMES, VENDO_THEME_VARIABLE_NAMES } from "../../src/contract/index.js";
+import {
+  KIT_COMPONENT_NAMES,
+  VENDO_THEME_VARIABLE_NAMES,
+  defaultVendoTheme,
+  themeCssVariables,
+} from "../../src/contract/index.js";
 import { checkComponentScreen } from "../../src/server/checking/component-screen.js";
 import { SCREEN_MODULE, screenCatalog } from "../../src/server/checking/screen-typings.js";
 import { describe, expect, it } from "vitest";
@@ -163,6 +168,22 @@ describe("the reference only teaches what a screen really has", () => {
     expect(named.map(([, name]) => name)).toEqual([...VENDO_THEME_VARIABLE_NAMES]);
     // Names alone would be a list to copy; the point is knowing which to reach for.
     expect(named.filter(([, , meaning]) => (meaning ?? "").trim() === "" || meaning === "undefined")).toEqual([]);
+  });
+
+  /** The list is one fixed set with ONE exception: `--vendo-heading-family` is
+   *  emitted only when a host names a heading face (`themeCssVariables`'s
+   *  `if (type.headingFamily)`). Documenting it flat, beside 51 names that are
+   *  always there, teaches a variable that may not exist — so its line carries
+   *  its own absence and the fallback to write instead, and the preamble's
+   *  promise is what defers to it. */
+  it("says so on the one line whose variable a host may not have set", () => {
+    const conditional = Object.keys(themeCssVariables(defaultVendoTheme));
+
+    expect(VENDO_THEME_VARIABLE_NAMES.filter((name) => !conditional.includes(name)))
+      .toEqual(["--vendo-heading-family"]);
+    expect(VENDO_FORMAT_REFERENCE)
+      .toMatch(/^`--vendo-heading-family` — .*set only when this host names one/m);
+    expect(VENDO_FORMAT_REFERENCE).toContain("unless its own line says otherwise");
   });
 
   it("lands the section in the reference, where the layout paragraph points", () => {

--- a/packages/apps/tests/skills/format-reference.test.ts
+++ b/packages/apps/tests/skills/format-reference.test.ts
@@ -15,7 +15,7 @@
  * reshape pipe left in the reference to check.
  */
 import type { HostToolInfo } from "../../src/server/checking/deps.js";
-import { KIT_COMPONENT_NAMES } from "../../src/contract/index.js";
+import { KIT_COMPONENT_NAMES, VENDO_THEME_VARIABLE_NAMES } from "../../src/contract/index.js";
 import { checkComponentScreen } from "../../src/server/checking/component-screen.js";
 import { SCREEN_MODULE, screenCatalog } from "../../src/server/checking/screen-typings.js";
 import { describe, expect, it } from "vitest";
@@ -150,6 +150,24 @@ describe("the reference only teaches what a screen really has", () => {
   it("says the save's own errors teach the repair, without naming a verb to call", () => {
     expect(VENDO_FORMAT_REFERENCE).toContain("Save errors tell you exactly what to fix. Fix and save again.");
     expect(VENDO_FORMAT_REFERENCE).not.toContain("`validate`");
+  });
+
+  /** The manual tells a model to style off the host's variables, so it has to say
+   *  which ones exist: a guessed name resolves to nothing and the declaration
+   *  falls back with no error anywhere. The section is walked off the EMITTER, so
+   *  this compares the names it prints against what `themeCssVariables` really
+   *  sets — the drift a hand-copied list would hide. */
+  it("names every CSS variable the host really sets, in the order it sets them", () => {
+    const named = [...VENDO_FORMAT_REFERENCE.matchAll(/^`(--vendo-[a-z0-9-]+)` — (.*)$/gm)];
+
+    expect(named.map(([, name]) => name)).toEqual([...VENDO_THEME_VARIABLE_NAMES]);
+    // Names alone would be a list to copy; the point is knowing which to reach for.
+    expect(named.filter(([, , meaning]) => (meaning ?? "").trim() === "" || meaning === "undefined")).toEqual([]);
+  });
+
+  it("lands the section in the reference, where the layout paragraph points", () => {
+    expect(VENDO_FORMAT_REFERENCE).toContain("# The host's CSS variables");
+    expect(VENDO_FORMAT_REFERENCE).toContain("listed at the end\nof this file");
   });
 
   it("carries the whole catalog, one line per component, generated from the specs", () => {


### PR DESCRIPTION
The screen manual tells a model to style its display tags off the host's own CSS variables, and it named exactly two: `--vendo-color-accent` and `--vendo-density-content-gap`. `themeCssVariables` sets **52**. A model reaching for the surface color, a radius, a chart series or any of the thirteen density steps had to guess — and a wrong guess is silent, because CSS resolves an unknown variable to nothing and the declaration falls back with no error on any surface. `safeStyle` never reads a value either, so nothing downstream can catch it.

## The fix

`references/format.md` gains a final section, generated the same way the component catalog is (`VENDO_FORMAT_REFERENCE = CHAPTER + componentsPromptSection() + variablesPromptSection()`). The names are walked off `VENDO_THEME_VARIABLE_NAMES`, which is itself `Object.keys(themeCssVariables(...))` — so a variable added or renamed reaches the manual the day it is emitted. Only the MEANINGS are hand-written, one short line each.

The layout paragraph gains one clause pointing at it; no other prose changed.

```
---

# The host's CSS variables

Every one of these is already set on your screen, at this product's own values.
Use the NAME — the values are in the brief, and a copied value stops being the
product's the moment its theme changes. A name outside this list resolves to
nothing and the declaration it was in silently falls back.

`--vendo-color-success` — a completed or positive state
`--vendo-color-warning` — something that needs attention, not yet wrong
`--vendo-color-surface-raised` — a panel resting on a surface
`--vendo-color-background` — the page behind everything
`--vendo-color-surface` — a panel resting on the page
…
```

Names and meanings only, never values: `--vendo-heading-family` is emitted only when a host declares one, and every value is per-theme. The briefing pack already carries the values (`renderBriefingPack`'s `THEME TOKENS:` block), and a copied value is exactly the hard-coded color the paragraph above already forbids. +3.4 KB on the manual.

## Tests

- **Drift** — the names the section prints are parsed back out of `VENDO_FORMAT_REFERENCE` and compared to `VENDO_THEME_VARIABLE_NAMES`, in order, with every meaning non-empty. Proven red: dropping `--vendo-radius-medium` from the meanings map fails with `` `--vendo-radius-medium` — undefined ``.
- **Placement** — the section lands in `VENDO_FORMAT_REFERENCE` and the layout paragraph's pointer is there.

## Ripple, checked

- No test pins `VENDO_FORMAT_REFERENCE` bytes or a size budget. `format-conformance.e2e.test.ts` asserts only that the manual quotes no `NN KB` figure — the section quotes none.
- The retired-name fence (`\bTable\b`) is case-sensitive; `--vendo-density-table-padding` is lowercase and does not trip it.
- **genbench fairness is unaffected.** `format.md` rides in `buildingAppsSkill.files`, which only `screenAssembler` reads (`packages/vendo/src/screen-agent.ts:485`). The `diy` and `claude-code` baselines are handed `worldBlock` + `HARNESS_CONTRACT` + the case prompt and never see the manual, so `genbench/tests/diy.test.ts` needs no change — this addition is on the same side of the line the whole manual has always been on, and the fence only polices *harness* coaching.

## Gate

`pnpm build` ✅ · `pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm test:affected` — `@vendoai/apps` 124 files green. Five reds are environmental and pre-existing on this laptop: three `Cool%20Code` ENOENTs from the space in the worktree path (`vendo` docs + `init-mcp`), and the two PGlite SIGKILL drills in `store`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lists every CSS variable the manual tells screens to use, generated from the theme emitter. Previously the manual showed two examples; now it enumerates all names with short meanings to prevent silent CSS fallbacks and notes the one variable that may not be set.

- Adds a generated “The host's CSS variables” section to `references/format.md` via `variablesPromptSection()` using `VENDO_THEME_VARIABLE_NAMES`, and links to it from the layout paragraph.
- Documents `--vendo-heading-family` as conditional and shows the fallback `var(--vendo-heading-family, var(--vendo-font-family))`; tests pin it as the only conditional variable and verify list order, complete coverage, non-empty meanings, and section placement.
- Omits values (they are per-theme in the briefing pack). Documentation-only change in `@vendoai/apps`; no runtime behavior or benchmarks change.

<sup>Written for commit e0c19c440f5d21dead743874d0e7c0daeffc794a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

