### PR TITLE
feat(vendo): a deployment enrols itself, and knows the secret Cloud signs its wake-up call with

### DIFF
--- a/.changeset/a-deployment-enrols-itself-for-ticks.md
+++ b/.changeset/a-deployment-enrols-itself-for-ticks.md
@@ -1,0 +1,35 @@
+---
+"@vendoai/vendo": minor
+---
+
+A deployment enrols itself with Vendo Cloud at boot, and derives the secret Cloud signs its wake-up call with.
+
+Nothing in this repo ever told Cloud that a deployment existed, so the heartbeat had no door to knock on: a hosted deployment served every request, armed its automations, and fired none of them — with no error anywhere to say so.
+
+**If you set `VENDO_API_KEY` and `VENDO_BASE_URL`, there is nothing else to do.** On the first request after boot (the same `ready()` latch the schema and the boot reconcile ride — construction stays free of I/O for Workers' sake), the deployment posts its own URL and a tick secret to Cloud, and that is the entire enrolment: no dashboard step, no second env var, nothing for a person to configure. Registering is idempotent on (project, host), so every replica and every redeploy calling it is the expected usage, and a re-register also clears Cloud's failure breaker. `VENDO_CLOUD_URL` repoints the console as everywhere else.
+
+The secret is DERIVED, not configured:
+
+```
+HMAC-SHA256(key = VENDO_API_KEY, message = "vendo:automations:tick:v1")  →  base64url
+```
+
+Every replica derives the same value, which is the point: they all enrol, and a secret that differed per instance would break the others' knock. The label is frozen for the same reason. It is never logged, never in an error message, and never in a URL.
+
+## Whether you still need `VENDO_TICK_SECRET`
+
+This supersedes the "with `VENDO_TICK_SECRET` unset, both are refused" line in the tick-door note. `POST /api/vendo/tick` now verifies against the derived secret too, so:
+
+- **On Vendo Cloud** — you do not need `VENDO_TICK_SECRET`. Remove it if you set it only to make the heartbeat work.
+- **Running your own cron, no Cloud key** — you still need it, exactly as before. Nothing changes for you.
+- **Both set** — `VENDO_TICK_SECRET` wins. It is the bring-your-own override, and it is *that* secret that gets registered with Cloud, so your cron and Cloud's heartbeat present the same one and both legs work.
+
+With neither set the door still refuses every knock, and its 401 now names both roads out.
+
+## When it cannot enrol, you hear about it
+
+Enrolment never throws and never delays a request — a console blip must not take a deployment down or hold up its first response. It logs at `error` under the code `vendo.tick-enrolment-failed`, once per composition, because an unenrolled deployment is otherwise indistinguishable from a healthy one: it serves everything correctly and fires nothing. Two reasons produce that line — Cloud refused the registration, or `VENDO_BASE_URL` is unset so there is no public URL to publish. If you see it, your scheduled automations are not running.
+
+It stays silent where there is nothing to publish and nothing wrong: no Cloud key, `automations: false`, and a development process — which fires its own ticks already and sits behind a URL no heartbeat could reach.
+
+`vendo doctor` reads the same ladder the door does, so a Cloud deployment that configured nothing no longer reports itself as having no schedule caller.

--- a/packages/vendo/src/cli/doctor-probe-checks.ts
+++ b/packages/vendo/src/cli/doctor-probe-checks.ts
@@ -312,9 +312,9 @@ export async function reportMachines(run: DoctorRun): Promise<void> {
     }
     const declaresSchedules = machines.some((machine) => (machine.schedules?.length ?? 0) > 0);
     if (body.scheduleCallerConfigured === true) {
-      run.pass("machines/schedule-caller", "schedule caller configured (VENDO_TICK_SECRET); point an external cron at POST /api/vendo/tick");
+      run.pass("machines/schedule-caller", "schedule caller configured; a waker can reach POST /api/vendo/tick");
     } else if (declaresSchedules) {
-      run.warn("machines/schedule-caller", "E-SCHED-001", "apps declare vendo.json schedules but no schedule caller is configured — set VENDO_TICK_SECRET and point an external cron (Vercel cron, GitHub Actions, crontab) at POST /api/vendo/tick");
+      run.warn("machines/schedule-caller", "E-SCHED-001", "apps declare vendo.json schedules but no schedule caller is configured — set VENDO_API_KEY and Vendo Cloud's heartbeat wakes this deployment, or set VENDO_TICK_SECRET and point an external cron (Vercel cron, GitHub Actions, crontab) at POST /api/vendo/tick");
     } else if (machines.length > 0) {
       run.note("  no schedule caller configured (VENDO_TICK_SECRET unset) — needed once an app declares vendo.json schedules");
     }

--- a/packages/vendo/src/compose-adapters.ts
+++ b/packages/vendo/src/compose-adapters.ts
@@ -190,6 +190,11 @@ export const composeReady = (composition: VendoComposition): Pick<VendoCompositi
       // call: a partial composition in a unit test may not have composed
       // automations at all.
       composition.startDevAutomationsTicker?.();
+      // Enrol with Cloud's heartbeat — the deployed process's only waker. NOT
+      // chained into the latch: a console round-trip must not delay the first
+      // request, and it never rejects (it shouts instead), so nothing here can
+      // turn a Cloud blip into a deployment that refuses to serve.
+      void composition.enrolForCloudTicks?.();
     }
     return readyState;
   };

--- a/packages/vendo/src/compose-automations.ts
+++ b/packages/vendo/src/compose-automations.ts
@@ -19,8 +19,10 @@ import {
   type RunContext,
 } from "@vendoai/core";
 import type { VendoComposition } from "./compose-context.js";
+import { cloudKeyOptions } from "./compose-selection.js";
 import { isHostedStore, reportHostedStoreOnce } from "./compose-store.js";
 import { assembleSystemPrompt } from "./prompt.js";
+import { enrolForTicks } from "./tick-enrolment.js";
 
 /** How often a development process ticks its own scheduler. One minute is the
  *  engine's own `start()` default: fine-grained enough for the shortest real
@@ -61,7 +63,8 @@ export function armDevTicker(start: () => () => void, host: Record<symbol, unkno
 /** The automations engine, the create seam the apps doors author through, and
  *  the boot reconcile the ready() latch drives. */
 export const composeAutomations = (composition: VendoComposition): Pick<VendoComposition,
-  "hostedStoreComposed" | "automations" | "createAutomation" | "bootReconcile" | "startDevAutomationsTicker"> => {
+  "hostedStoreComposed" | "automations" | "createAutomation" | "bootReconcile"
+  | "startDevAutomationsTicker" | "enrolForCloudTicks"> => {
   const { store, ops, boundTools, guard, harness, files, capability, inference } = composition;
   const { system, resolveRisk, membershipsSeam, automationsMounted, config } = composition;
   // The same derivation compose-wire's `development` uses: an explicit
@@ -166,12 +169,25 @@ export const composeAutomations = (composition: VendoComposition): Pick<VendoCom
     if (!development || !automationsMounted) return;
     armDevTicker(() => automations.start(DEV_TICK_INTERVAL_MS));
   };
+  // The DEPLOYED half of the same story: Cloud's heartbeat is what wakes a hosted
+  // deployment, and it can only knock on a door it has been told about. Nothing is
+  // configured — the secret is derived from the Cloud key this process already has
+  // — and enrolment is idempotent on (project, host), so every boot of every
+  // replica calling it is the intended usage. Fired from the ready() latch like
+  // the ticker; every condition and every failure lives in enrolForTicks.
+  const enrolForCloudTicks = (): Promise<void> => enrolForTicks({
+    cloud: cloudKeyOptions(),
+    automationsMounted,
+    development,
+    publicUrl: composition.urls?.publicUrl,
+  });
   return {
     hostedStoreComposed,
     automations,
     createAutomation: internals.create,
     bootReconcile,
     startDevAutomationsTicker,
+    enrolForCloudTicks,
   };
 };
 

--- a/packages/vendo/src/compose-context.ts
+++ b/packages/vendo/src/compose-context.ts
@@ -158,6 +158,11 @@ export interface VendoComposition {
    *  no laptop has one. Same ready()-latch arming as the sweep. Filled by
    *  compose-automations.ts; a no-op outside development. */
   startDevAutomationsTicker: () => void;
+  /** The other half: a DEPLOYED process is woken by Cloud's heartbeat, which can
+   *  only knock on a door it has been told about. Same ready()-latch firing;
+   *  never rejects, and shouts if it could not enrol. Filled by
+   *  compose-automations.ts. */
+  enrolForCloudTicks: () => Promise<void>;
   /** The boot-once latch every handler/emit touch awaits. */
   ready: () => Promise<void>;
   /** Filled by compose-apps.ts, read by `resolveRisk` inside a later check. */

--- a/packages/vendo/src/tick-enrolment.ts
+++ b/packages/vendo/src/tick-enrolment.ts
@@ -1,0 +1,122 @@
+/**
+ * The tick secret, and the enrolment that hands it to Vendo Cloud.
+ *
+ * Cloud's heartbeat is the only thing that wakes a hosted deployment, and it can
+ * only knock on a door it knows the URL and the secret of. Nobody configures
+ * either: the deployment derives the secret from the VENDO_API_KEY it already has
+ * and publishes both at boot, exactly as the text channel registers its inbound
+ * door (compose-channels.ts).
+ */
+import { base64url } from "@vendoai/automations";
+import { consoleSender, defaultFetch, log, raiseCloudError } from "@vendoai/core";
+import { environment } from "./wire/shared.js";
+
+/** The label the tick secret is derived under. FROZEN: both ends key an HMAC on
+ *  this derivation's output, so a change here 401s every enrolled deployment's
+ *  next knock until it re-registers. Distinct from the text channel's label
+ *  (INBOUND_SECRET_LABEL) so neither secret can ever be the other. */
+const TICK_SECRET_LABEL = "vendo:automations:tick:v1";
+
+/** Deterministic by construction — one HMAC of a frozen label under the Cloud
+ *  key — because a deployment runs many replicas and every one of them enrols:
+ *  two that derived different secrets would take turns breaking the other's
+ *  knock. base64url, because Cloud keys its HMAC on this string's DECODED BYTES
+ *  and the door's `verifySignature` decodes it the same way on the way back in.
+ *  WebCrypto only (no node:crypto), like channelInboundSecret, so the module
+ *  keeps bundling for edge/Worker targets. */
+export async function deriveTickSecret(apiKey: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const key = await globalThis.crypto.subtle.importKey(
+    "raw",
+    encoder.encode(apiKey),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const derived = await globalThis.crypto.subtle.sign("HMAC", key, encoder.encode(TICK_SECRET_LABEL));
+  return base64url(new Uint8Array(derived));
+}
+
+/** THE secret, singular: what the firing door verifies against AND what
+ *  enrolment publishes, so Cloud can never be told a secret the door refuses.
+ *  `VENDO_TICK_SECRET` is the BYO override and wins outright (hard BYO rule — a
+ *  deployment with no Cloud key keeps a working `/tick`); otherwise VENDO_API_KEY
+ *  derives it. Undefined for a deployment that has neither, which is what makes
+ *  the door refuse every knock. The door reads the key from the environment; the
+ *  composition already resolved one (cloudKeyOptions) and passes THAT, so the two
+ *  callers cannot end up deriving from different keys. */
+export async function tickSecret(
+  apiKey: string | undefined = environment("VENDO_API_KEY"),
+): Promise<string | undefined> {
+  const configured = environment("VENDO_TICK_SECRET");
+  if (configured !== undefined) return configured;
+  return apiKey === undefined ? undefined : await deriveTickSecret(apiKey);
+}
+
+/** Cloud's enrolment door. Idempotent on (project, host), so every boot of every
+ *  replica calling it is the intended usage rather than something to guard. */
+const REGISTER_PATH = "/api/v1/automations/deployments/register";
+const DEFAULT_CONSOLE_URL = "https://console.vendo.run";
+/** The other Cloud adapters' per-request budget (cloudTextChannel's). */
+const TIMEOUT_MS = 30_000;
+
+/** Loud, and never thrown: a console blip must not take the deployment down with
+ *  it, but it must not pass for health either — an unenrolled deployment serves
+ *  every request perfectly and never fires a single automation. */
+const shout = (why: string): void => log({
+  code: "vendo.tick-enrolment-failed",
+  level: "error",
+  message: `[vendo] this deployment could not enrol with Vendo Cloud, so its scheduled automations will not fire: ${why}`,
+});
+
+/**
+ * Publish this deployment's firing door and the secret that will sign the knock.
+ *
+ * Silent in the three cases where there is nothing to publish and nothing wrong:
+ * no Cloud key (nobody is going to knock), no automations mounted (a knock would
+ * have nothing to fire), and a development process — which fires its own ticks
+ * (compose-automations) behind a URL that is in no deployment inventory, so
+ * enrolling it would register a wire Cloud cannot reach and then alarm about the
+ * silence.
+ */
+export async function enrolForTicks(options: {
+  cloud: { apiKey: string; baseUrl?: string } | undefined;
+  automationsMounted: boolean;
+  development: boolean;
+  publicUrl: URL | undefined;
+  /** Injection seam for tests; defaults to the global fetch. */
+  fetch?: typeof fetch;
+}): Promise<void> {
+  const { cloud } = options;
+  if (cloud === undefined || !options.automationsMounted || options.development) return;
+  if (options.publicUrl === undefined) {
+    shout("this deployment has no public URL for the heartbeat to knock on — set VENDO_BASE_URL to its "
+      + "FULL public URL (path prefix included) and redeploy");
+    return;
+  }
+  const secret = await tickSecret(cloud.apiKey);
+  // Unreachable: the Cloud key that got us past the guard above is the
+  // derivation's input, so the ladder cannot come back empty here.
+  if (secret === undefined) return;
+  const send = consoleSender({
+    base: (cloud.baseUrl ?? DEFAULT_CONSOLE_URL).replace(/\/$/, ""),
+    mountPath: "",
+    apiKey: cloud.apiKey,
+    timeoutMs: TIMEOUT_MS,
+    fetchImpl: options.fetch ?? defaultFetch,
+    raise: (response) => raiseCloudError(response, "automations", (code, message) => {
+      throw Object.assign(new Error(message), { code: code ?? "unavailable" });
+    }),
+  });
+  try {
+    // Cloud appends /api/vendo/tick to what it stores, so the path prefix stays
+    // and the trailing slash goes — the knock must never double the separator.
+    await send(REGISTER_PATH, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ url: options.publicUrl.href.replace(/\/$/, ""), secret }),
+    });
+  } catch (error) {
+    shout(error instanceof Error ? error.message : String(error));
+  }
+}

--- a/packages/vendo/src/wire/doctor.ts
+++ b/packages/vendo/src/wire/doctor.ts
@@ -1,5 +1,6 @@
 import type { ExtractedTool } from "@vendoai/actions";
 import { principalSchema, type Principal, type ToolOutcome } from "@vendoai/core";
+import { tickSecret } from "../tick-enrolment.js";
 import { BASE_PATH, environment, json, route, type RouteEntry } from "./shared.js";
 
 /** The doctor probe surface (CLI `vendo doctor` targets a running dev server):
@@ -67,13 +68,15 @@ export const doctorBaseUrlRoutes: RouteEntry[] = [
     global. */
 export const doctorRoutes: RouteEntry[] = [
   // Machine/schedule reporting. Reporting only: which apps carry a machine, what
-  // their manifests declare, and whether a schedule caller (VENDO_TICK_SECRET)
-  // is configured for the /tick surface. WHEN a schedule last fired is not here:
+  // their manifests declare, and whether ANY waker can reach the /tick surface —
+  // the same ladder the door itself verifies against (tick-enrolment.ts), so a
+  // Cloud deployment that configured nothing still reads as configured, because
+  // its heartbeat knocks. WHEN a schedule last fired is not here:
   // a vendo.json schedule is a doc trigger, so its history is the automation's
   // run records.
   route("GET", "/doctor/machines", async ({ deps }) => {
     return json({
-      scheduleCallerConfigured: environment("VENDO_TICK_SECRET") !== undefined,
+      scheduleCallerConfigured: (await tickSecret()) !== undefined,
       machines: await deps.apps.machine.report(),
     });
   }),

--- a/packages/vendo/src/wire/misc.ts
+++ b/packages/vendo/src/wire/misc.ts
@@ -1,9 +1,9 @@
 import { signedWebhookBytes, verifySignature } from "@vendoai/automations";
 import { log, VendoError } from "@vendoai/core";
 import { computeImpact } from "../sync-impact.js";
+import { tickSecret } from "../tick-enrolment.js";
 import {
   VERSION,
-  environment,
   hex,
   json,
   orgsCloudRequired,
@@ -88,9 +88,11 @@ async function tickSignatureValid(request: Request, secret: string): Promise<boo
 /** The two credentials the ONE wake endpoint takes, side by side and against
     the SAME secret: the host's own `Bearer $VENDO_TICK_SECRET` (a Vercel cron,
     a GitHub Action, crontab) and a standard-webhooks signature (Vendo Cloud's
-    heartbeat). A deployment configures one thing and either waker works. */
+    heartbeat). A deployment configures one thing — or, with a Cloud key, nothing
+    at all: `tickSecret` derives the secret enrolment published (tick-enrolment.ts)
+    and VENDO_TICK_SECRET stays the BYO override that wins. Either waker works. */
 async function tickAuthorized(request: Request): Promise<boolean> {
-  const secret = environment("VENDO_TICK_SECRET");
+  const secret = await tickSecret();
   if (secret === undefined) return false;
   return await timingSafeEqual(request.headers.get("authorization") ?? "", `Bearer ${secret}`)
     || await tickSignatureValid(request, secret);
@@ -158,7 +160,8 @@ export const systemRoutes: RouteEntry[] = [
           message: "POST /api/vendo/tick needs a credential and this request carried none that verified. "
             + "Send either `Authorization: Bearer $VENDO_TICK_SECRET`, or a standard-webhooks signature "
             + "(webhook-id, webhook-timestamp, webhook-signature) over the empty body, signed with that same secret. "
-            + "Set VENDO_TICK_SECRET on this deployment if it has none.",
+            + "If this deployment has no secret at all: set VENDO_API_KEY and Vendo Cloud's heartbeat wakes it with "
+            + "nothing further to configure, or set VENDO_TICK_SECRET and point your own cron here.",
         },
       }, 401);
     }

--- a/packages/vendo/tests/tick-door.test.ts
+++ b/packages/vendo/tests/tick-door.test.ts
@@ -29,6 +29,7 @@ import type { LanguageModel } from "ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CODE_AUTOMATION_OWNER } from "../src/compose-automations.js";
 import { createVendo, type Vendo } from "../src/server.js";
+import { deriveTickSecret } from "../src/tick-enrolment.js";
 import { systemRoutes } from "../src/wire/misc.js";
 
 /** A tick secret exactly as Cloud mints one: 32 random BYTES, carried as
@@ -185,6 +186,47 @@ describe("the firing door's two credentials, side by side", () => {
 
     expect((await vendo.handler(tick({ authorization: "Bearer " }))).status).toBe(401);
     expect((await vendo.handler(tick((await signed(KEY_BYTES)).headers))).status).toBe(401);
+  });
+});
+
+/** A Cloud deployment configures NOTHING: the secret Cloud signs with is derived
+ *  from the VENDO_API_KEY the deployment already has, and enrolment publishes it.
+ *  So the door has to accept that derived value — and must still let an operator
+ *  who set VENDO_TICK_SECRET keep it (hard BYO rule). */
+describe("the Cloud deployment nobody configured a tick secret on", () => {
+  const CLOUD_KEY = `vnd_${"a".repeat(40)}`;
+  const decoded = (secret: string): Uint8Array<ArrayBuffer> =>
+    new Uint8Array(Buffer.from(secret, "base64url"));
+
+  it("answers 202 to a heartbeat signed with the secret DERIVED from VENDO_API_KEY", async () => {
+    vi.stubEnv("VENDO_TICK_SECRET", undefined);
+    vi.stubEnv("VENDO_API_KEY", CLOUD_KEY);
+    // Booting a Cloud deployment enrols it, and this one has no VENDO_BASE_URL to
+    // publish — so the shout IS the enrolment wiring, live, at the ready() latch.
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const { vendo } = await setup();
+    const derived = await deriveTickSecret(CLOUD_KEY);
+    const heartbeat = await signed(decoded(derived));
+
+    // ORACLE — the shipped verifier says a knock keyed on this secret's decoded
+    // bytes is good, so a 401 below would be the DOOR's fault, not the signer's.
+    expect(await verifySignature(derived, heartbeat.signature, heartbeat.signed)).toBe(true);
+
+    expect((await vendo.handler(tick(heartbeat.headers))).status).toBe(202);
+    expect(error).toHaveBeenCalledWith(expect.stringContaining("VENDO_BASE_URL"));
+  });
+
+  it("still lets VENDO_TICK_SECRET win when the operator set one", async () => {
+    vi.stubEnv("VENDO_TICK_SECRET", SECRET);
+    vi.stubEnv("VENDO_API_KEY", CLOUD_KEY);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const { vendo } = await setup();
+
+    expect((await vendo.handler(tick(bearer))).status).toBe(202);
+    // And the derived value is not a SECOND key into the door: the override wins
+    // outright, so what enrolment published is the one secret Cloud may knock with.
+    const derived = await deriveTickSecret(CLOUD_KEY);
+    expect((await vendo.handler(tick((await signed(decoded(derived))).headers))).status).toBe(401);
   });
 });
 

--- a/packages/vendo/tests/tick-enrolment.test.ts
+++ b/packages/vendo/tests/tick-enrolment.test.ts
@@ -1,0 +1,193 @@
+/**
+ * SELF-ENROLMENT: how a deployment tells Vendo Cloud where its firing door is
+ * and which secret will sign the knock. Nobody configures either — the secret is
+ * derived from the deployment's own VENDO_API_KEY — and without the call there is
+ * no failure to see: the deployment is healthy, its automations are armed, and
+ * Cloud has no URL to knock on, so nothing ever fires.
+ *
+ * The secret is proven against the SHIPPED verifier (`verifySignature` in
+ * @vendoai/automations) as the oracle, signed the way Cloud's heartbeat actually
+ * signs — HMAC over `${webhook-id}.${webhook-timestamp}.` keyed on the secret's
+ * base64url-DECODED BYTES. A derivation that only satisfied a scheme restated
+ * here would still have answered 401 to every knock in the fleet; that mistake
+ * has been made twice on this seam, once on each side.
+ */
+import { signedWebhookBytes, verifySignature } from "@vendoai/automations";
+import { setLogger, type VendoLogEvent } from "@vendoai/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { deriveTickSecret, enrolForTicks, tickSecret } from "../src/tick-enrolment.js";
+
+const API_KEY = `vnd_${"a".repeat(40)}`;
+
+const events: VendoLogEvent[] = [];
+afterEach(() => {
+  events.length = 0;
+  setLogger(undefined);
+  vi.unstubAllEnvs();
+});
+
+const capture = (): void => setLogger((event) => void events.push(event));
+
+/** One captured request, the only thing enrolment is allowed to send. */
+interface Sent { url: string; init: RequestInit }
+const recorder = (response: () => Response): { sent: Sent[]; fetch: typeof fetch } => {
+  const sent: Sent[] = [];
+  return {
+    sent,
+    fetch: (async (url, init) => {
+      sent.push({ url: String(url), init: init ?? {} });
+      return response();
+    }) as typeof fetch,
+  };
+};
+
+const ok = (): Response => new Response(JSON.stringify({ ok: {} }), {
+  status: 200,
+  headers: { "content-type": "application/json" },
+});
+
+const enrol = (options: Partial<Parameters<typeof enrolForTicks>[0]>): Promise<void> => enrolForTicks({
+  cloud: { apiKey: API_KEY },
+  automationsMounted: true,
+  development: false,
+  publicUrl: new URL("https://maple.example.com/"),
+  ...options,
+});
+
+describe("the derived tick secret", () => {
+  it("is the same value every time, so two replicas cannot register different secrets", async () => {
+    const [first, second] = await Promise.all([deriveTickSecret(API_KEY), deriveTickSecret(API_KEY)]);
+
+    expect(first).toBe(second);
+    expect(first).toBe(await deriveTickSecret(API_KEY));
+    // A different deployment's key is a different secret — the derivation is not
+    // a constant dressed up as one.
+    expect(await deriveTickSecret(`${API_KEY}z`)).not.toBe(first);
+  });
+
+  it("verifies a knock signed exactly the way Cloud's heartbeat signs one", async () => {
+    const secret = await deriveTickSecret(API_KEY);
+    const id = "msg_heartbeat_enrolled";
+    const timestamp = String(Math.floor(Date.now() / 1_000));
+    // The SHIPPED signed bytes, not a string built here.
+    const body = new Uint8Array(signedWebhookBytes(id, timestamp, new Uint8Array()));
+
+    // Cloud's `sign()` (vendo-web lib/automations/heartbeat.ts) keys the HMAC on
+    // `Buffer.from(secret, "base64url")` — the DECODED BYTES.
+    const key = await crypto.subtle.importKey(
+      "raw", Buffer.from(secret, "base64url"), { name: "HMAC", hash: "SHA-256" }, false, ["sign"],
+    );
+    const mac = await crypto.subtle.sign("HMAC", key, body);
+
+    // ORACLE — the artifact the deployment's own door calls says this is good.
+    expect(await verifySignature(secret, btoa(String.fromCharCode(...new Uint8Array(mac))), body)).toBe(true);
+
+    // And the mistake this pins: keying on the secret's CHARACTERS produces a
+    // signature the shipped verifier rejects. A derivation that only agreed with
+    // a local restatement of the scheme could not tell these two apart.
+    const characterKey = await crypto.subtle.importKey(
+      "raw", new TextEncoder().encode(secret), { name: "HMAC", hash: "SHA-256" }, false, ["sign"],
+    );
+    const wrong = await crypto.subtle.sign("HMAC", characterKey, body);
+    expect(await verifySignature(secret, btoa(String.fromCharCode(...new Uint8Array(wrong))), body)).toBe(false);
+  });
+
+  it("lets VENDO_TICK_SECRET win, and derives only for the host that set none", async () => {
+    vi.stubEnv("VENDO_API_KEY", API_KEY);
+    vi.stubEnv("VENDO_TICK_SECRET", "the-operator-s-own-passphrase");
+
+    // The hard BYO rule: setting a Cloud key never shadows a secret the operator
+    // already ships in the environment.
+    expect(await tickSecret()).toBe("the-operator-s-own-passphrase");
+
+    vi.stubEnv("VENDO_TICK_SECRET", undefined);
+    expect(await tickSecret()).toBe(await deriveTickSecret(API_KEY));
+
+    vi.stubEnv("VENDO_API_KEY", undefined);
+    expect(await tickSecret()).toBeUndefined();
+  });
+});
+
+describe("enrolment", () => {
+  it("publishes the door and the secret in the one request Cloud's register door takes", async () => {
+    const { sent, fetch } = recorder(ok);
+
+    await enrol({ fetch });
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.url).toBe("https://console.vendo.run/api/v1/automations/deployments/register");
+    expect(sent[0]!.init.method).toBe("POST");
+    const headers = new Headers(sent[0]!.init.headers);
+    expect(headers.get("authorization")).toBe(`Bearer ${API_KEY}`);
+    expect(headers.get("content-type")).toBe("application/json");
+    // `{url, secret}` and nothing else. The URL keeps its path prefix (Cloud
+    // appends /api/vendo/tick to what it stores) and loses its trailing slash,
+    // so the knock never doubles the separator.
+    expect(JSON.parse(String(sent[0]!.init.body))).toEqual({
+      url: "https://maple.example.com",
+      secret: await deriveTickSecret(API_KEY),
+    });
+  });
+
+  it("publishes the deployment's path prefix, and reaches a repointed console", async () => {
+    const { sent, fetch } = recorder(ok);
+
+    await enrol({
+      cloud: { apiKey: API_KEY, baseUrl: "https://console.localhost.test" },
+      publicUrl: new URL("https://maple.example.com/bank/"),
+      fetch,
+    });
+
+    expect(sent[0]!.url).toBe("https://console.localhost.test/api/v1/automations/deployments/register");
+    expect(JSON.parse(String(sent[0]!.init.body))).toMatchObject({ url: "https://maple.example.com/bank" });
+  });
+
+  it("shouts when Cloud refuses, because a deployment that never enrolled looks healthy", async () => {
+    capture();
+    const { sent, fetch } = recorder(() => new Response(
+      JSON.stringify({ error: { code: "unavailable", message: "Could not enrol the deployment — try again." } }),
+      { status: 503, headers: { "content-type": "application/json" } },
+    ));
+
+    // Never throws: a console blip must not take the deployment down with it.
+    await enrol({ fetch });
+
+    expect(sent).toHaveLength(1);
+    expect(events).toHaveLength(1);
+    expect(events[0]!.level).toBe("error");
+    expect(events[0]!.code).toBe("vendo.tick-enrolment-failed");
+    expect(events[0]!.message).toContain("will not fire");
+    expect(events[0]!.message).toContain("Could not enrol the deployment");
+    // The secret is never in a log line, an error message, or a URL.
+    expect(events[0]!.message).not.toContain(await deriveTickSecret(API_KEY));
+  });
+
+  it("shouts when there is no public URL to be woken at, and sends nothing", async () => {
+    capture();
+    const { sent, fetch } = recorder(ok);
+
+    await enrol({ publicUrl: undefined, fetch });
+
+    expect(sent).toHaveLength(0);
+    expect(events).toHaveLength(1);
+    expect(events[0]!.level).toBe("error");
+    expect(events[0]!.message).toContain("VENDO_BASE_URL");
+  });
+
+  it("says nothing at all with no Cloud key, no automations, or a development process", async () => {
+    capture();
+    const { sent, fetch } = recorder(ok);
+
+    // No Cloud: nothing is going to knock, and nothing is missing.
+    await enrol({ cloud: undefined, fetch });
+    // No automations mounted: there is nothing for a knock to fire.
+    await enrol({ automationsMounted: false, fetch });
+    // A development process fires its own ticks and its URL is in no
+    // deployment inventory — enrolling it would register a wire Cloud cannot
+    // reach and then alarm about the silence.
+    await enrol({ development: true, fetch });
+
+    expect(sent).toHaveLength(0);
+    expect(events).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What

A deployment can now tell Vendo Cloud that it exists.

- **`packages/vendo/src/tick-enrolment.ts`** (new, ~115 lines incl. comments) —
  `deriveTickSecret`, `tickSecret` (the ladder), `enrolForTicks` (the call).
- **`wire/misc.ts`** — the tick door verifies against `tickSecret()` instead of
  reading `VENDO_TICK_SECRET` directly. One line; the signature leg is S2c's and
  is untouched.
- **`compose-automations.ts` + `compose-adapters.ts` + `compose-context.ts`** —
  one composition slot, fired from the ready() latch beside the dev ticker.
- **`wire/doctor.ts` + `cli/doctor-probe-checks.ts`** — the schedule-caller probe
  reports the same ladder the door verifies against.
- **`.changeset/a-deployment-enrols-itself-for-ticks.md`** — `@vendoai/vendo: minor`.
  The release-prep lane left this note to this branch on purpose; it supersedes the
  "with `VENDO_TICK_SECRET` unset, both are refused" line in the tick-door changeset
  and tells a host who set that var by hand whether they still need it.

## Why

Cloud's heartbeat is the only thing that wakes a hosted deployment
(`vendo-web lib/automations/heartbeat.ts`), and it can only knock on a deployment
whose URL and secret it holds. Nothing in OSS ever registered either: there was
no call to `POST /api/v1/automations/deployments/register` anywhere in the tree,
and `VENDO_TICK_SECRET` was the only secret the door could verify against. So a
hosted deployment served every request perfectly, armed its automations, and
fired nothing — with no error anywhere to say so.

### The host mints the secret

Cloud generates nothing and reveals nothing: its register door takes `{url, secret}`
and stores `secret_ciphertext: await encryptSecret(body.secret)`, answering `{ok:{}}`.
So the deployment derives the secret itself:

```
HMAC-SHA256(key = VENDO_API_KEY, message = "vendo:automations:tick:v1")  →  base64url
```

Deterministic on purpose. A deployment runs many replicas and every one of them
enrols; two that derived different secrets would take turns breaking the other's
knock. The label is frozen for the same reason. This is the same shape
`channelInboundSecret` already uses for the text channel's inbound bearer — HMAC
of a frozen label under the Cloud key, WebCrypto only so the module keeps bundling
for edge/Worker targets — with a distinct label (neither secret can be the other)
and **base64url instead of hex**, because Cloud keys its HMAC on this string's
DECODED BYTES.

### The landmine, and how it is pinned

`verifySignature` base64url-**decodes** the secret before importing it as the HMAC
key. A signer that keyed on the characters would return 401 for every knock in the
fleet **while verifying green against any local restatement of the scheme** — the
mistake this project has now made twice, once on each side.

So the test signs with `Buffer.from(secret, "base64url")` exactly as Cloud's
`sign()` does, checks it with the **shipped** `verifySignature` as the oracle, and
then asserts the character-keyed signature is REJECTED by that same artifact. A
restatement cannot tell those two apart; the shipped function can.

### Enrolment is loud, never silent, and never fatal

`enrolForTicks` shouts at `level: "error"` (`vendo.tick-enrolment-failed`) when
Cloud refuses and when the deployment has no `VENDO_BASE_URL` to publish. It never
throws and is never chained into the ready() latch: a console blip must not delay
the first request or turn into a deployment that refuses to serve. Silent in the
three cases where there is nothing to publish and nothing wrong — no Cloud key, no
automations mounted, and a development process (which fires its own ticks and
whose URL is in no deployment inventory).

The secret never reaches a log line, an error message, or a URL; a test asserts it
is absent from the failure message.

### BYO survives

`VENDO_TICK_SECRET` is the override and wins outright, per the hard BYO rule. A
test proves both halves: the bearer is accepted, and the derived value is **not** a
second key into the door — so what enrolment published is the one secret Cloud may
knock with.

## Adapter rule

`VENDO_API_KEY` fills only the slot the host left unset (`selectConnections`'s
shape): an explicit `VENDO_TICK_SECRET` wins, and if both are set it is the BYO
secret that gets registered — so Cloud is never handed a secret the door refuses.
There is exactly one `tickSecret()` ladder and both the door and enrolment read it.

## Tests, and the red watched for each

`packages/vendo/tests/tick-enrolment.test.ts` (new, 8 tests) and two added to
`tests/tick-door.test.ts`. Every one was watched fail first:

| proof | the red that was watched |
| --- | --- |
| the derived secret verifies a knock signed the way Cloud signs it, shipped `verifySignature` as oracle | module absent, then green |
| the derivation is deterministic across calls, and key-dependent | module absent, then green |
| enrolment sends exactly `POST …/register` with `{url, secret}` and the Bearer | `expected [] to have a length of 1` — and this red found a real flaw: `tickSecret()` was reading `VENDO_API_KEY` from the environment while `enrolForTicks` was handed a key, two sources that could drift. Now one ladder, one source. |
| a failed enrolment is loud | `expected [] to have a length of 1` (no log event) |
| the door accepts the DERIVED secret | `expected 401 to be 202` — the behavioural red, on the door |
| `VENDO_TICK_SECRET` still wins | passed before and after, by design: it is the BYO regression guard |

### One thing I could not prove here

There is no Cloud key on this machine (`infisical` refuses value reads and no
`.env.local` exists), and Cloud's register route is not on `vendo-web` `main` yet —
it lives on lane S4a's branch. So no live call was made. The request shape is
asserted against Cloud's own source read directly
(`type RegisterBody = { url: string; secret: string }`, `auth: key`,
`body: { json: parseBody, max: 4096 }`, path from the route's own directory).

That is the lower-consequence half: a wrong path or field name 404s on the first
boot and the shout says so. The half that has burned this project twice — the
signature encoding — is closed against the shipped artifact, not a restatement.

## Gate

`packages/vendo` is the whole touched scope.

| gate | result |
| --- | --- |
| `node scripts/dependency-guard.mjs` | OK (30 packages checked) |
| `node scripts/portability-gate.mjs` | all legs green — including the workerd leg, which is what proves the new module bundles for a Worker target (WebCrypto only, no `node:crypto`) |
| `pnpm --filter @vendoai/vendo build` | exit 0 |
| `pnpm --filter @vendoai/vendo typecheck` | exit 0 (all three tsconfigs) |
| `eslint --config eslint.blocking.config.mjs packages/vendo` | exit 0 |
| `vitest run` (packages/vendo), run A | `Test Files 225 passed \| 11 skipped (236)` · `Tests 2427 passed \| 45 skipped (2472)` · 0 failures · 1304s |
| `vitest run` (packages/vendo), run B | identical: `225 passed \| 11 skipped (236)` · `2427 passed \| 45 skipped (2472)` · 0 failures · 1293s |

The full suite is CI's job; `packages/vendo` is the touched package and was run
twice on the final tree. `tests/tick-door.test.ts` (10) and
`tests/tick-enrolment.test.ts` (8) green in both.

### The new stderr lines, on purpose

The suite gained ~46 `vendo.tick-enrolment-failed` lines. No test broke and **no
call left the machine** — the 16 that reached the register path were absorbed by
those suites' own `fetch` stubs (`defaultFetch` late-binds through
`globalThis.fetch`), and there is no `fetch failed`/`ENOTFOUND` anywhere in the log.
The other 30 are compositions that set `VENDO_API_KEY` with no `VENDO_BASE_URL`, and
for those the sentence is simply true.

It is not deduped, and deliberately not suppressed by environment. The shout cannot
be gated on `NODE_ENV === "production"` the way `compose-actions`' base-URL warning
is: a deployment with an unset `NODE_ENV` is indistinguishable from a test process,
and silencing that case reintroduces exactly the "looks healthy, never fires"
failure this PR exists to close. Per-composition posture lines are already this
suite's convention (`[vendo] ready — …`, the `/tmp` store warning, `zero live host
tools`), so this is one more of that kind rather than a new mechanism.

## Not in this PR

`docs-site/reference/http-routes.mdx` and
`docs-site/production/troubleshooting/e-sched-001.mdx` still describe `/tick` as
bearer-only, which S2c already outdated. `docs-site/**` belongs to lane S3.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hosted deployments auto-enrol with Vendo Cloud and derive the heartbeat secret from `VENDO_API_KEY`. Previously the tick door verified only `VENDO_TICK_SECRET` and deployments never registered, so Cloud could not wake them; now we register `{url, secret}` at boot and verify the same derived secret, with `VENDO_TICK_SECRET` remaining an override.

**Review notes**
- Adds `packages/vendo/src/tick-enrolment.ts` with `deriveTickSecret`, `tickSecret`, and `enrolForTicks` (deterministic base64url HMAC using WebCrypto).
- Fires `enrolForCloudTicks` from `ready()` in `compose-automations.ts`; non-blocking and logs `vendo.tick-enrolment-failed` on failure.
- `wire/misc.ts` tick door verifies against `tickSecret()` for both Bearer and signature.
- `wire/doctor.ts` and CLI doctor probe read the same ladder, not the env var; messages updated.
- Tests pin signature behavior against `@vendoai/automations` `verifySignature`; changeset is `@vendoai/vendo: minor`.

**Rollout/Migration**
- Cloud-hosted: set `VENDO_API_KEY` and `VENDO_BASE_URL`; no other config. Remove `VENDO_TICK_SECRET` if it was only for heartbeat.
- Self-cron without Cloud: keep `VENDO_TICK_SECRET` and point your cron at `POST /api/vendo/tick`.
- Both set: `VENDO_TICK_SECRET` wins and is the value registered, so Cloud and your cron use the same secret.
- If enrolment fails or `VENDO_BASE_URL` is missing, scheduled automations will not fire; watch for `vendo.tick-enrolment-failed`.

<sup>Written for commit 5d1dabc9c1cca04bc58c24a00941f9cc8ce71a7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

