### PR TITLE
fix(guard): an away call binds to the identity it carries, so a boxed app can call host tools again

### DIFF
--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -389,12 +389,27 @@ function durationMatches(grant: PermissionGrant, ctx: RunContext): boolean {
 
 function presenceMatches(grant: PermissionGrant, ctx: RunContext): boolean {
   if (ctx.presence === "away") {
-    // Per AUTOMATION: an away run is one record, consented to on its own — the
-    // person arming it was shown that record's task. An automation carries no
-    // app reference at all, so the id is the whole match; a grant with none can
-    // never authorize an away call.
-    return grant.automationId !== undefined && grant.automationId === ctx.trigger?.automationId
-      && grant.source === "automation";
+    // The binding comes from WHICH IDENTITY THE CTX CARRIES, and the two arms are
+    // MUTUALLY EXCLUSIVE — the discriminator is the TRIGGER, because that is what
+    // makes a run an automation firing at all.
+    //
+    // A FIRING (it carries a trigger) is one record, consented to on its own — the
+    // person arming it was shown that record's task — and a record carries no app
+    // reference, so the automation id is the WHOLE match and a grant naming none
+    // rides nothing away. Keying this arm on `trigger.automationId` instead of on
+    // the trigger's mere presence would let a firing that carries an appId but no
+    // automation id fall through to the app arm and ride an app-bound yes
+    // (mint-grant.test.ts:118-130) — one app's yes riding every automation in it.
+    //
+    // NO trigger at all means it is nobody's firing: a boxed ("machine", layer-2)
+    // app callback, which `wire/box.ts:309-315` mints as
+    // `{ venue: "app", presence: "away", appId }`. It has only the app it runs as,
+    // so the app is the whole match — main's away rule for this venue.
+    if (grant.source !== "automation") return false;
+    if (ctx.trigger !== undefined) {
+      return grant.automationId !== undefined && grant.automationId === ctx.trigger.automationId;
+    }
+    return grant.appId !== undefined && grant.appId === ctx.appId;
   }
   return grant.appId === undefined || grant.appId === ctx.appId;
 }

--- a/packages/guard/test/security/box-away-binding.test.ts
+++ b/packages/guard/test/security/box-away-binding.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { createGuard } from "../../src/index.js";
+import { createMemoryStore } from "../fixtures/memory-store.js";
+import { AUTOMATION_ID, FixtureTools, call, context, descriptor, seedGrant } from "../fixtures/tools.js";
+
+// 05 §6: an away grant binds to the identity the ctx ACTUALLY CARRIES, and the
+// two arms are mutually exclusive. An automation firing carries
+// `trigger.automationId` and is matched on that alone — a record holds no app
+// reference. A boxed ("machine", layer-2) app callback carries no automation
+// identity at all, only the app it runs as (`wire/box.ts` mints
+// `{ venue: "app", presence: "away", appId }` with no trigger), so it is matched
+// on `appId`. Exclusivity is the security half of the rule: an app-bound grant
+// must never authorize an automation firing that merely happens to carry an
+// appId, or one app's yes would ride every automation in it.
+describe("away grants bind to the identity the ctx carries (05 §6)", () => {
+  /** A boxed app's server-side callback, byte-for-byte the ctx `wire/box.ts` builds. */
+  const boxCtx = (appId = "app_1") =>
+    context({ venue: "app", presence: "away", sessionId: `box_${appId}`, appId });
+
+  /** An automation FIRING, which may also name the app it renders into. */
+  const automationCtx = (appId?: string) =>
+    context({
+      venue: "automation",
+      presence: "away",
+      ...(appId === undefined ? {} : { appId }),
+      trigger: { runId: "run_away", kind: "host-event", automationId: AUTOMATION_ID },
+    });
+
+  it("an automation-bound grant authorizes the firing that names that automation", async () => {
+    const store = createMemoryStore();
+    const d = descriptor("write", { name: "host_atm_bound" });
+    await seedGrant(store, { descriptor: d, automationId: AUTOMATION_ID, source: "automation" });
+    const guard = createGuard({ store });
+    const tools = new FixtureTools([d]);
+    const bound = guard.bind(tools);
+
+    await expect(guard.check(call(d.name, { amount: 1 }, "call_atm"), d, automationCtx()))
+      .resolves.toMatchObject({ action: "run", decidedBy: "grant" });
+    await expect(bound.execute(call(d.name, { amount: 1 }, "call_atm"), automationCtx()))
+      .resolves.toMatchObject({ status: "ok" });
+    expect(tools.executions).toHaveLength(1);
+  });
+
+  it("an app-bound grant authorizes a boxed app's away callback", async () => {
+    const store = createMemoryStore();
+    const d = descriptor("write", { name: "host_app_bound" });
+    // Exactly the row the automations enable flow mints for a boxed app: bound to
+    // the app, source "automation", naming no automation id.
+    await seedGrant(store, { descriptor: d, appId: "app_1", source: "automation" });
+    const guard = createGuard({ store });
+    const tools = new FixtureTools([d]);
+    const bound = guard.bind(tools);
+
+    await expect(guard.check(call(d.name, { amount: 1 }, "call_box"), d, boxCtx()))
+      .resolves.toMatchObject({ action: "run", decidedBy: "grant" });
+    await expect(bound.execute(call(d.name, { amount: 1 }, "call_box"), boxCtx()))
+      .resolves.toMatchObject({ status: "ok" });
+    expect(tools.executions).toHaveLength(1);
+  });
+
+  it("that same app-bound grant does NOT authorize an automation firing in that app", async () => {
+    const store = createMemoryStore();
+    const d = descriptor("write", { name: "host_app_bound" });
+    await seedGrant(store, { descriptor: d, appId: "app_1", source: "automation" });
+    const guard = createGuard({ store });
+    const tools = new FixtureTools([d]);
+    const bound = guard.bind(tools);
+
+    // The ctx carries an automation identity, so ONLY an automation-bound grant
+    // can satisfy it. The app match is not available as a fallback.
+    await expect(guard.check(call(d.name, { amount: 1 }, "call_x"), d, automationCtx("app_1")))
+      .resolves.toMatchObject({ action: "ask", decidedBy: "default" });
+    await expect(bound.execute(call(d.name, { amount: 1 }, "call_x"), automationCtx("app_1")))
+      .resolves.toMatchObject({ status: "pending-approval" });
+    expect(tools.executions).toHaveLength(0);
+  });
+
+  it("a FIRING carrying an appId but no automation id does NOT ride the app-bound grant", async () => {
+    const store = createMemoryStore();
+    const d = descriptor("write", { name: "host_app_bound" });
+    await seedGrant(store, { descriptor: d, appId: "app_1", source: "automation" });
+    const guard = createGuard({ store });
+    const tools = new FixtureTools([d]);
+    const bound = guard.bind(tools);
+
+    // The discriminator between the arms is the TRIGGER, not `trigger.automationId`:
+    // this run carries one, so it is a firing and is bound to the record it fires —
+    // and it names none, so it rides nothing. Falling through to the app arm here
+    // would let one app's yes authorize every automation inside it.
+    const firing = context({
+      venue: "automation",
+      presence: "away",
+      appId: "app_1",
+      trigger: { runId: "run_unkeyed", kind: "schedule" },
+    });
+    await expect(guard.check(call(d.name, { amount: 1 }, "call_unkeyed"), d, firing))
+      .resolves.toMatchObject({ action: "ask", decidedBy: "default" });
+    await expect(bound.execute(call(d.name, { amount: 1 }, "call_unkeyed"), firing))
+      .resolves.toMatchObject({ status: "pending-approval" });
+    expect(tools.executions).toHaveLength(0);
+  });
+
+  it("an automation-bound grant does NOT authorize a boxed app's away callback", async () => {
+    const store = createMemoryStore();
+    const d = descriptor("write", { name: "host_atm_only" });
+    await seedGrant(store, { descriptor: d, automationId: AUTOMATION_ID, source: "automation" });
+    const guard = createGuard({ store });
+    const tools = new FixtureTools([d]);
+    const bound = guard.bind(tools);
+
+    // The box carries no automation identity, so it matches on the app — and this
+    // grant names none. An automation's consent is not the box's to spend.
+    await expect(guard.check(call(d.name, { amount: 1 }, "call_y"), d, boxCtx()))
+      .resolves.toMatchObject({ action: "ask", decidedBy: "default" });
+    await expect(bound.execute(call(d.name, { amount: 1 }, "call_y"), boxCtx()))
+      .resolves.toMatchObject({ status: "pending-approval" });
+    expect(tools.executions).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
> Base is `automations/s2c-vendo` (#1397), so this diff is lane S2h alone: three lines of predicate in `packages/guard/src/guard.ts` and one new guard security test. Nothing else is touched — not `wire/box.ts`, not the integration fixture.

## A boxed app could no longer call any host tool, ever

A customer clicks a button in a Vendo-generated app, its server-side function tries to read their invoices, and instead of data they get a permission card. They tap approve and **nothing changes**. Every subsequent click produces a fresh card. A permanent loop with no exit.

The stack introduced it and no lane saw it, because the only thing in the repo that catches it lives in the `integration` check's `node` leg, which no lane ran.

## The forcing chain

`presenceMatches` matched an away call's grant on the firing automation's id alone:

```ts
// before — packages/guard/src/guard.ts:396
return grant.automationId !== undefined && grant.automationId === ctx.trigger?.automationId
  && grant.source === "automation";
```

A boxed ("machine", layer-2) app callback carries no trigger at all. `wire/box.ts:309-315` mints:

```ts
{ principal, venue: "app", presence: "away", sessionId: `box_${appId}`, appId }
```

so `ctx.trigger?.automationId` is `undefined`, and the conjunction reads `grant.automationId !== undefined && grant.automationId === undefined` — **false for every grant that can ever exist.** Not "usually fails"; unsatisfiable by construction.

`box.ts` is **byte-identical to `main`**. The box did not change; `presenceMatches` changed underneath it. On `main` the away match keyed on `grant.appId === ctx.appId` with the trigger term defaulting on both sides, so an app-bound, automation-source grant matched a box call.

There is no bypass and no recovery:

- Dispatch goes through the guard-bound registry (`box.ts:286-290` → `wire/shared.ts:107-110`, wired at `compose-wire.ts:74`).
- Away + `decidedBy !== "grant"` is downgraded to `ask` and parks (`guard.ts:1104`).
- `#approvedReplay` needs the same call id, but the box mints a fresh `call_${randomUUID()}` per call (`box.ts:287`).
- The automations decide subscriber requires `ctx.request.ctx.venue === "automation"` (`packages/automations/src/consent.ts:204`); the box is `"app"`.
- The apps runtime's resume subscriber never sees it: `parkedActions` is written only by the tree-action caller's `onParkedAction` (`packages/apps/src/server/runtime/runtime-context.ts:322-325`), and the box's HTTP callback surface does not go through that caller.

So approving minted no authority the next call could use, and the parked call was never resumed.

## The fix

The binding comes from **which identity the ctx actually carries**, with the arms **mutually exclusive**. The discriminator is the **trigger**, because carrying one is what makes a run an automation firing at all:

```ts
if (grant.source !== "automation") return false;
if (ctx.trigger !== undefined) {
  return grant.automationId !== undefined && grant.automationId === ctx.trigger.automationId;
}
return grant.appId !== undefined && grant.appId === ctx.appId;
```

- ctx carries a trigger → it is a **firing**, bound to the record it fires. Today's rule, unchanged.
- ctx carries no trigger → nobody's firing, i.e. a **box**, which has only the app it runs as. `main`'s away rule for this venue, restored.
- `grant.source === "automation"` still holds in both arms, so chat-minted grants still authorize no away call — that deliberate security property is untouched.

Five lines of logic. The rest of the diff is the comment explaining why.

### Exclusivity is the security half, and it bites at a finer grain than it looks

An unqualified `OR` would let an app-bound grant authorize an automation firing that merely happens to carry an `appId` — one app's yes riding every automation inside it.

Subtler, and it caught an earlier draft of this fix: keying the automation arm on `trigger.automationId` rather than on the trigger's mere *presence* has the same effect. A firing that carries an `appId` but **no** automation id then falls through to the app arm and rides the app-bound yes. `mint-grant.test.ts:118-130` already pinned that case and went red on the first draft — the codebase's own statement of the rule, and the reason the discriminator is `ctx.trigger !== undefined`.

`box-away-binding.test.ts` now pins both arms and both directions of exclusivity, including that firing-with-an-appId case. The exclusivity assertions were additionally verified against a deliberate naive-`OR` mutant, under which `check` returns `action: "run"` and the test fails as designed.

## Rejected, deliberately

- **Giving the box a synthetic `trigger.automationId`.** A box is not an automation; an id collision would let a box ride an automation's consent.
- **Widening to accept chat-sourced grants.** Deliberate security property.
- **Changing the box to `presence: "present"`** (`box.ts:312`). Arguably more correct for a user-initiated call, but that is a security-posture decision, not a bug fix. `box.ts` is untouched.
- **Adding `automationId` to the fixture's seeded grant.** The tempting one-liner, and the wrong one: it would teach the test to seed a row the product cannot produce and make a real regression invisible.

## Evidence

`fixtures/integration/tests/machine-skin.e2e.test.ts` is **byte-identical to `main` and untouched** (`git diff` against `main` on that path is empty). It seeds an app-bound, `source: "automation"` grant with **no** `automationId` at `:202-212` — exactly the row the product mints — and asserts `outcome.list.status === "ok"` at `:234`.

- **Before:** `AssertionError: expected 'pending-approval' to be 'ok'` at `tests/machine-skin.e2e.test.ts:234:33`.
- **After:** 1 passed.

The new `packages/guard/test/security/box-away-binding.test.ts` pins five cases: both arms, and three ways the arms must not leak into each other. Watched red first — the box arm failed `expected { action: 'ask', decidedBy: 'default' } to match { action: 'run', decidedBy: 'grant' }`.

`@vendoai/guard`: 328 passed | 3 skipped, run twice identically.

## No-op for automations, traced not asserted

- The firing ctx (`packages/automations/src/sponsorship-gate.ts:80-96`) carries a trigger with its `automationId` and takes arm one — byte-for-byte the old predicate.
- The agent away runner (`packages/agents/src/away.ts:648`) carries neither a trigger nor an `appId`, so it still parks.
- The other `presence: "away"` producers (`agents/src/agent.ts:332`, `automations/src/ingestion-surface.ts:194`, `automations/src/run-rows.ts:56`, `vendo/src/compose-guard.ts:98`) are `guard.report` audit rows that never reach this predicate.
- The doctor act-as probe (`vendo/src/compose-actions.ts:141-152`) executes on a bare `createActions` registry; its `ctx.grant` is consumed for ActAs host auth (`actions/src/runtime/registry.ts:616`), never for grant matching.

`@vendoai/automations` and `@vendoai/vendo` suites confirm it empirically.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes away grant binding to use the identity the context carries, so boxed apps can call host tools again. Previously, away calls matched only on `grant.automationId === ctx.trigger?.automationId`, which made boxed app callbacks (no trigger) always park; now they match on `automationId` when a trigger is present, or `appId` when it is not.

- Updates `presenceMatches` in `packages/guard/src/guard.ts` to:
  - Require `grant.source === "automation"`.
  - If `ctx.trigger` exists, match `grant.automationId === ctx.trigger.automationId`.
  - Otherwise, match `grant.appId === ctx.appId`.
- Enforces mutual exclusivity between automation-bound and app-bound arms to prevent an app-bound grant from authorizing an automation firing.
- Adds `packages/guard/test/security/box-away-binding.test.ts` to pin both arms and exclusivity, including the firing-with-appId case.
- No changes to `wire/box.ts` or integration fixtures; automation paths behave as before. No migration required.

<sup>Written for commit e582e53a4cbc4a733c0d955548b11cd91c9310b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

