### PR TITLE
feat(demo-bank): texting Maple is a card and a modal, not a bare link

### DIFF
--- a/examples/demo-bank/package.json
+++ b/examples/demo-bank/package.json
@@ -38,6 +38,7 @@
     "lucide-react": "^1.21.0",
     "next": "16.2.11",
     "next-auth": "5.0.0-beta.32",
+    "qrcode-generator": "^2.0.4",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "recharts": "^3.8.1",

--- a/examples/demo-bank/src/app/api/vendo/text-link/route.ts
+++ b/examples/demo-bank/src/app/api/vendo/text-link/route.ts
@@ -1,4 +1,3 @@
-import { VendoError } from "@vendoai/core"
 import { ok, serverError } from "@/server/http"
 import { mapleAuth, vendo } from "@/vendo/server"
 
@@ -25,29 +24,32 @@ export const dynamic = "force-dynamic"
  * `url: null` is the graceful "this deployment has no text channel" answer —
  * the flag needs a Vendo Cloud key, and a demo without one must say so rather
  * than hand out a link that cannot work. It is reserved for EXACTLY that: the
- * deployment being CONFIGURED without one, which surfaces two ways: the
- * unconfigured adapter refusing with `not-implemented` (no Cloud key), and
- * `validation` when no public URL is set for Cloud to deliver to. Both mean the
- * same thing to a person — texting is not available on this deployment.
+ * deployment being configured without one — and that is answered from the
+ * CONFIGURATION, not from the shape of an error. The two env vars this channel
+ * needs are the same two `createVendo` composes it from: the Cloud key that
+ * carries the numbers, and the public URL Cloud delivers back to.
  *
- * Everything else is an outage, not a setting: a store blip, a console that is
- * down, a vendor timeout. Answering `url: null` to those would tell the customer
- * their text channel is switched OFF, and the modal caches that because it does
- * not revalidate — so one transient failure would read as permanently disabled.
- * Those get a 503 the UI can retry.
+ * Reading it off error codes was the wrong instinct and I had it: `validation`
+ * covers both "no VENDO_BASE_URL set" (a setting) and "Cloud returned no
+ * identity to text" (an outage), so no code-based rule can separate them. With
+ * the check up front, every error from `link()` is unambiguously an outage.
+ *
+ * That matters because `url: null` is sticky in the UI: it means "texting is not
+ * available here", and a passing failure reported that way would read as
+ * permanently switched off. Outages get a 503 the modal offers to retry.
  */
 export async function GET(request: Request) {
   // mapleAuth resolves every visitor, signed in or not (the shared demo guest),
   // so null is unreachable here — the seam's type just allows it.
   const principal = await mapleAuth.principal(request)
   if (principal === null) return ok({ url: null })
+  // No key or no public URL means this checkout of the demo has no text channel
+  // at all — the honest, permanent answer, and the one the modal explains.
+  if (!process.env.VENDO_API_KEY || !process.env.VENDO_BASE_URL) return ok({ url: null })
   try {
     const { url } = await vendo.channels.text.link(principal)
     return ok({ url })
   } catch (error) {
-    const unavailableByConfig = error instanceof VendoError
-      && (error.code === "not-implemented" || error.code === "validation")
-    if (unavailableByConfig) return ok({ url: null })
     console.error("[maple] text-link mint failed", {
       error: error instanceof Error ? `${error.name}: ${error.message}` : String(error),
     })

--- a/examples/demo-bank/src/app/api/vendo/text-link/route.ts
+++ b/examples/demo-bank/src/app/api/vendo/text-link/route.ts
@@ -25,9 +25,16 @@ export const dynamic = "force-dynamic"
  * the flag needs a Vendo Cloud key, and a demo without one must say so rather
  * than hand out a link that cannot work. It is reserved for EXACTLY that: the
  * deployment being configured without one — and that is answered from the
- * CONFIGURATION, not from the shape of an error. The two env vars this channel
- * needs are the same two `createVendo` composes it from: the Cloud key that
- * carries the numbers, and the public URL Cloud delivers back to.
+ * CONFIGURATION, not from the shape of an error. The channel needs two things:
+ * the Cloud key that carries the numbers, and a public URL Cloud can deliver
+ * back to.
+ *
+ * "Public" is load-bearing. `instrumentation.ts` fills an unset VENDO_BASE_URL
+ * with `http://localhost:<port>/maple` so local dev boots, which means the var is
+ * NEVER empty at runtime — a presence check would call this channel configured on
+ * every laptop. Vendo Cloud cannot deliver an inbound text to a loopback address,
+ * so a deployment pointing at one has no texting, permanently, and should say so
+ * rather than offer a retry that can never succeed.
  *
  * Reading it off error codes was the wrong instinct and I had it: `validation`
  * covers both "no VENDO_BASE_URL set" (a setting) and "Cloud returned no
@@ -38,14 +45,30 @@ export const dynamic = "force-dynamic"
  * available here", and a passing failure reported that way would read as
  * permanently switched off. Outages get a 503 the modal offers to retry.
  */
+/** Could Vendo Cloud actually POST an inbound text to this URL? A loopback or
+    unparseable one is a local-dev address, not a public callback. */
+function deliverableUrl(raw: string | undefined): boolean {
+  if (!raw) return false
+  let host: string
+  try {
+    host = new URL(raw).hostname.toLowerCase()
+  } catch {
+    return false
+  }
+  return host !== "localhost" && host !== "127.0.0.1" && host !== "[::1]" && host !== "::1"
+    && !host.endsWith(".localhost")
+}
+
 export async function GET(request: Request) {
   // mapleAuth resolves every visitor, signed in or not (the shared demo guest),
   // so null is unreachable here — the seam's type just allows it.
   const principal = await mapleAuth.principal(request)
   if (principal === null) return ok({ url: null })
-  // No key or no public URL means this checkout of the demo has no text channel
-  // at all — the honest, permanent answer, and the one the modal explains.
-  if (!process.env.VENDO_API_KEY || !process.env.VENDO_BASE_URL) return ok({ url: null })
+  // No key, or nowhere public for Cloud to deliver to, means this checkout of the
+  // demo has no text channel at all — the honest, permanent answer.
+  if (!process.env.VENDO_API_KEY || !deliverableUrl(process.env.VENDO_BASE_URL)) {
+    return ok({ url: null })
+  }
   try {
     const { url } = await vendo.channels.text.link(principal)
     return ok({ url })

--- a/examples/demo-bank/src/app/api/vendo/text-link/route.ts
+++ b/examples/demo-bank/src/app/api/vendo/text-link/route.ts
@@ -1,4 +1,5 @@
-import { ok } from "@/server/http"
+import { VendoError } from "@vendoai/core"
+import { ok, serverError } from "@/server/http"
 import { mapleAuth, vendo } from "@/vendo/server"
 
 export const runtime = "nodejs"
@@ -23,7 +24,17 @@ export const dynamic = "force-dynamic"
  *
  * `url: null` is the graceful "this deployment has no text channel" answer —
  * the flag needs a Vendo Cloud key, and a demo without one must say so rather
- * than hand out a link that cannot work.
+ * than hand out a link that cannot work. It is reserved for EXACTLY that: the
+ * deployment being CONFIGURED without one, which surfaces two ways: the
+ * unconfigured adapter refusing with `not-implemented` (no Cloud key), and
+ * `validation` when no public URL is set for Cloud to deliver to. Both mean the
+ * same thing to a person — texting is not available on this deployment.
+ *
+ * Everything else is an outage, not a setting: a store blip, a console that is
+ * down, a vendor timeout. Answering `url: null` to those would tell the customer
+ * their text channel is switched OFF, and the modal caches that because it does
+ * not revalidate — so one transient failure would read as permanently disabled.
+ * Those get a 503 the UI can retry.
  */
 export async function GET(request: Request) {
   // mapleAuth resolves every visitor, signed in or not (the shared demo guest),
@@ -33,7 +44,13 @@ export async function GET(request: Request) {
   try {
     const { url } = await vendo.channels.text.link(principal)
     return ok({ url })
-  } catch {
-    return ok({ url: null })
+  } catch (error) {
+    const unavailableByConfig = error instanceof VendoError
+      && (error.code === "not-implemented" || error.code === "validation")
+    if (unavailableByConfig) return ok({ url: null })
+    console.error("[maple] text-link mint failed", {
+      error: error instanceof Error ? `${error.name}: ${error.message}` : String(error),
+    })
+    return serverError("Could not start texting just now.")
   }
 }

--- a/examples/demo-bank/src/app/api/vendo/text-link/route.ts
+++ b/examples/demo-bank/src/app/api/vendo/text-link/route.ts
@@ -1,0 +1,39 @@
+import { ok } from "@/server/http"
+import { mapleAuth, vendo } from "@/vendo/server"
+
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+/**
+ * THIS USER'S TEXT-CHANNEL INVITE, minted on demand.
+ *
+ * The same call the wire's `/api/vendo/channels/text/link` anchor makes, but
+ * answering JSON so the settings modal can render the `sms:` link and its QR in
+ * Maple's own chrome instead of the door's fallback page.
+ *
+ * Called when the modal OPENS, never on page load: every mint replaces this
+ * user's outstanding code (ChannelLinkRepository.mint), so a page-load mint
+ * would invalidate the code of anyone who is mid-link on their phone.
+ *
+ * UNDER /api/vendo deliberately, beside the door's catch-all (Next prefers this
+ * static segment over `[...vendo]`). That prefix is where the extractor stops
+ * looking, so this stays a surface for Maple's own UI instead of joining the
+ * agent's host tools — and it is one of proxy.ts's public prefixes, so the demo's
+ * signed-out visitor reaches it exactly as they reach the anchor route.
+ *
+ * `url: null` is the graceful "this deployment has no text channel" answer —
+ * the flag needs a Vendo Cloud key, and a demo without one must say so rather
+ * than hand out a link that cannot work.
+ */
+export async function GET(request: Request) {
+  // mapleAuth resolves every visitor, signed in or not (the shared demo guest),
+  // so null is unreachable here — the seam's type just allows it.
+  const principal = await mapleAuth.principal(request)
+  if (principal === null) return ok({ url: null })
+  try {
+    const { url } = await vendo.channels.text.link(principal)
+    return ok({ url })
+  } catch {
+    return ok({ url: null })
+  }
+}

--- a/examples/demo-bank/src/app/globals.css
+++ b/examples/demo-bank/src/app/globals.css
@@ -52,6 +52,63 @@ body {
   }
 }
 
+/* The settings modal (components/settings/text-channel-card.tsx) is a native
+   <dialog>, so Esc, the top layer and focus containment come from the platform.
+   Motion is TRANSITIONS rather than keyframes, so a fast open→close is
+   retargeted instead of restarted. `@starting-style` carries the entrance;
+   `close()` drops the element out of the top layer at once, so the exit is
+   carried by `data-closing` and the component closes the dialog after it (the
+   `display: allow-discrete` spelling of this leaves the panel unpainted here).
+   Exit is quicker than the entrance — the system answering, not the user
+   deciding. */
+.maple-modal,
+.maple-modal::backdrop {
+  opacity: 1;
+  transition: opacity 180ms ease;
+}
+
+.maple-modal::backdrop {
+  background: rgb(17 17 17 / 0.22);
+  backdrop-filter: blur(2px);
+}
+
+.maple-modal-panel {
+  transition: transform 260ms cubic-bezier(0.16, 1, 0.3, 1), opacity 180ms ease;
+}
+
+@starting-style {
+  .maple-modal[open],
+  .maple-modal[open]::backdrop {
+    opacity: 0;
+  }
+
+  .maple-modal[open] .maple-modal-panel {
+    opacity: 0;
+    transform: translateY(10px) scale(0.97);
+  }
+}
+
+.maple-modal[data-closing],
+.maple-modal[data-closing]::backdrop {
+  opacity: 0;
+}
+
+.maple-modal[data-closing] .maple-modal-panel {
+  opacity: 0;
+  transform: translateY(10px) scale(0.97);
+  transition: transform 160ms ease-out, opacity 140ms ease;
+}
+
+/* Reduced motion keeps the fade — it explains where the panel went — and drops
+   the movement. */
+@media (prefers-reduced-motion: reduce) {
+  .maple-modal-panel,
+  .maple-modal[data-closing] .maple-modal-panel {
+    transform: none;
+    transition: opacity 140ms ease;
+  }
+}
+
 /* Vendo stage approval: the shell's approved ApprovalCard materializes
    in-flow beneath the generated view (brand-tier pick). */
 .maple-approval-inflow .fl-approval { animation: maple-approval-in 0.28s cubic-bezier(0.16, 1, 0.3, 1); }

--- a/examples/demo-bank/src/app/settings/page.tsx
+++ b/examples/demo-bank/src/app/settings/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 import * as React from "react"
 import { Bell, Lock, Mail, Globe, Moon } from "lucide-react"
+import { TextChannelCard } from "@/components/settings/text-channel-card"
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Switch } from "@/components/ui/switch"
@@ -8,7 +9,6 @@ import { Segmented } from "@/components/ui/segmented"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useToast } from "@/components/ui/toast"
 import { useProfile } from "@/lib/hooks"
-import { withBasePath } from "@/lib/base-path"
 import { BrandLogo } from "@/components/ui/brand-logo"
 import { domainForName } from "@/lib/logos"
 
@@ -258,23 +258,16 @@ export default function SettingsPage() {
       <div>
         <h1 className="text-xl font-semibold tracking-tight text-ink">Settings</h1>
         <p className="text-sm text-muted">Manage your profile, security, and preferences.</p>
-        {/* The whole text-channel opt-in: one anchor at the wire route, which
-            mints this user's code and sends a phone straight into the prefilled
-            first message. A raw href, so it carries the mount prefix itself
-            (base-path.ts), and a full navigation rather than a `next/link`
-            transition — the route answers a 302 into the messages app on a
-            phone and HTML on a desktop. */}
-        <a
-          className="mt-2 inline-block text-sm font-medium text-ink underline underline-offset-4"
-          href={withBasePath("/api/vendo/channels/text/link")}
-        >
-          Text Maple from your phone
-        </a>
       </div>
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
         <div className="space-y-6 lg:col-span-2">
           <ProfileCard />
+          {/* The text-channel opt-in. The card opens a modal that mints this
+              user's code and shows the prefilled first text as a QR; the wire
+              route it is built on still serves a phone a 302 straight into
+              Messages. */}
+          <TextChannelCard />
         </div>
 
         <ToggleSection

--- a/examples/demo-bank/src/components/settings/text-channel-card.tsx
+++ b/examples/demo-bank/src/components/settings/text-channel-card.tsx
@@ -1,0 +1,217 @@
+"use client"
+import * as React from "react"
+import { ArrowUpRight, MessageSquareText, X } from "lucide-react"
+import qrcode from "qrcode-generator"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { MapleMark } from "@/components/ui/maple-mark"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useTextLink } from "@/lib/hooks"
+
+/** How long the dismissal takes — the longest exit leg in globals.css (the
+ *  backdrop's fade). The dialog is closed once that has played. */
+const EXIT_MS = 180
+
+/** The invite link as a scannable code. Rendered as ONE path of unit squares in
+ *  a module-sized viewBox, so it scales to any plate size without resampling.
+ *  A QR is a contrast contract, not decoration — the modules are pinned to ink
+ *  on a white plate rather than inheriting the surface. */
+function QrCode({ value, className }: { value: string; className?: string }) {
+  const { d, modules } = React.useMemo(() => {
+    const qr = qrcode(0, "M")
+    qr.addData(value)
+    qr.make()
+    const modules = qr.getModuleCount()
+    let d = ""
+    for (let row = 0; row < modules; row += 1) {
+      for (let col = 0; col < modules; col += 1) {
+        if (qr.isDark(row, col)) d += `M${col} ${row}h1v1h-1z`
+      }
+    }
+    return { d, modules }
+  }, [value])
+
+  return (
+    <svg
+      viewBox={`0 0 ${modules} ${modules}`}
+      className={className}
+      role="img"
+      aria-label="QR code that opens the first text on your phone"
+      shapeRendering="crispEdges"
+    >
+      <path d={d} fill="#111111" />
+    </svg>
+  )
+}
+
+/**
+ * THE TEXT-CHANNEL OPT-IN on /settings.
+ *
+ * The card is the invitation; the modal is the nicer desktop version of the
+ * door's own link page (`/api/vendo/channels/text/link`, which still serves
+ * phones a 302 straight into Messages). Nothing is minted until the modal
+ * opens — see useTextLink.
+ *
+ * The modal is a native `<dialog>`, so Esc, focus containment and the top layer
+ * come from the platform rather than from a library — and its own `[open]` is
+ * the one source of truth for whether it is up, which is why the handlers drive
+ * `showModal()`/`close()` directly instead of mirroring that in React state.
+ */
+export function TextChannelCard() {
+  const dialog = React.useRef<HTMLDialogElement>(null)
+  // Sticky: once asked for, the invite stays fetched. It has to survive the
+  // close animation (the QR must not blink out from under it), and SWR then
+  // answers a re-open from cache — which matters here, because every mint
+  // replaces the user's outstanding code.
+  const [requested, setRequested] = React.useState(false)
+  const [closing, setClosing] = React.useState(false)
+  const { data } = useTextLink(requested)
+
+  const url = data?.url ?? null
+  // Only an ANSWERED request can say "no channel here" — until then the plate
+  // waits, so opening the modal never flashes an apology it is about to retract.
+  const unavailable = data !== undefined && data.url === null
+
+  const open = (): void => {
+    setRequested(true)
+    setClosing(false)
+    dialog.current?.showModal()
+  }
+
+  // Dismissal takes two beats: the panel animates out under `data-closing`, and
+  // only then does the dialog close — `close()` drops it out of the top layer at
+  // once, which would cut the animation off at its first frame.
+  const close = (): void => {
+    setClosing(true)
+    window.setTimeout(() => {
+      dialog.current?.close()
+      setClosing(false)
+    }, EXIT_MS)
+  }
+
+  return (
+    <Card className="bg-gradient-to-b from-surface to-hover/60">
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <CardTitle>Text channel</CardTitle>
+          <Badge>New</Badge>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {/* The CTA drops under the copy on a narrow screen: held on one row it
+            squeezes the description into a ribbon a few words wide. */}
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between sm:gap-5">
+          <div className="flex min-w-0 items-start gap-3.5">
+            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[12px] bg-ink text-white">
+              <MessageSquareText className="h-[18px] w-[18px]" strokeWidth={1.9} />
+            </span>
+            <div className="min-w-0">
+              <div className="text-sm font-semibold text-ink">Text with Maple</div>
+              <p className="mt-0.5 text-xs leading-relaxed text-muted">
+                Ask Maple from your phone&rsquo;s Messages app. One text links it — no app to
+                install.
+              </p>
+            </div>
+          </div>
+          <Button
+            size="sm"
+            onClick={open}
+            className="w-full shrink-0 transition-[background-color,transform] duration-150 active:scale-[0.97] sm:w-auto"
+          >
+            Set up texting
+          </Button>
+        </div>
+      </CardContent>
+
+      {/* Inside the card so the component is ONE box: a `space-y-*` stack in
+          Tailwind v4 margins every child but the last, and a display:none
+          sibling at the end would leave that margin behind as a phantom gap.
+          `showModal()` promotes the dialog to the top layer, so where it sits in
+          the DOM has no bearing on how it paints. */}
+      <dialog
+        ref={dialog}
+        className="maple-modal m-auto w-[calc(100%-2rem)] max-w-[25rem] border-0 bg-transparent p-0"
+        aria-labelledby="text-channel-title"
+        data-closing={closing || undefined}
+        // Esc goes through the same two beats as every other dismissal; left to
+        // the platform it would close the dialog instantly, mid-animation.
+        onCancel={(event) => {
+          event.preventDefault()
+          close()
+        }}
+        // The backdrop is the dialog's own hit area, so a click that lands on the
+        // dialog rather than on the panel inside it is a click outside.
+        onClick={(event) => {
+          if (event.target === dialog.current) close()
+        }}
+      >
+        <div className="maple-modal-panel relative rounded-card border border-border bg-surface p-6 text-left shadow-[0_1px_3px_rgba(17,17,17,.08),0_24px_60px_-20px_rgba(17,17,17,.28)]">
+          <button
+            type="button"
+            onClick={close}
+            aria-label="Close"
+            className="absolute right-3.5 top-3.5 flex h-8 w-8 items-center justify-center rounded-lg text-muted transition-[color,background-color,transform] duration-150 hover:bg-hover hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink/15 active:scale-95"
+          >
+            <X className="h-4 w-4" strokeWidth={2} />
+          </button>
+
+          <span className="flex h-10 w-10 items-center justify-center rounded-[12px] bg-ink text-white">
+            <MapleMark className="h-[18px] w-[18px]" />
+          </span>
+          <h2 id="text-channel-title" className="mt-4 text-lg font-semibold tracking-tight text-ink">
+            Maple, in your Messages
+          </h2>
+          <p className="mt-1.5 text-sm leading-relaxed text-ink-soft">
+            Ask Maple anything by text — it answers as you, exactly as it does here.
+          </p>
+
+          {unavailable ? (
+            <p className="mt-5 rounded-xl bg-hover px-4 py-3 text-xs leading-relaxed text-muted">
+              Texting isn&rsquo;t switched on for this deployment yet, so there&rsquo;s no number to
+              hand you.
+            </p>
+          ) : (
+            <>
+              <a
+                href={url ?? undefined}
+                aria-disabled={url === null}
+                className="mt-5 inline-flex h-10 w-full items-center justify-center gap-2 rounded-xl border border-ink bg-ink text-sm font-medium text-white transition-[background-color,transform] duration-150 hover:bg-ink/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink/15 focus-visible:ring-offset-1 active:scale-[0.985] aria-disabled:pointer-events-none aria-disabled:opacity-50"
+              >
+                Open Messages
+                <ArrowUpRight className="h-4 w-4" strokeWidth={2} />
+              </a>
+
+              <div className="my-5 flex items-center gap-3">
+                <span className="h-px flex-1 bg-border" />
+                <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted">
+                  or scan from your phone
+                </span>
+                <span className="h-px flex-1 bg-border" />
+              </div>
+
+              <div className="flex justify-center">
+                <div className="rounded-xl border border-border bg-white p-3 shadow-[0_1px_2px_rgba(17,17,17,.05)]">
+                  <div className="h-[152px] w-[152px]">
+                    {url === null ? (
+                      <Skeleton className="h-full w-full" />
+                    ) : (
+                      // Fades in when the code lands, so the plate settles
+                      // instead of the QR popping into the skeleton's hole.
+                      <QrCode value={url} className="block h-full w-full animate-fade-in" />
+                    )}
+                  </div>
+                </div>
+              </div>
+            </>
+          )}
+
+          <p className="mt-5 text-xs leading-relaxed text-muted">
+            One text links your phone — send it as it is; the code is already inside and lasts 30
+            minutes. A contact card called Maple comes back: text that from then on.
+          </p>
+        </div>
+      </dialog>
+    </Card>
+  )
+}

--- a/examples/demo-bank/src/components/settings/text-channel-card.tsx
+++ b/examples/demo-bank/src/components/settings/text-channel-card.tsx
@@ -66,12 +66,16 @@ export function TextChannelCard() {
   // replaces the user's outstanding code.
   const [requested, setRequested] = React.useState(false)
   const [closing, setClosing] = React.useState(false)
-  const { data } = useTextLink(requested)
+  const { data, error, isLoading, mutate } = useTextLink(requested)
 
   const url = data?.url ?? null
   // Only an ANSWERED request can say "no channel here" — until then the plate
   // waits, so opening the modal never flashes an apology it is about to retract.
   const unavailable = data !== undefined && data.url === null
+  // An outage is NOT the same answer as "no channel here": the first is passing
+  // and worth another try, the second is permanent. Without this the dialog sits
+  // on its skeleton for good, because nothing revalidates a failed request.
+  const failed = error !== undefined && data === undefined
 
   const open = (): void => {
     setRequested(true)
@@ -166,7 +170,21 @@ export function TextChannelCard() {
             Ask Maple anything by text — it answers as you, exactly as it does here.
           </p>
 
-          {unavailable ? (
+          {failed ? (
+            <div className="mt-5 rounded-xl bg-hover px-4 py-3">
+              <p className="text-xs leading-relaxed text-muted">
+                Couldn&rsquo;t reach Maple&rsquo;s texting service just now.
+              </p>
+              <button
+                type="button"
+                onClick={() => void mutate()}
+                disabled={isLoading}
+                className="mt-2.5 inline-flex h-8 items-center justify-center rounded-lg border border-border bg-surface px-3 text-xs font-medium text-ink transition-[background-color,transform] duration-150 hover:bg-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink/15 active:scale-95 disabled:opacity-60"
+              >
+                {isLoading ? "Trying…" : "Try again"}
+              </button>
+            </div>
+          ) : unavailable ? (
             <p className="mt-5 rounded-xl bg-hover px-4 py-3 text-xs leading-relaxed text-muted">
               Texting isn&rsquo;t switched on for this deployment yet, so there&rsquo;s no number to
               hand you.
@@ -206,10 +224,12 @@ export function TextChannelCard() {
             </>
           )}
 
+          {failed ? null : (
           <p className="mt-5 text-xs leading-relaxed text-muted">
             One text links your phone — send it as it is; the code is already inside and lasts 30
             minutes. A contact card called Maple comes back: text that from then on.
           </p>
+          )}
         </div>
       </dialog>
     </Card>

--- a/examples/demo-bank/src/lib/hooks.ts
+++ b/examples/demo-bank/src/lib/hooks.ts
@@ -33,7 +33,13 @@ export const useNotifications = () => useSWR<Notification[]>("/api/notifications
  *  looking at (or already scanned). */
 export const useTextLink = (enabled: boolean) =>
   useSWR<{ url: string | null }>(enabled ? "/api/vendo/text-link" : null, f, {
+    // Deliberately quiet: every mint replaces the user's outstanding code, so a
+    // focus or reconnect must not silently invalidate the code on their phone.
     revalidateOnFocus: false,
     revalidateOnReconnect: false,
     revalidateIfStale: false,
+    // A failure, though, has nothing to protect — and left alone it would strand
+    // the dialog on its loading state for good. `mutate()` from the retry button
+    // is the only thing that asks again.
+    shouldRetryOnError: false,
   })

--- a/examples/demo-bank/src/lib/hooks.ts
+++ b/examples/demo-bank/src/lib/hooks.ts
@@ -23,3 +23,17 @@ export const usePayees = () => useSWR<Payee[]>("/api/payees", f)
 export const useScheduled = () => useSWR<ScheduledPayment[]>("/api/payments/scheduled", f)
 export const useGoals = () => useSWR<Goal[]>("/api/goals", f)
 export const useNotifications = () => useSWR<Notification[]>("/api/notifications", f)
+
+/** The text-channel invite for the signed-in user — `url` is the prefilled
+ *  `sms:` link, or null when this deployment has no text channel.
+ *
+ *  Minted LAZILY and exactly once: the key is null until `enabled` (the modal
+ *  opening), and every revalidation trigger is off, because each mint replaces
+ *  the user's outstanding code — a refetch would strand the code they are
+ *  looking at (or already scanned). */
+export const useTextLink = (enabled: boolean) =>
+  useSWR<{ url: string | null }>(enabled ? "/api/vendo/text-link" : null, f, {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+    revalidateIfStale: false,
+  })

--- a/examples/demo-bank/src/server/http.ts
+++ b/examples/demo-bank/src/server/http.ts
@@ -7,3 +7,8 @@ export function notFound(message = "Not found") {
 export function badRequest(message: string) {
   return NextResponse.json({ error: { message, code: "bad_request" } }, { status: 400 })
 }
+/** Our fault, not the caller's: a transient failure the UI may retry. Distinct
+    from a 200 carrying an empty answer, which reads as "this is switched off". */
+export function serverError(message: string) {
+  return NextResponse.json({ error: { message, code: "server_error" } }, { status: 503 })
+}

--- a/examples/demo-bank/src/vendo/server.ts
+++ b/examples/demo-bank/src/vendo/server.ts
@@ -154,9 +154,10 @@ export const vendo = createVendo({
   }),
   mcp: mapleMcpConfig(),
   // Maple's customers can text the assistant: they link their phone from the
-  // anchor on /settings, and every text after that runs as them. Vendo Cloud
-  // carries the numbers, so this needs VENDO_API_KEY; the phone ↔ customer
-  // binding stays in Maple's own store.
+  // "Text with Maple" card on /settings (components/settings/text-channel-card.tsx
+  // — a QR and a prefilled first text), and every text after that runs as them.
+  // Vendo Cloud carries the numbers, so this needs VENDO_API_KEY; the phone ↔
+  // customer binding stays in Maple's own store.
   channels: { text: true },
   // BYO Composio when Maple brings its own key; otherwise the slot stays
   // UNSET so a VENDO_API_KEY deployment composes the Cloud tools connector

--- a/examples/demo-bank/tests/app/api/vendo/text-link/route.test.ts
+++ b/examples/demo-bank/tests/app/api/vendo/text-link/route.test.ts
@@ -44,6 +44,14 @@ describe("GET /api/vendo/text-link", () => {
 })
 
 describe("a broken channel is not a channel that is switched off", () => {
+  /** The route answers "no channel here" from the CONFIGURATION, so reaching the
+   *  mint at all takes a configured-looking deployment. */
+  const configured = <T,>(run: () => Promise<T>): Promise<T> => {
+    vi.stubEnv("VENDO_API_KEY", "vk_live_test")
+    vi.stubEnv("VENDO_BASE_URL", "https://maple.test")
+    return run().finally(() => vi.unstubAllEnvs())
+  }
+
   it("answers 503 when minting fails for an operational reason", async () => {
     // A console outage, a store blip, a vendor timeout. Distinct from the
     // configuration cases above, which really do mean "no texting here".
@@ -51,7 +59,7 @@ describe("a broken channel is not a channel that is switched off", () => {
       new VendoError("unavailable", "Vendo Cloud channels is unavailable"),
     )
     try {
-      const response = await linkFor("vendo-demo")
+      const response = await configured(() => linkFor("vendo-demo"))
 
       expect(response.status).toBe(503)
       const body = await response.json() as { error?: { code?: string } }
@@ -61,19 +69,17 @@ describe("a broken channel is not a channel that is switched off", () => {
     }
   })
 
-  it("still answers url: null when the deployment simply has no Cloud key", async () => {
-    // The `not-implemented` half of the configuration case, pinned explicitly so
-    // the two never collapse back into one catch.
-    const minting = vi.spyOn(vendo.channels.text, "link").mockRejectedValue(
-      new VendoError("not-implemented", "the text channel needs VENDO_API_KEY"),
-    )
-    try {
-      const response = await linkFor("vendo-demo")
+  it("never even asks when the deployment is not configured for texting", async () => {
+    // The permanent answer comes from configuration, not from an error shape —
+    // `validation` covers both "no VENDO_BASE_URL" (a setting) and "Cloud
+    // returned no identity" (an outage), so no code-based rule separates them.
+    const minting = vi.spyOn(vendo.channels.text, "link")
 
-      expect(response.status).toBe(200)
-      await expect(response.json()).resolves.toEqual({ data: { url: null } })
-    } finally {
-      minting.mockRestore()
-    }
+    const response = await linkFor("vendo-demo")
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ data: { url: null } })
+    expect(minting, "no key, no call").not.toHaveBeenCalled()
+    minting.mockRestore()
   })
 })

--- a/examples/demo-bank/tests/app/api/vendo/text-link/route.test.ts
+++ b/examples/demo-bank/tests/app/api/vendo/text-link/route.test.ts
@@ -69,6 +69,26 @@ describe("a broken channel is not a channel that is switched off", () => {
     }
   })
 
+  it("treats the local-dev loopback URL as no channel, not as a retriable fault", async () => {
+    // instrumentation.ts fills an unset VENDO_BASE_URL with
+    // http://localhost:<port>/maple, so the var is never empty at runtime. Cloud
+    // cannot deliver an inbound text to a laptop, so this is permanent — offering
+    // a "try again" for it would be offering a retry that can never succeed.
+    const minting = vi.spyOn(vendo.channels.text, "link")
+    vi.stubEnv("VENDO_API_KEY", "vk_live_test")
+    vi.stubEnv("VENDO_BASE_URL", "http://localhost:3000/maple")
+    try {
+      const response = await linkFor("vendo-demo")
+
+      expect(response.status).toBe(200)
+      await expect(response.json()).resolves.toEqual({ data: { url: null } })
+      expect(minting, "nowhere to deliver, so nothing to mint").not.toHaveBeenCalled()
+    } finally {
+      vi.unstubAllEnvs()
+      minting.mockRestore()
+    }
+  })
+
   it("never even asks when the deployment is not configured for texting", async () => {
     // The permanent answer comes from configuration, not from an error shape —
     // `validation` covers both "no VENDO_BASE_URL" (a setting) and "Cloud

--- a/examples/demo-bank/tests/app/api/vendo/text-link/route.test.ts
+++ b/examples/demo-bank/tests/app/api/vendo/text-link/route.test.ts
@@ -1,0 +1,37 @@
+import { encode } from "next-auth/jwt"
+import { describe, expect, it } from "vitest"
+import { GET } from "../../../../../src/app/api/vendo/text-link/route"
+
+/**
+ * The route behind the "Text with Maple" modal.
+ *
+ * This suite runs with no VENDO_API_KEY, which is exactly the posture the route
+ * has to survive: `channels: { text: true }` with no Cloud key composes the
+ * unconfigured channel (selectChannels), so minting an invite refuses. The modal
+ * reads that as `url: null` and says so; a 500 here would put a broken dialog on
+ * the settings page of every keyless checkout of this demo.
+ */
+
+const COOKIE = "authjs.session-token"
+const DEV_SECRET = "maple-local-development-auth-secret"
+
+const linkFor = async (sub: string): Promise<Response> => {
+  const token = await encode({ token: { sub }, secret: DEV_SECRET, salt: COOKIE, maxAge: 300 })
+  return GET(new Request("http://localhost:3000/api/vendo/text-link", {
+    headers: { cookie: `${COOKIE}=${token}` },
+  }))
+}
+
+describe("GET /api/vendo/text-link", () => {
+  it("answers url: null — not a 500 — when the deployment has no text channel", async () => {
+    const response = await linkFor("vendo-demo")
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ data: { url: null } })
+  })
+
+  it("answers a signed-out visitor the same way, since Maple resolves them to its guest", async () => {
+    const response = await GET(new Request("http://localhost:3000/api/vendo/text-link"))
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ data: { url: null } })
+  })
+})

--- a/examples/demo-bank/tests/app/api/vendo/text-link/route.test.ts
+++ b/examples/demo-bank/tests/app/api/vendo/text-link/route.test.ts
@@ -1,6 +1,8 @@
+import { VendoError } from "@vendoai/core"
 import { encode } from "next-auth/jwt"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { GET } from "../../../../../src/app/api/vendo/text-link/route"
+import { vendo } from "../../../../../src/vendo/server"
 
 /**
  * The route behind the "Text with Maple" modal.
@@ -10,6 +12,11 @@ import { GET } from "../../../../../src/app/api/vendo/text-link/route"
  * unconfigured channel (selectChannels), so minting an invite refuses. The modal
  * reads that as `url: null` and says so; a 500 here would put a broken dialog on
  * the settings page of every keyless checkout of this demo.
+ *
+ * The other half matters just as much: `url: null` means "not available on this
+ * deployment", and the modal does not revalidate — so answering it for a passing
+ * OUTAGE would tell a customer their text channel is switched off and keep saying
+ * it after the outage cleared.
  */
 
 const COOKIE = "authjs.session-token"
@@ -33,5 +40,40 @@ describe("GET /api/vendo/text-link", () => {
     const response = await GET(new Request("http://localhost:3000/api/vendo/text-link"))
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual({ data: { url: null } })
+  })
+})
+
+describe("a broken channel is not a channel that is switched off", () => {
+  it("answers 503 when minting fails for an operational reason", async () => {
+    // A console outage, a store blip, a vendor timeout. Distinct from the
+    // configuration cases above, which really do mean "no texting here".
+    const minting = vi.spyOn(vendo.channels.text, "link").mockRejectedValue(
+      new VendoError("unavailable", "Vendo Cloud channels is unavailable"),
+    )
+    try {
+      const response = await linkFor("vendo-demo")
+
+      expect(response.status).toBe(503)
+      const body = await response.json() as { error?: { code?: string } }
+      expect(body.error?.code).toBe("server_error")
+    } finally {
+      minting.mockRestore()
+    }
+  })
+
+  it("still answers url: null when the deployment simply has no Cloud key", async () => {
+    // The `not-implemented` half of the configuration case, pinned explicitly so
+    // the two never collapse back into one catch.
+    const minting = vi.spyOn(vendo.channels.text, "link").mockRejectedValue(
+      new VendoError("not-implemented", "the text channel needs VENDO_API_KEY"),
+    )
+    try {
+      const response = await linkFor("vendo-demo")
+
+      expect(response.status).toBe(200)
+      await expect(response.json()).resolves.toEqual({ data: { url: null } })
+    } finally {
+      minting.mockRestore()
+    }
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,6 +298,9 @@ importers:
       next-auth:
         specifier: '>=5.0.0-beta.32'
         version: 5.0.0-beta.32(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@20.19.43)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      qrcode-generator:
+        specifier: ^2.0.4
+        version: 2.0.4
       react:
         specifier: 19.2.4
         version: 19.2.4


### PR DESCRIPTION
Maple's text-channel opt-in was one bare underlined anchor under the Settings
header — "Text Maple from your phone" — that navigated a desktop visitor away
from the app into the door's own unstyled fallback page. It is now a designed
card on the settings page and a modal in Maple's chrome.

## What's here

- **A "Text channel" card** (`components/settings/text-channel-card.tsx`), second
  on the page under Profile, with the same anatomy as its neighbours (eyebrow
  title, ink tile, label + description) plus a `New` badge, a soft top-to-bottom
  wash, and a primary CTA. On a narrow screen the CTA drops under the copy
  instead of squeezing the description into a ribbon.
- **A modal** — a native `<dialog>`, so Esc, focus containment and the top layer
  come from the platform rather than a new dependency. It carries the Maple
  headline, one line on what texting Maple gets you, a primary **Open Messages**
  button, and the same link as a **QR** for desktop visitors, with the linking
  facts (one text, contact card called Maple, 30-minute code) as fine print.
- **Motion**: entrance is a 260ms `cubic-bezier(0.16, 1, 0.3, 1)` rise from
  `translateY(10px) scale(0.97)` with a 180ms backdrop fade, driven by
  `@starting-style` in `globals.css`; exit is quicker (160ms) and drives
  `dialog.close()` after it, because `close()` drops the element out of the top
  layer at once and would otherwise cut the animation at its first frame. Press
  and hover states on every control; `prefers-reduced-motion` keeps the fade and
  drops the movement.
- **The invite is minted lazily**, when the modal opens — `useTextLink(enabled)`
  keys SWR on that and turns every revalidation trigger off. Each mint replaces
  the user's outstanding code (`ChannelLinkRepository.mint`), so minting on page
  load would strand the code of anyone mid-link, and a re-open must answer from
  cache rather than mint again.
- **The CTA carries the minted `sms:` URL** rather than re-entering
  `/api/vendo/channels/text/link`, for the same reason: that route mints, so
  clicking it would silently invalidate the QR sitting right below it. The route
  is untouched and still serves phones a 302 straight into Messages.
- **No text channel, no promises**: `GET /api/vendo/text-link` answers
  `{ url: null }` when the channel is unconfigured (no Cloud key), and the modal
  says so instead of handing out a link that cannot work. That path is the new
  test.
- The route sits **under `/api/vendo`**, beside the door's catch-all (Next prefers
  the static segment). Two reasons, both load-bearing: that prefix is where the
  extractor stops looking, so the endpoint stays Maple's own UI surface instead of
  becoming a `host_text_link_list` agent tool that would need a grade in
  `.vendo/judgments.json`; and it is one of `proxy.ts`'s public prefixes, so the
  demo's signed-out visitor reaches it exactly as they reach the anchor route
  today.

## Scope

`examples/demo-bank` only, plus `qrcode-generator` (~10 kB, no deps, already in
the tree — `packages/vendo` uses it for the door's own fallback QR) added to
demo-bank's dependencies and one importer entry in `pnpm-lock.yaml`.

## Verification

Real headed Chromium against a local demo-bank, with a **fake console** standing
in for Vendo Cloud's `/api/v1/channels/text/register` (the pattern in
`packages/vendo/tests/channel-wire.e2e.test.ts`) so nothing touched the
production channel registration. Screenshots taken at 1440×940 and at a 430px
viewport, before and after:

`before-settings-desktop.png`, `before-link-page-desktop.png`,
`before-settings-narrow.png`, `after-settings-desktop.png`,
`after-card-desktop.png`, `after-modal-desktop.png`,
`after-settings-narrow.png`, `after-modal-narrow.png`.

Also verified in the browser: Esc, the close button and a backdrop click all
dismiss through the same animated path; re-opening does not re-mint (same `sms:`
URL); focus lands in the dialog on open and returns to the card's button on
close; the panel's enter/exit interpolation sampled frame by frame
(`opacity 0 → 1`, `scale 0.97 → 1`); `prefers-reduced-motion` renders with no
transform.

Gates on the touched scope: `pnpm --filter demo-bank test`, `lint`, `tsc
--noEmit`, and `pnpm build`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the settings-page anchor with a “Text channel” card and modal so desktop users stay in‑app; phones still 302 into Messages. The API now returns `url: null` only for unconfigured deployments (including loopback or invalid `VENDO_BASE_URL`) and uses 503 for outages, which the UI can retry.

- Adds a “Text channel” card and native `<dialog>` with QR; transitions handle open/close and respect reduced motion.
- Mints the invite lazily on modal open; `useTextLink(enabled)` fetches once with no revalidation, provides a retry that calls `mutate()`, and the CTA uses the minted `sms:` URL.
- Introduces `/api/vendo/text-link` under `/api/vendo` that answers `{ url }` or `{ url: null }` only when `VENDO_API_KEY` is missing or `VENDO_BASE_URL` is not publicly deliverable; operational failures return 503 `server_error`.
- Leaves `/api/vendo/channels/text/link` unchanged for phones.
- Renders the QR with `qrcode-generator`; tests cover unconfigured deployments, signed‑out access, 503 on outages, loopback URL treated as no channel, and “no key, no call.”

<sup>Written for commit d3846a0767ecadc1fe72880a09313218ef302bed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

