### PR TITLE
feat(apps): the catalog's props carry their types, and every brick a worked example

### DIFF
--- a/.changeset/a-catalog-prop-says-what-it-takes.md
+++ b/.changeset/a-catalog-prop-says-what-it-takes.md
@@ -1,0 +1,9 @@
+---
+"@vendoai/apps": patch
+---
+
+Every prop in the generated component catalog now says what it TAKES, and every brick carries one worked example. A line used to give prop NAMES only — `<DateTime> … · data: value · config: mode compact` — which tells a model nothing about whether `mode` wants a word from a closed list, a number or a function, and a prop written in the wrong shape is silently dropped at validation. Each prop is now `name: type`, with the type walked off its own zod schema: enums enumerated (`mode: "date"|"time"|"datetime"|"relative"`), primitives plain (`gap: number`), object shapes as their field names (`columns: {key?, label?, format?, align?, cell?}[]`), a handler as `fn`, a slot as `element`. The prop classes (`data` / `config` / `copy`) stay in front, because law 1 rides on them. Nothing is hand-written, so a schema that changes changes the prompt in the same commit.
+
+Under each line sits that component's first worked example, taken from the same place `kitPrompt` takes it, so the two prompts can never show a model different idioms. Seven examples still wrote the retired attribute dialect — `onClose="ui.cancel"`, `$state.confirming`, an inline tool call for data, and a `<KeyValue pairs=…>` naming a prop that does not exist — and are corrected to the shape a screen actually compiles: state and setters for the overlays, `useQuery` results for the data.
+
+The catalog costs 29,081 characters, up from 20,396; it still costs less than the 36,158 that a section per brick costs for the same bricks with no icon names at all.

--- a/packages/apps/src/contract/kit/catalog-prompt.ts
+++ b/packages/apps/src/contract/kit/catalog-prompt.ts
@@ -1,22 +1,34 @@
 /**
- * catalogPrompt() — the WHOLE catalog as one line per component.
+ * catalogPrompt() — the WHOLE catalog as one line per component, plus that
+ * component's one worked example under it.
  *
  * `kitPrompt` spends a section on every brick (props with docs, slots with docs,
- * a worked example) and costs ~550 characters each. That is affordable at 39
+ * a worked example) and costs ~680 characters each. That is affordable at 39
  * bricks and not at 55, and it teaches the Kit and the host's own components in
- * two different places and two different shapes. This renders both as ONE list,
- * one line apiece: what the component is, its props by class, its slots — and
- * the icon vocabulary once at the end, which no prompt has ever carried, so the
- * model stops inventing glyph names.
+ * two different places and two different shapes. This renders both as ONE list:
+ * what the component is, its props by class WITH THEIR TYPES, its slots, one
+ * example — and the icon vocabulary once at the end, which no prompt has ever
+ * carried, so the model stops inventing glyph names.
  *
- * The compression is the examples and the per-prop docs. Prop NAMES, classes,
- * required markers and slot docs stay: a name the model spells wrong is a
- * dropped prop, and a slot is unguessable from a prop list. The preamble is
- * `kitPrompt`'s, unchanged — the two laws do not depend on the layout.
+ * The compression is the per-prop docs and the second example. What a prop takes
+ * is not compressible: a name alone says nothing about whether `mode` wants a
+ * word from a closed list, a number or a function, and the model that guesses
+ * wrong writes a prop the validator drops. So every prop carries a COMPACT type
+ * walked off its own zod schema ({@link typeText}), and the one example shows
+ * the shape filled in. Both are derived, so neither can drift from the specs.
+ *
+ * The preamble is `kitPrompt`'s, unchanged — the two laws do not depend on the
+ * layout.
  */
+import { z, type ZodTypeAny } from "zod";
 import { KIT_ICON_NAMES } from "./icon-names.gen.js";
-import { PREAMBLE } from "./kit-prompt.js";
-import { KIT_PREAMBLE_PROP_NAMES, KIT_SPECS } from "./specs.js";
+import { PREAMBLE, promptExamples } from "./kit-prompt.js";
+import {
+  ACTION_PROP_DESCRIPTION,
+  KIT_PREAMBLE_PROP_NAMES,
+  KIT_SPECS,
+  SLOT_PROP_DESCRIPTION,
+} from "./specs.js";
 import type { KitComponentSpec, PropClass } from "./schema.js";
 import type { CatalogSummaryEntry } from "../briefing.js";
 
@@ -33,12 +45,65 @@ export interface CatalogPromptOptions {
 const LEGEND = [
   "",
   "One line per component: `<Name>` what it is, then its props grouped by class,",
-  "then its slots. `!` marks a required prop. A line marked `[host]` is one of",
-  "THIS host's own components — write it like any other, props as it describes.",
+  "then its slots, then ONE worked example indented under it. A prop reads",
+  "`name: type` and `!` marks a required one; `fn` is a function you write and",
+  "`element` is Kit elements. A line marked `[host]` is one of THIS host's own",
+  "components — write it like any other, props as it describes.",
 ].join("\n");
 
 /** data first: law 1 is the one a line must not bury. */
 const CLASS_ORDER: readonly PropClass[] = ["data", "config", "copy"];
+
+/** Which zod construct this is — the one cast the walker below needs. */
+const kind = (schema: ZodTypeAny): string | undefined =>
+  (schema as unknown as { _def: { typeName?: string } })._def.typeName;
+
+/**
+ * A prop's type, COMPACT, walked off its own zod schema — nothing here is
+ * hand-written, so a schema that changes changes the prompt in the same commit.
+ * The Kit's zod vocabulary is closed (it is our own schema file), so a direct
+ * walker beats a converter dependency, exactly as in `checking/screen-typings.ts`.
+ *
+ * Compact is the whole point: this text rides EVERY generation, so an object
+ * gives its field NAMES (`{key, label?, format?}`) rather than their types, and
+ * the worked example under the line shows what actually goes in them. The two
+ * schemas that are not what they parse as are named by their description — an
+ * `on*` prop is a function the screen writes, a slot holds elements — and
+ * anything outside the vocabulary degrades to `any` rather than to a lie.
+ */
+const typeText = (schema: ZodTypeAny): string => {
+  const def = (schema as unknown as { _def: { typeName?: string } })._def;
+  switch (def.typeName) {
+    case z.ZodFirstPartyTypeKind.ZodString:
+      return schema.description === ACTION_PROP_DESCRIPTION ? "fn" : "string";
+    case z.ZodFirstPartyTypeKind.ZodNumber: return "number";
+    case z.ZodFirstPartyTypeKind.ZodBoolean: return "boolean";
+    case z.ZodFirstPartyTypeKind.ZodUnknown:
+    case z.ZodFirstPartyTypeKind.ZodAny:
+      return schema.description === SLOT_PROP_DESCRIPTION ? "element" : "any";
+    case z.ZodFirstPartyTypeKind.ZodEnum:
+      return (def as { values: readonly string[] }).values.map((value) => JSON.stringify(value)).join("|");
+    case z.ZodFirstPartyTypeKind.ZodUnion:
+      return (def as { options: readonly ZodTypeAny[] }).options.map((option) => typeText(option)).join("|");
+    case z.ZodFirstPartyTypeKind.ZodArray: {
+      const item = typeText((def as { type: ZodTypeAny }).type);
+      return item.includes("|") ? `(${item})[]` : `${item}[]`;
+    }
+    case z.ZodFirstPartyTypeKind.ZodRecord:
+      return `{[key]: ${typeText((def as { valueType: ZodTypeAny }).valueType)}}`;
+    case z.ZodFirstPartyTypeKind.ZodObject: {
+      const shape = (schema as unknown as { shape: Record<string, ZodTypeAny> }).shape;
+      const fields = Object.entries(shape).map(([name, field]) =>
+        `${name}${kind(field) === z.ZodFirstPartyTypeKind.ZodOptional ? "?" : ""}`);
+      return `{${fields.join(", ")}}`;
+    }
+    case z.ZodFirstPartyTypeKind.ZodNullable:
+      return `${typeText((def as { innerType: ZodTypeAny }).innerType)}|null`;
+    case z.ZodFirstPartyTypeKind.ZodOptional:
+      return typeText((def as { innerType: ZodTypeAny }).innerType);
+    default: return "any";
+  }
+};
 
 function catalogLine(spec: KitComponentSpec): string {
   const parts = [`<${spec.name}> ${spec.summary}`];
@@ -46,10 +111,10 @@ function catalogLine(spec: KitComponentSpec): string {
     // The shared adjectives ride every component that reads one and `style` rides
     // all of them; the preamble teaches both, and 39 restatements would undo the
     // compression.
-    const names = Object.entries(spec.props)
+    const props = Object.entries(spec.props)
       .filter(([name, prop]) => prop.cls === cls && !KIT_PREAMBLE_PROP_NAMES.includes(name))
-      .map(([name, prop]) => (prop.required === true ? `${name}!` : name));
-    if (names.length > 0) parts.push(`${cls}: ${names.join(" ")}`);
+      .map(([name, prop]) => `${name}${prop.required === true ? "!" : ""}: ${typeText(prop.schema)}`);
+    if (props.length > 0) parts.push(`${cls}: ${props.join(", ")}`);
   }
   // The engine's NAME, which the preamble cannot supply: it can say that some
   // components pass props through, not whose vocabulary each one speaks.
@@ -57,7 +122,13 @@ function catalogLine(spec: KitComponentSpec): string {
   for (const [name, slot] of Object.entries(spec.slots ?? {})) {
     parts.push(`slot ${name}${slot.perRow === true ? " (per row)" : ""}: ${slot.doc}`);
   }
-  return parts.join(" · ");
+  // ONE example, indented under the line. A prop list says what MAY be written
+  // and never what a filled-in component looks like; the second example a spec
+  // carries mostly repeats the first's lesson, and this text rides every
+  // generation, so the catalog buys one apiece and no more.
+  const example = promptExamples(spec)[0];
+  const line = parts.join(" · ");
+  return example === undefined ? line : `${line}\n  ${example}`;
 }
 
 const hostLine = (entry: CatalogSummaryEntry): string => `<${entry.name}> [host] ${entry.description}`;

--- a/packages/apps/src/contract/kit/kit-prompt.ts
+++ b/packages/apps/src/contract/kit/kit-prompt.ts
@@ -105,6 +105,9 @@ const PROMPT_EXAMPLES: Readonly<Record<string, readonly string[]>> = {
   CardList: ['<CardList items={clients.data} titleField="name" badgeField="status" fields={[{key:"balance",label:"Balance",format:"money"},{key:"plan",cell:<EnumBadge field="plan"/>}]}/>'],
   LineChart: ['<LineChart data={revenue.data} xKey="month" series={["amount"]} format="money"/>'],
   DonutChart: ['<DonutChart data={spend.data} categoryKey="category" valueKey="amount" format="money"/>'],
+  KeyValue: ['<KeyValue record={invoice.data} items={[{key:"client.name",label:"Client"},{key:"amount",format:"money"},{key:"status",cell:<EnumBadge field="status"/>}]} dividers/>'],
+  Timeline: ['<Timeline entries={payments.data} titleField="description" timeField="paidAt" timeAlign="end"/>'],
+  CodeBlock: ['<CodeBlock language="json" code={webhook.data.payload}/>'],
   // Handlers are functions; every field is controlled.
   Button: ["<Button label=\"Cancel transfer\" variant=\"danger\" onClick={() => tools.cancel_transfer({ id: transfer.id })}/>"],
   Input: ['<Input label="Recipient" value={name} onChange={(e) => setName(e.target.value)}/>'],
@@ -115,11 +118,24 @@ const PROMPT_EXAMPLES: Readonly<Record<string, readonly string[]>> = {
   // fails the checks — so this one shows the handler only.
   Select: ['<Select label="Client" options={clients.data} labelField="name" valueField="id" onChange={(e) => setClientId(e.target.value)}/>'],
   Form: ['<Form onSubmit={() => tools.create_client({ name })} submitLabel="Add client"><Input .../></Form>'],
+  EmptyState: ['<EmptyState icon="inbox" title="No invoices yet" description="They show up here the moment one is issued."><Button label="New invoice" onClick={() => tools.create_invoice({})}/></EmptyState>'],
+  // The overlays: `open` is state the screen holds, and `onClose` is the setter
+  // that takes it down — the pair a quoted tool name could never express. The
+  // Modal puts its action LAST in `footer`, which is where the chapter sends it.
+  Modal: ['<Modal open={confirming} onClose={() => setConfirming(false)} title="Send reminders?" description="Three clients will be emailed." footer={<Button label="Send" onClick={() => tools.send_reminders({})}/>}/>'],
+  Sheet: ['<Sheet open={viewing} onClose={() => setViewing(false)} title="Invoice INV-204" side="right"><KeyValue record={invoice.data} items={[{key:"client.name",label:"Client"},{key:"amount",format:"money"}]}/></Sheet>'],
+  Toast: ['<Toast open={sent} onClose={() => setSent(false)} message="Reminders sent." tone="success"/>'],
   // Containers: the child shape is the teaching, not the child's own props.
   Card: ['<Card title="Overdue" description="Worst first"><DataTable .../></Card>'],
   Grid: ["<Grid minChildWidth={160}><Stat .../><Stat .../><Stat .../><Stat .../></Grid>"],
   Tabs: ['<Tabs tabs={["Overview","Detail"]}><Stat .../><DataTable .../></Tabs>'],
 };
+
+/** What the model is SHOWN for a component: the corrected example where one
+ *  exists, the spec's own otherwise. Both prompts read this, so neither can show
+ *  an idiom the other has retired. */
+export const promptExamples = (spec: KitComponentSpec): readonly string[] =>
+  PROMPT_EXAMPLES[spec.name] ?? spec.examples;
 
 function classTag(cls: PropClass): string {
   return cls;
@@ -158,7 +174,7 @@ function renderSpec(spec: KitComponentSpec): string {
     }
     lines.push("");
   }
-  const examples = PROMPT_EXAMPLES[spec.name] ?? spec.examples;
+  const examples = promptExamples(spec);
   lines.push(examples.length > 1 ? "Examples:" : "Example:");
   for (const ex of examples) lines.push("  " + ex);
   return lines.join("\n");

--- a/packages/apps/src/contract/kit/specs.ts
+++ b/packages/apps/src/contract/kit/specs.ts
@@ -27,6 +27,13 @@ const seriesInput = z.array(z.union([
   z.object({ key: z.string(), label: z.string().optional(), color: z.string().optional() }).passthrough(),
 ]));
 
+/** The two DESCRIPTIONS that mark a schema as something other than what it
+ *  parses as. Exported because every reader of a Kit schema — the screen
+ *  typings, the catalog's type printer — has to recognise the same two strings,
+ *  and a second copy of one is a marker that stops matching. */
+export const SLOT_PROP_DESCRIPTION = "holds Kit elements";
+export const ACTION_PROP_DESCRIPTION = "names a host tool";
+
 /**
  * A CELL SLOT — Kit value components composed for one record.
  *
@@ -45,9 +52,9 @@ const seriesInput = z.array(z.union([
  * The DESCRIPTION is the marker a slot is known by: `z.unknown()` prints as
  * `any` and `any` admitted exactly that function, so the component screen's
  * typings print a described slot as an element type instead and the compiler
- * refuses the closure (`checking/screen-typings.ts` `SLOT_PROP_DESCRIPTION`).
+ * refuses the closure ({@link SLOT_PROP_DESCRIPTION}).
  */
-const slot = z.unknown().describe("holds Kit elements");
+const slot = z.unknown().describe(SLOT_PROP_DESCRIPTION);
 const tableColumn = z.object({
   /** Optional, because an ACTION column has no field: giving it a fake key
    *  makes its header click-to-sort and its values globally searchable, on data
@@ -64,7 +71,7 @@ const cardField = z.object({
   format: valueFormat.optional(),
   cell: slot.optional(),
 });
-const action = z.string().describe("names a host tool");
+const action = z.string().describe(ACTION_PROP_DESCRIPTION);
 /** The one tone vocabulary. The two older spellings still parse, because stored
  *  apps carry them; only the five are taught. */
 const tone = z.enum(["neutral", "accent", "success", "warning", "danger"]).or(z.enum(["default", "info"]));

--- a/packages/apps/src/server/checking/screen-typings.ts
+++ b/packages/apps/src/server/checking/screen-typings.ts
@@ -27,9 +27,11 @@ import {
   type JsonSchema,
 } from "@vendoai/core";
 import {
+  ACTION_PROP_DESCRIPTION,
   DISPLAY_TAG_NAMES,
   KIT_COMPONENT_NAMES,
   KIT_SCREEN_COMPONENT_NAMES,
+  SLOT_PROP_DESCRIPTION,
   kitSpec,
   type KitComponentSpec,
   type NormalizedCatalog,
@@ -77,11 +79,6 @@ export interface ScreenTypingsInput {
 export const SCREEN_TYPINGS_FILE = "/vendo-screen-typings.d.ts";
 
 // ---- zod → TS type text ---------------------------------------------------
-
-/** A Kit prop whose zod schema is a SLOT — `z.unknown().describe(…)` in
- *  kit/specs.ts. The description is the marker, because `z.unknown()` anywhere
- *  else (a row's field values) must keep printing as `any`. */
-const SLOT_PROP_DESCRIPTION = "holds Kit elements";
 
 /**
  * What a slot may hold — an element tree, and NOT a function.
@@ -443,19 +440,14 @@ export interface ComponentScreenTypingsInput {
   readonly note?: TypeNote;
 }
 
-/** A Kit prop whose zod schema is the shared `action` — `z.string().describe(…)`
- *  in kit/specs.ts (`kit/specs.ts:27`). The WIRE dialect passes a tool NAME
- *  through it, which is why the zod says `string` and must keep saying so: it
- *  still validates stored documents in the old format. A component screen passes
- *  a real handler that calls `tools.tool_name(args)` itself, so THIS generator
- *  types it as a function — derived from the schema's own description, so the two
- *  readings stay one definition rather than a hand-kept prop-name list.
+/** A handler slot, printed for every prop whose schema carries
+ *  {@link ACTION_PROP_DESCRIPTION}. The WIRE dialect passed a tool NAME through
+ *  that prop, which is why its zod says `string` and must keep saying so — it
+ *  still validates stored documents in the old format — while a component screen
+ *  passes a real handler that calls `tools.tool_name(args)` itself. Without this,
+ *  every `onClick={() => tools.x(…)}` would fail the type check against a string.
  *
- *  Without this, every `onClick={() => tools.x(…)}` — which is every screen in
- *  the new format — would fail the type check against a `string` slot. */
-const ACTION_PROP_DESCRIPTION = "names a host tool";
-
-/** A handler slot. The event is the small React-shaped object a screen actually
+ *  The event is the small React-shaped object a screen actually
  *  reads off one (`event.target.value` from an Input, `event.target.checked` from
  *  a Checkbox) — this program has no DOM lib to describe the real thing, and
  *  anything wider would reject working code. It is OPTIONAL because most handlers

--- a/packages/apps/src/server/generation/contracts/sections.ts
+++ b/packages/apps/src/server/generation/contracts/sections.ts
@@ -22,10 +22,11 @@ import {
 } from "../../../contract/index.js";
 
 /** The COMPONENTS section is GENERATED from the Kit specs (catalogPrompt); no
- *  hand-written component list survives here. One line per component rather than
- *  a section apiece — the whole catalog plus the icon vocabulary for less than
- *  the sections cost without icons. Deps-independent, so it is rendered once per
- *  process (perf budget: gen-scripted:create). */
+ *  hand-written component list survives here. One typed line per component and
+ *  one worked example under it, rather than a section apiece — the whole
+ *  catalog, the icon vocabulary and an example each for less than the sections
+ *  cost without icons. Deps-independent, so it is rendered once per process
+ *  (perf budget: gen-scripted:create). */
 let componentsPromptCache: string | undefined;
 export const componentsPromptSection = (): string => componentsPromptCache ??= `COMPONENTS (generated from the component schemas — use these EXACT component and prop names; an unknown prop is silently dropped and fails validation):
 

--- a/packages/apps/tests/contract/kit/catalog-prompt.test.ts
+++ b/packages/apps/tests/contract/kit/catalog-prompt.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
+import type { z } from "zod";
 import { catalogPrompt } from "../../../src/contract/kit/catalog-prompt.js";
 import { KIT_ICON_NAMES } from "../../../src/contract/kit/icon-names.gen.js";
+import { kitPrompt, promptExamples } from "../../../src/contract/kit/kit-prompt.js";
 import { KIT_SPECS, kitSpec } from "../../../src/contract/kit/specs.js";
 
 const body = (options: Parameters<typeof catalogPrompt>[0] = {}) =>
@@ -9,16 +11,52 @@ const body = (options: Parameters<typeof catalogPrompt>[0] = {}) =>
 describe("catalogPrompt() — the whole catalog, one line per component", () => {
   // The FORMAT is pinned against the spec's own prose rather than a copy of it:
   // a summary reworded in specs.ts is not a regression here, a changed shape is.
-  it("renders a component as name, summary, then props by class", () => {
+  it("renders a component as name, summary, then typed props by class", () => {
     expect(body({ only: ["Money"] })[0]).toBe(
-      `<Money> ${kitSpec("Money")!.summary} · data: amount · config: currency`,
+      `<Money> ${kitSpec("Money")!.summary} · data: amount: number · config: currency: string`,
     );
   });
 
   it("marks a required prop with `!` and leaves an optional one bare", () => {
     const line = body({ only: ["Stat"] })[0]!;
-    expect(line).toContain("data: value!");
-    expect(line).toContain("copy: label! trend");
+    expect(line).toContain("data: value!: number|string");
+    expect(line).toContain("copy: label!: string, trend: string");
+  });
+
+  /**
+   * THE TYPE IS THE SCHEMA'S. The owner's complaint this format answers was that
+   * a prop name alone never says what may be written beside it — and a type
+   * written by hand in the renderer would answer it for exactly as long as the
+   * schema stood still.
+   *
+   * So the expectation is read off the zod enum itself: a printer that hand-wrote
+   * a vocabulary would fail here the moment the two disagreed. The literal beside
+   * it is what makes a CHANGED enum go red rather than silently re-render — the
+   * catalog is the model's whole idea of this prop, so its vocabulary moves
+   * deliberately.
+   */
+  it("renders a prop's type from its own schema, enum values and all", () => {
+    const mode = kitSpec("DateTime")!.props["mode"]!.schema as z.ZodEnum<[string, ...string[]]>;
+    const fromSchema = mode.options.map((value) => JSON.stringify(value)).join("|");
+    expect(body({ only: ["DateTime"] })[0]).toContain(`config: mode: ${fromSchema}`);
+    expect(fromSchema).toBe('"date"|"time"|"datetime"|"relative"');
+  });
+
+  /** The shapes a name cannot carry: an object gives its FIELD names (the worked
+   *  example shows what goes in them), a handler is a function rather than the
+   *  string its wire-era schema still parses, and a slot holds elements. */
+  it("prints objects, handlers and slots compactly", () => {
+    expect(body({ only: ["DataTable"] })[0]).toContain("columns: {key?, label?, format?, align?, cell?}[]");
+    expect(body({ only: ["Button"] })[0]).toContain("onClick: fn");
+    expect(body({ only: ["Surface"] })[0]).toContain("header: element");
+  });
+
+  /** ONE example per component, indented under its line — the half a prop list
+   *  cannot give, and taken from the same place `kitPrompt` takes it, so the two
+   *  prompts can never show the model different idioms. */
+  it("carries exactly one worked example per component", () => {
+    expect(body().filter((line) => line.startsWith("  "))).toHaveLength(KIT_SPECS.length);
+    expect(body({ only: ["Money"] })[1]).toBe(`  ${promptExamples(kitSpec("Money")!)[0]}`);
   });
 
   it("leads with the data props — law 1 is the one a line must not bury", () => {
@@ -78,27 +116,30 @@ describe("catalogPrompt() — the whole catalog, one line per component", () => 
 
   it("leads with the two laws and the legend, and drops them on request", () => {
     expect(catalogPrompt()).toContain("# The Kit");
-    expect(catalogPrompt()).toContain("`!` marks a required prop");
+    expect(catalogPrompt()).toContain("`!` marks a required one");
     expect(catalogPrompt({ omitPreamble: true })).not.toContain("# The Kit");
   });
 
   /**
-   * THE BUDGET. Measured 2026-08-15 on this base: the prompt this replaces —
-   * `componentsPromptSection()`, a `kitPrompt` section per brick — costs 20,819
-   * characters (~5.8k tokens) for 38 bricks and carries no icon names at all.
-   * This renders 39 bricks AND 227 icon names in 13,313 (~3.7k tokens), because
-   * a line drops the worked example and the per-prop docs.
+   * THE BUDGET, re-measured 2026-08-17 when types and one worked example apiece
+   * went back into the line: 53 bricks, 227 icon names and 53 examples cost
+   * 29,081 characters (~8.1k tokens), against the 20,396 the same 53 bricks cost
+   * as bare prop NAMES. That growth is the change — a name alone never said what
+   * may be written beside it — and it is bought against `kitPrompt`'s
+   * section-per-brick catalog, which costs 36,158 for the same bricks with no
+   * icon names at all.
    *
-   * The ceiling is that measured 20,819: the whole catalog plus icons may not
-   * cost more than the catalog alone used to. The per-brick bound is the half
-   * that bites — at 230 characters a brick, the 55-brick kit lands near 17,000
-   * and still fits, and a line that grows past 300 would break that promise
-   * long before the total ceiling noticed.
+   * The ceiling is 32,000, and the per-brick bound is the half that bites: at 440
+   * characters a brick — its line AND its example — the 55-brick kit lands near
+   * 30,600 and still fits, while a brick that grew past 440 would break that
+   * promise long before the total noticed. Both numbers move DELIBERATELY, in a
+   * commit that says why.
    */
-  it("costs less than the prompt it replaces, with room for the 55-brick kit", () => {
+  it("stays under the section-per-brick catalog, with room for the 55-brick kit", () => {
     const prompt = catalogPrompt();
-    expect(prompt.length).toBeLessThanOrEqual(20_819);
-    const lines = body().filter((line) => line.startsWith("<"));
-    expect(lines.join("\n").length / lines.length).toBeLessThanOrEqual(300);
+    expect(prompt.length).toBeLessThanOrEqual(32_000);
+    expect(prompt.length).toBeLessThan(kitPrompt().length);
+    const lines = body().filter((line) => line.startsWith("<") || line.startsWith("  "));
+    expect(lines.join("\n").length / KIT_SPECS.length).toBeLessThanOrEqual(440);
   });
 });


### PR DESCRIPTION
A catalog line gave prop NAMES only:

```
<DateTime> A date/time from an ISO string… · data: value · config: mode compact
```

Which never said what may be written beside one. `mode` could be a word from a closed list, a number or a function; `columns` could be anything at all. A prop written in the wrong shape is dropped at validation without a word, so the guessing was expensive.

## What a line says now

Every prop reads `name: type`, `!` still marking a required one, and the prop CLASSES stay in front of them — law 1 rides on `data`.

```
<DateTime> A date/time from an ISO string, epoch millis, or Date. Invalid input renders a dash, never 'Invalid Date'. `compact` drops the year — "Aug 7", for a narrow column or a date this year. · data: value: string|number · config: mode: "date"|"time"|"datetime"|"relative", compact: boolean
  <DateTime value={invoice.dueDate} mode="date"/>
```

```
<DataTable> The smart table. … prefer few, richer columns. · data: rows!: {[key]: any}[] · config: columns: {key?, label?, format?, align?, cell?}[], sortBy: string, limit: number, filterableBy: string[], searchable: boolean, paginate: number, empty: element, toolbar: element, rowActions: element · copy: emptyState: string, caption: string · slot cell (per row): … · slot rowActions (per row): … · slot toolbar: … · slot empty: …
  <DataTable rows={invoices.data} sortBy="dueDate asc" columns={[{key:"client.name",label:"Client",cell:<Stack gap={2}><Text field="client.name"/><Text field="number" variant="caption"/></Stack>},{key:"amount",format:"money",align:"end"},{key:"dueDate",format:"date"},{key:"status",label:"Status",cell:<EnumBadge field="status" tones={{overdue:"danger",paid:"success"}}/>}]} emptyState="No overdue invoices"/>
```

The type vocabulary, walked off each prop's own zod schema (`typeText` in `catalog-prompt.ts`) — nothing is hand-written, so a schema that changes changes the prompt in the same commit:

| schema | prints |
| --- | --- |
| `z.enum([...])` | `"date"\|"time"\|"datetime"\|"relative"` |
| `z.number()`, `z.string()`, `z.boolean()` | `number`, `string`, `boolean` |
| `z.array(z.object({...}))` | `{key, label?, format?}[]` — field NAMES; the example shows what goes in them |
| `z.union([...])` | `string\|number`, and `(string\|{key, label?, color?})[]` inside an array |
| `z.record(z.string(), T)` | `{[key]: T}` — so `tones: {[key]: "neutral"\|"accent"\|"success"\|"warning"\|"danger"}` |
| the shared `action` (an `on*` prop) | `fn` |
| a slot | `element` |
| anything outside the vocabulary | `any` — a degradation, never a lie |

An object gives its field names rather than their types on purpose: this text rides every generation, and the worked example under the line is what shows the shape filled in.

## The example line

Under each line sits that component's FIRST example, indented, taken from the same place `kitPrompt` takes it (`promptExamples`) — so the two prompts cannot show a model different idioms. One apiece, never two.

That exposed seven examples still written in the retired attribute dialect, which the catalog would otherwise have taught on every generation: `onClose="ui.cancel"`, `$state.confirming`, inline tool calls for data (`payments.list({}).data`), and a `<KeyValue pairs={…}>` naming a prop that does not exist. They are corrected to the shape a screen actually compiles — state and setters for Modal/Sheet/Toast/EmptyState, `useQuery` results for KeyValue/Timeline/CodeBlock — in `PROMPT_EXAMPLES`, the map that already carried thirteen such corrections.

## The bytes, and the budget

| | before | after |
| --- | ---: | ---: |
| whole catalog, `catalogPrompt()` | **20,396** | **29,081** (+8,685, +43%) |
| per brick | 265.7 (its line) | 427.1 (its line + its example) |

After the change that 29,081 is 4,315 of preamble and legend, 22,637 of bricks and examples, and 2,129 of icon names. `kitPrompt()` — a section per brick, with per-prop docs and no icon names at all — costs 36,158 for the same 53 bricks.

That growth is the change, and it is bought deliberately. The pinned budget moves with it:

- **ceiling 20,819 → 32,000.** The promise it was written for still holds: the whole catalog, WITH the icon vocabulary and an example apiece, costs less than a section per brick costs with neither (29,081 vs 36,158). The test now asserts that relation live as well as the number.
- **per-brick 300 → 440**, and it now measures the brick's two lines rather than one. At 440 the 55-brick kit lands near 30,600 and still fits. This is the bound that bites; the ceiling only notices later.

## Tests

- the drift test asked for: `DateTime.mode`'s rendered type is compared to the values read off the zod enum itself, so a printer with a hand-written vocabulary fails — and to the literal beside it, so **changing a schema enum goes red** rather than silently re-rendering. Proven both ways: adding `"ago"` to the enum turned it red, and the schema-derived half tracked the change.
- exactly one example per component, indented under its line, byte-equal to `promptExamples(spec)[0]`.
- the compact printing of objects, handlers and slots.
- the existing format assertions moved to the new grammar; `format-conformance.e2e.test.ts` pins the vocabulary and the bundle limits, neither of which this touches, and needed no change.

## A/B on the real pipeline

`GENBENCH_NO_OPEN=1 pnpm genbench run --prompt <case> --contenders vendo` (maple, sonnet), this branch against the unmodified base. Scoped to the `vendo` column because the two baselines never read this text — running them would have spent three times the money to measure nothing.

| case | | floor | judged | model calls | output tok | wall | $ |
| --- | --- | --- | --- | ---: | ---: | ---: | ---: |
| pending-transfers | base | 5/5 | **7/7** | 5 | 956 | 18.5s | 0.0713 |
| pending-transfers | this | 5/5 | **7/7** | **4** | 870 | 17.9s | 0.0774 |
| savings-goals | base | 4 + 1 vacuous | **4/6** | 5 | 2,133 | 33.3s | 0.0856 |
| savings-goals | this | 4 + 1 vacuous | **4/6** | **3** | 1,696 | 26.6s | 0.0828 |

Identical scores on both cases, and the fatter prompt paid for itself in TURNS: nine model calls became seven, and `savings-goals` came back 20% faster. Cost is flat within noise (+$0.006 on one, −$0.003 on the other) — the bigger prompt costs more to cache-write once and is then re-read fewer times. On `savings-goals` the base needed the triage to waive three on-screen values; this run needed none.

n=1 per case, so the honest reading is "no regression, fewer turns", not a proven speed-up.

## Local gate

`pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint` — build, typecheck and lint green; `test:affected` 40/42, the two reds being the laptop's known ones, both reproducing on a clean base: `@vendoai/vendo`'s three `Cool%20Code` path-with-space ENOENTs and `@vendoai/store`'s two PGlite SIGKILL drills. `@vendoai/apps` itself: 1366 passed, 19 skipped.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Typed catalog lines with one worked example per component to reduce guesswork and align with schemas. Previously lines listed prop names only; now each prop renders as `name: type` (enums enumerated, objects as field names, handlers as `fn`, slots as `element`), with `!` for required. This increases prompt size and updates the budget.

- The catalog now derives types from each prop’s zod schema in `catalog-prompt.ts`; props print comma‑separated by class, followed by one indented example from `promptExamples(spec)[0]`.
- Consolidated example source in `kit-prompt.ts` and corrected seven examples (KeyValue, Timeline, CodeBlock, Modal/Sheet/Toast/EmptyState) to the compiled screen shape.
- Exported `SLOT_PROP_DESCRIPTION` and `ACTION_PROP_DESCRIPTION` from `specs.ts`; both `catalog-prompt.ts` (type printer) and `screen-typings.ts` (TS types) consume these markers.
- Budget: catalog is ~29,081 chars; ceiling set to 32,000; per‑brick bound set to 440 (line + example). Tests assert ceiling, per‑brick bound, one example per component, compact printing, and that enum vocab is taken from the schema (schema changes turn tests red).
- `sections.ts` updates the components section description accordingly.

<sup>Written for commit 58a0c0838b244cde91c55c15cb585617e58bdfde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

