### PR TITLE
fix(ui): a column that fits is a column, whatever the pixel rounds to

### DIFF
--- a/packages/ui/src/kit/data/data-table.tsx
+++ b/packages/ui/src/kit/data/data-table.tsx
@@ -133,6 +133,16 @@ export const foldStyle: CSSProperties = {
   fontVariantNumeric: "normal",
 };
 
+/** A width to the FRACTION. `offsetWidth` and `clientWidth` are whole pixels,
+ *  and the element's own rect carries the fraction they rounded away — summing
+ *  rounded column widths against a rounded room overshoots by up to half a pixel
+ *  per column, which folds a column that fits. A rect is all zeroes where nothing
+ *  is laid out (SSR, jsdom), leaving the whole-pixel reading exactly as it was. */
+const unrounded = (whole: number, el: Element): number => {
+  const { width } = el.getBoundingClientRect();
+  return whole + width - Math.round(width);
+};
+
 export function DataTable(props: DataTableProps) {
   const {
     rows: rawRows,
@@ -311,13 +321,14 @@ export function DataTable(props: DataTableProps) {
       if (headers !== undefined && headers.length === expandedHeaderCount) {
         let edge = 0;
         naturalEdges.current = [...headers].slice(0, columns.length)
-          .map((th) => (edge += (th as HTMLElement).offsetWidth));
+          .map((th) => (edge += unrounded((th as HTMLElement).offsetWidth, th)));
       }
       const edges = naturalEdges.current;
       if (edges.length === 0) return;
       // Keep every column that has room, fold only the ones that do not. The
       // first column always stays, however narrow the surface is.
-      setVisibleCount(Math.max(1, edges.filter((right) => right <= node.clientWidth).length));
+      const room = unrounded(node.clientWidth, node);
+      setVisibleCount(Math.max(1, edges.filter((right) => right <= room).length));
     };
     measure();
     const observer = new ResizeObserver(measure);

--- a/packages/ui/src/kit/data/data-table.tsx
+++ b/packages/ui/src/kit/data/data-table.tsx
@@ -133,14 +133,20 @@ export const foldStyle: CSSProperties = {
   fontVariantNumeric: "normal",
 };
 
-/** A width to the FRACTION. `offsetWidth` and `clientWidth` are whole pixels,
- *  and the element's own rect carries the fraction they rounded away — summing
- *  rounded column widths against a rounded room overshoots by up to half a pixel
- *  per column, which folds a column that fits. A rect is all zeroes where nothing
- *  is laid out (SSR, jsdom), leaving the whole-pixel reading exactly as it was. */
-const unrounded = (whole: number, el: Element): number => {
-  const { width } = el.getBoundingClientRect();
-  return whole + width - Math.round(width);
+/** A whole-pixel reading (`offsetWidth`, `clientWidth`) put back to the fraction
+ *  its laid-out box really has: summing rounded column widths against a rounded
+ *  room overshoots by up to half a pixel per column, which folds a column that
+ *  fits. Nothing is laid out under SSR and jsdom, where `laidOut` is 0 (or NaN,
+ *  off a border those cannot resolve) and the whole-pixel reading stands. */
+const unrounded = (whole: number, laidOut: number): number =>
+  laidOut > 0 ? whole + laidOut - Math.round(laidOut) : whole;
+
+/** The scroller's CONTENT box, to the fraction. Its rect is the BORDER box, and
+ *  `borderWidth` is a host's own string: a fractional border handed back as room
+ *  keeps a column that overflows, which is the fold's failure mirrored. */
+const contentWidth = (el: HTMLElement): number => {
+  const { borderLeftWidth, borderRightWidth } = getComputedStyle(el);
+  return el.getBoundingClientRect().width - parseFloat(borderLeftWidth) - parseFloat(borderRightWidth);
 };
 
 export function DataTable(props: DataTableProps) {
@@ -321,13 +327,13 @@ export function DataTable(props: DataTableProps) {
       if (headers !== undefined && headers.length === expandedHeaderCount) {
         let edge = 0;
         naturalEdges.current = [...headers].slice(0, columns.length)
-          .map((th) => (edge += unrounded((th as HTMLElement).offsetWidth, th)));
+          .map((th) => (edge += unrounded((th as HTMLElement).offsetWidth, th.getBoundingClientRect().width)));
       }
       const edges = naturalEdges.current;
       if (edges.length === 0) return;
       // Keep every column that has room, fold only the ones that do not. The
       // first column always stays, however narrow the surface is.
-      const room = unrounded(node.clientWidth, node);
+      const room = unrounded(node.clientWidth, contentWidth(node));
       setVisibleCount(Math.max(1, edges.filter((right) => right <= room).length));
     };
     measure();

--- a/packages/ui/test/kit/data-table.test.tsx
+++ b/packages/ui/test/kit/data-table.test.tsx
@@ -284,6 +284,73 @@ describe("DataTable", () => {
   });
 
   /**
+   * What a browser really measures: a laid-out width is FRACTIONAL, and
+   * `offsetWidth`/`clientWidth` are that width rounded to a whole pixel. The
+   * scroller carries a 1px border on each side, so its rect is two pixels wider
+   * than the room inside it.
+   */
+  function stubSubpixelLayout(widths: Record<string, number>, room: number): () => void {
+    const observers = globalThis.ResizeObserver;
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as never;
+    const rects = HTMLElement.prototype.getBoundingClientRect;
+    const widthOf = (el: HTMLElement) =>
+      el.tagName === "TH" ? widths[el.textContent?.replace(/[▲▼]/gu, "").trim() ?? ""] ?? 0 : room;
+    for (const prop of ["offsetWidth", "clientWidth"] as const) {
+      Object.defineProperty(HTMLElement.prototype, prop, {
+        configurable: true,
+        get(this: HTMLElement) { return Math.round(widthOf(this)); },
+      });
+    }
+    HTMLElement.prototype.getBoundingClientRect = function (this: HTMLElement) {
+      return { width: widthOf(this) + (this.tagName === "TH" ? 0 : 2) } as DOMRect;
+    };
+    return () => {
+      globalThis.ResizeObserver = observers;
+      HTMLElement.prototype.getBoundingClientRect = rects;
+      Reflect.deleteProperty(HTMLElement.prototype, "offsetWidth");
+      Reflect.deleteProperty(HTMLElement.prototype, "clientWidth");
+    };
+  }
+
+  /**
+   * THE REGRESSION: a column that FITS must not fold. Three columns filling a
+   * 1000px table measure 320.8125 + 387.546875 + 291.640625 — exactly 1000 — but
+   * every `offsetWidth` rounds up, and summing them says 321 + 388 + 292 = 1001.
+   * One pixel of rounding per column, and the last column silently stops being a
+   * column. Chrome's own numbers, off a 1000px-wide viewport.
+   */
+  it("keeps a column whose fractional widths fill the room exactly", () => {
+    const restore = stubSubpixelLayout({ Client: 320.8125, Amount: 387.546875, Due: 291.640625 }, 1_000);
+    try {
+      render(<DataTable rows={rows} columns={columns} />);
+      expect(screen.getAllByRole("columnheader")).toHaveLength(3);
+      expect(screen.getAllByRole("row")[1]!.textContent).not.toContain("Due:");
+    } finally {
+      restore();
+    }
+  });
+
+  /**
+   * The other rounded reading is the room itself: a scroller laid out on a
+   * fraction reports a `clientWidth` rounded DOWN from what it has, and the
+   * column filling that fraction folds. Chrome's numbers off a 1025px viewport,
+   * where the table sits in a container of fractional width.
+   */
+  it("keeps a column that fits the room's own fraction", () => {
+    const restore = stubSubpixelLayout({ Client: 328.625, Amount: 397, Due: 298.765625 }, 1_024.390_625);
+    try {
+      render(<DataTable rows={rows} columns={columns} />);
+      expect(screen.getAllByRole("columnheader")).toHaveLength(3);
+    } finally {
+      restore();
+    }
+  });
+
+  /**
    * Every header keeps its OWN width wherever it sits, which is what the
    * uniform `stubLayout` cannot express: the bug below turns on the actions
    * header being narrower than the data column whose slot it takes over once

--- a/packages/ui/test/kit/data-table.test.tsx
+++ b/packages/ui/test/kit/data-table.test.tsx
@@ -289,7 +289,7 @@ describe("DataTable", () => {
    * scroller carries a 1px border on each side, so its rect is two pixels wider
    * than the room inside it.
    */
-  function stubSubpixelLayout(widths: Record<string, number>, room: number): () => void {
+  function stubSubpixelLayout(widths: Record<string, number>, room: number, border = 1): () => void {
     const observers = globalThis.ResizeObserver;
     globalThis.ResizeObserver = class {
       observe() {}
@@ -297,6 +297,7 @@ describe("DataTable", () => {
       disconnect() {}
     } as never;
     const rects = HTMLElement.prototype.getBoundingClientRect;
+    const styles = globalThis.getComputedStyle;
     const widthOf = (el: HTMLElement) =>
       el.tagName === "TH" ? widths[el.textContent?.replace(/[▲▼]/gu, "").trim() ?? ""] ?? 0 : room;
     for (const prop of ["offsetWidth", "clientWidth"] as const) {
@@ -306,10 +307,15 @@ describe("DataTable", () => {
       });
     }
     HTMLElement.prototype.getBoundingClientRect = function (this: HTMLElement) {
-      return { width: widthOf(this) + (this.tagName === "TH" ? 0 : 2) } as DOMRect;
+      return { width: widthOf(this) + (this.tagName === "TH" ? 0 : border * 2) } as DOMRect;
     };
+    globalThis.getComputedStyle = ((el: Element) =>
+      el.tagName === "DIV"
+        ? { borderLeftWidth: `${border}px`, borderRightWidth: `${border}px` }
+        : styles(el)) as typeof globalThis.getComputedStyle;
     return () => {
       globalThis.ResizeObserver = observers;
+      globalThis.getComputedStyle = styles;
       HTMLElement.prototype.getBoundingClientRect = rects;
       Reflect.deleteProperty(HTMLElement.prototype, "offsetWidth");
       Reflect.deleteProperty(HTMLElement.prototype, "clientWidth");
@@ -345,6 +351,24 @@ describe("DataTable", () => {
     try {
       render(<DataTable rows={rows} columns={columns} />);
       expect(screen.getAllByRole("columnheader")).toHaveLength(3);
+    } finally {
+      restore();
+    }
+  });
+
+  /**
+   * …and the room is the CONTENT box, so a themed border width that is itself
+   * fractional (`borderWidth` is a host's own string) belongs to neither side of
+   * the comparison. Reading the fraction off the scroller's border box instead
+   * hands the table its border back as room, and a column overflowing by a hair
+   * stays put — the fold's own failure, mirrored.
+   */
+  it("does not spend a fractional border as room", () => {
+    const restore = stubSubpixelLayout({ Client: 100, Amount: 100, Due: 100.093_75 }, 300, 0.093_75);
+    try {
+      render(<DataTable rows={rows} columns={columns} />);
+      expect(screen.getAllByRole("columnheader")).toHaveLength(2);
+      expect(screen.getAllByRole("row")[1]!.textContent).toContain("Due:");
     } finally {
       restore();
     }


### PR DESCRIPTION
## The bug

At some viewport widths `DataTable` folded its last column into the first cell although there was room for it — the column silently stopped being a column. Pre-existing; found during the mapped-rows build and reproduced in a real browser. Both the `columns` API and the mapped-rows children API are affected: `TableRow` does no measuring of its own, it reads the same `visibleCount` off `TableContext`.

## Root cause

The fold compared a sum of ROUNDED widths against a ROUNDED room. `offsetWidth` and `clientWidth` are whole pixels; a laid-out column is fractional.

Three columns filling a 1000px table measure `320.8125 + 387.546875 + 291.640625` — exactly 1000 — but each `offsetWidth` rounds up, so the cumulative edge reads `321 + 388 + 292 = 1001`: one pixel past a room it exactly filled. The error grows with the column count (up to half a pixel each).

The room rounds too. A scroller laid out on a fraction reports a `clientWidth` short of what it has, and the column filling that fraction folds as well — so fixing only the column side would have made the fractional-container case *worse* (41 bad widths vs 17 in the sweep below).

Both readings now carry the fraction their laid-out box really has, so the comparison is fractional on both sides. No tolerance, no epsilon. The room is the scroller's CONTENT box, with the border widths read off the element rather than assumed integral — a fractional themed border handed back as room would keep a column that overflows, the same failure mirrored (found in review, fixed in 1d90311fd, with a test). Nothing is laid out under SSR and jsdom, where the whole-pixel reading stands exactly as it was. The fold design itself is untouched.

## Proof

**Browser sweep** — Chromium, 1000→1200px in 5px steps across four container shapes (flush `100%` plus three fractional widths), asserting the last column is present whenever the true fractional widths fit the scroller's true fractional content box:

| | result |
|---|---|
| before | **FAIL** — 31 of 164 widths folded a fitting column (incl. 1100px) |
| after | **PASS** — 0 |

Screenshots at 1100px: `/tmp/fold-fix/before-1100.png` (CLIENT + AMOUNT only, "Due: Mar 14" folded into the first cell, half the table empty) and `/tmp/fold-fix/after-1100.png` (CLIENT, AMOUNT, DUE as real columns).

**Red→green** — two new tests carry Chrome's own measurements (one for each rounding) and fail on the old code with exactly the reported symptom, 2 columns of 3; they pass on the new. No existing test was modified — the 22 that were already there still pass untouched.

**Gates** — ui suite 1320/1320, `pnpm typecheck`, `pnpm lint`, `pnpm test:affected` (34/35 tasks; the one red was 3 unrelated 30s timeouts in `packages/vendo` under a load average of 56 from a concurrent worktree run — `tests/harness-wire.test.ts` 19/19 and `tests/server.test.ts` 126/126 both green when re-run scoped).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `DataTable` column folding by comparing fractional widths and measuring the room as the content box. Previously we summed rounded column widths against a rounded room from the scroller’s border box, which could fold a column that fits or keep one that overflows when borders were fractional; now we reconstruct fractions from each element’s rect and subtract borders from the room.

- Uses `unrounded(...)` for header edge sums and `unrounded(node.clientWidth, contentWidth(node))` for the scroller room, where `contentWidth` reads the rect and subtracts computed border widths.
- Keeps the existing fold design and “first column always stays” rule; no API changes to `DataTable`, `TableRow`, or `TableContext`.
- Leaves SSR/jsdom unchanged (rects read as zero, whole-pixel behavior persists).
- Adds three tests: fit under subpixel rounding, fit against fractional content width, and no “spending” of fractional borders as room; existing tests remain unchanged.

<sup>Written for commit 1d90311fde7f391d74c6ef2a64e37821334fcb90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


