### PR TITLE
docs(apps): the manual in the owner's words — bullets, HTML allowed, no door out

### DIFF
--- a/packages/apps/src/server/skills/building-apps.ts
+++ b/packages/apps/src/server/skills/building-apps.ts
@@ -92,10 +92,8 @@ Writing everything once at the end works and feels dead. Don't.
 - **It already exists and the change is small** — edit the file in place rather
   than rewriting it, so everything the person is looking at stays where it is.
 - **Bigger than a screen** — real code, its own server, or work that has to run
-  while nobody is watching. Hand it to the builder through \`escalate\`, where you
-  have that tool; it says what to send.
-- **This product cannot do it** — say so, in their words, and build nothing
-  around the hole.
+  while nobody is watching — or **this product cannot do it**: say so, in their
+  words, and build nothing around the hole.
 
 ## What a good screen looks like
 
@@ -148,9 +146,6 @@ marks, and no paragraph explaining a heading that explains itself.
 - **Call the query once** only when a tool declares no output schema, or when the
   actual values matter (what a status string really says, whether an amount is in
   cents or dollars).
-- **A cents field never rides a money column.** A binding cannot divide, so a
-  table showing money maps its own \`<TableRow>\` children and does the math
-  inline — as does any cell whose value is computed rather than read.
 - Look up every component you use: \`host/components/<Name>.md\` for this
   product's own, \`references/format.md\` for the ones that ship with the format.
   Props are checked by name, so a guessed prop is a failed app.

--- a/packages/apps/src/server/skills/format-reference.ts
+++ b/packages/apps/src/server/skills/format-reference.ts
@@ -42,57 +42,64 @@ export default function Overview() { … }
 
 Those two imports are everything there is. Nothing else can be loaded.
 
-**Data — \`useQuery("tool_name")\`.** Synchronous, and it hands back the tool's
-result exactly as the tool returns it, so read the field names off the tool's own
-schema. Money arrives in whatever unit that schema says: divide a \`_cents\` field
-by 100 where you read it, because the components format and never convert.
+## Data — \`useQuery("tool_name")\`
 
-**Actions — \`tools.<tool_name>(args)\`, inside an event handler only.** Never
-during render. \`await\` it when you need the result; the host runs the tool and
-answers. When an awaited call succeeds, every \`useQuery\` on the screen re-runs
-and the screen re-renders with fresh data on its own — so never patch state to
-mirror what the refresh will bring back. Destructive and money-moving calls are
-confirmed by the product OUTSIDE your screen — the guard asks the person before
-the call runs — so never build a confirm step of your own: no "are you sure"
-panel, no second button, no \`confirming\` state. The exception is a confirmation
-the person ASKED for, or one press that fires a whole batch of calls: that one is
-part of their app, and it is a \`<Modal>\` saying how many, with the button that
-runs the loop LAST in its \`footer\` — that footer is a right-aligned row, so the
-last button is the one a person reaches for. A guarded host still asks once per
-call on top of it, and that is the trade: only your Modal can say how many, and
-being asked twice beats a batch that goes out silently.
+- Synchronous, and it hands back the tool's result EXACTLY as the tool returns
+  it — read the field names off the tool's own schema.
+- Money in tool data is usually CENTS: \`amount_cents: 2850\` means $28.50. Every
+  money component takes DOLLARS and never converts — divide by 100 where you
+  read it (\`amount_cents / 100\`), or the screen shows $2,850.00.
 
-**Components — the catalog below, and nothing else.** Every component already
-carries this product's own theme, so anything with behavior — a table, a number,
-a date, a control — is a component, never HTML you assemble yourself. That holds
-inside a sentence too: an amount in prose is an inline \`<Money>\`, never a \`$\`
-and a \`toFixed\` you typed, which lose the grouping and the host's own currency.
+## Actions — \`tools.<tool_name>(args)\`
 
-**Tables — bind the plain values, MAP the rest.** A \`<DataTable>\` column binds a
-plain field straight off the row, and that stays the right way to show one. A
-cell that needs arithmetic has nowhere to put it — money in cents, a rate, a
-total, anything derived — so paint those rows yourself: one \`<TableRow>\` per
-record as the table's children, its children being that row's cells in column
-order, and do the math inline: \`<Money amount={row.amount_cents / 100}/>\`. A
-per-row control goes there too. \`rows\` and \`columns\` are required either way.
+- Inside an event handler only, never during render. \`await\` it when you need
+  the result; the host runs the tool and answers.
+- When an awaited call succeeds, every \`useQuery\` on the screen re-runs and the
+  screen re-renders with fresh data on its own — never patch state to mirror
+  what the refresh will bring back.
+- Destructive and money-moving calls are confirmed by the product OUTSIDE your
+  screen — the guard asks the person before the call runs — so never build a
+  confirm step of your own: no "are you sure" panel, no second button, no
+  \`confirming\` state.
+- The exception: a confirmation the person ASKED for, or one press that fires a
+  whole batch of calls. That one is part of their app — a \`<Modal>\` saying how
+  many, with the button that runs the loop LAST in its \`footer\` (that footer is
+  a right-aligned row, so the last button is the one a person reaches for). A
+  guarded host still asks once per call on top of it, and that is the trade:
+  only your Modal can say how many, and being asked twice beats a batch that
+  goes out silently.
 
-**Layout — the display tags, plus \`style\`.** \`${DISPLAY_TAG_NAMES.join("`, `")}\`
-are yours to arrange with, and they take children and an inline \`style\` and
-nothing else: no \`className\`, no \`id\`, no handlers. Style them off the host's own
-CSS variables (\`var(--vendo-color-accent)\`, \`var(--vendo-density-content-gap)\`)
-so the screen stays branded — a hard-coded color is your color, not the
-product's; every variable there is, and what each one means, is listed at the end
-of this file. There is no network in here, so a style that fetches (\`url(…)\`) is
-dropped.
-\`key={…}\` on every row you \`.map\`. Dates go to the date
-component as the ISO string you were given — there is no clock in here, so no
-\`new Date()\`; and no \`fetch\`, \`localStorage\` or \`setTimeout\` either, because
-there is no network, no storage and no timers.
+## Components and plain HTML
 
-**State — \`useState\`.** Inputs are controlled: \`value={x}\` with
-\`onChange={(e) => setX(e.target.value)}\`. A handler receives a plain
-\`{ target: { value } }\` — a checkbox, \`{ target: { checked } }\` — and there is no
-\`preventDefault\` to call: \`<Form>\` submits itself.
+- Prefer the catalog: a component already carries this product's theme and
+  formatting, and its props are checked — a \`<Money>\` is never mis-grouped, a
+  \`<DateTime>\` never prints "Invalid Date".
+- Beside it you have plain display HTML — \`${DISPLAY_TAG_NAMES.join("`, `")}\` — used the way you'd use
+  it anywhere: headings, prose, lists, and any structure the catalog doesn't
+  offer.
+- Display tags take children and an inline \`style\`, nothing else — no handlers,
+  so anything that ACTS is a component.
+- Whatever you build yourself, style it off the host's own CSS variables
+  (\`var(--vendo-color-accent)\`, \`var(--vendo-density-content-gap)\`), never
+  hard-coded values — a hard-coded color is your color, not the product's; every
+  variable there is, and what each one means, is listed at the end of this file.
+- Figures in prose still go through the value components: an amount in a
+  sentence is an inline \`<Money>\`, never a \`$\` and a \`toFixed\` you typed —
+  those lose the grouping and the host's currency.
+
+## The sandbox
+
+- No network, no storage, no timers, no clock: no \`fetch\`, no \`localStorage\`,
+  no \`setTimeout\`, no \`new Date()\`. A style that fetches (\`url(…)\`) is dropped.
+- Dates go to the date component as the ISO string you were given.
+- \`key={…}\` on every row you \`.map\`.
+
+## State — \`useState\`
+
+- Inputs are controlled: \`value={x}\` with \`onChange={(e) => setX(e.target.value)}\`.
+- A handler receives a plain \`{ target: { value } }\` — a checkbox,
+  \`{ target: { checked } }\`.
+- There is no \`preventDefault\` to call: \`<Form>\` submits itself.
 
 Save errors tell you exactly what to fix. Fix and save again.
 
@@ -103,7 +110,7 @@ Save errors tell you exactly what to fix. Fix and save again.
 The ask: "let me cancel a transfer before it goes out."
 
 \`\`\`tsx
-import { Button, DataTable, DateTime, Money, Stack, TableRow, Text, tools, useQuery } from "@vendo/screen";
+import { Button, Card, DateTime, Money, Row, Stack, Text, tools, useQuery } from "@vendo/screen";
 
 export default function PendingTransfers() {
   const pending = useQuery("list_pending_transfers");
@@ -112,36 +119,30 @@ export default function PendingTransfers() {
     <Stack gap={12}>
       <Text text="Transfers waiting to go out" variant="heading" />
 
-      <DataTable
-        rows={pending.data}
-        columns={[
-          { key: "recipient", label: "To" },
-          { key: "amount_cents", label: "Amount", align: "end" },
-          { key: "scheduled_for", label: "Goes out" },
-          { label: "", align: "end" },
-        ]}
-        emptyState="Nothing is waiting to go out."
-      >
-        {pending.data.map((transfer) => (
-          <TableRow key={transfer.id}>
-            <Text text={transfer.recipient} />
-            <Money amount={transfer.amount_cents / 100} />
-            <DateTime value={transfer.scheduled_for} mode="date" />
-            <Button label="Cancel" variant="danger" onClick={() => tools.cancel_transfer({ id: transfer.id })} />
-          </TableRow>
-        ))}
-      </DataTable>
+      {pending.data.length === 0 ? (
+        <Text text="Nothing is waiting to go out." variant="caption" />
+      ) : (
+        pending.data.map((transfer) => (
+          <Card key={transfer.id} title={transfer.recipient}>
+            <Row justify="between" align="center">
+              <Stack gap={4}>
+                <Money amount={transfer.amount_cents / 100} />
+                <DateTime value={transfer.scheduled_for} mode="date" />
+              </Stack>
+              <Button label="Cancel" variant="danger" onClick={() => tools.cancel_transfer({ id: transfer.id })} />
+            </Row>
+          </Card>
+        ))
+      )}
     </Stack>
   );
 }
 \`\`\`
 
-Nothing on that screen is typed in: every value is read off the query, the cents
-field is divided where it is read instead of being handed to a money column that
-would show it a hundred times over, every number and date is formatted by the
-component showing it, the empty list says so in one honest line, and the one
-thing that changes the product files its call straight from the press — the
-product does the asking.
+Nothing on that screen is typed in: every value is read off the query, every
+number and date is formatted by the component showing it, the empty list says so
+in one honest line, and the one thing that changes the product files its call
+straight from the press — the product does the asking.
 
 ---
 

--- a/packages/apps/tests/skills/format-reference.test.ts
+++ b/packages/apps/tests/skills/format-reference.test.ts
@@ -126,10 +126,10 @@ describe("the reference only teaches what a screen really has", () => {
     // The display bricks are the ONLY HTML in the check's program, and they take
     // children and a style and nothing else — so `className` is still a type
     // error, and a color the model invents is still unbranded.
-    expect(VENDO_FORMAT_REFERENCE).toMatch(/nothing else: no `className`, no `id`, no handlers/);
+    expect(VENDO_FORMAT_REFERENCE).toMatch(/take children and an inline `style`, nothing else — no handlers/);
     expect(VENDO_FORMAT_REFERENCE).toMatch(/var\(--vendo-color-accent\)/);
-    expect(VENDO_FORMAT_REFERENCE).toMatch(/no `fetch`, `localStorage` or `setTimeout`/);
-    expect(VENDO_FORMAT_REFERENCE).toMatch(/there is no clock in here, so no\s+`new Date\(\)`/);
+    expect(VENDO_FORMAT_REFERENCE).toMatch(/no `fetch`, no `localStorage`,\s+no `setTimeout`/);
+    expect(VENDO_FORMAT_REFERENCE).toMatch(/no timers, no clock:[\s\S]*no `new Date\(\)`/);
   });
 
   /** V4 retired the legacy prewired family — the Kit is the ONE component source,
@@ -188,7 +188,7 @@ describe("the reference only teaches what a screen really has", () => {
 
   it("lands the section in the reference, where the layout paragraph points", () => {
     expect(VENDO_FORMAT_REFERENCE).toContain("# The host's CSS variables");
-    expect(VENDO_FORMAT_REFERENCE).toContain("listed at the end\nof this file");
+    expect(VENDO_FORMAT_REFERENCE).toContain("is listed at the end of this file");
   });
 
   it("carries the whole catalog, one line per component, generated from the specs", () => {


### PR DESCRIPTION
The two hand-written prompt sources — the screen manual (`format-reference.ts`'s
`CHAPTER`) and the job description (`building-apps.ts`'s `BODY`) — now carry the
owner's approved text **verbatim**, written back from the markdown files he
edited. Nothing inside that text was reworded here.

## What ships

**The manual is sections and bullets, not bold-lead prose.** Data, Actions,
Components and plain HTML, The sandbox, State — each a heading with bullets under
it, instead of five long paragraphs a reader has to mine.

**"Never HTML you assemble yourself" is gone.** The rule is now: prefer the
catalog (a component carries the theme, its props are checked, a `<Money>` is
never mis-grouped), plain display HTML is allowed for headings, prose, lists and
anything the catalog does not offer — and whatever you build yourself is styled
off the host's own CSS variables, never hard-coded values.

**The money rule is stated plainly.** Tool data is usually cents
(`amount_cents: 2850` is $28.50), every money component takes dollars and never
converts, so divide by 100 where you read it — or the screen shows $2,850.00.
The old text said the same thing in a subordinate clause.

**One worked screen, one shape.** The example is a `Card` list rather than a
`DataTable` + `TableRow` pair, and the Tables paragraph it existed to justify is
gone with it. The example still runs the real save-time gauntlet in the tests and
lands with no findings.

**The job description loses the `escalate` paragraph.** #1407 took that door out
of the screen agent's loadout, so a body telling the reader to "hand it to the
builder through `escalate`" named a tool it no longer has. "Bigger than a screen"
and "this product cannot do it" are one answer now, with one honest reply. The
tool itself is untouched — only the prose that pointed at it.

## The one reconciliation

#1408 added a pointer from the Layout paragraph to the generated variable list.
That paragraph is gone in the restructure, so the pointer moves onto the
CSS-variables bullet, in the section's own voice and in #1408's own words:

> …never hard-coded values — a hard-coded color is your color, not the product's;
> every variable there is, and what each one means, is listed at the end of this
> file.

Nothing else differs from the owner's text.

## Round-trip proof

The write-back is mechanical: strip the scratch header, escape for a template
literal (`\` → `\\`, then backtick, then `${`), then substitute the `⟦AUTO-n⟧`
markers with their interpolations verbatim. Re-extracting each literal and
running the inverse transform reproduces the scratch body **byte-identically**
for both files — the only diff against the raw scratch is the reconciliation
clause above (plus the trailing blank line the template needs, which the editor
had stripped).

## Tests

Two prose pins in `packages/apps/tests/skills/format-reference.test.ts` follow
the new wording — both were red against the new source, both pin the same rules:

- the display-tag rule: `nothing else: no \`className\`, no \`id\`, no handlers` →
  `take children and an inline \`style\`, nothing else — no handlers`, and the
  sandbox list `no \`fetch\`, \`localStorage\` or \`setTimeout\`` → the bulleted
  `no \`fetch\`, no \`localStorage\`, no \`setTimeout\`` / `no timers, no clock`.
- the variables pointer, whose line wrap moved: `listed at the end\nof this
  file` → `is listed at the end of this file`.

No other test in the repo pins any of the removed prose. Nothing unrelated was
weakened.

## Gate

`pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint` — build 21/21,
`@vendoai/apps` 1369 passed, `@vendoai/harnesses` 48 files passed, typecheck
42/42, lint 4/4. The five reds are the known laptop ones, present on a clean
base: three `Cool%20Code` path-with-space ENOENTs in `@vendoai/vendo`
(`your-agent-docs.docs`, `cli/init-mcp`) and the two `@vendoai/store` PGlite
SIGKILL drills.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the screen manual and job description with the owner’s approved text verbatim and restructures the manual into concise sections. Updates guidance to allow plain display HTML (styled via host CSS variables), clarifies money handling, and removes the deprecated `escalate` path.

- **Reviewer notes**
  - `packages/apps/src/server/skills/format-reference.ts`: Manual shifts from prose to sectioned bullets; policy changes from “catalog only” to “prefer the catalog, allow display HTML”; style anything you build off host CSS variables; money rule is explicit (tool data in cents; value components take dollars; divide by 100 at read); sandbox rules are explicit; worked example switches from `DataTable`/`TableRow` to `Card` + `Row`; pointer from the removed layout paragraph is moved to the CSS-variables bullet (per #1408).
  - `packages/apps/src/server/skills/building-apps.ts`: Removes the `escalate` guidance; combines “bigger than a screen” and “this product cannot do it” into one direct answer (per #1407).
  - Tests: Updates two string pins in `packages/apps/tests/skills/format-reference.test.ts` to the new wording; no other tests pin removed prose. No runtime behavior changes or migrations.

<sup>Written for commit f23288f9225551b590c525ab9a4f80063cd6d691. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

