### PR TITLE
fix(vendo,guard): a boxed app's host-tool call asks once, and the tap runs it

### DIFF
--- a/.changeset/a-boxed-app-asks-then-runs.md
+++ b/.changeset/a-boxed-app-asks-then-runs.md
@@ -1,0 +1,17 @@
+---
+"@vendoai/core": minor
+"@vendoai/guard": minor
+"@vendoai/vendo": minor
+---
+
+A boxed app's host-tool call asks once, and the tap runs it. `POST
+/box/tools/<name>` dispatched straight at the guard-bound registry, so the
+permission card it parked was one nothing could ever resume: the customer tapped
+Allow and nothing happened, clicked again and got another card, forever — a
+layer-2 ("machine") app could not call a single host tool. The call now rides the
+same park-and-resume flow an in-app action does, and away execution accepts the
+tap itself as its authority: the consumed approval is projected into the grant
+shape the `actAs` seam takes (scoped `exact` to the arguments the person was
+shown, `source: "approval"`, never stored, never matched), exactly as the MCP
+door's OAuth consent already is. Approving runs THAT call and nothing else — no
+standing permission is minted, so each distinct call asks on its own account.

--- a/docs-site/reference/http-routes.mdx
+++ b/docs-site/reference/http-routes.mdx
@@ -127,7 +127,7 @@ An app machine calls back into the host through `/box/*`, authenticated with `Au
 | `/box/rows/<collection>` | GET | list durable rows. Query: `refs.<key>=<value>`, `limit`, `cursor`. Any other parameter is a `400` |
 | `/box/rows/<collection>/<id>` | GET · DELETE | read one row · delete it |
 | `/box/rows/<collection>/<id>` | PUT | body is exactly `{ data, refs? }`, JSON, 256 KiB cap. An unexpected key is a `400` |
-| `/box/tools/<name>` | POST | `{ args }` → `ToolOutcome`, executed through the same guard-bound registry chat uses. A pending-approval outcome is relayed, never bypassed |
+| `/box/tools/<name>` | POST | `{ args }` → `ToolOutcome`, executed through the same guard-bound registry chat uses. A pending-approval outcome is relayed, never bypassed, and approving it runs that exact call |
 
 Collection names match `^[A-Za-z0-9_-]{1,64}$` and row ids run 1 to 256 characters. Anything else under `/box/` answers `404`.
 

--- a/packages/core/src/grants.ts
+++ b/packages/core/src/grants.ts
@@ -109,8 +109,14 @@ export interface PermissionGrant {
    * (10-mcp §3) — the per-call, honestly-labeled authority handed to `actAs`
    * for venue="mcp" host execution. It is never persisted and never consulted
    * by guard; the other sources are minted from in-product decisions.
+   *
+   * `"approval"` is the other projection of that kind, and the same three things
+   * are true of it: one mint point (the guard's `#grantForExecution`, when an
+   * away call runs on a CONSUMED approval), never persisted, never matched. It
+   * says what it is — the person's tap on this one call — so a host reading it
+   * in `actAs` is told the authority is one allowed call, not a standing yes.
    */
-  source: "chat" | "batch" | "automation" | "mcp";
+  source: "chat" | "batch" | "automation" | "mcp" | "approval";
   grantedAt: IsoDateTime;
   expiresAt?: IsoDateTime;
   revokedAt?: IsoDateTime;
@@ -127,7 +133,7 @@ export const permissionGrantSchema = z.object({
   contextKey: z.string().optional(),
   appId: appIdSchema.optional(),
   automationId: z.string().optional(),
-  source: z.enum(["chat", "batch", "automation", "mcp"]),
+  source: z.enum(["chat", "batch", "automation", "mcp", "approval"]),
   grantedAt: isoDateTimeSchema,
   expiresAt: isoDateTimeSchema.optional(),
   revokedAt: isoDateTimeSchema.optional(),

--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -402,7 +402,7 @@ function presenceMatches(grant: PermissionGrant, ctx: RunContext): boolean {
     // (mint-grant.test.ts:118-130) — one app's yes riding every automation in it.
     //
     // NO trigger at all means it is nobody's firing: a boxed ("machine", layer-2)
-    // app callback, which `wire/box.ts:309-315` mints as
+    // app callback, which `wire/box.ts:311-317` mints as
     // `{ venue: "app", presence: "away", appId }`. It has only the app it runs as,
     // so the app is the whole match — main's away rule for this venue.
     if (grant.source !== "automation") return false;
@@ -1658,7 +1658,32 @@ class GuardImplementation implements VendoGuard {
       return record === null ? undefined : (record.data as PermissionGrant);
     }
     if (ctx.presence !== "away") return undefined;
-    return (await this.#matchingGrant(call, descriptor, ctx)).grant;
+    const captured = (await this.#matchingGrant(call, descriptor, ctx)).grant;
+    if (captured !== undefined || decision.decidedBy !== "grant") return captured;
+    // A run/"grant" with NO grantId is a CONSUMED APPROVAL (`replayApproved` in
+    // `bind`): a person tapped THIS call, with these arguments, moments ago. Away
+    // execution has one other authority besides a captured grant, and that is it
+    // — but the seam that authenticates the call (`actAs`) takes a grant, so the
+    // tap arrived with nothing to hand it and the registry refused the very call
+    // the human had just allowed ("away execution requires a captured grant").
+    // The tap is therefore projected INTO the shape the seam asks for, scoped
+    // `exact` to the arguments they were shown: never stored, never returned by
+    // `#matchingGrant`, spent with the approval that made it. It authorizes this
+    // one call and grants no standing authority, so the next call asks again —
+    // the same rule, and the same reason, as the MCP door's consent projection
+    // (`mcpConsentGrant`, actions registry).
+    return {
+      id: `grt_approved_${call.id}`,
+      subject: ctx.principal.subject,
+      tool: call.tool,
+      descriptorHash: descriptorHash(descriptor),
+      scope: { kind: "exact", inputHash: exactInputHash(call.args), inputPreview: inputPreview(call) },
+      duration: "task",
+      contextKey: call.id,
+      ...(ctx.appId === undefined ? {} : { appId: ctx.appId }),
+      source: "approval",
+      grantedAt: now(),
+    };
   }
 
   /** Wins (or loses) an approval's one-time transition by inserting its

--- a/packages/vendo/src/wire/box.ts
+++ b/packages/vendo/src/wire/box.ts
@@ -1,5 +1,5 @@
 import type { BoxRequest, BoxResponse } from "@vendoai/apps";
-import { VendoError, type Json, type RecordQuery, type RunContext } from "@vendoai/core";
+import { VendoError, type AppId, type Json, type RecordQuery, type RunContext } from "@vendoai/core";
 import { json, prefixRoute, route, string, type RouteEntry, type WireContext } from "./shared.js";
 
 /** execution-v2 skin contract (Lane C) — the two wire surfaces on the boundary
@@ -11,10 +11,11 @@ import { json, prefixRoute, route, string, type RouteEntry, type WireContext } f
     2. the CALLBACK surface (`/box/...`): plain HTTP, authenticated by the
        per-app bearer minted at provision (createAppTokens), curl-able from any
        language inside the box — durable rows over the app-scoped store, and
-       host tools through the SAME guard-bound registry chat uses (approvals
-       and audit intact; a pending approval relays as its pending outcome,
-       never bypasses). The box side of the contract. The box never holds host
-       credentials — this surface is its single authority path. */
+       host tools through the app's own action door (approvals and audit
+       intact; a pending approval relays as its pending outcome, never
+       bypasses, and the owner's tap resumes that exact call). The box side of
+       the contract. The box never holds host credentials — this surface is its
+       single authority path. */
 
 /** The fn-name half of core's 01 §8 grammar (mirrored in manifest.ts). */
 const FN_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_-]{0,63}$/;
@@ -267,7 +268,7 @@ async function handleRows(wire: WireContext, appId: string, owner: string): Prom
   return undefined;
 }
 
-async function handleTools(wire: WireContext, ctx: RunContext): Promise<Response | undefined> {
+async function handleTools(wire: WireContext, appId: AppId, ctx: RunContext): Promise<Response | undefined> {
   const { request, segments, deps } = wire;
   if (request.method !== "POST" || segments.length !== 3) return undefined;
   const name = segments[2]!;
@@ -280,17 +281,18 @@ async function handleTools(wire: WireContext, ctx: RunContext): Promise<Response
   if (typeof args !== "object" || args === null || Array.isArray(args)) {
     throw new VendoError("validation", "tool body must be an object containing an args object");
   }
-  // The SAME guard-bound registry every venue executes through: policy,
-  // grants, approvals, breakers, and audit all see this call. An ask-policy
-  // tool comes back { status: "pending-approval" } — relayed, never bypassed.
-  const outcome = await deps.tools.execute({
-    id: `call_${globalThis.crypto.randomUUID()}`,
-    tool: name,
-    args: args as Json,
-  }, ctx);
+  // The app's ACTION door, not the registry underneath it. Same guard-bound
+  // registry every venue executes through — policy, grants, approvals, breakers
+  // and audit all see this call — plus the one thing a raw dispatch lacked: the
+  // door REMEMBERS a parked call, so the owner's tap re-dispatches this exact
+  // one (apps' approve→resume seam). Dispatching straight at the registry parked
+  // a card nothing could ever resume: tap, nothing happens, click, another card.
+  // An ask-policy tool still comes back { status: "pending-approval" } here —
+  // relayed, never bypassed.
+  const outcome = await deps.apps.call(appId, name, args as Json, ctx);
   // Lane E redaction guard — a tool outcome relayed into a response is a
   // host-side artifact; scrub known secret values before it crosses back.
-  return json(await deps.apps.box.redact(ctx.appId ?? "", outcome as Json));
+  return json(await deps.apps.box.redact(appId, outcome as Json));
 }
 
 export const boxRoutes: RouteEntry[] = [
@@ -323,7 +325,7 @@ export const boxRoutes: RouteEntry[] = [
       if (handled !== undefined) return handled;
     }
     if (area === "tools") {
-      const handled = await handleTools(wire, ctx);
+      const handled = await handleTools(wire, identity.appId, ctx);
       if (handled !== undefined) return handled;
     }
     throw new VendoError("not-found", "unknown box route");

--- a/packages/vendo/tests/box-approve-resume.e2e.test.ts
+++ b/packages/vendo/tests/box-approve-resume.e2e.test.ts
@@ -1,0 +1,206 @@
+import { createServer, type Server } from "node:http";
+import { mkdtemp, rm } from "node:fs/promises";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtractedTool } from "@vendoai/actions";
+import { createAppTokens } from "@vendoai/apps";
+import {
+  VENDO_APP_FORMAT,
+  type ActAs,
+  type AppDocument,
+  type Principal,
+} from "@vendoai/core";
+import { createStore, createStoreOps, storeFiles, type VendoStore } from "@vendoai/store";
+import type { LanguageModel } from "ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createVendo, type Vendo } from "../src/server.js";
+
+/**
+ * A BOXED app's host-tool call asks, and the tap makes THAT CALL run.
+ *
+ * `approve-resume.e2e.test.ts` is this journey one layer down — a tree action,
+ * present. This is the layer-2 (machine) shape of it, and the difference is the
+ * whole test: the caller is the box, over its own callback door with its
+ * provision-time bearer, and it runs AWAY (nobody is looking at the box). A
+ * boxed app that could not do this could not call ANY host tool: click → card →
+ * Allow → nothing, then another card, forever.
+ *
+ * Everything here is the real thing: the composed umbrella, a real PGlite store,
+ * the real guard, the real actions registry over a ROUTE binding, the real
+ * `actAs` seam, and a real host HTTP server whose invoice really disappears.
+ * Nothing is seeded — no grant row exists at any point, and the tap mints none
+ * (asserted): a yes here authorizes exactly the call it was given, and the next
+ * call asks again.
+ */
+
+const ADA: Principal = { kind: "user", subject: "user_ada" };
+/** What the host's API accepts, and only the `actAs` seam can produce it. */
+const AWAY_BEARER = "away-token-for-ada";
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+/** The host's own API, really listening: it deletes a real invoice, and only for
+ *  a caller the away seam authenticated. */
+async function invoiceHost(): Promise<{ baseUrl: string; invoices: Set<string>; unauthenticated: number }> {
+  const state = { baseUrl: "", invoices: new Set(["inv_1"]), unauthenticated: 0 };
+  const server: Server = createServer((request, response) => {
+    let body = "";
+    request.on("data", (chunk) => (body += String(chunk)));
+    request.on("end", () => {
+      response.setHeader("content-type", "application/json");
+      if (request.headers.authorization !== `Bearer ${AWAY_BEARER}`) {
+        state.unauthenticated += 1;
+        response.statusCode = 401;
+        response.end(JSON.stringify({ error: "unauthenticated" }));
+        return;
+      }
+      const { id } = JSON.parse(body === "" ? "{}" : body) as { id?: string };
+      response.end(JSON.stringify({ deleted: id !== undefined && state.invoices.delete(id) }));
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  cleanups.push(async () => new Promise<void>((resolve) => server.close(() => resolve())));
+  state.baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  return state;
+}
+
+/** One of the host's OWN endpoints, the way `vendo sync` records it — a route
+ *  binding, which is the only kind of host tool that needs away authority. */
+const deleteInvoice: ExtractedTool = {
+  name: "host_invoices_delete",
+  description: "Delete one of the customer's invoices",
+  inputSchema: {
+    type: "object",
+    properties: { id: { type: "string" } },
+    required: ["id"],
+  },
+  risk: "write",
+  binding: { kind: "route", method: "POST", path: "/api/invoices/delete", argsIn: "body" },
+};
+
+/** A graduated (layer-2) app: its surface lives in a machine, and the machine
+ *  calls back with the bearer provision minted. */
+const doc = (): AppDocument => ({
+  format: VENDO_APP_FORMAT,
+  id: "app_box",
+  name: "Invoice chaser",
+  machine: { snapshotRef: "fake:snap", provisionedAt: "2026-08-01T00:00:00.000Z" },
+});
+
+const engineFor = (store: VendoStore) => createStoreOps(store, { files: storeFiles(store) }).engine;
+
+async function setup(): Promise<{
+  vendo: Vendo;
+  host: Awaited<ReturnType<typeof invoiceHost>>;
+  token: string;
+}> {
+  const host = await invoiceHost();
+  // Single origin, as a real deployment has it: the host API and the wire.
+  vi.stubEnv("VENDO_BASE_URL", host.baseUrl);
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-box-resume-"));
+  const store = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  await store.ensureSchema();
+  await store.records("vendo_apps").put({
+    id: "app_box",
+    data: { subject: ADA.subject, enabled: false, doc: doc() },
+    refs: { subject: ADA.subject },
+  });
+  const actAs: ActAs = async () => ({ headers: { authorization: `Bearer ${AWAY_BEARER}` } });
+  const vendo = createVendo({
+    models: { default: {} as LanguageModel },
+    principal: async (request) => {
+      const subject = request.headers.get("x-test-user");
+      return subject === null ? null : { kind: "user", subject };
+    },
+    store,
+    tools: [deleteInvoice],
+    actAs,
+  });
+  const token = await createAppTokens(engineFor(store)).mint("app_box", ADA.subject);
+  return { vendo, host, token };
+}
+
+const wireRequest = (path: string, init: RequestInit = {}, subject?: string): Request => {
+  const headers = new Headers(init.headers);
+  if (subject !== undefined) headers.set("x-test-user", subject);
+  return new Request(`http://wire.test/api/vendo${path}`, { ...init, headers });
+};
+
+/** The call the box makes: its own door, its own bearer, no host session. */
+const boxCall = (token: string, id: string): Request =>
+  wireRequest("/box/tools/host_invoices_delete", {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+    body: JSON.stringify({ args: { id } }),
+  });
+
+const decide = (vendo: Vendo, approvalId: string, approve: boolean): Promise<Response> =>
+  vendo.handler(wireRequest("/approvals/decide", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ ids: [approvalId], decision: { approve } }),
+  }, ADA.subject));
+
+async function park(vendo: Vendo, token: string, id: string): Promise<string> {
+  const response = await vendo.handler(boxCall(token, id));
+  expect(response.status).toBe(200);
+  const outcome = await response.json() as { status: string; approvalId?: string };
+  expect(outcome).toMatchObject({ status: "pending-approval" });
+  return outcome.approvalId as string;
+}
+
+describe.sequential("a boxed app's host-tool call asks, and the tap runs THAT call", () => {
+  it("parks, then lands the host effect the instant the owner approves", async () => {
+    const { vendo, host, token } = await setup();
+
+    const approvalId = await park(vendo, token, "inv_1");
+    // The gate is holding the write: the invoice is still there.
+    expect(host.invoices.has("inv_1")).toBe(true);
+
+    expect((await decide(vendo, approvalId, true)).status).toBe(200);
+
+    // THE REGRESSION: before the fix the tap changed nothing — no parked call
+    // was remembered, so nothing re-dispatched, so the invoice survived.
+    expect(host.invoices.has("inv_1")).toBe(false);
+    // The host authenticated every call it served — the away seam really ran.
+    expect(host.unauthenticated).toBe(0);
+    // And the box can learn what happened: the resume's answer is persisted,
+    // because the caller that pressed had its `pending-approval` long ago.
+    const answer = await vendo.handler(wireRequest(`/approvals/${approvalId}`, {}, ADA.subject));
+    expect(await answer.json()).toMatchObject({
+      state: "executed",
+      // The host's own answer, relayed: it deleted a row it really had.
+      outcome: { status: "ok", output: { deleted: true } },
+    });
+  });
+
+  it("a denied call never runs", async () => {
+    const { vendo, host, token } = await setup();
+
+    const approvalId = await park(vendo, token, "inv_1");
+    expect((await decide(vendo, approvalId, false)).status).toBe(200);
+
+    expect(host.invoices.has("inv_1")).toBe(true);
+  });
+
+  it("grants no standing authority: the yes runs one call, and the next asks again", async () => {
+    const { vendo, token } = await setup();
+
+    await decide(vendo, await park(vendo, token, "inv_1"), true);
+
+    // Not one grant row exists — the tap authorized a call, not the app.
+    const grants = await (await vendo.handler(wireRequest("/grants", {}, ADA.subject))).json();
+    expect(grants).toEqual([]);
+    // So the next call asks on its own account.
+    await park(vendo, token, "inv_2");
+  });
+});


### PR DESCRIPTION
# A boxed app's host-tool call asks once, and the tap runs it

Base: `automations/s2h-away-binding` (#1411). This is the second half of the
boxed-app regression this project introduced. S2h made the guard's away binding
satisfiable again; nothing in the product minted a decision the box could act on,
so a boxed ("machine", layer-2) app still could not call **any** host tool: click
→ card → **Allow** → nothing, then another card, forever.

Route taken: **park-and-resume**, per the recorded decision — no new standing
permission machinery, and no restoring the consent bug where a yes to an
automation silently authorized the app's server-side code too.

## The verdict on the risk first, because it was the whole question

Park-and-resume **can** satisfy an away execution. Every guard-side gate already
exempts a consumed approval; it failed at the last inch, and closing that inch
needed neither a standing grant nor a presence change.

| Gate | A resumed box call | Source |
| --- | --- | --- |
| 05 §6 away downgrade | survives — a replay is `decidedBy: "grant"` | `guard.ts:1119` |
| THE LAW (§12) | survives — `replayApproved` is exempt | `guard.ts:794, 827` |
| org clamp | survives — `consumedApproval` carve-out | `guard.ts:1153` |
| replay pins the call id | matches — park stores call + ctx verbatim | `parked-action.ts`, `guard.ts:1448` |
| **ActAs authority** | **refused** — nothing to hand the seam | `guard.ts:1660` → `registry.ts:616-617` |

Two footnotes that mattered:

- The risk brief noted that the existing resume machinery may be exempt only
  because tree actions run `presence: "present"`. It is not: the exemption is
  `decidedBy === "grant"`, which a replay carries, so presence never came into it.
- The away arm only bites HOST-API-bound tools (route/openapi/trpc/server-action).
  A `ToolDefinition` executes in-process and never reaches `hostHeaders` — which is
  exactly why every guard-level park/resume test is green with a fake registry
  (`guard/test/park-resume.test.ts` proves an away replay reaching `ok` today) and
  the product was still dead for real hosts.

## What changed (48 lines, 3 files)

**1. `packages/vendo/src/wire/box.ts` — the box calls through the door that
remembers.** `deps.tools.execute` → `deps.apps.call(appId, name, args, ctx)`. Same
guard-bound registry underneath (both are the composition's `boundTools`); the
difference is that the app's action door writes the `parkedActions` record the
`onApprovalDecision` subscriber re-dispatches. The door also mints the call id the
approved replay pins, and routes a read through the derived-id query arm so the
box's own retry is the refetch that satisfies an approved read. **Net one line
less code.**

**2. `packages/guard/src/guard.ts` — a consumed approval is authority the ActAs
seam can read.** `#grantForExecution` projects the tap into the grant shape that
seam takes, scoped `exact` to the arguments the person was shown: `source:
"approval"`, never persisted, never returned by `#matchingGrant`, spent with the
approval that made it. Same mechanism and same three properties as the MCP door's
OAuth-consent projection (`mcpConsentGrant`, `registry.ts:398`), which is where
the pattern comes from.

**3. `packages/core/src/grants.ts`** — `"approval"` joins `PermissionGrant`'s
`source` union, documented at the type exactly as `"mcp"` is. It is never
persisted, so no store row can carry it and no schema mirror moves.

## The consent boundary, explicitly

- **No standing authority.** Asserted, not asserted-about: after the tap `GET
  /grants` is empty and the next call parks on its own account. Each distinct call
  asks once.
- **`presence: "away"` is unchanged.** The box keeps its unattended
  classification.
- **The registry's away rule is untouched.** An ungranted away call with no
  approval behind it still refuses in the same words — still asserted by
  `actions/tests/runtime/fixture.e2e.test.ts:314`.
- **Nothing widens.** Only `presence: "away"` reaches the projection, and MCP door
  contexts are hardcoded `presence: "present"` (`mcp/door.ts:824, 1757`), so
  venue="mcp" host execution is unaffected.

## The test, and what it cost to trust it

`packages/vendo/tests/box-approve-resume.e2e.test.ts` — the real chain, **nothing
seeded**: composed umbrella (`createVendo`) → real PGlite store → box callback
door with a real minted app token → `apps.call` → real guard → real actions
registry over a ROUTE binding → real `actAs` seam → a real `node:http` host server
that only serves an authenticated caller and really deletes the invoice. The
approval is decided over the real wire (`POST /approvals/decide`).

It went red twice, for two different right reasons:

1. Before any fix — the invoice **survived** the approval
   (`expected true to be false`, `:174`). Nothing resumed.
2. With parking wired but no away authority — the resume **ran** and came back
   `{ state: "executed", outcome: { status: "error" } }`. That is the
   `registry.ts:617` refusal, reached only because the tap now re-dispatches.

The observable is the invoice, not a status string. Two more cases guard the
consent boundary: a denied call never runs, and after an approved one there are no
grants and the next call asks again.

`fixtures/integration/tests/machine-skin.e2e.test.ts` is **untouched** (`git diff`
on it is empty). Its hand-seeded grant is no longer the only way a box call can be
authorized, but it still covers the whole callback/env/secret boundary, so it is
not redundant — that call is not mine to make either way.

## Inherited break, flagged not fixed

`demo-bank#build` fails on the base branch: `DEFAULT_TRIGGER_ID` is imported by
five `examples/demo-bank` call sites and was removed from core by `163db4cb4`
(`feat(core)!: an automation is a record, not an app with triggers`). Evidence and
call sites in `/home/ubuntu/handoff/PARKED-s2i.md`. Not touched — another lane's
files, unrelated to this fix.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Boxed apps can now run host tools after a single approval. Previously, `/box/tools/<name>` asked for approval but never resumed, and away calls failed without a captured grant; now the call goes through the app action door and the guard projects the consumed approval into a one-time `"approval"` grant that authenticates the replay via `actAs`. Each distinct call asks once; no standing permission is minted.

- `@vendoai/vendo`: `/box/tools/<name>` now dispatches via `deps.apps.call(appId, name, args, ctx)` so parked calls are recorded and resumed; outcome redaction uses the real `appId`.
- `@vendoai/guard`: away execution reads a consumed approval as a transient grant (`source: "approval"`, scope `exact` to the shown arguments) to satisfy the `actAs` seam; no persisted grants are created or matched.
- `@vendoai/core`: adds `"approval"` to `PermissionGrant.source`; never persisted and never returned by `GET /grants`.
- Docs: `/box/tools/<name>` notes that approving runs that exact call.
- Tests: adds an end-to-end test proving park, approve, resume, and no standing authority.

**Review and rollout**

- No schema migration. The new `"approval"` source appears only in in-memory grant projection; persisted data and `GET /grants` remain unchanged.
- Code that narrows `PermissionGrant.source` by enum should include `"approval"` in type checks; no behavior change is required unless matching on sources.

<sup>Written for commit b4d70590f0fc2673beabded84ea8193ca7517239. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

