### PR TITLE
feat(genbench): the matrix grows four columns — three flagships bought through one door and a second agent at the bench

### DIFF
--- a/genbench/README.md
+++ b/genbench/README.md
@@ -2,14 +2,16 @@
 
 Answers "why not build this in-house?" with numbers.
 
-It runs hand-written prompts through four contenders — the real Vendo pipeline,
-two raw-Claude baselines and one bought product — against fourteen fictional
-products defined entirely in JSON, scores what comes back, and measures time and
-money. The three in-house contenders get the same model, the same tools, the same
-schemas, the same design brief and the same harness contract, because that
-equivalence is the whole claim; the bought product gets the same world and is
-configured as its own vendor says to configure it, which is a different claim and
-is spelled out under [The bought product](#the-bought-product).
+It runs hand-written prompts through five contenders — the real Vendo pipeline,
+two raw-Claude baselines, a rival coding agent and one bought product — against
+fourteen fictional products defined entirely in JSON, scores what comes back, and
+measures time and money. The three Claude contenders get the same model, the same
+tools, the same schemas, the same design brief and the same harness contract,
+because that equivalence is the whole claim; `codex` asks that same in-house
+question of another vendor's agent, so it brings its own engine and its own
+model; the bought product gets the same world and is configured as its own vendor
+says to configure it, which is a different claim and is spelled out under
+[The bought product](#the-bought-product).
 
 ## The contenders
 
@@ -19,8 +21,9 @@ is spelled out under [The bought product](#the-bought-product).
 | `diy` | the cheap in-house build: ONE `streamText` call, one HTML document, no product. Its artifact IS the page — no compile, no Kit, no mount |
 | `claude-code` | the strong in-house build: the stock Claude Agent SDK with its stock loadout — Bash included — writing and rewriting one `index.html` in a scratch directory. What is taken away is isolation and not capability: the operator's own settings, MCP config and shell environment stay out, because a laptop's private tooling would silently become this column's advantage. Its artifact IS the page too, and it is billed by its own session rather than by the run's meter |
 | `thesys` | the BOUGHT build: Thesys C1 (docs.thesys.dev), a hosted generative-UI API — the closest competing product on the market. Not another way to prompt a model, but a purchase: their model, their system prompt, their UI DSL, their React renderer. Its artifact IS the page, with their renderer inlined into it. See [The bought product](#the-bought-product) |
+| `codex` | the same build from the other vendor: OpenAI's Codex CLI with its stock loadout, writing and rewriting one `index.html` in a scratch directory, and isolated from the operator's own `~/.codex` config for the reason `claude-code` is isolated from theirs. Its artifact IS the page too, and it is billed by its own session against the OpenAI platform account |
 
-The three in-house columns are handed the same thing, and that is asserted rather
+The three Claude columns are handed the same thing, and that is asserted rather
 than asserted-to-be. There are exactly **two shared texts** — `worldBlock` in
 `src/vendo.ts`, the world every contender is briefed on, and `HARNESS_CONTRACT`
 in `src/render.ts`, the mechanical seam every page-writing contender must satisfy
@@ -106,10 +109,11 @@ timeout is recorded as its own failure without touching its siblings. Column
 order is the declaration order in `DRIVERS`, never the order they finished.
 
 The case budget is **per contender** (`CASE_TIMEOUT_MS`), not one number for the
-row: `vendo`, `diy` and `thesys` answer in one call and keep a five-minute bound, while
-`claude-code` runs its own ten-minute wall clock inside the driver before it has
-delivered anything, so its case gets twelve. A shared five-minute bound would
-have ended that column early and reported a timeout the contender never had.
+row: `vendo`, `diy` and `thesys` answer in one call and keep a five-minute bound,
+while `claude-code` and `codex` each run their own ten-minute wall clock inside
+the driver before they have delivered anything, so those cases get twelve. A
+shared five-minute bound would have ended both columns early and reported a
+timeout neither contender ever had.
 
 ## Run it
 
@@ -120,7 +124,7 @@ ANTHROPIC_API_KEY=… pnpm genbench run --prompt spend-overview
 
 Each case writes `runs/<run>/<contender>/<case>/`, where `<contender>` is the
 column's slug — `<harness>-<model>`, e.g. `vendo-sonnet`, `diy-opus`,
-`claude-code-haiku`, `thesys-c1`:
+`claude-code-haiku`, `thesys-c1`, `codex-sol`:
 
 | file | what it is |
 | --- | --- |
@@ -166,15 +170,30 @@ It stays one static file — no server, offline, forever. A contender that
 outruns its budget is recorded `failure: "timeout"`; its siblings finish
 normally.
 
-Flags: `--prompt <id>` for one case, `--models sonnet,opus,haiku`,
-`--world <name>` (default `maple`) or `--world all` for every world in one run
-folder — which is the only way to get one number for the whole corpus.
+Flags: `--prompt <id>` for one case, `--models sonnet,opus,haiku`, `--world
+<name>` (default `maple`), a comma list like `--world maple,buildlog`, or
+`--world all` for every world in one run folder — which is the only way to get
+one number for the whole corpus.
 
-The bought column runs on its own alias and its own key, so racing it against the
-in-house three is `--models sonnet,c1` with `THESYS_API_KEY` set beside
-`ANTHROPIC_API_KEY`. Asking for `c1` without that key fails before the first
-case rather than a case and a browser later; asking for it without `thesys` in
-`--contenders` produces no column, because no other harness may run that alias.
+`--contenders` takes a bare harness, crossed with every `--models` alias, or a
+pinned `harness:model` pair, which is exactly that column and skips the cross —
+so `--contenders vendo,diy:gpt,codex:sol` is those three columns and nothing
+else. The matrix stopped being a rectangle once some columns had a model line of
+their own, and naming a model to get one column of it used to cross that model
+onto every other harness in the row.
+
+The frontier arrives through OpenRouter as one alias per vendor: `claude`
+(`anthropic/claude-opus-5`), `gpt` (`openai/gpt-5.6-sol`) and `gemini`
+(`google/gemini-3.1-pro-preview`). All three run on `diy` alone — the one column
+that is nothing but a model call, which is what makes three vendors comparable —
+and they need `OPENROUTER_API_KEY`.
+
+The two product columns each run their own alias and nothing else, and no other
+column may run theirs: `thesys` on `c1` with `THESYS_API_KEY`, `codex` on `sol`
+with `OPENAI_API_KEY`, both beside `ANTHROPIC_API_KEY`, which the judge and the
+honesty check need whoever built the screen. Every key is demanded before the
+first case rather than a case and a browser later, and only for the columns the
+row really runs: narrowing `--contenders` narrows what is demanded with it.
 
 A `--prompt` run opens the preview on macOS when it finishes — that is one
 person watching one case, and a window is the point of it. A full run prints the
@@ -217,6 +236,16 @@ than smuggled into the token table. A plan's included calls are a subscription n
 other column has, and this benchmark does not model one. In practice one case on
 this column is a few cents: its prompt carries their own ~18k-token system prompt,
 which is billed to us on every call and cannot be read.
+
+The router's rows and the codex row are **priced as of 2026-08-17**. OpenRouter's
+own listing gives `anthropic/claude-opus-5` at $5/$25 — identical to first-party —
+`openai/gpt-5.6-sol` at $5/$30 and `google/gemini-3.1-pro-preview` at $2/$12,
+those two being the ≤272k and ≤200k context tiers, which a 10-20k-token genbench
+prompt never leaves. OpenRouter takes **0% on tokens**: what it really charges is
+5.5% (min $0.80) on credit top-ups, which is not a per-token price and is
+therefore in no number this benchmark produces. `codex` is priced at OpenAI's own
+list rate for the same model ($5/$30), because its CLI bills the platform account
+directly rather than through the router.
 
 ## The world
 
@@ -285,7 +314,7 @@ harness itself runs. Neither model can clear a number on its own word:
 - **valid** — the product's *own* checks floor blocks nothing in the saved bytes.
   Not the same as "something painted": the agent can save again after its last
   good view, and the seam keeps the older screen. A contender with no compile
-  step has nothing to block, so for `diy` and `claude-code` this check collapses
+  step has nothing to block, so for `diy`, `claude-code` and `codex` this check collapses
   onto `delivered` — the checks that do the work on a hand-written page are `renders`,
   `honestData` and `wiredActions`, and all three are the same code
 - **honestData** — every number on screen traces back to the tools, in three

--- a/genbench/package.json
+++ b/genbench/package.json
@@ -28,6 +28,7 @@
     "@anthropic-ai/claude-agent-sdk": ">=0.3.0 <1",
     "@crayonai/react-core": "0.7.7",
     "@crayonai/react-ui": "0.9.16",
+    "@openai/codex": "^0.147.0",
     "@playwright/test": "^1.49.0",
     "@radix-ui/react-dialog": "^1.1.23",
     "@thesysai/genui-sdk": "0.9.2",

--- a/genbench/src/codex.ts
+++ b/genbench/src/codex.ts
@@ -1,0 +1,275 @@
+/**
+ * The codex contender — the strong in-house baseline on the other side of the
+ * house: OpenAI's own coding agent, headless, working in a scratch directory and
+ * writing and rewriting one page. It is the peer of `claude-code` in everything
+ * the comparison rests on — the SAME world block, the same harness contract and
+ * the same case prompt, in the same bytes — and differs only in whose engine
+ * holds the pen.
+ *
+ * It is billed by its OWN session, not by genbench's metered model: the CLI
+ * spawns its own engine and never touches `meter.model`. So the tokens ride the
+ * outcome instead, priced through the same `usdFor` table as every other column.
+ * The meter is still the run's clock, and the only one.
+ */
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { MODEL_IDS, usdFor, type ModelAlias, type UsageTotals } from "./meter.js";
+import { HARNESS_CONTRACT } from "./render.js";
+import type { Contender, RunOutcome, RunRequest } from "./run.js";
+import { worldBlock } from "./vendo.js";
+import type { Case, World } from "./world.js";
+
+/** The bits of a `codex exec` process this driver uses: the `--json` stream it
+ *  prints, and a way to end it. */
+export interface CodexSession {
+  /** stdout as it arrives — chunks, which need not be whole lines. */
+  readonly output: AsyncIterable<string>;
+  kill(): void;
+}
+
+/** Test seam, at the process boundary the way `claude-code`'s is at the SDK's:
+ *  everything above it — the workspace, the brief, the event stream, the wall
+ *  clock — is the driver's own behaviour under test. */
+export type CodexSpawn = (
+  command: string,
+  args: readonly string[],
+  options: { cwd: string; env: Record<string, string> },
+) => CodexSession;
+
+export interface CodexOptions {
+  /** Which model the session thinks with. The run's matrix picks it. */
+  readonly model: ModelAlias;
+  /** Test seam — production spawns the pinned CLI. */
+  readonly spawn?: CodexSpawn;
+  /** Test seam; production uses {@link WALL_CLOCK_MS}. */
+  readonly timeoutMs?: number;
+}
+
+/** Agentic builds are slower than one generation call — a wall clock, not a
+ *  step count. Exported because this column's case budget in `run.ts` has to
+ *  outlast it: a case that ends first would report a timeout the contender
+ *  never had. */
+export const WALL_CLOCK_MS = 10 * 60_000;
+
+/** How long a session that outran the wall clock gets to stop being asked
+ *  before it is made to. */
+const KILL_GRACE_MS = 2_000;
+
+const PAGE = "index.html";
+
+/** Where this contender leaves its page, and nothing else — every rule the page
+ *  itself has to satisfy is the shared `HARNESS_CONTRACT`, in the bytes every
+ *  other page-writing column is handed. */
+const DELIVERY = `Write ONE file, \`${PAGE}\`, in your working directory: a complete document, saved over again each time you revise it. Nothing else is read.`;
+
+const brief = (world: World, testCase: Case): string =>
+  [worldBlock(world), "", DELIVERY, "", HARNESS_CONTRACT, "", `TASK: ${testCase.prompt}`].join("\n");
+
+/** The pinned devDependency's own binary, never a bare `codex`: the operator's
+ *  global install is some other version, and which engine wrote the page is part
+ *  of what a run reports. */
+const CODEX = join(dirname(fileURLToPath(import.meta.url)), "..", "node_modules", ".bin", "codex");
+
+/**
+ * The whole invocation, in one place.
+ *
+ * `workspace-write` is the loadout a team really runs headless — and it disables
+ * the network, which would handicap this column against `claude-code`'s stock
+ * Bash, so the network is turned back on by config override rather than by
+ * widening the sandbox to `danger-full-access`. There is no approval flag:
+ * `codex exec` never asks, and 0.147.0 rejects `-a` outright.
+ */
+const invocation = (workspace: string, modelId: string, prompt: string): readonly string[] => [
+  "exec",
+  "--cd",
+  workspace,
+  "--sandbox",
+  "workspace-write",
+  "--skip-git-repo-check",
+  "--json",
+  "-c",
+  "sandbox_workspace_write.network_access=true",
+  "-m",
+  modelId,
+  prompt,
+];
+
+/**
+ * The subprocess's whole environment, spelled out rather than inherited — the
+ * same rule as `claude-code`'s and for the same reason: an `OPENAI_BASE_URL` or
+ * a `CODEX_*` left in the operator's shell reshapes this column and no
+ * `result.json` would say so.
+ *
+ * `CODEX_HOME` is the fourth name because it IS the isolation: the operator's
+ * own `~/.codex` carries private plugins and MCP servers that would silently
+ * become this column's advantage, and its state files take locks that parallel
+ * sessions would fight over. A throwaway home also holds no `auth.json`, so the
+ * key below is what authenticates — the CLI reads `CODEX_API_KEY`, then
+ * `auth.json`, then `OPENAI_API_KEY`, and this column deliberately offers only
+ * the last.
+ */
+function sessionEnv(codexHome: string): Record<string, string> {
+  const env: Record<string, string> = { CODEX_HOME: codexHome };
+  for (const name of ["PATH", "HOME", "OPENAI_API_KEY"]) {
+    const value = process.env[name];
+    if (value !== undefined) env[name] = value;
+  }
+  return env;
+}
+
+/** The real process. stdin is IGNORED rather than merely unused: `codex exec`
+ *  reads an open non-TTY stdin to the end before it starts, so a pipe nobody
+ *  writes to hangs the session for its whole wall clock. stderr goes the same
+ *  way — it carries the CLI's tracing rather than the run's events, and a pipe
+ *  nobody drains fills up and blocks the child. */
+const spawnCodex: CodexSpawn = (command, args, options) => {
+  const child = spawn(command, args, { ...options, stdio: ["ignore", "pipe", "ignore"] });
+  const stdout = child.stdout!;
+  // A binary that never started would otherwise read as a session that said
+  // nothing, which is this column's own way of failing a case.
+  child.on("error", (error) => stdout.destroy(error));
+  return {
+    output: stdout.setEncoding("utf8"),
+    kill: () => {
+      child.kill("SIGTERM");
+      setTimeout(() => child.kill("SIGKILL"), KILL_GRACE_MS).unref();
+    },
+  };
+};
+
+/** The `--json` stream, one event per line. A line that is not JSON is the CLI
+ *  talking to a person and is dropped; a half line is held until the rest of it
+ *  arrives, because stdout chunks do not land on line boundaries. */
+async function* events(output: AsyncIterable<string>): AsyncGenerator<Record<string, unknown>> {
+  let held = "";
+  for await (const chunk of output) {
+    const lines = (held + chunk).split("\n");
+    held = lines.pop() ?? "";
+    for (const line of lines) {
+      if (line.startsWith("{")) yield JSON.parse(line) as Record<string, unknown>;
+    }
+  }
+}
+
+const numberOf = (value: unknown): number => (typeof value === "number" && Number.isFinite(value) ? value : 0);
+
+/** A completed turn's `usage` block in the vocabulary the report already speaks.
+ *  `input_tokens` is the WHOLE input including both cache halves, so the full
+ *  rate applies to what is left after subtracting them — the same arithmetic
+ *  `meteredModel` does for a provider that reports only a total. Reasoning
+ *  tokens are a subset of `output_tokens` rather than a number beside it, and
+ *  adding them would bill this column's thinking twice. */
+function record(totals: Record<keyof UsageTotals, number>, raw: unknown): void {
+  const usage = (typeof raw === "object" && raw !== null ? raw : {}) as Record<string, unknown>;
+  const cacheRead = numberOf(usage["cached_input_tokens"]);
+  const cacheWrite = numberOf(usage["cache_write_input_tokens"]);
+  totals.inputTokens += Math.max(0, numberOf(usage["input_tokens"]) - cacheRead - cacheWrite);
+  totals.outputTokens += numberOf(usage["output_tokens"]);
+  totals.cacheReadTokens += cacheRead;
+  totals.cacheWriteTokens += cacheWrite;
+  totals.calls += 1;
+}
+
+/** `turn.failed` carries the CLI's own sentence for how it ended, and the report
+ *  should say which failure it was rather than that there was one. */
+const failureOf = (event: Record<string, unknown>): string =>
+  String((event["error"] as { message?: unknown } | undefined)?.message ?? "the session failed without saying why");
+
+export function codexDriver(options: CodexOptions): Contender {
+  return { run: async (request) => await run(request, options) };
+}
+
+async function run(request: RunRequest, options: CodexOptions): Promise<RunOutcome> {
+  const { world, testCase, meter } = request;
+  const modelId = MODEL_IDS[options.model];
+  const workspace = await mkdtemp(join(tmpdir(), `genbench-${testCase.id}-`));
+  // A SIBLING of the workspace, never a directory inside it: `workspace-write`
+  // makes the workspace the only writable place and the CLI's home is state it
+  // has to write, so a home under the workspace is a session that cannot start —
+  // and one more directory the page's author can see.
+  const home = await mkdtemp(join(tmpdir(), "genbench-codex-"));
+  const page = join(workspace, PAGE);
+  const usage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, calls: 0 };
+  let turns = 0;
+  let artifact: string | undefined;
+  let firstRenderMs: number | undefined;
+  let failure: string | undefined;
+  let settledMs = 0;
+
+  /** The page as it stands, when it has changed. A write is only on disk once
+   *  the tool that made it has returned, so looking between events sees every
+   *  revision and never half of one — the first is the first moment there was
+   *  anything to paint, and the last is what the session delivered. */
+  const observe = async (): Promise<void> => {
+    const html = await readFile(page, "utf8").catch(() => undefined);
+    if (html === undefined || html === artifact) return;
+    firstRenderMs ??= meter.elapsedMs();
+    artifact = html;
+  };
+
+  try {
+    const session = (options.spawn ?? spawnCodex)(CODEX, invocation(workspace, modelId, brief(world, testCase)), {
+      cwd: workspace,
+      env: sessionEnv(home),
+    });
+    // The case's own budget, forwarded: a column whose case has already been
+    // recorded is a session nobody is waiting for, and it holds a laptop's worth
+    // of engine while the row moves on.
+    request.signal?.addEventListener("abort", () => session.kill());
+    const drain = (async () => {
+      for await (const event of events(session.output)) {
+        await observe();
+        // Every turn's tokens as they land. A session killed at the wall clock
+        // still burned them, and a column that reports $0.0000 for ten minutes
+        // of engine is the cheapest on the board by having failed.
+        if (event["type"] === "turn.completed") {
+          record(usage, event["usage"]);
+          turns += 1;
+        }
+        if (event["type"] === "turn.failed") failure = failureOf(event);
+      }
+    })();
+    const finished = await Promise.race([
+      drain.then(() => true),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), options.timeoutMs ?? WALL_CLOCK_MS).unref()),
+    ]);
+    if (!finished) {
+      // The session is told to stop, and the run does not wait to see it happen:
+      // a loop that already outran its budget is not one to hand the clock back
+      // to. Its rejection is absorbed so it cannot surface as an unhandled one.
+      session.kill();
+      void drain.catch(() => undefined);
+      failure = "timeout";
+    }
+  } catch (error) {
+    failure = error instanceof Error ? error.message : String(error);
+  } finally {
+    // Whatever is on disk when the session ends is what it delivered — a run
+    // that timed out still delivered the last page it wrote.
+    await observe();
+    settledMs = meter.elapsedMs();
+    await rm(workspace, { recursive: true, force: true });
+    await rm(home, { recursive: true, force: true });
+  }
+
+  return {
+    format: "html",
+    ...(artifact === undefined ? {} : { artifact }),
+    // Nothing stands between these bytes and the browser: no compile to fail, so
+    // no finding the product's own floor could raise about them.
+    blocking: [],
+    snapshots: [],
+    usage,
+    usd: usdFor(usage, modelId),
+    // How hard the session had to work, which is all it says about itself beyond
+    // its tokens: the CLI reports no dollar figure of its own, so `billedUsd` is
+    // absent rather than a zero that would read as a free session.
+    session: { turns },
+    ...(firstRenderMs === undefined ? {} : { firstRenderMs }),
+    settledMs,
+    ...(failure === undefined ? {} : { failure }),
+  };
+}

--- a/genbench/src/codex.ts
+++ b/genbench/src/codex.ts
@@ -103,17 +103,24 @@ const invocation = (workspace: string, modelId: string, prompt: string): readonl
  * a `CODEX_*` left in the operator's shell reshapes this column and no
  * `result.json` would say so.
  *
- * `CODEX_HOME` is the fourth name because it IS the isolation: the operator's
- * own `~/.codex` carries private plugins and MCP servers that would silently
- * become this column's advantage, and its state files take locks that parallel
- * sessions would fight over. A throwaway home also holds no `auth.json`, so the
- * key below is what authenticates — the CLI reads `CODEX_API_KEY`, then
- * `auth.json`, then `OPENAI_API_KEY`, and this column deliberately offers only
- * the last.
+ * `CODEX_HOME` is the isolation itself: the operator's own `~/.codex` carries
+ * private plugins and MCP servers that would silently become this column's
+ * advantage, and its state files take locks that parallel sessions fight over.
+ *
+ * The key goes in under the name the CLI actually reads. It arrives as
+ * `OPENAI_API_KEY`, which is the run's one name for it, and leaves as
+ * `CODEX_API_KEY`, because 0.147.0 with a fresh home reads neither an
+ * `auth.json` (there is none) nor `OPENAI_API_KEY`: it sends no `Authorization`
+ * header at all and the first call dies on `401 … Missing bearer`, with a live
+ * key sitting right there in the environment.
  */
 function sessionEnv(codexHome: string): Record<string, string> {
-  const env: Record<string, string> = { CODEX_HOME: codexHome };
-  for (const name of ["PATH", "HOME", "OPENAI_API_KEY"]) {
+  const key = process.env["OPENAI_API_KEY"];
+  const env: Record<string, string> = {
+    CODEX_HOME: codexHome,
+    ...(key === undefined ? {} : { CODEX_API_KEY: key }),
+  };
+  for (const name of ["PATH", "HOME"]) {
     const value = process.env[name];
     if (value !== undefined) env[name] = value;
   }

--- a/genbench/src/codex.ts
+++ b/genbench/src/codex.ts
@@ -147,18 +147,35 @@ const spawnCodex: CodexSpawn = (command, args, options) => {
   };
 };
 
-/** The `--json` stream, one event per line. A line that is not JSON is the CLI
- *  talking to a person and is dropped; a half line is held until the rest of it
- *  arrives, because stdout chunks do not land on line boundaries. */
+/** One line of the `--json` stream, or nothing: a line the CLI wrote for a
+ *  person to read, and the half line a killed process leaves behind, are both
+ *  things this driver has no use for. */
+const parsed = (line: string): Record<string, unknown> | undefined => {
+  if (!line.startsWith("{")) return undefined;
+  try {
+    return JSON.parse(line) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+};
+
+/** The `--json` stream, one event per line. A half line is held until the rest
+ *  of it arrives, because stdout chunks do not land on line boundaries. */
 async function* events(output: AsyncIterable<string>): AsyncGenerator<Record<string, unknown>> {
   let held = "";
   for await (const chunk of output) {
     const lines = (held + chunk).split("\n");
     held = lines.pop() ?? "";
     for (const line of lines) {
-      if (line.startsWith("{")) yield JSON.parse(line) as Record<string, unknown>;
+      const event = parsed(line);
+      if (event !== undefined) yield event;
     }
   }
+  // A stream can end on a whole event with nothing after it, and the last event
+  // a session sends is the one carrying its tokens: held back and never flushed,
+  // a finished session bills at zero.
+  const last = parsed(held);
+  if (last !== undefined) yield last;
 }
 
 const numberOf = (value: unknown): number => (typeof value === "number" && Number.isFinite(value) ? value : 0);

--- a/genbench/src/meter.ts
+++ b/genbench/src/meter.ts
@@ -19,12 +19,32 @@ export const WAFER_BASE_URL = "https://pass.wafer.ai/v1";
  *  confirmed against the live endpoint. */
 export const THESYS_MODEL_IDS = { c1: "c1/anthropic/claude-sonnet-4.6/v-20260331" } as const;
 
+/** One frontier model per vendor, all three through OpenRouter's single
+ *  OpenAI-compatible endpoint. One alias per vendor rather than a menu: this is
+ *  the cross-vendor row, and a vendor's second-best model answers a question
+ *  nobody asked. Membership here is what says an alias is served by the router —
+ *  the provider a run builds for it, the key it demands and the one harness it
+ *  may run under all read this. */
+export const OPENROUTER_MODEL_IDS = {
+  claude: "anthropic/claude-opus-5",
+  gpt: "openai/gpt-5.6-sol",
+  gemini: "google/gemini-3.1-pro-preview",
+} as const;
+
+/** The Codex CLI's own model line. That column spawns OpenAI's engine and never
+ *  reads `meter.model`, exactly as `claude-code` spawns Anthropic's, so the id
+ *  here is what prices its session rather than what a provider is built from.
+ *  One alias, and `contenders` in `run.ts` is what keeps it to it. */
+export const CODEX_MODEL_IDS = { sol: "gpt-5.6-sol" } as const;
+
 export type ModelAlias =
   | "opus"
   | "sonnet"
   | "haiku"
   | keyof typeof WAFER_MODEL_IDS
-  | keyof typeof THESYS_MODEL_IDS;
+  | keyof typeof THESYS_MODEL_IDS
+  | keyof typeof OPENROUTER_MODEL_IDS
+  | keyof typeof CODEX_MODEL_IDS;
 
 /**
  * Pinned ids. Each one was checked against the live API through
@@ -43,6 +63,8 @@ export const MODEL_IDS: Readonly<Record<ModelAlias, string>> = {
   haiku: "claude-haiku-4-5-20251001",
   ...WAFER_MODEL_IDS,
   ...THESYS_MODEL_IDS,
+  ...OPENROUTER_MODEL_IDS,
+  ...CODEX_MODEL_IDS,
 };
 
 interface ModelPrice {
@@ -71,6 +93,20 @@ const PRICING: Readonly<Record<string, ModelPrice>> = {
   // flat per-call platform fee is not a token rate and is billed by the driver
   // (`THESYS_CALL_USD` in `thesys.ts`) rather than smuggled in here.
   "c1/anthropic/claude-sonnet-4.6/v-20260331": { inputPerMTok: 3, outputPerMTok: 15 },
+  // The three router rows, read off OpenRouter's models API on 2026-08-17.
+  // OpenRouter takes 0% on tokens, so each is the vendor's own list rate — what
+  // it really charges is 5.5% (min $0.80) on credit TOP-UPS, which is not a
+  // per-token price and so is in no number this meter can produce.
+  // Identical to Anthropic's first-party Opus 5 rate above.
+  "anthropic/claude-opus-5": { inputPerMTok: 5, outputPerMTok: 25 },
+  // The ≤272k-context tier. A genbench prompt is 10-20k tokens, so the $10/$45
+  // tier above it is unreachable here.
+  "openai/gpt-5.6-sol": { inputPerMTok: 5, outputPerMTok: 30 },
+  // The ≤200k tier; Google still labels the model preview.
+  "google/gemini-3.1-pro-preview": { inputPerMTok: 2, outputPerMTok: 12 },
+  // OpenAI's own list rate (platform.openai.com/pricing, read 2026-08-17), not
+  // the router's: the codex CLI bills the platform account directly.
+  "gpt-5.6-sol": { inputPerMTok: 5, outputPerMTok: 30 },
 };
 
 /** Cache reads bill at a tenth of the input rate; 5-minute cache writes at 1.25x. */

--- a/genbench/src/run.ts
+++ b/genbench/src/run.ts
@@ -273,7 +273,12 @@ export function contenders(
       `genbench: ${asked.join(", ")} has no column for ${models.join(", ")} — name an Anthropic model, or another contender`,
     );
   }
-  return row;
+  // By slug, because the slug IS the column: it names the evidence directory and
+  // the report column, so `vendo,vendo:sonnet` has to be one column asked for
+  // twice rather than two contenders racing to overwrite one folder and be
+  // counted twice in the summary. The Map keeps the position of the first
+  // mention, which is the same doctrine as declaration order being column order.
+  return [...new Map(row.map((contender) => [contender.slug, contender])).values()];
 }
 
 /**

--- a/genbench/src/run.ts
+++ b/genbench/src/run.ts
@@ -456,7 +456,13 @@ export async function writeCase(
  *  total anywhere, so the question the benchmark exists to answer had nowhere to
  *  be answered. */
 export async function worldsFor(worldsDir: string, world: string): Promise<readonly string[]> {
-  if (world !== ALL_WORLDS) return world.split(",");
+  // Unique and first-seen, because the folder name IS the evidence key:
+  // `maple,maple` wrote every contender's `maple/<case>` twice, the second pass
+  // replacing the first's artifacts while both counted in the summary. `all`
+  // anywhere in the list takes the whole corpus, which is why it needs no dedupe
+  // of its own: it already contains every name written beside it.
+  const named = [...new Set(world.split(","))];
+  if (!named.includes(ALL_WORLDS)) return named;
   const entries = await readdir(worldsDir, { withFileTypes: true });
   return entries
     .filter((entry) => entry.isDirectory())

--- a/genbench/src/run.ts
+++ b/genbench/src/run.ts
@@ -7,13 +7,16 @@ import { createRequire } from "node:module";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { auditFloor, AUDITOR_CONTRACT } from "./audit.js";
-import { claudeCodeDriver, WALL_CLOCK_MS, type SessionRecord } from "./claude-code.js";
+import { claudeCodeDriver, WALL_CLOCK_MS as CLAUDE_CODE_WALL_CLOCK_MS, type SessionRecord } from "./claude-code.js";
+import { codexDriver, WALL_CLOCK_MS as CODEX_WALL_CLOCK_MS } from "./codex.js";
 import { diyDriver } from "./diy.js";
 import { checks, runFloor, type FloorResult } from "./floor.js";
 import { judge, JudgeContract, rubricLines, type JudgeResult } from "./judge.js";
 import {
+  CODEX_MODEL_IDS,
   meteredModel,
   MODEL_IDS,
+  OPENROUTER_MODEL_IDS,
   THESYS_MODEL_IDS,
   WAFER_BASE_URL,
   WAFER_MODEL_IDS,
@@ -29,7 +32,7 @@ import { TriageContract } from "./triage.js";
 import { vendoDriver } from "./vendo.js";
 import { caseHash, loadCases, loadWorld, worldForCase, type Case, type CaseShape, type Lane, type World } from "./world.js";
 
-export type HarnessId = "vendo" | "diy" | "claude-code" | "thesys";
+export type HarnessId = "vendo" | "diy" | "claude-code" | "thesys" | "codex";
 
 export interface ContenderId {
   readonly harness: HarnessId;
@@ -146,6 +149,7 @@ const DRIVERS: Record<HarnessId, (model: ModelAlias) => Contender> = {
   diy: diyDriver,
   "claude-code": (model) => claudeCodeDriver({ model }),
   thesys: thesysDriver,
+  codex: (model) => codexDriver({ model }),
 };
 
 const HARNESS_IDS = Object.keys(DRIVERS) as readonly HarnessId[];
@@ -159,14 +163,22 @@ const DEFAULT_WORLD = "maple";
  *  disconnected run folders. */
 const ALL_WORLDS = "all";
 
+/** What `--contenders` takes: a bare harness, crossed with every `--models`
+ *  alias, or one pinned `harness:model` pair, which is exactly that column and
+ *  nothing else. The matrix stopped being a rectangle once some columns had a
+ *  model line of their own — naming a model to get one column of it also crossed
+ *  that model onto every other harness in the list. */
+export type Column = HarnessId | { readonly harness: HarnessId; readonly model: ModelAlias };
+
 export interface Args {
   readonly only?: string;
   readonly models: readonly ModelAlias[];
   /** A folder under `worlds/`, holding `world.json`, `cases.json` and any face —
-   *  or `all`, which is every folder there. */
+   *  or a comma list of them, or `all`, which is every folder there. */
   readonly world: string;
-  /** The harnesses that race each case. Every driver, unless narrowed. */
-  readonly contenders: readonly HarnessId[];
+  /** The columns that race each case. Every driver in every model, unless
+   *  narrowed. */
+  readonly contenders: readonly Column[];
   /** How many cases are in flight at once. */
   readonly jobs: number;
 }
@@ -176,7 +188,7 @@ export function parseArgs(argv: readonly string[]): Args {
   let only: string | undefined;
   let models: readonly ModelAlias[] = ["sonnet"];
   let world = DEFAULT_WORLD;
-  let harnesses = HARNESS_IDS;
+  let columns: readonly Column[] = HARNESS_IDS;
   let jobs = 1;
   let index = 0;
   while (index < rest.length) {
@@ -186,12 +198,12 @@ export function parseArgs(argv: readonly string[]): Args {
     if (flag === "--prompt") only = value;
     else if (flag === "--models") models = value.split(",").map(asAlias);
     else if (flag === "--world") world = value;
-    else if (flag === "--contenders") harnesses = value.split(",").map(asHarness);
+    else if (flag === "--contenders") columns = value.split(",").map(asColumn);
     else if (flag === "--jobs") jobs = asJobs(value);
     else throw new Error(`genbench: unexpected argument "${flag}"`);
     index += 2;
   }
-  return { ...(only === undefined ? {} : { only }), models, world, contenders: harnesses, jobs };
+  return { ...(only === undefined ? {} : { only }), models, world, contenders: columns, jobs };
 }
 
 function asAlias(value: string): ModelAlias {
@@ -204,38 +216,89 @@ function asHarness(value: string): HarnessId {
   return value as HarnessId;
 }
 
+function asColumn(value: string): Column {
+  const [harness, ...model] = value.split(":");
+  // Everything after the first colon is the model, so `a:b:c` is refused as the
+  // model `b:c` rather than silently run as `a:b`.
+  return model.length === 0 ? asHarness(value) : { harness: asHarness(harness!), model: asAlias(model.join(":")) };
+}
+
 function asJobs(value: string): number {
   const jobs = Number(value);
   if (!Number.isInteger(jobs) || jobs < 1) throw new Error(`genbench: --jobs takes whole cases, not "${value}"`);
   return jobs;
 }
 
-/** Every contender that has a driver today, in every model that driver can
- *  think with. Claude Code spawns its own Anthropic engine and never reads
- *  `meter.model`, so a Wafer alias would reach its Agent SDK as an Anthropic id
- *  and the column would report the harness's mistake as the model's score.
- *  `thesys` is a PRODUCT rather than a harness over a model — the vendor picks
- *  it, not us — so it runs its own alias and nothing else, and no other column
- *  may run that alias: it only resolves at their endpoint. */
+/** The harnesses that are a PRODUCT rather than a harness over a model — the
+ *  vendor picks it, not us. Each runs its own aliases and nothing else, and no
+ *  other column may run one of those: they only resolve at that vendor's
+ *  endpoint or inside that vendor's CLI. */
+const EXCLUSIVE: ReadonlyArray<readonly [HarnessId, Readonly<Record<string, string>>]> = [
+  ["thesys", THESYS_MODEL_IDS],
+  ["codex", CODEX_MODEL_IDS],
+];
+
+/** Whether this harness may think with this model at all. Claude Code spawns its
+ *  own Anthropic engine and never reads `meter.model`, so a Wafer alias would
+ *  reach its Agent SDK as an Anthropic id and the column would report the
+ *  harness's mistake as the model's score. The router's aliases are the
+ *  cross-VENDOR row and stay on `diy`, the one column that is nothing but a
+ *  model call, which is what makes three vendors comparable at all; anywhere
+ *  else they would double a column that already exists first-party, since
+ *  `anthropic/claude-opus-5` is the `opus` column with a middleman in front. */
+const runs = (harness: HarnessId, model: ModelAlias): boolean =>
+  EXCLUSIVE.every(([owner, ids]) => Object.hasOwn(ids, model) === (harness === owner)) &&
+  (harness !== "claude-code" || !Object.hasOwn(WAFER_MODEL_IDS, model)) &&
+  (harness === "diy" || !Object.hasOwn(OPENROUTER_MODEL_IDS, model));
+
+/** Every contender that has a driver today, in every model that driver can think
+ *  with — except where a column was named as a `harness:model` pair, which is
+ *  that one column and skips the cross. Either way the rules above decide, so a
+ *  pair cannot ask for a column the matrix would never have produced. */
 export function contenders(
   models: readonly ModelAlias[],
-  harnesses: readonly HarnessId[] = HARNESS_IDS,
+  columns: readonly Column[] = HARNESS_IDS,
 ): readonly ContenderId[] {
-  const row = harnesses.flatMap((harness) =>
-    models
-      .filter((model) =>
-        Object.hasOwn(THESYS_MODEL_IDS, model)
-          ? harness === "thesys"
-          : harness !== "thesys" && (harness !== "claude-code" || !Object.hasOwn(WAFER_MODEL_IDS, model)),
-      )
-      .map((model) => ({ harness, model, slug: `${harness}-${model}` })),
-  );
+  const row = columns.flatMap((column) => {
+    const harness = typeof column === "string" ? column : column.harness;
+    return (typeof column === "string" ? models : [column.model])
+      .filter((model) => runs(harness, model))
+      .map((model) => ({ harness, model, slug: `${harness}-${model}` }));
+  });
   if (row.length === 0) {
+    // Named back the way it was asked for, pairs included, or the sentence
+    // cannot say which pairing emptied the row.
+    const asked = columns.map((column) => (typeof column === "string" ? column : `${column.harness}:${column.model}`));
     throw new Error(
-      `genbench: ${harnesses.join(", ")} has no column for ${models.join(", ")} — name an Anthropic model, or another contender`,
+      `genbench: ${asked.join(", ")} has no column for ${models.join(", ")} — name an Anthropic model, or another contender`,
     );
   }
   return row;
+}
+
+/**
+ * The first key the resolved row needs and has not been given, in words.
+ *
+ * Demanded up front rather than at the first call, which is a case and a browser
+ * later. Keyed off the ROW and not off `--models`, because narrowing
+ * `--contenders` drops columns: `--models sonnet,c1 --contenders vendo` runs no
+ * thesys column, and demanding its key would fail a run that never needed it.
+ * The Anthropic key is not in this table — the judge and the honesty check run
+ * on it whoever built the screen, so it is required whatever was asked for.
+ */
+export function missingKey(row: readonly ContenderId[], env: NodeJS.ProcessEnv): string | undefined {
+  for (const [name, ids] of [
+    ["WAFER_API_KEY", WAFER_MODEL_IDS],
+    ["THESYS_API_KEY", THESYS_MODEL_IDS],
+    ["OPENROUTER_API_KEY", OPENROUTER_MODEL_IDS],
+    ["OPENAI_API_KEY", CODEX_MODEL_IDS],
+  ] as const) {
+    const wanted = [...new Set(row.filter(({ model }) => Object.hasOwn(ids, model)).map(({ model }) => model))];
+    if (wanted.length > 0 && (env[name] ?? "") === "") {
+      return `genbench: ${name} is not set, and it is what serves ${wanted.join(", ")}`;
+    }
+  }
+  return undefined;
 }
 
 /**
@@ -267,16 +330,17 @@ const CHARTS = new Set(["LineChart", "BarChart", "DonutChart", "Sparkline"]);
  * One contender's whole budget for one case — generation, paint and probe.
  *
  * Per harness rather than one number for the row: an agentic build runs its own
- * ten-minute wall clock (`WALL_CLOCK_MS`) before it has delivered anything, so a
- * five-minute case would end it early and record a timeout the contender never
- * had. The one-call columns keep the tighter bound they have never needed more
- * than.
+ * ten-minute wall clock (`WALL_CLOCK_MS`, one per agentic driver) before it has
+ * delivered anything, so a five-minute case would end it early and record a
+ * timeout the contender never had. The one-call columns keep the tighter bound
+ * they have never needed more than.
  */
 export const CASE_TIMEOUT_MS: Readonly<Record<HarnessId, number>> = {
   vendo: 5 * 60_000,
   diy: 5 * 60_000,
-  "claude-code": WALL_CLOCK_MS + 2 * 60_000,
+  "claude-code": CLAUDE_CODE_WALL_CLOCK_MS + 2 * 60_000,
   thesys: 5 * 60_000,
+  codex: CODEX_WALL_CLOCK_MS + 2 * 60_000,
 };
 
 /**
@@ -382,12 +446,12 @@ export async function writeCase(
   await writeFile(join(caseDir, "result.json"), `${JSON.stringify(wrote.result, null, 2)}\n`);
 }
 
-/** The world folders one run covers: the one that was named, or every folder
+/** The world folders one run covers: the ones that were named, or every folder
  *  there. Fourteen worlds and 200 cases used to mean fourteen run folders and no
  *  total anywhere, so the question the benchmark exists to answer had nowhere to
  *  be answered. */
 export async function worldsFor(worldsDir: string, world: string): Promise<readonly string[]> {
-  if (world !== ALL_WORLDS) return [world];
+  if (world !== ALL_WORLDS) return world.split(",");
   const entries = await readdir(worldsDir, { withFileTypes: true });
   return entries
     .filter((entry) => entry.isDirectory())
@@ -422,25 +486,14 @@ async function main(argv: readonly string[]): Promise<number> {
   }
   // The row is built once, here, for the same reason the keys are demanded
   // here: a selection that leaves no column at all is a run with nothing to
-  // measure, and it should say so before a browser opens.
+  // measure, and it should say so before a browser opens. The preflight and the
+  // run itself then read that SAME list, so a key can never be demanded for a
+  // column that will not run.
   const row = contenders(args.models, args.contenders);
-
-  // Demanded up front rather than at the first call, which is a case and a
-  // browser later. The Anthropic key is still required whatever was asked for:
-  // the judge and the honesty check run on it, whoever built the screen.
-  // Keyed off the resolved row and not off `--models`, because narrowing
-  // `--contenders` drops columns: `--models sonnet,c1 --contenders vendo` runs
-  // no thesys column, and demanding its key would fail a run that never needed
-  // it.
-  for (const [name, ids] of [
-    ["WAFER_API_KEY", WAFER_MODEL_IDS],
-    ["THESYS_API_KEY", THESYS_MODEL_IDS],
-  ] as const) {
-    const wanted = [...new Set(row.filter(({ model }) => Object.hasOwn(ids, model)).map(({ model }) => model))];
-    if (wanted.length > 0 && (process.env[name] ?? "") === "") {
-      console.error(`genbench: ${name} is not set, and it is what serves ${wanted.join(", ")}`);
-      return 1;
-    }
+  const missing = missingKey(row, process.env);
+  if (missing !== undefined) {
+    console.error(missing);
+    return 1;
   }
 
   const root = dirname(dirname(fileURLToPath(import.meta.url)));
@@ -451,6 +504,14 @@ async function main(argv: readonly string[]): Promise<number> {
   const runDir = join(root, "runs", runId);
   const anthropic = createAnthropic({ apiKey });
   const wafer = createOpenAICompatible({ name: "wafer", baseURL: WAFER_BASE_URL, apiKey: process.env.WAFER_API_KEY });
+  // The official OpenRouter provider is AI SDK v7 only and this harness is on
+  // v6, so the router is reached through the same OpenAI-compatible adapter
+  // Wafer is — which is all their endpoint asks for.
+  const openrouter = createOpenAICompatible({
+    name: "openrouter",
+    baseURL: "https://openrouter.ai/api/v1",
+    apiKey: process.env.OPENROUTER_API_KEY,
+  });
   const thesys = thesysProvider({ apiKey: process.env.THESYS_API_KEY });
   const bundle = await bundleMount();
   const shooter = await openBrowser();
@@ -472,7 +533,9 @@ async function main(argv: readonly string[]): Promise<number> {
       ? wafer
       : Object.hasOwn(THESYS_MODEL_IDS, contender.model)
         ? thesys
-        : anthropic;
+        : Object.hasOwn(OPENROUTER_MODEL_IDS, contender.model)
+          ? openrouter
+          : anthropic;
     const meter = meteredModel(provider(modelId), modelId);
 
     /** Evidence as it is produced, not as it is returned. Losing the outer race

--- a/genbench/tests/codex.test.ts
+++ b/genbench/tests/codex.test.ts
@@ -232,6 +232,44 @@ describe("driving Codex", () => {
     expect(outcome.session).toEqual({ turns: 2 });
   });
 
+  /** stdout is not obliged to end on a newline, and the last line a session
+   *  writes is the one carrying its tokens: held back and never flushed, a whole
+   *  finished session bills at zero. */
+  it("bills a final event that arrives without a newline after it", async () => {
+    const unterminated: CodexSpawn = (_command, _args, options) => ({
+      output: (async function* () {
+        await writeFile(join(options.cwd, "index.html"), "<p>done</p>");
+        yield JSON.stringify({ type: "turn.completed", usage: TURN_USAGE });
+      })(),
+      kill: () => undefined,
+    });
+    const outcome = await runCase(unterminated);
+
+    expect(outcome.usage).toEqual(billed(1));
+    expect(outcome.session).toEqual({ turns: 1 });
+    expect(outcome.artifact).toBe("<p>done</p>");
+  });
+
+  /** The other half of that flush: what a killed process leaves at the end of
+   *  stdout is half a line, and parsing it throws. Swallowed, or the session's
+   *  own failure sentence is replaced by a JSON error about a line nobody
+   *  needed. */
+  it("swallows the half line a killed process leaves behind", async () => {
+    const cut: CodexSpawn = (_command, _args, options) => ({
+      output: (async function* () {
+        await writeFile(join(options.cwd, "index.html"), "<p>half</p>");
+        yield line({ type: "turn.completed", usage: TURN_USAGE });
+        yield '{"type":"item.completed","item":{"id":"item_1"';
+      })(),
+      kill: () => undefined,
+    });
+    const outcome = await runCase(cut);
+
+    expect(outcome.failure).toBeUndefined();
+    expect(outcome.usage).toEqual(billed(1));
+    expect(outcome.artifact).toBe("<p>half</p>");
+  });
+
   it("reports a session that ended badly as a failure, with whatever it wrote", async () => {
     const outcome = await runCase(
       writingCodex(["<p>half</p>"], {}, { type: "turn.failed", error: { message: "context window exhausted" } }),

--- a/genbench/tests/codex.test.ts
+++ b/genbench/tests/codex.test.ts
@@ -156,19 +156,29 @@ describe("driving Codex", () => {
     expect(seen.args!.at(-1)).toContain("Show my pending transfers");
   });
 
-  it("spells the subprocess environment out rather than handing over the operator's shell", async () => {
+  /** The allowlist, and the one rename in it. A live `OPENAI_API_KEY` is a key
+   *  0.147.0 never reads: with a fresh home it sends no `Authorization` header
+   *  at all, and the column's first call died on `401 … Missing bearer` for a
+   *  session that was holding a working key the whole time. */
+  it("spells the subprocess environment out, with the key under the name the CLI reads", async () => {
     const seen: Seen = {};
+    const held = process.env["OPENAI_API_KEY"];
+    process.env["OPENAI_API_KEY"] = "sk-not-a-key";
     process.env["OPENAI_BASE_URL"] = "https://a-gateway-nobody-declared.example";
     try {
       await runCase(writingCodex(["<html></html>"], seen));
     } finally {
+      if (held === undefined) delete process.env["OPENAI_API_KEY"];
+      else process.env["OPENAI_API_KEY"] = held;
       delete process.env["OPENAI_BASE_URL"];
     }
 
     const env = seen.options!.env;
-    expect(Object.keys(env).sort()).toEqual(
-      ["CODEX_HOME", "HOME", "OPENAI_API_KEY", "PATH"].filter((name) => name in env),
-    );
+    expect(Object.keys(env).sort()).toEqual(["CODEX_API_KEY", "CODEX_HOME", "HOME", "PATH"].filter((name) => name in env));
+    expect(env["CODEX_API_KEY"]).toBe("sk-not-a-key");
+    // The name that reaches the CLI is the only one that authenticates, and the
+    // operator's shell reaches it through neither.
+    expect(env["OPENAI_API_KEY"]).toBeUndefined();
     expect(env["OPENAI_BASE_URL"]).toBeUndefined();
   });
 
@@ -302,8 +312,13 @@ describe.skipIf(!LIVE)("one live session", () => {
           `${tokens.toLocaleString("en-US")} tokens · $${(outcome.usd ?? 0).toFixed(4)} · ${outcome.artifact?.length ?? 0} bytes`,
       );
       expect(outcome.failure).toBeUndefined();
-      // The two seams the page is measured through, in the bytes it left behind.
-      expect(outcome.artifact).toContain("__settled");
+      // A turn that completed is a session that authenticated: a key the CLI
+      // does not read ends the run with `turn.failed`, no turns and no tokens.
+      expect(outcome.session?.turns).toBeGreaterThan(0);
+      // The seam the page is measured through, in the bytes it left behind.
+      // Only this one: the shared contract asks the page to CALL the recorder,
+      // and says the harness decides when the screen has settled — so a page
+      // that never mentions `__settled` is obeying it, not failing it.
       expect(outcome.artifact).toContain("callTool");
     },
     12 * 60_000,

--- a/genbench/tests/codex.test.ts
+++ b/genbench/tests/codex.test.ts
@@ -1,0 +1,311 @@
+/**
+ * The codex contender, with everything real except the process.
+ *
+ * The double is the spawn boundary and nothing else: it writes into the
+ * workspace the driver actually made, on disk, and answers in the CLI's own
+ * JSONL, so the line parsing, the file watching, the accounting and the cleanup
+ * are the driver's own behaviour and not a fixture's.
+ */
+import { existsSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { codexDriver, type CodexSpawn } from "../src/codex.js";
+import { MODEL_IDS, usdFor, type Meter, type UsageTotals } from "../src/meter.js";
+import type { RunOutcome } from "../src/run.js";
+import { worldBlock } from "../src/vendo.js";
+import { loadCases, loadWorld, worldForCase, type Case, type World } from "../src/world.js";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+let world: World;
+beforeAll(async () => {
+  world = await loadWorld(join(root, "worlds", "maple"));
+});
+
+const caseFor = (id: string): Case => ({ id, lane: "screen", prompt: "Show my pending transfers", pass: [], shape: "table" });
+
+/** The run's clock, and nothing else the driver may lean on: this contender is
+ *  billed by its own session, so a meter it actually used would be a lie. */
+function clock(): Meter {
+  let tick = 0;
+  return {
+    model: MODEL_IDS.sol,
+    elapsedMs: () => (tick += 1),
+    totals: () => ({ inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, calls: 0 }),
+    usd: () => 0,
+    answeredBy: () => undefined,
+  };
+}
+
+/** One completed turn as the CLI reports it. `input_tokens` includes both cache
+ *  halves and `reasoning_output_tokens` is part of `output_tokens`, which is why
+ *  neither number is the one the report prices. */
+const TURN_USAGE = {
+  input_tokens: 12_000,
+  cached_input_tokens: 5_000,
+  cache_write_input_tokens: 900,
+  output_tokens: 8_400,
+  reasoning_output_tokens: 6_000,
+} as const;
+
+/** What the report bills for `turns` of {@link TURN_USAGE}: the full input rate
+ *  applies to what is left once both cache halves are taken out, and the
+ *  reasoning tokens are already inside the output count. */
+const billed = (turns: number): UsageTotals => ({
+  inputTokens: turns * (12_000 - 5_000 - 900),
+  outputTokens: turns * 8_400,
+  cacheReadTokens: turns * 5_000,
+  cacheWriteTokens: turns * 900,
+  calls: turns,
+});
+
+interface Seen {
+  command?: string;
+  args?: readonly string[];
+  options?: { cwd: string; env: Record<string, string> };
+  killed?: boolean;
+}
+
+const line = (event: Record<string, unknown>): string => `${JSON.stringify(event)}\n`;
+
+/** A session that writes each revision in turn and then completes, as the real
+ *  one does: the CLI's own events, one JSON object per line. */
+function writingCodex(revisions: readonly string[], seen: Seen, ending?: Record<string, unknown>): CodexSpawn {
+  return (command, args, options) => {
+    Object.assign(seen, { command, args, options });
+    return {
+      output: (async function* () {
+        yield line({ type: "thread.started", thread_id: "t1" });
+        for (const html of revisions) {
+          await writeFile(join(options.cwd, "index.html"), html);
+          yield line({ type: "item.completed", item: { type: "file_change" } });
+        }
+        yield line(ending ?? { type: "turn.completed", usage: TURN_USAGE });
+      })(),
+      kill: () => {
+        seen.killed = true;
+      },
+    };
+  };
+}
+
+/** A session that never ends — the shape a wall-clock bound exists for. It
+ *  writes and bills first, because that is what a real one does before it runs
+ *  out of clock. */
+function hangingCodex(seen: Seen, turns = 0, revisions: readonly string[] = []): CodexSpawn {
+  return (command, args, options) => {
+    Object.assign(seen, { command, args, options });
+    return {
+      output: (async function* () {
+        for (const html of revisions) {
+          await writeFile(join(options.cwd, "index.html"), html);
+          yield line({ type: "item.completed", item: { type: "file_change" } });
+        }
+        for (let turn = 0; turn < turns; turn += 1) yield line({ type: "turn.completed", usage: TURN_USAGE });
+        await new Promise<void>(() => undefined);
+      })(),
+      kill: () => {
+        seen.killed = true;
+      },
+    };
+  };
+}
+
+const runCase = async (spawn: CodexSpawn, timeoutMs?: number): Promise<RunOutcome> =>
+  await codexDriver({ model: "sol", spawn, ...(timeoutMs === undefined ? {} : { timeoutMs }) }).run({
+    world,
+    testCase: caseFor("pending-transfers"),
+    meter: clock(),
+  });
+
+describe("driving Codex", () => {
+  /**
+   * The column is STOCK `codex exec`, for the same reason `claude-code` is stock
+   * Claude Code: the baseline this column stands for is the one a team actually
+   * installs. What stays is isolation — the operator's own config, plugins, MCP
+   * servers and environment, all of which would silently become this column's
+   * advantage or its handicap.
+   */
+  it("runs the pinned binary with the world block, the case's prompt and the stock loadout", async () => {
+    const seen: Seen = {};
+    await runCase(writingCodex(["<html></html>"], seen));
+
+    // The declared devDependency's own binary, on disk, rather than whatever
+    // `codex` the operator's shell would have found.
+    expect(seen.command!.endsWith(join("node_modules", ".bin", "codex"))).toBe(true);
+    expect(existsSync(seen.command!)).toBe(true);
+    // The whole invocation, exactly: an added flag is a different loadout, and
+    // there is no approval flag because `codex exec` never asks and rejects one.
+    expect(seen.args!.slice(0, -1)).toEqual([
+      "exec",
+      "--cd",
+      seen.options!.cwd,
+      "--sandbox",
+      "workspace-write",
+      "--skip-git-repo-check",
+      "--json",
+      "-c",
+      // The sandbox turns the network off, and `claude-code` runs with stock
+      // Bash — a column that cannot fetch is a column handicapped by its wrapper.
+      "sandbox_workspace_write.network_access=true",
+      "-m",
+      MODEL_IDS.sol,
+    ]);
+    expect(seen.args!.at(-1)).toContain(worldBlock(world));
+    expect(seen.args!.at(-1)).toContain("Show my pending transfers");
+  });
+
+  it("spells the subprocess environment out rather than handing over the operator's shell", async () => {
+    const seen: Seen = {};
+    process.env["OPENAI_BASE_URL"] = "https://a-gateway-nobody-declared.example";
+    try {
+      await runCase(writingCodex(["<html></html>"], seen));
+    } finally {
+      delete process.env["OPENAI_BASE_URL"];
+    }
+
+    const env = seen.options!.env;
+    expect(Object.keys(env).sort()).toEqual(
+      ["CODEX_HOME", "HOME", "OPENAI_API_KEY", "PATH"].filter((name) => name in env),
+    );
+    expect(env["OPENAI_BASE_URL"]).toBeUndefined();
+  });
+
+  /** The operator's own `~/.codex` holds private plugins, MCP servers and state
+   *  files that take locks — so every session gets a home of its own, beside the
+   *  workspace rather than inside it, and it does not outlive the case. */
+  it("gives the session a throwaway home outside the workspace, and takes it away after", async () => {
+    const seen: Seen = {};
+    await runCase(writingCodex(["<html></html>"], seen));
+
+    const home = seen.options!.env["CODEX_HOME"]!;
+    expect(home.startsWith(seen.options!.cwd)).toBe(false);
+    expect(existsSync(home)).toBe(false);
+  });
+
+  it("reports the last page written as the artifact, on the run's clock", async () => {
+    const seen: Seen = {};
+    const outcome = await runCase(writingCodex(["<p>one</p>", "<p>two</p>", "<p>three</p>"], seen));
+
+    expect(outcome.artifact).toBe("<p>three</p>");
+    expect(outcome.format).toBe("html");
+    // The first page on disk is the first moment there was anything to paint,
+    // and it is earlier than the settle because the session went on revising.
+    expect(outcome.firstRenderMs).toBeLessThan(outcome.settledMs);
+    expect(outcome.failure).toBeUndefined();
+    expect(existsSync(seen.options!.cwd)).toBe(false);
+  });
+
+  /** Every turn's tokens, from a stream that does not land on line boundaries —
+   *  a half-read line dropped is a whole turn nobody was billed for. */
+  it("adds up every completed turn's tokens, priced from genbench's one table", async () => {
+    const seen: Seen = {};
+    const twoTurns: CodexSpawn = (command, args, options) => {
+      Object.assign(seen, { command, args, options });
+      const both = line({ type: "turn.completed", usage: TURN_USAGE }).repeat(2);
+      return {
+        output: (async function* () {
+          await writeFile(join(options.cwd, "index.html"), "<p>done</p>");
+          yield both.slice(0, 40);
+          yield both.slice(40);
+        })(),
+        kill: () => undefined,
+      };
+    };
+    const outcome = await runCase(twoTurns);
+
+    expect(outcome.usage).toEqual(billed(2));
+    expect(outcome.usd).toBe(usdFor(outcome.usage!, MODEL_IDS.sol));
+    // How hard an agentic column had to work is the only thing the session says
+    // about itself beyond its tokens, and the CLI names no price of its own.
+    expect(outcome.session).toEqual({ turns: 2 });
+  });
+
+  it("reports a session that ended badly as a failure, with whatever it wrote", async () => {
+    const outcome = await runCase(
+      writingCodex(["<p>half</p>"], {}, { type: "turn.failed", error: { message: "context window exhausted" } }),
+    );
+
+    expect(outcome.artifact).toBe("<p>half</p>");
+    expect(outcome.failure).toBe("context window exhausted");
+  });
+
+  it("kills the session and keeps its last page when it outruns its budget", async () => {
+    const seen: Seen = {};
+    const outcome = await runCase(hangingCodex(seen, 0, ["<p>half</p>"]), 50);
+
+    expect(outcome.failure).toBe("timeout");
+    expect(outcome.artifact).toBe("<p>half</p>");
+    expect(seen.killed).toBe(true);
+    // A workspace left behind by the one path that does not finish is the leak
+    // nobody would notice until a laptop ran out of disk.
+    expect(existsSync(seen.options!.cwd)).toBe(false);
+    expect(existsSync(seen.options!.env["CODEX_HOME"]!)).toBe(false);
+  });
+
+  /** A session that outruns its clock never reports a total, and a column that
+   *  burned ten minutes of engine for $0.0000 is the cheapest on the board by
+   *  having failed. */
+  it("reports the tokens a timed-out session really burned, not zero", async () => {
+    const outcome = await runCase(hangingCodex({}, 3), 50);
+
+    expect(outcome.failure).toBe("timeout");
+    expect(outcome.usage).toEqual(billed(3));
+    expect(outcome.usd).toBeGreaterThan(0);
+  });
+
+  /** The case's budget is the outer one: a column whose case has already been
+   *  recorded keeps a whole engine running for a screen nobody is waiting for. */
+  it("stops the session when the case's own budget is spent", async () => {
+    const seen: Seen = {};
+    const lost = new AbortController();
+    const running = codexDriver({ model: "sol", spawn: hangingCodex(seen), timeoutMs: 200 }).run({
+      world,
+      testCase: caseFor("pending-transfers"),
+      meter: clock(),
+      signal: lost.signal,
+    });
+    await vi.waitFor(() => expect(seen.options).toBeDefined());
+
+    lost.abort();
+    expect(seen.killed).toBe(true);
+    await running;
+  });
+});
+
+/** ONE live session, off unless asked for. Every double above answers the
+ *  question "does the driver read a session correctly"; only this one answers
+ *  "is this an invocation the real CLI accepts", which no fixture can. */
+const LIVE = process.env.GENBENCH_LIVE === "1" && (process.env.OPENAI_API_KEY ?? "") !== "";
+
+describe.skipIf(!LIVE)("one live session", () => {
+  it(
+    "builds a real page for a real case, and says what it cost",
+    async () => {
+      const testCase = (await loadCases(join(root, "worlds", "maple", "cases.json"))).find(
+        (entry) => entry.id === "pending-transfers",
+      )!;
+      const startedAt = performance.now();
+      const meter: Meter = { ...clock(), elapsedMs: () => Math.round(performance.now() - startedAt) };
+
+      const outcome = await codexDriver({ model: "sol" }).run({
+        world: worldForCase(world, testCase),
+        testCase,
+        meter,
+      });
+
+      const usage = outcome.usage!;
+      const tokens = usage.inputTokens + usage.outputTokens + usage.cacheReadTokens + usage.cacheWriteTokens;
+      console.log(
+        `live codex · ${outcome.settledMs} ms · ${outcome.session?.turns ?? 0} turns · ` +
+          `${tokens.toLocaleString("en-US")} tokens · $${(outcome.usd ?? 0).toFixed(4)} · ${outcome.artifact?.length ?? 0} bytes`,
+      );
+      expect(outcome.failure).toBeUndefined();
+      // The two seams the page is measured through, in the bytes it left behind.
+      expect(outcome.artifact).toContain("__settled");
+      expect(outcome.artifact).toContain("callTool");
+    },
+    12 * 60_000,
+  );
+});

--- a/genbench/tests/diy.test.ts
+++ b/genbench/tests/diy.test.ts
@@ -23,6 +23,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { beforeAll, describe, expect, it } from "vitest";
 import { claudeCodeDriver, type AgentSdk } from "../src/claude-code.js";
+import { codexDriver, type CodexSpawn } from "../src/codex.js";
 import { diyDriver, diySystemPrompt } from "../src/diy.js";
 import type { Meter } from "../src/meter.js";
 import { authoredPage, HARNESS_CONTRACT, openBrowser } from "../src/render.js";
@@ -126,6 +127,25 @@ async function sessionBriefFor(scoped: World, testCase: Case): Promise<string> {
   return brief;
 }
 
+/** The brief the codex driver really spawned its CLI with — the last argument of
+ *  the invocation, which is where `codex exec` takes its prompt. The double
+ *  writes a page for the same reason the one above does. */
+async function execBriefFor(scoped: World, testCase: Case): Promise<string> {
+  let brief = "";
+  const spawn: CodexSpawn = (_command, args, options) => {
+    brief = args.at(-1)!;
+    return {
+      output: (async function* () {
+        await writeFile(join(options.cwd, "index.html"), PAGE);
+        yield `${JSON.stringify({ type: "turn.completed", usage: {} })}\n`;
+      })(),
+      kill: () => undefined,
+    };
+  };
+  await codexDriver({ model: "sol", spawn }).run({ world: scoped, testCase, meter: replying(PAGE).meter });
+  return brief;
+}
+
 /** Every contender that is NOT the product, and the real prompt each one sent.
  *  The vendo column is the other side of every comparison below — it is what
  *  they are checked against, so it needs no row of its own. */
@@ -140,6 +160,7 @@ const BASELINES: ReadonlyArray<{ name: string; briefFor(scoped: World, testCase:
     },
   },
   { name: "claude-code", briefFor: sessionBriefFor },
+  { name: "codex", briefFor: execBriefFor },
 ];
 
 describe.each(BASELINES)("$name is handed exactly what vendo is handed", ({ briefFor }) => {

--- a/genbench/tests/run.test.ts
+++ b/genbench/tests/run.test.ts
@@ -18,6 +18,7 @@ import {
   contenders,
   exitCode,
   harnessStamp,
+  missingKey,
   parseArgs,
   pool,
   shouldOpen,
@@ -254,6 +255,13 @@ describe("worldsFor", () => {
     expect(await worldsFor(worldsDir, "maple")).toEqual(["maple"]);
   });
 
+  it("takes a comma list as those worlds, in the order they were written", async () => {
+    expect(await worldsFor(worldsDir, parseArgs(["run", "--world", "buildlog,maple"]).world)).toEqual([
+      "buildlog",
+      "maple",
+    ]);
+  });
+
   it("takes `all` as every world folder there is, in a fixed order", async () => {
     const all = await worldsFor(worldsDir, "all");
 
@@ -294,7 +302,7 @@ describe("--models", () => {
  *  harness should not spend the other two's tokens on the same case. */
 describe("--contenders", () => {
   it("races every driver when nobody narrows the row", () => {
-    expect(parseArgs(["run"]).contenders).toEqual(["vendo", "diy", "claude-code", "thesys"]);
+    expect(parseArgs(["run"]).contenders).toEqual(["vendo", "diy", "claude-code", "thesys", "codex"]);
   });
 
   it("narrows the row to the drivers named", () => {
@@ -308,6 +316,30 @@ describe("--contenders", () => {
 
   it("refuses a contender that has no driver", () => {
     expect(() => parseArgs(["run", "--contenders", "vendo,langchain"])).toThrow(/unknown contender "langchain"/);
+  });
+
+  /** The matrix stopped being a rectangle once some columns had a model line of
+   *  their own: naming a model to get one column of it also crossed that model
+   *  onto every other harness in the list. A `harness:model` pair is one column. */
+  it("takes a harness:model pair as exactly that column, and leaves --models out of it", () => {
+    const only = parseArgs(["run", "--contenders", "diy:gpt"]).contenders;
+
+    expect(contenders(["sonnet", "haiku"], only).map((contender) => contender.slug)).toEqual(["diy-gpt"]);
+  });
+
+  it("mixes bare harnesses and pairs, and keeps the order they were written in", () => {
+    const only = parseArgs(["run", "--contenders", "claude-code,diy:gemini,vendo"]).contenders;
+
+    expect(contenders(["sonnet"], only).map((contender) => contender.slug)).toEqual([
+      "claude-code-sonnet",
+      "diy-gemini",
+      "vendo-sonnet",
+    ]);
+  });
+
+  it("refuses a pair naming a model or a harness nothing here has", () => {
+    expect(() => parseArgs(["run", "--contenders", "diy:gpt-9"])).toThrow(/unknown model "gpt-9"/);
+    expect(() => parseArgs(["run", "--contenders", "langchain:sonnet"])).toThrow(/unknown contender "langchain"/);
   });
 
   /** Claude Code is Anthropic's own engine and never reads the meter's model, so
@@ -324,6 +356,47 @@ describe("--contenders", () => {
    *  named late. */
   it("refuses a row nothing can run, naming the pairing that emptied it", () => {
     expect(() => contenders(["glm-fast"], ["claude-code"])).toThrow(/claude-code has no column for glm-fast/);
+  });
+
+  /** The router's three aliases are the cross-VENDOR row, and `diy` — one model
+   *  call with no product around it — is what makes three vendors comparable.
+   *  Elsewhere they would double a column that already exists first-party, and a
+   *  pair that asks for one is a row nothing can run, named as it was written. */
+  it("keeps the OpenRouter aliases to the one column that is nothing but a model", () => {
+    expect(contenders(["gpt", "gemini"]).map((contender) => contender.slug)).toEqual(["diy-gpt", "diy-gemini"]);
+    expect(() => contenders(["sonnet"], parseArgs(["run", "--contenders", "vendo:claude"]).contenders)).toThrow(
+      /vendo:claude has no column/,
+    );
+  });
+
+  /** `codex` is a bought PRODUCT the way `thesys` is: it spawns OpenAI's own CLI
+   *  and never reads the meter's model, so it runs its one alias and nothing
+   *  else, and no other column may run that alias. */
+  it("runs the Codex CLI on its own alias, and runs that alias nowhere else", () => {
+    expect(contenders(["sol"]).map((contender) => contender.slug)).toEqual(["codex-sol"]);
+    expect(contenders(["sonnet", "sol"]).map((contender) => contender.slug)).not.toContain("codex-sonnet");
+  });
+});
+
+/**
+ * A key is demanded up front — before a case and a browser — and only for a
+ * column that will really run. It reads the resolved ROW rather than `--models`,
+ * so narrowing `--contenders` can never leave a key demanded for a column nobody
+ * asked for.
+ */
+describe("the credential preflight", () => {
+  it("demands the router's key for a row that runs an OpenRouter alias", () => {
+    expect(missingKey(contenders(["gpt"]), {})).toMatch(/OPENROUTER_API_KEY is not set.*serves gpt/);
+    expect(missingKey(contenders(["gpt"]), { OPENROUTER_API_KEY: "sk-or-x" })).toBeUndefined();
+  });
+
+  it("demands OpenAI's key for the codex column, which bills that account directly", () => {
+    expect(missingKey(contenders(["sol"]), {})).toMatch(/OPENAI_API_KEY is not set.*serves sol/);
+    expect(missingKey(contenders(["sol"]), { OPENAI_API_KEY: "sk-x" })).toBeUndefined();
+  });
+
+  it("demands nothing for an alias the narrowed row dropped", () => {
+    expect(missingKey(contenders(["sonnet", "gpt", "sol"], ["vendo"]), {})).toBeUndefined();
   });
 });
 

--- a/genbench/tests/run.test.ts
+++ b/genbench/tests/run.test.ts
@@ -262,6 +262,15 @@ describe("worldsFor", () => {
     ]);
   });
 
+  /** The folder name is the evidence key the same way a slug is: `maple,maple`
+   *  wrote every contender's `maple/<case>` folder twice, the second pass
+   *  replacing the first's artifacts while both counted in the summary. And a
+   *  name beside `all` asks for nothing `all` does not already cover. */
+  it("takes a world named twice as that world once, and `all` beside a name as the whole corpus", async () => {
+    expect(await worldsFor(worldsDir, "maple,maple")).toEqual(["maple"]);
+    expect(await worldsFor(worldsDir, "maple,all")).toEqual(await worldsFor(worldsDir, "all"));
+  });
+
   it("takes `all` as every world folder there is, in a fixed order", async () => {
     const all = await worldsFor(worldsDir, "all");
 

--- a/genbench/tests/run.test.ts
+++ b/genbench/tests/run.test.ts
@@ -337,6 +337,16 @@ describe("--contenders", () => {
     ]);
   });
 
+  /** A bare harness and a pinned pair can name the same column, and the slug is
+   *  the evidence directory: two of them would race to overwrite one
+   *  `vendo-sonnet/<case>` folder and be counted twice in the summary. Asking for
+   *  a column twice is asking for that column. */
+  it("collapses a column named twice into the one column, where it was first named", () => {
+    const only = parseArgs(["run", "--contenders", "diy:gemini,vendo,vendo:sonnet"]).contenders;
+
+    expect(contenders(["sonnet"], only).map((contender) => contender.slug)).toEqual(["diy-gemini", "vendo-sonnet"]);
+  });
+
   it("refuses a pair naming a model or a harness nothing here has", () => {
     expect(() => parseArgs(["run", "--contenders", "diy:gpt-9"])).toThrow(/unknown model "gpt-9"/);
     expect(() => parseArgs(["run", "--contenders", "langchain:sonnet"])).toThrow(/unknown contender "langchain"/);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -806,6 +806,9 @@ importers:
       '@crayonai/react-ui':
         specifier: 0.9.16
         version: 0.9.16(@crayonai/react-core@0.7.7(@crayonai/stream@0.6.4(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(eventsource-parser@3.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwind-merge@3.6.0)(tailwindcss-animate@1.0.7)(tiny-invariant@1.3.3)(zustand@4.5.7(@types/react@19.2.17)(immer@11.1.11)(react@19.2.7)))(@crayonai/stream@0.6.4(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zustand@4.5.7(@types/react@19.2.17)(immer@11.1.11)(react@19.2.7))
+      '@openai/codex':
+        specifier: ^0.147.0
+        version: 0.147.0
       '@playwright/test':
         specifier: ^1.49.0
         version: 1.61.1
@@ -3114,6 +3117,47 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@openai/codex@0.147.0':
+    resolution: {integrity: sha512-EQLEXecAG2ptxI7UpBMo2TR/ga5596/c/OsYF/0LoUDh5JANZ7IoGqlzBEWbuEVQ76JePIbtTW/ihCkp1a7Z3w==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  '@openai/codex@0.147.0-darwin-arm64':
+    resolution: {integrity: sha512-BEUVkiOW7kLcRyrMLfAr/h9wF8sRVJyZDy6OHtVn6QGDXiv3BvAZVTY1Pu9xF7KdIdkYXbp4uayN0aDQQaAUJw==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@openai/codex@0.147.0-darwin-x64':
+    resolution: {integrity: sha512-Tb8McE5SvJIH0Vs5R6sq7u+quiC931yan2KOOl6km1OdZ82+Wi7eF5XrSFPs5CF7xCgoIK4Vs+byMbT5hN+ZUw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@openai/codex@0.147.0-linux-arm64':
+    resolution: {integrity: sha512-SLC1JXw2TYfr/c3HhrJubyyLelq7vTOLWVmiThFA+z0+WgzCPmaseJ/kzDD3Gge/TO7fCnnj7UcPmC0d2c8XAg==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@openai/codex@0.147.0-linux-x64':
+    resolution: {integrity: sha512-0W9MBxPpWW0cSkNqrTDN2jR7rzzT7oNMhQY5446lT2Lw5cz5yhDTck4Va9rjkQEm+HlFzP/dmEMSZbXfJsINmw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@openai/codex@0.147.0-win32-arm64':
+    resolution: {integrity: sha512-e2ZstJ8zT8Rm1nvR7CUVO+Gr3cTChE41+VfOzGhynzDXEoW0wfbjUQbc2bWbh1arG94LMm4y3dqBtUIbSrfeGA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@openai/codex@0.147.0-win32-x64':
+    resolution: {integrity: sha512-oT7Ss5fAPf2fiWE9QNURqZcQGAAawSVxmIUdgPzckq4KFZAM+pRz9JbM4Rr498CjtbNgTOjWvDJ+DXvIBSfOPA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -11407,6 +11451,33 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@openai/codex@0.147.0':
+    optionalDependencies:
+      '@openai/codex-darwin-arm64': '@openai/codex@0.147.0-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.147.0-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.147.0-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.147.0-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.147.0-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.147.0-win32-x64'
+
+  '@openai/codex@0.147.0-darwin-arm64':
+    optional: true
+
+  '@openai/codex@0.147.0-darwin-x64':
+    optional: true
+
+  '@openai/codex@0.147.0-linux-arm64':
+    optional: true
+
+  '@openai/codex@0.147.0-linux-x64':
+    optional: true
+
+  '@openai/codex@0.147.0-win32-arm64':
+    optional: true
+
+  '@openai/codex@0.147.0-win32-x64':
+    optional: true
+
   '@opentelemetry/api@1.9.0': {}
 
   '@opentelemetry/api@1.9.1': {}
@@ -13664,6 +13735,14 @@ snapshots:
       '@vitest/utils': 3.2.7
       chai: 5.3.3
       tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.7(vite@6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 3.2.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
 
   '@vitest/mocker@3.2.7(vite@6.4.3(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
@@ -19136,7 +19215,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.7
-      '@vitest/mocker': 3.2.7(vite@6.4.3(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@vitest/mocker': 3.2.7(vite@6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.7
       '@vitest/runner': 3.2.7
       '@vitest/snapshot': 3.2.7


### PR DESCRIPTION
Supersedes #1413, which was auto-closed when its stacked base branch (`yousefh409/genbench-thesys`) was deleted on #1401's merge — same branch, now rebased onto main. All four review findings on #1413 were resolved there: three fixed with mutation-proven tests, one answered and acknowledged by the reviewer. Live one-case proof of all four new columns: https://github.com/runvendo/vendo/pull/1413#issuecomment-5313683072

Extends the matrix from four columns to seven. The three flagship single-model columns are bought through one door (OpenRouter), and a second agent joins the bench: OpenAI's Codex CLI as the exact peer of claude-code.

## The seven columns

| column | engine | model | listed $/MTok in/out |
| --- | --- | --- | --- |
| `vendo-sonnet` | the product | claude-sonnet-5 | 2 / 10 |
| `diy-claude` | one call, OpenRouter | anthropic/claude-opus-5 | 5 / 25 |
| `diy-gpt` | one call, OpenRouter | openai/gpt-5.6-sol | 5 / 30 |
| `diy-gemini` | one call, OpenRouter | google/gemini-3.1-pro-preview | 2 / 12 |
| `claude-code-opus` | Claude Agent SDK | claude-opus-5 | own session |
| `codex-sol` | Codex CLI (new driver) | gpt-5.6-sol | own session |
| `thesys-c1` | #1401 | c1 | in main |

## What changed

- **OpenRouter single-model columns** — three new aliases through the `@ai-sdk/openai-compatible` adapter the harness already uses (the official OpenRouter provider needs AI SDK v7; we are on v6). Exclusive to the `diy` harness: these are the cross-vendor row, and running `anthropic/claude-opus-5` elsewhere would only duplicate the existing `opus` column with a middleman in the path.
- **`codex` driver** (`src/codex.ts`) — headless `codex exec` writing one `index.html` in a sandboxed scratch dir. Every session gets a throwaway `CODEX_HOME` and an explicit env allowlist, so the operator's `~/.codex` plugins and MCP servers stay out — isolation, not capability, same doctrine as claude-code. Billed by its own session off the `--json` event stream (the key rides in as `CODEX_API_KEY`, the name the CLI actually reads; the final held JSONL fragment flushes at stream end so the last `turn.completed` always bills). Own 10-minute wall clock; `CASE_TIMEOUT_MS.codex` = 12 minutes. The CLI is pinned as a devDependency; the driver resolves the pinned binary, never the operator's global install.
- **Meter** — four pricing rows dated 2026-08-17 with sources, plus one honest note: OpenRouter adds 0% markup on tokens — its real fee is 5.5% on credit top-ups, which no per-run number can see.
- **CLI** — `--contenders` learns optional `harness:model` pairs (the only way to express this exact matrix); `--world` learns comma lists. Duplicate columns and duplicate worlds collapse first-seen (the slug/folder name IS the evidence identity).
- **Fairness** — `tests/diy.test.ts` now fences codex exactly like claude-code: both shared texts byte-for-byte on the wire, the user prompt unmodified, codex's own leftover words pass every MECHANICS regex, canary-proven.

## Test plan

- Post-rebase gate: run/codex/diy suites 86 passed | 1 skipped, `tsc --noEmit` clean; full local gate (`build` · `test:affected` · `typecheck` · `lint`) was green pre-rebase on identical content.
- Live proof (all four new columns, real case, real keys): see the #1413 evidence comment linked above.
- 25-case pilot across maple+buildlog completed on this branch: zero timeouts, zero judge degradation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the matrix from 4 to 7 columns to compare three flagship single‑model runs via OpenRouter and adds a second agent baseline with a sandboxed Codex CLI. This enables cross‑vendor head‑to‑head for pure model calls and a peer for `claude-code`, with accurate session billing and clearer row shaping.

- Adds `diy-claude` (`anthropic/claude-opus-5`), `diy-gpt` (`openai/gpt-5.6-sol`), and `diy-gemini` (`google/gemini-3.1-pro-preview`) via `@ai-sdk/openai-compatible` targeting OpenRouter; these aliases run on `diy` only.
- Introduces `codex-sol` using the pinned `@openai/codex` CLI (v0.147.0): headless `codex exec` in a scratch workspace, isolated `CODEX_HOME`, explicit env allowlist, 10‑minute wall clock; case timeout set to 12 minutes for this column.
- Updates the meter with OpenRouter and Codex model ids and prices (as of 2026‑08‑17); bills Codex by parsing `turn.completed` usage from the JSONL stream, including cache read/write handling and final-line flush.
- Enhances the runner: `--contenders` now accepts `harness:model` pairs (no cross with `--models` for that entry) and collapses duplicate columns; `--world` accepts comma lists and dedupes; OpenRouter provider is wired through the OpenAI‑compatible adapter; provider selection routes by alias.
- Enforces credential preflight per resolved row: demands `OPENROUTER_API_KEY` when running router aliases and `OPENAI_API_KEY` for Codex; continues to require `ANTHROPIC_API_KEY` for judging and honesty checks.
- Aligns fairness: `codex` receives the same world block and harness contract as `claude-code`; tests prove identical handed prompts and mechanics.
- Documentation reflects the new columns, timeouts, pricing notes (OpenRouter’s 0% token markup; top‑up fee not modeled), and CLI semantics.

**Migration and rollout**
- Set `OPENROUTER_API_KEY` to run `diy-claude`, `diy-gpt`, or `diy-gemini`.
- Set `OPENAI_API_KEY` to run `codex-sol`.
- Optional: use `--contenders <harness>:<model>` to pin non‑rectangular rows (e.g., `--contenders vendo,diy:gpt,codex:sol`); use `--world maple,buildlog` to run multiple worlds in one folder.

<sup>Written for commit 4cacc1ceea3cdcd70811df1996ef1815899b578b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

