### PR TITLE
docs: mount-the-surface next cards get their graphics (layout-dashboard was never an icon)

### DIFF
--- a/docs-site/product/mount-the-surface.mdx
+++ b/docs-site/product/mount-the-surface.mdx
@@ -308,11 +308,11 @@ panel. The decision itself is server-side: see
 [what stops a call](/product/how-it-works#what-stops-a-call).
 
 <CardGroup cols={2}>
-  <Card title="Theming" icon="palette" href="/customize/theming">
+  <Card title="Theming" href="/customize/theming" img="/images/cards/product-theming.svg">
     The token file every surface above reads, and how init fills it from your
     own brand.
   </Card>
-  <Card title="Generated apps" icon="layout-dashboard" href="/generated/apps">
+  <Card title="Generated apps" href="/generated/apps" img="/images/cards/generated-apps.svg">
     What a generated view can do, who owns it, and how it gets its data.
   </Card>
 </CardGroup>


### PR DESCRIPTION
The Generated apps card on /product/mount-the-surface asked for `icon="layout-dashboard"` — a Lucide name, not FontAwesome — so Mintlify reserved the icon space and rendered nothing (blank card top). Both cards in that row now use the drawn SVGs shipped in #1418 (`product-theming.svg`, `generated-apps.svg`), matching every other next-step row.

Verified in the browser: both images load, row is even. Docs-only; the nav seam test passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blank card graphics on `/product/mount-the-surface` by replacing icon names with explicit SVG images. Previously, “Generated apps” used the Lucide name `layout-dashboard`, so Mintlify reserved the icon space and rendered nothing; now both cards display their SVGs and the row layout is consistent.

**Review notes**
- Replace `icon` with `img` on both cards; paths: `/images/cards/product-theming.svg` and `/images/cards/generated-apps.svg`.
- Docs-only change; no runtime or navigation logic affected.
- Verified in browser: images load and spacing is even.

<sup>Written for commit 48d5abc7e7ed8c78211d1386b5343f69f53320cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

