### PR TITLE
test(automations-e2e): an unavailable model leaves the live leg unproven, not red

### DIFF
--- a/fixtures/automations-e2e/tests/live-agentic.e2e.test.ts
+++ b/fixtures/automations-e2e/tests/live-agentic.e2e.test.ts
@@ -22,10 +22,24 @@ interface RunRow {
 }
 
 describe.skipIf(!plausible)("live goal automation", () => {
-  it("runs a real-model goal automation within captured grants", { timeout: 180_000 }, async () => {
+  it("runs a real-model goal automation within captured grants", { timeout: 180_000 }, async ({ skip }) => {
     await resetFixture();
     const { createAnthropic } = await import("@ai-sdk/anthropic");
-    const anthropic = createAnthropic({ apiKey: liveKey });
+    // The transport is the only place upstream weather is legible. The run row
+    // cannot tell it from an engine defect: every model failure reaches it as
+    // the one generic sentence, whatever threw (wire-error.ts:27, away.ts:597).
+    // The LAST status Anthropic answered with can — a 429/5xx there is nothing
+    // this engine can cause (our own bad payload is a 400), and reading the last
+    // one means a failure the AI SDK retried into a success is not one.
+    let lastUpstream = 0;
+    const anthropic = createAnthropic({
+      apiKey: liveKey,
+      fetch: async (input, init) => {
+        const response = await fetch(input, init);
+        lastUpstream = response.status;
+        return response;
+      },
+    });
     const stack = await createStack({
       runnerFrom: ({ guard, store }) =>
         awayRunner({
@@ -71,6 +85,13 @@ describe.skipIf(!plausible)("live goal automation", () => {
         await new Promise((resolve) => setTimeout(resolve, 1000));
       }
       if (row === undefined) throw new Error("run row never appeared");
+      // An unavailable model leaves this UNPROVEN, never passed. Narrow on both
+      // axes: a run that finished still asserts, and every other way to fail
+      // still fails.
+      skip(
+        row.status !== "ok" && (lastUpstream === 429 || lastUpstream >= 500),
+        `Anthropic answered ${lastUpstream}: the model was unavailable, so this run proves nothing`,
+      );
       expect(row.status).toBe("ok");
       const listCalls = row.record.steps.filter((step) => step.tool === "host_invoices_list");
       expect(listCalls.length).toBeGreaterThanOrEqual(1);


### PR DESCRIPTION
## The problem

`fixtures/automations-e2e/tests/live-agentic.e2e.test.ts` runs on pushes to `main`
inside the `integration (automations)` leg, and `integration` is a **required check**.
`packages/agents/src/away.ts:581-594` wraps the model turn in a bare `catch { failed = true }`,
so **any** thrown model error becomes run status `"error"` and the test's
`expect(row.status).toBe("ok")` fails. A transient Anthropic 429/500/529 that survived
the AI SDK's automatic retries therefore reddens a required check on the default branch
and reads as "our engine is broken" when nothing of ours is.

## Why not the run row

The row cannot distinguish the two. `vendo()` reports every model failure as
`{ type: "error", message: wireErrorMessage(error) }` (`packages/harnesses/src/vendo/vendo.ts:633`),
and `wireErrorMessage` collapses anything that is not a `VendoError` or a Cloud meter
refusal to one fixed sentence (`packages/harnesses/src/wire-error.ts:27`). That sentence
becomes `report.summary` (`packages/agents/src/away.ts:597`), and the goal path writes the
terminal row with **no** error object, so `run.error` is deleted
(`packages/automations/src/run-execution.ts:216` → `packages/automations/src/run-rows.ts:101`).
An upstream 529 and a Vendo bug that makes the model call throw land byte-identical.
A skip keyed on the row would swallow real defects.

## The mechanism

The transport can tell them apart, and the test already builds its own Anthropic provider.
It now passes a `fetch` middleware (a documented `AnthropicProviderSettings` option) that
records the **last** status Anthropic answered with, and skips only when **both**:

```ts
row.status !== "ok" && (lastUpstream === 429 || lastUpstream >= 500)
```

Narrow on both axes:
- **`row.status !== "ok"`** — a run that finished still asserts everything it did before.
- **`429 || >= 500`** — a 400/401/404 is excluded by construction. Our own bad payload is a 400.
- **last, not any** — a 429 the AI SDK retried into a success leaves `lastUpstream === 200`, so it does not skip.

A skip says "not proven this run", never "proven working". No passing-path assertion changed.

## Verification

| What | Result |
|---|---|
| Normal path, live key (×3 incl. 2 final gate runs) | `✓ ... 5841ms` / `6267ms` — `1 passed`, not skipped |
| Skip path — simulated 529 at the real transport (`--import` preload patching `globalThis.fetch`, test file untouched) | `↓ ... [Anthropic answered 529: the model was unavailable, so this run proves nothing]` — `1 skipped` |
| **Engine defect — `dist` mutated so status is always `"error"`, healthy upstream** | **RED**: `AssertionError: expected 'error' to be 'ok'` — `1 failed`, exit 1 |
| **Engine defect — bogus `toolChoice` in `dist`, Anthropic answers 400** | **RED**: statusCode 400 `"Tool 'definitely_not_a_tool' not found in provided tools"` → `expected 'error' to be 'ok'` — `1 failed`, exit 1 |
| Engine defect — mutated tool names in `dist` | **RED**: `expected 0 to be greater than or equal to 1` (downstream assertions still bite) |
| `dist` restored | deleted both files, forced fresh `tsc` emit, md5 identical; zero `S2K-MUTANT` markers repo-wide |

Also green: `pnpm --filter=@vendoai-fixtures/automations-e2e typecheck`, `dependency-guard`,
`portability-gate`. The root blocking eslint config scopes to `packages/*/**`, so this
fixture file is outside it.

## Not done

- `.github/workflows/ci.yml` untouched — making the leg non-required is a merge-policy decision.
- No production code touched. The bare catch at `away.ts:581-594` may well deserve fixing;
  that is a separate, unauthorised change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks transient Anthropic unavailability as unproven instead of red in the live automation e2e. Previously, any thrown model error set the run status to "error" and failed the required `integration` check; now the test skips only when the run failed and the transport’s last response was 429 or 5xx.

- Adds `fetch` middleware to `createAnthropic` from `@ai-sdk/anthropic` to record the last upstream status; gates `skip` on `row.status !== "ok"` and `(lastUpstream === 429 || lastUpstream >= 500)`.
- Keeps passing-path assertions unchanged; engine defects and 4xx caused by our payload still fail.
- Only `fixtures/automations-e2e/tests/live-agentic.e2e.test.ts` changed; no production code or workflow changes.

<sup>Written for commit 6761bd15b3a062f06b9341dadac714d801e9aba0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

